### PR TITLE
Plugin and Theme Auto-Updates

### DIFF
--- a/src/js/_enqueues/wp/updates.js
+++ b/src/js/_enqueues/wp/updates.js
@@ -2600,7 +2600,7 @@
 						href = href.replace( 'action=disable-auto-update', 'action=enable-auto-update' );
 						$anchor.attr( {
 							'data-wp-action': 'enable',
-							href: href,
+							href: href
 						} );
 
 						$label.text( wp.updates.l10n.autoUpdatesEnable );

--- a/src/js/_enqueues/wp/updates.js
+++ b/src/js/_enqueues/wp/updates.js
@@ -2537,7 +2537,7 @@
 				_ajax_nonce: settings.ajax_nonce,
 				state: action,
 				type: type,
-				asset: asset,
+				asset: asset
 			};
 
 			$.post( window.ajaxurl, data )
@@ -2565,8 +2565,8 @@
 					if ( 'themes' !== pagenow ) {
 						$enabled       = $( '.auto-update-enabled span' );
 						$disabled      = $( '.auto-update-disabled span' );
-						enabledNumber  = parseInt( $enabled.text().replace( /[^\d]+/g, '' ) ) || 0;
-						disabledNumber = parseInt( $disabled.text().replace( /[^\d]+/g, '' ) ) || 0;
+						enabledNumber  = parseInt( $enabled.text().replace( /[^\d]+/g, '', 10 ) ) || 0;
+						disabledNumber = parseInt( $disabled.text().replace( /[^\d]+/g, '', 10 ) ) || 0;
 
 						switch ( action ) {
 							case 'enable':
@@ -2590,7 +2590,7 @@
 						href = href.replace( 'action=enable-auto-update', 'action=disable-auto-update' );
 						$anchor.attr( {
 							'data-wp-action': 'disable',
-							href: href,
+							href: href
 						} );
 
 						$label.text( wp.updates.l10n.autoUpdatesDisable );
@@ -2600,7 +2600,7 @@
 						href = href.replace( 'action=disable-auto-update', 'action=enable-auto-update' );
 						$anchor.attr( {
 							'data-wp-action': 'enable',
-							href: href,
+							href: href
 						} );
 
 						$label.text( wp.updates.l10n.autoUpdatesEnable );

--- a/src/js/_enqueues/wp/updates.js
+++ b/src/js/_enqueues/wp/updates.js
@@ -409,6 +409,7 @@
 	 *
 	 * @since 4.2.0
 	 * @since 4.6.0 More accurately named `updatePluginSuccess`.
+	 * @since 5.5.0 Auto-update "time to next update" text cleared.
 	 *
 	 * @param {object} response            Response from the server.
 	 * @param {string} response.slug       Slug of the plugin to be updated.
@@ -431,6 +432,9 @@
 			// Update the version number in the row.
 			newText = $pluginRow.find( '.plugin-version-author-uri' ).html().replace( response.oldVersion, response.newVersion );
 			$pluginRow.find( '.plugin-version-author-uri' ).html( newText );
+
+			// Clear the "time to next auto-update" text.
+			$pluginRow.find( '.auto-update-time' ).empty();
 		} else if ( 'plugin-install' === pagenow || 'plugin-install-network' === pagenow ) {
 			$updateMessage = $( '.plugin-card-' + response.slug ).find( '.update-now' )
 				.removeClass( 'updating-message' )
@@ -969,6 +973,7 @@
 	 * Updates the UI appropriately after a successful theme update.
 	 *
 	 * @since 4.6.0
+	 * @since 5.5.0 Auto-update "time to next update" text cleared.
 	 *
 	 * @param {object} response
 	 * @param {string} response.slug       Slug of the theme to be updated.
@@ -1002,12 +1007,16 @@
 			// Update the version number in the row.
 			newText = $theme.find( '.theme-version-author-uri' ).html().replace( response.oldVersion, response.newVersion );
 			$theme.find( '.theme-version-author-uri' ).html( newText );
+
+			// Clear the "time to next auto-update" text.
+			$theme.find( '.auto-update-time' ).empty();
 		} else {
 			$notice = $( '.theme-info .notice' ).add( $theme.find( '.update-message' ) );
 
 			// Focus on Customize button after updating.
 			if ( isModalOpen ) {
 				$( '.load-customize:visible' ).focus();
+				$( '.theme-info .theme-autoupdate' ).find( '.auto-update-time' ).empty();
 			} else {
 				$theme.find( '.load-customize' ).focus();
 			}
@@ -2461,5 +2470,152 @@
 		 * @since 4.2.0
 		 */
 		$( window ).on( 'beforeunload', wp.updates.beforeunload );
+	} );
+
+	/**
+	 * Click handler for enabling and disabling plugin and theme auto-updates.
+	 *
+	 * @since 5.5.0
+	 *
+	 * TODO: this needs to be refactored to be like the remainder of the handlers
+	 *       in this file.
+	 */
+	$( document ).ready( function() {
+		$( $document ).on( 'click', '.column-auto-updates a.toggle-auto-update, .theme-overlay a.toggle-auto-update', function( event ) {
+			var data, asset, type, $parent;
+			var $anchor = $( this ),
+				action = $anchor.attr( 'data-wp-action' ),
+				$label = $anchor.find( '.label' );
+
+			if ( 'themes' !== pagenow ) {
+				$parent = $anchor.closest( '.column-auto-updates' );
+			} else {
+				$parent = $anchor.closest( '.theme-autoupdate' );
+			}
+
+			event.preventDefault();
+
+			// Prevent multiple simultaneous requests.
+			if ( $anchor.attr( 'data-doing-ajax' ) === 'yes' ) {
+				return;
+			}
+
+			$anchor.attr( 'data-doing-ajax', 'yes' );
+
+			switch ( pagenow ) {
+				case 'plugins':
+				case 'plugins-network':
+					type = 'plugin';
+					asset = $anchor.closest( 'tr' ).attr( 'data-plugin' );
+					break;
+				case 'themes-network':
+					type = 'theme';
+					asset = $anchor.closest( 'tr' ).attr( 'data-slug' );
+					break;
+				case 'themes':
+					type = 'theme';
+					asset = $anchor.attr( 'data-slug' );
+					break;
+			}
+
+			// Clear any previous errors.
+			$parent.find( '.notice.error' ).addClass( 'hidden' );
+
+			// Show loading status.
+			// TODO: make it readable when network is fast, or possibly remove the interim text change.
+			if ( 'enable' === action ) {
+				$label.text( wp.updates.l10n.autoUpdatesEnabling );
+			} else {
+				$label.text( wp.updates.l10n.autoUpdatesDisabling );
+			}
+
+			// TODO: Needs design review - the link text jumps under the mouse (part may get selected).
+			$anchor.find( '.dashicons-update' ).removeClass( 'hidden' );
+
+			data = {
+				action: 'toggle-auto-updates',
+				_ajax_nonce: settings.ajax_nonce,
+				state: action,
+				type: type,
+				asset: asset,
+			};
+
+			$.post( window.ajaxurl, data )
+				.done( function( response ) {
+					var $enabled, $disabled, enabledNumber, disabledNumber, errorMessage;
+					var href = $anchor.attr( 'href' );
+
+					if ( ! response.success ) {
+						// if WP returns 0 for response (which can happen in a few cases
+						// that aren't quite failures), output the general error message,
+						// since we won't have response.data.error.
+						if ( response.data && response.data.error ) {
+							errorMessage = response.data.error;
+						} else {
+							errorMessage = wp.updates.l10n.autoUpdatesError;
+						}
+
+						$parent.find( '.notice.error' ).removeClass( 'hidden' ).find( 'p' ).text( errorMessage );
+						wp.a11y.speak( errorMessage, 'polite' );
+						return;
+					}
+
+					// Update the counts in the enabled/disabled views if on a screen
+					// with a list table.
+					if ( 'themes' !== pagenow ) {
+						$enabled       = $( '.auto-update-enabled span' );
+						$disabled      = $( '.auto-update-disabled span' );
+						enabledNumber  = parseInt( $enabled.text().replace( /[^\d]+/g, '' ) ) || 0;
+						disabledNumber = parseInt( $disabled.text().replace( /[^\d]+/g, '' ) ) || 0;
+
+						switch ( action ) {
+							case 'enable':
+								++enabledNumber;
+								--disabledNumber;
+								break;
+							case 'disable':
+								--enabledNumber;
+								++disabledNumber;
+								break;
+						}
+
+						enabledNumber = Math.max( 0, enabledNumber );
+						disabledNumber = Math.max( 0, disabledNumber );
+
+						$enabled.text( '(' + enabledNumber + ')' );
+						$disabled.text( '(' + disabledNumber + ')' );
+					}
+
+					if ( 'enable' === action ) {
+						href = href.replace( 'action=enable-auto-update', 'action=disable-auto-update' );
+						$anchor.attr( {
+							'data-wp-action': 'disable',
+							href: href,
+						} );
+
+						$label.text( wp.updates.l10n.autoUpdatesDisable );
+						$parent.find( '.auto-update-time' ).removeClass( 'hidden' );
+						wp.a11y.speak( wp.updates.l10n.autoUpdatesEnabled, 'polite' );
+					} else {
+						href = href.replace( 'action=disable-auto-update', 'action=enable-auto-update' );
+						$anchor.attr( {
+							'data-wp-action': 'enable',
+							href: href,
+						} );
+
+						$label.text( wp.updates.l10n.autoUpdatesEnable );
+						$parent.find( '.auto-update-time' ).addClass( 'hidden' );
+						wp.a11y.speak( wp.updates.l10n.autoUpdatesDisabled, 'polite' );
+					}
+				} )
+				.fail( function() {
+					$parent.find( '.notice.error' ).removeClass( 'hidden' ).find( 'p' ).text( wp.updates.l10n.autoUpdatesError );
+					wp.a11y.speak( wp.updates.l10n.autoUpdatesError, 'polite' );
+				} )
+				.always( function() {
+					$anchor.removeAttr( 'data-doing-ajax' ).find( '.dashicons-update' ).addClass( 'hidden' );
+				} );
+			}
+		);
 	} );
 })( jQuery, window.wp, window._wpUpdatesSettings );

