### PR TITLE
Set proper directory permissions when using ssh2

### DIFF
--- a/src/wp-admin/includes/class-wp-filesystem-ssh2.php
+++ b/src/wp-admin/includes/class-wp-filesystem-ssh2.php
@@ -665,6 +665,10 @@ class WP_Filesystem_SSH2 extends WP_Filesystem_Base {
 		if ( ! ssh2_sftp_mkdir( $this->sftp_link, $path, $chmod, true ) ) {
 			return false;
 		}
+
+		// Set directory permissions
+		ssh2_sftp_chmod( $this->sftp_link, $path, $chmod );
+
 		if ( $chown ) {
 			$this->chown( $path, $chown );
 		}


### PR DESCRIPTION
Explicitly set proper directory permissions as intended when using ssh2 connection (for example when installing plugin or theme).

Fixes https://core.trac.wordpress.org/ticket/49218