### PR TITLE
Modern Color Scheme: Fix SVG icon colors

### DIFF
--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -4380,9 +4380,9 @@ function register_admin_color_schemes() {
 		admin_url( "css/colors/modern/colors$suffix.css" ),
 		array( '#1e1e1e', '#3858e9', '#e26f56' ),
 		array(
-			'base'    => '#1e1e1e',
-			'focus'   => '#3858e9',
-			'current' => '#e26f56',
+			'base'    => '#f3f1f1',
+			'focus'   => '#fff',
+			'current' => '#fff',
 		)
 	);
 

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -4378,7 +4378,7 @@ function register_admin_color_schemes() {
 		'modern',
 		_x( 'Modern', 'admin color scheme' ),
 		admin_url( "css/colors/modern/colors$suffix.css" ),
-		array( '#1e1e1e', '#3858e9', '#e26f56' ),
+		array( '#1e1e1e', '#3858e9', '#33f078' ),
 		array(
 			'base'    => '#f3f1f1',
 			'focus'   => '#fff',


### PR DESCRIPTION
See ticket for before screenshots. After:

![Screen Shot 2020-07-03 at 7 30 20 PM](https://user-images.githubusercontent.com/541093/86501066-a4a65e80-bd63-11ea-8d17-a2cff0cac973.png)
![Screen Shot 2020-07-03 at 7 11 54 PM](https://user-images.githubusercontent.com/541093/86501068-a96b1280-bd63-11ea-97e9-9f6531f08398.png)

This also updates the color scheme preview to use the green color instead of the salmon color, since that ended up being removed from the scheme. Happy to remove that commit from this PR if it's not needed.

![Screen Shot 2020-07-03 at 7 13 01 PM](https://user-images.githubusercontent.com/541093/86501090-cef81c00-bd63-11ea-9b5b-d70230dc194b.png)

Trac ticket: https://core.trac.wordpress.org/ticket/50555

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
