### PR TITLE
Change Gutenberg function to WP function in wp_migrate_old_typography_shape

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -988,10 +988,10 @@ function wp_migrate_old_typography_shape( $metadata ) {
 		if ( null !== $support_for_key ) {
 			trigger_error(
 				/* translators: %1$s: Block type, %2$s: typography supports key e.g: fontSize, lineHeight etc... */
-				sprintf( __( 'Block %1$s is declaring %2$s support on block.json under supports.%2$s. %2$s support is now declared under supports.typography.%2$s.', 'gutenberg' ), $metadata['name'], $typography_key ),
+				sprintf( __( 'Block %1$s is declaring %2$s support on block.json under supports.%2$s. %2$s support is now declared under supports.typography.%2$s.' ), $metadata['name'], $typography_key ),
 				headers_sent() || WP_DEBUG ? E_USER_WARNING : E_USER_NOTICE
 			);
-			gutenberg_experimental_set( $metadata['supports'], array( 'typography', $typography_key ), $support_for_key );
+			_wp_array_set( $metadata['supports'], array( 'typography', $typography_key ), $support_for_key );
 			unset( $metadata['supports'][ $typography_key ] );
 		}
 	}


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/53369

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
