### PR TITLE
CSS: Reduce colors used in wp-admin

### DIFF
--- a/src/wp-admin/css/admin-menu.css
+++ b/src/wp-admin/css/admin-menu.css
@@ -3,7 +3,7 @@
 #adminmenu,
 #adminmenu .wp-submenu {
 	width: 160px;
-	background-color: #23282d;
+	background-color: #1d2327;
 }
 
 #adminmenuback {
@@ -47,7 +47,7 @@
 /* New Menu icons */
 
 .icon16:before {
-	color: #82878c; /* same as new icons */
+	color: #8c8f94; /* same as new icons */
 	font: normal 20px/1 dashicons;
 	speak: never;
 	padding: 6px 0;
@@ -169,12 +169,12 @@
 	display: block;
 	line-height: 1.3;
 	padding: 2px 5px;
-	color: #eee;
+	color: #f0f0f1;
 }
 
 #adminmenu .wp-submenu a {
-	color: #b4b9be;
-	color: rgba(240, 245, 250, 0.7);
+	color: #c3c4c7;
+	color: rgba(240, 246, 252, 0.7);
 	font-size: 13px;
 	line-height: 1.4;
 	margin: 0;
@@ -190,7 +190,7 @@
 #adminmenu li.menu-top > a:focus,
 #adminmenu .wp-submenu a:hover,
 #adminmenu .wp-submenu a:focus {
-	color: #00b9eb;
+	color: #72aee6;
 }
 
 #adminmenu a:hover,
@@ -220,7 +220,7 @@
 .folded #adminmenu .wp-has-current-submenu .wp-submenu {
 	padding: 7px 0 8px;
 	z-index: 9999;
-	background-color: #32373c;
+	background-color: #2c3338;
 	box-shadow: 0 3px 5px rgba(0, 0, 0, 0.2);
 }
 
@@ -245,7 +245,7 @@
 	border: 0 none;
 	margin-top: 0;
 	box-shadow: none;
-	background-color: #32373c;
+	background-color: #2c3338;
 }
 
 /* ensure that wp-submenu's box shadow doesn't appear on top of the focused menu item's background. */
@@ -253,8 +253,8 @@
 #adminmenu li.opensub > a.menu-top,
 #adminmenu li > a.menu-top:focus {
 	position: relative;
-	background-color: #191e23;
-	color: #00b9eb;
+	background-color: #1d2327;
+	color: #72aee6;
 }
 
 .folded #adminmenu li.menu-top:hover,
@@ -270,7 +270,7 @@
 #adminmenu .wp-menu-arrow,
 #adminmenu .wp-has-current-submenu .wp-submenu .wp-submenu-head,
 #adminmenu .wp-menu-arrow div {
-	background: #0073aa;
+	background: #2271b1;
 	color: #fff;
 }
 
@@ -378,15 +378,15 @@
 }
 
 div.wp-menu-image:before {
-	color: #a0a5aa;
-	color: rgba(240, 245, 250, 0.6);
+	color: #a7aaad;
+	color: rgba(240, 246, 252, 0.6);
 	padding: 7px 0;
 	transition: all .1s ease-in-out;
 }
 
 #adminmenu div.wp-menu-image:before {
-	color: #a0a5aa;
-	color: rgba(240, 245, 250, 0.6);
+	color: #a7aaad;
+	color: rgba(240, 246, 252, 0.6);
 }
 
 #adminmenu li.wp-has-current-submenu:hover div.wp-menu-image:before,
@@ -402,7 +402,7 @@ div.wp-menu-image:before {
 #adminmenu li:hover div.wp-menu-image:before,
 #adminmenu li a:focus div.wp-menu-image:before,
 #adminmenu li.opensub div.wp-menu-image:before {
-	color: #00b9eb;
+	color: #72aee6;
 }
 
 .folded #adminmenu div.wp-menu-image {
@@ -440,7 +440,7 @@ ul#adminmenu > li.current > a.current:after {
 	width: 0;
 	position: absolute;
 	pointer-events: none;
-	border-right-color: #f1f1f1;
+	border-right-color: #f0f0f1;
 	top: 50%;
 	margin-top: -8px;
 }
@@ -476,7 +476,7 @@ ul#adminmenu > li.current > a.current:after {
 }
 
 #adminmenu li.wp-has-submenu.wp-not-current-submenu.opensub:hover:after {
-	border-right-color: #32373c;
+	border-right-color: #2c3338;
 }
 
 #adminmenu li.menu-top:hover .wp-menu-image img,
@@ -525,7 +525,7 @@ ul#adminmenu > li.current > a.current:after {
 	min-width: 18px;
 	height: 18px;
 	border-radius: 9px;
-	background-color: #ca4a1f;
+	background-color: #d63638;
 	color: #fff;
 	font-size: 11px;
 	line-height: 1.6;
@@ -535,7 +535,7 @@ ul#adminmenu > li.current > a.current:after {
 
 #adminmenu li.current a .awaiting-mod,
 #adminmenu li a.wp-has-current-submenu .update-plugins {
-	background-color: #ca4a1f;
+	background-color: #d63638;
 	color: #fff;
 }
 
@@ -553,16 +553,16 @@ ul#adminmenu > li.current > a.current:after {
 	position: relative;
 	overflow: visible;
 	background: none;
-	color: #aaa;
+	color: #a7aaad;
 	cursor: pointer;
 }
 
 #collapse-button:hover {
-	color: #00b9eb;
+	color: #72aee6;
 }
 
 #collapse-button:focus {
-	color: #00b9eb;
+	color: #72aee6;
 	/* Only visible in Windows High Contrast mode */
 	outline: 1px solid transparent;
 	outline-offset: -1px;
@@ -887,7 +887,7 @@ li#wp-admin-bar-menu-toggle {
 	}
 
 	.wp-responsive-open #wpadminbar #wp-admin-bar-menu-toggle a {
-		background: #32373c;
+		background: #2c3338;
 	}
 
 	li#wp-admin-bar-menu-toggle {
@@ -918,7 +918,7 @@ li#wp-admin-bar-menu-toggle {
 	}
 
 	.wp-responsive-open #wpadminbar #wp-admin-bar-menu-toggle .ab-icon:before {
-		color: #00b9eb;
+		color: #72aee6;
 	}
 }
 

--- a/src/wp-admin/css/code-editor.css
+++ b/src/wp-admin/css/code-editor.css
@@ -34,25 +34,25 @@
 }
 
 .wp-core-ui .CodeMirror-lint-message-warning {
-	background-color: #fff8e5;
-	border-left: 4px solid #ffb900;
+	background-color: #fcf9e8;
+	border-left: 4px solid #dba617;
 }
 
 .wrap .CodeMirror-lint-marker-warning:before,
 .wp-core-ui .CodeMirror-lint-message-warning:before {
 	content: "\f534";
-	color: #f6a306;
+	color: #dba617;
 }
 
 .wp-core-ui .CodeMirror-lint-message-error {
-	background-color: #fbeaea;
-	border-left: 4px solid #dc3232;
+	background-color: #fcf0f1;
+	border-left: 4px solid #d63638;
 }
 
 .wrap .CodeMirror-lint-marker-error:before,
 .wp-core-ui .CodeMirror-lint-message-error:before {
 	content: "\f153";
-	color: #dc3232;
+	color: #d63638;
 }
 
 .wp-core-ui .CodeMirror-lint-tooltip {
@@ -63,7 +63,7 @@
 }
 
 .wrap .CodeMirror .CodeMirror-matchingbracket {
-	background: rgba(255, 150, 0, 0.3);
+	background: rgba(219, 166, 23, 0.3);
 	color: inherit;
 }
 
@@ -72,5 +72,5 @@
 }
 
 .wrap .CodeMirror .CodeMirror-linenumber {
-	color: #666;
+	color: #646970;
 }

