### PR TITLE
Widgets Screen: wp.editor.initialize is not a function notice

### DIFF
--- a/src/js/_enqueues/wp/widgets/text.js
+++ b/src/js/_enqueues/wp/widgets/text.js
@@ -161,7 +161,7 @@ wp.textWidgets = ( function( $ ) {
 					control.fields.text.val( syncInput.val() );
 				}
 			} else if ( control.editor && ! control.editorFocused && syncInput.val() !== control.fields.text.val() ) {
-				control.editor.setContent( wp.editor.autop( syncInput.val() ) );
+				control.editor.setContent( wp.oldEditor.autop( syncInput.val() ) );
 			}
 		},
 
@@ -237,7 +237,7 @@ wp.textWidgets = ( function( $ ) {
 
 				// The user has disabled TinyMCE.
 				if ( typeof window.tinymce === 'undefined' ) {
-					wp.editor.initialize( id, {
+					wp.oldEditor.initialize( id, {
 						quicktags: true,
 						mediaButtons: true
 					});
@@ -248,7 +248,7 @@ wp.textWidgets = ( function( $ ) {
 				// Destroy any existing editor so that it can be re-initialized after a widget-updated event.
 				if ( tinymce.get( id ) ) {
 					restoreTextMode = tinymce.get( id ).isHidden();
-					wp.editor.remove( id );
+					wp.oldEditor.remove( id );
 				}
 
 				// Add or enable the `wpview` plugin.
@@ -262,7 +262,7 @@ wp.textWidgets = ( function( $ ) {
 					}
 				} );
 
-				wp.editor.initialize( id, {
+				wp.oldEditor.initialize( id, {
 					tinymce: {
 						wpautop: true
 					},


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->
The text widget, uses the tinymce editor. This used to be on wp.editor, but now widget screen uses the gutenberg editor, wp.editor is used by gutenberg. Use `wp.oldEditor` to get the legacy editor back. 

Trac ticket: https://core.trac.wordpress.org/ticket/53437

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
