### PR TITLE
Return 404 without permalink flush to sitemap url if sitemap is disabled

### DIFF
--- a/src/wp-includes/sitemaps.php
+++ b/src/wp-includes/sitemaps.php
@@ -17,25 +17,12 @@
  *
  * @global WP_Sitemaps $wp_sitemaps Global Core Sitemaps instance.
  *
- * @return WP_Sitemaps|null Sitemaps instance, or null if sitemaps are disabled.
+ * @return WP_Sitemaps Sitemaps instance.
  */
 function wp_sitemaps_get_server() {
 	global $wp_sitemaps;
 
 	$is_enabled = (bool) get_option( 'blog_public' );
-
-	/**
-	 * Filters whether XML Sitemaps are enabled or not.
-	 *
-	 * @since 5.5.0
-	 *
-	 * @param bool $is_enabled Whether XML Sitemaps are enabled or not. Defaults to true for public sites.
-	 */
-	$is_enabled = (bool) apply_filters( 'wp_sitemaps_enabled', $is_enabled );
-
-	if ( ! $is_enabled ) {
-		return null;
-	}
 
 	// If there isn't a global instance, set and bootstrap the sitemaps system.
 	if ( empty( $wp_sitemaps ) ) {

--- a/src/wp-includes/sitemaps/class-wp-sitemaps.php
+++ b/src/wp-includes/sitemaps/class-wp-sitemaps.php
@@ -56,17 +56,46 @@ class WP_Sitemaps {
 	/**
 	 * Initiates all sitemap functionality.
 	 *
+	 * If sitemaps are disabled, only the rewrite rules will be registered
+	 * by this method, in order to properly send 404s.
+	 *
 	 * @since 5.5.0
 	 */
 	public function init() {
 		// These will all fire on the init hook.
 		$this->register_rewrites();
+
+		add_action( 'template_redirect', array( $this, 'render_sitemaps' ) );
+
+		if ( ! $this->sitemaps_enabled() ) {
+			return;
+		}
+
 		$this->register_sitemaps();
 
 		// Add additional action callbacks.
-		add_action( 'template_redirect', array( $this, 'render_sitemaps' ) );
 		add_filter( 'pre_handle_404', array( $this, 'redirect_sitemapxml' ), 10, 2 );
 		add_filter( 'robots_txt', array( $this, 'add_robots' ), 0, 2 );
+	}
+
+	/**
+	 * Determines whether sitemaps are enabled or not.
+	 *
+	 * @since 5.5.0
+	 *
+	 * @return bool Whether sitemaps are enabled.
+	 */
+	public function sitemaps_enabled() {
+		$is_enabled = (bool) get_option( 'blog_public' );
+
+		/**
+		 * Filters whether XML Sitemaps are enabled or not.
+		 *
+		 * @since 5.5.0
+		 *
+		 * @param bool $is_enabled Whether XML Sitemaps are enabled or not. Defaults to true for public sites.
+		 */
+		return (bool) apply_filters( 'wp_sitemaps_enabled', $is_enabled );
 	}
 
 	/**
@@ -155,6 +184,12 @@ class WP_Sitemaps {
 			return;
 		}
 
+		if ( ! $this->sitemaps_enabled() ) {
+			$wp_query->set_404();
+			status_header( 404 );
+			return;
+		}
+
 		// Render stylesheet if this is stylesheet route.
 		if ( $stylesheet_type ) {
 			$stylesheet = new WP_Sitemaps_Stylesheet();
@@ -186,6 +221,7 @@ class WP_Sitemaps {
 		// Force a 404 and bail early if no URLs are present.
 		if ( empty( $url_list ) ) {
 			$wp_query->set_404();
+			status_header( 404 );
 			return;
 		}
 

--- a/tests/phpunit/tests/sitemaps/sitemaps.php
+++ b/tests/phpunit/tests/sitemaps/sitemaps.php
@@ -444,4 +444,22 @@ class Test_Sitemaps extends WP_UnitTestCase {
 
 		$this->assertContains( $sitemap_string, $robots_text, 'Sitemap URL not prefixed with "\n".' );
 	}
+
+	/**
+	 * @ticket 50643
+	 */
+	public function test_disable_sitemap_should_return_404() {
+		// Disable sitemap.
+		add_filter( 'wp_sitemaps_enabled', '__return_false' );
+
+		// Setup $wp_query vars.
+		$this->set_permalink_structure( '/%postname%/' );
+		$this->go_to( home_url( '/wp-sitemap.xml' ) );
+
+		// Trigger 'template_redirect' action to invoke WP_Sitemaps::render_sitemaps().
+		do_action( 'template_redirect' );
+
+		// Disabling the sitemap should return to 404.
+		$this->assertTrue( is_404() );
+	}
 }


### PR DESCRIPTION
Return 404 on sitemap page without the need to flush permalinks. This PR is based on swissspidy's patch. I just added a unit test.

Trac ticket: https://core.trac.wordpress.org/ticket/50643

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
