### PR TITLE
Add gradient preset for Blocks on Twenty-Nineteen theme

### DIFF
--- a/src/wp-content/themes/twentynineteen/functions.php
+++ b/src/wp-content/themes/twentynineteen/functions.php
@@ -175,7 +175,7 @@ if ( ! function_exists( 'twentynineteen_setup' ) ) :
 		// Add support for responsive embedded content.
 		add_theme_support( 'responsive-embeds' );
 
-		// Get primary color, saturation and lightness
+		// convert hex to rgb.
 		function hex2rgb( $color ) {
 			$color = trim( $color, '#' );
 		  
@@ -198,9 +198,8 @@ if ( ! function_exists( 'twentynineteen_setup' ) ) :
 			);
 		  };
 
-		  $primary_gradient = hex2rgb(twentynineteen_hsl_hex( 'default' === get_theme_mod( 'primary_color' ) ? 199 : get_theme_mod( 'primary_color_hue', 199 ), 100, 33 ));
-
-		// Add gradient presets for Blocks
+		// Add gradient presets for Blocks.
+		$primary_gradient = hex2rgb(twentynineteen_hsl_hex( 'default' === get_theme_mod( 'primary_color' ) ? 199 : get_theme_mod( 'primary_color_hue', 199 ), 100, 33 ));
 		add_theme_support(
 			'editor-gradient-presets',
 			array(

--- a/src/wp-content/themes/twentynineteen/functions.php
+++ b/src/wp-content/themes/twentynineteen/functions.php
@@ -175,25 +175,40 @@ if ( ! function_exists( 'twentynineteen_setup' ) ) :
 		// Add support for responsive embedded content.
 		add_theme_support( 'responsive-embeds' );
 
-		// Add gradient presets
+		// Get primary color, saturation and lightness
+		function hex2rgb( $color ) {
+			$color = trim( $color, '#' );
+		  
+			if ( strlen( $color ) == 3 ) {
+			  $r = hexdec( substr( $color, 0, 1 ) . substr( $color, 0, 1 ) );
+			  $g = hexdec( substr( $color, 1, 1 ) . substr( $color, 1, 1 ) );
+			  $b = hexdec( substr( $color, 2, 1 ) . substr( $color, 2, 1 ) );
+			} elseif ( strlen( $color ) == 6 ) {
+			  $r = hexdec( substr( $color, 0, 2 ) );
+			  $g = hexdec( substr( $color, 2, 2 ) );
+			  $b = hexdec( substr( $color, 4, 2 ) );
+			} else {
+			  return array();
+			}
+		  
+			return array(
+			  'red'   => $r,
+			  'green' => $g,
+			  'blue'  => $b,
+			);
+		  };
+
+		  $primary_gradient = hex2rgb(twentynineteen_hsl_hex( 'default' === get_theme_mod( 'primary_color' ) ? 199 : get_theme_mod( 'primary_color_hue', 199 ), 100, 33 ));
+
+		// Add gradient presets for Blocks
 		add_theme_support(
 			'editor-gradient-presets',
 			array(
 				array(
 					'name'  => __( 'Primary color to lighter primary color', 'themeLangDomain' ),
+					'gradient' => 'linear-gradient(135deg,rgb('.$primary_gradient['red'].','.$primary_gradient['green'].','.$primary_gradient['blue'].') 0%,rgba('.$primary_gradient['red'].','.$primary_gradient['green'].','.$primary_gradient['blue'].', 0.8) 100%)',
 					'slug'  => 'primary-color-to-lighter-primary',
-					'gradient' => 'linear-gradient(135deg,rgb(14,0,168) 0%,rgba(14,0,168,0.8) 100%)',
-				),
-				array(
-					'name'     => __( 'Vivid cyan blue to vivid purple', 'themeLangDomain' ),
-					'gradient' => 'linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)',
-					'slug'     => 'vivid-cyan-blue-to-vivid-purple'
-				),
-				array(
-					'name'     => __( 'Vivid green cyan to vivid cyan blue', 'themeLangDomain' ),
-					'gradient' => 'linear-gradient(135deg,rgba(0,208,132,1) 0%,rgba(6,147,227,1) 100%)',
-					'slug'     =>  'vivid-green-cyan-to-vivid-cyan-blue',
-				),
+				)
 			)
 		);
 	}

--- a/src/wp-content/themes/twentynineteen/functions.php
+++ b/src/wp-content/themes/twentynineteen/functions.php
@@ -174,6 +174,28 @@ if ( ! function_exists( 'twentynineteen_setup' ) ) :
 
 		// Add support for responsive embedded content.
 		add_theme_support( 'responsive-embeds' );
