### PR TITLE
REST API: Add text-field and textarea-field as default formats for string sanitization

### DIFF
--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -2619,6 +2619,7 @@ function rest_validate_integer_value_from_schema( $value, $args, $param ) {
  * @since 4.7.0
  * @since 5.5.0 Added the `$param` parameter.
  * @since 5.6.0 Support the "anyOf" and "oneOf" keywords.
+ * @since 5.8.0 Added `text-field` and `textarea-field` formats.
  *
  * @param mixed  $value The value to sanitize.
  * @param array  $args  Schema array to use for sanitization.
@@ -2761,6 +2762,12 @@ function rest_sanitize_value_from_schema( $value, $args, $param = '' ) {
 
 			case 'uuid':
 				return sanitize_text_field( $value );
+
+			case 'text-field':
+				return sanitize_text_field( $value );
+
+			case 'textarea-field':
+				return sanitize_textarea_field( $value );
 		}
 	}
 

--- a/tests/phpunit/tests/rest-api/rest-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-controller.php
@@ -18,34 +18,42 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 			'/wp/v2/testroute',
 			array(
 				'args' => array(
-					'someinteger' => array(
+					'someinteger'       => array(
 						'type' => 'integer',
 					),
-					'someboolean' => array(
+					'someboolean'       => array(
 						'type' => 'boolean',
 					),
-					'somestring'  => array(
+					'somestring'        => array(
 						'type' => 'string',
 					),
-					'somehex'     => array(
+					'somehex'           => array(
 						'type'   => 'string',
 						'format' => 'hex-color',
 					),
-					'someenum'    => array(
+					'someenum'          => array(
 						'type' => 'string',
 						'enum' => array( 'a' ),
 					),
-					'somedate'    => array(
+					'somedate'          => array(
 						'type'   => 'string',
 						'format' => 'date-time',
 					),
-					'someemail'   => array(
+					'someemail'         => array(
 						'type'   => 'string',
 						'format' => 'email',
 					),
-					'someuuid'    => array(
+					'someuuid'          => array(
 						'type'   => 'string',
 						'format' => 'uuid',
+					),
+					'sometextfield'     => array(
+						'type'   => 'string',
+						'format' => 'text-field',
+					),
+					'sometextareafield' => array(
+						'type'   => 'string',
+						'format' => 'textarea-field',
 					),
 				),
 			)
@@ -223,6 +231,52 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 	}
 
 	/**
+	 * @ticket 99999
+	 */
+	public function test_validate_schema_format_text_field() {
+		$this->assertTrue(
+			rest_validate_request_arg( 'Hello World', $this->request, 'sometextfield' )
+		);
+
+		$this->assertErrorResponse(
+			'rest_invalid_type',
+			rest_validate_request_arg( false, $this->request, 'sometextfield' )
+		);
+
+		$this->assertSame(
+			'Hello World',
+			rest_sanitize_request_arg( 'Hello World', $this->request, 'sometextfield' )
+		);
+		$this->assertSame(
+			'Hello World',
+			rest_sanitize_request_arg( '<p>Hello World</p>', $this->request, 'sometextfield' )
+		);
+	}
+
+	/**
+	 * @ticket 99999
+	 */
+	public function test_validate_schema_format_textarea_field() {
+		$this->assertTrue(
+			rest_validate_request_arg( "Hello\nWorld", $this->request, 'sometextareafield' )
+		);
+
+		$this->assertErrorResponse(
+			'rest_invalid_type',
+			rest_validate_request_arg( false, $this->request, 'sometextareafield' )
+		);
+
+		$this->assertSame(
+			"Hello\nWorld",
+			rest_sanitize_request_arg( "Hello\nWorld", $this->request, 'sometextareafield' )
+		);
+		$this->assertSame(
+			"Hello\nWorld",
+			rest_sanitize_request_arg( "<p>Hello\nWorld</p>", $this->request, 'sometextareafield' )
+		);
+	}
+
+	/**
 	 * @ticket 50876
 	 */
 	public function test_get_endpoint_args_for_item_schema() {
@@ -237,6 +291,8 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 		$this->assertArrayHasKey( 'someemail', $args );
 		$this->assertArrayHasKey( 'somehex', $args );
 		$this->assertArrayHasKey( 'someuuid', $args );
+		$this->assertArrayHasKey( 'sometextfield', $args );
+		$this->assertArrayHasKey( 'sometextareafield', $args );
 		$this->assertArrayHasKey( 'someenum', $args );
 		$this->assertArrayHasKey( 'someargoptions', $args );
 		$this->assertArrayHasKey( 'somedefault', $args );
@@ -326,6 +382,8 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 				'someemail',
 				'somehex',
 				'someuuid',
+				'sometextfield',
+				'sometextareafield',
 				'someenum',
 				'someargoptions',
 				'somedefault',
@@ -359,6 +417,8 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 					'someemail',
 					'somehex',
 					'someuuid',
+					'sometextfield',
+					'sometextareafield',
 					'someenum',
 					'someargoptions',
 					'somedefault',

--- a/tests/phpunit/tests/rest-api/rest-test-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-test-controller.php
@@ -36,7 +36,7 @@ class WP_REST_Test_Controller extends WP_REST_Controller {
 			'title'      => 'type',
 			'type'       => 'object',
 			'properties' => array(
-				'somestring'     => array(
+				'somestring'        => array(
 					'type'        => 'string',
 					'description' => 'A pretty string.',
 					'minLength'   => 3,
@@ -44,7 +44,7 @@ class WP_REST_Test_Controller extends WP_REST_Controller {
 					'pattern'     => '[a-zA-Z]+',
 					'context'     => array( 'view' ),
 				),
-				'someinteger'    => array(
+				'someinteger'       => array(
 					'type'             => 'integer',
 					'multipleOf'       => 10,
 					'minimum'          => 100,
@@ -53,41 +53,51 @@ class WP_REST_Test_Controller extends WP_REST_Controller {
 					'exclusiveMaximum' => true,
 					'context'          => array( 'view' ),
 				),
-				'someboolean'    => array(
+				'someboolean'       => array(
 					'type'    => 'boolean',
 					'context' => array( 'view' ),
 				),
-				'someurl'        => array(
+				'someurl'           => array(
 					'type'    => 'string',
 					'format'  => 'uri',
 					'context' => array( 'view' ),
 				),
-				'somedate'       => array(
+				'somedate'          => array(
 					'type'    => 'string',
 					'format'  => 'date-time',
 					'context' => array( 'view' ),
 				),
-				'someemail'      => array(
+				'someemail'         => array(
 					'type'    => 'string',
 					'format'  => 'email',
 					'context' => array( 'view' ),
 				),
-				'somehex'        => array(
+				'somehex'           => array(
 					'type'    => 'string',
 					'format'  => 'hex-color',
 					'context' => array( 'view' ),
 				),
-				'someuuid'       => array(
+				'someuuid'          => array(
 					'type'    => 'string',
 					'format'  => 'uuid',
 					'context' => array( 'view' ),
 				),
-				'someenum'       => array(
+				'sometextfield'     => array(
+					'type'    => 'string',
+					'format'  => 'text-field',
+					'context' => array( 'view' ),
+				),
+				'sometextareafield' => array(
+					'type'    => 'string',
+					'format'  => 'textarea-field',
+					'context' => array( 'view' ),
+				),
+				'someenum'          => array(
 					'type'    => 'string',
 					'enum'    => array( 'a', 'b', 'c' ),
 					'context' => array( 'view' ),
 				),
-				'someargoptions' => array(
+				'someargoptions'    => array(
 					'type'        => 'integer',
 					'required'    => true,
 					'arg_options' => array(
@@ -95,13 +105,13 @@ class WP_REST_Test_Controller extends WP_REST_Controller {
 						'sanitize_callback' => '__return_true',
 					),
 				),
-				'somedefault'    => array(
+				'somedefault'       => array(
 					'type'    => 'string',
 					'enum'    => array( 'a', 'b', 'c' ),
 					'context' => array( 'view' ),
 					'default' => 'a',
 				),
-				'somearray'      => array(
+				'somearray'         => array(
 					'type'        => 'array',
 					'items'       => array(
 						'type' => 'string',
@@ -111,7 +121,7 @@ class WP_REST_Test_Controller extends WP_REST_Controller {
 					'uniqueItems' => true,
 					'context'     => array( 'view' ),
 				),
-				'someobject'     => array(
+				'someobject'        => array(
 					'type'                 => 'object',
 					'additionalProperties' => array(
 						'type' => 'string',


### PR DESCRIPTION
Probably going to create a separate ticket for this enhancement but it's related to [#WP49960](https://core.trac.wordpress.org/ticket/49960). 

So far the formats are only used in `rest_sanitize_value_from_schema()` because I'm not sure how a validation should look like. Do we need one?

Trac ticket: https://core.trac.wordpress.org/ticket/49960

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
