### PR TITLE
51937: Guards WP_Image_Editor_GD::crop to avoid PHP 8 fatal error

### DIFF
--- a/src/wp-includes/class-wp-image-editor-gd.php
+++ b/src/wp-includes/class-wp-image-editor-gd.php
@@ -323,7 +323,18 @@ class WP_Image_Editor_GD extends WP_Image_Editor {
 			$dst_h = $src_h;
 		}
 
-		$dst = wp_imagecreatetruecolor( $dst_w, $dst_h );
+		if ( ! is_numeric( $dst_w ) || ! is_numeric( $dst_h ) ) {
+			return new WP_Error( 'image_crop_error', __( 'Image crop failed.' ), $this->file );
+		}
+
+		$dst_w = (int) $dst_w;
+		$dst_h = (int) $dst_h;
+
+		if ( $dst_w > 0 && $dst_h > 0 ) {
+			$dst = wp_imagecreatetruecolor( $dst_w, $dst_h );
+		} else {
+			return new WP_Error( 'image_crop_error', __( 'Image crop failed.' ), $this->file );
+		}
 
 		if ( $src_abs ) {
 			$src_w -= $src_x;

--- a/src/wp-includes/class-wp-image-editor-gd.php
+++ b/src/wp-includes/class-wp-image-editor-gd.php
@@ -323,7 +323,7 @@ class WP_Image_Editor_GD extends WP_Image_Editor {
 			$dst_h = $src_h;
 		}
 
-		foreach( array( $src_x, $src_y, $src_w, $src_h, $dst_w, $dst_h ) as $value ) {
+		foreach ( array( $src_x, $src_y, $src_w, $src_h, $dst_w, $dst_h ) as $value ) {
 			if ( ! is_numeric( $value ) || (int) $value <= 0 ) {
 				return new WP_Error( 'image_crop_error', __( 'Image crop failed.' ), $this->file );
 			}

--- a/src/wp-includes/class-wp-image-editor-gd.php
+++ b/src/wp-includes/class-wp-image-editor-gd.php
@@ -323,18 +323,13 @@ class WP_Image_Editor_GD extends WP_Image_Editor {
 			$dst_h = $src_h;
 		}
 
-		if ( ! is_numeric( $dst_w ) || ! is_numeric( $dst_h ) ) {
-			return new WP_Error( 'image_crop_error', __( 'Image crop failed.' ), $this->file );
+		foreach( array( $src_x, $src_y, $src_w, $src_h, $dst_w, $dst_h ) as $value ) {
+			if ( ! is_numeric( $value ) || (int) $value <= 0 ) {
+				return new WP_Error( 'image_crop_error', __( 'Image crop failed.' ), $this->file );
+			}
 		}
 
-		$dst_w = (int) $dst_w;
-		$dst_h = (int) $dst_h;
-
-		if ( $dst_w > 0 && $dst_h > 0 ) {
-			$dst = wp_imagecreatetruecolor( $dst_w, $dst_h );
-		} else {
-			return new WP_Error( 'image_crop_error', __( 'Image crop failed.' ), $this->file );
-		}
+		$dst = wp_imagecreatetruecolor( (int) $dst_w, (int) $dst_h );
 
 		if ( $src_abs ) {
 			$src_w -= $src_x;
@@ -345,7 +340,7 @@ class WP_Image_Editor_GD extends WP_Image_Editor {
 			imageantialias( $dst, true );
 		}
 
-		imagecopyresampled( $dst, $this->image, 0, 0, $src_x, $src_y, $dst_w, $dst_h, $src_w, $src_h );
+		imagecopyresampled( $dst, $this->image, 0, 0, (int) $src_x, (int) (int) $src_y, (int) $dst_w, (int) $dst_h, (int) $src_w, (int) $src_h );
 
 		if ( is_gd_image( $dst ) ) {
 			imagedestroy( $this->image );

--- a/src/wp-includes/class-wp-image-editor-gd.php
+++ b/src/wp-includes/class-wp-image-editor-gd.php
@@ -323,7 +323,7 @@ class WP_Image_Editor_GD extends WP_Image_Editor {
 			$dst_h = $src_h;
 		}
 
-		foreach ( array( $src_x, $src_y, $src_w, $src_h, $dst_w, $dst_h ) as $value ) {
+		foreach ( array( $src_w, $src_h, $dst_w, $dst_h ) as $value ) {
 			if ( ! is_numeric( $value ) || (int) $value <= 0 ) {
 				return new WP_Error( 'image_crop_error', __( 'Image crop failed.' ), $this->file );
 			}
@@ -340,7 +340,7 @@ class WP_Image_Editor_GD extends WP_Image_Editor {
 			imageantialias( $dst, true );
 		}
 
-		imagecopyresampled( $dst, $this->image, 0, 0, (int) $src_x, (int) (int) $src_y, (int) $dst_w, (int) $dst_h, (int) $src_w, (int) $src_h );
+		imagecopyresampled( $dst, $this->image, 0, 0, (int) $src_x, (int) $src_y, (int) $dst_w, (int) $dst_h, (int) $src_w, (int) $src_h );
 
 		if ( is_gd_image( $dst ) ) {
 			imagedestroy( $this->image );

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -3505,7 +3505,7 @@ function is_gd_image( $image ) {
  *
  * @param int $width  Image width in pixels.
  * @param int $height Image height in pixels.
- * @return resource|GdImage|bool The GD image resource or GdImage instance on success; else, false on failure.
+ * @return resource|GdImage|false The GD image resource or GdImage instance on success. False on failure.
  */
 function wp_imagecreatetruecolor( $width, $height ) {
 	$img = imagecreatetruecolor( $width, $height );

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -3505,7 +3505,7 @@ function is_gd_image( $image ) {
  *
  * @param int $width  Image width in pixels.
  * @param int $height Image height in pixels.
- * @return resource|GdImage The GD image resource or GdImage instance.
+ * @return resource|GdImage|bool The GD image resource or GdImage instance on success; else, false on failure.
  */
 function wp_imagecreatetruecolor( $width, $height ) {
 	$img = imagecreatetruecolor( $width, $height );

--- a/tests/phpunit/tests/image/editorGd.php
+++ b/tests/phpunit/tests/image/editorGd.php
@@ -490,7 +490,7 @@ class Tests_Image_Editor_GD extends WP_Image_UnitTestCase {
 				'src_x' => 10,
 				'src_y' => '10',
 				'src_w' => 100,
-				'src_h' => NAN,
+				'src_h' => 'NaN',
 			),
 			array(
 				'src_x' => 0,
@@ -498,7 +498,7 @@ class Tests_Image_Editor_GD extends WP_Image_UnitTestCase {
 				'src_w' => 100,
 				'src_h' => 50,
 				'dst_w' => '100',
-				'dst_h' => NAN,
+				'dst_h' => 'NaN',
 			),
 			array(
 				'src_x' => 0,

--- a/tests/phpunit/tests/image/editorGd.php
+++ b/tests/phpunit/tests/image/editorGd.php
@@ -430,19 +430,27 @@ class Tests_Image_Editor_GD extends WP_Image_UnitTestCase {
 
 	public function data_crop() {
 		return array(
-			'src x,y = int 0; int w,h > 0'                 => array(
+			'src height and width must be greater than 0' => array(
 				'src_x' => 0,
 				'src_y' => 0,
 				'src_w' => 50,
 				'src_h' => 50,
 			),
-			'src x int, y string; string numeric w,h > 0'  => array(
+			'src height and width can be string but must be greater than 0' => array(
 				'src_x' => 10,
 				'src_y' => '10',
 				'src_w' => '50',
 				'src_h' => '50',
 			),
-			'src x int, y string; src and dst w,h > 0 int' => array(
+			'dst height and width must be greater than 0' => array(
+				'src_x' => 10,
+				'src_y' => '10',
+				'src_w' => 150,
+				'src_h' => 150,
+				'dst_w' => 150,
+				'dst_h' => 150,
+			),
+			'dst height and width can be string but must be greater than 0' => array(
 				'src_x' => 10,
 				'src_y' => '10',
 				'src_w' => 150,
@@ -474,25 +482,25 @@ class Tests_Image_Editor_GD extends WP_Image_UnitTestCase {
 
 	public function data_crop_invalid_dimensions() {
 		return array(
-			'int src_h = 0'                   => array(
+			'src height must be greater than 0' => array(
 				'src_x' => 0,
 				'src_y' => 0,
 				'src_w' => 100,
 				'src_h' => 0,
 			),
-			'int src_w = 0'                   => array(
+			'src width must be greater than 0'  => array(
 				'src_x' => 10,
 				'src_y' => '10',
 				'src_w' => 0,
 				'src_h' => 100,
 			),
-			'src h = "NaN"'                   => array(
+			'src height must be numeric and greater than 0' => array(
 				'src_x' => 10,
 				'src_y' => '10',
 				'src_w' => 100,
 				'src_h' => 'NaN',
 			),
-			'string dst_w > 0; dst_h = "NaN"' => array(
+			'dst height must be numeric and greater than 0' => array(
 				'src_x' => 0,
 				'src_y' => 0,
 				'src_w' => 100,
@@ -500,7 +508,7 @@ class Tests_Image_Editor_GD extends WP_Image_UnitTestCase {
 				'dst_w' => '100',
 				'dst_h' => 'NaN',
 			),
-			'all w,h = 0 int'                 => array(
+			'src and dst height and width must be greater than 0' => array(
 				'src_x' => 0,
 				'src_y' => 0,
 				'src_w' => 0,
@@ -508,7 +516,7 @@ class Tests_Image_Editor_GD extends WP_Image_UnitTestCase {
 				'dst_w' => 0,
 				'dst_h' => 0,
 			),
-			'all w,h = 0 string'              => array(
+			'src and dst height and width can be string but must be greater than 0' => array(
 				'src_x' => 0,
 				'src_y' => 0,
 				'src_w' => '0',

--- a/tests/phpunit/tests/image/editorGd.php
+++ b/tests/phpunit/tests/image/editorGd.php
@@ -405,22 +405,105 @@ class Tests_Image_Editor_GD extends WP_Image_UnitTestCase {
 	}
 
 	/**
-	 * Test cropping an image
+	 * Test cropping an image.
+	 *
+	 * @dataProvider data_crop
 	 */
-	public function test_crop() {
+	public function test_crop( $src_x, $src_y, $src_w, $src_h, $dst_w = null, $dst_h = null, $src_abs = false ) {
 		$file = DIR_TESTDATA . '/images/gradient-square.jpg';
 
 		$gd_image_editor = new WP_Image_Editor_GD( $file );
 		$gd_image_editor->load();
 
-		$gd_image_editor->crop( 0, 0, 50, 50 );
+		$gd_image_editor->crop( $src_x, $src_y, $src_w, $src_h, $dst_w, $dst_h, $src_abs );
 
 		$this->assertSame(
 			array(
-				'width'  => 50,
-				'height' => 50,
+				'width'  => (int) $src_w,
+				'height' => (int) $src_h,
 			),
 			$gd_image_editor->get_size()
+		);
+	}
+
+	public function data_crop() {
+		return array(
+			array(
+				'src_x' => 0,
+				'src_y' => 0,
+				'src_w' => 50,
+				'src_h' => 50,
+			),
+			array(
+				'src_x' => 10,
+				'src_y' => '10',
+				'src_w' => '50',
+				'src_h' => '50',
+			),
+			array(
+				'src_x' => 10,
+				'src_y' => '10',
+				'src_w' => 150,
+				'src_h' => 150,
+				'dst_w' => '150',
+				'dst_h' => '150',
+			),
+		);
+	}
+
+	/**
+	 * Test should return WP_Error when dimensions are not integer or are <= 0.
+	 *
+	 * @dataProvider data_crop_invalid_dimensions
+	 */
+	public function test_crop_invalid_dimensions( $src_x, $src_y, $src_w, $src_h, $dst_w = null, $dst_h = null, $src_abs = false ) {
+		$file = DIR_TESTDATA . '/images/gradient-square.jpg';
+
+		$gd_image_editor = new WP_Image_Editor_GD( $file );
+		$gd_image_editor->load();
+
+		$actual = $gd_image_editor->crop( $src_x, $src_y, $src_w, $src_h, $dst_w, $dst_h, $src_abs );
+
+		$this->assertInstanceOf( 'WP_Error', $actual );
+		$this->assertSame( 'image_crop_error', $actual->get_error_code() );
+	}
+
+	public function data_crop_invalid_dimensions() {
+		return array(
+			array(
+				'src_x' => 0,
+				'src_y' => 0,
+				'src_w' => 100,
+				'src_h' => 0,
+			),
+			array(
+				'src_x' => 10,
+				'src_y' => '10',
+				'src_w' => 0,
+				'src_h' => 100,
+			),
+			array(
+				'src_x' => 10,
+				'src_y' => '10',
+				'src_w' => 100,
+				'src_h' => NAN,
+			),
+			array(
+				'src_x' => 0,
+				'src_y' => 0,
+				'src_w' => 100,
+				'src_h' => 50,
+				'dst_w' => '100',
+				'dst_h' => NAN,
+			),
+			array(
+				'src_x' => 0,
+				'src_y' => 0,
+				'src_w' => 0,
+				'src_h' => 0,
+				'dst_w' => 0,
+				'dst_h' => 0,
+			),
 		);
 	}
 

--- a/tests/phpunit/tests/image/editorGd.php
+++ b/tests/phpunit/tests/image/editorGd.php
@@ -430,19 +430,19 @@ class Tests_Image_Editor_GD extends WP_Image_UnitTestCase {
 
 	public function data_crop() {
 		return array(
-			array(
+			'src x,y = int 0; int w,h > 0'                 => array(
 				'src_x' => 0,
 				'src_y' => 0,
 				'src_w' => 50,
 				'src_h' => 50,
 			),
-			array(
+			'src x int, y string; string numeric w,h > 0'  => array(
 				'src_x' => 10,
 				'src_y' => '10',
 				'src_w' => '50',
 				'src_h' => '50',
 			),
-			array(
+			'src x int, y string; src and dst w,h > 0 int' => array(
 				'src_x' => 10,
 				'src_y' => '10',
 				'src_w' => 150,
@@ -474,25 +474,25 @@ class Tests_Image_Editor_GD extends WP_Image_UnitTestCase {
 
 	public function data_crop_invalid_dimensions() {
 		return array(
-			array(
+			'int src_h = 0'                   => array(
 				'src_x' => 0,
 				'src_y' => 0,
 				'src_w' => 100,
 				'src_h' => 0,
 			),
-			array(
+			'int src_w = 0'                   => array(
 				'src_x' => 10,
 				'src_y' => '10',
 				'src_w' => 0,
 				'src_h' => 100,
 			),
-			array(
+			'src h = "NaN"'                   => array(
 				'src_x' => 10,
 				'src_y' => '10',
 				'src_w' => 100,
 				'src_h' => 'NaN',
 			),
-			array(
+			'string dst_w > 0; dst_h = "NaN"' => array(
 				'src_x' => 0,
 				'src_y' => 0,
 				'src_w' => 100,
@@ -500,13 +500,21 @@ class Tests_Image_Editor_GD extends WP_Image_UnitTestCase {
 				'dst_w' => '100',
 				'dst_h' => 'NaN',
 			),
-			array(
+			'all w,h = 0 int'                 => array(
 				'src_x' => 0,
 				'src_y' => 0,
 				'src_w' => 0,
 				'src_h' => 0,
 				'dst_w' => 0,
 				'dst_h' => 0,
+			),
+			'all w,h = 0 string'              => array(
+				'src_x' => 0,
+				'src_y' => 0,
+				'src_w' => '0',
+				'src_h' => '0',
+				'dst_w' => '0',
+				'dst_h' => '0',
 			),
 		);
 	}

--- a/tests/phpunit/tests/image/editorGd.php
+++ b/tests/phpunit/tests/image/editorGd.php
@@ -407,6 +407,8 @@ class Tests_Image_Editor_GD extends WP_Image_UnitTestCase {
 	/**
 	 * Test cropping an image.
 	 *
+	 * @ticket 51937
+	 *
 	 * @dataProvider data_crop
 	 */
 	public function test_crop( $src_x, $src_y, $src_w, $src_h, $dst_w = null, $dst_h = null, $src_abs = false ) {
@@ -453,6 +455,8 @@ class Tests_Image_Editor_GD extends WP_Image_UnitTestCase {
 
 	/**
 	 * Test should return WP_Error when dimensions are not integer or are <= 0.
+	 *
+	 * @ticket 51937
 	 *
 	 * @dataProvider data_crop_invalid_dimensions
 	 */


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/51937

Guards `WP_Image_Editor_GD::crop` to avoid PHP 8 fatal error by:

- Checking dimensions are integer
- And `> 0`.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
