### PR TITLE
Taxonomy: Fix cache issue in get_the_terms

### DIFF
--- a/src/wp-includes/category-template.php
+++ b/src/wp-includes/category-template.php
@@ -1240,7 +1240,7 @@ function get_the_terms( $post, $taxonomy ) {
 	}
 
 	$terms = get_object_term_cache( $post->ID, $taxonomy );
-	if ( false === $terms ) {
+	if ( false == $terms ) {
 		$terms = wp_get_object_terms( $post->ID, $taxonomy );
 		if ( ! is_wp_error( $terms ) ) {
 			$term_ids = wp_list_pluck( $terms, 'term_id' );


### PR DESCRIPTION
Loosened the condition to check the terms fetched fro mthe object term cache. The cache can return an empty array, which is a falsy value, so the get_the_terms will return false value.

Trac ticket: https://core.trac.wordpress.org/ticket/49799

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
