### PR TITLE
51976: Simplify core update footer display

### DIFF
--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -259,9 +259,16 @@ function core_update_footer( $msg = '' ) {
 			sprintf( __( 'Get Version %s' ), $cur->current )
 		);
 	} else {
-		/* translators: s: URL to WordPress Updates screen. */
+		/* translators: %s: URL to WordPress Updates screen. */
 		$stay_updated = sprintf( __( 'Please <a href="%s">stay updated</a>.' ), network_admin_url( 'update-core.php' ) );
-		$msg          = $is_development_version ? $msg . '&nbsp;' . $stay_updated : $msg;
+		if ( $is_development_version ) {
+			$msg = sprintf(
+				/* translators: 1: Version number. 2: "Stay updated" message. */
+				__( '%1$s &nbsp; %2$s' ),
+				$msg,
+				$stay_updated
+			);
+		}
 
 		return $msg;
 	}

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -226,9 +226,11 @@ function find_core_update( $version, $locale ) {
  * @return string
  */
 function core_update_footer( $msg = '' ) {
+	/* translators: %s: WordPress version. */
+	$msg = sprintf( __( 'Version %s.' ), get_bloginfo( 'version', 'display' ) );
+
 	if ( ! current_user_can( 'update_core' ) ) {
-		/* translators: %s: WordPress version. */
-		return sprintf( __( 'Version %s' ), get_bloginfo( 'version', 'display' ) );
+		return $msg;
 	}
 
 	$cur = get_preferred_from_update_core();
@@ -249,31 +251,19 @@ function core_update_footer( $msg = '' ) {
 
 	$is_development_version = preg_match( '/alpha|beta|RC/', $wp_version );
 
-	if ( $is_development_version && 'latest' === $cur->response ) {
-		$cur->response = 'development';
-	}
-
-	switch ( $cur->response ) {
-		case 'development':
-			return sprintf(
-				/* translators: 1: WordPress version number, 2: URL to WordPress Updates screen. */
-				__( 'You are using a development version (%1$s). Cool! Please <a href="%2$s">stay updated</a>.' ),
-				get_bloginfo( 'version', 'display' ),
-				network_admin_url( 'update-core.php' )
-			);
-
-		case 'upgrade':
-			return sprintf(
-				'<strong><a href="%s">%s</a></strong>',
-				network_admin_url( 'update-core.php' ),
-				/* translators: %s: WordPress version. */
-				sprintf( __( 'Get Version %s' ), $cur->current )
-			);
-
-		case 'latest':
-		default:
+	if ( 'upgrade' === $cur->response ) {
+		return sprintf(
+			'<strong><a href="%s">%s</a></strong>',
+			network_admin_url( 'update-core.php' ),
 			/* translators: %s: WordPress version. */
-			return sprintf( __( 'Version %s' ), get_bloginfo( 'version', 'display' ) );
+			sprintf( __( 'Get Version %s' ), $cur->current )
+		);
+	} else {
+		/* translators: s: URL to WordPress Updates screen. */
+		$stay_updated = sprintf( __( 'Please <a href="%s">stay updated</a>.' ), network_admin_url( 'update-core.php' ) );
+		$msg          = $is_development_version ? $msg . '&nbsp;' . $stay_updated : $msg;
+
+		return $msg;
 	}
 }
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

When the user is on the current release, but is set to receive nightlies, via the Beta Tester plugin or otherwise, the footer message will be You are using a development version... technically this is incorrect.

Simplify the footer message to `Version 5.7-alpha-xxx. Please stay updated.` or `Version 5.6.`

Trac ticket: https://core.trac.wordpress.org/ticket/51976

