### PR TITLE
Support streams from imagick image editor

### DIFF
--- a/src/wp-includes/class-wp-image-editor-imagick.php
+++ b/src/wp-includes/class-wp-image-editor-imagick.php
@@ -128,7 +128,7 @@ class WP_Image_Editor_Imagick extends WP_Image_Editor {
 			return true;
 		}
 
-		if ( ! is_file( $this->file ) && ! preg_match( '|^https?://|', $this->file ) ) {
+		if ( ! is_file( $this->file ) && ! wp_is_stream( $this->file ) ) {
 			return new WP_Error( 'error_loading_image', __( 'File doesn&#8217;t exist?' ), $this->file );
 		}
 

--- a/src/wp-includes/class-wp-image-editor-imagick.php
+++ b/src/wp-includes/class-wp-image-editor-imagick.php
@@ -688,7 +688,7 @@ class WP_Image_Editor_Imagick extends WP_Image_Editor {
 			$orig_format = $this->image->getImageFormat();
 
 			$this->image->setImageFormat( strtoupper( $this->get_extension( $mime_type ) ) );
-			$this->make_image( $filename, array( $this, '_write_image' ), array( $filename ) );
+			$this->_write_image( $this->image, $filename );
 
 			// Reset original format.
 			$this->image->setImageFormat( $orig_format );
@@ -725,22 +725,6 @@ class WP_Image_Editor_Imagick extends WP_Image_Editor {
 		} else {
 			return $image->writeImage( $filename );
 		}
-	}
-
-	/**
-	 * Returns the result of calling $function with $arguments.
-	 *
-	 * This disables the parent class's behaviour of buffering output when
-	 * $filename is a stream URL.  Instead, $function is expected to handle
-	 * stream URLs appropriately.
-	 *
-	 * @param string   $filename  The destination filename or stream URL.
-	 * @param callable $function  A function or method that writes the image.
-	 * @param array    $arguments Arguments to pass to $function.
-	 * @return bool    True on success.
-	 */
-	protected function make_image( $filename, $function, $arguments ) {
-		return call_user_func_array( $function, $arguments );
 	}
 
 	/**

--- a/src/wp-includes/class-wp-image-editor.php
+++ b/src/wp-includes/class-wp-image-editor.php
@@ -365,9 +365,13 @@ abstract class WP_Image_Editor {
 		$new_ext = strtolower( $extension ? $extension : $ext );
 
 		if ( ! is_null( $dest_path ) ) {
-			$_dest_path = realpath( $dest_path );
-			if ( $_dest_path ) {
-				$dir = $_dest_path;
+			if ( ! wp_is_stream( $dest_path ) ) {
+				$_dest_path = realpath( $dest_path );
+				if ( $_dest_path ) {
+					$dir = $_dest_path;
+				}
+			} else {
+				$dir = $dest_path;
 			}
 		}
 

--- a/tests/phpunit/includes/class-wp-test-stream.php
+++ b/tests/phpunit/includes/class-wp-test-stream.php
@@ -1,0 +1,248 @@
+<?php
+
+/**
+ * Class WP_Test_Stream.
+ *
+ * An in-memory streamWrapper implementation for testing streams.  Writes to a
+ * stream URL like "protocol://bucket/foo" will be stored in the static
+ * variable WP_Test_Stream::$data['bucket']['/foo'].
+ *
+ * Creating a directory at "protocol://bucket/foo" will store the string
+ * 'DIRECTORY' to the static variable WP_Test_Stream::$data['bucket']['/foo/']
+ * (note the trailing slash).
+ *
+ * This class can be used to test that code works with basic read/write streams,
+ * as such, operations such as seeking are not supported.
+ *
+ * This class does not register itself as a stream handler: test fixtures
+ * should make the appropriate call to stream_wrapper_register().
+ */
+class WP_Test_Stream {
+	const FILE_MODE      = 0100666;
+	const DIRECTORY_MODE = 040777;
+
+	/**
+	 * In-memory storage for files and directories simulated by this wrapper.
+	 */
+	static $data = array();
+
+	var $position;
+	var $file;
+	var $bucket;
+	var $data_ref;
+
+	/**
+	 * Initializes internal state for reading the given URL.
+	 *
+	 * @param string $url A URL of the form "protocol://bucket/path".
+	 */
+	private function open( $url ) {
+		$components = array_merge(
+			array(
+				'host' => '',
+				'path' => '',
+			),
+			parse_url( $url )
+		);
+
+		$this->bucket = $components['host'];
+		$this->file   = $components['path'] ? $components['path'] : '/';
+
+		if ( empty( $this->bucket ) ) {
+			trigger_error( 'Cannot use an empty bucket name', E_USER_ERROR );
+		}
+
+		if ( ! isset( WP_Test_Stream::$data[ $this->bucket ] ) ) {
+			WP_Test_Stream::$data[ $this->bucket ] = array();
+		}
+
+		$this->data_ref =& WP_Test_Stream::$data[ $this->bucket ][ $this->file ];
+
+		$this->position = 0;
+	}
+
+	/**
+	 * Opens a URL.
+	 *
+	 * @see streamWrapper::stream_open
+	 */
+	function stream_open( $path, $mode, $options, &$opened_path ) {
+		$this->open( $path );
+		return true;
+	}
+
+	/**
+	 * Reads from a stream.
+	 *
+	 * @see streamWrapper::stream_read
+	 */
+	function stream_read( $count ) {
+		if ( ! isset( $this->data_ref ) ) {
+			return '';
+		}
+
+		$ret = substr( $this->data_ref, $this->position, $count );
+
+		$this->position += strlen( $ret );
+		return $ret;
+	}
+
+	/**
+	 * Writes to a stream.
+	 *
+	 * @see streamWrapper::stream_write
+	 */
+	function stream_write( $data ) {
+		if ( ! isset( $this->data_ref ) ) {
+			$this->data_ref = '';
+		}
+
+		$left  = substr( $this->data_ref, 0, $this->position );
+		$right = substr( $this->data_ref, $this->position + strlen( $data ) );
+
+		WP_Test_Stream::$data[ $this->bucket ][ $this->file ] = $left . $data . $right;
+
+		$this->position += strlen( $data );
+		return strlen( $data );
+	}
+
+	/**
+	 * Retrieves the current position of a stream.
+	 *
+	 * @see streamWrapper::stream_tell
+	 */
+	function stream_tell() {
+		return $this->position;
+	}
+
+	/**
+	 * Tests for end-of-file.
+	 *
+	 * @see streamWrapper::stream_eof
+	 */
+	function stream_eof() {
+		if ( ! isset( $this->data_ref ) ) {
+			return true;
+		}
+
+		return $this->position >= strlen( $this->data_ref );
+	}
+
+	/**
+	 * Change stream metadata.
+	 *
+	 * @see streamWrapper::stream_metadata
+	 */
+	function stream_metadata( $path, $option, $var ) {
+		$this->open( $path );
+		if ( STREAM_META_TOUCH === $option ) {
+			if ( ! isset( $this->data_ref ) ) {
+				$this->data_ref = '';
+			}
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Creates a directory.
+	 *
+	 * @see streamWrapper::mkdir
+	 */
+	function mkdir( $path, $mode, $options ) {
+		$this->open( $path );
+		$plainfile = rtrim( $this->file, '/' );
+
+		if ( isset( WP_Test_Stream::$data[ $this->bucket ][ $file ] ) ) {
+			return false;
+		}
+		$dir_ref = & $this->get_directory_ref();
+		$dir_ref = 'DIRECTORY';
+		return true;
+	}
+
+	/**
+	 * Creates a file metadata object, with defaults.
+	 *
+	 * @param array $stats Partial file metadata.
+	 * @return array Complete file metadata.
+	 */
+	private function make_stat( $stats ) {
+		$defaults = array(
+			'dev'     => 0,
+			'ino'     => 0,
+			'mode'    => 0,
+			'nlink'   => 0,
+			'uid'     => 0,
+			'gid'     => 0,
+			'rdev'    => 0,
+			'size'    => 0,
+			'atime'   => 0,
+			'mtime'   => 0,
+			'ctime'   => 0,
+			'blksize' => 0,
+			'blocks'  => 0,
+		);
+
+		return array_merge( $defaults, $stats );
+	}
+
+	/**
+	 * Retrieves information about a file.
+	 *
+	 * @see streamWrapper::stream_stat
+	 */
+	public function stream_stat() {
+		$dir_ref = & $this->get_directory_ref();
+		if ( substr( $this->file, -1 ) === '/' || isset( $dir_ref ) ) {
+			return $this->make_stat(
+				array(
+					'mode' => WP_Test_Stream::DIRECTORY_MODE,
+				)
+			);
+		}
+
+		if ( ! isset( $this->data_ref ) ) {
+			return false;
+		}
+
+		return $this->make_stat(
+			array(
+				'size' => strlen( $this->data_ref ),
+				'mode' => WP_Test_Stream::FILE_MODE,
+			)
+		);
+	}
+
+	/**
+	 * Retrieves information about a file.
+	 *
+	 * @see streamWrapper::url_stat
+	 */
+	public function url_stat( $path, $flags ) {
+		$this->open( $path );
+		return $this->stream_stat();
+	}
+
+	/**
+	 * Deletes a file.
+	 *
+	 * @see streamWrapper::unlink
+	 */
+	public function unlink( $path ) {
+		if ( ! isset( $this->data_ref ) ) {
+			return false;
+		}
+		unset( WP_Test_Stream::$data[ $this->bucket ][ $this->file ] );
+		return true;
+	}
+
+	/**
+	 * Interprets this stream's path as a directory, and returns the entry.
+	 *
+	 * @return A reference to the data entry for the directory.
+	 */
+	private function &get_directory_ref() {
+		return WP_Test_Stream::$data[ $this->bucket ][ rtrim( $this->file, '/' ) . '/' ];
+	}
+}

--- a/tests/phpunit/tests/image/editor.php
+++ b/tests/phpunit/tests/image/editor.php
@@ -143,6 +143,9 @@ class Tests_Image_Editor extends WP_Image_UnitTestCase {
 
 		// Combo!
 		$this->assertSame( trailingslashit( realpath( get_temp_dir() ) ) . 'canola-new.png', $editor->generate_filename( 'new', realpath( get_temp_dir() ), 'png' ) );
+
+		// Test with a stream destination.
+		$this->assertSame( 'file://testing/path/canola-100x50.jpg', $editor->generate_filename( null, 'file://testing/path' ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/image/editorImagick.php
+++ b/tests/phpunit/tests/image/editorImagick.php
@@ -574,4 +574,26 @@ class Tests_Image_Editor_Imagick extends WP_Image_UnitTestCase {
 		unlink( $ret['path'] );
 	}
 
+	/**
+	 * Test that images can be loaded and written over streams
+	 */
+	public function test_streams() {
+		$file = 'file://' . DIR_TESTDATA . '/images/waffles.jpg';
+
+		$imagick_image_editor = new WP_Image_Editor_Imagick( $file );
+		$imagick_image_editor->load();
+		$this->assertNotWPError( $imagick_image_editor );
+
+		$temp_file = 'file://' . get_temp_dir() . 'waffles.jpg';
+
+		$ret = $imagick_image_editor->save( $temp_file );
+		$this->assertNotWPError( $ret );
+
+		$this->assertSame( $temp_file, $ret['path'] );
+
+		if ( $temp_file !== $ret['path'] ) {
+			unlink( $ret['path'] );
+		}
+		unlink( $temp_file );
+	}
 }

--- a/tests/phpunit/tests/image/editorImagick.php
+++ b/tests/phpunit/tests/image/editorImagick.php
@@ -16,6 +16,7 @@ class Tests_Image_Editor_Imagick extends WP_Image_UnitTestCase {
 	public function setUp() {
 		require_once ABSPATH . WPINC . '/class-wp-image-editor.php';
 		require_once ABSPATH . WPINC . '/class-wp-image-editor-imagick.php';
+		require_once DIR_TESTROOT . '/includes/class-wp-test-stream.php';
 
 		parent::setUp();
 	}
@@ -578,13 +579,20 @@ class Tests_Image_Editor_Imagick extends WP_Image_UnitTestCase {
 	 * Test that images can be loaded and written over streams
 	 */
 	public function test_streams() {
-		$file = 'file://' . DIR_TESTDATA . '/images/waffles.jpg';
+		stream_wrapper_register( 'wptest', 'WP_Test_Stream' );
+		WP_Test_Stream::$data = array(
+			'Tests_Image_Editor_Imagick' => array(
+				'/read.jpg' => file_get_contents( DIR_TESTDATA . '/images/waffles.jpg' ),
+			),
+		);
 
+		$file                 = 'wptest://Tests_Image_Editor_Imagick/read.jpg';
 		$imagick_image_editor = new WP_Image_Editor_Imagick( $file );
-		$imagick_image_editor->load();
-		$this->assertNotWPError( $imagick_image_editor );
 
-		$temp_file = 'file://' . get_temp_dir() . 'waffles.jpg';
+		$ret = $imagick_image_editor->load();
+		$this->assertNotWPError( $ret );
+
+		$temp_file = 'wptest://Tests_Image_Editor_Imagick/write.jpg';
 
 		$ret = $imagick_image_editor->save( $temp_file );
 		$this->assertNotWPError( $ret );


### PR DESCRIPTION
Support streams from the imagick image editor.  Fixes problems with using `realpath` and `imagick::readImage` with streams.

Trac ticket: https://core.trac.wordpress.org/ticket/42663

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
