### PR TITLE
Help/About: Try using ResizableBox for the image comparison

### DIFF
--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -9,6 +9,9 @@
 /** WordPress Administration Bootstrap */
 require_once __DIR__ . '/admin.php';
 
+wp_enqueue_script( 'wp-components' );
+wp_enqueue_style( 'wp-components' );
+
 /* translators: Page title of the About WordPress page in the admin. */
 $title = _x( 'About', 'page title' );
 
@@ -130,12 +133,12 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 		</div>
 
 		<div class="about__section has-subtle-background-color">
-			<div class="column about__image">
-				<div class="about__image-comparison">
+			<div class="column about__image" id="about-image-comparison">
+				<div class="about__image-comparison no-js">
+					<img src="https://make.wordpress.org/core/files/2021/02/about-57-color-old.png" />
 					<div class="about__image-comparison-resize">
 						<img src="https://make.wordpress.org/core/files/2021/02/about-57-color-new.png" />
 					</div>
-					<img src="https://make.wordpress.org/core/files/2021/02/about-57-color-old.png" />
 				</div>
 			</div>
 		</div>
@@ -234,9 +237,80 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 			<a href="<?php echo esc_url( self_admin_url() ); ?>"><?php is_blog_admin() ? _e( 'Go to Dashboard &rarr; Home' ) : _e( 'Go to Dashboard' ); ?></a>
 		</div>
 	</div>
-<?php
 
-require_once ABSPATH . 'wp-admin/admin-footer.php';
+<?php require_once ABSPATH . 'wp-admin/admin-footer.php'; ?>
+
+<script>
+	wp.domReady( function() {
+		var createElement = wp.element.createElement;
+		var render = wp.element.render;
+		var useState = wp.element.useState;
+		var ResizableBox = wp.components.ResizableBox;
+
+		var container = document.getElementById( 'about-image-comparison' );
+		var images = container ? container.querySelectorAll( 'img' ) : [];
+		if ( ! images.length ) {
+			// Something's wrong, return early.
+			return;
+		}
+
+		var beforeImage = images.item( 0 );
+		var afterImage = images.item( 1 );
+
+		function ImageComparison( props ) {
+			var stateHelper = useState( props.width );
+			var width = stateHelper[0];
+			var setWidth = stateHelper[1];
+
+			return createElement(
+				'div',
+				{
+					className: 'about__image-comparison'
+				},
+				createElement( 'img', { src: beforeImage.src, alt: '' } ),
+				createElement(
+					ResizableBox,
+					{
+						size: {
+							width: width,
+							height: props.height
+						},
+						onResizeStop: function( event, direction, elt, delta ) {
+							setWidth( parseInt( width + delta.width, 10 ) );
+						},
+						showHandle: true,
+						enable: {
+							top: false,
+							right: true,
+							bottom: false,
+							left: false
+						},
+						className: 'about__image-comparison-resize'
+					},
+					createElement(
+						'div',
+						{
+							style: { width: '100%', height: '100%', overflow: 'hidden' }
+						},
+						createElement('img', { src: afterImage.src, alt: '' } )
+					)
+				)
+			);
+		}
+
+		render(
+			createElement(
+				ImageComparison,
+				{
+					width: beforeImage.clientWidth / 2,
+					height: beforeImage.clientHeight
+				}
+			),
+			container
+		);
+	} );
+</script>
+<?php
 
 // These are strings we may use to describe maintenance/security releases, where we aim for no new strings.
 return;

--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -284,9 +284,9 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 						showHandle: true,
 						enable: {
 							top: false,
-							right: true,
+							right: ! wp.i18n.isRTL(),
 							bottom: false,
-							left: false
+							left: wp.i18n.isRTL(),
 						},
 						className: 'about__image-comparison-resize'
 					},

--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -198,9 +198,9 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 				<h3><?php _e( 'New Robots API' ); ?></h3>
 				<p>
 					<?php
