### PR TITLE
Unit Tests: Only enforce GD extension requirement when running core tests

### DIFF
--- a/tests/phpunit/includes/bootstrap.php
+++ b/tests/phpunit/includes/bootstrap.php
@@ -53,24 +53,27 @@ if ( version_compare( $phpunit_version, '5.4', '<' ) || version_compare( $phpuni
 	exit( 1 );
 }
 
-$required_extensions = array(
-	'gd',
-);
-$missing_extensions  = array();
-
-foreach ( $required_extensions as $extension ) {
-	if ( ! extension_loaded( $extension ) ) {
-		$missing_extensions[] = $extension;
-	}
-}
-
-if ( $missing_extensions ) {
-	printf(
-		"Error: The following required PHP extensions are missing from the testing environment: %s.\n",
-		implode( ', ', $missing_extensions )
+// If running core tests, check if all the required PHP extensions are loaded before running the test suite.
+if ( defined( 'WP_RUN_CORE_TESTS' ) && WP_RUN_CORE_TESTS ) {
+	$required_extensions = array(
+		'gd',
 	);
-	echo "Please make sure they are installed and enabled.\n",
-	exit( 1 );
+	$missing_extensions  = array();
+
+	foreach ( $required_extensions as $extension ) {
+		if ( ! extension_loaded( $extension ) ) {
+			$missing_extensions[] = $extension;
+		}
+	}
+
+	if ( $missing_extensions ) {
+		printf(
+			"Error: The following required PHP extensions are missing from the testing environment: %s.\n",
+			implode( ', ', $missing_extensions )
+		);
+		echo "Please make sure they are installed and enabled.\n",
+		exit( 1 );
+	}
 }
 
 $required_constants = array(


### PR DESCRIPTION
This allows other users of the WordPress unit test suite framework to run their own unit tests without needing the GD extension, which should only be a requirement if running core tests.

To skip the required PHP extension checks, set `WP_RUN_CORE_TESTS` to `false`.

Trac ticket: https://core.trac.wordpress.org/ticket/50640