### PR TITLE
PHP 8.0: fix "argument # must be passed by reference" warning (Trac: 50913)

### DIFF
--- a/src/wp-includes/pomo/po.php
+++ b/src/wp-includes/pomo/po.php
@@ -212,11 +212,11 @@ if ( ! class_exists( 'PO', false ) ) :
 		/**
 		 * Builds a string from the entry for inclusion in PO file
 		 *
-		 * @param Translation_Entry $entry the entry to convert to po string (passed by reference).
+		 * @param Translation_Entry $entry the entry to convert to po string.
 		 * @return string|false PO-style formatted string for the entry or
 		 *  false if the entry is empty
 		 */
-		public static function export_entry( &$entry ) {
+		public static function export_entry( $entry ) {
 			if ( null === $entry->singular || '' === $entry->singular ) {
 				return false;
 			}


### PR DESCRIPTION
WordPress should not throw any notices.

`array_map()` passes by value, while `array_walk()` passes by reference.

The use of `array_map()` on line 52 within the `export_entries()` method will cause a "Warning: PO::export_entry(): Argument #1 ($entry) must be passed by reference, value given" warning on PHP 8.0 because the `export_entry()` method is declared to expect the `$entry` object to be passed by reference.

Since PHP 5.0, objects are passed by reference by default and this does not have to be declared in the function signature of a method expecting this anymore.

Also, the code within the method doesn't even try to change `$entry` and return a value.

So, all in all, the reference in the function declaration is redundant, old-school and should be removed.

While this could be considered a BC-break, I have done a search for use of this method in plugins and reviewed a significant number of the returned results. None of these would run into trouble with the change now made. Rather this change fixes the same issue for a number of plugins also using `array_map()`.

All the same, this change should be mentioned in a dev-note as it is a very small and insignificant BC-break.

Search results: https://wpdirectory.net/search/01EMWBEKAM2B6ECSTCTEDAZGQW


Trac ticket: https://core.trac.wordpress.org/ticket/50913

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
