### PR TITLE
Add test and fix for block attribute serialization

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -488,13 +488,17 @@ function get_dynamic_block_names() {
  * substitution for characters which might otherwise interfere with embedding
  * the result in an HTML comment.
  *
+ * This function must produce output that remains in sync with the output of
+ * the serializeAttributes JavaScript function in Gutenberg in order to ensure
+ * consistent operation between PHP and JavaScript.
+ *
  * @since 5.3.1
  *
  * @param array $block_attributes Attributes object.
  * @return string Serialized attributes.
  */
 function serialize_block_attributes( $block_attributes ) {
-	$encoded_attributes = json_encode( $block_attributes );
+	$encoded_attributes = wp_json_encode( $block_attributes, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
 	$encoded_attributes = preg_replace( '/--/', '\\u002d\\u002d', $encoded_attributes );
 	$encoded_attributes = preg_replace( '/</', '\\u003c', $encoded_attributes );
 	$encoded_attributes = preg_replace( '/>/', '\\u003e', $encoded_attributes );

--- a/tests/phpunit/tests/blocks/serialize.php
+++ b/tests/phpunit/tests/blocks/serialize.php
@@ -47,6 +47,9 @@ class Tests_Blocks_Serialize extends WP_UnitTestCase {
 
 			// Block with attribute values that may conflict with HTML comment.
 			array( '<!-- wp:attributes {"key":"\\u002d\\u002d\\u003c\\u003e\\u0026\\u0022"} /-->' ),
+
+			// Block with attribute values that should not be escaped.
+			array( '<!-- wp:attributes {"key":"€1.00 / 3 for €2.00"} /-->' ),
 		);
 	}
 


### PR DESCRIPTION
The block attribute serialization function in PHP does not produce equivalent output to the JavaScript function in the Gutenberg codebase. Specifically, unicode characters and slashes are escaped in PHP whereas they are not in JavaScript. This update exposes the bug via a unit test and fixes it in the serialization function. Additionally, it replaces `json_encode` with `wp_json_encode`.

Trac ticket: https://core.trac.wordpress.org/ticket/53936

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
