### PR TITLE
fix: failed personal data export

### DIFF
--- a/src/js/_enqueues/admin/privacy-tools.js
+++ b/src/js/_enqueues/admin/privacy-tools.js
@@ -56,7 +56,7 @@ jQuery( function( $ ) {
 		});
 	}
 
-	$( '.export-personal-data-handle, .export-personal-data-failed' ).on( 'click', function( event ) {
+	$( '.export-personal-data-handle' ).on( 'click', function( event ) {
 		var $this          = $( this ),
 			$action        = $this.parents( '.export-personal-data' ),
 			$requestRow    = $this.parents( 'tr' ),

--- a/src/js/_enqueues/admin/privacy-tools.js
+++ b/src/js/_enqueues/admin/privacy-tools.js
@@ -56,7 +56,7 @@ jQuery( function( $ ) {
 		});
 	}
 
-	$( '.export-personal-data-handle' ).on( 'click', function( event ) {
+	$( '.export-personal-data-handle, .export-personal-data-failed' ).on( 'click', function( event ) {
 		var $this          = $( this ),
 			$action        = $this.parents( '.export-personal-data' ),
 			$requestRow    = $this.parents( 'tr' ),

--- a/src/wp-admin/includes/class-wp-privacy-data-export-requests-list-table.php
+++ b/src/wp-admin/includes/class-wp-privacy-data-export-requests-list-table.php
@@ -60,7 +60,7 @@ class WP_Privacy_Data_Export_Requests_List_Table extends WP_Privacy_Requests_Tab
 		$download_data_markup .= '<span class="export-personal-data-idle"><button type="button" class="button-link export-personal-data-handle">' . __( 'Download personal data' ) . '</button></span>' .
 			'<span class="export-personal-data-processing hidden">' . __( 'Downloading data...' ) . ' <span class="export-progress"></span></span>' .
 			'<span class="export-personal-data-success hidden"><button type="button" class="button-link export-personal-data-handle">' . __( 'Download personal data again' ) . '</button></span>' .
-			'<span class="export-personal-data-failed hidden">' . __( 'Download failed.' ) . ' <button type="button" class="button-link">' . __( 'Retry' ) . '</button></span>';
+			'<span class="export-personal-data-failed hidden">' . __( 'Download failed.' ) . ' <button type="button" class="button-link export-personal-data-handle">' . __( 'Retry' ) . '</button></span>';
 
 		$download_data_markup .= '</span>';
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
Fixes export of personal data when the retry on failure button is clicked.
Trac ticket: https://core.trac.wordpress.org/ticket/53032

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
