### PR TITLE
51423: wp-admin/includes/nav-menu.php: PHP 8.0 compatibility fix

### DIFF
--- a/src/wp-admin/includes/nav-menu.php
+++ b/src/wp-admin/includes/nav-menu.php
@@ -814,7 +814,7 @@ function wp_nav_menu_item_taxonomy_meta_box( $object, $box ) {
 		<div id="tabs-panel-<?php echo $taxonomy_name; ?>-pop" class="tabs-panel <?php echo ( 'most-used' === $current_tab ? 'tabs-panel-active' : 'tabs-panel-inactive' ); ?>" role="region" aria-label="<?php echo $taxonomy->labels->most_used; ?>" tabindex="0">
 			<ul id="<?php echo $taxonomy_name; ?>checklist-pop" class="categorychecklist form-no-clear" >
 				<?php
-				$popular_terms  = get_terms(
+				$popular_terms = get_terms(
 					array(
 						'taxonomy'     => $taxonomy_name,
 						'orderby'      => 'count',
@@ -823,9 +823,13 @@ function wp_nav_menu_item_taxonomy_meta_box( $object, $box ) {
 						'hierarchical' => false,
 					)
 				);
-				$args['walker'] = $walker;
-				echo walk_nav_menu_tree( array_map( 'wp_setup_nav_menu_item', $popular_terms ), 0, (object) $args );
-				?>
+				if ( is_array( $popular_terms ) ) :
+					$args['walker'] = $walker;
+					echo walk_nav_menu_tree( array_map( 'wp_setup_nav_menu_item', $popular_terms ), 0, (object) $args );
+				elseif ( is_wp_error( $popular_terms ) ) :
+					?>
+					<li><?php echo $popular_terms->get_error_message(); ?></li>
+				<?php endif; ?>
 			</ul>
 		</div><!-- /.tabs-panel -->
 
@@ -837,9 +841,13 @@ function wp_nav_menu_item_taxonomy_meta_box( $object, $box ) {
 			<?php endif; ?>
 			<ul id="<?php echo $taxonomy_name; ?>checklist" data-wp-lists="list:<?php echo $taxonomy_name; ?>" class="categorychecklist form-no-clear">
 				<?php
-				$args['walker'] = $walker;
-				echo walk_nav_menu_tree( array_map( 'wp_setup_nav_menu_item', $terms ), 0, (object) $args );
-				?>
+				if ( is_array( $terms ) ) :
+					$args['walker'] = $walker;
+					echo walk_nav_menu_tree( array_map( 'wp_setup_nav_menu_item', $terms ), 0, (object) $args );
+				elseif ( is_wp_error( $terms ) ) :
+					?>
+					<li><?php echo $terms->get_error_message(); ?></li>
+				<?php endif; ?>
 			</ul>
 			<?php if ( ! empty( $page_links ) ) : ?>
 				<div class="add-menu-item-pagelinks">
@@ -875,7 +883,7 @@ function wp_nav_menu_item_taxonomy_meta_box( $object, $box ) {
 			</p>
 
 			<ul id="<?php echo $taxonomy_name; ?>-search-checklist" data-wp-lists="list:<?php echo $taxonomy_name; ?>" class="categorychecklist form-no-clear">
-			<?php if ( ! empty( $search_results ) && ! is_wp_error( $search_results ) ) : ?>
+			<?php if ( ! empty( $search_results ) && is_array( $search_results ) ) : ?>
 				<?php
 				$args['walker'] = $walker;
 				echo walk_nav_menu_tree( array_map( 'wp_setup_nav_menu_item', $search_results ), 0, (object) $args );


### PR DESCRIPTION
Add WP_Error checks for the `get_terms` calls to avoid PHP 8.0 type errors.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/51423

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
