### PR TITLE
Generate a test coverage report with a GitHub Action workflow 

### DIFF
--- a/.env
+++ b/.env
@@ -13,7 +13,7 @@
 LOCAL_PORT=8889
 
 # Where to run WordPress from. Valid options are 'src' and 'build'.
-LOCAL_DIR=src
+LOCAL_DIR=build
 
 # The PHP version to use. Valid options are 'latest', and '{version}-fpm'.
 LOCAL_PHP=latest
@@ -40,7 +40,7 @@ LOCAL_PHP=latest
 LOCAL_PHPUNIT=${LOCAL_PHP}
 
 # Whether or not to enable XDebug.
-LOCAL_PHP_XDEBUG=false
+LOCAL_PHP_XDEBUG=true
 
 # Whether or not to enable Memcached.
 LOCAL_PHP_MEMCACHED=false

--- a/.env
+++ b/.env
@@ -13,7 +13,7 @@
 LOCAL_PORT=8889
 
 # Where to run WordPress from. Valid options are 'src' and 'build'.
-LOCAL_DIR=build
+LOCAL_DIR=src
 
 # The PHP version to use. Valid options are 'latest', and '{version}-fpm'.
 LOCAL_PHP=latest
@@ -40,7 +40,7 @@ LOCAL_PHP=latest
 LOCAL_PHPUNIT=${LOCAL_PHP}
 
 # Whether or not to enable XDebug.
-LOCAL_PHP_XDEBUG=true
+LOCAL_PHP_XDEBUG=false
 
 # Whether or not to enable Memcached.
 LOCAL_PHP_MEMCACHED=false

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -123,29 +123,29 @@ jobs:
         run: npm run env:install
 
       - name: Run tests as a single site
-        run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose -c phpunit.xml.dist --coverage-html wp-code-coverage-single
+        run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose -c phpunit.xml.dist --coverage-html wp-code-coverage-single-${{ github.sha }}
 
       - name: Create ZIP artifact of single site results
         uses: thedoctor0/zip-release@0.4.1
         with:
-          filename: wp-code-coverage-${{ github.sha }}.zip
-          path: wp-code-coverage-single
+          filename: wp-code-coverage-single-${{ github.sha }}.zip
+          path: wp-code-coverage-single-${{ github.sha }}
 
       - name: Upload single site coverage report
         uses: actions/upload-artifact@v2
         with:
-          name: wp-code-coverage-${{ github.sha }}
-          path: wp-code-coverage-${{ github.sha }}.zip
+          name: wp-code-coverage-single-${{ github.sha }}
+          path: wp-code-coverage-single-${{ github.sha }}.zip
           if-no-files-found: error
 
       - name: Run tests as a multisite install
-        run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose -c tests/phpunit/multisite.xml --coverage-html wp-code-coverage-multisite
+        run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose -c tests/phpunit/multisite.xml --coverage-html wp-code-coverage-multisite-${{ github.sha }}
 
       - name: Create ZIP artifact of multisite results
         uses: thedoctor0/zip-release@0.4.1
         with:
           filename: wp-code-coverage-multisite-${{ github.sha }}.zip
-          path: wp-code-coverage-multisite
+          path: wp-code-coverage-multisite-${{ github.sha }}
 
       - name: Upload multisite coverage report
         uses: actions/upload-artifact@v2

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -121,10 +121,11 @@ jobs:
     needs: setup-wordpress
     strategy:
       matrix:
+        type: [ 'Single site' ]
+        ruleset: [ 'phpunit.xml.dist' ]
+        report_name: [ 'wp-code-coverage-single' ]
+
         include:
-        - type: 'Single site'
-          ruleset: 'phpunit.xml.dist'
-          report_name: 'wp-code-coverage-single'
         - type: 'Multisite'
           ruleset: 'tests/phpunit/multisite.xml'
           report_name: 'wp-code-coverage-multisite'

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -124,7 +124,7 @@ jobs:
       - type: 'Single site'
         ruleset: 'phpunit.xml.dist'
         report_name: 'wp-code-coverage-single'
-      - type: 'Multisite'
+      - type: 'Multisite
         ruleset: 'tests/phpunit/multisite.xml'
         report_name: 'wp-code-coverage-multisite'
       - type: 'REST API'

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -120,13 +120,13 @@ jobs:
         run: npm run env:install
 
       - name: Run tests as a single site
-        run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose -c phpunit.xml.dist --coverage-html report
+        run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose -c phpunit.xml.dist --coverage-html wp-code-coverage-single
 
       - name: Create ZIP artifact of single site results
         uses: thedoctor0/zip-release@0.4.1
         with:
           filename: wp-code-coverage-${{ github.sha }}.zip
-          path: report
+          path: wp-code-coverage-single
 
       - name: Upload single site coverage report
         uses: actions/upload-artifact@v2
@@ -136,29 +136,29 @@ jobs:
           if-no-files-found: error
 
       - name: Run tests as a multisite install
-        run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose -c tests/phpunit/multisite.xml --coverage-html multisite-report
+        run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose -c tests/phpunit/multisite.xml --coverage-html wp-code-coverage-multisite
 
       - name: Create ZIP artifact of multisite results
         uses: thedoctor0/zip-release@0.4.1
         with:
           filename: wp-code-coverage-ms-${{ github.sha }}.zip
-          path: multisite-report
+          path: wp-code-coverage-multisite
 
       - name: Upload multisite coverage report
         uses: actions/upload-artifact@v2
         with:
-          name: wp-code-coverage-ms-${{ github.sha }}
-          path: wp-code-coverage-ms-${{ github.sha }}.zip
+          name: wp-code-coverage-multisite-${{ github.sha }}
+          path: wp-code-coverage-multisite-${{ github.sha }}.zip
           if-no-files-found: error
 
       - name: Run REST API tests
