### PR TITLE
[WIP] PHP 8.1: convert_invalid_entities() - fix handling of null (Trac 53635)

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2396,6 +2396,10 @@ function convert_chars( $content, $deprecated = '' ) {
  * @return string Converted string.
  */
 function convert_invalid_entities( $content ) {
+	if ( ! is_string( $content ) || '' === $content ) {
+		return $content;
+	}
+
 	$wp_htmltranswinuni = array(
 		'&#128;' => '&#8364;', // The Euro sign.
 		'&#129;' => '',

--- a/tests/phpunit/tests/formatting/ConvertInvalidEntries-php81-test-failures.txt
+++ b/tests/phpunit/tests/formatting/ConvertInvalidEntries-php81-test-failures.txt
@@ -1,0 +1,482 @@
+Tests failing due to issue in convert_invalid_entities()
+
+Note: with the correctly proposed fix, all these tests would still fail, just at another point in their processing
+=== New error once proposed fix is in place ===
+stripos(): Passing null to parameter #1 ($haystack) of type string is deprecated
+
+D:\000_GitHub\WP_test_suite\src\wp-includes\formatting.php:3173
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-hook.php:303
+D:\000_GitHub\WP_test_suite\src\wp-includes\plugin.php:189
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2643
+D:\000_GitHub\WP_test_suite\src\wp-admin\includes\post.php:781
+==============================================================
+
+
+=== Errors due to issue in convert_invalid_entities() ===
+
+
+15) Tests_Admin_Includes_Post::test_post_exists_should_support_post_type
+strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
+
+D:\000_GitHub\WP_test_suite\src\wp-includes\formatting.php:2434
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-hook.php:303
+D:\000_GitHub\WP_test_suite\src\wp-includes\plugin.php:189
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2643
+D:\000_GitHub\WP_test_suite\src\wp-admin\includes\post.php:781
+D:\000_GitHub\WP_test_suite\tests\phpunit\tests\admin\includesPost.php:887
+
+16) Tests_Admin_Includes_Post::test_post_exists_should_not_match_a_page_for_post
+strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
+
+D:\000_GitHub\WP_test_suite\src\wp-includes\formatting.php:2434
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-hook.php:303
+D:\000_GitHub\WP_test_suite\src\wp-includes\plugin.php:189
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2643
+D:\000_GitHub\WP_test_suite\src\wp-admin\includes\post.php:781
+D:\000_GitHub\WP_test_suite\tests\phpunit\tests\admin\includesPost.php:904
+
+17) Tests_Admin_Includes_Post::test_post_exists_should_support_post_status
+strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
+
+D:\000_GitHub\WP_test_suite\src\wp-includes\formatting.php:2434
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-hook.php:303
+D:\000_GitHub\WP_test_suite\src\wp-includes\plugin.php:189
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2643
+D:\000_GitHub\WP_test_suite\src\wp-admin\includes\post.php:781
+D:\000_GitHub\WP_test_suite\tests\phpunit\tests\admin\includesPost.php:923
+
+18) Tests_Admin_Includes_Post::test_post_exists_should_support_post_type_status_combined
+strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
+
+D:\000_GitHub\WP_test_suite\src\wp-includes\formatting.php:2434
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-hook.php:303
+D:\000_GitHub\WP_test_suite\src\wp-includes\plugin.php:189
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2643
+D:\000_GitHub\WP_test_suite\src\wp-admin\includes\post.php:781
+D:\000_GitHub\WP_test_suite\tests\phpunit\tests\admin\includesPost.php:943
+
+19) Tests_Admin_Includes_Post::test_post_exists_should_only_match_correct_post_status
+strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
+
+D:\000_GitHub\WP_test_suite\src\wp-includes\formatting.php:2434
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-hook.php:303
+D:\000_GitHub\WP_test_suite\src\wp-includes\plugin.php:189
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2643
+D:\000_GitHub\WP_test_suite\src\wp-admin\includes\post.php:781
+D:\000_GitHub\WP_test_suite\tests\phpunit\tests\admin\includesPost.php:962
+
+20) Tests_Admin_Includes_Post::test_post_exists_should_not_match_invalid_post_type_and_status_combined
+strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
+
+D:\000_GitHub\WP_test_suite\src\wp-includes\formatting.php:2434
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-hook.php:303
+D:\000_GitHub\WP_test_suite\src\wp-includes\plugin.php:189
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2643
+D:\000_GitHub\WP_test_suite\src\wp-admin\includes\post.php:781
+D:\000_GitHub\WP_test_suite\tests\phpunit\tests\admin\includesPost.php:982
+
+622) Tests_Date_XMLRPC::test_date_new_post
+strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
+
+D:\000_GitHub\WP_test_suite\src\wp-includes\formatting.php:2434
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-hook.php:303
+D:\000_GitHub\WP_test_suite\src\wp-includes\plugin.php:189
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2643
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2528
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:3867
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:5614
+D:\000_GitHub\WP_test_suite\tests\phpunit\tests\date\xmlrpc.php:34
+
+1303) Tests_XMLRPC_mw_editPost::test_draft_not_prematurely_published
+strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
+
+D:\000_GitHub\WP_test_suite\src\wp-includes\formatting.php:2434
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-hook.php:303
+D:\000_GitHub\WP_test_suite\src\wp-includes\plugin.php:189
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2643
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2528
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:3867
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:5614
+D:\000_GitHub\WP_test_suite\tests\phpunit\tests\xmlrpc\mw\editPost.php:315
+
+1304) Tests_XMLRPC_mw_newPost::test_no_content
+strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
+
+D:\000_GitHub\WP_test_suite\src\wp-includes\formatting.php:2434
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-hook.php:303
+D:\000_GitHub\WP_test_suite\src\wp-includes\plugin.php:189
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2643
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2528
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:3867
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:5614
+D:\000_GitHub\WP_test_suite\tests\phpunit\tests\xmlrpc\mw\newPost.php:28
+
+1305) Tests_XMLRPC_mw_newPost::test_basic_content
+strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
+
+D:\000_GitHub\WP_test_suite\src\wp-includes\formatting.php:2434
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-hook.php:303
+D:\000_GitHub\WP_test_suite\src\wp-includes\plugin.php:189
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2643
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2528
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:3867
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:5614
+D:\000_GitHub\WP_test_suite\tests\phpunit\tests\xmlrpc\mw\newPost.php:38
+
+1306) Tests_XMLRPC_mw_newPost::test_ignore_id
+strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
+
+D:\000_GitHub\WP_test_suite\src\wp-includes\formatting.php:2434
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-hook.php:303
+D:\000_GitHub\WP_test_suite\src\wp-includes\plugin.php:189
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2643
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2528
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:3867
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:5614
+D:\000_GitHub\WP_test_suite\tests\phpunit\tests\xmlrpc\mw\newPost.php:50
+
+1307) Tests_XMLRPC_mw_newPost::test_capable_publish
+strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
+
+D:\000_GitHub\WP_test_suite\src\wp-includes\formatting.php:2434
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-hook.php:303
+D:\000_GitHub\WP_test_suite\src\wp-includes\plugin.php:189
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2643
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2528
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:3867
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:5614
+D:\000_GitHub\WP_test_suite\tests\phpunit\tests\xmlrpc\mw\newPost.php:62
+
+1308) Tests_XMLRPC_mw_newPost::test_capable_other_author
+strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
+
+D:\000_GitHub\WP_test_suite\src\wp-includes\formatting.php:2434
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-hook.php:303
+D:\000_GitHub\WP_test_suite\src\wp-includes\plugin.php:189
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2643
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2528
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:3867
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:5614
+D:\000_GitHub\WP_test_suite\tests\phpunit\tests\xmlrpc\mw\newPost.php:86
+
+1309) Tests_XMLRPC_mw_newPost::test_empty_author
+strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
+
+D:\000_GitHub\WP_test_suite\src\wp-includes\formatting.php:2434
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-hook.php:303
+D:\000_GitHub\WP_test_suite\src\wp-includes\plugin.php:189
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2643
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2528
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:3867
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:5614
+D:\000_GitHub\WP_test_suite\tests\phpunit\tests\xmlrpc\mw\newPost.php:122
+
+1311) Tests_XMLRPC_mw_newPost::test_capable_set_post_type_as_page
+strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
+
+D:\000_GitHub\WP_test_suite\src\wp-includes\formatting.php:2434
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-hook.php:303
+D:\000_GitHub\WP_test_suite\src\wp-includes\plugin.php:189
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2643
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2528
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:3867
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:5614
+D:\000_GitHub\WP_test_suite\tests\phpunit\tests\xmlrpc\mw\newPost.php:173
+
+1312) Tests_XMLRPC_mw_newPost::test_draft_post_date
+strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
+
+D:\000_GitHub\WP_test_suite\src\wp-includes\formatting.php:2434
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-hook.php:303
+D:\000_GitHub\WP_test_suite\src\wp-includes\plugin.php:189
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2643
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2528
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:3867
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:5614
+D:\000_GitHub\WP_test_suite\tests\phpunit\tests\xmlrpc\mw\newPost.php:194
+
+1326) Tests_XMLRPC_wp_editPost::test_draft_not_prematurely_published
+strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
+
+D:\000_GitHub\WP_test_suite\src\wp-includes\formatting.php:2434
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-hook.php:303
+D:\000_GitHub\WP_test_suite\src\wp-includes\plugin.php:189
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2643
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2528
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:3867
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1683
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1347
+D:\000_GitHub\WP_test_suite\tests\phpunit\tests\xmlrpc\wp\editPost.php:482
+
+1327) Tests_XMLRPC_wp_editPost::test_draft_not_assigned_published_date
+strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
+
+D:\000_GitHub\WP_test_suite\src\wp-includes\formatting.php:2434
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-hook.php:303
+D:\000_GitHub\WP_test_suite\src\wp-includes\plugin.php:189
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2643
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2528
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:3867
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1683
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1347
+D:\000_GitHub\WP_test_suite\tests\phpunit\tests\xmlrpc\wp\editPost.php:514
+
+1336) Tests_XMLRPC_wp_getRevisions::test_revision_count_for_auto_draft_post_creation
+strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
+
+D:\000_GitHub\WP_test_suite\src\wp-includes\formatting.php:2434
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-hook.php:303
+D:\000_GitHub\WP_test_suite\src\wp-includes\plugin.php:189
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2643
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2528
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:3867
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1683
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1347
+D:\000_GitHub\WP_test_suite\tests\phpunit\tests\xmlrpc\wp\getRevisions.php:67
+
+1338) Tests_XMLRPC_wp_newPost::test_no_content
+strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
+
+D:\000_GitHub\WP_test_suite\src\wp-includes\formatting.php:2434
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-hook.php:303
+D:\000_GitHub\WP_test_suite\src\wp-includes\plugin.php:189
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2643
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2528
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:3867
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1683
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1347
+D:\000_GitHub\WP_test_suite\tests\phpunit\tests\xmlrpc\wp\newPost.php:25
+
+1339) Tests_XMLRPC_wp_newPost::test_basic_content
+strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
+
+D:\000_GitHub\WP_test_suite\src\wp-includes\formatting.php:2434
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-hook.php:303
+D:\000_GitHub\WP_test_suite\src\wp-includes\plugin.php:189
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2643
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2528
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:3867
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1683
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1347
+D:\000_GitHub\WP_test_suite\tests\phpunit\tests\xmlrpc\wp\newPost.php:35
+
+1340) Tests_XMLRPC_wp_newPost::test_ignore_id
+strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
+
+D:\000_GitHub\WP_test_suite\src\wp-includes\formatting.php:2434
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-hook.php:303
+D:\000_GitHub\WP_test_suite\src\wp-includes\plugin.php:189
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2643
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2528
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:3867
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1683
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1347
+D:\000_GitHub\WP_test_suite\tests\phpunit\tests\xmlrpc\wp\newPost.php:47
+
+1341) Tests_XMLRPC_wp_newPost::test_capable_publish
+strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
+
+D:\000_GitHub\WP_test_suite\src\wp-includes\formatting.php:2434
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-hook.php:303
+D:\000_GitHub\WP_test_suite\src\wp-includes\plugin.php:189
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2643
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2528
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:3867
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1683
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1347
+D:\000_GitHub\WP_test_suite\tests\phpunit\tests\xmlrpc\wp\newPost.php:59
+
+1342) Tests_XMLRPC_wp_newPost::test_capable_private
+strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
+
+D:\000_GitHub\WP_test_suite\src\wp-includes\formatting.php:2434
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-hook.php:303
+D:\000_GitHub\WP_test_suite\src\wp-includes\plugin.php:189
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2643
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2528
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:3867
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1683
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1347
+D:\000_GitHub\WP_test_suite\tests\phpunit\tests\xmlrpc\wp\newPost.php:82
+
+1343) Tests_XMLRPC_wp_newPost::test_capable_other_author
+strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
+
+D:\000_GitHub\WP_test_suite\src\wp-includes\formatting.php:2434
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-hook.php:303
+D:\000_GitHub\WP_test_suite\src\wp-includes\plugin.php:189
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2643
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2528
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:3867
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1683
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1347
+D:\000_GitHub\WP_test_suite\tests\phpunit\tests\xmlrpc\wp\newPost.php:106
+
+1344) Tests_XMLRPC_wp_newPost::test_empty_author
+strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
+
+D:\000_GitHub\WP_test_suite\src\wp-includes\formatting.php:2434
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-hook.php:303
+D:\000_GitHub\WP_test_suite\src\wp-includes\plugin.php:189
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2643
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2528
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:3867
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1683
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1347
+D:\000_GitHub\WP_test_suite\tests\phpunit\tests\xmlrpc\wp\newPost.php:139
+
+1346) Tests_XMLRPC_wp_newPost::test_invalid_post_status
+strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
+
+D:\000_GitHub\WP_test_suite\src\wp-includes\formatting.php:2434
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-hook.php:303
+D:\000_GitHub\WP_test_suite\src\wp-includes\plugin.php:189
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2643
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2528
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:3867
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1683
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1347
+D:\000_GitHub\WP_test_suite\tests\phpunit\tests\xmlrpc\wp\newPost.php:178
+
+1347) Tests_XMLRPC_wp_newPost::test_capable_sticky
+strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
+
+D:\000_GitHub\WP_test_suite\src\wp-includes\formatting.php:2434
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-hook.php:303
+D:\000_GitHub\WP_test_suite\src\wp-includes\plugin.php:189
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2643
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2528
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:3867
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1683
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1347
+D:\000_GitHub\WP_test_suite\tests\phpunit\tests\xmlrpc\wp\newPost.php:202
+
+1348) Tests_XMLRPC_wp_newPost::test_post_format
+strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
+
+D:\000_GitHub\WP_test_suite\src\wp-includes\formatting.php:2434
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-hook.php:303
+D:\000_GitHub\WP_test_suite\src\wp-includes\plugin.php:189
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2643
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2528
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:3867
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1683
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1347
+D:\000_GitHub\WP_test_suite\tests\phpunit\tests\xmlrpc\wp\newPost.php:227
+
+1349) Tests_XMLRPC_wp_newPost::test_invalid_post_format
+strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
+
+D:\000_GitHub\WP_test_suite\src\wp-includes\formatting.php:2434
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-hook.php:303
+D:\000_GitHub\WP_test_suite\src\wp-includes\plugin.php:189
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2643
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2528
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:3867
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1683
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1347
+D:\000_GitHub\WP_test_suite\tests\phpunit\tests\xmlrpc\wp\newPost.php:239
+
+1350) Tests_XMLRPC_wp_newPost::test_terms
+strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
+
+D:\000_GitHub\WP_test_suite\src\wp-includes\formatting.php:2434
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-hook.php:303
+D:\000_GitHub\WP_test_suite\src\wp-includes\plugin.php:189
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2643
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2528
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:3867
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1683
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1347
+D:\000_GitHub\WP_test_suite\tests\phpunit\tests\xmlrpc\wp\newPost.php:298
+
+1351) Tests_XMLRPC_wp_newPost::test_terms_names
+strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
+
+D:\000_GitHub\WP_test_suite\src\wp-includes\formatting.php:2434
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-hook.php:303
+D:\000_GitHub\WP_test_suite\src\wp-includes\plugin.php:189
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2643
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2528
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:3867
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1683
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1347
+D:\000_GitHub\WP_test_suite\tests\phpunit\tests\xmlrpc\wp\newPost.php:325
+
+1352) Tests_XMLRPC_wp_newPost::test_invalid_post_date_does_not_fatal
+strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
+
+D:\000_GitHub\WP_test_suite\src\wp-includes\formatting.php:2434
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-hook.php:303
+D:\000_GitHub\WP_test_suite\src\wp-includes\plugin.php:189
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2643
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2528
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:3867
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1683
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1347
+D:\000_GitHub\WP_test_suite\tests\phpunit\tests\xmlrpc\wp\newPost.php:358
+
+1353) Tests_XMLRPC_wp_newPost::test_invalid_post_date_gmt_does_not_fatal
+strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
+
+D:\000_GitHub\WP_test_suite\src\wp-includes\formatting.php:2434
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-hook.php:303
+D:\000_GitHub\WP_test_suite\src\wp-includes\plugin.php:189
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2643
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2528
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:3867
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1683
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1347
+D:\000_GitHub\WP_test_suite\tests\phpunit\tests\xmlrpc\wp\newPost.php:375
+
+1354) Tests_XMLRPC_wp_newPost::test_valid_string_post_date
+strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
+
+D:\000_GitHub\WP_test_suite\src\wp-includes\formatting.php:2434
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-hook.php:303
+D:\000_GitHub\WP_test_suite\src\wp-includes\plugin.php:189
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2643
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2528
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:3867
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1683
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1347
+D:\000_GitHub\WP_test_suite\tests\phpunit\tests\xmlrpc\wp\newPost.php:392
+
+1355) Tests_XMLRPC_wp_newPost::test_valid_string_post_date_gmt
+strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
+
+D:\000_GitHub\WP_test_suite\src\wp-includes\formatting.php:2434
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-hook.php:303
+D:\000_GitHub\WP_test_suite\src\wp-includes\plugin.php:189
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2643
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2528
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:3867
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1683
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1347
+D:\000_GitHub\WP_test_suite\tests\phpunit\tests\xmlrpc\wp\newPost.php:409
+
+1356) Tests_XMLRPC_wp_newPost::test_valid_IXR_post_date
+strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
+
+D:\000_GitHub\WP_test_suite\src\wp-includes\formatting.php:2434
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-hook.php:303
+D:\000_GitHub\WP_test_suite\src\wp-includes\plugin.php:189
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2643
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2528
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:3867
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1683
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1347
+D:\000_GitHub\WP_test_suite\tests\phpunit\tests\xmlrpc\wp\newPost.php:426
+
+1357) Tests_XMLRPC_wp_newPost::test_valid_IXR_post_date_gmt
+strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
+
+D:\000_GitHub\WP_test_suite\src\wp-includes\formatting.php:2434
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-hook.php:303
+D:\000_GitHub\WP_test_suite\src\wp-includes\plugin.php:189
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2643
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:2528
+D:\000_GitHub\WP_test_suite\src\wp-includes\post.php:3867
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1683
+D:\000_GitHub\WP_test_suite\src\wp-includes\class-wp-xmlrpc-server.php:1347
+D:\000_GitHub\WP_test_suite\tests\phpunit\tests\xmlrpc\wp\newPost.php:443

