### PR TITLE
Add 'format' in args to format output

### DIFF
--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -787,31 +787,57 @@ function get_objects_in_term( $term_ids, $taxonomies, $args = array() ) {
 		}
 	}
 
-	$defaults = array( 'order' => 'ASC' );
+	$defaults = array(
+		'order'  => 'ASC',
+		'format' => false
+	);
 	$args     = wp_parse_args( $args, $defaults );
 
-	$order = ( 'desc' === strtolower( $args['order'] ) ) ? 'DESC' : 'ASC';
+	$order  = ( 'desc' === strtolower( $args['order'] ) ) ? 'DESC' : 'ASC';
+	$format = (bool) $args['format'];
 
 	$term_ids = array_map( 'intval', $term_ids );
 
 	$taxonomies = "'" . implode( "', '", array_map( 'esc_sql', $taxonomies ) ) . "'";
 	$term_ids   = "'" . implode( "', '", $term_ids ) . "'";
 
-	$sql = "SELECT tr.object_id FROM $wpdb->term_relationships AS tr INNER JOIN $wpdb->term_taxonomy AS tt ON tr.term_taxonomy_id = tt.term_taxonomy_id WHERE tt.taxonomy IN ($taxonomies) AND tt.term_id IN ($term_ids) ORDER BY tr.object_id $order";
+	$select_cols = 'tr.object_id';
+	if ( $format ) {
+		$select_cols .= ', tt.term_id';
+	}
+
+	$sql = "SELECT $select_cols FROM $wpdb->term_relationships AS tr INNER JOIN $wpdb->term_taxonomy AS tt ON tr.term_taxonomy_id = tt.term_taxonomy_id WHERE tt.taxonomy IN ($taxonomies) AND tt.term_id IN ($term_ids) ORDER BY tr.object_id $order";
 
 	$last_changed = wp_cache_get_last_changed( 'terms' );
 	$cache_key    = 'get_objects_in_term:' . md5( $sql ) . ":$last_changed";
 	$cache        = wp_cache_get( $cache_key, 'terms' );
-	if ( false === $cache ) {
-		$object_ids = $wpdb->get_col( $sql );
-		wp_cache_set( $cache_key, $object_ids, 'terms' );
-	} else {
+
+	if ( false !== $cache ) {
 		$object_ids = (array) $cache;
+		return empty( $object_ids ) ? array() : $object_ids;
 	}
+
+	if ( $format ) {
+		$object_ids = $wpdb->get_results( $sql );
+		if ( ! empty( $object_ids ) ) {
+			$formatted_object = array();
+			foreach ( $object_ids as $obj ) {
+				if ( ! isset( $formatted_object[ $obj->term_id ] ) ) {
+					$formatted_object[ $obj->term_id ] = array();
+				}
+				$formatted_object[ $obj->term_id ][] = $obj->object_id;
+			}
+			$object_ids = $formatted_object;
+		}
+	} else {
+		$object_ids = $wpdb->get_col( $sql );
+	}
+	wp_cache_set( $cache_key, $object_ids, 'terms' );
 
 	if ( ! $object_ids ) {
 		return array();
 	}
+
 	return $object_ids;
 }
 

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -789,7 +789,7 @@ function get_objects_in_term( $term_ids, $taxonomies, $args = array() ) {
 
 	$defaults = array(
 		'order'  => 'ASC',
-		'format' => false
+		'format' => false,
 	);
 	$args     = wp_parse_args( $args, $defaults );
 

--- a/tests/phpunit/tests/taxonomy.php
+++ b/tests/phpunit/tests/taxonomy.php
@@ -1052,4 +1052,111 @@ class Tests_Taxonomy extends WP_UnitTestCase {
 		$this->assertContains( $tax1, $taxonomies );
 		$this->assertContains( $tax2, $taxonomies );
 	}
+
+	/**
+	 * @ticket 23635
+	 */
+	function test_get_objects_in_term_format() {
+		$heroes  = 'heroes';
+		$villains = 'villains';
+
+		register_taxonomy( $heroes, 'post' );
+		register_taxonomy( $villains, 'post' );
+
+		$batman   = wp_insert_term( 'Batman', $heroes );
+		$superman = wp_insert_term( 'Superman', $heroes );
+		$flash    = wp_insert_term( 'Flash', $heroes );
+
+		$joker   = wp_insert_term( 'Joker', $villains );
+		$lex     = wp_insert_term( 'Lex Luthor', $villains );
+		$thinker = wp_insert_term( 'Thinker', $villains );
+
+		$post1 = self::factory()->post->create();
+		$post2 = self::factory()->post->create();
+		$post3 = self::factory()->post->create();
+		$post4 = self::factory()->post->create();
+
+		/**
+		 * Visual representation
+		 *
+		 * Post 1 - Batman
+		 * Post 2 - Superman, Lex, Thinker
+		 * Post 3 - Flash, Thinker
+		 * Post 4 - Joker, Lex, Thinker
+		 */
+		wp_set_object_terms( $post1, $batman['term_id'], $heroes, true );
+		wp_set_object_terms( $post2, $superman['term_id'], $heroes, true );
+		wp_set_object_terms( $post2, array( $lex['term_id'], $thinker['term_id'] ), $villains, true );
+		wp_set_object_terms( $post3, $flash['term_id'], $heroes, true );
+		wp_set_object_terms( $post3, $thinker['term_id'], $villains, true );
+		wp_set_object_terms(
+			$post4,
+			array(
+				$joker['term_id'],
+				$lex['term_id'],
+				$thinker['term_id'],
+			),
+			$villains,
+			true
+		);
+
+		// Test normal behavior `get_objects_in_term()`.
+		$this->assertEqualSets( array( $post1 ), get_objects_in_term( $batman['term_id'], $heroes ) );
+		$this->assertEqualSets( array( $post2, $post4, ), get_objects_in_term( $lex['term_id'], $villains ) );
+		$this->assertEqualSets( array( $post2, $post3, $post4, ), get_objects_in_term( $thinker['term_id'], $villains ) );
+
+		// Test output with `format` on `$args`.
+		$this->assertEquals(
+			array(
+				$batman['term_id'] => array(
+					$post1,
+				),
+			),
+			get_objects_in_term( $batman['term_id'], $heroes, array( 'format' => true ) )
+		);
+		$this->assertEquals(
+			array(
+				$lex['term_id'] => array(
+					$post2,
+					$post4,
+				),
+			),
+			get_objects_in_term( $lex['term_id'], $villains, array( 'format' => true ) )
+		);
+		$this->assertEquals(
+			array(
+				$batman['term_id']   => array( $post1 ),
+				$superman['term_id'] => array( $post2 ),
+				$flash['term_id']    => array( $post3 ),
+			),
+			get_objects_in_term(
+				array(
+					$batman['term_id'],
+					$superman['term_id'],
+					$flash['term_id'],
+				),
+				$heroes,
+				array( 'format' => true )
+			)
+		);
+		$this->assertEquals(
+			array(
+				$batman['term_id']  => array( $post1 ),
+				$thinker['term_id'] => array( $post2, $post3, $post4 ),
+				$joker['term_id']   => array( $post4 ),
+			),
+			get_objects_in_term(
+				array(
+					$batman['term_id'],
+					$thinker['term_id'],
+					$joker['term_id'],
+				),
+				array(
+					$heroes,
+					$villains,
+				),
+				array( 'format' => true )
+			)
+		);
+	}
 }


### PR DESCRIPTION
This PR will add `$args['format']` which if set to `true` will format the output of `get_objects_in_term()`.

Trac ticket: https://core.trac.wordpress.org/ticket/23635

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
