### PR TITLE
Force scrollbar on `Manage Themes` to stop jitter

### DIFF
--- a/src/wp-admin/css/themes.css
+++ b/src/wp-admin/css/themes.css
@@ -7,6 +7,10 @@
   16.1 - Manage Themes
 ------------------------------------------------------------------------------*/
 
+.themes-php {
+	overflow-y: scroll;
+}
+
 body.js .theme-browser.search-loading {
 	display: none;
 }


### PR DESCRIPTION
On the `Manage Themes` screen, some device sizes will experience 'shaking' or 'jittering' due to the vertical scrollbar appearing when hovering over a theme. This occurs only when the `New theme activated. Visit site` notice is displayed after activating a different theme.

Changes: Add `overflow-y: scroll;` to `.themes-php`, forcing the vertical scrollbar to be visible on the `Manage Themes` screen by default.

While not an ideal solution, it is the most common one for this issue, due to the drawbacks of other solutions.

Trac ticket: https://core.trac.wordpress.org/ticket/53478