-        run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose -c phpunit.xml.dist --group restapi-jsclient --coverage-html rest-api-report
+        run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose -c phpunit.xml.dist --group restapi-jsclient --coverage-html wp-code-coverage-rest-api
 
       - name: Create ZIP artifact of REST API results
         uses: thedoctor0/zip-release@0.4.1
         with:
           filename: wp-code-coverage-rest-api-${{ github.sha }}.zip
-          path: rest-api-report
+          path: wp-code-coverage-rest-api
 
       - name: Upload REST API coverage report
         uses: actions/upload-artifact@v2

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -141,7 +141,7 @@ jobs:
       - name: Create ZIP artifact of multisite results
         uses: thedoctor0/zip-release@0.4.1
         with:
-          filename: wp-code-coverage-ms-${{ github.sha }}.zip
+          filename: wp-code-coverage-multisite-${{ github.sha }}.zip
           path: wp-code-coverage-multisite
 
       - name: Upload multisite coverage report

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -1,0 +1,151 @@
+name: Test Coverage Report
+
+on:
+  push:
+  schedule:
+    - cron: '0 0 * * *'
+
+env:
+  LOCAL_DIR: build
+  PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: ${{ true }}
+  COMPOSER_INSTALL: ${{ false }}
+  # Controls which NPM script to use for running PHPUnit tests. Options ar `php` and `php-composer`.
+  PHPUNIT_SCRIPT: php
+  LOCAL_PHP: '7.4'
+  LOCAL_PHP_XDEBUG: true
+  LOCAL_PHP_MEMCACHED: ${{ false }}
+
+jobs:
+  # Sets up WordPress for testing or development use.
+  #
+  # Performs the following steps:
+  # - Cancels all previous workflow runs for pull requests that have not completed.
+  # - Checks out the repository.
+  # - Checks out the WordPress Importer plugin (needed for the Core PHPUnit tests).
+  # - Logs debug information about the runner container.
+  # - Installs NodeJS 14.
+  # - Sets up caching for NPM.
+  # _ Installs NPM dependencies using install-changed to hash the `package.json` file.
+  # - Builds WordPress to run from the `build` directory.
+  # - Creates a ZIP file of compiled WordPress.
+  # - Uploads ZIP file as an artifact.
+  test-coverage-report:
+    name: Setup WordPress
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Configure environment variables
+        run: |
+          echo "PHP_FPM_UID=$(id -u)" >> $GITHUB_ENV
+          echo "PHP_FPM_GID=$(id -g)" >> $GITHUB_ENV
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Checkout the WordPress Importer plugin
+        run: svn checkout -r 2387243 https://plugins.svn.wordpress.org/wordpress-importer/trunk/ tests/phpunit/data/plugins/wordpress-importer
+
+      - name: Log debug information
+        run: |
+          echo "$GITHUB_REF"
+          echo "$GITHUB_EVENT_NAME"
+          npm --version
+          node --version
+          curl --version
+          git --version
+          svn --version
+          php --version
+          php -i
+          locale -a
+
+      - name: Install NodeJS
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+
+      - name: Cache NodeJS modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
+
+      - name: Install Dependencies
+        run: npx install-changed --install-command="npm ci"
+
+      - name: Build WordPress
+        run: npm run build
+
+      - name: Docker debug information
+        run: |
+          docker -v
+          docker-compose -v
+
+      - name: Start Docker environment
+        run: |
+          npm run env:start
+
+      - name: General debug information
+        run: |
+          npm --version
+          node --version
+          curl --version
+          git --version
+          svn --version
+
+      - name: Log running Docker containers
+        run: docker ps -a
+
+      - name: WordPress Docker container debug information
+        run: |
+          docker-compose run --rm mysql mysql --version
+          docker-compose run --rm php php --version
+          docker-compose run --rm php php -m
+          docker-compose run --rm php php -i
+          docker-compose run --rm php locale -a
+
+      - name: Run PHPUnit tests
+        run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose --coverage-html report -c phpunit.xml.dist
+
+      - name: Create ZIP artifact
+        uses: thedoctor0/zip-release@0.4.1
+        with:
+          filename: wp-code-coverage-${{ github.sha }}.zip
+          path: report
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: wp-code-coverage-${{ github.sha }}
+          path: wp-code-coverage-${{ github.sha }}.zip
+          if-no-files-found: error
+
+  # Runs the PHPUnit tests for WordPress.
+  #
+  # Performs the following steps:
+  # - Set environment variables.
+  # - Sets up the environment variables needed for testing with memcached (if desired).
+  # - Downloads the built WordPress artifact from the previous job.
+  # - Unzips the artifact.
+  # - Installs NodeJS 14.
+  # - Sets up caching for NPM.
+  # _ Installs NPM dependencies using install-changed to hash the `package.json` file.
+  # - Configures caching for Composer.
+  # _ Installs Composer dependencies (if desired).
+  # - Logs Docker debug information (about both the Docker installation within the runner).
+  # - Starts the WordPress Docker container.
+  # - Starts the memcached server after the Docker network has been created (if desired).
+  # - Logs WordPress Docker container debug information.
+  # - Logs debug general information.
+  # - Logs the running Docker containers.
+  # - Logs debug information about what's installed within the WordPress Docker containers.
+  # - Install WordPress within the Docker container.
+  # - Run the PHPUnit tests.
+  # - Checks out the WordPress Test reporter repository.
+  # - Reconnect the directory to the Git repository.
+  # - Submit the test results to the WordPress.org host test results.
+  # - todo: Configure Slack notifications for failing tests.

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -16,10 +16,9 @@ env:
   LOCAL_PHP_MEMCACHED: ${{ false }}
 
 jobs:
-  # Sets up WordPress for testing or development use.
   #
   # Performs the following steps:
-  # - Set environment variables.
+  # - Cancels all previous workflow runs for pull requests that have not completed.
   # - Checks out the repository.
   # - Checks out the WordPress Importer plugin (needed for the Core PHPUnit tests).
   # - Logs debug information about the runner container.
@@ -27,25 +26,19 @@ jobs:
   # - Sets up caching for NPM.
   # _ Installs NPM dependencies using install-changed to hash the `package.json` file.
   # - Builds WordPress to run from the `build` directory.
