### PR TITLE
fix: ajax-actions.php file line 3006 is creating divide by zero error

### DIFF
--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3003,7 +3003,9 @@ function wp_ajax_query_attachments() {
 		$total_posts = $count_query->found_posts;
 	}
 
-	$max_pages = ceil( $total_posts / (int) $attachments_query->query['posts_per_page'] );
+	$posts_per_page = (int) $attachments_query->query['posts_per_page'];
+
+	$max_pages = $posts_per_page ? ceil( $total_posts / $posts_per_page ) : 0;
 
 	header( 'X-WP-Total: ' . (int) $total_posts );
 	header( 'X-WP-TotalPages: ' . (int) $max_pages );


### PR DESCRIPTION
This PR will fix the /wp-admin/includes/ajax-actions.php file line 3006 is creating divide by zero error.

Trac Ticket: https://core.trac.wordpress.org/ticket/53773