### PR TITLE
Media library file upload bug

### DIFF
--- a/src/js/media/views/uploader/status.js
+++ b/src/js/media/views/uploader/status.js
@@ -96,9 +96,11 @@ UploaderStatus = View.extend(/** @lends wp.media.view.UploaderStatus.prototype *
 			return attachment.get('uploading');
 		});
 
-		this.$index.text( index + 1 );
-		this.$total.text( queue.length );
-		this.$filename.html( active ? this.filename( active.get('filename') ) : '' );
+		if ( this.$index && this.$total && this.$filename ) {
+			this.$index.text( index + 1 );
+			this.$total.text( queue.length );
+			this.$filename.html( active ? this.filename( active.get('filename') ) : '' );
+		}
 	},
 	/**
 	 * @param {string} filename


### PR DESCRIPTION


Trac ticket: https://core.trac.wordpress.org/ticket/53169

Related to https://github.com/WordPress/gutenberg/issues/11373, and possibly https://core.trac.wordpress.org/ticket/50210
If adding a Gallery via Gutenberg, if a file is dropped onto the core media library the first upload succeeds as expected. If a second Gallery is added and another image dropped on the core media library this uploaded freezes and an uncaught exception Uncaught TypeError: Cannot read property 'text' of undefined in the `wp_includes/js/media-views.js file.
To replicate:

1. Go to Posts > Add new.
2. Add a title.
3. Add a Gallery block.
4. Click on Media Library inside the Gallery Block, add two photos.
5. Enter the gallery on to the page. The photos appear. All is fine.
6. Add another Gallery block.
7. Click on Media Library in the Gallery Block again,
8. Drag a photo onto the Media library to upload it.
9. The upload bar shows 15%-ish done, but then just hangs. Nothing is shown on the far right side. If I click on the photo upload, I get the name of the image, so the Media library is only partially not working.
10. Using the x on the upper right to close the Media library and opening it again, just brings up the same frozen upload.
11. Drag another photo into the Media Library, upload also hangs.