### PR TITLE
Load theme styles in the Widgets editor.

### DIFF
--- a/.env
+++ b/.env
@@ -10,7 +10,7 @@
 ##
 
 # The site will be available at http://localhost:LOCAL_PORT
-LOCAL_PORT=8890
+LOCAL_PORT=8889
 
 # Where to run WordPress from. Valid options are 'src' and 'build'.
 LOCAL_DIR=src

--- a/.env
+++ b/.env
@@ -10,7 +10,7 @@
 ##
 
 # The site will be available at http://localhost:LOCAL_PORT
-LOCAL_PORT=8889
+LOCAL_PORT=8890
 
 # Where to run WordPress from. Valid options are 'src' and 'build'.
 LOCAL_DIR=src

--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -18,10 +18,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @global WP_Post_Type $post_type_object
  * @global WP_Post      $post             Global post object.
  * @global string       $title
- * @global array        $editor_styles
  * @global array        $wp_meta_boxes
  */
-global $post_type, $post_type_object, $post, $title, $editor_styles, $wp_meta_boxes;
+global $post_type, $post_type_object, $post, $title, $wp_meta_boxes;
 
 $block_editor_context = new WP_Block_Editor_Context( array( 'post' => $post ) );
 
@@ -128,36 +127,6 @@ $available_templates = ! empty( $available_templates ) ? array_merge(
 	$available_templates
 ) : $available_templates;
 
