### PR TITLE
PHP 8.0: only call libxml_disable_entity_loader() in PHP < 8 (Trac 50898)

### DIFF
--- a/src/wp-includes/class-wp-oembed.php
+++ b/src/wp-includes/class-wp-oembed.php
@@ -597,13 +597,21 @@ class WP_oEmbed {
 			return false;
 		}
 
-		$loader = libxml_disable_entity_loader( true );
+		if ( PHP_VERSION_ID < 80000 ) {
+			// This function has been deprecated in PHP 8.0 because in libxml 2.9.0, external entity loading is
+			// disabled by default, so this function is no longer needed to protect against XXE attacks.
+			// phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.libxml_disable_entity_loaderDeprecated
+			$loader = libxml_disable_entity_loader( true );
+		}
 		$errors = libxml_use_internal_errors( true );
 
 		$return = $this->_parse_xml_body( $response_body );
 
 		libxml_use_internal_errors( $errors );
-		libxml_disable_entity_loader( $loader );
+		if ( PHP_VERSION_ID < 80000 && isset( $loader ) ) {
+			// phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.libxml_disable_entity_loaderDeprecated
+			libxml_disable_entity_loader( $loader );
+		}
 
 		return $return;
 	}


### PR DESCRIPTION
As per the PHP 8.0 changelog:

> `libxml_disable_entity_loader()` has been deprecated. As libxml 2.9.0 is now
> required, external entity loading is guaranteed to be disabled by default,
> and this function is no longer needed to protect against XXE attacks.

Source: https://github.com/php/php-src/blob/71bfa5344ab207072f4cd25745d7023096338385/UPGRADING#L808-L811

Calling the function conditionally will prevent deprecation warnings.

Trac ticket: https://core.trac.wordpress.org/ticket/50898

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
