### PR TITLE
Editor: Move pre_render_block, render_block_data, render_block_context

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -661,6 +661,20 @@ function _excerpt_render_inner_columns_blocks( $columns, $allowed_blocks ) {
 function render_block( $parsed_block ) {
 	global $post, $wp_query;
 
+	/**
+	 * Allows render_block() or WP_Block::render() to be short-circuited, by
+	 * returning a non-null value.
+	 *
+	 * @since 5.1.0
+	 *
+	 * @param string|null $pre_render   The pre-rendered content. Default null.
+	 * @param array       $parsed_block The block being rendered.
+	 */
+	$pre_render = apply_filters( 'pre_render_block', null, $parsed_block );
+	if ( ! is_null( $pre_render ) ) {
+		return $pre_render;
+	}
+
 	$context = array();
 
 	if ( $post instanceof WP_Post ) {

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -661,31 +661,6 @@ function _excerpt_render_inner_columns_blocks( $columns, $allowed_blocks ) {
 function render_block( $parsed_block ) {
 	global $post, $wp_query;
 
-	/**
-	 * Allows render_block() to be short-circuited, by returning a non-null value.
-	 *
-	 * @since 5.1.0
-	 *
-	 * @param string|null $pre_render   The pre-rendered content. Default null.
-	 * @param array       $parsed_block The block being rendered.
-	 */
-	$pre_render = apply_filters( 'pre_render_block', null, $parsed_block );
-	if ( ! is_null( $pre_render ) ) {
-		return $pre_render;
-	}
-
-	$source_block = $parsed_block;
-
-	/**
-	 * Filters the block being rendered in render_block(), before it's processed.
-	 *
-	 * @since 5.1.0
-	 *
-	 * @param array $parsed_block The block being rendered.
-	 * @param array $source_block An un-modified copy of $parsed_block, as it appeared in the source content.
-	 */
-	$parsed_block = apply_filters( 'render_block_data', $parsed_block, $source_block );
-
 	$context = array();
 
 	if ( $post instanceof WP_Post ) {
@@ -706,16 +681,6 @@ function render_block( $parsed_block ) {
 			$context['query']['categoryIds'][] = 'slug' === $wp_query->tax_query->queried_terms['category']['field'] ? get_cat_ID( $category_slug_or_id ) : $category_slug_or_id;
 		}
 	}
-
-	/**
-	 * Filters the default context provided to a rendered block.
-	 *
-	 * @since 5.5.0
-	 *
-	 * @param array $context      Default context.
-	 * @param array $parsed_block Block being rendered, filtered by `render_block_data`.
-	 */
-	$context = apply_filters( 'render_block_context', $context, $parsed_block );
 
 	$block = new WP_Block( $parsed_block, $context );
 

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -218,15 +218,7 @@ class WP_Block {
 	public function render( $options = array() ) {
 		global $post;
 
-		/**
-		 * Allows render_block() or WP_Block::render() to be short-circuited, by
-		 * returning a non-null value.
-		 *
-		 * @since 5.1.0
-		 *
-		 * @param string|null $pre_render   The pre-rendered content. Default null.
-		 * @param array       $parsed_block The block being rendered.
-		 */
+		/** This filter is documented in src/wp-includes/blocks.php. */
 		$pre_render = apply_filters( 'pre_render_block', null, $this->parsed_block );
 		if ( ! is_null( $pre_render ) ) {
 			return $pre_render;

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -23,6 +23,15 @@ class WP_Block {
 	public $parsed_block;
 
 	/**
+	 * An un-modified copy of $parsed_block, as it was before the
+	 * render_block_data filter was applied.
+	 *
+	 * @since 5.6.0
+	 * @var array
+	 */
+	protected $source_block;
+
+	/**
 	 * Name of block.
 	 *
 	 * @example "core/paragraph"
@@ -108,7 +117,7 @@ class WP_Block {
 	 * @param WP_Block_Type_Registry $registry          Optional block type registry.
 	 */
 	public function __construct( $parsed_block, $available_context = array(), $registry = null ) {
-		$source_block = $parsed_block;
+		$this->source_block = $parsed_block;
 
 		/**
 		 * Filters a block which is to be rendered by render_block() or
@@ -119,7 +128,7 @@ class WP_Block {
 		 * @param array $parsed_block The block being rendered.
 		 * @param array $source_block An un-modified copy of $parsed_block, as it appeared in the source content.
 		 */
-		$parsed_block = apply_filters( 'render_block_data', $parsed_block, $source_block );
+		$parsed_block = apply_filters( 'render_block_data', $parsed_block, $this->source_block );
 
 		/**
 		 * Filters the default context of a block which is to be rendered by
@@ -219,7 +228,7 @@ class WP_Block {
 		global $post;
 
 		/** This filter is documented in src/wp-includes/blocks.php. */
-		$pre_render = apply_filters( 'pre_render_block', null, $this->parsed_block );
+		$pre_render = apply_filters( 'pre_render_block', null, $this->source_block );
 		if ( ! is_null( $pre_render ) ) {
 			return $pre_render;
 		}

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -11,6 +11,10 @@
  *
  * @since 5.5.0
  * @property array $attributes
+ * @property array $context
+ * @property WP_Block[] $inner_blocks;
+ * @property string $inner_html;
+ * @property array $inner_content;
  */
 class WP_Block {
 
@@ -23,13 +27,13 @@ class WP_Block {
 	public $parsed_block;
 
 	/**
-	 * An un-modified copy of $parsed_block, as it was before the
-	 * render_block_data filter was applied.
+	 * All available context of the current hierarchy.
 	 *
-	 * @since 5.6.0
+	 * @since 5.5.0
 	 * @var array
+	 * @access protected
 	 */
-	protected $source_block;
+	protected $available_context;
 
 	/**
 	 * Name of block.
@@ -50,59 +54,20 @@ class WP_Block {
 	public $block_type;
 
 	/**
-	 * Block context values.
+	 * Map of block property names and their cached value.
 	 *
-	 * @since 5.5.0
+	 * Some block properties are computed lazily using a getter function. The
+	 * result is then cached here for subsequent use.
+	 *
+	 * @since 5.7.0
 	 * @var array
 	 */
-	public $context = array();
+	protected $cached_properties = array();
 
 	/**
-	 * All available context of the current hierarchy.
-	 *
-	 * @since 5.5.0
-	 * @var array
-	 * @access protected
-	 */
-	protected $available_context;
-
-	/**
-	 * List of inner blocks (of this same class)
-	 *
-	 * @since 5.5.0
-	 * @var WP_Block[]
-	 */
-	public $inner_blocks = array();
-
-	/**
-	 * Resultant HTML from inside block comment delimiters after removing inner
-	 * blocks.
-	 *
-	 * @example "...Just <!-- wp:test /--> testing..." -> "Just testing..."
-	 *
-	 * @since 5.5.0
-	 * @var string
-	 */
-	public $inner_html = '';
-
-	/**
-	 * List of string fragments and null markers where inner blocks were found
-	 *
-	 * @example array(
-	 *   'inner_html'    => 'BeforeInnerAfter',
-	 *   'inner_blocks'  => array( block, block ),
-	 *   'inner_content' => array( 'Before', null, 'Inner', null, 'After' ),
-	 * )
-	 *
-	 * @since 5.5.0
-	 * @var array
-	 */
-	public $inner_content = array();
-
-	/**
-	 * Constructor.
-	 *
-	 * Populates object properties from the provided block instance argument.
+	 * Creates a block instance from a backing `$parsed_block` array and list of
+	 * `$available_context`. From these, the block's dynamic properties can be
+	 * derived.
 	 *
 	 * The given array of context values will not necessarily be available on
 	 * the instance itself, but is treated as the full set of values provided by
@@ -117,50 +82,111 @@ class WP_Block {
 	 * @param WP_Block_Type_Registry $registry          Optional block type registry.
 	 */
 	public function __construct( $parsed_block, $available_context = array(), $registry = null ) {
-		$this->source_block = $parsed_block;
-
-		/**
-		 * Filters a block which is to be rendered by render_block() or
-		 * WP_Block::render().
-		 *
-		 * @since 5.1.0
-		 *
-		 * @param array $parsed_block The block being rendered.
-		 * @param array $source_block An un-modified copy of $parsed_block, as it appeared in the source content.
-		 */
-		$parsed_block = apply_filters( 'render_block_data', $parsed_block, $this->source_block );
-
-		/**
-		 * Filters the default context of a block which is to be rendered by
-		 * render_block() or WP_Block::render().
-		 *
-		 * @since 5.5.0
-		 *
-		 * @param array $available_context Default context.
-		 * @param array $parsed_block      Block being rendered, filtered by `render_block_data`.
-		 */
-		$available_context = apply_filters( 'render_block_context', $available_context, $parsed_block );
-
-		$this->parsed_block = $parsed_block;
-		$this->name         = $parsed_block['blockName'];
-
 		if ( is_null( $registry ) ) {
-			$registry = WP_Block_Type_Registry::get_instance();
+			$this->registry = WP_Block_Type_Registry::get_instance();
+		} else {
+			$this->registry = $registry;
 		}
 
-		$this->block_type = $registry->get_registered( $this->name );
+		$this->reset( $parsed_block, $available_context );
+	}
 
+	/**
+	 * Changes the backing `$parsed_block` and `$available_context` used to
+	 * derive the block's dynamic properties.
+	 *
+	 * @since 5.7.0
+
+	 * @param array $parsed_block      Array of parsed block properties.
+	 * @param array $available_context Optional array of ancestry context values.
+	 * @param array $cached_properties Optional cache of dynamic properties to use.
+	 */
+	protected function reset(
+		$parsed_block,
+		$available_context = array(),
+		$cached_properties = array()
+	) {
+		$this->parsed_block      = $parsed_block;
 		$this->available_context = $available_context;
+		$this->name              = $parsed_block['blockName'];
+		$this->block_type        = $this->registry->get_registered( $this->name );
+		$this->cached_properties = $cached_properties;
+	}
+
+	/**
+	 * Getter used for the block's dynamic properties:
+	 *
+	 * - `$block->attributes`
+	 * - `$block->context`
+	 * - `$block->inner_blocks`
+	 * - `$block->inner_html`
+	 * - `$block->inner_content`
+	 *
+	 * Each dynamic property is obtained by calling the associated getter
+	 * function (e.g. `this->get_attributes()`). The result is then cached in
+	 * `$this->cached_attributes` for subsequent calls.
+	 *
+	 * @since 5.5.0
+	 *
+	 * @param string $name Property name.
+	 * @return array|null Prepared attributes, or null.
+	 */
+	public function __get( $name ) {
+		if ( method_exists( $this, "get_$name" ) ) {
+			if ( ! isset( $this->cached_properties[ $name ] ) ) {
+				$this->cached_properties[ $name ] = $this->{"get_$name"}();
+			}
+
+			return $this->cached_properties[ $name ];
+		}
+
+		return null;
+	}
+
+	protected function get_attributes() {
+		$attributes = isset( $this->parsed_block['attrs'] ) ?
+			$this->parsed_block['attrs'] :
+			array();
+
+		if ( ! is_null( $this->block_type ) ) {
+			return $this->block_type->prepare_attributes_for_render( $attributes );
+		}
+
+		return $attributes;
+	}
+
+	/**
+	 * Block context values.
+	 *
+	 * Use `$block->context` to access this.
+	 *
+	 * @since 5.7.0
+	 * @return array
+	 */
+	protected function get_context() {
+		$context = array();
 
 		if ( ! empty( $this->block_type->uses_context ) ) {
 			foreach ( $this->block_type->uses_context as $context_name ) {
 				if ( array_key_exists( $context_name, $this->available_context ) ) {
-					$this->context[ $context_name ] = $this->available_context[ $context_name ];
+					$context[ $context_name ] = $this->available_context[ $context_name ];
 				}
 			}
 		}
 
-		if ( ! empty( $parsed_block['innerBlocks'] ) ) {
+		return $context;
+	}
+
+	/**
+	 * List of inner blocks (of this same class).
+	 *
+	 * Use `$block->inner_blocks` to access this.
+	 *
+	 * @since 5.7.0
+	 * @return WP_Block[]
+	 */
+	protected function get_inner_blocks() {
+		if ( ! empty( $this->parsed_block['innerBlocks'] ) ) {
 			$child_context = $this->available_context;
 
 			if ( ! empty( $this->block_type->provides_context ) ) {
@@ -171,45 +197,55 @@ class WP_Block {
 				}
 			}
 
-			$this->inner_blocks = new WP_Block_List( $parsed_block['innerBlocks'], $child_context, $registry );
+			return new WP_Block_List(
+				$this->parsed_block['innerBlocks'],
+				$child_context,
+				$this->registry
+			);
 		}
 
-		if ( ! empty( $parsed_block['innerHTML'] ) ) {
-			$this->inner_html = $parsed_block['innerHTML'];
-		}
-
-		if ( ! empty( $parsed_block['innerContent'] ) ) {
-			$this->inner_content = $parsed_block['innerContent'];
-		}
+		return array();
 	}
 
 	/**
-	 * Returns a value from an inaccessible property.
+	 * Resultant HTML from inside block comment delimiters after removing inner
+	 * blocks.
 	 *
-	 * This is used to lazily initialize the `attributes` property of a block,
-	 * such that it is only prepared with default attributes at the time that
-	 * the property is accessed. For all other inaccessible properties, a `null`
-	 * value is returned.
+	 * Use `$block->inner_html` to access this.
 	 *
-	 * @since 5.5.0
+	 * @example "...Just <!-- wp:test /--> testing..." -> "Just testing..."
 	 *
-	 * @param string $name Property name.
-	 * @return array|null Prepared attributes, or null.
+	 * @since 5.7.0
+	 * @return string
 	 */
-	public function __get( $name ) {
-		if ( 'attributes' === $name ) {
-			$this->attributes = isset( $this->parsed_block['attrs'] ) ?
-				$this->parsed_block['attrs'] :
-				array();
-
-			if ( ! is_null( $this->block_type ) ) {
-				$this->attributes = $this->block_type->prepare_attributes_for_render( $this->attributes );
-			}
-
-			return $this->attributes;
+	protected function get_inner_html() {
+		if ( ! empty( $this->parsed_block['innerHTML'] ) ) {
+			return $this->parsed_block['innerHTML'];
 		}
 
-		return null;
+		return '';
+	}
+
+	/**
+	 * List of string fragments and null markers where inner blocks were found
+	 *
+	 * Use `$block->inner_content` to access this.
+	 *
+	 * @example array(
+	 *   'inner_html'    => 'BeforeInnerAfter',
+	 *   'inner_blocks'  => array( block, block ),
+	 *   'inner_content' => array( 'Before', null, 'Inner', null, 'After' ),
+	 * )
+	 *
+	 * @since 5.7.0
+	 * @return array
+	 */
+	protected function get_inner_content() {
+		if ( ! empty( $this->parsed_block['innerContent'] ) ) {
+			return $this->parsed_block['innerContent'];
+		}
+
+		return array();
 	}
 
 	/**
@@ -228,7 +264,7 @@ class WP_Block {
 		global $post;
 
 		/** This filter is documented in src/wp-includes/blocks.php. */
-		$pre_render = apply_filters( 'pre_render_block', null, $this->source_block );
+		$pre_render = apply_filters( 'pre_render_block', null, $this->parsed_block );
 		if ( ! is_null( $pre_render ) ) {
 			return $pre_render;
 		}
@@ -240,7 +276,47 @@ class WP_Block {
 			)
 		);
 
-		$is_dynamic    = $options['dynamic'] && $this->name && null !== $this->block_type && $this->block_type->is_dynamic();
+		$initial_parsed_block      = $this->parsed_block;
+		$initial_available_context = $this->available_context;
+		$initial_cached_properties = $this->cached_properties;
+
+		/**
+		 * Filters a block which is to be rendered by render_block() or
+		 * WP_Block::render().
+		 *
+		 * @since 5.1.0
+		 *
+		 * @param array $parsed_block The block being rendered.
+		 * @param array $source_block An un-modified copy of $parsed_block, as it appeared in the source content.
+		 */
+		$parsed_block = apply_filters(
+			'render_block_data',
+			$this->parsed_block,
+			$initial_parsed_block
+		);
+
+		/**
+		 * Filters the default context of a block which is to be rendered by
+		 * render_block() or WP_Block::render().
+		 *
+		 * @since 5.5.0
+		 *
+		 * @param array $available_context Default context.
+		 * @param array $parsed_block      Block being rendered, filtered by `render_block_data`.
+		 */
+		$available_context = apply_filters(
+			'render_block_context',
+			$this->available_context,
+			$this->parsed_block
+		);
+
+		$this->reset( $parsed_block, $available_context );
+
+		$is_dynamic = $options['dynamic']
+			&& $this->name
+			&& null !== $this->block_type
+			&& $this->block_type->is_dynamic();
+
 		$block_content = '';
 
 		if ( ! $options['dynamic'] || empty( $this->block_type->skip_inner_blocks ) ) {
@@ -258,7 +334,12 @@ class WP_Block {
 
 			WP_Block_Supports::$block_to_render = $this->parsed_block;
 
-			$block_content = (string) call_user_func( $this->block_type->render_callback, $this->attributes, $block_content, $this );
+			$block_content = (string) call_user_func(
+				$this->block_type->render_callback,
+				$this->attributes,
+				$block_content,
+				$this
+			);
 
 			WP_Block_Supports::$block_to_render = $parent;
 
@@ -281,7 +362,15 @@ class WP_Block {
 		 * @param string $block_content The block content about to be appended.
 		 * @param array  $block         The full block, including name and attributes.
 		 */
-		return apply_filters( 'render_block', $block_content, $this->parsed_block );
+		$block_content = apply_filters( 'render_block', $block_content, $this->parsed_block );
+
+		$this->reset(
+			$initial_parsed_block,
+			$initial_available_context,
+			$initial_cached_properties
+		);
+
+		return $block_content;
 	}
 
 }

--- a/tests/phpunit/tests/blocks/block.php
+++ b/tests/phpunit/tests/blocks/block.php
@@ -45,6 +45,23 @@ class WP_Block_Test extends WP_UnitTestCase {
 		return 'Original: "' . $content . '", from block "' . $parsed_block['blockName'] . '"';
 	}
 
+	function filter_pre_render_block( $pre_render, $parsed_block ) {
+		if ( 'core/skip' === $parsed_block['blockName'] ) {
+			return 'Hello world!';
+		}
+		return null;
+	}
+
+	function filter_render_block_data( $parsed_block, $source_block ) {
+		$parsed_block['attrs']['tag'] = $parsed_block['attrs']['tag'] . '-filtered';
+		return $parsed_block;
+	}
+
+	function filter_render_block_context( $available_context, $parsed_block ) {
+		$available_context['core/recordId'] += 1;
+		return $available_context;
+	}
+
 	/**
 	 * @ticket 49927
 	 */
@@ -392,6 +409,124 @@ class WP_Block_Test extends WP_UnitTestCase {
 		$block         = new WP_Block( $parsed_block, $context, $this->registry );
 
 		$this->assertSame( 'abc', $block->render() );
+	}
+
+	/**
+	 * @ticket 51612
+	 */
+	function test_applies_pre_render_block_filter() {
+		$this->registry->register( 'core/skip', array() );
+
+		add_filter( 'pre_render_block', array( $this, 'filter_pre_render_block' ), 10, 2 );
+
+		$parsed_blocks = parse_blocks( '<!-- wp:skip /-->' );
+		$parsed_block  = $parsed_blocks[0];
+		$context       = array();
+		$block         = new WP_Block( $parsed_block, $context, $this->registry );
+
+		$rendered_content = $block->render();
+
+		remove_filter( 'pre_render_block', array( $this, 'filter_pre_render_block' ) );
+
+		$this->assertSame( 'Hello world!', $rendered_content );
+	}
+
+	/**
+	 * @ticket 51612
+	 */
+	function test_applies_pre_render_block_filter_to_inner_blocks() {
+		$this->registry->register( 'core/outer', array() );
+		$this->registry->register( 'core/skip', array() );
+
+		add_filter( 'pre_render_block', array( $this, 'filter_pre_render_block' ), 10, 2 );
+
+		$parsed_blocks = parse_blocks( '<!-- wp:outer --><!-- wp:skip /--> How are you?<!-- /wp:outer -->' );
+		$parsed_block  = $parsed_blocks[0];
+		$context       = array();
+		$block         = new WP_Block( $parsed_block, $context, $this->registry );
+
+		$rendered_content = $block->render();
+
+		remove_filter( 'pre_render_block', array( $this, 'filter_pre_render_block' ) );
+
+		$this->assertSame( 'Hello world! How are you?', $rendered_content );
+	}
+
+	/**
+	 * @ticket 51612
+	 */
+	function test_applies_render_block_data_filter() {
+		$this->registry->register(
+			'core/wrapper',
+			array(
+				'attributes'      => array(
+					'tag' => array(
+						'type' => 'string',
+					),
+				),
+				'render_callback' => function( $block_attributes, $content ) {
+					return sprintf(
+						'<%1$s>%2$s</%1$s>',
+						$block_attributes['tag'],
+						$content
+					);
+				},
+			)
+		);
+
+		add_filter( 'render_block_data', array( $this, 'filter_render_block_data' ), 10, 2 );
+
+		$parsed_blocks = parse_blocks( '<!-- wp:wrapper {"tag":"outer"} --><!-- wp:wrapper {"tag":"inner"} -->Hello!<!-- /wp:wrapper --><!-- /wp:wrapper -->' );
+		$parsed_block  = $parsed_blocks[0];
+		$context       = array();
+		$block         = new WP_Block( $parsed_block, $context, $this->registry );
+
+		$rendered_content = $block->render();
+
+		remove_filter( 'render_block_data', array( $this, 'filter_render_block_data' ) );
+
+		$this->assertSame( '<outer-filtered><inner-filtered>Hello!</inner-filtered></outer-filtered>', $rendered_content );
+	}
+
+	/**
+	 * @ticket 51612
+	 */
+	function test_applies_render_block_context_filter() {
+		$this->registry->register(
+			'core/outer',
+			array(
+				'attributes'       => array(
+					'recordId' => array(
+						'type' => 'number',
+					),
+				),
+				'uses_context'     => array( 'core/recordId' ),
+				'provides_context' => array(
+					'core/recordId' => 'recordId',
+				),
+			)
+		);
+		$this->registry->register(
+			'core/inner',
+			array(
+				'uses_context' => array( 'core/recordId' ),
+			)
+		);
+
+		add_filter( 'render_block_context', array( $this, 'filter_render_block_context' ), 10, 2 );
+
+		$parsed_blocks = parse_blocks( '<!-- wp:outer {"recordId":20} --><!-- wp:inner /--><!-- /wp:outer -->' );
+		$parsed_block  = $parsed_blocks[0];
+		$context       = array( 'core/recordId' => 10 );
+		$block         = new WP_Block( $parsed_block, $context, $this->registry );
+
+		$outer_context = $block->context;
+		$inner_context = $block->inner_blocks[0]->context;
+
+		remove_filter( 'render_block_context', array( $this, 'filter_render_block_context' ) );
+
+		$this->assertSame( array( 'core/recordId' => 11 ), $outer_context );
+		$this->assertSame( array( 'core/recordId' => 21 ), $inner_context );
 	}
 
 }


### PR DESCRIPTION
Move the pre_render_block, render_block_data, and render_block_context filters from render_block() to WP_Block. This ensures that they are called for all blocks, including nested blocks, not just top-level blocks.

Trac ticket: https://core.trac.wordpress.org/ticket/51612

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**