### PR TITLE
PHP 8.1: wp_parse_str() - fix handling of null (Trac 53635) 

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -4964,7 +4964,7 @@ function map_deep( $value, $callback ) {
  * @param array  $array  Variables will be stored in this array.
  */
 function wp_parse_str( $string, &$array ) {
-	parse_str( $string, $array );
+	parse_str( (string) $string, $array );
 
 	/**
 	 * Filters the array of variables derived from a parsed string.

--- a/tests/phpunit/tests/formatting/WpParseStr.php
+++ b/tests/phpunit/tests/formatting/WpParseStr.php
@@ -1,0 +1,144 @@
+<?php
+
+/**
+ * @group formatting.php
+ * @covers ::wp_parse_str
+ */
+class Tests_Formatting_WpParseStr extends WP_UnitTestCase {
+
+	/**
+	 * Tests parsing of a string into variables.
+	 *
+	 * Note: while the function under test does not contain any significant logic,
+	 * these tests document the behaviour and safeguard PHP cross-version compatibility.
+	 *
+	 * @dataProvider data_wp_parse_str
+	 *
+	 * @param mixed $input    Value to parse.
+	 * @param array $expected Expected function output.
+	 */
+	public function test_wp_parse_str( $input, $expected ) {
+		wp_parse_str( $input, $output );
+		$this->assertSame( $expected, $output );
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function data_wp_parse_str() {
+		return array(
+			'null'              => array(
+				'input'    => null,
+				'expected' => array(),
+			),
+			'boolean false'     => array(
+				'input'    => false,
+				'expected' => array(),
+			),
+			'boolean true'      => array(
+				'input'    => true,
+				'expected' => array(
+					1 => '',
+				),
+			),
+			'integer 0'         => array(
+				'input'    => 0,
+				'expected' => array(
+					0 => '',
+				),
+			),
+			'integer 456'       => array(
+				'input'    => 456,
+				'expected' => array(
+					456 => '',
+				),
+			),
+			'float 12.53'       => array(
+				'input'    => 12.53,
+				'expected' => array(
+					'12_53' => '',
+				),
+			),
+			'plain string'      => array(
+				'input'    => 'foobar',
+				'expected' => array(
+					'foobar' => '',
+				),
+			),
+			'query string'      => array(
+				'input'    => 'x=5&_baba=dudu&',
+				'expected' => array(
+					'x'     => '5',
+					'_baba' => 'dudu',
+				),
+			),
+			'stringable object' => array(
+				'input'    => new Fixture_Formatting_WpParseStr(),
+				'expected' => array(
+					'foobar' => '',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Tests that the result array only contains the result of the string parsing
+	 * when provided with different types input for the $output parameter.
+	 *
+	 * @dataProvider data_wp_parse_str_result_array_is_always_overwritten
+	 *
+	 * @param array|null $output   Value for the $output parameter.
+	 * @param array      $expected Expected function output.
+	 */
+	public function test_wp_parse_str_result_array_is_always_overwritten( $output, $expected ) {
+		wp_parse_str( 'key=25&thing=text', $output );
+		$this->assertSame( $expected, $output );
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function data_wp_parse_str_result_array_is_always_overwritten() {
+		// Standard value for expected output.
+		$expected = array(
+			'key'   => '25',
+			'thing' => 'text',
+		);
+
+		return array(
+			'output null'                                 => array(
+				'output'   => null,
+				'expected' => $expected,
+			),
+			'output empty array'                          => array(
+				'output'   => array(),
+				'expected' => $expected,
+			),
+			'output non empty array, no conflicting keys' => array(
+				'output'   => array(
+					'foo' => 'bar',
+				),
+				'expected' => $expected,
+			),
+			'output non empty array, conflicting keys'    => array(
+				'output'   => array(
+					'key' => 'value',
+				),
+				'expected' => $expected,
+			),
+		);
+	}
+}
+
+/**
+ * Fixture for use in the tests.
+ */
+class Fixture_Formatting_WpParseStr {
+	public function __toString() {
+		return 'foobar';
+	}
+}


### PR DESCRIPTION
Fixes `parse_str(): Passing null to parameter #1 ($string) of type string is deprecated` notices on PHP 8.1.

Impact: 311 of the pre-existing tests are affected by this issue.

## Commit Details

### 
@jrfnl
Tests: add dedicated tests for the wp_parse_str() function
a1f6a48

Even though the function doesn't really contain any logic, these tests document the function behaviour when different input values and output values are passed and safeguard PHP cross-version compatibility.

### PHP 8.1: wp_parse_str() - fix handling of null

Fixes `parse_str(): Passing null to parameter #1 ($string) of type string is deprecated` notices on PHP 8.1, without change in behaviour.

Impact: 311 of the pre-existing tests are affected by this issue.

The PHP native `parse_str()` function expects a string, however, based on the failing tests, it is clear there are functions in WordPress which passes a non-string - including `null` - value to the `wp_parse_str()` function, which would subsequently pass it onto the PHP native function without further input validation.

Most notable offender is the `wp_parse_args()` function which special cases arrays and objects, but passes everything else off to `wp_parse_str()`.
A separate PR has been opened to expand the tests covering the `wp_parse_args()` method.

Several ways to fix this issue have been explored, including checking the received value with `is_string()` or `is_scalar()` before passing it off to the PHP native `parse_str()` function.

In the end it was decided against these in favour of a string cast as:
* `is_string()` would significantly change the behaviour for anything non-string.
* `is_scalar()` up to a point as well, as it does not take objects with a `__toString()` method into account.

Executing a string cast on the received value before passing it one maintains the pre-existing behaviour while still preventing the deprecation notice coming from PHP 81.

Ref: https://www.php.net/manual/en/function.parse-str.php



Trac ticket: https://core.trac.wordpress.org/ticket/53635

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
