### PR TITLE
50744: Add the WordPress-Docs standard to the PHPCS configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,32 +29,8 @@ env:
 
 jobs:
   include:
-  - env: WP_TRAVISCI=test:e2e PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=
-    name: E2E Tests
   - env: WP_TRAVISCI=lint:php COMPOSER_INSTALL=true NPM_INSTALL=false WP_INSTALL=false
     name: PHP Linting
-  - env: WP_TRAVISCI=test:compat COMPOSER_INSTALL=true NPM_INSTALL=false WP_INSTALL=false
-    name: "PHP Compatibility Check"
-  - env: WP_TRAVISCI=travis:js WP_INSTALL=false PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=
-    name: JS Tests
-  - env: LOCAL_PHP=7.4-fpm WP_TRAVISCI=test:php
-    name: "PHPUnit Tests: PHP 7.4"
-  - env: LOCAL_PHP=7.3-fpm WP_TRAVISCI=test:php
-    name: "PHPUnit Tests: PHP 7.3"
-  - env: LOCAL_PHP=7.3-fpm LOCAL_PHP_MEMCACHED=true WP_TRAVISCI=test:php
-    name: "PHPUnit Tests: PHP 7.3 with Memcached"
-  - env: LOCAL_PHP=7.2-fpm WP_TRAVISCI=test:php
-    name: "PHPUnit Tests: PHP 7.2"
-  - env: LOCAL_PHP=7.1-fpm WP_TRAVISCI=test:php
-    name: "PHPUnit Tests: PHP 7.1"
-  - env: LOCAL_PHP=7.0-fpm WP_TEST_REPORTER=true WP_TRAVISCI=test:php
-    name: "PHPUnit Tests: PHP 7.0"
-  - env: LOCAL_PHP=5.6-fpm WP_TRAVISCI=test:php
-    name: "PHPUnit Tests: PHP 5.6"
-  - env: LOCAL_PHP=8.0-fpm WP_TRAVISCI=test:php
-    name: "PHPUnit Tests: PHP 8.0"
-  allow_failures:
-  - env: LOCAL_PHP=8.0-fpm WP_TRAVISCI=test:php
   fast_finish: true
 
 before_install:

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 	"scripts": {
 		"compat": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --standard=phpcompat.xml.dist --report=summary,source",
 		"format": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf --report=summary,source",
-		"lint": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --report=summary,source",
+		"lint": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --report=full,source",
 		"lint:errors": "@lint -n",
 		"test": "@php ./vendor/phpunit/phpunit/phpunit"
 	}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -29,6 +29,7 @@
 	<rule ref="WordPress.CodeAnalysis.EmptyStatement"/>
 
 	<rule ref="WordPress-Docs">
+		<exclude-pattern>/src/wp-content/themes*</exclude-pattern>
 		<exclude-pattern>/tests*</exclude-pattern>
 	</rule>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -26,6 +26,7 @@
 	<file>.</file>
 
 	<rule ref="WordPress-Core"/>
+	<rule ref="WordPress-Docs"/>
 	<rule ref="WordPress.CodeAnalysis.EmptyStatement"/>
 
 	<!-- These rules are being set as warnings instead of errors, so we can error check the entire codebase. -->

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -26,8 +26,11 @@
 	<file>.</file>
 
 	<rule ref="WordPress-Core"/>
-	<rule ref="WordPress-Docs"/>
 	<rule ref="WordPress.CodeAnalysis.EmptyStatement"/>
+
+	<rule ref="WordPress-Docs">
+		<exclude-pattern>/tests*</exclude-pattern>
+	</rule>
 
 	<!-- These rules are being set as warnings instead of errors, so we can error check the entire codebase. -->
 	<rule ref="WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase">


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/50744

The non-linting tests have only been removed to speed up CI for this change.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