--- a/src/wp-admin/css/color-picker.css
+++ b/src/wp-admin/css/color-picker.css
@@ -17,10 +17,10 @@
 }
 
 .wp-color-result-text {
-	background: #f7f7f7;
+	background: #f6f7f7;
 	border-radius: 0 2px 2px 0;
-	border-left: 1px solid #ccc;
-	color: #555;
+	border-left: 1px solid #c3c4c7;
+	color: #50575e;
 	display: block;
 	line-height: 2.54545455; /* 28px */
 	padding: 0 6px;
@@ -29,16 +29,16 @@
 
 .wp-color-result:hover,
 .wp-color-result:focus {
-	background: #fafafa;
-	border-color: #999;
-	color: #23282d;
+	background: #f6f7f7;
+	border-color: #8c8f94;
+	color: #1d2327;
 }
 
 .wp-color-result:hover:after,
 .wp-color-result:focus:after {
-	color: #23282d;
-	border-color: #a0a5aa;
-	border-left: 1px solid #999;
+	color: #1d2327;
+	border-color: #a7aaad;
+	border-left: 1px solid #8c8f94;
 }
 
 .wp-picker-container {
@@ -46,8 +46,8 @@
 }
 
 .wp-color-result:focus {
-	border-color: #5b9dd9;
-	box-shadow: 0 0 3px rgba(0, 115, 170, 0.8);
+	border-color: #4f94d4;
+	box-shadow: 0 0 3px rgba(34, 113, 177, 0.8);
 }
 
 .wp-color-result:active {
@@ -81,12 +81,12 @@
 }
 
 .wp-picker-container .iris-square-slider .ui-slider-handle:focus {
-	background-color: #555
+	background-color: #50575e
 }
 
 .wp-picker-container .iris-picker {
 	border-radius: 0;
-	border-color: #ddd;
+	border-color: #dcdcde;
 	margin-top: 6px;
 }
 
@@ -102,34 +102,34 @@
 }
 
 .wp-color-picker::-webkit-input-placeholder {
-	color: #72777c;
+	color: #787c82;
 }
 
 .wp-color-picker::-moz-placeholder {
-	color: #72777c;
+	color: #787c82;
 	opacity: 1;
 }
 
 .wp-color-picker:-ms-input-placeholder {
-	color: #72777c;
+	color: #787c82;
 }
 
 .wp-picker-container input[type="text"].iris-error {
-	background-color: #ffebe8;
-	border-color: #c00;
+	background-color: #fcf0f1;
+	border-color: #d63638;
 	color: #000;
 }
 
 .iris-picker .ui-square-handle:focus,
 .iris-picker .iris-strip .ui-slider-handle:focus {
-	border-color: #007cba;
+	border-color: #3582c4;
 	border-style: solid;
-	box-shadow: 0 0 0 1px #007cba;
+	box-shadow: 0 0 0 1px #3582c4;
 	outline: 2px solid transparent;
 }
 
 .iris-picker .iris-palette:focus {
-	box-shadow: 0 0 0 2px #007cba;
+	box-shadow: 0 0 0 2px #3582c4;
 }
 
 @media screen and (max-width: 782px) {

--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -152,8 +152,8 @@
 	font-size: 14px;
 	font-weight: 600;
 	padding: 15px 23px 14px;
-	background: #f1f1f1;
-	color: #0073aa;
+	background: #f0f0f1;
+	color: #2271b1;
 	z-index: 100000;
 	line-height: normal;
 	box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
@@ -190,7 +190,7 @@ p.popular-tags,
 .feature-filter,
 .imgedit-group,
 .comment-ays {
-	border: 1px solid #ccd0d4;
+	border: 1px solid #c3c4c7;
 	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
 }
 
@@ -215,8 +215,8 @@ body {
 }
 
 body {
-	background: #f1f1f1;
-	color: #444;
+	background: #f0f0f1;
+	color: #3c434a;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	font-size: 13px;
 	line-height: 1.4em;
@@ -252,7 +252,7 @@ td {
 
 /* Any change to the default link style must be applied to button-link too. */
 a {
-	color: #0073aa;
+	color: #2271b1;
 	transition-property: border, background, color;
 	transition-duration: .05s;
 	transition-timing-function: ease-in-out;
@@ -265,16 +265,16 @@ div {
 
 a:hover,
 a:active {
-	color: #006799;
+	color: #135e96;
 }
 
 a:focus,
 a:focus .media-icon img,
 .wp-person a:focus .gravatar {
-	color: #124964;
+	color: #043959;
 	box-shadow:
-		0 0 0 1px #5b9dd9,
-		0 0 2px 1px rgba(30, 140, 190, 0.8);
+		0 0 0 1px #4f94d4,
+		0 0 2px 1px rgba(79, 148, 212, 0.8);
 		/* Only visible in Windows High Contrast mode */
 		outline: 1px solid transparent;
 }
@@ -331,14 +331,14 @@ h6 {
 }
 
 h1 {
-	color: #23282d;
+	color: #1d2327;
 	font-size: 2em;
 	margin: .67em 0;
 }
 
 h2,
 h3 {
-	color: #23282d;
+	color: #1d2327;
 	font-size: 1.3em;
 	margin: 1em 0;
 }
@@ -419,7 +419,7 @@ kbd,
 code {
 	padding: 3px 5px 2px 5px;
 	margin: 0 1px;
-	background: #eaeaea;
+	background: #f0f0f1;
 	background: rgba(0, 0, 0, 0.07);
 	font-size: 13px;
 }
@@ -430,7 +430,7 @@ code {
 	padding: 0;
 	font-size: 13px;
 	float: left;
-	color: #666;
+	color: #646970;
 }
 
 .subsubsub a {
@@ -441,7 +441,7 @@ code {
 
 .subsubsub a .count,
 .subsubsub a.current .count {
-	color: #555d66; /* #f1f1f1 background */
+	color: #50575e; /* #f1f1f1 background */
 	font-weight: 400;
 }
 
@@ -481,12 +481,12 @@ code {
 
 .widefat thead th,
 .widefat thead td {
-	border-bottom: 1px solid #ccd0d4;
+	border-bottom: 1px solid #c3c4c7;
 }
 
 .widefat tfoot th,
 .widefat tfoot td {
-	border-top: 1px solid #ccd0d4;
+	border-top: 1px solid #c3c4c7;
 	border-bottom: none;
 }
 
@@ -599,7 +599,7 @@ code {
 .subtitle {
 	margin: 0;
 	padding-left: 25px;
-	color: #555d66;
+	color: #50575e;
 	font-size: 14px;
 	font-weight: 400;
 	line-height: 1;
@@ -614,14 +614,14 @@ code {
 	position: relative;
 	top: -3px;
 	text-decoration: none;
-	border: 1px solid #0071a1;
+	border: 1px solid #2271b1;
 	border-radius: 2px;
 	text-shadow: none;
 	font-weight: 600;
 	font-size: 13px;
 	line-height: normal; /* IE8-IE11 need this for buttons */
-	color: #0071a1; /* use the standard color used for buttons */
-	background: #f3f5f6;
+	color: #2271b1; /* use the standard color used for buttons */
+	background: #f6f7f7;
 	cursor: pointer;
 }
 
@@ -631,14 +631,14 @@ code {
 
 .wrap .add-new-h2:hover, /* deprecated */
 .wrap .page-title-action:hover {
-	background: #f1f1f1;
-	border-color: #016087;
-	color: #016087;
+	background: #f0f0f1;
+	border-color: #0a4b78;
+	color: #0a4b78;
 }
 
 /* lower specificity: color needs to be overridden by :hover and :active */
 .page-title-action:focus {
-	color: #016087;
+	color: #0a4b78;
 }
 
 /* Dashicon for language options on General Settings and Profile screens */
@@ -648,8 +648,8 @@ code {
 }
 
 .wrap .page-title-action:focus {
-	border-color: #007cba;
-	box-shadow: 0 0 0 1px #007cba;
+	border-color: #3582c4;
+	box-shadow: 0 0 0 1px #3582c4;
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
 }
@@ -667,12 +667,12 @@ code {
 #available-widgets .widget-top:hover,
 div#widgets-right .widget-top:hover,
 #widgets-left .widget-top:hover {
-	border-color: #999;
+	border-color: #8c8f94;
 	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
 }
 
 .sorthelper {
-	background-color: #ccf3fa;
+	background-color: #c5d9ed;
 }
 
 .ac_match,
@@ -683,47 +683,47 @@ div#widgets-right .widget-top:hover,
 .striped > tbody > :nth-child(odd),
 ul.striped > :nth-child(odd),
 .alternate {
-	background-color: #f9f9f9;
+	background-color: #f6f7f7;
 }
 
 .bar {
-	background-color: #e8e8e8;
-	border-right-color: #99d;
+	background-color: #f0f0f1;
+	border-right-color: #4f94d4;
 }
 
 /* Helper classes for plugins to leverage the active WordPress color scheme */
 
 .highlight {
-	background-color: #e4f2fd;
+	background-color: #f0f6fc;
 	color: #000;
 }
 
 .wp-ui-primary {
 	color: #fff;
-	background-color: #32373c;
+	background-color: #2c3338;
 }
 .wp-ui-text-primary {
-	color: #32373c;
+	color: #2c3338;
 }
 
 .wp-ui-highlight {
 	color: #fff;
-	background-color: #1e8cbe;
+	background-color: #4f94d4;
 }
 .wp-ui-text-highlight {
-	color: #1e8cbe;
+	color: #4f94d4;
 }
 
 .wp-ui-notification {
 	color: #fff;
-	background-color: #d54e21;
+	background-color: #d63638;
 }
 .wp-ui-text-notification {
-	color: #d54e21;
+	color: #d63638;
 }
 
 .wp-ui-text-icon {
-	color: #82878c; /* same as new icons */
+	color: #8c8f94; /* same as new icons */
 }
 
 /* For emoji replacement images */
@@ -763,16 +763,16 @@ img.emoji {
 
 .widget .widget-top,
 .menu-item-handle {
-	background: #fafafa;
-	color: #23282d;
+	background: #f6f7f7;
+	color: #1d2327;
 }
 
 .stuffbox .hndle {
-	border-bottom: 1px solid #ccd0d4;
+	border-bottom: 1px solid #c3c4c7;
 }
 
 .quicktags {
-	background-color: #ccc;
+	background-color: #c3c4c7;
 	color: #000;
 	font-size: 12px;
 }
@@ -787,7 +787,7 @@ img.emoji {
 #bulk-titles div a:before,
 .notice-dismiss:before {
 	background: none;
-	color: #72777c;
+	color: #787c82;
 	content: "\f153";
 	display: block;
 	font: normal 16px/20px dashicons;
@@ -810,7 +810,7 @@ img.emoji {
 .tagchecklist .ntdelbutton .remove-tag-icon:before {
 	margin-left: 2px;
 	border-radius: 50%;
-	color: #0073aa;
+	color: #2271b1;
 	/* vertically center the icon cross browsers */
 	line-height: 1.28;
 }
@@ -825,13 +825,13 @@ img.emoji {
 .tagchecklist .ntdelbutton:focus .remove-tag-icon:before,
 #bulk-titles div a:hover:before,
 #bulk-titles div a:focus:before {
-	color: #c00;
+	color: #d63638;
 }
 
 .tagchecklist .ntdelbutton:focus .remove-tag-icon:before {
 	box-shadow:
-		0 0 0 1px #5b9dd9,
-		0 0 2px 1px rgba(30, 140, 190, 0.8);
+		0 0 0 1px #4f94d4,
+		0 0 2px 1px rgba(79, 148, 212, 0.8);
 }
 
 .key-labels label {
@@ -849,7 +849,7 @@ strong, b {
 }
 
 .howto {
-	color: #666;
+	color: #646970;
 	display: block;
 }
 
@@ -864,8 +864,8 @@ p.install-help {
 
 hr {
 	border: 0;
-	border-top: 1px solid #ddd;
-	border-bottom: 1px solid #fafafa;
+	border-top: 1px solid #dcdcde;
+	border-bottom: 1px solid #f6f7f7;
 }
 
 .row-actions span.delete a,
@@ -879,7 +879,7 @@ hr {
 #media-items a.delete-permanently,
 #nav-menu-footer .menu-delete,
 #delete-link a.delete {
-	color: #a00;
+	color: #d63638;
 }
 
 abbr.required,
@@ -896,7 +896,7 @@ span.required,
 #media-items a.delete-permanently:hover,
 #nav-menu-footer .menu-delete:hover,
 #delete-link a.delete:hover {
-	color: #dc3232;
+	color: #d63638;
 	border: none;
 }
 
@@ -907,8 +907,8 @@ span.required,
 #major-publishing-actions {
 	padding: 10px;
 	clear: both;
-	border-top: 1px solid #ddd;
-	background: #f5f5f5;
+	border-top: 1px solid #dcdcde;
+	background: #f6f7f7;
 }
 
 #delete-action {
@@ -997,9 +997,9 @@ th.action-links {
 	padding: 0 10px;
 	width: 100%;
 	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
-	border: 1px solid #ccd0d4;
+	border: 1px solid #c3c4c7;
 	background: #fff;
-	color: #555;
+	color: #50575e;
 	font-size: 13px;
 }
 
@@ -1020,7 +1020,7 @@ th.action-links {
 	top: -1px;
 	padding: 4px 10px;
 	border-radius: 30px;
-	background: #72777c;
+	background: #787c82;
 	color: #fff;
 	font-size: 14px;
 	font-weight: 600;
@@ -1053,21 +1053,21 @@ th.action-links {
 	margin: 0 10px;
 	padding: 15px 0;
 	border-bottom: 4px solid #fff;
-	color: #666;
+	color: #646970;
 	cursor: pointer;
 }
 
 .filter-links .current {
 	box-shadow: none;
-	border-bottom: 4px solid #666;
-	color: #23282d;
+	border-bottom: 4px solid #646970;
+	color: #1d2327;
 }
 
 .filter-links li > a:hover,
 .filter-links li > a:focus,
 .show-filters .filter-links a.current:hover,
 .show-filters .filter-links a.current:focus {
-	color: #006799;
+	color: #135e96;
 }
 
 .wp-filter .search-form {
@@ -1110,7 +1110,7 @@ th.action-links {
 	padding: 0 10px 0 6px;
 	border-color: transparent;
 	background-color: transparent;
-	color: #666;
+	color: #646970;
 	vertical-align: baseline;
 	box-shadow: none;
 }
@@ -1118,7 +1118,7 @@ th.action-links {
 .wp-filter .drawer-toggle:before {
 	content: "\f111";
 	margin: 0 5px 0 0;
-	color: #72777c;
+	color: #787c82;
 	font: normal 16px/1 dashicons;
 	vertical-align: text-bottom;
 	-webkit-font-smoothing: antialiased;
@@ -1130,7 +1130,7 @@ th.action-links {
 .wp-filter .button.drawer-toggle:focus,
 .wp-filter .drawer-toggle:focus:before {
 	background-color: transparent;
-	color: #006799;
+	color: #135e96;
 }
 
 .wp-filter .button.drawer-toggle:hover,
@@ -1139,7 +1139,7 @@ th.action-links {
 }
 
 .wp-filter .button.drawer-toggle:focus {
-	border-color: #5b9dd9;
+	border-color: #4f94d4;
 }
 
 .wp-filter .button.drawer-toggle:active {
@@ -1157,8 +1157,8 @@ th.action-links {
 	display: none;
 	margin: 0 -10px 0 -20px;
 	padding: 20px;
-	border-top: 1px solid #eee;
-	background: #fafafa;
+	border-top: 1px solid #f0f0f1;
+	background: #f6f7f7;
 	overflow: hidden;
 }
 
@@ -1173,13 +1173,13 @@ th.action-links {
 
 .show-filters .wp-filter .button.drawer-toggle {
 	border-radius: 2px;
-	background: #72777c;
+	background: #787c82;
 	color: #fff;
 }
 
 .show-filters .wp-filter .drawer-toggle:hover,
 .show-filters .wp-filter .drawer-toggle:focus {
-	background: rgb(46, 162, 204);
+	background: #72aee6;
 }
 
 .show-filters .wp-filter .drawer-toggle:before {
@@ -1194,7 +1194,7 @@ th.action-links {
 	padding: 20px 10px 10px;
 	width: 24%;
 	background: #fff;
-	border: 1px solid #e5e5e5;
+	border: 1px solid #dcdcde;
 	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
 }
 
@@ -1276,7 +1276,7 @@ th.action-links {
 .filtered-by .tag {
 	margin: 0 5px;
 	padding: 4px 8px;
-	border: 1px solid #e5e5e5;
+	border: 1px solid #dcdcde;
 	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
 	background: #fff;
 	font-size: 11px;
@@ -1316,7 +1316,7 @@ th.action-links {
 
 @media only screen and (max-width: 1120px) {
 	.filter-drawer {
-		border-bottom: 1px solid #eee;
+		border-bottom: 1px solid #f0f0f1;
 	}
 
 	.filter-group {
@@ -1374,9 +1374,9 @@ th.action-links {
 div.updated,
 div.error {
 	background: #fff;
-	border: 1px solid #ccd0d4;
+	border: 1px solid #c3c4c7;
 	border-left-width: 4px;
-	box-shadow: 0 1px 1px rgba(0, 0, 0, .04);
+	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
 	margin: 5px 15px 2px;
 	padding: 1px 12px;
 }
@@ -1412,7 +1412,7 @@ div.error p,
 
 .notice-title {
 	display: inline-block;
-	color: #23282d;
+	color: #1d2327;
 	font-size: 18px;
 }
 
@@ -1429,55 +1429,55 @@ div.error p,
 	margin: 0;
 	padding: 9px;
 	background: none;
-	color: #72777c;
+	color: #787c82;
 	cursor: pointer;
 }
 
 .notice-dismiss:hover:before,
 .notice-dismiss:active:before,
 .notice-dismiss:focus:before {
-	color: #c00;
+	color: #d63638;
 }
 
 .notice-dismiss:focus {
 	outline: none;
 	box-shadow:
-		0 0 0 1px #5b9dd9,
-		0 0 2px 1px rgba(30, 140, 190, 0.8);
+		0 0 0 1px #4f94d4,
+		0 0 2px 1px rgba(79, 148, 212, 0.8);
 }
 
 .notice-success,
 div.updated {
-	border-left-color: #46b450;
+	border-left-color: #00a32a;
 }
 
 .notice-success.notice-alt {
-	background-color: #ecf7ed;
+	background-color: #edfaef;
 }
 
 .notice-warning {
-	border-left-color: #ffb900;
+	border-left-color: #dba617;
 }
 
 .notice-warning.notice-alt {
-	background-color: #fff8e5;
+	background-color: #fcf9e8;
 }
 
 .notice-error,
 div.error {
-	border-left-color: #dc3232;
+	border-left-color: #d63638;
 }
 
 .notice-error.notice-alt {
-	background-color: #fbeaea;
+	background-color: #fcf0f1;
 }
 
 .notice-info {
-	border-left-color: #00a0d2;
+	border-left-color: #72aee6;
 }
 
 .notice-info.notice-alt {
-	background-color: #e5f5fa;
+	background-color: #f0f6fc;
 }
 
 .update-message p:before,
@@ -1525,7 +1525,7 @@ div.error {
 .import-php .updating-message:before,
 .button.updating-message:before,
 .button.installing:before {
-	color: #f56e28;
+	color: #d63638;
 	content: "\f463";
 }
 
@@ -1547,13 +1547,13 @@ div.error {
 .updated-message p:before,
 .installed p:before,
 .button.updated-message:before {
-	color: #79ba49;
+	color: #68de7c;
 	content: "\f147";
 }
 
 /* Error icon. */
 .update-message.notice-error p:before {
-	color: #dc3232;
+	color: #d63638;
 	content: "\f534";
 }
 
@@ -1637,7 +1637,7 @@ p.auto-update-status {
 }
 
 .button-primary.updated-message:before {
-	color: #66c6e4;
+	color: #9ec2e6;
 }
 
 .button.updated-message {
@@ -1693,7 +1693,7 @@ p.auto-update-status {
 	margin: 0 20px -1px 0px;
 	position: relative;
 	background-color: #fff;
-	border: 1px solid #ccd0d4;
+	border: 1px solid #c3c4c7;
 	border-top: none;
 	box-shadow: 0 0 0 transparent;
 }
@@ -1710,14 +1710,14 @@ p.auto-update-status {
 }
 
 #screen-meta-links .show-settings {
-	border: 1px solid #ccd0d4;
+	border: 1px solid #c3c4c7;
 	border-top: none;
 	height: auto;
 	margin-bottom: 0;
 	padding: 3px 6px 3px 16px;
 	background: #fff;
 	border-radius: 0 0 4px 4px;
-	color: #72777c;
+	color: #787c82;
 	line-height: 1.7;
 	box-shadow: 0 0 0 transparent;
 	transition: box-shadow 0.1s linear;
@@ -1726,12 +1726,12 @@ p.auto-update-status {
 #screen-meta-links .show-settings:hover,
 #screen-meta-links .show-settings:active,
 #screen-meta-links .show-settings:focus {
-	color: #32373c;
+	color: #2c3338;
 }
 
 #screen-meta-links .show-settings:focus {
-	border-color: #5b9dd9;
-	box-shadow: 0 0 3px rgba(0, 115, 170, 0.8);
+	border-color: #4f94d4;
+	box-shadow: 0 0 3px rgba(34, 113, 177, 0.8);
 }
 
 #screen-meta-links .show-settings:active {
@@ -1751,7 +1751,7 @@ p.auto-update-status {
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 	text-decoration: none;
-	color: #72777c;
+	color: #787c82;
 }
 
 #screen-meta-links .screen-meta-active:after {
@@ -1855,10 +1855,10 @@ p.auto-update-status {
 	bottom: 0;
 	left: 150px;
 	right: 170px;
-	border: 1px solid #ccd0d4;
+	border: 1px solid #c3c4c7;
 	border-top: none;
 	border-bottom: none;
-	background: #f6fbfd;
+	background: #f0f6fc;
 }
 
 #contextual-help-wrap.no-sidebar #contextual-help-back {
@@ -1896,20 +1896,20 @@ p.auto-update-status {
 }
 
 .contextual-help-tabs a:hover {
-	color: #32373c;
+	color: #2c3338;
 }
 
 .contextual-help-tabs .active {
 	padding: 0;
 	margin: 0 -1px 0 0;
-	border-left: 2px solid #00a0d2;
-	background: #f6fbfd;
+	border-left: 2px solid #72aee6;
+	background: #f0f6fc;
 	box-shadow: 0 2px 0 rgba(0, 0, 0, 0.02), 0 1px 0 rgba(0, 0, 0, 0.02);
 }
 
 .contextual-help-tabs .active a {
-	border-color: #ccd0d4;
-	color: #32373c;
+	border-color: #c3c4c7;
+	color: #2c3338;
 }
 
 .contextual-help-tabs-wrap {
@@ -1951,7 +1951,7 @@ html.wp-toolbar {
 
 .widefat th,
 .widefat td {
-	color: #555;
+	color: #50575e;
 }
 
 .widefat th,
@@ -1964,7 +1964,7 @@ html.wp-toolbar {
 .widefat thead tr td,
 .widefat tfoot tr th,
 .widefat tfoot tr td {
-	color: #32373c;
+	color: #2c3338;
 }
 
 .widefat td p {
@@ -1974,7 +1974,7 @@ html.wp-toolbar {
 .widefat p,
 .widefat ol,
 .widefat ul {
-	color: #32373c;
+	color: #2c3338;
 }
 
 .widefat .column-comment p {
@@ -2050,7 +2050,7 @@ html.wp-toolbar {
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
-	border-bottom: 1px solid #ccd0d4;
+	border-bottom: 1px solid #c3c4c7;
 }
 
 .postbox-header .hndle {
@@ -2080,7 +2080,7 @@ html.wp-toolbar {
 
 .postbox .handle-order-higher,
 .postbox .handle-order-lower {
-	color: #72777c;
+	color: #787c82;
 	width: 1.62rem;
 }
 
@@ -2089,17 +2089,17 @@ html.wp-toolbar {
 .edit-post-meta-boxes-area .postbox .handle-order-lower {
 	width: 44px;
 	height: 44px;
-	color: #191e23
+	color: #1d2327
 }
 
 .postbox .handle-order-higher[aria-disabled="true"],
 .postbox .handle-order-lower[aria-disabled="true"] {
 	cursor: default;
-	color: #a0a5aa;
+	color: #a7aaad;
 }
 
 .sortable-placeholder {
-	border: 1px dashed #b4b9be;
+	border: 1px dashed #c3c4c7;
 	margin-bottom: 20px;
 }
 
@@ -2159,7 +2159,7 @@ html.wp-toolbar {
 }
 
 .temp-border {
-	border: 1px dotted #ccc;
+	border: 1px dotted #c3c4c7;
 }
 
 .columns-prefs label {
@@ -2194,7 +2194,7 @@ html.wp-toolbar {
 	left: 0;
 	right: 0;
 	padding: 10px 20px;
-	color: #555d66;
+	color: #50575e;
 }
 
 #wpfooter p {
@@ -2213,15 +2213,15 @@ html.wp-toolbar {
 
 .nav-tab {
 	float: left;
-	border: 1px solid #ccc;
+	border: 1px solid #c3c4c7;
 	border-bottom: none;
 	margin-left: 0.5em; /* half the font size so set the font size properly */
 	padding: 5px 10px;
 	font-size: 14px;
 	line-height: 1.71428571;
 	font-weight: 600;
-	background: #e5e5e5;
-	color: #555;
+	background: #dcdcde;
+	color: #50575e;
 	text-decoration: none;
 	white-space: nowrap;
 }
@@ -2236,7 +2236,7 @@ h3 .nav-tab, /* Back-compat for pre-4.4 */
 .nav-tab:hover,
 .nav-tab:focus {
 	background-color: #fff;
-	color: #444;
+	color: #3c434a;
 }
 
 .nav-tab-active,
@@ -2246,22 +2246,22 @@ h3 .nav-tab, /* Back-compat for pre-4.4 */
 
 .nav-tab-active {
 	margin-bottom: -1px;
-	color: #444;
+	color: #3c434a;
 }
 
 .nav-tab-active,
 .nav-tab-active:hover,
 .nav-tab-active:focus,
 .nav-tab-active:focus:active {
-	border-bottom: 1px solid #f1f1f1;
-	background: #f1f1f1;
+	border-bottom: 1px solid #f0f0f1;
+	background: #f0f0f1;
 	color: #000;
 }
 
 h1.nav-tab-wrapper, /* Back-compat for pre-4.4 */
 .wrap h2.nav-tab-wrapper, /* higher specificity to override .wrap > h2:first-child */
 .nav-tab-wrapper {
-	border-bottom: 1px solid #ccc;
+	border-bottom: 1px solid #c3c4c7;
 	margin: 0;
 	padding-top: 9px;
 	padding-bottom: 0;
@@ -2345,7 +2345,7 @@ table .column-rating {
 
 .attention,
 .error-message {
-	color: #dc3232;
+	color: #d63638;
 	font-weight: 600;
 }
 
@@ -2371,7 +2371,7 @@ body.iframe {
 }
 
 .media-icon img {
-	border: 1px solid #e5e5e5;
+	border: 1px solid #dcdcde;
 	border: 1px solid rgba(0, 0, 0, 0.07);
 }
 
@@ -2414,7 +2414,7 @@ body.iframe {
 
 .importer-action {
 	line-height: 1.55; /* Same as with .updating-message */
-	color: #555;
+	color: #50575e;
 	margin-bottom: 1em;
 }
 
@@ -2424,8 +2424,8 @@ body.iframe {
 }
 
 .edit-comment-author {
-	color: #222;
-	border-bottom: 1px solid #eee;
+	color: #1d2327;
+	border-bottom: 1px solid #f0f0f1;
 }
 
 #namediv h3 label, /* Back-compat for pre-4.4 */
@@ -2521,7 +2521,7 @@ div.star-holder .star-rating {
 	vertical-align: top;
 	transition: color .1s ease-in;
 	text-align: center;
-	color: #ffb900;
+	color: #dba617;
 }
 
 .star-rating .star-full:before {
@@ -2565,7 +2565,7 @@ div.action-links {
 
 #plugin-information-title {
 	padding: 0 26px;
-	background: #f5f5f5;
+	background: #f6f7f7;
 	font-size: 22px;
 	font-weight: 600;
 	line-height: 2.4;
@@ -2600,7 +2600,7 @@ div.action-links {
 	padding: 0 15px;
 	margin-top: 174px;
 	color: #fff;
-	background: rgba(30, 30, 30, 0.9);
+	background: rgba(29, 35, 39, 0.9);
 	text-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
 	box-shadow: 0 0 30px rgba(255, 255, 255, 0.1);
 	border-radius: 8px;
@@ -2629,8 +2629,8 @@ div.action-links {
 	min-height: 36px;
 	font-size: 0;
 	z-index: 1;
-	border-bottom: 1px solid #ddd;
-	background: #f3f3f3;
+	border-bottom: 1px solid #dcdcde;
+	background: #f6f7f7;
 }
 
 #plugin-information-tabs a {
@@ -2648,10 +2648,10 @@ div.action-links {
 #plugin-information-tabs a.current {
 	margin: 0 -1px -1px;
 	background: #fff;
-	border: 1px solid #ddd;
+	border: 1px solid #dcdcde;
 	border-bottom-color: #fff;
 	padding-top: 8px;
-	color: #32373c;
+	color: #2c3338;
 }
 
 #plugin-information-tabs.with-banner a.current {
@@ -2711,20 +2711,20 @@ div.action-links {
 	margin-bottom: -99932px; /* 67px less than the padding below to accommodate footer height */
 	padding-bottom: 99999px; /* equal height column trick */
 	width: 217px;
-	border-left: 1px solid #ddd;
-	background: #f3f3f3;
-	color: #666;
+	border-left: 1px solid #dcdcde;
+	background: #f6f7f7;
+	color: #646970;
 }
 
 #plugin-information .fyi strong {
-	color: #444;
+	color: #3c434a;
 }
 
 #plugin-information .fyi h3 {
 	font-weight: 600;
 	text-transform: uppercase;
 	font-size: 12px;
-	color: #666;
+	color: #646970;
 	margin: 24px 0 8px;
 }
 
@@ -2761,13 +2761,13 @@ div.action-links {
 #plugin-information .counter-back {
 	height: 17px;
 	width: 92px;
-	background-color: #e5e5e5;
+	background-color: #dcdcde;
 	float: left;
 }
 
 #plugin-information .counter-bar {
 	height: 17px;
-	background-color: #ffc733; /* slightly lighter than stars due to larger expanse */
+	background-color: #f0c33c; /* slightly lighter than stars due to larger expanse */
 	float: left;
 }
 
@@ -2803,8 +2803,8 @@ div.action-links {
 	bottom: 0;
 	left: 0;
 	height: 40px; /* actual height: 40+13+13+1=67 */
-	border-top: 1px solid #ddd;
-	background: #f3f3f3;
+	border-top: 1px solid #dcdcde;
+	background: #f6f7f7;
 }
 
 /* rtl:ignore */
@@ -2848,12 +2848,12 @@ div.action-links {
 #plugin-information pre {
 	padding: 7px;
 	overflow: auto;
-	border: 1px solid #ccc;
+	border: 1px solid #c3c4c7;
 }
 
 #plugin-information blockquote {
-	border-left: 2px solid #ddd;
-	color: #666;
+	border-left: 2px solid #dcdcde;
+	color: #646970;
 	font-style: italic;
 	margin: 1em 0;
 	padding: 0 0 0 1em;
@@ -2864,7 +2864,7 @@ div.action-links {
 	overflow: hidden; /* clearfix */
 	width: 100%;
 	margin-bottom: 20px;
-	border-bottom: 1px solid #e5e5e5;
+	border-bottom: 1px solid #dcdcde;
 }
 
 #plugin-information .review-title-section {
@@ -2945,7 +2945,7 @@ div.action-links {
 
 	#plugin-information .fyi {
 		float: none;
-		border: 1px solid #ddd;
+		border: 1px solid #dcdcde;
 		position: static;
 		width: auto;
 		margin: 26px 26px 0;
@@ -2971,7 +2971,7 @@ div.action-links {
 
 /* Thickbox for the Plugin details modal. */
 #TB_window.plugin-details-modal {
-	background: #fcfcfc;
+	background: #fff;
 }
 
 #TB_window.plugin-details-modal.thickbox-loading:before {
@@ -2984,7 +2984,7 @@ div.action-links {
 	top: 50%;
 	z-index: -1;
 	margin: -10px 0 0 -10px;
-	background: #fcfcfc url(../images/spinner.gif) no-repeat center;
+	background: #fff url(../images/spinner.gif) no-repeat center;
 	background-size: 20px 20px;
 	transform: translateZ(0);
 }
@@ -3010,12 +3010,12 @@ div.action-links {
 .plugin-details-modal #TB_closeWindowButton {
 	left: auto;
 	right: -30px;
-	color: #eee;
+	color: #f0f0f1;
 }
 
 .plugin-details-modal #TB_closeWindowButton:hover,
 .plugin-details-modal #TB_closeWindowButton:focus {
-	color: #006799;
+	color: #135e96;
 	outline: none;
 	box-shadow: none;
 }
@@ -3104,15 +3104,15 @@ img {
 .bulk-action-notice .toggle-indicator::before {
 	line-height: 16px;
 	vertical-align: top;
-	color: #72777c;
+	color: #787c82;
 }
 
 .postbox .handle-order-higher:focus,
 .postbox .handle-order-lower:focus,
 .postbox .handlediv:focus {
 	box-shadow:
-		0 0 0 1px #5b9dd9,
-		0 0 2px 1px rgba(30, 140, 190, 0.8);
+		0 0 0 1px #4f94d4,
+		0 0 2px 1px rgba(79, 148, 212, 0.8);
 	/* Only visible in Windows High Contrast mode */
 	outline: 1px solid transparent;
 }
@@ -3138,7 +3138,7 @@ img {
 #template textarea {
 	font-family: Consolas, Monaco, monospace;
 	font-size: 13px;
-	background: #f9f9f9;
+	background: #f6f7f7;
 	-moz-tab-size: 4;
 	-o-tab-size: 4;
 	tab-size: 4;
@@ -3149,7 +3149,7 @@ img {
 	width: 100%;
 	min-height: 60vh;
 	height: calc( 100vh - 295px );
-	border: 1px solid #ddd;
+	border: 1px solid #dcdcde;
 	box-sizing: border-box;
 }
 
@@ -3171,8 +3171,8 @@ img {
 	padding: 0;
 	min-height: 60vh;
 	height: calc(100vh - 295px);
-	background-color: #f7f7f7;
-	border: 1px solid #ddd;
+	background-color: #f6f7f7;
+	border: 1px solid #dcdcde;
 	border-left: none;
 }
 #templateside ul ul {
@@ -3216,14 +3216,14 @@ img {
 	outline: 0;
 }
 [role="treeitem"] .folder-label.focus {
-	color: #124964;
+	color: #043959;
 	box-shadow:
-		0 0 0 1px #5b9dd9,
-		0 0 2px 1px rgba(30, 140, 190, 0.8);
+		0 0 0 1px #4f94d4,
+		0 0 2px 1px rgba(79, 148, 212, 0.8);
 }
 [role="treeitem"].hover,
 [role="treeitem"] .folder-label.hover {
-	background-color: #eaeaea;
+	background-color: #f0f0f1;
 }
 
 .tree-folder {
@@ -3240,7 +3240,7 @@ img {
 	display: block;
 	position: absolute;
 	left: 2px;
-	border-left: 1px solid #ccc;
+	border-left: 1px solid #c3c4c7;
 	top: -13px;
 	bottom: 10px;
 }
@@ -3248,18 +3248,18 @@ img {
 	content: "";
 	position: absolute;
 	display: block;
-	border-left: 1px solid #ccc;
+	border-left: 1px solid #c3c4c7;
 	left: 2px;
 	top: -5px;
 	height: 18px;
 	width: 7px;
-	border-bottom: 1px solid #ccc;
+	border-bottom: 1px solid #c3c4c7;
 }
 .tree-folder > li::after {
 	content: "";
 	position: absolute;
 	display: block;
-	border-left: 1px solid #ccc;
+	border-left: 1px solid #c3c4c7;
 	left: 2px;
 	bottom: -7px;
 	top: 0;
@@ -3380,7 +3380,7 @@ img {
 }
 
 .nonessential {
-	color: #666;
+	color: #646970;
 	font-size: 11px;
 	font-style: italic;
 	padding-left: 12px;
@@ -3428,11 +3428,11 @@ img {
 .item-edit,
 .toggle-indicator,
 .accordion-section-title:after {
-	color: #72777c;
+	color: #787c82;
 }
 
 .widget-action {
-	color: #555d66; /* #fafafa background in the Widgets screen */
+	color: #50575e; /* #fafafa background in the Widgets screen */
 }
 
 .widget-top:hover .widget-action,
@@ -3445,15 +3445,15 @@ img {
 .item-edit:focus,
 .sidebar-name:hover .toggle-indicator,
 .accordion-section-title:hover:after {
-	color: #23282d;
+	color: #1d2327;
 	/* Only visible in Windows High Contrast mode */
 	outline: 1px solid transparent;
 }
 
 .widget-top .widget-action:focus .toggle-indicator:before {
 	box-shadow:
-		0 0 0 1px #5b9dd9,
-		0 0 2px 1px rgba(30, 140, 190, 0.8);
+		0 0 0 1px #4f94d4,
+		0 0 2px 1px rgba(79, 148, 212, 0.8);
 }
 
 .control-section .accordion-section-title:after,
@@ -3486,7 +3486,7 @@ img {
 
 /* Accordion */
 .accordion-section {
-	border-bottom: 1px solid #ddd;
+	border-bottom: 1px solid #dcdcde;
 	margin: 0;
 }
 
@@ -3496,7 +3496,7 @@ img {
 }
 
 .accordion-section.open:hover {
-	border-bottom-color: #ddd;
+	border-bottom-color: #dcdcde;
 }
 
 .accordion-section-content {
@@ -3510,8 +3510,8 @@ img {
 	margin: 0;
 	padding: 12px 15px 15px;
 	position: relative;
-	border-left: 1px solid #ddd;
-	border-right: 1px solid #ddd;
+	border-left: 1px solid #dcdcde;
+	border-right: 1px solid #dcdcde;
 	-webkit-user-select: none;
 	-ms-user-select: none;
 	user-select: none;
@@ -3535,7 +3535,7 @@ img {
 
 .accordion-section-title:hover:after,
 .accordion-section-title:focus:after {
-	border-color: #a0a5aa transparent;
+	border-color: #a7aaad transparent;
 	/* Only visible in Windows High Contrast mode */
 	outline: 1px solid transparent;
 }
@@ -3566,13 +3566,13 @@ img {
 .js .control-section .accordion-section-title:hover,
 .js .control-section.open .accordion-section-title,
 .js .control-section .accordion-section-title:focus {
-	color: #23282d;
-	background: #f5f5f5;
+	color: #1d2327;
+	background: #f6f7f7;
 }
 
 .control-section.open .accordion-section-title {
 	/* When expanded */
-	border-bottom: 1px solid #ddd;
+	border-bottom: 1px solid #dcdcde;
 }
 
 /* Edit Site */
@@ -3612,7 +3612,7 @@ img {
 		position: absolute;
 		top: 0;
 		right: 0;
-		background: #ccc;
+		background: #c3c4c7;
 	}
 
 }
@@ -3632,7 +3632,7 @@ img {
 	}
 	.my-sites li:nth-of-type(4n+1),
 	.my-sites li:nth-of-type(4n+2) {
-		background-color: #f9f9f9;
+		background-color: #f6f7f7;
 	}
 
 }
@@ -3649,7 +3649,7 @@ img {
 	.my-sites li:nth-of-type(6n+1),
 	.my-sites li:nth-of-type(6n+2),
 	.my-sites li:nth-of-type(6n+3) {
-		background-color: #f9f9f9;
+		background-color: #f6f7f7;
 	}
 }
 
@@ -3670,7 +3670,7 @@ img {
 	.my-sites li:nth-of-type(8n+2),
 	.my-sites li:nth-of-type(8n+3),
 	.my-sites li:nth-of-type(8n+4) {
-		background-color: #f9f9f9;
+		background-color: #f6f7f7;
 	}
 }
 
@@ -3692,7 +3692,7 @@ img {
 	.my-sites li:nth-of-type(10n+3),
 	.my-sites li:nth-of-type(10n+4),
 	.my-sites li:nth-of-type(10n+5) {
-		background-color: #f9f9f9;
+		background-color: #f6f7f7;
 	}
 }
 
@@ -3715,7 +3715,7 @@ img {
 	.my-sites li:nth-of-type(12n+4),
 	.my-sites li:nth-of-type(12n+5),
 	.my-sites li:nth-of-type(12n+6) {
-		background-color: #f9f9f9;
+		background-color: #f6f7f7;
 	}
 }
 
@@ -3883,7 +3883,7 @@ img {
 	}
 
 	#templateside > ul {
-		border-left: 1px solid #ddd;
+		border-left: 1px solid #dcdcde;
 	}
 
 	#templateside li {
@@ -4093,13 +4093,13 @@ img {
 	h3 .nav-tab,
 	nav .nav-tab {
 		margin: 10px 10px 0 0;
-		border-bottom: 1px solid #ccc;
+		border-bottom: 1px solid #c3c4c7;
 	}
 
 	.nav-tab-active:hover,
 	.nav-tab-active:focus,
 	.nav-tab-active:focus:active {
-		border-bottom: 1px solid #ccc;
+		border-bottom: 1px solid #c3c4c7;
 	}
 
 	.wp-filter .search-form input[type="search"] {

--- a/src/wp-admin/css/customize-controls.css
+++ b/src/wp-admin/css/customize-controls.css
@@ -61,7 +61,7 @@ body {
 }
 
 #customize-controls .description {
-	color: #555d66;
+	color: #50575e;
 }
 
 #customize-save-button-wrapper {
@@ -80,7 +80,7 @@ body:not(.ready) #customize-save-button-wrapper .save {
 }
 
 #customize-save-button-wrapper .save:focus, #publish-settings:focus {
-	box-shadow: 0 1px 0 #0073aa, 0 0 2px 1px #33b3db; /* This is default box shadow for focus */
+	box-shadow: 0 1px 0 #2271b1, 0 0 2px 1px #72aee6; /* This is default box shadow for focus */
 }
 
 #customize-save-button-wrapper .save.has-next-sibling {
@@ -98,10 +98,10 @@ body:not(.ready) #customize-save-button-wrapper .save {
 	width: 100%;
 	margin: 0;
 	z-index: -1;
-	background: #eee;
+	background: #f0f0f1;
 	transition: left .18s;
-	border-right: 1px solid #ddd;
-	border-left: 1px solid #ddd;
+	border-right: 1px solid #dcdcde;
+	border-left: 1px solid #dcdcde;
 	height: 100%;
 }
 
@@ -179,7 +179,7 @@ body.trashing #publish-settings {
 }
 
 #customize-header-actions {
-	border-bottom: 1px solid #ddd;
+	border-bottom: 1px solid #dcdcde;
 }
 
 #customize-controls .wp-full-overlay-sidebar-content {
@@ -188,19 +188,19 @@ body.trashing #publish-settings {
 }
 
 .outer-section-open #customize-controls .wp-full-overlay-sidebar-content {
-	background: #eee;
+	background: #f0f0f1;
 }
 
 #customize-controls .customize-info {
 	border: none;
-	border-bottom: 1px solid #ddd;
+	border-bottom: 1px solid #dcdcde;
 	margin-bottom: 15px;
 }
 
 #customize-control-changeset_status .customize-inside-control-row,
 #customize-control-changeset_preview_link input {
-	background-color: #ffffff;
-	border-bottom: 1px solid #ddd;
+	background-color: #fff;
+	border-bottom: 1px solid #dcdcde;
 	box-sizing: content-box;
 	width: 100%;
 	margin-left: -12px;
@@ -226,7 +226,7 @@ body.trashing #publish-settings {
 }
 
 #customize-controls .date-input:invalid {
-	border-color: #dc3232;
+	border-color: #d63638;
 }
 
 #customize-control-changeset_status .customize-inside-control-row {
@@ -236,7 +236,7 @@ body.trashing #publish-settings {
 }
 
 #customize-control-changeset_status .customize-inside-control-row:first-of-type {
-	border-top: 1px solid #ddd;
+	border-top: 1px solid #dcdcde;
 }
 
 #customize-control-changeset_status .customize-control-title {
@@ -268,7 +268,7 @@ body.trashing #publish-settings {
 	content: "";
 	height: 28px;
 	position: absolute;
-	background: #ffffff;
+	background: #fff;
 	top: -1px;
 }
 
@@ -286,7 +286,7 @@ body.trashing #publish-settings {
 
 #customize-control-changeset_preview_link input {
 	line-height: 2.85714286; /* 40px */
-	border-top: 1px solid #ddd;
+	border-top: 1px solid #dcdcde;
 	border-left: none;
 	border-right: none;
 	text-indent: -999px;
@@ -315,7 +315,7 @@ body.trashing #publish-settings {
 #customize-control-changeset_preview_link a.disabled:active,
 #customize-control-changeset_preview_link a.disabled:focus,
 #customize-control-changeset_preview_link a.disabled:visited {
-	color: black;
+	color: #000;
 	opacity: 0.4;
 	cursor: default;
 	outline: none;
@@ -376,8 +376,8 @@ body.trashing #publish-settings {
 	width: 100%;
 	margin-left: -12px;
 	padding: 12px;
-	background: #ffffff;
-	border-bottom: 1px solid #ddd;
+	background: #fff;
+	border-bottom: 1px solid #dcdcde;
 	margin-bottom: 0;
 }
 
@@ -409,7 +409,7 @@ body.trashing #publish-settings {
 
 #customize-controls .customize-info .accordion-section-title {
 	background: #fff;
-	color: #555d66;
+	color: #50575e;
 	border-left: none;
 	border-right: none;
 	border-bottom: none;
@@ -419,7 +419,7 @@ body.trashing #publish-settings {
 #customize-controls .customize-info.open .accordion-section-title:after,
 #customize-controls .customize-info .accordion-section-title:hover:after,
 #customize-controls .customize-info .accordion-section-title:focus:after {
-	color: #32373c;
+	color: #2c3338;
 }
 
 #customize-controls .customize-info .accordion-section-title:after {
@@ -462,7 +462,7 @@ body.trashing #publish-settings {
 	box-shadow: none;
 	-webkit-appearance: none;
 	background: transparent;
-	color: #555d66;
+	color: #50575e;
 	border: none;
 }
 
@@ -475,18 +475,18 @@ body.trashing #publish-settings {
 #customize-controls .customize-info.open .customize-help-toggle,
 #customize-controls .customize-info .customize-help-toggle:focus,
 #customize-controls .customize-info .customize-help-toggle:hover {
-	color: #0073aa;
+	color: #2271b1;
 }
 
 #customize-controls .customize-info .customize-panel-description,
 #customize-controls .customize-info .customize-section-description,
 #customize-outer-theme-controls .customize-info .customize-section-description,
 #customize-controls .no-widget-areas-rendered-notice {
-	color: #555d66;
+	color: #50575e;
 	display: none;
 	background: #fff;
 	padding: 12px 15px;
-	border-top: 1px solid #ddd;
+	border-top: 1px solid #dcdcde;
 }
 
 #customize-controls .customize-info .customize-panel-description.open + .no-widget-areas-rendered-notice {
@@ -527,9 +527,9 @@ body.trashing #publish-settings {
 
 #customize-theme-controls .accordion-section-title,
 #customize-outer-theme-controls .accordion-section-title {
-	color: #555d66;
+	color: #50575e;
 	background-color: #fff;
-	border-bottom: 1px solid #ddd;
+	border-bottom: 1px solid #dcdcde;
 	border-left: 4px solid #fff;
 	transition:
 		.15s color ease-in-out,
@@ -538,7 +538,7 @@ body.trashing #publish-settings {
 }
 
 #customize-controls #customize-theme-controls .customize-themes-panel .accordion-section-title {
-	color: #555;
+	color: #50575e;
 	background-color: #fff;
 	border-left: 4px solid #fff;
 }
@@ -546,12 +546,12 @@ body.trashing #publish-settings {
 #customize-theme-controls .accordion-section-title:after,
 #customize-outer-theme-controls .accordion-section-title:after {
 	content: "\f345";
-	color: #a0a5aa;
+	color: #a7aaad;
 }
 
 #customize-theme-controls .accordion-section-content,
 #customize-outer-theme-controls .accordion-section-content {
-	color: #555d66;
+	color: #50575e;
 	background: transparent;
 }
 
@@ -559,20 +559,20 @@ body.trashing #publish-settings {
 #customize-controls .control-section .accordion-section-title:hover,
 #customize-controls .control-section.open .accordion-section-title,
 #customize-controls .control-section .accordion-section-title:focus {
-	color: #0073aa;
-	background: #f3f3f5;
-	border-left-color: #0073aa;
+	color: #2271b1;
+	background: #f6f7f7;
+	border-left-color: #2271b1;
 }
 
 #accordion-section-themes + .control-section {
-	border-top: 1px solid #ddd;
+	border-top: 1px solid #dcdcde;
 }
 
 .js .control-section:hover .accordion-section-title,
 .js .control-section .accordion-section-title:hover,
 .js .control-section.open .accordion-section-title,
 .js .control-section .accordion-section-title:focus {
-	background: #f3f3f5;
+	background: #f6f7f7;
 }
 
 #customize-theme-controls .control-section:hover > .accordion-section-title:after,
@@ -583,27 +583,27 @@ body.trashing #publish-settings {
 #customize-outer-theme-controls .control-section .accordion-section-title:hover:after,
 #customize-outer-theme-controls .control-section.open .accordion-section-title:after,
 #customize-outer-theme-controls .control-section .accordion-section-title:focus:after {
-	color: #0073aa;
+	color: #2271b1;
 }
 
 #customize-theme-controls .control-section.open {
-	border-bottom: 1px solid #eee;
+	border-bottom: 1px solid #f0f0f1;
 }
 
 #customize-theme-controls .control-section.open .accordion-section-title,
 #customize-outer-theme-controls .control-section.open .accordion-section-title {
-	border-bottom-color: #eee !important;
+	border-bottom-color: #f0f0f1 !important;
 }
 
 #customize-theme-controls .control-section:last-of-type.open,
 #customize-theme-controls .control-section:last-of-type > .accordion-section-title {
-	border-bottom-color: #ddd;
+	border-bottom-color: #dcdcde;
 }
 
 #customize-theme-controls .control-panel-content:not(.control-panel-nav_menus) .control-section:nth-child(2),
 #customize-theme-controls .control-panel-nav_menus .control-section-nav_menu,
 #customize-theme-controls .control-section-nav_menu_locations .accordion-section-title {
-	border-top: 1px solid #ddd;
+	border-top: 1px solid #dcdcde;
 }
 
 #customize-theme-controls .control-panel-nav_menus .control-section-nav_menu + .control-section-nav_menu {
@@ -717,7 +717,7 @@ body.trashing #publish-settings {
 
 .customize-section-title {
 	margin: -12px -12px 0 -12px;
-	border-bottom: 1px solid #ddd;
+	border-bottom: 1px solid #dcdcde;
 	background: #fff;
 }
 
@@ -738,7 +738,7 @@ div.customize-section-description p:last-child {
 }
 
 #customize-theme-controls .customize-themes-panel h3.customize-section-title:first-child {
-	border-bottom: 1px solid #ddd;
+	border-bottom: 1px solid #dcdcde;
 	padding: 12px 12px 12px 12px;
 }
 
@@ -751,7 +751,7 @@ h3.customize-section-title {
 	padding: 10px 10px 12px 14px;
 	margin: 0;
 	line-height: 21px;
-	color: #555d66;
+	color: #50575e;
 }
 
 .accordion-sub-container.control-panel-content {
@@ -777,11 +777,11 @@ h3.customize-section-title {
 	width: 45px;
 	height: 41px;
 	padding: 0 2px 0 0;
-	background: #eee;
+	background: #f0f0f1;
 	border: none;
-	border-top: 4px solid #eee;
-	border-right: 1px solid #ddd;
-	color: #444;
+	border-top: 4px solid #f0f0f1;
+	border-right: 1px solid #dcdcde;
+	color: #3c434a;
 	text-align: left;
 	cursor: pointer;
 	transition:
@@ -801,7 +801,7 @@ h3.customize-section-title {
 	margin: 0;
 	background: #fff;
 	border: none;
-	border-right: 1px solid #ddd;
+	border-right: 1px solid #dcdcde;
 	border-left: 4px solid #fff;
 	box-shadow: none;
 	cursor: pointer;
@@ -831,7 +831,7 @@ h3.customize-section-title {
 #customize-controls .panel-meta.customize-info .accordion-section-title:hover,
 #customize-controls .cannot-expand:hover .accordion-section-title {
 	background: #fff;
-	color: #555d66;
+	color: #50575e;
 	border-left-color: #fff;
 }
 
@@ -840,8 +840,8 @@ h3.customize-section-title {
 .customize-controls-preview-toggle:focus,
 .customize-controls-preview-toggle:hover {
 	background: #fff;
-	color: #0073aa;
-	border-top-color: #0073aa;
+	color: #2271b1;
+	border-top-color: #2271b1;
 	box-shadow: none;
 	/* Only visible in Windows High Contrast mode */
 	outline: 1px solid transparent;
@@ -857,9 +857,9 @@ h3.customize-section-title {
 .customize-panel-back:focus,
 .customize-section-back:hover,
 .customize-section-back:focus {
-	color: #0073aa;
-	background: #f3f3f5;
-	border-left-color: #0073aa;
+	color: #2271b1;
+	background: #f6f7f7;
+	border-left-color: #2271b1;
 	box-shadow: none;
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
@@ -883,7 +883,7 @@ h3.customize-section-title {
 }
 
 .wp-full-overlay-sidebar .wp-full-overlay-header {
-	background-color: #eee;
+	background-color: #f0f0f1;
 	transition: padding ease-in-out .18s;
 }
 
@@ -1062,7 +1062,7 @@ p.customize-section-description {
 	position: absolute;
 	bottom: 0;
 	z-index: 10;
-	background: #eee;
+	background: #f0f0f1;
 	display: flex;
 }
 
@@ -1084,7 +1084,7 @@ p.customize-section-description {
 }
 
 .customize-control-dropdown-pages .new-content-item .create-item-input.invalid {
-	border: 1px solid #dc3232;
+	border: 1px solid #d63638;
 }
 
 .customize-control-dropdown-pages .add-new-toggle {
@@ -1103,8 +1103,8 @@ p.customize-section-description {
 }
 
 .wp-full-overlay-sidebar {
-	background: #eee;
-	border-right: 1px solid #ddd;
+	background: #f0f0f1;
+	border-right: 1px solid #dcdcde;
 }
 
 
@@ -1120,7 +1120,7 @@ p.customize-section-description {
 
 #customize-controls .customize-control-widget_form.has-error .widget .widget-top,
 .customize-control-nav_menu_item.has-error .menu-item-bar .menu-item-handle {
-	box-shadow: inset 0 0 0 2px #dc3232;
+	box-shadow: inset 0 0 0 2px #d63638;
 	transition: .15s box-shadow linear;
 }
 
@@ -1147,14 +1147,14 @@ p.customize-section-description {
 }
 
 .customize-control-text.has-error input {
-	outline: 2px solid #dc3232;
+	outline: 2px solid #d63638;
 }
 
 #customize-controls #customize-notifications-area {
 	position: absolute;
 	top: 46px;
 	width: 100%;
-	border-bottom: 1px solid #ddd;
+	border-bottom: 1px solid #dcdcde;
 	display: block;
 	padding: 0;
 	margin: 0;
@@ -1182,7 +1182,7 @@ p.customize-section-description {
 }
 #customize-controls .panel-meta > .customize-control-notifications-container,
 #customize-controls .customize-section-title > .customize-control-notifications-container {
-	border-top: 1px solid #ddd;
+	border-top: 1px solid #dcdcde;
 }
 #customize-controls #customize-notifications-area .notice,
 #customize-controls .panel-meta > .customize-control-notifications-container .notice,
@@ -1219,7 +1219,7 @@ p.customize-section-description {
 /* Note: Styles for this are also defined in themes.css */
 #customize-controls #customize-notifications-area .notice.notification-overlay .notification-message {
 	clear: both;
-	color: #191e23;
+	color: #1d2327;
 	font-size: 18px;
 	font-style: normal;
 	margin: 0;
@@ -1263,7 +1263,7 @@ p.customize-section-description {
 	line-height: 16px;
 	margin-right: 16px;
 	padding: 4px 5px;
-	border: 2px solid #eee;
+	border: 2px solid #f0f0f1;
 	-webkit-user-select: none;
 	-ms-user-select: none;
 	user-select: none;
@@ -1276,7 +1276,7 @@ p.customize-section-description {
 	bottom: 0;
 	right: 0;
 	width: 20px;
-	background: #eee;
+	background: #f0f0f1;
 }
 
 .customize-control .dropdown-arrow:after {
@@ -1291,12 +1291,12 @@ p.customize-section-description {
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 	text-decoration: none !important;
-	color: #32373c;
+	color: #2c3338;
 }
 
 .customize-control .dropdown-status {
-	color: #32373c;
-	background: #eee;
+	color: #2c3338;
+	background: #f0f0f1;
 	display: none;
 	max-width: 112px;
 }
@@ -1307,7 +1307,7 @@ p.customize-section-description {
 }
 
 .customize-control-color .dropdown .dropdown-content {
-	background-color: #555d66;
+	background-color: #50575e;
 	border: 1px solid rgba(0, 0, 0, 0.15);
 }
 
@@ -1376,7 +1376,7 @@ p.customize-section-description {
 	position: relative;
 	text-align: center;
 	cursor: default;
-	border: 1px dashed #b4b9be;
+	border: 1px dashed #c3c4c7;
 	box-sizing: border-box;
 	padding: 9px 0;
 	line-height: 1.6;
@@ -1384,19 +1384,19 @@ p.customize-section-description {
 
 .customize-control .attachment-media-view .button-add-media {
 	cursor: pointer;
-	background-color: #edeff0;
-	color: #32373c;
+	background-color: #f0f0f1;
+	color: #2c3338;
 }
 
 .customize-control .attachment-media-view .button-add-media:hover {
-	background-color: #fbfbfc;
+	background-color: #fff;
 }
 
 .customize-control .attachment-media-view .button-add-media:focus {
-	background-color: #fbfbfc;
-	border-color: #007cba;
+	background-color: #fff;
+	border-color: #3582c4;
 	border-style: solid;
-	box-shadow: 0 0 0 1px #007cba;
+	box-shadow: 0 0 0 1px #3582c4;
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
 }
@@ -1405,7 +1405,7 @@ p.customize-section-description {
 	display: none;
 	position: absolute;
 	width: 100%;
-	color: #555d66;
+	color: #50575e;
 	white-space: nowrap;
 	text-overflow: ellipsis;
 	overflow: hidden;
@@ -1449,7 +1449,7 @@ p.customize-section-description {
 	left: 0;
 	bottom: 0;
 	right: 0;
-	border: 4px solid #00a0d2;
+	border: 4px solid #72aee6;
 	border-radius: 2px;
 }
 
@@ -1462,7 +1462,7 @@ p.customize-section-description {
 .customize-control-header .uploaded .header-view .close {
 	font-size: 20px;
 	color: #fff;
-	background: #555d66;
+	background: #50575e;
 	background: rgba(0, 0, 0, 0.5);
 	position: absolute;
 	top: 10px;
@@ -1480,7 +1480,7 @@ p.customize-section-description {
 }
 
 .customize-control-header .header-view .close:focus {
-	outline: 1px solid #5b9dd9;
+	outline: 1px solid #4f94d4;
 }
 
 /* Header control: randomiz(s)er */
@@ -1542,8 +1542,8 @@ p.customize-section-description {
 .customize-control-header .choice:focus {
 	outline: none;
 	box-shadow:
-		0 0 0 1px #5b9dd9,
-		0 0 3px 1px rgba(30, 140, 190, 0.8);
+		0 0 0 1px #4f94d4,
+		0 0 3px 1px rgba(79, 148, 212, 0.8);
 }
 
 .customize-control-header .uploaded div:last-child > .choice {
@@ -1660,9 +1660,9 @@ p.customize-section-description {
 #customize-theme-controls .control-panel-themes > .accordion-section-title {
 	cursor: default;
 	background: #fff;
-	color: #555d66;
-	border-top: 1px solid #ddd;
-	border-bottom: 1px solid #ddd;
+	color: #50575e;
+	border-top: 1px solid #dcdcde;
+	border-bottom: 1px solid #dcdcde;
 	border-left: none;
 	border-right: none;
 	margin: 0 0 15px 0;
@@ -1720,7 +1720,7 @@ p.customize-section-description {
 	overflow-y: scroll;
 	width: calc(100% - 300px);
 	height: calc(100% - 96px);
-	background: #eee;
+	background: #f0f0f1;
 	z-index: 20;
 }
 
@@ -1757,7 +1757,7 @@ p.customize-section-description {
 }
 
 .wp-full-overlay.in-themes-panel {
-	background: #eee; /* Prevents a black flash when fading in the panel */
+	background: #f0f0f1; /* Prevents a black flash when fading in the panel */
 }
 
 .in-themes-panel #customize-save-button-wrapper,
@@ -1795,8 +1795,8 @@ p.customize-section-description {
 }
 
 .themes-filter-bar .feature-filter-toggle.open {
-	background: #eee;
-	border-color: #999;
+	background: #f0f0f1;
+	border-color: #8c8f94;
 	box-shadow: inset 0 2px 5px -3px rgba(0, 0, 0, 0.5);
 }
 
@@ -1813,8 +1813,8 @@ p.customize-section-description {
 	padding: 25px 0 25px 25px;
 	border-top: 0;
 	margin: 0;
-	background: #eee;
-	border-bottom: 1px solid #ddd;
+	background: #f0f0f1;
+	border-bottom: 1px solid #dcdcde;
 }
 
 .filter-drawer .filter-group {
@@ -1853,7 +1853,7 @@ p.customize-section-description {
 
 .control-panel-themes .filter-themes-count .themes-displayed {
 	font-weight: 600;
-	color: #555d66;
+	color: #50575e;
 }
 
 .customize-themes-notifications {
@@ -1877,8 +1877,8 @@ p.customize-section-description {
 	padding: 0 0 8px 15px;
 	margin: 15px 0 0 0;
 	line-height: 16px;
-	border-bottom: 1px solid #ddd;
-	color: #555d66;
+	border-bottom: 1px solid #dcdcde;
+	color: #50575e;
 }
 
 .control-panel-themes .customize-themes-section-title {
@@ -1887,7 +1887,7 @@ p.customize-section-description {
 	box-shadow: none;
 	outline: none;
 	border-top: none;
-	border-bottom: 1px solid #ddd;
+	border-bottom: 1px solid #dcdcde;
 	border-left: 4px solid #fff;
 	border-right: none;
 	cursor: pointer;
@@ -1896,12 +1896,12 @@ p.customize-section-description {
 	text-align: left;
 	font-size: 14px;
 	font-weight: 600;
-	color: #555d66;
+	color: #50575e;
 	text-shadow: none;
 }
 
 .control-panel-themes #accordion-section-installed_themes {
-	border-top: 1px solid #ddd;
+	border-top: 1px solid #dcdcde;
 }
 
 .control-panel-themes .theme-section {
@@ -1911,9 +1911,9 @@ p.customize-section-description {
 
 .control-panel-themes .customize-themes-section-title:focus,
 .control-panel-themes .customize-themes-section-title:hover {
-	border-left-color: #0073aa;
-	color: #0073aa;
-	background: #f5f5f5;
+	border-left-color: #2271b1;
+	color: #2271b1;
+	background: #f6f7f7;
 }
 
 .customize-themes-section-title:not(.selected):after {
@@ -1925,7 +1925,7 @@ p.customize-section-description {
 	width: 18px;
 	height: 18px;
 	border-radius: 100%;
-	border: 1px solid #ccc;
+	border: 1px solid #c3c4c7;
 	background: #fff;
 }
 
@@ -1940,12 +1940,12 @@ p.customize-section-description {
 	position: absolute;
 	top: 9px;
 	right: 15px;
-	background: #0073aa;
+	background: #2271b1;
 	color: #fff;
 }
 
 .control-panel-themes .customize-themes-section-title.selected {
-	color: #0073aa;
+	color: #2271b1;
 }
 
 #customize-theme-controls .themes.accordion-section-content {
@@ -1979,7 +1979,7 @@ p.customize-section-description {
 .customize-control-theme .theme {
 	width: 100%;
 	margin: 0;
-	border: 1px solid #ddd;
+	border: 1px solid #dcdcde;
 	background: #fff;
 }
 
@@ -2056,11 +2056,11 @@ p.customize-section-description {
 	left: 300px;
 	width: calc(100% - 300px);
 	height: 46px;
-	background: #eee;
+	background: #f0f0f1;
 	z-index: 10;
 	padding: 6px 25px;
 	box-sizing: border-box;
-	border-bottom: 1px solid #ddd;
+	border-bottom: 1px solid #dcdcde;
 }
 
 @media screen and (min-width: 1670px) {
@@ -2181,8 +2181,8 @@ p.customize-section-description {
 		position: fixed;
 		top: 0;
 		left: 0;
-		background: #eee;
-		color: #444;
+		background: #f0f0f1;
+		color: #3c434a;
 		border-radius: 0;
 		box-shadow: none;
 		border: none;
@@ -2191,7 +2191,7 @@ p.customize-section-description {
 		z-index: 10;
 		text-align: left;
 		text-shadow: none;
-		border-bottom: 1px solid #ddd;
+		border-bottom: 1px solid #dcdcde;
 		border-left: 4px solid transparent;
 		margin: 0;
 		padding: 0;
@@ -2207,14 +2207,14 @@ p.customize-section-description {
 		display: block;
 		line-height: 2.3;
 		padding: 0 8px 0 8px;
-		border-right: 1px solid #ddd;
+		border-right: 1px solid #dcdcde;
 	}
 
 	.wp-customizer .showing-themes .control-panel-themes .customize-themes-mobile-back:hover,
 	.wp-customizer .showing-themes .control-panel-themes .customize-themes-mobile-back:focus {
-		color: #0073aa;
-		background: #f3f3f5;
-		border-left-color: #0073aa;
+		color: #2271b1;
+		background: #f6f7f7;
+		border-left-color: #2271b1;
 		box-shadow: none;
 		/* Only visible in Windows High Contrast mode */
 		outline: 2px solid transparent;
@@ -2257,7 +2257,7 @@ p.customize-section-description {
 }
 
 .wp-customizer .theme-overlay .theme-backdrop {
-	background: rgba(238, 238, 238, 0.75);
+	background: rgba(240, 240, 241, 0.75);
 	position: fixed;
 	z-index: 110;
 }
@@ -2282,8 +2282,8 @@ p.customize-section-description {
 .wp-customizer .theme-overlay .theme-actions {
 	text-align: right; /* Because there're only one or two actions, match the UI pattern of media modals and right-align the action. */
 	padding: 10px 25px;
-	background: #eee;
-	border-top: 1px solid #ddd;
+	background: #f0f0f1;
+	border-top: 1px solid #dcdcde;
 }
 
 .wp-customizer .theme-overlay .theme-actions .theme-install.preview {
@@ -2302,12 +2302,12 @@ p.customize-section-description {
 }
 
 .wp-customizer .theme-header {
-	background: #eee;
+	background: #f0f0f1;
 }
 
 .wp-customizer .theme-overlay .theme-header button,
 .wp-customizer .theme-overlay .theme-header .close:before {
-	color: #444;
+	color: #3c434a;
 }
 
 .wp-customizer .theme-overlay .theme-header .close:focus,
@@ -2317,13 +2317,13 @@ p.customize-section-description {
 .wp-customizer .theme-overlay .theme-header .left:focus,
 .wp-customizer .theme-overlay .theme-header .left:hover {
 	background: #fff;
-	border-bottom: 4px solid #0073aa;
-	color: #0073aa;
+	border-bottom: 4px solid #2271b1;
+	color: #2271b1;
 }
 
 .wp-customizer .theme-overlay .theme-header .close:focus:before,
 .wp-customizer .theme-overlay .theme-header .close:hover:before {
-	color: #0073aa;
+	color: #2271b1;
 }
 
 .wp-customizer .theme-overlay .theme-header button.disabled,
@@ -2331,7 +2331,7 @@ p.customize-section-description {
 .wp-customizer .theme-overlay .theme-header button.disabled:focus {
 	border-bottom: none;
 	background: transparent;
-	color: #ccc;
+	color: #c3c4c7;
 }
 
 /* Small Screens */
@@ -2353,18 +2353,18 @@ body.cheatin {
 	font-size: medium;
 	height: auto;
 	background: #fff;
-	border: 1px solid #ccd0d4;
+	border: 1px solid #c3c4c7;
 	margin: 50px auto 2em;
 	padding: 1em 2em;
 	max-width: 700px;
 	min-width: 0;
-	box-shadow: 0 1px 1px rgba(0, 0, 0, .04);
+	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
 }
 
 body.cheatin h1 {
-	border-bottom: 1px solid #ddd;
+	border-bottom: 1px solid #dcdcde;
 	clear: both;
-	color: #555d66;
+	color: #50575e;
 	font-size: 24px;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	margin: 30px 0 0 0;
@@ -2446,7 +2446,7 @@ body.cheatin p {
 	display: block;
 	width: 33px; /* was 42px for mobile */
 	height: 43px;
-	color: #82878c;
+	color: #8c8f94;
 	text-indent: -9999px;
 	cursor: pointer;
 	outline: none;
@@ -2479,8 +2479,8 @@ body.cheatin p {
 .widget-reorder-nav span:focus,
 .menu-item-reorder-nav button:hover,
 .menu-item-reorder-nav button:focus {
-	color: #191e23;
-	background: #eee;
+	color: #1d2327;
+	background: #f0f0f1;
 }
 
 .move-widget-down:before,
@@ -2499,7 +2499,7 @@ body.cheatin p {
 .move-down-disabled .menus-move-down,
 .move-right-disabled .menus-move-right,
 .move-left-disabled .menus-move-left {
-	color: #d5d5d5;
+	color: #dcdcde;
 	background-color: #fff;
 	cursor: default;
 	pointer-events: none;
@@ -2520,9 +2520,9 @@ body.adding-widget .add-new-widget:hover,
 .adding-menu-items .add-new-menu-item:hover,
 .add-menu-toggle.open,
 .add-menu-toggle.open:hover {
-	background: #eee;
-	border-color: #929793;
-	color: #32373c;
+	background: #f0f0f1;
+	border-color: #8c8f94;
+	color: #2c3338;
 	box-shadow: inset 0 2px 5px -3px rgba(0, 0, 0, 0.5);
 }
 
@@ -2544,9 +2544,9 @@ body.adding-widget .add-new-widget:before,
 	width: 300px;
 	margin: 0;
 	z-index: 4;
-	background: #eee;
+	background: #f0f0f1;
 	transition: left .18s;
-	border-right: 1px solid #ddd;
+	border-right: 1px solid #dcdcde;
 }
 
 #available-widgets .customize-section-title,
@@ -2560,7 +2560,7 @@ body.adding-widget .add-new-widget:before,
 	overflow: auto;
 	bottom: 0;
 	width: 100%;
-	border-top: 1px solid #ddd;
+	border-top: 1px solid #dcdcde;
 }
 
 .no-widgets-found #available-widgets-list {
@@ -2572,7 +2572,7 @@ body.adding-widget .add-new-widget:before,
 	top: 0;
 	z-index: 1;
 	width: 300px;
-	background: #eee;
+	background: #f0f0f1;
 }
 
 /* search field container */
@@ -2605,7 +2605,7 @@ body.adding-widget .add-new-widget:before,
 	height: 30px;
 	line-height: 2.1;
 	text-align: center;
-	color: #72777c;
+	color: #787c82;
 }
 
 #available-widgets-filter .clear-results,
@@ -2619,7 +2619,7 @@ body.adding-widget .add-new-widget:before,
 	border: 0;
 	cursor: pointer;
 	background: none;
-	color: #a00;
+	color: #d63638;
 	text-decoration: none;
 	outline: 0;
 }
@@ -2648,14 +2648,14 @@ body.adding-widget .add-new-widget:before,
 #available-widgets-filter .clear-results:focus,
 #available-menu-items-search .clear-results:hover,
 #available-menu-items-search .clear-results:focus {
-	color: #dc3232;
+	color: #d63638;
 }
 
 #available-widgets-filter .clear-results:focus,
 #available-menu-items-search .clear-results:focus {
 	box-shadow:
-		0 0 0 1px #5b9dd9,
-		0 0 2px 1px rgba(30, 140, 190, 0.8);
+		0 0 0 1px #4f94d4,
+		0 0 2px 1px rgba(79, 148, 212, 0.8);
 }
 
 #available-menu-items-search .search-icon:after,
@@ -2673,7 +2673,7 @@ body.adding-widget .add-new-widget:before,
 	top: 7px;
 	left: 26px;
 	z-index: 1;
-	color: #72777c;
+	color: #787c82;
 	height: 30px;
 	width: 30px;
 	line-height: 2;
@@ -2705,7 +2705,7 @@ body.adding-widget .add-new-widget:before,
 	position: relative;
 	padding: 15px 15px 15px 60px;
 	background: #fff;
-	border-bottom: 1px solid #ddd;
+	border-bottom: 1px solid #dcdcde;
 	border-left: 4px solid #fff;
 	transition:
 		.15s color ease-in-out,
@@ -2824,10 +2824,10 @@ body.adding-widget .add-new-widget:before,
 		padding: 0 12px;
 		margin: 0;
 		height: 45px;
-		background: #eee;
+		background: #f0f0f1;
 		border: 0;
-		border-right: 1px solid #ddd;
-		color: #555d66;
+		border-right: 1px solid #dcdcde;
+		color: #50575e;
 		cursor: pointer;
 		transition: color .1s ease-in-out, background .1s ease-in-out;
 	}
@@ -2902,7 +2902,7 @@ body.adding-widget .add-new-widget:before,
 		padding: 9px 10px 12px 14px;
 		margin: 0;
 		line-height: 24px;
-		color: #555d66;
+		color: #50575e;
 		display: block;
 		overflow: hidden;
 		white-space: nowrap;

--- a/src/wp-admin/css/customize-nav-menus.css
+++ b/src/wp-admin/css/customize-nav-menus.css
@@ -4,7 +4,7 @@
 }
 
 #customize-theme-controls #accordion-section-menu_locations > .accordion-section-title {
-	border-bottom-color: #ddd;
+	border-bottom-color: #dcdcde;
 	margin-top: 15px;
 }
 
@@ -29,7 +29,7 @@
 #customize-controls .theme-location-set,
 #customize-controls .control-section .accordion-section-title:focus .menu-in-location,
 #customize-controls .control-section .accordion-section-title:hover .menu-in-location {
-	color: #555;
+	color: #50575e;
 }
 
 /* The `edit-menu` and `create-menu` buttons also use the `button-link` class. */
@@ -84,7 +84,7 @@
 }
 
 .customize-control-nav_menu_item.has-notifications .menu-item-handle {
-	border-left: 4px solid #00a0d2;
+	border-left: 4px solid #72aee6;
 }
 
 .wp-customizer .menu-item-settings {
@@ -92,8 +92,8 @@
 	overflow: hidden;
 	z-index: 8;
 	padding: 10px;
-	background: #eee;
-	border: 1px solid #999;
+	background: #f0f0f1;
+	border: 1px solid #8c8f94;
 	border-top: none;
 }
 
@@ -194,7 +194,7 @@
 }
 
 .wp-customizer .menu-settings .menu-theme-locations {
-	border-top: 1px solid #ccc;
+	border-top: 1px solid #c3c4c7;
 }
 
 .wp-customizer .menu-settings {
@@ -209,7 +209,7 @@
 
 .wp-customizer .control-section-nav_menu .menu-location-settings {
 	margin-top: 24px;
-	border-top: 1px solid #ddd;
+	border-top: 1px solid #dcdcde;
 }
 
 .wp-customizer .control-section-nav_menu .menu-location-settings,
@@ -234,14 +234,14 @@
 }
 
 #customize-controls .customize-info.open.active-menu-screen-options .customize-help-toggle {
-	color: #555;
+	color: #50575e;
 }
 
 /* Screen Options */
 .customize-screen-options-toggle {
 	background: none;
 	border: none;
-	color: #555;
+	color: #50575e;
 	cursor: pointer;
 	margin: 0;
 	padding: 20px;
@@ -265,7 +265,7 @@
 #customize-controls .customize-info.open.active-menu-screen-options .customize-help-toggle:hover,
 #customize-controls .customize-info.open.active-menu-screen-options .customize-help-toggle:active,
 #customize-controls .customize-info.open.active-menu-screen-options .customize-help-toggle:focus {
-	color: #0073aa;
+	color: #2271b1;
 }
 
 .customize-screen-options-toggle:focus,
@@ -297,7 +297,7 @@
 .wp-customizer #screen-options-wrap {
 	display: none;
 	background: #fff;
-	border-top: 1px solid #ddd;
+	border-top: 1px solid #dcdcde;
 	padding: 4px 15px 15px;
 }
 
@@ -325,7 +325,7 @@
 	padding: 1px 2px 1px 0px;
 	speak: never;
 	border-radius: 50%;
-	color: #72777c;
+	color: #787c82;
 	font: normal 20px/1 dashicons;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
@@ -431,7 +431,7 @@
 	max-width: calc(100% - 2px);
 	float: left;
 	display: list-item;
-	border-color: #a0a5aa;
+	border-color: #a7aaad;
 }
 
 .menu-item-transport li.customize-control {
@@ -456,7 +456,7 @@
 }
 
 .menu-item-bar .item-delete {
-	color: #a00;
+	color: #d63638;
 	position: absolute;
 	top: 2px;
 	right: -19px;
@@ -481,7 +481,7 @@
 .menu-item-bar .item-delete:focus {
 	box-shadow: none;
 	outline: none;
-	color: #dc3232;
+	color: #d63638;
 }
 
 .adding-menu-items .menu-item-bar .item-edit {
@@ -518,7 +518,7 @@
 
 #available-menu-items .open .accordion-section-title,
 #available-menu-items #available-menu-items-search .accordion-section-title {
-	background: #eee;
+	background: #f0f0f1;
 }
 
 /* rework the arrow indicator implementation for NVDA bug see #32715 */
@@ -529,12 +529,12 @@
 #available-menu-items .accordion-section-title:hover .toggle-indicator:before,
 #available-menu-items .button-link:hover .toggle-indicator:before,
 #available-menu-items .button-link:focus .toggle-indicator:before {
-	color: #23282d;
+	color: #1d2327;
 }
 
 #available-menu-items .open .accordion-section-title .toggle-indicator:before {
 	content: "\f142";
-	color: #23282d;
+	color: #1d2327;
 }
 
 #available-menu-items .available-menu-items-list {
@@ -568,7 +568,7 @@
 
 #available-menu-items .cannot-expand .accordion-section-title .no-items {
 	float: right;
-	color: #555d66;
+	color: #50575e;
 	font-weight: 400;
 	margin-left: 5px;
 }
@@ -605,7 +605,7 @@
 .menu-name-field.invalid:focus,
 #available-menu-items .new-content-item .create-item-input.invalid,
 #available-menu-items .new-content-item .create-item-input.invalid:focus {
-	border: 1px solid #dc3232;
+	border: 1px solid #d63638;
 }
 
 #available-menu-items .menu-item-handle .item-type {
@@ -638,7 +638,7 @@
 	position: absolute;
 	top: 1px;
 	left: 1px;
-	color: #82878c;
+	color: #8c8f94;
 	width: 30px;
 	height: 38px;
 	box-shadow: none;
@@ -648,7 +648,7 @@
 }
 
 #available-menu-items .menu-item-handle .item-add:focus {
-	color: #23282d;
+	color: #1d2327;
 }
 
 #available-menu-items .item-add:before {
@@ -666,7 +666,7 @@
 #available-menu-items .menu-item-handle.item-added .item-title,
 #available-menu-items .menu-item-handle.item-added:hover .item-add,
 #available-menu-items .menu-item-handle.item-added .item-add:focus {
-	color: #82878c;
+	color: #8c8f94;
 }
 
 #available-menu-items .menu-item-handle.item-added .item-add:before {
@@ -761,7 +761,7 @@ body.adding-menu-items #customize-preview iframe {
 	cursor: default;
 	opacity: .5;
 	background: #fff;
-	color: #727773;
+	color: #787c82;
 }
 
 .added-menu-item .menu-item-handle {
@@ -773,7 +773,7 @@ body.adding-menu-items #customize-preview iframe {
 /* Add/delete Menus */
 
 #customize-theme-controls .control-panel-content .control-section-nav_menu:nth-last-child(2) .accordion-section-title {
-	border-bottom-color: #ddd;
+	border-bottom-color: #dcdcde;
 }
 
 /* @todo update selector */
@@ -827,17 +827,17 @@ li.assigned-to-menu-location .add-new-menu-item {
 .menu-item-handle:hover {
 	position: relative;
 	z-index: 10;
-	color: #0073aa;
+	color: #2271b1;
 }
 
 .menu-item-handle:hover .item-type,
 .menu-item-handle:hover .item-edit,
 #available-menu-items .menu-item-handle:hover .item-add {
-	color: #0073aa;
+	color: #2271b1;
 }
 
 .menu-item-edit-active .menu-item-handle {
-	border-color: #999;
+	border-color: #8c8f94;
 	border-bottom: none;
 }
 
@@ -866,8 +866,8 @@ li.assigned-to-menu-location .add-new-menu-item {
 .menu-item-bar .item-delete:focus:before,
 #available-menu-items .item-add:focus:before {
 	box-shadow:
-		0 0 0 1px #5b9dd9,
-		0 0 2px 1px rgba(30, 140, 190, 0.8);
+		0 0 0 1px #4f94d4,
+		0 0 2px 1px rgba(79, 148, 212, 0.8);
 }
 
 

--- a/src/wp-admin/css/customize-widgets.css
+++ b/src/wp-admin/css/customize-widgets.css
@@ -25,12 +25,12 @@
 }
 
 .customize-control .widget-action {
-	color: #72777c;
+	color: #787c82;
 }
 
 .customize-control .widget-top:hover .widget-action,
 .customize-control .widget-action:focus {
-	color: #23282d;
+	color: #1d2327;
 }
 
 .customize-control-widget_form:not(.widget-rendered) .widget-top {
@@ -66,7 +66,7 @@
 	position: fixed;
 	left: 299px;
 	top: 25%;
-	border: 1px solid rgb(229, 229, 229);
+	border: 1px solid #dcdcde;
 	overflow: auto;
 }
 .customize-control-widget_form.wide-widget-control .widget-inside > .form {
@@ -78,7 +78,7 @@
 }
 .customize-control-widget_form.wide-widget-control.expanding .widget-top,
 .customize-control-widget_form.wide-widget-control.expanded:not(.collapsing) .widget-top {
-	background-color: rgb(227, 227, 227);
+	background-color: #dcdcde;
 }
 
 .widget-inside {
@@ -111,7 +111,7 @@
 .control-section.accordion-section.highlighted > .accordion-section-title,
 .customize-control-widget_form.highlighted {
 	outline: none;
-	box-shadow: 0 0 2px rgba(30, 140, 190, 0.8);
+	box-shadow: 0 0 2px rgba(79, 148, 212, 0.8);
 	position: relative;
 	z-index: 1;
 }
@@ -127,7 +127,7 @@
 #customize-theme-controls .widget-reorder-nav {
 	display: none;
 	float: right;
-	background-color: #fafafa;
+	background-color: #f6f7f7;
 }
 
 .move-widget:before {
@@ -137,7 +137,7 @@
 #customize-theme-controls .move-widget-area {
 	display: none;
 	background: #fff;
-	border: 1px solid #ddd;
+	border: 1px solid #dcdcde;
 	border-top: none;
 	cursor: auto;
 }
@@ -162,8 +162,8 @@
 	position: relative;
 	margin: 0;
 	padding: 13px 15px 15px 42px;
-	color: #555;
-	border-top: 1px solid #eee;
+	color: #50575e;
+	border-top: 1px solid #f0f0f1;
 	cursor: pointer;
 	-webkit-user-select: none;
 	-ms-user-select: none;
@@ -182,13 +182,13 @@
 }
 
 #customize-theme-controls .widget-area-select li:last-child {
-	border-bottom: 1px solid #eee;
+	border-bottom: 1px solid #f0f0f1;
 }
 
 #customize-theme-controls .widget-area-select .selected {
 	color: #fff;
 	text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.4);
-	background: #00a0d2;
+	background: #72aee6;
 }
 
 #customize-theme-controls .widget-area-select .selected:before {
@@ -244,10 +244,10 @@
 
 #available-widgets .widget-tpl:hover,
 #available-widgets .widget-tpl.selected {
-	background: #f3f3f5;
-	border-bottom-color: #ccc;
-	color: #0073aa;
-	border-left: 4px solid #0073aa;
+	background: #f6f7f7;
+	border-bottom-color: #c3c4c7;
+	color: #2271b1;
+	border-left: 4px solid #2271b1;
 }
 
 #customize-controls .widget-title h3 {
@@ -261,7 +261,7 @@
 
 #available-widgets .widget .widget-description {
 	padding: 0;
-	color: #72777c;
+	color: #787c82;
 }
 
 #customize-preview {
@@ -300,7 +300,7 @@ body.adding-widget #customize-preview {
 	margin-right: 20px;
 	width: 20px;
 	height: 20px;
-	color: #32373c;
+	color: #2c3338;
 	font: normal 20px/1 dashicons;
 	text-align: center;
 	box-sizing: border-box;

--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -55,13 +55,13 @@
 }
 
 #dashboard-widgets .postbox-container .empty-container {
-	outline: 3px dashed #b4b9be;
+	outline: 3px dashed #c3c4c7;
 	height: 250px;
 }
 
 /* Only highlight drop zones when dragging and only in the 2 columns layout. */
 .is-dragging-metaboxes #dashboard-widgets .meta-box-sortables {
-	outline: 3px dashed #606a73;
+	outline: 3px dashed #646970;
 	/* Prevent margin on the child from collapsing with margin on the parent. */
 	display: flow-root;
 }
@@ -76,7 +76,7 @@
 	transform: translateY( -50% );
 	padding: 0 2em;
 	text-align: center;
-	color: #606a73;
+	color: #646970;
 	font-size: 16px;
 	line-height: 1.5;
 	display: none;
@@ -116,7 +116,7 @@
 	overflow: auto;
 	margin: 16px 0;
 	padding: 23px 10px 0;
-	border: 1px solid #ccd0d4;
+	border: 1px solid #c3c4c7;
 	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
 	background: #fff;
 	font-size: 13px;
@@ -140,7 +140,7 @@
 }
 
 .welcome-panel p {
-	color: #72777c;
+	color: #787c82;
 }
 
 .welcome-panel li a {
@@ -203,7 +203,7 @@
 
 .welcome-panel-column p {
 	margin-top: 7px;
-	color: #444;
+	color: #3c434a;
 }
 
 .welcome-panel .welcome-widgets-menus {
@@ -230,7 +230,7 @@
 #dashboard_right_now li a:before,
 #dashboard_right_now li span:before,
 #dashboard_right_now .search-engines-info:before {
-	color: #606a73;
+	color: #646970;
 	font: normal 20px/1 dashicons;
 	speak: never;
 	display: inline-block;
@@ -376,7 +376,7 @@
 }
 
 .community-events li.event-none {
-	border-left: 4px solid #00a0d2;
+	border-left: 4px solid #72aee6;
 }
 
 #dashboard-widgets .community-events li.event-none a {
@@ -414,7 +414,7 @@
 }
 
 .community-events ul {
-	background-color: #fafafa;
+	background-color: #f6f7f7;
 	padding-left: 0;
 	padding-right: 0;
 	padding-bottom: 0;
@@ -423,18 +423,18 @@
 .community-events li {
 	margin: 0;
 	padding: 8px 12px;
-	color: #32373c;
+	color: #2c3338;
 }
 .community-events li:first-child {
-	border-top: 1px solid #eee;
+	border-top: 1px solid #f0f0f1;
 }
 
 .community-events li ~ li {
-	border-top: 1px solid #eee;
+	border-top: 1px solid #f0f0f1;
 }
 
 .community-events .activity-block.last {
-	border-bottom: 1px solid #eee;
+	border-bottom: 1px solid #f0f0f1;
 	padding-top: 0;
 	margin-top: -1px;
 }
@@ -451,7 +451,7 @@
 }
 
 .event-icon:before {
-	color: #606a73;
+	color: #646970;
 	font-size: 18px;
 }
 .event-meetup .event-icon:before {
@@ -475,8 +475,8 @@
 	margin-top: 0;
 	margin-bottom: 0;
 	padding: 12px;
-	border-top: 1px solid #eee;
-	color: #ddd;
+	border-top: 1px solid #f0f0f1;
+	color: #dcdcde;
 }
 
 /* Safari 10 + VoiceOver specific: without this, the hidden text gets read out before the link. */
@@ -512,7 +512,7 @@ body #dashboard-widgets .postbox form .submit {
 }
 
 .rssSummary {
-	color: #72777c;
+	color: #787c82;
 	margin-top: 4px;
 }
 
@@ -532,7 +532,7 @@ body #dashboard-widgets .postbox form .submit {
 
 #dashboard_primary .rss-widget span,
 #dashboard_primary .rss-widget span.rss-date {
-	color: #72777c;
+	color: #787c82;
 }
 
 #dashboard_primary .rss-widget span.rss-date {
@@ -596,14 +596,14 @@ body #dashboard-widgets .postbox form .submit {
 /* Dashboard right now - Colors */
 
 #dashboard_right_now .sub {
-	color: #555d66;
-	background: #f5f5f5;
-	border-top: 1px solid #eee;
+	color: #50575e;
+	background: #f6f7f7;
+	border-top: 1px solid #f0f0f1;
 	padding: 10px 12px 6px 12px;
 }
 
 #dashboard_right_now .sub h3 {
-	color: #555;
+	color: #50575e;
 }
 
 #dashboard_right_now .sub p {
@@ -612,7 +612,7 @@ body #dashboard-widgets .postbox form .submit {
 
 #dashboard_right_now .warning a:before,
 #dashboard_right_now .warning span:before {
-	color: #d54e21;
+	color: #d63638;
 }
 
 /* Dashboard Quick Draft */
@@ -624,7 +624,7 @@ body #dashboard-widgets .postbox form .submit {
 
 #dashboard_quick_press div.updated {
 	margin-bottom: 10px;
-	border: 1px solid #eee;
+	border: 1px solid #f0f0f1;
 	border-width: 1px 1px 1px 0;
 }
 
@@ -669,7 +669,7 @@ body #dashboard-widgets .postbox form .submit {
 /* Dashboard Quick Draft - Drafts list */
 
 .js #dashboard_quick_press .drafts {
-	border-top: 1px solid #eee;
+	border-top: 1px solid #f0f0f1;
 }
 
 #dashboard_quick_press .drafts abbr {
@@ -693,7 +693,7 @@ body #dashboard-widgets .postbox form .submit {
 	margin-bottom: 1em;
 }
 #dashboard_quick_press .drafts li time {
-	color: #72777c;
+	color: #787c82;
 }
 
 #dashboard_quick_press .drafts p {
@@ -719,7 +719,7 @@ body #dashboard-widgets .postbox form .submit {
 	padding: 0;
 	font-size: 14px;
 	font-weight: 400;
-	color: #23282d;
+	color: #1d2327;
 }
 
 #dashboard_quick_press .drafts h2 {
@@ -756,20 +756,20 @@ body #dashboard-widgets .postbox form .submit {
 }
 
 #dashboard_activity .no-activity p {
-	color: #72777c;
+	color: #787c82;
 	font-size: 16px;
 }
 
 #dashboard_activity .subsubsub {
 	float: none;
-	border-top: 1px solid #eee;
+	border-top: 1px solid #f0f0f1;
 	margin: 0 -12px;
 	padding: 8px 12px 4px;
 }
 
 #dashboard_activity .subsubsub a .count,
 #dashboard_activity .subsubsub a.current .count {
-	color: #72777c; /* white background on the dashboard but #f1f1f1 on list tables */
+	color: #787c82; /* white background on the dashboard but #f1f1f1 on list tables */
 }
 
 #future-posts ul,
@@ -788,11 +788,11 @@ body #dashboard-widgets .postbox form .submit {
 	display: inline-block;
 	margin-right: 5px;
 	min-width: 150px;
-	color: #72777c;
+	color: #787c82;
 }
 
 .activity-block {
-	border-bottom: 1px solid #eee;
+	border-bottom: 1px solid #f0f0f1;
 	margin: 0 -12px;
 	padding: 8px 12px 4px;
 }
@@ -802,7 +802,7 @@ body #dashboard-widgets .postbox form .submit {
 }
 
 .activity-block .subsubsub li {
-	color: #ddd;
+	color: #dcdcde;
 }
 
 /* Dashboard activity widget - Comments */
@@ -816,7 +816,7 @@ body #dashboard-widgets .postbox form .submit {
 }
 
 #activity-widget #the-comment-list .comment-item {
-	background: #fafafa;
+	background: #f6f7f7;
 	padding: 12px;
 	position: relative;
 }
@@ -839,11 +839,11 @@ body #dashboard-widgets .postbox form .submit {
 }
 
 #activity-widget #the-comment-list .comment-item:first-child {
-	border-top: 1px solid #eeeeee;
+	border-top: 1px solid #f0f0f1;
 }
 
 #activity-widget #the-comment-list .unapproved {
-	background-color: #fef7f1;
+	background-color: #f6f7f7;
 }
 
 #activity-widget #the-comment-list .unapproved:before {
@@ -853,7 +853,7 @@ body #dashboard-widgets .postbox form .submit {
 	left: 0;
 	top: 0;
 	bottom: 0;
-	background: #d54e21;
+	background: #d63638;
 	width: 4px;
 }
 
@@ -955,7 +955,7 @@ body #dashboard-widgets .postbox form .submit {
 #latest-comments #the-comment-list .comment-meta {
 	line-height: 1.5;
 	margin: 0;
-	color: #666;
+	color: #646970;
 }
 
 #latest-comments #the-comment-list .comment-meta cite {
@@ -995,7 +995,7 @@ a.rsswidget {
 }
 
 .rss-widget span.rss-date {
-	color: #72777c;
+	color: #787c82;
 	font-size: 13px;
 	margin-left: 3px;
 }
@@ -1034,25 +1034,25 @@ a.rsswidget {
 }
 
 #dashboard_browser_nag.postbox.browser-insecure {
-	background-color: #ac1b1b;
-	border-color: #ac1b1b;
+	background-color: #b32d2e;
+	border-color: #b32d2e;
 }
 
 #dashboard_browser_nag.postbox {
-	background-color: #e29808;
+	background-color: #dba617;
 	background-image: none;
-	border-color: #edc048;
+	border-color: #f0c33c;
 	color: #fff;
 	box-shadow: none;
 }
 
 #dashboard_browser_nag.postbox.browser-insecure h2 {
-	border-bottom-color: #cd5a5a;
+	border-bottom-color: #e65054;
 	color: #fff;
 }
 
 #dashboard_browser_nag.postbox h2 {
-	border-bottom-color: #f6e2ac;
+	border-bottom-color: #f5e6ab;
 	background: transparent none;
 	color: #fff;
 	box-shadow: none;
@@ -1081,12 +1081,12 @@ a.rsswidget {
 
 /* PHP Nag */
 #dashboard_php_nag .dashicons-warning {
-	color: #ffb900;
+	color: #dba617;
 	padding-right: 6px;
 }
 
 #dashboard_php_nag.php-insecure .dashicons-warning {
-	color: #df3232;
+	color: #d63638;
 }
 
 #dashboard_php_nag h2 {

--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -843,7 +843,7 @@ body #dashboard-widgets .postbox form .submit {
 }
 
 #activity-widget #the-comment-list .unapproved {
-	background-color: #f6f7f7;
+	background-color: #fcf9e8;
 }
 
 #activity-widget #the-comment-list .unapproved:before {

--- a/src/wp-admin/css/deprecated-media.css
+++ b/src/wp-admin/css/deprecated-media.css
@@ -5,8 +5,8 @@ div#media-upload-header {
 	padding: 5px 5px 0;
 	font-weight: 600;
 	position: relative;
-	border-bottom: 1px solid #ddd;
-	background: #f9f9f9;
+	border-bottom: 1px solid #dcdcde;
+	background: #f6f7f7;
 }
 
 #sidemenu {
