### PR TITLE
Ensure that image selector use widths and heights use whole numbers.

### DIFF
--- a/src/js/_enqueues/vendor/imgareaselect/jquery.imgareaselect.js
+++ b/src/js/_enqueues/vendor/imgareaselect/jquery.imgareaselect.js
@@ -18,6 +18,7 @@
  * shortcuts
  */
 var abs = Math.abs,
+	ceil = Math.ceil,
     max = Math.max,
     min = Math.min,
     round = Math.round;
@@ -73,7 +74,7 @@ $.imgAreaSelect = function (img, options) {
         imgOfs = { left: 0, top: 0 },
 
         /* Image dimensions (as returned by .width() and .height()) */
-        imgWidth, imgHeight,
+        imgWidth, imgHeight, imgInnerWidth, imgInnerHeight,
 
         /*
          * jQuery object representing the parent element that the plugin
@@ -286,11 +287,14 @@ $.imgAreaSelect = function (img, options) {
         imgOfs = { left: round($img.offset().left), top: round($img.offset().top) };
 
         /* Get image dimensions */
-        imgWidth = $img.innerWidth();
-        imgHeight = $img.innerHeight();
+		imgWidth = ceil($img.innerWidth());
+		imgHeight = ceil($img.innerHeight());
 
-        imgOfs.top += ($img.outerHeight() - imgHeight) >> 1;
-        imgOfs.left += ($img.outerWidth() - imgWidth) >> 1;
+		imgInnerWidth = ceil($img.innerWidth());
+		imgInnerHeight = ceil($img.innerHeight());
+
+		imgOfs.top += (imgInnerHeight - imgHeight) >> 1;
+		imgOfs.left += (imgInnerWidth - imgWidth) >> 1;
 
         /* Set minimum and maximum selection area dimensions */
         minWidth = round(options.minWidth / scaleX) || 0;


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Ensure that image selector use widths and heights use whole numbers.

Trac ticket: https://core.trac.wordpress.org/ticket/53300

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
