### PR TITLE
Bugfix/53196

### DIFF
--- a/src/wp-content/themes/twentytwenty/package.json
+++ b/src/wp-content/themes/twentytwenty/package.json
@@ -10,10 +10,6 @@
 		"TwentyTwenty"
 	],
 	"homepage": "https://github.com/wordpress/twentytwenty#readme",
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/wordpress/twentytwenty.git"
-	},
 	"bugs": {
 		"url": "https://github.com/wordpress/twentytwenty/issues"
 	},

--- a/src/wp-content/themes/twentytwenty/package.json
+++ b/src/wp-content/themes/twentytwenty/package.json
@@ -11,7 +11,7 @@
 	],
 	"homepage": "https://github.com/wordpress/twentytwenty#readme",
 	"bugs": {
-		"url": "https://github.com/wordpress/twentytwenty/issues"
+		"url": "https://core.trac.wordpress.org/"
 	},
 	"devDependencies": {
 		"@wordpress/browserslist-config": "^3.0.2",

--- a/src/wp-content/themes/twentytwenty/package.json
+++ b/src/wp-content/themes/twentytwenty/package.json
@@ -9,7 +9,7 @@
 		"Theme",
 		"TwentyTwenty"
 	],
-	"homepage": "https://github.com/wordpress/twentytwenty#readme",
+	"homepage": "https://wordpress.org/themes/twentytwenty/",
 	"bugs": {
 		"url": "https://core.trac.wordpress.org/"
 	},


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/53196 <!-- insert a link to the WordPress Trac ticket here -->

The TwentyTwenty theme had outdated information in its `package.json` file. This PR:

1. Removes `repository` section of `package.json`
2. Updates bugs URL
3. Updates homepage link

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
