### PR TITLE
Prevent infinite loop on MS for application passwords.

### DIFF
--- a/src/wp-includes/capabilities.php
+++ b/src/wp-includes/capabilities.php
@@ -888,7 +888,7 @@ function get_super_admins() {
  * @return bool Whether the user is a site admin.
  */
 function is_super_admin( $user_id = false ) {
-	if ( ! $user_id ) {
+	if ( ! $user_id || get_current_user_id() == $user_id ) {
 		$user = wp_get_current_user();
 	} else {
 		$user = get_userdata( $user_id );

--- a/src/wp-includes/capabilities.php
+++ b/src/wp-includes/capabilities.php
@@ -888,7 +888,7 @@ function get_super_admins() {
  * @return bool Whether the user is a site admin.
  */
 function is_super_admin( $user_id = false ) {
-	if ( ! $user_id || get_current_user_id() == $user_id ) {
+	if ( ! $user_id ) {
 		$user = wp_get_current_user();
 	} else {
 		$user = get_userdata( $user_id );


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/53386

Prevent infinite loop on MS if `wp_is_application_passwords_available_for_user` includes a user cap check.

Bypass `wp_get_current_user()` in `is_super_admin()` when possible.

In [#28020](https://core.trac.wordpress.org/ticket/28020) `get_userdata()` and `wp_get_current_user()` started returning the same object so there is no need to duplicate the check used in the `is_super_admin()` function.

---

I need some assistance creating the infinite loop in the tests. I couldn't get one going prior to the patch being applied. 