### PR TITLE
Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Welcome to WordPress Development!
+
+For the in-depth documentation, please visit the [Contributor Handbook](https://make.wordpress.org/core/handbook/contribute/).
+
+## First Time?
+If this is your first time contributing, you may also find reviewing these guides first to be helpful:
+- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
+- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
+- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
+- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
+- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
+- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
+
+## Contributions using GitHub
+
+*If you're looking to report bugs or submit patches to the Block Editor, the [Gutenberg GitHub repository](https://github.com/wordpress/gutenberg/) is the canonical source.*
+
+The [WordPress.org Trac](https://core.trac.wordpress.org) is the official bug tracker for the WordPress Core.
+
+Patches can be submitted within Trac or via [GitHub](https://github.com/wordpress/wordpress-develop).
+
+Please read the [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) page for details on how to submit a pull request in GitHub to fix a Trac ticket.
+
+In particular, note that the full Trac URL of a ticket is required within the PR body and we request that you check the "Allow edits and access to secrets by maintainers" to allow Core contributors easier work with your submission.  
+
+## Questions about Contributing?
+
+The [WordPress Slack instance](https://make.wordpress.org/chat/) is the real-time communication platform. You can also join the conversation via the [Make Network of blogs](https://make.wordpress.org).
+
+For support using WordPress, please visit the [WordPress.org Support Forums](https://wordpress.org/support/)
+
+Thanks for contributing to the WordPress project! We're happy you're here.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,10 @@
 
 For the in-depth documentation, please visit the [Contributor Handbook](https://make.wordpress.org/core/handbook/contribute/).
 
+**Core WordPress Development does not occur on GitHub; however, pull requests are accepted as long there is a corresponding [Trac](https://core.trac.wordpress.org) ticket.**
+
+For WordPress Block Editor development, please see the [Gutenberg GitHub repository](https://github.com/wordpress/gutenberg/).
+
 ## First Time?
 If this is your first time contributing, you may also find reviewing these guides first to be helpful:
 - FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/


### PR DESCRIPTION
Adds a CONTRIBUTING.md to aid in helping direct folks to more information about contributing to WordPress.

Fixes https://core.trac.wordpress.org/ticket/33043

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
