### PR TITLE
Update React and fix Lodash version in script loader.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20380,9 +20380,9 @@
 			}
 		},
 		"react": {
-			"version": "16.9.0",
-			"resolved": "https://registry.npmjs.org/react/-/react-16.9.0.tgz",
-			"integrity": "sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==",
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
+			"integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -20429,14 +20429,14 @@
 			}
 		},
 		"react-dom": {
-			"version": "16.9.0",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.9.0.tgz",
-			"integrity": "sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==",
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
+			"integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
 				"prop-types": "^15.6.2",
-				"scheduler": "^0.15.0"
+				"scheduler": "^0.19.1"
 			}
 		},
 		"react-easy-crop": {
@@ -21884,9 +21884,9 @@
 			}
 		},
 		"scheduler": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.15.0.tgz",
-			"integrity": "sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==",
+			"version": "0.19.1",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+			"integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -140,8 +140,8 @@
 		"masonry-layout": "4.2.2",
 		"moment": "2.27.0",
 		"polyfill-library": "3.42.0",
-		"react": "16.9.0",
-		"react-dom": "16.9.0",
+		"react": "16.13.1",
+		"react-dom": "16.13.1",
 		"twemoji": "13.0.0",
 		"underscore": "1.8.3",
 		"whatwg-fetch": "3.0.0"

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -94,10 +94,10 @@ function wp_default_packages_vendor( $scripts ) {
 	);
 
 	$vendor_scripts_versions = array(
-		'react'                       => '16.9.0',
-		'react-dom'                   => '16.9.0',
+		'react'                       => '16.13.1',
+		'react-dom'                   => '16.13.1',
 		'moment'                      => '2.26.0',
-		'lodash'                      => '4.17.15',
+		'lodash'                      => '4.17.19',
 		'wp-polyfill-fetch'           => '3.0.0',
 		'wp-polyfill-formdata'        => '3.0.12',
 		'wp-polyfill-node-contains'   => '3.42.0',


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Updates React to version 16.13.1, matching the Gutenberg packages. Also updates the Lodash version in `wp-includes/script-loader.php` to match the one in package.json (already matches Gutenberg).

Trac ticket: https://core.trac.wordpress.org/ticket/51505

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
