### PR TITLE
52342: add more error reporting to `copy_dir()` and `_copy_dir()`

### DIFF
--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1763,22 +1763,20 @@ function _unzip_file_pclzip( $file, $to, $needed_dirs = array() ) {
  * Assumes that WP_Filesystem() has already been called and setup.
  *
  * @since 2.5.0
- * @since 5.7.0 Add $first_pass parameter.
  *
  * @global WP_Filesystem_Base $wp_filesystem WordPress filesystem subclass.
  *
  * @param string $from       Source directory.
  * @param string $to         Destination directory.
  * @param array  $skip_list  An array of files/folders to skip copying.
- * @param bool   $first_pass True on the initial call, but false on subsequent calls.
  * @return true|WP_Error True on success, WP_Error on failure.
  */
-function copy_dir( $from, $to, $skip_list = array(), $first_pass = true ) {
+function copy_dir( $from, $to, $skip_list = array() ) {
 	global $wp_filesystem;
 
 	$dirlist = $wp_filesystem->dirlist( $from );
 
-	if ( ! $dirlist && $first_pass ) {
+	if ( false === $dirlist ) {
 		return new WP_Error( 'dirlist_failed_copy_dir', __( 'Directory listing failed.' ), basename( $to ) );
 	}
 
@@ -1815,7 +1813,7 @@ function copy_dir( $from, $to, $skip_list = array(), $first_pass = true ) {
 				}
 			}
 
-			$result = copy_dir( $from . $filename, $to . $filename, $sub_skip_list, false );
+			$result = copy_dir( $from . $filename, $to . $filename, $sub_skip_list );
 			if ( is_wp_error( $result ) ) {
 				return $result;
 			}

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1763,18 +1763,24 @@ function _unzip_file_pclzip( $file, $to, $needed_dirs = array() ) {
  * Assumes that WP_Filesystem() has already been called and setup.
  *
  * @since 2.5.0
+ * @since 5.7.0 Add $first_pass parameter.
  *
  * @global WP_Filesystem_Base $wp_filesystem WordPress filesystem subclass.
  *
- * @param string   $from      Source directory.
- * @param string   $to        Destination directory.
- * @param string[] $skip_list An array of files/folders to skip copying.
+ * @param string $from       Source directory.
+ * @param string $to         Destination directory.
+ * @param array  $skip_list  An array of files/folders to skip copying.
+ * @param bool   $first_pass True on the initial call, but false on subsequent calls.
  * @return true|WP_Error True on success, WP_Error on failure.
  */
-function copy_dir( $from, $to, $skip_list = array() ) {
+function copy_dir( $from, $to, $skip_list = array(), $first_pass = true ) {
 	global $wp_filesystem;
 
 	$dirlist = $wp_filesystem->dirlist( $from );
+
+	if ( ! $dirlist && $first_pass ) {
+		return new WP_Error( 'dirlist_failed_copy_dir', __( 'Directory listing failed.' ), basename( $to ) );
+	}
 
 	$from = trailingslashit( $from );
 	$to   = trailingslashit( $to );
@@ -1809,7 +1815,7 @@ function copy_dir( $from, $to, $skip_list = array() ) {
 				}
 			}
 
-			$result = copy_dir( $from . $filename, $to . $filename, $sub_skip_list );
+			$result = copy_dir( $from . $filename, $to . $filename, $sub_skip_list, false );
 			if ( is_wp_error( $result ) ) {
 				return $result;
 			}

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1766,9 +1766,9 @@ function _unzip_file_pclzip( $file, $to, $needed_dirs = array() ) {
  *
  * @global WP_Filesystem_Base $wp_filesystem WordPress filesystem subclass.
  *
- * @param string $from      Source directory.
- * @param string $to        Destination directory.
- * @param array  $skip_list An array of files/folders to skip copying.
+ * @param string   $from      Source directory.
+ * @param string   $to        Destination directory.
+ * @param string[] $skip_list An array of files/folders to skip copying.
  * @return true|WP_Error True on success, WP_Error on failure.
  */
 function copy_dir( $from, $to, $skip_list = array() ) {

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1766,9 +1766,9 @@ function _unzip_file_pclzip( $file, $to, $needed_dirs = array() ) {
  *
  * @global WP_Filesystem_Base $wp_filesystem WordPress filesystem subclass.
  *
- * @param string $from       Source directory.
- * @param string $to         Destination directory.
- * @param array  $skip_list  An array of files/folders to skip copying.
+ * @param string $from      Source directory.
+ * @param string $to        Destination directory.
+ * @param array  $skip_list An array of files/folders to skip copying.
  * @return true|WP_Error True on success, WP_Error on failure.
  */
 function copy_dir( $from, $to, $skip_list = array() ) {

--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -1342,9 +1342,9 @@ function update_core( $from, $to ) {
  *
  * @global WP_Filesystem_Base $wp_filesystem
  *
- * @param string $from      Source directory.
- * @param string $to        Destination directory.
- * @param array  $skip_list Array of files/folders to skip copying.
+ * @param string   $from      Source directory.
+ * @param string   $to        Destination directory.
+ * @param string[] $skip_list Array of files/folders to skip copying.
  * @return true|WP_Error True on success, WP_Error on failure.
  */
 function _copy_dir( $from, $to, $skip_list = array() ) {

--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -1342,9 +1342,9 @@ function update_core( $from, $to ) {
  *
  * @global WP_Filesystem_Base $wp_filesystem
  *
- * @param string $from       Source directory.
- * @param string $to         Destination directory.
- * @param array  $skip_list  Array of files/folders to skip copying.
+ * @param string $from      Source directory.
+ * @param string $to        Destination directory.
+ * @param array  $skip_list Array of files/folders to skip copying.
  * @return true|WP_Error True on success, WP_Error on failure.
  */
 function _copy_dir( $from, $to, $skip_list = array() ) {

--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -1336,21 +1336,27 @@ function update_core( $from, $to ) {
  * @ignore
  * @since 3.2.0
  * @since 3.7.0 Updated not to use a regular expression for the skip list.
+ * @since 5.7.0 Add $first_pass parameter.
  *
  * @see copy_dir()
  * @link https://core.trac.wordpress.org/ticket/17173
  *
  * @global WP_Filesystem_Base $wp_filesystem
  *
- * @param string   $from      Source directory.
- * @param string   $to        Destination directory.
- * @param string[] $skip_list Array of files/folders to skip copying.
+ * @param string $from       Source directory.
+ * @param string $to         Destination directory.
+ * @param array  $skip_list  Array of files/folders to skip copying.
+ * @param bool   $first_pass True on initial call, but false on subsequent calls.
  * @return true|WP_Error True on success, WP_Error on failure.
  */
-function _copy_dir( $from, $to, $skip_list = array() ) {
+function _copy_dir( $from, $to, $skip_list = array(), $first_pass = true ) {
 	global $wp_filesystem;
 
 	$dirlist = $wp_filesystem->dirlist( $from );
+
+	if ( ! $dirlist && $first_pass ) {
+		return new WP_Error( 'dirlist_failed__copy_dir', __( 'Directory listing failed.' ), basename( $to ) );
+	}
 
 	$from = trailingslashit( $from );
 	$to   = trailingslashit( $to );
@@ -1391,7 +1397,7 @@ function _copy_dir( $from, $to, $skip_list = array() ) {
 				}
 			}
 
-			$result = _copy_dir( $from . $filename, $to . $filename, $sub_skip_list );
+			$result = _copy_dir( $from . $filename, $to . $filename, $sub_skip_list, false );
 			if ( is_wp_error( $result ) ) {
 				return $result;
 			}

--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -1336,7 +1336,6 @@ function update_core( $from, $to ) {
  * @ignore
  * @since 3.2.0
  * @since 3.7.0 Updated not to use a regular expression for the skip list.
- * @since 5.7.0 Add $first_pass parameter.
  *
  * @see copy_dir()
  * @link https://core.trac.wordpress.org/ticket/17173
@@ -1346,15 +1345,14 @@ function update_core( $from, $to ) {
  * @param string $from       Source directory.
  * @param string $to         Destination directory.
  * @param array  $skip_list  Array of files/folders to skip copying.
- * @param bool   $first_pass True on initial call, but false on subsequent calls.
  * @return true|WP_Error True on success, WP_Error on failure.
  */
-function _copy_dir( $from, $to, $skip_list = array(), $first_pass = true ) {
+function _copy_dir( $from, $to, $skip_list = array() ) {
 	global $wp_filesystem;
 
 	$dirlist = $wp_filesystem->dirlist( $from );
 
-	if ( ! $dirlist && $first_pass ) {
+	if ( false === $dirlist ) {
 		return new WP_Error( 'dirlist_failed__copy_dir', __( 'Directory listing failed.' ), basename( $to ) );
 	}
 
@@ -1397,7 +1395,7 @@ function _copy_dir( $from, $to, $skip_list = array(), $first_pass = true ) {
 				}
 			}
 
-			$result = _copy_dir( $from . $filename, $to . $filename, $sub_skip_list, false );
+			$result = _copy_dir( $from . $filename, $to . $filename, $sub_skip_list );
 			if ( is_wp_error( $result ) ) {
 				return $result;
 			}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Previously discussed patches to copy_dir() and _copy_dir() to return a WP_Error reporting a failed directory listing. This should help with $51928 telemetry data.

This was originally in #51857 patch, but extracted here as #51857 is going in a different direction.

Discussed in #core https://wordpress.slack.com/archives/C02RQBWTW/p1611255822032100

Trac ticket: https://core.trac.wordpress.org/ticket/52342

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
