### PR TITLE
Restore full width of the gallery block media browser on mobile phones

### DIFF
--- a/src/wp-includes/css/media-views.css
+++ b/src/wp-includes/css/media-views.css
@@ -2884,8 +2884,8 @@
 
 	.attachments-browser .attachments,
 	.attachments-browser .uploader-inline,
-	.attachments-browser.attachments-browser .attachments-wrapper,
-	.attachments-browser .media-toolbar {
+	.attachments-browser .media-toolbar,
+	.media-frame-content .attachments-browser .attachments-wrapper {
 		right: 0;
 	}
 

--- a/src/wp-includes/css/media-views.css
+++ b/src/wp-includes/css/media-views.css
@@ -2884,8 +2884,13 @@
 
 	.attachments-browser .attachments,
 	.attachments-browser .uploader-inline,
+	.attachments-browser.attachments-browser .attachments-wrapper,
 	.attachments-browser .media-toolbar {
 		right: 0;
+	}
+
+	.attachments-browser .attachments-wrapper {
+		padding-top: 12px;
 	}
 
 	.image-details .media-frame-title {

--- a/src/wp-includes/css/media-views.css
+++ b/src/wp-includes/css/media-views.css
@@ -2617,7 +2617,9 @@
 
 	.attachments-browser .attachments,
 	.attachments-browser .uploader-inline,
-	.attachments-browser .media-toolbar {
+	.attachments-browser .media-toolbar,
+	.attachments-browser .attachments-wrapper,
+	.attachments-browser.has-load-more .attachments-wrapper {
 		right: 262px;
 	}
 


### PR DESCRIPTION
While testing the new Widgets editor I found that browsing the media library while using a small screen device is unusable. Initially I thought that it's a problem of the Wdgets editor. However the bug exists in the post editor as well.

To reproduce:

1. Using latest Gutenberg trunk
1. On a mobile device with a small screen (phone)
1. Create a new post
1. Add an image block
1. Click the "media library" button

Without this PR, the contents of the media library are unusable: images are small, on one column, cannot scroll.

With this PR, the contents of the media library is usable unusable: images are appropriately sized, view is scrollable.

Trac ticket: https://core.trac.wordpress.org/ticket/53679

