### PR TITLE
Plugins that have the `Network: true` header defined should not be able to be activated on non-multisite installs.

### DIFF
--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -775,7 +775,7 @@ class WP_Plugins_List_Table extends WP_List_Table {
 			} else {
 				$is_active               = is_plugin_active( $plugin_file );
 				$restrict_network_active = ( is_multisite() && is_plugin_active_for_network( $plugin_file ) );
-				$restrict_network_only   = ( is_multisite() && is_network_only_plugin( $plugin_file ) && ! $is_active );
+				$restrict_network_only   = ( is_network_only_plugin( $plugin_file ) && ! $is_active );
 			}
 
 			if ( $screen->in_admin( 'network' ) ) {


### PR DESCRIPTION
Plugins that have the `Network: true` header defined should not be able to be activated on non-multisite installs.

Removing the check to `is_multisite()` when defining `$restrict_network_only` to achieve this.

Fixes: https://core.trac.wordpress.org/ticket/51878