### PR TITLE
Build: Remove `@babel/polyfill` in favor of `core-js/stable`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1217,15 +1217,6 @@
 				"@babel/helper-plugin-utils": "^7.12.13"
 			}
 		},
-		"@babel/polyfill": {
-			"version": "7.10.1",
-			"resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.10.1.tgz",
-			"integrity": "sha512-TviueJ4PBW5p48ra8IMtLXVkDucrlOZAIZ+EXqS3Ot4eukHbWiqcn7DcqpA1k5PcKtmJ4Xl9xwdv6yQvvcA+3g==",
-			"requires": {
-				"core-js": "^2.6.5",
-				"regenerator-runtime": "^0.13.4"
-			}
-		},
 		"@babel/preset-env": {
 			"version": "7.13.12",
 			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.13.12.tgz",
@@ -7844,9 +7835,9 @@
 			}
 		},
 		"core-js": {
-			"version": "2.6.12",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-			"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
+			"version": "3.10.1",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.10.1.tgz",
+			"integrity": "sha512-pwCxEXnj27XG47mu7SXAwhLP3L5CrlvCB91ANUkIz40P27kUcvNfSdvyZJ9CLHiVoKSp+TTChMQMSKQEH/IQxA=="
 		},
 		"core-js-compat": {
 			"version": "3.10.0",
@@ -14628,6 +14619,14 @@
 						"minimist": "^1.2.0",
 						"request": "^2.88.0",
 						"rx": "^4.1.0"
+					},
+					"dependencies": {
+						"core-js": {
+							"version": "2.6.12",
+							"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+							"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+							"dev": true
+						}
 					}
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
 		"webpack-livereload-plugin": "2.3.0"
 	},
 	"dependencies": {
-		"@babel/polyfill": "7.10.1",
 		"@wordpress/a11y": "2.14.3",
 		"@wordpress/annotations": "1.24.8",
 		"@wordpress/api-fetch": "3.21.5",
@@ -129,6 +128,7 @@
 		"@wordpress/wordcount": "2.14.1",
 		"backbone": "1.4.0",
 		"clipboard": "2.0.8",
+		"core-js": "3.10.1",
 		"core-js-url-browser": "3.6.4",
 		"element-closest": "^2.0.2",
 		"formdata-polyfill": "3.0.20",
@@ -145,6 +145,7 @@
 		"polyfill-library": "3.104.0",
 		"react": "16.13.1",
 		"react-dom": "16.13.1",
+		"regenerator-runtime": "0.13.7",
 		"twemoji": "13.0.2",
 		"underscore": "1.12.1",
 		"whatwg-fetch": "3.0.0"

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -91,7 +91,8 @@ function wp_default_packages_vendor( $scripts ) {
 		'wp-polyfill-dom-rect',
 		'wp-polyfill-element-closest',
 		'wp-polyfill-object-fit',
-		'wp-polyfill',
+		'wp-polyfill-regenerator',
+		'wp-polyfill-core-js',
 	);
 
 	$vendor_scripts_versions = array(
@@ -106,7 +107,8 @@ function wp_default_packages_vendor( $scripts ) {
 		'wp-polyfill-dom-rect'        => '3.104.0',
 		'wp-polyfill-element-closest' => '2.0.2',
 		'wp-polyfill-object-fit'      => '2.3.5',
-		'wp-polyfill'                 => '7.4.4',
+		'wp-polyfill-regenerator'     => '0.13.7',
+		'wp-polyfill-core-js'         => '3.10.1',
 	);
 
 	foreach ( $vendor_scripts as $handle => $dependencies ) {
@@ -121,7 +123,7 @@ function wp_default_packages_vendor( $scripts ) {
 		$scripts->add( $handle, $path, $dependencies, $version, 1 );
 	}
 
-	$scripts->add( 'wp-polyfill', null, array( 'wp-polyfill' ) );
+	$scripts->add( 'wp-polyfill', null, array( 'wp-polyfill-core-js', 'wp-polyfill-regenerator' ) );
 	did_action( 'init' ) && $scripts->add_inline_script(
 		'wp-polyfill',
 		wp_get_script_polyfill(

--- a/tools/webpack/packages.js
+++ b/tools/webpack/packages.js
@@ -73,7 +73,8 @@ module.exports = function( env = { environment: 'production', watch: false, buil
 
 	const vendors = {
 		'lodash.js': 'lodash/lodash.js',
-		'wp-polyfill.js': '@babel/polyfill/dist/polyfill.js',
+		'wp-polyfill-core-js.js': 'core-js/stable/index.js',
+		'wp-polyfill-regenerator.js': 'regenerator-runtime/runtime.js',
 		'wp-polyfill-fetch.js': 'whatwg-fetch/dist/fetch.umd.js',
 		'wp-polyfill-element-closest.js': 'element-closest/element-closest.js',
 		'wp-polyfill-node-contains.js': 'polyfill-library/polyfills/__dist/Node.prototype.contains/raw.js',
@@ -88,7 +89,6 @@ module.exports = function( env = { environment: 'production', watch: false, buil
 
 	const minifiedVendors = {
 		'lodash.min.js': 'lodash/lodash.min.js',
-		'wp-polyfill.min.js': '@babel/polyfill/dist/polyfill.min.js',
 		'wp-polyfill-formdata.min.js': 'formdata-polyfill/formdata.min.js',
 		'wp-polyfill-url.min.js': 'core-js-url-browser/url.min.js',
 		'wp-polyfill-object-fit.min.js': 'objectFitPolyfill/dist/objectFitPolyfill.min.js',
@@ -98,6 +98,8 @@ module.exports = function( env = { environment: 'production', watch: false, buil
 	};
 
 	const minifyVendors = {
+		'wp-polyfill-core-js.min.js': 'core-js/stable/index.js',
+		'wp-polyfill-regenerator.min.js': 'regenerator-runtime/runtime.js',
 		'wp-polyfill-fetch.min.js': 'whatwg-fetch/dist/fetch.umd.js',
 		'wp-polyfill-element-closest.min.js': 'element-closest/element-closest.js',
 		'wp-polyfill-node-contains.min.js': 'polyfill-library/polyfills/__dist/Node.prototype.contains/raw.js',


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/52941

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
