### PR TITLE
51956: Fix RSS fatal on category/tag/archive feeds

### DIFF
--- a/src/wp-includes/class-simplepie.php
+++ b/src/wp-includes/class-simplepie.php
@@ -2615,6 +2615,8 @@ class SimplePie
 			}
 		}
 
+		// todo is it correct for this to assume that there's only 1 `link` header? doesn't seem like it
+		// if not, then need to fix upstream instead, then merge to core
 		if (isset($this->data['headers']['link']) &&
 		    preg_match('/<([^>]+)>; rel='.preg_quote($rel).'/',
 		               $this->data['headers']['link'], $match))

--- a/src/wp-includes/feed.php
+++ b/src/wp-includes/feed.php
@@ -842,6 +842,7 @@ function fetch_feed( $url ) {
 		 * is this back-compat?
 		 *
 		 * props: NicolasKulka, Tonya Mork , mbabker, Toni Viemerö , sergey, jonathan, timothy, anyone else?
+		 *      also add folks from 51056?
 		 *
 		 * what should be done w/ the 2nd link? just ignore it?
 		 *      should the wp/v2/categories/id link actually e the ones that's used? i guess so, since it's a category feed
@@ -849,6 +850,12 @@ function fetch_feed( $url ) {
 		 *           neither seems reliable
 		 *
 		 * if #51056 is not a duplicate, then it should also be tested for php8 compat, and given the php8 keyword if it fatals
+		 *      todo: er, wait, maybe it is? https://core.trac.wordpress.org/ticket/51956#comment:17
+		 *      if so, then need to determine if the patch there is better solution than this
+		 *      it seems like 51056 is better,based on https://core.trac.wordpress.org/ticket/51056#comment:3
+		 *      it's valid for simplepie to expect a string instead of array, b/c its parser combined multiple headers into a command-separated string
+		 *      if that's the case, then close 51956 as duplicate, and mention that on both tickets
+		 *      iterate on 51056 patch if necessary & commit, include props from 51956
 		 */
 	}
 

--- a/src/wp-includes/feed.php
+++ b/src/wp-includes/feed.php
@@ -829,6 +829,11 @@ function fetch_feed( $url ) {
 	$feed->init();
 	$feed->set_output_encoding( get_option( 'blog_charset' ) );
 
+	$link = $feed->data['headers']->offsetGet( 'link' );
+	if ( is_array( $link ) ) {
+		$feed->data['headers']->offsetSet( 'link', $link[ 0 ] );
+	}
+
 	if ( $feed->error() ) {
 		return new WP_Error( 'simplepie-error', $feed->error() );
 	}

--- a/src/wp-includes/feed.php
+++ b/src/wp-includes/feed.php
@@ -831,7 +831,12 @@ function fetch_feed( $url ) {
 
 	$link = $feed->data['headers']->offsetGet( 'link' );
 	if ( is_array( $link ) ) {
-		$feed->data['headers']->offsetSet( 'link', $link[ 0 ] );
+		$feed->data['headers']->offsetSet( 'link', $link[0] );
+
+		/* todo
+		 * is this back-compat?
+		 * what should be done w/ the 2nd link? just ignore it?
+		 */
 	}
 
 	if ( $feed->error() ) {

--- a/src/wp-includes/feed.php
+++ b/src/wp-includes/feed.php
@@ -829,11 +829,15 @@ function fetch_feed( $url ) {
 	$feed->init();
 	$feed->set_output_encoding( get_option( 'blog_charset' ) );
 
+	// todo explain why it's doing this
 	$link = $feed->data['headers']->offsetGet( 'link' );
+
 	if ( is_array( $link ) ) {
 		$feed->data['headers']->offsetSet( 'link', $link[0] );
 
 		/* todo
+		 * is this the best solution?
+		 * should simplepie handle this scenario, or is core passing it invalid data?
 		 * is this back-compat?
 		 * what should be done w/ the 2nd link? just ignore it?
 		 */

--- a/src/wp-includes/feed.php
+++ b/src/wp-includes/feed.php
@@ -838,8 +838,17 @@ function fetch_feed( $url ) {
 		/* todo
 		 * is this the best solution?
 		 * should simplepie handle this scenario, or is core passing it invalid data?
+		 *      core it outputting 2 feeds, simplepie expects 1. is that a valid expectation for simplepie?
 		 * is this back-compat?
+		 *
+		 * props: NicolasKulka, Tonya Mork , mbabker, Toni Viemerö , sergey, jonathan, timothy, anyone else?
+		 *
 		 * what should be done w/ the 2nd link? just ignore it?
+		 *      should the wp/v2/categories/id link actually e the ones that's used? i guess so, since it's a category feed
+		 *      what's most reliable way to detect which link is the correct one? just hardcode a search for "category" etc, or just assume the 2nd/last one?
+		 *           neither seems reliable
+		 *
+		 * if #51056 is not a duplicate, then it should also be tested for php8 compat, and given the php8 keyword if it fatals
 		 */
 	}
 

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -958,6 +958,7 @@ function rest_output_link_header() {
 	$resource = rest_get_queried_resource_route();
 
 	if ( $resource ) {
+		// todo why doesn't this get triggered for category feed on most sites, like it does on the reporter's site?
 		header( sprintf( 'Link: <%s>; rel="alternate"; type="application/json"', esc_url_raw( rest_url( $resource ) ) ), false );
 	}
 }


### PR DESCRIPTION
This is still a WIP, but this demonstrates one possible fix.

Trac ticket: https://core.trac.wordpress.org/ticket/51956