### PR TITLE
Blocks Context: Confirm  is a WP_Post object

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -685,7 +685,7 @@ function render_block( $parsed_block ) {
 
 	$context = array();
 
-	if ( ! empty( $post ) ) {
+	if ( $post instanceof WP_Post ) {
 		$context['postId'] = $post->ID;
 
 		/*


### PR DESCRIPTION
Confirm `$post` is a `WP_Post` object.

Trac ticket: https://core.trac.wordpress.org/ticket/49927