### PR TITLE
Block Editor: Add missing border setting

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -179,6 +179,9 @@ class WP_Theme_JSON {
 	 * @var array
 	 */
 	const ALLOWED_SETTINGS = array(
+		'border'     => array(
+			'customRadius' => null,
+		),
 		'color'      => array(
 			'custom'         => null,
 			'customDuotone'  => null,
@@ -211,6 +214,9 @@ class WP_Theme_JSON {
 	 * @var array
 	 */
 	const ALLOWED_STYLES = array(
+		'border'     => array(
+			'radius' => null,
+		),
 		'color'      => array(
 			'background' => null,
 			'gradient'   => null,

--- a/src/wp-includes/theme.json
+++ b/src/wp-includes/theme.json
@@ -1,6 +1,9 @@
 {
 	"version": 1,
 	"settings": {
+		"border": {
+			"customRadius": false
+		},
 		"color": {
 			"custom": true,
 			"customDuotone": true,
@@ -209,6 +212,13 @@
 					"size": "42px"
 				}
 			]
+		},
+		"blocks": {
+			"core/button": {
+				"border": {
+					"customRadius": true
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/53697

Adds missing border setting and enables it for Button block.

I've only included border-radius settings. I wasn't sure about the others.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
