### PR TITLE
Fix #53806

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -202,9 +202,9 @@ function register_block_style_handle( $metadata, $field_name ) {
  */
 function register_block_type_from_metadata( $file_or_folder, $args = array() ) {
 	$filename      = 'block.json';
-	$metadata_file = ( substr( $file_or_folder, -strlen( $filename ) ) !== $filename ) ?
+	$metadata_file = (is_dir($file_or_folder) || substr($file_or_folder, -5) !== '.json') ?
 		trailingslashit( $file_or_folder ) . $filename :
-		$file_or_folder;
+        $file_or_folder;
 	if ( ! file_exists( $metadata_file ) ) {
 		return false;
 	}


### PR DESCRIPTION
Providing `register_block_type_from_metadata` with the path to a custom named metadata file would search for `path/to/metadata_file.json/block.json` instead of correctly searching for `path/to/metadata_file.json`.

The following checks are now carried out:

- If the `$file_or_folder` path provided is a directory, or doesn't end in `.json`, search for `$file_or_folder/block.json`.
- Otherwise, search for the `$file_or_folder` path exactly as provided.

Trac ticket: https://core.trac.wordpress.org/ticket/53806

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
