### PR TITLE
Alter how Twenty Twenty-One sets up Dark Mode support.

### DIFF
--- a/src/wp-content/themes/twentytwentyone/classes/class-twenty-twenty-one-dark-mode.php
+++ b/src/wp-content/themes/twentytwentyone/classes/class-twenty-twenty-one-dark-mode.php
@@ -18,6 +18,35 @@ class Twenty_Twenty_One_Dark_Mode {
 	 * @since Twenty Twenty-One 1.0
 	 */
 	public function __construct() {
+		if ( is_admin() ) {
+			$this->setup_admin();
+		} else {
+			$this->add_hooks();
+		}
+	}
+
+	/**
+	 * Sets up Dark Mode for use within the admin area.
+	 *
+	 * @since Twenty Twenty-One 1.4
+	 */
+	public function setup_admin() {
+		add_action( 'current_screen', array( $this, 'add_hooks' ) );
+
+		// Add the privacy policy content.
+		add_action( 'admin_init', array( $this, 'add_privacy_policy_content' ) );
+	}
+
+	/**
+	 * Adds the needed hooks to support Dark Mode.
+	 *
+	 * @since Twenty Twenty-One 1.4
+	 */
+	public function add_hooks() {
+		// Disable dark-mode in the widgets editor.
+		if ( is_admin() && 'widgets' === get_current_screen()->base ) {
+			return;
+		}
 
 		// Enqueue assets for the block-editor.
 		add_action( 'enqueue_block_editor_assets', array( $this, 'editor_custom_color_variables' ) );
@@ -39,9 +68,6 @@ class Twenty_Twenty_One_Dark_Mode {
 
 		// Add the switch on the frontend & customizer.
 		add_action( 'wp_footer', array( $this, 'the_switch' ) );
-
-		// Add the privacy policy content.
-		add_action( 'admin_init', array( $this, 'add_privacy_policy_content' ) );
 	}
 
 	/**

--- a/src/wp-content/themes/twentytwentyone/classes/class-twenty-twenty-one-dark-mode.php
+++ b/src/wp-content/themes/twentytwentyone/classes/class-twenty-twenty-one-dark-mode.php
@@ -33,7 +33,7 @@ class Twenty_Twenty_One_Dark_Mode {
 	public function setup_admin() {
 		add_action( 'current_screen', array( $this, 'add_hooks' ) );
 
-		// Add the privacy policy content.
+		// Add the privacy policy content. This is done here because current_screen is too late.
 		add_action( 'admin_init', array( $this, 'add_privacy_policy_content' ) );
 	}
 
@@ -43,7 +43,7 @@ class Twenty_Twenty_One_Dark_Mode {
 	 * @since Twenty Twenty-One 1.4
 	 */
 	public function add_hooks() {
-		// Disable dark-mode in the widgets editor.
+		// Disable Dark Mode in the widgets editor.
 		if ( is_admin() && 'widgets' === get_current_screen()->base ) {
 			return;
 		}

--- a/src/wp-content/themes/twentytwentyone/classes/class-twenty-twenty-one-dark-mode.php
+++ b/src/wp-content/themes/twentytwentyone/classes/class-twenty-twenty-one-dark-mode.php
@@ -35,6 +35,9 @@ class Twenty_Twenty_One_Dark_Mode {
 
 		// Add the privacy policy content. This is done here because current_screen is too late.
 		add_action( 'admin_init', array( $this, 'add_privacy_policy_content' ) );
+
+		// Add customizer controls.
+		add_action( 'customize_register', array( $this, 'customizer_controls' ) );
 	}
 
 	/**
@@ -44,7 +47,7 @@ class Twenty_Twenty_One_Dark_Mode {
 	 */
 	public function add_hooks() {
 		// Disable Dark Mode in the widgets editor.
-		if ( is_admin() && 'widgets' === get_current_screen()->base ) {
+		if ( ( is_admin() && 'widgets' === get_current_screen()->base ) || is_customize_preview() ) {
 			return;
 		}
 
@@ -56,9 +59,6 @@ class Twenty_Twenty_One_Dark_Mode {
 
 		// Add scripts for customizer controls.
 		add_action( 'customize_controls_enqueue_scripts', array( $this, 'customize_controls_enqueue_scripts' ) );
-
-		// Add customizer controls.
-		add_action( 'customize_register', array( $this, 'customizer_controls' ) );
 
 		// Add HTML classes.
 		add_filter( 'twentytwentyone_html_classes', array( $this, 'html_classes' ) );


### PR DESCRIPTION
This allows for a later setup, which allows `get_current_screen()` to be used to check that the user is on the widget screen.

Trac ticket: https://core.trac.wordpress.org/ticket/53429.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
