### PR TITLE
Call _doing_it_wrong when wp-editor are enqueued together with the new widgets editor

### DIFF
--- a/src/wp-includes/class.wp-dependencies.php
+++ b/src/wp-includes/class.wp-dependencies.php
@@ -390,16 +390,17 @@ class WP_Dependencies {
 
 		if (
 			in_array( 'wp-editor', $this->all_queued_deps ) &&
-			gutenberg_use_widgets_block_editor() &&
-			is_callable( 'get_current_screen' )
+			(
+				in_array( 'wp-edit-widgets-js', $this->all_queued_deps ) ||
+				in_array( 'wp-customize-widgets-js', $this->all_queued_deps )
+			)
 		) {
-			if ( in_array( get_current_screen()->base, array( 'widgets', 'customize' ), true ) ) {
-				_doing_it_wrong(
-					'enqueue_script',
-					'"wp-editor" script should not be enqueued inside on the widgets editor page as it replaces the window.wp.editor variable.',
-					'5.8.0'
-				);
-			}
+			_doing_it_wrong(
+				'enqueue_script',
+				'"wp-editor" script should not be enqueued together with "wp-edit-widgets-js" ' .
+				'and "wp-customize-widgets-js" as it replaces the window.wp.editor variable.',
+				'5.8.0'
+			);
 		}
 
 		return isset( $this->all_queued_deps[ $handle ] );

--- a/src/wp-includes/class.wp-dependencies.php
+++ b/src/wp-includes/class.wp-dependencies.php
@@ -370,6 +370,7 @@ class WP_Dependencies {
 		$all_deps = array_fill_keys( $queue, true );
 		$queues   = array();
 		$done     = array();
+		$old_deps = $all_deps;
 
 		while ( $queue ) {
 			foreach ( $queue as $queued ) {
@@ -386,6 +387,20 @@ class WP_Dependencies {
 		}
 
 		$this->all_queued_deps = $all_deps;
+
+		if (
+			in_array( 'wp-editor', $this->all_queued_deps ) &&
+			gutenberg_use_widgets_block_editor() &&
+			is_callable( 'get_current_screen' )
+		) {
+			if ( in_array( get_current_screen()->base, array( 'widgets', 'customize' ), true ) ) {
+				_doing_it_wrong(
+					'enqueue_script',
+					'"wp-editor" script should not be enqueued inside on the widgets editor page as it replaces the window.wp.editor variable.',
+					'5.8.0'
+				);
+			}
+		}
 
 		return isset( $this->all_queued_deps[ $handle ] );
 	}

--- a/src/wp-includes/class.wp-dependencies.php
+++ b/src/wp-includes/class.wp-dependencies.php
@@ -389,16 +389,14 @@ class WP_Dependencies {
 		$this->all_queued_deps = $all_deps;
 
 		if (
-			in_array( 'wp-editor', $this->all_queued_deps ) &&
-			(
-				in_array( 'wp-edit-widgets-js', $this->all_queued_deps ) ||
-				in_array( 'wp-customize-widgets-js', $this->all_queued_deps )
+			array_key_exists( 'wp-editor', $this->all_queued_deps ) && (
+				array_key_exists( 'wp-edit-widgets', $this->all_queued_deps ) ||
+				array_key_exists( 'wp-customize-widgets', $this->all_queued_deps )
 			)
 		) {
 			_doing_it_wrong(
 				'enqueue_script',
-				'"wp-editor" script should not be enqueued together with "wp-edit-widgets-js" ' .
-				'and "wp-customize-widgets-js" as it replaces the window.wp.editor variable.',
+				'"wp-editor" script should not be enqueued together with the new widgets editor (wp-edit-widgets or wp-customize-widgets).',
 				'5.8.0'
 			);
 		}

--- a/src/wp-includes/class.wp-dependencies.php
+++ b/src/wp-includes/class.wp-dependencies.php
@@ -388,19 +388,6 @@ class WP_Dependencies {
 
 		$this->all_queued_deps = $all_deps;
 
-		if (
-			array_key_exists( 'wp-editor', $this->all_queued_deps ) && (
-				array_key_exists( 'wp-edit-widgets', $this->all_queued_deps ) ||
-				array_key_exists( 'wp-customize-widgets', $this->all_queued_deps )
-			)
-		) {
-			_doing_it_wrong(
-				'enqueue_script',
-				'"wp-editor" script should not be enqueued together with the new widgets editor (wp-edit-widgets or wp-customize-widgets).',
-				'5.8.0'
-			);
-		}
-
 		return isset( $this->all_queued_deps[ $handle ] );
 	}
 

--- a/src/wp-includes/class.wp-dependencies.php
+++ b/src/wp-includes/class.wp-dependencies.php
@@ -370,7 +370,6 @@ class WP_Dependencies {
 		$all_deps = array_fill_keys( $queue, true );
 		$queues   = array();
 		$done     = array();
-		$old_deps = $all_deps;
 
 		while ( $queue ) {
 			foreach ( $queue as $queued ) {

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -566,6 +566,7 @@ add_action( 'admin_print_scripts-index.php', 'wp_localize_community_events' );
 add_filter( 'wp_print_scripts', 'wp_just_in_time_script_localization' );
 add_filter( 'print_scripts_array', 'wp_prototype_before_jquery' );
 add_filter( 'customize_controls_print_styles', 'wp_resource_hints', 1 );
+add_action( 'wp_print_scripts', 'wp_check_widget_editor_deps' );
 
 // Global styles can be enqueued in both the header and the footer. See https://core.trac.wordpress.org/ticket/53494.
 add_action( 'wp_enqueue_scripts', 'wp_enqueue_global_styles' );

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -566,7 +566,7 @@ add_action( 'admin_print_scripts-index.php', 'wp_localize_community_events' );
 add_filter( 'wp_print_scripts', 'wp_just_in_time_script_localization' );
 add_filter( 'print_scripts_array', 'wp_prototype_before_jquery' );
 add_filter( 'customize_controls_print_styles', 'wp_resource_hints', 1 );
-add_action( 'wp_print_scripts', 'wp_check_widget_editor_deps' );
+add_action( 'admin_head', 'wp_check_widget_editor_deps' );
 
 // Global styles can be enqueued in both the header and the footer. See https://core.trac.wordpress.org/ticket/53494.
 add_action( 'wp_enqueue_scripts', 'wp_enqueue_global_styles' );

--- a/src/wp-includes/widgets.php
+++ b/src/wp-includes/widgets.php
@@ -2020,21 +2020,21 @@ function wp_render_widget_control( $id ) {
 function wp_check_widget_editor_deps() {
 	global $wp_scripts, $wp_styles;
 	if (
-			$wp_scripts->query( 'wp-edit-widgets', 'enqueued' ) ||
-			$wp_scripts->query( 'wp-customize-widgets', 'enqueued' )
+		$wp_scripts->query( 'wp-edit-widgets', 'enqueued' ) ||
+		$wp_scripts->query( 'wp-customize-widgets', 'enqueued' )
 	) {
 		if ( $wp_scripts->query( 'wp-editor', 'enqueued' ) ) {
 			_doing_it_wrong(
-					'enqueue_script',
-					'"wp-editor" script should not be enqueued together with the new widgets editor (wp-edit-widgets or wp-customize-widgets).',
-					'5.8.0'
+				'enqueue_script',
+				'"wp-editor" script should not be enqueued together with the new widgets editor (wp-edit-widgets or wp-customize-widgets).',
+				'5.8.0'
 			);
 		}
 		if ( $wp_styles->query( 'wp-edit-post', 'enqueued' ) ) {
 			_doing_it_wrong(
-					'enqueue_style',
-					'"wp-edit-post" style should not be enqueued together with the new widgets editor (wp-edit-widgets or wp-customize-widgets).',
-					'5.8.0'
+				'enqueue_style',
+				'"wp-edit-post" style should not be enqueued together with the new widgets editor (wp-edit-widgets or wp-customize-widgets).',
+				'5.8.0'
 			);
 		}
 	}

--- a/src/wp-includes/widgets.php
+++ b/src/wp-includes/widgets.php
@@ -2006,3 +2006,38 @@ function wp_render_widget_control( $id ) {
 
 	return ob_get_clean();
 }
+
+/**
+ * Wp-editor JS module is exposed as window.wp.editor. This overrides the legacy TinyMCE editor module which
+ * is required by the widgets editor. Because of that conflict, these two shouldn't be enqueued together.
+ *
+ * For more context, see https://github.com/WordPress/gutenberg/issues/33203
+ *
+ * There is also another conflict related to styles where the block widgets editor is hidden if a block
+ * enqueues 'wp-edit-post' stylesheet:
+ * https://core.trac.wordpress.org/ticket/53569
+ */
+function wp_check_widget_editor_deps() {
+	global $wp_scripts, $wp_styles;
+	if (
+			$wp_scripts->query( 'wp-edit-widgets', 'enqueued' ) ||
+			$wp_scripts->query( 'wp-customize-widgets', 'enqueued' )
+	) {
+		if ( $wp_scripts->query( 'wp-editor', 'enqueued' ) ) {
+			_doing_it_wrong(
+					'enqueue_script',
+					'"wp-editor" script should not be enqueued together with the new widgets editor (wp-edit-widgets or wp-customize-widgets).',
+					'5.8.0'
+			);
+		}
+		if ( $wp_styles->query( 'wp-edit-post', 'enqueued' ) ) {
+			_doing_it_wrong(
+					'enqueue_style',
+					'"wp-edit-post" style should not be enqueued together with the new widgets editor (wp-edit-widgets or wp-customize-widgets).',
+					'5.8.0'
+			);
+		}
+	}
+}
+add_action( 'wp_print_scripts', 'wp_check_widget_editor_deps' );
+

--- a/src/wp-includes/widgets.php
+++ b/src/wp-includes/widgets.php
@@ -2008,13 +2008,14 @@ function wp_render_widget_control( $id ) {
 }
 
 /**
- * Wp-editor JS module is exposed as window.wp.editor. This overrides the legacy TinyMCE editor module which
- * is required by the widgets editor. Because of that conflict, these two shouldn't be enqueued together.
+ * Wp-editor JS module is exposed as window.wp.editor. This overrides the legacy
+ * TinyMCE editor module which is required by the widgets editor. Because of
+ * that conflict, these two shouldn't be enqueued together.
  *
  * For more context, see https://github.com/WordPress/gutenberg/issues/33203
  *
- * There is also another conflict related to styles where the block widgets editor is hidden if a block
- * enqueues 'wp-edit-post' stylesheet:
+ * There is also another conflict related to styles where the block widgets
+ * editor is hidden if a block enqueues 'wp-edit-post' stylesheet:
  * https://core.trac.wordpress.org/ticket/53569
  */
 function wp_check_widget_editor_deps() {
@@ -2039,5 +2040,3 @@ function wp_check_widget_editor_deps() {
 		}
 	}
 }
-add_action( 'wp_print_scripts', 'wp_check_widget_editor_deps' );
-


### PR DESCRIPTION
Following up on https://github.com/WordPress/wordpress-develop/pull/1481, this PR addresses the following comment expressed by @noisysocks:

> Makes me wonder if a “fix” could be to add code to Core which fires off doing_it_wrong() if you enqueue wp-editor or wp-edit-post in the widgets screen.

At first I thought about detecting the current screen in `class.wp-dependencies.php`, but then I realized that these JS files are just inherently incompatible and we don't really need to restrict the warning to a single screen – we should surface it whenever `wp-editor` and `wp-edit/customize-widgets-js` scripts are enqueued together.

Related to:
* WordPress/gutenberg#33203
* https://core.trac.wordpress.org/ticket/53437
* https://core.trac.wordpress.org/ticket/53569