### PR TITLE
48520: remove check on readme.txt for Requires headers for plugins/themes

### DIFF
--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -1136,19 +1136,6 @@ function validate_plugin_requirements( $plugin ) {
 
 	$readme_file = WP_PLUGIN_DIR . '/' . dirname( $plugin ) . '/readme.txt';
 
-	if ( file_exists( $readme_file ) ) {
-		$readme_headers = get_file_data(
-			$readme_file,
-			array(
-				'requires'     => 'Requires at least',
-				'requires_php' => 'Requires PHP',
-			),
-			'plugin'
-		);
-
-		$requirements = array_merge( $readme_headers, $requirements );
-	}
-
 	$compatible_wp  = is_wp_version_compatible( $requirements['requires'] );
 	$compatible_php = is_php_version_compatible( $requirements['requires_php'] );
 

--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -1116,12 +1116,10 @@ function validate_plugin( $plugin ) {
  * Uses the information from `Requires at least` and `Requires PHP` headers
  * defined in the plugin's main PHP file.
  *
- * If the headers are not present in the plugin's main PHP file,
- * `readme.txt` is also checked as a fallback.
- *
  * @since 5.2.0
  * @since 5.3.0 Added support for reading the headers from the plugin's
  *              main PHP file, with `readme.txt` as a fallback.
+ * @since 5.8.0 Removed support for using `readme.txt` as fallback.
  *
  * @param string $plugin Path to the plugin file relative to the plugins directory.
  * @return true|WP_Error True if requirements are met, WP_Error on failure.

--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -1132,8 +1132,6 @@ function validate_plugin_requirements( $plugin ) {
 		'requires_php' => ! empty( $plugin_headers['RequiresPHP'] ) ? $plugin_headers['RequiresPHP'] : '',
 	);
 
-	$readme_file = WP_PLUGIN_DIR . '/' . dirname( $plugin ) . '/readme.txt';
-
 	$compatible_wp  = is_wp_version_compatible( $requirements['requires'] );
 	$compatible_php = is_php_version_compatible( $requirements['requires_php'] );
 

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -899,8 +899,8 @@ function validate_current_theme() {
  * Uses the information from `Requires at least` and `Requires PHP` headers
  * defined in the theme's `style.css` file.
  *
- * @since 5.5.0 Added support for reading the headers from the themes's
- *              `style.css` file, with `readme.txt` as a fallback.
+ * @since 5.5.0 Support reading the headers from the themes's `style.css`
+ *              file, with `readme.txt` as a fallback.
  * @since 5.8.0 Removed support for using `readme.txt` as fallback.
  *
  * @param string $stylesheet Directory name for the theme.

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -899,8 +899,8 @@ function validate_current_theme() {
  * Uses the information from `Requires at least` and `Requires PHP` headers
  * defined in the theme's `style.css` file.
  *
- * @since 5.5.0 Support reading the headers from the themes's `style.css`
- *              file, with `readme.txt` as a fallback.
+ * @since 5.5.0 Support reading the headers from the themes's `style.css` file,
+ *              with `readme.txt` as a fallback.
  * @since 5.8.0 Removed support for using `readme.txt` as fallback.
  *
  * @param string $stylesheet Directory name for the theme.

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -899,10 +899,9 @@ function validate_current_theme() {
  * Uses the information from `Requires at least` and `Requires PHP` headers
  * defined in the theme's `style.css` file.
  *
- * If the headers are not present in the theme's stylesheet file,
- * `readme.txt` is also checked as a fallback.
- *
- * @since 5.5.0
+ * @since 5.5.0 Added support for reading the headers from the themes's
+ *              `style.css` file, with `readme.txt` as a fallback.
+ * @since 5.8.0 Removed support for using `readme.txt` as fallback.
  *
  * @param string $stylesheet Directory name for the theme.
  * @return true|WP_Error True if requirements are met, WP_Error on failure.

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -915,21 +915,6 @@ function validate_theme_requirements( $stylesheet ) {
 		'requires_php' => ! empty( $theme->get( 'RequiresPHP' ) ) ? $theme->get( 'RequiresPHP' ) : '',
 	);
 
-	$readme_file = $theme->theme_root . '/' . $stylesheet . '/readme.txt';
-
-	if ( file_exists( $readme_file ) ) {
-		$readme_headers = get_file_data(
-			$readme_file,
-			array(
-				'requires'     => 'Requires at least',
-				'requires_php' => 'Requires PHP',
-			),
-			'theme'
-		);
-
-		$requirements = array_merge( $readme_headers, $requirements );
-	}
-
 	$compatible_wp  = is_wp_version_compatible( $requirements['requires'] );
 	$compatible_php = is_php_version_compatible( $requirements['requires_php'] );
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Remove check in readme.txt file for `Requires at least` and `Requires PHP` headers in plugins and themes for validation. While these headers **may** be in the readme.txt files, they **should** be in the main plugin file and the theme's style.css file.

Trac ticket:https://core.trac.wordpress.org/ticket/48520

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
