### PR TITLE
Update quicktags toolbar hide if nojs

### DIFF
--- a/src/wp-includes/class-wp-editor.php
+++ b/src/wp-includes/class-wp-editor.php
@@ -249,7 +249,7 @@ final class _WP_Editors {
 				$toolbar_id = 'qt_' . $editor_id_attr . '_toolbar';
 			}
 
-			$quicktags_toolbar = '<div id="' . $toolbar_id . '" class="quicktags-toolbar"></div>';
+			$quicktags_toolbar = '<div id="' . $toolbar_id . '" class="quicktags-toolbar hide-if-no-js"></div>';
 		}
 
 		/**


### PR DESCRIPTION
Without javascript it looks better if the quicktags toolbar is hidden.

Trac ticket: https://core.trac.wordpress.org/ticket/40570
