### PR TITLE
Added note to readme about composer v2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ You will also need [Docker](https://www.docker.com/products/docker-desktop) inst
 
 Ensure [Docker](https://www.docker.com/products/docker-desktop) is running before using these commands.
 
+Ensure **Docker Composer V2** is not active (settings -> experimental features) if using docker desktop.
+
 #### To start the development environment for the first time
 
 Clone the current repository using `git clone https://github.com/WordPress/wordpress-develop.git`. Then in your terminal move to the repository folder `cd wordpress-develop` and run the following commands:


### PR DESCRIPTION
Just a note in the readme.md to turn off composer v2
until we have a support for it in the build

Trac ticket:https://core.trac.wordpress.org/ticket/53820

---
**This Pull Request is for code review only. Please keep all other discussions in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
