### PR TITLE
Refresh sidebars widgets global after calling wp_set_sidebars_widgets

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-widgets-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-widgets-controller.php
@@ -292,8 +292,8 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 		global $wp_widget_factory;
 
 		/*
-		 * The name retrieve_widgets() is somewhat misleading. It doesn't just "retrieve". It also
-		 * moves any "hidden" or "lost" widgets to the wp_inactive_widgets sidebar.
+		 * The name retrieve_widgets() is somewhat misleading. It doesn't just "retrieve". It
+		 * also moves any "hidden" or "lost" widgets to the wp_inactive_widgets sidebar.
 		 */
 		$this->retrieve_widgets();
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-widgets-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-widgets-controller.php
@@ -292,16 +292,9 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 		global $wp_widget_factory;
 
 		/*
-		 * retrieve_widgets() contains logic to move "hidden" or "lost" widgets to the
-		 * wp_inactive_widgets sidebar based on the contents of the $sidebars_widgets global.
-		 *
-		 * When batch requests are processed, this global is not properly updated by previous
-		 * calls, resulting in widgets incorrectly being moved to the wp_inactive_widgets
-		 * sidebar.
-		 *
-		 * See https://core.trac.wordpress.org/ticket/53657.
+		 * The name retrieve_widgets() is somewhat misleading. It doesn't just "retrieve". It also
+		 * moves any "hidden" or "lost" widgets to the wp_inactive_widgets sidebar.
 		 */
-		wp_get_sidebars_widgets();
 		$this->retrieve_widgets();
 
 		$widget_id  = $request['id'];
@@ -367,16 +360,9 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 		global $wp_widget_factory, $wp_registered_widget_updates;
 
 		/*
-		 * retrieve_widgets() contains logic to move "hidden" or "lost" widgets to the
-		 * wp_inactive_widgets sidebar based on the contents of the $sidebars_widgets global.
-		 *
-		 * When batch requests are processed, this global is not properly updated by previous
-		 * calls, resulting in widgets incorrectly being moved to the wp_inactive_widgets
-		 * sidebar.
-		 *
-		 * See https://core.trac.wordpress.org/ticket/53657.
+		 * The name retrieve_widgets() is somewhat misleading. It doesn't just "retrieve". It also
+		 * moves any "hidden" or "lost" widgets to the wp_inactive_widgets sidebar.
 		 */
-		wp_get_sidebars_widgets();
 		$this->retrieve_widgets();
 
 		$widget_id  = $request['id'];

