### PR TITLE
Skip password generation on wp-login screen

### DIFF
--- a/src/js/_enqueues/admin/user-profile.js
+++ b/src/js/_enqueues/admin/user-profile.js
@@ -146,12 +146,15 @@
 
 		bindToggleButton();
 
-		// Generate the first password and cache it, but don't set it yet.
-		wp.ajax.post( 'generate-password' )
-			.done( function( data ) {
-				// Cache password.
-				$pass1.data( 'pw', data );
-			} );
+		// Skip wp login pages.
+		if ( ! /\/wp-login\.php/.test( document.location ) ) {
+			// Generate the first password and cache it, but don't set it yet.
+			wp.ajax.post( 'generate-password' )
+				.done( function( data ) {
+					// Cache password.
+					$pass1.data( 'pw', data );
+				} );
+		}
 
 		$generateButton.show();
 		$generateButton.on( 'click', function () {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Password generation should not load on the WordPress login page.

Trac ticket: https://core.trac.wordpress.org/ticket/51613

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
