### PR TITLE
WP 5.2 - 5.8: backport select changes to the test suite 

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -30,7 +30,6 @@ concurrency:
 
 env:
   PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: ${{ true }}
-  COMPOSER_INSTALL: ${{ false }}
   # Controls which NPM script to use for running PHPUnit tests. Options ar `php` and `php-composer`.
   PHPUNIT_SCRIPT: php
   LOCAL_PHP_MEMCACHED: ${{ false }}
@@ -133,11 +132,9 @@ jobs:
 
       - name: Get composer cache directory
         id: composer-cache
-        if: ${{ env.COMPOSER_INSTALL == true || env.LOCAL_PHP == '8.0-fpm' }}
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
       - name: Cache Composer dependencies
-        if: ${{ env.COMPOSER_INSTALL == true || env.LOCAL_PHP == '8.0-fpm' }}
         uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6 # v2.1.4
         env:
           cache-name: cache-composer-dependencies
@@ -146,7 +143,6 @@ jobs:
           key: ${{ runner.os }}-php-${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}
 
       - name: Install Composer dependencies
-        if: ${{ env.COMPOSER_INSTALL == true || env.LOCAL_PHP == '8.0-fpm' }}
         run: |
           docker-compose run --rm php composer --version
 
@@ -156,6 +152,12 @@ jobs:
           if [ ${{ env.LOCAL_PHP }} == '8.0-fpm' ]; then
             docker-compose run --rm php composer install --ignore-platform-reqs
             echo "PHPUNIT_SCRIPT=php-composer" >> $GITHUB_ENV
+          elif [ ${{ env.LOCAL_PHP }} == '7.1-fpm' ]; then
+            docker-compose run --rm php composer update
+            git checkout -- composer.lock
+          elif [[ ${{ env.LOCAL_PHP }} == '5.6.20-fpm' || ${{ env.LOCAL_PHP }} == '7.0-fpm' ]]; then
+            docker-compose run --rm php composer require --dev phpunit/phpunit:"^5.7" --update-with-dependencies
+            git checkout -- composer.lock composer.json
           else
             docker-compose run --rm php composer install
           fi

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -18,7 +18,6 @@ on:
 
 env:
   PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: ${{ true }}
-  COMPOSER_INSTALL: ${{ false }}
   # Controls which NPM script to use for running PHPUnit tests. Options ar `php` and `php-composer`.
   PHPUNIT_SCRIPT: php
   LOCAL_PHP: '7.4-fpm'
@@ -96,6 +95,23 @@ jobs:
 
       - name: Install Dependencies
         run: npm ci
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6 # v2.1.4
+        env:
+          cache-name: cache-composer-dependencies
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-php-${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}
+
+      - name: Install Composer dependencies
+        run: |
+          docker-compose run --rm php composer --version
+          docker-compose run --rm php composer install
 
       - name: Docker debug information
         run: |

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7.0",
 		"wp-coding-standards/wpcs": "~2.3.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1.0",
-		"phpunit/phpunit": "^7.5"
+		"phpunit/phpunit": "^7.5",
+		"yoast/phpunit-polyfills": "^1.0.1"
 	},
 	"autoload-dev": {
 		"files": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "463db2b4afb439fb63d93173c0852e27",
+    "content-hash": "d8bcbf1466f6595287a44721f525844d",
     "packages": [],
     "packages-dev": [
         {
@@ -1827,6 +1827,69 @@
                 "wordpress"
             ],
             "time": "2020-05-13T23:57:56+00:00"
+        },
+        {
+            "name": "yoast/phpunit-polyfills",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
+                "reference": "f014fb21c2b0038fd329515d59025af42fb98715"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/f014fb21c2b0038fd329515d59025af42fb98715",
+                "reference": "f014fb21c2b0038fd329515d59025af42fb98715",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^0.5",
+                "php-parallel-lint/php-parallel-lint": "^1.3.0",
+                "yoast/yoastcs": "^2.1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "phpunitpolyfills-autoload.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Yoast/PHPUnit-Polyfills/graphs/contributors"
+                }
+            ],
+            "description": "Set of polyfills for changed PHPUnit functionality to allow for creating PHPUnit cross-version compatible tests",
+            "homepage": "https://github.com/Yoast/PHPUnit-Polyfills",
+            "keywords": [
+                "phpunit",
+                "polyfill",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
+                "source": "https://github.com/Yoast/PHPUnit-Polyfills"
+            },
+            "time": "2021-08-09T16:28:08+00:00"
         }
     ],
     "aliases": [],
