### PR TITLE
39265 Batch 1: add @covers to tests

### DIFF
--- a/tests/phpunit/tests/actions.php
+++ b/tests/phpunit/tests/actions.php
@@ -7,6 +7,9 @@
  */
 class Tests_Actions extends WP_UnitTestCase {
 
+	/**
+	 * @covers ::do_action
+	 */
 	function test_simple_action() {
 		$a   = new MockAction();
 		$tag = __FUNCTION__;
@@ -24,6 +27,9 @@ class Tests_Actions extends WP_UnitTestCase {
 		$this->assertSame( array( '' ), $args );
 	}
 
+	/**
+	 * @covers ::remove_action
+	 */
 	function test_remove_action() {
 		$a   = new MockAction();
 		$tag = __FUNCTION__;
@@ -43,6 +49,9 @@ class Tests_Actions extends WP_UnitTestCase {
 
 	}
 
+	/**
+	 * @covers ::has_action
+	 */
 	function test_has_action() {
 		$tag  = __FUNCTION__;
 		$func = __FUNCTION__ . '_func';
@@ -57,7 +66,11 @@ class Tests_Actions extends WP_UnitTestCase {
 		$this->assertFalse( has_action( $tag ) );
 	}
 
-	// One tag with multiple actions.
+	/**
+	 * One tag with multiple actions.
+	 *
+	 * @covers ::do_action
+	 */
 	function test_multiple_actions() {
 		$a1  = new MockAction();
 		$a2  = new MockAction();
@@ -74,6 +87,11 @@ class Tests_Actions extends WP_UnitTestCase {
 		$this->assertSame( 1, $a2->get_call_count() );
 	}
 
+	/**
+	 * One tag with multiple actions.
+	 *
+	 * @covers ::do_action
+	 */
 	function test_action_args_1() {
 		$a   = new MockAction();
 		$tag = __FUNCTION__;
@@ -89,6 +107,11 @@ class Tests_Actions extends WP_UnitTestCase {
 		$this->assertSame( array( $val ), array_pop( $argsvar ) );
 	}
 
+	/**
+	 * One tag with multiple actions.
+	 *
+	 * @covers ::do_action
+	 */
 	function test_action_args_2() {
 		$a1   = new MockAction();
 		$a2   = new MockAction();
@@ -120,6 +143,8 @@ class Tests_Actions extends WP_UnitTestCase {
 	 *
 	 * @see https://core.trac.wordpress.org/ticket/17817#comment:72
 	 * @ticket 17817
+	 *
+	 * @covers ::do_action
 	 */
 	function test_action_args_3() {
 		$a1   = new MockAction();
@@ -157,6 +182,8 @@ class Tests_Actions extends WP_UnitTestCase {
 	 * Tests PHP 4 notation for calling actions while passing in an object by reference.
 	 *
 	 * @ticket 48312
+	 *
+	 * @covers ::do_action
 	 */
 	function test_action_args_with_php4_syntax() {
 		$a   = new MockAction();
@@ -201,6 +228,9 @@ class Tests_Actions extends WP_UnitTestCase {
 		$this->assertSame( $expected, $a->get_events() );
 	}
 
+	/**
+	 * @covers ::did_action
+	 */
 	function test_did_action() {
 		$tag1 = 'action1';
 		$tag2 = 'action2';
@@ -222,6 +252,9 @@ class Tests_Actions extends WP_UnitTestCase {
 
 	}
 
+	/**
+	 * @covers ::do_action
+	 */
 	function test_all_action() {
 		$a    = new MockAction();
 		$tag1 = __FUNCTION__ . '_1';
@@ -246,6 +279,9 @@ class Tests_Actions extends WP_UnitTestCase {
 
 	}
 
+	/**
+	 * @covers ::remove_action
+	 */
 	function test_remove_all_action() {
 		$a   = new MockAction();
 		$tag = __FUNCTION__;
@@ -266,6 +302,9 @@ class Tests_Actions extends WP_UnitTestCase {
 		$this->assertSame( array( $tag ), $a->get_tags() );
 	}
 
+	/**
+	 * @covers ::do_action_ref_array
+	 */
 	function test_action_ref_array() {
 		$obj = new stdClass();
 		$a   = new MockAction();
@@ -284,6 +323,8 @@ class Tests_Actions extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 11241
+	 *
+	 * @covers ::do_action
 	 */
 	function test_action_keyed_array() {
 		$a = new MockAction();
@@ -309,6 +350,9 @@ class Tests_Actions extends WP_UnitTestCase {
 
 	}
 
+	/**
+	 * @covers ::remove_action
+	 */
 	function test_action_self_removal() {
 		add_action( 'test_action_self_removal', array( $this, 'action_self_removal' ) );
 		do_action( 'test_action_self_removal' );
@@ -321,6 +365,8 @@ class Tests_Actions extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 17817
+	 *
+	 * @covers ::do_action
 	 */
 	function test_action_recursion() {
 		$tag = __FUNCTION__;
@@ -336,6 +382,9 @@ class Tests_Actions extends WP_UnitTestCase {
 		$this->assertSame( 2, $b->get_call_count(), 'recursive actions should call callbacks with later priority' );
 	}
 
+	/**
+	 * @covers ::do_action
+	 */
 	function action_that_causes_recursion( $tag ) {
 		static $recursing = false;
 		if ( ! $recursing ) {
@@ -348,6 +397,9 @@ class Tests_Actions extends WP_UnitTestCase {
 	/**
 	 * @ticket 9968
 	 * @ticket 17817
+	 *
+	 * @covers ::remove_action
+	 * @covers ::add_action
 	 */
 	function test_action_callback_manipulation_while_running() {
 		$tag = __FUNCTION__;
@@ -383,6 +435,8 @@ class Tests_Actions extends WP_UnitTestCase {
 	 *
 	 * This specificaly addresses the concern raised at
 	 * https://core.trac.wordpress.org/ticket/17817#comment:52
+	 *
+	 * @covers ::remove_filter
 	 */
 	function test_remove_anonymous_callback() {
 		$tag = __FUNCTION__;
@@ -416,6 +470,10 @@ class Tests_Actions extends WP_UnitTestCase {
 	 * Test the ArrayAccess methods of WP_Hook
 	 *
 	 * @ticket 17817
+	 *
+	 * @covers WP_Hook::offsetGet
+	 * @covers WP_Hook::offsetSet
+	 * @covers WP_Hook::offsetUnset
 	 */
 	function test_array_access_of_wp_filter_global() {
 		global $wp_filter;
@@ -442,6 +500,8 @@ class Tests_Actions extends WP_UnitTestCase {
 	 * Make sure current_action() behaves as current_filter()
 	 *
 	 * @ticket 14994
+	 *
+	 * @covers ::current_action
 	 */
 	function test_current_action() {
 		global $wp_current_filter;
@@ -453,6 +513,8 @@ class Tests_Actions extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 14994
+	 *
+	 * @covers ::doing_filter
 	 */
 	function test_doing_filter() {
 		global $wp_current_filter;
@@ -472,6 +534,8 @@ class Tests_Actions extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 14994
+	 *
+	 * @covers ::doing_filter
 	 */
 	function test_doing_action() {
 		global $wp_current_filter;
@@ -491,6 +555,8 @@ class Tests_Actions extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 14994
+	 *
+	 * @covers ::doing_filter
 	 */
 	function test_doing_filter_real() {
 		$this->assertFalse( doing_filter() );            // No filter is passed in, and no filter is being processed.
@@ -541,6 +607,8 @@ class Tests_Actions extends WP_UnitTestCase {
 	/**
 	 * @ticket 10441
 	 * @expectedDeprecated tests_do_action_deprecated
+	 *
+	 * @covers ::do_action_deprecated
 	 */
 	public function test_do_action_deprecated() {
 		$p = new WP_Post( (object) array( 'post_title' => 'Foo' ) );
@@ -559,6 +627,8 @@ class Tests_Actions extends WP_UnitTestCase {
 	/**
 	 * @ticket 10441
 	 * @expectedDeprecated tests_do_action_deprecated
+	 *
+	 * @covers ::do_action_deprecated
 	 */
 	public function test_do_action_deprecated_with_multiple_params() {
 		$p1 = new WP_Post( (object) array( 'post_title' => 'Foo1' ) );

--- a/tests/phpunit/tests/actions/callbacks.php
+++ b/tests/phpunit/tests/actions/callbacks.php
@@ -7,6 +7,8 @@ class Tests_Actions_Callbacks extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 23265
+	 *
+	 * @covers ::add_action
 	 */
 	function test_callback_representations() {
 		$tag = __FUNCTION__;

--- a/tests/phpunit/tests/actions/closures.php
+++ b/tests/phpunit/tests/actions/closures.php
@@ -9,6 +9,10 @@ class Tests_Actions_Closures extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 10493
+	 *
+	 * @covers ::add_action
+	 * @covers ::has_action
+	 * @covers ::do_action
 	 */
 	function test_action_closure() {
 		$tag     = 'test_action_closure';

--- a/tests/phpunit/tests/admin/includesComment.php
+++ b/tests/phpunit/tests/admin/includesComment.php
@@ -47,6 +47,8 @@ class Tests_Admin_IncludesComment extends WP_UnitTestCase {
 
 	/**
 	 * Verify that both the comment date and author must match for a comment to exist.
+	 *
+	 * @covers ::comment_exists
 	 */
 	public function test_must_match_date_and_author() {
 		$this->assertNull( comment_exists( 1, '2004-01-02 12:00:00' ) );
@@ -55,6 +57,8 @@ class Tests_Admin_IncludesComment extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 33871
+	 *
+	 * @covers ::comment_exists
 	 */
 	public function test_default_value_of_timezone_should_be_blog() {
 		$this->assertEquals( self::$post_id, comment_exists( 1, '2014-05-06 12:00:00' ) );
@@ -62,6 +66,8 @@ class Tests_Admin_IncludesComment extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 33871
+	 *
+	 * @covers ::comment_exists
 	 */
 	public function test_should_respect_timezone_blog() {
 		$this->assertEquals( self::$post_id, comment_exists( 1, '2014-05-06 12:00:00', 'blog' ) );
@@ -69,6 +75,8 @@ class Tests_Admin_IncludesComment extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 33871
+	 *
+	 * @covers ::comment_exists
 	 */
 	public function test_should_respect_timezone_gmt() {
 		$this->assertEquals( self::$post_id, comment_exists( 1, '2014-05-06 07:00:00', 'gmt' ) );
@@ -76,6 +84,8 @@ class Tests_Admin_IncludesComment extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 33871
+	 *
+	 * @covers ::comment_exists
 	 */
 	public function test_invalid_timezone_should_fall_back_on_blog() {
 		$this->assertEquals( self::$post_id, comment_exists( 1, '2014-05-06 12:00:00', 'not_a_valid_value' ) );

--- a/tests/phpunit/tests/admin/includesCommunityEvents.php
+++ b/tests/phpunit/tests/admin/includesCommunityEvents.php
@@ -60,6 +60,8 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 	 * Test: get_events() should return an instance of WP_Error if the response code is not 200.
 	 *
 	 * @since 4.8.0
+	 *
+	 * @covers WP_Community_Events::get_events
 	 */
 	public function test_get_events_bad_response_code() {
 		add_filter( 'pre_http_request', array( $this, '_http_request_bad_response_code' ) );
@@ -73,6 +75,8 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 	 * Test: The response body should not be cached if the response code is not 200.
 	 *
 	 * @since 4.8.0
+	 *
+	 * @covers WP_Community_Events::get_events
 	 */
 	public function test_get_cached_events_bad_response_code() {
 		add_filter( 'pre_http_request', array( $this, '_http_request_bad_response_code' ) );
@@ -108,6 +112,8 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 	 * the required properties.
 	 *
 	 * @since 4.8.0
+	 *
+	 * @covers WP_Community_Events::get_events
 	 */
 	public function test_get_events_invalid_response() {
 		add_filter( 'pre_http_request', array( $this, '_http_request_invalid_response' ) );
@@ -121,6 +127,8 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 	 * Test: The response body should not be cached if it does not have the required properties.
 	 *
 	 * @since 4.8.0
+	 *
+	 * @covers WP_Community_Events::get_events
 	 */
 	public function test_get_cached_events_invalid_response() {
 		add_filter( 'pre_http_request', array( $this, '_http_request_invalid_response' ) );
@@ -156,6 +164,8 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 	 * an events array with individual events that have Unix start/end timestamps.
 	 *
 	 * @since 4.8.0
+	 *
+	 * @covers WP_Community_Events::get_events
 	 */
 	public function test_get_events_valid_response() {
 		add_filter( 'pre_http_request', array( $this, '_http_request_valid_response' ) );
@@ -175,6 +185,8 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 	 * timestamps for each event.
 	 *
 	 * @since 4.8.0
+	 *
+	 * @covers WP_Community_Events::get_events
 	 */
 	public function test_get_cached_events_valid_response() {
 		add_filter( 'pre_http_request', array( $this, '_http_request_valid_response' ) );
@@ -278,9 +290,9 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 	/**
 	 * Test: `trim_events()` should immediately remove expired events.
 	 *
-	 * @covers WP_Community_Events::trim_events
-	 *
 	 * @since 5.5.2
+	 *
+	 * @covers WP_Community_Events::trim_events
 	 */
 	public function test_trim_expired_events() {
 		$trim_events = new ReflectionMethod( $this->instance, 'trim_events' );
@@ -306,10 +318,10 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 	/**
 	 * Test: get_events() should return the events with the WordCamp pinned in the prepared list.
 	 *
-	 * @covers WP_Community_Events::trim_events
-	 *
 	 * @since 4.9.7
 	 * @since 5.5.2 Tests `trim_events()` directly instead of indirectly via `get_events()`.
+	 *
+	 * @covers WP_Community_Events::trim_events
 	 */
 	public function test_trim_events_pin_wordcamp() {
 		$trim_events = new ReflectionMethod( $this->instance, 'trim_events' );
@@ -411,10 +423,10 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 	 * Test: get_events() shouldn't stick an extra WordCamp when there's already one that naturally
 	 * falls into the list.
 	 *
-	 * @covers WP_Community_Events::trim_events
-	 *
 	 * @since 4.9.7
 	 * @since 5.5.2 Tests `trim_events()` directly instead of indirectly via `get_events()`.
+	 *
+	 * @covers WP_Community_Events::trim_events
 	 */
 	public function test_trim_events_dont_pin_multiple_wordcamps() {
 		$trim_events = new ReflectionMethod( $this->instance, 'trim_events' );
@@ -536,6 +548,8 @@ class Test_WP_Community_Events extends WP_UnitTestCase {
 	 * @dataProvider data_get_unsafe_client_ip
 	 *
 	 * @ticket 41083
+	 *
+	 * @covers WP_Community_Events::get_unsafe_client_ip
 	 */
 	public function test_get_unsafe_client_ip( $raw_ip, $expected_result ) {
 		$_SERVER['REMOTE_ADDR']    = 'this should not be used';

--- a/tests/phpunit/tests/admin/includesFile.php
+++ b/tests/phpunit/tests/admin/includesFile.php
@@ -8,6 +8,8 @@ class Tests_Admin_includesFile extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 20449
+	 *
+	 * @covers ::get_home_path
 	 */
 	function test_get_home_path() {
 		$home    = get_option( 'home' );
@@ -34,6 +36,8 @@ class Tests_Admin_includesFile extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 43329
+	 *
+	 * @covers ::download_url
 	 */
 	public function test_download_url_non_200_response_code() {
 		add_filter( 'pre_http_request', array( $this, '_fake_download_url_non_200_response_code' ), 10, 3 );

--- a/tests/phpunit/tests/admin/includesListTable.php
+++ b/tests/phpunit/tests/admin/includesListTable.php
@@ -75,6 +75,9 @@ class Tests_Admin_includesListTable extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 15459
+	 *
+	 * @covers WP_Posts_List_Table::display_rows
+	 * @covers WP_Posts_List_Table::set_hierarchical_display
 	 */
 	function test_list_hierarchical_pages_first_page() {
 		$this->_test_list_hierarchical_page(
@@ -91,6 +94,9 @@ class Tests_Admin_includesListTable extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 15459
+	 *
+	 * @covers WP_Posts_List_Table::display_rows
+	 * @covers WP_Posts_List_Table::set_hierarchical_display
 	 */
 	function test_list_hierarchical_pages_second_page() {
 		$this->_test_list_hierarchical_page(
@@ -108,6 +114,9 @@ class Tests_Admin_includesListTable extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 15459
+	 *
+	 * @covers WP_Posts_List_Table::display_rows
+	 * @covers WP_Posts_List_Table::set_hierarchical_display
 	 */
 	function test_search_hierarchical_pages_first_page() {
 		$this->_test_list_hierarchical_page(
@@ -125,6 +134,9 @@ class Tests_Admin_includesListTable extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 15459
+	 *
+	 * @covers WP_Posts_List_Table::display_rows
+	 * @covers WP_Posts_List_Table::set_hierarchical_display
 	 */
 	function test_search_hierarchical_pages_second_page() {
 		$this->_test_list_hierarchical_page(
@@ -142,6 +154,9 @@ class Tests_Admin_includesListTable extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 15459
+	 *
+	 * @covers WP_Posts_List_Table::display_rows
+	 * @covers WP_Posts_List_Table::set_hierarchical_display
 	 */
 	function test_grandchildren_hierarchical_pages_first_page() {
 		// Page 6 is the first page with grandchildren.
@@ -161,6 +176,9 @@ class Tests_Admin_includesListTable extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 15459
+	 *
+	 * @covers WP_Posts_List_Table::display_rows
+	 * @covers WP_Posts_List_Table::set_hierarchical_display
 	 */
 	function test_grandchildren_hierarchical_pages_second_page() {
 		// Page 7 is the second page with grandchildren.
@@ -227,6 +245,8 @@ class Tests_Admin_includesListTable extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 37407
+	 *
+	 * @covers WP_Posts_List_Table::extra_tablenav
 	 */
 	function test_filter_button_should_not_be_shown_if_there_are_no_posts() {
 		// Set post type to a non-existent one.
@@ -241,6 +261,8 @@ class Tests_Admin_includesListTable extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 37407
+	 *
+	 * @covers WP_Posts_List_Table::extra_tablenav
 	 */
 	function test_months_dropdown_should_not_be_shown_if_there_are_no_posts() {
 		// Set post type to a non-existent one.
@@ -255,6 +277,8 @@ class Tests_Admin_includesListTable extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 37407
+	 *
+	 * @covers WP_Posts_List_Table::extra_tablenav
 	 */
 	function test_category_dropdown_should_not_be_shown_if_there_are_no_posts() {
 		// Set post type to a non-existent one.
@@ -269,6 +293,8 @@ class Tests_Admin_includesListTable extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 38341
+	 *
+	 * @covers WP_Posts_List_Table::extra_tablenav
 	 */
 	public function test_empty_trash_button_should_not_be_shown_if_there_are_no_posts() {
 		// Set post type to a non-existent one.
@@ -283,6 +309,8 @@ class Tests_Admin_includesListTable extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 40188
+	 *
+	 * @covers WP_Posts_List_Table::extra_tablenav
 	 */
 	public function test_filter_button_should_not_be_shown_if_there_are_no_comments() {
 		$table = _get_list_table( 'WP_Comments_List_Table', array( 'screen' => 'edit-comments' ) );
@@ -296,6 +324,8 @@ class Tests_Admin_includesListTable extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 40188
+	 *
+	 * @covers WP_Posts_List_Table::extra_tablenav
 	 */
 	public function test_filter_button_should_be_shown_if_there_are_comments() {
 		$post_id    = self::factory()->post->create();
@@ -318,6 +348,8 @@ class Tests_Admin_includesListTable extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 40188
+	 *
+	 * @covers WP_Posts_List_Table::extra_tablenav
 	 */
 	public function test_filter_comment_type_dropdown_should_be_shown_if_there_are_comments() {
 		$post_id    = self::factory()->post->create();
@@ -341,6 +373,8 @@ class Tests_Admin_includesListTable extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 38341
+	 *
+	 * @covers WP_Posts_List_Table::extra_tablenav
 	 */
 	public function test_empty_trash_button_should_not_be_shown_if_there_are_no_comments() {
 		$table = _get_list_table( 'WP_Comments_List_Table', array( 'screen' => 'edit-comments' ) );
@@ -354,6 +388,8 @@ class Tests_Admin_includesListTable extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 19278
+	 *
+	 * @covers WP_Posts_List_Table::bulk_actions
 	 */
 	public function test_bulk_action_menu_supports_options_and_optgroups() {
 		$table = _get_list_table( 'WP_Comments_List_Table', array( 'screen' => 'edit-comments' ) );
@@ -389,6 +425,8 @@ OPTIONS;
 
 	/**
 	 * @ticket 45089
+	 *
+	 * @covers WP_Posts_List_Table::print_column_headers
 	 */
 	public function test_sortable_columns() {
 		require_once ABSPATH . 'wp-admin/includes/class-wp-comments-list-table.php';
@@ -423,6 +461,8 @@ OPTIONS;
 
 	/**
 	 * @ticket 45089
+	 *
+	 * @covers WP_Posts_List_Table::print_column_headers
 	 */
 	public function test_sortable_columns_with_current_ordering() {
 		require_once ABSPATH . 'wp-admin/includes/class-wp-comments-list-table.php';

--- a/tests/phpunit/tests/admin/includesMisc.php
+++ b/tests/phpunit/tests/admin/includesMisc.php
@@ -4,6 +4,10 @@
  * @group admin
  */
 class Tests_Admin_includesMisc extends WP_UnitTestCase {
+
+	/**
+	 * @covers ::url_shorten
+	 */
 	function test_shorten_url() {
 		$tests = array(
 			'wordpress\.org/about/philosophy'


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/39265

Batch patch of thoroughly reviewed `@covers` changes from PR #1255 for the following tests:

- `Tests_Actions` => file `tests/phpunit/tests/actions.php`
- `Tests_Actions_Callbacks` => file `tests/phpunit/tests/actions/callbacks.php`
- `Tests_Actions_Closures` => file `tests/phpunit/tests/actions/closures.php`
- `Tests_Admin_IncludesComments` => file `tests/phpunit/tests/admin/includesComment.php`
- `Test_WP_Community_Events` => file `tests/phpunit/tests/admin/includesCommunityEvents.php`
- `Tests_Admin_includesFile` => file `tests/phpunit/tests/admin/includesFile.php`
- `Tests_Admin_includesListTable` => file `tests/phpunit/tests/admin/includesListTable.php`
- `Tests_Admin_includesMisc` => file `tests/phpunit/tests/admin/includesMisc.php`

Here are links to the code reviews:

- [Code review 1](https://github.com/WordPress/wordpress-develop/pull/1255#pullrequestreview-683944153)
- [Code review 2](https://github.com/WordPress/wordpress-develop/pull/1255#pullrequestreview-685698381)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
