### PR TITLE
make emojis accessible by inheriting descriptive attribute from parent

### DIFF
--- a/src/js/_enqueues/wp/emoji.js
+++ b/src/js/_enqueues/wp/emoji.js
@@ -272,7 +272,42 @@
 				};
 			}
 
-			return twemoji.parse( object, params );
+			object = twemoji.parse( object, params );
+			inherit_accessibility_attributes( object );
+			return object;
+		}
+
+		function inherit_accessibility_attributes( object ) {
+			if (!( object instanceof HTMLElement )) {
+				return;
+			}
+
+			const emojis = [ ...object.querySelectorAll('img.emoji[alt]') ];
+			emojis.forEach(emoji => {
+				const parent_node = emoji.parentNode;
+				if (parent_node) {
+					const child_count = parent_node.querySelectorAll(':scope > img.emoji[alt]').length;
+					if (child_count === 1) {
+						let description, attrs, i, attr;
+
+						attrs = ['aria-label', 'title', 'label'];
+						for (i=0; !description && (i < attrs.length); i++) {
+							attr = attrs[i];
+							if (parent_node.hasAttribute(attr)) {
+								description = parent_node.getAttribute(attr);
+							}
+						}
+
+						if (description) {
+							attrs = ['aria-label', 'title'];
+							for (i=0; i < attrs.length; i++) {
+								attr = attrs[i];
+								emoji.setAttribute(attr, description);
+							}
+						}
+					}
+				}
+			})
 		}
 
 		/**

--- a/src/js/_enqueues/wp/emoji.js
+++ b/src/js/_enqueues/wp/emoji.js
@@ -281,18 +281,23 @@
 			if (!( object instanceof HTMLElement )) {
 				return;
 			}
+			var emojis, i, emoji, description, parent_node, child_count, attrs, j, attr;
 
-			const emojis = [ ...object.querySelectorAll('img.emoji[alt]') ];
-			emojis.forEach(emoji => {
-				const parent_node = emoji.parentNode;
+			emojis = object.querySelectorAll('img.emoji[alt]');
+			emojis = Array.prototype.slice.call(emojis);
+
+			for ( i=0; i < emojis.length; i++ ) {
+				emoji       = emojis[i];
+				description = null;
+				parent_node = emoji.parentNode;
+
 				if (parent_node) {
-					const child_count = parent_node.querySelectorAll(':scope > img.emoji[alt]').length;
+					child_count = parent_node.querySelectorAll(':scope > img.emoji[alt]').length;
 					if (child_count === 1) {
-						let description, attrs, i, attr;
 
 						attrs = ['aria-label', 'title', 'label'];
-						for (i=0; !description && (i < attrs.length); i++) {
-							attr = attrs[i];
+						for ( j=0; !description && (j < attrs.length); j++ ) {
+							attr = attrs[j];
 							if (parent_node.hasAttribute(attr)) {
 								description = parent_node.getAttribute(attr);
 							}
@@ -300,14 +305,14 @@
 
 						if (description) {
 							attrs = ['aria-label', 'title'];
-							for (i=0; i < attrs.length; i++) {
-								attr = attrs[i];
+							for ( j=0; j < attrs.length; j++ ) {
+								attr = attrs[j];
 								emoji.setAttribute(attr, description);
 							}
 						}
 					}
 				}
-			})
+			}
 		}
 
 		/**

--- a/src/js/_enqueues/wp/emoji.js
+++ b/src/js/_enqueues/wp/emoji.js
@@ -281,7 +281,10 @@
 			if (!( object instanceof HTMLElement )) {
 				return;
 			}
-			var emojis, i, emoji, description, parent_node, child_count, attrs, j, attr;
+			var emojis, i, emoji, description, parent_node, child_count, j, attr;
+
+			var attrs_read  = ['aria-label', 'title', 'label'];
+			var attrs_write = ['aria-label', 'title'];
 
 			emojis = object.querySelectorAll('img.emoji[alt]');
 			emojis = Array.prototype.slice.call(emojis);
@@ -293,20 +296,18 @@
 
 				if (parent_node) {
 					child_count = parent_node.querySelectorAll(':scope > img.emoji[alt]').length;
-					if (child_count === 1) {
 
-						attrs = ['aria-label', 'title', 'label'];
-						for ( j=0; !description && (j < attrs.length); j++ ) {
-							attr = attrs[j];
+					if (child_count === 1) {
+						for ( j=0; !description && (j < attrs_read.length); j++ ) {
+							attr = attrs_read[j];
 							if (parent_node.hasAttribute(attr)) {
 								description = parent_node.getAttribute(attr);
 							}
 						}
 
 						if (description) {
-							attrs = ['aria-label', 'title'];
-							for ( j=0; j < attrs.length; j++ ) {
-								attr = attrs[j];
+							for ( j=0; j < attrs_write.length; j++ ) {
+								attr = attrs_write[j];
 								emoji.setAttribute(attr, description);
 							}
 						}


### PR DESCRIPTION
* relevent to a 4 year old [issue in trac](https://core.trac.wordpress.org/ticket/37486)
* strictly speaking, this type of functionality should really be added into the upstream `twemoji` library
  - in [`function parseNode(node, options)`](https://github.com/twitter/twemoji/blob/v13.0.1/scripts/build.js#L365)