### PR TITLE
Harden SiteHealth checks against malformed responses

### DIFF
--- a/src/wp-admin/site-health.php
+++ b/src/wp-admin/site-health.php
@@ -144,7 +144,9 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 	<h4 class="health-check-accordion-heading">
 		<button aria-expanded="false" class="health-check-accordion-trigger" aria-controls="health-check-accordion-block-{{ data.test }}" type="button">
 			<span class="title">{{ data.label }}</span>
-			<span class="badge {{ data.badge.color }}">{{ data.badge.label }}</span>
+			<# if ( data.badge ) { #>
+				<span class="badge {{ data.badge.color }}">{{ data.badge.label }}</span>
+			<# } #>
 			<span class="icon"></span>
 		</button>
 	</h4>


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/50145

This PR adds a validator to the issue respones for Site Health tests, which will discard any invalid responses instead of causing fatal errors.

It also makes badges optional, on the same basis as actions are optional, it's expected, but there may be situations where they're not present.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
