### PR TITLE
48245 added additional information for minimum requirements

### DIFF
--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -1147,16 +1147,14 @@ function validate_plugin_requirements( $plugin ) {
 		$requirements = array_merge( $readme_headers, $requirements );
 	}
 
-
 	/* translators: %s: URL to Update PHP page. */
-	$php_update_message = ( !$php_compat ) ? '<p>' . sprintf( __( '<a href="%s">Learn more about updating PHP</a>.' ), esc_url( wp_get_update_php_url() ) ) : '';
+	$php_update_message = ( ! $php_compat ) ? '<p>' . sprintf( __( '<a href="%s">Learn more about updating PHP</a>.' ), esc_url( wp_get_update_php_url() ) ) : '';
 
-	$annotation = ( !$php_compat ) ? wp_get_update_php_annotation() : false;
+	$annotation = ( ! $php_compat ) ? wp_get_update_php_annotation() : false;
 
 	if ( $annotation ) {
 		$php_update_message .= '</p><p><em>' . $annotation . '</em>';
 	}
-
 
 	$compatible_wp  = is_wp_version_compatible( $requirements['requires'] );
 	$compatible_php = is_php_version_compatible( $requirements['requires_php'] );
@@ -1166,12 +1164,15 @@ function validate_plugin_requirements( $plugin ) {
 			'plugin_wp_php_incompatible',
 			sprintf(
 			/* translators: 1: WordPress version, 2: PHP version, 3: Plugin name, 4: Current WordPress version 5: Current PHP version. */
-				_x( 'Current WordPress and PHP versions do not meet minimum requirements of %1$s and %2$s for %3$s.
-                Your current versions of WordPress and PHP are %4$s and %5$s respectively.', 'plugin' ),
+				_x(
+					'Current WordPress and PHP versions do not meet minimum requirements of %1$s and %2$s for %3$s.
+	                Your current versions of WordPress and PHP are %4$s and %5$s respectively.',
+					'plugin'
+				),
 				$requirements['requires'],
 				$requirements['requires_php'],
 				$plugin_headers['Name'],
-				get_bloginfo('version'),
+				get_bloginfo( 'version' ),
 				phpversion()
 			) . $php_update_message
 		);
@@ -1193,7 +1194,7 @@ function validate_plugin_requirements( $plugin ) {
 			/* translators: 1: WordPress version, 2: Current WordPress version, 3: Plugin name. */
 				_x( 'Your current WordPress version is: %2$s. The current WordPress version does not meet minimum requirements of %1$s for %3$s.', 'plugin' ),
 				$requirements['requires'],
-				get_bloginfo('version'),
+				get_bloginfo( 'version' ),
 				$plugin_headers['Name']
 			) . $php_update_message
 		);


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Added extra details to the error message for a plugin's minimum supported PHP version. I reformatted some of the error messages and added a link to update PHP if the minimum version isn't met.

Trac ticket: https://core.trac.wordpress.org/ticket/48245

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
