### PR TITLE
TT1: added theme.json file to support layout

### DIFF
--- a/src/wp-content/themes/twentytwentyone/theme.json
+++ b/src/wp-content/themes/twentytwentyone/theme.json
@@ -1,0 +1,9 @@
+{
+	"version": 1,
+	"settings": {
+		"layout": {
+			"contentSize": "610px",
+			"wideSize": "1240px"
+		}
+	}
+}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

This PR tests adding layout support to TwentyTwentyOne by adding a theme.json file that enables it. These are the results:

Editor:

Before | After 
--- | ---
<img width="1617" alt="Screenshot 2021-06-28 at 12 17 05" src="https://user-images.githubusercontent.com/3593343/123620774-dd5c0500-d80a-11eb-91fa-0cbdf4f95053.png"> | <img width="1618" alt="Screenshot 2021-06-28 at 12 11 54" src="https://user-images.githubusercontent.com/3593343/123620808-e64cd680-d80a-11eb-8afd-0814642285d9.png">


Frontend:

Before | After 
--- | ---
<img width="1619" alt="Screenshot 2021-06-28 at 12 18 38" src="https://user-images.githubusercontent.com/3593343/123620907-fe245a80-d80a-11eb-8b7a-4baa067f6cdc.png"> | <img width="1618" alt="Screenshot 2021-06-28 at 12 12 09" src="https://user-images.githubusercontent.com/3593343/123620929-02e90e80-d80b-11eb-9e89-2097cc39e7f3.png">


This exposes a few differences that are related to this change, since the extra wrapper `wp-block-group__inner-container` is missing after this change and some css breaks. On the editor the paragraph tag is missing these rules that remove the margins from the inner block:

<img width="442" alt="Screenshot 2021-06-28 at 12 25 59" src="https://user-images.githubusercontent.com/3593343/123622026-0f219b80-d80c-11eb-9543-b9fbc35c267a.png">

The alignment of the inner element of the group block breaks because of this missing css (also related to the missing wrapper):

<img width="441" alt="Screenshot 2021-06-28 at 12 27 00" src="https://user-images.githubusercontent.com/3593343/123623230-7d1a9280-d80d-11eb-9f5f-ac5dfeaa5b6c.png">


The alignment issue is fixable when using a secondary group block to wrap the content of the first one:

<img width="1620" alt="Screenshot 2021-06-28 at 13 04 51" src="https://user-images.githubusercontent.com/3593343/123626814-886fbd00-d811-11eb-8733-79460d497a86.png">






<!-- Trac ticket: insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
