### PR TITLE
Fix: standardize comments pre query filter

### DIFF
--- a/src/wp-includes/class-wp-comment-query.php
+++ b/src/wp-includes/class-wp-comment-query.php
@@ -379,7 +379,7 @@ class WP_Comment_Query {
 			$this->meta_query_clauses = $this->meta_query->get_sql( 'comment', $wpdb->comments, 'comment_ID', $this );
 		}
 
-		$this->comments = null;
+		$comment_data = null;
 
 		/**
 		 * Filter the comments data before the query takes place.
@@ -388,19 +388,20 @@ class WP_Comment_Query {
 		 *
 		 * The expected return type from this filter depends on the value passed in the request query_vars.
 		 * When `$this->query_vars['count']` is set, the filter should return the comment count as an int.
-		 * When `'ids' == $this->query_vars['fields']`, the filter should return an array of comment ids.
+		 * When `'ids' === $this->query_vars['fields']`, the filter should return an array of comment IDs.
 		 * Otherwise the filter should return an array of WP_Comment objects.
 		 *
 		 * @since 5.3.0
 		 *
-		 * @param array|int|null   $comments Return an array of comment data to short-circuit WP's comment query,
-		 *                                   the comment count as an integer if `$this->query_vars['count']` is set,
-		 *                                   or null to allow WP to run its normal queries.
-		 * @param WP_Comment_Query $this     The WP_Comment_Query instance, passed by reference.
+		 * @param array|int|null   $comment_data Return an array of comment data to short-circuit WP's comment query,
+		 *                                       the comment count as an integer if `$this->query_vars['count']` is set,
+		 *                                       or null to allow WP to run its normal queries.
+		 * @param WP_Comment_Query $this         The WP_Comment_Query instance, passed by reference.
 		 */
-		$this->comments = apply_filters_ref_array( 'comments_pre_query', array( $this->comments, &$this ) );
+		$comment_data = apply_filters_ref_array( 'comments_pre_query', array( $comment_data, &$this ) );
 
-		if ( null !== $this->comments ) {
+		if ( null !== $comment_data ) {
+			$this->comments = $comment_data;
 			return $this->comments;
 		}
 

--- a/src/wp-includes/class-wp-comment-query.php
+++ b/src/wp-includes/class-wp-comment-query.php
@@ -403,7 +403,7 @@ class WP_Comment_Query {
 		$comment_data = apply_filters_ref_array( 'comments_pre_query', array( $comment_data, &$this ) );
 
 		if ( null !== $comment_data ) {
-			if ( is_array( $comment_data ) && empty( $this->query_vars['count'] ) ) {
+			if ( is_array( $comment_data ) && ! $this->query_vars['count'] ) {
 				$this->comments = $comment_data;
 			}
 			return $comment_data;

--- a/src/wp-includes/class-wp-comment-query.php
+++ b/src/wp-includes/class-wp-comment-query.php
@@ -403,7 +403,7 @@ class WP_Comment_Query {
 		$comment_data = apply_filters_ref_array( 'comments_pre_query', array( $comment_data, &$this ) );
 
 		if ( null !== $comment_data ) {
-			if ( is_array( $comment_data ) ) {
+			if ( is_array( $comment_data ) && empty( $this->query_vars['count'] ) ) {
 				$this->comments = $comment_data;
 			}
 			return $comment_data;

--- a/src/wp-includes/class-wp-comment-query.php
+++ b/src/wp-includes/class-wp-comment-query.php
@@ -379,7 +379,7 @@ class WP_Comment_Query {
 			$this->meta_query_clauses = $this->meta_query->get_sql( 'comment', $wpdb->comments, 'comment_ID', $this );
 		}
 
-		$comment_data = null;
+		$this->comments = null;
 
 		/**
 		 * Filter the comments data before the query takes place.
@@ -388,20 +388,20 @@ class WP_Comment_Query {
 		 *
 		 * The expected return type from this filter depends on the value passed in the request query_vars.
 		 * When `$this->query_vars['count']` is set, the filter should return the comment count as an int.
-		 * When `'ids' === $this->query_vars['fields']`, the filter should return an array of comment IDs.
+		 * When `'ids' == $this->query_vars['fields']`, the filter should return an array of comment ids.
 		 * Otherwise the filter should return an array of WP_Comment objects.
 		 *
 		 * @since 5.3.0
 		 *
-		 * @param array|int|null   $comment_data Return an array of comment data to short-circuit WP's comment query,
-		 *                                       the comment count as an integer if `$this->query_vars['count']` is set,
-		 *                                       or null to allow WP to run its normal queries.
-		 * @param WP_Comment_Query $this         The WP_Comment_Query instance, passed by reference.
+		 * @param array|int|null   $comments Return an array of comment data to short-circuit WP's comment query,
+		 *                                   the comment count as an integer if `$this->query_vars['count']` is set,
+		 *                                   or null to allow WP to run its normal queries.
+		 * @param WP_Comment_Query $this     The WP_Comment_Query instance, passed by reference.
 		 */
-		$comment_data = apply_filters_ref_array( 'comments_pre_query', array( $comment_data, &$this ) );
+		$this->comments = apply_filters_ref_array( 'comments_pre_query', array( $this->comments, &$this ) );
 
-		if ( null !== $comment_data ) {
-			return $comment_data;
+		if ( null !== $this->comments ) {
+			return $this->comments;
 		}
 
 		/*

--- a/src/wp-includes/class-wp-comment-query.php
+++ b/src/wp-includes/class-wp-comment-query.php
@@ -390,6 +390,8 @@ class WP_Comment_Query {
 		 * When `$this->query_vars['count']` is set, the filter should return the comment count as an int.
 		 * When `'ids' === $this->query_vars['fields']`, the filter should return an array of comment IDs.
 		 * Otherwise the filter should return an array of WP_Comment objects.
+		 * Note that if the filter return an array, that array will be assigned to the comments property of
+		 * the current WP_Comment_Query instance.
 		 *
 		 * @since 5.3.0
 		 *
@@ -401,8 +403,10 @@ class WP_Comment_Query {
 		$comment_data = apply_filters_ref_array( 'comments_pre_query', array( $comment_data, &$this ) );
 
 		if ( null !== $comment_data ) {
-			$this->comments = $comment_data;
-			return $this->comments;
+			if ( is_array( $comment_data ) ) {
+				$this->comments = $comment_data;
+			}
+			return $comment_data;
 		}
 
 		/*


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

This PR checks and assigns the value of filtered comment data returned from `comments_pre_query` to `WP_Comment_Query::$comments` before short-curcuiting.

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->
https://core.trac.wordpress.org/ticket/50521

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
