### PR TITLE
Basic Auth staging protections conflicts with App Passwords

### DIFF
--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -2288,7 +2288,8 @@ function upgrade_560() {
 		);
 
 		if ( ! empty( $results ) ) {
-			update_site_option( WP_Application_Passwords::OPTION_KEY_IN_USE, 1 );
+			$network_id = get_main_network_id();
+			update_network_option( $network_id, WP_Application_Passwords::OPTION_KEY_IN_USE, 1 );
 		}
 	}
 }

--- a/src/wp-includes/class-wp-application-passwords.php
+++ b/src/wp-includes/class-wp-application-passwords.php
@@ -50,7 +50,8 @@ class WP_Application_Passwords {
 	 * @return bool
 	 */
 	public static function is_in_use() {
-		return (bool) get_site_option( self::OPTION_KEY_IN_USE );
+		$network_id = get_main_network_id();
+		return (bool) get_network_option( $network_id, self::OPTION_KEY_IN_USE );
 	}
 
 	/**
@@ -89,8 +90,9 @@ class WP_Application_Passwords {
 			return new WP_Error( 'db_error', __( 'Could not save application password.' ) );
 		}
 
-		if ( ! get_site_option( self::OPTION_KEY_IN_USE ) ) {
-			update_site_option( self::OPTION_KEY_IN_USE, true );
+		$network_id = get_main_network_id();
+		if ( ! get_network_option( $network_id, self::OPTION_KEY_IN_USE ) ) {
+			update_network_option( $network_id, self::OPTION_KEY_IN_USE, true );
 		}
 
 		/**


### PR DESCRIPTION
Small fix to save detection of application password support to the main network to improve support for multi network support. 

Trac ticket: https://core.trac.wordpress.org/ticket/51939

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
