### PR TITLE
Media: ensure `item` is available before setting skipHistory on load.

### DIFF
--- a/src/js/media/routers/manage.js
+++ b/src/js/media/routers/manage.js
@@ -43,12 +43,13 @@ var Router = Backbone.Router.extend(/** @lends wp.media.view.MediaFrame.Manage.R
 
 		// Trigger the media frame to open the correct item
 		item = library.findWhere( { id: parseInt( query, 10 ) } );
-		item.set( 'skipHistory', true );
 
 		if ( item ) {
+			item.set( 'skipHistory', true );
 			frame.trigger( 'edit:attachment', item );
 		} else {
 			item = media.attachment( query );
+			item.set( 'skipHistory', true );
 			frame.listenTo( item, 'change', function( model ) {
 				frame.stopListening( item );
 				frame.trigger( 'edit:attachment', model );


### PR DESCRIPTION
See https://core.trac.wordpress.org/ticket/42760

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**