### PR TITLE
53002: correctly set result of individual bulk update

### DIFF
--- a/src/wp-admin/includes/class-plugin-upgrader.php
+++ b/src/wp-admin/includes/class-plugin-upgrader.php
@@ -347,7 +347,7 @@ class Plugin_Upgrader extends WP_Upgrader {
 				)
 			);
 
-			$results[ $plugin ] = $this->result;
+			$results[ $plugin ] = $result;
 
 			// Prevent credentials auth screen from displaying multiple times.
 			if ( false === $result ) {

--- a/src/wp-admin/includes/class-theme-upgrader.php
+++ b/src/wp-admin/includes/class-theme-upgrader.php
@@ -448,7 +448,7 @@ class Theme_Upgrader extends WP_Upgrader {
 				)
 			);
 
-			$results[ $theme ] = $this->result;
+			$results[ $theme ] = $result;
 
 			// Prevent credentials auth screen from displaying multiple times.
 			if ( false === $result ) {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

When bulk updating plugins/themes, the global `$this->result` is used to identify the result of `$this->run()`. This seems to only update for the first plugin/theme updated. Using the local variable `$result` seems to fix this issue.

Using the example in the description.

```
$ wp plugin update --all                         
Downloading update from https://downloads.wordpress.org/plugin/akismet.4.1.9.zip...
Using cached file '/Users/afragen/.wp-cli/cache/plugin/akismet-4.1.9.zip'...
Unpacking the update...
Installing the latest version...
Removing the old version of the plugin...
Plugin updated successfully.
Downloading update from https://downloads.wordpress.org/plugin/wordpress-importer.0.7.zip...
Using cached file '/Users/afragen/.wp-cli/cache/plugin/wordpress-importer-0.7.zip'...
Unpacking the update...
Installing the latest version...
Removing the old version of the plugin...
Warning: Could not remove the old plugin.
Plugin update failed.
+--------------------+-------------+-------------+---------+
| name               | old_version | new_version | status  |
+--------------------+-------------+-------------+---------+
| akismet            | 4.0         | 4.1.9       | Updated |
| wordpress-importer | 0.5         | 0.7         | Updated |
+--------------------+-------------+-------------+---------+
Success: Updated 2 of 2 plugins.
```

The success message is somewhere inside of WP-CLI.

Trac ticket: https://core.trac.wordpress.org/ticket/53002

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
