### PR TITLE
Admin Bar: Add custom property for responsive height value

### DIFF
--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -1158,12 +1158,8 @@ function _admin_bar_bump_cb() {
 	$type_attr = current_theme_supports( 'html5', 'style' ) ? '' : ' type="text/css"';
 	?>
 <style<?php echo $type_attr; ?> media="screen">
-	html { margin-top: 32px !important; }
-	* html body { margin-top: 32px !important; }
-	@media screen and ( max-width: 782px ) {
-		html { margin-top: 46px !important; }
-		* html body { margin-top: 46px !important; }
-	}
+	html { margin-top: var(--wp-admin--admin-bar--height, 32px) !important; }
+	* html body { margin-top: var(--wp-admin--admin-bar--height, 32px) !important; }
 </style>
 	<?php
 }

--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -87,7 +87,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 	font-weight: 400;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	line-height: 2.46153846;
-	height: 32px;
+	height: var(--wp-admin--admin-bar--height, 32px);
 	position: fixed;
 	top: 0;
 	left: 0;
@@ -133,7 +133,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 #wpadminbar .quicklinks a,
 #wpadminbar .quicklinks .ab-empty-item,
 #wpadminbar .shortlink-input {
-	height: 32px;
+	height: var(--wp-admin--admin-bar--height, 32px);
 	display: block;
 	padding: 0 10px;
 	margin: 0;
@@ -202,7 +202,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 #wpadminbar .menupop li:hover > .ab-sub-wrapper,
 #wpadminbar .menupop li.hover > .ab-sub-wrapper {
 	margin-left: 100%;
-	margin-top: -32px;
+	margin-top: calc(-1 * var(--wp-admin--admin-bar--height));
 }
 
 #wpadminbar .ab-top-secondary .menupop li:hover > .ab-sub-wrapper,
@@ -257,7 +257,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 
 #wpadminbar .ab-label {
 	display: inline-block;
-	height: 32px;
+	height: var(--wp-admin--admin-bar--height, 32px);
 }
 
 #wpadminbar .ab-submenu .ab-item {
@@ -615,7 +615,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 
 #wpadminbar #adminbarsearch {
 	position: relative;
-	height: 32px;
+	height: var(--wp-admin--admin-bar--height, 32px);
 	padding: 0 2px;
 	z-index: 1;
 }
@@ -731,7 +731,6 @@ html:lang(he-il) .rtl #wpadminbar * {
 
 	/* Toolbar Touchification*/
 	html #wpadminbar {
-		height: 46px;
 		min-width: 240px; /* match the min-width of the body in wp-admin/css/common.css */
 	}
 
@@ -745,7 +744,6 @@ html:lang(he-il) .rtl #wpadminbar * {
 	#wpadminbar .quicklinks > ul > li > a,
 	#wpadminbar .quicklinks .ab-empty-item {
 		padding: 0;
-		height: 46px;
 		line-height: 3.28571428;
 		width: auto;
 	}
@@ -755,7 +753,6 @@ html:lang(he-il) .rtl #wpadminbar * {
 		margin: 0;
 		padding: 0;
 		width: 52px;
-		height: 46px;
 		text-align: center;
 	}
 
@@ -785,11 +782,6 @@ html:lang(he-il) .rtl #wpadminbar * {
 		display: none;
 	}
 
-	#wpadminbar .menupop li:hover > .ab-sub-wrapper,
-	#wpadminbar .menupop li.hover > .ab-sub-wrapper {
-		margin-top: -46px;
-	}
-
 	#wpadminbar .ab-top-menu .menupop .ab-sub-wrapper .menupop > .ab-item {
 		padding-right: 30px;
 	}
@@ -816,7 +808,6 @@ html:lang(he-il) .rtl #wpadminbar * {
 	#wpadminbar #wp-admin-bar-wp-logo > .ab-item .ab-icon {
 		padding: 0;
 		width: 52px;
-		height: 46px;
 		text-align: center;
 		vertical-align: top;
 	}
@@ -886,7 +877,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 	#wpadminbar #wp-admin-bar-new-content .ab-icon:before {
 		top: 0;
 		line-height: 1.33333333;
-		height: 46px !important;
+		height: var(--wp-admin--admin-bar--height) !important;
 		text-align: center;
 		width: 52px;
 		display: block;
@@ -909,7 +900,6 @@ html:lang(he-il) .rtl #wpadminbar * {
 	#wpadminbar #wp-admin-bar-comments .ab-icon:before {
 		display: block;
 		font-size: 34px;
-		height: 46px;
 		line-height: 1.38235294;
 		top: 0;
 	}

--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -1,3 +1,8 @@
+/* This value is set on `html` for use in `_admin_bar_bump_cb`. */
+html {
+	--wp-admin--admin-bar--height: 32px;
+}
+
 #wpadminbar * {
 	height: auto;
 	width: auto;
@@ -720,6 +725,10 @@ html:lang(he-il) .rtl #wpadminbar * {
 }
 
 @media screen and (max-width: 782px) {
+	html {
+		--wp-admin--admin-bar--height: 46px;
+	}
+
 	/* Toolbar Touchification*/
 	html #wpadminbar {
 		height: 46px;


### PR DESCRIPTION
Sets up a new custom property `--wp-admin--admin-bar--height`, and uses it in all the places where the height (value) is used.

If we don't want to change all the CSS in `admin-bar.css`, we could also just use https://github.com/WordPress/wordpress-develop/commit/7ab4b040cdacb4d40984befea6ec6cf2822898d7 & https://github.com/WordPress/wordpress-develop/commit/716d654eb1e5ce1563a6569aa6b144e3d997eb55 - add the custom property and use it in the default frontend code.

Themes can use this in their CSS to offset content, and it will inherit the correct size. For example:

```css
.some-banner {
    top: var(--wp-admin--admin-bar--height);
}
```

It would be nice to set this to `0` when there is no admin bar, but the property needs to be on `html` and the admin-bar class is on `body`.

Trac ticket: https://core.trac.wordpress.org/ticket/52623

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
