### PR TITLE
Fix Search query parameter causes 404 on pagename match rules

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -2109,8 +2109,8 @@ class WP_Query {
 			}
 		}
 
-		// If a search pattern is specified, load the posts that match.
-		if ( strlen( $q['s'] ) ) {
+		// If this is a search query, and a search pattern is specified, load the posts that match.
+		if ( $this->is_search && strlen( $q['s'] ) ) {
 			$search = $this->parse_search( $q );
 		}
 

--- a/tests/phpunit/tests/query.php
+++ b/tests/phpunit/tests/query.php
@@ -696,4 +696,19 @@ class Tests_Query extends WP_UnitTestCase {
 		$this->assertSame( 'tax1', get_query_var( 'taxonomy' ) );
 		$this->assertSame( 'term1', get_query_var( 'term' ) );
 	}
+
+	/**
+	 * @ticket 50873
+	 */
+	public function test_post_match_result_with_search_query_should_not_return_404() {
+		$this->set_permalink_structure( '/%postname%/' );
+		$this->factory->post->create(
+			array(
+				'post_name'  => 'sample-post',
+				'post_title' => 'Sample Post',
+			)
+		);
+		$this->go_to( add_query_arg( 's', 'test-post', home_url( 'sample-post' ) ) );
+		$this->assertFalse( is_404() );
+	}
 }


### PR DESCRIPTION
This PR fixes the issue where 404 is returned when search query parameter is present and a post slug has a match. The PR uses `@daxelrod's` patch. I added a unit test.

Trac ticket: https://core.trac.wordpress.org/ticket/50873

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
