### PR TITLE
Allow `POST` requests in endpoint for `ServerSideRender` block component

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-renderer-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-renderer-controller.php
@@ -148,8 +148,7 @@ class WP_REST_Block_Renderer_Controller extends WP_REST_Controller {
 			);
 		}
 
-		// In a POST request, the attributes appear as JSON in the request body.
-		$attributes = WP_REST_Server::CREATABLE === $request->get_method() ? json_decode( $request->get_body(), true ) : $request->get_param( 'attributes' );
+		$attributes = $request->get_param( 'attributes' );
 
 		// Create an array representation simulating the output of parse_blocks.
 		$block = array(

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-renderer-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-renderer-controller.php
@@ -52,7 +52,7 @@ class WP_REST_Block_Renderer_Controller extends WP_REST_Controller {
 						),
 					),
 					array(
-						'methods'             => WP_REST_Server::READABLE,
+						'methods'             => array( WP_REST_Server::READABLE, WP_REST_Server::CREATABLE ),
 						'callback'            => array( $this, 'get_item' ),
 						'permission_callback' => array( $this, 'get_item_permissions_check' ),
 						'args'                => array(
@@ -148,7 +148,8 @@ class WP_REST_Block_Renderer_Controller extends WP_REST_Controller {
 			);
 		}
 
-		$attributes = $request->get_param( 'attributes' );
+		// In a POST request, the attributes appear as JSON in the request body.
+		$attributes = WP_REST_Server::CREATABLE === $request->get_method() ? json_decode( $request->get_body(), true ) : $request->get_param( 'attributes' );
 
 		// Create an array representation simulating the output of parse_blocks.
 		$block = array(

--- a/tests/phpunit/tests/rest-api/rest-block-renderer-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-block-renderer-controller.php
@@ -465,8 +465,8 @@ class REST_Block_Renderer_Controller_Test extends WP_Test_REST_Controller_Testca
 		$string_attribute = 'Lorem ipsum dolor';
 		$attributes       = array( 'some_string' => $string_attribute );
 		$request          = new WP_REST_Request( 'POST', self::$rest_api_route . self::$block_name );
-		$request->set_header( 'content-type', 'application/json' );
 		$request->set_param( 'context', 'edit' );
+		$request->set_header( 'content-type', 'application/json' );
 		$request->set_body( wp_json_encode( compact( 'attributes' ) ) );
 		$response = rest_get_server()->dispatch( $request );
 

--- a/tests/phpunit/tests/rest-api/rest-block-renderer-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-block-renderer-controller.php
@@ -457,6 +457,8 @@ class REST_Block_Renderer_Controller_Test extends WP_Test_REST_Controller_Testca
 
 	/**
 	 * Test a POST request, with the attributes in the body.
+	 *
+	 * @ticket 49680
 	 */
 	public function test_get_item_post_request() {
 		wp_set_current_user( self::$user_id );

--- a/tests/phpunit/tests/rest-api/rest-block-renderer-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-block-renderer-controller.php
@@ -466,7 +466,7 @@ class REST_Block_Renderer_Controller_Test extends WP_Test_REST_Controller_Testca
 		$attributes       = array( 'some_string' => $string_attribute );
 		$request          = new WP_REST_Request( 'POST', self::$rest_api_route . self::$block_name );
 		$request->set_param( 'context', 'edit' );
-		$request->set_body( wp_json_encode( $attributes ) );
+		$request->set_body( wp_json_encode( compact( 'attributes' ) ) );
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertEquals( 200, $response->get_status() );

--- a/tests/phpunit/tests/rest-api/rest-block-renderer-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-block-renderer-controller.php
@@ -465,6 +465,7 @@ class REST_Block_Renderer_Controller_Test extends WP_Test_REST_Controller_Testca
 		$string_attribute = 'Lorem ipsum dolor';
 		$attributes       = array( 'some_string' => $string_attribute );
 		$request          = new WP_REST_Request( 'POST', self::$rest_api_route . self::$block_name );
+		$request->set_header( 'content-type', 'application/json' );
 		$request->set_param( 'context', 'edit' );
 		$request->set_body( wp_json_encode( compact( 'attributes' ) ) );
 		$response = rest_get_server()->dispatch( $request );

--- a/tests/phpunit/tests/rest-api/rest-block-renderer-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-block-renderer-controller.php
@@ -456,6 +456,22 @@ class REST_Block_Renderer_Controller_Test extends WP_Test_REST_Controller_Testca
 	}
 
 	/**
+	 * Test a POST request, with the attributes in the body.
+	 */
+	public function test_get_item_post_request() {
+		wp_set_current_user( self::$user_id );
+		$string_attribute = 'Lorem ipsum dolor';
+		$attributes       = array( 'some_string' => $string_attribute );
+		$request          = new WP_REST_Request( 'POST', self::$rest_api_route . self::$block_name );
+		$request->set_param( 'context', 'edit' );
+		$request->set_body( wp_json_encode( $attributes ) );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertContains( $string_attribute, $response->get_data()['rendered'] );
+	}
+
+	/**
 	 * Test getting item with invalid post ID.
 	 *
 	 * @ticket 45098
@@ -503,7 +519,7 @@ class REST_Block_Renderer_Controller_Test extends WP_Test_REST_Controller_Testca
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
-		$this->assertEqualSets( array( 'GET' ), $data['endpoints'][0]['methods'] );
+		$this->assertEqualSets( array( 'GET', 'POST' ), $data['endpoints'][0]['methods'] );
 		$this->assertEqualSets(
 			array( 'name', 'context', 'attributes', 'post_id' ),
 			array_keys( $data['endpoints'][0]['args'] )


### PR DESCRIPTION

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This allows a block's `<ServerSideRender>` component to make a `POST` request, in case the attributes are too big for a `GET` request.

There have been several cases where sending the attributes in the `GET` request URL causes an error:

https://github.com/WordPress/gutenberg/issues/19935
https://github.com/WordPress/gutenberg/issues/16396#issuecomment-508709339
https://wordpress.org/support/topic/error-loading-block-the-response-is-not-a-valid-json-response-2/

This follows the suggestion in 2 of those issues to allow using `POST` for the block endpoint, in addition to `GET`.

Trac ticket: https://core.trac.wordpress.org/ticket/49680

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
