### PR TITLE
Fix _fields filtering on taxonomies and post_types endpoints

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-post-types-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-post-types-controller.php
@@ -120,6 +120,9 @@ class WP_REST_Post_Types_Controller extends WP_REST_Controller {
 			$data[ $type->name ] = $this->prepare_response_for_collection( $post_type );
 		}
 
+		// Fields were already filtered in the nested objects. No further filtering needed.
+		$request->set_param( '_fields', null );
+
 		return rest_ensure_response( $data );
 	}
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-taxonomies-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-taxonomies-controller.php
@@ -140,6 +140,9 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 			$data = (object) $data;
 		}
 
+		// Fields were already filtered in the nested objects. No further filtering needed.
+		$request->set_param( '_fields', null );
+
 		return rest_ensure_response( $data );
 	}
 

--- a/tests/phpunit/tests/rest-api/rest-post-types-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-post-types-controller.php
@@ -8,6 +8,7 @@
 
 /**
  * @group restapi
+ * @group my-test
  */
 class WP_Test_REST_Post_Types_Controller extends WP_Test_REST_Controller_Testcase {
 
@@ -44,6 +45,20 @@ class WP_Test_REST_Post_Types_Controller extends WP_Test_REST_Controller_Testcas
 		$this->assertEquals( $post_types['page']->name, $data['page']['slug'] );
 		$this->check_post_type_obj( 'view', $post_types['page'], $data['page'], $data['page']['_links'] );
 		$this->assertFalse( isset( $data['revision'] ) );
+	}
+
+	/**
+	 * @ticket 50012
+	 */
+	public function test_get_items_with_filtered_fields() {
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/types' );
+		$request->set_param( '_fields', 'rest_base,description' );
+		$response   = rest_get_server()->dispatch( $request );
+		$data       = $response->get_data();
+
+		$this->assertArrayHasKey( 'rest_base', $data['post'] );
+		$this->assertArrayHasKey( 'description', $data['post'] );
+		$this->assertFalse( array_key_exists( 'taxonomies', $data['post'] ) );
 	}
 
 	public function test_get_items_invalid_permission_for_context() {

--- a/tests/phpunit/tests/rest-api/rest-post-types-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-post-types-controller.php
@@ -8,7 +8,6 @@
 
 /**
  * @group restapi
- * @group my-test
  */
 class WP_Test_REST_Post_Types_Controller extends WP_Test_REST_Controller_Testcase {
 

--- a/tests/phpunit/tests/rest-api/rest-taxonomies-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-taxonomies-controller.php
@@ -8,7 +8,6 @@
 
 /**
  * @group restapi
- * @group my-test
  */
 class WP_Test_REST_Taxonomies_Controller extends WP_Test_REST_Controller_Testcase {
 

--- a/tests/phpunit/tests/rest-api/rest-taxonomies-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-taxonomies-controller.php
@@ -8,6 +8,7 @@
 
 /**
  * @group restapi
+ * @group my-test
  */
 class WP_Test_REST_Taxonomies_Controller extends WP_Test_REST_Controller_Testcase {
 
@@ -60,6 +61,20 @@ class WP_Test_REST_Taxonomies_Controller extends WP_Test_REST_Controller_Testcas
 		$this->assertEquals( 'post_tag', $data['post_tag']['slug'] );
 		$this->assertEquals( false, $data['post_tag']['hierarchical'] );
 		$this->assertEquals( 'tags', $data['post_tag']['rest_base'] );
+	}
+
+	/**
+	 * @ticket 50012
+	 */
+	public function test_get_items_with_filtered_fields() {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/taxonomies' );
+		$request->set_param( '_fields', 'name,hierarchical' );
+		$response   = rest_get_server()->dispatch( $request );
+		$data       = $response->get_data();
+
+		$this->assertArrayHasKey( 'name', $data['category'] );
+		$this->assertArrayHasKey( 'hierarchical', $data['category'] );
+		$this->assertFalse( array_key_exists( 'slug', $data['category'] ) );
 	}
 
 	public function test_get_items_context_edit() {


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/50012

This fixes support for the `_fields` parameter in REST requests for taxonomies and post types. These REST responses take the form of objects rather than arrays -- e.g. `{ category: { ...data }, post_tag: { ...data } }` -- and the `_fields` filter was being applied to that final data set, filtering out the top-level items. 

The `_fields` parameter is also applied earlier in the `get_items` logic to the nested objects themselves. This fix removes `_fields` from the request after that occurs and before the final response is processed. 

### Alternatives

One alternative option is here: https://github.com/johnwatkins0/wordpress-develop/commit/b81852609627f32bd841754d005ccbea68495053 This adds a couple of new methods to the WP_REST_Request class. Another possibility I looked at was adding a filter at the beginning `rest_filter_response_fields` and adding a filter callback in the endpoint classes that have the nested object structure. But both those options do essentially the same thing as this PR with much more code.

The drawback to this approach is it doesn't automatically apply to new endpoints that have similar structures, but the other approaches I thought of don't either. It might be worth exploring an option in `register_rest_route` or somewhere similar to indicate that `get_items` for a given endpoint returns an object rather than an array and `_fields` filtering should not be applied to the final object, but I also think anyone building custom endpoints at this level can figure out their own workarounds.