### PR TITLE
make_clickable nested links bug

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2982,7 +2982,7 @@ function make_clickable( $text ) {
 	}
 
 	// Cleanup of accidental links within links.
-	return preg_replace( '#(<a([ \r\n\t]+[^>]+?>|>))<a [^>]+?>([^>]+?)</a></a>#i', '$1$3</a>', $r );
+	return preg_replace( '#(<a([ \r\n\t]+[^>]+?>|>))(.+)?<a [^>]+?>([^>]+?)</a>(.+)?</a>#is', '$1$3$4$5</a>', $r );
 }
 
 /**


### PR DESCRIPTION
Fixes a `make_clickable` nested links potential bug, as the function cleans up any accidental links it fails to catch all accidental links.

More details in the trac ticket.

Trac ticket: https://core.trac.wordpress.org/ticket/50514

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
