### PR TITLE
REST API: Media edit - Load remote image if local not present

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -460,7 +460,15 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			);
 		}
 
-		$image_editor = wp_get_image_editor( $image_file );
+		// If the file doesn't exist, attempt a URL fopen on the src link.
+		// This can occur with certain file replication plugins.
+		// Keep the original file path to get a modified name later.
+		$image_file_to_edit = $image_file;
+		if ( ! file_exists( $image_file_to_edit ) ) {
+			$image_file_to_edit = _load_image_to_edit_path( $attachment_id );
+		}
+
+		$image_editor = wp_get_image_editor( $image_file_to_edit );
 
 		if ( is_wp_error( $image_editor ) ) {
 			return new WP_Error(


### PR DESCRIPTION
The media edit endpoint introduced in https://core.trac.wordpress.org/changeset/48291 fails to find files that are not on the local file system, for example when using some file replication plugins.

Use `_load_image_to_edit_path` to find remote images.

This is very similar to the approach currently in use in several places already, e.g.
https://core.trac.wordpress.org/browser/trunk/src/wp-admin/includes/image.php?rev=47461#L33

This fixes the issue described in https://github.com/WordPress/gutenberg/issues/23686.

Trac ticket: https://core.trac.wordpress.org/ticket/50595

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
