### PR TITLE
Tests: improve PHPUnit version retrieval (Trac: 52625)

### DIFF
--- a/tests/phpunit/includes/functions.php
+++ b/tests/phpunit/includes/functions.php
@@ -7,10 +7,10 @@ require_once __DIR__ . '/class-basic-object.php';
  * @return double The version number.
  */
 function tests_get_phpunit_version() {
-	if ( class_exists( 'PHPUnit_Runner_Version' ) ) {
-		$version = PHPUnit_Runner_Version::id();
-	} elseif ( class_exists( 'PHPUnit\Runner\Version' ) ) {
+	if ( class_exists( 'PHPUnit\Runner\Version' ) ) {
 		$version = PHPUnit\Runner\Version::id();
+	} elseif ( class_exists( 'PHPUnit_Runner_Version' ) ) {
+		$version = PHPUnit_Runner_Version::id();
 	} else {
 		$version = 0;
 	}


### PR DESCRIPTION
Always test for newer class names first and fall back to the older. This improves compatibility when running PHPUnit via a phar while there is also a Composer installed version of PHPUnit on the system.

Trac ticket: https://core.trac.wordpress.org/ticket/52625

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
