### PR TITLE
PHP 8.1: add input validation to the _set_cron_array() function (Trac 53635)

### DIFF
--- a/src/wp-includes/cron.php
+++ b/src/wp-includes/cron.php
@@ -1191,6 +1191,10 @@ function _get_cron_array() {
  * @return bool|WP_Error True if cron array updated. False or WP_Error on failure.
  */
 function _set_cron_array( $cron, $wp_error = false ) {
+	if ( ! is_array( $cron ) ) {
+		$cron = array();
+	}
+
 	$cron['version'] = 2;
 	$result          = update_option( 'cron', $cron );
 

--- a/tests/phpunit/tests/cron/setCronArray.php
+++ b/tests/phpunit/tests/cron/setCronArray.php
@@ -1,0 +1,175 @@
+<?php
+
+/**
+ * Test the `_set_cron_array()` function.
+ *
+ * @group cron
+ * @covers ::_set_cron_array
+ */
+class Tests_Cron_setCronArray extends WP_UnitTestCase {
+
+	public function set_up() {
+		parent::set_up();
+		// Make sure the schedule is clear.
+		_set_cron_array( array() );
+	}
+
+	public function tear_down() {
+		// Make sure the schedule is clear.
+		_set_cron_array( array() );
+		parent::tear_down();
+	}
+
+	/**
+	 * Tests the input validation for the `_set_cron_array()` function.
+	 *
+	 * Includes verifying that invalid input - typically `false` - does not result in a PHP
+	 * deprecation warning on PHP 8.1 or higher.
+	 *
+	 * The warning that we should not see:
+	 * `Deprecated: Automatic conversion of false to array is deprecated`.
+	 *
+	 * @ticket 53635
+	 *
+	 * @dataProvider data_set_cron_array_input_validation
+	 *
+	 * @param mixed $input    Cron "array".
+	 * @param array $expected Expected array entry count of the cron option after update.
+	 */
+	public function test_set_cron_array_input_validation( $input, $expected ) {
+		delete_option( 'cron' );
+		$this->assertTrue( _set_cron_array( $input ) );
+
+		$crons = get_option( 'cron' );
+		$this->assertIsArray( $crons, 'Cron option is not an array.' );
+		$this->assertArrayHasKey( 'version', $crons, 'Cron option does not have a "version" key.' );
+		$this->assertCount( $expected, $crons, 'Cron option does not contain the expected nr of entries.' );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_set_cron_array_input_validation() {
+		return array(
+			'null'        => array(
+				'input'    => null,
+				'expected' => 1,
+			),
+			// Function _get_cron_array() may return `false`, so this is the PHP 8.1 "problem" test.
+			'false'       => array(
+				'input'    => false,
+				'expected' => 1,
+			),
+			'empty array' => array(
+				'input'    => array(),
+				'expected' => 1,
+			),
+			'cron array'  => array(
+				'input'    => array(
+					'version' => 2,
+					time()    => array(
+						'hookname' => array(
+							'event key' => array(
+								'schedule' => 'schedule',
+								'args'     => 'args',
+								'interval' => 'interval',
+							),
+						),
+					),
+				),
+				'expected' => 2,
+			),
+		);
+	}
+
+	/**
+	 * Tests that `_set_cron_array()` returns `false` when the cron option was not updated.
+	 *
+	 * @dataProvider data_set_cron_array_returns_false_when_not_updated
+	 *
+	 * @param array $input    Cron array.
+	 * @param mixed $wp_error Value to use for $wp_error.
+	 */
+	public function test_set_cron_array_returns_false_when_not_updated( $input, $wp_error ) {
+		$this->assertFalse( _set_cron_array( $input ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_set_cron_array_returns_false_when_not_updated() {
+		return array(
+			'empty array' => array(
+				'input'    => array(),
+				'wp_error' => false,
+			),
+			'cron array'  => array(
+				'input'    => array(
+					'version' => 2,
+				),
+				'wp_error' => 0,
+			),
+		);
+	}
+
+	/**
+	 * Tests that `_set_cron_array()` returns a WP_Error object when the cron option was not updated and `$wp_error` is truthy.
+	 *
+	 * @dataProvider data_set_cron_array_returns_WP_Error_when_not_updated
+	 *
+	 * @param array $input    Cron array.
+	 * @param mixed $wp_error Value to use for $wp_error.
+	 */
+	public function test_set_cron_array_returns_WP_Error_when_not_updated( $input, $wp_error ) {
+		$result = _set_cron_array( $input, $wp_error );
+		$this->assertWPError( $result, 'Return value is not an instance of WP_Error.' );
+		$this->assertSame( 'could_not_set', $result->get_error_code(), 'WP_Error error code does not match expected code.' );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_set_cron_array_returns_WP_Error_when_not_updated() {
+		return array(
+			'empty array' => array(
+				'input'    => array(),
+				'wp_error' => true,
+			),
+			'cron array'  => array(
+				'input'    => array(
+					'version' => 2,
+				),
+				'wp_error' => 1,
+			),
+		);
+	}
+
+	/**
+	 * Tests that `_set_cron_array()` returns true when the cron option was updated and `$wp_error` is truthy.
+	 */
+	public function test_set_cron_array_does_not_return_WP_Error_when_updated() {
+		$result = _set_cron_array(
+			array(
+				'version' => 2,
+				time()    => array(
+					'hookname' => array(
+						'event key' => array(
+							'schedule' => 'schedule',
+							'args'     => 'args',
+							'interval' => 'interval',
+						),
+					),
+				),
+			),
+			true
+		);
+
+		$this->assertTrue( $result );
+	}
+}


### PR DESCRIPTION
### Tests: add dedicated test for _set_cron_array()

Add a full set of tests for the `_set_cron_array()` function.

### PHP 8.1: add input validation to the _set_cron_array() function

The `_set_cron_array()` function expects a cron array as the first parameter, but will often be passed the - potentially updated - output of a call to `_get_cron_array()`.

The `_get_cron_array()` function may, however, return `false`, in which case a "Deprecated: Automatic conversion of false to array is deprecated" warning will be thrown on PHP 8.1.

Fixed now by adding input validation to the `_set_cron_array()` function.

Ref: https://developer.wordpress.org/reference/functions/_get_cron_array/

Trac ticket: https://core.trac.wordpress.org/ticket/53635

/cc @pbearne I did see your test for `_set_cron_array()` in #1595, but I felt this function needed a more extensive set of tests, especially as it is prone to be hit by the PHP 8.1 deprecation notice. Please review when you have a chance.


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