@@ -27,9 +27,9 @@ div#media-upload-header {
 	display: block;
 	float: left;
 	line-height: 28px;
-	border-top: 1px solid #f9f9f9;
-	border-bottom: 1px solid #ddd;
-	background-color: #f9f9f9;
+	border-top: 1px solid #f6f7f7;
+	border-bottom: 1px solid #dcdcde;
+	background-color: #f6f7f7;
 	text-decoration: none;
 	transition: none;
 }
@@ -48,9 +48,9 @@ div#media-upload-header {
 	font-weight: 400;
 	padding-left: 6px;
 	padding-right: 6px;
-	border: 1px solid #ddd;
-	border-bottom-color: #f1f1f1;
-	background-color: #f1f1f1;
+	border: 1px solid #dcdcde;
+	border-bottom-color: #f0f0f1;
+	background-color: #f0f0f1;
 	color: #000;
 }
 
@@ -61,7 +61,7 @@ div#media-upload-header {
 }
 
 #media-upload .slidetoggle {
-	border-top-color: #ddd;
+	border-top-color: #dcdcde;
 }
 
 #media-upload input[type="radio"] {
@@ -70,7 +70,7 @@ div#media-upload-header {
 
 .media-upload-form label.form-help,
 td.help {
-	color: #72777c;
+	color: #787c82;
 }
 
 form {
@@ -218,8 +218,8 @@ span.required {
 
 #media-upload .tablenav-pages a {
 	min-width: 17px;
-	border: 1px solid #ccc;
-	background: #f7f7f7;
+	border: 1px solid #c3c4c7;
+	background: #f6f7f7;
 }
 
 #filter .tablenav select {
@@ -242,7 +242,7 @@ span.required {
 }
 
 .menu_order_input {
-	border: 1px solid #ddd;
+	border: 1px solid #dcdcde;
 	font-size: 10px;
 	padding: 1px;
 	width: 23px;
@@ -250,7 +250,7 @@ span.required {
 
 .ui-sortable-helper {
 	background-color: #fff;
-	border: 1px solid #a0a5aa;
+	border: 1px solid #a7aaad;
 	opacity: 0.6;
 	filter: alpha(opacity=60);
 }
@@ -291,7 +291,7 @@ span.required {
 	clear: both;
 	padding: 0 0 3px;
 	font-size: 1.6em;
-	border-bottom: 1px solid #ddd;
+	border-bottom: 1px solid #dcdcde;
 }
 
 h3.media-title {
@@ -299,7 +299,7 @@ h3.media-title {
 }
 
 h4.media-sub-title {
-	border-bottom: 1px solid #ddd;
+	border-bottom: 1px solid #dcdcde;
 	font-size: 1.3em;
 	margin: 12px;
 	padding: 0 0 3px;
@@ -310,7 +310,7 @@ h3.media-title,
 h4.media-sub-title {
 	font-family: Georgia,"Times New Roman",Times,serif;
 	font-weight: 400;
-	color: #5A5A5A;
+	color: #50575e;
 }
 
 #gallery-settings .describe td {
@@ -343,7 +343,7 @@ h4.media-sub-title {
 #gallery-settings label,
 #gallery-settings legend {
 	font-size: 13px;
-	color: #444;
+	color: #3c434a;
 	margin-right: 15px;
 }
 
@@ -352,7 +352,7 @@ h4.media-sub-title {
 }
 
 #gallery-settings p.ml-submit {
-	border-top: 1px solid #ddd;
+	border-top: 1px solid #dcdcde;
 }
 
 #gallery-settings select#columns {

--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -68,7 +68,7 @@
 }
 
 #titlediv #title-prompt-text {
-	color: #72777c;
+	color: #787c82;
 	position: absolute;
 	font-size: 1.7em;
 	padding: 10px;
@@ -94,7 +94,7 @@ input#link_url {
 	min-height: 25px;
 	margin-top: 5px;
 	padding: 0 10px;
-	color: #666;
+	color: #646970;
 }
 
 #edit-slug-box .cancel {
@@ -150,7 +150,7 @@ body.post-new-php .submitbox .submitdelete {
 
 /* Only highlight drop zones when dragging and only in the 2 columns layout. */
 .is-dragging-metaboxes .metabox-holder .postbox-container .meta-box-sortables {
-	outline: 3px dashed #606a73;
+	outline: 3px dashed #646970;
 	/* Prevent margin on the child from collapsing with margin on the parent. */
 	display: flow-root;
 	/*
@@ -166,7 +166,7 @@ body.post-new-php .submitbox .submitdelete {
 .postbox {
 	position: relative;
 	min-width: 255px;
-	border: 1px solid #ccd0d4;
+	border: 1px solid #c3c4c7;
 	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
 	background: #fff;
 }
@@ -218,7 +218,7 @@ ul.category-tabs li,
 .wp-tab-bar .wp-tab-active a,
 #post-body ul.category-tabs li.tabs a,
 #post-body ul.add-menu-item-tabs li.tabs a {
-	color: #32373c;
+	color: #2c3338;
 }
 
 .category-tabs {
@@ -270,9 +270,9 @@ ul.add-menu-item-tabs li {
 ul.category-tabs li.tabs,
 ul.add-menu-item-tabs li.tabs,
 .wp-tab-active {
-	border: 1px solid #ddd;
-	border-bottom-color: #fdfdfd;
-	background-color: #fdfdfd;
+	border: 1px solid #dcdcde;
+	border-bottom-color: #fff;
+	background-color: #fff;
 }
 
 ul.category-tabs li,
@@ -291,7 +291,7 @@ ul.wp-tab-bar li {
 	height: auto;
 	width: auto;
 	vertical-align: top;
-	background-image: linear-gradient(45deg, #c4c4c4 25%, transparent 25%, transparent 75%, #c4c4c4 75%, #c4c4c4), linear-gradient(45deg, #c4c4c4 25%, transparent 25%, transparent 75%, #c4c4c4 75%, #c4c4c4);
+	background-image: linear-gradient(45deg, #c3c4c7 25%, transparent 25%, transparent 75%, #c3c4c7 75%, #c3c4c7), linear-gradient(45deg, #c3c4c7 25%, transparent 25%, transparent 75%, #c3c4c7 75%, #c3c4c7);
 	background-position: 0 0, 10px 10px;
 	background-size: 20px 20px;
 }
@@ -322,9 +322,9 @@ form#tags-filter {
 #post-status-info {
 	width: 100%;
 	border-spacing: 0;
-	border: 1px solid #ccd0d4;
+	border: 1px solid #c3c4c7;
 	border-top: none;
-	background-color: #f7f7f7;
+	background-color: #f6f7f7;
 	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
 	z-index: 999;
 }
@@ -373,7 +373,7 @@ form#tags-filter {
 
 .wp-editor-expand #wp-content-editor-tools {
 	z-index: 1000;
-	border-bottom: 1px solid #ccd0d4;
+	border-bottom: 1px solid #c3c4c7;
 }
 
 .wp-editor-expand #wp-content-editor-container {
@@ -390,7 +390,7 @@ form#tags-filter {
 }
 
 .wp-editor-expand #post-status-info {
-	border-top: 1px solid #ccd0d4;
+	border-top: 1px solid #c3c4c7;
 }
 
 .wp-editor-expand div.mce-toolbar-grp {
@@ -422,7 +422,7 @@ form#tags-filter {
 /* End TinyMCE native fullscreen mode override */
 
 #wp-content-editor-tools {
-	background-color: #f1f1f1;
+	background-color: #f0f0f1;
 	padding-top: 20px;
 }
 
@@ -464,7 +464,7 @@ form#tags-filter {
 #post-body .misc-pub-revisions:before,
 #post-body .misc-pub-response-to:before,
 #post-body .misc-pub-comment-status:before {
-	color: #82878c;
+	color: #8c8f94;
 }
 
 #post-body .misc-pub-post-status:before,
@@ -647,7 +647,7 @@ form#tags-filter {
 }
 
 #poststuff .stuffbox > h2 {
-	border-bottom: 1px solid #eee;
+	border-bottom: 1px solid #f0f0f1;
 }
 
 #poststuff .inside {
