### PR TITLE
Tests/bootstrap: further improvements to messages about Polyfills (Trac 46149)

### DIFF
--- a/tests/phpunit/includes/bootstrap.php
+++ b/tests/phpunit/includes/bootstrap.php
@@ -105,14 +105,18 @@ if ( ! class_exists( 'Yoast\PHPUnitPolyfills\Autoload' ) ) {
 
 	if ( $phpunit_polyfills_error || ! file_exists( $phpunit_polyfills_autoloader ) ) {
 		echo 'Error: The PHPUnit Polyfills library is a requirement for running the WP test suite.' . PHP_EOL;
-		if ( isset( $phpunit_polyfills_path ) ) {
+		if ( defined( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' ) ) {
 			printf(
 				'The PHPUnit Polyfills autoload file was not found in "%s"' . PHP_EOL,
 				WP_TESTS_PHPUNIT_POLYFILLS_PATH
 			);
 			echo 'Please verify that the file path provided in the WP_TESTS_PHPUNIT_POLYFILLS_PATH constant is correct.' . PHP_EOL;
-		} else {
+		} elseif ( defined( 'WP_RUN_CORE_TESTS' ) && WP_RUN_CORE_TESTS ) {
 			echo 'You need to run `composer update` before running the tests.' . PHP_EOL;
+			echo 'Once the dependencies are installed, you can run the tests using the Composer-installed version of PHPUnit or using a PHPUnit phar file, but the dependencies do need to be installed whichever way the tests are run.' . PHP_EOL;
+		} else {
+			echo 'If you are trying to run plugin/theme integration tests, make sure the PHPUnit Polyfills library is available and either load the autoload file of this library in your own test bootstrap before calling the WP Core test bootstrap file; or set the path to the PHPUnit Polyfills library in a "WP_TESTS_PHPUNIT_POLYFILLS_PATH" constant to allow the WP Core bootstrap to load the Polyfills.' . PHP_EOL . PHP_EOL;
+			echo 'If you are trying to run the WP Core tests, make sure to set the "WP_RUN_CORE_TESTS" constant to 1 and run `composer update` before running the tests.' . PHP_EOL;
 			echo 'Once the dependencies are installed, you can run the tests using the Composer-installed version of PHPUnit or using a PHPUnit phar file, but the dependencies do need to be installed whichever way the tests are run.' . PHP_EOL;
 		}
 		exit( 1 );

--- a/tests/phpunit/includes/bootstrap.php
+++ b/tests/phpunit/includes/bootstrap.php
@@ -133,13 +133,20 @@ unset( $phpunit_polyfills_autoloader, $phpunit_polyfills_error, $phpunit_polyfil
 $phpunit_polyfills_minimum_version = '1.0.1';
 if ( class_exists( '\Yoast\PHPUnitPolyfills\Autoload' )
 	&& ( defined( '\Yoast\PHPUnitPolyfills\Autoload::VERSION' ) === false
-	|| version_compare( \Yoast\PHPUnitPolyfills\Autoload::VERSION, $phpunit_polyfills_minimum_version, '<' ) )
+	|| version_compare( Yoast\PHPUnitPolyfills\Autoload::VERSION, $phpunit_polyfills_minimum_version, '<' ) )
 ) {
 	printf(
-		'Error: Version mismatch detected for the PHPUnit Polyfills. Please ensure that PHPUnit Polyfills %s or higher is loaded.' . PHP_EOL,
-		$phpunit_polyfills_minimum_version
+		'Error: Version mismatch detected for the PHPUnit Polyfills. Please ensure that PHPUnit Polyfills %s or higher is loaded. Found version: %s' . PHP_EOL,
+		$phpunit_polyfills_minimum_version,
+		defined( '\Yoast\PHPUnitPolyfills\Autoload::VERSION' ) ? Yoast\PHPUnitPolyfills\Autoload::VERSION : '1.0.0 or lower'
 	);
-	if ( ! defined( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' ) ) {
+	if ( defined( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' ) ) {
+		printf(
+			'Please ensure that the PHPUnit Polyfill install in "%s" is updated to version %s or higher.' . PHP_EOL,
+			WP_TESTS_PHPUNIT_POLYFILLS_PATH,
+			$phpunit_polyfills_minimum_version
+		);
+	} elseif ( defined( 'WP_RUN_CORE_TESTS' ) && WP_RUN_CORE_TESTS ) {
 		echo 'Please run `composer update` to install the latest version.' . PHP_EOL;
 	}
 	exit( 1 );

--- a/tests/phpunit/includes/bootstrap.php
+++ b/tests/phpunit/includes/bootstrap.php
@@ -86,8 +86,13 @@ if ( ! class_exists( 'Yoast\PHPUnitPolyfills\Autoload' ) ) {
 		if ( is_string( WP_TESTS_PHPUNIT_POLYFILLS_PATH )
 			&& '' !== WP_TESTS_PHPUNIT_POLYFILLS_PATH
 		) {
-			$phpunit_polyfills_path = rtrim( $phpunit_polyfills_path, '/\\' );
-			$phpunit_polyfills_path = realpath( $phpunit_polyfills_path . '/phpunitpolyfills-autoload.php' );
+			// Be tolerant to the path being provided including the filename.
+			if ( substr( $phpunit_polyfills_path, -29 ) !== 'phpunitpolyfills-autoload.php' ) {
+				$phpunit_polyfills_path = rtrim( $phpunit_polyfills_path, '/\\' );
+				$phpunit_polyfills_path = $phpunit_polyfills_path . '/phpunitpolyfills-autoload.php';
+			}
+
+			$phpunit_polyfills_path = realpath( $phpunit_polyfills_path );
 			if ( false !== $phpunit_polyfills_path ) {
 				$phpunit_polyfills_autoloader = $phpunit_polyfills_path;
 			} else {

--- a/tests/phpunit/includes/bootstrap.php
+++ b/tests/phpunit/includes/bootstrap.php
@@ -61,22 +61,25 @@ if ( version_compare( $phpunit_version, '5.7.21', '<' ) ) {
  *
  * The PHPUnit Polyfills are a requirement for the WP test suite.
  *
+ * For running the Core tests, the Make WordPress Core handbook contains step-by-step instructions
+ * on how to get up and running for a variety of supported workflows:
+ * {@link https://make.wordpress.org/core/handbook/testing/automated-testing/phpunit/#test-running-workflow-options}
+ *
  * Plugin/theme integration tests can handle this in any of the following ways:
  * - When using a full WP install: run `composer update` for the WP install prior to running the tests.
  * - When using a partial WP test suite install:
- *   - Add a `yoast/phpunit-polyfills` (dev) requirement to their own `composer.json` file.
+ *   - Add a `yoast/phpunit-polyfills` (dev) requirement to the plugin/theme's own `composer.json` file.
  *   - And then:
  *     - Either load the PHPUnit Polyfills autoload file prior to running the WP core bootstrap file.
- *     - Or declare a `WP_TESTS_PHPUNIT_POLYFILLS_PATH` constant pointing to the root directory
- *       of the PHPUnit Polyfills installation.
- *       This constant can be declared in the `phpunit.xml[.dist]` file like this:
- *       `<php><const name="WP_TESTS_PHPUNIT_POLYFILLS_PATH" value="path/to/yoast/phpunit-polyfills"/></php>
- *       or can be declared as a PHP constant in the `wp-tests-config.php` file or the plugin/theme
- *       test bootstrap file.
+ *     - Or declare a `WP_TESTS_PHPUNIT_POLYFILLS_PATH` constant containing the absolute path to the
+ *       root directory of the PHPUnit Polyfills installation.
+ *       If the constant is used, it is strongly recommended to declare this constant in the plugin/theme's
+ *       own test bootstrap file.
+ *       The constant MUST be declared prior to calling this file.
  */
 if ( ! class_exists( 'Yoast\PHPUnitPolyfills\Autoload' ) ) {
 	// Default location of the autoloader for WP core test runs.
-	$phpunit_polyfills_autoloader = __DIR__ . '/../../../vendor/yoast/phpunit-polyfills/phpunitpolyfills-autoload.php';
+	$phpunit_polyfills_autoloader = dirname( dirname( dirname( __DIR__ ) ) ) . '/vendor/yoast/phpunit-polyfills/phpunitpolyfills-autoload.php';
 	$phpunit_polyfills_error      = false;
 
 	// Allow for a custom installation location to be provided for plugin/theme integration tests.
@@ -92,12 +95,7 @@ if ( ! class_exists( 'Yoast\PHPUnitPolyfills\Autoload' ) ) {
 				$phpunit_polyfills_path = $phpunit_polyfills_path . '/phpunitpolyfills-autoload.php';
 			}
 
-			$phpunit_polyfills_path = realpath( $phpunit_polyfills_path );
-			if ( false !== $phpunit_polyfills_path ) {
-				$phpunit_polyfills_autoloader = $phpunit_polyfills_path;
-			} else {
-				$phpunit_polyfills_error = true;
-			}
+			$phpunit_polyfills_autoloader = $phpunit_polyfills_path;
 		} else {
 			$phpunit_polyfills_error = true;
 		}
@@ -111,6 +109,8 @@ if ( ! class_exists( 'Yoast\PHPUnitPolyfills\Autoload' ) ) {
 				WP_TESTS_PHPUNIT_POLYFILLS_PATH
 			);
 			echo 'Please verify that the file path provided in the WP_TESTS_PHPUNIT_POLYFILLS_PATH constant is correct.' . PHP_EOL;
+			echo 'The WP_TESTS_PHPUNIT_POLYFILLS_PATH constant should contain an absolute path to the root directory'
+				. ' of the PHPUnit Polyfills library.' . PHP_EOL;
 		} elseif ( defined( 'WP_RUN_CORE_TESTS' ) && WP_RUN_CORE_TESTS ) {
 			echo 'You need to run `composer update` before running the tests.' . PHP_EOL;
 			echo 'Once the dependencies are installed, you can run the tests using the Composer-installed version'
@@ -120,7 +120,7 @@ if ( ! class_exists( 'Yoast\PHPUnitPolyfills\Autoload' ) ) {
 			echo 'If you are trying to run plugin/theme integration tests, make sure the PHPUnit Polyfills library'
 				. ' (https://github.com/Yoast/PHPUnit-Polyfills) is available and either load the autoload file'
 				. ' of this library in your own test bootstrap before calling the WP Core test bootstrap file;'
-				. ' or set the path to the PHPUnit Polyfills library in a "WP_TESTS_PHPUNIT_POLYFILLS_PATH"'
+				. ' or set the absolute path to the PHPUnit Polyfills library in a "WP_TESTS_PHPUNIT_POLYFILLS_PATH"'
 				. ' constant to allow the WP Core bootstrap to load the Polyfills.' . PHP_EOL . PHP_EOL;
 			echo 'If you are trying to run the WP Core tests, make sure to set the "WP_RUN_CORE_TESTS" constant'
 				. ' to 1 and run `composer update` before running the tests.' . PHP_EOL;

--- a/tests/phpunit/includes/bootstrap.php
+++ b/tests/phpunit/includes/bootstrap.php
@@ -113,11 +113,20 @@ if ( ! class_exists( 'Yoast\PHPUnitPolyfills\Autoload' ) ) {
 			echo 'Please verify that the file path provided in the WP_TESTS_PHPUNIT_POLYFILLS_PATH constant is correct.' . PHP_EOL;
 		} elseif ( defined( 'WP_RUN_CORE_TESTS' ) && WP_RUN_CORE_TESTS ) {
 			echo 'You need to run `composer update` before running the tests.' . PHP_EOL;
-			echo 'Once the dependencies are installed, you can run the tests using the Composer-installed version of PHPUnit or using a PHPUnit phar file, but the dependencies do need to be installed whichever way the tests are run.' . PHP_EOL;
+			echo 'Once the dependencies are installed, you can run the tests using the Composer-installed version'
+				. ' of PHPUnit or using a PHPUnit phar file, but the dependencies do need to be installed'
+				. ' whichever way the tests are run.' . PHP_EOL;
 		} else {
-			echo 'If you are trying to run plugin/theme integration tests, make sure the PHPUnit Polyfills library is available and either load the autoload file of this library in your own test bootstrap before calling the WP Core test bootstrap file; or set the path to the PHPUnit Polyfills library in a "WP_TESTS_PHPUNIT_POLYFILLS_PATH" constant to allow the WP Core bootstrap to load the Polyfills.' . PHP_EOL . PHP_EOL;
-			echo 'If you are trying to run the WP Core tests, make sure to set the "WP_RUN_CORE_TESTS" constant to 1 and run `composer update` before running the tests.' . PHP_EOL;
-			echo 'Once the dependencies are installed, you can run the tests using the Composer-installed version of PHPUnit or using a PHPUnit phar file, but the dependencies do need to be installed whichever way the tests are run.' . PHP_EOL;
+			echo 'If you are trying to run plugin/theme integration tests, make sure the PHPUnit Polyfills library'
+				. ' (https://github.com/Yoast/PHPUnit-Polyfills) is available and either load the autoload file'
+				. ' of this library in your own test bootstrap before calling the WP Core test bootstrap file;'
+				. ' or set the path to the PHPUnit Polyfills library in a "WP_TESTS_PHPUNIT_POLYFILLS_PATH"'
+				. ' constant to allow the WP Core bootstrap to load the Polyfills.' . PHP_EOL . PHP_EOL;
+			echo 'If you are trying to run the WP Core tests, make sure to set the "WP_RUN_CORE_TESTS" constant'
+				. ' to 1 and run `composer update` before running the tests.' . PHP_EOL;
+			echo 'Once the dependencies are installed, you can run the tests using the Composer-installed'
+				. ' version of PHPUnit or using a PHPUnit phar file, but the dependencies do need to be'
+				. ' installed whichever way the tests are run.' . PHP_EOL;
 		}
 		exit( 1 );
 	}
@@ -136,13 +145,14 @@ if ( class_exists( '\Yoast\PHPUnitPolyfills\Autoload' )
 	|| version_compare( Yoast\PHPUnitPolyfills\Autoload::VERSION, $phpunit_polyfills_minimum_version, '<' ) )
 ) {
 	printf(
-		'Error: Version mismatch detected for the PHPUnit Polyfills. Please ensure that PHPUnit Polyfills %s or higher is loaded. Found version: %s' . PHP_EOL,
+		'Error: Version mismatch detected for the PHPUnit Polyfills.'
+		. ' Please ensure that PHPUnit Polyfills %s or higher is loaded. Found version: %s' . PHP_EOL,
 		$phpunit_polyfills_minimum_version,
 		defined( '\Yoast\PHPUnitPolyfills\Autoload::VERSION' ) ? Yoast\PHPUnitPolyfills\Autoload::VERSION : '1.0.0 or lower'
 	);
 	if ( defined( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' ) ) {
 		printf(
-			'Please ensure that the PHPUnit Polyfill install in "%s" is updated to version %s or higher.' . PHP_EOL,
+			'Please ensure that the PHPUnit Polyfill installation in "%s" is updated to version %s or higher.' . PHP_EOL,
 			WP_TESTS_PHPUNIT_POLYFILLS_PATH,
 			$phpunit_polyfills_minimum_version
 		);


### PR DESCRIPTION
@schlessera gave me some really good further feedback on the messages shown when running the WP Core test bootstrap file in a plugin/theme integration test situation, most notably about when the plugin/theme test suite has not been adjusted yet for the changes in WP 5.9.

This PR attempts to address these comments.

There is one comment @schlessera made which I haven't addressed, which is to do with the use of `composer update` in the messages versus `composer install`.

Alain correctly stated that running `composer install` when there is no `composer.lock` file in place, is effectively the same as running `composer update` and will prevent accidental updates to other dependencies.

To address this, I have made sure that the `composer update` messages are now only shown in a WP Core test run context.

I have, however, **not** changed the message from `composer update` to `composer install` as WP Core, as of recently, no longer has a `composer.lock` file and if a user running the core tests has already previously run `composer install`, they will have a local-only `composer.lock` file in place.
In that situation running `composer install` will not update the dependency, it will verify the existing installation against the `lock` file and if necessary, (re-)install the dependencies as per the `composer.lock` file. It will also show a message that the `lock` file is out of date, but a next test run would in still be blocked by the outdated dependency.

@schlessera I can't tag you as a reviewer, but would appreciate it if you would look this PR over as well.


## Commit details

### Tests/bootstrap: make constant setting more flexible

The constant `WP_TESTS_PHPUNIT_POLYFILLS_PATH` is intended to contain the path to the root directory of the PHPUnit Polyfills library without trailing slash.

The code already took into account that the value could potentially include a trailing slash.
Now it will also take into account if it is accidentally set to point to the autoload file instead of the path.

### Tests/bootstrap: improve messaging when polyfills can not be found

Previously, two situations were taken in to account:
1. The `WP_TESTS_PHPUNIT_POLYFILLS_PATH` constant is defined => show message specific to that constant not being set correctly.
    This message would typically be shown for plugin/theme integration tests which are already aware of the changes in WP 5.9.
2. The constant is not defined => show a message to run `composer update`.
    This message is intended for people trying to run the WP Core tests.

This left two situations unaccounted for:
* Someone trying to run the WP Core tests, but not having set the `WP_RUN_CORE_TESTS` constant or not having set it to `1`.
* Someone trying to run plugin/theme integration tests without the new `WP_TESTS_PHPUNIT_POLYFILLS_PATH` constant being defined as they are not (yet) aware of the changes made in WP 5.9.

The changes made in this commit, are intended to improve the error messages displayed in those situations.

### Tests/bootstrap: improve messaging when polyfills do not comply with version requirements

Previously, two situations were taken into account:
1. The `WP_TESTS_PHPUNIT_POLYFILLS_PATH` constant is defined => just show a message about the version mismatch.
2. The constant is not defined => show a message to run `composer update`.
    This message is intended for people trying to run the WP Core tests.

This could lead to an unclear situation for people trying to run plugin/theme integration tests without the new `WP_TESTS_PHPUNIT_POLYFILLS_PATH` constant being defined.

They could be shown the message to run `composer update` while if they would do so for their local install without adding the Polyfills, the message would still display the next time they would attempt to run the tests.

This commit:
1. Provides more information about the PHPUnit Polyfills version detected vs the version expected.
2. Shows a more specific message to guide users which have the `WP_TESTS_PHPUNIT_POLYFILLS_PATH` constant declared.
3. Only shows the message to run `composer update` when the `WP_RUN_CORE_TESTS` constant is declared to prevent confusing people more.



Trac ticket: https://core.trac.wordpress.org/ticket/46149

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
