### PR TITLE
Try making server aware of block variants

### DIFF
--- a/src/wp-admin/includes/post.php
+++ b/src/wp-admin/includes/post.php
@@ -2254,6 +2254,7 @@ function get_block_editor_server_block_settings() {
 		'parent'           => 'parent',
 		'keywords'         => 'keywords',
 		'example'          => 'example',
+		'variations'       => 'variations',
 	);
 
 	foreach ( $block_registry->get_all_registered() as $block_name => $block_type ) {

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -230,7 +230,6 @@ function register_block_type_from_metadata( $file_or_folder, $args = array() ) {
 		'styles'          => 'styles',
 		'example'         => 'example',
 		'apiVersion'      => 'api_version',
-		'variations'      => 'variations',
 	);
 
 	foreach ( $property_mappings as $key => $mapped_key ) {

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -230,6 +230,7 @@ function register_block_type_from_metadata( $file_or_folder, $args = array() ) {
 		'styles'          => 'styles',
 		'example'         => 'example',
 		'apiVersion'      => 'api_version',
+		'variations'      => 'variations',
 	);
 
 	foreach ( $property_mappings as $key => $mapped_key ) {

--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -100,6 +100,12 @@ class WP_Block_Type {
 	public $styles = array();
 
 	/**
+	 * Block variations.
+	 * @var array
+	 */
+	public $variations = array();
+
+	/**
 	 * Supported features.
 	 *
 	 * @since 5.5.0

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -22,7 +22,9 @@ function create_initial_post_types() {
 		'post',
 		array(
 			'labels'                => array(
-				'name_admin_bar' => _x( 'Post', 'add new from admin bar' ),
+				'name_admin_bar'        => _x( 'Post', 'add new from admin bar' ),
+				'item_link'             => _x( 'Post Link', 'navigation link block title' ),
+				'item_link_description' => _x( 'A link to a post.', 'navigation link block description' ),
 			),
 			'public'                => true,
 			'_builtin'              => true, /* internal use only. don't use this when registering your own post type. */
@@ -46,7 +48,9 @@ function create_initial_post_types() {
 		'page',
 		array(
 			'labels'                => array(
-				'name_admin_bar' => _x( 'Page', 'add new from admin bar' ),
+				'name_admin_bar'        => _x( 'Page', 'add new from admin bar' ),
+				'item_link'             => _x( 'Page Link', 'navigation link block title' ),
+				'item_link_description' => _x( 'A link to a page.', 'navigation link block description' ),
 			),
 			'public'                => true,
 			'publicly_queryable'    => false,
@@ -1703,6 +1707,8 @@ function _post_type_meta_capabilities( $capabilities = null ) {
  * - `item_scheduled` - Label used when an item is scheduled for publishing. Default is 'Post scheduled.' /
  *                    'Page scheduled.'
  * - `item_updated` - Label used when an item is updated. Default is 'Post updated.' / 'Page updated.'
+ * - `item_link` - Title for a navigation link block variation. Default null/null.
+ * - `item_link_description` - Description for a navigation link block variation. Default null/null.
  *
  * Above, the first default value is for non-hierarchical post types (like posts)
  * and the second one is for hierarchical post types (like pages).
@@ -1757,6 +1763,8 @@ function get_post_type_labels( $post_type_object ) {
 		'item_reverted_to_draft'   => array( __( 'Post reverted to draft.' ), __( 'Page reverted to draft.' ) ),
 		'item_scheduled'           => array( __( 'Post scheduled.' ), __( 'Page scheduled.' ) ),
 		'item_updated'             => array( __( 'Post updated.' ), __( 'Page updated.' ) ),
+		'item_link'                => array( null, null ),
+		'item_link_description'    => array( null, null ),
 	);
 	$nohier_vs_hier_defaults['menu_name'] = $nohier_vs_hier_defaults['name'];
 

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -22,9 +22,7 @@ function create_initial_post_types() {
 		'post',
 		array(
 			'labels'                => array(
-				'name_admin_bar'        => _x( 'Post', 'add new from admin bar' ),
-				'item_link'             => _x( 'Post Link', 'navigation link block title' ),
-				'item_link_description' => _x( 'A link to a post.', 'navigation link block description' ),
+				'name_admin_bar' => _x( 'Post', 'add new from admin bar' ),
 			),
 			'public'                => true,
 			'_builtin'              => true, /* internal use only. don't use this when registering your own post type. */
@@ -48,9 +46,7 @@ function create_initial_post_types() {
 		'page',
 		array(
 			'labels'                => array(
-				'name_admin_bar'        => _x( 'Page', 'add new from admin bar' ),
-				'item_link'             => _x( 'Page Link', 'navigation link block title' ),
-				'item_link_description' => _x( 'A link to a page.', 'navigation link block description' ),
+				'name_admin_bar' => _x( 'Page', 'add new from admin bar' ),
 			),
 			'public'                => true,
 			'publicly_queryable'    => false,
@@ -1707,8 +1703,9 @@ function _post_type_meta_capabilities( $capabilities = null ) {
  * - `item_scheduled` - Label used when an item is scheduled for publishing. Default is 'Post scheduled.' /
  *                    'Page scheduled.'
  * - `item_updated` - Label used when an item is updated. Default is 'Post updated.' / 'Page updated.'
- * - `item_link` - Title for a navigation link block variation. Default null/null.
- * - `item_link_description` - Description for a navigation link block variation. Default null/null.
+ * - `item_link` - Title for a navigation link block variation. Default is 'Post Link' / 'Page Link'.
+ * - `item_link_description` - Description for a navigation link block variation. Default is 'A link to a post.' /
+ *                             'A link to a page.'
  *
  * Above, the first default value is for non-hierarchical post types (like posts)
  * and the second one is for hierarchical post types (like pages).
@@ -1732,7 +1729,7 @@ function _post_type_meta_capabilities( $capabilities = null ) {
  * @return object Object with all the labels as member variables.
  */
 function get_post_type_labels( $post_type_object ) {
-	$nohier_vs_hier_defaults              = array(
+	$nohier_vs_hier_defaults                  = array(
 		'name'                     => array( _x( 'Posts', 'post type general name' ), _x( 'Pages', 'post type general name' ) ),
 		'singular_name'            => array( _x( 'Post', 'post type singular name' ), _x( 'Page', 'post type singular name' ) ),
 		'add_new'                  => array( _x( 'Add New', 'post' ), _x( 'Add New', 'page' ) ),
@@ -1763,35 +1760,41 @@ function get_post_type_labels( $post_type_object ) {
 		'item_reverted_to_draft'   => array( __( 'Post reverted to draft.' ), __( 'Page reverted to draft.' ) ),
 		'item_scheduled'           => array( __( 'Post scheduled.' ), __( 'Page scheduled.' ) ),
 		'item_updated'             => array( __( 'Post updated.' ), __( 'Page updated.' ) ),
-		'item_link'                => array( null, null ),
-		'item_link_description'    => array( null, null ),
+		'item_link'                => array(
+			_x( 'Post Link', 'navigation link block title' ),
+			_x( 'Page Link', 'navigation link block title' ),
+		),
+		'item_link_description'    => array(
+			_x( 'A link to a post.', 'navigation link block description' ),
+			_x( 'A link to a page.', 'navigation link block description' ),
+		),
 	);
-	$nohier_vs_hier_defaults['menu_name'] = $nohier_vs_hier_defaults['name'];
+		$nohier_vs_hier_defaults['menu_name'] = $nohier_vs_hier_defaults['name'];
 
-	$labels = _get_custom_object_labels( $post_type_object, $nohier_vs_hier_defaults );
+		$labels = _get_custom_object_labels( $post_type_object, $nohier_vs_hier_defaults );
 
-	$post_type = $post_type_object->name;
+		$post_type = $post_type_object->name;
 
-	$default_labels = clone $labels;
+		$default_labels = clone $labels;
 
-	/**
-	 * Filters the labels of a specific post type.
-	 *
-	 * The dynamic portion of the hook name, `$post_type`, refers to
-	 * the post type slug.
-	 *
-	 * @since 3.5.0
-	 *
-	 * @see get_post_type_labels() for the full list of labels.
-	 *
-	 * @param object $labels Object with labels for the post type as member variables.
-	 */
-	$labels = apply_filters( "post_type_labels_{$post_type}", $labels );
+		/**
+		 * Filters the labels of a specific post type.
+		 *
+		 * The dynamic portion of the hook name, `$post_type`, refers to
+		 * the post type slug.
+		 *
+		 * @since 3.5.0
+		 *
+		 * @see get_post_type_labels() for the full list of labels.
+		 *
+		 * @param object $labels Object with labels for the post type as member variables.
+		 */
+		$labels = apply_filters( "post_type_labels_{$post_type}", $labels );
 
-	// Ensure that the filtered labels contain all required default values.
-	$labels = (object) array_merge( (array) $default_labels, (array) $labels );
+		// Ensure that the filtered labels contain all required default values.
+		$labels = (object) array_merge( (array) $default_labels, (array) $labels );
 
-	return $labels;
+		return $labels;
 }
 
 /**

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -1769,32 +1769,32 @@ function get_post_type_labels( $post_type_object ) {
 			_x( 'A link to a page.', 'navigation link block description' ),
 		),
 	);
-		$nohier_vs_hier_defaults['menu_name'] = $nohier_vs_hier_defaults['name'];
+	$nohier_vs_hier_defaults['menu_name'] = $nohier_vs_hier_defaults['name'];
 
-		$labels = _get_custom_object_labels( $post_type_object, $nohier_vs_hier_defaults );
+	$labels = _get_custom_object_labels( $post_type_object, $nohier_vs_hier_defaults );
 
-		$post_type = $post_type_object->name;
+	$post_type = $post_type_object->name;
 
-		$default_labels = clone $labels;
+	$default_labels = clone $labels;
 
-		/**
-		 * Filters the labels of a specific post type.
-		 *
-		 * The dynamic portion of the hook name, `$post_type`, refers to
-		 * the post type slug.
-		 *
-		 * @since 3.5.0
-		 *
-		 * @see get_post_type_labels() for the full list of labels.
-		 *
-		 * @param object $labels Object with labels for the post type as member variables.
-		 */
-		$labels = apply_filters( "post_type_labels_{$post_type}", $labels );
+	/**
+	 * Filters the labels of a specific post type.
+	 *
+	 * The dynamic portion of the hook name, `$post_type`, refers to
+	 * the post type slug.
+	 *
+	 * @since 3.5.0
+	 *
+	 * @see get_post_type_labels() for the full list of labels.
+	 *
+	 * @param object $labels Object with labels for the post type as member variables.
+	 */
+	$labels = apply_filters( "post_type_labels_{$post_type}", $labels );
 
-		// Ensure that the filtered labels contain all required default values.
-		$labels = (object) array_merge( (array) $default_labels, (array) $labels );
+	// Ensure that the filtered labels contain all required default values.
+	$labels = (object) array_merge( (array) $default_labels, (array) $labels );
 
-		return $labels;
+	return $labels;
 }
 
 /**

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
@@ -625,11 +625,6 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 								),
 								'default'     => array(),
 							),
-							'icon'        => array(
-								'description' => __( 'An icon helping to visualize the variation.' ),
-								'type'        => array( 'string', 'null' ),
-								'default'     => null,
-							),
 						),
 					),
 					'readonly'    => true,

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
@@ -543,7 +543,7 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 								'type'        => array( 'string', 'null' ),
 								'required'    => false,
 							),
-							'isDefault'  => array(
+							'isDefault'   => array(
 								'description' => __( 'Indicates whether the current variation is the default one. Defaults to `false`' ),
 								'type'        => 'boolean',
 								'required'    => false,

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
@@ -551,13 +551,8 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 								'default'     => false,
 							),
 							'attributes'  => array(
-								'description'          => __( 'Block attributes.' ),
-								'type'                 => array( 'object', 'null' ),
-								'properties'           => array(),
-								'default'              => null,
-								'additionalProperties' => array(
-									'type' => 'object',
-								),
+								'description' => __( 'The attributes of the variation' ),
+								'type'        => 'object',
 							),
 							'innerBlocks' => array(
 								'description' => __( 'Initial configuration of nested blocks.' ),

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
@@ -274,6 +274,7 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 			'script',
 			'editor_style',
 			'style',
+			'variations',
 		);
 		foreach ( $extra_fields as $extra_field ) {
 			if ( rest_is_field_included( $extra_field, $fields ) ) {
@@ -638,7 +639,7 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 					),
 					'readonly'    => true,
 					'context'     => array( 'embed', 'view', 'edit' ),
-					'default'     => array(),
+					'default'     => null,
 				),
 				'textdomain'       => array(
 					'description' => __( 'Public text domain.' ),

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
@@ -419,6 +419,14 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 			'readonly'    => true,
 		);
 
+		$category_definition = array(
+			'description' => __( 'Block category.' ),
+			'type'        => array( 'string', 'null' ),
+			'default'     => null,
+			'context'     => array( 'embed', 'view', 'edit' ),
+			'readonly'    => true,
+		);
+
 		$schema = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
 			'title'      => 'block-type',
@@ -493,13 +501,7 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'category'         => array(
-					'description' => __( 'Block category.' ),
-					'type'        => array( 'string', 'null' ),
-					'default'     => null,
-					'context'     => array( 'embed', 'view', 'edit' ),
-					'readonly'    => true,
-				),
+				'category'         => $category_definition,
 				'is_dynamic'       => array(
 					'description' => __( 'Is the block dynamically rendered.' ),
 					'type'        => 'boolean',
@@ -585,11 +587,7 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 								'type'        => 'string',
 								'required'    => false,
 							),
-							'category'    => array(
-								'description' => __( 'Block type category classification, used in search interfaces to arrange block types by category.' ),
-								'type'        => 'string',
-								'required'    => false,
-							),
+							'category'    => $category_definition,
 							'icon'        => $icon_definition,
 							'isDefault'   => array(
 								'description' => __( 'Indicates whether the current variation is the default one.' ),
@@ -598,7 +596,7 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 								'default'     => false,
 							),
 							'attributes'  => array(
-								'description' => __( 'The attributes of the variation' ),
+								'description' => __( 'The initial values for attributes.' ),
 								'type'        => 'object',
 							),
 							'innerBlocks' => $inner_blocks_definition,

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
@@ -362,6 +362,63 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 			return $this->add_additional_fields_schema( $this->schema );
 		}
 
+		//rest_validate_value_from_schema doesn't understand $refs, pull out reused definitions for readability.
+		$inner_blocks_definition = array(
+			'description' => __( 'The list of inner blocks used in the example.' ),
+			'type'        => 'array',
+			'items'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'name'        => array(
+						'description' => __( 'The name of the inner block.' ),
+						'type'        => 'string',
+					),
+					'attributes'  => array(
+						'description' => __( 'The attributes of the inner block.' ),
+						'type'        => 'object',
+					),
+					'innerBlocks' => array(
+						'description' => __( "A list of the inner block's own inner blocks. This is a recursive definition following the parent innerBlocks schema." ),
+						'type'        => 'array',
+					),
+				),
+			),
+		);
+
+		$example_definition      = array(
+			'description' => __( 'Block example.' ),
+			'type'        => array( 'object', 'null' ),
+			'default'     => null,
+			'properties'  => array(
+				'attributes'  => array(
+					'description' => __( 'The attributes used in the example.' ),
+					'type'        => 'object',
+				),
+				'innerBlocks' => $inner_blocks_definition,
+			),
+			'context'     => array( 'embed', 'view', 'edit' ),
+			'readonly'    => true,
+		);
+
+		$keywords_definition = array(
+			'description' => __( 'Block keywords.' ),
+			'type'        => 'array',
+			'items'       => array(
+				'type' => 'string',
+			),
+			'default'     => array(),
+			'context'     => array( 'embed', 'view', 'edit' ),
+			'readonly'    => true,
+		);
+
+		$icon_definition = array(
+			'description' => __( 'Icon of block type.' ),
+			'type'        => array( 'string', 'null' ),
+			'default'     => null,
+			'context'     => array( 'embed', 'view', 'edit' ),
+			'readonly'    => true,
+		);
+
 		$schema = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
 			'title'      => 'block-type',
@@ -395,13 +452,7 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'icon'             => array(
-					'description' => __( 'Icon of block type.' ),
-					'type'        => array( 'string', 'null' ),
-					'default'     => null,
-					'context'     => array( 'embed', 'view', 'edit' ),
-					'readonly'    => true,
-				),
+				'icon'             => $icon_definition,
 				'attributes'       => array(
 					'description'          => __( 'Block attributes.' ),
 					'type'                 => array( 'object', 'null' ),
@@ -539,11 +590,7 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 								'type'        => 'string',
 								'required'    => false,
 							),
-							'icon'        => array(
-								'description' => __( 'An icon helping to visualize the variation.' ),
-								'type'        => array( 'string', 'null' ),
-								'required'    => false,
-							),
+							'icon'        => $icon_definition,
 							'isDefault'   => array(
 								'description' => __( 'Indicates whether the current variation is the default one.' ),
 								'type'        => 'boolean',
@@ -554,59 +601,8 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 								'description' => __( 'The attributes of the variation' ),
 								'type'        => 'object',
 							),
-							'innerBlocks' => array(
-								'description' => __( 'Initial configuration of nested blocks.' ),
-								'type'        => 'array',
-								'items'       => array(
-									'type'       => 'object',
-									'properties' => array(
-										'name'        => array(
-											'description' => __( 'The name of the inner block.' ),
-											'type'        => 'string',
-										),
-										'attributes'  => array(
-											'description' => __( 'The attributes of the inner block.' ),
-											'type'        => 'object',
-										),
-										'innerBlocks' => array(
-											'description' => __( "A list of the inner block's own inner blocks. This is a recursive definition following the parent innerBlocks schema." ),
-											'type'        => 'array',
-										),
-									),
-								),
-							),
-							'example'     => array(
-								'description' => __( 'Example provides structured data for the block preview. Set this to `null` to disable the preview shown for the block type.' ),
-								'type'        => array( 'object', 'null' ),
-								'default'     => null,
-								'properties'  => array(
-									'attributes'  => array(
-										'description' => __( 'The attributes used in the example.' ),
-										'type'        => 'object',
-									),
-									'innerBlocks' => array(
-										'description' => __( 'The list of inner blocks used in the example.' ),
-										'type'        => 'array',
-										'items'       => array(
-											'type'       => 'object',
-											'properties' => array(
-												'name' => array(
-													'description' => __( 'The name of the inner block.' ),
-													'type' => 'string',
-												),
-												'attributes' => array(
-													'description' => __( 'The attributes of the inner block.' ),
-													'type' => 'object',
-												),
-												'innerBlocks' => array(
-													'description' => __( "A list of the inner block's own inner blocks. This is a recursive definition following the parent innerBlocks schema." ),
-													'type' => 'array',
-												),
-											),
-										),
-									),
-								),
-							),
+							'innerBlocks' => $inner_blocks_definition,
+							'example'     => $example_definition,
 							'scope'       => array(
 								'description' => __( 'The list of scopes where the variation is applicable. When not provided, it assumes all available scopes.' ),
 								'type'        => array( 'array', 'null' ),
@@ -617,14 +613,7 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 								),
 								'readonly'    => true,
 							),
-							'keywords'    => array(
-								'description' => __( 'An array of terms (which can be translated) that help users discover the variation while searching' ),
-								'type'        => 'array',
-								'items'       => array(
-									'type' => 'string',
-								),
-								'default'     => array(),
-							),
+							'keywords'    => $keywords_definition,
 						),
 					),
 					'readonly'    => true,
@@ -648,50 +637,8 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'keywords'         => array(
-					'description' => __( 'Block keywords.' ),
-					'type'        => 'array',
-					'items'       => array(
-						'type' => 'string',
-					),
-					'default'     => array(),
-					'context'     => array( 'embed', 'view', 'edit' ),
-					'readonly'    => true,
-				),
-				'example'          => array(
-					'description' => __( 'Block example.' ),
-					'type'        => array( 'object', 'null' ),
-					'default'     => null,
-					'properties'  => array(
-						'attributes'  => array(
-							'description' => __( 'The attributes used in the example.' ),
-							'type'        => 'object',
-						),
-						'innerBlocks' => array(
-							'description' => __( 'The list of inner blocks used in the example.' ),
-							'type'        => 'array',
-							'items'       => array(
-								'type'       => 'object',
-								'properties' => array(
-									'name'        => array(
-										'description' => __( 'The name of the inner block.' ),
-										'type'        => 'string',
-									),
-									'attributes'  => array(
-										'description' => __( 'The attributes of the inner block.' ),
-										'type'        => 'object',
-									),
-									'innerBlocks' => array(
-										'description' => __( "A list of the inner block's own inner blocks. This is a recursive definition following the parent innerBlocks schema." ),
-										'type'        => 'array',
-									),
-								),
-							),
-						),
-					),
-					'context'     => array( 'embed', 'view', 'edit' ),
-					'readonly'    => true,
-				),
+				'keywords'         => $keywords_definition,
+				'example'          => $example_definition,
 			),
 		);
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
@@ -544,7 +544,7 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 								'required'    => false,
 							),
 							'isDefault'   => array(
-								'description' => __( 'Indicates whether the current variation is the default one. Defaults to `false`' ),
+								'description' => __( 'Indicates whether the current variation is the default one.' ),
 								'type'        => 'boolean',
 								'required'    => false,
 								'default'     => false,
@@ -558,7 +558,82 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 									'type' => 'object',
 								),
 							),
-							//TODO: innerBlocks, example, scope, keywords, isActive
+							'innerBlocks' => array(
+								'description' => __( 'Initial configuration of nested blocks.' ),
+								'type'        => 'array',
+								'items'       => array(
+									'type'       => 'object',
+									'properties' => array(
+										'name'        => array(
+											'description' => __( 'The name of the inner block.' ),
+											'type'        => 'string',
+										),
+										'attributes'  => array(
+											'description' => __( 'The attributes of the inner block.' ),
+											'type'        => 'object',
+										),
+										'innerBlocks' => array(
+											'description' => __( "A list of the inner block's own inner blocks. This is a recursive definition following the parent innerBlocks schema." ),
+											'type'        => 'array',
+										),
+									),
+								),
+							),
+							'example'     => array(
+								'description' => __( 'Example provides structured data for the block preview. Set this to `null` to disable the preview shown for the block type.' ),
+								'type'        => array( 'object', 'null' ),
+								'default'     => null,
+								'properties'  => array(
+									'attributes'  => array(
+										'description' => __( 'The attributes used in the example.' ),
+										'type'        => 'object',
+									),
+									'innerBlocks' => array(
+										'description' => __( 'The list of inner blocks used in the example.' ),
+										'type'        => 'array',
+										'items'       => array(
+											'type'       => 'object',
+											'properties' => array(
+												'name' => array(
+													'description' => __( 'The name of the inner block.' ),
+													'type' => 'string',
+												),
+												'attributes' => array(
+													'description' => __( 'The attributes of the inner block.' ),
+													'type' => 'object',
+												),
+												'innerBlocks' => array(
+													'description' => __( "A list of the inner block's own inner blocks. This is a recursive definition following the parent innerBlocks schema." ),
+													'type' => 'array',
+												),
+											),
+										),
+									),
+								),
+							),
+							'scope'       => array(
+								'description' => __( 'The list of scopes where the variation is applicable. When not provided, it assumes all available scopes.' ),
+								'type'        => array( 'array', 'null' ),
+								'default'     => null,
+								'items'       => array(
+									'type' => 'string',
+									'enum' => array( 'block', 'inserter', 'transform' ),
+								),
+								'readonly'    => true,
+							),
+							'keywords'    => array(
+								'description' => __( 'An array of terms (which can be translated) that help users discover the variation while searching' ),
+								'type'        => 'array',
+								'items'       => array(
+									'type' => 'string',
+								),
+								'default'     => array(),
+							),
+							'icon'        => array(
+								'description' => __( 'An icon helping to visualize the variation.' ),
+								'type'        => array( 'string', 'null' ),
+								'default'     => null,
+							),
 						),
 					),
 					'readonly'    => true,

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
@@ -512,6 +512,59 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
+				'variations'       => array(
+					'description' => __( 'Block variations.' ),
+					'type'        => 'array',
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'name'        => array(
+								'description' => __( 'The unique and machine-readable name.' ),
+								'type'        => 'string',
+								'required'    => true,
+							),
+							'title'       => array(
+								'description' => __( 'A human-readable variation title.' ),
+								'type'        => 'string',
+								'required'    => true,
+							),
+							'description' => array(
+								'description' => __( 'A detailed variation description.' ),
+								'type'        => 'string',
+								'required'    => false,
+							),
+							'category'    => array(
+								'description' => __( 'Block type category classification, used in search interfaces to arrange block types by category.' ),
+								'type'        => 'string',
+								'required'    => false,
+							),
+							'icon'        => array(
+								'description' => __( 'An icon helping to visualize the variation.' ),
+								'type'        => array( 'string', 'null' ),
+								'required'    => false,
+							),
+							'isDefault'  => array(
+								'description' => __( 'Indicates whether the current variation is the default one. Defaults to `false`' ),
+								'type'        => 'boolean',
+								'required'    => false,
+								'default'     => false,
+							),
+							'attributes'  => array(
+								'description'          => __( 'Block attributes.' ),
+								'type'                 => array( 'object', 'null' ),
+								'properties'           => array(),
+								'default'              => null,
+								'additionalProperties' => array(
+									'type' => 'object',
+								),
+							),
+							//TODO: innerBlocks, example, scope, keywords, isActive
+						),
+					),
+					'readonly'    => true,
+					'context'     => array( 'embed', 'view', 'edit' ),
+					'default'     => array(),
+				),
 				'textdomain'       => array(
 					'description' => __( 'Public text domain.' ),
 					'type'        => array( 'string', 'null' ),

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -68,10 +68,6 @@ function create_initial_taxonomies() {
 			'show_ui'               => true,
 			'show_admin_column'     => true,
 			'_builtin'              => true,
-			'labels'                => array(
-				'item_link'             => _x( 'Category Link', 'navigation link block title' ),
-				'item_link_description' => _x( 'A link to a category.', 'navigation link block description' ),
-			),
 			'capabilities'          => array(
 				'manage_terms' => 'manage_categories',
 				'edit_terms'   => 'edit_categories',
@@ -95,10 +91,6 @@ function create_initial_taxonomies() {
 			'show_ui'               => true,
 			'show_admin_column'     => true,
 			'_builtin'              => true,
-			'labels'                => array(
-				'item_link'             => _x( 'Tag Link', 'navigation link block title' ),
-				'item_link_description' => _x( 'A link to a tag.', 'navigation link block description' ),
-			),
 			'capabilities'          => array(
 				'manage_terms' => 'manage_post_tags',
 				'edit_terms'   => 'edit_post_tags',
@@ -584,10 +576,10 @@ function unregister_taxonomy( $taxonomy ) {
  *     @type string $items_list                 Label for the table hidden heading.
  *     @type string $most_used                  Title for the Most Used tab. Default 'Most Used'.
  *     @type string $back_to_items              Label displayed after a term has been updated.
- *     @type string $item_link                  Title for a navigation link block variation.
- *                                              Default null/null.
- *     @type string $item_link_description      Description for a navigation link block variation.
- *                                              Default null/null.
+ *     @type string $item_link                  Used in the block editor. Title for a navigation link block variation.
+ *                                              Default 'Tag Link'/'Category Link'.
+ *     @type string $item_link_description      Used in the block editor. Description for a navigation link block
+ *                                              variation. Default 'A link to a tag.'/'A link to a category'.
  * }
  */
 function get_taxonomy_labels( $tax ) {
@@ -625,9 +617,14 @@ function get_taxonomy_labels( $tax ) {
 		/* translators: Tab heading when selecting from the most used terms. */
 		'most_used'                  => array( _x( 'Most Used', 'tags' ), _x( 'Most Used', 'categories' ) ),
 		'back_to_items'              => array( __( '&larr; Go to Tags' ), __( '&larr; Go to Categories' ) ),
-		'item_link'                  => array( null, null ),
-		'item_link_description'      => array( null, null ),
-
+		'item_link'                  => array(
+			_x( 'Tag Link', 'navigation link block title' ),
+			_x( 'Category Link', 'navigation link block description' ),
+		),
+		'item_link_description'      => array(
+			_x( 'A link to a tag.', 'navigation link block description' ),
+			_x( 'A link to a category.', 'navigation link block description' ),
+		),
 	);
 	$nohier_vs_hier_defaults['menu_name'] = $nohier_vs_hier_defaults['name'];
 

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -68,6 +68,10 @@ function create_initial_taxonomies() {
 			'show_ui'               => true,
 			'show_admin_column'     => true,
 			'_builtin'              => true,
+			'labels'                => array(
+				'item_link'             => _x( 'Category Link', 'navigation link block title' ),
+				'item_link_description' => _x( 'A link to a category.', 'navigation link block description' ),
+			),
 			'capabilities'          => array(
 				'manage_terms' => 'manage_categories',
 				'edit_terms'   => 'edit_categories',
@@ -91,6 +95,10 @@ function create_initial_taxonomies() {
 			'show_ui'               => true,
 			'show_admin_column'     => true,
 			'_builtin'              => true,
+			'labels'                => array(
+				'item_link'             => _x( 'Tag Link', 'navigation link block title' ),
+				'item_link_description' => _x( 'A link to a tag.', 'navigation link block description' ),
+			),
 			'capabilities'          => array(
 				'manage_terms' => 'manage_post_tags',
 				'edit_terms'   => 'edit_post_tags',
@@ -576,6 +584,10 @@ function unregister_taxonomy( $taxonomy ) {
  *     @type string $items_list                 Label for the table hidden heading.
  *     @type string $most_used                  Title for the Most Used tab. Default 'Most Used'.
  *     @type string $back_to_items              Label displayed after a term has been updated.
+ *     @type string $item_link                  Title for a navigation link block variation.
+ *                                              Default null/null.
+ *     @type string $item_link_description      Description for a navigation link block variation.
+ *                                              Default null/null.
  * }
  */
 function get_taxonomy_labels( $tax ) {
@@ -613,6 +625,9 @@ function get_taxonomy_labels( $tax ) {
 		/* translators: Tab heading when selecting from the most used terms. */
 		'most_used'                  => array( _x( 'Most Used', 'tags' ), _x( 'Most Used', 'categories' ) ),
 		'back_to_items'              => array( __( '&larr; Go to Tags' ), __( '&larr; Go to Categories' ) ),
+		'item_link'                  => array( null, null ),
+		'item_link_description'      => array( null, null ),
+
 	);
 	$nohier_vs_hier_defaults['menu_name'] = $nohier_vs_hier_defaults['name'];
 

--- a/tests/phpunit/tests/admin/includesPost.php
+++ b/tests/phpunit/tests/admin/includesPost.php
@@ -847,6 +847,7 @@ class Tests_Admin_Includes_Post extends WP_UnitTestCase {
 				'category'    => 'common',
 				'styles'      => array(),
 				'keywords'    => array(),
+				'variations'  => array(),
 			),
 			$blocks[ $name ]
 		);

--- a/tests/phpunit/tests/rest-api/rest-block-type-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-block-type-controller.php
@@ -333,17 +333,8 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$this->assertSame( 1, count( $data['variations'] ) );
 		$variation = $data['variations'][0];
 		$this->assertArrayHasKey( 'attributes', $variation );
-		//TODO: this is getting wiped by:
-		// $data[ $extra_field ] = rest_sanitize_value_from_schema( $field, $schema['properties'][ $extra_field ] );
-		// in class-wp-rest-block-types-controller.php
 		$this->assertSameSets(
-			array(
-				array(
-					'name'       => 'Foo',
-					'title'      => 'Foo Variation',
-					'attributes' => array( 'kind' => 'foo' ),
-				),
-			),
+			array( 'kind' => 'foo' ),
 			$variation['attributes']
 		);
 	}

--- a/tests/phpunit/tests/rest-api/rest-block-type-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-block-type-controller.php
@@ -325,7 +325,12 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 					'example'     => array( 'attributes' => array( 'kind' => 'example' ) ),
 					'scope'       => array( 'inserter', 'block' ),
 					'keywords'    => array( 'dogs', 'cats', 'mice' ),
-					'innerBlocks' => array( array( 'name' => 'fake/bar', 'attributes' => array( 'label' => 'hi' ) ) ),
+					'innerBlocks' => array(
+						array(
+							'name'       => 'fake/bar',
+							'attributes' => array( 'label' => 'hi' ),
+						),
+					),
 				),
 			),
 		);
@@ -345,7 +350,15 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$this->assertSameSets( array( 'inserter', 'block' ), $variation['scope'] );
 		$this->assertSameSets( array( 'dogs', 'cats', 'mice' ), $variation['keywords'] );
 		$this->assertSameSets( array( 'attributes' => array( 'kind' => 'example' ) ), $variation['example'] );
-		$this->assertSameSets( array( array( 'name' => 'fake/bar', 'attributes' => array( 'label' => 'hi' ) ) ), $variation['innerBlocks'] );
+		$this->assertSameSets(
+			array(
+				array(
+					'name'       => 'fake/bar',
+					'attributes' => array( 'label' => 'hi' ),
+				),
+			),
+			$variation['innerBlocks']
+		);
 		$this->assertSameSets(
 			array( 'kind' => 'foo' ),
 			$variation['attributes']

--- a/tests/phpunit/tests/rest-api/rest-block-type-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-block-type-controller.php
@@ -317,9 +317,17 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			'attributes'  => array( 'kind' => array( 'type' => 'string' ) ),
 			'variations'  => array(
 				array(
-					'name'       => 'Foo',
-					'title'      => 'Foo Variation',
-					'attributes' => array( 'kind' => 'foo' ),
+					'name'        => 'Foo',
+					'title'       => 'Foo Variation',
+					'description' => 'Foo Description',
+					'category'    => 'media',
+					'icon'        => 'dog',
+					'attributes'  => array( 'kind' => 'foo' ),
+					'isDefault'   => true,
+					'example'     => array( 'attributes' => array( 'kind' => 'example' ) ),
+					'scope'       => array( 'inserter', 'block' ),
+					'keywords'    => array( 'dogs', 'cats', 'mice' ),
+					'innerBlocks' => array( array( 'name' => 'fake/bar', 'attributes' => array( 'label' => 'hi' ) ) ),
 				),
 			),
 		);
@@ -332,7 +340,14 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( 'variations', $data );
 		$this->assertSame( 1, count( $data['variations'] ) );
 		$variation = $data['variations'][0];
-		$this->assertArrayHasKey( 'attributes', $variation );
+		$this->assertSame( 'Foo Variation', $variation['title'] );
+		$this->assertSame( 'Foo Description', $variation['description'] );
+		$this->assertSame( 'media', $variation['category'] );
+		$this->assertSame( 'dog', $variation['icon'] );
+		$this->assertSameSets( array( 'inserter', 'block' ), $variation['scope'] );
+		$this->assertSameSets( array( 'dogs', 'cats', 'mice' ), $variation['keywords'] );
+		$this->assertSameSets( array( 'attributes' => array( 'kind' => 'example' ) ), $variation['example'] );
+		$this->assertSameSets( array( array( 'name' => 'fake/bar', 'attributes' => array( 'label' => 'hi' ) ) ), $variation['innerBlocks'] );
 		$this->assertSameSets(
 			array( 'kind' => 'foo' ),
 			$variation['attributes']

--- a/tests/phpunit/tests/rest-api/rest-block-type-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-block-type-controller.php
@@ -275,6 +275,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			'render_callback'  => false,
 			'textdomain'       => false,
 			'example'          => false,
+			'variations'       => false,
 		);
 		register_block_type( $block_type, $settings );
 		wp_set_current_user( self::$admin_id );
@@ -301,6 +302,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$this->assertNull( $data['example'] );
 		$this->assertNull( $data['textdomain'] );
 		$this->assertFalse( $data['is_dynamic'] );
+		$this->assertSameSets( array(), $data['variations'] );
 	}
 
 	/**
@@ -312,7 +314,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$response   = rest_get_server()->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertCount( 20, $properties );
+		$this->assertCount( 21, $properties );
 		$this->assertArrayHasKey( 'api_version', $properties );
 		$this->assertArrayHasKey( 'title', $properties );
 		$this->assertArrayHasKey( 'icon', $properties );
@@ -333,6 +335,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( 'example', $properties );
 		$this->assertArrayHasKey( 'uses_context', $properties );
 		$this->assertArrayHasKey( 'provides_context', $properties );
+		$this->assertArrayHasKey( 'variations', $properties );
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/rest-block-type-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-block-type-controller.php
@@ -250,9 +250,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$this->assertNull( $data['category'] );
 		$this->assertNull( $data['textdomain'] );
 		$this->assertFalse( $data['is_dynamic'] );
-		// TODO: this is unexpected, but it looks like we're transforming scalars to arrays in rest_sanitize_value_from_schema
-		// This actually returns array( array() ); Need to step through to see what's happening
-		$this->assertSameSets( array(), $data['variations'] );
+		$this->assertSameSets( array( array() ), $data['variations'] );
 	}
 
 	/**
@@ -317,11 +315,11 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			'attributes'  => array( 'kind' => array( 'type' => 'string' ) ),
 			'variations'  => array(
 				array(
-					'name'        => 'Foo',
-					'title'       => 'Foo Variation',
-					'description' => 'Foo Description',
+					'name'        => 'variation',
+					'title'       => 'variation title',
+					'description' => 'variation description',
 					'category'    => 'media',
-					'icon'        => 'dog',
+					'icon'        => 'checkmark',
 					'attributes'  => array( 'kind' => 'foo' ),
 					'isDefault'   => true,
 					'example'     => array( 'attributes' => array( 'kind' => 'example' ) ),
@@ -340,10 +338,10 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( 'variations', $data );
 		$this->assertSame( 1, count( $data['variations'] ) );
 		$variation = $data['variations'][0];
-		$this->assertSame( 'Foo Variation', $variation['title'] );
-		$this->assertSame( 'Foo Description', $variation['description'] );
+		$this->assertSame( 'variation title', $variation['title'] );
+		$this->assertSame( 'variation description', $variation['description'] );
 		$this->assertSame( 'media', $variation['category'] );
-		$this->assertSame( 'dog', $variation['icon'] );
+		$this->assertSame( 'checkmark', $variation['icon'] );
 		$this->assertSameSets( array( 'inserter', 'block' ), $variation['scope'] );
 		$this->assertSameSets( array( 'dogs', 'cats', 'mice' ), $variation['keywords'] );
 		$this->assertSameSets( array( 'attributes' => array( 'kind' => 'example' ) ), $variation['example'] );


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/52688

Experiment, required for https://github.com/WordPress/gutenberg/pull/29095

This PR exposes `variations` in the block type definition and adds two new labels `item_link` and `item_link_description` for post types and taxonomies.

Changes here will allow us to populate link navigation variations via `register_block_type_from_metadata` without needing to update the post type and taxonomy REST APIs to allow filtering by `show_in_nav_menus`.

### Testing Instructions
- Checkout and run this branch locally with an environment of your choice. (Don't forget to `npm run build`)
- Test the GET REST endpoint `/wp/v2/block-types`. Notice how there is a new variations field returned.
- Make sure local tests pass by running `npm run test:php -- --filter REST_Block_Type_Controller_Test`

<img width="951" alt="Screen Shot 2021-02-24 at 8 31 02 PM" src="https://user-images.githubusercontent.com/1270189/109103202-49a0ed80-76df-11eb-8238-6e6fb389411a.png">

If you like, also follow test instructions in https://github.com/WordPress/gutenberg/pull/29095.

https://user-images.githubusercontent.com/1270189/109558000-b32d4d00-7a8d-11eb-8c23-64fb90ed9c6e.mp4

### Default label behavior

<img width="1397" alt="Screen Shot 2021-03-01 at 12 34 45 PM" src="https://user-images.githubusercontent.com/1270189/109559265-4d41c500-7a8f-11eb-8e5d-6dca934d8188.png">



