### PR TITLE
Refactor #49277 original patch to avoid using filter_var

### DIFF
--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -1204,6 +1204,26 @@ function rest_parse_hex_color( $color ) {
 }
 
 /**
+ * Sanitize email.
+ *
+ * @since 5.7.0
+ *
+ * @param string $email Email address
+ * @return string Valid email address.
+ */
+function rest_sanitize_email( $email ) {
+
+	if ( false !== is_email( $email ) ) {
+		return $email;
+	}
+
+	$email                      = sanitize_text_field( $email );
+	$allowed_characters_pattern = "/[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$%&'*+-=?\^_`{|}~@.\[\]]/";
+
+	return preg_replace( $allowed_characters_pattern, '', $email );
+}
+
+/**
  * Parses a date into both its local and UTC equivalent, in MySQL datetime format.
  *
  * @since 4.4.0
@@ -2455,7 +2475,7 @@ function rest_sanitize_value_from_schema( $value, $args, $param = '' ) {
 
 			case 'email':
 				// sanitize_email() validates, which would be unexpected.
-				return sanitize_text_field( $value );
+				return rest_sanitize_email( $value );
 
 			case 'uri':
 				return esc_url_raw( $value );

--- a/tests/phpunit/tests/rest-api/rest-schema-sanitization.php
+++ b/tests/phpunit/tests/rest-api/rest-schema-sanitization.php
@@ -62,6 +62,9 @@ class WP_Test_REST_Schema_Sanitization extends WP_UnitTestCase {
 			'format' => 'email',
 		);
 		$this->assertSame( 'email@example.com', rest_sanitize_value_from_schema( 'email@example.com', $schema ) );
+		$this->assertEquals( 'email@example.com', rest_sanitize_value_from_schema( 'email🙂@example.com', $schema ) );
+		$this->assertEquals( 'email@example.com', rest_sanitize_value_from_schema( '±email@example.com', $schema ) );
+		$this->assertEquals( 'email@example.com', rest_sanitize_value_from_schema( '(email@example.com)', $schema ) );
 		$this->assertSame( 'a@b.c', rest_sanitize_value_from_schema( 'a@b.c', $schema ) );
 		$this->assertSame( 'invalid', rest_sanitize_value_from_schema( 'invalid', $schema ) );
 	}


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/49277

@TimothyBJacobs @spacedmonkey this is the refreshed work of patch attached into Trac ticket. Based on your discussion I've ported behaviour of `filter_var` into PHP code. Additionally I've added an extra check to avoid sanitization of email when `is_email` function returns true what is most likely an indicator that value is recognized correctly and doesn't need to be sanitized.

Please let me know if you have any questions.