### PR TITLE
Twenty Twenty-One: Update table style for dark mode, editor consistency

### DIFF
--- a/src/wp-content/themes/twentytwentyone/assets/css/ie-editor.css
+++ b/src/wp-content/themes/twentytwentyone/assets/css/ie-editor.css
@@ -2885,11 +2885,11 @@ table.is-style-stripes tbody tr:nth-child(odd) {
 }
 
 table.is-style-stripes .has-background tbody tr:nth-child(odd) {
-	background-color: #f0f0f0;
+	background-color: rgba(255, 255, 255, 0.9);
 }
 
 .wp-block-table.is-style-stripes .has-background tbody tr:nth-child(odd) {
-	background-color: #f0f0f0;
+	background-color: rgba(255, 255, 255, 0.9);
 }
 
 table.wp-calendar-table td,

--- a/src/wp-content/themes/twentytwentyone/assets/css/ie-editor.css
+++ b/src/wp-content/themes/twentytwentyone/assets/css/ie-editor.css
@@ -2825,6 +2825,10 @@ table.is-style-regular .has-background {
 	color: #28303d;
 }
 
+table.is-style-stripes .has-background {
+	color: #28303d;
+}
+
 table.is-style-stripes .has-background thead tr {
 	color: #28303d;
 }
@@ -2833,11 +2837,15 @@ table.is-style-stripes .has-background tfoot tr {
 	color: #28303d;
 }
 
