### PR TITLE
Fix Missing Newline in WP_Rewrite // #51495

### DIFF
--- a/src/wp-includes/class-wp-rewrite.php
+++ b/src/wp-includes/class-wp-rewrite.php
@@ -1509,7 +1509,7 @@ class WP_Rewrite {
 
 		$rules  = "<IfModule mod_rewrite.c>\n";
 		$rules .= "RewriteEngine On\n";
-		$rules .= 'RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]';
+		$rules .= 'RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]\n';
 		$rules .= "RewriteBase $home_root\n";
 
 		// Prevent -f checks on index.php.

--- a/src/wp-includes/class-wp-rewrite.php
+++ b/src/wp-includes/class-wp-rewrite.php
@@ -1509,7 +1509,7 @@ class WP_Rewrite {
 
 		$rules  = "<IfModule mod_rewrite.c>\n";
 		$rules .= "RewriteEngine On\n";
-		$rules .= 'RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]\n';
+		$rules .= "RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]\n";
 		$rules .= "RewriteBase $home_root\n";
 
 		// Prevent -f checks on index.php.


### PR DESCRIPTION
I didn't add the suggested parentheses, as I don't believe they are necessary to do the regex capture, and the prior working art for this seemed to run perfectly without them -- https://github.com/WordPress/application-passwords/wiki/Basic-Authorization-Header----Missing

Trac ticket: https://core.trac.wordpress.org/ticket/51495

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
