### PR TITLE
PHP 8.1: WP::parse_request() - fix handling of null (Trac 53635)

### DIFF
--- a/src/wp-includes/class-wp.php
+++ b/src/wp-includes/class-wp.php
@@ -170,8 +170,13 @@ class WP {
 
 			list( $req_uri ) = explode( '?', $_SERVER['REQUEST_URI'] );
 			$self            = $_SERVER['PHP_SELF'];
-			$home_path       = trim( parse_url( home_url(), PHP_URL_PATH ), '/' );
-			$home_path_regex = sprintf( '|^%s|i', preg_quote( $home_path, '|' ) );
+
+			$home_path       = parse_url( home_url(), PHP_URL_PATH );
+			$home_path_regex = '';
+			if ( is_string( $home_path ) && '' !== $home_path ) {
+				$home_path       = trim( $home_path, '/' );
+				$home_path_regex = sprintf( '|^%s|i', preg_quote( $home_path, '|' ) );
+			}
 
 			/*
 			 * Trim path info from the end and the leading home path from the front.
@@ -180,14 +185,17 @@ class WP {
 			 */
 			$req_uri  = str_replace( $pathinfo, '', $req_uri );
 			$req_uri  = trim( $req_uri, '/' );
-			$req_uri  = preg_replace( $home_path_regex, '', $req_uri );
-			$req_uri  = trim( $req_uri, '/' );
-			$pathinfo = trim( $pathinfo, '/' );
-			$pathinfo = preg_replace( $home_path_regex, '', $pathinfo );
 			$pathinfo = trim( $pathinfo, '/' );
 			$self     = trim( $self, '/' );
-			$self     = preg_replace( $home_path_regex, '', $self );
-			$self     = trim( $self, '/' );
+
+			if ( ! empty( $home_path_regex ) ) {
+				$req_uri  = preg_replace( $home_path_regex, '', $req_uri );
+				$req_uri  = trim( $req_uri, '/' );
+				$pathinfo = preg_replace( $home_path_regex, '', $pathinfo );
+				$pathinfo = trim( $pathinfo, '/' );
+				$self     = preg_replace( $home_path_regex, '', $self );
+				$self     = trim( $self, '/' );
+			}
 
 			// The requested permalink is in $pathinfo for path info requests and
 			// $req_uri for other requests.

--- a/tests/phpunit/tests/wp/ParseRequest.php
+++ b/tests/phpunit/tests/wp/ParseRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @group wp
+ * @covers WP::parse_request
+ */
+class Tests_WP_ParseRequest extends WP_UnitTestCase {
+	/**
+	 * @var WP
+	 */
+	protected $wp;
+
+	public function set_up() {
+		parent::set_up();
+		$this->wp = new WP();
+	}
+
+	/**
+	 * Test that no PHP 8.1 "passing null to non-nullable" deprecation is thrown when the
+	 * home URL has no path/trailing slash (default setup).
+	 *
+	 * Note: this doesn't test the actual functioning of the parse_request() method.
+	 * It just and only tests for/against the deprecation notice.
+	 *
+	 * @ticket 53635
+	 */
+	public function test_no_deprecation_notice_when_homeurl_has_no_path() {
+		// Make sure rewrite rules are not empty.
+		$this->set_permalink_structure( '/%year%/%monthnum%/%postname%/' );
+
+		// Make sure the test will function independently of whatever the test user set in wp-test-config.php.
+		add_filter(
+			'home_url',
+			static function ( $url ) {
+				return 'http://example.org';
+			}
+		);
+
+		$this->wp->parse_request();
+		$this->assertSame( '', $this->wp->request );
+	}
+}


### PR DESCRIPTION
Fixes `trim(): Passing null to parameter #1 ($string) of type string is deprecated` notices on PHP 8.1.

Impact: 611 of the pre-existing tests are affected by this issue.

## Commit Summary

### Tests: add test for WP::parse_request()

This function was effectively completely untested up to now.

As this is a huge function, adding a fully featured set of tests for this, is outside of the scope of this ticket.

So, for now, I'm just adding one test which specifically tests for the PHP 8.1 issue we want to address.

### PHP 8.1: WP::parse_request(): prevent "passing null to non-nullable" notice

As per the PHP manual:
> If the component parameter is omitted, an associative array is returned.
> If the component parameter is specified, `parse_url()` returns a string (or an int, in the case of `PHP_URL_PORT`) instead of an array. If the requested component doesn't exist within the given URL, `null` will be returned.

Ref: https://www.php.net/manual/en/function.parse-url.php#refsect1-function.parse-url-returnvalues

In this case, `parse_url()` is called with the `PHP_URL_PATH` as `$component`. This will return `null` in the majority of cases, as - expect for subdirectory-based sites - `home_url()` will return a URL without trailing slash, like `http://example.org`.

The return value of `parse_url()` was subsequently passed to `trim()` leading to a `trim(): Passing null to parameter #1 ($string) of type string is deprecated` deprecation notice on PHP 8.1.

Fixed by adjusting the logic flow to:
* Only pass the return value of `parse_url()` to follow-on functions if it makes sense, i.e. if it isn't `null`, nor an empty string.
* Preventing calls to `preg_replace()` and `trim()` further down in the function logic flow, when `preg_replace()`/`trim()` would have nothing to do anyhow.



Trac ticket: https://core.trac.wordpress.org/ticket/53635

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
