### PR TITLE
Twenty Twenty-One: full stop in wrong place

### DIFF
--- a/src/wp-content/themes/twentytwentyone/classes/class-twenty-twenty-one-dark-mode.php
+++ b/src/wp-content/themes/twentytwentyone/classes/class-twenty-twenty-one-dark-mode.php
@@ -185,7 +185,7 @@ class Twenty_Twenty_One_Dark_Mode {
 		$description  = '<p>';
 		$description .= sprintf(
 			// translators: %s is the wordpress.org Twenty Twenty-One support article URL.
-			__( 'Dark Mode is a device setting. If a visitor to your site requests it, your site will be shown with a dark background and light text. <a href="%s">Learn more about Dark Mode.</a>', 'twentytwentyone' ),
+			__( 'Dark Mode is a device setting. If a visitor to your site requests it, your site will be shown with a dark background and light text. <a href="%s">Learn more about Dark Mode</a>.', 'twentytwentyone' ),
 			__( 'https://wordpress.org/support/article/twenty-twenty-one/', 'twentytwentyone' )
 		);
 		$description .= '</p>';


### PR DESCRIPTION
In classes/class-twenty-twenty-one-dark-mode.php:188:
__( 'Dark Mode is a device setting. If a visitor to your site requests it, your site will be shown with a dark background and light text. <a href="%s">Learn more about Dark Mode.</a>', 'twentytwentyone' ),

The full-stop should be put outside the </a> mark-up.
__( 'Dark Mode is a device setting. If a visitor to your site requests it, your site will be shown with a dark

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/51961

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
