### PR TITLE
Fix wp_localize_script for scalar values

### DIFF
--- a/.env
+++ b/.env
@@ -16,7 +16,7 @@ LOCAL_PORT=8889
 LOCAL_DIR=src
 
 # The PHP version to use. Valid options are 'latest', and '{version}-fpm'.
-LOCAL_PHP=8.0-fpm
+LOCAL_PHP=latest
 
 ##
 # The PHPUnit version to use when running tests.

--- a/.env
+++ b/.env
@@ -16,7 +16,7 @@ LOCAL_PORT=8889
 LOCAL_DIR=src
 
 # The PHP version to use. Valid options are 'latest', and '{version}-fpm'.
-LOCAL_PHP=latest
+LOCAL_PHP=8.0-fpm
 
 ##
 # The PHPUnit version to use when running tests.

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -215,6 +215,47 @@ JS;
 		// No scripts left to print.
 		$this->assertSame( '', get_echo( 'wp_print_scripts' ) );
 	}
+	/**
+	 * Testing `wp_localize_script` with scalar and array values.
+	 * @ticket 29722
+	 */
+	function test_wp_localize_script_with_non_array() {
+		// Enqueue & localize variables
+		wp_enqueue_script( 'test-l10n-data', 'example.com', array(), null );
+		wp_localize_script( 'test-l10n-data', 'data', true );
+
+		$test_array = array( 'var' => 'string' );
+		wp_localize_script( 'test-l10n-data', 'dataArray', $test_array );
+
+		$test_multidimensional = array(
+			'first-level' => array(
+					'second-level' => array(
+							'index' => "I'll \"walk\" the <b>dog</b> now",
+					),
+		        ),
+		);
+		wp_localize_script( 'test-l10n-data', 'dataMultiDimensionalArray', $test_multidimensional );
+
+		// Boolean output.
+		$expected = "var data = \"1\";\n";
+
+		// One-dimensional array output.
+		$expected .= "var dataArray = {\"var\":\"string\"};\n";
+
+		// Multi-dimensional array output with odd characters.
+		$string = '\"walk\"';
+		$expected .= "var dataMultiDimensionalArray = {\"first-level\":{\"second-level\":{\"index\":\"I'll " . $string . " the <b>dog<\/b> now\"}}};\n";
+
+		// var script wrapper output
+		$expected = "<script type='text/javascript'>\n/* <![CDATA[ */\n$expected/* ]]> */\n</script>\n";
+		// script link output
+		$expected .= "<script type='text/javascript' src='http://example.com'></script>\n";
+
+		$this->assertEquals( $expected, get_echo( 'wp_print_scripts' ) );
+
+		// No scripts left to print
+		$this->assertEquals( '', get_echo( 'wp_print_scripts' ) );
+	}
 
 	/**
 	 * Testing 'wp_register_script' return boolean success/failure value.


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

## Description

- Refreshed the [latest patch](https://core.trac.wordpress.org/attachment/ticket/29722/29722.4.diff) on 29722
- Passing scalars just outputs them,
- Passing strings now also works on PHP 8.

## Reference

Trac ticket: https://core.trac.wordpress.org/ticket/29722

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
