### PR TITLE
51857: Rollback failed plugin/theme update

### DIFF
--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -964,7 +964,7 @@ class WP_Upgrader {
 		$rollback_dir = $wp_filesystem->wp_content_dir() . 'upgrade/rollback/';
 		$type         = key( $hook_extra );
 		$slug         = 'plugin' === $type ? dirname( $hook_extra['plugin'] ) : $hook_extra['theme'];
-		$src          = 'plugin' === $type ? WP_PLUGIN_DIR . "/{$slug}" : get_theme_root(). "/{$slug}";
+		$src          = 'plugin' === $type ? WP_PLUGIN_DIR . '/' . $slug : get_theme_root(). '/' . $slug;
 		if ( $wp_filesystem->mkdir( $rollback_dir ) ) {
 			$path_prefix = strlen( $src ) + 1;
 			$zip         = new ZipArchive();
@@ -1022,7 +1022,7 @@ class WP_Upgrader {
 
 		$result = unzip_file( $rollback, $destination );
 		if ( is_wp_error( $result ) ) {
-			return new WP_Error( 'extract_rollback_failed', __( "Extract rollback of {$type} {$slug} failed." ) );
+			return new WP_Error( 'extract_rollback_failed', sprintf( __( "Extract rollback of %s %s failed." ), $type, $slug ) );
 		}
 	}
 }

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -961,19 +961,14 @@ class WP_Upgrader {
 	public function zip_to_rollback_dir( $response, $hook_extra ) {
 		global $wp_filesystem;
 
-		$rollback_dir = $wp_filesystem->wp_content_dir() . 'upgrade/rollback/';
-		$type         = key( $hook_extra );
-		if ( 'plugin' === $type ) {
-			$slug = dirname( $hook_extra['plugin'] );
-			$src  = WP_PLUGIN_DIR . '/' . $slug;
-		}
-		if ( 'theme' === $type ) {
-			$slug = $hook_extra['theme'];
-			$src  = get_theme_root() . '/' . $slug;
-		}
-		if ( ! isset( $slug, $src ) ) {
+		if ( ! isset( $hook_extra ) ) {
 			return new WP_Error( 'zip_rollback_failed', __( '$hook_extra not defined.' ) );
 		}
+
+		$rollback_dir = $wp_filesystem->wp_content_dir() . 'upgrade/rollback/';
+		$type         = key( $hook_extra );
+		$slug         = 'plugin' === $type ? dirname( $hook_extra['plugin'] ) : $hook_extra['theme'];
+		$src          = 'plugin' === $type ? WP_PLUGIN_DIR . '/' . $slug : get_theme_root() . '/' . $slug;
 
 		 // Zip can use a lot of memory. From `unzip_file()`.
 		 wp_raise_memory_limit( 'admin' );

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -961,7 +961,7 @@ class WP_Upgrader {
 	public function zip_to_rollback_dir( $response, $hook_extra ) {
 		global $wp_filesystem;
 
-		// Exit early.
+		// Exit early on plugin/theme installation.
 		if ( isset( $hook_extra['type'] ) ) {
 			if ( 'plugin' === $hook_extra['type'] && ! isset( $hook_extra['plugin'] ) ) {
 				return $response;
@@ -1029,12 +1029,12 @@ class WP_Upgrader {
 	public function extract_rollback( $destination, $hook_extra ) {
 		global $wp_filesystem;
 
-		// Exit early.
+		// Exit early on plugin/theme installation.
 		if ( isset( $hook_extra['type'] ) ) {
 			if ( 'plugin' === $hook_extra['type'] && ! isset( $hook_extra['plugin'] ) ) {
-				return new WP_Error( 'extract_rollback_error', __( '$hook_extra not correctly set' ) );
+				return new WP_Error( 'extract_rollback_error', __( '$hook_extra set for installation' ) );
 			} elseif ( 'theme' === $hook_extra['type'] && ! isset( $hook_extra['theme'] ) ) {
-				return new WP_Error( 'extract_rollback_error', __( '$hook_extra not correctly set' ) );
+				return new WP_Error( 'extract_rollback_error', __( '$hook_extra set for installation' ) );
 			}
 		}
 

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -964,7 +964,7 @@ class WP_Upgrader {
 		$rollback_dir = $wp_filesystem->wp_content_dir() . 'upgrade/rollback/';
 		$type         = key( $hook_extra );
 		$slug         = 'plugin' === $type ? dirname( $hook_extra['plugin'] ) : $hook_extra['theme'];
-		$src          = 'plugin' === $type ? WP_PLUGIN_DIR . '/' . $slug : get_theme_root(). '/' . $slug;
+		$src          = 'plugin' === $type ? WP_PLUGIN_DIR . '/' . $slug : get_theme_root() . '/' . $slug;
 		if ( $wp_filesystem->mkdir( $rollback_dir ) ) {
 			$path_prefix = strlen( $src ) + 1;
 			$zip         = new ZipArchive();

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -963,8 +963,17 @@ class WP_Upgrader {
 
 		$rollback_dir = $wp_filesystem->wp_content_dir() . 'upgrade/rollback/';
 		$type         = key( $hook_extra );
-		$slug         = 'plugin' === $type ? dirname( $hook_extra['plugin'] ) : $hook_extra['theme'];
-		$src          = 'plugin' === $type ? WP_PLUGIN_DIR . '/' . $slug : get_theme_root() . '/' . $slug;
+		if ( 'plugin' === $type ) {
+			$slug = dirname( $hook_extra['plugin'] );
+			$src  = WP_PLUGIN_DIR . '/' . $slug;
+		}
+		if ( 'theme' === $type ) {
+			$slug = $hook_extra['theme'];
+			$src  = get_theme_root() . '/' . $slug;
+		}
+		if ( ! isset( $slug, $src ) ) {
+			return new WP_Error( 'zip_rollback_failed', __( '$hook_extra not defined.' ) );
+		}
 
 		 // Zip can use a lot of memory. From `unzip_file()`.
 		 wp_raise_memory_limit( 'admin' );

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -1022,7 +1022,7 @@ class WP_Upgrader {
 
 		$result = unzip_file( $rollback, $destination );
 		if ( is_wp_error( $result ) ) {
-			return new WP_Error( 'extract_rollback_failed', sprintf( __( 'Extract rollback of %s %s failed.' ), $type, $slug ) );
+			return new WP_Error( 'extract_rollback_failed', sprintf( __( 'Extract rollback of %1$s %2$s failed.' ), $type, $slug ) );
 		}
 	}
 }

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -1022,7 +1022,7 @@ class WP_Upgrader {
 
 		$result = unzip_file( $rollback, $destination );
 		if ( is_wp_error( $result ) ) {
-			return new WP_Error( 'extract_rollback_failed', sprintf( __( "Extract rollback of %s %s failed." ), $type, $slug ) );
+			return new WP_Error( 'extract_rollback_failed', sprintf( __( 'Extract rollback of %s %s failed.' ), $type, $slug ) );
 		}
 	}
 }

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -965,6 +965,10 @@ class WP_Upgrader {
 		$type         = key( $hook_extra );
 		$slug         = 'plugin' === $type ? dirname( $hook_extra['plugin'] ) : $hook_extra['theme'];
 		$src          = 'plugin' === $type ? WP_PLUGIN_DIR . '/' . $slug : get_theme_root() . '/' . $slug;
+
+		 // Zip can use a lot of memory. From `unzip_file()`.
+		 wp_raise_memory_limit( 'admin' );
+
 		if ( $wp_filesystem->mkdir( $rollback_dir ) ) {
 			$path_prefix = strlen( $src ) + 1;
 			$zip         = new ZipArchive();

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1763,18 +1763,24 @@ function _unzip_file_pclzip( $file, $to, $needed_dirs = array() ) {
  * Assumes that WP_Filesystem() has already been called and setup.
  *
  * @since 2.5.0
+ * @since 5.7.0 Add $first_pass parameter.
  *
  * @global WP_Filesystem_Base $wp_filesystem WordPress filesystem subclass.
  *
- * @param string   $from      Source directory.
- * @param string   $to        Destination directory.
- * @param string[] $skip_list An array of files/folders to skip copying.
+ * @param string   $from       Source directory.
+ * @param string   $to         Destination directory.
+ * @param string[] $skip_list  An array of files/folders to skip copying.
+ * @param bool     $first_pass True on the initial call, but false on subsequent calls.
  * @return true|WP_Error True on success, WP_Error on failure.
  */
-function copy_dir( $from, $to, $skip_list = array() ) {
+function copy_dir( $from, $to, $skip_list = array(), $first_pass = true ) {
 	global $wp_filesystem;
 
 	$dirlist = $wp_filesystem->dirlist( $from );
+
+	if ( ! $dirlist && $first_pass ) {
+		return new WP_Error( 'dirlist_failed_copy_dir', __( 'Directory listing failed.' ), basename( $to ) );
+	}
 
 	$from = trailingslashit( $from );
 	$to   = trailingslashit( $to );
@@ -1809,7 +1815,7 @@ function copy_dir( $from, $to, $skip_list = array() ) {
 				}
 			}
 
-			$result = copy_dir( $from . $filename, $to . $filename, $sub_skip_list );
+			$result = copy_dir( $from . $filename, $to . $filename, $sub_skip_list, false );
 			if ( is_wp_error( $result ) ) {
 				return $result;
 			}

--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -1336,21 +1336,27 @@ function update_core( $from, $to ) {
  * @ignore
  * @since 3.2.0
  * @since 3.7.0 Updated not to use a regular expression for the skip list.
+ * @since 5.7.0 Add $first_pass parameter.
  *
  * @see copy_dir()
  * @link https://core.trac.wordpress.org/ticket/17173
  *
  * @global WP_Filesystem_Base $wp_filesystem
  *
- * @param string   $from      Source directory.
- * @param string   $to        Destination directory.
- * @param string[] $skip_list Array of files/folders to skip copying.
+ * @param string   $from       Source directory.
+ * @param string   $to         Destination directory.
+ * @param string[] $skip_list  Array of files/folders to skip copying.
+ * @param bool     $first_pass True on the initial call, but false on subsequent calls.
  * @return true|WP_Error True on success, WP_Error on failure.
  */
-function _copy_dir( $from, $to, $skip_list = array() ) {
+function _copy_dir( $from, $to, $skip_list = array(), $first_pass = true ) {
 	global $wp_filesystem;
 
 	$dirlist = $wp_filesystem->dirlist( $from );
+
+	if ( ! $dirlist && $first_pass ) {
+		return new WP_Error( 'dirlist_failed__copy_dir', __( 'Directory listing failed.' ), basename( $to ) );
+	}
 
 	$from = trailingslashit( $from );
 	$to   = trailingslashit( $to );
@@ -1391,7 +1397,7 @@ function _copy_dir( $from, $to, $skip_list = array() ) {
 				}
 			}
 
-			$result = _copy_dir( $from . $filename, $to . $filename, $sub_skip_list );
+			$result = _copy_dir( $from . $filename, $to . $filename, $sub_skip_list, false );
 			if ( is_wp_error( $result ) ) {
 				return $result;
 			}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Moving previous patch(es) to GitHub.

- Updates `copy_dir()` and `_copy_dir()` to include WP_Error return early if the `$dirlist` is empty.
- Adds function `zip_to_rollback_dir()` which creates a zip of the current plugin/theme that is being updated.
- Adds function `extract_rollback()` which on a WP_Error returned from `copy_dir()` will extract the above zip back into the appropriate location.

Trac ticket: https://core.trac.wordpress.org/ticket/51857

Props @pbiron, @dd32, @hellofromtonya, @TimothyBJacobs, @audrasjb 