-					_e( 'The new Robots API lets you include the filter directives in the robots meta tag, and the API includes the <code>max-image-preview: large</code> directive by default. That means search engines can show bigger image previews, which can boost your traffic*.'); ?>
+					_e( 'The new Robots API lets you include the filter directives in the robots meta tag, and the API includes the <code>max-image-preview: large</code> directive by default. That means search engines can show bigger image previews, which can boost your traffic (unless the site is marked <em>not-public</em>).' );
+					?>
 				</p>
-				<p><?php _e( '* (unless the site is marked <em>not-public</em>).' ); ?></p>
 			</div>
 			<div class="column">
 				<h3><?php _e( 'Ongoing cleanup after update to jQuery 3.5.1' ); ?></h3>

--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -116,7 +116,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 				</p>
 				<p>
 					<?php
-					_e( '<strong>Social Icons block:</strong> you can now change the size of the icons.' );
+					_e( '<strong>Social Icons block:</strong> now you can change the size of the icons.' );
 					?>
 				</p>
 			</div>

--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -297,7 +297,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 						},
 						createElement('img', { src: afterImage.src, alt: afterImage.alt } )
 					)
-				),
+				)
 			);
 		}
 

--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -93,7 +93,8 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 			</div>
 			<div class="column about__image">
 				<video controls>
-					<source src="https://make.wordpress.org/core/files/2021/02/about-57-drag-drop-image.mp4" type="video/mp4" />
+					<source src="https://s.w.org/images/core/5.7/about-57-drag-drop-image.mp4" type="video/mp4" />
+					<source src="https://s.w.org/images/core/5.7/about-57-drag-drop-image.mp4" type="video/webm" />
 				</video>
 			</div>
 		</div>
@@ -115,12 +116,12 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 				</p>
 				<p>
 					<?php
-					_e( '<strong>Social Icons block:</strong> you can now change the size of the icons in the Social Icons block.' );
+					_e( '<strong>Social Icons block:</strong> you can now change the size of the icons.' );
 					?>
 				</p>
 			</div>
 			<div class="column about__image">
-				<img src="https://make.wordpress.org/core/files/2021/02/about-57-cover-1.jpg" alt="" />
+				<img src="https://s.w.org/images/core/5.7/about-57-cover.jpg" alt="" />
 			</div>
 		</div>
 
@@ -135,9 +136,9 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 		<div class="about__section has-subtle-background-color">
 			<figure class="column about__image" id="about-image-comparison">
 				<div class="about__image-comparison no-js">
-					<img src="https://make.wordpress.org/core/files/2021/02/about-57-color-old.png" alt="<?php esc_attr_e( 'Dashboard with old color scheme.' ); ?>" />
+					<img src="https://s.w.org/images/core/5.7/about-57-color-old.png" alt="<?php esc_attr_e( 'Dashboard with old color scheme.' ); ?>" />
 					<div class="about__image-comparison-resize">
-						<img src="https://make.wordpress.org/core/files/2021/02/about-57-color-new.png" alt="<?php esc_attr_e( 'Dashboard with new color scheme.' ); ?>" />
+						<img src="https://s.w.org/images/core/5.7/about-57-color-new.png" alt="<?php esc_attr_e( 'Dashboard with new color scheme.' ); ?>" />
 					</div>
 				</div>
 				<figcaption><?php _e( 'Above, the Dashboard before and after the color update in 5.7.' ); ?></figcaption>
@@ -197,14 +198,14 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 				<h3><?php _e( 'New Robots API' ); ?></h3>
 				<p>
 					<?php
-					_e( 'The new Robots API lets you include the filter directives in the robots meta tag, and the API includes the directive <code>max-image-preview: large</code> by default. That means search engines can show bigger image previews (unless the blog is marked as not public), which can boost your traffic.' )
-					?>
+					_e( 'The new Robots API lets you include the filter directives in the robots meta tag, and the API includes the <code>max-image-preview: large</code> directive by default. That means search engines can show bigger image previews, which can boost your traffic*.'); ?>
 				</p>
+				<p><?php _e( '* (unless the site is marked <em>not-public</em>).' ); ?></p>
 			</div>
 			<div class="column">
 				<h3><?php _e( 'Ongoing cleanup after update to jQuery 3.5.1' ); ?></h3>
 				<p><?php _e( 'For years jQuery helped make things move on the screen in ways the basic tools couldn’t—but that keeps changing, and so does jQuery.' ); ?></p>
