### PR TITLE
Move and update unit tests for selected() and checked()

### DIFF
--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -552,10 +552,10 @@ function get_comment_class( $class = '', $comment_id = null, $post_id = null ) {
 function get_comment_date( $format = '', $comment_ID = 0 ) {
 	$comment = get_comment( $comment_ID );
 
-	if ( '' === $format || false === $format ) {
-		$date = mysql2date( get_option( 'date_format' ), $comment->comment_date );
-	} else {
+	if ( is_string( $format ) && '' !== $format ) {
 		$date = mysql2date( $format, $comment->comment_date );
+	} else {
+		$date = mysql2date( get_option( 'date_format' ), $comment->comment_date );
 	}
 
 	/**
@@ -1046,10 +1046,10 @@ function get_comment_time( $format = '', $gmt = false, $translate = true ) {
 
 	$comment_date = $gmt ? $comment->comment_date_gmt : $comment->comment_date;
 
-	if ( '' === $format || false === $format ) {
-		$date = mysql2date( get_option( 'time_format' ), $comment_date, $translate );
-	} else {
+	if ( is_string( $format ) && '' !== $format ) {
 		$date = mysql2date( $format, $comment_date, $translate );
+	} else {
+		$date = mysql2date( get_option( 'time_format' ), $comment_date, $translate );
 	}
 
 	/**

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -544,7 +544,7 @@ function get_comment_class( $class = '', $comment_id = null, $post_id = null ) {
  * @since 1.5.0
  * @since 4.4.0 Added the ability for `$comment_ID` to also accept a WP_Comment object.
  *
- * @param string         $format     Optional. The format of the date. Default user's setting.
+ * @param string|false   $format     Optional. The format of the date. Default user's setting.
  * @param int|WP_Comment $comment_ID WP_Comment or ID of the comment for which to get the date.
  *                                   Default current comment.
  * @return string The comment's date.
@@ -552,7 +552,7 @@ function get_comment_class( $class = '', $comment_id = null, $post_id = null ) {
 function get_comment_date( $format = '', $comment_ID = 0 ) {
 	$comment = get_comment( $comment_ID );
 
-	if ( '' === $format ) {
+	if ( '' === $format || false === $format ) {
 		$date = mysql2date( get_option( 'date_format' ), $comment->comment_date );
 	} else {
 		$date = mysql2date( $format, $comment->comment_date );
@@ -1035,10 +1035,10 @@ function comment_text( $comment_ID = 0, $args = array() ) {
  *
  * @since 1.5.0
  *
- * @param string $format    Optional. The format of the time. Default user's settings.
- * @param bool   $gmt       Optional. Whether to use the GMT date. Default false.
- * @param bool   $translate Optional. Whether to translate the time (for use in feeds).
- *                          Default true.
+ * @param string|false $format    Optional. The format of the time. Default user's settings.
+ * @param bool         $gmt       Optional. Whether to use the GMT date. Default false.
+ * @param bool         $translate Optional. Whether to translate the time (for use in feeds).
+ *                                Default true.
  * @return string The formatted time.
  */
 function get_comment_time( $format = '', $gmt = false, $translate = true ) {
@@ -1046,7 +1046,7 @@ function get_comment_time( $format = '', $gmt = false, $translate = true ) {
 
 	$comment_date = $gmt ? $comment->comment_date_gmt : $comment->comment_date;
 
-	if ( '' === $format ) {
+	if ( '' === $format || false === $format ) {
 		$date = mysql2date( get_option( 'time_format' ), $comment_date, $translate );
 	} else {
 		$date = mysql2date( $format, $comment_date, $translate );

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -545,12 +545,12 @@ function get_comment_class( $class = '', $comment_id = null, $post_id = null ) {
  * @since 4.4.0 Added the ability for `$comment_ID` to also accept a WP_Comment object.
  *
  * @param string         $format     Optional. The format of the date. Default user's setting.
- * @param int|WP_Comment $comment_ID WP_Comment or ID of the comment for which to get the date.
+ * @param int|WP_Comment $comment_id WP_Comment or ID of the comment for which to get the date.
  *                                   Default current comment.
  * @return string The comment's date.
  */
-function get_comment_date( $format = '', $comment_ID = 0 ) {
-	$comment = get_comment( $comment_ID );
+function get_comment_date( $format = '', $comment_id = 0 ) {
+	$comment = get_comment( $comment_id );
 
 	if ( is_string( $format ) && '' !== $format ) {
 		$date = mysql2date( $format, $comment->comment_date );

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -544,7 +544,7 @@ function get_comment_class( $class = '', $comment_id = null, $post_id = null ) {
  * @since 1.5.0
  * @since 4.4.0 Added the ability for `$comment_ID` to also accept a WP_Comment object.
  *
- * @param string|false   $format     Optional. The format of the date. Default user's setting.
+ * @param string         $format     Optional. The format of the date. Default user's setting.
  * @param int|WP_Comment $comment_ID WP_Comment or ID of the comment for which to get the date.
  *                                   Default current comment.
  * @return string The comment's date.
@@ -1035,10 +1035,10 @@ function comment_text( $comment_ID = 0, $args = array() ) {
  *
  * @since 1.5.0
  *
- * @param string|false $format    Optional. The format of the time. Default user's settings.
- * @param bool         $gmt       Optional. Whether to use the GMT date. Default false.
- * @param bool         $translate Optional. Whether to translate the time (for use in feeds).
- *                                Default true.
+ * @param string $format    Optional. The format of the time. Default user's settings.
+ * @param bool   $gmt       Optional. Whether to use the GMT date. Default false.
+ * @param bool   $translate Optional. Whether to translate the time (for use in feeds).
+ *                          Default true.
  * @return string The formatted time.
  */
 function get_comment_time( $format = '', $gmt = false, $translate = true ) {

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -2514,8 +2514,8 @@ function the_date( $format = '', $before = '', $after = '', $echo = true ) {
  *
  * @since 3.0.0
  *
- * @param string|false  $format Optional. PHP date format defaults to the date_format option if not specified.
- * @param int|WP_Post   $post   Optional. Post ID or WP_Post object. Default current post.
+ * @param string      $format Optional. PHP date format defaults to the date_format option if not specified.
+ * @param int|WP_Post $post   Optional. Post ID or WP_Post object. Default current post.
  * @return string|false Date the current post was written. False on failure.
  */
 function get_the_date( $format = '', $post = null ) {
@@ -2640,10 +2640,10 @@ function the_time( $format = '' ) {
  *
  * @since 1.5.0
  *
- * @param string|false $format Optional. Format to use for retrieving the time the post
- *                             was written. Either 'G', 'U', or PHP date format defaults
- *                             to the value specified in the time_format option. Default empty.
- * @param int|WP_Post  $post   WP_Post object or ID. Default is global `$post` object.
+ * @param string      $format Optional. Format to use for retrieving the time the post
+ *                            was written. Either 'G', 'U', or PHP date format defaults
+ *                            to the value specified in the time_format option. Default empty.
+ * @param int|WP_Post $post   WP_Post object or ID. Default is global `$post` object.
  * @return string|int|false Formatted date string or Unix timestamp if `$format` is 'U' or 'G'.
  *                          False on failure.
  */

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -2525,10 +2525,10 @@ function get_the_date( $format = '', $post = null ) {
 		return false;
 	}
 
-	if ( '' === $format || false === $format ) {
-		$the_date = get_post_time( get_option( 'date_format' ), false, $post, true );
-	} else {
+	if ( is_string( $format ) && '' !== $format ) {
 		$the_date = get_post_time( $format, false, $post, true );
+	} else {
+		$the_date = get_post_time( get_option( 'date_format' ), false, $post, true );
 	}
 
 	/**
@@ -2654,10 +2654,10 @@ function get_the_time( $format = '', $post = null ) {
 		return false;
 	}
 
-	if ( '' === $format || false === $format ) {
-		$the_time = get_post_time( get_option( 'time_format' ), false, $post, true );
-	} else {
+	if ( is_string( $format ) && '' !== $format ) {
 		$the_time = get_post_time( $format, false, $post, true );
+	} else {
+		$the_time = get_post_time( get_option( 'time_format' ), false, $post, true );
 	}
 
 	/**

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -2514,8 +2514,8 @@ function the_date( $format = '', $before = '', $after = '', $echo = true ) {
  *
  * @since 3.0.0
  *
- * @param string      $format Optional. PHP date format defaults to the date_format option if not specified.
- * @param int|WP_Post $post   Optional. Post ID or WP_Post object. Default current post.
+ * @param string|false  $format Optional. PHP date format defaults to the date_format option if not specified.
+ * @param int|WP_Post   $post   Optional. Post ID or WP_Post object. Default current post.
  * @return string|false Date the current post was written. False on failure.
  */
 function get_the_date( $format = '', $post = null ) {
@@ -2525,7 +2525,7 @@ function get_the_date( $format = '', $post = null ) {
 		return false;
 	}
 
-	if ( '' === $format ) {
+	if ( '' === $format || false === $format ) {
 		$the_date = get_post_time( get_option( 'date_format' ), false, $post, true );
 	} else {
 		$the_date = get_post_time( $format, false, $post, true );
@@ -2640,10 +2640,10 @@ function the_time( $format = '' ) {
  *
  * @since 1.5.0
  *
- * @param string      $format Optional. Format to use for retrieving the time the post
- *                            was written. Either 'G', 'U', or PHP date format defaults
- *                            to the value specified in the time_format option. Default empty.
- * @param int|WP_Post $post   WP_Post object or ID. Default is global `$post` object.
+ * @param string|false $format Optional. Format to use for retrieving the time the post
+ *                             was written. Either 'G', 'U', or PHP date format defaults
+ *                             to the value specified in the time_format option. Default empty.
+ * @param int|WP_Post  $post   WP_Post object or ID. Default is global `$post` object.
  * @return string|int|false Formatted date string or Unix timestamp if `$format` is 'U' or 'G'.
  *                          False on failure.
  */
@@ -2654,7 +2654,7 @@ function get_the_time( $format = '', $post = null ) {
 		return false;
 	}
 
-	if ( '' === $format ) {
+	if ( '' === $format || false === $format ) {
 		$the_time = get_post_time( get_option( 'time_format' ), false, $post, true );
 	} else {
 		$the_time = get_post_time( $format, false, $post, true );

--- a/tests/phpunit/tests/admin/includesTemplate.php
+++ b/tests/phpunit/tests/admin/includesTemplate.php
@@ -4,49 +4,6 @@
  */
 class Tests_Admin_includesTemplate extends WP_UnitTestCase {
 
-	function test_equal() {
-		$this->assertEquals( ' selected=\'selected\'', selected( 'foo', 'foo', false ) );
-		$this->assertEquals( ' checked=\'checked\'', checked( 'foo', 'foo', false ) );
-
-		$this->assertEquals( ' selected=\'selected\'', selected( '1', 1, false ) );
-		$this->assertEquals( ' checked=\'checked\'', checked( '1', 1, false ) );
-
-		$this->assertEquals( ' selected=\'selected\'', selected( '1', true, false ) );
-		$this->assertEquals( ' checked=\'checked\'', checked( '1', true, false ) );
-
-		$this->assertEquals( ' selected=\'selected\'', selected( 1, 1, false ) );
-		$this->assertEquals( ' checked=\'checked\'', checked( 1, 1, false ) );
-
-		$this->assertEquals( ' selected=\'selected\'', selected( 1, true, false ) );
-		$this->assertEquals( ' checked=\'checked\'', checked( 1, true, false ) );
-
-		$this->assertEquals( ' selected=\'selected\'', selected( true, true, false ) );
-		$this->assertEquals( ' checked=\'checked\'', checked( true, true, false ) );
-
-		$this->assertEquals( ' selected=\'selected\'', selected( '0', 0, false ) );
-		$this->assertEquals( ' checked=\'checked\'', checked( '0', 0, false ) );
-
-		$this->assertEquals( ' selected=\'selected\'', selected( 0, 0, false ) );
-		$this->assertEquals( ' checked=\'checked\'', checked( 0, 0, false ) );
-
-		$this->assertEquals( ' selected=\'selected\'', selected( '', false, false ) );
-		$this->assertEquals( ' checked=\'checked\'', checked( '', false, false ) );
-
-		$this->assertEquals( ' selected=\'selected\'', selected( false, false, false ) );
-		$this->assertEquals( ' checked=\'checked\'', checked( false, false, false ) );
-	}
-
-	function test_notequal() {
-		$this->assertEquals( '', selected( '0', '', false ) );
-		$this->assertEquals( '', checked( '0', '', false ) );
-
-		$this->assertEquals( '', selected( 0, '', false ) );
-		$this->assertEquals( '', checked( 0, '', false ) );
-
-		$this->assertEquals( '', selected( 0, false, false ) );
-		$this->assertEquals( '', checked( 0, false, false ) );
-	}
-
 	/**
 	 * @ticket 51147
 	 * @dataProvider data_wp_terms_checklist_with_selected_cats

--- a/tests/phpunit/tests/comment.php
+++ b/tests/phpunit/tests/comment.php
@@ -1367,6 +1367,7 @@ class Tests_Comment extends WP_UnitTestCase {
 	 */
 	function test_get_comment_date_with_different_formats_returns_correct_time() {
 		$c = self::factory()->comment->create( array( 'comment_date' => '2020-08-29 01:51:00' ) );
+
 		$this->assertEquals( 'August 29, 2020', get_comment_date( '', $c ) );
 		$this->assertEquals( 'August 29, 2020', get_comment_date( false, $c ) );
 		$this->assertEquals( 'August 29, 2020', get_comment_date( 'F j, Y', $c ) );
@@ -1377,8 +1378,9 @@ class Tests_Comment extends WP_UnitTestCase {
 	 */
 	function test_get_comment_time_with_different_formats_returns_correct_time() {
 		$c = self::factory()->comment->create( array( 'comment_date' => '2020-08-29 01:51:00' ) );
-		$GLOBALS['comment'] = get_comment($c);
-		$this->assertEquals( '1:51 am', get_comment_time( '') );
+
+		$GLOBALS['comment'] = get_comment( $c );
+		$this->assertEquals( '1:51 am', get_comment_time( '' ) );
 		$this->assertEquals( '1:51 am', get_comment_time( false ) );
 		$this->assertEquals( '1:51 am', get_comment_time( 'g:i a' ) );
 	}

--- a/tests/phpunit/tests/comment.php
+++ b/tests/phpunit/tests/comment.php
@@ -1361,4 +1361,26 @@ class Tests_Comment extends WP_UnitTestCase {
 		// Number of exported comments.
 		$this->assertSame( 0, count( $actual['data'] ) );
 	}
+
+	/**
+	 * @ticket 51184
+	 */
+	function test_get_comment_date_with_different_formats_returns_correct_time() {
+		$c = self::factory()->comment->create( array( 'comment_date' => '2020-08-29 01:51:00' ) );
+		$this->assertEquals( 'August 29, 2020', get_comment_date( '', $c ) );
+		$this->assertEquals( 'August 29, 2020', get_comment_date( false, $c ) );
+		$this->assertEquals( 'August 29, 2020', get_comment_date( 'F j, Y', $c ) );
+	}
+
+	/**
+	 * @ticket 51184
+	 */
+	function test_get_comment_time_with_different_formats_returns_correct_time() {
+		$c = self::factory()->comment->create( array( 'comment_date' => '2020-08-29 01:51:00' ) );
+		$GLOBALS['comment'] = get_comment($c);
+		$this->assertEquals( '1:51 am', get_comment_time( '') );
+		$this->assertEquals( '1:51 am', get_comment_time( false ) );
+		$this->assertEquals( '1:51 am', get_comment_time( 'g:i a' ) );
+	}
+
 }

--- a/tests/phpunit/tests/general/template.php
+++ b/tests/phpunit/tests/general/template.php
@@ -690,4 +690,60 @@ class Tests_General_Template extends WP_UnitTestCase {
 
 		get_template_part( 'template', 'part', array( 'foo' => 'baz' ) );
 	}
+
+	/**
+	 * @ticket 51166
+	 * @dataProvider data_selected_checked_equal_values
+	 */
+	public function test_selected_equal( $selected, $current ) {
+		$this->assertEquals( ' selected=\'selected\'', selected( $selected, $current, false ) );
+	}
+
+	/**
+	 * @ticket 51166
+	 * @dataProvider data_selected_checked_equal_values
+	 */
+	public function test_checked_equal( $checked, $current ) {
+		$this->assertEquals( ' checked=\'checked\'', checked( $checked, $current, false ) );
+	}
+
+	public function data_selected_checked_equal_values() {
+		return array(
+			array( 'foo', 'foo' ),
+			array( '1', 1 ),
+			array( '1', true ),
+			array( 1, 1 ),
+			array( 1, true ),
+			array( true, true ),
+			array( '0', 0 ),
+			array( 0, 0 ),
+			array( '', false ),
+			array( false, false ),
+		);
+	}
+
+	/**
+	 * @ticket 51166
+	 * @dataProvider data_selected_checked_notequal_values
+	 */
+	public function test_template_selected_notequal( $selected, $current ) {
+		$this->assertEquals( '', selected( $selected, $current, false ) );
+	}
+
+	/**
+	 * @ticket 51166
+	 * @dataProvider data_selected_checked_notequal_values
+	 */
+	public function test_template_checked_notequal( $checked, $current ) {
+		$this->assertEquals( '', checked( $checked, $current, false ) );
+	}
+
+	public function data_selected_checked_notequal_values() {
+		return array(
+			array( '0', '' ),
+			array( 0, '' ),
+			array( 0, false ),
+		);
+	}
+
 }

--- a/tests/phpunit/tests/post.php
+++ b/tests/phpunit/tests/post.php
@@ -914,6 +914,15 @@ class Tests_Post extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 51184
+	 */
+	function test_get_the_date_with_different_formats_returns_correct_time() {
+		$post_id = self::factory()->post->create( array( 'post_date' => '2020-08-29 01:51:00' ) );
+		$this->assertEquals( 'August 29, 2020', get_the_date( '', $post_id ) );
+		$this->assertEquals( 'August 29, 2020', get_the_date( false, $post_id ) );
+	}
+
+	/**
 	 * @ticket 28310
 	 */
 	function test_get_the_time_with_id_returns_correct_time() {
@@ -929,6 +938,16 @@ class Tests_Post extends WP_UnitTestCase {
 		$this->assertFalse( get_the_time( 'h:i:s' ) );
 		$this->assertFalse( get_the_time( '', 9 ) );
 		$this->assertFalse( get_the_time( 'h:i:s', 9 ) );
+	}
+
+	/**
+	 * @ticket 51184
+	 */
+	function test_get_the_time_with_different_formats_returns_correct_time() {
+		$post_id = self::factory()->post->create( array( 'post_date' => '2020-08-29 01:51:00' ) );
+		$this->assertEquals( '1:51 am', get_the_time( '', $post_id ) );
+		$this->assertEquals( '1:51 am', get_the_time( false, $post_id ) );
+		$this->assertEquals( '1:51 am', get_the_time( 'g:i a', $post_id ) );
 	}
 
 	/**


### PR DESCRIPTION
Unit tests for selected() and checked() functions were added in [231/tests] and expanded in [232/tests].

At the time, the functions were in wp-admin/includes/template.php, so the tests were added to phpunit/tests/admin/includesTemplate.php.

The functions were later moved to wp-includes/general-template.php in [13658], but the tests were never updated for the new location, they should now be in phpunit/tests/general/template.php.

The tests could also be converted to use data providers.

Fixes #51166