-  # - Logs Docker debug information (about the Docker installation within the runner).
-  # - Starts the WordPress Docker container.
-  # - Logs debug general information.
-  # - Logs the running Docker containers.
-  # - Logs WordPress Docker container debug information.
-  # - Logs debug information about what's installed within the WordPress Docker containers.
-  # - Install WordPress within the Docker container.
-  # - Run the PHPUnit tests.
-  # - Creates a ZIP file of the code coverage report.
+  # - Creates a ZIP file of compiled WordPress.
   # - Uploads ZIP file as an artifact.
-  test-coverage-report:
-    name: Generate a code coverage report
+  setup-wordpress:
+    name: Setup WordPress
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
 
     steps:
-      - name: Configure environment variables
-        run: |
-          echo "PHP_FPM_UID=$(id -u)" >> $GITHUB_ENV
-          echo "PHP_FPM_GID=$(id -g)" >> $GITHUB_ENV
+      - name: Cancel previous runs of this workflow (pull requests only)
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: styfle/cancel-workflow-action@0.5.0
+        with:
+          access_token: ${{ github.token }}
 
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -88,6 +81,102 @@ jobs:
       - name: Build WordPress
         run: npm run build
 
+      - name: Create ZIP artifact
+        uses: thedoctor0/zip-release@0.4.1
+        with:
+          filename: built-wp-${{ github.sha }}.zip
+          exclusions: '*.git* /*node_modules/* packagehash.txt'
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: built-wp-${{ github.sha }}
+          path: built-wp-${{ github.sha }}.zip
+          if-no-files-found: error
+
+  # Sets up WordPress for testing or development use.
+  #
+  # Performs the following steps:
+  # - Set environment variables.
+  # - Checks out the repository.
+  # - Checks out the WordPress Importer plugin (needed for the Core PHPUnit tests).
+  # - Logs debug information about the runner container.
+  # - Installs NodeJS 14.
+  # - Sets up caching for NPM.
+  # _ Installs NPM dependencies using install-changed to hash the `package.json` file.
+  # - Builds WordPress to run from the `build` directory.
+  # - Logs Docker debug information (about the Docker installation within the runner).
+  # - Starts the WordPress Docker container.
+  # - Logs debug general information.
+  # - Logs the running Docker containers.
+  # - Logs WordPress Docker container debug information.
+  # - Logs debug information about what's installed within the WordPress Docker containers.
+  # - Install WordPress within the Docker container.
+  # - Run the PHPUnit tests.
+  # - Creates a ZIP file of the code coverage report.
+  # - Uploads ZIP file as an artifact.
+  test-coverage-report:
+    name: Generate a code coverage report
+    runs-on: ubuntu-latest
+    needs: setup-wordpress
+    strategy:
+      include:
+      - type: 'Single site'
+        ruleset: 'phpunit.xml.dist'
+        report_name: 'wp-code-coverage-single'
+      - type: 'Multisite
+        ruleset: 'tests/phpunit/multisite.xml'
+        report_name: 'wp-code-coverage-multisite'
+      - type: 'REST API'
+        ruleset: 'phpunit.xml.dist'
+        report_name: 'wp-code-coverage-rest-api'
+
+    steps:
+      - name: Configure environment variables
+        run: |
+          echo "PHP_FPM_UID=$(id -u)" >> $GITHUB_ENV
+          echo "PHP_FPM_GID=$(id -g)" >> $GITHUB_ENV
+
+      - name: Download the built WordPress artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: built-wp-${{ github.sha }}
+
+      - name: Unzip built artifact
+        run: unzip built-wp-${{ github.sha }}.zip
+
+      - name: Log debug information
+        run: |
+          echo "$GITHUB_REF"
+          echo "$GITHUB_EVENT_NAME"
+          npm --version
+          node --version
+          curl --version
+          git --version
+          svn --version
+          php --version
+          php -i
+          locale -a
+
+      - name: Install NodeJS
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+
+      - name: Cache NodeJS modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
+
+      - name: Install Dependencies
+        run: npx install-changed --install-command="npm ci"
+
       - name: Docker debug information
         run: |
           docker -v
@@ -119,50 +208,18 @@ jobs:
       - name: Install WordPress
         run: npm run env:install
 
-      - name: Run tests as a single site
-        run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose -c phpunit.xml.dist --coverage-html wp-code-coverage-single
+      - name: 'Run PHPUnit tests - ${{ matrix.type }}
+        run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose -c ${{ matrix.ruleset }} --coverage-html ${{ matrix.report_name }}
 
       - name: Create ZIP artifact of single site results
         uses: thedoctor0/zip-release@0.4.1
         with:
-          filename: wp-code-coverage-${{ github.sha }}.zip
-          path: wp-code-coverage-single
+          filename: ${{ matrix.report_name }}-${{ github.sha }}.zip
+          path: ${{ matrix.report_name }}
 
       - name: Upload single site coverage report
         uses: actions/upload-artifact@v2
         with:
-          name: wp-code-coverage-${{ github.sha }}
-          path: wp-code-coverage-${{ github.sha }}.zip
-          if-no-files-found: error
-
-      - name: Run tests as a multisite install
-        run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose -c tests/phpunit/multisite.xml --coverage-html wp-code-coverage-multisite
-
-      - name: Create ZIP artifact of multisite results
-        uses: thedoctor0/zip-release@0.4.1
-        with:
-          filename: wp-code-coverage-ms-${{ github.sha }}.zip
-          path: wp-code-coverage-multisite
-
-      - name: Upload multisite coverage report
-        uses: actions/upload-artifact@v2
-        with:
-          name: wp-code-coverage-multisite-${{ github.sha }}
-          path: wp-code-coverage-multisite-${{ github.sha }}.zip
-          if-no-files-found: error
-
-      - name: Run REST API tests
-        run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose -c phpunit.xml.dist --group restapi-jsclient --coverage-html wp-code-coverage-rest-api
-
-      - name: Create ZIP artifact of REST API results
-        uses: thedoctor0/zip-release@0.4.1
-        with:
-          filename: wp-code-coverage-rest-api-${{ github.sha }}.zip
-          path: wp-code-coverage-rest-api
-
-      - name: Upload REST API coverage report
-        uses: actions/upload-artifact@v2
-        with:
-          name: wp-code-coverage-rest-api-${{ github.sha }}
-          path: wp-code-coverage-rest-api-${{ github.sha }}.zip
+          name: ${{ matrix.report_name }}-${{ github.sha }}
+          path: ${{ matrix.report_name }}-${{ github.sha }}.zip
           if-no-files-found: error

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -121,11 +121,10 @@ jobs:
     needs: setup-wordpress
     strategy:
       matrix:
-        type: [ 'Single site' ]
-        ruleset: [ 'phpunit.xml.dist' ]
-        report_name: [ 'wp-code-coverage-single' ]
-
         include:
+        - type: 'Single site'
+          ruleset: 'phpunit.xml.dist'
+          report_name: 'wp-code-coverage-single'
         - type: 'Multisite'
           ruleset: 'tests/phpunit/multisite.xml'
           report_name: 'wp-code-coverage-multisite'

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -120,16 +120,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup-wordpress
     strategy:
-      include:
-      - type: 'Single site'
-        ruleset: 'phpunit.xml.dist'
-        report_name: 'wp-code-coverage-single'
-      - type: 'Multisite'
-        ruleset: 'tests/phpunit/multisite.xml'
-        report_name: 'wp-code-coverage-multisite'
-      - type: 'REST API'
-        ruleset: 'phpunit.xml.dist'
-        report_name: 'wp-code-coverage-rest-api'
+      matrix:
+        include:
+        - type: 'Single site'
+          ruleset: 'phpunit.xml.dist'
+          report_name: 'wp-code-coverage-single'
+        - type: 'Multisite'
+          ruleset: 'tests/phpunit/multisite.xml'
+          report_name: 'wp-code-coverage-multisite'
+        - type: 'REST API'
+          ruleset: 'phpunit.xml.dist'
+          report_name: 'wp-code-coverage-rest-api'
 
     steps:
       - name: Configure environment variables

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -120,17 +120,16 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup-wordpress
     strategy:
-      matrix:
-        include:
-        - type: 'Single site'
-          ruleset: 'phpunit.xml.dist'
-          report_name: 'wp-code-coverage-single'
-        - type: 'Multisite'
-          ruleset: 'tests/phpunit/multisite.xml'
-          report_name: 'wp-code-coverage-multisite'
-        - type: 'REST API'
-          ruleset: 'phpunit.xml.dist'
-          report_name: 'wp-code-coverage-rest-api'
+      include:
+      - type: 'Single site'
+        ruleset: 'phpunit.xml.dist'
+        report_name: 'wp-code-coverage-single'
+      - type: 'Multisite'
+        ruleset: 'tests/phpunit/multisite.xml'
+        report_name: 'wp-code-coverage-multisite'
+      - type: 'REST API'
+        ruleset: 'phpunit.xml.dist'
+        report_name: 'wp-code-coverage-rest-api'
 
     steps:
       - name: Configure environment variables

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -11,7 +11,7 @@ env:
   COMPOSER_INSTALL: ${{ false }}
   # Controls which NPM script to use for running PHPUnit tests. Options ar `php` and `php-composer`.
   PHPUNIT_SCRIPT: php
-  LOCAL_PHP: '7.4'
+  LOCAL_PHP: '7.4-fpm'
   LOCAL_PHP_XDEBUG: true
   LOCAL_PHP_MEMCACHED: ${{ false }}
 

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -16,9 +16,10 @@ env:
   LOCAL_PHP_MEMCACHED: ${{ false }}
 
 jobs:
+  # Sets up WordPress for testing or development use.
   #
   # Performs the following steps:
-  # - Cancels all previous workflow runs for pull requests that have not completed.
+  # - Set environment variables.
   # - Checks out the repository.
   # - Checks out the WordPress Importer plugin (needed for the Core PHPUnit tests).
   # - Logs debug information about the runner container.
@@ -26,19 +27,25 @@ jobs:
   # - Sets up caching for NPM.
   # _ Installs NPM dependencies using install-changed to hash the `package.json` file.
   # - Builds WordPress to run from the `build` directory.
-  # - Creates a ZIP file of compiled WordPress.
+  # - Logs Docker debug information (about the Docker installation within the runner).
+  # - Starts the WordPress Docker container.
+  # - Logs debug general information.
+  # - Logs the running Docker containers.
+  # - Logs WordPress Docker container debug information.
+  # - Logs debug information about what's installed within the WordPress Docker containers.
+  # - Install WordPress within the Docker container.
+  # - Run the PHPUnit tests.
+  # - Creates a ZIP file of the code coverage report.
   # - Uploads ZIP file as an artifact.
-  setup-wordpress:
-    name: Setup WordPress
+  test-coverage-report:
+    name: Generate a code coverage report
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
 
     steps:
-      - name: Cancel previous runs of this workflow (pull requests only)
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: styfle/cancel-workflow-action@0.5.0
-        with:
-          access_token: ${{ github.token }}
+      - name: Configure environment variables
+        run: |
+          echo "PHP_FPM_UID=$(id -u)" >> $GITHUB_ENV
+          echo "PHP_FPM_GID=$(id -g)" >> $GITHUB_ENV
 
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -81,102 +88,6 @@ jobs:
       - name: Build WordPress
         run: npm run build
 
