### PR TITLE
First Pass on docs update for wp_should_load_separate_core_block_assets

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2328,6 +2328,15 @@ function wp_should_load_block_editor_scripts_and_styles() {
 /**
  * Checks whether separate assets should be loaded for core blocks on-render.
  *
+ * This function is used to decide whether seperate styles for blocks
+ * should be loaded. When this function returns true, other functions ensure that
+ * Core blocks only load their styles on-render, and each block loads its own,
+ * individual stylesheet. This doesn't affect blocks that come from outside of
+ * WordPress Core.
+ *
+ * @see wp_enqueue_registered_block_scripts_and_styles()
+ * @see register_block_style_handle()
+ *
  * @since 5.8.0
  *
  * @return bool Whether separate assets will be loaded.


### PR DESCRIPTION
See https://core.trac.wordpress.org/ticket/53505

Props aristath who gave a fantastic explanation of how and why this function exists. I synthasysed that into a more docs friendly paragraph and added a couple of @see for places that use this function.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
