### PR TITLE
Pass the $rel parameter to 'image_send_to_editor' filter

### DIFF
--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -162,8 +162,9 @@ function get_image_send_to_editor( $id, $caption, $title, $align, $url = '', $re
 	 * @param string|array $size    Size of image. Image size or array of width and height values
 	 *                              (in that order). Default 'medium'.
 	 * @param string       $alt     The image alternative, or alt, text.
+	 * @param string       $rel     The image rel attribute.
 	 */
-	$html = apply_filters( 'image_send_to_editor', $html, $id, $caption, $title, $align, $url, $size, $alt );
+	$html = apply_filters( 'image_send_to_editor', $html, $id, $caption, $title, $align, $url, $size, $alt, $rel );
 
 	return $html;
 }


### PR DESCRIPTION
As previously mentioned in [comment:1:ticket:35595](https://core.trac.wordpress.org/ticket/35595#comment:1), the `image_send_to_editor` filter accepts all the parameters of `get_image_send_to_editor()`, except for `$rel`.
This seems like an oversight, it would be helpful if `$rel` was passed too.

Trac ticket: https://core.trac.wordpress.org/ticket/50765