### PR TITLE
Block Editor: Apply allowed_block_types filter to registered blocks

### DIFF
--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -137,6 +137,8 @@ $color_palette    = current( (array) get_theme_support( 'editor-color-palette' )
 $font_sizes       = current( (array) get_theme_support( 'editor-font-sizes' ) );
 $gradient_presets = current( (array) get_theme_support( 'editor-gradient-presets' ) );
 
+$registered_blocks = WP_Block_Type_Registry::get_instance()->get_all_registered();
+
 /**
  * Filters the allowed block types for the editor, defaulting to true (all
  * block types supported).
@@ -147,7 +149,7 @@ $gradient_presets = current( (array) get_theme_support( 'editor-gradient-presets
  *                                        boolean to enable/disable all.
  * @param WP_Post    $post                The post resource data.
  */
-$allowed_block_types = apply_filters( 'allowed_block_types', true, $post );
+$allowed_block_types = apply_filters( 'allowed_block_types', $registered_blocks, $post );
 
 /*
  * Get all available templates for the post/page attributes meta-box.

--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -137,7 +137,7 @@ $color_palette    = current( (array) get_theme_support( 'editor-color-palette' )
 $font_sizes       = current( (array) get_theme_support( 'editor-font-sizes' ) );
 $gradient_presets = current( (array) get_theme_support( 'editor-gradient-presets' ) );
 
-$registered_blocks = WP_Block_Type_Registry::get_instance()->get_all_registered();
+$registered_block_types = WP_Block_Type_Registry::get_instance()->get_all_registered();
 
 /**
  * Filters the allowed block types for the editor, defaulting to true (all
@@ -149,7 +149,7 @@ $registered_blocks = WP_Block_Type_Registry::get_instance()->get_all_registered(
  *                                        boolean to enable/disable all.
  * @param WP_Post    $post                The post resource data.
  */
-$allowed_block_types = apply_filters( 'allowed_block_types', $registered_blocks, $post );
+$allowed_block_types = apply_filters( 'allowed_block_types', $registered_block_types, $post );
 
 /*
  * Get all available templates for the post/page attributes meta-box.


### PR DESCRIPTION
The [`allowed_block_types` hook](https://developer.wordpress.org/reference/hooks/allowed_block_types/) filters a list of blocks. Alternatively, it's possible to pass a bool to indicate that either all blocks are allowed (`true`), or none of them are (`false`).

It's currently [applied](https://github.com/WordPress/wordpress-develop/blob/83e78d8cdd0282883d1b61d0b4d2820a9cadcebf/src/wp-admin/edit-form-blocks.php#L150) in `lib/edit-form-blocks.php` to a default value of `true` -- meaning all blocks are allowed.

However, this means that the filter can only really be used for an allowlist, but not for a denylist: Since we don't really have access to the full list of available blocks from the filter (but just that `true` bool), we cannot choose to remove a set of blocks from that list.

I'm thus suggesting to pass the full list of registered blocks to the filter as the default value instead.

Trac ticket: https://core.trac.wordpress.org/ticket/50706

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