-				<p><?php _e( 'One side effect: it generated a set of cryptic messages on the dashboard that informed only developers. In 5.7, you will get far fewer of those messages, and they will be in plain language.' ); ?></p>
+				<p><?php _e( 'In 5.7, jQuery gets more focused and less intrusive, with fewer messages in the console.' ); ?></p>
 				<h3><?php _e( 'Lazy-load your iframes' ); ?></h3>
 				<p><?php _e( 'Now it’s simple to let iframes lazy-load. Just add the <code>loading="lazy"</code> attribute to iframe tags on the front end.' ); ?></p>
 			</div>

--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -133,14 +133,15 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 		</div>
 
 		<div class="about__section has-subtle-background-color">
-			<div class="column about__image" id="about-image-comparison">
+			<figure class="column about__image" id="about-image-comparison">
 				<div class="about__image-comparison no-js">
-					<img src="https://make.wordpress.org/core/files/2021/02/about-57-color-old.png" />
+					<img src="https://make.wordpress.org/core/files/2021/02/about-57-color-old.png" alt="<?php esc_attr_e( 'Dashboard using old color scheme.' ); ?>" />
 					<div class="about__image-comparison-resize">
-						<img src="https://make.wordpress.org/core/files/2021/02/about-57-color-new.png" />
+						<img src="https://make.wordpress.org/core/files/2021/02/about-57-color-new.png" alt="<?php esc_attr_e( 'Dashboard using new color scheme.' ); ?>" />
 					</div>
 				</div>
-			</div>
+				<figcaption><?php _e( 'Comparison of the Dashboard before and after the color update.' ); ?></figcaption>
+			</figure>
 		</div>
 
 		<div class="about__section has-2-columns has-subtle-background-color">
@@ -243,6 +244,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 <script>
 	wp.domReady( function() {
 		var createElement = wp.element.createElement;
+		var Fragment = wp.element.Fragment;
 		var render = wp.element.render;
 		var useState = wp.element.useState;
 		var ResizableBox = wp.components.ResizableBox;
@@ -256,6 +258,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 
 		var beforeImage = images.item( 0 );
 		var afterImage = images.item( 1 );
+		var caption = container.querySelector( 'figcaption' ).innerText;
 
 		function ImageComparison( props ) {
 			var stateHelper = useState( props.width );
@@ -267,7 +270,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 				{
 					className: 'about__image-comparison'
 				},
-				createElement( 'img', { src: beforeImage.src, alt: '' } ),
+				createElement( 'img', { src: beforeImage.src, alt: beforeImage.alt } ),
 				createElement(
 					ResizableBox,
 					{
@@ -292,19 +295,24 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 						{
 							style: { width: '100%', height: '100%', overflow: 'hidden' }
 						},
-						createElement('img', { src: afterImage.src, alt: '' } )
+						createElement('img', { src: afterImage.src, alt: afterImage.alt } )
 					)
-				)
+				),
 			);
 		}
 
 		render(
 			createElement(
-				ImageComparison,
-				{
-					width: beforeImage.clientWidth / 2,
-					height: beforeImage.clientHeight
-				}
+				Fragment,
+				{},
+				createElement(
+					ImageComparison,
+					{
+						width: beforeImage.clientWidth / 2,
+						height: beforeImage.clientHeight
+					}
+				),
+				createElement( 'figcaption', {}, caption )
 			),
 			container
 		);

--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -135,12 +135,12 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 		<div class="about__section has-subtle-background-color">
 			<figure class="column about__image" id="about-image-comparison">
 				<div class="about__image-comparison no-js">
-					<img src="https://make.wordpress.org/core/files/2021/02/about-57-color-old.png" alt="<?php esc_attr_e( 'Dashboard using old color scheme.' ); ?>" />
+					<img src="https://make.wordpress.org/core/files/2021/02/about-57-color-old.png" alt="<?php esc_attr_e( 'Dashboard with old color scheme.' ); ?>" />
 					<div class="about__image-comparison-resize">
