### PR TITLE
Switch to Ubuntu 20.04

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -30,7 +30,7 @@ jobs:
   # - todo: Configure Slack notifications for failing scans.
   phpcs:
     name: PHP coding standards
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
 
     steps:
@@ -81,7 +81,7 @@ jobs:
   # - todo: Configure Slack notifications for failing tests.
   jshint:
     name: JavaScript coding standards
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
     env:
       PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: ${{ true }}

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -36,7 +36,7 @@ jobs:
   # - todo: Configure Slack notifications for failing tests.
   e2e-tests:
     name: E2E Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
 
     steps:

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -27,7 +27,7 @@ jobs:
   # - todo: Configure Slack notifications for failing tests.
   test-js:
     name: QUnit Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
 
     steps:

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -29,7 +29,7 @@ jobs:
   # - todo: Configure Slack notifications for failing scans.
   php-comatibility:
     name: Check PHP compatibility
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
 
     steps:

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -37,7 +37,7 @@ jobs:
   # - Uploads ZIP file as an artifact.
   setup-wordpress:
     name: Setup WordPress
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
 
     steps:
@@ -130,16 +130,16 @@ jobs:
     strategy:
       matrix:
         php: [ '8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6.20' ]
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-20.04 ]
         memcached: [ false ]
         include:
           # Include job for PHP 7.4 with memcached.
           - php: '7.4'
-            os: ubuntu-latest
+            os: ubuntu-20.04
             memcached: true
           # Report the results of the PHP 7.4 without memcached job.
           - php: '7.4'
-            os: ubuntu-latest
+            os: ubuntu-20.04
             memcached: false
             report: true
     env:

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -40,7 +40,7 @@ jobs:
   # - Upload the multisite code coverage report to Codecov.io.
   test-coverage-report:
     name: Generate a code coverage report
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
 
     steps:

--- a/.github/workflows/welcome-new-contributors.yml
+++ b/.github/workflows/welcome-new-contributors.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   # Comments on a pull request when the author is a new contributor.
   post-welcome-message:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
 
     steps:


### PR DESCRIPTION
Ubuntu-latest workflows will use Ubuntu-20.04 soon. This change is to make sure everything runs okay before the switch actually happens.

A test was previously done in #750 but the test coverage workflow has been added since.

Ref: https://github.com/actions/virtual-environments/issues/1816