-      - name: Create ZIP artifact
-        uses: thedoctor0/zip-release@0.4.1
-        with:
-          filename: built-wp-${{ github.sha }}.zip
-          exclusions: '*.git* /*node_modules/* packagehash.txt'
-
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: built-wp-${{ github.sha }}
-          path: built-wp-${{ github.sha }}.zip
-          if-no-files-found: error
-
-  # Sets up WordPress for testing or development use.
-  #
-  # Performs the following steps:
-  # - Set environment variables.
-  # - Checks out the repository.
-  # - Checks out the WordPress Importer plugin (needed for the Core PHPUnit tests).
-  # - Logs debug information about the runner container.
-  # - Installs NodeJS 14.
-  # - Sets up caching for NPM.
-  # _ Installs NPM dependencies using install-changed to hash the `package.json` file.
-  # - Builds WordPress to run from the `build` directory.
-  # - Logs Docker debug information (about the Docker installation within the runner).
-  # - Starts the WordPress Docker container.
-  # - Logs debug general information.
-  # - Logs the running Docker containers.
-  # - Logs WordPress Docker container debug information.
-  # - Logs debug information about what's installed within the WordPress Docker containers.
-  # - Install WordPress within the Docker container.
-  # - Run the PHPUnit tests.
-  # - Creates a ZIP file of the code coverage report.
-  # - Uploads ZIP file as an artifact.
-  test-coverage-report:
-    name: Generate a code coverage report
-    runs-on: ubuntu-latest
-    needs: setup-wordpress
-    strategy:
-      include:
-      - type: 'Single site'
-        ruleset: 'phpunit.xml.dist'
-        report_name: 'wp-code-coverage-single'
-      - type: 'Multisite
-        ruleset: 'tests/phpunit/multisite.xml'
-        report_name: 'wp-code-coverage-multisite'
-      - type: 'REST API'
-        ruleset: 'phpunit.xml.dist'
-        report_name: 'wp-code-coverage-rest-api'
-
-    steps:
-      - name: Configure environment variables
-        run: |
-          echo "PHP_FPM_UID=$(id -u)" >> $GITHUB_ENV
-          echo "PHP_FPM_GID=$(id -g)" >> $GITHUB_ENV
-
-      - name: Download the built WordPress artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: built-wp-${{ github.sha }}
-
-      - name: Unzip built artifact
-        run: unzip built-wp-${{ github.sha }}.zip
-
-      - name: Log debug information
-        run: |
-          echo "$GITHUB_REF"
-          echo "$GITHUB_EVENT_NAME"
-          npm --version
-          node --version
-          curl --version
-          git --version
-          svn --version
-          php --version
-          php -i
-          locale -a
-
-      - name: Install NodeJS
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14
-
-      - name: Cache NodeJS modules
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-node-modules
-        with:
-          # npm cache files are stored in `~/.npm` on Linux/macOS
-          path: ~/.npm
-          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-npm-
-
-      - name: Install Dependencies
-        run: npx install-changed --install-command="npm ci"
-
       - name: Docker debug information
         run: |
           docker -v
@@ -208,18 +119,50 @@ jobs:
       - name: Install WordPress
         run: npm run env:install
 
-      - name: 'Run PHPUnit tests - ${{ matrix.type }}
-        run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose -c ${{ matrix.ruleset }} --coverage-html ${{ matrix.report_name }}
+      - name: Run tests as a single site
+        run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose -c phpunit.xml.dist --coverage-html wp-code-coverage-single
 
       - name: Create ZIP artifact of single site results
         uses: thedoctor0/zip-release@0.4.1
         with:
-          filename: ${{ matrix.report_name }}-${{ github.sha }}.zip
-          path: ${{ matrix.report_name }}
+          filename: wp-code-coverage-${{ github.sha }}.zip
+          path: wp-code-coverage-single
 
       - name: Upload single site coverage report
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.report_name }}-${{ github.sha }}
-          path: ${{ matrix.report_name }}-${{ github.sha }}.zip
+          name: wp-code-coverage-${{ github.sha }}
+          path: wp-code-coverage-${{ github.sha }}.zip
+          if-no-files-found: error
+
+      - name: Run tests as a multisite install
+        run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose -c tests/phpunit/multisite.xml --coverage-html wp-code-coverage-multisite
+
+      - name: Create ZIP artifact of multisite results
+        uses: thedoctor0/zip-release@0.4.1
+        with:
+          filename: wp-code-coverage-ms-${{ github.sha }}.zip
+          path: wp-code-coverage-multisite
+
+      - name: Upload multisite coverage report
+        uses: actions/upload-artifact@v2
+        with:
+          name: wp-code-coverage-multisite-${{ github.sha }}
+          path: wp-code-coverage-multisite-${{ github.sha }}.zip
+          if-no-files-found: error
+
+      - name: Run REST API tests
+        run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose -c phpunit.xml.dist --group restapi-jsclient --coverage-html wp-code-coverage-rest-api
+
+      - name: Create ZIP artifact of REST API results
+        uses: thedoctor0/zip-release@0.4.1
+        with:
+          filename: wp-code-coverage-rest-api-${{ github.sha }}.zip
+          path: wp-code-coverage-rest-api
+
+      - name: Upload REST API coverage report
+        uses: actions/upload-artifact@v2
+        with:
+          name: wp-code-coverage-rest-api-${{ github.sha }}
+          path: wp-code-coverage-rest-api-${{ github.sha }}.zip
           if-no-files-found: error

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -122,15 +122,31 @@ jobs:
       - name: Run PHPUnit tests
         run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose --coverage-html report -c phpunit.xml.dist
 
-      - name: Create ZIP artifact
+      - name: Run tests as a multisite install
+        run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose --coverage-html multisite-report -c tests/phpunit/multisite.xml
+
+      - name: Create ZIP artifact of single site results
         uses: thedoctor0/zip-release@0.4.1
         with:
           filename: wp-code-coverage-${{ github.sha }}.zip
           path: report
 
-      - name: Upload build artifact
+      - name: Create ZIP artifact of multisite results
+        uses: thedoctor0/zip-release@0.4.1
+        with:
+          filename: wp-code-coverage-ms-${{ github.sha }}.zip
+          path: multisite-report
+
+      - name: Upload single site coveragre report
         uses: actions/upload-artifact@v2
         with:
           name: wp-code-coverage-${{ github.sha }}
           path: wp-code-coverage-${{ github.sha }}.zip
