### PR TITLE
Fix undefined index error during plugin install

### DIFF
--- a/src/wp-admin/includes/class-plugin-installer-skin.php
+++ b/src/wp-admin/includes/class-plugin-installer-skin.php
@@ -52,6 +52,7 @@ class Plugin_Installer_Skin extends WP_Upgrader_Skin {
 	 */
 	public function before() {
 		if ( ! empty( $this->api ) ) {
+			$this->upgrader->upgrade_strings();
 			$this->upgrader->strings['process_success'] = sprintf(
 				$this->upgrader->strings['process_success_specific'],
 				$this->api->name,


### PR DESCRIPTION
This PR fixes an undefined index error that occurs when attempting to access the `process_success_specific` key. The fix prepopulates the `WP_Upgrader->strings` array, ensuring the `process_success_specific` key exists.

**Before:**
<img width="705" alt="Screen Shot 2020-08-04 at 02 54 43" src="https://user-images.githubusercontent.com/105005/89268255-e560f400-d5fd-11ea-8a80-df385beab0c4.png">

**After:**
<img width="713" alt="Screen Shot 2020-08-04 at 02 30 16" src="https://user-images.githubusercontent.com/105005/89267979-8602e400-d5fd-11ea-8a85-53dbcd200705.png">

Trac ticket: https://core.trac.wordpress.org/ticket/50837
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
