### PR TITLE
#50907: Add a method to opt-in to core auto-updates

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -344,7 +344,7 @@ h3 {
 }
 
 .update-core-php h2 {
-	margin-top: 2em;
+	margin-top: 4em;
 }
 
 .update-php h2,

--- a/src/wp-admin/includes/class-core-upgrader.php
+++ b/src/wp-admin/includes/class-core-upgrader.php
@@ -48,14 +48,14 @@ class Core_Upgrader extends WP_Upgrader {
 	 *
 	 * @param object $current Response object for whether WordPress is current.
 	 * @param array  $args {
-	 *     Optional. Arguments for upgrading WordPress core. Default empty array.
+	 *        Optional. Arguments for upgrading WordPress core. Default empty array.
 	 *
-	 *     @type bool $pre_check_md5    Whether to check the file checksums before
-	 *                                  attempting the upgrade. Default true.
-	 *     @type bool $attempt_rollback Whether to attempt to rollback the chances if
-	 *                                  there is a problem. Default false.
-	 *     @type bool $do_rollback      Whether to perform this "upgrade" as a rollback.
-	 *                                  Default false.
+	 *        @type bool $pre_check_md5    Whether to check the file checksums before
+	 *                                     attempting the upgrade. Default true.
+	 *        @type bool $attempt_rollback Whether to attempt to rollback the chances if
+	 *                                     there is a problem. Default false.
+	 *        @type bool $do_rollback      Whether to perform this "upgrade" as a rollback.
+	 *                                     Default false.
 	 * }
 	 * @return string|false|WP_Error New WordPress version on success, false or WP_Error on failure.
 	 */
@@ -279,9 +279,9 @@ class Core_Upgrader extends WP_Upgrader {
 		$current_is_development_version = (bool) strpos( $wp_version, '-' );
 
 		// Defaults:
-		$upgrade_dev   = true;
-		$upgrade_minor = true;
-		$upgrade_major = false;
+		$upgrade_dev   = get_site_option( 'auto_update_core_dev', true );
+		$upgrade_minor = get_site_option( 'auto_update_core_minor', true );
+		$upgrade_major = get_site_option( 'auto_update_core_major', false );
 
 		// WP_AUTO_UPDATE_CORE = true (all), 'beta', 'rc', 'minor', false.
 		if ( defined( 'WP_AUTO_UPDATE_CORE' ) ) {


### PR DESCRIPTION
Syncing patches for tests and review

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/50907

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
