### PR TITLE
Take into account that username can have @ char

### DIFF
--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -2717,7 +2717,7 @@ function retrieve_password( $user_login = null ) {
 		$user_data                   = get_user_by( 'email', trim( wp_unslash( $user_login ) ) );
 	}
 
-		// If user data not found by email, attempt to get user data by `login`. 
+		// If user data not found by email, attempt to get user data by `login`.
 	if ( empty( $user_data ) && ! empty( $user_login ) ) {
 		$user_data = get_user_by( 'login', trim( wp_unslash( $user_login ) ) );
 

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -2714,7 +2714,7 @@ function retrieve_password( $user_login = null ) {
 		$errors->add( 'empty_username', __( '<strong>Error</strong>: Please enter a username or email address.' ) );
 	} elseif ( strpos( $user_login, '@' ) ) {
 		$attempt_user_fetch_by_email = true;
-		$user_data = get_user_by( 'email', trim( wp_unslash( $user_login ) ) );
+		$user_data                   = get_user_by( 'email', trim( wp_unslash( $user_login ) ) );
 	}
 
 		// If user data not found by email, attempt to get user data by `login`. 


### PR DESCRIPTION
This PR takes into account that username can have @ char.

For backward-compatibility, we are still sending the `WP_Error` with error message `invalid_email` if the passed user login has `@` character and no user data was found.

Trac ticket: https://core.trac.wordpress.org/ticket/53634

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
