### PR TITLE
Sanitize settings object values before sending

### DIFF
--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -2197,7 +2197,7 @@ final class WP_Customize_Manager {
 						printf(
 							"v[%s] = %s;\n",
 							wp_json_encode( $id ),
-							wp_json_encode( $setting->js_value() )
+							wp_json_encode( $this->widgets->sanitize_widget_js_instance( $setting->js_value() ) )
 						);
 					}
 				}


### PR DESCRIPTION
Hi there!

#### The issue
I explain the issue thoroughly in the Trac ticket. 

#### The proposed solution
I'm not entirely confident about this solution. But it does fix the issue. I think that it's masking a deeper problem that I can't put my finger on.

To hydrate the client state, the server echos a JavaScript object that has all the state that the Customizer needs to render. Part of this state is the widgets state, and it seems to be invalid when the site is fresh and the starter content is rendered. The JS object I mention is shaped like a map of `setting_id => setting_value`. When you try to publish the site, this same data is sent back to the server, and it fails the check in [`validate_setting_values`](https://core.trac.wordpress.org/browser/trunk/src/wp-includes/class-wp-customize-manager.php#L2359).

My proposed solution is to call `sanitize_widget_js_instance` on the data before echoing it to the browser. So that it's valid when it is sent back on save. This satisfies the [`validate_setting_values`](https://core.trac.wordpress.org/browser/trunk/src/wp-includes/class-wp-customize-manager.php#L2359) and all works as expected. 

My gut feeling is that `$setting->js_value()` should return an already valid value. But I couldn't find where `$setting->js_value()` gets its information from to fix that. 

This fix, if invalid, I think it would still be of some help to the next person.

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/50730

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
