### PR TITLE
Use x86_64 architecture for mysql image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,7 @@ services:
   # The MySQL container.
   ##
   mysql:
+    platform: linux/x86_64
     image: ${LOCAL_DB_TYPE-mysql}:${LOCAL_DB_VERSION-latest}
 
     networks:


### PR DESCRIPTION
This PR allows pulling MySQL image on arm architectures while 

Fixes https://core.trac.wordpress.org/ticket/52591
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