+          if-no-files-found: error
+
+      - name: Upload mutlsite coverage report
+        uses: actions/upload-artifact@v2
+        with:
+          name: wp-code-coverage-ms-${{ github.sha }}
+          path: wp-code-coverage-ms-${{ github.sha }}.zip
           if-no-files-found: error

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -144,7 +144,7 @@ jobs:
           filename: wp-code-coverage-ms-${{ github.sha }}.zip
           path: ./multisite-report
 
-      - name: Upload mutlsite coverage report
+      - name: Upload multisite coverage report
         uses: actions/upload-artifact@v2
         with:
           name: wp-code-coverage-ms-${{ github.sha }}
@@ -166,4 +166,3 @@ jobs:
           name: wp-code-coverage-rest-api-${{ github.sha }}
           path: wp-code-coverage-rest-api-${{ github.sha }}.zip
           if-no-files-found: error
-

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -126,7 +126,7 @@ jobs:
         uses: thedoctor0/zip-release@0.4.1
         with:
           filename: wp-code-coverage-${{ github.sha }}.zip
-          path: report
+          path: ./report
 
       - name: Upload single site coveragre report
         uses: actions/upload-artifact@v2
@@ -142,7 +142,7 @@ jobs:
         uses: thedoctor0/zip-release@0.4.1
         with:
           filename: wp-code-coverage-ms-${{ github.sha }}.zip
-          path: multisite-report
+          path: ./multisite-report
 
       - name: Upload mutlsite coverage report
         uses: actions/upload-artifact@v2
@@ -158,7 +158,7 @@ jobs:
         uses: thedoctor0/zip-release@0.4.1
         with:
           filename: wp-code-coverage-rest-api-${{ github.sha }}.zip
-          path: rest-api-report
+          path: ./rest-api-report
 
       - name: Upload REST API coverage report
         uses: actions/upload-artifact@v2

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -208,7 +208,7 @@ jobs:
       - name: Install WordPress
         run: npm run env:install
 
-      - name: 'Run PHPUnit tests - ${{ matrix.type }}
+      - name: Run PHPUnit tests - ${{ matrix.type }}
         run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose -c ${{ matrix.ruleset }} --coverage-html ${{ matrix.report_name }}
 
       - name: Create ZIP artifact of single site results

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -124,7 +124,7 @@ jobs:
       - type: 'Single site'
         ruleset: 'phpunit.xml.dist'
         report_name: 'wp-code-coverage-single'
-      - type: 'Multisite
+      - type: 'Multisite'
         ruleset: 'tests/phpunit/multisite.xml'
         report_name: 'wp-code-coverage-multisite'
       - type: 'REST API'

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -119,16 +119,16 @@ jobs:
       - name: Install WordPress
         run: npm run env:install
 
-      - name: Run tests as a multisite install
-        run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose --coverage-html multisite-report -c tests/phpunit/multisite.xml
+      - name: Run tests as a single site
+        run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose -c phpunit.xml.dist --coverage-html report
 
       - name: Create ZIP artifact of single site results
         uses: thedoctor0/zip-release@0.4.1
         with:
           filename: wp-code-coverage-${{ github.sha }}.zip
-          path: ./report
+          path: report
 
-      - name: Upload single site coveragre report
+      - name: Upload single site coverage report
         uses: actions/upload-artifact@v2
         with:
           name: wp-code-coverage-${{ github.sha }}
@@ -136,13 +136,13 @@ jobs:
           if-no-files-found: error
 
       - name: Run tests as a multisite install
-        run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose --coverage-html multisite-report -c phpunit.xml.dist
+        run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose -c tests/phpunit/multisite.xml --coverage-html multisite-report
 
       - name: Create ZIP artifact of multisite results
         uses: thedoctor0/zip-release@0.4.1
         with:
           filename: wp-code-coverage-ms-${{ github.sha }}.zip
-          path: ./multisite-report
+          path: multisite-report
 
       - name: Upload multisite coverage report
         uses: actions/upload-artifact@v2
@@ -152,13 +152,13 @@ jobs:
           if-no-files-found: error
 
       - name: Run REST API tests
-        run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose --coverage-html rest-api-report -c phpunit.xml.dist --group restapi-jsclient
+        run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose -c phpunit.xml.dist --group restapi-jsclient --coverage-html rest-api-report
 
       - name: Create ZIP artifact of REST API results
         uses: thedoctor0/zip-release@0.4.1
         with:
           filename: wp-code-coverage-rest-api-${{ github.sha }}.zip
-          path: ./rest-api-report
+          path: rest-api-report
 
       - name: Upload REST API coverage report
         uses: actions/upload-artifact@v2

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -208,7 +208,7 @@ jobs:
       - name: Install WordPress
         run: npm run env:install
 
-      - name: Run PHPUnit tests - ${{ matrix.type }}
+      - name: 'Run PHPUnit tests - ${{ matrix.type }}
         run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose -c ${{ matrix.ruleset }} --coverage-html ${{ matrix.report_name }}
 
       - name: Create ZIP artifact of single site results

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -37,6 +37,9 @@ jobs:
   # - Run the PHPUnit tests.
   # - Creates a ZIP file of the code coverage report.
   # - Uploads ZIP file as an artifact.
+  # - Run the PHPUnit tests as a multisite.
+  # - Creates a ZIP file of the code coverage report.
+  # - Uploads ZIP file as an artifact.
   test-coverage-report:
     name: Generate a code coverage report
     runs-on: ubuntu-latest
@@ -149,20 +152,4 @@ jobs:
         with:
           name: wp-code-coverage-multisite-${{ github.sha }}
           path: wp-code-coverage-multisite-${{ github.sha }}.zip
-          if-no-files-found: error
-
-      - name: Run REST API tests
-        run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose -c phpunit.xml.dist --group restapi-jsclient --coverage-html wp-code-coverage-rest-api
-
-      - name: Create ZIP artifact of REST API results
-        uses: thedoctor0/zip-release@0.4.1
-        with:
-          filename: wp-code-coverage-rest-api-${{ github.sha }}.zip
-          path: wp-code-coverage-rest-api
-
-      - name: Upload REST API coverage report
-        uses: actions/upload-artifact@v2
-        with:
-          name: wp-code-coverage-rest-api-${{ github.sha }}
-          path: wp-code-coverage-rest-api-${{ github.sha }}.zip
           if-no-files-found: error

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -19,7 +19,7 @@ jobs:
   # Sets up WordPress for testing or development use.
   #
   # Performs the following steps:
