### PR TITLE
Editor: Introduce new API method that register block from `block.json` metadata file

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -91,10 +91,10 @@ function generate_block_asset_handle( $block_name, $field_name ) {
  *
  * @since 5.5.0
  *
- * @param array  $metadata Block metadata.
+ * @param array  $metadata   Block metadata.
  * @param string $field_name Field name to pick from metadata.
  *
- * @return string|boolean Script handle provided directly or created through
+ * @return string|bool Script handle provided directly or created through
  *     script's registration, or false on failure.
  */
 function register_block_script_handle( $metadata, $field_name ) {
@@ -172,7 +172,7 @@ function register_block_style_handle( $metadata, $field_name ) {
  * @since 5.5.0
  *
  * @param string $file_or_folder Path to the JSON file with metadata definition for
- *     the block or path to the folder where the `block.json` file is located.
+ *                               the block or path to the folder where the `block.json` file is located.
  * @param array  $args {
  *     Optional. Array of block type arguments. Any arguments may be defined, however the
  *     ones described below are supported by default. Default empty array.

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -46,7 +46,6 @@ function unregister_block_type( $name ) {
  * @since 5.5.0
  *
  * @param string $asset_handle_or_path Asset handle or prefixed path.
- *
  * @return string Path without the prefix or the original value.
  */
 function remove_block_asset_path_prefix( $asset_handle_or_path ) {
@@ -93,7 +92,7 @@ function generate_block_asset_handle( $block_name, $field_name ) {
  * @param array  $metadata   Block metadata.
  * @param string $field_name Field name to pick from metadata.
  * @return string|bool Script handle provided directly or created through
- *     script's registration, or false on failure.
+ *                     script's registration, or false on failure.
  */
 function register_block_script_handle( $metadata, $field_name ) {
 	if ( empty( $metadata[ $field_name ] ) ) {
@@ -140,7 +139,7 @@ function register_block_script_handle( $metadata, $field_name ) {
  * @param array  $metadata Block metadata.
  * @param string $field_name Field name to pick from metadata.
  * @return string|boolean Style handle provided directly or created through
- *     style's registration, or false on failure.
+ *                        style's registration, or false on failure.
  */
 function register_block_style_handle( $metadata, $field_name ) {
 	if ( empty( $metadata[ $field_name ] ) ) {

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -68,7 +68,6 @@ function remove_block_asset_path_prefix( $asset_handle_or_path ) {
  *
  * @param string $block_name Name of the block.
  * @param string $field_name Name of the metadata field.
- *
  * @return string Generated asset name for the block's field.
  */
 function generate_block_asset_handle( $block_name, $field_name ) {
@@ -93,7 +92,6 @@ function generate_block_asset_handle( $block_name, $field_name ) {
  *
  * @param array  $metadata   Block metadata.
  * @param string $field_name Field name to pick from metadata.
- *
  * @return string|bool Script handle provided directly or created through
  *     script's registration, or false on failure.
  */
@@ -141,7 +139,6 @@ function register_block_script_handle( $metadata, $field_name ) {
  *
  * @param array  $metadata Block metadata.
  * @param string $field_name Field name to pick from metadata.
- *
  * @return string|boolean Style handle provided directly or created through
  *     style's registration, or false on failure.
  */

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -50,7 +50,7 @@ function unregister_block_type( $name ) {
  */
 function remove_block_asset_path_prefix( $asset_handle_or_path ) {
 	$path_prefix = 'file:';
-	if ( strpos( $asset_handle_or_path, $path_prefix ) !== 0 ) {
+	if ( 0 !== strpos( $asset_handle_or_path, $path_prefix ) ) {
 		return $asset_handle_or_path;
 	}
 	return substr(
@@ -119,7 +119,7 @@ function register_block_script_handle( $metadata, $field_name ) {
 		_doing_it_wrong( __FUNCTION__, $message, '5.5.0' );
 		return false;
 	}
-	$script_asset = require( $script_asset_path );
+	$script_asset = require $script_asset_path;
 	$result       = wp_register_script(
 		$script_handle,
 		plugins_url( $script_path, $metadata['file'] ),

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -41,6 +41,221 @@ function unregister_block_type( $name ) {
 }
 
 /**
+ * Removes the block asset's path prefix if provided.
+ *
+ * @since 5.5.0
+ *
+ * @param string $asset_handle_or_path Asset handle or prefixed path.
+ *
+ * @return string Path without the prefix or the original value.
+ */
+function remove_block_asset_path_prefix( $asset_handle_or_path ) {
+	$path_prefix = 'file:';
+	if ( strpos( $asset_handle_or_path, $path_prefix ) !== 0 ) {
+		return $asset_handle_or_path;
+	}
+	return substr(
+		$asset_handle_or_path,
+		strlen( $path_prefix )
+	);
+}
+
+/**
+ * Generates the name for an asset based on the name of the block
+ * and the field name provided.
+ *
+ * @since 5.5.0
+ *
+ * @param string $block_name Name of the block.
+ * @param string $field_name Name of the metadata field.
+ *
+ * @return string Generated asset name for the block's field.
+ */
+function generate_block_asset_handle( $block_name, $field_name ) {
+	$field_mappings = array(
+		'editorScript' => 'editor-script',
+		'script'       => 'script',
+		'editorStyle'  => 'editor-style',
+		'style'        => 'style',
+	);
+	return str_replace( '/', '-', $block_name ) .
+		'-' . $field_mappings[ $field_name ];
+}
+
+/**
+ * Finds a script handle for the selected block metadata field. It detects
+ * when a path to file was provided and finds a corresponding
+ * asset file with details necessary to register the script under
+ * automatically generated handle name. It returns unprocessed script handle
+ * otherwise.
+ *
+ * @since 5.5.0
+ *
+ * @param array  $metadata Block metadata.
+ * @param string $field_name Field name to pick from metadata.
+ *
+ * @return string|boolean Script handle provided directly or created through
+ *     script's registration, or false on failure.
+ */
+function register_block_script_handle( $metadata, $field_name ) {
+	if ( empty( $metadata[ $field_name ] ) ) {
+		return false;
+	}
+	$script_handle = $metadata[ $field_name ];
+	$script_path   = remove_block_asset_path_prefix( $metadata[ $field_name ] );
+	if ( $script_handle === $script_path ) {
+		return $script_handle;
+	}
+
+	$script_handle     = generate_block_asset_handle( $metadata['name'], $field_name );
+	$script_asset_path = realpath(
+		dirname( $metadata['file'] ) . '/' .
+		substr_replace( $script_path, '.asset.php', - strlen( '.js' ) )
+	);
+	if ( ! file_exists( $script_asset_path ) ) {
+		$message = sprintf(
+			/* translators: %1: field name. %2: block name */
+			__( 'The asset file for the "%1$s" defined in "%2$s" block definition is missing.', 'default' ),
+			$field_name,
+			$metadata['name']
+		);
+		_doing_it_wrong( __FUNCTION__, $message, '5.5.0' );
+		return false;
+	}
+	$script_asset = require( $script_asset_path );
+	$result       = wp_register_script(
+		$script_handle,
+		plugins_url( $script_path, $metadata['file'] ),
+		$script_asset['dependencies'],
+		$script_asset['version']
+	);
+	return $result ? $script_handle : false;
+}
+
+/**
+ * Finds a style handle for the block metadata field. It detects when a path
+ * to file was provided and registers the style under automatically
+ * generated handle name. It returns unprocessed style handle otherwise.
+ *
+ * @since 5.5.0
+ *
+ * @param array  $metadata Block metadata.
+ * @param string $field_name Field name to pick from metadata.
+ *
+ * @return string|boolean Style handle provided directly or created through
+ *     style's registration, or false on failure.
+ */
+function register_block_style_handle( $metadata, $field_name ) {
+	if ( empty( $metadata[ $field_name ] ) ) {
+		return false;
+	}
+	$style_handle = $metadata[ $field_name ];
+	$style_path   = remove_block_asset_path_prefix( $metadata[ $field_name ] );
+	if ( $style_handle === $style_path ) {
+		return $style_handle;
+	}
+
+	$style_handle = generate_block_asset_handle( $metadata['name'], $field_name );
+	$block_dir    = dirname( $metadata['file'] );
+	$result       = wp_register_style(
+		$style_handle,
+		plugins_url( $style_path, $metadata['file'] ),
+		array(),
+		filemtime( realpath( "$block_dir/$style_path" ) )
+	);
+	return $result ? $style_handle : false;
+}
+
+/**
+ * Registers a block type from metadata stored in the `block.json` file.
+ *
+ * @since 5.5.0
+ *
+ * @param string $file_or_folder Path to the JSON file with metadata definition for
+ *     the block or path to the folder where the `block.json` file is located.
+ * @param array  $args {
+ *     Optional. Array of block type arguments. Any arguments may be defined, however the
+ *     ones described below are supported by default. Default empty array.
+ *
+ *     @type callable $render_callback Callback used to render blocks of this block type.
+ * }
+ * @return WP_Block_Type|false The registered block type on success, or false on failure.
+ */
+function register_block_type_from_metadata( $file_or_folder, $args = array() ) {
+	$filename      = 'block.json';
+	$metadata_file = ( substr( $file_or_folder, -strlen( $filename ) ) !== $filename ) ?
+		trailingslashit( $file_or_folder ) . $filename :
+		$file_or_folder;
+	if ( ! file_exists( $metadata_file ) ) {
+		return false;
+	}
+
+	$metadata = json_decode( file_get_contents( $metadata_file ), true );
+	if ( ! is_array( $metadata ) || empty( $metadata['name'] ) ) {
+		return false;
+	}
+	$metadata['file'] = $metadata_file;
+
+	$settings          = array();
+	$property_mappings = array(
+		'title'           => 'title',
+		'category'        => 'category',
+		'parent'          => 'parent',
+		'icon'            => 'icon',
+		'description'     => 'description',
+		'keywords'        => 'keywords',
+		'attributes'      => 'attributes',
+		'providesContext' => 'provides_context',
+		'usesContext'     => 'uses_context',
+		'supports'        => 'supports',
+		'styles'          => 'styles',
+		'example'         => 'example',
+	);
+
+	foreach ( $property_mappings as $key => $mapped_key ) {
+		if ( isset( $metadata[ $key ] ) ) {
+			$settings[ $mapped_key ] = $metadata[ $key ];
+		}
+	}
+
+	if ( ! empty( $metadata['editorScript'] ) ) {
+		$settings['editor_script'] = register_block_script_handle(
+			$metadata,
+			'editorScript'
+		);
+	}
+
+	if ( ! empty( $metadata['script'] ) ) {
+		$settings['script'] = register_block_script_handle(
+			$metadata,
+			'script'
+		);
+	}
+
+	if ( ! empty( $metadata['editorStyle'] ) ) {
+		$settings['editor_style'] = register_block_style_handle(
+			$metadata,
+			'editorStyle'
+		);
+	}
+
+	if ( ! empty( $metadata['style'] ) ) {
+		$settings['style'] = register_block_style_handle(
+			$metadata,
+			'style'
+		);
+	}
+
+	return register_block_type(
+		$metadata['name'],
+		array_merge(
+			$settings,
+			$args
+		)
+	);
+}
+
+/**
  * Determine whether a post or content string has blocks.
  *
  * This test optimizes for performance rather than strict accuracy, detecting

--- a/tests/phpunit/tests/blocks/fixtures/block.asset.php
+++ b/tests/phpunit/tests/blocks/fixtures/block.asset.php
@@ -1,0 +1,6 @@
+<?php
+
+return array(
+	'dependencies' => array(),
+	'version'      => 'test',
+);

--- a/tests/phpunit/tests/blocks/fixtures/block.css
+++ b/tests/phpunit/tests/blocks/fixtures/block.css
@@ -1,0 +1,1 @@
+/* Test CSS file */

--- a/tests/phpunit/tests/blocks/fixtures/block.js
+++ b/tests/phpunit/tests/blocks/fixtures/block.js
@@ -1,0 +1,1 @@
+/* Test JavaScript file. */

--- a/tests/phpunit/tests/blocks/fixtures/block.json
+++ b/tests/phpunit/tests/blocks/fixtures/block.json
@@ -1,0 +1,52 @@
+{
+	"name": "my-plugin/notice",
+	"title": "Notice",
+	"category": "common",
+	"parent": [
+		"core/group"
+	],
+	"providesContext": {
+		"my-plugin/message": "message"
+	},
+	"usesContext": [
+		"groupId"
+	],
+	"icon": "star",
+	"description": "Shows warning, error or success notices…",
+	"keywords": [
+		"alert",
+		"message"
+	],
+	"textDomain": "my-plugin",
+	"attributes": {
+		"message": {
+			"type": "string",
+			"source": "html",
+			"selector": ".message"
+		}
+	},
+	"supports": {
+		"align": true,
+		"lightBlockWrapper": true
+	},
+	"styles": [
+		{
+			"name": "default",
+			"label": "Default",
+			"isDefault": true
+		},
+		{
+			"name": "other",
+			"label": "Other"
+		}
+	],
+	"example": {
+		"attributes": {
+			"message": "This is a notice!"
+		}
+	},
+	"editorScript": "my-plugin-notice-editor-script",
+	"script": "my-plugin-notice-script",
+	"editorStyle": "my-plugin-notice-editor-style",
+	"style": "my-plugin-notice-style"
+}

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -103,6 +103,248 @@ class WP_Test_Block_Register extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 50263
+	 */
+	function test_does_not_remove_block_asset_path_prefix() {
+		$result = remove_block_asset_path_prefix( 'script-handle' );
+
+		$this->assertSame( 'script-handle', $result );
+	}
+
+	/**
+	 * @ticket 50263
+	 */
+	function test_removes_block_asset_path_prefix() {
+		$result = remove_block_asset_path_prefix( 'file:./block.js' );
+
+		$this->assertSame( './block.js', $result );
+	}
+
+	/**
+	 * @ticket 50263
+	 */
+	function test_generate_block_asset_handle() {
+		$block_name = 'unit-tests/my-block';
+
+		$this->assertSame(
+			'unit-tests-my-block-editor-script',
+			generate_block_asset_handle( $block_name, 'editorScript' )
+		);
+		$this->assertSame(
+			'unit-tests-my-block-script',
+			generate_block_asset_handle( $block_name, 'script' )
+		);
+		$this->assertSame(
+			'unit-tests-my-block-editor-style',
+			generate_block_asset_handle( $block_name, 'editorStyle' )
+		);
+		$this->assertSame(
+			'unit-tests-my-block-style',
+			generate_block_asset_handle( $block_name, 'style' )
+		);
+	}
+
+	/**
+	 * @ticket 50263
+	 */
+	function test_field_not_found_register_block_script_handle() {
+		$result = register_block_script_handle( array(), 'script' );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * @ticket 50263
+	 */
+	function test_empty_value_register_block_script_handle() {
+		$metadata = array( 'script' => '' );
+		$result   = register_block_script_handle( $metadata, 'script' );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * @expectedIncorrectUsage register_block_script_handle
+	 * @ticket 50263
+	 */
+	function test_missing_asset_file_register_block_script_handle() {
+		$metadata = array(
+			'file'   => __FILE__,
+			'name'   => 'unit-tests/test-block',
+			'script' => 'file:./fixtures/missing-asset.js',
+		);
+		$result   = register_block_script_handle( $metadata, 'script' );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * @ticket 50263
+	 */
+	function test_handle_passed_register_block_script_handle() {
+		$metadata = array(
+			'editorScript' => 'test-script-handle',
+		);
+		$result   = register_block_script_handle( $metadata, 'editorScript' );
+
+		$this->assertSame( 'test-script-handle', $result );
+	}
+
+	/**
+	 * @ticket 50263
+	 */
+	function test_success_register_block_script_handle() {
+		$metadata = array(
+			'file'   => __FILE__,
+			'name'   => 'unit-tests/test-block',
+			'script' => 'file:./fixtures/block.js',
+		);
+		$result   = register_block_script_handle( $metadata, 'script' );
+
+		$this->assertSame( 'unit-tests-test-block-script', $result );
+	}
+
+	/**
+	 * @ticket 50263
+	 */
+	function test_field_not_found_register_block_style_handle() {
+		$result = register_block_style_handle( array(), 'style' );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * @ticket 50263
+	 */
+	function test_empty_value_found_register_block_style_handle() {
+		$metadata = array( 'style' => '' );
+		$result   = register_block_style_handle( $metadata, 'style' );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * @ticket 50263
+	 */
+	function test_handle_passed_register_block_style_handle() {
+		$metadata = array(
+			'style' => 'test-style-handle',
+		);
+		$result   = register_block_style_handle( $metadata, 'style' );
+
+		$this->assertSame( 'test-style-handle', $result );
+	}
+
+	/**
+	 * @ticket 50263
+	 */
+	function test_success_register_block_style_handle() {
+		$metadata = array(
+			'file'  => __FILE__,
+			'name'  => 'unit-tests/test-block',
+			'style' => 'file:./fixtures/block.css',
+		);
+		$result   = register_block_style_handle( $metadata, 'style' );
+
+		$this->assertSame( 'unit-tests-test-block-style', $result );
+	}
+
+	/**
+	 * Tests that the function returns false when the `block.json` is not found
+	 * in the WordPress core.
+	 *
+	 * @ticket 50263
+	 */
+	function test_metadata_not_found_in_wordpress_core() {
+		$result = register_block_type_from_metadata( 'unknown' );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Tests that the function returns false when the `block.json` is not found
+	 * in the current directory.
+	 *
+	 * @ticket 50263
+	 */
+	function test_metadata_not_found_in_the_current_directory() {
+		$result = register_block_type_from_metadata( __DIR__ );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Tests that the function returns the registered block when the `block.json`
+	 * is found in the fixtures directory.
+	 *
+	 * @ticket 50263
+	 */
+	function test_block_registers_with_metadata_fixture() {
+		$result = register_block_type_from_metadata(
+			__DIR__ . '/fixtures'
+		);
+
+		$this->assertInstanceOf( 'WP_Block_Type', $result );
+		$this->assertSame( 'my-plugin/notice', $result->name );
+		$this->assertSame( 'Notice', $result->title );
+		$this->assertSame( 'common', $result->category );
+		$this->assertEqualSets( array( 'core/group' ), $result->parent );
+		$this->assertSame( 'star', $result->icon );
+		$this->assertSame( 'Shows warning, error or success notices…', $result->description );
+		$this->assertEqualSets( array( 'alert', 'message' ), $result->keywords );
+		$this->assertEquals(
+			array(
+				'message' => array(
+					'type'     => 'string',
+					'source'   => 'html',
+					'selector' => '.message',
+				),
+			),
+			$result->attributes
+		);
+		$this->assertEquals(
+			array(
+				'my-plugin/message' => 'message',
+			),
+			$result->provides_context
+		);
+		$this->assertEqualSets( array( 'groupId' ), $result->uses_context );
+		$this->assertEquals(
+			array(
+				'align'             => true,
+				'lightBlockWrapper' => true,
+			),
+			$result->supports
+		);
+		$this->assertEquals(
+			array(
+				array(
+					'name'      => 'default',
+					'label'     => 'Default',
+					'isDefault' => true,
+				),
+				array(
+					'name'  => 'other',
+					'label' => 'Other',
+				),
+			),
+			$result->styles
+		);
+		$this->assertEquals(
+			array(
+				'attributes' => array(
+					'message' => 'This is a notice!',
+				),
+			),
+			$result->example
+		);
+		$this->assertSame( 'my-plugin-notice-editor-script', $result->editor_script );
+		$this->assertSame( 'my-plugin-notice-script', $result->script );
+		$this->assertSame( 'my-plugin-notice-editor-style', $result->editor_style );
+		$this->assertSame( 'my-plugin-notice-style', $result->style );
+	}
+
+	/**
 	 * @ticket 45109
 	 */
 	function test_get_dynamic_block_names() {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/50263

This patch includes changes added to Gutenberg in:
- https://github.com/WordPress/gutenberg/pull/20794
- https://github.com/WordPress/gutenberg/pull/22519

This is how the interface looks like:

```php
<?php
/**
  * Registers a block type from metadata stored in the `block.json` file.
  *
  * @since 5.5.0
  *
  * @param string $file_or_folder Path to the JSON file with metadata definition for
  *     the block or path to the folder where the `block.json` file is located.
  * @param array  $args {
  *     Optional. Array of block type arguments. Any arguments may be defined, however the
  *     ones described below are supported by default. Default empty array.
  *
  *     @type callable $render_callback Callback used to render blocks of this block type.
  * }
  * @return WP_Block_Type|false The registered block type on success, or false on failure.
  */
function register_block_type_from_metadata( $file_or_folder, $args = array() );
```

This function is going to be used to register all blocks on the server when backporting the block editor changes in https://core.trac.wordpress.org/ticket/50420.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
