### PR TITLE
Return WP_Error for get_post() failure

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
@@ -210,7 +210,7 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 			define( 'DOING_AUTOSAVE', true );
 		}
 
-		$post = get_post( $request['id'] );
+		$post = $this->get_post( $request['id'] );
 
 		if ( is_wp_error( $post ) ) {
 			return $post;
@@ -344,9 +344,8 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 	 * @return mixed The autosave revision ID or WP_Error.
 	 */
 	public function create_post_autosave( $post_data ) {
-
 		$post_id = (int) $post_data['ID'];
-		$post    = get_post( $post_id );
+		$post    = $this->get_post( $post_id );
 
 		if ( is_wp_error( $post ) ) {
 			return $post;
@@ -449,5 +448,33 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 		return array(
 			'context' => $this->get_context_param( array( 'default' => 'view' ) ),
 		);
+	}
+
+	/**
+	 * Get the post, if the ID is valid.
+	 *
+	 * @since 5.8.0
+	 *
+	 * @param int    $id        Supplied ID.
+	 * @return WP_Post|WP_Error Post object if ID is valid, WP_Error otherwise.
+	 */
+	public function get_post( $id ) {
+		$error = new WP_Error(
+			'rest_post_invalid_id',
+			__( 'Invalid post ID.' ),
+			array( 'status' => 404 )
+		);
+
+		if ( (int) $id <= 0 ) {
+			return $error;
+		}
+
+		$post = get_post( (int) $id );
+
+		if ( empty( $post ) || empty( $post->ID ) ) {
+			return $error;
+		}
+
+		return $post;
 	}
 }


### PR DESCRIPTION
This PR copies the implementation of `get_post()` from `WP_REST_Posts_Controller` to `WP_REST_Autosaves_Controller` so `create_item()` and `create_post_autosave()` would return the correct `WP_Error` on `get_post()` failure.

I'll try to add a unit test when possible.

Trac ticket: https://core.trac.wordpress.org/ticket/52925
