### PR TITLE
Allow forks to configure their own workflow running granularity.

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -9,6 +9,10 @@ on:
       - '[6-9].*'
   pull_request:
 
+env:
+  WP_CODING_STANDARDS: ${{ secrets.WP_CODING_STANDARDS }}
+  WP_CODING_STANDARDS_PR: ${{ secrets.WP_CODING_STANDARDS_PR }}
+
 jobs:
   # Runs PHP coding standards checks.
   #
@@ -27,6 +31,8 @@ jobs:
   phpcs:
     name: PHP coding standards
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'WordPress/wordpress-develop' || env.WP_CODING_STANDARDS || ( github.event_name == 'pull_request' && env.WP_CODING_STANDARDS_PR ) }}
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -85,8 +91,10 @@ jobs:
   jshint:
     name: JavaScript coding standards
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'WordPress/wordpress-develop' || env.WP_CODING_STANDARDS || ( github.event_name == 'pull_request' && env.WP_CODING_STANDARDS_PR ) }}
     env:
       PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: ${{ true }}
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
 
 env:
+  WP_GHA_FORK: ${{ secrets.WP_GHA_FORK }}
   WP_CODING_STANDARDS: ${{ secrets.WP_CODING_STANDARDS }}
   WP_CODING_STANDARDS_PR: ${{ secrets.WP_CODING_STANDARDS_PR }}
 
@@ -31,7 +32,7 @@ jobs:
   phpcs:
     name: PHP coding standards
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || env.WP_CODING_STANDARDS || ( github.event_name == 'pull_request' && env.WP_CODING_STANDARDS_PR ) }}
+    if: ${{ github.repository == 'WordPress/wordpress-develop' || env.WP_GHA_FORK || env.WP_CODING_STANDARDS || ( github.event_name == 'pull_request' && env.WP_CODING_STANDARDS_PR ) }}
 
     steps:
       - name: Checkout repository
@@ -91,7 +92,7 @@ jobs:
   jshint:
     name: JavaScript coding standards
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || env.WP_CODING_STANDARDS || ( github.event_name == 'pull_request' && env.WP_CODING_STANDARDS_PR ) }}
+    if: ${{ github.repository == 'WordPress/wordpress-develop' || env.WP_GHA_FORK || env.WP_CODING_STANDARDS || ( github.event_name == 'pull_request' && env.WP_CODING_STANDARDS_PR ) }}
     env:
       PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: ${{ true }}
 

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -11,6 +11,8 @@ on:
 
 env:
   LOCAL_DIR: build
+  WP_E2E: ${{ secrets.WP_E2E }}
+  WP_E2E_PR: ${{ secrets.WP_E2E_PR }}
 
 jobs:
   # Runs the end-to-end test suite.
@@ -34,6 +36,8 @@ jobs:
   e2e-tests:
     name: E2E Tests
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'WordPress/wordpress-develop' || env.WP_E2E || ( github.event_name == 'pull_request' && env.WP_E2E_PR ) }}
+
     steps:
       - name: Cancel previous runs of this workflow (pull requests only)
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -11,6 +11,7 @@ on:
 
 env:
   LOCAL_DIR: build
+  WP_GHA_FORK: ${{ secrets.WP_GHA_FORK }}
   WP_E2E: ${{ secrets.WP_E2E }}
   WP_E2E_PR: ${{ secrets.WP_E2E_PR }}
 
@@ -36,7 +37,7 @@ jobs:
   e2e-tests:
     name: E2E Tests
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || env.WP_E2E || ( github.event_name == 'pull_request' && env.WP_E2E_PR ) }}
+    if: ${{ github.repository == 'WordPress/wordpress-develop' || env.WP_GHA_FORK || env.WP_E2E || ( github.event_name == 'pull_request' && env.WP_E2E_PR ) }}
 
     steps:
       - name: Cancel previous runs of this workflow (pull requests only)

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
 
 env:
+  WP_GHA_FORK: ${{ secrets.WP_GHA_FORK }}
   WP_JS_TESTS: ${{ secrets.WP_JS_TESTS }}
   WP_JS_TESTS_PR: ${{ secrets.WP_JS_TESTS_PR }}
 
@@ -27,7 +28,7 @@ jobs:
   test-js:
     name: QUnit Tests
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || WP_JS_TESTS || ( github.event_name == 'pull_request' && env.WP_JS_TESTS_PR ) }}
+    if: ${{ github.repository == 'WordPress/wordpress-develop' || env.WP_GHA_FORK || WP_JS_TESTS || ( github.event_name == 'pull_request' && env.WP_JS_TESTS_PR ) }}
 
     steps:
       - name: Cancel previous runs of this workflow (pull requests only)

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -7,6 +7,10 @@ on:
       - '*.*'
   pull_request:
 
+env:
+  WP_JS_TESTS: ${{ secrets.WP_JS_TESTS }}
+  WP_JS_TESTS_PR: ${{ secrets.WP_JS_TESTS_PR }}
+
 jobs:
   # Runs the QUnit tests for WordPress.
   #
@@ -23,6 +27,8 @@ jobs:
   test-js:
     name: QUnit Tests
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'WordPress/wordpress-develop' || WP_JS_TESTS || ( github.event_name == 'pull_request' && env.WP_JS_TESTS_PR ) }}
+
     steps:
       - name: Cancel previous runs of this workflow (pull requests only)
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -9,6 +9,10 @@ on:
       - '[6-9].*'
   pull_request:
 
+env:
+  WP_PHP_COMPAT: ${{ secrets.WP_PHP_COMPAT }}
+  WP_PHP_COMPAT_PR: ${{ secrets.WP_PHP_COMPAT_PR }}
+
 jobs:
 
   # Runs PHP compatibility testing.
