### PR TITLE
wp-admin/includes/privacy-tools.php: Fix a PHP 8.0 fatal 

### DIFF
--- a/src/wp-admin/includes/privacy-tools.php
+++ b/src/wp-admin/includes/privacy-tools.php
@@ -352,6 +352,9 @@ function wp_privacy_generate_personal_data_export_file( $request_id ) {
 
 	// And now, all the Groups.
 	$groups = get_post_meta( $request_id, '_export_data_grouped', true );
+	if ( ! is_array( $groups ) ) {
+		$groups = array();
+	}
 
 	// First, build an "About" group on the fly for this report.
 	$about_group = array(
@@ -388,6 +391,10 @@ function wp_privacy_generate_personal_data_export_file( $request_id ) {
 
 	// Convert the groups to JSON format.
 	$groups_json = wp_json_encode( $groups );
+
+	if ( false === $groups_json ) {
+		wp_send_json_error( __( 'Unable to encode the export file (JSON report).' ) );
+	}
 
 	/*
 	 * Handle the JSON export.
@@ -769,7 +776,7 @@ function wp_privacy_process_personal_data_export_page( $response, $exporter_inde
 	} else {
 		$accumulated_data = get_post_meta( $request_id, '_export_data_raw', true );
 
-		if ( $accumulated_data ) {
+		if ( $accumulated_data && is_array( $accumulated_data ) ) {
 			$export_data = $accumulated_data;
 		}
 	}


### PR DESCRIPTION
"Parameter #1 $arr1 of function array_merge expects array, array|bool given."

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/51423

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
