### PR TITLE
53431: moves reset of current screen globals to base test case

### DIFF
--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -162,13 +162,14 @@ abstract class WP_UnitTestCase_Base extends PHPUnit\Framework\TestCase {
 
 		/*
 		 * Reset globals related to current screen to provide a consistent global starting state for tests that interact
-		 * with admin screens. Replaces the need for individual tests to invoke `set_current_screen( 'front' )` as a reset.
+		 * with admin screens. Replaces the need for individual tests to invoke `set_current_screen( 'front' )` (or an
+		 * alternative implementation) as a reset.
 		 *
 		 * The globals are from `WP_Screen::set_current_screen`.
 		 *
 		 * Why not invoke `set_current_screen( 'front' )`?
-		 * Performance (faster test runs with less memory usage). How so? It saves instantiating an instance of WP_Screen,
-		 * making 2 method calls, and firing of the `current_screen` action.
+		 * Performance (faster test runs with less memory usage). How so? For each test, it saves instantiating an instance
+		 * of WP_Screen, making 2 method calls, and firing of the `current_screen` action.
 		 */
 		$current_screen_globals = array( 'current_screen', 'taxnow', 'typenow' );
 		foreach ( $current_screen_globals as $global ) {

--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -160,6 +160,15 @@ abstract class WP_UnitTestCase_Base extends PHPUnit\Framework\TestCase {
 		// Reset $wp_sitemap global so that sitemap-related dynamic $wp->public_query_vars are added when the next test runs.
 		$GLOBALS['wp_sitemaps'] = null;
 
+		/*
+		 * Reset globals related to current screen.
+		 * Ticket #53431
+		 */
+		$current_screen_globals = array( 'current_screen', 'taxnow', 'typenow' );
+		foreach ( $current_screen_globals as $global ) {
+			$GLOBALS[ $global ] = null;
+		}
+
 		$this->unregister_all_meta_keys();
 		remove_theme_support( 'html5' );
 		remove_filter( 'query', array( $this, '_create_temporary_tables' ) );

--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -161,8 +161,14 @@ abstract class WP_UnitTestCase_Base extends PHPUnit\Framework\TestCase {
 		$GLOBALS['wp_sitemaps'] = null;
 
 		/*
-		 * Reset globals related to current screen.
-		 * Ticket #53431
+		 * Reset globals related to current screen to provide a consistent global starting state for tests that interact
+		 * with admin screens. Replaces the need for individual tests to invoke `set_current_screen( 'front' )` as a reset.
+		 *
+		 * The globals are from `WP_Screen::set_current_screen`.
+		 *
+		 * Why not invoke `set_current_screen( 'front' )`?
+		 * Performance (faster test runs with less memory usage). How so? It saves instantiating an instance of WP_Screen,
+		 * making 2 method calls, and firing of the `current_screen` action.
 		 */
 		$current_screen_globals = array( 'current_screen', 'taxnow', 'typenow' );
 		foreach ( $current_screen_globals as $global ) {

--- a/tests/phpunit/tests/admin/includesPlugin.php
+++ b/tests/phpunit/tests/admin/includesPlugin.php
@@ -97,8 +97,6 @@ class Tests_Admin_includesPlugin extends WP_UnitTestCase {
 
 		// Clean up the temporary user.
 		wp_delete_user( $admin_user );
-		// Reset current screen.
-		set_current_screen( 'front' );
 
 		// Verify the menu was inserted at the expected position.
 		$this->assertSame( 'custom-position', $submenu[ $parent ][ $expected_position ][2] );
@@ -207,8 +205,6 @@ class Tests_Admin_includesPlugin extends WP_UnitTestCase {
 
 		// Clean up the temporary user.
 		wp_delete_user( $admin_user );
-		// Reset current screen.
-		set_current_screen( 'front' );
 
 		foreach ( $actual_positions as $test => $actual_position ) {
 			// Verify the menu was inserted at the expected position.
@@ -292,8 +288,6 @@ class Tests_Admin_includesPlugin extends WP_UnitTestCase {
 		// Clean up the temporary user.
 		wp_set_current_user( $current_user );
 		wp_delete_user( $admin_user );
-		// Reset current screen.
-		set_current_screen( 'front' );
 
 		// Verify the menu was inserted at the expected position.
 		$this->assertSame( 'main_slug', $submenu['main_slug'][0][2] );
@@ -325,8 +319,6 @@ class Tests_Admin_includesPlugin extends WP_UnitTestCase {
 		// Clean up the temporary user.
 		wp_set_current_user( $current_user );
 		wp_delete_user( $admin_user );
-		// Reset current screen.
-		set_current_screen( 'front' );
 
 		// Verify the menu was inserted at the expected position.
 		$this->assertSame( 'submenu_page_1', $submenu['main_slug'][1][2] );

--- a/tests/phpunit/tests/admin/includesScreen.php
+++ b/tests/phpunit/tests/admin/includesScreen.php
@@ -304,7 +304,7 @@ class Tests_Admin_includesScreen extends WP_UnitTestCase {
 			'callback' => false,
 		);
 
-		set_current_screen( 'front' );
+		set_current_screen( 'edit.php' );
 		$screen = get_current_screen();
 		$screen->add_help_tab( $tab_args );
 		$this->assertSame(
@@ -366,7 +366,7 @@ class Tests_Admin_includesScreen extends WP_UnitTestCase {
 			// Don't include a priority.
 		);
 
-		set_current_screen( 'front' );
+		set_current_screen( 'edit.php' );
 		$screen = get_current_screen();
 
 		// Add help tabs.
@@ -435,7 +435,7 @@ class Tests_Admin_includesScreen extends WP_UnitTestCase {
 			'option'  => $option,
 		);
 
-		set_current_screen( 'front' );
+		set_current_screen( 'edit.php' );
 		$screen = get_current_screen();
 
 		$screen->add_option( $option, $option_args );

--- a/tests/phpunit/tests/admin/includesScreen.php
+++ b/tests/phpunit/tests/admin/includesScreen.php
@@ -155,15 +155,8 @@ class Tests_Admin_includesScreen extends WP_UnitTestCase {
 		),
 	);
 
-	function setUp() {
-		parent::setUp();
-		set_current_screen( 'front' );
-	}
-
 	function tearDown() {
 		unset( $GLOBALS['wp_taxonomies']['old-or-new'] );
-		unset( $GLOBALS['screen'] );
-		unset( $GLOBALS['current_screen'] );
 		parent::tearDown();
 	}
 
@@ -311,6 +304,7 @@ class Tests_Admin_includesScreen extends WP_UnitTestCase {
 			'callback' => false,
 		);
 
+		set_current_screen( 'front' );
 		$screen = get_current_screen();
 		$screen->add_help_tab( $tab_args );
 		$this->assertSame(
@@ -372,6 +366,7 @@ class Tests_Admin_includesScreen extends WP_UnitTestCase {
 			// Don't include a priority.
 		);
 
+		set_current_screen( 'front' );
 		$screen = get_current_screen();
 
 		// Add help tabs.
@@ -440,6 +435,7 @@ class Tests_Admin_includesScreen extends WP_UnitTestCase {
 			'option'  => $option,
 		);
 
+		set_current_screen( 'front' );
 		$screen = get_current_screen();
 
 		$screen->add_option( $option, $option_args );
@@ -456,8 +452,6 @@ class Tests_Admin_includesScreen extends WP_UnitTestCase {
 	}
 
 	function test_in_admin() {
-		$screen = get_current_screen();
-
 		set_current_screen( 'edit.php' );
 		$this->assertTrue( get_current_screen()->in_admin() );
 		$this->assertTrue( get_current_screen()->in_admin( 'site' ) );
@@ -481,8 +475,6 @@ class Tests_Admin_includesScreen extends WP_UnitTestCase {
 		$this->assertFalse( get_current_screen()->in_admin( 'site' ) );
 		$this->assertFalse( get_current_screen()->in_admin( 'network' ) );
 		$this->assertFalse( get_current_screen()->in_admin( 'user' ) );
-
-		$GLOBALS['current_screen'] = $screen;
 	}
 
 	/**

--- a/tests/phpunit/tests/admin/includesTemplate.php
+++ b/tests/phpunit/tests/admin/includesTemplate.php
@@ -234,8 +234,6 @@ class Tests_Admin_includesTemplate extends WP_UnitTestCase {
 
 		// This doesn't actually get removed due to the invalid priority.
 		remove_meta_box( 'dashboard2', 'dashboard', 'normal' );
-
-		set_current_screen( 'front' );
 	}
 
 }

--- a/tests/phpunit/tests/adminbar.php
+++ b/tests/phpunit/tests/adminbar.php
@@ -400,8 +400,6 @@ class Tests_AdminBar extends WP_UnitTestCase {
 		$wp_admin_bar = $this->get_standard_admin_bar();
 		$node         = $wp_admin_bar->get_node( 'archive' );
 
-		set_current_screen( 'front' );
-
 		$this->assertNull( $node );
 	}
 
@@ -415,8 +413,6 @@ class Tests_AdminBar extends WP_UnitTestCase {
 		$wp_admin_bar = $this->get_standard_admin_bar();
 		$node         = $wp_admin_bar->get_node( 'archive' );
 
-		set_current_screen( 'front' );
-
 		$this->assertNotNull( $node );
 	}
 
@@ -428,8 +424,6 @@ class Tests_AdminBar extends WP_UnitTestCase {
 
 		$wp_admin_bar = $this->get_standard_admin_bar();
 		$node         = $wp_admin_bar->get_node( 'archive' );
-
-		set_current_screen( 'front' );
 
 		$this->assertNull( $node );
 	}
@@ -508,7 +502,6 @@ class Tests_AdminBar extends WP_UnitTestCase {
 		$wp_admin_bar = $this->get_standard_admin_bar();
 		$node         = $wp_admin_bar->get_node( 'archive' );
 
-		set_current_screen( 'front' );
 		unregister_post_type( 'foo-non-public' );
 
 		$this->assertNull( $node );
@@ -532,7 +525,6 @@ class Tests_AdminBar extends WP_UnitTestCase {
 		$wp_admin_bar = $this->get_standard_admin_bar();
 		$node         = $wp_admin_bar->get_node( 'archive' );
 
-		set_current_screen( 'front' );
 		unregister_post_type( 'foo-non-public' );
 
 		$this->assertNull( $node );
@@ -556,7 +548,6 @@ class Tests_AdminBar extends WP_UnitTestCase {
 		$wp_admin_bar = $this->get_standard_admin_bar();
 		$node         = $wp_admin_bar->get_node( 'archive' );
 
-		set_current_screen( 'front' );
 		unregister_post_type( 'foo-non-public' );
 
 		$this->assertNull( $node );
@@ -679,7 +670,6 @@ class Tests_AdminBar extends WP_UnitTestCase {
 		);
 		$wp_customize->start_previewing_theme();
 
-		set_current_screen( 'front' );
 		$wp_admin_bar = $this->get_standard_admin_bar();
 		$node         = $wp_admin_bar->get_node( 'customize' );
 		$this->assertNotEmpty( $node );

--- a/tests/phpunit/tests/dependencies/jquery.php
+++ b/tests/phpunit/tests/dependencies/jquery.php
@@ -82,8 +82,6 @@ class Tests_Dependencies_jQuery extends WP_UnitTestCase {
 			wp_deregister_script( $library );
 			$this->assertTrue( wp_script_is( $library, 'registered' ) );
 		}
-
-		set_current_screen( 'front' );
 	}
 
 	/**

--- a/tests/phpunit/tests/l10n/getUserLocale.php
+++ b/tests/phpunit/tests/l10n/getUserLocale.php
@@ -20,12 +20,6 @@ class Tests_L10n_GetUserLocale extends WP_UnitTestCase {
 		wp_set_current_user( $this->user_id );
 	}
 
-	public function tearDown() {
-		set_current_screen( 'front' );
-
-		parent::tearDown();
-	}
-
 	public function test_user_locale_property() {
 		set_current_screen( 'dashboard' );
 		$this->assertSame( 'de_DE', get_user_locale() );

--- a/tests/phpunit/tests/l10n/loadTextdomain.php
+++ b/tests/phpunit/tests/l10n/loadTextdomain.php
@@ -195,8 +195,6 @@ class Tests_L10n_LoadTextdomain extends WP_UnitTestCase {
 
 		load_muplugin_textdomain( 'wp-tests-domain' );
 
-		set_current_screen( 'front' );
-
 		$this->assertSame( get_user_locale(), $this->locale );
 	}
 
@@ -215,8 +213,6 @@ class Tests_L10n_LoadTextdomain extends WP_UnitTestCase {
 
 		load_plugin_textdomain( 'wp-tests-domain' );
 
-		set_current_screen( 'front' );
-
 		$this->assertSame( get_user_locale(), $this->locale );
 	}
 
@@ -234,8 +230,6 @@ class Tests_L10n_LoadTextdomain extends WP_UnitTestCase {
 		wp_set_current_user( self::$user_id );
 
 		load_theme_textdomain( 'wp-tests-domain' );
-
-		set_current_screen( 'front' );
 
 		$this->assertSame( get_user_locale(), $this->locale );
 	}

--- a/tests/phpunit/tests/l10n/loadTextdomainJustInTime.php
+++ b/tests/phpunit/tests/l10n/loadTextdomainJustInTime.php
@@ -211,8 +211,6 @@ class Tests_L10n_LoadTextdomainJustInTime extends WP_UnitTestCase {
 
 		$expected = i18n_plugin_test();
 
-		set_current_screen( 'front' );
-
 		$this->assertSame( 'Das ist ein Dummy Plugin', $expected );
 	}
 
@@ -228,7 +226,6 @@ class Tests_L10n_LoadTextdomainJustInTime extends WP_UnitTestCase {
 
 		$expected = i18n_theme_test();
 
-		set_current_screen( 'front' );
 		switch_theme( WP_DEFAULT_THEME );
 
 		$this->assertSame( 'Das ist ein Dummy Theme', $expected );

--- a/tests/phpunit/tests/l10n/wpLocaleSwitcher.php
+++ b/tests/phpunit/tests/l10n/wpLocaleSwitcher.php
@@ -284,8 +284,6 @@ class Tests_L10n_wpLocaleSwitcher extends WP_UnitTestCase {
 
 		$wp_locale_switcher = $locale_switcher;
 
-		set_current_screen( 'front' );
-
 		$this->assertFalse( $locale_switched_user_locale );
 		$this->assertTrue( $locale_switched_site_locale );
 		$this->assertSame( $site_locale, $site_locale_after_switch );
@@ -335,8 +333,6 @@ class Tests_L10n_wpLocaleSwitcher extends WP_UnitTestCase {
 
 		$wp_locale_switcher = $locale_switcher;
 
-		set_current_screen( 'front' );
-
 		remove_filter( 'locale', array( $this, 'filter_locale' ) );
 
 		$this->assertFalse( $locale_switched_user_locale );
@@ -381,8 +377,6 @@ class Tests_L10n_wpLocaleSwitcher extends WP_UnitTestCase {
 		restore_current_locale();
 
 		$wp_locale_switcher = $locale_switcher;
-
-		set_current_screen( 'front' );
 
 		$this->assertSame( 'en_US', get_locale() );
 		$this->assertSame( 'This is a dummy plugin', $expected );

--- a/tests/phpunit/tests/menu/wpAjaxMenuQuickSearch.php
+++ b/tests/phpunit/tests/menu/wpAjaxMenuQuickSearch.php
@@ -6,32 +6,6 @@
 class Tests_Menu_WpAjaxMenuQuickSeach extends WP_UnitTestCase {
 
 	/**
-	 * Current screen.
-	 *
-	 * @var mixed
-	 */
-	protected $current_screen;
-
-	/**
-	 * Set up. Workaround set_current_screen( null ) not working due to $hook_suffix not being set.
-	 */
-	function setUp() {
-		parent::setUp();
-
-		global $current_screen;
-		$this->current_screen = $current_screen;
-	}
-
-	/**
-	 * Tear down. Workaround set_current_screen( null ) not working due to $hook_suffix not being set.
-	 */
-	function tearDown() {
-		global $current_screen;
-		$current_screen = $this->current_screen;
-		parent::tearDown();
-	}
-
-	/**
 	 * Test search returns results for pages.
 	 *
 	 * @ticket 27042

--- a/tests/phpunit/tests/post/attachments.php
+++ b/tests/phpunit/tests/post/attachments.php
@@ -410,9 +410,6 @@ class Tests_Post_Attachments extends WP_UnitTestCase {
 
 		$url = wp_get_attachment_url( $attachment_id );
 
-		// Cleanup.
-		set_current_screen( 'front' );
-
 		$this->assertSame( set_url_scheme( $url, 'http' ), $url );
 	}
 
@@ -438,7 +435,6 @@ class Tests_Post_Attachments extends WP_UnitTestCase {
 		$url = wp_get_attachment_url( $attachment_id );
 
 		// Cleanup.
-		set_current_screen( 'front' );
 		remove_filter( 'upload_dir', '_upload_dir_https' );
 
 		$this->assertSame( 'https', parse_url( $url, PHP_URL_SCHEME ) );

--- a/tests/phpunit/tests/query/conditionals.php
+++ b/tests/phpunit/tests/query/conditionals.php
@@ -17,8 +17,6 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	function setUp() {
 		parent::setUp();
 
-		set_current_screen( 'front' );
-
 		update_option( 'comments_per_page', 5 );
 		update_option( 'posts_per_page', 5 );
 

--- a/tests/phpunit/tests/query/isTerm.php
+++ b/tests/phpunit/tests/query/isTerm.php
@@ -25,8 +25,6 @@ class Tests_Query_IsTerm extends WP_UnitTestCase {
 	function setUp() {
 		parent::setUp();
 
-		set_current_screen( 'front' );
-
 		$GLOBALS['wp_the_query'] = new WP_Query();
 		$GLOBALS['wp_query']     = $GLOBALS['wp_the_query'];
 

--- a/tests/phpunit/tests/query/postStatus.php
+++ b/tests/phpunit/tests/query/postStatus.php
@@ -211,7 +211,6 @@ class Tests_Query_PostStatus extends WP_UnitTestCase {
 		);
 
 		$this->assertContains( "post_status = 'foo", $q->request );
-		set_current_screen( 'front' );
 	}
 
 	public function test_private_statuses_should_be_included_when_current_user_can_read_private_posts() {

--- a/tests/phpunit/tests/rest-api.php
+++ b/tests/phpunit/tests/rest-api.php
@@ -793,8 +793,6 @@ class Tests_REST_API extends WP_UnitTestCase {
 
 		// Reset.
 		update_option( 'siteurl', $_siteurl );
-		set_current_screen( 'front' );
-
 	}
 
 	/**

--- a/tests/phpunit/tests/url.php
+++ b/tests/phpunit/tests/url.php
@@ -199,8 +199,6 @@ class Tests_URL extends WP_UnitTestCase {
 	}
 
 	function test_home_url_from_admin() {
-		$screen = get_current_screen();
-
 		// Pretend to be in the site admin.
 		set_current_screen( 'dashboard' );
 		$home       = get_option( 'home' );
@@ -243,13 +241,9 @@ class Tests_URL extends WP_UnitTestCase {
 		$this->assertSame( $home, home_url() );
 
 		update_option( 'home', set_url_scheme( $home, 'http' ) );
-
-		$GLOBALS['current_screen'] = $screen;
 	}
 
 	function test_network_home_url_from_admin() {
-		$screen = get_current_screen();
-
 		// Pretend to be in the site admin.
 		set_current_screen( 'dashboard' );
 		$home       = network_home_url();
@@ -268,8 +262,6 @@ class Tests_URL extends WP_UnitTestCase {
 		$this->assertSame( $home, network_home_url() );
 		$_SERVER['HTTPS'] = 'on';
 		$this->assertSame( $home_https, network_home_url() );
-
-		$GLOBALS['current_screen'] = $screen;
 	}
 
 	function test_set_url_scheme() {

--- a/tests/phpunit/tests/user/wpSendUserRequest.php
+++ b/tests/phpunit/tests/user/wpSendUserRequest.php
@@ -79,9 +79,6 @@ class Tests_User_WpSendUserRequest extends WP_UnitTestCase {
 		reset_phpmailer_instance();
 
 		unset( $GLOBALS['locale'] );
-		unset( $GLOBALS['current_screen'] );
-		unset( $GLOBALS['taxnow'] );
-		unset( $GLOBALS['typenow'] );
 
 		restore_previous_locale();
 		parent::tearDown();


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/53431

Moves the resetting of current screen globals from individual tests to the base test case.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
