### PR TITLE
[WIP] Add Slack notifications for GH Actions

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -128,3 +128,12 @@ jobs:
 
       - name: Run JSHint
         run: npm run grunt jshint
+
+      - name: Slack Notification
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took # selectable (default: repo,message)
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
+        if: always() # Pick up events even if the job fails or is canceled.


### PR DESCRIPTION
Setting up Slack notifications for GH Actions. Brain dump follows:

* Each workflow is treated separately, not sure how to group all checks per commit the way the GH Slack action does for PRs 
(probably need to look at their source)
* Do we still want to only notify on status change? I rather like knowing pass/fail for all commits to trunk and branches but can be convinced otherwise.

See #tmp-notification-testing, didn't want to leave it in a DM so others could collaborate as desired.

Trac ticket: https://core.trac.wordpress.org/ticket/50401

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
