### PR TITLE
Fix infinite canonical redirect on pages with urlencoded slugs

### DIFF
--- a/src/wp-includes/canonical.php
+++ b/src/wp-includes/canonical.php
@@ -683,8 +683,8 @@ function redirect_canonical( $requested_url = null, $do_redirect = true ) {
 	}
 
 	$build_redirect_url = false;
-	foreach( $original as $k => $v ) {
-		if ( ! in_array( $k, [ 'host', 'path', 'port', 'query' ] ) ) {
+	foreach ( $original as $k => $v ) {
+		if ( ! in_array( $k, array( 'host', 'path', 'port', 'query' ), true ) ) {
 			continue;
 		}
 
@@ -697,7 +697,7 @@ function redirect_canonical( $requested_url = null, $do_redirect = true ) {
 		 * is the 'query' part and if the urlencoded version of `$redirect['query']`
 		 * is the same as `$original['query']`.
 		 */
-		if ( isset( $redirect[ 'query' ] ) && 'query' === $k ) {
+		if ( isset( $redirect['query'] ) && 'query' === $k ) {
 			$encoded_equals_query_original = str_replace( '=', '%3D', $original[ $k ] );
 			if ( strtolower( $encoded_equals_query_original ) === strtolower( urlencode( $redirect[ $k ] ) ) ) {
 				continue;


### PR DESCRIPTION
The issue is `$redirect['query']` and `$original['query']` are never equal because it's comparing the urlencoded vs non urlencoded version.

For example
```
$original['query'] = 'genre=%e3%83%af%e3%83%bc%e3%83%89%e3%83%97%e3%83%ac%e3%82%b9'
$redirect['query'] = 'genre=ワードプレス'
```

Basically the **_value_** of **_genre_** are the same, urlencoded-wise.

We still use the same logic as the previous `$compare_original !== $compare_redirect`, we just changed it so that we can handle the `query` difference.

This still needs more eyes and testing.

Trac ticket: https://core.trac.wordpress.org/ticket/52376

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
