### PR TITLE
passing the block Object to the block renderer

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -260,7 +260,7 @@ function render_block( $block ) {
 
 	if ( $is_dynamic ) {
 		$global_post   = $post;
-		$block_content = $block_type->render( $block['attrs'], $block_content );
+		$block_content = $block_type->render( $block['attrs'], $block_content, $block );
 		$post          = $global_post;
 	}
 

--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -97,16 +97,17 @@ class WP_Block_Type {
 	 *
 	 * @param array  $attributes Optional. Block attributes. Default empty array.
 	 * @param string $content    Optional. Block content. Default empty string.
+	 * @param string $block      Optional. The block object. Default null.
 	 * @return string Rendered block type output.
 	 */
-	public function render( $attributes = array(), $content = '' ) {
+	public function render( $attributes = array(), $content = '', $block = null ) {
 		if ( ! $this->is_dynamic() ) {
 			return '';
 		}
 
 		$attributes = $this->prepare_attributes_for_render( $attributes );
 
-		return (string) call_user_func( $this->render_callback, $attributes, $content );
+		return (string) call_user_func( $this->render_callback, $attributes, $content, $block );
 	}
 
 	/**


### PR DESCRIPTION
Added a way to pass the block object to the server side render function. Used 1st in the Navigation Block, but useful for all server side rendered blocks that need access to InnerBlocks data, not rendered.