### PR TITLE
Rename `fse` functions and references.

### DIFF
--- a/src/wp-admin/customize.php
+++ b/src/wp-admin/customize.php
@@ -189,7 +189,7 @@ do_action( 'customize_controls_head' );
 			// Check if the theme requires the FSE to work correctly.
 			$theme_tags = $wp_customize->theme()->get( 'Tags' );
 
-			if ( ! empty( $theme_tags ) && in_array( 'full-site-editing', $theme_tags, true ) && ! function_exists( 'gutenberg_is_fse_theme' ) ) {
+			if ( ! empty( $theme_tags ) && in_array( 'full-site-editing', $theme_tags, true ) && ! function_exists( 'gutenberg_is_block_theme' ) ) {
 				$fse_safe = false;
 			}
 			?>

--- a/src/wp-admin/customize.php
+++ b/src/wp-admin/customize.php
@@ -186,7 +186,7 @@ do_action( 'customize_controls_head' );
 			$compatible_php = is_php_version_compatible( $wp_customize->theme()->get( 'RequiresPHP' ) );
 			$fse_safe       = true;
 
-			// Check if the theme requires the FSE to work correctly.
+			// Check if the theme requires the Gutenberg plugin to work correctly.
 			$theme_tags = $wp_customize->theme()->get( 'Tags' );
 
 			if ( ! empty( $theme_tags ) && in_array( 'full-site-editing', $theme_tags, true ) && ! function_exists( 'gutenberg_is_block_theme' ) ) {

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -913,7 +913,7 @@ function validate_theme_requirements( $stylesheet ) {
 
 	if ( ! empty( $theme_tags ) && in_array( 'full-site-editing', $theme_tags, true ) && ! function_exists( 'gutenberg_is_block_theme' ) ) {
 		return new WP_Error(
-			'theme_requires_fse',
+			'theme_requires_gutenberg_plugin',
 			sprintf(
 					/* translators: %s: Theme name. */
 				_x( '<strong>Error:</strong> This theme (%s) uses Full Site Editing, which requires the Gutenberg plugin to be activated.', 'theme' ),

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -911,7 +911,7 @@ function validate_theme_requirements( $stylesheet ) {
 	// If the theme is a Full Site Editing theme, check for the presence of the Gutenberg plugin.
 	$theme_tags = $theme->get( 'Tags' );
 
-	if ( ! empty( $theme_tags ) && in_array( 'full-site-editing', $theme_tags, true ) && ! function_exists( 'gutenberg_is_fse_theme' ) ) {
+	if ( ! empty( $theme_tags ) && in_array( 'full-site-editing', $theme_tags, true ) && ! function_exists( 'gutenberg_is_block_theme' ) ) {
 		return new WP_Error(
 			'theme_requires_fse',
 			sprintf(


### PR DESCRIPTION
This is a companion to https://github.com/WordPress/gutenberg/pull/32950, renaming `fse` references

Trac ticket: https://core.trac.wordpress.org/ticket/53497

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
