### PR TITLE
Update return types to reflect the real return types

### DIFF
--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -25,7 +25,7 @@
  *
  * @param string $option  Name of the option to retrieve. Expected to not be SQL-escaped.
  * @param mixed  $default Optional. Default value to return if the option does not exist.
- * @return bool|string|array|object Value set for the option.
+ * @return mixed Value set for the option. Any type may be returned, including arrays, booleans, integers and objects.
  */
 function get_option( $option, $default = false ) {
 	global $wpdb;

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -25,7 +25,7 @@
  *
  * @param string $option  Name of the option to retrieve. Expected to not be SQL-escaped.
  * @param mixed  $default Optional. Default value to return if the option does not exist.
- * @return mixed Value set for the option.
+ * @return bool|string|array|object Value set for the option.
  */
 function get_option( $option, $default = false ) {
 	global $wpdb;


### PR DESCRIPTION
In the DocBlocks, we document return values with `mixed` only.

That is no good practice as it does not show the real available and possible return types. 
A better approach is to declare and document explicitly return values separated by a pipe character like this `@return bool|string`

That is much clearer because developers do not need to check the return values by reading the entire docBlock, reading the whole code of a method, or reading the (lengthy) function description under developer.wordpress.org. 

A simple`mixed` is outdated and makes it hard for every severe developer to start with coding for WordPress as he has to continually check the expected return values when there is a `mixed`.

As a bonus, the documentation under developer.wordpress.org will be updated as well by this change automatically. It will help developers getting know the correct return values immediately from the docs without reading all the extra special explanations that we added to our docs whenever we use `mixed`.

That is a huge time saver and makes it much faster for every developer to write solid and better code faster.

If this is accepted for core, I will offer to work on this on all other methods as well.

That will be a long-lasting process due to the number of functions, but it's definitely worth the effort. We should make this change to all methods where we use`mixed` and make it to our daily little take-care moment when we add new methods to WordPress.

Sample Patch as an example for all methods that use `mixed`: 

get_option() is a special case, though as it automatically unserializes. So it supports all non-scalar types. Most other methods in WordPress uses `mixed` with only two return types like `bool|string` representation, which makes the updates easier.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/51278#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
