### PR TITLE
49824: Site Health instantiation prevents use of some hooks by plugins.

### DIFF
--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -366,12 +366,6 @@ if ( ! is_multisite() ) {
 	wp_recovery_mode()->initialize();
 }
 
-// Create an instance of WP_Site_Health so that Cron events may fire.
-if ( ! class_exists( 'WP_Site_Health' ) ) {
-	require_once ABSPATH . 'wp-admin/includes/class-wp-site-health.php';
-}
-WP_Site_Health::get_instance();
-
 // Load active plugins.
 foreach ( wp_get_active_and_valid_plugins() as $plugin ) {
 	wp_register_plugin_realpath( $plugin );
@@ -523,6 +517,12 @@ unset( $theme );
  * @since 3.0.0
  */
 do_action( 'after_setup_theme' );
+
+// Create an instance of WP_Site_Health so that Cron events may fire.
+if ( ! class_exists( 'WP_Site_Health' ) ) {
+	require_once ABSPATH . 'wp-admin/includes/class-wp-site-health.php';
+}
+WP_Site_Health::get_instance();
 
 // Set up current user.
 $GLOBALS['wp']->init();


### PR DESCRIPTION
As the `WP_Site_Health` class is instantiated prior to plugins being required and the `plugins_loaded` hook being fired, it prevents plugins from using the following hooks in the functions called by `maybe_create_scheduled_event()`.

That is, each of the hooks in these functions:

* `update_option` (relating to cron array)
* `get_option` (cron array)
* `wp_get_scheduled_event`
* `wp_schedule_event`
* `wp_load_alloptions`

Scanning the code, it looks like this has the potential to lead to false reports in `WP_Site_Health::wp_cron_scheduled_check()`.

Is it possible to move the instantiation so it follows `plugins_loaded` (or even `after_setup_theme` to account for themes using features)?

--- 

Initially PR moves to after `after_theme_setup` (needs testing though).

https://core.trac.wordpress.org/ticket/49824