### PR TITLE
oEmbed Controller: Add pre_oembed_result filter

### DIFF
--- a/src/wp-includes/class-wp-oembed-controller.php
+++ b/src/wp-includes/class-wp-oembed-controller.php
@@ -191,6 +191,13 @@ final class WP_oEmbed_Controller {
 			return $data;
 		}
 
+		/** This filter is documented in wp-includes/class-wp-oembed.php */
+		$data = apply_filters( 'pre_oembed_result', null, $url, $args );
+
+		if ( null !== $data ) {
+			return $data;
+		}
+
 		$data = _wp_oembed_get_object()->get_data( $url, $args );
 
 		if ( false === $data ) {


### PR DESCRIPTION
[`WP_oEmbed::get_html()`](https://github.com/WordPress/WordPress/blob/5cee7eced0b691089a875d7e918d4380bac408af/wp-includes/class-wp-oembed.php#L363-L415) [applies](https://github.com/WordPress/WordPress/blob/5cee7eced0b691089a875d7e918d4380bac408af/wp-includes/class-wp-oembed.php#L393) the `pre_oembed_result` filter, allowing it to short-circuit the actual request to the oEmbed provider's REST API.
 
That same filter is however missing from [`WP_oEmbed_Controller::get_proxy_item()`](https://github.com/WordPress/WordPress/blob/5cee7eced0b691089a875d7e918d4380bac408af/wp-includes/class-wp-oembed-controller.php#L154-L220). (Note that both `WP_oEmbed::get_html()` and `WP_oEmbed_Controller::get_proxy_item()` are otherwise quite similar, sharing the `get_data()` and `data2html()` calls, and `oembed_result` filter.)
 
It's arguable that the oembed REST API endpoint should allow for the same kind of filtering as the `oEmbed` class.
 
This issue seems somewhat similar to Core ticket 45142, which was about the `oembed_result` filter.
 
cc @swissspidy @danielbachhuber

Trac ticket: https://core.trac.wordpress.org/ticket/51471

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
