### PR TITLE
Add special text handling when `post_max_size` is defined as `0`

### DIFF
--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -2177,15 +2177,29 @@ class WP_Site_Health {
 				'upload_max_filesize'
 			);
 			$result['status']      = 'recommended';
-			$result['description'] = sprintf(
-				'<p>%s</p>',
-				sprintf(
-					/* translators: 1: post_max_size, 2: upload_max_filesize */
-					__( 'The setting for %1$s is smaller than %2$s, this could cause some problems when trying to upload files.' ),
-					'<code>post_max_size</code>',
-					'<code>upload_max_filesize</code>'
-				)
-			);
+
+			if ( 0 === wp_convert_hr_to_bytes( $post_max_size ) ) {
+				$result['description'] = sprintf(
+					'<p>%s</p>',
+					sprintf(
+						/* translators: 1: post_max_size, 2: upload_max_filesize */
+						__( 'The setting for %1$s is currently configured as 0, this could cause some problems when trying to upload files through plugin or theme features that rely on various upload methods. It is recommended to configure this setting to a fixed value, ideally matching the value of %2$s, as some upload methods read the value 0 as either unlimited, or disabled.' ),
+						'<code>post_max_size</code>',
+						'<code>upload_max_filesize</code>'
+					)
+				);
+			} else {
+				$result['description'] = sprintf(
+					'<p>%s</p>',
+					sprintf(
+						/* translators: 1: post_max_size, 2: upload_max_filesize */
+						__( 'The setting for %1$s is smaller than %2$s, this could cause some problems when trying to upload files.' ),
+						'<code>post_max_size</code>',
+						'<code>upload_max_filesize</code>'
+					)
+				);
+			}
+
 			return $result;
 		}
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/51466

Adds more descriptive text in scenarios where `post_max_size` and `upload_max_filesize` differ, and `post_max_size` is set to a value of `0`.

This because of how PHP may, in some scenarios, read `0` as a literal zero size, and not as unlimited, which it also means in other scenarios.

See https://www.php.net/manual/en/ini.core.php#ini.post-max-size for details, as PHP 5.3.4 introduced this behavior for absolute-null interpretation when the content type of a request is that of `application/x-www-form-urlencoded`. 

Core does not currently do this in any locations I'm aware of, but plugins or themes may have code that does, so this is more a precaution (and having a fixed limit to avoid excessive memory consumption if something goes wrong is also always nice I guess), as such the text is geared to let users know that this is a recommendation, and it may affect plugins or themes.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
