### PR TITLE
Fix mismatched parameter names in child classes (Trac 51553 - task 1)

### DIFF
--- a/src/wp-admin/includes/class-automatic-upgrader-skin.php
+++ b/src/wp-admin/includes/class-automatic-upgrader-skin.php
@@ -67,17 +67,18 @@ class Automatic_Upgrader_Skin extends WP_Upgrader_Skin {
 	 *
 	 * @since 3.7.0
 	 *
-	 * @param string|array|WP_Error $data    Message data.
-	 * @param mixed                 ...$args Optional text replacements.
+	 * @param string|array|WP_Error $feedback Message data.
+	 * @param mixed                 ...$args  Optional text replacements.
 	 */
-	public function feedback( $data, ...$args ) {
-		if ( is_wp_error( $data ) ) {
-			$string = $data->get_error_message();
-		} elseif ( is_array( $data ) ) {
+	public function feedback( $feedback, ...$args ) {
+		if ( is_wp_error( $feedback ) ) {
+			$string = $feedback->get_error_message();
+		} elseif ( is_array( $feedback ) ) {
 			return;
 		} else {
-			$string = $data;
+			$string = $feedback;
 		}
+
 		if ( ! empty( $this->upgrader->strings[ $string ] ) ) {
 			$string = $this->upgrader->strings[ $string ];
 		}

--- a/src/wp-admin/includes/class-bulk-upgrader-skin.php
+++ b/src/wp-admin/includes/class-bulk-upgrader-skin.php
@@ -87,18 +87,18 @@ class Bulk_Upgrader_Skin extends WP_Upgrader_Skin {
 	}
 
 	/**
-	 * @param string|WP_Error $error
+	 * @param string|WP_Error $errors
 	 */
-	public function error( $error ) {
-		if ( is_string( $error ) && isset( $this->upgrader->strings[ $error ] ) ) {
-			$this->error = $this->upgrader->strings[ $error ];
+	public function error( $errors ) {
+		if ( is_string( $errors ) && isset( $this->upgrader->strings[ $errors ] ) ) {
+			$this->error = $this->upgrader->strings[ $errors ];
 		}
 
-		if ( is_wp_error( $error ) ) {
+		if ( is_wp_error( $errors ) ) {
 			$messages = array();
-			foreach ( $error->get_error_messages() as $emessage ) {
-				if ( $error->get_error_data() && is_string( $error->get_error_data() ) ) {
-					$messages[] = $emessage . ' ' . esc_html( strip_tags( $error->get_error_data() ) );
+			foreach ( $errors->get_error_messages() as $emessage ) {
+				if ( $errors->get_error_data() && is_string( $errors->get_error_data() ) ) {
+					$messages[] = $emessage . ' ' . esc_html( strip_tags( $errors->get_error_data() ) );
 				} else {
 					$messages[] = $emessage;
 				}

--- a/src/wp-admin/includes/class-bulk-upgrader-skin.php
+++ b/src/wp-admin/includes/class-bulk-upgrader-skin.php
@@ -49,28 +49,28 @@ class Bulk_Upgrader_Skin extends WP_Upgrader_Skin {
 	}
 
 	/**
-	 * @param string $string
-	 * @param mixed  ...$args Optional text replacements.
+	 * @param string $feedback Message data.
+	 * @param mixed  ...$args  Optional text replacements.
 	 */
-	public function feedback( $string, ...$args ) {
-		if ( isset( $this->upgrader->strings[ $string ] ) ) {
-			$string = $this->upgrader->strings[ $string ];
+	public function feedback( $feedback, ...$args ) {
+		if ( isset( $this->upgrader->strings[ $feedback ] ) ) {
+			$feedback = $this->upgrader->strings[ $feedback ];
 		}
 
-		if ( strpos( $string, '%' ) !== false ) {
+		if ( strpos( $feedback, '%' ) !== false ) {
 			if ( $args ) {
-				$args   = array_map( 'strip_tags', $args );
-				$args   = array_map( 'esc_html', $args );
-				$string = vsprintf( $string, $args );
+				$args     = array_map( 'strip_tags', $args );
+				$args     = array_map( 'esc_html', $args );
+				$feedback = vsprintf( $feedback, $args );
 			}
 		}
-		if ( empty( $string ) ) {
+		if ( empty( $feedback ) ) {
 			return;
 		}
 		if ( $this->in_loop ) {
-			echo "$string<br />\n";
+			echo "$feedback<br />\n";
 		} else {
-			echo "<p>$string</p>\n";
+			echo "<p>$feedback</p>\n";
 		}
 	}
 

--- a/src/wp-admin/includes/class-language-pack-upgrader-skin.php
+++ b/src/wp-admin/includes/class-language-pack-upgrader-skin.php
@@ -52,11 +52,11 @@ class Language_Pack_Upgrader_Skin extends WP_Upgrader_Skin {
 	}
 
 	/**
-	 * @param string|WP_Error $error
+	 * @param string|WP_Error $errors
 	 */
-	public function error( $error ) {
+	public function error( $errors ) {
 		echo '<div class="lp-error">';
-		parent::error( $error );
+		parent::error( $errors );
 		echo '</div>';
 	}
 

--- a/src/wp-admin/includes/class-walker-category-checklist.php
+++ b/src/wp-admin/includes/class-walker-category-checklist.php
@@ -127,12 +127,12 @@ class Walker_Category_Checklist extends Walker {
 	 *
 	 * @since 2.5.1
 	 *
-	 * @param string  $output   Used to append additional content (passed by reference).
-	 * @param WP_Term $category The current term object.
-	 * @param int     $depth    Depth of the term in reference to parents. Default 0.
-	 * @param array   $args     An array of arguments. @see wp_terms_checklist()
+	 * @param string  $output      Used to append additional content (passed by reference).
+	 * @param WP_Term $data_object The current term object. Not used.
+	 * @param int     $depth       Depth of the term in reference to parents. Default 0.
+	 * @param array   $args        An array of arguments. @see wp_terms_checklist()
 	 */
-	public function end_el( &$output, $category, $depth = 0, $args = array() ) {
+	public function end_el( &$output, $data_object, $depth = 0, $args = array() ) {
 		$output .= "</li>\n";
 	}
 }

--- a/src/wp-admin/includes/class-walker-category-checklist.php
+++ b/src/wp-admin/includes/class-walker-category-checklist.php
@@ -62,13 +62,19 @@ class Walker_Category_Checklist extends Walker {
 	 *
 	 * @since 2.5.1
 	 *
-	 * @param string  $output   Used to append additional content (passed by reference).
-	 * @param WP_Term $category The current term object.
-	 * @param int     $depth    Depth of the term in reference to parents. Default 0.
-	 * @param array   $args     An array of arguments. @see wp_terms_checklist()
-	 * @param int     $id       ID of the current term.
+	 * @param string  $output      Used to append additional content (passed by reference).
+	 * @param WP_Term $data_object The current term object.
+	 * @param int     $depth       Depth of the term in reference to parents. Default 0.
+	 * @param array   $args        An array of arguments. @see wp_terms_checklist()
+	 * @param int     $id          ID of the current term.
 	 */
-	public function start_el( &$output, $category, $depth = 0, $args = array(), $id = 0 ) {
+	public function start_el( &$output, $data_object, $depth = 0, $args = array(), $id = 0 ) {
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$category = $data_object;
+
 		if ( empty( $args['taxonomy'] ) ) {
 			$taxonomy = 'category';
 		} else {

--- a/src/wp-admin/includes/class-walker-category-checklist.php
+++ b/src/wp-admin/includes/class-walker-category-checklist.php
@@ -62,13 +62,13 @@ class Walker_Category_Checklist extends Walker {
 	 *
 	 * @since 2.5.1
 	 *
-	 * @param string  $output      Used to append additional content (passed by reference).
-	 * @param WP_Term $data_object The current term object.
-	 * @param int     $depth       Depth of the term in reference to parents. Default 0.
-	 * @param array   $args        An array of arguments. @see wp_terms_checklist()
-	 * @param int     $id          ID of the current term.
+	 * @param string  $output            Used to append additional content (passed by reference).
+	 * @param WP_Term $data_object       The current term object.
+	 * @param int     $depth             Depth of the term in reference to parents. Default 0.
+	 * @param array   $args              An array of arguments. @see wp_terms_checklist()
+	 * @param int     $current_object_id ID of the current term.
 	 */
-	public function start_el( &$output, $data_object, $depth = 0, $args = array(), $id = 0 ) {
+	public function start_el( &$output, $data_object, $depth = 0, $args = array(), $current_object_id = 0 ) {
 		/*
 		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
 		 * Also see Trac #51553.

--- a/src/wp-admin/includes/class-walker-nav-menu-checklist.php
+++ b/src/wp-admin/includes/class-walker-nav-menu-checklist.php
@@ -65,13 +65,13 @@ class Walker_Nav_Menu_Checklist extends Walker_Nav_Menu {
 	 * @global int        $_nav_menu_placeholder
 	 * @global int|string $nav_menu_selected_id
 	 *
-	 * @param string   $output      Used to append additional content (passed by reference).
-	 * @param WP_Post  $data_object Menu item data object.
-	 * @param int      $depth       Depth of menu item. Used for padding.
-	 * @param stdClass $args        Not used.
-	 * @param int      $id          Not used.
+	 * @param string   $output            Used to append additional content (passed by reference).
+	 * @param WP_Post  $data_object       Menu item data object.
+	 * @param int      $depth             Depth of menu item. Used for padding.
+	 * @param stdClass $args              Not used.
+	 * @param int      $current_object_id Not used.
 	 */
-	public function start_el( &$output, $data_object, $depth = 0, $args = null, $id = 0 ) {
+	public function start_el( &$output, $data_object, $depth = 0, $args = null, $current_object_id = 0 ) {
 		global $_nav_menu_placeholder, $nav_menu_selected_id;
 
 		/*

--- a/src/wp-admin/includes/class-walker-nav-menu-checklist.php
+++ b/src/wp-admin/includes/class-walker-nav-menu-checklist.php
@@ -65,18 +65,24 @@ class Walker_Nav_Menu_Checklist extends Walker_Nav_Menu {
 	 * @global int        $_nav_menu_placeholder
 	 * @global int|string $nav_menu_selected_id
 	 *
-	 * @param string   $output Used to append additional content (passed by reference).
-	 * @param WP_Post  $item   Menu item data object.
-	 * @param int      $depth  Depth of menu item. Used for padding.
-	 * @param stdClass $args   Not used.
-	 * @param int      $id     Not used.
+	 * @param string   $output      Used to append additional content (passed by reference).
+	 * @param WP_Post  $data_object Menu item data object.
+	 * @param int      $depth       Depth of menu item. Used for padding.
+	 * @param stdClass $args        Not used.
+	 * @param int      $id          Not used.
 	 */
-	public function start_el( &$output, $item, $depth = 0, $args = null, $id = 0 ) {
+	public function start_el( &$output, $data_object, $depth = 0, $args = null, $id = 0 ) {
 		global $_nav_menu_placeholder, $nav_menu_selected_id;
 
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$menu_item = $data_object;
+
 		$_nav_menu_placeholder = ( 0 > $_nav_menu_placeholder ) ? (int) $_nav_menu_placeholder - 1 : -1;
-		$possible_object_id    = isset( $item->post_type ) && 'nav_menu_item' === $item->post_type ? $item->object_id : $_nav_menu_placeholder;
-		$possible_db_id        = ( ! empty( $item->ID ) ) && ( 0 < $possible_object_id ) ? (int) $item->ID : 0;
+		$possible_object_id    = isset( $menu_item->post_type ) && 'nav_menu_item' === $menu_item->post_type ? $menu_item->object_id : $_nav_menu_placeholder;
+		$possible_db_id        = ( ! empty( $menu_item->ID ) ) && ( 0 < $possible_object_id ) ? (int) $menu_item->ID : 0;
 
 		$indent = ( $depth ) ? str_repeat( "\t", $depth ) : '';
 
@@ -84,39 +90,39 @@ class Walker_Nav_Menu_Checklist extends Walker_Nav_Menu {
 		$output .= '<label class="menu-item-title">';
 		$output .= '<input type="checkbox"' . wp_nav_menu_disabled_check( $nav_menu_selected_id, false ) . ' class="menu-item-checkbox';
 
-		if ( ! empty( $item->front_or_home ) ) {
+		if ( ! empty( $menu_item->front_or_home ) ) {
 			$output .= ' add-to-top';
 		}
 
-		$output .= '" name="menu-item[' . $possible_object_id . '][menu-item-object-id]" value="' . esc_attr( $item->object_id ) . '" /> ';
+		$output .= '" name="menu-item[' . $possible_object_id . '][menu-item-object-id]" value="' . esc_attr( $menu_item->object_id ) . '" /> ';
 
-		if ( ! empty( $item->label ) ) {
-			$title = $item->label;
-		} elseif ( isset( $item->post_type ) ) {
+		if ( ! empty( $menu_item->label ) ) {
+			$title = $menu_item->label;
+		} elseif ( isset( $menu_item->post_type ) ) {
 			/** This filter is documented in wp-includes/post-template.php */
-			$title = apply_filters( 'the_title', $item->post_title, $item->ID );
+			$title = apply_filters( 'the_title', $menu_item->post_title, $menu_item->ID );
 		}
 
-		$output .= isset( $title ) ? esc_html( $title ) : esc_html( $item->title );
+		$output .= isset( $title ) ? esc_html( $title ) : esc_html( $menu_item->title );
 
-		if ( empty( $item->label ) && isset( $item->post_type ) && 'page' === $item->post_type ) {
+		if ( empty( $menu_item->label ) && isset( $menu_item->post_type ) && 'page' === $menu_item->post_type ) {
 			// Append post states.
-			$output .= _post_states( $item, false );
+			$output .= _post_states( $menu_item, false );
 		}
 
 		$output .= '</label>';
 
 		// Menu item hidden fields.
 		$output .= '<input type="hidden" class="menu-item-db-id" name="menu-item[' . $possible_object_id . '][menu-item-db-id]" value="' . $possible_db_id . '" />';
-		$output .= '<input type="hidden" class="menu-item-object" name="menu-item[' . $possible_object_id . '][menu-item-object]" value="' . esc_attr( $item->object ) . '" />';
-		$output .= '<input type="hidden" class="menu-item-parent-id" name="menu-item[' . $possible_object_id . '][menu-item-parent-id]" value="' . esc_attr( $item->menu_item_parent ) . '" />';
-		$output .= '<input type="hidden" class="menu-item-type" name="menu-item[' . $possible_object_id . '][menu-item-type]" value="' . esc_attr( $item->type ) . '" />';
-		$output .= '<input type="hidden" class="menu-item-title" name="menu-item[' . $possible_object_id . '][menu-item-title]" value="' . esc_attr( $item->title ) . '" />';
-		$output .= '<input type="hidden" class="menu-item-url" name="menu-item[' . $possible_object_id . '][menu-item-url]" value="' . esc_attr( $item->url ) . '" />';
-		$output .= '<input type="hidden" class="menu-item-target" name="menu-item[' . $possible_object_id . '][menu-item-target]" value="' . esc_attr( $item->target ) . '" />';
-		$output .= '<input type="hidden" class="menu-item-attr-title" name="menu-item[' . $possible_object_id . '][menu-item-attr-title]" value="' . esc_attr( $item->attr_title ) . '" />';
-		$output .= '<input type="hidden" class="menu-item-classes" name="menu-item[' . $possible_object_id . '][menu-item-classes]" value="' . esc_attr( implode( ' ', $item->classes ) ) . '" />';
-		$output .= '<input type="hidden" class="menu-item-xfn" name="menu-item[' . $possible_object_id . '][menu-item-xfn]" value="' . esc_attr( $item->xfn ) . '" />';
+		$output .= '<input type="hidden" class="menu-item-object" name="menu-item[' . $possible_object_id . '][menu-item-object]" value="' . esc_attr( $menu_item->object ) . '" />';
+		$output .= '<input type="hidden" class="menu-item-parent-id" name="menu-item[' . $possible_object_id . '][menu-item-parent-id]" value="' . esc_attr( $menu_item->menu_item_parent ) . '" />';
+		$output .= '<input type="hidden" class="menu-item-type" name="menu-item[' . $possible_object_id . '][menu-item-type]" value="' . esc_attr( $menu_item->type ) . '" />';
+		$output .= '<input type="hidden" class="menu-item-title" name="menu-item[' . $possible_object_id . '][menu-item-title]" value="' . esc_attr( $menu_item->title ) . '" />';
+		$output .= '<input type="hidden" class="menu-item-url" name="menu-item[' . $possible_object_id . '][menu-item-url]" value="' . esc_attr( $menu_item->url ) . '" />';
+		$output .= '<input type="hidden" class="menu-item-target" name="menu-item[' . $possible_object_id . '][menu-item-target]" value="' . esc_attr( $menu_item->target ) . '" />';
+		$output .= '<input type="hidden" class="menu-item-attr-title" name="menu-item[' . $possible_object_id . '][menu-item-attr-title]" value="' . esc_attr( $menu_item->attr_title ) . '" />';
+		$output .= '<input type="hidden" class="menu-item-classes" name="menu-item[' . $possible_object_id . '][menu-item-classes]" value="' . esc_attr( implode( ' ', $menu_item->classes ) ) . '" />';
+		$output .= '<input type="hidden" class="menu-item-xfn" name="menu-item[' . $possible_object_id . '][menu-item-xfn]" value="' . esc_attr( $menu_item->xfn ) . '" />';
 	}
 
 }

--- a/src/wp-admin/includes/class-walker-nav-menu-edit.php
+++ b/src/wp-admin/includes/class-walker-nav-menu-edit.php
@@ -49,13 +49,13 @@ class Walker_Nav_Menu_Edit extends Walker_Nav_Menu {
 	 *
 	 * @global int $_wp_nav_menu_max_depth
 	 *
-	 * @param string   $output      Used to append additional content (passed by reference).
-	 * @param WP_Post  $data_object Menu item data object.
-	 * @param int      $depth       Depth of menu item. Used for padding.
-	 * @param stdClass $args        Not used.
-	 * @param int      $id          Not used.
+	 * @param string   $output            Used to append additional content (passed by reference).
+	 * @param WP_Post  $data_object       Menu item data object.
+	 * @param int      $depth             Depth of menu item. Used for padding.
+	 * @param stdClass $args              An object of menu item arguments.
+	 * @param int      $current_object_id Nav menu ID.
 	 */
-	public function start_el( &$output, $data_object, $depth = 0, $args = null, $id = 0 ) {
+	public function start_el( &$output, $data_object, $depth = 0, $args = null, $current_object_id = 0 ) {
 		global $_wp_nav_menu_max_depth;
 
 		/*
@@ -243,13 +243,13 @@ class Walker_Nav_Menu_Edit extends Walker_Nav_Menu {
 				 *
 				 * @since 5.4.0
 				 *
-				 * @param int      $item_id   Menu item ID.
-				 * @param WP_Post  $menu_item Menu item data object.
-				 * @param int      $depth     Depth of menu item. Used for padding.
-				 * @param stdClass $args      An object of menu item arguments.
-				 * @param int      $id        Nav menu ID.
+				 * @param int      $item_id           Menu item ID.
+				 * @param WP_Post  $menu_item         Menu item data object.
+				 * @param int      $depth             Depth of menu item. Used for padding.
+				 * @param stdClass $args              An object of menu item arguments.
+				 * @param int      $current_object_id Nav menu ID.
 				 */
-				do_action( 'wp_nav_menu_item_custom_fields', $item_id, $menu_item, $depth, $args, $id );
+				do_action( 'wp_nav_menu_item_custom_fields', $item_id, $menu_item, $depth, $args, $current_object_id );
 				?>
 
 				<fieldset class="field-move hide-if-no-js description description-wide">

--- a/src/wp-admin/includes/class-walker-nav-menu-edit.php
+++ b/src/wp-admin/includes/class-walker-nav-menu-edit.php
@@ -49,18 +49,24 @@ class Walker_Nav_Menu_Edit extends Walker_Nav_Menu {
 	 *
 	 * @global int $_wp_nav_menu_max_depth
 	 *
-	 * @param string   $output Used to append additional content (passed by reference).
-	 * @param WP_Post  $item   Menu item data object.
-	 * @param int      $depth  Depth of menu item. Used for padding.
-	 * @param stdClass $args   Not used.
-	 * @param int      $id     Not used.
+	 * @param string   $output      Used to append additional content (passed by reference).
+	 * @param WP_Post  $data_object Menu item data object.
+	 * @param int      $depth       Depth of menu item. Used for padding.
+	 * @param stdClass $args        Not used.
+	 * @param int      $id          Not used.
 	 */
-	public function start_el( &$output, $item, $depth = 0, $args = null, $id = 0 ) {
+	public function start_el( &$output, $data_object, $depth = 0, $args = null, $id = 0 ) {
 		global $_wp_nav_menu_max_depth;
+
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$menu_item              = $data_object;
 		$_wp_nav_menu_max_depth = $depth > $_wp_nav_menu_max_depth ? $depth : $_wp_nav_menu_max_depth;
 
 		ob_start();
-		$item_id      = esc_attr( $item->ID );
+		$item_id      = esc_attr( $menu_item->ID );
 		$removed_args = array(
 			'action',
 			'customlink-tab',
@@ -72,18 +78,18 @@ class Walker_Nav_Menu_Edit extends Walker_Nav_Menu {
 
 		$original_title = false;
 
-		if ( 'taxonomy' === $item->type ) {
-			$original_object = get_term( (int) $item->object_id, $item->object );
+		if ( 'taxonomy' === $menu_item->type ) {
+			$original_object = get_term( (int) $menu_item->object_id, $menu_item->object );
 			if ( $original_object && ! is_wp_error( $original_object ) ) {
 				$original_title = $original_object->name;
 			}
-		} elseif ( 'post_type' === $item->type ) {
-			$original_object = get_post( $item->object_id );
+		} elseif ( 'post_type' === $menu_item->type ) {
+			$original_object = get_post( $menu_item->object_id );
 			if ( $original_object ) {
 				$original_title = get_the_title( $original_object->ID );
 			}
-		} elseif ( 'post_type_archive' === $item->type ) {
-			$original_object = get_post_type_object( $item->object );
+		} elseif ( 'post_type_archive' === $menu_item->type ) {
+			$original_object = get_post_type_object( $menu_item->object );
 			if ( $original_object ) {
 				$original_title = $original_object->labels->archives;
 			}
@@ -91,23 +97,23 @@ class Walker_Nav_Menu_Edit extends Walker_Nav_Menu {
 
 		$classes = array(
 			'menu-item menu-item-depth-' . $depth,
-			'menu-item-' . esc_attr( $item->object ),
+			'menu-item-' . esc_attr( $menu_item->object ),
 			'menu-item-edit-' . ( ( isset( $_GET['edit-menu-item'] ) && $item_id === $_GET['edit-menu-item'] ) ? 'active' : 'inactive' ),
 		);
 
-		$title = $item->title;
+		$title = $menu_item->title;
 
-		if ( ! empty( $item->_invalid ) ) {
+		if ( ! empty( $menu_item->_invalid ) ) {
 			$classes[] = 'menu-item-invalid';
 			/* translators: %s: Title of an invalid menu item. */
-			$title = sprintf( __( '%s (Invalid)' ), $item->title );
-		} elseif ( isset( $item->post_status ) && 'draft' === $item->post_status ) {
+			$title = sprintf( __( '%s (Invalid)' ), $menu_item->title );
+		} elseif ( isset( $menu_item->post_status ) && 'draft' === $menu_item->post_status ) {
 			$classes[] = 'pending';
 			/* translators: %s: Title of a menu item in draft status. */
-			$title = sprintf( __( '%s (Pending)' ), $item->title );
+			$title = sprintf( __( '%s (Pending)' ), $menu_item->title );
 		}
 
-		$title = ( ! isset( $item->label ) || '' === $item->label ) ? $title : $item->label;
+		$title = ( ! isset( $menu_item->label ) || '' === $menu_item->label ) ? $title : $menu_item->label;
 
 		$submenu_text = '';
 		if ( 0 === $depth ) {
@@ -124,7 +130,7 @@ class Walker_Nav_Menu_Edit extends Walker_Nav_Menu {
 						<span class="is-submenu" <?php echo $submenu_text; ?>><?php _e( 'sub item' ); ?></span>
 					</label>
 					<span class="item-controls">
-						<span class="item-type"><?php echo esc_html( $item->type_label ); ?></span>
+						<span class="item-type"><?php echo esc_html( $menu_item->type_label ); ?></span>
 						<span class="item-order hide-if-js">
 							<?php
 							printf(
@@ -185,48 +191,48 @@ class Walker_Nav_Menu_Edit extends Walker_Nav_Menu {
 			</div>
 
 			<div class="menu-item-settings wp-clearfix" id="menu-item-settings-<?php echo $item_id; ?>">
-				<?php if ( 'custom' === $item->type ) : ?>
+				<?php if ( 'custom' === $menu_item->type ) : ?>
 					<p class="field-url description description-wide">
 						<label for="edit-menu-item-url-<?php echo $item_id; ?>">
 							<?php _e( 'URL' ); ?><br />
-							<input type="text" id="edit-menu-item-url-<?php echo $item_id; ?>" class="widefat code edit-menu-item-url" name="menu-item-url[<?php echo $item_id; ?>]" value="<?php echo esc_attr( $item->url ); ?>" />
+							<input type="text" id="edit-menu-item-url-<?php echo $item_id; ?>" class="widefat code edit-menu-item-url" name="menu-item-url[<?php echo $item_id; ?>]" value="<?php echo esc_attr( $menu_item->url ); ?>" />
 						</label>
 					</p>
 				<?php endif; ?>
 				<p class="description description-wide">
 					<label for="edit-menu-item-title-<?php echo $item_id; ?>">
 						<?php _e( 'Navigation Label' ); ?><br />
-						<input type="text" id="edit-menu-item-title-<?php echo $item_id; ?>" class="widefat edit-menu-item-title" name="menu-item-title[<?php echo $item_id; ?>]" value="<?php echo esc_attr( $item->title ); ?>" />
+						<input type="text" id="edit-menu-item-title-<?php echo $item_id; ?>" class="widefat edit-menu-item-title" name="menu-item-title[<?php echo $item_id; ?>]" value="<?php echo esc_attr( $menu_item->title ); ?>" />
 					</label>
 				</p>
 				<p class="field-title-attribute field-attr-title description description-wide">
 					<label for="edit-menu-item-attr-title-<?php echo $item_id; ?>">
 						<?php _e( 'Title Attribute' ); ?><br />
-						<input type="text" id="edit-menu-item-attr-title-<?php echo $item_id; ?>" class="widefat edit-menu-item-attr-title" name="menu-item-attr-title[<?php echo $item_id; ?>]" value="<?php echo esc_attr( $item->post_excerpt ); ?>" />
+						<input type="text" id="edit-menu-item-attr-title-<?php echo $item_id; ?>" class="widefat edit-menu-item-attr-title" name="menu-item-attr-title[<?php echo $item_id; ?>]" value="<?php echo esc_attr( $menu_item->post_excerpt ); ?>" />
 					</label>
 				</p>
 				<p class="field-link-target description">
 					<label for="edit-menu-item-target-<?php echo $item_id; ?>">
-						<input type="checkbox" id="edit-menu-item-target-<?php echo $item_id; ?>" value="_blank" name="menu-item-target[<?php echo $item_id; ?>]"<?php checked( $item->target, '_blank' ); ?> />
+						<input type="checkbox" id="edit-menu-item-target-<?php echo $item_id; ?>" value="_blank" name="menu-item-target[<?php echo $item_id; ?>]"<?php checked( $menu_item->target, '_blank' ); ?> />
 						<?php _e( 'Open link in a new tab' ); ?>
 					</label>
 				</p>
 				<p class="field-css-classes description description-thin">
 					<label for="edit-menu-item-classes-<?php echo $item_id; ?>">
 						<?php _e( 'CSS Classes (optional)' ); ?><br />
-						<input type="text" id="edit-menu-item-classes-<?php echo $item_id; ?>" class="widefat code edit-menu-item-classes" name="menu-item-classes[<?php echo $item_id; ?>]" value="<?php echo esc_attr( implode( ' ', $item->classes ) ); ?>" />
+						<input type="text" id="edit-menu-item-classes-<?php echo $item_id; ?>" class="widefat code edit-menu-item-classes" name="menu-item-classes[<?php echo $item_id; ?>]" value="<?php echo esc_attr( implode( ' ', $menu_item->classes ) ); ?>" />
 					</label>
 				</p>
 				<p class="field-xfn description description-thin">
 					<label for="edit-menu-item-xfn-<?php echo $item_id; ?>">
 						<?php _e( 'Link Relationship (XFN)' ); ?><br />
-						<input type="text" id="edit-menu-item-xfn-<?php echo $item_id; ?>" class="widefat code edit-menu-item-xfn" name="menu-item-xfn[<?php echo $item_id; ?>]" value="<?php echo esc_attr( $item->xfn ); ?>" />
+						<input type="text" id="edit-menu-item-xfn-<?php echo $item_id; ?>" class="widefat code edit-menu-item-xfn" name="menu-item-xfn[<?php echo $item_id; ?>]" value="<?php echo esc_attr( $menu_item->xfn ); ?>" />
 					</label>
 				</p>
 				<p class="field-description description description-wide">
 					<label for="edit-menu-item-description-<?php echo $item_id; ?>">
 						<?php _e( 'Description' ); ?><br />
-						<textarea id="edit-menu-item-description-<?php echo $item_id; ?>" class="widefat edit-menu-item-description" rows="3" cols="20" name="menu-item-description[<?php echo $item_id; ?>]"><?php echo esc_html( $item->description ); // textarea_escaped ?></textarea>
+						<textarea id="edit-menu-item-description-<?php echo $item_id; ?>" class="widefat edit-menu-item-description" rows="3" cols="20" name="menu-item-description[<?php echo $item_id; ?>]"><?php echo esc_html( $menu_item->description ); // textarea_escaped ?></textarea>
 						<span class="description"><?php _e( 'The description will be displayed in the menu if the current theme supports it.' ); ?></span>
 					</label>
 				</p>
@@ -237,13 +243,13 @@ class Walker_Nav_Menu_Edit extends Walker_Nav_Menu {
 				 *
 				 * @since 5.4.0
 				 *
-				 * @param int      $item_id Menu item ID.
-				 * @param WP_Post  $item    Menu item data object.
-				 * @param int      $depth   Depth of menu item. Used for padding.
-				 * @param stdClass $args    An object of menu item arguments.
-				 * @param int      $id      Nav menu ID.
+				 * @param int      $item_id   Menu item ID.
+				 * @param WP_Post  $menu_item Menu item data object.
+				 * @param int      $depth     Depth of menu item. Used for padding.
+				 * @param stdClass $args      An object of menu item arguments.
+				 * @param int      $id        Nav menu ID.
 				 */
-				do_action( 'wp_nav_menu_item_custom_fields', $item_id, $item, $depth, $args, $id );
+				do_action( 'wp_nav_menu_item_custom_fields', $item_id, $menu_item, $depth, $args, $id );
 				?>
 
 				<fieldset class="field-move hide-if-no-js description description-wide">
@@ -256,11 +262,11 @@ class Walker_Nav_Menu_Edit extends Walker_Nav_Menu {
 				</fieldset>
 
 				<div class="menu-item-actions description-wide submitbox">
-					<?php if ( 'custom' !== $item->type && false !== $original_title ) : ?>
+					<?php if ( 'custom' !== $menu_item->type && false !== $original_title ) : ?>
 						<p class="link-to-original">
 							<?php
 							/* translators: %s: Link to menu item's original object. */
-							printf( __( 'Original: %s' ), '<a href="' . esc_attr( $item->url ) . '">' . esc_html( $original_title ) . '</a>' );
+							printf( __( 'Original: %s' ), '<a href="' . esc_attr( $menu_item->url ) . '">' . esc_html( $original_title ) . '</a>' );
 							?>
 						</p>
 					<?php endif; ?>
@@ -303,11 +309,11 @@ class Walker_Nav_Menu_Edit extends Walker_Nav_Menu {
 				</div>
 
 				<input class="menu-item-data-db-id" type="hidden" name="menu-item-db-id[<?php echo $item_id; ?>]" value="<?php echo $item_id; ?>" />
-				<input class="menu-item-data-object-id" type="hidden" name="menu-item-object-id[<?php echo $item_id; ?>]" value="<?php echo esc_attr( $item->object_id ); ?>" />
-				<input class="menu-item-data-object" type="hidden" name="menu-item-object[<?php echo $item_id; ?>]" value="<?php echo esc_attr( $item->object ); ?>" />
-				<input class="menu-item-data-parent-id" type="hidden" name="menu-item-parent-id[<?php echo $item_id; ?>]" value="<?php echo esc_attr( $item->menu_item_parent ); ?>" />
-				<input class="menu-item-data-position" type="hidden" name="menu-item-position[<?php echo $item_id; ?>]" value="<?php echo esc_attr( $item->menu_order ); ?>" />
-				<input class="menu-item-data-type" type="hidden" name="menu-item-type[<?php echo $item_id; ?>]" value="<?php echo esc_attr( $item->type ); ?>" />
+				<input class="menu-item-data-object-id" type="hidden" name="menu-item-object-id[<?php echo $item_id; ?>]" value="<?php echo esc_attr( $menu_item->object_id ); ?>" />
+				<input class="menu-item-data-object" type="hidden" name="menu-item-object[<?php echo $item_id; ?>]" value="<?php echo esc_attr( $menu_item->object ); ?>" />
+				<input class="menu-item-data-parent-id" type="hidden" name="menu-item-parent-id[<?php echo $item_id; ?>]" value="<?php echo esc_attr( $menu_item->menu_item_parent ); ?>" />
+				<input class="menu-item-data-position" type="hidden" name="menu-item-position[<?php echo $item_id; ?>]" value="<?php echo esc_attr( $menu_item->menu_order ); ?>" />
+				<input class="menu-item-data-type" type="hidden" name="menu-item-type[<?php echo $item_id; ?>]" value="<?php echo esc_attr( $menu_item->type ); ?>" />
 			</div><!-- .menu-item-settings-->
 			<ul class="menu-item-transport"></ul>
 		<?php

--- a/src/wp-admin/includes/class-wp-ajax-upgrader-skin.php
+++ b/src/wp-admin/includes/class-wp-ajax-upgrader-skin.php
@@ -122,16 +122,16 @@ class WP_Ajax_Upgrader_Skin extends Automatic_Upgrader_Skin {
 	 * @since 5.3.0 Formalized the existing `...$args` parameter by adding it
 	 *              to the function signature.
 	 *
-	 * @param string|array|WP_Error $data    Message data.
-	 * @param mixed                 ...$args Optional text replacements.
+	 * @param string|array|WP_Error $feedback Message data.
+	 * @param mixed                 ...$args  Optional text replacements.
 	 */
-	public function feedback( $data, ...$args ) {
-		if ( is_wp_error( $data ) ) {
-			foreach ( $data->get_error_codes() as $error_code ) {
-				$this->errors->add( $error_code, $data->get_error_message( $error_code ), $data->get_error_data( $error_code ) );
+	public function feedback( $feedback, ...$args ) {
+		if ( is_wp_error( $feedback ) ) {
+			foreach ( $feedback->get_error_codes() as $error_code ) {
+				$this->errors->add( $error_code, $feedback->get_error_message( $error_code ), $feedback->get_error_data( $error_code ) );
 			}
 		}
 
-		parent::feedback( $data, ...$args );
+		parent::feedback( $feedback, ...$args );
 	}
 }

--- a/src/wp-admin/includes/class-wp-comments-list-table.php
+++ b/src/wp-admin/includes/class-wp-comments-list-table.php
@@ -868,9 +868,15 @@ class WP_Comments_List_Table extends WP_List_Table {
 	}
 
 	/**
-	 * @param WP_Comment $comment The comment object.
+	 * @param WP_Comment $item The comment object.
 	 */
-	public function column_cb( $comment ) {
+	public function column_cb( $item ) {
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$comment = $item;
+
 		if ( $this->user_can ) {
 			?>
 		<label class="screen-reader-text" for="cb-select-<?php echo $comment->comment_ID; ?>"><?php _e( 'Select comment' ); ?></label>

--- a/src/wp-admin/includes/class-wp-comments-list-table.php
+++ b/src/wp-admin/includes/class-wp-comments-list-table.php
@@ -1047,10 +1047,10 @@ class WP_Comments_List_Table extends WP_List_Table {
 	}
 
 	/**
-	 * @param WP_Comment $comment     The comment object.
+	 * @param WP_Comment $item        The comment object.
 	 * @param string     $column_name The custom column's name.
 	 */
-	public function column_default( $comment, $column_name ) {
+	public function column_default( $item, $column_name ) {
 		/**
 		 * Fires when the default column output is displayed for a single row.
 		 *
@@ -1059,6 +1059,6 @@ class WP_Comments_List_Table extends WP_List_Table {
 		 * @param string $column_name The custom column's name.
 		 * @param int    $comment_id  The custom column's unique ID number.
 		 */
-		do_action( 'manage_comments_custom_column', $column_name, $comment->comment_ID );
+		do_action( 'manage_comments_custom_column', $column_name, $item->comment_ID );
 	}
 }

--- a/src/wp-admin/includes/class-wp-comments-list-table.php
+++ b/src/wp-admin/includes/class-wp-comments-list-table.php
@@ -654,14 +654,14 @@ class WP_Comments_List_Table extends WP_List_Table {
 	 *
 	 * @global string $comment_status Status for the current listed comments.
 	 *
-	 * @param WP_Comment $comment     The comment object.
+	 * @param WP_Comment $item        The comment object.
 	 * @param string     $column_name Current column name.
 	 * @param string     $primary     Primary column name.
 	 * @return string Row actions output for comments. An empty string
 	 *                if the current column is not the primary column,
 	 *                or if the current user cannot edit the comment.
 	 */
-	protected function handle_row_actions( $comment, $column_name, $primary ) {
+	protected function handle_row_actions( $item, $column_name, $primary ) {
 		global $comment_status;
 
 		if ( $primary !== $column_name ) {
@@ -672,6 +672,11 @@ class WP_Comments_List_Table extends WP_List_Table {
 			return '';
 		}
 
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$comment            = $item;
 		$the_comment_status = wp_get_comment_status( $comment );
 
 		$out = '';

--- a/src/wp-admin/includes/class-wp-links-list-table.php
+++ b/src/wp-admin/includes/class-wp-links-list-table.php
@@ -319,17 +319,22 @@ class WP_Links_List_Table extends WP_List_Table {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param object $link        Link being acted upon.
+	 * @param object $item        Link being acted upon.
 	 * @param string $column_name Current column name.
 	 * @param string $primary     Primary column name.
 	 * @return string Row actions output for links, or an empty string
 	 *                if the current column is not the primary column.
 	 */
-	protected function handle_row_actions( $link, $column_name, $primary ) {
+	protected function handle_row_actions( $item, $column_name, $primary ) {
 		if ( $primary !== $column_name ) {
 			return '';
 		}
 
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$link      = $item;
 		$edit_link = get_edit_bookmark_link( $link );
 
 		$actions           = array();

--- a/src/wp-admin/includes/class-wp-links-list-table.php
+++ b/src/wp-admin/includes/class-wp-links-list-table.php
@@ -280,10 +280,10 @@ class WP_Links_List_Table extends WP_List_Table {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param object $link        Link object.
+	 * @param object $item        Link object.
 	 * @param string $column_name Current column name.
 	 */
-	public function column_default( $link, $column_name ) {
+	public function column_default( $item, $column_name ) {
 		/**
 		 * Fires for each registered custom link column.
 		 *
@@ -292,7 +292,7 @@ class WP_Links_List_Table extends WP_List_Table {
 		 * @param string $column_name Name of the custom column.
 		 * @param int    $link_id     Link ID.
 		 */
-		do_action( 'manage_link_custom_column', $column_name, $link->link_id );
+		do_action( 'manage_link_custom_column', $column_name, $item->link_id );
 	}
 
 	public function display_rows() {

--- a/src/wp-admin/includes/class-wp-links-list-table.php
+++ b/src/wp-admin/includes/class-wp-links-list-table.php
@@ -167,9 +167,15 @@ class WP_Links_List_Table extends WP_List_Table {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param object $link The current link object.
+	 * @param object $item The current link object.
 	 */
-	public function column_cb( $link ) {
+	public function column_cb( $item ) {
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$link = $item;
+
 		?>
 		<label class="screen-reader-text" for="cb-select-<?php echo $link->link_id; ?>">
 			<?php

--- a/src/wp-admin/includes/class-wp-media-list-table.php
+++ b/src/wp-admin/includes/class-wp-media-list-table.php
@@ -384,9 +384,15 @@ class WP_Media_List_Table extends WP_List_Table {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param WP_Post $post The current WP_Post object.
+	 * @param WP_Post $item The current WP_Post object.
 	 */
-	public function column_cb( $post ) {
+	public function column_cb( $item ) {
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$post = $item;
+
 		if ( current_user_can( 'edit_post', $post->ID ) ) {
 			?>
 			<label class="screen-reader-text" for="cb-select-<?php echo $post->ID; ?>">

--- a/src/wp-admin/includes/class-wp-media-list-table.php
+++ b/src/wp-admin/includes/class-wp-media-list-table.php
@@ -828,19 +828,22 @@ class WP_Media_List_Table extends WP_List_Table {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param WP_Post $post        Attachment being acted upon.
+	 * @param WP_Post $item        Attachment being acted upon.
 	 * @param string  $column_name Current column name.
 	 * @param string  $primary     Primary column name.
 	 * @return string Row actions output for media attachments, or an empty string
 	 *                if the current column is not the primary column.
 	 */
-	protected function handle_row_actions( $post, $column_name, $primary ) {
+	protected function handle_row_actions( $item, $column_name, $primary ) {
 		if ( $primary !== $column_name ) {
 			return '';
 		}
 
-		$att_title = _draft_or_post_title();
+		$actions = $this->_get_row_actions(
+			$item, // WP_Post object for an attachment. See Trac #51553.
+			_draft_or_post_title()
+		);
 
-		return $this->row_actions( $this->_get_row_actions( $post, $att_title ) );
+		return $this->row_actions( $actions );
 	}
 }

--- a/src/wp-admin/includes/class-wp-media-list-table.php
+++ b/src/wp-admin/includes/class-wp-media-list-table.php
@@ -591,10 +591,16 @@ class WP_Media_List_Table extends WP_List_Table {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param WP_Post $post        The current WP_Post object.
+	 * @param WP_Post $item        The current WP_Post object.
 	 * @param string  $column_name Current column name.
 	 */
-	public function column_default( $post, $column_name ) {
+	public function column_default( $item, $column_name ) {
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$post = $item;
+
 		if ( 'categories' === $column_name ) {
 			$taxonomy = 'category';
 		} elseif ( 'tags' === $column_name ) {

--- a/src/wp-admin/includes/class-wp-ms-sites-list-table.php
+++ b/src/wp-admin/includes/class-wp-ms-sites-list-table.php
@@ -397,9 +397,15 @@ class WP_MS_Sites_List_Table extends WP_List_Table {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param array $blog Current site.
+	 * @param array $item Current site.
 	 */
-	public function column_cb( $blog ) {
+	public function column_cb( $item ) {
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$blog = $item;
+
 		if ( ! is_main_site( $blog['blog_id'] ) ) :
 			$blogname = untrailingslashit( $blog['domain'] . $blog['path'] );
 			?>

--- a/src/wp-admin/includes/class-wp-ms-sites-list-table.php
+++ b/src/wp-admin/includes/class-wp-ms-sites-list-table.php
@@ -670,17 +670,22 @@ class WP_MS_Sites_List_Table extends WP_List_Table {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param array  $blog        Site being acted upon.
+	 * @param array  $item        Site being acted upon.
 	 * @param string $column_name Current column name.
 	 * @param string $primary     Primary column name.
 	 * @return string Row actions output for sites in Multisite, or an empty string
 	 *                if the current column is not the primary column.
 	 */
-	protected function handle_row_actions( $blog, $column_name, $primary ) {
+	protected function handle_row_actions( $item, $column_name, $primary ) {
 		if ( $primary !== $column_name ) {
 			return '';
 		}
 
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$blog     = $item;
 		$blogname = untrailingslashit( $blog['domain'] . $blog['path'] );
 
 		// Preordered.

--- a/src/wp-admin/includes/class-wp-ms-sites-list-table.php
+++ b/src/wp-admin/includes/class-wp-ms-sites-list-table.php
@@ -561,10 +561,10 @@ class WP_MS_Sites_List_Table extends WP_List_Table {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param array  $blog        Current site.
+	 * @param array  $item        Current site.
 	 * @param string $column_name Current column name.
 	 */
-	public function column_default( $blog, $column_name ) {
+	public function column_default( $item, $column_name ) {
 		/**
 		 * Fires for each registered custom column in the Sites list table.
 		 *
@@ -573,7 +573,7 @@ class WP_MS_Sites_List_Table extends WP_List_Table {
 		 * @param string $column_name The name of the column to display.
 		 * @param int    $blog_id     The site ID.
 		 */
-		do_action( 'manage_sites_custom_column', $column_name, $blog['blog_id'] );
+		do_action( 'manage_sites_custom_column', $column_name, $item['blog_id'] );
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-ms-themes-list-table.php
+++ b/src/wp-admin/includes/class-wp-ms-themes-list-table.php
@@ -955,10 +955,16 @@ class WP_MS_Themes_List_Table extends WP_List_Table {
 	 * @global string $status
 	 * @global array  $totals
 	 *
-	 * @param WP_Theme $theme
+	 * @param WP_Theme $item Theme.
 	 */
-	public function single_row( $theme ) {
+	public function single_row( $item ) {
 		global $status, $totals;
+
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$theme = $item;
 
 		if ( $this->is_site_themes ) {
 			$allowed = $theme->is_allowed( 'site', $this->site_id );

--- a/src/wp-admin/includes/class-wp-ms-themes-list-table.php
+++ b/src/wp-admin/includes/class-wp-ms-themes-list-table.php
@@ -506,9 +506,14 @@ class WP_MS_Themes_List_Table extends WP_List_Table {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param WP_Theme $theme The current WP_Theme object.
+	 * @param WP_Theme $item The current WP_Theme object.
 	 */
-	public function column_cb( $theme ) {
+	public function column_cb( $item ) {
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$theme       = $item;
 		$checkbox_id = 'checkbox_' . md5( $theme->get( 'Name' ) );
 		?>
 		<input type="checkbox" name="checked[]" value="<?php echo esc_attr( $theme->get_stylesheet() ); ?>" id="<?php echo $checkbox_id; ?>" />

--- a/src/wp-admin/includes/class-wp-ms-themes-list-table.php
+++ b/src/wp-admin/includes/class-wp-ms-themes-list-table.php
@@ -856,12 +856,10 @@ class WP_MS_Themes_List_Table extends WP_List_Table {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param WP_Theme $theme       The current WP_Theme object.
+	 * @param WP_Theme $item        The current WP_Theme object.
 	 * @param string   $column_name The current column name.
 	 */
-	public function column_default( $theme, $column_name ) {
-		$stylesheet = $theme->get_stylesheet();
-
+	public function column_default( $item, $column_name ) {
 		/**
 		 * Fires inside each custom column of the Multisite themes list table.
 		 *
@@ -871,7 +869,12 @@ class WP_MS_Themes_List_Table extends WP_List_Table {
 		 * @param string   $stylesheet  Directory name of the theme.
 		 * @param WP_Theme $theme       Current WP_Theme object.
 		 */
-		do_action( 'manage_themes_custom_column', $column_name, $stylesheet, $theme );
+		do_action(
+			'manage_themes_custom_column',
+			$column_name,
+			$item->get_stylesheet(), // Directory name of the theme.
+			$item // Theme object. See Trac #51553.
+		);
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-ms-users-list-table.php
+++ b/src/wp-admin/includes/class-wp-ms-users-list-table.php
@@ -228,9 +228,15 @@ class WP_MS_Users_List_Table extends WP_List_Table {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param WP_User $user The current WP_User object.
+	 * @param WP_User $item The current WP_User object.
 	 */
-	public function column_cb( $user ) {
+	public function column_cb( $item ) {
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$user = $item;
+
 		if ( is_super_admin( $user->ID ) ) {
 			return;
 		}

--- a/src/wp-admin/includes/class-wp-ms-users-list-table.php
+++ b/src/wp-admin/includes/class-wp-ms-users-list-table.php
@@ -501,17 +501,22 @@ class WP_MS_Users_List_Table extends WP_List_Table {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param WP_User $user        User being acted upon.
+	 * @param WP_User $item        User being acted upon.
 	 * @param string  $column_name Current column name.
 	 * @param string  $primary     Primary column name.
 	 * @return string Row actions output for users in Multisite, or an empty string
 	 *                if the current column is not the primary column.
 	 */
-	protected function handle_row_actions( $user, $column_name, $primary ) {
+	protected function handle_row_actions( $item, $column_name, $primary ) {
 		if ( $primary !== $column_name ) {
 			return '';
 		}
 
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$user         = $item;
 		$super_admins = get_super_admins();
 
 		$actions = array();

--- a/src/wp-admin/includes/class-wp-ms-users-list-table.php
+++ b/src/wp-admin/includes/class-wp-ms-users-list-table.php
@@ -443,12 +443,17 @@ class WP_MS_Users_List_Table extends WP_List_Table {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param WP_User $user        The current WP_User object.
+	 * @param WP_User $item        The current WP_User object.
 	 * @param string  $column_name The current column name.
 	 */
-	public function column_default( $user, $column_name ) {
+	public function column_default( $item, $column_name ) {
 		/** This filter is documented in wp-admin/includes/class-wp-users-list-table.php */
-		echo apply_filters( 'manage_users_custom_column', '', $column_name, $user->ID );
+		echo apply_filters(
+			'manage_users_custom_column',
+			'', // Custom column output. Default empty.
+			$column_name,
+			$item->ID // User ID. See Trac #51553.
+		);
 	}
 
 	public function display_rows() {

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -972,9 +972,14 @@ class WP_Posts_List_Table extends WP_List_Table {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param WP_Post $post The current WP_Post object.
+	 * @param WP_Post $item The current WP_Post object.
 	 */
-	public function column_cb( $post ) {
+	public function column_cb( $item ) {
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$post = $item;
 		$show = current_user_can( 'edit_post', $post->ID );
 
 		/**

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -1346,13 +1346,13 @@ class WP_Posts_List_Table extends WP_List_Table {
 	/**
 	 * @global WP_Post $post Global post object.
 	 *
-	 * @param int|WP_Post $post
+	 * @param int|WP_Post $item
 	 * @param int         $level
 	 */
-	public function single_row( $post, $level = 0 ) {
+	public function single_row( $item, $level = 0 ) {
 		$global_post = get_post();
 
-		$post                = get_post( $post );
+		$post                = get_post( $item );
 		$this->current_level = $level;
 
 		$GLOBALS['post'] = $post;

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -1236,10 +1236,16 @@ class WP_Posts_List_Table extends WP_List_Table {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param WP_Post $post        The current WP_Post object.
+	 * @param WP_Post $item        The current WP_Post object.
 	 * @param string  $column_name The current column name.
 	 */
-	public function column_default( $post, $column_name ) {
+	public function column_default( $item, $column_name ) {
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$post = $item;
+
 		if ( 'categories' === $column_name ) {
 			$taxonomy = 'category';
 		} elseif ( 'tags' === $column_name ) {

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -1407,17 +1407,22 @@ class WP_Posts_List_Table extends WP_List_Table {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param WP_Post $post        Post being acted upon.
+	 * @param WP_Post $item        Post being acted upon.
 	 * @param string  $column_name Current column name.
 	 * @param string  $primary     Primary column name.
 	 * @return string Row actions output for posts, or an empty string
 	 *                if the current column is not the primary column.
 	 */
-	protected function handle_row_actions( $post, $column_name, $primary ) {
+	protected function handle_row_actions( $item, $column_name, $primary ) {
 		if ( $primary !== $column_name ) {
 			return '';
 		}
 
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$post             = $item;
 		$post_type_object = get_post_type_object( $post->post_type );
 		$can_edit_post    = current_user_can( 'edit_post', $post->ID );
 		$actions          = array();

--- a/src/wp-admin/includes/class-wp-terms-list-table.php
+++ b/src/wp-admin/includes/class-wp-terms-list-table.php
@@ -463,17 +463,22 @@ class WP_Terms_List_Table extends WP_List_Table {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param WP_Term $tag         Tag being acted upon.
+	 * @param WP_Term $item        Tag being acted upon.
 	 * @param string  $column_name Current column name.
 	 * @param string  $primary     Primary column name.
 	 * @return string Row actions output for terms, or an empty string
 	 *                if the current column is not the primary column.
 	 */
-	protected function handle_row_actions( $tag, $column_name, $primary ) {
+	protected function handle_row_actions( $item, $column_name, $primary ) {
 		if ( $primary !== $column_name ) {
 			return '';
 		}
 
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$tag      = $item;
 		$taxonomy = $this->screen->taxonomy;
 		$tax      = get_taxonomy( $taxonomy );
 		$uri      = wp_doing_ajax() ? wp_get_referer() : $_SERVER['REQUEST_URI'];

--- a/src/wp-admin/includes/class-wp-terms-list-table.php
+++ b/src/wp-admin/includes/class-wp-terms-list-table.php
@@ -342,13 +342,13 @@ class WP_Terms_List_Table extends WP_List_Table {
 
 	/**
 	 * @global string $taxonomy
-	 * @param WP_Term $tag   Term object.
+	 * @param WP_Term $item  Term object.
 	 * @param int     $level
 	 */
-	public function single_row( $tag, $level = 0 ) {
+	public function single_row( $item, $level = 0 ) {
 		global $taxonomy;
-		$tag = sanitize_term( $tag, $taxonomy );
 
+		$tag         = sanitize_term( $item, $taxonomy );
 		$this->level = $level;
 
 		if ( $tag->parent ) {

--- a/src/wp-admin/includes/class-wp-terms-list-table.php
+++ b/src/wp-admin/includes/class-wp-terms-list-table.php
@@ -364,10 +364,16 @@ class WP_Terms_List_Table extends WP_List_Table {
 	}
 
 	/**
-	 * @param WP_Term $tag Term object.
+	 * @param WP_Term $item Term object.
 	 * @return string
 	 */
-	public function column_cb( $tag ) {
+	public function column_cb( $item ) {
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$tag = $item;
+
 		if ( current_user_can( 'delete_term', $tag->term_id ) ) {
 			return sprintf(
 				'<label class="screen-reader-text" for="cb-select-%1$s">%2$s</label>' .

--- a/src/wp-admin/includes/class-wp-terms-list-table.php
+++ b/src/wp-admin/includes/class-wp-terms-list-table.php
@@ -620,11 +620,11 @@ class WP_Terms_List_Table extends WP_List_Table {
 	}
 
 	/**
-	 * @param WP_Term $tag         Term object.
+	 * @param WP_Term $item        Term object.
 	 * @param string  $column_name Name of the column.
 	 * @return string
 	 */
-	public function column_default( $tag, $column_name ) {
+	public function column_default( $item, $column_name ) {
 		/**
 		 * Filters the displayed columns in the terms list table.
 		 *
@@ -638,11 +638,16 @@ class WP_Terms_List_Table extends WP_List_Table {
 		 *
 		 * @since 2.8.0
 		 *
-		 * @param string $string      Blank string.
+		 * @param string $string      Custom column output. Default empty.
 		 * @param string $column_name Name of the column.
 		 * @param int    $term_id     Term ID.
 		 */
-		return apply_filters( "manage_{$this->screen->taxonomy}_custom_column", '', $column_name, $tag->term_id );
+		return apply_filters(
+			"manage_{$this->screen->taxonomy}_custom_column",
+			'',
+			$column_name,
+			$item->term_id
+		);
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-theme-install-list-table.php
+++ b/src/wp-admin/includes/class-wp-theme-install-list-table.php
@@ -251,7 +251,7 @@ class WP_Theme_Install_List_Table extends WP_Themes_List_Table {
 	 *
 	 * @global array $themes_allowedtags
 	 *
-	 * @param object $theme {
+	 * @param object $item {
 	 *     An object that contains theme data returned by the WordPress.org API.
 	 *
 	 *     @type string $name           Theme name, e.g. 'Twenty Twenty-One'.
@@ -267,13 +267,18 @@ class WP_Theme_Install_List_Table extends WP_Themes_List_Table {
 	 *     @type string $download_link  Theme ZIP download URL.
 	 * }
 	 */
-	public function single_row( $theme ) {
+	public function single_row( $item ) {
 		global $themes_allowedtags;
 
-		if ( empty( $theme ) ) {
+		if ( empty( $item ) ) {
 			return;
 		}
 
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$theme  = $item;
 		$name   = wp_kses( $theme->name, $themes_allowedtags );
 		$author = wp_kses( $theme->author, $themes_allowedtags );
 

--- a/src/wp-admin/includes/class-wp-upgrader-skin.php
+++ b/src/wp-admin/includes/class-wp-upgrader-skin.php
@@ -187,25 +187,25 @@ class WP_Upgrader_Skin {
 	/**
 	 * @since 2.8.0
 	 *
-	 * @param string $string
-	 * @param mixed  ...$args Optional text replacements.
+	 * @param string $feedback Message data.
+	 * @param mixed  ...$args  Optional text replacements.
 	 */
-	public function feedback( $string, ...$args ) {
-		if ( isset( $this->upgrader->strings[ $string ] ) ) {
-			$string = $this->upgrader->strings[ $string ];
+	public function feedback( $feedback, ...$args ) {
+		if ( isset( $this->upgrader->strings[ $feedback ] ) ) {
+			$feedback = $this->upgrader->strings[ $feedback ];
 		}
 
-		if ( strpos( $string, '%' ) !== false ) {
+		if ( strpos( $feedback, '%' ) !== false ) {
 			if ( $args ) {
-				$args   = array_map( 'strip_tags', $args );
-				$args   = array_map( 'esc_html', $args );
-				$string = vsprintf( $string, $args );
+				$args     = array_map( 'strip_tags', $args );
+				$args     = array_map( 'esc_html', $args );
+				$feedback = vsprintf( $feedback, $args );
 			}
 		}
-		if ( empty( $string ) ) {
+		if ( empty( $feedback ) ) {
 			return;
 		}
-		show_message( $string );
+		show_message( $feedback );
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-users-list-table.php
+++ b/src/wp-admin/includes/class-wp-users-list-table.php
@@ -411,14 +411,19 @@ class WP_Users_List_Table extends WP_List_Table {
 	 * @since 4.2.0 The `$style` parameter was deprecated.
 	 * @since 4.4.0 The `$role` parameter was deprecated.
 	 *
-	 * @param WP_User $user_object The current user object.
-	 * @param string  $style       Deprecated. Not used.
-	 * @param string  $role        Deprecated. Not used.
-	 * @param int     $numposts    Optional. Post count to display for this user. Defaults
-	 *                             to zero, as in, a new user has made zero posts.
+	 * @param WP_User $item     The current user object.
+	 * @param string  $style    Deprecated. Not used.
+	 * @param string  $role     Deprecated. Not used.
+	 * @param int     $numposts Optional. Post count to display for this user. Defaults
+	 *                          to zero, as in, a new user has made zero posts.
 	 * @return string Output for a single row.
 	 */
-	public function single_row( $user_object, $style = '', $role = '', $numposts = 0 ) {
+	public function single_row( $item, $style = '', $role = '', $numposts = 0 ) {
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$user_object = $item;
 		if ( ! ( $user_object instanceof WP_User ) ) {
 			$user_object = get_userdata( (int) $user_object );
 		}

--- a/src/wp-content/themes/twentyfourteen/inc/widgets.php
+++ b/src/wp-content/themes/twentyfourteen/inc/widgets.php
@@ -264,10 +264,11 @@ class Twenty_Fourteen_Ephemera_Widget extends WP_Widget {
 	 * @since Twenty Fourteen 1.0
 	 *
 	 * @param array $new_instance New widget instance.
-	 * @param array $instance     Original widget instance.
+	 * @param array $old_instance Original widget instance.
 	 * @return array Updated widget instance.
 	 */
-	function update( $new_instance, $instance ) {
+	function update( $new_instance, $old_instance ) {
+		$instance           = $old_instance;
 		$instance['title']  = strip_tags( $new_instance['title'] );
 		$instance['number'] = empty( $new_instance['number'] ) ? 2 : absint( $new_instance['number'] );
 

--- a/src/wp-content/themes/twentytwenty/classes/class-twentytwenty-walker-page.php
+++ b/src/wp-content/themes/twentytwenty/classes/class-twentytwenty-walker-page.php
@@ -24,12 +24,17 @@ if ( ! class_exists( 'TwentyTwenty_Walker_Page' ) ) {
 		 * @see Walker::start_el()
 		 *
 		 * @param string  $output       Used to append additional content. Passed by reference.
-		 * @param WP_Post $page         Page data object.
+		 * @param WP_Post $data_object  Page data object.
 		 * @param int     $depth        Optional. Depth of page. Used for padding. Default 0.
 		 * @param array   $args         Optional. Array of arguments. Default empty array.
 		 * @param int     $current_page Optional. Page ID. Default 0.
 		 */
-		public function start_el( &$output, $page, $depth = 0, $args = array(), $current_page = 0 ) {
+		public function start_el( &$output, $data_object, $depth = 0, $args = array(), $current_page = 0 ) {
+			/*
+			 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+			 * Also see Trac #51553.
+			 */
+			$page = $data_object;
 
 			if ( isset( $args['item_spacing'] ) && 'preserve' === $args['item_spacing'] ) {
 				$t = "\t";

--- a/src/wp-includes/class-walker-category-dropdown.php
+++ b/src/wp-includes/class-walker-category-dropdown.php
@@ -47,15 +47,20 @@ class Walker_CategoryDropdown extends Walker {
 	 *
 	 * @see Walker::start_el()
 	 *
-	 * @param string  $output   Used to append additional content (passed by reference).
-	 * @param WP_Term $category Category data object.
-	 * @param int     $depth    Depth of category. Used for padding.
-	 * @param array   $args     Uses 'selected', 'show_count', and 'value_field' keys, if they exist.
-	 *                          See wp_dropdown_categories().
-	 * @param int     $id       Optional. ID of the current category. Default 0 (unused).
+	 * @param string  $output      Used to append additional content (passed by reference).
+	 * @param WP_Term $data_object Category data object.
+	 * @param int     $depth       Depth of category. Used for padding.
+	 * @param array   $args        Uses 'selected', 'show_count', and 'value_field' keys, if they exist.
+	 *                             See wp_dropdown_categories().
+	 * @param int     $id          Optional. ID of the current category. Default 0 (unused).
 	 */
-	public function start_el( &$output, $category, $depth = 0, $args = array(), $id = 0 ) {
-		$pad = str_repeat( '&nbsp;', $depth * 3 );
+	public function start_el( &$output, $data_object, $depth = 0, $args = array(), $id = 0 ) {
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$category = $data_object;
+		$pad      = str_repeat( '&nbsp;', $depth * 3 );
 
 		/** This filter is documented in wp-includes/category-template.php */
 		$cat_name = apply_filters( 'list_cats', $category->name, $category );

--- a/src/wp-includes/class-walker-category-dropdown.php
+++ b/src/wp-includes/class-walker-category-dropdown.php
@@ -47,14 +47,14 @@ class Walker_CategoryDropdown extends Walker {
 	 *
 	 * @see Walker::start_el()
 	 *
-	 * @param string  $output      Used to append additional content (passed by reference).
-	 * @param WP_Term $data_object Category data object.
-	 * @param int     $depth       Depth of category. Used for padding.
-	 * @param array   $args        Uses 'selected', 'show_count', and 'value_field' keys, if they exist.
-	 *                             See wp_dropdown_categories().
-	 * @param int     $id          Optional. ID of the current category. Default 0 (unused).
+	 * @param string  $output            Used to append additional content (passed by reference).
+	 * @param WP_Term $data_object       Category data object.
+	 * @param int     $depth             Depth of category. Used for padding.
+	 * @param array   $args              Uses 'selected', 'show_count', and 'value_field' keys, if they exist.
+	 *                                   See wp_dropdown_categories().
+	 * @param int     $current_object_id Optional. ID of the current category. Default 0 (unused).
 	 */
-	public function start_el( &$output, $data_object, $depth = 0, $args = array(), $id = 0 ) {
+	public function start_el( &$output, $data_object, $depth = 0, $args = array(), $current_object_id = 0 ) {
 		/*
 		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
 		 * Also see Trac #51553.

--- a/src/wp-includes/class-walker-category.php
+++ b/src/wp-includes/class-walker-category.php
@@ -258,13 +258,13 @@ class Walker_Category extends Walker {
 	 *
 	 * @see Walker::end_el()
 	 *
-	 * @param string $output Used to append additional content (passed by reference).
-	 * @param object $page   Not used.
-	 * @param int    $depth  Optional. Depth of category. Not used.
-	 * @param array  $args   Optional. An array of arguments. Only uses 'list' for whether should append
-	 *                       to output. See wp_list_categories(). Default empty array.
+	 * @param string $output      Used to append additional content (passed by reference).
+	 * @param object $data_object Not used.
+	 * @param int    $depth       Optional. Depth of category. Not used.
+	 * @param array  $args        Optional. An array of arguments. Only uses 'list' for whether should
+	 *                            append to output. See wp_list_categories(). Default empty array.
 	 */
-	public function end_el( &$output, $page, $depth = 0, $args = array() ) {
+	public function end_el( &$output, $data_object, $depth = 0, $args = array() ) {
 		if ( 'list' !== $args['style'] ) {
 			return;
 		}

--- a/src/wp-includes/class-walker-category.php
+++ b/src/wp-includes/class-walker-category.php
@@ -89,13 +89,20 @@ class Walker_Category extends Walker {
 	 *
 	 * @see Walker::start_el()
 	 *
-	 * @param string  $output   Used to append additional content (passed by reference).
-	 * @param WP_Term $category Category data object.
-	 * @param int     $depth    Optional. Depth of category in reference to parents. Default 0.
-	 * @param array   $args     Optional. An array of arguments. See wp_list_categories(). Default empty array.
-	 * @param int     $id       Optional. ID of the current category. Default 0.
+	 * @param string  $output      Used to append additional content (passed by reference).
+	 * @param WP_Term $data_object Category data object.
+	 * @param int     $depth       Optional. Depth of category in reference to parents. Default 0.
+	 * @param array   $args        Optional. An array of arguments. See wp_list_categories().
+	 *                             Default empty array.
+	 * @param int     $id          Optional. ID of the current category. Default 0.
 	 */
-	public function start_el( &$output, $category, $depth = 0, $args = array(), $id = 0 ) {
+	public function start_el( &$output, $data_object, $depth = 0, $args = array(), $id = 0 ) {
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$category = $data_object;
+
 		/** This filter is documented in wp-includes/category-template.php */
 		$cat_name = apply_filters( 'list_cats', esc_attr( $category->name ), $category );
 

--- a/src/wp-includes/class-walker-category.php
+++ b/src/wp-includes/class-walker-category.php
@@ -89,14 +89,14 @@ class Walker_Category extends Walker {
 	 *
 	 * @see Walker::start_el()
 	 *
-	 * @param string  $output      Used to append additional content (passed by reference).
-	 * @param WP_Term $data_object Category data object.
-	 * @param int     $depth       Optional. Depth of category in reference to parents. Default 0.
-	 * @param array   $args        Optional. An array of arguments. See wp_list_categories().
-	 *                             Default empty array.
-	 * @param int     $id          Optional. ID of the current category. Default 0.
+	 * @param string  $output            Used to append additional content (passed by reference).
+	 * @param WP_Term $data_object       Category data object.
+	 * @param int     $depth             Optional. Depth of category in reference to parents. Default 0.
+	 * @param array   $args              Optional. An array of arguments. See wp_list_categories().
+	 *                                   Default empty array.
+	 * @param int     $current_object_id Optional. ID of the current category. Default 0.
 	 */
-	public function start_el( &$output, $data_object, $depth = 0, $args = array(), $id = 0 ) {
+	public function start_el( &$output, $data_object, $depth = 0, $args = array(), $current_object_id = 0 ) {
 		/*
 		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
 		 * Also see Trac #51553.
@@ -137,12 +137,12 @@ class Walker_Category extends Walker {
 		 *     @type string $href  The href attribute.
 		 *     @type string $title The title attribute.
 		 * }
-		 * @param WP_Term $category Term data object.
-		 * @param int     $depth    Depth of category, used for padding.
-		 * @param array   $args     An array of arguments.
-		 * @param int     $id       ID of the current category.
+		 * @param WP_Term $category          Term data object.
+		 * @param int     $depth             Depth of category, used for padding.
+		 * @param array   $args              An array of arguments.
+		 * @param int     $current_object_id ID of the current category.
 		 */
-		$atts = apply_filters( 'category_list_link_attributes', $atts, $category, $depth, $args, $id );
+		$atts = apply_filters( 'category_list_link_attributes', $atts, $category, $depth, $args, $current_object_id );
 
 		$attributes = '';
 		foreach ( $atts as $attr => $value ) {

--- a/src/wp-includes/class-walker-comment.php
+++ b/src/wp-includes/class-walker-comment.php
@@ -163,13 +163,19 @@ class Walker_Comment extends Walker {
 	 * @global int        $comment_depth
 	 * @global WP_Comment $comment       Global comment object.
 	 *
-	 * @param string     $output  Used to append additional content. Passed by reference.
-	 * @param WP_Comment $comment Comment data object.
-	 * @param int        $depth   Optional. Depth of the current comment in reference to parents. Default 0.
-	 * @param array      $args    Optional. An array of arguments. Default empty array.
-	 * @param int        $id      Optional. ID of the current comment. Default 0 (unused).
+	 * @param string     $output      Used to append additional content. Passed by reference.
+	 * @param WP_Comment $data_object Comment data object.
+	 * @param int        $depth       Optional. Depth of the current comment in reference to parents. Default 0.
+	 * @param array      $args        Optional. An array of arguments. Default empty array.
+	 * @param int        $id          Optional. ID of the current comment. Default 0 (unused).
 	 */
-	public function start_el( &$output, $comment, $depth = 0, $args = array(), $id = 0 ) {
+	public function start_el( &$output, $data_object, $depth = 0, $args = array(), $id = 0 ) {
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$comment = $data_object;
+
 		$depth++;
 		$GLOBALS['comment_depth'] = $depth;
 		$GLOBALS['comment']       = $comment;

--- a/src/wp-includes/class-walker-comment.php
+++ b/src/wp-includes/class-walker-comment.php
@@ -163,13 +163,13 @@ class Walker_Comment extends Walker {
 	 * @global int        $comment_depth
 	 * @global WP_Comment $comment       Global comment object.
 	 *
-	 * @param string     $output      Used to append additional content. Passed by reference.
-	 * @param WP_Comment $data_object Comment data object.
-	 * @param int        $depth       Optional. Depth of the current comment in reference to parents. Default 0.
-	 * @param array      $args        Optional. An array of arguments. Default empty array.
-	 * @param int        $id          Optional. ID of the current comment. Default 0 (unused).
+	 * @param string     $output            Used to append additional content. Passed by reference.
+	 * @param WP_Comment $data_object       Comment data object.
+	 * @param int        $depth             Optional. Depth of the current comment in reference to parents. Default 0.
+	 * @param array      $args              Optional. An array of arguments. Default empty array.
+	 * @param int        $current_object_id Optional. ID of the current comment. Default 0 (unused).
 	 */
-	public function start_el( &$output, $data_object, $depth = 0, $args = array(), $id = 0 ) {
+	public function start_el( &$output, $data_object, $depth = 0, $args = array(), $current_object_id = 0 ) {
 		/*
 		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
 		 * Also see Trac #51553.

--- a/src/wp-includes/class-walker-comment.php
+++ b/src/wp-includes/class-walker-comment.php
@@ -218,15 +218,20 @@ class Walker_Comment extends Walker {
 	 * @see Walker::end_el()
 	 * @see wp_list_comments()
 	 *
-	 * @param string     $output  Used to append additional content. Passed by reference.
-	 * @param WP_Comment $comment The current comment object. Default current comment.
-	 * @param int        $depth   Optional. Depth of the current comment. Default 0.
-	 * @param array      $args    Optional. An array of arguments. Default empty array.
+	 * @param string     $output      Used to append additional content. Passed by reference.
+	 * @param WP_Comment $data_object The current comment object.
+	 * @param int        $depth       Optional. Depth of the current comment. Default 0.
+	 * @param array      $args        Optional. An array of arguments. Default empty array.
 	 */
-	public function end_el( &$output, $comment, $depth = 0, $args = array() ) {
+	public function end_el( &$output, $data_object, $depth = 0, $args = array() ) {
 		if ( ! empty( $args['end-callback'] ) ) {
 			ob_start();
-			call_user_func( $args['end-callback'], $comment, $args, $depth );
+			call_user_func(
+				$args['end-callback'],
+				$data_object, // The current comment object. See Trac #51553.
+				$args,
+				$depth
+			);
 			$output .= ob_get_clean();
 			return;
 		}

--- a/src/wp-includes/class-walker-nav-menu.php
+++ b/src/wp-includes/class-walker-nav-menu.php
@@ -109,13 +109,13 @@ class Walker_Nav_Menu extends Walker {
 	 *
 	 * @see Walker::start_el()
 	 *
-	 * @param string   $output Used to append additional content (passed by reference).
-	 * @param WP_Post  $item   Menu item data object.
-	 * @param int      $depth  Depth of menu item. Used for padding.
-	 * @param stdClass $args   An object of wp_nav_menu() arguments.
-	 * @param int      $id     Current item ID.
+	 * @param string   $output      Used to append additional content (passed by reference).
+	 * @param WP_Post  $data_object Menu item data object.
+	 * @param int      $depth       Depth of menu item. Used for padding.
+	 * @param stdClass $args        An object of wp_nav_menu() arguments.
+	 * @param int      $id          Current item ID.
 	 */
-	public function start_el( &$output, $item, $depth = 0, $args = null, $id = 0 ) {
+	public function start_el( &$output, $data_object, $depth = 0, $args = null, $id = 0 ) {
 		if ( isset( $args->item_spacing ) && 'discard' === $args->item_spacing ) {
 			$t = '';
 			$n = '';
@@ -125,19 +125,24 @@ class Walker_Nav_Menu extends Walker {
 		}
 		$indent = ( $depth ) ? str_repeat( $t, $depth ) : '';
 
-		$classes   = empty( $item->classes ) ? array() : (array) $item->classes;
-		$classes[] = 'menu-item-' . $item->ID;
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$menu_item = $data_object;
+		$classes   = empty( $menu_item->classes ) ? array() : (array) $menu_item->classes;
+		$classes[] = 'menu-item-' . $menu_item->ID;
 
 		/**
 		 * Filters the arguments for a single nav menu item.
 		 *
 		 * @since 4.4.0
 		 *
-		 * @param stdClass $args  An object of wp_nav_menu() arguments.
-		 * @param WP_Post  $item  Menu item data object.
-		 * @param int      $depth Depth of menu item. Used for padding.
+		 * @param stdClass $args      An object of wp_nav_menu() arguments.
+		 * @param WP_Post  $menu_item Menu item data object.
+		 * @param int      $depth     Depth of menu item. Used for padding.
 		 */
-		$args = apply_filters( 'nav_menu_item_args', $args, $item, $depth );
+		$args = apply_filters( 'nav_menu_item_args', $args, $menu_item, $depth );
 
 		/**
 		 * Filters the CSS classes applied to a menu item's list item element.
@@ -145,12 +150,12 @@ class Walker_Nav_Menu extends Walker {
 		 * @since 3.0.0
 		 * @since 4.1.0 The `$depth` parameter was added.
 		 *
-		 * @param string[] $classes Array of the CSS classes that are applied to the menu item's `<li>` element.
-		 * @param WP_Post  $item    The current menu item.
-		 * @param stdClass $args    An object of wp_nav_menu() arguments.
-		 * @param int      $depth   Depth of menu item. Used for padding.
+		 * @param string[] $classes   Array of the CSS classes that are applied to the menu item's `<li>` element.
+		 * @param WP_Post  $menu_item The current menu item object.
+		 * @param stdClass $args      An object of wp_nav_menu() arguments.
+		 * @param int      $depth     Depth of menu item. Used for padding.
 		 */
-		$class_names = implode( ' ', apply_filters( 'nav_menu_css_class', array_filter( $classes ), $item, $args, $depth ) );
+		$class_names = implode( ' ', apply_filters( 'nav_menu_css_class', array_filter( $classes ), $menu_item, $args, $depth ) );
 		$class_names = $class_names ? ' class="' . esc_attr( $class_names ) . '"' : '';
 
 		/**
@@ -159,26 +164,26 @@ class Walker_Nav_Menu extends Walker {
 		 * @since 3.0.1
 		 * @since 4.1.0 The `$depth` parameter was added.
 		 *
-		 * @param string   $menu_id The ID that is applied to the menu item's `<li>` element.
-		 * @param WP_Post  $item    The current menu item.
-		 * @param stdClass $args    An object of wp_nav_menu() arguments.
-		 * @param int      $depth   Depth of menu item. Used for padding.
+		 * @param string   $menu_id   The ID that is applied to the menu item's `<li>` element.
+		 * @param WP_Post  $menu_item The current menu item.
+		 * @param stdClass $args      An object of wp_nav_menu() arguments.
+		 * @param int      $depth     Depth of menu item. Used for padding.
 		 */
-		$id = apply_filters( 'nav_menu_item_id', 'menu-item-' . $item->ID, $item, $args, $depth );
+		$id = apply_filters( 'nav_menu_item_id', 'menu-item-' . $menu_item->ID, $menu_item, $args, $depth );
 		$id = $id ? ' id="' . esc_attr( $id ) . '"' : '';
 
 		$output .= $indent . '<li' . $id . $class_names . '>';
 
 		$atts           = array();
-		$atts['title']  = ! empty( $item->attr_title ) ? $item->attr_title : '';
-		$atts['target'] = ! empty( $item->target ) ? $item->target : '';
-		if ( '_blank' === $item->target && empty( $item->xfn ) ) {
+		$atts['title']  = ! empty( $menu_item->attr_title ) ? $menu_item->attr_title : '';
+		$atts['target'] = ! empty( $menu_item->target ) ? $menu_item->target : '';
+		if ( '_blank' === $menu_item->target && empty( $menu_item->xfn ) ) {
 			$atts['rel'] = 'noopener';
 		} else {
-			$atts['rel'] = $item->xfn;
+			$atts['rel'] = $menu_item->xfn;
 		}
-		$atts['href']         = ! empty( $item->url ) ? $item->url : '';
-		$atts['aria-current'] = $item->current ? 'page' : '';
+		$atts['href']         = ! empty( $menu_item->url ) ? $menu_item->url : '';
+		$atts['aria-current'] = $menu_item->current ? 'page' : '';
 
 		/**
 		 * Filters the HTML attributes applied to a menu item's anchor element.
@@ -195,11 +200,11 @@ class Walker_Nav_Menu extends Walker {
 		 *     @type string $href         The href attribute.
 		 *     @type string $aria-current The aria-current attribute.
 		 * }
-		 * @param WP_Post  $item  The current menu item.
-		 * @param stdClass $args  An object of wp_nav_menu() arguments.
-		 * @param int      $depth Depth of menu item. Used for padding.
+		 * @param WP_Post  $menu_item The current menu item object.
+		 * @param stdClass $args      An object of wp_nav_menu() arguments.
+		 * @param int      $depth     Depth of menu item. Used for padding.
 		 */
-		$atts = apply_filters( 'nav_menu_link_attributes', $atts, $item, $args, $depth );
+		$atts = apply_filters( 'nav_menu_link_attributes', $atts, $menu_item, $args, $depth );
 
 		$attributes = '';
 		foreach ( $atts as $attr => $value ) {
@@ -210,19 +215,19 @@ class Walker_Nav_Menu extends Walker {
 		}
 
 		/** This filter is documented in wp-includes/post-template.php */
-		$title = apply_filters( 'the_title', $item->title, $item->ID );
+		$title = apply_filters( 'the_title', $menu_item->title, $menu_item->ID );
 
 		/**
 		 * Filters a menu item's title.
 		 *
 		 * @since 4.4.0
 		 *
-		 * @param string   $title The menu item's title.
-		 * @param WP_Post  $item  The current menu item.
-		 * @param stdClass $args  An object of wp_nav_menu() arguments.
-		 * @param int      $depth Depth of menu item. Used for padding.
+		 * @param string   $title     The menu item's title.
+		 * @param WP_Post  $menu_item The current menu item object.
+		 * @param stdClass $args      An object of wp_nav_menu() arguments.
+		 * @param int      $depth     Depth of menu item. Used for padding.
 		 */
-		$title = apply_filters( 'nav_menu_item_title', $title, $item, $args, $depth );
+		$title = apply_filters( 'nav_menu_item_title', $title, $menu_item, $args, $depth );
 
 		$item_output  = $args->before;
 		$item_output .= '<a' . $attributes . '>';
@@ -240,11 +245,11 @@ class Walker_Nav_Menu extends Walker {
 		 * @since 3.0.0
 		 *
 		 * @param string   $item_output The menu item's starting HTML output.
-		 * @param WP_Post  $item        Menu item data object.
+		 * @param WP_Post  $menu_item   Menu item data object.
 		 * @param int      $depth       Depth of menu item. Used for padding.
 		 * @param stdClass $args        An object of wp_nav_menu() arguments.
 		 */
-		$output .= apply_filters( 'walker_nav_menu_start_el', $item_output, $item, $depth, $args );
+		$output .= apply_filters( 'walker_nav_menu_start_el', $item_output, $menu_item, $depth, $args );
 	}
 
 	/**

--- a/src/wp-includes/class-walker-nav-menu.php
+++ b/src/wp-includes/class-walker-nav-menu.php
@@ -259,12 +259,12 @@ class Walker_Nav_Menu extends Walker {
 	 *
 	 * @see Walker::end_el()
 	 *
-	 * @param string   $output Used to append additional content (passed by reference).
-	 * @param WP_Post  $item   Page data object. Not used.
-	 * @param int      $depth  Depth of page. Not Used.
-	 * @param stdClass $args   An object of wp_nav_menu() arguments.
+	 * @param string   $output      Used to append additional content (passed by reference).
+	 * @param WP_Post  $data_object Page data object. Not used.
+	 * @param int      $depth       Depth of page. Not Used.
+	 * @param stdClass $args        An object of wp_nav_menu() arguments.
 	 */
-	public function end_el( &$output, $item, $depth = 0, $args = null ) {
+	public function end_el( &$output, $data_object, $depth = 0, $args = null ) {
 		if ( isset( $args->item_spacing ) && 'discard' === $args->item_spacing ) {
 			$t = '';
 			$n = '';

--- a/src/wp-includes/class-walker-nav-menu.php
+++ b/src/wp-includes/class-walker-nav-menu.php
@@ -109,13 +109,13 @@ class Walker_Nav_Menu extends Walker {
 	 *
 	 * @see Walker::start_el()
 	 *
-	 * @param string   $output      Used to append additional content (passed by reference).
-	 * @param WP_Post  $data_object Menu item data object.
-	 * @param int      $depth       Depth of menu item. Used for padding.
-	 * @param stdClass $args        An object of wp_nav_menu() arguments.
-	 * @param int      $id          Current item ID.
+	 * @param string   $output            Used to append additional content (passed by reference).
+	 * @param WP_Post  $data_object       Menu item data object.
+	 * @param int      $depth             Depth of menu item. Used for padding.
+	 * @param stdClass $args              An object of wp_nav_menu() arguments.
+	 * @param int      $current_object_id Current item ID.
 	 */
-	public function start_el( &$output, $data_object, $depth = 0, $args = null, $id = 0 ) {
+	public function start_el( &$output, $data_object, $depth = 0, $args = null, $current_object_id = 0 ) {
 		if ( isset( $args->item_spacing ) && 'discard' === $args->item_spacing ) {
 			$t = '';
 			$n = '';

--- a/src/wp-includes/class-walker-page-dropdown.php
+++ b/src/wp-includes/class-walker-page-dropdown.php
@@ -47,17 +47,22 @@ class Walker_PageDropdown extends Walker {
 	 *
 	 * @see Walker::start_el()
 	 *
-	 * @param string  $output Used to append additional content. Passed by reference.
-	 * @param WP_Post $page   Page data object.
-	 * @param int     $depth  Optional. Depth of page in reference to parent pages. Used for padding.
-	 *                        Default 0.
-	 * @param array   $args   Optional. Uses 'selected' argument for selected page to set selected HTML
-	 *                        attribute for option element. Uses 'value_field' argument to fill "value"
-	 *                        attribute. See wp_dropdown_pages(). Default empty array.
-	 * @param int     $id     Optional. ID of the current page. Default 0 (unused).
+	 * @param string  $output      Used to append additional content. Passed by reference.
+	 * @param WP_Post $data_object Page data object.
+	 * @param int     $depth       Optional. Depth of page in reference to parent pages. Used for padding.
+	 *                             Default 0.
+	 * @param array   $args        Optional. Uses 'selected' argument for selected page to set selected HTML
+	 *                             attribute for option element. Uses 'value_field' argument to fill "value"
+	 *                             attribute. See wp_dropdown_pages(). Default empty array.
+	 * @param int     $id          Optional. ID of the current page. Default 0 (unused).
 	 */
-	public function start_el( &$output, $page, $depth = 0, $args = array(), $id = 0 ) {
-		$pad = str_repeat( '&nbsp;', $depth * 3 );
+	public function start_el( &$output, $data_object, $depth = 0, $args = array(), $id = 0 ) {
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$page = $data_object;
+		$pad  = str_repeat( '&nbsp;', $depth * 3 );
 
 		if ( ! isset( $args['value_field'] ) || ! isset( $page->{$args['value_field']} ) ) {
 			$args['value_field'] = 'ID';

--- a/src/wp-includes/class-walker-page-dropdown.php
+++ b/src/wp-includes/class-walker-page-dropdown.php
@@ -47,16 +47,17 @@ class Walker_PageDropdown extends Walker {
 	 *
 	 * @see Walker::start_el()
 	 *
-	 * @param string  $output      Used to append additional content. Passed by reference.
-	 * @param WP_Post $data_object Page data object.
-	 * @param int     $depth       Optional. Depth of page in reference to parent pages. Used for padding.
-	 *                             Default 0.
-	 * @param array   $args        Optional. Uses 'selected' argument for selected page to set selected HTML
-	 *                             attribute for option element. Uses 'value_field' argument to fill "value"
-	 *                             attribute. See wp_dropdown_pages(). Default empty array.
-	 * @param int     $id          Optional. ID of the current page. Default 0 (unused).
+	 * @param string  $output            Used to append additional content. Passed by reference.
+	 * @param WP_Post $data_object       Page data object.
+	 * @param int     $depth             Optional. Depth of page in reference to parent pages.
+	 *                                   Used for padding. Default 0.
+	 * @param array   $args              Optional. Uses 'selected' argument for selected page to set
+	 *                                   selected HTML attribute for option element. Uses 'value_field'
+	 *                                   argument to fill "value" attribute. See wp_dropdown_pages().
+	 *                                   Default empty array.
+	 * @param int     $current_object_id Optional. ID of the current page. Default 0 (unused).
 	 */
-	public function start_el( &$output, $data_object, $depth = 0, $args = array(), $id = 0 ) {
+	public function start_el( &$output, $data_object, $depth = 0, $args = array(), $current_object_id = 0 ) {
 		/*
 		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
 		 * Also see Trac #51553.

--- a/src/wp-includes/class-walker-page.php
+++ b/src/wp-includes/class-walker-page.php
@@ -94,13 +94,13 @@ class Walker_Page extends Walker {
 	 * @see Walker::start_el()
 	 * @since 2.1.0
 	 *
-	 * @param string  $output       Used to append additional content. Passed by reference.
-	 * @param WP_Post $data_object  Page data object.
-	 * @param int     $depth        Optional. Depth of page. Used for padding. Default 0.
-	 * @param array   $args         Optional. Array of arguments. Default empty array.
-	 * @param int     $current_page Optional. Page ID. Default 0.
+	 * @param string  $output            Used to append additional content. Passed by reference.
+	 * @param WP_Post $data_object       Page data object.
+	 * @param int     $depth             Optional. Depth of page. Used for padding. Default 0.
+	 * @param array   $args              Optional. Array of arguments. Default empty array.
+	 * @param int     $current_object_id Optional. Page ID. Default 0.
 	 */
-	public function start_el( &$output, $data_object, $depth = 0, $args = array(), $current_page = 0 ) {
+	public function start_el( &$output, $data_object, $depth = 0, $args = array(), $current_object_id = 0 ) {
 		/*
 		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
 		 * Also see Trac #51553.
@@ -126,14 +126,14 @@ class Walker_Page extends Walker {
 			$css_class[] = 'page_item_has_children';
 		}
 
-		if ( ! empty( $current_page ) ) {
-			$_current_page = get_post( $current_page );
+		if ( ! empty( $current_object_id ) ) {
+			$_current_page = get_post( $current_object_id );
 
 			if ( $_current_page && in_array( $page->ID, $_current_page->ancestors, true ) ) {
 				$css_class[] = 'current_page_ancestor';
 			}
 
-			if ( $page->ID == $current_page ) {
+			if ( $page->ID == $current_object_id ) {
 				$css_class[] = 'current_page_item';
 			} elseif ( $_current_page && $page->ID === $_current_page->post_parent ) {
 				$css_class[] = 'current_page_parent';
@@ -149,13 +149,13 @@ class Walker_Page extends Walker {
 		 *
 		 * @see wp_list_pages()
 		 *
-		 * @param string[] $css_class    An array of CSS classes to be applied to each list item.
-		 * @param WP_Post  $page         Page data object.
-		 * @param int      $depth        Depth of page, used for padding.
-		 * @param array    $args         An array of arguments.
-		 * @param int      $current_page ID of the current page.
+		 * @param string[] $css_class         An array of CSS classes to be applied to each list item.
+		 * @param WP_Post  $page              Page data object.
+		 * @param int      $depth             Depth of page, used for padding.
+		 * @param array    $args              An array of arguments.
+		 * @param int      $current_object_id ID of the current page.
 		 */
-		$css_classes = implode( ' ', apply_filters( 'page_css_class', $css_class, $page, $depth, $args, $current_page ) );
+		$css_classes = implode( ' ', apply_filters( 'page_css_class', $css_class, $page, $depth, $args, $current_object_id ) );
 		$css_classes = $css_classes ? ' class="' . esc_attr( $css_classes ) . '"' : '';
 
 		if ( '' === $page->post_title ) {
@@ -168,7 +168,7 @@ class Walker_Page extends Walker {
 
 		$atts                 = array();
 		$atts['href']         = get_permalink( $page->ID );
-		$atts['aria-current'] = ( $page->ID == $current_page ) ? 'page' : '';
+		$atts['aria-current'] = ( $page->ID == $current_object_id ) ? 'page' : '';
 
 		/**
 		 * Filters the HTML attributes applied to a page menu item's anchor element.
@@ -181,12 +181,12 @@ class Walker_Page extends Walker {
 		 *     @type string $href         The href attribute.
 		 *     @type string $aria-current The aria-current attribute.
 		 * }
-		 * @param WP_Post $page         Page data object.
-		 * @param int     $depth        Depth of page, used for padding.
-		 * @param array   $args         An array of arguments.
-		 * @param int     $current_page ID of the current page.
+		 * @param WP_Post $page              Page data object.
+		 * @param int     $depth             Depth of page, used for padding.
+		 * @param array   $args              An array of arguments.
+		 * @param int     $current_object_id ID of the current page.
 		 */
-		$atts = apply_filters( 'page_menu_link_attributes', $atts, $page, $depth, $args, $current_page );
+		$atts = apply_filters( 'page_menu_link_attributes', $atts, $page, $depth, $args, $current_object_id );
 
 		$attributes = '';
 		foreach ( $atts as $attr => $value ) {

--- a/src/wp-includes/class-walker-page.php
+++ b/src/wp-includes/class-walker-page.php
@@ -225,12 +225,12 @@ class Walker_Page extends Walker {
 	 *
 	 * @see Walker::end_el()
 	 *
-	 * @param string  $output Used to append additional content. Passed by reference.
-	 * @param WP_Post $page   Page data object. Not used.
-	 * @param int     $depth  Optional. Depth of page. Default 0 (unused).
-	 * @param array   $args   Optional. Array of arguments. Default empty array.
+	 * @param string  $output      Used to append additional content. Passed by reference.
+	 * @param WP_Post $data_object Page data object. Not used.
+	 * @param int     $depth       Optional. Depth of page. Default 0 (unused).
+	 * @param array   $args        Optional. Array of arguments. Default empty array.
 	 */
-	public function end_el( &$output, $page, $depth = 0, $args = array() ) {
+	public function end_el( &$output, $data_object, $depth = 0, $args = array() ) {
 		if ( isset( $args['item_spacing'] ) && 'preserve' === $args['item_spacing'] ) {
 			$t = "\t";
 			$n = "\n";

--- a/src/wp-includes/class-walker-page.php
+++ b/src/wp-includes/class-walker-page.php
@@ -95,12 +95,18 @@ class Walker_Page extends Walker {
 	 * @since 2.1.0
 	 *
 	 * @param string  $output       Used to append additional content. Passed by reference.
-	 * @param WP_Post $page         Page data object.
+	 * @param WP_Post $data_object  Page data object.
 	 * @param int     $depth        Optional. Depth of page. Used for padding. Default 0.
 	 * @param array   $args         Optional. Array of arguments. Default empty array.
 	 * @param int     $current_page Optional. Page ID. Default 0.
 	 */
-	public function start_el( &$output, $page, $depth = 0, $args = array(), $current_page = 0 ) {
+	public function start_el( &$output, $data_object, $depth = 0, $args = array(), $current_page = 0 ) {
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$page = $data_object;
+
 		if ( isset( $args['item_spacing'] ) && 'preserve' === $args['item_spacing'] ) {
 			$t = "\t";
 			$n = "\n";

--- a/src/wp-includes/class-wp-customize-setting.php
+++ b/src/wp-includes/class-wp-customize-setting.php
@@ -559,7 +559,7 @@ class WP_Customize_Setting {
 	 *
 	 * @since 3.4.0
 	 *
-	 * @param string|array $value    The value to sanitize.
+	 * @param string|array $value The value to sanitize.
 	 * @return string|array|null|WP_Error Sanitized value, or `null`/`WP_Error` if invalid.
 	 */
 	public function sanitize( $value ) {

--- a/src/wp-includes/class-wp-image-editor-gd.php
+++ b/src/wp-includes/class-wp-image-editor-gd.php
@@ -424,12 +424,12 @@ class WP_Image_Editor_GD extends WP_Image_Editor {
 	 *
 	 * @since 3.5.0
 	 *
-	 * @param string|null $filename
+	 * @param string|null $destfilename
 	 * @param string|null $mime_type
 	 * @return array|WP_Error {'path'=>string, 'file'=>string, 'width'=>int, 'height'=>int, 'mime-type'=>string}
 	 */
-	public function save( $filename = null, $mime_type = null ) {
-		$saved = $this->_save( $this->image, $filename, $mime_type );
+	public function save( $destfilename = null, $mime_type = null ) {
+		$saved = $this->_save( $this->image, $destfilename, $mime_type );
 
 		if ( ! is_wp_error( $saved ) ) {
 			$this->file      = $saved['path'];

--- a/src/wp-includes/class-wp-walker.php
+++ b/src/wp-includes/class-wp-walker.php
@@ -86,12 +86,12 @@ class Walker {
 	 * @abstract
 	 *
 	 * @param string $output            Used to append additional content (passed by reference).
-	 * @param object $object            The data object.
+	 * @param object $data_object       The data object.
 	 * @param int    $depth             Depth of the item.
 	 * @param array  $args              An array of additional arguments.
 	 * @param int    $current_object_id ID of the current item.
 	 */
-	public function start_el( &$output, $object, $depth = 0, $args = array(), $current_object_id = 0 ) {}
+	public function start_el( &$output, $data_object, $depth = 0, $args = array(), $current_object_id = 0 ) {}
 
 	/**
 	 * Ends the element output, if needed.

--- a/src/wp-includes/class-wp-walker.php
+++ b/src/wp-includes/class-wp-walker.php
@@ -101,12 +101,12 @@ class Walker {
 	 * @since 2.1.0
 	 * @abstract
 	 *
-	 * @param string $output Used to append additional content (passed by reference).
-	 * @param object $object The data object.
-	 * @param int    $depth  Depth of the item.
-	 * @param array  $args   An array of additional arguments.
+	 * @param string $output      Used to append additional content (passed by reference).
+	 * @param object $data_object The data object.
+	 * @param int    $depth       Depth of the item.
+	 * @param array  $args        An array of additional arguments.
 	 */
-	public function end_el( &$output, $object, $depth = 0, $args = array() ) {}
+	public function end_el( &$output, $data_object, $depth = 0, $args = array() ) {}
 
 	/**
 	 * Traverse elements to create list from elements.

--- a/src/wp-includes/customize/class-wp-customize-custom-css-setting.php
+++ b/src/wp-includes/customize/class-wp-customize-custom-css-setting.php
@@ -174,16 +174,16 @@ final class WP_Customize_Custom_CSS_Setting extends WP_Customize_Setting {
 	 *
 	 * @since 4.7.0
 	 *
-	 * @param string $css The input value.
+	 * @param string $value The input value.
 	 * @return int|false The post ID or false if the value could not be saved.
 	 */
-	public function update( $css ) {
-		if ( empty( $css ) ) {
-			$css = '';
+	public function update( $value ) {
+		if ( empty( $value ) ) {
+			$value = '';
 		}
 
 		$r = wp_update_custom_css_post(
-			$css,
+			$value,
 			array(
 				'stylesheet' => $this->stylesheet,
 			)

--- a/src/wp-includes/customize/class-wp-customize-custom-css-setting.php
+++ b/src/wp-includes/customize/class-wp-customize-custom-css-setting.php
@@ -145,7 +145,7 @@ final class WP_Customize_Custom_CSS_Setting extends WP_Customize_Setting {
 	}
 
 	/**
-	 * Validate CSS.
+	 * Validate a received value for being valid CSS.
 	 *
 	 * Checks for imbalanced braces, brackets, and comments.
 	 * Notifications are rendered when the customizer state is saved.
@@ -153,18 +153,18 @@ final class WP_Customize_Custom_CSS_Setting extends WP_Customize_Setting {
 	 * @since 4.7.0
 	 * @since 4.9.0 Checking for balanced characters has been moved client-side via linting in code editor.
 	 *
-	 * @param string $css The input string.
+	 * @param string $value The input string.
 	 * @return true|WP_Error True if the input was validated, otherwise WP_Error.
 	 */
-	public function validate( $css ) {
+	public function validate( $value ) {
 		$validity = new WP_Error();
 
-		if ( preg_match( '#</?\w+#', $css ) ) {
+		if ( preg_match( '#</?\w+#', $value ) ) {
 			$validity->add( 'illegal_markup', __( 'Markup is not allowed in CSS.' ) );
 		}
 
 		if ( ! $validity->has_errors() ) {
-			$validity = parent::validate( $css );
+			$validity = parent::validate( $value );
 		}
 		return $validity;
 	}

--- a/src/wp-includes/customize/class-wp-customize-nav-menu-item-setting.php
+++ b/src/wp-includes/customize/class-wp-customize-nav-menu-item-setting.php
@@ -654,18 +654,18 @@ class WP_Customize_Nav_Menu_Item_Setting extends WP_Customize_Setting {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param array $menu_item_value The value to sanitize.
+	 * @param array $value The menu item value to sanitize.
 	 * @return array|false|null|WP_Error Null or WP_Error if an input isn't valid. False if it is marked for deletion.
 	 *                                   Otherwise the sanitized value.
 	 */
-	public function sanitize( $menu_item_value ) {
+	public function sanitize( $value ) {
 		// Menu is marked for deletion.
-		if ( false === $menu_item_value ) {
-			return $menu_item_value;
+		if ( false === $value ) {
+			return $value;
 		}
 
 		// Invalid.
-		if ( ! is_array( $menu_item_value ) ) {
+		if ( ! is_array( $value ) ) {
 			return null;
 		}
 
@@ -687,7 +687,7 @@ class WP_Customize_Nav_Menu_Item_Setting extends WP_Customize_Setting {
 			'nav_menu_term_id' => 0,
 			'_invalid'         => false,
 		);
-		$menu_item_value             = array_merge( $default, $menu_item_value );
+		$menu_item_value             = array_merge( $default, $value );
 		$menu_item_value             = wp_array_slice_assoc( $menu_item_value, array_keys( $default ) );
 		$menu_item_value['position'] = (int) $menu_item_value['position'];
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -708,11 +708,16 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 	 *
 	 * @since 4.7.0
 	 *
-	 * @param WP_Post         $post    Attachment object.
+	 * @param WP_Post         $item    Attachment object.
 	 * @param WP_REST_Request $request Request object.
 	 * @return WP_REST_Response Response object.
 	 */
-	public function prepare_item_for_response( $post, $request ) {
+	public function prepare_item_for_response( $item, $request ) {
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$post     = $item;
 		$response = parent::prepare_item_for_response( $post, $request );
 		$fields   = $this->get_fields_for_response( $request );
 		$data     = $response->get_data();

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
@@ -397,12 +397,16 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 	 *
 	 * @since 5.0.0
 	 *
-	 * @param WP_Post         $post    Post revision object.
+	 * @param WP_Post         $item    Post revision object.
 	 * @param WP_REST_Request $request Request object.
 	 * @return WP_REST_Response Response object.
 	 */
-	public function prepare_item_for_response( $post, $request ) {
-
+	public function prepare_item_for_response( $item, $request ) {
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$post     = $item;
 		$response = $this->revisions_controller->prepare_item_for_response( $post, $request );
 
 		$fields = $this->get_fields_for_response( $request );

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-directory-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-directory-controller.php
@@ -110,11 +110,17 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 	 *
 	 * @since 5.5.0
 	 *
-	 * @param array           $plugin  The plugin metadata.
+	 * @param array           $item    The plugin metadata.
 	 * @param WP_REST_Request $request Request object.
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
-	public function prepare_item_for_response( $plugin, $request ) {
+	public function prepare_item_for_response( $item, $request ) {
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$plugin = $item;
+
 		// There might be multiple blocks in a plugin. Only the first block is mapped.
 		$block_data = reset( $plugin['blocks'] );
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
@@ -237,14 +237,18 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 	 *
 	 * @since 5.5.0
 	 *
-	 * @param WP_Block_Type   $block_type Block type data.
-	 * @param WP_REST_Request $request    Full details about the request.
+	 * @param WP_Block_Type   $item    Block type data.
+	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response Block type data.
 	 */
-	public function prepare_item_for_response( $block_type, $request ) {
-
-		$fields = $this->get_fields_for_response( $request );
-		$data   = array();
+	public function prepare_item_for_response( $item, $request ) {
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$block_type = $item;
+		$fields     = $this->get_fields_for_response( $request );
+		$data       = array();
 
 		if ( rest_is_field_included( 'attributes', $fields ) ) {
 			$data['attributes'] = $block_type->get_attributes();

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
@@ -1029,14 +1029,18 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 	 *
 	 * @since 4.7.0
 	 *
-	 * @param WP_Comment      $comment Comment object.
+	 * @param WP_Comment      $item    Comment object.
 	 * @param WP_REST_Request $request Request object.
 	 * @return WP_REST_Response Response object.
 	 */
-	public function prepare_item_for_response( $comment, $request ) {
-
-		$fields = $this->get_fields_for_response( $request );
-		$data   = array();
+	public function prepare_item_for_response( $item, $request ) {
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$comment = $item;
+		$fields  = $this->get_fields_for_response( $request );
+		$data    = array();
 
 		if ( in_array( 'id', $fields, true ) ) {
 			$data['id'] = (int) $comment->comment_ID;

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-post-statuses-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-post-statuses-controller.php
@@ -214,12 +214,16 @@ class WP_REST_Post_Statuses_Controller extends WP_REST_Controller {
 	 *
 	 * @since 4.7.0
 	 *
-	 * @param stdClass        $status  Post status data.
+	 * @param stdClass        $item    Post status data.
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response Post status data.
 	 */
-	public function prepare_item_for_response( $status, $request ) {
-
+	public function prepare_item_for_response( $item, $request ) {
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$status = $item;
 		$fields = $this->get_fields_for_response( $request );
 		$data   = array();
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-post-types-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-post-types-controller.php
@@ -169,11 +169,16 @@ class WP_REST_Post_Types_Controller extends WP_REST_Controller {
 	 *
 	 * @since 4.7.0
 	 *
-	 * @param WP_Post_Type    $post_type Post type object.
-	 * @param WP_REST_Request $request   Full details about the request.
+	 * @param WP_Post_Type    $item    Post type object.
+	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response Response object.
 	 */
-	public function prepare_item_for_response( $post_type, $request ) {
+	public function prepare_item_for_response( $item, $request ) {
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$post_type  = $item;
 		$taxonomies = wp_list_filter( get_object_taxonomies( $post_type->name, 'objects' ), array( 'show_in_rest' => true ) );
 		$taxonomies = wp_list_pluck( $taxonomies, 'name' );
 		$base       = ! empty( $post_type->rest_base ) ? $post_type->rest_base : $post_type->name;

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -1680,11 +1680,16 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 	 *
 	 * @since 4.7.0
 	 *
-	 * @param WP_Post         $post    Post object.
+	 * @param WP_Post         $item    Post object.
 	 * @param WP_REST_Request $request Request object.
 	 * @return WP_REST_Response Response object.
 	 */
-	public function prepare_item_for_response( $post, $request ) {
+	public function prepare_item_for_response( $item, $request ) {
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$post            = $item;
 		$GLOBALS['post'] = $post;
 
 		setup_postdata( $post );

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
@@ -134,20 +134,20 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 	 *
 	 * @since 4.7.2
 	 *
-	 * @param int $parent Supplied ID.
+	 * @param int $parent_id Supplied ID.
 	 * @return WP_Post|WP_Error Post object if ID is valid, WP_Error otherwise.
 	 */
-	protected function get_parent( $parent ) {
+	protected function get_parent( $parent_id ) {
 		$error = new WP_Error(
 			'rest_post_invalid_parent',
 			__( 'Invalid post parent ID.' ),
 			array( 'status' => 404 )
 		);
-		if ( (int) $parent <= 0 ) {
+		if ( (int) $parent_id <= 0 ) {
 			return $error;
 		}
 
-		$parent = get_post( (int) $parent );
+		$parent = get_post( (int) $parent_id );
 		if ( empty( $parent ) || empty( $parent->ID ) || $this->parent_post_type !== $parent->post_type ) {
 			return $error;
 		}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
@@ -536,11 +536,16 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 	 *
 	 * @since 4.7.0
 	 *
-	 * @param WP_Post         $post    Post revision object.
+	 * @param WP_Post         $item    Post revision object.
 	 * @param WP_REST_Request $request Request object.
 	 * @return WP_REST_Response Response object.
 	 */
-	public function prepare_item_for_response( $post, $request ) {
+	public function prepare_item_for_response( $item, $request ) {
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$post            = $item;
 		$GLOBALS['post'] = $post;
 
 		setup_postdata( $post );

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-search-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-search-controller.php
@@ -187,11 +187,11 @@ class WP_REST_Search_Controller extends WP_REST_Controller {
 	 * @since 5.0.0
 	 * @since 5.6.0 The `$id` parameter can accept a string.
 	 *
-	 * @param int|string      $id      ID of the item to prepare.
+	 * @param int|string      $item    ID of the item to prepare.
 	 * @param WP_REST_Request $request Request object.
 	 * @return WP_REST_Response Response object.
 	 */
-	public function prepare_item_for_response( $id, $request ) {
+	public function prepare_item_for_response( $item, $request ) {
 		$handler = $this->get_search_handler( $request );
 		if ( is_wp_error( $handler ) ) {
 			return new WP_REST_Response();
@@ -199,7 +199,7 @@ class WP_REST_Search_Controller extends WP_REST_Controller {
 
 		$fields = $this->get_fields_for_response( $request );
 
-		$data = $handler->prepare_item( $id, $fields );
+		$data = $handler->prepare_item( $item, $fields );
 		$data = $this->add_additional_fields_to_object( $data, $request );
 
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
@@ -207,7 +207,7 @@ class WP_REST_Search_Controller extends WP_REST_Controller {
 
 		$response = rest_ensure_response( $data );
 
-		$links               = $handler->prepare_item_links( $id );
+		$links               = $handler->prepare_item_links( $item );
 		$links['collection'] = array(
 			'href' => rest_url( sprintf( '%s/%s', $this->namespace, $this->rest_base ) ),
 		);

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-taxonomies-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-taxonomies-controller.php
@@ -201,12 +201,17 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 	 *
 	 * @since 4.7.0
 	 *
-	 * @param WP_Taxonomy     $taxonomy Taxonomy data.
-	 * @param WP_REST_Request $request  Full details about the request.
+	 * @param WP_Taxonomy     $item    Taxonomy data.
+	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response Response object.
 	 */
-	public function prepare_item_for_response( $taxonomy, $request ) {
-		$base = ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxonomy->name;
+	public function prepare_item_for_response( $item, $request ) {
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$taxonomy = $item;
+		$base     = ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxonomy->name;
 
 		$fields = $this->get_fields_for_response( $request );
 		$data   = array();

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -205,11 +205,16 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 	 *
 	 * @since 5.0.0
 	 *
-	 * @param WP_Theme        $theme   Theme object.
+	 * @param WP_Theme        $item    Theme object.
 	 * @param WP_REST_Request $request Request object.
 	 * @return WP_REST_Response Response object.
 	 */
-	public function prepare_item_for_response( $theme, $request ) {
+	public function prepare_item_for_response( $item, $request ) {
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$theme  = $item;
 		$data   = array();
 		$fields = $this->get_fields_for_response( $request );
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
@@ -964,12 +964,16 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 	 *
 	 * @since 4.7.0
 	 *
-	 * @param WP_User         $user    User object.
+	 * @param WP_User         $item    User object.
 	 * @param WP_REST_Request $request Request object.
 	 * @return WP_REST_Response Response object.
 	 */
-	public function prepare_item_for_response( $user, $request ) {
-
+	public function prepare_item_for_response( $item, $request ) {
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$user   = $item;
 		$data   = array();
 		$fields = $this->get_fields_for_response( $request );
 

--- a/src/wp-includes/sitemaps/providers/class-wp-sitemaps-posts.php
+++ b/src/wp-includes/sitemaps/providers/class-wp-sitemaps-posts.php
@@ -54,11 +54,17 @@ class WP_Sitemaps_Posts extends WP_Sitemaps_Provider {
 	 *
 	 * @since 5.5.0
 	 *
-	 * @param int    $page_num  Page of results.
-	 * @param string $post_type Optional. Post type name. Default empty.
+	 * @param int    $page_num       Page of results.
+	 * @param string $object_subtype Optional. Post type name. Default empty.
 	 * @return array Array of URLs for a sitemap.
 	 */
-	public function get_url_list( $page_num, $post_type = '' ) {
+	public function get_url_list( $page_num, $object_subtype = '' ) {
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$post_type = $object_subtype;
+
 		// Bail early if the queried post type is not supported.
 		$supported_types = $this->get_object_subtypes();
 

--- a/src/wp-includes/sitemaps/providers/class-wp-sitemaps-posts.php
+++ b/src/wp-includes/sitemaps/providers/class-wp-sitemaps-posts.php
@@ -149,13 +149,19 @@ class WP_Sitemaps_Posts extends WP_Sitemaps_Provider {
 	 *
 	 * @since 5.5.0
 	 *
-	 * @param string $post_type Optional. Post type name. Default empty.
+	 * @param string $object_subtype Optional. Post type name. Default empty.
 	 * @return int Total number of pages.
 	 */
-	public function get_max_num_pages( $post_type = '' ) {
-		if ( empty( $post_type ) ) {
+	public function get_max_num_pages( $object_subtype = '' ) {
+		if ( empty( $object_subtype ) ) {
 			return 0;
 		}
+
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$post_type = $object_subtype;
 
 		/**
 		 * Filters the max number of pages before it is generated.

--- a/src/wp-includes/sitemaps/providers/class-wp-sitemaps-taxonomies.php
+++ b/src/wp-includes/sitemaps/providers/class-wp-sitemaps-taxonomies.php
@@ -136,13 +136,19 @@ class WP_Sitemaps_Taxonomies extends WP_Sitemaps_Provider {
 	 *
 	 * @since 5.5.0
 	 *
-	 * @param string $taxonomy Taxonomy name.
+	 * @param string $object_subtype Taxonomy name.
 	 * @return int Total number of pages.
 	 */
-	public function get_max_num_pages( $taxonomy = '' ) {
-		if ( empty( $taxonomy ) ) {
+	public function get_max_num_pages( $object_subtype = '' ) {
+		if ( empty( $object_subtype ) ) {
 			return 0;
 		}
+
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$taxonomy = $object_subtype;
 
 		/**
 		 * Filters the max number of pages before it is generated.

--- a/src/wp-includes/sitemaps/providers/class-wp-sitemaps-taxonomies.php
+++ b/src/wp-includes/sitemaps/providers/class-wp-sitemaps-taxonomies.php
@@ -52,11 +52,16 @@ class WP_Sitemaps_Taxonomies extends WP_Sitemaps_Provider {
 	 *
 	 * @since 5.5.0
 	 *
-	 * @param int    $page_num Page of results.
-	 * @param string $taxonomy Optional. Taxonomy name. Default empty.
+	 * @param int    $page_num       Page of results.
+	 * @param string $object_subtype Optional. Taxonomy name. Default empty.
 	 * @return array Array of URLs for a sitemap.
 	 */
-	public function get_url_list( $page_num, $taxonomy = '' ) {
+	public function get_url_list( $page_num, $object_subtype = '' ) {
+		/*
+		 * Renamed generic parameter name to more descriptive, specific name for use in the function.
+		 * Also see Trac #51553.
+		 */
+		$taxonomy        = $object_subtype;
 		$supported_types = $this->get_object_subtypes();
 
 		// Bail early if the queried taxonomy is not supported.

--- a/src/wp-includes/widgets/class-wp-widget-media.php
+++ b/src/wp-includes/widgets/class-wp-widget-media.php
@@ -265,12 +265,13 @@ abstract class WP_Widget_Media extends WP_Widget {
 	 * @see WP_REST_Request::sanitize_params()
 	 *
 	 * @param array $new_instance Values just sent to be saved.
-	 * @param array $instance     Previously saved values from database.
+	 * @param array $old_instance Previously saved values from database.
 	 * @return array Updated safe values to be saved.
 	 */
-	public function update( $new_instance, $instance ) {
+	public function update( $new_instance, $old_instance ) {
 
-		$schema = $this->get_instance_schema();
+		$instance = $old_instance;
+		$schema   = $this->get_instance_schema();
 		foreach ( $schema as $field => $field_schema ) {
 			if ( ! array_key_exists( $field, $new_instance ) ) {
 				continue;


### PR DESCRIPTION
This PR fixes all known instances of parameter name mismatches between methods in child classes vs the names used in the parent class.

Notes:
* Whenever the parameter name which was originally used in the method signature of the child class was significantly more descriptive than the parameter name used in the method signature of the parent class, the parameter name in the method signature has been changed, but an assignment to the "old" parameter name is made near the top of the function to keep the readability of the rest of the function code intact. This also reduces code churn.
* While doing these renames I noticed that a _lot_ of these functions violate the LISKOV principle by having covariant parameters, while parameters are supposed to be contravariant. This is outside the scope of this ticket, but is a concern.
    Ref: https://www.php.net/manual/en/language.oop5.variance.php

Trac ticket: https://core.trac.wordpress.org/ticket/51553

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
