### PR TITLE
Fix PHP Warning on PHP7.2 in class-wp-http-curl.php

### DIFF
--- a/src/wp-includes/class-wp-http-curl.php
+++ b/src/wp-includes/class-wp-http-curl.php
@@ -78,6 +78,7 @@ class WP_Http_Curl {
 			'body'        => null,
 			'cookies'     => array(),
 			'decompress'  => false,
+			'filename'    => '',
 		);
 
 		$parsed_args = wp_parse_args( $args, $defaults );

--- a/src/wp-includes/class-wp-http-curl.php
+++ b/src/wp-includes/class-wp-http-curl.php
@@ -77,6 +77,7 @@ class WP_Http_Curl {
 			'headers'     => array(),
 			'body'        => null,
 			'cookies'     => array(),
+			'decompress'  => false,
 		);
 
 		$parsed_args = wp_parse_args( $args, $defaults );

--- a/src/wp-includes/class-wp-http-curl.php
+++ b/src/wp-includes/class-wp-http-curl.php
@@ -78,6 +78,7 @@ class WP_Http_Curl {
 			'body'        => null,
 			'cookies'     => array(),
 			'decompress'  => false,
+			'stream'      => null,
 			'filename'    => '',
 		);
 


### PR DESCRIPTION
Added the default settings parameter 'decompress' with the default value 'false'.
If this array element is not pre-defined it will result in a warning on line 316:
 
if ( true === $parsed_args['decompress'] && ...

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/52622

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
