### PR TITLE
Make media_sideload_image extension list filterable

### DIFF
--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -977,14 +977,25 @@ function wp_media_upload_handler() {
 function media_sideload_image( $file, $post_id = 0, $desc = null, $return = 'html' ) {
 	if ( ! empty( $file ) ) {
 
+		$allowed_extensions = array( 'jpg', 'jpeg', 'jpe', 'png', 'gif' );
+
 		/**
-		 * Filters the file extensions used for media sideload.
+		 * Filters the list of allowed file extensions when sideloading an image from a URL.
 		 *
-		 * @since 5.5.0
+		 * The default allowed extensions are:
 		 *
-		 * @param array $extensions The original extension list.
+		 *  - `jpg`
+		 *  - `jpeg`
+		 *  - `jpe`
+		 *  - `png`
+		 *  - `gif`
+		 *
+		 * @since 5.6.0
+		 *
+		 * @param string[] $allowed_extensions Array of allowed extensions.
+		 * @param string   $file               The URL of the image to download.
 		 */
-		$allowed_extensions = apply_filters( 'media_sideload_extensions', array( 'jpg', 'jpeg', 'jpe', 'png', 'gif' ) );
+		$allowed_extensions = apply_filters( 'image_sideload_extensions', $allowed_extensions, $file );
 
 		// Set variables for storage, fix file filename for query strings.
 		preg_match( '/[^\?]+\.(' . join( '|', $allowed_extensions ) . ')\b/i', $file, $matches );

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -984,7 +984,7 @@ function media_sideload_image( $file, $post_id = 0, $desc = null, $return = 'htm
 		 *
 		 * @param array $extensions The original extension list.
 		 */
-		$allowed_extensions =  apply_filters( 'media_sideload_extensions',  array( 'jpg', 'jpeg', 'jpe', 'png', 'gif' ) );
+		$allowed_extensions = apply_filters( 'media_sideload_extensions', array( 'jpg', 'jpeg', 'jpe', 'png', 'gif' ) );
 
 		// Set variables for storage, fix file filename for query strings.
 		preg_match( '/[^\?]+\.(' . join( '|', $allowed_extensions ) . ')\b/i', $file, $matches );

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -996,6 +996,7 @@ function media_sideload_image( $file, $post_id = 0, $desc = null, $return = 'htm
 		 * @param string   $file               The URL of the image to download.
 		 */
 		$allowed_extensions = apply_filters( 'image_sideload_extensions', $allowed_extensions, $file );
+		$allowed_extensions = array_map( 'preg_quote', $allowed_extensions );
 
 		// Set variables for storage, fix file filename for query strings.
 		preg_match( '/[^\?]+\.(' . join( '|', $allowed_extensions ) . ')\b/i', $file, $matches );

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -977,8 +977,17 @@ function wp_media_upload_handler() {
 function media_sideload_image( $file, $post_id = 0, $desc = null, $return = 'html' ) {
 	if ( ! empty( $file ) ) {
 
+		/**
+		 * Filters the file extensions used for media sideload.
+		 *
+		 * @since 5.5.0
+		 *
+		 * @param array $extensions The original extension list.
+		 */
+		$allowed_extensions =  apply_filters( 'media_sideload_extensions',  array( 'jpg', 'jpeg', 'jpe', 'png', 'gif' ) );
+
 		// Set variables for storage, fix file filename for query strings.
-		preg_match( '/[^\?]+\.(jpe?g|jpe|gif|png)\b/i', $file, $matches );
+		preg_match( '/[^\?]+\.(' . join( '|', $allowed_extensions ) . ')\b/i', $file, $matches );
 
 		if ( ! $matches ) {
 			return new WP_Error( 'image_sideload_failed', __( 'Invalid image URL.' ) );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Makes `media_sideload_image()` extension list filterable.

Trac ticket: https://core.trac.wordpress.org/ticket/50695#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
