### PR TITLE
Implement WP admin UI for plugin dependencies

### DIFF
--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -1190,12 +1190,12 @@ ul.cat-checklist {
 	box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.1);
 }
 
-.plugins tr.active.plugin-update-tr + tr.inactive th,
-.plugins tr.active.plugin-update-tr + tr.inactive td,
-.plugins tr.active.plugin-dependencies-tr + tr.inactive th,
-.plugins tr.active.plugin-dependencies-tr + tr.inactive td,
-.plugins tr.active + tr.inactive th,
-.plugins tr.active + tr.inactive td {
+.plugins tr.active.plugin-update-tr + tr.inactive:not(.dependency) th,
+.plugins tr.active.plugin-update-tr + tr.inactive:not(.dependency) td,
+.plugins tr.active.plugin-dependencies-tr + tr.inactive:not(.dependency) th,
+.plugins tr.active.plugin-dependencies-tr + tr.inactive:not(.dependency) td,
+.plugins tr.active + tr.inactive:not(.dependency) th,
+.plugins tr.active + tr.inactive:not(.dependency) td {
 	border-top: 1px solid rgba(0, 0, 0, 0.03);
 	box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.02), inset 0 -1px 0 #dcdcde;
 }

--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -1174,7 +1174,9 @@ ul.cat-checklist {
 }
 
 .plugins .update th,
