### PR TITLE
TwentyTwenty-One theme: Add a check and disable dark-mode in the widget editor previews

### DIFF
--- a/src/wp-content/themes/twentytwentyone/classes/class-twenty-twenty-one-dark-mode.php
+++ b/src/wp-content/themes/twentytwentyone/classes/class-twenty-twenty-one-dark-mode.php
@@ -19,6 +19,11 @@ class Twenty_Twenty_One_Dark_Mode {
 	 */
 	public function __construct() {
 
+		// Disable dark-mode in the widgets editor.
+		if ( is_admin() && $_SERVER['REQUEST_URI'] && strpos( $_SERVER['REQUEST_URI'], '/widgets.php' ) ) {
+			return;
+		}
+
 		// Enqueue assets for the block-editor.
 		add_action( 'enqueue_block_editor_assets', array( $this, 'editor_custom_color_variables' ) );
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/53429

Disables dark mode in the widgets editing screens (both the widgets screen and the customizer)

cc @carolinan

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
