### PR TITLE
Multisite: Assign 'sites_pre_query' and 'networks_pre_query' filter results to the class property

### DIFF
--- a/src/wp-includes/class-wp-network-query.php
+++ b/src/wp-includes/class-wp-network-query.php
@@ -212,7 +212,17 @@ class WP_Network_Query {
 		 *   an array of network IDs.
 		 * - Otherwise the filter should return an array of WP_Network objects.
 		 *
+		 * Note that if the filter returns an array of network data, it will be assigned
+		 * to the `networks` property of the current WP_Network_Query instance.
+		 *
+		 * Filtering functions that require pagination information are encouraged to set
+		 * the `found_networks` and `max_num_pages` properties of the WP_Network_Query object,
+		 * passed to the filter by reference. If WP_Network_Query does not perform a database
+		 * query, it will not have enough information to generate these values itself.
+		 *
 		 * @since 5.2.0
+		 * @since 5.6.0 The returned array of network data is assigned to the `networks` property
+		 *              of the current WP_Network_Query instance.
 		 *
 		 * @param array|int|null   $network_data Return an array of network data to short-circuit WP's network query,
 		 *                                       the network count as an integer if `$this->query_vars['count']` is set,
@@ -222,6 +232,10 @@ class WP_Network_Query {
 		$network_data = apply_filters_ref_array( 'networks_pre_query', array( $network_data, &$this ) );
 
 		if ( null !== $network_data ) {
+			if ( is_array( $network_data ) && ! $this->query_vars['count'] ) {
+				$this->networks = $network_data;
+			}
+
 			return $network_data;
 		}
 

--- a/src/wp-includes/class-wp-site-query.php
+++ b/src/wp-includes/class-wp-site-query.php
@@ -303,7 +303,17 @@ class WP_Site_Query {
 		 *   an array of site IDs.
 		 * - Otherwise the filter should return an array of WP_Site objects.
 		 *
+		 * Note that if the filter returns an array of site data, it will be assigned
+		 * to the `sites` property of the current WP_Site_Query instance.
+		 *
+		 * Filtering functions that require pagination information are encouraged to set
+		 * the `found_sites` and `max_num_pages` properties of the WP_Site_Query object,
+		 * passed to the filter by reference. If WP_Site_Query does not perform a database
+		 * query, it will not have enough information to generate these values itself.
+		 *
 		 * @since 5.2.0
+		 * @since 5.6.0 The returned array of site data is assigned to the `sites` property
+		 *              of the current WP_Site_Query instance.
 		 *
 		 * @param array|int|null $site_data Return an array of site data to short-circuit WP's site query,
 		 *                                  the site count as an integer if `$this->query_vars['count']` is set,
@@ -313,6 +323,10 @@ class WP_Site_Query {
 		$site_data = apply_filters_ref_array( 'sites_pre_query', array( $site_data, &$this ) );
 
 		if ( null !== $site_data ) {
+			if ( is_array( $site_data ) && ! $this->query_vars['count'] ) {
+				$this->sites = $site_data;
+			}
+
 			return $site_data;
 		}
 

--- a/tests/phpunit/tests/multisite/networkQuery.php
+++ b/tests/phpunit/tests/multisite/networkQuery.php
@@ -554,6 +554,28 @@ if ( is_multisite() ) :
 
 			return array( 555 );
 		}
+
+		/**
+		 * @ticket 51333
+		 */
+		public function test_networks_pre_query_filter_should_set_networks_property() {
+			add_filter( 'networks_pre_query', array( __CLASS__, 'filter_networks_pre_query_and_set_networks' ), 10, 2 );
+
+			$q       = new WP_Network_Query();
+			$results = $q->query( array() );
+
+			remove_filter( 'networks_pre_query', array( __CLASS__, 'filter_networks_pre_query_and_set_networks' ), 10 );
+
+			// Make sure the networks property is the same as the results.
+			$this->assertSame( $results, $q->networks );
+
+			// Make sure the network domain is `wordpress.org`.
+			$this->assertSame( 'wordpress.org', $q->networks[0]->domain );
+		}
+
+		public static function filter_networks_pre_query_and_set_networks( $networks, $query ) {
+			return array( get_network( self::$network_ids['wordpress.org/'] ) );
+		}
 	}
 
 endif;

--- a/tests/phpunit/tests/multisite/siteQuery.php
+++ b/tests/phpunit/tests/multisite/siteQuery.php
@@ -1095,6 +1095,28 @@ if ( is_multisite() ) :
 
 			return array( 555 );
 		}
+
+		/**
+		 * @ticket 51333
+		 */
+		public function test_sites_pre_query_filter_should_set_sites_property() {
+			add_filter( 'sites_pre_query', array( __CLASS__, 'filter_sites_pre_query_and_set_sites' ), 10, 2 );
+
+			$q       = new WP_Site_Query();
+			$results = $q->query( array() );
+
+			remove_filter( 'sites_pre_query', array( __CLASS__, 'filter_sites_pre_query_and_set_sites' ), 10 );
+
+			// Make sure the sites property is the same as the results.
+			$this->assertSame( $results, $q->sites );
+
+			// Make sure the site domain is `wordpress.org`.
+			$this->assertSame( 'wordpress.org', $q->sites[0]->domain );
+		}
+
+		public static function filter_sites_pre_query_and_set_sites( $sites, $query ) {
+			return array( get_site( self::$site_ids['wordpress.org/'] ) );
+		}
 	}
 
 endif;


### PR DESCRIPTION
Changes:
* `networks_pre_query` filter result assigned to the `networks` property of the current `WP_Network_Query` instance.
* `sites_pre_query` filter result assigned to the `sites` property of the current `WP_Site_Query` instance.

Trac ticket: https://core.trac.wordpress.org/ticket/51333