### PR TITLE
Administration: Use admin_url() for canonical URL

### DIFF
--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -1396,7 +1396,7 @@ function wp_admin_canonical_url() {
 	}
 
 	// Ensure we're using an absolute URL.
-	$current_url  = set_url_scheme( 'http://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] );
+	$current_url  = admin_url( preg_replace( '#^[^?]*/wp-admin/#i', '', $_SERVER['REQUEST_URI'] ) );
 	$filtered_url = remove_query_arg( $removable_query_args, $current_url );
 	?>
 	<link id="wp-admin-canonical" rel="canonical" href="<?php echo esc_url( $filtered_url ); ?>" />


### PR DESCRIPTION
Currently, `wp_admin_canonical_url()` uses `$_SERVER['HTTP_HOST']` to build an admin page's canonical URL. This URL will point to an incorrect host if `$_SERVER['HTTP_HOST']` does not match the site URL host, e.g. when Wordpress is used behind a reverse proxy.

This uses `admin_url()` so that the canonical URL will take the configured site URL into account.

Trac ticket: https://core.trac.wordpress.org/ticket/35561

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
