### PR TITLE
Editor: Abstract block editor configuration

### DIFF
--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -23,7 +23,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 global $post_type, $post_type_object, $post, $title, $editor_styles, $wp_meta_boxes;
 
-$editor_name          = 'post-editor';
 $block_editor_context = new WP_Block_Editor_Context( array( 'post' => $post ) );
 
 // Flag that we're loading the block editor.
@@ -280,7 +279,7 @@ if ( ! isset( $core_meta_boxes['postcustom'] ) || ! $core_meta_boxes['postcustom
 	unset( $editor_settings['enableCustomFields'] );
 }
 
-$editor_settings = get_block_editor_settings( $editor_name, $editor_settings );
+$editor_settings = get_block_editor_settings( $editor_settings, $block_editor_context );
 
 $init_script = <<<JS
 ( function() {

--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -58,28 +58,33 @@ function get_default_block_categories() {
  * Returns all the categories for block types that will be shown in the block editor.
  *
  * @since 5.0.0
+ * @since 5.8.0 It is possible to pass the block editor context as param.
  *
- * @param string|WP_Post $editor_name_or_post The name of the editor (e.g. 'post-editor')
- *                                            or the post object.
+ * @param WP_Post|WP_Block_Editor_Context $post_or_block_editor_context The current post object or
+ *                                                                      the block editor context.
  *
  * @return array[] Array of categories for block types.
  */
-function get_block_categories( $editor_name_or_post ) {
-	// Assume the post editor when the WP_Post object passed.
-	$editor_name      = is_object( $editor_name_or_post ) ? 'post-editor' : $editor_name_or_post;
-	$block_categories = get_default_block_categories();
+function get_block_categories( $post_or_block_editor_context ) {
+	$block_categories     = get_default_block_categories();
+	$block_editor_context = $post_or_block_editor_context instanceof WP_Post ?
+		new WP_Block_Editor_Context(
+			array(
+				'post' => $post_or_block_editor_context,
+			)
+		) : $post_or_block_editor_context;
 
 	/**
 	 * Filters the default array of categories for block types.
 	 *
 	 * @since 5.8.0
 	 *
-	 * @param array[] $block_categories Array of categories for block types.
-	 * @param string  $editor_name      The name of the editor, e.g. 'post-editor'.
+	 * @param array[]                 $block_categories     Array of categories for block types.
+	 * @param WP_Block_Editor_Context $block_editor_context The current block editor context.
 	 */
-	$block_categories = apply_filters( 'block_categories_all', $block_categories, $editor_name );
-	if ( 'post-editor' === $editor_name ) {
-		$post = is_object( $editor_name_or_post ) ? $editor_name_or_post : get_post();
+	$block_categories = apply_filters( 'block_categories_all', $block_categories, $block_editor_context );
+	if ( ! empty( $block_editor_context->post ) ) {
+		$post = $block_editor_context->post;
 
 		/**
 		 * Filters the default array of categories for block types.
@@ -101,11 +106,11 @@ function get_block_categories( $editor_name_or_post ) {
  *
  * @since 5.8.0
  *
- * @param string $editor_name The name of the editor (e.g. 'post-editor').
+ * @param WP_Block_Editor_Context $block_editor_context The current block editor context.
  *
  * @return bool|array Array of block type slugs, or boolean to enable/disable all.
  */
-function get_allowed_block_types( $editor_name ) {
+function get_allowed_block_types( $block_editor_context ) {
 	$allowed_block_types = true;
 
 	/**
@@ -115,13 +120,13 @@ function get_allowed_block_types( $editor_name ) {
 	 *
 	 * @since 5.8.0
 	 *
-	 * @param bool|array $allowed_block_types Array of block type slugs, or
-	 *                                        boolean to enable/disable all.
-	 * @param string     $editor_name         The name of the editor, e.g. 'post-editor'.
+	 * @param bool|array              $allowed_block_types  Array of block type slugs, or
+	 *                                                      boolean to enable/disable all.
+	 * @param WP_Block_Editor_Context $block_editor_context The current block editor context.
 	 */
-	$allowed_block_types = apply_filters( 'allowed_block_types_all', $allowed_block_types, $editor_name );
-	if ( 'post-editor' === $editor_name ) {
-		$post = get_post();
+	$allowed_block_types = apply_filters( 'allowed_block_types_all', $allowed_block_types, $block_editor_context );
+	if ( ! empty( $block_editor_context->post ) ) {
+		$post = $block_editor_context->post;
 
 		/**
 		 * Filters the allowed block types for the editor, defaulting to true (all
@@ -224,21 +229,21 @@ function get_default_block_editor_settings() {
 }
 
 /**
- * Returns the contextualized block editor settings settings for a selected editor type.
+ * Returns the contextualized block editor settings settings for a selected editor context.
  *
  * @since 5.8.0
  *
- * @param string $editor_name     The name of the editor (e.g. 'post-editor').
- * @param array  $custom_settings Optional custom settings to use with the editor type.
+ * @param array                   $custom_settings      Optional custom settings to use with the editor type.
+ * @param WP_Block_Editor_Context $block_editor_context The current block editor context.
  *
  * @return array The contextualized block editor settings.
  */
-function get_block_editor_settings( $editor_name, $custom_settings = array() ) {
+function get_block_editor_settings( array $custom_settings, $block_editor_context ) {
 	$editor_settings = array_merge(
 		get_default_block_editor_settings(),
 		array(
-			'allowedBlockTypes' => get_allowed_block_types( $editor_name ),
-			'blockCategories'   => get_block_categories( $editor_name ),
+			'allowedBlockTypes' => get_allowed_block_types( $block_editor_context ),
+			'blockCategories'   => get_block_categories( $block_editor_context ),
 		),
 		$custom_settings
 	);
@@ -292,12 +297,12 @@ function get_block_editor_settings( $editor_name, $custom_settings = array() ) {
 	 *
 	 * @since 5.8.0
 	 *
-	 * @param array  $editor_settings Default editor settings.
-	 * @param string $editor_name     The name of the editor, e.g. 'post-editor'.
+	 * @param array                   $editor_settings      Default editor settings.
+	 * @param WP_Block_Editor_Context $block_editor_context The current block editor context.
 	 */
-	$editor_settings = apply_filters( 'block_editor_settings_all', $editor_settings, $editor_name );
-	if ( 'post-editor' === $editor_name ) {
-		$post = get_post();
+	$editor_settings = apply_filters( 'block_editor_settings_all', $editor_settings, $block_editor_context );
+	if ( ! empty( $block_editor_context->post ) ) {
+		$post = $block_editor_context->post;
 
 		/**
 		 * Filters the settings to pass to the block editor.

--- a/tests/phpunit/tests/blocks/block-editor.php
+++ b/tests/phpunit/tests/blocks/block-editor.php
@@ -76,9 +76,9 @@ class WP_Test_Block_Editor extends WP_UnitTestCase {
 	 * @ticket 52920
 	 */
 	function test_block_editor_context_post() {
-		$context = new WP_Block_Editor_Context( array( 'post' => $this->post ) );
+		$context = new WP_Block_Editor_Context( array( 'post' => get_post() ) );
 
-		$this->assertSame( $this->post, $context->post );
+		$this->assertSame( get_post(), $context->post );
 	}
 
 	/**
@@ -111,7 +111,8 @@ class WP_Test_Block_Editor extends WP_UnitTestCase {
 	function test_get_block_categories_deprecated_filter_post_editor() {
 		add_filter( 'block_categories', array( $this, 'filter_set_block_categories_post' ), 10, 2 );
 
-		$block_categories = get_block_categories( 'post-editor' );
+		$post_editor_context = new WP_Block_Editor_Context( array( 'post' => get_post() ) );
+		$block_categories    = get_block_categories( $post_editor_context );
 
 		remove_filter( 'block_categories', array( $this, 'filter_set_block_categories_post' ) );
 
@@ -131,7 +132,8 @@ class WP_Test_Block_Editor extends WP_UnitTestCase {
 	 * @ticket 52920
 	 */
 	function test_get_allowed_block_types_default() {
-		$allowed_block_types = get_allowed_block_types( 'post-editor' );
+		$post_editor_context = new WP_Block_Editor_Context( array( 'post' => get_post() ) );
+		$allowed_block_types = get_allowed_block_types( $post_editor_context );
 
 		$this->assertTrue( $allowed_block_types );
 	}
@@ -143,7 +145,8 @@ class WP_Test_Block_Editor extends WP_UnitTestCase {
 	function test_get_allowed_block_types_deprecated_filter_post_editor() {
 		add_filter( 'allowed_block_types', array( $this, 'filter_set_allowed_block_types_post' ), 10, 2 );
 
-		$allowed_block_types = get_allowed_block_types( 'post-editor' );
+		$post_editor_context = new WP_Block_Editor_Context( array( 'post' => get_post() ) );
+		$allowed_block_types = get_allowed_block_types( $post_editor_context );
 
 		remove_filter( 'allowed_block_types', array( $this, 'filter_set_allowed_block_types_post' ) );
 
@@ -279,7 +282,8 @@ class WP_Test_Block_Editor extends WP_UnitTestCase {
 		add_filter( 'block_categories_all', 'filter_block_categories_my_editor', 10, 1 );
 		add_filter( 'block_editor_settings_all', 'filter_block_editor_settings_my_editor', 10, 1 );
 
-		$settings = get_block_editor_settings( 'my-editor' );
+		$my_editor_context = new WP_Block_Editor_Context();
+		$settings          = get_block_editor_settings( array(), $my_editor_context );
 
 		remove_filter( 'allowed_block_types_all', 'filter_allowed_block_types_my_editor' );
 		remove_filter( 'block_categories_all', 'filter_block_categories_my_editor' );
@@ -306,7 +310,8 @@ class WP_Test_Block_Editor extends WP_UnitTestCase {
 	function test_get_block_editor_settings_deprecated_filter_post_editor() {
 		add_filter( 'block_editor_settings', array( $this, 'filter_set_block_editor_settings_post' ), 10, 2 );
 
-		$settings = get_block_editor_settings( 'post-editor' );
+		$post_editor_context = new WP_Block_Editor_Context( array( 'post' => get_post() ) );
+		$settings            = get_block_editor_settings( array(), $post_editor_context );
 
 		remove_filter( 'block_editor_settings', array( $this, 'filter_set_block_editor_settings_post' ) );
 
@@ -322,8 +327,8 @@ class WP_Test_Block_Editor extends WP_UnitTestCase {
 	 * @ticket 52920
 	 */
 	function test_block_editor_rest_api_preload_no_paths() {
-		$context = new WP_Block_Editor_Context();
-		block_editor_rest_api_preload( array(), $context );
+		$editor_context = new WP_Block_Editor_Context();
+		block_editor_rest_api_preload( array(), $editor_context );
 
 		$after = implode( '', wp_scripts()->registered['wp-api-fetch']->extra['after'] );
 		$this->assertNotContains( 'wp.apiFetch.createPreloadingMiddleware', $after );
@@ -342,12 +347,12 @@ class WP_Test_Block_Editor extends WP_UnitTestCase {
 		}
 		add_filter( 'block_editor_preload_paths', 'filter_remove_preload_paths', 10, 2 );
 
-		$context = new WP_Block_Editor_Context( array( 'post' => get_post() ) );
+		$post_editor_context = new WP_Block_Editor_Context( array( 'post' => get_post() ) );
 		block_editor_rest_api_preload(
 			array(
 				array( '/wp/v2/blocks', 'OPTIONS' ),
 			),
-			$context
+			$post_editor_context
 		);
 
 		remove_filter( 'block_editor_preload_paths', 'filter_remove_preload_paths' );
@@ -369,12 +374,12 @@ class WP_Test_Block_Editor extends WP_UnitTestCase {
 		}
 		add_filter( 'block_editor_rest_api_preload_paths', 'filter_add_preload_paths', 10, 2 );
 
-		$context = new WP_Block_Editor_Context();
+		$editor_context = new WP_Block_Editor_Context();
 		block_editor_rest_api_preload(
 			array(
 				array( '/wp/v2/blocks', 'OPTIONS' ),
 			),
-			$context
+			$editor_context
 		);
 
 		remove_filter( 'block_editor_rest_api_preload_paths', 'filter_add_preload_paths' );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/52920

Related to https://github.com/WordPress/gutenberg/pull/28701.

Required for https://github.com/WordPress/gutenberg/pull/29969 - new REST API endpoint for the editor settings.

We are approaching the day where new screens with the block editor get included in WordPress core. It looks like there are several WordPress hooks defined on the server that depends on `$post` object that isn’t present on the edit site, edit widgets, or edit navigation screens. It feels like we should deprecate existing filters and create replacements that are going to be context-aware.

It's a work in progress. 

Changes included so far:
- new method `get_default_block_categories` were introduced to make is possible to share default block categories
- new method `get_allowed_block_types` was introduced to handle filters depending on the editor type
- most of the settings that are defined on the client in the block editor package in https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/store/defaults.js are already exposed from the new `get_default_block_editor_settings` method
- another method `get_block_editor_settings` got introduced to ensure that editor settings can be filtered depending on the editor type
- the logic that preloads common data used with the block editor by processing an array of REST API paths is now abstracted in `block_editor_rest_api_preload` method

All existing filters that depend on `$post` object get deprecated with `apply_filters_deprecated` as suggested by @jeremyfelt:
- `allowed_block_types`
- `block_categories`
- `block_editor_preload_paths`
- `block_editor_settings`

New filters are introduced that are context-aware:
- `allowed_block_types_all`
- ~`allowed_block_types_{$editor_name}`~
- `block_categories_all`
- `block_editor_rest_api_preload_paths`
- ~`block_editor_preload_paths_{$editor_name}`~
- `block_editor_settings_all`
- ~`block_editor_settings_{$editor_name}`~

~In the case where there are two filters for a general use case that covers any editor type and a specific one, I followed https://core.trac.wordpress.org/ticket/46187 and the implementation for `render_block` + `render_block_{$block_name}`. @johnbillion shared more examples in https://core.trac.wordpress.org/ticket/46187#comment:9:~
Detailed filters per editor type are on hold upon feedback received from @youknowriad, @chrisvanpatten, and @TimothyBJacobs . We want to make it more flexible and it might end up with a special object that holds context.

<details>
> This is a fairly common pattern in core, see for example: `gettext/gettext_{$domain}`, `plugin_action_links/plugin_action_links_{$plugin_file}`, `manage_posts_columns/manage_{$post_type}_posts_columns`, etc. The dynamically named filter should come after the generic one.
</details>

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
