### PR TITLE
Language switcher on the login screen

### DIFF
--- a/src/wp-admin/css/login.css
+++ b/src/wp-admin/css/login.css
@@ -261,6 +261,7 @@ p {
 	margin: auto;
 }
 
+#language-switcher
 .login #nav,
 .login #backtoblog {
 	font-size: 13px;
@@ -378,6 +379,40 @@ body.interim-login {
 /* Hide the Edge "reveal password" native button */
 input::-ms-reveal {
 	display: none;
+}
+
+#language-switcher {
+	background: none;
+	border: none;
+	box-shadow: none;
+	padding: 0 0 0 24px;
+	margin: 0;
+}
+
+#language-switcher select {
+	height: 30px;
+}
+
+#language-switcher label {
+	margin-right: .5em;
+}
+
+#language-switcher .dashicons {
+	line-height: 25px;
+}
+
+.screen-reader-text {
+	border: 0;
+	clip: rect(1px, 1px, 1px, 1px);
+	-webkit-clip-path: inset(50%);
+	clip-path: inset(50%);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute;
+	width: 1px;
+	word-wrap: normal !important;
 }
 
 @-ms-viewport {

--- a/src/wp-includes/default-constants.php
+++ b/src/wp-includes/default-constants.php
@@ -314,6 +314,13 @@ function wp_cookie_constants() {
 		 */
 		define( 'RECOVERY_MODE_COOKIE', 'wordpress_rec_' . COOKIEHASH );
 	}
+
+	/**
+	 * @since x.x.x
+	 */
+	if ( ! defined( 'LANGUAGE_COOKIE' ) ) {
+		define( 'LANGUAGE_COOKIE', 'wordpress_lang_' . COOKIEHASH );
+	}
 }
 
 /**

--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -143,8 +143,16 @@ function determine_locale() {
 		$determined_locale = get_user_locale();
 	}
 
-	if ( ! empty( $_GET['wp_lang'] ) && ! empty( $GLOBALS['pagenow'] ) && 'wp-login.php' === $GLOBALS['pagenow'] ) {
-		$determined_locale = sanitize_text_field( $_GET['wp_lang'] );
+	$wp_lang = '';
+
+	if ( ! empty( $_GET['wp_lang'] ) ) {
+		$wp_lang = $_GET['wp_lang'];
+	} elseif ( ! empty( $_COOKIE[ LANGUAGE_COOKIE ] ) ) {
+		$wp_lang = $_COOKIE[ LANGUAGE_COOKIE ];
+	}
+
+	if ( ! empty( $wp_lang ) && ! empty( $GLOBALS['pagenow'] ) && 'wp-login.php' === $GLOBALS['pagenow'] ) {
+		$determined_locale = sanitize_text_field( $wp_lang );
 	}
 
 	/**
@@ -1411,6 +1419,7 @@ function wp_get_pomo_file_data( $po_file ) {
  * @since 4.3.0 Introduced the `echo` argument.
  * @since 4.7.0 Introduced the `show_option_site_default` argument.
  * @since 5.1.0 Introduced the `show_option_en_us` argument.
+ * @since x.x.x Introduced the `explicit_option_en_us` argument.
  *
  * @see get_available_languages()
  * @see wp_get_available_translations()
@@ -1430,6 +1439,8 @@ function wp_get_pomo_file_data( $po_file ) {
  *     @type bool     $show_available_translations  Whether to show available translations. Default true.
  *     @type bool     $show_option_site_default     Whether to show an option to fall back to the site's locale. Default false.
  *     @type bool     $show_option_en_us            Whether to show an option for English (United States). Default true.
+ *     @type bool     $explicit_option_en_us        Whether the English (United States) option uses an explict value of en_US
+ *                                                  instead of an empty value. Default false.
  * }
  * @return string HTML dropdown list of languages.
  */
@@ -1447,6 +1458,7 @@ function wp_dropdown_languages( $args = array() ) {
 			'show_available_translations' => true,
 			'show_option_site_default'    => false,
 			'show_option_en_us'           => true,
+			'explicit_option_en_us'       => false,
 		)
 	);
 
@@ -1456,7 +1468,7 @@ function wp_dropdown_languages( $args = array() ) {
 	}
 
 	// English (United States) uses an empty string for the value attribute.
