### PR TITLE
5.0 Branch - Local Docker environment

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,34 @@
+##
+# Default configuration options for the local dev environment.
+#
+# All of these options can be overridden by setting them as environment variables before starting
+# the environment. You will need to restart your environment when changing any of these.
+##
+
+# The site will be available at http://localhost:LOCAL_PORT
+LOCAL_PORT=8889
+
+# Where to run WordPress from. Valid options are 'src' and 'build'.
+LOCAL_DIR=src
+
+# The PHP version to use. Valid options are 'latest', and '{version}-fpm', where '{version}' is any
+# x.y PHP version from 5.2 onwards.
+LOCAL_PHP=7.3-fpm
+
+# Whether or not to enable XDebug.
+LOCAL_PHP_XDEBUG=false
+
+# Whether or not to enable Memcached.
+LOCAL_PHP_MEMCACHED=false
+
+# The MySQL version to use. See https://hub.docker.com/_/mysql/ for valid versions.
+LOCAL_MYSQL=5.7
+
+# The debug settings to add to `wp-config.php`.
+LOCAL_WP_DEBUG=true
+LOCAL_WP_DEBUG_LOG=true
+LOCAL_WP_DEBUG_DISPLAY=true
+LOCAL_SCRIPT_DEBUG=true
+
+# The URL to use when running e2e tests.
+WP_BASE_URL=http://localhost:${LOCAL_PORT}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,96 +1,117 @@
-sudo: false
-dist: trusty
-language: php
+language: generic
+
+services:
+  - docker
+
+addons:
+  apt:
+    packages:
+      - docker-ce
+
 cache:
   apt: true
   directories:
     - $HOME/.npm
     - vendor
-    - $HOME/.composer/cache
+
 env:
   global:
-    - WP_TRAVISCI=travis:phpunit
+    - LOCAL_DIR: build
+    - COMPOSER_INSTALL: false
+    - NPM_INSTALL: true
+    - WP_INSTALL: true
+    - PHP_FPM_UID: "`id -u`"
+    - PHP_FPM_GID: "`id -g`"
+
 matrix:
   include:
-  - php: 7.3
-  - php: 7.1
-    env: WP_TRAVISCI=travis:js
-  - php: 5.6
-    env: WP_TRAVIS_OBJECT_CACHE=true
-    services: memcached
-  - php: 5.2
-    dist: precise
+    - env: WP_TRAVISCI=travis:js LOCAL_PHP=7.1-fpm WP_INSTALL=false
+      name: "JS Tests"
+    - env: LOCAL_PHP=7.3-fpm WP_TRAVISCI=test:php
+      name: "PHPUnit Tests: PHP 7.3"
+    - env: LOCAL_PHP=5.6-fpm LOCAL_PHP_MEMCACHED=true WP_TRAVISCI=test:php
+      name: "PHPUnit Tests: PHP 5.6 with Memcached"
+    - env: LOCAL_PHP=5.2-fpm LOCAL_MYSQL=5.6 WP_TRAVISCI=test:php
+      name: "PHPUnit Tests: PHP 5.2"
+  fast_finish: true
+
 before_install:
-- |
-  if [[ "$WP_TRAVISCI" == "travis:phpunit" ]]; then
-      mysql -u root -e "CREATE DATABASE wordpress_tests;"
-      cp wp-tests-config-sample.php wp-tests-config.php
-      sed -i "s/youremptytestdbnamehere/wordpress_tests/" wp-tests-config.php
-      sed -i "s/yourusernamehere/root/" wp-tests-config.php
-      sed -i "s/yourpasswordhere//" wp-tests-config.php
+  - |
+    if [[ "$WP_TRAVISCI" == "test:php" ]]; then
       travis_retry svn checkout https://plugins.svn.wordpress.org/wordpress-importer/tags/0.6.3/ tests/phpunit/data/plugins/wordpress-importer
-  fi
-- |
-  if [[ "$WP_TRAVIS_OBJECT_CACHE" == "true" ]]; then
-    cp tests/phpunit/includes/object-cache.php src/wp-content/object-cache.php
-    echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-  fi
+    fi
+  - |
+    sudo rm /usr/local/bin/docker-compose
+    curl -L https://github.com/docker/compose/releases/download/1.24.0/docker-compose-`uname -s`-`uname -m` > docker-compose
+    chmod +x docker-compose
+    sudo mv docker-compose /usr/local/bin
+
 before_script:
