### PR TITLE
Trac 53056 – Send 500 status on JSON encode error

### DIFF
--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -497,6 +497,7 @@ class WP_REST_Server {
 			$json_error_message = $this->get_json_last_error();
 
 			if ( $json_error_message ) {
+				$this->set_status( 500 );
 				$json_error_obj = new WP_Error(
 					'rest_encode_error',
 					$json_error_message,

--- a/tests/phpunit/includes/spy-rest-server.php
+++ b/tests/phpunit/includes/spy-rest-server.php
@@ -6,6 +6,7 @@ class Spy_REST_Server extends WP_REST_Server {
 	public $sent_body           = '';
 	public $last_request        = null;
 	public $override_by_default = false;
+	public $status              = null;
 
 	/**
 	 * Gets the raw $endpoints data from the server.
@@ -35,6 +36,14 @@ class Spy_REST_Server extends WP_REST_Server {
 	 */
 	public function send_header( $header, $value ) {
 		$this->sent_headers[ $header ] = $value;
+	}
+
+	/**
+	 * Stores last set status.
+	 * @param int $code HTTP status.
+	 */
+	public function set_status( $status ) {
+		$this->status = $status;
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/rest-server.php
+++ b/tests/phpunit/tests/rest-api/rest-server.php
@@ -2022,6 +2022,28 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 		$this->assertArrayHasKey( 'https://api.w.org/active-theme', $index->get_links() );
 	}
 
+	/**
+	 * @ticket 53056
+	 */
+	public function test_json_encode_error_results_in_500_status_code() {
+		register_rest_route(
+			'test-ns/v1',
+			'/test',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => function() {
+						return new \WP_REST_Response( INF );
+					},
+					'permission_callback' => '__return_true',
+					'args'                => array(),
+				),
+			)
+		);
+		rest_get_server()->serve_request( '/test-ns/v1/test' );
+		$this->assertSame( 500, rest_get_server()->status );
+	}
+
 	public function _validate_as_integer_123( $value, $request, $key ) {
 		if ( ! is_int( $value ) ) {
 			return new WP_Error( 'some-error', 'This is not valid!' );

--- a/tests/phpunit/tests/rest-api/rest-server.php
+++ b/tests/phpunit/tests/rest-api/rest-server.php
@@ -2040,7 +2040,7 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 				),
 			)
 		);
-		rest_get_server()->serve_request( '/test-ns/v1/test' );
+		rest_do_request( '/test-ns/v1/test' );
 		$this->assertSame( 500, rest_get_server()->status );
 	}
 

--- a/tests/phpunit/tests/rest-api/rest-server.php
+++ b/tests/phpunit/tests/rest-api/rest-server.php
@@ -2040,7 +2040,7 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 				),
 			)
 		);
-		rest_do_request( '/test-ns/v1/test' );
+		rest_get_server()->serve_request( '/test-ns/v1/test' );
 		$this->assertSame( 500, rest_get_server()->status );
 	}
 


### PR DESCRIPTION
Fixes issue in the REST API where a JSON encode failure of the response body does not result in a 500 error.

An automated test is included for this case, requiring an expansion of the test spy.

Trac ticket: https://core.trac.wordpress.org/ticket/53056

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
