### PR TITLE
49889 Adds wp get image size() to skip error suppression when WP_DEBUG true.

### DIFF
--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3927,7 +3927,7 @@ function wp_ajax_crop_image() {
 			$parent_url = wp_get_attachment_url( $attachment_id );
 			$url        = str_replace( wp_basename( $parent_url ), wp_basename( $cropped ), $parent_url );
 
-			$size       = @getimagesize( $cropped );
+			$size       = wp_getimagesize( $cropped );
 			$image_type = ( $size ) ? $size['mime'] : 'image/jpeg';
 
 			$object = array(

--- a/src/wp-admin/includes/class-custom-image-header.php
+++ b/src/wp-admin/includes/class-custom-image-header.php
@@ -791,7 +791,7 @@ endif;
 		}
 
 		if ( file_exists( $file ) ) {
-			list( $width, $height, $type, $attr ) = @getimagesize( $file );
+			list( $width, $height, $type, $attr ) = wp_getimagesize( $file );
 		} else {
 			$data   = wp_get_attachment_metadata( $attachment_id );
 			$height = isset( $data['height'] ) ? $data['height'] : 0;
@@ -1223,7 +1223,7 @@ endif;
 		$parent_url = wp_get_attachment_url( $parent->ID );
 		$url        = str_replace( wp_basename( $parent_url ), wp_basename( $cropped ), $parent_url );
 
-		$size       = @getimagesize( $cropped );
+		$size       = wp_getimagesize( $cropped );
 		$image_type = ( $size ) ? $size['mime'] : 'image/jpeg';
 
 		$object = array(

--- a/src/wp-admin/includes/class-wp-site-icon.php
+++ b/src/wp-admin/includes/class-wp-site-icon.php
@@ -87,7 +87,7 @@ class WP_Site_Icon {
 		$parent_url = wp_get_attachment_url( $parent->ID );
 		$url        = str_replace( wp_basename( $parent_url ), wp_basename( $cropped ), $parent_url );
 
-		$size       = @getimagesize( $cropped );
+		$size       = wp_getimagesize( $cropped );
 		$image_type = ( $size ) ? $size['mime'] : 'image/jpeg';
 
 		$object = array(

--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -719,7 +719,13 @@ function wp_read_image_metadata( $file ) {
 		wp_getimagesize( $file, $info );
 
 		if ( ! empty( $info['APP13'] ) ) {
-			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			if (
+				// Skip when running unit tests.
+				! defined( 'DIR_TESTDATA' )
+				&&
+				// Process without silencing errors when in debug mode.
+				defined( 'WP_DEBUG' ) && WP_DEBUG
+			) {
 				$iptc = iptcparse( $info['APP13'] );
 			} else {
 				$iptc = @iptcparse( $info['APP13'] );
@@ -783,7 +789,13 @@ function wp_read_image_metadata( $file ) {
 	$exif_image_types = apply_filters( 'wp_read_image_metadata_types', array( IMAGETYPE_JPEG, IMAGETYPE_TIFF_II, IMAGETYPE_TIFF_MM ) );
 
 	if ( is_callable( 'exif_read_data' ) && in_array( $image_type, $exif_image_types, true ) ) {
-		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+		if (
+			// Skip when running unit tests.
+			! defined( 'DIR_TESTDATA' )
+			&&
+			// Process without silencing errors when in debug mode.
+			defined( 'WP_DEBUG' ) && WP_DEBUG
+		) {
 			$exif = exif_read_data( $file );
 		} else {
 			$exif = @exif_read_data( $file );

--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -93,7 +93,7 @@ function wp_get_missing_image_subsizes( $attachment_id ) {
 	// Use the originally uploaded image dimensions as full_width and full_height.
 	if ( ! empty( $image_meta['original_image'] ) ) {
 		$image_file = wp_get_original_image_path( $attachment_id );
-		$imagesize  = @getimagesize( $image_file );
+		$imagesize  = wp_getimagesize( $image_file );
 	}
 
 	if ( ! empty( $imagesize ) ) {
@@ -224,7 +224,7 @@ function _wp_image_meta_replace_original( $saved_data, $original_file, $image_me
  * @return array The image attachment meta data.
  */
 function wp_create_image_subsizes( $file, $attachment_id ) {
-	$imagesize = @getimagesize( $file );
+	$imagesize = wp_getimagesize( $file );
 
 	if ( empty( $imagesize ) ) {
 		// File is not an image.
@@ -687,7 +687,7 @@ function wp_read_image_metadata( $file ) {
 		return false;
 	}
 
-	list( , , $image_type ) = @getimagesize( $file );
+	list( , , $image_type ) = wp_getimagesize( $file );
 
 	/*
 	 * EXIF contains a bunch of data we'll probably never need formatted in ways
@@ -716,10 +716,14 @@ function wp_read_image_metadata( $file ) {
 	 * as caption, description etc.
 	 */
 	if ( is_callable( 'iptcparse' ) ) {
-		@getimagesize( $file, $info );
+		wp_getimagesize( $file, $info );
 
 		if ( ! empty( $info['APP13'] ) ) {
-			$iptc = @iptcparse( $info['APP13'] );
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				$iptc = iptcparse( $info['APP13'] );
+			} else {
+				$iptc = @iptcparse( $info['APP13'] );
+			}
 
 			// Headline, "A brief synopsis of the caption".
 			if ( ! empty( $iptc['2#105'][0] ) ) {
@@ -779,7 +783,11 @@ function wp_read_image_metadata( $file ) {
 	$exif_image_types = apply_filters( 'wp_read_image_metadata_types', array( IMAGETYPE_JPEG, IMAGETYPE_TIFF_II, IMAGETYPE_TIFF_MM ) );
 
 	if ( is_callable( 'exif_read_data' ) && in_array( $image_type, $exif_image_types, true ) ) {
-		$exif = @exif_read_data( $file );
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			$exif = exif_read_data( $file );
+		} else {
+			$exif = @exif_read_data( $file );
+		}
 
 		if ( ! empty( $exif['ImageDescription'] ) ) {
 			mbstring_binary_safe_encoding();
@@ -877,7 +885,7 @@ function wp_read_image_metadata( $file ) {
  * @return bool True if valid image, false if not valid image.
  */
 function file_is_valid_image( $path ) {
-	$size = @getimagesize( $path );
+	$size = wp_getimagesize( $path );
 	return ! empty( $size );
 }
 
@@ -892,7 +900,7 @@ function file_is_valid_image( $path ) {
 function file_is_displayable_image( $path ) {
 	$displayable_image_types = array( IMAGETYPE_GIF, IMAGETYPE_JPEG, IMAGETYPE_PNG, IMAGETYPE_BMP, IMAGETYPE_ICO );
 
-	$info = @getimagesize( $path );
+	$info = wp_getimagesize( $path );
 	if ( empty( $info ) ) {
 		$result = false;
 	} elseif ( ! in_array( $info[2], $displayable_image_types, true ) ) {

--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -728,6 +728,7 @@ function wp_read_image_metadata( $file ) {
 			) {
 				$iptc = iptcparse( $info['APP13'] );
 			} else {
+				// phpcs:ignore WordPress.PHP.NoSilencedErrors -- Silencing notice and warning is intentional. See https://core.trac.wordpress.org/ticket/42480
 				$iptc = @iptcparse( $info['APP13'] );
 			}
 
@@ -798,6 +799,7 @@ function wp_read_image_metadata( $file ) {
 		) {
 			$exif = exif_read_data( $file );
 		} else {
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors -- Silencing notice and warning is intentional. See https://core.trac.wordpress.org/ticket/42480
 			$exif = @exif_read_data( $file );
 		}
 

--- a/src/wp-includes/class-wp-image-editor-gd.php
+++ b/src/wp-includes/class-wp-image-editor-gd.php
@@ -105,7 +105,7 @@ class WP_Image_Editor_GD extends WP_Image_Editor {
 			return new WP_Error( 'invalid_image', __( 'File is not an image.' ), $this->file );
 		}
 
-		$size = @getimagesize( $this->file );
+		$size = wp_getimagesize( $this->file );
 
 		if ( ! $size ) {
 			return new WP_Error( 'invalid_image', __( 'Could not read image size.' ), $this->file );

--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -1948,7 +1948,7 @@ function get_attachment_icon( $id = 0, $fullsize = false, $max_dims = false ) {
 	// Do we need to constrain the image?
 	if ( ($max_dims = apply_filters('attachment_max_dims', $max_dims)) && file_exists($src_file) ) {
 
-		$imagesize = @getimagesize($src_file);
+		$imagesize = wp_getimagesize($src_file);
 
 		if (($imagesize[0] > $max_dims[0]) || $imagesize[1] > $max_dims[1] ) {
 			$actual_aspect = $imagesize[0] / $imagesize[1];

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -7785,7 +7785,7 @@ function wp_fuzzy_number_match( $expected, $actual, $precision = 1 ) {
 /**
  * Allows PHP's getimagesize() to be debuggable when necessary.
  *
- * @since 5.6.0
+ * @since 5.7.0
  *
  * @param string $filename The file path.
  * @param array $imageinfo Extended image information, passed by reference.

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -7796,5 +7796,15 @@ function wp_getimagesize( $filename, &$imageinfo = array() ) {
 		return getimagesize( $filename, $imageinfo );
 	}
 
+	/**
+	 * Silencing notice and warning is intentional.
+	 *
+	 * getimagesize() has a tendency to generate errors, such as "corrupt JPEG data: 7191 extraneous bytes before
+	 * marker", even when it's able to provide image size information.
+	 *
+	 * See https://core.trac.wordpress.org/ticket/42480
+	 *
+	 * phpcs:ignore WordPress.PHP.NoSilencedErrors
+	 */
 	return @getimagesize( $filename, $imageinfo );
 }

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -7792,7 +7792,13 @@ function wp_fuzzy_number_match( $expected, $actual, $precision = 1 ) {
  * @return array|false Array of image information or false on failure.
  */
 function wp_getimagesize( $filename, &$imageinfo = array() ) {
-	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+	if (
+		// Skip when running unit tests.
+		! defined( 'DIR_TESTDATA' )
+		&&
+		// Return without silencing errors when in debug mode.
+		defined( 'WP_DEBUG' ) && WP_DEBUG
+	) {
 		return getimagesize( $filename, $imageinfo );
 	}
 

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -3052,7 +3052,7 @@ function wp_get_image_mime( $file ) {
 			$imagetype = exif_imagetype( $file );
 			$mime      = ( $imagetype ) ? image_type_to_mime_type( $imagetype ) : false;
 		} elseif ( function_exists( 'getimagesize' ) ) {
-			$imagesize = @getimagesize( $file );
+			$imagesize = wp_getimagesize( $file );
 			$mime      = ( isset( $imagesize['mime'] ) ) ? $imagesize['mime'] : false;
 		} else {
 			$mime = false;
@@ -7780,4 +7780,21 @@ function is_php_version_compatible( $required ) {
  */
 function wp_fuzzy_number_match( $expected, $actual, $precision = 1 ) {
 	return abs( (float) $expected - (float) $actual ) <= $precision;
+}
+
+/**
+ * Allows PHP's getimagesize() to be debuggable when necessary.
+ *
+ * @since 5.6.0
+ *
+ * @param string $filename The file path.
+ * @param array $imageinfo Extended image information, passed by reference.
+ * @return array|false Array of image information or false on failure.
+ */
+function wp_getimagesize( $filename, &$imageinfo = array() ) {
+	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+		return getimagesize( $filename, $imageinfo );
+	}
+
+	return @getimagesize( $filename, $imageinfo );
 }

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -244,7 +244,7 @@ function image_downsize( $id, $size = 'medium' ) {
 		$info       = null;
 
 		if ( $thumb_file ) {
-			$info = @getimagesize( $thumb_file );
+			$info = wp_getimagesize( $thumb_file );
 		}
 
 		if ( $thumb_file && $info ) {
@@ -962,7 +962,7 @@ function wp_get_attachment_image_src( $attachment_id, $size = 'thumbnail', $icon
 				$icon_dir = apply_filters( 'icon_dir', ABSPATH . WPINC . '/images/media' );
 
 				$src_file               = $icon_dir . '/' . wp_basename( $src );
-				list( $width, $height ) = @getimagesize( $src_file );
+				list( $width, $height ) = wp_getimagesize( $src_file );
 			}
 		}
 

--- a/tests/phpunit/tests/image/intermediateSize.php
+++ b/tests/phpunit/tests/image/intermediateSize.php
@@ -67,8 +67,6 @@ class Tests_Image_Intermediate_Size extends WP_UnitTestCase {
 	 * @requires function imagejpeg
 	 */
 	function test_get_intermediate_sizes_by_name() {
-		printf( "\nWP_DEBUG on? %s \n", defined( 'WP_DEBUG' ) ? 'Yes' : 'No' );
-		exit;
 		add_image_size( 'test-size', 330, 220, true );
 
 		$file = DIR_TESTDATA . '/images/waffles.jpg';

--- a/tests/phpunit/tests/image/intermediateSize.php
+++ b/tests/phpunit/tests/image/intermediateSize.php
@@ -67,6 +67,8 @@ class Tests_Image_Intermediate_Size extends WP_UnitTestCase {
 	 * @requires function imagejpeg
 	 */
 	function test_get_intermediate_sizes_by_name() {
+		printf( "\nWP_DEBUG on? %s \n", defined( 'WP_DEBUG' ) ? 'Yes' : 'No' );
+		exit;
 		add_image_size( 'test-size', 330, 220, true );
 
 		$file = DIR_TESTDATA . '/images/waffles.jpg';


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/49889

- Applies 49889.4.diff​ patch
- Fixes failing tests by skipping debug mode when running unit tests (ie suppress errors during tests)
- Ignores phpcs `NoSilencedErrors` sniff for intentional error suppressions and adds reason why
- Changes `@since` to 5.7.0

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
