### PR TITLE
Add initial modern color scheme work.

### DIFF
--- a/src/wp-admin/css/colors/modern/colors.scss
+++ b/src/wp-admin/css/colors/modern/colors.scss
@@ -1,0 +1,17 @@
+$base-color: #1e1e1e;
+$highlight-color: #3858e9;
+$notification-color: #e26f56;
+$menu-submenu-focus-text: #33f078;
+
+@import "../_admin.scss";
+
+// Customize block editor colors.
+:root {
+	--wp-admin-theme-color: #3858e9;
+	--wp-admin-theme-color-darker-10: #1D35B4;
+	--wp-admin-theme-color-darker-20: #152A9C;
+}
+
+#adminmenu .wp-submenu, #adminmenu .wp-has-current-submenu .wp-submenu, #adminmenu .wp-has-current-submenu.opensub .wp-submenu, .folded #adminmenu .wp-has-current-submenu .wp-submenu, #adminmenu a.wp-has-current-submenu:focus + .wp-submenu {
+	padding-bottom: 12px;
+}

--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -932,6 +932,7 @@ function admin_color_scheme_picker( $user_id ) {
 				array(
 					'fresh' => '',
 					'light' => '',
+					'modern' => '',
 				),
 				$_wp_admin_css_colors
 			)

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -4338,6 +4338,18 @@ function register_admin_color_schemes() {
 	}
 
 	wp_admin_css_color(
+		'modern',
+		_x( 'Modern', 'admin color scheme' ),
+		admin_url( "css/colors/modern/colors$suffix.css" ),
+		array( '#1e1e1e', '#3858e9', '#e26f56' ),
+		array(
+			'base'    => '#1e1e1e',
+			'focus'   => '#3858e9',
+			'current' => '#e26f56',
+		)
+	);
+
+	wp_admin_css_color(
 		'light',
 		_x( 'Light', 'admin color scheme' ),
 		admin_url( "css/colors/light/colors$suffix.css" ),


### PR DESCRIPTION
This PR adds a new color scheme option, which uses a high luminosity blue spot color, almost-black menu, and pure white for menu items. This helps increase contrast, and bring more consistency with some of the higher contrast colors used in the block editor. 

Trac ticket: https://core.trac.wordpress.org/ticket/50504

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
