### PR TITLE
WP_Media_List_Table::prepare_items(): fix PHP warning (Trac 53949)

### DIFF
--- a/src/wp-admin/includes/class-wp-media-list-table.php
+++ b/src/wp-admin/includes/class-wp-media-list-table.php
@@ -77,13 +77,15 @@ class WP_Media_List_Table extends WP_List_Table {
 		 * See File_Upload_Upgrader class.
 		 */
 		$not_in = array();
+		$crons  = _get_cron_array();
+		if ( is_array( $crons ) ) {
+			foreach ( $crons as $cron ) {
+				if ( isset( $cron['upgrader_scheduled_cleanup'] ) ) {
+					$details = reset( $cron['upgrader_scheduled_cleanup'] );
 
-		foreach ( _get_cron_array() as $cron ) {
-			if ( isset( $cron['upgrader_scheduled_cleanup'] ) ) {
-				$details = reset( $cron['upgrader_scheduled_cleanup'] );
-
-				if ( ! empty( $details['args'][0] ) ) {
-					$not_in[] = (int) $details['args'][0];
+					if ( ! empty( $details['args'][0] ) ) {
+						$not_in[] = (int) $details['args'][0];
+					}
 				}
 			}
 		}

--- a/tests/phpunit/tests/admin/includesMediaListTable.php
+++ b/tests/phpunit/tests/admin/includesMediaListTable.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @group admin
+ */
+class Tests_Admin_includesMediaListTable extends WP_UnitTestCase {
+
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+		require_once ABSPATH . 'wp-admin/includes/class-wp-media-list-table.php';
+	}
+
+	/**
+	 * Tests that a call to WP_Media_List_Table::prepare_items() on a site without any scheduled events,
+	 * does not result in a PHP warning.
+	 *
+	 * Warning which we should not see:
+	 * PHP 5.6 - 7.4: `Invalid argument supplied for foreach()`.
+	 * PHP 8.0 and higher: `Warning: foreach() argument must be of type array|object, bool given`.
+	 *
+	 * Note: this doesn't test the actual functioning of the WP_Media_List_Table::prepare_items() method.
+	 * It just and only tests for/against the PHP warning.
+	 *
+	 * @ticket 53949
+	 *
+	 * @covers WP_Media_List_Table::prepare_items
+	 */
+	public function test_prepare_items_without_cron_option_does_not_throw_warning() {
+		global $wp_query;
+
+		// Note: setMethods() is deprecated in PHPUnit 9, but still supported.
+		$mock = $this->getMockBuilder( WP_Media_List_Table::class )
+			->disableOriginalConstructor()
+			->disallowMockingUnknownTypes()
+			->setMethods( array( 'set_pagination_args' ) )
+			->getMock();
+
+		$mock->expects( $this->once() )
+			->method( 'set_pagination_args' );
+
+		$wp_query->query_vars['posts_per_page'] = 10;
+		delete_option( 'cron' );
+
+		// Verify that the cause of the error is in place.
+		$this->assertFalse( _get_cron_array(), '_get_cron_array() does not return false' );
+
+		// If this test doesn't error out due to the PHP warning, we're good.
+		$mock->prepare_items();
+	}
+}


### PR DESCRIPTION
### Tests: add test for WP_Media_List_Table::prepare_items()

... to specifically test a particular PHP warning.

### WP_Media_List_Table::prepare_items(): fix PHP warning

The following warnings could, in very select circumstances, be shown:
```
// PHP 8.0 and higher:
Warning: foreach() argument must be of type array|object, bool given

// PHP 5.6 - 7.4
Warning: Invalid argument supplied for foreach()
```

In `WP_Media_List_Table::prepare_items()`, the cron info array is retrieved via a call to `_get_cron_array()`, but as the documentation for that function (correctly) states, the return type of that function is `array|false`, where `false` is returned for a virgin site, where no cron jobs have been scheduled yet.

However, no type check is done on the return value and the method just blindly continues by using the return value in a `foreach`.

Fixed by adding validation for the returned value from `_get_cron_array()` and only running the `foreach` when the returned value is an array.

Ref: https://developer.wordpress.org/reference/functions/_get_cron_array/



Trac ticket: https://core.trac.wordpress.org/ticket/53949

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
