### PR TITLE
Add does_plugin_auto_updates()

### DIFF
--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -1287,6 +1287,18 @@ function uninstall_plugin( $plugin ) {
 	}
 }
 
+/**
+ * Determines whether a plugin is toggled to auto update.
+ *
+ * @since 5.8.0
+ *
+ * @param string $plugin Path to the plugin file relative to the plugins directory.
+ * @return bool True, if in the auto update list. False, not in the list.
+ */
+function does_plugin_auto_updates( $plugin ) {
+	return in_array( $plugin, (array) get_option( 'auto_update_plugins', array() ), true );
+}
+
 //
 // Menu.
 //

--- a/tests/phpunit/tests/admin/includesPlugin.php
+++ b/tests/phpunit/tests/admin/includesPlugin.php
@@ -588,6 +588,24 @@ class Tests_Admin_includesPlugin extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 52963
+	 */
+	public function test_does_plugin_auto_updates() {
+		$plugin = 'hello.php';
+		// Get auto updated plugins list.
+		$auto_updates = (array) get_site_option( 'auto_update_plugins', array() );
+
+		// Auto update hello dolly.
+		$auto_updates[] = $plugin;
+		$auto_updates   = array_unique( $auto_updates );
+
+		update_site_option( 'auto_update_plugins', $auto_updates );
+
+		// Set auto update on "Hello Dolly" plugin
+		$this->assertTrue( does_plugin_auto_updates( 'hello.php' ) );
+	}
+
+	/**
 	 * Generate a plugin.
 	 *
 	 * This creates a single-file plugin.


### PR DESCRIPTION
This PR adds a new function `does_plugin_auto_updates( $plugin )` which returns whether a plugin is toggled for auto updates.

A few things.

1. The function **does not** check whether a plugin is activated or not since it's possible to enable or disable the auto updates regardless of a plugin activation state.
2. The function is added in `src/wp-admin/includes/plugin.php` so that file should be included first, `include_once( ABSPATH . 'wp-admin/includes/plugin.php' );`, if the function is needed in the frontend.

Trac ticket: https://core.trac.wordpress.org/ticket/52963

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
