### PR TITLE
51423: wp-includes/bookmark.php PHP 8 compatibility fix for array_unique 

### DIFF
--- a/src/wp-includes/bookmark.php
+++ b/src/wp-includes/bookmark.php
@@ -40,7 +40,8 @@ function get_bookmark( $bookmark, $output = OBJECT, $filter = 'raw' ) {
 			if ( ! $_bookmark ) {
 				$_bookmark = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->links WHERE link_id = %d LIMIT 1", $bookmark ) );
 				if ( $_bookmark ) {
-					$_bookmark->link_category = array_unique( wp_get_object_terms( $_bookmark->link_id, 'link_category', array( 'fields' => 'ids' ) ) );
+					$link_category            = wp_get_object_terms( $_bookmark->link_id, 'link_category', array( 'fields' => 'ids' ) );
+					$_bookmark->link_category = array_unique( $link_category );
 					wp_cache_add( $_bookmark->link_id, $_bookmark, 'bookmark' );
 				}
 			}

--- a/src/wp-includes/bookmark.php
+++ b/src/wp-includes/bookmark.php
@@ -48,7 +48,7 @@ function get_bookmark( $bookmark, $output = OBJECT, $filter = 'raw' ) {
 		}
 	}
 
-	if ( ! $_bookmark ) {
+	if ( empty( $_bookmark ) ) {
 		return $_bookmark;
 	}
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/51423

Fixes `array_unique` in `wp-includes/bookmark.php`:
>"Parameter 1 $input of function array_unique expects array, array|WP_Error given."

- `wp_get_object_terms` returns `array` or `WP_Error`. Check if an error is returned. If no, then pass the array into `array_unique`; else, return the error.

- Adds happy and unhappy path tests for `get_bookmark()` function.
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
