### PR TITLE
fix issue 49832 get_post_thumbnail_id return value doc amendment

### DIFF
--- a/src/wp-includes/post-thumbnail-template.php
+++ b/src/wp-includes/post-thumbnail-template.php
@@ -43,9 +43,10 @@ function has_post_thumbnail( $post = null ) {
  *
  * @since 2.9.0
  * @since 4.4.0 `$post` can be a post ID or WP_Post object.
+ * @since 5.5 update php_doc to reflect range of return values
  *
  * @param int|WP_Post $post Optional. Post ID or WP_Post object. Default is global `$post`.
- * @return int|string Post thumbnail ID or empty string if the post does not exist.
+ * @return int|string Post thumbnail ID if found, 0 if the thumbnail image is not set, or empty string if the post does not exist.
  */
 function get_post_thumbnail_id( $post = null ) {
 	$post = get_post( $post );


### PR DESCRIPTION
get_post_thumbnail_id return value doc amendment

This correction to the php_doc brings the notes in line with the actual range of return values of the function.

Props theMikeD.
Fixes #49832.

Trac ticket: https://core.trac.wordpress.org/ticket/49832

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
