### PR TITLE
Don't update translations asynchronously during tests

### DIFF
--- a/tests/phpunit/includes/bootstrap.php
+++ b/tests/phpunit/includes/bootstrap.php
@@ -144,6 +144,10 @@ $GLOBALS['_wp_die_disabled'] = false;
 tests_add_filter( 'wp_die_handler', '_wp_die_handler_filter' );
 // Use the Spy REST Server instead of default.
 tests_add_filter( 'wp_rest_server_class', '_wp_rest_server_class_filter' );
+// Prevent updating translations asynchronously.
+tests_add_filter( 'async_update_translation', '__return_false' );
+// Disable background updates.
+tests_add_filter( 'automatic_updater_disabled', '__return_true' );
 
 // Preset WordPress options defined in bootstrap file.
 // Used to activate themes, plugins, as well as other settings.

--- a/tests/phpunit/tests/rest-api/rest-plugins-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-plugins-controller.php
@@ -43,15 +43,6 @@ class WP_REST_Plugins_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	private static $admin;
 
 	/**
-	 * Don't update translations asynchronously.
-	 */
-	public function setUp() {
-		parent::setUp();
-
-		add_filter( 'async_update_translation', '__return_false' );
-	}
-
-	/**
 	 * Set up class test fixtures.
 	 *
 	 * @since 5.5.0
@@ -97,8 +88,6 @@ class WP_REST_Plugins_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		if ( file_exists( WP_PLUGIN_DIR . '/test-plugin/test-plugin.php' ) ) {
 			$this->rmdir( WP_PLUGIN_DIR . '/test-plugin' );
 		}
-
-		remove_filter( 'async_update_translation', '__return_false' );
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/rest-plugins-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-plugins-controller.php
@@ -43,6 +43,15 @@ class WP_REST_Plugins_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	private static $admin;
 
 	/**
+	 * Don't update translations asynchronously.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		add_filter( 'async_update_translation', '__return_false' );
+	}
+
+	/**
 	 * Set up class test fixtures.
 	 *
 	 * @since 5.5.0
@@ -88,6 +97,8 @@ class WP_REST_Plugins_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		if ( file_exists( WP_PLUGIN_DIR . '/test-plugin/test-plugin.php' ) ) {
 			$this->rmdir( WP_PLUGIN_DIR . '/test-plugin' );
 		}
+
+		remove_filter( 'async_update_translation', '__return_false' );
 	}
 
 	/**


### PR DESCRIPTION
The tests for `WP_REST_Plugins_Controller::create_item()` in `WP_REST_Plugins_Controller_Test` are doing real api.w.org requests which will also return data about outdated translations. If the tests are run again,  `Language_Pack_Upgrader::sync_upgrade()` will now update the translations based on the previous data.

Trac ticket: https://core.trac.wordpress.org/ticket/51670

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
