### PR TITLE
Update BrowseHappy notice for IE users

### DIFF
--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -1026,33 +1026,23 @@ a.rsswidget {
 }
 
 #dashboard_browser_nag p.browser-update-nag.has-browser-icon {
-	padding-right: 125px;
+	padding-right: 128px;
 }
 
 #dashboard_browser_nag .browser-icon {
-	margin-top: -35px;
-}
-
-#dashboard_browser_nag.postbox.browser-insecure {
-	background-color: #b32d2e;
-	border-color: #b32d2e;
+	margin-top: -32px;
 }
 
 #dashboard_browser_nag.postbox {
-	background-color: #dba617;
+	background-color: #b32d2e;
 	background-image: none;
-	border-color: #f0c33c;
+	border-color: #b32d2e;
 	color: #fff;
 	box-shadow: none;
 }
 
-#dashboard_browser_nag.postbox.browser-insecure h2 {
-	border-bottom-color: #e65054;
-	color: #fff;
-}
-
 #dashboard_browser_nag.postbox h2 {
-	border-bottom-color: #f5e6ab;
+	border-bottom-color: transparent;
 	background: transparent none;
 	color: #fff;
 	box-shadow: none;
@@ -1060,6 +1050,10 @@ a.rsswidget {
 
 #dashboard_browser_nag a {
 	color: #fff;
+}
+
+#dashboard_browser_nag.postbox .postbox-header {
+	border-color: transparent;
 }
 
 #dashboard_browser_nag h2.hndle {

--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -865,10 +865,6 @@ body #dashboard-widgets .postbox form .submit {
 
 /* Browse happy box */
 
-#dashboard-widgets #dashboard_browser_nag.postbox .inside {
-	margin: 10px;
-}
-
 .postbox .button-link .edit-box {
 	display: none;
 }
@@ -1025,31 +1021,42 @@ a.rsswidget {
 	text-decoration: underline;
 }
 
-#dashboard_browser_nag p.browser-update-nag.has-browser-icon {
-	padding-right: 128px;
+#dashboard_browser_nag.postbox {
+	background-color: #f2d675;
+	background-image: none;
+	border-color: #f2d675;
+	color: #000;
+	box-shadow: none;
+}
+
+#dashboard_browser_nag.postbox.browser-insecure {
+	background-color: #b32d2e;
+	border-color: #b32d2e;
+	color: #fff;
+}
+
+#dashboard_browser_nag .inside {
+	display: flex;
+	margin-top: 0;
 }
 
 #dashboard_browser_nag .browser-icon {
-	margin-top: -32px;
-}
-
-#dashboard_browser_nag.postbox {
-	background-color: #b32d2e;
-	background-image: none;
-	border-color: #b32d2e;
-	color: #fff;
-	box-shadow: none;
+	margin-left: 16px;
 }
 
 #dashboard_browser_nag.postbox h2 {
 	border-bottom-color: transparent;
 	background: transparent none;
-	color: #fff;
+	color: currentColor;
 	box-shadow: none;
 }
 
 #dashboard_browser_nag a {
