### PR TITLE
fix(Site Health): don't run rest test from cron

### DIFF
--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -2361,8 +2361,9 @@ class WP_Site_Health {
 		// Conditionally include REST rules if the function for it exists.
 		if ( function_exists( 'rest_url' ) ) {
 			$tests['direct']['rest_availability'] = array(
-				'label' => __( 'REST API availability' ),
-				'test'  => 'rest_availability',
+				'label'     => __( 'REST API availability' ),
+				'test'      => 'rest_availability',
+				'skip_cron' => true,
 			);
 		}
 
@@ -2729,6 +2730,9 @@ class WP_Site_Health {
 		}
 
 		foreach ( $tests['direct'] as $test ) {
+			if ( ! empty( $test['skip_cron'] ) ) {
+				continue;
+			}
 
 			if ( is_string( $test['test'] ) ) {
 				$test_function = sprintf(


### PR DESCRIPTION
The rest test checks an authenticated context and so is unsuitable for
running from a system cron job which has no authenticated user.

This change skips the rest test when running from cron, fixing a false
positive from temporarily appearing in the dashboard widget.

Trac #52112

Trac ticket: https://core.trac.wordpress.org/ticket/52112

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
