### PR TITLE
Add debug info for file_uploads, post_max_size, and etc.

### DIFF
--- a/src/wp-admin/includes/class-wp-debug-data.php
+++ b/src/wp-admin/includes/class-wp-debug-data.php
@@ -519,6 +519,46 @@ class WP_Debug_Data {
 			'value' => ( is_array( $imagick_version ) ? $imagick_version['versionString'] : $imagick_version ),
 		);
 
+		if ( ! function_exists( 'ini_get' ) ) {
+			$info['wp-media']['fields']['ini_get'] = array(
+				'label' => __( 'File upload settings' ),
+				'value' => sprintf(
+					/* translators: %s: ini_get() */
+					__( 'Unable to determine some settings, as the %s function has been disabled.' ),
+					'ini_get()'
+				),
+				'debug' => 'ini_get() is disabled',
+			);
+		} else {
+			// Get the PHP ini directive values.
+			$post_max_size    = ini_get( 'post_max_size' );
+			$upload_max_size  = ini_get( 'upload_max_filesize' );
+			$max_file_uploads = ini_get( 'max_file_uploads' );
+			$effective        = min( $post_max_size, $upload_max_size );
+			// Add info in Media section.
+			$info['wp-media']['fields']['file_uploads']        = array(
+				'label' => __( 'File uploads' ),
+				'value' => empty( ini_get( 'file_uploads' ) ) ? __( 'Disabled' ) : __( 'Enabled' ),
+				'debug' => 'File uploads is turned off',
+			);
+			$info['wp-media']['fields']['post_max_size']       = array(
+				'label' => __( 'Max size of post data allowed' ),
+				'value' => $post_max_size,
+			);
+			$info['wp-media']['fields']['upload_max_filesize'] = array(
+				'label' => __( 'Max size of an uploaded file' ),
+				'value' => $upload_max_size,
+			);
+			$info['wp-media']['fields']['upload_max']          = array(
+				'label' => __( 'Max effective file size' ),
+				'value' => $effective,
+			);
+			$info['wp-media']['fields']['max_file_uploads']    = array(
+				'label' => __( 'Max number of files allowed' ),
+				'value' => $max_file_uploads,
+			);
+		}
+
 		// If Imagick is used as our editor, provide some more information about its limitations.
 		if ( 'WP_Image_Editor_Imagick' === _wp_image_editor_choose() && isset( $imagick ) && $imagick instanceof Imagick ) {
 			$limits = array(

--- a/src/wp-admin/includes/class-wp-debug-data.php
+++ b/src/wp-admin/includes/class-wp-debug-data.php
@@ -534,7 +534,7 @@ class WP_Debug_Data {
 			$post_max_size    = ini_get( 'post_max_size' );
 			$upload_max_size  = ini_get( 'upload_max_filesize' );
 			$max_file_uploads = ini_get( 'max_file_uploads' );
-			$effective        = min( $post_max_size, $upload_max_size );
+			$effective        = min( WP_Site_Health::parse_ini_size( $post_max_size ), WP_Site_Health::parse_ini_size( $upload_max_size ) );
 			// Add info in Media section.
 			$info['wp-media']['fields']['file_uploads']        = array(
 				'label' => __( 'File uploads' ),
@@ -551,11 +551,11 @@ class WP_Debug_Data {
 			);
 			$info['wp-media']['fields']['upload_max']          = array(
 				'label' => __( 'Max effective file size' ),
-				'value' => $effective,
+				'value' => size_format( $effective ),
 			);
 			$info['wp-media']['fields']['max_file_uploads']    = array(
 				'label' => __( 'Max number of files allowed' ),
-				'value' => $max_file_uploads,
+				'value' => number_format( $max_file_uploads ),
 			);
 		}
 

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -2445,7 +2445,7 @@ class WP_Site_Health {
 	 * @param  string $size_string Shorthand byte string
 	 * @return int                 `$size_string` converted to bytes.
 	 */
-	private function parse_ini_size( $size_string ) {
+	public static function parse_ini_size( $size_string ) {
 		$size_string = trim( $size_string );
 		$last        = strtolower( substr( $size_string, - 1 ) );
 		$value       = intval( $size_string );

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -1999,7 +1999,7 @@ class WP_Site_Health {
 
 		if ( $this->parse_ini_size( ini_get( 'post_max_size' ) ) !== $this->parse_ini_size( ini_get( 'upload_max_filesize' ) ) ) {
 			$result['label']       = __( 'Mismatched "post_max_size" and "upload_max_filesize" values.' );
-			$result['status']      = 'critical';
+			$result['status']      = 'recommended';
 			$result['description'] = sprintf(
 				'<p>%s</p>',
 				__( 'Mismatched values for PHP INI directives <code>post_max_size</code> and <code>upload_max_filesize</code> may cause problems. These values are in PHP INI.' )


### PR DESCRIPTION
This PR does a few things.

1. Display `file_uploads`, `post_max_size`, `upload_max_filesize`, `upload_max`, and `max_file_uploads` in **Media Handling** section in Site Health > Debug tab.
<img width="1680" alt="Screen Shot 2020-06-26 at 10 13 30 PM" src="https://user-images.githubusercontent.com/5747475/85866918-bd11f880-b7fa-11ea-959d-4b776c346365.png">

2. Display a "Recommended" notice in Site Health Status page for mismatch `post_max_size` and `upload_max_filesize`.
<img width="1680" alt="Screen Shot 2020-06-26 at 10 18 17 PM" src="https://user-images.githubusercontent.com/5747475/85867171-124e0a00-b7fb-11ea-8a53-44832e1ff775.png">

3. Display a "Critical" notice in Site Health Status page if `file_uploads` is off.
<img width="1680" alt="Screen Shot 2020-06-26 at 10 21 12 PM" src="https://user-images.githubusercontent.com/5747475/85867432-7a045500-b7fb-11ea-92bb-67dcc5489e8a.png">

Trac ticket: https://core.trac.wordpress.org/ticket/50038

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
