### PR TITLE
Add wp-packages-update command to update WordPress packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,6 +166,7 @@
 		"env:pull": "node ./tools/local-env/scripts/docker.js pull",
 		"test:php": "node ./tools/local-env/scripts/docker.js run --rm phpunit phpunit",
 		"test:php-composer": "node ./tools/local-env/scripts/docker.js run --rm phpunit php ./vendor/bin/phpunit",
-		"test:e2e": "node ./tests/e2e/run-tests.js"
+		"test:e2e": "node ./tests/e2e/run-tests.js",
+		"wp-packages-update": "wp-scripts packages-update"
 	}
 }


### PR DESCRIPTION
This PR exposes the packages-update script implemented at https://github.com/WordPress/gutenberg/pull/19448 on WordPress core.
By running "npm run wp-packages-update" all the WordPress packages are updated to the latest version. The command is very useful when updating the Gutenberg editor core exposes.
cc: @isabel_brison

Trac ticket: https://core.trac.wordpress.org/ticket/51491