### PR TITLE
Community Events: Generate en dash explicitly for consistency.

### DIFF
--- a/src/js/_enqueues/wp/dashboard.js
+++ b/src/js/_enqueues/wp/dashboard.js
@@ -745,9 +745,12 @@ jQuery( function( $ ) {
 			/* translators: Date format for upcoming events on the dashboard. Include the day of the week. See https://www.php.net/manual/datetime.format.php */
 			var singleDayEvent = __( 'l, M j, Y' ),
 				/* translators: Date string for upcoming events. 1: Month, 2: Starting day, 3: Ending day, 4: Year. */
-				multipleDayEvent = __( '%1$s %2$d–%3$d, %4$d' ),
+				multipleDayEvent = __( '%1$s %2$d'+ String.fromCharCode( 8211 ) + '%3$d, %4$d' ),
 				/* translators: Date string for upcoming events. 1: Starting month, 2: Starting day, 3: Ending month, 4: Ending day, 5: Ending year. */
-				multipleMonthEvent = __( '%1$s %2$d – %3$s %4$d, %5$d' );
+				multipleMonthEvent = __( '%1$s %2$d '+ String.fromCharCode( 8211 ) +' %3$s %4$d, %5$d' );
+
+				console.log( multipleDayEvent.charCodeAt( 9 ) ); // 8211
+				console.log( multipleMonthEvent.charCodeAt( 10 ) ); // 8211
 
 			// Detect single-day events.
 			if ( ! endDate || format( 'Y-m-d', startDate ) === format( 'Y-m-d', endDate ) ) {

--- a/tests/qunit/wp-admin/js/dashboard.js
+++ b/tests/qunit/wp-admin/js/dashboard.js
@@ -103,7 +103,12 @@ jQuery( document ).ready( function () {
 					communityEventsData.l10n.date_formats
 				);
 
-				assert.strictEqual( actual, 'September 15–17, 2020' );
+				var expected = 'September 15' + String.fromCharCode( 8211 ) + '17, 2020';
+
+				console.log( actual.charCodeAt( 12 ) );
+				console.log( expected.charCodeAt( 12 ) );
+
+				assert.strictEqual( actual, expected );
 			} );
 
 			QUnit.test( 'multiple month event should use corresponding format', function( assert ) {
@@ -114,7 +119,15 @@ jQuery( document ).ready( function () {
 					communityEventsData.l10n.date_formats
 				);
 
-				assert.strictEqual( actual, 'September 15 – October 6, 2020' );
+				var expected = 'September 15 ' + String.fromCharCode( 8211 ) +' October 6, 2020';
+
+				// don't need ^? can just type a hyphon? or  is phostorm converting it to an hyphon
+				// what do other places in core do?
+				// maybe some kind of interaction with datei18n / moment is part of problem?
+
+				console.log( actual.charCodeAt( 13 ) );
+				console.log( expected.charCodeAt( 13 ) );
+				assert.strictEqual( actual, expected );
 			} );
 
 			QUnit.test( 'undefined end date should be treated as a single-day event', function( assert ) {


### PR DESCRIPTION
En dashes (`8211`) and hyphens (`45`) are getting mixed up, causing some QUnit tests to fail. They all appear to be en dashes in the code itself, but there could be something in `dateI18n` / Moment that is converting to a hypen.

See 51130#comment:48

021e8ef demonstrates the problem, but isn't necessarily the best solution.

Trac ticket: https://core.trac.wordpress.org/ticket/51130
