### PR TITLE
Triggers deleting fresh site option when saved in new Widgets screen

### DIFF
--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -246,7 +246,17 @@ add_filter( 'wp_robots', 'wp_robots_noindex_search' );
 add_filter( 'wp_robots', 'wp_robots_max_image_preview_large' );
 
 // Mark site as no longer fresh.
-foreach ( array( 'publish_post', 'publish_page', 'wp_ajax_save-widget', 'wp_ajax_widgets-order', 'customize_save_after' ) as $action ) {
+foreach (
+	array(
+		'publish_post',
+		'publish_page',
+		'wp_ajax_save-widget',
+		'wp_ajax_widgets-order',
+		'customize_save_after',
+		'rest_after_save_widget',
+		'rest_delete_widget',
+	) as $action
+) {
 	add_action( $action, '_delete_option_fresh_site', 0 );
 }
 

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -255,6 +255,7 @@ foreach (
 		'customize_save_after',
 		'rest_after_save_widget',
 		'rest_delete_widget',
+		'rest_save_sidebar',
 	) as $action
 ) {
 	add_action( $action, '_delete_option_fresh_site', 0 );

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-sidebars-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-sidebars-controller.php
@@ -213,8 +213,10 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 		 * Fires after a sidebar is updated via the REST API.
 		 *
 		 * @since 5.8.0
+		 * @param array           $sidebar  The updated sidebar.
+		 * @param WP_REST_Request $request  Request object.
 		 */
-		do_action( 'rest_save_sidebar' );
+		do_action( 'rest_save_sidebar', $sidebar, $request );
 
 		return $this->prepare_item_for_response( $sidebar, $request );
 	}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-sidebars-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-sidebars-controller.php
@@ -209,6 +209,13 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 
 		$sidebar = $this->get_sidebar( $request['id'] );
 
+		/**
+		 * Fires after a sidebar is updated via the REST API.
+		 *
+		 * @since 5.8.0
+		 */
+		do_action( 'rest_save_sidebar' );
+
 		return $this->prepare_item_for_response( $sidebar, $request );
 	}
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-widgets-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-widgets-controller.php
@@ -204,9 +204,6 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 
 		$response->set_status( 201 );
 
-		// Triggers _delete_option_fresh_site to mark the site as no longer fresh.
-		do_action( 'wp_ajax_save-widget' );
-
 		return $response;
 	}
 
@@ -257,6 +254,8 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 			}
 		}
 
+		do_action( 'rest_save_sidebar' );
+
 		if ( $request->has_param( 'sidebar' ) ) {
 			if ( $sidebar_id !== $request['sidebar'] ) {
 				$sidebar_id = $request['sidebar'];
@@ -267,7 +266,7 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 		$request['context'] = 'edit';
 
 		// Triggers _delete_option_fresh_site to mark the site as no longer fresh.
-		do_action( 'wp_ajax_save-widget' );
+		do_action( 'rest_after_save_sidebar' );
 
 		return $this->prepare_item_for_response( compact( 'widget_id', 'sidebar_id' ), $request );
 	}
@@ -363,7 +362,7 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 		}
 
 		// Triggers _delete_option_fresh_site to mark the site as no longer fresh.
-		do_action( 'wp_ajax_save-widget' );
+		do_action( 'rest_delete_widget' );
 
 		return $response;
 	}
@@ -479,6 +478,8 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 			$form_data = array();
 		}
 
+		do_action( 'rest_save_widget' );
+
 		$original_post    = $_POST;
 		$original_request = $_REQUEST;
 
@@ -510,6 +511,8 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 			// want in the REST API, though, as we support batch requests.
 			$widget_object->updated = false;
 		}
+
+		do_action( 'rest_after_save_widget' );
 
 		return $id;
 	}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-widgets-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-widgets-controller.php
@@ -254,6 +254,11 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 			}
 		}
 
