### PR TITLE
Media: Revert r51211 to restore `ms-files` assets.

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -3300,13 +3300,6 @@ function get_allowed_mime_types( $user = null ) {
 		unset( $t['htm|html'], $t['js'] );
 	}
 
-	// Add WebP if the server supports it.
-	unset( $t['webp'] );
-
-	if ( wp_image_editor_supports( array( 'mime_type' => 'image/webp' ) ) ) {
-		$t['webp'] = 'image/webp';
-	}
-
 	/**
 	 * Filters list of allowed mime types and file extensions.
 	 *

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -851,7 +851,7 @@ function wp_default_scripts( $scripts ) {
 		/* translators: %s: File name. */
 		'file_exceeds_size_limit'   => __( '%s exceeds the maximum upload size for this site.' ),
 		'zero_byte_file'            => __( 'This file is empty. Please try another.' ),
-		'invalid_filetype'          => __( 'Sorry, this file type is not supported.' ),
+		'invalid_filetype'          => __( 'Sorry, this file type is not permitted for security reasons.' ),
 		'not_an_image'              => __( 'This file is not an image. Please try another.' ),
 		'image_memory_exceeded'     => __( 'Memory exceeded. Please try another smaller file.' ),
 		'image_dimensions_exceeded' => __( 'This is larger than the maximum size. Please try another.' ),


### PR DESCRIPTION
r51211 accidentally introduced a fatal error for Multisite instances with `ms_files_rewriting` enabled. Reverting removes the error, and the original purpose of the commit can be solved in another way.

Props azaozz.
Fixes #53492. See #53475.

SVN command for actual commit: `svn merge -c -51211 .`, to preserve history etc

----

Trac ticket: https://core.trac.wordpress.org/ticket/53492