### PR TITLE
Add should_load_block_editor_scripts_and_styles filter

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2455,7 +2455,7 @@ function script_concat_settings() {
  * @global WP_Screen $current_screen WordPress current screen object.
  */
 function wp_common_block_scripts_and_styles() {
-	if ( is_admin() && ! should_load_block_editor_scripts_and_styles() ) {
+	if ( is_admin() && ! _should_load_block_editor_scripts_and_styles() ) {
 		return;
 	}
 
@@ -2482,9 +2482,10 @@ function wp_common_block_scripts_and_styles() {
  * Checks if the editor scripts and styles for all registered block types
  * should be enqueued on the current screen.
  *
+ * @private
  * @return boolean
  */
-function should_load_block_editor_scripts_and_styles() {
+function _should_load_block_editor_scripts_and_styles() {
 	global $current_screen;
 	$is_block_editor_screen = ( $current_screen instanceof WP_Screen ) && $current_screen->is_block_editor();
 
@@ -2510,7 +2511,7 @@ function should_load_block_editor_scripts_and_styles() {
 function wp_enqueue_registered_block_scripts_and_styles() {
 	global $current_screen;
 
-	$load_editor_scripts = should_load_block_editor_scripts_and_styles();
+	$load_editor_scripts = _should_load_block_editor_scripts_and_styles();
 
 	$block_registry = WP_Block_Type_Registry::get_instance();
 	foreach ( $block_registry->get_all_registered() as $block_name => $block_type ) {

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2482,7 +2482,8 @@ function wp_common_block_scripts_and_styles() {
  * Checks if the editor scripts and styles for all registered block types
  * should be enqueued on the current screen.
  *
- * @private
+ * @access private
+ *
  * @return boolean
  */
 function _should_load_block_editor_scripts_and_styles() {

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2455,9 +2455,7 @@ function script_concat_settings() {
  * @global WP_Screen $current_screen WordPress current screen object.
  */
 function wp_common_block_scripts_and_styles() {
-	global $current_screen;
-
-	if ( is_admin() && ( $current_screen instanceof WP_Screen ) && ! $current_screen->is_block_editor() ) {
+	if ( is_admin() && ! should_load_block_editor_scripts_and_styles() ) {
 		return;
 	}
 
@@ -2481,6 +2479,27 @@ function wp_common_block_scripts_and_styles() {
 }
 
 /**
+ * Checks if the editor scripts and styles for all registered block types
+ * should be enqueued on the current screen.
+ *
+ * @return boolean
+ */
+function should_load_block_editor_scripts_and_styles() {
+	global $current_screen;
+	$is_block_editor_screen = ( $current_screen instanceof WP_Screen ) && $current_screen->is_block_editor();
+
+	/**
+	 * Filters the flag that decides whether or not block editor scripts and
+	 * styles are going to be enqueued on the current screen.
+	 *
+	 * @since 5.6.0
+	 *
+	 * @param boolean $is_block_editor_screen Current value of the flag
+	 */
+	return apply_filters( 'should_load_block_editor_scripts_and_styles', $is_block_editor_screen );
+}
+
+/**
  * Enqueues registered block scripts and styles, depending on current rendered
  * context (only enqueuing editor scripts while in context of the editor).
  *
@@ -2491,7 +2510,7 @@ function wp_common_block_scripts_and_styles() {
 function wp_enqueue_registered_block_scripts_and_styles() {
 	global $current_screen;
 
-	$is_editor = ( ( $current_screen instanceof WP_Screen ) && $current_screen->is_block_editor() );
+	$load_editor_scripts = should_load_block_editor_scripts_and_styles();
 
 	$block_registry = WP_Block_Type_Registry::get_instance();
 	foreach ( $block_registry->get_all_registered() as $block_name => $block_type ) {
@@ -2506,12 +2525,12 @@ function wp_enqueue_registered_block_scripts_and_styles() {
 		}
 
 		// Editor styles.
-		if ( $is_editor && ! empty( $block_type->editor_style ) ) {
+		if ( $load_editor_scripts && ! empty( $block_type->editor_style ) ) {
 			wp_enqueue_style( $block_type->editor_style );
 		}
 
 		// Editor script.
-		if ( $is_editor && ! empty( $block_type->editor_script ) ) {
+		if ( $load_editor_scripts && ! empty( $block_type->editor_script ) ) {
 			wp_enqueue_script( $block_type->editor_script );
 		}
 	}


### PR DESCRIPTION
As discussed in https://github.com/WordPress/gutenberg/issues/15644, block scripts and styles are being loaded only when `$current_screen->is_block_editor() === true`. The experimental widgets and navigation editor should provide access to custom block types but should not use a "block editor screen" mode which comes with more than just scripts and styles. In my opinion, having a way to control just the script&styles enqueuing aspect would be a good solution here.

Trac ticket: https://core.trac.wordpress.org/ticket/51330

**Test plan:**

1. Confirm the post and page editors are still full-screen and the admin sidebar remains hidden.
1. Confirm the widgets and navigation editors are unchanged after applying this PR - they should NOT be full-screen editors and the admin sidebar should remain visible.