### PR TITLE
Combine CSS from Site Health with Privacy Settings

### DIFF
--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -808,7 +808,7 @@ form#tags-filter {
 }
 
 .privacy-settings-accordion-heading,
-health-check-accordion-heading {
+.health-check-accordion-heading {
 	margin: 0;
 	border-top: 1px solid #c3c4c7;
 	font-size: inherit;
@@ -838,9 +838,8 @@ health-check-accordion-heading {
 	width: 100%;
 	align-items: center;
 	justify-content: space-between;
-	/*
-	This is in site health -webkit-user-select: auto;
-	user-select: auto; */
+	-webkit-user-select: auto;
+	user-select: auto;
 }
 
 .privacy-settings-accordion-trigger:hover,

--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -886,6 +886,9 @@ form#tags-filter {
 	padding: 0.1rem 0.5rem 0.15rem;
 	color: #2c3338;
 	font-weight: 600;
+}
+
+.privacy-settings-accordion-trigger .badge {
 	margin-left: 0.5rem;
 }
 

--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -701,15 +701,22 @@ form#tags-filter {
 
 /**
 * Privacy Settings section
+*
+* Note: This section includes selectors from
+* Site Health where duplicate styling is used.
 */
 
 /* General */
 .privacy-settings #wpcontent,
-.privacy-settings.auto-fold #wpcontent {
+.privacy-settings.auto-fold #wpcontent,
+.site-health #wpcontent,
+.site-health.auto-fold #wpcontent {
 	padding-left: 0;
 }
 