--- a/src/wp-includes/widgets.php
+++ b/src/wp-includes/widgets.php
@@ -1078,9 +1078,9 @@ function wp_get_sidebar( $id ) {
  * @global array $_wp_sidebars_widgets
  * @global array $sidebars_widgets
  *
- * @param array   $new_sidebars_widgets            Sidebar widgets and their settings.
- * @param bool  $refresh_global_sidebars_widgets Optional. Whether to update $sidebars_widgets.
- *                                                 global. Default true.
+ * @param array $new_sidebars_widgets            Sidebar widgets and their settings.
+ * @param bool  $refresh_global_sidebars_widgets Optional. Whether to update $sidebars_widgets
+ *                                               global. Default true.
  */
 function wp_set_sidebars_widgets( $new_sidebars_widgets, $refresh_global_sidebars_widgets = true ) {
 	global $_wp_sidebars_widgets, $sidebars_widgets;

--- a/src/wp-includes/widgets.php
+++ b/src/wp-includes/widgets.php
@@ -1096,7 +1096,11 @@ function wp_set_sidebars_widgets( $new_sidebars_widgets, $refresh_global_sidebar
 	// Refresh the $sidebars_widgets global.
 	if ( $refresh_global_sidebars_widgets ) {
 		$sidebars_widgets = wp_get_sidebars_widgets();
-		sync_registered_widgets( true );
+		/*
+		 * The name retrieve_widgets() is somewhat misleading. It doesn't just "retrieve". It also
+		 * moves any "hidden" or "lost" widgets to the wp_inactive_widgets sidebar.
+		 */
+		retrieve_widgets( true );
 	}
 }
 

--- a/src/wp-includes/widgets.php
+++ b/src/wp-includes/widgets.php
@@ -1072,6 +1072,7 @@ function wp_get_sidebar( $id ) {
  * Set the sidebar widget option to update sidebars.
  *
  * @since 2.2.0
+ * @since 6.0.1 Added the optional $refresh_global_sidebars_widgets argument.
  * @access private
  *
  * @global array $_wp_sidebars_widgets

--- a/src/wp-includes/widgets.php
+++ b/src/wp-includes/widgets.php
@@ -1079,7 +1079,7 @@ function wp_get_sidebar( $id ) {
  * @global array $sidebars_widgets
  *
  * @param array   $new_sidebars_widgets            Sidebar widgets and their settings.
- * @param boolean $refresh_global_sidebars_widgets Optional. Whether to update $sidebars_widgets
+ * @param bool  $refresh_global_sidebars_widgets Optional. Whether to update $sidebars_widgets.
  *                                                 global. Default true.
  */
 function wp_set_sidebars_widgets( $new_sidebars_widgets, $refresh_global_sidebars_widgets = true ) {

--- a/src/wp-includes/widgets.php
+++ b/src/wp-includes/widgets.php
@@ -1075,19 +1075,29 @@ function wp_get_sidebar( $id ) {
  * @access private
  *
  * @global array $_wp_sidebars_widgets
- * @param array $sidebars_widgets Sidebar widgets and their settings.
+ * @global array $sidebars_widgets
+ *
+ * @param array   $new_sidebars_widgets            Sidebar widgets and their settings.
+ * @param boolean $refresh_global_sidebars_widgets Optional. Whether to update $sidebars_widgets
+ *                                                 global. Default true.
  */
-function wp_set_sidebars_widgets( $sidebars_widgets ) {
-	global $_wp_sidebars_widgets;
+function wp_set_sidebars_widgets( $new_sidebars_widgets, $refresh_global_sidebars_widgets = true ) {
+	global $_wp_sidebars_widgets, $sidebars_widgets;
 
 	// Clear cached value used in wp_get_sidebars_widgets().
 	$_wp_sidebars_widgets = null;
 
-	if ( ! isset( $sidebars_widgets['array_version'] ) ) {
-		$sidebars_widgets['array_version'] = 3;
+	if ( ! isset( $new_sidebars_widgets['array_version'] ) ) {
+		$new_sidebars_widgets['array_version'] = 3;
 	}
 
-	update_option( 'sidebars_widgets', $sidebars_widgets );
+	update_option( 'sidebars_widgets', $new_sidebars_widgets );
+
+	// Refresh the $sidebars_widgets global.
+	if ( $refresh_global_sidebars_widgets ) {
+		$sidebars_widgets = wp_get_sidebars_widgets();
+		sync_registered_widgets( true );
+	}
 }
 
 /**
@@ -1353,8 +1363,11 @@ function retrieve_widgets( $theme_changed = false ) {
 	$sidebars_widgets['wp_inactive_widgets'] = array_merge( $lost_widgets, (array) $sidebars_widgets['wp_inactive_widgets'] );
 
 	if ( 'customize' !== $theme_changed ) {
-		// Update the widgets settings in the database.
-		wp_set_sidebars_widgets( $sidebars_widgets );
+		/*
+		 * The second parameter is false to avoid recursion: refreshing the global
+		 * $sidebars_widgets entails calling retrieve_widgets().
+		 */
+		wp_set_sidebars_widgets( $sidebars_widgets, false );
 	}
 
 	return $sidebars_widgets;

--- a/src/wp-includes/widgets.php
+++ b/src/wp-includes/widgets.php
@@ -1072,7 +1072,7 @@ function wp_get_sidebar( $id ) {
  * Set the sidebar widget option to update sidebars.
  *
  * @since 2.2.0
- * @since 6.2.0 Added the optional $refresh_global_sidebars_widgets argument.
+ * @since 6.2.0 Added the optional `$refresh_global_sidebars_widgets` parameter.
  * @access private
  *
  * @global array $_wp_sidebars_widgets

--- a/src/wp-includes/widgets.php
+++ b/src/wp-includes/widgets.php
@@ -1072,7 +1072,7 @@ function wp_get_sidebar( $id ) {
  * Set the sidebar widget option to update sidebars.
  *
  * @since 2.2.0
- * @since 6.0.1 Added the optional $refresh_global_sidebars_widgets argument.
+ * @since 6.2.0 Added the optional $refresh_global_sidebars_widgets argument.
  * @access private
  *
  * @global array $_wp_sidebars_widgets

--- a/tests/phpunit/tests/rest-api/rest-widgets-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-widgets-controller.php
@@ -927,7 +927,14 @@ class WP_Test_REST_Widgets_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	/**
+	 * Tests that running multiple request handlers (create and delete) deletes the intended widget.
+	 *
+	 * See this comment for more details:
+	 * https://github.com/WordPress/gutenberg/issues/33335#issuecomment-879903958
+	 *
 	 * @ticket 53816
+	 * @covers WP_REST_Widgets_Controller::create_item
+	 * @covers WP_REST_Widgets_Controller::delete_item
 	 */
 	public function test_create_and_delete() {
 		$this->setup_widget(

--- a/tests/phpunit/tests/rest-api/rest-widgets-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-widgets-controller.php
@@ -996,16 +996,17 @@ class WP_Test_REST_Widgets_Controller extends WP_Test_REST_Controller_Testcase {
 		 * request handlers during the same run. See the following comment for more details:
 		 * https://github.com/WordPress/gutenberg/issues/33335#issuecomment-879903958
 		 */
-		$this->assertCount( 1, $data );
-		$this->assertSame( 'text-2', $data[0]['id'] );
-		$this->assertSame( 'sidebar-1', $data[0]['sidebar'] );
+		$this->assertCount( 1, $data, 'The text-1 widget was not deleted' );
+		$this->assertSame( 'text-2', $data[0]['id'], 'The text-2 widget was not preserved' );
+		$this->assertSame( 'sidebar-1', $data[0]['sidebar'], 'The text-2 widget is no longer assigned to sidebar-1' );
 		$this->assertSameSetsWithIndex(
 			array(
 				'text'   => 'Updated text test',
 				'title'  => '',
 				'filter' => false,
 			),
-			$data[0]['instance']['raw']
+			$data[0]['instance']['raw'],
+			'The content of the text-2 widget changed'
 		);
 	}
 

--- a/tests/phpunit/tests/rest-api/rest-widgets-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-widgets-controller.php
@@ -977,10 +977,11 @@ class WP_Test_REST_Widgets_Controller extends WP_Test_REST_Controller_Testcase {
 		rest_do_request( $request );
 
 		// Get a list of all widgets.
-		$request  = new WP_REST_Request( 'GET', '/wp/v2/widgets' );
-		$response = rest_get_server()->dispatch( $request );
-		$data     = $response->get_data();
-		$data     = $this->remove_links( $data );
+		$request            = new WP_REST_Request( 'GET', '/wp/v2/widgets' );
+		$request['context'] = 'edit';
+		$response           = rest_get_server()->dispatch( $request );
+		$data               = $response->get_data();
+		$data               = $this->remove_links( $data );
 
 		// Confirm that we deleted exactly the widget that we wanted, and
 		// no other one. This tests against a regression in running multiple

--- a/tests/phpunit/tests/rest-api/rest-widgets-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-widgets-controller.php
@@ -983,10 +983,12 @@ class WP_Test_REST_Widgets_Controller extends WP_Test_REST_Controller_Testcase {
 		$data               = $response->get_data();
 		$data               = $this->remove_links( $data );
 
-		// Confirm that we deleted exactly the widget that we wanted, and
-		// no other one. This tests against a regression in running multiple
-		// request handlers during the same run. See the following comment for more details:
-		// https://github.com/WordPress/gutenberg/issues/33335#issuecomment-879903958
+		/*
+		 * Confirm that we deleted exactly the widget that we wanted, and
+		 * no other one. This tests against a regression in running multiple
+		 * request handlers during the same run. See the following comment for more details:
+		 * https://github.com/WordPress/gutenberg/issues/33335#issuecomment-879903958
+		 */
 		$this->assertCount( 1, $data );
 		$this->assertSame( 'text-2', $data[0]['id'] );
 		$this->assertSame( 'sidebar-1', $data[0]['sidebar'] );


### PR DESCRIPTION
### Description

Before this PR, batch-saving widgets sometimes moves one of them to "Inactive widgets". The full, step-by-step problem description can be found [here](https://github.com/WordPress/gutenberg/issues/33335#issuecomment-879903958).

Tactically, this PR removes the `retrieve_widget` call that was placed in the API endpoints as a workaround for the following problem:

```
		 * When batch requests are processed, this global is not properly updated by previous
		 * calls, resulting in widgets incorrectly being moved to the wp_inactive_widgets
		 * sidebar.
```

The solution introduced in this PR is correctly refreshing the related global variable in `wp_set_sidebar_widgets`.

### Test plan

* Confirm the attached unit test correctly checks for the regression.
* Confirm all the tests pass.
* If you'd like to do some manual testing – it's hard to trigger the problem from the UI. Instead, switch themes to Twenty twenty one, go to your widgets screen in wp-admin, run the script below in your devtools, and refresh the page – you should have exactly three widgets assigned to the sidebar and zero widgets in "Inactive widgets":

```js
async function giveMeThreeWidgets(){
    
	const sidebars = ['sidebar-1', 'wp_inactive_widgets'];
	async function* getWidgetsIds() {
		for(const sidebar of sidebars) {
				const sidebarWidgets = await window.wp.apiFetch({
					path: `/index.php?rest_route=%2Fwp%2Fv2%2Fsidebars%2F${sidebar}&_locale=user`
				});
				yield* sidebarWidgets.widgets;
		}
	}
	async function toArray(asyncIterator){
		const arr = [];
		for await(const i of asyncIterator) arr.push(i);
		return arr;
	}

	const ids = await toArray(getWidgetsIds());
	return await window.wp.apiFetch( {
		path: "/index.php?rest_route=%2Fbatch%2Fv1&_locale=user", 
		"data": {
			"validation": "require-all-validate", "requests": [
				{ "path": "/wp/v2/widgets","body": {"id_base": "block","instance": { "raw": { "content": "<!-- wp:legacy-widget /-->" } },"sidebar": "sidebar-1"},					"method": "POST"				},
				{ "path": "/wp/v2/widgets", "body": {"id_base": "block", "instance": { "raw": { "content": "<!-- wp:gallery {\"ids\":[10,8,7],\"linkTo\":\"none\"} -->\n<figure class=\"wp-block-gallery columns-3 is-cropped\"><ul class=\"blocks-gallery-grid\"><li class=\"blocks-gallery-item\"><figure><img src=\"http://localhost:8888/wp-content/uploads/2021/07/L-Misc5-1024x576.jpg\" alt=\"\" data-id=\"10\" data-full-url=\"http://localhost:8888/wp-content/uploads/2021/07/L-Misc5.jpg\" data-link=\"http://localhost:8888/?attachment_id=10\" class=\"wp-image-10\"/></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"http://localhost:8888/wp-content/uploads/2021/07/L-Misc3-1024x576.jpg\" alt=\"\" data-id=\"8\" data-full-url=\"http://localhost:8888/wp-content/uploads/2021/07/L-Misc3.jpg\" data-link=\"http://localhost:8888/?attachment_id=8\" class=\"wp-image-8\"/></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"http://localhost:8888/wp-content/uploads/2021/07/L-Misc2-1024x640.jpg\" alt=\"\" data-id=\"7\" data-full-url=\"http://localhost:8888/wp-content/uploads/2021/07/L-Misc2.jpg\" data-link=\"http://localhost:8888/?attachment_id=7\" class=\"wp-image-7\"/></figure></li></ul></figure>\n<!-- /wp:gallery -->" }						}, "sidebar": "sidebar-1"					}, "method": "POST"				},
				{ "path": "/wp/v2/widgets","body": {"id_base": "block","instance": { "raw": { "content": "<!-- wp:gallery {\"ids\":[9,7],\"linkTo\":\"none\"} -->\n<figure class=\"wp-block-gallery columns-2 is-cropped\"><ul class=\"blocks-gallery-grid\"><li class=\"blocks-gallery-item\"><figure><img src=\"http://localhost:8888/wp-content/uploads/2021/07/L-Misc4-1024x576.jpg\" alt=\"\" data-id=\"9\" data-full-url=\"http://localhost:8888/wp-content/uploads/2021/07/L-Misc4.jpg\" data-link=\"http://localhost:8888/?attachment_id=9\" class=\"wp-image-9\"/></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"http://localhost:8888/wp-content/uploads/2021/07/L-Misc2-1024x640.jpg\" alt=\"\" data-id=\"7\" data-full-url=\"http://localhost:8888/wp-content/uploads/2021/07/L-Misc2.jpg\" data-link=\"http://localhost:8888/?attachment_id=7\" class=\"wp-image-7\"/></figure></li></ul></figure>\n<!-- /wp:gallery -->" } },"sidebar": "sidebar-1"},"method": "POST" },
				...ids.map( id => ( { "path": `/wp/v2/widgets/${ id }?force=true`, "method": "DELETE" } ) ),
			]
		},
		"method": "POST",
	} )
}
giveMeThreeWidgets()
```

Trac ticket: https://core.trac.wordpress.org/ticket/53816

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
