### PR TITLE
Prevent redirect of non-pretty URL to pretty URL when post is private

### DIFF
--- a/src/wp-includes/canonical.php
+++ b/src/wp-includes/canonical.php
@@ -238,11 +238,21 @@ function redirect_canonical( $requested_url = null, $do_redirect = true ) {
 				$redirect_url = get_attachment_link();
 			}
 		} elseif ( is_single() && ! empty( $_GET['p'] ) && ! $redirect_url ) {
-			$redirect_url = get_permalink( get_query_var( 'p' ) );
 
-			if ( $redirect_url ) {
-				$redirect['query'] = remove_query_arg( array( 'p', 'post_type' ), $redirect['query'] );
+			// Don't get the redirect url if post is private and visitor has no priviledge.
+			$should_get_redirect = true;
+			if ( 'private' === get_post_status( get_query_var( 'p' ) ) && ! current_user_can( 'read_private_posts' ) ) {
+				$should_get_redirect = false;
 			}
+
+			if ( $should_get_redirect ) {
+				$redirect_url = get_permalink( get_query_var( 'p' ) );
+
+				if ( $redirect_url ) {
+					$redirect['query'] = remove_query_arg( array( 'p', 'post_type' ), $redirect['query'] );
+				}
+			}
+			
 		} elseif ( is_single() && ! empty( $_GET['name'] ) && ! $redirect_url ) {
 			$redirect_url = get_permalink( $wp_query->get_queried_object_id() );
 

--- a/src/wp-includes/canonical.php
+++ b/src/wp-includes/canonical.php
@@ -148,14 +148,21 @@ function redirect_canonical( $requested_url = null, $do_redirect = true ) {
 		if ( $redirect_post ) {
 			$post_type_obj = get_post_type_object( $redirect_post->post_type );
 
-			if ( $post_type_obj->public && ! in_array( $redirect_post->post_status, array( 'auto-draft', 'private' ), true ) ) {
-				$redirect_url = get_permalink( $redirect_post );
+			if ( $post_type_obj->public && 'auto-draft' !== $redirect_post->post_status ) {
+				$get_redirect_url = true;
+				if ( 'private' === $redirect_post->post_status && ! current_user_can( 'read_private_posts' ) ) {
+					$get_redirect_url = false;
+				}
 
-				$redirect['query'] = _remove_qs_args_if_not_in_url(
-					$redirect['query'],
-					array( 'p', 'page_id', 'attachment_id', 'pagename', 'name', 'post_type' ),
-					$redirect_url
-				);
+				if ( $get_redirect_url ) {
+					$redirect_url = get_permalink( $redirect_post );
+
+					$redirect['query'] = _remove_qs_args_if_not_in_url(
+						$redirect['query'],
+						array( 'p', 'page_id', 'attachment_id', 'pagename', 'name', 'post_type' ),
+						$redirect_url
+					);
+				}
 			}
 		}
 

--- a/src/wp-includes/canonical.php
+++ b/src/wp-includes/canonical.php
@@ -148,7 +148,7 @@ function redirect_canonical( $requested_url = null, $do_redirect = true ) {
 		if ( $redirect_post ) {
 			$post_type_obj = get_post_type_object( $redirect_post->post_type );
 
-			if ( $post_type_obj->public && ! in_array( $redirect_post->post_status, [ 'auto-draft', 'private' ], true )  ) {
+			if ( $post_type_obj->public && ! in_array( $redirect_post->post_status, array( 'auto-draft', 'private' ), true ) ) {
 				$redirect_url = get_permalink( $redirect_post );
 
 				$redirect['query'] = _remove_qs_args_if_not_in_url(

--- a/src/wp-includes/canonical.php
+++ b/src/wp-includes/canonical.php
@@ -148,7 +148,7 @@ function redirect_canonical( $requested_url = null, $do_redirect = true ) {
 		if ( $redirect_post ) {
 			$post_type_obj = get_post_type_object( $redirect_post->post_type );
 
-			if ( $post_type_obj->public && 'auto-draft' !== $redirect_post->post_status ) {
+			if ( $post_type_obj->public && ! in_array( $redirect_post->post_status, [ 'auto-draft', 'private' ], true )  ) {
 				$redirect_url = get_permalink( $redirect_post );
 
 				$redirect['query'] = _remove_qs_args_if_not_in_url(

--- a/tests/phpunit/tests/canonical.php
+++ b/tests/phpunit/tests/canonical.php
@@ -294,4 +294,27 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 
 		delete_option( 'page_on_front' );
 	}
+
+	/**
+	 * @ticket 5272
+	 */
+	public function test_private_post_should_not_redirect_for_non_logged_users() {
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_title'  => 'Private Post',
+				'post_status' => 'private',
+			)
+		);
+
+		// Simulate going to the private post.
+		$this->go_to( add_query_arg( 'p', $post->ID, home_url( '/' ) ) );
+
+		$redirect = redirect_canonical(
+			null,
+			false
+		);
+
+		// Non-logged users shouldnt be redirected to pretty URL.
+		$this->assertEquals( null, $redirect );
+	}
 }


### PR DESCRIPTION
Prevent canonical redirect for private post.

Trac ticket: https://core.trac.wordpress.org/ticket/5272

~~**TODO:**~~
✅ 1. Unit test.
✅ 2. Allow the redirect if user is logged and has permission to read the post.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