-.privacy-settings-header h1 {
+/* Emulates .wrap h1 styling */
+.privacy-settings-header h1,
+.health-check-header h1 {
 	display: inline-block;
 	font-weight: 600;
 	margin: 0 0.8rem 1rem;
@@ -719,18 +726,21 @@ form#tags-filter {
 }
 
 /* Header */
-.privacy-settings-header {
+.privacy-settings-header,
+.health-check-header {
 	text-align: center;
 	margin: 0 0 1rem;
 	background: #fff;
 	border-bottom: 1px solid #dcdcde;
 }
 
-.privacy-settings-title-section {
+.privacy-settings-title-section,
+.health-check-title-section {
 	display: flex;
 	align-items: center;
 	justify-content: center;
 	clear: both;
+	padding-top: 8px;
 }
 
 .privacy-settings-tabs-wrapper {
@@ -752,27 +762,32 @@ form#tags-filter {
 	transition: box-shadow 0.5s ease-in-out;
 }
 
-.privacy-settings-tab:nth-child(1) {
+.privacy-settings-tab:nth-child(1),
+.health-check-tab:nth-child(1) {
 	-ms-grid-column: 1; /* IE 11 */
 }
 
-.privacy-settings-tab:nth-child(2) {
+.privacy-settings-tab:nth-child(2),
+.health-check-tab:nth-child(2) {
 	-ms-grid-column: 2; /* IE 11 */
 }
 
-.privacy-settings-tab:focus {
+.privacy-settings-tab:focus,
+.health-check-tab:focus {
 	color: #1d2327;
 	outline: 1px solid #787c82;
 	box-shadow: none;
 }
 
-.privacy-settings-tab.active {
+.privacy-settings-tab.active,
+.health-check-tab.active {
 	box-shadow: inset 0 -3px #3582c4;
 	font-weight: 600;
 }
 
 /* Body */
-.privacy-settings-body {
+.privacy-settings-body,
+.health-check-body {
 	max-width: 800px;
 	margin: 0 auto;
 }
@@ -787,11 +802,13 @@ form#tags-filter {
 }
 
 /* Accordions */
-.privacy-settings-accordion {
+.privacy-settings-accordion,
+.health-check-accordion {
 	border: 1px solid #c3c4c7;
 }
 
-.privacy-settings-accordion-heading {
+.privacy-settings-accordion-heading,
+health-check-accordion-heading {
 	margin: 0;
 	border-top: 1px solid #c3c4c7;
 	font-size: inherit;
@@ -800,11 +817,13 @@ form#tags-filter {
 	color: inherit;
 }
 
-.privacy-settings-accordion-heading:first-child {
+.privacy-settings-accordion-heading:first-child,
+.health-check-accordion-heading:first-child {
 	border-top: none;
 }
 
-.privacy-settings-accordion-trigger {
+.privacy-settings-accordion-trigger,
+.health-check-accordion-trigger {
 	background: #fff;
 	border: 0;
 	color: #2c3338;
@@ -819,14 +838,20 @@ form#tags-filter {
 	width: 100%;
 	align-items: center;
 	justify-content: space-between;
+	/*
+	This is in site health -webkit-user-select: auto;
+	user-select: auto; */
 }
 
 .privacy-settings-accordion-trigger:hover,
-.privacy-settings-accordion-trigger:active {
+.privacy-settings-accordion-trigger:active,
+.health-check-accordion-trigger:hover,
+.health-check-accordion-trigger:active {
 	background: #f6f7f7;
 }
 
-.privacy-settings-accordion-trigger:focus {
+.privacy-settings-accordion-trigger:focus,
+.health-check-accordion-trigger:focus {
 	color: #1d2327;
 	border: none;
 	box-shadow: none;
@@ -835,14 +860,17 @@ form#tags-filter {
 	background-color: #f6f7f7;
 }
 
-.privacy-settings-accordion-trigger .title {
+.privacy-settings-accordion-trigger .title,
+.health-check-accordion-trigger .title {
 	pointer-events: none;
 	font-weight: 600;
 	flex-grow: 1;
 }
 
 .privacy-settings-accordion-trigger .icon,
-.privacy-settings-view-read .icon {
+.privacy-settings-view-read .icon,
+.health-check-accordion-trigger .icon,
+.site-health-view-passed .icon {
 	border: solid #50575e;
 	border-width: 0 2px 2px 0;
 	height: 0.5rem;
@@ -854,53 +882,65 @@ form#tags-filter {
 	width: 0.5rem;
 }
 
-.privacy-settings-accordion-trigger .badge {
+.privacy-settings-accordion-trigger .badge,
+.health-check-accordion-trigger .badge {
 	padding: 0.1rem 0.5rem 0.15rem;
 	color: #2c3338;
 	font-weight: 600;
 	margin-left: 0.5rem;
 }
 
-.privacy-settings-accordion-trigger .badge.blue {
+.privacy-settings-accordion-trigger .badge.blue,
+.health-check-accordion-trigger .badge.blue {
 	border: 1px solid #72aee6;
 }
 
-.privacy-settings-accordion-trigger .badge.orange {
+.privacy-settings-accordion-trigger .badge.orange,
+.health-check-accordion-trigger .badge.orange {
 	border: 1px solid #dba617;
 }
 
-.privacy-settings-accordion-trigger .badge.red {
+.privacy-settings-accordion-trigger .badge.red,
+.health-check-accordion-trigger .badge.red {
 	border: 1px solid #e65054;
 }
 
-.privacy-settings-accordion-trigger .badge.green {
+.privacy-settings-accordion-trigger .badge.green,
+.health-check-accordion-trigger .badge.green {
 	border: 1px solid #00ba37;
 }
 
-.privacy-settings-accordion-trigger .badge.purple {
+.privacy-settings-accordion-trigger .badge.purple,
+.health-check-accordion-trigger .badge.purple {
 	border: 1px solid #2271b1;
 }
 
-.privacy-settings-accordion-trigger .badge.gray {
+.privacy-settings-accordion-trigger .badge.gray,
+.health-check-accordion-trigger .badge.gray {
 	border: 1px solid #c3c4c7;
 }
 
 .privacy-settings-accordion-trigger[aria-expanded="true"] .icon,
-.privacy-settings-view-passed[aria-expanded="true"] .icon {
+.privacy-settings-view-passed[aria-expanded="true"] .icon,
+.health-check-accordion-trigger[aria-expanded="true"] .icon,
+.site-health-view-passed[aria-expanded="true"] .icon {
 	transform: translateY(-30%) rotate(-135deg)
 }
 
-.privacy-settings-accordion-panel {
+.privacy-settings-accordion-panel,
+.health-check-accordion-panel {
 	margin: 0;
 	padding: 1em 1.5em;
 	background: #fff;
 }
 
-.privacy-settings-accordion-panel[hidden] {
+.privacy-settings-accordion-panel[hidden],
+.health-check-accordion-panel[hidden] {
 	display: none;
 }
 
-.privacy-settings-accordion-panel a .dashicons {
+.privacy-settings-accordion-panel a .dashicons,
+.health-check-accordion-panel a .dashicons {
 	text-decoration: none;
 }
 
@@ -945,16 +985,19 @@ form#tags-filter {
 /* Media queries */
 @media screen and (max-width: 782px) {
 
-	.privacy-settings-body {
+	.privacy-settings-body,
+	.health-check-body {
 		margin: 0 12px;
 		width: auto;
 	}
 
-	.privacy-settings .notice {
+	.privacy-settings .notice,
+	.site-health .notice {
 		margin: 5px 10px 15px;
 	}
 
-	.privacy-settings .update-nag {
+	.privacy-settings .update-nag,
+	.site-health .update-nag {
 		margin-right: 10px;
 		margin-left: 10px;
 	}
@@ -971,7 +1014,8 @@ form#tags-filter {
 
 @media only screen and (max-width: 1004px) {
 
-	.privacy-settings-body {
+	.privacy-settings-body,
+	.health-check-body {
 		margin: 0 22px;
 		width: auto;
 	}

--- a/src/wp-admin/css/site-health.css
+++ b/src/wp-admin/css/site-health.css
@@ -1,17 +1,6 @@
-.site-health #wpcontent,
-.site-health.auto-fold #wpcontent {
-	padding-left: 0;
-}
-
-/* Emulates .wrap h1 styling */
-.health-check-header h1 {
-	display: inline-block;
-	font-weight: 600;
-	margin: 0 0.8rem 1rem;
-	font-size: 23px;
-	padding: 9px 0 4px 0;
-	line-height: 1.3;
-}
+/* Note: Any Site Health selectors that use
+duplicate styling from the Privacy settings screen
+are styled in the Privacy section of edit.css */
 
 .health-check-body h2 {
 	line-height: 1.4;
@@ -20,25 +9,6 @@
 .health-check-body h3 {
 	padding: 0;
 	font-weight: 400;
-}
-
-.health-check-header {
-	text-align: center;
-	margin: 0 0 1rem;
-	background: #fff;
-	border-bottom: 1px solid #dcdcde;
-}
-
-.health-check-title-section {
-	clear: both;
-	text-align: center;
-	padding-top: 8px;
-}
-
-.site-health .health-check-title-section {
-	display: flex;
-	align-items: center;
-	justify-content: center;
 }
 
 .site-health-progress-wrapper {
@@ -186,24 +156,6 @@
 	box-shadow: 0 2px 5px 0 rgba( 0, 0, 0, 0.75 );
 }
 
-.health-check-tab:nth-child(1) {
-	-ms-grid-column: 1; /* IE 11 */
-}
-
-.health-check-tab:nth-child(2) {
-	-ms-grid-column: 2; /* IE 11 */
-}
-
-.health-check-tab:focus {
-	color: #1d2327;
-	outline: 1px solid #787c82;
-	box-shadow: none;
-}
-
-.health-check-tab.active {
-	box-shadow: inset 0 -3px #3582c4;
-	font-weight: 600;
-}
 .health-check-offscreen-nav .health-check-tab.active {
 	box-shadow: inset 3px 0 #3582c4;
 	font-weight: 600;
@@ -321,130 +273,12 @@
 	margin: 0;
 }
 
-.health-check-accordion {
-	border: 1px solid #c3c4c7;
-}
-
-.health-check-accordion-heading {
-	margin: 0;
-	border-top: 1px solid #c3c4c7;
-	font-size: inherit;
-	line-height: inherit;
-	font-weight: 600;
-	color: inherit;
-}
-
-.health-check-accordion-heading:first-child {
-	border-top: none;
-}
-
-.health-check-accordion-trigger {
-	background: #fff;
-	border: 0;
-	color: #2c3338;
-	cursor: pointer;
-	display: flex;
-	font-weight: 400;
-	margin: 0;
-	padding: 1em 3.5em 1em 1.5em;
-	min-height: 46px;
-	position: relative;
-	text-align: left;
-	width: 100%;
-	align-items: center;
-	justify-content: space-between;
-	-webkit-user-select: auto;
-	user-select: auto;
-}
-
 .wp-core-ui .button.site-health-view-passed {
 	position: relative;
 	padding-right: 40px;
 	padding-left: 20px;
 }
 
-.health-check-accordion-trigger:hover,
-.health-check-accordion-trigger:active {
-	background: #f6f7f7;
-}
-
-.health-check-accordion-trigger:focus {
-	color: #1d2327;
-	border: none;
-	box-shadow: none;
-	outline-offset: -1px;
-	outline: 2px solid #2271b1;
-	background-color: #f6f7f7;
-}
-
-.health-check-accordion-trigger .title {
-	pointer-events: none;
-	font-weight: 600;
-	flex-grow: 1;
-}
-
-.health-check-accordion-trigger .icon,
-.site-health-view-passed .icon {
-	border: solid #50575e;
-	border-width: 0 2px 2px 0;
-	height: 0.5rem;
-	pointer-events: none;
-	position: absolute;
-	right: 1.5em;
-	top: 50%;
-	transform: translateY(-70%) rotate(45deg);
-	width: 0.5rem;
-}
-
-.health-check-accordion-trigger .badge {
-	padding: 0.1rem 0.5rem 0.15rem;
-	color: #2c3338;
-	font-weight: 600;
-	margin-left: 0.5rem;
-}
-
-.health-check-accordion-trigger .badge.blue {
-	border: 1px solid #72aee6;
-}
-
-.health-check-accordion-trigger .badge.orange {
-	border: 1px solid #dba617;
-}
-
-.health-check-accordion-trigger .badge.red {
-	border: 1px solid #e65054;
-}
-
-.health-check-accordion-trigger .badge.green {
-	border: 1px solid #00ba37;
-}
-
-.health-check-accordion-trigger .badge.purple {
-	border: 1px solid #2271b1;
-}
-
-.health-check-accordion-trigger .badge.gray {
-	border: 1px solid #c3c4c7;
-}
-
-.health-check-accordion-trigger[aria-expanded="true"] .icon,
-.site-health-view-passed[aria-expanded="true"] .icon {
-	transform: translateY(-30%) rotate(-135deg)
-}
-
-.health-check-accordion-panel {
-	margin: 0;
-	padding: 1em 1.5em;
-	background: #fff;
-}
-
-.health-check-accordion-panel[hidden] {
-	display: none;
-}
-
-.health-check-accordion-panel a .dashicons {
-	text-decoration: none;
-}
 
 /* Better position for the WordPress admin notices and update nag. */
 .site-health .notice {
@@ -486,19 +320,6 @@
 }
 
 @media screen and (max-width: 782px) {
-	.health-check-body {
-		margin: 0 12px;
-		width: auto;
-	}
-
-	.site-health .notice {
-		margin: 5px 10px 15px;
-	}
-
-	.site-health .update-nag {
-		margin-right: 10px;
-		margin-left: 10px;
-	}
 
 	.site-health-issues-wrapper .health-check-accordion-trigger {
 		flex-direction: column;
@@ -531,10 +352,3 @@
 	}
 }
 
-/* The breakpoint is usually at 960px, the additional space is to allow for the margin. */
-@media only screen and (max-width: 1004px) {
-	.health-check-body {
-		margin: 0 22px;
-		width: auto;
-	}
-}

--- a/src/wp-admin/css/site-health.css
+++ b/src/wp-admin/css/site-health.css
@@ -11,6 +11,10 @@ are styled in the Privacy section of edit.css */
 	font-weight: 400;
 }
 
+.health-check-widget-title-section {
+	text-align: center;
+}
+
 .site-health-progress-wrapper {
 	margin-bottom: 1rem;
 }

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1891,7 +1891,7 @@ function wp_dashboard_site_health() {
 
 	$issues_total = $issue_counts['recommended'] + $issue_counts['critical'];
 	?>
-	<div class="health-check-title-section site-health-progress-wrapper loading hide-if-no-js">
+	<div class="health-check-widget-title-section site-health-progress-wrapper loading hide-if-no-js">
 		<div class="site-health-progress">
 			<svg role="img" aria-hidden="true" focusable="false" width="100%" height="100%" viewBox="0 0 200 200" version="1.1" xmlns="http://www.w3.org/2000/svg">
 				<circle r="90" cx="100" cy="100" fill="transparent" stroke-dasharray="565.48" stroke-dashoffset="0"></circle>


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
For declaration blocks in site-health.css that are duplicates of those for Privacy Settings in edit.css, add the selectors from site-health.css to the ruleset in edit.css to combine these duplicate styles.

There were two areas with inconsistency that I changed when moving the selectors:
* Addition of `user-select: auto` to `.privacy-settings-accordion-trigger`
* Use flex for alignment in `.health-check-title-section` vs. only text-align
* Add `padding-top: 8px` to `.privacy-settings-title-section` to match that of Site Health

Trac ticket: https://core.trac.wordpress.org/ticket/52429

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
