### PR TITLE
Return WP_Error object on wpmu_create_user

### DIFF
--- a/src/wp-admin/network/site-new.php
+++ b/src/wp-admin/network/site-new.php
@@ -122,7 +122,7 @@ if ( isset( $_REQUEST['action'] ) && 'add-site' === $_REQUEST['action'] ) {
 		}
 		$password = wp_generate_password( 12, false );
 		$user_id  = wpmu_create_user( $domain, $password, $email );
-		if ( false === $user_id ) {
+		if ( is_wp_error( $user_id ) ) {
 			wp_die( __( 'There was an error creating the user.' ) );
 		}
 

--- a/src/wp-admin/network/site-new.php
+++ b/src/wp-admin/network/site-new.php
@@ -123,7 +123,7 @@ if ( isset( $_REQUEST['action'] ) && 'add-site' === $_REQUEST['action'] ) {
 		$password = wp_generate_password( 12, false );
 		$user_id  = wpmu_create_user( $domain, $password, $email );
 		if ( is_wp_error( $user_id ) ) {
-			wp_die( __( 'There was an error creating the user.' ) );
+			wp_die( sprintf( __( 'There was an error creating the user. %s' ), $user_id->get_error_message() ) );
 		}
 
 		/**

--- a/src/wp-admin/network/site-users.php
+++ b/src/wp-admin/network/site-users.php
@@ -68,7 +68,7 @@ if ( $action ) {
 				$password = wp_generate_password( 12, false );
 				$user_id  = wpmu_create_user( esc_html( strtolower( $user['username'] ) ), $password, esc_html( $user['email'] ) );
 
-				if ( false === $user_id ) {
+				if ( is_wp_error( $user_id ) ) {
 					$update = 'err_new_dup';
 				} else {
 					$result = add_user_to_blog( $id, $user_id, $_POST['new_role'] );

--- a/src/wp-admin/network/user-new.php
+++ b/src/wp-admin/network/user-new.php
@@ -51,7 +51,7 @@ if ( isset( $_REQUEST['action'] ) && 'add-user' === $_REQUEST['action'] ) {
 		$password = wp_generate_password( 12, false );
 		$user_id  = wpmu_create_user( esc_html( strtolower( $user['username'] ) ), $password, sanitize_email( $user['email'] ) );
 
-		if ( ! $user_id ) {
+		if ( is_wp_error( $user_id ) ) {
 			$add_user_errors = new WP_Error( 'add_user_fail', __( 'Cannot add user.' ) );
 		} else {
 			/**

--- a/src/wp-includes/ms-functions.php
+++ b/src/wp-includes/ms-functions.php
@@ -1187,7 +1187,7 @@ function wpmu_activate_signup( $key ) {
 		$user_already_exists = true;
 	}
 
-	if ( ! $user_id ) {
+	if ( is_wp_error( $user_id ) ) {
 		return new WP_Error( 'create_user', __( 'Could not create user' ), $signup );
 	}
 

--- a/src/wp-includes/ms-functions.php
+++ b/src/wp-includes/ms-functions.php
@@ -1307,28 +1307,30 @@ function wp_delete_signup_on_user_delete( $id, $reassign, $user ) {
  * @param string $user_name The new user's login name.
  * @param string $password  The new user's password.
  * @param string $email     The new user's email address.
- * @return int|false Returns false on failure, or int $user_id on success
+ * @return int|WP_Error     The newly created user's ID or a WP_Error object if the user could not
+ *                          be created.
  */
 function wpmu_create_user( $user_name, $password, $email ) {
 	$user_name = preg_replace( '/\s+/', '', sanitize_user( $user_name, true ) );
 
 	$user_id = wp_create_user( $user_name, $password, $email );
-	if ( is_wp_error( $user_id ) ) {
-		return false;
-	}
 
-	// Newly created users have no roles or caps until they are added to a blog.
-	delete_user_option( $user_id, 'capabilities' );
-	delete_user_option( $user_id, 'user_level' );
+	if ( ! is_wp_error( $user_id ) ) {
 
-	/**
-	 * Fires immediately after a new user is created.
-	 *
-	 * @since MU (3.0.0)
-	 *
-	 * @param int $user_id User ID.
-	 */
-	do_action( 'wpmu_new_user', $user_id );
+        // Newly created users have no roles or caps until they are added to a blog.
+        delete_user_option( $user_id, 'capabilities' );
+        delete_user_option( $user_id, 'user_level' );
+
+        /**
+         * Fires immediately after a new user is created.
+         *
+         * @since MU (3.0.0)
+         *
+         * @param int $user_id User ID.
+         */
+        do_action( 'wpmu_new_user', $user_id );
+
+    }
 
 	return $user_id;
 }

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
@@ -561,7 +561,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		if ( is_multisite() ) {
 			$user_id = wpmu_create_user( $user->user_login, $user->user_pass, $user->user_email );
 
-			if ( ! $user_id ) {
+			if ( is_wp_error( $user_id ) ) {
 				return new WP_Error(
 					'rest_user_create',
 					__( 'Error creating new user.' ),


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Return WP_Error object on failure from `wpmu_create_user()`

Trac ticket: https://core.trac.wordpress.org/ticket/50880


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
