### PR TITLE
Update the IRC link from Freenode to Libera.chat

### DIFF
--- a/src/readme.html
+++ b/src/readme.html
@@ -76,7 +76,7 @@
 	<dt><a href="https://wordpress.org/support/forums/">WordPress Support Forums</a></dt>
 		<dd>If you&#8217;ve looked everywhere and still can&#8217;t find an answer, the support forums are very active and have a large community ready to help. To help them help you be sure to use a descriptive thread title and describe your question in as much detail as possible.</dd>
 	<dt><a href="https://make.wordpress.org/support/handbook/appendix/other-support-locations/introduction-to-irc/">WordPress <abbr>IRC</abbr> (Internet Relay Chat) Channel</a></dt>
-		<dd>There is an online chat channel that is used for discussion among people who use WordPress and occasionally support topics. The above wiki page should point you in the right direction. (<a href="irc://irc.freenode.net/wordpress">irc.freenode.net #wordpress</a>)</dd>
+		<dd>There is an online chat channel that is used for discussion among people who use WordPress and occasionally support topics. The above wiki page should point you in the right direction. (<a href="https://web.libera.chat/#wordpress">irc.libera.chat #wordpress</a>)</dd>
 </dl>
 
 <h2>Final Notes</h2>


### PR DESCRIPTION
The wiki entry for IRC is updated and points to Libera.chat, while the actual IRC link in readme.html still points to Freenode. I created a pull requested that change the link to point to #wordpress on Libera's webchat.

Trac ticket: https://core.trac.wordpress.org/ticket/53590