-	color: #fff;
+	color: currentColor;
+}
+
+#dashboard_browser_nag.postbox .postbox-header {
+	border-color: transparent;
 }
 
 #dashboard_browser_nag.postbox .postbox-header {

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1626,7 +1626,7 @@ function wp_dashboard_browser_nag() {
 
 	if ( $response ) {
 		if ( $is_IE ) {
-			$msg = __( "For the best WordPress experience, please use Microsoft Edge or another modern browser instead of Internet Explorer." );
+			$msg = __( 'For the best WordPress experience, please use Microsoft Edge or another modern browser instead of Internet Explorer.' );
 		} elseif ( $response['insecure'] ) {
 			$msg = sprintf(
 				/* translators: %s: Browser name and link. */

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1613,13 +1613,21 @@ function wp_dashboard_quota() {
  * Displays the browser update nag.
  *
  * @since 3.2.0
+ * @since 5.8.0 Display special message for Internet Explorer users.
+ *
+ * @global bool $is_IE
+ *
  */
 function wp_dashboard_browser_nag() {
+	global $is_IE;
+
 	$notice   = '';
 	$response = wp_check_browser_version();
 
 	if ( $response ) {
-		if ( $response['insecure'] ) {
+		if ( $is_IE ) {
+			$msg = __( "For the best WordPress experience, please use Microsoft Edge or another modern browser instead of Internet Explorer." );
+		} elseif ( $response['insecure'] ) {
 			$msg = sprintf(
 				/* translators: %s: Browser name and link. */
 				__( "It looks like you're using an insecure version of %s. Using an outdated browser makes your computer unsafe. For the best WordPress experience, please update your browser." ),
@@ -1637,7 +1645,7 @@ function wp_dashboard_browser_nag() {
 		if ( ! empty( $response['img_src'] ) ) {
 			$img_src = ( is_ssl() && ! empty( $response['img_src_ssl'] ) ) ? $response['img_src_ssl'] : $response['img_src'];
 
-			$notice           .= '<div class="alignright browser-icon"><a href="' . esc_attr( $response['update_url'] ) . '"><img src="' . esc_attr( $img_src ) . '" alt="" /></a></div>';
+			$notice .= '<div class="alignright browser-icon"><img src="' . esc_attr( $img_src ) . '" alt="" /></div>';
 			$browser_nag_class = ' has-browser-icon';
 		}
 		$notice .= "<p class='browser-update-nag{$browser_nag_class}'>{$msg}</p>";
@@ -1648,13 +1656,23 @@ function wp_dashboard_browser_nag() {
 			$browsehappy = add_query_arg( 'locale', $locale, $browsehappy );
 		}
 
-		$notice .= '<p>' . sprintf(
-			/* translators: 1: Browser update URL, 2: Browser name, 3: Browse Happy URL. */
-			__( '<a href="%1$s" class="update-browser-link">Update %2$s</a> or learn how to <a href="%3$s" class="browse-happy-link">browse happy</a>' ),
-			esc_attr( $response['update_url'] ),
-			esc_html( $response['name'] ),
-			esc_url( $browsehappy )
-		) . '</p>';
+		if ( $is_IE ) {
+			$msg_browsehappy = sprintf(
+				/* translators: %s: Browse Happy URL. */
+				__( 'Learn how to <a href="%s" class="update-browser-link">browse happy</a>' ),
+				esc_url( $browsehappy )
+			);
+		} else {
+			$msg_browsehappy = sprintf(
+				/* translators: 1: Browser update URL, 2: Browser name, 3: Browse Happy URL. */
+				__( '<a href="%1$s" class="update-browser-link">Update %2$s</a> or learn how to <a href="%3$s" class="browse-happy-link">browse happy</a>' ),
+				esc_attr( $response['update_url'] ),
+				esc_html( $response['name'] ),
+				esc_url( $browsehappy )
+			);
+		}
+
+		$notice .= '<p>' . $msg_browsehappy . '</p>';
 		$notice .= '<p class="hide-if-no-js"><a href="" class="dismiss" aria-label="' . esc_attr__( 'Dismiss the browser warning panel' ) . '">' . __( 'Dismiss' ) . '</a></p>';
 		$notice .= '<div class="clear"></div>';
 	}

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1641,14 +1641,8 @@ function wp_dashboard_browser_nag() {
 			);
 		}
 
-		$browser_nag_class = '';
-		if ( ! empty( $response['img_src'] ) ) {
-			$img_src = ( is_ssl() && ! empty( $response['img_src_ssl'] ) ) ? $response['img_src_ssl'] : $response['img_src'];
-
-			$notice .= '<div class="alignright browser-icon"><img src="' . esc_attr( $img_src ) . '" alt="" /></div>';
-			$browser_nag_class = ' has-browser-icon';
-		}
-		$notice .= "<p class='browser-update-nag{$browser_nag_class}'>{$msg}</p>";
+		$notice .= '<div>';
+		$notice .= "<p class='browser-update-nag'>{$msg}</p>";
 
 		$browsehappy = 'https://browsehappy.com/';
 		$locale      = get_user_locale();
@@ -1674,7 +1668,13 @@ function wp_dashboard_browser_nag() {
 
 		$notice .= '<p>' . $msg_browsehappy . '</p>';
 		$notice .= '<p class="hide-if-no-js"><a href="" class="dismiss" aria-label="' . esc_attr__( 'Dismiss the browser warning panel' ) . '">' . __( 'Dismiss' ) . '</a></p>';
-		$notice .= '<div class="clear"></div>';
+		$notice .= '</div>';
+
+		if ( ! empty( $response['img_src'] ) ) {
+			$img_src = ( is_ssl() && ! empty( $response['img_src_ssl'] ) ) ? $response['img_src_ssl'] : $response['img_src'];
+
+			$notice .= '<div class="browser-icon"><img src="' . esc_attr( $img_src ) . '" alt="" /></div>';
+		}
 	}
 
 	/**


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/48743

When using IE:
<img width="620" alt="Screen Shot 2021-03-12 at 1 15 46 PM" src="https://user-images.githubusercontent.com/541093/110984716-8143a280-8339-11eb-9c72-ef2f518efc04.png">

When using an insecure browser:
<img width="620" alt="Screen Shot 2021-03-12 at 1 17 05 PM" src="https://user-images.githubusercontent.com/541093/110984719-81dc3900-8339-11eb-9fc9-7d15149f05cf.png">

Outdated but not insecure browser:
<img width="631" alt="Screen Shot 2021-03-12 at 1 17 29 PM" src="https://user-images.githubusercontent.com/541093/110984723-8274cf80-8339-11eb-8a21-1a5a592c5335.png">

This PR iterates on @sabernhardt's patch - I brought back the yellow background for non-insecure notices, with black text for contrast - I think it's worth using the "warning" style instead of red/error, just to avoid over-saturating the user with alerts.

Additionally I swapped out the floating image for a flexbox layout, which also does away with needing to juggle padding & margins. The source order has been updated (it's now "text image"), but if we need to keep it as-is (for back compat?), I can adjust the flex code.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
