### PR TITLE
Allow optgroups in Customizer Select Control

### DIFF
--- a/src/wp-includes/class-wp-customize-control.php
+++ b/src/wp-includes/class-wp-customize-control.php
@@ -551,8 +551,17 @@ class WP_Customize_Control {
 
 				<select id="<?php echo esc_attr( $input_id ); ?>" <?php echo $describedby_attr; ?> <?php $this->link(); ?>>
 					<?php
-					foreach ( $this->choices as $value => $label ) {
-						echo '<option value="' . esc_attr( $value ) . '"' . selected( $this->value(), $value, false ) . '>' . $label . '</option>';
+					foreach ( $this->choices as $value => $data ) {
+						if ( is_array( $data ) && ! empty( $data ) ) {
+							echo '<optgroup label="' . esc_attr( $value ) . '">';
+							foreach ( $data as $optgroup_val => $optgroup_label ) {
+								echo '<option value="' . esc_attr( $optgroup_val ) . '"' . selected( $this->value(), $value, false ) . '>' . $optgroup_label . '</option>';
+							}
+							echo '</optgroup>';
+						}
+						else{
+							echo '<option value="' . esc_attr( $value ) . '"' . selected( $this->value(), $value, false ) . '>' . $data . '</option>';
+						}
 					}
 					?>
 				</select>

--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -4230,14 +4230,53 @@ final class WP_Customize_Manager {
 								<#
 								var value, text;
 								if ( _.isObject( val ) ) {
-									value = val.value;
-									text = val.text;
+									if(val.hasOwnProperty('value') && val.hasOwnProperty('text') ){
+										value = val.value;
+										text = val.text;
+										#>
+										<option value="{{ value }}">{{ text }}</option>
+										<#
+									}
+									else{
+										//if val is an object but doesn't directly have "value" or "text" properties, we are probably dealing with an optgroup
+										text = key;
+										value = val;
+										#>
+										<optgroup label="{{ text }}">                                                                           
+										<#
+										var optgroupvalue, optgrouptext;
+										if( _.isArray( value ) ){
+											_.each( value, function( val, key ) {
+												if( _.isObject( val ) && val.hasOwnProperty('value') && val.hasOwnProperty('text') ){
+													optgroupvalue = val.value;
+													optgrouptext = val.text;
+													#>
+													<option value="{{ optgroupvalue }}">{{ optgrouptext }}</option>
+													<#
+												}
+											} );
+										}
+										else{
+											_.each( value, function( val, key ) {
+												optgroupvalue = key;
+												optgrouptext = val;
+												#>
+												<option value="{{ optgroupvalue }}">{{ optgrouptext }}</option>
+												<#
+											} );
+										}
+										#>
+										</optgroup>
+										<#
+									}
 								} else {
 									value = key;
 									text = val;
+									#>
+									<option value="{{ value }}">{{ text }}</option>
+									<#
 								}
 								#>
-								<option value="{{ value }}">{{ text }}</option>
 							<# } ); #>
 						</select>
 					<# } else { #>


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

1. Applied [patch](https://core.trac.wordpress.org/attachment/ticket/47692/47692-updated.patch) by @chintan1896 which allows for optgroups in **`Customizer Select Control`**s when created in `PHP` (just fixed whitespacing and changed `$optgroup_data` variable to `$optgroup_label` (`$optgroup_value => $optgroup_data` to `$optgroup_value => $optgroup_label`) in order to be more in line with the original code for creating Select Controls, which uses `$value` => `$label`)
2. Applied [patch](https://core.trac.wordpress.org/attachment/ticket/47692/customizer_javascript_optgroup.diff) by yours truly @JohnRDOrazio (@Lwangaman)  which allows for optgroups in **`Customizer Select Control`**s when created using the `Javascript API`

Examples of creating a `Customizer Select Control` after applying the patches (tested locally, working according to my testing): 
1. Creation of `Customizer Select Control` in `PHP` allowing for both *top level options* and *optgroup options* together:

```php
<?php
                $wp_customize->add_setting(
                        'myoptgroup', //No need to use a SERIALIZED name, as `theme_mod` settings already live under one db record
                        array(
                                'default'    => 'carrots', //Default setting/value to save
                                'type'       => 'theme_mod', //Is this an 'option' or a 'theme_mod'?
                                'capability' => 'edit_theme_options', //Optional. Special permissions for accessing this setting.
                                'transport'  => 'postMessage' //What triggers a refresh of the setting? 'refresh' or 'postMessage' (instant)?
                        )
                );

                $wp_customize->add_control(
                        'myoptgroup_ctl',
                        array(
                                'label'                 => 'My OptGroup with Food choices',
                                'settings'              => 'myoptgroup',
                                'priority'              => 10,
                                'section'               => 'a_section_of_my_options',
                                'type'                  => 'select',
                                'choices'               => array(
                                                        'Fruits'                => array('apples' => 'Green apples', 'pears' => 'Pears', 'bananas' => 'Chiquita bananas' ),
                                                        'Vegetables'    => array('peas' => 'Peas', 'carrots' => 'Carrots', 'tomatoes' => 'Cherry tomatoes' ),
                                                        'Meats'                 => array('chicken' => 'Grilled chicken breast', 'turkey' => 'Roasted turkey', 'sausages' => 'Blood sausages' ),
                                                        'Desserts'              => array('icecream' => 'Mint chocolate chip ice cream', 'pudding' => 'Tapioca pudding'),
                                                        'supper'                => 'Home cooked dinner meal',
                                                        'lunch'                 => 'Fast food take-away lunch'
                                                )
                        )
                );
        }
```

2. Creation  of `Customizer Select Control` in `Javascript` using only *top level options* and using an **array of objects** with `value` and `text` properties  (already available in current wordpress core without applying the patch, useful for comparison with the example that comes after):

```javascript
wp.customize.control.add(new wp.customize.Control('myoptgroup2', {
        type: 'select',
        settings: 'myoptgroup2',
        section: 'a_section_of_my_options',
        label: 'My OptGroup with Animal choices',
        choices: [
                { value: 'tiger', text: 'Tiger' },
                { value: 'lion', text: 'Lion' },
                { value: 'eagle', text: 'Eagle' },
                { value: 'whale', text: 'Whale' },
        ]
}));
```

3. Creation  of `Customizer Select Control` in `Javascript` using both *top level options* and *optgroup options*, using an **array of objects** with `value` and `text` properties (after patch is applied):

```javascript
wp.customize.control.add(new wp.customize.Control('myoptgroup2', {
        type: 'select',
        settings: 'myoptgroup2',
        section: 'a_section_of_my_options',
        label: 'My OptGroup with Animal choices',
        choices: {
                'Land' : [
                        { value: 'tiger', text: 'Tiger' }, 
                        { value: 'lion', text: 'Lion' }
                ],
                'Sea': [
                        { value: 'whale', text: 'Whale' }, 
                        { value: 'salmon', text: 'Salmon' }
                ],
                'Air': [
                        { value: 'eagle', text: 'Eagle' }, 
                        { value: 'woodpecker', text: 'Woodpecker' }
                ],
                'mammals' : 'Mammals',
                'jungle' : 'Jungle wildlife'
        },
}));
```

4. Creation  of `Customizer Select Control` in `Javascript` using only *top level options* and using an object with **key : value** pairs (already available in current wordpress core without applying the patch, useful for comparison with the example that comes after):

```javascript
wp.customize.control.add(new wp.customize.Control('myoptgroup2', {
        type: 'select',
        settings: 'myoptgroup2',
        section: 'a_section_of_my_options',
        label: 'My OptGroup with Animal choices',
        choices: {
                'tiger' : 'Tiger',
                'lion' : 'Lion',
                'eagle' : 'Eagle',
                'whale' : 'Whale',
        }
}));
```

5. Creation  of `Customizer Select Control` in `Javascript` using both *top level options* and *optgroup options*, using an object with **key : value** pairs (after patch is applied):

```javascript
wp.customize.control.add(new wp.customize.Control('myoptgroup2', {
        type: 'select',
        settings: 'myoptgroup2',
        section: 'a_section_of_my_options',
        label: 'My OptGroup with Animal choices',
        choices: {
                'Land': { 'tiger': 'Tiger', 'lion': 'Lion' },
                'Sea': { 'whale': 'Whale', 'salmon': 'Salmon' },
                'Air': { 'eagle': 'Eagle', 'woodpecker': 'Woodpecker' },
                'mammals' : 'Mammals',
                'jungle' : 'Jungle wildlife'
        },
}));
```

In the examples **3** and **5**, I believe you would only be able to insert the top level options as `key:value` pairs, you would not be able to use an object that has `value` and `text` properties because `choices` can only take an `object` with `key:value` pairs, it can no longer be an **array of objects** with `value` and `text` properties. So as long as there are *only* top-level options, you can use either style, but if you use **optgoups** the top-level options could only be simple `key:value` pairs.

Here is an image of the result of the last examples **3** and **5** from my local testing after applying the patch:

https://imgur.com/bMA4n3k

Trac ticket: #47692

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
