### PR TITLE
Trigger _doing_it_wrong() for wrong usages

### DIFF
--- a/src/wp-includes/functions.wp-scripts.php
+++ b/src/wp-includes/functions.wp-scripts.php
@@ -245,7 +245,36 @@ function wp_set_script_translations( $handle, $domain = 'default', $path = null 
 		return false;
 	}
 
-	return $wp_scripts->set_translations( $handle, $domain, $path );
+	$wp_scripts_set_translations = $wp_scripts->set_translations( $handle, $domain, $path );
+
+	if ( ! is_string( $domain ) ) {
+		$message = __( '$domain should be a string.' );
+
+		_doing_it_wrong(
+			__FUNCTION__,
+			$message,
+			'5.6.0'
+		);
+		return false;
+	}
+
+	if ( false === $wp_scripts_set_translations ) {
+		$message = sprintf(
+		/* translators: 1: The handle, 2: wp_set_script_translations */
+			__( '%1$s should be enqueued before using %2$s with it.' ),
+			"<code>{$handle}</code>",
+			'<code>' . __FUNCTION__ . '</code>'
+		);
+
+		_doing_it_wrong(
+			__FUNCTION__,
+			$message,
+			'5.6.0'
+		);
+		return false;
+	}
+
+	return $wp_scripts_set_translations;
 }
 
 /**

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -1413,4 +1413,20 @@ JS;
 			$this->assertSame( $found, 0, "sourceMappingURL found in $js_file" );
 		}
 	}
+
+	/**
+	 * @ticket 50749
+	 */
+	public function test_wp_set_script_translations_doing_it_wrong_for_non_string_domain() {
+		wp_set_script_translations( 'test-example', 123, DIR_TESTDATA . '/languages' );
+		$this->setExpectedIncorrectUsage( 'wp_set_script_translations' );
+	}
+
+	/**
+	 * @ticket 50749
+	 */
+	public function test_wp_set_script_translations_doing_it_wrong_for_early_call() {
+		wp_set_script_translations( 'test-example', 'default', DIR_TESTDATA . '/languages' );
+		$this->setExpectedIncorrectUsage( 'wp_set_script_translations' );
+	}
 }


### PR DESCRIPTION
Trigger `_doing_it_wrong()` when passed `$domain` is not a string and if `$wp_scripts->set_translations()` returns `false`.

Trac ticket: https://core.trac.wordpress.org/ticket/50749

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
