### PR TITLE
51131:Remove constraint that search handlers must return integer ids

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-search-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-search-controller.php
@@ -140,7 +140,7 @@ class WP_REST_Search_Controller extends WP_REST_Controller {
 			);
 		}
 
-		$ids = array_map( 'absint', $result[ WP_REST_Search_Handler::RESULT_IDS ] );
+		$ids = $result[ WP_REST_Search_Handler::RESULT_IDS ];
 
 		$results = array();
 
@@ -186,7 +186,7 @@ class WP_REST_Search_Controller extends WP_REST_Controller {
 	 *
 	 * @since 5.0.0
 	 *
-	 * @param int             $id      ID of the item to prepare.
+	 * @param int|string $id ID of the item to prepare
 	 * @param WP_REST_Request $request Request object.
 	 * @return WP_REST_Response Response object.
 	 */
@@ -245,7 +245,7 @@ class WP_REST_Search_Controller extends WP_REST_Controller {
 			'properties' => array(
 				self::PROP_ID      => array(
 					'description' => __( 'Unique identifier for the object.' ),
-					'type'        => 'integer',
+					'type'        => array( 'integer', 'string' ),
 					'context'     => array( 'view', 'embed' ),
 					'readonly'    => true,
 				),

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-search-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-search-controller.php
@@ -186,7 +186,7 @@ class WP_REST_Search_Controller extends WP_REST_Controller {
 	 *
 	 * @since 5.0.0
 	 *
-	 * @param int|string $id ID of the item to prepare
+	 * @param int|string      $id      ID of the item to prepare
 	 * @param WP_REST_Request $request Request object.
 	 * @return WP_REST_Response Response object.
 	 */

--- a/src/wp-includes/rest-api/search/class-wp-rest-search-handler.php
+++ b/src/wp-includes/rest-api/search/class-wp-rest-search-handler.php
@@ -79,8 +79,8 @@ abstract class WP_REST_Search_Handler {
 	 *
 	 * @since 5.0.0
 	 *
-	 * @param int|string   $id     Item ID.
-	 * @param array $fields Fields to include for the item.
+	 * @param int|string $id     Item ID.
+	 * @param array      $fields Fields to include for the item.
 	 * @return array Associative array containing all fields for the item.
 	 */
 	abstract public function prepare_item( $id, array $fields );

--- a/src/wp-includes/rest-api/search/class-wp-rest-search-handler.php
+++ b/src/wp-includes/rest-api/search/class-wp-rest-search-handler.php
@@ -79,7 +79,7 @@ abstract class WP_REST_Search_Handler {
 	 *
 	 * @since 5.0.0
 	 *
-	 * @param int   $id     Item ID.
+	 * @param int|string   $id     Item ID.
 	 * @param array $fields Fields to include for the item.
 	 * @return array Associative array containing all fields for the item.
 	 */
@@ -90,7 +90,7 @@ abstract class WP_REST_Search_Handler {
 	 *
 	 * @since 5.0.0
 	 *
-	 * @param int $id Item ID.
+	 * @param int|string $id Item ID.
 	 * @return array Links for the given item.
 	 */
 	abstract public function prepare_item_links( $id );


### PR DESCRIPTION
Removed the constraints in WP_REST_Search_Controller, updated id schema, and updated the docs. Edited the docs for WP_REST_Search_Handler.

Trac ticket: https://core.trac.wordpress.org/ticket/51131
