### PR TITLE
Add the main tag to kses $allowedposttags

### DIFF
--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -252,6 +252,12 @@ if ( ! CUSTOM_TAGS ) {
 			'align' => true,
 			'value' => true,
 		),
+		'main'        => array(
+			'align'    => true,
+			'dir'      => true,
+			'lang'     => true,
+			'xml:lang' => true,
+		),
 		'map'        => array(
 			'name' => true,
 		),

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -1453,15 +1453,15 @@ EOF;
 	 * @ticket 53156
 	 */
 	function test_wp_kses_main_tag_standard_attributes() {
-		global $allowedposttags;
-
 		$test = array(
 			'<main',
 			'class="wp-group-block"',
 			'style="padding:10px"',
 			'/>',
 		);
+		
+		$html = implode( ' ', $test );
 
-		$this->assertSame( implode( ' ', $test ), wp_kses( implode( ' ', $test ), $allowedposttags ) );
+		$this->assertSame( $html, wp_kses_post( $html ) );
 	}
 }

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -1446,4 +1446,22 @@ EOF;
 
 		$this->assertSame( $html, wp_kses_post( $html ) );
 	}
+
+	/**
+	 * Test filtering a standard main tag.
+	 *
+	 * @ticket 53156
+	 */
+	function test_wp_kses_main_tag_standard_attributes() {
+		global $allowedposttags;
+
+		$test = array(
+			'<main',
+			'class="wp-group-block"',
+			'style="padding:10px"',
+			'/>',
+		);
+
+		$this->assertSame( implode( ' ', $test ), wp_kses( implode( ' ', $test ), $allowedposttags ) );
+	}
 }


### PR DESCRIPTION
Gutenberg recently [added the main tag as a wrapper option for the group block for accessibility reasons](https://github.com/WordPress/gutenberg/pull/28576).

This tag is not currently included in $allowedposttags in wp-includes/kses.php, so if this tag is selected by a user without unfiltered_html rights it is stripped from the content on save and the block invalidates when the post/page is reloaded.

To replicate the issue this causes:

- In an WP env with Gutenberg plugin installed add a user with author permissions
- Log in as that user and add a group block and set the wrapper as main under Advanced settings
- Save the post and reload

Trac ticket: https://core.trac.wordpress.org/ticket/53156

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
