### PR TITLE
Remove 'wp-auth-check' data and timing from heartbeat requests

### DIFF
--- a/src/js/_enqueues/lib/auth-check.js
+++ b/src/js/_enqueues/lib/auth-check.js
@@ -6,7 +6,7 @@
 
 /* global adminpage */
 (function($){
-	var wrap, next;
+	var wrap;
 
 	/**
 	 * Shows the authentication form popup.
@@ -111,18 +111,6 @@
 	}
 
 	/**
-	 * Schedules when the next time the authentication check will be done.
-	 *
-	 * @since 3.6.0
-	 * @private
-	 */
-	function schedule() {
-		// In seconds, default 3 min.
-		var interval = parseInt( window.authcheckL10n.interval, 10 ) || 180;
-		next = ( new Date() ).getTime() + ( interval * 1000 );
-	}
-
-	/**
 	 * Binds to the Heartbeat Tick event.
 	 *
 	 * - Shows the authentication form popup if user is not logged in.
@@ -138,31 +126,13 @@
 	 */
 	$( document ).on( 'heartbeat-tick.wp-auth-check', function( e, data ) {
 		if ( 'wp-auth-check' in data ) {
-			schedule();
 			if ( ! data['wp-auth-check'] && wrap.hasClass('hidden') ) {
 				show();
 			} else if ( data['wp-auth-check'] && ! wrap.hasClass('hidden') ) {
 				hide();
 			}
 		}
-
-	/**
-	 * Binds to the Heartbeat Send event.
-	 *
-	 * @ignore
-	 *
-	 * @since 3.6.0
-	 *
-	 * @param {Object} e The heartbeat-send event that has been triggered.
-	 * @param {Object} data Response data.
-	 */
-	}).on( 'heartbeat-send.wp-auth-check', function( e, data ) {
-		if ( ( new Date() ).getTime() > next ) {
-			data['wp-auth-check'] = true;
-		}
-
 	}).ready( function() {
-		schedule();
 
 		/**
 		 * Hides the authentication form popup when the close icon is clicked.

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -719,16 +719,6 @@ function wp_default_scripts( $scripts ) {
 		'authcheckL10n',
 		array(
 			'beforeunload' => __( 'Your session has expired. You can log in again from this page or go to the login page.' ),
-
-			/**
-			 * Filters the authentication check interval.
-			 *
-			 * @since 3.6.0
-			 *
-			 * @param int $interval The interval in which to check a user's authentication.
-			 *                      Default 3 minutes in seconds, or 180.
-			 */
-			'interval'     => apply_filters( 'wp_auth_check_interval', 3 * MINUTE_IN_SECONDS ),
 		)
 	);
 


### PR DESCRIPTION
As of [27153], wp-auth-check is returned on all heartbeats without the need for data from client-side. This also means that the timing and scheduling of this request data is ineffectual.

Trac ticket: https://core.trac.wordpress.org/ticket/50305

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
