### PR TITLE
51894: WP_Hooks doing it wrong when callback is not callable (PHP8)

### DIFF
--- a/src/wp-includes/class-wp-hook.php
+++ b/src/wp-includes/class-wp-hook.php
@@ -291,9 +291,9 @@ final class WP_Hook implements Iterator, ArrayAccess {
 				}
 
 				// Avoid the array_slice() if possible.
-				if ( 0 == $the_['accepted_args'] ) {
+				if ( 0 === (int) $the_['accepted_args'] ) {
 					$value = call_user_func( $the_['function'] );
-				} elseif ( $the_['accepted_args'] >= $num_args ) {
+				} elseif ( (int) $the_['accepted_args'] >= $num_args ) {
 					$value = call_user_func_array( $the_['function'], $args );
 				} else {
 					$value = call_user_func_array( $the_['function'], array_slice( $args, 0, (int) $the_['accepted_args'] ) );

--- a/src/wp-includes/class-wp-hook.php
+++ b/src/wp-includes/class-wp-hook.php
@@ -320,7 +320,7 @@ final class WP_Hook implements Iterator, ArrayAccess {
 	 */
 	protected function get_invalid_callback_error_message( $callback ) {
 		return sprintf(
-		/* translators: %s: Invalid callback name or type. */
+			/* translators: %s: Invalid callback name or type. */
 			__( 'Requires <code>%s</code> to be a valid callback.' ),
 			$this->convert_callback_to_string( $callback )
 		);

--- a/tests/phpunit/tests/hooks/HooksTrait.php
+++ b/tests/phpunit/tests/hooks/HooksTrait.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace phpunit\tests\hooks;
+
+use MockAction;
+use WP_Hook;
+
+trait HooksTrait {
+
+	public function data_not_valid_callback() {
+		$obj = new MockAction();
+
+		return array(
+			'function callback'                 => array(
+				'callback'           => 'not_callable_callback',
+				'callback_as_string' => 'not_callable_callback',
+			),
+			'static method callback as string'  => array(
+				'callback'           => 'Foo::not_callable_callback',
+				'callback_as_string' => 'Foo::not_callable_callback',
+			),
+			'static method callback as array'   => array(
+				'callback'           => array( 'Foo', 'not_callable_callback' ),
+				'callback_as_string' => 'Foo::not_callable_callback',
+			),
+			'object method callback'            => array(
+				'callback'           => array( $obj, 'not_callable_callback' ),
+				'callback_as_string' => 'MockAction::not_callable_callback',
+			),
+			'a boolean type is not a callback'  => array(
+				'callback'           => false,
+				'callback_as_string' => 'boolean',
+			),
+			'an integer type is not a callback' => array(
+				'callback'           => 100,
+				'callback_as_string' => 'integer',
+			),
+		);
+	}
+
+	protected function setup_hook( $tag, $callback, $priority = 10, $num_args = 1 ) {
+		$hook = new WP_Hook();
+		$hook->add_filter( $tag, $callback, $priority, $num_args );
+
+		return $hook;
+	}
+}

--- a/tests/phpunit/tests/hooks/HooksTrait.php
+++ b/tests/phpunit/tests/hooks/HooksTrait.php
@@ -35,6 +35,10 @@ trait HooksTrait {
 				'callback'           => 100,
 				'callback_as_string' => 'integer',
 			),
+			'an empty array' => array(
+				'callback'           => array(),
+				'callback_as_string' => 'integer',
+			),
 		);
 	}
 

--- a/tests/phpunit/tests/hooks/applyFilters.php
+++ b/tests/phpunit/tests/hooks/applyFilters.php
@@ -5,23 +5,17 @@ use phpunit\tests\hooks\HooksTrait;
 /**
  * Test the apply_filters method of WP_Hook
  *
- * @group hooks
- *
+ * @group  hooks
  * @covers WP_Hook::apply_filters
  */
 class Tests_WP_Hook_Apply_Filters extends WP_UnitTestCase {
 	use HooksTrait;
 
 	public function test_apply_filters_with_callback() {
-		$a             = new MockAction();
-		$callback      = array( $a, 'filter' );
-		$hook          = new WP_Hook();
-		$tag           = __FUNCTION__;
-		$priority      = rand( 1, 100 );
-		$accepted_args = rand( 1, 100 );
-		$arg           = __FUNCTION__ . '_arg';
-
-		$hook->add_filter( $tag, $callback, $priority, $accepted_args );
+		$a        = new MockAction();
+		$callback = array( $a, 'filter' );
+		$hook     = $this->setup_hook( __FUNCTION__, $callback, rand( 1, 100 ), rand( 1, 100 ) );
+		$arg      = __FUNCTION__ . '_arg';
 
 		$returned = $hook->apply_filters( $arg, array( $arg ) );
 
@@ -30,15 +24,10 @@ class Tests_WP_Hook_Apply_Filters extends WP_UnitTestCase {
 	}
 
 	public function test_apply_filters_with_multiple_calls() {
-		$a             = new MockAction();
-		$callback      = array( $a, 'filter' );
-		$hook          = new WP_Hook();
-		$tag           = __FUNCTION__;
-		$priority      = rand( 1, 100 );
-		$accepted_args = rand( 1, 100 );
-		$arg           = __FUNCTION__ . '_arg';
-
-		$hook->add_filter( $tag, $callback, $priority, $accepted_args );
+		$a        = new MockAction();
+		$callback = array( $a, 'filter' );
+		$hook     = $this->setup_hook( __FUNCTION__, $callback, rand( 1, 100 ), rand( 1, 100 ) );
+		$arg      = __FUNCTION__ . '_arg';
 
 		$returned_one = $hook->apply_filters( $arg, array( $arg ) );
 		$returned_two = $hook->apply_filters( $returned_one, array( $returned_one ) );

--- a/tests/phpunit/tests/hooks/applyFilters.php
+++ b/tests/phpunit/tests/hooks/applyFilters.php
@@ -1,11 +1,16 @@
 <?php
 
+use phpunit\tests\hooks\HooksTrait;
+
 /**
  * Test the apply_filters method of WP_Hook
  *
  * @group hooks
+ *
+ * @covers WP_Hook::apply_filters
  */
 class Tests_WP_Hook_Apply_Filters extends WP_UnitTestCase {
+	use HooksTrait;
 
 	public function test_apply_filters_with_callback() {
 		$a             = new MockAction();
@@ -42,4 +47,29 @@ class Tests_WP_Hook_Apply_Filters extends WP_UnitTestCase {
 		$this->assertSame( 2, $a->get_call_count() );
 	}
 
+	/**
+	 * @ticket 51894
+	 *
+	 * @dataProvider data_not_valid_callback
+	 *
+	 * @param mixed  $callback           Invalid callback to test.
+	 * @param string $callback_as_string Callback as a string for the error message.
+	 */
+	public function test_not_valid_callback( $callback, $callback_as_string ) {
+		remove_action( 'doing_it_wrong_trigger_error', '__return_false' );
+		$this->setExpectedIncorrectUsage( 'WP_Hook::apply_filters' );
+		$this->expectException( 'PHPUnit_Framework_Error_Notice' );
+		$this->expectExceptionMessage(
+			sprintf(
+				'WP_Hook::apply_filters was called <strong>incorrectly</strong>. Requires <code>%s</code> to be a valid callback. Please see <a href="https://wordpress.org/support/article/debugging-in-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 5.6.0.)',
+				$callback_as_string
+			)
+		);
+
+		$hook = $this->setup_hook( __FUNCTION__, $callback );
+		$arg  = __FUNCTION__ . '_arg';
+
+		$actual = $hook->apply_filters( $arg, array( $arg ) );
+		$this->assertSame( $arg, $actual );
+	}
 }

--- a/tests/phpunit/tests/hooks/doAction.php
+++ b/tests/phpunit/tests/hooks/doAction.php
@@ -6,6 +6,7 @@ use phpunit\tests\hooks\HooksTrait;
  * Test the do_action method of WP_Hook
  *
  * @group hooks
+ * @covers WP_Hook::do_action
  */
 class Tests_WP_Hook_Do_Action extends WP_UnitTestCase {
 	use HooksTrait;
@@ -20,30 +21,22 @@ class Tests_WP_Hook_Do_Action extends WP_UnitTestCase {
 	}
 
 	public function test_do_action_with_callback() {
-		$a             = new MockAction();
-		$callback      = array( $a, 'action' );
-		$hook          = new WP_Hook();
-		$tag           = __FUNCTION__;
-		$priority      = rand( 1, 100 );
-		$accepted_args = rand( 1, 100 );
-		$arg           = __FUNCTION__ . '_arg';
+		$a        = new MockAction();
+		$callback = array( $a, 'action' );
+		$hook     = $this->setup_hook( __FUNCTION__, $callback, rand( 1, 100 ), rand( 1, 100 ) );
+		$arg      = __FUNCTION__ . '_arg';
 
-		$hook->add_filter( $tag, $callback, $priority, $accepted_args );
 		$hook->do_action( array( $arg ) );
 
 		$this->assertSame( 1, $a->get_call_count() );
 	}
 
 	public function test_do_action_with_multiple_calls() {
-		$a             = new MockAction();
-		$callback      = array( $a, 'filter' );
-		$hook          = new WP_Hook();
-		$tag           = __FUNCTION__;
-		$priority      = rand( 1, 100 );
-		$accepted_args = rand( 1, 100 );
-		$arg           = __FUNCTION__ . '_arg';
+		$a        = new MockAction();
+		$callback = array( $a, 'filter' );
+		$hook     = $this->setup_hook( __FUNCTION__, $callback, rand( 1, 100 ), rand( 1, 100 ) );
+		$arg      = __FUNCTION__ . '_arg';
 
-		$hook->add_filter( $tag, $callback, $priority, $accepted_args );
 		$hook->do_action( array( $arg ) );
 		$hook->do_action( array( $arg ) );
 
@@ -89,42 +82,30 @@ class Tests_WP_Hook_Do_Action extends WP_UnitTestCase {
 	}
 
 	public function test_do_action_with_no_accepted_args() {
-		$callback      = array( $this, '_action_callback' );
-		$hook          = new WP_Hook();
-		$tag           = __FUNCTION__;
-		$priority      = rand( 1, 100 );
-		$accepted_args = 0;
-		$arg           = __FUNCTION__ . '_arg';
+		$callback = array( $this, '_action_callback' );
+		$hook     = $this->setup_hook( __FUNCTION__, $callback, rand( 1, 100 ), 0 );
+		$arg      = __FUNCTION__ . '_arg';
 
-		$hook->add_filter( $tag, $callback, $priority, $accepted_args );
 		$hook->do_action( array( $arg ) );
 
 		$this->assertEmpty( $this->events[0]['args'] );
 	}
 
 	public function test_do_action_with_one_accepted_arg() {
-		$callback      = array( $this, '_action_callback' );
-		$hook          = new WP_Hook();
-		$tag           = __FUNCTION__;
-		$priority      = rand( 1, 100 );
-		$accepted_args = 1;
-		$arg           = __FUNCTION__ . '_arg';
+		$callback = array( $this, '_action_callback' );
+		$hook     = $this->setup_hook( __FUNCTION__, $callback, rand( 1, 100 ), 1 );
+		$arg      = __FUNCTION__ . '_arg';
 
-		$hook->add_filter( $tag, $callback, $priority, $accepted_args );
 		$hook->do_action( array( $arg ) );
 
 		$this->assertCount( 1, $this->events[0]['args'] );
 	}
 
 	public function test_do_action_with_more_accepted_args() {
-		$callback      = array( $this, '_action_callback' );
-		$hook          = new WP_Hook();
-		$tag           = __FUNCTION__;
-		$priority      = rand( 1, 100 );
-		$accepted_args = 1000;
-		$arg           = __FUNCTION__ . '_arg';
+		$callback = array( $this, '_action_callback' );
+		$hook     = $this->setup_hook( __FUNCTION__, $callback, rand( 1, 100 ), 100 );
+		$arg      = __FUNCTION__ . '_arg';
 
-		$hook->add_filter( $tag, $callback, $priority, $accepted_args );
 		$hook->do_action( array( $arg ) );
 
 		$this->assertCount( 1, $this->events[0]['args'] );
@@ -145,8 +126,10 @@ class Tests_WP_Hook_Do_Action extends WP_UnitTestCase {
 
 	public function _filter_do_action_doesnt_change_value1( $value ) {
 		$this->action_output .= $value . 1;
+
 		return 'x1';
 	}
+
 	public function _filter_do_action_doesnt_change_value2( $value ) {
 		$this->hook->remove_filter( 'do_action_doesnt_change_value', array( $this, '_filter_do_action_doesnt_change_value2' ), 10 );
 
@@ -163,6 +146,7 @@ class Tests_WP_Hook_Do_Action extends WP_UnitTestCase {
 
 	public function _filter_do_action_doesnt_change_value3( $value ) {
 		$this->action_output .= $value . 3;
+
 		return 'x3';
 	}
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/51894

Adds `_doing_it_wrong()` when the callback is not callable to prevent PHP 8 `TypeErrors` fatal error when passing the callback to `call_user_func()` or `call_user_func_array()`.

TODO:

- [x] Add to `WP_Hook::apply_filters()` (also for `WP_Hook::do_action()`)
- [ ] Add to `WP_Hook::do_all_hook()`
- [ ] Change error level from `E_USER_NOTICE` to `E_USER_WARNING` [per @jrfnl](https://core.trac.wordpress.org/ticket/51894#comment:5):

>I'd advocate for the doing it wrong notice to be elevated from an E_USER_NOTICE to an E_USER_WARNING in that case though, as an E_USER_NOTICE is too often silenced, even by developers, or more particularly: especially by beginner/inexperienced developers who are more often than not the reason for these type of issues occurring.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
