### PR TITLE
Populate WP_ENVIRONMENT_TYPE for local environment

### DIFF
--- a/.env
+++ b/.env
@@ -29,7 +29,7 @@ LOCAL_WP_DEBUG=true
 LOCAL_WP_DEBUG_LOG=true
 LOCAL_WP_DEBUG_DISPLAY=true
 LOCAL_SCRIPT_DEBUG=true
-LOCAL_WP_ENVIRONMENT_TYPE=development
+LOCAL_WP_ENVIRONMENT_TYPE=local
 
 # The URL to use when running e2e tests.
 WP_BASE_URL=http://localhost:${LOCAL_PORT}

--- a/.env
+++ b/.env
@@ -29,6 +29,7 @@ LOCAL_WP_DEBUG=true
 LOCAL_WP_DEBUG_LOG=true
 LOCAL_WP_DEBUG_DISPLAY=true
 LOCAL_SCRIPT_DEBUG=true
+LOCAL_WP_ENVIRONMENT_TYPE=development
 
 # The URL to use when running e2e tests.
 WP_BASE_URL=http://localhost:${LOCAL_PORT}

--- a/tools/local-env/scripts/install.js
+++ b/tools/local-env/scripts/install.js
@@ -14,6 +14,7 @@ wp_cli( `config set WP_DEBUG ${process.env.LOCAL_WP_DEBUG} --raw` );
 wp_cli( `config set WP_DEBUG_LOG ${process.env.LOCAL_WP_DEBUG_LOG} --raw` );
 wp_cli( `config set WP_DEBUG_DISPLAY ${process.env.LOCAL_WP_DEBUG_DISPLAY} --raw` );
 wp_cli( `config set SCRIPT_DEBUG ${process.env.LOCAL_SCRIPT_DEBUG} --raw` );
+wp_cli( `config set WP_ENVIRONMENT_TYPE ${process.env.LOCAL_WP_ENVIRONMENT_TYPE}`);
 
 // Move wp-config.php to the base directory, so it doesn't get mixed up in the src or build directories.
 renameSync( 'src/wp-config.php', 'wp-config.php' );

--- a/tools/local-env/scripts/install.js
+++ b/tools/local-env/scripts/install.js
@@ -14,7 +14,7 @@ wp_cli( `config set WP_DEBUG ${process.env.LOCAL_WP_DEBUG} --raw` );
 wp_cli( `config set WP_DEBUG_LOG ${process.env.LOCAL_WP_DEBUG_LOG} --raw` );
 wp_cli( `config set WP_DEBUG_DISPLAY ${process.env.LOCAL_WP_DEBUG_DISPLAY} --raw` );
 wp_cli( `config set SCRIPT_DEBUG ${process.env.LOCAL_SCRIPT_DEBUG} --raw` );
-wp_cli( `config set WP_ENVIRONMENT_TYPE ${process.env.LOCAL_WP_ENVIRONMENT_TYPE}`);
+wp_cli( `config set WP_ENVIRONMENT_TYPE ${process.env.LOCAL_WP_ENVIRONMENT_TYPE}` );
 
 // Move wp-config.php to the base directory, so it doesn't get mixed up in the src or build directories.
 renameSync( 'src/wp-config.php', 'wp-config.php' );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This change populates the new `WP_ENVIRONMENT_TYPE` variable for the local development environment with the value of 'development' using the WordPress CLI.

Trac ticket: https://core.trac.wordpress.org/ticket/50903

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
