### PR TITLE
51423: 'limited_email_domains' option to string fix for PHP 8

### DIFF
--- a/src/wp-admin/network/settings.php
+++ b/src/wp-admin/network/settings.php
@@ -254,14 +254,16 @@ if ( isset( $_GET['updated'] ) ) {
 				<td>
 					<?php
 					$limited_email_domains = get_site_option( 'limited_email_domains' );
-					$limited_email_domains = str_replace( ' ', "\n", $limited_email_domains );
 
-					if ( $limited_email_domains ) {
-						$limited_email_domains = implode( "\n", (array) $limited_email_domains );
+					$limited_email_domains_string = '';
+					if ( is_array( $limited_email_domains ) ) {
+						$limited_email_domains_string = implode( "\n", $limited_email_domains );
+					} elseif ( is_string( $limited_email_domains ) ) {
+						$limited_email_domains_string = str_replace( ' ', "\n", $limited_email_domains );
 					}
 					?>
 					<textarea name="limited_email_domains" id="limited_email_domains" aria-describedby="limited-email-domains-desc" cols="45" rows="5">
-<?php echo esc_textarea( $limited_email_domains ); ?></textarea>
+<?php echo esc_textarea( $limited_email_domains_string ); ?></textarea>
 					<p class="description" id="limited-email-domains-desc">
 						<?php _e( 'If you want to limit site registrations to certain domains. One domain per line.' ); ?>
 					</p>

--- a/src/wp-admin/network/settings.php
+++ b/src/wp-admin/network/settings.php
@@ -254,10 +254,14 @@ if ( isset( $_GET['updated'] ) ) {
 				<td>
 					<?php
 					$limited_email_domains = get_site_option( 'limited_email_domains' );
-					$limited_email_domains = str_replace( ' ', "\n", $limited_email_domains );
+					if ( is_null( $limited_email_domains ) ) {
+						$limited_email_domains = '';
+					} else {
+						$limited_email_domains = str_replace( ' ', "\n", $limited_email_domains );
 
-					if ( $limited_email_domains ) {
-						$limited_email_domains = implode( "\n", (array) $limited_email_domains );
+						if ( $limited_email_domains ) {
+							$limited_email_domains = implode( "\n", (array) $limited_email_domains );
+						}
 					}
 					?>
 					<textarea name="limited_email_domains" id="limited_email_domains" aria-describedby="limited-email-domains-desc" cols="45" rows="5">

--- a/src/wp-admin/network/settings.php
+++ b/src/wp-admin/network/settings.php
@@ -254,6 +254,8 @@ if ( isset( $_GET['updated'] ) ) {
 				<td>
 					<?php
 					$limited_email_domains = get_site_option( 'limited_email_domains' );
+
+					// Guard for null to prevent PHP 8.1+ deprecation notice.
 					if ( is_null( $limited_email_domains ) ) {
 						$limited_email_domains = '';
 					} else {

--- a/src/wp-admin/network/settings.php
+++ b/src/wp-admin/network/settings.php
@@ -259,8 +259,8 @@ if ( isset( $_GET['updated'] ) ) {
 					} else {
 						$limited_email_domains = str_replace( ' ', "\n", $limited_email_domains );
 
-						if ( ! empty( $limited_email_domains ) ) {
-							$limited_email_domains = implode( "\n", (array) $limited_email_domains );
+						if ( is_array( $limited_email_domains ) ) {
+							$limited_email_domains = implode( "\n", $limited_email_domains );
 						}
 					}
 					?>

--- a/src/wp-admin/network/settings.php
+++ b/src/wp-admin/network/settings.php
@@ -259,7 +259,7 @@ if ( isset( $_GET['updated'] ) ) {
 					} else {
 						$limited_email_domains = str_replace( ' ', "\n", $limited_email_domains );
 
-						if ( $limited_email_domains ) {
+						if ( ! empty( $limited_email_domains ) ) {
 							$limited_email_domains = implode( "\n", (array) $limited_email_domains );
 						}
 					}

--- a/src/wp-admin/network/settings.php
+++ b/src/wp-admin/network/settings.php
@@ -242,7 +242,16 @@ if ( isset( $_GET['updated'] ) ) {
 			<tr>
 				<th scope="row"><label for="illegal_names"><?php _e( 'Banned Names' ); ?></label></th>
 				<td>
-					<input name="illegal_names" type="text" id="illegal_names" aria-describedby="illegal-names-desc" class="large-text" value="<?php echo esc_attr( implode( ' ', (array) get_site_option( 'illegal_names' ) ) ); ?>" size="45" />
+					<?php
+					$illegal_names = get_site_option( 'illegal_names' );
+
+					if ( empty( $illegal_names ) ) {
+						$illegal_names = '';
+					} elseif ( is_array( $illegal_names ) ) {
+						$illegal_names = implode( ' ', $illegal_names );
+					}
+					?>
+					<input name="illegal_names" type="text" id="illegal_names" aria-describedby="illegal-names-desc" class="large-text" value="<?php echo esc_attr( $illegal_names ); ?>" size="45" />
 					<p class="description" id="illegal-names-desc">
 						<?php _e( 'Users are not allowed to register these sites. Separate names by spaces.' ); ?>
 					</p>
@@ -279,8 +288,10 @@ if ( isset( $_GET['updated'] ) ) {
 					<?php
 					$banned_email_domains = get_site_option( 'banned_email_domains' );
 
-					if ( $banned_email_domains ) {
-						$banned_email_domains = implode( "\n", (array) $banned_email_domains );
+					if ( empty( $banned_email_domains ) ) {
+						$banned_email_domains = '';
+					} elseif ( is_array( $banned_email_domains ) ) {
+						$banned_email_domains = implode( "\n", $banned_email_domains );
 					}
 					?>
 					<textarea name="banned_email_domains" id="banned_email_domains" aria-describedby="banned-email-domains-desc" cols="45" rows="5">

--- a/src/wp-admin/network/settings.php
+++ b/src/wp-admin/network/settings.php
@@ -254,16 +254,14 @@ if ( isset( $_GET['updated'] ) ) {
 				<td>
 					<?php
 					$limited_email_domains = get_site_option( 'limited_email_domains' );
+					$limited_email_domains = str_replace( ' ', "\n", $limited_email_domains );
 
-					$limited_email_domains_string = '';
-					if ( is_array( $limited_email_domains ) ) {
-						$limited_email_domains_string = implode( "\n", $limited_email_domains );
-					} elseif ( is_string( $limited_email_domains ) ) {
-						$limited_email_domains_string = str_replace( ' ', "\n", $limited_email_domains );
+					if ( $limited_email_domains ) {
+						$limited_email_domains = implode( "\n", (array) $limited_email_domains );
 					}
 					?>
 					<textarea name="limited_email_domains" id="limited_email_domains" aria-describedby="limited-email-domains-desc" cols="45" rows="5">
-<?php echo esc_textarea( $limited_email_domains_string ); ?></textarea>
+<?php echo esc_textarea( $limited_email_domains ); ?></textarea>
 					<p class="description" id="limited-email-domains-desc">
 						<?php _e( 'If you want to limit site registrations to certain domains. One domain per line.' ); ?>
 					</p>

--- a/src/wp-admin/network/settings.php
+++ b/src/wp-admin/network/settings.php
@@ -255,8 +255,7 @@ if ( isset( $_GET['updated'] ) ) {
 					<?php
 					$limited_email_domains = get_site_option( 'limited_email_domains' );
 
-					// Guard for null to prevent PHP 8.1+ deprecation notice.
-					if ( is_null( $limited_email_domains ) ) {
+					if ( empty( $limited_email_domains ) ) {
 						$limited_email_domains = '';
 					} else {
 						$limited_email_domains = str_replace( ' ', "\n", $limited_email_domains );


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/51423

File: `wp-admin/network/settings.php`
Code: prepping `'limited_email_domains'` option for textarea field

No fix is needed for PHP 8.0.x and earlier. This PR is for code improvements and guarding for PHP 8.1:

- For 8.1, null will generate a deprecation. Fix in this PR checks for null and then sets to an empty string. This fix is an opportunity to guard for the future deprecation.

- The implode is not necessary when not an array. For better quality and stability, check if an array and if yes, then do the implode.

Reference:
- PR #720 
- Gist: https://gist.github.com/jrfnl/ca6ed0642e839e2ca8711bc2a389c01b (not valid)
- Gist: https://gist.github.com/jrfnl/106ff1b0585f88862e5bb030a332be72 (valid)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