-table.is-style-stripes .has-background tbody tr:nth-child(even) {
+table.is-style-stripes .has-background tbody tr {
 	color: #28303d;
 }
 
 .wp-block-table.is-style-regular .has-background {
+	color: #28303d;
+}
+
+.wp-block-table.is-style-stripes .has-background {
 	color: #28303d;
 }
 
@@ -2849,7 +2857,7 @@ table.is-style-stripes .has-background tbody tr:nth-child(even) {
 	color: #28303d;
 }
 
-.wp-block-table.is-style-stripes .has-background tbody tr:nth-child(even) {
+.wp-block-table.is-style-stripes .has-background tbody tr {
 	color: #28303d;
 }
 
@@ -2873,6 +2881,14 @@ table.is-style-stripes tbody tr:nth-child(odd) {
 }
 
 .wp-block-table.is-style-stripes tbody tr:nth-child(odd) {
+	background-color: #f0f0f0;
+}
+
+table.is-style-stripes .has-background tbody tr:nth-child(odd) {
+	background-color: #f0f0f0;
+}
+
+.wp-block-table.is-style-stripes .has-background tbody tr:nth-child(odd) {
 	background-color: #f0f0f0;
 }
 

--- a/src/wp-content/themes/twentytwentyone/assets/css/ie-editor.css
+++ b/src/wp-content/themes/twentytwentyone/assets/css/ie-editor.css
@@ -2790,6 +2790,13 @@ hr.is-style-dots:before {
 	background: none;
 }
 
+table thead,
+table tfoot,
+.wp-block-table thead,
+.wp-block-table tfoot {
+	text-align: center;
+}
+
 table th {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 }

--- a/src/wp-content/themes/twentytwentyone/assets/css/ie.css
+++ b/src/wp-content/themes/twentytwentyone/assets/css/ie.css
@@ -5094,11 +5094,11 @@ table.is-style-stripes tbody tr:nth-child(odd) {
 }
 
 table.is-style-stripes .has-background tbody tr:nth-child(odd) {
-	background-color: #f0f0f0;
+	background-color: rgba(255, 255, 255, 0.9);
 }
 
 .wp-block-table.is-style-stripes .has-background tbody tr:nth-child(odd) {
-	background-color: #f0f0f0;
+	background-color: rgba(255, 255, 255, 0.9);
 }
 
 table.wp-calendar-table td,

--- a/src/wp-content/themes/twentytwentyone/assets/css/ie.css
+++ b/src/wp-content/themes/twentytwentyone/assets/css/ie.css
@@ -4985,6 +4985,13 @@ table,
 	border-collapse: collapse;
 }
 
+table thead,
+table tfoot,
+.wp-block-table thead,
+.wp-block-table tfoot {
+	text-align: center;
+}
+
 table th {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 }
@@ -5011,6 +5018,16 @@ table th {
 .wp-block-table th {
 	padding: 10px;
 	border: 1px solid;
+}
+
+table figcaption {
+	color: #28303d;
+	font-size: 1rem;
+}
+
+.wp-block-table figcaption {
+	color: #28303d;
+	font-size: 1rem;
 }
 
 table.is-style-regular .has-background {

--- a/src/wp-content/themes/twentytwentyone/assets/css/ie.css
+++ b/src/wp-content/themes/twentytwentyone/assets/css/ie.css
@@ -5034,6 +5034,10 @@ table.is-style-regular .has-background {
 	color: #28303d;
 }
 
+table.is-style-stripes .has-background {
+	color: #28303d;
+}
+
 table.is-style-stripes .has-background thead tr {
 	color: #28303d;
 }
@@ -5042,11 +5046,15 @@ table.is-style-stripes .has-background tfoot tr {
 	color: #28303d;
 }
 
-table.is-style-stripes .has-background tbody tr:nth-child(even) {
+table.is-style-stripes .has-background tbody tr {
 	color: #28303d;
 }
 
 .wp-block-table.is-style-regular .has-background {
+	color: #28303d;
+}
+
+.wp-block-table.is-style-stripes .has-background {
 	color: #28303d;
 }
 
@@ -5058,7 +5066,7 @@ table.is-style-stripes .has-background tbody tr:nth-child(even) {
 	color: #28303d;
 }
 
-.wp-block-table.is-style-stripes .has-background tbody tr:nth-child(even) {
+.wp-block-table.is-style-stripes .has-background tbody tr {
 	color: #28303d;
 }
 
@@ -5082,6 +5090,14 @@ table.is-style-stripes tbody tr:nth-child(odd) {
 }
 
 .wp-block-table.is-style-stripes tbody tr:nth-child(odd) {
+	background-color: #f0f0f0;
+}
+
+table.is-style-stripes .has-background tbody tr:nth-child(odd) {
+	background-color: #f0f0f0;
+}
+
+.wp-block-table.is-style-stripes .has-background tbody tr:nth-child(odd) {
 	background-color: #f0f0f0;
 }
 

--- a/src/wp-content/themes/twentytwentyone/assets/css/style-dark-mode-rtl.css
+++ b/src/wp-content/themes/twentytwentyone/assets/css/style-dark-mode-rtl.css
@@ -11,6 +11,10 @@
 		--button--color-background: var(--global--color-secondary);
 		--button--color-background-active: var(--global--color-background);
 		--global--color-border: #9ea1a7;
+
+		/* Block: Table */
+		--table--stripes-border-color: rgba(240, 240, 240, 0.15);
+		--table--stripes-background-color: rgba(240, 240, 240, 0.15);
 	}
 
 	.is-dark-theme.is-dark-theme .site a:focus:not(.wp-block-button__link):not(.wp-block-file__button),

--- a/src/wp-content/themes/twentytwentyone/assets/css/style-dark-mode.css
+++ b/src/wp-content/themes/twentytwentyone/assets/css/style-dark-mode.css
@@ -11,6 +11,10 @@
 		--button--color-background: var(--global--color-secondary);
 		--button--color-background-active: var(--global--color-background);
 		--global--color-border: #9ea1a7;
+
+		/* Block: Table */
+		--table--stripes-border-color: rgba(240, 240, 240, 0.15);
+		--table--stripes-background-color: rgba(240, 240, 240, 0.15);
 	}
 
 	.is-dark-theme.is-dark-theme .site a:focus:not(.wp-block-button__link):not(.wp-block-file__button),

--- a/src/wp-content/themes/twentytwentyone/assets/css/style-editor.css
+++ b/src/wp-content/themes/twentytwentyone/assets/css/style-editor.css
@@ -2081,7 +2081,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 
 table.is-style-stripes .has-background tbody tr:nth-child(odd),
 .wp-block-table.is-style-stripes .has-background tbody tr:nth-child(odd) {
-	background-color: var(--global--color-light-gray);
+	background-color: var(--global--color-white-90);
 }
 
 table.wp-calendar-table td,

--- a/src/wp-content/themes/twentytwentyone/assets/css/style-editor.css
+++ b/src/wp-content/themes/twentytwentyone/assets/css/style-editor.css
@@ -2050,13 +2050,15 @@ table th,
 }
 
 table.is-style-regular .has-background,
+table.is-style-stripes .has-background,
 table.is-style-stripes .has-background thead tr,
 table.is-style-stripes .has-background tfoot tr,
-table.is-style-stripes .has-background tbody tr:nth-child(even),
+table.is-style-stripes .has-background tbody tr,
 .wp-block-table.is-style-regular .has-background,
+.wp-block-table.is-style-stripes .has-background,
 .wp-block-table.is-style-stripes .has-background thead tr,
 .wp-block-table.is-style-stripes .has-background tfoot tr,
-.wp-block-table.is-style-stripes .has-background tbody tr:nth-child(even) {
+.wp-block-table.is-style-stripes .has-background tbody tr {
 	color: var(--table--has-background-text-color);
 }
 
@@ -2075,6 +2077,11 @@ table.is-style-stripes td,
 table.is-style-stripes tbody tr:nth-child(odd),
 .wp-block-table.is-style-stripes tbody tr:nth-child(odd) {
 	background-color: var(--table--stripes-background-color);
+}
+
+table.is-style-stripes .has-background tbody tr:nth-child(odd),
+.wp-block-table.is-style-stripes .has-background tbody tr:nth-child(odd) {
+	background-color: var(--global--color-light-gray);
 }
 
 table.wp-calendar-table td,

--- a/src/wp-content/themes/twentytwentyone/assets/css/style-editor.css
+++ b/src/wp-content/themes/twentytwentyone/assets/css/style-editor.css
@@ -2030,6 +2030,13 @@ hr.is-style-dots:before {
 	background: none;
 }
 
+table thead,
+table tfoot,
+.wp-block-table thead,
+.wp-block-table tfoot {
+	text-align: center;
+}
+
 table th,
 .wp-block-table th {
 	font-family: var(--heading--font-family);

--- a/src/wp-content/themes/twentytwentyone/assets/sass/05-blocks/table/_editor.scss
+++ b/src/wp-content/themes/twentytwentyone/assets/sass/05-blocks/table/_editor.scss
@@ -1,6 +1,11 @@
 table,
 .wp-block-table {
 
+	thead,
+	tfoot {
+		text-align: center;
+	}
+
 	th {
 		font-family: var(--heading--font-family);
 	}

--- a/src/wp-content/themes/twentytwentyone/assets/sass/05-blocks/table/_editor.scss
+++ b/src/wp-content/themes/twentytwentyone/assets/sass/05-blocks/table/_editor.scss
@@ -16,9 +16,10 @@ table,
 	}
 
 	&.is-style-regular .has-background,
+	&.is-style-stripes .has-background,
 	&.is-style-stripes .has-background thead tr,
 	&.is-style-stripes .has-background tfoot tr,
-	&.is-style-stripes .has-background tbody tr:nth-child(even) {
+	&.is-style-stripes .has-background tbody tr {
 		color: var(--table--has-background-text-color);
 	}
 
@@ -32,6 +33,10 @@ table,
 
 		tbody tr:nth-child(odd) {
 			background-color: var(--table--stripes-background-color);
+		}
+
+		.has-background tbody tr:nth-child(odd) {
+			background-color: var(--global--color-light-gray);
 		}
 	}
 }

--- a/src/wp-content/themes/twentytwentyone/assets/sass/05-blocks/table/_editor.scss
+++ b/src/wp-content/themes/twentytwentyone/assets/sass/05-blocks/table/_editor.scss
@@ -36,7 +36,7 @@ table,
 		}
 
 		.has-background tbody tr:nth-child(odd) {
-			background-color: var(--global--color-light-gray);
+			background-color: var(--global--color-white-90);
 		}
 	}
 }

