### PR TITLE
Added 'wp_next_scheduled' filter

### DIFF
--- a/src/wp-includes/cron.php
+++ b/src/wp-includes/cron.php
@@ -811,7 +811,7 @@ function wp_next_scheduled( $hook, $args = array() ) {
 		return false;
 	}
 
-	return $next_event->timestamp;
+	return apply_filters( 'wp_next_scheduled', $next_event->timestamp, $next_event, $hook, $args );
 }
 
 /**


### PR DESCRIPTION
Added 'wp_next_scheduled' filter to add the ability to change the wp_next_scheduled() function output.

Trac ticket: https://core.trac.wordpress.org/ticket/52655
