### PR TITLE
PHP 8.1: wp_schedule_event(): fix deprecation notice (Trac 53635)

### DIFF
--- a/src/wp-includes/cron.php
+++ b/src/wp-includes/cron.php
@@ -302,6 +302,10 @@ function wp_schedule_event( $timestamp, $recurrence, $hook, $args = array(), $wp
 	$key = md5( serialize( $event->args ) );
 
 	$crons = _get_cron_array();
+	if ( ! is_array( $crons ) ) {
+		$crons = array();
+	}
+
 	$crons[ $event->timestamp ][ $event->hook ][ $key ] = array(
 		'schedule' => $event->schedule,
 		'args'     => $event->args,

--- a/tests/phpunit/tests/cron.php
+++ b/tests/phpunit/tests/cron.php
@@ -1112,4 +1112,27 @@ class Tests_Cron extends WP_UnitTestCase {
 		$this->assertSame( 'could_not_set', $unscheduled->get_error_code() );
 	}
 
+	/**
+	 * Tests that a call to wp_schedule_event() on a site without any scheduled events,
+	 * does not result in a PHP deprecation warning on PHP 8.1 or higher.
+	 *
+	 * Warning which we should not see:
+	 * `Deprecated: Automatic conversion of false to array is deprecated`
+	 *
+	 * @ticket 53635
+	 *
+	 * @covers ::wp_schedule_event
+	 */
+	function test_wp_schedule_event_without_cron_option_does_not_throw_warning() {
+		delete_option( 'cron' );
+
+		// Verify that the cause of the error is in place.
+		$this->assertFalse( _get_cron_array(), '_get_cron_array() does not return false' );
+
+		$hook = __FUNCTION__;
+		$ts1  = strtotime( '+10 minutes' );
+
+		// Add an event.
+		$this->assertTrue( wp_schedule_event( $ts1, 'daily', $hook ) );
+	}
 }


### PR DESCRIPTION
### Tests_Cron: add test for wp_schedule_event()

### PHP 8.1: wp_schedule_event(): fix deprecation notice

The following deprecation notice shows at the top of a test run on PHP 8.1-beta2:
```
Deprecated: Automatic conversion of false to array is deprecated in path/to/src/wp-includes/cron.php on line 305
```

In `wp_schedule_event()`, the cron info array is retrieved via a call to `_get_cron_array()`, but as the documentation for that function (correctly) states, the return type of that function is `array|false`, where `false` is returned for a virgin site, where no cron jobs have been scheduled yet.

However, no type check is done on the return value and the `wp_schedule_event()` function just blindly continues by assigning a value to a subkey of the `$crons` "array".

Fixed by adding validation for the returned value from `_get_cron_array()` and initializing an empty array if `false` was returned.

Ref: https://developer.wordpress.org/reference/functions/_get_cron_array/



Trac ticket: https://core.trac.wordpress.org/ticket/53635

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
