### PR TITLE
Add support for uuid format in REST schema

### DIFF
--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -1395,8 +1395,8 @@ function rest_validate_value_from_schema( $value, $args, $param = '' ) {
 				break;
 			case 'uuid':
 				if ( ! wp_is_uuid( $value ) ) {
-					/* translators: %s is an invalid universally unique identifier (UUID). */
-					return new WP_Error( 'rest_invalid_uuid', sprintf( __( '%s is not a valid UUID.' ), strval( $param ) ) );
+					/* translators: %s is the name of a JSON field expecting a valid uuid. */
+					return new WP_Error( 'rest_invalid_uuid', sprintf( __( '%s is not a valid UUID.' ), $param ) );
 				}
 				break;
 		}

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -1393,6 +1393,11 @@ function rest_validate_value_from_schema( $value, $args, $param = '' ) {
 					return new WP_Error( 'rest_invalid_param', sprintf( __( '%s is not a valid IP address.' ), $param ) );
 				}
 				break;
+			case 'uuid':
+				if ( ! wp_is_uuid( $value ) ) {
+					return new WP_Error( 'rest_invalid_uuid', __( 'Invalid UUID' ) );
+				}
+				break;
 		}
 	}
 
@@ -1548,6 +1553,9 @@ function rest_sanitize_value_from_schema( $value, $args ) {
 				return esc_url_raw( $value );
 
 			case 'ip':
+				return sanitize_text_field( $value );
+
+			case 'uuid':
 				return sanitize_text_field( $value );
 		}
 	}

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -1395,7 +1395,8 @@ function rest_validate_value_from_schema( $value, $args, $param = '' ) {
 				break;
 			case 'uuid':
 				if ( ! wp_is_uuid( $value ) ) {
-					return new WP_Error( 'rest_invalid_uuid', __( 'Invalid UUID' ) );
+					/* translators: %s is an invalid universally unique identifier (UUID). */
+					return new WP_Error( 'rest_invalid_uuid', sprintf( __( '%s is not a valid UUID.' ), strval( $param ) ) );
 				}
 				break;
 		}

--- a/tests/phpunit/tests/rest-api/rest-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-controller.php
@@ -46,7 +46,7 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 					'someuuid'    => array(
 						'type'   => 'string',
 						'format' => 'uuid',
-					)
+					),
 				),
 			)
 		);

--- a/tests/phpunit/tests/rest-api/rest-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-controller.php
@@ -43,6 +43,10 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 						'type'   => 'string',
 						'format' => 'email',
 					),
+					'someuuid'    => array(
+						'type'   => 'string',
+						'format' => 'uuid',
+					)
 				),
 			)
 		);
@@ -204,6 +208,20 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 		);
 	}
 
+	/**
+	 * @ticket 50053
+	 */
+	public function test_validate_schema_format_uuid() {
+		$this->assertTrue(
+			rest_validate_request_arg( '123e4567-e89b-12d3-a456-426655440000', $this->request, 'someuuid' )
+		);
+
+		$this->assertErrorResponse(
+			'rest_invalid_uuid',
+			rest_validate_request_arg( '123e4567-e89b-12d3-a456-426655440000X', $this->request, 'someuuid' )
+		);
+	}
+
 	public function test_get_endpoint_args_for_item_schema_description() {
 		$controller = new WP_REST_Test_Controller();
 		$args       = $controller->get_endpoint_args_for_item_schema();
@@ -245,6 +263,7 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 				'somedate',
 				'someemail',
 				'somehex',
+				'someuuid',
 				'someenum',
 				'someargoptions',
 				'somedefault',
@@ -275,6 +294,7 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 					'somedate',
 					'someemail',
 					'somehex',
+					'someuuid',
 					'someenum',
 					'someargoptions',
 					'somedefault',

--- a/tests/phpunit/tests/rest-api/rest-schema-sanitization.php
+++ b/tests/phpunit/tests/rest-api/rest-schema-sanitization.php
@@ -90,6 +90,22 @@ class WP_Test_REST_Schema_Sanitization extends WP_UnitTestCase {
 		$this->assertEquals( '', rest_sanitize_value_from_schema( 'WordPress', $schema ) );
 	}
 
+	/**
+	 * @ticket 50053
+	 */
+	public function test_format_uuid() {
+		$schema = array(
+			'type'   => 'string',
+			'format' => 'uuid',
+		);
+		$this->assertEquals( '44', rest_sanitize_value_from_schema( 44, $schema ) );
+		$this->assertEquals( 'hello', rest_sanitize_value_from_schema( 'hello', $schema ) );
+		$this->assertEquals(
+			'123e4567-e89b-12d3-a456-426655440000',
+			rest_sanitize_value_from_schema( '123e4567-e89b-12d3-a456-426655440000', $schema )
+		);
+	}
+
 	public function test_type_array() {
 		$schema = array(
 			'type'  => 'array',

--- a/tests/phpunit/tests/rest-api/rest-schema-validation.php
+++ b/tests/phpunit/tests/rest-api/rest-schema-validation.php
@@ -85,6 +85,19 @@ class WP_Test_REST_Schema_Validation extends WP_UnitTestCase {
 		$this->assertWPError( rest_validate_value_from_schema( 'WordPress', $schema ) );
 	}
 
+	/**
+	 * @ticket 50053
+	 */
+	public function test_format_uuid() {
+		$schema = array(
+			'type'   => 'string',
+			'format' => 'uuid',
+		);
+		$this->assertTrue( rest_validate_value_from_schema( '123e4567-e89b-12d3-a456-426655440000', $schema ) );
+		$this->assertWPError( rest_validate_value_from_schema( '123e4567-e89b-12d3-a456-426655440000X', $schema ) );
+		$this->assertWPError( rest_validate_value_from_schema( '123e4567-e89b-?2d3-a456-426655440000', $schema ) );
+	}
+
 	public function test_format_date_time() {
 		$schema = array(
 			'type'   => 'string',

--- a/tests/phpunit/tests/rest-api/rest-test-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-test-controller.php
@@ -69,6 +69,11 @@ class WP_REST_Test_Controller extends WP_REST_Controller {
 					'format'  => 'hex-color',
 					'context' => array( 'view' ),
 				),
+				'someuuid'        => array(
+					'type'    => 'string',
+					'format'  => 'uuid',
+					'context' => array( 'view' ),
+				),
 				'someenum'       => array(
 					'type'    => 'string',
 					'enum'    => array( 'a', 'b', 'c' ),

--- a/tests/phpunit/tests/rest-api/rest-test-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-test-controller.php
@@ -69,7 +69,7 @@ class WP_REST_Test_Controller extends WP_REST_Controller {
 					'format'  => 'hex-color',
 					'context' => array( 'view' ),
 				),
-				'someuuid'        => array(
+				'someuuid'       => array(
 					'type'    => 'string',
 					'format'  => 'uuid',
 					'context' => array( 'view' ),


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/50053

This adds support for the uuid format in WP REST JSON schema. As suggested in the ticket description, the format is validated with `wp_is_uuid` and sanitized with `sanitize_text_field`.