### PR TITLE
Match the multi-type based only on the type information, not the additional validation keywords.

### DIFF
--- a/tests/phpunit/tests/rest-api/rest-schema-sanitization.php
+++ b/tests/phpunit/tests/rest-api/rest-schema-sanitization.php
@@ -430,10 +430,25 @@ class WP_Test_REST_Schema_Sanitization extends WP_UnitTestCase {
 	 * @ticket 50300
 	 */
 	public function test_multi_type_with_no_known_types() {
+		$this->setExpectedIncorrectUsage( 'rest_handle_multi_type_schema' );
 		$this->setExpectedIncorrectUsage( 'rest_sanitize_value_from_schema' );
 
 		$schema = array(
 			'type' => array( 'invalid', 'type' ),
+		);
+
+		$this->assertEquals( 'My Value', rest_sanitize_value_from_schema( 'My Value', $schema ) );
+	}
+
+	/**
+	 * @ticket 50300
+	 */
+	public function test_multi_type_with_some_unknown_types() {
+		$this->setExpectedIncorrectUsage( 'rest_handle_multi_type_schema' );
+		$this->setExpectedIncorrectUsage( 'rest_sanitize_value_from_schema' );
+
+		$schema = array(
+			'type' => array( 'object', 'type' ),
 		);
 
 		$this->assertEquals( 'My Value', rest_sanitize_value_from_schema( 'My Value', $schema ) );

--- a/tests/phpunit/tests/rest-api/rest-schema-sanitization.php
+++ b/tests/phpunit/tests/rest-api/rest-schema-sanitization.php
@@ -341,7 +341,7 @@ class WP_Test_REST_Schema_Sanitization extends WP_UnitTestCase {
 
 		$this->assertNull( rest_sanitize_value_from_schema( null, $schema ) );
 		$this->assertEquals( '2019-09-19T18:00:00', rest_sanitize_value_from_schema( '2019-09-19T18:00:00', $schema ) );
-		$this->assertNull( rest_sanitize_value_from_schema( 'lalala', $schema ) );
+		$this->assertEquals( 'lalala', rest_sanitize_value_from_schema( 'lalala', $schema ) );
 	}
 
 	/**
@@ -394,7 +394,7 @@ class WP_Test_REST_Schema_Sanitization extends WP_UnitTestCase {
 
 		$this->assertEquals( 'My Value', rest_sanitize_value_from_schema( 'My Value', $schema ) );
 		$this->assertEquals( array( 'raw' => 'My Value' ), rest_sanitize_value_from_schema( array( 'raw' => 'My Value' ), $schema ) );
-		$this->assertNull( rest_sanitize_value_from_schema( array( 'raw' => 1 ), $schema ) );
+		$this->assertEquals( array( 'raw' => '1' ), rest_sanitize_value_from_schema( array( 'raw' => 1 ), $schema ) );
 	}
 
 	public function test_object_or_bool() {
@@ -423,6 +423,6 @@ class WP_Test_REST_Schema_Sanitization extends WP_UnitTestCase {
 		$this->assertEquals( array( 'raw' => false ), rest_sanitize_value_from_schema( array( 'raw' => '0' ), $schema ) );
 		$this->assertEquals( array( 'raw' => false ), rest_sanitize_value_from_schema( array( 'raw' => 0 ), $schema ) );
 
-		$this->assertNull( rest_sanitize_value_from_schema( array( 'raw' => 'something non boolean' ), $schema ) );
+		$this->assertEquals( array( 'raw' => true ), rest_sanitize_value_from_schema( array( 'raw' => 'something non boolean' ), $schema ) );
 	}
 }

--- a/tests/phpunit/tests/rest-api/rest-schema-sanitization.php
+++ b/tests/phpunit/tests/rest-api/rest-schema-sanitization.php
@@ -425,4 +425,28 @@ class WP_Test_REST_Schema_Sanitization extends WP_UnitTestCase {
 
 		$this->assertEquals( array( 'raw' => true ), rest_sanitize_value_from_schema( array( 'raw' => 'something non boolean' ), $schema ) );
 	}
+
+	/**
+	 * @ticket 50300
+	 */
+	public function test_multi_type_with_no_known_types() {
+		$this->setExpectedIncorrectUsage( 'rest_sanitize_value_from_schema' );
+
+		$schema = array(
+			'type' => array( 'invalid', 'type' ),
+		);
+
+		$this->assertEquals( 'My Value', rest_sanitize_value_from_schema( 'My Value', $schema ) );
+	}
+
+	/**
+	 * @ticket 50300
+	 */
+	public function test_multi_type_returns_null_if_no_valid_type() {
+		$schema = array(
+			'type' => array( 'number', 'string' ),
+		);
+
+		$this->assertNull( rest_sanitize_value_from_schema( array( 'Hello!' ), $schema ) );
+	}
 }

--- a/tests/phpunit/tests/rest-api/rest-schema-validation.php
+++ b/tests/phpunit/tests/rest-api/rest-schema-validation.php
@@ -409,10 +409,25 @@ class WP_Test_REST_Schema_Validation extends WP_UnitTestCase {
 	 * @ticket 50300
 	 */
 	public function test_multi_type_with_no_known_types() {
+		$this->setExpectedIncorrectUsage( 'rest_handle_multi_type_schema' );
 		$this->setExpectedIncorrectUsage( 'rest_validate_value_from_schema' );
 
 		$schema = array(
 			'type' => array( 'invalid', 'type' ),
+		);
+
+		$this->assertTrue( rest_validate_value_from_schema( 'My Value', $schema ) );
+	}
+
+	/**
+	 * @ticket 50300
+	 */
+	public function test_multi_type_with_some_unknown_types() {
+		$this->setExpectedIncorrectUsage( 'rest_handle_multi_type_schema' );
+		$this->setExpectedIncorrectUsage( 'rest_validate_value_from_schema' );
+
+		$schema = array(
+			'type' => array( 'object', 'type' ),
 		);
 
 		$this->assertTrue( rest_validate_value_from_schema( 'My Value', $schema ) );

--- a/tests/phpunit/tests/rest-api/rest-schema-validation.php
+++ b/tests/phpunit/tests/rest-api/rest-schema-validation.php
@@ -406,6 +406,19 @@ class WP_Test_REST_Schema_Validation extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 50300
+	 */
+	public function test_multi_type_with_no_known_types() {
+		$this->setExpectedIncorrectUsage( 'rest_validate_value_from_schema' );
+
+		$schema = array(
+			'type' => array( 'invalid', 'type' ),
+		);
+
+		$this->assertTrue( rest_validate_value_from_schema( 'My Value', $schema ) );
+	}
+
+	/**
 	 * @ticket 48820
 	 */
 	public function test_string_min_length() {

--- a/tests/phpunit/tests/rest-api/rest-schema-validation.php
+++ b/tests/phpunit/tests/rest-api/rest-schema-validation.php
@@ -387,7 +387,10 @@ class WP_Test_REST_Schema_Validation extends WP_UnitTestCase {
 
 		$this->assertTrue( rest_validate_value_from_schema( null, $schema ) );
 		$this->assertTrue( rest_validate_value_from_schema( '2019-09-19T18:00:00', $schema ) );
-		$this->assertWPError( rest_validate_value_from_schema( 'some random string', $schema ) );
+
+		$error = rest_validate_value_from_schema( 'some random string', $schema );
+		$this->assertWPError( $error );
+		$this->assertEquals( 'Invalid date.', $error->get_error_message() );
 	}
 
 	public function test_object_or_string() {
@@ -402,7 +405,29 @@ class WP_Test_REST_Schema_Validation extends WP_UnitTestCase {
 
 		$this->assertTrue( rest_validate_value_from_schema( 'My Value', $schema ) );
 		$this->assertTrue( rest_validate_value_from_schema( array( 'raw' => 'My Value' ), $schema ) );
-		$this->assertWPError( rest_validate_value_from_schema( array( 'raw' => array( 'a list' ) ), $schema ) );
+
+		$error = rest_validate_value_from_schema( array( 'raw' => array( 'a list' ) ), $schema );
+		$this->assertWPError( $error );
+		$this->assertEquals( '[raw] is not of type string.', $error->get_error_message() );
+	}
+
+	/**
+	 * @ticket 50300
+	 */
+	public function test_null_or_integer() {
+		$schema = array(
+			'type'    => array( 'null', 'integer' ),
+			'minimum' => 10,
+			'maximum' => 20,
+		);
+
+		$this->assertTrue( rest_validate_value_from_schema( null, $schema ) );
+		$this->assertTrue( rest_validate_value_from_schema( 15, $schema ) );
+		$this->assertTrue( rest_validate_value_from_schema( '15', $schema ) );
+
+		$error = rest_validate_value_from_schema( 30, $schema, 'param' );
+		$this->assertWPError( $error );
+		$this->assertEquals( 'param must be between 10 (inclusive) and 20 (inclusive)', $error->get_error_message() );
 	}
 
 	/**


### PR DESCRIPTION
This gives us better error messages and makes sanitization more usable in different scenarios.
Trac ticket: https://core.trac.wordpress.org/ticket/50300

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
