### PR TITLE
Trac ticket 47719: Fixes WP_Term_Query include to return null when [0]

### DIFF
--- a/src/wp-includes/class-wp-term-query.php
+++ b/src/wp-includes/class-wp-term-query.php
@@ -423,9 +423,9 @@ class WP_Term_Query {
 		$include      = $args['include'];
 
 		if ( ! empty( $include ) ) {
-			$exclude      = '';
-			$exclude_tree = '';
-			$inclusions   = implode( ',', wp_parse_id_list( $include ) );
+			$exclude                                  = '';
+			$exclude_tree                             = '';
+			$inclusions                               = implode( ',', wp_parse_id_list( $include ) );
 			$this->sql_clauses['where']['inclusions'] = 't.term_id IN ( ' . $inclusions . ' )';
 		}
 

--- a/src/wp-includes/class-wp-term-query.php
+++ b/src/wp-includes/class-wp-term-query.php
@@ -422,14 +422,10 @@ class WP_Term_Query {
 		$exclude_tree = $args['exclude_tree'];
 		$include      = $args['include'];
 
-		$inclusions = '';
 		if ( ! empty( $include ) ) {
 			$exclude      = '';
 			$exclude_tree = '';
 			$inclusions   = implode( ',', wp_parse_id_list( $include ) );
-		}
-
-		if ( ! empty( $inclusions ) ) {
 			$this->sql_clauses['where']['inclusions'] = 't.term_id IN ( ' . $inclusions . ' )';
 		}
 

--- a/src/wp-includes/class-wp-term-query.php
+++ b/src/wp-includes/class-wp-term-query.php
@@ -734,7 +734,8 @@ class WP_Term_Query {
 
 		if ( empty( $terms ) ) {
 			wp_cache_add( $cache_key, array(), 'terms', DAY_IN_SECONDS );
-			return array();
+			$this->terms = array();
+			return $this->terms;
 		}
 
 		if ( $child_of ) {

--- a/tests/phpunit/tests/post/query.php
+++ b/tests/phpunit/tests/post/query.php
@@ -758,4 +758,21 @@ class Tests_Post_Query extends WP_UnitTestCase {
 
 		$this->assertInternalType( 'int', $q->found_posts );
 	}
+
+	/**
+	 * @ticket 47719
+	 */
+	public function test_should_return_no_posts_when_post__in_0() {
+		self::factory()->post->create_many( 4 );
+
+		$query = new WP_Query(
+			array(
+				'post_type' => 'post',
+				'post__in'  => array( 0 ),
+			)
+		);
+
+		$this->assertSame( array(), $query->posts );
+		$this->assertSame( 0, $query->found_posts );
+	}
 }

--- a/tests/phpunit/tests/term/query.php
+++ b/tests/phpunit/tests/term/query.php
@@ -858,7 +858,7 @@ class Tests_Term_Query extends WP_UnitTestCase {
 		$query = new WP_Term_Query(
 			array(
 				'taxonomy'   => 'wptests_tax',
-				'include'    => [ 0 ],
+				'include'    => array( 0 ),
 				'orderby'    => 'include',
 				'hide_empty' => false,
 			)

--- a/tests/phpunit/tests/term/query.php
+++ b/tests/phpunit/tests/term/query.php
@@ -850,20 +850,19 @@ class Tests_Term_Query extends WP_UnitTestCase {
 	/**
 	 * @ticket 47719
 	 */
-	public function test_should_return_null_when_include_0() {
+	public function test_should_return_no_terms_when_include_0() {
 		register_taxonomy( 'wptests_tax', 'post' );
 
 		self::factory()->term->create_many( 3, array( 'taxonomy' => 'wptests_tax' ) );
 
 		$query = new WP_Term_Query(
 			array(
-				'taxonomy'   => 'wptests_tax',
-				'include'    => array( 0 ),
-				'orderby'    => 'include',
-				'hide_empty' => false,
+				'taxonomy' => 'wptests_tax',
+				'include'  => array( 0 ),
 			)
 		);
 
 		$this->assertNull( $query->terms );
+		$this->assertSame( array(), $query->get_terms() );
 	}
 }

--- a/tests/phpunit/tests/term/query.php
+++ b/tests/phpunit/tests/term/query.php
@@ -862,7 +862,8 @@ class Tests_Term_Query extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertNull( $query->terms );
-		$this->assertSame( array(), $query->get_terms() );
+		$expected = array();
+		$this->assertSame( $expected, $query->terms );
+		$this->assertSame( $expected, $query->get_terms() );
 	}
 }

--- a/tests/phpunit/tests/term/query.php
+++ b/tests/phpunit/tests/term/query.php
@@ -848,7 +848,7 @@ class Tests_Term_Query extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket 49145
+	 * @ticket 47719
 	 */
 	public function test_should_return_null_when_include_0() {
 		register_taxonomy( 'wptests_tax', 'post' );

--- a/tests/phpunit/tests/term/query.php
+++ b/tests/phpunit/tests/term/query.php
@@ -846,4 +846,24 @@ class Tests_Term_Query extends WP_UnitTestCase {
 
 		$this->assertContains( $t1, $q->terms );
 	}
+
+	/**
+	 * @ticket 49145
+	 */
+	public function test_should_return_null_when_include_0() {
+		register_taxonomy( 'wptests_tax', 'post' );
+
+		self::factory()->term->create_many( 3, array( 'taxonomy' => 'wptests_tax' ) );
+
+		$query = new WP_Term_Query(
+			array(
+				'taxonomy'   => 'wptests_tax',
+				'include'    => [ 0 ],
+				'orderby'    => 'include',
+				'hide_empty' => false,
+			)
+		);
+
+		$this->assertNull( $query->terms );
+	}
 }

--- a/tests/phpunit/tests/user/query.php
+++ b/tests/phpunit/tests/user/query.php
@@ -1720,6 +1720,20 @@ class Tests_User_Query extends WP_UnitTestCase {
 		$this->assertSame( 1, $q->total_users );
 	}
 
+	/**
+	 * @ticket 47719
+	 */
+	public function test_should_return_no_users_when_include_0() {
+		$query = new WP_User_Query(
+			array(
+				'include' => array( 0 ),
+				'role'    => '',
+			)
+		);
+
+		$this->assertSame( array(), $query->get_results() );
+	}
+
 	public static function filter_users_pre_query( $posts, $query ) {
 		$query->total_users = 1;
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/47719

- Adds unit test
- Validated issue, ie returns all terms when `'include' => array( 0 ),`
- Applies [patch `47719.2.diff`](https://core.trac.wordpress.org/attachment/ticket/47719/47719.2.diff)
- Tests pass, ie returns `null`

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
