### PR TITLE
Use New CSS Scroll-Padding Feature to Account for Admin Bar When Deep Linking

### DIFF
--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -1153,10 +1153,10 @@ function _admin_bar_bump_cb() {
 	$type_attr = current_theme_supports( 'html5', 'style' ) ? '' : ' type="text/css"';
 	?>
 <style<?php echo $type_attr; ?> media="screen">
-	html { margin-top: 32px !important; }
+	html { margin-top: 32px !important; scroll-padding-top: 32px; }
 	* html body { margin-top: 32px !important; }
 	@media screen and ( max-width: 782px ) {
-		html { margin-top: 46px !important; }
+		html { margin-top: 46px !important; scroll-padding-top: 46px; }
 		* html body { margin-top: 46px !important; }
 	}
 </style>


### PR DESCRIPTION
Adding scroll-padding-top to the html to make scrolling to content much more enjoyable.

Trac ticket: https://core.trac.wordpress.org/ticket/51910

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