--- a/src/wp-content/themes/twentytwentyone/assets/sass/05-blocks/table/_style.scss
+++ b/src/wp-content/themes/twentytwentyone/assets/sass/05-blocks/table/_style.scss
@@ -25,9 +25,10 @@ table,
 	}
 
 	&.is-style-regular .has-background,
+	&.is-style-stripes .has-background,
 	&.is-style-stripes .has-background thead tr,
 	&.is-style-stripes .has-background tfoot tr,
-	&.is-style-stripes .has-background tbody tr:nth-child(even) {
+	&.is-style-stripes .has-background tbody tr {
 		color: var(--table--has-background-text-color);
 	}
 
@@ -41,6 +42,10 @@ table,
 
 		tbody tr:nth-child(odd) {
 			background-color: var(--table--stripes-background-color);
+		}
+
+		.has-background tbody tr:nth-child(odd) {
+			background-color: var(--global--color-light-gray);
 		}
 	}
 }

--- a/src/wp-content/themes/twentytwentyone/assets/sass/05-blocks/table/_style.scss
+++ b/src/wp-content/themes/twentytwentyone/assets/sass/05-blocks/table/_style.scss
@@ -4,6 +4,11 @@ table,
 	min-width: 240px;
 	border-collapse: collapse;
 
+	thead,
+	tfoot {
+		text-align: center;
+	}
+
 	th {
 		font-family: var(--heading--font-family);
 	}
