### PR TITLE
Post Attributes default template's value is empty

### DIFF
--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -159,7 +159,7 @@ $available_templates = wp_get_theme()->get_page_templates( get_post( $post->ID )
 $available_templates = ! empty( $available_templates ) ? array_merge(
 	array(
 		/** This filter is documented in wp-admin/includes/meta-boxes.php */
-		'' => apply_filters( 'default_page_template_title', __( 'Default template' ), 'rest-api' ),
+		'default' => apply_filters( 'default_page_template_title', __( 'Default template' ), 'rest-api' ),
 	),
 	$available_templates
 ) : $available_templates;


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Default template value is empty in gutenberg.
File : wp-admin\edit-form-blocks.php
Line number : 162

Before the value was "default"
File : wp-admin\includes\meta-boxes.php
Line number : 988

Trac ticket: https://core.trac.wordpress.org/ticket/50030

---
**This Pull Request is for code review only. Please keep all other discussions in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
