### PR TITLE
Use action for Composer caching/installation.

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v1
         with:
-          composer-options: "--no-suggest --no-progress --no-ansi --no-interaction"
+          composer-options: "--no-progress --no-ansi --no-interaction"
 
       - name: Make Composer packages available globally
         run: echo "${PWD}/vendor/bin" >> $GITHUB_PATH

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -49,6 +49,9 @@ jobs:
         with:
           composer-options: "--no-suggest --no-progress --no-ansi --no-interaction"
 
+      - name: Make Composer packages available globally
+        run: echo "${PWD}/vendor/bin" >> $GITHUB_PATH
+
       - name: Log PHPCS debug information
         run: phpcs -i
 

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -16,7 +16,6 @@ jobs:
   #
   # Performs the following steps:
   # - Checks out the repository.
-  # - Configures caching for Composer.
   # - Sets up PHP.
   # - Logs debug information.
   # - Installs Composer dependencies (from cache if possible).
@@ -33,20 +32,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Get Composer cache directory
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Set up Composer caching
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-composer-dependencies
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
-
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -60,9 +45,9 @@ jobs:
           composer --version
 
       - name: Install Composer dependencies
-        run: |
-          composer install --prefer-dist --no-suggest --no-progress --no-ansi --no-interaction
-          echo "${PWD}/vendor/bin" >> $GITHUB_PATH
+        uses: ramsey/composer-install@v1
+        with:
+          composer-options: "--no-suggest --no-progress --no-ansi --no-interaction"
 
       - name: Log PHPCS debug information
         run: phpcs -i

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -19,6 +19,7 @@ jobs:
   # - Sets up PHP.
   # - Logs debug information.
   # - Installs Composer dependencies (from cache if possible).
+  # - Make Composer packages available globally.
   # - Logs PHP_CodeSniffer debug information.
   # - Runs PHPCS on the full codebase with warnings suppressed.
   # - Runs PHPCS on the `tests` directory without warnings suppressed.

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -18,7 +18,7 @@ jobs:
   # - Checks out the repository.
   # - Sets up PHP.
   # - Logs debug information.
-  # - Installs Composer dependencies (from cache if possible).
+  # - Installs Composer dependencies (use cache if possible).
   # - Make Composer packages available globally.
   # - Logs PHP_CodeSniffer debug information.
   # - Runs PHPCS on the full codebase with warnings suppressed.

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v1
         with:
-          composer-options: "--no-suggest --no-progress --no-ansi --no-interaction"
+          composer-options: "--no-progress --no-ansi --no-interaction"
 
       - name: Make Composer packages available globally
         run: echo "${PWD}/vendor/bin" >> $GITHUB_PATH

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -20,6 +20,7 @@ jobs:
   # - Sets up PHP.
   # - Logs debug information about the runner container.
   # - Installs Composer dependencies (from cache if possible).
+  # - Make Composer packages available globally.
   # - Logs PHP_CodeSniffer debug information.
   # - Runs the PHP compatibility tests.
   # - todo: Configure Slack notifications for failing scans.

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -49,6 +49,9 @@ jobs:
         with:
           composer-options: "--no-suggest --no-progress --no-ansi --no-interaction"
 
+      - name: Make Composer packages available globally
+        run: echo "${PWD}/vendor/bin" >> $GITHUB_PATH
+
       - name: Log PHPCS debug information
         run: phpcs -i
 

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -17,7 +17,6 @@ jobs:
   #
   # Performs the following steps:
   # - Checks out the repository.
-  # - Configures caching for Composer.
   # - Sets up PHP.
   # - Logs debug information about the runner container.
   # - Installs Composer dependencies (from cache if possible).
@@ -33,20 +32,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Get Composer cache directory
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Set up Composer caching
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-composer-dependencies
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
-
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -60,9 +45,9 @@ jobs:
           composer --version
 
       - name: Install Composer dependencies
-        run: |
-          composer install --prefer-dist --no-suggest --no-progress --no-ansi --no-interaction
-          echo "${PWD}/vendor/bin" >> $GITHUB_PATH
+        uses: ramsey/composer-install@v1
+        with:
+          composer-options: "--no-suggest --no-progress --no-ansi --no-interaction"
 
       - name: Log PHPCS debug information
         run: phpcs -i

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -19,7 +19,7 @@ jobs:
   # - Checks out the repository.
   # - Sets up PHP.
   # - Logs debug information about the runner container.
-  # - Installs Composer dependencies (from cache if possible).
+  # - Installs Composer dependencies (use cache if possible).
   # - Make Composer packages available globally.
   # - Logs PHP_CodeSniffer debug information.
   # - Runs the PHP compatibility tests.

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -191,9 +191,9 @@ jobs:
           cache-name: cache-composer-dependencies
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          key: ${{ runner.os }}-php-${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
-            ${{ runner.os }}-composer-
+            ${{ runner.os }}-php-${{ matrix.php }}-composer-
 
       - name: Install Composer dependencies
         if: ${{ env.COMPOSER_INSTALL == true || env.LOCAL_PHP == '8.0-fpm' }}

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -182,7 +182,7 @@ jobs:
       - name: Get composer cache directory
         id: composer-cache
         if: ${{ env.COMPOSER_INSTALL == true || env.LOCAL_PHP == '8.0-fpm' }}
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "::set-output name=dir::$(docker-compose run --rm php composer config cache-files-dir)"
 
       - name: Cache Composer dependencies
         if: ${{ env.COMPOSER_INSTALL == true || env.LOCAL_PHP == '8.0-fpm' }}

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -182,7 +182,7 @@ jobs:
       - name: Get composer cache directory
         id: composer-cache
         if: ${{ env.COMPOSER_INSTALL == true || env.LOCAL_PHP == '8.0-fpm' }}
-        run: echo "::set-output name=dir::$(docker-compose run --rm php composer config cache-files-dir)"
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
       - name: Cache Composer dependencies
         if: ${{ env.COMPOSER_INSTALL == true || env.LOCAL_PHP == '8.0-fpm' }}


### PR DESCRIPTION
This PR switches from manually configuring caching for Composer dependencies to using a published action instead. This  allows the 3-4 steps used to configure Composer caching to be combined into one.

This also removes the `--prefer-dist` (which is now the default) and `--no-suggest` (deprecated) flags from Composer commands.

The PHPUnit workflow's Composer caching will remain the same, but the cache key has been adjusted to include the PHP version being used. Currently only the PHP 8.0 job utilizes Composer dependencies, but if other versions run `composer install` in the future, it would result in incompatible package versions being loaded as all jobs would currently share a cache key.

Trac ticket: https://core.trac.wordpress.org/ticket/50401.
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
