### PR TITLE
Trac 52814: Fixes notice in get_post_comments_feed_link() when post does not exist 

### DIFF
--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -748,7 +748,11 @@ function get_post_comments_feed_link( $post_id = 0, $feed = '' ) {
 		$feed = get_default_feed();
 	}
 
-	$post       = get_post( $post_id );
+	$post = get_post( $post_id );
+	if ( ! $post ) {
+		return false;
+	}
+	
 	$unattached = 'attachment' === $post->post_type && 0 === (int) $post->post_parent;
 
 	if ( get_option( 'permalink_structure' ) ) {

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -754,7 +754,7 @@ function get_post_comments_feed_link( $post_id = 0, $feed = '' ) {
 	if ( ! $post instanceof WP_Post ) {
 		return '';
 	}
-	
+
 	$unattached = 'attachment' === $post->post_type && 0 === (int) $post->post_parent;
 
 	if ( get_option( 'permalink_structure' ) ) {

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -735,7 +735,7 @@ function get_feed_link( $feed = '' ) {
  * @param int    $post_id Optional. Post ID. Default is the ID of the global `$post`.
  * @param string $feed    Optional. Feed type. Possible values include 'rss2', 'atom'.
  *                        Default is the value of get_default_feed().
- * @return string|false The permalink for the comments feed for the given post on success, false on failure.
+ * @return string The permalink for the comments feed for the given post on success, empty string on failure.
  */
 function get_post_comments_feed_link( $post_id = 0, $feed = '' ) {
 	$post_id = absint( $post_id );
@@ -749,8 +749,10 @@ function get_post_comments_feed_link( $post_id = 0, $feed = '' ) {
 	}
 
 	$post = get_post( $post_id );
+
+	// Bail out if the post does not exist.
 	if ( ! $post instanceof WP_Post ) {
-		return false;
+		return '';
 	}
 	
 	$unattached = 'attachment' === $post->post_type && 0 === (int) $post->post_parent;

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -735,7 +735,7 @@ function get_feed_link( $feed = '' ) {
  * @param int    $post_id Optional. Post ID. Default is the ID of the global `$post`.
  * @param string $feed    Optional. Feed type. Possible values include 'rss2', 'atom'.
  *                        Default is the value of get_default_feed().
- * @return string The permalink for the comments feed for the given post.
+ * @return string|false The permalink for the comments feed for the given post on success, false on failure.
  */
 function get_post_comments_feed_link( $post_id = 0, $feed = '' ) {
 	$post_id = absint( $post_id );
@@ -749,7 +749,7 @@ function get_post_comments_feed_link( $post_id = 0, $feed = '' ) {
 	}
 
 	$post = get_post( $post_id );
-	if ( ! $post ) {
+	if ( ! $post instanceof WP_Post ) {
 		return false;
 	}
 	

--- a/tests/phpunit/tests/link/getPostCommentsFeedLink.php
+++ b/tests/phpunit/tests/link/getPostCommentsFeedLink.php
@@ -138,4 +138,17 @@ class Tests_Link_GetPostCommentsFeedLink extends WP_UnitTestCase {
 
 		$this->assertSame( $expected, $link );
 	}
+
+	/**
+	 * @ticket 52814
+	 */
+	public function test_nonexistent_page() {
+		$this->set_permalink_structure( '/%year%/%monthnum%/%day%/%postname%/' );
+
+		// Use the largest integer to ensure the post does not exist.
+		$post_id = PHP_INT_MAX;
+		$link    = get_post_comments_feed_link( $post_id );
+		
+		$this->assertEmpty( $link );
+	}
 }

--- a/tests/phpunit/tests/link/getPostCommentsFeedLink.php
+++ b/tests/phpunit/tests/link/getPostCommentsFeedLink.php
@@ -148,7 +148,7 @@ class Tests_Link_GetPostCommentsFeedLink extends WP_UnitTestCase {
 		// Use the largest integer to ensure the post does not exist.
 		$post_id = PHP_INT_MAX;
 		$link    = get_post_comments_feed_link( $post_id );
-		
+
 		$this->assertEmpty( $link );
 	}
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/52814

- Adds unit test
- Applies `52814.diff` props to @dd32 
- Replaces implicit loose comparison in guard clause to bail out if not an instance of `WP_Post`. Why? `WP_Post` is the expected data type _if_ the post exists.
- Returns an empty string instead of boolean `false`. Why?
    - Backwards compatibility
    - Retain the return data type of `string`

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
