### PR TITLE
Add excerpt_allowed_wrapper_blocks filter

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -716,6 +716,16 @@ function excerpt_remove_blocks( $content ) {
 		'core/group',
 	);
 
+	/**
+	 * Filters the list of blocks that can be used as wrapper blocks,
+	 * allowing excerpts to be generated from their `innerBlocks`<div class=""></div>
+	 *
+	 * @since 5.8.0
+	 *
+	 * @param array $allowed_wrapper_blocks The list of allowed wrapper blocks.
+	 */
+	$allowed_wrapper_blocks = apply_filters( 'excerpt_allowed_wrapper_blocks', $allowed_wrapper_blocks );
+
 	$allowed_blocks = array_merge( $allowed_inner_blocks, $allowed_wrapper_blocks );
 
 	/**

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -718,7 +718,7 @@ function excerpt_remove_blocks( $content ) {
 
 	/**
 	 * Filters the list of blocks that can be used as wrapper blocks,
-	 * allowing excerpts to be generated from their `innerBlocks`<div class=""></div>
+	 * allowing excerpts to be generated from their `innerBlocks`.
 	 *
 	 * @since 5.8.0
 	 *


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/53604

Adds an `excerpt_allowed_wrapper_blocks` filter.
This is a followup on https://github.com/WordPress/wordpress-develop/pull/1472 following a discussion on https://github.com/WordPress/wordpress-develop/pull/1472#discussion_r664561244 and https://core.trac.wordpress.org/ticket/53604#comment:11

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
