### PR TITLE
Block Editor: Add defaultEditorStyles

### DIFF
--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -185,7 +185,9 @@ if ( ! $max_upload_size ) {
 $styles = array(
 	array(
 		'css' => file_get_contents(
-			ABSPATH . WPINC . '/css/dist/editor/editor-styles.css'
+			is_rtl()
+				? ABSPATH . WPINC . '/css/dist/editor/editor-styles-rtl.css'
+				: ABSPATH . WPINC . '/css/dist/editor/editor-styles.css'
 		),
 	),
 );
@@ -216,6 +218,17 @@ if ( $editor_styles && current_theme_supports( 'editor-styles' ) ) {
 		}
 	}
 }
+
+// Default editor styles.
+$default_editor_styles = array(
+	array(
+		'css' => file_get_contents(
+			is_rtl()
+				? ABSPATH . WPINC . '/css/dist/editor/editor-styles-rtl.css'
+				: ABSPATH . WPINC . '/css/dist/editor/editor-styles.css'
+		),
+	),
+);
 
 // Image sizes.
 
@@ -309,6 +322,7 @@ $editor_settings = array(
 	'maxUploadFileSize'                    => $max_upload_size,
 	'allowedMimeTypes'                     => get_allowed_mime_types(),
 	'styles'                               => $styles,
+	'defaultEditorStyles'                  => $default_editor_styles,
 	'imageSizes'                           => $available_image_sizes,
 	'imageDimensions'                      => $image_dimensions,
 	'richEditingEnabled'                   => user_can_richedit(),


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

The `defaultEditorStyles` setting was missing from the default block editor settings. This causes the "Use theme styles" setting which was added in WordPress 5.6 to not function properly.

Also, the RTL version of editor styles were not being loaded. This change has not yet been ported over from Gutenberg.

Trac ticket: https://core.trac.wordpress.org/ticket/52394

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
