### PR TITLE
[PHP 8.1] MySQLi error reporting value changes

### DIFF
--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -1628,6 +1628,10 @@ class wpdb {
 		$client_flags = defined( 'MYSQL_CLIENT_FLAGS' ) ? MYSQL_CLIENT_FLAGS : 0;
 
 		if ( $this->use_mysqli ) {
+			// Set the MySQLi error reporting off because WordPress handles
+			// its own. This is due to default value change in PHP 8.1.
+			mysqli_report( MYSQLI_REPORT_OFF );
+
 			$this->dbh = mysqli_init();
 
 			$host    = $this->dbhost;


### PR DESCRIPTION
In PHP 8.1, the default error reporting is set to always throw an exception, as opposed to emitting a warning. WordPress gracefully handles the database errors by inspecting the error codes.

 - [PHP 8.1: MySQLi: Default error mode set to exceptions](https://php.watch/versions/8.1/mysqli-error-mode)
 - [RFC](https://wiki.php.net/rfc/mysqli_default_errmode)

I suggest that WordPress set the error reporting mode to off, which is the default value prior to this change. Unless we do this, any bad MySQLi connection will throw an exception, leading to a WSOD, or a blank page with the uncaught exception error.

Trac ticket: https://core.trac.wordpress.org/ticket/52825