### PR TITLE
Further deprecations

### DIFF
--- a/src/js/_enqueues/admin/auth-app.js
+++ b/src/js/_enqueues/admin/auth-app.js
@@ -15,7 +15,7 @@
 			rejectUrl: authApp.reject
 		};
 
-	$approveBtn.click( function( e ) {
+	$approveBtn.on( 'click', function( e ) {
 		var name = $appNameField.val(),
 			appId = $( 'input[name="app_id"]', $form ).val();
 
@@ -26,7 +26,7 @@
 		}
 
 		if ( 0 === name.length ) {
-			$appNameField.focus();
+			$appNameField.trigger( 'focus' );
 			return;
 		}
 
@@ -102,7 +102,7 @@
 				$( 'input', $notice ).val( response.password );
 
 				$form.replaceWith( $notice );
-				$notice.focus();
+				$notice.trigger( 'focus' );
 			}
 		} ).fail( function( jqXHR, textStatus, errorThrown ) {
 			var errorMessage = errorThrown,
@@ -140,7 +140,7 @@
 		} );
 	} );
 
-	$rejectBtn.click( function( e ) {
+	$rejectBtn.on( 'click', function( e ) {
 		e.preventDefault();
 
 		/**

--- a/src/js/_enqueues/admin/common.js
+++ b/src/js/_enqueues/admin/common.js
@@ -840,7 +840,7 @@ $document.ready( function() {
 	 * @return {void}
 	 */
 	$adminmenu.on('click.wp-submenu-head', '.wp-submenu-head', function(e){
-		$(e.target).parent().siblings('a').get(0).click();
+		$(e.target).parent().siblings('a').get(0).trigger( 'click' );
 	});
 
 	/**

--- a/src/js/_enqueues/admin/custom-background.js
+++ b/src/js/_enqueues/admin/custom-background.js
@@ -83,7 +83,7 @@
 		 *
 		 * @return {void}
 		 */
-		$('#choose-from-library-link').on( 'change', function( event ) {
+		$('#choose-from-library-link').on( 'click', function( event ) {
 			var $el = $(this);
 
 			event.preventDefault();

--- a/src/js/_enqueues/admin/custom-background.js
+++ b/src/js/_enqueues/admin/custom-background.js
@@ -39,7 +39,7 @@
 		 *
 		 * @return {void}
 		 */
-		$( 'select[name="background-size"]' ).change( function() {
+		$( 'select[name="background-size"]' ).on( 'change', function() {
 			bgImage.css( 'background-size', $( this ).val() );
 		});
 
@@ -50,7 +50,7 @@
 		 *
 		 * @return {void}
 		 */
-		$( 'input[name="background-position"]' ).change( function() {
+		$( 'input[name="background-position"]' ).on( 'change', function() {
 			bgImage.css( 'background-position', $( this ).val() );
 		});
 
@@ -61,7 +61,7 @@
 		 *
 		 * @return {void}
 		 */
-		$( 'input[name="background-repeat"]' ).change( function() {
+		$( 'input[name="background-repeat"]' ).on( 'change',  function() {
 			bgImage.css( 'background-repeat', $( this ).is( ':checked' ) ? 'repeat' : 'no-repeat' );
 		});
 
@@ -72,7 +72,7 @@
 		 *
 		 * @return {void}
 		 */
-		$( 'input[name="background-attachment"]' ).change( function() {
+		$( 'input[name="background-attachment"]' ).on( 'change', function() {
 			bgImage.css( 'background-attachment', $( this ).is( ':checked' ) ? 'scroll' : 'fixed' );
 		});
 
@@ -83,7 +83,7 @@
 		 *
 		 * @return {void}
 		 */
-		$('#choose-from-library-link').click( function( event ) {
+		$('#choose-from-library-link').on( 'change', function( event ) {
 			var $el = $(this);
 
 			event.preventDefault();

--- a/src/js/_enqueues/admin/custom-header.js
+++ b/src/js/_enqueues/admin/custom-header.js
@@ -35,7 +35,7 @@
 		 *
 		 * @return {void}
 		 */
-		$('#choose-from-library-link').click( function( event ) {
+		$('#choose-from-library-link').on( 'click', function( event ) {
 			var $el = $(this);
 			event.preventDefault();
 

--- a/src/js/_enqueues/admin/edit-comments.js
+++ b/src/js/_enqueues/admin/edit-comments.js
@@ -850,7 +850,7 @@ window.commentReply = {
 	 */
 	toggle : function(el) {
 		if ( 'none' !== $( el ).css( 'display' ) && ( $( '#replyrow' ).parent().is('#com-reply') || window.confirm( __( 'Are you sure you want to edit this comment?\nThe changes you made will be lost.' ) ) ) ) {
-			$( el ).find( 'button.vim-q' ).click();
+			$( el ).find( 'button.vim-q' ).trigger( 'click' );
 		}
 	},
 
@@ -1298,7 +1298,7 @@ $(document).ready(function(){
 			return function() {
 				var scope = $('select[name="action"]');
 				$('option[value="' + value + '"]', scope).prop('selected', true);
-				$('#doaction').click();
+				$('#doaction').trigger( 'click' );
 			};
 		};
 

--- a/src/js/_enqueues/admin/link.js
+++ b/src/js/_enqueues/admin/link.js
@@ -8,7 +8,7 @@ jQuery(document).ready( function($) {
 
 	var newCat, noSyncChecks = false, syncChecks, catAddAfter;
 
-	$('#link_name').focus();
+	$('#link_name').trigger( 'focus' );
 	// Postboxes.
 	postboxes.add_postbox_toggles('link');
 
@@ -19,7 +19,7 @@ jQuery(document).ready( function($) {
 	 *
 	 * @return {boolean} Always returns false to prevent the default behavior.
 	 */
-	$('#category-tabs a').click(function(){
+	$('#category-tabs a').on( 'click', function(){
 		var t = $(this).attr('href');
 		$(this).parent().addClass('tabs').siblings('li').removeClass('tabs');
 		$('.tabs-panel').hide();
@@ -31,7 +31,7 @@ jQuery(document).ready( function($) {
 		return false;
 	});
 	if ( getUserSetting('cats') )
-		$('#category-tabs a[href="#categories-pop"]').click();
+		$('#category-tabs a[href="#categories-pop"]').trigger( 'click' );
 
 	// Ajax Cat.
 	newCat = $('#newcat').one( 'focus', function() { $(this).val( '' ).removeClass( 'form-input-tip' ); } );
@@ -41,7 +41,7 @@ jQuery(document).ready( function($) {
 	 *
 	 * @return {void}
 	 */
-	$('#link-category-add-submit').click( function() { newCat.focus(); } );
+	$('#link-category-add-submit').on( 'click', function() { newCat.focus(); } );
 
 	/**
 	 * Synchronize category checkboxes.
@@ -82,7 +82,7 @@ jQuery(document).ready( function($) {
 			var t = $($(this).text());
 			t.find( 'label' ).each( function() {
 				var th = $(this), val = th.find('input').val(), id = th.find('input')[0].id, name = $.trim( th.text() ), o;
-				$('#' + id).change( syncChecks );
+				$('#' + id).on( 'change', syncChecks );
 				o = $( '<option value="' +  parseInt( val, 10 ) + '"></option>' ).text( name );
 			} );
 		} );
@@ -108,13 +108,13 @@ jQuery(document).ready( function($) {
 	} );
 
 	// All categories is the default tab, so we delete the user setting.
-	$('a[href="#categories-all"]').click(function(){deleteUserSetting('cats');});
+	$('a[href="#categories-all"]').on( 'click', function(){deleteUserSetting('cats');});
 
 	// Set a preference for the popular categories to cookies.
-	$('a[href="#categories-pop"]').click(function(){setUserSetting('cats','pop');});
+	$('a[href="#categories-pop"]').on( 'click', function(){setUserSetting('cats','pop');});
 
 	if ( 'pop' == getUserSetting('cats') )
-		$('a[href="#categories-pop"]').click();
+		$('a[href="#categories-pop"]').trigger( 'click' );
 
 	/**
 	 * Adds event handler that shows the interface controls to add a new category.
@@ -125,12 +125,12 @@ jQuery(document).ready( function($) {
 	 * @return {boolean} Always returns false to prevent regular link
 	 *                   functionality.
 	 */
-	$('#category-add-toggle').click( function() {
+	$('#category-add-toggle').on( 'click', function() {
 		$(this).parents('div:first').toggleClass( 'wp-hidden-children' );
-		$('#category-tabs a[href="#categories-all"]').click();
-		$('#newcategory').focus();
+		$('#category-tabs a[href="#categories-all"]').trigger( 'click' );
+		$('#newcategory').trigger( 'focus' );
 		return false;
 	} );
 
-	$('.categorychecklist :checkbox').change( syncChecks ).filter( ':checked' ).change();
+	$('.categorychecklist :checkbox').on( 'change', syncChecks ).filter( ':checked' ).trigger( 'change' );
 });

--- a/src/js/_enqueues/admin/media.js
+++ b/src/js/_enqueues/admin/media.js
@@ -46,7 +46,7 @@
 			$( '#find-posts' ).show();
 
 			// Close the dialog when the escape key is pressed.
-			$('#find-posts-input').focus().keyup( function( event ){
+			$('#find-posts-input').trigger( 'focus' ).on( 'keyup', function( event ){
 				if ( event.which == 27 ) {
 					findPosts.close();
 				}

--- a/src/js/_enqueues/admin/plugin-install.js
+++ b/src/js/_enqueues/admin/plugin-install.js
@@ -75,7 +75,7 @@ jQuery( document ).ready( function( $ ) {
 		.on( 'thickbox:removed', function() {
 			// Set focus back to the element that opened the modal dialog.
 			// Note: IE 8 would need this wrapped in a fake setTimeout `0`.
-			$focusedBefore.focus();
+			$focusedBefore.trigger( 'focus' );
 		});
 
 	function iframeLoaded() {
@@ -88,7 +88,7 @@ jQuery( document ).ready( function( $ ) {
 		handleTabbables();
 
 		// Set initial focus on the "Close" button.
-		$firstTabbable.focus();
+		$firstTabbable.trigger( 'focus' );
 
 		/*
 		 * When the "Install" button is disabled (e.g. the Plugin is already installed)
@@ -141,10 +141,10 @@ jQuery( document ).ready( function( $ ) {
 
 		if ( $lastTabbable[0] === event.target && ! event.shiftKey ) {
 			event.preventDefault();
-			$firstTabbable.focus();
+			$firstTabbable.trigger( 'focus' );
 		} else if ( $firstTabbable[0] === event.target && event.shiftKey ) {
 			event.preventDefault();
-			$lastTabbable.focus();
+			$lastTabbable.trigger( 'focus' );
 		}
 	}
 

--- a/src/js/_enqueues/admin/post.js
+++ b/src/js/_enqueues/admin/post.js
@@ -68,7 +68,7 @@ window.wp = window.wp || {};
 						$('#the-comment-list').append( r.responses[0].data );
 
 						theList = theExtraList = null;
-						$( 'a[className*=\':\']' ).unbind();
+						$( 'a[className*=\':\']' ).off();
 
 						// If the offset is over the total number of comments we cannot fetch any more, so hide the button.
 						if ( commentsBox.st > commentsBox.total )
@@ -414,7 +414,7 @@ jQuery(document).ready( function($) {
 		}
 
 		$previewField.val('dopreview');
-		$form.attr( 'target', target ).submit().attr( 'target', '' );
+		$form.attr( 'target', target ).trigger( 'submit' ).attr( 'target', '' );
 
 		// Workaround for WebKit bug preventing a form submitting twice to the same action.
 		// https://bugs.webkit.org/show_bug.cgi?id=28633
@@ -448,7 +448,7 @@ jQuery(document).ready( function($) {
 
 	// Auto save new posts after a title is typed.
 	if ( $( '#auto_draft' ).val() ) {
-		$( '#title' ).blur( function() {
+		$( '#title' ).on( 'blur', function() {
 			var cancel;
 
 			if ( ! this.value || $('#edit-slug-box > *').length ) {
@@ -592,7 +592,7 @@ jQuery(document).ready( function($) {
 		});
 
 		if ( getUserSetting( settingName ) )
-			$('a[href="#' + taxonomy + '-pop"]', '#' + taxonomy + '-tabs').click();
+			$('a[href="#' + taxonomy + '-pop"]', '#' + taxonomy + '-tabs').trigger( 'click' );
 
 		// Add category button controls.
 		$('#new' + taxonomy).one( 'focus', function() {
@@ -600,10 +600,10 @@ jQuery(document).ready( function($) {
 		});
 
 		// On [Enter] submit the taxonomy.
-		$('#new' + taxonomy).keypress( function(event){
+		$('#new' + taxonomy).on( 'keypress', function(event){
 			if( 13 === event.keyCode ) {
 				event.preventDefault();
-				$('#' + taxonomy + '-add-submit').click();
+				$('#' + taxonomy + '-add-submit').trigger( 'click' );
 			}
 		});
 
@@ -1001,7 +1001,7 @@ jQuery(document).ready( function($) {
 			var new_slug = $el.children( 'input' ).val();
 
 			if ( new_slug == $('#editable-post-name-full').text() ) {
-				buttons.children('.cancel').click();
+				buttons.children('.cancel').trigger( 'click' );
 				return;
 			}
 
@@ -1054,11 +1054,11 @@ jQuery(document).ready( function($) {
 			// On [Enter], just save the new slug, don't save the post.
 			if ( 13 === key ) {
 				e.preventDefault();
-				buttons.children( '.save' ).click();
+				buttons.children( '.save' ).trigger( 'click' );
 			}
 			// On [Esc] cancel the editing.
 			if ( 27 === key ) {
-				buttons.children( '.cancel' ).click();
+				buttons.children( '.cancel' ).trigger( 'click' );
 			}
 		} ).on( 'keyup', function() {
 			real_slug.val( this.value );
@@ -1177,7 +1177,7 @@ jQuery(document).ready( function($) {
 			} else {
 				mce = false;
 				offset = $textarea.height() - event.pageY;
-				$textarea.blur();
+				$textarea.trigger( 'blur' );
 			}
 
 			$document.on( 'mousemove.wp-editor-resize', dragging )
@@ -1261,7 +1261,7 @@ jQuery(document).ready( function($) {
 		// Clear the selection and move focus back to the trigger.
 		event.clearSelection();
 		// Handle ClipboardJS focus bug, see https://github.com/zenorocha/clipboard.js/issues/680
-		triggerElement.focus();
+		triggerElement.trigger( 'focus' );
 
 		// Show success visual feedback.
 		clearTimeout( copyAttachmentURLSuccessTimeout );

--- a/src/js/_enqueues/admin/postbox.js
+++ b/src/js/_enqueues/admin/postbox.js
@@ -127,7 +127,7 @@
 				}
 
 				postbox.prevAll( '.postbox:visible' ).eq( 0 ).before( postbox );
-				button.focus();
+				button.trigger( 'focus' );
 				postboxes.updateOrderButtonsProperties();
 				postboxes.save_order( postboxes.page );
 			}
@@ -141,7 +141,7 @@
 				}
 
 				postbox.nextAll( '.postbox:visible' ).eq( 0 ).after( postbox );
-				button.focus();
+				button.trigger( 'focus' );
 				postboxes.updateOrderButtonsProperties();
 				postboxes.save_order( postboxes.page );
 			}

--- a/src/js/_enqueues/admin/privacy-tools.js
+++ b/src/js/_enqueues/admin/privacy-tools.js
@@ -328,7 +328,7 @@ jQuery( document ).ready( function( $ ) {
 	// Label handling to focus the create page button on Privacy settings page.
 	$( 'body.options-privacy-php label[for=create-page]' ).on( 'click', function( e ) {
 		e.preventDefault();
-		$( 'input#create-page' ).focus();
+		$( 'input#create-page' ).trigger( 'focus' );
 	} );
 
 	// Accordion handling in various new Privacy settings pages.

--- a/src/js/_enqueues/admin/tags-box.js
+++ b/src/js/_enqueues/admin/tags-box.js
@@ -188,7 +188,7 @@
 							 * key this will fire the `keyup` event on the input.
 							 */
 							if ( 13 === e.keyCode || 32 === e.keyCode ) {
- 								$( this ).closest( '.tagsdiv' ).find( 'input.newtag' ).focus();
+ 								$( this ).closest( '.tagsdiv' ).find( 'input.newtag' ).trigger( 'focus' );
  							}
 
 							tagBox.userAction = 'remove';
@@ -255,7 +255,7 @@
 			if ( ! a )
 				newtag.val('');
 			if ( 'undefined' == typeof( f ) )
-				newtag.focus();
+				newtag.trigger( 'focus' );
 
 			return false;
 		},
@@ -303,7 +303,7 @@
 				 *
 				 * @return {boolean} Returns false to prevent the default action.
 				 */
-				$( 'a', r ).click( function() {
+				$( 'a', r ).on( 'click', function() {
 					tagBox.userAction = 'add';
 					tagBox.flushTags( $( '#' + tax ), this );
 					return false;
@@ -368,7 +368,7 @@
 				tagBox.quickClicks( this );
 			});
 
-			$( '.tagadd', ajaxtag ).click( function() {
+			$( '.tagadd', ajaxtag ).on( 'click', function() {
 				tagBox.userAction = 'add';
 				tagBox.flushTags( $( this ).closest( '.tagsdiv' ) );
 			});
@@ -385,7 +385,7 @@
 			 *
 			 * @return {void}
 			 */
-			$( 'input.newtag', ajaxtag ).keypress( function( event ) {
+			$( 'input.newtag', ajaxtag ).on( 'keypress', function( event ) {
 				if ( 13 == event.which ) {
 					tagBox.userAction = 'add';
 					tagBox.flushTags( $( this ).closest( '.tagsdiv' ) );
@@ -404,7 +404,7 @@
 			 *
 			 * @return {void}
 			 */
-			$('#post').submit(function(){
+			$('#post').on( 'submit', function(){
 				$('div.tagsdiv').each( function() {
 					tagBox.flushTags(this, false, 1);
 				});
@@ -419,14 +419,14 @@
 			 *
 			 * @return {void}
 			 */
-			$('.tagcloud-link').click(function(){
+			$('.tagcloud-link').on( 'click', function(){
 				// On the first click, fetch the tag cloud and insert it in the DOM.
 				tagBox.get( $( this ).attr( 'id' ) );
 				// Update button state, remove previous click event and attach a new one to toggle the cloud.
 				$( this )
 					.attr( 'aria-expanded', 'true' )
-					.unbind()
-					.click( function() {
+					.off()
+					.on( 'click', function() {
 						$( this )
 							.attr( 'aria-expanded', 'false' === $( this ).attr( 'aria-expanded' ) ? 'true' : 'false' )
 							.siblings( '.the-tagcloud' ).toggle();

--- a/src/js/_enqueues/admin/user-profile.js
+++ b/src/js/_enqueues/admin/user-profile.js
@@ -408,7 +408,7 @@
 				// Repaint icons.
 				if ( typeof wp !== 'undefined' && wp.svgPainter ) {
 					try {
-						colors = $.parseJSON( $this.children( '.icon_colors' ).val() );
+						colors = JSON.parse( $this.children( '.icon_colors' ).val() );
 					} catch ( error ) {}
 
 					if ( colors ) {

--- a/src/js/_enqueues/admin/widgets.js
+++ b/src/js/_enqueues/admin/widgets.js
@@ -81,7 +81,7 @@ window.wpWidgets = {
 				});
 				unsavedWidgetsElements.each( function() {
 					if ( ! $( this ).hasClass( 'open' ) ) {
-						$( this ).find( '.widget-title-action:first' ).click();
+						$( this ).find( '.widget-title-action:first' ).trigger( 'click' );
 					}
 				});
 
@@ -92,7 +92,7 @@ window.wpWidgets = {
 					} else {
 						this.scrollIntoView();
 					}
-					$( this ).find( '.widget-inside :tabbable:first' ).focus();
+					$( this ).find( '.widget-inside :tabbable:first' ).trigger( 'focus' );
 				} );
 
 				event.returnValue = wp.i18n.__( 'The changes you made will be lost if you navigate away from this page.' );

--- a/src/js/_enqueues/deprecated/media-gallery.js
+++ b/src/js/_enqueues/deprecated/media-gallery.js
@@ -10,7 +10,7 @@ jQuery(function($) {
 	/**
 	 * Adds a click event handler to the element with a 'wp-gallery' class.
 	 */
-	$( 'body' ).bind( 'click.wp-gallery', function(e) {
+	$( 'body' ).on( 'click.wp-gallery', function(e) {
 		var target = $( e.target ), id, img_size, nonceValue;
 
 		if ( target.hasClass( 'wp-set-header' ) ) {

--- a/src/js/_enqueues/lib/ajax-response.js
+++ b/src/js/_enqueues/lib/ajax-response.js
@@ -11,7 +11,7 @@ window.wpAjax = jQuery.extend( {
 		q = s.split('?'); if ( q[1] ) { s = q[1]; }
 		pp = s.split('&');
 		for ( i in pp ) {
-			if ( jQuery.isFunction(pp.hasOwnProperty) && !pp.hasOwnProperty(i) ) { continue; }
+			if ( typeof pp.hasOwnProperty === "function" && !pp.hasOwnProperty(i) ) { continue; }
 			p = pp[i].split('=');
 			r[p[0]] = p[1];
 		}

--- a/src/js/_enqueues/lib/ajax-response.js
+++ b/src/js/_enqueues/lib/ajax-response.js
@@ -11,7 +11,7 @@ window.wpAjax = jQuery.extend( {
 		q = s.split('?'); if ( q[1] ) { s = q[1]; }
 		pp = s.split('&');
 		for ( i in pp ) {
-			if ( typeof pp.hasOwnProperty === "function" && !pp.hasOwnProperty(i) ) { continue; }
+			if ( typeof pp.hasOwnProperty === 'function' && !pp.hasOwnProperty(i) ) { continue; }
 			p = pp[i].split('=');
 			r[p[0]] = p[1];
 		}

--- a/src/js/_enqueues/lib/color-picker.js
+++ b/src/js/_enqueues/lib/color-picker.js
@@ -67,7 +67,7 @@
 				 * @return {void}
 				 */
 				change: function( event, ui ) {
-					if ( $.isFunction( self.options.change ) ) {
+					if ( typeof self.options.change === 'function' ) {
 						self.options.change.call( this, event, ui );
 					}
 				},
@@ -189,7 +189,7 @@
 				change: function( event, ui ) {
 					self.toggler.css( { backgroundColor: ui.color.toString() } );
 
-					if ( $.isFunction( self.options.change ) ) {
+					if ( typeof self.options.change === 'function' ) {
 						self.options.change.call( this, event, ui );
 					}
 				}
@@ -257,7 +257,7 @@
 				if ( val === '' || val === '#' ) {
 					self.toggler.css( 'backgroundColor', '' );
 					// Fire clear callback if we have one.
-					if ( $.isFunction( self.options.clear ) ) {
+					if ( typeof self.options.clear === 'function' ) {
 						self.options.clear.call( this, event );
 					}
 				}

--- a/src/js/_enqueues/lib/gallery.js
+++ b/src/js/_enqueues/lib/gallery.js
@@ -42,28 +42,28 @@ jQuery(document).ready(function($) {
 		});
 	};
 
-	$('#asc').click( function( e ) {
+	$('#asc').on( 'click', function( e ) {
 		e.preventDefault();
 		desc = false;
 		sortIt();
 	});
-	$('#desc').click( function( e ) {
+	$('#desc').on( 'click', function( e ) {
 		e.preventDefault();
 		desc = true;
 		sortIt();
 	});
-	$('#clear').click( function( e ) {
+	$('#clear').on( 'click', function( e ) {
 		e.preventDefault();
 		clearAll(1);
 	});
-	$('#showall').click( function( e ) {
+	$('#showall').on( 'click', function( e ) {
 		e.preventDefault();
 		$('#sort-buttons span a').toggle();
 		$('a.describe-toggle-on').hide();
 		$('a.describe-toggle-off, table.slidetoggle').show();
 		$('img.pinkynail').toggle(false);
 	});
-	$('#hideall').click( function( e ) {
+	$('#hideall').on( 'click', function( e ) {
 		e.preventDefault();
 		$('#sort-buttons span a').toggle();
 		$('a.describe-toggle-on').show();
@@ -88,7 +88,7 @@ jQuery(document).ready(function($) {
 	}
 });
 
-jQuery(window).unload( function () { window.tinymce = window.tinyMCE = window.wpgallery = null; } ); // Cleanup.
+jQuery(window).on( 'unload', function () { window.tinymce = window.tinyMCE = window.wpgallery = null; } ); // Cleanup.
 
 /* gallery settings */
 window.tinymce = null;

--- a/src/js/_enqueues/lib/image-edit.js
+++ b/src/js/_enqueues/lib/image-edit.js
@@ -127,7 +127,7 @@
 
 			// Key codes 37 through 40 are the arrow keys.
 			if ( 36 < k && k < 41 ) {
-				$(this).blur();
+				$(this).trigger( 'blur' );
 			}
 
 			// The key code 13 is the Enter key.

--- a/src/js/_enqueues/lib/language-chooser.js
+++ b/src/js/_enqueues/lib/language-chooser.js
@@ -14,7 +14,7 @@ if ( ! $( 'body' ).hasClass( 'language-chooser' ) ) {
 	return;
 }
 
-select.focus().on( 'change', function() {
+select.trigger( 'focus' ).on( 'change', function() {
 	/*
 	 * When a language is selected, set matching translation to continue button
 	 * and attach the language attribute.
@@ -26,7 +26,7 @@ select.focus().on( 'change', function() {
 	});
 });
 
-$( 'form' ).submit( function() {
+$( 'form' ).on( 'submit', function() {
 	// Show spinner for languages that need to be downloaded.
 	if ( ! select.children( 'option:selected' ).data( 'installed' ) ) {
 		$( this ).find( '.step .spinner' ).css( 'visibility', 'visible' );

--- a/src/js/_enqueues/lib/link.js
+++ b/src/js/_enqueues/lib/link.js
@@ -189,7 +189,7 @@
 				 * IE will show a flashing cursor over the dialog.
 				 */
 				window.setTimeout( function() {
-					inputs.url[0].trigger( 'select' );
+					inputs.url[0].select();
 					inputs.url.trigger( 'focus' );
 				} );
 			}

--- a/src/js/_enqueues/lib/link.js
+++ b/src/js/_enqueues/lib/link.js
@@ -181,7 +181,7 @@
 
 			if ( isTouch ) {
 				// Close the onscreen keyboard.
-				inputs.url.focus().blur();
+				inputs.url.trigger( 'focus' ).trigger( 'blur' );
 			} else {
 				/*
 				 * Focus the URL field and highlight its contents.
@@ -189,8 +189,8 @@
 				 * IE will show a flashing cursor over the dialog.
 				 */
 				window.setTimeout( function() {
-					inputs.url[0].select();
-					inputs.url.focus();
+					inputs.url[0].trigger( 'select' );
+					inputs.url.trigger( 'focus' );
 				} );
 			}
 
@@ -557,10 +557,10 @@
 				// wp-link-submit must always be the last focusable element in the dialog.
 				// Following focusable elements will be skipped on keyboard navigation.
 				if ( id === 'wp-link-submit' && ! event.shiftKey ) {
-					inputs.close.focus();
+					inputs.close.trigger( 'focus' );
 					event.preventDefault();
 				} else if ( id === 'wp-link-close' && event.shiftKey ) {
-					inputs.submit.focus();
+					inputs.submit.trigger( 'focus' );
 					event.preventDefault();
 				}
 			}

--- a/src/js/_enqueues/lib/lists.js
+++ b/src/js/_enqueues/lib/lists.js
@@ -271,7 +271,7 @@ wpList = {
 			target:  list.get( 0 )
 		}, settings || {} );
 
-		if ( $.isFunction( settings.confirm ) ) {
+		if ( typeof settings.confirm === 'function' ) {
 			$element = $( '#' + settings.element );
 
 			if ( 'add' !== action ) {
@@ -337,13 +337,13 @@ wpList = {
 		}, wpAjax.unserialize( data[4] || '' ) ) );
 
 		formValues = $( '#' + settings.element + ' :input' ).not( '[name="_ajax_nonce"], [name="_wpnonce"], [name="action"]' );
-		formData   = $.isFunction( formValues.fieldSerialize ) ? formValues.fieldSerialize() : formValues.serialize();
+		formData   = typeof formValues.fieldSerialize === 'function' ? formValues.fieldSerialize() : formValues.serialize();
 
 		if ( formData ) {
 			settings.data += '&' + formData;
 		}
 
-		if ( $.isFunction( settings.addBefore ) ) {
+		if ( typeof settings.addBefore === 'function' ) {
 			settings = settings.addBefore( settings );
 
 			if ( ! settings ) {
@@ -381,7 +381,7 @@ wpList = {
 		};
 
 		settings.complete = function( jqXHR, status ) {
-			if ( $.isFunction( settings.addAfter ) ) {
+			if ( typeof settings.addAfter === 'function' ) {
 				settings.addAfter( returnedResponse, $.extend( {
 					xml:    jqXHR,
 					status: status,
@@ -427,7 +427,7 @@ wpList = {
 			id:          settings.element.split( '-' ).pop()
 		}, wpAjax.unserialize( data[4] || '' ) );
 
-		if ( $.isFunction( settings.delBefore ) ) {
+		if ( typeof settings.delBefore === 'function' ) {
 			settings = settings.delBefore( settings, list );
 
 			if ( ! settings ) {
@@ -466,7 +466,7 @@ wpList = {
 		};
 
 		settings.complete = function( jqXHR, status ) {
-			if ( $.isFunction( settings.delAfter ) ) {
+			if ( typeof settings.delAfter === 'function' ) {
 				$eventTarget.queue( function() {
 					settings.delAfter( returnedResponse, $.extend( {
 						xml:    jqXHR,
@@ -522,7 +522,7 @@ wpList = {
 			dimClass:    settings.dimClass
 		}, wpAjax.unserialize( data[6] || '' ) );
 
-		if ( $.isFunction( settings.dimBefore ) ) {
+		if ( typeof settings.dimBefore === 'function' ) {
 			settings = settings.dimBefore( settings );
 
 			if ( ! settings ) {
@@ -591,7 +591,7 @@ wpList = {
 		};
 
 		settings.complete = function( jqXHR, status ) {
-			if ( $.isFunction( settings.dimAfter ) ) {
+			if ( typeof settings.dimAfter === 'function' ) {
 				$eventTarget.queue( function() {
 					settings.dimAfter( returnedResponse, $.extend( {
 						xml:    jqXHR,

--- a/src/js/_enqueues/lib/nav-menu.js
+++ b/src/js/_enqueues/lib/nav-menu.js
@@ -857,7 +857,7 @@
 
 				if ( e.keyCode === 13 ) {
 					e.preventDefault();
-					$( '#submit-customlinkdiv' ).click();
+					$( '#submit-customlinkdiv' ).trigger( 'click' );
 				}
 			});
 		},
@@ -967,7 +967,7 @@
 				// Remove the Ajax spinner.
 				$( '.customlinkdiv .spinner' ).removeClass( 'is-active' );
 				// Set custom link form back to defaults.
-				$('#custom-menu-item-name').val('').blur();
+				$('#custom-menu-item-name').val('').trigger( 'blur' );
 				$( '#custom-menu-item-url' ).val( '' ).attr( 'placeholder', 'https://' );
 			});
 		},
@@ -1059,7 +1059,7 @@
 				};
 			} else {
 				// Make the post boxes read-only, as they can't be used yet.
-				$( '#menu-settings-column' ).find( 'input,select' ).end().find( 'a' ).attr( 'href', '#' ).unbind( 'click' );
+				$( '#menu-settings-column' ).find( 'input,select' ).end().find( 'a' ).attr( 'href', '#' ).off( 'click' );
 			}
 		},
 
@@ -1141,7 +1141,7 @@
 
 				$.post( ajaxurl, this.href.replace( /.*\?/, '' ).replace( /action=([^&]*)/, '' ) + '&action=menu-get-metabox',
 					function( resp ) {
-						var metaBoxData = $.parseJSON( resp ),
+						var metaBoxData = JSON.parse( resp ),
 							toReplace;
 
 						if ( -1 === resp.indexOf( 'replace-id' ) ) {

--- a/src/js/_enqueues/vendor/jquery/jquery.hotkeys.js
+++ b/src/js/_enqueues/vendor/jquery/jquery.hotkeys.js
@@ -39,7 +39,7 @@ USAGE:
         ".":">",  "/":"?",  "\\":"|" };
 
     this.add = function(combi, options, callback) {
-        if (jQuery.isFunction(options)){
+        if ( typeof options === 'function' ){
             callback = options;
             options = {};
         }

--- a/src/js/_enqueues/vendor/jquery/jquery.serialize-object.js
+++ b/src/js/_enqueues/vendor/jquery/jquery.serialize-object.js
@@ -1,7 +1,7 @@
 /*!
- * jQuery serializeObject - v0.2 - 1/20/2010
+ * jQuery serializeObject - v0.2-wp - 1/20/2010
  * http://benalman.com/projects/jquery-misc-plugins/
- * 
+ *
  * Copyright (c) 2010 "Cowboy" Ben Alman
  * Dual licensed under the MIT and GPL licenses.
  * http://benalman.com/about/license/
@@ -12,20 +12,20 @@
 
 (function($,undefined){
   '$:nomunge'; // Used by YUI compressor.
-  
+
   $.fn.serializeObject = function(){
     var obj = {};
-    
+
     $.each( this.serializeArray(), function(i,o){
       var n = o.name,
         v = o.value;
-        
+
         obj[n] = obj[n] === undefined ? v
-          : $.isArray( obj[n] ) ? obj[n].concat( v )
+          : Array.isArray( obj[n] ) ? obj[n].concat( v )
           : [ obj[n], v ];
     });
-    
+
     return obj;
   };
-  
+
 })(jQuery);

--- a/src/js/_enqueues/vendor/jquery/jquery.table-hotkeys.js
+++ b/src/js/_enqueues/vendor/jquery/jquery.table-hotkeys.js
@@ -14,7 +14,7 @@
 	$.table_hotkeys = function(table, keys, opts) {
 		opts = $.extend($.table_hotkeys.defaults, opts);
 		var selected_class, destructive_class, set_current_row, adjacent_row_callback, get_adjacent_row, adjacent_row, prev_row, next_row, check, get_first_row, get_last_row, make_key_callback, first_row;
-		
+
 		selected_class = opts.class_prefix + opts.selected_suffix;
 		destructive_class = opts.class_prefix + opts.destructive_suffix;
 		set_current_row = function (tr) {
@@ -24,13 +24,13 @@
 			$.table_hotkeys.current_row = tr;
 		};
 		adjacent_row_callback = function(which) {
-			if (!adjacent_row(which) && $.isFunction(opts[which+'_page_link_cb'])) {
+			if (!adjacent_row(which) && typeof opts[which+'_page_link_cb'] === 'function' ) {
 				opts[which+'_page_link_cb']();
 			}
 		};
 		get_adjacent_row = function(which) {
 			var first_row, method;
-			
+
 			if (!$.table_hotkeys.current_row) {
 				first_row = get_first_row();
 				$.table_hotkeys.current_row = first_row;
@@ -65,7 +65,7 @@
 				var clickable = $(expr, $.table_hotkeys.current_row);
 				if (!clickable.length) return false;
 				if (clickable.is('.'+destructive_class)) next_row() || prev_row();
-				clickable.click();
+				clickable.trigger( 'click' );
 			};
 		};
 		first_row = get_first_row();
@@ -79,8 +79,8 @@
 		$.hotkeys.add(opts.mark_key, opts.hotkeys_opts, check);
 		$.each(keys, function() {
 			var callback, key;
-			
-			if ($.isFunction(this[1])) {
+
+			if ( typeof this[1] === 'function' ) {
 				callback = this[1];
 				key = this[0];
 				$.hotkeys.add(key, opts.hotkeys_opts, function(event) { return callback(event, $.table_hotkeys.current_row); });

--- a/src/js/_enqueues/wp/autosave.js
+++ b/src/js/_enqueues/wp/autosave.js
@@ -541,7 +541,7 @@ window.autosave = function() {
 					lastCompareString = getCompareString( postData );
 
 					if ( $( '#title' ).val() !== postData.post_title ) {
-						$( '#title' ).focus().val( postData.post_title || '' );
+						$( '#title' ).trigger( 'focus' ).val( postData.post_title || '' );
 					}
 
 					$( '#excerpt' ).val( postData.excerpt || '' );
@@ -560,8 +560,8 @@ window.autosave = function() {
 					} else {
 
 						// Make sure the Text editor is selected.
-						$( '#content-html' ).click();
-						$( '#content' ).focus();
+						$( '#content-html' ).trigger( 'click' );
+						$( '#content' ).trigger( 'focus' );
 
 						// Using document.execCommand() will let the user undo.
 						document.execCommand( 'selectAll' );

--- a/src/js/_enqueues/wp/dashboard.js
+++ b/src/js/_enqueues/wp/dashboard.js
@@ -154,7 +154,7 @@ jQuery(document).ready( function($) {
 				highlightLatestPost();
 
 				// Focus the title to allow for quickly drafting another post.
-				$('#title').focus();
+				$('#title').trigger( 'focus' );
 			});
 
 			/**
@@ -391,7 +391,7 @@ jQuery( function( $ ) {
 				 * lose their place.
 				 */
 				if ( $target.hasClass( 'community-events-cancel' ) ) {
-					$toggleButton.focus();
+					$toggleButton.trigger( 'focus' );
 				}
 			} else {
 				$toggleButton.attr( 'aria-expanded', 'true' );
@@ -610,7 +610,7 @@ jQuery( function( $ ) {
 					 * bring the focus back to the toggle button so users relying
 					 * on screen readers don't lose their place.
 					 */
-					$toggleButton.focus();
+					$toggleButton.trigger( 'focus' );
 				}
 			} else {
 				app.toggleLocationForm( 'show' );

--- a/src/js/_enqueues/wp/svg-painter.js
+++ b/src/js/_enqueues/wp/svg-painter.js
@@ -160,17 +160,14 @@ wp.svgPainter = ( function( $, window, document, undefined ) {
 					painter.paintElement( $element, 'base' );
 
 					// Set hover callbacks.
-					$menuitem.hover(
-						function() {
-							painter.paintElement( $element, 'focus' );
-						},
-						function() {
-							// Match the delay from hoverIntent.
-							window.setTimeout( function() {
-								painter.paintElement( $element, 'base' );
-							}, 100 );
-						}
-					);
+					$menuitem.on( 'mouseenter', function() {
+						painter.paintElement( $element, 'focus' );
+					} ).on( 'mouseleave', function() {
+						// Match the delay from hoverIntent.
+						window.setTimeout( function() {
+							painter.paintElement( $element, 'base' );
+						}, 100 );
+					} );
 				}
 			});
 		},

--- a/src/js/_enqueues/wp/updates.js
+++ b/src/js/_enqueues/wp/updates.js
@@ -629,7 +629,7 @@
 				setTimeout( function() {
 					$card
 						.removeClass( 'plugin-card-update-failed' )
-						.find( '.column-name a' ).focus();
+						.find( '.column-name a' ).trigger( 'focus' );
 
 					$card.find( '.update-now' )
 						.attr( 'aria-label', false )
@@ -801,7 +801,7 @@
 			setTimeout( function() {
 				$card
 					.removeClass( 'plugin-card-update-failed' )
-					.find( '.column-name a' ).focus();
+					.find( '.column-name a' ).trigger( 'focus' );
 			}, 200 );
 		} );
 
@@ -1215,10 +1215,10 @@
 
 			// Focus on Customize button after updating.
 			if ( isModalOpen ) {
-				$( '.load-customize:visible' ).focus();
+				$( '.load-customize:visible' ).trigger( 'focus' );
 				$( '.theme-info .theme-autoupdate' ).find( '.auto-update-time' ).empty();
 			} else {
-				$theme.find( '.load-customize' ).focus();
+				$theme.find( '.load-customize' ).trigger( 'focus' );
 			}
 		}
 
@@ -1271,7 +1271,7 @@
 		} else {
 			$notice = $( '.theme-info .notice' ).add( $theme.find( '.notice' ) );
 
-			$( 'body.modal-open' ).length ? $( '.load-customize:visible' ).focus() : $theme.find( '.load-customize' ).focus();
+			$( 'body.modal-open' ).length ? $( '.load-customize:visible' ).trigger( 'focus' ) : $theme.find( '.load-customize' ).trigger( 'focus');
 		}
 
 		wp.updates.addAdminNotice( {
@@ -1768,11 +1768,11 @@
 
 			// #upgrade button must always be the last focus-able element in the dialog.
 			if ( 'upgrade' === event.target.id && ! event.shiftKey ) {
-				$( '#hostname' ).focus();
+				$( '#hostname' ).trigger( 'focus' );
 
 				event.preventDefault();
 			} else if ( 'hostname' === event.target.id && event.shiftKey ) {
-				$( '#upgrade' ).focus();
+				$( '#upgrade' ).trigger( 'focus' );
 
 				event.preventDefault();
 			}
@@ -1789,7 +1789,7 @@
 
 		$( 'body' ).addClass( 'modal-open' );
 		$modal.show();
-		$modal.find( 'input:enabled:first' ).focus();
+		$modal.find( 'input:enabled:first' ).trigger( 'focus' );
 		$modal.on( 'keydown', wp.updates.keydown );
 	};
 

--- a/src/js/_enqueues/wp/widgets/text.js
+++ b/src/js/_enqueues/wp/widgets/text.js
@@ -59,7 +59,7 @@ wp.textWidgets = ( function( $ ) {
 				control.customHtmlWidgetPointer.find( '.close' ).on( 'click', function( event ) {
 					event.preventDefault();
 					control.customHtmlWidgetPointer.hide();
-					$( '#' + control.fields.text.attr( 'id' ) + '-html' ).focus();
+					$( '#' + control.fields.text.attr( 'id' ) + '-html' ).trigger( 'focus' );
 					control.dismissPointers( [ 'text_widget_custom_html' ] );
 				});
 				control.customHtmlWidgetPointer.find( '.add-widget' ).on( 'click', function( event ) {
@@ -278,7 +278,7 @@ wp.textWidgets = ( function( $ ) {
 				 */
 				showPointerElement = function( pointerElement ) {
 					pointerElement.show();
-					pointerElement.find( '.close' ).focus();
+					pointerElement.find( '.close' ).trigger( 'focus' );
 					wp.a11y.speak( pointerElement.find( 'h3, p' ).map( function() {
 						return $( this ).text();
 					} ).get().join( '\n\n' ) );

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -827,7 +827,7 @@ function wp_default_scripts( $scripts ) {
 	$scripts->add( 'jquery-color', '/wp-includes/js/jquery/jquery.color.min.js', array( 'jquery' ), '2.1.2', 1 );
 	$scripts->add( 'schedule', '/wp-includes/js/jquery/jquery.schedule.js', array( 'jquery' ), '20m', 1 );
 	$scripts->add( 'jquery-query', '/wp-includes/js/jquery/jquery.query.js', array( 'jquery' ), '2.1.7', 1 );
-	$scripts->add( 'jquery-serialize-object', '/wp-includes/js/jquery/jquery.serialize-object.js', array( 'jquery' ), '0.2', 1 );
+	$scripts->add( 'jquery-serialize-object', '/wp-includes/js/jquery/jquery.serialize-object.js', array( 'jquery' ), '0.2-wp', 1 );
 	$scripts->add( 'jquery-hotkeys', "/wp-includes/js/jquery/jquery.hotkeys$suffix.js", array( 'jquery' ), '0.0.2m', 1 );
 	$scripts->add( 'jquery-table-hotkeys', "/wp-includes/js/jquery/jquery.table-hotkeys$suffix.js", array( 'jquery', 'jquery-hotkeys' ), false, 1 );
 	$scripts->add( 'jquery-touch-punch', '/wp-includes/js/jquery/jquery.ui.touch-punch.js', array( 'jquery-ui-core', 'jquery-ui-mouse' ), '0.2.2', 1 );


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/51812

I apparently just can't get enough of this jQuery stuff :)

Now with 100% more jQuery 3.5 deprecations included in my matching. There were further things, but this close to RC I'm not comfortable making adjustments beyond the simple and safe triggers that are just replacing shorthands with full declarations.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
