### PR TITLE
Fix loss of focus in custom attachment fields when updating a value

### DIFF
--- a/src/js/media/views/attachment-compat.js
+++ b/src/js/media/views/attachment-compat.js
@@ -74,7 +74,7 @@ AttachmentCompat = View.extend(/** @lends wp.media.view.AttachmentCompat.prototy
 		});
 
 		this.controller.trigger( 'attachment:compat:waiting', ['waiting'] );
-		this.model.saveCompat( data ).always( _.bind( this.postSave, this ) );
+		this.model.saveCompat( data,  { silent: true }).always( _.bind( this.postSave, this ) );
 	},
 
 	postSave: function() {


### PR DESCRIPTION
I solved the problem as suggested by [syhc](https://profiles.wordpress.org/syhc/) in the Trac ticket [#40909](https://core.trac.wordpress.org/ticket/40909).

Trac ticket: https://core.trac.wordpress.org/ticket/40909
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
