### PR TITLE
51423: wp-admin/setup-config.php fixes fwrite handle mismatch

### DIFF
--- a/src/wp-admin/setup-config.php
+++ b/src/wp-admin/setup-config.php
@@ -438,7 +438,7 @@ if ( ! /iPad|iPod|iPhone/.test( navigator.userAgent ) ) {
 			}
 
 			$error_message = '';
-			$handle 	   = fopen( $path_to_wp_config, 'w' );
+			$handle       = fopen( $path_to_wp_config, 'w' );
 			if ( false !== $handle ) {
 				foreach ( $config_file as $line ) {
 					fwrite( $handle, $line );

--- a/src/wp-admin/setup-config.php
+++ b/src/wp-admin/setup-config.php
@@ -438,10 +438,12 @@ if ( ! /iPad|iPod|iPhone/.test( navigator.userAgent ) ) {
 			}
 
 			$handle = fopen( $path_to_wp_config, 'w' );
-			foreach ( $config_file as $line ) {
-				fwrite( $handle, $line );
+			if ( false !== $handle ) {
+				foreach ( $config_file as $line ) {
+					fwrite( $handle, $line );
+				}
+				fclose( $handle );
 			}
-			fclose( $handle );
 			chmod( $path_to_wp_config, 0666 );
 			setup_config_display_header();
 			?>

--- a/src/wp-admin/setup-config.php
+++ b/src/wp-admin/setup-config.php
@@ -426,33 +426,33 @@ if ( ! /iPad|iPod|iPhone/.test( navigator.userAgent ) ) {
 })();
 </script>
 			<?php
-	else :
-		/*
-		 * If this file doesn't exist, then we are using the wp-config-sample.php
-		 * file one level up, which is for the develop repo.
-		 */
-		if ( file_exists( ABSPATH . 'wp-config-sample.php' ) ) {
-			$path_to_wp_config = ABSPATH . 'wp-config.php';
-		} else {
-			$path_to_wp_config = dirname( ABSPATH ) . '/wp-config.php';
-		}
+		else :
+			/*
+			 * If this file doesn't exist, then we are using the wp-config-sample.php
+			 * file one level up, which is for the develop repo.
+			 */
+			if ( file_exists( ABSPATH . 'wp-config-sample.php' ) ) {
+				$path_to_wp_config = ABSPATH . 'wp-config.php';
+			} else {
+				$path_to_wp_config = dirname( ABSPATH ) . '/wp-config.php';
+			}
 
-		$handle = fopen( $path_to_wp_config, 'w' );
-		foreach ( $config_file as $line ) {
-			fwrite( $handle, $line );
-		}
-		fclose( $handle );
-		chmod( $path_to_wp_config, 0666 );
-		setup_config_display_header();
-		?>
+			$handle = fopen( $path_to_wp_config, 'w' );
+			foreach ( $config_file as $line ) {
+				fwrite( $handle, $line );
+			}
+			fclose( $handle );
+			chmod( $path_to_wp_config, 0666 );
+			setup_config_display_header();
+			?>
 <h1 class="screen-reader-text"><?php _e( 'Successful database connection' ); ?></h1>
 <p><?php _e( 'All right, sparky! You&#8217;ve made it through this part of the installation. WordPress can now communicate with your database. If you are ready, time now to&hellip;' ); ?></p>
 
 <p class="step"><a href="<?php echo $install; ?>" class="button button-large"><?php _e( 'Run the installation' ); ?></a></p>
-		<?php
-	endif;
+			<?php
+		endif;
 		break;
-}
+} // end of the steps switch.
 ?>
 <?php wp_print_scripts( 'language-chooser' ); ?>
 </body>

--- a/src/wp-admin/setup-config.php
+++ b/src/wp-admin/setup-config.php
@@ -448,19 +448,22 @@ if ( ! /iPad|iPod|iPhone/.test( navigator.userAgent ) ) {
 				$wp_config_perms = fileperms( $path_to_wp_config );
 				if ( ! empty( $wp_config_perms ) && ! is_writable( $path_to_wp_config ) ) {
 					$wp_config_perms = substr( decoct( $wp_config_perms ), 2 );
-					/* translators: 1: wp-config.php, 2: wp-config.php file permission */
 					$error_message = sprintf(
-							__( 'Unable to write to %1$s file due to its permissions: %2$s. Please try again.' ),
+							/* translators: 1: wp-config.php, 2: wp-config.php file permission */
+							__( 'Unable to write to %1$s file due to the file permissions being too restrictive: %2$s. Please update the chmod file permissions to allow for write access.' ),
 							'<code>wp-config.php</code>',
 							"<code>{$wp_config_perms}</code>"
 					);
 				} else {
 					/* translators: %s: wp-config.php */
-					$error_message = sprintf( __( 'Unable to write to %s file. Please try again' ), '<code>wp-config.php</code>' );
+					$error_message = sprintf( __( 'Unable to write to %s file.' ), '<code>wp-config.php</code>' );
 				}
 			}
 
