### PR TITLE
Ticket 49483 solution

### DIFF
--- a/src/wp-admin/network/settings.php
+++ b/src/wp-admin/network/settings.php
@@ -380,7 +380,7 @@ if ( isset( $_GET['updated'] ) ) {
 			<tr>
 				<th scope="row"><label for="upload_filetypes"><?php _e( 'Upload file types' ); ?></label></th>
 				<td>
-					<input name="upload_filetypes" type="text" id="upload_filetypes" aria-describedby="upload-filetypes-desc" class="large-text" value="<?php echo esc_attr( get_site_option( 'upload_filetypes', 'jpg jpeg png gif' ) ); ?>" size="45" />
+					<textarea name="upload_filetypes" id="upload_filetypes" aria-describedby="upload-filetypes-desc" cols="45" rows="5"><?php echo esc_attr( get_site_option( 'upload_filetypes', 'jpg jpeg png gif' ) ); ?></textarea>
 					<p class="description" id="upload-filetypes-desc">
 						<?php _e( 'Allowed file types. Separate types by spaces.' ); ?>
 					</p>

--- a/src/wp-admin/network/settings.php
+++ b/src/wp-admin/network/settings.php
@@ -382,7 +382,7 @@ if ( isset( $_GET['updated'] ) ) {
 				<td>
 					<textarea name="upload_filetypes" id="upload_filetypes" aria-describedby="upload-filetypes-desc" cols="45" rows="5"><?php echo esc_attr( get_site_option( 'upload_filetypes', 'jpg jpeg png gif' ) ); ?></textarea>
 					<p class="description" id="upload-filetypes-desc">
-						<?php _e( 'Allowed file types. Separate types by spaces.' ); ?>
+						<?php _e( 'Allowed file types. Separate types by spaces or new lines.' ); ?>
 					</p>
 				</td>
 			</tr>

--- a/src/wp-includes/ms-functions.php
+++ b/src/wp-includes/ms-functions.php
@@ -1830,7 +1830,8 @@ function get_most_recent_post_of_user( $user_id ) {
  * @return array
  */
 function check_upload_mimes( $mimes ) {
-	$site_exts  = explode( ' ', get_site_option( 'upload_filetypes', 'jpg jpeg png gif' ) );
+	$site_exts  = preg_split( '/[\s]+/', get_site_option( 'upload_filetypes', 'jpg jpeg png gif' ) );
++	$site_exts  = str_replace( '.', '', strtolower( $site_exts ) );
 	$site_mimes = array();
 	foreach ( $site_exts as $ext ) {
 		foreach ( $mimes as $ext_pattern => $mime ) {


### PR DESCRIPTION
**Trac Ticket URL**
https://core.trac.wordpress.org/ticket/49483

**Description** 
The setting field 'Upload file types' (CSS name='upload_filetypes') is currently a text input with visible width of 45 characters.
However, the default content of that field is 135 characters. Thus, it would be good to have it in the form of textarea to have a better look at all the content without the need for scrolling.

**Steps to find -**
At a multisite WordPress installation, go to My Sites -> Network Admin -> Settings.
Find the setting under the heading 'Upload Settings' with label 'Upload file types'.
The default value in that field is as follows -
_jpg jpeg png gif mov avi mpg 3gp 3g2 midi mid pdf doc ppt odt pptx docx pps ppsx xls xlsx key mp3 ogg flac m4a wav mp4 m4v webm ogv flv_