### PR TITLE
Introduce ability to validate options via `validate_callback`

### DIFF
--- a/src/wp-admin/options.php
+++ b/src/wp-admin/options.php
@@ -311,7 +311,18 @@ if ( 'update' === $action ) { // We are saving settings sent from a settings pag
 				}
 				$value = wp_unslash( $value );
 			}
-			update_option( $option, $value );
+
+			$validity = validate_option( $option, $value );
+
+			if ( is_wp_error( $validity ) ) {
+				foreach ( $validity->errors as $code => $messages ) {
+					foreach ( $messages as $message ) {
+						add_settings_error( $option, $code, $message );
+					}
+				}
+			} else {
+				update_option( $option, $value );
+			}
 		}
 
 		/*

--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -2357,8 +2357,18 @@ final class WP_Customize_Manager {
 				$validity = $setting->validate( $unsanitized_value );
 			}
 			if ( ! is_wp_error( $validity ) ) {
+				$late_validity = new WP_Error();
+
+				// Use the regular option validation if the Customize setting is an option.
+				if ( 'option' === $setting->type && ! $setting->is_multidimensional() ) {
+					$option_validity = validate_option( $setting->id, $unsanitized_value );
+					if ( is_wp_error( $option_validity ) ) {
+						$late_validity = $option_validity;
+					}
+				}
+
 				/** This filter is documented in wp-includes/class-wp-customize-setting.php */
-				$late_validity = apply_filters( "customize_validate_{$setting->id}", new WP_Error(), $unsanitized_value, $setting );
+				$late_validity = apply_filters( "customize_validate_{$setting->id}", $late_validity, $unsanitized_value, $setting );
 				if ( is_wp_error( $late_validity ) && $late_validity->has_errors() ) {
 					$validity = $late_validity;
 				}

--- a/src/wp-includes/class-wp-customize-setting.php
+++ b/src/wp-includes/class-wp-customize-setting.php
@@ -326,7 +326,7 @@ class WP_Customize_Setting {
 		}
 
 		$id_base                 = $this->id_data['base'];
