### PR TITLE
Added locale-level WP_Textdomain_Registry cache.

### DIFF
--- a/src/wp-includes/class-wp-textdomain-registry.php
+++ b/src/wp-includes/class-wp-textdomain-registry.php
@@ -37,14 +37,15 @@ class WP_Textdomain_Registry {
 	 * @since 5.6.0
 	 *
 	 * @param string $domain Text domain.
+	 * @param string $locale Locale.
 	 * @return string|false MO file path or false if there is none available.
 	 */
-	public function get( $domain ) {
-		if ( isset( $this->domains[ $domain ] ) ) {
-			return $this->domains[ $domain ];
+	public function get( $domain, $locale ) {
+		if ( isset( $this->domains[ $domain ][ $locale ] ) ) {
+			return $this->domains[ $domain ][ $locale ];
 		}
 
-		return $this->get_path_from_lang_dir( $domain );
+		return $this->get_path_from_lang_dir( $domain, $locale );
 	}
 
 	/**
@@ -53,10 +54,11 @@ class WP_Textdomain_Registry {
 	 * @since 5.6.0
 	 *
 	 * @param string $domain Text domain.
+	 * @param string $locale Locale.
 	 * @param string|false $path Language directory path or false if there is none available.
 	 */
-	public function set( $domain, $path ) {
-		$this->domains[ $domain ] = $path ? trailingslashit( $path ) : false;
+	public function set( $domain, $locale, $path ) {
+		$this->domains[ $domain ][ $locale ] = $path ? trailingslashit( $path ) : false;
 	}
 
 	/**
@@ -75,22 +77,22 @@ class WP_Textdomain_Registry {
 	 * @since 5.6.0
 	 *
 	 * @param string $domain Text domain.
+	 * @param string $locale Locale.
 	 * @return string|false MO file path or false if there is none available.
 	 */
-	private function get_path_from_lang_dir( $domain ) {
+	private function get_path_from_lang_dir( $domain, $locale ) {
 		if ( null === $this->cached_mo_files ) {
 			$this->cached_mo_files = array();
 
 			$this->set_cached_mo_files();
 		}
 
-		$locale = determine_locale();
 		$mofile = "{$domain}-{$locale}.mo";
 
 		$path = WP_LANG_DIR . '/plugins/' . $mofile;
 		if ( in_array( $path, $this->cached_mo_files, true ) ) {
 			$path = WP_LANG_DIR . '/plugins/';
-			$this->set( $domain, $path );
+			$this->set( $domain, $locale, $path );
 
 			return $path;
 		}
@@ -98,12 +100,12 @@ class WP_Textdomain_Registry {
 		$path = WP_LANG_DIR . '/themes/' . $mofile;
 		if ( in_array( $path, $this->cached_mo_files, true ) ) {
 			$path = WP_LANG_DIR . '/themes/';
-			$this->set( $domain, $path );
+			$this->set( $domain, $locale, $path );
 
 			return $path;
 		}
 
-		$this->set( $domain, false );
+		$this->set( $domain, $locale, false );
 
 		return false;
 	}

--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -1685,11 +1685,11 @@ function is_locale_switched() {
 
 /**
  * Parses the mo file path & name and returns the locale part.
- * 
+ *
  * I.e. Extracts 'locale' from '/path/to/mo/file/domain-name-locale.mo'.
  *
  * @since 5.6.0
- * 
+ *
  * @param string $mofile Path to the .mo file.
  * @return string Locale, if found in the mo file path.
  */


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/51678

This is first POC at making WP_Textdomain_Registry locale-aware. 

Because of how `load_textdomain` gets called from multiple places with different locale sources (theme, plugin, core, sth else potentially?), I _think_ the early exit within `is_readable` cannot use `determine_locale`, but has to guess it from the mo file. Therefore, I added another function, `get_locale_from_mo_file()`.

I'm setting up the test suite and a proper dev environment now to be able to run WP coding standards test and unit tests to see if anything further needs to be updated.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