--- a/tests/phpunit/tests/formatting/convertInvalidEntries.php
+++ b/tests/phpunit/tests/formatting/convertInvalidEntries.php
@@ -24,14 +24,30 @@ class Tests_Formatting_ConvertInvalidEntities extends WP_UnitTestCase {
 	 */
 	public function data_convert_invalid_entities_strings() {
 		return array(
+			'empty string'                                => array(
+				'input'    => '',
+				'expected' => '',
+			),
 			'replaces windows1252 entities with unicode ones' => array(
 				'input'    => '&#130;&#131;&#132;&#133;&#134;&#135;&#136;&#137;&#138;&#139;&#140;&#145;&#146;&#147;&#148;&#149;&#150;&#151;&#152;&#153;&#154;&#155;&#156;&#159;',
 				'expected' => '&#8218;&#402;&#8222;&#8230;&#8224;&#8225;&#710;&#8240;&#352;&#8249;&#338;&#8216;&#8217;&#8220;&#8221;&#8226;&#8211;&#8212;&#732;&#8482;&#353;&#8250;&#339;&#376;',
 			),
 			// @ticket 20503
-			'replaces latin letter z with caron' => array(
+			'replaces latin letter z with caron'          => array(
 				'input'    => '&#142;&#158;',
 				'expected' => '&#381;&#382;',
+			),
+			'string without entity is returned unchanged' => array(
+				'input'    => 'Hello! This is just text.',
+				'expected' => 'Hello! This is just text.',
+			),
+			'string with unlisted entity is returned unchanged' => array(
+				'input'    => 'English pound: &#163;.',
+				'expected' => 'English pound: &#163;.',
+			),
+			'string with entity in thousand range (not win 1252) is returned unchanged' => array(
+				'input'    => '&#1031;&#1315;',
+				'expected' => '&#1031;&#1315;',
 			),
 		);
 	}

--- a/tests/phpunit/tests/formatting/convertInvalidEntries.php
+++ b/tests/phpunit/tests/formatting/convertInvalidEntries.php
@@ -83,6 +83,16 @@ class Tests_Formatting_ConvertInvalidEntities extends WP_UnitTestCase {
 				'input'  => 25.689,
 				'output' => 25.689,
 			),
+			/*
+			'array'  => array(
+				'input'  => array( 1, 2, 3 ),
+				'output' => '',
+			),
+			'object' => array(
+				'input'  => $std_class,
+				'output' => '',
+			),
+			*/
 		);
 	}
 

