### PR TITLE
 #44317 wp_safe_redirect() and wp_redirect() shouldn't allow non-3xx status codes

### DIFF
--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -1250,6 +1250,10 @@ if ( ! function_exists( 'wp_redirect' ) ) :
 			return false;
 		}
 
+		if ( 300 >= $status && 400 < $status ) {
+			wp_die( __( 'HTTP redirect status code must be a redirection code, 3xx.' ) );
+		}
+
 		$location = wp_sanitize_redirect( $location );
 
 		if ( ! $is_IIS && PHP_SAPI != 'cgi-fcgi' ) {


### PR DESCRIPTION
wp_redirect() will now call wp_die() if status code is not a redirection status code, 3XX.

BREAKING CHANGE: If status code is not valid, function will now cause a wp_die().

Closes 44317