### PR TITLE
Block Editor: Align the version of React with the one used in Gutenberg

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18044,14 +18044,13 @@
 			}
 		},
 		"react": {
-			"version": "16.8.4",
-			"resolved": "https://registry.npmjs.org/react/-/react-16.8.4.tgz",
-			"integrity": "sha512-0GQ6gFXfUH7aZcjGVymlPOASTuSjlQL4ZtVC5YKH+3JL6bBLCVO21DknzmaPlI90LN253ojj02nsapy+j7wIjg==",
+			"version": "16.9.0",
+			"resolved": "https://registry.npmjs.org/react/-/react-16.9.0.tgz",
+			"integrity": "sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
-				"prop-types": "^15.6.2",
-				"scheduler": "^0.13.4"
+				"prop-types": "^15.6.2"
 			}
 		},
 		"react-addons-shallow-compare": {
@@ -18094,14 +18093,14 @@
 			}
 		},
 		"react-dom": {
-			"version": "16.8.4",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.4.tgz",
-			"integrity": "sha512-Ob2wK7XG2tUDt7ps7LtLzGYYB6DXMCLj0G5fO6WeEICtT4/HdpOi7W/xLzZnR6RCG1tYza60nMdqtxzA8FaPJQ==",
+			"version": "16.9.0",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.9.0.tgz",
+			"integrity": "sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
 				"prop-types": "^15.6.2",
-				"scheduler": "^0.13.4"
+				"scheduler": "^0.15.0"
 			}
 		},
 		"react-is": {
@@ -19183,9 +19182,9 @@
 			"dev": true
 		},
 		"scheduler": {
-			"version": "0.13.6",
-			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
-			"integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.15.0.tgz",
+			"integrity": "sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -114,8 +114,8 @@
 		"masonry-layout": "3.3.2",
 		"moment": "2.22.2",
 		"polyfill-library": "3.27.4",
-		"react": "16.8.4",
-		"react-dom": "16.8.4",
+		"react": "16.9.0",
+		"react-dom": "16.9.0",
 		"twemoji": "12.1.2",
 		"underscore": "1.8.3",
 		"whatwg-fetch": "3.0.0"

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -91,8 +91,8 @@ function wp_default_packages_vendor( &$scripts ) {
 	);
 
 	$vendor_scripts_versions = array(
-		'react'                       => '16.8.4',
-		'react-dom'                   => '16.8.4',
+		'react'                       => '16.9.0',
+		'react-dom'                   => '16.9.0',
 		'moment'                      => '2.22.2',
 		'lodash'                      => '4.17.15',
 		'wp-polyfill-fetch'           => '3.0.0',


### PR DESCRIPTION
Gutenberg 6.5 works with `react` and `react-dom` set to v16.9.0. This change tries to align both.

See:
https://github.com/WordPress/gutenberg/blob/d15ced026638e33c2a0b61cfbcc12d014d31b542/package.json#L129-L130

I'll move this PR to Trac as soon as Travis reports that everything works as expected.