### PR TITLE
REST API: Add batch image editing

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -474,14 +474,14 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 					),
 				);
 			}
-		}
 
-		if ( 0 === count( $modifiers ) ) {
-			return new WP_Error(
-				'rest_image_not_edited',
-				__( 'The image was not edited. Edit the image before applying the changes.' ),
-				array( 'status' => 400 )
-			);
+			if ( 0 === count( $modifiers ) ) {
+				return new WP_Error(
+					'rest_image_not_edited',
+					__( 'The image was not edited. Edit the image before applying the changes.' ),
+					array( 'status' => 400 )
+				);
+			}
 		}
 
 		/*
@@ -1357,6 +1357,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			'modifiers' => array(
 				'description' => __( 'Array of image edits.' ),
 				'type'        => 'array',
+				'minItems'    => 1,
 				'items'       => array(
 					'description' => __( 'Image edit.' ),
 					'type'        => 'object',
@@ -1366,7 +1367,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 					),
 					'oneOf'       => array(
 						array(
-							'title'       => __( 'rotation' ),
+							'title'       => __( 'Rotation' ),
 							'properties'  => array(
 								'type' => array(
 									'description' => __( 'Rotation type.' ),
@@ -1389,7 +1390,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 							),
 						),
 						array(
-							'title'       => __( 'crop' ),
+							'title'       => __( 'Crop' ),
 							'properties'  => array(
 								'type' => array(
 									'description' => __( 'Crop type.' ),

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -1399,7 +1399,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 				),
 			),
 			'rotation'  => array(
-				'description'      => __( 'DEPRECATED: Use `modifiers` instead. The amount to rotate the image clockwise in degrees.' ),
+				'description'      => __( 'The amount to rotate the image clockwise in degrees. DEPRECATED: Use `modifiers` instead.' ),
 				'type'             => 'integer',
 				'minimum'          => 0,
 				'exclusiveMinimum' => true,
@@ -1407,25 +1407,25 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 				'exclusiveMaximum' => true,
 			),
 			'x'         => array(
-				'description' => __( 'DEPRECATED: Use `modifiers` instead. As a percentage of the image, the x position to start the crop from.' ),
+				'description' => __( 'As a percentage of the image, the x position to start the crop from. DEPRECATED: Use `modifiers` instead.' ),
 				'type'        => 'number',
 				'minimum'     => 0,
 				'maximum'     => 100,
 			),
 			'y'         => array(
-				'description' => __( 'DEPRECATED: Use `modifiers` instead. As a percentage of the image, the y position to start the crop from.' ),
+				'description' => __( 'As a percentage of the image, the y position to start the crop from. DEPRECATED: Use `modifiers` instead.' ),
 				'type'        => 'number',
 				'minimum'     => 0,
 				'maximum'     => 100,
 			),
 			'width'     => array(
-				'description' => __( 'DEPRECATED: Use `modifiers` instead. As a percentage of the image, the width to crop the image to.' ),
+				'description' => __( 'As a percentage of the image, the width to crop the image to. DEPRECATED: Use `modifiers` instead.' ),
 				'type'        => 'number',
 				'minimum'     => 0,
 				'maximum'     => 100,
 			),
 			'height'    => array(
-				'description' => __( 'DEPRECATED: Use `modifiers` instead. As a percentage of the image, the height to crop the image to.' ),
+				'description' => __( 'As a percentage of the image, the height to crop the image to. DEPRECATED: Use `modifiers` instead.' ),
 				'type'        => 'number',
 				'minimum'     => 0,
 				'maximum'     => 100,

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -1316,38 +1316,6 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 	 */
 	protected function get_edit_media_item_args() {
 		return array(
-			'rotation'  => array(
-				'description'      => __( 'DEPRECATED: Use `modifiers` instead. The amount to rotate the image clockwise in degrees.' ),
-				'type'             => 'integer',
-				'minimum'          => 0,
-				'exclusiveMinimum' => true,
-				'maximum'          => 360,
-				'exclusiveMaximum' => true,
-			),
-			'x'         => array(
-				'description' => __( 'DEPRECATED: Use `modifiers` instead. As a percentage of the image, the x position to start the crop from.' ),
-				'type'        => 'number',
-				'minimum'     => 0,
-				'maximum'     => 100,
-			),
-			'y'         => array(
-				'description' => __( 'DEPRECATED: Use `modifiers` instead. As a percentage of the image, the y position to start the crop from.' ),
-				'type'        => 'number',
-				'minimum'     => 0,
-				'maximum'     => 100,
-			),
-			'width'     => array(
-				'description' => __( 'DEPRECATED: Use `modifiers` instead. As a percentage of the image, the width to crop the image to.' ),
-				'type'        => 'number',
-				'minimum'     => 0,
-				'maximum'     => 100,
-			),
-			'height'    => array(
-				'description' => __( 'DEPRECATED: Use `modifiers` instead. As a percentage of the image, the height to crop the image to.' ),
-				'type'        => 'number',
-				'minimum'     => 0,
-				'maximum'     => 100,
-			),
 			'src'       => array(
 				'description' => __( 'URL to the edited image file.' ),
 				'type'        => 'string',
@@ -1429,6 +1397,38 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 						),
 					),
 				),
