### PR TITLE
Fix bare variable names in var() fallback parameters

### DIFF
--- a/src/wp-content/themes/twentytwentyone/assets/sass/05-blocks/heading/_editor.scss
+++ b/src/wp-content/themes/twentytwentyone/assets/sass/05-blocks/heading/_editor.scss
@@ -25,7 +25,7 @@ h6,
 	}
 
 	&[style*="--wp--typography--line-height"] {
-		line-height: var(--wp--typography--line-height, --global--line-height-body);
+		line-height: var(--wp--typography--line-height, var(--global--line-height-body));
 	}
 }
 

--- a/src/wp-content/themes/twentytwentyone/assets/sass/05-blocks/paragraph/_editor.scss
+++ b/src/wp-content/themes/twentytwentyone/assets/sass/05-blocks/paragraph/_editor.scss
@@ -1,5 +1,5 @@
 p {
-	line-height: var(--wp--typography--line-height, --global--line-height-body);
+	line-height: var(--wp--typography--line-height, var(--global--line-height-body));
 
 	&.has-background {
 		padding: var(--global--spacing-unit);

--- a/src/wp-content/themes/twentytwentyone/assets/sass/05-blocks/paragraph/_style.scss
+++ b/src/wp-content/themes/twentytwentyone/assets/sass/05-blocks/paragraph/_style.scss
@@ -1,6 +1,6 @@
 p {
 
-	line-height: var(--wp--typography--line-height, --global--line-height-body);
+	line-height: var(--wp--typography--line-height, var(--global--line-height-body));
 
 	// inherits general font style set at <body>
 	&.has-background {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This patch fixes three cases where the fallback parameter to a `var(…)` call was meant to be a CSS variable, but was not itself surrounded in `var(…)`.

Trac ticket: https://core.trac.wordpress.org/ticket/52477

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
