### PR TITLE
Remove experimental link color support

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -1219,14 +1219,6 @@ class WP_Theme_JSON {
 			$theme_settings['settings']['spacing']['customPadding'] = $settings['enableCustomSpacing'];
 		}
 
-		// Things that didn't land in core yet, so didn't have a setting assigned.
-		if ( current( (array) get_theme_support( 'experimental-link-color' ) ) ) {
-			if ( ! isset( $theme_settings['settings']['color'] ) ) {
-				$theme_settings['settings']['color'] = array();
-			}
-			$theme_settings['settings']['color']['link'] = true;
-		}
-
 		return $theme_settings;
 	}
 


### PR DESCRIPTION
Part of https://core.trac.wordpress.org/ticket/53175

In one of the ports to WordPress core from the plugin we inadvertently landed support for `experimental-link-color`, which has been plugin only so far and should remain so. See https://github.com/WordPress/gutenberg/pull/33162#discussion_r662851026 for context.
