### PR TITLE
Update Readme of wordpress-develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,15 @@ Starting the environment again is a single command:
 npm run env:start
 ```
 
+#### To clean up the development environment
+
+Clean up the environment including docker images with:
+
+```
+npm run env:clean
+npm run env:reset
+```
+
 ## Credentials
 
 These are the default environment credentials:


### PR DESCRIPTION
Add `npm run env:clean` and `npm run env:reset` to the Readme of https://github.com/WordPress/wordpress-develop.

I think it's more helpful to include these information in these commands.