### PR TITLE
Plugins: Remove Hello Dolly translations.

### DIFF
--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -1001,6 +1001,12 @@ function delete_plugins( $plugins, $deprecated = '' ) {
 
 		// Remove language files, silently.
 		$plugin_slug = dirname( $plugin_file );
+
+		// Add the correct slug for Hello Dolly.
+		if ( 'hello.php' === $plugin_file ) {
+			$plugin_slug = 'hello-dolly';
+		}
+
 		if ( '.' !== $plugin_slug && ! empty( $plugin_translations[ $plugin_slug ] ) ) {
 			$translations = $plugin_translations[ $plugin_slug ];
 


### PR DESCRIPTION
`delete_plugins()` tests two conditions:

1) That the `$plugin_slug` is not equal to `.`.
2) That `$plugin_translations[ $plugin_slug ]` is not `empty()`.

As Hello Dolly does not have its own directory, its `$plugin_slug` is `.`.
The first condition returns `false` and the translations files for Hello Dolly remain in `wp-content/languages/plugins`.

This edge case is now rectified by a conditional which specifically checks if `$plugin_file` is `hello.php` and correctly assigns `$plugin_slug` to `hello-dolly`.

Fixes #52817.

Trac ticket: https://core.trac.wordpress.org/ticket/52817
