### PR TITLE
Conditionally load registered block-styles depending on wp_should_load_separate_core_block_assets

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2426,13 +2426,36 @@ function wp_enqueue_registered_block_scripts_and_styles() {
 function enqueue_block_styles_assets() {
 	$block_styles = WP_Block_Styles_Registry::get_instance()->get_all_registered();
 
-	foreach ( $block_styles as $styles ) {
+	foreach ( $block_styles as $block_name => $styles ) {
 		foreach ( $styles as $style_properties ) {
 			if ( isset( $style_properties['style_handle'] ) ) {
-				wp_enqueue_style( $style_properties['style_handle'] );
+
+				// If the site loads separate styles per-block, enqueue the stylesheet on render.
+				if ( wp_should_load_separate_core_block_assets() ) {
+					add_filter( 'render_block', function( $html, $block ) use ( $style_properties ) {
+						wp_enqueue_style( $style_properties['style_handle'] );
+						return $html;
+					} );
+				} else {
+					wp_enqueue_style( $style_properties['style_handle'] );
+				}
 			}
 			if ( isset( $style_properties['inline_style'] ) ) {
-				wp_add_inline_style( 'wp-block-library', $style_properties['inline_style'] );
+
+				// Default to "wp-block-library".
+				$handle = 'wp-block-library';
+
+				// If the site loads separate styles per-block, check if the block has a stylesheet registered.
+				if ( wp_should_load_separate_core_block_assets() ) {
+					$block_stylesheet_handle = generate_block_asset_handle( $block_name, 'style' );
+					global $wp_styles;
+					if ( isset( $wp_styles->registered[ $block_stylesheet_handle ] ) ) {
+						$handle = $block_stylesheet_handle;
+					}
+				}
+
+				// Add inline styles to the calculated handle.
+				wp_add_inline_style( $handle, $style_properties['inline_style'] );
 			}
 		}
 	}

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2432,10 +2432,13 @@ function enqueue_block_styles_assets() {
 
 				// If the site loads separate styles per-block, enqueue the stylesheet on render.
 				if ( wp_should_load_separate_core_block_assets() ) {
-					add_filter( 'render_block', function( $html, $block ) use ( $style_properties ) {
-						wp_enqueue_style( $style_properties['style_handle'] );
-						return $html;
-					} );
+					add_filter(
+						'render_block',
+						function( $html, $block ) use ( $style_properties ) {
+							wp_enqueue_style( $style_properties['style_handle'] );
+							return $html;
+						}
+					);
 				} else {
 					wp_enqueue_style( $style_properties['style_handle'] );
 				}


### PR DESCRIPTION
This PR modifies the `enqueue_block_styles_assets` function, adding conditions for `wp_should_load_separate_core_block_assets()` and making sure that registered block-styles only load when a block gets rendered on a page.

Trac ticket: https://core.trac.wordpress.org/ticket/53616

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
