### PR TITLE
Add `site_url` param to return data.  Also fix fallback var name (oops)

### DIFF
--- a/src/js/_enqueues/admin/auth-app.js
+++ b/src/js/_enqueues/admin/auth-app.js
@@ -68,6 +68,7 @@
 
 			if ( raw ) {
 				url = raw + ( -1 === raw.indexOf( '?' ) ? '?' : '&' ) +
+					'site_url=' + encodeURIComponent( authApp.site_url ) +
 					'user_login=' + encodeURIComponent( authApp.user_login ) +
 					'&password=' + encodeURIComponent( response.password );
 

--- a/src/js/_enqueues/admin/auth-app.js
+++ b/src/js/_enqueues/admin/auth-app.js
@@ -69,7 +69,7 @@
 			if ( raw ) {
 				url = raw + ( -1 === raw.indexOf( '?' ) ? '?' : '&' ) +
 					'site_url=' + encodeURIComponent( authApp.site_url ) +
-					'user_login=' + encodeURIComponent( authApp.user_login ) +
+					'&user_login=' + encodeURIComponent( authApp.user_login ) +
 					'&password=' + encodeURIComponent( response.password );
 
 				window.location = url;

--- a/src/wp-admin/authorize-application.php
+++ b/src/wp-admin/authorize-application.php
@@ -37,6 +37,7 @@ if ( isset( $_POST['action'] ) && 'authorize_application_password' === $_POST['a
 			if ( $success_url ) {
 				$redirect = add_query_arg(
 					array(
+						'siteurl'  => urlencode( site_url() ),
 						'username' => urlencode( wp_get_current_user()->user_login ),
 						'password' => urlencode( $new_password ),
 					),

--- a/src/wp-admin/authorize-application.php
+++ b/src/wp-admin/authorize-application.php
@@ -220,9 +220,9 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 							'<strong><kbd>' . esc_html(
 								add_query_arg(
 									array(
-										'site_url' => site_url(),
+										'site_url'   => site_url(),
 										'user_login' => $user->user_login,
-										'password' => '[------]',
+										'password'   => '[------]',
 									),
 									$success_url
 								)

--- a/src/wp-admin/authorize-application.php
+++ b/src/wp-admin/authorize-application.php
@@ -12,6 +12,7 @@ require_once __DIR__ . '/admin.php';
 $error        = null;
 $new_password = '';
 
+// This is the no-js fallback script.  Generally this will all be handled by `auth-app.js`
 if ( isset( $_POST['action'] ) && 'authorize_application_password' === $_POST['action'] ) {
 	check_admin_referer( 'authorize_application_password' );
 

--- a/src/wp-admin/authorize-application.php
+++ b/src/wp-admin/authorize-application.php
@@ -37,9 +37,9 @@ if ( isset( $_POST['action'] ) && 'authorize_application_password' === $_POST['a
 			if ( $success_url ) {
 				$redirect = add_query_arg(
 					array(
-						'siteurl'  => urlencode( site_url() ),
-						'username' => urlencode( wp_get_current_user()->user_login ),
-						'password' => urlencode( $new_password ),
+						'site_url'   => urlencode( site_url() ),
+						'user_login' => urlencode( wp_get_current_user()->user_login ),
+						'password'   => urlencode( $new_password ),
 					),
 					$success_url
 				);
@@ -101,6 +101,7 @@ wp_localize_script(
 	'auth-app',
 	'authApp',
 	array(
+		'site_url'   => site_url(),
 		'user_login' => $user->user_login,
 		'success'    => $success_url,
 		'reject'     => $reject_url ? $reject_url : admin_url(),
@@ -218,7 +219,8 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 							'<strong><kbd>' . esc_html(
 								add_query_arg(
 									array(
-										'username' => $user->user_login,
+										'site_url' => site_url(),
+										'user_login' => $user->user_login,
 										'password' => '[------]',
 									),
 									$success_url


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

* Add a comment clarifying that the php code block is a fallback for no-js
* Fix `username` to `user_login` -- we've been doing the latter in practice, but some code still returned the former.
* Most relevantly, add a `site_url` parameter to the return data so clients have confirmation of what url they can use the returned credentials with.

Trac ticket: https://core.trac.wordpress.org/ticket/51602#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
