### PR TITLE
Customize: Fix adding a widget when the widget block editor is disabled

### DIFF
--- a/src/wp-includes/class-wp-customize-widgets.php
+++ b/src/wp-includes/class-wp-customize-widgets.php
@@ -1411,7 +1411,7 @@ final class WP_Customize_Widgets {
 		global $wp_widget_factory;
 
 		if ( array() === $value ) {
-			return;
+			return $value;
 		}
 
 		if ( isset( $value['raw_instance'] ) && $id_base && wp_use_widgets_block_editor() ) {

--- a/tests/phpunit/tests/customize/widgets.php
+++ b/tests/phpunit/tests/customize/widgets.php
@@ -402,6 +402,71 @@ class Tests_WP_Customize_Widgets extends WP_UnitTestCase {
 	}
 
 	/**
+	 * There should be a 'raw_instance' key when the block editor is enabled and
+	 * the widget supports them via `show_instance_in_rest`.
+	 */
+	function test_sanitize_widget_instance_raw_instance() {
+		remove_action( 'widgets_init', array( $this, 'remove_widgets_block_editor' ) );
+		$this->do_customize_boot_actions();
+
+		$block_instance = array(
+			'content' => '<!-- wp:paragraph --><p>Hello</p><!-- /wp:paragraph -->',
+		);
+
+		$sanitized_for_js = $this->manager->widgets->sanitize_widget_js_instance( $block_instance, 'block' );
+		$this->assertArrayHasKey( 'encoded_serialized_instance', $sanitized_for_js );
+		$this->assertTrue( is_serialized( base64_decode( $sanitized_for_js['encoded_serialized_instance'] ), true ) );
+		$this->assertSame( '', $sanitized_for_js['title'] );
+		$this->assertTrue( $sanitized_for_js['is_widget_customizer_js_value'] );
+		$this->assertArrayHasKey( 'instance_hash_key', $sanitized_for_js );
+		$this->assertEquals( (object) $block_instance, $sanitized_for_js['raw_instance'] );
+
+		$unsanitized_from_js = $this->manager->widgets->sanitize_widget_instance( $sanitized_for_js );
+		$this->assertSame( $unsanitized_from_js, $block_instance );
+	}
+
+	/**
+	 * There should NOT be a 'raw_instance' key when the block editor is enabled
+	 * but the widget does not support them because `show_instance_in_rest` on
+	 * the widget is set to false.
+	 */
+	function test_sanitize_widget_instance_with_no_show_instance_in_rest() {
+		global $wp_widget_factory;
+
+		remove_action( 'widgets_init', array( $this, 'remove_widgets_block_editor' ) );
+		$this->do_customize_boot_actions();
+
+		$widget_object = $wp_widget_factory->get_widget_object( 'block' );
+		$widget_object->widget_options['show_instance_in_rest'] = false;
+
+		$block_instance = array(
+			'content' => '<!-- wp:paragraph --><p>Hello</p><!-- /wp:paragraph -->',
+		);
+
+		$sanitized_for_js = $this->manager->widgets->sanitize_widget_js_instance( $block_instance, 'block' );
+		$this->assertArrayHasKey( 'encoded_serialized_instance', $sanitized_for_js );
+		$this->assertTrue( is_serialized( base64_decode( $sanitized_for_js['encoded_serialized_instance'] ), true ) );
+		$this->assertSame( '', $sanitized_for_js['title'] );
+		$this->assertTrue( $sanitized_for_js['is_widget_customizer_js_value'] );
+		$this->assertArrayHasKey( 'instance_hash_key', $sanitized_for_js );
+		$this->assertArrayNotHasKey( 'raw_instance', $sanitized_for_js );
+
+		$unsanitized_from_js = $this->manager->widgets->sanitize_widget_instance( $sanitized_for_js );
+		$this->assertSame( $unsanitized_from_js, $block_instance );
+	}
+
+	/**
+	 * Empty instances, seen when inserting a new widget, should be left alone
+	 * when sanitized.
+	 *
+	 * @ticket 53479
+	 */
+	function test_sanitize_widget_instance_empty_instance() {
+		$this->do_customize_boot_actions();
+		$this->assertSame( $this->manager->widgets->sanitize_widget_instance( array() ), array() );
+	}
+
+	/**
 	 * Get the widget control args for tests.
 	 *
 	 * @return array


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/53479

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
