### PR TITLE
Full-text search support

### DIFF
--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -2292,20 +2292,20 @@ function upgrade_570() {
 		/*
 		 * Create fulltext indexes for `wp_posts`.
 		 */
-		$result = $wpdb->query("ALTER TABLE $wpdb->posts ADD FULLTEXT INDEX `wp_posts_fulltext` (`post_title` ASC, `post_excerpt` ASC, `post_content` ASC);");
+		$result = $wpdb->query( "ALTER TABLE $wpdb->posts ADD FULLTEXT INDEX `wp_posts_fulltext` (`post_title` ASC, `post_excerpt` ASC, `post_content` ASC);" );
 		// Return early if fulltext indexes are unsupported
 		if ( ! $result || is_wp_error( $result ) ) {
 			return;
 		}
-		$wpdb->query("ALTER TABLE $wpdb->posts ADD FULLTEXT INDEX `wp_posts_fulltext_title` (`post_title` ASC);");
-		$wpdb->query("ALTER TABLE $wpdb->posts ADD FULLTEXT INDEX `wp_posts_fulltext_excerpt` (`post_excerpt` ASC);");
-		$wpdb->query("ALTER TABLE $wpdb->posts ADD FULLTEXT INDEX `wp_posts_fulltext_content` (`post_content` ASC);");
+		$wpdb->query( "ALTER TABLE $wpdb->posts ADD FULLTEXT INDEX `wp_posts_fulltext_title` (`post_title` ASC);" );
+		$wpdb->query( "ALTER TABLE $wpdb->posts ADD FULLTEXT INDEX `wp_posts_fulltext_excerpt` (`post_excerpt` ASC);" );
+		$wpdb->query( "ALTER TABLE $wpdb->posts ADD FULLTEXT INDEX `wp_posts_fulltext_content` (`post_content` ASC);" );
 
 		/*
 		 * When upgrading from WP < 5.7.0 enable fulltext search.
 		 */
-		update_option( "fulltext_search_available", '1' );
-		update_option( "fulltext_search_enabled", '1' );
+		update_option( 'fulltext_search_available', '1' );
+		update_option( 'fulltext_search_enabled', '1' );
 	}
 }
 

--- a/src/wp-admin/options-reading.php
+++ b/src/wp-admin/options-reading.php
@@ -208,12 +208,12 @@ else :
 </fieldset></td>
 </tr>
 
-<?php if ( wp_fulltext_search_available() ): ?>
+<?php if ( wp_fulltext_search_available() ) : ?>
 <tr class="option-site-visibility">
 <th scope="row"><?php _e( 'Full-text search' ); ?> </th>
 <td><fieldset><legend class="screen-reader-text"><span><?php _e( 'Full-text search' ); ?> </span></legend>
 <label for="fulltext_search_enabled"><input name="fulltext_search_enabled" type="checkbox" id="fulltext_search_enabled" value="1" <?php echo checked( '1', get_option( 'fulltext_search_enabled' ) ); ?> />
-<?php _e( 'Use full-text search on this site' ); ?></label>
+	<?php _e( 'Use full-text search on this site' ); ?></label>
 </fieldset></td>
 </tr>
 <?php endif ?>

--- a/src/wp-admin/options-reading.php
+++ b/src/wp-admin/options-reading.php
@@ -208,6 +208,16 @@ else :
 </fieldset></td>
 </tr>
 
+<?php if ( wp_fulltext_search_available() ): ?>
+<tr class="option-site-visibility">
+<th scope="row"><?php _e( 'Full-text search' ); ?> </th>
+<td><fieldset><legend class="screen-reader-text"><span><?php _e( 'Full-text search' ); ?> </span></legend>
+<label for="fulltext_search_enabled"><input name="fulltext_search_enabled" type="checkbox" id="fulltext_search_enabled" value="1" <?php echo checked( '1', get_option( 'fulltext_search_enabled' ) ); ?> />
+<?php _e( 'Use full-text search on this site' ); ?></label>
+</fieldset></td>
+</tr>
+<?php endif ?>
+
 <?php do_settings_fields( 'reading', 'default' ); ?>
 </table>
 

