### PR TITLE
Posts pagination  ( trac : 42936 )

### DIFF
--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1803,8 +1803,10 @@ function get_adjacent_post( $in_same_term = false, $excluded_terms = '', $previo
 		$where .= " AND p.post_status = 'publish'";
 	}
 
-	$op    = $previous ? '<' : '>';
+	$op    = $previous ? '<=' : '>=';
 	$order = $previous ? 'DESC' : 'ASC';
+	/* Store the partial where clause before apply_filters. We are going to need it on our Limit Query. */
+	$where_was = $where;
 
 	/**
 	 * Filters the JOIN clause in the SQL for an adjacent post query.
@@ -1839,6 +1841,12 @@ function get_adjacent_post( $in_same_term = false, $excluded_terms = '', $previo
 	 * @param WP_Post $post           WP_Post object.
 	 */
 	$where = apply_filters( "get_{$adjacent}_post_where", $wpdb->prepare( "WHERE p.post_date $op %s AND p.post_type = %s $where", $current_post_date, $post->post_type ), $in_same_term, $excluded_terms, $taxonomy, $post );
+	/**
+	 * Searches for the number of posts that have the exact same post date in the DB.
+	 * Then sets the limit variable to the result + 1.
+	 */
+	$limit_query = $wpdb->prepare( "SELECT COUNT(p.ID) FROM $wpdb->posts AS p $join WHERE p.post_date = %s AND p.post_type = %s $where_was", $current_post_date, $post->post_type );
+	$limit       = 1 + (int) $wpdb->get_var( $limit_query );
 
 	/**
 	 * Filters the ORDER BY clause in the SQL for an adjacent post query.
@@ -1854,7 +1862,7 @@ function get_adjacent_post( $in_same_term = false, $excluded_terms = '', $previo
 	 * @param WP_Post $post    WP_Post object.
 	 * @param string  $order   Sort order. 'DESC' for previous post, 'ASC' for next.
 	 */
-	$sort = apply_filters( "get_{$adjacent}_post_sort", "ORDER BY p.post_date $order LIMIT 1", $post, $order );
+	$sort = apply_filters( "get_{$adjacent}_post_sort", "ORDER BY p.post_date $order, p.ID $order LIMIT $limit", $post, $order );
 
 	$query     = "SELECT p.ID FROM $wpdb->posts AS p $join $where $sort";
 	$query_key = 'adjacent_post_' . md5( $query );
@@ -1866,7 +1874,53 @@ function get_adjacent_post( $in_same_term = false, $excluded_terms = '', $previo
 		return $result;
 	}
 
-	$result = $wpdb->get_var( $query );
+	/**
+	 * Retrieves post ids.
+	 *
+	 * The array will contain the following
+	 *     the active's post id always,
+	 *     all the post ids that have the same post_date as the active post if they exist,
+	 *     the post_id of the next or previous post that has different post_date if it exists
+	 *
+	 * Because of the ORDER BY clause the previous or next post id will always be the next ( offset $key + 1 ) in the array $results,
+	 * relevant to the active post it.
+	 */
+	$results = $wpdb->get_results( $query );
+
+	/**
+	 * If the active post 's term is in the excluded term array.
+	 * The active's post id is not included in the $results, so we should return
+	 * the first item in the $results array.
+	 */
+	$return_first = false;
+	if ( 1 === $limit && ! empty( $excluded_terms ) ) {
+		if ( ! is_array( $excluded_terms ) && strstr( $excluded_terms, ',' ) ) {
+			$excluded_terms = explode( ',', $excluded_terms );
+		}
+		if ( is_array( $excluded_terms ) ) {
+			$act_terms = wp_get_object_terms( $post->ID, $taxonomy, array( 'fields' => 'ids' ) );
+			if ( ! is_wp_error( $act_terms ) && ! empty( $act_terms ) ) {
+				$excluded_terms = array_map( 'intval', $excluded_terms );
+				$act_terms      = array_map( 'intval', $act_terms );
+				foreach ( $act_terms as $act_term ) {
+					if ( in_array( $act_term, $excluded_terms, true ) ) {
+						$return_first = true;
+						break;
+					}
+				}
+			}
+		}
+	}
+	if ( $return_first ) {
+		$result = ! empty( $results[0]->ID ) ? (int) $results[0]->ID : null;
+	} else {
+		foreach ( $results as $key => $val ) {
+			if ( ! empty( $val->ID ) && (int) $val->ID === $post->ID ) {
+				$result = ! empty( $results[ $key + 1 ]->ID ) ? (int) $results[ $key + 1 ]->ID : null;
+			}
+		}
+	}
+
 	if ( null === $result ) {
 		$result = '';
 	}
@@ -1876,7 +1930,7 @@ function get_adjacent_post( $in_same_term = false, $excluded_terms = '', $previo
 	if ( $result ) {
 		$result = get_post( $result );
 	}
-
+	
 	return $result;
 }
 

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1878,12 +1878,12 @@ function get_adjacent_post( $in_same_term = false, $excluded_terms = '', $previo
 	 * Retrieves post ids.
 	 *
 	 * The array will contain the following
-	 *     the active's post id always,
+	 *     the active's post id always if $excluded_terms does not contain the active post's term(s),
 	 *     all the post ids that have the same post_date as the active post if they exist,
 	 *     the post_id of the next or previous post that has different post_date if it exists
 	 *
-	 * Because of the ORDER BY clause the previous or next post id will always be the next ( offset $key + 1 ) in the array $results,
-	 * relevant to the active post it.
+	 * Because of the ORDER BY clause the previous or next post id will be the next ( offset $key + 1 ) in the array $results,
+	 * relevant to the active post it or the first when the active post's term(s) is included in the $excluded_terms.
 	 */
 	$results = $wpdb->get_results( $query );
 

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1930,7 +1930,7 @@ function get_adjacent_post( $in_same_term = false, $excluded_terms = '', $previo
 	if ( $result ) {
 		$result = get_post( $result );
 	}
-	
+
 	return $result;
 }
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
This PR is an updated version of https://github.com/WordPress/wordpress-develop/pull/619 which mainly focuses on the case where $excluded_terms is not empty.
When the active post's term(s) is included in the $excluded_terms, the active post id is not included in the $results of $wpdb->get_results(). In that case, we should return the first post ID inside the $results array if it exists.

Trac ticket: https://core.trac.wordpress.org/ticket/42936

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
