### PR TITLE
Blocks: Align with Gutenberg the name of generated asset handle for core blocks

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -73,7 +73,7 @@ function remove_block_asset_path_prefix( $asset_handle_or_path ) {
 function generate_block_asset_handle( $block_name, $field_name ) {
 	if ( 0 === strpos( $block_name, 'core/' ) ) {
 		$asset_handle = str_replace( 'core/', 'wp-block-', $block_name );
-		if ( strpos( $field_name, 'editor' ) === 0 ) {
+		if ( 0 === strpos( $field_name, 'editor' ) ) {
 			$asset_handle .= '-editor';
 		}
 		return $asset_handle;

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -71,7 +71,7 @@ function remove_block_asset_path_prefix( $asset_handle_or_path ) {
  * @return string Generated asset name for the block's field.
  */
 function generate_block_asset_handle( $block_name, $field_name ) {
-	if ( strpos( $block_name, 'core/' ) === 0 ) {
+	if ( 0 === strpos( $block_name, 'core/' ) ) {
 		$asset_handle = str_replace( 'core/', 'wp-block-', $block_name );
 		if ( strpos( $field_name, 'editor' ) === 0 ) {
 			$asset_handle .= '-editor';

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -71,6 +71,14 @@ function remove_block_asset_path_prefix( $asset_handle_or_path ) {
  * @return string Generated asset name for the block's field.
  */
 function generate_block_asset_handle( $block_name, $field_name ) {
+	if ( strpos( $block_name, 'core/' ) === 0 ) {
+		$asset_handle = str_replace( 'core/', 'wp-block-', $block_name );
+		if ( strpos( $field_name, 'editor' ) === 0 ) {
+			$asset_handle .= '-editor';
+		}
+		return $asset_handle;
+	}
+
 	$field_mappings = array(
 		'editorScript' => 'editor-script',
 		'script'       => 'script',

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -145,6 +145,30 @@ class WP_Test_Block_Register extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 50328
+	 */
+	function test_generate_block_asset_handle_core_block() {
+		$block_name = 'core/paragraph';
+
+		$this->assertSame(
+			'wp-block-paragraph-editor',
+			generate_block_asset_handle( $block_name, 'editorScript' )
+		);
+		$this->assertSame(
+			'wp-block-paragraph',
+			generate_block_asset_handle( $block_name, 'script' )
+		);
+		$this->assertSame(
+			'wp-block-paragraph-editor',
+			generate_block_asset_handle( $block_name, 'editorStyle' )
+		);
+		$this->assertSame(
+			'wp-block-paragraph',
+			generate_block_asset_handle( $block_name, 'style' )
+		);
+	}
+
+	/**
 	 * @ticket 50263
 	 */
 	function test_field_not_found_register_block_script_handle() {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/50328

Related Gutenberg PR: https://github.com/WordPress/gutenberg/pull/25220.

This change tries to align with the latest changes added by @aristath to the Gutenberg project. As part of styles splitting for core blocks, there was a special pattern introduced for how style handles are named. Ideally, we would apply it to all blocks but there might be some backward compatibility considerations so I left the handling for non-core blocks unchanged.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
