### PR TITLE
Added a notice when permission_callback is misspelled

### DIFF
--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -21,6 +21,7 @@ define( 'REST_API_VERSION', '2.0' );
  *
  * @since 4.4.0
  * @since 5.1.0 Added a _doing_it_wrong() notice when not called on or after the rest_api_init hook.
+ * @since 5.5.0 Added a _doing_it_wrong() notice when permission_callback is misspelled.
  *
  * @param string $namespace The first URL segment after core prefix. Should be unique to your package/plugin.
  * @param string $route     The base URL for route you are adding.
@@ -54,6 +55,11 @@ function register_rest_route( $namespace, $route, $args = array(), $override = f
 			),
 			'5.1.0'
 		);
+	}
+
+	if ( isset( $args['permissions_callback'] ) ) {
+		_doing_it_wrong( 'register_rest_route', __( 'You have misspelled the permission_callback option.' ), '5.5.0' );
+		return false;
 	}
 
 	if ( isset( $args['args'] ) ) {

--- a/tests/phpunit/tests/rest-api/rest-server.php
+++ b/tests/phpunit/tests/rest-api/rest-server.php
@@ -1496,6 +1496,32 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 		$this->assertEquals( 204, $response->get_status(), '/test-ns/v1/test' );
 	}
 
+	/**
+	 * @ticket 50075
+	 */
+	public function test_misspelled_permission_callback() {
+		$result = register_rest_route(
+			'test-ns',
+			'/test',
+			array(
+				'methods'             => array( 'GET' ),
+				'permission_callback' => '__return_true',
+			)
+		);
+		$this->assertTrue( $result );
+
+		$this->setExpectedIncorrectUsage( 'register_rest_route' );
+		$result = register_rest_route(
+			'test-ns',
+			'/test',
+			array(
+				'methods'              => array( 'GET' ),
+				'permissions_callback' => '__return_true',
+			)
+		);
+		$this->assertFalse( $result );
+	}
+
 	public function _validate_as_integer_123( $value, $request, $key ) {
 		if ( ! is_int( $value ) ) {
 			return new WP_Error( 'some-error', 'This is not valid!' );


### PR DESCRIPTION
Added a notice when permission_callback is misspelled

Trac ticket: https://core.trac.wordpress.org/ticket/50075