@@ -12,6 +17,11 @@ table,
 	th {
 		padding: calc(0.5 * var(--global--spacing-unit));
 		border: 1px solid;
+	}
+
+	figcaption {
+		color: var(--global--color-primary);
+		font-size: var(--global--font-size-xs);
 	}
 
 	&.is-style-regular .has-background,

--- a/src/wp-content/themes/twentytwentyone/assets/sass/05-blocks/table/_style.scss
+++ b/src/wp-content/themes/twentytwentyone/assets/sass/05-blocks/table/_style.scss
@@ -45,7 +45,7 @@ table,
 		}
 
 		.has-background tbody tr:nth-child(odd) {
-			background-color: var(--global--color-light-gray);
+			background-color: var(--global--color-white-90);
 		}
 	}
 }

--- a/src/wp-content/themes/twentytwentyone/assets/sass/style-dark-mode.scss
+++ b/src/wp-content/themes/twentytwentyone/assets/sass/style-dark-mode.scss
@@ -12,6 +12,10 @@
 		--button--color-background-active: var(--global--color-background);
 		--global--color-border: #9ea1a7;
 
+		/* Block: Table */
+		--table--stripes-border-color: rgba(240, 240, 240, 0.15);
+		--table--stripes-background-color: rgba(240, 240, 240, 0.15);
+
 		.site a:focus:not(.wp-block-button__link):not(.wp-block-file__button),
 		.site a:focus:not(.wp-block-button__link):not(.wp-block-file__button) .meta-nav {
 			background: #000;

--- a/src/wp-content/themes/twentytwentyone/classes/class-twenty-twenty-one-custom-colors.php
+++ b/src/wp-content/themes/twentytwentyone/classes/class-twenty-twenty-one-custom-colors.php
@@ -74,8 +74,8 @@ class Twenty_Twenty_One_Custom_Colors {
 			$theme_css .= '--button--color-text-hover: ' . $this->custom_get_readable_color( $background_color ) . ';';
 
 			if ( '#fff' === $this->custom_get_readable_color( $background_color ) ) {
-				$theme_css .= '--table--stripes-border-color: var(--global--color-dark-gray);';
-				$theme_css .= '--table--stripes-background-color: var(--global--color-dark-gray);';
+				$theme_css .= '--table--stripes-border-color: rgba(240, 240, 240, 0.15);';
+				$theme_css .= '--table--stripes-background-color: rgba(240, 240, 240, 0.15);';
 			}
 		}
 

--- a/src/wp-content/themes/twentytwentyone/classes/class-twenty-twenty-one-dark-mode.php
+++ b/src/wp-content/themes/twentytwentyone/classes/class-twenty-twenty-one-dark-mode.php
@@ -65,7 +65,7 @@ class Twenty_Twenty_One_Dark_Mode {
 			// Add Dark Mode variable overrides.
 			wp_add_inline_style(
 				'twenty-twenty-one-custom-color-overrides',
-				'.is-dark-theme.is-dark-theme .editor-styles-wrapper { --global--color-background: var(--global--color-dark-gray); --global--color-primary: var(--global--color-light-gray); --global--color-secondary: var(--global--color-light-gray); --button--color-text: var(--global--color-background); --button--color-text-hover: var(--global--color-secondary); --button--color-text-active: var(--global--color-secondary); --button--color-background: var(--global--color-secondary); --button--color-background-active: var(--global--color-background); --global--color-border: #9ea1a7; }'
+				'.is-dark-theme.is-dark-theme .editor-styles-wrapper { --global--color-background: var(--global--color-dark-gray); --global--color-primary: var(--global--color-light-gray); --global--color-secondary: var(--global--color-light-gray); --button--color-text: var(--global--color-background); --button--color-text-hover: var(--global--color-secondary); --button--color-text-active: var(--global--color-secondary); --button--color-background: var(--global--color-secondary); --button--color-background-active: var(--global--color-background); --global--color-border: #9ea1a7; --table--stripes-border-color: rgba(240, 240, 240, 0.15); --table--stripes-background-color: rgba(240, 240, 240, 0.15); }'
 			);
 		}
 		wp_enqueue_script(

--- a/src/wp-content/themes/twentytwentyone/style-rtl.css
+++ b/src/wp-content/themes/twentytwentyone/style-rtl.css
@@ -3508,6 +3508,13 @@ table,
 	border-collapse: collapse;
 }
 
+table thead,
+table tfoot,
+.wp-block-table thead,
+.wp-block-table tfoot {
+	text-align: center;
+}
+
 table th,
 .wp-block-table th {
 	font-family: var(--heading--font-family);
@@ -3519,6 +3526,12 @@ table th,
 .wp-block-table th {
 	padding: calc(0.5 * var(--global--spacing-unit));
 	border: 1px solid;
+}
+
+table figcaption,
+.wp-block-table figcaption {
+	color: var(--global--color-primary);
+	font-size: var(--global--font-size-xs);
 }
 
 table.is-style-regular .has-background,

--- a/src/wp-content/themes/twentytwentyone/style-rtl.css
+++ b/src/wp-content/themes/twentytwentyone/style-rtl.css
@@ -3535,13 +3535,15 @@ table figcaption,
 }
 
 table.is-style-regular .has-background,
+table.is-style-stripes .has-background,
 table.is-style-stripes .has-background thead tr,
 table.is-style-stripes .has-background tfoot tr,
-table.is-style-stripes .has-background tbody tr:nth-child(even),
+table.is-style-stripes .has-background tbody tr,
 .wp-block-table.is-style-regular .has-background,
+.wp-block-table.is-style-stripes .has-background,
 .wp-block-table.is-style-stripes .has-background thead tr,
 .wp-block-table.is-style-stripes .has-background tfoot tr,
-.wp-block-table.is-style-stripes .has-background tbody tr:nth-child(even) {
+.wp-block-table.is-style-stripes .has-background tbody tr {
 	color: var(--table--has-background-text-color);
 }
 
@@ -3560,6 +3562,11 @@ table.is-style-stripes td,
 table.is-style-stripes tbody tr:nth-child(odd),
 .wp-block-table.is-style-stripes tbody tr:nth-child(odd) {
 	background-color: var(--table--stripes-background-color);
+}
+
+table.is-style-stripes .has-background tbody tr:nth-child(odd),
+.wp-block-table.is-style-stripes .has-background tbody tr:nth-child(odd) {
+	background-color: var(--global--color-light-gray);
 }
 
 table.wp-calendar-table td,

--- a/src/wp-content/themes/twentytwentyone/style-rtl.css
+++ b/src/wp-content/themes/twentytwentyone/style-rtl.css
@@ -3566,7 +3566,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 
 table.is-style-stripes .has-background tbody tr:nth-child(odd),
 .wp-block-table.is-style-stripes .has-background tbody tr:nth-child(odd) {
-	background-color: var(--global--color-light-gray);
+	background-color: var(--global--color-white-90);
 }
 
 table.wp-calendar-table td,

--- a/src/wp-content/themes/twentytwentyone/style.css
+++ b/src/wp-content/themes/twentytwentyone/style.css
@@ -3518,6 +3518,13 @@ table,
 	border-collapse: collapse;
 }
 
+table thead,
+table tfoot,
+.wp-block-table thead,
+.wp-block-table tfoot {
+	text-align: center;
+}
+
 table th,
 .wp-block-table th {
 	font-family: var(--heading--font-family);
@@ -3529,6 +3536,12 @@ table th,
 .wp-block-table th {
 	padding: calc(0.5 * var(--global--spacing-unit));
 	border: 1px solid;
+}
+
+table figcaption,
+.wp-block-table figcaption {
+	color: var(--global--color-primary);
+	font-size: var(--global--font-size-xs);
 }
 
 table.is-style-regular .has-background,

--- a/src/wp-content/themes/twentytwentyone/style.css
+++ b/src/wp-content/themes/twentytwentyone/style.css
@@ -3576,7 +3576,7 @@ table.is-style-stripes tbody tr:nth-child(odd),
 
 table.is-style-stripes .has-background tbody tr:nth-child(odd),
 .wp-block-table.is-style-stripes .has-background tbody tr:nth-child(odd) {
-	background-color: var(--global--color-light-gray);
+	background-color: var(--global--color-white-90);
 }
 
 table.wp-calendar-table td,

--- a/src/wp-content/themes/twentytwentyone/style.css
+++ b/src/wp-content/themes/twentytwentyone/style.css
@@ -3545,13 +3545,15 @@ table figcaption,
 }
 
 table.is-style-regular .has-background,
+table.is-style-stripes .has-background,
 table.is-style-stripes .has-background thead tr,
 table.is-style-stripes .has-background tfoot tr,
-table.is-style-stripes .has-background tbody tr:nth-child(even),
+table.is-style-stripes .has-background tbody tr,
 .wp-block-table.is-style-regular .has-background,
+.wp-block-table.is-style-stripes .has-background,
 .wp-block-table.is-style-stripes .has-background thead tr,
 .wp-block-table.is-style-stripes .has-background tfoot tr,
-.wp-block-table.is-style-stripes .has-background tbody tr:nth-child(even) {
+.wp-block-table.is-style-stripes .has-background tbody tr {
 	color: var(--table--has-background-text-color);
 }
 
@@ -3570,6 +3572,11 @@ table.is-style-stripes td,
 table.is-style-stripes tbody tr:nth-child(odd),
 .wp-block-table.is-style-stripes tbody tr:nth-child(odd) {
 	background-color: var(--table--stripes-background-color);
+}
+
+table.is-style-stripes .has-background tbody tr:nth-child(odd),
+.wp-block-table.is-style-stripes .has-background tbody tr:nth-child(odd) {
+	background-color: var(--global--color-light-gray);
 }
 
 table.wp-calendar-table td,


### PR DESCRIPTION
This fixes the striped table style on dark backgrounds, and also improves the frontend + editor consistency- fixing the caption style and centering both table headers and footers.

For the dark mode stripes, I've used `rgba(240, 240, 240, 0.15)`, so that it will show up on all dark backgrounds. Previously dark colors were using `--global--color-dark-gray` which was invisible if the site background was dark grey.

Normal, default background:

![Screen Shot 2020-12-21 at 12 03 17 PM](https://user-images.githubusercontent.com/541093/102802849-50308300-4385-11eb-8403-e59fdf26fc59.png)

Dark mode on:

![Screen Shot 2020-12-21 at 12 03 05 PM](https://user-images.githubusercontent.com/541093/102802850-50308300-4385-11eb-9491-3854a1593c87.png)

Custom background color, dark enough to trigger light text:

![Screen Shot 2020-12-21 at 12 02 46 PM](https://user-images.githubusercontent.com/541093/102802851-50c91980-4385-11eb-8473-67758cafc05a.png)

Dark background color from palette:

![Screen Shot 2020-12-21 at 12 02 09 PM](https://user-images.githubusercontent.com/541093/102802852-50c91980-4385-11eb-853e-ecde84ccd8fe.png)

Trac ticket: https://core.trac.wordpress.org/ticket/52129

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
