### PR TITLE
Fix: Trac#52990 - Account for single quoted attrs

### DIFF
--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -1870,7 +1870,11 @@ function wp_filter_content_tags( $content, $context = null ) {
  */
 function wp_img_tag_add_loading_attr( $image, $context ) {
 	// Images should have source and dimension attributes for the `loading` attribute to be added.
-	if ( false === strpos( $image, ' src="' ) || false === strpos( $image, ' width="' ) || false === strpos( $image, ' height="' ) ) {
+	if (
+		( false === strpos( $image, ' src="' ) && false === strpos( $image, " src='" ) )
+		|| ( false === strpos( $image, ' width="' ) && false === strpos( $image, " width='" ) )
+		|| ( false === strpos( $image, ' height="' ) && false === strpos( $image, " height='" ) )
+	) {
 		return $image;
 	}
 

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -1996,7 +1996,11 @@ function wp_iframe_tag_add_loading_attr( $iframe, $context ) {
 	}
 
 	// Iframes should have source and dimension attributes for the `loading` attribute to be added.
-	if ( false === strpos( $iframe, ' src="' ) || false === strpos( $iframe, ' width="' ) || false === strpos( $iframe, ' height="' ) ) {
+	if (
+		( false === strpos( $iframe, ' src="' ) && false === strpos( $iframe, " src='" ) )
+		|| ( false === strpos( $iframe, ' width="' ) && false === strpos( $iframe, " width='" ) )
+		|| ( false === strpos( $iframe, ' height="' ) && false === strpos( $iframe, " height='" ) )
+	) {
 		return $iframe;
 	}
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/52990

This PR accounts for attributes using single quotes in images and iframes to address the issue described in [Trac:52990]( https://core.trac.wordpress.org/ticket/52990)