### PR TITLE
Do not enqueue font-family if theme has `theme.json` support

### DIFF
--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -474,12 +474,17 @@ function block_editor_rest_api_preload( array $preload_paths, $block_editor_cont
 function get_block_editor_theme_styles() {
 	global $editor_styles;
 
-	$styles = array(
-		array(
-			'css'            => 'body { font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif }',
-			'__unstableType' => 'core',
-		),
-	);
+	if ( ! WP_Theme_JSON_Resolver::theme_has_support() ) {
+		$styles = array(
+			array(
+				'css'            => 'body { font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif }',
+				'__unstableType' => 'core',
+			),
+		);
+	} else {
+		$styles = array();
+	}
+
 	if ( $editor_styles && current_theme_supports( 'editor-styles' ) ) {
 		foreach ( $editor_styles as $style ) {
 			if ( preg_match( '~^(https?:)?//~', $style ) ) {


### PR DESCRIPTION
If the theme has `theme.json` support, we should not enqueue the default font-family.

## How to test

- Use a theme without `theme.json` support, load the editor, and verify that the font-family declaration is present. You should see an embedded `style` tag within the `edit-post-visual-editor__content-area` div with a single font-family declaration using the `editor-styles-wrapper` selector (there may be others unrelated to this).
- Use a theme with `theme.json` support, load the editor, and verify that the font-family declaration is not present. You shouldn't see the above font-family declaration.

