### PR TITLE
Add dedicated test for short length

### DIFF
--- a/tests/phpunit/tests/formatting/IsEmail.php
+++ b/tests/phpunit/tests/formatting/IsEmail.php
@@ -4,6 +4,10 @@
  * @group formatting
  */
 class Tests_Formatting_IsEmail extends WP_UnitTestCase {
+	function test_returns_false_if_length_is_less_than_six() {
+		$this->assertFalse( is_email( 'a@b.c' ) );
+	}
+
 	function test_returns_the_email_address_if_it_is_valid() {
 		$data = array(
 			'bob@example.com',


### PR DESCRIPTION
This PR includes a dedicated unit test for `is_email()` for short length string (`< 6`) as per @swissspidy's suggestion 3 yrs ago.

Trac ticket: https://core.trac.wordpress.org/ticket/39133

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
