### PR TITLE
Add missing `api_version` to WP_Block_Type arg list

### DIFF
--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -202,6 +202,7 @@ class WP_Block_Type {
 	 *     however the ones described below are supported by default. Default empty array.
 	 *
 	 *
+	 *     @type string        $api_version      Block API version.
 	 *     @type string        $title            Human-readable block type label.
 	 *     @type string|null   $category         Block type category classification, used in
 	 *                                           search interfaces to arrange block types by category.


### PR DESCRIPTION
Since WordPress 5.6, the `api_version` can be specified when registering a block type, but this is not included in the list specified in the `WP_Block_Type` constructor.  This PR adds the argument to the list.

Fixes https://core.trac.wordpress.org/ticket/53518