### PR TITLE
Keep track of selected plugins.

### DIFF
--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -699,6 +699,32 @@ class WP_Plugins_List_Table extends WP_List_Table {
 	}
 
 	/**
+	 * Get the plugins that were checked.
+	 *
+	 * @return array
+	 */
+	private function get_checked_plugins() {
+		static $checked_plugins = null;
+
+		if ( is_null( $checked_plugins ) ) {
+			$checked_plugins = get_transient( 'checked_plugins' );
+			delete_transient( 'checked_plugins' );
+		}
+
+		return is_array( $checked_plugins ) ? $checked_plugins : array();
+	}
+
+	/**
+	 * Was a plugin checked?
+	 *
+	 * @param  string $plugin_file Plugin file.
+	 * @return bool
+	 */
+	private function was_checked( $plugin_file ) {
+		return in_array( $plugin_file, $this->get_checked_plugins(), true );
+	}
+
+	/**
 	 * @global string $status
 	 * @global int $page
 	 * @global string $s
@@ -955,11 +981,12 @@ class WP_Plugins_List_Table extends WP_List_Table {
 		} else {
 			$checkbox = sprintf(
 				'<label class="screen-reader-text" for="%1$s">%2$s</label>' .
-				'<input type="checkbox" name="checked[]" value="%3$s" id="%1$s" />',
+				'<input type="checkbox" name="checked[]" value="%3$s" id="%1$s" %4$s />',
 				$checkbox_id,
 				/* translators: %s: Plugin name. */
 				sprintf( __( 'Select %s' ), $plugin_data['Name'] ),
-				esc_attr( $plugin_file )
+				esc_attr( $plugin_file ),
+				checked( $this->was_checked( $plugin_file ), true, false )
 			);
 		}
 

--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -40,6 +40,10 @@ $_SERVER['REQUEST_URI'] = remove_query_arg( $query_args_to_remove, $_SERVER['REQ
 
 wp_enqueue_script( 'updates' );
 
+if ( isset( $_REQUEST['checked'] ) && is_array( $_REQUEST['checked'] ) ) {
+	set_transient( 'checked_plugins', $_REQUEST['checked'] );
+}
+
 if ( $action ) {
 
 	switch ( $action ) {


### PR DESCRIPTION
This uses transients to remember selected plugins so the next screen
still retains the selection.

The reason I went with transients here was to avoid the issue where via
current GET method the URL could end up being too long.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This is another method to keep track of selected plugins on the plugin screen like other patches on https://core.trac.wordpress.org/ticket/30976 but subverts the issue of passing the selections in the URL.

Trac ticket: https://core.trac.wordpress.org/ticket/30976

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
