### PR TITLE
Try different matrix for PHP/memcached

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -112,27 +112,33 @@ jobs:
   # - Reports test results to the Distributed Hosting Tests.
   # - todo: Configure Slack notifications for failing tests.
   test-php:
-    name: ${{ matrix.php_versions }} on ${{ matrix.os }}
+    name: ${{ matrix.php }} on ${{ matrix.os }}
     needs: setup-wordpress
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        php_versions: [ '8.0', 7.4, '7.4 with memcached', 7.3, 7.2, 7.1, '7.0', 5.6.20 ]
+        php: [ '8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6.20' ]
         os: [ ubuntu-latest ]
+        memcached: [ false ]
+        include:
+          # Include job for PHP 7.4 with memcached.
+          - php: '7.4'
+            os: ubuntu-latest
+            memcached: true
+          # Report the results of the PHP 7.4 (without memcached) job.
+          - php: '7.4'
+            os: ubuntu-latest
+            memcached: false
+            report: true
     env:
-      LOCAL_PHP: ${{ matrix.php_versions }}-fpm
+      LOCAL_PHP: ${{ matrix.php }}-fpm
+      LOCAL_PHP_MEMCACHED: ${{ matrix.memcached }}
 
     steps:
       - name: Configure environment variables
         run: |
           echo "PHP_FPM_UID=$(id -u)" >> $GITHUB_ENV
           echo "PHP_FPM_GID=$(id -g)" >> $GITHUB_ENV
-
-      - name: Configure memcached
-        if: ${{ contains( matrix.php_versions, 'memcached' ) }}
-        run: |
-          echo "LOCAL_PHP=$(echo ${{ matrix.php_versions }} | cut -c1-3)-fpm" >> $GITHUB_ENV
-          echo "LOCAL_PHP_MEMCACHED=true" >> $GITHUB_ENV
 
       - name: Download the built WordPress artifact
         uses: actions/download-artifact@v2
@@ -203,7 +209,7 @@ jobs:
 
       # The memcached server needs to start after the Docker network has been set up with `npm run env:start`.
       - name: Start the Memcached server.
-        if: ${{ contains( matrix.php_versions, 'memcached' ) }}
+        if: ${{ matrix.memcached }}
         run: |
           cp tests/phpunit/includes/object-cache.php build/wp-content/object-cache.php
           docker run --name memcached --net $(basename "$PWD")_wpdevnet -d memcached
@@ -258,7 +264,7 @@ jobs:
         run: LOCAL_PHP_XDEBUG=true npm run test:php -- -v --group xdebug --exclude-group __fakegroup__
 
       - name: WordPress Test Reporter
-        if: ${{ matrix.php_versions == '7.4' }}
+        if: ${{ matrix.report }}
         uses: actions/checkout@v2
         with:
           repository: 'WordPress/phpunit-test-runner'

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -112,7 +112,7 @@ jobs:
   # - Reports test results to the Distributed Hosting Tests.
   # - todo: Configure Slack notifications for failing tests.
   test-php:
-    name: ${{ matrix.php }} on ${{ matrix.os }}
+    name: ${{ matrix.php }}${{ matrix.memcached && ' (with memcached)' || '' }} on ${{ matrix.os }}
     needs: setup-wordpress
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -116,6 +116,7 @@ jobs:
     needs: setup-wordpress
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         php: [ '8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6.20' ]
         os: [ ubuntu-latest ]

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -112,7 +112,7 @@ jobs:
   # - Reports test results to the Distributed Hosting Tests.
   # - todo: Configure Slack notifications for failing tests.
   test-php:
-    name: ${{ matrix.php }}${{ matrix.memcached && ' (with memcached)' || '' }} on ${{ matrix.os }}
+    name: ${{ matrix.php }}${{ matrix.memcached && ' with memcached' || '' }} on ${{ matrix.os }}
     needs: setup-wordpress
     runs-on: ${{ matrix.os }}
     strategy:
@@ -126,7 +126,7 @@ jobs:
           - php: '7.4'
             os: ubuntu-latest
             memcached: true
-          # Report the results of the PHP 7.4 (without memcached) job.
+          # Report the results of the PHP 7.4 without memcached job.
           - php: '7.4'
             os: ubuntu-latest
             memcached: false

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -116,7 +116,6 @@ jobs:
     needs: setup-wordpress
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
       matrix:
         php: [ '8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6.20' ]
         os: [ ubuntu-latest ]

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -247,7 +247,7 @@ jobs:
       - name: Run tests as a multisite install
         run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose -c tests/phpunit/multisite.xml
 
-      - name: Run mutlisite file tests
+      - name: Run ms-files tests as a multisite install
         run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose -c tests/phpunit/multisite.xml --group ms-files
 
       - name: Run external HTTP tests

--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -181,20 +181,26 @@ abstract class WP_UnitTestCase_Base extends PHPUnit\Framework\TestCase {
 	/**
 	 * Allow tests to be skipped on some automated runs.
 	 *
-	 * For test runs on Travis for something other than trunk/master
-	 * we want to skip tests that only need to run for master.
+	 * For test runs on Travis/GitHub Actions for something
+	 * other than trunk/master, we want to skip tests that
+	 * only need to run for master.
 	 */
 	public function skipOnAutomatedBranches() {
 		// https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
 		$travis_branch       = getenv( 'TRAVIS_BRANCH' );
 		$travis_pull_request = getenv( 'TRAVIS_PULL_REQUEST' );
 
-		if ( ! $travis_branch || ! $travis_pull_request ) {
-			return;
-		}
+		// https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables#default-environment-variables
+		$github_branch = getenv( 'GITHUB_REF' );
 
-		if ( 'master' !== $travis_branch || 'false' !== $travis_pull_request ) {
-			$this->markTestSkipped( 'For automated test runs, this test is only run on trunk/master' );
+		if ( $travis_branch && $travis_pull_request ) {
+			if ( 'master' !== $travis_branch || 'false' !== $travis_pull_request ) {
+				$this->markTestSkipped( 'For automated test runs, this test is only run on trunk/master' );
+			}
+		} elseif ( $github_branch ) {
+			if ( false !== strpos( $github_branch, 'master' ) ) {
+				$this->markTestSkipped( 'For automated test runs, this test is only run on trunk/master' );
+			}
 		}
 	}
 


### PR DESCRIPTION
This updates the matrix to make use of https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#example-including-additional-values-into-combinations and https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#example-including-new-combinations. This should make it more clear what is tested right from reading the matrix.

It also renames `php_versions` to `php` which seems to be the more common syntax for matrix keys. `fail-fast` can be ignored, I only added it to get other jobs running while some are having issues with the external HTTP tests.

Trac ticket: https://core.trac.wordpress.org/ticket/50401

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
