### PR TITLE
Plugins List Table: Fix update row background color on small screens

### DIFF
--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -2073,11 +2073,6 @@ div.action-links,
 		display: table-cell;
 	}
 
-	.plugins .active.update + .plugin-update-tr:before {
-		border-left: 4px solid #d63638;
-		background-color: #f6f7f7;
-	}
-
 	.plugins #the-list .plugin-update-tr .plugin-update {
 		border-left: none;
 	}
@@ -2087,7 +2082,7 @@ div.action-links,
 	}
 
 	.plugins .active.update + .plugin-update-tr:before {
-		background-color: #fff;
+		background-color: #f0f6fc;
 		border-left: 4px solid #72aee6;
 	}
 


### PR DESCRIPTION
This also removes a redundant rule which is immediately overwritten.

Screenshot of this branch:
<img width="421" alt="Screen Shot 2021-02-05 at 6 37 15 PM" src="https://user-images.githubusercontent.com/541093/107100063-3df98f80-67e1-11eb-9e72-69e2ad719ae8.png">

Trac ticket: https://core.trac.wordpress.org/ticket/52452

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
