### PR TITLE
Partial term counts: don't affect other objects when preventing double counting.

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -4075,7 +4075,7 @@ function wp_insert_post( $postarr, $wp_error = false, $fire_after_hooks = true )
 	}
 
 	// Allow term counts to be handled by transitioning post type.
-	_wp_prevent_term_counting( true );
+	_wp_prevent_term_counting( $post_ID, 'post', true );
 	if ( is_object_in_taxonomy( $post_type, 'category' ) ) {
 		wp_set_post_categories( $post_ID, $post_category );
 	}
@@ -4133,7 +4133,7 @@ function wp_insert_post( $postarr, $wp_error = false, $fire_after_hooks = true )
 		}
 	}
 	// Restore term counting.
-	_wp_prevent_term_counting( false );
+	_wp_prevent_term_counting( $post_ID, 'post', false );
 
 	if ( ! empty( $postarr['meta_input'] ) ) {
 		foreach ( $postarr['meta_input'] as $field => $value ) {
@@ -4450,9 +4450,9 @@ function wp_publish_post( $post ) {
 		if ( ! $default_term_id ) {
 			continue;
 		}
-		_wp_prevent_term_counting( true );
+		_wp_prevent_term_counting( $post->ID, 'post', true );
 		wp_set_post_terms( $post->ID, array( $default_term_id ), $taxonomy );
-		_wp_prevent_term_counting( false );
+		_wp_prevent_term_counting( $post->ID, 'post', false );
 	}
 
 	$wpdb->update( $wpdb->posts, array( 'post_status' => 'publish' ), array( 'ID' => $post->ID ) );

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -3288,6 +3288,12 @@ function wp_defer_term_counting( $defer = null ) {
  * This is used by functions calling wp_transition_post_status() to indicate the
  * term count will be handled during the post's transition.
  *
+ *      *********************************** REMOVE THIS WILSON ***********
+ * @todo fix this so it only affects the current object.
+ *       - setting per object maybe, say `'post:10', $new_setting = null`.
+ *       - does it default to the current global post? Probably not.
+ *      *********************************** REMOVE THIS WILSON ***********
+ *
  * @private
  * @since 5.6.0
  *

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -3304,7 +3304,7 @@ function wp_defer_term_counting( $defer = null ) {
  */
 function _wp_prevent_term_counting( $object_id, $object_type = 'post', $new_setting = null ) {
 	static $prevent = array();
-	$object_key = "{$object_type}::{$object_id}";
+	$object_key     = "{$object_type}::{$object_id}";
 
 	if ( is_bool( $new_setting ) ) {
 		$prevent[ $object_key ] = $new_setting;

--- a/tests/phpunit/tests/term/termCounts.php
+++ b/tests/phpunit/tests/term/termCounts.php
@@ -722,10 +722,12 @@ class Tests_Term_termCount extends WP_UnitTestCase {
 		 */
 		$post_id = $this->factory()->post->create( array( 'tags_input' => array( $terms[2] ) ) );
 		// Term applied to inserted object.
+		$this->assertSame( array( $terms[2] ), wp_get_post_tags( $post_id, array( 'fields' => 'ids' ) ), 'Term not applied to original object.' );
 		$term = get_term( $terms[2] );
 		$this->assertEquals( 1, $term->count, "Count on original object's term incorrect." );
 
 		// Term applied to secondary object.
+		$this->assertSame( array( $terms[1] ), wp_get_post_tags( $other_post, array( 'fields' => 'ids' ) ), 'Term not applied to secondary object.' );
 		$term = get_term( $terms[1] );
 		$this->assertEquals( 1, $term->count, "Count on secondary object's term incorrect." );
 	}
@@ -759,6 +761,8 @@ class Tests_Term_termCount extends WP_UnitTestCase {
 		 */
 		$post_id = $this->factory()->post->create( array( 'tags_input' => array( $terms[1] ) ) );
 		// Term applied to both objects.
+		$this->assertSame( array( $terms[1] ), wp_get_post_tags( $post_id, array( 'fields' => 'ids' ) ), 'Term not applied to original object.' );
+		$this->assertSame( array( $terms[1] ), wp_get_post_tags( $other_post, array( 'fields' => 'ids' ) ), 'Term not applied to secondary object.' );
 		$term = get_term( $terms[1] );
 		$this->assertEquals( 2, $term->count, 'Count on term did not increment for both objects.' );
 	}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/51630

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
