### PR TITLE
Remove usage of deprecated MySQL SQL_CALC_FOUND_ROWS

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -84,6 +84,14 @@ class WP_Query {
 	public $request;
 
 	/**
+	 * Get post database count query
+	 *
+	 * @since xxx
+	 * @var string
+	 */
+	public $request_count;
+
+	/**
 	 * List of posts.
 	 *
 	 * @since 1.5.0
@@ -2910,13 +2918,9 @@ class WP_Query {
 			$orderby = 'ORDER BY ' . $orderby;
 		}
 
-		$found_rows = '';
-		if ( ! $q['no_found_rows'] && ! empty( $limits ) ) {
-			$found_rows = 'SQL_CALC_FOUND_ROWS';
-		}
-
-		$old_request   = "SELECT $found_rows $distinct $fields FROM {$wpdb->posts} $join WHERE 1=1 $where $groupby $orderby $limits";
+		$old_request   = "SELECT $distinct $fields FROM {$wpdb->posts} $join WHERE 1=1 $where $groupby $orderby $limits";
 		$this->request = $old_request;
+		$this->request_count = "SELECT COUNT($distinct {$wpdb->posts}.ID) FROM {$wpdb->posts} $join WHERE 1=1 $where $groupby";
 
 		if ( ! $q['suppress_filters'] ) {
 			/**
@@ -2999,7 +3003,7 @@ class WP_Query {
 			if ( $split_the_query ) {
 				// First get the IDs and then fill in the objects.
 
-				$this->request = "SELECT $found_rows $distinct {$wpdb->posts}.ID FROM {$wpdb->posts} $join WHERE 1=1 $where $groupby $orderby $limits";
+				$this->request = "SELECT $distinct {$wpdb->posts}.ID FROM {$wpdb->posts} $join WHERE 1=1 $where $groupby $orderby $limits";
 
 				/**
 				 * Filters the Post IDs SQL request before sending.
@@ -3238,7 +3242,7 @@ class WP_Query {
 			 * @param string   $found_posts The query to run to find the found posts.
 			 * @param WP_Query $this        The WP_Query instance (passed by reference).
 			 */
-			$this->found_posts = $wpdb->get_var( apply_filters_ref_array( 'found_posts_query', array( 'SELECT FOUND_ROWS()', &$this ) ) );
+			$this->found_posts = $wpdb->get_var( apply_filters_ref_array( 'found_posts_query', array( $this->request_count, &$this ) ) );
 		} else {
 			if ( is_array( $this->posts ) ) {
 				$this->found_posts = count( $this->posts );

--- a/src/wp-includes/class-wp-user-query.php
+++ b/src/wp-includes/class-wp-user-query.php
@@ -248,10 +248,6 @@ class WP_User_Query {
 			$this->query_fields = "$wpdb->users.ID";
 		}
 
-		if ( isset( $qv['count_total'] ) && $qv['count_total'] ) {
-			$this->query_fields = 'SQL_CALC_FOUND_ROWS ' . $this->query_fields;
-		}
-
 		$this->query_from  = "FROM $wpdb->users";
 		$this->query_where = 'WHERE 1=1';
 
@@ -621,8 +617,12 @@ class WP_User_Query {
 			}
 
 			if ( isset( $qv['count_total'] ) && $qv['count_total'] ) {
+
 				/**
-				 * Filters SELECT FOUND_ROWS() query for the current WP_User_Query instance.
+				 * Return a total count of users.
+				 * Historically this ran SELECT FOUND_ROWS() after issuing the main query,
+				 * but since SQL_CALC_FOUND_ROWS is now deprecated from MySQL, it instead repeats
+				 * the same query with COUNT(*) instead of $this->query_fields.
 				 *
 				 * @since 3.2.0
 				 * @since 5.1.0 Added the `$this` parameter.
@@ -632,8 +632,7 @@ class WP_User_Query {
 				 * @param string $sql         The SELECT FOUND_ROWS() query for the current WP_User_Query.
 				 * @param WP_User_Query $this The current WP_User_Query instance.
 				 */
-				$found_users_query = apply_filters( 'found_users_query', 'SELECT FOUND_ROWS()', $this );
-
+				$found_users_query = apply_filters( 'found_users_query', "SELECT COUNT(*) $this->query_from $this->query_where", $this );
 				$this->total_users = (int) $wpdb->get_var( $found_users_query );
 			}
 		}

--- a/tests/phpunit/tests/query/noFoundRows.php
+++ b/tests/phpunit/tests/query/noFoundRows.php
@@ -11,7 +11,7 @@ class Tests_Query_NoFoundRows extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertContains( 'SQL_CALC_FOUND_ROWS', $q->request );
+		$this->assertNotContains( 'SQL_CALC_FOUND_ROWS', $q->request );
 	}
 
 	public function test_no_found_rows_false() {
@@ -22,7 +22,7 @@ class Tests_Query_NoFoundRows extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertContains( 'SQL_CALC_FOUND_ROWS', $q->request );
+		$this->assertNotContains( 'SQL_CALC_FOUND_ROWS', $q->request );
 	}
 
 	public function test_no_found_rows_0() {
@@ -33,7 +33,7 @@ class Tests_Query_NoFoundRows extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertContains( 'SQL_CALC_FOUND_ROWS', $q->request );
+		$this->assertNotContains( 'SQL_CALC_FOUND_ROWS', $q->request );
 	}
 
 	public function test_no_found_rows_empty_string() {
@@ -44,7 +44,7 @@ class Tests_Query_NoFoundRows extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertContains( 'SQL_CALC_FOUND_ROWS', $q->request );
+		$this->assertNotContains( 'SQL_CALC_FOUND_ROWS', $q->request );
 	}
 
 	public function test_no_found_rows_true() {


### PR DESCRIPTION
Signed-off-by: Morgan Tocker <tocker@gmail.com>

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/47280

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
