### PR TITLE
Send the correct `$raw_excerpt` parameter

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -3804,6 +3804,7 @@ function human_time_diff( $from, $to = 0 ) {
  *
  * @since 1.5.0
  * @since 5.2.0 Added the `$post` parameter.
+ * @since 5.8.0 Send the correct `$raw_excerpt` parameter.
  *
  * @param string             $text Optional. The excerpt. If set to empty, an excerpt is generated.
  * @param WP_Post|object|int $post Optional. WP_Post instance or Post ID/object. Default null.
@@ -3822,6 +3823,8 @@ function wp_trim_excerpt( $text = '', $post = null ) {
 		/** This filter is documented in wp-includes/post-template.php */
 		$text = apply_filters( 'the_content', $text );
 		$text = str_replace( ']]>', ']]&gt;', $text );
+
+		$raw_excerpt = $text;
 
 		/* translators: Maximum number of words used in a post excerpt. */
 		$excerpt_length = (int) _x( '55', 'excerpt_length' );

--- a/tests/phpunit/tests/formatting/WpTrimExcerpt.php
+++ b/tests/phpunit/tests/formatting/WpTrimExcerpt.php
@@ -81,4 +81,56 @@ class Tests_Formatting_WpTrimExcerpt extends WP_UnitTestCase {
 		$this->assertSame( 'Post content', wp_trim_excerpt( null, $post ) );
 		$this->assertSame( 'Post content', wp_trim_excerpt( false, $post ) );
 	}
+
+	/**
+	 * @ticket 52820
+	 */
+	public function test_raw_excerpt_should_return_untrimmed() {
+		$words_60 = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. ' .
+		'Aenean vehicula nibh eget ligula sodales, id maximus erat semper. ' .
+		'Donec elementum lobortis est in elementum. Etiam tempor mauris felis, ' .
+		'non accumsan urna dignissim et. Donec sed tortor hendrerit, fermentum lacus non, ' .
+		'scelerisque ante. Integer nunc lacus, varius quis maximus sed, ornare eu nisl. ' .
+		'Vivamus egestas ipsum eget urna sollicitudin, feugiat placerat.';
+
+		$words_55 = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. ' .
+		'Aenean vehicula nibh eget ligula sodales, id maximus erat semper. ' .
+		'Donec elementum lobortis est in elementum. Etiam tempor mauris felis, ' .
+		'non accumsan urna dignissim et. Donec sed tortor hendrerit, fermentum lacus non, ' .
+		'scelerisque ante. Integer nunc lacus, varius quis maximus sed, ornare eu nisl. ' .
+		'Vivamus egestas ipsum';
+
+		$post = self::factory()->post->create(
+			array(
+				'post_content' => $words_60,
+			)
+		);
+
+		// Default behavior
+		add_filter( 'excerpt_more', array( $this, 'remove_excerpt_more') );
+		$this->assertSame( $words_55, wp_trim_excerpt( '', $post ) );
+		$this->assertSame( 'Overwrite', wp_trim_excerpt( 'Overwrite', $post ) );
+
+		// This filter will make use of `$raw_excerpt` as the excerpt.
+		add_filter( 'wp_trim_excerpt', array( $this, 'return_raw_excerpt' ), 10, 2 );
+		remove_filter( 'the_content', 'wpautop' );
+
+		$this->assertSame( $words_60, wp_trim_excerpt( '', $post ) );
+	}
+
+	/**
+	 * This filter removes the excerpt more.
+	 */
+	public function remove_excerpt_more() {
+		return '';
+	}
+
+	/**
+	 * @param string $trimmed The trimmed text.
+	 * @param string $raw     The text prior to trimming.
+	 * @see {wp_trim_excerpt}
+	 */
+	public function return_raw_excerpt( $trimmed, $raw ) {
+		return $raw;
+	}
 }


### PR DESCRIPTION
This PR assigns the correct value for `$raw_excerpt` if the passed `$text` is empty. Right now `$raw_excerpt` is empty if `$text` is empty.

Trac ticket: https://core.trac.wordpress.org/ticket/52820

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
