### PR TITLE
Extend namespaced version of PHPUnit's testcase

### DIFF
--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -12,7 +12,7 @@ require_once __DIR__ . '/trac.php';
  *
  * All WordPress unit tests should inherit from this class.
  */
-abstract class WP_UnitTestCase_Base extends PHPUnit_Framework_TestCase {
+abstract class WP_UnitTestCase_Base extends PHPUnit\Framework\TestCase {
 
 	protected static $forced_tickets   = array();
 	protected $expected_deprecated     = array();

--- a/tests/phpunit/includes/bootstrap.php
+++ b/tests/phpunit/includes/bootstrap.php
@@ -37,9 +37,9 @@ if ( ! is_readable( $config_file_path ) ) {
 require_once $config_file_path;
 require_once __DIR__ . '/functions.php';
 
-if ( version_compare( tests_get_phpunit_version(), '8.0', '>=' ) ) {
+if ( version_compare( tests_get_phpunit_version(), '5.7', '<' ) || version_compare( tests_get_phpunit_version(), '8.0', '>=' ) ) {
 	printf(
-		"Error: Looks like you're using PHPUnit %s. WordPress is currently only compatible with PHPUnit up to 7.x.\n",
+		"Error: Looks like you're using PHPUnit %s. WordPress requires at least PHPUnit 5.7.x and is currently only compatible with PHPUnit up to 7.x.\n",
 		tests_get_phpunit_version()
 	);
 	echo "Please use the latest PHPUnit version from the 7.x branch.\n";


### PR DESCRIPTION
Replace the old `PHPUnit_Framework_TestCase` class, [currently aliased](https://github.com/WordPress/wordpress-develop/blob/4b79e69d890b0444e5b2adfedca50f55a6bd3421/tests/phpunit/includes/phpunit6/compat.php#L5), to the new namespaced class.

Trac ticket: https://core.trac.wordpress.org/ticket/50236

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
