### PR TITLE
Feature/i18n size format

### DIFF
--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -3340,7 +3340,18 @@ function gd_edit_image_support($mime_type) {
 function wp_convert_bytes_to_hr( $bytes ) {
 	_deprecated_function( __FUNCTION__, '3.6.0', 'size_format()' );
 
-	$units = array( 0 => 'B', 1 => 'KB', 2 => 'MB', 3 => 'GB', 4 => 'TB' );
+	$units = array(
+		/* translators: File size in bytes. */
+		0 => __( 'B' ),
+		/* translators: File size in kilobytes. */
+		1 => __( 'KB' ),
+		/* translators: File size in megabytes. */
+		2 => __( 'MB' ),
+		/* translators: File size in gigabytes. */
+		3 => __( 'GB' ),
+		/* translators: File size in terabytes. */
+		4 => __( 'TB' ),
+	);
 	$log   = log( $bytes, KB_IN_BYTES );
 	$power = (int) $log;
 	$size  = KB_IN_BYTES ** ( $log - $power );

--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -3341,16 +3341,16 @@ function wp_convert_bytes_to_hr( $bytes ) {
 	_deprecated_function( __FUNCTION__, '3.6.0', 'size_format()' );
 
 	$units = array(
-		/* translators: File size in bytes. */
-		0 => __( 'B' ),
-		/* translators: File size in kilobytes. */
-		1 => __( 'KB' ),
-		/* translators: File size in megabytes. */
-		2 => __( 'MB' ),
-		/* translators: File size in gigabytes. */
-		3 => __( 'GB' ),
-		/* translators: File size in terabytes. */
-		4 => __( 'TB' ),
+		/* translators: Unit symbol for byte. */
+		0 => _x( 'B', 'unit symbol' ),
+		/* translators: Unit symbol for kilobyte. */
+		1 => _x( 'KB', 'unit symbol' ),
+		/* translators: Unit symbol for megabyte. */
+		2 => _x( 'MB', 'unit symbol' ),
+		/* translators: Unit symbol for gigabyte. */
+		3 => _x( 'GB', 'unit symbol' ),
+		/* translators: Unit symbol for terabyte. */
+		4 => _x( 'TB', 'unit symbol' ),
 	);
 	$log   = log( $bytes, KB_IN_BYTES );
 	$power = (int) $log;

--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -3340,18 +3340,7 @@ function gd_edit_image_support($mime_type) {
 function wp_convert_bytes_to_hr( $bytes ) {
 	_deprecated_function( __FUNCTION__, '3.6.0', 'size_format()' );
 
-	$units = array(
-		/* translators: Unit symbol for byte. */
-		0 => _x( 'B', 'unit symbol' ),
-		/* translators: Unit symbol for kilobyte. */
-		1 => _x( 'KB', 'unit symbol' ),
-		/* translators: Unit symbol for megabyte. */
-		2 => _x( 'MB', 'unit symbol' ),
-		/* translators: Unit symbol for gigabyte. */
-		3 => _x( 'GB', 'unit symbol' ),
-		/* translators: Unit symbol for terabyte. */
-		4 => _x( 'TB', 'unit symbol' ),
-	);
+	$units = array( 0 => 'B', 1 => 'KB', 2 => 'MB', 3 => 'GB', 4 => 'TB' );
 	$log   = log( $bytes, KB_IN_BYTES );
 	$power = (int) $log;
 	$size  = KB_IN_BYTES ** ( $log - $power );

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -450,15 +450,21 @@ function number_format_i18n( $number, $decimals = 0 ) {
  */
 function size_format( $bytes, $decimals = 0 ) {
 	$quant = array(
-		'TB' => TB_IN_BYTES,
-		'GB' => GB_IN_BYTES,
-		'MB' => MB_IN_BYTES,
-		'KB' => KB_IN_BYTES,
-		'B'  => 1,
+		/* translators: File size in terabytes. */
+		__( 'TB' ) => TB_IN_BYTES,
+		/* translators: File size in gigabytes. */
+		__( 'GB' ) => GB_IN_BYTES,
+		/* translators: File size in megabytes. */
+		__( 'MB' ) => MB_IN_BYTES,
+		/* translators: File size in kilobytes. */
+		__( 'KB' ) => KB_IN_BYTES,
+		/* translators: File size in bytes. */
+		__( 'B' )  => 1,
 	);
 
 	if ( 0 === $bytes ) {
-		return number_format_i18n( 0, $decimals ) . ' B';
+		/* translators: File size in bytes. */
+		return number_format_i18n( 0, $decimals ) . __( ' B' );
 	}
 
 	foreach ( $quant as $unit => $mag ) {

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -450,21 +450,21 @@ function number_format_i18n( $number, $decimals = 0 ) {
  */
 function size_format( $bytes, $decimals = 0 ) {
 	$quant = array(
-		/* translators: File size in terabytes. */
-		__( 'TB' ) => TB_IN_BYTES,
-		/* translators: File size in gigabytes. */
-		__( 'GB' ) => GB_IN_BYTES,
-		/* translators: File size in megabytes. */
-		__( 'MB' ) => MB_IN_BYTES,
-		/* translators: File size in kilobytes. */
-		__( 'KB' ) => KB_IN_BYTES,
-		/* translators: File size in bytes. */
-		__( 'B' )  => 1,
+		/* translators: Unit symbol for terabyte. */
+		_x( 'TB', 'unit symbol' ) => TB_IN_BYTES,
+		/* translators: Unit symbol for gigabyte. */
+		_x( 'GB', 'unit symbol' ) => GB_IN_BYTES,
+		/* translators: Unit symbol for megabyte. */
+		_x( 'MB', 'unit symbol' ) => MB_IN_BYTES,
+		/* translators: Unit symbol for kilobyte. */
+		_x( 'KB', 'unit symbol' ) => KB_IN_BYTES,
+		/* translators: Unit symbol for byte. */
+		_x( 'B', 'unit symbol' )  => 1,
 	);
 
 	if ( 0 === $bytes ) {
-		/* translators: File size in bytes when 0 bytes. */
-		return number_format_i18n( 0, $decimals ) . __( ' B' );
+		/* translators: Unit symbol for byte. */
+		return number_format_i18n( 0, $decimals ) . ' ' . _x( 'B', 'unit symbol' );
 	}
 
 	foreach ( $quant as $unit => $mag ) {

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -463,7 +463,7 @@ function size_format( $bytes, $decimals = 0 ) {
 	);
 
 	if ( 0 === $bytes ) {
-		/* translators: File size in bytes. */
+		/* translators: File size in bytes when 0 bytes. */
 		return number_format_i18n( 0, $decimals ) . __( ' B' );
 	}
 


### PR DESCRIPTION
Change the size_format and wp_convert_bytes_to_hr to add translatable strings for the units

Trac ticket: https://core.trac.wordpress.org/ticket/50194

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
