### PR TITLE
add spaces to define() statements

### DIFF
--- a/src/wp-admin/includes/network.php
+++ b/src/wp-admin/includes/network.php
@@ -487,12 +487,12 @@ function network_step2( $errors = false ) {
 		?>
 		</p>
 		<textarea class="code" readonly="readonly" cols="100" rows="7">
-define('MULTISITE', true);
-define('SUBDOMAIN_INSTALL', <?php echo $subdomain_install ? 'true' : 'false'; ?>);
-define('DOMAIN_CURRENT_SITE', '<?php echo $hostname; ?>');
-define('PATH_CURRENT_SITE', '<?php echo $base; ?>');
-define('SITE_ID_CURRENT_SITE', 1);
-define('BLOG_ID_CURRENT_SITE', 1);
+define( 'MULTISITE', true );
+define( 'SUBDOMAIN_INSTALL', <?php echo $subdomain_install ? 'true' : 'false'; ?> );
+define( 'DOMAIN_CURRENT_SITE', '<?php echo $hostname; ?>' );
+define( 'PATH_CURRENT_SITE', '<?php echo $base; ?>' );
+define( 'SITE_ID_CURRENT_SITE', 1 );
+define( 'BLOG_ID_CURRENT_SITE', 1 );
 </textarea>
 		<?php
 		$keys_salts = array(


### PR DESCRIPTION
Adds spacing so `define()` statements conform to WordPress coding standards.

Trac ticket: https://core.trac.wordpress.org/ticket/53182