### PR TITLE
Blocks: Add filters for registration from metadata

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -208,7 +208,7 @@ function register_block_type_from_metadata( $file_or_folder, $args = array() ) {
 	 *
 	 * @param array $metadata Metadata for registering a block type.
 	 */
-	$metadata = apply_filters( 'pre_register_block_type_from_metadata', $metadata );
+	$metadata = apply_filters( 'block_type_metadata', $metadata );
 
 	$settings          = array();
 	$property_mappings = array(
@@ -270,7 +270,7 @@ function register_block_type_from_metadata( $file_or_folder, $args = array() ) {
 	 * @param array $metadata Metadata provided for registering a block type.
 	 */
 	$settings = apply_filters(
-		'post_register_block_type_from_metadata',
+		'block_type_metadata_settings',
 		array_merge(
 			$settings,
 			$args

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -201,6 +201,15 @@ function register_block_type_from_metadata( $file_or_folder, $args = array() ) {
 	}
 	$metadata['file'] = $metadata_file;
 
+	/**
+	 * Filters the metadata provided for registering a block type.
+	 *
+	 * @since 5.7.0
+	 *
+	 * @param array $metadata Metadata for registering a block type.
+	 */
+	$metadata = apply_filters( 'pre_register_block_type_from_metadata', $metadata );
+
 	$settings          = array();
 	$property_mappings = array(
 		'title'           => 'title',
@@ -252,12 +261,26 @@ function register_block_type_from_metadata( $file_or_folder, $args = array() ) {
 		);
 	}
 
-	return register_block_type(
-		$metadata['name'],
+	/**
+	 * Filters the settings determined from the block type metadata.
+	 *
+	 * @since 5.7.0
+	 *
+	 * @param array $settings Array of determined settings for registering a block type.
+	 * @param array $metadata Metadata provided for registering a block type.
+	 */
+	$settings = apply_filters(
+		'post_register_block_type_from_metadata',
 		array_merge(
 			$settings,
 			$args
-		)
+		),
+		$metadata
+	);
+
+	return register_block_type(
+		$metadata['name'],
+		$settings
 	);
 }
 

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -422,7 +422,10 @@ class WP_Test_Block_Register extends WP_UnitTestCase {
 		$this->assertSame( 'boolean', $block_type->attributes['core/test-filtered']['type'] );
 	}
 
-	public function test_filter_pre_block_registration_from_metadata() {
+	/**
+	 * @ticket 52138
+	 */
+	public function test_filter_block_registration_metadata() {
 		$filter_metadata_registration = function( $metadata ) {
 			$metadata['apiVersion'] = 3;
 			return $metadata;
@@ -437,7 +440,10 @@ class WP_Test_Block_Register extends WP_UnitTestCase {
 		$this->assertSame( 3, $result->api_version );
 	}
 
-	public function test_filter_post_block_registration_from_metadata() {
+	/**
+	 * @ticket 52138
+	 */
+	public function test_filter_block_registration_metadata_settings() {
 		$filter_metadata_registration = function( $settings, $metadata ) {
 			$settings['api_version'] = $metadata['apiVersion'] + 1;
 			return $settings;

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -428,11 +428,11 @@ class WP_Test_Block_Register extends WP_UnitTestCase {
 			return $metadata;
 		};
 
-		add_filter( 'pre_register_block_type_from_metadata', $filter_metadata_registration, 10, 2 );
+		add_filter( 'block_type_metadata', $filter_metadata_registration, 10, 2 );
 		$result = register_block_type_from_metadata(
 			__DIR__ . '/fixtures'
 		);
-		remove_filter( 'pre_register_block_type_from_metadata', $filter_metadata_registration );
+		remove_filter( 'block_type_metadata', $filter_metadata_registration );
 
 		$this->assertSame( 3, $result->api_version );
 	}
@@ -443,11 +443,11 @@ class WP_Test_Block_Register extends WP_UnitTestCase {
 			return $settings;
 		};
 
-		add_filter( 'post_register_block_type_from_metadata', $filter_metadata_registration, 10, 2 );
+		add_filter( 'block_type_metadata_settings', $filter_metadata_registration, 10, 2 );
 		$result = register_block_type_from_metadata(
 			__DIR__ . '/fixtures'
 		);
-		remove_filter( 'post_register_block_type_from_metadata', $filter_metadata_registration );
+		remove_filter( 'block_type_metadata_settings', $filter_metadata_registration );
 
 		$this->assertSame( 3, $result->api_version );
 	}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->https://core.trac.wordpress.org/ticket/52138

Related: https://github.com/WordPress/gutenberg/pull/25220, https://core.trac.wordpress.org/ticket/49615

With changes added in https://core.trac.wordpress.org/ticket/49615, it is possible to filter the settings of a block type during its registration with `register_block_type_args`. However, when working https://github.com/WordPress/gutenberg/pull/25220, we discovered that it is still not enough for the case when blocks are registered with block.json metadata. As of today, all core blocks are registered this way and it's impossible to customize the way their styles and scripts are registered or i18n support is handled. The idea here is to add more filters to give more options for plugin authors in the future and account for the needs that Gutenberg has in the constant work to improve the experience around block registration.

The attached patch seeks to follow with 2 new hooks:

- Named `pre_register_block_type_from_metadata` to filter the content of metadata read from block.json
- Named `post_register_block_type_from_metadata` to filter the settings object determined from the metadata that is passed to `register_block_type` call
I'm 100% sure we need the first one. In terms of adding the second one, I'm open to discussion since it might duplicate the scope of `register_block_type_args` with the only difference that it contains also the metadata object as an argument passed for processing.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
