### PR TITLE
Solve REST API: Using _embed and _fields query parameters in the same query

### DIFF
--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -819,6 +819,13 @@ function rest_filter_response_fields( $response, $server, $request ) {
 	$data = $response->get_data();
 
 	$fields = wp_parse_list( $request['_fields'] );
+	$embeds = wp_parse_list( $request['_embed'] );
+
+	if ( ! empty( $embeds ) && ! isset( $fields['_links'] ) ) {
+		foreach ( $embeds as $embed ) {
+			$fields[] = "_links.{$embed}";
+		}
+	}
 
 	if ( 0 === count( $fields ) ) {
 		return $response;


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/49985

- [x] Adjust the code to check if request has embed and _links are not inside fields then add specific embeds fields to be fetched only.
- [ ] Adjust tests