### PR TITLE
Change function signature of `wp_count_terms()` to be compliant with recent `get_terms()` changes

### DIFF
--- a/src/wp-admin/includes/class-wp-terms-list-table.php
+++ b/src/wp-admin/includes/class-wp-terms-list-table.php
@@ -129,7 +129,12 @@ class WP_Terms_List_Table extends WP_List_Table {
 
 		$this->set_pagination_args(
 			array(
-				'total_items' => wp_count_terms( $this->screen->taxonomy, compact( 'search' ) ),
+				'total_items' => wp_count_terms(
+					array(
+						'taxonomy' => $this->screen->taxonomy,
+						'search'   => $search,
+					)
+				),
 				'per_page'    => $tags_per_page,
 			)
 		);

--- a/src/wp-admin/includes/nav-menu.php
+++ b/src/wp-admin/includes/nav-menu.php
@@ -725,7 +725,6 @@ function wp_nav_menu_item_taxonomy_meta_box( $object, $box ) {
 
 	$num_pages = ceil(
 		wp_count_terms(
-			$taxonomy_name,
 			array_merge(
 				$args,
 				array(

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php
@@ -263,7 +263,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 
 		unset( $count_args['number'], $count_args['offset'] );
 
-		$total_terms = wp_count_terms( $this->taxonomy, $count_args );
+		$total_terms = wp_count_terms( $count_args );
 
 		// wp_count_terms() can return a falsey value when the term has no children.
 		if ( ! $total_terms ) {

--- a/src/wp-includes/sitemaps/providers/class-wp-sitemaps-taxonomies.php
+++ b/src/wp-includes/sitemaps/providers/class-wp-sitemaps-taxonomies.php
@@ -150,7 +150,7 @@ class WP_Sitemaps_Taxonomies extends WP_Sitemaps_Provider {
 			return $max_num_pages;
 		}
 
-		$term_count = wp_count_terms( $taxonomy, $this->get_taxonomies_query_args( $taxonomy ) );
+		$term_count = wp_count_terms( $this->get_taxonomies_query_args( $taxonomy ) );
 
 		return (int) ceil( $term_count / wp_sitemaps_get_max_urls( $this->object_type ) );
 	}

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -1730,18 +1730,24 @@ function sanitize_term_field( $field, $value, $term_id, $taxonomy, $context ) {
  * Default $args is 'hide_empty' which can be 'hide_empty=true' or array('hide_empty' => true).
  *
  * @since 2.3.0
+ * @since 5.6.0 Changed the function signature so that the `$args` array can be provided as the first parameter.
  *
- * @param string       $taxonomy Taxonomy name.
- * @param array|string $args     Optional. Array of arguments that get passed to get_terms().
- *                               Default empty array.
+ * @param array|string $args       Optional. Array of arguments that get passed to get_terms().
+ *                                 Default empty array.
+ * @param array|string $deprecated Taxonomy name.
  * @return array|int|WP_Error Number of terms in that taxonomy or WP_Error if the taxonomy does not exist.
  */
-function wp_count_terms( $taxonomy, $args = array() ) {
-	$defaults = array(
-		'taxonomy'   => $taxonomy,
-		'hide_empty' => false,
-	);
-	$args     = wp_parse_args( $args, $defaults );
+function wp_count_terms( $args = array(), $deprecated = array() ) {
+	// Check whether function is used with legacy signature `$taxonomy` and `$args`.
+	$use_legacy_args = $args && ( is_string( $args ) && taxonomy_exists( $args ) || is_array( $args ) && wp_is_numeric_array( $args ) );
+
+	$defaults = array( 'hide_empty' => false );
+	if ( $use_legacy_args ) {
+		$defaults['taxonomy'] = $args;
+		$args                 = $deprecated;
+	}
+
+	$args = wp_parse_args( $args, $defaults );
 
 	// Backward compatibility.
 	if ( isset( $args['ignore_empty'] ) ) {

--- a/tests/phpunit/tests/import/import.php
+++ b/tests/phpunit/tests/import/import.php
@@ -65,8 +65,8 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 		$this->assertEquals( 'author@example.org', $author->user_email );
 
 		// Check that terms were imported correctly.
-		$this->assertEquals( 30, wp_count_terms( 'category' ) );
-		$this->assertEquals( 3, wp_count_terms( 'post_tag' ) );
+		$this->assertEquals( 30, wp_count_terms( array( 'taxonomy' => 'category' ) ) );
+		$this->assertEquals( 3, wp_count_terms( array( 'taxonomy' => 'post_tag' ) ) );
 		$foo = get_term_by( 'slug', 'foo', 'category' );
 		$this->assertEquals( 0, $foo->parent );
 		$bar     = get_term_by( 'slug', 'bar', 'category' );
@@ -230,8 +230,8 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 		$this->assertEquals( 'author', $author->user_login );
 		$this->assertEquals( 'author@example.org', $author->user_email );
 
-		$this->assertEquals( 30, wp_count_terms( 'category' ) );
-		$this->assertEquals( 3, wp_count_terms( 'post_tag' ) );
+		$this->assertEquals( 30, wp_count_terms( array( 'taxonomy' => 'category' ) ) );
+		$this->assertEquals( 3, wp_count_terms( array( 'taxonomy' => 'post_tag' ) ) );
 		$foo = get_term_by( 'slug', 'foo', 'category' );
 		$this->assertEquals( 0, $foo->parent );
 		$bar     = get_term_by( 'slug', 'bar', 'category' );

--- a/tests/phpunit/tests/term/wpInsertTerm.php
+++ b/tests/phpunit/tests/term/wpInsertTerm.php
@@ -24,14 +24,14 @@ class Tests_Term_WpInsertTerm extends WP_UnitTestCase {
 		$term = 'term';
 		$this->assertNull( term_exists( $term ) );
 
-		$initial_count = wp_count_terms( $taxonomy );
+		$initial_count = wp_count_terms( array( 'taxonomy' => $taxonomy ) );
 
 		$t = wp_insert_term( $term, $taxonomy );
 		$this->assertInternalType( 'array', $t );
 		$this->assertNotWPError( $t );
 		$this->assertTrue( $t['term_id'] > 0 );
 		$this->assertTrue( $t['term_taxonomy_id'] > 0 );
-		$this->assertEquals( $initial_count + 1, wp_count_terms( $taxonomy ) );
+		$this->assertEquals( $initial_count + 1, wp_count_terms( array( 'taxonomy' => $taxonomy ) ) );
 
 		// Make sure the term exists.
 		$this->assertTrue( term_exists( $term ) > 0 );
@@ -43,7 +43,7 @@ class Tests_Term_WpInsertTerm extends WP_UnitTestCase {
 		remove_filter( 'delete_term', array( $this, 'deleted_term_cb' ), 10, 5 );
 		$this->assertNull( term_exists( $term ) );
 		$this->assertNull( term_exists( $t['term_id'] ) );
-		$this->assertEquals( $initial_count, wp_count_terms( $taxonomy ) );
+		$this->assertEquals( $initial_count, wp_count_terms( array( 'taxonomy' => $taxonomy ) ) );
 	}
 
 	public function test_wp_insert_term_taxonomy_does_not_exist() {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/36399

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