-		$is_multidimensional     = ! empty( $this->id_data['keys'] );
+		$is_multidimensional     = $this->is_multidimensional();
 		$multidimensional_filter = array( $this, '_multidimensional_preview_filter' );
 
 		/*
@@ -594,6 +594,14 @@ class WP_Customize_Setting {
 
 		$validity = new WP_Error();
 
+		// Use the regular option validation if the Customize setting is an option.
+		if ( 'option' === $this->type && ! $this->is_multidimensional() ) {
+			$option_validity = validate_option( $this->id, $value );
+			if ( is_wp_error( $option_validity ) ) {
+				$validity = $option_validity;
+			}
+		}
+
 		/**
 		 * Validates a Customize setting value.
 		 *
@@ -650,6 +658,11 @@ class WP_Customize_Setting {
 	protected function set_root_value( $value ) {
 		$id_base = $this->id_data['base'];
 		if ( 'option' === $this->type ) {
+			$option_validity = validate_option( $id_base, $value );
+			if ( is_wp_error( $option_validity ) ) {
+				return false;
+			}
+
 			$autoload = true;
 			if ( isset( self::$aggregated_multidimensionals[ $this->type ][ $this->id_data['base'] ]['autoload'] ) ) {
 				$autoload = self::$aggregated_multidimensionals[ $this->type ][ $this->id_data['base'] ]['autoload'];
@@ -839,6 +852,17 @@ class WP_Customize_Setting {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Checks whether the setting is part of a multidimensional root.
+	 *
+	 * @since 5.0.0
+	 *
+	 * @return bool True if the setting is multidimensional, false otherwise.
+	 */
+	final public function is_multidimensional() {
+		return ! empty( $this->id_data['keys'] );
 	}
 
 	/**

--- a/src/wp-includes/class-wp-customize-setting.php
+++ b/src/wp-includes/class-wp-customize-setting.php
@@ -857,7 +857,7 @@ class WP_Customize_Setting {
 	/**
 	 * Checks whether the setting is part of a multidimensional root.
 	 *
-	 * @since 5.0.0
+	 * @since 5.7.0
 	 *
 	 * @return bool True if the setting is multidimensional, false otherwise.
 	 */

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -4637,7 +4637,7 @@ function wp_make_link_relative( $link ) {
  * The {@see 'validate_option_$option'} action should be used to add errors
  * to the `WP_Error` object passed-through.
  *
- * @since 5.0.0
+ * @since 5.7.0
  *
  * @param string $option The name of the option.
  * @param string $value  The unsanitized value.
@@ -4653,7 +4653,7 @@ function validate_option( $option, $value ) {
 	 *
 	 * The dynamic portion of the hook name, `$option`, refers to the option name.
 	 *
-	 * @since 5.0.0
+	 * @since 5.7.0
 	 *
 	 * @param WP_Error $errors Error object to add validation errors to.
 	 * @param mixed    $value  The option value.

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -4632,6 +4632,42 @@ function wp_make_link_relative( $link ) {
 }
 
 /**
+ * Validates an option value based on the nature of the option.
+ *
+ * The {@see 'validate_option_$option'} action should be used to add errors
+ * to the `WP_Error` object passed-through.
+ *
+ * @since 5.0.0
+ *
+ * @param string $option The name of the option.
+ * @param string $value  The unsanitized value.
+ * @return true|WP_Error True if the input was validated, otherwise WP_Error.
+ */
+function validate_option( $option, $value ) {
+	$errors = new WP_Error();
+
+	/**
+	 * Validates an option value.
+	 *
+	 * Plugins should amend the `$errors` object via its `WP_Error::add()` method.
+	 *
+	 * The dynamic portion of the hook name, `$option`, refers to the option name.
+	 *
+	 * @since 5.0.0
+	 *
+	 * @param WP_Error $errors Error object to add validation errors to.
+	 * @param mixed    $value  The option value.
+	 */
+	do_action( "validate_option_{$option}", $errors, $value );
+
+	if ( empty( $errors->errors ) ) {
+		return true;
+	}
+
+	return $errors;
+}
+
+/**
  * Sanitises various option values based on the nature of the option.
  *
  * This is basically a switch statement which will pass $value through a number

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -2194,7 +2194,7 @@ function register_initial_settings() {
  * @since 4.7.0 `$args` can be passed to set flags on the setting, similar to `register_meta()`.
  * @since 5.5.0 `$new_whitelist_options` was renamed to `$new_allowed_options`.
  *              Please consider writing more inclusive code.
- * @since 5.0.0 Introduced the `$validate_callback` argument.
+ * @since 5.7.0 Introduced the `$validate_callback` argument.
  *
  * @global array $new_allowed_options
  * @global array $wp_registered_settings

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -2390,7 +2390,7 @@ function unregister_setting( $option_group, $option_name, $deprecated = '' ) {
 	if ( isset( $wp_registered_settings[ $option_name ] ) ) {
 		// Remove the validate callback if one was set during registration.
 		if ( ! empty( $wp_registered_settings[ $option_name ]['validate_callback'] ) ) {
-			remove_filter( "validate_option_{$option_name}", $wp_registered_settings[ $option_name ]['validate_callback'], 10 );
+			remove_action( "validate_option_{$option_name}", $wp_registered_settings[ $option_name ]['validate_callback'], 10 );
 		}
 
 		// Remove the sanitize callback if one was set during registration.

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-settings-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-settings-controller.php
@@ -201,6 +201,15 @@ class WP_REST_Settings_Controller extends WP_REST_Controller {
 
 				delete_option( $args['option_name'] );
 			} else {
+				$validity = validate_option( $args['option_name'], $request[ $name ] );
+				if ( is_wp_error( $validity ) ) {
+					foreach ( $validity->errors as $code => $messages ) {
+						$validity->add_data( array( 'status' => 400 ), $code );
+					}
+
+					return $validity;
+				}
+
 				update_option( $args['option_name'], $request[ $name ] );
 			}
 		}


### PR DESCRIPTION
* Introduces `validate_option()` function.
* Introduces `validate_option_{$option}` action, which receives a `WP_Error` object to amend in case of validation errors, as well as the value to validate. The value is explicitly not to modify, keeping validation and sanitization separate.
* Allows passing a `validate_callback` argument to `register_setting()`, causing this callback to be added as an action for `validate_option_{$option}`.
* Integrates option validation via `validate_option()` into the following areas:
    * updating options via Settings API
    * updating options via REST API
    * updating options via Customizer

Note that `validate_option()` should be called separately from (and prior to) `update_option()`. If the `validate_option()` call then returns a `WP_Error`, the option should not be updated, i.e. the call should not be made. Alternatively this could be integrated into the main Option API, however then we would need to alter `update/add_option()` return values to support `WP_Error` etc., making this more complex and furthermore coupling the functionality too much IMO.

Trac ticket: https://core.trac.wordpress.org/ticket/43208

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
