### PR TITLE
Prevent redirection if query string is unchanged

### DIFF
--- a/src/wp-includes/canonical.php
+++ b/src/wp-includes/canonical.php
@@ -541,13 +541,29 @@ function redirect_canonical( $requested_url = null, $do_redirect = true ) {
 				unset( $_parsed_query['name'] );
 			}
 		}
+		
+		/**
+		 * Confirm the old and new query strings are genuinely different before updating the redirect URL.
+		 *
+		 * This prevents caching plugins like Batcache from creating cached redirect loops when processing
+		 * the query string.
+		 *
+		 * https://core.trac.wordpress.org/ticket/41712
+		 */
+		parse_str( $original['query'], $_parsed_original_query );
+		ksort( $_parsed_original_query );
+		ksort( $_parsed_query );
 
-		$_parsed_query = array_combine(
-			rawurlencode_deep( array_keys( $_parsed_query ) ),
-			rawurlencode_deep( array_values( $_parsed_query ) )
-		);
+		if ( $_parsed_query !== $_parsed_original_query ) {
+			$_parsed_query = array_combine(
+				rawurlencode_deep( array_keys( $_parsed_query ) ),
+				rawurlencode_deep( array_values( $_parsed_query ) )
+			);
 
-		$redirect_url = add_query_arg( $_parsed_query, $redirect_url );
+			$redirect_url = add_query_arg( $_parsed_query, $redirect_url );
+		} else {
+			$redirect_url .= '?' . $original['query'];
+		}
 	}
 
 	if ( $redirect_url ) {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

When processing the redirect URL query string and rebuilding it a false positive can be reported because the new query string is URL encoded and will have trailing `=` operators removed. This means the new redirect URL does not match the requested URL and an unnecessary redirect will occur.

This can cause caching plugins like Batcache to cache the redirect and create and endless redirect loop as the two query strings will yield the same cache key.



Trac ticket: https://core.trac.wordpress.org/ticket/41712

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
