### PR TITLE
Embeds: Add support for TikTok videos

### DIFF
--- a/src/wp-includes/class-wp-oembed.php
+++ b/src/wp-includes/class-wp-oembed.php
@@ -65,6 +65,7 @@ class WP_oEmbed {
 			'#https?://(.+\.)?polldaddy\.com/.*#i'         => array( 'https://api.crowdsignal.com/oembed', true ),
 			'#https?://poll\.fm/.*#i'                      => array( 'https://api.crowdsignal.com/oembed', true ),
 			'#https?://(.+\.)?survey\.fm/.*#i'             => array( 'https://api.crowdsignal.com/oembed', true ),
+			'#https?://(www\.)?tiktok\.com/.*/video/.*#i'  => array( 'https://www.tiktok.com/oembed', true ),
 			'#https?://(www\.)?twitter\.com/\w{1,15}/status(es)?/.*#i' => array( 'https://publish.twitter.com/oembed', true ),
 			'#https?://(www\.)?twitter\.com/\w{1,15}$#i'   => array( 'https://publish.twitter.com/oembed', true ),
 			'#https?://(www\.)?twitter\.com/\w{1,15}/likes$#i' => array( 'https://publish.twitter.com/oembed', true ),
@@ -150,6 +151,7 @@ class WP_oEmbed {
 		 * | Crowdsignal  | polldaddy.com                             | 3.0.0   |
 		 * | SmugMug      | smugmug.com                               | 3.0.0   |
 		 * | YouTube      | youtu.be                                  | 3.0.0   |
+		 * | TikTok       | tiktok.com                                | 5.?.?   |
 		 * | Twitter      | twitter.com                               | 3.4.0   |
 		 * | Instagram    | instagram.com                             | 3.5.0   |
 		 * | Instagram    | instagr.am                                | 3.5.0   |


### PR DESCRIPTION
Adds the pattern for TikTok videos & oembed URL to the list of allowed providers.

|Before|After|
|---|---|
|![Screen Shot 2019-12-26 at 4 08 49 PM](https://user-images.githubusercontent.com/1587282/71490742-7d8e3380-27fa-11ea-91ca-acbe46cd988f.png)|![Screen Shot 2019-12-26 at 4 12 48 PM](https://user-images.githubusercontent.com/1587282/71490762-9b5b9880-27fa-11ea-9e9d-0a5f31fee851.png)|

Fixes: https://core.trac.wordpress.org/ticket/49083