### PR TITLE
REST API: Add support for the REDIRECT_HTTP_AUTHORIZATION header.

### DIFF
--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -1374,7 +1374,7 @@ class WP_REST_Server {
 				 * In some server configurations, the authorization header is passed in this alternate location.
 				 * Since it would not be passed in in both places we do not check for both headers and resolve.
 				 */
-				$headers[ 'AUTHORIZATION' ] = $value;
+				$headers['AUTHORIZATION'] = $value;
 			} elseif ( isset( $additional[ $key ] ) ) {
 				$headers[ $key ] = $value;
 			}

--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -1369,6 +1369,12 @@ class WP_REST_Server {
 		foreach ( $server as $key => $value ) {
 			if ( strpos( $key, 'HTTP_' ) === 0 ) {
 				$headers[ substr( $key, 5 ) ] = $value;
+			} elseif ( 'REDIRECT_HTTP_AUTHORIZATION' === $key && empty( $server['HTTP_AUTHORIZATION'] ) ) {
+				/*
+				 * In some server configurations, the authorization header is passed in this alternate location.
+				 * Since it would not be passed in in both places we do not check for both headers and resolve.
+				 */
+				$headers[ 'AUTHORIZATION' ] = $value;
 			} elseif ( isset( $additional[ $key ] ) ) {
 				$headers[ $key ] = $value;
 			}

--- a/tests/phpunit/tests/rest-api/rest-server.php
+++ b/tests/phpunit/tests/rest-api/rest-server.php
@@ -1343,7 +1343,10 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 	 * @ticket 47077
 	 */
 	public function test_redirect_http_authorization_with_http_authorization_header_substitution() {
-		$headers        = array( 'HTTP_AUTHORIZATION' => 'foo', 'REDIRECT_HTTP_AUTHORIZATION' => 'bar' );
+		$headers        = array(
+			'HTTP_AUTHORIZATION'          => 'foo',
+			'REDIRECT_HTTP_AUTHORIZATION' => 'bar',
+		);
 		$parsed_headers = rest_get_server()->get_headers( $headers );
 
 		$this->assertSame(
@@ -1356,7 +1359,10 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 	 * @ticket 47077
 	 */
 	public function test_redirect_http_authorization_with_empty_http_authorization_header_substitution() {
-		$headers        = array( 'HTTP_AUTHORIZATION' => '', 'REDIRECT_HTTP_AUTHORIZATION' => 'bar' );
+		$headers        = array(
+			'HTTP_AUTHORIZATION'          => '',
+			'REDIRECT_HTTP_AUTHORIZATION' => 'bar',
+		);
 		$parsed_headers = rest_get_server()->get_headers( $headers );
 
 		$this->assertSame(

--- a/tests/phpunit/tests/rest-api/rest-server.php
+++ b/tests/phpunit/tests/rest-api/rest-server.php
@@ -1313,6 +1313,58 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 		$this->assertEquals( '', rest_get_server()->sent_body );
 	}
 
+	/**
+	 * @ticket 47077
+	 */
+	public function test_http_authorization_header_substitution() {
+		$headers        = array( 'HTTP_AUTHORIZATION' => 'foo' );
+		$parsed_headers = rest_get_server()->get_headers( $headers );
+
+		$this->assertSame(
+			array( 'AUTHORIZATION' => 'foo' ),
+			$parsed_headers
+		);
+	}
+
+	/**
+	 * @ticket 47077
+	 */
+	public function test_redirect_http_authorization_header_substitution() {
+		$headers        = array( 'REDIRECT_HTTP_AUTHORIZATION' => 'foo' );
+		$parsed_headers = rest_get_server()->get_headers( $headers );
+
+		$this->assertSame(
+			array( 'AUTHORIZATION' => 'foo' ),
+			$parsed_headers
+		);
+	}
+
+	/**
+	 * @ticket 47077
+	 */
+	public function test_redirect_http_authorization_with_http_authorization_header_substitution() {
+		$headers        = array( 'HTTP_AUTHORIZATION' => 'foo', 'REDIRECT_HTTP_AUTHORIZATION' => 'bar' );
+		$parsed_headers = rest_get_server()->get_headers( $headers );
+
+		$this->assertSame(
+			array( 'AUTHORIZATION' => 'foo' ),
+			$parsed_headers
+		);
+	}
+
+	/**
+	 * @ticket 47077
+	 */
+	public function test_redirect_http_authorization_with_empty_http_authorization_header_substitution() {
+		$headers        = array( 'HTTP_AUTHORIZATION' => '', 'REDIRECT_HTTP_AUTHORIZATION' => 'bar' );
+		$parsed_headers = rest_get_server()->get_headers( $headers );
+
+		$this->assertSame(
+			array( 'AUTHORIZATION' => 'bar' ),
+			$parsed_headers
+		);
+	}
+
 	public function _validate_as_integer_123( $value, $request, $key ) {
 		if ( ! is_int( $value ) ) {
 			return new WP_Error( 'some-error', 'This is not valid!' );


### PR DESCRIPTION
Previously the REST API did not account for server configurations where the Authorization header must be added using ModRewrite. This caused major DUX issues when trying to use custom authentication mechanisms.

Fixes #47077.
Props dshanske, cklosows.