### PR TITLE
Display events in user's local (browser) timezone (#core51130)

### DIFF
--- a/src/js/_enqueues/wp/dashboard.js
+++ b/src/js/_enqueues/wp/dashboard.js
@@ -266,6 +266,11 @@ jQuery( function( $ ) {
 	'use strict';
 
 	var communityEventsData = window.communityEventsData || {},
+		dateI18n = wp.date.dateI18n,
+		format = wp.date.format,
+		sprintf = wp.i18n.sprintf,
+		__ = wp.i18n.__,
+		_x = wp.i18n._x,
 		app;
 
 	/**
@@ -441,6 +446,7 @@ jQuery( function( $ ) {
 				.fail( function() {
 					app.renderEventsTemplate({
 						'location' : false,
+						'events'   : [],
 						'error'    : true
 					}, initiatedBy );
 				});
@@ -464,6 +470,11 @@ jQuery( function( $ ) {
 				$toggleButton    = $( '.community-events-toggle-location' ),
 				$locationMessage = $( '#community-events-location-message' ),
 				$results         = $( '.community-events-results' );
+
+			templateParams.events = app.populateDynamicEventFields(
+				templateParams.events,
+				communityEventsData.time_format
+			);
 
 			/*
 			 * Hide all toggleable elements by default, to keep the logic simple.
@@ -576,6 +587,195 @@ jQuery( function( $ ) {
 			} else {
 				app.toggleLocationForm( 'show' );
 			}
+		},
+
+		/**
+		 * Populate event fields that have to be calculated on the fly.
+		 *
+		 * These can't be stored in the database, because they're dependent on
+		 * the user's current time zone, locale, etc.
+		 *
+		 * @since 5.6.0
+		 *
+		 * @param {Array}  rawEvents  The events that should have dynamic fields added to them.
+		 * @param {string} timeFormat A time format acceptable by `wp.date.dateI18n()`.
+		 *
+		 * @returns {Array}
+		 */
+		populateDynamicEventFields: function( rawEvents, timeFormat ) {
+			// Clone the parameter to avoid mutating it, so that this can remain a pure function.
+			var populatedEvents = JSON.parse( JSON.stringify( rawEvents ) );
+
+			$.each( populatedEvents, function( index, event ) {
+				var timeZone = app.getTimeZone( event.start_unix_timestamp * 1000 );
+
+				event.user_formatted_date = app.getFormattedDate(
+					event.start_unix_timestamp * 1000,
+					event.end_unix_timestamp * 1000,
+					timeZone
+				);
+
+				event.user_formatted_time = dateI18n(
+					timeFormat,
+					event.start_unix_timestamp * 1000,
+					timeZone
+				);
+
+				event.timeZoneAbbreviation = app.getTimeZoneAbbreviation( event.start_unix_timestamp * 1000 );
+			} );
+
+			return populatedEvents;
+		},
+
+		/**
+		 * Returns the user's local/browser time zone, in a form suitable for `wp.date.i18n()`.
+		 *
+		 * @since 5.6.0
+		 *
+		 * @param startTimestamp
+		 *
+		 * @returns {string|number}
+		 */
+		getTimeZone: function( startTimestamp ) {
+			/*
+			 * Prefer a name like `Europe/Helsinki`, since that automatically tracks daylight savings. This
+			 * doesn't need to take `startTimestamp` into account for that reason.
+			 */
+			var timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+			/*
+			 * Fall back to an offset for IE11, which declares the property but doesn't assign a value.
+			 */
+			if ( 'undefined' === typeof timeZone ) {
+				/*
+				 * It's important to use the _event_ time, not the _current_
+				 * time, so that daylight savings time is accounted for.
+				 */
+				timeZone = app.getFlippedTimeZoneOffset( startTimestamp );
+			}
+
+			return timeZone;
+		},
+
+		/**
+		 * Get intuitive time zone offset.
+		 *
+		 * `Data.prototype.getTimezoneOffset()` returns a positive value for time zones
+		 * that are _behind_ UTC, and a _negative_ value for ones that are ahead.
+		 *
+		 * See https://stackoverflow.com/questions/21102435/why-does-javascript-date-gettimezoneoffset-consider-0500-as-a-positive-off.
+		 *
+		 * @since 5.6.0
+		 *
+		 * @param {number} startTimestamp
+		 *
+		 * @returns {number}
+		 */
+		getFlippedTimeZoneOffset: function( startTimestamp ) {
+			return new Date( startTimestamp ).getTimezoneOffset() * -1;
+		},
+
+		/**
+		 * Get a short time zone name, like `PST`.
+		 *
+		 * @since 5.6.0
+		 *
+		 * @param {number} startTimestamp
+		 *
+		 * @returns {string}
+		 */
+		getTimeZoneAbbreviation: function( startTimestamp ) {
+			var timeZoneAbbreviation,
+				eventDateTime = new Date( startTimestamp );
+
+			/*
+			 * Leaving the `locales` argument undefined is important, so that the browser
+			 * displays the abbreviation that's most appropriate for the current locale. For
+			 * some that will be `UTC{+|-}{n}`, and for others it will be a code like `PST`.
+			 *
+			 * This doesn't need to take `startTimestamp` into account, because a name like
+			 * `America/Chicago` automatically tracks daylight savings.
+			 */
+			var shortTimeStringParts = eventDateTime.toLocaleTimeString( undefined, { timeZoneName : 'short' } ).split( ' ' );
+
+			if ( 3 === shortTimeStringParts.length ) {
+				timeZoneAbbreviation = shortTimeStringParts[2];
+			}
+
+			if ( 'undefined' === typeof timeZoneAbbreviation ) {
+				/*
+				 * It's important to use the _event_ time, not the _current_
+				 * time, so that daylight savings time is accounted for.
+				 */
+				var timeZoneOffset = app.getFlippedTimeZoneOffset( startTimestamp ),
+					sign = -1 === Math.sign( timeZoneOffset ) ? '' : '+';
+
+				// translators: Used as part of a string like `GMT+5` in the Events Widget.
+				timeZoneAbbreviation = _x( 'GMT', 'Events widget offset prefix' ) + sign + ( timeZoneOffset / 60 );
+			}
+
+			return timeZoneAbbreviation;
+		},
+
+		/**
+		 * Format a start/end date in the user's local time zone and locale.
+		 *
+		 * @since 5.6.0
+		 *
+		 * @param {int}    startDate   The Unix timestamp in milliseconds when the the event starts.
+		 * @param {int}    endDate     The Unix timestamp in milliseconds when the the event ends.
+		 * @param {string} timeZone    A time zone string or offset which is parsable by `wp.date.i18n()`.
+		 *
+		 * @returns {string}
+		 */
+		getFormattedDate: function( startDate, endDate, timeZone ) {
+			var formattedDate;
+
+			/*
+			 * The `date_format` option is not used because it's important
+			 * in this context to keep the day of the week in the displayed date,
+			 * so that users can tell at a glance if the event is on a day they
+			 * are available, without having to open the link.
+			 *
+			 * The case of crossing a year boundary is intentionally not handled.
+			 * It's so rare in practice that it's not worth the complexity
+			 * tradeoff. The _ending_ year should be passed to
+			 * `multiple_month_event`, though, just in case.
+			 */
+			/* translators: Date format for upcoming events on the dashboard. Include the day of the week. See https://www.php.net/manual/datetime.format.php */
+			var singleDayEvent = __( 'l, M j, Y' ),
+				/* translators: Date string for upcoming events. 1: Month, 2: Starting day, 3: Ending day, 4: Year. */
+				multipleDayEvent = __( '%1$s %2$d–%3$d, %4$d' ),
+				/* translators: Date string for upcoming events. 1: Starting month, 2: Starting day, 3: Ending month, 4: Ending day, 5: Ending year. */
+				multipleMonthEvent = __( '%1$s %2$d – %3$s %4$d, %5$d' );
+
+			// Detect single-day events.
+			if ( ! endDate || format( 'Y-m-d', startDate ) === format( 'Y-m-d', endDate ) ) {
+				formattedDate = dateI18n( singleDayEvent, startDate, timeZone );
+
+			// Multiple day events.
+			} else if ( format( 'Y-m', startDate ) === format( 'Y-m', endDate ) ) {
+				formattedDate = sprintf(
+					multipleDayEvent,
+					dateI18n( _x( 'F', 'upcoming events month format' ), startDate, timeZone ),
+					dateI18n( _x( 'j', 'upcoming events day format' ), startDate, timeZone ),
+					dateI18n( _x( 'j', 'upcoming events day format' ), endDate, timeZone ),
+					dateI18n( _x( 'Y', 'upcoming events year format' ), endDate, timeZone )
+				);
+
+			// Multi-day events that cross a month boundary.
+			} else {
+				formattedDate = sprintf(
+					multipleMonthEvent,
+					dateI18n( _x( 'F', 'upcoming events month format' ), startDate, timeZone ),
+					dateI18n( _x( 'j', 'upcoming events day format' ), startDate, timeZone ),
+					dateI18n( _x( 'F', 'upcoming events month format' ), endDate, timeZone ),
+					dateI18n( _x( 'j', 'upcoming events day format' ), endDate, timeZone ),
+					dateI18n( _x( 'Y', 'upcoming events year format' ), endDate, timeZone )
+				);
+			}
+
+			return formattedDate;
 		}
 	};
 

--- a/src/wp-admin/includes/class-wp-community-events.php
+++ b/src/wp-admin/includes/class-wp-community-events.php
@@ -77,6 +77,8 @@ class WP_Community_Events {
 	 * mitigates possible privacy concerns.
 	 *
 	 * @since 4.8.0
+	 * @since 5.6.0 Response no longer contains formatted date field. They're added
+	 *              in `wp.communityEvents.populateDynamicEventFields()` now.
 	 *
 	 * @param string $location_search Optional. City name to help determine the location.
 	 *                                e.g., "Seattle". Default empty string.
@@ -165,7 +167,6 @@ class WP_Community_Events {
 			$this->cache_events( $response_body, $expiration );
 
 			$response_body['events'] = $this->trim_events( $response_body['events'] );
-			$response_body = $this->format_event_data_time( $response_body );
 
 			return $response_body;
 		}
@@ -344,6 +345,8 @@ class WP_Community_Events {
 	 * Gets cached events.
 	 *
 	 * @since 4.8.0
+	 * @since 5.6.0 Response no longer contains formatted date field. They're added
+	 *              in `wp.communityEvents.populateDynamicEventFields()` now.
 	 *
 	 * @return array|false An array containing `location` and `events` items
 	 *                     on success, false on failure.
@@ -355,7 +358,7 @@ class WP_Community_Events {
 			$cached_response['events'] = $this->trim_events( $cached_response['events'] );
 		}
 
-		return $this->format_event_data_time( $cached_response );
+		return $cached_response;
 	}
 
 	/**
@@ -372,6 +375,12 @@ class WP_Community_Events {
 	 * @return array The response with dates and times formatted.
 	 */
 	protected function format_event_data_time( $response_body ) {
+		_deprecated_function(
+			__METHOD__,
+			'5.6.0',
+			'This is no longer used by Core, and only kept for backwards-compatibility.'
+		);
+
 		if ( isset( $response_body['events'] ) ) {
 			foreach ( $response_body['events'] as $key => $event ) {
 				$timestamp = strtotime( $event['date'] );

--- a/src/wp-admin/includes/class-wp-community-events.php
+++ b/src/wp-admin/includes/class-wp-community-events.php
@@ -158,9 +158,13 @@ class WP_Community_Events {
 				$response_body['location']['description'] = $this->user_location['description'];
 			}
 
+			/*
+			 * Store the raw response, because events will expire before the cache does.
+			 * The response will need to be processed every page load.
+			 */
 			$this->cache_events( $response_body, $expiration );
 
-			$response_body = $this->trim_events( $response_body );
+			$response_body['events'] = $this->trim_events( $response_body['events'] );
 			$response_body = $this->format_event_data_time( $response_body );
 
 			return $response_body;
@@ -346,7 +350,10 @@ class WP_Community_Events {
 	 */
 	public function get_cached_events() {
 		$cached_response = get_site_transient( $this->get_events_transient_key( $this->user_location ) );
-		$cached_response = $this->trim_events( $cached_response );
+
+		if ( isset( $cached_response['events'] ) ) {
+			$cached_response['events'] = $this->trim_events( $cached_response['events'] );
+		}
 
 		return $this->format_event_data_time( $cached_response );
 	}
@@ -435,44 +442,44 @@ class WP_Community_Events {
 	 *
 	 * @since 4.8.0
 	 * @since 4.9.7 Stick a WordCamp to the final list.
+	 * @since 5.6.0 Accepts and returns only the events, rather than an entire HTTP response.
 	 *
-	 * @param array $response_body The response body which contains the events.
+	 * @param array $events The events that will be prepared.
 	 * @return array The response body with events trimmed.
 	 */
-	protected function trim_events( $response_body ) {
-		if ( isset( $response_body['events'] ) ) {
-			$wordcamps = array();
-			$today     = current_time( 'Y-m-d' );
+	protected function trim_events( array $events ) {
+		$future_events = array();
 
-			foreach ( $response_body['events'] as $key => $event ) {
-				/*
-				 * Skip WordCamps, because they might be multi-day events.
-				 * Save a copy so they can be pinned later.
-				 */
-				if ( 'wordcamp' === $event['type'] ) {
-					$wordcamps[] = $event;
-					continue;
-				}
+		foreach ( $events as $event ) {
+			/*
+			 * The API's `date` and `end_date` fields are in the _event's_ local timezone, but UTC is needed so
+			 * it can be converted to the _user's_ local time.
+			 */
+			$end_time = (int) $event['end_unix_timestamp'];
 
-				// We don't get accurate time with timezone from API, so we only take the date part (Y-m-d).
-				$event_date = substr( $event['date'], 0, 10 );
-
-				if ( $today > $event_date ) {
-					unset( $response_body['events'][ $key ] );
-				}
-			}
-
-			$response_body['events'] = array_slice( $response_body['events'], 0, 3 );
-			$trimmed_event_types     = wp_list_pluck( $response_body['events'], 'type' );
-
-			// Make sure the soonest upcoming WordCamp is pinned in the list.
-			if ( ! in_array( 'wordcamp', $trimmed_event_types, true ) && $wordcamps ) {
-				array_pop( $response_body['events'] );
-				array_push( $response_body['events'], $wordcamps[0] );
+			if ( time() < $end_time ) {
+				array_push( $future_events, $event );
 			}
 		}
 
-		return $response_body;
+		$future_wordcamps = array_filter(
+			$future_events,
+			function( $wordcamp ) {
+				return 'wordcamp' === $wordcamp['type'];
+			}
+		);
+
+		$future_wordcamps    = array_values( $future_wordcamps ); // Remove gaps in indices.
+		$trimmed_events      = array_slice( $future_events, 0, 3 );
+		$trimmed_event_types = wp_list_pluck( $trimmed_events, 'type' );
+
+		// Make sure the soonest upcoming WordCamp is pinned in the list.
+		if ( $future_wordcamps && ! in_array( 'wordcamp', $trimmed_event_types, true ) ) {
+			array_pop( $trimmed_events );
+			array_push( $trimmed_events, $future_wordcamps[0] );
+		}
+
+		return $trimmed_events;
 	}
 
 	/**

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1389,9 +1389,11 @@ function wp_print_community_events_templates() {
 				</div>
 
 				<div class="event-date-time">
-					<span class="event-date">{{ event.formatted_date }}</span>
+					<span class="event-date">{{ event.user_formatted_date }}</span>
 					<# if ( 'meetup' === event.type ) { #>
-						<span class="event-time">{{ event.formatted_time }}</span>
+						<span class="event-time">
+							{{ event.user_formatted_time }} {{ event.timeZoneAbbreviation }}
+						</span>
 					<# } #>
 				</div>
 			</li>

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1308,7 +1308,8 @@ function wp_default_scripts( $scripts ) {
 		$scripts->add( 'wp-color-picker', "/wp-admin/js/color-picker$suffix.js", array( 'iris' ), false, 1 );
 		$scripts->set_translations( 'wp-color-picker' );
 
-		$scripts->add( 'dashboard', "/wp-admin/js/dashboard$suffix.js", array( 'jquery', 'admin-comments', 'postbox', 'wp-util', 'wp-a11y' ), false, 1 );
+		$scripts->add( 'dashboard', "/wp-admin/js/dashboard$suffix.js", array( 'jquery', 'admin-comments', 'postbox', 'wp-util', 'wp-a11y', 'wp-date' ), false, 1 );
+		$scripts->set_translations( 'dashboard' );
 
 		$scripts->add( 'list-revisions', "/wp-includes/js/wp-list-revisions$suffix.js" );
 
@@ -1755,6 +1756,7 @@ function wp_localize_community_events() {
 		array(
 			'nonce' => wp_create_nonce( 'community_events' ),
 			'cache' => $events_client->get_cached_events(),
+			'time_format' => get_option( 'time_format' ),
 
 			'l10n'  => array(
 				'enter_closest_city'              => __( 'Enter your closest city to find nearby events.' ),

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1754,11 +1754,11 @@ function wp_localize_community_events() {
 		'dashboard',
 		'communityEventsData',
 		array(
-			'nonce' => wp_create_nonce( 'community_events' ),
-			'cache' => $events_client->get_cached_events(),
+			'nonce'       => wp_create_nonce( 'community_events' ),
+			'cache'       => $events_client->get_cached_events(),
 			'time_format' => get_option( 'time_format' ),
 
-			'l10n'  => array(
+			'l10n'        => array(
 				'enter_closest_city'              => __( 'Enter your closest city to find nearby events.' ),
 				'error_occurred_please_try_again' => __( 'An error occurred. Please try again.' ),
 				'attend_event_near_generic'       => __( 'Attend an upcoming event near you.' ),

--- a/tests/phpunit/tests/admin/includesCommunityEvents.php
+++ b/tests/phpunit/tests/admin/includesCommunityEvents.php
@@ -153,7 +153,7 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 
 	/**
 	 * Test: With a valid response, get_events() should return an associative array containing a location array and
-	 * an events array with individual events that have formatted time and date.
+	 * an events array with individual events that have Unix start/end timestamps.
 	 *
 	 * @since 4.8.0
 	 */
@@ -164,15 +164,15 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 
 		$this->assertNotWPError( $response );
 		$this->assertSameSetsWithIndex( $this->get_user_location(), $response['location'] );
-		$this->assertSame( gmdate( 'l, M j, Y', strtotime( 'next Sunday 1pm' ) ), $response['events'][0]['formatted_date'] );
-		$this->assertSame( '1:00 pm', $response['events'][0]['formatted_time'] );
+		$this->assertSame( strtotime( 'next Sunday 1pm' ), $response['events'][0]['start_unix_timestamp'] );
+		$this->assertSame( strtotime( 'next Sunday 2pm' ), $response['events'][0]['end_unix_timestamp'] );
 
 		remove_filter( 'pre_http_request', array( $this, '_http_request_valid_response' ) );
 	}
 
 	/**
-	 * Test: get_cached_events() should return the same data as get_events(), including formatted time
-	 * and date values for each event.
+	 * Test: `get_cached_events()` should return the same data as get_events(), including Unix start/end
+	 * timestamps for each event.
 	 *
 	 * @since 4.8.0
 	 */
@@ -185,8 +185,8 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 
 		$this->assertNotWPError( $cached_events );
 		$this->assertSameSetsWithIndex( $this->get_user_location(), $cached_events['location'] );
-		$this->assertSame( gmdate( 'l, M j, Y', strtotime( 'next Sunday 1pm' ) ), $cached_events['events'][0]['formatted_date'] );
-		$this->assertSame( '1:00 pm', $cached_events['events'][0]['formatted_time'] );
+		$this->assertSame( strtotime( 'next Sunday 1pm' ), $cached_events['events'][0]['start_unix_timestamp'] );
+		$this->assertSame( strtotime( 'next Sunday 2pm' ), $cached_events['events'][0]['end_unix_timestamp'] );
 
 		remove_filter( 'pre_http_request', array( $this, '_http_request_valid_response' ) );
 	}
@@ -204,50 +204,7 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 			'body'     => wp_json_encode(
 				array(
 					'location' => $this->get_user_location(),
-					'events'   => array(
-						array(
-							'type'       => 'meetup',
-							'title'      => 'Flexbox + CSS Grid: Magic for Responsive Layouts',
-							'url'        => 'https://www.meetup.com/Eastbay-WordPress-Meetup/events/236031233/',
-							'meetup'     => 'The East Bay WordPress Meetup Group',
-							'meetup_url' => 'https://www.meetup.com/Eastbay-WordPress-Meetup/',
-							'date'       => gmdate( 'Y-m-d H:i:s', strtotime( 'next Sunday 1pm' ) ),
-							'location'   => array(
-								'location'  => 'Oakland, CA, USA',
-								'country'   => 'us',
-								'latitude'  => 37.808453,
-								'longitude' => -122.26593,
-							),
-						),
-						array(
-							'type'       => 'meetup',
-							'title'      => 'Part 3- Site Maintenance - Tools to Make It Easy',
-							'url'        => 'https://www.meetup.com/Wordpress-Bay-Area-CA-Foothills/events/237706839/',
-							'meetup'     => 'WordPress Bay Area Foothills Group',
-							'meetup_url' => 'https://www.meetup.com/Wordpress-Bay-Area-CA-Foothills/',
-							'date'       => gmdate( 'Y-m-d H:i:s', strtotime( 'next Wednesday 1:30pm' ) ),
-							'location'   => array(
-								'location'  => 'Milpitas, CA, USA',
-								'country'   => 'us',
-								'latitude'  => 37.432813,
-								'longitude' => -121.907095,
-							),
-						),
-						array(
-							'type'       => 'wordcamp',
-							'title'      => 'WordCamp Kansas City',
-							'url'        => 'https://2017.kansascity.wordcamp.org',
-							'meetup'     => null,
-							'meetup_url' => null,
-							'date'       => gmdate( 'Y-m-d H:i:s', strtotime( 'next Saturday' ) ),
-							'location'   => array(
-								'location'  => 'Kansas City, MO',
-								'country'   => 'US',
-								'latitude'  => 39.0392325,
-								'longitude' => -94.577076,
-							),
-						),
-					),
+					'events'   => $this->get_valid_events(),
 				)
 			),
 			'response' => array(
@@ -259,51 +216,136 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test: get_events() should return the events with the WordCamp pinned in the prepared list.
+	 * Get a sample of valid events.
 	 *
-	 * @since 4.9.7
+	 * @return array[]
 	 */
-	public function test_get_events_pin_wordcamp() {
-		add_filter( 'pre_http_request', array( $this, '_http_request_valid_response_unpinned_wordcamp' ) );
+	protected function get_valid_events() {
+		return array(
+			array(
+				'type'                 => 'meetup',
+				'title'                => 'Flexbox + CSS Grid: Magic for Responsive Layouts',
+				'url'                  => 'https://www.meetup.com/Eastbay-WordPress-Meetup/events/236031233/',
+				'meetup'               => 'The East Bay WordPress Meetup Group',
+				'meetup_url'           => 'https://www.meetup.com/Eastbay-WordPress-Meetup/',
+				'start_unix_timestamp' => strtotime( 'next Sunday 1pm' ),
+				'end_unix_timestamp'   => strtotime( 'next Sunday 2pm' ),
 
-		$response_body = $this->instance->get_events();
+				'location'             => array(
+					'location'  => 'Oakland, CA, USA',
+					'country'   => 'us',
+					'latitude'  => 37.808453,
+					'longitude' => -122.26593,
+				),
+			),
 
-		/*
-		 * San Diego was at position 3 in the mock API response, but pinning puts it at position 2,
-		 * so that it remains in the list. The other events should remain unchanged.
-		 */
-		$this->assertCount( 3, $response_body['events'] );
-		$this->assertSame( $response_body['events'][0]['title'], 'Flexbox + CSS Grid: Magic for Responsive Layouts' );
-		$this->assertSame( $response_body['events'][1]['title'], 'Part 3- Site Maintenance - Tools to Make It Easy' );
-		$this->assertSame( $response_body['events'][2]['title'], 'WordCamp San Diego' );
+			array(
+				'type'                 => 'meetup',
+				'title'                => 'Part 3- Site Maintenance - Tools to Make It Easy',
+				'url'                  => 'https://www.meetup.com/Wordpress-Bay-Area-CA-Foothills/events/237706839/',
+				'meetup'               => 'WordPress Bay Area Foothills Group',
+				'meetup_url'           => 'https://www.meetup.com/Wordpress-Bay-Area-CA-Foothills/',
+				'start_unix_timestamp' => strtotime( 'next Wednesday 1:30pm' ),
+				'end_unix_timestamp'   => strtotime( 'next Wednesday 2:30pm' ),
 
-		remove_filter( 'pre_http_request', array( $this, '_http_request_valid_response_unpinned_wordcamp' ) );
+				'location'             => array(
+					'location'  => 'Milpitas, CA, USA',
+					'country'   => 'us',
+					'latitude'  => 37.432813,
+					'longitude' => -121.907095,
+				),
+			),
+
+			array(
+				'type'                 => 'wordcamp',
+				'title'                => 'WordCamp San Francisco',
+				'url'                  => 'https://sf.wordcamp.org/2020/',
+				'meetup'               => null,
+				'meetup_url'           => null,
+				'start_unix_timestamp' => strtotime( 'next Saturday' ),
+				'end_unix_timestamp'   => strtotime( 'next Saturday 8pm' ),
+
+				'location'             => array(
+					'location'  => 'San Francisco, CA',
+					'country'   => 'US',
+					'latitude'  => 37.432813,
+					'longitude' => -121.907095,
+				),
+			),
+		);
 	}
 
 	/**
-	 * Simulates a valid HTTP response where a WordCamp needs to be pinned higher than it's default position.
+	 * Test: `trim_events()` should immediately remove expired events.
+	 *
+	 * @covers WP_Community_Events::trim_events
+	 *
+	 * @since 5.6.0
+	 */
+	public function test_trim_expired_events() {
+		$trim_events = new ReflectionMethod( $this->instance, 'trim_events' );
+		$trim_events->setAccessible( true );
+
+		$events = $this->get_valid_events();
+
+		// This should be removed because it's already ended.
+		$events[0]['start_unix_timestamp'] = strtotime( '1 hour ago' );
+		$events[0]['end_unix_timestamp']   = strtotime( '2 seconds ago' );
+
+		// This should remain because it hasn't ended yet.
+		$events[1]['start_unix_timestamp'] = strtotime( '2 seconds ago' );
+		$events[1]['end_unix_timestamp']   = strtotime( '+1 hour' );
+
+		$actual = $trim_events->invoke( $this->instance, $events );
+
+		$this->assertCount( 2, $actual );
+		$this->assertSame( $actual[0]['title'], 'Part 3- Site Maintenance - Tools to Make It Easy' );
+		$this->assertSame( $actual[1]['title'], 'WordCamp San Francisco' );
+	}
+
+	/**
+	 * Test: get_events() should return the events with the WordCamp pinned in the prepared list.
+	 *
+	 * @covers WP_Community_Events::trim_events
 	 *
 	 * @since 4.9.7
-	 *
-	 * @return array A mock HTTP response.
+	 * @since 5.6.0 Tests `trim_events()` directly instead of indirectly via `get_events()`.
 	 */
-	public function _http_request_valid_response_unpinned_wordcamp() {
+	public function test_trim_events_pin_wordcamp() {
+		$trim_events = new ReflectionMethod( $this->instance, 'trim_events' );
+		$trim_events->setAccessible( true );
+
+		$actual = $trim_events->invoke( $this->instance, $this->_events_with_unpinned_wordcamp() );
+
+		/*
+		 * San Diego was at index 3 in the mock API response, but pinning puts it at index 2,
+		 * so that it remains in the list. The other events should remain unchanged.
+		 */
+		$this->assertCount( 3, $actual );
+		$this->assertSame( $actual[0]['title'], 'Flexbox + CSS Grid: Magic for Responsive Layouts' );
+		$this->assertSame( $actual[1]['title'], 'Part 3- Site Maintenance - Tools to Make It Easy' );
+		$this->assertSame( $actual[2]['title'], 'WordCamp San Diego' );
+	}
+
+	/**
+	 * Simulates a scenario where a WordCamp needs to be pinned higher than it's default position.
+	 *
+	 * @since 4.9.7
+	 * @since 5.6.0 Accepts and returns only the events, rather than an entire HTTP response.
+	 *
+	 * @return array A list of mock events.
+	 */
+	public function _events_with_unpinned_wordcamp() {
 		return array(
-			'headers'  => '',
-			'response' => array( 'code' => 200 ),
-			'cookies'  => '',
-			'filename' => '',
-			'body'     => wp_json_encode(
-				array(
-					'location' => $this->get_user_location(),
-					'events'   => array(
 						array(
 							'type'       => 'meetup',
 							'title'      => 'Flexbox + CSS Grid: Magic for Responsive Layouts',
 							'url'        => 'https://www.meetup.com/Eastbay-WordPress-Meetup/events/236031233/',
 							'meetup'     => 'The East Bay WordPress Meetup Group',
 							'meetup_url' => 'https://www.meetup.com/Eastbay-WordPress-Meetup/',
-							'date'       => gmdate( 'Y-m-d H:i:s', strtotime( 'next Monday 1pm' ) ),
+							'start_unix_timestamp' => strtotime( 'next Monday 1pm' ),
+							'end_unix_timestamp'   => strtotime( 'next Monday 2pm' ),
+
 							'location'   => array(
 								'location'  => 'Oakland, CA, USA',
 								'country'   => 'us',
@@ -317,7 +359,9 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 							'url'        => 'https://www.meetup.com/Wordpress-Bay-Area-CA-Foothills/events/237706839/',
 							'meetup'     => 'WordPress Bay Area Foothills Group',
 							'meetup_url' => 'https://www.meetup.com/Wordpress-Bay-Area-CA-Foothills/',
-							'date'       => gmdate( 'Y-m-d H:i:s', strtotime( 'next Tuesday 1:30pm' ) ),
+							'start_unix_timestamp' => strtotime( 'next Tuesday 1:30pm' ),
+							'end_unix_timestamp'   => strtotime( 'next Tuesday 2:30pm' ),
+
 							'location'   => array(
 								'location'  => 'Milpitas, CA, USA',
 								'country'   => 'us',
@@ -331,7 +375,9 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 							'url'        => 'https://www.meetup.com/sanjosewp/events/245419844/',
 							'meetup'     => 'The San Jose WordPress Meetup',
 							'meetup_url' => 'https://www.meetup.com/sanjosewp/',
-							'date'       => gmdate( 'Y-m-d H:i:s', strtotime( 'next Wednesday 5:30pm' ) ),
+							'start_unix_timestamp' => strtotime( 'next Wednesday 5:30pm' ),
+							'end_unix_timestamp'   => strtotime( 'next Wednesday 6:30pm' ),
+
 							'location'   => array(
 								'location'  => 'Milpitas, CA, USA',
 								'country'   => 'us',
@@ -345,7 +391,9 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 							'url'        => 'https://2018.sandiego.wordcamp.org',
 							'meetup'     => null,
 							'meetup_url' => null,
-							'date'       => gmdate( 'Y-m-d H:i:s', strtotime( 'next Thursday 9am' ) ),
+							'start_unix_timestamp' => strtotime( 'next Thursday 9am' ),
+							'end_unix_timestamp'   => strtotime( 'next Thursday 10am' ),
+
 							'location'   => array(
 								'location'  => 'San Diego, CA',
 								'country'   => 'US',
@@ -353,9 +401,6 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 								'longitude' => -117.1534513,
 							),
 						),
-					),
-				)
-			),
 		);
 	}
 
@@ -363,23 +408,25 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 	 * Test: get_events() shouldn't stick an extra WordCamp when there's already one that naturally
 	 * falls into the list.
 	 *
+	 * @covers WP_Community_Events::trim_events
+	 *
 	 * @since 4.9.7
+	 * @since 5.6.0 Tests `trim_events()` directly instead of indirectly via `get_events()`.
 	 */
-	public function test_get_events_dont_pin_multiple_wordcamps() {
-		add_filter( 'pre_http_request', array( $this, '_http_request_valid_response_multiple_wordcamps' ) );
+	public function test_trim_events_dont_pin_multiple_wordcamps() {
+		$trim_events = new ReflectionMethod( $this->instance, 'trim_events' );
+		$trim_events->setAccessible( true );
 
-		$response_body = $this->instance->get_events();
+		$actual = $trim_events->invoke( $this->instance, $this->_events_with_multiple_wordcamps() );
 
 		/*
 		 * The first meetup should be removed because it's expired, while the next 3 events are selected.
 		 * WordCamp LA should not be stuck to the list, because San Diego already appears naturally.
 		 */
-		$this->assertCount( 3, $response_body['events'] );
-		$this->assertSame( $response_body['events'][0]['title'], 'WordCamp San Diego' );
-		$this->assertSame( $response_body['events'][1]['title'], 'Part 3- Site Maintenance - Tools to Make It Easy' );
-		$this->assertSame( $response_body['events'][2]['title'], 'WordPress Q&A' );
-
-		remove_filter( 'pre_http_request', array( $this, '_http_request_valid_response_multiple_wordcamps' ) );
+		$this->assertCount( 3, $actual );
+		$this->assertSame( $actual[0]['title'], 'WordCamp San Diego' );
+		$this->assertSame( $actual[1]['title'], 'Part 3- Site Maintenance - Tools to Make It Easy' );
+		$this->assertSame( $actual[2]['title'], 'WordPress Q&A' );
 	}
 
 	/**
@@ -387,26 +434,21 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 	 * no need to pin extra camp b/c one already exists in response
 	 *
 	 * @since 4.9.7
+	 * @since 5.6.0 Tests `trim_events()` directly instead of indirectly via `get_events()`.
 	 *
 	 * @return array A mock HTTP response.
 	 */
-	public function _http_request_valid_response_multiple_wordcamps() {
+	public function _events_with_multiple_wordcamps() {
 		return array(
-			'headers'  => '',
-			'response' => array( 'code' => 200 ),
-			'cookies'  => '',
-			'filename' => '',
-			'body'     => wp_json_encode(
-				array(
-					'location' => $this->get_user_location(),
-					'events'   => array(
 						array(
 							'type'       => 'meetup',
 							'title'      => 'Flexbox + CSS Grid: Magic for Responsive Layouts',
 							'url'        => 'https://www.meetup.com/Eastbay-WordPress-Meetup/events/236031233/',
 							'meetup'     => 'The East Bay WordPress Meetup Group',
 							'meetup_url' => 'https://www.meetup.com/Eastbay-WordPress-Meetup/',
-							'date'       => gmdate( 'Y-m-d H:i:s', strtotime( '2 days ago' ) ),
+							'start_unix_timestamp' => strtotime( '2 days ago' ) - HOUR_IN_SECONDS,
+							'end_unix_timestamp'   => strtotime( '2 days ago' ),
+
 							'location'   => array(
 								'location'  => 'Oakland, CA, USA',
 								'country'   => 'us',
@@ -414,13 +456,16 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 								'longitude' => -122.26593,
 							),
 						),
+
 						array(
 							'type'       => 'wordcamp',
 							'title'      => 'WordCamp San Diego',
 							'url'        => 'https://2018.sandiego.wordcamp.org',
 							'meetup'     => null,
 							'meetup_url' => null,
-							'date'       => gmdate( 'Y-m-d H:i:s', strtotime( 'next Tuesday 9am' ) ),
+							'start_unix_timestamp' => strtotime( 'next Tuesday 9am' ),
+							'end_unix_timestamp'   => strtotime( 'next Tuesday 10am' ),
+
 							'location'   => array(
 								'location'  => 'San Diego, CA',
 								'country'   => 'US',
@@ -428,13 +473,16 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 								'longitude' => -117.1534513,
 							),
 						),
+
 						array(
 							'type'       => 'meetup',
 							'title'      => 'Part 3- Site Maintenance - Tools to Make It Easy',
 							'url'        => 'https://www.meetup.com/Wordpress-Bay-Area-CA-Foothills/events/237706839/',
 							'meetup'     => 'WordPress Bay Area Foothills Group',
 							'meetup_url' => 'https://www.meetup.com/Wordpress-Bay-Area-CA-Foothills/',
-							'date'       => gmdate( 'Y-m-d H:i:s', strtotime( 'next Wednesday 1:30pm' ) ),
+							'start_unix_timestamp' => strtotime( 'next Wednesday 1:30pm' ),
+							'end_unix_timestamp'   => strtotime( 'next Wednesday 2:30pm' ),
+
 							'location'   => array(
 								'location'  => 'Milpitas, CA, USA',
 								'country'   => 'us',
@@ -442,13 +490,16 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 								'longitude' => -121.907095,
 							),
 						),
+
 						array(
 							'type'       => 'meetup',
 							'title'      => 'WordPress Q&A',
 							'url'        => 'https://www.meetup.com/sanjosewp/events/245419844/',
 							'meetup'     => 'The San Jose WordPress Meetup',
 							'meetup_url' => 'https://www.meetup.com/sanjosewp/',
-							'date'       => gmdate( 'Y-m-d H:i:s', strtotime( 'next Thursday 5:30pm' ) ),
+							'start_unix_timestamp' => strtotime( 'next Thursday 5:30pm' ),
+							'end_unix_timestamp'   => strtotime( 'next Thursday 6:30pm' ),
+
 							'location'   => array(
 								'location'  => 'Milpitas, CA, USA',
 								'country'   => 'us',
@@ -456,13 +507,16 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 								'longitude' => -121.889313,
 							),
 						),
+
 						array(
 							'type'       => 'wordcamp',
 							'title'      => 'WordCamp Los Angeles',
 							'url'        => 'https://2018.la.wordcamp.org',
 							'meetup'     => null,
 							'meetup_url' => null,
-							'date'       => gmdate( 'Y-m-d H:i:s', strtotime( 'next Friday 9am' ) ),
+							'start_unix_timestamp' => strtotime( 'next Friday 9am' ),
+							'end_unix_timestamp'   => strtotime( 'next Friday 10am' ),
+
 							'location'   => array(
 								'location'  => 'Los Angeles, CA',
 								'country'   => 'US',
@@ -470,9 +524,6 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 								'longitude' => -118.285426,
 							),
 						),
-					),
-				)
-			),
 		);
 	}
 

--- a/tests/phpunit/tests/admin/includesCommunityEvents.php
+++ b/tests/phpunit/tests/admin/includesCommunityEvents.php
@@ -337,70 +337,73 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 	 */
 	public function _events_with_unpinned_wordcamp() {
 		return array(
-						array(
-							'type'       => 'meetup',
-							'title'      => 'Flexbox + CSS Grid: Magic for Responsive Layouts',
-							'url'        => 'https://www.meetup.com/Eastbay-WordPress-Meetup/events/236031233/',
-							'meetup'     => 'The East Bay WordPress Meetup Group',
-							'meetup_url' => 'https://www.meetup.com/Eastbay-WordPress-Meetup/',
-							'start_unix_timestamp' => strtotime( 'next Monday 1pm' ),
-							'end_unix_timestamp'   => strtotime( 'next Monday 2pm' ),
+			array(
+				'type'                 => 'meetup',
+				'title'                => 'Flexbox + CSS Grid: Magic for Responsive Layouts',
+				'url'                  => 'https://www.meetup.com/Eastbay-WordPress-Meetup/events/236031233/',
+				'meetup'               => 'The East Bay WordPress Meetup Group',
+				'meetup_url'           => 'https://www.meetup.com/Eastbay-WordPress-Meetup/',
+				'start_unix_timestamp' => strtotime( 'next Monday 1pm' ),
+				'end_unix_timestamp'   => strtotime( 'next Monday 2pm' ),
 
-							'location'   => array(
-								'location'  => 'Oakland, CA, USA',
-								'country'   => 'us',
-								'latitude'  => 37.808453,
-								'longitude' => -122.26593,
-							),
-						),
-						array(
-							'type'       => 'meetup',
-							'title'      => 'Part 3- Site Maintenance - Tools to Make It Easy',
-							'url'        => 'https://www.meetup.com/Wordpress-Bay-Area-CA-Foothills/events/237706839/',
-							'meetup'     => 'WordPress Bay Area Foothills Group',
-							'meetup_url' => 'https://www.meetup.com/Wordpress-Bay-Area-CA-Foothills/',
-							'start_unix_timestamp' => strtotime( 'next Tuesday 1:30pm' ),
-							'end_unix_timestamp'   => strtotime( 'next Tuesday 2:30pm' ),
+				'location'             => array(
+					'location'  => 'Oakland, CA, USA',
+					'country'   => 'us',
+					'latitude'  => 37.808453,
+					'longitude' => -122.26593,
+				),
+			),
 
-							'location'   => array(
-								'location'  => 'Milpitas, CA, USA',
-								'country'   => 'us',
-								'latitude'  => 37.432813,
-								'longitude' => -121.907095,
-							),
-						),
-						array(
-							'type'       => 'meetup',
-							'title'      => 'WordPress Q&A',
-							'url'        => 'https://www.meetup.com/sanjosewp/events/245419844/',
-							'meetup'     => 'The San Jose WordPress Meetup',
-							'meetup_url' => 'https://www.meetup.com/sanjosewp/',
-							'start_unix_timestamp' => strtotime( 'next Wednesday 5:30pm' ),
-							'end_unix_timestamp'   => strtotime( 'next Wednesday 6:30pm' ),
+			array(
+				'type'                 => 'meetup',
+				'title'                => 'Part 3- Site Maintenance - Tools to Make It Easy',
+				'url'                  => 'https://www.meetup.com/Wordpress-Bay-Area-CA-Foothills/events/237706839/',
+				'meetup'               => 'WordPress Bay Area Foothills Group',
+				'meetup_url'           => 'https://www.meetup.com/Wordpress-Bay-Area-CA-Foothills/',
+				'start_unix_timestamp' => strtotime( 'next Tuesday 1:30pm' ),
+				'end_unix_timestamp'   => strtotime( 'next Tuesday 2:30pm' ),
 
-							'location'   => array(
-								'location'  => 'Milpitas, CA, USA',
-								'country'   => 'us',
-								'latitude'  => 37.244194,
-								'longitude' => -121.889313,
-							),
-						),
-						array(
-							'type'       => 'wordcamp',
-							'title'      => 'WordCamp San Diego',
-							'url'        => 'https://2018.sandiego.wordcamp.org',
-							'meetup'     => null,
-							'meetup_url' => null,
-							'start_unix_timestamp' => strtotime( 'next Thursday 9am' ),
-							'end_unix_timestamp'   => strtotime( 'next Thursday 10am' ),
+				'location'             => array(
+					'location'  => 'Milpitas, CA, USA',
+					'country'   => 'us',
+					'latitude'  => 37.432813,
+					'longitude' => -121.907095,
+				),
+			),
 
-							'location'   => array(
-								'location'  => 'San Diego, CA',
-								'country'   => 'US',
-								'latitude'  => 32.7220419,
-								'longitude' => -117.1534513,
-							),
-						),
+			array(
+				'type'                 => 'meetup',
+				'title'                => 'WordPress Q&A',
+				'url'                  => 'https://www.meetup.com/sanjosewp/events/245419844/',
+				'meetup'               => 'The San Jose WordPress Meetup',
+				'meetup_url'           => 'https://www.meetup.com/sanjosewp/',
+				'start_unix_timestamp' => strtotime( 'next Wednesday 5:30pm' ),
+				'end_unix_timestamp'   => strtotime( 'next Wednesday 6:30pm' ),
+
+				'location'             => array(
+					'location'  => 'Milpitas, CA, USA',
+					'country'   => 'us',
+					'latitude'  => 37.244194,
+					'longitude' => -121.889313,
+				),
+			),
+
+			array(
+				'type'                 => 'wordcamp',
+				'title'                => 'WordCamp San Diego',
+				'url'                  => 'https://2018.sandiego.wordcamp.org',
+				'meetup'               => null,
+				'meetup_url'           => null,
+				'start_unix_timestamp' => strtotime( 'next Thursday 9am' ),
+				'end_unix_timestamp'   => strtotime( 'next Thursday 10am' ),
+
+				'location'             => array(
+					'location'  => 'San Diego, CA',
+					'country'   => 'US',
+					'latitude'  => 32.7220419,
+					'longitude' => -117.1534513,
+				),
+			),
 		);
 	}
 
@@ -440,90 +443,90 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 	 */
 	public function _events_with_multiple_wordcamps() {
 		return array(
-						array(
-							'type'       => 'meetup',
-							'title'      => 'Flexbox + CSS Grid: Magic for Responsive Layouts',
-							'url'        => 'https://www.meetup.com/Eastbay-WordPress-Meetup/events/236031233/',
-							'meetup'     => 'The East Bay WordPress Meetup Group',
-							'meetup_url' => 'https://www.meetup.com/Eastbay-WordPress-Meetup/',
-							'start_unix_timestamp' => strtotime( '2 days ago' ) - HOUR_IN_SECONDS,
-							'end_unix_timestamp'   => strtotime( '2 days ago' ),
+			array(
+				'type'                 => 'meetup',
+				'title'                => 'Flexbox + CSS Grid: Magic for Responsive Layouts',
+				'url'                  => 'https://www.meetup.com/Eastbay-WordPress-Meetup/events/236031233/',
+				'meetup'               => 'The East Bay WordPress Meetup Group',
+				'meetup_url'           => 'https://www.meetup.com/Eastbay-WordPress-Meetup/',
+				'start_unix_timestamp' => strtotime( '2 days ago' ) - HOUR_IN_SECONDS,
+				'end_unix_timestamp'   => strtotime( '2 days ago' ),
 
-							'location'   => array(
-								'location'  => 'Oakland, CA, USA',
-								'country'   => 'us',
-								'latitude'  => 37.808453,
-								'longitude' => -122.26593,
-							),
-						),
+				'location'             => array(
+					'location'  => 'Oakland, CA, USA',
+					'country'   => 'us',
+					'latitude'  => 37.808453,
+					'longitude' => -122.26593,
+				),
+			),
 
-						array(
-							'type'       => 'wordcamp',
-							'title'      => 'WordCamp San Diego',
-							'url'        => 'https://2018.sandiego.wordcamp.org',
-							'meetup'     => null,
-							'meetup_url' => null,
-							'start_unix_timestamp' => strtotime( 'next Tuesday 9am' ),
-							'end_unix_timestamp'   => strtotime( 'next Tuesday 10am' ),
+			array(
+				'type'                 => 'wordcamp',
+				'title'                => 'WordCamp San Diego',
+				'url'                  => 'https://2018.sandiego.wordcamp.org',
+				'meetup'               => null,
+				'meetup_url'           => null,
+				'start_unix_timestamp' => strtotime( 'next Tuesday 9am' ),
+				'end_unix_timestamp'   => strtotime( 'next Tuesday 10am' ),
 
-							'location'   => array(
-								'location'  => 'San Diego, CA',
-								'country'   => 'US',
-								'latitude'  => 32.7220419,
-								'longitude' => -117.1534513,
-							),
-						),
+				'location'             => array(
+					'location'  => 'San Diego, CA',
+					'country'   => 'US',
+					'latitude'  => 32.7220419,
+					'longitude' => -117.1534513,
+				),
+			),
 
-						array(
-							'type'       => 'meetup',
-							'title'      => 'Part 3- Site Maintenance - Tools to Make It Easy',
-							'url'        => 'https://www.meetup.com/Wordpress-Bay-Area-CA-Foothills/events/237706839/',
-							'meetup'     => 'WordPress Bay Area Foothills Group',
-							'meetup_url' => 'https://www.meetup.com/Wordpress-Bay-Area-CA-Foothills/',
-							'start_unix_timestamp' => strtotime( 'next Wednesday 1:30pm' ),
-							'end_unix_timestamp'   => strtotime( 'next Wednesday 2:30pm' ),
+			array(
+				'type'                 => 'meetup',
+				'title'                => 'Part 3- Site Maintenance - Tools to Make It Easy',
+				'url'                  => 'https://www.meetup.com/Wordpress-Bay-Area-CA-Foothills/events/237706839/',
+				'meetup'               => 'WordPress Bay Area Foothills Group',
+				'meetup_url'           => 'https://www.meetup.com/Wordpress-Bay-Area-CA-Foothills/',
+				'start_unix_timestamp' => strtotime( 'next Wednesday 1:30pm' ),
+				'end_unix_timestamp'   => strtotime( 'next Wednesday 2:30pm' ),
 
-							'location'   => array(
-								'location'  => 'Milpitas, CA, USA',
-								'country'   => 'us',
-								'latitude'  => 37.432813,
-								'longitude' => -121.907095,
-							),
-						),
+				'location'             => array(
+					'location'  => 'Milpitas, CA, USA',
+					'country'   => 'us',
+					'latitude'  => 37.432813,
+					'longitude' => -121.907095,
+				),
+			),
 
-						array(
-							'type'       => 'meetup',
-							'title'      => 'WordPress Q&A',
-							'url'        => 'https://www.meetup.com/sanjosewp/events/245419844/',
-							'meetup'     => 'The San Jose WordPress Meetup',
-							'meetup_url' => 'https://www.meetup.com/sanjosewp/',
-							'start_unix_timestamp' => strtotime( 'next Thursday 5:30pm' ),
-							'end_unix_timestamp'   => strtotime( 'next Thursday 6:30pm' ),
+			array(
+				'type'                 => 'meetup',
+				'title'                => 'WordPress Q&A',
+				'url'                  => 'https://www.meetup.com/sanjosewp/events/245419844/',
+				'meetup'               => 'The San Jose WordPress Meetup',
+				'meetup_url'           => 'https://www.meetup.com/sanjosewp/',
+				'start_unix_timestamp' => strtotime( 'next Thursday 5:30pm' ),
+				'end_unix_timestamp'   => strtotime( 'next Thursday 6:30pm' ),
 
-							'location'   => array(
-								'location'  => 'Milpitas, CA, USA',
-								'country'   => 'us',
-								'latitude'  => 37.244194,
-								'longitude' => -121.889313,
-							),
-						),
+				'location'             => array(
+					'location'  => 'Milpitas, CA, USA',
+					'country'   => 'us',
+					'latitude'  => 37.244194,
+					'longitude' => -121.889313,
+				),
+			),
 
-						array(
-							'type'       => 'wordcamp',
-							'title'      => 'WordCamp Los Angeles',
-							'url'        => 'https://2018.la.wordcamp.org',
-							'meetup'     => null,
-							'meetup_url' => null,
-							'start_unix_timestamp' => strtotime( 'next Friday 9am' ),
-							'end_unix_timestamp'   => strtotime( 'next Friday 10am' ),
+			array(
+				'type'                 => 'wordcamp',
+				'title'                => 'WordCamp Los Angeles',
+				'url'                  => 'https://2018.la.wordcamp.org',
+				'meetup'               => null,
+				'meetup_url'           => null,
+				'start_unix_timestamp' => strtotime( 'next Friday 9am' ),
+				'end_unix_timestamp'   => strtotime( 'next Friday 10am' ),
 
-							'location'   => array(
-								'location'  => 'Los Angeles, CA',
-								'country'   => 'US',
-								'latitude'  => 34.050888,
-								'longitude' => -118.285426,
-							),
-						),
+				'location'             => array(
+					'location'  => 'Los Angeles, CA',
+					'country'   => 'US',
+					'latitude'  => 34.050888,
+					'longitude' => -118.285426,
+				),
+			),
 		);
 	}
 

--- a/tests/qunit/index.html
+++ b/tests/qunit/index.html
@@ -85,7 +85,12 @@
 		</div>
 
 		<!-- Tested files -->
+		<script src="../../build/wp-admin/js/dashboard.js"></script>
 		<script src="../../build/wp-admin/js/password-strength-meter.js"></script>
+		<script src="../../build/wp-admin/js/postbox.js"></script>
+		<script src="../../build/wp-includes/js/dist/vendor/moment.js"></script>
+		<script src="../../build/wp-includes/js/dist/date.js"></script>
+		<script src="../../build/wp-includes/js/dist/i18n.js"></script>
 		<script src="../../build/wp-includes/js/customize-base.js"></script>
 		<script src="../../build/wp-includes/js/customize-models.js"></script>
 		<script src="../../build/wp-includes/js/shortcode.js"></script>
@@ -142,6 +147,7 @@
 		<script src="wp-admin/js/password-strength-meter.js"></script>
 		<script src="wp-admin/js/customize-base.js"></script>
 		<script src="wp-admin/js/customize-header.js"></script>
+		<script src="wp-admin/js/dashboard.js"></script>
 		<script src="wp-includes/js/shortcode.js"></script>
 		<script src="wp-includes/js/api-request.js"></script>
 		<script src="wp-includes/js/wp-api.js"></script>

--- a/tests/qunit/wp-admin/js/dashboard.js
+++ b/tests/qunit/wp-admin/js/dashboard.js
@@ -1,0 +1,219 @@
+/* global wp, sinon, JSON */
+var communityEventsData, dateI18n, pagenow;
+
+jQuery( document ).ready( function () {
+	var getFormattedDate = wp.communityEvents.getFormattedDate,
+		getTimeZone = wp.communityEvents.getTimeZone,
+		getTimeZoneAbbreviation = wp.communityEvents.getTimeZoneAbbreviation,
+		populateDynamicEventFields = wp.communityEvents.populateDynamicEventFields,
+		startDate = 1600185600 * 1000, // Tue Sep 15 9:00:00 AM PDT 2020
+		HOUR_IN_MS = 60 * 60 * 1000,
+		DAY_IN_MS = HOUR_IN_MS * 24,
+		WEEK_IN_MS = DAY_IN_MS * 7;
+
+	QUnit.module( 'dashboard', function( hooks ) {
+		hooks.beforeEach( function() {
+			this.oldDateI18n = dateI18n;
+			this.oldPagenow = pagenow;
+
+			dateI18n = wp.date.dateI18n;
+			pagenow = 'dashboard';
+
+			communityEventsData = {
+				time_format: 'g:i a',
+				l10n: {
+					date_formats: {
+						single_day_event: 'l, M j, Y',
+						multiple_day_event: '%1$s %2$d–%3$d, %4$d',
+						multiple_month_event: '%1$s %2$d – %3$s %4$d, %5$d'
+					}
+				}
+			};
+		} );
+
+		hooks.afterEach( function() {
+			dateI18n = this.oldDateI18n;
+			pagenow = this.oldPagenow;
+		} );
+
+		QUnit.module( 'communityEvents.populateDynamicEventFields', function() {
+			QUnit.test( 'dynamic fields should be added', function( assert ) {
+				var timeFormat = communityEventsData.time_format;
+
+				var getFormattedDateStub = sinon.stub( wp.communityEvents, 'getFormattedDate' ),
+					getTimeZoneStub = sinon.stub( wp.communityEvents, 'getTimeZone' ),
+					getTimeZoneAbbreviationStub = sinon.stub( wp.communityEvents, 'getTimeZoneAbbreviation' );
+
+				getFormattedDateStub.returns( 'Tuesday, Sep 15, 2020' );
+				getTimeZoneStub.returns( 'America/Chicago' );
+				getTimeZoneAbbreviationStub.returns( 'CDT' );
+
+				var rawEvents = [
+					{
+						start_unix_timestamp: 1600185600,
+						end_unix_timestamp: 1600189200
+					},
+
+					{
+						start_unix_timestamp: 1602232400,
+						end_unix_timestamp: 1602236000
+					}
+				];
+
+				var expected = JSON.parse( JSON.stringify( rawEvents ) );
+				expected[0].user_formatted_date = 'Tuesday, Sep 15, 2020';
+				expected[0].user_formatted_time = '11:00 am';
+				expected[0].timeZoneAbbreviation = 'CDT';
+
+				expected[1].user_formatted_date = 'Tuesday, Sep 15, 2020'; // This is expected to be the same as item 0, because of the stub.
+				expected[1].user_formatted_time = '3:33 am';
+				expected[1].timeZoneAbbreviation = 'CDT';
+
+				var actual = populateDynamicEventFields( rawEvents, timeFormat );
+
+				assert.strictEqual(
+					JSON.stringify( actual ),
+					JSON.stringify( expected )
+				);
+
+				getFormattedDateStub.restore();
+				getTimeZoneStub.restore();
+				getTimeZoneAbbreviationStub.restore();
+			} );
+		} );
+
+
+		QUnit.module( 'communityEvents.getFormattedDate', function() {
+			QUnit.test( 'single month event should use corresponding format', function( assert ) {
+				var actual = getFormattedDate(
+					startDate,
+					startDate + HOUR_IN_MS,
+					'America/Vancouver',
+					communityEventsData.l10n.date_formats
+				);
+
+				assert.strictEqual( actual, 'Tuesday, Sep 15, 2020' );
+			} );
+
+			QUnit.test( 'multiple day event should use corresponding format', function( assert ) {
+				var actual = getFormattedDate(
+					startDate,
+					startDate + ( 2 * DAY_IN_MS ),
+					'America/Vancouver',
+					communityEventsData.l10n.date_formats
+				);
+
+				assert.strictEqual( actual, 'September 15–17, 2020' );
+			} );
+
+			QUnit.test( 'multiple month event should use corresponding format', function( assert ) {
+				var actual = getFormattedDate(
+					startDate,
+					startDate + ( 3 * WEEK_IN_MS ),
+					'America/Vancouver',
+					communityEventsData.l10n.date_formats
+				);
+
+				assert.strictEqual( actual, 'September 15 – October 6, 2020' );
+			} );
+
+			QUnit.test( 'undefined end date should be treated as a single-day event', function( assert ) {
+				var actual = getFormattedDate(
+					startDate,
+					undefined,
+					'America/Vancouver',
+					communityEventsData.l10n.date_formats
+				);
+
+				assert.strictEqual( actual, 'Tuesday, Sep 15, 2020' );
+			} );
+
+			QUnit.test( 'empty end date should be treated as a single-day event', function( assert ) {
+				var actual = getFormattedDate(
+					startDate,
+					'',
+					'America/Vancouver',
+					communityEventsData.l10n.date_formats
+				);
+
+				assert.strictEqual( actual, 'Tuesday, Sep 15, 2020' );
+			} );
+		} );
+
+
+		QUnit.module( 'communityEvents.getTimeZone', function() {
+			QUnit.test( 'modern browsers should return a time zone name', function( assert ) {
+				// Simulate a modern browser.
+				var stub = sinon.stub( Intl.DateTimeFormat.prototype, 'resolvedOptions' );
+				stub.returns( { timeZone: 'America/Chicago' } );
+
+				var actual = getTimeZone( startDate );
+
+				stub.restore();
+
+				assert.strictEqual( actual, 'America/Chicago' );
+			} );
+
+			QUnit.test( 'older browsers should fallback to a raw UTC offset', function( assert ) {
+				// Simulate IE11.
+				var resolvedOptionsStub = sinon.stub( Intl.DateTimeFormat.prototype, 'resolvedOptions' );
+				var getTimezoneOffsetStub = sinon.stub( Date.prototype, 'getTimezoneOffset' );
+
+				resolvedOptionsStub.returns( { timeZone: undefined } );
+
+				getTimezoneOffsetStub.returns( 300 );
+				var actual = getTimeZone( startDate );
+				assert.strictEqual( actual, -300, 'negative offset' ); // Intentionally opposite, see `getTimeZone()`.
+
+				getTimezoneOffsetStub.returns( 0 );
+				actual = getTimeZone( startDate );
+				assert.strictEqual( actual, 0, 'no offset' );
+
+				getTimezoneOffsetStub.returns( -300 );
+				actual = getTimeZone( startDate );
+				assert.strictEqual( actual, 300, 'positive offset' ); // Intentionally opposite, see `getTimeZone()`.
+
+				resolvedOptionsStub.restore();
+				getTimezoneOffsetStub.restore();
+			} );
+		} );
+
+
+		QUnit.module( 'communityEvents.getTimeZoneAbbreviation', function() {
+			QUnit.test( 'modern browsers should return a time zone abbreviation', function( assert ) {
+				// Modern browsers append a short time zone code to the time string.
+				var stub = sinon.stub( Date.prototype, 'toLocaleTimeString' );
+				stub.returns( '4:00:00 PM CDT' );
+
+				var actual = getTimeZoneAbbreviation( startDate );
+
+				stub.restore();
+
+				assert.strictEqual( actual, 'CDT' );
+			} );
+
+			QUnit.test( 'older browsers should fallback to a formatted UTC offset', function( assert ) {
+				var toLocaleTimeStringStub = sinon.stub( Date.prototype, 'toLocaleTimeString' );
+				var getTimezoneOffsetStub = sinon.stub( Date.prototype, 'getTimezoneOffset' );
+
+				// IE 11 doesn't add the abbreviation like modern browsers do.
+				toLocaleTimeStringStub.returns( '4:00:00 PM' );
+
+				getTimezoneOffsetStub.returns( 300 );
+				var actual = getTimeZoneAbbreviation( startDate );
+				assert.strictEqual( actual, 'GMT-5', 'negative offset' ); // Intentionally opposite, see `getTimeZone()`.
+
+				getTimezoneOffsetStub.returns( 0 );
+				actual = getTimeZoneAbbreviation( startDate );
+				assert.strictEqual( actual, 'GMT+0', 'no offset' );
+
+				getTimezoneOffsetStub.returns( -300 );
+				actual = getTimeZoneAbbreviation( startDate );
+				assert.strictEqual( actual, 'GMT+5', 'positive offset' ); // Intentionally opposite, see `getTimeZone()`.
+
+				toLocaleTimeStringStub.restore();
+				getTimezoneOffsetStub.restore();
+			} );
+		} );
+	} );
+} );


### PR DESCRIPTION
> [...] events are displayed in the venue's timezone, rather than the user's. That's usually accurate for in-person events, but usually inaccurate for online events, where attendees can be located in any timezone.

See https://core.trac.wordpress.org/ticket/51130
See https://meta.trac.wordpress.org/ticket/4480