### PR TITLE
Adding hooks to site-info.php screen

### DIFF
--- a/src/wp-admin/network/site-info.php
+++ b/src/wp-admin/network/site-info.php
@@ -102,6 +102,14 @@ if ( isset( $_REQUEST['action'] ) && 'update-site' == $_REQUEST['action'] ) {
 		update_option( 'siteurl', $new_site_url );
 	}
 
+    /**
+     * Fires immediately after the saving of default site options.
+     *
+     * @since   5.5
+     * @param   int     $id     Site ID
+     */
+    do_action( 'update_site_info', $id );
+
 	restore_current_blog();
 	wp_redirect(
 		add_query_arg(
@@ -153,6 +161,7 @@ if ( ! empty( $messages ) ) {
 <form method="post" action="site-info.php?action=update-site">
 	<?php wp_nonce_field( 'edit-site' ); ?>
 	<input type="hidden" name="id" value="<?php echo esc_attr( $id ); ?>" />
+
 	<table class="form-table" role="presentation">
 		<?php
 		// The main site of the network should not be updated on this page.
@@ -172,15 +181,23 @@ if ( ! empty( $messages ) ) {
 		</tr>
 		<?php endif; ?>
 
+        <?php do_action( 'network_site_info_after_address_field', $id, $details ); ?>
+
 		<tr class="form-field">
 			<th scope="row"><label for="blog_registered"><?php _ex( 'Registered', 'site' ); ?></label></th>
 			<td><input name="blog[registered]" type="text" id="blog_registered" value="<?php echo esc_attr( $details->registered ); ?>" /></td>
 		</tr>
+
+        <?php do_action( 'network_site_info_after_registered_field', $id, $details ); ?>
+
 		<tr class="form-field">
 			<th scope="row"><label for="blog_last_updated"><?php _e( 'Last Updated' ); ?></label></th>
 			<td><input name="blog[last_updated]" type="text" id="blog_last_updated" value="<?php echo esc_attr( $details->last_updated ); ?>" /></td>
 		</tr>
 		<?php
+
+        do_action( 'network_site_info_after_last_updated_field', $id, $details );
+
 		$attribute_fields = array( 'public' => __( 'Public' ) );
 		if ( ! $is_main_site ) {
 			$attribute_fields['archived'] = __( 'Archived' );
@@ -201,6 +218,9 @@ if ( ! empty( $messages ) ) {
 			<fieldset>
 			</td>
 		</tr>
+
+        <?php do_action( 'network_site_info_after_attributes_field', $id, $details ); ?>    
+
 	</table>
 	<?php submit_button(); ?>
 </form>


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/49968#ticket

Currently, there are no hooks to enable developers to add fields to the site info table.

I propose to add hooks after each field to enable developers to add fields as required. Furthermore, a hook to enable the saving of the fields also.

`do_action( 'update_site_info', $id );` will run immediately after the default fields are saved and before the restoring of current blog and subsequent redirect occurs.

* `do_action( 'network_site_info_after_address_field', $id, $details );`
* `do_action( 'network_site_info_after_registered_field', $id, $details );`
* `do_action( 'network_site_info_after_last_updated_field', $id, $details );`
* `do_action( 'network_site_info_after_attributes_field', $id, $details );`

Will all run immediately after the respective default fields.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
