### PR TITLE
Don't load wp-editor in the widgets screen

### DIFF
--- a/src/wp-admin/widgets-form-blocks.php
+++ b/src/wp-admin/widgets-form-blocks.php
@@ -29,6 +29,26 @@ $editor_settings = get_block_editor_settings(
 	$block_editor_context
 );
 
+// The widgets editor doesn't support the Block Directory, so don't load any of
+// its assets. This also prevents 'wp-editor' from being enqueued which we
+// cannot load in the widgets screen because many widget scripts rely on
+// `wp.editor`.
+remove_action( 'enqueue_block_editor_assets', 'wp_enqueue_editor_block_directory_assets' );
+
+// Remove 'wp-editor' as a dependency of 'wp-block-library'. We must not load
+// 'wp-editor' in the widgets screen because many widget scripts rely on
+// `wp.editor`. The block library will still function without this dependency as
+// it is only used by the Classic block which is disabled in the widgets editor.
+$wp_block_library = wp_scripts()->query( 'wp-block-library' );
+wp_scripts()->remove( $wp_block_library->handle );
+wp_scripts()->add(
+	$wp_block_library->handle,
+	$wp_block_library->src,
+	array_diff( $wp_block_library->deps, array( 'wp-editor' ) ),
+	$wp_block_library->ver,
+	$wp_block_library->args
+);
+
 wp_add_inline_script(
 	'wp-edit-widgets',
 	sprintf(


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/53437

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