-						<img src="https://make.wordpress.org/core/files/2021/02/about-57-color-new.png" alt="<?php esc_attr_e( 'Dashboard using new color scheme.' ); ?>" />
+						<img src="https://make.wordpress.org/core/files/2021/02/about-57-color-new.png" alt="<?php esc_attr_e( 'Dashboard with new color scheme.' ); ?>" />
 					</div>
 				</div>
-				<figcaption><?php _e( 'Comparison of the Dashboard before and after the color update.' ); ?></figcaption>
+				<figcaption><?php _e( 'Above, the Dashboard before and after the color update in 5.7.' ); ?></figcaption>
 			</figure>
 		</div>
 

--- a/src/wp-admin/css/about.css
+++ b/src/wp-admin/css/about.css
@@ -112,6 +112,11 @@
 	color: var(--text-light);
 }
 
+.about__container .has-accent-background-color a {
+	color: #fff;
+	color: var(--text-light);
+}
+
 .about__container .has-transparent-background-color {
 	background-color: transparent;
 }

--- a/src/wp-admin/css/about.css
+++ b/src/wp-admin/css/about.css
@@ -551,6 +551,11 @@
 	height: auto;
 }
 
+.about__container .about__image figcaption {
+	margin-top: 0.5em;
+	text-align: center;
+}
+
 .about__container .about__image .wp-video {
 	margin-left: auto;
 	margin-right: auto;
@@ -559,7 +564,6 @@
 .about__container .about__image-comparison {
 	position: relative;
 	display: inline-block;
-	line-height: 0;
 	max-width: 100%;
 }
 

--- a/src/wp-admin/css/about.css
+++ b/src/wp-admin/css/about.css
@@ -575,29 +575,25 @@
 }
 
 .about__container .about__image-comparison-resize {
-	position: absolute;
+	position: absolute !important; /* Needed to override inline style on ResizableBox */
 	top: 0;
 	bottom: 0;
 	left: 0;
 	width: 50%;
 	max-width: 100%;
-	overflow: hidden;
-	resize: horizontal;
-	border-right: 2px solid white;
 }
 
-.about__container .about__image-comparison-resize:after {
-	content: "";
-	display: block;
-	position: absolute;
-	right: 0;
-	bottom: 0;
-	width: 20px;
-	height: 20px;
-	font-family: dashicons;
-	font-size: 20px;
-	line-height: 1;
+.about__container .about__image-comparison.no-js .about__image-comparison-resize {
 	overflow: hidden;
+	border-right: 2px solid var(--wp-admin-theme-color);
+}
+
+.about__container .about__image-comparison-resize .components-resizable-box__side-handle::before {
+	width: 4px;
+	right: calc(50% - 2px);
+	transition: none;
+	animation: none;
+	opacity: 1;
 }
 
 .about__container .about__image + h3 {

--- a/src/wp-admin/css/about.css
+++ b/src/wp-admin/css/about.css
@@ -589,6 +589,7 @@
 
 .about__container .about__image-comparison.no-js .about__image-comparison-resize {
 	overflow: hidden;
+	border-right: 2px solid #007cba;
 	border-right: 2px solid var(--wp-admin-theme-color);
 }
 


### PR DESCRIPTION
This is another take on the image comparison UI in the About page. It uses the ResizeableBox from `@wordpress/components` for a draggable resize handle, which should be recognizable from the editor. It's much more obvious, and can be dragged from any point in the line:

![Screen Shot 2021-02-25 at 12 45 26](https://user-images.githubusercontent.com/541093/109195322-5fa6c080-7768-11eb-90a6-5868b913f7a6.png)

This _should_ work back to IE11, but if something happens and the JS can't load, it has a basic (static) presentation:

![Screen Shot 2021-02-25 at 12 51 02](https://user-images.githubusercontent.com/541093/109195324-603f5700-7768-11eb-8a62-f79e4e62cef4.png)

It still needs work for RTL

Trac ticket: https://core.trac.wordpress.org/ticket/52347

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
