### PR TITLE
Apply filters to auhor HTML link

### DIFF
--- a/src/wp-includes/author-template.php
+++ b/src/wp-includes/author-template.php
@@ -223,19 +223,33 @@ function the_author_meta( $field = '', $user_id = false ) {
  * author's name.
  *
  * @since 3.0.0
+ * @since 5.6.0 Apply filters to the author's HTML link.
  *
  * @return string|null An HTML link if the author's url exist in user meta,
  *                     else the result of get_the_author().
  */
 function get_the_author_link() {
 	if ( get_the_author_meta( 'url' ) ) {
-		return sprintf(
+		$author_url          = get_the_author_meta( 'url' );
+		$author_display_name = get_the_author();
+		$author_html_link    = sprintf(
 			'<a href="%1$s" title="%2$s" rel="author external">%3$s</a>',
-			esc_url( get_the_author_meta( 'url' ) ),
+			esc_url( $author_url ),
 			/* translators: %s: Author's display name. */
-			esc_attr( sprintf( __( 'Visit %s&#8217;s website' ), get_the_author() ) ),
-			get_the_author()
+			esc_attr( sprintf( __( 'Visit %s&#8217;s website' ), $author_display_name ) ),
+			$author_display_name
 		);
+
+		/**
+		 * Filters the author link HTML.
+		 *
+		 * @since 5.6.0
+		 *
+		 * @param string $author_html_link    The default rendered author HTML link.
+		 * @param string $author_url          Author's url.
+		 * @param string $author_display_name Author's display name.
+		 */
+		return apply_filters( 'author_html_link', $author_html_link, $author_url, $author_display_name );
 	} else {
 		return get_the_author();
 	}


### PR DESCRIPTION
Apply filter to author's HTML link using `author_html_link` filter.

**Example usage**

```php
/**
 * @param string $html_link       The default HTML author link.
 * @param string $author_url      The author's url.
 * @param string $display_name The author's display name. 
 */
add_filter( 'author_html_link', function( $html_link, $author_url, $display_name ) {
	return '<a href="https://wp.org">Mico</a>'; 
}, 10, 3 );
```

Trac ticket: https://core.trac.wordpress.org/ticket/51859
