### PR TITLE
Blocks: add transform_callback for dynamic blocks

### DIFF
--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -259,4 +259,40 @@ class WP_Block {
 		return $block_content;
 	}
 
+	/**
+	 * Generates the transform output for the block.
+	 *
+	 * @since ?.?.?
+	 *
+	 * @param string Block name to transform to
+	 * @return string Rendered block output.
+	 */
+	public function transform( $to ) {
+
+		if ( null === $this->block_type ) {
+			return '';
+		}
+
+		if ( ! $this->block_type->has_dynamic_transform() ) {
+			return '';
+		}
+
+		global $post;
+
+		$global_post = $post;
+
+		$block_content = '';
+		$blocks        = call_user_func( $this->block_type->transform_callback, $to, $this->attributes, $block_content, $this );
+
+		$post = $global_post;
+
+		$output = '';
+
+		foreach ( $blocks as $block ) {
+			$output .= serialize_block( $block );
+		}
+
+		return $output;
+	}
+
 }


### PR DESCRIPTION
WIP for https://github.com/WordPress/gutenberg/issues/29437 pairs with https://github.com/WordPress/gutenberg/pull/30358


```js
// Example call in console:

wp.apiFetch( { path: '/__experimental/block-transform/core/page-list?to=core/navigation-link' } ).then( ( data ) => { 
    console.log( data )
} );
```

<img width="1129" alt="Screen Shot 2021-03-29 at 1 39 12 PM" src="https://user-images.githubusercontent.com/1270189/112897260-3e513100-9094-11eb-8f3f-737ae4565551.png">

Exploration Notes:

- The block transformation APIs expect transforms to be relatively quick. Supporting any async transforms will require a lot of API surface area to update. So this approach isn't particularly viable.
- I didn't really suss out folks having a need to transform other dynamic blocks yet which is another point to pause on this approach.
- There were a few use cases of wanting to build up blocks on the server. A helper like `create_blocks` might be useful. I saw a few spots where we mimicked output of `parse_blocks`
- I need to explore this, but it may be interesting to allow `render_callback` to return blocks.

Next:

- Is a PageList refactor viable?

