### PR TITLE
Add variable for admin-bar height

### DIFF
--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -1,3 +1,7 @@
+.admin-bar {
+	--wp-admin-bar-height: 32px;
+}
+
 #wpadminbar * {
 	height: auto;
 	width: auto;
@@ -720,6 +724,11 @@ html:lang(he-il) .rtl #wpadminbar * {
 }
 
 @media screen and (max-width: 782px) {
+
+	.admin-bar {
+		--wp-admin-bar-height: 46px;
+	}
+	
 	/* Toolbar Touchification*/
 	html #wpadminbar {
 		height: 46px;


### PR DESCRIPTION
This adds a variable for the admin-bar height as seen in the 2021 theme but in core for all plugins and themes to utilize.

Trac ticket: https://core.trac.wordpress.org/ticket/52623#ticket
