### PR TITLE
Remove hardcoded strong definitions

### DIFF
--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -470,7 +470,6 @@ table.media .column-title .filename {
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 	text-decoration: none !important;
-	color: #444;
 }
 
 .column-comments .sorting-indicator:before {

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -1012,13 +1012,15 @@ class WP_Posts_List_Table extends WP_List_Table {
 		}
 
 		$pad = str_repeat( '&#8212; ', $this->current_level );
-		echo '<strong>';
 
 		$title = _draft_or_post_title();
 
 		if ( $can_edit_post && 'trash' !== $post->post_status ) {
+			$column       = apply_filters( 'list_table_primary_column', WP_List_Table::get_default_primary_column_name(), $this->screen->id );
+			$bolded_class = ( 'title' === $column ) ? 'bolded-class' : false;
 			printf(
-				'<a class="row-title" href="%s" aria-label="%s">%s%s</a>',
+				'<a class="row-title%s" href="%s" aria-label="%s">%s%s</a>',
+				$bolded_class,
 				get_edit_post_link( $post->ID ),
 				/* translators: %s: Post title. */
 				esc_attr( sprintf( __( '&#8220;%s&#8221; (Edit)' ), $title ) ),
@@ -1038,7 +1040,6 @@ class WP_Posts_List_Table extends WP_List_Table {
 			$post_type_object = get_post_type_object( $post->post_type );
 			echo ' | ' . $post_type_object->labels->parent_item_colon . ' ' . esc_html( $parent_name );
 		}
-		echo "</strong>\n";
 
 		if ( ! is_post_type_hierarchical( $this->screen->post_type ) && 'excerpt' === $mode && current_user_can( 'read_post', $post->ID ) ) {
 			if ( post_password_required( $post ) ) {
@@ -1200,9 +1201,10 @@ class WP_Posts_List_Table extends WP_List_Table {
 						$posts_in_term_qv['term']     = $t->slug;
 					}
 
-					$label = esc_html( sanitize_term_field( 'name', $t->name, $t->term_id, $taxonomy, 'display' ) );
-
-					$term_links[] = $this->get_edit_link( $posts_in_term_qv, $label );
+					$label          = esc_html( sanitize_term_field( 'name', $t->name, $t->term_id, $taxonomy, 'display' ) );
+					$default_column = WP_List_Table::get_default_primary_column_name();
+					$bolded_class   = ( $column_name === $default_column ) ? 'bolded-class' : false;
+					$term_links[]   = $this->get_edit_link( $posts_in_term_qv, $label, $bolded_class );
 				}
 
 				/**


### PR DESCRIPTION
There is a hardcoded strong definition to 'bold' the title column in posts list table.

If you use the filter to define another column as default, the bolding stays on the title, why that might not be what you want (like in my case).

With my change the hardcoded strong definition is removed from the title column and dynamically added.

Trac ticket: https://core.trac.wordpress.org/ticket/49962

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
