### PR TITLE
51423: WP_User_Search::$page data type mismatch fix for PHP 8

### DIFF
--- a/src/wp-admin/includes/deprecated.php
+++ b/src/wp-admin/includes/deprecated.php
@@ -497,7 +497,7 @@ class WP_User_Search {
 
 		$this->search_term = wp_unslash( $search_term );
 		$this->raw_page = ( '' == $page ) ? false : (int) $page;
-		$this->page = (int) ( '' == $page ) ? 1 : $page;
+		$this->page = ( '' == $page ) ? 1 : (int) $page;
 		$this->role = $role;
 
 		$this->prepare_query();


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/51423

Fixes a data type bug as well as correcting the expected data type for the `WP_User_Search::$page` property.

The property's type is integer. However, there's a bug in the constructor where the the parentheses are around the conditional expression instead of around the entire ternary. As such, the type cast to int applies to the boolean returned from the conditional expression and then to the result of the entire ternary.

```php
$this->page = (int) ( '' == $page ) ? 1 : $page;
```

There are 2 ways to fix this:

- Option 1: Wrap the entire ternary in parentheses and then type cast the return of it
```php
$this->page = (int) ( '' == $page ? 1 : $page );
```
- Option 2:Type cast the value of the variable `$page` in the else part of the ternary
```php
$this->page = '' == $page ? 1 : (int) $page;
```

Option 2 is preferred. Why? The `true` part of the ternary is already an integer. Plus, applying the type cast to the appropriate is more readable than option 1.

This PR uses option 2.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