+			),
+			'rotation'  => array(
+				'description'      => __( 'DEPRECATED: Use `modifiers` instead. The amount to rotate the image clockwise in degrees.' ),
+				'type'             => 'integer',
+				'minimum'          => 0,
+				'exclusiveMinimum' => true,
+				'maximum'          => 360,
+				'exclusiveMaximum' => true,
+			),
+			'x'         => array(
+				'description' => __( 'DEPRECATED: Use `modifiers` instead. As a percentage of the image, the x position to start the crop from.' ),
+				'type'        => 'number',
+				'minimum'     => 0,
+				'maximum'     => 100,
+			),
+			'y'         => array(
+				'description' => __( 'DEPRECATED: Use `modifiers` instead. As a percentage of the image, the y position to start the crop from.' ),
+				'type'        => 'number',
+				'minimum'     => 0,
+				'maximum'     => 100,
+			),
+			'width'     => array(
+				'description' => __( 'DEPRECATED: Use `modifiers` instead. As a percentage of the image, the width to crop the image to.' ),
+				'type'        => 'number',
+				'minimum'     => 0,
+				'maximum'     => 100,
+			),
+			'height'    => array(
+				'description' => __( 'DEPRECATED: Use `modifiers` instead. As a percentage of the image, the height to crop the image to.' ),
+				'type'        => 'number',
+				'minimum'     => 0,
+				'maximum'     => 100,
 			),
 		);
 	}

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -2048,7 +2048,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 					),
 				),
 			),
-			'src'      => wp_get_attachment_image_url( $attachment, 'full' ),
+			'src'       => wp_get_attachment_image_url( $attachment, 'full' ),
 		);
 
 		$request = new WP_REST_Request( 'POST', "/wp/v2/media/{$attachment}/edit" );

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -2023,6 +2023,49 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	}
 
 	/**
+	 * @ticket 52192
+	 * @requires function imagejpeg
+	 */
+	public function test_batch_edit_image() {
+		wp_set_current_user( self::$superadmin_id );
+		$attachment = self::factory()->attachment->create_upload_object( $this->test_file );
+
+		$params = array(
+			'modifiers' => array(
+				array(
+					'type' => 'rotate',
+					'args' => array(
+						'angle' => 60,
+					),
+				),
+				array(
+					'type' => 'crop',
+					'args' => array(
+						'left'   => 50,
+						'top'    => 10,
+						'width'  => 10,
+						'height' => 5,
+					),
+				),
+			),
+			'src'      => wp_get_attachment_image_url( $attachment, 'full' ),
+		);
+
+		$request = new WP_REST_Request( 'POST', "/wp/v2/media/{$attachment}/edit" );
+		$request->set_body_params( $params );
+		$response = rest_do_request( $request );
+		$item     = $response->get_data();
+
+		$this->assertSame( 201, $response->get_status() );
+		$this->assertSame( rest_url( '/wp/v2/media/' . $item['id'] ), $response->get_headers()['Location'] );
+
+		$this->assertStringEndsWith( '-edited.jpg', $item['media_details']['file'] );
+		$this->assertArrayHasKey( 'parent_image', $item['media_details'] );
+		$this->assertEquals( $attachment, $item['media_details']['parent_image']['attachment_id'] );
+		$this->assertContains( 'canola', $item['media_details']['parent_image']['file'] );
+	}
+
+	/**
 	 * @ticket 50565
 	 */
 	public function test_edit_image_returns_error_if_mismatched_src() {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/52192

See: https://github.com/WordPress/gutenberg/pull/23369

This proposes a new API for image editing that should be more flexible and extensible than the existing API. The new API takes an array of modifiers that will be applied in the order they appear.

An example request body looks like this.

```json
{
  "modifiers": [
    {
      "type": "crop",
      "args": {
        "left": 12.875,
        "top": 0.125,
        "width": 50,
        "height": 50
      }
    },
    {
      "type": "rotate",
      "args": {
        "angle": 90
      }
    }
  ]
}
```

Crop values are as a percentage of the original image and rotation angle is in degrees clockwise.

The crop values need to be percentages because the image loaded on the frontend may not be a scaled version of the original image, so `naturalWidth` and `naturalHeight` cannot be trusted as the actual width and height of the original image.

The rotation value is in degrees to avoid rounding errors for the types of rotations that are most common like 90 degrees. Clockwise versus anticlockwise may be up for debate. When using degrees it seems more natural to me to rotate clockwise, but mathematically, when you've converted to radians, a positive value indicates an anticlockwise rotation.

Different front-end implementations may apply edits in a different order, so passing an array will allow them to use their edits as-is without converting to a fixed order. 

One example in the wild that actually uses both orders in different contexts is [BeFunky](https://www.befunky.com/create/photo-editor/). To see the difference, try one of their demo images with a horizon in it so you have a line that you can pay attention to. Then use the 'straighten' option followed by a 'horizontal flip' to see that the angle of the horizon hasn't changed even though you flipped the image. This means that the flip happens before the rotation. If you use the 'rotate' option instead of 'straighten, the rotation happens before the flip.

The old API continues to work, but when supplying the `modifiers` option, the old `crop` and `rotation` options are ignored.

Cropping and rotation are not constrained since the underlying `WP_Image_Editor_Imagick` and `WP_Image_Editor_GD` do not appear to be constrained.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