-- |
-  # Remove Xdebug for a huge performance increase:
-  if [ -f ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini ]; then
-    phpenv config-rm xdebug.ini
-  else
-    echo "xdebug.ini does not exist"
-  fi
-- |
-  # Export Composer's global bin dir to PATH, but not on PHP 5.2:
-  if [[ ${TRAVIS_PHP_VERSION:0:3} != "5.2" ]]; then
-    composer config --list --global
-    export PATH=`composer config --list --global | grep '\[home\]' | { read a; echo "${a#* }/vendor/bin:$PATH"; }`
-  fi
-- |
-  # Install the specified version of PHPUnit depending on the PHP version:
-  if [[ "$WP_TRAVISCI" == "travis:phpunit" ]]; then
-    case "$TRAVIS_PHP_VERSION" in
-      7.3|7.2|7.1|7.0|nightly)
-        echo "Using PHPUnit 6.x"
-        travis_retry composer global require "phpunit/phpunit:^6"
-        ;;
-      5.6|5.5|5.4|5.3)
-        echo "Using PHPUnit 4.x"
-        travis_retry composer global require "phpunit/phpunit:^4"
-        ;;
-      5.2)
-        # Do nothing, use default PHPUnit 3.6.x
-        echo "Using default PHPUnit, hopefully 3.6"
-        ;;
-      *)
-        echo "No PHPUnit version handling for PHP version $TRAVIS_PHP_VERSION"
-        exit 1
-        ;;
-    esac
-  fi
-- npm --version
-- node --version
-- nvm install 10.13.0
-- npm install -g grunt-cli
-- npm install
-- npm prune
-- mysql --version
-- phpenv versions
-- php --version
-- php -m
-- npm --version
-- node --version
-- which phpunit
-- phpunit --version
-- curl --version
-- grunt --version
-- git --version
-- svn --version
-- locale -a
-script: grunt $WP_TRAVISCI
+  - |
+    if [[ "$COMPOSER_INSTALL" == "true" ]]; then
+      docker-compose run --rm php composer --version
+      docker-compose run --rm php composer install
+    fi
+  - npm --version
+  - node --version
+  - nvm install 10.13.0
+  - |
+    if [[ "$NPM_INSTALL" == "true" ]]; then
+      npm ci
+    fi
+  - |
+    if [[ "$WP_TRAVISCI" == "test:php" ]]; then
+      npm run env:start
+      npm run build
+      docker-compose run --rm mysql mysql --version
+      docker-compose run --rm php php --version
+      docker-compose run --rm php php -m
+      docker-compose run --rm phpunit phpunit --version
+    fi
+  - |
+    if [[ "$LOCAL_PHP_MEMCACHED" == "true" ]]; then
+      cp tests/phpunit/includes/object-cache.php build/wp-content/object-cache.php
+      # The memcached server needs to start after `npm run env:start`, which sets up the Docker network.
+      docker run --name memcached --net $(basename "$PWD")_wpdevnet -d memcached
+    fi
+  - |
+    if [[ "$WP_INSTALL" == "true" ]]; then
+      # Run the install process after memcached has started.
+      npm run env:install
+    fi
+  - npm --version
+  - node --version
+  - curl --version
+  - git --version
+  - svn --version
+  - php --version
+  - php -i
+  - locale -a
+
+script:
+  - |
+    if [[ "$WP_TRAVISCI" == "test:php" ]]; then
+      npm run test:php -- --verbose -c phpunit.xml.dist &&
+      npm run test:php -- --verbose -c phpunit.xml.dist --group ajax &&
+      npm run test:php -- --verbose -c tests/phpunit/multisite.xml &&
+      npm run test:php -- --verbose -c tests/phpunit/multisite.xml --group ms-files &&
+      npm run test:php -- --verbose -c phpunit.xml.dist --group external-http &&
+      npm run test:php -- --verbose -c phpunit.xml.dist --group restapi-jsclient &&
+      # __fakegroup__ is excluded to force PHPUnit to ignore the <exclude> settings in phpunit.xml.dist.
+      LOCAL_PHP_XDEBUG=true npm run test:php -- -v --group xdebug --exclude-group __fakegroup__
+    elif [[ "$WP_TRAVISCI" == "lint:php" ]]; then
+      docker-compose run --rm php composer format
+    else
+      npm run grunt $WP_TRAVISCI
+    fi
+
+after_script:
+  - |
+    if [[ "$WP_TEST_REPORTER" == "true" ]]; then
+      git clone https://github.com/WordPress/phpunit-test-runner.git test-runner
+      docker-compose run --rm -e WPT_PREPARE_DIR=/var/www -e WPT_TEST_DIR=/var/www php php test-runner/report.php
+    fi
+
 notifications:
   slack:
     rooms:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
       name: "PHPUnit Tests: PHP 7.3"
     - env: LOCAL_PHP=5.6-fpm LOCAL_PHP_MEMCACHED=true WP_TRAVISCI=test:php
       name: "PHPUnit Tests: PHP 5.6 with Memcached"