-	if ( 'en_US' === $parsed_args['selected'] ) {
+	if ( 'en_US' === $parsed_args['selected'] && ! $parsed_args['explicit_option_en_us'] ) {
 		$parsed_args['selected'] = '';
 	}
 
@@ -1511,8 +1523,10 @@ function wp_dropdown_languages( $args = array() ) {
 	}
 
 	if ( $parsed_args['show_option_en_us'] ) {
+		$value = ( $parsed_args['explicit_option_en_us'] ) ? 'en_US' : '';
 		$structure[] = sprintf(
-			'<option value="" lang="en" data-installed="1"%s>English (United States)</option>',
+			'<option value="%1$s" lang="en" data-installed="1"%2$s>English (United States)</option>',
+			esc_attr( $value ),
 			selected( '', $parsed_args['selected'], false )
 		);
 	}

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -2037,14 +2037,30 @@ if ( ! function_exists( 'wp_new_user_notification' ) ) :
 			return;
 		}
 
-		$switched_locale = switch_to_locale( get_user_locale( $user ) );
+		$user_locale     = get_user_locale( $user );
+		$switched_locale = switch_to_locale( $user_locale );
+
+		$reset_url = add_query_arg(
+			array(
+				'action'  => 'rp',
+				'key'     => $key,
+				'login'   => rawurlencode( $user->user_login ),
+				'wp_lang' => $user_locale,
+			),
+			network_site_url( 'wp-login.php', 'login' )
+		);
+		$login_url = add_query_arg(
+			array(
+				'wp_lang' => $user_locale,
+			),
+			wp_login_url()
+		);
 
 		/* translators: %s: User login. */
 		$message  = sprintf( __( 'Username: %s' ), $user->user_login ) . "\r\n\r\n";
 		$message .= __( 'To set your password, visit the following address:' ) . "\r\n\r\n";
