### PR TITLE
Fix/twentynineteen blocks spacing

### DIFF
--- a/src/wp-content/themes/twentynineteen/style-editor.css
+++ b/src/wp-content/themes/twentynineteen/style-editor.css
@@ -583,8 +583,18 @@ h6:lang(vi), figcaption:lang(vi),
 /** === Editor Frame === */
 body .wp-block[data-align="full"],
 body .wp-block.alignfull {
-  width: calc(100% + 20px);
-  max-width: calc(100% + 20px);
+  max-width: calc(100% + 16px);
+  padding-left: 8px;
+  padding-right: 8px;
+  width: calc(100% + 16px);
+}
+
+body .wp-block[data-align="left"],
+body .wp-block.alignleft,
+body .wp-block[data-align="right"],
+body .wp-block.alignright {
+  height: auto;
+  overflow: auto;
 }
 
 body .wp-block[data-align="left"],
@@ -620,8 +630,8 @@ body .wp-block.aligncenter {
   }
   body .wp-block[data-align="full"],
   body .wp-block.alignfull {
-    width: calc( 125% + 20px);
-    max-width: calc( 125% + 20px);
+    width: calc(125% + 16px);
+    max-width: calc(125% + 16px);
     position: relative;
     left: -12.5%;
   }

--- a/src/wp-content/themes/twentynineteen/style-editor.css
+++ b/src/wp-content/themes/twentynineteen/style-editor.css
@@ -1570,3 +1570,12 @@ ul.wp-block-archives li ul,
     width: calc(125% + 120px);
   }
 }
+
+.wp-block-post-template .wp-block[data-align="full"],
+.wp-block-post-template .wp-block.alignfull {
+  left: 0;
+  max-width: 100%;
+  padding-left: 0;
+  padding-right: 0;
+  width: 100%;
+}

