### PR TITLE
REST API: Add overriding of the PUT and DELETE methods in wp.apiRequest.

### DIFF
--- a/src/js/_enqueues/wp/api-request.js
+++ b/src/js/_enqueues/wp/api-request.js
@@ -9,6 +9,7 @@
  * - Allows specifying only an endpoint namespace/path instead of a full URL.
  *
  * @since 4.9.0
+ * @since 5.6.0 Added overriding of the "PUT" and "DELETE" methods with "POST".
  * @output wp-includes/js/api-request.js
  */
 
@@ -23,6 +24,7 @@
 	apiRequest.buildAjaxOptions = function( options ) {
 		var url = options.url;
 		var path = options.path;
+		var method = options.method;
 		var namespaceTrimmed, endpointTrimmed, apiRoot;
 		var headers, addNonceHeader, headerName;
 
@@ -76,10 +78,23 @@
 			}, headers );
 		}
 
+		if ( typeof method === 'string' ) {
+			method = method.toUpperCase();
+
+			if ( 'PUT' === method || 'DELETE' === method ) {
+				headers = $.extend( {
+					'X-HTTP-Method-Override': method
+				}, headers );
+
+				method = 'POST';
+			}
+		}
+
 		// Do not mutate the original options object.
 		options = $.extend( {}, options, {
 			headers: headers,
-			url: url
+			url: url,
+			method: method
 		} );
 
 		delete options.path;


### PR DESCRIPTION
Added overriding of the PUT and DELETE methods with the POST method in wp.apiRequest library.

Trac ticket: https://core.trac.wordpress.org/ticket/43605