### PR TITLE
PHP 8.0: fix fatal "argument must be passed by reference, value given" [1] (Trac 50913-1)

### DIFF
--- a/src/wp-includes/class-wp-comment-query.php
+++ b/src/wp-includes/class-wp-comment-query.php
@@ -481,7 +481,8 @@ class WP_Comment_Query {
 		$_comments = apply_filters_ref_array( 'the_comments', array( $_comments, &$this ) );
 
 		// Convert to WP_Comment instances.
-		$comments = array_map( 'get_comment', $_comments );
+		array_walk( $_comments, 'get_comment' );
+		$comments = $_comments;
 
 		if ( $this->query_vars['hierarchical'] ) {
 			$comments = $this->fill_descendants( $comments );


### PR DESCRIPTION
The WP native `get_comment()` function expects the first argument `$comment` to be passed by reference.

The PHP `array_map()` function, however, passes by value, not by reference, resulting in a fatal `arguments must be passed by reference, value given` error.

The PHP native `array_walk()` function _does_ pass by reference. Using this prevents the fatal error on PHP 8 and maintains the existing behaviour on PHP < 8.

This patch fixes 96 errors + 62 failures + 3 warnings of the test failures on PHP 8.

Refs:
* https://developer.wordpress.org/reference/functions/get_comment/
* https://www.php.net/manual/en/function.array-map.php
* https://www.php.net/manual/en/function.array-walk.php

Trac ticket: https://core.trac.wordpress.org/ticket/50913

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
