### PR TITLE
Do not store actual HTTP request exception messages in option since they could be encoded

### DIFF
--- a/src/wp-includes/https-detection.php
+++ b/src/wp-includes/https-detection.php
@@ -130,13 +130,13 @@ function wp_update_https_detection_errors() {
 
 		if ( is_wp_error( $unverified_response ) ) {
 			$support_errors->add(
-				$unverified_response->get_error_code(),
-				$unverified_response->get_error_message()
+				'https_request_failed',
+				__( 'HTTPS request failed.' )
 			);
 		} else {
 			$support_errors->add(
 				'ssl_verification_failed',
-				$response->get_error_message()
+				__( 'SSL verification failed.' )
 			);
 		}
 

--- a/tests/phpunit/tests/https-detection.php
+++ b/tests/phpunit/tests/https-detection.php
@@ -56,6 +56,7 @@ class Tests_HTTPS_Detection extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 47577
+	 * @ticket 52484
 	 */
 	public function test_wp_update_https_detection_errors() {
 		// Set HTTP URL, the request below should use its HTTPS version.
@@ -68,22 +69,22 @@ class Tests_HTTPS_Detection extends WP_UnitTestCase {
 		$this->assertSame( array(), get_option( 'https_detection_errors' ) );
 
 		// If initial request fails and request without SSL verification succeeds,
-		// return error with 'ssl_verification_failed' error code.
+		// return 'ssl_verification_failed' error.
 		add_filter( 'pre_http_request', array( $this, 'mock_error_with_sslverify' ), 10, 2 );
 		add_filter( 'pre_http_request', array( $this, 'mock_success_without_sslverify' ), 10, 2 );
 		wp_update_https_detection_errors();
 		$this->assertSame(
-			array( 'ssl_verification_failed' => array( 'Bad SSL certificate.' ) ),
+			array( 'ssl_verification_failed' => array( __( 'SSL verification failed.' ) ) ),
 			get_option( 'https_detection_errors' )
 		);
 
 		// If both initial request and request without SSL verification fail,
-		// return actual error from request.
+		// return 'https_request_failed' error.
 		add_filter( 'pre_http_request', array( $this, 'mock_error_with_sslverify' ), 10, 2 );
 		add_filter( 'pre_http_request', array( $this, 'mock_error_without_sslverify' ), 10, 2 );
 		wp_update_https_detection_errors();
 		$this->assertSame(
-			array( 'bad_ssl_certificate' => array( 'Bad SSL certificate.' ) ),
+			array( 'https_request_failed' => array( __( 'HTTPS request failed.' ) ) ),
 			get_option( 'https_detection_errors' )
 		);
 


### PR DESCRIPTION
This patch changes the logic in `update_https_detection_errors()` to never store error messages from the actual request since they could be UTF-8 encoded, which would make storing them in an option potentially fail, leading WordPress to then falsely assume that HTTPS is supported.

While this doesn't actually fix the encoding issue, it is not crucial to do so anyway, since these messages are not used anywhere. A simple differentiation between whether the overall HTTPS request or only the SSL verification failed should be sufficient.

Trac ticket: https://core.trac.wordpress.org/ticket/52484

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
