### PR TITLE
Preserve current `wp-polyfill` while adding a new, built version.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1086,6 +1086,22 @@
 				"@babel/helper-plugin-utils": "^7.14.5"
 			}
 		},
+		"@babel/polyfill": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
+			"integrity": "sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==",
+			"requires": {
+				"core-js": "^2.6.5",
+				"regenerator-runtime": "^0.13.4"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "2.6.12",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+					"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
+				}
+			}
+		},
 		"@babel/preset-env": {
 			"version": "7.14.5",
 			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.14.5.tgz",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
 		"webpack-livereload-plugin": "2.3.0"
 	},
 	"dependencies": {
+		"@babel/polyfill": "7.12.1",
 		"@wordpress/a11y": "3.1.1",
 		"@wordpress/annotations": "2.1.2",
 		"@wordpress/api-fetch": "5.1.1",
@@ -147,6 +148,7 @@
 		"polyfill-library": "3.105.0",
 		"react": "16.13.1",
 		"react-dom": "16.13.1",
+		"regenerator-runtime": "0.13.7",
 		"twemoji": "13.1.0",
 		"underscore": "1.13.1",
 		"whatwg-fetch": "3.0.0"

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -82,6 +82,7 @@ function wp_default_packages_vendor( $scripts ) {
 	$vendor_scripts = array(
 		'react'     => array( 'wp-polyfill' ),
 		'react-dom' => array( 'react' ),
+		'regenerator-runtime',
 		'moment',
 		'lodash',
 		'wp-polyfill-fetch',
@@ -91,12 +92,14 @@ function wp_default_packages_vendor( $scripts ) {
 		'wp-polyfill-dom-rect',
 		'wp-polyfill-element-closest',
 		'wp-polyfill-object-fit',
+		'wp-polyfill-built',
 		'wp-polyfill',
 	);
 
 	$vendor_scripts_versions = array(
 		'react'                       => '16.13.1',
 		'react-dom'                   => '16.13.1',
+		'regenerator-runtime'         => '0.13.7',
 		'moment'                      => '2.29.1',
 		'lodash'                      => '4.17.19',
 		'wp-polyfill-fetch'           => '3.0.0',
@@ -106,7 +109,8 @@ function wp_default_packages_vendor( $scripts ) {
 		'wp-polyfill-dom-rect'        => '3.104.0',
 		'wp-polyfill-element-closest' => '2.0.2',
 		'wp-polyfill-object-fit'      => '2.3.5',
-		'wp-polyfill'                 => '7.4.4',
+		'wp-polyfill-built'           => '6.2.0',
+		'wp-polyfill'                 => '7.10.1',
 	);
 
 	foreach ( $vendor_scripts as $handle => $dependencies ) {
@@ -121,7 +125,7 @@ function wp_default_packages_vendor( $scripts ) {
 		$scripts->add( $handle, $path, $dependencies, $version, 1 );
 	}
 
-	$scripts->add( 'wp-polyfill', null, array( 'wp-polyfill' ) );
+	$scripts->add( 'wp-polyfill', null, array( 'regenerator-runtime', 'wp-polyfill-built' ) );
 
 	did_action( 'init' ) && $scripts->add_inline_script( 'lodash', 'window.lodash = _.noConflict();' );
 

--- a/tools/webpack/packages.js
+++ b/tools/webpack/packages.js
@@ -73,7 +73,8 @@ module.exports = function( env = { environment: 'production', watch: false, buil
 
 	const vendors = {
 		'lodash.js': 'lodash/lodash.js',
-		'wp-polyfill.js': '@wordpress/babel-preset-default/build/polyfill.js',
+		'wp-polyfill.js': '@babel/polyfill/dist/polyfill.js',
+		'wp-polyfill-built.js': '@wordpress/babel-preset-default/build/polyfill.js',
 		'wp-polyfill-fetch.js': 'whatwg-fetch/dist/fetch.umd.js',
 		'wp-polyfill-element-closest.js': 'element-closest/element-closest.js',
 		'wp-polyfill-node-contains.js': 'polyfill-library/polyfills/__dist/Node.prototype.contains/raw.js',
@@ -84,11 +85,13 @@ module.exports = function( env = { environment: 'production', watch: false, buil
 		'moment.js': 'moment/moment.js',
 		'react.js': 'react/umd/react.development.js',
 		'react-dom.js': 'react-dom/umd/react-dom.development.js',
+		'regenerator-runtime.js': 'regenerator-runtime/runtime.js',
 	};
 
 	const minifiedVendors = {
 		'lodash.min.js': 'lodash/lodash.min.js',
-		'wp-polyfill.min.js': '@wordpress/babel-preset-default/build/polyfill.min.js',
+		'wp-polyfill.min.js': '@babel/polyfill/dist/polyfill.min.js',
+		'wp-polyfill-built.min.js': '@wordpress/babel-preset-default/build/polyfill.min.js',
 		'wp-polyfill-formdata.min.js': 'formdata-polyfill/formdata.min.js',
 		'wp-polyfill-url.min.js': 'core-js-url-browser/url.min.js',
 		'wp-polyfill-object-fit.min.js': 'objectFitPolyfill/dist/objectFitPolyfill.min.js',
@@ -98,6 +101,7 @@ module.exports = function( env = { environment: 'production', watch: false, buil
 	};
 
 	const minifyVendors = {
+		'regenerator-runtime.min.js': 'regenerator-runtime/runtime.js',
 		'wp-polyfill-fetch.min.js': 'whatwg-fetch/dist/fetch.umd.js',
 		'wp-polyfill-element-closest.min.js': 'element-closest/element-closest.js',
 		'wp-polyfill-node-contains.min.js': 'polyfill-library/polyfills/__dist/Node.prototype.contains/raw.js',


### PR DESCRIPTION
This is an alternate approach to fixing the regression in [Core-52941](https://core.trac.wordpress.org/ticket/52941).

In this PR:

- The original `wp-polyfill.js` and `wp-polyfill.min.js` files are preserved to prevent 404 errors, just in case someone is targeting them directly.
- A new `wp-polyfill-built` script handle is added to represent the new, custom built polyfill.
- the `regenerator-runtime` script handle has been added representing the `regenerator-runtime` dependency. Scripts are built appropriately.
- The `wp-polyfill` script handle is updated to be a psuedo script with `wp-polyfill-built` and `regenerator-runtime` as dependencies.

Trac ticket: https://core.trac.wordpress.org/ticket/52941.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
