### PR TITLE
50160: Use the custom size width for the caption width

### DIFF
--- a/src/wp-includes/widgets/class-wp-widget-media-image.php
+++ b/src/wp-includes/widgets/class-wp-widget-media-image.php
@@ -209,15 +209,15 @@ class WP_Widget_Media_Image extends WP_Widget_Media {
 
 			$size = $instance['size'];
 			if ( 'custom' === $size || ! in_array( $size, array_merge( get_intermediate_image_sizes(), array( 'full' ) ), true ) ) {
-				$size = array( $instance['width'], $instance['height'] );
+				$size  = array( $instance['width'], $instance['height'] );
+				$width = $instance['width'];
+			} else {
+				$caption_size = _wp_get_image_size_from_meta( $instance['size'], wp_get_attachment_metadata( $attachment->ID ) );
+				$width        = empty( $caption_size[0] ) ? 0 : $caption_size[0];
 			}
 			$image_attributes['class'] .= sprintf( ' attachment-%1$s size-%1$s', is_array( $size ) ? join( 'x', $size ) : $size );
 
 			$image = wp_get_attachment_image( $attachment->ID, $size, false, $image_attributes );
-
-			$caption_size = _wp_get_image_size_from_meta( $instance['size'], wp_get_attachment_metadata( $attachment->ID ) );
-			$width        = empty( $caption_size[0] ) ? 0 : $caption_size[0];
-
 		} else {
 			if ( empty( $instance['url'] ) ) {
 				return;

--- a/tests/phpunit/tests/widgets/media-image-widget.php
+++ b/tests/phpunit/tests/widgets/media-image-widget.php
@@ -598,7 +598,7 @@ class Test_WP_Widget_Media_Image extends WP_UnitTestCase {
 			)
 		);
 		$output = ob_get_clean();
-		$this->assertContains( 'style="width: 300px"', $output );
+		$this->assertContains( 'style="width: 310px"', $output );
 		$this->assertContains( '<p class="wp-caption-text">Caption for an image with custom size</p>', $output );
 	}
 

--- a/tests/phpunit/tests/widgets/media-image-widget.php
+++ b/tests/phpunit/tests/widgets/media-image-widget.php
@@ -585,6 +585,21 @@ class Test_WP_Widget_Media_Image extends WP_UnitTestCase {
 		$output = ob_get_clean();
 		$this->assertContains( 'class="wp-caption alignnone"', $output );
 		$this->assertContains( '<p class="wp-caption-text">Custom caption</p>', $output );
+
+		// Attachments with custom sizes can render captions.
+		ob_start();
+		$widget->render_media(
+			array(
+				'attachment_id' => $attachment_id,
+				'size'          => 'custom',
+				'width'         => '300',
+				'height'        => '200',
+				'caption'       => 'Caption for an image with custom size'
+			)
+		);
+		$output = ob_get_clean();
+		$this->assertContains( 'style="width: 300px"', $output );
+		$this->assertContains( '<p class="wp-caption-text">Caption for an image with custom size</p>', $output );
 	}
 
 	/**

--- a/tests/phpunit/tests/widgets/media-image-widget.php
+++ b/tests/phpunit/tests/widgets/media-image-widget.php
@@ -594,7 +594,7 @@ class Test_WP_Widget_Media_Image extends WP_UnitTestCase {
 				'size'          => 'custom',
 				'width'         => '300',
 				'height'        => '200',
-				'caption'       => 'Caption for an image with custom size'
+				'caption'       => 'Caption for an image with custom size',
 			)
 		);
 		$output = ob_get_clean();


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/50160

Use the `width` of a custom image size in an Image Widget instead of doing a lookup for an image size `custom` which doesn't have a registered width and height.

This ensures that the `$width` used for setting the caption width is not `0` and the captions are rendered for images with custom sizes.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
