### PR TITLE
52513: Update button in update-core.php to show beta/RC version

### DIFF
--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -61,12 +61,8 @@ function list_core_update( $update ) {
 	$submit = $is_development_version ? __( 'Update to latest nightly' ) : __( 'Update now' );
 	if ( $is_development_version ) {
 		if ( defined( 'WP_AUTO_UPDATE_CORE' ) && in_array( WP_AUTO_UPDATE_CORE, array( 'beta', 'rc' ), true ) ) {
-			if ( 'beta' === WP_AUTO_UPDATE_CORE ) {
-				$submit = __( 'Update to latest beta/RC' );
-			}
-			if ( 'rc' === WP_AUTO_UPDATE_CORE ) {
-				$submit = __( 'Update to latest RC' );
-			}
+			/* translators: %s: version being updated to */
+			$submit = sprintf(__( 'Update to version %s' ), $update->current );
 		}
 	}
 	$submit = apply_filters( 'pre_core_update_button', $submit, $is_development_version );

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -59,11 +59,9 @@ function list_core_update( $update ) {
 
 	$message = '';
 	$submit  = $is_development_version ? __( 'Update to latest nightly' ) : __( 'Update now' );
-	if ( $is_development_version ) {
-		if ( ! preg_match( '/-\w+-/', $update->current ) ) {
-			/* translators: %s: version number */
-			$submit = sprintf( __( 'Update to version %s' ), $update->current );
-		}
+	if ( ! preg_match( '/-\w+-/', $update->current ) ) {
+		/* translators: %s: version number */
+		$submit = sprintf( __( 'Update to version %s' ), $update->current );
 	}
 	$form_action   = 'update-core.php?action=do-core-upgrade';
 	$php_version   = phpversion();

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -57,16 +57,17 @@ function list_core_update( $update ) {
 
 	$is_development_version = preg_match( '/alpha|beta|RC/', $version_string );
 
-	$message = '';
-	$submit  = $is_development_version ? __( 'Update to latest nightly' ) : __( 'Update now' );
-	if ( ! preg_match( '/-\w+-/', $update->current ) ) {
-		/* translators: %s: version number */
-		$submit = sprintf( __( 'Update to version %s' ), $update->current );
-	}
+	$message       = '';
+	$submit        = $is_development_version ? __( 'Update to latest nightly' ) : __( 'Update now' );
 	$form_action   = 'update-core.php?action=do-core-upgrade';
 	$php_version   = phpversion();
 	$mysql_version = $wpdb->db_version();
 	$show_buttons  = true;
+
+	if ( ! preg_match( '/-\w+-/', $update->current ) ) {
+		/* translators: %s: version number */
+		$submit = sprintf( __( 'Update to version %s' ), $update->current );
+	}
 
 	if ( 'development' === $update->response ) {
 		$message = __( 'You can update to the latest nightly build manually:' );

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -58,7 +58,18 @@ function list_core_update( $update ) {
 	$is_development_version = preg_match( '/alpha|beta|RC/', $version_string );
 
 	$message       = '';
-	$submit        = $is_development_version ? __( 'Update to latest nightly' ) : __( 'Update now' );
+	$submit = $is_development_version ? __( 'Update to latest nightly' ) : __( 'Update now' );
+	if ( $is_development_version ) {
+		if ( defined( 'WP_AUTO_UPDATE_CORE' ) && in_array( WP_AUTO_UPDATE_CORE, array( 'beta', 'rc' ), true ) ) {
+			if ( 'beta' === WP_AUTO_UPDATE_CORE ) {
+				$submit = __( 'Update to latest beta/RC' );
+			}
+			if ( 'rc' === WP_AUTO_UPDATE_CORE ) {
+				$submit = __( 'Update to latest RC' );
+			}
+		}
+	}
+	$submit = apply_filters( 'pre_core_update_button', $submit, $is_development_version );
 	$form_action   = 'update-core.php?action=do-core-upgrade';
 	$php_version   = phpversion();
 	$mysql_version = $wpdb->db_version();

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -57,15 +57,14 @@ function list_core_update( $update ) {
 
 	$is_development_version = preg_match( '/alpha|beta|RC/', $version_string );
 
-	$message       = '';
-	$submit = $is_development_version ? __( 'Update to latest nightly' ) : __( 'Update now' );
+	$message = '';
+	$submit  = $is_development_version ? __( 'Update to latest nightly' ) : __( 'Update now' );
 	if ( $is_development_version ) {
-		if ( defined( 'WP_AUTO_UPDATE_CORE' ) && in_array( WP_AUTO_UPDATE_CORE, array( 'beta', 'rc' ), true ) ) {
-			/* translators: %s: version being updated to */
-			$submit = sprintf(__( 'Update to version %s' ), $update->current );
+		if ( ! preg_match( '/-\w+-/', $update->current ) ) {
+			/* translators: %s: version number */
+			$submit = sprintf( __( 'Update to version %s' ), $update->current );
 		}
 	}
-	$submit = apply_filters( 'pre_core_update_button', $submit, $is_development_version );
 	$form_action   = 'update-core.php?action=do-core-upgrade';
 	$php_version   = phpversion();
 	$mysql_version = $wpdb->db_version();


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

In [#51774](https://core.trac.wordpress.org/ticket/51774) we added the version number to the 'Re-install' button on update-core.php.

I propose we add the version number to the 'Update' button when the user is set to update to the next beta/RC or release, whether they are using the `WP_AUTO_UPDATE_CORE` constant or the Beta Tester plugin.

The patch identifies the `$update->current` as a `beta` or `rc` offer by `prep_match` for 2 hyphens in the version number. 2 hyphens indicate a nightly, where a single hyphen indicates a beta, RC, or release offer.

Trac ticket: https://core.trac.wordpress.org/ticket/52513

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
