### PR TITLE
wp_dropdown_users(): checking the user's existence

### DIFF
--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -1198,8 +1198,8 @@ function wp_dropdown_users( $args = '' ) {
 				}
 			}
 
-			if ( ! $found_selected ) {
-				$users[] = get_userdata( $parsed_args['selected'] );
+			if ( ! $found_selected && $user = get_userdata( $parsed_args['selected'] ) ) {
+				$users[] = $user;
 			}
 		}
 


### PR DESCRIPTION
Added a check for the existence of a user, since the function can get the ID of the user (for example, the author of the page) that was deleted.

Trac ticket: https://core.trac.wordpress.org/ticket/51370

