### PR TITLE
Defaulted cached statuses with no count to 0

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -2627,6 +2627,13 @@ function wp_count_posts( $type = 'post', $perm = '' ) {
 
 	$counts = wp_cache_get( $cache_key, 'counts' );
 	if ( false !== $counts ) {
+		// We may have cached this before every status was registered.
+		foreach ( get_post_stati() as $status ) {
+			if ( ! isset( $counts->{$status} ) ) {
+				$counts->{$status} = 0;
+			}
+		}
+
 		/** This filter is documented in wp-includes/post.php */
 		return apply_filters( 'wp_count_posts', $counts, $type, $perm );
 	}

--- a/tests/phpunit/tests/post.php
+++ b/tests/phpunit/tests/post.php
@@ -880,6 +880,22 @@ class Tests_Post extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 49685
+	 */
+	function test_wp_count_posts_status_changes_visible() {
+		self::factory()->post->create_many( 3 );
+
+		// Trigger a cache.
+		wp_count_posts();
+
+		register_post_status( 'test' );
+
+		$counts = wp_count_posts();
+		$this->assertTrue( isset( $counts->test ) );
+		$this->assertEquals( 0, $counts->test );
+	}
+
+	/**
 	 * @ticket 13771
 	 */
 	function test_get_the_date_with_id_returns_correct_time() {


### PR DESCRIPTION
When `wp_count_posts()` is cached, it does so with all statuses defaulted to 0. The problem is however, if this is called before all plugins have registered their desired statuses, they won't have that default.

Related Issues:
woocommerce/woocommerce#25949

Trac ticket: https://core.trac.wordpress.org/ticket/49685

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