-			chmod( $path_to_wp_config, 0666 );
+			if ( ! chmod( $path_to_wp_config, 0666 ) ) {
+				/* translators: %s: wp-config.php */
+				$error_message = sprintf( __( 'Unable to change the %s file permissions to 0666.' ), '<code>wp-config.php</code>' );
+			}
 			setup_config_display_header();
 
 			if ( false !== $handle ) :

--- a/src/wp-admin/setup-config.php
+++ b/src/wp-admin/setup-config.php
@@ -438,7 +438,7 @@ if ( ! /iPad|iPod|iPhone/.test( navigator.userAgent ) ) {
 			}
 
 			$error_message = '';
-			$handle       = fopen( $path_to_wp_config, 'w' );
+			$handle        = fopen( $path_to_wp_config, 'w' );
 			if ( false !== $handle ) {
 				foreach ( $config_file as $line ) {
 					fwrite( $handle, $line );
@@ -448,11 +448,11 @@ if ( ! /iPad|iPod|iPhone/.test( navigator.userAgent ) ) {
 				$wp_config_perms = fileperms( $path_to_wp_config );
 				if ( ! empty( $wp_config_perms ) && ! is_writable( $path_to_wp_config ) ) {
 					$wp_config_perms = substr( decoct( $wp_config_perms ), 2 );
-					$error_message = sprintf(
-							/* translators: 1: wp-config.php, 2: wp-config.php file permission */
-							__( 'Unable to write to %1$s file due to the file permissions being too restrictive: %2$s. Please update the chmod file permissions to allow for write access.' ),
-							'<code>wp-config.php</code>',
-							"<code>{$wp_config_perms}</code>"
+					$error_message   = sprintf(
+						/* translators: 1: wp-config.php, 2: wp-config.php file permission */
+						__( 'Unable to write to %1$s file due to the file permissions being too restrictive: %2$s. Please update the chmod file permissions to allow for write access.' ),
+						'<code>wp-config.php</code>',
+						"<code>{$wp_config_perms}</code>"
 					);
 				} else {
 					/* translators: %s: wp-config.php */
@@ -467,13 +467,13 @@ if ( ! /iPad|iPod|iPhone/.test( navigator.userAgent ) ) {
 			setup_config_display_header();
 
 			if ( false !== $handle ) :
-			?>
+				?>
 <h1 class="screen-reader-text"><?php _e( 'Successful database connection' ); ?></h1>
 <p><?php _e( 'All right, sparky! You&#8217;ve made it through this part of the installation. WordPress can now communicate with your database. If you are ready, time now to&hellip;' ); ?></p>
 
 <p class="step"><a href="<?php echo $install; ?>" class="button button-large"><?php _e( 'Run the installation' ); ?></a></p>
-<?php
-			else:
+				<?php
+			else :
 				printf( '<p>%s</p>', $error_message );
 			endif;
 		endif;

--- a/src/wp-admin/setup-config.php
+++ b/src/wp-admin/setup-config.php
@@ -457,8 +457,11 @@ if ( ! /iPad|iPod|iPhone/.test( navigator.userAgent ) ) {
 						__( 'https://wordpress.org/support/article/changing-file-permissions/' )
 					);
 				} else {
-					/* translators: %s: wp-config.php */
-					$error_message = sprintf( __( 'Unable to write to %s file.' ), '<code>wp-config.php</code>' );
+					$error_message = sprintf(
+						/* translators: %s: wp-config.php */
+						__( 'Unable to write to %s file.' ),
+						'<code>wp-config.php</code>'
+					);
 				}
 			}
 

--- a/src/wp-admin/setup-config.php
+++ b/src/wp-admin/setup-config.php
@@ -442,7 +442,6 @@ if ( ! /iPad|iPod|iPhone/.test( navigator.userAgent ) ) {
 			// Why check for the absence of false instead of checking for resource with is_resource()?
 			// To future-proof the check for when fopen returns object instead of resource, i.e. a known
 			// change coming in PHP.
-			// @see https://github.com/php/php-tasks/issues/6
 			if ( false !== $handle ) {
 				foreach ( $config_file as $line ) {
 					fwrite( $handle, $line );

--- a/src/wp-admin/setup-config.php
+++ b/src/wp-admin/setup-config.php
@@ -475,7 +475,7 @@ if ( ! /iPad|iPod|iPhone/.test( navigator.userAgent ) ) {
 			endif;
 		endif;
 		break;
-} // end of the steps switch.
+} // End of the steps switch.
 ?>
 <?php wp_print_scripts( 'language-chooser' ); ?>
 </body>

--- a/src/wp-admin/setup-config.php
+++ b/src/wp-admin/setup-config.php
@@ -439,9 +439,11 @@ if ( ! /iPad|iPod|iPhone/.test( navigator.userAgent ) ) {
 
 			$error_message = '';
 			$handle        = fopen( $path_to_wp_config, 'w' );
-			// Why check for the absence of false instead of checking for resource with is_resource()?
-			// To future-proof the check for when fopen returns object instead of resource, i.e. a known
-			// change coming in PHP.
+			/*
+			 * Why check for the absence of false instead of checking for resource with is_resource()?
+			 * To future-proof the check for when fopen returns object instead of resource, i.e. a known
+			 * change coming in PHP.
+			 */
 			if ( false !== $handle ) {
 				foreach ( $config_file as $line ) {
 					fwrite( $handle, $line );

--- a/src/wp-admin/setup-config.php
+++ b/src/wp-admin/setup-config.php
@@ -453,6 +453,7 @@ if ( ! /iPad|iPod|iPhone/.test( navigator.userAgent ) ) {
 					$error_message   = sprintf(
 						/* translators: 1 wp-config.php, 2: Documentation URL. */
 						__( 'You need to make the file %1$s writable before you can save your changes. See <a href="%2$s">Changing File Permissions</a> for more information.' ),
+						'<code>wp-config.php</code>',
 						__( 'https://wordpress.org/support/article/changing-file-permissions/' )
 					);
 				} else {

--- a/src/wp-admin/setup-config.php
+++ b/src/wp-admin/setup-config.php
@@ -460,10 +460,7 @@ if ( ! /iPad|iPod|iPhone/.test( navigator.userAgent ) ) {
 				}
 			}
 
-			if ( ! chmod( $path_to_wp_config, 0666 ) ) {
-				/* translators: %s: wp-config.php */
-				$error_message = sprintf( __( 'Unable to change the %s file permissions to 0666.' ), '<code>wp-config.php</code>' );
-			}
+			chmod( $path_to_wp_config, 0666 );
 			setup_config_display_header();
 
 			if ( false !== $handle ) :

--- a/src/wp-admin/setup-config.php
+++ b/src/wp-admin/setup-config.php
@@ -439,6 +439,10 @@ if ( ! /iPad|iPod|iPhone/.test( navigator.userAgent ) ) {
 
 			$error_message = '';
 			$handle        = fopen( $path_to_wp_config, 'w' );
+			// Why check for the absence of false instead of checking for resource with is_resource()?
+			// To future-proof the check for when fopen returns object instead of resource, i.e. a known
+			// change coming in PHP.
+			// @see https://github.com/php/php-tasks/issues/6
 			if ( false !== $handle ) {
 				foreach ( $config_file as $line ) {
 					fwrite( $handle, $line );

--- a/src/wp-admin/setup-config.php
+++ b/src/wp-admin/setup-config.php
@@ -451,12 +451,10 @@ if ( ! /iPad|iPod|iPhone/.test( navigator.userAgent ) ) {
 			} else {
 				$wp_config_perms = fileperms( $path_to_wp_config );
 				if ( ! empty( $wp_config_perms ) && ! is_writable( $path_to_wp_config ) ) {
-					$wp_config_perms = substr( decoct( $wp_config_perms ), 2 );
 					$error_message   = sprintf(
-						/* translators: 1: wp-config.php, 2: wp-config.php file permission */
-						__( 'Unable to write to %1$s file due to the file permissions being too restrictive: %2$s. Please update the chmod file permissions to allow for write access.' ),
-						'<code>wp-config.php</code>',
-						"<code>{$wp_config_perms}</code>"
+						/* translators: 1 wp-config.php, 2: Documentation URL. */
+						__( 'You need to make the file %1$s writable before you can save your changes. See <a href="%2$s">Changing File Permissions</a> for more information.' ),
+						__( 'https://wordpress.org/support/article/changing-file-permissions/' )
 					);
 				} else {
 					/* translators: %s: wp-config.php */


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/51423

- Fixes a `fwrite` handle type mismatch which happens if [`fopen`](https://www.php.net/manual/en/function.fopen.php) fails, i.e. returns `false`
- Adds error messaging for it

Note:
The new conditional uses the absence of `false` instead of checking for a resource. Why? PHP has plans to change `fopen` to return `object` instead of current `resource` in a future version. This not falsey check though opposite ensures the code is future-proof when the new version is released. 

An inline comment (thanks @peterwilsoncc) is added to explain and provides a learning opportunity for those who read the code.

@props xknown, hellofromTonya, jrf, peterwilsoncc

## TODO

- [x] Review new error messaging with the Polyglots team
- [x] Review `chmod` failed error messaging

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
