### PR TITLE
Users: Add pre-filters for adding and removing a role and skip if role set is unchanged

### DIFF
--- a/src/wp-includes/class-wp-user.php
+++ b/src/wp-includes/class-wp-user.php
@@ -541,6 +541,21 @@ class WP_User {
 			return;
 		}
 
+		/**
+		 * Filters the role-to-be-added  to a user. Return an empty string to prevent the role being added.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param string  $role          The new role.
+		 * @param WP_User $user          The user object
+		 * @param string  $original_role The new role (as originally requested).
+		 */
+		$role = apply_filters( 'pre_add_user_role', $role, $this, $original_role = $role );
+
+		if ( empty( $role ) || in_array( $role, $this->roles, true ) ) {
+			return;
+		}
+
 		$this->caps[ $role ] = true;
 		update_user_meta( $this->ID, $this->cap_key, $this->caps );
 		$this->get_role_caps();
@@ -551,10 +566,12 @@ class WP_User {
 		 *
 		 * @since 4.3.0
 		 *
-		 * @param int    $user_id The user ID.
-		 * @param string $role    The new role.
+		 * @param int     $user_id       The user ID.
+		 * @param string  $role          The new role.
+		 * @param WP_User $user          The user object
+		 * @param string  $original_role The new role (as originally requested).
 		 */
-		do_action( 'add_user_role', $this->ID, $role );
+		do_action( 'add_user_role', $this->ID, $role, $this, $original_role );
 	}
 
 	/**
@@ -565,9 +582,25 @@ class WP_User {
 	 * @param string $role Role name.
 	 */
 	public function remove_role( $role ) {
-		if ( ! in_array( $role, $this->roles, true ) ) {
+		if ( empty( $role ) ) {
 			return;
 		}
+
+		/**
+		 * Filters the role-to-be-removed from a user. Return an empty string to prevent the role being removed.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param string  $role          The role to be removed.
+		 * @param WP_User $user          The user object
+		 * @param string  $original_role The role to be removed (as originally requested).
+		 */
+		$role = apply_filters( 'pre_remove_user_role', $role, $this, $original_role = $role );
+
+		if ( empty( $role ) || ! in_array( $role, $this->roles, true ) ) {
+			return;
+		}
+
 		unset( $this->caps[ $role ] );
 		update_user_meta( $this->ID, $this->cap_key, $this->caps );
 		$this->get_role_caps();
@@ -578,10 +611,12 @@ class WP_User {
 		 *
 		 * @since 4.3.0
 		 *
-		 * @param int    $user_id The user ID.
-		 * @param string $role    The removed role.
+		 * @param int     $user_id       The user ID.
+		 * @param string  $role          The removed role.
+		 * @param WP_User $user          The user object
+		 * @param string  $original_role The role to be removed (as originally requested).
 		 */
-		do_action( 'remove_user_role', $this->ID, $role );
+		do_action( 'remove_user_role', $this->ID, $role, $this, $original_role );
 	}
 
 	/**


### PR DESCRIPTION
- Fixing a "bug" where add_user_role would be fired, even if the user already has that role
- Introduces two new filters (`pre_add_user_role` and `pre_remove_user_role`) to prevent or change the role being added or removed respectively.

Trac ticket: [53199](https://core.trac.wordpress.org/ticket/53199)
