### PR TITLE
Add old_slug field to post rest API fields

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -1699,6 +1699,10 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			$data['slug'] = $post->post_name;
 		}
 
+		if ( rest_is_field_included( 'old_slug', $fields ) ) {
+			$data['old_slug'] = get_post_meta( $post->ID, '_wp_old_slug', true );
+		}
+
 		if ( rest_is_field_included( 'status', $fields ) ) {
 			$data['status'] = $post->post_status;
 		}
@@ -2165,6 +2169,14 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 					'readonly'    => true,
 				),
 				'slug'         => array(
+					'description' => __( 'An alphanumeric identifier for the object unique to its type.' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit', 'embed' ),
+					'arg_options' => array(
+						'sanitize_callback' => array( $this, 'sanitize_slug' ),
+					),
+				),
+				'old_slug'         => array(
 					'description' => __( 'An alphanumeric identifier for the object unique to its type.' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit', 'embed' ),

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -1465,7 +1465,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$response   = rest_get_server()->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertSame( 27, count( $properties ) );
+		$this->assertSame( 28, count( $properties ) );
 		$this->assertArrayHasKey( 'author', $properties );
 		$this->assertArrayHasKey( 'alt_text', $properties );
 		$this->assertArrayHasKey( 'caption', $properties );
@@ -1492,6 +1492,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$this->assertArrayHasKey( 'permalink_template', $properties );
 		$this->assertArrayHasKey( 'status', $properties );
 		$this->assertArrayHasKey( 'slug', $properties );
+		$this->assertArrayHasKey( 'old_slug', $properties );
 		$this->assertArrayHasKey( 'source_url', $properties );
 		$this->assertArrayHasKey( 'template', $properties );
 		$this->assertArrayHasKey( 'title', $properties );

--- a/tests/phpunit/tests/rest-api/rest-pages-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-pages-controller.php
@@ -737,7 +737,7 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$response   = rest_get_server()->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertSame( 24, count( $properties ) );
+		$this->assertSame( 25, count( $properties ) );
 		$this->assertArrayHasKey( 'author', $properties );
 		$this->assertArrayHasKey( 'comment_status', $properties );
 		$this->assertArrayHasKey( 'content', $properties );
@@ -758,6 +758,7 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertArrayHasKey( 'permalink_template', $properties );
 		$this->assertArrayHasKey( 'ping_status', $properties );
 		$this->assertArrayHasKey( 'slug', $properties );
+		$this->assertArrayHasKey( 'old_slug', $properties );
 		$this->assertArrayHasKey( 'status', $properties );
 		$this->assertArrayHasKey( 'template', $properties );
 		$this->assertArrayHasKey( 'title', $properties );

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -4100,7 +4100,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$response   = rest_get_server()->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertSame( 26, count( $properties ) );
+		$this->assertSame( 27, count( $properties ) );
 		$this->assertArrayHasKey( 'author', $properties );
 		$this->assertArrayHasKey( 'comment_status', $properties );
 		$this->assertArrayHasKey( 'content', $properties );
@@ -4169,6 +4169,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 			'meta',
 			'modified',
 			'modified_gmt',
+			'old_slug',
 			'ping_status',
 			'slug',
 			'status',
@@ -4208,6 +4209,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 			'meta',
 			'modified',
 			'modified_gmt',
+			'old_slug',
 			'password',
 			'permalink_template',
 			'ping_status',
@@ -4237,6 +4239,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 			'featured_media',
 			'id',
 			'link',
+			'old_slug',
 			'slug',
 			'title',
 			'type',

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -607,6 +607,11 @@ mockedApiResponse.Schema = {
                             "type": "string",
                             "required": false
                         },
+                        "old_slug": {
+                            "description": "An alphanumeric identifier for the object unique to its type.",
+                            "type": "string",
+                            "required": false
+                        },
                         "status": {
                             "description": "A named status for the object.",
                             "type": "string",
@@ -876,6 +881,11 @@ mockedApiResponse.Schema = {
                             "required": false
                         },
                         "slug": {
+                            "description": "An alphanumeric identifier for the object unique to its type.",
+                            "type": "string",
+                            "required": false
+                        },
+                        "old_slug": {
                             "description": "An alphanumeric identifier for the object unique to its type.",
                             "type": "string",
                             "required": false
@@ -1312,6 +1322,11 @@ mockedApiResponse.Schema = {
                             "required": false
                         },
                         "slug": {
+                            "description": "An alphanumeric identifier for the object unique to its type.",
+                            "type": "string",
+                            "required": false
+                        },
+                        "old_slug": {
                             "description": "An alphanumeric identifier for the object unique to its type.",
                             "type": "string",
                             "required": false
@@ -1771,6 +1786,11 @@ mockedApiResponse.Schema = {
                             "type": "string",
                             "required": false
                         },
+                        "old_slug": {
+                            "description": "An alphanumeric identifier for the object unique to its type.",
+                            "type": "string",
+                            "required": false
+                        },
                         "status": {
                             "description": "A named status for the object.",
                             "type": "string",
@@ -2012,6 +2032,11 @@ mockedApiResponse.Schema = {
                             "required": false
                         },
                         "slug": {
+                            "description": "An alphanumeric identifier for the object unique to its type.",
+                            "type": "string",
+                            "required": false
+                        },
+                        "old_slug": {
                             "description": "An alphanumeric identifier for the object unique to its type.",
                             "type": "string",
                             "required": false
@@ -2420,6 +2445,11 @@ mockedApiResponse.Schema = {
                             "required": false
                         },
                         "slug": {
+                            "description": "An alphanumeric identifier for the object unique to its type.",
+                            "type": "string",
+                            "required": false
+                        },
+                        "old_slug": {
                             "description": "An alphanumeric identifier for the object unique to its type.",
                             "type": "string",
                             "required": false
@@ -2849,6 +2879,11 @@ mockedApiResponse.Schema = {
                             "type": "string",
                             "required": false
                         },
+                        "old_slug": {
+                            "description": "An alphanumeric identifier for the object unique to its type.",
+                            "type": "string",
+                            "required": false
+                        },
                         "status": {
                             "description": "A named status for the object.",
                             "type": "string",
@@ -3047,6 +3082,11 @@ mockedApiResponse.Schema = {
                             "required": false
                         },
                         "slug": {
+                            "description": "An alphanumeric identifier for the object unique to its type.",
+                            "type": "string",
+                            "required": false
+                        },
+                        "old_slug": {
                             "description": "An alphanumeric identifier for the object unique to its type.",
                             "type": "string",
                             "required": false
@@ -3546,6 +3586,11 @@ mockedApiResponse.Schema = {
                             "type": "string",
                             "required": false
                         },
+                        "old_slug": {
+                            "description": "An alphanumeric identifier for the object unique to its type.",
+                            "type": "string",
+                            "required": false
+                        },
                         "status": {
                             "description": "A named status for the object.",
                             "type": "string",
@@ -3692,6 +3737,11 @@ mockedApiResponse.Schema = {
                             "required": false
                         },
                         "slug": {
+                            "description": "An alphanumeric identifier for the object unique to its type.",
+                            "type": "string",
+                            "required": false
+                        },
+                        "old_slug": {
                             "description": "An alphanumeric identifier for the object unique to its type.",
                             "type": "string",
                             "required": false
@@ -3847,6 +3897,11 @@ mockedApiResponse.Schema = {
                             "required": false
                         },
                         "slug": {
+                            "description": "An alphanumeric identifier for the object unique to its type.",
+                            "type": "string",
+                            "required": false
+                        },
+                        "old_slug": {
                             "description": "An alphanumeric identifier for the object unique to its type.",
                             "type": "string",
                             "required": false
@@ -6623,6 +6678,7 @@ mockedApiResponse.PostsCollection = [
         "modified": "2017-02-14T00:00:00",
         "modified_gmt": "2017-02-14T00:00:00",
         "slug": "restapi-client-fixture-post",
+        "old_slug": "",
         "status": "publish",
         "type": "post",
         "link": "http://example.org/?p=4",
@@ -6723,6 +6779,7 @@ mockedApiResponse.PostModel = {
     "modified": "2017-02-14T00:00:00",
     "modified_gmt": "2017-02-14T00:00:00",
     "slug": "restapi-client-fixture-post",
+    "old_slug": "",
     "status": "publish",
     "type": "post",
     "link": "http://example.org/?p=4",
@@ -6903,6 +6960,7 @@ mockedApiResponse.PagesCollection = [
         "modified": "2017-02-14T00:00:00",
         "modified_gmt": "2017-02-14T00:00:00",
         "slug": "restapi-client-fixture-page",
+        "old_slug": "",
         "status": "publish",
         "type": "page",
         "link": "http://example.org/?page_id=7",
@@ -6987,6 +7045,7 @@ mockedApiResponse.PageModel = {
     "modified": "2017-02-14T00:00:00",
     "modified_gmt": "2017-02-14T00:00:00",
     "slug": "restapi-client-fixture-page",
+    "old_slug": "",
     "status": "publish",
     "type": "page",
     "link": "http://example.org/?page_id=7",
@@ -7163,6 +7222,7 @@ mockedApiResponse.MediaCollection = [
         "modified": "2017-02-14T00:00:00",
         "modified_gmt": "2017-02-14T00:00:00",
         "slug": "restapi-client-fixture-attachment",
+        "old_slug": "",
         "status": "inherit",
         "type": "attachment",
         "link": "http://example.org/?attachment_id=10",
@@ -7224,6 +7284,7 @@ mockedApiResponse.MediaModel = {
     "modified": "2017-02-14T00:00:00",
     "modified_gmt": "2017-02-14T00:00:00",
     "slug": "restapi-client-fixture-attachment",
+    "old_slug": "",
     "status": "inherit",
     "type": "attachment",
     "link": "http://example.org/?attachment_id=10",


### PR DESCRIPTION
Add `old_slug` to list of fields returned with post details.

Trac ticket: https://core.trac.wordpress.org/ticket/41616

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
