### PR TITLE
Twenty Twenty-One: Set a max-width on inputs

### DIFF
--- a/src/wp-content/themes/twentytwentyone/assets/css/ie.css
+++ b/src/wp-content/themes/twentytwentyone/assets/css/ie.css
@@ -1475,6 +1475,7 @@ input[type=text] {
 	line-height: 1.7;
 	padding: 10px;
 	margin: 0 2px;
+	max-width: 100%;
 }
 
 input[type=email] {
@@ -1484,6 +1485,7 @@ input[type=email] {
 	line-height: 1.7;
 	padding: 10px;
 	margin: 0 2px;
+	max-width: 100%;
 }
 
 input[type=url] {
@@ -1493,6 +1495,7 @@ input[type=url] {
 	line-height: 1.7;
 	padding: 10px;
 	margin: 0 2px;
+	max-width: 100%;
 }
 
 input[type=password] {
@@ -1502,6 +1505,7 @@ input[type=password] {
 	line-height: 1.7;
 	padding: 10px;
 	margin: 0 2px;
+	max-width: 100%;
 }
 
 input[type=search] {
@@ -1511,6 +1515,7 @@ input[type=search] {
 	line-height: 1.7;
 	padding: 10px;
 	margin: 0 2px;
+	max-width: 100%;
 }
 
 input[type=number] {
@@ -1520,6 +1525,7 @@ input[type=number] {
 	line-height: 1.7;
 	padding: 10px;
 	margin: 0 2px;
+	max-width: 100%;
 }
 
 input[type=tel] {
@@ -1529,6 +1535,7 @@ input[type=tel] {
 	line-height: 1.7;
 	padding: 10px;
 	margin: 0 2px;
+	max-width: 100%;
 }
 
 input[type=date] {
@@ -1538,6 +1545,7 @@ input[type=date] {
 	line-height: 1.7;
 	padding: 10px;
 	margin: 0 2px;
+	max-width: 100%;
 }
 
 input[type=month] {
@@ -1547,6 +1555,7 @@ input[type=month] {
 	line-height: 1.7;
 	padding: 10px;
 	margin: 0 2px;
+	max-width: 100%;
 }
 
 input[type=week] {
@@ -1556,6 +1565,7 @@ input[type=week] {
 	line-height: 1.7;
 	padding: 10px;
 	margin: 0 2px;
+	max-width: 100%;
 }
 
 input[type=time] {
@@ -1565,6 +1575,7 @@ input[type=time] {
 	line-height: 1.7;
 	padding: 10px;
 	margin: 0 2px;
+	max-width: 100%;
 }
 
 input[type=datetime] {
@@ -1574,6 +1585,7 @@ input[type=datetime] {
 	line-height: 1.7;
 	padding: 10px;
 	margin: 0 2px;
+	max-width: 100%;
 }
 
 input[type=datetime-local] {
@@ -1583,6 +1595,7 @@ input[type=datetime-local] {
 	line-height: 1.7;
 	padding: 10px;
 	margin: 0 2px;
+	max-width: 100%;
 }
 
 input[type=color] {
@@ -1592,6 +1605,7 @@ input[type=color] {
 	line-height: 1.7;
 	padding: 10px;
 	margin: 0 2px;
+	max-width: 100%;
 }
 
 .site textarea {
@@ -1601,6 +1615,7 @@ input[type=color] {
 	line-height: 1.7;
 	padding: 10px;
 	margin: 0 2px;
+	max-width: 100%;
 }
 
 input[type=text]:focus {

--- a/src/wp-content/themes/twentytwentyone/assets/sass/04-elements/forms.scss
+++ b/src/wp-content/themes/twentytwentyone/assets/sass/04-elements/forms.scss
@@ -20,6 +20,7 @@ input[type="color"],
 	padding: var(--form--spacing-unit);
 	// Gives a little more space for the outline offset.
 	margin: 0 2px;
+	max-width: 100%;
 
 	&:focus {
 		color: var(--form--color-text);

--- a/src/wp-content/themes/twentytwentyone/style-rtl.css
+++ b/src/wp-content/themes/twentytwentyone/style-rtl.css
@@ -1217,6 +1217,7 @@ input[type=color],
 	line-height: var(--global--line-height-body);
 	padding: var(--form--spacing-unit);
 	margin: 0 2px;
+	max-width: 100%;
 }
 
 input[type=text]:focus,

--- a/src/wp-content/themes/twentytwentyone/style.css
+++ b/src/wp-content/themes/twentytwentyone/style.css
@@ -1225,6 +1225,7 @@ input[type=color],
 	line-height: var(--global--line-height-body);
 	padding: var(--form--spacing-unit);
 	margin: 0 2px;
+	max-width: 100%;
 }
 
 input[type=text]:focus,


### PR DESCRIPTION
Inputs with a set `size` attribute are not correctly resized on very small screens. For example, if an input is 40 characters wide, when the screen goes smaller than 400px, it scrolls offscreen. This adds a `max-width` to cap the width to the container size.

Before:
![400-before](https://user-images.githubusercontent.com/541093/102641913-e0bf5700-412a-11eb-83a5-88ac04453748.png)

After:
![400-after](https://user-images.githubusercontent.com/541093/102641911-e0bf5700-412a-11eb-98ec-0fa51d812e38.png)

Trac ticket: https://core.trac.wordpress.org/ticket/52083

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
