### PR TITLE
Images: Add ICO mime types to getimagesize_mimes_to_exts list

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -3085,12 +3085,14 @@ function wp_check_filetype_and_ext( $file, $filename, $mimes = null ) {
 			$mime_to_ext = apply_filters(
 				'getimagesize_mimes_to_exts',
 				array(
-					'image/jpeg' => 'jpg',
-					'image/png'  => 'png',
-					'image/gif'  => 'gif',
-					'image/bmp'  => 'bmp',
-					'image/tiff' => 'tif',
-					'image/webp' => 'webp',
+					'image/jpeg'               => 'jpg',
+					'image/png'                => 'png',
+					'image/gif'                => 'gif',
+					'image/bmp'                => 'bmp',
+					'image/tiff'               => 'tif',
+					'image/webp'               => 'webp',
+					'image/x-icon'             => 'ico',
+					'image/vnd.microsoft.icon' => 'ico',
 				)
 			);
 


### PR DESCRIPTION
This adds the two common mime types for ICO files to the default `getimagesize_mimes_to_exts` list, for related reasons:

* `image/x-icon` - This allows an ICO file with an incorrect extension to be uploaded and have its filename corrected (e.g. "logo.bmp" to "logo.ico").

* `image/vnd.microsoft.icon` - In some server configurations, `wp_get_image_mime()` will return this mime type for ICO files. Since `wp_check_filetype()` will always return `image/x-icon`, ICO files will not be allowed to be uploaded unless this mime type is in the `getimagesize_mimes_to_exts` list.

Trac ticket: https://core.trac.wordpress.org/ticket/52531

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
