### PR TITLE
No longer allow changing the environment type

### DIFF
--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -150,12 +150,21 @@ function wp_get_environment_type() {
 	}
 
 	$wp_environments = array(
-		'offline',
 		'local',
 		'development',
 		'staging',
 		'production',
 	);
+
+	// Add note about deprecated WPLANG constant.
+	if ( defined( 'WP_ENVIRONMENT_TYPES' ) ) {
+		_deprecated_argument(
+			'define()',
+			'4.0.0',
+			/* translators: 1: WP_ENVIRONMENT_TYPES */
+			sprintf( __( 'The %1$s constant is no longer supported.' ), 'WP_ENVIRONMENT_TYPES' )
+		);
+	}
 
 	// Check if the environment variable has been set, if `getenv` is available on the system.
 	if ( function_exists( 'getenv' ) ) {
@@ -164,7 +173,7 @@ function wp_get_environment_type() {
 			$current_env = $has_env;
 		}
 	}
-	
+
 	// Fetch the environment from a constant, this overrides the global system variable.
 	if ( defined( 'WP_ENVIRONMENT_TYPE' ) ) {
 		$current_env = WP_ENVIRONMENT_TYPE;

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -160,7 +160,7 @@ function wp_get_environment_type() {
 	if ( defined( 'WP_ENVIRONMENT_TYPES' ) ) {
 		_deprecated_argument(
 			'define()',
-			'4.0.0',
+			'5.5.1',
 			/* translators: 1: WP_ENVIRONMENT_TYPES */
 			sprintf( __( 'The %1$s constant is no longer supported.' ), 'WP_ENVIRONMENT_TYPES' )
 		);

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -162,6 +162,14 @@ function wp_get_environment_type() {
 		$current_env = WP_ENVIRONMENT_TYPE;
 	}
 
+	// Check if the environment variable has been set, if `getenv` is available on the system.
+	if ( function_exists( 'getenv' ) ) {
+		$has_env = getenv( 'WP_ENVIRONMENT_TYPE' );
+		if ( false !== $has_env ) {
+			$current_env = $has_env;
+		}
+	}
+	
 	// Make sure the environment is an allowed one, and not accidentally set to an invalid value.
 	if ( ! in_array( $current_env, $wp_environments, true ) ) {
 		$current_env = 'production';

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -150,32 +150,12 @@ function wp_get_environment_type() {
 	}
 
 	$wp_environments = array(
+		'offline',
 		'local',
 		'development',
 		'staging',
 		'production',
 	);
-
-	// Check if the environment variable has been set, if `getenv` is available on the system.
-	if ( function_exists( 'getenv' ) ) {
-		$has_env = getenv( 'WP_ENVIRONMENT_TYPES' );
-		if ( false !== $has_env ) {
-			$wp_environments = explode( ',', $has_env );
-		}
-	}
-
-	// Fetch the environment types from a constant, this overrides the global system variable.
-	if ( defined( 'WP_ENVIRONMENT_TYPES' ) ) {
-		$wp_environments = WP_ENVIRONMENT_TYPES;
-	}
-
-	// Check if the environment variable has been set, if `getenv` is available on the system.
-	if ( function_exists( 'getenv' ) ) {
-		$has_env = getenv( 'WP_ENVIRONMENT_TYPE' );
-		if ( false !== $has_env ) {
-			$current_env = $has_env;
-		}
-	}
 
 	// Fetch the environment from a constant, this overrides the global system variable.
 	if ( defined( 'WP_ENVIRONMENT_TYPE' ) ) {

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -157,11 +157,6 @@ function wp_get_environment_type() {
 		'production',
 	);
 
-	// Fetch the environment from a constant, this overrides the global system variable.
-	if ( defined( 'WP_ENVIRONMENT_TYPE' ) ) {
-		$current_env = WP_ENVIRONMENT_TYPE;
-	}
-
 	// Check if the environment variable has been set, if `getenv` is available on the system.
 	if ( function_exists( 'getenv' ) ) {
 		$has_env = getenv( 'WP_ENVIRONMENT_TYPE' );
@@ -170,6 +165,11 @@ function wp_get_environment_type() {
 		}
 	}
 	
+	// Fetch the environment from a constant, this overrides the global system variable.
+	if ( defined( 'WP_ENVIRONMENT_TYPE' ) ) {
+		$current_env = WP_ENVIRONMENT_TYPE;
+	}
+
 	// Make sure the environment is an allowed one, and not accidentally set to an invalid value.
 	if ( ! in_array( $current_env, $wp_environments, true ) ) {
 		$current_env = 'production';

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -156,7 +156,7 @@ function wp_get_environment_type() {
 		'production',
 	);
 
-	// Add note about deprecated WPLANG constant.
+	// Add note about deprecated WP_ENVIRONMENT_TYPES constant.
 	if ( defined( 'WP_ENVIRONMENT_TYPES' ) ) {
 		_deprecated_argument(
 			'define()',


### PR DESCRIPTION
Removes the ability to change the allowed environment types.

Trac ticket: https://core.trac.wordpress.org/ticket/50992

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
