### PR TITLE
REST API: Install plugin translations after the plugin install. 

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-plugins-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-plugins-controller.php
@@ -361,13 +361,19 @@ class WP_REST_Plugins_Controller extends WP_REST_Controller {
 		/** This filter is documented in wp-includes/update.php */
 		$installed_locales = apply_filters( 'plugins_update_check_locales', $installed_locales );
 
-		$language_packs = array_map( function( $item ) {
-			return (object) $item;
-		}, $api->language_packs );
+		$language_packs = array_map(
+			function( $item ) {
+					return (object) $item;
+			},
+			$api->language_packs
+		);
 
-		$language_packs = array_filter( $language_packs, function( $pack ) use ( $installed_locales ) {
-			return in_array( $pack->language, $installed_locales, true );
-		} );
+		$language_packs = array_filter(
+			$language_packs,
+			function( $pack ) use ( $installed_locales ) {
+				return in_array( $pack->language, $installed_locales, true );
+			}
+		);
 
 		if ( $language_packs ) {
 			$lp_upgrader = new Language_Pack_Upgrader( $skin );

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-plugins-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-plugins-controller.php
@@ -363,7 +363,7 @@ class WP_REST_Plugins_Controller extends WP_REST_Controller {
 
 		$language_packs = array_map(
 			function( $item ) {
-					return (object) $item;
+				return (object) $item;
 			},
 			$api->language_packs
 		);

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-plugins-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-plugins-controller.php
@@ -285,7 +285,8 @@ class WP_REST_Plugins_Controller extends WP_REST_Controller {
 			array(
 				'slug'   => $slug,
 				'fields' => array(
-					'sections' => false,
+					'sections'      => false,
+					'language_pack' => true,
 				),
 			)
 		);
@@ -353,6 +354,14 @@ class WP_REST_Plugins_Controller extends WP_REST_Controller {
 			if ( is_wp_error( $changed_status ) ) {
 				return $changed_status;
 			}
+		}
+
+		// Install translations.
+		if ( ! empty( $api->language_pack ) ) {
+			$lp_upgrader = new Language_Pack_Upgrader( $skin );
+
+			// Assume a singular language pack was returned.
+			$lp_upgrader->upgrade( (object) $api->language_pack[0] );
 		}
 
 		$path          = WP_PLUGIN_DIR . '/' . $file;


### PR DESCRIPTION
REST API: Install plugin translations after the plugin install. This only installs for the plugin in question, not all plugins.

Support for retrieving the langauge pack alongside the install API request was added in https://meta.trac.wordpress.org/changeset/10091 to avoid having to make a plugin update check during the REST API check.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here --> https://core.trac.wordpress.org/ticket/50732

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
