### PR TITLE
Add modern color scheme.

### DIFF
--- a/src/wp-admin/css/colors/modern/colors.scss
+++ b/src/wp-admin/css/colors/modern/colors.scss
@@ -1,0 +1,10 @@
+$base-color: #1e1e1e;
+$highlight-color: #3858e9;
+$notification-color: #e26f56;
+$menu-submenu-focus-text: #33f078;
+
+@import "../_admin.scss";
+
+#adminmenu .wp-submenu, #adminmenu .wp-has-current-submenu .wp-submenu, #adminmenu .wp-has-current-submenu.opensub .wp-submenu, .folded #adminmenu .wp-has-current-submenu .wp-submenu, #adminmenu a.wp-has-current-submenu:focus + .wp-submenu {
+	padding-bottom: 12px;
+}

--- a/src/wp-admin/css/colors/modern/colors.scss
+++ b/src/wp-admin/css/colors/modern/colors.scss
@@ -1,7 +1,7 @@
 $base-color: #1e1e1e;
 $highlight-color: #3858e9;
 $menu-submenu-focus-text: #33f078;
-$notification-color: #e26f56;
+$notification-color: $highlight-color;
 
 $link: $highlight-color;
 $link-focus: darken($highlight-color, 10%);

--- a/src/wp-admin/css/colors/modern/colors.scss
+++ b/src/wp-admin/css/colors/modern/colors.scss
@@ -1,7 +1,11 @@
 $base-color: #1e1e1e;
 $highlight-color: #3858e9;
-$notification-color: #e26f56;
 $menu-submenu-focus-text: #33f078;
+$notification-color: #e26f56;
+
+$link: $highlight-color;
+$link-focus: darken($highlight-color, 10%);
+
 
 @import "../_admin.scss";
 

--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -932,6 +932,7 @@ function admin_color_scheme_picker( $user_id ) {
 				array(
 					'fresh' => '',
 					'light' => '',
+					'modern' => '',
 				),
 				$_wp_admin_css_colors
 			)

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -4366,6 +4366,18 @@ function register_admin_color_schemes() {
 	);
 
 	wp_admin_css_color(
+		'modern',
+		_x( 'Modern', 'admin color scheme' ),
+		admin_url( "css/colors/modern/colors$suffix.css" ),
+		array( '#1e1e1e', '#3858e9', '#e26f56' ),
+		array(
+			'base'    => '#1e1e1e',
+			'focus'   => '#3858e9',
+			'current' => '#e26f56',
+		)
+	);
+
+	wp_admin_css_color(
 		'blue',
 		_x( 'Blue', 'admin color scheme' ),
 		admin_url( "css/colors/blue/colors$suffix.css" ),


### PR DESCRIPTION
Alternative to https://github.com/WordPress/wordpress-develop/pull/368.

This PR adds a new color scheme option, which uses a high luminosity blue spot color, almost-black menu, and pure white for menu items. This helps increase contrast, and bring more consistency with some of the higher contrast colors used in the block editor.

Note that this version of the PR addresses feedback in https://github.com/WordPress/wordpress-develop/pull/368#pullrequestreview-439046195, and omits styling of the block editor in favor of a separate block editor PR happening to handle that. 

Trac ticket: https://core.trac.wordpress.org/ticket/50504

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
