### PR TITLE
Import deps in load-styles & wp-settings instead of script-loader

### DIFF
--- a/src/wp-admin/load-styles.php
+++ b/src/wp-admin/load-styles.php
@@ -13,8 +13,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( 'WPINC', 'wp-includes' );
+define( 'WP_CONTENT_DIR', ABSPATH . 'wp-content' );
 
 require ABSPATH . 'wp-admin/includes/noop.php';
+require ABSPATH . WPINC . '/theme.php';
+require ABSPATH . WPINC . '/class-wp-theme-json-resolver.php';
 require ABSPATH . WPINC . '/script-loader.php';
 require ABSPATH . WPINC . '/version.php';
 

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -34,14 +34,6 @@ require ABSPATH . WPINC . '/class.wp-styles.php';
 /** WordPress Styles Functions */
 require ABSPATH . WPINC . '/functions.wp-styles.php';
 
-// get_stylesheet_directory() is used by WP_Theme_JSON_Resolver::theme_has_support().
-if ( ! function_exists( 'get_stylesheet_directory' ) ) {
-	require_once ABSPATH . WPINC . '/theme.php';
-}
-if ( ! class_exists( 'WP_Theme_JSON_Resolver' ) ) {
-	require_once ABSPATH . WPINC . '/class-wp-theme-json-resolver.php';
-}
-
 /**
  * Registers TinyMCE scripts.
  *

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -171,6 +171,7 @@ require ABSPATH . WPINC . '/class-wp-date-query.php';
 require ABSPATH . WPINC . '/theme.php';
 require ABSPATH . WPINC . '/class-wp-theme.php';
 require ABSPATH . WPINC . '/class-wp-theme-json.php';
+require ABSPATH . WPINC . '/class-wp-theme-json-resolver.php';
 require ABSPATH . WPINC . '/class-wp-block-template.php';
 require ABSPATH . WPINC . '/block-template-utils.php';
 require ABSPATH . WPINC . '/block-template.php';


### PR DESCRIPTION
Fixes https://core.trac.wordpress.org/ticket/53175#comment:34
Alternative to https://github.com/WordPress/wordpress-develop/pull/1324

Steps to reproduce:

- Use a WordPress environment with PHP 8.
- Activate the debug logs.
- Set `error_reporting( -1 );` at the head of `load-styles.php`.
- Visit `/wp-admin/load-styles.php?load=wp-components`

The expected result is that the styles load and that there's no message in the log.

Previous to this change, the styles won't load and you'll see this error in the log `Fatal error: Uncaught Error: Undefined constant "WP_CONTENT_DIR"`.
