### PR TITLE
51423: wp_privacy_process_personal_data_export_page() fixes type match for array_merge (PHP 8)

### DIFF
--- a/src/wp-admin/includes/privacy-tools.php
+++ b/src/wp-admin/includes/privacy-tools.php
@@ -769,7 +769,7 @@ function wp_privacy_process_personal_data_export_page( $response, $exporter_inde
 	} else {
 		$accumulated_data = get_post_meta( $request_id, '_export_data_raw', true );
 
-		if ( $accumulated_data ) {
+		if ( $accumulated_data && is_array( $accumulated_data ) ) {
 			$export_data = $accumulated_data;
 		}
 	}

--- a/src/wp-admin/includes/privacy-tools.php
+++ b/src/wp-admin/includes/privacy-tools.php
@@ -769,8 +769,17 @@ function wp_privacy_process_personal_data_export_page( $response, $exporter_inde
 	} else {
 		$accumulated_data = get_post_meta( $request_id, '_export_data_raw', true );
 
-		if ( $accumulated_data && is_array( $accumulated_data ) ) {
-			$export_data = $accumulated_data;
+		if ( $accumulated_data ) {
+			if ( is_array( $accumulated_data ) ) {
+				$export_data = $accumulated_data;
+			} else {
+				wp_send_json_error(
+					sprintf(
+						'Warning: array_merge(): Expected parameter 1 to be an array, %1$s given.',
+						gettype( $accumulated_data )
+					)
+				);
+			}
 		}
 	}
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/51423

Function: `wp_privacy_process_personal_data_export_page()`

Resolves "Parameter #1 $arr1 of function array_merge expects array, array|bool given."

Fixes the type match for `array_merge` to prevent the PHP 8 fatal error
- Adds test coverage
- Retains error behavior when/if `'_export_data_raw'` is not an array type. Error is passed via wp_send_json_error. Tests added to validate.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
