### PR TITLE
Media: Sanity check image meta in 'wp_image_src_get_dimensions'

### DIFF
--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -1602,7 +1602,10 @@ function wp_image_src_get_dimensions( $image_src, $image_meta, $attachment_id = 
 	$dimensions = false;
 
 	// Is it a full size image?
-	if ( strpos( $image_src, $image_meta['file'] ) !== false ) {
+	if (
+		isset( $image_meta['file'] ) &&
+		strpos( $image_src, $image_meta['file'] ) !== false
+	) {
 		$dimensions = array(
 			(int) $image_meta['width'],
 			(int) $image_meta['height'],


### PR DESCRIPTION
This fixes a potential illegal offset error introduced in [50134] if the
`$image_meta` doesn't include a `file` key.

Props dd32.
Fixes https://core.trac.wordpress.org/ticket/51865.