### PR TITLE
REST API: Themes: Expose some additional basic fields

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -115,6 +115,13 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 		$data   = array();
 		$fields = $this->get_fields_for_response( $request );
 
+		$simple_fields = array( 'name', 'stylesheet', 'template' );
+		$simple_fields_to_include = array_intersect( $simple_fields, $fields );
+
+		foreach ( $simple_fields_to_include as $field_name ) {
+			$data[ $field_name ] = $theme->$field_name;
+		}
+
 		if ( in_array( 'theme_supports', $fields, true ) ) {
 			$item_schemas   = $this->get_item_schema();
 			$theme_supports = $item_schemas['properties']['theme_supports']['properties'];
@@ -192,6 +199,21 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 			'title'      => 'theme',
 			'type'       => 'object',
 			'properties' => array(
+				'name' => array(
+					'description' => __( 'The theme\'s name.' ),
+					'type'        => 'string',
+					'readonly'    => true,
+				),
+				'stylesheet' => array(
+					'description' => __( 'The theme\'s stylesheet.' ),
+					'type'        => 'string',
+					'readonly'    => true,
+				),
+				'template' => array(
+					'description' => __( 'The theme\'s template name.' ),
+					'type'        => 'string',
+					'readonly'    => true,
+				),
 				'theme_supports' => array(
 					'description' => __( 'Features supported by this theme.' ),
 					'type'        => 'object',

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -132,8 +132,8 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 
 		if ( in_array( 'author', $fields, true ) ) {
 			$data['author'] = array(
-				'raw'      => $theme->display( 'Author', false, true ),
-				'rendered' => $theme->display( 'Author' ),
+				'raw'      => $theme['Author Name'],
+				'rendered' => $theme['Author'],
 			);
 		}
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -115,12 +115,23 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 		$data   = array();
 		$fields = $this->get_fields_for_response( $request );
 
-		$simple_fields            = array( 'name', 'stylesheet', 'template' );
+		$simple_fields            = array(
+			'author',
+			'description',
+			'name',
+			//'screenshot', // Needs different treatment to get absolute URL.
+			'stylesheet',
+			'template',
+			'version',
+		);
 		$simple_fields_to_include = array_intersect( $simple_fields, $fields );
 
 		foreach ( $simple_fields_to_include as $field_name ) {
 			$data[ $field_name ] = $theme->$field_name;
 		}
+
+		// Using $theme->get_screenshot() with no args to get absolute URL.
+		$data['screenshot'] = $theme->get_screenshot();
 
 		if ( in_array( 'theme_supports', $fields, true ) ) {
 			$item_schemas   = $this->get_item_schema();
@@ -199,8 +210,23 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 			'title'      => 'theme',
 			'type'       => 'object',
 			'properties' => array(
+				'author'         => array(
+					'description' => __( 'The author of the theme.' ),
+					'type'        => 'string',
+					'readonly'    => true,
+				),
+				'description'    => array(
+					'description' => __( 'A description of the theme.' ),
+					'type'        => 'string',
+					'readonly'    => true,
+				),
 				'name'           => array(
-					'description' => __( 'The theme\'s name.' ),
+					'description' => __( 'The name of the theme.' ),
+					'type'        => 'string',
+					'readonly'    => true,
+				),
+				'screenshot'     => array(
+					'description' => __( 'A theme screenshot URL.' ),
 					'type'        => 'string',
 					'readonly'    => true,
 				),
@@ -479,6 +505,11 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 							'type'        => 'boolean',
 						),
 					),
+				),
+				'version'        => array(
+					'description' => __( 'The theme\'s current version.' ),
+					'type'        => 'string',
+					'readonly'    => true,
 				),
 			),
 		);

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -116,8 +116,6 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 		$fields = $this->get_fields_for_response( $request );
 
 		$field_mappings    = array(
-			'author'      => 'Author',
-			'author_name' => 'Author Name',
 			'author_uri'  => 'Author URI',
 			'description' => 'Description',
 			'name'        => 'Name',
@@ -130,6 +128,13 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 
 		foreach ( $fields_to_include as $field ) {
 			$data[ $field ] = $theme[ $field_mappings[ $field ] ];
+		}
+
+		if ( in_array( 'author', $fields, true ) ) {
+			$data['author'] = array(
+				'raw'      => $theme->display( 'Author', false, true ),
+				'rendered' => $theme->display( 'Author' ),
+			);
 		}
 
 		if ( in_array( 'screenshot', $fields, true ) ) {
@@ -218,11 +223,18 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 					'description' => __( 'The theme author.' ),
 					'type'        => 'string',
 					'readonly'    => true,
-				),
-				'author_name'    => array(
-					'description' => __( 'The theme author\'s name.' ),
-					'type'        => 'string',
-					'readonly'    => true,
+					'properties'  => array(
+						'raw'      => array(
+							'description' => __( 'The theme author\'s name.' ),
+							'type'        => 'string',
+							'readonly'    => true,
+						),
+						'rendered' => array(
+							'description' => __( 'HTML for the theme author, transformed for display.' ),
+							'type'        => 'string',
+							'readonly'    => true,
+						),
+					),
 				),
 				'author_uri'     => array(
 					'description' => __( 'The website of the theme author.' ),

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -226,6 +226,7 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 				),
 				'author_uri'     => array(
 					'description' => __( 'The website of the theme author.' ),
+					'format'      => 'uri',
 					'type'        => 'string',
 					'readonly'    => true,
 				),
@@ -524,6 +525,7 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 					'description' => __( 'The URI of the theme\'s webpage.' ),
 					'type'        => 'string',
 					'readonly'    => true,
+					'format'      => 'uri',
 				),
 				'version'        => array(
 					'description' => __( 'The theme\'s current version.' ),

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -115,31 +115,38 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 		$data   = array();
 		$fields = $this->get_fields_for_response( $request );
 
-		$field_mappings    = array(
-			'author_uri'  => 'Author URI',
-			'description' => 'Description',
-			'name'        => 'Name',
-			'stylesheet'  => 'Stylesheet',
-			'template'    => 'Template',
-			'theme_uri'   => 'Theme URI',
-			'version'     => 'Version',
+		$plain_field_mappings = array(
+			'stylesheet' => 'Stylesheet',
+			'template'   => 'Template',
+			'version'    => 'Version',
 		);
-		$fields_to_include = array_intersect( array_keys( $field_mappings ), $fields );
 
-		foreach ( $fields_to_include as $field ) {
-			$data[ $field ] = $theme[ $field_mappings[ $field ] ];
-		}
+		$plain_fields_to_include = array_intersect( array_keys( $plain_field_mappings ), $fields );
 
-		if ( in_array( 'author', $fields, true ) ) {
-			$data['author'] = array(
-				'raw'      => $theme['Author Name'],
-				'rendered' => $theme['Author'],
-			);
+		foreach ( $plain_fields_to_include as $field ) {
+			$data[ $field ] = $theme[ $plain_field_mappings[ $field ] ];
 		}
 
 		if ( in_array( 'screenshot', $fields, true ) ) {
 			// Using $theme->get_screenshot() with no args to get absolute URL.
 			$data['screenshot'] = $theme->get_screenshot() ?: '';
+		}
+
+		$rich_field_mappings = array(
+			'author'      => 'Author',
+			'author_uri'  => 'AuthorURI',
+			'description' => 'Description',
+			'name'        => 'Name',
+			'theme_uri'   => 'ThemeURI',
+		);
+
+		$rich_fields_to_include = array_intersect( array_keys( $rich_field_mappings ), $fields );
+
+		foreach ( $rich_fields_to_include as $field ) {
+			$data[ $field ] = array(
+				'raw'      => $theme->display( $rich_field_mappings[ $field ], false, true ),
+				'rendered' => $theme->display( $rich_field_mappings[ $field ] ),
+			);
 		}
 
 		if ( in_array( 'theme_supports', $fields, true ) ) {
@@ -225,7 +232,7 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 					'readonly'    => true,
 					'properties'  => array(
 						'raw'      => array(
-							'description' => __( 'The theme author\'s name.' ),
+							'description' => __( 'The theme author\'s name, as it exists in the database.' ),
 							'type'        => 'string',
 							'readonly'    => true,
 						),
@@ -241,16 +248,52 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 					'format'      => 'uri',
 					'type'        => 'string',
 					'readonly'    => true,
+					'properties'  => array(
+						'raw'      => array(
+							'description' => __( 'The website of the theme author, as it exists in the database.' ),
+							'type'        => 'string',
+							'readonly'    => true,
+						),
+						'rendered' => array(
+							'description' => __( 'The website of the theme author, transformed for display.' ),
+							'type'        => 'string',
+							'readonly'    => true,
+						),
+					),
 				),
 				'description'    => array(
 					'description' => __( 'A description of the theme.' ),
 					'type'        => 'string',
 					'readonly'    => true,
+					'properties'  => array(
+						'raw'      => array(
+							'description' => __( 'The theme description, as it exists in the database.' ),
+							'type'        => 'string',
+							'readonly'    => true,
+						),
+						'rendered' => array(
+							'description' => __( 'The theme description, transformed for display.' ),
+							'type'        => 'string',
+							'readonly'    => true,
+						),
+					),
 				),
 				'name'           => array(
 					'description' => __( 'The name of the theme.' ),
 					'type'        => 'string',
 					'readonly'    => true,
+					'properties'  => array(
+						'raw'      => array(
+							'description' => __( 'The theme name, as it exists in the database.' ),
+							'type'        => 'string',
+							'readonly'    => true,
+						),
+						'rendered' => array(
+							'description' => __( 'The theme name, transformed for display.' ),
+							'type'        => 'string',
+							'readonly'    => true,
+						),
+					),
 				),
 				'screenshot'     => array(
 					'description' => __( 'A theme screenshot URL.' ),
@@ -538,6 +581,18 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 					'type'        => 'string',
 					'readonly'    => true,
 					'format'      => 'uri',
+					'properties'  => array(
+						'raw'      => array(
+							'description' => __( 'The URI of the theme\'s webpage, as it exists in the database.' ),
+							'type'        => 'string',
+							'readonly'    => true,
+						),
+						'rendered' => array(
+							'description' => __( 'The URI of the theme\'s webpage, transformed for display.' ),
+							'type'        => 'string',
+							'readonly'    => true,
+						),
+					),
 				),
 				'version'        => array(
 					'description' => __( 'The theme\'s current version.' ),

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -134,7 +134,7 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 
 		if ( in_array( 'screenshot', $fields, true ) ) {
 			// Using $theme->get_screenshot() with no args to get absolute URL.
-			$data['screenshot'] = $theme->get_screenshot();
+			$data['screenshot'] = $theme->get_screenshot() ?: '';
 		}
 
 		if ( in_array( 'theme_supports', $fields, true ) ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -115,19 +115,18 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 		$data   = array();
 		$fields = $this->get_fields_for_response( $request );
 
-		$simple_fields            = array(
-			'author',
-			'description',
-			'name',
-			//'screenshot', // Needs different treatment to get absolute URL.
-			'stylesheet',
-			'template',
-			'version',
+		$field_mappings    = array(
+			'author'      => 'Author Name',
+			'description' => 'Description',
+			'name'        => 'Name',
+			'stylesheet'  => 'Stylesheet',
+			'template'    => 'Template',
+			'version'     => 'Version',
 		);
-		$simple_fields_to_include = array_intersect( $simple_fields, $fields );
+		$fields_to_include = array_intersect( array_keys( $field_mappings ), $fields );
 
-		foreach ( $simple_fields_to_include as $field_name ) {
-			$data[ $field_name ] = $theme->$field_name;
+		foreach ( $fields_to_include as $field ) {
+			$data[ $field ] = $theme[ $field_mappings[ $field ] ];
 		}
 
 		if ( in_array( 'screenshot', $fields, true ) ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -232,7 +232,7 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 					'readonly'    => true,
 					'properties'  => array(
 						'raw'      => array(
-							'description' => __( 'The theme author\'s name, as it exists in the database.' ),
+							'description' => __( 'The theme author\'s name, as found in the theme header.' ),
 							'type'        => 'string',
 							'readonly'    => true,
 						),
@@ -250,7 +250,7 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 					'readonly'    => true,
 					'properties'  => array(
 						'raw'      => array(
-							'description' => __( 'The website of the theme author, as it exists in the database.' ),
+							'description' => __( 'The website of the theme author, as found in the theme header.' ),
 							'type'        => 'string',
 							'readonly'    => true,
 						),
@@ -267,7 +267,7 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 					'readonly'    => true,
 					'properties'  => array(
 						'raw'      => array(
-							'description' => __( 'The theme description, as it exists in the database.' ),
+							'description' => __( 'The theme description, as found in the theme header.' ),
 							'type'        => 'string',
 							'readonly'    => true,
 						),
@@ -284,7 +284,7 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 					'readonly'    => true,
 					'properties'  => array(
 						'raw'      => array(
-							'description' => __( 'The theme name, as it exists in the database.' ),
+							'description' => __( 'The theme name, as found in the theme header.' ),
 							'type'        => 'string',
 							'readonly'    => true,
 						),
@@ -583,7 +583,7 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 					'format'      => 'uri',
 					'properties'  => array(
 						'raw'      => array(
-							'description' => __( 'The URI of the theme\'s webpage, as it exists in the database.' ),
+							'description' => __( 'The URI of the theme\'s webpage, as found in the theme header.' ),
 							'type'        => 'string',
 							'readonly'    => true,
 						),

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -130,8 +130,10 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 			$data[ $field_name ] = $theme->$field_name;
 		}
 
-		// Using $theme->get_screenshot() with no args to get absolute URL.
-		$data['screenshot'] = $theme->get_screenshot();
+		if ( in_array( 'screenshot', $fields, true ) ) {
+			// Using $theme->get_screenshot() with no args to get absolute URL.
+			$data['screenshot'] = $theme->get_screenshot();
+		}
 
 		if ( in_array( 'theme_supports', $fields, true ) ) {
 			$item_schemas   = $this->get_item_schema();

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -116,11 +116,14 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 		$fields = $this->get_fields_for_response( $request );
 
 		$field_mappings    = array(
+			'author'      => 'Author',
 			'author_name' => 'Author Name',
+			'author_uri'  => 'Author URI',
 			'description' => 'Description',
 			'name'        => 'Name',
 			'stylesheet'  => 'Stylesheet',
 			'template'    => 'Template',
+			'theme_uri'   => 'Theme URI',
 			'version'     => 'Version',
 		);
 		$fields_to_include = array_intersect( array_keys( $field_mappings ), $fields );
@@ -211,8 +214,18 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 			'title'      => 'theme',
 			'type'       => 'object',
 			'properties' => array(
+				'author'         => array(
+					'description' => __( 'The theme author.' ),
+					'type'        => 'string',
+					'readonly'    => true,
+				),
 				'author_name'    => array(
 					'description' => __( 'The theme author\'s name.' ),
+					'type'        => 'string',
+					'readonly'    => true,
+				),
+				'author_uri'     => array(
+					'description' => __( 'The website of the theme author.' ),
 					'type'        => 'string',
 					'readonly'    => true,
 				),
@@ -506,6 +519,11 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 							'type'        => 'boolean',
 						),
 					),
+				),
+				'theme_uri'      => array(
+					'description' => __( 'The URI of the theme\'s webpage.' ),
+					'type'        => 'string',
+					'readonly'    => true,
 				),
 				'version'        => array(
 					'description' => __( 'The theme\'s current version.' ),

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -115,7 +115,7 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 		$data   = array();
 		$fields = $this->get_fields_for_response( $request );
 
-		$simple_fields = array( 'name', 'stylesheet', 'template' );
+		$simple_fields            = array( 'name', 'stylesheet', 'template' );
 		$simple_fields_to_include = array_intersect( $simple_fields, $fields );
 
 		foreach ( $simple_fields_to_include as $field_name ) {
@@ -199,17 +199,17 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 			'title'      => 'theme',
 			'type'       => 'object',
 			'properties' => array(
-				'name' => array(
+				'name'           => array(
 					'description' => __( 'The theme\'s name.' ),
 					'type'        => 'string',
 					'readonly'    => true,
 				),
-				'stylesheet' => array(
+				'stylesheet'     => array(
 					'description' => __( 'The theme\'s stylesheet.' ),
 					'type'        => 'string',
 					'readonly'    => true,
 				),
-				'template' => array(
+				'template'       => array(
 					'description' => __( 'The theme\'s template name.' ),
 					'type'        => 'string',
 					'readonly'    => true,

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -116,7 +116,7 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 		$fields = $this->get_fields_for_response( $request );
 
 		$field_mappings    = array(
-			'author'      => 'Author Name',
+			'author_name' => 'Author Name',
 			'description' => 'Description',
 			'name'        => 'Name',
 			'stylesheet'  => 'Stylesheet',
@@ -211,8 +211,8 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 			'title'      => 'theme',
 			'type'       => 'object',
 			'properties' => array(
-				'author'         => array(
-					'description' => __( 'The author of the theme.' ),
+				'author_name'    => array(
+					'description' => __( 'The theme author\'s name.' ),
 					'type'        => 'string',
 					'readonly'    => true,
 				),

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -263,7 +263,7 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 				),
 				'description'    => array(
 					'description' => __( 'A description of the theme.' ),
-					'type'        => 'string',
+					'type'        => 'object',
 					'readonly'    => true,
 					'properties'  => array(
 						'raw'      => array(

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -228,7 +228,7 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 			'properties' => array(
 				'author'         => array(
 					'description' => __( 'The theme author.' ),
-					'type'        => 'string',
+					'type'        => 'object',
 					'readonly'    => true,
 					'properties'  => array(
 						'raw'      => array(

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -155,8 +155,6 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 			'theme_uri'   => 'ThemeURI',
 		);
 
-		$rich_fields_to_include = array_intersect( array_keys( $rich_field_mappings ), $fields );
-
 		foreach ( $rich_field_mappings as $field => $header ) {
 			if ( rest_is_field_included( "{$field}.raw", $fields ) ) {
 				$data[ $field ]['raw'] = $theme->display( $header, false, true );
@@ -248,6 +246,11 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 			'title'      => 'theme',
 			'type'       => 'object',
 			'properties' => array(
+				'stylesheet'     => array(
+					'description' => __( 'The theme\'s stylesheet. This uniquely identifies the theme.' ),
+					'type'        => 'string',
+					'readonly'    => true,
+				),
 				'author'         => array(
 					'description' => __( 'The theme author.' ),
 					'type'        => 'object',
@@ -256,32 +259,27 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 						'raw'      => array(
 							'description' => __( 'The theme author\'s name, as found in the theme header.' ),
 							'type'        => 'string',
-							'readonly'    => true,
 						),
 						'rendered' => array(
 							'description' => __( 'HTML for the theme author, transformed for display.' ),
 							'type'        => 'string',
-							'readonly'    => true,
 						),
 					),
 				),
 				'author_uri'     => array(
 					'description' => __( 'The website of the theme author.' ),
 					'type'        => 'object',
-					'format'      => 'uri',
 					'readonly'    => true,
 					'properties'  => array(
 						'raw'      => array(
 							'description' => __( 'The website of the theme author, as found in the theme header.' ),
 							'type'        => 'string',
 							'format'      => 'uri',
-							'readonly'    => true,
 						),
 						'rendered' => array(
 							'description' => __( 'The website of the theme author, transformed for display.' ),
 							'type'        => 'string',
 							'format'      => 'uri',
-							'readonly'    => true,
 						),
 					),
 				),
@@ -293,12 +291,10 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 						'raw'      => array(
 							'description' => __( 'The theme description, as found in the theme header.' ),
 							'type'        => 'string',
-							'readonly'    => true,
 						),
 						'rendered' => array(
 							'description' => __( 'The theme description, transformed for display.' ),
 							'type'        => 'string',
-							'readonly'    => true,
 						),
 					),
 				),
@@ -310,12 +306,10 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 						'raw'      => array(
 							'description' => __( 'The theme name, as found in the theme header.' ),
 							'type'        => 'string',
-							'readonly'    => true,
 						),
 						'rendered' => array(
 							'description' => __( 'The theme name, transformed for display.' ),
 							'type'        => 'string',
-							'readonly'    => true,
 						),
 					),
 				),
@@ -330,13 +324,9 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 					'readonly'    => true,
 				),
 				'screenshot'     => array(
-					'description' => __( 'A theme screenshot URL.' ),
+					'description' => __( 'The theme\'s screenshot URL.' ),
 					'type'        => 'string',
-					'readonly'    => true,
-				),
-				'stylesheet'     => array(
-					'description' => __( 'The theme\'s stylesheet.' ),
-					'type'        => 'string',
+					'format'      => 'uri',
 					'readonly'    => true,
 				),
 				'tags'           => array(
@@ -345,17 +335,15 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 					'readonly'    => true,
 					'properties'  => array(
 						'raw'      => array(
-							'description' => __( 'Theme tags, as found in the theme header.' ),
+							'description' => __( 'The theme tags, as found in the theme header.' ),
 							'type'        => 'array',
-							'readonly'    => true,
 							'items'       => array(
 								'type' => 'string',
 							),
 						),
 						'rendered' => array(
-							'description' => __( 'Theme tags, transformed for display.' ),
+							'description' => __( 'The theme tags, transformed for display.' ),
 							'type'        => 'string',
-							'readonly'    => true,
 						),
 					),
 				),
@@ -638,20 +626,17 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 				'theme_uri'      => array(
 					'description' => __( 'The URI of the theme\'s webpage.' ),
 					'type'        => 'object',
-					'format'      => 'uri',
 					'readonly'    => true,
 					'properties'  => array(
 						'raw'      => array(
 							'description' => __( 'The URI of the theme\'s webpage, as found in the theme header.' ),
 							'type'        => 'string',
 							'format'      => 'uri',
-							'readonly'    => true,
 						),
 						'rendered' => array(
 							'description' => __( 'The URI of the theme\'s webpage, transformed for display.' ),
 							'type'        => 'string',
 							'format'      => 'uri',
-							'readonly'    => true,
 						),
 					),
 				),

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -578,7 +578,7 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 				),
 				'theme_uri'      => array(
 					'description' => __( 'The URI of the theme\'s webpage.' ),
-					'type'        => 'string',
+					'type'        => 'object',
 					'readonly'    => true,
 					'format'      => 'uri',
 					'properties'  => array(

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -117,19 +117,30 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 
 		$plain_field_mappings = array(
 			'stylesheet' => 'Stylesheet',
-			'template'   => 'Template',
 			'version'    => 'Version',
 		);
 
 		$plain_fields_to_include = array_intersect( array_keys( $plain_field_mappings ), $fields );
 
 		foreach ( $plain_fields_to_include as $field ) {
-			$data[ $field ] = $theme[ $plain_field_mappings[ $field ] ];
+			$data[ $field ] = $theme->get( $plain_field_mappings[ $field ] );
 		}
 
 		if ( in_array( 'screenshot', $fields, true ) ) {
 			// Using $theme->get_screenshot() with no args to get absolute URL.
 			$data['screenshot'] = $theme->get_screenshot() ?: '';
+		}
+
+		if ( in_array( 'template', $fields, true ) ) {
+			/**
+			 * @see WP_Theme::get()
+			 *
+			 * Use the get_template() method, not the 'Template' header, for finding the template.
+			 * The 'Template' header is only good for what was written in the style.css, while
+			 * get_template() takes into account where WordPress actually located the theme and
+			 * whether it is actually valid.
+			 */
+			$data['template'] = $theme->get_template();
 		}
 
 		$rich_field_mappings = array(

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -260,18 +260,20 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 				),
 				'author_uri'     => array(
 					'description' => __( 'The website of the theme author.' ),
-					'format'      => 'uri',
 					'type'        => 'object',
+					'format'      => 'uri',
 					'readonly'    => true,
 					'properties'  => array(
 						'raw'      => array(
 							'description' => __( 'The website of the theme author, as found in the theme header.' ),
-							'type'        => 'uri',
+							'type'        => 'string',
+							'format'      => 'uri',
 							'readonly'    => true,
 						),
 						'rendered' => array(
 							'description' => __( 'The website of the theme author, transformed for display.' ),
-							'type'        => 'uri',
+							'type'        => 'string',
+							'format'      => 'uri',
 							'readonly'    => true,
 						),
 					),
@@ -629,17 +631,19 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 				'theme_uri'      => array(
 					'description' => __( 'The URI of the theme\'s webpage.' ),
 					'type'        => 'object',
-					'readonly'    => true,
 					'format'      => 'uri',
+					'readonly'    => true,
 					'properties'  => array(
 						'raw'      => array(
 							'description' => __( 'The URI of the theme\'s webpage, as found in the theme header.' ),
-							'type'        => 'uri',
+							'type'        => 'string',
+							'format'      => 'uri',
 							'readonly'    => true,
 						),
 						'rendered' => array(
 							'description' => __( 'The URI of the theme\'s webpage, transformed for display.' ),
-							'type'        => 'uri',
+							'type'        => 'string',
+							'format'      => 'uri',
 							'readonly'    => true,
 						),
 					),

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -115,10 +115,23 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 		$data   = array();
 		$fields = $this->get_fields_for_response( $request );
 
+		if ( rest_is_field_included( 'stylesheet', $fields ) ) {
+			$data['stylesheet'] = $theme->get_stylesheet();
+		}
+
+		if ( rest_is_field_included( 'template', $fields ) ) {
+			/**
+			 * Use the get_template() method, not the 'Template' header, for finding the template.
+			 * The 'Template' header is only good for what was written in the style.css, while
+			 * get_template() takes into account where WordPress actually located the theme and
+			 * whether it is actually valid.
+			 */
+			$data['template'] = $theme->get_template();
+		}
+
 		$plain_field_mappings = array(
 			'requires_php' => 'RequiresPHP',
 			'requires_wp'  => 'RequiresWP',
-			'stylesheet'   => 'Stylesheet',
 			'textdomain'   => 'TextDomain',
 			'version'      => 'Version',
 		);
@@ -132,18 +145,6 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 		if ( rest_is_field_included( 'screenshot', $fields ) ) {
 			// Using $theme->get_screenshot() with no args to get absolute URL.
 			$data['screenshot'] = $theme->get_screenshot() ?: '';
-		}
-
-		if ( rest_is_field_included( 'template', $fields ) ) {
-			/**
-			 * @see WP_Theme::get()
-			 *
-			 * Use the get_template() method, not the 'Template' header, for finding the template.
-			 * The 'Template' header is only good for what was written in the style.css, while
-			 * get_template() takes into account where WordPress actually located the theme and
-			 * whether it is actually valid.
-			 */
-			$data['template'] = $theme->get_template();
 		}
 
 		$rich_field_mappings = array(
@@ -251,6 +252,11 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 					'type'        => 'string',
 					'readonly'    => true,
 				),
+				'template'       => array(
+					'description' => __( 'The theme\'s template. If this is a child theme, this refers to the parent theme, otherwise this is the same as the theme\'s stylesheet.' ),
+					'type'        => 'string',
+					'readonly'    => true,
+				),
 				'author'         => array(
 					'description' => __( 'The theme author.' ),
 					'type'        => 'object',
@@ -346,11 +352,6 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 							'type'        => 'string',
 						),
 					),
-				),
-				'template'       => array(
-					'description' => __( 'The theme\'s template name.' ),
-					'type'        => 'string',
-					'readonly'    => true,
 				),
 				'textdomain'     => array(
 					'description' => __( 'The theme\'s textdomain.' ),

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -280,7 +280,7 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 				),
 				'name'           => array(
 					'description' => __( 'The name of the theme.' ),
-					'type'        => 'string',
+					'type'        => 'object',
 					'readonly'    => true,
 					'properties'  => array(
 						'raw'      => array(

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -315,6 +315,9 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 							'description' => __( 'Theme tags, as found in the theme header.' ),
 							'type'        => 'array',
 							'readonly'    => true,
+							'items'       => array(
+								'type' => 'string',
+							),
 						),
 						'rendered' => array(
 							'description' => __( 'Theme tags, transformed for display.' ),

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -246,7 +246,7 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 				'author_uri'     => array(
 					'description' => __( 'The website of the theme author.' ),
 					'format'      => 'uri',
-					'type'        => 'string',
+					'type'        => 'object',
 					'readonly'    => true,
 					'properties'  => array(
 						'raw'      => array(

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -256,7 +256,7 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 						),
 						'rendered' => array(
 							'description' => __( 'The website of the theme author, transformed for display.' ),
-							'type'        => 'string',
+							'type'        => 'uri',
 							'readonly'    => true,
 						),
 					),
@@ -589,7 +589,7 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 						),
 						'rendered' => array(
 							'description' => __( 'The URI of the theme\'s webpage, transformed for display.' ),
-							'type'        => 'string',
+							'type'        => 'uri',
 							'readonly'    => true,
 						),
 					),

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -137,6 +137,7 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 			'author_uri'  => 'AuthorURI',
 			'description' => 'Description',
 			'name'        => 'Name',
+			'tags'        => 'Tags',
 			'theme_uri'   => 'ThemeURI',
 		);
 
@@ -304,6 +305,23 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 					'description' => __( 'The theme\'s stylesheet.' ),
 					'type'        => 'string',
 					'readonly'    => true,
+				),
+				'tags'           => array(
+					'description' => __( 'Tags indicating styles and features of the theme.' ),
+					'type'        => 'object',
+					'readonly'    => true,
+					'properties'  => array(
+						'raw'      => array(
+							'description' => __( 'Theme tags, as found in the theme header.' ),
+							'type'        => 'array',
+							'readonly'    => true,
+						),
+						'rendered' => array(
+							'description' => __( 'Theme tags, transformed for display.' ),
+							'type'        => 'string',
+							'readonly'    => true,
+						),
+					),
 				),
 				'template'       => array(
 					'description' => __( 'The theme\'s template name.' ),

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -117,6 +117,7 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 
 		$plain_field_mappings = array(
 			'stylesheet' => 'Stylesheet',
+			'textdomain' => 'TextDomain',
 			'version'    => 'Version',
 		);
 
@@ -339,6 +340,11 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 				),
 				'template'       => array(
 					'description' => __( 'The theme\'s template name.' ),
+					'type'        => 'string',
+					'readonly'    => true,
+				),
+				'textdomain'     => array(
+					'description' => __( 'The theme\'s textdomain.' ),
 					'type'        => 'string',
 					'readonly'    => true,
 				),

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -251,7 +251,7 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 					'properties'  => array(
 						'raw'      => array(
 							'description' => __( 'The website of the theme author, as found in the theme header.' ),
-							'type'        => 'string',
+							'type'        => 'uri',
 							'readonly'    => true,
 						),
 						'rendered' => array(
@@ -584,7 +584,7 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 					'properties'  => array(
 						'raw'      => array(
 							'description' => __( 'The URI of the theme\'s webpage, as found in the theme header.' ),
-							'type'        => 'string',
+							'type'        => 'uri',
 							'readonly'    => true,
 						),
 						'rendered' => array(

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -116,9 +116,11 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 		$fields = $this->get_fields_for_response( $request );
 
 		$plain_field_mappings = array(
-			'stylesheet' => 'Stylesheet',
-			'textdomain' => 'TextDomain',
-			'version'    => 'Version',
+			'requires_php' => 'RequiresPHP',
+			'requires_wp'  => 'RequiresWP',
+			'stylesheet'   => 'Stylesheet',
+			'textdomain'   => 'TextDomain',
+			'version'      => 'Version',
 		);
 
 		$plain_fields_to_include = array_intersect( array_keys( $plain_field_mappings ), $fields );
@@ -307,6 +309,16 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 							'readonly'    => true,
 						),
 					),
+				),
+				'requires_php'   => array(
+					'description' => __( 'The minimum PHP version required for the theme to work.' ),
+					'type'        => 'string',
+					'readonly'    => true,
+				),
+				'requires_wp'    => array(
+					'description' => __( 'The minimum WordPress version required for the theme to work.' ),
+					'type'        => 'string',
+					'readonly'    => true,
 				),
 				'screenshot'     => array(
 					'description' => __( 'A theme screenshot URL.' ),

--- a/tests/phpunit/data/themedir1/rest-api/style.css
+++ b/tests/phpunit/data/themedir1/rest-api/style.css
@@ -1,0 +1,15 @@
+/*
+Theme Name: REST Theme
+Theme URI: http://wordpress.org/?search=1&term=2
+Description: The 9' foot tall theme.
+Version: 1.6
+Author: Michael Heilemann
+Author URI: http://binarybonsai.com/?search=1&term=2
+Tags: holiday, custom-menu
+Template: default
+Requires at least: 5.3
+Requires PHP: 7.4
+Text Domain: rest-api
+*/
+
+

--- a/tests/phpunit/data/themedir1/rest-api/style.css
+++ b/tests/phpunit/data/themedir1/rest-api/style.css
@@ -8,7 +8,7 @@ Author URI: http://binarybonsai.com/?search=1&term=2
 Tags: holiday, custom-menu
 Template: default
 Requires at least: 5.3
-Requires PHP: 7.4
+Requires PHP: 5.6
 Text Domain: rest-api
 */
 

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -249,12 +249,14 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_theme_template() {
-		add_filter( 'template', array( $this, 'return_template' ) );
+		add_filter( 'stylesheet', array( $this, 'return_stylesheet' ) );
+		add_filter( 'template', array( $this, 'return_stylesheet' ) ); // Both need to be filtered to work for template.
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
 		$this->assertArrayHasKey( 'template', $result[0] );
-		$this->assertSame( $this->return_template(), $result[0]['template'] );
-		remove_filter( 'template', array( $this, 'return_template' ) );
+		$this->assertSame( $this->return_stylesheet(), $result[0]['template'] );
+		add_filter( 'template', array( $this, 'return_stylesheet' ) );
+		remove_filter( 'stylesheet', array( $this, 'return_stylesheet' ) );
 	}
 
 	/**
@@ -882,13 +884,6 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 	 */
 	public function return_stylesheet() {
 		return 'twentytestingchild';
-	}
-
-	/**
-	 * Return a value for the current theme's template.
-	 */
-	public function return_template() {
-		return 'twentytesting';
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -299,7 +299,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
 		$this->assertArrayHasKey( 'screenshot', $result[0] );
-		$this->assertFalse( $result[0]['screenshot'] ); // No screenshot for default theme
+		$this->assertSame( '', $result[0]['screenshot'] ); // No screenshot for default theme
 	}
 
 	public function test_theme_stylesheet() {

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -150,7 +150,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 
 		$this->check_get_theme_response( $response );
 		$fields = array(
-			'author',
+			'author_name',
 			'description',
 			'name',
 			'screenshot',
@@ -215,7 +215,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 		$this->assertEquals( 8, count( $properties ) );
-		$this->assertArrayHasKey( 'author', $properties );
+		$this->assertArrayHasKey( 'author_name', $properties );
 		$this->assertArrayHasKey( 'description', $properties );
 		$this->assertArrayHasKey( 'name', $properties );
 		$this->assertArrayHasKey( 'screenshot', $properties );
@@ -248,6 +248,37 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( 'wp-block-styles', $theme_supports );
 	}
 
+	public function test_theme_author_name() {
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertArrayHasKey( 'author_name', $result[0] );
+		$this->assertSame( 'Michael Heilemann', $result[0]['author_name'] );
+	}
+
+	public function test_theme_description() {
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertArrayHasKey( 'description', $result[0] );
+		$this->assertSame(
+			'The default WordPress theme based on the famous <a href="http://binarybonsai.com/kubrick/">Kubrick</a>.',
+			$result[0]['description']
+		);
+	}
+
+	public function test_theme_name() {
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertArrayHasKey( 'name', $result[0] );
+		$this->assertSame( 'WordPress Default', $result[0]['name'] );
+	}
+
+	public function test_theme_screenshot() {
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertArrayHasKey( 'screenshot', $result[0] );
+		$this->assertFalse( $result[0]['screenshot'] ); // No screenshot for default theme
+	}
+
 	public function test_theme_stylesheet() {
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
@@ -260,6 +291,13 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$result   = $response->get_data();
 		$this->assertArrayHasKey( 'template', $result[0] );
 		$this->assertSame( 'default', $result[0]['template'] );
+	}
+
+	public function test_theme_version() {
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertArrayHasKey( 'version', $result[0] );
+		$this->assertSame( '1.6', $result[0]['version'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -248,6 +248,15 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		remove_filter( 'stylesheet', array( $this, 'return_stylesheet' ) );
 	}
 
+	public function test_theme_template() {
+		add_filter( 'template', array( $this, 'return_template' ) );
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertArrayHasKey( 'template', $result[0] );
+		$this->assertSame( $this->return_template(), $result[0]['template'] );
+		remove_filter( 'template', array( $this, 'return_template' ) );
+	}
+
 	/**
 	 * @ticket 49037
 	 */
@@ -872,6 +881,13 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 	 * Return a value for the current theme's stylesheet.
 	 */
 	public function return_stylesheet() {
+		return 'twentytestingchild';
+	}
+
+	/**
+	 * Return a value for the current theme's template.
+	 */
+	public function return_template() {
 		return 'twentytesting';
 	}
 

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -249,23 +249,17 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_theme_stylesheet() {
-		add_filter( 'stylesheet', array( $this, 'return_stylesheet' ) );
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
 		$this->assertArrayHasKey( 'stylesheet', $result[0] );
-		$this->assertSame( $this->return_stylesheet(), $result[0]['stylesheet'] );
-		remove_filter( 'stylesheet', array( $this, 'return_stylesheet' ) );
+		$this->assertSame( 'default', $result[0]['stylesheet'] );
 	}
 
 	public function test_theme_template() {
-		add_filter( 'stylesheet', array( $this, 'return_stylesheet' ) );
-		add_filter( 'template', array( $this, 'return_stylesheet' ) ); // Both need to be filtered to work for template.
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
 		$this->assertArrayHasKey( 'template', $result[0] );
-		$this->assertSame( $this->return_stylesheet(), $result[0]['template'] );
-		add_filter( 'template', array( $this, 'return_stylesheet' ) );
-		remove_filter( 'stylesheet', array( $this, 'return_stylesheet' ) );
+		$this->assertSame( 'default', $result[0]['template'] );
 	}
 
 	/**
@@ -886,13 +880,6 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 	 */
 	public function additional_field_get_callback( $theme ) {
 		return 2;
-	}
-
-	/**
-	 * Return a value for the current theme's stylesheet.
-	 */
-	public function return_stylesheet() {
-		return 'twentytestingchild';
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -239,6 +239,15 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( 'wp-block-styles', $theme_supports );
 	}
 
+	public function test_theme_stylesheet() {
+		add_filter( 'stylesheet', array( $this, 'return_stylesheet' ) );
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertArrayHasKey( 'stylesheet', $result[0] );
+		$this->assertSame( $this->return_stylesheet(), $result[0]['stylesheet'] );
+		remove_filter( 'stylesheet', array( $this, 'return_stylesheet' ) );
+	}
+
 	/**
 	 * @ticket 49037
 	 */
@@ -857,6 +866,13 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 	 */
 	public function additional_field_get_callback( $theme ) {
 		return 2;
+	}
+
+	/**
+	 * Return a value for the current theme's stylesheet.
+	 */
+	public function return_stylesheet() {
+		return 'twentytesting';
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -150,13 +150,16 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 
 		$this->check_get_theme_response( $response );
 		$fields = array(
+			'author',
 			'author_name',
+			'author_uri',
 			'description',
 			'name',
 			'screenshot',
 			'stylesheet',
 			'template',
 			'theme_supports',
+			'theme_uri',
 			'version',
 		);
 		$this->assertEqualSets( $fields, array_keys( $data[0] ) );
@@ -214,14 +217,17 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$response   = self::perform_active_theme_request( 'OPTIONS' );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertEquals( 8, count( $properties ) );
+		$this->assertEquals( 11, count( $properties ) );
+		$this->assertArrayHasKey( 'author', $properties );
 		$this->assertArrayHasKey( 'author_name', $properties );
+		$this->assertArrayHasKey( 'author_uri', $properties );
 		$this->assertArrayHasKey( 'description', $properties );
 		$this->assertArrayHasKey( 'name', $properties );
 		$this->assertArrayHasKey( 'screenshot', $properties );
 		$this->assertArrayHasKey( 'stylesheet', $properties );
 		$this->assertArrayHasKey( 'template', $properties );
 		$this->assertArrayHasKey( 'theme_supports', $properties );
+		$this->assertArrayHasKey( 'theme_uri', $properties );
 		$this->assertArrayHasKey( 'version', $properties );
 
 		$theme_supports = $properties['theme_supports']['properties'];
@@ -248,11 +254,28 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( 'wp-block-styles', $theme_supports );
 	}
 
+	public function test_theme_author() {
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertArrayHasKey( 'author', $result[0] );
+		$this->assertSame(
+			'<a href="http://binarybonsai.com/">Michael Heilemann</a>',
+			$result[0]['author']
+		);
+	}
+
 	public function test_theme_author_name() {
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
 		$this->assertArrayHasKey( 'author_name', $result[0] );
 		$this->assertSame( 'Michael Heilemann', $result[0]['author_name'] );
+	}
+
+	public function test_theme_author_uri() {
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertArrayHasKey( 'author_uri', $result[0] );
+		$this->assertSame( 'http://binarybonsai.com/', $result[0]['author_uri'] );
 	}
 
 	public function test_theme_description() {
@@ -291,6 +314,13 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$result   = $response->get_data();
 		$this->assertArrayHasKey( 'template', $result[0] );
 		$this->assertSame( 'default', $result[0]['template'] );
+	}
+
+	public function test_theme_theme_uri() {
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertArrayHasKey( 'theme_uri', $result[0] );
+		$this->assertNull( $result[0]['theme_uri'] ); // Theme URI is null for default theme.
 	}
 
 	public function test_theme_version() {

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -219,7 +219,9 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$properties = $data['schema']['properties'];
 		$this->assertEquals( 11, count( $properties ) );
 		$this->assertArrayHasKey( 'author', $properties );
-		$this->assertArrayHasKey( 'author_name', $properties );
+		$this->assertArrayHasKey( 'raw', $properties['author']['properties'] );
+		$this->assertArrayHasKey( 'rendered', $properties['author']['properties'] );
+
 		$this->assertArrayHasKey( 'author_uri', $properties );
 		$this->assertArrayHasKey( 'description', $properties );
 		$this->assertArrayHasKey( 'name', $properties );
@@ -258,9 +260,10 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
 		$this->assertArrayHasKey( 'author', $result[0] );
+		$this->assertSame( 'Michael Heilemann', $result[0]['author']['raw'] );
 		$this->assertSame(
 			'<a href="http://binarybonsai.com/">Michael Heilemann</a>',
-			$result[0]['author']
+			$result[0]['author']['rendered']
 		);
 	}
 

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -217,18 +217,32 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 		$this->assertEquals( 10, count( $properties ) );
+
 		$this->assertArrayHasKey( 'author', $properties );
 		$this->assertArrayHasKey( 'raw', $properties['author']['properties'] );
 		$this->assertArrayHasKey( 'rendered', $properties['author']['properties'] );
 
 		$this->assertArrayHasKey( 'author_uri', $properties );
+		$this->assertArrayHasKey( 'raw', $properties['author_uri']['properties'] );
+		$this->assertArrayHasKey( 'rendered', $properties['author_uri']['properties'] );
+
 		$this->assertArrayHasKey( 'description', $properties );
+		$this->assertArrayHasKey( 'raw', $properties['description']['properties'] );
+		$this->assertArrayHasKey( 'rendered', $properties['description']['properties'] );
+
 		$this->assertArrayHasKey( 'name', $properties );
+		$this->assertArrayHasKey( 'raw', $properties['name']['properties'] );
+		$this->assertArrayHasKey( 'rendered', $properties['name']['properties'] );
+
 		$this->assertArrayHasKey( 'screenshot', $properties );
 		$this->assertArrayHasKey( 'stylesheet', $properties );
 		$this->assertArrayHasKey( 'template', $properties );
 		$this->assertArrayHasKey( 'theme_supports', $properties );
+
 		$this->assertArrayHasKey( 'theme_uri', $properties );
+		$this->assertArrayHasKey( 'raw', $properties['theme_uri']['properties'] );
+		$this->assertArrayHasKey( 'rendered', $properties['theme_uri']['properties'] );
+
 		$this->assertArrayHasKey( 'version', $properties );
 
 		$theme_supports = $properties['theme_supports']['properties'];
@@ -270,7 +284,8 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
 		$this->assertArrayHasKey( 'author_uri', $result[0] );
-		$this->assertSame( 'http://binarybonsai.com/', $result[0]['author_uri'] );
+		$this->assertSame( 'http://binarybonsai.com/', $result[0]['author_uri']['raw'] );
+		$this->assertSame( 'http://binarybonsai.com/', $result[0]['author_uri']['rendered'] );
 	}
 
 	public function test_theme_description() {
@@ -279,7 +294,11 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( 'description', $result[0] );
 		$this->assertSame(
 			'The default WordPress theme based on the famous <a href="http://binarybonsai.com/kubrick/">Kubrick</a>.',
-			$result[0]['description']
+			$result[0]['description']['raw']
+		);
+		$this->assertSame(
+			'The default WordPress theme based on the famous <a href="http://binarybonsai.com/kubrick/">Kubrick</a>.',
+			$result[0]['description']['rendered']
 		);
 	}
 
@@ -287,7 +306,8 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
 		$this->assertArrayHasKey( 'name', $result[0] );
-		$this->assertSame( 'WordPress Default', $result[0]['name'] );
+		$this->assertSame( 'WordPress Default', $result[0]['name']['raw'] );
+		$this->assertSame( 'WordPress Default', $result[0]['name']['rendered'] );
 	}
 
 	public function test_theme_screenshot() {
@@ -315,8 +335,8 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
 		$this->assertArrayHasKey( 'theme_uri', $result[0] );
-		$this->assertNull( $result[0]['theme_uri'] ); // Theme URI is null for default theme.
-	}
+		$this->assertSame( 'http://wordpress.org/', $result[0]['theme_uri']['raw'] );
+		$this->assertSame( 'http://wordpress.org/', $result[0]['theme_uri']['rendered'] );  }
 
 	public function test_theme_version() {
 		$response = self::perform_active_theme_request();

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -150,6 +150,9 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 
 		$this->check_get_theme_response( $response );
 		$fields = array(
+			'name',
+			'stylesheet',
+			'template',
 			'theme_supports',
 		);
 		$this->assertEqualSets( $fields, array_keys( $data[0] ) );
@@ -207,7 +210,10 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$response   = self::perform_active_theme_request( 'OPTIONS' );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertEquals( 1, count( $properties ) );
+		$this->assertEquals( 4, count( $properties ) );
+		$this->assertArrayHasKey( 'name', $properties );
+		$this->assertArrayHasKey( 'stylesheet', $properties );
+		$this->assertArrayHasKey( 'template', $properties );
 		$this->assertArrayHasKey( 'theme_supports', $properties );
 		$theme_supports = $properties['theme_supports']['properties'];
 		$this->assertEquals( 20, count( $theme_supports ) );

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -150,10 +150,14 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 
 		$this->check_get_theme_response( $response );
 		$fields = array(
+			'author',
+			'description',
 			'name',
+			'screenshot',
 			'stylesheet',
 			'template',
 			'theme_supports',
+			'version',
 		);
 		$this->assertEqualSets( $fields, array_keys( $data[0] ) );
 	}
@@ -210,11 +214,16 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$response   = self::perform_active_theme_request( 'OPTIONS' );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertEquals( 4, count( $properties ) );
+		$this->assertEquals( 8, count( $properties ) );
+		$this->assertArrayHasKey( 'author', $properties );
+		$this->assertArrayHasKey( 'description', $properties );
 		$this->assertArrayHasKey( 'name', $properties );
+		$this->assertArrayHasKey( 'screenshot', $properties );
 		$this->assertArrayHasKey( 'stylesheet', $properties );
 		$this->assertArrayHasKey( 'template', $properties );
 		$this->assertArrayHasKey( 'theme_supports', $properties );
+		$this->assertArrayHasKey( 'version', $properties );
+
 		$theme_supports = $properties['theme_supports']['properties'];
 		$this->assertEquals( 20, count( $theme_supports ) );
 		$this->assertArrayHasKey( 'align-wide', $theme_supports );

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -151,7 +151,6 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->check_get_theme_response( $response );
 		$fields = array(
 			'author',
-			'author_name',
 			'author_uri',
 			'description',
 			'name',
@@ -217,7 +216,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$response   = self::perform_active_theme_request( 'OPTIONS' );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertEquals( 11, count( $properties ) );
+		$this->assertEquals( 10, count( $properties ) );
 		$this->assertArrayHasKey( 'author', $properties );
 		$this->assertArrayHasKey( 'raw', $properties['author']['properties'] );
 		$this->assertArrayHasKey( 'rendered', $properties['author']['properties'] );
@@ -265,13 +264,6 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 			'<a href="http://binarybonsai.com/">Michael Heilemann</a>',
 			$result[0]['author']['rendered']
 		);
-	}
-
-	public function test_theme_author_name() {
-		$response = self::perform_active_theme_request();
-		$result   = $response->get_data();
-		$this->assertArrayHasKey( 'author_name', $result[0] );
-		$this->assertSame( 'Michael Heilemann', $result[0]['author_name'] );
 	}
 
 	public function test_theme_author_uri() {

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -332,7 +332,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
 		$this->assertArrayHasKey( 'requires_php', $result[0] );
-		$this->assertSame( '7.4', $result[0]['requires_php'] );
+		$this->assertSame( '5.6', $result[0]['requires_php'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -154,6 +154,8 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 			'author_uri',
 			'description',
 			'name',
+			'requires_php',
+			'requires_wp',
 			'screenshot',
 			'stylesheet',
 			'tags',
@@ -218,7 +220,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$response   = self::perform_active_theme_request( 'OPTIONS' );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertEquals( 12, count( $properties ) );
+		$this->assertEquals( 14, count( $properties ) );
 
 		$this->assertArrayHasKey( 'author', $properties );
 		$this->assertArrayHasKey( 'raw', $properties['author']['properties'] );
@@ -236,6 +238,8 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( 'raw', $properties['name']['properties'] );
 		$this->assertArrayHasKey( 'rendered', $properties['name']['properties'] );
 
+		$this->assertArrayHasKey( 'requires_php', $properties );
+		$this->assertArrayHasKey( 'requires_wp', $properties );
 		$this->assertArrayHasKey( 'screenshot', $properties );
 		$this->assertArrayHasKey( 'stylesheet', $properties );
 
@@ -309,6 +313,20 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 			'The default WordPress theme based on the famous <a href="http://binarybonsai.com/kubrick/">Kubrick</a>.',
 			$result[0]['description']['rendered']
 		);
+	}
+
+	public function test_theme_requires_php() {
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertArrayHasKey( 'requires_php', $result[0] );
+		$this->assertSame( '', $result[0]['requires_php'] );
+	}
+
+	public function test_theme_requires_wp() {
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertArrayHasKey( 'requires_wp', $result[0] );
+		$this->assertSame( '', $result[0]['requires_wp'] );
 	}
 
 	public function test_theme_name() {

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -125,6 +125,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		parent::setUp();
 
 		wp_set_current_user( self::$contributor_id );
+		switch_theme( 'rest-api' );
 	}
 
 	/**
@@ -282,61 +283,82 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( 'wp-block-styles', $theme_supports );
 	}
 
+	/**
+	 * @ticket 49906
+	 */
 	public function test_theme_author() {
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
 		$this->assertArrayHasKey( 'author', $result[0] );
 		$this->assertSame( 'Michael Heilemann', $result[0]['author']['raw'] );
 		$this->assertSame(
-			'<a href="http://binarybonsai.com/">Michael Heilemann</a>',
+			'<a href="http://binarybonsai.com/?search=1&#038;term=2">Michael Heilemann</a>',
 			$result[0]['author']['rendered']
 		);
 	}
 
+	/**
+	 * @ticket 49906
+	 */
 	public function test_theme_author_uri() {
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
 		$this->assertArrayHasKey( 'author_uri', $result[0] );
-		$this->assertSame( 'http://binarybonsai.com/', $result[0]['author_uri']['raw'] );
-		$this->assertSame( 'http://binarybonsai.com/', $result[0]['author_uri']['rendered'] );
+		$this->assertSame( 'http://binarybonsai.com/?search=1&term=2', $result[0]['author_uri']['raw'] );
+		$this->assertSame( 'http://binarybonsai.com/?search=1&#038;term=2', $result[0]['author_uri']['rendered'] );
 	}
 
+	/**
+	 * @ticket 49906
+	 */
 	public function test_theme_description() {
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
 		$this->assertArrayHasKey( 'description', $result[0] );
 		$this->assertSame(
-			'The default WordPress theme based on the famous <a href="http://binarybonsai.com/kubrick/">Kubrick</a>.',
+			'The 9\' foot tall theme.',
 			$result[0]['description']['raw']
 		);
 		$this->assertSame(
-			'The default WordPress theme based on the famous <a href="http://binarybonsai.com/kubrick/">Kubrick</a>.',
+			'The 9&#8242; foot tall theme.',
 			$result[0]['description']['rendered']
 		);
 	}
 
+	/**
+	 * @ticket 49906
+	 */
 	public function test_theme_requires_php() {
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
 		$this->assertArrayHasKey( 'requires_php', $result[0] );
-		$this->assertSame( '', $result[0]['requires_php'] );
+		$this->assertSame( '7.4', $result[0]['requires_php'] );
 	}
 
+	/**
+	 * @ticket 49906
+	 */
 	public function test_theme_requires_wp() {
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
 		$this->assertArrayHasKey( 'requires_wp', $result[0] );
-		$this->assertSame( '', $result[0]['requires_wp'] );
+		$this->assertSame( '5.3', $result[0]['requires_wp'] );
 	}
 
+	/**
+	 * @ticket 49906
+	 */
 	public function test_theme_name() {
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
 		$this->assertArrayHasKey( 'name', $result[0] );
-		$this->assertSame( 'WordPress Default', $result[0]['name']['raw'] );
-		$this->assertSame( 'WordPress Default', $result[0]['name']['rendered'] );
+		$this->assertSame( 'REST Theme', $result[0]['name']['raw'] );
+		$this->assertSame( 'REST Theme', $result[0]['name']['rendered'] );
 	}
 
+	/**
+	 * @ticket 49906
+	 */
 	public function test_theme_screenshot() {
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
@@ -344,21 +366,30 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertSame( '', $result[0]['screenshot'] ); // No screenshot for default theme
 	}
 
+	/**
+	 * @ticket 49906
+	 */
 	public function test_theme_stylesheet() {
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
 		$this->assertArrayHasKey( 'stylesheet', $result[0] );
-		$this->assertFalse( $result[0]['stylesheet'] );
+		$this->assertSame( 'rest-api', $result[0]['stylesheet'] );
 	}
 
+	/**
+	 * @ticket 49906
+	 */
 	public function test_theme_tags() {
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
 		$this->assertArrayHasKey( 'tags', $result[0] );
-		$this->assertSame( array(), $result[0]['tags']['raw'] );
-		$this->assertSame( '', $result[0]['tags']['rendered'] );
+		$this->assertSame( array( 'holiday', 'custom-menu' ), $result[0]['tags']['raw'] );
+		$this->assertSame( 'holiday, custom-menu', $result[0]['tags']['rendered'] );
 	}
 
+	/**
+	 * @ticket 49906
+	 */
 	public function test_theme_template() {
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
@@ -366,21 +397,27 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertSame( 'default', $result[0]['template'] );
 	}
 
+	/**
+	 * @ticket 49906
+	 */
 	public function test_theme_textdomain() {
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
 		$this->assertArrayHasKey( 'textdomain', $result[0] );
-		$this->assertSame( '', $result[0]['textdomain'] );
+		$this->assertSame( 'rest-api', $result[0]['textdomain'] );
 	}
 
 	public function test_theme_theme_uri() {
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
 		$this->assertArrayHasKey( 'theme_uri', $result[0] );
-		$this->assertSame( 'http://wordpress.org/', $result[0]['theme_uri']['raw'] );
-		$this->assertSame( 'http://wordpress.org/', $result[0]['theme_uri']['rendered'] );
+		$this->assertSame( 'http://wordpress.org/?search=1&term=2', $result[0]['theme_uri']['raw'] );
+		$this->assertSame( 'http://wordpress.org/?search=1&#038;term=2', $result[0]['theme_uri']['rendered'] );
 	}
 
+	/**
+	 * @ticket 49906
+	 */
 	public function test_theme_version() {
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -156,6 +156,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 			'name',
 			'screenshot',
 			'stylesheet',
+			'tags',
 			'template',
 			'theme_supports',
 			'theme_uri',
@@ -216,7 +217,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$response   = self::perform_active_theme_request( 'OPTIONS' );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertEquals( 10, count( $properties ) );
+		$this->assertEquals( 11, count( $properties ) );
 
 		$this->assertArrayHasKey( 'author', $properties );
 		$this->assertArrayHasKey( 'raw', $properties['author']['properties'] );
@@ -236,6 +237,11 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 
 		$this->assertArrayHasKey( 'screenshot', $properties );
 		$this->assertArrayHasKey( 'stylesheet', $properties );
+
+		$this->assertArrayHasKey( 'tags', $properties );
+		$this->assertArrayHasKey( 'raw', $properties['tags']['properties'] );
+		$this->assertArrayHasKey( 'rendered', $properties['tags']['properties'] );
+
 		$this->assertArrayHasKey( 'template', $properties );
 		$this->assertArrayHasKey( 'theme_supports', $properties );
 
@@ -322,6 +328,14 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$result   = $response->get_data();
 		$this->assertArrayHasKey( 'stylesheet', $result[0] );
 		$this->assertSame( 'default', $result[0]['stylesheet'] );
+	}
+
+	public function test_theme_tags() {
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertArrayHasKey( 'tags', $result[0] );
+		$this->assertSame( array(), $result[0]['tags']['raw'] );
+		$this->assertSame( '', $result[0]['tags']['rendered'] );
 	}
 
 	public function test_theme_template() {

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -240,6 +240,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 
 		$this->assertArrayHasKey( 'tags', $properties );
 		$this->assertArrayHasKey( 'raw', $properties['tags']['properties'] );
+		$this->assertArrayHasKey( 'items', $properties['tags']['properties']['raw'] );
 		$this->assertArrayHasKey( 'rendered', $properties['tags']['properties'] );
 
 		$this->assertArrayHasKey( 'template', $properties );

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -328,7 +328,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
 		$this->assertArrayHasKey( 'stylesheet', $result[0] );
-		$this->assertSame( 'default', $result[0]['stylesheet'] );
+		$this->assertFalse( $result[0]['stylesheet'] );
 	}
 
 	public function test_theme_tags() {

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -158,6 +158,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 			'stylesheet',
 			'tags',
 			'template',
+			'textdomain',
 			'theme_supports',
 			'theme_uri',
 			'version',
@@ -217,7 +218,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$response   = self::perform_active_theme_request( 'OPTIONS' );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertEquals( 11, count( $properties ) );
+		$this->assertEquals( 12, count( $properties ) );
 
 		$this->assertArrayHasKey( 'author', $properties );
 		$this->assertArrayHasKey( 'raw', $properties['author']['properties'] );
@@ -244,6 +245,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( 'rendered', $properties['tags']['properties'] );
 
 		$this->assertArrayHasKey( 'template', $properties );
+		$this->assertArrayHasKey( 'textdomain', $properties );
 		$this->assertArrayHasKey( 'theme_supports', $properties );
 
 		$this->assertArrayHasKey( 'theme_uri', $properties );
@@ -344,6 +346,13 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$result   = $response->get_data();
 		$this->assertArrayHasKey( 'template', $result[0] );
 		$this->assertSame( 'default', $result[0]['template'] );
+	}
+
+	public function test_theme_textdomain() {
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+		$this->assertArrayHasKey( 'textdomain', $result[0] );
+		$this->assertSame( '', $result[0]['textdomain'] );
 	}
 
 	public function test_theme_theme_uri() {

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -350,7 +350,8 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$result   = $response->get_data();
 		$this->assertArrayHasKey( 'theme_uri', $result[0] );
 		$this->assertSame( 'http://wordpress.org/', $result[0]['theme_uri']['raw'] );
-		$this->assertSame( 'http://wordpress.org/', $result[0]['theme_uri']['rendered'] );  }
+		$this->assertSame( 'http://wordpress.org/', $result[0]['theme_uri']['rendered'] );
+	}
 
 	public function test_theme_version() {
 		$response = self::perform_active_theme_request();

--- a/tests/phpunit/tests/theme/themeDir.php
+++ b/tests/phpunit/tests/theme/themeDir.php
@@ -163,6 +163,7 @@ class Tests_Theme_ThemeDir extends WP_UnitTestCase {
 			'Theme with Spaces in the Directory',
 			'Internationalized Theme',
 			'camelCase',
+			'REST Theme',
 		);
 
 		sort( $theme_names );


### PR DESCRIPTION
The `/wp/v2/themes` [endpoint](https://developer.wordpress.org/rest-api/reference/themes/) currently only exposes each theme's theme_supports field, but nothing else -- not even theme name or title.

See https://core.trac.wordpress.org/ticket/49906.

Needed for https://github.com/WordPress/gutenberg/pull/21578 -- you can use that PR to test this one :slightly_smiling_face: I'm adding all the fields that I think will be needed to implement https://github.com/WordPress/gutenberg/issues/20469#issuecomment-597806801:

<img width="626" alt="image" src="https://user-images.githubusercontent.com/191598/76452488-9b097d00-63a7-11ea-9ecd-23f573246ea3.png">

That is:
- `author`
- `author_name`
- `author_uri`
- `description`
- `name`
- `screenshot`
- `stylesheet`
- `template`
- `theme_uri`
- `version`

Implementation loosely inspired by https://github.com/Automattic/jetpack/blob/f6f313d268c336491c8bca1afcf3e5d3663597ce/json-endpoints/jetpack/class.jetpack-json-api-themes-endpoint.php.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