-// Editor Styles.
-$styles = array(
-	array(
-		'css'            => 'body { font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif }',
-		'__unstableType' => 'core',
-	),
-);
-if ( $editor_styles && current_theme_supports( 'editor-styles' ) ) {
-	foreach ( $editor_styles as $style ) {
-		if ( preg_match( '~^(https?:)?//~', $style ) ) {
-			$response = wp_remote_get( $style );
-			if ( ! is_wp_error( $response ) ) {
-				$styles[] = array(
-					'css'            => wp_remote_retrieve_body( $response ),
-					'__unstableType' => 'theme',
-				);
-			}
-		} else {
-			$file = get_theme_file_path( $style );
-			if ( is_file( $file ) ) {
-				$styles[] = array(
-					'css'            => file_get_contents( $file ),
-					'baseURL'        => get_theme_file_uri( $style ),
-					'__unstableType' => 'theme',
-				);
-			}
-		}
-	}
-}
-
 // Lock settings.
 $user_id = wp_check_post_lock( $post->ID );
 if ( $user_id ) {
@@ -212,7 +181,7 @@ $editor_settings = array(
 	'titlePlaceholder'                     => apply_filters( 'enter_title_here', __( 'Add title' ), $post ),
 	'bodyPlaceholder'                      => $body_placeholder,
 	'autosaveInterval'                     => AUTOSAVE_INTERVAL,
-	'styles'                               => $styles,
+	'styles'                               => get_block_editor_theme_styles(),
 	'richEditingEnabled'                   => user_can_richedit(),
 	'postLock'                             => $lock_details,
 	'postLockUtils'                        => array(

--- a/src/wp-admin/widgets-form-blocks.php
+++ b/src/wp-admin/widgets-form-blocks.php
@@ -24,39 +24,8 @@ $preload_paths = array(
 );
 block_editor_rest_api_preload( $preload_paths, $block_editor_context );
 
-
-// Editor Styles.
-$styles = array(
-	array(
-		'css'            => 'body { font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif }',
-		'__unstableType' => 'core',
-	),
-);
-if ( $editor_styles && current_theme_supports( 'editor-styles' ) ) {
-	foreach ( $editor_styles as $style ) {
-		if ( preg_match( '~^(https?:)?//~', $style ) ) {
-			$response = wp_remote_get( $style );
-			if ( ! is_wp_error( $response ) ) {
-				$styles[] = array(
-					'css'            => wp_remote_retrieve_body( $response ),
-					'__unstableType' => 'theme',
-				);
-			}
-		} else {
-			$file = get_theme_file_path( $style );
-			if ( is_file( $file ) ) {
-				$styles[] = array(
-					'css'            => file_get_contents( $file ),
-					'baseURL'        => get_theme_file_uri( $style ),
-					'__unstableType' => 'theme',
-				);
-			}
-		}
-	}
-}
-
 $editor_settings = get_block_editor_settings(
-	array_merge( get_legacy_widget_block_editor_settings(), array( 'styles' => $styles ) ),
+	array_merge( get_legacy_widget_block_editor_settings(), array( 'styles' => get_block_editor_theme_styles() ) ),
 	$block_editor_context
 );
 

--- a/src/wp-admin/widgets-form-blocks.php
+++ b/src/wp-admin/widgets-form-blocks.php
@@ -24,8 +24,39 @@ $preload_paths = array(
 );
 block_editor_rest_api_preload( $preload_paths, $block_editor_context );
 
+
+// Editor Styles.
+$styles = array(
+	array(
+		'css'            => 'body { font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif }',
+		'__unstableType' => 'core',
+	),
+);
+if ( $editor_styles && current_theme_supports( 'editor-styles' ) ) {
+	foreach ( $editor_styles as $style ) {
+		if ( preg_match( '~^(https?:)?//~', $style ) ) {
+			$response = wp_remote_get( $style );
+			if ( ! is_wp_error( $response ) ) {
+				$styles[] = array(
+					'css'            => wp_remote_retrieve_body( $response ),
+					'__unstableType' => 'theme',
+				);
+			}
+		} else {
+			$file = get_theme_file_path( $style );
+			if ( is_file( $file ) ) {
+				$styles[] = array(
+					'css'            => file_get_contents( $file ),
+					'baseURL'        => get_theme_file_uri( $style ),
+					'__unstableType' => 'theme',
+				);
+			}
+		}
+	}
+}
+
 $editor_settings = get_block_editor_settings(
-	get_legacy_widget_block_editor_settings(),
+	array_merge( get_legacy_widget_block_editor_settings(), array( 'styles' => $styles ) ),
 	$block_editor_context
 );
 

--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -466,7 +466,7 @@ function block_editor_rest_api_preload( array $preload_paths, $block_editor_cont
 }
 
 /**
- * Creates an array of theme styles to load into the block editor
+ * Creates an array of theme styles to load into the block editor.
  *
  * @since 5.8.0
  *

--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -472,7 +472,7 @@ function block_editor_rest_api_preload( array $preload_paths, $block_editor_cont
  *
  * @global array $editor_styles
  *
- * @return array
+ * @return array Includes default font family style and theme stylesheets.
  */
 function get_block_editor_theme_styles() {
 	global $editor_styles;

--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -464,3 +464,47 @@ function block_editor_rest_api_preload( array $preload_paths, $block_editor_cont
 		'after'
 	);
 }
+
+/**
+ * Creates an array of theme styles to load into the block editor
+ *
+ * @since 5.8.0
+ *
+ * @global array $editor_styles
+ *
+ * @return array
+ */
+function get_block_editor_theme_styles() {
+	global $editor_styles;
+
+	$styles = array(
+		array(
+			'css'            => 'body { font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif }',
+			'__unstableType' => 'core',
+		),
+	);
+	if ( $editor_styles && current_theme_supports( 'editor-styles' ) ) {
+		foreach ( $editor_styles as $style ) {
+			if ( preg_match( '~^(https?:)?//~', $style ) ) {
+				$response = wp_remote_get( $style );
+				if ( ! is_wp_error( $response ) ) {
+					$styles[] = array(
+						'css'            => wp_remote_retrieve_body( $response ),
+						'__unstableType' => 'theme',
+					);
+				}
+			} else {
+				$file = get_theme_file_path( $style );
+				if ( is_file( $file ) ) {
+					$styles[] = array(
+						'css'            => file_get_contents( $file ),
+						'baseURL'        => get_theme_file_uri( $style ),
+						'__unstableType' => 'theme',
+					);
+				}
+			}
+		}
+	}
+
+	return $styles;
+}

--- a/tests/phpunit/tests/blocks/block-editor.php
+++ b/tests/phpunit/tests/blocks/block-editor.php
@@ -429,4 +429,19 @@ class WP_Test_Block_Editor extends WP_UnitTestCase {
 		$this->assertContains( '"\/wp\/v2\/blocks"', $after );
 		$this->assertContains( '"\/wp\/v2\/types"', $after );
 	}
+
+	/**
+	 * @ticket 53344
+	 */
+	function test_get_block_editor_theme_styles() {
+		$theme_styles = get_block_editor_theme_styles();
+		$this->assertCount( 1, $theme_styles );
+		$this->assertSameSets(
+			array(
+				'css'            => 'body { font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif }',
+				'__unstableType' => 'core',
+			),
+			$theme_styles[0]
+		);
+	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/53344

Also fixes https://github.com/WordPress/gutenberg/issues/26163

Loads theme styles in the Widgets editor in the same way as they are loaded in the post editor. Will also require some CSS changes on the Gutenberg side, but basic functionality can already be tested in this PR by enabling Twenty Twenty One and checking that its styles are loaded in the Widgets editor.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
