### PR TITLE
PHP 8.1: syntax error due to new 'readonly' property + tests (Trac 53858)

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,6 +3,7 @@
 		backupGlobals="false"
 		colors="true"
 		beStrictAboutTestsThatDoNotTestAnything="true"
+		beStrictAboutOutputDuringTests="true"
 		>
 	<testsuites>
 		<!-- Default test suite to run all tests. -->

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -4813,15 +4813,26 @@ function disabled( $disabled, $current = true, $echo = true ) {
  *
  * Compares the first two arguments and if identical marks as readonly
  *
- * @since 4.9.0
+ * @since 5.9.0
  *
  * @param mixed $readonly One of the values to compare
  * @param mixed $current  (true) The other value to compare if not just true
  * @param bool  $echo     Whether to echo or just return the string
  * @return string HTML attribute or empty string
  */
-function readonly( $readonly, $current = true, $echo = true ) {
+function wp_readonly( $readonly, $current = true, $echo = true ) {
 	return __checked_selected_helper( $readonly, $current, $echo, 'readonly' );
+}
+
+/**
+ * Include a compat `readonly` function on PHP < 8.1. Since PHP 8.1,
+ * `readonly` is a reserved keyword, and it is not possible to use
+ * it as a function name. In order to maintain compatibility with
+ * existing functions, this function was extracted to a separate file,
+ * and included on PHP < 8.1.
+ */
+if ( PHP_VERSION_ID < 80100 ) {
+	require_once __DIR__ . '/php-compat/readonly.php';
 }
 
 /**

--- a/src/wp-includes/php-compat/readonly.php
+++ b/src/wp-includes/php-compat/readonly.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Conditionally declares a `readonly` function, which was renamed to
+ * `wp_readonly` in WordPress 5.9.0.
+ *
+ * In order to avoid PHP parser errors, this function was extracted to
+ * this separate file, and only included conditionally on PHP 8.1.
+ *
+ * Including this file on PHP >= 8.1 results in a fatal error.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Outputs the HTML readonly attribute.
+ *
+ * Compares the first two arguments and if identical marks as readonly
+ *
+ * This function is deprecated, and cannot be used on PHP >= 8.1.
+ * @see wp_readonly
+ *
+ * @since 4.9.0
+ * @deprecated 5.9.0 Use `wp_readonly` introduced in 5.9.0.
+ *
+ * @param mixed $readonly One of the values to compare
+ * @param mixed $current  (true) The other value to compare if not just true
+ * @param bool  $echo     Whether to echo or just return the string
+ * @return string HTML attribute or empty string
+ */
+function readonly( $readonly, $current = true, $echo = true ) {
+	_deprecated_function( __FUNCTION__, '5.9.0', 'wp_readonly()' );
+	return wp_readonly( $readonly, $current, $echo );
+}

--- a/tests/phpunit/multisite.xml
+++ b/tests/phpunit/multisite.xml
@@ -3,6 +3,7 @@
 		backupGlobals="false"
 		colors="true"
 		beStrictAboutTestsThatDoNotTestAnything="true"
+		beStrictAboutOutputDuringTests="true"
 		>
 	<php>
 		<const name="WP_TESTS_MULTISITE" value="1" />

--- a/tests/phpunit/tests/general/template.php
+++ b/tests/phpunit/tests/general/template.php
@@ -572,55 +572,6 @@ class Tests_General_Template extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket 9862
-	 * @ticket 51166
-	 * @dataProvider data_selected_and_checked_with_equal_values
-	 *
-	 * @covers ::selected
-	 * @covers ::checked
-	 */
-	function test_selected_and_checked_with_equal_values( $selected, $current ) {
-		$this->assertSame( " selected='selected'", selected( $selected, $current, false ) );
-		$this->assertSame( " checked='checked'", checked( $selected, $current, false ) );
-	}
-
-	function data_selected_and_checked_with_equal_values() {
-		return array(
-			array( 'foo', 'foo' ),
-			array( '1', 1 ),
-			array( '1', true ),
-			array( 1, 1 ),
-			array( 1, true ),
-			array( true, true ),
-			array( '0', 0 ),
-			array( 0, 0 ),
-			array( '', false ),
-			array( false, false ),
-		);
-	}
-
-	/**
-	 * @ticket 9862
-	 * @ticket 51166
-	 * @dataProvider data_selected_and_checked_with_non_equal_values
-	 *
-	 * @covers ::selected
-	 * @covers ::checked
-	 */
-	function test_selected_and_checked_with_non_equal_values( $selected, $current ) {
-		$this->assertSame( '', selected( $selected, $current, false ) );
-		$this->assertSame( '', checked( $selected, $current, false ) );
-	}
-
-	function data_selected_and_checked_with_non_equal_values() {
-		return array(
-			array( '0', '' ),
-			array( 0, '' ),
-			array( 0, false ),
-		);
-	}
-
-	/**
 	 * @ticket 44183
 	 *
 	 * @covers ::get_the_archive_title

--- a/tests/phpunit/tests/general/template_CheckedSelectedHelper.php
+++ b/tests/phpunit/tests/general/template_CheckedSelectedHelper.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * A set of unit tests for the __checked_selected_helper() and associated functions in wp-includes/general-template.php.
+ *
+ * @group general
+ */
+
+class Tests_General_Template_CheckedSelectedHelper extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 9862
+	 * @ticket 51166
+	 * @dataProvider data_selected_and_checked_with_equal_values
+	 *
+	 * @covers ::selected
+	 * @covers ::checked
+	 */
+	function test_selected_and_checked_with_equal_values( $selected, $current ) {
+		$this->assertSame( " selected='selected'", selected( $selected, $current, false ) );
+		$this->assertSame( " checked='checked'", checked( $selected, $current, false ) );
+	}
+
+	function data_selected_and_checked_with_equal_values() {
+		return array(
+			array( 'foo', 'foo' ),
+			array( '1', 1 ),
+			array( '1', true ),
+			array( 1, 1 ),
+			array( 1, true ),
+			array( true, true ),
+			array( '0', 0 ),
+			array( 0, 0 ),
+			array( '', false ),
+			array( false, false ),
+		);
+	}
+
+	/**
+	 * @ticket 9862
+	 * @ticket 51166
+	 * @dataProvider data_selected_and_checked_with_non_equal_values
+	 *
+	 * @covers ::selected
+	 * @covers ::checked
+	 */
+	function test_selected_and_checked_with_non_equal_values( $selected, $current ) {
+		$this->assertSame( '', selected( $selected, $current, false ) );
+		$this->assertSame( '', checked( $selected, $current, false ) );
+	}
+
+	function data_selected_and_checked_with_non_equal_values() {
+		return array(
+			array( '0', '' ),
+			array( 0, '' ),
+			array( 0, false ),
+		);
+	}
+}

--- a/tests/phpunit/tests/general/template_CheckedSelectedHelper.php
+++ b/tests/phpunit/tests/general/template_CheckedSelectedHelper.php
@@ -10,17 +10,24 @@ class Tests_General_Template_CheckedSelectedHelper extends WP_UnitTestCase {
 	/**
 	 * @ticket 9862
 	 * @ticket 51166
-	 * @dataProvider data_selected_and_checked_with_equal_values
 	 *
-	 * @covers ::selected
-	 * @covers ::checked
+	 * @dataProvider data_equal_values
+	 *
+	 * @covers ::__checked_selected_helper
+	 *
+	 * @param mixed $helper  One of the values to compare.
+	 * @param mixed $current The other value to compare.
 	 */
-	function test_selected_and_checked_with_equal_values( $selected, $current ) {
-		$this->assertSame( " selected='selected'", selected( $selected, $current, false ) );
-		$this->assertSame( " checked='checked'", checked( $selected, $current, false ) );
+	public function test_checked_selected_helper_with_equal_values( $helper, $current ) {
+		$this->assertSame( " test='test'", __checked_selected_helper( $helper, $current, false, 'test' ) );
 	}
 
-	function data_selected_and_checked_with_equal_values() {
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_equal_values() {
 		return array(
 			'same value, "foo"; 1: string; 2: string'     => array( 'foo', 'foo' ),
 			'same value, 1; 1: string; 2: int'            => array( '1', 1 ),
@@ -38,17 +45,24 @@ class Tests_General_Template_CheckedSelectedHelper extends WP_UnitTestCase {
 	/**
 	 * @ticket 9862
 	 * @ticket 51166
-	 * @dataProvider data_selected_and_checked_with_non_equal_values
 	 *
-	 * @covers ::selected
-	 * @covers ::checked
+	 * @dataProvider data_non_equal_values
+	 *
+	 * @covers ::__checked_selected_helper
+	 *
+	 * @param mixed $helper  One of the values to compare.
+	 * @param mixed $current The other value to compare.
 	 */
-	function test_selected_and_checked_with_non_equal_values( $selected, $current ) {
-		$this->assertSame( '', selected( $selected, $current, false ) );
-		$this->assertSame( '', checked( $selected, $current, false ) );
+	public function test_checked_selected_helper_with_non_equal_values( $helper, $current ) {
+		$this->assertSame( '', __checked_selected_helper( $helper, $current, false, 'test' ) );
 	}
 
-	function data_selected_and_checked_with_non_equal_values() {
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_non_equal_values() {
 		return array(
 			'1: string 0; 2: empty string' => array( '0', '' ),
 			'1: int 0; 2: empty string'    => array( 0, '' ),

--- a/tests/phpunit/tests/general/template_CheckedSelectedHelper.php
+++ b/tests/phpunit/tests/general/template_CheckedSelectedHelper.php
@@ -8,6 +8,20 @@
 class Tests_General_Template_CheckedSelectedHelper extends WP_UnitTestCase {
 
 	/**
+	 * List of functions using the __checked_selected_helper() function.
+	 *
+	 * Doesn't list the conditionally available `readonly` function on purpose.
+	 *
+	 * @var array
+	 */
+	private $child_functions = array(
+		'selected'    => true,
+		'checked'     => true,
+		'disabled'    => true,
+		'wp_readonly' => true,
+	);
+
+	/**
 	 * Tests that the return value for selected() is as expected with equal values.
 	 *
 	 * @covers ::selected
@@ -154,5 +168,72 @@ class Tests_General_Template_CheckedSelectedHelper extends WP_UnitTestCase {
 		$expected = " disabled='disabled'";
 		$this->expectOutputString( $expected );
 		$this->assertSame( $expected, disabled( 'foo', 'foo' ) );
+	}
+
+	/**
+	 * Tests that the function compares against `true` when the second parameter is not passed.
+	 *
+	 * @dataProvider data_checked_selected_helper_default_value_for_second_parameter
+	 *
+	 * @covers ::__checked_selected_helper
+	 * @covers ::selected
+	 * @covers ::checked
+	 * @covers ::disabled
+	 * @covers ::wp_readonly
+	 *
+	 * @param mixed $input         Input value
+	 * @param mixed $expect_output Optional. Whether output is expected. Defaults to false.
+	 */
+	public function test_checked_selected_helper_default_value_for_second_parameter( $input, $expect_output = false ) {
+		$fn       = array_rand( $this->child_functions );
+		$expected = '';
+
+		if ( false !== $expect_output ) {
+			$expected = " {$fn}='{$fn}'";
+			if ( 'wp_readonly' === $fn ) {
+				// Account for the function name not matching the expected output strings.
+				$expected = " readonly='readonly'";
+			}
+
+			// Only set output expectation when output is expected, so the test will fail on unexpected output.
+			$this->expectOutputString( $expected );
+		}
+
+		// Function will always return the value, even when echo-ing it out.
+		$this->assertSame( $expected, $fn( $input ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_checked_selected_helper_default_value_for_second_parameter() {
+		return array(
+			'truthy; boolean true'          => array(
+				'input'         => true,
+				'expect_output' => true,
+			),
+			'truthy; int 1'                 => array(
+				'input'         => 1,
+				'expect_output' => true,
+			),
+			'truthy; string 1'              => array(
+				'input'         => '1',
+				'expect_output' => true,
+			),
+			'truthy, but not equal to true' => array(
+				'input' => 'foo',
+			),
+			'falsy; null'                   => array(
+				'input' => null,
+			),
+			'falsy; bool false'             => array(
+				'input' => false,
+			),
+			'falsy; int 0'                  => array(
+				'input' => 0,
+			),
+		);
 	}
 }

--- a/tests/phpunit/tests/general/template_CheckedSelectedHelper.php
+++ b/tests/phpunit/tests/general/template_CheckedSelectedHelper.php
@@ -82,16 +82,26 @@ class Tests_General_Template_CheckedSelectedHelper extends WP_UnitTestCase {
 	 */
 	public function data_equal_values() {
 		return array(
-			'same value, "foo"; 1: string; 2: string'     => array( 'foo', 'foo' ),
-			'same value, 1; 1: string; 2: int'            => array( '1', 1 ),
-			'same value, 1; 1: string; 2: bool true'      => array( '1', true ),
-			'same value, 1; 1: int; 2: int'               => array( 1, 1 ),
-			'same value, 1; 1: int; 2: bool true'         => array( 1, true ),
-			'same value, 1; 1: bool true; 2: bool true'   => array( true, true ),
-			'same value, 0; 1: string; 2: int'            => array( '0', 0 ),
-			'same value, 0; 1: int; 2: int'               => array( 0, 0 ),
-			'same value, 0; 1: empty string; 2: bool false' => array( '', false ),
-			'same value, 0; 1: bool false; 2: bool false' => array( false, false ),
+			'same value, "foo"; 1: string; 2: string'   => array( 'foo', 'foo' ),
+			'same value, 1; 1: string; 2: int'          => array( '1', 1 ),
+			'same value, 1; 1: string; 2: float'        => array( '1', 1.0 ),
+			'same value, 1; 1: string; 2: bool true'    => array( '1', true ),
+			'same value, 1; 1: int; 2: int'             => array( 1, 1 ),
+			'same value, 1; 1: int; 2: float'           => array( 1, 1.0 ),
+			'same value, 1; 1: int; 2: bool true'       => array( 1, true ),
+			'same value, 1; 1: float; 2: bool true'     => array( 1.0, true ),
+			'same value, 1; 1: bool true; 2: bool true' => array( true, true ),
+			'same value, 1; 1: float 1.0; 2: float calculation 1.0' => array( 1.0, 3 / 3 ),
+			'same value, 0; 1: string; 2: int'          => array( '0', 0 ),
+			'same value, 0; 1: string; 2: float'        => array( '0', 0.0 ),
+			'same value, 0; 1: int; 2: int'             => array( 0, 0 ),
+			'same value, 0; 1: int; 2: float'           => array( 0, 0.0 ),
+			'same value, empty string; 1: string; 2: string' => array( '', '' ),
+			'same value, empty string; 1: empty string; 2: bool false' => array( '', false ),
+			'same value, empty string; 1: bool false; 2: bool false' => array( false, false ),
+			'same value, empty string; 1: empty string; 2: null' => array( '', null ),
+			'same value, empty string; 1: bool false; 2: null' => array( false, null ),
+			'same value, null; 1: null; 2: null'        => array( null, null ),
 		);
 	}
 
@@ -117,9 +127,20 @@ class Tests_General_Template_CheckedSelectedHelper extends WP_UnitTestCase {
 	 */
 	public function data_non_equal_values() {
 		return array(
+			'1: string foo; 2: string bar' => array( 'foo', 'bar' ),
 			'1: string 0; 2: empty string' => array( '0', '' ),
+			'1: string 0; 2: null'         => array( '0', null ),
 			'1: int 0; 2: empty string'    => array( 0, '' ),
+			'1: int 0; 2: bool true'       => array( 0, true ),
 			'1: int 0; 2: bool false'      => array( 0, false ),
+			'1: int 0; 2: null'            => array( 0, null ),
+			'1: float 0; 2: empty string'  => array( 0.0, '' ),
+			'1: float 0; 2: bool true'     => array( 0.0, true ),
+			'1: float 0; 2: bool false'    => array( 0.0, false ),
+			'1: float 0; 2: null'          => array( 0.0, null ),
+			'1: null; 2: bool true'        => array( null, true ),
+			'1: null 0; 2: string "foo"'   => array( null, 'foo' ),
+			'1: int 1; 2: float 1.5'       => array( 1, 1.5 ),
 		);
 	}
 

--- a/tests/phpunit/tests/general/template_CheckedSelectedHelper.php
+++ b/tests/phpunit/tests/general/template_CheckedSelectedHelper.php
@@ -22,16 +22,16 @@ class Tests_General_Template_CheckedSelectedHelper extends WP_UnitTestCase {
 
 	function data_selected_and_checked_with_equal_values() {
 		return array(
-			array( 'foo', 'foo' ),
-			array( '1', 1 ),
-			array( '1', true ),
-			array( 1, 1 ),
-			array( 1, true ),
-			array( true, true ),
-			array( '0', 0 ),
-			array( 0, 0 ),
-			array( '', false ),
-			array( false, false ),
+			'same value, "foo"; 1: string; 2: string'     => array( 'foo', 'foo' ),
+			'same value, 1; 1: string; 2: int'            => array( '1', 1 ),
+			'same value, 1; 1: string; 2: bool true'      => array( '1', true ),
+			'same value, 1; 1: int; 2: int'               => array( 1, 1 ),
+			'same value, 1; 1: int; 2: bool true'         => array( 1, true ),
+			'same value, 1; 1: bool true; 2: bool true'   => array( true, true ),
+			'same value, 0; 1: string; 2: int'            => array( '0', 0 ),
+			'same value, 0; 1: int; 2: int'               => array( 0, 0 ),
+			'same value, 0; 1: empty string; 2: bool false' => array( '', false ),
+			'same value, 0; 1: bool false; 2: bool false' => array( false, false ),
 		);
 	}
 
@@ -50,9 +50,9 @@ class Tests_General_Template_CheckedSelectedHelper extends WP_UnitTestCase {
 
 	function data_selected_and_checked_with_non_equal_values() {
 		return array(
-			array( '0', '' ),
-			array( 0, '' ),
-			array( 0, false ),
+			'1: string 0; 2: empty string' => array( '0', '' ),
+			'1: int 0; 2: empty string'    => array( 0, '' ),
+			'1: int 0; 2: bool false'      => array( 0, false ),
 		);
 	}
 }

--- a/tests/phpunit/tests/general/template_CheckedSelectedHelper.php
+++ b/tests/phpunit/tests/general/template_CheckedSelectedHelper.php
@@ -8,6 +8,59 @@
 class Tests_General_Template_CheckedSelectedHelper extends WP_UnitTestCase {
 
 	/**
+	 * Tests that the return value for selected() is as expected with equal values.
+	 *
+	 * @covers ::selected
+	 */
+	public function test_selected_with_equal_values() {
+		$this->assertSame( " selected='selected'", selected( 'foo', 'foo', false ) );
+	}
+
+	/**
+	 * Tests that the return value for checked() is as expected with equal values.
+	 *
+	 * @covers ::checked
+	 */
+	public function test_checked_with_equal_values() {
+		$this->assertSame( " checked='checked'", checked( 'foo', 'foo', false ) );
+	}
+
+	/**
+	 * Tests that the return value for disabled() is as expected with equal values.
+	 *
+	 * @covers ::disabled
+	 */
+	public function test_disabled_with_equal_values() {
+		$this->assertSame( " disabled='disabled'", disabled( 'foo', 'foo', false ) );
+	}
+
+	/**
+	 * Tests that the return value for readonly() is as expected with equal values.
+	 *
+	 * @covers ::readonly
+	 */
+	public function test_readonly_with_equal_values() {
+		if ( ! function_exists( 'readonly' ) ) {
+			$this->markTestSkipped( 'readonly() function is not available on PHP 8.1' );
+		}
+
+		$this->setExpectedDeprecated( 'readonly' );
+
+		// Call the function via a variable to prevent a parse error for this file on PHP 8.1.
+		$fn = 'readonly';
+		$this->assertSame( " readonly='readonly'", $fn( 'foo', 'foo', false ) );
+	}
+
+	/**
+	 * Tests that the return value for wp_readonly() is as expected with equal values.
+	 *
+	 * @covers ::wp_readonly
+	 */
+	public function test_wp_readonly_with_equal_values() {
+		$this->assertSame( " readonly='readonly'", wp_readonly( 'foo', 'foo', false ) );
+	}
+
+	/**
 	 * @ticket 9862
 	 * @ticket 51166
 	 *

--- a/tests/phpunit/tests/general/template_CheckedSelectedHelper.php
+++ b/tests/phpunit/tests/general/template_CheckedSelectedHelper.php
@@ -122,4 +122,16 @@ class Tests_General_Template_CheckedSelectedHelper extends WP_UnitTestCase {
 			'1: int 0; 2: bool false'      => array( 0, false ),
 		);
 	}
+
+	/**
+	 * Tests that the $echo parameter is handled correctly and that even when the output is echoed out,
+	 * the text is also returned.
+	 *
+	 * @covers ::__checked_selected_helper
+	 */
+	public function test_checked_selected_helper_echos_result_by_default() {
+		$expected = " disabled='disabled'";
+		$this->expectOutputString( $expected );
+		$this->assertSame( $expected, disabled( 'foo', 'foo' ) );
+	}
 }


### PR DESCRIPTION
This PR contains:
* @Ayesh's `53858-3.patch` patch with those last two remarks addressed.
* Moves the tests related to the `__checked_selected_helper()` function and all it's helper functions to its own file.
* Improves those tests to make them feature complete.

Trac ticket: https://core.trac.wordpress.org/ticket/53858

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
