### PR TITLE
General: Fix get_the_archive_description() for default blog index

### DIFF
--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -1779,7 +1779,7 @@ function the_archive_description( $before = '', $after = '' ) {
 function get_the_archive_description() {
 	if ( is_author() ) {
 		$description = get_the_author_meta( 'description' );
-	} elseif ( is_post_type_archive() ) {
+	} elseif ( is_post_type_archive() || is_home() ) {
 		$description = get_the_post_type_description();
 	} else {
 		$description = term_description();
@@ -1807,6 +1807,8 @@ function get_the_post_type_description() {
 
 	if ( is_array( $post_type ) ) {
 		$post_type = reset( $post_type );
+	} else {
+		$post_type = 'post';
 	}
 
 	$post_type_obj = get_post_type_object( $post_type );


### PR DESCRIPTION
get_the_archive_description() returns nothing
when viewing the default blog index.
When viewing a custom post type index, it
returns the description parameter but even if I
add the description to 'post' nothing is displayed.

The fix requires only adding additional
is_home() check to is_post_type_archive()
condition in get_the_archive_description() and
setting a fallback $post_type = 'post' in
get_the_post_type_description().

Note that description for 'post' doesn't exist by
default so this shouldn't cause any surprising
changes. It just makes the function more logical.

With these to very minor changes, adding
archive description for blog index is simple by
filtering 'register_post_type_args'

Trac ticket: https://core.trac.wordpress.org/ticket/52404#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
