### PR TITLE
Swap width/height when video is rotated 90/270deg.

### DIFF
--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -3597,6 +3597,12 @@ function wp_read_video_metadata( $file ) {
 		$metadata['height'] = (int) $data['video']['resolution_y'];
 	}
 
+	if ( isset( $metadata['width'], $metadata['height'] ) ) {
+		if ( ! empty( $data['video']['rotate'] ) && in_array( $data['video']['rotate'], array( 90, 270 ), true ) ) {
+			list( $metadata['width'], $metadata['height'] ) = array( $metadata['height'], $metadata['width'] );
+		}
+	}
+
 	if ( ! empty( $data['fileformat'] ) ) {
 		$metadata['fileformat'] = $data['fileformat'];
 	}


### PR DESCRIPTION
Check if the video has been rotated 90/270 degrees and if so, swap the `width` and `height` values.

Trac ticket: https://core.trac.wordpress.org/ticket/53944
