### PR TITLE
Fix typo (trac ticket 50884)

### DIFF
--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -98,7 +98,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 						<source src="https://s.w.org/images/core/5.5/auto-updates.mp4" type="video/mp4" />
 						<source src="https://s.w.org/images/core/5.5/auto-updates.webm" type="video/webm" />
 					</video>
-					<figcaption id="about-security" class="screen-reader-text"><?php _e( 'Video: Installed plugin screen, which shows a new column, Automatic Updates. In this column are buttons that say "Enable auto-updates." When clicked, the auto-updates feature is turned on for that plugin, and the button switches to say "Disable auto-updates".' ); ?></figcaption>
+					<figcaption id="about-security" class="screen-reader-text"><?php _e( 'Video: Installed plugin screen, which shows a new column, Automatic Updates. In this column are buttons that say "Enable auto-updates". When clicked, the auto-updates feature is turned on for that plugin, and the button switches to say "Disable auto-updates".' ); ?></figcaption>
 				</figure>
 			</div>
 		</div>


### PR DESCRIPTION
Trac Ticket https://core.trac.wordpress.org/ticket/50884

Typo found in translatable string in https://build.trac.wordpress.org/browser/trunk/wp-admin/about.php?marks=101#L101

Original strings:
`Video: Installed plugin screen, which shows a new column, Automatic Updates. In this column are buttons that say "Enable auto-updates." When clicked, the auto-updates feature is turned on for that plugin, and the button switches to say "Disable auto-updates".`

Typo: `"Enable auto-updates."` -> `"Enable auto-updates".`