### PR TITLE
Improve identifying of non–trivial callbacks in hooks

### DIFF
--- a/tests/phpunit/tests/hooks/addFilter.php
+++ b/tests/phpunit/tests/hooks/addFilter.php
@@ -19,7 +19,7 @@ class Tests_WP_Hook_Add_Filter extends WP_UnitTestCase {
 
 		$hook->add_filter( $tag, $callback, $priority, $accepted_args );
 
-		$function_index = _wp_filter_build_unique_id( $tag, $callback, $priority );
+		list( $function_index ) = _wp_filter_build_callback_key_and_hash( $callback );
 		$this->assertSame( $callback, $hook->callbacks[ $priority ][ $function_index ]['function'] );
 		$this->assertSame( $accepted_args, $hook->callbacks[ $priority ][ $function_index ]['accepted_args'] );
 	}
@@ -34,7 +34,7 @@ class Tests_WP_Hook_Add_Filter extends WP_UnitTestCase {
 
 		$hook->add_filter( $tag, $callback, $priority, $accepted_args );
 
-		$function_index = _wp_filter_build_unique_id( $tag, $callback, $priority );
+		list( $function_index ) = _wp_filter_build_callback_key_and_hash( $callback );
 		$this->assertSame( $callback, $hook->callbacks[ $priority ][ $function_index ]['function'] );
 		$this->assertSame( $accepted_args, $hook->callbacks[ $priority ][ $function_index ]['accepted_args'] );
 	}
@@ -48,7 +48,7 @@ class Tests_WP_Hook_Add_Filter extends WP_UnitTestCase {
 
 		$hook->add_filter( $tag, $callback, $priority, $accepted_args );
 
-		$function_index = _wp_filter_build_unique_id( $tag, $callback, $priority );
+		list( $function_index ) = _wp_filter_build_callback_key_and_hash( $callback );
 		$this->assertSame( $callback, $hook->callbacks[ $priority ][ $function_index ]['function'] );
 		$this->assertSame( $accepted_args, $hook->callbacks[ $priority ][ $function_index ]['accepted_args'] );
 	}

