### PR TITLE
Fix: Wrong language when resetting password

### DIFF
--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -868,7 +868,7 @@ switch ( $action ) {
 
 		?>
 
-		<form name="lostpasswordform" id="lostpasswordform" action="<?php echo esc_url( network_site_url( 'wp-login.php?action=lostpassword', 'login_post' ) ); ?>" method="post">
+		<form name="lostpasswordform" id="lostpasswordform" action="<?php echo esc_url( site_url( 'wp-login.php?action=lostpassword', 'login_post' ) ); ?>" method="post">
 			<p>
 				<label for="user_login"><?php _e( 'Username or Email Address' ); ?></label>
 				<input type="text" name="user_login" id="user_login" class="input" value="<?php echo esc_attr( $user_login ); ?>" size="20" autocapitalize="off" />


### PR DESCRIPTION
In this update I changed the login URL to fix reset password email comes in wrong language.

Trac ticket: [#36439](https://core.trac.wordpress.org/ticket/36439)
