### PR TITLE
Canonical redirect on front page (with trailing slashes disabled)

### DIFF
--- a/src/wp-includes/canonical.php
+++ b/src/wp-includes/canonical.php
@@ -498,7 +498,7 @@ function redirect_canonical( $requested_url = null, $do_redirect = true ) {
 
 			// Strip off trailing /index.php/.
 			$redirect['path'] = preg_replace( '|/' . preg_quote( $wp_rewrite->index, '|' ) . '/?$|', '/', $redirect['path'] );
-			$redirect['path'] = ( $redirect['path'] === '/' ) ? $redirect['path'] : user_trailingslashit( $redirect['path'] );
+			$redirect['path'] = ( '/' === $redirect['path'] ) ? $redirect['path'] : user_trailingslashit( $redirect['path'] );
 
 			if ( ! empty( $addl_path )
 				&& $wp_rewrite->using_index_permalinks()

--- a/src/wp-includes/canonical.php
+++ b/src/wp-includes/canonical.php
@@ -498,7 +498,7 @@ function redirect_canonical( $requested_url = null, $do_redirect = true ) {
 
 			// Strip off trailing /index.php/.
 			$redirect['path'] = preg_replace( '|/' . preg_quote( $wp_rewrite->index, '|' ) . '/?$|', '/', $redirect['path'] );
-			$redirect['path'] = user_trailingslashit( $redirect['path'] );
+			$redirect['path'] = ( $redirect['path'] === '/' ) ? $redirect['path'] : user_trailingslashit( $redirect['path'] );
 
 			if ( ! empty( $addl_path )
 				&& $wp_rewrite->using_index_permalinks()

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -48,7 +48,7 @@ function user_trailingslashit( $string, $type_of_url = '' ) {
 	global $wp_rewrite;
 	if ( $wp_rewrite->use_trailing_slashes ) {
 		$string = trailingslashit( $string );
-	} else {
+	} else if ( $string !== '/' ) {
 		$string = untrailingslashit( $string );
 	}
 

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -48,7 +48,7 @@ function user_trailingslashit( $string, $type_of_url = '' ) {
 	global $wp_rewrite;
 	if ( $wp_rewrite->use_trailing_slashes ) {
 		$string = trailingslashit( $string );
-	} else if ( $string !== '/' ) {
+	} else if ( '/' !== $string ) {
 		$string = untrailingslashit( $string );
 	}
 


### PR DESCRIPTION
Both code changes should prevent malformed output of _user_trailingslashit()_ function when the input value is a single slash:
`$foo = user_trailingslashit('/');`

This is the case, when the trailing slashes are removed from WP permalinks:
`$wp_rewrite->use_trailing_slashes  = false`

and _redirect_canonical()_ function is used to force the canonical redirect on front page.

Trac ticket: [https://core.trac.wordpress.org/ticket/51725](https://core.trac.wordpress.org/ticket/51725)
