### PR TITLE
Add reusable blocks post type submenu

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -284,7 +284,7 @@ function create_initial_post_types() {
 			'public'                => false,
 			'_builtin'              => true, /* internal use only. don't use this when registering your own post type. */
 			'show_ui'               => true,
-			'show_in_menu'          => false,
+			'show_in_menu'          => 'themes.php',
 			'rewrite'               => false,
 			'show_in_rest'          => true,
 			'rest_base'             => 'blocks',


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/51534
Related: WordPress/gutenberg#20557

Adds reusable blocks post type as "Appearance" submenu.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
