### PR TITLE
Various CS/QA fixes (Trac: 50767)

### DIFF
--- a/src/wp-admin/edit-comments.php
+++ b/src/wp-admin/edit-comments.php
@@ -120,7 +120,7 @@ if ( $doaction ) {
 		$redirect_to = add_query_arg( 'deleted', $deleted, $redirect_to );
 	}
 	if ( $trashed || $spammed ) {
-		$redirect_to = add_query_arg( 'ids', join( ',', $comment_ids ), $redirect_to );
+		$redirect_to = add_query_arg( 'ids', implode( ',', $comment_ids ), $redirect_to );
 	}
 
 	wp_safe_redirect( $redirect_to );

--- a/src/wp-admin/edit.php
+++ b/src/wp-admin/edit.php
@@ -126,7 +126,7 @@ if ( $doaction ) {
 			$sendback = add_query_arg(
 				array(
 					'trashed' => $trashed,
-					'ids'     => join( ',', $post_ids ),
+					'ids'     => implode( ',', $post_ids ),
 					'locked'  => $locked,
 				),
 				$sendback
@@ -442,7 +442,7 @@ foreach ( $bulk_counts as $message => $count ) {
 }
 
 if ( $messages ) {
-	echo '<div id="message" class="updated notice is-dismissible"><p>' . join( ' ', $messages ) . '</p></div>';
+	echo '<div id="message" class="updated notice is-dismissible"><p>' . implode( ' ', $messages ) . '</p></div>';
 }
 unset( $messages );
 

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -162,7 +162,7 @@ function wp_ajax_ajax_tag_search() {
 		)
 	);
 
-	echo join( "\n", $results );
+	echo implode( "\n", $results );
 	wp_die();
 }
 

--- a/src/wp-admin/includes/class-pclzip.php
+++ b/src/wp-admin/includes/class-pclzip.php
@@ -1171,7 +1171,7 @@
     $this->privErrorReset();
 
     // ----- Look if the $p_archive is a PclZip object
-    if ((is_object($p_archive)) && (get_class($p_archive) == 'pclzip'))
+    if ((is_object($p_archive)) && $p_archive instanceof pclzip)
     {
 
       // ----- Duplicate the archive
@@ -1235,7 +1235,7 @@
     }
 
     // ----- Look if the $p_archive_to_add is a PclZip object
