### PR TITLE
Add filter to get_sitemap_url() function

### DIFF
--- a/src/wp-includes/sitemaps.php
+++ b/src/wp-includes/sitemaps.php
@@ -121,5 +121,13 @@ function get_sitemap_url( $name, $subtype_name = '', $page = 1 ) {
 	if ( 0 >= $page ) {
 		$page = 1;
 	}
-	return $provider->get_sitemap_url( $subtype_name, $page );
+	
+	/**
+	 * Filters the sitemap URL.
+	 *
+	 * @since 5.5.2
+	 *
+	 * @param string|false $sitemap_url The sitemap URL or false if the sitemap doesn't exist.
+	 */
+	return apply_filters('sitemap_url', $provider->get_sitemap_url( $subtype_name, $page ));
 }


### PR DESCRIPTION
Added a filter to the returned string within the `get_sitemap_url()` function so that the sitemap URL can easily be retrieved even when third-party plugins use their own sitemap/location.

Trac ticket: https://core.trac.wordpress.org/ticket/51211

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
