### PR TITLE
Mark plugins that don't support auto-updates as Unavailable.

### DIFF
--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -210,6 +210,21 @@ class WP_Plugins_List_Table extends WP_List_Table {
 				$plugin_data['auto-update-supported'] = false;
 			}
 
+			// TODO: The slug isn't set for non-update-enabled plugins, but must be set for the filter.
+			if ( ! isset( $plugin_data['slug'] ) ) {
+				if ( '.' === dirname( $plugin_file ) ) {
+					$plugin_data['slug'] = basename( $plugin_file );
+				} else {
+					$plugin_data['slug'] = dirname( $plugin_file );
+				}
+			}
+
+			// TODO: Document, make sure we're passing the right data as $plugin_data.
+			$auto_update_forced = apply_filters( 'auto_update_plugin', null, (object) $plugin_data );
+			if ( ! is_null( $auto_update_forced ) ) {
+				$plugin_data['auto-update-forced'] = $auto_update_forced;
+			}
+
 			$plugins['all'][ $plugin_file ] = $plugin_data;
 			// Make sure that $plugins['upgrade'] also receives the extra info since it is used on ?plugin_status=upgrade.
 			if ( isset( $plugins['upgrade'][ $plugin_file ] ) ) {
@@ -1058,8 +1073,17 @@ class WP_Plugins_List_Table extends WP_List_Table {
 
 					$html = array();
 
-					if ( ! $plugin_data['auto-update-supported'] ) {
-						$text       = __( 'Not available' );
+					if ( isset( $plugin_data['auto-update-forced'] ) ) {
+						if ( $plugin_data['auto-update-forced'] ) {
+							// Forced on
+							$text = __( 'Automatic Updates Enabled' );
+						} else {
+							$text = __( 'Automatic Updates Disabled' );
+						}
+						$action     = 'unavailable';
+						$time_class = ' hidden';
+					} elseif ( ! $plugin_data['auto-update-supported'] ) {
+						$text       = ''; // __( 'Not available' );
 						$action     = 'unavailable';
 						$time_class = ' hidden';
 					} elseif ( in_array( $plugin_file, $auto_updates, true ) ) {

--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -1088,22 +1088,22 @@ class WP_Plugins_List_Table extends WP_List_Table {
 					if ( isset( $plugin_data['auto-update-forced'] ) ) {
 						if ( $plugin_data['auto-update-forced'] ) {
 							// Forced on
-							$text = __( 'Automatic updates enabled' );
+							$text = __( 'Auto-updates enabled' );
 						} else {
-							$text = __( 'Automatic updates disabled' );
+							$text = __( 'Auto-updates disabled' );
 						}
 						$action     = 'unavailable';
 						$time_class = ' hidden';
 					} elseif ( ! $plugin_data['auto-update-supported'] ) {
-						$text       = ''; // __( 'Not available' );
+						$text       = '';
 						$action     = 'unavailable';
 						$time_class = ' hidden';
 					} elseif ( in_array( $plugin_file, $auto_updates, true ) ) {
-						$text       = __( 'Disable automatic updates' );
+						$text       = __( 'Disable auto-updates' );
 						$action     = 'disable';
 						$time_class = '';
 					} else {
-						$text       = __( 'Enable automatic updates' );
+						$text       = __( 'Enable auto-updates' );
 						$action     = 'enable';
 						$time_class = ' hidden';
 					}

--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -1096,9 +1096,7 @@ class WP_Plugins_List_Table extends WP_List_Table {
 						$html[] = '</a>';
 					}
 
-					$available_updates = get_site_transient( 'update_plugins' );
-
-					if ( isset( $available_updates->response[ $plugin_file ] ) ) {
+					if ( ! empty( $plugin_data['update'] ) ) {
 						$html[] = sprintf(
 							'<div class="auto-update-time%s">%s</div>',
 							$time_class,

--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -1076,9 +1076,9 @@ class WP_Plugins_List_Table extends WP_List_Table {
 					if ( isset( $plugin_data['auto-update-forced'] ) ) {
 						if ( $plugin_data['auto-update-forced'] ) {
 							// Forced on
-							$text = __( 'Automatic Updates Enabled' );
+							$text = __( 'Automatic updates enabled' );
 						} else {
-							$text = __( 'Automatic Updates Disabled' );
+							$text = __( 'Automatic updates disabled' );
 						}
 						$action     = 'unavailable';
 						$time_class = ' hidden';
@@ -1087,11 +1087,11 @@ class WP_Plugins_List_Table extends WP_List_Table {
 						$action     = 'unavailable';
 						$time_class = ' hidden';
 					} elseif ( in_array( $plugin_file, $auto_updates, true ) ) {
-						$text       = __( 'Disable auto-updates' );
+						$text       = __( 'Disable automatic updates' );
 						$action     = 'disable';
 						$time_class = '';
 					} else {
-						$text       = __( 'Enable auto-updates' );
+						$text       = __( 'Enable automatic updates' );
 						$action     = 'enable';
 						$time_class = ' hidden';
 					}

--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -1082,7 +1082,6 @@ class WP_Plugins_List_Table extends WP_List_Table {
 					$url = add_query_arg( $query_args, 'plugins.php' );
 
 					if ( 'unavailable' == $action ) {
-						$html[] = '<span class="dashicons dashicons-warning" aria-hidden="true"></span>';
 						$html[] = '<span class="label">' . $text . '</span>';
 					} else {
 						$html[] = sprintf(

--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -210,17 +210,29 @@ class WP_Plugins_List_Table extends WP_List_Table {
 				$plugin_data['auto-update-supported'] = false;
 			}
 
-			// TODO: The slug isn't set for non-update-enabled plugins, but must be set for the filter.
-			if ( ! isset( $plugin_data['slug'] ) ) {
-				if ( '.' === dirname( $plugin_file ) ) {
-					$plugin_data['slug'] = basename( $plugin_file );
-				} else {
-					$plugin_data['slug'] = dirname( $plugin_file );
-				}
-			}
+			/*
+			 * Create the payload that's used for the auto_update_plugin filter.
+			 * This is the same data contained within $plugin_info->(response|no_update) however
+			 * not all plugins will be contained in those keys, this avoids unexpected warnings.
+			 */
+			$filter_payload = array(
+				'id'            => $plugin_file,
+				'slug'          => '',
+				'plugin'        => $plugin_file,
+				'new_version'   => '',
+				'url'           => '',
+				'package'       => '',
+				'icons'         => array(),
+				'banners'       => array(),
+				'banners_rtl'   => array(),
+				'tested'        => '',
+				'requires_php'  => '',
+				'compatibility' => new stdClass(),
+			);
+			$filter_payload = (object) array_merge( $filter_payload, array_intersect_key( $plugin_data, $filter_payload ) );
 
-			// TODO: Document, make sure we're passing the right data as $plugin_data.
-			$auto_update_forced = apply_filters( 'auto_update_plugin', null, (object) $plugin_data );
+			/** This action is documented in wp-admin/includes/class-wp-automatic-updater.php */
+			$auto_update_forced = apply_filters( 'auto_update_plugin', null, $filter_payload );
 			if ( ! is_null( $auto_update_forced ) ) {
 				$plugin_data['auto-update-forced'] = $auto_update_forced;
 			}

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -949,6 +949,15 @@ function wp_recovery_mode_nag() {
  * @return bool True if auto-updates are enabled for `$type`, false otherwise.
  */
 function wp_is_auto_update_enabled_for_type( $type ) {
+	if ( ! class_exists( 'WP_Automatic_Updater' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/class-wp-automatic-updater.php';
+	}
+
+	$updater = new WP_Automatic_Updater();
+	if ( $updater->is_disabled() ) {
+		return false;
+	}
+
 	switch ( $type ) {
 		case 'plugin':
 			/**

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -954,9 +954,7 @@ function wp_is_auto_update_enabled_for_type( $type ) {
 	}
 
 	$updater = new WP_Automatic_Updater();
-	if ( $updater->is_disabled() ) {
-		return false;
-	}
+	$enabled = ! $updater->is_disabled();
 
 	switch ( $type ) {
 		case 'plugin':
@@ -967,7 +965,7 @@ function wp_is_auto_update_enabled_for_type( $type ) {
 			 *
 			 * @param bool $enabled True if plugins auto-update is enabled, false otherwise.
 			 */
-			return apply_filters( 'plugins_auto_update_enabled', true );
+			return apply_filters( 'plugins_auto_update_enabled', $enabled );
 		case 'theme':
 			/**
 			 * Filters whether themes auto-update is enabled.
@@ -976,7 +974,7 @@ function wp_is_auto_update_enabled_for_type( $type ) {
 			 *
 			 * @param bool $enabled True if themes auto-update is enabled, false otherwise.
 			 */
-			return apply_filters( 'themes_auto_update_enabled', true );
+			return apply_filters( 'themes_auto_update_enabled', $enabled );
 	}
 
 	return false;

--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -574,7 +574,7 @@ if ( current_user_can( 'update_plugins' ) && wp_is_auto_update_enabled_for_type(
 			'title'   => __( 'Auto-updates' ),
 			'content' =>
 					'<p>' . __( 'Auto-updates can be enabled or disabled for each individual plugin. Plugins with auto-updates enabled will display the estimated date of the next auto-update. Auto-updates depends on the WP-Cron task scheduling system.' ) . '</p>' .
-					'<p>' . __( "Plugins that are not recognised by WordPress.org and isn't offered by the author may show as as not having auto-updates available." ) . '</p>' .
+					'<p>' . __( 'Auto-updates are only available for plugins recognised by WordPress.org, or that include a compatible update system.' ) . '</p>' .
 					'<p>' . __( 'Please note: Third-party themes and plugins, or custom code, may override WordPress scheduling.' ) . '</p>',
 		)
 	);

--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -574,6 +574,7 @@ if ( current_user_can( 'update_plugins' ) && wp_is_auto_update_enabled_for_type(
 			'title'   => __( 'Auto-updates' ),
 			'content' =>
 					'<p>' . __( 'Auto-updates can be enabled or disabled for each individual plugin. Plugins with auto-updates enabled will display the estimated date of the next auto-update. Auto-updates depends on the WP-Cron task scheduling system.' ) . '</p>' .
+					'<p>' . __( "Plugins that are not recognised by WordPress.org and isn't offered by the author may show as as not having auto-updates available." ) . '</p>' .
 					'<p>' . __( 'Please note: Third-party themes and plugins, or custom code, may override WordPress scheduling.' ) . '</p>',
 		)
 	);

--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -574,7 +574,7 @@ if ( current_user_can( 'update_plugins' ) && wp_is_auto_update_enabled_for_type(
 			'title'   => __( 'Auto-updates' ),
 			'content' =>
 					'<p>' . __( 'Auto-updates can be enabled or disabled for each individual plugin. Plugins with auto-updates enabled will display the estimated date of the next auto-update. Auto-updates depends on the WP-Cron task scheduling system.' ) . '</p>' .
-					'<p>' . __( 'Auto-updates are only available for plugins recognised by WordPress.org, or that include a compatible update system.' ) . '</p>' .
+					'<p>' . __( 'Auto-updates are only available for plugins recognized by WordPress.org, or that include a compatible update system.' ) . '</p>' .
 					'<p>' . __( 'Please note: Third-party themes and plugins, or custom code, may override WordPress scheduling.' ) . '</p>',
 		)
 	);


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

This PR enhances the Auto-updates section for plugins to mark plugins that do not support automatic updates as not being available.

See https://core.trac.wordpress.org/ticket/50280#comment:23 for my concerns here.

Trac ticket: https://core.trac.wordpress.org/ticket/50280

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
