### PR TITLE
Add unit tests for `construct_wp_query_args`

### DIFF
--- a/tests/phpunit/tests/blocks/block.php
+++ b/tests/phpunit/tests/blocks/block.php
@@ -414,36 +414,17 @@ class WP_Block_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests `construct_wp_query_args` that is
-	 * helper function that constructs a WP_Query args
-	 * array from a `Query` block properties.
-	 *
 	 * @ticket 53240
 	 */
-	public function test_construct_wp_query_args() {
+	public function test_build_query_vars_from_query_block() {
 		$this->registry->register(
 			'core/example',
 			array( 'uses_context' => array( 'query' ) )
 		);
 
-		$parsed_blocks    = parse_blocks( '<!-- wp:example {"ok":true} -->a<!-- wp:example /-->b<!-- /wp:example -->' );
-		$parsed_block     = $parsed_blocks[0];
-		$block_no_context = new WP_Block( $parsed_block, array(), $this->registry );
-
-		// It should return the default context when block doesn't use `query` context.
-		$query = construct_wp_query_args( $block_no_context, 1 );
-		$this->assertSame(
-			$query,
-			array(
-				'post_type'    => 'post',
-				'order'        => 'DESC',
-				'orderby'      => 'date',
-				'post__not_in' => array(),
-			)
-		);
-
-		// It should return proper results.
-		$context = array(
+		$parsed_blocks = parse_blocks( '<!-- wp:example {"ok":true} -->a<!-- wp:example /-->b<!-- /wp:example -->' );
+		$parsed_block  = $parsed_blocks[0];
+		$context       = array(
 			'query' => array(
 				'postType'    => 'page',
 				'exclude'     => array( 1, 2 ),
@@ -452,8 +433,9 @@ class WP_Block_Test extends WP_UnitTestCase {
 				'tagIds'      => array( 3, 11, 10 ),
 			),
 		);
-		$block   = new WP_Block( $parsed_block, $context, $this->registry );
-		$query   = construct_wp_query_args( $block, 1 );
+		$block         = new WP_Block( $parsed_block, $context, $this->registry );
+		$query         = construct_wp_query_args( $block, 1 );
+
 		$this->assertSame(
 			$query,
 			array(
@@ -465,16 +447,50 @@ class WP_Block_Test extends WP_UnitTestCase {
 				'tag__in'      => array( 3, 11, 10 ),
 			)
 		);
+	}
 
-		// Case for first `$page` with no `offset`.
-		$context = array(
+	/**
+	 * @ticket 53240
+	 */
+	public function test_build_query_vars_from_query_block_no_context() {
+		$this->registry->register( 'core/example', array() );
+
+		$parsed_blocks    = parse_blocks( '<!-- wp:example {"ok":true} -->a<!-- wp:example /-->b<!-- /wp:example -->' );
+		$parsed_block     = $parsed_blocks[0];
+		$block_no_context = new WP_Block( $parsed_block, array(), $this->registry );
+		$query            = construct_wp_query_args( $block_no_context, 1 );
+
+		$this->assertSame(
+			$query,
+			array(
+				'post_type'    => 'post',
+				'order'        => 'DESC',
+				'orderby'      => 'date',
+				'post__not_in' => array(),
+			)
+		);
+	}
+
+	/**
+	 * @ticket 53240
+	 */
+	public function test_build_query_vars_from_query_block_first_page() {
+		$this->registry->register(
+			'core/example',
+			array( 'uses_context' => array( 'query' ) )
+		);
+
+		$parsed_blocks = parse_blocks( '<!-- wp:example {"ok":true} -->a<!-- wp:example /-->b<!-- /wp:example -->' );
+		$parsed_block  = $parsed_blocks[0];
+		$context       = array(
 			'query' => array(
 				'perPage' => 2,
 				'offset'  => 0,
 			),
 		);
-		$block   = new WP_Block( $parsed_block, $context, $this->registry );
-		$query   = construct_wp_query_args( $block, 1 );
+		$block         = new WP_Block( $parsed_block, $context, $this->registry );
+		$query         = construct_wp_query_args( $block, 1 );
+
 		$this->assertSame(
 			$query,
 			array(
@@ -486,16 +502,27 @@ class WP_Block_Test extends WP_UnitTestCase {
 				'posts_per_page' => 2,
 			)
 		);
+	}
 
-		// Case for set `$page` with no `offset`.
-		$context = array(
+	/**
+	 * @ticket 53240
+	 */
+	public function test_build_query_vars_from_query_block_page_no_offset() {
+		$this->registry->register(
+			'core/example',
+			array( 'uses_context' => array( 'query' ) )
+		);
+
+		$parsed_blocks = parse_blocks( '<!-- wp:example {"ok":true} -->a<!-- wp:example /-->b<!-- /wp:example -->' );
+		$parsed_block  = $parsed_blocks[0];
+		$context       = array(
 			'query' => array(
 				'perPage' => 5,
 				'offset'  => 0,
 			),
 		);
-		$block   = new WP_Block( $parsed_block, $context, $this->registry );
-		$query   = construct_wp_query_args( $block, 3 );
+		$block         = new WP_Block( $parsed_block, $context, $this->registry );
+		$query         = construct_wp_query_args( $block, 3 );
 		$this->assertSame(
 			$query,
 			array(
@@ -507,16 +534,27 @@ class WP_Block_Test extends WP_UnitTestCase {
 				'posts_per_page' => 5,
 			)
 		);
+	}
 
-		// Case for set `$page` with `offset`.
-		$context = array(
+	/**
+	 * @ticket 53240
+	 */
+	public function test_build_query_vars_from_query_block_page_with_offset() {
+		$this->registry->register(
+			'core/example',
+			array( 'uses_context' => array( 'query' ) )
+		);
+
+		$parsed_blocks = parse_blocks( '<!-- wp:example {"ok":true} -->a<!-- wp:example /-->b<!-- /wp:example -->' );
+		$parsed_block  = $parsed_blocks[0];
+		$context       = array(
 			'query' => array(
 				'perPage' => 5,
 				'offset'  => 2,
 			),
 		);
-		$block   = new WP_Block( $parsed_block, $context, $this->registry );
-		$query   = construct_wp_query_args( $block, 3 );
+		$block         = new WP_Block( $parsed_block, $context, $this->registry );
+		$query         = construct_wp_query_args( $block, 3 );
 		$this->assertSame(
 			$query,
 			array(

--- a/tests/phpunit/tests/blocks/block.php
+++ b/tests/phpunit/tests/blocks/block.php
@@ -418,7 +418,7 @@ class WP_Block_Test extends WP_UnitTestCase {
 	 * helper function that constructs a WP_Query args
 	 * array from a `Query` block properties.
 	 *
-	 * @since 5.8.0
+	 * @ticket 53240
 	 */
 	public function test_construct_wp_query_args() {
 		$this->registry->register(


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/53240

This PR just adds unit tests for the new `construct_wp_query_args` function.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
