### PR TITLE
removed extra "settings" in doc block

### DIFF
--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -272,7 +272,7 @@ function get_legacy_widget_block_editor_settings() {
 }
 
 /**
- * Returns the contextualized block editor settings settings for a selected editor context.
+ * Returns the contextualized block editor settings for a selected editor context.
  *
  * @since 5.8.0
  *


### PR DESCRIPTION
Removed extra "setting" in doc block

Trac ticket: https://core.trac.wordpress.org/ticket/53922
