### PR TITLE
PHP 8.1: download_url() - fix handling of null (Trac 53635)

### DIFF
--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1126,7 +1126,11 @@ function download_url( $url, $timeout = 300, $signature_verification = false ) {
 		return new WP_Error( 'http_no_url', __( 'Invalid URL Provided.' ) );
 	}
 
-	$url_filename = basename( parse_url( $url, PHP_URL_PATH ) );
+	$url_path     = parse_url( $url, PHP_URL_PATH );
+	$url_filename = '';
+	if ( is_string( $url_path ) && '' !== $url_path ) {
+		$url_filename = basename( $url_path );
+	}
 
 	$tmpfname = wp_tempnam( $url_filename );
 	if ( ! $tmpfname ) {
@@ -1212,7 +1216,6 @@ function download_url( $url, $timeout = 300, $signature_verification = false ) {
 			// WordPress.org stores signatures at $package_url.sig.
 
 			$signature_url = false;
-			$url_path      = parse_url( $url, PHP_URL_PATH );
 
 			if ( '.zip' === substr( $url_path, -4 ) || '.tar.gz' === substr( $url_path, -7 ) ) {
 				$signature_url = str_replace( $url_path, $url_path . '.sig', $url );
@@ -1243,7 +1246,7 @@ function download_url( $url, $timeout = 300, $signature_verification = false ) {
 		}
 
 		// Perform the checks.
-		$signature_verification = verify_file_signature( $tmpfname, $signature, basename( parse_url( $url, PHP_URL_PATH ) ) );
+		$signature_verification = verify_file_signature( $tmpfname, $signature, $url_filename );
 	}
 
 	if ( is_wp_error( $signature_verification ) ) {

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1217,7 +1217,7 @@ function download_url( $url, $timeout = 300, $signature_verification = false ) {
 
 			$signature_url = false;
 
-			if ( '.zip' === substr( $url_path, -4 ) || '.tar.gz' === substr( $url_path, -7 ) ) {
+			if ( is_string( $url_path ) && ( '.zip' === substr( $url_path, -4 ) || '.tar.gz' === substr( $url_path, -7 ) ) ) {
 				$signature_url = str_replace( $url_path, $url_path . '.sig', $url );
 			}
 

--- a/tests/phpunit/tests/admin/includesFile.php
+++ b/tests/phpunit/tests/admin/includesFile.php
@@ -77,4 +77,50 @@ class Tests_Admin_includesFile extends WP_UnitTestCase {
 	public function __return_5() {
 		return 5;
 	}
+
+	/**
+	 * Verify that a WP_Error object is returned when invalid input is passed as the $url parameter.
+	 *
+	 * @covers ::download_url
+	 *
+	 * @dataProvider data_download_url_empty_url
+	 *
+	 * @param mixed $url Input URL.
+	 */
+	public function test_download_url_empty_url( $url ) {
+		$error = download_url( $url );
+		$this->assertWPError( $error );
+		$this->assertSame( 'http_no_url', $error->get_error_code() );
+		$this->assertSame( 'Invalid URL Provided.', $error->get_error_message() );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_download_url_empty_url() {
+		return array(
+			'null'         => array( null ),
+			'false'        => array( false ),
+			'integer 0'    => array( 0 ),
+			'empty string' => array( '' ),
+			'string 0'     => array( '0' ),
+		);
+	}
+
+	/**
+	 * Verify that no "passing null to non-nullable" error is thrown on PHP 8.1,
+	 * when the $url does not have a path component.
+	 *
+	 * @covers ::download_url
+	 *
+	 * @ticket 53635
+	 */
+	public function test_download_url_no_warning_with_url_without_path() {
+		$result = download_url( 'https://example.com' );
+
+		$this->assertIsString( $result );
+		$this->assertNotEmpty( $result ); // File path will be generated, but will never be empty.
+	}
 }


### PR DESCRIPTION
### Tests_Admin_includesFile: add two tests for the download_url() function

The first test is "girl-scouting" to make sure that the code up to the point where the error is expected is tested.

The second test exposed a PHP 8.1 `basename(): Passing null to parameter #1 ($path) of type string is deprecated` error due to the call to `parse_url()` returning `null` when the component requested does not exist in the passed URL.

### PHP 8.1: download_url(): prevent "passing null to non-nullable" notice [1]

Includes removing duplicate function calls.

I've verified that neither the `$url`, nor the `$url_filename` are changed between when they are first received/defined and when they are re-used, so there is no need to repeat the function calls.

### Tests_Admin_includesFile: add yet another test for the download_url() function

The output of the call to `parse_url()` stored in the `$url_path` variable is used in more places in the function logic.
This test exposes a second PHP 8.1 deprecation notice, this time for `substr(): Passing null to parameter #1 ($string) of type string is deprecated`.

### PHP 8.1: download_url(): prevent "passing null to non-nullable" notice [2]



Trac ticket: https://core.trac.wordpress.org/ticket/53635

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
