### PR TITLE
Fix uninitialized variable wp_filter

### DIFF
--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -95,7 +95,7 @@ if ( WP_CACHE && apply_filters( 'enable_loading_advanced_cache_dropin', true ) &
 	include WP_CONTENT_DIR . '/advanced-cache.php';
 
 	// Re-initialize any hooks added manually by advanced-cache.php.
-	if ( $wp_filter ) {
+	if ( isset($wp_filter) ) {
 		$wp_filter = WP_Hook::build_preinitialized_hooks( $wp_filter );
 	}
 }


### PR DESCRIPTION
The variable is not set on a first installation of WordPress, so it is triggering a NOTICE debug error.
Although NOTICE errors are suppressed, this code smell should be fixed.

Trac ticket: https://core.trac.wordpress.org/ticket/51728#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
