### PR TITLE
WP 5.8 Backport: Introduce function `wp_readonly()` (Trac 53858)

### DIFF
--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -4825,6 +4825,22 @@ function readonly( $readonly, $current = true, $echo = true ) {
 }
 
 /**
+ * Outputs the HTML readonly attribute.
+ *
+ * Compares the first two arguments and if identical marks as readonly
+ *
+ * @since 5.9.0 with backports in 5.8.x, 5.7.x, 5.6.x, 5.5.x
+ *
+ * @param mixed $readonly One of the values to compare
+ * @param mixed $current  (true) The other value to compare if not just true
+ * @param bool  $echo     Whether to echo or just return the string
+ * @return string HTML attribute or empty string
+ */
+function wp_readonly( $readonly, $current = true, $echo = true ) {
+	return __checked_selected_helper( $readonly, $current, $echo, 'readonly' );
+}
+
+/**
  * Private helper function for checked, selected, disabled and readonly.
  *
  * Compares the first two arguments and if identical marks as $type


### PR DESCRIPTION
Since PHP 8.1, `readonly` is a reserved keyword and cannot be used as a function name.

In order to avoid PHP parser errors, the `readonly()` function was extracted to a separate file and is now only included conditionally on PHP < 8.1 in WP 5.9.

To prevent plugins/themes using this function each having to polyfill it, the new `wp_readonly()` function is being backported.

Trac ticket: https://core.trac.wordpress.org/ticket/53858

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
