### PR TITLE
PHP 8.1: validate_file(): prevent "passing null to non-nullable" notice

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -5661,6 +5661,10 @@ function iis7_supports_permalinks() {
  * @return int 0 means nothing is wrong, greater than 0 means something was wrong.
  */
 function validate_file( $file, $allowed_files = array() ) {
+	if ( ! is_scalar( $file ) || '' === $file ) {
+		return 0;
+	}
+
 	// `../` on its own is not allowed:
 	if ( '../' === $file ) {
 		return 1;


### PR DESCRIPTION
No input validation was done. Covered by existing `Tests_Functions::test_validate_file()` test (well, the `null` and string part is).

Error fixed: `preg_match_all(): Passing null to parameter #2 ($subject) of type string is deprecated`

Effect: Errors down by 238, assertions up by 1920, failures down by 1.

Trac ticket: https://core.trac.wordpress.org/ticket/53635

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
