### PR TITLE
Change autoembed and do_blocks filter order

### DIFF
--- a/src/wp-includes/class-wp-embed.php
+++ b/src/wp-includes/class-wp-embed.php
@@ -36,7 +36,7 @@ class WP_Embed {
 		add_shortcode( 'embed', '__return_false' );
 
 		// Attempts to embed all URLs in a post.
-		add_filter( 'the_content', array( $this, 'autoembed' ), 8 );
+		add_filter( 'the_content', array( $this, 'autoembed' ), 9 );
 		add_filter( 'widget_text_content', array( $this, 'autoembed' ), 8 );
 
 		// After a post is saved, cache oEmbed items via Ajax.

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -169,7 +169,7 @@ add_filter( 'the_title', 'wptexturize' );
 add_filter( 'the_title', 'convert_chars' );
 add_filter( 'the_title', 'trim' );
 
-add_filter( 'the_content', 'do_blocks', 9 );
+add_filter( 'the_content', 'do_blocks', 8 );
 add_filter( 'the_content', 'wptexturize' );
 add_filter( 'the_content', 'convert_smilies', 20 );
 add_filter( 'the_content', 'wpautop' );


### PR DESCRIPTION
This changes the order of two filters on `the_content`. It moves `do_blocks` up and moves `WP_Embed->autoembed()` later. 

It solves the issue of auto-embed blocks that have been converted to reusable blocks not being rendered on the front-end of a site and instead just showing the URL.

It feels risky, but from what I can tell the tests are passing both here and in Gutenberg when trying this. 

Trac ticket: https://core.trac.wordpress.org/ticket/46457

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
