### PR TITLE
Auth check improvements

### DIFF
--- a/src/js/_enqueues/lib/auth-check.js
+++ b/src/js/_enqueues/lib/auth-check.js
@@ -48,6 +48,13 @@
 				if ( height ) {
 					if ( body && body.hasClass('interim-login-success') )
 						hide();
+						// When on the Edit Post screen, speed up heartbeat
+						// after the user logs in to quickly refresh nonces.
+						if ( typeof adminpage !== 'undefined' && ( adminpage === 'post-php' || adminpage === 'post-new-php' ) &&
+							typeof wp !== 'undefined' && wp.heartbeat ) {
+
+							wp.heartbeat.connectNow();
+						}
 					else
 						parent.css( 'max-height', height + 40 + 'px' );
 				} else if ( ! body || ! body.length ) {
@@ -94,14 +101,7 @@
 	function hide() {
 		$(window).off( 'beforeunload.wp-auth-check' );
 
-		// When on the Edit Post screen, speed up heartbeat
-		// after the user logs in to quickly refresh nonces.
-		if ( typeof adminpage !== 'undefined' && ( adminpage === 'post-php' || adminpage === 'post-new-php' ) &&
-			typeof wp !== 'undefined' && wp.heartbeat ) {
 
-			$(document).off( 'heartbeat-tick.wp-auth-check' );
-			wp.heartbeat.connectNow();
-		}
 
 		wrap.fadeOut( 200, function() {
 			wrap.addClass('hidden').css('display', '');
@@ -174,6 +174,10 @@
 		wrap = $('#wp-auth-check-wrap');
 		wrap.find('.wp-auth-check-close').on( 'click', function() {
 			hide();
+			// The authentication popup was closed intentionally, slow heartbeat
+			if ( typeof wp !== 'undefined' && wp.heartbeat ) {
+				wp.heartbeat.interval(120);
+			}
 		});
 	});
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Improve auth-check
1. Remove scheduling/request data, since `wp-auth-check` is sent on every heartbeat regardless
2. Modify the mechanism for hiding the login dialog so that users can both:
    1. Close the dialog and interact with the page for some time without the dialog re-appering
    2. Log in repeatedly without navigating to a new page

Trac ticket: https://core.trac.wordpress.org/ticket/49573

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
