### PR TITLE
Fix a notice caused by the `viewScript` containing `.min` for the `core/file` block.

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -82,7 +82,12 @@ function register_block_script_handle( $metadata, $field_name ) {
 		return $script_handle;
 	}
 
-	$script_handle     = generate_block_asset_handle( $metadata['name'], $field_name );
+	$script_handle = generate_block_asset_handle( $metadata['name'], $field_name );
+
+	if ( 'viewScript' === $field_name ) {
+		$script_path = str_replace( '.min.js', '.js', $script_path );
+	}
+
 	$script_asset_path = realpath(
 		dirname( $metadata['file'] ) . '/' .
 		substr_replace( $script_path, '.asset.php', - strlen( '.js' ) )


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/53397

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
