### PR TITLE
Community Events: Show organizer CTA when less than 4 events.

### DIFF
--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1398,6 +1398,19 @@ function wp_print_community_events_templates() {
 				</div>
 			</li>
 		<# } ) #>
+
+		<# if ( data.events.length <= 2 ) { #>
+			<li class="event-none">
+				<?php
+				printf(
+					/* translators: 1: Localized meetup organization documentation URL. */
+					__( 'Want more events? <a href="%1$s">Help organize the next one</a>!' ),
+					__( 'https://make.wordpress.org/community/organize-event-landing-page/' )
+				);
+				?>
+			</li>
+		<# } #>
+
 	</script>
 
 	<script id="tmpl-community-events-no-upcoming-events" type="text/template">


### PR DESCRIPTION
When no events are available in the Events Widget, people have always been shown a message encouraging them to help organize one (see `tmpl-community-events-no-upcoming-events`). Now that it's common for online WordCamps and Learn discussion groups to be pinned to the Events API, it's rare that there are no events in the widget, even if there are no _local_ events. Because of that, users are rarely encouraged to join their local community and help organize.

This commit adds an additional call-to-action message, which is shown when there are 1 or 2 events available.

Trac ticket: https://core.trac.wordpress.org/ticket/51664

