### PR TITLE
PHP 8.1: strftime() is deprecated (Trac 53897)

### DIFF
--- a/tests/phpunit/tests/canonical/postStatus.php
+++ b/tests/phpunit/tests/canonical/postStatus.php
@@ -34,7 +34,7 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 		foreach ( $post_statuses as $post_status ) {
 			$post_date = '';
 			if ( 'future' === $post_status ) {
-				$post_date = strftime( '%Y-%m-%d %H:%M:%S', strtotime( '+1 year' ) );
+				$post_date = date_format( date_create( '+1 year' ), 'Y-m-d H:i:s' );
 			}
 
 			self::$posts[ $post_status ] = $factory->post->create_and_get(

--- a/tests/phpunit/tests/comment.php
+++ b/tests/phpunit/tests/comment.php
@@ -857,8 +857,8 @@ class Tests_Comment extends WP_UnitTestCase {
 		// Close comments more than one day old.
 		update_option( 'close_comments_days_old', 1 );
 
-		$old_date    = strtotime( '-25 hours' );
-		$old_post_id = self::factory()->post->create( array( 'post_date' => strftime( '%Y-%m-%d %H:%M:%S', $old_date ) ) );
+		$old_date    = date_create( '-25 hours' );
+		$old_post_id = self::factory()->post->create( array( 'post_date' => date_format( $old_date, 'Y-m-d H:i:s' ) ) );
 
 		$old_post_comment_status = _close_comments_for_old_post( true, $old_post_id );
 		$this->assertFalse( $old_post_comment_status );

--- a/tests/phpunit/tests/link.php
+++ b/tests/phpunit/tests/link.php
@@ -108,7 +108,7 @@ class Tests_Link extends WP_UnitTestCase {
 		$p = self::factory()->post->create(
 			array(
 				'post_status' => 'publish',
-				'post_date'   => strftime( '%Y-%m-%d %H:%M:%S', strtotime( '+1 day' ) ),
+				'post_date'   => date_format( date_create( '+1 day' ), 'Y-m-d H:i:s' ),
 			)
 		);
 
@@ -131,7 +131,7 @@ class Tests_Link extends WP_UnitTestCase {
 			array(
 				'post_status' => 'future',
 				'post_type'   => 'wptests_pt',
-				'post_date'   => strftime( '%Y-%m-%d %H:%M:%S', strtotime( '+1 day' ) ),
+				'post_date'   => date_format( date_create( '+1 day' ), 'Y-m-d H:i:s' ),
 			)
 		);
 

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -21,7 +21,7 @@ class Tests_Media extends WP_UnitTestCase {
 		foreach ( $post_statuses as $post_status ) {
 			$date = '';
 			if ( 'future' === $post_status ) {
-				strftime( '%Y-%m-%d %H:%M:%S', strtotime( '+1 year' ) );
+				date_format( date_create( '+1 year' ), 'Y-m-d H:i:s' );
 			}
 
 			self::$post_ids[ $post_status ] = $factory->post->create(

--- a/tests/phpunit/tests/multisite/ms-files-rewriting.php
+++ b/tests/phpunit/tests/multisite/ms-files-rewriting.php
@@ -35,21 +35,22 @@ if ( is_multisite() ) :
 			$this->assertTrue( is_main_site() );
 
 			$site = get_current_site();
+			$date = date_format( date_create( 'now' ), 'Y/m' );
 
 			$user_id  = self::factory()->user->create( array( 'role' => 'administrator' ) );
 			$blog_id2 = self::factory()->blog->create( array( 'user_id' => $user_id ) );
 			$info     = wp_upload_dir();
-			$this->assertSame( 'http://' . $site->domain . '/wp-content/uploads/' . gmstrftime( '%Y/%m' ), $info['url'] );
-			$this->assertSame( ABSPATH . 'wp-content/uploads/' . gmstrftime( '%Y/%m' ), $info['path'] );
-			$this->assertSame( gmstrftime( '/%Y/%m' ), $info['subdir'] );
+			$this->assertSame( 'http://' . $site->domain . '/wp-content/uploads/' . $date, $info['url'] );
+			$this->assertSame( ABSPATH . 'wp-content/uploads/' . $date, $info['path'] );
+			$this->assertSame( '/' . $date, $info['subdir'] );
 			$this->assertFalse( $info['error'] );
 
 			switch_to_blog( $blog_id2 );
 			$info2 = wp_upload_dir();
 			$this->assertNotEquals( $info, $info2 );
-			$this->assertSame( get_option( 'siteurl' ) . '/wp-content/blogs.dir/' . get_current_blog_id() . '/files/' . gmstrftime( '%Y/%m' ), $info2['url'] );
-			$this->assertSame( ABSPATH . 'wp-content/blogs.dir/' . get_current_blog_id() . '/files/' . gmstrftime( '%Y/%m' ), $info2['path'] );
-			$this->assertSame( gmstrftime( '/%Y/%m' ), $info2['subdir'] );
+			$this->assertSame( get_option( 'siteurl' ) . '/wp-content/blogs.dir/' . get_current_blog_id() . '/files/' . $date, $info2['url'] );
+			$this->assertSame( ABSPATH . 'wp-content/blogs.dir/' . get_current_blog_id() . '/files/' . $date, $info2['path'] );
+			$this->assertSame( '/' . $date, $info2['subdir'] );
 			$this->assertFalse( $info2['error'] );
 			restore_current_blog();
 		}

--- a/tests/phpunit/tests/multisite/site.php
+++ b/tests/phpunit/tests/multisite/site.php
@@ -838,27 +838,28 @@ if ( is_multisite() ) :
 			$this->assertTrue( is_main_site() );
 
 			$site = get_current_site();
+			$date = date_format( date_create( 'now' ), 'Y/m' );
 
 			$info = wp_upload_dir();
-			$this->assertSame( 'http://' . $site->domain . '/wp-content/uploads/' . gmstrftime( '%Y/%m' ), $info['url'] );
-			$this->assertSame( ABSPATH . 'wp-content/uploads/' . gmstrftime( '%Y/%m' ), $info['path'] );
-			$this->assertSame( gmstrftime( '/%Y/%m' ), $info['subdir'] );
+			$this->assertSame( 'http://' . $site->domain . '/wp-content/uploads/' . $date, $info['url'] );
+			$this->assertSame( ABSPATH . 'wp-content/uploads/' . $date, $info['path'] );
+			$this->assertSame( '/' . $date, $info['subdir'] );
 			$this->assertFalse( $info['error'] );
 
 			$blog_id = self::factory()->blog->create();
 
 			switch_to_blog( $blog_id );
 			$info = wp_upload_dir();
-			$this->assertSame( 'http://' . $site->domain . '/wp-content/uploads/sites/' . get_current_blog_id() . '/' . gmstrftime( '%Y/%m' ), $info['url'] );
-			$this->assertSame( ABSPATH . 'wp-content/uploads/sites/' . get_current_blog_id() . '/' . gmstrftime( '%Y/%m' ), $info['path'] );
-			$this->assertSame( gmstrftime( '/%Y/%m' ), $info['subdir'] );
+			$this->assertSame( 'http://' . $site->domain . '/wp-content/uploads/sites/' . get_current_blog_id() . '/' . $date, $info['url'] );
+			$this->assertSame( ABSPATH . 'wp-content/uploads/sites/' . get_current_blog_id() . '/' . $date, $info['path'] );
+			$this->assertSame( '/' . $date, $info['subdir'] );
 			$this->assertFalse( $info['error'] );
 			restore_current_blog();
 
 			$info = wp_upload_dir();
-			$this->assertSame( 'http://' . $site->domain . '/wp-content/uploads/' . gmstrftime( '%Y/%m' ), $info['url'] );
-			$this->assertSame( ABSPATH . 'wp-content/uploads/' . gmstrftime( '%Y/%m' ), $info['path'] );
-			$this->assertSame( gmstrftime( '/%Y/%m' ), $info['subdir'] );
+			$this->assertSame( 'http://' . $site->domain . '/wp-content/uploads/' . $date, $info['url'] );
+			$this->assertSame( ABSPATH . 'wp-content/uploads/' . $date, $info['path'] );
+			$this->assertSame( '/' . $date, $info['subdir'] );
 			$this->assertFalse( $info['error'] );
 		}
 

--- a/tests/phpunit/tests/oembed/getResponseData.php
+++ b/tests/phpunit/tests/oembed/getResponseData.php
@@ -119,7 +119,7 @@ class Tests_oEmbed_Response_Data extends WP_UnitTestCase {
 		$post = self::factory()->post->create_and_get(
 			array(
 				'post_status' => 'future',
-				'post_date'   => strftime( '%Y-%m-%d %H:%M:%S', strtotime( '+1 day' ) ),
+				'post_date'   => date_format( date_create( '+1 day' ), 'Y-m-d H:i:s' ),
 			)
 		);
 

--- a/tests/phpunit/tests/oembed/template.php
+++ b/tests/phpunit/tests/oembed/template.php
@@ -143,7 +143,7 @@ class Tests_Embed_Template extends WP_UnitTestCase {
 				'post_content' => 'Foo Bar',
 				'post_excerpt' => 'Bar Baz',
 				'post_status'  => 'future',
-				'post_date'    => strftime( '%Y-%m-%d %H:%M:%S', strtotime( '+1 day' ) ),
+				'post_date'    => date_format( date_create( '+1 day' ), 'Y-m-d H:i:s' ),
 			)
 		);
 

--- a/tests/phpunit/tests/post.php
+++ b/tests/phpunit/tests/post.php
@@ -128,7 +128,7 @@ class Tests_Post extends WP_UnitTestCase {
 			'post_status'  => 'publish',
 			'post_content' => rand_str(),
 			'post_title'   => rand_str(),
-			'post_date'    => strftime( '%Y-%m-%d %H:%M:%S', $future_date ),
+			'post_date'    => date_format( date_create( "@{$future_date}" ), 'Y-m-d H:i:s' ),
 		);
 
 		// Insert a post and make sure the ID is OK.
@@ -164,7 +164,7 @@ class Tests_Post extends WP_UnitTestCase {
 			'post_status'  => 'publish',
 			'post_content' => rand_str(),
 			'post_title'   => rand_str(),
-			'post_date'    => strftime( '%Y-%m-%d %H:%M:%S', $future_date_1 ),
+			'post_date'    => date_format( date_create( "@{$future_date_1}" ), 'Y-m-d H:i:s' ),
 		);
 
 		// Insert a post and make sure the ID is OK.
@@ -182,7 +182,7 @@ class Tests_Post extends WP_UnitTestCase {
 		// Now save it again with a date further in the future.
 
 		$post['ID']            = $id;
-		$post['post_date']     = strftime( '%Y-%m-%d %H:%M:%S', $future_date_2 );
+		$post['post_date']     = date_format( date_create( "@{$future_date_2}" ), 'Y-m-d H:i:s' );
 		$post['post_date_gmt'] = null;
 		wp_update_post( $post );
 
@@ -209,7 +209,7 @@ class Tests_Post extends WP_UnitTestCase {
 			'post_status'  => 'publish',
 			'post_content' => rand_str(),
 			'post_title'   => rand_str(),
-			'post_date'    => strftime( '%Y-%m-%d %H:%M:%S', $future_date_1 ),
+			'post_date'    => date_format( date_create( "@{$future_date_1}" ), 'Y-m-d H:i:s' ),
 		);
 
 		// Insert a post and make sure the ID is OK.
@@ -227,7 +227,7 @@ class Tests_Post extends WP_UnitTestCase {
 		// Now save it again with a date further in the future.
 
 		$post['ID']            = $id;
-		$post['post_date']     = strftime( '%Y-%m-%d %H:%M:%S', $future_date_2 );
+		$post['post_date']     = date_format( date_create( "@{$future_date_2}" ), 'Y-m-d H:i:s' );
 		$post['post_date_gmt'] = null;
 		wp_update_post( $post );
 
@@ -251,7 +251,7 @@ class Tests_Post extends WP_UnitTestCase {
 			'post_status'  => 'draft',
 			'post_content' => rand_str(),
 			'post_title'   => rand_str(),
-			'post_date'    => strftime( '%Y-%m-%d %H:%M:%S', $future_date ),
+			'post_date'    => date_format( date_create( "@{$future_date}" ), 'Y-m-d H:i:s' ),
 		);
 
 		// Insert a post and make sure the ID is OK.
@@ -286,7 +286,7 @@ class Tests_Post extends WP_UnitTestCase {
 			'post_status'  => 'publish',
 			'post_content' => rand_str(),
 			'post_title'   => rand_str(),
-			'post_date'    => strftime( '%Y-%m-%d %H:%M:%S', $future_date_1 ),
+			'post_date'    => date_format( date_create( "@{$future_date_1}" ), 'Y-m-d H:i:s' ),
 		);
 
 		// Insert a post and make sure the ID is OK.
@@ -330,7 +330,7 @@ class Tests_Post extends WP_UnitTestCase {
 				'post_status'  => 'publish',
 				'post_content' => rand_str(),
 				'post_title'   => rand_str(),
-				'post_date'    => strftime( '%Y-%m-%d %H:%M:%S', $future_date_1 ),
+				'post_date'    => date_format( date_create( "@{$future_date_1}" ), 'Y-m-d H:i:s' ),
 			);
 
 			// Insert a post and make sure the ID is OK.
@@ -372,7 +372,7 @@ class Tests_Post extends WP_UnitTestCase {
 			'post_status'  => 'private',
 			'post_content' => rand_str(),
 			'post_title'   => rand_str(),
-			'post_date'    => strftime( '%Y-%m-%d %H:%M:%S', $future_date ),
+			'post_date'    => date_format( date_create( "@{$future_date}" ), 'Y-m-d H:i:s' ),
 		);
 
 		// Insert a post and make sure the ID is OK.
@@ -429,7 +429,7 @@ class Tests_Post extends WP_UnitTestCase {
 			'post_status'  => 'publish',
 			'post_content' => rand_str(),
 			'post_title'   => rand_str(),
-			'post_date'    => strftime( '%Y-%m-%d %H:%M:%S', $future_date_1 ),
+			'post_date'    => date_format( date_create( "@{$future_date_1}" ), 'Y-m-d H:i:s' ),
 		);
 
 		// Insert a post and make sure the ID is OK.
@@ -535,7 +535,7 @@ class Tests_Post extends WP_UnitTestCase {
 			'post_status'  => 'publish',
 			'post_content' => rand_str(),
 			'post_title'   => rand_str(),
-			'post_date'    => strftime( '%Y-%m-%d %H:%M:%S', $future_date ),
+			'post_date'    => date_format( date_create( "@{$future_date}" ), 'Y-m-d H:i:s' ),
 		);
 
 		// Insert a post and make sure the ID is OK.

--- a/tests/phpunit/tests/post/getPostStatus.php
+++ b/tests/phpunit/tests/post/getPostStatus.php
@@ -21,7 +21,7 @@ class Tests_Post_GetPostStatus extends WP_UnitTestCase {
 			$date          = '';
 			$actual_status = $post_status;
 			if ( 'future' === $post_status ) {
-				$date = strftime( '%Y-%m-%d %H:%M:%S', strtotime( '+1 year' ) );
+				$date = date_format( date_create( '+1 year' ), 'Y-m-d H:i:s' );
 			} elseif ( in_array( $post_status, array( 'trash', 'delete' ), true ) ) {
 				$actual_status = 'publish';
 			}

--- a/tests/phpunit/tests/post/isPostPubliclyViewable.php
+++ b/tests/phpunit/tests/post/isPostPubliclyViewable.php
@@ -18,7 +18,7 @@ class Tests_Post_IsPostPubliclyViewable extends WP_UnitTestCase {
 			$date          = '';
 			$actual_status = $post_status;
 			if ( 'future' === $post_status ) {
-				$date = strftime( '%Y-%m-%d %H:%M:%S', strtotime( '+1 year' ) );
+				$date = date_format( date_create( '+1 year' ), 'Y-m-d H:i:s' );
 			} elseif ( in_array( $post_status, array( 'trash', 'delete' ), true ) ) {
 				$actual_status = 'publish';
 			}
@@ -51,7 +51,7 @@ class Tests_Post_IsPostPubliclyViewable extends WP_UnitTestCase {
 	public function test_is_post_publicly_viewable( $post_type, $post_status, $expected, $parent_key = '' ) {
 		$date = '';
 		if ( 'future' === $post_status ) {
-			$date = strftime( '%Y-%m-%d %H:%M:%S', strtotime( '+1 year' ) );
+			$date = date_format( date_create( '+1 year' ), 'Y-m-d H:i:s' );
 		}
 
 		$post_id = $this->factory()->post->create(

--- a/tests/phpunit/tests/upload.php
+++ b/tests/phpunit/tests/upload.php
@@ -22,7 +22,7 @@ class Tests_Upload extends WP_UnitTestCase {
 	function test_upload_dir_default() {
 		// wp_upload_dir() with default parameters.
 		$info   = wp_upload_dir();
-		$subdir = gmstrftime( '/%Y/%m' );
+		$subdir = date_format( date_create( 'now' ), '/Y/m' );
 
 		$this->assertSame( get_option( 'siteurl' ) . '/wp-content/uploads' . $subdir, $info['url'] );
 		$this->assertSame( ABSPATH . 'wp-content/uploads' . $subdir, $info['path'] );
@@ -34,7 +34,7 @@ class Tests_Upload extends WP_UnitTestCase {
 		// wp_upload_dir() with a relative upload path that is not 'wp-content/uploads'.
 		update_option( 'upload_path', 'foo/bar' );
 		$info   = _wp_upload_dir();
-		$subdir = gmstrftime( '/%Y/%m' );
+		$subdir = date_format( date_create( 'now' ), '/Y/m' );
 
 		$this->assertSame( get_option( 'siteurl' ) . '/foo/bar' . $subdir, $info['url'] );
 		$this->assertSame( ABSPATH . 'foo/bar' . $subdir, $info['path'] );
@@ -57,7 +57,7 @@ class Tests_Upload extends WP_UnitTestCase {
 		// Use `_wp_upload_dir()` directly to bypass caching and work with the changed options.
 		// It doesn't create the /year/month directories.
 		$info   = _wp_upload_dir();
-		$subdir = gmstrftime( '/%Y/%m' );
+		$subdir = date_format( date_create( 'now' ), '/Y/m' );
 
 		$this->assertSame( '/baz' . $subdir, $info['url'] );
 		$this->assertSame( $path . $subdir, $info['path'] );
@@ -83,7 +83,7 @@ class Tests_Upload extends WP_UnitTestCase {
 		// Use `_wp_upload_dir()` directly to bypass caching and work with the changed options.
 		// It doesn't create the /year/month directories.
 		$info   = _wp_upload_dir();
-		$subdir = gmstrftime( '/%Y/%m' );
+		$subdir = date_format( date_create( 'now' ), '/Y/m' );
 
 		$this->assertSame( 'http://' . WP_TESTS_DOMAIN . '/asdf' . $subdir, $info['url'] );
 		$this->assertSame( ABSPATH . 'wp-content/uploads' . $subdir, $info['path'] );
@@ -98,7 +98,7 @@ class Tests_Upload extends WP_UnitTestCase {
 		// Use `_wp_upload_dir()` directly to bypass caching and work with the changed options.
 		// It doesn't create the /year/month directories.
 		$info   = _wp_upload_dir();
-		$subdir = gmstrftime( '/%Y/%m' );
+		$subdir = date_format( date_create( 'now' ), '/Y/m' );
 
 		$this->assertSame( get_option( 'siteurl' ) . '/wp-content/uploads' . $subdir, $info['url'] );
 		$this->assertSame( ABSPATH . 'wp-content/uploads' . $subdir, $info['path'] );

--- a/tests/phpunit/tests/xmlrpc/mw/editPost.php
+++ b/tests/phpunit/tests/xmlrpc/mw/editPost.php
@@ -332,7 +332,7 @@ class Tests_XMLRPC_mw_editPost extends WP_XMLRPC_UnitTestCase {
 		$after = get_post( $post_id );
 		$this->assertSame( 'future', $after->post_status );
 
-		$future_date_string = strftime( '%Y-%m-%d %H:%M:%S', $future_time );
+		$future_date_string = date_format( date_create( "@{$future_time}" ), 'Y-m-d H:i:s' );
 		$this->assertSame( $future_date_string, $after->post_date );
 	}
 }

--- a/tests/phpunit/tests/xmlrpc/mw/getPost.php
+++ b/tests/phpunit/tests/xmlrpc/mw/getPost.php
@@ -16,7 +16,7 @@ class Tests_XMLRPC_mw_getPost extends WP_XMLRPC_UnitTestCase {
 						'role'       => 'author',
 					)
 				),
-				'post_date'   => strftime( '%Y-%m-%d %H:%M:%S', strtotime( '+1 day' ) ),
+				'post_date'   => date_format( date_create( '+1 day' ), 'Y-m-d H:i:s' ),
 			)
 		);
 	}

--- a/tests/phpunit/tests/xmlrpc/mw/getRecentPosts.php
+++ b/tests/phpunit/tests/xmlrpc/mw/getRecentPosts.php
@@ -17,7 +17,7 @@ class Tests_XMLRPC_mw_getRecentPosts extends WP_XMLRPC_UnitTestCase {
 						'role'       => 'author',
 					)
 				),
-				'post_date'   => strftime( '%Y-%m-%d %H:%M:%S', strtotime( '+1 day' ) ),
+				'post_date'   => date_format( date_create( '+1 day' ), 'Y-m-d H:i:s' ),
 			)
 		);
 	}

--- a/tests/phpunit/tests/xmlrpc/wp/editPost.php
+++ b/tests/phpunit/tests/xmlrpc/wp/editPost.php
@@ -496,7 +496,7 @@ class Tests_XMLRPC_wp_editPost extends WP_XMLRPC_UnitTestCase {
 		$after = get_post( $post_id );
 		$this->assertSame( 'future', $after->post_status );
 
-		$future_date_string = strftime( '%Y-%m-%d %H:%M:%S', $future_time );
+		$future_date_string = date_format( date_create( "@{$future_time}" ), 'Y-m-d H:i:s' );
 		$this->assertSame( $future_date_string, $after->post_date );
 	}
 

--- a/tests/phpunit/tests/xmlrpc/wp/getPage.php
+++ b/tests/phpunit/tests/xmlrpc/wp/getPage.php
@@ -17,7 +17,7 @@ class Tests_XMLRPC_wp_getPage extends WP_XMLRPC_UnitTestCase {
 						'role'       => 'author',
 					)
 				),
-				'post_date'   => strftime( '%Y-%m-%d %H:%M:%S', strtotime( '+1 day' ) ),
+				'post_date'   => date_format( date_create( '+1 day' ), 'Y-m-d H:i:s' ),
 			)
 		);
 	}

--- a/tests/phpunit/tests/xmlrpc/wp/getPageList.php
+++ b/tests/phpunit/tests/xmlrpc/wp/getPageList.php
@@ -17,7 +17,7 @@ class Tests_XMLRPC_wp_getPageList extends WP_XMLRPC_UnitTestCase {
 						'role'       => 'author',
 					)
 				),
-				'post_date'   => strftime( '%Y-%m-%d %H:%M:%S', strtotime( '+1 day' ) ),
+				'post_date'   => date_format( date_create( '+1 day' ), 'Y-m-d H:i:s' ),
 			)
 		);
 	}

--- a/tests/phpunit/tests/xmlrpc/wp/getPages.php
+++ b/tests/phpunit/tests/xmlrpc/wp/getPages.php
@@ -18,7 +18,7 @@ class Tests_XMLRPC_wp_getPages extends WP_XMLRPC_UnitTestCase {
 						'role'       => 'administrator',
 					)
 				),
