### PR TITLE
51423: wp-admin/includes/taxonomy.php: PHP 8.0 compatibility fix

### DIFF
--- a/src/wp-admin/includes/taxonomy.php
+++ b/src/wp-admin/includes/taxonomy.php
@@ -226,7 +226,7 @@ function tag_exists( $tag_name ) {
  *
  * @since 2.3.0
  *
- * @param int|string $tag_name
+ * @param string $tag_name
  * @return array|WP_Error
  */
 function wp_create_tag( $tag_name ) {
@@ -264,6 +264,9 @@ function get_terms_to_edit( $post_id, $taxonomy = 'post_tag' ) {
 	$terms = get_object_term_cache( $post_id, $taxonomy );
 	if ( false === $terms ) {
 		$terms = wp_get_object_terms( $post_id, $taxonomy );
+		if ( is_wp_error( $terms ) ) {
+			return $terms;
+		}
 		wp_cache_add( $post_id, wp_list_pluck( $terms, 'term_id' ), $taxonomy . '_relationships' );
 	}
 


### PR DESCRIPTION
Don't attempt to use `wp_list_pluck` on a `WP_Error` object.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/51423

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
