### PR TITLE
Move and update unit tests for selected() and checked()

### DIFF
--- a/tests/phpunit/tests/admin/includesTemplate.php
+++ b/tests/phpunit/tests/admin/includesTemplate.php
@@ -4,49 +4,6 @@
  */
 class Tests_Admin_includesTemplate extends WP_UnitTestCase {
 
-	function test_equal() {
-		$this->assertEquals( ' selected=\'selected\'', selected( 'foo', 'foo', false ) );
-		$this->assertEquals( ' checked=\'checked\'', checked( 'foo', 'foo', false ) );
-
-		$this->assertEquals( ' selected=\'selected\'', selected( '1', 1, false ) );
-		$this->assertEquals( ' checked=\'checked\'', checked( '1', 1, false ) );
-
-		$this->assertEquals( ' selected=\'selected\'', selected( '1', true, false ) );
-		$this->assertEquals( ' checked=\'checked\'', checked( '1', true, false ) );
-
-		$this->assertEquals( ' selected=\'selected\'', selected( 1, 1, false ) );
-		$this->assertEquals( ' checked=\'checked\'', checked( 1, 1, false ) );
-
-		$this->assertEquals( ' selected=\'selected\'', selected( 1, true, false ) );
-		$this->assertEquals( ' checked=\'checked\'', checked( 1, true, false ) );
-
-		$this->assertEquals( ' selected=\'selected\'', selected( true, true, false ) );
-		$this->assertEquals( ' checked=\'checked\'', checked( true, true, false ) );
-
-		$this->assertEquals( ' selected=\'selected\'', selected( '0', 0, false ) );
-		$this->assertEquals( ' checked=\'checked\'', checked( '0', 0, false ) );
-
-		$this->assertEquals( ' selected=\'selected\'', selected( 0, 0, false ) );
-		$this->assertEquals( ' checked=\'checked\'', checked( 0, 0, false ) );
-
-		$this->assertEquals( ' selected=\'selected\'', selected( '', false, false ) );
-		$this->assertEquals( ' checked=\'checked\'', checked( '', false, false ) );
-
-		$this->assertEquals( ' selected=\'selected\'', selected( false, false, false ) );
-		$this->assertEquals( ' checked=\'checked\'', checked( false, false, false ) );
-	}
-
-	function test_notequal() {
-		$this->assertEquals( '', selected( '0', '', false ) );
-		$this->assertEquals( '', checked( '0', '', false ) );
-
-		$this->assertEquals( '', selected( 0, '', false ) );
-		$this->assertEquals( '', checked( 0, '', false ) );
-
-		$this->assertEquals( '', selected( 0, false, false ) );
-		$this->assertEquals( '', checked( 0, false, false ) );
-	}
-
 	/**
 	 * @ticket 51147
 	 * @dataProvider data_wp_terms_checklist_with_selected_cats

--- a/tests/phpunit/tests/general/template.php
+++ b/tests/phpunit/tests/general/template.php
@@ -690,4 +690,60 @@ class Tests_General_Template extends WP_UnitTestCase {
 
 		get_template_part( 'template', 'part', array( 'foo' => 'baz' ) );
 	}
+
+	/**
+	 * @ticket 51166
+	 * @dataProvider data_selected_checked_equal_values
+	 */
+	public function test_selected_equal( $selected, $current ) {
+		$this->assertEquals( ' selected=\'selected\'', selected( $selected, $current, false ) );
+	}
+
+	/**
+	 * @ticket 51166
+	 * @dataProvider data_selected_checked_equal_values
+	 */
+	public function test_checked_equal( $checked, $current ) {
+		$this->assertEquals( ' checked=\'checked\'', checked( $checked, $current, false ) );
+	}
+
+	public function data_selected_checked_equal_values() {
+		return array(
+			array( 'foo', 'foo' ),
+			array( '1', 1 ),
+			array( '1', true ),
+			array( 1, 1 ),
+			array( 1, true ),
+			array( true, true ),
+			array( '0', 0 ),
+			array( 0, 0 ),
+			array( '', false ),
+			array( false, false ),
+		);
+	}
+
+	/**
+	 * @ticket 51166
+	 * @dataProvider data_selected_checked_notequal_values
+	 */
+	public function test_template_selected_notequal( $selected, $current ) {
+		$this->assertEquals( '', selected( $selected, $current, false ) );
+	}
+
+	/**
+	 * @ticket 51166
+	 * @dataProvider data_selected_checked_notequal_values
+	 */
+	public function test_template_checked_notequal( $checked, $current ) {
+		$this->assertEquals( '', checked( $checked, $current, false ) );
+	}
+
+	public function data_selected_checked_notequal_values() {
+		return array(
+			array( '0', '' ),
+			array( 0, '' ),
+			array( 0, false ),
+		);
+	}
+
 }


### PR DESCRIPTION
Unit tests for selected() and checked() functions were added in [231/tests] and expanded in [232/tests].

At the time, the functions were in wp-admin/includes/template.php, so the tests were added to phpunit/tests/admin/includesTemplate.php.

The functions were later moved to wp-includes/general-template.php in [13658], but the tests were never updated for the new location, they should now be in phpunit/tests/general/template.php.

The tests could also be converted to use data providers.

Fixes #51166