### PR TITLE
Improve the installation guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Ensure [Docker](https://www.docker.com/products/docker-desktop) is running befor
 
 #### To start the development environment for the first time
 
+Clone the current repository using `git clone https://github.com/WordPress/wordpress-develop.git`. Then in your terminal move to the repository folder `cd wordpress-develop` and run the following commands:
+
 ```
 npm install
 npm run build:dev


### PR DESCRIPTION
The main readme of wordpress-develop repo is a bit unclear about the instructions to install WordPress.
There is no mention of cloning the repo before running the npm commands in the terminal. I've made a pull request on GitHub with these improvements.

This pull request is linked to this ticket on Trac https://core.trac.wordpress.org/ticket/52278.