### PR TITLE
52892: Privacy Export Personal Data: JSON encoding failure generates invalid JSON in export file

### DIFF
--- a/src/wp-admin/includes/privacy-tools.php
+++ b/src/wp-admin/includes/privacy-tools.php
@@ -400,9 +400,9 @@ function wp_privacy_generate_personal_data_export_file( $request_id ) {
 
 	// Convert the groups to JSON format.
 	$groups_json = wp_json_encode( $groups );
-	if ( false === $groups_json ) {
-		wp_send_json_error( __( 'Unable to encode the export file (JSON report).' ) );
-	}
+//	if ( false === $groups_json ) {
+//		wp_send_json_error( __( 'Unable to encode the export file (JSON report).' ) );
+//	}
 
 	/*
 	 * Handle the JSON export.

--- a/src/wp-admin/includes/privacy-tools.php
+++ b/src/wp-admin/includes/privacy-tools.php
@@ -402,6 +402,14 @@ function wp_privacy_generate_personal_data_export_file( $request_id ) {
 	$groups_json = wp_json_encode( $groups );
 	if ( false === $groups_json ) {
 		$groups_json = '"false"';
+
+		// Get the error message.
+		$last_error_code    = json_last_error();
+		$json_error_message = JSON_ERROR_NONE === $last_error_code || empty( $last_error_code )
+			? __( 'Unable to encode the export file (JSON report)' )
+			: json_last_error_msg();
+
+		_doing_it_wrong( 'privacy_export_personal_data_json_encode_error', $json_error_message, '5.8.0' );
 	}
 
 	/*

--- a/src/wp-admin/includes/privacy-tools.php
+++ b/src/wp-admin/includes/privacy-tools.php
@@ -400,6 +400,9 @@ function wp_privacy_generate_personal_data_export_file( $request_id ) {
 
 	// Convert the groups to JSON format.
 	$groups_json = wp_json_encode( $groups );
+	if ( false === $groups_json ) {
+		wp_send_json_error( __( 'Unable to encode the export file (JSON report).' ) );
+	}
 
 	/*
 	 * Handle the JSON export.

--- a/src/wp-admin/includes/privacy-tools.php
+++ b/src/wp-admin/includes/privacy-tools.php
@@ -400,9 +400,9 @@ function wp_privacy_generate_personal_data_export_file( $request_id ) {
 
 	// Convert the groups to JSON format.
 	$groups_json = wp_json_encode( $groups );
-//	if ( false === $groups_json ) {
-//		wp_send_json_error( __( 'Unable to encode the export file (JSON report).' ) );
-//	}
+	if ( false === $groups_json ) {
+		$groups_json = '"false"';
+	}
 
 	/*
 	 * Handle the JSON export.

--- a/src/wp-admin/includes/privacy-tools.php
+++ b/src/wp-admin/includes/privacy-tools.php
@@ -401,13 +401,15 @@ function wp_privacy_generate_personal_data_export_file( $request_id ) {
 	// Convert the groups to JSON format.
 	$groups_json = wp_json_encode( $groups );
 	if ( false === $groups_json ) {
-		// Get the error message.
-		$last_error_code    = json_last_error();
-		$json_error_message = JSON_ERROR_NONE === $last_error_code || empty( $last_error_code )
-			? __( 'Unable to encode the export file (JSON report)' )
-			: json_last_error_msg();
+		$error_message = __( 'Unable to encode the personal data for export.' );
 
-		wp_send_json_error( $json_error_message );
+		// Get the error message.
+		$last_error_code = json_last_error();
+		if ( JSON_ERROR_NONE === $last_error_code || empty( $last_error_code ) ) {
+			$error_message .= ' ' . json_last_error_msg();
+		}
+
+		wp_send_json_error( $error_message );
 	}
 
 	/*

--- a/src/wp-admin/includes/privacy-tools.php
+++ b/src/wp-admin/includes/privacy-tools.php
@@ -401,13 +401,11 @@ function wp_privacy_generate_personal_data_export_file( $request_id ) {
 	// Convert the groups to JSON format.
 	$groups_json = wp_json_encode( $groups );
 	if ( false === $groups_json ) {
-		$error_message = __( 'Unable to encode the personal data for export.' );
-
-		// Get the error message.
-		$last_error_code = json_last_error();
-		if ( JSON_ERROR_NONE === $last_error_code || empty( $last_error_code ) ) {
-			$error_message .= ' ' . json_last_error_msg();
-		}
+		$error_message = sprintf(
+			/* translators: %s: Error message. */
+			__( 'Unable to encode the personal data for export. Error: %s' ),
+			json_last_error_msg()
+		);
 
 		wp_send_json_error( $error_message );
 	}