-    if ((is_object($p_archive_to_add)) && (get_class($p_archive_to_add) == 'pclzip'))
+    if ((is_object($p_archive_to_add)) && $p_archive_to_add instanceof pclzip)
     {
 
       // ----- Merge the archive

--- a/src/wp-admin/includes/class-wp-comments-list-table.php
+++ b/src/wp-admin/includes/class-wp-comments-list-table.php
@@ -615,7 +615,7 @@ class WP_Comments_List_Table extends WP_List_Table {
 		if ( ! $the_comment_class ) {
 			$the_comment_class = '';
 		}
-		$the_comment_class = join( ' ', get_comment_class( $the_comment_class, $comment, $comment->comment_post_ID ) );
+		$the_comment_class = implode( ' ', get_comment_class( $the_comment_class, $comment, $comment->comment_post_ID ) );
 
 		if ( $comment->comment_post_ID > 0 ) {
 			$post = get_post( $comment->comment_post_ID );

--- a/src/wp-admin/includes/class-wp-importer.php
+++ b/src/wp-admin/includes/class-wp-importer.php
@@ -291,7 +291,7 @@ function get_cli_args( $param, $required = false ) {
 	$last_arg = null;
 	$return   = null;
 
-	$il = sizeof( $args );
+	$il = count( $args );
 
 	for ( $i = 1, $il; $i < $il; $i++ ) {
 		if ( (bool) preg_match( '/^--(.+)/', $args[ $i ], $match ) ) {

--- a/src/wp-admin/includes/class-wp-list-table.php
+++ b/src/wp-admin/includes/class-wp-list-table.php
@@ -947,7 +947,7 @@ class WP_List_Table {
 		if ( ! empty( $infinite_scroll ) ) {
 			$pagination_links_class .= ' hide-if-js';
 		}
-		$output .= "\n<span class='$pagination_links_class'>" . join( "\n", $page_links ) . '</span>';
+		$output .= "\n<span class='$pagination_links_class'>" . implode( "\n", $page_links ) . '</span>';
 
 		if ( $total_pages ) {
 			$page_class = $total_pages < 2 ? ' one-page' : '';
@@ -1213,7 +1213,7 @@ class WP_List_Table {
 			$id    = $with_id ? "id='$column_key'" : '';
 
 			if ( ! empty( $class ) ) {
-				$class = "class='" . join( ' ', $class ) . "'";
+				$class = "class='" . implode( ' ', $class ) . "'";
 			}
 
 			echo "<$tag $scope $id $class>$column_display_name</$tag>";

--- a/src/wp-admin/includes/class-wp-list-table.php
+++ b/src/wp-admin/includes/class-wp-list-table.php
@@ -1044,7 +1044,7 @@ class WP_List_Table {
 		// If the primary column doesn't exist,
 		// fall back to the first non-checkbox column.
 		if ( ! isset( $columns[ $default ] ) ) {
-			$default = WP_List_Table::get_default_primary_column_name();
+			$default = self::get_default_primary_column_name();
 		}
 
 		/**

--- a/src/wp-admin/includes/class-wp-media-list-table.php
+++ b/src/wp-admin/includes/class-wp-media-list-table.php
@@ -614,7 +614,7 @@ class WP_Media_List_Table extends WP_List_Table {
 					);
 				}
 				/* translators: Used between list items, there is a space after the comma. */
-				echo join( __( ', ' ), $out );
+				echo implode( __( ', ' ), $out );
 			} else {
 				echo '<span aria-hidden="true">&#8212;</span><span class="screen-reader-text">' . get_taxonomy( $taxonomy )->labels->no_terms . '</span>';
 			}

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -1219,7 +1219,7 @@ class WP_Posts_List_Table extends WP_List_Table {
 				$term_links = apply_filters( 'post_column_taxonomy_links', $term_links, $taxonomy, $terms );
 
 				/* translators: Used between list items, there is a space after the comma. */
-				echo join( __( ', ' ), $term_links );
+				echo implode( __( ', ' ), $term_links );
 			} else {
 				echo '<span aria-hidden="true">&#8212;</span><span class="screen-reader-text">' . $taxonomy_object->labels->no_terms . '</span>';
 			}

--- a/src/wp-admin/includes/class-wp-screen.php
+++ b/src/wp-admin/includes/class-wp-screen.php
@@ -377,7 +377,7 @@ final class WP_Screen {
 				return $screen;
 			}
 		} else {
-			$screen     = new WP_Screen();
+			$screen     = new self();
 			$screen->id = $id;
 		}
 

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -1855,7 +1855,7 @@ class WP_Site_Health {
 			$hosts = explode( ',', WP_ACCESSIBLE_HOSTS );
 		}
 
-		if ( $blocked && 0 === sizeof( $hosts ) ) {
+		if ( $blocked && 0 === count( $hosts ) ) {
 			$result['status'] = 'critical';
 
 			$result['label'] = __( 'HTTP requests are blocked' );
@@ -1870,7 +1870,7 @@ class WP_Site_Health {
 			);
 		}
 
-		if ( $blocked && 0 < sizeof( $hosts ) ) {
+		if ( $blocked && 0 < count( $hosts ) ) {
 			$result['status'] = 'recommended';
 
 			$result['label'] = __( 'HTTP requests are partially blocked' );

--- a/src/wp-admin/includes/export.php
+++ b/src/wp-admin/includes/export.php
@@ -534,7 +534,7 @@ function export_wp( $args = array() ) {
 
 		// Fetch 20 posts at a time rather than loading the entire table into memory.
 		while ( $next_posts = array_splice( $post_ids, 0, 20 ) ) {
-			$where = 'WHERE ID IN (' . join( ',', $next_posts ) . ')';
+			$where = 'WHERE ID IN (' . implode( ',', $next_posts ) . ')';
 			$posts = $wpdb->get_results( "SELECT * FROM {$wpdb->posts} $where" );
 
 			// Begin Loop.

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -489,7 +489,7 @@ function wp_edit_theme_plugin_file( $args ) {
 
 	$previous_content = file_get_contents( $real_file );
 
-	if ( ! is_writeable( $real_file ) ) {
+	if ( ! is_writable( $real_file ) ) {
 		return new WP_Error( 'file_not_writable' );
 	}
 

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -1118,7 +1118,7 @@ function image_align_input_fields( $post, $checked = '' ) {
 			" /><label for='image-align-{$name}-{$post->ID}' class='align image-align-{$name}-label'>$label</label>";
 	}
 
-	return join( "\n", $out );
+	return implode( "\n", $out );
 }
 
 /**
@@ -1195,7 +1195,7 @@ function image_size_input_fields( $post, $check = '' ) {
 	return array(
 		'label' => __( 'Size' ),
 		'input' => 'html',
-		'html'  => join( "\n", $out ),
+		'html'  => implode( "\n", $out ),
 	);
 }
 
@@ -1424,7 +1424,7 @@ function get_attachment_fields_to_edit( $post, $errors = null ) {
 			$values[] = $term->slug;
 		}
 
-		$t['value'] = join( ', ', $values );
+		$t['value'] = implode( ', ', $values );
 
 		$form_fields[ $taxonomy ] = $t;
 	}
@@ -1784,7 +1784,7 @@ function get_media_item( $attachment_id, $args = null ) {
 		}
 
 		if ( ! empty( $field['helps'] ) ) {
-			$item .= "<p class='help'>" . join( "</p>\n<p class='help'>", array_unique( (array) $field['helps'] ) ) . '</p>';
+			$item .= "<p class='help'>" . implode( "</p>\n<p class='help'>", array_unique( (array) $field['helps'] ) ) . '</p>';
 		}
 		$item .= "</td>\n\t\t</tr>\n";
 
@@ -1883,7 +1883,7 @@ function get_compat_media_markup( $attachment_id, $args = null ) {
 				$values[] = $term->slug;
 			}
 
-			$t['value']    = join( ', ', $values );
+			$t['value']    = implode( ', ', $values );
 			$t['taxonomy'] = true;
 
 			$form_fields[ $taxonomy ] = $t;
@@ -1976,7 +1976,7 @@ function get_compat_media_markup( $attachment_id, $args = null ) {
 		}
 
 		if ( ! empty( $field['helps'] ) ) {
-			$item .= "<p class='help'>" . join( "</p>\n<p class='help'>", array_unique( (array) $field['helps'] ) ) . '</p>';
+			$item .= "<p class='help'>" . implode( "</p>\n<p class='help'>", array_unique( (array) $field['helps'] ) ) . '</p>';
 		}
 
 		$item .= "</td>\n\t\t</tr>\n";

--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -121,7 +121,7 @@ function insert_with_markers( $filename, $marker, $insertion ) {
 		if ( $perms ) {
 			chmod( $filename, $perms | 0644 );
 		}
-	} elseif ( ! is_writeable( $filename ) ) {
+	} elseif ( ! is_writable( $filename ) ) {
 		return false;
 	}
 

--- a/src/wp-admin/includes/revision.php
+++ b/src/wp-admin/includes/revision.php
@@ -275,7 +275,7 @@ function wp_prepare_revisions_for_js( $post, $selected_revision_id, $from = null
 	 * If we only have one revision, the initial revision is missing; This happens
 	 * when we have an autsosave and the user has clicked 'View the Autosave'
 	 */
-	if ( 1 === sizeof( $revisions ) ) {
+	if ( 1 === count( $revisions ) ) {
 		$revisions[ $post->ID ] = array(
 			'id'         => $post->ID,
 			'title'      => get_the_title( $post->ID ),

--- a/src/wp-admin/includes/taxonomy.php
+++ b/src/wp-admin/includes/taxonomy.php
@@ -278,7 +278,7 @@ function get_terms_to_edit( $post_id, $taxonomy = 'post_tag' ) {
 		$term_names[] = $term->name;
 	}
 
-	$terms_to_edit = esc_attr( join( ',', $term_names ) );
+	$terms_to_edit = esc_attr( implode( ',', $term_names ) );
 
 	/**
 	 * Filters the comma-separated list of terms available to edit.

--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -1112,7 +1112,7 @@ function upgrade_130() {
 			$limit    = $option->dupes - 1;
 			$dupe_ids = $wpdb->get_col( $wpdb->prepare( "SELECT option_id FROM $wpdb->options WHERE option_name = %s LIMIT %d", $option->option_name, $limit ) );
 			if ( $dupe_ids ) {
-				$dupe_ids = join( ',', $dupe_ids );
+				$dupe_ids = implode( ',', $dupe_ids );
 				$wpdb->query( "DELETE FROM $wpdb->options WHERE option_id IN ($dupe_ids)" );
 			}
 		}

--- a/src/wp-admin/link.php
+++ b/src/wp-admin/link.php
@@ -60,7 +60,7 @@ switch ( $action ) {
 			wp_redirect( $this_file );
 			exit;
 		}
-		$all_links = join( ',', $linkcheck );
+		$all_links = implode( ',', $linkcheck );
 		/*
 		 * Should now have an array of links we can change:
 		 *     $q = $wpdb->query("update $wpdb->links SET link_category='$category' WHERE link_id IN ($all_links)");

--- a/src/wp-admin/menu-header.php
+++ b/src/wp-admin/menu-header.php
@@ -106,7 +106,7 @@ function _wp_menu_output( $menu, $submenu, $submenu_as_parent = true ) {
 			$class[] = esc_attr( $item[4] );
 		}
 
-		$class     = $class ? ' class="' . join( ' ', $class ) . '"' : '';
+		$class     = $class ? ' class="' . implode( ' ', $class ) . '"' : '';
 		$id        = ! empty( $item[5] ) ? ' id="' . preg_replace( '|[^a-zA-Z0-9_:.]|', '-', $item[5] ) . '"' : '';
 		$img       = '';
 		$img_style = '';
@@ -240,7 +240,7 @@ function _wp_menu_output( $menu, $submenu, $submenu_as_parent = true ) {
 					$class[] = esc_attr( $sub_item[4] );
 				}
 
-				$class = $class ? ' class="' . join( ' ', $class ) . '"' : '';
+				$class = $class ? ' class="' . implode( ' ', $class ) . '"' : '';
 
 				$menu_hook = get_plugin_page_hook( $sub_item[2], $item[2] );
 				$sub_file  = $sub_item[2];

--- a/src/wp-admin/network/themes.php
+++ b/src/wp-admin/network/themes.php
@@ -89,7 +89,7 @@ if ( $action ) {
 			echo '<div class="wrap">';
 			echo '<h1>' . esc_html( $title ) . '</h1>';
 
-			$url = self_admin_url( 'update.php?action=update-selected-themes&amp;themes=' . urlencode( join( ',', $themes ) ) );
+			$url = self_admin_url( 'update.php?action=update-selected-themes&amp;themes=' . urlencode( implode( ',', $themes ) ) );
 			$url = wp_nonce_url( $url, 'bulk-update-themes' );
 
 			echo "<iframe src='$url' style='width: 100%; height:100%; min-height:850px;'></iframe>";

--- a/src/wp-admin/plugin-editor.php
+++ b/src/wp-admin/plugin-editor.php
@@ -195,7 +195,7 @@ $content = esc_textarea( $content );
 <h2>
 	<?php
 	if ( is_plugin_active( $plugin ) ) {
-		if ( is_writeable( $real_file ) ) {
+		if ( is_writable( $real_file ) ) {
 			/* translators: %s: Plugin file name. */
 			printf( __( 'Editing %s (active)' ), '<strong>' . esc_html( $file ) . '</strong>' );
 		} else {
@@ -203,7 +203,7 @@ $content = esc_textarea( $content );
 			printf( __( 'Browsing %s (active)' ), '<strong>' . esc_html( $file ) . '</strong>' );
 		}
 	} else {
-		if ( is_writeable( $real_file ) ) {
+		if ( is_writable( $real_file ) ) {
 			/* translators: %s: Plugin file name. */
 			printf( __( 'Editing %s (inactive)' ), '<strong>' . esc_html( $file ) . '</strong>' );
 		} else {
@@ -275,7 +275,7 @@ $content = esc_textarea( $content );
 		</div>
 	<?php endif; ?>
 
-	<?php if ( is_writeable( $real_file ) ) : ?>
+	<?php if ( is_writable( $real_file ) ) : ?>
 		<div class="editor-notices">
 		<?php if ( in_array( $plugin, (array) get_option( 'active_plugins', array() ), true ) ) { ?>
 			<div class="notice notice-warning inline active-plugin-edit-warning">

--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -162,7 +162,7 @@ if ( $action ) {
 			echo '<div class="wrap">';
 			echo '<h1>' . esc_html( $title ) . '</h1>';
 
-			$url = self_admin_url( 'update.php?action=update-selected&amp;plugins=' . urlencode( join( ',', $plugins ) ) );
+			$url = self_admin_url( 'update.php?action=update-selected&amp;plugins=' . urlencode( implode( ',', $plugins ) ) );
 			$url = wp_nonce_url( $url, 'bulk-update-plugins' );
 
 			echo "<iframe src='$url' style='width: 100%; height:100%; min-height:850px;'></iframe>";

--- a/src/wp-admin/theme-editor.php
+++ b/src/wp-admin/theme-editor.php
@@ -301,7 +301,7 @@ else :
 				<?php if ( is_child_theme() && $theme->get_stylesheet() === get_template() ) : ?>
 					<div class="notice notice-warning inline">
 						<p>
-							<?php if ( is_writeable( $file ) ) : ?>
+							<?php if ( is_writable( $file ) ) : ?>
 								<strong><?php _e( 'Caution:' ); ?></strong>
 							<?php endif; ?>
 							<?php _e( 'This is a file in your current parent theme.' ); ?>
@@ -309,7 +309,7 @@ else :
 					</div>
 				<?php endif; ?>
 			</div>
-			<?php if ( is_writeable( $file ) ) : ?>
+			<?php if ( is_writable( $file ) ) : ?>
 				<p class="submit">
 					<?php submit_button( __( 'Update File' ), 'primary', 'submit', false ); ?>
 					<span class="spinner"></span>

--- a/src/wp-admin/upload.php
+++ b/src/wp-admin/upload.php
@@ -162,7 +162,7 @@ if ( $doaction ) {
 			$location = add_query_arg(
 				array(
 					'trashed' => count( $post_ids ),
-					'ids'     => join( ',', $post_ids ),
+					'ids'     => implode( ',', $post_ids ),
 				),
 				$location
 			);

--- a/src/wp-content/themes/twentytwenty/inc/starter-content.php
+++ b/src/wp-content/themes/twentytwenty/inc/starter-content.php
@@ -48,7 +48,7 @@ function twentytwenty_get_starter_content() {
 				'post_title'   => __( 'The New UMoMA Opens its Doors', 'twentytwenty' ),
 				// Use the above featured image with the predefined about page.
 				'thumbnail'    => '{{image-opening}}',
-				'post_content' => join(
+				'post_content' => implode(
 					'',
 					array(
 						'<!-- wp:group {"align":"wide"} -->',

--- a/src/wp-includes/Text/Diff.php
+++ b/src/wp-includes/Text/Diff.php
@@ -276,7 +276,7 @@ class Text_Diff {
 
         $prevtype = null;
         foreach ($this->_edits as $edit) {
-            if ($prevtype == get_class($edit)) {
+            if ($edit instanceof $prevtype) {
                 trigger_error("Edit sequence is non-optimal", E_USER_ERROR);
             }
             $prevtype = get_class($edit);

--- a/src/wp-includes/bookmark-template.php
+++ b/src/wp-includes/bookmark-template.php
@@ -234,7 +234,7 @@ function wp_list_bookmarks( $args = '' ) {
 		$parsed_args['class'] = explode( ' ', $parsed_args['class'] );
 	}
 	$parsed_args['class'] = array_map( 'sanitize_html_class', $parsed_args['class'] );
-	$parsed_args['class'] = trim( join( ' ', $parsed_args['class'] ) );
+	$parsed_args['class'] = trim( implode( ' ', $parsed_args['class'] ) );
 
 	if ( $parsed_args['categorize'] ) {
 		$cats = get_terms(

--- a/src/wp-includes/category-template.php
+++ b/src/wp-includes/category-template.php
@@ -1010,11 +1010,11 @@ function wp_generate_tag_cloud( $tags, $args = '' ) {
 			 * Note: this is redundant but doesn't harm.
 			 */
 			$return  = "<ul class='wp-tag-cloud' role='list'>\n\t<li>";
-			$return .= join( "</li>\n\t<li>", $a );
+			$return .= implode( "</li>\n\t<li>", $a );
 			$return .= "</li>\n</ul>\n";
 			break;
 		default:
-			$return = join( $args['separator'], $a );
+			$return = implode( $args['separator'], $a );
 			break;
 	}
 
@@ -1349,7 +1349,7 @@ function get_the_term_list( $post_id, $taxonomy, $before = '', $sep = '', $after
 	 */
 	$term_links = apply_filters( "term_links-{$taxonomy}", $links );  // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 
-	return $before . join( $sep, $term_links ) . $after;
+	return $before . implode( $sep, $term_links ) . $after;
 }
 
 /**

--- a/src/wp-includes/class-json.php
+++ b/src/wp-includes/class-json.php
@@ -918,7 +918,7 @@ class Services_JSON
 
         if (class_exists('pear')) {
             return PEAR::isError($data, $code);
-        } elseif (is_object($data) && (get_class($data) == 'services_json_error' ||
+        } elseif (is_object($data) && ($data instanceof services_json_error ||
                                  is_subclass_of($data, 'services_json_error'))) {
             return true;
         }

--- a/src/wp-includes/class-walker-nav-menu.php
+++ b/src/wp-includes/class-walker-nav-menu.php
@@ -72,7 +72,7 @@ class Walker_Nav_Menu extends Walker {
 		 * @param stdClass $args    An object of `wp_nav_menu()` arguments.
 		 * @param int      $depth   Depth of menu item. Used for padding.
 		 */
-		$class_names = join( ' ', apply_filters( 'nav_menu_submenu_css_class', $classes, $args, $depth ) );
+		$class_names = implode( ' ', apply_filters( 'nav_menu_submenu_css_class', $classes, $args, $depth ) );
 		$class_names = $class_names ? ' class="' . esc_attr( $class_names ) . '"' : '';
 
 		$output .= "{$n}{$indent}<ul$class_names>{$n}";
@@ -150,7 +150,7 @@ class Walker_Nav_Menu extends Walker {
 		 * @param stdClass $args    An object of wp_nav_menu() arguments.
 		 * @param int      $depth   Depth of menu item. Used for padding.
 		 */
-		$class_names = join( ' ', apply_filters( 'nav_menu_css_class', array_filter( $classes ), $item, $args, $depth ) );
+		$class_names = implode( ' ', apply_filters( 'nav_menu_css_class', array_filter( $classes ), $item, $args, $depth ) );
 		$class_names = $class_names ? ' class="' . esc_attr( $class_names ) . '"' : '';
 
 		/**

--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -2397,7 +2397,7 @@ final class WP_Customize_Manager {
 			$notification = array();
 			foreach ( $validity->errors as $error_code => $error_messages ) {
 				$notification[ $error_code ] = array(
-					'message' => join( ' ', $error_messages ),
+					'message' => implode( ' ', $error_messages ),
 					'data'    => $validity->get_error_data( $error_code ),
 				);
 			}

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -2420,10 +2420,10 @@ class WP_Query {
 			if ( empty( $in_search_post_types ) ) {
 				$where .= ' AND 1=0 ';
 			} else {
-				$where .= " AND {$wpdb->posts}.post_type IN ('" . join( "', '", array_map( 'esc_sql', $in_search_post_types ) ) . "')";
+				$where .= " AND {$wpdb->posts}.post_type IN ('" . implode( "', '", array_map( 'esc_sql', $in_search_post_types ) ) . "')";
 			}
 		} elseif ( ! empty( $post_type ) && is_array( $post_type ) ) {
-			$where .= " AND {$wpdb->posts}.post_type IN ('" . join( "', '", esc_sql( $post_type ) ) . "')";
+			$where .= " AND {$wpdb->posts}.post_type IN ('" . implode( "', '", esc_sql( $post_type ) ) . "')";
 		} elseif ( ! empty( $post_type ) ) {
 			$where           .= $wpdb->prepare( " AND {$wpdb->posts}.post_type = %s", $post_type );
 			$post_type_object = get_post_type_object( $post_type );
@@ -2485,20 +2485,20 @@ class WP_Query {
 			}
 
 			if ( ! empty( $e_status ) ) {
-				$statuswheres[] = '(' . join( ' AND ', $e_status ) . ')';
+				$statuswheres[] = '(' . implode( ' AND ', $e_status ) . ')';
 			}
 			if ( ! empty( $r_status ) ) {
 				if ( ! empty( $q['perm'] ) && 'editable' === $q['perm'] && ! current_user_can( $edit_others_cap ) ) {
-					$statuswheres[] = "({$wpdb->posts}.post_author = $user_id " . 'AND (' . join( ' OR ', $r_status ) . '))';
+					$statuswheres[] = "({$wpdb->posts}.post_author = $user_id " . 'AND (' . implode( ' OR ', $r_status ) . '))';
 				} else {
-					$statuswheres[] = '(' . join( ' OR ', $r_status ) . ')';
+					$statuswheres[] = '(' . implode( ' OR ', $r_status ) . ')';
 				}
 			}
 			if ( ! empty( $p_status ) ) {
 				if ( ! empty( $q['perm'] ) && 'readable' === $q['perm'] && ! current_user_can( $read_private_cap ) ) {
-					$statuswheres[] = "({$wpdb->posts}.post_author = $user_id " . 'AND (' . join( ' OR ', $p_status ) . '))';
+					$statuswheres[] = "({$wpdb->posts}.post_author = $user_id " . 'AND (' . implode( ' OR ', $p_status ) . '))';
 				} else {
-					$statuswheres[] = '(' . join( ' OR ', $p_status ) . ')';
+					$statuswheres[] = '(' . implode( ' OR ', $p_status ) . ')';
 				}
 			}
 			if ( $post_status_join ) {
@@ -2669,7 +2669,7 @@ class WP_Query {
 				$post_ids[] = (int) $comment->comment_post_ID;
 			}
 
-			$post_ids = join( ',', $post_ids );
+			$post_ids = implode( ',', $post_ids );
 			$join     = '';
 			if ( $post_ids ) {
 				$where = "AND {$wpdb->posts}.ID IN ($post_ids) ";

--- a/src/wp-includes/class-wp-text-diff-renderer-table.php
+++ b/src/wp-includes/class-wp-text-diff-renderer-table.php
@@ -274,7 +274,7 @@ class WP_Text_Diff_Renderer_Table extends Text_Diff_Renderer {
 				// If they're too different, don't include any <ins> or <del>'s.
 				if ( preg_match_all( '!(<ins>.*?</ins>|<del>.*?</del>)!', $diff, $diff_matches ) ) {
 					// Length of all text between <ins> or <del>.
-					$stripped_matches = strlen( strip_tags( join( ' ', $diff_matches[0] ) ) );
+					$stripped_matches = strlen( strip_tags( implode( ' ', $diff_matches[0] ) ) );
 					// Since we count length of text between <ins> or <del> (instead of picking just one),
 					// we double the length of chars not in those tags.
 					$stripped_diff = strlen( strip_tags( $diff ) ) * 2 - $stripped_matches;

--- a/src/wp-includes/class-wp-user-query.php
+++ b/src/wp-includes/class-wp-user-query.php
@@ -279,7 +279,7 @@ class WP_User_Query {
 			}
 
 			$posts_table        = $wpdb->get_blog_prefix( $blog_id ) . 'posts';
-			$this->query_where .= " AND $wpdb->users.ID IN ( SELECT DISTINCT $posts_table.post_author FROM $posts_table WHERE $posts_table.post_status = 'publish' AND $posts_table.post_type IN ( " . join( ', ', $post_types ) . ' ) )';
+			$this->query_where .= " AND $wpdb->users.ID IN ( SELECT DISTINCT $posts_table.post_author FROM $posts_table WHERE $posts_table.post_status = 'publish' AND $posts_table.post_type IN ( " . implode( ', ', $post_types ) . ' ) )';
 		}
 
 		// nicename

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -432,7 +432,7 @@ function comment_author_url_link( $linktext = '', $before = '', $after = '', $co
  */
 function comment_class( $class = '', $comment = null, $post_id = null, $echo = true ) {
 	// Separates classes with a single space, collates classes for comment DIV.
-	$class = 'class="' . join( ' ', get_comment_class( $class, $comment, $post_id ) ) . '"';
+	$class = 'class="' . implode( ' ', get_comment_class( $class, $comment, $post_id ) ) . '"';
 
 	if ( $echo ) {
 		echo $class;

--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -3235,7 +3235,7 @@ function _prime_comment_caches( $comment_ids, $update_meta_cache = true ) {
 
 	$non_cached_ids = _get_non_cached_ids( $comment_ids, 'comment' );
 	if ( ! empty( $non_cached_ids ) ) {
-		$fresh_comments = $wpdb->get_results( sprintf( "SELECT $wpdb->comments.* FROM $wpdb->comments WHERE comment_ID IN (%s)", join( ',', array_map( 'intval', $non_cached_ids ) ) ) );
+		$fresh_comments = $wpdb->get_results( sprintf( "SELECT $wpdb->comments.* FROM $wpdb->comments WHERE comment_ID IN (%s)", implode( ',', array_map( 'intval', $non_cached_ids ) ) ) );
 
 		update_comment_cache( $fresh_comments, $update_meta_cache );
 	}

--- a/src/wp-includes/compat.php
+++ b/src/wp-includes/compat.php
@@ -127,7 +127,7 @@ function _mb_substr( $str, $start, $length = null, $encoding = null ) {
 		// If there's anything left over, repeat the loop.
 	} while ( count( $pieces ) > 1 && $str = array_pop( $pieces ) );
 
-	return join( '', array_slice( $chars, $start, $length ) );
+	return implode( '', array_slice( $chars, $start, $length ) );
 }
 
 if ( ! function_exists( 'mb_strlen' ) ) :

--- a/src/wp-includes/embed.php
+++ b/src/wp-includes/embed.php
@@ -204,7 +204,7 @@ function wp_maybe_load_embeds() {
 	 *
 	 * @param callable $handler Audio embed handler callback function.
 	 */
-	wp_embed_register_handler( 'audio', '#^https?://.+?\.(' . join( '|', wp_get_audio_extensions() ) . ')$#i', apply_filters( 'wp_audio_embed_handler', 'wp_embed_handler_audio' ), 9999 );
+	wp_embed_register_handler( 'audio', '#^https?://.+?\.(' . implode( '|', wp_get_audio_extensions() ) . ')$#i', apply_filters( 'wp_audio_embed_handler', 'wp_embed_handler_audio' ), 9999 );
 
 	/**
 	 * Filters the video embed handler callback.
@@ -213,7 +213,7 @@ function wp_maybe_load_embeds() {
 	 *
 	 * @param callable $handler Video embed handler callback function.
 	 */
-	wp_embed_register_handler( 'video', '#^https?://.+?\.(' . join( '|', wp_get_video_extensions() ) . ')$#i', apply_filters( 'wp_video_embed_handler', 'wp_embed_handler_video' ), 9999 );
+	wp_embed_register_handler( 'video', '#^https?://.+?\.(' . implode( '|', wp_get_video_extensions() ) . ')$#i', apply_filters( 'wp_video_embed_handler', 'wp_embed_handler_video' ), 9999 );
 }
 
 /**
@@ -841,7 +841,7 @@ function wp_filter_oembed_iframe_title_attribute( $result, $data, $url ) {
 
 	if ( isset( $attrs['title'] ) ) {
 		unset( $attrs['title'] );
-		$attr_string = join( ' ', wp_list_pluck( $attrs, 'whole' ) );
+		$attr_string = implode( ' ', wp_list_pluck( $attrs, 'whole' ) );
 		$result      = str_replace( $matches[0], '<iframe ' . trim( $attr_string ) . '>', $result );
 	}
 	return str_ireplace( '<iframe ', sprintf( '<iframe title="%s" ', esc_attr( $title ) ), $result );

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -722,7 +722,7 @@ function _get_wptexturize_split_regex( $shortcode_regex = '' ) {
  * @return string The regular expression
  */
 function _get_wptexturize_shortcode_regex( $tagnames ) {
-	$tagregexp = join( '|', array_map( 'preg_quote', $tagnames ) );
+	$tagregexp = implode( '|', array_map( 'preg_quote', $tagnames ) );
 	$tagregexp = "(?:$tagregexp)(?=[\\s\\]\\/])"; // Excerpt of get_shortcode_regex().
 	// phpcs:disable Squiz.Strings.ConcatenationSpacing.PaddingFound -- don't remove regex indentation
 	$regex =
@@ -824,7 +824,7 @@ function shortcode_unautop( $pee ) {
 		return $pee;
 	}
 
-	$tagregexp = join( '|', array_map( 'preg_quote', array_keys( $shortcode_tags ) ) );
+	$tagregexp = implode( '|', array_map( 'preg_quote', array_keys( $shortcode_tags ) ) );
 	$spaces    = wp_spaces_regexp();
 
 	// phpcs:disable Squiz.Strings.ConcatenationSpacing.PaddingFound,WordPress.WhiteSpace.PrecisionAlignment.Found -- don't remove regex indentation
@@ -3232,7 +3232,7 @@ function wp_targeted_link_rel_callback( $matches ) {
 	}
 
 	$atts['rel']['whole'] = 'rel="' . esc_attr( $rel ) . '"';
-	$link_html            = join( ' ', array_column( $atts, 'whole' ) );
+	$link_html            = implode( ' ', array_column( $atts, 'whole' ) );
 
 	if ( $is_escaped ) {
 		$link_html = preg_replace( '/[\'"]/', '\\\\$0', $link_html );
@@ -3696,7 +3696,7 @@ function sanitize_email( $email ) {
 	}
 
 	// Join valid subs into the new domain.
-	$domain = join( '.', $new_subs );
+	$domain = implode( '.', $new_subs );
 
 	// Put the email back together.
 	$sanitized_email = $local . '@' . $domain;

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -467,7 +467,7 @@ function size_format( $bytes, $decimals = 0 ) {
 	}
 
 	foreach ( $quant as $unit => $mag ) {
-		if ( doubleval( $bytes ) >= $mag ) {
+		if ( (float) $bytes >= $mag ) {
 			return number_format_i18n( $bytes / $mag, $decimals ) . ' ' . $unit;
 		}
 	}
@@ -3431,7 +3431,7 @@ function _default_wp_die_handler( $message, $title = '', $args = array() ) {
 				array( $message ),
 				wp_list_pluck( $parsed_args['additional_errors'], 'message' )
 			);
-			$message = "<ul>\n\t\t<li>" . join( "</li>\n\t\t<li>", $message ) . "</li>\n\t</ul>";
+			$message = "<ul>\n\t\t<li>" . implode( "</li>\n\t\t<li>", $message ) . "</li>\n\t</ul>";
 		}
 
 		$message = sprintf(
@@ -5880,7 +5880,7 @@ function wp_timezone_choice( $selected_zone, $locale = null ) {
 		}
 
 		// Build the value.
-		$value    = join( '/', $value );
+		$value    = implode( '/', $value );
 		$selected = '';
 		if ( $value === $selected_zone ) {
 			$selected = 'selected="selected" ';
@@ -5981,7 +5981,7 @@ function wp_timezone_choice( $selected_zone, $locale = null ) {
 	}
 	$structure[] = '</optgroup>';
 
-	return join( "\n", $structure );
+	return implode( "\n", $structure );
 }
 
 /**
@@ -6419,7 +6419,7 @@ function wp_debug_backtrace_summary( $ignore_class = null, $skip_frames = 0, $pr
 		}
 	}
 	if ( $pretty ) {
-		return join( ', ', array_reverse( $caller ) );
+		return implode( ', ', array_reverse( $caller ) );
 	} else {
 		return $caller;
 	}

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -4345,12 +4345,12 @@ function paginate_links( $args = '' ) {
 
 		case 'list':
 			$r .= "<ul class='page-numbers'>\n\t<li>";
-			$r .= join( "</li>\n\t<li>", $page_links );
+			$r .= implode( "</li>\n\t<li>", $page_links );
 			$r .= "</li>\n</ul>\n";
 			break;
 
 		default:
-			$r = join( "\n", $page_links );
+			$r = implode( "\n", $page_links );
 			break;
 	}
 

--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -1617,7 +1617,7 @@ function wp_dropdown_languages( $args = array() ) {
 
 	// Combine the output string.
 	$output  = sprintf( '<select name="%s" id="%s">', esc_attr( $parsed_args['name'] ), esc_attr( $parsed_args['id'] ) );
-	$output .= join( "\n", $structure );
+	$output .= implode( "\n", $structure );
 	$output .= '</select>';
 
 	if ( $parsed_args['echo'] ) {

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -1035,7 +1035,7 @@ function wp_get_attachment_image( $attachment_id, $size = 'thumbnail', $icon = f
 		$size_class = $size;
 
 		if ( is_array( $size_class ) ) {
-			$size_class = join( 'x', $size_class );
+			$size_class = implode( 'x', $size_class );
 		}
 
 		$default_attr = array(
@@ -2950,7 +2950,7 @@ function wp_audio_shortcode( $attr, $content = '' ) {
 		$html .= "<!--[if lt IE 9]><script>document.createElement('audio');</script><![endif]-->\n";
 	}
 
-	$html .= sprintf( '<audio %s controls="controls">', join( ' ', $attr_strings ) );
+	$html .= sprintf( '<audio %s controls="controls">', implode( ' ', $attr_strings ) );
 
 	$fileurl = '';
 	$source  = '<source type="%s" src="%s" />';
@@ -3218,7 +3218,7 @@ function wp_video_shortcode( $attr, $content = '' ) {
 		$html .= "<!--[if lt IE 9]><script>document.createElement('video');</script><![endif]-->\n";
 	}
 
-	$html .= sprintf( '<video %s controls="controls">', join( ' ', $attr_strings ) );
+	$html .= sprintf( '<video %s controls="controls">', implode( ' ', $attr_strings ) );
 
 	$fileurl = '';
 	$source  = '<source type="%s" src="%s" />';

--- a/src/wp-includes/meta.php
+++ b/src/wp-includes/meta.php
@@ -1055,7 +1055,7 @@ function update_meta_cache( $meta_type, $object_ids ) {
 	}
 
 	// Get meta info.
-	$id_list   = join( ',', $non_cached_ids );
+	$id_list   = implode( ',', $non_cached_ids );
 	$id_column = ( 'user' === $meta_type ) ? 'umeta_id' : 'meta_id';
 
 	$meta_list = $wpdb->get_results( "SELECT $column, meta_key, meta_value FROM $table WHERE $column IN ($id_list) ORDER BY $id_column ASC", ARRAY_A );

--- a/src/wp-includes/ms-functions.php
+++ b/src/wp-includes/ms-functions.php
@@ -543,7 +543,7 @@ function wpmu_validate_user_signup( $user_name, $user_email ) {
 
 	// Has someone already signed up for this username?
 	$signup = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->signups WHERE user_login = %s", $user_name ) );
-	if ( null != $signup ) {
+	if ( $signup instanceof stdClass ) {
 		$registered_at = mysql2date( 'U', $signup->registered );
 		$now           = time();
 		$diff          = $now - $registered_at;
@@ -556,7 +556,7 @@ function wpmu_validate_user_signup( $user_name, $user_email ) {
 	}
 
 	$signup = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->signups WHERE user_email = %s", $user_email ) );
-	if ( null != $signup ) {
+	if ( $signup instanceof stdClass ) {
 		$diff = time() - mysql2date( 'U', $signup->registered );
 		// If registered more than two days ago, cancel registration and let this signup go through.
 		if ( $diff > 2 * DAY_IN_SECONDS ) {

--- a/src/wp-includes/ms-network.php
+++ b/src/wp-includes/ms-network.php
@@ -131,7 +131,7 @@ function _prime_network_caches( $network_ids ) {
 
 	$non_cached_ids = _get_non_cached_ids( $network_ids, 'networks' );
 	if ( ! empty( $non_cached_ids ) ) {
-		$fresh_networks = $wpdb->get_results( sprintf( "SELECT $wpdb->site.* FROM $wpdb->site WHERE id IN (%s)", join( ',', array_map( 'intval', $non_cached_ids ) ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$fresh_networks = $wpdb->get_results( sprintf( "SELECT $wpdb->site.* FROM $wpdb->site WHERE id IN (%s)", implode( ',', array_map( 'intval', $non_cached_ids ) ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 
 		update_network_cache( $fresh_networks );
 	}

--- a/src/wp-includes/ms-site.php
+++ b/src/wp-includes/ms-site.php
@@ -352,7 +352,7 @@ function _prime_site_caches( $ids, $update_meta_cache = true ) {
 
 	$non_cached_ids = _get_non_cached_ids( $ids, 'sites' );
 	if ( ! empty( $non_cached_ids ) ) {
-		$fresh_sites = $wpdb->get_results( sprintf( "SELECT * FROM $wpdb->blogs WHERE blog_id IN (%s)", join( ',', array_map( 'intval', $non_cached_ids ) ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$fresh_sites = $wpdb->get_results( sprintf( "SELECT * FROM $wpdb->blogs WHERE blog_id IN (%s)", implode( ',', array_map( 'intval', $non_cached_ids ) ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 
 		update_site_cache( $fresh_sites, $update_meta_cache );
 	}

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -2723,7 +2723,7 @@ if ( ! function_exists( 'get_avatar' ) ) :
 			esc_attr( $args['alt'] ),
 			esc_url( $url ),
 			esc_url( $url2x ) . ' 2x',
-			esc_attr( join( ' ', $class ) ),
+			esc_attr( implode( ' ', $class ) ),
 			(int) $args['height'],
 			(int) $args['width'],
 			$extra_attr

--- a/src/wp-includes/post-template.php
+++ b/src/wp-includes/post-template.php
@@ -456,7 +456,7 @@ function has_excerpt( $post = 0 ) {
  */
 function post_class( $class = '', $post_id = null ) {
 	// Separates classes with a single space, collates classes for post DIV.
-	echo 'class="' . esc_attr( join( ' ', get_post_class( $class, $post_id ) ) ) . '"';
+	echo 'class="' . esc_attr( implode( ' ', get_post_class( $class, $post_id ) ) ) . '"';
 }
 
 /**
@@ -592,7 +592,7 @@ function get_post_class( $class = '', $post_id = null ) {
  */
 function body_class( $class = '' ) {
 	// Separates class names with a single space, collates class names for body element.
-	echo 'class="' . esc_attr( join( ' ', get_body_class( $class ) ) ) . '"';
+	echo 'class="' . esc_attr( implode( ' ', get_body_class( $class ) ) ) . '"';
 }
 
 /**

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -2955,7 +2955,7 @@ function wp_post_mime_type_where( $post_mime_types, $table_alias = '' ) {
 	}
 
 	if ( ! empty( $wheres ) ) {
-		$where = ' AND (' . join( ' OR ', $wheres ) . ') ';
+		$where = ' AND (' . implode( ' OR ', $wheres ) . ') ';
 	}
 
 	return $where;
@@ -7466,7 +7466,7 @@ function _prime_post_caches( $ids, $update_term_cache = true, $update_meta_cache
 
 	$non_cached_ids = _get_non_cached_ids( $ids, 'posts' );
 	if ( ! empty( $non_cached_ids ) ) {
-		$fresh_posts = $wpdb->get_results( sprintf( "SELECT $wpdb->posts.* FROM $wpdb->posts WHERE ID IN (%s)", join( ',', $non_cached_ids ) ) );
+		$fresh_posts = $wpdb->get_results( sprintf( "SELECT $wpdb->posts.* FROM $wpdb->posts WHERE ID IN (%s)", implode( ',', $non_cached_ids ) ) );
 
 		update_post_caches( $fresh_posts, 'any', $update_term_cache, $update_meta_cache );
 	}

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -2390,7 +2390,7 @@ function rest_get_route_for_term( $term ) {
 	$route = '';
 
 	// The only controller that works is the Terms controller.
-	if ( 'WP_REST_Terms_Controller' === get_class( $controller ) ) {
+	if ( $controller instanceof WP_REST_Terms_Controller ) {
 		$namespace = 'wp/v2';
 		$rest_base = ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxonomy->name;
 		$route     = sprintf( '/%s/%s/%d', $namespace, $rest_base, $term->term_id );

--- a/src/wp-includes/shortcodes.php
+++ b/src/wp-includes/shortcodes.php
@@ -252,7 +252,7 @@ function get_shortcode_regex( $tagnames = null ) {
 	if ( empty( $tagnames ) ) {
 		$tagnames = array_keys( $shortcode_tags );
 	}
-	$tagregexp = join( '|', array_map( 'preg_quote', $tagnames ) );
+	$tagregexp = implode( '|', array_map( 'preg_quote', $tagnames ) );
 
 	// WARNING! Do not change this regex without changing do_shortcode_tag() and strip_shortcode_tag().
 	// Also, see shortcode_unautop() and shortcode.js.

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -2708,7 +2708,7 @@ function wp_set_object_terms( $object_id, $terms, $taxonomy, $append = false ) {
 		}
 
 		if ( $values ) {
-			if ( false === $wpdb->query( "INSERT INTO $wpdb->term_relationships (object_id, term_taxonomy_id, term_order) VALUES " . join( ',', $values ) . ' ON DUPLICATE KEY UPDATE term_order = VALUES(term_order)' ) ) {
+			if ( false === $wpdb->query( "INSERT INTO $wpdb->term_relationships (object_id, term_taxonomy_id, term_order) VALUES " . implode( ',', $values ) . ' ON DUPLICATE KEY UPDATE term_order = VALUES(term_order)' ) ) {
 				return new WP_Error( 'db_insert_error', __( 'Could not insert term relationship into the database.' ), $wpdb->last_error );
 			}
 		}
@@ -4058,7 +4058,7 @@ function _prime_term_caches( $term_ids, $update_meta_cache = true ) {
 
 	$non_cached_ids = _get_non_cached_ids( $term_ids, 'terms' );
 	if ( ! empty( $non_cached_ids ) ) {
-		$fresh_terms = $wpdb->get_results( sprintf( "SELECT t.*, tt.* FROM $wpdb->terms AS t INNER JOIN $wpdb->term_taxonomy AS tt ON t.term_id = tt.term_id WHERE t.term_id IN (%s)", join( ',', array_map( 'intval', $non_cached_ids ) ) ) );
+		$fresh_terms = $wpdb->get_results( sprintf( "SELECT t.*, tt.* FROM $wpdb->terms AS t INNER JOIN $wpdb->term_taxonomy AS tt ON t.term_id = tt.term_id WHERE t.term_id IN (%s)", implode( ',', array_map( 'intval', $non_cached_ids ) ) ) );
 
 		update_term_cache( $fresh_terms, $update_meta_cache );
 
@@ -4708,7 +4708,7 @@ function the_taxonomies( $args = array() ) {
 
 	$parsed_args = wp_parse_args( $args, $defaults );
 
-	echo $parsed_args['before'] . join( $parsed_args['sep'], get_the_taxonomies( $parsed_args['post'], $parsed_args ) ) . $parsed_args['after'];
+	echo $parsed_args['before'] . implode( $parsed_args['sep'], get_the_taxonomies( $parsed_args['post'], $parsed_args ) ) . $parsed_args['after'];
 }
 
 /**

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -2149,7 +2149,7 @@ function get_theme_starter_content() {
 				'text',
 				array(
 					'title'  => _x( 'Find Us', 'Theme starter content' ),
-					'text'   => join(
+					'text'   => implode(
 						'',
 						array(
 							'<strong>' . _x( 'Address', 'Theme starter content' ) . "</strong>\n",

--- a/src/wp-includes/widgets/class-wp-widget-custom-html.php
+++ b/src/wp-includes/widgets/class-wp-widget-custom-html.php
@@ -281,7 +281,7 @@ class WP_Widget_Custom_HTML extends WP_Widget {
 					<# if ( data.codeEditorDisabled ) { #>
 						<p>
 							<?php _e( 'Some HTML tags are not permitted, including:' ); ?>
-							<code><?php echo join( '</code>, <code>', $disallowed_html ); ?></code>
+							<code><?php echo implode( '</code>, <code>', $disallowed_html ); ?></code>
 						</p>
 					<# } #>
 				<?php endif; ?>

--- a/src/wp-includes/widgets/class-wp-widget-media-image.php
+++ b/src/wp-includes/widgets/class-wp-widget-media-image.php
@@ -219,7 +219,7 @@ class WP_Widget_Media_Image extends WP_Widget_Media {
 				$width        = empty( $caption_size[0] ) ? 0 : $caption_size[0];
 			}
 
-			$image_attributes['class'] .= sprintf( ' attachment-%1$s size-%1$s', is_array( $size ) ? join( 'x', $size ) : $size );
+			$image_attributes['class'] .= sprintf( ' attachment-%1$s size-%1$s', is_array( $size ) ? implode( 'x', $size ) : $size );
 
 			$image = wp_get_attachment_image( $attachment->ID, $size, false, $image_attributes );
 

--- a/src/wp-includes/widgets/class-wp-widget-media.php
+++ b/src/wp-includes/widgets/class-wp-widget-media.php
@@ -208,7 +208,7 @@ abstract class WP_Widget_Media extends WP_Widget {
 		}
 		$tokens = array_map( 'sanitize_html_class', $tokens );
 		$tokens = array_filter( $tokens );
-		return join( ' ', $tokens );
+		return implode( ' ', $tokens );
 	}
 
 	/**
@@ -343,7 +343,7 @@ abstract class WP_Widget_Media extends WP_Widget {
 				class="media-widget-instance-property"
 				name="<?php echo esc_attr( $this->get_field_name( $name ) ); ?>"
 				id="<?php echo esc_attr( $this->get_field_id( $name ) ); // Needed specifically by wpWidgets.appendTitle(). ?>"
-				value="<?php echo esc_attr( is_array( $value ) ? join( ',', $value ) : (string) $value ); ?>"
+				value="<?php echo esc_attr( is_array( $value ) ? implode( ',', $value ) : (string) $value ); ?>"
 			/>
 			<?php
 		endforeach;

--- a/tests/phpunit/includes/utils.php
+++ b/tests/phpunit/includes/utils.php
@@ -28,7 +28,7 @@ function strip_ws( $txt ) {
 		}
 	}
 
-	return trim( join( "\n", $result ) );
+	return trim( implode( "\n", $result ) );
 }
 
 /*
@@ -275,7 +275,7 @@ function xml_join_atts( $atts ) {
 	foreach ( $atts as $k => $v ) {
 		$a[] = $k . '="' . $v . '"';
 	}
-	return join( ' ', $a );
+	return implode( ' ', $a );
 }
 
 function xml_array_dumbdown( &$data ) {
@@ -332,7 +332,7 @@ function gen_tests_array( $name, $array ) {
 			$out[] = gen_tests_array( "{$name}[{$index}]", $v );
 		}
 	}
-	return join( "\n", $out ) . "\n";
+	return implode( "\n", $out ) . "\n";
 }
 
 /**

--- a/tests/phpunit/tests/customize/manager.php
+++ b/tests/phpunit/tests/customize/manager.php
@@ -2719,7 +2719,7 @@ class Tests_WP_Customize_Manager extends WP_UnitTestCase {
 		foreach ( $error->errors as $code => $messages ) {
 			$this->assertArrayHasKey( $code, $validity );
 			$this->assertInternalType( 'array', $validity[ $code ] );
-			$this->assertSame( join( ' ', $messages ), $validity[ $code ]['message'] );
+			$this->assertSame( implode( ' ', $messages ), $validity[ $code ]['message'] );
 			$this->assertArrayHasKey( 'data', $validity[ $code ] );
 			$this->assertSame( $validity[ $code ]['data'], $error->get_error_data( $code ) );
 		}

--- a/tests/phpunit/tests/db.php
+++ b/tests/phpunit/tests/db.php
@@ -489,7 +489,7 @@ class Tests_DB extends WP_UnitTestCase {
 		global $wpdb;
 		$str    = $wpdb->get_caller();
 		$calls  = explode( ', ', $str );
-		$called = join( '->', array( __CLASS__, __FUNCTION__ ) );
+		$called = implode( '->', array( __CLASS__, __FUNCTION__ ) );
 		$this->assertSame( $called, end( $calls ) );
 	}
 

--- a/tests/phpunit/tests/formatting/Autop.php
+++ b/tests/phpunit/tests/formatting/Autop.php
@@ -337,12 +337,12 @@ Paragraph two.';
 			$content[] = "<$block>foo</$block>";
 		}
 
-		$expected = join( "\n", $content );
-		$input    = join( "\n\n", $content ); // Whitespace difference.
+		$expected = implode( "\n", $content );
+		$input    = implode( "\n\n", $content ); // Whitespace difference.
 
 		$this->assertSame( $expected, trim( wpautop( $input ) ) );
 
-		$input = join( '', $content ); // Whitespace difference.
+		$input = implode( '', $content ); // Whitespace difference.
 
 		$this->assertSame( $expected, trim( wpautop( $input ) ) );
 
@@ -353,8 +353,8 @@ Paragraph two.';
 			$content[] = "<$block/>";
 		}
 
-		$expected = join( "\n", $content );
-		$input    = join( '', $content );
+		$expected = implode( "\n", $content );
+		$input    = implode( '', $content );
 
 		$this->assertSame( $expected, trim( wpautop( $input ) ) );
 
@@ -365,8 +365,8 @@ Paragraph two.';
 			$content[] = "<$block attr='value'>foo</$block>";
 		}
 
-		$expected = join( "\n", $content );
-		$input    = join( '', $content );
+		$expected = implode( "\n", $content );
+		$input    = implode( '', $content );
 
 		$this->assertSame( $expected, trim( wpautop( $input ) ) );
 	}
@@ -426,8 +426,8 @@ Paragraph two.';
 			$expected[] = "<p><$inline>foo</$inline></p>";
 		}
 
-		$content  = join( "\n\n", $content );
-		$expected = join( "\n", $expected );
+		$content  = implode( "\n\n", $content );
+		$expected = implode( "\n", $expected );
 
 		$this->assertSame( $expected, trim( wpautop( $content ) ) );
 	}

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -512,8 +512,8 @@ https://w.org</a>',
 			$ids2_srcs[] = 'http://' . WP_TESTS_DOMAIN . '/wp-content/uploads/' . "image$i.jpg";
 		}
 
-		$ids1_joined = join( ',', $ids1 );
-		$ids2_joined = join( ',', $ids2 );
+		$ids1_joined = implode( ',', $ids1 );
+		$ids2_joined = implode( ',', $ids2 );
 
 		$blob    = <<<BLOB
 [gallery ids="$ids1_joined"]
@@ -662,8 +662,8 @@ BLOB;
 			$ids2_srcs[] = 'http://' . WP_TESTS_DOMAIN . '/wp-content/uploads/' . "image$i.jpg";
 		}
 
-		$ids1_joined = join( ',', $ids1 );
-		$ids2_joined = join( ',', $ids2 );
+		$ids1_joined = implode( ',', $ids1 );
+		$ids2_joined = implode( ',', $ids2 );
 
 		$blob    = <<<BLOB
 [gallery ids="$ids1_joined"]

--- a/tests/phpunit/tests/post/bodyClass.php
+++ b/tests/phpunit/tests/post/bodyClass.php
@@ -13,7 +13,7 @@ class Tests_Post_BodyClass extends WP_UnitTestCase {
 	}
 
 	public function test_body_class() {
-		$expected = 'class="' . join( ' ', get_body_class( '', $this->post_id ) ) . '"';
+		$expected = 'class="' . implode( ' ', get_body_class( '', $this->post_id ) ) . '"';
 		$this->expectOutputString( $expected );
 		body_class( '', $this->post_id );
 	}
@@ -21,7 +21,7 @@ class Tests_Post_BodyClass extends WP_UnitTestCase {
 	public function test_body_class_extra_esc_attr() {
 		$classes              = get_body_class( '', $this->post_id );
 		$escaped_again        = array_map( 'esc_attr', $classes );
-		$escaped_another_time = 'class="' . esc_attr( join( ' ', $escaped_again ) ) . '"';
+		$escaped_another_time = 'class="' . esc_attr( implode( ' ', $escaped_again ) ) . '"';
 
 		$this->expectOutputString( $escaped_another_time );
 		body_class( '', $this->post_id );

--- a/tests/phpunit/tests/post/postClass.php
+++ b/tests/phpunit/tests/post/postClass.php
@@ -13,7 +13,7 @@ class Tests_Post_PostClass extends WP_UnitTestCase {
 	}
 
 	public function test_post_class() {
-		$expected = 'class="' . join( ' ', get_post_class( '', $this->post_id ) ) . '"';
+		$expected = 'class="' . implode( ' ', get_post_class( '', $this->post_id ) ) . '"';
 		$this->expectOutputString( $expected );
 		post_class( '', $this->post_id );
 	}
@@ -21,7 +21,7 @@ class Tests_Post_PostClass extends WP_UnitTestCase {
 	public function test_post_class_extra_esc_attr() {
 		$classes              = get_post_class( '', $this->post_id );
 		$escaped_again        = array_map( 'esc_attr', $classes );
-		$escaped_another_time = 'class="' . esc_attr( join( ' ', $escaped_again ) ) . '"';
+		$escaped_another_time = 'class="' . esc_attr( implode( ' ', $escaped_again ) ) . '"';
 
 		$this->expectOutputString( $escaped_another_time );
 		post_class( '', $this->post_id );

--- a/tests/phpunit/tests/post/template.php
+++ b/tests/phpunit/tests/post/template.php
@@ -7,7 +7,7 @@ class Tests_Post_Template extends WP_UnitTestCase {
 
 	function test_wp_link_pages() {
 		$contents = array( 'One', 'Two', 'Three' );
-		$content  = join( '<!--nextpage-->', $contents );
+		$content  = implode( '<!--nextpage-->', $contents );
 		$post_id  = self::factory()->post->create( array( 'post_content' => $content ) );
 
 		$this->go_to( '?p=' . $post_id );

--- a/tests/phpunit/tests/widgets/media-gallery-widget.php
+++ b/tests/phpunit/tests/widgets/media-gallery-widget.php
@@ -101,7 +101,7 @@ class Test_WP_Widget_Media_Gallery extends WP_UnitTestCase {
 
 		$this->assertTrue( wp_script_is( 'media-gallery-widget' ) );
 
-		$after = join( '', wp_scripts()->registered['media-gallery-widget']->extra['after'] );
+		$after = implode( '', wp_scripts()->registered['media-gallery-widget']->extra['after'] );
 		$this->assertContains( 'wp.mediaWidgets.modelConstructors[ "media_gallery" ].prototype', $after );
 	}
 


### PR DESCRIPTION
### CS: use `self` when appropriate

* `get_default_primary_column_name()` is a protected method, so calling it statically with the class name is bad practice.
* Similarly this applies when calling a `private` constructor.

### QA: don't use alias functions

Using the canonical function name for PHP functions is strongly recommended as aliases may be deprecated or removed without (much) warning.

This replaces all uses of the following:
* `join()` with `implode()`
* `sizeof()` with `count()`
* `is_writeable()` with `is_writable()`
* `doubleval()` with a `(float)` cast

In part, this is a follow-up to 47746

### QA: remove assumption in code

Use a more stable condition.
If `$wpdb->get_row()` is successful and the `$output` parameter has not been set, the output will be an instance of `stdClass`, so test to confirm that instead of testing against "not null".

### Modernize: use `instanceof` instead of a comparison with `get_class()` 

Includes adjusting external libraries which are no longer maintained externally.

Trac ticket: https://core.trac.wordpress.org/ticket/50767

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
