### PR TITLE
Add block supports render hook

### DIFF
--- a/src/wp-includes/class-wp-block-supports.php
+++ b/src/wp-includes/class-wp-block-supports.php
@@ -68,6 +68,18 @@ class WP_Block_Supports {
 	}
 
 	/**
+	 * Applies the render_block filter.
+	 *
+	 * @param  string $block_content Rendered block content.
+	 * @param  array  $block         Block object.
+	 * @return string                Filtered block content.
+	 */
+	public static function render( $block_content, $block ) {
+		$instance = self::get_instance();
+		return $instance->render_block_supports( $block_content, $block );
+	}
+
+	/**
 	 * Registers a block support.
 	 *
 	 * @since 5.6.0
@@ -154,6 +166,37 @@ class WP_Block_Supports {
 				);
 			}
 		}
+	}
+
+	/**
+	 * Modify the rendered block content with additional filters.
+	 *
+	 * @param  string $block_content Rendered block content.
+	 * @param  array  $block         Block object.
+	 * @return string                Filtered block content.
+	 */
+	public function render_block_supports( $block_content, $block ) {
+		$block_type       = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
+		$block_attributes = $block['attrs'];
+
+		if ( ! $block_type ) {
+			return $block_content;
+		}
+
+		foreach ( $this->block_supports as $name => $block_support_config ) {
+			if ( ! isset( $block_support_config['render_block'] ) ) {
+				continue;
+			}
+
+			$block_content = call_user_func(
+				$block_support_config['render_block'],
+				$block_type,
+				$block_attributes,
+				$block_content
+			);
+		}
+
+		return $block_content;
 	}
 }
 

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -315,6 +315,7 @@ add_action( 'wp_print_footer_scripts', '_wp_footer_scripts' );
 add_action( 'init', '_register_core_block_patterns_and_categories' );
 add_action( 'init', 'check_theme_switched', 99 );
 add_action( 'init', array( 'WP_Block_Supports', 'init' ), 22 );
+add_filter( 'render_block', array( 'WP_Block_Supports', 'render' ), 10, 2 );
 add_action( 'after_switch_theme', '_wp_menus_changed' );
 add_action( 'after_switch_theme', '_wp_sidebars_changed' );
 add_action( 'wp_print_styles', 'print_emoji_styles' );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/52476#ticket <!-- insert a link to the WordPress Trac ticket here -->

In conjunction with WordPress/gutenberg#26361 for adding block supports for duotone filters, this adds a render hook for block supports.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
