### PR TITLE
Fix Warning on PHP 8.0 for non-posts/pages

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -4038,6 +4038,10 @@ class WP_Query {
 		}
 
 		$page_obj = $this->get_queried_object();
+		
+		if ( ! isset( $page_obj->ID ) && ! isset( $page_obj->post_title ) && ! isset( $page_obj->post_name ) ) {
+			return false;
+		}
 
 		$page = array_map( 'strval', (array) $page );
 
@@ -4192,6 +4196,10 @@ class WP_Query {
 		}
 
 		$post_obj = $this->get_queried_object();
+		
+		if ( ! isset( $post_obj->post_type ) ) {
+			return false;
+		}
 
 		return in_array( $post_obj->post_type, (array) $post_types, true );
 	}

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -4196,7 +4196,7 @@ class WP_Query {
 		}
 
 		$post_obj = $this->get_queried_object();
-		
+
 		if ( ! isset( $post_obj->post_type ) ) {
 			return false;
 		}

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -4038,7 +4038,7 @@ class WP_Query {
 		}
 
 		$page_obj = $this->get_queried_object();
-		
+
 		if ( ! isset( $page_obj->ID ) && ! isset( $page_obj->post_title ) && ! isset( $page_obj->post_name ) ) {
 			return false;
 		}


### PR DESCRIPTION
In PHP 8.0, when accessing the non-posts/pages like /data/feed and /data/rss, it shows an PHP Warning error saying "Attempt to read property "post_title" on null".

here are the example errors:

`2021/02/12 12:49:21 [error] 101518#101518: *74 FastCGI sent in stderr: "PHP message: PHP Warning: Attempt to read property "ID" on null in /var/www/gamingph.com/wp-includes/class-wp-query.php on line 4027PHP message: PHP Warning: Attempt to read property "post_title" on null in /var/www/gamingph.com/wp-includes/class-wp-query.php on line 4029PHP message: PHP Warning: Attempt to read property "post_name" on null in /var/www/gamingph.com/wp-includes/class-wp-query.php on line 4031PHP message: PHP Warning: Attempt to read property "ID" on null in /var/www/gamingph.com/wp-includes/class-wp-query.php on line 4027PHP message: PHP Warning: Attempt to read property "post_title" on null in /var/www/gamingph.com/wp-includes/class-wp-query.php on line 4029PHP message: PHP Warning: Attempt to read property "post_name" on null in /var/www/gamingph.com/wp-includes/class-wp-query.php on line 4031PHP message: PHP Warning: Attempt to read property "ID" on null in /var/www/gamingph.com/wp-includes/class-wp-query.php on line 4027PHP message: PHP Warning: Attempt to read property "post_title" on null in /var/www/gamingph.com/wp-includes/class-wp-query.php on line 4029PHP message: PHP Warning: Attempt to read property "post_name" on null in /var/www/gamingph.com/wp-includes/class-wp-query.php on line 4031PHP message: PHP Warning: Attempt to read property "post_type" on null in /var/www/gamingph.com/wp-includes/class-wp-query.php on line 4179PHP message: PHP Warning: Attempt to read property "post_type" on null in /var/www/gamingph.com/wp-includes/class-wp-query.php on line 4179PHP message: PHP Warning: Attempt to read property "post_type" on null in /var/www/gamingph.com/wp-includes/class-wp-query.php on line 4179" while reading response header from upstream, client: 49.145.229.24, server: gamingph.com, request: "GET /data/feed/ HTTP/2.0", upstream: "fastcgi://unix:/var/run/php/php8.0-fpm.sock:", host: "gamingph.com"`

`2021/02/12 10:56:58 [error] 84487#84487: *9570 FastCGI sent in stderr: "PHP message: PHP Warning: Attempt to read property "ID" on null in /var/www/gamingph.com/wp-includes/class-wp-query.php on line 4027PHP message: PHP Warning: Attempt to read property "post_title" on null in /var/www/gamingph.com/wp-includes/class-wp-query.php on line 4029PHP message: PHP Warning: Attempt to read property "post_name" on null in /var/www/gamingph.com/wp-includes/class-wp-query.php on line 4031PHP message: PHP Warning: Attempt to read property "ID" on null in /var/www/gamingph.com/wp-includes/class-wp-query.php on line 4027PHP message: PHP Warning: Attempt to read property "post_title" on null in /var/www/gamingph.com/wp-includes/class-wp-query.php on line 4029PHP message: PHP Warning: Attempt to read property "post_name" on null in /var/www/gamingph.com/wp-includes/class-wp-query.php on line 4031" while reading response header from upstream, client: 212.83.184.228, server: gamingph.com, request: "GET /data/rss HTTP/1.1", upstream: "fastcgi://unix:/var/run/php/php8.0-fpm.sock:", host: "gamingph.com"`

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This fix added an isset check for all variable that has null value when accessing non-posts/pages, it immediately return false value.

Trac ticket: https://core.trac.wordpress.org/ticket/52510

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
