### PR TITLE
Reset postdata after calling setup_postdata()

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -1873,6 +1873,8 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			}
 		}
 
+		wp_reset_postdata();
+
 		/**
 		 * Filters the post data for a REST API response.
 		 *

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
@@ -620,6 +620,8 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 			$response->add_link( 'parent', rest_url( sprintf( '%s/%s/%d', $this->namespace, $this->parent_base, $data['parent'] ) ) );
 		}
 
+		wp_reset_postdata();
+
 		/**
 		 * Filters a revision returned from the REST API.
 		 *


### PR DESCRIPTION
Call `wp_reset_postdata` at the end of `prepare_item_for_response` method

Trac ticket: https://core.trac.wordpress.org/ticket/43502

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
