### PR TITLE
Set post modified to post date when publishing scheduled post

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -4560,12 +4560,21 @@ function wp_publish_post( $post ) {
 		wp_set_post_terms( $post->ID, array( $default_term_id ), $taxonomy );
 	}
 
-	$wpdb->update( $wpdb->posts, array( 'post_status' => 'publish' ), array( 'ID' => $post->ID ) );
+	$wpdb->update( $wpdb->posts,
+		array(
+			'post_status'       => 'publish',
+			'post_modified'     => $post->post_date,
+			'post_modified_gmt' => $post->post_date_gmt,
+		),
+		array( 'ID' => $post->ID )
+	);
 
 	clean_post_cache( $post->ID );
 
-	$old_status        = $post->post_status;
-	$post->post_status = 'publish';
+	$old_status              = $post->post_status;
+	$post->post_status       = 'publish';
+	$post->post_modified     = $post->post_date;
+	$post->post_modified_gmt = $post->post_date_gmt;
 	wp_transition_post_status( 'publish', $old_status, $post );
 
 	/** This action is documented in wp-includes/post.php */


### PR DESCRIPTION
This PR updates the `post_modified` and `post_modified_gmt` to `post_date` and `post_date_gmt` respectively when publishing new post.

Trac ticket: https://core.trac.wordpress.org/ticket/26980

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
