### PR TITLE
Fix 49701

### DIFF
--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -342,7 +342,7 @@ function get_inline_data( $post ) {
 	foreach ( $taxonomy_names as $taxonomy_name ) {
 		$taxonomy = get_taxonomy( $taxonomy_name );
 
-		if ( $taxonomy->hierarchical && $taxonomy->show_ui ) {
+		if ( $taxonomy->hierarchical && $taxonomy->show_in_quick_edit ) {
 
 			$terms = get_object_term_cache( $post->ID, $taxonomy_name );
 			if ( false === $terms ) {
@@ -353,7 +353,7 @@ function get_inline_data( $post ) {
 
 			echo '<div class="post_category" id="' . $taxonomy_name . '_' . $post->ID . '">' . implode( ',', $term_ids ) . '</div>';
 
-		} elseif ( $taxonomy->show_ui ) {
+		} elseif ( $taxonomy->show_in_quick_edit ) {
 
 			$terms_to_edit = get_terms_to_edit( $post->ID, $taxonomy_name );
 			if ( ! is_string( $terms_to_edit ) ) {


### PR DESCRIPTION
Fixes 49701 by changing `show_ui` to `show_in_quick_edit` when deciding whether to echo the hidden div containing the assigned taxonomy terms for each post on the All Posts screen in WordPress Dashboard.

Trac ticket: https://core.trac.wordpress.org/ticket/49701
