### PR TITLE
Trac 53278: Fixes RSS Widget infinite loop when undefined URL and PHP 8+

### DIFF
--- a/src/wp-includes/widgets.php
+++ b/src/wp-includes/widgets.php
@@ -1565,7 +1565,7 @@ function wp_widget_rss_output( $rss, $args = array() ) {
 	echo '<ul>';
 	foreach ( $rss->get_items( 0, $items ) as $item ) {
 		$link = $item->get_link();
-		while ( $link && stristr( $link, 'http' ) !== $link ) {
+		while ( ! empty( $link ) && stristr( $link, 'http' ) !== $link ) {
 			$link = substr( $link, 1 );
 		}
 		$link = esc_url( strip_tags( $link ) );

--- a/src/wp-includes/widgets.php
+++ b/src/wp-includes/widgets.php
@@ -1565,7 +1565,7 @@ function wp_widget_rss_output( $rss, $args = array() ) {
 	echo '<ul>';
 	foreach ( $rss->get_items( 0, $items ) as $item ) {
 		$link = $item->get_link();
-		while ( stristr( $link, 'http' ) !== $link ) {
+		while ( $link && stristr( $link, 'http' ) !== $link ) {
 			$link = substr( $link, 1 );
 		}
 		$link = esc_url( strip_tags( $link ) );

--- a/src/wp-includes/widgets/class-wp-widget-rss.php
+++ b/src/wp-includes/widgets/class-wp-widget-rss.php
@@ -50,7 +50,7 @@ class WP_Widget_RSS extends WP_Widget {
 		}
 
 		$url = ! empty( $instance['url'] ) ? $instance['url'] : '';
-		while ( $url && stristr( $url, 'http' ) !== $url ) {
+		while ( ! empty( $url ) && stristr( $url, 'http' ) !== $url ) {
 			$url = substr( $url, 1 );
 		}
 
@@ -74,7 +74,7 @@ class WP_Widget_RSS extends WP_Widget {
 				$title = strip_tags( $rss->get_title() );
 			}
 			$link = strip_tags( $rss->get_permalink() );
-			while ( $link && stristr( $link, 'http' ) !== $link ) {
+			while ( ! empty( $link ) && stristr( $link, 'http' ) !== $link ) {
 				$link = substr( $link, 1 );
 			}
 		}

--- a/src/wp-includes/widgets/class-wp-widget-rss.php
+++ b/src/wp-includes/widgets/class-wp-widget-rss.php
@@ -50,7 +50,7 @@ class WP_Widget_RSS extends WP_Widget {
 		}
 
 		$url = ! empty( $instance['url'] ) ? $instance['url'] : '';
-		while ( stristr( $url, 'http' ) !== $url ) {
+		while ( $url && stristr( $url, 'http' ) !== $url ) {
 			$url = substr( $url, 1 );
 		}
 
@@ -74,7 +74,7 @@ class WP_Widget_RSS extends WP_Widget {
 				$title = strip_tags( $rss->get_title() );
 			}
 			$link = strip_tags( $rss->get_permalink() );
-			while ( stristr( $link, 'http' ) !== $link ) {
+			while ( $link && stristr( $link, 'http' ) !== $link ) {
 				$link = substr( $link, 1 );
 			}
 		}

--- a/tests/phpunit/tests/widgets/rss-widget.php
+++ b/tests/phpunit/tests/widgets/rss-widget.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Unit tests covering WP_Widget_RSS functionality.
+ *
+ * @package    WordPress
+ * @subpackage widgets
+ */
+
+/**
+ * Test wp-includes/widgets/class-wp-widget-rss.php
+ *
+ * @group widgets
+ */
+class Test_WP_Widget_RSS extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 53278
+	 * @covers WP_Widget_RSS::widget
+	 * @dataProvider data_url_unhappy_path
+	 * 
+	 * @param mixed $url When null, unsets 'url' arg, else, sets to given value.
+	 */
+	public function test_url_unhappy_path( $url ) {
+		$widget  = new WP_Widget_RSS();
+
+		$args     = array(
+			'before_title'  => '<h2>',
+			'after_title'   => "</h2>\n",
+			'before_widget' => '<section id="widget_rss-5" class="widget widget_rss">',
+			'after_widget'  => "</section>\n",
+		);
+		$instance = array( 
+			'title' => 'Foo',
+			'url'   => $url,
+		);
+
+		if ( is_null( $url ) ) {
+			unset( $instance['ur'] );
+		}
+
+		$this->expectOutputString( '' ); 
+
+		$widget->widget( $args, $instance );
+	}
+
+	public function data_url_unhappy_path() {
+		return array(
+			'when unset' => array( 
+				'url' => null,
+			),
+			'when empty string' => array( 
+				'url' => '',
+			),
+			'when boolean false' => array( 
+				'url' => false,
+			),
+		);
+	}
+
+	/**
+	 * @ticket 53278
+	 * @covers WP_Widget_RSS::widget
+	 * @dataProvider data_url_happy_path
+	 * 
+	 * @param mixed  $url      URL argument.
+	 * @param string $expected Expected output.
+	 */
+	public function test_url_happy_path( $url, $expected ) {
+		$widget  = new WP_Widget_RSS();
+
+		$args     = array(
+			'before_title'  => '<h2>',
+			'after_title'   => "</h2>\n",
+			'before_widget' => '<section id="widget_rss-5" class="widget widget_rss">',
+			'after_widget'  => "</section>\n",
+		);
+		$instance = array( 
+			'title' => 'Foo',
+			'url'   => $url,
+		);
+
+		if ( is_null( $url ) ) {
+			unset( $instance['ur'] );
+		}
+
+		ob_start();
+		$widget->widget( $args, $instance );
+		$actual = ob_get_clean();
+
+		$this->assertContains( $expected,  $actual );
+	}
+
+	public function data_url_happy_path() {
+		return array(
+			'when url is given' => array( 
+				'url' => 'http://wordpress.org/news/feed/',
+				'<section id="widget_rss-5" class="widget widget_rss"><h2><a class="rsswidget" href="http://wordpress.org/news/feed/">',
+			),
+		);
+	}	
+
+}

--- a/tests/phpunit/tests/widgets/rss-widget.php
+++ b/tests/phpunit/tests/widgets/rss-widget.php
@@ -17,19 +17,18 @@ class Test_WP_Widget_RSS extends WP_UnitTestCase {
 	 * @ticket 53278
 	 * @covers WP_Widget_RSS::widget
 	 * @dataProvider data_url_unhappy_path
-	 * 
+	 *
 	 * @param mixed $url When null, unsets 'url' arg, else, sets to given value.
 	 */
 	public function test_url_unhappy_path( $url ) {
-		$widget  = new WP_Widget_RSS();
-
+		$widget   = new WP_Widget_RSS();
 		$args     = array(
 			'before_title'  => '<h2>',
 			'after_title'   => "</h2>\n",
 			'before_widget' => '<section id="widget_rss-5" class="widget widget_rss">',
 			'after_widget'  => "</section>\n",
 		);
-		$instance = array( 
+		$instance = array(
 			'title' => 'Foo',
 			'url'   => $url,
 		);
@@ -38,20 +37,20 @@ class Test_WP_Widget_RSS extends WP_UnitTestCase {
 			unset( $instance['ur'] );
 		}
 
-		$this->expectOutputString( '' ); 
+		$this->expectOutputString( '' );
 
 		$widget->widget( $args, $instance );
 	}
 
 	public function data_url_unhappy_path() {
 		return array(
-			'when unset' => array( 
+			'when unset'         => array(
 				'url' => null,
 			),
-			'when empty string' => array( 
+			'when empty string'  => array(
 				'url' => '',
 			),
-			'when boolean false' => array( 
+			'when boolean false' => array(
 				'url' => false,
 			),
 		);
@@ -61,20 +60,19 @@ class Test_WP_Widget_RSS extends WP_UnitTestCase {
 	 * @ticket 53278
 	 * @covers WP_Widget_RSS::widget
 	 * @dataProvider data_url_happy_path
-	 * 
+	 *
 	 * @param mixed  $url      URL argument.
 	 * @param string $expected Expected output.
 	 */
 	public function test_url_happy_path( $url, $expected ) {
-		$widget  = new WP_Widget_RSS();
-
+		$widget   = new WP_Widget_RSS();
 		$args     = array(
 			'before_title'  => '<h2>',
 			'after_title'   => "</h2>\n",
 			'before_widget' => '<section id="widget_rss-5" class="widget widget_rss">',
 			'after_widget'  => "</section>\n",
 		);
-		$instance = array( 
+		$instance = array(
 			'title' => 'Foo',
 			'url'   => $url,
 		);
@@ -87,16 +85,15 @@ class Test_WP_Widget_RSS extends WP_UnitTestCase {
 		$widget->widget( $args, $instance );
 		$actual = ob_get_clean();
 
-		$this->assertContains( $expected,  $actual );
+		$this->assertContains( $expected, $actual );
 	}
 
 	public function data_url_happy_path() {
 		return array(
-			'when url is given' => array( 
+			'when url is given' => array(
 				'url' => 'http://wordpress.org/news/feed/',
 				'<section id="widget_rss-5" class="widget widget_rss"><h2><a class="rsswidget" href="http://wordpress.org/news/feed/">',
 			),
 		);
-	}	
-
+	}
 }

--- a/tests/phpunit/tests/widgets/wpWidgetRss.php
+++ b/tests/phpunit/tests/widgets/wpWidgetRss.php
@@ -11,7 +11,7 @@
  *
  * @group widgets
  */
-class Test_WP_Widget_RSS extends WP_UnitTestCase {
+class Test_Widgets_wpWidgetRss extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 53278


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/53278

- Adds happy and unhappy path unit tests for testing the URL argument
- Applies `53278.diff` patch. Props @dd32 
- Replaces implicit loose comparison with `! empty()` ([see comment 7](https://core.trac.wordpress.org/ticket/53278#comment:7));

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
