### PR TITLE
Fix: Option name is pass instead of an old admin email address.

### DIFF
--- a/src/wp-admin/includes/admin-filters.php
+++ b/src/wp-admin/includes/admin-filters.php
@@ -60,7 +60,7 @@ add_action( 'update_option_siteurl', 'update_home_siteurl', 10, 2 );
 add_action( 'update_option_page_on_front', 'update_home_siteurl', 10, 2 );
 add_action( 'update_option_admin_email', 'wp_site_admin_email_change_notification', 10, 3 );
 
-add_action( 'add_option_new_admin_email', 'update_option_new_admin_email', 10, 2 );
+add_action( 'add_option_new_admin_email', 'add_option_new_admin_email', 10, 2 );
 add_action( 'update_option_new_admin_email', 'update_option_new_admin_email', 10, 2 );
 
 add_filter( 'heartbeat_received', 'wp_check_locked_posts', 10, 3 );

--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -1329,6 +1329,18 @@ function wp_page_reload_on_back_button_js() {
 }
 
 /**
+ * Retrieve the old admin email address before sending an email of the change of site admin email address.
+ *
+ * @param string $option The name of the option.
+ * @param mixed $value The proposed new site email address.
+ * @return void
+ */
+function add_option_new_admin_email( $option, $value ) {
+	$old_value = get_option( 'admin_email' );
+	update_option_new_admin_email( $old_value, $value );
+}
+
+/**
  * Send a confirmation request email when a change of site admin email address is attempted.
  *
  * The new site admin address will not become active until confirmed.


### PR DESCRIPTION
When changing the admin email address, the argument passed to `update_option_new_admin_email()` function is a string instead of an email address.

Trac ticket: https://core.trac.wordpress.org/ticket/52464

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