--- a/src/js/_enqueues/wp/updates.js
+++ b/src/js/_enqueues/wp/updates.js
@@ -2565,8 +2565,8 @@
 					if ( 'themes' !== pagenow ) {
 						$enabled       = $( '.auto-update-enabled span' );
 						$disabled      = $( '.auto-update-disabled span' );
-						enabledNumber  = parseInt( $enabled.text().replace( /[^\d]+/g, '', 10 ) ) || 0;
-						disabledNumber = parseInt( $disabled.text().replace( /[^\d]+/g, '', 10 ) ) || 0;
+						enabledNumber  = parseInt( $enabled.text().replace( /[^\d]+/g, '' ), 10 ) || 0;
+						disabledNumber = parseInt( $disabled.text().replace( /[^\d]+/g, '' ), 10 ) || 0;
 
 						switch ( action ) {
 							case 'enable':
@@ -2600,7 +2600,7 @@
 						href = href.replace( 'action=disable-auto-update', 'action=enable-auto-update' );
 						$anchor.attr( {
 							'data-wp-action': 'enable',
-							href: href
+							href: href,
 						} );
 
 						$label.text( wp.updates.l10n.autoUpdatesEnable );

--- a/src/wp-admin/admin-ajax.php
+++ b/src/wp-admin/admin-ajax.php
@@ -139,6 +139,7 @@ $core_actions_post = array(
 	'health-check-background-updates',
 	'health-check-loopback-requests',
 	'health-check-get-sizes',
+	'toggle-auto-updates',
 );
 
 // Deprecated.

--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -1524,7 +1524,9 @@ div.error {
 .updating-message p:before,
 .import-php .updating-message:before,
 .button.updating-message:before,
-.button.installing:before {
+.button.installing:before,
+.plugins .column-auto-updates .dashicons-update.spin,
+.theme-overlay .theme-autoupdate .dashicons-update.spin {
 	animation: rotation 2s infinite linear;
 }
 

--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -1236,6 +1236,10 @@ ul.cat-checklist {
 	width: 85px;
 }
 
+.plugins .column-auto-updates {
+	width: 14.2em;
+}
+
 .plugins .inactive .plugin-title strong {
 	font-weight: 400;
 }

--- a/src/wp-admin/css/themes.css
+++ b/src/wp-admin/css/themes.css
@@ -679,7 +679,8 @@ body.folded .theme-browser ~ .theme-overlay .theme-wrap {
 	line-height: inherit;
 }
 
-.theme-overlay .theme-author a {
+.theme-overlay .theme-author a,
+.theme-overlay .theme-autoupdate a {
 	text-decoration: none;
 }
 

--- a/src/wp-admin/includes/class-wp-automatic-updater.php
+++ b/src/wp-admin/includes/class-wp-automatic-updater.php
@@ -158,6 +158,12 @@ class WP_Automatic_Updater {
 		// Next up, is this an item we can update?
 		if ( 'core' === $type ) {
 			$update = Core_Upgrader::should_update_to_version( $item->current );
+		} elseif ( 'plugin' === $type || 'theme' === $type ) {
+			$update = false;
+			if ( wp_is_auto_update_enabled_for_type( $type ) ) {
+				$auto_updates = (array) get_site_option( "auto_update_{$type}s", array() );
+				$update      = in_array( $item->{$type}, $auto_updates, true ) || ! empty( $item->autoupdate );
+			}
 		} else {
 			$update = ! empty( $item->autoupdate );
 		}
@@ -501,6 +507,8 @@ class WP_Automatic_Updater {
 
 			if ( ! empty( $this->update_results['core'] ) ) {
 				$this->after_core_update( $this->update_results['core'][0] );
+			} elseif ( ! empty( $this->update_results['plugin'] ) || ! empty( $this->update_results['theme'] ) ) {
+				$this->after_plugin_theme_update( $this->update_results );
 			}
 
 			/**
@@ -851,6 +859,190 @@ class WP_Automatic_Updater {
 		 */
 		$email = apply_filters( 'auto_core_update_email', $email, $type, $core_update, $result );
 
+		wp_mail( $email['to'], wp_specialchars_decode( $email['subject'] ), $email['body'], $email['headers'] );
+	}
+
+
+	/**
+	 * If we tried to perform plugin or theme updates, check if we should send an email.
+	 *
+	 * @since 5.5.0
+	 *
+	 * @param object $results The result of updates tasks.
+	 */
+	protected function after_plugin_theme_update( $update_results ) {
+		$successful_updates = array();
+		$failed_updates     = array();
+
+		/**
+		 * Filters whether to send an email following an automatic background plugin update.
+		 *
+		 * @since 5.5.0
+		 *
+		 * @param bool $enabled True if plugins notifications are enabled, false otherwise.
+		 */
+		$notifications_enabled = apply_filters( 'auto_plugin_update_send_email', true );
+
+		if ( ! empty( $update_results['plugin'] ) && $notifications_enabled ) {
+			foreach ( $update_results['plugin'] as $update_result ) {
+				if ( true === $update_result->result ) {
+					$successful_updates['plugin'][] = $update_result;
+				} else {
+					$failed_updates['plugin'][] = $update_result;
+				}
+			}
+		}
+
+		/**
+		 * Filters whether to send an email following an automatic background theme update.
+		 *
+		 * @since 5.5.0
+		 *
+		 * @param bool $enabled True if notifications are enabled, false otherwise.
+		 */
+		$notifications_enabled = apply_filters( 'send_theme_auto_update_email', true );
+
+		if ( ! empty( $update_results['theme'] ) && $notifications_enabled ) {
+			foreach ( $update_results['theme'] as $update_result ) {
+				if ( true === $update_result->result ) {
+					$successful_updates['theme'][] = $update_result;
+				} else {
+					$failed_updates['theme'][] = $update_result;
+				}
+			}
+		}
+
+		if ( empty( $successful_updates ) && empty( $failed_updates ) ) {
+			return;
+		}
+
+		if ( empty( $failed_updates ) ) {
+			$this->send_plugin_theme_email( 'success', $successful_updates, $failed_updates );
+		} elseif ( empty( $successful_updates ) ) {
+			$this->send_plugin_theme_email( 'fail', $successful_updates, $failed_updates );
+		} else {
+			$this->send_plugin_theme_email( 'mixed', $successful_updates, $failed_updates );
+		}
+	}
+
+	/**
+	 * Sends an email upon the completion or failure of a plugin or theme background update.
+	 *
+	 * @since 5.5.0
+	 *
+	 * @param string $type               The type of email to send. Can be one of 'success', 'failure', 'mixed'.
+	 * @param array  $successful_updates A list of updates that succeeded.
+	 * @param array  $failed_updates     A list of updates that failed.
+	 */
+	protected function send_plugin_theme_email( $type, $successful_updates, $failed_updates ) {
+		// No updates were attempted.
+		if ( empty( $successful_updates ) && empty( $failed_updates ) ) {
+			return;
+		}
+		$body = array();
+
+		switch ( $type ) {
+			case 'success':
+				/* translators: %s: Site title. */
+				$subject = __( '[%s] Some plugins or themes were automatically updated' );
+				break;
+			case 'fail':
+				/* translators: %s: Site title. */
+				$subject = __( '[%s] Some plugins or themes have failed to update' );
+				$body[]  = sprintf(
+					/* translators: %s: Home URL. */
+					__( 'Howdy! Failures occurred when attempting to update plugins/themes on your site at %s.' ),
+					home_url()
+				);
+				$body[] = "\n";
+				$body[] = __( 'Please check out your site now. It’s possible that everything is working. If it says you need to update, you should do so.' );
+				break;
+			case 'mixed':
+				/* translators: %s: Site title. */
+				$subject = __( '[%s] Some plugins or themes were automatically updated' );
+				$body[] = sprintf(
+					/* translators: %s: Home URL. */
+					__( 'Howdy! Failures occurred when attempting to update plugins/themes on your site at %s.' ),
+					home_url()
+				);
+				$body[] = "\n";
+				$body[] = __( 'Please check out your site now. It’s possible that everything is working. If it says you need to update, you should do so.' );
+				$body[] = "\n";
+				break;
+		}
+
+		// Get failed plugin updates.
+		if ( in_array( $type, array( 'fail', 'mixed' ), true ) && ! empty( $failed_updates['plugin'] ) ) {
+			$body[] = __( 'The following plugins failed to update:' );
+			// List failed updates.
+			foreach ( $failed_updates['plugin'] as $item ) {
+				/* translators: %s: Name of the related plugin. */
+				$body[] = ' ' . sprintf( __( '- %s' ), $item->name );
+			}
+			$body[] = "\n";
+		}
+		// Get failed theme updates.
+		if ( in_array( $type, array( 'fail', 'mixed' ), true ) && ! empty( $failed_updates['theme'] ) ) {
+			$body[] = __( 'The following themes failed to update:' );
+			// List failed updates.
+			foreach ( $failed_updates['theme'] as $item ) {
+				/* translators: %s: Name of the related plugin. */
+				$body[] = ' ' . sprintf( __( '- %s' ), $item->name );
+			}
+			$body[] = "\n";
+		}
+		// Get successful plugin updates.
+		if ( in_array( $type, array( 'success', 'mixed' ), true ) && ! empty( $successful_updates['plugin'] ) ) {
+			$body[] = __( 'The following plugins were successfully updated:' );
+			// List successful updates.
+			foreach ( $successful_updates['plugin'] as $item ) {
+				/* translators: %s: Name of the related plugin. */
+				$body[] = ' ' . sprintf( __( '- %s' ), $item->name );
+			}
+			$body[] = "\n";
+		}
+		// Get successful theme updates.
+		if ( in_array( $type, array( 'success', 'mixed' ), true ) && ! empty( $successful_updates['theme'] ) ) {
+			$body[] = __( 'The following themes were successfully updated:' );
+			// List successful updates.
+			foreach ( $successful_updates['theme'] as $item ) {
+				/* translators: %s: Name of the related plugin. */
+				$body[] = ' ' . sprintf( __( '- %s' ), $item->name );
+			}
+			$body[] = "\n";
+		}
+		$body[] = "\n";
+
+		// Add a note about the support forums.
+		$body[] = __( 'If you experience any issues or need support, the volunteers in the WordPress.org support forums may be able to help.' );
+		$body[] = __( 'https://wordpress.org/support/forums/' );
+		$body[] = "\n" . __( 'The WordPress Team' );
+
+		$body    = implode( "\n", $body );
+		$to      = get_site_option( 'admin_email' );
+		$subject = sprintf( $subject, wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) );
+		$headers = '';
+
+		$email = compact( 'to', 'subject', 'body', 'headers' );
+
+		/**
+		 * Filters the email sent following an automatic background plugin update.
+		 *
+		 * @param array $email {
+		 *     Array of email arguments that will be passed to wp_mail().
+		 *
+		 *     @type string $to      The email recipient. An array of emails
+		 *                           can be returned, as handled by wp_mail().
+		 *     @type string $subject The email's subject.
+		 *     @type string $body    The email message body.
+		 *     @type string $headers Any email headers, defaults to no headers.
+		 * }
+		 * @param string $type               The type of email being sent. Can be one of
+		 *                                   'success', 'fail', 'mixed'.
+		 * @param object $successful_updates The updates that succeeded.
+		 * @param object $failed_updates     The updates that failed.
+		 */
+		$email = apply_filters( 'auto_plugin_theme_update_email', $email, $type, $successful_updates, $failed_updates );
 		wp_mail( $email['to'], wp_specialchars_decode( $email['subject'] ), $email['body'], $email['headers'] );
 	}
 

--- a/src/wp-admin/includes/class-wp-automatic-updater.php
+++ b/src/wp-admin/includes/class-wp-automatic-updater.php
@@ -162,7 +162,7 @@ class WP_Automatic_Updater {
 			$update = false;
 			if ( wp_is_auto_update_enabled_for_type( $type ) ) {
 				$auto_updates = (array) get_site_option( "auto_update_{$type}s", array() );
-				$update      = in_array( $item->{$type}, $auto_updates, true ) || ! empty( $item->autoupdate );
+				$update       = in_array( $item->{$type}, $auto_updates, true ) || ! empty( $item->autoupdate );
 			}
 		} else {
 			$update = ! empty( $item->autoupdate );
@@ -960,7 +960,7 @@ class WP_Automatic_Updater {
 			case 'mixed':
 				/* translators: %s: Site title. */
 				$subject = __( '[%s] Some plugins or themes were automatically updated' );
-				$body[] = sprintf(
+				$body[]  = sprintf(
 					/* translators: %s: Home URL. */
 					__( 'Howdy! Failures occurred when attempting to update plugins/themes on your site at %s.' ),
 					home_url()

--- a/src/wp-admin/includes/class-wp-debug-data.php
+++ b/src/wp-admin/includes/class-wp-debug-data.php
@@ -856,8 +856,13 @@ class WP_Debug_Data {
 		}
 
 		// List all available plugins.
-		$plugins        = get_plugins();
-		$plugin_updates = get_plugin_updates();
+		$plugins              = get_plugins();
+		$plugin_updates       = get_plugin_updates();
+		$auto_updates         = array();
+		$auto_updates_enabled = wp_is_auto_update_enabled_for_type( 'plugin' );
+		if ( $auto_updates_enabled ) {
+			$auto_updates = (array) get_site_option( 'auto_update_plugins', array() );
+		}
 
 		foreach ( $plugins as $plugin_path => $plugin ) {
 			$plugin_part = ( is_plugin_active( $plugin_path ) ) ? 'wp-plugins-active' : 'wp-plugins-inactive';
@@ -892,6 +897,16 @@ class WP_Debug_Data {
 				$plugin_version_string_debug .= sprintf( ' (latest version: %s)', $plugin_updates[ $plugin_path ]->update->new_version );
 			}
 
+			if ( $auto_updates_enabled ) {
+				if ( in_array( $plugin_path, $auto_updates, true ) ) {
+					$plugin_version_string       .= ' | ' . __( 'Auto-updates enabled' );
+					$plugin_version_string_debug .= ', ' . __( 'Auto-updates enabled' );
+				} else {
+					$plugin_version_string       .= ' | ' . __( 'Auto-updates disabled' );
+					$plugin_version_string_debug .= ', ' . __( 'Auto-updates disabled' );
+				}
+			}
+
 			$info[ $plugin_part ]['fields'][ sanitize_text_field( $plugin['Name'] ) ] = array(
 				'label' => $plugin['Name'],
 				'value' => $plugin_version_string,
@@ -914,6 +929,12 @@ class WP_Debug_Data {
 
 		$active_theme_version       = $active_theme->version;
 		$active_theme_version_debug = $active_theme_version;
+
+		$auto_updates         = array();
+		$auto_updates_enabled = wp_is_auto_update_enabled_for_type( 'theme' );
+		if ( $auto_updates_enabled ) {
+			$auto_updates = (array) get_site_option( 'auto_update_themes', array() );
+		}
 
 		if ( array_key_exists( $active_theme->stylesheet, $theme_updates ) ) {
 			$theme_update_new_version = $theme_updates[ $active_theme->stylesheet ]->update['new_version'];
@@ -980,7 +1001,19 @@ class WP_Debug_Data {
 				'value' => get_stylesheet_directory(),
 			),
 		);
+		if ( $auto_updates_enabled ) {
+			if ( in_array( $active_theme->stylesheet, $auto_updates ) ) {
+				$theme_auto_update_string = __( 'Enabled' );
+			} else {
+				$theme_auto_update_string = __( 'Disabled' );
+			}
 
+			$info['wp-active-theme']['fields']['auto_update'] = array(
+				'label' => __( 'Auto-update' ),
+				'value' => $theme_auto_update_string,
+				'debug' => $theme_auto_update_string,
+			);
+		}
 		$parent_theme = $active_theme->parent();
 
 		if ( $parent_theme ) {
@@ -1026,6 +1059,19 @@ class WP_Debug_Data {
 					'value' => get_template_directory(),
 				),
 			);
+			if ( $auto_updates_enabled ) {
+				if ( in_array( $parent_theme->stylesheet, $auto_updates ) ) {
+					$parent_theme_auto_update_string = __( 'Enabled' );
+				} else {
+					$parent_theme_auto_update_string = __( 'Disabled' );
+				}
+
+				$info['wp-parent-theme']['fields']['auto_update'] = array(
+					'label' => __( 'Auto-update' ),
+					'value' => $parent_theme_auto_update_string,
+					'debug' => $parent_theme_auto_update_string,
+				);
+			}
 		}
 
 		// Populate a list of all themes available in the install.
@@ -1073,6 +1119,16 @@ class WP_Debug_Data {
 				/* translators: %s: Latest theme version number. */
 				$theme_version_string       .= ' ' . sprintf( __( '(Latest version: %s)' ), $theme_updates[ $theme_slug ]->update['new_version'] );
 				$theme_version_string_debug .= sprintf( ' (latest version: %s)', $theme_updates[ $theme_slug ]->update['new_version'] );
+			}
+
+			if ( $auto_updates_enabled ) {
+				if ( in_array( $theme_slug, $auto_updates ) ) {
+					$theme_version_string       .= ' | ' . __( 'Auto-updates enabled' );
+					$theme_version_string_debug .= ',' . __( 'Auto-updates enabled' );
+				} else {
+					$theme_version_string       .= ' | ' . __( 'Auto-updates disabled' );
+					$theme_version_string_debug .= ', ' . __( 'Auto-updates disabled' );
+				}
 			}
 
 			$info['wp-themes-inactive']['fields'][ sanitize_text_field( $theme->name ) ] = array(

--- a/src/wp-admin/includes/class-wp-ms-themes-list-table.php
+++ b/src/wp-admin/includes/class-wp-ms-themes-list-table.php
@@ -23,6 +23,15 @@ class WP_MS_Themes_List_Table extends WP_List_Table {
 	private $has_items;
 
 	/**
+	 * Whether to show the auto-updates UI.
+	 *
+	 * @since 5.5.0
+	 *
+	 * @var bool True if auto-updates UI is to be shown, false otherwise.
+	 */
+	protected $show_autoupdates = true;
+
+	/**
 	 * Constructor.
 	 *
 	 * @since 3.1.0
@@ -45,7 +54,7 @@ class WP_MS_Themes_List_Table extends WP_List_Table {
 		);
 
 		$status = isset( $_REQUEST['theme_status'] ) ? $_REQUEST['theme_status'] : 'all';
-		if ( ! in_array( $status, array( 'all', 'enabled', 'disabled', 'upgrade', 'search', 'broken' ), true ) ) {
+		if ( ! in_array( $status, array( 'all', 'enabled', 'disabled', 'upgrade', 'search', 'broken', 'auto-update-enabled', 'auto-update-disabled' ), true ) ) {
 			$status = 'all';
 		}
 
@@ -56,6 +65,9 @@ class WP_MS_Themes_List_Table extends WP_List_Table {
 		if ( $this->is_site_themes ) {
 			$this->site_id = isset( $_REQUEST['id'] ) ? intval( $_REQUEST['id'] ) : 0;
 		}
+
+		$this->show_autoupdates = wp_is_auto_update_enabled_for_type( 'theme' ) &&
+			! $this->is_site_themes && current_user_can( 'update_themes' );
 	}
 
 	/**
@@ -106,6 +118,12 @@ class WP_MS_Themes_List_Table extends WP_List_Table {
 			'upgrade'  => array(),
 			'broken'   => $this->is_site_themes ? array() : wp_get_themes( array( 'errors' => true ) ),
 		);
+		if ( $this->show_autoupdates ) {
+			$auto_updates                   = (array) get_site_option( 'auto_update_themes', array() );
+
+			$themes['auto-update-enabled']  = array();
+			$themes['auto-update-disabled'] = array();
+		}
 
 		if ( $this->is_site_themes ) {
 			$themes_per_page = $this->get_items_per_page( 'site_themes_network_per_page' );
@@ -131,6 +149,14 @@ class WP_MS_Themes_List_Table extends WP_List_Table {
 
 			$filter                    = $theme->is_allowed( $allowed_where, $this->site_id ) ? 'enabled' : 'disabled';
 			$themes[ $filter ][ $key ] = $themes['all'][ $key ];
+
+			if ( $this->show_autoupdates ) {
+				if ( in_array( $key, $auto_updates, true ) ) {
+					$themes['auto-update-enabled'][ $key ]  = $themes['all'][ $key ];
+				} else {
+					$themes['auto-update-disabled'][ $key ] = $themes['all'][ $key ];
+				}
+			}
 		}
 
 		if ( $s ) {
@@ -257,11 +283,15 @@ class WP_MS_Themes_List_Table extends WP_List_Table {
 	 * @return array
 	 */
 	public function get_columns() {
-		return array(
+		$columns = array(
 			'cb'          => '<input type="checkbox" />',
 			'name'        => __( 'Theme' ),
 			'description' => __( 'Description' ),
 		);
+		if ( $this->show_autoupdates ) {
+			$columns['auto-updates'] = __( 'Automatic Updates' );
+		}
+		return $columns;
 	}
 
 	/**
@@ -344,6 +374,22 @@ class WP_MS_Themes_List_Table extends WP_List_Table {
 						'themes'
 					);
 					break;
+				case 'auto-update-enabled':
+					/* translators: %s: Number of themes. */
+					$text = _n(
+						'Auto-updates Enabled <span class="count">(%s)</span>',
+						'Auto-updates Enabled <span class="count">(%s)</span>',
+						$count
+					);
+					break;
+				case 'auto-update-disabled':
+					/* translators: %s: Number of themes. */
+					$text = _n(
+						'Auto-updates Disabled <span class="count">(%s)</span>',
+						'Auto-updates Disabled <span class="count">(%s)</span>',
+						$count
+					);
+					break;
 			}
 
 			if ( $this->is_site_themes ) {
@@ -386,6 +432,14 @@ class WP_MS_Themes_List_Table extends WP_List_Table {
 			}
 			if ( current_user_can( 'delete_themes' ) ) {
 				$actions['delete-selected'] = __( 'Delete' );
+			}
+		}
+		if ( $this->show_autoupdates ) {
+			if ( 'auto-update-enabled' !== $status ) {
+				$actions['enable-auto-update-selected']  = __( 'Enable Auto-updates' );
+			}
+			if ( 'auto-update-disabled' !== $status ) {
+				$actions['disable-auto-update-selected'] = __( 'Disable Auto-updates' );
 			}
 		}
 		return $actions;
@@ -640,6 +694,58 @@ class WP_MS_Themes_List_Table extends WP_List_Table {
 	}
 
 	/**
+	 * Handles the auto-updates column output.
+	 *
+	 * @since 5.5.0
+	 *
+	 * @global string $status
+	 * @global int  $page
+	 *
+	 * @param WP_Theme $theme The current WP_Theme object.
+	 */
+	function column_autoupdates( $theme ) {
+		global $status, $page;
+
+		static $auto_updates, $available_updates;
+
+		if ( ! $auto_updates ) {
+			$auto_updates = (array) get_site_option( 'auto_update_themes', array() );
+		}
+		if ( ! $available_updates ) {
+			$available_updates = get_site_transient( 'update_themes' );
+		}
+
+		$stylesheet = $theme->get_stylesheet();
+
+		if ( in_array( $stylesheet, $auto_updates, true ) ) {
+			$text                   = __( 'Disable auto-updates', 'wp-autoupdates' );
+			$auto_update_time_class = '';
+			$action                 = 'disable';
+		} else {
+			$text                   = __( 'Enable auto-updates', 'wp-autoupdates' );
+			$action                 = 'enable';
+			$auto_update_time_class = ' hidden';
+		}
+
+		printf(
+			'<a href="%s" class="toggle-auto-update" data-wp-action="%s"><span class="dashicons dashicons-update spin hidden"></span><span class="label">%s</span></a>',
+			wp_nonce_url( 'themes.php?action=' . $action . '-auto-update&amp;theme=' . urlencode( $stylesheet ) . '&amp;paged=' . $page . '&amp;theme_status=' . $status, 'updates' ),
+			$action,
+			$text
+		);
+
+		$available_updates = get_site_transient( 'update_themes' );
+		if ( isset( $available_updates->response[ $stylesheet ] ) ) {
+			printf(
+				'<div class="auto-update-time%s">%s</div>',
+				$auto_update_time_class,
+				wp_get_auto_update_message()
+			);
+		}
+		echo '<div class="auto-updates-error inline notice error hidden"><p></p></div>';
+	}
+
+	/**
 	 * Handles default column output.
 	 *
 	 * @since 4.3.0
@@ -721,6 +827,13 @@ class WP_MS_Themes_List_Table extends WP_List_Table {
 					echo '</td>';
 					break;
 
+				case 'auto-updates':
+					echo "<td class='column-auto-updates{$extra_classes}'>";
+
+					$this->column_autoupdates( $item );
+
+					echo '</td>';
+					break;
 				default:
 					echo "<td class='$column_name column-$column_name{$extra_classes}'>";
 

--- a/src/wp-admin/includes/class-wp-ms-themes-list-table.php
+++ b/src/wp-admin/includes/class-wp-ms-themes-list-table.php
@@ -119,7 +119,7 @@ class WP_MS_Themes_List_Table extends WP_List_Table {
 			'broken'   => $this->is_site_themes ? array() : wp_get_themes( array( 'errors' => true ) ),
 		);
 		if ( $this->show_autoupdates ) {
-			$auto_updates                   = (array) get_site_option( 'auto_update_themes', array() );
+			$auto_updates = (array) get_site_option( 'auto_update_themes', array() );
 
 			$themes['auto-update-enabled']  = array();
 			$themes['auto-update-disabled'] = array();
@@ -152,7 +152,7 @@ class WP_MS_Themes_List_Table extends WP_List_Table {
 
 			if ( $this->show_autoupdates ) {
 				if ( in_array( $key, $auto_updates, true ) ) {
-					$themes['auto-update-enabled'][ $key ]  = $themes['all'][ $key ];
+					$themes['auto-update-enabled'][ $key ] = $themes['all'][ $key ];
 				} else {
 					$themes['auto-update-disabled'][ $key ] = $themes['all'][ $key ];
 				}
@@ -436,7 +436,7 @@ class WP_MS_Themes_List_Table extends WP_List_Table {
 		}
 		if ( $this->show_autoupdates ) {
 			if ( 'auto-update-enabled' !== $status ) {
-				$actions['enable-auto-update-selected']  = __( 'Enable Auto-updates' );
+				$actions['enable-auto-update-selected'] = __( 'Enable Auto-updates' );
 			}
 			if ( 'auto-update-disabled' !== $status ) {
 				$actions['disable-auto-update-selected'] = __( 'Disable Auto-updates' );

--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -16,6 +16,14 @@
  * @see WP_List_Table
  */
 class WP_Plugins_List_Table extends WP_List_Table {
+	/**
+	 * Whether to show the auto-updates UI.
+	 *
+	 * @since 5.5.0
+	 *
+	 * @var bool True if auto-updates UI is to be shown, false otherwise.
+	 */
+	protected $show_autoupdates = true;
 
 	/**
 	 * Constructor.
@@ -39,7 +47,7 @@ class WP_Plugins_List_Table extends WP_List_Table {
 			)
 		);
 
-		$status_whitelist = array( 'active', 'inactive', 'recently_activated', 'upgrade', 'mustuse', 'dropins', 'search', 'paused' );
+		$status_whitelist = array( 'active', 'inactive', 'recently_activated', 'upgrade', 'mustuse', 'dropins', 'search', 'paused', 'auto-update-enabled', 'auto-update-disabled' );
 
 		$status = 'all';
 		if ( isset( $_REQUEST['plugin_status'] ) && in_array( $_REQUEST['plugin_status'], $status_whitelist, true ) ) {
@@ -51,6 +59,10 @@ class WP_Plugins_List_Table extends WP_List_Table {
 		}
 
 		$page = $this->get_pagenum();
+
+		$this->show_autoupdates = wp_is_auto_update_enabled_for_type( 'plugin' ) &&
+			current_user_can( 'update_plugins' ) &&
+			( ! is_multisite() || $this->screen->in_admin( 'network' ) );
 	}
 
 	/**
@@ -103,6 +115,12 @@ class WP_Plugins_List_Table extends WP_List_Table {
 			'dropins'            => array(),
 			'paused'             => array(),
 		);
+		if ( $this->show_autoupdates ) {
+			$auto_updates                    = (array) get_site_option( 'auto_update_plugins', array() );
+
+			$plugins['auto-update-enabled']  = array();
+			$plugins['auto-update-disabled'] = array();
+		}
 
 		$screen = $this->screen;
 
@@ -232,6 +250,14 @@ class WP_Plugins_List_Table extends WP_List_Table {
 				}
 				// Populate the inactive list with plugins that aren't activated.
 				$plugins['inactive'][ $plugin_file ] = $plugin_data;
+			}
+
+			if ( $this->show_autoupdates ) {
+				if ( in_array( $plugin_file, $auto_updates, true ) ) {
+					$plugins['auto-update-enabled'][ $plugin_file]  = $plugins['all'][ $plugin_file ];
+				} else {
+					$plugins['auto-update-disabled'][ $plugin_file] = $plugins['all'][ $plugin_file ];
+				}
 			}
 		}
 
@@ -399,11 +425,16 @@ class WP_Plugins_List_Table extends WP_List_Table {
 	public function get_columns() {
 		global $status;
 
-		return array(
+		$columns = array(
 			'cb'          => ! in_array( $status, array( 'mustuse', 'dropins' ), true ) ? '<input type="checkbox" />' : '',
 			'name'        => __( 'Plugin' ),
 			'description' => __( 'Description' ),
 		);
+		if ( $this->show_autoupdates ) {
+			$columns['auto-updates'] = __( 'Automatic Updates' );
+		}
+
+		return $columns;
 	}
 
 	/**
@@ -493,6 +524,22 @@ class WP_Plugins_List_Table extends WP_List_Table {
 						$count
 					);
 					break;
+				case 'auto-update-enabled':
+					/* translators: %s: Number of plugins. */
+					$text = _n(
+						'Auto-updates Enabled <span class="count">(%s)</span>',
+						'Auto-updates Enabled <span class="count">(%s)</span>',
+						$count
+					);
+					break;
+				case 'auto-update-disabled':
+					/* translators: %s: Number of plugins. */
+					$text = _n(
+						'Auto-updates Disabled <span class="count">(%s)</span>',
+						'Auto-updates Disabled <span class="count">(%s)</span>',
+						$count
+					);
+					break;
 			}
 
 			if ( 'search' !== $type ) {
@@ -532,6 +579,15 @@ class WP_Plugins_List_Table extends WP_List_Table {
 
 			if ( current_user_can( 'delete_plugins' ) && ( 'active' !== $status ) ) {
 				$actions['delete-selected'] = __( 'Delete' );
+			}
+
+			if ( $this->show_autoupdates ) {
+				if ( 'auto-update-enabled' !== $status ) {
+					$actions['enable-auto-update-selected']  = __( 'Enable Auto-updates' );
+				}
+				if ( 'auto-update-disabled' !== $status ) {
+					$actions['disable-auto-update-selected'] = __( 'Disable Auto-updates' );
+				}
 			}
 		}
 
@@ -882,6 +938,9 @@ class WP_Plugins_List_Table extends WP_List_Table {
 
 		list( $columns, $hidden, $sortable, $primary ) = $this->get_column_info();
 
+		$auto_updates      = (array) get_site_option( 'auto_update_plugins', array() );
+		$available_updates = get_site_transient( 'update_plugins' );
+
 		foreach ( $columns as $column_name => $column_display_name ) {
 			$extra_classes = '';
 			if ( in_array( $column_name, $hidden, true ) ) {
@@ -974,6 +1033,41 @@ class WP_Plugins_List_Table extends WP_List_Table {
 
 					echo '</td>';
 					break;
+				case 'auto-updates':
+					if ( ! $this->show_autoupdates ) {
+						break;
+					}
+
+					echo "<td class='column-auto-updates{$extra_classes}'>";
+
+					if ( in_array( $plugin_file, $auto_updates, true ) ) {
+						$text                   = __( 'Disable auto-updates', 'wp-autoupdates' );
+						$action                 = 'disable';
+						$auto_update_time_class = '';
+					} else {
+						$text                   = __( 'Enable auto-updates', 'wp-autoupdates' );
+						$action                 = 'enable';
+						$auto_update_time_class = ' hidden';
+					}
+
+					printf(
+						'<a href="%s" class="toggle-auto-update" data-wp-action="%s"><span class="dashicons dashicons-update spin hidden"></span><span class="label">%s</span></a>',
+						wp_nonce_url( 'plugins.php?action=' . $action . '-auto-update&amp;plugin=' . urlencode( $plugin_file ) . '&amp;paged=' . $page . '&amp;plugin_status=' . $status, 'updates' ),
+						$action,
+						$text
+					);
+
+					$available_updates = get_site_transient( 'update_plugins' );
+					if ( isset( $available_updates->response[ $plugin_file ] ) ) {
+						printf(
+							'<div class="auto-update-time%s">%s</div>',
+							$auto_update_time_class,
+							wp_get_auto_update_message()
+						);
+					}
+					echo '<div class="inline notice error hidden"><p></p></div>';
+					echo '</td>';
+					break;
 				default:
 					$classes = "$column_name column-$column_name $class";
 
@@ -1000,12 +1094,14 @@ class WP_Plugins_List_Table extends WP_List_Table {
 		 * Fires after each row in the Plugins list table.
 		 *
 		 * @since 2.3.0
+		 * @since 5.5.0 Added 'Auto-updates Enabled' and 'Auto-updates Disabled' `$status`.
 		 *
 		 * @param string $plugin_file Path to the plugin file relative to the plugins directory.
 		 * @param array  $plugin_data An array of plugin data.
 		 * @param string $status      Status of the plugin. Defaults are 'All', 'Active',
 		 *                            'Inactive', 'Recently Activated', 'Upgrade', 'Must-Use',
-		 *                            'Drop-ins', 'Search', 'Paused'.
+		 *                            'Drop-ins', 'Search', 'Paused', 'Auto-updates Enabled',
+		 *                            'Auto-updates Disabled'.
 		 */
 		do_action( 'after_plugin_row', $plugin_file, $plugin_data, $status );
 
@@ -1016,12 +1112,14 @@ class WP_Plugins_List_Table extends WP_List_Table {
 		 * to the plugin file, relative to the plugins directory.
 		 *
 		 * @since 2.7.0
+		 * @since 5.5.0 Added 'Auto-updates Enabled' and 'Auto-updates Disabled' `$status`.
 		 *
 		 * @param string $plugin_file Path to the plugin file relative to the plugins directory.
 		 * @param array  $plugin_data An array of plugin data.
 		 * @param string $status      Status of the plugin. Defaults are 'All', 'Active',
 		 *                            'Inactive', 'Recently Activated', 'Upgrade', 'Must-Use',
-		 *                            'Drop-ins', 'Search', 'Paused'.
+		 *                            'Drop-ins', 'Search', 'Paused', 'Auto-updates Enabled',
+		 *                            'Auto-updates Disabled'.
 		 */
 		do_action( "after_plugin_row_{$plugin_file}", $plugin_file, $plugin_data, $status );
 	}

--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -116,7 +116,7 @@ class WP_Plugins_List_Table extends WP_List_Table {
 			'paused'             => array(),
 		);
 		if ( $this->show_autoupdates ) {
-			$auto_updates                    = (array) get_site_option( 'auto_update_plugins', array() );
+			$auto_updates = (array) get_site_option( 'auto_update_plugins', array() );
 
 			$plugins['auto-update-enabled']  = array();
 			$plugins['auto-update-disabled'] = array();
@@ -254,9 +254,9 @@ class WP_Plugins_List_Table extends WP_List_Table {
 
 			if ( $this->show_autoupdates ) {
 				if ( in_array( $plugin_file, $auto_updates, true ) ) {
-					$plugins['auto-update-enabled'][ $plugin_file]  = $plugins['all'][ $plugin_file ];
+					$plugins['auto-update-enabled'][ $plugin_file ] = $plugins['all'][ $plugin_file ];
 				} else {
-					$plugins['auto-update-disabled'][ $plugin_file] = $plugins['all'][ $plugin_file ];
+					$plugins['auto-update-disabled'][ $plugin_file ] = $plugins['all'][ $plugin_file ];
 				}
 			}
 		}
@@ -583,7 +583,7 @@ class WP_Plugins_List_Table extends WP_List_Table {
 
 			if ( $this->show_autoupdates ) {
 				if ( 'auto-update-enabled' !== $status ) {
-					$actions['enable-auto-update-selected']  = __( 'Enable Auto-updates' );
+					$actions['enable-auto-update-selected'] = __( 'Enable Auto-updates' );
 				}
 				if ( 'auto-update-disabled' !== $status ) {
 					$actions['disable-auto-update-selected'] = __( 'Disable Auto-updates' );

--- a/src/wp-admin/includes/theme.php
+++ b/src/wp-admin/includes/theme.php
@@ -660,6 +660,8 @@ function wp_prepare_themes_for_js( $themes = null ) {
 
 	$parents = array();
 
+	$auto_updates = (array) get_site_option( 'auto_update_themes', array() );
+
 	foreach ( $themes as $theme ) {
 		$slug         = $theme->get_stylesheet();
 		$encoded_slug = urlencode( $slug );
@@ -683,6 +685,9 @@ function wp_prepare_themes_for_js( $themes = null ) {
 			);
 		}
 
+		$auto_update        = in_array( $slug, $auto_updates, true );
+		$auto_update_action = $auto_update ? 'disable-auto-update' : 'enable-auto-update';
+
 		$prepared_themes[ $slug ] = array(
 			'id'            => $slug,
 			'name'          => $theme->display( 'Name' ),
@@ -699,10 +704,14 @@ function wp_prepare_themes_for_js( $themes = null ) {
 			'hasUpdate'     => isset( $updates[ $slug ] ),
 			'hasPackage'    => isset( $updates[ $slug ] ) && ! empty( $updates[ $slug ]['package'] ),
 			'update'        => get_theme_update_available( $theme ),
+			'autoupdate'    => $auto_update,
 			'actions'       => array(
-				'activate'  => current_user_can( 'switch_themes' ) ? wp_nonce_url( admin_url( 'themes.php?action=activate&amp;stylesheet=' . $encoded_slug ), 'switch-theme_' . $slug ) : null,
-				'customize' => $customize_action,
-				'delete'    => current_user_can( 'delete_themes' ) ? wp_nonce_url( admin_url( 'themes.php?action=delete&amp;stylesheet=' . $encoded_slug ), 'delete-theme_' . $slug ) : null,
+				'activate'   => current_user_can( 'switch_themes' ) ? wp_nonce_url( admin_url( 'themes.php?action=activate&amp;stylesheet=' . $encoded_slug ), 'switch-theme_' . $slug ) : null,
+				'customize'  => $customize_action,
+				'delete'     => current_user_can( 'delete_themes' ) ? wp_nonce_url( admin_url( 'themes.php?action=delete&amp;stylesheet=' . $encoded_slug ), 'delete-theme_' . $slug ) : null,
+				'autoupdate' => wp_is_auto_update_enabled_for_type( 'theme' ) && ! is_multisite() && current_user_can( 'update_themes' )
+					? wp_nonce_url( admin_url( 'themes.php?action=' . $auto_update_action . '&amp;stylesheet=' . $encoded_slug ), 'updates' )
+					: null,
 			),
 		);
 	}

--- a/src/wp-admin/network/themes.php
+++ b/src/wp-admin/network/themes.php
@@ -215,13 +215,13 @@ if ( $action ) {
 
 			check_admin_referer( 'updates' );
 
-			$all_items      = wp_get_themes();
-			$auto_updates   = (array) get_site_option( 'auto_update_themes', array() );
+			$all_items    = wp_get_themes();
+			$auto_updates = (array) get_site_option( 'auto_update_themes', array() );
 
 			$auto_updates[] = $_GET['theme'];
 			$auto_updates   = array_unique( $auto_updates );
 			// Remove themes that have been deleted since the site option was last updated.
-			$auto_updates   = array_intersect( $auto_updates, array_keys( $all_items ) );
+			$auto_updates = array_intersect( $auto_updates, array_keys( $all_items ) );
 
 			update_site_option( 'auto_update_themes', $auto_updates );
 
@@ -254,8 +254,8 @@ if ( $action ) {
 
 			$themes = isset( $_POST['checked'] ) ? (array) wp_unslash( $_POST['checked'] ) : array();
 
-			$all_items        = wp_get_themes();
-			$auto_updates     = (array) get_site_option( 'auto_update_themes', array() );
+			$all_items    = wp_get_themes();
+			$auto_updates = (array) get_site_option( 'auto_update_themes', array() );
 
 			$new_auto_updates = array_merge( $auto_updates, $themes );
 			$new_auto_updates = array_unique( $new_auto_updates );
@@ -275,8 +275,8 @@ if ( $action ) {
 
 			$themes = isset( $_POST['checked'] ) ? (array) wp_unslash( $_POST['checked'] ) : array();
 
-			$all_items        = wp_get_themes();
-			$auto_updates     = (array) get_site_option( 'auto_update_themes', array() );
+			$all_items    = wp_get_themes();
+			$auto_updates = (array) get_site_option( 'auto_update_themes', array() );
 
 			$new_auto_updates = array_diff( $auto_updates, $themes );
 

--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -437,7 +437,7 @@ if ( $action ) {
 			$auto_updates[] = $plugin;
 			$auto_updates   = array_unique( $auto_updates );
 			// Remove plugins that have been deleted since the site option was last updated.
-			$auto_updates   = array_intersect( $auto_updates, array_keys( $all_items ) );
+			$auto_updates = array_intersect( $auto_updates, array_keys( $all_items ) );
 
 			update_site_option( 'auto_update_plugins', $auto_updates );
 
@@ -486,7 +486,7 @@ if ( $action ) {
 
 			$plugins = isset( $_POST['checked'] ) ? (array) wp_unslash( $_POST['checked'] ) : array();
 
-			$auto_updates     = (array) get_site_option( 'auto_update_plugins', array() );
+			$auto_updates = (array) get_site_option( 'auto_update_plugins', array() );
 
 			$new_auto_updates = array_merge( $auto_updates, $plugins );
 			$new_auto_updates = array_unique( $new_auto_updates );
@@ -499,7 +499,7 @@ if ( $action ) {
 			}
 
 			/** This filter is documented in wp-admin/includes/class-wp-plugins-list-table.php */
-			$all_items    = apply_filters( 'all_plugins', get_plugins() );
+			$all_items = apply_filters( 'all_plugins', get_plugins() );
 			// Remove plugins that have been deleted since the site option was last updated.
 			$auto_updates = array_intersect( $new_auto_updates, array_keys( $all_items ) );
 
@@ -532,7 +532,7 @@ if ( $action ) {
 			}
 
 			/** This filter is documented in wp-admin/includes/class-wp-plugins-list-table.php */
-			$all_items    = apply_filters( 'all_plugins', get_plugins() );
+			$all_items = apply_filters( 'all_plugins', get_plugins() );
 			// Remove plugins that have been deleted since the site option was last updated.
 			$auto_updates = array_intersect( $new_auto_updates, array_keys( $all_items ) );
 

--- a/src/wp-admin/themes.php
+++ b/src/wp-admin/themes.php
@@ -81,6 +81,45 @@ if ( current_user_can( 'switch_themes' ) && isset( $_GET['action'] ) ) {
 			wp_redirect( admin_url( 'themes.php?deleted=true' ) );
 		}
 		exit;
+	} elseif ( 'enable-auto-update' === $_GET['action'] ) {
+		if ( ! ( current_user_can( 'update_themes' ) && wp_is_auto_update_enabled_for_type( 'theme' ) ) ) {
+			wp_die( __( 'Sorry, you are not allowed to enable themes automatic updates.' ) );
+		}
+
+		check_admin_referer( 'updates' );
+
+		$all_items    = wp_get_themes();
+		$auto_updates = (array) get_site_option( 'auto_update_themes', array() );
+
+		$auto_updates[] = $_GET['stylesheet'];
+		$auto_updates   = array_unique( $auto_updates );
+		// Remove themes that have been deleted since the site option was last updated.
+		$auto_updates   = array_intersect( $auto_updates, array_keys( $all_items ) );
+
+		update_site_option( 'auto_update_themes', $auto_updates );
+
+		wp_redirect( admin_url( "themes.php?enabled-auto-update=true" ) );
+
+		exit;
+	} elseif ( 'disable-auto-update' === $_GET['action'] ) {
+		if ( ! ( current_user_can( 'update_themes' ) && wp_is_auto_update_enabled_for_type( 'theme' ) ) ) {
+			wp_die( __( 'Sorry, you are not allowed to disable themes automatic updates.' ) );
+		}
+
+		check_admin_referer( 'updates' );
+
+		$all_items    = wp_get_themes();
+		$auto_updates = (array) get_site_option( 'auto_update_themes', array() );
+
+		$auto_updates = array_diff( $auto_updates, array( $_GET['stylesheet'] ) );
+		// Remove themes that have been deleted since the site option was last updated.
+		$auto_updates = array_intersect( $auto_updates, array_keys( $all_items ) );
+
+		update_site_option( 'auto_update_themes', $auto_updates );
+
+		wp_redirect( admin_url( "themes.php?disabled-auto-update=true" ) );
+
+		exit;
 	}
 }
 
@@ -227,6 +266,14 @@ if ( ! validate_current_theme() || isset( $_GET['broken'] ) ) {
 } elseif ( isset( $_GET['error'] ) && 'resuming' === $_GET['error'] ) {
 	?>
 	<div id="message6" class="error"><p><?php _e( 'Theme could not be resumed because it triggered a <strong>fatal error</strong>.' ); ?></p></div>
+	<?php
+} elseif ( isset( $_GET['enabled-auto-update'] ) ) {
+	?>
+	<div id="message7" class="updated notice is-dismissible"><p><?php _e( 'Theme will be auto-updated.' ); ?></p></div>
+	<?php
+} elseif ( isset( $_GET['disabled-auto-update'] ) ) {
+	?>
+	<div id="message8" class="updated notice is-dismissible"><p><?php _e( 'Theme will no longer be auto-updated.' ); ?></p></div>
 	<?php
 }
 
@@ -580,6 +627,30 @@ if ( ! is_multisite() && $broken_themes ) {
 					printf( __( 'By %s' ), '{{{ data.authorAndUri }}}' );
 					?>
 				</p>
+
+				<# if ( data.actions.autoupdate ) { #>
+				<p class="theme-autoupdate">
+				<# if ( data.autoupdate ) { #>
+					<a href="{{{ data.actions.autoupdate }}}" class="toggle-auto-update" data-slug="{{ data.id }}" data-wp-action="disable">
+						<span class="dashicons dashicons-update spin hidden"></span>
+						<span class="label"><?php _e( 'Disable auto-updates' ) ?></span>
+					</a>
+				<# } else { #>
+					<a href="{{{ data.actions.autoupdate }}}" class="toggle-auto-update" data-slug="{{ data.id }}" data-wp-action="enable">
+						<span class="dashicons dashicons-update spin hidden"></span>
+						<span class="label"><?php _e( 'Enable auto-updates' ) ?></span>
+					</a>
+				<# } #>
+				<# if ( data.hasUpdate ) { #>
+					<# if ( data.autoupdate) { #>
+					<span class="auto-update-time"><br /><?php echo wp_get_auto_update_message() ?></span>
+					<# } else { #>
+					<span class="auto-update-time hidden"><br /><?php echo wp_get_auto_update_message() ?></span>
+					<# } #>
+				<# } #>
+					<span class="auto-updates-error hidden"><p></p></span>
+				</p>
+				<# } #>
 
 				<# if ( data.hasUpdate ) { #>
 				<div class="notice notice-warning notice-alt notice-large">

--- a/src/wp-admin/themes.php
+++ b/src/wp-admin/themes.php
@@ -94,11 +94,11 @@ if ( current_user_can( 'switch_themes' ) && isset( $_GET['action'] ) ) {
 		$auto_updates[] = $_GET['stylesheet'];
 		$auto_updates   = array_unique( $auto_updates );
 		// Remove themes that have been deleted since the site option was last updated.
-		$auto_updates   = array_intersect( $auto_updates, array_keys( $all_items ) );
+		$auto_updates = array_intersect( $auto_updates, array_keys( $all_items ) );
 
 		update_site_option( 'auto_update_themes', $auto_updates );
 
-		wp_redirect( admin_url( "themes.php?enabled-auto-update=true" ) );
+		wp_redirect( admin_url( 'themes.php?enabled-auto-update=true' ) );
 
 		exit;
 	} elseif ( 'disable-auto-update' === $_GET['action'] ) {
@@ -117,7 +117,7 @@ if ( current_user_can( 'switch_themes' ) && isset( $_GET['action'] ) ) {
 
 		update_site_option( 'auto_update_themes', $auto_updates );
 
-		wp_redirect( admin_url( "themes.php?disabled-auto-update=true" ) );
+		wp_redirect( admin_url( 'themes.php?disabled-auto-update=true' ) );
 
 		exit;
 	}
@@ -633,19 +633,19 @@ if ( ! is_multisite() && $broken_themes ) {
 				<# if ( data.autoupdate ) { #>
 					<a href="{{{ data.actions.autoupdate }}}" class="toggle-auto-update" data-slug="{{ data.id }}" data-wp-action="disable">
 						<span class="dashicons dashicons-update spin hidden"></span>
-						<span class="label"><?php _e( 'Disable auto-updates' ) ?></span>
+						<span class="label"><?php _e( 'Disable auto-updates' ); ?></span>
 					</a>
 				<# } else { #>
 					<a href="{{{ data.actions.autoupdate }}}" class="toggle-auto-update" data-slug="{{ data.id }}" data-wp-action="enable">
 						<span class="dashicons dashicons-update spin hidden"></span>
-						<span class="label"><?php _e( 'Enable auto-updates' ) ?></span>
+						<span class="label"><?php _e( 'Enable auto-updates' ); ?></span>
 					</a>
 				<# } #>
 				<# if ( data.hasUpdate ) { #>
 					<# if ( data.autoupdate) { #>
-					<span class="auto-update-time"><br /><?php echo wp_get_auto_update_message() ?></span>
+					<span class="auto-update-time"><br /><?php echo wp_get_auto_update_message(); ?></span>
 					<# } else { #>
-					<span class="auto-update-time hidden"><br /><?php echo wp_get_auto_update_message() ?></span>
+					<span class="auto-update-time hidden"><br /><?php echo wp_get_auto_update_message(); ?></span>
 					<# } #>
 				<# } #>
 					<span class="auto-updates-error hidden"><p></p></span>

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -328,6 +328,13 @@ function list_plugin_updates() {
 
 	<tbody class="plugins">
 	<?php
+
+	$auto_updates = array();
+	if ( wp_is_auto_update_enabled_for_type( 'plugin' ) ) {
+		$auto_updates       = (array) get_site_option( 'auto_update_plugins', array() );
+		$auto_update_notice = ' | ' . wp_get_auto_update_message();
+	}
+
 	foreach ( (array) $plugins as $plugin_file => $plugin_data ) {
 		$plugin_data = (object) _get_plugin_data_markup_translate( $plugin_file, (array) $plugin_data, false, true );
 
@@ -419,6 +426,9 @@ function list_plugin_updates() {
 				$plugin_data->update->new_version
 			);
 			echo ' ' . $details . $compat . $upgrade_notice;
+			if ( in_array( $plugin_file, $auto_updates, true ) ) {
+				echo $auto_update_notice;
+			}
 			?>
 		</p></td>
 	</tr>
@@ -478,8 +488,15 @@ function list_theme_updates() {
 
 	<tbody class="plugins">
 	<?php
+	$auto_updates = array();
+	if ( wp_is_auto_update_enabled_for_type( 'theme' ) ) {
+		$auto_updates = (array) get_site_option( 'auto_update_themes', array() );
+		$auto_update_notice = ' | ' . wp_get_auto_update_message();
+	}
+
 	foreach ( $themes as $stylesheet => $theme ) {
 		$checkbox_id = 'checkbox_' . md5( $theme->get( 'Name' ) );
+
 		?>
 	<tr>
 		<td class="check-column">
@@ -501,6 +518,9 @@ function list_theme_updates() {
 				$theme->display( 'Version' ),
 				$theme->update['new_version']
 			);
+			if ( in_array( $stylesheet, $auto_updates, true ) ) {
+				echo $auto_update_notice;
+			}
 			?>
 		</p></td>
 	</tr>

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -490,7 +490,7 @@ function list_theme_updates() {
 	<?php
 	$auto_updates = array();
 	if ( wp_is_auto_update_enabled_for_type( 'theme' ) ) {
-		$auto_updates = (array) get_site_option( 'auto_update_themes', array() );
+		$auto_updates       = (array) get_site_option( 'auto_update_themes', array() );
 		$auto_update_notice = ' | ' . wp_get_auto_update_message();
 	}
 

--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -5856,8 +5856,8 @@ final class WP_Customize_Manager {
 				$theme->id            = $theme->slug;
 				$theme->screenshot    = array( $theme->screenshot_url );
 				$theme->authorAndUri  = wp_kses( $theme->author['display_name'], $themes_allowedtags );
-				$theme->compatibleWP  = is_wp_version_compatible( $theme->requires );
-				$theme->compatiblePHP = is_php_version_compatible( $theme->requires_php );
+				$theme->compatibleWP  = is_wp_version_compatible( $theme->requires ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				$theme->compatiblePHP = is_php_version_compatible( $theme->requires_php ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
 				if ( isset( $theme->parent ) ) {
 					$theme->parent = $theme->parent['slug'];

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1520,6 +1520,13 @@ function wp_default_scripts( $scripts ) {
 					/* translators: %s: Number of plugins. */
 					'pluginsFound'             => __( 'Number of plugins found: %d' ),
 					'noPluginsFound'           => __( 'No plugins found. Try a different search.' ),
+					'autoUpdatesEnable'        => __( 'Enable auto-updates' ),
+					'autoUpdatesEnabling'      => __( 'Enabling...' ),
+					'autoUpdatesEnabled'       => __( 'Auto-updates enabled' ),
+					'autoUpdatesDisable'       => __( 'Disable auto-updates' ),
+					'autoUpdatesDisabling'     => __( 'Disabling...' ),
+					'autoUpdatesDisabled'      => __( 'Auto-updates disabled' ),
+					'autoUpdatesError'         => __( 'The request could not be completed.' ),
 				),
 			)
 		);


### PR DESCRIPTION
PR to bring auto-updates to WordPress themes and plugins.

Closing #279 in favor of this updated PR.

This is an extension of https://github.com/WordPress/wp-autoupdates

Trac ticket: https://core.trac.wordpress.org/ticket/50052