### PR TITLE
Remove `gutenberg` domain from block patterns

### DIFF
--- a/src/wp-includes/block-patterns/query-grid-posts.php
+++ b/src/wp-includes/block-patterns/query-grid-posts.php
@@ -6,7 +6,7 @@
  */
 
 return array(
-	'title'      => __( 'Grid', 'gutenberg' ),
+	'title'      => _x( 'Grid', 'Block pattern title' ),
 	'blockTypes' => array( 'core/query' ),
 	'categories' => array( 'query' ),
 	'content'    => '<!-- wp:query {"query":{"perPage":6,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"displayLayout":{"type":"flex","columns":3}} -->

--- a/src/wp-includes/block-patterns/query-large-title-posts.php
+++ b/src/wp-includes/block-patterns/query-large-title-posts.php
@@ -6,7 +6,7 @@
  */
 
 return array(
-	'title'      => __( 'Large title', 'gutenberg' ),
+	'title'      => _x( 'Large title', 'Block pattern title' ),
 	'blockTypes' => array( 'core/query' ),
 	'categories' => array( 'query' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"100px","right":"100px","bottom":"100px","left":"100px"}},"color":{"text":"#ffffff","background":"#000000"}}} -->

--- a/src/wp-includes/block-patterns/query-medium-posts.php
+++ b/src/wp-includes/block-patterns/query-medium-posts.php
@@ -6,7 +6,7 @@
  */
 
 return array(
-	'title'      => __( 'Image at left', 'gutenberg' ),
+	'title'      => _x( 'Image at left', 'Block pattern title' ),
 	'blockTypes' => array( 'core/query' ),
 	'categories' => array( 'query' ),
 	'content'    => '<!-- wp:query {"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->

--- a/src/wp-includes/block-patterns/query-offset-posts.php
+++ b/src/wp-includes/block-patterns/query-offset-posts.php
@@ -6,7 +6,7 @@
  */
 
 return array(
-	'title'      => __( 'Offset', 'gutenberg' ),
+	'title'      => _x( 'Offset', 'Block pattern title' ),
 	'blockTypes' => array( 'core/query' ),
 	'categories' => array( 'query' ),
 	'content'    => '<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"30px","right":"30px","bottom":"30px","left":"30px"}}},"layout":{"inherit":false}} -->

--- a/src/wp-includes/block-patterns/query-small-posts.php
+++ b/src/wp-includes/block-patterns/query-small-posts.php
@@ -6,7 +6,7 @@
  */
 
 return array(
-	'title'      => __( 'Small image and title', 'gutenberg' ),
+	'title'      => _x( 'Small image and title', 'Block pattern title' ),
 	'blockTypes' => array( 'core/query' ),
 	'categories' => array( 'query' ),
 	'content'    => '<!-- wp:query {"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->

--- a/src/wp-includes/block-patterns/query-standard-posts.php
+++ b/src/wp-includes/block-patterns/query-standard-posts.php
@@ -6,7 +6,7 @@
  */
 
 return array(
-	'title'      => __( 'Standard', 'gutenberg' ),
+	'title'      => _x( 'Standard', 'Block pattern title' ),
 	'blockTypes' => array( 'core/query' ),
 	'categories' => array( 'query' ),
 	'content'    => '<!-- wp:query {"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->

--- a/src/wp-includes/block-patterns/social-links-shared-background-color.php
+++ b/src/wp-includes/block-patterns/social-links-shared-background-color.php
@@ -6,7 +6,7 @@
  */
 
 return array(
-	'title'         => __( 'Social links with a shared background color', 'gutenberg' ),
+	'title'         => _x( 'Social links with a shared background color', 'Block pattern title' ),
 	'categories'    => array( 'buttons' ),
 	'blockTypes'    => array( 'core/social-links' ),
 	'viewportWidth' => 500,


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/53265

Follow up on:https://github.com/WordPress/wordpress-develop/pull/1274 where the `gutenberg` domain was not removed.


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
