### PR TITLE
Fix `register_activation_hook` callback `$network_wide` parameter

### DIFF
--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -190,7 +190,7 @@ if ( $action ) {
 			// Go back to "sandbox" scope so we get the same errors as before.
 			plugin_sandbox_scrape( $plugin );
 			/** This action is documented in wp-admin/includes/plugin.php */
-			do_action( "activate_{$plugin}" );
+			do_action( "activate_{$plugin}", is_network_admin() );
 			exit;
 
 		case 'deactivate':


### PR DESCRIPTION
When using `register_activation_hook`, the `"activate_{$plugin}"` action doesn't pass the `$network_wide` boolean as the parameter for the callback.

Instead, the parameter gets substituted with an empty string, breaking the page when using strict typing, as it expects a boolean.

Looking at how it's done when activating plugins, it uses `is_network_admin()` as the parameter
https://github.com/WordPress/wordpress-develop/blob/6ef5edd41f8e6cdd5bc372fc02489f7bb423d8d1/src/wp-admin/plugins.php#L124

Same thing should happen here:
https://github.com/WordPress/wordpress-develop/blob/6ef5edd41f8e6cdd5bc372fc02489f7bb423d8d1/src/wp-admin/plugins.php#L193
`do_action( "activate_{$plugin}", is_network_admin() );`

Trac ticket: https://core.trac.wordpress.org/ticket/52405#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
