### PR TITLE
REST API: Support the (min|max)Properties JSON Schema keywords.

### DIFF
--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -1551,6 +1551,7 @@ function rest_stabilize_value( $value ) {
  *              Support the "minLength", "maxLength" and "pattern" keywords for strings.
  *              Support the "minItems", "maxItems" and "uniqueItems" keywords for arrays.
  *              Validate required properties.
+ * @since 5.7.0 Support the "minProperties" and "maxProperties" keywords for objects.
  *
  * @param mixed  $value The value to validate.
  * @param array  $args  Schema array to use for validation.
@@ -1661,6 +1662,16 @@ function rest_validate_value_from_schema( $value, $args, $param = '' ) {
 					}
 				}
 			}
+		}
+
+		if ( isset( $args['minProperties'] ) && count( $value ) < $args['minProperties'] ) {
+			/* translators: 1: Parameter, 2: Number. */
+			return new WP_Error( 'rest_invalid_param', sprintf( __( '%1$s must contain at least %2$s properties.' ), $param, number_format_i18n( $args['minProperties'] ) ) );
+		}
+
+		if ( isset( $args['maxProperties'] ) && count( $value ) > $args['maxProperties'] ) {
+			/* translators: 1: Parameter, 2: Number. */
+			return new WP_Error( 'rest_invalid_param', sprintf( __( '%1$s must contain at most %2$s properties.' ), $param, number_format_i18n( $args['maxProperties'] ) ) );
 		}
 	}
 
@@ -2291,6 +2302,8 @@ function rest_get_endpoint_args_for_schema( $schema, $method = WP_REST_Server::C
 		'minItems',
 		'maxItems',
 		'uniqueItems',
+		'minProperties',
+		'maxProperties',
 	);
 
 	foreach ( $schema_properties as $field_id => $params ) {

--- a/tests/phpunit/tests/rest-api/rest-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-controller.php
@@ -291,7 +291,7 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 			$this->assertArrayHasKey( $property, $args['somearray'] );
 		}
 
-		foreach ( array( 'properties', 'additionalProperties' ) as $property ) {
+		foreach ( array( 'properties', 'additionalProperties', 'minProperties', 'maxProperties' ) as $property ) {
 			$this->assertArrayHasKey( $property, $args['someobject'] );
 		}
 

--- a/tests/phpunit/tests/rest-api/rest-schema-validation.php
+++ b/tests/phpunit/tests/rest-api/rest-schema-validation.php
@@ -837,6 +837,61 @@ class WP_Test_REST_Schema_Validation extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 51023
+	 */
+	public function test_object_min_properties() {
+		$schema = array(
+			'type'          => 'object',
+			'minProperties' => 1,
+		);
+
+		$this->assertTrue(
+			rest_validate_value_from_schema(
+				array(
+					'propA' => 'a',
+					'propB' => 'b',
+				),
+				$schema
+			)
+		);
+		$this->assertTrue( rest_validate_value_from_schema( array( 'propA' => 'a' ), $schema ) );
+		$this->assertWPError( rest_validate_value_from_schema( array(), $schema ) );
+		$this->assertWPError( rest_validate_value_from_schema( '', $schema ) );
+	}
+
+	/**
+	 * @ticket 51023
+	 */
+	public function test_object_max_properties() {
+		$schema = array(
+			'type'          => 'object',
+			'maxProperties' => 2,
+		);
+
+		$this->assertTrue( rest_validate_value_from_schema( array( 'propA' => 'a' ), $schema ) );
+		$this->assertTrue(
+			rest_validate_value_from_schema(
+				array(
+					'propA' => 'a',
+					'propB' => 'b',
+				),
+				$schema
+			)
+		);
+		$this->assertWPError(
+			rest_validate_value_from_schema(
+				array(
+					'propA' => 'a',
+					'propB' => 'b',
+					'propC' => 'c',
+				),
+				$schema
+			)
+		);
+		$this->assertWPError( rest_validate_value_from_schema( 'foobar', $schema ) );
+	}
+
+	/**
 	 * @ticket 44949
 	 */
 	public function test_string_pattern() {

--- a/tests/phpunit/tests/rest-api/rest-test-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-test-controller.php
@@ -120,6 +120,8 @@ class WP_REST_Test_Controller extends WP_REST_Controller {
 							'type' => 'integer',
 						),
 					),
+					'minProperties'        => 1,
+					'maxProperties'        => 10,
 					'ignored_prop'         => 'ignored_prop',
 					'context'              => array( 'view' ),
 				),


### PR DESCRIPTION
Added support for the minProperties and maxProperties JSON Schema keywords.

Trac ticket: https://core.trac.wordpress.org/ticket/51023