### PR TITLE
#53837 Move the PHPCS basepath config out of phpcs.xml.dist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
 	"scripts": {
 		"compat": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --standard=phpcompat.xml.dist --report=summary,source",
 		"format": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf --report=summary,source",
-		"lint": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --report=summary,source",
+		"lint": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --report=summary,source --basepath='./'",
 		"lint:errors": "@lint -n",
 		"test": "@php ./vendor/phpunit/phpunit/phpunit"
 	}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -14,9 +14,6 @@
 	-->
 	<ini name="memory_limit" value="256M"/>
 
-	<!-- Strip the filepaths down to the relevant bit. -->
-	<arg name="basepath" value="./"/>
-
 	<!-- Check up to 20 files simultaneously. -->
 	<arg name="parallel" value="20"/>
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/53837