### PR TITLE
Update wp_is_local_html_output() to also use protocol-agnostic check for RSD link

### DIFF
--- a/src/wp-includes/https-detection.php
+++ b/src/wp-includes/https-detection.php
@@ -204,7 +204,7 @@ function wp_cron_conditionally_prevent_sslverify( $request ) {
 function wp_is_local_html_output( $html ) {
 	// 1. Check if HTML includes the site's Really Simple Discovery link.
 	if ( has_action( 'wp_head', 'rsd_link' ) ) {
-		$pattern = esc_url( site_url( 'xmlrpc.php?rsd', 'rpc' ) ); // See rsd_link().
+		$pattern = preg_replace( '#^https?:(?=//)#', '', esc_url( site_url( 'xmlrpc.php?rsd', 'rpc' ) ) ); // See rsd_link().
 		return false !== strpos( $html, $pattern );
 	}
 
@@ -218,7 +218,7 @@ function wp_is_local_html_output( $html ) {
 	// 3. Check if HTML includes the site's REST API link.
 	if ( has_action( 'wp_head', 'rest_output_link_wp_head' ) ) {
 		// Try both HTTPS and HTTP since the URL depends on context.
-		$pattern = esc_url( preg_replace( '#^https?:(?=//)#', '', get_rest_url() ) ); // See rest_output_link_wp_head().
+		$pattern = preg_replace( '#^https?:(?=//)#', '', esc_url( get_rest_url() ) ); // See rest_output_link_wp_head().
 		return false !== strpos( $html, $pattern );
 	}
 

--- a/tests/phpunit/tests/https-detection.php
+++ b/tests/phpunit/tests/https-detection.php
@@ -171,6 +171,7 @@ class Tests_HTTPS_Detection extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 47577
+	 * @ticket 52542
 	 */
 	public function test_wp_is_local_html_output_via_rsd_link() {
 		// HTML includes RSD link.
@@ -180,6 +181,12 @@ class Tests_HTTPS_Detection extends WP_UnitTestCase {
 
 		// HTML includes modified RSD link but same URL.
 		$head_tag = str_replace( ' />', '>', get_echo( 'rsd_link' ) );
+		$html     = $this->get_sample_html_string( $head_tag );
+		$this->assertTrue( wp_is_local_html_output( $html ) );
+
+		// HTML includes RSD link with alternative URL scheme.
+		$head_tag = get_echo( 'rsd_link' );
+		$head_tag = false !== strpos( $head_tag, 'https://' ) ? str_replace( 'https://', 'http://', $head_tag ) : str_replace( 'http://', 'https://', $head_tag );
 		$html     = $this->get_sample_html_string( $head_tag );
 		$this->assertTrue( wp_is_local_html_output( $html ) );
 


### PR DESCRIPTION
* Updates the RSD link check in `wp_is_local_html_output()` to be protocol-agnostic as expected, like the other ones.
* Updates a minor issue in the REST API link check: The removal of the protocol should happen on the complete URL as included in the HTML output, which is run through `esc_url`. Before `esc_url` was called after removing the protocol which is not correct.

Trac ticket: https://core.trac.wordpress.org/ticket/52542

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
