### PR TITLE
Merge conflicting wp.editor objects into a single, non-conflicting module

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -388,7 +388,7 @@ function wp_default_packages_inline_scripts( $scripts ) {
 	// For more context, see https://github.com/WordPress/gutenberg/issues/33203
 	$scripts->add_inline_script(
 		'wp-editor',
-		'Object.assign(window.wp.editor, window.wp.oldEditor);',
+		'Object.assign( window.wp.editor, window.wp.oldEditor );',
 		'after'
 	);
 }

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -31,7 +31,7 @@ require ABSPATH . WPINC . '/functions.wp-scripts.php';
 /** WordPress Styles Class */
 require ABSPATH . WPINC . '/class.wp-styles.php';
 
-/** WordPress Styles Functions */
+/** WordPress Styles Function */
 require ABSPATH . WPINC . '/functions.wp-styles.php';
 
 /**
@@ -379,6 +379,16 @@ function wp_default_packages_inline_scripts( $scripts ) {
 	$scripts->add_inline_script(
 		'editor',
 		'window.wp.oldEditor = window.wp.editor;',
+		'after'
+	);
+
+	// wp-editor module is exposed as window.wp.editor
+	// Problem: there is quite some code expecting window.wp.oldEditor object available under window.wp.editor
+	// Solution: fuse the two objects together to maintain backward compatibility
+	// For more context, see https://github.com/WordPress/gutenberg/issues/33203
+	$scripts->add_inline_script(
+		'wp-editor',
+		'Object.assign(window.wp.editor, window.wp.oldEditor);',
 		'after'
 	);
 }

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -31,7 +31,7 @@ require ABSPATH . WPINC . '/functions.wp-scripts.php';
 /** WordPress Styles Class */
 require ABSPATH . WPINC . '/class.wp-styles.php';
 
-/** WordPress Styles Function */
+/** WordPress Styles Functions */
 require ABSPATH . WPINC . '/functions.wp-styles.php';
 
 /**


### PR DESCRIPTION
## Description
Solves https://github.com/WordPress/gutenberg/issues/33203
Solves https://core.trac.wordpress.org/ticket/53437
Related to https://core.trac.wordpress.org/ticket/53569

Situation: `packages/editor` is exposed as `window.wp.editor` in wp-admin

Problem: there is quite some code expecting to see a different (legacy) object under `window.wp.editor`

Proposed solution: export all the members of legacy window.wp.editor from this new module to maintain backward compatibility

As @noisysocks noticed in https://github.com/WordPress/gutenberg/pull/33228:

> Makes me wonder if a “fix” could be to add code to Core which fires off doing_it_wrong() if you enqueue wp-editor or wp-edit-post in the widgets screen.

This is addressed in https://github.com/WordPress/wordpress-develop/pull/1484

## How has this been tested?
1. Activate classic widgets plugins.
1. Insert text widget
1. Add some text to widget.
1. Deactivate classic widgets plugins.
1. Go to widget screen.
1. There is an error message if this PR is not applied.
1. There are no error messages if this PR is applied.

## Screenshots

<img width="1904" alt="124498441-3f40df80-ddb4-11eb-99e1-581b287f96de" src="https://user-images.githubusercontent.com/205419/124633716-d9bd2380-de85-11eb-9228-742facbacaf9.png">

(Credits for the screenshot and the test plan to @spacedmonkey)

## Types of changes
Bug fix (non-breaking change which fixes an issue)
