### PR TITLE
CS: use static closures (Trac 53359)

### DIFF
--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -31,7 +31,7 @@ $current_screen->is_block_editor( true );
 // Default to is-fullscreen-mode to avoid jumps in the UI.
 add_filter(
 	'admin_body_class',
-	function( $classes ) {
+	static function( $classes ) {
 		return "$classes is-fullscreen-mode";
 	}
 );

--- a/src/wp-admin/includes/class-wp-community-events.php
+++ b/src/wp-admin/includes/class-wp-community-events.php
@@ -474,7 +474,7 @@ class WP_Community_Events {
 
 		$future_wordcamps = array_filter(
 			$future_events,
-			function( $wordcamp ) {
+			static function( $wordcamp ) {
 				return 'wordcamp' === $wordcamp['type'];
 			}
 		);

--- a/src/wp-admin/includes/class-wp-site-health-auto-updates.php
+++ b/src/wp-admin/includes/class-wp-site-health-auto-updates.php
@@ -41,7 +41,7 @@ class WP_Site_Health_Auto_Updates {
 
 		$tests = array_filter( $tests );
 		$tests = array_map(
-			function( $test ) {
+			static function( $test ) {
 				$test = (object) $test;
 
 				if ( empty( $test->severity ) ) {

--- a/src/wp-admin/options-privacy.php
+++ b/src/wp-admin/options-privacy.php
@@ -20,7 +20,7 @@ if ( isset( $_GET['tab'] ) && 'policyguide' === $_GET['tab'] ) {
 
 add_filter(
 	'admin_body_class',
-	function( $body_class ) {
+	static function( $body_class ) {
 		$body_class .= ' privacy-settings ';
 
 		return $body_class;

--- a/src/wp-admin/privacy-policy-guide.php
+++ b/src/wp-admin/privacy-policy-guide.php
@@ -19,7 +19,7 @@ if ( ! class_exists( 'WP_Privacy_Policy_Content' ) ) {
 
 add_filter(
 	'admin_body_class',
-	function( $body_class ) {
+	static function( $body_class ) {
 		$body_class .= ' privacy-settings ';
 
 		return $body_class;

--- a/src/wp-content/themes/twentytwenty/classes/class-twentytwenty-customize.php
+++ b/src/wp-content/themes/twentytwenty/classes/class-twentytwenty-customize.php
@@ -186,7 +186,7 @@ if ( ! class_exists( 'TwentyTwenty_Customize' ) ) {
 						'settings'        => 'accent_hue',
 						'description'     => __( 'Apply a custom color for links, buttons, featured images.', 'twentytwenty' ),
 						'mode'            => 'hue',
-						'active_callback' => function() use ( $wp_customize ) {
+						'active_callback' => static function() use ( $wp_customize ) {
 							return ( 'custom' === $wp_customize->get_setting( 'accent_hue_active' )->value() );
 						},
 					)

--- a/src/wp-content/themes/twentytwentyone/classes/class-twenty-twenty-one-customize.php
+++ b/src/wp-content/themes/twentytwentyone/classes/class-twenty-twenty-one-customize.php
@@ -92,7 +92,7 @@ if ( ! class_exists( 'Twenty_Twenty_One_Customize' ) ) {
 				array(
 					'capability'        => 'edit_theme_options',
 					'default'           => 'excerpt',
-					'sanitize_callback' => function( $value ) {
+					'sanitize_callback' => static function( $value ) {
 						return 'excerpt' === $value || 'full' === $value ? $value : 'excerpt';
 					},
 				)

--- a/src/wp-content/themes/twentytwentyone/classes/class-twenty-twenty-one-dark-mode.php
+++ b/src/wp-content/themes/twentytwentyone/classes/class-twenty-twenty-one-dark-mode.php
@@ -153,7 +153,7 @@ class Twenty_Twenty_One_Dark_Mode {
 				array(
 					'section'         => 'colors',
 					'priority'        => 100,
-					'active_callback' => function() {
+					'active_callback' => static function() {
 						return 127 >= Twenty_Twenty_One_Custom_Colors::get_relative_luminance_from_hex( get_theme_mod( 'background_color', 'D1E4DD' ) );
 					},
 				)
@@ -165,7 +165,7 @@ class Twenty_Twenty_One_Dark_Mode {
 			array(
 				'capability'        => 'edit_theme_options',
 				'default'           => false,
-				'sanitize_callback' => function( $value ) {
+				'sanitize_callback' => static function( $value ) {
 					return (bool) $value;
 				},
 			)
@@ -188,7 +188,7 @@ class Twenty_Twenty_One_Dark_Mode {
 				'label'           => esc_html__( 'Dark Mode support', 'twentytwentyone' ),
 				'priority'        => 110,
 				'description'     => $description,
-				'active_callback' => function( $value ) {
+				'active_callback' => static function( $value ) {
 					return 127 < Twenty_Twenty_One_Custom_Colors::get_relative_luminance_from_hex( get_theme_mod( 'background_color', 'D1E4DD' ) );
 				},
 			)

--- a/src/wp-includes/block-supports/duotone.php
+++ b/src/wp-includes/block-supports/duotone.php
@@ -361,7 +361,7 @@ function wp_render_duotone_support( $block_content, $block ) {
 
 	$selectors        = explode( ',', $duotone_support );
 	$selectors_scoped = array_map(
-		function ( $selector ) use ( $duotone_id ) {
+		static function ( $selector ) use ( $duotone_id ) {
 			return '.' . $duotone_id . ' ' . trim( $selector );
 		},
 		$selectors

--- a/src/wp-includes/block-supports/layout.php
+++ b/src/wp-includes/block-supports/layout.php
@@ -131,7 +131,7 @@ function wp_restore_group_inner_container( $block_content, $block ) {
 	$replace_regex   = '/(^\s*<div\b[^>]*wp-block-group[^>]*>)(.*)(<\/div>\s*$)/ms';
 	$updated_content = preg_replace_callback(
 		$replace_regex,
-		function( $matches ) {
+		static function( $matches ) {
 			return $matches[1] . '<div class="wp-block-group__inner-container">' . $matches[2] . '</div>' . $matches[3];
 		},
 		$block_content

--- a/src/wp-includes/block-template.php
+++ b/src/wp-includes/block-template.php
@@ -124,7 +124,7 @@ function resolve_block_template( $template_type, $template_hierarchy ) {
 
 	usort(
 		$templates,
-		function ( $template_a, $template_b ) use ( $slug_priorities ) {
+		static function ( $template_a, $template_b ) use ( $slug_priorities ) {
 			return $slug_priorities[ $template_a->slug ] - $slug_priorities[ $template_b->slug ];
 		}
 	);

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -636,7 +636,7 @@ class WP_Theme_JSON {
 
 		$declaration_block = array_reduce(
 			$declarations,
-			function ( $carry, $element ) {
+			static function ( $carry, $element ) {
 				return $carry .= $element['name'] . ': ' . $element['value'] . ';'; },
 			''
 		);

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -3113,7 +3113,7 @@ function wp_rel_nofollow( $text ) {
 	$text = stripslashes( $text );
 	$text = preg_replace_callback(
 		'|<a (.+?)>|i',
-		function( $matches ) {
+		static function( $matches ) {
 			return wp_rel_callback( $matches, 'nofollow' );
 		},
 		$text
@@ -3147,7 +3147,7 @@ function wp_rel_ugc( $text ) {
 	$text = stripslashes( $text );
 	$text = preg_replace_callback(
 		'|<a (.+?)>|i',
-		function( $matches ) {
+		static function( $matches ) {
 			return wp_rel_callback( $matches, 'nofollow ugc' );
 		},
 		$text

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -3222,7 +3222,7 @@ function rest_get_endpoint_args_for_schema( $schema, $method = WP_REST_Server::C
 function rest_convert_error_to_response( $error ) {
 	$status = array_reduce(
 		$error->get_all_error_data(),
-		function ( $status, $error_data ) {
+		static function ( $status, $error_data ) {
 			return is_array( $error_data ) && isset( $error_data['status'] ) ? $error_data['status'] : $status;
 		},
 		500

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-controller.php
@@ -597,7 +597,7 @@ abstract class WP_REST_Controller {
 		// Return the list of all requested fields which appear in the schema.
 		return array_reduce(
 			$requested_fields,
-			function( $response_fields, $field ) use ( $fields ) {
+			static function( $response_fields, $field ) use ( $fields ) {
 				if ( in_array( $field, $fields, true ) ) {
 					$response_fields[] = $field;
 					return $response_fields;

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-plugins-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-plugins-controller.php
@@ -381,7 +381,7 @@ class WP_REST_Plugins_Controller extends WP_REST_Controller {
 		$installed_locales = apply_filters( 'plugins_update_check_locales', $installed_locales );
 
 		$language_packs = array_map(
-			function( $item ) {
+			static function( $item ) {
 				return (object) $item;
 			},
 			$api->language_packs
@@ -389,7 +389,7 @@ class WP_REST_Plugins_Controller extends WP_REST_Controller {
 
 		$language_packs = array_filter(
 			$language_packs,
-			function( $pack ) use ( $installed_locales ) {
+			static function( $pack ) use ( $installed_locales ) {
 				return in_array( $pack->language, $installed_locales, true );
 			}
 		);

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-widget-types-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-widget-types-controller.php
@@ -85,7 +85,7 @@ class WP_REST_Widget_Types_Controller extends WP_REST_Controller {
 					'form_data' => array(
 						'description'       => __( 'Serialized widget form data to encode into instance settings.' ),
 						'type'              => 'string',
-						'sanitize_callback' => function( $string ) {
+						'sanitize_callback' => static function( $string ) {
 							$array = array();
 							wp_parse_str( $string, $array );
 							return $array;

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-widgets-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-widgets-controller.php
@@ -792,7 +792,7 @@ class WP_REST_Widgets_Controller extends WP_REST_Controller {
 					'type'        => 'string',
 					'context'     => array(),
 					'arg_options' => array(
-						'sanitize_callback' => function( $string ) {
+						'sanitize_callback' => static function( $string ) {
 							$array = array();
 							wp_parse_str( $string, $array );
 							return $array;

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2692,7 +2692,7 @@ function wp_maybe_inline_styles() {
 		// Reorder styles array based on size.
 		usort(
 			$styles,
-			function( $a, $b ) {
+			static function( $a, $b ) {
 				return ( $a['size'] <= $b['size'] ) ? -1 : 1;
 			}
 		);

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -517,7 +517,7 @@ function wp_update_plugins( $extra_stats = array() ) {
 		}
 	}
 
-	$sanitize_plugin_update_payload = function( &$item ) {
+	$sanitize_plugin_update_payload = static function( &$item ) {
 		$item = (object) $item;
 
 		unset( $item->translations, $item->compatibility );

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -3459,7 +3459,7 @@ function wp_user_personal_data_exporter( $email_address ) {
 		// Remove items that use reserved names.
 		$extra_data = array_filter(
 			$_extra_data,
-			function( $item ) use ( $reserved_names ) {
+			static function( $item ) use ( $reserved_names ) {
 				return ! in_array( $item['name'], $reserved_names, true );
 			}
 		);

--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -709,14 +709,14 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 	public function assertSameIgnoreEOL( $expected, $actual, $message = '' ) {
 		$expected = map_deep(
 			$expected,
-			function ( $value ) {
+			static function ( $value ) {
 				return str_replace( "\r\n", "\n", $value );
 			}
 		);
 
 		$actual = map_deep(
 			$actual,
-			function ( $value ) {
+			static function ( $value ) {
 				return str_replace( "\r\n", "\n", $value );
 			}
 		);

--- a/tests/phpunit/includes/plural-form-function.php
+++ b/tests/phpunit/includes/plural-form-function.php
@@ -7,7 +7,7 @@
  * @param string $expression
  */
 function tests_make_plural_form_function( $nplurals, $expression ) {
-	$closure = function ( $n ) use ( $nplurals, $expression ) {
+	$closure = static function ( $n ) use ( $nplurals, $expression ) {
 		$expression = str_replace( 'n', $n, $expression );
 
 		// phpcs:ignore Squiz.PHP.Eval -- This is test code, not production.

--- a/tests/phpunit/tests/actions/closures.php
+++ b/tests/phpunit/tests/actions/closures.php
@@ -12,7 +12,7 @@ class Tests_Actions_Closures extends WP_UnitTestCase {
 	 */
 	function test_action_closure() {
 		$tag     = 'test_action_closure';
-		$closure = function( $a, $b ) {
+		$closure = static function( $a, $b ) {
 			$GLOBALS[ $a ] = $b;
 		};
 		add_action( $tag, $closure, 10, 2 );
@@ -25,7 +25,7 @@ class Tests_Actions_Closures extends WP_UnitTestCase {
 		$this->assertSame( $GLOBALS[ $context[0] ], $context[1] );
 
 		$tag2     = 'test_action_closure_2';
-		$closure2 = function() {
+		$closure2 = static function() {
 			$GLOBALS['closure_no_args'] = true;
 		};
 		add_action( $tag2, $closure2 );

--- a/tests/phpunit/tests/admin/includesListTable.php
+++ b/tests/phpunit/tests/admin/includesListTable.php
@@ -360,7 +360,7 @@ class Tests_Admin_includesListTable extends WP_UnitTestCase {
 
 		add_filter(
 			'bulk_actions-edit-comments',
-			function() {
+			static function() {
 				return array(
 					'delete'       => 'Delete',
 					'Change State' => array(

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -70,7 +70,7 @@ class Block_Template_Utils_Test extends WP_UnitTestCase {
 	function test_get_block_templates() {
 		function get_template_ids( $templates ) {
 			return array_map(
-				function( $template ) {
+				static function( $template ) {
 					return $template->id;
 				},
 				$templates

--- a/tests/phpunit/tests/blocks/context.php
+++ b/tests/phpunit/tests/blocks/context.php
@@ -115,7 +115,7 @@ class Tests_Blocks_Context extends WP_UnitTestCase {
 					'gutenberg/contextWithAssigned',
 					'gutenberg/contextWithoutDefault',
 				),
-				'render_callback' => function( $attributes, $content, $block ) use ( &$provided_context ) {
+				'render_callback' => static function( $attributes, $content, $block ) use ( &$provided_context ) {
 					$provided_context[] = $block->context;
 
 					return '';
@@ -155,7 +155,7 @@ class Tests_Blocks_Context extends WP_UnitTestCase {
 			'gutenberg/test-context-consumer',
 			array(
 				'uses_context'    => array( 'postId', 'postType' ),
-				'render_callback' => function( $attributes, $content, $block ) use ( &$provided_context ) {
+				'render_callback' => static function( $attributes, $content, $block ) use ( &$provided_context ) {
 					$provided_context[] = $block->context;
 
 					return '';
@@ -188,7 +188,7 @@ class Tests_Blocks_Context extends WP_UnitTestCase {
 			'gutenberg/test-context-consumer',
 			array(
 				'uses_context'    => array( 'example' ),
-				'render_callback' => function( $attributes, $content, $block ) use ( &$provided_context ) {
+				'render_callback' => static function( $attributes, $content, $block ) use ( &$provided_context ) {
 					$provided_context[] = $block->context;
 
 					return '';
@@ -196,7 +196,7 @@ class Tests_Blocks_Context extends WP_UnitTestCase {
 			)
 		);
 
-		$filter_block_context = function( $context ) {
+		$filter_block_context = static function( $context ) {
 			$context['example'] = 'ok';
 			return $context;
 		};

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -482,7 +482,7 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 	 * @ticket 49615
 	 */
 	public function test_filter_block_registration() {
-		$filter_registration = function( $args, $name ) {
+		$filter_registration = static function( $args, $name ) {
 			$args['attributes'] = array( $name => array( 'type' => 'boolean' ) );
 			return $args;
 		};
@@ -500,7 +500,7 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 	 * @ticket 52138
 	 */
 	public function test_filter_block_registration_metadata() {
-		$filter_metadata_registration = function( $metadata ) {
+		$filter_metadata_registration = static function( $metadata ) {
 			$metadata['apiVersion'] = 3;
 			return $metadata;
 		};
@@ -518,7 +518,7 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 	 * @ticket 52138
 	 */
 	public function test_filter_block_registration_metadata_settings() {
-		$filter_metadata_registration = function( $settings, $metadata ) {
+		$filter_metadata_registration = static function( $settings, $metadata ) {
 			$settings['api_version'] = $metadata['apiVersion'] + 1;
 			return $settings;
 		};

--- a/tests/phpunit/tests/blocks/supportedStyles.php
+++ b/tests/phpunit/tests/blocks/supportedStyles.php
@@ -712,7 +712,7 @@ class Tests_Blocks_SupportedStyles extends WP_UnitTestCase {
 		// Custom error handler's see Warnings even if they are suppressed by the @ symbol.
 		$errors = array();
 		set_error_handler(
-			function ( $errno = 0, $errstr = '' ) use ( &$errors ) {
+			static function ( $errno = 0, $errstr = '' ) use ( &$errors ) {
 				$errors[] = $errstr;
 				return false;
 			}

--- a/tests/phpunit/tests/blocks/wpBlock.php
+++ b/tests/phpunit/tests/blocks/wpBlock.php
@@ -275,7 +275,7 @@ class Tests_Blocks_wpBlock extends WP_UnitTestCase {
 		$this->registry->register(
 			'core/dynamic',
 			array(
-				'render_callback' => function() {
+				'render_callback' => static function() {
 					return 'b';
 				},
 			)
@@ -296,7 +296,7 @@ class Tests_Blocks_wpBlock extends WP_UnitTestCase {
 		$this->registry->register(
 			'core/greeting',
 			array(
-				'render_callback' => function( $attributes, $content, $block ) {
+				'render_callback' => static function( $attributes, $content, $block ) {
 					return sprintf( 'Hello from %s', $block->name );
 				},
 			)
@@ -366,7 +366,7 @@ class Tests_Blocks_wpBlock extends WP_UnitTestCase {
 						'default' => '!',
 					),
 				),
-				'render_callback' => function( $block_attributes ) {
+				'render_callback' => static function( $block_attributes ) {
 					return sprintf(
 						'Hello %s%s',
 						$block_attributes['toWhom'],
@@ -391,7 +391,7 @@ class Tests_Blocks_wpBlock extends WP_UnitTestCase {
 		$this->registry->register(
 			'core/outer',
 			array(
-				'render_callback' => function( $block_attributes, $content ) {
+				'render_callback' => static function( $block_attributes, $content ) {
 					return $content;
 				},
 			)
@@ -399,7 +399,7 @@ class Tests_Blocks_wpBlock extends WP_UnitTestCase {
 		$this->registry->register(
 			'core/inner',
 			array(
-				'render_callback' => function() {
+				'render_callback' => static function() {
 					return 'b';
 				},
 			)

--- a/tests/phpunit/tests/canonical.php
+++ b/tests/phpunit/tests/canonical.php
@@ -247,7 +247,7 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 		// Test short-circuit filter.
 		add_filter(
 			'pre_redirect_guess_404_permalink',
-			function() {
+			static function() {
 				return 'wp';
 			}
 		);

--- a/tests/phpunit/tests/category/walkerCategory.php
+++ b/tests/phpunit/tests/category/walkerCategory.php
@@ -38,7 +38,7 @@ class Tests_Category_Walker_Category extends WP_UnitTestCase {
 
 		add_filter(
 			'category_list_link_attributes',
-			function( $atts ) use ( $value ) {
+			static function( $atts ) use ( $value ) {
 				$atts['data-test'] = $value;
 				return $atts;
 			}

--- a/tests/phpunit/tests/comment/commentsTemplate.php
+++ b/tests/phpunit/tests/comment/commentsTemplate.php
@@ -993,7 +993,7 @@ class Tests_Comment_CommentsTemplate extends WP_UnitTestCase {
 
 		add_filter(
 			'comments_template_query_args',
-			function ( $args ) use ( &$offset, $query_args ) {
+			static function ( $args ) use ( &$offset, $query_args ) {
 				$offset = $args['offset'];
 
 				return array_merge( $args, $query_args );
@@ -1003,7 +1003,7 @@ class Tests_Comment_CommentsTemplate extends WP_UnitTestCase {
 		if ( ! empty( $top_level_query_args ) ) {
 			add_filter(
 				'comments_template_top_level_query_args',
-				function ( $args ) use ( $top_level_query_args ) {
+				static function ( $args ) use ( $top_level_query_args ) {
 					return array_merge( $args, $top_level_query_args );
 				}
 			);

--- a/tests/phpunit/tests/cron.php
+++ b/tests/phpunit/tests/cron.php
@@ -1031,7 +1031,7 @@ class Tests_Cron extends WP_UnitTestCase {
 		// Force update_option() to fail by setting the new value to match the existing:
 		add_filter(
 			'pre_update_option_cron',
-			function() {
+			static function() {
 				return get_option( 'cron' );
 			}
 		);
@@ -1051,7 +1051,7 @@ class Tests_Cron extends WP_UnitTestCase {
 		// Force update_option() to fail by setting the new value to match the existing:
 		add_filter(
 			'pre_update_option_cron',
-			function() {
+			static function() {
 				return get_option( 'cron' );
 			}
 		);
@@ -1074,7 +1074,7 @@ class Tests_Cron extends WP_UnitTestCase {
 		// Force update_option() to fail by setting the new value to match the existing:
 		add_filter(
 			'pre_update_option_cron',
-			function() {
+			static function() {
 				return get_option( 'cron' );
 			}
 		);
@@ -1098,7 +1098,7 @@ class Tests_Cron extends WP_UnitTestCase {
 		// Force update_option() to fail by setting the new value to match the existing:
 		add_filter(
 			'pre_update_option_cron',
-			function() {
+			static function() {
 				return get_option( 'cron' );
 			}
 		);

--- a/tests/phpunit/tests/dependencies/wpInlineScriptTag.php
+++ b/tests/phpunit/tests/dependencies/wpInlineScriptTag.php
@@ -80,7 +80,7 @@ JS;
 	public function test_print_script_tag_prints_get_inline_script_tag() {
 		add_filter(
 			'wp_inline_script_attributes',
-			function ( $attributes ) {
+			static function ( $attributes ) {
 				if ( isset( $attributes['id'] ) && 'utils-js-extra' === $attributes['id'] ) {
 					$attributes['async'] = true;
 				}

--- a/tests/phpunit/tests/dependencies/wpScriptTag.php
+++ b/tests/phpunit/tests/dependencies/wpScriptTag.php
@@ -64,7 +64,7 @@ class Tests_Functions_wpScriptTag extends WP_UnitTestCase {
 	function test_print_script_tag_prints_get_script_tag() {
 		add_filter(
 			'wp_script_attributes',
-			function ( $attributes ) {
+			static function ( $attributes ) {
 				if ( isset( $attributes['id'] ) && 'utils-js-extra' === $attributes['id'] ) {
 					$attributes['async'] = true;
 				}

--- a/tests/phpunit/tests/https-detection.php
+++ b/tests/phpunit/tests/https-detection.php
@@ -117,7 +117,7 @@ class Tests_HTTPS_Detection extends WP_UnitTestCase {
 		// Override to enforce no errors being detected.
 		add_filter(
 			'pre_wp_update_https_detection_errors',
-			function() {
+			static function() {
 				return new WP_Error();
 			}
 		);
@@ -127,7 +127,7 @@ class Tests_HTTPS_Detection extends WP_UnitTestCase {
 		// Override to enforce an error being detected.
 		add_filter(
 			'pre_wp_update_https_detection_errors',
-			function() {
+			static function() {
 				return new WP_Error(
 					'ssl_verification_failed',
 					'Bad SSL certificate.'
@@ -345,7 +345,7 @@ class Tests_HTTPS_Detection extends WP_UnitTestCase {
 	 * @return callable Filter callback.
 	 */
 	private function filter_set_url_scheme( $scheme ) {
-		return function( $url ) use ( $scheme ) {
+		return static function( $url ) use ( $scheme ) {
 			return set_url_scheme( $url, $scheme );
 		};
 	}

--- a/tests/phpunit/tests/https-migration.php
+++ b/tests/phpunit/tests/https-migration.php
@@ -161,7 +161,7 @@ class Tests_HTTPS_Migration extends WP_UnitTestCase {
 	private function force_wp_is_using_https( $enabled ) {
 		$scheme = $enabled ? 'https' : 'http';
 
-		$replace_scheme = function( $url ) use ( $scheme ) {
+		$replace_scheme = static function( $url ) use ( $scheme ) {
 			return str_replace( array( 'http://', 'https://' ), $scheme . '://', $url );
 		};
 
@@ -172,7 +172,7 @@ class Tests_HTTPS_Migration extends WP_UnitTestCase {
 	private function force_option( $option, $value ) {
 		add_filter(
 			"option_$option",
-			function() use ( $value ) {
+			static function() use ( $value ) {
 				return $value;
 			}
 		);

--- a/tests/phpunit/tests/image/intermediateSize.php
+++ b/tests/phpunit/tests/image/intermediateSize.php
@@ -69,7 +69,7 @@ class Tests_Image_Intermediate_Size extends WP_UnitTestCase {
 	function test_image_editor_output_format_filter() {
 		add_filter(
 			'image_editor_output_format',
-			function() {
+			static function() {
 				return array( 'image/jpeg' => 'image/webp' );
 			}
 		);

--- a/tests/phpunit/tests/l10n/loadScriptTextdomain.php
+++ b/tests/phpunit/tests/l10n/loadScriptTextdomain.php
@@ -49,7 +49,7 @@ class Tests_L10n_LoadScriptTextdomain extends WP_UnitTestCase {
 				'default',
 				array(
 					'site_url',
-					function ( $site_url ) {
+					static function ( $site_url ) {
 						return $site_url . '/wp';
 					},
 				),
@@ -62,7 +62,7 @@ class Tests_L10n_LoadScriptTextdomain extends WP_UnitTestCase {
 				'internationalized-plugin',
 				array(
 					'plugins_url',
-					function () {
+					static function () {
 						return 'https://plugins.example.com';
 					},
 				),
@@ -75,7 +75,7 @@ class Tests_L10n_LoadScriptTextdomain extends WP_UnitTestCase {
 				'internationalized-plugin',
 				array(
 					'content_url',
-					function () {
+					static function () {
 						return 'https://content.example.com';
 					},
 				),
@@ -88,7 +88,7 @@ class Tests_L10n_LoadScriptTextdomain extends WP_UnitTestCase {
 				'internationalized-plugin',
 				array(
 					'content_url',
-					function () {
+					static function () {
 						return '/';
 					},
 				),
@@ -101,7 +101,7 @@ class Tests_L10n_LoadScriptTextdomain extends WP_UnitTestCase {
 				'internationalized-plugin',
 				array(
 					'plugins_url',
-					function () {
+					static function () {
 						return '/';
 					},
 				),
@@ -114,7 +114,7 @@ class Tests_L10n_LoadScriptTextdomain extends WP_UnitTestCase {
 				'default',
 				array(
 					'site_url',
-					function () {
+					static function () {
 						return '/wp';
 					},
 				),

--- a/tests/phpunit/tests/menu/walker-nav-menu.php
+++ b/tests/phpunit/tests/menu/walker-nav-menu.php
@@ -94,7 +94,7 @@ class Tests_Menu_Walker_Nav_Menu extends WP_UnitTestCase {
 
 		add_filter(
 			'nav_menu_link_attributes',
-			function( $atts ) use ( $value ) {
+			static function( $atts ) use ( $value ) {
 				$atts['data-test'] = $value;
 				return $atts;
 			}

--- a/tests/phpunit/tests/post/revisions.php
+++ b/tests/phpunit/tests/post/revisions.php
@@ -594,7 +594,7 @@ class Tests_Post_Revisions extends WP_UnitTestCase {
 
 		add_filter(
 			'wp_revisions_to_keep',
-			function () use ( $expected ) {
+			static function () use ( $expected ) {
 				return $expected;
 			}
 		);
@@ -619,7 +619,7 @@ class Tests_Post_Revisions extends WP_UnitTestCase {
 
 		add_filter(
 			'wp_revisions_to_keep',
-			function () use ( $generic ) {
+			static function () use ( $generic ) {
 				return $generic;
 			}
 		);
@@ -630,7 +630,7 @@ class Tests_Post_Revisions extends WP_UnitTestCase {
 
 		add_filter(
 			"wp_{$post->post_type}_revisions_to_keep",
-			function () use ( $expected ) {
+			static function () use ( $expected ) {
 				return $expected;
 			}
 		);

--- a/tests/phpunit/tests/post/walkerPage.php
+++ b/tests/phpunit/tests/post/walkerPage.php
@@ -33,7 +33,7 @@ class Tests_Post_Walker_Page extends WP_UnitTestCase {
 
 		add_filter(
 			'page_menu_link_attributes',
-			function( $atts ) use ( $value ) {
+			static function( $atts ) use ( $value ) {
 				$atts['data-test'] = $value;
 				return $atts;
 			}

--- a/tests/phpunit/tests/rest-api/rest-application-passwords-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-application-passwords-controller.php
@@ -937,7 +937,7 @@ class WP_Test_REST_Application_Passwords_Controller extends WP_Test_REST_Control
 		$this->setup_app_password_authenticated_request();
 		add_action(
 			'application_password_did_authenticate',
-			function() {
+			static function() {
 				$GLOBALS['wp_rest_application_password_uuid'] = 'invalid_uuid';
 			}
 		);

--- a/tests/phpunit/tests/rest-api/rest-block-renderer-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-block-renderer-controller.php
@@ -435,7 +435,7 @@ class REST_Block_Renderer_Controller_Test extends WP_Test_REST_Controller_Testca
 	public function test_get_item_with_pre_render_block_filter() {
 		wp_set_current_user( self::$user_id );
 
-		$pre_render_filter = function( $output, $block ) {
+		$pre_render_filter = static function( $output, $block ) {
 			if ( $block['blockName'] === self::$block_name ) {
 				return '<p>Alternate content.</p>';
 			}

--- a/tests/phpunit/tests/rest-api/rest-pattern-directory-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-pattern-directory-controller.php
@@ -272,7 +272,7 @@ class WP_REST_Pattern_Directory_Controller_Test extends WP_Test_REST_Controller_
 		// Test that filter changes uncached values.
 		add_filter(
 			'rest_prepare_block_pattern',
-			function( $response ) {
+			static function( $response ) {
 				return 'initial value';
 			}
 		);
@@ -286,7 +286,7 @@ class WP_REST_Pattern_Directory_Controller_Test extends WP_Test_REST_Controller_
 		// Test that filter changes cached values (the previous request primed the cache).
 		add_filter(
 			'rest_prepare_block_pattern',
-			function( $response ) {
+			static function( $response ) {
 				return 'modified the cache';
 			},
 			11

--- a/tests/phpunit/tests/rest-api/rest-post-meta-fields.php
+++ b/tests/phpunit/tests/rest-api/rest-post-meta-fields.php
@@ -2708,7 +2708,7 @@ class WP_Test_REST_Post_Meta_Fields extends WP_Test_REST_TestCase {
 				'single'            => true,
 				'type'              => 'boolean',
 				'show_in_rest'      => true,
-				'sanitize_callback' => function( $value ) {
+				'sanitize_callback' => static function( $value ) {
 					return $value ? '1' : '0';
 				},
 			)

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -2137,7 +2137,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	 */
 	public function test_prepare_item_filters_content_when_needed() {
 		$filter_count   = 0;
-		$filter_content = function() use ( &$filter_count ) {
+		$filter_content = static function() use ( &$filter_count ) {
 			$filter_count++;
 			return '<p>Filtered content.</p>';
 		};
@@ -2173,7 +2173,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	 */
 	public function test_prepare_item_skips_content_filter_if_not_needed() {
 		$filter_count   = 0;
-		$filter_content = function() use ( &$filter_count ) {
+		$filter_content = static function() use ( &$filter_count ) {
 			$filter_count++;
 			return '<p>Filtered content.</p>';
 		};

--- a/tests/phpunit/tests/rest-api/rest-request.php
+++ b/tests/phpunit/tests/rest-api/rest-request.php
@@ -475,7 +475,7 @@ class Tests_REST_Request extends WP_UnitTestCase {
 			array(
 				'args' => array(
 					'failparam' => array(
-						'sanitize_callback' => function () {
+						'sanitize_callback' => static function () {
 							$error = new WP_Error( 'invalid', 'Invalid.' );
 							$error->add( 'invalid', 'Super Invalid.' );
 							$error->add( 'broken', 'Broken.' );
@@ -510,7 +510,7 @@ class Tests_REST_Request extends WP_UnitTestCase {
 			array(
 				'args' => array(
 					'failparam' => array(
-						'sanitize_callback' => function () {
+						'sanitize_callback' => static function () {
 							return new WP_Error( 'invalid', 'Invalid.', 'mydata' );
 						},
 					),
@@ -738,7 +738,7 @@ class Tests_REST_Request extends WP_UnitTestCase {
 			array(
 				'args' => array(
 					'failparam' => array(
-						'validate_callback' => function () {
+						'validate_callback' => static function () {
 							$error = new WP_Error( 'invalid', 'Invalid.' );
 							$error->add( 'invalid', 'Super Invalid.' );
 							$error->add( 'broken', 'Broken.' );
@@ -773,7 +773,7 @@ class Tests_REST_Request extends WP_UnitTestCase {
 			array(
 				'args' => array(
 					'failparam' => array(
-						'validate_callback' => function () {
+						'validate_callback' => static function () {
 							return new WP_Error( 'invalid', 'Invalid.', 'mydata' );
 						},
 					),

--- a/tests/phpunit/tests/rest-api/rest-server.php
+++ b/tests/phpunit/tests/rest-api/rest-server.php
@@ -1392,7 +1392,7 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 			'/test',
 			array(
 				'methods'             => array( 'GET' ),
-				'callback'            => function () {
+				'callback'            => static function () {
 					return new WP_REST_Response();
 				},
 				'permission_callback' => '__return_true',
@@ -1414,7 +1414,7 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 			'/test',
 			array(
 				'methods'             => array( 'GET' ),
-				'callback'            => function () {
+				'callback'            => static function () {
 					return new WP_REST_Response( 'data', 204 );
 				},
 				'permission_callback' => '__return_true',
@@ -1505,7 +1505,7 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 			'/test',
 			array(
 				'methods'             => array( 'GET' ),
-				'callback'            => function() {
+				'callback'            => static function() {
 					return new WP_REST_Response( 'data', 204 );
 				},
 				'permission_callback' => '__return_true',
@@ -1516,7 +1516,7 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 			'/test',
 			array(
 				'methods'             => array( 'GET' ),
-				'callback'            => function() {
+				'callback'            => static function() {
 					return new WP_REST_Response( 'data', 204 );
 				},
 				'permission_callback' => '__return_true',
@@ -1928,7 +1928,7 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 			'/test/(?P<id>[\d+])',
 			array(
 				'methods'             => array( 'POST', 'DELETE' ),
-				'callback'            => function ( WP_REST_Request $request ) {
+				'callback'            => static function ( WP_REST_Request $request ) {
 					return new WP_REST_Response( 'test' );
 				},
 				'permission_callback' => '__return_true',

--- a/tests/phpunit/tests/rest-api/rest-widget-types-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-widget-types-controller.php
@@ -149,7 +149,7 @@ class WP_Test_REST_Widget_Types_Controller extends WP_Test_REST_Controller_Testc
 		$data         = $response->get_data();
 		$text_widgets = array_filter(
 			$data,
-			function( $widget ) {
+			static function( $widget ) {
 				return 'text' === $widget['id'];
 			}
 		);
@@ -177,7 +177,7 @@ class WP_Test_REST_Widget_Types_Controller extends WP_Test_REST_Controller_Testc
 		wp_register_sidebar_widget(
 			$widget_id,
 			'WP legacy widget',
-			function() {}
+			static function() {}
 		);
 		wp_set_current_user( self::$admin_id );
 		$request     = new WP_REST_Request( 'GET', '/wp/v2/widget-types/' . $widget_id );
@@ -208,7 +208,7 @@ class WP_Test_REST_Widget_Types_Controller extends WP_Test_REST_Controller_Testc
 		wp_register_sidebar_widget(
 			$widget_id,
 			'&#8216;Legacy &#8209; Archive &#8209; Widget&#8217;',
-			function() {},
+			static function() {},
 			array(
 				'description' => '&#8220;A great &amp; interesting archive of your site&#8217;s posts!&#8221;',
 			)

--- a/tests/phpunit/tests/rest-api/rest-widgets-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-widgets-controller.php
@@ -108,7 +108,7 @@ class WP_Test_REST_Widgets_Controller extends WP_Test_REST_Controller_Testcase {
 		wp_register_widget_control(
 			'testwidget',
 			'WP test widget',
-			function () {
+			static function () {
 				$settings = get_option( 'widget_testwidget' );
 
 				// check if anything's been sent.
@@ -127,7 +127,7 @@ class WP_Test_REST_Widgets_Controller extends WP_Test_REST_Controller_Testcase {
 		wp_register_sidebar_widget(
 			'testwidget',
 			'WP test widget',
-			function () {
+			static function () {
 				$settings = wp_parse_args(
 					get_option( 'widget_testwidget' ),
 					array(

--- a/tests/phpunit/tests/robots.php
+++ b/tests/phpunit/tests/robots.php
@@ -43,7 +43,7 @@ class Tests_Robots extends WP_UnitTestCase {
 	public function test_wp_robots_parses_directives_correctly() {
 		add_filter(
 			'wp_robots',
-			function( array $robots ) {
+			static function( array $robots ) {
 				// Directives that should have values must use strings.
 				$robots['directive-with-value']         = 'yes';
 				$robots['directive-with-numeric-value'] = '1';


### PR DESCRIPTION
If a closure doesn't use `$this`, it can be made `static` for improved performance.

Static closures are supported in PHP since PHP 5.4.



Trac ticket: https://core.trac.wordpress.org/ticket/53359

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
