### PR TITLE
Rely on unserialize() to check serialized data.

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -604,7 +604,7 @@ function maybe_serialize( $data ) {
 	 * See https://core.trac.wordpress.org/ticket/12930
 	 * Also the world will end. See WP 3.6.1.
 	 */
-	if ( is_serialized( $data, false ) ) {
+	if ( is_serialized( $data ) ) {
 		return serialize( $data );
 	}
 
@@ -636,65 +636,14 @@ function maybe_unserialize( $data ) {
  * @since 2.0.5
  *
  * @param string $data   Value to check to see if was serialized.
- * @param bool   $strict Optional. Whether to be strict about the end of the string. Default true.
  * @return bool False if not serialized and true if it was.
  */
-function is_serialized( $data, $strict = true ) {
+function is_serialized( $data ) {
 	// If it isn't a string, it isn't serialized.
 	if ( ! is_string( $data ) ) {
 		return false;
 	}
-	$data = trim( $data );
-	if ( 'N;' === $data ) {
-		return true;
-	}
-	if ( strlen( $data ) < 4 ) {
-		return false;
-	}
-	if ( ':' !== $data[1] ) {
-		return false;
-	}
-	if ( $strict ) {
-		$lastc = substr( $data, -1 );
-		if ( ';' !== $lastc && '}' !== $lastc ) {
-			return false;
-		}
-	} else {
-		$semicolon = strpos( $data, ';' );
-		$brace     = strpos( $data, '}' );
-		// Either ; or } must exist.
-		if ( false === $semicolon && false === $brace ) {
-			return false;
-		}
-		// But neither must be in the first X characters.
-		if ( false !== $semicolon && $semicolon < 3 ) {
-			return false;
-		}
-		if ( false !== $brace && $brace < 4 ) {
-			return false;
-		}
-	}
-	$token = $data[0];
-	switch ( $token ) {
-		case 's':
-			if ( $strict ) {
-				if ( '"' !== substr( $data, -2, 1 ) ) {
-					return false;
-				}
-			} elseif ( false === strpos( $data, '"' ) ) {
-				return false;
-			}
-			// Or else fall through.
-		case 'a':
-		case 'O':
-			return (bool) preg_match( "/^{$token}:[0-9]+:/s", $data );
-		case 'b':
-		case 'i':
-		case 'd':
-			$end = $strict ? '$' : '';
-			return (bool) preg_match( "/^{$token}:[0-9.E+-]+;$end/", $data );
-	}
-	return false;
+	return false !== @unserialize( $data, [ 'allowed_classes' => false ] ) || serialize( false ) === $data;
 }
 
 /**


### PR DESCRIPTION
Rely on PHP proper unserliaze() return value to check whether a string contains serialized data instead of implementing a custom heuristic and break third-party software.

Trac ticket: https://core.trac.wordpress.org/ticket/53295