### PR TITLE
REST API: Fix routing when one namespaces is the prefix of another.

### DIFF
--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -879,16 +879,17 @@ class WP_REST_Server {
 		$method = $request->get_method();
 		$path   = $request->get_route();
 
-		$routes = array();
+		$with_namespace = array();
 
 		foreach ( $this->get_namespaces() as $namespace ) {
-			if ( 0 === strpos( ltrim( $path, '/' ), $namespace ) ) {
-				$routes = $this->get_routes( $namespace );
-				break;
+			if ( 0 === strpos( trailingslashit( ltrim( $path, '/' ) ), $namespace ) ) {
+				$with_namespace[] = $this->get_routes( $namespace );
 			}
 		}
 
-		if ( ! $routes ) {
+		if ( $with_namespace ) {
+			$routes = array_merge( ...$with_namespace );
+		} else {
 			$routes = $this->get_routes();
 		}
 

--- a/tests/phpunit/tests/rest-api/rest-server.php
+++ b/tests/phpunit/tests/rest-api/rest-server.php
@@ -1442,6 +1442,37 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 		}
 	}
 
+	/**
+	 * @ticket 48530
+	 */
+	public function test_get_routes_no_namespace_overriding() {
+		register_rest_route(
+			'test-ns',
+			'/test',
+			array(
+				'methods'  => array( 'GET' ),
+				'callback' => function() {
+					return new WP_REST_Response( 'data', 204 );
+				},
+			)
+		);
+		register_rest_route(
+			'test-ns/v1',
+			'/test',
+			array(
+				'methods'  => array( 'GET' ),
+				'callback' => function() {
+					return new WP_REST_Response( 'data', 204 );
+				},
+			)
+		);
+
+		$request  = new WP_REST_Request( 'GET', '/test-ns/v1/test' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertEquals( 204, $response->get_status(), '/test-ns/v1/test' );
+	}
+
 	public function _validate_as_integer_123( $value, $request, $key ) {
 		if ( ! is_int( $value ) ) {
 			return new WP_Error( 'some-error', 'This is not valid!' );


### PR DESCRIPTION
While not recommended, a plugin may register routes in both the "test" prefix and the "test/v1" prefix. After r47260 routes registered in the latter prefix would not be discoverable.

The REST API now includes routes from all possible namespaces instead of stopping at the first match.

Fixes https://core.trac.wordpress.org/ticket/48530.
Props david.binda.