--- a/src/wp-admin/includes/privacy-tools.php
+++ b/src/wp-admin/includes/privacy-tools.php
@@ -409,7 +409,7 @@ function wp_privacy_generate_personal_data_export_file( $request_id ) {
 			? __( 'Unable to encode the export file (JSON report)' )
 			: json_last_error_msg();
 
-		_doing_it_wrong( 'privacy_export_personal_data_json_encode_error', $json_error_message, '5.8.0' );
+		_doing_it_wrong( __FUNCTION__, $json_error_message, '5.8.0' );
 	}
 
 	/*

--- a/src/wp-admin/includes/privacy-tools.php
+++ b/src/wp-admin/includes/privacy-tools.php
@@ -401,15 +401,13 @@ function wp_privacy_generate_personal_data_export_file( $request_id ) {
 	// Convert the groups to JSON format.
 	$groups_json = wp_json_encode( $groups );
 	if ( false === $groups_json ) {
-		$groups_json = '"null"';
-
 		// Get the error message.
 		$last_error_code    = json_last_error();
 		$json_error_message = JSON_ERROR_NONE === $last_error_code || empty( $last_error_code )
 			? __( 'Unable to encode the export file (JSON report)' )
 			: json_last_error_msg();
 
-		_doing_it_wrong( __FUNCTION__, $json_error_message, '5.8.0' );
+		wp_send_json_error( $json_error_message );
 	}
 
 	/*

--- a/src/wp-admin/includes/privacy-tools.php
+++ b/src/wp-admin/includes/privacy-tools.php
@@ -401,7 +401,7 @@ function wp_privacy_generate_personal_data_export_file( $request_id ) {
 	// Convert the groups to JSON format.
 	$groups_json = wp_json_encode( $groups );
 	if ( false === $groups_json ) {
-		$groups_json = '"false"';
+		$groups_json = '"null"';
 
 		// Get the error message.
 		$last_error_code    = json_last_error();

--- a/tests/phpunit/tests/privacy/wpPrivacyGeneratePersonalDataExportFile.php
+++ b/tests/phpunit/tests/privacy/wpPrivacyGeneratePersonalDataExportFile.php
@@ -659,7 +659,7 @@ class Tests_Privacy_WpPrivacyGeneratePersonalDataExportFile extends WP_UnitTestC
 	/**
 	 * Test should generate a valid JSON report when/if JSON encoding fails.
 	 *
-	 * @ticket 51423b
+	 * @ticket 51423
 	 */
 	public function test_should_generate_valid_json_when_json_encoding_fails() {
 		add_filter( 'get_post_metadata', array( $this, 'filter_export_data_grouped_metadata' ), 10, 3 );
@@ -668,7 +668,9 @@ class Tests_Privacy_WpPrivacyGeneratePersonalDataExportFile extends WP_UnitTestC
 		$metadata = get_post_meta( self::$export_request_id, '_export_data_grouped', true );
 		$this->assertFalse( wp_json_encode( $metadata ) );
 
+		$this->setExpectedIncorrectUsage( 'privacy_export_personal_data_json_encode_error' );
 		$this->expectOutputString( '' );
+
 		wp_privacy_generate_personal_data_export_file( self::$export_request_id );
 
 		$this->assertTrue( file_exists( $this->export_file_name ) );

--- a/tests/phpunit/tests/privacy/wpPrivacyGeneratePersonalDataExportFile.php
+++ b/tests/phpunit/tests/privacy/wpPrivacyGeneratePersonalDataExportFile.php
@@ -94,8 +94,6 @@ class Tests_Privacy_WpPrivacyGeneratePersonalDataExportFile extends WP_UnitTestC
 	 * @since 5.2.0
 	 */
 	public function tearDown() {
-		// Reset for `test_should_generate_valid_json_when_json_encoding_fails()`.
-		remove_filter( 'get_post_metadata', array( $this, 'filter_export_data_grouped_metadata' ) );
 		$this->remove_exports_dir();
 		error_reporting( $this->_error_level );
 		parent::tearDown();

--- a/tests/phpunit/tests/privacy/wpPrivacyGeneratePersonalDataExportFile.php
+++ b/tests/phpunit/tests/privacy/wpPrivacyGeneratePersonalDataExportFile.php
@@ -669,7 +669,7 @@ class Tests_Privacy_WpPrivacyGeneratePersonalDataExportFile extends WP_UnitTestC
 		$metadata = get_post_meta( self::$export_request_id, '_export_data_grouped', true );
 		$this->assertFalse( wp_json_encode( $metadata ) );
 
-		$this->setExpectedIncorrectUsage( 'privacy_export_personal_data_json_encode_error' );
+		$this->setExpectedIncorrectUsage( 'wp_privacy_generate_personal_data_export_file' );
 		$this->expectOutputString( '' );
 
 		wp_privacy_generate_personal_data_export_file( self::$export_request_id );

--- a/tests/phpunit/tests/privacy/wpPrivacyGeneratePersonalDataExportFile.php
+++ b/tests/phpunit/tests/privacy/wpPrivacyGeneratePersonalDataExportFile.php
@@ -689,7 +689,7 @@ class Tests_Privacy_WpPrivacyGeneratePersonalDataExportFile extends WP_UnitTestC
 
 		// Check valid JSON is created.
 		$request  = wp_get_user_request( self::$export_request_id );
-		$expected = '{"Personal Data Export for ' . $request->email . '":"false"}';
+		$expected = '{"Personal Data Export for ' . $request->email . '":"null"}';
 		$this->assertSame( $expected, $report_contents_json );
 	}
 

--- a/tests/phpunit/tests/privacy/wpPrivacyGeneratePersonalDataExportFile.php
+++ b/tests/phpunit/tests/privacy/wpPrivacyGeneratePersonalDataExportFile.php
@@ -94,6 +94,7 @@ class Tests_Privacy_WpPrivacyGeneratePersonalDataExportFile extends WP_UnitTestC
 	 * @since 5.2.0
 	 */
 	public function tearDown() {
+		// Reset for `test_should_generate_valid_json_when_json_encoding_fails()`.
 		remove_filter( 'get_post_metadata', array( $this, 'filter_export_data_grouped_metadata' ) );
 		$this->remove_exports_dir();
 		error_reporting( $this->_error_level );

--- a/tests/phpunit/tests/privacy/wpPrivacyGeneratePersonalDataExportFile.php
+++ b/tests/phpunit/tests/privacy/wpPrivacyGeneratePersonalDataExportFile.php
@@ -670,7 +670,7 @@ class Tests_Privacy_WpPrivacyGeneratePersonalDataExportFile extends WP_UnitTestC
 		$this->assertFalse( wp_json_encode( $metadata ) );
 
 		$this->expectException( 'WPDieException' );
-		$this->expectOutputString( '{"success":false,"data":"Unable to encode the personal data for export."}' );
+		$this->expectOutputString( '{"success":false,"data":"Unable to encode the personal data for export. Error: Type is not supported"}' );
 		wp_privacy_generate_personal_data_export_file( self::$export_request_id );
 	}
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/52892

Function: `wp_privacy_generate_personal_data_export_file()`

PHPStan flagged a type mismatch if `false` is passed into `fwrite` for groups JSON:
```php
fwrite( $file, $groups_json );
```

The groups JSON is assigned from `wp_json_encode`:
```php
$groups_json = wp_json_encode( $groups );
```

The [return signatures of `wp_json_encode`](https://developer.wordpress.org/reference/functions/wp_json_encode/#return) are `string` or `false`:
>_(string|false)_ The JSON encoded string, or false if it cannot be encoded.

### Is Passing `false` a problem?
See it in action here https://3v4l.org/bpmqG

- No errors, warnings, or notices happen in PHP 5.6 to 8.0.3
- Generates invalid JSON as `false` writes nothing into the file:
```json
"{Personal Data Export for tester@test.com:}"
```

This is the current behavior 👆, where generating invalid JSON is a bug.

### What can cause JSON encoding to fail?
`json_encode` returns `false` when:

- attempting to encode a non-UTF-8 string
- a resource is given

WordPress automatically remedies the encoding with `_wp_json_sanity_check` where it converts string(s) to UTF-8.

A resource could exist an element of the groups _when_ the post meta data is filtered. Using this [test script](https://gist.github.com/hellofromtonya/5f8fc3cfb8c51e448d01d8c72d0d291c) reproduces the failed JSON encoding and invalid JSON report.

## Bug fix solution

Update: After pair programming session, @jrfnl and I agreed this is a bug. Fixing the JSON solves the invalid JSON problem; however, the export is empty and not usable. Instead, generating an error alerts that there 's a problem, which is a preferred experience.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
