### PR TITLE
Define constant in use

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -34,6 +34,11 @@ require ABSPATH . WPINC . '/class.wp-styles.php';
 /** WordPress Styles Functions */
 require ABSPATH . WPINC . '/functions.wp-styles.php';
 
+// WP_CONTENT_DIR ends up being used by get_stylesheet_directory
+// through the get_theme_root call.
+if ( ! defined( 'WP_CONTENT_DIR' ) ) {
+	define( 'WP_CONTENT_DIR', ABSPATH . 'wp-content' );
+}
 // get_stylesheet_directory() is used by WP_Theme_JSON_Resolver::theme_has_support().
 if ( ! function_exists( 'get_stylesheet_directory' ) ) {
 	require_once ABSPATH . WPINC . '/theme.php';


### PR DESCRIPTION
Fixes https://core.trac.wordpress.org/ticket/53175#comment:34

Steps to reproduce:

- Use a WordPress environment with PHP 8.
- Activate the debug logs.
- Set `error_reporting( -1 );` at the head of `load-styles.php`.
- Visit `/wp-admin/load-styles.php?load=wp-components`

The expected result is that the styles load and that there's no message in the log.

Previous to this change, the styles won't load and you'll see this error in the log `Fatal error: Uncaught Error: Undefined constant "WP_CONTENT_DIR"`.
