### PR TITLE
remove_meta_box triggers warning in PHP 7.4

### DIFF
--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -1052,7 +1052,7 @@ function add_meta_box( $id, $title, $callback, $screen = null, $context = 'advan
 
 	foreach ( array_keys( $wp_meta_boxes[ $page ] ) as $a_context ) {
 		foreach ( array( 'high', 'core', 'default', 'low' ) as $a_priority ) {
-			if ( ! isset( $wp_meta_boxes[ $page ][ $a_context ][ $a_priority ][ $id ] ) ) {
+			if ( empty( $wp_meta_boxes[ $page ][ $a_context ][ $a_priority ][ $id ] ) ) {
 				continue;
 			}
 


### PR DESCRIPTION
After updating my local sandbox to PHP 7.4, I started seeing errors on my Edit Page screen for my custom post type:

Notice: Trying to access array offset on value of type bool in /../wp-admin/includes/template.php on line 1079, 1080, 1081

After some research, I narrowed down the issue to a call in one of my plugins, which removes one of the meta boxes on that screen:

remove_meta_box( 'profile_rolediv', 'people', 'normal' );

Everything had been working fine in earlier versions. Looking at the code in template.php, it looks like remove_meta_box just sets values to false, instead of removing the entry:

function remove_meta_box( $id, $screen, $context ) {
.
$wp_meta_boxes[ $page ][ $context ][ $priority ][ $id ] = false;
.
}

which then causes this line in template.php to fail:

$title = $wp_meta_boxes[ $page ][ $a_context ][ $a_priority ][ $id ]['title'];

Changing a line in wp-admin/includes/template.php fixes the issue (replace isset with empty):

if ( empty( $wp_meta_boxes[ $page ][ $a_context ][ $a_priority ][ $id ] ) ) {

Thank you,
Jason

Trac ticket: https://core.trac.wordpress.org/ticket/50019
