### PR TITLE
#52465: Allow same URL resource hints with and without crossorigin

### DIFF
--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -3298,12 +3298,12 @@ function wp_resource_hints() {
 			$atts = array();
 
 			if ( is_array( $url ) ) {
-				if ( isset( $url['href'] ) ) {
-					$atts = $url;
-					$url  = $url['href'];
-				} else {
+				if ( ! isset( $url['href'] ) ) {
 					continue;
 				}
+
+				$atts = $url;
+				$url  = $url['href'];
 			}
 
 			$url = esc_url( $url, array( 'http', 'https' ) );
@@ -3312,7 +3312,11 @@ function wp_resource_hints() {
 				continue;
 			}
 
-			if ( isset( $unique_urls[ $url ] ) ) {
+			if (
+				( isset( $unique_urls[ $url ] ) && ! isset( $atts['crossorigin'] ) )
+				||
+				( isset( $unique_urls[ $url . '-crossorigin' ] ) && isset( $atts['crossorigin'] ) )
+			) {
 				continue;
 			}
 
@@ -3333,6 +3337,10 @@ function wp_resource_hints() {
 
 			$atts['rel']  = $relation_type;
 			$atts['href'] = $url;
+
+			if ( isset( $atts['crossorigin'] ) ) {
+				$url .= '-crossorigin';
+			}
 
 			$unique_urls[ $url ] = $atts;
 		}

--- a/tests/phpunit/tests/general/wpResourceHints.php
+++ b/tests/phpunit/tests/general/wpResourceHints.php
@@ -300,4 +300,44 @@ class Tests_General_wpResourceHints extends WP_UnitTestCase {
 
 		return $hints;
 	}
+
+	/**
+	 * @ticket 52465
+	 */
+	function test_same_url_different_attributes() {
+		$expected = "<link rel='dns-prefetch' href='//s.w.org' />\n" .
+					"<link href='https://example.org' rel='preconnect' />\n" .
+					"<link href='https://example.org' crossorigin='anonymous' rel='preconnect' />\n";
+
+		add_filter( 'wp_resource_hints', array( $this, '_add_same_url_with_different_attributes' ), 10, 2 );
+
+		$actual = get_echo( 'wp_resource_hints' );
+
+		remove_filter( 'wp_resource_hints', array( $this, '_add_same_url_with_different_attributes' ) );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	function _add_same_url_with_different_attributes( $urls, $relation_type ) {
+		if ( 'preconnect' !== $relation_type ) {
+			return $urls;
+		}
+
+		$urls[] = array(
+			'href' => 'https://example.org',
+		);
+
+		$urls[] = array(
+			'href'        => 'https://example.org',
+			'crossorigin' => 'anonymous',
+		);
+
+		// Ignored because we already have a crossorigin declaration for the same URL.
+		$urls[] = array(
+			'href'        => 'https://example.org',
+			'crossorigin' => 'use-credentials',
+		);
+
+		return $urls;
+	}
 }


### PR DESCRIPTION
This change allows to have the same URL in the `wp_resource_hints()` array, and added to the HTML, if:
- there is one entry using the `crossorigin` attribute
- and one not using it

Example:
```
$urls[] = array(
	'href' => 'https://example.org',
);

$urls[] = array(
	'href'        => 'https://example.org',
	'crossorigin' => 'anonymous',
);
```

will output:
```
<link href='https://example.org' rel='preconnect' />
<link href='https://example.org' crossorigin='anonymous' rel='preconnect' />
```

A new unit test has been added to validate the code change. Existing tests still passes too.

Trac ticket: https://core.trac.wordpress.org/ticket/52465
