### PR TITLE
Set $GLOBALS['wp_sitemaps'] = null so that sitemaps will correctly be initialized before each test is run

### DIFF
--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -161,6 +161,9 @@ abstract class WP_UnitTestCase_Base extends PHPUnit\Framework\TestCase {
 			$GLOBALS[ $global ] = null;
 		}
 
+		// Reset $wp_sitemap global so that sitemap-related dynamic $wp->public_query_vars are added when the next test runs.
+		$GLOBALS['wp_sitemaps'] = null;
+
 		$this->unregister_all_meta_keys();
 		remove_theme_support( 'html5' );
 		remove_filter( 'query', array( $this, '_create_temporary_tables' ) );

--- a/tests/phpunit/tests/query/vars.php
+++ b/tests/phpunit/tests/query/vars.php
@@ -9,6 +9,7 @@ class Tests_Query_Vars extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 35115
+	 * @ticket 51154
 	 */
 	public function testPublicQueryVarsAreAsExpected() {
 		global $wp;
@@ -70,6 +71,9 @@ class Tests_Query_Vars extends WP_UnitTestCase {
 				// Dynamically added public query vars:
 				'post_format',
 				'rest_route',
+				'sitemap',
+				'sitemap-subtype',
+				'sitemap-stylesheet',
 
 			),
 			$wp->public_query_vars,


### PR DESCRIPTION
See https://core.trac.wordpress.org/ticket/51154.

I expect that `testPublicQueryVarsAreAsExpected()` will fail after this.  I will then update this PR with the necessary correction.