-    - env: LOCAL_PHP=5.2-fpm LOCAL_MYSQL=5.6 WP_TRAVISCI=test:php
+    - env: LOCAL_PHP=5.2-fpm LOCAL_MYSQL=5.5 WP_TRAVISCI=test:php
       name: "PHPUnit Tests: PHP 5.2"
   fast_finish: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,9 @@ env:
 
 matrix:
   include:
-    - env: WP_TRAVISCI=travis:js LOCAL_PHP=7.1-fpm WP_INSTALL=false
+    - env: LOCAL_PHP=7.1-fpm WP_TRAVISCI=travis:js WP_INSTALL=false
       name: "JS Tests"
-    - env: LOCAL_PHP=7.3-fpm WP_TRAVISCI=test:php
+    - env: WP_TRAVISCI=test:php
       name: "PHPUnit Tests: PHP 7.3"
     - env: LOCAL_PHP=5.6-fpm LOCAL_PHP_MEMCACHED=true WP_TRAVISCI=test:php
       name: "PHPUnit Tests: PHP 5.6 with Memcached"

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 		"wp-coding-standards/wpcs": "~1.0.0"
 	},
 	"scripts": {
-		"format": "phpcbf --standard=phpcs.xml.dist --report-summary --report-source",
-		"lint": "phpcs --standard=phpcs.xml.dist --report-summary --report-source"
+		"format": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf --report=summary,source",
+		"lint": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --report=summary,source"
 	}
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,131 @@
+version: '3.7'
+
+services:
+
+  ##
+  # The web server container.
+  ##
+  wordpress-develop:
+    image: nginx:alpine
+
+    networks:
+      - wpdevnet
+
+    ports:
+      - ${LOCAL_PORT-8889}:80
+
+    environment:
+      LOCAL_DIR: ${LOCAL_DIR-src}
+
+    volumes:
+      - ./tools/local-env/default.template:/etc/nginx/conf.d/default.template
+      - ./:/var/www
+
+    # Load our config file, substituning environment variables into the config.
+    command: /bin/sh -c "envsubst '$$LOCAL_DIR' < /etc/nginx/conf.d/default.template > /etc/nginx/conf.d/default.conf && exec nginx -g 'daemon off;'"
+
+    depends_on:
+      - php
+
+  ##
+  # The PHP container.
+  ##
+  php:
+    image: wordpressdevelop/php:${LOCAL_PHP-7.3-fpm}
+
+    networks:
+      - wpdevnet
+
+    environment:
+      LOCAL_PHP_XDEBUG: ${LOCAL_PHP_XDEBUG-false}
+      LOCAL_PHP_MEMCACHED: ${LOCAL_PHP_MEMCACHED-false}
+      PHP_FPM_UID: ${PHP_FPM_UID-1000}
+      PHP_FPM_GID: ${PHP_FPM_GID-1000}
+
+    volumes:
+      - ./tools/local-env/php-config.ini:/usr/local/etc/php/conf.d/php-config.ini
+      - ./:/var/www
+
+    depends_on:
+      - mysql
+
+  ##
+  # The MySQL container.
+  ##
+  mysql:
+    image: mysql:${LOCAL_MYSQL-latest}
+
+    networks:
+      - wpdevnet
+
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+
+    volumes:
+      - ./tools/local-env/mysql-init.sql:/docker-entrypoint-initdb.d/mysql-init.sql
+      - mysql:/var/lib/mysql
+
+    # For compatibility with PHP versions that don't support the caching_sha2_password auth plugin used in MySQL 8.0.
+    command: --default-authentication-plugin=mysql_native_password
+
+  ##
+  # The WP CLI container.
+  ##
+  cli:
+    image: wordpressdevelop/cli:${LOCAL_PHP-7.3-fpm}
+
+    networks:
+      - wpdevnet
+
+    environment:
+      LOCAL_PHP_XDEBUG: ${LOCAL_PHP_XDEBUG-false}
+      LOCAL_PHP_MEMCACHED: ${LOCAL_PHP_MEMCACHED-false}
+      PHP_FPM_UID: ${PHP_FPM_UID-1000}
+      PHP_FPM_GID: ${PHP_FPM_GID-1000}
+
+    volumes:
+      - ./:/var/www
+
+    # The init directive ensures the command runs with a PID > 1, so Ctrl+C works correctly.
+    init: true
+
+  ##
+  # The PHPUnit container.
+  ##
+  phpunit:
+    image: wordpressdevelop/phpunit:${LOCAL_PHP-7.3-fpm}
+
+    networks:
+      - wpdevnet
+
+    environment:
+      LOCAL_PHP_XDEBUG: ${LOCAL_PHP_XDEBUG-false}
+      LOCAL_PHP_MEMCACHED: ${LOCAL_PHP_MEMCACHED-false}
+      LOCAL_DIR: ${LOCAL_DIR-src}
+      WP_MULTISITE: ${WP_MULTISITE-false}
+      PHP_FPM_UID: ${PHP_FPM_UID-1000}
+      PHP_FPM_GID: ${PHP_FPM_GID-1000}
+      TRAVIS_BRANCH: ${TRAVIS_BRANCH-false}
+      TRAVIS_PULL_REQUEST: ${TRAVIS_PULL_REQUEST-false}
+
+    volumes:
+      - ./tools/local-env/phpunit-config.ini:/usr/local/etc/php/conf.d/phpunit-config.ini
+      - ./:/var/www
+      - phpunit-uploads:/var/www/${LOCAL_DIR-src}/wp-content/uploads
+
+    # The init directive ensures the command runs with a PID > 1, so Ctrl+C works correctly.
+    init: true
+
+    depends_on:
+      - mysql
+
+volumes:
+  # So that sites aren't wiped every time containers are restarted, MySQL uses a persistent volume.
+  mysql: {}
+  # Using a volume for the uploads directory improves PHPUnit performance.
+  phpunit-uploads: {}
+
+networks:
+  # Creating our own network allows us to connect between containers using their service name.
+  wpdevnet:
+    driver: bridge

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,45 @@
 				}
 			}
 		},