+
+		// Add gradient presets
+		add_theme_support(
+			'editor-gradient-presets',
+			array(
+				array(
+					'name'  => __( 'Primary color to lighter primary color', 'themeLangDomain' ),
+					'slug'  => 'primary-color-to-lighter-primary',
+					'gradient' => 'linear-gradient(135deg,rgb(14,0,168) 0%,rgba(14,0,168,0.8) 100%)',
+				),
+				array(
+					'name'     => __( 'Vivid cyan blue to vivid purple', 'themeLangDomain' ),
+					'gradient' => 'linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)',
+					'slug'     => 'vivid-cyan-blue-to-vivid-purple'
+				),
+				array(
+					'name'     => __( 'Vivid green cyan to vivid cyan blue', 'themeLangDomain' ),
+					'gradient' => 'linear-gradient(135deg,rgba(0,208,132,1) 0%,rgba(6,147,227,1) 100%)',
+					'slug'     =>  'vivid-green-cyan-to-vivid-cyan-blue',
+				),
+			)
+		);
 	}
 endif;
 add_action( 'after_setup_theme', 'twentynineteen_setup' );

--- a/src/wp-content/themes/twentynineteen/inc/color-patterns.php
+++ b/src/wp-content/themes/twentynineteen/inc/color-patterns.php
@@ -17,6 +17,8 @@ function twentynineteen_custom_colors_css() {
 		$primary_color = absint( get_theme_mod( 'primary_color_hue', 199 ) );
 	}
 
+	$primary_gradient = hex2rgb(twentynineteen_hsl_hex( 'default' === get_theme_mod( 'primary_color' ) ? 199 : get_theme_mod( 'primary_color_hue', 199 ), 100, 33 ));
+
 	/**
 	 * Filter Twenty Nineteen default saturation level.
 	 *
@@ -204,7 +206,13 @@ function twentynineteen_custom_colors_css() {
 		}
 		::-moz-selection {
 			background-color: hsl( ' . $primary_color . ', ' . $saturation_selection . ', ' . $lightness_selection . ' ); /* base: #005177; */
-		}';
+		}
+
+		/* Gradient background for blocks */
+		.has-primary-color-to-lighter-primary-gradient-background {
+			background: linear-gradient(135deg,rgb('.$primary_gradient['red'].','.$primary_gradient['green'].','.$primary_gradient['blue'].') 0%,rgba('.$primary_gradient['red'].','.$primary_gradient['green'].','.$primary_gradient['blue'].', 0.8) 100%) 
+		}
+		';
 
 	$editor_css = '
 		/*
@@ -251,6 +259,11 @@ function twentynineteen_custom_colors_css() {
 		.editor-block-list__layout .editor-block-list__block .wp-block-pullquote.is-style-solid-color a,
 		.editor-block-list__layout .editor-block-list__block .wp-block-cover a {
 			color: inherit;
+		}
+
+		/* Gradient background for blocks */
+		.has-primary-color-to-lighter-primary-gradient-background {
+			background: linear-gradient(135deg,rgb('.$primary_gradient['red'].','.$primary_gradient['green'].','.$primary_gradient['blue'].') 0%,rgba('.$primary_gradient['red'].','.$primary_gradient['green'].','.$primary_gradient['blue'].', 0.8) 100%) 
 		}
 		';
 

--- a/src/wp-content/themes/twentynineteen/style.css
+++ b/src/wp-content/themes/twentynineteen/style.css
@@ -6565,3 +6565,7 @@ svg {
 .gallery-item > div > a:focus {
   box-shadow: 0 0 0 2px #0073aa;
 }
+
+.has-primary-color-to-lighter-primary-background {
+  background: linear-gradient(135deg,rgb(14,0,168) 0%,rgba(14,0,168,0.5) 100%);
+}

--- a/src/wp-content/themes/twentynineteen/style.css
+++ b/src/wp-content/themes/twentynineteen/style.css
@@ -6565,7 +6565,3 @@ svg {
 .gallery-item > div > a:focus {
   box-shadow: 0 0 0 2px #0073aa;
 }
-
-.has-primary-color-to-lighter-primary-background {
-  background: linear-gradient(135deg,rgb(14,0,168) 0%,rgba(14,0,168,0.5) 100%);
-}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

I've added support for block gradient presets in the Twenty-Nineteen theme. It currently grabs the primary color and sets a linear gradient to 80% of the color. 

Trac ticket: https://core.trac.wordpress.org/ticket/49712

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
