### PR TITLE
Added patch from ticket 38622

### DIFF
--- a/src/wp-includes/class-wp-xmlrpc-server.php
+++ b/src/wp-includes/class-wp-xmlrpc-server.php
@@ -3909,6 +3909,11 @@ class wp_xmlrpc_server extends IXR_Server {
 				$comment['comment_author_url'] = $content_struct['author_url'];
 			}
 
+			$comment['comment_type'] = '';
+			if ( isset( $content_struct['comment_type'] ) ) {
+				$comment['comment_type'] = $content_struct['comment_type'];
+			}
+
 			$comment['user_ID'] = 0;
 
 			if ( get_option( 'require_name_email' ) ) {

--- a/tests/phpunit/tests/comment.php
+++ b/tests/phpunit/tests/comment.php
@@ -372,7 +372,8 @@ class Tests_Comment extends WP_UnitTestCase {
 		);
 
 		foreach ( $fixtures as $fixture ) {
-			$data                     = array(
+
+			$data = array(
 				'comment_post_ID'      => self::$post_id,
 				'comment_author'       => '',
 				'comment_author_url'   => '',
@@ -380,7 +381,9 @@ class Tests_Comment extends WP_UnitTestCase {
 				'comment_content'      => '',
 				'comment_type'         => '',
 			);
-			$data[$fixture['name']] = $fixture['value'];
+
+			$data[ $fixture['name'] ] = $fixture['value'];
+
 			try {
 				wp_new_comment( $data );
 				$this->fail( 'Exception an exception' );

--- a/tests/phpunit/tests/comment.php
+++ b/tests/phpunit/tests/comment.php
@@ -344,23 +344,50 @@ class Tests_Comment extends WP_UnitTestCase {
 	}
 
 
-	public function test_comment_field_lengths() {
-		$data = array(
-			'comment_post_ID'      => self::$post_id,
-			'comment_author'       => 'Comment Author',
-			'comment_author_url'   => '',
-			'comment_author_email' => '',
-			'comment_type'         => '',
-			'comment_content'      => str_repeat( 'A', 65536 ),
-			'comment_date'         => '2011-01-01 10:00:00',
-			'comment_date_gmt'     => '2011-01-01 10:00:00',
+	/**
+	 * @ticket 38622
+	 */
+	public function test_incorrect_comment_field_lengths() {
+		$fixtures = array(
+			array(
+				'name'   => 'comment_author',
+				'value'  => str_repeat( 'A', 250 ),
+				'expect' => '<strong>Error</strong>: Your name is too long.',
+			),
+			array(
+				'name'   => 'comment_author_url',
+				'value'  => 'http://' . str_repeat( 'A', 250 ) . '.net',
+				'expect' => '<strong>Error</strong>: Your URL is too long.',
+			),
+			array(
+				'name'   => 'comment_author_email',
+				'value'  => str_repeat( 'A', 250 ) . '@somewhere.net',
+				'expect' => '<strong>Error</strong>: Your email address is too long.',
+			),
+			array(
+				'name'   => 'comment_content',
+				'value'  => str_repeat( 'A', 70000 ),
+				'expect' => '<strong>Error</strong>: Your comment is too long.',
+			),
 		);
 
-		$id = wp_new_comment( $data );
-
-		$comment = get_comment( $id );
-
-		$this->assertEquals( strlen( $comment->comment_content ), 65535 );
+		foreach ( $fixtures as $fixture ) {
+			$data                     = array(
+				'comment_post_ID'      => self::$post_id,
+				'comment_author'       => '',
+				'comment_author_url'   => '',
+				'comment_author_email' => '',
+				'comment_content'      => '',
+				'comment_type'         => '',
+			);
+			$data[$fixture['name']] = $fixture['value'];
+			try {
+				wp_new_comment( $data );
+				$this->fail( 'Exception an exception' );
+			} catch ( WPDieException $e ) {
+				$this->assertEquals( $e->getMessage(), $fixture['expect'] );
+			}
+		}
 	}
 
 	/**

--- a/tests/phpunit/tests/xmlrpc/wp/newComment.php
+++ b/tests/phpunit/tests/xmlrpc/wp/newComment.php
@@ -122,26 +122,34 @@ class Tests_XMLRPC_wp_newComment extends WP_XMLRPC_UnitTestCase {
 			),
 		);
 
-		add_filter( 'xmlrpc_allow_anonymous_comments', function(){return true;} );
+		add_filter(
+			'xmlrpc_allow_anonymous_comments',
+			function() {
+				return true;
+			}
+		);
 
 		//$this->make_user_by_role( 'administrator' );
 		$post = self::factory()->post->create_and_get();
 
 		foreach ( $fixtures as $fixture ) {
-			$data                     = array(
+
+			$data = array(
 				'author'       => 'author',
 				'author_url'   => '',
 				'author_email' => 'author@somewhere.net',
 				'content'      => 'required',
 			);
-			$data[$fixture['name']] = $fixture['value'];
+
+			$data[ $fixture['name'] ] = $fixture['value'];
+
 			$result = $this->myxmlrpcserver->wp_newComment(
 				array(
 					1,
 					'',
 					'',
 					$post->ID,
-					$data
+					$data,
 				)
 			);
 
@@ -150,7 +158,12 @@ class Tests_XMLRPC_wp_newComment extends WP_XMLRPC_UnitTestCase {
 	}
 
 	function test_anon_comment() {
-		add_filter( 'xmlrpc_allow_anonymous_comments', function(){return true;} );
+		add_filter(
+			'xmlrpc_allow_anonymous_comments',
+			function() {
+				return true;
+			}
+		);
 		$post = self::factory()->post->create_and_get();
 
 		$result = $this->myxmlrpcserver->wp_newComment(
@@ -163,7 +176,7 @@ class Tests_XMLRPC_wp_newComment extends WP_XMLRPC_UnitTestCase {
 					'author'       => 'author',
 					'author_url'   => '',
 					'author_email' => 'author@somewhere.net',
-					'content' => rand_str( 100 ),
+					'content'      => rand_str( 100 ),
 				),
 			)
 		);

--- a/tests/phpunit/tests/xmlrpc/wp/newComment.php
+++ b/tests/phpunit/tests/xmlrpc/wp/newComment.php
@@ -95,4 +95,79 @@ class Tests_XMLRPC_wp_newComment extends WP_XMLRPC_UnitTestCase {
 		$this->assertEquals( 403, $result->code );
 	}
 
+	/*
+	 * @ticket 38622
+	 */
+	function test_new_comment_with_incorrect_comment_field_lengths() {
+		$fixtures = array(
+			array(
+				'name'   => 'author',
+				'value'  => str_repeat( 'A', 250 ),
+				'expect' => '<strong>Error</strong>: Your name is too long.',
+			),
+			array(
+				'name'   => 'author_url',
+				'value'  => 'http://' . str_repeat( 'A', 250 ) . '.net',
+				'expect' => '<strong>Error</strong>: Your URL is too long.',
+			),
+			array(
+				'name'   => 'author_email',
+				'value'  => str_repeat( 'A', 250 ) . '@somewhere.net',
+				'expect' => '<strong>Error</strong>: Your email address is too long.',
+			),
+			array(
+				'name'   => 'content',
+				'value'  => str_repeat( 'A', 70000 ),
+				'expect' => '<strong>Error</strong>: Your comment is too long.',
+			),
+		);
+
+		add_filter( 'xmlrpc_allow_anonymous_comments', function(){return true;} );
+
+		//$this->make_user_by_role( 'administrator' );
+		$post = self::factory()->post->create_and_get();
+
+		foreach ( $fixtures as $fixture ) {
+			$data                     = array(
+				'author'       => 'author',
+				'author_url'   => '',
+				'author_email' => 'author@somewhere.net',
+				'content'      => 'required',
+			);
+			$data[$fixture['name']] = $fixture['value'];
+			$result = $this->myxmlrpcserver->wp_newComment(
+				array(
+					1,
+					'',
+					'',
+					$post->ID,
+					$data
+				)
+			);
+
+			$this->assertIXRError( $result );
+		}
+	}
+
+	function test_anon_comment() {
+		add_filter( 'xmlrpc_allow_anonymous_comments', function(){return true;} );
+		$post = self::factory()->post->create_and_get();
+
+		$result = $this->myxmlrpcserver->wp_newComment(
+			array(
+				1,
+				'',
+				'',
+				$post->ID,
+				array(
+					'author'       => 'author',
+					'author_url'   => '',
+					'author_email' => 'author@somewhere.net',
+					'content' => rand_str( 100 ),
+				),
+			)
+		);
+
+		$this->assertNotIXRError( $result );
+	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

I have applied the patch from this ticket and fixed at bug when posting a comment via xmlrpc. Anon posting was missing the content_type which resulted in an error.

Trac ticket: https://core.trac.wordpress.org/ticket/38622

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
