### PR TITLE
Multiple Bundled Themes: Fix alignment and styles for quote, verse, and code blocks. 

### DIFF
--- a/src/wp-content/themes/twentyeleven/editor-blocks.css
+++ b/src/wp-content/themes/twentyeleven/editor-blocks.css
@@ -267,17 +267,19 @@ p.has-drop-cap:not(:focus)::first-letter {
 	padding: 0;
 }
 
-.edit-post-visual-editor .editor-block-list__block .wp-block-quote p {
+.edit-post-visual-editor .editor-block-list__block .wp-block-quote p,
+.editor-styles-wrapper .wp-block-quote p {
 	font-family: Georgia, "Bitstream Charter", serif;
 }
 
 .wp-block-quote:not(.is-large):not(.is-style-large) {
 	border: 0;
-	padding-left: 0;
-	padding-right: 0;
+	padding-left: 3em;
+	padding-right: 3em;
 }
 
-.wp-block-quote .wp-block-quote__citation.editor-rich-text__tinymce.mce-content-body {
+.wp-block-quote .wp-block-quote__citation.editor-rich-text__tinymce.mce-content-body,
+.wp-block-quote .wp-block-quote__citation {
 	color: #666;
 	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 	font-weight: 300;
@@ -331,7 +333,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 
 /* Code */
 
-.wp-block-code {
+.editor-styles-wrapper .wp-block-code {
 	background: transparent;
 	border: 0;
 	padding: 0;
@@ -339,7 +341,8 @@ p.has-drop-cap:not(:focus)::first-letter {
 
 /* Pullquote */
 
-.edit-post-visual-editor .editor-block-list__block .wp-block-pullquote p {
+.edit-post-visual-editor .editor-block-list__block .wp-block-pullquote p,
+.editor-styles-wrapper .wp-block-pullquote p {
 	font-family: Georgia, "Bitstream Charter", serif;
 	font-style: italic;
 	font-weight: normal;

--- a/src/wp-content/themes/twentyfifteen/css/editor-blocks.css
+++ b/src/wp-content/themes/twentyfifteen/css/editor-blocks.css
@@ -635,7 +635,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 
 /* Code */
 
-.wp-block-code,
+.editor-styles-wrapper .wp-block-code,
 .wp-block-freeform.block-library-rich-text__tinymce code {
 	background: transparent;
 	border: 0;
@@ -704,6 +704,12 @@ p.has-drop-cap:not(:focus)::first-letter {
 
 .rtl .editor-block-list__block .wp-block-table th {
 	text-align: right;
+}
+
+/* Verse */
+
+.editor-styles-wrapper .wp-block-verse {
+	font-family: inherit;
 }
 
 /*--------------------------------------------------------------

--- a/src/wp-content/themes/twentyfifteen/css/editor-style.css
+++ b/src/wp-content/themes/twentyfifteen/css/editor-style.css
@@ -163,7 +163,6 @@ pre {
 	font-size: 17px;
 	line-height: 1.2353;
 	margin-bottom: 28px;
-	max-width: 100%;
 	overflow: auto;
 	padding: 14px;
 	white-space: pre;

--- a/src/wp-content/themes/twentyfourteen/css/editor-blocks.css
+++ b/src/wp-content/themes/twentyfourteen/css/editor-blocks.css
@@ -350,9 +350,9 @@ p.has-drop-cap:not(:focus)::first-letter {
 4.0 Blocks - Formatting
 --------------------------------------------------------------*/
 
-/* Code */
+/* Code (Added specficity required to override TinyMCE styles) */
 
-.wp-block-code {
+.editor-styles-wrapper .wp-block-code {
 	border: 0;
 	padding: 0;
 }

--- a/src/wp-content/themes/twentyfourteen/css/editor-style.css
+++ b/src/wp-content/themes/twentyfourteen/css/editor-style.css
@@ -153,7 +153,6 @@ pre {
 pre {
 	border: 1px solid rgba(0, 0, 0, 0.1);
 	margin-bottom: 24px;
-	max-width: 100%;
 	overflow: auto;
 	padding: 12px;
 	white-space: pre;

--- a/src/wp-content/themes/twentyseventeen/assets/css/editor-blocks.css
+++ b/src/wp-content/themes/twentyseventeen/assets/css/editor-blocks.css
@@ -518,7 +518,7 @@ html[lang="th"] .edit-post-visual-editor * {
 	padding: 0;
 }
 
-.editor-block-list__block .wp-block-quote .wp-block-quote__citation {
+.wp-block-quote .wp-block-quote__citation {
 	color: inherit;
 	display: block;
 	font-size: inherit;
@@ -533,16 +533,16 @@ html[lang="th"] .edit-post-visual-editor * {
 	width: 48%;
 }
 
-.editor-block-list__block .wp-block-quote.alignleft p,
-.editor-block-list__block .wp-block-quote.alignright p,
-.editor-block-list__block .wp-block-quote.alignleft .wp-block-quote__citation,
-.editor-block-list__block .wp-block-quote.alignright .wp-block-quote__citation {
+.wp-block-quote.alignleft p,
+.wp-block-quote.alignright p,
+.wp-block-quote.alignleft .wp-block-quote__citation,
+.wp-block-quote.alignright .wp-block-quote__citation {
 	font-size: 13px;
 	font-size: 0.8125rem;
 }
 
-.editor-block-list__block .wp-block-quote.alignleft p:last-of-type,
-.editor-block-list__block .wp-block-quote.alignright p:last-of-type {
+.wp-block-quote.alignleft p:last-of-type,
+.wp-block-quote.alignright p:last-of-type {
 	margin-bottom: 0;
 }
 
@@ -557,31 +557,31 @@ html[lang="th"] .edit-post-visual-editor * {
 }
 
 @media screen and (min-width: 30em) {
-	.editor-block-list__block .wp-block-quote.alignleft p,
-	.editor-block-list__block .wp-block-quote.alignright p,
-	.editor-block-list__block .wp-block-quote.alignleft .wp-block-quote__citation,
-	.editor-block-list__block .wp-block-quote.alignright .wp-block-quote__citation,
-	.editor-block-list__block .wp-block-quote footer {
+	.wp-block-quote.alignleft p,
+	.wp-block-quote.alignright p,
+	.wp-block-quote.alignleft .wp-block-quote__citation,
+	.wp-block-quote.alignright .wp-block-quote__citation,
+	.wp-block-quote footer {
 		font-size: 14px;
 		font-size: 0.875rem;
 	}
 }
 
 @media screen and (min-width: 48em) {
-	.editor-block-list__block .wp-block-quote.alignleft p,
-	.editor-block-list__block .wp-block-quote.alignright p,
-	.editor-block-list__block .wp-block-quote.alignleft .wp-block-quote__citation,
-	.editor-block-list__block .wp-block-quote.alignright .wp-block-quote__citation {
+	.wp-block-quote.alignleft p,
+	.wp-block-quote.alignright p,
+	.wp-block-quote.alignleft .wp-block-quote__citation,
+	.wp-block-quote.alignright .wp-block-quote__citation {
 		font-size: 13px;
 		font-size: 0.8125rem;
 	}
 
-	.editor-block-list__block .wp-block-quote.alignleft {
+	.wp-block-quote.alignleft {
 		margin-left: -17.5%;
 		width: 48%;
 	}
 
-	.editor-block-list__block .wp-block-quote.alignright {
+	.wp-block-quote.alignright {
 		margin-right: -17.5%;
 		width: 48%;
 	}
@@ -617,9 +617,10 @@ html[lang="th"] .edit-post-visual-editor * {
 
 /* Code */
 
-.wp-block-code {
+.editor-styles-wrapper .wp-block-code {
 	border: 0;
 	padding: 0;
+	background-color: transparent;
 }
 
 /* Classic */
@@ -698,6 +699,12 @@ table.wp-block-table td:last-child {
 .rtl table.wp-block-table th,
 .rtl table.wp-block-table td {
 	text-align: right;
+}
+
+/* Verse */
+
+.editor-styles-wrapper .wp-block-verse {
+	font-family: inherit;
 }
 
 /*--------------------------------------------------------------

--- a/src/wp-content/themes/twentyseventeen/assets/css/editor-style.css
+++ b/src/wp-content/themes/twentyseventeen/assets/css/editor-style.css
@@ -149,7 +149,6 @@ pre {
 	font-size: 0.9375rem;
 	line-height: 1.6;
 	margin-bottom: 1.6em;
-	max-width: 100%;
 	overflow: auto;
 	padding: 1.6em;
 }

--- a/src/wp-content/themes/twentysixteen/css/editor-blocks.css
+++ b/src/wp-content/themes/twentysixteen/css/editor-blocks.css
@@ -365,15 +365,6 @@ Description: Used to style blocks in the editor.
 		width: -webkit-calc(50% - 0.736842105em);
 		width: calc(50% - 0.736842105em);
 	}
-
-	.wp-block-quote:not(.alignleft):not(.alignright) {
-		margin-left: -1.473684211em;
-	}
-
-	.rtl .wp-block-quote:not(.alignleft):not(.alignright) {
-		margin-left: 0;
-		margin-right: -1.473684211em;
-	}
 }
 
 @media screen and (min-width: 80em) {
@@ -410,9 +401,10 @@ Description: Used to style blocks in the editor.
 
 /* Code */
 
-.wp-block-code {
+.editor-styles-wrapper .wp-block-code {
 	border: 0;
 	padding: 0.125em 0.25em;
+	background-color: #d1d1d1;
 }
 
 /* Classic */
@@ -533,6 +525,12 @@ Description: Used to style blocks in the editor.
 .rtl .wp-block-table th,
 .rtl .wp-block-table td {
 	text-align: right;
+}
+
+/* Verse */
+
+.editor-styles-wrapper .wp-block-verse {
+	font-family: inherit;
 }
 
 /*--------------------------------------------------------------

--- a/src/wp-content/themes/twentysixteen/css/editor-style.css
+++ b/src/wp-content/themes/twentysixteen/css/editor-style.css
@@ -120,10 +120,6 @@ blockquote {
 	padding: 0 0 0 24px;
 }
 
-blockquote:not(.alignleft):not(.alignright) {
-	margin-left: -28px;
-}
-
 blockquote blockquote:not(.alignleft):not(.alignright) {
 	margin-left: 0;
 }
@@ -188,7 +184,6 @@ pre {
 	font-size: 16px;
 	line-height: 1.3125;
 	margin: 0 0 28px;
-	max-width: 100%;
 	overflow: auto;
 	padding: 14px;
 	white-space: pre;
@@ -519,7 +514,6 @@ fieldset {
 }
 
 .rtl blockquote:not(.alignleft):not(.alignright) {
-	margin-right: -28px;
 	padding: 0 24px 0 0;
 }
 

--- a/src/wp-content/themes/twentythirteen/css/editor-blocks.css
+++ b/src/wp-content/themes/twentythirteen/css/editor-blocks.css
@@ -164,7 +164,8 @@ Description: Used to style blocks in the editor.
 
 /* Code */
 
-.wp-block-freeform.block-library-rich-text__tinymce code {
+.wp-block-freeform.block-library-rich-text__tinymce code,
+.editor-styles-wrapper .wp-block-code {
 	background: transparent;
 }
 
@@ -220,14 +221,16 @@ p.has-drop-cap:not(:focus)::first-letter {
 .wp-block-quote:not(.is-large):not(.is-style-large) {
 	border-left: 0;
 	border-right: 0;
-	padding-left: 0;
-	padding-right: 0;
+	padding-left: 40px;
+	padding-right: 40px;
 }
 
-.wp-block-quote .wp-block-quote__citation.editor-rich-text__tinymce.mce-content-body {
+.wp-block-quote .wp-block-quote__citation.editor-rich-text__tinymce.mce-content-body,
+.wp-block-quote .wp-block-quote__citation {
 	color: inherit;
 	font-size: 16px;
 	font-style: italic;
+	font-weight: normal;
 	text-transform: uppercase;
 }
 
@@ -275,7 +278,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 
 /* Code */
 
-.wp-block-code {
+.editor-styles-wrapper .wp-block-code {
 	border: 0;
 	padding: 0;
 }

--- a/src/wp-content/themes/twentytwenty/assets/css/editor-style-block-rtl.css
+++ b/src/wp-content/themes/twentytwenty/assets/css/editor-style-block-rtl.css
@@ -619,7 +619,8 @@ hr.wp-block-separator.is-style-dots::before {
 	border-color: #cd2653;
 	border-style: solid;
 	border-width: 0 2px 0 0;
-	margin: 20px 0;
+	margin-top: 20px;
+	margin-bottom: 20px;
 	padding: 5px 20px 5px 0;
 }
 
@@ -878,7 +879,8 @@ hr.wp-block-separator.is-style-dots::before {
 
 .editor-styles-wrapper .wp-block-verse pre,
 .editor-styles-wrapper pre.wp-block-verse {
-	font-size: 0.75em;
+	font-family: NonBreakingSpaceOverride, "Hoefler Text", Garamond, "Times New Roman", serif;
+	font-size: 0.9em;
 }
 
 

--- a/src/wp-content/themes/twentytwenty/assets/css/editor-style-block.css
+++ b/src/wp-content/themes/twentytwenty/assets/css/editor-style-block.css
@@ -619,7 +619,8 @@ hr.wp-block-separator.is-style-dots::before {
 	border-color: #cd2653;
 	border-style: solid;
 	border-width: 0 0 0 2px;
-	margin: 20px 0;
+	margin-top: 20px;
+	margin-bottom: 20px;
 	padding: 5px 0 5px 20px;
 }
 
@@ -878,7 +879,8 @@ hr.wp-block-separator.is-style-dots::before {
 
 .editor-styles-wrapper .wp-block-verse pre,
 .editor-styles-wrapper pre.wp-block-verse {
-	font-size: 0.75em;
+	font-family: NonBreakingSpaceOverride, "Hoefler Text", Garamond, "Times New Roman", serif;
+	font-size: 0.9em;
 }
 
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Trac ticket: https://core.trac.wordpress.org/ticket/52009

Fixes alignment and style issues for the Quote, Verse, and Code blocks in Twenty Eleven, Twenty Thirteen, Twenty Fourteen, Twenty Sixteen, Twenty Seventeen, and Twenty Twenty. 

Full changes are listed below. 

---

## **Twenty Eleven**

Fixes block quote block layout problems in the editor by adding the 3em of left/right margin that is present in the front-end. Also fixes font styles for the quote and citations. Finally, properly styles the code block to match the front end. 

Before:
![](https://cldup.com/hC98OAY17q-3000x3000.png)
![](https://cldup.com/wEFPVRLofM-3000x3000.png)

After:
![](https://cldup.com/G1w1_xIbS7-3000x3000.png)
![](https://cldup.com/JsULunU2nf-3000x3000.png)

---

## **Twenty Thirteen**

Fixes block quote block layout problems in the editor by adding the 40px of left/right margin that is present in the front-end. Adds a less specific font style rule for block quote citations so that they're picked up in the editor. Matches the font-weight for these citations to the front end. 

Before:
![](https://cldup.com/3KXtGHQ0bh-3000x3000.png)
![](https://cldup.com/F-ghcudBup-3000x3000.png)

After:
![](https://cldup.com/PFKzH1siUh-3000x3000.png)
![](https://cldup.com/Xk1Dnip1Xg-2000x2000.png)

---

## **Twenty Fourteen**

Fixes preformatted, verse, and code block layout problems in the editor by removing the max-width from the `pre` element. Adds some specificity to the `wp-block-code` styles to clear out the margin/padding, so that it matches the front end. 

Before:
![](https://cldup.com/vpaan5JYbY-3000x3000.png)
![](https://cldup.com/kkwApwRIM3-3000x3000.png)

After:
![](https://cldup.com/7GHzUcgR_B-2000x2000.png)
![](https://cldup.com/pSb8RzAXr6-3000x3000.png)

---

## **Twenty Fifteen**

Fixes the alignment of code blocks by removing the max-width from the `pre` element. Changes the font for the Verse block to match the front end. Removes the padding, background, and border for code blocks in the editor so they match the front-end too. 

Before:
![](https://cldup.com/2giC4bgZ2Y-1200x1200.png)

After:
![](https://cldup.com/guavBNq2Kp-1200x1200.png)

---

## **Twenty Sixteen**

Fixes the alignment of code blocks by removing the max-width from the `pre` element. 

Fixes the alignment of blockquote blocks by removing the negative margins. Note that this indents the quotes a little bit which doesn’t _exactly_ match the front end. But it’s better than it was. I don’t think we can actually match the front end it without using relative positioning hacks, which I think we should avoid for now. 

Removes the padding and border for code blocks in the editor so they match the front-end. Changes the font for the Verse block to match the front end. 

Before:
![](https://cldup.com/xmkxiPWG0X-3000x3000.png)

After:
![](https://cldup.com/lBKNfzxaBg-3000x3000.png)

---

## **Twenty Seventeen**

Fixes the alignment of code blocks by removing the max-width from the `pre` element. 

Removes the padding and border for code blocks in the editor so they match the front-end. Changes the font for the Verse block to match the front end. 

Removed outdated (and unnecessary) `editor-block-list__block` selector from the blockquote rules to get them working again. 

Before:
![](https://cldup.com/XzzKXR3cuo-1200x1200.png)

After:
![](https://cldup.com/DW4TzxaY3g-1200x1200.png)

---

## **Twenty Twenty**

Fixes the alignment of quote blocks by removing the `0` left and right margin. Corrects the font family and size used in Verse blocks to match the front end. 

Before:
![](https://cldup.com/OktNOWuU5C-3000x3000.png)

After:
![](https://cldup.com/4Yon8zkAbT-3000x3000.png)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
