### PR TITLE
Use 0 instead of null as post_id in wp_terms_checklist()

### DIFF
--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -1679,7 +1679,7 @@ class WP_Posts_List_Table extends WP_List_Table {
 						<span class="title inline-edit-categories-label"><?php echo esc_html( $taxonomy->labels->name ); ?></span>
 						<input type="hidden" name="<?php echo ( 'category' === $taxonomy->name ) ? 'post_category[]' : 'tax_input[' . esc_attr( $taxonomy->name ) . '][]'; ?>" value="0" />
 						<ul class="cat-checklist <?php echo esc_attr( $taxonomy->name ); ?>-checklist">
-							<?php wp_terms_checklist( null, array( 'taxonomy' => $taxonomy->name ) ); ?>
+							<?php wp_terms_checklist( 0, array( 'taxonomy' => $taxonomy->name ) ); ?>
 						</ul>
 
 					<?php endforeach; // $hierarchical_taxonomies as $taxonomy ?>


### PR DESCRIPTION
Pass `0` instead of `null` on `wp_terms_checklist()` for consistency.

Trac ticket: https://core.trac.wordpress.org/ticket/43639

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
