### PR TITLE
fix: fatal error when in action pre get posts call *_template()

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -1781,7 +1781,9 @@ class WP_Query {
 		 *
 		 * @param WP_Query $query The WP_Query instance (passed by reference).
 		 */
-		do_action_ref_array( 'pre_get_posts', array( &$this ) );
+		if ( ! did_action( 'pre_get_posts' ) ) {
+			do_action_ref_array( 'pre_get_posts', array( &$this ) );
+		}
 
 		// Shorthand.
 		$q = &$this->query_vars;

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -1781,7 +1781,7 @@ class WP_Query {
 		 *
 		 * @param WP_Query $query The WP_Query instance (passed by reference).
 		 */
-		if ( ! did_action( 'pre_get_posts' ) ) {
+		if ( ! doing_action( 'pre_get_posts' ) ) {
 			do_action_ref_array( 'pre_get_posts', array( &$this ) );
 		}
 


### PR DESCRIPTION
This PR will fix fatal error when in action pre get posts call *_template()

Tested with below templates-
get_single_template()
get_category_template()
get_post_type_archive_template()
get_taxonomy_template()
get_archive_template()
get_home_template()

Trac Ticket: https://core.trac.wordpress.org/ticket/53824