### PR TITLE
Use PHP 7.3 for the persistent object cache CI job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,14 +18,14 @@ matrix:
     env: WP_TRAVISCI=travis:js
   - php: 7.4snapshot
   - php: 7.3
+  - php: 7.3
+    env: WP_TRAVIS_OBJECT_CACHE=true
+    services: memcached
   - php: 7.2
   - php: 7.1
   - php: 7.0
     env: WP_TEST_REPORTER=true
   - php: 5.6
-  - php: 5.6
-    env: WP_TRAVIS_OBJECT_CACHE=true
-    services: memcached
   - php: 5.5
   - php: 5.4
   - php: 5.3


### PR DESCRIPTION
See [#WP46633](https://core.trac.wordpress.org/ticket/46633) Enable the persistent object cache on a PHP 7 build on Travis CI