### PR TITLE
Include the 'sidebar' in the `$form_data` when saving a legacy widget

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-widgets-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-widgets-controller.php
@@ -478,6 +478,7 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 				"widget-$id_base" => array(
 					$number => $instance,
 				),
+				'sidebar' => $sidebar_id,
 			);
 		} elseif ( isset( $request['form_data'] ) ) {
 			$form_data = $request['form_data'];


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/53452
