### PR TITLE
Remove get_post() logic and add a unit test

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -5954,12 +5954,11 @@ function wp_delete_attachment_files( $post_id, $meta, $backup_sizes, $file ) {
 function wp_get_attachment_metadata( $attachment_id = 0, $unfiltered = false ) {
 	$attachment_id = (int) $attachment_id;
 
-	$post = get_post( $attachment_id );
-	if ( ! $post ) {
+	$data = get_post_meta( $attachment_id, '_wp_attachment_metadata', true );
+
+	if ( empty( $data ) ) {
 		return false;
 	}
-
-	$data = get_post_meta( $post->ID, '_wp_attachment_metadata', true );
 
 	if ( $unfiltered ) {
 		return $data;
@@ -5974,7 +5973,7 @@ function wp_get_attachment_metadata( $attachment_id = 0, $unfiltered = false ) {
 	 *                                  if the object does not exist.
 	 * @param int        $attachment_id Attachment post ID.
 	 */
-	return apply_filters( 'wp_get_attachment_metadata', $data, $post->ID );
+	return apply_filters( 'wp_get_attachment_metadata', $data, $attachment_id );
 }
 
 /**

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -2375,6 +2375,15 @@ EOF;
 	}
 
 	/**
+	 * @ticket 50679
+	 */
+	function test_wp_get_attachment_metadata_should_return_false_if_no_attachment() {
+		$post_id = self::factory()->post->create();
+		$data   = wp_get_attachment_metadata( $post_id );
+		$this->assertFalse( $data );
+	}
+
+	/**
 	 * @ticket 37813
 	 */
 	public function test_return_type_when_inserting_attachment_with_error_in_data() {


### PR DESCRIPTION
Optimize `wp_get_attachment_metadata ()` by removing the `get_post()` logic and pass `$attachment_id ` directly to `get_post_meta()`. See benchmarks posted here - https://core.trac.wordpress.org/ticket/50679#comment:3

Props to **Tkama** for creating the ticket and providing the benchmarks. Great work! 

Trac ticket: https://core.trac.wordpress.org/ticket/50679

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
