### PR TITLE
Ensure rest_ensure_response() upgrades WP_HTTP_Response to WP_REST_Response

### DIFF
--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -506,15 +506,15 @@ function rest_ensure_request( $request ) {
 /**
  * Ensures a REST response is a response object (for consistency).
  *
- * This implements WP_HTTP_Response, allowing usage of `set_status`/`header`/etc
+ * This implements WP_REST_Response, allowing usage of `set_status`/`header`/etc
  * without needing to double-check the object. Will also allow WP_Error to indicate error
  * responses, so users should immediately check for this value.
  *
  * @since 4.4.0
  *
- * @param WP_HTTP_Response|WP_Error|mixed $response Response to check.
+ * @param WP_REST_Response|WP_Error|WP_HTTP_Response|mixed $response Response to check.
  * @return WP_REST_Response|mixed If response generated an error, WP_Error, if response
- *                                is already an instance, WP_HTTP_Response, otherwise
+ *                                is already an instance, WP_REST_Response, otherwise
  *                                returns a new WP_REST_Response instance.
  */
 function rest_ensure_response( $response ) {
@@ -522,8 +522,16 @@ function rest_ensure_response( $response ) {
 		return $response;
 	}
 
-	if ( $response instanceof WP_HTTP_Response ) {
+	if ( $response instanceof WP_REST_Response ) {
 		return $response;
+	}
+
+	if ( $response instanceof WP_HTTP_Response ) {
+		return new WP_REST_Response(
+			$response->get_data(),
+			$response->get_status(),
+			$response->get_headers()
+		);
 	}
 
 	return new WP_REST_Response( $response );

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -526,6 +526,8 @@ function rest_ensure_response( $response ) {
 		return $response;
 	}
 
+	// While WP_HTTP_Response is the base class of WP_REST_Response, it doesn't provide
+	// all the required methods used in WP_REST_Server::dispatch().
 	if ( $response instanceof WP_HTTP_Response ) {
 		return new WP_REST_Response(
 			$response->get_data(),

--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -969,9 +969,9 @@ class WP_REST_Server {
 				 *
 				 * @since 4.7.0
 				 *
-				 * @param WP_HTTP_Response|WP_Error $response Result to send to the client. Usually a WP_REST_Response or WP_Error.
-				 * @param array                     $handler  Route handler used for the request.
-				 * @param WP_REST_Request           $request  Request used to generate the response.
+				 * @param WP_REST_Response|WP_HTTP_Response|WP_Error $response Result to send to the client. Usually a WP_REST_Response or WP_Error.
+				 * @param array                                      $handler  Route handler used for the request.
+				 * @param WP_REST_Request                            $request  Request used to generate the response.
 				 */
 				$response = apply_filters( 'rest_request_before_callbacks', $response, $handler, $request );
 
@@ -1032,9 +1032,9 @@ class WP_REST_Server {
 				 *
 				 * @since 4.7.0
 				 *
-				 * @param WP_HTTP_Response|WP_Error $response Result to send to the client. Usually a WP_REST_Response or WP_Error.
-				 * @param array                     $handler  Route handler used for the request.
-				 * @param WP_REST_Request           $request  Request used to generate the response.
+				 * @param WP_REST_Response|WP_HTTP_Response|WP_Error $response Result to send to the client. Usually a WP_REST_Response or WP_Error.
+				 * @param array                                      $handler  Route handler used for the request.
+				 * @param WP_REST_Request                            $request  Request used to generate the response.
 				 */
 				$response = apply_filters( 'rest_request_after_callbacks', $response, $handler, $request );
 

--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -969,9 +969,9 @@ class WP_REST_Server {
 				 *
 				 * @since 4.7.0
 				 *
-				 * @param WP_REST_Response|WP_HTTP_Response|WP_Error $response Result to send to the client. Usually a WP_REST_Response or WP_Error.
-				 * @param array                                      $handler  Route handler used for the request.
-				 * @param WP_REST_Request                            $request  Request used to generate the response.
+				 * @param WP_REST_Response|WP_HTTP_Response|WP_Error|mixed $response Result to send to the client. Usually a WP_REST_Response or WP_Error.
+				 * @param array                                            $handler  Route handler used for the request.
+				 * @param WP_REST_Request                                  $request  Request used to generate the response.
 				 */
 				$response = apply_filters( 'rest_request_before_callbacks', $response, $handler, $request );
 
@@ -1032,9 +1032,9 @@ class WP_REST_Server {
 				 *
 				 * @since 4.7.0
 				 *
-				 * @param WP_REST_Response|WP_HTTP_Response|WP_Error $response Result to send to the client. Usually a WP_REST_Response or WP_Error.
-				 * @param array                                      $handler  Route handler used for the request.
-				 * @param WP_REST_Request                            $request  Request used to generate the response.
+				 * @param WP_REST_Response|WP_HTTP_Response|WP_Error|mixed $response Result to send to the client. Usually a WP_REST_Response or WP_Error.
+				 * @param array                                            $handler  Route handler used for the request.
+				 * @param WP_REST_Request                                  $request  Request used to generate the response.
 				 */
 				$response = apply_filters( 'rest_request_after_callbacks', $response, $handler, $request );
 

--- a/tests/phpunit/tests/rest-api.php
+++ b/tests/phpunit/tests/rest-api.php
@@ -942,7 +942,7 @@ class Tests_REST_API extends WP_UnitTestCase {
 	/**
 	 * @ticket 40614
 	 */
-	function test_rest_ensure_response_accepts_path_string() {
+	function test_rest_ensure_request_accepts_path_string() {
 		$request = rest_ensure_request( '/wp/v2/posts' );
 		$this->assertInstanceOf( 'WP_REST_Request', $request );
 		$this->assertEquals( '/wp/v2/posts', $request->get_route() );
@@ -1313,6 +1313,41 @@ class Tests_REST_API extends WP_UnitTestCase {
 					),
 				),
 			),
+		);
+	}
+
+	function test_rest_ensure_response_accepts_wp_error_and_returns_wp_error() {
+		$response = rest_ensure_response( new WP_Error() );
+		$this->assertInstanceOf( 'WP_Error', $response );
+	}
+
+	/**
+	 * @dataProvider rest_ensure_response_data_provider
+	 * @group test1
+	 *
+	 * @param mixed $response      The response passed to rest_ensure_response().
+	 * @param mixed $expected_data The expected data a response should include.
+	 */
+	function test_rest_ensure_response_returns_instance_of_wp_rest_response( $response, $expected_data ) {
+		$response_object = rest_ensure_response( $response );
+		$this->assertInstanceOf( 'WP_REST_Response', $response_object );
+		$this->assertSame( $expected_data, $response_object->get_data() );
+	}
+
+	/**
+	 * Data provider for test_rest_ensure_response_returns_instance_of_wp_rest_response().
+	 *
+	 * @return array
+	 */
+	function rest_ensure_response_data_provider() {
+		return array(
+			array( null, null ),
+			array( array( 'chocolate' => 'cookies' ), array( 'chocolate' => 'cookies' ) ),
+			array( 123, 123 ),
+			array( true, true ),
+			array( 'chocolate', 'chocolate' ),
+			array( new WP_HTTP_Response( 'http' ), 'http' ),
+			array( new WP_REST_Response( 'rest' ), 'rest' ),
 		);
 	}
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/49495

An instance of `WP_HTTP_Response` doesn't ensure that the required methods by `WP_REST_Server::dispatch()` exists.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**