### PR TITLE
Fix fatal error in site health test_check_wp_filesystem_method

### DIFF
--- a/src/wp-admin/includes/class-wp-site-health-auto-updates.php
+++ b/src/wp-admin/includes/class-wp-site-health-auto-updates.php
@@ -278,6 +278,11 @@ class WP_Site_Health_Auto_Updates {
 			require_once ABSPATH . '/wp-admin/includes/file.php';
 		}
 
+		// Make sure the `submit_button` function is available during our REST call.
+		if ( ! function_exists( 'submit_button' ) ) {
+			require_once ABSPATH . '/wp-admin/includes/template.php';
+		}
+
 		$skin    = new Automatic_Upgrader_Skin;
 		$success = $skin->request_filesystem_credentials( false, ABSPATH );
 


### PR DESCRIPTION
Adds a function exists check for submit_button to make sure the site health tests do not trigger a fatal error when another FS_METHOD than direct is being used.

Trac ticket: https://core.trac.wordpress.org/ticket/53206
