### PR TITLE
Use the block editor when editing the page for posts

### DIFF
--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -333,6 +333,10 @@ $script = sprintf(
 );
 wp_add_inline_script( 'wp-edit-post', $script );
 
+if ( (int) get_option( 'page_for_posts' ) === (int) $post->ID ) {
+	add_action( 'admin_notices', '_wp_block_editor_posts_page_notice' );
+}
+
 require_once ABSPATH . 'wp-admin/admin-header.php';
 ?>
 

--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -334,7 +334,7 @@ $script = sprintf(
 wp_add_inline_script( 'wp-edit-post', $script );
 
 if ( (int) get_option( 'page_for_posts' ) === (int) $post->ID ) {
-	add_action( 'admin_notices', '_wp_block_editor_posts_page_notice' );
+	add_action( 'admin_enqueue_scripts', '_wp_block_editor_posts_page_notice' );
 }
 
 require_once ABSPATH . 'wp-admin/admin-header.php';

--- a/src/wp-admin/includes/admin-filters.php
+++ b/src/wp-admin/includes/admin-filters.php
@@ -118,7 +118,6 @@ add_action( 'admin_notices', 'paused_plugins_notice', 5 );
 add_action( 'admin_notices', 'paused_themes_notice', 5 );
 add_action( 'admin_notices', 'maintenance_nag', 10 );
 add_action( 'admin_notices', 'wp_recovery_mode_nag', 1 );
-add_action( 'admin_notices', 'wp_block_editor_posts_page_notice' );
 
 add_filter( 'update_footer', 'core_update_footer' );
 

--- a/src/wp-admin/includes/admin-filters.php
+++ b/src/wp-admin/includes/admin-filters.php
@@ -118,6 +118,7 @@ add_action( 'admin_notices', 'paused_plugins_notice', 5 );
 add_action( 'admin_notices', 'paused_themes_notice', 5 );
 add_action( 'admin_notices', 'maintenance_nag', 10 );
 add_action( 'admin_notices', 'wp_recovery_mode_nag', 1 );
+add_action( 'admin_notices', 'wp_block_editor_posts_page_notice' );
 
 add_filter( 'update_footer', 'core_update_footer' );
 

--- a/src/wp-admin/includes/post.php
+++ b/src/wp-admin/includes/post.php
@@ -2126,11 +2126,6 @@ function use_block_editor_for_post( $post ) {
 		return false;
 	}
 
-	// The posts page can't be edited in the block editor.
-	if ( absint( get_option( 'page_for_posts' ) ) === $post->ID && empty( $post->post_content ) ) {
-		return false;
-	}
-
 	$use_block_editor = use_block_editor_for_post_type( $post->post_type );
 
 	/**

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -2668,3 +2668,25 @@ function wp_star_rating( $args = array() ) {
 function _wp_posts_page_notice() {
 	echo '<div class="notice notice-warning inline"><p>' . __( 'You are currently editing the page that shows your latest posts.' ) . '</p></div>';
 }
+
+/**
+ * Output a notice when editing the page for posts in the block editor.
+ *
+ * @since 5.8.0
+ *
+ * @global WP_Post $post Global post object.
+ */
+function wp_block_editor_posts_page_notice() {
+	global $post;
+
+	if ( $post && (int) get_option( 'page_for_posts' ) === (int) $post->ID ) {
+		wp_add_inline_script(
+			'wp-notices',
+			sprintf(
+				'wp.data.dispatch( "core/notices" ).createWarningNotice( "%s", { isDismissible: false } )',
+				__( 'You are currently editing the page that shows your latest posts.' ),
+			),
+			'after'
+		);
+	}
+}

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -2670,23 +2670,18 @@ function _wp_posts_page_notice() {
 }
 
 /**
- * Output a notice when editing the page for posts in the block editor.
+ * Output a notice when editing the page for posts in the block editor (internal use only).
  *
+ * @ignore
  * @since 5.8.0
- *
- * @global WP_Post $post Global post object.
  */
-function wp_block_editor_posts_page_notice() {
-	global $post;
-
-	if ( $post && (int) get_option( 'page_for_posts' ) === (int) $post->ID ) {
-		wp_add_inline_script(
-			'wp-notices',
-			sprintf(
-				'wp.data.dispatch( "core/notices" ).createWarningNotice( "%s", { isDismissible: false } )',
-				__( 'You are currently editing the page that shows your latest posts.' ),
-			),
-			'after'
-		);
-	}
+function _wp_block_editor_posts_page_notice() {
+	wp_add_inline_script(
+		'wp-notices',
+		sprintf(
+			'wp.data.dispatch( "core/notices" ).createWarningNotice( "%s", { isDismissible: false } )',
+			__( 'You are currently editing the page that shows your latest posts.' )
+		),
+		'after'
+	);
 }


### PR DESCRIPTION
Summary of changes

- Default to the block editor when opening the `page_for_posts` page in the editor
- Add a notice to the block editor for this page: "You are currently editing the page that shows your latest posts."

<img width="500" alt="Screen Shot 2021-05-18 at 15 25 11" src="https://user-images.githubusercontent.com/1699996/118718781-45233700-b7ed-11eb-9d51-76317abcfe7d.png">


Trac ticket: https://core.trac.wordpress.org/ticket/45537

---

**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