@@ -27,6 +31,7 @@ jobs:
   php-comatibility:
     name: Check PHP compatibility
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'WordPress/wordpress-develop' || env.WP_PHP_COMPAT || ( github.event_name == 'pull_request' && env.WP_PHP_COMPAT_PR ) }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
 
 env:
+  WP_GHA_FORK: ${{ secrets.WP_GHA_FORK }}
   WP_PHP_COMPAT: ${{ secrets.WP_PHP_COMPAT }}
   WP_PHP_COMPAT_PR: ${{ secrets.WP_PHP_COMPAT_PR }}
 
@@ -31,7 +32,7 @@ jobs:
   php-comatibility:
     name: Check PHP compatibility
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || env.WP_PHP_COMPAT || ( github.event_name == 'pull_request' && env.WP_PHP_COMPAT_PR ) }}
+    if: ${{ github.repository == 'WordPress/wordpress-develop' || env.WP_GHA_FORK || env.WP_PHP_COMPAT || ( github.event_name == 'pull_request' && env.WP_PHP_COMPAT_PR ) }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -11,6 +11,7 @@ on:
     - cron: '0 0 * * 0'
 
 env:
+  WP_GHA_FORK: ${{ secrets.WP_GHA_FORK }}
   WP_PHP_TESTS: ${{ secrets.WP_PHP_TESTS }}
   WP_PHP_TESTS_PR: ${{ secrets.WP_PHP_TESTS_PR }}
   LOCAL_DIR: build
@@ -37,7 +38,7 @@ jobs:
   setup-wordpress:
     name: Setup WordPress
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || env.WP_PHP_TESTS || ( github.event_name == 'pull_request' && env.WP_PHP_TESTS_PR ) }}
+    if: ${{ github.repository == 'WordPress/wordpress-develop' || env.WP_GHA_FORK || env.WP_PHP_TESTS || ( github.event_name == 'pull_request' && env.WP_PHP_TESTS_PR ) }}
 
     steps:
       - name: Cancel previous runs of this workflow (pull requests only)

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -11,6 +11,8 @@ on:
     - cron: '0 0 * * 0'
 
 env:
+  WP_PHP_TESTS: ${{ secrets.WP_PHP_TESTS }}
+  WP_PHP_TESTS_PR: ${{ secrets.WP_PHP_TESTS_PR }}
   LOCAL_DIR: build
   PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: ${{ true }}
   COMPOSER_INSTALL: ${{ false }}
@@ -35,6 +37,7 @@ jobs:
   setup-wordpress:
     name: Setup WordPress
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'WordPress/wordpress-develop' || env.WP_PHP_TESTS || ( github.event_name == 'pull_request' && env.WP_PHP_TESTS_PR ) }}
 
     steps:
       - name: Cancel previous runs of this workflow (pull requests only)

--- a/.github/workflows/verify-npm-on-windows.yml
+++ b/.github/workflows/verify-npm-on-windows.yml
@@ -9,6 +9,8 @@ on:
 
 env:
   PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: ${{ true }}
+  WP_NPM_WINDOWS: ${{ secrets.WP_NPM_WINDOWS }}
+  WP_NPM_WINDOWS_PR: ${{ secrets.WP_NPM_WINDOWS_PULL }}
 
 jobs:
   # Verifies that installing NPM dependencies and building WordPress works on Windows.
@@ -24,6 +26,8 @@ jobs:
   test-npm:
     name: Tests NPM on Windows
     runs-on: windows-latest
+    if: ${{ github.repository == 'WordPress/wordpress-develop' || env.WP_NPM_WINDOWS || ( github.event_name == 'pull_request' && env.WP_NPM_WINDOWS_PR ) }}
+
     steps:
       - name: Cancel previous runs of this workflow (pull requests only)
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/verify-npm-on-windows.yml
+++ b/.github/workflows/verify-npm-on-windows.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: ${{ true }}
+  WP_GHA_FORK: ${{ secrets.WP_GHA_FORK }}
   WP_NPM_WINDOWS: ${{ secrets.WP_NPM_WINDOWS }}
   WP_NPM_WINDOWS_PR: ${{ secrets.WP_NPM_WINDOWS_PULL }}
 
@@ -26,7 +27,7 @@ jobs:
   test-npm:
     name: Tests NPM on Windows
     runs-on: windows-latest
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || env.WP_NPM_WINDOWS || ( github.event_name == 'pull_request' && env.WP_NPM_WINDOWS_PR ) }}
+    if: ${{ github.repository == 'WordPress/wordpress-develop' || env.WP_GHA_FORK || env.WP_NPM_WINDOWS || ( github.event_name == 'pull_request' && env.WP_NPM_WINDOWS_PR ) }}
 
     steps:
       - name: Cancel previous runs of this workflow (pull requests only)

--- a/.github/workflows/welcome-new-contributors.yml
+++ b/.github/workflows/welcome-new-contributors.yml
@@ -8,6 +8,7 @@ jobs:
   # Comments on a pull request when the author is a new contributor.
   post-welcome-message:
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'WordPress/wordpress-develop' }}
 
     steps:
       - uses: bubkoo/welcome-action@v1


### PR DESCRIPTION
This limits the workflow from running by default on forks, and adds support for 2 secrets per workflow that allows for granular configuration to run workflows as desired:
- One for running the workflow under the same conditions as the mirror
- One for only running on pull requests to the forked repo.

Unfortunately, GitHub Actions does not yet support using `secrets` or `env` within the context and expression syntax used for `if:` conditions, regardless if the `env` variables are defined on the workflow, or individual job level.

Trac ticket: https://core.trac.wordpress.org/ticket/50401

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
