### PR TITLE
Leave non-string values untouched in wp_slash()

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -5465,6 +5465,7 @@ function sanitize_trackback_urls( $to_ping ) {
  * This should not be used to escape data going directly into an SQL query.
  *
  * @since 3.6.0
+ * @since 5.5.0 Leave non-string value untouched.
  *
  * @param string|array $value String or array of strings to slash.
  * @return string|array Slashed $value
@@ -5472,14 +5473,12 @@ function sanitize_trackback_urls( $to_ping ) {
 function wp_slash( $value ) {
 	if ( is_array( $value ) ) {
 		foreach ( $value as $k => $v ) {
-			if ( is_array( $v ) ) {
-				$value[ $k ] = wp_slash( $v );
-			} else {
-				$value[ $k ] = addslashes( $v );
-			}
+			$value[ $k ] = wp_slash( $v );
 		}
-	} else {
-		$value = addslashes( $value );
+	}
+
+	if ( is_string( $value ) ) {
+		return addslashes( $value );
 	}
 
 	return $value;

--- a/tests/phpunit/tests/formatting/WPSlash.php
+++ b/tests/phpunit/tests/formatting/WPSlash.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @group formatting
+ */
+class Tests_Formatting_WPSlash extends WP_UnitTestCase {
+
+	/**
+	 * @dataProvider data_wp_slash
+	 *
+	 * @ticket 42195
+	 *
+	 * @param string $value
+	 * @param string $expected
+	 */
+	public function test_wp_slash_with( $value, $expected ) {
+		$this->assertSame( $expected, wp_slash( $value ) );
+	}
+
+	/**
+	 * Data provider for test_wp_slash().
+	 *
+	 * @return array {
+	 *     @type array {
+	 *         @type mixed  $value    The value passed to wp_slash().
+	 *         @type string $expected The expected output of wp_slash().
+	 *     }
+	 * }
+	 */
+	public function data_wp_slash() {
+		return [
+			[ 123, 123 ],
+			[ 123.4, 123.4 ],
+			[ true, true ],
+			[ false, false ],
+			[
+				[
+					'hello',
+					null,
+					'"string"',
+					125.41
+				],
+				[
+					'hello',
+					null,
+					'\"string\"',
+					125.41
+				],
+			],
+			[ "first level 'string'", "first level \'string\'" ]
+		];
+	}
+}


### PR DESCRIPTION
Leave non-string values untouched in wp_slash()

Trac ticket: https://core.trac.wordpress.org/ticket/42195

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