+		"@hapi/address": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
+			"integrity": "sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ==",
+			"dev": true
+		},
+		"@hapi/bourne": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
+			"integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==",
+			"dev": true
+		},
+		"@hapi/hoek": {
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
+			"integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw==",
+			"dev": true
+		},
+		"@hapi/joi": {
+			"version": "15.1.1",
+			"resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
+			"integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
+			"dev": true,
+			"requires": {
+				"@hapi/address": "2.x.x",
+				"@hapi/bourne": "1.x.x",
+				"@hapi/hoek": "8.x.x",
+				"@hapi/topo": "3.x.x"
+			}
+		},
+		"@hapi/topo": {
+			"version": "3.1.6",
+			"resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
+			"integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
+			"dev": true,
+			"requires": {
+				"@hapi/hoek": "^8.3.0"
+			}
+		},
 		"@tannin/compile": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.0.1.tgz",
@@ -4311,6 +4350,18 @@
 			"requires": {
 				"is-obj": "^1.0.0"
 			}
+		},
+		"dotenv": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.1.0.tgz",
+			"integrity": "sha512-GUE3gqcDCaMltj2++g6bRQ5rBJWtkWTmqmD0fo1RnnMuUqHNCt2oTPeDnS9n6fKYvlhn7AeBkb38lymBtWBQdA==",
+			"dev": true
+		},
+		"dotenv-expand": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
+			"integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
+			"dev": true
 		},
 		"download": {
 			"version": "4.4.3",
@@ -12434,6 +12485,12 @@
 			"resolved": "https://registry.npmjs.org/rungen/-/rungen-0.3.2.tgz",
 			"integrity": "sha1-QAwJ6+kU57F+C27zJjQA/Cq8fLM="
 		},
