### PR TITLE
Twenty Nineteen: Add text color rule for buttons

### DIFF
--- a/src/wp-content/themes/twentynineteen/style-editor.css
+++ b/src/wp-content/themes/twentynineteen/style-editor.css
@@ -969,6 +969,10 @@ figcaption,
   font-weight: bold;
 }
 
+.wp-block-button .wp-block-button__link:not(.has-text-color) {
+  color: white;
+}
+
 .wp-block-button:not(.is-style-outline) .wp-block-button__link {
   background: #0073aa;
 }

--- a/src/wp-content/themes/twentynineteen/style-editor.scss
+++ b/src/wp-content/themes/twentynineteen/style-editor.scss
@@ -373,6 +373,10 @@ figcaption,
 		@include font-family( $font__heading );
 		font-size: $font__size-sm;
 		font-weight: bold;
+
+		&:not(.has-text-color) {
+			color: white;
+		}
 	}
 
 	&:not(.is-style-outline) .wp-block-button__link {


### PR DESCRIPTION
This adds a text color for the `.wp-block-button__link` element in the editor. This is already done in the frontend css, just not within the editor css.

Trac ticket: https://core.trac.wordpress.org/ticket/52555

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
