### PR TITLE
REST API: Inconsistent parameter type handling in `set_param()`

### DIFF
--- a/src/wp-includes/rest-api/class-wp-rest-request.php
+++ b/src/wp-includes/rest-api/class-wp-rest-request.php
@@ -434,7 +434,7 @@ class WP_REST_Request implements ArrayAccess {
 		$found_key 	= false;
 
 		foreach ( $order as $type ) {
-			if ( isset( $this->params[ $type ][ $key ] ) ) {
+			if ( $type !== 'defaults' && isset( $this->params[ $type ][ $key ] ) ) {
 				$this->params[ $type ][ $key ] = $value;
 				$found_key = true;
 			}

--- a/src/wp-includes/rest-api/class-wp-rest-request.php
+++ b/src/wp-includes/rest-api/class-wp-rest-request.php
@@ -430,17 +430,17 @@ class WP_REST_Request implements ArrayAccess {
 	 * @param mixed  $value Parameter value.
 	 */
 	public function set_param( $key, $value ) {
-		$order 		= $this->get_parameter_order();
-		$found_key 	= false;
+		$order     = $this->get_parameter_order();
+		$found_key = false;
 
 		foreach ( $order as $type ) {
-			if ( $type !== 'defaults' && isset( $this->params[ $type ][ $key ] ) ) {
+			if ( 'defaults' !== $type && isset( $this->params[ $type ][ $key ] ) ) {
 				$this->params[ $type ][ $key ] = $value;
-				$found_key = true;
+				$found_key                     = true;
 			}
 		}
 
-		if ( !$found_key ) {
+		if ( ! $found_key ) {
 			$this->params[ $order[0] ][ $key ] = $value;
 		}
 	}

--- a/src/wp-includes/rest-api/class-wp-rest-request.php
+++ b/src/wp-includes/rest-api/class-wp-rest-request.php
@@ -434,7 +434,7 @@ class WP_REST_Request implements ArrayAccess {
 		$found_key = false;
 
 		foreach ( $order as $type ) {
-			if ( 'defaults' !== $type && isset( $this->params[ $type ][ $key ] ) ) {
+			if ( 'defaults' !== $type && array_key_exists( $key, $this->params[ $type ] ) ) {
 				$this->params[ $type ][ $key ] = $value;
 				$found_key                     = true;
 			}

--- a/src/wp-includes/rest-api/class-wp-rest-request.php
+++ b/src/wp-includes/rest-api/class-wp-rest-request.php
@@ -420,14 +420,29 @@ class WP_REST_Request implements ArrayAccess {
 	/**
 	 * Sets a parameter on the request.
 	 *
+	 * If the given parameter key exists in any parameter type an update will take place,
+	 * otherwise a new param will be created in the first parameter type (respecting
+	 * get_parameter_order()).
+	 *
 	 * @since 4.4.0
 	 *
 	 * @param string $key   Parameter name.
 	 * @param mixed  $value Parameter value.
 	 */
 	public function set_param( $key, $value ) {
-		$order                             = $this->get_parameter_order();
-		$this->params[ $order[0] ][ $key ] = $value;
+		$order 		= $this->get_parameter_order();
+		$found_key 	= false;
+
+		foreach ( $order as $type ) {
+			if ( isset( $this->params[ $type ][ $key ] ) ) {
+				$this->params[ $type ][ $key ] = $value;
+				$found_key = true;
+			}
+		}
+
+		if ( !$found_key ) {
+			$this->params[ $order[0] ][ $key ] = $value;
+		}
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/rest-request.php
+++ b/tests/phpunit/tests/rest-api/rest-request.php
@@ -673,7 +673,7 @@ class Tests_REST_Request extends WP_UnitTestCase {
 		$request->set_param( 'param', 'new_value' );
 
 		$this->assertEquals( 'new_value', $request->get_param( 'param' ) );
-		$this->assertEquals( array( 'param' => 'new_value' ), $request->get_body_params() );
+		$this->assertEquals( array(), $request->get_body_params() );
 		$this->assertEquals( array( 'param' => 'new_value' ), $request->get_json_params() );
 		$this->assertEquals( array( 'param' => 'new_value' ), $request->get_query_params() );
 	}

--- a/tests/phpunit/tests/rest-api/rest-request.php
+++ b/tests/phpunit/tests/rest-api/rest-request.php
@@ -675,6 +675,11 @@ class Tests_REST_Request extends WP_UnitTestCase {
 		$request->set_body( wp_json_encode( array(
 			'param_body' => 'value_body',
 		) ) );
+		$original_defaults = array(
+			'param_query'=> 'default_query_value',
+			'param_body' => 'default_body_value'
+		);
+		$request->set_default_params( $original_defaults );
 		$request->set_query_params( array(
 			'param_query' => 'value_query',
 		) );
@@ -683,5 +688,7 @@ class Tests_REST_Request extends WP_UnitTestCase {
 		$this->assertEquals( 'new_value', $request->get_param( 'param_query' ) );
 		$this->assertEquals( array( 'param_body' => 'value_body' ), $request->get_json_params() );
 		$this->assertEquals( array( 'param_query' => 'new_value' ), $request->get_query_params() );
+		// Verify the default wasn't overwritten.
+		$this->assertEquals($original_defaults, $request->get_default_params());
 	}
 }

--- a/tests/phpunit/tests/rest-api/rest-request.php
+++ b/tests/phpunit/tests/rest-api/rest-request.php
@@ -655,12 +655,18 @@ class Tests_REST_Request extends WP_UnitTestCase {
 		$request = new WP_REST_Request();
 		$request->add_header( 'content-type', 'application/json' );
 		$request->set_method( 'POST' );
-		$request->set_body( wp_json_encode( array(
-			'param' => 'value_body',
-		) ) );
-		$request->set_query_params( array(
-			'param' => 'value_query',
-		) );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'param' => 'value_body',
+				)
+			)
+		);
+		$request->set_query_params(
+			array(
+				'param' => 'value_query',
+			)
+		);
 		$request->set_param( 'param', 'new_value' );
 
 		$this->assertEquals( 'new_value', $request->get_param( 'param' ) );
@@ -672,23 +678,29 @@ class Tests_REST_Request extends WP_UnitTestCase {
 		$request = new WP_REST_Request();
 		$request->add_header( 'content-type', 'application/json' );
 		$request->set_method( 'POST' );
-		$request->set_body( wp_json_encode( array(
-			'param_body' => 'value_body',
-		) ) );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'param_body' => 'value_body',
+				)
+			)
+		);
 		$original_defaults = array(
-			'param_query'=> 'default_query_value',
-			'param_body' => 'default_body_value'
+			'param_query' => 'default_query_value',
+			'param_body'  => 'default_body_value',
 		);
 		$request->set_default_params( $original_defaults );
-		$request->set_query_params( array(
-			'param_query' => 'value_query',
-		) );
+		$request->set_query_params(
+			array(
+				'param_query' => 'value_query',
+			)
+		);
 		$request->set_param( 'param_query', 'new_value' );
 
 		$this->assertEquals( 'new_value', $request->get_param( 'param_query' ) );
 		$this->assertEquals( array( 'param_body' => 'value_body' ), $request->get_json_params() );
 		$this->assertEquals( array( 'param_query' => 'new_value' ), $request->get_query_params() );
 		// Verify the default wasn't overwritten.
-		$this->assertEquals($original_defaults, $request->get_default_params());
+		$this->assertEquals( $original_defaults, $request->get_default_params() );
 	}
 }

--- a/tests/phpunit/tests/rest-api/rest-request.php
+++ b/tests/phpunit/tests/rest-api/rest-request.php
@@ -650,4 +650,38 @@ class Tests_REST_Request extends WP_UnitTestCase {
 			$request->get_json_params()
 		);
 	}
+
+	public function test_set_param_updates_param_in_json_and_query() {
+		$request = new WP_REST_Request();
+		$request->add_header( 'content-type', 'application/json' );
+		$request->set_method( 'POST' );
+		$request->set_body( wp_json_encode( array(
+			'param' => 'value_body',
+		) ) );
+		$request->set_query_params( array(
+			'param' => 'value_query',
+		) );
+		$request->set_param( 'param', 'new_value' );
+
+		$this->assertEquals( 'new_value', $request->get_param( 'param' ) );
+		$this->assertEquals( array( 'param' => 'new_value' ), $request->get_json_params() );
+		$this->assertEquals( array( 'param' => 'new_value' ), $request->get_query_params() );
+	}
+
+	public function test_set_param_updates_param_if_already_exists_in_query() {
+		$request = new WP_REST_Request();
+		$request->add_header( 'content-type', 'application/json' );
+		$request->set_method( 'POST' );
+		$request->set_body( wp_json_encode( array(
+			'param_body' => 'value_body',
+		) ) );
+		$request->set_query_params( array(
+			'param_query' => 'value_query',
+		) );
+		$request->set_param( 'param_query', 'new_value' );
+
+		$this->assertEquals( 'new_value', $request->get_param( 'param_query' ) );
+		$this->assertEquals( array( 'param_body' => 'value_body' ), $request->get_json_params() );
+		$this->assertEquals( array( 'param_query' => 'new_value' ), $request->get_query_params() );
+	}
 }

--- a/tests/phpunit/tests/rest-api/rest-request.php
+++ b/tests/phpunit/tests/rest-api/rest-request.php
@@ -651,6 +651,9 @@ class Tests_REST_Request extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * @ticket 40838
+	 */
 	public function test_set_param_updates_param_in_json_and_query() {
 		$request = new WP_REST_Request();
 		$request->add_header( 'content-type', 'application/json' );
@@ -670,10 +673,14 @@ class Tests_REST_Request extends WP_UnitTestCase {
 		$request->set_param( 'param', 'new_value' );
 
 		$this->assertEquals( 'new_value', $request->get_param( 'param' ) );
+		$this->assertEquals( array( 'param' => 'new_value' ), $request->get_body_params() );
 		$this->assertEquals( array( 'param' => 'new_value' ), $request->get_json_params() );
 		$this->assertEquals( array( 'param' => 'new_value' ), $request->get_query_params() );
 	}
 
+	/**
+	 * @ticket 40838
+	 */
 	public function test_set_param_updates_param_if_already_exists_in_query() {
 		$request = new WP_REST_Request();
 		$request->add_header( 'content-type', 'application/json' );
@@ -698,9 +705,64 @@ class Tests_REST_Request extends WP_UnitTestCase {
 		$request->set_param( 'param_query', 'new_value' );
 
 		$this->assertEquals( 'new_value', $request->get_param( 'param_query' ) );
+		$this->assertEquals( array(), $request->get_body_params() );
 		$this->assertEquals( array( 'param_body' => 'value_body' ), $request->get_json_params() );
 		$this->assertEquals( array( 'param_query' => 'new_value' ), $request->get_query_params() );
 		// Verify the default wasn't overwritten.
 		$this->assertEquals( $original_defaults, $request->get_default_params() );
+	}
+
+	/**
+	 * @ticket 40838
+	 */
+	public function test_set_param_to_null_updates_param_in_json_and_query() {
+		$request = new WP_REST_Request();
+		$request->add_header( 'content-type', 'application/json' );
+		$request->set_method( 'POST' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'param' => 'value_body',
+				)
+			)
+		);
+		$request->set_query_params(
+			array(
+				'param' => 'value_query',
+			)
+		);
+		$request->set_param( 'param', null );
+
+		$this->assertEquals( null, $request->get_param( 'param' ) );
+		$this->assertEquals( array(), $request->get_body_params() );
+		$this->assertEquals( array( 'param' => null ), $request->get_json_params() );
+		$this->assertEquals( array( 'param' => null ), $request->get_query_params() );
+	}
+
+	/**
+	 * @ticket 40838
+	 */
+	public function test_set_param_from_null_updates_param_in_json_and_query_with_null() {
+		$request = new WP_REST_Request();
+		$request->add_header( 'content-type', 'application/json' );
+		$request->set_method( 'POST' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'param' => null,
+				)
+			)
+		);
+		$request->set_query_params(
+			array(
+				'param' => null,
+			)
+		);
+		$request->set_param( 'param', 'new_value' );
+
+		$this->assertEquals( 'new_value', $request->get_param( 'param' ) );
+		$this->assertEquals( array(), $request->get_body_params() );
+		$this->assertEquals( array( 'param' => 'new_value' ), $request->get_json_params() );
+		$this->assertEquals( array( 'param' => 'new_value' ), $request->get_query_params() );
 	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->https://core.trac.wordpress.org/ticket/40838

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
