### PR TITLE
Fix Restore Autosave Notice dismissal

### DIFF
--- a/src/js/_enqueues/admin/common.js
+++ b/src/js/_enqueues/admin/common.js
@@ -1092,6 +1092,10 @@ $document.ready( function() {
 			var $el = $( this ),
 				$button = $( '<button type="button" class="notice-dismiss"><span class="screen-reader-text"></span></button>' );
 
+			if ( $el.find( '.notice-dismiss' ).length ) {
+				return;
+			}
+
 			// Ensure plain text.
 			$button.find( '.screen-reader-text' ).text( __( 'Dismiss this notice.' ) );
 			$button.on( 'click.wp-dismiss-notice', function( event ) {


### PR DESCRIPTION
After 5.5.1 upgrade `dismissAutosave` function is not being called on notice dismissal for recent Autosave Notice (Under `customize-control.js`).
An extra `.notice-dismiss` button is added under `common.js`

Fix: Check if the `.notice-dismiss` already exists under the notice element.

Trac ticket: https://core.trac.wordpress.org/ticket/51425

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