+		"rx": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
+			"integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
+			"dev": true
+		},
 		"rxjs": {
 			"version": "5.5.12",
 			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
@@ -14547,6 +14604,33 @@
 			"dev": true,
 			"requires": {
 				"indexof": "0.0.1"
+			}
+		},
+		"wait-on": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/wait-on/-/wait-on-3.3.0.tgz",
+			"integrity": "sha512-97dEuUapx4+Y12aknWZn7D25kkjMk16PbWoYzpSdA8bYpVfS6hpl2a2pOWZ3c+Tyt3/i4/pglyZctG3J4V1hWQ==",
+			"dev": true,
+			"requires": {
+				"@hapi/joi": "^15.0.3",
+				"core-js": "^2.6.5",
+				"minimist": "^1.2.0",
+				"request": "^2.88.0",
+				"rx": "^4.1.0"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+					"dev": true
+				},
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
+				}
 			}
 		},
 		"walkdir": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
 		"autoprefixer": "^9.1.5",
 		"copy-webpack-plugin": "^4.6.0",
 		"cssnano": "^4.1.4",
+		"dotenv": "8.1.0",
+		"dotenv-expand": "5.1.0",
 		"grunt": "~1.0.3",
 		"grunt-banner": "^0.6.0",
 		"grunt-contrib-clean": "~2.0.0",
@@ -44,6 +46,7 @@
 		"matchdep": "~2.0.0",
 		"source-map-loader": "^0.2.4",
 		"uglify-js": "^3.4.9",
+		"wait-on": "3.3.0",
 		"webpack": "^4.24.0",
 		"webpack-dev-server": "^3.1.9",
 		"webpack-livereload-plugin": "^2.1.1"
@@ -97,6 +100,20 @@
 		"whatwg-fetch": "^3.0.0"
 	},
 	"scripts": {
-		"grunt": "grunt"
+		"build": "grunt build",
+		"build:dev": "grunt build --dev",
+		"dev": "grunt watch --dev",
+		"test": "grunt test",
+		"watch": "grunt watch",
+		"grunt": "grunt",
+		"env:start": "node ./tools/local-env/scripts/start.js",
+		"env:stop": "node ./tools/local-env/scripts/docker.js down",
+		"env:clean": "node ./tools/local-env/scripts/docker.js down -v --remove-orphans",
+		"env:reset": "node ./tools/local-env/scripts/docker.js down --rmi all -v --remove-orphans",
+		"env:install": "node ./tools/local-env/scripts/install.js",
+		"env:cli": "node ./tools/local-env/scripts/docker.js run cli",
+		"env:logs": "node ./tools/local-env/scripts/docker.js logs",
+		"env:pull": "node ./tools/local-env/scripts/docker.js pull",
+		"test:php": "node ./tools/local-env/scripts/docker.js run --rm phpunit phpunit"
 	}
 }

