### PR TITLE
wpmu_new_blog hook has been deprecated. Use wp_initialize_site instead

### DIFF
--- a/src/wp-includes/ms-site.php
+++ b/src/wp-includes/ms-site.php
@@ -130,7 +130,7 @@ function wp_insert_site( array $data ) {
 		 * @param int    $network_id Network ID. Only relevant on multi-network installations.
 		 * @param array  $meta       Meta data. Used to set initial site options.
 		 */
-		do_action_deprecated( 'wpmu_new_blog', array( $new_site->id, $user_id, $new_site->domain, $new_site->path, $new_site->network_id, $meta ), '5.1.0', 'wp_insert_site' );
+		do_action_deprecated( 'wpmu_new_blog', array( $new_site->id, $user_id, $new_site->domain, $new_site->path, $new_site->network_id, $meta ), '5.1.0', 'wp_initialize_site' );
 	}
 
 	return (int) $new_site->id;


### PR DESCRIPTION
Please use this hook wp_initialize_site instead of wp_insert_site on deprecated message. Because if we use wp_insert_site hook, we couldn’t access wp_options table for newly created sites eg: updating option table data with update_options with error message:
WordPress database error Table 'ex.wp_10_options' doesn't exist for query SELECT autoload FROM wp_10_options WHERE option_name = 'ex_version' made by wpmu_create_blog, wp_insert_site, do_action('wp_insert_site')

Trac ticket: https://core.trac.wordpress.org/ticket/49612
