### PR TITLE
51660 Adds short-circuit filter to skip query for `WP_List_Table::months_dropdown()`

### DIFF
--- a/src/wp-admin/includes/class-wp-list-table.php
+++ b/src/wp-admin/includes/class-wp-list-table.php
@@ -603,23 +603,15 @@ class WP_List_Table {
 		}
 
 		/**
-		* Allows overriding the list of months displayed in the admin post lists.
-		*
-		* By default (if this filter does not return an array), a query will be
-		* run to determine the months that have post items.  This query can be
-		* expensive for a large number of posts, so it may be desirable for sites to
-		* override this behavior.
-		*
-		* @since 5.7
-		*
-		* @link https://core.trac.wordpress.org/ticket/51660
-		*
-		* @param string $post_type The post type.
-		* @param string $extra_checks Filtering options for the post status.
-		*/
-		$months = apply_filters( 'edit_months_dropdown', $post_type, $extra_checks );
-
-		if ( ! is_array( $months ) ) {
+		 * Filters whether to short-circuit performing the months dropdown query.
+		 *
+		 * @since 5.7.0
+		 *
+		 * @param bool   $skip_query Whether to skip doing the query. Default false.
+		 * @param string $post_type  The post type.
+		 */
+		$skip_query = apply_filters( 'pre_months_dropdown_query', false, $post_type );
+		if ( ! $skip_query ) {
 			$months = $wpdb->get_results(
 				$wpdb->prepare(
 					"
@@ -632,6 +624,8 @@ class WP_List_Table {
 					$post_type
 				)
 			);
+		} else {
+			$months = array();
 		}
 
 		/**

--- a/src/wp-admin/includes/class-wp-list-table.php
+++ b/src/wp-admin/includes/class-wp-list-table.php
@@ -595,23 +595,24 @@ class WP_List_Table {
 			return;
 		}
 
-		$extra_checks = "AND post_status != 'auto-draft'";
-		if ( ! isset( $_GET['post_status'] ) || 'trash' !== $_GET['post_status'] ) {
-			$extra_checks .= " AND post_status != 'trash'";
-		} elseif ( isset( $_GET['post_status'] ) ) {
-			$extra_checks = $wpdb->prepare( ' AND post_status = %s', $_GET['post_status'] );
-		}
-
 		/**
-		 * Filters whether to short-circuit performing the months dropdown query.
+		 * Filters to short-circuit performing the months dropdown query.
 		 *
 		 * @since 5.7.0
 		 *
-		 * @param bool   $skip_query Whether to skip doing the query. Default false.
-		 * @param string $post_type  The post type.
+		 * @param object[]|false $months   'Months' drop-down results. Default false.
+		 * @param string         $post_type The post type.
 		 */
-		$skip_query = apply_filters( 'pre_months_dropdown_query', false, $post_type );
-		if ( ! $skip_query ) {
+		$months = apply_filters( 'pre_months_dropdown_query', false, $post_type );
+
+		if ( ! is_array( $months ) ) {
+			$extra_checks = "AND post_status != 'auto-draft'";
+			if ( ! isset( $_GET['post_status'] ) || 'trash' !== $_GET['post_status'] ) {
+				$extra_checks .= " AND post_status != 'trash'";
+			} elseif ( isset( $_GET['post_status'] ) ) {
+				$extra_checks = $wpdb->prepare( ' AND post_status = %s', $_GET['post_status'] );
+			}
+
 			$months = $wpdb->get_results(
 				$wpdb->prepare(
 					"
@@ -624,19 +625,17 @@ class WP_List_Table {
 					$post_type
 				)
 			);
-		} else {
-			$months = array();
-		}
 
-		/**
-		 * Filters the 'Months' drop-down results.
-		 *
-		 * @since 3.7.0
-		 *
-		 * @param object[] $months    Array of the months drop-down query results.
-		 * @param string   $post_type The post type.
-		 */
-		$months = apply_filters( 'months_dropdown_results', $months, $post_type );
+			/**
+			 * Filters the 'Months' drop-down results.
+			 *
+			 * @since 3.7.0
+			 *
+			 * @param object[] $months    Array of the months drop-down query results.
+			 * @param string   $post_type The post type.
+			 */
+			$months = apply_filters( 'months_dropdown_results', $months, $post_type );
+		}
 
 		$month_count = count( $months );
 

--- a/src/wp-admin/includes/class-wp-list-table.php
+++ b/src/wp-admin/includes/class-wp-list-table.php
@@ -602,18 +602,37 @@ class WP_List_Table {
 			$extra_checks = $wpdb->prepare( ' AND post_status = %s', $_GET['post_status'] );
 		}
 
-		$months = $wpdb->get_results(
-			$wpdb->prepare(
-				"
-			SELECT DISTINCT YEAR( post_date ) AS year, MONTH( post_date ) AS month
-			FROM $wpdb->posts
-			WHERE post_type = %s
-			$extra_checks
-			ORDER BY post_date DESC
-		",
-				$post_type
-			)
-		);
+		/**
+		* Allows overriding the list of months displayed in the admin post lists.
+		*
+		* By default (if this filter does not return an array), a query will be
+		* run to determine the months that have post items.  This query can be
+		* expensive for a large number of posts, so it may be desirable for sites to
+		* override this behavior.
+		*
+		* @since 5.7
+		*
+		* @link https://core.trac.wordpress.org/ticket/51660
+		*
+		* @param string $post_type The post type.
+		* @param string $extra_checks Filtering options for the post status.
+		*/
+		$months = apply_filters( 'edit_months_dropdown', $post_type, $extra_checks );
+
+		if ( ! is_array( $months ) ) {
+			$months = $wpdb->get_results(
+				$wpdb->prepare(
+					"
+				SELECT DISTINCT YEAR( post_date ) AS year, MONTH( post_date ) AS month
+				FROM $wpdb->posts
+				WHERE post_type = %s
+				$extra_checks
+				ORDER BY post_date DESC
+			",
+					$post_type
+				)
+			);
+		}
 
 		/**
 		 * Filters the 'Months' drop-down results.


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/51660

Updates PR #767 to modify the added filter to be a short-circuit for the query.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
