### PR TITLE
Fix erroneous padding.

### DIFF
--- a/src/wp-admin/css/colors/modern/colors.scss
+++ b/src/wp-admin/css/colors/modern/colors.scss
@@ -6,9 +6,4 @@ $notification-color: $highlight-color;
 $link: $highlight-color;
 $link-focus: darken($highlight-color, 10%);
 
-
 @import "../_admin.scss";
-
-#adminmenu .wp-submenu, #adminmenu .wp-has-current-submenu .wp-submenu, #adminmenu .wp-has-current-submenu.opensub .wp-submenu, .folded #adminmenu .wp-has-current-submenu .wp-submenu, #adminmenu a.wp-has-current-submenu:focus + .wp-submenu {
-	padding-bottom: 12px;
-}


### PR DESCRIPTION
This PR fixes a padding value present in the modern scheme, which shouldn't be there.

Fixes https://core.trac.wordpress.org/ticket/51127

Before:

<img width="200" alt="Screenshot 2020-08-25 at 09 39 22" src="https://user-images.githubusercontent.com/1204802/91146756-9ca9d180-e6b7-11ea-9975-06f8eb71f210.png">

After:

<img width="179" alt="Screenshot 2020-08-25 at 09 42 52" src="https://user-images.githubusercontent.com/1204802/91146763-9f0c2b80-e6b7-11ea-92bd-950879f5a479.png">
