### PR TITLE
Return a filter in wp_get_attachment_image()

### DIFF
--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -1002,6 +1002,7 @@ function wp_get_attachment_image_src( $attachment_id, $size = 'thumbnail', $icon
  * browser scale down the image.
  *
  * @since 2.5.0
+ * @since 5.6.0 Returns `wp_get_attachment_image` filter.
  *
  * @param int          $attachment_id Image attachment ID.
  * @param string|array $size          Optional. Image size. Accepts any valid image size, or an array of width
@@ -1021,8 +1022,9 @@ function wp_get_attachment_image_src( $attachment_id, $size = 'thumbnail', $icon
  * @return string HTML img element or empty string on failure.
  */
 function wp_get_attachment_image( $attachment_id, $size = 'thumbnail', $icon = false, $attr = '' ) {
-	$html  = '';
-	$image = wp_get_attachment_image_src( $attachment_id, $size, $icon );
+	$attachment = '';
+	$html       = '';
+	$image      = wp_get_attachment_image_src( $attachment_id, $size, $icon );
 
 	if ( $image ) {
 		list( $src, $width, $height ) = $image;
@@ -1096,7 +1098,16 @@ function wp_get_attachment_image( $attachment_id, $size = 'thumbnail', $icon = f
 		$html .= ' />';
 	}
 
-	return $html;
+	/**
+	 * HTML img element representing an image attachment
+	 *
+	 * @since 5.6.0
+	 *
+	 * @param string       $html       HTML img element or empty string on failure.
+	 * @param string       $attachment The attachment WP_Post object.
+	 * @param string|array $size       Image size.
+	 */
+	return apply_filters( 'wp_get_attachment_image', $html, $attachment, $size );
 }
 
 /**

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -1344,6 +1344,20 @@ EOF;
 	}
 
 	/**
+	 * @ticket 50801
+	 */
+	function test_wp_get_attachment_image_filter_output() {
+		$image = image_downsize( self::$large_id, 'thumbnail' );
+		add_filter( 'wp_get_attachment_image', array( $this, 'wp_get_attachment_image_filter' ) );
+		$this->assertEquals( 'Override wp_get_attachment_image', wp_get_attachment_image( self::$large_id ) );
+		remove_filter( 'wp_get_attachment_image', array( $this, 'wp_get_attachment_image_filter' ) );
+	}
+
+	function wp_get_attachment_image_filter() {
+		return 'Override wp_get_attachment_image';
+	}
+
+	/**
 	 * Test that `wp_get_attachment_image()` returns a proper alt value.
 	 *
 	 * @ticket 34635


### PR DESCRIPTION
Return a filter in wp_get_attachment_image(). Props to @prionkor for https://github.com/WordPress/wordpress-develop/pull/440. I initialized `$attachment`, add unit test, and filter docs.

Trac ticket: https://core.trac.wordpress.org/ticket/50801

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
