### PR TITLE
Add "local" as an option to wp_get_environment_type

### DIFF
--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -149,6 +149,7 @@ function wp_get_environment_type() {
 	}
 
 	$wp_environments = array(
+		'local',
 		'development',
 		'staging',
 		'production',

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -134,7 +134,7 @@ function wp_check_php_mysql_versions() {
  * The type can be set via the `WP_ENVIRONMENT_TYPE` global system variable,
  * or a constant of the same name.
  *
- * Possible values include 'development', 'staging', 'production'. If not set,
+ * Possible values include 'local', 'development', 'staging', 'production'. If not set,
  * the type defaults to 'production'.
  *
  * @since 5.5.0


### PR DESCRIPTION
Add `local` as an option to `wp_get_environment_type()` so that developers can distinguish from cloud-hosted environments.

Trac ticket: https://core.trac.wordpress.org/ticket/51064

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