-  # - Cancels all previous workflow runs for pull requests that have not completed.
+  # - Set environment variables.
   # - Checks out the repository.
   # - Checks out the WordPress Importer plugin (needed for the Core PHPUnit tests).
   # - Logs debug information about the runner container.
@@ -27,10 +27,18 @@ jobs:
   # - Sets up caching for NPM.
   # _ Installs NPM dependencies using install-changed to hash the `package.json` file.
   # - Builds WordPress to run from the `build` directory.
-  # - Creates a ZIP file of compiled WordPress.
+  # - Logs Docker debug information (about the Docker installation within the runner).
+  # - Starts the WordPress Docker container.
+  # - Logs debug general information.
+  # - Logs the running Docker containers.
+  # - Logs WordPress Docker container debug information.
+  # - Logs debug information about what's installed within the WordPress Docker containers.
+  # - Install WordPress within the Docker container.
+  # - Run the PHPUnit tests.
+  # - Creates a ZIP file of the code coverage report.
   # - Uploads ZIP file as an artifact.
   test-coverage-report:
-    name: Setup WordPress
+    name: Generate a code coverage report
     runs-on: ubuntu-latest
 
     steps:
@@ -108,6 +116,9 @@ jobs:
           docker-compose run --rm php php -i
           docker-compose run --rm php locale -a
 
+      - name: Install WordPress
+        run: npm run env:install
+
       - name: Run PHPUnit tests
         run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose --coverage-html report -c phpunit.xml.dist
 
@@ -123,29 +134,3 @@ jobs:
           name: wp-code-coverage-${{ github.sha }}
           path: wp-code-coverage-${{ github.sha }}.zip
           if-no-files-found: error
-
-  # Runs the PHPUnit tests for WordPress.
-  #
-  # Performs the following steps:
-  # - Set environment variables.
-  # - Sets up the environment variables needed for testing with memcached (if desired).
-  # - Downloads the built WordPress artifact from the previous job.
-  # - Unzips the artifact.
-  # - Installs NodeJS 14.
-  # - Sets up caching for NPM.
-  # _ Installs NPM dependencies using install-changed to hash the `package.json` file.
-  # - Configures caching for Composer.
-  # _ Installs Composer dependencies (if desired).
-  # - Logs Docker debug information (about both the Docker installation within the runner).
-  # - Starts the WordPress Docker container.
-  # - Starts the memcached server after the Docker network has been created (if desired).
-  # - Logs WordPress Docker container debug information.
-  # - Logs debug general information.
-  # - Logs the running Docker containers.
-  # - Logs debug information about what's installed within the WordPress Docker containers.
-  # - Install WordPress within the Docker container.
-  # - Run the PHPUnit tests.
-  # - Checks out the WordPress Test reporter repository.
-  # - Reconnect the directory to the Git repository.
-  # - Submit the test results to the WordPress.org host test results.
-  # - todo: Configure Slack notifications for failing tests.

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -119,9 +119,6 @@ jobs:
       - name: Install WordPress
         run: npm run env:install
 
-      - name: Run PHPUnit tests
-        run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose --coverage-html report -c phpunit.xml.dist
-
       - name: Run tests as a multisite install
         run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose --coverage-html multisite-report -c tests/phpunit/multisite.xml
 
@@ -131,12 +128,6 @@ jobs:
           filename: wp-code-coverage-${{ github.sha }}.zip
           path: report
 
-      - name: Create ZIP artifact of multisite results
-        uses: thedoctor0/zip-release@0.4.1
-        with:
-          filename: wp-code-coverage-ms-${{ github.sha }}.zip
-          path: multisite-report
-
       - name: Upload single site coveragre report
         uses: actions/upload-artifact@v2
         with:
@@ -144,9 +135,35 @@ jobs:
           path: wp-code-coverage-${{ github.sha }}.zip
           if-no-files-found: error
 
+      - name: Run tests as a multisite install
+        run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose --coverage-html multisite-report -c phpunit.xml.dist
+
+      - name: Create ZIP artifact of multisite results
+        uses: thedoctor0/zip-release@0.4.1
+        with:
+          filename: wp-code-coverage-ms-${{ github.sha }}.zip
+          path: multisite-report
+
       - name: Upload mutlsite coverage report
         uses: actions/upload-artifact@v2
         with:
           name: wp-code-coverage-ms-${{ github.sha }}
           path: wp-code-coverage-ms-${{ github.sha }}.zip
           if-no-files-found: error
+
+      - name: Run REST API tests
+        run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose --coverage-html rest-api-report -c phpunit.xml.dist --group restapi-jsclient
+
+      - name: Create ZIP artifact of REST API results
+        uses: thedoctor0/zip-release@0.4.1
+        with:
+          filename: wp-code-coverage-rest-api-${{ github.sha }}.zip
+          path: rest-api-report
+
+      - name: Upload REST API coverage report
+        uses: actions/upload-artifact@v2
+        with:
+          name: wp-code-coverage-rest-api-${{ github.sha }}
+          path: wp-code-coverage-rest-api-${{ github.sha }}.zip
+          if-no-files-found: error
+

--- a/tests/phpunit/multisite.xml
+++ b/tests/phpunit/multisite.xml
@@ -45,4 +45,41 @@
 			</arguments>
 		</listener>
 	</listeners>
