### PR TITLE
XML-RPC: Removed workaround for PHP < 5.2.2 bug

### DIFF
--- a/src/xmlrpc.php
+++ b/src/xmlrpc.php
@@ -15,11 +15,7 @@ define( 'XMLRPC_REQUEST', true );
 // Some browser-embedded clients send cookies. We don't want them.
 $_COOKIE = array();
 
-// A bug in PHP < 5.2.2 makes $HTTP_RAW_POST_DATA not set by default,
-// but we can do it ourself.
-if ( ! isset( $HTTP_RAW_POST_DATA ) ) {
-	$HTTP_RAW_POST_DATA = file_get_contents( 'php://input' );
-}
+$HTTP_RAW_POST_DATA = file_get_contents( 'php://input' );
 
 // Fix for mozBlog and other cases where '<?xml' isn't on the very first line.
 if ( isset( $HTTP_RAW_POST_DATA ) ) {


### PR DESCRIPTION
Removed workaround for $HTTP_RAW_POST_DATA bug present in PHP < 5.2.2, since that version is no longer supported.

Trac ticket: https://core.trac.wordpress.org/ticket/49810