--- a/tests/phpunit/tests/hooks/hasFilters.php
+++ b/tests/phpunit/tests/hooks/hasFilters.php
@@ -44,7 +44,7 @@ class Tests_WP_Hook_Has_Filters extends WP_UnitTestCase {
 		$accepted_args = rand( 1, 100 );
 
 		$hook->add_filter( $tag, $callback, $priority, $accepted_args );
-		$function_key = _wp_filter_build_unique_id( $tag, $callback, $priority );
+		list( $function_key ) = _wp_filter_build_callback_key_and_hash( $callback );
 		unset( $hook->callbacks[ $priority ][ $function_key ] );
 
 		$this->assertFalse( $hook->has_filters() );


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/46635

---

## Premise

Now that WordPress is having PHP 5.6 as minimum version, and it is working toward plans to move forward the minimum version at a predictable pace, the usage of closures, or even _short closures_, is something that [many developers will be willling to use](https://twitter.com/markjaquith/status/1309480913047355392), many already do.

However, it is "officially"<sup>1</sup> considered bad practice to use those because it is not possible to remove hook callbacks added that way.

In the linked ticket, Rarst proposed make it possible to remove hooks by a sort of predictable "string representation" of closures, and more generally for hooks callbacks that make use of object instances.

Rarst's proposal is inspired by what [Brain Monkey](https://brain-wp.github.io/BrainMonkey/docs/wordpress-hooks-added.html), a testing tool for WordPress that I happen to write a few years ago and still maintain.

What Brain Monkey does, and what Rarst proposes is however something that I believe would make calculation and retrieval of "string representation" too expensive for something like hooks.

In this PR I will _not_ support all the possibilities listed by Rarst in the Trac ticket, but it I will support a basic subset (with some variations) but keeping an open door to the possibility to extend the support for other possibilities in a later iteraction.



## Scope

When I started working on this PR I had in mind the following priorities:

- do not break backward compatibility in ***any*** way, even supporting code that makes use of "internal" or "private" WordPress functions
- allow the check (`has_filter`/ `has_action`) and the removal of hook callbacks supporting all the possibility offered by PHP callable



## Implementation

Assuming a `functions.php` that contain the following code:

```php
add_action('some_hook', function () { /* some code here */ });

add_filter('some_other_hook', [new SomeObject, 'a_method']);
```

If merged, this PR will make possible to check and remove the added hooks like so:

```php
// Check

has_action('some_hook', 'function()@functions.php'); // true

has_filter('some_other_hook', 'SomeObject->a_method'); // true

// Remove

remove_action('some_hook', 'function()@functions.php');

remove_action('some_other_hook', 'SomeObject->a_method');
```

Please note that:

- for closures, the file name to use after the `@` is the *basename*, not the full path.
- in both cases namespace is relevant.

### Namespace

Let's assume our  `functions.php` contains:

```php
namespace My\Awesome\Plugin;

use Another\Name\Space\SomeObject;

add_action('some_hook', function () { /* some code here */ });

add_filter('some_other_hook', [new SomeObject, 'a_method']);
```

If merged, this PR will make possible to check and remove the added hooks like so:

```php
remove_action('some_hook', 'My\Awesome\Plugin\function()@functions.php');

remove_action('some_other_hook', 'Another\Name\Space\SomeObject->a_method');
```

Note how the namespace is the namespace where classes/closures are _defined_ not where they are _used_ even if for closures the great majority of times the namespace where they are defined is the same where they are used.

There're peculiar cases that it is worth to see in detail.

### Anonymous classes

PHP does not allow to retrieve the namespace of [anonymous classes](https://www.php.net/manual/en/language.oop5.anonymous.php). In other words, anonymous classes are always in the root namespace. Similarly to what is done for anonymous functions (aka closures) the way anonymous classes can be identified is `class()@filename.php`.

However, unlike functions, classes can extend other classes. This is captured by the code in this PR that requires the parent class to be included in the "string representation" of the class.

For example:

```php
$object1 = new class {
  
  public function toArray() {
    return [];
  }
};

$object2 = new class extends ArrayObject {
  
  public function toArray() {
    return $this->getArrayCopy();
  }
};

add_filter('some_filter', [$object1, 'toArray']);
add_filter('some_filter', [$object2, 'toArray']);

// Remove filter using $object1
remove_filter('some_filter', 'class()filename.php->toArray');

// Remove filter using $object2
remove_filter('some_filter', 'class()ArrayObject@filename.php->toArray');
```

Remember that namespace does not affect "callback id" for anonymous classes but does affect id generated for closures and named classes.



### Invokable objects

In PHP any object implementing a method named `__invoke()` [can be used as a callback](https://www.php.net/manual/en/language.oop5.magic.php#object.invoke).

Anonymous functions are behind the scenes nothing more than instances of a class (`Closure`) that has a `__invoke()` method. (see https://3v4l.org/OXpBe).

When using an invokable object, we can use the `__invoke()` method as hook callback both explicitly and implicitly. For example:

```php
class MyInvokable {
  
  public function __invoke() {
    return true;
  }
}

$invokable = new MyInvokable;

// Following two lines do **exact same thing**:

add_filter('an_hook', $invokable);

add_filter('an_hook', [$invokable, '__invoke']);
```

For this reason the "string representation" used by this PR will use exact same representation for both. For example, *both* the two filters added in the snippet right above can be removed like this:

```php
remove_filter('an_hook', 'MyInvokable->__invoke');
```

To see how things works together, we can see an anonymous class that extend another class and is also invokable:

```php
$invokable = new class extends AnotherClass {
  
  public function __invoke() {
    return true;
  }
};

// Hook added like this:
add_filter('an_hook', $invokable);

// Can be removed like this:
remove_filter('an_hook', 'class()AnotherClass@filename.php->__invoke');
```



## Backward compatility

This PR is 100% backward compatible.

Code that uses "static" callbacks, like function names or static methods are **not** affected at all.

For code that make use of object instances (and that includes anonymous functions) all the current approaches continue to work.

For example, let's assume the following code:

```php
global $func, $object; 
$func =  function () { /* some code here */ };
$object = new SomeObject;

add_action('some_hook', $func);

add_filter('some_other_hook', [$object, 'a_method']);
```

Currently, in some other place we can remove these hooks like this:

```php
global $func, $object;

remove_action('some_hook', $func);

remove_filter('some_other_hook', [$object, 'a_method']);
```

That is: if we have access to exact same instance that was used to add the hooks, we will be able to remove the hooks. This PR continues to fully support this approach.

Even more, something that is not really documented is that we can use [`spl_object_hash`](https://www.php.net/manual/en/function.spl-object-hash.php) to remove hooks that make use of objects.

For example, following code has the exact same effect of the code right above:

```php
global $func, $object;

remove_action('some_hook', spl_object_hash($func));

remove_filter('some_other_hook', spl_object_hash($object) . 'a_method');
// or alternatively:
remove_filter('some_other_hook', _wp_filter_build_unique_id('', [$object, 'a_method'], false);
```

This approach, even if can be considered quite "hackish", continues to be fully supported by this PR.



## A new approach: custom callback ID

As *additional* functionality, that works side-by-side with the workflow described above, this PR introduces a new parameter to `add_action` and `add_filter` that allow to define a custom ID for callbacks that make use of object instances.

For example, hooks added like this:

```php
class MyPlugin {
  
  public function init() {
    add_action('init', [$this, 'init'], 10, 2, 'my-plugin/init');
    add_action('wp', [$this, 'wp'], 10, 2, 'my-plugin/wp');
    add_action('pre_get_posts', [$this, 'pre_get_posts'], 10, 2, 'my-plugin/pre_get_posts');
  }
}
```

Can be removed like this:

```php
remove_action('init', 'my-plugin/init');
remove_action('wp', 'my-plugin/wp');
remove_action('pre_get_posts', 'my-plugin/pre_get_posts');
```

The additional ID is entirely optional, but when it is used it becomes the **only** way to check or remove the hook will be the custom ID.

In the current implementation the custom ID is only supported for callbacks that make use of object instances: any custom ID used for callbacks represented by plain function names or static methods will be ignored and will end up in `_doing_it_wrong` being called (assuming that function is alredy loaded).



## Tests

This PR includes small changes to the WordPress unit tests suite to prevent existing tests to fail, however the new functionality is not really tested in here.

The reason is that not being familiar with development practices at core I'm not sure how I should test things that require PHP 7+ (like anonymous classes) or closures declared in a namespaced context.

This is why to test my code I created a [separate repository](https://github.com/gmazzap/wp-hooks-tests) where I copied `plugin.php` and `class-wp-hook.php` from this PR and [I tested](https://github.com/gmazzap/wp-hooks-tests/blob/main/tests/cases/HookCallbacksSerializationTest.php) them to ensure the new functionalities work as expected and that backward compatibility is ensured.



## Gotchas

Even if this PR took backward compatibility as primary goal there's a sort-of edge case that will break if it would be merged.

Consider the following code:

```php
add_action('say_hi', function() { echo "Hello"; });
add_action('say_hi', function() { echo "World"; });

do_action('say_hi');
```

Currently in WP the code above will end in *"Hello World"* being printed, because _both_ closures are added, even if the hook and priority are the same.

With this PR merged the second closure would override the first, and executing the code above only *"World"* would be printed.

The reason is that both closures are "serialized" as `function()@filename.php` and this identifier is identical for both (assuming both are placed in the same file).

If this look bad to you, please notice that this is something that *already* happens for "static" callbacks and even for object methods using same instance.

For example:

```php
function say_hi() {
  echo "Hi";
}

add_action('say_hi', 'say_hi');
add_action('say_hi', 'say_hi');

do_action('say_hi');
```

The code above prints *"Hi"* once, not twice.

Or consider the following:

```php
public MyPlugin {
  
  public function add_test_hook() {
    add_action('test', [$this, 'test']);
  }
  
  public function test() {
    static $counter = 1;
    echo "Counter: $counter";
    $counter++;
  }
}

$plugin = new MyPlugin;

$plugin->add_test_hook();
$plugin->add_test_hook();
$plugin->add_test_hook();

do_action('test');
```

The code above will print *"Counter: 1"* even if `add_test_hook` was called 3 times. 

What I mean is that by using same hook, same callback, and same priority WordPress _already_ add the hook only once so I believe that what this PR does is actually to add more consistence.

Of course, by defining closures in different files, or even just using a different priority will be enough to make them distinguable.

For example the following code:

```php
add_action('say_hi', function() { echo "Hello"; });
add_action('say_hi', function() { echo "World"; }, 11);

do_action('say_hi');
```

Will print *"Hello World"* as expected.



---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**

------

<sup>1</sup> For "officially" I mean _for code to be written for core_.