### PR TITLE
Always enable application passwords for local environments

### DIFF
--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -4097,14 +4097,16 @@ function wp_get_user_request( $request_id ) {
 /**
  * Checks if Application Passwords is globally available.
  *
- * By default, Application Passwords is available to all sites using SSL, but this function is
- * filterable to adjust its availability.
+ * By default, Application Passwords is available to all sites using SSL or to local environments.
+ * Use {@see 'wp_is_application_passwords_available'} to adjust its availability.
  *
  * @since 5.6.0
  *
  * @return bool
  */
 function wp_is_application_passwords_available() {
+	$available = is_ssl() || 'local' === wp_get_environment_type();
+
 	/**
 	 * Filters whether Application Passwords is available.
 	 *
@@ -4112,14 +4114,14 @@ function wp_is_application_passwords_available() {
 	 *
 	 * @param bool $available True if available, false otherwise.
 	 */
-	return apply_filters( 'wp_is_application_passwords_available', is_ssl() );
+	return apply_filters( 'wp_is_application_passwords_available', $available );
 }
 
 /**
  * Checks if Application Passwords is enabled for a specific user.
  *
- * By default all users can use Application Passwords, but this function is filterable to restrict
- * availability to certain users.
+ * By default all users can use Application Passwords. Use {@see 'wp_is_application_passwords_available_for_user'}
+ * to restrict availability to certain users.
  *
  * @since 5.6.0
  *


### PR DESCRIPTION
Currently when using the local development environment no application passwords are visible since the site is only available via HTTP and application passwords require HTTPS. To make testing easier I'm proposing to enable application passwords if the current environment type is `local`.

Trac ticket: https://core.trac.wordpress.org/ticket/51503

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
