### PR TITLE
Prevent Admin Bar Items From Wrapping if There's More Items Than the Available Adminbar Width

### DIFF
--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -138,6 +138,11 @@ html:lang(he-il) .rtl #wpadminbar * {
 	padding: 0 8px 0 7px;
 }
 
+#wpadminbar .quicklinks > ul > li,
+#wpadminbar .quicklinks .ab-item {
+	max-width: 100px; /* Improve spacing and prevent Site Title from eating WP Logo */
+}
+
 #wpadminbar .menupop .ab-sub-wrapper,
 #wpadminbar .shortlink-input {
 	margin: 0;
@@ -706,6 +711,51 @@ html:lang(he-il) .rtl #wpadminbar * {
 	line-height: normal;
 	text-decoration: none;
 	box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
+}
+
+@media only screen and (min-width: 1061px) {
+	/* Reset the spacing */
+	#wpadminbar .quicklinks > ul > li,
+	#wpadminbar .quicklinks .ab-item {
+		max-width: initial;
+		text-overflow: clip;
+	}
+}
+
+@media screen and (min-width: 782px) {
+	/* Prevent wrapping of admin bar that has more items than admin bar area (mobile-friendly toolbar doesn't need this) */
+	#wpadminbar .quicklinks {
+		justify-content: space-between;
+	}
+	#wpadminbar .quicklinks > ul > li {
+		float: none !important;
+	}
+	#wpadminbar .quicklinks > ul > li,
+	#wpadminbar .quicklinks .ab-item {
+		white-space: nowrap;
+		text-overflow: ellipsis;
+		min-width: 0 !important;
+	}
+	#wpadminbar .quicklinks .ab-item {
+		overflow: hidden;
+	}
+	#wpadminbar .quicklinks .ab-item .ab-label,
+	#wpadminbar .quicklinks .ab-item .display-name {
+		float: none;
+		display: inline;
+	}
+	#wpadminbar .quicklinks,
+	#wpadminbar .quicklinks > ul {
+		display: -ms-flexbox;
+		display: flex;
+		flex-wrap: nowrap;
+		-ms-flex-wrap: nowrap;
+		min-width: 0 !important;
+	}
+	#wpadminbar #wp-admin-bar-top-secondary {
+		flex-direction: row-reverse;
+		-ms-flex-direction: row-reverse;
+	}
 }
 
 @media screen and (max-width: 782px) {


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/44438 (has been open for some time without being really followed up on so hopefully this PR breathes some life back into this.)

The Trac ticket has a bunch of additional details regarding the issue being resolved here, screenshots, etc.

Code here is from version 1.0.3 of https://wordpress.org/plugins/admin-bar-wrap-fix/ (June 22, 2020) per that plugin ideally not being necessary to prevent issues that this resolves (with WordPress just preventing it from the start.) Somewhat of a "patch plugin" equivalent to a "feature plugin" WordPress has for forthcoming features, and it might be good to include it in the WP core at some point (if not now).

**Edit:** Also see https://core.trac.wordpress.org/ticket/28983 as this ticket may take precedent as it's older than my ticket mentioned above while discussing the same issue (though the actual method/implementation to proceed with is yet to be decided, it seems.)