### PR TITLE
Allow `_embed` to include all embedded objects

### DIFF
--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -716,6 +716,12 @@ class WP_REST_Server {
 						continue;
 					}
 
+					$matched = $this->match_request_to_handler( $request );
+
+					if ( ! empty( $matched ) && ! is_wp_error( $matched ) && isset( $matched[1]['args']['per_page']['maximum'] ) ) {
+						$request['per_page'] = (int) $matched[1]['args']['per_page']['maximum'];
+					}
+
 					// Embedded resources get passed context=embed.
 					if ( empty( $request['context'] ) ) {
 						$request['context'] = 'embed';


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/43439

Allow `_embed` to include all embedded object such as taxonomies, comments etc.