+	<filter>
+		<whitelist addUncoveredFilesFromWhitelist="true">
+			<directory suffix=".php">build</directory>
+			<exclude>
+				<!-- Third party library exclusions. -->
+				<directory suffix=".php">build/wp-includes/ID3</directory>
+				<directory suffix=".php">build/wp-includes/IXR</directory>
+				<directory suffix=".php">build/wp-includes/random_compat</directory>
+				<directory suffix=".php">build/wp-includes/PHPMailer</directory>
+				<directory suffix=".php">build/wp-includes/Requests</directory>
+				<directory suffix=".php">build/wp-includes/SimplePie</directory>
+				<directory suffix=".php">build/wp-includes/sodium_compat</directory>
+				<directory suffix=".php">build/wp-includes/Text</directory>
+
+				<!-- Plugins and themes. -->
+				<directory suffix=".php">build/wp-content/</directory>
+
+				<file>build/wp-admin/includes/class-ftp*</file>
+				<file>build/wp-admin/includes/class-pclzip.php</file>
+				<file>build/wp-admin/includes/deprecated.php</file>
+				<file>build/wp-admin/includes/ms-deprecated.php</file>
+
+				<file>build/wp-includes/atomlib.php</file>
+				<file>build/wp-includes/class-IXR.php</file>
+				<file>build/wp-includes/class-json.php</file>
+				<file>build/wp-includes/class-phpass.php</file>
+				<file>build/wp-includes/class-pop3.php</file>
+				<file>build/wp-includes/class-requests.php</file>
+				<file>build/wp-includes/class-simplepie.php</file>
+				<file>build/wp-includes/class-snoopy.php</file>
+				<file>build/wp-includes/deprecated.php</file>
+				<file>build/wp-includes/ms-deprecated.php</file>
+				<file>build/wp-includes/pluggable-deprecated.php</file>
+				<file>build/wp-includes/rss.php</file>
+			</exclude>
+		</whitelist>
+	</filter>
 </phpunit>

--- a/tests/phpunit/multisite.xml
+++ b/tests/phpunit/multisite.xml
@@ -47,38 +47,38 @@
 	</listeners>
 	<filter>
 		<whitelist addUncoveredFilesFromWhitelist="true">
-			<directory suffix=".php">build</directory>
+			<directory suffix=".php">../../build</directory>
 			<exclude>
 				<!-- Third party library exclusions. -->
-				<directory suffix=".php">build/wp-includes/ID3</directory>
-				<directory suffix=".php">build/wp-includes/IXR</directory>
-				<directory suffix=".php">build/wp-includes/random_compat</directory>
-				<directory suffix=".php">build/wp-includes/PHPMailer</directory>
-				<directory suffix=".php">build/wp-includes/Requests</directory>
-				<directory suffix=".php">build/wp-includes/SimplePie</directory>
-				<directory suffix=".php">build/wp-includes/sodium_compat</directory>
-				<directory suffix=".php">build/wp-includes/Text</directory>
+				<directory suffix=".php">../../build/wp-includes/ID3</directory>
+				<directory suffix=".php">../../build/wp-includes/IXR</directory>
+				<directory suffix=".php">../../build/wp-includes/random_compat</directory>
+				<directory suffix=".php">../../build/wp-includes/PHPMailer</directory>
+				<directory suffix=".php">../../build/wp-includes/Requests</directory>
+				<directory suffix=".php">../../build/wp-includes/SimplePie</directory>
+				<directory suffix=".php">../../build/wp-includes/sodium_compat</directory>
+				<directory suffix=".php">../../build/wp-includes/Text</directory>
 
 				<!-- Plugins and themes. -->
-				<directory suffix=".php">build/wp-content/</directory>
+				<directory suffix=".php">../../build/wp-content/</directory>
 
-				<file>build/wp-admin/includes/class-ftp*</file>
-				<file>build/wp-admin/includes/class-pclzip.php</file>
-				<file>build/wp-admin/includes/deprecated.php</file>
-				<file>build/wp-admin/includes/ms-deprecated.php</file>
+				<file>../../build/wp-admin/includes/class-ftp*</file>
+				<file>../../build/wp-admin/includes/class-pclzip.php</file>
+				<file>../../build/wp-admin/includes/deprecated.php</file>
+				<file>../../build/wp-admin/includes/ms-deprecated.php</file>
 
-				<file>build/wp-includes/atomlib.php</file>
-				<file>build/wp-includes/class-IXR.php</file>
-				<file>build/wp-includes/class-json.php</file>
-				<file>build/wp-includes/class-phpass.php</file>
-				<file>build/wp-includes/class-pop3.php</file>
-				<file>build/wp-includes/class-requests.php</file>
-				<file>build/wp-includes/class-simplepie.php</file>
-				<file>build/wp-includes/class-snoopy.php</file>
-				<file>build/wp-includes/deprecated.php</file>
-				<file>build/wp-includes/ms-deprecated.php</file>
-				<file>build/wp-includes/pluggable-deprecated.php</file>
-				<file>build/wp-includes/rss.php</file>
+				<file>../../build/wp-includes/atomlib.php</file>
+				<file>../../build/wp-includes/class-IXR.php</file>
+				<file>../../build/wp-includes/class-json.php</file>
+				<file>../../build/wp-includes/class-phpass.php</file>
+				<file>../../build/wp-includes/class-pop3.php</file>
+				<file>../../build/wp-includes/class-requests.php</file>
+				<file>../../build/wp-includes/class-simplepie.php</file>
+				<file>../../build/wp-includes/class-snoopy.php</file>
+				<file>../../build/wp-includes/deprecated.php</file>
+				<file>../../build/wp-includes/ms-deprecated.php</file>
+				<file>../../build/wp-includes/pluggable-deprecated.php</file>
+				<file>../../build/wp-includes/rss.php</file>
 			</exclude>
 		</whitelist>
 	</filter>


### PR DESCRIPTION
This generates a code coverage report on a nightly cron with a GitHub Action workflow (the `push` event will be removed when committed to `trunk`.

For now, reports are only generated for single site, multisite, and REST API results, as those are the only setups/groups that would generate any meaningful reports.

See https://github.com/desrosj/wordpress-develop/runs/1538054211?check_suite_focus=true for test run of the workflow.

Trac ticket: https://core.trac.wordpress.org/ticket/52034.