### PR TITLE
51423: wp-admin/includes/class-wp-site-icon.php: PHP 8.0 compatibility fix

### DIFF
--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3896,12 +3896,18 @@ function wp_ajax_crop_image() {
 			/** This filter is documented in wp-admin/includes/class-custom-image-header.php */
 			$cropped = apply_filters( 'wp_create_file_in_uploads', $cropped, $attachment_id ); // For replication.
 			$object  = $wp_site_icon->create_attachment_object( $cropped, $attachment_id );
+			if ( is_wp_error( $object ) ) {
+				wp_send_json_error();
+			}
 			unset( $object['ID'] );
 
 			// Update the attachment.
 			add_filter( 'intermediate_image_sizes_advanced', array( $wp_site_icon, 'additional_sizes' ) );
 			$attachment_id = $wp_site_icon->insert_attachment( $object, $cropped );
 			remove_filter( 'intermediate_image_sizes_advanced', array( $wp_site_icon, 'additional_sizes' ) );
+			if ( is_wp_error( $attachment_id ) ) {
+				wp_send_json_error();
+			}
 
 			// Additional sizes in wp_prepare_attachment_for_js().
 			add_filter( 'image_size_names_choose', array( $wp_site_icon, 'additional_sizes' ) );

--- a/src/wp-admin/includes/class-wp-site-icon.php
+++ b/src/wp-admin/includes/class-wp-site-icon.php
@@ -80,10 +80,13 @@ class WP_Site_Icon {
 	 *
 	 * @param string $cropped              Cropped image URL.
 	 * @param int    $parent_attachment_id Attachment ID of parent image.
-	 * @return array Attachment object.
+	 * @return array|WP_Error Attachment object, or a WP_Error instance on an invalid attachment ID.
 	 */
 	public function create_attachment_object( $cropped, $parent_attachment_id ) {
-		$parent     = get_post( $parent_attachment_id );
+		$parent = get_post( $parent_attachment_id );
+		if ( null === $parent || ! $parent->ID ) {
+			return new WP_Error( 'invalid_post_id', __( 'Invalid post ID.' ) );
+		}
 		$parent_url = wp_get_attachment_url( $parent->ID );
 		$url        = str_replace( wp_basename( $parent_url ), wp_basename( $cropped ), $parent_url );
 
@@ -109,11 +112,14 @@ class WP_Site_Icon {
 	 *
 	 * @param array  $object Attachment object.
 	 * @param string $file   File path of the attached image.
-	 * @return int           Attachment ID
+	 * @return int|WP_Error  Attachment ID, or a WP_Error instance if there's an error while inserting the attachment object.
 	 */
 	public function insert_attachment( $object, $file ) {
 		$attachment_id = wp_insert_attachment( $object, $file );
-		$metadata      = wp_generate_attachment_metadata( $attachment_id, $file );
+		if ( is_wp_error( $attachment_id ) ) {
+			return $attachment_id;
+		}
+		$metadata = wp_generate_attachment_metadata( $attachment_id, $file );
 
 		/**
 		 * Filters the site icon attachment metadata.


### PR DESCRIPTION
Update `WP_Site_Icon::create_attachment_object()` as well as
`WP_Site_Icon::insert_attachment()` to handle error conditions.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/51423

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