-		$message .= network_site_url( "wp-login.php?action=rp&key=$key&login=" . rawurlencode( $user->user_login ), 'login' ) . "\r\n\r\n";
-
-		$message .= wp_login_url() . "\r\n";
+		$message .= $reset_url . "\r\n\r\n";
+		$message .= $login_url . "\r\n";
 
 		$wp_new_user_notification_email = array(
 			'to'      => $user->user_email,

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -985,6 +985,9 @@ if ( ! function_exists( 'wp_clear_auth_cookie' ) ) :
 		setcookie( 'wp-settings-' . get_current_user_id(), ' ', time() - YEAR_IN_SECONDS, SITECOOKIEPATH );
 		setcookie( 'wp-settings-time-' . get_current_user_id(), ' ', time() - YEAR_IN_SECONDS, SITECOOKIEPATH );
 
+		// Language cookie from the login screen.
+		setcookie( LANGUAGE_COOKIE, ' ', time() - YEAR_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN );
+
 		// Old cookies.
 		setcookie( AUTH_COOKIE, ' ', time() - YEAR_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN );
 		setcookie( AUTH_COOKIE, ' ', time() - YEAR_IN_SECONDS, SITECOOKIEPATH, COOKIE_DOMAIN );

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -464,6 +464,9 @@ function retrieve_password() {
 		return $key;
 	}
 
+	$user_locale = get_user_locale( $user_data );
+	$switched_locale = switch_to_locale( $user_locale );
+
 	if ( is_multisite() ) {
 		$site_name = get_network()->site_name;
 	} else {
@@ -513,6 +516,8 @@ function retrieve_password() {
 	 */
 	$message = apply_filters( 'retrieve_password_message', $message, $key, $user_login, $user_data );
 
+	$result = true;
+
 	if ( $message && ! wp_mail( $user_email, wp_specialchars_decode( $title ), $message ) ) {
 		$errors->add(
 			'retrieve_password_email_failure',
@@ -522,10 +527,14 @@ function retrieve_password() {
 				esc_url( __( 'https://wordpress.org/support/article/resetting-your-password/' ) )
 			)
 		);
-		return $errors;
+		$result = $errors;
 	}
 
-	return true;
+	if ( $switched_locale ) {
+		restore_previous_locale();
+	}
+
+	return $result;
 }
 
 //

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -296,6 +296,65 @@ function login_footer( $input_id = '' ) {
 		</a></p>
 		<?php
 
+		$languages = get_available_languages();
+
+		if ( ! empty( $languages ) ) {
+			?>
+			<form id="language-switcher" action="" method="GET">
+				<label for="language-switcher-locales">
+					<span class="screen-reader-text"><?php _e( 'Language' ); ?></span>
+					<span aria-hidden="true" class="dashicons dashicons-translation"></span>
+				</label>
+
+				<?php if ( $interim_login ) { ?>
+					<input type="hidden" name="interim-login" value="1" />
+				<?php } ?>
+
+				<?php
+				$query_vars = array(
+					'action',
+					'checkemail',
+					'error',
+					'redirect_to',
+				);
+
+				foreach ( $query_vars as $query_var ) {
+					if ( isset( $_GET[ $query_var ] ) && '' !== $_GET[ $query_var ] ) {
+						printf(
+							'<input type="hidden" name="%1$s" value="%2$s" />',
+							esc_attr( $query_var ),
+							esc_attr( sanitize_text_field( $_GET[ $query_var ] ) )
+						);
+					}
+				}
+
+				$args = array(
+					'id'                          => 'language-switcher-locales',
+					'name'                        => 'wp_lang',
+					'selected'                    => determine_locale(),
+					'show_available_translations' => false,
+					'explicit_option_en_us'       => true,
+					'languages'                   => $languages,
+				);
+
+				/**
+				 * Filters the arguments for the Language selector on the login screen.
+				 *
+				 * @since x.x.x
+				 *
+				 * @param Array $args Arguments for the Language selector on the login screen.
+				 */
+				wp_dropdown_languages( apply_filters( 'wp_login_language_switcher_args', $args ) );
+				?>
+			</form>
+			<script>
+				document.getElementById( 'language-switcher-locales' ).addEventListener( 'change', function() {
+					document.getElementById( 'language-switcher' ).submit()
+				} );
+			</script>
+			<?php
+		}
+
 		the_privacy_policy_link( '<div class="privacy-policy-page-link">', '</div>' );
 	}
 
@@ -521,6 +580,10 @@ setcookie( TEST_COOKIE, 'WP Cookie check', 0, COOKIEPATH, COOKIE_DOMAIN, $secure
 
 if ( SITECOOKIEPATH !== COOKIEPATH ) {
 	setcookie( TEST_COOKIE, 'WP Cookie check', 0, SITECOOKIEPATH, COOKIE_DOMAIN, $secure );
+}
+
+if ( isset( $_GET['wp_lang'] ) ) {
+	setcookie( LANGUAGE_COOKIE, wp_unslash( $_GET['wp_lang'] ), 0, COOKIEPATH, COOKIE_DOMAIN, $secure );
 }
 
 /**

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -477,6 +477,16 @@ function retrieve_password() {
 		$site_name = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
 	}
 
+	$reset_url = add_query_arg(
+		array(
+			'action'  => 'rp',
+			'key'     => $key,
+			'login'   => rawurlencode( $user_login ),
+			'wp_lang' => $user_locale,
+		),
+		network_site_url( 'wp-login.php', 'login' )
+	);
+
 	$message = __( 'Someone has requested a password reset for the following account:' ) . "\r\n\r\n";
 	/* translators: %s: Site name. */
 	$message .= sprintf( __( 'Site Name: %s' ), $site_name ) . "\r\n\r\n";
@@ -484,7 +494,7 @@ function retrieve_password() {
 	$message .= sprintf( __( 'Username: %s' ), $user_login ) . "\r\n\r\n";
 	$message .= __( 'If this was a mistake, just ignore this email and nothing will happen.' ) . "\r\n\r\n";
 	$message .= __( 'To reset your password, visit the following address:' ) . "\r\n\r\n";
-	$message .= network_site_url( "wp-login.php?action=rp&key=$key&login=" . rawurlencode( $user_login ), 'login' ) . "\r\n";
+	$message .= $reset_url . "\r\n";
 
 	/* translators: Password reset notification email subject. %s: Site title. */
 	$title = sprintf( __( '[%s] Password Reset' ), $site_name );


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/43700

This continues the work on the patches already uploaded to 43700. It introduces a language switcher to the login screen, which also affects its derivatives such as the password reset screens and user registration.

The following closely related functionality has also been implemented:

* Add the language parameter to the login and password reset URLs in the email sent to a user when they are added to a site.
* Ensure the password reset email is always sent to the user in their chosen language.
* Add the language parameter to the URL in the password reset email.

Still to do:

* Decide whether, upon login, the user's locale should be updated to the one they chose on the login screen. Probably yes.