@@ -713,7 +713,7 @@ form#tags-filter {
 .privacy-text-box-toc p {
 	margin: 0;
 	padding: 0.7em 1em;
-	border-bottom: 1px solid #eee;
+	border-bottom: 1px solid #f0f0f1;
 }
 
 .privacy-text-box-toc ol {
@@ -731,7 +731,7 @@ form#tags-filter {
 
 .privacy-text-section {
 	position: relative;
-	border-top: 1px solid #e3e3e3;
+	border-top: 1px solid #dcdcde;
 }
 
 .privacy-text-box-head,
@@ -740,10 +740,10 @@ form#tags-filter {
 }
 
 .text-removed .policy-text {
-	color: #666;
+	color: #646970;
 	font-weight: 300;
 	padding-left: 1em;
-	border-left: 3px solid #ffb900;
+	border-left: 3px solid #dba617;
 }
 
 .text-removed .policy-text h1,
@@ -752,7 +752,7 @@ form#tags-filter {
 .text-removed .policy-text h4,
 .text-removed .policy-text h5,
 .text-removed .policy-text h6 {
-	color: #39424a;
+	color: #3c434a;
 	font-weight: 500;
 }
 
@@ -766,7 +766,7 @@ form#tags-filter {
 
 .privacy-text-actions .success {
 	display: none;
-	color: #40860a;
+	color: #008a20;
 	float: right;
 	padding-right: 1em;
 }
@@ -853,7 +853,7 @@ strong.privacy-policy-tutorial {
 
 #postcustomstuff thead th {
 	padding: 5px 8px 8px;
-	background-color: #f1f1f1;
+	background-color: #f0f0f1;
 }
 
 #postcustom #postcustomstuff .submit {
@@ -880,9 +880,9 @@ strong.privacy-policy-tutorial {
 #postcustomstuff table {
 	margin: 0;
 	width: 100%;
-	border: 1px solid #ddd;
+	border: 1px solid #dcdcde;
 	border-spacing: 0;
-	background-color: #f9f9f9;
+	background-color: #f6f7f7;
 }
 
 #postcustomstuff tr {
