### PR TITLE
i10n: Return early before trying to file_get_contents of a directory

### DIFF
--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -1089,7 +1089,7 @@ function load_script_translations( $file, $handle, $domain ) {
 	 */
 	$file = apply_filters( 'load_script_translation_file', $file, $handle, $domain );
 
-	if ( ! $file || ! is_readable( $file ) ) {
+	if ( ! $file || ! is_readable( $file ) || is_dir( $file ) ) {
 		return false;
 	}
 


### PR DESCRIPTION
Defensive coding to avoid an error when trying to `file_get_contents` of a directory.

I think this is an incomplete solution, though, as _why_ is a directory being passed. This would at least prevent the PHP warning.

Trac ticket: https://core.trac.wordpress.org/ticket/49979

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