-				'post_date'   => strftime( '%Y-%m-%d %H:%M:%S', strtotime( '+1 day' ) ),
+				'post_date'   => date_format( date_create( '+1 day' ), 'Y-m-d H:i:s' ),
 			)
 		);
 		self::$editor_id = $factory->user->create(

--- a/tests/phpunit/tests/xmlrpc/wp/getPost.php
+++ b/tests/phpunit/tests/xmlrpc/wp/getPost.php
@@ -18,7 +18,7 @@ class Tests_XMLRPC_wp_getPost extends WP_XMLRPC_UnitTestCase {
 			'post_content' => rand_str( 2000 ),
 			'post_excerpt' => rand_str( 100 ),
 			'post_author'  => $this->make_user_by_role( 'author' ),
-			'post_date'    => strftime( '%Y-%m-%d %H:%M:%S', $this->post_date_ts ),
+			'post_date'    => date_format( date_create( "@{$this->post_date_ts}" ), 'Y-m-d H:i:s' ),
 		);
 		$this->post_id                 = wp_insert_post( $this->post_data );
 		$this->post_custom_field       = array(

--- a/tests/phpunit/tests/xmlrpc/wp/getUser.php
+++ b/tests/phpunit/tests/xmlrpc/wp/getUser.php
@@ -61,7 +61,7 @@ class Tests_XMLRPC_wp_getUser extends WP_XMLRPC_UnitTestCase {
 			'user_url'        => 'http://www.example.com/testuser',
 			'role'            => 'author',
 			'aim'             => 'wordpress',
-			'user_registered' => strftime( '%Y-%m-%d %H:%M:%S', $registered_date ),
+			'user_registered' => date_format( date_create( "@{$registered_date}" ), 'Y-m-d H:i:s' ),
 		);
 		$user_id         = wp_insert_user( $user_data );
 


### PR DESCRIPTION
>  The strftime() and gmstrftime() functions exhibit similar issues as strptime(), in that the formats they support, as well as their behavior, is platform-dependent. Unlike strptime(), these functions are available on Windows, though with a different feature set than on Linux. Musl-based distributions like Alpine do not support timezone-related format specifiers correctly. These functions are also locale-based, and as such may exhibit thread-safety issues.
>
> Once again date() or DateTime::format() provide portable alternatives, and IntlDateFormatter::format() provides a more sophisticated, localization-aware alternative.

Ref: https://wiki.php.net/rfc/deprecations_php_8_1#strftime_and_gmstrftime

> The strftime() and gmstrftime() functions have been deprecated in favor of
>  date()/DateTime::format() (for locale-independent formatting) or
>  IntlDateFormatter::format() (for locale-dependent formatting).

Ref: https://github.com/php/php-src/blob/1cf4fb739f7a4fa8404a4c0958f13d04eae519d4/UPGRADING#L379-L381

Other references:
* https://www.php.net/manual/en/function.strftime.php (for the old format string characters)
* https://www.php.net/manual/en/datetime.format.php (for the new format string characters)
* https://www.php.net/manual/en/datetime.construct.php (see Example 2 for a Unix timestamp code sample)

Verification of the principle:
https://3v4l.org/MCURg


Trac ticket: https://core.trac.wordpress.org/ticket/53897

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
