### PR TITLE
match urls without a dot in the initial chunk, e.g. http://localhost …

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -800,9 +800,12 @@ function xmlrpc_removepostdata( $content ) {
 function wp_extract_urls( $content ) {
 	preg_match_all(
 		"#([\"']?)("
-			. '(?:([\w-]+:)?//?)'
+			. '(?:'
+				. '(?:(?<=\s)/{1,2})|'
+				. '(?:^/)|'
+				. '(?:(?:[.\w-]+:)?//)'
+			. ')'
 			. '[^\s()<>]+'
-			. '[.]'
 			. '(?:'
 				. '\([\w\d]+\)|'
 				. '(?:'

--- a/tests/phpunit/tests/functions.php
+++ b/tests/phpunit/tests/functions.php
@@ -844,6 +844,11 @@ class Tests_Functions extends WP_UnitTestCase {
 			'ftp://127.0.0.1/',
 			'http://www.woo.com/video?v=exvUH2qKLTU',
 			'http://taco.com?burrito=enchilada#guac',
+			'http://localhost.tld/?p=3',
+			'http://localhost/?p=3',
+			'http://localhost:8888/?p=3',
+			'//localhost:8888',
+			'/some/path'
 		);
 
 		$blob = '
@@ -906,6 +911,13 @@ class Tests_Functions extends WP_UnitTestCase {
 			http://www.woo.com/video?v=exvUH2qKLTU
 
 			http://taco.com?burrito=enchilada#guac
+
+			http://localhost.tld/?p=3
+			http://localhost/?p=3
+			http://localhost:8888/?p=3
+			//localhost:8888
+
+			/some/path
 		';
 
 		$urls = wp_extract_urls( $blob );


### PR DESCRIPTION
Patch in response to "#52235 (wp_extract_urls doesn't match localhost)" at https://core.trac.wordpress.org/ticket/52235

Adds matching to strings without a dot in the initial chunk so it now matches strings like "//localhost" and "http://localhost:8888".

I found that my initial solution caused unit tests for _doEnclose.php_ to fail, so it also matches strings with an opening slash like "/path/to/file" but not "path/to/file" to avoid misidentifying strings like "red/green".