### PR TITLE
Update class class-pclzip.php

### DIFF
--- a/src/wp-admin/includes/class-pclzip.php
+++ b/src/wp-admin/includes/class-pclzip.php
@@ -4205,11 +4205,16 @@
       // ----- Do the extraction (if not a folder)
       if (!(($p_entry['external']&0x00000010)==0x00000010)) {
         // ----- Look for not compressed file
-  //      if ($p_entry['compressed_size'] == $p_entry['size'])
         if ($p_entry['compression'] == 0) {
-
-          // ----- Reading the file
-          $p_string = @fread($this->zip_fd, $p_entry['compressed_size']);
+	     if ($p_entry['compressed_size'] == 0){
+		 // ----- Fread requires a non zero length parameter
+                 // ----- Reading the file
+                 $p_string = @fread($this->zip_fd, filesize($this->zipname));
+	     }
+             else {
+                 // ----- Reading the file
+                 $p_string = @fread($this->zip_fd, $p_entry['compressed_size']);
+             }
         }
         else {
 


### PR DESCRIPTION
Installing a plugin results in a warning because a 0 filesize is passed to fread()
Changed to read the filesize before passing to fread()
Tested on :
System	Linux ubuntu 4.4.0-66-generic #87-Ubuntu SMP Fri Mar 3 15:29:05 UTC 2017 x86_64
PHP Version 	7.0.15-0ubuntu0.16.04.4
MySQL Version 	5.7.17-0ubuntu0.16.04.1