### PR TITLE
#51734 - Allow the shortcode regex test to run against either src or build

### DIFF
--- a/tests/phpunit/tests/shortcode.php
+++ b/tests/phpunit/tests/shortcode.php
@@ -744,9 +744,22 @@ EOF;
 		return data_whole_posts();
 	}
 
+	/**
+	 * @ticket 34191
+	 */
 	function test_php_and_js_shortcode_attribute_regexes_match() {
+		$file_src   = ABSPATH . 'js/_enqueues/wp/shortcode.js';
+		$file_build = ABSPATH . 'wp-includes/js/shortcode.js';
 
-		$file    = file_get_contents( ABSPATH . 'js/_enqueues/wp/shortcode.js' );
+		$this->assertTrue( file_exists( $file_src ) || file_exists( $file_build ) );
+
+		$path = $file_src;
+
+		if ( file_exists( $file_build ) ) {
+			$path = $file_build;
+		}
+
+		$file    = file_get_contents( $path );
 		$matched = preg_match( '|\s+pattern = (\/.+\/)g;|', $file, $matches );
 		$php     = get_shortcode_atts_regex();
 


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/51734

In [[50441]](https://core.trac.wordpress.org/changeset/50441) the tests were switched to run against `src` by default instead of `build`.

This introduced one issue, the `test_php_and_js_shortcode_attribute_regexes_match()` now fails when run against `build` because it assumes the `js/_enqueues/wp/shortcode.js` file exists, which it does not in `build`. Running the tests against `build` is still possible so we should fix this, especially as existing contributors will see this unless (or until) they switch to using `src` for their tests.

## To test:

1. Delete the `build` directory if you have one
2. Change `ABSPATH` in `wp-tests-config.php` to point to `src`
3. Run `npm run env:restart`
4. Run `npm run test:php -- --filter test_php_and_js_shortcode_attribute_regexes_match` and confirm it passes
5. Change `ABSPATH` in `wp-tests-config.php` to point to `build`
6. Run `npm run env:restart`
7. Run `npm run build`
8. Run `npm run test:php -- --filter test_php_and_js_shortcode_attribute_regexes_match` and confirm it passes