### PR TITLE
Remove edge case `false` values from cron array.

### DIFF
--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -832,6 +832,10 @@ function upgrade_all() {
 		upgrade_560();
 	}
 
+	if ( $wp_current_db_version < 51645 ) {
+		upgrade_590();
+	}
+
 	maybe_disable_link_manager();
 
 	maybe_disable_automattic_widgets();
@@ -2245,6 +2249,23 @@ function upgrade_560() {
 			$network_id = get_main_network_id();
 			update_network_option( $network_id, WP_Application_Passwords::OPTION_KEY_IN_USE, 1 );
 		}
+	}
+}
+
+/**
+ * Executes changes made in WordPress 5.9.0.
+ *
+ * @ignore
+ * @since 5.9.0
+ */
+function upgrade_590() {
+	global $wp_current_db_version;
+
+	if ( $wp_current_db_version < 51645 ) {
+		$crons = _get_cron_array();
+		// Remove errant `false` values, see #53950.
+		$crons = array_filter( $crons );
+		_set_cron_array( $crons );
 	}
 }
 

--- a/src/wp-includes/version.php
+++ b/src/wp-includes/version.php
@@ -20,7 +20,7 @@ $wp_version = '5.9-alpha-51272-src';
  *
  * @global int $wp_db_version
  */
-$wp_db_version = 49752;
+$wp_db_version = 51645;
 
 /**
  * Holds the TinyMCE version.


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/53950

Follow up to PR #1598 to clean the cron array during the next version update.

As the cron array containing `false` is an edge case I decided cleaning it can wait until the next time sites need to run a DB upgrade rather than running it as part of the cron getter and changing the version it contains. 