### PR TITLE
Trac 50617

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
@@ -252,7 +252,8 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		}
 
 		// Set modified_before into date query. Date query must be specified as an array of an array.
-		if ( isset( $registered['modified_before'], $request['modified_before'] ) ) {
+		// Guard against using 'before' and 'modified_before' in the same request.
+		if ( isset( $registered['modified_before'], $request['modified_before'] ) && ! isset( $request['after'] ) ) {
 			$prepared_args['date_query'][0]['before'] = $request['modified_before'];
 			$prepared_args['date_query'][0]['column'] = 'post_modified';
 		}
@@ -263,7 +264,8 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		}
 
 		// Set modified_after into date query. Date query must be specified as an array of an array.
-		if ( isset( $registered['modified_after'], $request['modified_after'] ) ) {
+		// Guard against using 'after' and 'modified_after' in the same request.
+		if ( isset( $registered['modified_after'], $request['modified_after'] ) && ! isset( $request['after'] ) ) {
 			$prepared_args['date_query'][0]['after']  = $request['modified_after'];
 			$prepared_args['date_query'][0]['column'] = 'post_modified';
 		}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
@@ -251,9 +251,21 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			$prepared_args['date_query'][0]['before'] = $request['before'];
 		}
 
+		// Set modified_before into date query. Date query must be specified as an array of an array.
+		if ( isset( $registered['modified_before'], $request['modified_before'] ) ) {
+			$prepared_args['date_query'][0]['before'] = $request['modified_before'];
+			$prepared_args['date_query'][0]['column'] = 'post_modified';
+		}
+
 		// Set after into date query. Date query must be specified as an array of an array.
 		if ( isset( $registered['after'], $request['after'] ) ) {
 			$prepared_args['date_query'][0]['after'] = $request['after'];
+		}
+
+		// Set modified_after into date query. Date query must be specified as an array of an array.
+		if ( isset( $registered['modified_after'], $request['modified_after'] ) ) {
+			$prepared_args['date_query'][0]['after']  = $request['modified_after'];
+			$prepared_args['date_query'][0]['column'] = 'post_modified';
 		}
 
 		if ( isset( $registered['page'] ) && empty( $request['offset'] ) ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
@@ -1550,6 +1550,12 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			'format'      => 'date-time',
 		);
 
+		$query_params['modified_after'] = array(
+			'description' => __( 'Limit response to comments modified after a given ISO8601 compliant date.' ),
+			'type'        => 'string',
+			'format'      => 'date-time',
+		);
+
 		$query_params['author'] = array(
 			'description' => __( 'Limit result set to comments assigned to specific user IDs. Requires authorization.' ),
 			'type'        => 'array',
@@ -1575,6 +1581,12 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 
 		$query_params['before'] = array(
 			'description' => __( 'Limit response to comments published before a given ISO8601 compliant date.' ),
+			'type'        => 'string',
+			'format'      => 'date-time',
+		);
+
+		$query_params['modified_before'] = array(
+			'description' => __( 'Limit response to comments modified before a given ISO8601 compliant date.' ),
 			'type'        => 'string',
 			'format'      => 'date-time',
 		);

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
@@ -251,9 +251,17 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			$prepared_args['date_query'][0]['before'] = $request['before'];
 		}
 
-		// Set modified_before into date query. Date query must be specified as an array of an array.
 		// Guard against using 'before' and 'modified_before' in the same request.
