### PR TITLE
43441: Dashboard: Show `2` w.org news items to preserve clustered posts.

### DIFF
--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1450,7 +1450,7 @@ function wp_dashboard_primary() {
 			 * @param string $title Title attribute for the widget's primary link.
 			 */
 			'title'        => apply_filters( 'dashboard_primary_title', __( 'WordPress Blog' ) ),
-			'items'        => 1,
+			'items'        => 2,
 			'show_summary' => 0,
 			'show_author'  => 0,
 			'show_date'    => 0,


### PR DESCRIPTION
These days there are often 2 posts published close to each other, like a release announcement and a Month In WordPress post. When that happens, the earlier post is often pushed out of the widget before many people have had a chance to see it.

Ideally, the number of total items would remain at `4`, to reduce visual clutter. Implementing a conditional item would require a significant refactor, though. Increasing the total number of items to `5` is a practical compromise.

Trac ticket: https://core.trac.wordpress.org/ticket/43441
