### PR TITLE
Fix/update unzip rollbacks

### DIFF
--- a/src/wp-admin/includes/class-plugin-upgrader.php
+++ b/src/wp-admin/includes/class-plugin-upgrader.php
@@ -210,6 +210,7 @@ class Plugin_Upgrader extends WP_Upgrader {
 
 		add_filter( 'upgrader_pre_install', array( $this, 'deactivate_plugin_before_upgrade' ), 10, 2 );
 		add_filter( 'upgrader_pre_install', array( $this, 'active_before' ), 10, 2 );
+		add_filter( 'upgrader_pre_install', array( $this, 'move_to_rollbacks_dir' ), 10, 2 );
 		add_filter( 'upgrader_clear_destination', array( $this, 'delete_old_plugin' ), 10, 4 );
 		add_filter( 'upgrader_post_install', array( $this, 'active_after' ), 10, 2 );
 		// There's a Trac ticket to move up the directory for zips which are made a bit differently, useful for non-.org plugins.

--- a/src/wp-admin/includes/class-plugin-upgrader.php
+++ b/src/wp-admin/includes/class-plugin-upgrader.php
@@ -231,7 +231,7 @@ class Plugin_Upgrader extends WP_Upgrader {
 					'action'   => 'update',
 					'rollback' => array(
 						'slug' => dirname( $plugin ),
-						'src'  => $wp_filesystem->wp_plugins_dir(),
+						'src'  => WP_PLUGIN_DIR,
 						'dir'  => 'plugins',
 					),
 				),
@@ -339,8 +339,6 @@ class Plugin_Upgrader extends WP_Upgrader {
 
 			$this->skin->plugin_active = is_plugin_active( $plugin );
 
-			global $wp_filesystem;
-
 			$result = $this->run(
 				array(
 					'package'           => $r->package,
@@ -352,7 +350,7 @@ class Plugin_Upgrader extends WP_Upgrader {
 						'plugin'   => $plugin,
 						'rollback' => array(
 							'slug' => dirname( $plugin ),
-							'src'  => $wp_filesystem->wp_plugins_dir(),
+							'src'  => WP_PLUGIN_DIR,
 							'dir'  => 'plugins',
 						),
 					),

--- a/src/wp-admin/includes/class-plugin-upgrader.php
+++ b/src/wp-admin/includes/class-plugin-upgrader.php
@@ -657,4 +657,32 @@ class Plugin_Upgrader extends WP_Upgrader {
 
 		return true;
 	}
+
+	/**
+	 * Get a rollback param.
+	 *
+	 * @since 5.9.0
+	 *
+	 * @global WP_Filesystem_Base $wp_filesystem WordPress filesystem subclass.
+	 *
+	 * @param string $param      The parameter to get.
+	 * @param array  $hook_extra Extra params.
+	 *
+	 * @return string|null
+	 */
+	public function get_rollback_param( $param, $hook_extra = array() ) {
+		if ( empty( $hook_extra['plugin'] ) ) {
+			return;
+		}
+		global $wp_filesystem;
+		$params = array(
+			'type'                => 'plugin',
+			'rollbacks_subfolder' => 'plugins',
+			'destination_dir'     => $wp_filesystem->wp_plugins_dir(),
+			'slug'                => dirname( $hook_extra['plugin'] ),
+		);
+		if ( isset( $params[ $param ] ) ) {
+			return $params[ $param ];
+		}
+	}
 }

--- a/src/wp-admin/includes/class-plugin-upgrader.php
+++ b/src/wp-admin/includes/class-plugin-upgrader.php
@@ -226,10 +226,10 @@ class Plugin_Upgrader extends WP_Upgrader {
 				'clear_destination' => true,
 				'clear_working'     => true,
 				'hook_extra'        => array(
-					'plugin'   => $plugin,
-					'type'     => 'plugin',
-					'action'   => 'update',
-					'rollback' => array(
+					'plugin'      => $plugin,
+					'type'        => 'plugin',
+					'action'      => 'update',
+					'temp_backup' => array(
 						'slug' => dirname( $plugin ),
 						'src'  => WP_PLUGIN_DIR,
 						'dir'  => 'plugins',
@@ -347,8 +347,8 @@ class Plugin_Upgrader extends WP_Upgrader {
 					'clear_working'     => true,
 					'is_multi'          => true,
 					'hook_extra'        => array(
-						'plugin'   => $plugin,
-						'rollback' => array(
+						'plugin'      => $plugin,
+						'temp_backup' => array(
 							'slug' => dirname( $plugin ),
 							'src'  => WP_PLUGIN_DIR,
 							'dir'  => 'plugins',

--- a/src/wp-admin/includes/class-plugin-upgrader.php
+++ b/src/wp-admin/includes/class-plugin-upgrader.php
@@ -286,6 +286,7 @@ class Plugin_Upgrader extends WP_Upgrader {
 
 		$current = get_site_transient( 'update_plugins' );
 
+		add_filter( 'upgrader_pre_install', array( $this, 'move_to_rollbacks_dir' ), 10, 2 );
 		add_filter( 'upgrader_clear_destination', array( $this, 'delete_old_plugin' ), 10, 4 );
 
 		$this->skin->header();

--- a/src/wp-admin/includes/class-plugin-upgrader.php
+++ b/src/wp-admin/includes/class-plugin-upgrader.php
@@ -230,9 +230,9 @@ class Plugin_Upgrader extends WP_Upgrader {
 					'type'     => 'plugin',
 					'action'   => 'update',
 					'rollback' => array(
-						'slug'      => dirname( $plugin ),
-						'src'       => $wp_filesystem->wp_plugins_dir(),
-						'subfolder' => 'plugins',
+						'slug' => dirname( $plugin ),
+						'src'  => $wp_filesystem->wp_plugins_dir(),
+						'dir'  => 'plugins',
 					),
 				),
 			)
@@ -351,9 +351,9 @@ class Plugin_Upgrader extends WP_Upgrader {
 					'hook_extra'        => array(
 						'plugin'   => $plugin,
 						'rollback' => array(
-							'slug'      => dirname( $plugin ),
-							'src'       => $wp_filesystem->wp_plugins_dir(),
-							'subfolder' => 'plugins',
+							'slug' => dirname( $plugin ),
+							'src'  => $wp_filesystem->wp_plugins_dir(),
+							'dir'  => 'plugins',
 						),
 					),
 				)

--- a/src/wp-admin/includes/class-theme-upgrader.php
+++ b/src/wp-admin/includes/class-theme-upgrader.php
@@ -387,6 +387,7 @@ class Theme_Upgrader extends WP_Upgrader {
 		$current = get_site_transient( 'update_themes' );
 
 		add_filter( 'upgrader_pre_install', array( $this, 'current_before' ), 10, 2 );
+		add_filter( 'upgrader_pre_install', array( $this, 'move_to_rollbacks_dir' ), 10, 2 );
 		add_filter( 'upgrader_post_install', array( $this, 'current_after' ), 10, 2 );
 		add_filter( 'upgrader_clear_destination', array( $this, 'delete_old_theme' ), 10, 4 );
 

--- a/src/wp-admin/includes/class-theme-upgrader.php
+++ b/src/wp-admin/includes/class-theme-upgrader.php
@@ -332,9 +332,9 @@ class Theme_Upgrader extends WP_Upgrader {
 					'type'     => 'theme',
 					'action'   => 'update',
 					'rollback' => array(
-						'slug'      => $theme,
-						'src'       => get_theme_root(),
-						'subfolder' => 'themes',
+						'slug' => $theme,
+						'src'  => get_theme_root(),
+						'dir'  => 'themes',
 					),
 				),
 			)
@@ -450,9 +450,9 @@ class Theme_Upgrader extends WP_Upgrader {
 					'hook_extra'        => array(
 						'theme'    => $theme,
 						'rollback' => array(
-							'slug'      => $theme,
-							'src'       => get_theme_root(),
-							'subfolder' => 'themes',
+							'slug' => $theme,
+							'src'  => get_theme_root(),
+							'src'  => 'themes',
 						),
 					),
 				)

--- a/src/wp-admin/includes/class-theme-upgrader.php
+++ b/src/wp-admin/includes/class-theme-upgrader.php
@@ -314,7 +314,6 @@ class Theme_Upgrader extends WP_Upgrader {
 		$r = $current->response[ $theme ];
 
 		add_filter( 'upgrader_pre_install', array( $this, 'current_before' ), 10, 2 );
-		add_filter( 'upgrader_pre_install', array( $this, 'move_to_rollbacks_dir' ), 10, 2 );
 		add_filter( 'upgrader_post_install', array( $this, 'current_after' ), 10, 2 );
 		add_filter( 'upgrader_clear_destination', array( $this, 'delete_old_theme' ), 10, 4 );
 		if ( $parsed_args['clear_update_cache'] ) {
@@ -329,9 +328,14 @@ class Theme_Upgrader extends WP_Upgrader {
 				'clear_destination' => true,
 				'clear_working'     => true,
 				'hook_extra'        => array(
-					'theme'  => $theme,
-					'type'   => 'theme',
-					'action' => 'update',
+					'theme'    => $theme,
+					'type'     => 'theme',
+					'action'   => 'update',
+					'rollback' => array(
+						'slug'      => $theme,
+						'src'       => get_theme_root(),
+						'subfolder' => 'themes',
+					),
 				),
 			)
 		);
@@ -387,7 +391,6 @@ class Theme_Upgrader extends WP_Upgrader {
 		$current = get_site_transient( 'update_themes' );
 
 		add_filter( 'upgrader_pre_install', array( $this, 'current_before' ), 10, 2 );
-		add_filter( 'upgrader_pre_install', array( $this, 'move_to_rollbacks_dir' ), 10, 2 );
 		add_filter( 'upgrader_post_install', array( $this, 'current_after' ), 10, 2 );
 		add_filter( 'upgrader_clear_destination', array( $this, 'delete_old_theme' ), 10, 4 );
 
@@ -445,7 +448,12 @@ class Theme_Upgrader extends WP_Upgrader {
 					'clear_working'     => true,
 					'is_multi'          => true,
 					'hook_extra'        => array(
-						'theme' => $theme,
+						'theme'    => $theme,
+						'rollback' => array(
+							'slug'      => $theme,
+							'src'       => get_theme_root(),
+							'subfolder' => 'themes',
+						),
 					),
 				)
 			);
@@ -742,34 +750,6 @@ class Theme_Upgrader extends WP_Upgrader {
 		$theme->cache_delete();
 
 		return $theme;
-	}
-
-	/**
-	 * Get a rollback param.
-	 *
-	 * @since 5.9.0
-	 *
-	 * @global WP_Filesystem_Base $wp_filesystem WordPress filesystem subclass.
-	 *
-	 * @param string $param      The parameter to get.
-	 * @param array  $hook_extra Extra params.
-	 *
-	 * @return string|null
-	 */
-	public function get_rollback_param( $param, $hook_extra = array() ) {
-		if ( empty( $hook_extra['theme'] ) ) {
-			return;
-		}
-		global $wp_filesystem;
-		$params = array(
-			'type'                => 'theme',
-			'rollbacks_subfolder' => 'themes',
-			'destination_dir'     => get_theme_root(),
-			'slug'                => $hook_extra['theme'],
-		);
-		if ( isset( $params[ $param ] ) ) {
-			return $params[ $param ];
-		}
 	}
 
 }

--- a/src/wp-admin/includes/class-theme-upgrader.php
+++ b/src/wp-admin/includes/class-theme-upgrader.php
@@ -452,7 +452,7 @@ class Theme_Upgrader extends WP_Upgrader {
 						'rollback' => array(
 							'slug' => $theme,
 							'src'  => get_theme_root( $theme ),
-							'src'  => 'themes',
+							'dir'  => 'themes',
 						),
 					),
 				)

--- a/src/wp-admin/includes/class-theme-upgrader.php
+++ b/src/wp-admin/includes/class-theme-upgrader.php
@@ -328,10 +328,10 @@ class Theme_Upgrader extends WP_Upgrader {
 				'clear_destination' => true,
 				'clear_working'     => true,
 				'hook_extra'        => array(
-					'theme'    => $theme,
-					'type'     => 'theme',
-					'action'   => 'update',
-					'rollback' => array(
+					'theme'       => $theme,
+					'type'        => 'theme',
+					'action'      => 'update',
+					'temp_backup' => array(
 						'slug' => $theme,
 						'src'  => get_theme_root( $theme ),
 						'dir'  => 'themes',
@@ -448,8 +448,8 @@ class Theme_Upgrader extends WP_Upgrader {
 					'clear_working'     => true,
 					'is_multi'          => true,
 					'hook_extra'        => array(
-						'theme'    => $theme,
-						'rollback' => array(
+						'theme'       => $theme,
+						'temp_backup' => array(
 							'slug' => $theme,
 							'src'  => get_theme_root( $theme ),
 							'dir'  => 'themes',

--- a/src/wp-admin/includes/class-theme-upgrader.php
+++ b/src/wp-admin/includes/class-theme-upgrader.php
@@ -314,6 +314,7 @@ class Theme_Upgrader extends WP_Upgrader {
 		$r = $current->response[ $theme ];
 
 		add_filter( 'upgrader_pre_install', array( $this, 'current_before' ), 10, 2 );
+		add_filter( 'upgrader_pre_install', array( $this, 'move_to_rollbacks_dir' ), 10, 2 );
 		add_filter( 'upgrader_post_install', array( $this, 'current_after' ), 10, 2 );
 		add_filter( 'upgrader_clear_destination', array( $this, 'delete_old_theme' ), 10, 4 );
 		if ( $parsed_args['clear_update_cache'] ) {

--- a/src/wp-admin/includes/class-theme-upgrader.php
+++ b/src/wp-admin/includes/class-theme-upgrader.php
@@ -333,7 +333,7 @@ class Theme_Upgrader extends WP_Upgrader {
 					'action'   => 'update',
 					'rollback' => array(
 						'slug' => $theme,
-						'src'  => get_theme_root(),
+						'src'  => get_theme_root( $theme ),
 						'dir'  => 'themes',
 					),
 				),
@@ -451,7 +451,7 @@ class Theme_Upgrader extends WP_Upgrader {
 						'theme'    => $theme,
 						'rollback' => array(
 							'slug' => $theme,
-							'src'  => get_theme_root(),
+							'src'  => get_theme_root( $theme ),
 							'src'  => 'themes',
 						),
 					),

--- a/src/wp-admin/includes/class-theme-upgrader.php
+++ b/src/wp-admin/includes/class-theme-upgrader.php
@@ -744,4 +744,32 @@ class Theme_Upgrader extends WP_Upgrader {
 		return $theme;
 	}
 
+	/**
+	 * Get a rollback param.
+	 *
+	 * @since 5.9.0
+	 *
+	 * @global WP_Filesystem_Base $wp_filesystem WordPress filesystem subclass.
+	 *
+	 * @param string $param      The parameter to get.
+	 * @param array  $hook_extra Extra params.
+	 *
+	 * @return string|null
+	 */
+	public function get_rollback_param( $param, $hook_extra = array() ) {
+		if ( empty( $hook_extra['theme'] ) ) {
+			return;
+		}
+		global $wp_filesystem;
+		$params = array(
+			'type'                => 'theme',
+			'rollbacks_subfolder' => 'themes',
+			'destination_dir'     => get_theme_root(),
+			'slug'                => $hook_extra['theme'],
+		);
+		if ( isset( $params[ $param ] ) ) {
+			return $params[ $param ];
+		}
+	}
+
 }

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -1886,13 +1886,8 @@ class WP_Site_Health {
 	 * @return array The test results.
 	 */
 	public function get_test_available_updates_disk_space() {
-		$available_space          = (int) disk_free_space( WP_CONTENT_DIR . '/upgrade/' );
-		$available_space_in_mb    = round( $available_space / MB_IN_BYTES, 2 );
-		$available_space_in_gb    = round( $available_space / GB_IN_BYTES, 2 );
-		$available_space_readable = $available_space_in_mb . ' MB';
-		if ( 1024 < $available_space_in_mb ) {
-			$available_space_readable = $available_space_in_gb . ' GB';
-		}
+		$available_space       = (int) disk_free_space( WP_CONTENT_DIR . '/upgrade/' );
+		$available_space_in_mb = round( $available_space / MB_IN_BYTES, 2 );
 
 		$result = array(
 			'label'       => __( 'Disk-space available to safely perform updates' ),
@@ -1904,7 +1899,7 @@ class WP_Site_Health {
 			'description' => sprintf(
 				/* Translators: %s: Available disk-space in MB or GB. */
 				'<p>' . __( '%s available disk space was detected, update routines can be performed safely.' ),
-				$available_space_readable
+				size_format( $available_space )
 			),
 			'actions'     => '',
 			'test'        => 'available_updates_disk_space',

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -1887,7 +1887,7 @@ class WP_Site_Health {
 	 */
 	public function get_test_available_updates_disk_space() {
 		$available_space       = (int) disk_free_space( WP_CONTENT_DIR . '/upgrade/' );
-		$available_space_in_mb = round( $available_space / MB_IN_BYTES, 2 );
+		$available_space_in_mb = $available_space / MB_IN_BYTES;
 
 		$result = array(
 			'label'       => __( 'Disk-space available to safely perform updates' ),

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -1886,9 +1886,9 @@ class WP_Site_Health {
 	 * @return array The test results.
 	 */
 	public function get_test_available_updates_disk_space() {
-		$available_space       = (int) disk_free_space( WP_CONTENT_DIR . '/upgrade/' );
-		$available_space_in_mb = round( $available_space / MB_IN_BYTES, 2 );
-		$available_space_in_gb = round( $available_space / GB_IN_BYTES, 2 );
+		$available_space          = (int) disk_free_space( WP_CONTENT_DIR . '/upgrade/' );
+		$available_space_in_mb    = round( $available_space / MB_IN_BYTES, 2 );
+		$available_space_in_gb    = round( $available_space / GB_IN_BYTES, 2 );
 		$available_space_readable = $available_space_in_mb . ' MB';
 		if ( 1024 < $available_space_in_mb ) {
 			$available_space_readable = $available_space_in_gb . ' GB';
@@ -2404,76 +2404,76 @@ class WP_Site_Health {
 	public static function get_tests() {
 		$tests = array(
 			'direct' => array(
-				'wordpress_version'           => array(
+				'wordpress_version'                     => array(
 					'label' => __( 'WordPress Version' ),
 					'test'  => 'wordpress_version',
 				),
-				'plugin_version'              => array(
+				'plugin_version'                        => array(
 					'label' => __( 'Plugin Versions' ),
 					'test'  => 'plugin_version',
 				),
-				'theme_version'               => array(
+				'theme_version'                         => array(
 					'label' => __( 'Theme Versions' ),
 					'test'  => 'theme_version',
 				),
-				'php_version'                 => array(
+				'php_version'                           => array(
 					'label' => __( 'PHP Version' ),
 					'test'  => 'php_version',
 				),
-				'php_extensions'              => array(
+				'php_extensions'                        => array(
 					'label' => __( 'PHP Extensions' ),
 					'test'  => 'php_extensions',
 				),
-				'php_default_timezone'        => array(
+				'php_default_timezone'                  => array(
 					'label' => __( 'PHP Default Timezone' ),
 					'test'  => 'php_default_timezone',
 				),
-				'php_sessions'                => array(
+				'php_sessions'                          => array(
 					'label' => __( 'PHP Sessions' ),
 					'test'  => 'php_sessions',
 				),
-				'sql_server'                  => array(
+				'sql_server'                            => array(
 					'label' => __( 'Database Server version' ),
 					'test'  => 'sql_server',
 				),
-				'utf8mb4_support'             => array(
+				'utf8mb4_support'                       => array(
 					'label' => __( 'MySQL utf8mb4 support' ),
 					'test'  => 'utf8mb4_support',
 				),
-				'ssl_support'                 => array(
+				'ssl_support'                           => array(
 					'label' => __( 'Secure communication' ),
 					'test'  => 'ssl_support',
 				),
-				'scheduled_events'            => array(
+				'scheduled_events'                      => array(
 					'label' => __( 'Scheduled events' ),
 					'test'  => 'scheduled_events',
 				),
-				'http_requests'               => array(
+				'http_requests'                         => array(
 					'label' => __( 'HTTP Requests' ),
 					'test'  => 'http_requests',
 				),
-				'rest_availability'           => array(
+				'rest_availability'                     => array(
 					'label'     => __( 'REST API availability' ),
 					'test'      => 'rest_availability',
 					'skip_cron' => true,
 				),
-				'debug_enabled'               => array(
+				'debug_enabled'                         => array(
 					'label' => __( 'Debugging enabled' ),
 					'test'  => 'is_in_debug_mode',
 				),
-				'file_uploads'                => array(
+				'file_uploads'                          => array(
 					'label' => __( 'File uploads' ),
 					'test'  => 'file_uploads',
 				),
-				'plugin_theme_auto_updates'   => array(
+				'plugin_theme_auto_updates'             => array(
 					'label' => __( 'Plugin and theme auto-updates' ),
 					'test'  => 'plugin_theme_auto_updates',
 				),
-				'update_temp_backup_writable' => array(
+				'update_temp_backup_writable'           => array(
 					'label' => __( 'Updates temp-backup folder access' ),
 					'test'  => 'update_temp_backup_writable',
 				),
-				'get_test_available_updates_disk_space'		 => array(
+				'get_test_available_updates_disk_space' => array(
 					'label' => __( 'Available disk space' ),
 					'test'  => 'available_updates_disk_space',
 				),

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -1962,7 +1962,7 @@ class WP_Site_Health {
 		$backup_folder_is_writable  = $wp_filesystem->is_writable( "$wp_content/upgrade/temp-backup" );
 		$plugins_folder_exists      = $wp_filesystem->is_dir( "$wp_content/upgrade/temp-backup/plugins" );
 		$plugins_folder_is_writable = $wp_filesystem->is_writable( "$wp_content/upgrade/temp-backup/plugins" );
-		$themes_folder_exists       =  $wp_filesystem->is_dir( "$wp_content/upgrade/temp-backup/themes" );
+		$themes_folder_exists       = $wp_filesystem->is_dir( "$wp_content/upgrade/temp-backup/themes" );
 		$themes_folder_is_writable  = $wp_filesystem->is_writable( "$wp_content/upgrade/temp-backup/themes" );
 
 		if ( $plugins_folder_exists && ! $plugins_folder_is_writable && $themes_folder_exists && ! $themes_folder_is_writable ) {
@@ -2025,7 +2025,7 @@ class WP_Site_Health {
 			$result['status']      = 'critical';
 			$result['label']       = __( 'The upgrade folder can not be created' );
 			$result['description'] = sprintf(
-				/* ranslators: %1$s: <code>wp-content/upgrade</code>. %2$s: <code>wp-content</code>. */
+				/* translators: %1$s: <code>wp-content/upgrade</code>. %2$s: <code>wp-content</code>. */
 				'<p>' . __( 'The %1$s folder does not exist, and the server does not have write permissions in %2$s to create it. This folder is used to for plugin and theme updates. Please make sure the server has write permissions in %2$s.' ) . '</p>',
 				'<code>wp-content/upgrade</code>',
 				'<code>wp-content</code>'

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -2404,76 +2404,76 @@ class WP_Site_Health {
 	public static function get_tests() {
 		$tests = array(
 			'direct' => array(
-				'wordpress_version'                     => array(
+				'wordpress_version'            => array(
 					'label' => __( 'WordPress Version' ),
 					'test'  => 'wordpress_version',
 				),
-				'plugin_version'                        => array(
+				'plugin_version'               => array(
 					'label' => __( 'Plugin Versions' ),
 					'test'  => 'plugin_version',
 				),
-				'theme_version'                         => array(
+				'theme_version'                => array(
 					'label' => __( 'Theme Versions' ),
 					'test'  => 'theme_version',
 				),
-				'php_version'                           => array(
+				'php_version'                  => array(
 					'label' => __( 'PHP Version' ),
 					'test'  => 'php_version',
 				),
-				'php_extensions'                        => array(
+				'php_extensions'               => array(
 					'label' => __( 'PHP Extensions' ),
 					'test'  => 'php_extensions',
 				),
-				'php_default_timezone'                  => array(
+				'php_default_timezone'         => array(
 					'label' => __( 'PHP Default Timezone' ),
 					'test'  => 'php_default_timezone',
 				),
-				'php_sessions'                          => array(
+				'php_sessions'                 => array(
 					'label' => __( 'PHP Sessions' ),
 					'test'  => 'php_sessions',
 				),
-				'sql_server'                            => array(
+				'sql_server'                   => array(
 					'label' => __( 'Database Server version' ),
 					'test'  => 'sql_server',
 				),
-				'utf8mb4_support'                       => array(
+				'utf8mb4_support'              => array(
 					'label' => __( 'MySQL utf8mb4 support' ),
 					'test'  => 'utf8mb4_support',
 				),
-				'ssl_support'                           => array(
+				'ssl_support'                  => array(
 					'label' => __( 'Secure communication' ),
 					'test'  => 'ssl_support',
 				),
-				'scheduled_events'                      => array(
+				'scheduled_events'             => array(
 					'label' => __( 'Scheduled events' ),
 					'test'  => 'scheduled_events',
 				),
-				'http_requests'                         => array(
+				'http_requests'                => array(
 					'label' => __( 'HTTP Requests' ),
 					'test'  => 'http_requests',
 				),
-				'rest_availability'                     => array(
+				'rest_availability'            => array(
 					'label'     => __( 'REST API availability' ),
 					'test'      => 'rest_availability',
 					'skip_cron' => true,
 				),
-				'debug_enabled'                         => array(
+				'debug_enabled'                => array(
 					'label' => __( 'Debugging enabled' ),
 					'test'  => 'is_in_debug_mode',
 				),
-				'file_uploads'                          => array(
+				'file_uploads'                 => array(
 					'label' => __( 'File uploads' ),
 					'test'  => 'file_uploads',
 				),
-				'plugin_theme_auto_updates'             => array(
+				'plugin_theme_auto_updates'    => array(
 					'label' => __( 'Plugin and theme auto-updates' ),
 					'test'  => 'plugin_theme_auto_updates',
 				),
-				'update_temp_backup_writable'           => array(
+				'update_temp_backup_writable'  => array(
 					'label' => __( 'Updates temp-backup folder access' ),
 					'test'  => 'update_temp_backup_writable',
 				),
-				'get_test_available_updates_disk_space' => array(
+				'available_updates_disk_space' => array(
 					'label' => __( 'Available disk space' ),
 					'test'  => 'available_updates_disk_space',
 				),

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -1956,7 +1956,28 @@ class WP_Site_Health {
 		}
 		$wp_content = $wp_filesystem->wp_content_dir();
 
-		if ( $wp_filesystem->is_dir( "$wp_content/upgrade/temp-backup/plugins" ) && ! $wp_filesystem->is_writable( "$wp_content/upgrade/temp-backup/plugins" ) ) {
+		$upgrade_folder_exists      = $wp_filesystem->is_dir( "$wp_content/upgrade" );
+		$upgrade_folder_is_writable = $wp_filesystem->is_writable( "$wp_content/upgrade" );
+		$backup_folder_exists       = $wp_filesystem->is_dir( "$wp_content/upgrade/temp-backup" );
+		$backup_folder_is_writable  = $wp_filesystem->is_writable( "$wp_content/upgrade/temp-backup" );
+		$plugins_folder_exists      = $wp_filesystem->is_dir( "$wp_content/upgrade/temp-backup/plugins" );
+		$plugins_folder_is_writable = $wp_filesystem->is_writable( "$wp_content/upgrade/temp-backup/plugins" );
+		$themes_folder_exists       =  $wp_filesystem->is_dir( "$wp_content/upgrade/temp-backup/themes" );
+		$themes_folder_is_writable  = $wp_filesystem->is_writable( "$wp_content/upgrade/temp-backup/themes" );
+
+		if ( $plugins_folder_exists && ! $plugins_folder_is_writable && $themes_folder_exists && ! $themes_folder_is_writable ) {
+			$result['status']      = 'critical';
+			$result['label']       = __( 'Plugins and themes temp-backup folders exist but are not writable' );
+			$result['description'] = sprintf(
+				/* translators: %s: '<code>wp-content/upgrade/temp-backup/plugins</code>' */
+				'<p>' . __( 'The %1$s and %2$s folders exist but are not writable. These folders are used to improve the stability of plugin updates. Please make sure the server has write permissions to these folders.' ) . '</p>',
+				'<code>wp-content/upgrade/temp-backup/plugins</code>',
+				'<code>wp-content/upgrade/temp-backup/themes</code>'
+			);
+			return $result;
+		}
+
+		if ( $plugins_folder_exists && ! $plugins_folder_is_writable ) {
 			$result['status']      = 'critical';
 			$result['label']       = __( 'Plugins temp-backup folder exists but is not writable' );
 			$result['description'] = sprintf(
@@ -1967,7 +1988,7 @@ class WP_Site_Health {
 			return $result;
 		}
 
-		if ( $wp_filesystem->is_dir( "$wp_content/upgrade/temp-backup/themes" ) && ! $wp_filesystem->is_writable( "$wp_content/upgrade/temp-backup/themes" ) ) {
+		if ( $themes_folder_exists && ! $themes_folder_is_writable ) {
 			$result['status']      = 'critical';
 			$result['label']       = __( 'Themes temp-backup folder exists but is not writable' );
 			$result['description'] = sprintf(
@@ -1978,7 +1999,7 @@ class WP_Site_Health {
 			return $result;
 		}
 
-		if ( ( ! $wp_filesystem->is_dir( "$wp_content/upgrade/temp-backup/plugins" ) || ! $wp_filesystem->is_dir( "$wp_content/upgrade/temp-backup/themes" ) ) && $wp_filesystem->is_dir( "$wp_content/upgrade/temp-backup" ) && ! $wp_filesystem->is_writable( "$wp_content/upgrade/temp-backup" ) ) {
+		if ( ( ! $plugins_folder_exists || ! $themes_folder_exists ) && $backup_folder_exists && ! $backup_folder_is_writable ) {
 			$result['status']      = 'critical';
 			$result['label']       = __( 'The temp-backup folder exists but is not writable' );
 			$result['description'] = sprintf(
@@ -1989,7 +2010,7 @@ class WP_Site_Health {
 			return $result;
 		}
 
-		if ( ! $wp_filesystem->is_dir( "$wp_content/upgrade/temp-backup" ) && $wp_filesystem->is_dir( "$wp_content/upgrade" ) && ! $wp_filesystem->is_writable( "$wp_content/upgrade" ) ) {
+		if ( ! $backup_folder_exists && $upgrade_folder_exists && ! $upgrade_folder_is_writable ) {
 			$result['status']      = 'critical';
 			$result['label']       = __( 'The upgrade folder exists but is not writable' );
 			$result['description'] = sprintf(
@@ -2000,7 +2021,7 @@ class WP_Site_Health {
 			return $result;
 		}
 
-		if ( ! $wp_filesystem->is_dir( "$wp_content/upgrade" ) && ! $wp_filesystem->is_writable( $wp_content ) ) {
+		if ( ! $upgrade_folder_exists && ! $wp_filesystem->is_writable( $wp_content ) ) {
 			$result['status']      = 'critical';
 			$result['label']       = __( 'The upgrade folder can not be created' );
 			$result['description'] = sprintf(

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -1886,7 +1886,8 @@ class WP_Site_Health {
 	 * @return array The test results.
 	 */
 	public function get_test_available_updates_disk_space() {
-		$available_space       = (int) disk_free_space( WP_CONTENT_DIR . '/upgrade/' );
+		$disabled              = explode( ',', ini_get( 'disable_functions' ) );
+		$available_space       = ! in_array( 'disk_free_space', $disabled, true ) ? (int) disk_free_space( WP_CONTENT_DIR . '/upgrade/' ) : false;
 		$available_space_in_mb = $available_space / MB_IN_BYTES;
 
 		$result = array(

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -1879,27 +1879,27 @@ class WP_Site_Health {
 	}
 
 	/**
-	 * Test if plugin and theme updates rollbacks folders are writable or can be created.
+	 * Test if plugin and theme updates temp_backup folders are writable or can be created.
 	 *
 	 * @since 5.9.0
 	 *
 	 * @return array The test results.
 	 */
-	public function get_test_update_rollbacks_writable() {
+	public function get_test_update_temp_backup_writable() {
 		$result = array(
-			'label'       => __( 'Plugin and theme update rollbacks folder is writable' ),
+			'label'       => __( 'Plugin and theme update temp_backup folder is writable' ),
 			'status'      => 'good',
 			'badge'       => array(
 				'label' => __( 'Security' ),
 				'color' => 'blue',
 			),
 			'description' => sprintf(
-				/* Translators: %s: "wp-content/upgrade/rollback". */
+				/* Translators: %s: "wp-content/upgrade/temp_backup". */
 				'<p>' . __( 'The %s folder used to improve the stability of plugin and theme updates is writable.' ),
-				'<code>wp-content/upgrade/rollback</code>'
+				'<code>wp-content/upgrade/temp_backup</code>'
 			),
 			'actions'     => '',
-			'test'        => 'update_rollbacks_writable',
+			'test'        => 'update_temp_backup_writable',
 		);
 
 		global $wp_filesystem;
@@ -1911,42 +1911,42 @@ class WP_Site_Health {
 		}
 		$wp_content = $wp_filesystem->wp_content_dir();
 
-		if ( $wp_filesystem->is_dir( "$wp_content/upgrade/rollback/plugins" ) && ! $wp_filesystem->is_writable( "$wp_content/upgrade/rollback/plugins" ) ) {
-			$result['status'] = 'critical';
-			$result['label']  = __( 'Plugins rollback folder exists but is not writable' );
+		if ( $wp_filesystem->is_dir( "$wp_content/upgrade/temp_backup/plugins" ) && ! $wp_filesystem->is_writable( "$wp_content/upgrade/temp_backup/plugins" ) ) {
+			$result['status']      = 'critical';
+			$result['label']       = __( 'Plugins temp_backup folder exists but is not writable' );
 			$result['description'] = sprintf(
-				/* translators: %s: '<code>wp-content/upgrade/rollback/plugins</code>' */
+				/* translators: %s: '<code>wp-content/upgrade/temp_backup/plugins</code>' */
 				'<p>' . __( 'The %s folder exists but is not writable. This folder is used to improve the stability of plugin updates. Please make sure the server has write permissions to this folder.' ) . '</p>',
-				'<code>wp-content/upgrade/rollback/plugins</code>'
+				'<code>wp-content/upgrade/temp_backup/plugins</code>'
 			);
 			return $result;
 		}
 
-		if ( $wp_filesystem->is_dir( "$wp_content/upgrade/rollback/themes" ) && ! $wp_filesystem->is_writable( "$wp_content/upgrade/rollback/themes" ) ) {
-			$result['status'] = 'critical';
-			$result['label']  = __( 'Themes rollback folder exists but is not writable' );
+		if ( $wp_filesystem->is_dir( "$wp_content/upgrade/temp_backup/themes" ) && ! $wp_filesystem->is_writable( "$wp_content/upgrade/temp_backup/themes" ) ) {
+			$result['status']      = 'critical';
+			$result['label']       = __( 'Themes temp_backup folder exists but is not writable' );
 			$result['description'] = sprintf(
-				/* translators: %s: '<code>wp-content/upgrade/rollback/themes</code>' */
+				/* translators: %s: '<code>wp-content/upgrade/temp_backup/themes</code>' */
 				'<p>' . __( 'The %s folder exists but is not writable. This folder is used to improve the stability of theme updates. Please make sure the server has write permissions to this folder.' ) . '</p>',
-				'<code>wp-content/upgrade/rollback/themes</code>'
+				'<code>wp-content/upgrade/temp_backup/themes</code>'
 			);
 			return $result;
 		}
 
-		if ( ( ! $wp_filesystem->is_dir( "$wp_content/upgrade/rollback/plugins" ) || ! $wp_filesystem->is_dir( "$wp_content/upgrade/rollback/themes" ) ) && $wp_filesystem->is_dir( "$wp_content/upgrade/rollback" ) && ! $wp_filesystem->is_writable( "$wp_content/upgrade/rollback" ) ) {
-			$result['status'] = 'critical';
-			$result['label']  = __( 'The rollbacks folder exists but is not writable' );
+		if ( ( ! $wp_filesystem->is_dir( "$wp_content/upgrade/temp_backup/plugins" ) || ! $wp_filesystem->is_dir( "$wp_content/upgrade/temp_backup/themes" ) ) && $wp_filesystem->is_dir( "$wp_content/upgrade/temp_backup" ) && ! $wp_filesystem->is_writable( "$wp_content/upgrade/temp_backup" ) ) {
+			$result['status']      = 'critical';
+			$result['label']       = __( 'The temp_backup folder exists but is not writable' );
 			$result['description'] = sprintf(
-				/* translators: %s: '<code>wp-content/upgrade/rollback</code>' */
+				/* translators: %s: '<code>wp-content/upgrade/temp_backup</code>' */
 				'<p>' . __( 'The %s folder exists but is not writable. This folder is used to improve the stability of plugin and theme updates. Please make sure the server has write permissions to this folder.' ) . '</p>',
-				'<code>wp-content/upgrade/rollback</code>'
+				'<code>wp-content/upgrade/temp_backup</code>'
 			);
 			return $result;
 		}
 
-		if ( ! $wp_filesystem->is_dir( "$wp_content/upgrade/rollback" ) && $wp_filesystem->is_dir( "$wp_content/upgrade" ) && ! $wp_filesystem->is_writable( "$wp_content/upgrade" ) ) {
-			$result['status'] = 'critical';
-			$result['label']  = __( 'The upgrade folder exists but is not writable' );
+		if ( ! $wp_filesystem->is_dir( "$wp_content/upgrade/temp_backup" ) && $wp_filesystem->is_dir( "$wp_content/upgrade" ) && ! $wp_filesystem->is_writable( "$wp_content/upgrade" ) ) {
+			$result['status']      = 'critical';
+			$result['label']       = __( 'The upgrade folder exists but is not writable' );
 			$result['description'] = sprintf(
 				/* translators: %s: '<code>wp-content/upgrade</code>' */
 				'<p>' . __( 'The %s folder exists but is not writable. This folder is used to for plugin and theme updates. Please make sure the server has write permissions to this folder.' ) . '</p>',
@@ -1956,8 +1956,8 @@ class WP_Site_Health {
 		}
 
 		if ( ! $wp_filesystem->is_dir( "$wp_content/upgrade" ) && ! $wp_filesystem->is_writable( $wp_content ) ) {
-			$result['status'] = 'critical';
-			$result['label']  = __( 'The upgrade folder can not be created' );
+			$result['status']      = 'critical';
+			$result['label']       = __( 'The upgrade folder can not be created' );
 			$result['description'] = sprintf(
 				/* ranslators: %1$s: <code>wp-content/upgrade</code>. %2$s: <code>wp-content</code>. */
 				'<p>' . __( 'The %1$s folder does not exist, and the server does not have write permissions in %2$s to create it. This folder is used to for plugin and theme updates. Please make sure the server has write permissions in %2$s.' ) . '</p>',
@@ -2354,74 +2354,74 @@ class WP_Site_Health {
 	public static function get_tests() {
 		$tests = array(
 			'direct' => array(
-				'wordpress_version'         => array(
+				'wordpress_version'           => array(
 					'label' => __( 'WordPress Version' ),
 					'test'  => 'wordpress_version',
 				),
-				'plugin_version'            => array(
+				'plugin_version'              => array(
 					'label' => __( 'Plugin Versions' ),
 					'test'  => 'plugin_version',
 				),
-				'theme_version'             => array(
+				'theme_version'               => array(
 					'label' => __( 'Theme Versions' ),
 					'test'  => 'theme_version',
 				),
-				'php_version'               => array(
+				'php_version'                 => array(
 					'label' => __( 'PHP Version' ),
 					'test'  => 'php_version',
 				),
-				'php_extensions'            => array(
+				'php_extensions'              => array(
 					'label' => __( 'PHP Extensions' ),
 					'test'  => 'php_extensions',
 				),
-				'php_default_timezone'      => array(
+				'php_default_timezone'        => array(
 					'label' => __( 'PHP Default Timezone' ),
 					'test'  => 'php_default_timezone',
 				),
-				'php_sessions'              => array(
+				'php_sessions'                => array(
 					'label' => __( 'PHP Sessions' ),
 					'test'  => 'php_sessions',
 				),
-				'sql_server'                => array(
+				'sql_server'                  => array(
 					'label' => __( 'Database Server version' ),
 					'test'  => 'sql_server',
 				),
-				'utf8mb4_support'           => array(
+				'utf8mb4_support'             => array(
 					'label' => __( 'MySQL utf8mb4 support' ),
 					'test'  => 'utf8mb4_support',
 				),
-				'ssl_support'               => array(
+				'ssl_support'                 => array(
 					'label' => __( 'Secure communication' ),
 					'test'  => 'ssl_support',
 				),
-				'scheduled_events'          => array(
+				'scheduled_events'            => array(
 					'label' => __( 'Scheduled events' ),
 					'test'  => 'scheduled_events',
 				),
-				'http_requests'             => array(
+				'http_requests'               => array(
 					'label' => __( 'HTTP Requests' ),
 					'test'  => 'http_requests',
 				),
-				'rest_availability'         => array(
+				'rest_availability'           => array(
 					'label'     => __( 'REST API availability' ),
 					'test'      => 'rest_availability',
 					'skip_cron' => true,
 				),
-				'debug_enabled'             => array(
+				'debug_enabled'               => array(
 					'label' => __( 'Debugging enabled' ),
 					'test'  => 'is_in_debug_mode',
 				),
-				'file_uploads'              => array(
+				'file_uploads'                => array(
 					'label' => __( 'File uploads' ),
 					'test'  => 'file_uploads',
 				),
-				'plugin_theme_auto_updates' => array(
+				'plugin_theme_auto_updates'   => array(
 					'label' => __( 'Plugin and theme auto-updates' ),
 					'test'  => 'plugin_theme_auto_updates',
 				),
-				'update_rollbacks_writable' => array(
-					'label' => __( 'Updates rollback folder access' ),
-					'test'  => 'update_rollbacks_writable',
+				'update_temp_backup_writable' => array(
+					'label' => __( 'Updates temp_backup folder access' ),
+					'test'  => 'update_temp_backup_writable',
 				),
 			),
 			'async'  => array(

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -1932,9 +1932,13 @@ class WP_Site_Health {
 	 *
 	 * @since 5.9.0
 	 *
+	 * @global WP_Filesystem_Base $wp_filesystem WordPress filesystem subclass.
+	 *
 	 * @return array The test results.
 	 */
 	public function get_test_update_temp_backup_writable() {
+		global $wp_filesystem;
+
 		$result = array(
 			'label'       => __( 'Plugin and theme update temp-backup folder is writable' ),
 			'status'      => 'good',
@@ -1951,7 +1955,6 @@ class WP_Site_Health {
 			'test'        => 'update_temp_backup_writable',
 		);
 
-		global $wp_filesystem;
 		if ( ! $wp_filesystem ) {
 			if ( ! function_exists( 'WP_Filesystem' ) ) {
 				require_once wp_normalize_path( ABSPATH . '/wp-admin/includes/file.php' );

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -1883,7 +1883,7 @@ class WP_Site_Health {
 	}
 
 	/**
-	 * Test available disk-space for updates/upgrades.
+	 * Test available disk space for updates.
 	 *
 	 * @since 5.9.0
 	 *
@@ -1894,14 +1894,14 @@ class WP_Site_Health {
 		$available_space_in_mb = $available_space / MB_IN_BYTES;
 
 		$result = array(
-			'label'       => __( 'Disk-space available to safely perform updates' ),
+			'label'       => __( 'Disk space available to safely perform updates' ),
 			'status'      => 'good',
 			'badge'       => array(
 				'label' => __( 'Security' ),
 				'color' => 'blue',
 			),
 			'description' => sprintf(
-				/* Translators: %s: Available disk-space in MB or GB. */
+				/* translators: %s: Available disk space in MB or GB. */
 				'<p>' . __( '%s available disk space was detected, update routines can be performed safely.' ),
 				size_format( $available_space )
 			),
@@ -1909,13 +1909,13 @@ class WP_Site_Health {
 			'test'        => 'available_updates_disk_space',
 		);
 
-		if ( 100 > $available_space_in_mb ) {
-			$result['description'] = __( 'Available disk space is low, less than 100MB available.' );
+		if ( $available_space_in_mb < 100 ) {
+			$result['description'] = __( 'Available disk space is low, less than 100 MB available.' );
 			$result['status']      = 'recommended';
 		}
 
-		if ( 20 > $available_space_in_mb ) {
-			$result['description'] = __( 'Available disk space is critically low, less than 20MB available. Proceed with caution, updates may fail.' );
+		if ( $available_space_in_mb < 20 ) {
+			$result['description'] = __( 'Available disk space is critically low, less than 20 MB available. Proceed with caution, updates may fail.' );
 			$result['status']      = 'critical';
 		}
 
@@ -1947,7 +1947,7 @@ class WP_Site_Health {
 				'color' => 'blue',
 			),
 			'description' => sprintf(
-				/* Translators: %s: "wp-content/upgrade/temp-backup". */
+				/* translators: %s: wp-content/upgrade/temp-backup */
 				'<p>' . __( 'The %s folder used to improve the stability of plugin and theme updates is writable.' ),
 				'<code>wp-content/upgrade/temp-backup</code>'
 			),
@@ -1976,7 +1976,7 @@ class WP_Site_Health {
 			$result['status']      = 'critical';
 			$result['label']       = __( 'Plugins and themes temp-backup folders exist but are not writable' );
 			$result['description'] = sprintf(
-				/* translators: %s: '<code>wp-content/upgrade/temp-backup/plugins</code>' */
+				/* translators: 1: wp-content/upgrade/temp-backup/plugins, 2: wp-content/upgrade/temp-backup/themes. */
 				'<p>' . __( 'The %1$s and %2$s folders exist but are not writable. These folders are used to improve the stability of plugin updates. Please make sure the server has write permissions to these folders.' ) . '</p>',
 				'<code>wp-content/upgrade/temp-backup/plugins</code>',
 				'<code>wp-content/upgrade/temp-backup/themes</code>'
@@ -1988,7 +1988,7 @@ class WP_Site_Health {
 			$result['status']      = 'critical';
 			$result['label']       = __( 'Plugins temp-backup folder exists but is not writable' );
 			$result['description'] = sprintf(
-				/* translators: %s: '<code>wp-content/upgrade/temp-backup/plugins</code>' */
+				/* translators: %s: wp-content/upgrade/temp-backup/plugins */
 				'<p>' . __( 'The %s folder exists but is not writable. This folder is used to improve the stability of plugin updates. Please make sure the server has write permissions to this folder.' ) . '</p>',
 				'<code>wp-content/upgrade/temp-backup/plugins</code>'
 			);
@@ -1999,7 +1999,7 @@ class WP_Site_Health {
 			$result['status']      = 'critical';
 			$result['label']       = __( 'Themes temp-backup folder exists but is not writable' );
 			$result['description'] = sprintf(
-				/* translators: %s: '<code>wp-content/upgrade/temp-backup/themes</code>' */
+				/* translators: %s: wp-content/upgrade/temp-backup/themes */
 				'<p>' . __( 'The %s folder exists but is not writable. This folder is used to improve the stability of theme updates. Please make sure the server has write permissions to this folder.' ) . '</p>',
 				'<code>wp-content/upgrade/temp-backup/themes</code>'
 			);
@@ -2010,7 +2010,7 @@ class WP_Site_Health {
 			$result['status']      = 'critical';
 			$result['label']       = __( 'The temp-backup folder exists but is not writable' );
 			$result['description'] = sprintf(
-				/* translators: %s: '<code>wp-content/upgrade/temp-backup</code>' */
+				/* translators: %s: wp-content/upgrade/temp-backup */
 				'<p>' . __( 'The %s folder exists but is not writable. This folder is used to improve the stability of plugin and theme updates. Please make sure the server has write permissions to this folder.' ) . '</p>',
 				'<code>wp-content/upgrade/temp-backup</code>'
 			);
@@ -2021,8 +2021,8 @@ class WP_Site_Health {
 			$result['status']      = 'critical';
 			$result['label']       = __( 'The upgrade folder exists but is not writable' );
 			$result['description'] = sprintf(
-				/* translators: %s: '<code>wp-content/upgrade</code>' */
-				'<p>' . __( 'The %s folder exists but is not writable. This folder is used to for plugin and theme updates. Please make sure the server has write permissions to this folder.' ) . '</p>',
+				/* translators: %s: wp-content/upgrade */
+				'<p>' . __( 'The %s folder exists but is not writable. This folder is used for plugin and theme updates. Please make sure the server has write permissions to this folder.' ) . '</p>',
 				'<code>wp-content/upgrade</code>'
 			);
 			return $result;
@@ -2030,10 +2030,10 @@ class WP_Site_Health {
 
 		if ( ! $upgrade_folder_exists && ! $wp_filesystem->is_writable( $wp_content ) ) {
 			$result['status']      = 'critical';
-			$result['label']       = __( 'The upgrade folder can not be created' );
+			$result['label']       = __( 'The upgrade folder cannot be created' );
 			$result['description'] = sprintf(
-				/* translators: %1$s: <code>wp-content/upgrade</code>. %2$s: <code>wp-content</code>. */
-				'<p>' . __( 'The %1$s folder does not exist, and the server does not have write permissions in %2$s to create it. This folder is used to for plugin and theme updates. Please make sure the server has write permissions in %2$s.' ) . '</p>',
+				/* translators: 1: wp-content/upgrade, 2: wp-content. */
+				'<p>' . __( 'The %1$s folder does not exist, and the server does not have write permissions in %2$s to create it. This folder is used for plugin and theme updates. Please make sure the server has write permissions in %2$s.' ) . '</p>',
 				'<code>wp-content/upgrade</code>',
 				'<code>wp-content</code>'
 			);

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -1879,7 +1879,7 @@ class WP_Site_Health {
 	}
 
 	/**
-	 * Test if plugin and theme updates temp_backup folders are writable or can be created.
+	 * Test if plugin and theme updates temp-backup folders are writable or can be created.
 	 *
 	 * @since 5.9.0
 	 *
@@ -1887,16 +1887,16 @@ class WP_Site_Health {
 	 */
 	public function get_test_update_temp_backup_writable() {
 		$result = array(
-			'label'       => __( 'Plugin and theme update temp_backup folder is writable' ),
+			'label'       => __( 'Plugin and theme update temp-backup folder is writable' ),
 			'status'      => 'good',
 			'badge'       => array(
 				'label' => __( 'Security' ),
 				'color' => 'blue',
 			),
 			'description' => sprintf(
-				/* Translators: %s: "wp-content/upgrade/temp_backup". */
+				/* Translators: %s: "wp-content/upgrade/temp-backup". */
 				'<p>' . __( 'The %s folder used to improve the stability of plugin and theme updates is writable.' ),
-				'<code>wp-content/upgrade/temp_backup</code>'
+				'<code>wp-content/upgrade/temp-backup</code>'
 			),
 			'actions'     => '',
 			'test'        => 'update_temp_backup_writable',
@@ -1911,40 +1911,40 @@ class WP_Site_Health {
 		}
 		$wp_content = $wp_filesystem->wp_content_dir();
 
-		if ( $wp_filesystem->is_dir( "$wp_content/upgrade/temp_backup/plugins" ) && ! $wp_filesystem->is_writable( "$wp_content/upgrade/temp_backup/plugins" ) ) {
+		if ( $wp_filesystem->is_dir( "$wp_content/upgrade/temp-backup/plugins" ) && ! $wp_filesystem->is_writable( "$wp_content/upgrade/temp-backup/plugins" ) ) {
 			$result['status']      = 'critical';
-			$result['label']       = __( 'Plugins temp_backup folder exists but is not writable' );
+			$result['label']       = __( 'Plugins temp-backup folder exists but is not writable' );
 			$result['description'] = sprintf(
-				/* translators: %s: '<code>wp-content/upgrade/temp_backup/plugins</code>' */
+				/* translators: %s: '<code>wp-content/upgrade/temp-backup/plugins</code>' */
 				'<p>' . __( 'The %s folder exists but is not writable. This folder is used to improve the stability of plugin updates. Please make sure the server has write permissions to this folder.' ) . '</p>',
-				'<code>wp-content/upgrade/temp_backup/plugins</code>'
+				'<code>wp-content/upgrade/temp-backup/plugins</code>'
 			);
 			return $result;
 		}
 
-		if ( $wp_filesystem->is_dir( "$wp_content/upgrade/temp_backup/themes" ) && ! $wp_filesystem->is_writable( "$wp_content/upgrade/temp_backup/themes" ) ) {
+		if ( $wp_filesystem->is_dir( "$wp_content/upgrade/temp-backup/themes" ) && ! $wp_filesystem->is_writable( "$wp_content/upgrade/temp-backup/themes" ) ) {
 			$result['status']      = 'critical';
-			$result['label']       = __( 'Themes temp_backup folder exists but is not writable' );
+			$result['label']       = __( 'Themes temp-backup folder exists but is not writable' );
 			$result['description'] = sprintf(
-				/* translators: %s: '<code>wp-content/upgrade/temp_backup/themes</code>' */
+				/* translators: %s: '<code>wp-content/upgrade/temp-backup/themes</code>' */
 				'<p>' . __( 'The %s folder exists but is not writable. This folder is used to improve the stability of theme updates. Please make sure the server has write permissions to this folder.' ) . '</p>',
-				'<code>wp-content/upgrade/temp_backup/themes</code>'
+				'<code>wp-content/upgrade/temp-backup/themes</code>'
 			);
 			return $result;
 		}
 
-		if ( ( ! $wp_filesystem->is_dir( "$wp_content/upgrade/temp_backup/plugins" ) || ! $wp_filesystem->is_dir( "$wp_content/upgrade/temp_backup/themes" ) ) && $wp_filesystem->is_dir( "$wp_content/upgrade/temp_backup" ) && ! $wp_filesystem->is_writable( "$wp_content/upgrade/temp_backup" ) ) {
+		if ( ( ! $wp_filesystem->is_dir( "$wp_content/upgrade/temp-backup/plugins" ) || ! $wp_filesystem->is_dir( "$wp_content/upgrade/temp-backup/themes" ) ) && $wp_filesystem->is_dir( "$wp_content/upgrade/temp-backup" ) && ! $wp_filesystem->is_writable( "$wp_content/upgrade/temp-backup" ) ) {
 			$result['status']      = 'critical';
-			$result['label']       = __( 'The temp_backup folder exists but is not writable' );
+			$result['label']       = __( 'The temp-backup folder exists but is not writable' );
 			$result['description'] = sprintf(
-				/* translators: %s: '<code>wp-content/upgrade/temp_backup</code>' */
+				/* translators: %s: '<code>wp-content/upgrade/temp-backup</code>' */
 				'<p>' . __( 'The %s folder exists but is not writable. This folder is used to improve the stability of plugin and theme updates. Please make sure the server has write permissions to this folder.' ) . '</p>',
-				'<code>wp-content/upgrade/temp_backup</code>'
+				'<code>wp-content/upgrade/temp-backup</code>'
 			);
 			return $result;
 		}
 
-		if ( ! $wp_filesystem->is_dir( "$wp_content/upgrade/temp_backup" ) && $wp_filesystem->is_dir( "$wp_content/upgrade" ) && ! $wp_filesystem->is_writable( "$wp_content/upgrade" ) ) {
+		if ( ! $wp_filesystem->is_dir( "$wp_content/upgrade/temp-backup" ) && $wp_filesystem->is_dir( "$wp_content/upgrade" ) && ! $wp_filesystem->is_writable( "$wp_content/upgrade" ) ) {
 			$result['status']      = 'critical';
 			$result['label']       = __( 'The upgrade folder exists but is not writable' );
 			$result['description'] = sprintf(
@@ -2420,7 +2420,7 @@ class WP_Site_Health {
 					'test'  => 'plugin_theme_auto_updates',
 				),
 				'update_temp_backup_writable' => array(
-					'label' => __( 'Updates temp_backup folder access' ),
+					'label' => __( 'Updates temp-backup folder access' ),
 					'test'  => 'update_temp_backup_writable',
 				),
 			),

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -1940,7 +1940,11 @@ class WP_Site_Health {
 		global $wp_filesystem;
 
 		$result = array(
-			'label'       => __( 'Plugin and theme update temp-backup folder is writable' ),
+			'label'       => sprintf(
+				/* translators: %s: temp-backup */
+				__( 'Plugin and theme update %s folder is writable' ),
+				'temp-backup'
+			),
 			'status'      => 'good',
 			'badge'       => array(
 				'label' => __( 'Security' ),
@@ -1967,6 +1971,7 @@ class WP_Site_Health {
 		$upgrade_folder_is_writable = $wp_filesystem->is_writable( "$wp_content/upgrade" );
 		$backup_folder_exists       = $wp_filesystem->is_dir( "$wp_content/upgrade/temp-backup" );
 		$backup_folder_is_writable  = $wp_filesystem->is_writable( "$wp_content/upgrade/temp-backup" );
+
 		$plugins_folder_exists      = $wp_filesystem->is_dir( "$wp_content/upgrade/temp-backup/plugins" );
 		$plugins_folder_is_writable = $wp_filesystem->is_writable( "$wp_content/upgrade/temp-backup/plugins" );
 		$themes_folder_exists       = $wp_filesystem->is_dir( "$wp_content/upgrade/temp-backup/themes" );
@@ -1974,7 +1979,11 @@ class WP_Site_Health {
 
 		if ( $plugins_folder_exists && ! $plugins_folder_is_writable && $themes_folder_exists && ! $themes_folder_is_writable ) {
 			$result['status']      = 'critical';
-			$result['label']       = __( 'Plugins and themes temp-backup folders exist but are not writable' );
+			$result['label']       = sprintf(
+				/* translators: %s: temp-backup */
+				__( 'Plugins and themes %s folders exist but are not writable' ),
+				'temp-backup'
+			);
 			$result['description'] = sprintf(
 				/* translators: 1: wp-content/upgrade/temp-backup/plugins, 2: wp-content/upgrade/temp-backup/themes. */
 				'<p>' . __( 'The %1$s and %2$s folders exist but are not writable. These folders are used to improve the stability of plugin updates. Please make sure the server has write permissions to these folders.' ) . '</p>',
@@ -1986,7 +1995,11 @@ class WP_Site_Health {
 
 		if ( $plugins_folder_exists && ! $plugins_folder_is_writable ) {
 			$result['status']      = 'critical';
-			$result['label']       = __( 'Plugins temp-backup folder exists but is not writable' );
+			$result['label']       = sprintf(
+				/* translators: %s: temp-backup */
+				__( 'Plugins %s folder exists but is not writable' ),
+				'temp-backup'
+			);
 			$result['description'] = sprintf(
 				/* translators: %s: wp-content/upgrade/temp-backup/plugins */
 				'<p>' . __( 'The %s folder exists but is not writable. This folder is used to improve the stability of plugin updates. Please make sure the server has write permissions to this folder.' ) . '</p>',
@@ -1997,7 +2010,11 @@ class WP_Site_Health {
 
 		if ( $themes_folder_exists && ! $themes_folder_is_writable ) {
 			$result['status']      = 'critical';
-			$result['label']       = __( 'Themes temp-backup folder exists but is not writable' );
+			$result['label']       = sprintf(
+				/* translators: %s: temp-backup */
+				__( 'Themes %s folder exists but is not writable' ),
+				'temp-backup'
+			);
 			$result['description'] = sprintf(
 				/* translators: %s: wp-content/upgrade/temp-backup/themes */
 				'<p>' . __( 'The %s folder exists but is not writable. This folder is used to improve the stability of theme updates. Please make sure the server has write permissions to this folder.' ) . '</p>',
@@ -2008,7 +2025,11 @@ class WP_Site_Health {
 
 		if ( ( ! $plugins_folder_exists || ! $themes_folder_exists ) && $backup_folder_exists && ! $backup_folder_is_writable ) {
 			$result['status']      = 'critical';
-			$result['label']       = __( 'The temp-backup folder exists but is not writable' );
+			$result['label']       = sprintf(
+				/* translators: %s: temp-backup */
+				__( 'The %s folder exists but is not writable' ),
+				'temp-backup'
+			);
 			$result['description'] = sprintf(
 				/* translators: %s: wp-content/upgrade/temp-backup */
 				'<p>' . __( 'The %s folder exists but is not writable. This folder is used to improve the stability of plugin and theme updates. Please make sure the server has write permissions to this folder.' ) . '</p>',
@@ -2019,7 +2040,11 @@ class WP_Site_Health {
 
 		if ( ! $backup_folder_exists && $upgrade_folder_exists && ! $upgrade_folder_is_writable ) {
 			$result['status']      = 'critical';
-			$result['label']       = __( 'The upgrade folder exists but is not writable' );
+			$result['label']       = sprintf(
+				/* translators: %s: upgrade */
+				__( 'The %s folder exists but is not writable' ),
+				'upgrade'
+			);
 			$result['description'] = sprintf(
 				/* translators: %s: wp-content/upgrade */
 				'<p>' . __( 'The %s folder exists but is not writable. This folder is used for plugin and theme updates. Please make sure the server has write permissions to this folder.' ) . '</p>',
@@ -2030,7 +2055,11 @@ class WP_Site_Health {
 
 		if ( ! $upgrade_folder_exists && ! $wp_filesystem->is_writable( $wp_content ) ) {
 			$result['status']      = 'critical';
-			$result['label']       = __( 'The upgrade folder cannot be created' );
+			$result['label']       = sprintf(
+				/* translators: %s: upgrade */
+				__( 'The %s folder cannot be created' ),
+				'upgrade'
+			);
 			$result['description'] = sprintf(
 				/* translators: 1: wp-content/upgrade, 2: wp-content. */
 				'<p>' . __( 'The %1$s folder does not exist, and the server does not have write permissions in %2$s to create it. This folder is used for plugin and theme updates. Please make sure the server has write permissions in %2$s.' ) . '</p>',
@@ -2493,7 +2522,8 @@ class WP_Site_Health {
 					'test'  => 'plugin_theme_auto_updates',
 				),
 				'update_temp_backup_writable'  => array(
-					'label' => __( 'Updates temp-backup folder access' ),
+					/* translators: %s: temp-backup */
+					'label' => sprintf( __( 'Updates %s folder access' ), 'temp-backup' ),
 					'test'  => 'update_temp_backup_writable',
 				),
 				'available_updates_disk_space' => array(

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -1886,8 +1886,7 @@ class WP_Site_Health {
 	 * @return array The test results.
 	 */
 	public function get_test_available_updates_disk_space() {
-		$disabled              = explode( ',', ini_get( 'disable_functions' ) );
-		$available_space       = ! in_array( 'disk_free_space', $disabled, true ) ? (int) disk_free_space( WP_CONTENT_DIR . '/upgrade/' ) : false;
+		$available_space       = function_exists( 'disk_free_space' ) ? (int) @disk_free_space( WP_CONTENT_DIR . '/upgrade/' ) : false;
 		$available_space_in_mb = $available_space / MB_IN_BYTES;
 
 		$result = array(

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -1928,7 +1928,7 @@ class WP_Site_Health {
 	}
 
 	/**
-	 * Test if plugin and theme updates temp-backup folders are writable or can be created.
+	 * Test if plugin and theme updates temp-backup directories are writable or can be created.
 	 *
 	 * @since 5.9.0
 	 *
@@ -1942,7 +1942,7 @@ class WP_Site_Health {
 		$result = array(
 			'label'       => sprintf(
 				/* translators: %s: temp-backup */
-				__( 'Plugin and theme update %s folder is writable' ),
+				__( 'Plugin and theme update %s directory is writable' ),
 				'temp-backup'
 			),
 			'status'      => 'good',
@@ -1952,7 +1952,7 @@ class WP_Site_Health {
 			),
 			'description' => sprintf(
 				/* translators: %s: wp-content/upgrade/temp-backup */
-				'<p>' . __( 'The %s folder used to improve the stability of plugin and theme updates is writable.' ),
+				'<p>' . __( 'The %s directory used to improve the stability of plugin and theme updates is writable.' ),
 				'<code>wp-content/upgrade/temp-backup</code>'
 			),
 			'actions'     => '',
@@ -1967,102 +1967,102 @@ class WP_Site_Health {
 		}
 		$wp_content = $wp_filesystem->wp_content_dir();
 
-		$upgrade_folder_exists      = $wp_filesystem->is_dir( "$wp_content/upgrade" );
-		$upgrade_folder_is_writable = $wp_filesystem->is_writable( "$wp_content/upgrade" );
-		$backup_folder_exists       = $wp_filesystem->is_dir( "$wp_content/upgrade/temp-backup" );
-		$backup_folder_is_writable  = $wp_filesystem->is_writable( "$wp_content/upgrade/temp-backup" );
+		$upgrade_dir_exists      = $wp_filesystem->is_dir( "$wp_content/upgrade" );
+		$upgrade_dir_is_writable = $wp_filesystem->is_writable( "$wp_content/upgrade" );
+		$backup_dir_exists       = $wp_filesystem->is_dir( "$wp_content/upgrade/temp-backup" );
+		$backup_dir_is_writable  = $wp_filesystem->is_writable( "$wp_content/upgrade/temp-backup" );
 
-		$plugins_folder_exists      = $wp_filesystem->is_dir( "$wp_content/upgrade/temp-backup/plugins" );
-		$plugins_folder_is_writable = $wp_filesystem->is_writable( "$wp_content/upgrade/temp-backup/plugins" );
-		$themes_folder_exists       = $wp_filesystem->is_dir( "$wp_content/upgrade/temp-backup/themes" );
-		$themes_folder_is_writable  = $wp_filesystem->is_writable( "$wp_content/upgrade/temp-backup/themes" );
+		$plugins_dir_exists      = $wp_filesystem->is_dir( "$wp_content/upgrade/temp-backup/plugins" );
+		$plugins_dir_is_writable = $wp_filesystem->is_writable( "$wp_content/upgrade/temp-backup/plugins" );
+		$themes_dir_exists       = $wp_filesystem->is_dir( "$wp_content/upgrade/temp-backup/themes" );
+		$themes_dir_is_writable  = $wp_filesystem->is_writable( "$wp_content/upgrade/temp-backup/themes" );
 
-		if ( $plugins_folder_exists && ! $plugins_folder_is_writable && $themes_folder_exists && ! $themes_folder_is_writable ) {
+		if ( $plugins_dir_exists && ! $plugins_dir_is_writable && $themes_dir_exists && ! $themes_dir_is_writable ) {
 			$result['status']      = 'critical';
 			$result['label']       = sprintf(
 				/* translators: %s: temp-backup */
-				__( 'Plugins and themes %s folders exist but are not writable' ),
+				__( 'Plugins and themes %s directories exist but are not writable' ),
 				'temp-backup'
 			);
 			$result['description'] = sprintf(
 				/* translators: 1: wp-content/upgrade/temp-backup/plugins, 2: wp-content/upgrade/temp-backup/themes. */
-				'<p>' . __( 'The %1$s and %2$s folders exist but are not writable. These folders are used to improve the stability of plugin updates. Please make sure the server has write permissions to these folders.' ) . '</p>',
+				'<p>' . __( 'The %1$s and %2$s directories exist but are not writable. These directories are used to improve the stability of plugin updates. Please make sure the server has write permissions to these directories.' ) . '</p>',
 				'<code>wp-content/upgrade/temp-backup/plugins</code>',
 				'<code>wp-content/upgrade/temp-backup/themes</code>'
 			);
 			return $result;
 		}
 
-		if ( $plugins_folder_exists && ! $plugins_folder_is_writable ) {
+		if ( $plugins_dir_exists && ! $plugins_dir_is_writable ) {
 			$result['status']      = 'critical';
 			$result['label']       = sprintf(
 				/* translators: %s: temp-backup */
-				__( 'Plugins %s folder exists but is not writable' ),
+				__( 'Plugins %s directory exists but is not writable' ),
 				'temp-backup'
 			);
 			$result['description'] = sprintf(
 				/* translators: %s: wp-content/upgrade/temp-backup/plugins */
-				'<p>' . __( 'The %s folder exists but is not writable. This folder is used to improve the stability of plugin updates. Please make sure the server has write permissions to this folder.' ) . '</p>',
+				'<p>' . __( 'The %s directory exists but is not writable. This directory is used to improve the stability of plugin updates. Please make sure the server has write permissions to this directory.' ) . '</p>',
 				'<code>wp-content/upgrade/temp-backup/plugins</code>'
 			);
 			return $result;
 		}
 
-		if ( $themes_folder_exists && ! $themes_folder_is_writable ) {
+		if ( $themes_dir_exists && ! $themes_dir_is_writable ) {
 			$result['status']      = 'critical';
 			$result['label']       = sprintf(
 				/* translators: %s: temp-backup */
-				__( 'Themes %s folder exists but is not writable' ),
+				__( 'Themes %s directory exists but is not writable' ),
 				'temp-backup'
 			);
 			$result['description'] = sprintf(
 				/* translators: %s: wp-content/upgrade/temp-backup/themes */
-				'<p>' . __( 'The %s folder exists but is not writable. This folder is used to improve the stability of theme updates. Please make sure the server has write permissions to this folder.' ) . '</p>',
+				'<p>' . __( 'The %s directory exists but is not writable. This directory is used to improve the stability of theme updates. Please make sure the server has write permissions to this directory.' ) . '</p>',
 				'<code>wp-content/upgrade/temp-backup/themes</code>'
 			);
 			return $result;
 		}
 
-		if ( ( ! $plugins_folder_exists || ! $themes_folder_exists ) && $backup_folder_exists && ! $backup_folder_is_writable ) {
+		if ( ( ! $plugins_dir_exists || ! $themes_dir_exists ) && $backup_dir_exists && ! $backup_dir_is_writable ) {
 			$result['status']      = 'critical';
 			$result['label']       = sprintf(
 				/* translators: %s: temp-backup */
-				__( 'The %s folder exists but is not writable' ),
+				__( 'The %s directory exists but is not writable' ),
 				'temp-backup'
 			);
 			$result['description'] = sprintf(
 				/* translators: %s: wp-content/upgrade/temp-backup */
-				'<p>' . __( 'The %s folder exists but is not writable. This folder is used to improve the stability of plugin and theme updates. Please make sure the server has write permissions to this folder.' ) . '</p>',
+				'<p>' . __( 'The %s directory exists but is not writable. This directory is used to improve the stability of plugin and theme updates. Please make sure the server has write permissions to this directory.' ) . '</p>',
 				'<code>wp-content/upgrade/temp-backup</code>'
 			);
 			return $result;
 		}
 
-		if ( ! $backup_folder_exists && $upgrade_folder_exists && ! $upgrade_folder_is_writable ) {
+		if ( ! $backup_dir_exists && $upgrade_dir_exists && ! $upgrade_dir_is_writable ) {
 			$result['status']      = 'critical';
 			$result['label']       = sprintf(
 				/* translators: %s: upgrade */
-				__( 'The %s folder exists but is not writable' ),
+				__( 'The %s directory exists but is not writable' ),
 				'upgrade'
 			);
 			$result['description'] = sprintf(
 				/* translators: %s: wp-content/upgrade */
-				'<p>' . __( 'The %s folder exists but is not writable. This folder is used for plugin and theme updates. Please make sure the server has write permissions to this folder.' ) . '</p>',
+				'<p>' . __( 'The %s directory exists but is not writable. This directory is used for plugin and theme updates. Please make sure the server has write permissions to this directory.' ) . '</p>',
 				'<code>wp-content/upgrade</code>'
 			);
 			return $result;
 		}
 
-		if ( ! $upgrade_folder_exists && ! $wp_filesystem->is_writable( $wp_content ) ) {
+		if ( ! $upgrade_dir_exists && ! $wp_filesystem->is_writable( $wp_content ) ) {
 			$result['status']      = 'critical';
 			$result['label']       = sprintf(
 				/* translators: %s: upgrade */
-				__( 'The %s folder cannot be created' ),
+				__( 'The %s directory cannot be created' ),
 				'upgrade'
 			);
 			$result['description'] = sprintf(
 				/* translators: 1: wp-content/upgrade, 2: wp-content. */
-				'<p>' . __( 'The %1$s folder does not exist, and the server does not have write permissions in %2$s to create it. This folder is used for plugin and theme updates. Please make sure the server has write permissions in %2$s.' ) . '</p>',
+				'<p>' . __( 'The %1$s directory does not exist, and the server does not have write permissions in %2$s to create it. This directory is used for plugin and theme updates. Please make sure the server has write permissions in %2$s.' ) . '</p>',
 				'<code>wp-content/upgrade</code>',
 				'<code>wp-content</code>'
 			);
@@ -2523,7 +2523,7 @@ class WP_Site_Health {
 				),
 				'update_temp_backup_writable'  => array(
 					/* translators: %s: temp-backup */
-					'label' => sprintf( __( 'Updates %s folder access' ), 'temp-backup' ),
+					'label' => sprintf( __( 'Updates %s directory access' ), 'temp-backup' ),
 					'test'  => 'update_temp_backup_writable',
 				),
 				'available_updates_disk_space' => array(

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -1879,6 +1879,56 @@ class WP_Site_Health {
 	}
 
 	/**
+	 * Test available disk-space for updates/upgrades.
+	 *
+	 * @since 5.9.0
+	 *
+	 * @return array The test results.
+	 */
+	public function get_test_available_updates_disk_space() {
+		$available_space       = (int) disk_free_space( WP_CONTENT_DIR . '/upgrade/' );
+		$available_space_in_mb = round( $available_space / MB_IN_BYTES, 2 );
+		$available_space_in_gb = round( $available_space / GB_IN_BYTES, 2 );
+		$available_space_readable = $available_space_in_mb . ' MB';
+		if ( 1024 < $available_space_in_mb ) {
+			$available_space_readable = $available_space_in_gb . ' GB';
+		}
+
+		$result = array(
+			'label'       => __( 'Disk-space available to safely perform updates' ),
+			'status'      => 'good',
+			'badge'       => array(
+				'label' => __( 'Security' ),
+				'color' => 'blue',
+			),
+			'description' => sprintf(
+				/* Translators: %s: Available disk-space in MB or GB. */
+				'<p>' . __( '%s available disk space was detected, update routines can be performed safely.' ),
+				$available_space_readable
+			),
+			'actions'     => '',
+			'test'        => 'available_updates_disk_space',
+		);
+
+		if ( 100 > $available_space_in_mb ) {
+			$result['description'] = __( 'Available disk space is low, less than 100MB available.' );
+			$result['status']      = 'recommended';
+		}
+
+		if ( 20 > $available_space_in_mb ) {
+			$result['description'] = __( 'Available disk space is critically low, less than 20MB available. Proceed with caution, updates may fail.' );
+			$result['status']      = 'critical';
+		}
+
+		if ( ! $available_space ) {
+			$result['description'] = __( 'Could not determine available disk space for updates.' );
+			$result['status']      = 'recommended';
+		}
+
+		return $result;
+	}
+
+	/**
 	 * Test if plugin and theme updates temp-backup folders are writable or can be created.
 	 *
 	 * @since 5.9.0
@@ -2422,6 +2472,10 @@ class WP_Site_Health {
 				'update_temp_backup_writable' => array(
 					'label' => __( 'Updates temp-backup folder access' ),
 					'test'  => 'update_temp_backup_writable',
+				),
+				'get_test_available_updates_disk_space'		 => array(
+					'label' => __( 'Available disk space' ),
+					'test'  => 'available_updates_disk_space',
 				),
 			),
 			'async'  => array(

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -1056,10 +1056,13 @@ class WP_Upgrader {
 	 */
 	public function delete_rollback( $args ) {
 		global $wp_filesystem;
-		if ( empty( $args['slug'] ) || empty( $args['src'] ) || empty( $args['dest'] ) ) {
+		if ( empty( $args['slug'] ) || empty( $args['subfolder'] ) ) {
 			return false;
 		}
-		return $wp_filesystem->delete( $wp_filesystem->wp_content_dir() . '/' . $args['dest'] . '/' . $args['slug'], true );
+		return $wp_filesystem->delete(
+			$wp_filesystem->wp_content_dir() . "upgrade/rollback/{$args['subfolder']}/{$args['slug']}",
+			true
+		);
 	}
 }
 

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -1042,10 +1042,8 @@ class WP_Upgrader {
 		if ( $wp_filesystem->is_dir( $src ) ) {
 
 			// Cleanup.
-			if ( $wp_filesystem->is_dir( $dest ) ) {
-				if ( ! $wp_filesystem->delete( $dest, true ) ) {
-					return new WP_Error( 'fs_rollback_delete', $this->strings['rollback_restore_failed'] );
-				}
+			if ( $wp_filesystem->is_dir( $dest ) && ! $wp_filesystem->delete( $dest, true ) ) {
+				return new WP_Error( 'fs_rollback_delete', $this->strings['rollback_restore_failed'] );
 			}
 
 			// Move it.

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -829,6 +829,9 @@ class WP_Upgrader {
 
 		$this->skin->after();
 
+		// Cleanup backup kept in the rollbacks folder.
+		$this->delete_rollback( $options['hook_extra'] );
+
 		if ( ! $options['is_multi'] ) {
 
 			/**
@@ -1032,6 +1035,31 @@ class WP_Upgrader {
 			}
 		}
 		return true;
+	}
+	/**
+	 * Deletes a rollback.
+	 *
+ 	 * @since 5.9.0
+	 *
+	 * @global WP_Filesystem_Base $wp_filesystem WordPress filesystem subclass.
+	 *
+	 * @param array $hook_extra Array of data for plugin/theme being updated.
+	 *
+	 * @return bool|WP_Error
+	 */
+	public function delete_rollback( $hook_extra ) {
+		global $wp_filesystem;
+		if ( isset( $hook_extra['plugin'] ) || isset( $hook_extra['theme'] ) ) {
+			$rollback_dir       = $wp_filesystem->wp_content_dir() . 'upgrade/rollback/';
+			$rollback_subfolder = isset( $hook_extra['plugin'] ) ? 'plugins' : 'themes';
+			$slug               = isset( $hook_extra['plugin'] ) ? dirname( $hook_extra['plugin'] ) : $hook_extra['theme'];
+			$src                = "$rollback_dir/$rollback_subfolder/$slug";
+
+			if ( $wp_filesystem->is_dir( $src ) ) {
+				return $wp_filesystem->delete( $src, true );
+			}
+		}
+		return false;
 	}
 }
 

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -979,11 +979,11 @@ class WP_Upgrader {
 			return $response;
 		}
 
-		if ( isset( $hook_extra['plugin'] ) || isset( $hook_extra['theme'] ) ) {
+		if ( $this->get_rollback_param( 'type', $hook_extra ) && ! empty( $hook_extra[ $this->get_rollback_param( 'type', $hook_extra ) ] ) ) {
 			$rollback_dir       = $wp_filesystem->wp_content_dir() . 'upgrade/rollback/';
-			$rollback_subfolder = isset( $hook_extra['plugin'] ) ? 'plugins' : 'themes';
-			$slug               = isset( $hook_extra['plugin'] ) ? dirname( $hook_extra['plugin'] ) : $hook_extra['theme'];
-			$src                = isset( $hook_extra['plugin'] ) ? $wp_filesystem->wp_plugins_dir() . '/' . $slug : get_theme_root() . '/' . $slug;
+			$rollback_subfolder = $this->get_rollback_param( 'rollbacks_subfolder', $hook_extra );
+			$slug               = $this->get_rollback_param( 'slug', $hook_extra );
+			$src                = $this->get_rollback_param( 'destination_dir', $hook_extra ) . '/' . $slug;
 
 			// Create the rollbacks dir if it doesn't exist.
 			if ( ! $wp_filesystem->mkdir( $rollback_dir ) || ! $wp_filesystem->mkdir( "$rollback_dir/$rollback_subfolder/" ) ) {
@@ -1012,11 +1012,11 @@ class WP_Upgrader {
 	 */
 	public function restore_rollback( $hook_extra ) {
 		global $wp_filesystem;
-		if ( isset( $hook_extra['plugin'] ) || isset( $hook_extra['theme'] ) ) {
+		if ( $this->get_rollback_param( 'type', $hook_extra ) && ! empty( $hook_extra[ $this->get_rollback_param( 'type', $hook_extra ) ] ) ) {
 			$rollback_dir       = $wp_filesystem->wp_content_dir() . 'upgrade/rollback/';
-			$rollback_subfolder = isset( $hook_extra['plugin'] ) ? 'plugins' : 'themes';
-			$slug               = isset( $hook_extra['plugin'] ) ? dirname( $hook_extra['plugin'] ) : $hook_extra['theme'];
-			$destination_dir    = isset( $hook_extra['plugin'] ) ? $wp_filesystem->wp_plugins_dir() . '/' . $slug : get_theme_root() . '/' . $slug;
+			$rollback_subfolder = $this->get_rollback_param( 'rollbacks_subfolder', $hook_extra );
+			$slug               = $this->get_rollback_param( 'slug', $hook_extra );
+			$destination_dir    = $this->get_rollback_param( 'destination_dir', $hook_extra ) . '/' . $slug;
 			$src                = "$rollback_dir/$rollback_subfolder/$slug";
 
 			if ( $wp_filesystem->is_dir( $src ) ) {
@@ -1049,17 +1049,29 @@ class WP_Upgrader {
 	 */
 	public function delete_rollback( $hook_extra ) {
 		global $wp_filesystem;
-		if ( isset( $hook_extra['plugin'] ) || isset( $hook_extra['theme'] ) ) {
+		if ( $this->get_rollback_param( 'type', $hook_extra ) && ! empty( $hook_extra[ $this->get_rollback_param( 'type', $hook_extra ) ] ) ) {
 			$rollback_dir       = $wp_filesystem->wp_content_dir() . 'upgrade/rollback/';
-			$rollback_subfolder = isset( $hook_extra['plugin'] ) ? 'plugins' : 'themes';
-			$slug               = isset( $hook_extra['plugin'] ) ? dirname( $hook_extra['plugin'] ) : $hook_extra['theme'];
-			$src                = "$rollback_dir/$rollback_subfolder/$slug";
+			$rollback_subfolder = $this->get_rollback_param( 'rollbacks_subfolder', $hook_extra );
+			$slug               = $this->get_rollback_param( 'slug', $hook_extra );
 
-			if ( $wp_filesystem->is_dir( $src ) ) {
-				return $wp_filesystem->delete( $src, true );
-			}
+			return $wp_filesystem->delete( "$rollback_dir/$rollback_subfolder/$slug", true );
 		}
 		return false;
+	}
+
+	/**
+	 * Get a rollback param.
+	 * Extend this method in child classes to implement rollbacks.
+	 *
+	 * @since 5.9.0
+	 *
+	 * @param string $param      The parameter to get.
+	 * @param array  $hook_extra Extra params.
+	 *
+	 * @return string|null
+	 */
+	public function get_rollback_param( $param, $hook_extra = array() ) {
+		return null;
 	}
 }
 

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -1046,7 +1046,7 @@ class WP_Upgrader {
 	/**
 	 * Deletes a rollback.
 	 *
- 	 * @since 5.9.0
+	 * @since 5.9.0
 	 *
 	 * @global WP_Filesystem_Base $wp_filesystem WordPress filesystem subclass.
 	 *
@@ -1059,7 +1059,7 @@ class WP_Upgrader {
 		if ( empty( $args['slug'] ) || empty( $args['src'] ) || empty( $args['dest'] ) ) {
 			return false;
 		}
-		return $wp_filesystem->delete(  $wp_filesystem->wp_content_dir() . '/' . $args['dest'] . '/' . $args['slug'], true );
+		return $wp_filesystem->delete( $wp_filesystem->wp_content_dir() . '/' . $args['dest'] . '/' . $args['slug'], true );
 	}
 }
 

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -147,7 +147,6 @@ class WP_Upgrader {
 	 * Schedule cleanup of the temp-backup folder.
 	 *
 	 * @since 5.9.0
-	 *
 	 */
 	protected function schedule_temp_backup_cleanup() {
 		wp_schedule_event( time(), 'weekly', 'delete_temp_updater_backups' );

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -978,12 +978,12 @@ class WP_Upgrader {
 	 *
 	 * @global WP_Filesystem_Base $wp_filesystem WordPress filesystem subclass.
 	 *
-	 * @param array $args Array of data for the rollback. Must include a slug, the source and subfolder.
+	 * @param array $args Array of data for the rollback. Must include a slug, the source and directory.
 	 *
 	 * @return bool|WP_Error
 	 */
 	public function move_to_rollbacks_dir( $args ) {
-		if ( empty( $args['slug'] ) || empty( $args['src'] ) || empty( $args['subfolder'] ) ) {
+		if ( empty( $args['slug'] ) || empty( $args['src'] ) || empty( $args['dir'] ) ) {
 			return false;
 		}
 		global $wp_filesystem;
@@ -996,15 +996,15 @@ class WP_Upgrader {
 				! $wp_filesystem->mkdir( $dest_folder )
 			) ||
 			(
-				! $wp_filesystem->is_dir( $dest_folder . $args['subfolder'] . '/' ) &&
-				! $wp_filesystem->mkdir( $dest_folder . $args['subfolder'] . '/' )
+				! $wp_filesystem->is_dir( $dest_folder . $args['dir'] . '/' ) &&
+				! $wp_filesystem->mkdir( $dest_folder . $args['dir'] . '/' )
 			)
 		) {
 			return new WP_Error( 'fs_rollback_mkdir', $this->strings['rollback_mkdir_failed'] );
 		}
 
 		$src  = trailingslashit( $args['src'] ) . $args['slug'];
-		$dest = $dest_folder . $args['subfolder'] . '/' . $args['slug'];
+		$dest = $dest_folder . $args['dir'] . '/' . $args['slug'];
 
 		// Delete rollback folder if it already exists.
 		if ( $wp_filesystem->is_dir( $dest ) ) {
@@ -1026,17 +1026,17 @@ class WP_Upgrader {
 	 *
 	 * @global WP_Filesystem_Base $wp_filesystem WordPress filesystem subclass.
 	 *
-	 * @param array $args Array of data for the rollback. Must include a slug, the source and subfolder.
+	 * @param array $args Array of data for the rollback. Must include a slug, the source and directory.
 	 *
 	 * @return bool|WP_Error
 	 */
 	public function restore_rollback( $args ) {
-		if ( empty( $args['slug'] ) || empty( $args['src'] ) || empty( $args['subfolder'] ) ) {
+		if ( empty( $args['slug'] ) || empty( $args['src'] ) || empty( $args['dir'] ) ) {
 			return false;
 		}
 
 		global $wp_filesystem;
-		$src  = $wp_filesystem->wp_content_dir() . 'upgrade/rollback/' . $args['subfolder'] . '/' . $args['slug'];
+		$src  = $wp_filesystem->wp_content_dir() . 'upgrade/rollback/' . $args['dir'] . '/' . $args['slug'];
 		$dest = trailingslashit( $args['src'] ) . $args['slug'];
 
 		if ( $wp_filesystem->is_dir( $src ) ) {
@@ -1063,17 +1063,17 @@ class WP_Upgrader {
 	 *
 	 * @global WP_Filesystem_Base $wp_filesystem WordPress filesystem subclass.
 	 *
-	 * @param array $args Array of data for the rollback. Must include a slug, the source and subfolder.
+	 * @param array $args Array of data for the rollback. Must include a slug, the source and directory.
 	 *
 	 * @return bool
 	 */
 	public function delete_rollback( $args ) {
 		global $wp_filesystem;
-		if ( empty( $args['slug'] ) || empty( $args['subfolder'] ) ) {
+		if ( empty( $args['slug'] ) || empty( $args['dir'] ) ) {
 			return false;
 		}
 		return $wp_filesystem->delete(
-			$wp_filesystem->wp_content_dir() . "upgrade/rollback/{$args['subfolder']}/{$args['slug']}",
+			$wp_filesystem->wp_content_dir() . "upgrade/rollback/{$args['dir']}/{$args['slug']}",
 			true
 		);
 	}

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -980,7 +980,7 @@ class WP_Upgrader {
 	 * @return bool|WP_Error
 	 */
 	public function move_to_rollbacks_dir( $args ) {
-		if ( empty( $args['slug'] ) || empty( $args['src'] ) || empty( $args['dest'] ) ) {
+		if ( empty( $args['slug'] ) || empty( $args['src'] ) || empty( $args['subfolder'] ) ) {
 			return false;
 		}
 		global $wp_filesystem;
@@ -1018,13 +1018,13 @@ class WP_Upgrader {
 	 * @return bool|WP_Error
 	 */
 	public function restore_rollback( $args ) {
-		if ( empty( $args['slug'] ) || empty( $args['src'] ) || empty( $args['dest'] ) ) {
+		if ( empty( $args['slug'] ) || empty( $args['src'] ) || empty( $args['subfolder'] ) ) {
 			return false;
 		}
 
 		global $wp_filesystem;
-		$src  = $wp_filesystem->wp_content_dir() . '/' . $args['dest'] . '/' . $args['slug'];
-		$dest = $args['src'] . '/' . $args['slug'];
+		$src  = $wp_filesystem->wp_content_dir() . 'upgrade/rollback/' . $args['subfolder'] . '/' . $args['slug'];
+		$dest = trailingslashit( $args['src'] ) . $args['slug'];
 
 		if ( $wp_filesystem->is_dir( $src ) ) {
 

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -181,8 +181,10 @@ class WP_Upgrader {
 		$this->strings['maintenance_start'] = __( 'Enabling Maintenance mode&#8230;' );
 		$this->strings['maintenance_end']   = __( 'Disabling Maintenance mode&#8230;' );
 
-		$this->strings['temp_backup_mkdir_failed']   = __( 'Could not create temp-backup directory.' );
-		$this->strings['temp_backup_move_failed']    = __( 'Could not move old version to the temp-backup directory.' );
+		/* translators: %s: temp-backup */
+		$this->strings['temp_backup_mkdir_failed'] = sprintf( __( 'Could not create the %s directory.' ), 'temp-backup' );
+		/* translators: %s: temp-backup */
+		$this->strings['temp_backup_move_failed']    = sprintf( __( 'Could not move old version to the %s directory.' ), 'temp-backup' );
 		$this->strings['temp_backup_restore_failed'] = __( 'Could not restore original version.' );
 
 	}

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -1115,6 +1115,10 @@ class WP_Upgrader {
 			 */
 			function() {
 				global $wp_filesystem;
+				if ( ! $wp_filesystem ) {
+					include_once ABSPATH . '/wp-admin/includes/file.php';
+					WP_Filesystem();
+				}
 				$dirlist = $wp_filesystem->dirlist( $wp_filesystem->wp_content_dir() . 'upgrade/temp-backup/' );
 				foreach ( array_keys( $dirlist ) as $dir ) {
 					if ( '.' === $dir || '..' === $dir ) {

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -133,7 +133,7 @@ class WP_Upgrader {
 	 * This will set the relationship between the skin being used and this upgrader,
 	 * and also add the generic strings to `WP_Upgrader::$strings`.
 	 *
-	 * Additionally, it will schedule a weekly task to clean up the temp-backup folder.
+	 * Additionally, it will schedule a weekly task to clean up the temp-backup directory.
 	 *
 	 * @since 2.8.0
 	 * @since 5.9.0 Added the `schedule_temp_backup_cleanup()` task.
@@ -145,7 +145,7 @@ class WP_Upgrader {
 	}
 
 	/**
-	 * Schedule cleanup of the temp-backup folder.
+	 * Schedule cleanup of the temp-backup directory.
 	 *
 	 * @since 5.9.0
 	 */
@@ -857,7 +857,7 @@ class WP_Upgrader {
 
 		$this->skin->after();
 
-		// Clean up the backup kept in the temp-backup folder.
+		// Clean up the backup kept in the temp-backup directory.
 		if ( ! empty( $options['hook_extra']['temp_backup'] ) ) {
 			$this->delete_temp_backup( $options['hook_extra']['temp_backup'] );
 		}
@@ -1004,30 +1004,28 @@ class WP_Upgrader {
 			return false;
 		}
 
-		$dest_folder = $wp_filesystem->wp_content_dir() . 'upgrade/temp-backup/';
-		// Create the temp-backup dir if it doesn't exist.
-		if (
-			(
-				! $wp_filesystem->is_dir( $dest_folder ) &&
-				! $wp_filesystem->mkdir( $dest_folder )
-			) ||
-			(
-				! $wp_filesystem->is_dir( $dest_folder . $args['dir'] . '/' ) &&
-				! $wp_filesystem->mkdir( $dest_folder . $args['dir'] . '/' )
+		$dest_dir = $wp_filesystem->wp_content_dir() . 'upgrade/temp-backup/';
+		// Create the temp-backup directory if it doesn't exist.
+		if ( (
+				! $wp_filesystem->is_dir( $dest_dir )
+				&& ! $wp_filesystem->mkdir( $dest_dir )
+			) || (
+				! $wp_filesystem->is_dir( $dest_dir . $args['dir'] . '/' )
+				&& ! $wp_filesystem->mkdir( $dest_dir . $args['dir'] . '/' )
 			)
 		) {
 			return new WP_Error( 'fs_temp_backup_mkdir', $this->strings['temp_backup_mkdir_failed'] );
 		}
 
 		$src  = trailingslashit( $args['src'] ) . $args['slug'];
-		$dest = $dest_folder . $args['dir'] . '/' . $args['slug'];
+		$dest = $dest_dir . $args['dir'] . '/' . $args['slug'];
 
-		// Delete the temp-backup folder if it already exists.
+		// Delete the temp-backup directory if it already exists.
 		if ( $wp_filesystem->is_dir( $dest ) ) {
 			$wp_filesystem->delete( $dest, true );
 		}
 
-		// Move to the temp-backup folder.
+		// Move to the temp-backup directory.
 		if ( ! $wp_filesystem->move( $src, $dest, true ) ) {
 			return new WP_Error( 'fs_temp_backup_move', $this->strings['temp_backup_move_failed'] );
 		}

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -996,10 +996,11 @@ class WP_Upgrader {
 	 * @return bool|WP_Error
 	 */
 	public function move_to_temp_backup_dir( $args ) {
+		global $wp_filesystem;
+
 		if ( empty( $args['slug'] ) || empty( $args['src'] ) || empty( $args['dir'] ) ) {
 			return false;
 		}
-		global $wp_filesystem;
 
 		$dest_folder = $wp_filesystem->wp_content_dir() . 'upgrade/temp-backup/';
 		// Create the temp-backup dir if it doesn't exist.
@@ -1044,11 +1045,12 @@ class WP_Upgrader {
 	 * @return bool|WP_Error
 	 */
 	public function restore_temp_backup( $args ) {
+		global $wp_filesystem;
+
 		if ( empty( $args['slug'] ) || empty( $args['src'] ) || empty( $args['dir'] ) ) {
 			return false;
 		}
 
-		global $wp_filesystem;
 		$src  = $wp_filesystem->wp_content_dir() . 'upgrade/temp-backup/' . $args['dir'] . '/' . $args['slug'];
 		$dest = trailingslashit( $args['src'] ) . $args['slug'];
 

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -975,7 +975,7 @@ class WP_Upgrader {
 	 *
 	 * @global WP_Filesystem_Base $wp_filesystem WordPress filesystem subclass.
 	 *
-	 * @param array $args Array of data for the rollback. Must include a slug, the source and destination.
+	 * @param array $args Array of data for the rollback. Must include a slug, the source and subfolder.
 	 *
 	 * @return bool|WP_Error
 	 */
@@ -1013,7 +1013,7 @@ class WP_Upgrader {
 	 *
 	 * @global WP_Filesystem_Base $wp_filesystem WordPress filesystem subclass.
 	 *
-	 * @param array $args Array of data for the rollback. Must include a slug, the source and destination.
+	 * @param array $args Array of data for the rollback. Must include a slug, the source and subfolder.
 	 *
 	 * @return bool|WP_Error
 	 */
@@ -1050,7 +1050,7 @@ class WP_Upgrader {
 	 *
 	 * @global WP_Filesystem_Base $wp_filesystem WordPress filesystem subclass.
 	 *
-	 * @param array $args Array of data for the rollback. Must include a slug, the source and destination.
+	 * @param array $args Array of data for the rollback. Must include a slug, the source and subfolder.
 	 *
 	 * @return bool
 	 */

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -167,8 +167,8 @@ class WP_Upgrader {
 		$this->strings['maintenance_start'] = __( 'Enabling Maintenance mode&#8230;' );
 		$this->strings['maintenance_end']   = __( 'Disabling Maintenance mode&#8230;' );
 
-		$this->strings['temp_backup_mkdir_failed']   = __( 'Could not create temp_backup directory.' );
-		$this->strings['temp_backup_move_failed']    = __( 'Could not move old version to the temp_backup directory.' );
+		$this->strings['temp_backup_mkdir_failed']   = __( 'Could not create temp-backup directory.' );
+		$this->strings['temp_backup_move_failed']    = __( 'Could not move old version to the temp-backup directory.' );
 		$this->strings['temp_backup_restore_failed'] = __( 'Could not restore original version.' );
 
 	}
@@ -318,7 +318,7 @@ class WP_Upgrader {
 		$upgrade_files = $wp_filesystem->dirlist( $upgrade_folder );
 		if ( ! empty( $upgrade_files ) ) {
 			foreach ( $upgrade_files as $file ) {
-				if ( 'temp_backup' === $file['name'] ) {
+				if ( 'temp-backup' === $file['name'] ) {
 					continue;
 				}
 				$wp_filesystem->delete( $upgrade_folder . $file['name'], true );
@@ -841,7 +841,7 @@ class WP_Upgrader {
 
 		$this->skin->after();
 
-		// Cleanup backup kept in the temp_backup folder.
+		// Cleanup backup kept in the temp-backup folder.
 		if ( ! empty( $options['hook_extra']['temp_backup'] ) ) {
 			$this->delete_temp_backup( $options['hook_extra']['temp_backup'] );
 		}
@@ -972,7 +972,7 @@ class WP_Upgrader {
 	}
 
 	/**
-	 * Move the plugin/theme being upgraded into a temp_backup directory.
+	 * Move the plugin/theme being upgraded into a temp-backup directory.
 	 *
 	 * @since 5.9.0
 	 *
@@ -988,8 +988,8 @@ class WP_Upgrader {
 		}
 		global $wp_filesystem;
 
-		$dest_folder = $wp_filesystem->wp_content_dir() . 'upgrade/temp_backup/';
-		// Create the temp_backup dir if it doesn't exist.
+		$dest_folder = $wp_filesystem->wp_content_dir() . 'upgrade/temp-backup/';
+		// Create the temp-backup dir if it doesn't exist.
 		if (
 			(
 				! $wp_filesystem->is_dir( $dest_folder ) &&
@@ -1006,12 +1006,12 @@ class WP_Upgrader {
 		$src  = trailingslashit( $args['src'] ) . $args['slug'];
 		$dest = $dest_folder . $args['dir'] . '/' . $args['slug'];
 
-		// Delete temp_backup folder if it already exists.
+		// Delete temp-backup folder if it already exists.
 		if ( $wp_filesystem->is_dir( $dest ) ) {
 			$wp_filesystem->delete( $dest, true );
 		}
 
-		// Move to the temp_backup folder.
+		// Move to the temp-backup folder.
 		if ( ! $wp_filesystem->move( $src, $dest, true ) ) {
 			return new WP_Error( 'fs_temp_backup_move', $this->strings['temp_backup_move_failed'] );
 		}
@@ -1020,7 +1020,7 @@ class WP_Upgrader {
 	}
 
 	/**
-	 * Restore the plugin/theme from the temp_backup directory.
+	 * Restore the plugin/theme from the temp-backup directory.
 	 *
 	 * @since 5.9.0
 	 *
@@ -1036,7 +1036,7 @@ class WP_Upgrader {
 		}
 
 		global $wp_filesystem;
-		$src  = $wp_filesystem->wp_content_dir() . 'upgrade/temp_backup/' . $args['dir'] . '/' . $args['slug'];
+		$src  = $wp_filesystem->wp_content_dir() . 'upgrade/temp-backup/' . $args['dir'] . '/' . $args['slug'];
 		$dest = trailingslashit( $args['src'] ) . $args['slug'];
 
 		if ( $wp_filesystem->is_dir( $src ) ) {
@@ -1055,7 +1055,7 @@ class WP_Upgrader {
 	}
 
 	/**
-	 * Deletes a temp_backup.
+	 * Deletes a temp-backup.
 	 *
 	 * @since 5.9.0
 	 *
@@ -1071,7 +1071,7 @@ class WP_Upgrader {
 			return false;
 		}
 		return $wp_filesystem->delete(
-			$wp_filesystem->wp_content_dir() . "upgrade/temp_backup/{$args['dir']}/{$args['slug']}",
+			$wp_filesystem->wp_content_dir() . "upgrade/temp-backup/{$args['dir']}/{$args['slug']}",
 			true
 		);
 	}

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -1061,21 +1061,6 @@ class WP_Upgrader {
 		}
 		return $wp_filesystem->delete(  $wp_filesystem->wp_content_dir() . '/' . $args['dest'] . '/' . $args['slug'], true );
 	}
-
-	/**
-	 * Get a rollback param.
-	 * Extend this method in child classes to implement rollbacks.
-	 *
-	 * @since 5.9.0
-	 *
-	 * @param string $param      The parameter to get.
-	 * @param array  $hook_extra Extra params.
-	 *
-	 * @return string|null
-	 */
-	public function get_rollback_param( $param, $hook_extra = array() ) {
-		return null;
-	}
 }
 
 /** Plugin_Upgrader class */


### PR DESCRIPTION
This patch aims to improve the stability of plugin/theme updates, by adding the ability to "rollback" failed updates.

* When updating a plugin/theme, the old version of the plugin/theme gets moved to a `wp-content/upgrade/temp-backup/plugins/PLUGINNAME` or `wp-content/upgrade/temp-backup/themes/THEMENAME` folder. The reason we chose to **move** instead of **zip**, is because zipping/unzipping are very resources-intensive processes, and would increase the risk on low-end, shared hosts. Moving on the other hand is performed instantly and won't be a bottleneck.
* If the update fails, then the "backup" we kept in the `upgrade/temp-backup` folder gets restored to its original location
* If the update succeeds, then the "backup" is deleted
* 2 new checks were added in the site-health screen:
  * Check to make sure that the rollbacks folder is writable.
  * Check there is enough disk-space available to safely perform updates.

To avoid confusion: The "temp-backup" folder will NOT be used to "roll-back" a plugin to a previous version after an update. This folder will simply contain a **transient backup** of the previous version of a plugins/themes getting updated, and as soon as the update process finishes, the folder will be empty.

## Testing instructions:
* If the `wp-content/temp-backup` folder is not writable, there should be an error in the site-health screen.
* If the server has less than 20MB available, there should be an error in the site-health screen that updates may fail. If the server has less than 100MB, it should be a notice that disk space is running low.
* When updating a plugin, you should be able to see the old plugin in the `wp-content/upgrade/temp-backup/plugins/PLUGINNAME` folder. The same should apply for themes. Since updates sometimes run fast and we may miss the folder creation during testing, you can add `return true;` as the 1st line inside the `WP_Upgrader->delete_temp_backup()` method. This will return early and skip deleting the backup on update-success.
* When a plugin update fails, the previous version should be restored. To test that, change the version of a plugin to a previous number, run the update, and on fail the previous version (the one where you changed the version number) should still be installed on the site. To simulate an update failure and confirm this works, you can use the snippet below:
 ```php
add_filter( 'upgrader_install_package_result', function() {
	return new WP_Error( 'simulated_error', 'Simulated Error' );
});
```
^ That is the main feature in this PR and what should be thoroughly tested: Update failures.


Trac ticket: https://core.trac.wordpress.org/ticket/51857

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
