### PR TITLE
List Tables: Try using flexbox for row actions on smaller screens

### DIFF
--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -1871,21 +1871,25 @@ div.action-links,
 		padding-top: 10px;
 	}
 
-	/* Make row actions more easy to select on mobile */
-	body:not(.plugins-php) .row-actions {
-		display: grid;
-		grid-template-columns: auto auto auto;
-		color: transparent;
+	.row-actions {
+		margin-left: -8px;
+		margin-right: -8px;
+		padding-top: 4px;
 	}
 
-	.row-actions span {
-		padding: 4px 0;
+	/* Make row actions more easy to select on mobile */
+	body:not(.plugins-php) .row-actions {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 8px;
+		justify-content: space-between;
+		color: transparent;
 	}
 
 	.row-actions span a,
 	.row-actions span .button-link {
 		display: inline-block;
-		padding: 4px 0;
+		padding: 4px 8px;
 		line-height: 1.5;
 	}
 
@@ -2135,16 +2139,16 @@ div.action-links,
 		margin-right: 0;
 		width: 100%;
 	}
+
+	table.media .column-title .has-media-icon ~ .row-actions {
+		margin-left: 0;
+		clear: both;
+	}
 }
 
 @media screen and (max-width: 480px) {
 	.tablenav-pages .current-page {
 		margin: 0;
-	}
-
-	/* Drop row actions to two columns on a small screen */
-	.row-actions:not(.plugins-php) {
-		grid-template-columns: auto auto;
 	}
 
 	.tablenav.bottom .displaying-num {

--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -1882,7 +1882,6 @@ div.action-links,
 		display: flex;
 		flex-wrap: wrap;
 		gap: 8px;
-		justify-content: space-between;
 		color: transparent;
 	}
 


### PR DESCRIPTION
This updates the row actions CSS to use flexbox with a full-width layout, placing the extra space between each action item.

~It also updates the min-width of each item to `10em`, just to keep that larger touch-target. That's an arbitrary amount, we can tweak that if another value looks better.~

I removed the 10em width in favor of extra padding around each item, since it wasn't very clear that the whole space is a touch target.

<details>
<summary>These screenshots are out of date.</summary>

At 782px, it switches to the full-width flexbox layout:

![780px](https://user-images.githubusercontent.com/541093/102548507-c46ade00-4088-11eb-844a-6ba44a7c1918.png)

Around 660px the last item wraps

![660px](https://user-images.githubusercontent.com/541093/102548506-c46ade00-4088-11eb-9322-790b8593cbeb.png)

Around 510px the 3rd item wraps

![510px](https://user-images.githubusercontent.com/541093/102548505-c46ade00-4088-11eb-8e83-305910800f56.png)

Around 375px, each item it on its own line

![375px](https://user-images.githubusercontent.com/541093/102548503-c3d24780-4088-11eb-96cd-2c314df8df05.png)
</details>

Trac ticket: https://core.trac.wordpress.org/ticket/47895

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
