### PR TITLE
Only load wp-editor-classic-layout-styles styles for themes without theme.json support

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1513,7 +1513,7 @@ function wp_default_styles( $styles ) {
 	);
 
 	// Only load the default layout and margin styles for themes without theme.json file.
-	if ( ! WP_Theme_JSON_Resolver_Gutenberg::theme_has_support() ) {
+	if ( ! WP_Theme_JSON_Resolver::theme_has_support() ) {
 		$wp_edit_blocks_dependencies[] = 'wp-editor-classic-layout-styles';
 	}
 
@@ -1618,7 +1618,7 @@ function wp_default_styles( $styles ) {
 	);
 
 	// Only load the default layout and margin styles for themes without theme.json file.
-	if ( ! WP_Theme_JSON_Resolver_Gutenberg::theme_has_support() ) {
+	if ( ! WP_Theme_JSON_Resolver::theme_has_support() ) {
 		$rtl_styles[] = 'wp-editor-classic-layout-styles';
 	}
 

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1621,7 +1621,7 @@ function wp_default_styles( $styles ) {
 	if ( ! WP_Theme_JSON_Resolver_Gutenberg::theme_has_support() ) {
 		$rtl_styles[] = 'wp-editor-classic-layout-styles';
 	}
-	
+
 	foreach ( $rtl_styles as $rtl_style ) {
 		$styles->add_data( $rtl_style, 'rtl', 'replace' );
 		if ( $suffix ) {

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1600,6 +1600,7 @@ function wp_default_styles( $styles ) {
 		'wp-jquery-ui-dialog',
 		// Package styles.
 		'wp-reset-editor-styles',
+		'wp-editor-classic-layout-styles',
 		'wp-block-library-theme',
 		'wp-edit-blocks',
 		'wp-block-editor',
@@ -1616,11 +1617,6 @@ function wp_default_styles( $styles ) {
 		'deprecated-media',
 		'farbtastic',
 	);
-
-	// Only load the default layout and margin styles for themes without theme.json file.
-	if ( ! WP_Theme_JSON_Resolver::theme_has_support() ) {
-		$rtl_styles[] = 'wp-editor-classic-layout-styles';
-	}
 
 	foreach ( $rtl_styles as $rtl_style ) {
 		$styles->add_data( $rtl_style, 'rtl', 'replace' );

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1600,7 +1600,6 @@ function wp_default_styles( $styles ) {
 		'wp-jquery-ui-dialog',
 		// Package styles.
 		'wp-reset-editor-styles',
-		'wp-editor-classic-layout-styles',
 		'wp-block-library-theme',
 		'wp-edit-blocks',
 		'wp-block-editor',
@@ -1618,6 +1617,11 @@ function wp_default_styles( $styles ) {
 		'farbtastic',
 	);
 
+	// Only load the default layout and margin styles for themes without theme.json file.
+	if ( ! WP_Theme_JSON_Resolver_Gutenberg::theme_has_support() ) {
+		$rtl_styles[] = 'wp-editor-classic-layout-styles';
+	}
+	
 	foreach ( $rtl_styles as $rtl_style ) {
 		$styles->add_data( $rtl_style, 'rtl', 'replace' );
 		if ( $suffix ) {

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1510,12 +1510,13 @@ function wp_default_styles( $styles ) {
 		'wp-reset-editor-styles',
 		'wp-block-library',
 		'wp-reusable-blocks',
-
-		// This dependency shouldn't be added for themes with theme.json support
-		// It's here for backward compatibility only.
-		// A check should be added here when theme.json is backported to Core.
-		'wp-editor-classic-layout-styles',
 	);
+
+	// Only load the default layout and margin styles for themes without theme.json file.
+	if ( ! WP_Theme_JSON_Resolver_Gutenberg::theme_has_support() ) {
+		$wp_edit_blocks_dependencies[] = 'wp-editor-classic-layout-styles';
+	}
+
 	global $editor_styles;
 	if ( ! is_array( $editor_styles ) || count( $editor_styles ) === 0 ) {
 		// Include opinionated block styles if no $editor_styles are declared, so the editor never appears broken.


### PR DESCRIPTION
Part of https://core.trac.wordpress.org/ticket/53175
See https://github.com/WordPress/gutenberg/issues/31322
Related https://github.com/WordPress/gutenberg/pull/30375

## How to test

Activate a theme without `theme.json` support (TwentyTwenty):

- Load the post editor.
- Verify that the `wp-editor-classic-layout-styles-css` external stylesheet is loaded.

Activate a theme with `theme.json` support (TT1-blocks from the github repo not from the WordPress theme's repo, or add a theme.json file to the TwentyTwentyOne theme):

- Load the post editor.
- Verify that the `wp-editor-classic-layout-styles-css` external stylesheet is **not** loaded.

