### PR TITLE
Editor: Add block directory styles to script-loader

### DIFF
--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -361,14 +361,13 @@ wp_enqueue_media(
 );
 wp_tinymce_inline_scripts();
 wp_enqueue_editor();
-wp_enqueue_script( 'wp-block-directory' );
+
 
 /**
  * Styles
  */
 wp_enqueue_style( 'wp-edit-post' );
 wp_enqueue_style( 'wp-format-library' );
-wp_enqueue_style( 'wp-block-directory' );
 
 /**
  * Fires after block assets have been enqueued for the editing interface.

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -515,6 +515,7 @@ add_filter( 'print_scripts_array', 'wp_prototype_before_jquery' );
 add_filter( 'customize_controls_print_styles', 'wp_resource_hints', 1 );
 add_action( 'enqueue_block_assets', 'enqueue_block_styles_assets', 30 );
 add_action( 'enqueue_block_editor_assets', 'enqueue_editor_block_styles_assets' );
+add_action( 'enqueue_block_editor_assets', 'wp_enqueue_block_editor_assets_block_directory' );
 
 add_action( 'wp_default_styles', 'wp_default_styles' );
 add_filter( 'style_loader_src', 'wp_style_loader_src', 10, 2 );

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1471,7 +1471,6 @@ function wp_default_styles( $styles ) {
 			'wp-editor',
 			'wp-edit-blocks',
 			'wp-block-library',
-			'wp-block-directory',
 			'wp-nux',
 		),
 		'editor'               => array(
@@ -2271,4 +2270,14 @@ function enqueue_editor_block_styles_assets() {
 	wp_register_script( 'wp-block-styles', false, array( 'wp-blocks' ), true, true );
 	wp_add_inline_script( 'wp-block-styles', $inline_script );
 	wp_enqueue_script( 'wp-block-styles' );
+}
+
+/**
+ * Handles enqueuing the block directory script & style.
+ *
+ * @since 5.5.0
+ */
+function wp_enqueue_block_editor_assets_block_directory() {
+	wp_enqueue_script( 'wp-block-directory' );
+	wp_enqueue_style( 'wp-block-directory' );
 }

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1463,6 +1463,7 @@ function wp_default_styles( $styles ) {
 			'wp-editor-font',
 		),
 		'block-library'        => array(),
+		'block-directory'      => array(),
 		'components'           => array(),
 		'edit-post'            => array(
 			'wp-components',
@@ -1470,6 +1471,7 @@ function wp_default_styles( $styles ) {
 			'wp-editor',
 			'wp-edit-blocks',
 			'wp-block-library',
+			'wp-block-directory',
 			'wp-nux',
 		),
 		'editor'               => array(
@@ -1527,6 +1529,7 @@ function wp_default_styles( $styles ) {
 		'wp-edit-blocks',
 		'wp-block-editor',
 		'wp-block-library',
+		'wp-block-directory',
 		'wp-components',
 		'wp-edit-post',
 		'wp-editor',


### PR DESCRIPTION
This adds the block directory styles as a dependency of the `edit-post` style.

Fixed screenshot:

![Screen Shot 2020-07-14 at 1 34 27 PM](https://user-images.githubusercontent.com/541093/87458438-fc508f80-c5d7-11ea-8c06-1f6144d0b206.png)

Trac ticket: https://core.trac.wordpress.org/ticket/50661

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
