### PR TITLE
REST API: Fix comparison of int and float values in the rest_are_values_equal.

### DIFF
--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -1926,6 +1926,10 @@ function rest_are_values_equal( $value1, $value2 ) {
 		return true;
 	}
 
+	if ( ( is_int( $value1 ) && is_float( $value2 ) ) || ( is_float( $value1 ) && is_int( $value2 ) ) ) {
+		return (float) $value1 === (float) $value2;
+	}
+
 	return $value1 === $value2;
 }
 

--- a/tests/phpunit/tests/rest-api/rest-schema-validation.php
+++ b/tests/phpunit/tests/rest-api/rest-schema-validation.php
@@ -321,6 +321,14 @@ class WP_Test_REST_Schema_Validation extends WP_UnitTestCase {
 				true,
 			),
 			array(
+				1,
+				array(
+					'type' => 'integer',
+					'enum' => array( 0.0, 1.0 ),
+				),
+				true,
+			),
+			array(
 				2,
 				array(
 					'type' => 'integer',
@@ -391,6 +399,14 @@ class WP_Test_REST_Schema_Validation extends WP_UnitTestCase {
 				array(
 					'type' => 'number',
 					'enum' => array( 0.0, 1.0 ),
+				),
+				true,
+			),
+			array(
+				1,
+				array(
+					'type' => 'number',
+					'enum' => array( 0, 1 ),
 				),
 				true,
 			),


### PR DESCRIPTION
With this fix, if `rest_are_values_equal` compares two values of type `int` or `float` (in any combination), we first cast both of them to `float` and then compare.

Trac ticket: https://core.trac.wordpress.org/ticket/52932