### PR TITLE
Speed up tests for wp_allow_comment

### DIFF
--- a/tests/phpunit/tests/comment/wpAllowComment.php
+++ b/tests/phpunit/tests/comment/wpAllowComment.php
@@ -7,9 +7,7 @@ class Tests_Comment_WpAllowComment extends WP_UnitTestCase {
 	protected static $post_id;
 	protected static $comment_id;
 
-	function setUp() {
-		parent::setUp();
-
+	public static function wpSetupBeforeClass() {
 		self::$post_id    = self::factory()->post->create();
 		self::$comment_id = self::factory()->comment->create(
 			array(
@@ -25,10 +23,7 @@ class Tests_Comment_WpAllowComment extends WP_UnitTestCase {
 		update_option( 'comment_previously_approved', 0 );
 	}
 
-	function tearDown() {
-		wp_delete_post( self::$post_id, true );
-		wp_delete_comment( self::$comment_id, true );
-
+	public static function wpTeardownAfterClass() {
 		update_option( 'comment_previously_approved', 1 );
 	}
 


### PR DESCRIPTION
The fixtures in Tests_Comment_WpAllowComment are stored in static properties. But they are (re)created in the setUp() method before every test run.

We should use shared fixtures to speed up this test case.

Trac ticket: https://core.trac.wordpress.org/ticket/51216

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**