### PR TITLE
REST API: Update post search handler to use rest_get_route_for_post()

### DIFF
--- a/src/wp-includes/rest-api/search/class-wp-rest-post-search-handler.php
+++ b/src/wp-includes/rest-api/search/class-wp-rest-post-search-handler.php
@@ -148,7 +148,7 @@ class WP_REST_Post_Search_Handler extends WP_REST_Search_Handler {
 
 		$links = array();
 
-		$item_route = $this->detect_rest_item_route( $post );
+		$item_route = rest_get_route_for_post( $post );
 		if ( ! empty( $item_route ) ) {
 			$links['self'] = array(
 				'href'       => rest_url( $item_route ),
@@ -189,8 +189,8 @@ class WP_REST_Post_Search_Handler extends WP_REST_Search_Handler {
 	 * @return string REST route relative to the REST base URI, or empty string if unknown.
 	 */
 	protected function detect_rest_item_route( $post ) {
-
 		_deprecated_function( __METHOD__, '5.5.0', 'rest_get_route_for_post()' );
+
 		return rest_get_route_for_post( $post );
 	}
 

--- a/src/wp-includes/rest-api/search/class-wp-rest-post-search-handler.php
+++ b/src/wp-includes/rest-api/search/class-wp-rest-post-search-handler.php
@@ -190,7 +190,7 @@ class WP_REST_Post_Search_Handler extends WP_REST_Search_Handler {
 	 */
 	protected function detect_rest_item_route( $post ) {
 
-		_deprecated_function( __FUNCTION__, '5.5.0', 'wp_set_current_user()' );
+		_deprecated_function( __METHOD__, '5.5.0', 'rest_get_route_for_post()' );
 		return rest_get_route_for_post( $post );
 	}
 

--- a/src/wp-includes/rest-api/search/class-wp-rest-post-search-handler.php
+++ b/src/wp-includes/rest-api/search/class-wp-rest-post-search-handler.php
@@ -182,25 +182,16 @@ class WP_REST_Post_Search_Handler extends WP_REST_Search_Handler {
 	 * Attempts to detect the route to access a single item.
 	 *
 	 * @since 5.0.0
+	 * @deprecated 5.5.0 Use rest_get_route_for_post()
+	 * @see rest_get_route_for_post()
 	 *
 	 * @param WP_Post $post Post object.
 	 * @return string REST route relative to the REST base URI, or empty string if unknown.
 	 */
 	protected function detect_rest_item_route( $post ) {
-		$post_type = get_post_type_object( $post->post_type );
-		if ( ! $post_type ) {
-			return '';
-		}
 
-		// It's currently impossible to detect the REST URL from a custom controller.
-		if ( ! empty( $post_type->rest_controller_class ) && 'WP_REST_Posts_Controller' !== $post_type->rest_controller_class ) {
-			return '';
-		}
-
-		$namespace = 'wp/v2';
-		$rest_base = ! empty( $post_type->rest_base ) ? $post_type->rest_base : $post_type->name;
-
-		return sprintf( '%s/%s/%d', $namespace, $rest_base, $post->ID );
+		_deprecated_function( __FUNCTION__, '5.5.0', 'wp_set_current_user()' );
+		return rest_get_route_for_post( $post );
 	}
 
 }


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/50529