### PR TITLE
PHP 8.0: fix final private methods (Trac 50897)

### DIFF
--- a/src/wp-includes/class-wp-session-tokens.php
+++ b/src/wp-includes/class-wp-session-tokens.php
@@ -66,7 +66,7 @@ abstract class WP_Session_Tokens {
 	 * @param string $token Session token to hash.
 	 * @return string A hash of the session token (a verifier).
 	 */
-	final private function hash_token( $token ) {
+	private function hash_token( $token ) {
 		// If ext/hash is not present, use sha1() instead.
 		if ( function_exists( 'hash' ) ) {
 			return hash( 'sha256', $token );

--- a/tests/phpunit/tests/user/capabilities.php
+++ b/tests/phpunit/tests/user/capabilities.php
@@ -73,7 +73,7 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 		return $meta_value;
 	}
 
-	final private function _getSingleSitePrimitiveCaps() {
+	private function _getSingleSitePrimitiveCaps() {
 		return array(
 
 			'unfiltered_html'         => array( 'administrator', 'editor' ),
@@ -155,7 +155,7 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 
 	}
 
-	final private function _getMultiSitePrimitiveCaps() {
+	private function _getMultiSitePrimitiveCaps() {
 		return array(
 
 			'unfiltered_html'         => array(),
@@ -238,7 +238,7 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 
 	}
 
-	final private function _getSingleSiteMetaCaps() {
+	private function _getSingleSiteMetaCaps() {
 		return array(
 			'create_sites'                => array(),
 			'delete_sites'                => array(),
@@ -276,7 +276,7 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 		);
 	}
 
-	final private function _getMultiSiteMetaCaps() {
+	private function _getMultiSiteMetaCaps() {
 		return array(
 			'create_sites'                => array(),
 			'delete_sites'                => array(),


### PR DESCRIPTION
Declaring a `private` method as `final` is an oxymoron, as `private` methods cannot be overloaded anyway.

This will generate a warning in PHP 8.

Trac ticket: https://core.trac.wordpress.org/ticket/50897

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
