### PR TITLE
Display events in user's local (browser) timezone (#core51130)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1127,6 +1127,7 @@ module.exports = function(grunt) {
 				files: [
 					SOURCE_DIR + '**',
 					'!' + SOURCE_DIR + 'js/**/*.js',
+					'!' + SOURCE_DIR + 'wp-content/**',
 					// Ignore version control directories.
 					'!' + SOURCE_DIR + '**/.{svn,git}/**'
 				],

--- a/src/js/_enqueues/wp/dashboard.js
+++ b/src/js/_enqueues/wp/dashboard.js
@@ -485,11 +485,16 @@ jQuery( function( $ ) {
 				'.community-events-results'          : false
 			};
 
+			// somewhere in here, convert the utc date to browser's timezone w/ wp.date ?
+			// can use online-events page as example
+			// wp.date.format( 'whatever you want', 'the int timestamp as actual utc' ); // does this convert to browser timezone automatically?
+
 			/*
 			 * Determine which templates should be rendered and which elements
 			 * should be displayed.
 			 */
 			if ( templateParams.location.ip ) {
+				// todo all the ui stuff should be a separate commit, for reviewables sake
 				/*
 				 * If the API determined the location by geolocating an IP, it will
 				 * provide events, but not a specific location.

--- a/src/wp-admin/includes/class-wp-community-events.php
+++ b/src/wp-admin/includes/class-wp-community-events.php
@@ -369,6 +369,9 @@ class WP_Community_Events {
 	 * @return array The response with dates and times formatted.
 	 */
 	protected function format_event_data_time( $response_body ) {
+		// port this whole thing to JS, b/c will need to set there now?
+		// if not redo using end_date_timestamp. make separate commit from trim_events
+
 		if ( isset( $response_body['events'] ) ) {
 			foreach ( $response_body['events'] as $key => $event ) {
 				$timestamp = strtotime( $event['date'] );

--- a/src/wp-admin/includes/class-wp-community-events.php
+++ b/src/wp-admin/includes/class-wp-community-events.php
@@ -158,9 +158,10 @@ class WP_Community_Events {
 				$response_body['location']['description'] = $this->user_location['description'];
 			}
 
+			// store before preparing, because events will expire before cache does. need to trim on every page load.
 			$this->cache_events( $response_body, $expiration );
 
-			$response_body = $this->trim_events( $response_body );
+			$response_body['events'] = $this->trim_events( $response_body['events'] );
 			$response_body = $this->format_event_data_time( $response_body );
 
 			return $response_body;
@@ -346,7 +347,10 @@ class WP_Community_Events {
 	 */
 	public function get_cached_events() {
 		$cached_response = get_site_transient( $this->get_events_transient_key( $this->user_location ) );
-		$cached_response = $this->trim_events( $cached_response );
+
+		if ( isset( $cached_response['events'] ) ) {
+			$cached_response['events'] = $this->trim_events( $cached_response['events'] );
+		}
 
 		return $this->format_event_data_time( $cached_response );
 	}
@@ -435,44 +439,47 @@ class WP_Community_Events {
 	 *
 	 * @since 4.8.0
 	 * @since 4.9.7 Stick a WordCamp to the final list.
+	 * @since {todo} Accepts and returns only the events, rather than an entire HTTP response.
 	 *
-	 * @param array $response_body The response body which contains the events.
+	 * @param array $events The events that will be prepared.
 	 * @return array The response body with events trimmed.
 	 */
-	protected function trim_events( $response_body ) {
-		if ( isset( $response_body['events'] ) ) {
-			$wordcamps = array();
-			$today     = current_time( 'Y-m-d' );
+	protected function trim_events( array $events ) {
+		// manually test that
+			// expired events are discarded
+			// wordcamps are stuck
+		// update existing unit tests to test this directly, then check that all paths are covered
 
-			foreach ( $response_body['events'] as $key => $event ) {
-				/*
-				 * Skip WordCamps, because they might be multi-day events.
-				 * Save a copy so they can be pinned later.
-				 */
-				if ( 'wordcamp' === $event['type'] ) {
-					$wordcamps[] = $event;
-					continue;
-				}
+		$future_events = array();
 
-				// We don't get accurate time with timezone from API, so we only take the date part (Y-m-d).
-				$event_date = substr( $event['date'], 0, 10 );
+		foreach ( $events as $event ) {
+			/*
+			 * The API's `date` and `end_date` fields are in the _event's_ local timezone, but UTC is needed so
+			 * it can be converted to the _user's_ local time.
+			 */
+			$end_time = (int) $event['end_unix_timestamp'];
+			// todo - need to deploy meta patch in order to see this working in wp-admin/insommia
 
-				if ( $today > $event_date ) {
-					unset( $response_body['events'][ $key ] );
-				}
-			}
-
-			$response_body['events'] = array_slice( $response_body['events'], 0, 3 );
-			$trimmed_event_types     = wp_list_pluck( $response_body['events'], 'type' );
-
-			// Make sure the soonest upcoming WordCamp is pinned in the list.
-			if ( ! in_array( 'wordcamp', $trimmed_event_types, true ) && $wordcamps ) {
-				array_pop( $response_body['events'] );
-				array_push( $response_body['events'], $wordcamps[0] );
+			if ( time() < $end_time ) {
+				array_push( $future_events, $event );
 			}
 		}
 
-		return $response_body;
+		$future_wordcamps = array_filter( $future_events, function( $wordcamp ) {
+			return 'wordcamp' === $wordcamp['type'];
+		} );
+		$future_wordcamps = array_values( $future_wordcamps ); // Remove gaps in indices.
+
+		$trimmed_events      = array_slice( $future_events, 0, 3 );
+		$trimmed_event_types = wp_list_pluck( $trimmed_events, 'type' );
+
+		// Make sure the soonest upcoming WordCamp is pinned in the list.
+		if ( $future_wordcamps && ! in_array( 'wordcamp', $trimmed_event_types, true ) ) {
+			array_pop( $trimmed_events );
+			array_push( $trimmed_events, $future_wordcamps[0] );
+		}
+
+		return $trimmed_events;
 	}
 
 	/**

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1369,7 +1369,7 @@ function wp_print_community_events_templates() {
 
 	<script id="tmpl-community-events-event-list" type="text/template">
 		<# _.each( data.events, function( event ) { #>
-			<li class="event event-{{ event.type }} wp-clearfix">
+			<li class="event event-{{ event.type }} wp-clearfix" data-date-utc="{{event.date_utc}}">
 				<div class="event-info">
 					<div class="dashicons event-icon" aria-hidden="true"></div>
 					<div class="event-info-inner">
@@ -1381,7 +1381,9 @@ function wp_print_community_events_templates() {
 				<div class="event-date-time">
 					<span class="event-date">{{ event.formatted_date }}</span>
 					<# if ( 'meetup' === event.type ) { #>
-						<span class="event-time">{{ event.formatted_time }}</span>
+						<span class="event-time">
+							{{ event.formatted_time }} TZID
+						</span>
 					<# } #>
 				</div>
 			</li>

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1277,7 +1277,7 @@ function wp_default_scripts( $scripts ) {
 		$scripts->add( 'wp-color-picker', "/wp-admin/js/color-picker$suffix.js", array( 'iris' ), false, 1 );
 		$scripts->set_translations( 'wp-color-picker' );
 
-		$scripts->add( 'dashboard', "/wp-admin/js/dashboard$suffix.js", array( 'jquery', 'admin-comments', 'postbox', 'wp-util', 'wp-a11y' ), false, 1 );
+		$scripts->add( 'dashboard', "/wp-admin/js/dashboard$suffix.js", array( 'jquery', 'admin-comments', 'postbox', 'wp-util', 'wp-a11y', 'wp-date' ), false, 1 );
 
 		$scripts->add( 'list-revisions', "/wp-includes/js/wp-list-revisions$suffix.js" );
 

--- a/tests/phpunit/tests/admin/includesCommunityEvents.php
+++ b/tests/phpunit/tests/admin/includesCommunityEvents.php
@@ -261,42 +261,40 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 	/**
 	 * Test: get_events() should return the events with the WordCamp pinned in the prepared list.
 	 *
+	 * @covers WP_Community_Events::trim_events
+	 *
 	 * @since 4.9.7
+	 * @since {todo} Tests `trim_events()` directly instead of indirectly via `get_events()`.
 	 */
-	public function test_get_events_pin_wordcamp() {
-		add_filter( 'pre_http_request', array( $this, '_http_request_valid_response_unpinned_wordcamp' ) );
+	public function test_trim_events_pin_wordcamp() {
+		// Make the `protected` method callable.
+		$trim_events = new ReflectionMethod( $this->instance, 'trim_events' );
+		$trim_events->setAccessible( true );
 
-		$response_body = $this->instance->get_events();
+
+		$actual = $trim_events->invoke( $this->instance, $this->_events_with_unpinned_wordcamp() );
 
 		/*
-		 * San Diego was at position 3 in the mock API response, but pinning puts it at position 2,
+		 * San Diego was at index 3 in the mock API response, but pinning puts it at index 2,
 		 * so that it remains in the list. The other events should remain unchanged.
 		 */
-		$this->assertCount( 3, $response_body['events'] );
-		$this->assertSame( $response_body['events'][0]['title'], 'Flexbox + CSS Grid: Magic for Responsive Layouts' );
-		$this->assertSame( $response_body['events'][1]['title'], 'Part 3- Site Maintenance - Tools to Make It Easy' );
-		$this->assertSame( $response_body['events'][2]['title'], 'WordCamp San Diego' );
-
-		remove_filter( 'pre_http_request', array( $this, '_http_request_valid_response_unpinned_wordcamp' ) );
+		$this->assertCount( 3, $actual );
+		$this->assertSame( $actual[0]['title'], 'Flexbox + CSS Grid: Magic for Responsive Layouts' );
+		$this->assertSame( $actual[1]['title'], 'Part 3- Site Maintenance - Tools to Make It Easy' );
+		$this->assertSame( $actual[2]['title'], 'WordCamp San Diego' );
 	}
 
 	/**
-	 * Simulates a valid HTTP response where a WordCamp needs to be pinned higher than it's default position.
+	 * Simulates a scenario where a WordCamp needs to be pinned higher than it's default position.
 	 *
 	 * @since 4.9.7
+	 * @since {todo} Accepts and returns only the events, rather than an entire HTTP response.
 	 *
-	 * @return array A mock HTTP response.
+	 * @return array A list of mock events.
 	 */
-	public function _http_request_valid_response_unpinned_wordcamp() {
+	public function _events_with_unpinned_wordcamp() {
+		// todo reformat in separate coding standards commit at the end, to avoid diff noise
 		return array(
-			'headers'  => '',
-			'response' => array( 'code' => 200 ),
-			'cookies'  => '',
-			'filename' => '',
-			'body'     => wp_json_encode(
-				array(
-					'location' => $this->get_user_location(),
-					'events'   => array(
 						array(
 							'type'       => 'meetup',
 							'title'      => 'Flexbox + CSS Grid: Magic for Responsive Layouts',
@@ -304,6 +302,11 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 							'meetup'     => 'The East Bay WordPress Meetup Group',
 							'meetup_url' => 'https://www.meetup.com/Eastbay-WordPress-Meetup/',
 							'date'       => gmdate( 'Y-m-d H:i:s', strtotime( 'next Monday 1pm' ) ),
+							'end_date'   => gmdate( 'Y-m-d H:i:s', strtotime( 'next Monday 2pm' ) ),
+							'start_unix_timestamp' => strtotime( 'next Monday 1pm' ),
+							'end_unix_timestamp'   => strtotime( 'next Monday 2pm' ),
+								// todo convert to utc, same for all the others
+
 							'location'   => array(
 								'location'  => 'Oakland, CA, USA',
 								'country'   => 'us',
@@ -318,6 +321,10 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 							'meetup'     => 'WordPress Bay Area Foothills Group',
 							'meetup_url' => 'https://www.meetup.com/Wordpress-Bay-Area-CA-Foothills/',
 							'date'       => gmdate( 'Y-m-d H:i:s', strtotime( 'next Tuesday 1:30pm' ) ),
+							'end_date'   => gmdate( 'Y-m-d H:i:s', strtotime( 'next Tuesday 2:30pm' ) ),
+							'start_unix_timestamp' => strtotime( 'next Tuesday 1:30pm' ),
+							'end_unix_timestamp'   => strtotime( 'next Tuesday 2:30pm' ),
+
 							'location'   => array(
 								'location'  => 'Milpitas, CA, USA',
 								'country'   => 'us',
@@ -332,6 +339,10 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 							'meetup'     => 'The San Jose WordPress Meetup',
 							'meetup_url' => 'https://www.meetup.com/sanjosewp/',
 							'date'       => gmdate( 'Y-m-d H:i:s', strtotime( 'next Wednesday 5:30pm' ) ),
+							'end_date'   => gmdate( 'Y-m-d H:i:s', strtotime( 'next Wednesday 6:30pm' ) ),
+							'start_unix_timestamp' => strtotime( 'next Wednesday 5:30pm' ),
+							'end_unix_timestamp'   => strtotime( 'next Wednesday 6:30pm' ),
+
 							'location'   => array(
 								'location'  => 'Milpitas, CA, USA',
 								'country'   => 'us',
@@ -346,6 +357,10 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 							'meetup'     => null,
 							'meetup_url' => null,
 							'date'       => gmdate( 'Y-m-d H:i:s', strtotime( 'next Thursday 9am' ) ),
+							'end_date'   => gmdate( 'Y-m-d H:i:s', strtotime( 'next Thursday 10am' ) ),
+							'start_unix_timestamp' => strtotime( 'next Thursday 9am' ),
+							'end_unix_timestamp'   => strtotime( 'next Thursday 10am' ),
+
 							'location'   => array(
 								'location'  => 'San Diego, CA',
 								'country'   => 'US',
@@ -353,9 +368,6 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 								'longitude' => -117.1534513,
 							),
 						),
-					),
-				)
-			),
 		);
 	}
 

--- a/tests/phpunit/tests/admin/includesCommunityEvents.php
+++ b/tests/phpunit/tests/admin/includesCommunityEvents.php
@@ -199,6 +199,8 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 	 * @return array A mock HTTP response with valid data.
 	 */
 	public function _http_request_valid_response() {
+		// todo need to add `start_unix_timestamp` and end to all tests, otherwise not testing the new functionality
+
 		return array(
 			'headers'  => '',
 			'body'     => wp_json_encode(
@@ -212,6 +214,14 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 							'meetup'     => 'The East Bay WordPress Meetup Group',
 							'meetup_url' => 'https://www.meetup.com/Eastbay-WordPress-Meetup/',
 							'date'       => gmdate( 'Y-m-d H:i:s', strtotime( 'next Sunday 1pm' ) ),
+								// this doesn't match real data, b/c `date` field returns WP timestamp, but strtotime() returns Unix timestamp?
+								// maybe just remove the date/end_date fields, since won't be used in tests anyway?
+									// have to wait until format() function is updated though
+							'end_date'   => gmdate( 'Y-m-d H:i:s', strtotime( 'next Sunday 2pm' ) ),
+
+							'start_unix_timestamp' => strtotime( 'next Sunday 1pm' ),
+							'end_unix_timestamp'   => strtotime( 'next Sunday 2pm' ),
+
 							'location'   => array(
 								'location'  => 'Oakland, CA, USA',
 								'country'   => 'us',
@@ -226,6 +236,7 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 							'meetup'     => 'WordPress Bay Area Foothills Group',
 							'meetup_url' => 'https://www.meetup.com/Wordpress-Bay-Area-CA-Foothills/',
 							'date'       => gmdate( 'Y-m-d H:i:s', strtotime( 'next Wednesday 1:30pm' ) ),
+							'end_date'   => gmdate( 'Y-m-d H:i:s', strtotime( 'next Wednesday 2:30pm' ) ),
 							'location'   => array(
 								'location'  => 'Milpitas, CA, USA',
 								'country'   => 'us',
@@ -240,6 +251,7 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 							'meetup'     => null,
 							'meetup_url' => null,
 							'date'       => gmdate( 'Y-m-d H:i:s', strtotime( 'next Saturday' ) ),
+							'end_date'   => gmdate( 'Y-m-d H:i:s', strtotime( 'next Saturday 8pm' ) ),
 							'location'   => array(
 								'location'  => 'Kansas City, MO',
 								'country'   => 'US',
@@ -380,6 +392,8 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 	public function test_get_events_dont_pin_multiple_wordcamps() {
 		add_filter( 'pre_http_request', array( $this, '_http_request_valid_response_multiple_wordcamps' ) );
 
+		// convert this to just testing trim_events?
+
 		$response_body = $this->instance->get_events();
 
 		/*
@@ -418,7 +432,8 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 							'url'        => 'https://www.meetup.com/Eastbay-WordPress-Meetup/events/236031233/',
 							'meetup'     => 'The East Bay WordPress Meetup Group',
 							'meetup_url' => 'https://www.meetup.com/Eastbay-WordPress-Meetup/',
-							'date'       => gmdate( 'Y-m-d H:i:s', strtotime( '2 days ago' ) ),
+							'date'       => gmdate( 'Y-m-d H:i:s', strtotime( '2 days ago' ) - HOUR_IN_SECONDS ),
+							'end_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '2 days ago' ) ),
 							'location'   => array(
 								'location'  => 'Oakland, CA, USA',
 								'country'   => 'us',
@@ -433,6 +448,7 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 							'meetup'     => null,
 							'meetup_url' => null,
 							'date'       => gmdate( 'Y-m-d H:i:s', strtotime( 'next Tuesday 9am' ) ),
+							'end_date'   => gmdate( 'Y-m-d H:i:s', strtotime( 'next Tuesday 10am' ) ),
 							'location'   => array(
 								'location'  => 'San Diego, CA',
 								'country'   => 'US',
@@ -447,6 +463,7 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 							'meetup'     => 'WordPress Bay Area Foothills Group',
 							'meetup_url' => 'https://www.meetup.com/Wordpress-Bay-Area-CA-Foothills/',
 							'date'       => gmdate( 'Y-m-d H:i:s', strtotime( 'next Wednesday 1:30pm' ) ),
+							'end_date'   => gmdate( 'Y-m-d H:i:s', strtotime( 'next Wednesday 2:30pm' ) ),
 							'location'   => array(
 								'location'  => 'Milpitas, CA, USA',
 								'country'   => 'us',
@@ -461,6 +478,7 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 							'meetup'     => 'The San Jose WordPress Meetup',
 							'meetup_url' => 'https://www.meetup.com/sanjosewp/',
 							'date'       => gmdate( 'Y-m-d H:i:s', strtotime( 'next Thursday 5:30pm' ) ),
+							'end_date'   => gmdate( 'Y-m-d H:i:s', strtotime( 'next Thursday 6:30pm' ) ),
 							'location'   => array(
 								'location'  => 'Milpitas, CA, USA',
 								'country'   => 'us',
@@ -475,6 +493,7 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 							'meetup'     => null,
 							'meetup_url' => null,
 							'date'       => gmdate( 'Y-m-d H:i:s', strtotime( 'next Friday 9am' ) ),
+							'end_date'   => gmdate( 'Y-m-d H:i:s', strtotime( 'next Friday 10am' ) ),
 							'location'   => array(
 								'location'  => 'Los Angeles, CA',
 								'country'   => 'US',
@@ -487,6 +506,20 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 			),
 		);
 	}
+
+	// migrate/add tests for format...() just like did for tirm..(), unless porting to JS
+
+		// test an event where the local time vs utc time matters
+			// like around expiration, like api still serving event that's 11.5 hours past end date?
+				// er, no, have 11.5 hour old cache, but event finished 10 minutes ago
+
+	// discard expired meetups
+		// discard expired wordcamps
+		// pin wordcamp upcoming
+
+	// maybe test this against the old function to make sure continuity?
+
+	// make sure test all paths in the function
 
 	/**
 	 * Test that get_unsafe_client_ip() properly anonymizes all possible address formats


### PR DESCRIPTION
> [...] events are displayed in the venue's timezone, rather than the user's. That's usually accurate for in-person events, but usually inaccurate for online events, where attendees can be located in any timezone.

See https://core.trac.wordpress.org/ticket/51130
See https://meta.trac.wordpress.org/ticket/4480