### PR TITLE
Show all X-WP-DoingItWrong headers in response

### DIFF
--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -653,7 +653,7 @@ function rest_handle_doing_it_wrong( $function, $message, $version ) {
 		$string = sprintf( $string, $function, $message );
 	}
 
-	header( sprintf( 'X-WP-DoingItWrong: %s', $string ) );
+	header( sprintf( 'X-WP-DoingItWrong: %s', $string ), false );
 }
 
 /**


### PR DESCRIPTION
This change allows all X-WP-DoingItWrong headers to be shown in the response, not just the last one.

Trac ticket: https://core.trac.wordpress.org/ticket/53243 <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
