### PR TITLE
Allow embedded links in preloaded api request

### DIFF
--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -2512,19 +2512,18 @@ function rest_preload_api_request( $memo, $path ) {
 	}
 
 	$request = new WP_REST_Request( $method, $path_parts['path'] );
+	$embed   = false;
 	if ( ! empty( $path_parts['query'] ) ) {
+		$query_params = array();
 		parse_str( $path_parts['query'], $query_params );
+		$embed = isset( $query_params['_embed'] ) ? $query_params['_embed'] : false;
 		$request->set_query_params( $query_params );
 	}
 
 	$response = rest_do_request( $request );
 	if ( 200 === $response->status ) {
 		$server = rest_get_server();
-		$data   = (array) $response->get_data();
-		$links  = $server::get_compact_response_links( $response );
-		if ( ! empty( $links ) ) {
-			$data['_links'] = $links;
-		}
+		$data   = $server->response_to_data( $response, $embed );
 
 		if ( 'OPTIONS' === $method ) {
 			$response = rest_send_allow_header( $response, $server, $request );

--- a/tests/phpunit/tests/rest-api.php
+++ b/tests/phpunit/tests/rest-api.php
@@ -957,6 +957,39 @@ class Tests_REST_API extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 51722
+	 */
+	function test_rest_preload_api_request_links_embeds() {
+		$rest_server               = $GLOBALS['wp_rest_server'];
+		$GLOBALS['wp_rest_server'] = null;
+
+		$this->factory->post->create(
+			array(
+				'post_status' => 'publish',
+				'post_date'   => '2001-02-03 04:05:06',
+			)
+		);
+
+		$preload_paths = array(
+			'/wp/v2/posts?_embed=wp:term',
+		);
+
+		$preload_data = array_reduce(
+			$preload_paths,
+			'rest_preload_api_request',
+			array()
+		);
+
+		$this->assertSame( array_keys( $preload_data ), $preload_paths );
+		$this->assertArrayHasKey( 'body', $preload_data['/wp/v2/posts?_embed=wp:term'] );
+		$body = $preload_data['/wp/v2/posts?_embed=wp:term']['body'][0];
+		$this->assertArrayHasKey( '_embedded', $body );
+		$this->assertArrayHasKey( '_links', $body );
+
+		$GLOBALS['wp_rest_server'] = $rest_server;
+	}
+
+	/**
 	 * @ticket 40614
 	 */
 	function test_rest_ensure_request_accepts_path_string() {

--- a/tests/phpunit/tests/rest-api.php
+++ b/tests/phpunit/tests/rest-api.php
@@ -963,16 +963,15 @@ class Tests_REST_API extends WP_UnitTestCase {
 		$rest_server               = $GLOBALS['wp_rest_server'];
 		$GLOBALS['wp_rest_server'] = null;
 
-		$this->factory->post->create(
+		$post_id = $this->factory->post->create(
 			array(
 				'post_status' => 'publish',
 				'post_date'   => '2001-02-03 04:05:06',
 			)
 		);
 
-		$preload_paths = array(
-			'/wp/v2/posts?_embed=wp:term',
-		);
+		$url           = sprintf( '/wp/v2/posts/%d?_embed=wp:term', $post_id );
+		$preload_paths = array( $url );
 
 		$preload_data = array_reduce(
 			$preload_paths,
@@ -981,10 +980,9 @@ class Tests_REST_API extends WP_UnitTestCase {
 		);
 
 		$this->assertSame( array_keys( $preload_data ), $preload_paths );
-		$this->assertArrayHasKey( 'body', $preload_data['/wp/v2/posts?_embed=wp:term'] );
-		$body = $preload_data['/wp/v2/posts?_embed=wp:term']['body'][0];
-		$this->assertArrayHasKey( '_embedded', $body );
-		$this->assertArrayHasKey( '_links', $body );
+		$this->assertArrayHasKey( 'body', $preload_data[ $url ] );
+		$this->assertArrayHasKey( '_embedded', $preload_data[ $url ]['body'] );
+		$this->assertArrayHasKey( '_links', $preload_data[ $url ]['body'] );
 
 		$GLOBALS['wp_rest_server'] = $rest_server;
 	}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Adding a simple fix for [51722](https://core.trac.wordpress.org/ticket/51722). The `response_to_data` method to resolve the links and embed fields. 

Trac ticket: https://core.trac.wordpress.org/ticket/51722

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
