### PR TITLE
Set Envelope/Sender address (default) in PhpMailer

### DIFF
--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -361,7 +361,7 @@ if ( ! function_exists( 'wp_mail' ) ) :
 		$from_name = apply_filters( 'wp_mail_from_name', $from_name );
 
 		try {
-			$phpmailer->setFrom( $from_email, $from_name, false );
+			$phpmailer->setFrom( $from_email, $from_name );
 		} catch ( PHPMailer\PHPMailer\Exception $e ) {
 			$mail_error_data                             = compact( 'to', 'subject', 'message', 'headers', 'attachments' );
 			$mail_error_data['phpmailer_exception_code'] = $e->getCode();


### PR DESCRIPTION
Removed the `false` of `$phpmailer->setFrom( $from_email, $from_name, false )` which is the  `$auto` parameter of PhpMailer to also set the Sender address to the same value the From address has been specified.
Currently, the `false` leads to some www-data sending addresses on default domains which are marked as spam. For sure, it depends on the hosting or sendmail configuration - but the default would be better.


Trac ticket: https://core.trac.wordpress.org/ticket/51206

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
