### PR TITLE
Remove unnecessary static var from get_column_headers implementation

### DIFF
--- a/src/wp-admin/includes/screen.php
+++ b/src/wp-admin/includes/screen.php
@@ -10,8 +10,8 @@
  * Get the column headers for a screen
  *
  * @since 2.7.0
- * @since 5.4.0 Removed static var making it difficult to instantiate list
- *              tables after the page header has been rendered.
+ * @since 5.5.0 Removed a static var that made it difficult to instantiate list
+ *              tables after the page header had been rendered.
  *
  * @param string|WP_Screen $screen The screen you want the headers for
  * @return string[] The column header labels keyed by column ID.

--- a/src/wp-admin/includes/screen.php
+++ b/src/wp-admin/includes/screen.php
@@ -10,8 +10,8 @@
  * Get the column headers for a screen
  *
  * @since 2.7.0
- *
- * @staticvar array $column_headers
+ * @since 5.4.0 Removed static var making it difficult to instantiate list
+ *              tables after the page header has been rendered.
  *
  * @param string|WP_Screen $screen The screen you want the headers for
  * @return string[] The column header labels keyed by column ID.
@@ -21,25 +21,19 @@ function get_column_headers( $screen ) {
 		$screen = convert_to_screen( $screen );
 	}
 
-	static $column_headers = array();
-
-	if ( ! isset( $column_headers[ $screen->id ] ) ) {
-		/**
-		 * Filters the column headers for a list table on a specific screen.
-		 *
-		 * The dynamic portion of the hook name, `$screen->id`, refers to the
-		 * ID of a specific screen. For example, the screen ID for the Posts
-		 * list table is edit-post, so the filter for that screen would be
-		 * manage_edit-post_columns.
-		 *
-		 * @since 3.0.0
-		 *
-		 * @param string[] $columns The column header labels keyed by column ID.
-		 */
-		$column_headers[ $screen->id ] = apply_filters( "manage_{$screen->id}_columns", array() );
-	}
-
-	return $column_headers[ $screen->id ];
+	/**
+	 * Filters the column headers for a list table on a specific screen.
+	 *
+	 * The dynamic portion of the hook name, `$screen->id`, refers to the
+	 * ID of a specific screen. For example, the screen ID for the Posts
+	 * list table is edit-post, so the filter for that screen would be
+	 * manage_edit-post_columns.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param string[] $columns The column header labels keyed by column ID.
+	 */
+	return apply_filters( "manage_{$screen->id}_columns", array() );
 }
 
 /**

--- a/tests/phpunit/tests/admin/includesListTable.php
+++ b/tests/phpunit/tests/admin/includesListTable.php
@@ -293,4 +293,26 @@ class Tests_Admin_includesListTable extends WP_UnitTestCase {
 
 		$this->assertNotContains( 'id="delete_all"', $output );
 	}
+
+	/**
+	 * Test that can a list can display with no dependency on core screen context.
+	 *
+	 * @ticket 15386
+	 */
+	public function test_table_list_renders() {
+		$table = _get_list_table( 'WP_Comments_List_Table', array( 'screen' => 'my-plugin-page' ) );
+
+		// At least one comment needed.
+		$this->factory->comment->create_many( 10 );
+
+		ob_start();
+
+		$table->views();
+		$table->prepare_items();
+		$table->display();
+		$output = ob_get_clean();
+
+		// CSS class only exists if the table has at least one comment.
+		$this->assertContains( 'class="submitted-on"', $output );
+	}
 }


### PR DESCRIPTION
Core ticket: https://core.trac.wordpress.org/ticket/15386

## Description of the change

This allows the filter in the `get_column_headers` function to be applied multiple times during page execution. Previously this function used a static variable to ensure the filter was only applied once per screen object per page load.

That static variable is not needed. The function doesn't need to maintain internal state because it's never called more than once within core, and I don't see any reason that the performance-related use cases for static variables apply here. I'm happy to discuss this further.

## Test steps

Before pulling these changes, put this in a file in `wp-content/plugins`

```
<?php
/**
 * Plugin Name: My List Table Plugin
 */

add_action( 'admin_menu', 'my_list_table_plugin_init' );

function my_list_table_plugin_init() {
	add_menu_page( 'Test', 'Test', 'manage_options', 'test', 'my_list_table_plugin_display' );
}

function my_list_table_plugin_display() {
	$table = _get_list_table( 'WP_Comments_List_Table' );
	$table->views();
	$table->prepare_items();
	$table->display();
}
```

#### Before

Activate the plugin. Visit /wp-admin/admin.php?page=test in your local environment. Note that the table displays without the expected table rows.

#### After

After pulling these changes, visit that page again. The table rows should now display.

## Further considerations

If this change were merged, wouldn't it mean that at least the `WP_List_Table` class and maybe also `_get_list_table` would no longer need to be private? If so, how would I deprecate `_get_list_table` in favor of `get_list_table`? Do we have documentation on that somewhere?

I feel the API around these list tables could be improved, however, and maybe even Gutenbergized. If others agree, then maybe that class and function should stay private for now.