--- a/src/wp-content/themes/twentynineteen/style-editor.scss
+++ b/src/wp-content/themes/twentynineteen/style-editor.scss
@@ -884,100 +884,112 @@ $group-block-background__padding: $font__size_base;
 // Full alignment
 .wp-block[data-align="full"] > .wp-block-group {
 
-		// Margins & padding are added to this container to mimic
-		// the style + spacing of the .editor-writing-flow global
-		// container. This way, child items sync up with the placement
-		// and size of other top-level blocks.
-		> .wp-block-group__inner-container {
+	// Margins & padding are added to this container to mimic
+	// the style + spacing of the .editor-writing-flow global
+	// container. This way, child items sync up with the placement
+	// and size of other top-level blocks.
+	> .wp-block-group__inner-container {
 
-			// 2px of extra padding are added to each side here
-			// To better match up with the spacing of the whole
-			// document.
+		// 2px of extra padding are added to each side here
+		// To better match up with the spacing of the whole
+		// document.
+		@include media(tablet) {
+			width: 80%;
+			margin-left: 10%;
+			margin-right: 10%;
+			padding-left: 10px;
+			padding-right: 10px;
+		}
+
+		// Child blocks: Normal Alignments
+		> .wp-block:not([data-align="wide"]):not(.alignwide):not([data-align="full"]):not(.alignfull) {
+
 			@include media(tablet) {
-				width: 80%;
-				margin-left: 10%;
-				margin-right: 10%;
-				padding-left: 10px;
-				padding-right: 10px;
+				max-width: calc(8 * (100vw / 12));
 			}
 
-			// Child blocks: Normal Alignments
-			> .wp-block:not([data-align="wide"]):not(.alignwide):not([data-align="full"]):not(.alignfull) {
-
-				@include media(tablet) {
-					max-width: calc(8 * (100vw / 12));
-				}
-
-				@include media(desktop) {
-					max-width: calc(6 * (100vw / 12));
-				}
-			}
-
-			// Child blocks: Not Full Alignments
-			> .wp-block:not([data-align="full"]):not(.alignfull) {
-				padding-left: 10px;
-				padding-right: 10px;
-
-				@include media(tablet) {
-					padding-left: 0;
-					padding-right: 0;
-				}
-			}
-
-			// Child blocks: Right alignments
-			> .wp-block[data-align="right"] {
-
-				@include media(tablet) {
-					max-width: 125%;
-				}
-			}
-
-			// Child blocks: Wide alignments
-			> .wp-block[data-align="wide"],
-			> .wp-block.alignwide {
-
-				@include media(tablet) {
-					width: 100%;
-					max-width: 100%;
-				}
-			}
-
-			// Child blocks: Full alignments
-			> .wp-block[data-align=full],
-			> .wp-block.alignfull {
-
-				@include media(tablet) {
-					left: calc( -12.5% - 13px );
-					width: calc( 125% + 26px );
-					max-width: calc( 125% + 25px );
-				}
+			@include media(desktop) {
+				max-width: calc(6 * (100vw / 12));
 			}
 		}
 
-		// Group block with background color
-		&.has-background {
+		// Child blocks: Not Full Alignments
+		> .wp-block:not([data-align="full"]):not(.alignfull) {
+			padding-left: 10px;
+			padding-right: 10px;
 
-			// When the Group block is full width, we can remove the left/right padding.
-			padding: $group-block-background__padding 0;
-
-			@include media(mobile) {
+			@include media(tablet) {
 				padding-left: 0;
 				padding-right: 0;
 			}
+		}
 
-			// Child blocks: Full alignment
-			> .wp-block-group__inner-container > .wp-block[data-align="full"],
-			> .wp-block-group__inner-container > .wp-block.alignfull {
-				margin-left: 0;
+		// Child blocks: Right alignments
+		> .wp-block[data-align="right"] {
+
+			@include media(tablet) {
+				max-width: 125%;
+			}
+		}
+
+		// Child blocks: Wide alignments
+		> .wp-block[data-align="wide"],
+		> .wp-block.alignwide {
+
+			@include media(tablet) {
 				width: 100%;
+				max-width: 100%;
+			}
+		}
 
-				@include media(mobile) {
-					width: calc(100% + 92px);
-				}
+		// Child blocks: Full alignments
+		> .wp-block[data-align=full],
+		> .wp-block.alignfull {
 
-				@include media(tablet) {
-					width: calc(125% + 120px);
-				}
+			@include media(tablet) {
+				left: calc( -12.5% - 13px );
+				width: calc( 125% + 26px );
+				max-width: calc( 125% + 25px );
 			}
 		}
 	}
+
+	// Group block with background color
+	&.has-background {
+
+		// When the Group block is full width, we can remove the left/right padding.
+		padding: $group-block-background__padding 0;
+
+		@include media(mobile) {
+			padding-left: 0;
+			padding-right: 0;
+		}
+
+		// Child blocks: Full alignment
+		> .wp-block-group__inner-container > .wp-block[data-align="full"],
+		> .wp-block-group__inner-container > .wp-block.alignfull {
+			margin-left: 0;
+			width: 100%;
+
+			@include media(mobile) {
+				width: calc(100% + 92px);
+			}
+
+			@include media(tablet) {
+				width: calc(125% + 120px);
+			}
+		}
+	}
+}
+
+.wp-block-post-template {
+
+	.wp-block[data-align="full"],
+	.wp-block.alignfull {
+		left: 0;
+		max-width: 100%;
+		padding-left: 0;
+		padding-right: 0;
+		width: 100%;
+	}
+}

--- a/src/wp-content/themes/twentynineteen/style-editor.scss
+++ b/src/wp-content/themes/twentynineteen/style-editor.scss
@@ -20,6 +20,14 @@ body {
 	}
 
 	.wp-block[data-align="left"],
+	.wp-block.alignleft,
+	.wp-block[data-align="right"],
+	.wp-block.alignright {
+		height: auto;
+		overflow: auto;
+	}
+
+	.wp-block[data-align="left"],
 	.wp-block.alignleft {
 		margin-right: $size__spacing-unit;
 		width: inherit;

--- a/src/wp-content/themes/twentynineteen/style-editor.scss
+++ b/src/wp-content/themes/twentynineteen/style-editor.scss
@@ -13,8 +13,10 @@ body {
 
 	.wp-block[data-align="full"],
 	.wp-block.alignfull {
-		width: calc(100% + 20px);
-		max-width: calc(100% + 20px);
+		max-width: calc(100% + 16px);
+		padding-left: 8px;
+		padding-right: 8px;
+		width: calc(100% + 16px);
 	}
 
 	.wp-block[data-align="left"],
@@ -54,8 +56,8 @@ body {
 
 		.wp-block[data-align="full"],
 		.wp-block.alignfull {
-			width: calc( 125% + 20px );
-			max-width: calc( 125% + 20px );
+			width: calc(125% + 16px);
+			max-width: calc(125% + 16px);
 			position: relative;
 			left: -12.5%;
 		}
@@ -806,8 +808,8 @@ ul.wp-block-archives,
 /** === Group Block === */
 
 // This matches the 22px value for 1rem that used on the front end.
-// It must be specified in pixels for the editor, since the root font 
-// size is different here. 
+// It must be specified in pixels for the editor, since the root font
+// size is different here.
 $group-block-background__padding: $font__size_base;
 
 .wp-block-group {
@@ -857,7 +859,7 @@ $group-block-background__padding: $font__size_base;
 
 	// Group block with background color
 	&.has-background {
-		
+
 		// Child blocks: Default alignments
 		> .wp-block-group__inner-container > .wp-block:not([data-align="wide"]):not([data-align="full"]):not(.alignwide):not(.alignfull) {
 			@include media(tablet) {
@@ -874,19 +876,19 @@ $group-block-background__padding: $font__size_base;
 // Full alignment
 .wp-block[data-align="full"] > .wp-block-group {
 
-		// Margins & padding are added to this container to mimic 
-		// the style + spacing of the .editor-writing-flow global 
-		// container. This way, child items sync up with the placement 
-		// and size of other top-level blocks. 
+		// Margins & padding are added to this container to mimic
+		// the style + spacing of the .editor-writing-flow global
+		// container. This way, child items sync up with the placement
+		// and size of other top-level blocks.
 		> .wp-block-group__inner-container {
 
 			// 2px of extra padding are added to each side here
-			// To better match up with the spacing of the whole 
-			// document. 
+			// To better match up with the spacing of the whole
+			// document.
 			@include media(tablet) {
 				width: 80%;
 				margin-left: 10%;
-				margin-right: 10%; 
+				margin-right: 10%;
 				padding-left: 10px;
 				padding-right: 10px;
 			}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Hello!

This PR aims to fix margins for several blocks in Twenty Nineteen theme:

## No margin around full-width blocks
![Screenshot 2021-06-16 at 13 55 03](https://user-images.githubusercontent.com/5501685/122239481-436a9300-cec1-11eb-9b8e-1ea6d8f541f2.png)

### Steps to reproduce

1. Activate _Twenty Nineteen_ theme
2. Create a new page.
3. Add a cover block.
4. Change the block alignment to 'Full-width'.
5. You'll now notice there are no margins around.

## No margin bottom on left and right aligned blocks
![Screenshot 2021-06-16 at 11 34 02](https://user-images.githubusercontent.com/5501685/122239352-26ce5b00-cec1-11eb-9091-beda45e5babf.png)

### Steps to reproduce

1. Activate _Twenty Nineteen_ theme
2. Create a new page.
3. Add a cover block.
4. Change the block alignment to 'Left align' or 'Right align'.
5. Add any other block below (e.g. heading as in the screenshot above).
6. You'll now notice there are no margins below thus no separation from the block below.

## Full-width blocks within a query loop block
![Screenshot 2021-06-16 at 15 10 57](https://user-images.githubusercontent.com/5501685/122239531-4bc2ce00-cec1-11eb-90d5-faadd743c759.png)

### Steps to reproduce

1. Activate _Twenty Nineteen_ theme
2. Create a new page.
3. Add a query loop block.
4. Change alignment to full-width.
5. Insert blocks inside the loop block and set its alignment to full-width as well.
6. This last block will be cropped and be placed out of the viewport.

Trac ticket: https://core.trac.wordpress.org/ticket/53428

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
