### PR TITLE
Send the actual error data in response

### DIFF
--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -530,7 +530,8 @@ class WP_REST_Server {
 				);
 
 				$result = $this->error_to_response( $json_error_obj );
-				$result = wp_json_encode( $result->data[0] );
+				
+				$result = wp_json_encode( $result->data );
 			}
 
 			if ( $jsonp_callback ) {


### PR DESCRIPTION
Fixes a bug where null responses were sent when a PHP error occurs.

In this case, the array key `0` doesn't exist, so a Notice is thrown. By correcting this inaccurate array key usage, the output is as expected.

I did not include a test with this PR because `tests/rest-api/rest-server::test_does_not_echo_body_for_null_responses()` already checks null responses. This one fails because of the notice.

Trac ticket: https://core.trac.wordpress.org/ticket/52106

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
