### PR TITLE
Add option to `paginate_links` to apply format on all pages

### DIFF
--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -4161,14 +4161,15 @@ function language_attributes( $doctype = 'html' ) {
  *                                      Default 1.
  *     @type int    $mid_size           How many numbers to either side of the current pages. Default 2.
  *     @type bool   $prev_next          Whether to include the previous and next links in the list. Default true.
- *     @type bool   $prev_text          The previous page text. Default '&laquo; Previous'.
- *     @type bool   $next_text          The next page text. Default 'Next &raquo;'.
+ *     @type string $prev_text          The previous page text. Default '&laquo; Previous'.
+ *     @type string $next_text          The next page text. Default 'Next &raquo;'.
  *     @type string $type               Controls format of the returned value. Possible values are 'plain',
  *                                      'array' and 'list'. Default is 'plain'.
  *     @type array  $add_args           An array of query args to add. Default false.
  *     @type string $add_fragment       A string to append to each link. Default empty.
  *     @type string $before_page_number A string to appear before the page number. Default empty.
  *     @type string $after_page_number  A string to append after the page number. Default empty.
+ *     @type bool   $format_all_pages   Whether to apply the provided `format` on all page's links. Default false.
  * }
  * @return string|array|void String of page links or array of page links, depending on 'type' argument.
  *                           Void if total number of pages is less than 2.
@@ -4208,6 +4209,7 @@ function paginate_links( $args = '' ) {
 		'add_fragment'       => '',
 		'before_page_number' => '',
 		'after_page_number'  => '',
+		'format_all_pages'   => false,
 	);
 
 	$args = wp_parse_args( $args, $defaults );
@@ -4287,7 +4289,7 @@ function paginate_links( $args = '' ) {
 			$dots = true;
 		else :
 			if ( $args['show_all'] || ( $n <= $end_size || ( $current && $n >= $current - $mid_size && $n <= $current + $mid_size ) || $n > $total - $end_size ) ) :
-				$link = str_replace( '%_%', 1 == $n ? '' : $args['format'], $args['base'] );
+				$link = str_replace( '%_%', 1 == $n && ! $args['format_all_pages'] ? '' : $args['format'], $args['base'] );
 				$link = str_replace( '%#%', $n, $link );
 				if ( $add_args ) {
 					$link = add_query_arg( $add_args, $link );

--- a/tests/phpunit/tests/general/paginateLinks.php
+++ b/tests/phpunit/tests/general/paginateLinks.php
@@ -362,4 +362,21 @@ EXPECTED;
 		$page_2_url = home_url() . '?foo=2';
 		$this->assertContains( "<a class=\"page-numbers\" href=\"$page_2_url\">2</a>", $links );
 	}
+
+	/**
+	 * @ticket 53868
+	 */
+	function test_paginate_links_format_all_pages() {
+		$links = paginate_links(
+			array(
+				'current'          => 2,
+				'total'            => 5,
+				'prev_next'        => false,
+				'format_all_pages' => true,
+				'type'             => 'array',
+			)
+		);
+
+		$this->assertStringContainsString( '?paged=1', $links[0] );
+	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/53868

`paginate_links` doesn't use the provided `format` when the page is `1`. This is great for the main query as it removes the extra query params making the URL shorter, but in the case of custom queries is problematic.

If no additional data is appended via. add args / add fragment, the string remains empty at the time of output, which browsers then default it to the current page URL.

The code for this behavior is this: `$link = str_replace( '%_%', 1 == $n ? '' : $args['format'], $args['base'] );`


My proposed solution is to add a new `format_all_pages` option in `paginate_links` that would enforce applying the format for all pages, including the first one. I could use some input for a better name for this option 😄 .

## Notes
In order to test this properly you have to enable pretty permalinks. If not the url will have the `page_id` param and therefore the final url will not be empty.

## Testing instructions

To reproduce:
1. Create a couple of posts - no content is needed
2. Create a page and insert `Query Loop` block, set the `Items per Page` to `1` and make sure the `inherit` is `false`. After that insert a `Query Pagination` block inside `Query Loop`.
3. Save and in front-end `navigate to the second page` of the query.
4. Observe that the link for the first page is pointing to the current url.

To test the solution:
1. You can test by editing this line in `Query Pagination Numbers`:https://github.com/WordPress/wordpress-develop/blob/master/src/wp-includes/blocks/query-pagination-numbers.php#L46 and add the new option: `format_all_pages = true`. (Noting that this will need a follow up in GB to update the block functionality.
2. Observe that after navigating to the second page, the first page's link is correct and is not the current url.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
