### PR TITLE
Editor Settings: Avoid losing original template keys

### DIFF
--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -119,12 +119,12 @@ wp_add_inline_script(
  * besides the default value.
  */
 $available_templates = wp_get_theme()->get_page_templates( get_post( $post->ID ) );
-$available_templates = ! empty( $available_templates ) ? array_merge(
+$available_templates = ! empty( $available_templates ) ? array_replace(
+	$available_templates,
 	array(
 		/** This filter is documented in wp-admin/includes/meta-boxes.php */
 		'' => apply_filters( 'default_page_template_title', __( 'Default template' ), 'rest-api' ),
-	),
-	$available_templates
+	)
 ) : $available_templates;
 
 // Lock settings.

--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -120,11 +120,11 @@ wp_add_inline_script(
  */
 $available_templates = wp_get_theme()->get_page_templates( get_post( $post->ID ) );
 $available_templates = ! empty( $available_templates ) ? array_replace(
-	$available_templates,
 	array(
 		/** This filter is documented in wp-admin/includes/meta-boxes.php */
 		'' => apply_filters( 'default_page_template_title', __( 'Default template' ), 'rest-api' ),
-	)
+	),
+	$available_templates
 ) : $available_templates;
 
 // Lock settings.


### PR DESCRIPTION
Changes `array_merge` with `array_replace`. The latter will keep the same numeric keys.

Verification example: https://3v4l.org/tlft6

Trac ticket: https://core.trac.wordpress.org/ticket/53898

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
