### PR TITLE
#53910

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2251,13 +2251,11 @@ function sanitize_title_with_dashes( $title, $raw_title = '', $context = 'displa
 	// Restore octets.
 	$title = preg_replace( '|---([a-fA-F0-9][a-fA-F0-9])---|', '%$1', $title );
 
-	$title_seems_utf8 = seems_utf8( $title );
-
-	if ( $title_seems_utf8 ) {
+	if ( seems_utf8( $title ) ) {
 		if ( function_exists( 'mb_strtolower' ) ) {
 			$title = mb_strtolower( $title, 'UTF-8' );
 		}
-		$title = utf8_uri_encode( $title, max( 200, strlen( $title ) ) );
+		$title = utf8_uri_encode( $title );
 	}
 
 	$title = strtolower( $title );
@@ -2361,7 +2359,7 @@ function sanitize_title_with_dashes( $title, $raw_title = '', $context = 'displa
 	$title = preg_replace( '|-+|', '-', $title );
 	$title = trim( $title, '-' );
 
-	if ( $title_seems_utf8 && strlen( $title ) > 200 ) {
+	if ( seems_utf8( $title ) ) {
 		$title = substr( $title, 0, 200 );
 	}
 

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2251,11 +2251,13 @@ function sanitize_title_with_dashes( $title, $raw_title = '', $context = 'displa
 	// Restore octets.
 	$title = preg_replace( '|---([a-fA-F0-9][a-fA-F0-9])---|', '%$1', $title );
 
-	if ( seems_utf8( $title ) ) {
+	$title_seems_utf8 = seems_utf8( $title );
+
+	if ( $title_seems_utf8 ) {
 		if ( function_exists( 'mb_strtolower' ) ) {
 			$title = mb_strtolower( $title, 'UTF-8' );
 		}
-		$title = utf8_uri_encode( $title, 200 );
+		$title = utf8_uri_encode( $title, max( 200, strlen( $title ) ) );
 	}
 
 	$title = strtolower( $title );
@@ -2358,6 +2360,10 @@ function sanitize_title_with_dashes( $title, $raw_title = '', $context = 'displa
 	$title = preg_replace( '/\s+/', '-', $title );
 	$title = preg_replace( '|-+|', '-', $title );
 	$title = trim( $title, '-' );
+
+	if ( $title_seems_utf8 && strlen( $title ) > 200 ) {
+		$title = substr( $title, 0, 200 );
+	}
 
 	return $title;
 }

--- a/tests/phpunit/tests/formatting/sanitizeTitleWithDashes.php
+++ b/tests/phpunit/tests/formatting/sanitizeTitleWithDashes.php
@@ -357,4 +357,15 @@ class Tests_Formatting_SanitizeTitleWithDashes extends WP_UnitTestCase {
 			),
 		);
 	}
+
+	/**
+	 * @ticket 53910
+	 */
+	function test_removes_encoded_values_before_trimming_title() {
+		$title  = 'this-very-long-title-is-to-help-demonstrate-that-';
+		$title .= 'partial-encoded-values-remain-when-you-try-to-use-';
+		$title .= 'sanitize-title-with-dashes-on-encoded-strings-trimmed-';
+		$title .= 'to-200-chars-instead-of-using-max-and-strlen';
+		$this->assertSame( $title, sanitize_title_with_dashes( $title . '%e2%80%98', '', 'save' ) );
+	}
 }


### PR DESCRIPTION
`sanitize_title_with_dashes()` does a check to see if the title `seems_utf8()` and subsequently url encodes it.

The call to `utf8_uri_encode()` has a `$length` argument of `200`.

If an encoded value crosses the 200 boundary, the encoded value is cut and the remainder isn't picked up by any of the subsequent actions taken by `sanitize_title_with_dashes()`.

Resolved by:
- storing the `seems_utf8()` value.
- changing the call to `utf8_uri_encode()`, so that the `length` argument is the `max()` of `strlen( $title )` and `200`.
- trimming the `$title` to `200` at the end of `sanitize_title_with_dashes()` instead.

Trac ticket: https://core.trac.wordpress.org/ticket/53910
