### PR TITLE
Properly pass `--dev` flag to the `grunt clean` command.

### DIFF
--- a/.github/workflows/test-npm.yml
+++ b/.github/workflows/test-npm.yml
@@ -114,7 +114,7 @@ jobs:
         run: npm run build:dev
 
       - name: Clean after building in /src
-        run: npm run grunt clean --dev
+        run: npm run grunt clean -- --dev
 
   # Verifies that installing NPM dependencies and building WordPress works as expected on MacOS.
   #

--- a/.github/workflows/test-npm.yml
+++ b/.github/workflows/test-npm.yml
@@ -172,4 +172,4 @@ jobs:
         run: npm run build:dev
 
       - name: Clean after building in /src
-        run: npm run grunt clean --dev
+        run: npm run grunt clean -- --dev


### PR DESCRIPTION
The `--` separator is missing from the `grunt clean -- --dev` command in the test NPM workflow.

Trac ticket: https://core.trac.wordpress.org/ticket/52625

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