@@ -975,7 +975,7 @@ strong.privacy-policy-tutorial {
 	width: 20px;
 	margin-top: -4px;
 	margin-right: 7px;
-	color: #ddd;
+	color: #dcdcde;
 	font: normal 20px/1 dashicons;
 	speak: never;
 	-webkit-font-smoothing: antialiased;
@@ -983,7 +983,7 @@ strong.privacy-policy-tutorial {
 }
 
 a.post-format-icon:hover:before {
-	color: #006799;
+	color: #135e96;
 }
 
 #post-formats-select {
@@ -1069,8 +1069,8 @@ label.post-format-icon {
 	max-height: 200px;
 	overflow: auto;
 	padding: 0 0.9em;
-	border: solid 1px #ddd;
-	background-color: #fdfdfd;
+	border: solid 1px #dcdcde;
+	background-color: #fff;
 }
 
 div.tabs-panel-active {
@@ -1082,7 +1082,7 @@ div.tabs-panel-inactive {
 }
 
 div.tabs-panel-active:focus {
-	box-shadow: inset 0 0 0 1px #5b9dd9, inset 0 0 2px 1px rgba(30, 140, 190, 0.8);
+	box-shadow: inset 0 0 0 1px #4f94d4, inset 0 0 2px 1px rgba(79, 148, 212, 0.8);
 	outline: 0 none;
 }
 
@@ -1138,7 +1138,7 @@ ul.categorychecklist li {
 p.description,
 .form-wrap p {
 	margin: 2px 0 5px;
-	color: #666;
+	color: #646970;
 }
 
 p.help,
@@ -1226,7 +1226,7 @@ p.popular-tags a {
 #poststuff .inside .the-tagcloud {
 	margin: 5px 0 10px;
 	padding: 8px;
-	border: 1px solid #ddd;
+	border: 1px solid #dcdcde;
 	line-height: 1.2;
 	word-spacing: 3px;
 }
@@ -1247,7 +1247,7 @@ p.popular-tags a {
 	list-style: none;
 	position: absolute;
 	z-index: 10000;
-	border: 1px solid #5b9dd9;
+	border: 1px solid #4f94d4;
 	background-color: #fff;
 }
 
@@ -1264,7 +1264,7 @@ p.popular-tags a {
 
 .ac_results .ac_over,
 .ac_over .ac_match {
-	background-color: #0073aa;
+	background-color: #2271b1;
 	color: #fff;
 	cursor: pointer;
 }
@@ -1306,7 +1306,7 @@ p.popular-tags a {
 	content: "(" attr( href ) ")";
 	display: inline-block;
 	padding: 0 4px;
-	color: #72777C;
+	color: #787c82;
 	font-size: 13px;
 	word-break: break-all;
 }

--- a/src/wp-admin/css/forms.css
+++ b/src/wp-admin/css/forms.css
@@ -53,9 +53,9 @@ select,
 textarea {
 	box-shadow: 0 0 0 transparent;
 	border-radius: 4px;
-	border: 1px solid #7e8993;
+	border: 1px solid #8c8f94;
 	background-color: #fff;
-	color: #32373c;
+	color: #2c3338;
 }
 
 input[type="text"],
@@ -101,8 +101,8 @@ input[type="checkbox"]:focus,
 input[type="radio"]:focus,
 select:focus,
 textarea:focus {
-	border-color: #007cba;
-	box-shadow: 0 0 0 1px #007cba;
+	border-color: #3582c4;
+	box-shadow: 0 0 0 1px #3582c4;
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
 }
@@ -115,10 +115,10 @@ input[type="url"] {
 
 input[type="checkbox"],
 input[type="radio"] {
-	border: 1px solid #7e8993;
+	border: 1px solid #8c8f94;
 	border-radius: 4px;
 	background: #fff;
-	color: #555;
+	color: #50575e;
 	clear: none;
 	cursor: pointer;
 	display: inline-block;
@@ -137,12 +137,12 @@ input[type="radio"] {
 }
 
 input[type="radio"]:checked + label:before {
-	color: #82878c;
+	color: #8c8f94;
 }
 
 .wp-core-ui input[type="reset"]:hover,
 .wp-core-ui input[type="reset"]:active {
-	color: #006799;
+	color: #135e96;
 }
 
 td > input[type="checkbox"],
@@ -191,7 +191,7 @@ input[type="radio"]:checked::before {
 	width: 0.5rem; /* 8px */
 	height: 0.5rem; /* 8px */
 	margin: 0.1875rem; /* 3px */
-	background-color: #1e8cbe;
+	background-color: #4f94d4;
 	/* 16px not sure if still necessary, comes from the MP6 redesign in r26072 */
 	line-height: 1.14285714;
 }
@@ -222,20 +222,20 @@ input.readonly,
 input[readonly],
 textarea.readonly,
 textarea[readonly] {
-	background-color: #eee;
+	background-color: #f0f0f1;
 }
 
 ::-webkit-input-placeholder {
-	color: #72777c;
+	color: #787c82;
 }
 
 ::-moz-placeholder {
-	color: #72777c;
+	color: #787c82;
 	opacity: 1;
 }
 
 :-ms-input-placeholder {
-	color: #72777c;
+	color: #787c82;
 }
 
 .form-invalid .form-required,
@@ -244,14 +244,14 @@ textarea[readonly] {
 .form-invalid.form-required input:focus,
 .form-invalid.form-required select,
 .form-invalid.form-required select:focus {
-	border-color: #dc3232 !important;
-	box-shadow: 0 0 2px rgba(204, 0, 0, 0.8);
+	border-color: #d63638 !important;
+	box-shadow: 0 0 2px rgba(214, 54, 56, 0.8);
 }
 
 .form-table .form-required.form-invalid td:after {
 	content: "\f534";
 	font: normal 20px/1 dashicons;
-	color: #dc3232;
+	color: #d63638;
 	margin-left: -25px;
 	vertical-align: middle;
 }
@@ -264,13 +264,13 @@ textarea[readonly] {
 .form-table .form-required.user-pass1-wrap.form-invalid .password-input-wrapper:after {
 	content: "\f534";
 	font: normal 20px/1 dashicons;
-	color: #dc3232;
+	color: #d63638;
 	margin: 0 6px 0 -29px;
 	vertical-align: middle;
 }
 
 .form-input-tip {
-	color: #666;
+	color: #646970;
 }
 
 input:disabled,
@@ -280,9 +280,9 @@ select.disabled,
 textarea:disabled,
 textarea.disabled {
 	background: rgba(255, 255, 255, 0.5);
-	border-color: rgba(222, 222, 222, 0.75);
+	border-color: rgba(220, 220, 222, 0.75);
 	box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.04);
-	color: rgba(51, 51, 51, 0.5);
+	color: rgba(44, 51, 56, 0.5);
 }
 
 input[type="file"]:disabled,
@@ -313,8 +313,8 @@ input[type="radio"].disabled:checked:before {
 .wp-core-ui select {
 	font-size: 14px;
 	line-height: 2; /* 28px */
-	color: #32373c;
-	border-color: #7e8993;
+	color: #2c3338;
+	border-color: #8c8f94;
 	box-shadow: none;
 	border-radius: 3px;
 	padding: 0 24px 0 8px;
@@ -329,25 +329,25 @@ input[type="radio"].disabled:checked:before {
 }
 
 .wp-core-ui select:hover {
-	color: #007cba;
+	color: #3582c4;
 }
 
 .wp-core-ui select:focus {
-	border-color: #007cba;
-	color: #016087;
-	box-shadow: 0 0 0 1px #007cba;
+	border-color: #3582c4;
+	color: #0a4b78;
+	box-shadow: 0 0 0 1px #3582c4;
 }
 
 .wp-core-ui select:active {
-	border-color: #999;
+	border-color: #8c8f94;
 	box-shadow: none;
 }
 
 .wp-core-ui select.disabled,
 .wp-core-ui select:disabled {
-	color: #a0a5aa;
-	border-color: #ddd;
-	background-color: #f7f7f7;
+	color: #a7aaad;
+	border-color: #dcdcde;
+	background-color: #f6f7f7;
 	/* The SVG is arrow-down-alt2 from Dashicons. */
 	background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20width%3D%2220%22%20height%3D%2220%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M5%206l5%205%205-5%202%201-7%207-7-7%202-1z%22%20fill%3D%22%23a0a5aa%22%2F%3E%3C%2Fsvg%3E');
 	box-shadow: none;
@@ -360,26 +360,26 @@ input[type="radio"].disabled:checked:before {
 /* This ruleset overrides the color change on :focus thus needs to be after select:focus. */
 .wp-core-ui select:-moz-focusring {
 	color: transparent;
-	text-shadow: 0 0 0 #016087;
+	text-shadow: 0 0 0 #0a4b78;
 }
 
 /* Remove background focus style from IE11 while keeping focus style available on option elements. */
 .wp-core-ui select::-ms-value {
 	background: transparent;
-	color: #555;
+	color: #50575e;
 }
 
 .wp-core-ui select:hover::-ms-value {
-	color: #007cba;
+	color: #3582c4;
 }
 
 .wp-core-ui select:focus::-ms-value {
-	color: #016087;
+	color: #0a4b78;
 }
 
 .wp-core-ui select.disabled::-ms-value,
 .wp-core-ui select:disabled::-ms-value {
-	color: #a0a5aa;
+	color: #a7aaad;
 }
 
 /* Hide the native down arrow for select element on IE. */
@@ -558,9 +558,9 @@ fieldset label,
 }
 
 #pass-strength-result {
-	background-color: #eee;
-	border: 1px solid #ddd;
-	color: #23282d;
+	background-color: #f0f0f1;
+	border: 1px solid #dcdcde;
+	color: #1d2327;
 	margin: -1px 1px 5px;
 	padding: 3px 5px;
 	text-align: center;
@@ -570,43 +570,43 @@ fieldset label,
 }
 
 #pass-strength-result.short {
-	background-color: #f1adad;
-	border-color: #e35b5b;
+	background-color: #ffabaf;
+	border-color: #e65054;
 	opacity: 1;
 }
 
 #pass-strength-result.bad {
-	background-color: #fbc5a9;
-	border-color: #f78b53;
+	background-color: #facfd2;
+	border-color: #f86368;
 	opacity: 1;
 }
 
 #pass-strength-result.good {
-	background-color: #ffe399;
-	border-color: #ffc733;
+	background-color: #f5e6ab;
+	border-color: #f0c33c;
 	opacity: 1;
 }
 
 #pass-strength-result.strong {
-	background-color: #c1e1b9;
-	border-color: #83c373;
+	background-color: #b8e6bf;
+	border-color: #68de7c;
 	opacity: 1;
 }
 
 #pass1.short, #pass1-text.short {
-	border-color: #e35b5b;
+	border-color: #e65054;
 }
 
 #pass1.bad, #pass1-text.bad {
-	border-color: #f78b53;
+	border-color: #f86368;
 }
 
 #pass1.good, #pass1-text.good {
-	border-color: #ffc733;
+	border-color: #f0c33c;
 }
 
 #pass1.strong, #pass1-text.strong {
-	border-color: #83c373;
+	border-color: #68de7c;
 }
 
 .pw-weak {
@@ -685,8 +685,8 @@ ul#add-to-blog-users {
 	list-style: none;
 	position: absolute;
 	z-index: 10000;
-	border: 1px solid #5b9dd9;
-	box-shadow: 0 1px 2px rgba(30, 140, 190, 0.8);
+	border: 1px solid #4f94d4;
+	box-shadow: 0 1px 2px rgba(79, 148, 212, 0.8);
 	background-color: #fff;
 }
 
@@ -700,12 +700,12 @@ ul#add-to-blog-users {
 
 /* Colors for the wplink toolbar autocomplete. */
 .ui-autocomplete .ui-state-focus {
-	background-color: #ddd;
+	background-color: #dcdcde;
 }
 
 /* Colors for the tags autocomplete. */
 .wp-tags-autocomplete .ui-state-focus {
-	background-color: #0073aa;
+	background-color: #2271b1;
 	color: #fff;
 }
 
@@ -736,7 +736,7 @@ ul#add-to-blog-users {
 
 .form-table th,
 .form-wrap label {
-	color: #23282d;
+	color: #1d2327;
 	font-weight: 400;
 	text-shadow: none;
 	vertical-align: baseline;
@@ -843,7 +843,7 @@ table.form-table td .updated p {
 
 .color-option:hover,
 .color-option.selected {
-	background: #ddd;
+	background: #dcdcde;
 }
 
 .color-palette {
@@ -923,7 +923,7 @@ table.form-table td .updated p {
 	padding: 0.7em 2em 1em;
 	min-width: 255px;
 	max-width: 520px;
-	border: 1px solid #ccd0d4;
+	border: 1px solid #c3c4c7;
 	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
 	background: #fff;
 	box-sizing: border-box;
@@ -958,10 +958,10 @@ table.form-table td .updated p {
 	display: inline-block;
 	position: relative;
 	cursor: move;
-	color: #32373c;
-	background: #e5e5e5;
+	color: #2c3338;
+	background: #dcdcde;
 	border-radius: 5px;
-	border: 1px solid #b4b9be;
+	border: 1px solid #c3c4c7;
 	font-style: normal;
 	line-height: 16px;
 	font-size: 14px;
@@ -997,7 +997,7 @@ table.form-table td .updated p {
 }
 
 .pressthis-bookmarklet span:before {
-	color: #72777c;
+	color: #787c82;
 	font: normal 20px/1 dashicons;
 	content: "\f157";
 	position: relative;
@@ -1023,7 +1023,7 @@ table.form-table td .updated p {
 
 .pressthis-js-toggle .dashicons {
 	margin: 5px 8px 6px 7px;
-	color: #555d66;
+	color: #50575e;
 }
 
 /*------------------------------------------------------------------------------
@@ -1200,7 +1200,7 @@ table.form-table td .updated p {
 }
 
 .request-filesystem-credentials-dialog .ftp-password em {
-	color: #888;
+	color: #8c8f94;
 }
 
 .request-filesystem-credentials-dialog label {
@@ -1262,7 +1262,7 @@ table.form-table td .updated p {
 }
 
 .privacy_requests .row-actions {
-	color: #72777c;
+	color: #787c82;
 }
 
 .privacy_requests .row-actions.processing {
@@ -1293,14 +1293,14 @@ table.form-table td .updated p {
 
 .privacy_requests .status-request-confirmed th,
 .privacy_requests .status-request-confirmed td {
-	background-color: #f7fcfe;
-	border-left-color: #00a0d2;
+	background-color: #fff;
+	border-left-color: #72aee6;
 }
 
 .privacy_requests .status-request-failed th,
 .privacy_requests .status-request-failed td {
-	background-color: #fef7f1;
-	border-left-color: #d64d21;
+	background-color: #f6f7f7;
+	border-left-color: #d63638;
 }
 
 .privacy_requests .export_personal_data_failed a {
@@ -1314,11 +1314,11 @@ table.form-table td .updated p {
 .status-label.status-request-pending {
 	font-weight: 400;
 	font-style: italic;
-	color: #6c7781;
+	color: #787c82;
 }
 
 .status-label.status-request-failed {
-	color: #aa0000;
+	color: #d63638;
 	font-weight: 600;
 }
 
@@ -1352,13 +1352,13 @@ table.form-table td .updated p {
 }
 
 .email-personal-data--sending::before {
-	color: #f56e28;
+	color: #d63638;
 	content: "\f463";
 	animation: rotation 2s infinite linear;
 }
 
 .email-personal-data--sent::before {
-	color: #79ba49;
+	color: #68de7c;
 	content: "\f147";
 }
 

--- a/src/wp-admin/css/install.css
+++ b/src/wp-admin/css/install.css
@@ -1,40 +1,40 @@
 html {
-	background: #f1f1f1;
+	background: #f0f0f1;
 	margin: 0 20px;
 }
 
 body {
 	background: #fff;
-	border: 1px solid #ccd0d4;
-	color: #444;
+	border: 1px solid #c3c4c7;
+	color: #3c434a;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	margin: 140px auto 25px;
 	padding: 20px 20px 10px 20px;
 	max-width: 700px;
 	-webkit-font-smoothing: subpixel-antialiased;
-	box-shadow: 0 1px 1px rgba(0, 0, 0, .04);
+	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
 }
 
 a {
-	color: #0073aa;
+	color: #2271b1;
 }
 
 a:hover,
 a:active {
-	color: #006799;
+	color: #135e96;
 }
 
 a:focus {
-	color: #124964;
+	color: #043959;
 	box-shadow:
-		0 0 0 1px #5b9dd9,
-		0 0 2px 1px rgba(30, 140, 190, 0.8);
+		0 0 0 1px #4f94d4,
+		0 0 2px 1px rgba(79, 148, 212, 0.8);
 }
 
 h1, h2 {
-	border-bottom: 1px solid #ddd;
+	border-bottom: 1px solid #dcdcde;
 	clear: both;
-	color: #666;
+	color: #646970;
 	font-size: 24px;
 	padding: 0;
 	padding-bottom: 7px;
@@ -88,7 +88,7 @@ label {
 	background-size: 84px;
 	background-position: center top;
 	background-repeat: no-repeat;
-	color: #444; /* same as login.css */
+	color: #3c434a; /* same as login.css */
 	font-size: 20px;
 	font-weight: 400;
 	line-height: 1.3em;
@@ -109,7 +109,7 @@ label {
 	font-size: 14px;
 }
 textarea {
-	border: 1px solid #ddd;
+	border: 1px solid #dcdcde;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	width: 100%;
 	box-sizing: border-box;
@@ -200,9 +200,9 @@ submit {
 }
 
 .message {
-	border-left: 4px solid #dc3232;
+	border-left: 4px solid #d63638;
 	padding: .7em .6em;
-	background-color: #fbeaea;
+	background-color: #fcf0f1;
 }
 
 /* rtl:ignore */
@@ -308,21 +308,21 @@ body.language-chooser {
 	padding: 8px;
 	width: 100%;
 	display: block;
-	border: 1px solid #ddd;
+	border: 1px solid #dcdcde;
 	background: #fff;
-	color: #32373c;
+	color: #2c3338;
 	font-size: 16px;
 	font-family: Arial, sans-serif;
 	font-weight: 400;
 }
 
 .language-chooser select:focus {
-	color: #32373c;
+	color: #2c3338;
 }
 
 .language-chooser select option:hover,
 .language-chooser select option:focus {
-	color: #016087;
+	color: #0a4b78;
 }
 
 .language-chooser p {

--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -1167,7 +1167,7 @@ ul.cat-checklist {
 
 .plugins .active td,
 .plugins .active th {
-	background-color: #fff;
+	background-color: #f0f6fc;
 }
 
 .plugins .update th,

--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -219,7 +219,7 @@
 
 #the-comment-list .unapproved th,
 #the-comment-list .unapproved td {
-	background-color: #f6f7f7;
+	background-color: #fcf9e8;
 }
 
 #the-comment-list .unapproved th.check-column {

--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -55,7 +55,7 @@
 	min-width: 24px;
 	height: 2em;
 	border-radius: 5px;
-	background-color: #72777c;
+	background-color: #787c82;
 	color: #fff;
 	font-size: 11px;
 	line-height: 1.90909090;
@@ -71,7 +71,7 @@
 	margin-left: 8px;
 	width: 0;
 	height: 0;
-	border-top: 5px solid #72777c;
+	border-top: 5px solid #787c82;
 	border-right: 5px solid transparent;
 }
 
@@ -79,14 +79,14 @@
 .column-response a.post-com-count-approved:focus .comment-count-approved,
 .column-comments a.post-com-count-approved:hover .comment-count-approved,
 .column-comments a.post-com-count-approved:focus .comment-count-approved {
-	background: #0073aa;
+	background: #2271b1;
 }
 
 .column-response a.post-com-count-approved:hover:after,
 .column-response a.post-com-count-approved:focus:after,
 .column-comments a.post-com-count-approved:hover:after,
 .column-comments a.post-com-count-approved:focus:after {
-	border-top-color: #0073aa;
+	border-top-color: #2271b1;
 }
 
 /* @todo: consider to use a single rule for these counters and the admin menu counters. */
@@ -99,7 +99,7 @@
 	height: 17px;
 	border: 2px solid #fff;
 	border-radius: 11px;
-	background: #ca4a1f;
+	background: #d63638;
 	color: #fff;
 	font-size: 9px;
 	line-height: 1.88888888;
@@ -116,7 +116,7 @@
 .commentlist li {
 	padding: 1em 1em .2em;
 	margin: 0;
-	border-bottom: 1px solid #ccc;
+	border-bottom: 1px solid #c3c4c7;
 }
 
 .commentlist li li {
@@ -131,7 +131,7 @@
 
 #submitted-on,
 .submitted-on {
-	color: #555d66;
+	color: #50575e;
 }
 
 /* reply to comments */
@@ -203,8 +203,8 @@
 }
 
 #replyerror {
-	border-color: #ddd;
-	background-color: #f9f9f9;
+	border-color: #dcdcde;
+	background-color: #f6f7f7;
 }
 
 /* @todo: is this used? */
@@ -214,16 +214,16 @@
 
 #the-comment-list tr.undo,
 #the-comment-list div.undo {
-	background-color: #f5f5f5;
+	background-color: #f6f7f7;
 }
 
 #the-comment-list .unapproved th,
 #the-comment-list .unapproved td {
-	background-color: #fef7f1;
+	background-color: #f6f7f7;
 }
 
 #the-comment-list .unapproved th.check-column {
-	border-left: 4px solid #d54e21;
+	border-left: 4px solid #d63638;
 }
 
 #the-comment-list .unapproved th.check-column input {
@@ -231,11 +231,11 @@
 }
 
 #the-comment-list .approve a {
-	color: #006505;
+	color: #007017;
 }
 
 #the-comment-list .unapprove a {
-	color: #d98500;
+	color: #bd8600;
 }
 
 #the-comment-list th,
@@ -257,7 +257,7 @@
 .vim-current,
 .vim-current th,
 .vim-current td {
-	background-color: #e4f2fd !important;
+	background-color: #f0f6fc !important;
 }
 
 th .comment-grey-bubble {
@@ -278,7 +278,7 @@ th .comment-grey-bubble:before {
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 	text-decoration: none !important;
-	color: #444;
+	color: #3c434a;
 }
 
 /*------------------------------------------------------------------------------
@@ -458,14 +458,14 @@ table.media .column-title .filename {
 	padding: 0;
 	top: -4px;
 	left: -8px;
-	color: #444;
+	color: #3c434a;
 	line-height: 0.5;
 	position: relative;
 	vertical-align: top;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 	text-decoration: none !important;
-	color: #444;
+	color: #3c434a;
 }
 
 .column-comments .sorting-indicator:before {
@@ -504,8 +504,8 @@ th.asc a:focus span.sorting-indicator:before {
 
 .wp-list-table .toggle-row:focus:before {
 	box-shadow:
-		0 0 0 1px #5b9dd9,
-		0 0 2px 1px rgba(30, 140, 190, 0.8);
+		0 0 0 1px #4f94d4,
+		0 0 2px 1px rgba(79, 148, 212, 0.8);
 }
 
 .wp-list-table .toggle-row:active {
@@ -519,7 +519,7 @@ th.asc a:focus span.sorting-indicator:before {
 	border-radius: 50%;
 	display: block;
 	padding: 1px 2px 1px 0;
-	color: #444; /* same as table headers sort arrows */
+	color: #3c434a; /* same as table headers sort arrows */
 	content: "\f140";
 	font: normal 20px/1 dashicons;
 	line-height: 1;
@@ -540,7 +540,7 @@ th.asc a:focus span.sorting-indicator:before {
 }
 
 .locked-indicator-icon:before {
-	color: #82878c;
+	color: #8c8f94;
 	content: "\f160";
 	display: inline-block;
 	font: normal 20px/1 dashicons;
@@ -709,7 +709,7 @@ th.asc a:focus span.sorting-indicator {
 }
 
 .view-switch a:before {
-	color: #b4b9be;
+	color: #c3c4c7;
 	display: inline-block;
 	font: normal 20px/1 dashicons;
 	speak: never;
@@ -720,11 +720,11 @@ th.asc a:focus span.sorting-indicator {
 
 .view-switch a:hover:before,
 .view-switch a:focus:before {
-	color: #727272;
+	color: #787c82;
 }
 
 .view-switch a.current:before {
-	color: #0073aa;
+	color: #2271b1;
 }
 
 .view-switch .view-list:before {
@@ -794,7 +794,7 @@ p.pagenav {
 }
 
 .row-actions {
-	color: #ddd;
+	color: #dcdcde;
 	font-size: 13px;
 	padding: 2px 0 0;
 	position: relative;
@@ -1030,7 +1030,7 @@ tr.inline-edit-row td,
 
 ul.cat-checklist {
 	height: 12em;
-	border: solid 1px #ddd;
+	border: solid 1px #dcdcde;
 	overflow-y: scroll;
 	padding: 0 5px;
 	margin: 0;
@@ -1040,7 +1040,7 @@ ul.cat-checklist {
 #bulk-titles {
 	display: block;
 	height: 12em;
-	border: 1px solid #ddd;
+	border: 1px solid #dcdcde;
 	overflow-y: scroll;
 	padding: 0 5px;
 	margin: 0 0 5px;
@@ -1167,7 +1167,7 @@ ul.cat-checklist {
 
 .plugins .active td,
 .plugins .active th {
-	background-color: #f7fcfe;
+	background-color: #fff;
 }
 
 .plugins .update th,
@@ -1190,7 +1190,7 @@ ul.cat-checklist {
 .plugins tr.active + tr.inactive th,
 .plugins tr.active + tr.inactive td {
 	border-top: 1px solid rgba(0, 0, 0, 0.03);
-	box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.02), inset 0 -1px 0 #e1e1e1;
+	box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.02), inset 0 -1px 0 #dcdcde;
 }
 
 .plugins .update td,
@@ -1208,7 +1208,7 @@ ul.cat-checklist {
 
 .plugins .active th.check-column,
 .plugin-update-tr.active td {
-	border-left: 4px solid #00a0d2;
+	border-left: 4px solid #72aee6;
 }
 
 .wp-list-table.plugins .plugin-title,
@@ -1227,10 +1227,10 @@ ul.cat-checklist {
 
 .plugins .plugin-title .dashicons:before {
 	padding: 2px;
-	background-color: #eee;
-	box-shadow: inset 0 0 10px rgba(160, 165, 170, 0.15);
+	background-color: #f0f0f1;
+	box-shadow: inset 0 0 10px rgba(167, 170, 173, 0.15);
 	font-size: 60px;
-	color: #B4B9BE;
+	color: #c3c4c7;
 }
 
 #update-themes-table .plugin-title img,
@@ -1286,31 +1286,31 @@ ul.cat-checklist {
 }
 
 .plugins tr.paused th.check-column {
-	border-left: 4px solid #d54e21;
+	border-left: 4px solid #d63638;
 }
 
 .plugins tr.paused th,
 .plugins tr.paused td {
-	background-color: #fef7f1;
+	background-color: #f6f7f7;
 }
 
 .plugins tr.paused .plugin-title,
 .plugins .paused .dashicons-warning {
-	color: #dc3232;
+	color: #d63638;
 }
 
 .plugins .paused .error-display p,
 .plugins .paused .error-display code {
 	font-size: 90%;
-	color: rgba( 0, 0, 0, 0.7 );
+	color: rgba(0, 0, 0, 0.7);
 }
 
 .plugins .resume-link {
-	color: #dc3232;
+	color: #d63638;
 }
 
 .plugin-card .update-now:before {
-	color: #f56e28;
+	color: #d63638;
 	content: "\f463";
 	display: inline-block;
 	font: normal 20px/1 dashicons;
@@ -1336,7 +1336,7 @@ ul.cat-checklist {
 }
 
 .plugin-card .updated-message:before {
-	color: #79ba49;
+	color: #68de7c;
 	content: "\f147";
 }
 
@@ -1368,7 +1368,7 @@ ul.cat-checklist {
 	width: 48.5%;
 	width: calc( 50% - 8px );
 	background-color: #fff;
-	border: 1px solid #ddd;
+	border: 1px solid #dcdcde;
 	box-sizing: border-box;
 }
 
@@ -1475,8 +1475,8 @@ div.action-links,
 .plugin-card-bottom {
 	clear: both;
 	padding: 12px 20px;
-	background-color: #fafafa;
-	border-top: 1px solid #ddd;
+	background-color: #f6f7f7;
+	border-top: 1px solid #dcdcde;
 	overflow: hidden;
 }
 
@@ -1491,7 +1491,7 @@ div.action-links,
 .plugin-card-update-failed .notice-error {
 	margin: 0;
 	padding-left: 16px;
-	box-shadow: 0 -1px 0 #ddd;
+	box-shadow: 0 -1px 0 #dcdcde;
 }
 
 .plugin-card-update-failed .plugin-card-bottom {
@@ -1535,17 +1535,17 @@ div.action-links,
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 	text-decoration: none !important;
-	color: #444;
+	color: #3c434a;
 }
 
 .plugin-card .column-compatibility .compatibility-incompatible:before {
 	content: "\f158";
-	color: #c62d2d;
+	color: #d63638;
 }
 
 .plugin-card .column-compatibility .compatibility-compatible:before {
 	content: "\f147";
-	color: #31843f;
+	color: #007017;
 }
 
 .plugin-card .notice {
@@ -1562,7 +1562,7 @@ div.action-links,
 }
 
 .no-plugin-results {
-	color: #666; /* same as no themes and no media */
+	color: #646970; /* same as no themes and no media */
 	font-size: 18px;
 	font-style: normal;
 	margin: 0;
@@ -1574,19 +1574,19 @@ div.action-links,
 /* Background Color for Site Status */
 .wp-list-table .site-deleted,
 .wp-list-table tr.site-deleted {
-	background: #ff8573;
+	background: #ff8085;
 }
 .wp-list-table .site-spammed,
 .wp-list-table tr.site-spammed {
-	background: #faafaa;
+	background: #ffabaf;
 }
 .wp-list-table .site-archived,
 .wp-list-table tr.site-archived {
-	background: #ffebe8;
+	background: #fcf0f1;
 }
 .wp-list-table .site-mature,
 .wp-list-table tr.site-mature {
-	background: #fecac2;
+	background: #facfd2;
 }
 
 .sites.fixed .column-lastupdated,
@@ -1856,7 +1856,7 @@ div.action-links,
 		border: none;
 		border-radius: 0;
 		background: none;
-		color: #bb2a2a;
+		color: #b32d2e;
 		font-size: inherit;
 		line-height: inherit;
 		text-align: left;
@@ -1864,7 +1864,7 @@ div.action-links,
 
 	.column-response .post-com-count-pending:hover,
 	.column-comments .post-com-count-pending:hover {
-		color: #dc3232;
+		color: #d63638;
 	}
 
 	.widefat thead td.check-column,
@@ -2070,8 +2070,8 @@ div.action-links,
 	}
 
 	.plugins .active.update + .plugin-update-tr:before {
-		border-left: 4px solid #d54e21;
-		background-color: #fef7f1;
+		border-left: 4px solid #d63638;
+		background-color: #f6f7f7;
 	}
 
 	.plugins #the-list .plugin-update-tr .plugin-update {
@@ -2083,8 +2083,8 @@ div.action-links,
 	}
 
 	.plugins .active.update + .plugin-update-tr:before {
-		background-color: #f7fcfe;
-		border-left: 4px solid #00a0d2;
+		background-color: #fff;
+		border-left: 4px solid #72aee6;
 	}
 
 	.plugins .plugin-update-tr .update-message {

--- a/src/wp-admin/css/login.css
+++ b/src/wp-admin/css/login.css
@@ -6,16 +6,16 @@ body {
 }
 
 body {
-	background: #f1f1f1;
+	background: #f0f0f1;
 	min-width: 0;
-	color: #444;
+	color: #3c434a;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	font-size: 13px;
 	line-height: 1.4;
 }
 
 a {
-	color: #0073aa;
+	color: #2271b1;
 	transition-property: border, background, color;
 	transition-duration: .05s;
 	transition-timing-function: ease-in-out;
@@ -27,14 +27,14 @@ a {
 
 a:hover,
 a:active {
-	color: #006799;
+	color: #135e96;
 }
 
 a:focus {
-	color: #124964;
+	color: #043959;
 	box-shadow:
-		0 0 0 1px #5b9dd9,
-		0 0 2px 1px rgba(30, 140, 190, 0.8);
+		0 0 0 1px #4f94d4,
+		0 0 2px 1px rgba(79, 148, 212, 0.8);
 }
 
 p {
@@ -44,7 +44,7 @@ p {
 .login .message,
 .login .success,
 .login #login_error {
-	border-left: 4px solid #00a0d2;
+	border-left: 4px solid #72aee6;
 	padding: 12px;
 	margin-left: 0;
 	margin-bottom: 20px;
@@ -53,11 +53,11 @@ p {
 }
 
 .login .success {
-	border-left-color: #46b450;
+	border-left-color: #00a32a;
 }
 
 .login #login_error {
-	border-left-color: #dc3232;
+	border-left-color: #d63638;
 }
 
 #loginform p.submit,
@@ -102,8 +102,8 @@ p {
 
 .login .button.wp-hide-pw:focus {
 	background: transparent;
-	border-color: #007cba;
-	box-shadow: 0 0 0 1px #007cba;
+	border-color: #3582c4;
+	box-shadow: 0 0 0 1px #3582c4;
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
 }
@@ -135,7 +135,7 @@ p {
 	font-weight: 400;
 	overflow: hidden;
 	background: #fff;
-	border: 1px solid #ccd0d4;
+	border: 1px solid #c3c4c7;
 	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
 }
 
@@ -203,8 +203,8 @@ p {
 }
 
 .login h1.admin-email__heading {
-	border-bottom: 1px rgb(241, 241, 241) solid;
-	color: rgb(95, 95, 95);
+	border-bottom: 1px #f0f0f1 solid;
+	color: #50575e;
 	font-weight: normal;
 	padding-bottom: 0.5em;
 	text-align: left;
@@ -252,7 +252,7 @@ p {
 	background-size: 84px;
 	background-position: center top;
 	background-repeat: no-repeat;
-	color: #444;
+	color: #3c434a;
 	height: 84px;
 	font-size: 20px;
 	font-weight: 400;
@@ -290,19 +290,19 @@ p {
 .login #nav a,
 .login #backtoblog a {
 	text-decoration: none;
-	color: #555d66;
+	color: #50575e;
 }
 
 .login #nav a:hover,
 .login #backtoblog a:hover,
 .login h1 a:hover {
-	color: #006799;
+	color: #135e96;
 }
 
 .login #nav a:focus,
 .login #backtoblog a:focus,
 .login h1 a:focus {
-	color: #124964;
+	color: #043959;
 }
 
 .login .privacy-policy-page-link {
@@ -333,7 +333,7 @@ p {
 .login form .input,
 .login input[type="text"],
 .login form input[type="checkbox"] {
-	background: #fbfbfb;
+	background: #fff;
 }
 
 .js.login-action-rp input[type="text"],

--- a/src/wp-admin/css/media.css
+++ b/src/wp-admin/css/media.css
@@ -5,7 +5,7 @@
 .media-item .describe {
 	border-collapse: collapse;
 	width: 100%;
-	border-top: 1px solid #ddd;
+	border-top: 1px solid #dcdcde;
 	clear: both;
 	cursor: default;
 }
@@ -124,7 +124,7 @@
 
 .media-upload-form .media-item,
 .media-upload-form .media-item .error {
-	box-shadow: 0 1px 0 #ddd;
+	box-shadow: 0 1px 0 #dcdcde;
 }
 
 #media-items:empty {
@@ -163,7 +163,7 @@
 	padding: 0;
 	overflow: hidden;
 	border-radius: 22px;
-	background: #ddd;
+	background: #dcdcde;
 	box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
 }
 
@@ -173,7 +173,7 @@
 	height: 100%;
 	margin-top: -22px;
 	border-radius: 22px;
-	background-color: #0073aa;
+	background-color: #2271b1;
 	box-shadow: inset 0 0 2px rgba(0, 0, 0, 0.3);
 }
 
@@ -238,8 +238,8 @@
 }
 
 .find-box-head {
-	background: #fcfcfc;
-	border-bottom: 1px solid #ddd;
+	background: #fff;
+	border-bottom: 1px solid #dcdcde;
 	height: 36px;
 	font-size: 18px;
 	font-weight: 600;
@@ -305,18 +305,18 @@
 	cursor: pointer;
 	text-align: center;
 	background: none;
-	color: #666;
+	color: #646970;
 }
 
 #find-posts-close:hover,
 #find-posts-close:focus {
-	color: #006799;
+	color: #135e96;
 }
 
 #find-posts-close:focus {
 	box-shadow:
-		0 0 0 1px #5b9dd9,
-		0 0 2px 1px rgba(30, 140, 190, 0.8);
+		0 0 0 1px #4f94d4,
+		0 0 2px 1px rgba(79, 148, 212, 0.8);
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
 	outline-offset: -2px;
@@ -333,8 +333,8 @@
 
 .find-box-buttons {
 	padding: 8px 16px;
-	background: #fcfcfc;
-	border-top: 1px solid #ddd;
+	background: #fff;
+	border-top: 1px solid #dcdcde;
 	position: absolute;
 	bottom: 0;
 	left: 0;
@@ -373,7 +373,7 @@
 }
 
 .drag-drop #drag-drop-area {
-	border: 4px dashed #b4b9be;
+	border: 4px dashed #c3c4c7;
 	height: 200px;
 }
 
@@ -407,7 +407,7 @@
 }
 border color while dragging a file over the uploader drop area */
 .drag-drop.drag-over #drag-drop-area {
-	border-color: #83b4d8;
+	border-color: #9ec2e6;
 }
 
 #plupload-upload-ui {
@@ -442,7 +442,7 @@ border color while dragging a file over the uploader drop area */
 	width: auto;
 	margin-top: 12px;
 	padding: 0 16px;
-	border-left: 4px solid #dd3d36;
+	border-left: 4px solid #d63638;
 	box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.1);
 	background-color: #fff;
 }
@@ -475,12 +475,12 @@ border color while dragging a file over the uploader drop area */
 	content: "\f153";
 	display: block;
 	font: normal 16px/1 dashicons;
-	color: #72777c;
+	color: #787c82;
 }
 
 .upload-php .mode-grid .media-sidebar .media-uploader-status .upload-dismiss-errors:focus:before,
 .upload-php .mode-grid .media-sidebar .media-uploader-status .upload-dismiss-errors:hover:before {
-	color: #c00;
+	color: #d63638;
 }
 
 .upload-php .mode-grid .media-sidebar .media-uploader-status.errors h2 {
@@ -495,7 +495,7 @@ border color while dragging a file over the uploader drop area */
 	bottom: auto;
 	padding-top: 0;
 	margin-top: 20px;
-	border: 4px dashed #b4b9be;
+	border: 4px dashed #c3c4c7;
 }
 
 .media-frame.mode-select .attachments-browser.fixed .attachments {
@@ -508,8 +508,8 @@ border color while dragging a file over the uploader drop area */
 .media-frame.mode-grid .selected.attachment:focus,
 .media-frame.mode-grid .attachment.details:focus {
 	box-shadow:
-		inset 0 0 2px 3px #f1f1f1,
-		inset 0 0 0 7px #5b9dd9;
+		inset 0 0 2px 3px #f0f0f1,
+		inset 0 0 0 7px #4f94d4;
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
 	outline-offset: -6px;
@@ -517,14 +517,14 @@ border color while dragging a file over the uploader drop area */
 
 .media-frame.mode-grid .selected.attachment {
 	box-shadow:
-		inset 0 0 0 5px #f1f1f1,
-		inset 0 0 0 7px #ccc;
+		inset 0 0 0 5px #f0f0f1,
+		inset 0 0 0 7px #c3c4c7;
 }
 
 .media-frame.mode-grid .attachment.details {
 	box-shadow:
-		inset 0 0 0 3px #f1f1f1,
-		inset 0 0 0 7px #1e8cbe;
+		inset 0 0 0 3px #f0f0f1,
+		inset 0 0 0 7px #4f94d4;
 }
 
 .media-frame.mode-grid.mode-select .attachment .thumbnail {
@@ -589,7 +589,7 @@ border color while dragging a file over the uploader drop area */
 }
 
 .media-frame.mode-grid .attachments-browser .no-media {
-	color: #666; /* same as no plugins and no themes */
+	color: #646970; /* same as no plugins and no themes */
 	font-size: 18px;
 	font-style: normal;
 	margin: 0;
@@ -620,7 +620,7 @@ border color while dragging a file over the uploader drop area */
 .edit-attachment-frame .edit-media-header .left,
 .edit-attachment-frame .edit-media-header .right {
 	cursor: pointer;
-	color: #72777c;
+	color: #787c82;
 	background-color: transparent;
 	height: 50px;
 	width: 50px;
@@ -628,7 +628,7 @@ border color while dragging a file over the uploader drop area */
 	position: absolute;
 	text-align: center;
 	border: 0;
-	border-left: 1px solid #ddd;
+	border-left: 1px solid #dcdcde;
 	transition: color .1s ease-in-out, background .1s ease-in-out;
 }
 
@@ -663,8 +663,8 @@ border color while dragging a file over the uploader drop area */
 .edit-attachment-frame .edit-media-header .right:hover,
 .edit-attachment-frame .edit-media-header .left:focus,
 .edit-attachment-frame .edit-media-header .right:focus {
-	background: #ddd;
-	border-color: #ccc;
+	background: #dcdcde;
+	border-color: #c3c4c7;
 	color: #000;
 	outline: none;
 	box-shadow: none;
@@ -693,7 +693,7 @@ border color while dragging a file over the uploader drop area */
 
 .edit-attachment-frame .edit-media-header [disabled],
 .edit-attachment-frame .edit-media-header [disabled]:hover {
-	color: #ccc;
+	color: #c3c4c7;
 	background: inherit;
 	cursor: default;
 }
@@ -737,7 +737,7 @@ border color while dragging a file over the uploader drop area */
 	max-width: 100%;
 	max-height: 90%;
 	max-height: calc( 100% - 42px ); /* leave space for actions underneath */
-	background-image: linear-gradient(45deg, #c4c4c4 25%, transparent 25%, transparent 75%, #c4c4c4 75%, #c4c4c4), linear-gradient(45deg, #c4c4c4 25%, transparent 25%, transparent 75%, #c4c4c4 75%, #c4c4c4);
+	background-image: linear-gradient(45deg, #c3c4c7 25%, transparent 25%, transparent 75%, #c3c4c7 75%, #c3c4c7), linear-gradient(45deg, #c3c4c7 25%, transparent 25%, transparent 75%, #c3c4c7 75%, #c3c4c7);
 	background-position: 0 0, 10px 10px;
 	background-size: 20px 20px;
 }
@@ -769,8 +769,8 @@ border color while dragging a file over the uploader drop area */
 	height: 100%;
 	box-shadow: inset 0px 4px 4px -4px rgba(0, 0, 0, 0.1);
 	border-bottom: 0;
-	border-left: 1px solid #ddd;
-	background: #f3f3f3;
+	border-left: 1px solid #dcdcde;
+	background: #f6f7f7;
 }
 
 .edit-attachment-frame .attachment-info .details,
@@ -780,12 +780,12 @@ border color while dragging a file over the uploader drop area */
 	float: none;
 	margin-bottom: 15px;
 	padding-bottom: 15px;
-	border-bottom: 1px solid #ddd;
+	border-bottom: 1px solid #dcdcde;
 }
 
 .edit-attachment-frame .attachment-info .filename {
 	font-weight: 400;
-	color: #666;
+	color: #646970;
 }
 
 .edit-attachment-frame .attachment-info .thumbnail {
@@ -813,7 +813,7 @@ border color while dragging a file over the uploader drop area */
 }
 
 .copy-to-clipboard-container .success {
-	color: #40860a;
+	color: #008a20;
 	margin-left: 8px;
 }
 
@@ -918,7 +918,7 @@ border color while dragging a file over the uploader drop area */
 .imgedit-settings .disabled {
 	/* WCAG 1.4.3 Text or images of text that are part of an inactive user
 	   interface component ... have no contrast requirement. */
-	color: #a0a5aa;
+	color: #a7aaad;
 }
 
 .A1B1 {
@@ -971,9 +971,9 @@ border color while dragging a file over the uploader drop area */
 }
 
 .imgedit-menu .button.disabled {
-	color: #a0a5aa;
-	border-color: #ddd;
-	background: #f7f7f7;
+	color: #a7aaad;
+	border-color: #dcdcde;
+	background: #f6f7f7;
 	box-shadow: none;
 	text-shadow: 0 1px 0 #fff;
 	cursor: default;
@@ -1013,7 +1013,7 @@ border color while dragging a file over the uploader drop area */
 }
 
 .imgedit-crop-wrap img {
-	background-image: linear-gradient(45deg, #c4c4c4 25%, transparent 25%, transparent 75%, #c4c4c4 75%, #c4c4c4), linear-gradient(45deg, #c4c4c4 25%, transparent 25%, transparent 75%, #c4c4c4 75%, #c4c4c4);
+	background-image: linear-gradient(45deg, #c3c4c7 25%, transparent 25%, transparent 75%, #c3c4c7 75%, #c3c4c7), linear-gradient(45deg, #c3c4c7 25%, transparent 25%, transparent 75%, #c3c4c7 75%, #c3c4c7);
 	background-position: 0 0, 10px 10px;
 	background-size: 20px 20px;
 }
@@ -1064,7 +1064,7 @@ border color while dragging a file over the uploader drop area */
 
 #poststuff .imgedit-group-top .button-link {
 	text-decoration: none;
-	color: #23282d;
+	color: #1d2327;
 }
 
 .imgedit-applyto .imgedit-label {
@@ -1089,7 +1089,7 @@ border color while dragging a file over the uploader drop area */
 	margin: -1px 0 0 -1px;
 	padding: 0;
 	background: transparent;
-	color: #0074a2;
+	color: #2271b1;
 	font-size: 20px;
 	line-height: 1;
 	cursor: pointer;
@@ -1098,9 +1098,9 @@ border color while dragging a file over the uploader drop area */
 }
 
 .image-editor .imgedit-settings .imgedit-help-toggle:focus {
-	color: #0074a2;
-	border-color: #5b9dd9;
-	box-shadow: 0 0 3px rgba(0, 115, 170, 0.8);
+	color: #2271b1;
+	border-color: #4f94d4;
+	box-shadow: 0 0 3px rgba(34, 113, 177, 0.8);
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
 }
@@ -1124,7 +1124,7 @@ border color while dragging a file over the uploader drop area */
 }
 
 span.imgedit-scale-warn {
-	color: #dc3232;
+	color: #d63638;
 	font-size: 20px;
 	font-style: normal;
 	visibility: hidden;
@@ -1161,7 +1161,7 @@ span.imgedit-scale-warn {
 	width: 7px;
 	text-align: center;
 	font-size: 13px;
-	color: #444;
+	color: #3c434a;
 }
 
 .imgedit-settings .imgedit-scale-button-wrapper {

--- a/src/wp-admin/css/nav-menus.css
+++ b/src/wp-admin/css/nav-menus.css
@@ -66,7 +66,7 @@ ul.add-menu-item-tabs li {
 }
 
 .is-submenu {
-	color: #555d66; /* #fafafa background */
+	color: #50575e; /* #fafafa background */
 	font-style: italic;
 	font-weight: 400;
 	margin-left: 4px;
@@ -76,7 +76,7 @@ ul.add-menu-item-tabs li {
 	margin-top: 23px;
 	padding: 10px;
 	overflow: hidden;
-	background: #fbfbfb;
+	background: #fff;
 }
 
 .manage-menus .selected-menu,
@@ -98,7 +98,7 @@ ul.add-menu-item-tabs li {
 }
 
 .menu-settings {
-	border-top: 1px solid #eee;
+	border-top: 1px solid #f0f0f1;
 	margin-top: 2em;
 }
 
@@ -135,7 +135,7 @@ ul.add-menu-item-tabs li {
 }
 
 .theme-location-set {
-	color: #72777c;
+	color: #787c82;
 	font-size: 11px;
 }
 
@@ -163,18 +163,18 @@ ul.add-menu-item-tabs li {
 .nav-menus-php #post-body {
 	padding: 0 10px;
 	border-top: 1px solid #fff;
-	border-bottom: 1px solid #ddd;
+	border-bottom: 1px solid #dcdcde;
 	background: #fff;
 }
 
 #nav-menu-header,
 #nav-menu-footer {
 	padding: 0 10px;
-	background: #f5f5f5;
+	background: #f6f7f7;
 }
 
 #nav-menu-header {
-	border-bottom: 1px solid #ddd;
+	border-bottom: 1px solid #dcdcde;
 	margin-bottom: 0;
 }
 
@@ -251,7 +251,7 @@ ul.add-menu-item-tabs li {
 
 .locations-edit-menu-link {
 	padding-right: 3px;
-	border-right: 1px solid #ccc;
+	border-right: 1px solid #c3c4c7;
 }
 
 #menu-management .inside {
@@ -440,7 +440,7 @@ ul.add-menu-item-tabs li {
 }
 
 .menu-item-bar .menu-item-handle {
-	border: 1px solid #ddd;
+	border: 1px solid #dcdcde;
 	position: relative;
 	padding: 10px 15px;
 	height: auto;
@@ -452,12 +452,12 @@ ul.add-menu-item-tabs li {
 }
 
 .menu-item-bar .menu-item-handle:hover {
-	border-color: #999;
+	border-color: #8c8f94;
 }
 
 #menu-to-edit .menu-item-invalid .menu-item-handle {
-	background: #f6c9cc;
-	border-color: #f1acb1;
+	background: #facfd2;
+	border-color: #ffabaf;
 }
 
 .no-js .menu-item-edit-active .item-edit {
@@ -470,7 +470,7 @@ ul.add-menu-item-tabs li {
 
 .menu li.deleting .menu-item-handle {
 	background-image: none;
-	background-color: #f66;
+	background-color: #f86368;
 }
 
 .menu-item-handle .item-title {
@@ -483,7 +483,7 @@ ul.add-menu-item-tabs li {
 }
 
 .menu-item-handle .menu-item-title.no-title {
-	color: #72777c;
+	color: #787c82;
 }
 
 /* Sortables */
@@ -550,7 +550,7 @@ body.menu-max-depth-11 { min-width: 1280px !important; }
 .item-type {
 	display: inline-block;
 	padding: 12px 16px;
-	color: #666;
+	color: #646970;
 	font-size: 12px;
 	line-height: 1.5;
 }
@@ -591,7 +591,7 @@ body.menu-max-depth-11 { min-width: 1280px !important; }
 	height: auto;
 	margin: 12px -10px 12px 0;
 	padding: 0;
-	color: #0073aa;
+	color: #2271b1;
 	text-decoration: underline;
 	font-size: 12px;
 	line-height: 1.5;
@@ -628,8 +628,8 @@ body.menu-max-depth-11 { min-width: 1280px !important; }
 
 .nav-menus-php .item-edit:focus:before {
 	box-shadow:
-		0 0 0 1px #5b9dd9,
-		0 0 2px 1px rgba(30, 140, 190, 0.8);
+		0 0 0 1px #4f94d4,
+		0 0 2px 1px rgba(79, 148, 212, 0.8);
 }
 
 /* Menu editing */
@@ -643,7 +643,7 @@ body.menu-max-depth-11 { min-width: 1280px !important; }
 	padding: 10px;
 	position: relative;
 	z-index: 10; /* Keep .item-title's shadow from appearing on top of .menu-item-settings */
-	border: 1px solid #ccd0d4;
+	border: 1px solid #c3c4c7;
 	border-top: none;
 	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
 }
@@ -689,8 +689,8 @@ body.menu-max-depth-11 { min-width: 1280px !important; }
 	display: block;
 	margin: 0 0 15px;
 	padding: 3px 5px 5px;
-	border: 1px solid #ddd;
-	color: #72777c;
+	border: 1px solid #dcdcde;
+	color: #787c82;
 	font-size: 12px;
 }
 

--- a/src/wp-admin/css/revisions.css
+++ b/src/wp-admin/css/revisions.css
@@ -42,7 +42,7 @@
 .revisions-tickmarks > div {
 	position: absolute;
 	height: 100%;
-	border-left: 1px solid #a0a5aa;
+	border-left: 1px solid #a7aaad;
 	box-sizing: border-box;
 }
 
@@ -131,11 +131,11 @@ body.folded .revisions .loading-indicator {
 }
 
 .revisions-controls .author-card .date {
-	color: #72777c;
+	color: #787c82;
 }
 
 .revisions-controls .author-card.autosave {
-	color: #d54e21;
+	color: #d63638;
 }
 
 .revisions-controls .author-card .author-name {
@@ -242,16 +242,16 @@ table.diff .diff-addedline ins {
 
 table.diff .diff-deletedline {
 	position: relative;
-	background-color: #ffe9e9;
+	background-color: #fcf0f1;
 }
 
 table.diff .diff-deletedline del {
-	background-color: #faa;
+	background-color: #ffabaf;
 }
 
 table.diff .diff-addedline {
 	position: relative;
-	background-color: #e9ffe9;
+	background-color: #edfaef;
 }
 
 table.diff .diff-deletedline .dashicons,
@@ -271,7 +271,7 @@ table.diff .diff-addedline .dashicons {
 }
 
 table.diff .diff-addedline ins {
-	background-color: #afa;
+	background-color: #68de7c;
 }
 
 .diff-meta {
@@ -384,7 +384,7 @@ table.diff .diff-addedline ins {
 
 .revisions-tooltip,
 .revisions-tooltip-arrow > span {
-	border: 1px solid #ddd;
+	border: 1px solid #dcdcde;
 	background-color: #fff;
 }
 
@@ -445,7 +445,7 @@ div.revisions-controls > .wp-slider > .ui-slider-handle {
 /* jQuery UI Slider */
 .wp-slider.ui-slider {
 	position: relative;
-	border: 1px solid #ddd;
+	border: 1px solid #dcdcde;
 	text-align: left;
 	cursor: pointer;
 }
@@ -464,21 +464,21 @@ div.revisions-controls > .wp-slider > .ui-slider-handle {
 
 .wp-slider .ui-slider-handle,
 .wp-slider .ui-slider-handle.focus {
-	background: #f7f7f7;
-	border: 1px solid #ccc;
-	box-shadow: 0 1px 0 #cccccc;
+	background: #f6f7f7;
+	border: 1px solid #c3c4c7;
+	box-shadow: 0 1px 0 #c3c4c7;
 }
 
 .wp-slider .ui-slider-handle:hover,
 .wp-slider .ui-slider-handle.ui-state-hover {
-	background: #fafafa;
-	border-color: #999;
+	background: #f6f7f7;
+	border-color: #8c8f94;
 }
 
 .wp-slider .ui-slider-handle:active,
 .wp-slider .ui-slider-handle.ui-state-active {
-	background: #eee;
-	border-color: #999;
+	background: #f0f0f1;
+	border-color: #8c8f94;
 	box-shadow: inset 0 2px 5px -3px rgba(0, 0, 0, 0.5);
 	transform: translateY(1px);
 }
@@ -488,7 +488,7 @@ div.revisions-controls > .wp-slider > .ui-slider-handle {
 	position: absolute;
 	top: 2px;
 	left: 2px;
-	color: #555;
+	color: #50575e;
 	content: "\f229";
 	font: normal 18px/1 dashicons;
 	speak: never;
@@ -498,7 +498,7 @@ div.revisions-controls > .wp-slider > .ui-slider-handle {
 
 .wp-slider .ui-slider-handle:hover:before,
 .wp-slider .ui-slider-handle.ui-state-hover:before {
-	color: #23282d;
+	color: #1d2327;
 }
 
 .wp-slider .ui-slider-handle.from-handle:before,

--- a/src/wp-admin/css/site-health.css
+++ b/src/wp-admin/css/site-health.css
@@ -26,7 +26,7 @@
 	text-align: center;
 	margin: 0 0 1rem;
 	background: #fff;
-	border-bottom: 1px solid #e2e4e7;
+	border-bottom: 1px solid #dcdcde;
 }
 
 .health-check-title-section {
@@ -67,34 +67,34 @@
 
 .loading .site-health-progress svg #bar {
 	stroke-dashoffset: 0;
-	stroke: #adc5d2;
+	stroke: #c3c4c7;
 	animation: loadingPulse 3s infinite ease-in-out;
 }
 
 .site-health-progress svg circle {
 	stroke-dashoffset: 0;
 	transition: stroke-dashoffset 1s linear;
-	stroke: #ccc;
+	stroke: #c3c4c7;
 	stroke-width: 2em;
 }
 
 .site-health-progress svg #bar {
 	stroke-dashoffset: 565;
-	stroke: #dc3232;
+	stroke: #d63638;
 }
 
 .green .site-health-progress #bar {
-	stroke: #46b450;
+	stroke: #00a32a;
 }
 .green .site-health-progress .site-health-progress-label {
-	color: #46b450;
+	color: #00a32a;
 }
 
 .orange .site-health-progress #bar {
-	stroke: #ffb900;
+	stroke: #dba617;
 }
 .orange .site-health-progress .site-health-progress-label {
-	color: #ffb900;
+	color: #dba617;
 }
 
 .site-health-progress-label {
@@ -105,13 +105,13 @@
 
 @keyframes loadingPulse {
 	0% {
-		stroke: #adc5d2;
+		stroke: #c3c4c7;
 	}
 	50% {
-		stroke: #00a0d2;
+		stroke: #72aee6;
 	}
 	100% {
-		stroke: #adc5d2;
+		stroke: #c3c4c7;
 	}
 }
 
@@ -143,13 +143,13 @@
 }
 
 .health-check-tab:focus {
-	color: #191e23;
-	outline: 1px solid #6c7781;
+	color: #1d2327;
+	outline: 1px solid #787c82;
 	box-shadow: none;
 }
 
 .health-check-tab.active {
-	box-shadow: inset 0 -3px #007cba;
+	box-shadow: inset 0 -3px #3582c4;
 	font-weight: 600;
 }
 
@@ -178,23 +178,23 @@
 .health-check-body .pass::before,
 .health-check-body .good::before {
 	content: "\f147";
-	color: #46b450;
+	color: #00a32a;
 }
 
 .health-check-body .warning::before {
 	content: "\f460";
-	color: #ffb900;
+	color: #dba617;
 }
 
 .health-check-body .info::before {
 	content: "\f348";
-	color: #00a0d2;
+	color: #72aee6;
 }
 
 .health-check-body .fail::before,
 .health-check-body .error::before {
 	content: "\f335";
-	color: #dc3232;
+	color: #d63638;
 }
 
 .site-health-copy-buttons {
@@ -208,7 +208,7 @@
 }
 
 .site-health-copy-buttons .success {
-	color: #40860a;
+	color: #008a20;
 	margin-left: 0.5rem;
 }
 
@@ -266,12 +266,12 @@
 }
 
 .health-check-accordion {
-	border: 1px solid #ccd0d4;
+	border: 1px solid #c3c4c7;
 }
 
 .health-check-accordion-heading {
 	margin: 0;
-	border-top: 1px solid #ccd0d4;
+	border-top: 1px solid #c3c4c7;
 	font-size: inherit;
 	line-height: inherit;
 	font-weight: 600;
@@ -285,7 +285,7 @@
 .health-check-accordion-trigger {
 	background: #fff;
 	border: 0;
-	color: #32373c;
+	color: #2c3338;
 	cursor: pointer;
 	display: flex;
 	font-weight: 400;
@@ -310,16 +310,16 @@
 
 .health-check-accordion-trigger:hover,
 .health-check-accordion-trigger:active {
-	background: #f8f9f9;
+	background: #f6f7f7;
 }
 
 .health-check-accordion-trigger:focus {
-	color: #191e23;
+	color: #1d2327;
 	border: none;
 	box-shadow: none;
 	outline-offset: -1px;
-	outline: 2px solid #0071a1;
-	background-color: #f8f9f9;
+	outline: 2px solid #2271b1;
+	background-color: #f6f7f7;
 }
 
 .health-check-accordion-trigger .title {
@@ -330,7 +330,7 @@
 
 .health-check-accordion-trigger .icon,
 .site-health-view-passed .icon {
-	border: solid #555d66;
+	border: solid #50575e;
 	border-width: 0 2px 2px 0;
 	height: 0.5rem;
 	pointer-events: none;
@@ -343,33 +343,33 @@
 
 .health-check-accordion-trigger .badge {
 	padding: 0.1rem 0.5rem 0.15rem;
-	color: #32373c;
+	color: #2c3338;
 	font-weight: 600;
 	margin-left: 0.5rem;
 }
 
 .health-check-accordion-trigger .badge.blue {
-	border: 1px solid #bfe7f3;
+	border: 1px solid #c5d9ed;
 }
 
 .health-check-accordion-trigger .badge.orange {
-	border: 1px solid #ffb900;
+	border: 1px solid #dba617;
 }
 
 .health-check-accordion-trigger .badge.red {
-	border: 1px solid #dc3232;
+	border: 1px solid #d63638;
 }
 
 .health-check-accordion-trigger .badge.green {
-	border: 1px solid #46b450;
+	border: 1px solid #00a32a;
 }
 
 .health-check-accordion-trigger .badge.purple {
-	border: 1px solid #826eb4;
+	border: 1px solid #2271b1;
 }
 
 .health-check-accordion-trigger .badge.gray {
-	border: 1px solid #ccd0d4;
+	border: 1px solid #c3c4c7;
 }
 
 .health-check-accordion-trigger[aria-expanded="true"] .icon,

--- a/src/wp-admin/css/themes.css
+++ b/src/wp-admin/css/themes.css
@@ -56,7 +56,7 @@ body.js .theme-browser.search-loading {
 	margin: 0 4% 4% 0;
 	position: relative;
 	width: 30.6%;
-	border: 1px solid #ddd;
+	border: 1px solid #dcdcde;
 	box-shadow: 0 1px 1px -1px rgba(0, 0, 0, 0.1);
 	box-sizing: border-box;
 }
@@ -90,7 +90,7 @@ body.js .theme-browser.search-loading {
 	opacity: 0;
 	transition: opacity 0.1s ease-in-out;
 	height: auto;
-	background: rgba(244, 244, 244, 0.7);
+	background: rgba(246, 247, 247, 0.7);
 	border-left: 1px solid rgba(0, 0, 0, 0.05);
 }
 
@@ -156,7 +156,7 @@ body.js .theme-browser.search-loading {
 	top: 35%;
 	right: 20%;
 	left: 20%;
-	background: #23282d;
+	background: #1d2327;
 	background: rgba(0, 0, 0, 0.7);
 	color: #fff;
 	font-size: 15px;
@@ -170,8 +170,8 @@ body.js .theme-browser.search-loading {
 }
 
 .theme-browser .theme:focus {
-	border-color: #5b9dd9;
-	box-shadow: 0 0 2px rgba(30, 140, 190, 0.8);
+	border-color: #4f94d4;
+	box-shadow: 0 0 2px rgba(79, 148, 212, 0.8);
 }
 
 .theme-browser .theme:focus .more-details {
@@ -193,7 +193,7 @@ body.js .theme-browser.search-loading {
  * The currently active theme
  */
 .theme-browser .theme.active .theme-name {
-	background: #23282d;
+	background: #1d2327;
 	color: #fff;
 	padding-right: 110px;
 	font-weight: 300;
@@ -209,7 +209,7 @@ body.js .theme-browser.search-loading {
 }
 
 .theme-browser .theme.active .theme-actions {
-	background: rgba(49, 49, 49, 0.7);
+	background: rgba(44, 51, 56, 0.7);
 	border-left: none;
 	opacity: 1;
 }
@@ -233,8 +233,8 @@ body.js .theme-browser.search-loading {
 }
 
 .theme-browser .theme .theme-author {
-	background: #23282d;
-	color: #eee;
+	background: #1d2327;
+	color: #f0f0f1;
 	display: none;
 	font-size: 14px;
 	margin: 0 10px;
@@ -278,14 +278,14 @@ body.js .theme-browser.search-loading {
 	bottom: 0;
 	padding: 0;
 	text-shadow: none;
-	border: 5px dashed #d5d2ca;
+	border: 5px dashed #dcdcde;
 	border: 5px dashed rgba(0, 0, 0, 0.1);
 	box-sizing: border-box;
 }
 
 .theme-browser .theme.add-new-theme span:after {
-	background: #e5e5e5;
-	background: rgba(153, 153, 153, 0.1);
+	background: #dcdcde;
+	background: rgba(140, 143, 148, 0.1);
 	border-radius: 50%;
 	display: inline-block;
 	content: "\f132";
@@ -295,7 +295,7 @@ body.js .theme-browser.search-loading {
 	height: 100px;
 	vertical-align: middle;
 	text-align: center;
-	color: rgb(153, 153, 153);
+	color: #8c8f94;
 	position: absolute;
 	top: 30%;
 	left: 50%;
@@ -318,14 +318,14 @@ body.js .theme-browser.search-loading {
 .theme-browser .theme.add-new-theme a:hover span:after,
 .theme-browser .theme.add-new-theme a:focus span:after {
 	background: #fff;
-	color: #0073aa;
+	color: #2271b1;
 }
 
 .theme-browser .theme.add-new-theme a:hover:after,
 .theme-browser .theme.add-new-theme a:focus:after {
 	border-color: transparent;
 	color: #fff;
-	background: #0073aa;
+	background: #2271b1;
 	content: "";
 }
 
@@ -357,8 +357,8 @@ body.js .theme-browser.search-loading {
 	right: 0;
 	top: 0;
 	bottom: 0;
-	background: #f1f1f1;
-	background: rgba(238, 238, 238, 0.9);
+	background: #f0f0f1;
+	background: rgba(240, 240, 241, 0.9);
 	z-index: 10000; /* Over WP Pointers. */
 }
 
@@ -368,7 +368,7 @@ body.js .theme-browser.search-loading {
 	left: 0;
 	right: 0;
 	height: 48px;
-	border-bottom: 1px solid #ddd;
+	border-bottom: 1px solid #dcdcde;
 }
 
 .theme-overlay .theme-header button {
@@ -382,14 +382,14 @@ body.js .theme-browser.search-loading {
 	text-align: center;
 	float: right;
 	border: 0;
-	border-left: 1px solid #ddd;
+	border-left: 1px solid #dcdcde;
 	background-color: transparent;
 	transition: color .1s ease-in-out, background .1s ease-in-out;
 }
 
 .theme-overlay .theme-header .close:before {
 	font: normal 22px/50px dashicons !important;
-	color: #72777c;
+	color: #787c82;
 	display: inline-block;
 	content: "\f335";
 	font-weight: 300;
@@ -399,14 +399,14 @@ body.js .theme-browser.search-loading {
 .theme-overlay .theme-header .right,
 .theme-overlay .theme-header .left {
 	cursor: pointer;
-	color: #72777c;
+	color: #787c82;
 	background-color: transparent;
 	height: 48px;
 	width: 54px;
 	float: left;
 	text-align: center;
 	border: 0;
-	border-right: 1px solid #ddd;
+	border-right: 1px solid #dcdcde;
 	transition: color .1s ease-in-out, background .1s ease-in-out;
 }
 
@@ -416,8 +416,8 @@ body.js .theme-browser.search-loading {
 .theme-overlay .theme-header .right:hover,
 .theme-overlay .theme-header .left:focus,
 .theme-overlay .theme-header .left:hover {
-	background: #ddd;
-	border-color: #ccc;
+	background: #dcdcde;
+	border-color: #c3c4c7;
 	color: #000;
 }
 
@@ -437,7 +437,7 @@ body.js .theme-browser.search-loading {
 .theme-overlay .theme-header .right.disabled,
 .theme-overlay .theme-header .left.disabled:hover,
 .theme-overlay .theme-header .right.disabled:hover {
-	color: #ccc;
+	color: #c3c4c7;
 	background: inherit;
 	cursor: inherit;
 }
@@ -492,10 +492,10 @@ body.folded .theme-browser ~ .theme-overlay .theme-wrap {
 	left: 0;
 	right: 0;
 	padding: 10px 25px 5px;
-	background: #f3f3f3;
+	background: #f6f7f7;
 	z-index: 30;
 	box-sizing: border-box;
-	border-top: 1px solid #eee;
+	border-top: 1px solid #f0f0f1;
 }
 
 .theme-overlay .theme-actions a {
@@ -511,7 +511,7 @@ body.folded .theme-browser ~ .theme-overlay .theme-wrap {
 
 .broken-themes a.delete-theme,
 .theme-overlay .theme-actions .delete-theme {
-	color: #a00;
+	color: #d63638;
 	text-decoration: none;
 	border-color: transparent;
 	box-shadow: none;
@@ -528,9 +528,9 @@ body.folded .theme-browser ~ .theme-overlay .theme-wrap {
 .broken-themes a.delete-theme:focus,
 .theme-overlay .theme-actions .delete-theme:hover,
 .theme-overlay .theme-actions .delete-theme:focus {
-	background: #d54e21;
+	background: #d63638;
 	color: #fff;
-	border-color: #d54e21;
+	border-color: #d63638;
 }
 
 .theme-overlay .theme-actions .active-theme,
@@ -588,8 +588,8 @@ body.folded .theme-browser ~ .theme-overlay .theme-wrap {
 
 /* Other screenshots, shown small and square */
 .theme-overlay .screenshot.thumb {
-	background: #ccc;
-	border: 1px solid #eee;
+	background: #c3c4c7;
+	border: 1px solid #f0f0f1;
 	float: none;
 	display: inline-block;
 	margin: 10px 5px 0;
@@ -616,7 +616,7 @@ body.folded .theme-browser ~ .theme-overlay .theme-wrap {
 
 .theme-overlay .screenshot.selected {
 	background: transparent;
-	border: 2px solid #00a0d2;
+	border: 2px solid #72aee6;
 }
 
 .theme-overlay .screenshot.selected img {
@@ -638,7 +638,7 @@ body.folded .theme-browser ~ .theme-overlay .theme-wrap {
 }
 
 .theme-overlay .current-label {
-	background: #32373c;
+	background: #2c3338;
 	color: #fff;
 	font-size: 11px;
 	display: inline-block;
@@ -651,7 +651,7 @@ body.folded .theme-browser ~ .theme-overlay .theme-wrap {
 }
 
 .theme-overlay .theme-name {
-	color: #23282d;
+	color: #1d2327;
 	font-size: 32px;
 	font-weight: 100;
 	margin: 10px 0 0;
@@ -661,7 +661,7 @@ body.folded .theme-browser ~ .theme-overlay .theme-wrap {
 }
 
 .theme-overlay .theme-version {
-	color: #72777c;
+	color: #787c82;
 	font-size: 13px;
 	font-weight: 400;
 	float: none;
@@ -671,7 +671,7 @@ body.folded .theme-browser ~ .theme-overlay .theme-wrap {
 
 .theme-overlay .theme-author {
 	margin: 15px 0 25px;
-	color: #72777c;
+	color: #787c82;
 	font-size: 16px;
 	font-weight: 400;
 	line-height: inherit;
@@ -695,7 +695,7 @@ body.folded .theme-browser ~ .theme-overlay .theme-wrap {
 }
 
 .theme-overlay .theme-description {
-	color: #555;
+	color: #50575e;
 	font-size: 15px;
 	font-weight: 400;
 	line-height: 1.5;
@@ -703,8 +703,8 @@ body.folded .theme-browser ~ .theme-overlay .theme-wrap {
 }
 
 .theme-overlay .theme-tags {
-	border-top: 3px solid #eee;
-	color: #82878c;
+	border-top: 3px solid #f0f0f1;
+	color: #8c8f94;
 	font-size: 13px;
 	font-weight: 400;
 	margin: 30px 0 0 0;
@@ -712,15 +712,15 @@ body.folded .theme-browser ~ .theme-overlay .theme-wrap {
 }
 
 .theme-overlay .theme-tags span {
-	color: #444;
+	color: #3c434a;
 	font-weight: 600;
 	margin-right: 5px;
 }
 
 .theme-overlay .parent-theme {
-	background: #f7fcfe;
-	border: 1px solid #eee;
-	border-left: 4px solid #00a0d2;
+	background: #fff;
+	border: 1px solid #f0f0f1;
+	border-left: 4px solid #72aee6;
 	font-size: 14px;
 	font-weight: 400;
 	margin-top: 30px;
@@ -1000,11 +1000,11 @@ body.folded .theme-browser ~ .theme-overlay .theme-wrap {
 
 /* Already installed theme */
 .theme-browser .theme .theme-installed {
-	background: #0073aa;
+	background: #2271b1;
 }
 
 .theme-browser .theme .notice-success p:before {
-	color: #79ba49;
+	color: #68de7c;
 	content: "\f147";
 	display: inline-block;
 	font: normal 20px/1 'dashicons';
@@ -1057,8 +1057,8 @@ body.folded .theme-browser ~ .theme-overlay .theme-wrap {
 
 .upload-theme .wp-upload-form,
 .upload-plugin .wp-upload-form {
-	background: #fafafa;
-	border: 1px solid #ccd0d4;
+	background: #f6f7f7;
+	border: 1px solid #c3c4c7;
 	padding: 30px;
 	margin: 30px auto;
 	display: inline-flex;
@@ -1073,7 +1073,7 @@ body.folded .theme-browser ~ .theme-overlay .theme-wrap {
 
 .upload-theme .install-help,
 .upload-plugin .install-help {
-	color: #555d66; /* #f1f1f1 background */
+	color: #50575e; /* #f1f1f1 background */
 	font-size: 18px;
 	font-style: normal;
 	margin: 0;
@@ -1084,7 +1084,7 @@ body.folded .theme-browser ~ .theme-overlay .theme-wrap {
 p.no-themes,
 p.no-themes-local {
 	clear: both;
-	color: #666;
+	color: #646970;
 	font-size: 18px;
 	font-style: normal;
 	margin: 0;
@@ -1123,7 +1123,7 @@ p.no-themes-local {
 .theme-details .num-ratings,
 .theme-details .no-rating {
 	font-size: 11px;
-	color: #72777c;
+	color: #787c82;
 }
 
 .theme-details .no-rating {
@@ -1132,8 +1132,8 @@ p.no-themes-local {
 }
 
 .update-from-upload-comparison {
-	border-top: 1px solid #ddd;
-	border-bottom: 1px solid #ddd;
+	border-top: 1px solid #dcdcde;
+	border-bottom: 1px solid #dcdcde;
 	text-align: left;
 	margin: 1rem 0 1.4rem;
 	border-collapse: collapse;
@@ -1161,7 +1161,7 @@ p.no-themes-local {
 }
 
 .update-from-upload-comparison td.warning {
-	color: #a00;
+	color: #d63638;
 }
 
 .update-from-upload-actions {
@@ -1173,7 +1173,7 @@ p.no-themes-local {
 ------------------------------------------------------------------------------*/
 
 .appearance_page_custom-header #headimg {
-	border: 1px solid #ddd;
+	border: 1px solid #dcdcde;
 	overflow: hidden;
 	width: 100%;
 }
@@ -1209,7 +1209,7 @@ p.no-themes-local {
 
 div#custom-background-image {
 	min-height: 100px;
-	border: 1px solid #ddd;
+	border: 1px solid #dcdcde;
 }
 
 div#custom-background-image img {
@@ -1218,16 +1218,16 @@ div#custom-background-image img {
 }
 
 .background-position-control input[type="radio"]:checked ~ .button {
-	background: #eee;
-	border-color: #999;
+	background: #f0f0f1;
+	border-color: #8c8f94;
 	box-shadow: inset 0 2px 5px -3px rgba(0, 0, 0, 0.5);
 	z-index: 1;
 }
 
 .background-position-control input[type="radio"]:focus ~ .button {
-	border-color: #5b9dd9;
-	box-shadow: inset 0 2px 5px -3px rgba(0, 0, 0, 0.5), 0 0 3px rgba(0, 115, 170, 0.8);
-	color: #23282d;
+	border-color: #4f94d4;
+	box-shadow: inset 0 2px 5px -3px rgba(0, 0, 0, 0.5), 0 0 3px rgba(34, 113, 177, 0.8);
+	color: #1d2327;
 }
 
 .background-position-control .background-position-center-icon,
@@ -1246,7 +1246,7 @@ div#custom-background-image img {
 }
 
 .background-position-control .background-position-center-icon:before {
-	background-color: #555;
+	background-color: #50575e;
 	border-radius: 50%;
 	content: "";
 	height: 12px;
@@ -1255,7 +1255,7 @@ div#custom-background-image img {
 
 .background-position-control .button:hover .background-position-center-icon:before,
 .background-position-control input[type="radio"]:focus ~ .button .background-position-center-icon:before {
-	background-color: #23282d;
+	background-color: #1d2327;
 }
 
 .background-position-control .button-group {
@@ -1280,7 +1280,7 @@ div#custom-background-image img {
 }
 
 .background-position-control .button-group:last-child .button {
-	box-shadow: 0 1px 0 #ccc;
+	box-shadow: 0 1px 0 #c3c4c7;
 }
 
 .background-position-control .button-group > label {
@@ -1363,7 +1363,7 @@ body.full-overlay-active {
 	padding: 0;
 	margin: 0;
 	z-index: 10;
-	background: #eee;
+	background: #f0f0f1;
 	border-right: none;
 }
 
@@ -1470,9 +1470,9 @@ body.full-overlay-active {
 	float: left;
 	width: 45px;
 	height: 45px;
-	background: #eee;
-	border-right: 1px solid #ddd;
-	color: #444;
+	background: #f0f0f1;
+	border-right: 1px solid #dcdcde;
+	color: #3c434a;
 	cursor: pointer;
 	text-decoration: none;
 	transition: color .1s ease-in-out, background .1s ease-in-out;
@@ -1484,8 +1484,8 @@ body.full-overlay-active {
 .theme-install-overlay .previous-theme:focus,
 .theme-install-overlay .next-theme:hover,
 .theme-install-overlay .next-theme:focus {
-	background: #ddd;
-	border-color: #ccc;
+	background: #dcdcde;
+	border-color: #c3c4c7;
 	color: #000;
 	outline: none;
 	box-shadow: none;
@@ -1521,8 +1521,8 @@ body.full-overlay-active {
 .theme-install-overlay .previous-theme.disabled:focus,
 .theme-install-overlay .next-theme.disabled:hover,
 .theme-install-overlay .next-theme.disabled:focus {
-	color: #b4b9be;
-	background: #eee;
+	color: #c3c4c7;
+	background: #f0f0f1;
 	cursor: default;
 	pointer-events: none;
 }
@@ -1549,7 +1549,7 @@ body.full-overlay-active {
 	left: 0;
 	padding: 9px 0 9px 10px;
 	height: 45px;
-	color: #656a6f;
+	color: #646970;
 	outline: 0;
 	line-height: 1;
 	background-color: transparent !important;
@@ -1560,7 +1560,7 @@ body.full-overlay-active {
 
 .wp-core-ui .wp-full-overlay .collapse-sidebar:hover,
 .wp-core-ui .wp-full-overlay .collapse-sidebar:focus {
-	color: #0073aa;
+	color: #2271b1;
 }
 
 .wp-full-overlay .collapse-sidebar-arrow,
@@ -1581,8 +1581,8 @@ body.full-overlay-active {
 .wp-full-overlay .collapse-sidebar:hover .collapse-sidebar-arrow,
 .wp-full-overlay .collapse-sidebar:focus .collapse-sidebar-arrow {
 	box-shadow:
-		0 0 0 1px #5b9dd9,
-		0 0 2px 1px rgba(30, 140, 190, 0.8);
+		0 0 0 1px #4f94d4,
+		0 0 2px 1px rgba(79, 148, 212, 0.8);
 }
 
 .wp-full-overlay .collapse-sidebar-label {
@@ -1596,7 +1596,7 @@ body.full-overlay-active {
 .wp-full-overlay .collapse-sidebar-arrow:before {
 	display: block;
 	content: "\f148";
-	background: #eee;
+	background: #f0f0f1;
 	font: normal 20px/1 dashicons;
 	speak: never;
 	padding: 0;
@@ -1630,11 +1630,11 @@ body.full-overlay-active {
 /* Device/preview size toggles */
 
 .wp-full-overlay {
-	background: #191e23;
+	background: #1d2327;
 }
 
 .wp-full-overlay-main {
-	background-color: #f1f1f1;
+	background-color: #f0f0f1;
 }
 
 .expanded .wp-full-overlay-footer {
@@ -1646,8 +1646,8 @@ body.full-overlay-active {
 	width: 18%;
 	width: calc( 18% - 1px );
 	height: 45px;
-	border-top: 1px solid #ddd;
-	background: #eee;
+	border-top: 1px solid #dcdcde;
+	background: #f0f0f1;
 }
 
 .wp-full-overlay-footer .devices-wrapper {
@@ -1656,8 +1656,8 @@ body.full-overlay-active {
 
 .wp-full-overlay-footer .devices {
 	position: relative;
-	background: #eee;
-	box-shadow: -20px 0 10px -5px #eee;
+	background: #f0f0f1;
+	box-shadow: -20px 0 10px -5px #f0f0f1;
 }
 
 .wp-full-overlay-footer .devices button {
@@ -1688,11 +1688,11 @@ body.full-overlay-active {
 	vertical-align: top;
 	margin: 3px 0;
 	padding: 4px 8px;
-	color: #656a6f;
+	color: #646970;
 }
 
 .wp-full-overlay-footer .devices button.active {
-	border-bottom-color: #191e23;
+	border-bottom-color: #1d2327;
 }
 
 .wp-full-overlay-footer .devices button:hover,
@@ -1702,16 +1702,16 @@ body.full-overlay-active {
 
 .wp-full-overlay-footer .devices button:focus,
 .wp-full-overlay-footer .devices button.active:hover {
-	border-bottom-color: #0073aa;
+	border-bottom-color: #2271b1;
 }
 
 .wp-full-overlay-footer .devices button.active:before {
-	color: #191e23;
+	color: #1d2327;
 }
 
 .wp-full-overlay-footer .devices button:hover:before,
 .wp-full-overlay-footer .devices button:focus:before {
-	color: #0073aa;
+	color: #2271b1;
 }
 
 .wp-full-overlay-footer .devices .preview-desktop:before {
@@ -1770,7 +1770,7 @@ body.full-overlay-active {
 
 #customize-container,
 #customize-controls .notice.notification-overlay {
-	background: #eee;
+	background: #f0f0f1;
 	z-index: 500000;
 	position: fixed;
 	overflow: visible;
@@ -1842,7 +1842,7 @@ body.full-overlay-active {
 .install-theme-info .theme-screenshot {
 	margin: 15px 0;
 	width: 258px;
-	border: 1px solid #ccc;
+	border: 1px solid #c3c4c7;
 }
 
 .install-theme-info .theme-details {
@@ -1855,7 +1855,7 @@ body.full-overlay-active {
 
 .theme-details .theme-description {
 	float: left;
-	color: #72777c;
+	color: #787c82;
 	line-height: 1.6;
 	max-width: 100%;
 }
@@ -1866,24 +1866,24 @@ body.full-overlay-active {
 }
 
 .theme-install-overlay .wp-full-overlay-sidebar {
-	background: #eee;
-	border-right: 1px solid #ddd;
+	background: #f0f0f1;
+	border-right: 1px solid #dcdcde;
 }
 
 .theme-install-overlay .wp-full-overlay-sidebar-content {
 	background: #fff;
-	border-top: 1px solid #ddd;
-	border-bottom: 1px solid #ddd;
+	border-top: 1px solid #dcdcde;
+	border-bottom: 1px solid #dcdcde;
 }
 
 .theme-install-overlay .wp-full-overlay-main {
 	position: absolute;
 	z-index: 0;
-	background-color: #f1f1f1;
+	background-color: #f0f0f1;
 }
 
 .customize-loading #customize-container {
-	background-color: #f1f1f1;
+	background-color: #f0f0f1;
 }
 
 #customize-preview.wp-full-overlay-main:before,

--- a/src/wp-admin/css/widgets.css
+++ b/src/wp-admin/css/widgets.css
@@ -16,7 +16,7 @@
 .widget-top {
 	font-size: 13px;
 	font-weight: 600;
-	background: #f7f7f7;
+	background: #f6f7f7;
 }
 
 .widget-top .widget-action {
@@ -54,12 +54,12 @@
 .in-widget-title,
 #widgets-right a.widget-control-edit,
 #available-widgets .widget-description {
-	color: #666;
+	color: #646970;
 }
 
 .deleting .widget-title,
 .deleting .widget-top .widget-action .toggle-indicator:before {
-	color: #a0a5aa;
+	color: #a7aaad;
 }
 
 /* Media Widgets */
@@ -91,7 +91,7 @@
 
 .media-widget-control .attachment-media-view .button-add-media,
 .media-widget-control .placeholder {
-	border: 1px dashed #b4b9be;
+	border: 1px dashed #c3c4c7;
 	box-sizing: border-box;
 	cursor: pointer;
 	line-height: 1.6;
@@ -103,19 +103,19 @@
 
 .media-widget-control .attachment-media-view .button-add-media {
 	cursor: pointer;
-	background-color: #edeff0;
-	color: #32373c;
+	background-color: #f0f0f1;
+	color: #2c3338;
 }
 
 .media-widget-control .attachment-media-view .button-add-media:hover {
-	background-color: #fbfbfc;
+	background-color: #fff;
 }
 
 .media-widget-control .attachment-media-view .button-add-media:focus {
-	background-color: #fbfbfc;
+	background-color: #fff;
 	border-style: solid;
-	border-color: #5b9dd9;
-	box-shadow: 0 0 3px rgba( 0, 115, 170, .8 );
+	border-color: #4f94d4;
+	box-shadow: 0 0 3px rgba(34, 113, 177, 0.8);
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
 	outline-offset: -2px;
@@ -138,7 +138,7 @@
 .media-widget-control .media-widget-preview img {
 	max-width: 100%;
 	vertical-align: middle;
-	background-image: linear-gradient(45deg, #c4c4c4 25%, transparent 25%, transparent 75%, #c4c4c4 75%, #c4c4c4), linear-gradient(45deg, #c4c4c4 25%, transparent 25%, transparent 75%, #c4c4c4 75%, #c4c4c4);
+	background-image: linear-gradient(45deg, #c3c4c7 25%, transparent 25%, transparent 75%, #c3c4c7 75%, #c3c4c7), linear-gradient(45deg, #c3c4c7 25%, transparent 25%, transparent 75%, #c3c4c7 75%, #c3c4c7);
 	background-position: 0 0, 10px 10px;
 	background-size: 20px 20px;
 }
@@ -168,7 +168,7 @@
 	display: inline-block;
 	min-height: 132px;
 	width: 100%;
-	background: black;
+	background: #000;
 }
 
 .media-widget-video-link .dashicons {
@@ -176,7 +176,7 @@
 	position: relative;
 	width: 100%;
 	top: -90px;
-	color: white;
+	color: #fff;
 	text-decoration: none;
 }
 
@@ -186,7 +186,7 @@
 
 .media-frame #embed-url-field.invalid,
 .media-widget-image-link > .link:invalid {
-	border: 1px solid #dc3232;
+	border: 1px solid #d63638;
 }
 
 .media-widget-image-link {
@@ -206,7 +206,7 @@
 }
 
 .media-widget-preview .placeholder {
-	background: #f1f1f1;
+	background: #f0f0f1;
 }
 
 .media-widget-gallery-preview .gallery-item {
@@ -258,7 +258,7 @@
 .media-widget-gallery-preview .gallery-icon-placeholder-text {
 	font-weight: 600;
 	font-size: 2em;
-	color: white;
+	color: #fff;
 }
 
 
@@ -272,7 +272,7 @@
 }
 
 .widget-placeholder {
-	border: 1px dashed #b4b9be;
+	border: 1px dashed #c3c4c7;
 	margin: 0 auto 10px;
 	height: 45px;
 	width: 100%;
@@ -338,8 +338,8 @@
 
 .sidebar-name .handlediv:focus .toggle-indicator:before {
 	box-shadow:
-		0 0 0 1px #5b9dd9,
-		0 0 2px 1px rgba(30, 140, 190, 0.8);
+		0 0 0 1px #4f94d4,
+		0 0 2px 1px rgba(79, 148, 212, 0.8);
 }
 
 .sidebar-name h2,
@@ -354,12 +354,12 @@
 	padding: 0 0 15px;
 	margin: 0;
 	font-style: normal;
-	color: #72777c;
+	color: #787c82;
 }
 
 .widget-holder .description,
 .inactive-sidebar .description {
-	color: #555d66;
+	color: #50575e;
 }
 
 #widgets-right .widgets-holder-wrap .description {
@@ -512,7 +512,7 @@ div#widgets-right .closed .widgets-sortables {
 
 /* Dragging a widget over a closed sidebar */
 #widgets-right .widgets-holder-wrap.widget-hover {
-	border-color: #72777c;
+	border-color: #787c82;
 	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
 }
 
@@ -534,7 +534,7 @@ div#widgets-right .closed .widgets-sortables {
 
 .widgets_access #widgets-left .widget .widget-top:hover,
 .widgets_access #widgets-right .widget .widget-top:hover {
-	border-color: #ddd;
+	border-color: #dcdcde;
 }
 
 #available-widgets .widget-control-edit .edit,
@@ -548,19 +548,19 @@ div#widgets-right .closed .widgets-sortables {
 
 .widget-control-edit {
 	display: block;
-	color: #666;
-	background: #EEE;
+	color: #646970;
+	background: #f0f0f1;
 	padding: 0 15px;
 	line-height: 3.30769230;
-	border-left: 1px solid #DDD;
+	border-left: 1px solid #dcdcde;
 }
 
 #widgets-left .widget-control-edit:hover,
 #widgets-right .widget-control-edit:hover {
 	color: #fff;
-	background: #444;
+	background: #3c434a;
 	border-left: 0;
-	outline: 1px solid #444;
+	outline: 1px solid #3c434a;
 }
 
 .widgets-holder-wrap .sidebar-name,
@@ -616,11 +616,11 @@ div#widgets-right .closed .widgets-sortables {
 	padding-left: 15px;
 	font-size: 12px;
 	line-height: 1;
-	color: black;
+	color: #000;
 }
 
 .js #removing-widget {
-	color: #00a0d2;
+	color: #72aee6;
 }
 
 .widget-control-noform,
@@ -672,7 +672,7 @@ div#widgets-right .closed .widgets-sortables {
 #available-widgets .widget-top:hover,
 div#widgets-right .widget-top:hover,
 #widgets-left .widget-top:hover {
-	border-color: #999;
+	border-color: #8c8f94;
 	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
 }
 
@@ -688,11 +688,11 @@ div#widgets-right .widget-top:hover,
 }
 
 .widgets-chooser ul {
-	border: 1px solid #ccc;
+	border: 1px solid #c3c4c7;
 }
 
 .widgets-chooser li {
-	border-bottom: 1px solid #ccc;
+	border-bottom: 1px solid #c3c4c7;
 	background: #fff;
 	margin: 0;
 	position: relative;
@@ -721,7 +721,7 @@ div#widgets-right .widget-top:hover,
 }
 
 .widgets-chooser .widgets-chooser-selected .widgets-chooser-button {
-	background: #0073aa;
+	background: #2271b1;
 	color: #fff;
 }
 
@@ -773,7 +773,7 @@ div#widgets-right .widget-top:hover,
 }
 
 .custom-html-widget-fields > p > .CodeMirror {
-	border: 1px solid #e5e5e5;
+	border: 1px solid #dcdcde;
 }
 .custom-html-widget-fields code {
 	padding-top: 1px;

--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -34,7 +34,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 #wpadminbar a.ab-item,
 #wpadminbar > #wp-toolbar span.ab-label,
 #wpadminbar > #wp-toolbar span.noticon {
-	color: #eee;
+	color: #f0f0f1;
 }
 
 #wpadminbar #wp-admin-bar-site-name a.ab-item,
@@ -77,7 +77,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 
 #wpadminbar {
 	direction: ltr;
-	color: #ccc;
+	color: #c3c4c7;
 	font-size: 13px;
 	font-weight: 400;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
@@ -89,7 +89,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 	width: 100%;
 	min-width: 600px; /* match the min-width of the body in wp-admin/css/common.css */
 	z-index: 99999;
-	background: #23282d;
+	background: #1d2327;
 }
 
 #wpadminbar .ab-sub-wrapper,
@@ -143,7 +143,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 	margin: 0;
 	padding: 0;
 	box-shadow: 0 3px 5px rgba(0, 0, 0, 0.2);
-	background: #32373c;
+	background: #2c3338;
 	display: none;
 	position: absolute;
 	float: none;
@@ -211,14 +211,14 @@ html:lang(he-il) .rtl #wpadminbar * {
 #wpadminbar.nojq .quicklinks .ab-top-menu > li > .ab-item:focus,
 #wpadminbar:not(.mobile) .ab-top-menu > li:hover > .ab-item,
 #wpadminbar .ab-top-menu > li.hover > .ab-item {
-	background: #32373c;
-	color: #00b9eb;
+	background: #2c3338;
+	color: #72aee6;
 }
 
 #wpadminbar:not(.mobile) > #wp-toolbar li:hover span.ab-label,
 #wpadminbar > #wp-toolbar li.hover span.ab-label,
 #wpadminbar:not(.mobile) > #wp-toolbar a:focus span.ab-label {
-	color: #00b9eb;
+	color: #72aee6;
 }
 
 #wpadminbar > #wp-toolbar > #wp-admin-bar-root-default .ab-icon,
@@ -239,8 +239,8 @@ html:lang(he-il) .rtl #wpadminbar * {
 #wpadminbar .ab-icon:before,
 #wpadminbar .ab-item:before,
 #wpadminbar #adminbarsearch:before {
-	color: #a0a5aa;
-	color: rgba(240, 245, 250, 0.6);
+	color: #a7aaad;
+	color: rgba(240, 246, 252, 0.6);
 }
 
 #wpadminbar .ab-icon:before,
@@ -256,16 +256,16 @@ html:lang(he-il) .rtl #wpadminbar * {
 }
 
 #wpadminbar .ab-submenu .ab-item {
-	color: #b4b9be;
-	color: rgba(240, 245, 250, 0.7);
+	color: #c3c4c7;
+	color: rgba(240, 246, 252, 0.7);
 }
 
 #wpadminbar .quicklinks .menupop ul li a,
 #wpadminbar .quicklinks .menupop ul li a strong,
 #wpadminbar .quicklinks .menupop.hover ul li a,
 #wpadminbar.nojs .quicklinks .menupop:hover ul li a {
-	color: #b4b9be;
-	color: rgba(240, 245, 250, 0.7);
+	color: #c3c4c7;
+	color: rgba(240, 246, 252, 0.7);
 }
 
 #wpadminbar .quicklinks .menupop ul li a:hover,
@@ -288,17 +288,17 @@ html:lang(he-il) .rtl #wpadminbar * {
 #wpadminbar li.hover .ab-item:before,
 #wpadminbar li:hover #adminbarsearch:before,
 #wpadminbar li #adminbarsearch.adminbar-focused:before {
-	color: #00b9eb;
+	color: #72aee6;
 }
 
 #wpadminbar.mobile .quicklinks .ab-icon:before,
 #wpadminbar.mobile .quicklinks .ab-item:before {
-	color: #b4b9be;
+	color: #c3c4c7;
 }
 
 #wpadminbar.mobile .quicklinks .hover .ab-icon:before,
 #wpadminbar.mobile .quicklinks .hover .ab-item:before {
-	color: #00b9eb;
+	color: #72aee6;
 }
 
 #wpadminbar .menupop .menupop > .ab-item .wp-admin-bar-arrow:before,
@@ -344,17 +344,17 @@ html:lang(he-il) .rtl #wpadminbar * {
 
 #wpadminbar .quicklinks .menupop ul.ab-sub-secondary,
 #wpadminbar .quicklinks .menupop ul.ab-sub-secondary .ab-submenu {
-	background: #464b50;
+	background: #3c434a;
 }
 
 #wpadminbar .quicklinks .menupop .ab-sub-secondary > li > a:hover,
 #wpadminbar .quicklinks .menupop .ab-sub-secondary > li .ab-item:focus a {
-	color: #00b9eb;
+	color: #72aee6;
 }
 
 #wpadminbar .quicklinks a span#ab-updates {
-	background: #eee;
-	color: #32373c;
+	background: #f0f0f1;
+	color: #2c3338;
 	display: inline;
 	padding: 2px 5px;
 	font-size: 10px;
@@ -381,7 +381,7 @@ html:lang(he-il) .rtl #wpadminbar * {
  */
 #wpadminbar #wp-admin-bar-recovery-mode {
 	color: #fff;
-	background-color: #ca4a1f;
+	background-color: #d63638;
 }
 
 #wpadminbar .ab-top-menu > #wp-admin-bar-recovery-mode.hover >.ab-item,
@@ -389,7 +389,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 #wpadminbar:not(.mobile) .ab-top-menu > #wp-admin-bar-recovery-mode:hover > .ab-item,
 #wpadminbar:not(.mobile) .ab-top-menu > #wp-admin-bar-recovery-mode > .ab-item:focus {
 	color: #fff;
-	background-color: #c0461e;
+	background-color: #d63638;
 }
 
 /**
@@ -461,7 +461,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 }
 
 #wpadminbar #wp-admin-bar-user-info .username {
-	color: #a0a5aa;
+	color: #a7aaad;
 	font-size: 11px;
 }
 
@@ -470,8 +470,8 @@ html:lang(he-il) .rtl #wpadminbar * {
 	width: auto;
 	height: 16px;
 	padding: 0;
-	border: 1px solid #82878c;
-	background: #eee;
+	border: 1px solid #8c8f94;
+	background: #f0f0f1;
 	line-height: 1.84615384;
 	vertical-align: middle;
 	margin: -4px 0 0 6px;
@@ -508,13 +508,13 @@ html:lang(he-il) .rtl #wpadminbar * {
 	speak: never;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
-	color: #eee;
+	color: #f0f0f1;
 }
 
 #wpadminbar .quicklinks li a:hover .blavatar,
 #wpadminbar .quicklinks li a:focus .blavatar,
 #wpadminbar .quicklinks .ab-sub-wrapper .menupop.hover > a .blavatar {
-	color: #00b9eb;
+	color: #72aee6;
 }
 
 #wpadminbar .quicklinks li .blavatar:before {
@@ -631,7 +631,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 	max-width: none;
 	padding: 0 3px 0 24px;
 	margin: 0;
-	color: #ccc;
+	color: #c3c4c7;
 	background-color: rgba(255, 255, 255, 0);
 	border: none;
 	outline: none;
@@ -700,8 +700,8 @@ html:lang(he-il) .rtl #wpadminbar * {
 	font-size: 14px;
 	font-weight: 600;
 	padding: 15px 23px 14px;
-	background: #f1f1f1;
-	color: #0073aa;
+	background: #f0f0f1;
+	color: #2271b1;
 	z-index: 100000;
 	line-height: normal;
 	text-decoration: none;
@@ -822,7 +822,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 		overflow: hidden;
 		width: 52px;
 		padding: 0;
-		color: #a0a5aa; /* @todo not needed? this text is hidden */
+		color: #a7aaad; /* @todo not needed? this text is hidden */
 		position: relative;
 	}
 
@@ -928,7 +928,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 		height: auto;
 		font-size: 16px;
 		line-height: 1.5;
-		color: #eee;
+		color: #f0f0f1;
 	}
 
 	#wpadminbar #wp-admin-bar-user-info a {

--- a/src/wp-includes/css/buttons.css
+++ b/src/wp-includes/css/buttons.css
@@ -115,9 +115,9 @@ TABLE OF CONTENTS:
 
 .wp-core-ui .button,
 .wp-core-ui .button-secondary {
-	color: #0071a1;
-	border-color: #0071a1;
-	background: #f3f5f6;
+	color: #2271b1;
+	border-color: #2271b1;
+	background: #f6f7f7;
 	vertical-align: top;
 }
 
@@ -128,18 +128,18 @@ TABLE OF CONTENTS:
 .wp-core-ui .button.hover,
 .wp-core-ui .button:hover,
 .wp-core-ui .button-secondary:hover{
-	background: #f1f1f1;
-	border-color: #016087;
-	color: #016087;
+	background: #f0f0f1;
+	border-color: #0a4b78;
+	color: #0a4b78;
 }
 
 .wp-core-ui .button.focus,
 .wp-core-ui .button:focus,
 .wp-core-ui .button-secondary:focus {
-	background: #f3f5f6;
-	border-color: #007cba;
-	color: #016087;
-	box-shadow: 0 0 0 1px #007cba;
+	background: #f6f7f7;
+	border-color: #3582c4;
+	color: #0a4b78;
+	box-shadow: 0 0 0 1px #3582c4;
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
 	/* Reset inherited offset from Gutenberg */
@@ -149,25 +149,25 @@ TABLE OF CONTENTS:
 /* :active state */
 .wp-core-ui .button:active,
 .wp-core-ui .button-secondary:active {
-	background: #f3f5f6;
-	border-color: #7e8993;
+	background: #f6f7f7;
+	border-color: #8c8f94;
 	box-shadow: none;
 }
 
 /* pressed state e.g. a selected setting */
 .wp-core-ui .button.active,
 .wp-core-ui .button.active:hover {
-	background-color: #e2e4e7;
-	color: #00669b;
-	border-color: #016087;
-	box-shadow: inset 0 2px 5px -3px #016087;
+	background-color: #dcdcde;
+	color: #135e96;
+	border-color: #0a4b78;
+	box-shadow: inset 0 2px 5px -3px #0a4b78;
 }
 
 .wp-core-ui .button.active:focus {
-	border-color: #007cba;
+	border-color: #3582c4;
 	box-shadow:
-		inset 0 2px 5px -3px #016087,
-		0 0 0 1px #007cba;
+		inset 0 2px 5px -3px #0a4b78,
+		0 0 0 1px #3582c4;
 }
 
 .wp-core-ui .button[disabled],
@@ -177,9 +177,9 @@ TABLE OF CONTENTS:
 .wp-core-ui .button-secondary:disabled,
 .wp-core-ui .button-secondary.disabled,
 .wp-core-ui .button-disabled {
-	color: #a0a5aa !important;
-	border-color: #ddd !important;
-	background: #f7f7f7 !important;
+	color: #a7aaad !important;
+	border-color: #dcdcde !important;
+	background: #f6f7f7 !important;
 	box-shadow: none !important;
 	cursor: default;
 	transform: none !important;
@@ -196,7 +196,7 @@ TABLE OF CONTENTS:
 	cursor: pointer;
 	text-align: left;
 	/* Mimics the default link style in common.css */
-	color: #0073aa;
+	color: #2271b1;
 	text-decoration: underline;
 	transition-property: border, background, color;
 	transition-duration: .05s;
@@ -205,25 +205,25 @@ TABLE OF CONTENTS:
 
 .wp-core-ui .button-link:hover,
 .wp-core-ui .button-link:active {
-	color: #006799;
+	color: #135e96;
 }
 
 .wp-core-ui .button-link:focus {
-	color: #124964;
+	color: #043959;
 	box-shadow:
-		0 0 0 1px #5b9dd9,
-		0 0 2px 1px rgba(30, 140, 190, 0.8);
+		0 0 0 1px #4f94d4,
+		0 0 2px 1px rgba(79, 148, 212, 0.8);
 	/* Only visible in Windows High Contrast mode */
 	outline: 1px solid transparent;
 }
 
 .wp-core-ui .button-link-delete {
-	color: #a00;
+	color: #d63638;
 }
 
 .wp-core-ui .button-link-delete:hover,
 .wp-core-ui .button-link-delete:focus {
-	color: #dc3232;
+	color: #d63638;
 	background: transparent;
 }
 
@@ -238,8 +238,8 @@ TABLE OF CONTENTS:
 ---------------------------------------------------------------------------- */
 
 .wp-core-ui .button-primary {
-	background: #007cba;
-	border-color: #007cba;
+	background: #3582c4;
+	border-color: #3582c4;
 	color: #fff;
 	text-decoration: none;
 	text-shadow: none;
@@ -249,8 +249,8 @@ TABLE OF CONTENTS:
 .wp-core-ui .button-primary:hover,
 .wp-core-ui .button-primary.focus,
 .wp-core-ui .button-primary:focus {
-	background: #0071a1;
-	border-color: #0071a1;
+	background: #2271b1;
+	border-color: #2271b1;
 	color: #fff;
 }
 
@@ -258,15 +258,15 @@ TABLE OF CONTENTS:
 .wp-core-ui .button-primary:focus {
 	box-shadow:
 		0 0 0 1px #fff,
-		0 0 0 3px #007cba;
+		0 0 0 3px #3582c4;
 }
 
 .wp-core-ui .button-primary.active,
 .wp-core-ui .button-primary.active:hover,
 .wp-core-ui .button-primary.active:focus,
 .wp-core-ui .button-primary:active {
-	background: #00669b;
-	border-color: #00669b;
+	background: #135e96;
+	border-color: #135e96;
 	box-shadow: none;
 	color: #fff;
 }
@@ -275,9 +275,9 @@ TABLE OF CONTENTS:
 .wp-core-ui .button-primary:disabled,
 .wp-core-ui .button-primary-disabled,
 .wp-core-ui .button-primary.disabled {
-	color: #a0a5aa !important;
-	background: #f7f7f7 !important;
-	border-color: #ddd !important;
+	color: #a7aaad !important;
+	background: #f6f7f7 !important;
+	border-color: #dcdcde !important;
 	box-shadow: none !important;
 	text-shadow: none !important;
 	cursor: default;
@@ -320,17 +320,17 @@ TABLE OF CONTENTS:
 
 /* pressed state e.g. a selected setting */
 .wp-core-ui .button-group > .button.active {
-	background-color: #e2e4e7;
-	color: #00669b;
-	border-color: #016087;
-	box-shadow: inset 0 2px 5px -3px #016087;
+	background-color: #dcdcde;
+	color: #135e96;
+	border-color: #0a4b78;
+	box-shadow: inset 0 2px 5px -3px #0a4b78;
 }
 
 .wp-core-ui .button-group > .button.active:focus {
-	border-color: #007cba;
+	border-color: #3582c4;
 	box-shadow:
-		inset 0 2px 5px -3px #016087,
-		0 0 0 1px #007cba;
+		inset 0 2px 5px -3px #0a4b78,
+		0 0 0 1px #3582c4;
 }
 
 /* ----------------------------------------------------------------------------

--- a/src/wp-includes/css/customize-preview.css
+++ b/src/wp-includes/css/customize-preview.css
@@ -44,10 +44,10 @@
 	line-height: 1 !important;
 	font-size: 18px;
 	z-index: 5;
-	background: #0085ba !important;
+	background: #3582c4 !important;
 	border-radius: 50%;
 	border: 2px solid #fff;
-	box-shadow: 0 2px 1px rgba(46, 68, 83, 0.15);
+	box-shadow: 0 2px 1px rgba(60, 67, 74, 0.15);
 	text-align: center;
 	cursor: pointer;
 	box-sizing: border-box;
@@ -57,10 +57,10 @@
 	opacity: 0;
 	pointer-events: none;
 	text-shadow:
-		0 -1px 1px #006799,
-		1px 0 1px #006799,
-		0 1px 1px #006799,
-		-1px 0 1px #006799;
+		0 -1px 1px #135e96,
+		1px 0 1px #135e96,
+		0 1px 1px #135e96,
+		-1px 0 1px #135e96;
 }
 .wp-custom-header .customize-partial-edit-shortcut button {
 	left: 2px
@@ -76,11 +76,11 @@
 }
 
 .customize-partial-edit-shortcut button:hover {
-	background: #008ec2 !important; /* matches primary buttons */
+	background: #4f94d4 !important; /* matches primary buttons */
 }
 
 .customize-partial-edit-shortcut button:focus {
-	box-shadow: 0 0 0 2px #008ec2;
+	box-shadow: 0 0 0 2px #4f94d4;
 }
 
 body.customize-partial-edit-shortcuts-shown .customize-partial-edit-shortcut button {

--- a/src/wp-includes/css/editor.css
+++ b/src/wp-includes/css/editor.css
@@ -44,14 +44,14 @@
 }
 
 .mce-window .mce-window-head {
-	background: #fcfcfc;
-	border-bottom: 1px solid #ddd;
+	background: #fff;
+	border-bottom: 1px solid #dcdcde;
 	padding: 0;
 	min-height: 36px;
 }
 
 .mce-window .mce-window-head .mce-title {
-	color: #444;
+	color: #3c434a;
 	font-size: 18px;
 	font-weight: 600;
 	line-height: 36px;
@@ -74,7 +74,7 @@
 .mce-window-head .mce-close .mce-i-remove:before {
 	font: normal 20px/36px dashicons;
 	text-align: center;
-	color: #666;
+	color: #646970;
 	width: 36px;
 	height: 36px;
 	display: block;
@@ -82,13 +82,13 @@
 
 .mce-window-head .mce-close:hover .mce-i-remove:before,
 .mce-window-head .mce-close:focus .mce-i-remove:before {
-	color: #006799;
+	color: #135e96;
 }
 
 .mce-window-head .mce-close:focus .mce-i-remove,
 div.mce-tab:focus {
-	box-shadow: 0 0 0 1px #5b9dd9,
-		0 0 2px 1px rgba(30, 140, 190, 0.8);
+	box-shadow: 0 0 0 1px #4f94d4,
+		0 0 2px 1px rgba(79, 148, 212, 0.8);
 }
 
 .mce-window .mce-window-head .mce-dragh {
@@ -96,13 +96,13 @@ div.mce-tab:focus {
 }
 
 .mce-window .mce-foot {
-	border-top: 1px solid #ddd;
+	border-top: 1px solid #dcdcde;
 }
 
 .mce-textbox,
 .mce-checkbox i.mce-i-checkbox,
 #wp-link .query-results {
-	border: 1px solid #ddd;
+	border: 1px solid #dcdcde;
 	border-radius: 0;
 	box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.07);
 	transition: .05s all ease-in-out;
@@ -112,8 +112,8 @@ div.mce-tab:focus {
 .mce-textbox.mce-focus,
 .mce-checkbox:focus i.mce-i-checkbox,
 #wp-link .query-results:focus {
-	border-color: #5b9dd9;
-	box-shadow: 0 0 2px rgba(30, 140, 190, 0.8);
+	border-color: #4f94d4;
+	box-shadow: 0 0 2px rgba(79, 148, 212, 0.8);
 }
 
 .mce-window .mce-wp-help {
@@ -188,7 +188,7 @@ div.mce-tab:focus {
 	padding: 2px 7px 3px;
 	font-weight: 600;
 	margin: 0;
-	background: #eaeaea;
+	background: #f0f0f1;
 	background: rgba(0, 0, 0, 0.08);
 }
 
@@ -235,7 +235,7 @@ div.mce-panel {
 }
 
 .mce-panel.mce-menu {
-	border: 1px solid #ddd;
+	border: 1px solid #dcdcde;
 }
 
 div.mce-tab {
@@ -244,14 +244,14 @@ div.mce-tab {
 
 /* TinyMCE toolbars */
 div.mce-toolbar-grp {
-	border-bottom: 1px solid #ddd;
-	background: #f5f5f5;
+	border-bottom: 1px solid #dcdcde;
+	background: #f6f7f7;
 	padding: 0;
 	position: relative;
 }
 
 div.mce-inline-toolbar-grp {
-	border: 1px solid #a0a5aa;
+	border: 1px solid #a7aaad;
 	border-radius: 2px;
 	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
 	box-sizing: border-box;
@@ -287,28 +287,28 @@ div.mce-inline-toolbar-grp:after {
 
 div.mce-inline-toolbar-grp.mce-arrow-up:before {
 	top: -9px;
-	border-bottom-color: #a0a5aa;
+	border-bottom-color: #a7aaad;
 	border-width: 0 9px 9px;
 	margin-left: -9px;
 }
 
 div.mce-inline-toolbar-grp.mce-arrow-down:before {
 	bottom: -9px;
-	border-top-color: #a0a5aa;
+	border-top-color: #a7aaad;
 	border-width: 9px 9px 0;
 	margin-left: -9px;
 }
 
 div.mce-inline-toolbar-grp.mce-arrow-up:after {
 	top: -8px;
-	border-bottom-color: #f5f5f5;
+	border-bottom-color: #f6f7f7;
 	border-width: 0 8px 8px;
 	margin-left: -8px;
 }
 
 div.mce-inline-toolbar-grp.mce-arrow-down:after {
 	bottom: -8px;
-	border-top-color: #f5f5f5;
+	border-top-color: #f6f7f7;
 	border-width: 8px 8px 0;
 	margin-left: -8px;
 }
@@ -370,7 +370,7 @@ div.mce-toolbar-grp > div {
 }
 
 div.mce-statusbar {
-	border-top: 1px solid #e5e5e5;
+	border-top: 1px solid #dcdcde;
 }
 
 div.mce-path {
@@ -409,9 +409,9 @@ div.mce-path {
 .mce-toolbar .mce-btn-group .mce-btn:focus,
 .qt-dfw:hover,
 .qt-dfw:focus {
-	background: #fafafa;
-	border-color: #555d66;
-	color: #23282d;
+	background: #f6f7f7;
+	border-color: #50575e;
+	color: #1d2327;
 	box-shadow: inset 0 1px 0 #fff, 0 1px 0 rgba(0, 0, 0, 0.08);
 	outline: none;
 }
@@ -419,8 +419,8 @@ div.mce-path {
 .mce-toolbar .mce-btn-group .mce-btn.mce-active,
 .mce-toolbar .mce-btn-group .mce-btn:active,
 .qt-dfw.active {
-	background: #ebebeb;
-	border-color: #555d66;
+	background: #f0f0f1;
+	border-color: #50575e;
 	box-shadow: inset 0 2px 5px -3px rgba(0, 0, 0, 0.3);
 }
 
@@ -434,20 +434,20 @@ div.mce-path {
 
 .mce-toolbar .mce-btn-group .mce-btn.mce-active:hover,
 .mce-toolbar .mce-btn-group .mce-btn.mce-active:focus {
-	border-color: #23282d;
+	border-color: #1d2327;
 }
 
 .mce-toolbar .mce-btn-group .mce-btn.mce-disabled:hover,
 .mce-toolbar .mce-btn-group .mce-btn.mce-disabled:focus {
-	color: #a0a5aa;
+	color: #a7aaad;
 	background: none;
-	border-color: #ddd;
+	border-color: #dcdcde;
 	text-shadow: 0 1px 0 #fff;
 	box-shadow: none;
 }
 
 .mce-toolbar .mce-btn-group .mce-btn.mce-disabled:focus {
-	border-color: #555d66;
+	border-color: #50575e;
 }
 
 .mce-toolbar .mce-btn-group .mce-first,
@@ -488,14 +488,14 @@ div.mce-path {
 	left: 3px;
 	height: 3px;
 	width: 20px;
-	background: #555d66;
+	background: #50575e;
 }
 
 .mce-toolbar .mce-btn-group .mce-btn.mce-primary {
 	min-width: 0;
-	background: #0085ba;
-	border-color: #0073aa #006799 #006799;
-	box-shadow: 0 1px 0 #006799;
+	background: #3582c4;
+	border-color: #2271b1 #135e96 #135e96;
+	box-shadow: 0 1px 0 #135e96;
 	color: #fff;
 	text-decoration: none;
 	text-shadow: none;
@@ -512,19 +512,19 @@ div.mce-path {
 
 .mce-toolbar .mce-btn-group .mce-btn.mce-primary:hover,
 .mce-toolbar .mce-btn-group .mce-btn.mce-primary:focus {
-	background: #008ec2;
-	border-color: #006799;
+	background: #4f94d4;
+	border-color: #135e96;
 	color: #fff;
 }
 
 .mce-toolbar .mce-btn-group .mce-btn.mce-primary:focus {
-	box-shadow: 0 0 1px 1px #33b3db;
+	box-shadow: 0 0 1px 1px #72aee6;
 }
 
 .mce-toolbar .mce-btn-group .mce-btn.mce-primary:active {
-	background: #0073aa;
-	border-color: #006799;
-	box-shadow: inset 0 2px 0 #006799;
+	background: #2271b1;
+	border-color: #135e96;
+	box-shadow: inset 0 2px 0 #135e96;
 }
 
 /* mce listbox */
@@ -532,17 +532,17 @@ div.mce-path {
 	border-radius: 0;
 	direction: ltr;
 	background: #fff;
-	border: 1px solid #ddd;
+	border: 1px solid #dcdcde;
 	box-shadow: inset 0 1px 1px -1px rgba(0, 0, 0, 0.2);
 }
 
 .mce-toolbar .mce-btn-group .mce-btn.mce-listbox:hover,
 .mce-toolbar .mce-btn-group .mce-btn.mce-listbox:focus {
-	border-color: #b4b9be;
+	border-color: #c3c4c7;
 }
 
 .mce-panel .mce-btn i.mce-caret {
-	border-top: 6px solid #555d66;
+	border-top: 6px solid #50575e;
 	margin-left: 2px;
 	margin-right: 2px;
 }
@@ -553,12 +553,12 @@ div.mce-path {
 
 .mce-panel .mce-btn:hover i.mce-caret,
 .mce-panel .mce-btn:focus i.mce-caret {
-	border-top-color: #23282d;
+	border-top-color: #1d2327;
 }
 
 .mce-panel .mce-active i.mce-caret {
 	border-top: 0;
-	border-bottom: 6px solid #23282d;
+	border-bottom: 6px solid #1d2327;
 	margin-top: 7px;
 }
 
@@ -580,7 +580,7 @@ div.mce-path {
 .mce-menu .mce-menu-item:focus,
 .mce-menu .mce-menu-item.mce-active.mce-menu-item-normal,
 .mce-menu .mce-menu-item.mce-active.mce-menu-item-preview {
-	background: #0073aa; /* See color scheme. */
+	background: #2271b1; /* See color scheme. */
 	color: #fff;
 }
 
@@ -617,12 +617,12 @@ div.mce-path {
 }
 
 .mce-menu .mce-menu-item.mce-disabled:hover {
-	background: #ccc;
+	background: #c3c4c7;
 }
 
 /* Menubar */
 div.mce-menubar {
-	border-color: #e5e5e5;
+	border-color: #dcdcde;
 	background: #fff;
 	border-width: 0px 0px 1px;
 }
@@ -635,15 +635,15 @@ div.mce-menubar {
 }
 
 .mce-menubar .mce-menubtn:focus {
-	color: #124964;
+	color: #043959;
 	box-shadow:
-		0 0 0 1px #5b9dd9,
-		0 0 2px 1px rgba(30, 140, 190, 0.8);
+		0 0 0 1px #4f94d4,
+		0 0 2px 1px rgba(79, 148, 212, 0.8);
 }
 
 div.mce-menu .mce-menu-item-sep,
 .mce-menu-item-sep:hover {
-	border-bottom: 1px solid #ddd;
+	border-bottom: 1px solid #dcdcde;
 	height: 0px;
 	margin: 5px 0;
 }
@@ -678,8 +678,8 @@ div.mce-menu .mce-menu-item-sep,
 }
 
 .mce-window .mce-btn {
-	color: #555;
-	background: #f7f7f7;
+	color: #50575e;
+	background: #f6f7f7;
 	text-decoration: none;
 	font-size: 13px;
 	line-height: 26px;
@@ -687,11 +687,11 @@ div.mce-menu .mce-menu-item-sep,
 	margin: 0;
 	padding: 0;
 	cursor: pointer;
-	border: 1px solid #cccccc;
+	border: 1px solid #c3c4c7;
 	-webkit-appearance: none;
 	border-radius: 3px;
 	white-space: nowrap;
-	box-shadow: 0 1px 0 #cccccc;
+	box-shadow: 0 1px 0 #c3c4c7;
 }
 
 /* Remove the dotted border on :focus and the extra padding in Firefox */
@@ -703,27 +703,27 @@ div.mce-menu .mce-menu-item-sep,
 
 .mce-window .mce-btn:hover,
 .mce-window .mce-btn:focus {
-	background: #fafafa;
-	border-color: #999;
-	color: #23282d;
+	background: #f6f7f7;
+	border-color: #8c8f94;
+	color: #1d2327;
 }
 
 .mce-window .mce-btn:focus {
-	border-color: #5b9dd9;
-	box-shadow: 0 0 3px rgba(0, 115, 170, 0.8);
+	border-color: #4f94d4;
+	box-shadow: 0 0 3px rgba(34, 113, 177, 0.8);
 }
 
 .mce-window .mce-btn:active {
-	background: #eee;
-	border-color: #999;
+	background: #f0f0f1;
+	border-color: #8c8f94;
 	box-shadow: inset 0 2px 5px -3px rgba(0, 0, 0, 0.5);
 	transform: translateY(1px);
 }
 
 .mce-window .mce-btn.mce-disabled {
-	color: #a0a5aa !important;
-	border-color: #ddd !important;
-	background: #f7f7f7 !important;
+	color: #a7aaad !important;
+	border-color: #dcdcde !important;
+	background: #f6f7f7 !important;
 	box-shadow: none !important;
 	text-shadow: 0 1px 0 #fff !important;
 	cursor: default;
@@ -731,40 +731,40 @@ div.mce-menu .mce-menu-item-sep,
 }
 
 .mce-window .mce-btn.mce-primary {
-	background: #0085ba;
-	border-color: #0073aa #006799 #006799;
-	box-shadow: 0 1px 0 #006799;
+	background: #3582c4;
+	border-color: #2271b1 #135e96 #135e96;
+	box-shadow: 0 1px 0 #135e96;
 	color: #fff;
 	text-decoration: none;
-	text-shadow: 0 -1px 1px #006799,
-		1px 0 1px #006799,
-		0 1px 1px #006799,
-		-1px 0 1px #006799;
+	text-shadow: 0 -1px 1px #135e96,
+		1px 0 1px #135e96,
+		0 1px 1px #135e96,
+		-1px 0 1px #135e96;
 }
 
 .mce-window .mce-btn.mce-primary:hover,
 .mce-window .mce-btn.mce-primary:focus {
-	background: #008ec2;
-	border-color: #006799;
+	background: #4f94d4;
+	border-color: #135e96;
 	color: #fff;
 }
 
 .mce-window .mce-btn.mce-primary:focus {
-	box-shadow: 0 1px 0 #0073aa,
-		0 0 2px 1px #33b3db;
+	box-shadow: 0 1px 0 #2271b1,
+		0 0 2px 1px #72aee6;
 }
 
 .mce-window .mce-btn.mce-primary:active {
-	background: #0073aa;
-	border-color: #006799;
-	box-shadow: inset 0 2px 0 #006799;
+	background: #2271b1;
+	border-color: #135e96;
+	box-shadow: inset 0 2px 0 #135e96;
 	vertical-align: top;
 }
 
 .mce-window .mce-btn.mce-primary.mce-disabled {
-	color: #66c6e4 !important;
-	background: #008ec2 !important;
-	border-color: #007cb2 !important;
+	color: #9ec2e6 !important;
+	background: #4f94d4 !important;
+	border-color: #3582c4 !important;
 	box-shadow: none !important;
 	text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.1) !important;
 	cursor: default;
@@ -783,12 +783,12 @@ div.mce-menu .mce-menu-item-sep,
 
 .mce-charmap td {
 	padding: 0;
-	border-color: #ddd;
+	border-color: #dcdcde;
 	cursor: pointer;
 }
 
 .mce-charmap td:hover {
-	background: #f3f3f3;
+	background: #f6f7f7;
 }
 
 .mce-charmap td div {
@@ -819,7 +819,7 @@ div.mce-menu .mce-menu-item-sep,
 }
 
 .mce-toolbar .mce-ico {
-	color: #555d66;
+	color: #50575e;
 	line-height: 1;
 	width: 20px;
 	height: 20px;
@@ -830,7 +830,7 @@ div.mce-menu .mce-menu-item-sep,
 }
 
 .qt-dfw {
-	color: #555d66;
+	color: #50575e;
 	line-height: 1;
 	width: 28px;
 	height: 26px;
@@ -845,7 +845,7 @@ div.mce-menu .mce-menu-item-sep,
 .mce-toolbar .mce-btn:hover .mce-open,
 .mce-toolbar .mce-btn:focus .mce-open,
 .mce-toolbar .mce-btn.mce-active .mce-open {
-	border-left-color: #23282d;
+	border-left-color: #1d2327;
 }
 
 div.mce-notification {
@@ -857,7 +857,7 @@ div.mce-notification {
 	right: 6px;
 	top: 3px;
 	font-weight: 400;
-	color: #555d66;
+	color: #50575e;
 }
 
 .mce-notification button.mce-close:hover,
@@ -1081,7 +1081,7 @@ i.mce-i-wp_code:before {
 
 .wp-editor-container {
 	clear: both;
-	border: 1px solid #e5e5e5;
+	border: 1px solid #dcdcde;
 }
 
 .wp-editor-area {
@@ -1120,23 +1120,23 @@ i.mce-i-wp_code:before {
 	box-sizing: content-box;
 	position: relative;
 	top: 1px;
-	background: #ebebeb;
-	color: #666;
+	background: #f0f0f1;
+	color: #646970;
 	cursor: pointer;
 	font-size: 13px;
 	line-height: 1.46153846;
 	height: 20px;
 	margin: 5px 0 0 5px;
 	padding: 3px 8px 4px;
-	border: 1px solid #e5e5e5;
+	border: 1px solid #dcdcde;
 }
 
 .wp-switch-editor:focus {
 	box-shadow:
-		0 0 0 1px #5b9dd9,
-		0 0 2px 1px rgba(30, 140, 190, 0.8);
+		0 0 0 1px #4f94d4,
+		0 0 2px 1px rgba(79, 148, 212, 0.8);
 	outline: none;
-	color: #23282d;
+	color: #1d2327;
 }
 
 .wp-switch-editor:active,
@@ -1146,7 +1146,7 @@ i.mce-i-wp_code:before {
 }
 
 .wp-switch-editor:active {
-	background-color: #f5f5f5;
+	background-color: #f6f7f7;
 	box-shadow: none;
 }
 
@@ -1160,9 +1160,9 @@ i.mce-i-wp_code:before {
 
 .tmce-active .switch-tmce,
 .html-active .switch-html {
-	background: #f5f5f5;
-	color: #555;
-	border-bottom-color: #f5f5f5;
+	background: #f6f7f7;
+	color: #50575e;
+	border-bottom-color: #f6f7f7;
 }
 
 .wp-media-buttons {
@@ -1189,7 +1189,7 @@ i.mce-i-wp_code:before {
 
 .wp-media-buttons a {
 	text-decoration: none;
-	color: #444;
+	color: #3c434a;
 	font-size: 12px;
 }
 
@@ -1230,8 +1230,8 @@ i.mce-i-wp_code:before {
 .quicktags-toolbar {
 	padding: 3px;
 	position: relative;
-	border-bottom: 1px solid #ddd;
-	background: #f5f5f5;
+	border-bottom: 1px solid #dcdcde;
+	background: #f6f7f7;
 	min-height: 30px;
 }
 
@@ -1339,8 +1339,8 @@ i.mce-i-wp_code:before {
 #wp_delimgbtn,
 #wp_editgallery,
 #wp_delgallery {
-	border-color: #999;
-	background-color: #eee;
+	border-color: #8c8f94;
+	background-color: #f0f0f1;
 	margin: 2px;
 	padding: 2px;
 	border-width: 1px;
@@ -1352,8 +1352,8 @@ i.mce-i-wp_code:before {
 #wp_delimgbtn:hover,
 #wp_editgallery:hover,
 #wp_delgallery:hover {
-	border-color: #555;
-	background-color: #ccc;
+	border-color: #50575e;
+	background-color: #c3c4c7;
 }
 
 /*------------------------------------------------------------------------------
@@ -1408,8 +1408,8 @@ i.mce-i-wp_code:before {
 }
 
 #link-modal-title {
-	background: #fcfcfc;
-	border-bottom: 1px solid #ddd;
+	background: #fff;
+	border-bottom: 1px solid #dcdcde;
 	height: 36px;
 	font-size: 18px;
 	font-weight: 600;
@@ -1419,7 +1419,7 @@ i.mce-i-wp_code:before {
 }
 
 #wp-link-close {
-	color: #666;
+	color: #646970;
 	padding: 0;
 	position: absolute;
 	top: 0;
@@ -1445,14 +1445,14 @@ i.mce-i-wp_code:before {
 
 #wp-link-close:hover,
 #wp-link-close:focus {
-	color: #006799;
+	color: #135e96;
 }
 
 #wp-link-close:focus {
 	outline: none;
 	box-shadow:
-		0 0 0 1px #5b9dd9,
-		0 0 2px 1px rgba(30, 140, 190, 0.8);
+		0 0 0 1px #4f94d4,
+		0 0 2px 1px rgba(79, 148, 212, 0.8);
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
 	outline-offset: -2px;
@@ -1536,7 +1536,7 @@ i.mce-i-wp_code:before {
 }
 
 #wp-link .query-results {
-	border: 1px #dfdfdf solid;
+	border: 1px #dcdcde solid;
 	margin: 0 0 12px;
 	background: #fff;
 	overflow: auto;
@@ -1554,8 +1554,8 @@ i.mce-i-wp_code:before {
 #wp-link li {
 	clear: both;
 	margin-bottom: 0;
-	border-bottom: 1px solid #f1f1f1;
-	color: #32373c;
+	border-bottom: 1px solid #f0f0f1;
+	color: #2c3338;
 	padding: 4px 6px 4px 10px;
 	cursor: pointer;
 	position: relative;
@@ -1563,8 +1563,8 @@ i.mce-i-wp_code:before {
 
 #wp-link .query-notice {
 	padding: 0;
-	border-bottom: 1px solid #dfdfdf;
-	background-color: #f7fcfe;
+	border-bottom: 1px solid #dcdcde;
+	background-color: #fff;
 	color: #000;
 }
 
@@ -1572,19 +1572,19 @@ i.mce-i-wp_code:before {
 #wp-link .query-notice .query-notice-hint {
 	display: block;
 	padding: 6px;
-	border-left: 4px solid #00a0d2;
+	border-left: 4px solid #72aee6;
 }
 
 #wp-link .unselectable.no-matches-found {
 	padding: 0;
-	border-bottom: 1px solid #dfdfdf;
-	background-color: #fef7f1;
+	border-bottom: 1px solid #dcdcde;
+	background-color: #f6f7f7;
 }
 
 #wp-link .no-matches-found .item-title {
 	display: block;
 	padding: 6px;
-	border-left: 4px solid #d54e21;
+	border-left: 4px solid #d63638;
 }
 
 #wp-link .query-results em {
@@ -1592,23 +1592,23 @@ i.mce-i-wp_code:before {
 }
 
 #wp-link li:hover {
-	background: #eaf2fa;
-	color: #151515;
+	background: #f0f6fc;
+	color: #101517;
 }
 
 #wp-link li.unselectable {
-	border-bottom: 1px solid #dfdfdf;
+	border-bottom: 1px solid #dcdcde;
 }
 
 #wp-link li.unselectable:hover {
 	background: #fff;
 	cursor: auto;
-	color: #32373c;
+	color: #2c3338;
 }
 
 #wp-link li.selected {
-	background: #ddd;
-	color: #32373c;
+	background: #dcdcde;
+	color: #2c3338;
 }
 
 #wp-link li.selected .item-title {
@@ -1628,7 +1628,7 @@ i.mce-i-wp_code:before {
 
 #wp-link .item-info {
 	text-transform: uppercase;
-	color: #666;
+	color: #646970;
 	font-size: 11px;
 	position: absolute;
 	right: 5px;
@@ -1642,8 +1642,8 @@ i.mce-i-wp_code:before {
 
 #wp-link .submitbox {
 	padding: 8px 16px;
-	background: #fcfcfc;
-	border-top: 1px solid #ddd;
+	background: #fff;
+	border-top: 1px solid #dcdcde;
 	position: absolute;
 	bottom: 0;
 	left: 0;
@@ -1754,7 +1754,7 @@ div.wp-link-preview {
 }
 
 div.wp-link-preview a {
-	color: #0073aa;
+	color: #2271b1;
 	text-decoration: underline;
 	transition-property: border, background, color;
 	transition-duration: .05s;
@@ -1763,7 +1763,7 @@ div.wp-link-preview a {
 }
 
 div.wp-link-preview a.wplink-url-error {
-	color: #dc3232;
+	color: #d63638;
 }
 
 div.wp-link-input {
@@ -1798,8 +1798,8 @@ div.wp-link-input input {
 	margin: 0;
 	list-style: none;
 	position: absolute;
-	border: 1px solid #5b9dd9;
-	box-shadow: 0 1px 2px rgba(30, 140, 190, 0.8);
+	border: 1px solid #4f94d4;
+	box-shadow: 0 1px 2px rgba(79, 148, 212, 0.8);
 	background-color: #fff;
 }
 
@@ -1816,7 +1816,7 @@ div.wp-link-input input {
 }
 
 .ui-autocomplete.wplink-autocomplete li.ui-state-focus {
-	background-color: #ddd;
+	background-color: #dcdcde;
 	cursor: pointer;
 }
 

--- a/src/wp-includes/css/jquery-ui-dialog.css
+++ b/src/wp-includes/css/jquery-ui-dialog.css
@@ -193,10 +193,10 @@
 	border-radius: 3px;
 	white-space: nowrap;
 	box-sizing: border-box;
-	color: #555;
-	border-color: #cccccc;
-	background: #f7f7f7;
-	box-shadow: 0 1px 0 #cccccc;
+	color: #50575e;
+	border-color: #c3c4c7;
+	background: #f6f7f7;
+	box-shadow: 0 1px 0 #c3c4c7;
 	vertical-align: top;
 }
 
@@ -214,27 +214,27 @@
 
 .ui-button:hover,
 .ui-button:focus {
-	background: #fafafa;
-	border-color: #999;
-	color: #23282d;
+	background: #f6f7f7;
+	border-color: #8c8f94;
+	color: #1d2327;
 }
 
 .ui-button:focus {
-	border-color: #5b9dd9;
-	box-shadow: 0 0 3px rgba(0, 115, 170, 0.8);
+	border-color: #4f94d4;
+	box-shadow: 0 0 3px rgba(34, 113, 177, 0.8);
 }
 
 .ui-button:active {
-	background: #eee;
-	border-color: #999;
+	background: #f0f0f1;
+	border-color: #8c8f94;
 	box-shadow: inset 0 2px 5px -3px rgba(0, 0, 0, 0.5);
 }
 
 .ui-button[disabled],
 .ui-button:disabled {
-	color: #a0a5aa !important;
-	border-color: #ddd !important;
-	background: #f7f7f7 !important;
+	color: #a7aaad !important;
+	border-color: #dcdcde !important;
+	background: #f6f7f7 !important;
 	box-shadow: none !important;
 	text-shadow: 0 1px 0 #fff !important;
 	cursor: default;
@@ -267,8 +267,8 @@
 }
 
 .ui-dialog-titlebar {
-	background: #fcfcfc;
-	border-bottom: 1px solid #dfdfdf;
+	background: #fff;
+	border-bottom: 1px solid #dcdcde;
 	height: 36px;
 	font-size: 18px;
 	font-weight: 600;
@@ -280,7 +280,7 @@
 	background: none;
 	border: none;
 	box-shadow: none;
-	color: #666;
+	color: #646970;
 	cursor: pointer;
 	display: block;
 	padding: 0;
@@ -308,13 +308,13 @@
 
 .ui-button.ui-dialog-titlebar-close:hover,
 .ui-button.ui-dialog-titlebar-close:focus {
-	color: #006799;
+	color: #135e96;
 }
 
 .ui-button.ui-dialog-titlebar-close:focus {
 	box-shadow:
-		0 0 0 1px #5b9dd9,
-		0 0 2px 1px rgba(30, 140, 190, 0.8);
+		0 0 0 1px #4f94d4,
+		0 0 2px 1px rgba(79, 148, 212, 0.8);
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
 	outline-offset: -2px;
@@ -326,8 +326,8 @@
 }
 
 .ui-dialog-buttonpane {
-	background: #fcfcfc;
-	border-top: 1px solid #dfdfdf;
+	background: #fff;
+	border-top: 1px solid #dcdcde;
 	padding: 16px;
 }
 

--- a/src/wp-includes/css/media-views.css
+++ b/src/wp-includes/css/media-views.css
@@ -36,29 +36,29 @@
 
 .media-frame a {
 	border-bottom: none;
-	color: #0073aa;
+	color: #2271b1;
 }
 
 .media-frame a:hover,
 .media-frame a:active {
-	color: #006799;
+	color: #135e96;
 }
 
 .media-frame a:focus {
 	box-shadow:
-		0 0 0 1px #5b9dd9,
-		0 0 2px 1px rgba(30, 140, 190, 0.8);
-	color: #124964;
+		0 0 0 1px #4f94d4,
+		0 0 2px 1px rgba(79, 148, 212, 0.8);
+	color: #043959;
 	/* Only visible in Windows High Contrast mode */
 	outline: 1px solid transparent;
 }
 
 .media-frame a.button {
-	color: #32373c;
+	color: #2c3338;
 }
 
 .media-frame a.button:hover {
-	color: #23282d;
+	color: #1d2327;
 }
 
 .media-frame a.button-primary,
@@ -95,9 +95,9 @@
 .media-frame select {
 	box-shadow: 0 0 0 transparent;
 	border-radius: 4px;
-	border: 1px solid #7e8993;
+	border: 1px solid #8c8f94;
 	background-color: #fff;
-	color: #32373c;
+	color: #2c3338;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	font-size: 13px;
 }
@@ -134,8 +134,8 @@
 .media-frame input[type="url"]:focus,
 .media-frame textarea:focus,
 .media-frame select:focus {
-	border-color: #007cba;
-	box-shadow: 0 0 0 1px #007cba;
+	border-color: #3582c4;
+	box-shadow: 0 0 0 1px #3582c4;
 	outline: 2px solid transparent;
 }
 
@@ -143,7 +143,7 @@
 .media-frame textarea:disabled,
 .media-frame input[readonly],
 .media-frame textarea[readonly] {
-	background-color: #eee;
+	background-color: #f0f0f1;
 }
 
 .media-frame input[type="search"] {
@@ -151,16 +151,16 @@
 }
 
 .media-frame ::-webkit-input-placeholder {
-	color: #72777c;
+	color: #787c82;
 }
 
 .media-frame ::-moz-placeholder {
-	color: #72777c;
+	color: #787c82;
 	opacity: 1;
 }
 
 .media-frame :-ms-input-placeholder {
-	color: #72777c;
+	color: #787c82;
 }
 
 /*
@@ -227,7 +227,7 @@
 	padding: 0;
 	border: 1px solid transparent;
 	background: none;
-	color: #666;
+	color: #646970;
 	z-index: 1000;
 	cursor: pointer;
 	outline: none;
@@ -236,13 +236,13 @@
 
 .media-modal-close:hover,
 .media-modal-close:active {
-	color: #006799;
+	color: #135e96;
 }
 
 .media-modal-close:focus {
-	color: #006799;
-	border-color: #5b9dd9;
-	box-shadow: 0 0 3px rgba(0, 115, 170, 0.8);
+	color: #135e96;
+	border-color: #4f94d4;
+	box-shadow: 0 0 3px rgba(34, 113, 177, 0.8);
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
 }
@@ -269,7 +269,7 @@
 	overflow: auto;
 	min-height: 300px;
 	box-shadow: 0 5px 15px rgba(0, 0, 0, 0.7);
-	background: #fcfcfc;
+	background: #fff;
 	-webkit-font-smoothing: subpixel-antialiased;
 }
 
@@ -301,7 +301,7 @@
 	z-index: 100;
 	height: 60px;
 	padding: 0 16px;
-	border: 0 solid #ddd;
+	border: 0 solid #dcdcde;
 	overflow: hidden;
 }
 
@@ -310,7 +310,7 @@
 	bottom: -47px;
 	height: auto;
 	overflow: visible;
-	border-top: 1px solid #ddd;
+	border-top: 1px solid #dcdcde;
 }
 
 .media-toolbar-primary {
@@ -348,8 +348,8 @@
 	width: 267px;
 	padding: 0 16px;
 	z-index: 75;
-	background: #f3f3f3;
-	border-left: 1px solid #ddd;
+	background: #f6f7f7;
+	border-left: 1px solid #dcdcde;
 	overflow: auto;
 	-webkit-overflow-scrolling: touch;
 }
@@ -375,7 +375,7 @@
 	font-weight: 600;
 	text-transform: uppercase;
 	font-size: 12px;
-	color: #666;
+	color: #646970;
 	margin: 24px 0 8px;
 }
 
@@ -450,7 +450,7 @@
 	padding-top: 8px;
 	line-height: 1.33333333;
 	font-weight: 400;
-	color: #666;
+	color: #646970;
 }
 
 .media-sidebar .checkbox-label-inline {
@@ -476,7 +476,7 @@
 	min-height: 0;
 	line-height: 2.18181818;
 	text-align: left;
-	color: #40860a;
+	color: #008a20;
 }
 
 .compat-item label span {
@@ -604,10 +604,10 @@
 	bottom: 0;
 	margin: 0;
 	padding: 50px 0 10px;
-	background: #f3f3f3;
+	background: #f6f7f7;
 	border-right-width: 1px;
 	border-right-style: solid;
-	border-right-color: #ccc;
+	border-right-color: #c3c4c7;
 	-webkit-user-select: none;
 	-ms-user-select: none;
 	user-select: none;
@@ -624,7 +624,7 @@
 	font-size: 14px;
 	line-height: 1.28571428;
 	background: transparent;
-	color: #0073aa;
+	color: #2271b1;
 	text-align: left;
 	text-decoration: none;
 	cursor: pointer;
@@ -635,21 +635,21 @@
 }
 
 .media-menu .media-menu-item:active {
-	color: #0073aa;
+	color: #2271b1;
 	outline: none;
 }
 
 .media-menu .active,
 .media-menu .active:hover {
-	color: #23282d;
+	color: #1d2327;
 	font-weight: 600;
 }
 
 .media-menu .media-menu-item:focus {
 	box-shadow:
-		0 0 0 1px #5b9dd9,
-		0 0 2px 1px rgba(30, 140, 190, 0.8);
-	color: #124964;
+		0 0 0 1px #4f94d4,
+		0 0 2px 1px rgba(79, 148, 212, 0.8);
+	color: #043959;
 	/* Only visible in Windows High Contrast mode */
 	outline: 1px solid transparent;
 }
@@ -658,7 +658,7 @@
 	height: 0;
 	margin: 12px 20px;
 	padding: 0;
-	border-top: 1px solid #ddd;
+	border-top: 1px solid #dcdcde;
 }
 
 /**
@@ -692,19 +692,19 @@
 
 .media-router .media-menu-item:hover,
 .media-router .media-menu-item:active {
-	color: #0073aa;
+	color: #2271b1;
 }
 
 .media-router .active,
 .media-router .active:hover {
-	color: #23282d;
+	color: #1d2327;
 }
 
 .media-router .media-menu-item:focus {
 	box-shadow:
-		0 0 0 1px #5b9dd9,
-		0 0 2px 1px rgba(30, 140, 190, 0.8);
-	color: #124964;
+		0 0 0 1px #4f94d4,
+		0 0 2px 1px rgba(79, 148, 212, 0.8);
+	color: #043959;
 	/* Only visible in Windows High Contrast mode */
 	outline: 1px solid transparent;
 }
@@ -713,7 +713,7 @@
 .media-router .media-menu-item.active:last-child {
 	margin: -1px -1px 0;
 	background: #fff;
-	border: 1px solid #ddd;
+	border: 1px solid #dcdcde;
 	border-bottom: none;
 }
 
@@ -771,7 +771,7 @@
 	margin: 0;
 	overflow: auto;
 	background: #fff;
-	border-top: 1px solid #ddd;
+	border-top: 1px solid #dcdcde;
 }
 
 .media-frame-toolbar {
@@ -910,7 +910,7 @@
 	margin: 32px 0 0;
 	padding: 4px;
 	font-size: 13px;
-	color: #444;
+	color: #3c434a;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	-webkit-appearance: none;
 }
@@ -943,7 +943,7 @@
 	float: left;
 	padding: 8px;
 	margin: 0;
-	color: #444;
+	color: #3c434a;
 	cursor: pointer;
 	list-style: none;
 	text-align: center;
@@ -959,7 +959,7 @@
 .wp-core-ui .attachment.details:focus {
 	box-shadow:
 		inset 0 0 2px 3px #fff,
-		inset 0 0 0 7px #5b9dd9;
+		inset 0 0 0 7px #4f94d4;
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
 	outline-offset: -6px;
@@ -968,13 +968,13 @@
 .wp-core-ui .selected.attachment {
 	box-shadow:
 		inset 0 0 0 5px #fff,
-		inset 0 0 0 7px #ccc;
+		inset 0 0 0 7px #c3c4c7;
 }
 
 .wp-core-ui .attachment.details {
 	box-shadow:
 		inset 0 0 0 3px #fff,
-		inset 0 0 0 7px #0073aa;
+		inset 0 0 0 7px #2271b1;
 }
 
 .wp-core-ui .attachment-preview {
@@ -982,7 +982,7 @@
 	box-shadow:
 		inset 0 0 15px rgba(0, 0, 0, 0.1),
 		inset 0 0 0 1px rgba(0, 0, 0, 0.05);
-	background: #eee;
+	background: #f0f0f1;
 	cursor: pointer;
 }
 
@@ -1103,7 +1103,7 @@
 	top: 0;
 	right: 0;
 	outline: none;
-	background: #eee;
+	background: #f0f0f1;
 	cursor: pointer;
 	box-shadow: 0 0 0 1px #fff, 0 0 0 2px rgba(0, 0, 0, 0.15);
 }
@@ -1127,10 +1127,10 @@
 .wp-core-ui .attachment.details .check,
 .wp-core-ui .attachment.selected .check:focus,
 .wp-core-ui .media-frame.mode-grid .attachment.selected .check {
-	background-color: #0073aa;
+	background-color: #2271b1;
 	box-shadow:
 		0 0 0 1px #fff,
-		0 0 0 2px #0073aa;
+		0 0 0 2px #2271b1;
 }
 
 .wp-core-ui .attachment.selected .check:focus {
@@ -1239,7 +1239,7 @@
 
 .uploader-inline .close:before {
 	font: normal 30px/1 dashicons !important;
-	color: #555d66;
+	color: #50575e;
 	display: inline-block;
 	content: "\f335";
 	font-weight: 300;
@@ -1247,8 +1247,8 @@
 }
 
 .uploader-inline .close:focus {
-	outline: 1px solid #5b9dd9;
-	box-shadow: 0 0 3px rgba(0, 115, 170, 0.8);
+	outline: 1px solid #4f94d4;
+	box-shadow: 0 0 3px rgba(34, 113, 177, 0.8);
 }
 
 .attachments-browser.hide-sidebar .attachments,
@@ -1262,7 +1262,7 @@
 	margin-top: 16px;
 	line-height: 1.38461538;
 	font-size: 13px;
-	color: #666;
+	color: #646970;
 }
 
 .attachments-browser .no-media {
@@ -1278,7 +1278,7 @@
 	width: 70%;
 	margin: 10px auto;
 	border-radius: 10px;
-	background: #ddd;
+	background: #dcdcde;
 	background: rgba(0, 0, 0, 0.1);
 }
 
@@ -1286,7 +1286,7 @@
 	height: 10px;
 	min-width: 20px;
 	width: 0;
-	background: #0073aa;
+	background: #2271b1;
 	border-radius: 10px;
 	transition: width 300ms;
 }
@@ -1322,7 +1322,7 @@
 .media-uploader-status .upload-details {
 	display: none;
 	font-size: 12px;
-	color: #666;
+	color: #646970;
 }
 
 .uploading.media-uploader-status .upload-details {
@@ -1334,7 +1334,7 @@
 }
 
 .media-uploader-status .upload-count {
-	color: #444;
+	color: #3c434a;
 }
 
 .media-uploader-status .upload-dismiss-errors,
@@ -1366,29 +1366,29 @@
 	content: "\f153";
 	display: block;
 	font: normal 16px/1 dashicons;
-	color: #72777c;
+	color: #787c82;
 }
 
 .uploader-inline .errors.media-uploader-status .upload-dismiss-errors::before {
-	color: #606a73;
+	color: #646970;
 }
 
 .errors.media-uploader-status .upload-dismiss-errors:hover::before,
 .errors.media-uploader-status .upload-dismiss-errors:focus::before {
-	color: #c00;
+	color: #d63638;
 }
 
 .upload-errors .upload-error {
 	padding: 12px;
 	margin-bottom: 12px;
 	background: #fff;
-	border-left: 4px solid #dc3232;
+	border-left: 4px solid #d63638;
 	box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.1);
 }
 
 .uploader-inline .upload-errors .upload-error {
 	padding: 12px 30px;
-	background-color: #fbeaea;
+	background-color: #fcf0f1;
 	box-shadow: none;
 }
 
@@ -1425,12 +1425,12 @@
 .wp-editor-wrap .uploader-editor {
 	position: absolute;
 	z-index: 99998; /* under the toolbar */
-	background: rgba(150, 150, 150, 0.9);
+	background: rgba(140, 143, 148, 0.9);
 }
 
 .uploader-window,
 .wp-editor-wrap .uploader-editor.droppable {
-	background: rgba(0, 86, 132, 0.9);
+	background: rgba(10, 75, 120, 0.9);
 }
 
 .uploader-window-content,
@@ -1518,7 +1518,7 @@
 
 .uploader-inline .has-upload-message .upload-instructions {
 	font-size: 14px;
-	color: #444;
+	color: #3c434a;
 	font-weight: 400;
 }
 
@@ -1590,14 +1590,14 @@
 	padding: 1px 8px;
 	margin: 1px 8px 1px -8px;
 	line-height: 1.4;
-	border-right: 1px solid #ddd;
-	color: #0073aa;
+	border-right: 1px solid #dcdcde;
+	color: #2271b1;
 	text-decoration: none;
 }
 
 .media-selection .button-link:hover,
 .media-selection .button-link:focus {
-	color: #006799;
+	color: #135e96;
 }
 
 .media-selection .button-link:last-child {
@@ -1606,12 +1606,12 @@
 }
 
 .selection-info .clear-selection {
-	color: #bc0b0b;
+	color: #d63638;
 }
 
 .selection-info .clear-selection:hover,
 .selection-info .clear-selection:focus {
-	color: #dc3232;
+	color: #d63638;
 }
 
 .media-selection .selection-view {
@@ -1655,7 +1655,7 @@
 .wp-core-ui .media-selection .attachment.details:focus {
 	box-shadow:
 		0 0 0 1px #fff,
-		0 0 2px 3px #5b9dd9;
+		0 0 2px 3px #4f94d4;
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
 }
@@ -1667,7 +1667,7 @@
 .wp-core-ui .media-selection .attachment.details {
 	box-shadow:
 		0 0 0 1px #fff,
-		0 0 0 3px #0073aa;
+		0 0 0 3px #2271b1;
 }
 
 .media-selection:after {
@@ -1678,7 +1678,7 @@
 	right: 0;
 	bottom: 0;
 	width: 25px;
-	background-image: linear-gradient(to left, rgba(255, 255, 255, 1), rgba(255, 255, 255, 0));
+	background-image: linear-gradient(to left,#fff,rgba(255, 255, 255, 0));
 }
 
 .media-selection .attachment .filename {
@@ -1758,8 +1758,8 @@
 	min-height: 60px;
 	margin-bottom: 16px;
 	line-height: 1.5;
-	color: #666;
-	border-bottom: 1px solid #ddd;
+	color: #646970;
+	border-bottom: 1px solid #dcdcde;
 	padding-bottom: 11px;
 }
 
@@ -1773,7 +1773,7 @@
 
 .attachment-info .filename {
 	font-weight: 600;
-	color: #444;
+	color: #3c434a;
 	word-wrap: break-word;
 }
 
@@ -1844,7 +1844,7 @@
 .media-modal .untrash-attachment {
 	display: inline;
 	padding: 0;
-	color: #bc0b0b;
+	color: #d63638;
 }
 
 .media-modal .delete-attachment:hover,
@@ -1853,7 +1853,7 @@
 .media-modal .trash-attachment:focus,
 .media-modal .untrash-attachment:hover,
 .media-modal .untrash-attachment:focus {
-	color: #dc3232;
+	color: #d63638;
 }
 
 /**
@@ -1905,8 +1905,8 @@
 }
 
 .media-modal .imgedit-wrap .imgedit-settings {
-	background: #f3f3f3;
-	border-left: 1px solid #ddd;
+	background: #f6f7f7;
+	border-left: 1px solid #dcdcde;
 	padding: 20px 16px 0;
 	position: absolute;
 	top: 0;
@@ -1927,7 +1927,7 @@
 .media-modal .imgedit-group {
 	background: none;
 	border: none;
-	border-bottom: 1px solid #ddd;
+	border-bottom: 1px solid #dcdcde;
 	box-shadow: none;
 	margin: 0;
 	margin-bottom: 16px;
@@ -1951,7 +1951,7 @@
 	display: inline-block;
 	text-transform: uppercase;
 	font-size: 12px;
-	color: #666;
+	color: #646970;
 	margin: 0;
 	margin-top: 3px;
 }
@@ -1959,7 +1959,7 @@
 .media-modal .imgedit-group-top h2 a,
 .media-modal .imgedit-group-top h2 .button-link {
 	text-decoration: none;
-	color: #666;
+	color: #646970;
 }
 
 /* higher specificity than media.css */
@@ -1970,7 +1970,7 @@
 	margin: 0;
 	padding: 0;
 	background: transparent;
-	color: #0074a2;
+	color: #2271b1;
 	font-size: 20px;
 	line-height: 1;
 	cursor: pointer;
@@ -1979,9 +1979,9 @@
 }
 
 .wp-core-ui.media-modal .image-editor .imgedit-help-toggle:focus {
-	color: #0074a2;
-	border-color: #5b9dd9;
-	box-shadow: 0 0 3px rgba(0, 115, 170, 0.8);
+	color: #2271b1;
+	border-color: #4f94d4;
+	box-shadow: 0 0 3px rgba(34, 113, 177, 0.8);
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
 }
@@ -2094,8 +2094,8 @@
 }
 
 .mejs-container:focus {
-	outline: 1px solid #5b9dd9;
-	box-shadow: 0 0 2px 1px rgba(30, 140, 190, 0.8);
+	outline: 1px solid #4f94d4;
+	box-shadow: 0 0 2px 1px rgba(79, 148, 212, 0.8);
 }
 
 .image-details .media-modal {
@@ -2125,8 +2125,8 @@
 }
 
 .image-details .column-settings {
-	background: #f3f3f3;
-	border-right: 1px solid #ddd;
+	background: #f6f7f7;
+	border-right: 1px solid #dcdcde;
 	min-height: 100%;
 	width: 55%;
 	position: absolute;
@@ -2137,8 +2137,8 @@
 .image-details .column-settings h2 {
 	margin: 20px;
 	padding-top: 20px;
-	border-top: 1px solid #ddd;
-	color: #23282d;
+	border-top: 1px solid #dcdcde;
+	color: #1d2327;
 }
 
 .image-details .column-image {
@@ -2159,14 +2159,14 @@
 
 .image-details .advanced-toggle {
 	padding: 0;
-	color: #666;
+	color: #646970;
 	text-transform: uppercase;
 	text-decoration: none;
 }
 
 .image-details .advanced-toggle:hover,
 .image-details .advanced-toggle:active {
-	color: #666;
+	color: #646970;
 }
 
 .image-details .advanced-toggle:after {
@@ -2326,7 +2326,7 @@
 	display: inline-block;
 	font-size: 13px;
 	line-height: 1.84615384;
-	color: #666;
+	color: #646970;
 }
 
 .media-embed .setting span {
@@ -2463,7 +2463,7 @@
 		right: auto;
 		bottom: auto;
 		padding: 5px 0;
-		border: 1px solid #ccc;
+		border: 1px solid #c3c4c7;
 	}
 
 	.media-frame:not(.hide-menu) .media-menu.visible {

--- a/src/wp-includes/css/wp-auth-check.css
+++ b/src/wp-includes/css/wp-auth-check.css
@@ -28,7 +28,7 @@
 	width: 380px;
 	margin: 0 0 0 -190px;
 	padding: 30px 0 0;
-	background-color: #f1f1f1;
+	background-color: #f0f0f1;
 	z-index: 1000011; /* needs to appear above #wp-auth-check-bg */
 	box-shadow: 0 3px 6px rgba(0, 0, 0, 0.3);
 }
@@ -88,7 +88,7 @@
 	right: 5px;
 	height: 22px;
 	width: 22px;
-	color: #72777c;
+	color: #787c82;
 	text-decoration: none;
 	text-align: center;
 }
@@ -103,7 +103,7 @@
 
 #wp-auth-check-wrap .wp-auth-check-close:hover,
 #wp-auth-check-wrap .wp-auth-check-close:focus {
-	color: #0073aa;
+	color: #2271b1;
 }
 
 #wp-auth-check-wrap .wp-auth-fallback-expired {

--- a/src/wp-includes/css/wp-embed-template.css
+++ b/src/wp-includes/css/wp-embed-template.css
@@ -67,9 +67,9 @@ body {
 	font-weight: 400;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	line-height: 1.5;
-	color: #82878c;
+	color: #8c8f94;
 	background: #fff;
-	border: 1px solid #e5e5e5;
+	border: 1px solid #dcdcde;
 	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
 	/* Clearfix */
 	overflow: auto;
@@ -77,7 +77,7 @@ body {
 }
 
 .wp-embed a {
-	color: #82878c;
+	color: #8c8f94;
 	text-decoration: none;
 }
 
@@ -113,11 +113,11 @@ p.wp-embed-heading {
 }
 
 .wp-embed-heading a {
-	color: #32373c;
+	color: #2c3338;
 }
 
 .wp-embed .wp-embed-more {
-	color: #b4b9be;
+	color: #c3c4c7;
 }
 
 .wp-embed-footer {
@@ -165,7 +165,7 @@ p.wp-embed-heading {
 
 .wp-embed-meta a:hover {
 	text-decoration: none;
-	color: #0073aa;
+	color: #2271b1;
 }
 
 .wp-embed-comments a {
@@ -183,8 +183,8 @@ p.wp-embed-heading {
 	left: 0;
 	right: 0;
 	bottom: 0;
-	background-color: #222;
-	background-color: rgba(10, 10, 10, 0.9);
+	background-color: #1d2327;
+	background-color: rgba(0, 0, 0, 0.9);
 	color: #fff;
 	opacity: 1;
 	transition: opacity .25s ease-in-out;
@@ -216,7 +216,7 @@ p.wp-embed-heading {
 
 .wp-embed-share-dialog-open:focus .dashicons,
 .wp-embed-share-dialog-close:focus .dashicons {
-	box-shadow: 0 0 0 1px #5b9dd9, 0 0 2px 1px rgba(30, 140, 190, 0.8);
+	box-shadow: 0 0 0 1px #4f94d4, 0 0 2px 1px rgba(79, 148, 212, 0.8);
 	border-radius: 100%;
 }
 
@@ -265,7 +265,7 @@ p.wp-embed-heading {
 	background: transparent;
 	font-size: 16px;
 	line-height: 1.3;
-	color: #aaa;
+	color: #a7aaad;
 	cursor: pointer;
 	transition: color .1s ease-in;
 }
@@ -281,7 +281,7 @@ p.wp-embed-heading {
 .wp-embed-share-tab-button + .wp-embed-share-tab-button {
 	margin: 0 0 0 10px;
 	padding: 0 0 0 11px;
-	border-left: 1px solid #aaa;
+	border-left: 1px solid #a7aaad;
 }
 
 .wp-embed-share-tab[aria-hidden="true"] {
@@ -293,7 +293,7 @@ p.wp-embed-share-description {
 	font-size: 14px;
 	line-height: 1;
 	font-style: italic;
-	color: #aaa;
+	color: #a7aaad;
 }
 
 .wp-embed-share-input {
@@ -355,5 +355,5 @@ html[dir="rtl"] .wp-embed-share-tab-button + .wp-embed-share-tab-button {
 	margin: 0 10px 0 0;
 	padding: 0 11px 0 0;
 	border-left: none;
-	border-right: 1px solid #aaa;
+	border-right: 1px solid #a7aaad;
 }

--- a/src/wp-includes/css/wp-pointer.css
+++ b/src/wp-includes/css/wp-pointer.css
@@ -3,26 +3,26 @@
 	position: relative;
 	font-size: 13px;
 	background: #fff;
-	border: 1px solid #ddd;
-	box-shadow: 0 3px 6px rgba(0, 0, 0, 0.075);
+	border: 1px solid #dcdcde;
+	box-shadow: 0 3px 6px rgba(0, 0, 0, 0.08);
 }
 
 .wp-pointer-content h3 {
 	position: relative;
 	margin: -1px -1px 5px;
 	padding: 15px 18px 14px 60px;
-	border: 1px solid #3592b6;
+	border: 1px solid #72aee6;
 	border-bottom: none;
 	line-height: 1.4;
 	font-size: 14px;
 	color: #fff;
-	background: #00a0d2;
+	background: #72aee6;
 }
 
 .wp-pointer-content h3:before {
 	background: #fff;
 	border-radius: 50%;
-	color: #00a0d2;
+	color: #72aee6;
 	content: "\f227";
 	font: normal 20px/1.6 dashicons;
 	position: absolute;
@@ -64,7 +64,7 @@
 
 .wp-pointer-buttons a.close:before {
 	background: none;
-	color: #72777c;
+	color: #787c82;
 	content: "\f153";
 	display: block !important;
 	font: normal 16px/1 dashicons;
@@ -80,7 +80,7 @@
 }
 
 .wp-pointer-buttons a.close:hover:before {
-	color: #c00;
+	color: #d63638;
 }
 
 /* The arrow base class must take up no space, even with transparent borders. */
@@ -141,7 +141,7 @@
 .wp-pointer-undefined .wp-pointer-arrow {
 	top: 0;
 	border-width: 0 13px 13px 13px;
-	border-bottom-color: #3592b6;
+	border-bottom-color: #72aee6;
 }
 
 .wp-pointer-top .wp-pointer-arrow-inner,
@@ -150,7 +150,7 @@
 	margin-left: -13px;
 	margin-top: -13px;
 	border: 13px solid transparent;
-	border-bottom-color: #00a0d2;
+	border-bottom-color: #72aee6;
 	display: block;
 	content: " ";
 }
@@ -158,7 +158,7 @@
 .wp-pointer-bottom .wp-pointer-arrow {
 	bottom: 0;
 	border-width: 13px 13px 0 13px;
-	border-top-color: #ccc;
+	border-top-color: #c3c4c7;
 }
 
 .wp-pointer-bottom .wp-pointer-arrow-inner {
@@ -175,7 +175,7 @@
 .wp-pointer-left .wp-pointer-arrow {
 	left: 0;
 	border-width: 13px 13px 13px 0;
-	border-right-color: #ccc;
+	border-right-color: #c3c4c7;
 }
 
 /* rtl:ignore */
@@ -193,7 +193,7 @@
 .wp-pointer-right .wp-pointer-arrow {
 	right: 0;
 	border-width: 13px 0 13px 13px;
-	border-left-color: #ccc;
+	border-left-color: #c3c4c7;
 }
 
 /* rtl:ignore */


### PR DESCRIPTION
This is part of a longer project in cleaning up core's admin CSS; eventually making color schemes easier and a dark mode possible. It collapses all colors used in the CSS to one of the colors listed in [this color palette](https://i2.wp.com/make.wordpress.org/design/files/2019/11/image-21-scaled.png?ssl=1).

In the short-term, it also visually cleans up the admin, and should help any newer projects make design decisions with consistency.

The process was initially **automated**, with some very basic manual cleanup, so it should be visually checked for contrast and if anything's off with the design.

[See some before & after screenshots here.](https://ryelle.codes/core/colors/index.html)

This brings down the total number of colors used in core CSS down to **97** unique values (from 258 ❗ ).

Trac ticket: https://core.trac.wordpress.org/ticket/49999

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
