### PR TITLE
Embeds: Use youtube-nocookie.com for YouTube embeds.

### DIFF
--- a/src/wp-includes/class-wp-oembed.php
+++ b/src/wp-includes/class-wp-oembed.php
@@ -539,7 +539,7 @@ class WP_oEmbed {
 			if ( is_wp_error( $result ) && 'not-implemented' === $result->get_error_code() ) {
 				continue;
 			}
-			// use youtube-nocookie.com for YouTube embeds
+			// Use youtube-nocookie.com for YouTube embeds.
 			if ( strpos( $provider, 'https://www.youtube.com/oembed' ) === 0 && ! empty( $result->html ) ) {
 				$from = 'src="https://www.youtube.com/embed/';
 				$to   = 'src="https://www.youtube-nocookie.com/embed/';

--- a/src/wp-includes/class-wp-oembed.php
+++ b/src/wp-includes/class-wp-oembed.php
@@ -539,6 +539,12 @@ class WP_oEmbed {
 			if ( is_wp_error( $result ) && 'not-implemented' === $result->get_error_code() ) {
 				continue;
 			}
+			// use youtube-nocookie.com for YouTube embeds
+			if ( strpos( $provider, 'https://www.youtube.com/oembed' ) === 0 && ! empty( $result->html ) ) {
+				$from = 'src="https://www.youtube.com/embed/';
+				$to   = 'src="https://www.youtube-nocookie.com/embed/';
+				$result->html = str_replace( $from, $to, $result->html );
+			}
 			return ( $result && ! is_wp_error( $result ) ) ? $result : false;
 		}
 		return false;

--- a/src/wp-includes/class-wp-oembed.php
+++ b/src/wp-includes/class-wp-oembed.php
@@ -540,7 +540,7 @@ class WP_oEmbed {
 				continue;
 			}
 			// Use youtube-nocookie.com for YouTube embeds.
-			if ( strpos( $provider, 'https://www.youtube.com/oembed' ) === 0 && ! empty( $result->html ) ) {
+			if ( str_contains( $provider, 'https://www.youtube.com/oembed' ) && ! empty( $result->html ) ) {
 				$from = 'src="https://www.youtube.com/embed/';
 				$to   = 'src="https://www.youtube-nocookie.com/embed/';
 				$result->html = str_replace( $from, $to, $result->html );


### PR DESCRIPTION
Modify YouTube's oEmbed response to use youtube-nocookie.com instead of youtube.com in the iframe's src. This enhances visitors' privacy.

Trac ticket: https://core.trac.wordpress.org/ticket/44610.

Props jepperask, birgire, BjornW.