### PR TITLE
Twenty Twenty-One: Clean up CSS build process

### DIFF
--- a/src/wp-content/themes/twentytwentyone/assets/css/ie-editor.css
+++ b/src/wp-content/themes/twentytwentyone/assets/css/ie-editor.css
@@ -149,15 +149,11 @@ blockquote p {
 
 blockquote cite {
 	font-weight: normal;
-	color: #28303d;
-	font-size: 1rem;
 	letter-spacing: normal;
 }
 
 blockquote footer {
 	font-weight: normal;
-	color: #28303d;
-	font-size: 1rem;
 	letter-spacing: normal;
 }
 
@@ -385,14 +381,6 @@ a:hover {
 
 .site a:focus:not(.wp-block-button__link):not(.wp-block-file__button) img {
 	outline: 2px dotted #28303d;
-}
-
-.has-background .has-link-color a {
-	color: #28303d;
-}
-
-.has-background.has-link-color a {
-	color: #28303d;
 }
 
 .wp-block-button__link {
@@ -712,12 +700,6 @@ a:hover {
 		font-size: 3rem;
 	}
 }
-@media only screen and (min-width: 652px) {
-
-	.wp-block-cover h2 {
-		font-size: 3rem;
-	}
-}
 
 .wp-block-cover-image h2 {
 	font-size: 2.25rem;
@@ -726,12 +708,6 @@ a:hover {
 	padding: 0;
 	max-width: inherit;
 	text-align: inherit;
-}
-@media only screen and (min-width: 652px) {
-
-	.wp-block-cover-image h2 {
-		font-size: 3rem;
-	}
 }
 @media only screen and (min-width: 652px) {
 
@@ -1304,13 +1280,6 @@ h1 {
 	}
 }
 
-@media only screen and (min-width: 652px) {
-
-	.wp-block-heading h2 {
-		font-size: 3rem;
-	}
-}
-
 h2 {
 	font-size: 2.25rem;
 	letter-spacing: normal;
@@ -1324,24 +1293,10 @@ h2 {
 	}
 }
 
-@media only screen and (min-width: 652px) {
-
-	h2 {
-		font-size: 3rem;
-	}
-}
-
 .h2 {
 	font-size: 2.25rem;
 	letter-spacing: normal;
 	line-height: 1.3;
-}
-
-@media only screen and (min-width: 652px) {
-
-	.h2 {
-		font-size: 3rem;
-	}
 }
 
 @media only screen and (min-width: 652px) {
@@ -3133,17 +3088,6 @@ pre.wp-block-verse {
 	color: #39414d;
 }
 
-.has-background a,
-.has-background p,
-.has-background h1,
-.has-background h2,
-.has-background h3,
-.has-background h4,
-.has-background h5,
-.has-background h6 {
-	color: currentColor;
-}
-
 .has-primary-background-color[class] {
 	background-color: #28303d;
 	color: #d1e4dd;
@@ -3155,12 +3099,10 @@ pre.wp-block-verse {
 }
 
 .has-white-background-color[class] {
-	background-color: #fff;
 	color: #39414d;
 }
 
 .has-black-background-color[class] {
-	background-color: #000;
 	color: #28303d;
 }
 

--- a/src/wp-content/themes/twentytwentyone/assets/css/ie.css
+++ b/src/wp-content/themes/twentytwentyone/assets/css/ie.css
@@ -545,8 +545,6 @@ template {
  */
 .post-thumbnail {
 	max-width: calc(100vw - 30px);
-	margin-left: auto;
-	margin-right: auto;
 }
 @media only screen and (min-width: 482px) {
 
@@ -635,8 +633,6 @@ template {
 
 .widget-area {
 	max-width: calc(100vw - 30px);
-	margin-left: auto;
-	margin-right: auto;
 }
 
 @media only screen and (min-width: 482px) {
@@ -715,8 +711,6 @@ template {
 
 .site-footer {
 	max-width: calc(100vw - 30px);
-	margin-left: auto;
-	margin-right: auto;
 }
 
 @media only screen and (min-width: 482px) {
@@ -735,8 +729,6 @@ template {
 
 .site-header {
 	max-width: calc(100vw - 30px);
-	margin-left: auto;
-	margin-right: auto;
 }
 
 @media only screen and (min-width: 482px) {
@@ -923,12 +915,6 @@ template {
 			margin-left: calc(50vw - min(calc(100vw - 4 * 25px), 610px) *1);
 		}
 	}
-	@media only screen and (min-width: 482px) {
-
-		.entry-content > .alignleft {
-			margin-left: calc(50vw - min(calc(100vw - 4 * 25px), 610px) *1);
-		}
-	}
 	@media only screen and (min-width: 822px) {
 
 		.entry-content > .alignleft {
@@ -945,12 +931,6 @@ template {
 
 		/*rtl:ignore*/
 		margin-right: calc(50vw - min(calc(100vw - 4 * 25px), 610px) *1);
-	}
-	@media only screen and (min-width: 482px) {
-
-		.entry-content > .alignright {
-			margin-right: calc(50vw - min(calc(100vw - 4 * 25px), 610px) *1);
-		}
 	}
 	@media only screen and (min-width: 482px) {
 
@@ -1379,15 +1359,11 @@ blockquote p {
 
 blockquote cite {
 	font-weight: normal;
-	color: #28303d;
-	font-size: 1rem;
 	letter-spacing: normal;
 }
 
 blockquote footer {
 	font-weight: normal;
-	color: #28303d;
-	font-size: 1rem;
 	letter-spacing: normal;
 }
 
@@ -2100,8 +2076,6 @@ fieldset input[type=checkbox] + label {
 
 img {
 	display: block;
-	height: auto;
-	max-width: 100%;
 }
 
 /* Classic editor images */
@@ -2892,12 +2866,6 @@ input[type=reset]:hover {
 		font-size: 3rem;
 	}
 }
-@media only screen and (min-width: 652px) {
-
-	.wp-block-cover h2 {
-		font-size: 3rem;
-	}
-}
 
 .wp-block-cover-image h2 {
 	font-size: 2.25rem;
@@ -2906,12 +2874,6 @@ input[type=reset]:hover {
 	max-width: inherit;
 	text-align: inherit;
 	padding: 0;
-}
-@media only screen and (min-width: 652px) {
-
-	.wp-block-cover-image h2 {
-		font-size: 3rem;
-	}
 }
 @media only screen and (min-width: 652px) {
 
@@ -3372,24 +3334,10 @@ h2 {
 	}
 }
 
-@media only screen and (min-width: 652px) {
-
-	h2 {
-		font-size: 3rem;
-	}
-}
-
 .h2 {
 	font-size: 2.25rem;
 	letter-spacing: normal;
 	line-height: 1.3;
-}
-
-@media only screen and (min-width: 652px) {
-
-	.h2 {
-		font-size: 3rem;
-	}
 }
 
 @media only screen and (min-width: 652px) {
@@ -5379,13 +5327,6 @@ table.wp-calendar-table caption {
 		}
 	}
 
-	@media only screen and (min-width: 482px) {
-
-		.entry-content > .alignleft {
-			max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px) *1);
-		}
-	}
-
 	@media only screen and (min-width: 822px) {
 
 		.entry-content > .alignleft {
@@ -5445,13 +5386,6 @@ table.wp-calendar-table caption {
 
 	.entry-content > .alignright {
 		max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px) *1);
-	}
-
-	@media only screen and (min-width: 482px) {
-
-		.entry-content > .alignright {
-			max-width: calc(50% - 50vw + min(calc(100vw - 4 * 25px), 610px) *1);
-		}
 	}
 
 	@media only screen and (min-width: 482px) {
@@ -5847,13 +5781,6 @@ a.custom-logo-link {
 	letter-spacing: normal;
 	line-height: 1.3;
 	overflow-wrap: break-word;
-}
-
-@media only screen and (min-width: 652px) {
-
-	.entry-title {
-		font-size: 3rem;
-	}
 }
 
 @media only screen and (min-width: 652px) {
@@ -6263,22 +6190,10 @@ h1.page-title {
 		font-size: 3rem;
 	}
 }
-@media only screen and (min-width: 652px) {
-
-	.comments-title {
-		font-size: 3rem;
-	}
-}
 
 .comment-reply-title {
 	font-size: 2.25rem;
 	letter-spacing: normal;
-}
-@media only screen and (min-width: 652px) {
-
-	.comment-reply-title {
-		font-size: 3rem;
-	}
 }
 @media only screen and (min-width: 652px) {
 

--- a/src/wp-content/themes/twentytwentyone/package-lock.json
+++ b/src/wp-content/themes/twentytwentyone/package-lock.json
@@ -413,14 +413,6 @@
 				"globals": "^12.0.0",
 				"prettier": "npm:wp-prettier@2.0.5",
 				"requireindex": "^1.2.0"
-			},
-			"dependencies": {
-				"prettier": {
-					"version": "npm:wp-prettier@2.0.5",
-					"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.0.5.tgz",
-					"integrity": "sha512-5GCgdeevIXwR3cW4Qj5XWC5MO1iSCz8+IPn0mMw6awAt/PBiey8yyO7MhePRsaMqghJAhg6Q3QLYWSnUHWkG6A==",
-					"dev": true
-				}
 			}
 		},
 		"@wordpress/prettier-config": {
@@ -3010,6 +3002,15 @@
 				"postcss": "^7.0.14"
 			}
 		},
+		"postcss-discard-duplicates": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-4.0.2.tgz",
+			"integrity": "sha512-ZNQfR1gPNAiXZhgENFfEglF93pciw0WxMkJeVmw8eF+JZBbMD7jp6C67GqJAXVZP2BWbOztKfbsdmMp/k8c6oQ==",
+			"dev": true,
+			"requires": {
+				"postcss": "^7.0.0"
+			}
+		},
 		"postcss-focus-within": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-focus-within/-/postcss-focus-within-3.0.0.tgz",
@@ -3177,6 +3178,12 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
 			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+			"dev": true
+		},
+		"prettier": {
+			"version": "npm:wp-prettier@2.0.5",
+			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.0.5.tgz",
+			"integrity": "sha512-5GCgdeevIXwR3cW4Qj5XWC5MO1iSCz8+IPn0mMw6awAt/PBiey8yyO7MhePRsaMqghJAhg6Q3QLYWSnUHWkG6A==",
 			"dev": true
 		},
 		"prettier-linter-helpers": {

--- a/src/wp-content/themes/twentytwentyone/package.json
+++ b/src/wp-content/themes/twentytwentyone/package.json
@@ -24,6 +24,7 @@
 		"postcss-cli": "^7.1.0",
 		"postcss-css-variables": "^0.17.0",
 		"postcss-custom-media": "^7.0.8",
+		"postcss-discard-duplicates": "^4.0.2",
 		"postcss-focus-within": "^3.0.0",
 		"postcss-nested": "^4.2.1",
 		"rtlcss": "^2.6.1",

--- a/src/wp-content/themes/twentytwentyone/postcss.config.js
+++ b/src/wp-content/themes/twentytwentyone/postcss.config.js
@@ -8,6 +8,6 @@ module.exports = {
 		require('postcss-calc')({
 			precision: 0
 		}),
-		require('postcss-discard-duplicates'),
+		require('postcss-discard-duplicates')
 	]
 };

--- a/src/wp-content/themes/twentytwentyone/postcss.config.js
+++ b/src/wp-content/themes/twentytwentyone/postcss.config.js
@@ -7,6 +7,7 @@ module.exports = {
 		}),
 		require('postcss-calc')({
 			precision: 0
-		})
+		}),
+		require('postcss-discard-duplicates'),
 	]
 };


### PR DESCRIPTION
This adds [`postcss-discard-duplicates`](https://github.com/cssnano/cssnano/tree/master/packages/postcss-discard-duplicates) to the PostCSS step to clean up the IE styles. All the CSS that is removed shows up again later in the file (in the case of, ex, `blockquote cite`). The duplicate media queries are due to a bug in postcss-css-variables.

Also, this has disabled source map generation in the sass, since these files are not to be committed. I'm open to leaving this out & instead adding `*.map` to gitignore - my main issue has been that they show up in my git changesets.

Trac ticket: https://core.trac.wordpress.org/ticket/52158#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
