### PR TITLE
Trac 53489: Set sidebar state when rendering widgets block editor screen 

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-sidebars-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-sidebars-controller.php
@@ -99,7 +99,7 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 	 */
 	public function get_items( $request ) {
 		$data = array();
-		foreach ( (array) wp_get_sidebars_widgets() as $id => $widgets ) {
+		foreach ( wp_get_sidebars_widgets() as $id => $widgets ) {
 			$sidebar = $this->get_sidebar( $id );
 
 			if ( ! $sidebar ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-sidebars-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-sidebars-controller.php
@@ -137,6 +137,8 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function get_item( $request ) {
+		retrieve_widgets();
+
 		$sidebar = $this->get_sidebar( $request['id'] );
 
 		if ( ! $sidebar ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-sidebars-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-sidebars-controller.php
@@ -98,6 +98,8 @@ class WP_REST_Sidebars_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function get_items( $request ) {
+		retrieve_widgets();
+
 		$data = array();
 		foreach ( wp_get_sidebars_widgets() as $id => $widgets ) {
 			$sidebar = $this->get_sidebar( $id );

--- a/tests/phpunit/tests/rest-api/rest-sidebars-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-sidebars-controller.php
@@ -8,7 +8,7 @@
  */
 
 /**
- * Tests for REST API for Menus.
+ * Tests for REST API for Widgets.
  *
  * @see WP_Test_REST_Controller_Testcase
  * @group restapi
@@ -26,14 +26,6 @@ class WP_Test_REST_Sidebars_Controller extends WP_Test_REST_Controller_Testcase 
 	 * @var int
 	 */
 	protected static $author_id;
-
-	/**
-	 * Starting state of the registered widgets.
-	 * Used to reset state between tests.
-	 *
-	 * @var array
-	 */
-	private $original_widgets;
 
 	/**
 	 * Create fake data before our tests run.
@@ -68,16 +60,18 @@ class WP_Test_REST_Sidebars_Controller extends WP_Test_REST_Controller_Testcase 
 		$wp_registered_sidebars = array();
 		$_wp_sidebars_widgets   = array();
 		update_option( 'sidebars_widgets', array() );
-
-		// Capture registered widgets for restoring between tests.
-		global $wp_registered_widgets;
-		$this->original_widgets = $wp_registered_widgets;
 	}
 
-	public function tearDown() {
-		// Restore the registered widgets.
-		global $wp_registered_widgets;
-		$wp_registered_widgets = $this->original_widgets;
+	function clean_up_global_scope() {
+		global $wp_widget_factory, $wp_registered_sidebars, $wp_registered_widgets, $wp_registered_widget_controls, $wp_registered_widget_updates;
+
+		$wp_registered_sidebars        = array();
+		$wp_registered_widgets         = array();
+		$wp_registered_widget_controls = array();
+		$wp_registered_widget_updates  = array();
+		$wp_widget_factory->widgets    = array();
+
+		parent::clean_up_global_scope();
 	}
 
 	private function setup_widget( $option_name, $number, $settings ) {
@@ -147,6 +141,8 @@ class WP_Test_REST_Sidebars_Controller extends WP_Test_REST_Controller_Testcase 
 	 * @ticket 41683
 	 */
 	public function test_get_items() {
+		wp_widgets_init();
+
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/sidebars' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
@@ -212,6 +208,8 @@ class WP_Test_REST_Sidebars_Controller extends WP_Test_REST_Controller_Testcase 
 	 * @ticket 41683
 	 */
 	public function test_get_items_active_sidebar_with_widgets() {
+		wp_widgets_init();
+
 		$this->setup_widget(
 			'widget_rss',
 			1,
@@ -291,10 +289,7 @@ class WP_Test_REST_Sidebars_Controller extends WP_Test_REST_Controller_Testcase 
 					'before_title'  => '',
 					'after_title'   => '',
 					'status'        => 'inactive',
-					'widgets'       => array(
-						'block-5',
-						'block-6',
-					),
+					'widgets'       => array(),
 				),
 				array(
 					'id'            => 'new-sidebar',
@@ -306,12 +301,8 @@ class WP_Test_REST_Sidebars_Controller extends WP_Test_REST_Controller_Testcase 
 					'before_title'  => '',
 					'after_title'   => '',
 					'status'        => 'active',
-					'widgets'       => array(
-						'block-2',
-						'block-3',
-						'block-4',
-					),
-				),				
+					'widgets'       => array(),
+				),
 			),
 			$data
 		);
@@ -393,6 +384,8 @@ class WP_Test_REST_Sidebars_Controller extends WP_Test_REST_Controller_Testcase 
 	 * @ticket 41683
 	 */
 	public function test_update_item() {
+		wp_widgets_init();
+
 		$this->setup_widget(
 			'widget_rss',
 			1,
@@ -458,6 +451,8 @@ class WP_Test_REST_Sidebars_Controller extends WP_Test_REST_Controller_Testcase 
 	 * @ticket 41683
 	 */
 	public function test_update_item_removes_widget_from_existing_sidebar() {
+		wp_widgets_init();
+
 		$this->setup_widget(
 			'widget_text',
 			1,
@@ -499,6 +494,8 @@ class WP_Test_REST_Sidebars_Controller extends WP_Test_REST_Controller_Testcase 
 	 * @ticket 41683
 	 */
 	public function test_update_item_moves_omitted_widget_to_inactive_sidebar() {
+		wp_widgets_init();
+
 		$this->setup_widget(
 			'widget_text',
 			1,
@@ -541,6 +538,8 @@ class WP_Test_REST_Sidebars_Controller extends WP_Test_REST_Controller_Testcase 
 	 * @ticket 41683
 	 */
 	public function test_get_items_inactive_widgets() {
+		wp_widgets_init();
+
 		$this->setup_widget(
 			'widget_rss',
 			1,

--- a/tests/phpunit/tests/rest-api/rest-widget-types-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-widget-types-controller.php
@@ -112,6 +112,7 @@ class WP_Test_REST_Widget_Types_Controller extends WP_Test_REST_Controller_Testc
 	 * @ticket 41683
 	 */
 	public function test_get_items() {
+		wp_widgets_init();
 		wp_set_current_user( self::$admin_id );
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/widget-types' );
 		$response = rest_get_server()->dispatch( $request );


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/53489

Uses the same strategy as the classic widgets screen by running `retrieve_widgets()`. In doing so, newly added sidebars are displayed in the Widgets Block Editor.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
