### PR TITLE
51423: PHP 8.0 fix for wp-includes/class-walker-comment.php

### DIFF
--- a/src/wp-includes/class-walker-comment.php
+++ b/src/wp-includes/class-walker-comment.php
@@ -310,7 +310,8 @@ class Walker_Comment extends Walker {
 		<?php endif; ?>
 		<div class="comment-author vcard">
 			<?php
-			if ( 0 !== (int) $args['avatar_size'] ) {
+			$args['avatar_size'] = (int) $args['avatar_size'];
+			if ( 0 !== $args['avatar_size'] ) {
 				echo get_avatar( $comment, $args['avatar_size'] );
 			}
 			?>
@@ -413,7 +414,8 @@ class Walker_Comment extends Walker {
 				<footer class="comment-meta">
 					<div class="comment-author vcard">
 						<?php
-						if ( 0 !== (int) $args['avatar_size'] ) {
+						$args['avatar_size'] = (int) $args['avatar_size'];
+						if ( 0 !== $args['avatar_size'] ) {
 							echo get_avatar( $comment, $args['avatar_size'] );
 						}
 						?>

--- a/src/wp-includes/class-walker-comment.php
+++ b/src/wp-includes/class-walker-comment.php
@@ -310,7 +310,7 @@ class Walker_Comment extends Walker {
 		<?php endif; ?>
 		<div class="comment-author vcard">
 			<?php
-			if ( 0 != $args['avatar_size'] ) {
+			if ( 0 !== (int) $args['avatar_size'] ) {
 				echo get_avatar( $comment, $args['avatar_size'] );
 			}
 			?>
@@ -413,7 +413,7 @@ class Walker_Comment extends Walker {
 				<footer class="comment-meta">
 					<div class="comment-author vcard">
 						<?php
-						if ( 0 != $args['avatar_size'] ) {
+						if ( 0 !== (int) $args['avatar_size'] ) {
 							echo get_avatar( $comment, $args['avatar_size'] );
 						}
 						?>

--- a/tests/phpunit/tests/comment/walker.php
+++ b/tests/phpunit/tests/comment/walker.php
@@ -5,25 +5,26 @@
  */
 class Tests_Comment_Walker extends WP_UnitTestCase {
 	private $post_id;
+	private $comment_id;
 
 	public function setUp() {
 		parent::setUp();
 
-		$this->post_id = self::factory()->post->create();
+		$this->post_id    = self::factory()->post->create();
+		$this->comment_id = self::factory()->comment->create( array( 'comment_post_ID' => $this->post_id ) );
 	}
 
 	/**
 	 * @ticket 14041
 	 */
 	public function test_has_children() {
-		$comment_parent = self::factory()->comment->create( array( 'comment_post_ID' => $this->post_id ) );
 		$comment_child  = self::factory()->comment->create(
 			array(
 				'comment_post_ID' => $this->post_id,
-				'comment_parent'  => $comment_parent,
+				'comment_parent'  => $this->comment_id,
 			)
 		);
-		$comment_parent = get_comment( $comment_parent );
+		$comment_parent = get_comment( $this->comment_id );
 		$comment_child  = get_comment( $comment_child );
 
 		$comment_walker   = new Walker_Comment();
@@ -47,18 +48,137 @@ class Tests_Comment_Walker extends WP_UnitTestCase {
 		);
 	}
 
-	public function test_do_not_output_avatar_size_on_empty_string() {
-		$comment_id = self::factory()->comment->create( array( 'comment_post_ID' => $this->post_id ) );
-		$comment    = get_comment( $comment_id );
-		$output     = wp_list_comments(
-			array(
-				'walker'      => new Walker_Comment(),
-				'echo'        => false,
-				'avatar_size' => '',
+	/**
+	 * @dataProvider dataAvatarSize
+	 *
+	 * @param bool  $has_avatar Indicates if the output should contain an avatar.
+	 * @param array $args       Formatting options.
+	 */
+	public function test_avatar_size( $has_avatar, $args ) {
+		$comment = get_comment( $this->comment_id );
+		$actual  = wp_list_comments( $args, array( $comment ) );
+
+		if ( $has_avatar ) {
+			$this->assertContains( 'gravatar.com/avatar', $actual );
+		} else {
+			$this->assertNotContains( 'gravatar.com/avatar', $actual );
+		}
+	}
+
+	public function dataAvatarSize() {
+		$walker = new Walker_Comment();
+
+		return array(
+			// HTML5 format.
+			'should_not_contain_avatar_when_size_false'              => array(
+				'has_avatar' => false,
+				'args'       => array(
+					'walker'      => $walker,
+					'echo'        => false,
+					'avatar_size' => false,
+					'format'      => 'html5',
+				),
 			),
-			array( $comment )
+			'should_not_contain_avatar_when_size_empty_string'       => array(
+				'has_avatar' => false,
+				'args'       => array(
+					'walker'      => $walker,
+					'echo'        => false,
+					'avatar_size' => '',
+					'format'      => 'html5',
+				),
+			),
+			'should_not_contain_avatar_when_size_0'                  => array(
+				'has_avatar' => false,
+				'args'       => array(
+					'walker'      => $walker,
+					'echo'        => false,
+					'avatar_size' => 0,
+					'format'      => 'html5',
+				),
+			),
+			'should_contain_avatar_when_no_size'                     => array(
+				'has_avatar' => true,
+				'args'       => array(
+					'walker' => $walker,
+					'echo'   => false,
+					'format' => 'html5',
+				),
+			),
+			'should_contain_avatar_when_size_100'                    => array(
+				'has_avatar' => true,
+				'args'       => array(
+					'walker'      => $walker,
+					'echo'        => false,
+					'avatar_size' => 100,
+					'format'      => 'html5',
+				),
+			),
+			'should_contain_avatar_when_size_string_200'             => array(
+				'has_avatar' => true,
+				'args'       => array(
+					'walker'      => $walker,
+					'echo'        => false,
+					'avatar_size' => '200',
+					'format'      => 'html5',
+				),
+			),
+
+			// xhtml format.
+			'should_not_contain_avatar_when_xhtml_size_false'        => array(
+				'has_avatar' => false,
+				'args'       => array(
+					'walker'      => $walker,
+					'echo'        => false,
+					'avatar_size' => false,
+					'format'      => 'xhtml',
+				),
+			),
+			'should_not_contain_avatar_when_xhtml_size_empty_string' => array(
+				'has_avatar' => false,
+				'args'       => array(
+					'walker'      => $walker,
+					'echo'        => false,
+					'avatar_size' => '',
+					'format'      => 'xhtml',
+				),
+			),
+			'should_not_contain_avatar_xhtml_when_size_int_0'        => array(
+				'has_avatar' => false,
+				'args'       => array(
+					'walker'      => $walker,
+					'echo'        => false,
+					'avatar_size' => 0,
+					'format'      => 'xhtml',
+				),
+			),
+			'should_contain_avatar_when_xhtml_no_size'               => array(
+				'has_avatar' => true,
+				'args'       => array(
+					'walker' => $walker,
+					'echo'   => false,
+					'format' => 'xhtml',
+				),
+			),
+			'should_contain_avatar_when_xhtml_size_int_100'          => array(
+				'has_avatar' => true,
+				'args'       => array(
+					'walker'      => $walker,
+					'echo'        => false,
+					'avatar_size' => 100,
+					'format'      => 'xhtml',
+				),
+			),
+			'should_contain_avatar_when_xhtml_size_string_200'       => array(
+				'has_avatar' => true,
+				'args'       => array(
+					'walker'      => $walker,
+					'echo'        => false,
+					'avatar_size' => '200',
+					'format'      => 'xhtml',
+				),
+			),
 		);
-		$this->assertNotContains( 'gravatar.com/avatar', $output );
 	}
 }
 

--- a/tests/phpunit/tests/comment/walker.php
+++ b/tests/phpunit/tests/comment/walker.php
@@ -48,11 +48,11 @@ class Tests_Comment_Walker extends WP_UnitTestCase {
 
 	public function test_do_not_output_avatar_size_on_empty_string() {
 		$comment_id = self::factory()->comment->create( array( 'comment_post_ID' => $this->post_id ) );
-		$comment = get_comment( $comment_id );
-		$output = wp_list_comments(
+		$comment    = get_comment( $comment_id );
+		$output     = wp_list_comments(
 			array(
-				'walker' => new Walker_Comment(),
-				'echo' => false,
+				'walker'      => new Walker_Comment(),
+				'echo'        => false,
 				'avatar_size' => '',
 			),
 			array( $comment )

--- a/tests/phpunit/tests/comment/walker.php
+++ b/tests/phpunit/tests/comment/walker.php
@@ -45,6 +45,20 @@ class Tests_Comment_Walker extends WP_UnitTestCase {
 			array( $comment_child, $comment_parent )
 		);
 	}
+
+	public function test_do_not_output_avatar_size_on_empty_string() {
+		$comment_id = self::factory()->comment->create( array( 'comment_post_ID' => $this->post_id ) );
+		$comment = get_comment( $comment_id );
+		$output = wp_list_comments(
+			array(
+				'walker' => new Walker_Comment(),
+				'echo' => false,
+				'avatar_size' => '',
+			),
+			array( $comment )
+		);
+		$this->assertNotContains( 'gravatar.com/avatar', $output );
+	}
 }
 
 class Comment_Callback_Test {

--- a/tests/phpunit/tests/comment/walker.php
+++ b/tests/phpunit/tests/comment/walker.php
@@ -4,8 +4,9 @@
  * @group comment
  */
 class Tests_Comment_Walker extends WP_UnitTestCase {
+	private $post_id;
 
-	function setUp() {
+	public function setUp() {
 		parent::setUp();
 
 		$this->post_id = self::factory()->post->create();
@@ -14,7 +15,7 @@ class Tests_Comment_Walker extends WP_UnitTestCase {
 	/**
 	 * @ticket 14041
 	 */
-	function test_has_children() {
+	public function test_has_children() {
 		$comment_parent = self::factory()->comment->create( array( 'comment_post_ID' => $this->post_id ) );
 		$comment_child  = self::factory()->comment->create(
 			array(


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/51423

- `Walker_Comment`: ensures avatar size is an `integer` type when passed to `get_avatar()` 
- Adds happy and unhappy path to validate avatar for different size types

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
