### PR TITLE
Making sure post name is unique when publishing article with wp_publish_post

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -4318,6 +4318,8 @@ function wp_update_post( $postarr = array(), $wp_error = false ) {
 /**
  * Publish a post by transitioning the post status.
  *
+ * Makes sure the new permalink is unique.
+ *
  * @since 2.1.0
  *
  * @global wpdb $wpdb WordPress database abstraction object.
@@ -4336,7 +4338,9 @@ function wp_publish_post( $post ) {
 		return;
 	}
 
-	$wpdb->update( $wpdb->posts, array( 'post_status' => 'publish' ), array( 'ID' => $post->ID ) );
+	$post_name = wp_unique_post_slug( $post->post_name, $post->ID, 'publish', $post->post_type, $post->post_parent );
+
+	$wpdb->update( $wpdb->posts, array( 'post_status' => 'publish', 'post_name' => $post_name ), array( 'ID' => $post->ID ) );
 
 	clean_post_cache( $post->ID );
 


### PR DESCRIPTION
Making sure post name is unique when publishing article with wp_publish_post

When wp_publish_post is called there is no check to see if the slug (post_name) or the post is unique. This leads to multiple posts having the same URL.

Added a call to wp_unique_post_slug and setting the new slug on DB update to publish

Trac ticket: https://core.trac.wordpress.org/ticket/50447
