### PR TITLE
wp-includes/class-wp-feed-cache.php: Fix PHP 8.0 fatal.

### DIFF
--- a/src/wp-includes/class-wp-feed-cache.php
+++ b/src/wp-includes/class-wp-feed-cache.php
@@ -26,7 +26,7 @@ class WP_Feed_Cache extends SimplePie_Cache {
 	 * @param string $extension 'spi' or 'spc'.
 	 * @return WP_Feed_Cache_Transient Feed cache handler object that uses transients.
 	 */
-	public function create( $location, $filename, $extension ) {
+	public static function create( $location, $filename, $extension ) {
 		return new WP_Feed_Cache_Transient( $location, $filename, $extension );
 	}
 }


### PR DESCRIPTION
It fixes the following PHP fatal when the fetch_feed function is called.
```
PHP Fatal error:  Uncaught TypeError: call_user_func_array(): Argument
WP_Feed_Cache::create() cannot be called statically in /var/www/wp/wp-includes/SimplePie/Registry.php:214
```

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/51423

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
