### PR TITLE
Comments: comments_template needs a filter for $top_level_args

### DIFF
--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -1434,6 +1434,21 @@ function comments_template( $file = '/comments.php', $separate_comments = false 
 				$top_level_args['include_unapproved'] = $comment_args['include_unapproved'];
 			}
 
+			/**
+			 * Filters the arguments used in the top level comments query.
+			 *
+			 * @since 5.6.0
+			 *
+			 * @see WP_Comment_Query::__construct()
+			 *
+			 * @param array $top_level_args {
+			 *     @type bool         $count   Whether to return a comment count.
+			 *     @type string|array $orderby Field(s) to order by.
+			 *     @type int          $post_id ID of post
+			 *     @type string|array $status  Comment status to limit results by.
+			 * }
+			 */
+			$top_level_args  = apply_filters( 'comments_template_top_level_query_args', $top_level_args );
 			$top_level_count = $top_level_query->query( $top_level_args );
 
 			$comment_args['offset'] = ( ceil( $top_level_count / $per_page ) - 1 ) * $per_page;


### PR DESCRIPTION
Adds a new filter to the `comments_template` function to allow changes to `$top_level_args`.

Trac ticket: https://core.trac.wordpress.org/ticket/38074

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
