### PR TITLE
Enhancement: Add 's' alias for search in WP_Term_Query

### DIFF
--- a/src/wp-includes/class-wp-term-query.php
+++ b/src/wp-includes/class-wp-term-query.php
@@ -155,6 +155,7 @@ class WP_Term_Query {
 	 *                                                (even if $hide_empty is set to true). Default true.
 	 *     @type string       $search                 Search criteria to match terms. Will be SQL-formatted with
 	 *                                                wildcards before and after. Default empty.
+	 *     @type string       $s                      Alias of `$search`. Default empty.
 	 *     @type string       $name__like             Retrieve terms with criteria by which a term is LIKE
 	 *                                                `$name__like`. Default empty.
 	 *     @type string       $description__like      Retrieve terms where the description is LIKE
@@ -205,6 +206,7 @@ class WP_Term_Query {
 			'term_taxonomy_id'       => '',
 			'hierarchical'           => true,
 			'search'                 => '',
+			's'                      => '',
 			'name__like'             => '',
 			'description__like'      => '',
 			'pad_counts'             => false,
@@ -256,6 +258,7 @@ class WP_Term_Query {
 
 		$query['number'] = absint( $query['number'] );
 		$query['offset'] = absint( $query['offset'] );
+		$query['search'] = $query['search'] == '' && $query['s'] != '' ? $query['s'] : $query['search'];
 
 		// 'parent' overrides 'child_of'.
 		if ( 0 < (int) $query['parent'] ) {

--- a/tests/phpunit/tests/term/getTerms.php
+++ b/tests/phpunit/tests/term/getTerms.php
@@ -423,6 +423,45 @@ class Tests_Term_getTerms extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 51811
+	 */
+	function test_get_terms_search_using_alias() {
+		$term_id1 = self::factory()->tag->create( array( 'slug' => 'burrito' ) );
+		$term_id2 = self::factory()->tag->create( array( 'name' => 'Wilbur' ) );
+		$term_id3 = self::factory()->tag->create( array( 'name' => 'Foo' ) );
+
+		$terms = get_terms(
+			'post_tag',
+			array(
+				'hide_empty' => false,
+				's'          => 'bur',
+				'fields'     => 'ids',
+			)
+		);
+		$this->assertSameSets( array( $term_id1, $term_id2 ), $terms );
+	}
+
+	/**
+	 * @ticket 51811
+	 */
+	function test_get_terms_search_using_both_alias_and_search() {
+		$term_id1 = self::factory()->tag->create( array( 'slug' => 'burrito' ) );
+		$term_id2 = self::factory()->tag->create( array( 'name' => 'Wilbur' ) );
+		$term_id3 = self::factory()->tag->create( array( 'name' => 'Foo' ) );
+
+		$terms = get_terms(
+			'post_tag',
+			array(
+				'hide_empty' => false,
+				'search'     => 'bur',
+				's'          => 'oo',
+				'fields'     => 'ids',
+			)
+		);
+		$this->assertSameSets( array( $term_id1, $term_id2 ), $terms );
+	}
+
+	/**
 	 * @ticket 8214
 	 */
 	function test_get_terms_like() {


### PR DESCRIPTION
The 'search' parameter takes precendence if both 's' and 'search' are populated. I've included two unit tests:
- Test that the 's' returns the correct terms
- Test that 'search' takes precedence when both 's' and 'search' are used

This is my first pull request so please let me know if anything needs amending! :)

Fixes: https://core.trac.wordpress.org/ticket/51811

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
