### PR TITLE
Fix spelling error typo

### DIFF
--- a/src/wp-includes/category-template.php
+++ b/src/wp-includes/category-template.php
@@ -248,7 +248,7 @@ function get_the_category_list( $separator = '', $parents = '', $post_id = false
  * @since 1.2.0
  * @since 2.7.0 The `$post` parameter was added.
  *
- * @param int|string|array $category Category ID, name or slug, or array of said.
+ * @param int|string|array $category Category ID, name or slug, or array of IDs.
  * @param int|object       $post     Optional. Post to check instead of the current post.
  * @return bool True if the current post is in any of the given categories.
  */


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

On **wp-includes/category-template.php** file there is a spelling error in the documentation of the in_category function.
It is saying **array of said** instead of **array of IDs**.

Trac ticket: https://core.trac.wordpress.org/ticket/51825

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
