### PR TITLE
Edit content of PR description comments.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,6 @@
-<!-- Hi there! Thanks for contributing to WordPress!
-Please insert a description of your changes here -->
+Trac ticket: <!-- REQUIRED: Insert a link to the https://core.trac.wordpress.org ticket here -->
 
-Trac ticket: <!-- Pull Requests in this repository **must** be linked to a WordPress Trac ticket -->
+<!-- Insert a description of your changes here -->
 
 ---
 **This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,22 +1,7 @@
-<!--
-Hi there! Thanks for contributing to WordPress!
+<!-- Hi there! Thanks for contributing to WordPress!
+Please insert a description of your changes here -->
 
-Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**
-
-See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/
-
-If this is your first time contributing, you may also find reviewing these guides first to be helpful:
-- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
-- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
-- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
-- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
-- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
-- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
--->
-
-<!-- Insert a description of your changes here -->
-
-Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->
+Trac ticket: <!-- Pull Requests in this repository **must** be linked to a WordPress Trac ticket -->
 
 ---
 **This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**


### PR DESCRIPTION
<!-- Insert a description of your changes here -->

Removes most of the boilerplate from the PR description field, so that the synced Trac comment won't be too noisy.
(I have manually deleted the boilerplate from this PR, so see 38009 for a sample of what it looks like currently)

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->
Fixes https://core.trac.wordpress.org/ticket/49508

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
