### PR TITLE
add basic auth to WP API on SSL environments

### DIFF
--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -298,7 +298,7 @@ function rest_api_loaded() {
 	// Populate the correct $_SERVER variables via an alternate header for fastcgi compatibility.
 	if ( isset( $_SERVER['HTTP_WP_AUTHORIZATION'] ) && preg_match( '%^Basic [a-z\d/+]*={0,2}$%i', $_SERVER['HTTP_WP_AUTHORIZATION'] ) ) {
 		// Removing `Basic ` the token would start six characters in.
-		$token = substr( $_SERVER['HTTP_WP_AUTHORIZATION'], 6 );
+		$token    = substr( $_SERVER['HTTP_WP_AUTHORIZATION'], 6 );
 		$userpass = base64_decode( $token );
 		list( $_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW'] ) = explode( ':', $userpass );
 	}

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -281,7 +281,6 @@ function create_initial_rest_routes() {
  * @since 4.4.0
  *
  * @global WP $wp Current WordPress environment instance.
- * @global WP_User|null   $user           Current WordPress User.
  */
 function rest_api_loaded() {
 	if ( empty( $GLOBALS['wp']->query_vars['rest_route'] ) ) {

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -311,7 +311,7 @@ function rest_api_loaded() {
 			die();
 		}
 		$user = wp_authenticate( $_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW'] );
-		wp_set_current_user( $user );
+		wp_set_current_user( $user->ID );
 	}
 
 	// Initialize the server.

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -311,8 +311,8 @@ function rest_api_loaded() {
 			wp_send_json_error( __( 'HTTP Basic Auth is unavailable for non-HTTPS requests.' ), 403 );
 			die();
 		}
-		$GLOBALS['user'] = wp_authenticate( $_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW'] );
-		wp_set_current_user( $GLOBALS['user']->id );
+		$user = wp_authenticate( $_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW'] );
+		wp_set_current_user( $user );
 	}
 
 	// Initialize the server.


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/42790

Refreshes the proposed patch to apply cleanly to current WordPress master and also fixes setting the authenticated user as the current user (props @georgestephanis).

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
