### PR TITLE
Adding a filter to WP_List_Table::months_dropdown() to allow overriding the list of months displayed

### DIFF
--- a/src/wp-admin/includes/class-wp-list-table.php
+++ b/src/wp-admin/includes/class-wp-list-table.php
@@ -607,12 +607,20 @@ class WP_List_Table {
 		}
 
 		/**
-		 * Filters the 'Months' drop-down query.
-		 *
-		 *
-		 * @param string $post_type The post type.
-		 * @param string $extra_checks Filtering options for the post status.
-		 */
+		* Allows overriding the list of months displayed in the admin post lists.
+		*
+		* By default (if this filter does not return an array), a query will be
+		* run to determine the months that have post items.  This query can be
+		* expensive for a large number of posts, so it may be desirable for sites to
+		* override this behavior.
+		*
+		* @since 5.7
+		*
+		* @link https://core.trac.wordpress.org/ticket/51660
+		*
+		* @param string $post_type The post type.
+		* @param string $extra_checks Filtering options for the post status.
+		*/
 		$months = apply_filters( 'edit_months_dropdown', $post_type, $extra_checks );
 
 		if ( ! is_array( $months ) ) {

--- a/src/wp-admin/includes/class-wp-list-table.php
+++ b/src/wp-admin/includes/class-wp-list-table.php
@@ -606,6 +606,13 @@ class WP_List_Table {
 			$extra_checks = $wpdb->prepare( ' AND post_status = %s', $_GET['post_status'] );
 		}
 
+		/**
+		 * Filters the 'Months' drop-down query.
+		 *
+		 *
+		 * @param string $post_type The post type.
+		 * @param string $extra_checks Filtering options for the post status.
+		 */
 		$months = apply_filters( 'edit_months_dropdown', $post_type, $extra_checks );
 
 		if ( ! is_array( $months ) ) {

--- a/src/wp-admin/includes/class-wp-list-table.php
+++ b/src/wp-admin/includes/class-wp-list-table.php
@@ -606,18 +606,22 @@ class WP_List_Table {
 			$extra_checks = $wpdb->prepare( ' AND post_status = %s', $_GET['post_status'] );
 		}
 
-		$months = $wpdb->get_results(
-			$wpdb->prepare(
-				"
-			SELECT DISTINCT YEAR( post_date ) AS year, MONTH( post_date ) AS month
-			FROM $wpdb->posts
-			WHERE post_type = %s
-			$extra_checks
-			ORDER BY post_date DESC
-		",
-				$post_type
-			)
-		);
+		$months = apply_filters( 'edit_months_dropdown', $post_type, $extra_checks );
+
+		if ( ! is_array( $months ) ) {
+			$months = $wpdb->get_results(
+				$wpdb->prepare(
+					"
+				SELECT DISTINCT YEAR( post_date ) AS year, MONTH( post_date ) AS month
+				FROM $wpdb->posts
+				WHERE post_type = %s
+				$extra_checks
+				ORDER BY post_date DESC
+			",
+					$post_type
+				)
+			);
+		}
 
 		/**
 		 * Filters the 'Months' drop-down results.


### PR DESCRIPTION
In `WP_List_Table::months_dropdown()`, a query is run to determine the months that have post items.
This query can be expensive for large posts/custom posts listing, so it may be desirable for sites to override this behavior. I am monitoring around 500ms for 500k+ posts.
The filter available, `disable_months_dropdown`, only allows removing the dropdown not overriding the query.

This modification will enable to override the query. A similar filter (media_library_months_with_files) has been set previously for the media library. 

Trac ticket: https://core.trac.wordpress.org/ticket/51660

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
