### PR TITLE
Switch away from `npx install-changed` to increase the cache performance

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -121,7 +121,7 @@ jobs:
           node --version
 
       - name: Install Dependencies
-        run: npx install-changed --install-command="npm ci"
+        run: npm ci
 
       - name: Run JSHint
         run: npm run grunt jshint

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -84,7 +84,7 @@ jobs:
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
 
       - name: Install Dependencies
-        run: npx install-changed --install-command="npm ci"
+        run: npm ci
 
       - name: Build WordPress
         run: npm run build

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -71,7 +71,7 @@ jobs:
           node --version
 
       - name: Install Dependencies
-        run: npx install-changed --install-command="npm ci"
+        run: npm ci
 
       - name: Run QUnit tests
         run: npm run grunt qunit:compiled

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -120,7 +120,7 @@ jobs:
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
 
       - name: Install Dependencies
-        run: npx install-changed --install-command="npm ci"
+        run: npm ci
 
       - name: Get composer cache directory
         id: composer-cache

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -81,7 +81,7 @@ jobs:
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
 
       - name: Install Dependencies
-        run: npx install-changed --install-command="npm ci"
+        run: npm ci
 
       - name: Docker debug information
         run: |

--- a/.github/workflows/verify-npm-on-windows.yml
+++ b/.github/workflows/verify-npm-on-windows.yml
@@ -67,7 +67,7 @@ jobs:
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
 
       - name: Install Dependencies
-        run: npx install-changed --install-command="npm ci"
+        run: npm ci
 
       - name: Build WordPress
         run: npm run build


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/52660

This reduces the npm installation time from approx 55-60 seconds to approx 25-30 seconds in each run