### PR TITLE
Support REST API Resource Links in page heads

### DIFF
--- a/src/wp-includes/class-wp-taxonomy.php
+++ b/src/wp-includes/class-wp-taxonomy.php
@@ -202,7 +202,7 @@ final class WP_Taxonomy {
 	/**
 	 * The controller for this taxonomy's REST API endpoints.
 	 *
-	 * Custom controllers must extend WP_REST_Controller.
+	 * Custom controllers must extend WP_REST_Controller. Should be accessed using {@see WP_Taxonomy::get_rest_controller()}.
 	 *
 	 * @since 4.7.4
 	 * @var string|bool $rest_controller_class
@@ -451,5 +451,42 @@ final class WP_Taxonomy {
 	 */
 	public function remove_hooks() {
 		remove_filter( 'wp_ajax_add-' . $this->name, '_wp_ajax_add_hierarchical_term' );
+	}
+
+
+	/**
+	 * Gets the REST API controller for this taxonomy.
+	 *
+	 * Will only instantiate the controller class once per request.
+	 *
+	 * @since 5.5.0
+	 *
+	 * @return WP_REST_Controller|null The controller instance, or null if the taxonomy
+	 *                                 is set not to show in rest.
+	 */
+	public function get_rest_controller() {
+		if ( ! $this->show_in_rest ) {
+			return null;
+		}
+
+		$class = $this->rest_controller_class ? $this->rest_controller_class : WP_REST_Terms_Controller::class;
+
+		if ( ! class_exists( $class ) ) {
+			return null;
+		}
+
+		if ( ! is_subclass_of( $class, WP_REST_Controller::class ) ) {
+			return null;
+		}
+
+		if ( ! $this->rest_controller ) {
+			$this->rest_controller = new $class( $this->name );
+		}
+
+		if ( ! ( $this->rest_controller instanceof $class ) ) {
+			return null;
+		}
+
+		return $this->rest_controller;
 	}
 }

