### PR TITLE
Better handling of inner blocks when generating excerpts

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -713,7 +713,7 @@ function excerpt_remove_blocks( $content ) {
 	$allowed_wrapper_blocks = array(
 		'core/columns',
 		'core/column',
-		'core/group'
+		'core/group',
 	);
 
 	$allowed_blocks = array_merge( $allowed_inner_blocks, $allowed_wrapper_blocks );

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -773,10 +773,14 @@ function _excerpt_render_inner_blocks( $parsed_block, $allowed_blocks ) {
 	$output = '';
 
 	foreach ( $parsed_block['innerBlocks'] as $inner_block ) {
-		if ( in_array( $inner_block['blockName'], $allowed_blocks, true ) ) {
-			$output .= empty( $inner_block['innerBlocks'] )
-				? render_block( $inner_block )
-				: _excerpt_render_inner_blocks( $inner_block, $allowed_blocks );
+		if ( ! in_array( $inner_block['blockName'], $allowed_blocks, true ) ) {
+			continue;
+		}
+
+		if ( empty( $inner_block['innerBlocks'] ) ) {
+			$output .= render_block( $inner_block );
+		} else {
+			$output .= _excerpt_render_inner_blocks( $inner_block, $allowed_blocks );
 		}
 	}
 

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -710,7 +710,13 @@ function excerpt_remove_blocks( $content ) {
 		'core/verse',
 	);
 
-	$allowed_blocks = array_merge( $allowed_inner_blocks, array( 'core/columns' ) );
+	$allowed_wrapper_blocks = array(
+		'core/columns',
+		'core/column',
+		'core/group'
+	);
+
+	$allowed_blocks = array_merge( $allowed_inner_blocks, $allowed_wrapper_blocks );
 
 	/**
 	 * Filters the list of blocks that can contribute to the excerpt.
@@ -729,8 +735,8 @@ function excerpt_remove_blocks( $content ) {
 	foreach ( $blocks as $block ) {
 		if ( in_array( $block['blockName'], $allowed_blocks, true ) ) {
 			if ( ! empty( $block['innerBlocks'] ) ) {
-				if ( 'core/columns' === $block['blockName'] ) {
-					$output .= _excerpt_render_inner_columns_blocks( $block, $allowed_inner_blocks );
+				if ( in_array( $block['blockName'], $allowed_wrapper_blocks, true ) ) {
+					$output .= _excerpt_render_inner_blocks( $block, $allowed_blocks );
 					continue;
 				}
 
@@ -753,23 +759,24 @@ function excerpt_remove_blocks( $content ) {
 }
 
 /**
- * Render inner blocks from the `core/columns` block for generating an excerpt.
+ * Render inner blocks from the allowed wrapper blocks
+ * for generating an excerpt.
  *
- * @since 5.2.0
+ * @since 5.8
  * @access private
  *
- * @param array $columns        The parsed columns block.
+ * @param array $parsed_block   The parsed block.
  * @param array $allowed_blocks The list of allowed inner blocks.
  * @return string The rendered inner blocks.
  */
-function _excerpt_render_inner_columns_blocks( $columns, $allowed_blocks ) {
+function _excerpt_render_inner_blocks( $parsed_block, $allowed_blocks ) {
 	$output = '';
 
-	foreach ( $columns['innerBlocks'] as $column ) {
-		foreach ( $column['innerBlocks'] as $inner_block ) {
-			if ( in_array( $inner_block['blockName'], $allowed_blocks, true ) && empty( $inner_block['innerBlocks'] ) ) {
-				$output .= render_block( $inner_block );
-			}
+	foreach ( $parsed_block['innerBlocks'] as $inner_block ) {
+		if ( in_array( $inner_block['blockName'], $allowed_blocks, true ) ) {
+			$output .= empty( $inner_block['innerBlocks'] )
+				? render_block( $inner_block )
+				: _excerpt_render_inner_blocks( $inner_block, $allowed_blocks );
 		}
 	}
 

--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -4221,6 +4221,6 @@ function wp_sensitive_page_meta() {
  * @return string The rendered inner blocks.
  */
 function _excerpt_render_inner_columns_blocks( $columns, $allowed_blocks ) {
-	_deprecated_function( __FUNCTION__, '5.7.0', '_excerpt_render_inner_blocks()' );
+	_deprecated_function( __FUNCTION__, '5.8.0', '_excerpt_render_inner_blocks()' );
 	return _excerpt_render_inner_blocks( $columns, $allowed_blocks );
 }

--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -4207,3 +4207,20 @@ function wp_sensitive_page_meta() {
 	<?php
 	wp_strict_cross_origin_referrer();
 }
+
+/**
+ * Render inner blocks from the `core/columns` block for generating an excerpt.
+ *
+ * @since 5.2.0
+ * @deprecated 5.8.0
+ *
+ * @access private
+ *
+ * @param array $columns        The parsed columns block.
+ * @param array $allowed_blocks The list of allowed inner blocks.
+ * @return string The rendered inner blocks.
+ */
+function _excerpt_render_inner_columns_blocks( $columns, $allowed_blocks ) {
+	_deprecated_function( __FUNCTION__, '5.7.0', '_excerpt_render_inner_blocks()' );
+	return _excerpt_render_inner_blocks( $columns, $allowed_blocks );
+}

--- a/tests/phpunit/tests/post/getTheExcerpt.php
+++ b/tests/phpunit/tests/post/getTheExcerpt.php
@@ -145,4 +145,42 @@ class Tests_Post_GetTheExcerpt extends WP_UnitTestCase {
 
 		$this->assertSame( 'Bar', $found );
 	}
+
+	/**
+	 * @ticket 53604
+	 */
+	public function test_inner_blocks_excerpt() {
+		$post_content = '<!-- wp:group -->
+<div class="wp-block-group"><!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:paragraph -->
+<p>Column 1</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:paragraph -->
+<p>Column 2</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->';
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_content' => $post_content,
+				'post_excerpt' => '',
+			)
+		);
+		$query  = new WP_Query(
+			array(
+				'p' => $post->ID,
+			)
+		);
+
+		$this->assertSame( 'Column 1 Column 2', get_the_excerpt( $query->posts[0] ) );
+	}
 }

--- a/tests/phpunit/tests/post/getTheExcerpt.php
+++ b/tests/phpunit/tests/post/getTheExcerpt.php
@@ -150,7 +150,7 @@ class Tests_Post_GetTheExcerpt extends WP_UnitTestCase {
 	 * @ticket 53604
 	 */
 	public function test_inner_blocks_excerpt() {
-		$post_content = '<!-- wp:group -->
+		$content_1 = '<!-- wp:group -->
 <div class="wp-block-group"><!-- wp:columns -->
 <div class="wp-block-columns"><!-- wp:column -->
 <div class="wp-block-column"><!-- wp:paragraph -->
@@ -169,18 +169,39 @@ class Tests_Post_GetTheExcerpt extends WP_UnitTestCase {
 <!-- wp:paragraph -->
 <p></p>
 <!-- /wp:paragraph -->';
-		$post = self::factory()->post->create_and_get(
+
+		$content_2 = '<!-- wp:group -->
+<div class="wp-block-group"><!-- wp:paragraph -->
+<p>Paragraph inside group block</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->';
+
+		$post_1 = self::factory()->post->create_and_get(
 			array(
-				'post_content' => $post_content,
+				'post_content' => $content_1,
 				'post_excerpt' => '',
 			)
 		);
-		$query  = new WP_Query(
+
+		$post_2 = self::factory()->post->create_and_get(
 			array(
-				'p' => $post->ID,
+				'post_content' => $content_2,
+				'post_excerpt' => '',
 			)
 		);
 
-		$this->assertSame( 'Column 1 Column 2', get_the_excerpt( $query->posts[0] ) );
+		$this->assertSame(
+			'Column 1 Column 2',
+			get_the_excerpt( ( new WP_Query( array( 'p' => $post_1->ID ) ) )->posts[0] )
+		);
+
+		$this->assertSame(
+			'Paragraph inside group block',
+			get_the_excerpt( ( new WP_Query( array( 'p' => $post_2->ID ) ) )->posts[0] )
+		);
 	}
 }


### PR DESCRIPTION
When generating a post excerpt, we run the content through `excerpt_remove_blocks`. That function doesn't currently handle `innerBlocks` for groups properly, as well as deeply-nested columns.
This PR changes the implem,entation to allow handling nested blocks more efficiently.

Trac ticket: https://core.trac.wordpress.org/ticket/53604

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