-.plugins .update td {
+.plugins .update td,
+.plugins .dependency th,
+.plugins .dependency td {
 	border-bottom: 0;
 }
 
@@ -1190,6 +1192,8 @@ ul.cat-checklist {
 
 .plugins tr.active.plugin-update-tr + tr.inactive th,
 .plugins tr.active.plugin-update-tr + tr.inactive td,
+.plugins tr.active.plugin-dependencies-tr + tr.inactive th,
+.plugins tr.active.plugin-dependencies-tr + tr.inactive td,
 .plugins tr.active + tr.inactive th,
 .plugins tr.active + tr.inactive td {
 	border-top: 1px solid rgba(0, 0, 0, 0.03);
@@ -1198,6 +1202,8 @@ ul.cat-checklist {
 
 .plugins .update td,
 .plugins .update th,
+.plugins .dependency td,
+.plugins .dependency th,
 .upgrade .plugins tr:last-of-type td,
 .upgrade .plugins tr:last-of-type th,
 .plugins tr.active + tr.inactive.update th,
@@ -1210,7 +1216,8 @@ ul.cat-checklist {
 }
 
 .plugins .active th.check-column,
-.plugin-update-tr.active td {
+.plugin-update-tr.active td,
+.plugin-dependencies-tr.active td {
 	border-left: 4px solid #72aee6;
 }
 
@@ -1267,13 +1274,15 @@ ul.cat-checklist {
 	border-top-width: 1px;
 }
 
-.plugins .plugin-update-tr .plugin-update {
+.plugins .plugin-update-tr .plugin-update,
+.plugins .plugin-dependencies-tr .plugin-dependencies {
 	box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.1);
 	overflow: hidden; /* clearfix */
 	padding: 0;
 }
 
 .plugins .plugin-update-tr .notice,
+.plugins .plugin-dependencies-tr .notice,
 .plugins .plugin-update-tr div[class="update-message"] { /* back-compat for pre-4.6 */
 	margin: 5px 20px 15px 40px;
 }
@@ -2039,6 +2048,8 @@ div.action-links,
 	.plugins #the-list tr > td:not(:last-child),
 	.plugins #the-list .update th,
 	.plugins #the-list .update td,
+	.plugins #the-list .dependency th,
+	.plugins #the-list .dependency td,
 	.wp-list-table.plugins #the-list .theme-title {
 		box-shadow: none;
 		border-top: none;
@@ -2071,7 +2082,8 @@ div.action-links,
 		display: table-cell;
 	}
 
-	.plugins #the-list .plugin-update-tr .plugin-update {
+	.plugins #the-list .plugin-update-tr .plugin-update,
+	.plugins #the-list .plugin-dependencies-tr .plugin-dependencies {
 		border-left: none;
 	}
 
@@ -2086,7 +2098,8 @@ div.action-links,
 		border-left: 4px solid #72aee6;
 	}
 
-	.plugins .plugin-update-tr .update-message {
+	.plugins .plugin-update-tr .update-message,
+	.plugins .plugin-dependencies-tr .dependencies-message {
 		margin-left: 0;
 	}
 

--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -1281,6 +1281,11 @@ ul.cat-checklist {
 	padding: 0;
 }
 
+.plugins .plugin-dependencies-tr.active .dependencies-message.notice-info {
+	border: none;
+	padding-left: 0;
+}
+
 .plugins .plugin-update-tr .notice,
 .plugins .plugin-dependencies-tr .notice,
 .plugins .plugin-update-tr div[class="update-message"] { /* back-compat for pre-4.6 */

--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -2054,7 +2054,8 @@ div.action-links,
 
 	.plugins tr.active + tr.inactive th.check-column,
 	.plugins tr.active + tr.inactive td.column-description,
-	.plugins .plugin-update-tr:before {
+	.plugins .plugin-update-tr:before,
+	.plugins .plugin-dependencies-tr:before {
 		box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.1);
 	}
 
@@ -2064,7 +2065,8 @@ div.action-links,
 	}
 
 	/* mimic the checkbox th */
-	.plugins .plugin-update-tr:before {
+	.plugins .plugin-update-tr:before,
+	.plugins .plugin-dependencies-tr:before {
 		content: "";
 		display: table-cell;
 	}
@@ -2078,7 +2080,8 @@ div.action-links,
 	}
 
 	.plugins .active.update + .plugin-update-tr:before,
-	.plugins .active.updated + .plugin-update-tr:before {
+	.plugins .active.updated + .plugin-update-tr:before,
+	.plugins .active + .plugin-dependencies-tr:before {
 		background-color: #f0f6fc;
 		border-left: 4px solid #72aee6;
 	}

--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -1202,8 +1202,8 @@ ul.cat-checklist {
 
 .plugins .update td,
 .plugins .update th,
-.plugins .dependency td,
-.plugins .dependency th,
+.plugins tr.dependency td,
+.plugins tr.dependency th,
 .upgrade .plugins tr:last-of-type td,
 .upgrade .plugins tr:last-of-type th,
 .plugins tr.active + tr.inactive.update th,

--- a/src/wp-admin/includes/admin.php
+++ b/src/wp-admin/includes/admin.php
@@ -49,6 +49,9 @@ require_once ABSPATH . 'wp-admin/includes/options.php';
 /** WordPress Plugin Administration API */
 require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
+/** WordPress Plugin Dependencies */
+require_once ABSPATH . 'wp-admin/includes/class-wp-plugin-dependencies.php';
+
 /** WordPress Post Administration API */
 require_once ABSPATH . 'wp-admin/includes/post.php';
 

--- a/src/wp-admin/includes/admin.php
+++ b/src/wp-admin/includes/admin.php
@@ -47,10 +47,8 @@ require_once ABSPATH . 'wp-admin/includes/class-wp-privacy-policy-content.php';
 require_once ABSPATH . 'wp-admin/includes/options.php';
 
 /** WordPress Plugin Administration API */
-require_once ABSPATH . 'wp-admin/includes/plugin.php';
-
-/** WordPress Plugin Dependencies */
 require_once ABSPATH . 'wp-admin/includes/class-wp-plugin-dependencies.php';
+require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
 /** WordPress Post Administration API */
 require_once ABSPATH . 'wp-admin/includes/post.php';

--- a/src/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/src/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -402,14 +402,14 @@ class WP_Plugin_Dependencies {
 
 			$notice_contents = sprintf(
 				/* translators: %1$s: plugin name. %2$s: Parent plugin name. */
-				esc_html__( 'Plugin %1$s is a dependency for the "%2$s" plugin.' ),
+				esc_html__( 'Plugin %1$s cannot be deactivated because it is a dependency for the "%2$s" plugin.' ),
 				esc_html( $plugin_data['Name'] ),
 				esc_html( $parents_names[0] )
 			);
 			if ( 1 < count( $parents_names ) ) {
 				$notice_contents = sprintf(
 					/* translators: %1$s: plugin name. %2$s: Parent plugin names, comma-separated. */
-					esc_html__( 'Plugin %1$s is a dependency for the following plugins: %2$s.' ),
+					esc_html__( 'Plugin %1$s cannot be deactivated because it is a dependency for the following plugins: %2$s.' ),
 					esc_html( $plugin_data['Name'] ),
 					esc_html( implode( ', ', $parents_names ) )
 				);

--- a/src/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/src/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -420,7 +420,6 @@ class WP_Plugin_Dependencies {
 
 		// Add extra info to parents.
 		if ( $has_dependencies ) {
-			$style = is_rtl() ? 'border-top:none;border-left:none' : 'border-top:none;border-right:none';
 			if ( $pending_activation ) {
 				if ( $in_circular_dependency ) {
 					$this->inline_plugin_row_notice(

--- a/src/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/src/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -292,7 +292,7 @@ class WP_Plugin_Dependencies {
 		}
 
 		foreach ( $this->notices as $notice ) {
-			echo '<div class="notice notice-warning plugin-dependencies"><p>' . wp_kses_post( $notice['content'] ) . '</p></div>';
+			echo '<div class="notice notice-' . esc_attr( $notice['type'] ) . ' plugin-dependencies"><p>' . wp_kses_post( $notice['content'] ) . '</p></div>';
 		}
 	}
 
@@ -514,6 +514,7 @@ class WP_Plugin_Dependencies {
 			require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
 		}
 		$this->notices[] = array(
+			'type'    => 'warning',
 			'content' => sprintf(
 				/* translators: %1$s: The plugin we want to activate. %2$s: The slug of the plugin to install. %3$s: "Install & Activate" button. */
 				__( 'Plugin "%1$s" depends on plugin "%2$s" to be installed. %3$s' ),
@@ -540,6 +541,7 @@ class WP_Plugin_Dependencies {
 		$activate_url = wp_nonce_url( 'plugins.php?action=activate&amp;plugin=' . rawurlencode( $dependency['file'] ) . '&amp;plugin_status=all', 'activate-plugin_' . $dependency['file'] );
 
 		$this->notices[] = array(
+			'type'    => 'warning',
 			'content' => sprintf(
 				/* translators: %1$s: The plugin we want to activate. %2$s: The name of the plugin to install. %3$s: "Activate" button. */
 				__( 'Plugin "%1$s" depends on plugin "%2$s" to be activated. %3$s' ),

--- a/src/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/src/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -597,7 +597,7 @@ class WP_Plugin_Dependencies {
 
 		foreach ( $plugin_dependencies as $dependency ) {
 			$dependency_file = $this->get_plugin_file_from_slug( $dependency['slug'] );
-			if ( $this->in_circular_dependency( $dependency_file, array_merge( $previous, array( $plugin_file ) ) ) ) {
+			if ( $dependency_file && $this->in_circular_dependency( $dependency_file, array_merge( $previous, array( $plugin_file ) ) ) ) {
 				$this->circular_dependencies[ $plugin_file ]     = true;
 				$this->circular_dependencies[ $dependency_file ] = true;
 			}

--- a/src/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/src/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -72,6 +72,12 @@ class WP_Plugin_Dependencies {
 	 * @since 5.9.0
 	 */
 	public function __construct() {
+
+		// Early exit if DISALLOW_FILE_MODS is enabled.
+		if ( defined( 'DISALLOW_FILE_MODS' ) && DISALLOW_FILE_MODS ) {
+			return;
+		}
+
 		// Get an array of installed plugins and set it in the object's $installed_plugins prop.
 		$this->get_plugins();
 

--- a/src/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/src/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -108,6 +108,8 @@ class WP_Plugin_Dependencies {
 
 		// Filter available plugin actions.
 		add_filter( 'plugin_action_links', array( $this, 'plugin_action_links' ), 10, 2 );
+
+		add_filter( 'plugin_display_checkbox', array( $this, 'hide_checkbox_for_dependency' ), 10, 2 );
 	}
 
 	/**
@@ -373,6 +375,23 @@ class WP_Plugin_Dependencies {
 			return array();
 		}
 		return $this->dependencies_parents[ $plugin_file ];
+	}
+
+	/**
+	 * Hide the checkbox in plugin rows when the plugin is a dependency for another active plugin.
+	 *
+	 * @since 5.9.0
+	 *
+	 * @param bool   $display    Whether the checkbox should be displayed.
+	 * @param string $plugin_file Path to the plugin file relative to the plugins' directory.
+	 *
+	 * @return bool
+	 */
+	public function hide_checkbox_for_dependency( $display, $plugin_file ) {
+		if ( ! empty( $this->get_parents( $plugin_file ) ) && is_plugin_active( $plugin_file ) ) {
+			return false;
+		}
+		return $display;
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/src/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -683,5 +683,5 @@ class WP_Plugin_Dependencies {
 	}
 }
 
-global $plugin_dependencies;
-$plugin_dependencies = new WP_Plugin_Dependencies();
+global $wp_plugin_dependencies;
+$wp_plugin_dependencies = new WP_Plugin_Dependencies();

--- a/src/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/src/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -78,6 +78,11 @@ class WP_Plugin_Dependencies {
 			return;
 		}
 
+		// Early exit it DISALLOW_PLUGIN_DEPENDENCIES is enabled.
+		if ( defined( 'DISALLOW_PLUGIN_DEPENDENCIES' ) && DISALLOW_PLUGIN_DEPENDENCIES ) {
+			return;
+		}
+
 		// Get an array of installed plugins and set it in the object's $installed_plugins prop.
 		$this->get_plugins();
 

--- a/src/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/src/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -11,7 +11,7 @@
  *
  * @since 1.0.0
  */
-class WP_Plugins_Dependencies {
+class WP_Plugin_Dependencies {
 
 	/**
 	 * The database option where we store the array of plugins that should be active
@@ -125,7 +125,7 @@ class WP_Plugins_Dependencies {
 	/**
 	 * Check plugin dependencies.
 	 *
- 	 * @since 5.9.0
+	 * @since 5.9.0
 	 * @access public
 	 *
 	 * @param string $file The plugin file.
@@ -520,4 +520,4 @@ class WP_Plugins_Dependencies {
 }
 
 global $plugin_dependencies;
-$plugin_dependencies = new WP_Plugins_Dependencies();
+$plugin_dependencies = new WP_Plugin_Dependencies();

--- a/src/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/src/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -18,7 +18,7 @@ class WP_Plugin_Dependencies {
 	 * but are not due to unmet dependencies.
 	 *
 	 * @since 5.9.0
-	 * @access private
+	 * @access protected
 	 *
 	 * @var string
 	 */
@@ -28,51 +28,51 @@ class WP_Plugin_Dependencies {
 	 * Installed plugins.
 	 *
 	 * @since 5.9.0
-	 * @access private
+	 * @access protected
 	 *
 	 * @var array[]
 	 */
-	private $installed_plugins;
+	protected $installed_plugins;
 
 	/**
 	 * An array of admin notices to show.
 	 *
 	 * @since 5.9.0
-	 * @access private
+	 * @access protected
 	 *
 	 * @var array<int, array>
 	 */
-	private $notices = array();
+	protected $notices = array();
 
 	/**
 	 * Array of parents for dependencies.
 	 *
 	 * @since 5.9.0
-	 * @access private
+	 * @access protected
 	 *
 	 * @var array<string, array>
 	 */
-	private $dependencies_parents = array();
+	protected $dependencies_parents = array();
 
 	/**
 	 * An array of plugin dependencies.
 	 *
 	 * @since 5.9.0
-	 * @access private
+	 * @access protected
 	 *
 	 * @var array<string, array>
 	 */
-	private $plugin_dependencies = array();
+	protected $plugin_dependencies = array();
 
 	/**
 	 * An array of plugins participating in a circular dependencies loop.
 	 *
 	 * @since 5.9.0
-	 * @access private
+	 * @access protected
 	 *
 	 * @var array<string, bool>
 	 */
-	private $circular_dependencies = array();
+	protected $circular_dependencies = array();
 
 	/**
 	 * Constructor.
@@ -116,11 +116,11 @@ class WP_Plugin_Dependencies {
 	 * Get an array of installed plugins and set it in the object's $installed_plugins prop.
 	 *
 	 * @since 5.9.0
-	 * @access private
+	 * @access protected
 	 *
 	 * @return array[]
 	 */
-	private function get_plugins() {
+	protected function get_plugins() {
 		if ( ! function_exists( 'get_plugins' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
@@ -137,11 +137,11 @@ class WP_Plugin_Dependencies {
 	 * Loop installed plugins and process dependencies.
 	 *
 	 * @since 5.9.0
-	 * @access private
+	 * @access protected
 	 *
 	 * @return void
 	 */
-	private function loop_installed_plugins() {
+	protected function loop_installed_plugins() {
 		foreach ( $this->installed_plugins as $file => $plugin ) {
 			$this->maybe_process_plugin_dependencies( $file );
 		}
@@ -151,13 +151,13 @@ class WP_Plugin_Dependencies {
 	 * Check plugin dependencies.
 	 *
 	 * @since 5.9.0
-	 * @access private
+	 * @access protected
 	 *
 	 * @param string $file The plugin file.
 	 *
 	 * @return void
 	 */
-	private function maybe_process_plugin_dependencies( $file ) {
+	protected function maybe_process_plugin_dependencies( $file ) {
 
 		$plugin_is_active           = is_plugin_active( $file );
 		$plugin_awaiting_activation = in_array( $file, $this->get_plugins_to_activate(), true );
@@ -245,14 +245,14 @@ class WP_Plugin_Dependencies {
 	 * Parses a dependency and adds name, file, installed and active args.
 	 *
 	 * @since 5.9.0
-	 * @access private
+	 * @access protected
 	 *
 	 * @param string               $plugin The plugin defining the dependency.
 	 * @param array<string, mixed> $dependency A dependency.
 	 *
 	 * @return array<string, mixed> Returns the dependency with extra args.
 	 */
-	private function parse_dependency( $plugin, $dependency ) {
+	protected function parse_dependency( $plugin, $dependency ) {
 		$dependency['installed'] = false;
 		$dependency['active']    = false;
 		$dependency['file']       = '';
@@ -304,11 +304,11 @@ class WP_Plugin_Dependencies {
 	 * Cancel plugin's activation request.
 	 *
 	 * @since 5.9.0
-	 * @access private
+	 * @access protected
 	 *
 	 * @return void
 	 */
-	private function cancel_activation_request() {
+	protected function cancel_activation_request() {
 		if ( empty( $_GET['action'] ) || 'cancel-activate' !== $_GET['action'] || empty( $_GET['plugin'] ) ) {
 			return;
 		}
@@ -496,7 +496,7 @@ class WP_Plugin_Dependencies {
 	 * Generate the contents of an inline plugin row notice.
 	 *
 	 * @since 5.9.0
-	 * @access private
+	 * @access protected
 	 *
 	 * @param string $contents         Content of the plugin row notice.
 	 * @param string $notice_type      Type of the plugin notice. Default: 'info'.
@@ -504,7 +504,7 @@ class WP_Plugin_Dependencies {
 	 *
 	 * @return void
 	 */
-	private function inline_plugin_row_notice( $contents = '', $notice_type = 'info', $is_plugin_active = false ) {
+	protected function inline_plugin_row_notice( $contents = '', $notice_type = 'info', $is_plugin_active = false ) {
 		$tr_class = $is_plugin_active ? 'plugin-dependencies-tr active' : 'plugin-dependencies-tr';
 		$colspan  = _get_list_table( 'WP_Plugins_List_Table', array( 'screen' => get_current_screen() ) )->get_column_count();
 		?>
@@ -522,14 +522,14 @@ class WP_Plugin_Dependencies {
 	 * Show a notice to install a dependency.
 	 *
 	 * @since 5.9.0
-	 * @access private
+	 * @access protected
 	 *
 	 * @param array<string, mixed> $plugin     The plugin calling the dependencies.
 	 * @param array<string, mixed> $dependency The plugin slug.
 	 *
 	 * @return void
 	 */
-	private function add_notice_install( $plugin, $dependency ) {
+	protected function add_notice_install( $plugin, $dependency ) {
 		if ( ! function_exists( 'install_plugin_install_status' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
 		}
@@ -550,14 +550,14 @@ class WP_Plugin_Dependencies {
 	 * Show a notice to activate a dependency.
 	 *
 	 * @since 5.9.0
-	 * @access private
+	 * @access protected
 	 *
 	 * @param array<string, mixed> $plugin     The plugin calling the dependencies.
 	 * @param array<string, mixed> $dependency The plugin slug.
 	 *
 	 * @return void
 	 */
-	private function add_notice_activate( $plugin, $dependency ) {
+	protected function add_notice_activate( $plugin, $dependency ) {
 		$activate_url = wp_nonce_url( 'plugins.php?action=activate&amp;plugin=' . rawurlencode( $dependency['file'] ) . '&amp;plugin_status=all', 'activate-plugin_' . $dependency['file'] );
 
 		$this->notices[] = array(
@@ -589,13 +589,13 @@ class WP_Plugin_Dependencies {
 	 * Set plugin to the to-be-activated queue.
 	 *
 	 * @since 5.9.0
-	 * @access private
+	 * @access protected
 	 *
 	 * @param string $plugin The plugin file.
 	 *
 	 * @return void
 	 */
-	private function add_plugin_to_queue( $plugin ) {
+	protected function add_plugin_to_queue( $plugin ) {
 		$queue = $this->get_plugins_to_activate();
 		if ( in_array( $plugin, $queue, true ) ) {
 			return;
@@ -609,13 +609,13 @@ class WP_Plugin_Dependencies {
 	 * Remove plugin from the to-be-activated queue.
 	 *
 	 * @since 5.9.0
-	 * @access private
+	 * @access protected
 	 *
 	 * @param string $plugin The plugin file.
 	 *
 	 * @return void
 	 */
-	private function remove_plugin_from_queue( $plugin ) {
+	protected function remove_plugin_from_queue( $plugin ) {
 		$queue = $this->get_plugins_to_activate();
 		if ( ! in_array( $plugin, $queue, true ) ) {
 			return;
@@ -628,7 +628,7 @@ class WP_Plugin_Dependencies {
 	 * Check if a plugin is part of a circular dependencies loop.
 	 *
 	 * @since 5.9.0
-	 * @access private
+	 * @access protected
 	 *
 	 * @param string                   $plugin_file The plugin file.
 	 * @param array<int|string, mixed> $previous    If this is a dependency of a dependency,
@@ -636,7 +636,7 @@ class WP_Plugin_Dependencies {
 	 *
 	 * @return bool
 	 */
-	private function in_circular_dependency( $plugin_file, $previous = array() ) {
+	protected function in_circular_dependency( $plugin_file, $previous = array() ) {
 		if ( isset( $this->circular_dependencies[ $plugin_file ] ) ) {
 			return $this->circular_dependencies[ $plugin_file ];
 		}
@@ -666,13 +666,13 @@ class WP_Plugin_Dependencies {
 	 * Get plugin file from its slug.
 	 *
 	 * @since 5.9.0
-	 * @access private
+	 * @access protected
 	 *
 	 * @param string $slug The plugin slug.
 	 *
 	 * @return string|false Returns the plugin file on success, false on failure.
 	 */
-	private function get_plugin_file_from_slug( $slug ) {
+	protected function get_plugin_file_from_slug( $slug ) {
 		$plugins = $this->get_plugins();
 		foreach ( array_keys( $plugins ) as $plugin ) {
 			if ( 0 === strpos( $plugin, "$slug/" ) || 0 === strpos( $plugin, "$slug\\" ) ) {

--- a/src/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/src/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -109,7 +109,7 @@ class WP_Plugin_Dependencies {
 		// Filter available plugin actions.
 		add_filter( 'plugin_action_links', array( $this, 'plugin_action_links' ), 10, 2 );
 
-		add_filter( 'plugin_display_checkbox', array( $this, 'hide_checkbox_for_dependency' ), 10, 2 );
+		add_filter( 'plugin_checkbox_disabled', array( $this, 'disable_checkbox_for_dependency' ), 10, 2 );
 	}
 
 	/**
@@ -382,16 +382,17 @@ class WP_Plugin_Dependencies {
 	 *
 	 * @since 5.9.0
 	 *
-	 * @param bool   $display    Whether the checkbox should be displayed.
+	 * @param bool   $disabled   Whether the checkbox should be disabled or not.
 	 * @param string $plugin_file Path to the plugin file relative to the plugins' directory.
 	 *
 	 * @return bool
 	 */
-	public function hide_checkbox_for_dependency( $display, $plugin_file ) {
+	public function disable_checkbox_for_dependency( $disabled, $plugin_file ) {
 		if ( ! empty( $this->get_parents( $plugin_file ) ) && is_plugin_active( $plugin_file ) ) {
-			return false;
+			var_dump( $plugin_file );
+			return true;
 		}
-		return $display;
+		return $disabled;
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/src/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -3,13 +3,13 @@
  * Dependencies manager for plugins.
  *
  * @package dependencies-manager.
- * @since 1.0
+ * @since 5.9.0
  */
 
 /**
  * Plugins dependencies manager.
  *
- * @since 1.0.0
+ * @since 5.9.0
  */
 class WP_Plugin_Dependencies {
 

--- a/src/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/src/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -382,18 +382,20 @@ class WP_Plugin_Dependencies {
 				$parents_names[] = get_plugin_data( WP_PLUGIN_DIR . '/' . $parent )['Name'];
 			}
 
-			$notice_contents = ( 1 < count( $parents_names ) )
-				? sprintf(
+			$notice_contents = sprintf(
+				/* translators: %1$s: plugin name. %2$s: Parent plugin name. */
+				esc_html__( 'Plugin %1$s is a dependency for the "%2$s" plugin.' ),
+				esc_html( $plugin_data['Name'] ),
+				esc_html( $parents_names[0] )
+			);
+			if ( 1 < count( $parents_names ) ) {
+				$notice_contents = sprintf(
 					/* translators: %1$s: plugin name. %2$s: Parent plugin names, comma-separated. */
 					esc_html__( 'Plugin %1$s is a dependency for the following plugins: %2$s.' ),
 					esc_html( $plugin_data['Name'] ),
 					esc_html( implode( ', ', $parents_names ) )
-				) : sprintf(
-					/* translators: %1$s: plugin name. %2$s: Parent plugin name. */
-					esc_html__( 'Plugin %1$s is a dependency for the "%2$s" plugin.' ),
-					esc_html( $plugin_data['Name'] ),
-					esc_html( $parents_names[0] )
 				);
+			}
 
 			$this->inline_plugin_row_notice( $notice_contents, 'info', $plugin_file );
 		}

--- a/src/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/src/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -263,7 +263,7 @@ class WP_Plugin_Dependencies {
 	 * @param string   $plugin     The plugin defining the dependency.
 	 * @param stdClass $dependency A dependency.
 	 *
-	 * @return bool Returns false if the plugin has unmet dependencies, otherwise returns true.
+	 * @return void
 	 */
 	private function process_plugin_dependency( $plugin, $dependency ) {
 		$dependency_is_installed = false;
@@ -284,13 +284,11 @@ class WP_Plugin_Dependencies {
 		// If the dependency is not installed, install it, otherwise activate it.
 		if ( ! $dependency_is_installed ) {
 			$this->add_notice_install( get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin ), $dependency );
-			return false;
 		}
 
 		// If the plugin is not activated, activate it.
 		if ( ! $dependency_is_active ) {
 			$this->add_notice_activate( get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin ), $dependency );
-			return false;
 		}
 
 		// Add item to the $dependencies_parents array.
@@ -298,8 +296,6 @@ class WP_Plugin_Dependencies {
 			$this->dependencies_parents[ $dependency['file'] ] = array();
 		}
 		$this->dependencies_parents[ $dependency['file'] ][] = $plugin;
-
-		return true;
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/src/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -358,6 +358,23 @@ class WP_Plugin_Dependencies {
 	}
 
 	/**
+	 * Get a plugin's parents.
+	 *
+	 * @since 5.9.0
+	 * @access public
+	 *
+	 * @param string $plugin_file Path to the plugin file relative to the plugins directory.
+	 *
+	 * @return array Returns an array of parent plugins.
+	 */
+	public function get_parents( $plugin_file ) {
+		if ( ! isset( $this->dependencies_parents[ $plugin_file ] ) ) {
+			return array();
+		}
+		return $this->dependencies_parents[ $plugin_file ];
+	}
+
+	/**
 	 * Add dependencies info in plugins.
 	 *
 	 * @since 5.9.0

--- a/src/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/src/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -350,6 +350,7 @@ class WP_Plugin_Dependencies {
 					__( 'Cancel activation request' )
 				);
 
+				// Use `array_merge` to make sure the action is added as the 1st item in the array.
 				$actions = array_merge( array( 'cancel-activation' => $cancel_activation ), $actions );
 			}
 		}

--- a/src/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/src/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -1,0 +1,523 @@
+<?php
+/**
+ * Dependencies manager for plugins.
+ *
+ * @package dependencies-manager.
+ * @since 1.0
+ */
+
+/**
+ * Plugins dependencies manager.
+ *
+ * @since 1.0.0
+ */
+class WP_Plugins_Dependencies {
+
+	/**
+	 * The database option where we store the array of plugins that should be active
+	 * but are not due to unmet dependencies.
+	 *
+	 * @since 5.9.0
+	 * @access protected
+	 *
+	 * @var string
+	 */
+	protected $pending_plugin_activations_option = 'pending_plugin_activations';
+
+	/**
+	 * Installed plugins.
+	 *
+	 * @since 5.9.0
+	 * @access protected
+	 *
+	 * @var array
+	 */
+	protected $installed_plugins;
+
+	/**
+	 * An array of admin notices to show.
+	 *
+	 * @since 5.9.0
+	 * @access protected
+	 *
+	 * @var array
+	 */
+	protected $notices = array();
+
+	/**
+	 * Array of parents for dependencies.
+	 *
+	 * @since 5.9.0
+	 * @access protected
+	 *
+	 * @var array
+	 */
+	protected $dependencies_parents = array();
+
+	/**
+	 * An array of plugin dependencies.
+	 *
+	 * @since 5.9.0
+	 * @access protected
+	 *
+	 * @var array
+	 */
+	protected $plugin_dependencies = array();
+
+	/**
+	 * Constructor.
+	 *
+	 * Add hooks.
+	 *
+	 * @since 5.9.0
+	 */
+	public function __construct() {
+		// Get an array of installed plugins and set it in the object's $installed_plugins prop.
+		$this->get_plugins();
+
+		// Add a hook to allow canceling an activation request.
+		$this->cancel_activation_request();
+
+		// Go through installed plugins and process their dependencies.
+		$this->loop_installed_plugins();
+
+		// Add the admin notices.
+		add_action( 'admin_notices', array( $this, 'admin_notices' ) );
+
+		// Add extra info below plugins that are dependencies.
+		add_action( 'after_plugin_row', array( $this, 'after_plugin_row' ), 10, 2 );
+
+		// Filter available plugin actions.
+		add_filter( 'plugin_action_links', array( $this, 'plugin_action_links' ), 10, 4 );
+	}
+
+	/**
+	 * Get an array of installed plugins and set it in the object's $installed_plugins prop.
+	 *
+	 * @since 5.9.0
+	 * @access protected
+	 *
+	 * @return void
+	 */
+	protected function get_plugins() {
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		// Get an array of all plugins.
+		$this->installed_plugins = get_plugins();
+	}
+
+	/**
+	 * Loop installed plugins and process dependencies.
+	 *
+	 * @since 5.9.0
+	 * @access public
+	 *
+	 * @return void
+	 */
+	public function loop_installed_plugins() {
+		foreach ( $this->installed_plugins as $file => $plugin ) {
+			$this->maybe_process_plugin_dependencies( $file );
+		}
+	}
+
+	/**
+	 * Check plugin dependencies.
+	 *
+ 	 * @since 5.9.0
+	 * @access public
+	 *
+	 * @param string $file The plugin file.
+	 *
+	 * @return void
+	 */
+	public function maybe_process_plugin_dependencies( $file ) {
+
+		$plugin_is_active           = is_plugin_active( $file );
+		$plugin_awaiting_activation = in_array( $file, $this->get_plugins_to_activate(), true );
+
+		// Early return if the plugin is not active or we don't want to activate it.
+		if ( ! $plugin_is_active && ! $plugin_awaiting_activation ) {
+			return;
+		}
+
+		// Get the dependencies.
+		$dependencies = $this->get_plugin_dependencies( $file );
+
+		// Early return if there are no dependencies.
+		if ( empty( $dependencies ) ) {
+			return;
+		}
+
+		// Loop dependencies.
+		$dependencies_met = true;
+		foreach ( $dependencies as $dependency ) {
+
+			// Set $dependencies_met to false if one of the dependencies is not met.
+			if ( ! $this->process_plugin_dependency( $file, $dependency ) ) {
+				$dependencies_met = false;
+			}
+		}
+
+		if ( ! $dependencies_met ) {
+
+			// Make sure plugin is deactivated when its dependencies are not met.
+			if ( $plugin_is_active ) {
+				deactivate_plugins( $file );
+			}
+
+			// Add plugin to queue of plugins to be activated.
+			$this->add_plugin_to_queue( $file );
+
+		} elseif ( $plugin_awaiting_activation ) {
+			activate_plugin( $file );
+			$this->remove_plugin_from_queue( $file );
+		}
+	}
+
+	/**
+	 * Get an array of dependencies.
+	 *
+	 * @since 5.9.0
+	 * @access public
+	 *
+	 * @param string $file The plugin file.
+	 *
+	 * @return array
+	 */
+	public function get_plugin_dependencies( $file ) {
+
+		if ( ! isset( $this->plugin_dependencies[ $file ] ) ) {
+			// Get the plugin directory.
+			$plugin_dir = dirname( WP_PLUGIN_DIR . '/' . $file );
+
+			$this->plugin_dependencies[ $file ] = array();
+			if ( file_exists( "$plugin_dir/dependencies.json" ) ) {
+				$this->plugin_dependencies[ $file ] = json_decode( file_get_contents( "$plugin_dir/dependencies.json" ) );
+			}
+		}
+
+		return $this->plugin_dependencies[ $file ];
+	}
+
+	/**
+	 * Processes a plugin dependency.
+	 *
+	 * @since 5.9.0
+	 * @access protected
+	 *
+	 * @param string   $plugin     The plugin defining the dependency.
+	 * @param stdClass $dependency A dependency.
+	 *
+	 * @return bool
+	 */
+	protected function process_plugin_dependency( $plugin, $dependency ) {
+		$dependency_is_installed = false;
+		$dependency_is_active    = false;
+		$dependency_needs_update = false;
+
+		foreach ( $this->installed_plugins as $file => $installed_plugin ) {
+			if ( dirname( $file ) === $dependency->slug ) {
+				$dependency->file        = $file;
+				$dependency_is_installed = true;
+				if ( is_plugin_active( $file ) ) {
+					$dependency_is_active = true;
+				}
+				$installed_version = get_plugin_data( WP_PLUGIN_DIR . '/' . $file )['Version'];
+				if ( ! empty( $installed_version ) && ! empty( $dependency->version ) && version_compare( $installed_version, $dependency->version, '<' ) ) {
+					$dependency_needs_update = true;
+				}
+
+				break;
+			}
+		}
+
+		// If the dependency is not installed, install it, otherwise activate it.
+		if ( ! $dependency_is_installed ) {
+			$this->add_notice_install( get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin ), $dependency );
+			return false;
+		}
+
+		// If the installed version is lower than the required version, update it.
+		if ( $dependency_needs_update ) {
+			$this->add_notice_update( get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin ), $dependency );
+			return false;
+		}
+
+		// If the plugin is not activated, activate it.
+		if ( ! $dependency_is_active ) {
+			$this->add_notice_activate( get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin ), $dependency );
+			return false;
+		}
+
+		// Add item to the $dependencies_parents array.
+		if ( empty( $this->dependencies_parents[ $dependency->file ] ) ) {
+			$this->dependencies_parents[ $dependency->file ] = array();
+		}
+		$this->dependencies_parents[ $dependency->file ][] = $plugin;
+
+		return true;
+	}
+
+	/**
+	 * Add notices.
+	 *
+	 * @since 5.9.0
+	 * @access public
+	 *
+	 * @return void
+	 */
+	public function admin_notices() {
+		// Early return if there are no notices to display.
+		if ( empty( $this->notices ) ) {
+			return;
+		}
+
+		foreach ( $this->notices as $notice ) {
+			echo '<div class="notice notice-warning plugin-dependencies"><p>' . wp_kses_post( $notice['content'] ) . '</p></div>';
+		}
+	}
+
+	/**
+	 * Cancel plugin's activation request.
+	 *
+	 * @since 5.9.0
+	 * @access public
+	 *
+	 * @return void
+	 */
+	public function cancel_activation_request() {
+		if ( empty( $_GET['action'] ) || 'cancel-activate' !== $_GET['action'] || empty( $_GET['plugin'] ) ) {
+			return;
+		}
+		$file = sanitize_text_field( wp_unslash( $_GET['plugin'] ) );
+		check_admin_referer( 'cancel-activate-plugin_' . $file );
+
+		$this->remove_plugin_from_queue( $file );
+	}
+
+	/**
+	 * Filters the action links displayed for each plugin in the Plugins list table.
+	 *
+	 * @since 5.9.0
+	 * @access public
+	 *
+	 * @param string[] $actions     An array of plugin action links.
+	 * @param string   $plugin_file Path to the plugin file relative to the plugins directory.
+	 * @param array    $plugin_data An array of plugin data. See `get_plugin_data()`.
+	 *
+	 * @return string[]
+	 */
+	public function plugin_action_links( $actions, $plugin_file, $plugin_data ) {
+
+		// Remove deactivation link from dependencies.
+		if ( ! empty( $this->dependencies_parents[ $plugin_file ] ) ) {
+			unset( $actions['deactivate'] );
+		}
+
+		// On plugins with unmet dependencies that the user has already requested for the plugin's activation,
+		// removes the activation link from its actions and add a "Cancel pending activation" link in its place.
+		if ( in_array( $plugin_file, $this->get_plugins_to_activate(), true ) && ! empty( $this->get_plugin_dependencies( $plugin_file ) ) ) {
+			unset( $actions['activate'] );
+			if ( current_user_can( 'activate_plugin', $plugin_file ) ) {
+				$cancel_activation = sprintf(
+					'<a href="%s" class="cancel-activate unmet-dependencies" aria-label="%s">%s</a>',
+					wp_nonce_url( 'plugins.php?action=cancel-activate&amp;plugin=' . rawurlencode( $plugin_file ), 'cancel-activate-plugin_' . $plugin_file ),
+					/* translators: %s: Plugin name. */
+					esc_attr( sprintf( _x( 'Cancel activation of %s', 'plugin' ), get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin_file )['Name'] ) ),
+					__( 'Cancel activation request' )
+				);
+
+				$actions = array_merge( array( 'cancel-activation' => $cancel_activation ), $actions );
+			}
+		}
+		return $actions;
+	}
+
+	/**
+	 * Add dependencies info in plugins.
+	 *
+	 * @since 5.9.0
+	 * @access public
+	 *
+	 * @param string $plugin_file Path to the plugin file relative to the plugins directory.
+	 * @param array  $plugin_data An array of plugin data.
+	 *
+	 * @return void
+	 */
+	public function after_plugin_row( $plugin_file, $plugin_data ) {
+
+		// Add extra info to dependencies.
+		if ( ! empty( $this->dependencies_parents[ $plugin_file ] ) ) {
+			$parents_names = array();
+			foreach ( $this->dependencies_parents[ $plugin_file ] as $parent ) {
+				$parents_names[] = get_plugin_data( WP_PLUGIN_DIR . '/' . $parent )['Name'];
+			}
+
+			$style = is_rtl() ? 'border-top:none;border-left:none' : 'border-top:none;border-right:none';
+			echo '<tr><td colspan="5" class="notice notice-info notice-alt" style="' . esc_attr( $style ) . '">';
+			if ( 1 < count( $parents_names ) ) {
+				printf(
+					/* translators: %1$s: plugin name. %2$s: Parent plugin names, comma-separated. */
+					esc_html__( 'Plugin %1$s is a dependency for the following plugins: %2$s.' ),
+					esc_html( $plugin_data['Name'] ),
+					esc_html( implode( ', ', $parents_names ) )
+				);
+			} else {
+				printf(
+					/* translators: %1$s: plugin name. %2$s: Parent plugin name. */
+					esc_html__( 'Plugin %1$s is a dependency for the "%2$s" plugin.' ),
+					esc_html( $plugin_data['Name'] ),
+					esc_html( $parents_names[0] )
+				);
+			}
+			echo '</td></tr>';
+		}
+
+		// Add extra info to parents with unmet dependencies.
+		if ( in_array( $plugin_file, $this->get_plugins_to_activate(), true ) && ! empty( $this->get_plugin_dependencies( $plugin_file ) ) ) {
+			$style = is_rtl() ? 'border-top:none;border-left:none' : 'border-top:none;border-right:none';
+			echo '<tr><td colspan="5" class="notice notice-warning notice-alt" style="' . esc_attr( $style ) . '">';
+			printf(
+				/* translators: %s: plugin name. */
+				esc_html__( 'Plugin "%s" has unmet dependencies. Once all required plugins are installed the plugin will be automatically activated. Alternatively you can cancel the activation of this plugin by clicking on the "cancel activation request" link above.' ),
+				esc_html( $plugin_data['Name'] )
+			);
+			echo '</td></tr>';
+		}
+	}
+
+	/**
+	 * Show a notice to install a dependency.
+	 *
+	 * @since 5.9.0
+	 * @access protected
+	 *
+	 * @param array    $plugin     The plugin calling the dependencies.
+	 * @param stdClass $dependency The plugin slug.
+	 *
+	 * @return void
+	 */
+	protected function add_notice_install( $plugin, $dependency ) {
+		if ( ! function_exists( 'install_plugin_install_status' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
+		}
+		$this->notices[] = array(
+			'content' => sprintf(
+				/* translators: %1$s: The plugin we want to activate. %2$s: The name of the plugin to install. %3$s: "Install & Activate" button. */
+				__( 'Plugin "%1$s" depends on plugin "%2$s" to be installed. %3$s' ),
+				$plugin['Name'],
+				$dependency->name,
+				/* translators: %s: Plugin name. */
+				'<a href="' . esc_url( install_plugin_install_status( array( 'slug' => $dependency->name ) )['url'] ) . '">' . sprintf( __( 'Install and activate %s' ), $dependency->name ) . '</a>'
+			),
+		);
+	}
+
+	/**
+	 * Show a notice to update a dependency.
+	 *
+	 * @since 5.9.0
+	 * @access protected
+	 *
+	 * @param array    $plugin     The plugin calling the dependencies.
+	 * @param stdClass $dependency The plugin slug.
+	 *
+	 * @return void
+	 */
+	protected function add_notice_update( $plugin, $dependency ) {
+		if ( ! current_user_can( 'update_plugins' ) ) {
+			return;
+		}
+		$this->notices[] = array(
+			'content' => sprintf(
+				/* translators: %1$s: The plugin we want to activate. %2$s: The name of the plugin to install. %3$s: Minimum required version. %4$s: Currently installed version. %5$s: Update URL. */
+				__( 'Plugin "%1$s" depends on plugin "%2$s" version %3$s or higher to be installed, and you currently have version %4$s installed. <a href="%5$s">Update %2$s</a>' ),
+				$plugin['Name'],
+				$dependency->name,
+				$dependency->version,
+				get_plugin_data( WP_PLUGIN_DIR . '/' . $dependency->file )['Version'],
+				wp_nonce_url( self_admin_url( 'update.php?action=upgrade-plugin&plugin=' . $dependency->file ), 'upgrade-plugin_' . $dependency->file )
+			),
+		);
+	}
+
+	/**
+	 * Show a notice to activate a dependency.
+	 *
+	 * @since 5.9.0
+	 * @access protected
+	 *
+	 * @param array    $plugin     The plugin calling the dependencies.
+	 * @param stdClass $dependency The plugin slug.
+	 *
+	 * @return void
+	 */
+	protected function add_notice_activate( $plugin, $dependency ) {
+		$activate_url = wp_nonce_url( 'plugins.php?action=activate&amp;plugin=' . rawurlencode( $dependency->file ) . '&amp;plugin_status=all', 'activate-plugin_' . $dependency->file );
+
+		$this->notices[] = array(
+			'content' => sprintf(
+				/* translators: %1$s: The plugin we want to activate. %2$s: The name of the plugin to install. %3$s: "Activate" button. */
+				__( 'Plugin "%1$s" depends on plugin "%2$s" to be activated. %3$s' ),
+				$plugin['Name'],
+				$dependency->name,
+				'<a href="' . $activate_url . '">' . __( 'Activate plugin' ) . '</a>'
+			),
+		);
+	}
+
+	/**
+	 * Get an array of plugins that should be activated but are not,
+	 * due to missing/unmet dependencies.
+	 *
+	 * @since 5.9.0
+	 * @access public
+	 *
+	 * @return array
+	 */
+	public function get_plugins_to_activate() {
+		return get_option( $this->pending_plugin_activations_option, array() );
+	}
+
+	/**
+	 * Set plugin to the to-be-activated queue.
+	 *
+	 * @since 5.9.0
+	 * @access protected
+	 *
+	 * @param string $plugin The plugin file.
+	 *
+	 * @return bool
+	 */
+	protected function add_plugin_to_queue( $plugin ) {
+		$queue = $this->get_plugins_to_activate();
+		if ( in_array( $plugin, $queue, true ) ) {
+			return true;
+		}
+		$queue[] = $plugin;
+		return update_option( $this->pending_plugin_activations_option, $queue );
+	}
+
+	/**
+	 * Remove plugin from the to-be-activated queue.
+	 *
+	 * @since 5.9.0
+	 * @access protected
+	 *
+	 * @param string $plugin The plugin file.
+	 *
+	 * @return bool
+	 */
+	protected function remove_plugin_from_queue( $plugin ) {
+		$queue = $this->get_plugins_to_activate();
+		if ( ! in_array( $plugin, $queue, true ) ) {
+			return true;
+		}
+		return update_option( $this->pending_plugin_activations_option, array_diff( $queue, array( $plugin ) ) );
+	}
+}
+
+global $plugin_dependencies;
+$plugin_dependencies = new WP_Plugins_Dependencies();

--- a/src/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/src/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -214,7 +214,7 @@ class WP_Plugin_Dependencies {
 	public function get_plugin_dependencies( $file ) {
 		if ( ! isset( $this->plugin_dependencies[ $file ] ) ) {
 			$this->plugin_dependencies[ $file ] = array();
-			$plugin_dependencies = get_plugin_data( WP_PLUGIN_DIR . '/' . $file )['RequiresPlugins'];
+			$plugin_dependencies                = get_plugin_data( WP_PLUGIN_DIR . '/' . $file )['RequiresPlugins'];
 			if ( empty( $plugin_dependencies ) ) {
 				$this->plugin_dependencies[ $file ] = array();
 				return array();
@@ -598,7 +598,7 @@ class WP_Plugin_Dependencies {
 		foreach ( $plugin_dependencies as $dependency ) {
 			$dependency_file = $this->get_plugin_file_from_slug( $dependency['slug'] );
 			if ( $this->in_circular_dependency( $dependency_file, array_merge( $previous, array( $plugin_file ) ) ) ) {
-				$this->circular_dependencies[ $plugin_file ] = true;
+				$this->circular_dependencies[ $plugin_file ]     = true;
 				$this->circular_dependencies[ $dependency_file ] = true;
 			}
 		}

--- a/src/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/src/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -263,7 +263,7 @@ class WP_Plugin_Dependencies {
 	 * @param string   $plugin     The plugin defining the dependency.
 	 * @param stdClass $dependency A dependency.
 	 *
-	 * @return void
+	 * @return bool Returns false if the plugin has unmet dependencies, otherwise returns true.
 	 */
 	private function process_plugin_dependency( $plugin, $dependency ) {
 		$dependency_is_installed = false;
@@ -284,11 +284,13 @@ class WP_Plugin_Dependencies {
 		// If the dependency is not installed, install it, otherwise activate it.
 		if ( ! $dependency_is_installed ) {
 			$this->add_notice_install( get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin ), $dependency );
+			return false;
 		}
 
 		// If the plugin is not activated, activate it.
 		if ( ! $dependency_is_active ) {
 			$this->add_notice_activate( get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin ), $dependency );
+			return false;
 		}
 
 		// Add item to the $dependencies_parents array.
@@ -296,6 +298,8 @@ class WP_Plugin_Dependencies {
 			$this->dependencies_parents[ $dependency['file'] ] = array();
 		}
 		$this->dependencies_parents[ $dependency['file'] ][] = $plugin;
+
+		return true;
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/src/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -460,7 +460,7 @@ class WP_Plugin_Dependencies {
 		<tr class="<?php echo esc_attr( $tr_class ); ?>">
 			<td class="plugin-dependencies colspanchange" colspan="<?php echo esc_attr( $colspan ); ?>">
 				<div class="dependencies-message notice inline notice-<?php echo esc_attr( $notice_type ); ?> notice-alt">
-					<p><?php echo $contents; ?></p>
+					<p><?php echo $contents; // phpcs:ignore WordPress.Security.EscapeOutput This output is escaped beforehand. ?></p>
 				</div>
 			</td>
 		</tr>

--- a/src/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/src/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -244,7 +244,7 @@ class WP_Plugin_Dependencies {
 				}
 				$dependencies[] = array(
 					'namespace' => '',
-					'slug'      => trim( $dependency )
+					'slug'      => trim( $dependency ),
 				);
 			}
 

--- a/src/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/src/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -18,61 +18,61 @@ class WP_Plugin_Dependencies {
 	 * but are not due to unmet dependencies.
 	 *
 	 * @since 5.9.0
-	 * @access protected
+	 * @access private
 	 *
 	 * @var string
 	 */
-	protected $pending_plugin_activations_option = 'pending_plugin_activations';
+	private $pending_plugin_activations_option = 'pending_plugin_activations';
 
 	/**
 	 * Installed plugins.
 	 *
 	 * @since 5.9.0
-	 * @access protected
+	 * @access private
 	 *
 	 * @var array
 	 */
-	protected $installed_plugins;
+	private $installed_plugins;
 
 	/**
 	 * An array of admin notices to show.
 	 *
 	 * @since 5.9.0
-	 * @access protected
+	 * @access private
 	 *
 	 * @var array
 	 */
-	protected $notices = array();
+	private $notices = array();
 
 	/**
 	 * Array of parents for dependencies.
 	 *
 	 * @since 5.9.0
-	 * @access protected
+	 * @access private
 	 *
 	 * @var array
 	 */
-	protected $dependencies_parents = array();
+	private $dependencies_parents = array();
 
 	/**
 	 * An array of plugin dependencies.
 	 *
 	 * @since 5.9.0
-	 * @access protected
+	 * @access private
 	 *
 	 * @var array
 	 */
-	protected $plugin_dependencies = array();
+	private $plugin_dependencies = array();
 
 	/**
 	 * An array of plugins participating in a circular dependencies loop.
 	 *
 	 * @since 5.9.0
-	 * @access protected
+	 * @access private
 	 *
 	 * @var array
 	 */
-	protected $circular_dependencies = array();
+	private $circular_dependencies = array();
 
 	/**
 	 * Constructor.

--- a/src/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/src/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -454,14 +454,12 @@ class WP_Plugin_Dependencies {
 	 * @access protected
 	 */
 	protected function inline_plugin_row_notice( $contents = '', $notice_type = 'info', $plugin_file = '' ) {
-		$is_plugin_active = is_plugin_active( $plugin_file );
-		$tr_class         = $is_plugin_active ? 'plugin-dependencies-tr active' : 'plugin-dependencies-tr';
-		$td_class         = 'plugin-dependencies colspanchange';
-		$colspan          = (int) _get_list_table( 'WP_Plugins_List_Table', array( 'screen' => get_current_screen() ) )->get_column_count();
+		$tr_class = is_plugin_active( $plugin_file ) ? 'plugin-dependencies-tr active' : 'plugin-dependencies-tr';
+		$colspan  = (int) _get_list_table( 'WP_Plugins_List_Table', array( 'screen' => get_current_screen() ) )->get_column_count();
 		?>
 		<tr class="<?php echo esc_attr( $tr_class ); ?>">
-			<td class="<?php echo esc_attr( $td_class ); ?>" colspan="<?php echo esc_attr( $colspan ); ?>" style="padding:0">
-				<div class="dependencies-message notice inline notice-<?php echo esc_attr( $notice_type ); ?> notice-alt" style="margin:0;border-top:none;border-<?php echo is_rtl() ? 'left' : 'right'; ?>:none;">
+			<td class="plugin-dependencies colspanchange" colspan="<?php echo esc_attr( $colspan ); ?>">
+				<div class="dependencies-message notice inline notice-<?php echo esc_attr( $notice_type ); ?> notice-alt">
 					<p><?php echo $contents; ?></p>
 				</div>
 			</td>

--- a/src/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/src/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -114,11 +114,11 @@ class WP_Plugin_Dependencies {
 	 * Get an array of installed plugins and set it in the object's $installed_plugins prop.
 	 *
 	 * @since 5.9.0
-	 * @access protected
+	 * @access private
 	 *
 	 * @return array
 	 */
-	protected function get_plugins() {
+	private function get_plugins() {
 		if ( ! function_exists( 'get_plugins' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
@@ -135,11 +135,11 @@ class WP_Plugin_Dependencies {
 	 * Loop installed plugins and process dependencies.
 	 *
 	 * @since 5.9.0
-	 * @access public
+	 * @access private
 	 *
 	 * @return void
 	 */
-	public function loop_installed_plugins() {
+	private function loop_installed_plugins() {
 		foreach ( $this->installed_plugins as $file => $plugin ) {
 			$this->maybe_process_plugin_dependencies( $file );
 		}
@@ -149,13 +149,13 @@ class WP_Plugin_Dependencies {
 	 * Check plugin dependencies.
 	 *
 	 * @since 5.9.0
-	 * @access public
+	 * @access private
 	 *
 	 * @param string $file The plugin file.
 	 *
 	 * @return void
 	 */
-	public function maybe_process_plugin_dependencies( $file ) {
+	private function maybe_process_plugin_dependencies( $file ) {
 
 		$plugin_is_active           = is_plugin_active( $file );
 		$plugin_awaiting_activation = in_array( $file, $this->get_plugins_to_activate(), true );
@@ -233,14 +233,14 @@ class WP_Plugin_Dependencies {
 	 * Processes a plugin dependency.
 	 *
 	 * @since 5.9.0
-	 * @access protected
+	 * @access private
 	 *
 	 * @param string   $plugin     The plugin defining the dependency.
 	 * @param stdClass $dependency A dependency.
 	 *
 	 * @return bool
 	 */
-	protected function process_plugin_dependency( $plugin, $dependency ) {
+	private function process_plugin_dependency( $plugin, $dependency ) {
 		$dependency_is_installed = false;
 		$dependency_is_active    = false;
 
@@ -300,11 +300,11 @@ class WP_Plugin_Dependencies {
 	 * Cancel plugin's activation request.
 	 *
 	 * @since 5.9.0
-	 * @access public
+	 * @access private
 	 *
 	 * @return void
 	 */
-	public function cancel_activation_request() {
+	private function cancel_activation_request() {
 		if ( empty( $_GET['action'] ) || 'cancel-activate' !== $_GET['action'] || empty( $_GET['plugin'] ) ) {
 			return;
 		}
@@ -454,9 +454,9 @@ class WP_Plugin_Dependencies {
 	 * Generate the contents of an inline plugin row notice.
 	 *
 	 * @since 5.9.0
-	 * @access protected
+	 * @access private
 	 */
-	protected function inline_plugin_row_notice( $contents = '', $notice_type = 'info', $plugin_file = '' ) {
+	private function inline_plugin_row_notice( $contents = '', $notice_type = 'info', $plugin_file = '' ) {
 		$tr_class = is_plugin_active( $plugin_file ) ? 'plugin-dependencies-tr active' : 'plugin-dependencies-tr';
 		$colspan  = (int) _get_list_table( 'WP_Plugins_List_Table', array( 'screen' => get_current_screen() ) )->get_column_count();
 		?>
@@ -474,14 +474,14 @@ class WP_Plugin_Dependencies {
 	 * Show a notice to install a dependency.
 	 *
 	 * @since 5.9.0
-	 * @access protected
+	 * @access private
 	 *
 	 * @param array    $plugin     The plugin calling the dependencies.
 	 * @param stdClass $dependency The plugin slug.
 	 *
 	 * @return void
 	 */
-	protected function add_notice_install( $plugin, $dependency ) {
+	private function add_notice_install( $plugin, $dependency ) {
 		if ( ! function_exists( 'install_plugin_install_status' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
 		}
@@ -501,14 +501,14 @@ class WP_Plugin_Dependencies {
 	 * Show a notice to activate a dependency.
 	 *
 	 * @since 5.9.0
-	 * @access protected
+	 * @access private
 	 *
 	 * @param array    $plugin     The plugin calling the dependencies.
 	 * @param stdClass $dependency The plugin slug.
 	 *
 	 * @return void
 	 */
-	protected function add_notice_activate( $plugin, $dependency ) {
+	private function add_notice_activate( $plugin, $dependency ) {
 		$activate_url = wp_nonce_url( 'plugins.php?action=activate&amp;plugin=' . rawurlencode( $dependency['file'] ) . '&amp;plugin_status=all', 'activate-plugin_' . $dependency['file'] );
 
 		$this->notices[] = array(
@@ -539,13 +539,13 @@ class WP_Plugin_Dependencies {
 	 * Set plugin to the to-be-activated queue.
 	 *
 	 * @since 5.9.0
-	 * @access protected
+	 * @access private
 	 *
 	 * @param string $plugin The plugin file.
 	 *
 	 * @return bool
 	 */
-	protected function add_plugin_to_queue( $plugin ) {
+	private function add_plugin_to_queue( $plugin ) {
 		$queue = $this->get_plugins_to_activate();
 		if ( in_array( $plugin, $queue, true ) ) {
 			return true;
@@ -558,13 +558,13 @@ class WP_Plugin_Dependencies {
 	 * Remove plugin from the to-be-activated queue.
 	 *
 	 * @since 5.9.0
-	 * @access protected
+	 * @access private
 	 *
 	 * @param string $plugin The plugin file.
 	 *
 	 * @return bool
 	 */
-	protected function remove_plugin_from_queue( $plugin ) {
+	private function remove_plugin_from_queue( $plugin ) {
 		$queue = $this->get_plugins_to_activate();
 		if ( ! in_array( $plugin, $queue, true ) ) {
 			return true;
@@ -576,7 +576,7 @@ class WP_Plugin_Dependencies {
 	 * Check if a plugin is part of a circular dependencies loop.
 	 *
 	 * @since 5.9.0
-	 * @access protected
+	 * @access private
 	 *
 	 * @param string $plugin_file The plugin file.
 	 * @param array  $previous    If this is a dependency of a dependency,
@@ -584,7 +584,7 @@ class WP_Plugin_Dependencies {
 	 *
 	 * @return bool
 	 */
-	protected function in_circular_dependency( $plugin_file, $previous = array() ) {
+	private function in_circular_dependency( $plugin_file, $previous = array() ) {
 		if ( isset( $this->circular_dependencies[ $plugin_file ] ) ) {
 			return $this->circular_dependencies[ $plugin_file ];
 		}
@@ -614,13 +614,13 @@ class WP_Plugin_Dependencies {
 	 * Get plugin file from its slug.
 	 *
 	 * @since 5.9.0
-	 * @access protected
+	 * @access private
 	 *
 	 * @param string $slug The plugin slug.
 	 *
 	 * @return string|false Returns the plugin file on success, false on failure.
 	 */
-	protected function get_plugin_file_from_slug( $slug ) {
+	private function get_plugin_file_from_slug( $slug ) {
 		$plugins = $this->get_plugins();
 		foreach ( array_keys( $plugins ) as $plugin ) {
 			if ( 0 === strpos( $plugin, "$slug/" ) || 0 === strpos( $plugin, "$slug\\" ) ) {

--- a/src/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/src/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -415,7 +415,7 @@ class WP_Plugin_Dependencies {
 				);
 			}
 
-			$this->inline_plugin_row_notice( $notice_contents, 'info', $plugin_file );
+			$this->inline_plugin_row_notice( $notice_contents, 'info', $plugin_file, $is_plugin_active );
 		}
 
 		// Add extra info to parents.
@@ -427,7 +427,8 @@ class WP_Plugin_Dependencies {
 						sprintf(
 							/* translators: %s: plugin name. */
 							esc_html__( 'Warning: Circular dependencies detected. Plugin "%s" has unmet dependencies. Please contact the plugin author to report this circular dependencies issue.' ),
-							esc_html( $plugin_data['Name'] )
+							esc_html( $plugin_data['Name'] ),
+							false
 						),
 						'warning',
 						$plugin_file
@@ -440,7 +441,8 @@ class WP_Plugin_Dependencies {
 							esc_html( $plugin_data['Name'] )
 						),
 						'warning',
-						$plugin_file
+						$plugin_file,
+						false
 					);
 				}
 			} elseif ( ! $is_plugin_active ) {
@@ -461,7 +463,8 @@ class WP_Plugin_Dependencies {
 						esc_html( implode( ', ', $dependencies_human_readable ) )
 					),
 					'info',
-					$plugin_file
+					$plugin_file,
+					false
 				);
 			}
 		}
@@ -473,8 +476,8 @@ class WP_Plugin_Dependencies {
 	 * @since 5.9.0
 	 * @access private
 	 */
-	private function inline_plugin_row_notice( $contents = '', $notice_type = 'info', $plugin_file = '' ) {
-		$tr_class = is_plugin_active( $plugin_file ) ? 'plugin-dependencies-tr active' : 'plugin-dependencies-tr';
+	private function inline_plugin_row_notice( $contents = '', $notice_type = 'info', $plugin_file = '', $is_plugin_active = false ) {
+		$tr_class = $is_plugin_active ? 'plugin-dependencies-tr active' : 'plugin-dependencies-tr';
 		$colspan  = (int) _get_list_table( 'WP_Plugins_List_Table', array( 'screen' => get_current_screen() ) )->get_column_count();
 		?>
 		<tr class="<?php echo esc_attr( $tr_class ); ?>">

--- a/src/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/src/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -338,7 +338,7 @@ class WP_Plugin_Dependencies {
 		}
 
 		// On plugins with unmet dependencies that the user has already requested for the plugin's activation,
-		// removes the activation link from its actions and add a "Cancel pending activation" link in its place.
+		// removes the activation link from its actions and adds a "Cancel pending activation" link in its place.
 		if ( $pending_activation && $has_dependencies ) {
 			unset( $actions['activate'] );
 			if ( current_user_can( 'activate_plugin', $plugin_file ) ) {

--- a/src/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/src/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -427,7 +427,7 @@ class WP_Plugin_Dependencies {
 			if ( $in_circular_dependency ) {
 				$this->inline_plugin_row_notice(
 					sprintf(
-					/* translators: %s: plugin name. */
+						/* translators: %s: plugin name. */
 						esc_html__( 'Warning: Circular dependencies detected. Plugin "%s" has unmet dependencies. Please contact the plugin author to report this circular dependencies issue.' ),
 						esc_html( $plugin_data['Name'] ),
 						false
@@ -438,7 +438,7 @@ class WP_Plugin_Dependencies {
 			}
 			$this->inline_plugin_row_notice(
 				sprintf(
-				/* translators: %s: plugin name. */
+					/* translators: %s: plugin name. */
 					esc_html__( 'Plugin "%s" has unmet dependencies. Once all required plugins are installed the plugin will be automatically activated. Alternatively you can cancel the activation of this plugin by clicking on the "cancel activation request" link above.' ),
 					esc_html( $plugin_data['Name'] )
 				),
@@ -460,7 +460,7 @@ class WP_Plugin_Dependencies {
 			}
 			$this->inline_plugin_row_notice(
 				sprintf(
-				/* translators: %1$s: plugin name. %2$s: plugin requirements, comma-separated. */
+					/* translators: %1$s: plugin name. %2$s: plugin requirements, comma-separated. */
 					esc_html__( 'Plugin "%1$s" depends on the following plugin(s): %2$s' ),
 					esc_html( $plugin_data['Name'] ),
 					esc_html( implode( ', ', $dependencies_human_readable ) )

--- a/src/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/src/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -107,7 +107,7 @@ class WP_Plugin_Dependencies {
 		add_action( 'after_plugin_row', array( $this, 'after_plugin_row' ), 10, 2 );
 
 		// Filter available plugin actions.
-		add_filter( 'plugin_action_links', array( $this, 'plugin_action_links' ), 10, 4 );
+		add_filter( 'plugin_action_links', array( $this, 'plugin_action_links' ), 10, 2 );
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/src/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -194,7 +194,7 @@ class WP_Plugin_Dependencies {
 				return array();
 			}
 
-			$plugin_dependencies = explode( ',', $plugin_dependencies );
+			$plugin_dependencies = str_getcsv( $plugin_dependencies );
 			foreach ( $plugin_dependencies as $key => $dependency ) {
 				$this->plugin_dependencies[ $file ][] = array( 'slug' => trim( $dependency ) );
 			}

--- a/src/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/src/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -22,7 +22,7 @@ class WP_Plugin_Dependencies {
 	 *
 	 * @var string
 	 */
-	private $pending_plugin_activations_option = 'pending_plugin_activations';
+	const PENDING_PLUGIN_ACTIVATIONS_OPTION = 'pending_plugin_activations';
 
 	/**
 	 * Installed plugins.
@@ -532,7 +532,7 @@ class WP_Plugin_Dependencies {
 	 * @return array
 	 */
 	public function get_plugins_to_activate() {
-		return get_option( $this->pending_plugin_activations_option, array() );
+		return get_option( self::PENDING_PLUGIN_ACTIVATIONS_OPTION, array() );
 	}
 
 	/**
@@ -551,7 +551,7 @@ class WP_Plugin_Dependencies {
 			return true;
 		}
 		$queue[] = $plugin;
-		return update_option( $this->pending_plugin_activations_option, $queue );
+		return update_option( self::PENDING_PLUGIN_ACTIVATIONS_OPTION, $queue );
 	}
 
 	/**
@@ -569,7 +569,7 @@ class WP_Plugin_Dependencies {
 		if ( ! in_array( $plugin, $queue, true ) ) {
 			return true;
 		}
-		return update_option( $this->pending_plugin_activations_option, array_diff( $queue, array( $plugin ) ) );
+		return update_option( self::PENDING_PLUGIN_ACTIVATIONS_OPTION, array_diff( $queue, array( $plugin ) ) );
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/src/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -389,7 +389,6 @@ class WP_Plugin_Dependencies {
 	 */
 	public function disable_checkbox_for_dependency( $disabled, $plugin_file ) {
 		if ( ! empty( $this->get_parents( $plugin_file ) ) && is_plugin_active( $plugin_file ) ) {
-			var_dump( $plugin_file );
 			return true;
 		}
 		return $disabled;

--- a/src/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/src/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -406,7 +406,7 @@ class WP_Plugin_Dependencies {
 					$this->inline_plugin_row_notice(
 						sprintf(
 							/* translators: %s: plugin name. */
-							esc_html__( 'Warning: Circular dependencies detected. Plugin "%s" has unmet dependencies.' ),
+							esc_html__( 'Warning: Circular dependencies detected. Plugin "%s" has unmet dependencies. Please contact the plugin author to report this circular dependencies issue.' ),
 							esc_html( $plugin_data['Name'] )
 						),
 						'warning',

--- a/src/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/src/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -146,6 +146,32 @@ class WP_Plugin_Dependencies {
 	}
 
 	/**
+	 * Determine if a plugin has unmet dependencies or not.
+	 *
+	 * @since 5.9.0
+	 * @access public
+	 *
+	 * @param string $plugin_file The plugin file.
+	 *
+	 * @return bool Return true if the plugin has unmet depoendencies, otherwise return false.
+	 */
+	public function has_unmet_dependencies( $plugin_file ) {
+		$dependencies = $this->get_plugin_dependencies( $plugin_file );
+
+		foreach ( $dependencies as $dependency ) {
+			$dependency_is_installed = false;
+			$dependency_is_active    = false;
+
+			foreach ( $this->installed_plugins as $file => $installed_plugin ) {
+				if ( dirname( $file ) === $dependency['slug'] && ! is_plugin_active( $file ) ) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	/**
 	 * Check plugin dependencies.
 	 *
 	 * @since 5.9.0
@@ -173,32 +199,31 @@ class WP_Plugin_Dependencies {
 			return;
 		}
 
-		// Loop dependencies.
-		$dependencies_met = true;
-		foreach ( $dependencies as $dependency ) {
+		// Early return if there are no unmet dependencies.
+		if ( ! $this->has_unmet_dependencies( $file ) ) {
 
-			// Set $dependencies_met to false if one of the dependencies is not met.
-			if ( ! $this->process_plugin_dependency( $file, $dependency ) ) {
-				$dependencies_met = false;
+			// Activate plugin if it's awaiting activation.
+			if ( $plugin_awaiting_activation ) {
+				activate_plugin( $file );
+				$this->remove_plugin_from_queue( $file );
 			}
+			return;
+		}
+
+		// Loop dependencies to add notices where needed.
+		foreach ( $dependencies as $dependency ) {
+			$this->process_plugin_dependency( $file, $dependency );
 		}
 
 		$in_circular_dependency = $this->in_circular_dependency( $file );
 
-		if ( ! $dependencies_met ) {
-
-			// Make sure plugin is deactivated when its dependencies are not met.
-			if ( $plugin_is_active && ! $in_circular_dependency ) {
-				deactivate_plugins( $file );
-			}
-
-			// Add plugin to queue of plugins to be activated.
-			$this->add_plugin_to_queue( $file );
-
-		} elseif ( $plugin_awaiting_activation ) {
-			activate_plugin( $file );
-			$this->remove_plugin_from_queue( $file );
+		// Make sure plugin is deactivated when its dependencies are not met.
+		if ( $plugin_is_active && ! $in_circular_dependency ) {
+			deactivate_plugins( $file );
 		}
+
+		// Add plugin to queue of plugins to be activated.
+		$this->add_plugin_to_queue( $file );
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/src/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -253,6 +253,8 @@ class WP_Plugin_Dependencies {
 	private function parse_dependency( $plugin, $dependency ) {
 		$dependency['installed'] = false;
 		$dependency['active']    = false;
+		$dependency['file']       = '';
+		$dependency['name']      = '';
 
 		foreach ( $this->installed_plugins as $file => $installed_plugin ) {
 			if ( dirname( $file ) === $dependency['slug'] ) {
@@ -267,10 +269,12 @@ class WP_Plugin_Dependencies {
 		}
 
 		// Add item to the $dependencies_parents array.
-		if ( empty( $this->dependencies_parents[ $dependency['file'] ] ) ) {
-			$this->dependencies_parents[ $dependency['file'] ] = array();
+		if ( $dependency['file'] ) {
+			if ( empty( $this->dependencies_parents[ $dependency['file'] ] ) ) {
+				$this->dependencies_parents[ $dependency['file'] ] = array();
+			}
+			$this->dependencies_parents[ $dependency['file'] ][] = $plugin;
 		}
-		$this->dependencies_parents[ $dependency['file'] ][] = $plugin;
 
 		return $dependency;
 	}

--- a/src/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/src/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -238,7 +238,7 @@ class WP_Plugin_Dependencies {
 	 * @param string   $plugin     The plugin defining the dependency.
 	 * @param stdClass $dependency A dependency.
 	 *
-	 * @return bool
+	 * @return bool Returns false if the plugin has unmet dependencies, otherwise returns true.
 	 */
 	private function process_plugin_dependency( $plugin, $dependency ) {
 		$dependency_is_installed = false;

--- a/src/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/src/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -73,13 +73,11 @@ class WP_Plugin_Dependencies {
 	 */
 	public function __construct() {
 
-		// Early exit if DISALLOW_FILE_MODS is enabled.
-		if ( defined( 'DISALLOW_FILE_MODS' ) && DISALLOW_FILE_MODS ) {
-			return;
-		}
-
-		// Early exit it DISALLOW_PLUGIN_DEPENDENCIES is enabled.
-		if ( defined( 'DISALLOW_PLUGIN_DEPENDENCIES' ) && DISALLOW_PLUGIN_DEPENDENCIES ) {
+		// Early exit if DISALLOW_FILE_MODS or DISALLOW_PLUGIN_DEPENDENCIES is enabled.
+		if (
+			( defined( 'DISALLOW_FILE_MODS' ) && DISALLOW_FILE_MODS ) ||
+			( defined( 'DISALLOW_PLUGIN_DEPENDENCIES' ) && DISALLOW_PLUGIN_DEPENDENCIES )
+		) {
 			return;
 		}
 

--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -703,12 +703,12 @@ class WP_Plugins_List_Table extends WP_List_Table {
 	 * @global int $page
 	 * @global string $s
 	 * @global array $totals
-	 * @global WP_Plugin_Dependencies $plugin_dependencies
+	 * @global WP_Plugin_Dependencies $wp_plugin_dependencies
 	 *
 	 * @param array $item
 	 */
 	public function single_row( $item ) {
-		global $status, $page, $s, $totals, $plugin_dependencies;
+		global $status, $page, $s, $totals, $wp_plugin_dependencies;
 
 		static $plugin_id_attrs = array();
 
@@ -1009,7 +1009,7 @@ class WP_Plugins_List_Table extends WP_List_Table {
 			$class .= ' update';
 		}
 
-		if ( ! empty( $plugin_dependencies->get_plugin_dependencies( $plugin_file ) ) || ! empty( $plugin_dependencies->get_parents( $plugin_file ) ) ) {
+		if ( ! empty( $wp_plugin_dependencies->get_plugin_dependencies( $plugin_file ) ) || ! empty( $wp_plugin_dependencies->get_parents( $plugin_file ) ) ) {
 			$class .= ' dependency';
 		}
 

--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -703,11 +703,13 @@ class WP_Plugins_List_Table extends WP_List_Table {
 	 * @global int $page
 	 * @global string $s
 	 * @global array $totals
+	 * @global WP_Plugin_Dependencies $plugin_dependencies
 	 *
 	 * @param array $item
 	 */
 	public function single_row( $item ) {
-		global $status, $page, $s, $totals;
+		global $status, $page, $s, $totals, $plugin_dependencies;
+
 		static $plugin_id_attrs = array();
 
 		list( $plugin_file, $plugin_data ) = $item;
@@ -990,6 +992,10 @@ class WP_Plugins_List_Table extends WP_List_Table {
 			|| ! $compatible_php || ! $compatible_wp
 		) {
 			$class .= ' update';
+		}
+
+		if ( ! empty( $plugin_dependencies->get_plugin_dependencies( $plugin_file ) ) ) {
+			$class .= ' dependency';
 		}
 
 		$paused = ! $screen->in_admin( 'network' ) && is_plugin_paused( $plugin_file );

--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -994,7 +994,7 @@ class WP_Plugins_List_Table extends WP_List_Table {
 			$class .= ' update';
 		}
 
-		if ( ! empty( $plugin_dependencies->get_plugin_dependencies( $plugin_file ) ) ) {
+		if ( ! empty( $plugin_dependencies->get_plugin_dependencies( $plugin_file ) ) || ! empty( $plugin_dependencies->get_parents( $plugin_file ) ) ) {
 			$class .= ' dependency';
 		}
 

--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -1028,7 +1028,21 @@ class WP_Plugins_List_Table extends WP_List_Table {
 
 			switch ( $column_name ) {
 				case 'cb':
-					echo "<th scope='row' class='check-column'>$checkbox</th>";
+					echo '<th scope="row" class="check-column">';
+					/**
+					 * Determines whether the checkbox should be displayed in the plugin row.
+					 *
+					 * @since 5.9.0
+					 *
+					 * @param bool   $display True to show the checkblox, false to hide it. Defaults to true.
+					 * @param string   $plugin_file Path to the plugin file relative to the plugins directory.
+					 *
+					 * @return bool True if the checkbox should be displayed, false otherwise.
+					 */
+					if ( apply_filters( 'plugin_display_checkbox', true, $plugin_file ) ) {
+						echo $checkbox;
+					}
+					echo '</th>';
 					break;
 				case 'name':
 					echo "<td class='plugin-title column-primary'><strong>$plugin_name</strong>";

--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -973,9 +973,24 @@ class WP_Plugins_List_Table extends WP_List_Table {
 		if ( $restrict_network_active || $restrict_network_only || in_array( $status, array( 'mustuse', 'dropins' ), true ) || ! $compatible_php ) {
 			$checkbox = '';
 		} else {
+			/**
+			 * Determines whether the checkbox should be disabled or not.
+			 *
+			 * @since 5.9.0
+			 *
+			 * @param bool   $disabled   Set to true to disable the checkbox. Defaults to false.
+			 * @param string $plugin_file Path to the plugin file relative to the plugins directory.
+			 *
+			 * @return bool
+			 */
+			$checkbox_disabled = apply_filters( 'plugin_checkbox_disabled', false, $plugin_file );
+
+			$checkbox_input = '<input type="checkbox" name="checked[]" value="%3$s" id="%1$s" />';
+			if ( $checkbox_disabled ) {
+				$checkbox_input = '<input type="checkbox" name="checked[]" value="%3$s" id="%1$s" disabled="disabled" />';
+			}
 			$checkbox = sprintf(
-				'<label class="screen-reader-text" for="%1$s">%2$s</label>' .
-				'<input type="checkbox" name="checked[]" value="%3$s" id="%1$s" />',
+				'<label class="screen-reader-text" for="%1$s">%2$s</label>' . $checkbox_input,
 				$checkbox_id,
 				/* translators: %s: Plugin name. */
 				sprintf( __( 'Select %s' ), $plugin_data['Name'] ),
@@ -1028,21 +1043,7 @@ class WP_Plugins_List_Table extends WP_List_Table {
 
 			switch ( $column_name ) {
 				case 'cb':
-					echo '<th scope="row" class="check-column">';
-					/**
-					 * Determines whether the checkbox should be displayed in the plugin row.
-					 *
-					 * @since 5.9.0
-					 *
-					 * @param bool   $display True to show the checkblox, false to hide it. Defaults to true.
-					 * @param string   $plugin_file Path to the plugin file relative to the plugins directory.
-					 *
-					 * @return bool True if the checkbox should be displayed, false otherwise.
-					 */
-					if ( apply_filters( 'plugin_display_checkbox', true, $plugin_file ) ) {
-						echo $checkbox;
-					}
-					echo '</th>';
+					echo "<th scope='row' class='check-column'>$checkbox</th>";
 					break;
 				case 'name':
 					echo "<td class='plugin-title column-primary'><strong>$plugin_name</strong>";

--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -70,18 +70,19 @@
 function get_plugin_data( $plugin_file, $markup = true, $translate = true ) {
 
 	$default_headers = array(
-		'Name'        => 'Plugin Name',
-		'PluginURI'   => 'Plugin URI',
-		'Version'     => 'Version',
-		'Description' => 'Description',
-		'Author'      => 'Author',
-		'AuthorURI'   => 'Author URI',
-		'TextDomain'  => 'Text Domain',
-		'DomainPath'  => 'Domain Path',
-		'Network'     => 'Network',
-		'RequiresWP'  => 'Requires at least',
-		'RequiresPHP' => 'Requires PHP',
-		'UpdateURI'   => 'Update URI',
+		'Name'            => 'Plugin Name',
+		'PluginURI'       => 'Plugin URI',
+		'Version'         => 'Version',
+		'Description'     => 'Description',
+		'Author'          => 'Author',
+		'AuthorURI'       => 'Author URI',
+		'TextDomain'      => 'Text Domain',
+		'DomainPath'      => 'Domain Path',
+		'Network'         => 'Network',
+		'RequiresWP'      => 'Requires at least',
+		'RequiresPHP'     => 'Requires PHP',
+		'RequiresPlugins' => 'Requires Plugins',
+		'UpdateURI'       => 'Update URI',
 		// Site Wide Only is deprecated in favor of Network.
 		'_sitewide'   => 'Site Wide Only',
 	);

--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -1131,24 +1131,13 @@ function validate_plugin( $plugin ) {
 function validate_plugin_requirements( $plugin ) {
 	$plugin_headers = get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin );
 
-	global $plugin_dependencies;
-	if ( ! $plugin_dependencies ) {
-		require_once ABSPATH . 'wp-admin/includes/class-wp-plugin-dependencies.php';
-	}
-
 	$requirements = array(
-		'requires'         => ! empty( $plugin_headers['RequiresWP'] ) ? $plugin_headers['RequiresWP'] : '',
-		'requires_php'     => ! empty( $plugin_headers['RequiresPHP'] ) ? $plugin_headers['RequiresPHP'] : '',
-		'requires_plugins' => ! empty( $plugin_headers['RequiresPlugins'] ) ? $plugin_headers['RequiresPlugins'] : '',
+		'requires'     => ! empty( $plugin_headers['RequiresWP'] ) ? $plugin_headers['RequiresWP'] : '',
+		'requires_php' => ! empty( $plugin_headers['RequiresPHP'] ) ? $plugin_headers['RequiresPHP'] : '',
 	);
 
 	$compatible_wp  = is_wp_version_compatible( $requirements['requires'] );
 	$compatible_php = is_php_version_compatible( $requirements['requires_php'] );
-
-	// Check if there are unmet plugin dependencies.
-	$has_unmet_plugin_dependencies = empty( $requirements['RequiresPlugins'] )
-		? false
-		: $plugin_dependencies->has_unmet_dependencies( $plugin );
 
 	$php_update_message = '</p><p>' . sprintf(
 		/* translators: %s: URL to Update PHP page. */
@@ -1196,11 +1185,6 @@ function validate_plugin_requirements( $plugin ) {
 				$plugin_headers['Name'],
 				$requirements['requires']
 			) . '</p>'
-		);
-	} elseif ( $has_unmet_plugin_dependencies ) {
-		return new WP_Error(
-			'plugin_unmet_dependencies',
-			'<p>' . __( '<strong>Error:</strong> The plugin has unmet plugin dependencies. Please activate all required plugins.', 'plugin' ) . '</p>'
 		);
 	}
 


### PR DESCRIPTION
This patch adds the ability to define plugin dependencies using a `Requires Plugins` header.

```php
<?php
/**
 * Plugin Name: Sample
 * Requires Plugins: woocommerce, gutenberg
 */
```

When we try to activate a plugin with the above, the user sees this:
![Screenshot](https://user-images.githubusercontent.com/588688/128348980-92b3d51b-b37f-4e48-bc94-a73323dbd393.png)

* There is a new notice on the top of the screen, urging users to install and activate the dependencies
* The plugin with unmet dependencies doesn't actually get activated, but instead gets added to a queue (database option) and will only be activated once the dependencies are met.
* The plugin with unmet dependencies gets a notification added to its row, explaining why the plugin is not activated.
* The "activate" link is replaced with a "Cancel activation request" link. If users click on that link, the plugin is removed from the queue and its dependencies notifications are dismissed.

When a dependency is installed, it gets a notice that the plugin is a dependency, and also the "deactivate" link gets removed from the UI:
![Screenshot](https://user-images.githubusercontent.com/588688/128349687-5ef9631f-e26a-4458-9345-f2b36858af2e.png)

Trac ticket: https://core.trac.wordpress.org/ticket/22316

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
