### PR TITLE
WP 5.1 and lower: backport select changes to the test suite 

### DIFF
--- a/tests/phpunit/includes/phpunit7/testcase.php
+++ b/tests/phpunit/includes/phpunit7/testcase.php
@@ -29,4 +29,32 @@ class WP_UnitTestCase extends WP_UnitTestCase_Base {
 	public static function assertNotFalse( $condition, string $message = '' ): void {
 		self::assertThat( $condition, self::logicalNot( self::isFalse() ), $message );
 	}
+
+	/**
+	 * Wrapper method for the `setUpBeforeClass()` method for forward-compatibility with WP 5.9.
+	 */
+	public static function set_up_before_class() {
+		static::setUpBeforeClass();
+	}
+
+	/**
+	 * Wrapper method for the `tearDownAfterClass()` method for forward-compatibility with WP 5.9.
+	 */
+	public static function tear_down_after_class() {
+		static::tearDownAfterClass();
+	}
+
+	/**
+	 * Wrapper method for the `setUp()` method for forward-compatibility with WP 5.9.
+	 */
+	public function set_up() {
+		static::setUp();
+	}
+
+	/**
+	 * Wrapper method for the `tearDown()` method for forward-compatibility with WP 5.9.
+	 */
+	public function tear_down() {
+		static::tearDown();
+	}
 }

--- a/tests/phpunit/includes/testcase.php
+++ b/tests/phpunit/includes/testcase.php
@@ -29,4 +29,32 @@ class WP_UnitTestCase extends WP_UnitTestCase_Base {
 	public static function assertNotFalse( $condition, $message = '' ) {
 		self::assertThat( $condition, self::logicalNot( self::isFalse() ), $message );
 	}
+
+	/**
+	 * Wrapper method for the `setUpBeforeClass()` method for forward-compatibility with WP 5.9.
+	 */
+	public static function set_up_before_class() {
+		static::setUpBeforeClass();
+	}
+
+	/**
+	 * Wrapper method for the `tearDownAfterClass()` method for forward-compatibility with WP 5.9.
+	 */
+	public static function tear_down_after_class() {
+		static::tearDownAfterClass();
+	}
+
+	/**
+	 * Wrapper method for the `setUp()` method for forward-compatibility with WP 5.9.
+	 */
+	public function set_up() {
+		static::setUp();
+	}
+
+	/**
+	 * Wrapper method for the `tearDown()` method for forward-compatibility with WP 5.9.
+	 */
+	public function tear_down() {
+		static::tearDown();
+	}
 }


### PR DESCRIPTION
Implementation of the backport proposal for WP 5.1 and lower.

## Commit Details

### Tests: introduce wrapper method for the PHPUnit fixture methods

The wrapper methods are intended to make it easier for plugin/theme integration tests to make their test suite compatible with the changes in WordPress 5.9, while still allowing the test suite to be run on WP < 5.2.

Plugin/theme integration test suites which still want to run their tests against WP < 5.2 will need to handle conditionally making the assertion and expectation polyfill traits available based on the WP version on which the tests are being run from within their own test suite, but with these wrapper methods in place, the fixture method rename will no longer be problematic.



Trac ticket: https://core.trac.wordpress.org/ticket/53911

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
