### PR TITLE
Allow to filter global styles in the editor

### DIFF
--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -285,10 +285,14 @@ function get_block_editor_settings( array $custom_settings, $block_editor_contex
 	$theme_json = WP_Theme_JSON_Resolver::get_merged_data( $editor_settings );
 
 	if ( WP_Theme_JSON_Resolver::theme_has_support() ) {
-		$editor_settings['styles'][] = array( 'css' => $theme_json->get_stylesheet( 'block_styles' ) );
 		$editor_settings['styles'][] = array(
-			'css'                     => $theme_json->get_stylesheet( 'css_variables' ),
-			'__experimentalNoWrapper' => true,
+			'css'                        => $theme_json->get_stylesheet( 'block_styles' ),
+			'__experimentalGlobalStyles' => true
+		);
+		$editor_settings['styles'][] = array(
+			'css'                        => $theme_json->get_stylesheet( 'css_variables' ),
+			'__experimentalNoWrapper'    => true,
+			'__experimentalGlobalStyles' => true
 		);
 	}
 


### PR DESCRIPTION
Part of https://core.trac.wordpress.org/ticket/53175

Global settings are filterable by hooking into the `block_editor_settings` filter. Global styles in the front end are filterable as well by getting the `global-styles` style handle ([see](https://github.com/WordPress/gutenberg/pull/32372)). However, there's no mechanism to filter the global styles that come with the editor.

This PR allows third-party to identify the styles that are going to be sent to the editor, so they can filter them.

## How to test

- Using WordPress 5.8, activate a theme with `theme.json` support.
  - Alternatively, using the TwentyTwentyOne theme, create a file named `theme.json` in the top-level folder of the theme and paste the following contents `{"version": 1}`.
- Load the post editor. Open the devtools and in the inspector search for `--wp--preset--color`.
- The expected result is that there are two occurrences: the `wp-edit-post-js-after` script and within a `<style>` tag in the body of the document, just before the `editor-styles-wrapper` node.

Now, install and activate the Gutenberg plugin from the plugin repository and do the same. What happens is that there will be three occurrences, the `wp-edit-post-js-after` embedded script and two identical `<style>` tags.

## Changes introduced

It adds a `__experimentalGlobalStyles` key to the styles so they can be inspected by others.

## Alternatives I've considered

I haven't seen many options to do something like this. A similar approach could be to add some sort of metadata in the first lines of the stylesheet instead. While feasible it seems more error-prone than this.
