### PR TITLE
Fix deleting multiple widgets in one batch REST API request

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-widgets-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-widgets-controller.php
@@ -295,7 +295,7 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function delete_item( $request ) {
-		global $wp_registered_widget_updates;
+		global $wp_registered_widget_updates, $wp_widget_factory;
 
 		retrieve_widgets();
 
@@ -343,6 +343,15 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 
 			$_POST    = $original_post;
 			$_REQUEST = $original_request;
+
+			$widget_object = $wp_widget_factory->get_widget_object( $id_base );
+			if ( $widget_object ) {
+				// WP_Widget sets updated = true after an update to prevent more
+				// than one widget from being saved per request. This isn't what
+				// we want in the REST API, though, as we support batch
+				// requests.
+				$widget_object->updated = false;
+			}
 
 			wp_assign_widget_to_sidebar( $widget_id, '' );
 

--- a/tests/phpunit/tests/rest-api/rest-widgets-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-widgets-controller.php
@@ -1353,7 +1353,7 @@ class WP_Test_REST_Widgets_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	/**
-	 * @ticket XXXXX
+	 * @ticket 53557
 	 */
 	public function test_delete_item_multiple() {
 		$this->setup_widgets(

--- a/tests/phpunit/tests/rest-api/rest-widgets-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-widgets-controller.php
@@ -165,19 +165,20 @@ class WP_Test_REST_Widgets_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	private function setup_widget( $id_base, $number, $settings ) {
+		$this->setup_widgets( $id_base, array( $number => $settings ) );
+	}
+
+	private function setup_widgets( $id_base, $settings ) {
 		global $wp_widget_factory;
 
 		$option_name = "widget_$id_base";
-		update_option(
-			$option_name,
-			array(
-				$number => $settings,
-			)
-		);
+		update_option( $option_name, $settings );
 
 		$widget_object = $wp_widget_factory->get_widget_object( $id_base );
-		$widget_object->_set( $number );
-		$widget_object->_register_one( $number );
+		foreach ( array_keys( $settings ) as $number ) {
+			$widget_object->_set( $number );
+			$widget_object->_register_one( $number );
+		}
 	}
 
 	private function setup_sidebar( $id, $attrs = array(), $widgets = array() ) {
@@ -1349,6 +1350,61 @@ class WP_Test_REST_Widgets_Controller extends WP_Test_REST_Controller_Testcase {
 		$response = rest_do_request( $request );
 
 		$this->assertErrorResponse( 'rest_cannot_manage_widgets', $response, 401 );
+	}
+
+	/**
+	 * @ticket XXXXX
+	 */
+	public function test_delete_item_multiple() {
+		$this->setup_widgets(
+			'text',
+			array(
+				2 => array( 'text' => 'Text widget' ),
+				3 => array( 'text' => 'Text widget' ),
+				4 => array( 'text' => 'Text widget' ),
+			)
+		);
+		$this->setup_sidebar(
+			'sidebar-1',
+			array(
+				'name' => 'Test sidebar',
+			),
+			array( 'text-2', 'text-3', 'text-4' )
+		);
+
+		$request = new WP_REST_Request( 'POST', '/batch/v1' );
+		$request->set_body_params(
+			array(
+				'requests' => array(
+					array(
+						'method' => 'DELETE',
+						'path'   => '/wp/v2/widgets/text-2?force=1',
+					),
+					array(
+						'method' => 'DELETE',
+						'path'   => '/wp/v2/widgets/text-3?force=1',
+					),
+					array(
+						'method' => 'DELETE',
+						'path'   => '/wp/v2/widgets/text-4?force=1',
+					),
+				),
+			)
+		);
+		$response = rest_do_request( $request );
+
+		$this->assertEquals(
+			array(
+				'sidebar-1' => array(),
+			),
+			wp_get_sidebars_widgets()
+		);
+		$this->assertEquals(
+			array(
+				'_multiwidget' => 1,
+			),
+			get_option( 'widget_text' )
+		);
 	}
 
 	/**


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/53557

If you try to delete multiple widgets in a single batch request, only one widget is deleted. This is because deleting a widget sets the `WP_Widget::$updated` flag which blocks all future updates in a request. The fix is to reset the flag.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
