### PR TITLE
Editor: Add __isset() to WP_Block

### DIFF
--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -144,6 +144,25 @@ class WP_Block {
 	}
 
 	/**
+	 * Whether or not the block has a given property. Returns true for each of
+	 * the block's dynamic properties:
+	 *
+	 * - `$block->attributes`
+	 * - `$block->context`
+	 * - `$block->inner_blocks`
+	 * - `$block->inner_html`
+	 * - `$block->inner_content`
+	 *
+	 * @since 5.6.0
+	 *
+	 * @param string $name Property name.
+	 * @return bool
+	 */
+	public function __isset( $name ) {
+		return method_exists( $this, "get_$name" );
+	}
+
+	/**
 	 * Block attributes.
 	 *
 	 * Use `$block->attributes` to access this.

--- a/tests/phpunit/tests/blocks/block.php
+++ b/tests/phpunit/tests/blocks/block.php
@@ -534,4 +534,32 @@ class WP_Block_Test extends WP_UnitTestCase {
 		$this->assertSame( 'Record ID: 11 Record ID: 21 ', $rendered_content );
 	}
 
+	/**
+	 * @ticket 51850
+	 */
+	function test_dynamic_attributes_are_set() {
+		$this->registry->register( 'core/example', array() );
+
+		$parsed_blocks = parse_blocks( '<!-- wp:example {"ok":true} /-->' );
+		$parsed_block  = $parsed_blocks[0];
+		$context       = array();
+		$block         = new WP_Block( $parsed_block, $context, $this->registry );
+
+		$this->assertTrue( isset( $block->attributes ) );
+		$this->assertTrue( isset( $block->context ) );
+		$this->assertTrue( isset( $block->inner_blocks ) );
+		$this->assertTrue( isset( $block->inner_html ) );
+		$this->assertTrue( isset( $block->inner_content ) );
+
+		$this->assertFalse( isset( $block->missing ) );
+
+		$this->assertNotEmpty( $block->attributes );
+		$this->assertEmpty( $block->context );
+		$this->assertEmpty( $block->inner_blocks );
+		$this->assertEmpty( $block->inner_html );
+		$this->assertEmpty( $block->inner_content );
+
+		$this->assertEmpty( $block->missing );
+	}
+
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Implements `_iiset()` in `WP_Block`. This makes expressions like `isset( $block→inner_blocks )` evaluate to true.

Trac ticket: https://core.trac.wordpress.org/ticket/51850

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
