### PR TITLE
Refresh $sidebars_widgets before calling retrieve_widgets in WP_REST_Widgets_Controller a safe, RC-friendly way

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-widgets-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-widgets-controller.php
@@ -142,7 +142,7 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 		return $this->permissions_check( $request );
 	}
 
-	/**n create_item
+	/**
 	 * Gets an individual widget.
 	 *
 	 * @since 5.8.0

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-widgets-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-widgets-controller.php
@@ -142,7 +142,7 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 		return $this->permissions_check( $request );
 	}
 
-	/**
+	/**n create_item
 	 * Gets an individual widget.
 	 *
 	 * @since 5.8.0
@@ -236,6 +236,10 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 	public function update_item( $request ) {
 		global $wp_widget_factory;
 
+		// Calling wp_get_sidebars_widgets() here is a safe fix for https://github.com/WordPress/gutenberg/issues/33335
+		// @TODO: Remove this after WP 5.8 RC1 in favor of updating retrieve_widgets and wp_set_sidebars_widgets
+		wp_get_sidebars_widgets();
+
 		retrieve_widgets();
 
 		$widget_id  = $request['id'];
@@ -299,6 +303,10 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 	 */
 	public function delete_item( $request ) {
 		global $wp_widget_factory, $wp_registered_widget_updates;
+
+		// Calling wp_get_sidebars_widgets() here is a safe fix for https://github.com/WordPress/gutenberg/issues/33335
+		// @TODO: Remove this after WP 5.8 RC1 in favor of updating retrieve_widgets and wp_set_sidebars_widgets
+		wp_get_sidebars_widgets();
 
 		retrieve_widgets();
 


### PR DESCRIPTION
Solves https://github.com/WordPress/gutenberg/issues/33335, https://core.trac.wordpress.org/ticket/53657

Calling `wp_get_sidebars_widgets()` is required, because `retrieve_widgets()` runs some logic to move "hidden/lost" widgets to wp_inactive_widgets sidebar. It does so based on the global `$sidebars_widgets`. Normally this is not a problem, but when processing batch requests, `$sidebars_widgets` isn't properly updated by a previous call to 
 `WP_REST_Widgets_Controller::create_item()` – only `global $_wp_sidebars_widgets` has been changed. So, as far as `retrieve_widgets()` is concerned, the last created widget isn't assigned to any sidebar and so it is mistakenly moved to the `wp_inactive_widgets` sidebar.

This fix is a temporary one so that we may ship WordPress 5.8 without that bug. I will also propose another PR to address the fundamental root cause of the problem here. For more context, see https://github.com/WordPress/gutenberg/issues/33335

**Test plan**

1. Go to `/wp-admin/widgets.php` without this PR applied
2. Run the gist from https://gist.github.com/adamziel/857d18a9cc9a99ac6be9dc2714b699d4 in your browser's dev tools
3. Wait a few seconds and confirm it says `Broken state generated on attempt 1`
4. Apply this PR, refresh the page in your browser
5. Run the same gist
6. Confirm it keeps saying `Valid state generated on attempt 1` and doesn't report problems regardless of how long you keep waiting
7. Also, play with the widgets editor for a while and confirm nothing is broken with respect to updating and deleting widgets
