### PR TITLE
PHP 8.0: change `create_function()` to closure (Trac 50899)

### DIFF
--- a/tests/phpunit/includes/plural-form-function.php
+++ b/tests/phpunit/includes/plural-form-function.php
@@ -7,11 +7,13 @@
  * @param string $expression
  */
 function tests_make_plural_form_function( $nplurals, $expression ) {
-	$expression = str_replace( 'n', '$n', $expression );
-	$func_body  = "
-		\$index = (int)($expression);
-		return (\$index < $nplurals)? \$index : $nplurals - 1;";
+	$closure = function ( $n ) use ( $nplurals, $expression ) {
+		$expression = str_replace( 'n', $n, $expression );
 
-	// phpcs:ignore WordPress.PHP.RestrictedPHPFunctions.create_function_create_function
-	return create_function( '$n', $func_body );
+		// phpcs:ignore Squiz.PHP.Eval -- This is test code, not production.
+		$index = (int) eval( 'return ' . $expression . ';' );
+		return ( $index < $nplurals ) ? $index : $nplurals - 1;
+	};
+
+	return $closure;
 }

--- a/tests/phpunit/tests/pomo/pluralForms.php
+++ b/tests/phpunit/tests/pomo/pluralForms.php
@@ -74,10 +74,6 @@ class PluralFormsTest extends WP_UnitTestCase {
 	 * @group external-http
 	 */
 	public function test_regression( $lang, $nplurals, $expression ) {
-		if ( version_compare( phpversion(), '7.2', '>=' ) ) {
-			$this->markTestSkipped( 'Lambda functions are deprecated in PHP 7.2' );
-		}
-
 		require_once dirname( dirname( __DIR__ ) ) . '/includes/plural-form-function.php';
 
 		$parenthesized = self::parenthesize_plural_expression( $expression );


### PR DESCRIPTION
`create_function()` has been removed in PHP 8.

While not optimal due to the usage of `eval`, this change _should_ work and shouldn't cause any real world issues as the logic is only used within the test suite.


Trac ticket: https://core.trac.wordpress.org/ticket/50899

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