+		/**
+		 * Fires after a widget is updated via the REST API.
+		 *
+		 * @since 5.8.0
+		 */
 		do_action( 'rest_save_sidebar' );
 
 		if ( $request->has_param( 'sidebar' ) ) {
@@ -265,7 +270,11 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 
 		$request['context'] = 'edit';
 
-		// Triggers _delete_option_fresh_site to mark the site as no longer fresh.
+		/**
+		 * Fires after a widget is completely updated via the REST API.
+		 *
+		 * @since 5.8.0
+		 */
 		do_action( 'rest_after_save_sidebar' );
 
 		return $this->prepare_item_for_response( compact( 'widget_id', 'sidebar_id' ), $request );
@@ -361,7 +370,11 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 			);
 		}
 
-		// Triggers _delete_option_fresh_site to mark the site as no longer fresh.
+		/**
+		 * Fires after a widget is deleted via the REST API.
+		 *
+		 * @since 5.8.0
+		 */
 		do_action( 'rest_delete_widget' );
 
 		return $response;
@@ -478,6 +491,11 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 			$form_data = array();
 		}
 
+		/**
+		 * Fires after a widget is created or updated via the REST API.
+		 *
+		 * @since 5.8.0
+		 */
 		do_action( 'rest_save_widget' );
 
 		$original_post    = $_POST;
@@ -512,6 +530,11 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 			$widget_object->updated = false;
 		}
 
+		/**
+		 * Fires after a widget is completely created or updated via the REST API.
+		 *
+		 * @since 5.8.0
+		 */
 		do_action( 'rest_after_save_widget' );
 
 		return $id;

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-widgets-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-widgets-controller.php
@@ -204,6 +204,9 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 
 		$response->set_status( 201 );
 
+		// Triggers _delete_option_fresh_site to mark the site as no longer fresh.
+		do_action( 'wp_ajax_save-widget' );
+
 		return $response;
 	}
 
@@ -262,6 +265,9 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 		}
 
 		$request['context'] = 'edit';
+
+		// Triggers _delete_option_fresh_site to mark the site as no longer fresh.
+		do_action( 'wp_ajax_save-widget' );
 
 		return $this->prepare_item_for_response( compact( 'widget_id', 'sidebar_id' ), $request );
 	}
@@ -355,6 +361,9 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 				$request
 			);
 		}
+
+		// Triggers _delete_option_fresh_site to mark the site as no longer fresh.
+		do_action( 'wp_ajax_save-widget' );
 
 		return $response;
 	}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-widgets-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-widgets-controller.php
@@ -412,6 +412,7 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 			$id_base       = $parsed_id['id_base'];
 			$number        = isset( $parsed_id['number'] ) ? $parsed_id['number'] : null;
 			$widget_object = $wp_widget_factory->get_widget_object( $id_base );
+			$sidebar_id    = wp_find_widgets_sidebar( $id );
 			$creating      = false;
 		} elseif ( $request['id_base'] ) {
 			// Saving a new widget.
@@ -419,6 +420,7 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 			$widget_object = $wp_widget_factory->get_widget_object( $id_base );
 			$number        = $widget_object ? next_widget_id_number( $id_base ) : null;
 			$id            = $widget_object ? $id_base . '-' . $number : $id_base;
+			$sidebar_id    = $request['sidebar'];
 			$creating      = true;
 		} else {
 			return new WP_Error(
@@ -483,16 +485,6 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 			$form_data = array();
 		}
 
-		/**
-		 * Fires after a widget is created or updated via the REST API.
-		 *
-		 * @since 5.8.0
-		 * @param WP_Widget       $widget_object Inserted or updated widget object.
-		 * @param WP_REST_Request $request       Request object.
-		 * @param bool            $creating      True when creating a post, false when updating.
-		 */
-		do_action( 'rest_save_widget', $widget_object, $request, $creating );
-
 		$original_post    = $_POST;
 		$original_request = $_REQUEST;
 
@@ -526,14 +518,15 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 		}
 
 		/**
-		 * Fires after a widget is completely created or updated via the REST API.
+		 * Fires after a widget is created or updated via the REST API.
 		 *
 		 * @since 5.8.0
-		 * @param WP_Widget       $widget_object Inserted or updated widget object.
-		 * @param WP_REST_Request $request       Request object.
-		 * @param bool            $creating      True when creating a post, false when updating.
+		 * @param string          $id         ID of the widget being saved.
+		 * @param string          $sidebar_id ID of the sidebar containing the widget being saved.
+		 * @param WP_REST_Request $request    Request object.
+		 * @param bool            $creating   True when creating a widget, false when updating.
 		 */