-		if ( isset( $registered['modified_before'], $request['modified_before'] ) && ! isset( $request['after'] ) ) {
+		if ( isset( $registered['modified_before'], $request['modified_before'] ) && isset( $request['before'] ) ) {
+			return new WP_Error(
+				'rest_comment_invalid_date_query',
+				__( 'Sorry, you cannot query by modified_before and before at the same time.' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		// Set modified_before into date query. Date query must be specified as an array of an array.
+		if ( isset( $registered['modified_before'], $request['modified_before'] ) && ! isset( $request['before'] ) ) {
 			$prepared_args['date_query'][0]['before'] = $request['modified_before'];
 			$prepared_args['date_query'][0]['column'] = 'post_modified';
 		}
@@ -263,8 +271,16 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			$prepared_args['date_query'][0]['after'] = $request['after'];
 		}
 
-		// Set modified_after into date query. Date query must be specified as an array of an array.
 		// Guard against using 'after' and 'modified_after' in the same request.
+		if ( isset( $registered['modified_after'], $request['modified_after'] ) && isset( $request['after'] ) ) {
+			return new WP_Error(
+				'rest_comment_invalid_date_query',
+				__( 'Sorry, you cannot query by modified_after and after at the same time.' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		// Set modified_after into date query. Date query must be specified as an array of an array.
 		if ( isset( $registered['modified_after'], $request['modified_after'] ) && ! isset( $request['after'] ) ) {
 			$prepared_args['date_query'][0]['after']  = $request['modified_after'];
 			$prepared_args['date_query'][0]['column'] = 'post_modified';

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
@@ -246,44 +246,32 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 
 		$prepared_args['date_query'] = array();
 
-		// Set before into date query. Date query must be specified as an array of an array.
 		if ( isset( $registered['before'], $request['before'] ) ) {
-			$prepared_args['date_query'][0]['before'] = $request['before'];
-		}
-
-		// Guard against using 'before' and 'modified_before' in the same request.
-		if ( isset( $registered['modified_before'], $request['modified_before'] ) && isset( $request['before'] ) ) {
-			return new WP_Error(
-				'rest_comment_invalid_date_query',
-				__( 'Sorry, you cannot query by modified_before and before at the same time.' ),
-				array( 'status' => 400 )
+			$prepared_args['date_query'][] = array(
+				'before' => $request['before'],
+				'column' => 'post_date',
 			);
 		}
 
-		// Set modified_before into date query. Date query must be specified as an array of an array.
-		if ( isset( $registered['modified_before'], $request['modified_before'] ) && ! isset( $request['before'] ) ) {
-			$prepared_args['date_query'][0]['before'] = $request['modified_before'];
-			$prepared_args['date_query'][0]['column'] = 'post_modified';
+		if ( isset( $registered['modified_before'], $request['modified_before'] ) ) {
+			$prepared_args['date_query'][] = array(
+				'before' => $request['modified_before'],
+				'column' => 'post_modified',
+			);
 		}
 
-		// Set after into date query. Date query must be specified as an array of an array.
 		if ( isset( $registered['after'], $request['after'] ) ) {
-			$prepared_args['date_query'][0]['after'] = $request['after'];
-		}
-
-		// Guard against using 'after' and 'modified_after' in the same request.
-		if ( isset( $registered['modified_after'], $request['modified_after'] ) && isset( $request['after'] ) ) {
-			return new WP_Error(
-				'rest_comment_invalid_date_query',
-				__( 'Sorry, you cannot query by modified_after and after at the same time.' ),
-				array( 'status' => 400 )
+			$prepared_args['date_query'][] = array(
+				'after'  => $request['after'],
+				'column' => 'post_date',
 			);
 		}
 
-		// Set modified_after into date query. Date query must be specified as an array of an array.
-		if ( isset( $registered['modified_after'], $request['modified_after'] ) && ! isset( $request['after'] ) ) {
-			$prepared_args['date_query'][0]['after']  = $request['modified_after'];
-			$prepared_args['date_query'][0]['column'] = 'post_modified';
+		if ( isset( $registered['modified_after'], $request['modified_after'] ) ) {
+			$prepared_args['date_query'][] = array(
+				'after'  => $request['modified_after'],
+				'column' => 'post_modified',
+			);
 		}
 
 		if ( isset( $registered['page'] ) && empty( $request['offset'] ) ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
@@ -246,32 +246,14 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 
 		$prepared_args['date_query'] = array();
 
+		// Set before into date query. Date query must be specified as an array of an array.
 		if ( isset( $registered['before'], $request['before'] ) ) {
-			$prepared_args['date_query'][] = array(
-				'before' => $request['before'],
-				'column' => 'post_date',
-			);
+			$prepared_args['date_query'][0]['before'] = $request['before'];
 		}
 
-		if ( isset( $registered['modified_before'], $request['modified_before'] ) ) {
-			$prepared_args['date_query'][] = array(
-				'before' => $request['modified_before'],
-				'column' => 'post_modified',
-			);
-		}
-
+		// Set after into date query. Date query must be specified as an array of an array.
 		if ( isset( $registered['after'], $request['after'] ) ) {
-			$prepared_args['date_query'][] = array(
-				'after'  => $request['after'],
-				'column' => 'post_date',
-			);
-		}
-
-		if ( isset( $registered['modified_after'], $request['modified_after'] ) ) {
-			$prepared_args['date_query'][] = array(
-				'after'  => $request['modified_after'],
-				'column' => 'post_modified',
-			);
+			$prepared_args['date_query'][0]['after'] = $request['after'];
 		}
 
 		if ( isset( $registered['page'] ) && empty( $request['offset'] ) ) {
@@ -1568,12 +1550,6 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			'format'      => 'date-time',
 		);
 
-		$query_params['modified_after'] = array(
-			'description' => __( 'Limit response to comments modified after a given ISO8601 compliant date.' ),
-			'type'        => 'string',
-			'format'      => 'date-time',
-		);
-
 		$query_params['author'] = array(
 			'description' => __( 'Limit result set to comments assigned to specific user IDs. Requires authorization.' ),
 			'type'        => 'array',
@@ -1599,12 +1575,6 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 
 		$query_params['before'] = array(
 			'description' => __( 'Limit response to comments published before a given ISO8601 compliant date.' ),
-			'type'        => 'string',
-			'format'      => 'date-time',
-		);
-
-		$query_params['modified_before'] = array(
-			'description' => __( 'Limit response to comments modified before a given ISO8601 compliant date.' ),
 			'type'        => 'string',
 			'format'      => 'date-time',
 		);

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -222,8 +222,8 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		}
 
 		// Set modified_before into date query. Date query must be specified as an array of an array.
-		if ( isset( $registered['modified_before'], $request['modified_before'] ) ) {
-			$args['date_query'][0]['modified_before'] = $request['modified_before'];
+		if ( isset( $registered['modified_before'], $request['modified_before'] ) && ! isset( $request['before'] ) ) {
+			$args['date_query'][0]['before'] = $request['modified_before'];
 			$args['date_query'][0]['column'] 		  = 'post_modified';
 		}
 
@@ -233,8 +233,8 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		}
 
 		// Set modified_after into date query. Date query must be specified as an array of an array.
-		if ( isset( $registered['modified_after'], $request['modified_after'] ) ) {
-			$args['date_query'][0]['modified_after'] = $request['modified_after'];
+		if ( isset( $registered['modified_after'], $request['modified_after'] ) && ! isset( $request['after'] ) ) {
+			$args['date_query'][0]['after'] = $request['modified_after'];
 			$args['date_query'][0]['column'] 		 = 'post_modified';
 		}
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -224,7 +224,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		// Set modified_before into date query. Date query must be specified as an array of an array.
 		if ( isset( $registered['modified_before'], $request['modified_before'] ) && ! isset( $request['before'] ) ) {
 			$args['date_query'][0]['before'] = $request['modified_before'];
-			$args['date_query'][0]['column'] 		  = 'post_modified';
+			$args['date_query'][0]['column'] = 'post_modified';
 		}
 
 		// Set after into date query. Date query must be specified as an array of an array.
@@ -235,7 +235,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		// Set modified_after into date query. Date query must be specified as an array of an array.
 		if ( isset( $registered['modified_after'], $request['modified_after'] ) && ! isset( $request['after'] ) ) {
 			$args['date_query'][0]['after'] = $request['modified_after'];
-			$args['date_query'][0]['column'] 		 = 'post_modified';
+			$args['date_query'][0]['column'] = 'post_modified';
 		}
 
 		// Ensure our per_page parameter overrides any provided posts_per_page filter.

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -224,6 +224,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		// Set modified_before into date query. Date query must be specified as an array of an array.
 		if ( isset( $registered['modified_before'], $request['modified_before'] ) ) {
 			$args['date_query'][0]['modified_before'] = $request['modified_before'];
+			$args['date_query'][0]['column'] 		  = 'post_modified';
 		}
 
 		// Set after into date query. Date query must be specified as an array of an array.
@@ -234,6 +235,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		// Set modified_after into date query. Date query must be specified as an array of an array.
 		if ( isset( $registered['modified_after'], $request['modified_after'] ) ) {
 			$args['date_query'][0]['modified_after'] = $request['modified_after'];
+			$args['date_query'][0]['column'] 		 = 'post_modified';
 		}
 
 		// Ensure our per_page parameter overrides any provided posts_per_page filter.

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -221,9 +221,19 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			$args['date_query'][0]['before'] = $request['before'];
 		}
 
+		// Set modified_before into date query. Date query must be specified as an array of an array.
+		if ( isset( $registered['modified_before'], $request['modified_before'] ) ) {
+			$args['date_query'][0]['modified_before'] = $request['modified_before'];
+		}
+
 		// Set after into date query. Date query must be specified as an array of an array.
 		if ( isset( $registered['after'], $request['after'] ) ) {
 			$args['date_query'][0]['after'] = $request['after'];
+		}
+
+		// Set modified_after into date query. Date query must be specified as an array of an array.
+		if ( isset( $registered['modified_after'], $request['modified_after'] ) ) {
+			$args['date_query'][0]['modified_after'] = $request['modified_after'];
 		}
 
 		// Ensure our per_page parameter overrides any provided posts_per_page filter.

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -221,8 +221,16 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			$args['date_query'][0]['before'] = $request['before'];
 		}
 
-		// Set modified_before into date query. Date query must be specified as an array of an array.
 		// Guard against using 'before' and 'modified_before' in the same request.
+		if ( isset( $registered['modified_before'], $request['modified_before'] ) && isset( $request['before'] ) ) {
+			return new WP_Error(
+				'rest_post_invalid_date_query',
+				__( 'Sorry, you cannot query by modified_before and before at the same time.' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		// Set modified_before into date query. Date query must be specified as an array of an array.
 		if ( isset( $registered['modified_before'], $request['modified_before'] ) && ! isset( $request['before'] ) ) {
 			$args['date_query'][0]['before'] = $request['modified_before'];
 			$args['date_query'][0]['column'] = 'post_modified';
@@ -233,8 +241,16 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			$args['date_query'][0]['after'] = $request['after'];
 		}
 
-		// Set modified_after into date query. Date query must be specified as an array of an array.
 		// Guard against using 'after' and 'modified_after' in the same request.
+		if ( isset( $registered['modified_after'], $request['modified_after'] ) && isset( $request['after'] ) ) {
+			return new WP_Error(
+				'rest_post_invalid_date_query',
+				__( 'Sorry, you cannot query by modified_after and after at the same time.' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		// Set modified_after into date query. Date query must be specified as an array of an array.
 		if ( isset( $registered['modified_after'], $request['modified_after'] ) && ! isset( $request['after'] ) ) {
 			$args['date_query'][0]['after']  = $request['modified_after'];
 			$args['date_query'][0]['column'] = 'post_modified';

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -2585,6 +2585,12 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			'format'      => 'date-time',
 		);
 
+		$query_params['modified_after'] = array(
+			'description' => __( 'Limit response to posts modified after a given ISO8601 compliant date.' ),
+			'type'        => 'string',
+			'format'      => 'date-time',
+		);
+
 		if ( post_type_supports( $this->post_type, 'author' ) ) {
 			$query_params['author']         = array(
 				'description' => __( 'Limit result set to posts assigned to specific authors.' ),
@@ -2606,6 +2612,12 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 		$query_params['before'] = array(
 			'description' => __( 'Limit response to posts published before a given ISO8601 compliant date.' ),
+			'type'        => 'string',
+			'format'      => 'date-time',
+		);
+
+		$query_params['modified_before'] = array(
+			'description' => __( 'Limit response to posts modified before a given ISO8601 compliant date.' ),
 			'type'        => 'string',
 			'format'      => 'date-time',
 		);

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -222,6 +222,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		}
 
 		// Set modified_before into date query. Date query must be specified as an array of an array.
+		// Guard against using 'before' and 'modified_before' in the same request.
 		if ( isset( $registered['modified_before'], $request['modified_before'] ) && ! isset( $request['before'] ) ) {
 			$args['date_query'][0]['before'] = $request['modified_before'];
 			$args['date_query'][0]['column'] = 'post_modified';
@@ -233,8 +234,9 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		}
 
 		// Set modified_after into date query. Date query must be specified as an array of an array.
+		// Guard against using 'after' and 'modified_after' in the same request.
 		if ( isset( $registered['modified_after'], $request['modified_after'] ) && ! isset( $request['after'] ) ) {
-			$args['date_query'][0]['after'] = $request['modified_after'];
+			$args['date_query'][0]['after']  = $request['modified_after'];
 			$args['date_query'][0]['column'] = 'post_modified';
 		}
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -216,44 +216,32 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		// Check for & assign any parameters which require special handling or setting.
 		$args['date_query'] = array();
 
-		// Set before into date query. Date query must be specified as an array of an array.
 		if ( isset( $registered['before'], $request['before'] ) ) {
-			$args['date_query'][0]['before'] = $request['before'];
-		}
-
-		// Guard against using 'before' and 'modified_before' in the same request.
-		if ( isset( $registered['modified_before'], $request['modified_before'] ) && isset( $request['before'] ) ) {
-			return new WP_Error(
-				'rest_post_invalid_date_query',
-				__( 'Sorry, you cannot query by modified_before and before at the same time.' ),
-				array( 'status' => 400 )
+			$args['date_query'][] = array(
+				'before' => $request['before'],
+				'column' => 'post_date',
 			);
 		}
 
-		// Set modified_before into date query. Date query must be specified as an array of an array.
-		if ( isset( $registered['modified_before'], $request['modified_before'] ) && ! isset( $request['before'] ) ) {
-			$args['date_query'][0]['before'] = $request['modified_before'];
-			$args['date_query'][0]['column'] = 'post_modified';
+		if ( isset( $registered['modified_before'], $request['modified_before'] ) ) {
+			$args['date_query'][] = array(
+				'before' => $request['modified_before'],
+				'column' => 'post_modified',
+			);
 		}
 
-		// Set after into date query. Date query must be specified as an array of an array.
 		if ( isset( $registered['after'], $request['after'] ) ) {
-			$args['date_query'][0]['after'] = $request['after'];
-		}
-
-		// Guard against using 'after' and 'modified_after' in the same request.
-		if ( isset( $registered['modified_after'], $request['modified_after'] ) && isset( $request['after'] ) ) {
-			return new WP_Error(
-				'rest_post_invalid_date_query',
-				__( 'Sorry, you cannot query by modified_after and after at the same time.' ),
-				array( 'status' => 400 )
+			$args['date_query'][] = array(
+				'after'  => $request['after'],
+				'column' => 'post_date',
 			);
 		}
 
-		// Set modified_after into date query. Date query must be specified as an array of an array.
-		if ( isset( $registered['modified_after'], $request['modified_after'] ) && ! isset( $request['after'] ) ) {
-			$args['date_query'][0]['after']  = $request['modified_after'];
-			$args['date_query'][0]['column'] = 'post_modified';
+		if ( isset( $registered['modified_after'], $request['modified_after'] ) ) {
+			$args['date_query'][] = array(
+				'after'  => $request['modified_after'],
+				'column' => 'post_modified',
+			);
 		}
 
 		// Ensure our per_page parameter overrides any provided posts_per_page filter.

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -566,6 +566,9 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$this->assertEquals( $id2, $data[0]['id'] );
 	}
 
+	/**
+	 * @ticket 50617
+	 */
 	public function test_get_items_invalid_modified_date() {
 		$request = new WP_REST_Request( 'GET', '/wp/v2/media' );
 		$request->set_param( 'modified_after', rand_str() );
@@ -574,6 +577,9 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
 	}
 
+	/**
+	 * @ticket 50617
+	 */
 	public function test_get_items_valid_modified_date() {
 		$id1     = $this->factory->attachment->create_object(
 			$this->test_file,

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -566,6 +566,51 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$this->assertEquals( $id2, $data[0]['id'] );
 	}
 
+	public function test_get_items_invalid_modified_date() {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/media' );
+		$request->set_param( 'modified_after', rand_str() );
+		$request->set_param( 'modified_before', rand_str() );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
+	}
+
+	public function test_get_items_valid_modified_date() {
+		$id1     = $this->factory->attachment->create_object(
+			$this->test_file,
+			0,
+			array(
+				'post_modified'  => '2016-01-15T00:00:00Z',
+				'post_mime_type' => 'image/jpeg',
+				'post_excerpt'   => 'A sample caption',
+			)
+		);
+		$id2     = $this->factory->attachment->create_object(
+			$this->test_file,
+			0,
+			array(
+				'post_modified'  => '2016-01-16T00:00:00Z',
+				'post_mime_type' => 'image/jpeg',
+				'post_excerpt'   => 'A sample caption',
+			)
+		);
+		$id3     = $this->factory->attachment->create_object(
+			$this->test_file,
+			0,
+			array(
+				'post_modified'  => '2016-01-17T00:00:00Z',
+				'post_mime_type' => 'image/jpeg',
+				'post_excerpt'   => 'A sample caption',
+			)
+		);
+		$request = new WP_REST_Request( 'GET', '/wp/v2/media' );
+		$request->set_param( 'modified_after', '2016-01-15T00:00:00Z' );
+		$request->set_param( 'modified_before', '2016-01-17T00:00:00Z' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		$this->assertCount( 1, $data );
+		$this->assertEquals( $id2, $data[0]['id'] );
+	}
+
 	public function test_get_item() {
 		$attachment_id = $this->factory->attachment->create_object(
 			$this->test_file,

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -587,7 +587,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 			$this->test_file,
 			0,
 			array(
-				'post_date'      => '2016-01-01T00:00:00Z',
+				'post_date'      => '2016-01-01 00:00:00',
 				'post_mime_type' => 'image/jpeg',
 				'post_excerpt'   => 'A sample caption',
 			)
@@ -596,7 +596,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 			$this->test_file,
 			0,
 			array(
-				'post_date'      => '2016-01-02T00:00:00Z',
+				'post_date'      => '2016-01-02 00:00:00',
 				'post_mime_type' => 'image/jpeg',
 				'post_excerpt'   => 'A sample caption',
 			)
@@ -605,17 +605,17 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 			$this->test_file,
 			0,
 			array(
-				'post_date'      => '2016-01-03T00:00:00Z',
+				'post_date'      => '2016-01-03 00:00:00',
 				'post_mime_type' => 'image/jpeg',
 				'post_excerpt'   => 'A sample caption',
 			)
 		);
-		$this->update_post_modified( $id1, '2016-01-15T00:00:00Z' );
-		$this->update_post_modified( $id2, '2016-01-16T00:00:00Z' );
-		$this->update_post_modified( $id3, '2016-01-17T00:00:00Z' );
+		$this->update_post_modified( $id1, '2016-01-15 00:00:00' );
+		$this->update_post_modified( $id2, '2016-01-16 00:00:00' );
+		$this->update_post_modified( $id3, '2016-01-17 00:00:00' );
 		$request = new WP_REST_Request( 'GET', '/wp/v2/media' );
-		$request->set_param( 'modified_after', '2016-01-15T00:00:00Z' );
-		$request->set_param( 'modified_before', '2016-01-17T00:00:00Z' );
+		$request->set_param( 'modified_after', '2016-01-15 00:00:00' );
+		$request->set_param( 'modified_before', '2016-01-17 00:00:00' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 		$this->assertCount( 1, $data );

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -198,6 +198,8 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 				'include',
 				'media_type',
 				'mime_type',
+				'modified_after',
+				'modified_before',
 				'offset',
 				'order',
 				'orderby',

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -583,33 +583,36 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	 * @ticket 50617
 	 */
 	public function test_get_items_valid_modified_date() {
-		$id1     = $this->factory->attachment->create_object(
+		$id1 = $this->factory->attachment->create_object(
 			$this->test_file,
 			0,
 			array(
-				'post_modified'  => '2016-01-15T00:00:00Z',
+				'post_date'      => '2016-01-01T00:00:00Z',
 				'post_mime_type' => 'image/jpeg',
 				'post_excerpt'   => 'A sample caption',
 			)
 		);
-		$id2     = $this->factory->attachment->create_object(
+		$id2 = $this->factory->attachment->create_object(
 			$this->test_file,
 			0,
 			array(
-				'post_modified'  => '2016-01-16T00:00:00Z',
+				'post_date'      => '2016-01-02T00:00:00Z',
 				'post_mime_type' => 'image/jpeg',
 				'post_excerpt'   => 'A sample caption',
 			)
 		);
-		$id3     = $this->factory->attachment->create_object(
+		$id3 = $this->factory->attachment->create_object(
 			$this->test_file,
 			0,
 			array(
-				'post_modified'  => '2016-01-17T00:00:00Z',
+				'post_date'      => '2016-01-03T00:00:00Z',
 				'post_mime_type' => 'image/jpeg',
 				'post_excerpt'   => 'A sample caption',
 			)
 		);
+		$this->update_post_modified( $id1, '2016-01-15T00:00:00Z' );
+		$this->update_post_modified( $id2, '2016-01-16T00:00:00Z' );
+		$this->update_post_modified( $id3, '2016-01-17T00:00:00Z' );
 		$request = new WP_REST_Request( 'GET', '/wp/v2/media' );
 		$request->set_param( 'modified_after', '2016-01-15T00:00:00Z' );
 		$request->set_param( 'modified_before', '2016-01-17T00:00:00Z' );

--- a/tests/phpunit/tests/rest-api/rest-pages-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-pages-controller.php
@@ -361,6 +361,42 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertEquals( $post2, $data[0]['id'] );
 	}
 
+	public function test_get_items_invalid_modified_date() {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/pages' );
+		$request->set_param( 'modified_after', rand_str() );
+		$request->set_param( 'modified_before', rand_str() );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
+	}
+
+	public function test_get_items_valid_modified_date() {
+		$post1   = $this->factory->post->create(
+			array(
+				'post_modified' => '2016-01-15T00:00:00Z',
+				'post_type' => 'page',
+			)
+		);
+		$post2   = $this->factory->post->create(
+			array(
+				'post_modified' => '2016-01-16T00:00:00Z',
+				'post_type' => 'page',
+			)
+		);
+		$post3   = $this->factory->post->create(
+			array(
+				'post_modified' => '2016-01-17T00:00:00Z',
+				'post_type' => 'page',
+			)
+		);
+		$request = new WP_REST_Request( 'GET', '/wp/v2/pages' );
+		$request->set_param( 'modified_after', '2016-01-15T00:00:00Z' );
+		$request->set_param( 'modified_before', '2016-01-17T00:00:00Z' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		$this->assertCount( 1, $data );
+		$this->assertEquals( $post2, $data[0]['id'] );
+	}
+
 	public function test_get_item() {
 
 	}

--- a/tests/phpunit/tests/rest-api/rest-pages-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-pages-controller.php
@@ -373,19 +373,19 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$post1   = $this->factory->post->create(
 			array(
 				'post_modified' => '2016-01-15T00:00:00Z',
-				'post_type' => 'page',
+				'post_type'     => 'page',
 			)
 		);
 		$post2   = $this->factory->post->create(
 			array(
 				'post_modified' => '2016-01-16T00:00:00Z',
-				'post_type' => 'page',
+				'post_type'     => 'page',
 			)
 		);
 		$post3   = $this->factory->post->create(
 			array(
 				'post_modified' => '2016-01-17T00:00:00Z',
-				'post_type' => 'page',
+				'post_type'     => 'page',
 			)
 		);
 		$request = new WP_REST_Request( 'GET', '/wp/v2/pages' );

--- a/tests/phpunit/tests/rest-api/rest-pages-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-pages-controller.php
@@ -361,6 +361,9 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertEquals( $post2, $data[0]['id'] );
 	}
 
+	/**
+	 * @ticket 50617
+	 */
 	public function test_get_items_invalid_modified_date() {
 		$request = new WP_REST_Request( 'GET', '/wp/v2/pages' );
 		$request->set_param( 'modified_after', rand_str() );
@@ -369,6 +372,9 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
 	}
 
+	/**
+	 * @ticket 50617
+	 */
 	public function test_get_items_valid_modified_date() {
 		$post1   = $this->factory->post->create(
 			array(

--- a/tests/phpunit/tests/rest-api/rest-pages-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-pages-controller.php
@@ -380,28 +380,28 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_get_items_valid_modified_date() {
 		$post1 = $this->factory->post->create(
 			array(
-				'post_date' => '2016-01-01T00:00:00Z',
+				'post_date' => '2016-01-01 00:00:00',
 				'post_type' => 'page',
 			)
 		);
 		$post2 = $this->factory->post->create(
 			array(
-				'post_date' => '2016-01-02T00:00:00Z',
+				'post_date' => '2016-01-02 00:00:00',
 				'post_type' => 'page',
 			)
 		);
 		$post3 = $this->factory->post->create(
 			array(
-				'post_date' => '2016-01-03T00:00:00Z',
+				'post_date' => '2016-01-03 00:00:00',
 				'post_type' => 'page',
 			)
 		);
-		$this->update_post_modified( $post1, '2016-01-15T00:00:00Z' );
-		$this->update_post_modified( $post2, '2016-01-16T00:00:00Z' );
-		$this->update_post_modified( $post3, '2016-01-17T00:00:00Z' );
+		$this->update_post_modified( $post1, '2016-01-15 00:00:00' );
+		$this->update_post_modified( $post2, '2016-01-16 00:00:00' );
+		$this->update_post_modified( $post3, '2016-01-17 00:00:00' );
 		$request = new WP_REST_Request( 'GET', '/wp/v2/pages' );
-		$request->set_param( 'modified_after', '2016-01-15T00:00:00Z' );
-		$request->set_param( 'modified_before', '2016-01-17T00:00:00Z' );
+		$request->set_param( 'modified_after', '2016-01-15 00:00:00' );
+		$request->set_param( 'modified_before', '2016-01-17 00:00:00' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 		$this->assertCount( 1, $data );

--- a/tests/phpunit/tests/rest-api/rest-pages-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-pages-controller.php
@@ -378,24 +378,27 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	 * @ticket 50617
 	 */
 	public function test_get_items_valid_modified_date() {
-		$post1   = $this->factory->post->create(
+		$post1 = $this->factory->post->create(
 			array(
-				'post_modified' => '2016-01-15T00:00:00Z',
-				'post_type'     => 'page',
+				'post_date' => '2016-01-01T00:00:00Z',
+				'post_type' => 'page',
 			)
 		);
-		$post2   = $this->factory->post->create(
+		$post2 = $this->factory->post->create(
 			array(
-				'post_modified' => '2016-01-16T00:00:00Z',
-				'post_type'     => 'page',
+				'post_date' => '2016-01-02T00:00:00Z',
+				'post_type' => 'page',
 			)
 		);
-		$post3   = $this->factory->post->create(
+		$post3 = $this->factory->post->create(
 			array(
-				'post_modified' => '2016-01-17T00:00:00Z',
-				'post_type'     => 'page',
+				'post_date' => '2016-01-03T00:00:00Z',
+				'post_type' => 'page',
 			)
 		);
+		$this->update_post_modified( $post1, '2016-01-15T00:00:00Z' );
+		$this->update_post_modified( $post2, '2016-01-16T00:00:00Z' );
+		$this->update_post_modified( $post3, '2016-01-17T00:00:00Z' );
 		$request = new WP_REST_Request( 'GET', '/wp/v2/pages' );
 		$request->set_param( 'modified_after', '2016-01-15T00:00:00Z' );
 		$request->set_param( 'modified_before', '2016-01-17T00:00:00Z' );

--- a/tests/phpunit/tests/rest-api/rest-pages-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-pages-controller.php
@@ -76,6 +76,8 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 				'exclude',
 				'include',
 				'menu_order',
+				'modified_after',
+				'modified_before',
 				'offset',
 				'order',
 				'orderby',

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -1490,6 +1490,28 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertEquals( $post2, $data[0]['id'] );
 	}
 
+	public function test_get_items_invalid_modified_date() {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
+		$request->set_param( 'modified_after', rand_str() );
+		$request->set_param( 'modified_before', rand_str() );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
+	}
+
+	public function test_get_items_valid_modified_date() {
+		$post1 = $this->factory->post->create( array( 'post_modified' => '2016-01-15T00:00:00Z' ) );
+		$post2 = $this->factory->post->create( array( 'post_modified' => '2016-01-16T00:00:00Z' ) );
+		$post3 = $this->factory->post->create( array( 'post_modified' => '2016-01-17T00:00:00Z' ) );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
+		$request->set_param( 'modified_after', '2016-01-15T00:00:00Z' );
+		$request->set_param( 'modified_before', '2016-01-17T00:00:00Z' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		$this->assertCount( 1, $data );
+		$this->assertEquals( $post2, $data[0]['id'] );
+	}
+
 	public function test_get_items_all_post_formats() {
 		$request  = new WP_REST_Request( 'OPTIONS', '/wp/v2/posts' );
 		$response = rest_get_server()->dispatch( $request );

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -1490,6 +1490,9 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertEquals( $post2, $data[0]['id'] );
 	}
 
+	/**
+	 * @ticket 50617
+	 */
 	public function test_get_items_invalid_modified_date() {
 		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
 		$request->set_param( 'modified_after', rand_str() );
@@ -1498,6 +1501,9 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
 	}
 
+	/**
+	 * @ticket 50617
+	 */
 	public function test_get_items_valid_modified_date() {
 		$post1 = $this->factory->post->create( array( 'post_modified' => '2016-01-15T00:00:00Z' ) );
 		$post2 = $this->factory->post->create( array( 'post_modified' => '2016-01-16T00:00:00Z' ) );

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -1507,15 +1507,15 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	 * @ticket 50617
 	 */
 	public function test_get_items_valid_modified_date() {
-		$post1 = $this->factory->post->create( array( 'post_date' => '2016-01-01T00:00:00Z' ) );
-		$post2 = $this->factory->post->create( array( 'post_date' => '2016-01-02T00:00:00Z' ) );
-		$post3 = $this->factory->post->create( array( 'post_date' => '2016-01-03T00:00:00Z' ) );
-		$this->update_post_modified( $post1, '2016-01-15T00:00:00Z' );
-		$this->update_post_modified( $post2, '2016-01-16T00:00:00Z' );
-		$this->update_post_modified( $post3, '2016-01-17T00:00:00Z' );
+		$post1 = $this->factory->post->create( array( 'post_date' => '2016-01-01 00:00:00' ) );
+		$post2 = $this->factory->post->create( array( 'post_date' => '2016-01-02 00:00:00' ) );
+		$post3 = $this->factory->post->create( array( 'post_date' => '2016-01-03 00:00:00' ) );
+		$this->update_post_modified( $post1, '2016-01-15 00:00:00' );
+		$this->update_post_modified( $post2, '2016-01-16 00:00:00' );
+		$this->update_post_modified( $post3, '2016-01-17 00:00:00' );
 		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
-		$request->set_param( 'modified_after', '2016-01-15T00:00:00Z' );
-		$request->set_param( 'modified_before', '2016-01-17T00:00:00Z' );
+		$request->set_param( 'modified_after', '2016-01-15 00:00:00' );
+		$request->set_param( 'modified_before', '2016-01-17 00:00:00' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 		$this->assertCount( 1, $data );

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -181,6 +181,8 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 				'context',
 				'exclude',
 				'include',
+				'modified_after',
+				'modified_before',
 				'offset',
 				'order',
 				'orderby',

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -1507,10 +1507,12 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	 * @ticket 50617
 	 */
 	public function test_get_items_valid_modified_date() {
-		$post1 = $this->factory->post->create( array( 'post_modified' => '2016-01-15T00:00:00Z' ) );
-		$post2 = $this->factory->post->create( array( 'post_modified' => '2016-01-16T00:00:00Z' ) );
-		$post3 = $this->factory->post->create( array( 'post_modified' => '2016-01-17T00:00:00Z' ) );
-
+		$post1 = $this->factory->post->create( array( 'post_date' => '2016-01-01T00:00:00Z' ) );
+		$post2 = $this->factory->post->create( array( 'post_date' => '2016-01-02T00:00:00Z' ) );
+		$post3 = $this->factory->post->create( array( 'post_date' => '2016-01-03T00:00:00Z' ) );
+		$this->update_post_modified( $post1, '2016-01-15T00:00:00Z' );
+		$this->update_post_modified( $post2, '2016-01-16T00:00:00Z' );
+		$this->update_post_modified( $post3, '2016-01-17T00:00:00Z' );
 		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
 		$request->set_param( 'modified_after', '2016-01-15T00:00:00Z' );
 		$request->set_param( 'modified_before', '2016-01-17T00:00:00Z' );


### PR DESCRIPTION
Code and tests for adding an additional query parameter to the REST API request. 

Added two new arguments, `modified_before` and `modified_after` which request data based on the `post_modified` field from the WP_Post object.

Trac ticket: https://core.trac.wordpress.org/ticket/50617

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