--- a/tests/phpunit/includes/object-cache.php
+++ b/tests/phpunit/includes/object-cache.php
@@ -829,7 +829,7 @@ class WP_Object_Cache {
 		if ( isset( $memcached_servers ) )
 			$this->servers = $memcached_servers;
 		else
-			$this->servers = array( array( '127.0.0.1', 11211 ) );
+			$this->servers = array( array( 'memcached', 11211 ) );
 
 		$this->addServers( $this->servers );
 

--- a/tests/phpunit/tests/ajax/CustomizeMenus.php
+++ b/tests/phpunit/tests/ajax/CustomizeMenus.php
@@ -54,7 +54,7 @@ class Tests_Ajax_CustomizeMenus extends WP_Ajax_UnitTestCase {
 
 		if ( 'administrator' != $role ) {
 			// If we're not an admin, we should get a wp_die(-1).
-			$this->setExpectedException( 'WPAjaxDieStopException' );
+			$this->setExpectedException( 'WPAjaxDieStopException', '-1' );
 		}
 
 		wp_set_current_user( self::factory()->user->create( array( 'role' => $role ) ) );
@@ -429,7 +429,7 @@ class Tests_Ajax_CustomizeMenus extends WP_Ajax_UnitTestCase {
 
 		if ( 'administrator' != $role ) {
 			// If we're not an admin, we should get a wp_die(-1).
-			$this->setExpectedException( 'WPAjaxDieStopException' );
+			$this->setExpectedException( 'WPAjaxDieStopException', '-1' );
 		}
 
 		wp_set_current_user( self::factory()->user->create( array( 'role' => $role ) ) );

--- a/tools/local-env/default.template
+++ b/tools/local-env/default.template
@@ -1,0 +1,31 @@
+server {
+	index index.php index.html;
+
+	listen 80 default_server;
+	listen [::]:80 default_server;
+
+	server_name localhost;
+
+	client_max_body_size 1g;
+
+	error_log  /var/log/nginx/error.log;
+	access_log /var/log/nginx/access.log;
+
+	root /var/www/${LOCAL_DIR};
+
+	absolute_redirect off;
+
+	location / {
+		try_files $uri $uri/ /index.php?$args;
+	}
+
+	location ~ \.php$ {
+		try_files $uri =404;
+		fastcgi_split_path_info ^(.+\.php)(/.+)$;
+		fastcgi_pass php:9000;
+		fastcgi_index index.php;
+		include fastcgi_params;
+		fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+		fastcgi_param PATH_INFO $fastcgi_path_info;
+	}
+}

--- a/tools/local-env/mysql-init.sql
+++ b/tools/local-env/mysql-init.sql
@@ -1,0 +1,8 @@
+/**
+ * MySQL server init.
+ *
+ * SQL queries in this file will be executed the first time the MySQL server is started.
+ */
+
+CREATE DATABASE IF NOT EXISTS wordpress_develop;
+CREATE DATABASE IF NOT EXISTS wordpress_develop_tests;

--- a/tools/local-env/php-config.ini
+++ b/tools/local-env/php-config.ini
@@ -1,0 +1,2 @@
+upload_max_filesize = 1G
+post_max_size = 1G

--- a/tools/local-env/phpunit-config.ini
+++ b/tools/local-env/phpunit-config.ini
@@ -1,0 +1,6 @@
+upload_max_filesize = 1G
+post_max_size = 1G
+
+opcache.enable = 1
+opcache.enable_cli = 1
+opache.file_cache = /tmp/php-opcache

--- a/tools/local-env/scripts/docker.js
+++ b/tools/local-env/scripts/docker.js
@@ -1,0 +1,6 @@
+const dotenv = require( 'dotenv' );
+const { execSync } = require( 'child_process' );
+dotenv.config();
+
+// Execute any docker-compose command passed to this script.
+execSync( 'docker-compose ' + process.argv.slice( 2 ).join( ' ' ), { stdio: 'inherit' } );

--- a/tools/local-env/scripts/install.js
+++ b/tools/local-env/scripts/install.js
@@ -1,0 +1,45 @@
+const dotenv = require( 'dotenv' );
+const wait_on = require( 'wait-on' );
+const { execSync } = require( 'child_process' );
+const { renameSync, readFileSync, writeFileSync } = require( 'fs' );
+
+dotenv.config();
+
+// Create wp-config.php.
+wp_cli( 'config create --dbname=wordpress_develop --dbuser=root --dbpass=password --dbhost=mysql --path=/var/www/src --force' );
+
+// Add the debug settings to wp-config.php.
+// Windows requires this to be done as an additional step, rather than using the --extra-php option in the previous step.
+wp_cli( `config set WP_DEBUG ${process.env.LOCAL_WP_DEBUG} --raw` );
+wp_cli( `config set WP_DEBUG_LOG ${process.env.LOCAL_WP_DEBUG_LOG} --raw` );
+wp_cli( `config set WP_DEBUG_DISPLAY ${process.env.LOCAL_WP_DEBUG_DISPLAY} --raw` );
+wp_cli( `config set SCRIPT_DEBUG ${process.env.LOCAL_SCRIPT_DEBUG} --raw` );
+
+// Move wp-config.php to the base directory, so it doesn't get mixed up in the src or build directories.
+renameSync( 'src/wp-config.php', 'wp-config.php' );
+
+// Read in wp-tests-config-sample.php, edit it to work with our config, then write it to wp-tests-config.php.
+const testConfig = readFileSync( 'wp-tests-config-sample.php', 'utf8' )
+	.replace( 'youremptytestdbnamehere', 'wordpress_develop_tests' )
+	.replace( 'yourusernamehere', 'root' )
+	.replace( 'yourpasswordhere', 'password' )
+	.replace( 'localhost', 'mysql' )
+	.concat( "\ndefine( 'FS_METHOD', 'direct' );\n" );
+
+writeFileSync( 'wp-tests-config.php', testConfig );
+
+// Once the site is available, install WordPress!
+wait_on( { resources: [ `tcp:localhost:${process.env.LOCAL_PORT}`] } )
+	.then( () => {
+		wp_cli( 'db reset --yes' );
+		wp_cli( `core install --title="WordPress Develop" --admin_user=admin --admin_password=password --admin_email=test@test.com --skip-email --url=http://localhost:${process.env.LOCAL_PORT}` );
+	} );
+
+/**
+ * Runs WP-CLI commands in the Docker environment.
+ *
+ * @param {string} cmd The WP-CLI command to run.
+ */
+function wp_cli( cmd ) {
+	execSync( `docker-compose run --rm cli ${cmd}`, { stdio: 'inherit' } );
+}

--- a/tools/local-env/scripts/start.js
+++ b/tools/local-env/scripts/start.js
@@ -1,0 +1,35 @@
+const dotenv = require( 'dotenv' );
+const { execSync } = require( 'child_process' );
+
+dotenv.config();
+
+// Start the local-env containers.
+execSync( 'docker-compose up -d wordpress-develop', { stdio: 'inherit' } );
+
+// If Docker Toolbox is being used, we need to manually forward LOCAL_PORT to the Docker VM.
+if ( process.env.DOCKER_TOOLBOX_INSTALL_PATH ) {
+	// VBoxManage is added to the PATH on every platform except Windows.
+	const vboxmanage = process.env.VBOX_MSI_INSTALL_PATH ? `${ process.env.VBOX_MSI_INSTALL_PATH }/VBoxManage` : 'VBoxManage'
+
+	// Check if the port forwarding is already configured for this port.
+	const vminfoBuffer = execSync( `"${ vboxmanage }" showvminfo "${ process.env.DOCKER_MACHINE_NAME }" --machinereadable` );
+	const vminfo = vminfoBuffer.toString().split( /[\r\n]+/ );
+
+	vminfo.forEach( ( info ) => {
+		if ( ! info.startsWith( 'Forwarding' ) ) {
+			return;
+		}
+
+		// `info` is in the format: Forwarding(1)="tcp-port8889,tcp,127.0.0.1,8889,,8889"
+		// Parse it down so `rule` only contains the data inside quotes, split by ','.
+		const rule = info.replace( /(^.*?"|"$)/, '' ).split( ',' );
+
+		// Delete rules that are using the port we need.
+		if ( rule[ 3 ] === process.env.LOCAL_PORT || rule[ 5 ] === process.env.LOCAL_PORT ) {
+			execSync( `"${ vboxmanage }" controlvm "${ process.env.DOCKER_MACHINE_NAME }" natpf1 delete ${ rule[ 0 ] }`, { stdio: 'inherit' } );
+		}
+	} );
+
+	// Add our port forwarding rule.
+	execSync( `"${ vboxmanage }" controlvm "${ process.env.DOCKER_MACHINE_NAME }" natpf1 "tcp-port${ process.env.LOCAL_PORT },tcp,127.0.0.1,${ process.env.LOCAL_PORT },,${ process.env.LOCAL_PORT }"`, { stdio: 'inherit' } );
+}


### PR DESCRIPTION
Current issues:

PHP 7.3: There is a `Fatal error: Class PHPUnit_Util_Test may not inherit from final class (PHPUnit\Util\Test) in /var/www/tests/phpunit/includes/phpunit6-compat.php on line 18` fatal error occurring. I believe that this is being caused because PHPUnit 7 is being packaged in the `PHP 7.1-7.3 images, but WordPress 5.0 required PHPUnit 6.

For the 5.2 build, the issue is similar to #134 where there is an error returned when starting the MySQL server:
`/usr/local/bin/docker-php-ext-enable: 5: cd: can't cd to /usr/local/lib/php/extensions/no-debug-non-zts-20060613`

See https://core.trac.wordpress.org/ticket/48301.