### PR TITLE
49856 Typo in WP_Upgrader::__construct() DocBlock

### DIFF
--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -116,7 +116,7 @@ class WP_Upgrader {
 	 *
 	 * @since 2.8.0
 	 *
-	 * @param WP_Upgrader_Skin $skin The upgrader skin to use. Default is a WP_Upgrader_Skin.
+	 * @param WP_Upgrader_Skin $skin The upgrader skin to use. Default is a WP_Upgrader_Skin
 	 *                               instance.
 	 */
 	public function __construct( $skin = null ) {


### PR DESCRIPTION
Removed full stop typo in DocBlock for `__construct` in `/wp-admin/includes/class-wp-upgrader.php`.

Trac ticket: https://core.trac.wordpress.org/ticket/49856