### PR TITLE
PHP 8.0: fix fatal error "Non-static method cannot be called statically" (Trac: 51559)

### DIFF
--- a/src/wp-includes/Text/Diff.php
+++ b/src/wp-includes/Text/Diff.php
@@ -220,14 +220,12 @@ class Text_Diff {
     /**
      * Determines the location of the system temporary directory.
      *
-     * @static
-     *
      * @access protected
      *
      * @return string  A directory name which can be used for temp files.
      *                 Returns false if one could not be found.
      */
-    function _getTempDir()
+    static function _getTempDir()
     {
         $tmp_locations = array('/tmp', '/var/tmp', 'c:\WUTemp', 'c:\temp',
                                'c:\windows\temp', 'c:\winnt\temp');


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/51559

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
