### PR TITLE
Add support for custom spacing in core

### DIFF
--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -147,6 +147,7 @@ $font_sizes         = current( (array) get_theme_support( 'editor-font-sizes' ) 
 $gradient_presets   = current( (array) get_theme_support( 'editor-gradient-presets' ) );
 $custom_line_height = get_theme_support( 'custom-line-height' );
 $custom_units       = get_theme_support( 'custom-units' );
+$custom_spacing     = get_theme_support( 'custom-spacing' );
 
 /**
  * Filters the allowed block types for the editor, defaulting to true (all
@@ -326,6 +327,7 @@ $editor_settings = array(
 	'enableCustomFields'                   => (bool) get_user_meta( get_current_user_id(), 'enable_custom_fields', true ),
 	'enableCustomLineHeight'               => $custom_line_height,
 	'enableCustomUnits'                    => $custom_units,
+	'enableCustomSpacing'                  => $custom_spacing,
 );
 
 $autosave = wp_get_post_autosave( $post_ID );


### PR DESCRIPTION
See track ticket https://core.trac.wordpress.org/ticket/51760

As per https://github.com/WordPress/gutenberg/pull/25788 the `experimental-custom-spacing` was marked stable and themes can now add support for it via `add_theme_support('custom-spacing')`. This PR adds support for it in core.

## Test instructions

For this to work, it needs https://github.com/WordPress/gutenberg/pull/28548 to be part of Gutenberg 9.9 and the packages to be released and merged in WordPress core.

When that's done, the instructions below should be reproducible:

- Install TwentyTwentyOne them, which has support for `custom-spacing`.
- Make sure the Gutenberg plugin is **not** enabled.
- Go to the post editor and add a group block.
- Verify that there's a spacing panel:

![Captura de ecrã de 2021-01-28 11-50-07](https://user-images.githubusercontent.com/583546/106127642-00e92980-615f-11eb-9648-3d91544c6451.png)
