### PR TITLE
Skip WordPress embeds (and other iframes which are hidden on pageload due to fallback content) from being lazy-loaded

### DIFF
--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -1989,6 +1989,12 @@ function wp_img_tag_add_srcset_and_sizes_attr( $image, $context, $attachment_id 
  * @return string Converted `iframe` tag with `loading` attribute added.
  */
 function wp_iframe_tag_add_loading_attr( $iframe, $context ) {
+	// Iframes with fallback content (see `wp_filter_oembed_result()`) should not be lazy-loaded because they are
+	// visually hidden initially.
+	if ( false !== strpos( $iframe, ' data-secret="' ) ) {
+		return $iframe;
+	}
+
 	// Iframes should have source and dimension attributes for the `loading` attribute to be added.
 	if ( false === strpos( $iframe, ' src="' ) || false === strpos( $iframe, ' width="' ) || false === strpos( $iframe, ' height="' ) ) {
 		return $iframe;

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -1869,6 +1869,11 @@ function wp_filter_content_tags( $content, $context = null ) {
  * @return string Converted `img` tag with `loading` attribute added.
  */
 function wp_img_tag_add_loading_attr( $image, $context ) {
+	// Images should have source and dimension attributes for the `loading` attribute to be added.
+	if ( false === strpos( $image, ' src="' ) || false === strpos( $image, ' width="' ) || false === strpos( $image, ' height="' ) ) {
+		return $image;
+	}
+
 	/**
 	 * Filters the `loading` attribute value to add to an image. Default `lazy`.
 	 *
@@ -1887,11 +1892,6 @@ function wp_img_tag_add_loading_attr( $image, $context ) {
 	if ( $value ) {
 		if ( ! in_array( $value, array( 'lazy', 'eager' ), true ) ) {
 			$value = 'lazy';
-		}
-
-		// Images should have source and dimension attributes for the `loading` attribute to be added.
-		if ( false === strpos( $image, ' src="' ) || false === strpos( $image, ' width="' ) || false === strpos( $image, ' height="' ) ) {
-			return $image;
 		}
 
 		return str_replace( '<img', '<img loading="' . esc_attr( $value ) . '"', $image );
@@ -1989,6 +1989,11 @@ function wp_img_tag_add_srcset_and_sizes_attr( $image, $context, $attachment_id 
  * @return string Converted `iframe` tag with `loading` attribute added.
  */
 function wp_iframe_tag_add_loading_attr( $iframe, $context ) {
+	// Iframes should have source and dimension attributes for the `loading` attribute to be added.
+	if ( false === strpos( $iframe, ' src="' ) || false === strpos( $iframe, ' width="' ) || false === strpos( $iframe, ' height="' ) ) {
+		return $iframe;
+	}
+
 	/**
 	 * Filters the `loading` attribute value to add to an iframe. Default `lazy`.
 	 *
@@ -2007,11 +2012,6 @@ function wp_iframe_tag_add_loading_attr( $iframe, $context ) {
 	if ( $value ) {
 		if ( ! in_array( $value, array( 'lazy', 'eager' ), true ) ) {
 			$value = 'lazy';
-		}
-
-		// Iframes should have source and dimension attributes for the `loading` attribute to be added.
-		if ( false === strpos( $iframe, ' src="' ) || false === strpos( $iframe, ' width="' ) || false === strpos( $iframe, ' height="' ) ) {
-			return $iframe;
 		}
 
 		return str_replace( '<iframe', '<iframe loading="' . esc_attr( $value ) . '"', $iframe );

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -2941,6 +2941,7 @@ EOF;
 	function test_wp_iframe_tag_add_loading_attr_opt_out() {
 		$iframe = '<iframe src="https://www.example.com" width="640" height="360"></iframe>';
 		add_filter( 'wp_iframe_tag_add_loading_attr', '__return_false' );
+		$iframe = wp_iframe_tag_add_loading_attr( $iframe, 'test' );
 
 		$this->assertNotContains( ' loading=', $iframe );
 	}

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -2946,6 +2946,18 @@ EOF;
 	}
 
 	/**
+	 * @ticket 52768
+	 */
+	function test_wp_iframe_tag_add_loading_attr_skip_wp_embed() {
+		$iframe   = '<iframe src="https://www.example.com" width="640" height="360"></iframe>';
+		$fallback = '<blockquote>Fallback content.</blockquote>';
+		$iframe   = wp_filter_oembed_result( $fallback . $iframe, (object) array( 'type' => 'rich' ), 'https://www.example.com' );
+		$iframe   = wp_iframe_tag_add_loading_attr( $iframe, 'test' );
+
+		$this->assertNotContains( ' loading=', $iframe );
+	}
+
+	/**
 	 * @ticket 44427
 	 * @ticket 50425
 	 */


### PR DESCRIPTION
`wp_filter_oembed_result()` checks for any "unknown" oEmbed provider whether there is a fallback `blockquote` element present for the iframe to load. If so, it hides the iframe visually and adds a generated `data-secret` attribute to the `iframe` and `blockquote` to associate them with each other. Then, the `wp-embed.js` script goes through the page looking for such elements. Once the iframe has been loaded (and thus notified the `wp-embed.js` script via `postMessage`), the script makes the iframe visible and hides the blockquote.

This mechanism can break when the iframe is marked to be lazy-loaded: Since the browser may interpret the hidden iframe as being irrelevant (since it's hidden), it will never load it, hence the iframe will not send the `postMessage` event to become visible.

This PR ensures that such iframes do not receive the `loading` attribute and are instead kept unmodified. It also fixes a minor issue so that the `wp_img_tag_add_loading_attr` and `wp_iframe_tag_add_loading_attr` filters no longer fire unnecessarily, and it fixes a pointless iframe test from before.

Trac ticket: https://core.trac.wordpress.org/ticket/52768

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