--- a/tests/phpunit/tests/formatting/convertInvalidEntries.php
+++ b/tests/phpunit/tests/formatting/convertInvalidEntries.php
@@ -4,19 +4,36 @@
  * @group formatting
  */
 class Tests_Formatting_ConvertInvalidEntities extends WP_UnitTestCase {
-	function test_replaces_windows1252_entities_with_unicode_ones() {
-		$input  = '&#130;&#131;&#132;&#133;&#134;&#135;&#136;&#137;&#138;&#139;&#140;&#145;&#146;&#147;&#148;&#149;&#150;&#151;&#152;&#153;&#154;&#155;&#156;&#159;';
-		$output = '&#8218;&#402;&#8222;&#8230;&#8224;&#8225;&#710;&#8240;&#352;&#8249;&#338;&#8216;&#8217;&#8220;&#8221;&#8226;&#8211;&#8212;&#732;&#8482;&#353;&#8250;&#339;&#376;';
-		$this->assertSame( $output, convert_invalid_entities( $input ) );
+
+	/**
+	 * @dataProvider data_convert_invalid_entities_strings
+	 *
+	 * @covers ::convert_invalid_entities
+	 *
+	 * @param mixed  $input    Supposedly a string with entities that need converting.
+	 * @param string $expected Expected function output.
+	 */
+	public function test_convert_invalid_entities( $input, $expected ) {
+		$this->assertSame( $expected, convert_invalid_entities( $input ) );
 	}
 
 	/**
-	 * @ticket 20503
+	 * Data provider with test cases intended to be handled by the function.
+	 *
+	 * @return array
 	 */
-	function test_replaces_latin_letter_z_with_caron() {
-		$input  = '&#142;&#158;';
-		$output = '&#381;&#382;';
-		$this->assertSame( $output, convert_invalid_entities( $input ) );
+	public function data_convert_invalid_entities_strings() {
+		return array(
+			'replaces windows1252 entities with unicode ones' => array(
+				'input'    => '&#130;&#131;&#132;&#133;&#134;&#135;&#136;&#137;&#138;&#139;&#140;&#145;&#146;&#147;&#148;&#149;&#150;&#151;&#152;&#153;&#154;&#155;&#156;&#159;',
+				'expected' => '&#8218;&#402;&#8222;&#8230;&#8224;&#8225;&#710;&#8240;&#352;&#8249;&#338;&#8216;&#8217;&#8220;&#8221;&#8226;&#8211;&#8212;&#732;&#8482;&#353;&#8250;&#339;&#376;',
+			),
+			// @ticket 20503
+			'replaces latin letter z with caron' => array(
+				'input'    => '&#142;&#158;',
+				'expected' => '&#381;&#382;',
+			),
+		);
 	}
 
 	function test_escapes_lone_ampersands() {

--- a/tests/phpunit/tests/formatting/convertInvalidEntries.php
+++ b/tests/phpunit/tests/formatting/convertInvalidEntries.php
@@ -7,6 +7,7 @@ class Tests_Formatting_ConvertInvalidEntities extends WP_UnitTestCase {
 
 	/**
 	 * @dataProvider data_convert_invalid_entities_strings
+	 * @dataProvider data_convert_invalid_entities_non_string
 	 *
 	 * @covers ::convert_invalid_entities
 	 *
@@ -48,6 +49,39 @@ class Tests_Formatting_ConvertInvalidEntities extends WP_UnitTestCase {
 			'string with entity in thousand range (not win 1252) is returned unchanged' => array(
 				'input'    => '&#1031;&#1315;',
 				'expected' => '&#1031;&#1315;',
+			),
+		);
+	}
+
+	/**
+	 * Data provider to safeguard consistent handling on unexpected data types.
+	 *
+	 * @return array
+	 */
+	public function data_convert_invalid_entities_non_string() {
+		$std_class           = new stdClass();
+		$std_class->property = 'value';
+
+		return array(
+			'null'  => array(
+				'input'  => null,
+				'output' => null,
+			),
+			'false' => array(
+				'input'  => false,
+				'output' => false,
+			),
+			'true'  => array(
+				'input'  => true,
+				'output' => true,
+			),
+			'int'   => array(
+				'input'  => 7486,
+				'output' => 7486,
+			),
+			'float' => array(
+				'input'  => 25.689,
+				'output' => 25.689,
 			),
 		);
 	}


### PR DESCRIPTION
Fixes `strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated` notices on PHP 8.1.

Impact: 38 of the pre-existing tests are affected by this issue.


Note: trac ticket link below not added yet on purpose while this ticket is still WIP.

Trac ticket: https://core.trac.wordpress.org/ticket/55656
Trac ticket: https://core.trac.wordpress.org/ticket/54730

Update: Though this is WIP, adding the new 6.0 ticket to ensure this PR moves forward in the 6.0 cycle.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
