### PR TITLE
Twenty Twenty-One: Add block template support, including a default template

### DIFF
--- a/src/wp-content/themes/twentytwentyone/block-templates/default.html
+++ b/src/wp-content/themes/twentytwentyone/block-templates/default.html
@@ -1,0 +1,45 @@
+<!-- wp:spacer {"height":70} -->
+<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:columns {"align":"wide"} -->
+<div class="wp-block-columns alignwide"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:site-title {"fontSize":"normal"} /-->
+
+<!-- wp:site-tagline {"fontSize":"normal"} /--></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:spacer {"height":70} -->
+<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:group {"align":"full","tagName":"main"} -->
+<div class="wp-block-group alignfull"><!-- wp:group {"align":"wide","layout":{"inherit":true}} -->
+<div class="wp-block-group alignwide"><!-- wp:post-title {"level":1,"align":"wide"} /-->
+
+<!-- wp:separator {"align":"wide","className":"is-style-twentytwentyone-separator-thick"} -->
+<hr class="wp-block-separator alignwide is-style-twentytwentyone-separator-thick"/>
+<!-- /wp:separator -->
+
+<!-- wp:spacer {"height":70} -->
+<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer --></div>
+<!-- /wp:group -->
+
+<!-- wp:post-content /-->
+
+<!-- wp:spacer {"height":70} -->
+<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:separator {"align":"center","className":"is-style-twentytwentyone-separator-thick"} -->
+<hr class="wp-block-separator aligncenter is-style-twentytwentyone-separator-thick"/>
+<!-- /wp:separator -->
+
+<!-- wp:post-date /-->
+
+<!-- wp:spacer {"height":70} -->
+<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer --></div>
+<!-- /wp:group -->

--- a/src/wp-content/themes/twentytwentyone/functions.php
+++ b/src/wp-content/themes/twentytwentyone/functions.php
@@ -338,6 +338,9 @@ if ( ! function_exists( 'twenty_twenty_one_setup' ) ) {
 		// Add support for custom units.
 		// This was removed in WordPress 5.6 but is still required to properly support WP 5.5.
 		add_theme_support( 'custom-units' );
+
+		// Add support for block templates. 
+		add_theme_support( 'block-templates' );
 	}
 }
 add_action( 'after_setup_theme', 'twenty_twenty_one_setup' );
@@ -627,3 +630,18 @@ function twentytwentyone_add_ie_class() {
 	<?php
 }
 add_action( 'wp_footer', 'twentytwentyone_add_ie_class' );
+
+/**
+ * Add a default block template.
+ *
+ * @since Twenty Twenty-One 1.3
+ *
+ * @return string (block template markup)
+ */
+function twenty_twenty_one_default_block_template() {
+	add_filter( 'block_editor_settings_all', function( $settings ) {
+	     $settings['defaultBlockTemplate'] = file_get_contents( get_theme_file_path( 'block-templates/default.html' ) );
+	     return $settings;
+	});
+}
+add_action( 'after_setup_theme', 'twenty_twenty_one_default_block_template', 0 );


### PR DESCRIPTION
This PR adds block template support to Twenty Twenty-One, and also provides a default block template, as per the instructions here: 

https://make.wordpress.org/core/2021/06/16/introducing-the-template-editor-in-wordpress-5-8/

The default template includes a simplified approximation of the default page layout, minus things like navigation and a footer (which requires translatable text — something not yet possible in block templates). This was pulled from TT1 Blocks, but simplified down a little bit. 

Note: The theme stylesheet is not loaded in the template editor. [A warning is thrown about this](https://cloudup.com/cUf03QQ8J0M), but I'm not sure what to make of it since Twenty Twenty-One does enqueue the stylesheet properly via `add_editor_style()`. 

## GIF:

![block-templates](https://user-images.githubusercontent.com/1202812/124005549-3660a000-d9a7-11eb-9a5f-e18e91ee23be.gif)

Trac ticket: https://core.trac.wordpress.org/ticket/53564

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
