### PR TITLE
Trac/50653 Replace _doing_it_wrong() with WP_Error as return

### DIFF
--- a/src/wp-includes/class-wp-block-patterns-registry.php
+++ b/src/wp-includes/class-wp-block-patterns-registry.php
@@ -35,22 +35,19 @@ final class WP_Block_Patterns_Registry {
 	 * @param string $pattern_name       Pattern name including namespace.
 	 * @param array  $pattern_properties Array containing the properties of the pattern: title,
 	 *                                   content, description, viewportWidth, categories, keywords.
-	 * @return bool True if the pattern was registered with success and false otherwise.
+	 * @return bool|WP_Error True if the pattern was registered with success and WP_Error otherwise.
 	 */
 	public function register( $pattern_name, $pattern_properties ) {
 		if ( ! isset( $pattern_name ) || ! is_string( $pattern_name ) ) {
-			_doing_it_wrong( __METHOD__, __( 'Pattern name must be a string.' ), '5.5.0' );
-			return false;
+			return new WP_Error( 'block_patterns_registry_' . __METHOD__, __( 'Pattern name must be a string.' ) );
 		}
 
 		if ( ! isset( $pattern_properties['title'] ) || ! is_string( $pattern_properties['title'] ) ) {
-			_doing_it_wrong( __METHOD__, __( 'Pattern title must be a string.' ), '5.5.0' );
-			return false;
+			return new WP_Error( 'block_patterns_registry_' . __METHOD__, __( 'Pattern title must be a string.' ) );
 		}
 
 		if ( ! isset( $pattern_properties['content'] ) || ! is_string( $pattern_properties['content'] ) ) {
-			_doing_it_wrong( __METHOD__, __( 'Pattern content must be a string.' ), '5.5.0' );
-			return false;
+			return new WP_Error( 'block_patterns_registry_' . __METHOD__, __( 'Pattern content must be a string.' ) );
 		}
 
 		$this->registered_patterns[ $pattern_name ] = array_merge(
@@ -67,14 +64,13 @@ final class WP_Block_Patterns_Registry {
 	 * @since 5.5.0
 	 *
 	 * @param string $pattern_name Pattern name including namespace.
-	 * @return bool True if the pattern was unregistered with success and false otherwise.
+	 * @return bool|WP_Error True if the pattern was unregistered with success and WP_Error otherwise.
 	 */
 	public function unregister( $pattern_name ) {
 		if ( ! $this->is_registered( $pattern_name ) ) {
 			/* translators: 1: Pattern name. */
 			$message = sprintf( __( 'Pattern "%1$s" not found.' ), $pattern_name );
-			_doing_it_wrong( __METHOD__, $message, '5.5.0' );
-			return false;
+			return new WP_Error( 'block_patterns_registry_' . __METHOD__, $message );
 		}
 
 		unset( $this->registered_patterns[ $pattern_name ] );


### PR DESCRIPTION
Remove `_doing_it_wrong()` in `WP_Block_Patterns_Registry::register()` and `WP_Block_Patterns_Registry::unregister()` and return `WP_Error` instead of `false` when used with incorrect data.

Trac ticket: https://core.trac.wordpress.org/ticket/50653

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
