### PR TITLE
Fixes two regressions with colors

### DIFF
--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -295,14 +295,34 @@ function get_block_editor_settings( array $custom_settings, $block_editor_contex
 	}
 
 	$editor_settings['__experimentalFeatures'] = $theme_json->get_settings();
+
 	// These settings may need to be updated based on data coming from theme.json sources.
-	if ( isset( $editor_settings['__experimentalFeatures']['color']['palette'] ) ) {
-		$editor_settings['colors'] = $editor_settings['__experimentalFeatures']['color']['palette'];
-		unset( $editor_settings['__experimentalFeatures']['color']['palette'] );
+	if ( isset( $settings['__experimentalFeatures']['color']['palette'] ) ) {
+		$colors_by_origin   = $settings['__experimentalFeatures']['color']['palette'];
+		$settings['colors'] = isset( $colors_by_origin['user'] ) ?
+			$colors_by_origin['user'] : (
+				isset( $colors_by_origin['theme'] ) ?
+					$colors_by_origin['theme'] :
+					$colors_by_origin['core']
+			);
 	}
-	if ( isset( $editor_settings['__experimentalFeatures']['color']['gradients'] ) ) {
-		$editor_settings['gradients'] = $editor_settings['__experimentalFeatures']['color']['gradients'];
-		unset( $editor_settings['__experimentalFeatures']['color']['gradients'] );
+	if ( isset( $settings['__experimentalFeatures']['color']['gradients'] ) ) {
+		$gradients_by_origin   = $settings['__experimentalFeatures']['color']['gradients'];
+		$settings['gradients'] = isset( $gradients_by_origin['user'] ) ?
+			$gradients_by_origin['user'] : (
+				isset( $gradients_by_origin['theme'] ) ?
+					$gradients_by_origin['theme'] :
+					$gradients_by_origin['core']
+			);
+	}
+	if ( isset( $settings['__experimentalFeatures']['typography']['fontSizes'] ) ) {
+		$font_sizes_by_origin  = $settings['__experimentalFeatures']['typography']['fontSizes'];
+		$settings['fontSizes'] = isset( $font_sizes_by_origin['user'] ) ?
+			$font_sizes_by_origin['user'] : (
+				isset( $font_sizes_by_origin['theme'] ) ?
+					$font_sizes_by_origin['theme'] :
+					$font_sizes_by_origin['core']
+			);
 	}
 	if ( isset( $editor_settings['__experimentalFeatures']['color']['custom'] ) ) {
 		$editor_settings['disableCustomColors'] = ! $editor_settings['__experimentalFeatures']['color']['custom'];
@@ -311,10 +331,6 @@ function get_block_editor_settings( array $custom_settings, $block_editor_contex
 	if ( isset( $editor_settings['__experimentalFeatures']['color']['customGradient'] ) ) {
 		$editor_settings['disableCustomGradients'] = ! $editor_settings['__experimentalFeatures']['color']['customGradient'];
 		unset( $editor_settings['__experimentalFeatures']['color']['customGradient'] );
-	}
-	if ( isset( $editor_settings['__experimentalFeatures']['typography']['fontSizes'] ) ) {
-		$editor_settings['fontSizes'] = $editor_settings['__experimentalFeatures']['typography']['fontSizes'];
-		unset( $editor_settings['__experimentalFeatures']['typography']['fontSizes'] );
 	}
 	if ( isset( $editor_settings['__experimentalFeatures']['typography']['customFontSize'] ) ) {
 		$editor_settings['disableCustomFontSizes'] = ! $editor_settings['__experimentalFeatures']['typography']['customFontSize'];

--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -284,7 +284,7 @@ class WP_Theme_JSON_Resolver {
 		 * to override the ones declared via add_theme_support.
 		 */
 		$with_theme_supports = new WP_Theme_JSON( $theme_support_data );
-		$with_theme_supports->merge( self::$theme );
+		$with_theme_supports->merge( self::$theme, 'theme' );
 
 		return $with_theme_supports;
 	}
@@ -309,8 +309,8 @@ class WP_Theme_JSON_Resolver {
 		$theme_support_data = WP_Theme_JSON::get_from_editor_settings( $settings );
 
 		$result = new WP_Theme_JSON();
-		$result->merge( self::get_core_data() );
-		$result->merge( self::get_theme_data( $theme_support_data ) );
+		$result->merge( self::get_core_data(), 'core' );
+		$result->merge( self::get_theme_data( $theme_support_data ), 'theme' );
 
 		return $result;
 	}

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -632,10 +632,35 @@ class WP_Theme_JSON {
 	}
 
 	/**
+	 * Given an array of presets keyed by origin and the value key of the preset,
+	 * it returns an array where each key is the preset slug and each value the preset value.
+	 *
+	 * @param array  $preset_per_origin Array of presets keyed by origin.
+	 * @param string $value_key         The property of the preset that contains its value.
+	 *
+	 * @return array Array of presets where each key is a slug and each value is the preset value.
+	 */
+	private static function get_merged_preset_by_slug( $preset_per_origin, $value_key ) {
+		$origins = array( 'core', 'theme', 'user' );
+		$result  = array();
+		foreach ( $origins as $origin ) {
+			if ( ! isset( $preset_per_origin[ $origin ] ) ) {
+				continue;
+			}
+			foreach ( $preset_per_origin[ $origin ] as $preset ) {
+				// We don't want to use kebabCase here,
+				// see https://github.com/WordPress/gutenberg/issues/32347
+				// However, we need to make sure the generated class or css variable
+				// doesn't contain spaces.
+				$result[ preg_replace( '/\s+/', '-', $preset['slug'] ) ] = $preset[ $value_key ];
+			}
+		}
+		return $result;
+	}
+
+	/**
 	 * Given a settings array, it returns the generated rulesets
 	 * for the preset classes.
-	 *
-	 * @since 5.8.0
 	 *
 	 * @param array  $settings Settings to process.
 	 * @param string $selector Selector wrapping the classes.
@@ -651,19 +676,16 @@ class WP_Theme_JSON {
 
 		$stylesheet = '';
 		foreach ( self::PRESETS_METADATA as $preset ) {
-			$values = _wp_array_get( $settings, $preset['path'], array() );
-			foreach ( $values as $value ) {
-				foreach ( $preset['classes'] as $class ) {
+			$preset_per_origin = _wp_array_get( $settings, $preset['path'], array() );
+			$preset_by_slug    = self::get_merged_preset_by_slug( $preset_per_origin, $preset['value_key'] );
+			foreach ( $preset['classes'] as $class ) {
+				foreach ( $preset_by_slug as $slug => $value ) {
 					$stylesheet .= self::to_ruleset(
-						// We don't want to use kebabCase here,
-						// see https://github.com/WordPress/gutenberg/issues/32347
-						// However, we need to make sure the generated class
-						// doesn't contain spaces.
-						self::append_to_selector( $selector, '.has-' . preg_replace( '/\s+/', '-', $value['slug'] ) . '-' . $class['class_suffix'] ),
+						self::append_to_selector( $selector, '.has-' . $slug . '-' . $class['class_suffix'] ),
 						array(
 							array(
 								'name'  => $class['property_name'],
-								'value' => $value[ $preset['value_key'] ] . ' !important',
+								'value' => $value . ' !important',
 							),
 						)
 					);
@@ -695,11 +717,12 @@ class WP_Theme_JSON {
 	private static function compute_preset_vars( $settings ) {
 		$declarations = array();
 		foreach ( self::PRESETS_METADATA as $preset ) {
-			$values = _wp_array_get( $settings, $preset['path'], array() );
-			foreach ( $values as $value ) {
+			$preset_per_origin = _wp_array_get( $settings, $preset['path'], array() );
+			$preset_by_slug    = self::get_merged_preset_by_slug( $preset_per_origin, $preset['value_key'] );
+			foreach ( $preset_by_slug as $slug => $value ) {
 				$declarations[] = array(
-					'name'  => '--wp--preset--' . $preset['css_var_infix'] . '--' . $value['slug'],
-					'value' => $value[ $preset['value_key'] ],
+					'name'  => '--wp--preset--' . $preset['css_var_infix'] . '--' . $slug,
+					'value' => $value,
 				);
 			}
 		}
@@ -1039,85 +1062,59 @@ class WP_Theme_JSON {
 	/**
 	 * Merge new incoming data.
 	 *
-	 * @since 5.8.0
-	 *
 	 * @param WP_Theme_JSON $incoming Data to merge.
+	 * @param string        $origin origin of the incoming data (e.g: core, theme, or user).
 	 */
-	public function merge( $incoming, $update_or_remove = 'remove' ) {
-		$incoming_data = $incoming->get_raw_data();
-		$existing_data = $this->theme_json;
+	public function merge( $incoming, $origin ) {
+
+		$incoming_data    = $incoming->get_raw_data();
+		$this->theme_json = array_replace_recursive( $this->theme_json, $incoming_data );
 
 		// The array_replace_recursive algorithm merges at the leaf level.
 		// For leaf values that are arrays it will use the numeric indexes for replacement.
-		$this->theme_json = array_replace_recursive( $this->theme_json, $incoming_data );
+		// In those cases, what we want is to use the incoming value, if it exists.
+		//
+		// These are the cases that have array values at the leaf levels.
+		$properties   = array();
+		$properties[] = array( 'custom' );
+		$properties[] = array( 'spacing', 'units' );
+		$properties[] = array( 'color', 'duotone' );
 
-		// There are a few cases in which we want to merge things differently
-		// from what array_replace_recursive does.
-
-		// Some incoming properties should replace the existing.
-		$to_replace   = array();
-		$to_replace[] = array( 'custom' );
-		$to_replace[] = array( 'spacing', 'units' );
-		$to_replace[] = array( 'typography', 'fontSizes' );
-		$to_replace[] = array( 'typography', 'fontFamilies' );
-
-		// Some others should be appended to the existing.
-		// If the slug is the same than an existing element,
-		// the $update_or_remove param is used to decide
-		// what to do with the existing element:
-		// either remove it and append the incoming,
-		// or update it with the incoming.
 		$to_append   = array();
-		$to_append[] = array( 'color', 'duotone' );
-		$to_append[] = array( 'color', 'gradients' );
 		$to_append[] = array( 'color', 'palette' );
+		$to_append[] = array( 'color', 'gradients' );
+		$to_append[] = array( 'typography', 'fontSizes' );
+		$to_append[] = array( 'typography', 'fontFamilies' );
 
 		$nodes = self::get_setting_nodes( $this->theme_json );
 		foreach ( $nodes as $metadata ) {
-			foreach ( $to_replace as $path_to_replace ) {
-				$path = array_merge( $metadata['path'], $path_to_replace );
+			foreach ( $properties as $property_path ) {
+				$path = array_merge( $metadata['path'], $property_path );
 				$node = _wp_array_get( $incoming_data, $path, array() );
 				if ( ! empty( $node ) ) {
 					_wp_array_set( $this->theme_json, $path, $node );
 				}
 			}
-			foreach ( $to_append as $path_to_append ) {
-				$path          = array_merge( $metadata['path'], $path_to_append );
-				$incoming_node = _wp_array_get( $incoming_data, $path, array() );
-				$existing_node = _wp_array_get( $existing_data, $path, array() );
 
-				if ( empty( $incoming_node ) && empty( $existing_node ) ) {
-					continue;
-				}
-
-				$index_table    = array();
-				$existing_slugs = array();
-				$merged         = array();
-				foreach ( $existing_node as $key => $value ) {
-					$index_table[ $value['slug'] ] = $key;
-					$existing_slugs[]              = $value['slug'];
-					$merged[ $key ]                = $value;
-				}
-
-				$to_remove = array();
-				foreach ( $incoming_node as $value ) {
-					if ( ! in_array( $value['slug'], $existing_slugs, true ) ) {
-						$merged[] = $value;
-					} elseif ( 'update' === $update_or_remove ) {
-						$merged[ $index_table[ $value['slug'] ] ] = $value;
+			foreach ( $to_append as $property_path ) {
+				$path = array_merge( $metadata['path'], $property_path );
+				$node = _wp_array_get( $incoming_data, $path, null );
+				if ( null !== $node ) {
+					$existing_node = _wp_array_get( $this->theme_json, $path, null );
+					$new_node      = array_filter(
+						$existing_node,
+						function ( $key ) {
+							return in_array( $key, array( 'core', 'theme', 'user ' ), true );
+						},
+						ARRAY_FILTER_USE_KEY
+					);
+					if ( isset( $node[ $origin ] ) ) {
+						$new_node[ $origin ] = $node[ $origin ];
 					} else {
-						$merged[]    = $value;
-						$to_remove[] = $index_table[ $value['slug'] ];
+						$new_node[ $origin ] = $node;
 					}
+					_wp_array_set( $this->theme_json, $path, $new_node );
 				}
-
-				// Remove the duplicated values and pack the sparsed array.
-				foreach ( $to_remove as $index ) {
-					unset( $merged[ $index ] );
-				}
-				$merged = array_values( $merged );
-
-				_wp_array_set( $this->theme_json, $path, $merged );
 			}
 		}
 

--- a/src/wp-includes/theme.json
+++ b/src/wp-includes/theme.json
@@ -50,74 +50,62 @@
 				{
 					"name": "Vivid cyan blue to vivid purple",
 					"gradient": "linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)",
-					"slug": "vivid-cyan-blue-to-vivid-purple",
-					"origin": "core"
+					"slug": "vivid-cyan-blue-to-vivid-purple"
 				},
 				{
 					"name": "Light green cyan to vivid green cyan",
 					"gradient": "linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%)",
-					"slug": "light-green-cyan-to-vivid-green-cyan",
-					"origin": "core"
+					"slug": "light-green-cyan-to-vivid-green-cyan"
 				},
 				{
 					"name": "Luminous vivid amber to luminous vivid orange",
 					"gradient": "linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%)",
-					"slug": "luminous-vivid-amber-to-luminous-vivid-orange",
-					"origin": "core"
+					"slug": "luminous-vivid-amber-to-luminous-vivid-orange"
 				},
 				{
 					"name": "Luminous vivid orange to vivid red",
 					"gradient": "linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%)",
-					"slug": "luminous-vivid-orange-to-vivid-red",
-					"origin": "core"
+					"slug": "luminous-vivid-orange-to-vivid-red"
 				},
 				{
 					"name": "Very light gray to cyan bluish gray",
 					"gradient": "linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%)",
-					"slug": "very-light-gray-to-cyan-bluish-gray",
-					"origin": "core"
+					"slug": "very-light-gray-to-cyan-bluish-gray"
 				},
 				{
 					"name": "Cool to warm spectrum",
 					"gradient": "linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%)",
-					"slug": "cool-to-warm-spectrum",
-					"origin": "core"
+					"slug": "cool-to-warm-spectrum"
 				},
 				{
 					"name": "Blush light purple",
 					"gradient": "linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%)",
-					"slug": "blush-light-purple",
-					"origin": "core"
+					"slug": "blush-light-purple"
 				},
 				{
 					"name": "Blush bordeaux",
 					"gradient": "linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%)",
-					"slug": "blush-bordeaux",
-					"origin": "core"
+					"slug": "blush-bordeaux"
 				},
 				{
 					"name": "Luminous dusk",
 					"gradient": "linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%)",
-					"slug": "luminous-dusk",
-					"origin": "core"
+					"slug": "luminous-dusk"
 				},
 				{
 					"name": "Pale ocean",
 					"gradient": "linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%)",
-					"slug": "pale-ocean",
-					"origin": "core"
+					"slug": "pale-ocean"
 				},
 				{
 					"name": "Electric grass",
 					"gradient": "linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%)",
-					"slug": "electric-grass",
-					"origin": "core"
+					"slug": "electric-grass"
 				},
 				{
 					"name": "Midnight",
 					"gradient": "linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%)",
-					"slug": "midnight",
-					"origin": "core"
+					"slug": "midnight"
 				}
 			],
 			"link": false,
@@ -125,74 +113,62 @@
 				{
 					"name": "Black",
 					"slug": "black",
-					"color": "#000000",
-					"origin": "core"
+					"color": "#000000"
 				},
 				{
 					"name": "Cyan bluish gray",
 					"slug": "cyan-bluish-gray",
-					"color": "#abb8c3",
-					"origin": "core"
+					"color": "#abb8c3"
 				},
 				{
 					"name": "White",
 					"slug": "white",
-					"color": "#ffffff",
-					"origin": "core"
+					"color": "#ffffff"
 				},
 				{
 					"name": "Pale pink",
 					"slug": "pale-pink",
-					"color": "#f78da7",
-					"origin": "core"
+					"color": "#f78da7"
 				},
 				{
 					"name": "Vivid red",
 					"slug": "vivid-red",
-					"color": "#cf2e2e",
-					"origin": "core"
+					"color": "#cf2e2e"
 				},
 				{
 					"name": "Luminous vivid orange",
 					"slug": "luminous-vivid-orange",
-					"color": "#ff6900",
-					"origin": "core"
+					"color": "#ff6900"
 				},
 				{
 					"name": "Luminous vivid amber",
 					"slug": "luminous-vivid-amber",
-					"color": "#fcb900",
-					"origin": "core"
+					"color": "#fcb900"
 				},
 				{
 					"name": "Light green cyan",
 					"slug": "light-green-cyan",
-					"color": "#7bdcb5",
-					"origin": "core"
+					"color": "#7bdcb5"
 				},
 				{
 					"name": "Vivid green cyan",
 					"slug": "vivid-green-cyan",
-					"color": "#00d084",
-					"origin": "core"
+					"color": "#00d084"
 				},
 				{
 					"name": "Pale cyan blue",
 					"slug": "pale-cyan-blue",
-					"color": "#8ed1fc",
-					"origin": "core"
+					"color": "#8ed1fc"
 				},
 				{
 					"name": "Vivid cyan blue",
 					"slug": "vivid-cyan-blue",
-					"color": "#0693e3",
-					"origin": "core"
+					"color": "#0693e3"
 				},
 				{
 					"name": "Vivid purple",
 					"slug": "vivid-purple",
-					"color": "#9b51e0",
-					"origin": "core"
+					"color": "#9b51e0"
 				}
 			]
 		},

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -476,7 +476,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 					),
 				),
 				'typography' => array(
-					'fontSizes'    => array(
+					'fontSizes' => array(
 						'core' => array(
 							array(
 								'slug' => 'fontSize',

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -65,95 +65,99 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 	}
 
 	function test_get_stylesheet() {
-		$theme_json = new WP_Theme_JSON(
-			array(
-				'version'  => WP_Theme_JSON::LATEST_SCHEMA,
-				'settings' => array(
-					'color'  => array(
-						'text'    => 'value',
-						'palette' => array(
-							array(
-								'slug'  => 'grey',
-								'color' => 'grey',
+		$theme_json = new WP_Theme_JSON();
+		$theme_json->merge(
+			new WP_Theme_JSON(
+				array(
+					'version'  => WP_Theme_JSON::LATEST_SCHEMA,
+					'settings' => array(
+						'color'  => array(
+							'text'    => 'value',
+							'palette' => array(
+								array(
+									'slug'  => 'grey',
+									'color' => 'grey',
+								),
 							),
 						),
-					),
-					'misc'   => 'value',
-					'blocks' => array(
-						'core/group' => array(
-							'custom' => array(
-								'base-font'   => 16,
-								'line-height' => array(
-									'small'  => 1.2,
-									'medium' => 1.4,
-									'large'  => 1.8,
+						'misc'   => 'value',
+						'blocks' => array(
+							'core/group' => array(
+								'custom' => array(
+									'base-font'   => 16,
+									'line-height' => array(
+										'small'  => 1.2,
+										'medium' => 1.4,
+										'large'  => 1.8,
+									),
 								),
 							),
 						),
 					),
-				),
-				'styles'   => array(
-					'color'    => array(
-						'text' => 'var:preset|color|grey',
+					'styles'   => array(
+						'color'    => array(
+							'text' => 'var:preset|color|grey',
+						),
+						'misc'     => 'value',
+						'elements' => array(
+							'link' => array(
+								'color' => array(
+									'text'       => '#111',
+									'background' => '#333',
+								),
+							),
+						),
+						'blocks'   => array(
+							'core/group'     => array(
+								'elements' => array(
+									'link' => array(
+										'color' => array(
+											'text' => '#111',
+										),
+									),
+								),
+								'spacing'  => array(
+									'padding' => array(
+										'top'    => '12px',
+										'bottom' => '24px',
+									),
+								),
+							),
+							'core/heading'   => array(
+								'color'    => array(
+									'text' => '#123456',
+								),
+								'elements' => array(
+									'link' => array(
+										'color'      => array(
+											'text'       => '#111',
+											'background' => '#333',
+										),
+										'typography' => array(
+											'fontSize' => '60px',
+										),
+									),
+								),
+							),
+							'core/post-date' => array(
+								'color'    => array(
+									'text' => '#123456',
+								),
+								'elements' => array(
+									'link' => array(
+										'color' => array(
+											'background' => '#777',
+											'text'       => '#555',
+										),
+									),
+								),
+							),
+						),
 					),
 					'misc'     => 'value',
-					'elements' => array(
-						'link' => array(
-							'color' => array(
-								'text'       => '#111',
-								'background' => '#333',
-							),
-						),
-					),
-					'blocks'   => array(
-						'core/group'     => array(
-							'elements' => array(
-								'link' => array(
-									'color' => array(
-										'text' => '#111',
-									),
-								),
-							),
-							'spacing'  => array(
-								'padding' => array(
-									'top'    => '12px',
-									'bottom' => '24px',
-								),
-							),
-						),
-						'core/heading'   => array(
-							'color'    => array(
-								'text' => '#123456',
-							),
-							'elements' => array(
-								'link' => array(
-									'color'      => array(
-										'text'       => '#111',
-										'background' => '#333',
-									),
-									'typography' => array(
-										'fontSize' => '60px',
-									),
-								),
-							),
-						),
-						'core/post-date' => array(
-							'color'    => array(
-								'text' => '#123456',
-							),
-							'elements' => array(
-								'link' => array(
-									'color' => array(
-										'background' => '#777',
-										'text'       => '#555',
-									),
-								),
-							),
-						),
-					),
-				),
-				'misc'     => 'value',
-			)
+				)
+			),
+			'core'
 		);
 
 		$this->assertSame(
@@ -171,24 +175,28 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 	}
 
 	function test_get_stylesheet_preset_classes_work_with_compounded_selectors() {
-		$theme_json = new WP_Theme_JSON(
-			array(
-				'version'  => WP_Theme_JSON::LATEST_SCHEMA,
-				'settings' => array(
-					'blocks' => array(
-						'core/heading' => array(
-							'color' => array(
-								'palette' => array(
-									array(
-										'slug'  => 'white',
-										'color' => '#fff',
+		$theme_json = new WP_Theme_JSON();
+		$theme_json->merge(
+			new WP_Theme_JSON(
+				array(
+					'version'  => WP_Theme_JSON::LATEST_SCHEMA,
+					'settings' => array(
+						'blocks' => array(
+							'core/heading' => array(
+								'color' => array(
+									'palette' => array(
+										array(
+											'slug'  => 'white',
+											'color' => '#fff',
+										),
 									),
 								),
 							),
 						),
 					),
-				),
-			)
+				)
+			),
+			'theme'
 		);
 
 		$this->assertSame(
@@ -198,33 +206,37 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 	}
 
 	function test_get_stylesheet_preset_rules_come_after_block_rules() {
-		$theme_json = new WP_Theme_JSON(
-			array(
-				'version'  => WP_Theme_JSON::LATEST_SCHEMA,
-				'settings' => array(
-					'blocks' => array(
-						'core/group' => array(
-							'color' => array(
-								'palette' => array(
-									array(
-										'slug'  => 'grey',
-										'color' => 'grey',
+		$theme_json = new WP_Theme_JSON();
+		$theme_json->merge(
+			new WP_Theme_JSON(
+				array(
+					'version'  => WP_Theme_JSON::LATEST_SCHEMA,
+					'settings' => array(
+						'blocks' => array(
+							'core/group' => array(
+								'color' => array(
+									'palette' => array(
+										array(
+											'slug'  => 'grey',
+											'color' => 'grey',
+										),
 									),
 								),
 							),
 						),
 					),
-				),
-				'styles'   => array(
-					'blocks' => array(
-						'core/group' => array(
-							'color' => array(
-								'text' => 'red',
+					'styles'   => array(
+						'blocks' => array(
+							'core/group' => array(
+								'color' => array(
+									'text' => 'red',
+								),
 							),
 						),
 					),
-				),
-			)
+				)
+			),
+			'theme'
 		);
 
 		$this->assertSame(
@@ -238,34 +250,38 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 	}
 
 	public function test_get_stylesheet_preset_values_are_marked_as_important() {
-		$theme_json = new WP_Theme_JSON(
-			array(
-				'version'  => WP_Theme_JSON::LATEST_SCHEMA,
-				'settings' => array(
-					'color' => array(
-						'palette' => array(
-							array(
-								'slug'  => 'grey',
-								'color' => 'grey',
+		$theme_json = new WP_Theme_JSON();
+		$theme_json->merge(
+			new WP_Theme_JSON(
+				array(
+					'version'  => WP_Theme_JSON::LATEST_SCHEMA,
+					'settings' => array(
+						'color' => array(
+							'palette' => array(
+								array(
+									'slug'  => 'grey',
+									'color' => 'grey',
+								),
 							),
 						),
 					),
-				),
-				'styles'   => array(
-					'blocks' => array(
-						'core/paragraph' => array(
-							'color'      => array(
-								'text'       => 'red',
-								'background' => 'blue',
-							),
-							'typography' => array(
-								'fontSize'   => '12px',
-								'lineHeight' => '1.3',
+					'styles'   => array(
+						'blocks' => array(
+							'core/paragraph' => array(
+								'color'      => array(
+									'text'       => 'red',
+									'background' => 'blue',
+								),
+								'typography' => array(
+									'fontSize'   => '12px',
+									'lineHeight' => '1.3',
+								),
 							),
 						),
 					),
-				),
-			)
+				)
+			),
+			'core'
 		);
 
 		$this->assertSame(
@@ -278,35 +294,42 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 	 * @ticket 52991
 	 */
 	public function test_merge_incoming_data() {
-		$initial = array(
-			'version'  => WP_Theme_JSON::LATEST_SCHEMA,
-			'settings' => array(
-				'color'  => array(
-					'custom'  => false,
-					'palette' => array(
-						array(
-							'slug'  => 'red',
-							'color' => 'red',
+		$theme_json = new WP_Theme_JSON( array() );
+		$theme_json->merge(
+			new WP_Theme_JSON(
+				array(
+					'version'  => WP_Theme_JSON::LATEST_SCHEMA,
+					'settings' => array(
+						'color'  => array(
+							'custom'  => false,
+							'palette' => array(
+								array(
+									'slug'  => 'red',
+									'color' => 'red',
+								),
+								array(
+									'slug'  => 'green',
+									'color' => 'green',
+								),
+							),
 						),
-						array(
-							'slug'  => 'green',
-							'color' => 'green',
+						'blocks' => array(
+							'core/paragraph' => array(
+								'color' => array(
+									'custom' => false,
+								),
+							),
 						),
 					),
-				),
-				'blocks' => array(
-					'core/paragraph' => array(
-						'color' => array(
-							'custom' => false,
+					'styles'   => array(
+						'typography' => array(
+							'fontSize' => '12',
 						),
 					),
-				),
+
+				)
 			),
-			'styles'   => array(
-				'typography' => array(
-					'fontSize' => '12',
-				),
-			),
+			'core'
 		);
 
 		$add_new_block = array(
@@ -436,31 +459,29 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 					'custom'         => true,
 					'customGradient' => true,
 					'palette'        => array(
-						array(
-							'slug'  => 'red',
-							'color' => 'red',
-						),
-						array(
-							'slug'  => 'green',
-							'color' => 'green',
-						),
-						array(
-							'slug'  => 'blue',
-							'color' => 'blue',
+						'core' => array(
+							array(
+								'slug'  => 'blue',
+								'color' => 'blue',
+							),
 						),
 					),
 					'gradients'      => array(
-						array(
-							'slug'     => 'gradient',
-							'gradient' => 'gradient',
+						'core' => array(
+							array(
+								'slug'     => 'gradient',
+								'gradient' => 'gradient',
+							),
 						),
 					),
 				),
 				'typography' => array(
-					'fontSizes' => array(
-						array(
-							'slug' => 'fontSize',
-							'size' => 'fontSize',
+					'fontSizes'    => array(
+						'core' => array(
+							array(
+								'slug' => 'fontSize',
+								'size' => 'fontSize',
+							),
 						),
 					),
 				),
@@ -502,14 +523,13 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 			),
 		);
 
-		$theme_json = new WP_Theme_JSON( $initial );
-		$theme_json->merge( new WP_Theme_JSON( $add_new_block ) );
-		$theme_json->merge( new WP_Theme_JSON( $add_key_in_settings ) );
-		$theme_json->merge( new WP_Theme_JSON( $update_key_in_settings ) );
-		$theme_json->merge( new WP_Theme_JSON( $add_styles ) );
-		$theme_json->merge( new WP_Theme_JSON( $add_key_in_styles ) );
-		$theme_json->merge( new WP_Theme_JSON( $add_invalid_context ) );
-		$theme_json->merge( new WP_Theme_JSON( $update_presets ) );
+		$theme_json->merge( new WP_Theme_JSON( $add_new_block ), 'core' );
+		$theme_json->merge( new WP_Theme_JSON( $add_key_in_settings ), 'core' );
+		$theme_json->merge( new WP_Theme_JSON( $update_key_in_settings ), 'core' );
+		$theme_json->merge( new WP_Theme_JSON( $add_styles ), 'core' );
+		$theme_json->merge( new WP_Theme_JSON( $add_key_in_styles ), 'core' );
+		$theme_json->merge( new WP_Theme_JSON( $add_invalid_context ), 'core' );
+		$theme_json->merge( new WP_Theme_JSON( $update_presets ), 'core' );
 		$actual = $theme_json->get_raw_data();
 
 		$this->assertEqualSetsWithIndex( $expected, $actual );


### PR DESCRIPTION
Fixes https://core.trac.wordpress.org/ticket/53378

We found a couple of regressions with colors:

- themes could no longer pass an empty array to disable the feature
- the legacy `settings.color`  setting in the `core/block-editor` store didn't have the proper value

These have been fixed in the plugin with this PR https://github.com/WordPress/gutenberg/pull/32358

props @jorgefilipecosta 
