### PR TITLE
Allow parentheses in safecss_filter_attr

### DIFF
--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -2383,14 +2383,14 @@ function safecss_filter_attr( $css, $deprecated = '' ) {
 		}
 
 		if ( $found ) {
-			// Check for any CSS containing \ ( & } = or comments, except for url() usage checked above.
-			$allow_css = ! preg_match( '%[\\\(&=}]|/\*%', $css_test_string );
+			// Check for any CSS containing \ & } = or comments, except for url() usage checked above.
+			$allow_css = ! preg_match( '%[\\&=}]|/\*%', $css_test_string );
 
 			/**
 			 * Filters the check for unsafe CSS in `safecss_filter_attr`.
 			 *
 			 * Enables developers to determine whether a section of CSS should be allowed or discarded.
-			 * By default, the value will be false if the part contains \ ( & } = or comments.
+			 * By default, the value will be false if the part contains \ & } = or comments.
 			 * Return true to allow the CSS part to be included in the output.
 			 *
 			 * @since 5.5.0


### PR DESCRIPTION
This patch allows using `(` in CSS sanitized using the `safecss_filter_attr` function.
The original regex was created more than a decade ago, and back then we didn't have things like `calc()`, `var()` etc - so disallowing `(` made sense. This is no longer the case.

Trac ticket: https://core.trac.wordpress.org/ticket/46197

This also fixes https://github.com/WordPress/gutenberg/pull/31740 in Gutenberg, as well as https://core.trac.wordpress.org/ticket/46498

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