-		do_action( 'rest_after_save_widget', $widget_object, $request, $creating );
+		do_action( 'rest_after_save_widget', $id, $sidebar_id, $request, $creating );
 
 		return $id;
 	}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-widgets-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-widgets-controller.php
@@ -254,13 +254,6 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 			}
 		}
 
-		/**
-		 * Fires after a widget is updated via the REST API.
-		 *
-		 * @since 5.8.0
-		 */
-		do_action( 'rest_save_sidebar' );
-
 		if ( $request->has_param( 'sidebar' ) ) {
 			if ( $sidebar_id !== $request['sidebar'] ) {
 				$sidebar_id = $request['sidebar'];
@@ -269,13 +262,6 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 		}
 
 		$request['context'] = 'edit';
-
-		/**
-		 * Fires after a widget is completely updated via the REST API.
-		 *
-		 * @since 5.8.0
-		 */
-		do_action( 'rest_after_save_sidebar' );
 
 		return $this->prepare_item_for_response( compact( 'widget_id', 'sidebar_id' ), $request );
 	}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-widgets-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-widgets-controller.php
@@ -186,7 +186,7 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 	public function create_item( $request ) {
 		$sidebar_id = $request['sidebar'];
 
-		$widget_id = $this->save_widget( $request );
+		$widget_id = $this->save_widget( $request, $sidebar_id );
 
 		if ( is_wp_error( $widget_id ) ) {
 			return $widget_id;
@@ -248,7 +248,7 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 			$request->has_param( 'instance' ) ||
 			$request->has_param( 'form_data' )
 		) {
-			$maybe_error = $this->save_widget( $request );
+			$maybe_error = $this->save_widget( $request, $sidebar_id );
 			if ( is_wp_error( $maybe_error ) ) {
 				return $maybe_error;
 			}
@@ -396,11 +396,12 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 	 *
 	 * @since 5.8.0
 	 *
-	 * @param WP_REST_Request $request Full details about the request.
+	 * @param WP_REST_Request $request    Full details about the request.
+	 * @param string          $sidebar_id ID of the sidebar the widget belongs to.
 	 *
 	 * @return string|WP_Error The saved widget ID.
 	 */
-	protected function save_widget( $request ) {
+	protected function save_widget( $request, $sidebar_id ) {
 		global $wp_widget_factory, $wp_registered_widget_updates;
 
 		require_once ABSPATH . 'wp-admin/includes/widgets.php'; // For next_widget_id_number().
@@ -412,7 +413,6 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 			$id_base       = $parsed_id['id_base'];
 			$number        = isset( $parsed_id['number'] ) ? $parsed_id['number'] : null;
 			$widget_object = $wp_widget_factory->get_widget_object( $id_base );
-			$sidebar_id    = wp_find_widgets_sidebar( $id );
 			$creating      = false;
 		} elseif ( $request['id_base'] ) {
 			// Saving a new widget.
@@ -420,7 +420,6 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 			$widget_object = $wp_widget_factory->get_widget_object( $id_base );
 			$number        = $widget_object ? next_widget_id_number( $id_base ) : null;
 			$id            = $widget_object ? $id_base . '-' . $number : $id_base;
-			$sidebar_id    = $request['sidebar'];
 			$creating      = true;
 		} else {
 			return new WP_Error(

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-widgets-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-widgets-controller.php
@@ -360,8 +360,12 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 		 * Fires after a widget is deleted via the REST API.
 		 *
 		 * @since 5.8.0
+		 * @param string           $widget_id  ID of the widget marked for deletion.
+		 * @param string           $sidebar_id ID of the sidebar the widget was deleted from.
+		 * @param WP_REST_Response $response   The response data.
+		 * @param WP_REST_Request  $request    The request sent to the API.
 		 */
-		do_action( 'rest_delete_widget' );
+		do_action( 'rest_delete_widget', $widget_id, $sidebar_id, $response, $request );
 
 		return $response;
 	}
@@ -408,12 +412,14 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 			$id_base       = $parsed_id['id_base'];
 			$number        = isset( $parsed_id['number'] ) ? $parsed_id['number'] : null;
 			$widget_object = $wp_widget_factory->get_widget_object( $id_base );
+			$creating      = false;
 		} elseif ( $request['id_base'] ) {
 			// Saving a new widget.
 			$id_base       = $request['id_base'];
 			$widget_object = $wp_widget_factory->get_widget_object( $id_base );
 			$number        = $widget_object ? next_widget_id_number( $id_base ) : null;
 			$id            = $widget_object ? $id_base . '-' . $number : $id_base;
+			$creating      = true;
 		} else {
 			return new WP_Error(
 				'rest_invalid_widget',
@@ -481,8 +487,11 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 		 * Fires after a widget is created or updated via the REST API.
 		 *
 		 * @since 5.8.0
+		 * @param WP_Widget       $widget_object Inserted or updated widget object.
+		 * @param WP_REST_Request $request       Request object.
+		 * @param bool            $creating      True when creating a post, false when updating.
 		 */
-		do_action( 'rest_save_widget' );
+		do_action( 'rest_save_widget', $widget_object, $request, $creating );
 
 		$original_post    = $_POST;
 		$original_request = $_REQUEST;
@@ -520,8 +529,11 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 		 * Fires after a widget is completely created or updated via the REST API.
 		 *
 		 * @since 5.8.0
+		 * @param WP_Widget       $widget_object Inserted or updated widget object.
+		 * @param WP_REST_Request $request       Request object.
+		 * @param bool            $creating      True when creating a post, false when updating.
 		 */
-		do_action( 'rest_after_save_widget' );
+		do_action( 'rest_after_save_widget', $widget_object, $request, $creating );
 
 		return $id;
 	}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
Originally reported in https://github.com/WordPress/gutenberg/issues/26241.

The idea is to trigger the `_delete_option_fresh_site` function when saved. We can reuse the `wp_ajax_save-widget` action from the old widgets screen, but it could be confusing.

Another idea would be to add new actions to the default filters list and call them in each rest endpoint.

https://github.com/WordPress/wordpress-develop/blob/910c2db68aef58ba14353e8c771dc3cfcd5ee9b5/src/wp-includes/default-filters.php#L245-L248

I'm not sure about the naming of those actions yet though, and open to any suggestions.

## Testing instructions

**The slow way**
1. Nuke the site and start over (`wp-env destroy && wp-env start`)
2. Go to Appearance -> Widgets, update or add some widgets
3. Go to Appearance -> Themes, change the theme to TwentyTwenty
4. Go to Appearance -> Customize -> Widgets, Footer#1 should remain the same and should not reset to the starter template of TwentyTwenty

**The fast way**
1. Run `wp-env run cli wp option update fresh_site 1` to reset the `fresh_site` option to `1`
2. Update some widgets in the widgets screen
3. Run `wp-env run cli wp option get fresh_site` and expect it to be `0`

Trac ticket: https://core.trac.wordpress.org/ticket/53317

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
