### PR TITLE
Place the Multisite jobs into the matrix for more concurrency

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -151,6 +151,7 @@ jobs:
     env:
       LOCAL_PHP: ${{ matrix.php }}-fpm
       LOCAL_PHP_MEMCACHED: ${{ matrix.memcached }}
+      PHPUNIT_CONFIG: ${{ matrix.multisite && 'tests/phpunit/multisite.xml' || 'phpunit.xml.dist' }}
 
     steps:
       - name: Configure environment variables
@@ -255,20 +256,10 @@ jobs:
         run: npm run env:install
 
       - name: Run PHPUnit tests
-        if: ${{ ! matrix.multisite }}
-        run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose -c phpunit.xml.dist
+        run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose -c ${{ env.PHPUNIT_CONFIG }}
 
       - name: Run AJAX tests
-        if: ${{ ! matrix.multisite }}
-        run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose -c phpunit.xml.dist --group ajax
-
-      - name: Run tests as a multisite install
-        if: ${{ matrix.multisite }}
-        run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose -c tests/phpunit/multisite.xml
-
-      - name: Run AJAX tests as a multisite install
-        if: ${{ matrix.multisite }}
-        run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose -c tests/phpunit/multisite.xml --group ajax
+        run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose -c ${{ env.PHPUNIT_CONFIG }} --group ajax
 
       - name: Run ms-files tests as a multisite install
         if: ${{ matrix.multisite }}

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -147,6 +147,7 @@ jobs:
           - php: '7.4'
             os: ubuntu-latest
             memcached: false
+            multisite: false
             report: true
     env:
       LOCAL_PHP: ${{ matrix.php }}-fpm

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -124,7 +124,7 @@ jobs:
   # - Submit the test results to the WordPress.org host test results.
   # - todo: Configure Slack notifications for failing tests.
   test-php:
-    name: ${{ matrix.php }}${{ matrix.multisite && ' multisite' }}${{ matrix.memcached && ' with memcached' }} on ${{ matrix.os }}
+    name: ${{ matrix.php }}${{ matrix.multisite && ' multisite' || '' }}${{ matrix.memcached && ' with memcached' || '' }} on ${{ matrix.os }}
     needs: setup-wordpress
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -124,7 +124,7 @@ jobs:
   # - Submit the test results to the WordPress.org host test results.
   # - todo: Configure Slack notifications for failing tests.
   test-php:
-    name: ${{ matrix.php }}${{ matrix.memcached && ' with memcached' || '' }} on ${{ matrix.os }}
+    name: ${{ matrix.php }}${{ matrix.multisite && ' multisite' }}${{ matrix.memcached && ' with memcached' }} on ${{ matrix.os }}
     needs: setup-wordpress
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -134,10 +134,15 @@ jobs:
         memcached: [ false ]
         multisite: [ false, true ]
         include:
-          # Include job for PHP 7.4 with memcached.
+          # Include jobs for PHP 7.4 with memcached.
           - php: '7.4'
             os: ubuntu-latest
             memcached: true
+            multisite: false
+          - php: '7.4'
+            os: ubuntu-latest
+            memcached: true
+            multisite: true
           # Report the results of the PHP 7.4 without memcached job.
           - php: '7.4'
             os: ubuntu-latest

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -129,7 +129,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        php: [ '5.6.20', '8.0', '7.4', '7.3', '7.2', '7.1', '7.0' ]
+        php: [ '5.6.20', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0' ]
         os: [ ubuntu-latest ]
         memcached: [ false ]
         multisite: [ false, true ]

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -132,6 +132,7 @@ jobs:
         php: [ '8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6.20' ]
         os: [ ubuntu-latest ]
         memcached: [ false ]
+        multisite: [ false, true ]
         include:
           # Include job for PHP 7.4 with memcached.
           - php: '7.4'
@@ -249,24 +250,31 @@ jobs:
         run: npm run env:install
 
       - name: Run PHPUnit tests
+        if: ${{ ! matrix.multisite }}
         run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose -c phpunit.xml.dist
 
       - name: Run AJAX tests
+        if: ${{ ! matrix.multisite }}
         run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose -c phpunit.xml.dist --group ajax
 
       - name: Run tests as a multisite install
+        if: ${{ matrix.multisite }}
         run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose -c tests/phpunit/multisite.xml
 
       - name: Run AJAX tests as a multisite install
+        if: ${{ matrix.multisite }}
         run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose -c tests/phpunit/multisite.xml --group ajax
 
       - name: Run ms-files tests as a multisite install
+        if: ${{ matrix.multisite }}
         run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose -c tests/phpunit/multisite.xml --group ms-files
 
       - name: Run external HTTP tests
+        if: ${{ ! matrix.multisite }}
         run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose -c phpunit.xml.dist --group external-http
 
       - name: Run REST API tests
+        if: ${{ ! matrix.multisite }}
         run: npm run test:${{ env.PHPUNIT_SCRIPT }} -- --verbose -c phpunit.xml.dist --group restapi-jsclient
 
       # __fakegroup__ is excluded to force PHPUnit to ignore the <exclude> settings in phpunit.xml.dist.

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -129,7 +129,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        php: [ '8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6.20' ]
+        php: [ '5.6.20', '8.0', '7.4', '7.3', '7.2', '7.1', '7.0' ]
         os: [ ubuntu-latest ]
         memcached: [ false ]
         multisite: [ false, true ]


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/52548

This splits the Multisite tests out into their own jobs, and adds a multisite entry to the matrix, thus allowing the Multisite and single site tests to run in parallel.

In addition I pushed the 5.6.20 PHP version to the front of its matrix entry, the theory being that if any jobs start to queue up then we want the slowest jobs to start first, followed by faster jobs that may start later but finish sooner. In practice this might not have any effect unless a large number of commits land in quick succession during backporting.