### PR TITLE
#50790 - Pass an empty array to remove non-single registered meta

### DIFF
--- a/src/wp-includes/rest-api/fields/class-wp-rest-meta-fields.php
+++ b/src/wp-includes/rest-api/fields/class-wp-rest-meta-fields.php
@@ -150,8 +150,10 @@ abstract class WP_REST_Meta_Fields {
 			/*
 			 * A null value means reset the field, which is essentially deleting it
 			 * from the database and then relying on the default value.
+			 *
+			 * Non-single meta can also be removed by passing an empty array.
 			 */
-			if ( is_null( $value ) ) {
+			if ( is_null( $value ) || ( array() === $value && ! $args['single'] ) ) {
 				$args = $this->get_registered_fields()[ $meta_key ];
 
 				if ( $args['single'] ) {
@@ -167,17 +169,6 @@ abstract class WP_REST_Meta_Fields {
 					}
 				}
 
-				$result = $this->delete_meta_value( $object_id, $meta_key, $name );
-				if ( is_wp_error( $result ) ) {
-					return $result;
-				}
-				continue;
-			}
-
-			/*
-			 * Non-single meta can also be removed by sending an empty array.
-			 */
-			if ( is_array( $value ) && empty( $value ) && ! $args['single'] ) {
 				$result = $this->delete_meta_value( $object_id, $meta_key, $name );
 				if ( is_wp_error( $result ) ) {
 					return $result;

--- a/src/wp-includes/rest-api/fields/class-wp-rest-meta-fields.php
+++ b/src/wp-includes/rest-api/fields/class-wp-rest-meta-fields.php
@@ -145,11 +145,13 @@ abstract class WP_REST_Meta_Fields {
 				continue;
 			}
 
+			$value = $meta[ $name ];
+
 			/*
 			 * A null value means reset the field, which is essentially deleting it
 			 * from the database and then relying on the default value.
 			 */
-			if ( is_null( $meta[ $name ] ) ) {
+			if ( is_null( $value ) ) {
 				$args = $this->get_registered_fields()[ $meta_key ];
 
 				if ( $args['single'] ) {
@@ -172,7 +174,16 @@ abstract class WP_REST_Meta_Fields {
 				continue;
 			}
 
-			$value = $meta[ $name ];
+			/*
+			 * Non-single meta can also be removed by sending an empty array.
+			 */
+			if ( is_array( $value ) && empty( $value ) && ! $args['single'] ) {
+				$result = $this->delete_meta_value( $object_id, $meta_key, $name );
+				if ( is_wp_error( $result ) ) {
+					return $result;
+				}
+				continue;
+			}
 
 			if ( ! $args['single'] && is_array( $value ) && count( array_filter( $value, 'is_null' ) ) ) {
 				return new WP_Error(

--- a/tests/phpunit/tests/rest-api/rest-post-meta-fields.php
+++ b/tests/phpunit/tests/rest-api/rest-post-meta-fields.php
@@ -1027,6 +1027,28 @@ class WP_Test_REST_Post_Meta_Fields extends WP_Test_REST_TestCase {
 		$this->assertSame( $post_original->post_content, $post_updated->post_content );
 	}
 
+	public function test_remove_multi_value_with_empty_array() {
+		add_post_meta( self::$post_id, 'test_multi', 'val1' );
+		$values = get_post_meta( self::$post_id, 'test_multi', false );
+		$this->assertSame( array( 'val1' ), $values );
+
+		$this->grant_write_permission();
+
+		$data    = array(
+			'meta' => array(
+				'test_multi' => array(),
+			),
+		);
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d', self::$post_id ) );
+		$request->set_body_params( $data );
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 200, $response->get_status() );
+
+		$meta = get_post_meta( self::$post_id, 'test_multi', false );
+		$this->assertEmpty( $meta );
+	}
+
 	public function test_remove_multi_value_db_error() {
 		add_post_meta( self::$post_id, 'test_multi', 'val1' );
 		$values = get_post_meta( self::$post_id, 'test_multi', false );

--- a/tests/phpunit/tests/rest-api/rest-post-meta-fields.php
+++ b/tests/phpunit/tests/rest-api/rest-post-meta-fields.php
@@ -1027,6 +1027,9 @@ class WP_Test_REST_Post_Meta_Fields extends WP_Test_REST_TestCase {
 		$this->assertSame( $post_original->post_content, $post_updated->post_content );
 	}
 
+	/**
+	 * @ticket 50790
+	 */
 	public function test_remove_multi_value_with_empty_array() {
 		add_post_meta( self::$post_id, 'test_multi', 'val1' );
 		$values = get_post_meta( self::$post_id, 'test_multi', false );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Allow passing an empty array to the REST API for registered non-single meta to remove the DB values, as an alternative to sending `null`.

Trac ticket: https://core.trac.wordpress.org/ticket/50790

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
