### PR TITLE
Media: Clear the selection fields after cropping.

### DIFF
--- a/src/js/_enqueues/lib/image-edit.js
+++ b/src/js/_enqueues/lib/image-edit.js
@@ -910,6 +910,10 @@
 			sel.fh = h;
 			this.addStep({ 'c': sel }, postid, nonce);
 		}
+
+		// Clear the selection fields after cropping.
+		$('#imgedit-sel-width-' + postid).val('');
+		$('#imgedit-sel-height-' + postid).val('');
 	},
 
 	/**


### PR DESCRIPTION
Resovle an issue where the media selection would be reapplied if the crop button was clicked again after clicking undo.

See https://core.trac.wordpress.org/ticket/30155