### PR TITLE
Fixed so that drafts do not have the same slug as existing posts.

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -828,7 +828,8 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 		// Hack: wp_unique_post_slug() doesn't work for drafts, so we will fake that our post is published.
 		if ( ! empty( $post->post_name ) && in_array( $post_status, array( 'draft', 'pending' ), true ) ) {
-			$post->post_name = wp_unique_post_slug( $post->post_name, $post->id, 'publish', $post->post_type, $post->post_parent );
+			$post_parent = ! empty( $post->post_parent ) ? $post->post_parent : 0;
+			$post->post_name = wp_unique_post_slug( $post->post_name, $post->ID, 'publish', $post->post_type, $post_parent );
 		}
 
 		// Convert the post object to an array, otherwise wp_update_post() will expect non-escaped input.

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -828,7 +828,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 		// Hack: wp_unique_post_slug() doesn't work for drafts, so we will fake that our post is published.
 		if ( ! empty( $post->post_name ) && in_array( $post_status, array( 'draft', 'pending' ), true ) ) {
-			$post_parent = ! empty( $post->post_parent ) ? $post->post_parent : 0;
+			$post_parent     = ! empty( $post->post_parent ) ? $post->post_parent : 0;
 			$post->post_name = wp_unique_post_slug( $post->post_name, $post->ID, 'publish', $post->post_type, $post_parent );
 		}
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -635,7 +635,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		}
 
 		// Hack: wp_unique_post_slug() doesn't work for drafts, so we will fake that our post is published.
-		if ( ! empty( $prepared_post->post_name ) && in_array( $prepared_post->post_status, array( 'draft', 'pending' ), true ) ) {
+		if ( ! empty( $prepared_post->post_name ) && ! empty( $prepared_post->post_status ) && in_array( $prepared_post->post_status, array( 'draft', 'pending' ), true ) ) {
 			$prepared_post->post_name = wp_unique_post_slug( $prepared_post->post_name, $prepared_post->id, 'publish', $prepared_post->post_type, $prepared_post->post_parent );
 		}
 
@@ -820,7 +820,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			return $post;
 		}
 
-		if ( $post->post_status ) {
+		if ( ! empty( $post->post_status ) ) {
 			$post_status = $post->post_status;
 		} else {
 			$post_status = $post_before->post_status;

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -5158,15 +5158,15 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	 * @ticket 52422
 	 *
 	 */
-	public function test_draft_post_do_not_have_the_same_slug_as_existing_post () {
+	public function test_draft_post_do_not_have_the_same_slug_as_existing_post() {
 		wp_set_current_user( self::$editor_id );
-		$this->factory()->post->create( array( 'post_name' => 'sample-slug') );
+		$this->factory()->post->create( array( 'post_name' => 'sample-slug' ) );
 
 		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d', self::$post_id ) );
 		$params  = $this->set_post_data(
 			array(
 				'status' => 'draft',
-				'slug' => 'sample-slug',
+				'slug'   => 'sample-slug',
 			)
 		);
 		$request->set_body_params( $params );

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -5154,6 +5154,31 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$GLOBALS['wp_rest_server']->override_by_default = false;
 	}
 
+	/**
+	 * @ticket 52422
+	 *
+	 */
+	public function test_draft_post_do_not_have_the_same_slug_as_existing_post () {
+		wp_set_current_user( self::$editor_id );
+		$this->factory()->post->create( array( 'post_name' => 'sample-slug') );
+
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d', self::$post_id ) );
+		$params  = $this->set_post_data(
+			array(
+				'status' => 'draft',
+				'slug' => 'sample-slug',
+			)
+		);
+		$request->set_body_params( $params );
+		$response = rest_get_server()->dispatch( $request );
+
+		$new_data = $response->get_data();
+		$this->assertSame( 'sample-slug-2', $new_data['slug'] );
+		$post = get_post( $new_data['id'] );
+		$this->assertSame( 'draft', $post->post_status );
+		$this->assertSame( 'sample-slug-2', $post->post_name );
+	}
+
 	public function tearDown() {
 		if ( isset( $this->attachment_id ) ) {
 			$this->remove_added_uploads();


### PR DESCRIPTION

Trac ticket: https://core.trac.wordpress.org/ticket/52422.

Using the block editor, a draft can have the same slug as a post that already exists.

There is a part in WP_Query that uses get_page_by_path, so it may load the wrong post.

A hack similar to wp_ajax_inline_save, fixed so that the slug is different.

![issue-on-page](https://user-images.githubusercontent.com/1908815/120768076-c2bda580-c556-11eb-9b2b-88333c6e3af6.gif)


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
