### PR TITLE
Add unit tests for `block_has_support`

### DIFF
--- a/tests/phpunit/tests/blocks/block.php
+++ b/tests/phpunit/tests/blocks/block.php
@@ -585,7 +585,7 @@ class WP_Block_Test extends WP_UnitTestCase {
 				),
 			)
 		);
-		$block_type = $this->registry->get_registered( 'core/example' );
+		$block_type    = $this->registry->get_registered( 'core/example' );
 		$align_support = block_has_support( $block_type, array( 'align' ) );
 		$this->assertSame( $align_support, true );
 		$gradient_support = block_has_support( $block_type, array( 'color', 'gradient' ) );
@@ -603,7 +603,7 @@ class WP_Block_Test extends WP_UnitTestCase {
 	 */
 	public function test_block_has_support_no_supports() {
 		$this->registry->register( 'core/example', array() );
-		$block_type = $this->registry->get_registered( 'core/example' );
+		$block_type  = $this->registry->get_registered( 'core/example' );
 		$has_support = block_has_support( $block_type, array( 'color' ) );
 		$this->assertSame( $has_support, false );
 	}
@@ -622,7 +622,7 @@ class WP_Block_Test extends WP_UnitTestCase {
 				),
 			)
 		);
-		$block_type = $this->registry->get_registered( 'core/example' );
+		$block_type    = $this->registry->get_registered( 'core/example' );
 		$align_support = block_has_support( $block_type, array( 'align' ), true );
 		$this->assertSame( $align_support, true );
 		$gradient_support = block_has_support( $block_type, array( 'color', 'gradient' ), true );

--- a/tests/phpunit/tests/blocks/block.php
+++ b/tests/phpunit/tests/blocks/block.php
@@ -567,4 +567,65 @@ class WP_Block_Test extends WP_UnitTestCase {
 			)
 		);
 	}
+
+	/**
+	 * @ticket 53257
+	 */
+	public function test_block_has_support() {
+		$this->registry->register(
+			'core/example',
+			array(
+				'supports' => array(
+					'align'    => array( 'wide', 'full' ),
+					'fontSize' => true,
+					'color'    => array(
+						'link'     => true,
+						'gradient' => false,
+					),
+				),
+			)
+		);
+		$block_type = $this->registry->get_registered( 'core/example' );
+		$align_support = block_has_support( $block_type, array( 'align' ) );
+		$this->assertSame( $align_support, true );
+		$gradient_support = block_has_support( $block_type, array( 'color', 'gradient' ) );
+		$this->assertSame( $gradient_support, false );
+		$link_support = block_has_support( $block_type, array( 'color', 'link' ), false );
+		$this->assertSame( $link_support, true );
+		$text_support = block_has_support( $block_type, array( 'color', 'text' ) );
+		$this->assertSame( $text_support, false );
+		$font_nested = block_has_support( $block_type, array( 'fontSize', 'nested' ) );
+		$this->assertSame( $font_nested, false );
+	}
+
+	/**
+	 * @ticket 53257
+	 */
+	public function test_block_has_support_no_supports() {
+		$this->registry->register( 'core/example', array() );
+		$block_type = $this->registry->get_registered( 'core/example' );
+		$has_support = block_has_support( $block_type, array( 'color' ) );
+		$this->assertSame( $has_support, false );
+	}
+
+	/**
+	 * @ticket 53257
+	 */
+	public function test_block_has_support_provided_defaults() {
+		$this->registry->register(
+			'core/example',
+			array(
+				'supports' => array(
+					'color' => array(
+						'gradient' => false,
+					),
+				),
+			)
+		);
+		$block_type = $this->registry->get_registered( 'core/example' );
+		$align_support = block_has_support( $block_type, array( 'align' ), true );
+		$this->assertSame( $align_support, true );
+		$gradient_support = block_has_support( $block_type, array( 'color', 'gradient' ), true );
+		$this->assertSame( $gradient_support, false );
+	}
 }

--- a/tests/phpunit/tests/blocks/block.php
+++ b/tests/phpunit/tests/blocks/block.php
@@ -569,7 +569,7 @@ class WP_Block_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket 53257
+	 * @ticket 52991
 	 */
 	public function test_block_has_support() {
 		$this->registry->register(
@@ -587,29 +587,29 @@ class WP_Block_Test extends WP_UnitTestCase {
 		);
 		$block_type    = $this->registry->get_registered( 'core/example' );
 		$align_support = block_has_support( $block_type, array( 'align' ) );
-		$this->assertSame( $align_support, true );
+		$this->assertTrue( $align_support );
 		$gradient_support = block_has_support( $block_type, array( 'color', 'gradient' ) );
-		$this->assertSame( $gradient_support, false );
+		$this->assertFalse( $gradient_support );
 		$link_support = block_has_support( $block_type, array( 'color', 'link' ), false );
-		$this->assertSame( $link_support, true );
+		$this->assertTrue( $link_support );
 		$text_support = block_has_support( $block_type, array( 'color', 'text' ) );
-		$this->assertSame( $text_support, false );
+		$this->assertFalse( $text_support );
 		$font_nested = block_has_support( $block_type, array( 'fontSize', 'nested' ) );
-		$this->assertSame( $font_nested, false );
+		$this->assertFalse( $font_nested );
 	}
 
 	/**
-	 * @ticket 53257
+	 * @ticket 52991
 	 */
 	public function test_block_has_support_no_supports() {
 		$this->registry->register( 'core/example', array() );
 		$block_type  = $this->registry->get_registered( 'core/example' );
 		$has_support = block_has_support( $block_type, array( 'color' ) );
-		$this->assertSame( $has_support, false );
+		$this->assertFalse( $has_support );
 	}
 
 	/**
-	 * @ticket 53257
+	 * @ticket 52991
 	 */
 	public function test_block_has_support_provided_defaults() {
 		$this->registry->register(
@@ -624,8 +624,8 @@ class WP_Block_Test extends WP_UnitTestCase {
 		);
 		$block_type    = $this->registry->get_registered( 'core/example' );
 		$align_support = block_has_support( $block_type, array( 'align' ), true );
-		$this->assertSame( $align_support, true );
+		$this->assertTrue( $align_support );
 		$gradient_support = block_has_support( $block_type, array( 'color', 'gradient' ), true );
-		$this->assertSame( $gradient_support, false );
+		$this->assertFalse( $gradient_support );
 	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/53257


This PR just adds some unit tests for `block_has_support` function.

What I wanted to verify though is if this is the expected behavior in the case we have declared `supports` for a key with an `empty array`. Should this return true as it does now?

Example test that passes with an empty array:
```
public function test_block_has_support_empty_array() {
	$this->registry->register(
		'core/example',
		array(
			'supports' => array(
				'align' => array(),
			),
		)
	);
	$block_type = $this->registry->get_registered( 'core/example' );
	$align_support = block_has_support( $block_type, array( 'align' ) );
	$this->assertSame( $align_support, true );
}
```



---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