@@ -1838,5 +1901,5 @@
         "php": ">=5.6"
     },
     "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/tests/phpunit/includes/bootstrap.php
+++ b/tests/phpunit/includes/bootstrap.php
@@ -44,9 +44,9 @@ if ( defined( 'WP_RUN_CORE_TESTS' ) && WP_RUN_CORE_TESTS && ! is_dir( ABSPATH ) 
 
 $phpunit_version = tests_get_phpunit_version();
 
-if ( version_compare( $phpunit_version, '5.4', '<' ) || version_compare( $phpunit_version, '8.0', '>=' ) ) {
+if ( version_compare( $phpunit_version, '5.7.21', '<' ) || version_compare( $phpunit_version, '8.0', '>=' ) ) {
 	printf(
-		"Error: Looks like you're using PHPUnit %s. WordPress requires at least PHPUnit 5.4 and is currently only compatible with PHPUnit up to 7.x.\n",
+		"Error: Looks like you're using PHPUnit %s. WordPress requires at least PHPUnit 5.7.21 and is currently only compatible with PHPUnit up to 7.x.\n",
 		$phpunit_version
 	);
 	echo "Please use the latest PHPUnit version from the 7.x branch.\n";

--- a/tests/phpunit/includes/bootstrap.php
+++ b/tests/phpunit/includes/bootstrap.php
@@ -53,6 +53,113 @@ if ( version_compare( $phpunit_version, '5.7.21', '<' ) || version_compare( $php
 	exit( 1 );
 }
 
+/*
+ * Load the PHPUnit Polyfills autoloader.
+ *
+ * The PHPUnit Polyfills are a requirement for the WP test suite.
+ *
+ * For running the Core tests, the Make WordPress Core handbook contains step-by-step instructions
+ * on how to get up and running for a variety of supported workflows:
+ * {@link https://make.wordpress.org/core/handbook/testing/automated-testing/phpunit/#test-running-workflow-options}
+ *
+ * Plugin/theme integration tests can handle this in any of the following ways:
+ * - When using a full WP install: run `composer install` for the WP install prior to running the tests.
+ * - When using a partial WP test suite install:
+ *   - Add a `yoast/phpunit-polyfills` (dev) requirement to the plugin/theme's own `composer.json` file.
+ *   - And then:
+ *     - Either load the PHPUnit Polyfills autoload file prior to running the WP core bootstrap file.
+ *     - Or declare a `WP_TESTS_PHPUNIT_POLYFILLS_PATH` constant containing the absolute path to the
+ *       root directory of the PHPUnit Polyfills installation.
+ *       If the constant is used, it is strongly recommended to declare this constant in the plugin/theme's
+ *       own test bootstrap file.
+ *       The constant MUST be declared prior to calling this file.
+ */
+if ( ! class_exists( 'Yoast\PHPUnitPolyfills\Autoload' ) ) {
+	// Default location of the autoloader for WP core test runs.
+	$phpunit_polyfills_autoloader = dirname( dirname( dirname( __DIR__ ) ) ) . '/vendor/yoast/phpunit-polyfills/phpunitpolyfills-autoload.php';
+	$phpunit_polyfills_error      = false;
+
+	// Allow for a custom installation location to be provided for plugin/theme integration tests.
+	if ( defined( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' ) ) {
+		$phpunit_polyfills_path = WP_TESTS_PHPUNIT_POLYFILLS_PATH;
+
+		if ( is_string( WP_TESTS_PHPUNIT_POLYFILLS_PATH )
+			&& '' !== WP_TESTS_PHPUNIT_POLYFILLS_PATH
+		) {
+			// Be tolerant to the path being provided including the filename.
+			if ( substr( $phpunit_polyfills_path, -29 ) !== 'phpunitpolyfills-autoload.php' ) {
+				$phpunit_polyfills_path = rtrim( $phpunit_polyfills_path, '/\\' );
+				$phpunit_polyfills_path = $phpunit_polyfills_path . '/phpunitpolyfills-autoload.php';
+			}
+
+			$phpunit_polyfills_autoloader = $phpunit_polyfills_path;
+		} else {
+			$phpunit_polyfills_error = true;
+		}
+	}
+
+	if ( $phpunit_polyfills_error || ! file_exists( $phpunit_polyfills_autoloader ) ) {
+		echo 'Error: The PHPUnit Polyfills library is a requirement for running the WP test suite.' . PHP_EOL;
+		if ( defined( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' ) ) {
+			printf(
+				'The PHPUnit Polyfills autoload file was not found in "%s"' . PHP_EOL,
+				WP_TESTS_PHPUNIT_POLYFILLS_PATH
+			);
+			echo 'Please verify that the file path provided in the WP_TESTS_PHPUNIT_POLYFILLS_PATH constant is correct.' . PHP_EOL;
+			echo 'The WP_TESTS_PHPUNIT_POLYFILLS_PATH constant should contain an absolute path to the root directory'
+				. ' of the PHPUnit Polyfills library.' . PHP_EOL;
+		} elseif ( defined( 'WP_RUN_CORE_TESTS' ) && WP_RUN_CORE_TESTS ) {
+			echo 'You need to run `composer install` before running the tests.' . PHP_EOL;
+			echo 'Once the dependencies are installed, you can run the tests using the Composer-installed version'
+				. ' of PHPUnit or using a PHPUnit phar file, but the dependencies do need to be installed'
+				. ' whichever way the tests are run.' . PHP_EOL;
+		} else {
+			echo 'If you are trying to run plugin/theme integration tests, make sure the PHPUnit Polyfills library'
+				. ' (https://github.com/Yoast/PHPUnit-Polyfills) is available and either load the autoload file'
+				. ' of this library in your own test bootstrap before calling the WP Core test bootstrap file;'
+				. ' or set the absolute path to the PHPUnit Polyfills library in a "WP_TESTS_PHPUNIT_POLYFILLS_PATH"'
+				. ' constant to allow the WP Core bootstrap to load the Polyfills.' . PHP_EOL . PHP_EOL;
+			echo 'If you are trying to run the WP Core tests, make sure to set the "WP_RUN_CORE_TESTS" constant'
+				. ' to 1 and run `composer install` before running the tests.' . PHP_EOL;
+			echo 'Once the dependencies are installed, you can run the tests using the Composer-installed'
+				. ' version of PHPUnit or using a PHPUnit phar file, but the dependencies do need to be'
+				. ' installed whichever way the tests are run.' . PHP_EOL;
+		}
+		exit( 1 );
+	}
+
+	require_once $phpunit_polyfills_autoloader;
+}
+unset( $phpunit_polyfills_autoloader, $phpunit_polyfills_error, $phpunit_polyfills_path );
+
+/*
+ * Minimum version of the PHPUnit Polyfills package as declared in `composer.json`.
+ * Only needs updating when new polyfill features start being used in the test suite.
+ */
+$phpunit_polyfills_minimum_version = '1.0.1';
+if ( class_exists( '\Yoast\PHPUnitPolyfills\Autoload' )
+	&& ( defined( '\Yoast\PHPUnitPolyfills\Autoload::VERSION' ) === false
+	|| version_compare( Yoast\PHPUnitPolyfills\Autoload::VERSION, $phpunit_polyfills_minimum_version, '<' ) )
+) {
+	printf(
+		'Error: Version mismatch detected for the PHPUnit Polyfills.'
+		. ' Please ensure that PHPUnit Polyfills %s or higher is loaded. Found version: %s' . PHP_EOL,
+		$phpunit_polyfills_minimum_version,
+		defined( '\Yoast\PHPUnitPolyfills\Autoload::VERSION' ) ? Yoast\PHPUnitPolyfills\Autoload::VERSION : '1.0.0 or lower'
+	);
+	if ( defined( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' ) ) {
+		printf(
+			'Please ensure that the PHPUnit Polyfill installation in "%s" is updated to version %s or higher.' . PHP_EOL,
+			WP_TESTS_PHPUNIT_POLYFILLS_PATH,
+			$phpunit_polyfills_minimum_version
+		);
+	} elseif ( defined( 'WP_RUN_CORE_TESTS' ) && WP_RUN_CORE_TESTS ) {
+		echo 'Please run `composer install` to install the latest version.' . PHP_EOL;
+	}
+	exit( 1 );
+}
+unset( $phpunit_polyfills_minimum_version );
+
 // If running core tests, check if all the required PHP extensions are loaded before running the test suite.
 if ( defined( 'WP_RUN_CORE_TESTS' ) && WP_RUN_CORE_TESTS ) {
 	$required_extensions = array(

--- a/tests/phpunit/includes/phpunit7/testcase.php
+++ b/tests/phpunit/includes/phpunit7/testcase.php
@@ -44,4 +44,32 @@ class WP_UnitTestCase extends WP_UnitTestCase_Base {
 	use ExpectExceptionMessageMatches;
 	use ExpectExceptionObject;
 	use ExpectPHPException;
+
+	/**
+	 * Wrapper method for the `setUpBeforeClass()` method for forward-compatibility with WP 5.9.
+	 */
+	public static function set_up_before_class() {
+		static::setUpBeforeClass();
+	}
+
+	/**
+	 * Wrapper method for the `tearDownAfterClass()` method for forward-compatibility with WP 5.9.
+	 */
+	public static function tear_down_after_class() {
+		static::tearDownAfterClass();
+	}
+
+	/**
+	 * Wrapper method for the `setUp()` method for forward-compatibility with WP 5.9.
+	 */
+	public function set_up() {
+		static::setUp();
+	}
+
+	/**
+	 * Wrapper method for the `tearDown()` method for forward-compatibility with WP 5.9.
+	 */
+	public function tear_down() {
+		static::tearDown();
+	}
 }

--- a/tests/phpunit/includes/phpunit7/testcase.php
+++ b/tests/phpunit/includes/phpunit7/testcase.php
@@ -1,5 +1,21 @@
 <?php
 
+use Yoast\PHPUnitPolyfills\Helpers\AssertAttributeHelper;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertEqualsSpecializations;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertFileDirectory;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertFileEqualsSpecializations;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertionRenames;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertIsType;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertNumericType;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertObjectEquals;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertStringContains;
+use Yoast\PHPUnitPolyfills\Polyfills\EqualToSpecializations;
+use Yoast\PHPUnitPolyfills\Polyfills\ExpectException;
+use Yoast\PHPUnitPolyfills\Polyfills\ExpectExceptionMessageMatches;
+use Yoast\PHPUnitPolyfills\Polyfills\ExpectExceptionObject;
+use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
+
 require_once dirname( __DIR__ ) . '/abstract-testcase.php';
 
 /**
@@ -11,4 +27,21 @@ require_once dirname( __DIR__ ) . '/abstract-testcase.php';
  *
  * All WordPress unit tests should inherit from this class.
  */
-class WP_UnitTestCase extends WP_UnitTestCase_Base {}
+class WP_UnitTestCase extends WP_UnitTestCase_Base {
+
+	use AssertAttributeHelper;
+	use AssertClosedResource;
+	use AssertEqualsSpecializations;
+	use AssertFileDirectory;
+	use AssertFileEqualsSpecializations;
+	use AssertionRenames;
+	use AssertIsType;
+	use AssertNumericType;
+	use AssertObjectEquals;
+	use AssertStringContains;
+	use EqualToSpecializations;
+	use ExpectException;
+	use ExpectExceptionMessageMatches;
+	use ExpectExceptionObject;
+	use ExpectPHPException;
+}

--- a/tests/phpunit/includes/testcase.php
+++ b/tests/phpunit/includes/testcase.php
@@ -44,4 +44,32 @@ class WP_UnitTestCase extends WP_UnitTestCase_Base {
 	use ExpectExceptionMessageMatches;
 	use ExpectExceptionObject;
 	use ExpectPHPException;
+
+	/**
+	 * Wrapper method for the `setUpBeforeClass()` method for forward-compatibility with WP 5.9.
+	 */
+	public static function set_up_before_class() {
+		static::setUpBeforeClass();
+	}
+
+	/**
+	 * Wrapper method for the `tearDownAfterClass()` method for forward-compatibility with WP 5.9.
+	 */
+	public static function tear_down_after_class() {
+		static::tearDownAfterClass();
+	}
+
+	/**
+	 * Wrapper method for the `setUp()` method for forward-compatibility with WP 5.9.
+	 */
+	public function set_up() {
+		static::setUp();
+	}
+
+	/**
+	 * Wrapper method for the `tearDown()` method for forward-compatibility with WP 5.9.
+	 */
+	public function tear_down() {
+		static::tearDown();
+	}
 }

--- a/tests/phpunit/includes/testcase.php
+++ b/tests/phpunit/includes/testcase.php
@@ -1,5 +1,21 @@
 <?php
 
+use Yoast\PHPUnitPolyfills\Helpers\AssertAttributeHelper;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertEqualsSpecializations;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertFileDirectory;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertFileEqualsSpecializations;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertionRenames;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertIsType;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertNumericType;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertObjectEquals;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertStringContains;
+use Yoast\PHPUnitPolyfills\Polyfills\EqualToSpecializations;
+use Yoast\PHPUnitPolyfills\Polyfills\ExpectException;
+use Yoast\PHPUnitPolyfills\Polyfills\ExpectExceptionMessageMatches;
+use Yoast\PHPUnitPolyfills\Polyfills\ExpectExceptionObject;
+use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
+
 require_once __DIR__ . '/abstract-testcase.php';
 
 /**
@@ -13,23 +29,19 @@ require_once __DIR__ . '/abstract-testcase.php';
  */
 class WP_UnitTestCase extends WP_UnitTestCase_Base {
 
-	/**
-	 * Asserts that two variables are equal (with delta).
-	 *
-	 * This method has been backported from a more recent PHPUnit version,
-	 * as tests running on PHP 5.6 use PHPUnit 5.7.x.
-	 *
-	 * @since 5.6.0
-	 *
-	 * @param mixed  $expected First value to compare.
-	 * @param mixed  $actual   Second value to compare.
-	 * @param float  $delta    Allowed numerical distance between two values to consider them equal.
-	 * @param string $message  Optional. Message to display when the assertion fails.
-	 *
-	 * @throws ExpectationFailedException
-	 * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
-	 */
-	public static function assertEqualsWithDelta( $expected, $actual, $delta, $message = '' ) {
-		static::assertEquals( $expected, $actual, $message, $delta );
-	}
+	use AssertAttributeHelper;
+	use AssertClosedResource;
+	use AssertEqualsSpecializations;
+	use AssertFileDirectory;
+	use AssertFileEqualsSpecializations;
+	use AssertionRenames;
+	use AssertIsType;
+	use AssertNumericType;
+	use AssertObjectEquals;
+	use AssertStringContains;
+	use EqualToSpecializations;
+	use ExpectException;
+	use ExpectExceptionMessageMatches;
+	use ExpectExceptionObject;
+	use ExpectPHPException;
 }


### PR DESCRIPTION
Implementation of the backport proposal for WP 5.2 - 5.8 and lower.

## Commit Details

### Build/Test Tools: Add Composer dependency on the PHPUnit Polyfills package.

The PHPUnit Polyfills package is an add-on for PHPUnit, which works around common issues for writing PHPUnit cross-version compatible tests.

Features:
* It offers a full set of polyfills for assertions and expectations introduced in PHPUnit since PHPUnit 4.8.
* It offers two generic TestCases which include these polyfills, but also solve the `void` return type issue for the fixtures methods.
* It offers a PHPUnit cross-version solution for the changes to the PHPUnit `TestListener` implementation.
* Supports PHPUnit 4.8 – current.
* Supports and is compatible with PHP 5.4 – current.

The package has no outside dependencies, other than PHPUnit, is actively maintained and endorsed by the maintainer of PHPUnit itself (the only package of its kind which has ever been endorsed).

While use of the package will not be actively implemented in WP < 5.9, adding the dependency will allow for future backports of (security) tests to WP 5.2 - 5.8 to be executed without the need for adjusting the tests.

The minimum supported PHPUnit version, as checked in the test bootstrap file, has been adjusted to comply with the minimum version supported by the PHPUnit Polyfills.

### Build: always run composer install for the test workflows

As the PHPUnit Polyfills is now a requirement, the test workflows need to run some form of `composer install` to make them available.
The tests themselves can, and will, still be run via a PHPUnit PHAR file.

Note: The version juggling done to get Composer to install on all PHP versions, means that in select cases, the `composer.lock` file and sometimes even the `composer.json` file needs to be changed on the fly.
This would then fail then build on the "Ensure version-controlled files are not modified" step.
To mitigate this, a very select `git checkout -- file...` command is added right after the Composer install to reset those files to their committed state.
This way any _real_ changes to version controlled files will still be picked up on, but the build won't fail on these changes made specifically for the Composer install.

Second note: alternatively, a choice could be made to forego the `composer install` in favour of cloning the Polyfills repo in a `vendor/yoast/phpunit-polyfills` directory for CI.
That should also allow for the tests to be able to run and would prevent making changes to the `composer.json`/`composer.lock` files.

### Tests: make the polyfills available to all tests

... and add loading of the polyfills to the test bootstrap with the same messages as per PR 1587.

### Tests: introduce wrapper method for the PHPUnit fixture methods

The wrapper methods are intended to make it easier for plugin/theme integration tests to make their test suite compatible with the changes in WordPress 5.9, while still allowing the test suite to be run on WP < 5.2.

Plugin/theme integration test suites which still want to run their tests against WP < 5.2 will need to handle conditionally making the assertion and expectation polyfill traits available based on the WP version on which the tests are being run from within their own test suite, but with these wrapper methods in place, the fixture method rename will no longer be problematic.

Notes:
As these wrapper methods use `static::...`, these wrapper methods will automatically call the camelCase method name in the "highest" class in the hierarchy, effectively making the wrapper methods available to all test case classes.



Trac ticket: https://core.trac.wordpress.org/ticket/53911

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
