### PR TITLE
Sanitize term name before checking if it exists.

### DIFF
--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -2686,7 +2686,7 @@ function wp_set_object_terms( $object_id, $terms, $taxonomy, $append = false ) {
 		}
 
 		// Make sure we're not sanitizing the term slug.
-		if ( sanitize_title( $term ) !== $term ) {
+		if ( is_string( $term ) && sanitize_title( $term ) !== $term ) {
 			$term_info = term_exists( sanitize_term_field( 'name', $term, null, $taxonomy, 'db' ), $taxonomy );
 		} else {
 			$term_info = term_exists( $term, $taxonomy );

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -2685,7 +2685,12 @@ function wp_set_object_terms( $object_id, $terms, $taxonomy, $append = false ) {
 			continue;
 		}
 
-		$term_info = term_exists( $term, $taxonomy );
+		// Make sure we're not sanitizing the term slug.
+		if ( sanitize_title( $term ) !== $term ) {
+			$term_info = term_exists( sanitize_term_field( 'name', $term, null, $taxonomy, 'db' ), $taxonomy );
+		} else {
+			$term_info = term_exists( $term, $taxonomy );
+		}
 
 		if ( ! $term_info ) {
 			// Skip if a non-existent term ID is passed.

--- a/tests/phpunit/tests/term.php
+++ b/tests/phpunit/tests/term.php
@@ -258,8 +258,6 @@ class Tests_Term extends WP_UnitTestCase {
 
 	public function test_wp_set_term_objects_finds_term_name_with_special_characters( $name ) {
 		$post_id  = self::factory()->post->create();
-		$taxonomy = 'category';
-
 		$expected = wp_set_object_terms( $post_id, $name, 'category', false );
 		$actual   = wp_set_object_terms( $post_id, $name, 'category', false );
 		$this->assertEquals( $expected, $actual );

--- a/tests/phpunit/tests/term.php
+++ b/tests/phpunit/tests/term.php
@@ -250,6 +250,55 @@ class Tests_Term extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 53152
+	 * @dataProvider data_wp_set_term_objects_finds_term_name_with_special_characters
+	 *
+	 * @param string $name  A term name containing special characters.
+	 */
+
+	public function test_wp_set_term_objects_finds_term_name_with_special_characters( $name ) {
+		$post_id  = self::factory()->post->create();
+		$taxonomy = 'category';
+
+		$expected = wp_set_object_terms( $post_id, $name, 'category', false );
+		$actual   = wp_set_object_terms( $post_id, $name, 'category', false );
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+
+	public function data_wp_set_term_objects_finds_term_name_with_special_characters() {
+		return array(
+			'ampersand'               => array( 'name' => 'Foo & Bar' ),
+			'ndash and mdash'         => array( 'name' => 'Foo – Bar' ),
+			'trademark'               => array( 'name' => 'Foo Bar™' ),
+			'copyright'               => array( 'name' => 'Foo Bar©' ),
+			'registered'              => array( 'name' => 'Foo Bar®' ),
+			'degree'                  => array( 'name' => 'Foo ° Bar' ),
+			'forward slash'           => array( 'name' => 'Fo/o Ba/r' ),
+			'back slash'              => array( 'name' => 'F\oo \Bar' ),
+			'multiply'                => array( 'name' => 'Foo × Bar' ),
+			'standalone diacritic'    => array( 'name' => 'Foo Bāáǎàr' ),
+			'acute accents'           => array( 'name' => 'ááa´aˊ' ),
+			'iexcel and iquest'       => array( 'name' => '¡Foo ¿Bar' ),
+			'angle quotes'            => array( 'name' => '‹Foo« »Bar›' ),
+			'curly quotes'            => array( 'name' => '“F‘o„o‚ „ ‟ ‛B“a’r”' ),
+			'bullet'                  => array( 'name' => 'Foo • Bar' ),
+			'unencoded percent'       => array( 'name' => 'Foo % Bar' ),
+			'encoded ampersand'       => array( 'name' => 'Foo &amp; Bar' ),
+			'encoded ndash and mdash' => array( 'name' => 'Foo &mdash; &ndash; Bar' ),
+			'encoded trademark'       => array( 'name' => 'Foo Bar &trade;' ),
+			'encoded copyright'       => array( 'name' => 'Foo Bar &copy;' ),
+			'encoded registered'      => array( 'name' => 'Foo Bar &reg;' ),
+			'encoded bullet'          => array( 'name' => 'Foo &bullet; Bar' ),
+		);
+	}
+
+	/**
 	 * @ticket 19205
 	 */
 	function test_orphan_category() {


### PR DESCRIPTION
Sanitize the `$term` argument being supplied to `wp_set_object_terms()` using `sanitize_term_field('name' ...)`.

Includes prior checks for `is_string( $term )` and `sanitize_title( $term ) !== $term` to avoid sanitizing if the `$term` argument provided is the term's slug.

N.B. `sanitize_title()` is specifically what `wp_insert_term()` does to create a term slug.

Before/After video will be posted in the Trac ticket below.

Trac ticket: https://core.trac.wordpress.org/ticket/53152
