### PR TITLE
#52232 - Remove useless <strong> tags in labels displayed in plugin/theme editor screens

### DIFF
--- a/src/wp-admin/plugin-editor.php
+++ b/src/wp-admin/plugin-editor.php
@@ -216,7 +216,7 @@ $content = esc_textarea( $content );
 </div>
 <div class="alignright">
 	<form action="plugin-editor.php" method="get">
-		<strong><label for="plugin"><?php _e( 'Select plugin to edit:' ); ?> </label></strong>
+		<label for="plugin"><?php _e( 'Select plugin to edit:' ); ?> </label>
 		<select name="plugin" id="plugin">
 		<?php
 		foreach ( $plugins as $plugin_key => $a_plugin ) {

--- a/src/wp-admin/theme-editor.php
+++ b/src/wp-admin/theme-editor.php
@@ -222,7 +222,7 @@ if ( $file_description !== $file_show ) {
 </div>
 <div class="alignright">
 	<form action="theme-editor.php" method="get">
-		<strong><label for="theme"><?php _e( 'Select theme to edit:' ); ?> </label></strong>
+		<label for="theme"><?php _e( 'Select theme to edit:' ); ?> </label>
 		<select name="theme" id="theme">
 		<?php
 		foreach ( wp_get_themes( array( 'errors' => null ) ) as $a_stylesheet => $a_theme ) {


### PR DESCRIPTION
Removes `<strong>` tags as suggested in #52232. It must be mentioned that the font-weight of the labels "Documentation" and "Select plugin to edit:" remain bold due to their CSS styling.

Trac ticket: https://core.trac.wordpress.org/ticket/52232