### PR TITLE
When custom fields meta box is removed, set enableCustomFields to null instead of unsetting

### DIFF
--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -258,7 +258,7 @@ register_and_do_post_meta_boxes( $post );
 // Check if the Custom Fields meta box has been removed at some point.
 $core_meta_boxes = $wp_meta_boxes[ $current_screen->id ]['normal']['core'];
 if ( ! isset( $core_meta_boxes['postcustom'] ) || ! $core_meta_boxes['postcustom'] ) {
-	unset( $editor_settings['enableCustomFields'] );
+	$editor_settings['enableCustomFields'] = null;
 }
 
 $editor_settings = get_block_editor_settings( $editor_settings, $block_editor_context );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

### Scope Note

**This is a coordination problem between WordPress and Gutenberg and requires changes on both sides.** I have patches for both that I will be submitting shortly.

### Summary

When using a plugin to disable Custom Fields in the post editor, WordPress attempts to change `$editor_settings` to tell Gutenberg not to render the Custom Fields settings toggle in a preferences modal. However, Gutenberg is listening for a value that is impossible to send in PHP, and the settings toggle remains visible even when the feature itself is disabled.

### Steps to reproduce

See trac ticket.

### Proposed solution:

* (WordPress): When custom fields are disabled, explicitly set `$editor_settings['enableCustomFields']` to a `null` value instead of unsetting it.
* (Gutenberg): Hide the custom field toggle when `getEditorSettings().enableCustomFields === null` in addition to the already existing ` === undefined` condition.


### Trac Ticket

Trac ticket: https://core.trac.wordpress.org/ticket/53883

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
