### PR TITLE
Rename `$new_whitelist_options`

### DIFF
--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -2168,16 +2168,16 @@ function user_can_access_admin_page() {
  *
  * @since 2.7.0
  *
- * @global array $new_whitelist_options
+ * @global array $new_allowed_options
  *
  * @param array $options
  * @return array
  */
 function option_update_filter( $options ) {
-	global $new_whitelist_options;
+	global $new_allowed_options;
 
-	if ( is_array( $new_whitelist_options ) ) {
-		$options = add_allowed_options( $new_whitelist_options, $options );
+	if ( is_array( $new_allowed_options ) ) {
+		$options = add_allowed_options( $new_allowed_options, $options );
 	}
 
 	return $options;

--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -2167,6 +2167,8 @@ function user_can_access_admin_page() {
  * See the {@see 'allowed_options'} filter.
  *
  * @since 2.7.0
+ * @since 5.5.0 `$new_whiltelist_options` was renamed to `$new_allowed_options`.
+ *              Please consider writing more inclusive code.
  *
  * @global array $new_allowed_options
  *

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -2124,7 +2124,7 @@ function register_initial_settings() {
  * @since 2.7.0
  * @since 4.7.0 `$args` can be passed to set flags on the setting, similar to `register_meta()`.
  *
- * @global array $new_whitelist_options
+ * @global array $new_allowed_options
  * @global array $wp_registered_settings
  *
  * @param string $option_group A settings group name. Should correspond to an allowed option key name.
@@ -2145,7 +2145,13 @@ function register_initial_settings() {
  * }
  */
 function register_setting( $option_group, $option_name, $args = array() ) {
-	global $new_whitelist_options, $wp_registered_settings;
+	global $new_allowed_options, $wp_registered_settings;
+
+	/**
+	 * In 5.5.0, the `$new_whitelist_options` global variable has been renamed to `$new_allowlist_options`.
+	 * Please consider writing more inclusive code.
+	 */
+	$GLOBALS['new_whitelist_options'] = &$new_allowlist_options;
 
 	$defaults = array(
 		'type'              => 'string',
@@ -2211,7 +2217,7 @@ function register_setting( $option_group, $option_name, $args = array() ) {
 		$option_group = 'reading';
 	}
 
-	$new_whitelist_options[ $option_group ][] = $option_name;
+	$new_allowed_options[ $option_group ][] = $option_name;
 
 	if ( ! empty( $args['sanitize_callback'] ) ) {
 		add_filter( "sanitize_option_{$option_name}", $args['sanitize_callback'] );
@@ -2240,7 +2246,7 @@ function register_setting( $option_group, $option_name, $args = array() ) {
  * @since 2.7.0
  * @since 4.7.0 `$sanitize_callback` was deprecated. The callback from `register_setting()` is now used instead.
  *
- * @global array $new_whitelist_options
+ * @global array $new_allowed_options
  * @global array $wp_registered_settings
  *
  * @param string   $option_group The settings group name used during registration.
@@ -2248,7 +2254,13 @@ function register_setting( $option_group, $option_name, $args = array() ) {
  * @param callable $deprecated   Deprecated.
  */
 function unregister_setting( $option_group, $option_name, $deprecated = '' ) {
-	global $new_whitelist_options, $wp_registered_settings;
+	global $new_allowlist_options, $wp_registered_settings;
+
+	/**
+	 * In 5.5.0, the `$new_whitelist_options` global variable has been renamed to `$new_allowlist_options`.
+	 * Please consider writing more inclusive code.
+	 */
+	$GLOBALS['new_whitelist_options'] = &$new_allowlist_options;
 
 	if ( 'misc' === $option_group ) {
 		_deprecated_argument(
@@ -2276,10 +2288,10 @@ function unregister_setting( $option_group, $option_name, $deprecated = '' ) {
 		$option_group = 'reading';
 	}
 
-	$pos = array_search( $option_name, (array) $new_whitelist_options[ $option_group ], true );
+	$pos = array_search( $option_name, (array) $new_allowed_options[ $option_group ], true );
 
 	if ( false !== $pos ) {
-		unset( $new_whitelist_options[ $option_group ][ $pos ] );
+		unset( $new_allowlist_options[ $option_group ][ $pos ] );
 	}
 
 	if ( '' !== $deprecated ) {

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -2123,6 +2123,8 @@ function register_initial_settings() {
  *
  * @since 2.7.0
  * @since 4.7.0 `$args` can be passed to set flags on the setting, similar to `register_meta()`.
+ * @since 5.5.0 `$new_whiltelist_options` was renamed to `$new_allowed_options`.
+ *              Please consider writing more inclusive code.
  *
  * @global array $new_allowed_options
  * @global array $wp_registered_settings
@@ -2148,10 +2150,10 @@ function register_setting( $option_group, $option_name, $args = array() ) {
 	global $new_allowed_options, $wp_registered_settings;
 
 	/**
-	 * In 5.5.0, the `$new_whitelist_options` global variable has been renamed to `$new_allowlist_options`.
+	 * In 5.5.0, the `$new_whitelist_options` global variable has been renamed to `$new_allowed_options`.
 	 * Please consider writing more inclusive code.
 	 */
-	$GLOBALS['new_whitelist_options'] = &$new_allowlist_options;
+	$GLOBALS['new_whitelist_options'] = &$new_allowed_options;
 
 	$defaults = array(
 		'type'              => 'string',
@@ -2245,6 +2247,8 @@ function register_setting( $option_group, $option_name, $args = array() ) {
  *
  * @since 2.7.0
  * @since 4.7.0 `$sanitize_callback` was deprecated. The callback from `register_setting()` is now used instead.
+ * @since 5.5.0 `$new_whiltelist_options` was renamed to `$new_allowed_options`.
+ *              Please consider writing more inclusive code.
  *
  * @global array $new_allowed_options
  * @global array $wp_registered_settings
@@ -2254,13 +2258,13 @@ function register_setting( $option_group, $option_name, $args = array() ) {
  * @param callable $deprecated   Deprecated.
  */
 function unregister_setting( $option_group, $option_name, $deprecated = '' ) {
-	global $new_allowlist_options, $wp_registered_settings;
+	global $new_allowed_options, $wp_registered_settings;
 
 	/**
-	 * In 5.5.0, the `$new_whitelist_options` global variable has been renamed to `$new_allowlist_options`.
+	 * In 5.5.0, the `$new_whitelist_options` global variable has been renamed to `$new_allowed_options`.
 	 * Please consider writing more inclusive code.
 	 */
-	$GLOBALS['new_whitelist_options'] = &$new_allowlist_options;
+	$GLOBALS['new_whitelist_options'] = &$new_allowed_options;
 
 	if ( 'misc' === $option_group ) {
 		_deprecated_argument(
@@ -2291,7 +2295,7 @@ function unregister_setting( $option_group, $option_name, $deprecated = '' ) {
 	$pos = array_search( $option_name, (array) $new_allowed_options[ $option_group ], true );
 
 	if ( false !== $pos ) {
-		unset( $new_allowlist_options[ $option_group ][ $pos ] );
+		unset( $new_allowed_options[ $option_group ][ $pos ] );
 	}
 
 	if ( '' !== $deprecated ) {


### PR DESCRIPTION
Deprecate the old `$new_whitelist_options` variable in favor of `$new_allowed_options` and pass by reference.

Trac ticket: https://core.trac.wordpress.org/ticket/50434

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
