### PR TITLE
Show forced auto-update plugins correctly in Auto-update Enabled view

### DIFF
--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -279,7 +279,7 @@ class WP_Plugins_List_Table extends WP_List_Table {
 			}
 
 			if ( $this->show_autoupdates ) {
-				if ( in_array( $plugin_file, $auto_updates, true ) ) {
+				if ( $auto_update_forced || in_array( $plugin_file, $auto_updates, true ) ) {
 					$plugins['auto-update-enabled'][ $plugin_file ] = $plugins['all'][ $plugin_file ];
 				} else {
 					$plugins['auto-update-disabled'][ $plugin_file ] = $plugins['all'][ $plugin_file ];


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/50825

Plugins that filter `auto_update_plugin` and returns true should be listed in `Auto-updates Enabled` view instead of `Auto-updates Disabled` view.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
