### PR TITLE
Fix issue with cache on delete_option

### DIFF
--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -648,6 +648,17 @@ function delete_option( $option ) {
 
 	wp_protect_special_option( $option );
 
+	// Delete the option in cache.
+	if ( ! wp_installing() ) {
+		$alloptions = wp_load_alloptions( true );
+		if ( is_array( $alloptions ) && isset( $alloptions[ $option ] ) ) {
+			unset( $alloptions[ $option ] );
+			wp_cache_set( 'alloptions', $alloptions, 'options' );
+		} else {
+			wp_cache_delete( $option, 'options' );
+		}
+	}
+
 	// Get the ID, if no ID then return.
 	$row = $wpdb->get_row( $wpdb->prepare( "SELECT autoload FROM $wpdb->options WHERE option_name = %s", $option ) );
 	if ( is_null( $row ) ) {
@@ -664,18 +675,6 @@ function delete_option( $option ) {
 	do_action( 'delete_option', $option );
 
 	$result = $wpdb->delete( $wpdb->options, array( 'option_name' => $option ) );
-
-	if ( ! wp_installing() ) {
-		if ( 'yes' === $row->autoload ) {
-			$alloptions = wp_load_alloptions( true );
-			if ( is_array( $alloptions ) && isset( $alloptions[ $option ] ) ) {
-				unset( $alloptions[ $option ] );
-				wp_cache_set( 'alloptions', $alloptions, 'options' );
-			}
-		} else {
-			wp_cache_delete( $option, 'options' );
-		}
-	}
 
 	if ( $result ) {
 

--- a/tests/phpunit/tests/option/option.php
+++ b/tests/phpunit/tests/option/option.php
@@ -140,4 +140,49 @@ class Tests_Option_Option extends WP_UnitTestCase {
 		$actual = $wpdb->get_row( $wpdb->prepare( "SELECT autoload FROM $wpdb->options WHERE option_name = %s LIMIT 1", $name ) );
 		$this->assertSame( $expected, $actual->autoload );
 	}
+
+	/**
+	 * @ticket 52798
+	 */
+	function test_delete_option_with_cache_handling() {
+		// Setup sample_option
+		$this->assertFalse( get_option( 'sample_option', false ) );
+		$this->assertTrue( update_option( 'sample_option', 'sample_value', false ) );
+		$this->assertEquals( 'sample_value', get_option( 'sample_option', false ) );
+		// Test the cache
+		$this->assertEquals( 'sample_value', wp_cache_get( 'sample_option', 'options' ) );
+
+		// Delete the option directly.
+		global $wpdb;
+		$delete = $wpdb->delete( $wpdb->options, array( 'option_name' => 'sample_option' ) );
+		$this->assertEquals( 1, $delete );
+
+		$this->assertFalse( delete_option( 'sample_option' ) );
+		$this->assertFalse( get_option( 'sample_option', false ) );
+		$this->assertFalse( wp_cache_get( 'sample_option', 'options' ) );
+	}
+
+	/**
+	 * @ticket 52798
+	 */
+	function test_delete_option_autoload_with_cache_handling() {
+		// Setup sample_option
+		$this->assertFalse( get_option( 'sample_option', false ) );
+		$this->assertTrue( update_option( 'sample_option', 'sample_value', true ) );
+		$this->assertEquals( 'sample_value', get_option( 'sample_option', false ) );
+		// Test the cache
+		$alloptions = wp_load_alloptions( true );
+		$this->assertTrue( array_key_exists( 'sample_option', $alloptions ) );
+		$this->assertEquals( 'sample_value', $alloptions['sample_option'] );
+
+		// Delete the option directly.
+		global $wpdb;
+		$delete = $wpdb->delete( $wpdb->options, array( 'option_name' => 'sample_option' ) );
+		$this->assertEquals( 1, $delete );
+
+		$this->assertFalse( delete_option( 'sample_option' ) );
+		$new_alloptions = wp_load_alloptions( true );
+		$this->assertFalse( array_key_exists( 'sample_option', $new_alloptions ) );
+		$this->assertFalse( get_option( 'sample_option', false ) );
+	}
 }


### PR DESCRIPTION
This PR fixes the issue with `delete_option` failing to delete the cache if the option no longer exist in the database (deleted manually).

Trac ticket: https://core.trac.wordpress.org/ticket/52798

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
