### PR TITLE
Use get_comment_author in get_comment_reply_link

### DIFF
--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -1760,7 +1760,7 @@ function get_comment_reply_link( $args = array(), $comment = null, $post = null 
 				)
 			) . '#' . $args['respond_id'],
 			$data_attribute_string,
-			esc_attr( sprintf( $args['reply_to_text'], get_comment_author( $comment->comment_ID ) ) ),
+			esc_attr( sprintf( $args['reply_to_text'], get_comment_author( $comment ) ) ),
 			$args['reply_text']
 		);
 	}

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -1736,7 +1736,7 @@ function get_comment_reply_link( $args = array(), $comment = null, $post = null 
 			'postid'         => $post->ID,
 			'belowelement'   => $args['add_below'] . '-' . $comment->comment_ID,
 			'respondelement' => $args['respond_id'],
-			'replyto'        => sprintf( $args['reply_to_text'], get_comment_author( $comment->comment_ID ) ),
+			'replyto'        => sprintf( $args['reply_to_text'], get_comment_author( $comment ) ),
 		);
 
 		$data_attribute_string = '';

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -1736,7 +1736,7 @@ function get_comment_reply_link( $args = array(), $comment = null, $post = null 
 			'postid'         => $post->ID,
 			'belowelement'   => $args['add_below'] . '-' . $comment->comment_ID,
 			'respondelement' => $args['respond_id'],
-			'replyto'        => sprintf( $args['reply_to_text'], $comment->comment_author ),
+			'replyto'        => sprintf( $args['reply_to_text'], get_comment_author( $comment->comment_ID ) ),
 		);
 
 		$data_attribute_string = '';
@@ -1760,7 +1760,7 @@ function get_comment_reply_link( $args = array(), $comment = null, $post = null 
 				)
 			) . '#' . $args['respond_id'],
 			$data_attribute_string,
-			esc_attr( sprintf( $args['reply_to_text'], $comment->comment_author ) ),
+			esc_attr( sprintf( $args['reply_to_text'], get_comment_author( $comment->comment_ID ) ) ),
 			$args['reply_text']
 		);
 	}


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/53678

`get_comment_author` filters are applied in the output of the comment form, but not during the comment reply.

`get_comment_author( $comment->comment_ID )` should be used instead of `$comment->comment_author` inside `get_comment_reply_link()` function.