### PR TITLE
PHP 8.1: various files / fix handling of null (Trac 53635)

### DIFF
--- a/src/wp-admin/plugin-editor.php
+++ b/src/wp-admin/plugin-editor.php
@@ -312,10 +312,12 @@ if ( ! in_array( 'plugin_editor_notice', $dismissed_pointers, true ) ) :
 
 	$excluded_referer_basenames = array( 'plugin-editor.php', 'wp-login.php' );
 
-	if ( $referer && ! in_array( basename( parse_url( $referer, PHP_URL_PATH ) ), $excluded_referer_basenames, true ) ) {
-		$return_url = $referer;
-	} else {
-		$return_url = admin_url( '/' );
+	$return_url = admin_url( '/' );
+	if ( $referer ) {
+		$referer_path = parse_url( $referer, PHP_URL_PATH );
+		if ( is_string( $referer_path ) && ! in_array( basename( $referer_path ), $excluded_referer_basenames, true ) ) {
+			$return_url = $referer;
+		}
 	}
 	?>
 	<div id="file-editor-warning" class="notification-dialog-wrap file-editor-warning hide-if-no-js hidden">

--- a/src/wp-admin/theme-editor.php
+++ b/src/wp-admin/theme-editor.php
@@ -343,10 +343,12 @@ if ( ! in_array( 'theme_editor_notice', $dismissed_pointers, true ) ) :
 
 	$excluded_referer_basenames = array( 'theme-editor.php', 'wp-login.php' );
 
-	if ( $referer && ! in_array( basename( parse_url( $referer, PHP_URL_PATH ) ), $excluded_referer_basenames, true ) ) {
-		$return_url = $referer;
-	} else {
-		$return_url = admin_url( '/' );
+	$return_url = admin_url( '/' );
+	if ( $referer ) {
+		$referer_path = parse_url( $referer, PHP_URL_PATH );
+		if ( is_string( $referer_path ) && ! in_array( basename( $referer_path ), $excluded_referer_basenames, true ) ) {
+			$return_url = $referer;
+		}
 	}
 	?>
 	<div id="file-editor-warning" class="notification-dialog-wrap file-editor-warning hide-if-no-js hidden">

--- a/src/wp-includes/ms-default-constants.php
+++ b/src/wp-includes/ms-default-constants.php
@@ -68,7 +68,8 @@ function ms_cookie_constants() {
 	 * @since 2.6.0
 	 */
 	if ( ! defined( 'ADMIN_COOKIE_PATH' ) ) {
-		if ( ! is_subdomain_install() || trim( parse_url( get_option( 'siteurl' ), PHP_URL_PATH ), '/' ) ) {
+		$site_path = parse_url( get_option( 'siteurl' ), PHP_URL_PATH );
+		if ( ! is_subdomain_install() || ( is_string( $site_path ) && trim( $site_path, '/' ) ) ) {
 			define( 'ADMIN_COOKIE_PATH', SITECOOKIEPATH );
 		} else {
 			define( 'ADMIN_COOKIE_PATH', SITECOOKIEPATH . 'wp-admin' );


### PR DESCRIPTION
More fixes for `null` after `parse_url()`, but in files for which unit tests can't easily be added.

Note: trac ticket link below not added yet on purpose while this ticket is still WIP.

## Commit Summary

###  PHP 8.1: plugin/theme editor pages: prevent "passing null to non-nullable" notice

While it is probably unlikely that someone would have a direct link to the plugin/theme editor on their home page or even on someone else's homepage, it is entirely possible for the referrer URL to not have a "path" component.

In PHP 8.1, this would lead to a `basename(): Passing null to parameter #1 ($string) of type string is deprecated` deprecation notice.

Changing the logic around and adding validation for the return type value of `parse_url()` prevents that.

### PHP 8.1: ms_cookie_constants(): prevent "passing null to non-nullable" notice

It is entirely possible for the `siteurl` option to not have a "path" component.

In PHP 8.1, this would lead to a `trim(): Passing null to parameter #1 ($string) of type string is deprecated` deprecation notice.

Changing the logic around and adding validation for the return type value of `parse_url()` prevents that.

Unfortunately, as this function is declaring global constants, adding tests for this change is not really an option without potentially affecting other tests.

Also note, that it is possible, though unlikely, for the option to not be available.
In that case though, the `get_option()` method returns `false` and while passing that to `parse_url()` does not deserve any prices for clean code, it also is not problematic (at this point in time).

Trac ticket: https://core.trac.wordpress.org/ticket/53635

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
