### PR TITLE
REST API: Prevent duplicate widget types

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-widget-types-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-widget-types-controller.php
@@ -225,7 +225,7 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 			}
 			$widget['classname'] = ltrim( $classname, '_' );
 
-			$widgets[] = $widget;
+			$widgets[ $widget['id'] ] = $widget;
 		}
 
 		return $widgets;


### PR DESCRIPTION
Modifies the `/wp/v2/widget-types` endpoint to de-duplicate widget types by their id. Duplicates appear because `WP_Widget::_register` will add one entry to `$wp_registered_widgets` per widget instance.

Trac ticket: https://core.trac.wordpress.org/ticket/53305

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
