### PR TITLE
Fix Missing args properties on `WP_REST_Controller::get_endpoint_args_for_item_schema…

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-controller.php
@@ -626,9 +626,24 @@ abstract class WP_REST_Controller {
 	 */
 	public function get_endpoint_args_for_item_schema( $method = WP_REST_Server::CREATABLE ) {
 
-		$schema            = $this->get_item_schema();
-		$schema_properties = ! empty( $schema['properties'] ) ? $schema['properties'] : array();
-		$endpoint_args     = array();
+		$schema                  = $this->get_item_schema();
+		$schema_properties       = ! empty( $schema['properties'] ) ? $schema['properties'] : array();
+		$endpoint_args           = array();
+		$valid_schema_properties = array(
+			'type',
+			'format',
+			'enum',
+			'items',
+			'properties',
+			'additionalProperties',
+			'minimum',
+			'maximum',
+			'exclusiveMinimum',
+			'exclusiveMaximum',
+			'minLength',
+			'maxLength',
+			'pattern',
+		);
 
 		foreach ( $schema_properties as $field_id => $params ) {
 
@@ -654,7 +669,7 @@ abstract class WP_REST_Controller {
 				$endpoint_args[ $field_id ]['required'] = true;
 			}
 
-			foreach ( array( 'type', 'format', 'enum', 'items', 'properties', 'additionalProperties' ) as $schema_prop ) {
+			foreach ( $valid_schema_properties as $schema_prop ) {
 				if ( isset( $params[ $schema_prop ] ) ) {
 					$endpoint_args[ $field_id ][ $schema_prop ] = $params[ $schema_prop ];
 				}

--- a/tests/phpunit/tests/rest-api/rest-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-controller.php
@@ -2,7 +2,7 @@
 /**
  * Unit tests covering WP_REST_Controller functionality
  *
- * @package WordPress
+ * @package    WordPress
  * @subpackage REST API
  */
 
@@ -248,6 +248,33 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 	}
 
 	/**
+	 * @ticket 50301
+	 */
+	public function test_get_endpoint_args_for_item_schema_arg_properties() {
+
+		$controller = new WP_REST_Test_Controller();
+		$args       = $controller->get_endpoint_args_for_item_schema();
+
+		foreach ( array( 'minLength', 'maxLength', 'pattern' ) as $property ) {
+			$this->assertArrayHasKey( $property, $args['somestring'] );
+		}
+
+		foreach ( array( 'minimum', 'maximum', 'exclusiveMinimum', 'exclusiveMaximum' ) as $property ) {
+			$this->assertArrayHasKey( $property, $args['someinteger'] );
+		}
+
+		$this->assertArrayHasKey( 'items', $args['somearray'] );
+
+		foreach ( array( 'properties', 'additionalProperties' ) as $property ) {
+			$this->assertArrayHasKey( $property, $args['someobject'] );
+		}
+
+		// ignored properties
+		$this->assertArrayNotHasKey( 'ignored_prop', $args['someobject'] );
+
+	}
+
+	/**
 	 * @dataProvider data_get_fields_for_response,
 	 */
 	public function test_get_fields_for_response( $param, $expected ) {
@@ -267,6 +294,8 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 				'someenum',
 				'someargoptions',
 				'somedefault',
+				'somearray',
+				'someobject',
 			),
 			$fields
 		);
@@ -298,6 +327,8 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 					'someenum',
 					'someargoptions',
 					'somedefault',
+					'somearray',
+					'someobject',
 				),
 			),
 		);
@@ -467,7 +498,7 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 
 	/**
 	 * @dataProvider data_filter_nested_registered_rest_fields
-	 * @ticket 49648
+	 * @ticket       49648
 	 */
 	public function test_filter_nested_registered_rest_fields( $filter, $expected ) {
 		$controller = new WP_REST_Test_Controller();

--- a/tests/phpunit/tests/rest-api/rest-test-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-test-controller.php
@@ -2,7 +2,7 @@
 /**
  * Unit tests covering WP_REST_Controller functionality
  *
- * @package WordPress
+ * @package    WordPress
  * @subpackage REST API
  */
 
@@ -15,6 +15,7 @@ class WP_REST_Test_Controller extends WP_REST_Controller {
 	 *
 	 * @param mixed           $item    WordPress representation of the item.
 	 * @param WP_REST_Request $request Request object.
+	 *
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function prepare_item_for_response( $item, $request ) {
@@ -22,6 +23,7 @@ class WP_REST_Test_Controller extends WP_REST_Controller {
 		$item     = $this->add_additional_fields_to_object( $item, $request );
 		$item     = $this->filter_response_by_context( $item, $context );
 		$response = rest_ensure_response( $item );
+
 		return $response;
 	}
 
@@ -39,11 +41,18 @@ class WP_REST_Test_Controller extends WP_REST_Controller {
 				'somestring'     => array(
 					'type'        => 'string',
 					'description' => 'A pretty string.',
+					'minLength'   => 3,
+					'maxLength'   => 3,
+					'pattern'     => '[a-zA-Z]+',
 					'context'     => array( 'view' ),
 				),
 				'someinteger'    => array(
-					'type'    => 'integer',
-					'context' => array( 'view' ),
+					'type'             => 'integer',
+					'minimum'          => 100,
+					'maximum'          => 200,
+					'exclusiveMinimum' => true,
+					'exclusiveMaximum' => true,
+					'context'          => array( 'view' ),
 				),
 				'someboolean'    => array(
 					'type'    => 'boolean',
@@ -92,6 +101,26 @@ class WP_REST_Test_Controller extends WP_REST_Controller {
 					'enum'    => array( 'a', 'b', 'c' ),
 					'context' => array( 'view' ),
 					'default' => 'a',
+				),
+				'somearray'      => array(
+					'type'    => 'array',
+					'items'   => array(
+						'type' => 'string',
+					),
+					'context' => array( 'view' ),
+				),
+				'someobject'     => array(
+					'type'                 => 'object',
+					'additionalProperties' => array(
+						'type' => 'string',
+					),
+					'properties'           => array(
+						'object_id' => array(
+							'type' => 'integer',
+						),
+					),
+					'ignored_prop'         => 'ignored_prop',
+					'context'              => array( 'view' ),
 				),
 			),
 		);


### PR DESCRIPTION
- Add new var `$valid_schema_properties` to match `rest_validate_value_from_schema()`
- Unit test to ensure all valid properties exists, and non-valid properties are ignored 

Trac ticket: https://core.trac.wordpress.org/ticket/50301

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
