### PR TITLE
Tests: minimize the chances of signature conflicts (Trac: 52625)

### DIFF
--- a/tests/phpunit/includes/bootstrap.php
+++ b/tests/phpunit/includes/bootstrap.php
@@ -193,7 +193,7 @@ require_once ABSPATH . '/wp-settings.php';
 // Delete any default posts & related data.
 _delete_all_posts();
 
-if ( version_compare( tests_get_phpunit_version(), '7.0', '>=' ) ) {
+if ( version_compare( tests_get_phpunit_version(), '7.5', '>=' ) ) {
 	require __DIR__ . '/phpunit7/testcase.php';
 } else {
 	require __DIR__ . '/testcase.php';

--- a/tests/phpunit/includes/phpunit6/compat.php
+++ b/tests/phpunit/includes/phpunit6/compat.php
@@ -11,7 +11,6 @@ if ( class_exists( 'PHPUnit\Runner\Version' ) && version_compare( PHPUnit\Runner
 	class_alias( 'PHPUnit\Framework\Test', 'PHPUnit_Framework_Test' );
 	class_alias( 'PHPUnit\Framework\Warning', 'PHPUnit_Framework_Warning' );
 	class_alias( 'PHPUnit\Framework\AssertionFailedError', 'PHPUnit_Framework_AssertionFailedError' );
-	class_alias( 'PHPUnit\Framework\Constraint\IsEqual', 'PHPUnit_Framework_Constraint_IsEqual' );
 	class_alias( 'PHPUnit\Framework\TestSuite', 'PHPUnit_Framework_TestSuite' );
 	class_alias( 'PHPUnit\Framework\TestListener', 'PHPUnit_Framework_TestListener' );
 	class_alias( 'PHPUnit\Util\GlobalState', 'PHPUnit_Util_GlobalState' );

--- a/tests/phpunit/includes/phpunit7/testcase.php
+++ b/tests/phpunit/includes/phpunit7/testcase.php
@@ -11,30 +11,4 @@ require_once dirname( __DIR__ ) . '/abstract-testcase.php';
  *
  * All WordPress unit tests should inherit from this class.
  */
-class WP_UnitTestCase extends WP_UnitTestCase_Base {
-
-	/**
-	 * Asserts that two variables are equal (with delta).
-	 *
-	 * This method has been backported from a more recent PHPUnit version,
-	 * as tests running on PHP 5.6 use PHPUnit 5.7.x.
-	 *
-	 * @since 5.6.0
-	 *
-	 * @param mixed  $expected First value to compare.
-	 * @param mixed  $actual   Second value to compare.
-	 * @param float  $delta    Allowed numerical distance between two values to consider them equal.
-	 * @param string $message  Optional. Message to display when the assertion fails.
-	 *
-	 * @throws ExpectationFailedException
-	 * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
-	 */
-	public static function assertEqualsWithDelta( $expected, $actual, float $delta, string $message = '' ): void {
-		$constraint = new PHPUnit\Framework\Constraint\IsEqual(
-			$expected,
-			$delta
-		);
-
-		static::assertThat( $actual, $constraint, $message );
-	}
-}
+class WP_UnitTestCase extends WP_UnitTestCase_Base {}

--- a/tests/phpunit/includes/testcase.php
+++ b/tests/phpunit/includes/testcase.php
@@ -30,11 +30,6 @@ class WP_UnitTestCase extends WP_UnitTestCase_Base {
 	 * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
 	 */
 	public static function assertEqualsWithDelta( $expected, $actual, $delta, $message = '' ) {
-		$constraint = new PHPUnit_Framework_Constraint_IsEqual(
-			$expected,
-			$delta
-		);
-
-		static::assertThat( $actual, $constraint, $message );
+		static::assertEquals( $expected, $actual, $message, $delta );
 	}
 }


### PR DESCRIPTION
The PHPUnit 7.5+ method `assertEqualsWithDelta()` is polyfilled for PHPUnit < 7.5, but also overloaded in PHPUnit 7.5 itself, which is not necessary and creates a higher chance of signature conflicts, especially when the WP test suite is used as a basis for integration tests with plugins/themes.

This small change fixes this, by:
* Changing the `version_compare()` for when to use which `WP_UnitTestCase` class to check for PHPUnit 7.5, not 7.0.
* By removing the `assertEqualsWithDelta()` method overload for the `TestCase` which will now only be loaded when on PHPUnit 7.5, where the method overload is not needed as the method already exists in PHPUnit itself.
* And simplifying the overloaded method which is loaded for PHPUnit < 7.5 in a way that namespaced vs non-namespaced classes in PHPUnit itself don't have to be taken into account, including removing the - now unnecessary - class alias declaration.


Trac ticket: https://core.trac.wordpress.org/ticket/52625

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