--- a/src/wp-includes/class-wp-taxonomy.php
+++ b/src/wp-includes/class-wp-taxonomy.php
@@ -210,7 +210,7 @@ final class WP_Taxonomy {
 	public $rest_controller_class;
 
 	/**
-	 * The controller instance for this post type's REST API endpoints.
+	 * The controller instance for this taxonomy's REST API endpoints.
 	 *
 	 * Lazily computed. Should be accessed using {@see WP_Taxonomy::get_rest_controller()}.
 	 *

--- a/src/wp-includes/class-wp-taxonomy.php
+++ b/src/wp-includes/class-wp-taxonomy.php
@@ -202,12 +202,22 @@ final class WP_Taxonomy {
 	/**
 	 * The controller for this taxonomy's REST API endpoints.
 	 *
-	 * Custom controllers must extend WP_REST_Controller. Should be accessed using {@see WP_Taxonomy::get_rest_controller()}.
+	 * Custom controllers must extend WP_REST_Controller.
 	 *
 	 * @since 4.7.4
 	 * @var string|bool $rest_controller_class
 	 */
 	public $rest_controller_class;
+
+	/**
+	 * The controller instance for this post type's REST API endpoints.
+	 *
+	 * Lazily computed. Should be accessed using {@see WP_Taxonomy::get_rest_controller()}.
+	 *
+	 * @since 5.5.0
+	 * @var WP_REST_Controller $rest_controller
+	 */
+	public $rest_controller;
 
 	/**
 	 * Whether it is a built-in taxonomy.

--- a/src/wp-includes/class-wp-taxonomy.php
+++ b/src/wp-includes/class-wp-taxonomy.php
@@ -463,7 +463,6 @@ final class WP_Taxonomy {
 		remove_filter( 'wp_ajax_add-' . $this->name, '_wp_ajax_add_hierarchical_term' );
 	}
 
-
 	/**
 	 * Gets the REST API controller for this taxonomy.
 	 *

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -284,6 +284,7 @@ add_action( 'wp_head', 'wp_enqueue_scripts', 1 );
 add_action( 'wp_head', 'wp_resource_hints', 2 );
 add_action( 'wp_head', 'feed_links', 2 );
 add_action( 'wp_head', 'feed_links_extra', 3 );
+add_action( 'wp_head', 'rest_add_resource_link', 4 );
 add_action( 'wp_head', 'rsd_link' );
 add_action( 'wp_head', 'wlwmanifest_link' );
 add_action( 'wp_head', 'adjacent_posts_rel_link_wp_head', 10, 0 );

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -284,7 +284,6 @@ add_action( 'wp_head', 'wp_enqueue_scripts', 1 );
 add_action( 'wp_head', 'wp_resource_hints', 2 );
 add_action( 'wp_head', 'feed_links', 2 );
 add_action( 'wp_head', 'feed_links_extra', 3 );
-add_action( 'wp_head', 'rest_add_resource_link', 4 );
 add_action( 'wp_head', 'rsd_link' );
 add_action( 'wp_head', 'wlwmanifest_link' );
 add_action( 'wp_head', 'adjacent_posts_rel_link_wp_head', 10, 0 );

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -871,7 +871,7 @@ function rest_output_link_wp_head() {
 
 	printf( '<link rel="https://api.w.org/" href="%s" />', esc_url( $api_root ) );
 
-	$resource = rest_get_current_resource_route();
+	$resource = rest_get_queried_resource_route();
 
 	if ( $resource ) {
 		printf( '<link rel="alternate" type="application/json" href="%s" />', esc_url( rest_url( $resource ) ) );
@@ -896,7 +896,7 @@ function rest_output_link_header() {
 
 	header( sprintf( 'Link: <%s>; rel="https://api.w.org/"', esc_url_raw( $api_root ) ), false );
 
-	$resource = rest_get_current_resource_route();
+	$resource = rest_get_queried_resource_route();
 
 	if ( $resource ) {
 		header( sprintf( 'Link: <%s>; rel="alternate"; type="application/json"', esc_url_raw( rest_url( $resource ) ) ), false );
@@ -1929,13 +1929,13 @@ function rest_get_route_for_term( $term ) {
  *
  * @return string The REST route of the resource, or an empty string if no resource identified.
  */
-function rest_get_current_resource_route() {
+function rest_get_queried_resource_route() {
 	if ( is_singular() ) {
-		$route = rest_get_route_for_post( get_post() );
+		$route = rest_get_route_for_post( get_queried_object() );
 	} elseif ( is_category() || is_tag() || is_tax() ) {
 		$route = rest_get_route_for_term( get_queried_object() );
 	} elseif ( is_author() ) {
-		$route = '/wp/v2/users/' . get_the_author_meta( 'ID' );
+		$route = '/wp/v2/users/' . get_queried_object_id();
 	} else {
 		$route = '';
 	}
@@ -1945,7 +1945,7 @@ function rest_get_current_resource_route() {
 	 *
 	 * @since 5.5.0
 	 *
-	 * @param string $link The URL or an empty string.
+	 * @param string $link The route with a leading slash, or an empty string.
 	 */
-	return apply_filters( 'rest_current_resource_route', $route );
+	return apply_filters( 'rest_queried_resource_route', $route );
 }

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -871,7 +871,7 @@ function rest_output_link_wp_head() {
 
 	printf( '<link rel="https://api.w.org/" href="%s" />', esc_url( $api_root ) );
 
-	$resource = rest_get_current_resource_link();
+	$resource = rest_get_current_resource_url();
 
 	if ( $resource ) {
 		printf( '<link rel="alternate" type="application/json" href="%s" />', esc_url( $resource ) );
@@ -896,7 +896,7 @@ function rest_output_link_header() {
 
 	header( sprintf( 'Link: <%s>; rel="https://api.w.org/"', esc_url_raw( $api_root ) ), false );
 
-	$resource = rest_get_current_resource_link();
+	$resource = rest_get_current_resource_url();
 
 	if ( $resource ) {
 		header( sprintf( 'Link: <%s>; rel="alternate"; type="application/json"', esc_url_raw( $resource ) ), false );
@@ -1929,18 +1929,23 @@ function rest_get_route_for_term( $term ) {
  *
  * @return string The REST URL of the resource, or an empty string if no resource identified.
  */
-function rest_get_current_resource_link() {
+function rest_get_current_resource_url() {
 	if ( is_singular() ) {
-		return rest_url( rest_get_route_for_post( get_post() ) );
+		$link = rest_url( rest_get_route_for_post( get_post() ) );
+	} elseif ( is_category() || is_tag() || is_tax() ) {
+		$link = rest_url( rest_get_route_for_term( get_queried_object() ) );
+	} elseif ( is_author() ) {
+		$link = rest_url( '/wp/v2/users/' . get_the_author_meta( 'ID' ) );
+	} else {
+		$link = '';
 	}
 
-	if ( is_category() || is_tag() || is_tax() ) {
-		return rest_url( rest_get_route_for_term( get_queried_object() ) );
-	}
-
-	if ( is_author() ) {
-		return rest_url( '/wp/v2/users/' . get_the_author_meta( 'ID' ) );
-	}
-
-	return '';
+	/**
+	 * Filters the REST URL for the currently queried object.
+	 *
+	 * @since 5.5.0
+	 *
+	 * @param string $link The URL or an empty string.
+	 */
+	return apply_filters( 'rest_current_resource_url', $link );
 }

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -1923,11 +1923,17 @@ function rest_get_route_for_term( $term ) {
 function rest_get_current_resource_link() {
 	if ( is_singular() ) {
 		return rest_url( rest_get_route_for_post( get_post() ) );
-	} elseif ( is_category() || is_tag() || is_tax() ) {
+	}
+
+	if ( is_category() || is_tag() || is_tax() ) {
 		return rest_url( rest_get_route_for_term( get_queried_object() );
-	} elseif ( is_author() ) {
+	}
+
+	if ( is_author() ) {
 		return rest_url( 'wp/v2/users/' . get_the_author_meta( 'ID' ) );
 	}
+
+	return '';
 }
 
 /**

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -1856,7 +1856,7 @@ function rest_get_route_for_post( $post ) {
 	$controller = $post_type->get_rest_controller();
 
 	// The only two controllers that we can detect are the Attachments and Posts controllers.
-	if ( in_array( $controller::class, array( 'WP_REST_Attachments_Controller', 'WP_REST_Posts_Controller' ), true ) ) {
+	if ( in_array( get_class( $controller ), array( 'WP_REST_Attachments_Controller', 'WP_REST_Posts_Controller' ), true ) ) {
 		$namespace = 'wp/v2';
 		$rest_base = ! empty( $post_type->rest_base ) ? $post_type->rest_base : $post_type->name;
 		$route = sprintf( '%s/%s/%d', $namespace, $rest_base, $post->ID );

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -1898,7 +1898,7 @@ function rest_get_route_for_term( $term ) {
 	$route = '';
 	$controller = $taxonomy->get_rest_controller();
 	// The only controller that works is the Terms controller.
-	if ( ! empty( $controller ) && 'WP_REST_Terms_Controller' === $controller ) {
+	if ( 'WP_REST_Terms_Controller' === $controller ) {
 		$namespace = 'wp/v2';
 		$rest_base = ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxnomomy->name;
 		$route = sprintf( '%s/%s/%d', $namespace, $rest_base, $term->term_id );

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -1852,17 +1852,17 @@ function rest_get_route_for_post( $post ) {
 		return '';
 	}
 
-	$route = '';
+	$route      = '';
 	$controller = $post_type->get_rest_controller();
 	if ( ! $controller ) {
 		return '';
 	}
-        
+
 	// The only two controllers that we can detect are the Attachments and Posts controllers.
 	if ( in_array( get_class( $controller ), array( 'WP_REST_Attachments_Controller', 'WP_REST_Posts_Controller' ), true ) ) {
 		$namespace = 'wp/v2';
 		$rest_base = ! empty( $post_type->rest_base ) ? $post_type->rest_base : $post_type->name;
-		$route = sprintf( '%s/%s/%d', $namespace, $rest_base, $post->ID );
+		$route     = sprintf( '%s/%s/%d', $namespace, $rest_base, $post->ID );
 	}
 
 	/**
@@ -1894,7 +1894,7 @@ function rest_get_route_for_term( $term ) {
 		return '';
 	}
 
-	$route = '';
+	$route      = '';
 	$controller = $taxonomy->get_rest_controller();
 	if ( ! $controller ) {
 		return '';
@@ -1904,7 +1904,7 @@ function rest_get_route_for_term( $term ) {
 	if ( 'WP_REST_Terms_Controller' === get_class( $controller ) ) {
 		$namespace = 'wp/v2';
 		$rest_base = ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxnomomy->name;
-		$route = sprintf( '%s/%s/%d', $namespace, $rest_base, $term->term_id );
+		$route     = sprintf( '%s/%s/%d', $namespace, $rest_base, $term->term_id );
 	}
 
 	/**

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -1901,7 +1901,7 @@ function rest_get_route_for_term( $term ) {
 	}
 
 	// The only controller that works is the Terms controller.
-	if ( 'WP_REST_Terms_Controller' === $controller::class ) {
+	if ( 'WP_REST_Terms_Controller' === get_class( $controller ) ) {
 		$namespace = 'wp/v2';
 		$rest_base = ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxnomomy->name;
 		$route = sprintf( '%s/%s/%d', $namespace, $rest_base, $term->term_id );

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -1838,7 +1838,7 @@ function rest_default_additional_properties_to_false( $schema ) {
  * @since 5.5.0
  *
  * @param WP_Post $post The post object.
- * @return string The route path for the given post, or an empty string if there is not a route.
+ * @return string The route path with a leading slash for the given post, or an empty string if there is not a route.
  */
 function rest_get_route_for_post( $post ) {
 	if ( ! $post instanceof WP_Post ) {
@@ -1861,7 +1861,7 @@ function rest_get_route_for_post( $post ) {
 	if ( in_array( get_class( $controller ), array( 'WP_REST_Attachments_Controller', 'WP_REST_Posts_Controller' ), true ) ) {
 		$namespace = 'wp/v2';
 		$rest_base = ! empty( $post_type->rest_base ) ? $post_type->rest_base : $post_type->name;
-		$route     = sprintf( '%s/%s/%d', $namespace, $rest_base, $post->ID );
+		$route     = sprintf( '/%s/%s/%d', $namespace, $rest_base, $post->ID );
 	}
 
 	/**
@@ -1881,7 +1881,7 @@ function rest_get_route_for_post( $post ) {
  * @since 5.5.0
  *
  * @param WP_Term $term The term object.
- * @return string The route path for the given term, or an empty string if there is not a route.
+ * @return string The route path with a leading slash for the given term, or an empty string if there is not a route.
  */
 function rest_get_route_for_term( $term ) {
 	if ( ! $term instanceof WP_Term ) {
@@ -1904,7 +1904,7 @@ function rest_get_route_for_term( $term ) {
 	if ( 'WP_REST_Terms_Controller' === get_class( $controller ) ) {
 		$namespace = 'wp/v2';
 		$rest_base = ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxonomy->name;
-		$route     = sprintf( '%s/%s/%d', $namespace, $rest_base, $term->term_id );
+		$route     = sprintf( '/%s/%s/%d', $namespace, $rest_base, $term->term_id );
 	}
 
 	/**
@@ -1935,7 +1935,7 @@ function rest_get_current_resource_link() {
 	}
 
 	if ( is_author() ) {
-		return rest_url( 'wp/v2/users/' . get_the_author_meta( 'ID' ) );
+		return rest_url( '/wp/v2/users/' . get_the_author_meta( 'ID' ) );
 	}
 
 	return '';

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -1822,11 +1822,11 @@ function rest_default_additional_properties_to_false( $schema ) {
 
 
 /**
- * Outputs a header link to a REST resource
+ * Outputs a header link to a REST resource.
  *
  * @since 5.5.0
  *
- * @param string       $url URL.
+ * @param string $url The URL to print.
  */
 function rest_head_link( $url ) {
 	if ( ! empty( $url ) ) {
@@ -1835,12 +1835,12 @@ function rest_head_link( $url ) {
 }
 
 /**
- * Return the rest route for a post.
+ * Gets the REST API route for a post.
  *
  * @since 5.5.0
  *
- * @param WP_Post       $post Post Object.
- * @return string           Route.
+ * @param WP_Post $post The post object.
+ * @return string The route path for the given post, or an empty string if there is not a route.
  */
 function rest_get_route_for_post( $post ) {
 	if ( ! $post instanceof WP_Post ) {
@@ -1867,23 +1867,23 @@ function rest_get_route_for_post( $post ) {
 	}
 
 	/**
-	 * Filters the route based on information in the post object.
+	 * Filters the REST API route for a post.
 	 *
 	 * @since 5.5.0
 	 *
-	 * @param string $route Route.
-	 * @param WP_Post $post Post Object.
+	 * @param string  $route The route path.
+	 * @param WP_Post $post  The post object.
 	 */
 	return apply_filters( 'rest_route_for_post', $route, $post );
 }
 
 /**
- * Return the rest route for a term.
+ * Gets the REST API route for a term.
  *
  * @since 5.5.0
  *
- * @param WP_Term       $term Term.
- * @return string           Route.
+ * @param WP_Term $term The term object.
+ * @return string The route path for the given term, or an empty string if there is not a route.
  */
 function rest_get_route_for_term( $term ) {
 	if ( ! $term instanceof WP_Term ) {
@@ -1905,25 +1905,27 @@ function rest_get_route_for_term( $term ) {
 	// The only controller that works is the Terms controller.
 	if ( 'WP_REST_Terms_Controller' === get_class( $controller ) ) {
 		$namespace = 'wp/v2';
-		$rest_base = ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxnomomy->name;
+		$rest_base = ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxonomy->name;
 		$route     = sprintf( '%s/%s/%d', $namespace, $rest_base, $term->term_id );
 	}
 
 	/**
-	 * Filters the route based on information in the term object.
+	 * Filters the REST API route for a term.
 	 *
 	 * @since 5.5.0
 	 *
-	 * @param string $route Route.
-	 * @param WP_Term $term Term Object.
+	 * @param string  $route The route path.
+	 * @param WP_Term $term  The term object.
 	 */
 	return apply_filters( 'rest_route_for_term', $route, $term );
 }
 
 /**
- * Get a REST URL for the current object.
+ * Gets the REST URL for the currently queried object.
  *
- * @param string URL.
+ * @since 5.5.0
+ *
+ * @return string The REST URL of the resource, or an empty string if no resource identified.
  */
 function rest_get_current_resource_link() {
 	if ( is_singular() ) {
@@ -1942,10 +1944,9 @@ function rest_get_current_resource_link() {
 }
 
 /**
- * Add a link to the current REST API resource.
+ * Adds a link to the current REST API resource in the <head> of the page.
  *
  * @since 5.5.0
- *
  */
 function rest_add_resource_link() {
 	rest_head_link( rest_get_current_resource_link() );

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -1854,7 +1854,10 @@ function rest_get_route_for_post( $post ) {
 
 	$route = '';
 	$controller = $post_type->get_rest_controller();
-
+	if ( ! $controller ) {
+		return '';
+	}
+        
 	// The only two controllers that we can detect are the Attachments and Posts controllers.
 	if ( in_array( get_class( $controller ), array( 'WP_REST_Attachments_Controller', 'WP_REST_Posts_Controller' ), true ) ) {
 		$namespace = 'wp/v2';

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -1860,7 +1860,7 @@ function rest_get_route_for_post( $post ) {
 	$controller = $post_type->get_rest_controller();
 
 	// The only two controllers that we can detect are the Attachments and Posts controllers.
-	if ( in_array( $controller, array( 'WP_REST_Attachments_Controller', 'WP_REST_Posts_Controller' ), true ) ) {
+	if ( in_array( $controller::class, array( 'WP_REST_Attachments_Controller', 'WP_REST_Posts_Controller' ), true ) ) {
 		$namespace = 'wp/v2';
 		$rest_base = ! empty( $post_type->rest_base ) ? $post_type->rest_base : $post_type->name;
 		$route = sprintf( '%s/%s/%d', $namespace, $rest_base, $post->ID );
@@ -1898,7 +1898,7 @@ function rest_get_route_for_term( $term ) {
 	$route = '';
 	$controller = $taxonomy->get_rest_controller();
 	// The only controller that works is the Terms controller.
-	if ( 'WP_REST_Terms_Controller' === $controller ) {
+	if ( 'WP_REST_Terms_Controller' === $controller::class ) {
 		$namespace = 'wp/v2';
 		$rest_base = ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxnomomy->name;
 		$route = sprintf( '%s/%s/%d', $namespace, $rest_base, $term->term_id );

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -1852,11 +1852,12 @@ function rest_get_route_for_post( $post ) {
 		return '';
 	}
 
-	$route      = '';
 	$controller = $post_type->get_rest_controller();
 	if ( ! $controller ) {
 		return '';
 	}
+
+	$route = '';
 
 	// The only two controllers that we can detect are the Attachments and Posts controllers.
 	if ( in_array( get_class( $controller ), array( 'WP_REST_Attachments_Controller', 'WP_REST_Posts_Controller' ), true ) ) {
@@ -1894,11 +1895,12 @@ function rest_get_route_for_term( $term ) {
 		return '';
 	}
 
-	$route      = '';
 	$controller = $taxonomy->get_rest_controller();
 	if ( ! $controller ) {
 		return '';
 	}
+
+	$route = '';
 
 	// The only controller that works is the Terms controller.
 	if ( 'WP_REST_Terms_Controller' === get_class( $controller ) ) {

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -1896,6 +1896,10 @@ function rest_get_route_for_term( $term ) {
 
 	$route = '';
 	$controller = $taxonomy->get_rest_controller();
+	if ( ! $controller ) {
+		return '';
+	}
+
 	// The only controller that works is the Terms controller.
 	if ( 'WP_REST_Terms_Controller' === $controller::class ) {
 		$namespace = 'wp/v2';

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -1837,10 +1837,12 @@ function rest_default_additional_properties_to_false( $schema ) {
  *
  * @since 5.5.0
  *
- * @param WP_Post $post The post object.
+ * @param int|WP_Post $post Post ID or post object.
  * @return string The route path with a leading slash for the given post, or an empty string if there is not a route.
  */
 function rest_get_route_for_post( $post ) {
+	$post = get_post( $post );
+
 	if ( ! $post instanceof WP_Post ) {
 		return '';
 	}
@@ -1880,10 +1882,12 @@ function rest_get_route_for_post( $post ) {
  *
  * @since 5.5.0
  *
- * @param WP_Term $term The term object.
+ * @param int|WP_Term $term Term ID or term object.
  * @return string The route path with a leading slash for the given term, or an empty string if there is not a route.
  */
 function rest_get_route_for_term( $term ) {
+	$term = get_term( $term );
+
 	if ( ! $term instanceof WP_Term ) {
 		return '';
 	}

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -871,10 +871,10 @@ function rest_output_link_wp_head() {
 
 	printf( '<link rel="https://api.w.org/" href="%s" />', esc_url( $api_root ) );
 
-	$resource = rest_get_current_resource_url();
+	$resource = rest_get_current_resource_route();
 
 	if ( $resource ) {
-		printf( '<link rel="alternate" type="application/json" href="%s" />', esc_url( $resource ) );
+		printf( '<link rel="alternate" type="application/json" href="%s" />', esc_url( rest_url( $resource ) ) );
 	}
 }
 
@@ -896,10 +896,10 @@ function rest_output_link_header() {
 
 	header( sprintf( 'Link: <%s>; rel="https://api.w.org/"', esc_url_raw( $api_root ) ), false );
 
-	$resource = rest_get_current_resource_url();
+	$resource = rest_get_current_resource_route();
 
 	if ( $resource ) {
-		header( sprintf( 'Link: <%s>; rel="alternate"; type="application/json"', esc_url_raw( $resource ) ), false );
+		header( sprintf( 'Link: <%s>; rel="alternate"; type="application/json"', esc_url_raw( rest_url( $resource ) ) ), false );
 	}
 }
 
@@ -1923,29 +1923,29 @@ function rest_get_route_for_term( $term ) {
 }
 
 /**
- * Gets the REST URL for the currently queried object.
+ * Gets the REST route for the currently queried object.
  *
  * @since 5.5.0
  *
- * @return string The REST URL of the resource, or an empty string if no resource identified.
+ * @return string The REST route of the resource, or an empty string if no resource identified.
  */
-function rest_get_current_resource_url() {
+function rest_get_current_resource_route() {
 	if ( is_singular() ) {
-		$link = rest_url( rest_get_route_for_post( get_post() ) );
+		$route = rest_get_route_for_post( get_post() );
 	} elseif ( is_category() || is_tag() || is_tax() ) {
-		$link = rest_url( rest_get_route_for_term( get_queried_object() ) );
+		$route = rest_get_route_for_term( get_queried_object() );
 	} elseif ( is_author() ) {
-		$link = rest_url( '/wp/v2/users/' . get_the_author_meta( 'ID' ) );
+		$route = '/wp/v2/users/' . get_the_author_meta( 'ID' );
 	} else {
-		$link = '';
+		$route = '';
 	}
 
 	/**
-	 * Filters the REST URL for the currently queried object.
+	 * Filters the REST route for the currently queried object.
 	 *
 	 * @since 5.5.0
 	 *
 	 * @param string $link The URL or an empty string.
 	 */
-	return apply_filters( 'rest_current_resource_url', $link );
+	return apply_filters( 'rest_current_resource_route', $route );
 }

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -234,13 +234,9 @@ function create_initial_rest_routes() {
 
 	// Terms.
 	foreach ( get_taxonomies( array( 'show_in_rest' => true ), 'object' ) as $taxonomy ) {
-		$class = ! empty( $taxonomy->rest_controller_class ) ? $taxonomy->rest_controller_class : 'WP_REST_Terms_Controller';
+		$controller = $taxonomy->get_rest_controller();
 
-		if ( ! class_exists( $class ) ) {
-			continue;
-		}
-		$controller = new $class( $taxonomy->name );
-		if ( ! is_subclass_of( $controller, 'WP_REST_Controller' ) ) {
+		if ( ! $controller ) {
 			continue;
 		}
 

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -869,7 +869,13 @@ function rest_output_link_wp_head() {
 		return;
 	}
 
-	echo "<link rel='https://api.w.org/' href='" . esc_url( $api_root ) . "' />\n";
+	printf( '<link rel="https://api.w.org/" href="%s" />', esc_url( $api_root ) );
+
+	$resource = rest_get_current_resource_link();
+
+	if ( $resource ) {
+		printf( '<link rel="alternate" type="application/json" href="%s" />', esc_url( $resource ) );
+	}
 }
 
 /**
@@ -888,7 +894,13 @@ function rest_output_link_header() {
 		return;
 	}
 
-	header( 'Link: <' . esc_url_raw( $api_root ) . '>; rel="https://api.w.org/"', false );
+	header( sprintf( 'Link: <%s>; rel="https://api.w.org/"', esc_url_raw( $api_root ) ), false );
+
+	$resource = rest_get_current_resource_link();
+
+	if ( $resource ) {
+		header( sprintf( 'Link: <%s>; rel="alternate"; type="application/json"', esc_url_raw( $resource ) ), false );
+	}
 }
 
 /**
@@ -1820,20 +1832,6 @@ function rest_default_additional_properties_to_false( $schema ) {
 	return $schema;
 }
 
-
-/**
- * Outputs a header link to a REST resource.
- *
- * @since 5.5.0
- *
- * @param string $url The URL to print.
- */
-function rest_head_link( $url ) {
-	if ( ! empty( $url ) ) {
-		printf( '<link rel="alternate" type="application/json" href="%s" />', esc_url( $url ) );
-	}
-}
-
 /**
  * Gets the REST API route for a post.
  *
@@ -1941,13 +1939,4 @@ function rest_get_current_resource_link() {
 	}
 
 	return '';
-}
-
-/**
- * Adds a link to the current REST API resource in the <head> of the page.
- *
- * @since 5.5.0
- */
-function rest_add_resource_link() {
-	rest_head_link( rest_get_current_resource_link() );
 }

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -1929,7 +1929,7 @@ function rest_get_current_resource_link() {
 	}
 
 	if ( is_category() || is_tag() || is_tax() ) {
-		return rest_url( rest_get_route_for_term( get_queried_object() );
+		return rest_url( rest_get_route_for_term( get_queried_object() ) );
 	}
 
 	if ( is_author() ) {

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -1860,7 +1860,7 @@ function rest_get_route_for_post( $post ) {
 	$controller = $post_type->get_rest_controller();
 
 	// The only two controllers that we can detect are the Attachments and Posts controllers.
-	if ( ! empty( $controller )  && in_array( $controller, array( 'WP_REST_Attachments_Controller', 'WP_REST_Posts_Controller' ), true ) ) {
+	if ( in_array( $controller, array( 'WP_REST_Attachments_Controller', 'WP_REST_Posts_Controller' ), true ) ) {
 		$namespace = 'wp/v2';
 		$rest_base = ! empty( $post_type->rest_base ) ? $post_type->rest_base : $post_type->name;
 		$route = sprintf( '%s/%s/%d', $namespace, $rest_base, $post->ID );

--- a/tests/phpunit/tests/rest-api.php
+++ b/tests/phpunit/tests/rest-api.php
@@ -1352,100 +1352,109 @@ class Tests_REST_API extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 49116
-	 * @dataProvider _dp_rest_get_route_for_post
-	 * @param string $expected
-	 * @param mixed  $post
 	 */
-	public function test_rest_get_route_for_post( $expected, $post ) {
-		$this->assertEquals( $expected, rest_get_route_for_post( $post ) );
-	}
-
-	public function _dp_rest_get_route_for_post() {
-		$post = self::factory()->post->create_and_get();
-
-		$invalid_post_type            = clone $post;
-		$invalid_post_type->post_type = 'invalid_cpt';
-
-		$non_rest = self::factory()->post->create_and_get( array( 'post_type' => 'custom_css' ) );
-		$block    = self::factory()->post->create_and_get( array( 'post_type' => 'wp_block' ) );
-		$media    = self::factory()->attachment->create_and_get();
-
-		return array(
-			'non post'          => array(
-				'',
-				'garbage',
-			),
-			'no post type'      => array(
-				'',
-				$invalid_post_type,
-			),
-			'not rest'          => array(
-				'',
-				$non_rest,
-			),
-			'custom controller' => array(
-				'',
-				$block,
-			),
-			'post'              => array(
-				'/wp/v2/posts/' . $post->ID,
-				$post,
-			),
-			'media'             => array(
-				'/wp/v2/media/' . $media->ID,
-				$media,
-			),
-			'post id'           => array(
-				'/wp/v2/posts/1',
-				1,
-			),
-		);
+	public function test_rest_get_route_for_post_non_post() {
+		$this->assertEquals( '', rest_get_route_for_post( 'garbage' ) );
 	}
 
 	/**
 	 * @ticket 49116
-	 * @dataProvider _dp_rest_get_route_for_term
-	 * @param string $expected
-	 * @param mixed  $term
 	 */
-	public function test_rest_get_route_for_term( $expected, $term ) {
-		$this->assertEquals( $expected, rest_get_route_for_term( $term ) );
+	public function test_rest_get_route_for_post_invalid_post_type() {
+		register_post_type( 'invalid' );
+		$post = self::factory()->post->create_and_get( array( 'post_type' => 'invalid' ) );
+		unregister_post_type( 'invalid' );
+
+		$this->assertEquals( '', rest_get_route_for_post( $post ) );
 	}
 
-	public function _dp_rest_get_route_for_term() {
+	/**
+	 * @ticket 49116
+	 */
+	public function test_rest_get_route_for_post_non_rest() {
+		$post = self::factory()->post->create_and_get( array( 'post_type' => 'custom_css' ) );
+		$this->assertEquals( '', rest_get_route_for_post( $post ) );
+	}
+
+	/**
+	 * @ticket 49116
+	 */
+	public function test_rest_get_route_for_post_custom_controller() {
+		$post = self::factory()->post->create_and_get( array( 'post_type' => 'wp_block' ) );
+		$this->assertEquals( '', rest_get_route_for_post( $post ) );
+	}
+
+	/**
+	 * @ticket 49116
+	 */
+	public function test_rest_get_route_for_post() {
+		$post = self::factory()->post->create_and_get();
+		$this->assertEquals( '/wp/v2/posts/' . $post->ID, rest_get_route_for_post( $post ) );
+	}
+
+	/**
+	 * @ticket 49116
+	 */
+	public function test_rest_get_route_for_media() {
+		$post = self::factory()->attachment->create_and_get();
+		$this->assertEquals( '/wp/v2/media/' . $post->ID, rest_get_route_for_post( $post ) );
+	}
+
+	/**
+	 * @ticket 49116
+	 */
+	public function test_rest_get_route_for_post_id() {
+		$post = self::factory()->post->create_and_get();
+		$this->assertEquals( '/wp/v2/posts/' . $post->ID, rest_get_route_for_post( $post->ID ) );
+	}
+
+	/**
+	 * @ticket 49116
+	 */
+	public function test_rest_get_route_for_term_non_term() {
+		$this->assertEquals( '', rest_get_route_for_term( 'garbage' ) );
+	}
+
+	/**
+	 * @ticket 49116
+	 */
+	public function test_rest_get_route_for_term_invalid_term_type() {
+		register_taxonomy( 'invalid', 'post' );
+		$term = self::factory()->term->create_and_get( array( 'taxonomy' => 'invalid' ) );
+		unregister_taxonomy( 'invalid' );
+
+		$this->assertEquals( '', rest_get_route_for_term( $term ) );
+	}
+
+	/**
+	 * @ticket 49116
+	 */
+	public function test_rest_get_route_for_term_non_rest() {
+		$term = self::factory()->term->create_and_get( array( 'taxonomy' => 'post_format' ) );
+		$this->assertEquals( '', rest_get_route_for_term( $term ) );
+	}
+
+	/**
+	 * @ticket 49116
+	 */
+	public function test_rest_get_route_for_term() {
 		$term = self::factory()->term->create_and_get();
+		$this->assertEquals( '/wp/v2/tags/' . $term->term_id, rest_get_route_for_term( $term ) );
+	}
 
-		$invalid_taxonomy           = clone $term;
-		$invalid_taxonomy->taxonomy = 'invalid_tax';
+	/**
+	 * @ticket 49116
+	 */
+	public function test_rest_get_route_for_category() {
+		$term = self::factory()->category->create_and_get();
+		$this->assertEquals( '/wp/v2/categories/' . $term->term_id, rest_get_route_for_term( $term ) );
+	}
 
-		$non_rest = self::factory()->term->create_and_get( array( 'taxonomy' => 'post_format' ) );
-		$cat      = self::factory()->term->create_and_get( array( 'taxonomy' => 'category' ) );
-
-		return array(
-			'non term'    => array(
-				'',
-				'garbage',
-			),
-			'no taxonomy' => array(
-				'',
-				$invalid_taxonomy,
-			),
-			'not rest'    => array(
-				'',
-				$non_rest,
-			),
-			'tag'         => array(
-				'/wp/v2/tags/' . $term->term_id,
-				$term,
-			),
-			'category'    => array(
-				'/wp/v2/categories/' . $cat->term_id,
-				$cat,
-			),
-			'category id' => array(
-				'/wp/v2/categories/1',
-				1,
-			),
-		);
+	/**
+	 * @ticket 49116
+	 */
+	public function test_rest_get_route_for_term_id() {
+		$term = self::factory()->term->create_and_get();
+		$this->assertEquals( '/wp/v2/tags/' . $term->term_id, rest_get_route_for_term( $term->term_id ) );
 	}
 }

--- a/tests/phpunit/tests/rest-api.php
+++ b/tests/phpunit/tests/rest-api.php
@@ -1354,7 +1354,7 @@ class Tests_REST_API extends WP_UnitTestCase {
 	 * @ticket 49116
 	 * @dataProvider _dp_rest_get_route_for_post
 	 * @param string $expected
-	 * @param mixed $post
+	 * @param mixed  $post
 	 */
 	public function test_rest_get_route_for_post( $expected, $post ) {
 		$this->assertEquals( $expected, rest_get_route_for_post( $post ) );
@@ -1373,7 +1373,7 @@ class Tests_REST_API extends WP_UnitTestCase {
 		return array(
 			'non post'          => array(
 				'',
-				1,
+				'garbage',
 			),
 			'no post type'      => array(
 				'',
@@ -1395,6 +1395,10 @@ class Tests_REST_API extends WP_UnitTestCase {
 				'/wp/v2/media/' . $media->ID,
 				$media,
 			),
+			'post id'           => array(
+				'/wp/v2/posts/' . $post->ID,
+				$post->ID,
+			),
 		);
 	}
 
@@ -1402,7 +1406,7 @@ class Tests_REST_API extends WP_UnitTestCase {
 	 * @ticket 49116
 	 * @dataProvider _dp_rest_get_route_for_term
 	 * @param string $expected
-	 * @param mixed $term
+	 * @param mixed  $term
 	 */
 	public function test_rest_get_route_for_term( $expected, $term ) {
 		$this->assertEquals( $expected, rest_get_route_for_term( $term ) );
@@ -1420,7 +1424,7 @@ class Tests_REST_API extends WP_UnitTestCase {
 		return array(
 			'non term'    => array(
 				'',
-				1,
+				'garbage',
 			),
 			'no taxonomy' => array(
 				'',
@@ -1437,6 +1441,10 @@ class Tests_REST_API extends WP_UnitTestCase {
 			'category'    => array(
 				'/wp/v2/categories/' . $cat->term_id,
 				$cat,
+			),
+			'tag id'      => array(
+				'/wp/v2/tags/' . $term->term_id,
+				$term->term_id,
 			),
 		);
 	}

--- a/tests/phpunit/tests/rest-api.php
+++ b/tests/phpunit/tests/rest-api.php
@@ -1349,4 +1349,95 @@ class Tests_REST_API extends WP_UnitTestCase {
 			array( new WP_REST_Response( 'rest' ), 'rest' ),
 		);
 	}
+
+	/**
+	 * @ticket 49116
+	 * @dataProvider _dp_rest_get_route_for_post
+	 * @param string $expected
+	 * @param mixed $post
+	 */
+	public function test_rest_get_route_for_post( $expected, $post ) {
+		$this->assertEquals( $expected, rest_get_route_for_post( $post ) );
+	}
+
+	public function _dp_rest_get_route_for_post() {
+		$post = self::factory()->post->create_and_get();
+
+		$invalid_post_type            = clone $post;
+		$invalid_post_type->post_type = 'invalid_cpt';
+
+		$non_rest = self::factory()->post->create_and_get( array( 'post_type' => 'custom_css' ) );
+		$block    = self::factory()->post->create_and_get( array( 'post_type' => 'wp_block' ) );
+		$media    = self::factory()->attachment->create_and_get();
+
+		return array(
+			'non post'          => array(
+				'',
+				1,
+			),
+			'no post type'      => array(
+				'',
+				$invalid_post_type,
+			),
+			'not rest'          => array(
+				'',
+				$non_rest,
+			),
+			'custom controller' => array(
+				'',
+				$block,
+			),
+			'post'              => array(
+				'/wp/v2/posts/' . $post->ID,
+				$post,
+			),
+			'media'             => array(
+				'/wp/v2/media/' . $media->ID,
+				$media,
+			),
+		);
+	}
+
+	/**
+	 * @ticket 49116
+	 * @dataProvider _dp_rest_get_route_for_term
+	 * @param string $expected
+	 * @param mixed $term
+	 */
+	public function test_rest_get_route_for_term( $expected, $term ) {
+		$this->assertEquals( $expected, rest_get_route_for_term( $term ) );
+	}
+
+	public function _dp_rest_get_route_for_term() {
+		$term = self::factory()->term->create_and_get();
+
+		$invalid_taxonomy           = clone $term;
+		$invalid_taxonomy->taxonomy = 'invalid_tax';
+
+		$non_rest = self::factory()->term->create_and_get( array( 'taxonomy' => 'post_format' ) );
+		$cat      = self::factory()->term->create_and_get( array( 'taxonomy' => 'category' ) );
+
+		return array(
+			'non term'    => array(
+				'',
+				1,
+			),
+			'no taxonomy' => array(
+				'',
+				$invalid_taxonomy,
+			),
+			'not rest'    => array(
+				'',
+				$non_rest,
+			),
+			'tag'         => array(
+				'/wp/v2/tags/' . $term->term_id,
+				$term,
+			),
+			'category'    => array(
+				'/wp/v2/categories/' . $cat->term_id,
+				$cat,
+			),
+		);
+	}
 }

--- a/tests/phpunit/tests/rest-api.php
+++ b/tests/phpunit/tests/rest-api.php
@@ -1396,8 +1396,8 @@ class Tests_REST_API extends WP_UnitTestCase {
 				$media,
 			),
 			'post id'           => array(
-				'/wp/v2/posts/' . $post->ID,
-				$post->ID,
+				'/wp/v2/posts/1',
+				1,
 			),
 		);
 	}
@@ -1442,9 +1442,9 @@ class Tests_REST_API extends WP_UnitTestCase {
 				'/wp/v2/categories/' . $cat->term_id,
 				$cat,
 			),
-			'tag id'      => array(
-				'/wp/v2/tags/' . $term->term_id,
-				$term->term_id,
+			'category id' => array(
+				'/wp/v2/categories/1',
+				1,
 			),
 		);
 	}

--- a/tests/phpunit/tests/rest-api/rest-taxonomies-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-taxonomies-controller.php
@@ -301,7 +301,7 @@ class WP_Test_REST_Taxonomies_Controller extends WP_Test_REST_Controller_Testcas
 	public function test_get_for_taxonomy_returns_terms_controller_if_custom_class_not_specified() {
 		register_taxonomy(
 			'test',
-			'post'
+			'post',
 			array(
 				'show_in_rest' => true,
 			)

--- a/tests/phpunit/tests/rest-api/rest-taxonomies-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-taxonomies-controller.php
@@ -291,6 +291,9 @@ class WP_Test_REST_Taxonomies_Controller extends WP_Test_REST_Controller_Testcas
 		$this->assertEquals( count( $taxonomies ), count( $data ) );
 	}
 
+	/**
+	 * @ticket 49116
+	 */
 	public function test_get_for_taxonomy_reuses_same_instance() {
 		$this->assertSame(
 			get_taxonomy( 'category' )->get_rest_controller(),
@@ -298,6 +301,9 @@ class WP_Test_REST_Taxonomies_Controller extends WP_Test_REST_Controller_Testcas
 		);
 	}
 
+	/**
+	 * @ticket 49116
+	 */
 	public function test_get_for_taxonomy_returns_terms_controller_if_custom_class_not_specified() {
 		register_taxonomy(
 			'test',

--- a/tests/phpunit/tests/rest-api/rest-taxonomies-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-taxonomies-controller.php
@@ -291,4 +291,26 @@ class WP_Test_REST_Taxonomies_Controller extends WP_Test_REST_Controller_Testcas
 		$this->assertEquals( count( $taxonomies ), count( $data ) );
 	}
 
+	public function test_get_for_taxonomy_reuses_same_instance() {
+		$this->assertSame(
+			get_taxonomy( 'category' )->get_rest_controller(),
+			get_taxonomy( 'category' )->get_rest_controller()
+		);
+	}
+
+	public function test_get_for_taxonomy_returns_terms_controller_if_custom_class_not_specified() {
+		register_taxonomy(
+			'test',
+			'post'
+			array(
+				'show_in_rest' => true,
+			)
+		);
+
+		$this->assertInstanceOf(
+			WP_REST_Terms_Controller::class,
+			get_taxonomy( 'test' )->get_rest_controller()
+		);
+	}
+
 }


### PR DESCRIPTION
Posts, terms, and other URLs on the site should have head links to the REST API representation of the data contained.

Trac ticket: https://core.trac.wordpress.org/ticket/49116