### PR TITLE
Navigation: Try filtering by show_in_nav_menus for post types and taxonomies

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-taxonomies-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-taxonomies-controller.php
@@ -84,6 +84,8 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 		if ( 'edit' === $request['context'] ) {
 			if ( ! empty( $request['type'] ) ) {
 				$taxonomies = get_object_taxonomies( $request['type'], 'objects' );
+			} elseif ( ! empty( $request['show_in_nav_menus'] ) ) {
+				$taxonomies = get_taxonomies( array( 'show_in_nav_menus' => (bool) $request['show_in_nav_menus'] ), 'objects' );
 			} else {
 				$taxonomies = get_taxonomies( '', 'objects' );
 			}
@@ -119,6 +121,8 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 
 		if ( isset( $registered['type'] ) && ! empty( $request['type'] ) ) {
 			$taxonomies = get_object_taxonomies( $request['type'], 'objects' );
+		} elseif ( ! empty( $request['show_in_nav_menus'] ) ) {
+			$taxonomies = get_taxonomies( array( 'show_in_nav_menus' => filter_var( $request['show_in_nav_menus'], FILTER_VALIDATE_BOOLEAN ) ), 'objects' );
 		} else {
 			$taxonomies = get_taxonomies( '', 'objects' );
 		}


### PR DESCRIPTION
WIP Part of https://github.com/WordPress/gutenberg/issues/24814 this PR experiments with allowing post types and taxonomies to be filtered by `show_in_nav_menus`. This will be used to help build the navigation/menu flows.

Experiments with if we need to expose `show_in_nav_menus` and `show_ui` for the post type response.

TODO: update  related unit tests

<img width="1011" alt="Screen Shot 2021-02-12 at 2 30 38 PM" src="https://user-images.githubusercontent.com/1270189/107829599-ef974400-6d3e-11eb-903a-c5e0184894d9.png">

<img width="643" alt="Screen Shot 2021-02-12 at 2 30 16 PM" src="https://user-images.githubusercontent.com/1270189/107829616-f625bb80-6d3e-11eb-9268-c7064f5631c0.png">

