### PR TITLE
Reading Settings: Adjust padding around the "pages should not be the …

### DIFF
--- a/src/wp-admin/options-reading.php
+++ b/src/wp-admin/options-reading.php
@@ -137,7 +137,7 @@ else :
 </label></li>
 </ul>
 	<?php if ( 'page' === get_option( 'show_on_front' ) && get_option( 'page_for_posts' ) === get_option( 'page_on_front' ) ) : ?>
-	<div id="front-page-warning" class="error inline"><p><?php _e( '<strong>Warning:</strong> these pages should not be the same!' ); ?></p></div>
+	<div id="front-page-warning" class="error notice inline"><p><?php _e( '<strong>Warning:</strong> these pages should not be the same!' ); ?></p></div>
 	<?php endif; ?>
 	<?php if ( get_option( 'wp_page_for_privacy_policy' ) === get_option( 'page_for_posts' ) || get_option( 'wp_page_for_privacy_policy' ) === get_option( 'page_on_front' ) ) : ?>
 	<div id="privacy-policy-page-warning" class="error inline"><p><?php _e( '<strong>Warning:</strong> these pages should not be the same as your Privacy Policy page!' ); ?></p></div>


### PR DESCRIPTION
…same!" warning

Adding the `notice` class to the warning fixes this problem.

Props SergeyBiryukov, man4toman.
Fixes #50766

Added the `notice` class to the Reading Settings `front-page-warning`. 

Trac ticket: https://core.trac.wordpress.org/ticket/50766