--- a/src/wp-admin/options.php
+++ b/src/wp-admin/options.php
@@ -138,6 +138,7 @@ $allowed_options            = array(
 		'page_on_front',
 		'page_for_posts',
 		'blog_public',
+		'fulltext_search_enabled',
 	),
 	'writing'    => array(
 		'default_category',

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -1379,17 +1379,21 @@ class WP_Query {
 
 			foreach ( $q['search_terms'] as $term ) {
 				if ( $exclusion_prefix && ( substr( $term, 0, 1 ) === $exclusion_prefix ) ) {
-					$term = "-" . substr( $term, 1 );
+					$term = '-' . substr( $term, 1 );
 				} else {
 					$positive_terms[] = $term;
 				}
 				$fulltext_terms[] = $term;
 			}
 			$fulltext_query              = implode( ' ', $fulltext_terms );
-			$q['search_orderby_title'][] = $wpdb->prepare( "MATCH({$wpdb->posts}.post_title) AGAINST (%s IN BOOLEAN MODE)",
-				implode( ' ', $positive_terms ) );
-			$search                      .= $wpdb->prepare( "{$searchand}(MATCH ({$wpdb->posts}.post_title, {$wpdb->posts}.post_excerpt, {$wpdb->posts}.post_content) AGAINST (%s IN BOOLEAN MODE))",
-				$fulltext_query );
+			$q['search_orderby_title'][] = $wpdb->prepare(
+				"MATCH({$wpdb->posts}.post_title) AGAINST (%s IN BOOLEAN MODE)",
+				implode( ' ', $positive_terms )
+			);
+			$search                     .= $wpdb->prepare(
+				"{$searchand}(MATCH ({$wpdb->posts}.post_title, {$wpdb->posts}.post_excerpt, {$wpdb->posts}.post_content) AGAINST (%s IN BOOLEAN MODE))",
+				$fulltext_query
+			);
 		} else {
 			foreach ( $q['search_terms'] as $term ) {
 				// If there is an $exclusion_prefix, terms prefixed with it should be excluded.
@@ -1410,7 +1414,7 @@ class WP_Query {
 
 				$like      = $n . $wpdb->esc_like( $term ) . $n;
 				$search   .= $wpdb->prepare( "{$searchand}(({$wpdb->posts}.post_title $like_op %s) $andor_op ({$wpdb->posts}.post_excerpt $like_op %s) $andor_op ({$wpdb->posts}.post_content $like_op %s))", $like, $like, $like );
-				$searchand     = ' AND ';
+				$searchand = ' AND ';
 			}
 		}
 

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -7790,7 +7790,7 @@ function wp_fuzzy_number_match( $expected, $actual, $precision = 1 ) {
  * @return bool Whether fulltext search is available.
  */
 function wp_fulltext_search_available() {
-	$is_available = get_option( 'fulltext_search_available' ) === "1";
+	$is_available = get_option( 'fulltext_search_available' ) === '1';
 	return apply_filters( 'fulltext_search_available', $is_available );
 }
 
@@ -7804,6 +7804,6 @@ function wp_fulltext_search_available() {
  * @return bool Whether fulltext search is enabled.
  */
 function wp_fulltext_search_enabled() {
-	$is_enabled = get_option( 'fulltext_search_enabled' ) === "1";
+	$is_enabled = get_option( 'fulltext_search_enabled' ) === '1';
 	return wp_fulltext_search_available() && apply_filters( 'fulltext_search_enabled', $is_enabled );
 }

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -7781,3 +7781,29 @@ function is_php_version_compatible( $required ) {
 function wp_fuzzy_number_match( $expected, $actual, $precision = 1 ) {
 	return abs( (float) $expected - (float) $actual ) <= $precision;
 }
+
+/**
+ * Check if fulltext search is available.
+ *
+ * @since 5.7.0
+ *
+ * @return bool Whether fulltext search is available.
+ */
+function wp_fulltext_search_available() {
+	$is_available = get_option( 'fulltext_search_available' ) === "1";
+	return apply_filters( 'fulltext_search_available', $is_available );
+}
+
+/**
+ * Check if fulltext search is enabled.
+ *
+ * Returns false if it's enabled but not available.
+ *
+ * @since 5.7.0
+ *
+ * @return bool Whether fulltext search is enabled.
+ */
+function wp_fulltext_search_enabled() {
+	$is_enabled = get_option( 'fulltext_search_enabled' ) === "1";
+	return wp_fulltext_search_available() && apply_filters( 'fulltext_search_enabled', $is_enabled );
+}

--- a/src/wp-includes/version.php
+++ b/src/wp-includes/version.php
@@ -20,7 +20,7 @@ $wp_version = '5.7-alpha-49644-src';
  *
  * @global int $wp_db_version
  */
-$wp_db_version = 49632;
+$wp_db_version = 51769;
 
 /**
  * Holds the TinyMCE version.


### PR DESCRIPTION
This PR proposes core support for fulltext search with fallback to `LIKE` when fulltext search isn't available.

Sites that would like to keep using `LIKE` could disable the `fulltext_search_enabled` option:

<img width="768" alt="Zrzut ekranu 2020-11-26 o 17 12 46" src="https://user-images.githubusercontent.com/205419/100373190-ae7a7800-300a-11eb-9429-bd4545ee7b82.png">

Trac ticket: https://core.trac.wordpress.org/ticket/51769

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
