### PR TITLE
get_theme_mods: PHP 8.0 compatibility fix - always return an array.

### DIFF
--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -967,7 +967,7 @@ function validate_theme_requirements( $stylesheet ) {
  *
  * @since 3.1.0
  *
- * @return array|void Theme modifications.
+ * @return array Theme modifications.
  */
 function get_theme_mods() {
 	$theme_slug = get_option( 'stylesheet' );
@@ -983,7 +983,7 @@ function get_theme_mods() {
 			delete_option( "mods_$theme_name" );
 		}
 	}
-	return $mods;
+	return is_array( $mods ) ? $mods : array();
 }
 
 /**

--- a/tests/phpunit/tests/option/themeMods.php
+++ b/tests/phpunit/tests/option/themeMods.php
@@ -19,6 +19,12 @@ class Tests_Option_Theme_Mods extends WP_UnitTestCase {
 		$this->assertSame( $expected, get_theme_mod( 'test_name' ) );
 	}
 
+	function test_theme_mod_set_invalid_theme_mods_option() {
+		$theme_slug = get_option( 'stylesheet' );
+		update_option( 'theme_mods_' . $theme_slug, '' );
+		self::test_theme_mod_set();
+	}
+
 	function test_theme_mod_update() {
 		set_theme_mod( 'test_update', 'first_value' );
 		$expected = 'updated_value';


### PR DESCRIPTION
We noticed quite a few PHP warnings related triggered by `set_theme_mod`
calls. It turns out that some of these sites used to have empty strings
stored in the `mods_CURRENT_THEME`/`theme_mods_CURRENT_THEME_SLUG`
options.

The warnings happen because we are attempting to use an invalid offset
on `$mods[ $name ] = apply_filters( "pre_set_theme_mod_{$name}", $value,
$old_value );`

Trac ticket: https://core.trac.wordpress.org/ticket/51423


<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
