### PR TITLE
Editor: Move printing TinyMCE scripts into an action

### DIFF
--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -349,6 +349,16 @@ if ( $is_new_post && ! isset( $editor_settings['template'] ) && 'post' === $post
 	}
 }
 
+// In order to duplicate classic meta box behaviour, we need to run the classic meta box actions.
+require_once ABSPATH . 'wp-admin/includes/meta-boxes.php';
+register_and_do_post_meta_boxes( $post );
+
+// Check if the Custom Fields meta box has been removed at some point.
+$core_meta_boxes = $wp_meta_boxes[ $current_screen->id ]['normal']['core'];
+if ( ! isset( $core_meta_boxes['postcustom'] ) || ! $core_meta_boxes['postcustom'] ) {
+	unset( $editor_settings['enableCustomFields'] );
+}
+
 /**
  * Scripts
  */
@@ -377,16 +387,6 @@ wp_enqueue_style( 'wp-format-library' );
  * @since 5.0.0
  */
 do_action( 'enqueue_block_editor_assets' );
-
-// In order to duplicate classic meta box behaviour, we need to run the classic meta box actions.
-require_once ABSPATH . 'wp-admin/includes/meta-boxes.php';
-register_and_do_post_meta_boxes( $post );
-
-// Check if the Custom Fields meta box has been removed at some point.
-$core_meta_boxes = $wp_meta_boxes[ $current_screen->id ]['normal']['core'];
-if ( ! isset( $core_meta_boxes['postcustom'] ) || ! $core_meta_boxes['postcustom'] ) {
-	unset( $editor_settings['enableCustomFields'] );
-}
 
 /**
  * Filters the settings to pass to the block editor.

--- a/src/wp-includes/class-wp-editor.php
+++ b/src/wp-includes/class-wp-editor.php
@@ -1550,9 +1550,7 @@ final class _WP_Editors {
 			script_concat_settings();
 		}
 
-		wp_print_scripts( array( 'wp-tinymce' ) );
-
-		echo "<script type='text/javascript'>\n" . self::wp_mce_translation() . "</script>\n";
+		do_action( 'print_tinymce_scripts' );
 	}
 
 	/**

--- a/src/wp-includes/class.wp-scripts.php
+++ b/src/wp-includes/class.wp-scripts.php
@@ -684,6 +684,34 @@ JS;
 	}
 
 	/**
+	 * Gets the script URL for a given handle including version
+	 *
+	 * @param string $handle Script handle name.
+	 *
+	 * @return string|null
+	 */
+	public function get_url( $handle ) {
+		$script = $this->registered[ $handle ];
+		$src    = $script->src;
+		$ver    = $script->ver;
+
+		if ( is_bool( $src ) ) {
+			// $handle is an alias for its dependencies, has no URL of its own
+			return null;
+		}
+
+		if ( ! preg_match( '|^(https?:)?//|', $src ) && ! ( $this->content_url && 0 === strpos( $src, $this->content_url ) ) ) {
+			$src = $this->base_url . $src;
+		}
+		if ( ! empty( $ver ) ) {
+			$src = add_query_arg( 'ver', $ver, $src );
+		}
+
+		/** This filter is documented in wp-includes/class.wp-scripts.php */
+		return esc_url( apply_filters( 'script_loader_src', $src, $handle ) );
+	}
+
+	/**
 	 * Resets class properties.
 	 *
 	 * @since 2.8.0

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -64,6 +64,25 @@ function wp_register_tinymce_scripts( $scripts, $force_uncompressed = false ) {
 }
 
 /**
+ * Function responsible for printing the TinyMCE scripts.
+ *
+ * @since 5.4.0
+ */
+function wp_print_tinymce_scripts() {
+	wp_print_scripts( array( 'wp-tinymce' ) );
+
+	echo "<script type='text/javascript'>\n" . _WP_Editors::wp_mce_translation() . "</script>\n";
+}
+
+/**
+ * Executed in _WP_Editors::print_tinymce_scripts
+ * after concatenation settings have been initialized.
+ *
+ * @see _WP_Editors::print_tinymce_scripts()
+ */
+add_action( 'print_tinymce_scripts', 'wp_print_tinymce_scripts' );
+
+/**
  * Registers all the WordPress vendor scripts that are in the standardized
  * `js/dist/vendor/` location.
  *

--- a/tests/phpunit/tests/editor/wpEditors.php
+++ b/tests/phpunit/tests/editor/wpEditors.php
@@ -91,4 +91,12 @@ class Tests_WP_Editors extends WP_UnitTestCase {
 			$actual
 		);
 	}
+
+	public function test_print_tinymce_scripts_calls_print_tinymce_scripts_action() {
+		$this->assertEquals( 0, did_action( 'print_tinymce_scripts' ) );
+
+		_WP_Editors::print_tinymce_scripts();
+
+		$this->assertEquals( 1, did_action( 'print_tinymce_scripts' ) );
+	}
 }


### PR DESCRIPTION
This is a draft PR to start addressing the issue in the ticket. Moving this logic into an action allows plugins to override how/when TinyMCE is loaded. Specifically, Gutenberg needs to be able to prevent TinyMCE scripts from being written into the page when TinyMCE should be loaded asynchronously when it is actually needed.

This is the first time I've made changes in WordPress core and I had a hard time deciding where to put the `wp_print_tinymce_scripts` function (or what to name it, for that matter).

I'm also not even sure that this is exactly the correct approach for the issue described in the ticket, so any and all feedback is super welcome!

Trac ticket: https://core.trac.wordpress.org/ticket/49964

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
