### PR TITLE
Use `rest_default_additional_properties_to_false` for meta field schema

### DIFF
--- a/src/wp-includes/rest-api/fields/class-wp-rest-meta-fields.php
+++ b/src/wp-includes/rest-api/fields/class-wp-rest-meta-fields.php
@@ -466,7 +466,7 @@ abstract class WP_REST_Meta_Fields {
 				$rest_args['schema']['default'] = static::get_empty_value_for_type( $type );
 			}
 
-			$rest_args['schema'] = $this->default_additional_properties_to_false( $rest_args['schema'] );
+			$rest_args['schema'] = rest_default_additional_properties_to_false( $rest_args['schema'] );
 
 			if ( ! in_array( $type, array( 'string', 'boolean', 'integer', 'number', 'array', 'object' ), true ) ) {
 				continue;
@@ -571,11 +571,13 @@ abstract class WP_REST_Meta_Fields {
 	 * default.
 	 *
 	 * @since 5.3.0
+	 * @deprecated 5.5.0 Use rest_default_additional_properties_to_false()
 	 *
 	 * @param array $schema The schema array.
 	 * @return array
 	 */
 	protected function default_additional_properties_to_false( $schema ) {
+		_deprecated_function( __METHOD__, '5.5.0', 'rest_default_additional_properties_to_false()' );
 		switch ( $schema['type'] ) {
 			case 'object':
 				foreach ( $schema['properties'] as $key => $child_schema ) {

--- a/src/wp-includes/rest-api/fields/class-wp-rest-meta-fields.php
+++ b/src/wp-includes/rest-api/fields/class-wp-rest-meta-fields.php
@@ -577,7 +577,7 @@ abstract class WP_REST_Meta_Fields {
 	 * @return array
 	 */
 	protected function default_additional_properties_to_false( $schema ) {
-		_deprecated_function( __METHOD__, '5.5.0', 'rest_default_additional_properties_to_false()' );
+		_deprecated_function( __METHOD__, '5.6.0', 'rest_default_additional_properties_to_false()' );
 		switch ( $schema['type'] ) {
 			case 'object':
 				foreach ( $schema['properties'] as $key => $child_schema ) {

--- a/src/wp-includes/rest-api/fields/class-wp-rest-meta-fields.php
+++ b/src/wp-includes/rest-api/fields/class-wp-rest-meta-fields.php
@@ -578,22 +578,8 @@ abstract class WP_REST_Meta_Fields {
 	 */
 	protected function default_additional_properties_to_false( $schema ) {
 		_deprecated_function( __METHOD__, '5.6.0', 'rest_default_additional_properties_to_false()' );
-		switch ( $schema['type'] ) {
-			case 'object':
-				foreach ( $schema['properties'] as $key => $child_schema ) {
-					$schema['properties'][ $key ] = $this->default_additional_properties_to_false( $child_schema );
-				}
-
-				if ( ! isset( $schema['additionalProperties'] ) ) {
-					$schema['additionalProperties'] = false;
-				}
-				break;
-			case 'array':
-				$schema['items'] = $this->default_additional_properties_to_false( $schema['items'] );
-				break;
-		}
-
-		return $schema;
+		
+		return rest_default_additional_properties_to_false( $schema );
 	}
 
 	/**

--- a/src/wp-includes/rest-api/fields/class-wp-rest-meta-fields.php
+++ b/src/wp-includes/rest-api/fields/class-wp-rest-meta-fields.php
@@ -578,7 +578,7 @@ abstract class WP_REST_Meta_Fields {
 	 */
 	protected function default_additional_properties_to_false( $schema ) {
 		_deprecated_function( __METHOD__, '5.6.0', 'rest_default_additional_properties_to_false()' );
-		
+
 		return rest_default_additional_properties_to_false( $schema );
 	}
 

--- a/src/wp-includes/rest-api/fields/class-wp-rest-meta-fields.php
+++ b/src/wp-includes/rest-api/fields/class-wp-rest-meta-fields.php
@@ -571,7 +571,7 @@ abstract class WP_REST_Meta_Fields {
 	 * default.
 	 *
 	 * @since 5.3.0
-	 * @deprecated 5.5.0 Use rest_default_additional_properties_to_false()
+	 * @deprecated 5.6.0 Use rest_default_additional_properties_to_false() instead.
 	 *
 	 * @param array $schema The schema array.
 	 * @return array


### PR DESCRIPTION
Signed-off-by: Austin Chang <austin880625@gmail.com>

Change the call to the default_additional_properties_to_false method into rest_default_addtional_properties_to_false introduced in 5.5

Trac ticket: https://core.trac.wordpress.org/ticket/51389
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
