### PR TITLE
Expand values and properties support in safecss_filter_attr

### DIFF
--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -1098,15 +1098,62 @@ EOF;
 				'css'      => 'height: expression( body.scrollTop + 50 + "px" )',
 				'expected' => '',
 			),
-			// RGB color values are not allowed.
+			// RGB color values ARE allowed.
 			array(
 				'css'      => 'color: rgb( 100, 100, 100 )',
-				'expected' => '',
+				'expected' => 'color: rgb( 100, 100, 100 )',
 			),
-			// RGBA color values are not allowed.
+			// RGBA color values ARE allowed.
 			array(
 				'css'      => 'color: rgb( 100, 100, 100, .4 )',
-				'expected' => '',
+				'expected' => 'color: rgb( 100, 100, 100, .4 )',
+			),
+			// Keyword values.
+			array(
+				'css'      => 'transform: none;',
+				'expected' => 'transform: none',
+			),
+			// Function values.
+			array(
+				'css'      => 'transform: rotate(90deg);',
+				'expected' => 'transform: rotate(90deg)',
+			),
+			// Multiple function values.
+			array(
+				'css'      => 'transform: perspective(500px) translate(10px, 0, 20px) rotateY(3deg);',
+				'expected' => 'transform: perspective(500px) translate(10px, 0, 20px) rotateY(3deg)',
+			),
+			// Global values.
+			array(
+				'css'      => 'transform: inherit;',
+				'expected' => 'transform: inherit',
+			),
+			// Multiple fonts.
+			array(
+				'css'      => 'font-family: "Roboto", "Helvetica Neue", "Helvetica", sans-serif',
+				'expected' => 'font-family: "Roboto", "Helvetica Neue", "Helvetica", sans-serif',
+			),
+			// RGBA Background color.
+			array(
+				'css'      => 'background-color:rgba(255,255,255,0.6);',
+				'expected' => 'background-color:rgba(255,255,255,0.6)',
+			),
+			// CSS clip paths.
+			array(
+				'css'      => 'clip-path:url(#mask-circle-foo-bar)',
+				'expected' => 'clip-path:url(#mask-circle-foo-bar)',
+			),
+			array(
+				'css'      => '-webkit-clip-path:url(#mask-circle-foo-bar)',
+				'expected' => '-webkit-clip-path:url(#mask-circle-foo-bar)',
+			),
+			array(
+				'css'      => 'pointer-events: initial',
+				'expected' => 'pointer-events: initial',
+			),
+			array(
+				'css'      => 'will-change: transform',
+				'expected' => 'will-change: transform',
 			),
 		);
 	}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->


* Added support for `rgb()` and `rgba()` values.
* Added support for `display`, `position`, `top`, `left`, `transform`, `opacity`, `white-space`, `clip-path`, `-webkit-clip-path`, `pointer-events` and `will-change` properties.

Trac ticket: https://core.trac.wordpress.org/ticket/24157

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
