### PR TITLE
Enable support for revisions in "wp_block" custom post type

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -305,6 +305,7 @@ function create_initial_post_types() {
 			'supports'              => array(
 				'title',
 				'editor',
+				'revisions',
 			),
 		)
 	);

--- a/tests/phpunit/tests/rest-api/rest-schema-setup.php
+++ b/tests/phpunit/tests/rest-api/rest-schema-setup.php
@@ -103,6 +103,8 @@ class WP_Test_REST_Schema_Initialization extends WP_Test_REST_TestCase {
 			'/wp/v2/blocks/(?P<id>[\d]+)',
 			'/wp/v2/blocks/(?P<id>[\d]+)/autosaves',
 			'/wp/v2/blocks/(?P<parent>[\d]+)/autosaves/(?P<id>[\d]+)',
+			'/wp/v2/blocks/(?P<parent>[\d]+)/revisions',
+			'/wp/v2/blocks/(?P<parent>[\d]+)/revisions/(?P<id>[\d]+)',
 			'/wp/v2/types',
 			'/wp/v2/types/(?P<type>[\\w-]+)',
 			'/wp/v2/statuses',


### PR DESCRIPTION
Supersedes https://github.com/WordPress/wordpress-develop/pull/1205/.

Trac ticket: https://core.trac.wordpress.org/ticket/53072.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
