### PR TITLE
REST API: Add action-delete flag to declare delete_post capability for post objects

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -2467,6 +2467,20 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		}
 
 		$links[] = array(
+			'rel'          => 'https://api.w.org/action-delete',
+			'title'        => __( 'The current user can delete this post.' ),
+			'href'         => $href,
+			'targetSchema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'delete' => array(
+						'type' => 'boolean',
+					),
+				),
+			),
+		);
+
+		$links[] = array(
 			'rel'          => 'https://api.w.org/action-unfiltered-html',
 			'title'        => __( 'The current user can post unfiltered HTML markup and JavaScript.' ),
 			'href'         => $href,

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -1981,8 +1981,12 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 		$post_type = get_post_type_object( $post->post_type );
 
-		if ( 'attachment' !== $this->post_type && current_user_can( $post_type->cap->publish_posts ) ) {
+		if ( 'attachment' !== $this->post_type && current_user_can( 'publish_post', $post->ID ) ) {
 			$rels[] = 'https://api.w.org/action-publish';
+		}
+
+		if ( current_user_can( 'delete_post', $post->ID ) ) {
+			$rels[] = 'https://api.w.org/action-delete';
 		}
 
 		if ( current_user_can( 'unfiltered_html' ) ) {


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/50388

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
