### PR TITLE
Build/Test Tools: Only scan core files when verifying sourcemaps

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1553,8 +1553,13 @@ module.exports = function(grunt) {
 	 * @ticket 46218
 	 */
 	grunt.registerTask( 'verify:source-maps', function() {
-		const path = `${ BUILD_DIR }**/*.js`;
-		const files = glob.sync( path );
+		const files = buildFiles.reduce( ( acc, path ) => {
+			if ( '!' === path[0] || '**' !== path.substr( -2 ) ) {
+				return acc;
+			}
+			acc.push( ...glob.sync( `${ BUILD_DIR }/${ path }/*.js` ) );
+			return acc;
+		}, [] );
 
 		assert(
 			files.length > 0,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1554,6 +1554,7 @@ module.exports = function(grunt) {
 	 */
 	grunt.registerTask( 'verify:source-maps', function() {
 		const files = buildFiles.reduce( ( acc, path ) => {
+			// Skip excluded paths and any path that isn't a file.
 			if ( '!' === path[0] || '**' !== path.substr( -2 ) ) {
 				return acc;
 			}


### PR DESCRIPTION
This switches the `verify:source-maps` command to only check core files, by using the `buildFiles` array. It will only check JS files in `'wp-includes/**', 'wp-admin/**', 'wp-content/themes/twenty*/**', 'wp-content/plugins/akismet/**'`, instead of all `build/**/*.js`.

Currently, if you have a plugin in `build/` that has sourcemaps, it will flag the `npm run build` process as incomplete/aborted, for example: 

```
Running "verify:source-maps" task
Warning: The build/wp-content/plugins/demo/index.js file must not contain a sourceMappingURL. Use --force to continue.

Aborted due to warnings.
```

With this PR, it won't pick up that plugin file, but would flag a sourcemap in a core file. You can test by running `npx grunt build:js` to build the files, then `npx grunt verify:source-maps`; that will leave sourcemaps, and trigger the warning. `npm run build` removes the sourcemaps and should complete successfully.

Trac ticket: https://core.trac.wordpress.org/ticket/52689

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
