### PR TITLE
fix: deprecated jQuery click function

### DIFF
--- a/src/js/_enqueues/vendor/plupload/handlers.js
+++ b/src/js/_enqueues/vendor/plupload/handlers.js
@@ -149,7 +149,7 @@ function prepareMediaItemInit( fileObj ) {
 	jQuery( '.filename.original', item ).replaceWith( jQuery( '.filename.new', item ) );
 
 	// Bind Ajax to the new Delete button.
-	jQuery( 'a.delete', item ).click( function(){
+	jQuery( 'a.delete', item ).on( 'click', function(){
 		// Tell the server to delete it. TODO: Handle exceptions.
 		jQuery.ajax({
 			url: ajaxurl,
@@ -167,7 +167,7 @@ function prepareMediaItemInit( fileObj ) {
 	});
 
 	// Bind Ajax to the new Undo button.
-	jQuery( 'a.undo', item ).click( function(){
+	jQuery( 'a.undo', item ).on( 'click', function(){
 		// Tell the server to untrash it. TODO: Handle exceptions.
 		jQuery.ajax({
 			url: ajaxurl,


### PR DESCRIPTION
This PR will fix the deprecated jQuery click function in `js/_enqueues/vendor/plupload/handlers.js`

Trac ticket: https://core.trac.wordpress.org/ticket/53261