### PR TITLE
Check comment is approved before allowing replies.

### DIFF
--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -2078,7 +2078,8 @@ function comment_form_title( $no_reply_text = false, $reply_text = false, $link_
 /**
  * Gets the comment's reply to ID from the $_GET['replytocom'].
  *
- * @since 5.9.0
+ * @since 6.2.0
+ *
  * @access private
  *
  * @param int|WP_Post $post_id Post ID or WP_Post object. Default current post.

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -1927,16 +1927,32 @@ function post_reply_link( $args = array(), $post = null ) {
  *
  * @since 2.7.0
  *
- * @param string $text Optional. Text to display for cancel reply link. If empty,
- *                     defaults to 'Click here to cancel reply'. Default empty.
+ * @param string $text    Optional. Text to display for cancel reply link. If empty,
+ *                        defaults to 'Click here to cancel reply'. Default empty.
+ * @param int    $post_id Optional. The post ID the comment thread is being
+ *                        displayed for. Default: current global post ID.
  * @return string
  */
-function get_cancel_comment_reply_link( $text = '' ) {
+function get_cancel_comment_reply_link( $text = '', $post_id = 0 ) {
 	if ( empty( $text ) ) {
 		$text = __( 'Click here to cancel reply.' );
 	}
 
-	$style = isset( $_GET['replytocom'] ) ? '' : ' style="display:none;"';
+	if ( empty( $post_id ) ) {
+		$post_id = get_the_ID();
+	}
+
+	$reply_to_id = isset( $_GET['replytocom'] ) ? (int) $_GET['replytocom'] : 0;
+
+	if ( 0 !== $reply_to_id ) {
+		$parent_comment = get_comment( $reply_to_id );
+
+		if ( ! $parent_comment || 0 === (int) $parent_comment->comment_approved || $post_id !== (int) $parent_comment->comment_post_ID ) {
+			$reply_to_id = 0;
+		}
+	}
+
+	$style = ! empty( $reply_to_id ) ? '' : ' style="display:none;"';
 	$link  = esc_html( remove_query_arg( array( 'replytocom', 'unapproved', 'moderation-hash' ) ) ) . '#respond';
 
 	$formatted_link = '<a rel="nofollow" id="cancel-comment-reply-link" href="' . $link . '"' . $style . '>' . $text . '</a>';

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -2000,6 +2000,7 @@ function get_comment_id_fields( $post_id = 0 ) {
 	if ( 0 !== $reply_to_id ) {
 		$comment = get_comment( $reply_to_id );
 
+		if ( ! $comment || 0 === (int) $comment->comment_approved || $post_id !== (int) $comment->comment_post_ID ) {
 			$reply_to_id = 0;
 		}
 	}
@@ -2077,7 +2078,7 @@ function comment_form_title( $no_reply_text = false, $reply_text = false, $link_
 		// Sets the global so that template tags can be used in the comment form.
 		$comment = get_comment( $reply_to_id );
 
-		if ( 0 === (int) $comment->comment_approved ) {
+		if ( $comment && 0 === (int) $comment->comment_approved ) {
 			echo $no_reply_text;
 			return;
 		}

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -1926,11 +1926,12 @@ function post_reply_link( $args = array(), $post = null ) {
  * Retrieves HTML content for cancel comment reply link.
  *
  * @since 2.7.0
+ * @since 6.2.0 Added the `$post` parameter.
  *
- * @param string      $text Optional. Text to display for cancel reply link. If empty,
- *                          defaults to 'Click here to cancel reply'. Default empty.
- * @param int|WP_Post $post Optional. The post the comment thread is being
- *                          displayed for. Defaults to the current global post.
+ * @param string           $text Optional. Text to display for cancel reply link. If empty,
+ *                               defaults to 'Click here to cancel reply'. Default empty.
+ * @param int|WP_Post|null $post Optional. The post the comment thread is being
+ *                               displayed for. Defaults to the current global post.
  * @return string
  */
 function get_cancel_comment_reply_link( $text = '', $post = null ) {
@@ -1975,8 +1976,8 @@ function cancel_comment_reply_link( $text = '' ) {
  * @since 3.0.0
  * @since 6.2.0 Renamed `$post_id` to `$post` and added WP_Post support.
  *
- * @param int|WP_Post $post Optional. The post the comment is being displayed for.
- *                          Defaults to the current global post.
+ * @param int|WP_Post|null $post Optional. The post the comment is being displayed for.
+ *                               Defaults to the current global post.
  * @return string Hidden input HTML for replying to comments.
  */
 function get_comment_id_fields( $post = null ) {
@@ -2015,8 +2016,8 @@ function get_comment_id_fields( $post = null ) {
  *
  * @see get_comment_id_fields()
  *
- * @param int|WP_Post $post Optional. The post the comment is being displayed for.
- *                          Defaults to the current global post.
+ * @param int|WP_Post|null $post Optional. The post the comment is being displayed for.
+ *                               Defaults to the current global post.
  */
 function comment_id_fields( $post = null ) {
 	echo get_comment_id_fields( $post );
@@ -2033,21 +2034,17 @@ function comment_id_fields( $post = null ) {
  * @since 2.7.0
  * @since 6.2.0 Added the `$post` parameter.
  *
- * @global WP_Comment $comment Global comment object.
- *
- * @param string|false $no_reply_text  Optional. Text to display when not replying to a comment.
- *                                     Default false.
- * @param string|false $reply_text     Optional. Text to display when replying to a comment.
- *                                     Default false. Accepts "%s" for the author of the comment
- *                                     being replied to.
- * @param bool         $link_to_parent Optional. Boolean to control making the author's name a link
- *                                     to their comment. Default true.
- * @param int|WP_Post  $post           Optional. The post that the comment form is being displayed for.
- *                                     Defaults to the current global post.
+ * @param string|false      $no_reply_text  Optional. Text to display when not replying to a comment.
+ *                                          Default false.
+ * @param string|false      $reply_text     Optional. Text to display when replying to a comment.
+ *                                          Default false. Accepts "%s" for the author of the comment
+ *                                          being replied to.
+ * @param bool              $link_to_parent Optional. Boolean to control making the author's name a link
+ *                                          to their comment. Default true.
+ * @param int|WP_Post|null  $post           Optional. The post that the comment form is being displayed for.
+ *                                          Defaults to the current global post.
  */
 function comment_form_title( $no_reply_text = false, $reply_text = false, $link_to_parent = true, $post = null ) {
-	global $comment;
-
 	if ( false === $no_reply_text ) {
 		$no_reply_text = __( 'Leave a Reply' );
 	}

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -2035,6 +2035,7 @@ function comment_id_fields( $post = null ) {
  *           comment. See https://core.trac.wordpress.org/changeset/36512.
  *
  * @since 2.7.0
+ * @since 6.2.0 Added the `$post` parameter.
  *
  * @global WP_Comment $comment Global comment object.
  *
@@ -2045,10 +2046,10 @@ function comment_id_fields( $post = null ) {
  *                                     being replied to.
  * @param bool         $link_to_parent Optional. Boolean to control making the author's name a link
  *                                     to their comment. Default true.
- * @param int          $post_id        Optional. The post ID the comment form is being displayed for.
- *                                     Default 0.
+ * @param int|WP_Post  $post           Optional. The post that the comment form is being displayed for.
+ *                                     Defaults to the current global post.
  */
-function comment_form_title( $no_reply_text = false, $reply_text = false, $link_to_parent = true, $post_id = 0 ) {
+function comment_form_title( $no_reply_text = false, $reply_text = false, $link_to_parent = true, $post = null ) {
 	global $comment;
 
 	if ( false === $no_reply_text ) {
@@ -2060,12 +2061,13 @@ function comment_form_title( $no_reply_text = false, $reply_text = false, $link_
 		$reply_text = __( 'Leave a Reply to %s' );
 	}
 
-	if ( 0 === $post_id ) {
+	$post = get_post( $post );
+	if ( ! $post ) {
 		echo $no_reply_text;
 		return;
 	}
 
-	$reply_to_id = _get_comment_reply_id( $post_id );
+	$reply_to_id = _get_comment_reply_id( $post->ID );
 
 	if ( 0 === $reply_to_id ) {
 		echo $no_reply_text;

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -2056,7 +2056,8 @@ function comment_id_fields( $post_id = 0 ) {
  *                                     being replied to.
  * @param bool         $link_to_parent Optional. Boolean to control making the author's name a link
  *                                     to their comment. Default true.
- * @param int|WP_Post  $post_id        Optional. Post ID or WP_Post object. Default null.
+ * @param int          $post_id        Optional. The post ID the comment form is being displayed for.
+ *                                     Default 0.
  */
 function comment_form_title( $no_reply_text = false, $reply_text = false, $link_to_parent = true, $post_id = 0 ) {
 	global $comment;

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -2072,7 +2072,7 @@ function comment_form_title( $no_reply_text = false, $reply_text = false, $link_
 
 	$reply_to_id = isset( $_GET['replytocom'] ) ? (int) $_GET['replytocom'] : 0;
 
-	if ( ! $post_id || 0 == $reply_to_id ) {
+	if ( ! $post_id || 0 === $reply_to_id ) {
 		echo $no_reply_text;
 		return;
 	}

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -2090,18 +2090,19 @@ function comment_form_title( $no_reply_text = false, $reply_text = false, $link_
  *
  * @access private
  *
- * @param int|WP_Post $post_id Post ID or WP_Post object. Default current post.
+ * @param int|WP_Post $post The post the comment is being displayed for.
+ *                          Defaults to the current global post.
  * @return int Comment's reply to ID.
  */
-function _get_comment_reply_id( $post_id ) {
+function _get_comment_reply_id( $post ) {
 	if ( ! isset( $_GET['replytocom'] ) || ! is_numeric( $_GET['replytocom'] ) ) {
 		return 0;
 	}
 
 	$reply_to_id = (int) $_GET['replytocom'];
 
-	if ( $post_id instanceof WP_Post ) {
-		$post_id = $post_id->ID;
+	if ( $post instanceof WP_Post ) {
+		$post = $post->ID;
 	}
 
 	/*
@@ -2110,9 +2111,12 @@ function _get_comment_reply_id( $post_id ) {
 	 * `comment_post_ID` does not match the given post ID.
 	 */
 	$comment = get_comment( $reply_to_id );
-	if ( ! $comment instanceof WP_Comment ||
-		 0 === (int) $comment->comment_approved ||
-		 $post_id !== (int) $comment->comment_post_ID ) {
+
+	if (
+		! $comment instanceof WP_Comment ||
+		0 === (int) $comment->comment_approved ||
+		$post !== (int) $comment->comment_post_ID
+	) {
 		return 0;
 	}
 

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -1984,7 +1984,7 @@ function get_comment_id_fields( $post_id = 0 ) {
 	if ( 0 !== $reply_to_id ) {
 		$comment = get_comment( $reply_to_id );
 
-		if ( 0 !== (int) $comment->comment_approved ) {
+		if ( 0 !== (int) $comment->comment_approved && $post_id === (int) $comment->comment_post_ID ) {
 			$result .= "<input type='hidden' name='comment_parent' id='comment_parent' value='$reply_to_id' />\n";
 		}
 	}

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -2015,13 +2015,15 @@ function get_comment_id_fields( $post = null ) {
  * This tag must be within the `<form>` section of the `comments.php` template.
  *
  * @since 2.7.0
+ * @since 6.2.0 Renamed `$post_id` to `$post` and added WP_Post support.
  *
  * @see get_comment_id_fields()
  *
- * @param int $post_id Optional. Post ID. Defaults to the current post ID.
+ * @param int|WP_Post $post Optional. The post the comment is being displayed for.
+ *                          Defaults to the current global post.
  */
-function comment_id_fields( $post_id = 0 ) {
-	echo get_comment_id_fields( $post_id );
+function comment_id_fields( $post = null ) {
+	echo get_comment_id_fields( $post );
 }
 
 /**

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -1982,7 +1982,7 @@ function cancel_comment_reply_link( $text = '' ) {
  * @return string Hidden input HTML for replying to comments.
  */
 function get_comment_id_fields( $post_id = 0 ) {
-	if ( empty( $post_id ) ) {
+	if ( 0 === $post_id ) {
 		$post_id = get_the_ID();
 	}
 

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -1930,7 +1930,7 @@ function post_reply_link( $args = array(), $post = null ) {
  * @param string $text    Optional. Text to display for cancel reply link. If empty,
  *                        defaults to 'Click here to cancel reply'. Default empty.
  * @param int    $post_id Optional. The post ID the comment thread is being
- *                        displayed for. Default: current global post ID.
+ *                        displayed for. Default current global post ID.
  * @return string
  */
 function get_cancel_comment_reply_link( $text = '', $post_id = 0 ) {

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -1977,15 +1977,19 @@ function cancel_comment_reply_link( $text = '' ) {
  * Retrieves hidden input HTML for replying to comments.
  *
  * @since 3.0.0
+ * @since 6.2.0 Renamed `$post_id` to `$post` and added WP_Post support.
  *
- * @param int $post_id Optional. Post ID. Defaults to the current post ID.
+ * @param int|WP_Post $post Optional. The post the comment is being displayed for.
+ *                          Defaults to the current global post.
  * @return string Hidden input HTML for replying to comments.
  */
-function get_comment_id_fields( $post_id = 0 ) {
-	if ( 0 === $post_id ) {
-		$post_id = get_the_ID();
+function get_comment_id_fields( $post = null ) {
+	$post = get_post( $post );
+	if ( ! $post ) {
+		return '';
 	}
 
+	$post_id     = $post->ID;
 	$reply_to_id = _get_comment_reply_id( $post_id );
 	$result      = "<input type='hidden' name='comment_post_ID' value='$post_id' id='comment_post_ID' />\n";
 	$result     .= "<input type='hidden' name='comment_parent' id='comment_parent' value='$reply_to_id' />\n";

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -1930,7 +1930,7 @@ function post_reply_link( $args = array(), $post = null ) {
  * @param string $text    Optional. Text to display for cancel reply link. If empty,
  *                        defaults to 'Click here to cancel reply'. Default empty.
  * @param int    $post_id Optional. The post ID the comment thread is being
- *                        displayed for. Default current global post ID.
+ *                        displayed for. Default: current global post ID.
  * @return string
  */
 function get_cancel_comment_reply_link( $text = '', $post_id = 0 ) {

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -2056,7 +2056,7 @@ function comment_id_fields( $post_id = 0 ) {
  *                                     being replied to.
  * @param bool         $link_to_parent Optional. Boolean to control making the author's name a link
  *                                     to their comment. Default true.
- * @param int|WP_Post  $post_id        Post ID or WP_Post object. Default current post.
+ * @param int|WP_Post  $post_id        Optional. Post ID or WP_Post object. Default null.
  */
 function comment_form_title( $no_reply_text = false, $reply_text = false, $link_to_parent = true, $post_id = null ) {
 	global $comment;

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -1980,7 +1980,14 @@ function get_comment_id_fields( $post_id = 0 ) {
 
 	$reply_to_id = isset( $_GET['replytocom'] ) ? (int) $_GET['replytocom'] : 0;
 	$result      = "<input type='hidden' name='comment_post_ID' value='$post_id' id='comment_post_ID' />\n";
-	$result     .= "<input type='hidden' name='comment_parent' id='comment_parent' value='$reply_to_id' />\n";
+
+	if ( 0 !== $reply_to_id ) {
+		$comment = get_comment( $reply_to_id );
+
+		if ( 0 !== (int) $comment->comment_approved ) {
+			$result .= "<input type='hidden' name='comment_parent' id='comment_parent' value='$reply_to_id' />\n";
+		}
+	}
 
 	/**
 	 * Filters the returned comment ID fields.
@@ -2049,8 +2056,14 @@ function comment_form_title( $no_reply_text = false, $reply_text = false, $link_
 	if ( 0 == $reply_to_id ) {
 		echo $no_reply_text;
 	} else {
+
 		// Sets the global so that template tags can be used in the comment form.
 		$comment = get_comment( $reply_to_id );
+
+		if ( 0 === (int) $comment->comment_approved ) {
+			echo $no_reply_text;
+			return;
+		}
 
 		if ( $link_to_parent ) {
 			$author = '<a href="#comment-' . get_comment_ID() . '">' . get_comment_author( $comment ) . '</a>';

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -2058,7 +2058,7 @@ function comment_id_fields( $post_id = 0 ) {
  *                                     to their comment. Default true.
  * @param int|WP_Post  $post_id        Optional. Post ID or WP_Post object. Default null.
  */
-function comment_form_title( $no_reply_text = false, $reply_text = false, $link_to_parent = true, $post_id = null ) {
+function comment_form_title( $no_reply_text = false, $reply_text = false, $link_to_parent = true, $post_id = 0 ) {
 	global $comment;
 
 	if ( false === $no_reply_text ) {

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -2090,16 +2090,18 @@ function comment_form_title( $no_reply_text = false, $reply_text = false, $link_
  *                          Defaults to the current global post.
  * @return int Comment's reply to ID.
  */
-function _get_comment_reply_id( $post ) {
-	if ( ! isset( $_GET['replytocom'] ) || ! is_numeric( $_GET['replytocom'] ) ) {
+function _get_comment_reply_id( $post = null ) {
+```suggestion
+ *                          Defaults to the current global post.
+ * @return int Comment's reply to ID.
+ */
+function _get_comment_reply_id( $post = null ) {
+	$post = get_post( $post );
+	if ( ! $post || ! isset( $_GET['replytocom'] ) || ! is_numeric( $_GET['replytocom'] ) ) {
 		return 0;
 	}
 
 	$reply_to_id = (int) $_GET['replytocom'];
-
-	if ( $post instanceof WP_Post ) {
-		$post = $post->ID;
-	}
 
 	/*
 	 * Validate the comment.
@@ -2111,7 +2113,7 @@ function _get_comment_reply_id( $post ) {
 	if (
 		! $comment instanceof WP_Comment ||
 		0 === (int) $comment->comment_approved ||
-		$post !== (int) $comment->comment_post_ID
+		$post->ID !== (int) $comment->comment_post_ID
 	) {
 		return 0;
 	}

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -2067,9 +2067,9 @@ function comment_form_title( $no_reply_text = false, $reply_text = false, $link_
 	}
 
 	if ( $link_to_parent ) {
-		$author = '<a href="#comment-' . get_comment_ID() . '">' . get_comment_author( $comment ) . '</a>';
+		$author = '<a href="#comment-' . get_comment_ID() . '">' . get_comment_author( $reply_to_id ) . '</a>';
 	} else {
-		$author = get_comment_author( $comment );
+		$author = get_comment_author( $reply_to_id );
 	}
 
 	printf( $reply_text, $author );

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -1944,7 +1944,7 @@ function get_cancel_comment_reply_link( $text = '', $post_id = 0 ) {
 
 	$reply_to_id = _get_comment_reply_id( $post_id );
 
-	$style = ! empty( $reply_to_id ) ? '' : ' style="display:none;"';
+	$style = 0 !== $reply_to_id ? '' : ' style="display:none;"';
 	$link  = esc_html( remove_query_arg( array( 'replytocom', 'unapproved', 'moderation-hash' ) ) ) . '#respond';
 
 	$formatted_link = '<a rel="nofollow" id="cancel-comment-reply-link" href="' . $link . '"' . $style . '>' . $text . '</a>';

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -2091,12 +2091,8 @@ function comment_form_title( $no_reply_text = false, $reply_text = false, $link_
  * @return int Comment's reply to ID.
  */
 function _get_comment_reply_id( $post = null ) {
-```suggestion
- *                          Defaults to the current global post.
- * @return int Comment's reply to ID.
- */
-function _get_comment_reply_id( $post = null ) {
 	$post = get_post( $post );
+
 	if ( ! $post || ! isset( $_GET['replytocom'] ) || ! is_numeric( $_GET['replytocom'] ) ) {
 		return 0;
 	}

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -1938,7 +1938,7 @@ function get_cancel_comment_reply_link( $text = '', $post_id = 0 ) {
 		$text = __( 'Click here to cancel reply.' );
 	}
 
-	if ( empty( $post_id ) ) {
+	if ( 0 === $post_id ) {
 		$post_id = get_the_ID();
 	}
 
@@ -2070,9 +2070,7 @@ function comment_form_title( $no_reply_text = false, $reply_text = false, $link_
 		$reply_text = __( 'Leave a Reply to %s' );
 	}
 
-	$reply_to_id = isset( $_GET['replytocom'] ) ? (int) $_GET['replytocom'] : 0;
-
-	if ( ! $post_id || 0 === $reply_to_id ) {
+	if ( 0 === $post_id ) {
 		echo $no_reply_text;
 		return;
 	}

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -2081,7 +2081,7 @@ function comment_form_title( $no_reply_text = false, $reply_text = false, $link_
  * @since 5.9.0
  * @access private
  *
- * @param int $post_id Post ID.
+ * @param int|WP_Post $post_id Post ID or WP_Post object. Default current post.
  * @return int Comment's reply to ID.
  */
 function _get_comment_reply_id( $post_id ) {
@@ -2090,6 +2090,10 @@ function _get_comment_reply_id( $post_id ) {
 	}
 
 	$reply_to_id = (int) $_GET['replytocom'];
+
+	if ( $post_id instanceof WP_Post ) {
+		$post_id = $post_id->ID;
+	}
 
 	/*
 	 * Validate the comment.

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -1938,12 +1938,8 @@ function get_cancel_comment_reply_link( $text = '', $post = null ) {
 		$text = __( 'Click here to cancel reply.' );
 	}
 
-	$post = get_post( $post );
-	if ( ! $post ) {
-		return '';
-	}
-
-	$reply_to_id = _get_comment_reply_id( $post->ID );
+	$post        = get_post( $post );
+	$reply_to_id = $post ? _get_comment_reply_id( $post->ID ) : 0;
 	$style       = 0 !== $reply_to_id ? '' : ' style="display:none;"';
 	$link        = esc_html( remove_query_arg( array( 'replytocom', 'unapproved', 'moderation-hash' ) ) ) . '#respond';
 

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -2000,10 +2000,11 @@ function get_comment_id_fields( $post_id = 0 ) {
 	if ( 0 !== $reply_to_id ) {
 		$comment = get_comment( $reply_to_id );
 
-		if ( 0 !== (int) $comment->comment_approved && $post_id === (int) $comment->comment_post_ID ) {
-			$result .= "<input type='hidden' name='comment_parent' id='comment_parent' value='$reply_to_id' />\n";
+			$reply_to_id = 0;
 		}
 	}
+
+	$result .= "<input type='hidden' name='comment_parent' id='comment_parent' value='$reply_to_id' />\n";
 
 	/**
 	 * Filters the returned comment ID fields.

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -1927,25 +1927,25 @@ function post_reply_link( $args = array(), $post = null ) {
  *
  * @since 2.7.0
  *
- * @param string $text    Optional. Text to display for cancel reply link. If empty,
- *                        defaults to 'Click here to cancel reply'. Default empty.
- * @param int    $post_id Optional. The post ID the comment thread is being
- *                        displayed for. Default current global post ID.
+ * @param string      $text Optional. Text to display for cancel reply link. If empty,
+ *                          defaults to 'Click here to cancel reply'. Default empty.
+ * @param int|WP_Post $post Optional. The post the comment thread is being
+ *                          displayed for. Defaults to the current global post.
  * @return string
  */
-function get_cancel_comment_reply_link( $text = '', $post_id = 0 ) {
+function get_cancel_comment_reply_link( $text = '', $post = null ) {
 	if ( empty( $text ) ) {
 		$text = __( 'Click here to cancel reply.' );
 	}
 
-	if ( 0 === $post_id ) {
-		$post_id = get_the_ID();
+	$post = get_post( $post );
+	if ( ! $post ) {
+		return '';
 	}
 
-	$reply_to_id = _get_comment_reply_id( $post_id );
-
-	$style = 0 !== $reply_to_id ? '' : ' style="display:none;"';
-	$link  = esc_html( remove_query_arg( array( 'replytocom', 'unapproved', 'moderation-hash' ) ) ) . '#respond';
+	$reply_to_id = _get_comment_reply_id( $post->ID );
+	$style       = 0 !== $reply_to_id ? '' : ' style="display:none;"';
+	$link        = esc_html( remove_query_arg( array( 'replytocom', 'unapproved', 'moderation-hash' ) ) ) . '#respond';
 
 	$formatted_link = '<a rel="nofollow" id="cancel-comment-reply-link" href="' . $link . '"' . $style . '>' . $text . '</a>';
 

--- a/tests/phpunit/tests/comment.php
+++ b/tests/phpunit/tests/comment.php
@@ -423,7 +423,37 @@ class Tests_Comment extends WP_UnitTestCase {
 	/**
 	 * @ticket 53962
 	 */
-	public function test_output_author_of_approved_comment() {
+	public function test_should_not_allow_replying_to_an_unapproved_comment_on_another_post() {
+		// Must be set for `get_comment_id_fields()`.
+		$_GET['replytocom'] = $this->create_comment_with_approval_status( false );
+
+		$another_post = $this->factory->post->create();
+		$expected     = "<input type='hidden' name='comment_post_ID' value='" . $another_post . "' id='comment_post_ID' />\n";
+		$expected    .= "<input type='hidden' name='comment_parent' id='comment_parent' value='0' />\n";
+		$actual       = get_comment_id_fields( $another_post );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+
+	/**
+	 * @ticket 53962
+	 */
+	public function test_should_not_allow_a_parent_comment_id_that_is_not_castable_to_an_integer() {
+		// Must be set for `get_comment_id_fields()`.
+		$_GET['replytocom'] = array( "I'm not castable to an integer." );
+
+		$expected  = "<input type='hidden' name='comment_post_ID' value='" . self::$post_id . "' id='comment_post_ID' />\n";
+		$expected .= "<input type='hidden' name='comment_parent' id='comment_parent' value='0' />\n";
+		$actual    = get_comment_id_fields( self::$post_id );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * @ticket 53962
+	 */
+	public function test_should_output_the_author_of_an_approved_comment() {
 		// Must be set for `comment_form_title()`.
 		$_GET['replytocom'] = $this->create_comment_with_approval_status( true );
 

--- a/tests/phpunit/tests/comment.php
+++ b/tests/phpunit/tests/comment.php
@@ -378,6 +378,85 @@ class Tests_Comment extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that get_cancel_comment_reply_link() returns the expected value.
+	 *
+	 * @ticket 53962
+	 *
+	 * @dataProvider data_get_cancel_comment_reply_link
+	 *
+	 * @covers ::get_cancel_comment_reply_link
+	 *
+	 * @param string     $text          Text to display for cancel reply link.
+	 *                                  If empty, defaults to 'Click here to cancel reply'.
+	 * @param string|int $post          The post the comment thread is being displayed for.
+	 *                                  Accepts 'POST_ID', 'POST', or an integer post ID.
+	 * @param int|bool|null $replytocom A comment ID (int), whether to generate an approved (true) or unapproved (false) comment,
+	 *                                  or null not to create a comment.
+	 * @param string     $expected      The expected reply link.
+	 */
+	public function test_get_cancel_comment_reply_link( $text, $post, $replytocom, $expected ) {
+		if ( 'POST_ID' === $post ) {
+			$post = self::$post_id;
+		} elseif ( 'POST' === $post ) {
+			$post = self::factory()->post->get_object_by_id( self::$post_id );
+		}
+
+		if ( null === $replytocom ) {
+			unset( $_GET['replytocom'] );
+		} else {
+			$_GET['replytocom'] = $this->create_comment_with_approval_status( $replytocom );
+		}
+
+		$this->assertSame( $expected, get_cancel_comment_reply_link( $text, $post ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_get_cancel_comment_reply_link() {
+		return array(
+			'text as empty string, a valid post ID and an approved comment'    => array(
+				'text'       => '',
+				'post'       => 'POST_ID',
+				'replytocom' => true,
+				'expected'   => '<a rel="nofollow" id="cancel-comment-reply-link" href="#respond">Click here to cancel reply.</a>',
+			),
+			'text as a custom string, a valid post ID and an approved comment' => array(
+				'text'       => 'Leave a reply!',
+				'post'       => 'POST_ID',
+				'replytocom' => true,
+				'expected'   => '<a rel="nofollow" id="cancel-comment-reply-link" href="#respond">Leave a reply!</a>',
+			),
+			'text as empty string, a valid WP_Post object and an approved comment' => array(
+				'text'       => '',
+				'post'       => 'POST',
+				'replytocom' => true,
+				'expected'   => '<a rel="nofollow" id="cancel-comment-reply-link" href="#respond">Click here to cancel reply.</a>',
+			),
+			'text as a custom string, a valid WP_Post object and an approved comment' => array(
+				'text'       => 'Leave a reply!',
+				'post'       => 'POST',
+				'replytocom' => true,
+				'expected'   => '<a rel="nofollow" id="cancel-comment-reply-link" href="#respond">Leave a reply!</a>',
+			),
+			'text as empty string, an invalid post and an approved comment'    => array(
+				'text'       => '',
+				'post'       => -99999,
+				'replytocom' => true,
+				'expected'   => '',
+			),
+			'text as a custom string, a valid post, but no replytocom' => array(
+				'text'       => 'Leave a reply!',
+				'post'       => 'POST',
+				'replytocom' => null,
+				'expected'   => '<a rel="nofollow" id="cancel-comment-reply-link" href="#respond" style="display:none;">Leave a reply!</a>',
+			),
+		);
+	}
+
+	/**
 	 * Tests that comment_form_title() outputs the author of an approved comment.
 	 *
 	 * @ticket 53962
@@ -419,17 +498,67 @@ class Tests_Comment extends WP_UnitTestCase {
 	 *
 	 * @ticket 53962
 	 *
+	 * @dataProvider data_should_allow_reply_to_an_approved_comment
+	 *
 	 * @covers ::get_comment_id_fields
+	 *
+	 * @param string $comment_post The post of the comment.
+	 *                             Accepts 'POST', 'NEW_POST', 'POST_ID' and 'NEW_POST_ID'.
 	 */
-	public function test_should_allow_reply_to_an_approved_comment() {
+	public function test_should_allow_reply_to_an_approved_comment( $comment_post ) {
 		// Must be set for `get_comment_id_fields()`.
 		$_GET['replytocom'] = $this->create_comment_with_approval_status( true );
 
+		if ( 'POST_ID' === $comment_post ) {
+			$comment_post = self::$post_id;
+		} elseif ( 'POST' === $comment_post ) {
+			$comment_post = self::factory()->post->get_object_by_id( self::$post_id );
+		}
+
 		$expected  = "<input type='hidden' name='comment_post_ID' value='" . self::$post_id . "' id='comment_post_ID' />\n";
 		$expected .= "<input type='hidden' name='comment_parent' id='comment_parent' value='" . $_GET['replytocom'] . "' />\n";
-		$actual    = get_comment_id_fields( self::$post_id );
+		$actual    = get_comment_id_fields( $comment_post );
 
 		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_should_allow_reply_to_an_approved_comment() {
+		return array(
+			'a post ID'        => array( 'comment_post' => 'POST_ID' ),
+			'a WP_Post object' => array( 'comment_post' => 'POST' ),
+		);
+	}
+
+	/**
+	 * Tests that get_comment_id_fields() returns an empty string
+	 * when the post cannot be retrieved.
+	 *
+	 * @ticket 53962
+	 *
+	 * @dataProvider data_non_existent_posts
+	 *
+	 * @covers ::get_comment_id_fields
+	 *
+	 * @param bool  $replytocom   Whether to create an approved (true) or unapproved (false) comment.
+	 * @param int   $comment_post The post of the comment.
+	 *
+	 */
+	public function test_should_return_empty_string( $replytocom, $comment_post ) {
+		if ( is_bool( $replytocom ) ) {
+			$replytocom = $this->create_comment_with_approval_status( $replytocom );
+		}
+
+		// Must be set for `get_comment_id_fields()`.
+		$_GET['replytocom'] = $replytocom;
+
+		$actual = get_comment_id_fields( $comment_post );
+
+		$this->assertSame( '', $actual );
 	}
 
 	/**
@@ -440,31 +569,55 @@ class Tests_Comment extends WP_UnitTestCase {
 	 * @covers ::comment_form_title
 	 *
 	 * @dataProvider data_parent_comments
+	 * @dataProvider data_non_existent_posts
 	 *
-	 * @param mixed $replytocom       The ID of the parent comment.
-	 * @param int   $comment_post_id  The post ID of the comment.
+	 * @param bool   $replytocom   Whether to create an approved (true) or unapproved (false) comment.
+	 * @param string $comment_post The post of the comment.
+	 *                             Accepts 'POST', 'NEW_POST', 'POST_ID' and 'NEW_POST_ID'.
 	 */
-	public function test_should_not_output_the_author( $replytocom, $comment_post_id ) {
-		$comment_post_id = str_replace(
-			array(
-				'POST_ID',
-				'NEW_POST_ID',
-			),
-			array(
-				self::$post_id,
-				self::factory()->post->create(),
-			),
-			$comment_post_id
-		);
+	public function test_should_not_output_the_author( $replytocom, $comment_post ) {
+		if ( is_bool( $replytocom ) ) {
+			$replytocom = $this->create_comment_with_approval_status( $replytocom );
+		}
 
 		// Must be set for `comment_form_title()`.
 		$_GET['replytocom'] = $replytocom;
+
+		if ( 'NEW_POST_ID' === $comment_post ) {
+			$comment_post = self::factory()->post->create();
+		} elseif ( 'NEW_POST' === $comment_post ) {
+			$comment_post = self::factory()->post->create_and_get();
+		} elseif ( 'POST_ID' === $comment_post ) {
+			$comment_post = self::$post_id;
+		} elseif ( 'POST' === $comment_post ) {
+			$comment_post = self::factory()->post->get_object_by_id( self::$post_id );
+		}
+
+		$comment_post_id = $comment_post instanceof WP_Post ? $comment_post->ID : $comment_post;
 
 		get_comment( $_GET['replytocom'] );
 
 		comment_form_title( false, false, false, $comment_post_id );
 
 		$this->expectOutputString( 'Leave a Reply' );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_non_existent_posts() {
+		return array(
+			'an unapproved comment and a non-existent post ID' => array(
+				'replytocom'   => false,
+				'comment_post' => -99999,
+			),
+			'an approved comment and a non-existent post ID' => array(
+				'replytocom'   => true,
+				'comment_post' => -99999,
+			),
+		);
 	}
 
 	/**
@@ -477,16 +630,34 @@ class Tests_Comment extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_parent_comments
 	 *
-	 * @param mixed $replytocom       The ID of the parent comment.
-	 * @param int   $comment_post_id  The post ID of the comment.
+	 * @param mixed  $replytocom   Whether to create an approved (true) or unapproved (false) comment,
+	 *                             or an invalid comment ID.
+	 * @param string $comment_post The post of the comment.
+	 *                             Accepts 'POST', 'NEW_POST', 'POST_ID' and 'NEW_POST_ID'.
 	 */
-	public function test_should_not_allow_reply( $replytocom, $comment_post_id ) {
+	public function test_should_not_allow_reply( $replytocom, $comment_post ) {
+		if ( is_bool( $replytocom ) ) {
+			$replytocom = $this->create_comment_with_approval_status( $replytocom );
+		}
+
 		// Must be set for `get_comment_id_fields()`.
 		$_GET['replytocom'] = $replytocom;
 
+		if ( 'NEW_POST_ID' === $comment_post ) {
+			$comment_post = self::factory()->post->create();
+		} elseif ( 'NEW_POST' === $comment_post ) {
+			$comment_post = self::factory()->post->create_and_get();
+		} elseif ( 'POST_ID' === $comment_post ) {
+			$comment_post = self::$post_id;
+		} elseif ( 'POST' === $comment_post ) {
+			$comment_post = self::factory()->post->get_object_by_id( self::$post_id );
+		}
+
+		$comment_post_id = $comment_post instanceof WP_Post ? $comment_post->ID : $comment_post;
+
 		$expected  = "<input type='hidden' name='comment_post_ID' value='" . $comment_post_id . "' id='comment_post_ID' />\n";
 		$expected .= "<input type='hidden' name='comment_parent' id='comment_parent' value='0' />\n";
-		$actual    = get_comment_id_fields( $comment_post_id );
+		$actual    = get_comment_id_fields( $comment_post );
 
 		$this->assertSame( $expected, $actual );
 	}
@@ -498,21 +669,37 @@ class Tests_Comment extends WP_UnitTestCase {
 	 */
 	public function data_parent_comments() {
 		return array(
-			'an unapproved parent comment'                 => array(
-				'replytocom'      => $this->create_comment_with_approval_status( false ),
-				'comment_post_id' => 'POST_ID',
+			'an unapproved parent comment (ID)'      => array(
+				'replytocom'   => false,
+				'comment_post' => 'POST_ID',
 			),
-			'an approved parent comment on another post'   => array(
-				'replytocom'      => $this->create_comment_with_approval_status( true ),
-				'comment_post_id' => 'NEW_POST_ID',
+			'an approved parent comment on another post (ID)' => array(
+				'replytocom'   => true,
+				'comment_post' => 'NEW_POST_ID',
 			),
-			'an unapproved parent comment on another post' => array(
-				'replytocom'      => $this->create_comment_with_approval_status( false ),
-				'comment_post_id' => 'NEW_POST_ID',
+			'an unapproved parent comment on another post (ID)' => array(
+				'replytocom'   => false,
+				'comment_post' => 'NEW_POST_ID',
 			),
-			'a parent comment id that cannot be cast to an integer' => array(
-				'replytocom'      => array( 'I cannot be cast to an integer.' ),
-				'comment_post_id' => 'POST_ID',
+			'a parent comment ID that cannot be cast to an integer' => array(
+				'replytocom'   => array( 'I cannot be cast to an integer.' ),
+				'comment_post' => 'POST_ID',
+			),
+			'an unapproved parent comment (WP_Post)' => array(
+				'replytocom'   => false,
+				'comment_post' => 'POST',
+			),
+			'an approved parent comment on another post (WP_Post)' => array(
+				'replytocom'   => true,
+				'comment_post' => 'NEW_POST',
+			),
+			'an unapproved parent comment on another post (WP_Post)' => array(
+				'replytocom'   => false,
+				'comment_post' => 'NEW_POST',
+			),
+			'a parent comment WP_Post that cannot be cast to an integer' => array(
+				'replytocom'   => array( 'I cannot be cast to an integer.' ),
+				'comment_post' => 'POST',
 			),
 		);
 	}
@@ -531,6 +718,85 @@ class Tests_Comment extends WP_UnitTestCase {
 				'comment_post_ID'  => self::$post_id,
 				'comment_approved' => ( $approved ) ? '1' : '0',
 			)
+		);
+	}
+
+	/**
+	 * Tests that _get_comment_reply_id() returns the expected value.
+	 *
+	 * @ticket 53962
+	 *
+	 * @dataProvider data_get_comment_reply_id
+	 *
+	 * @covers ::_get_comment_reply_id
+	 *
+	 * @param int|bool|null $replytocom A comment ID (int), whether to generate an approved (true) or unapproved (false) comment,
+	 *                                  or null not to create a comment.
+	 * @param int|WP_Post   $post       Post ID or WP_Post object.
+	 * @param int           $expected   The expected result.
+	 */
+	public function test_get_comment_reply_id( $replytocom, $post, $expected ) {
+		if ( false === $replytocom ) {
+			unset( $_GET['replytocom'] );
+		} else {
+			$_GET['replytocom'] = $this->create_comment_with_approval_status( (bool) $replytocom );
+		}
+
+		if ( 'POST_ID' === $post ) {
+			$post = self::$post_id;
+		} elseif ( 'POST' === $post ) {
+			$post = self::factory()->post->get_object_by_id( self::$post_id );
+		}
+
+		if ( 'replytocom' === $expected ) {
+			$expected = $_GET['replytocom'];
+		}
+
+		$this->assertSame( $expected, _get_comment_reply_id( $post ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_get_comment_reply_id() {
+		return array(
+			'no comment ID set ($_GET["replytocom"])'     => array(
+				'replytocom' => false,
+				'post'       => null,
+				'expected'   => 0,
+			),
+			'a non-numeric comment ID'                    => array(
+				'replytocom' => 'three',
+				'post'       => null,
+				'expected'   => 0,
+			),
+			'a non-existent comment ID'                   => array(
+				'replytocom' => -999999,
+				'post'       => null,
+				'expected'   => 0,
+			),
+			'an unapproved comment'                       => array(
+				'replytocom' => false,
+				'post'       => null,
+				'expected'   => 0,
+			),
+			'a post that does not match the parent'       => array(
+				'replytocom' => false,
+				'post'       => -999999,
+				'expected'   => 0,
+			),
+			'an approved comment and the correct post ID' => array(
+				'replytocom' => true,
+				'post'       => 'POST_ID',
+				'expected'   => 'replytocom',
+			),
+			'an approved comment and the correct WP_Post object' => array(
+				'replytocom' => true,
+				'post'       => 'POST',
+				'expected'   => 'replytocom',
+			),
 		);
 	}
 

--- a/tests/phpunit/tests/comment.php
+++ b/tests/phpunit/tests/comment.php
@@ -386,13 +386,13 @@ class Tests_Comment extends WP_UnitTestCase {
 	 *
 	 * @covers ::get_cancel_comment_reply_link
 	 *
-	 * @param string     $text          Text to display for cancel reply link.
+	 * @param string        $text       Text to display for cancel reply link.
 	 *                                  If empty, defaults to 'Click here to cancel reply'.
-	 * @param string|int $post          The post the comment thread is being displayed for.
+	 * @param string|int    $post       The post the comment thread is being displayed for.
 	 *                                  Accepts 'POST_ID', 'POST', or an integer post ID.
 	 * @param int|bool|null $replytocom A comment ID (int), whether to generate an approved (true) or unapproved (false) comment,
 	 *                                  or null not to create a comment.
-	 * @param string     $expected      The expected reply link.
+	 * @param string        $expected   The expected reply link.
 	 */
 	public function test_get_cancel_comment_reply_link( $text, $post, $replytocom, $expected ) {
 		if ( 'POST_ID' === $post ) {

--- a/tests/phpunit/tests/comment.php
+++ b/tests/phpunit/tests/comment.php
@@ -378,6 +378,41 @@ class Tests_Comment extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 53962
+	 */
+	public function test_do_not_output_author_of_unapproved_comment() {
+		$_GET['replytocom'] = $this->create_unapproved_comment();
+		$expected = 'Leave a Reply';
+		comment_form_title( false, false, false );
+
+		$this->expectOutputString( $expected );
+	}
+
+	public function test_cannot_reply_to_unapproved_comment() {
+		$_GET['replytocom'] = $this->create_unapproved_comment();
+		$expected = "<input type='hidden' name='comment_post_ID' value='" . self::$post_id . "' id='comment_post_ID' />\n";
+		$actual = get_comment_id_fields( self::$post_id );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Helper function to create an unapproved comment
+	 *
+	 * @since 5.9.0
+	 * @access public
+	 * @return int  The comment ID.
+	 */
+	public function create_unapproved_comment() {
+		return self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => self::$post_id,
+				'comment_approved' => 0,
+			),
+		);
+	}
+
+	/**
 	 * @ticket 14279
 	 *
 	 * @covers ::wp_new_comment

--- a/tests/phpunit/tests/comment.php
+++ b/tests/phpunit/tests/comment.php
@@ -445,7 +445,7 @@ class Tests_Comment extends WP_UnitTestCase {
 				'text'       => '',
 				'post'       => -99999,
 				'replytocom' => true,
-				'expected'   => '',
+				'expected'   => '<a rel="nofollow" id="cancel-comment-reply-link" href="#respond" style="display:none;">Click here to cancel reply.</a>',
 			),
 			'text as a custom string, a valid post, but no replytocom' => array(
 				'text'       => 'Leave a reply!',

--- a/tests/phpunit/tests/comment.php
+++ b/tests/phpunit/tests/comment.php
@@ -416,11 +416,11 @@ class Tests_Comment extends WP_UnitTestCase {
 	 */
 	public function data_should_not_allow_reply() {
 		return array(
-			'an unapproved parent comment' => array(
+			'an unapproved parent comment'                 => array(
 				'replytocom'      => $this->create_comment_with_approval_status( false ),
 				'comment_post_id' => self::$post_id,
 			),
-			'an approved parent comment on another post' => array(
+			'an approved parent comment on another post'   => array(
 				'replytocom'      => $this->create_comment_with_approval_status( true ),
 				'comment_post_id' => self::factory()->post->create(),
 			),
@@ -460,7 +460,7 @@ class Tests_Comment extends WP_UnitTestCase {
 		// Must be set for `comment_form_title()`.
 		$_GET['replytocom'] = $replytocom;
 
-		$comment = get_comment( $_GET['replytocom'] );
+		$comment  = get_comment( $_GET['replytocom'] );
 		$expected = 'Leave a Reply';
 		comment_form_title( false, false, false, $comment_post_id );
 
@@ -474,11 +474,11 @@ class Tests_Comment extends WP_UnitTestCase {
 	 */
 	public function data_should_not_output_the_author() {
 		return array(
-			'an unapproved parent comment' => array(
+			'an unapproved parent comment'                 => array(
 				'replytocom'      => $this->create_comment_with_approval_status( false ),
 				'comment_post_id' => self::$post_id,
 			),
-			'an approved parent comment on another post' => array(
+			'an approved parent comment on another post'   => array(
 				'replytocom'      => $this->create_comment_with_approval_status( true ),
 				'comment_post_id' => self::factory()->post->create(),
 			),

--- a/tests/phpunit/tests/comment.php
+++ b/tests/phpunit/tests/comment.php
@@ -393,7 +393,21 @@ class Tests_Comment extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 53962
-	 * @dataProvider data_should_not_allow_reply
+	 */
+	public function test_should_output_the_author_of_an_approved_comment() {
+		// Must be set for `comment_form_title()`.
+		$_GET['replytocom'] = $this->create_comment_with_approval_status( true );
+
+		$comment  = get_comment( $_GET['replytocom'] );
+		$expected = 'Leave a Reply to ' . $comment->comment_author;
+		comment_form_title( false, false, false, self::$post_id );
+
+		$this->expectOutputString( $expected );
+	}
+
+	/**
+	 * @ticket 53962
+	 * @dataProvider data_parent_comments
 	 *
 	 * @param mixed $replytocom       The ID of the parent comment.
 	 * @param int   $comment_post_id  The post ID of the comment.
@@ -410,48 +424,8 @@ class Tests_Comment extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Data provider.
-	 *
-	 * @return array
-	 */
-	public function data_should_not_allow_reply() {
-		return array(
-			'an unapproved parent comment'                 => array(
-				'replytocom'      => $this->create_comment_with_approval_status( false ),
-				'comment_post_id' => self::$post_id,
-			),
-			'an approved parent comment on another post'   => array(
-				'replytocom'      => $this->create_comment_with_approval_status( true ),
-				'comment_post_id' => self::factory()->post->create(),
-			),
-			'an unapproved parent comment on another post' => array(
-				'replytocom'      => $this->create_comment_with_approval_status( false ),
-				'comment_post_id' => self::factory()->post->create(),
-			),
-			'a parent comment id that cannot be cast to an integer' => array(
-				'replytocom'      => array( 'I cannot be cast to an integer.' ),
-				'comment_post_id' => self::$post_id,
-			),
-		);
-	}
-
-	/**
 	 * @ticket 53962
-	 */
-	public function test_should_output_the_author_of_an_approved_comment() {
-		// Must be set for `comment_form_title()`.
-		$_GET['replytocom'] = $this->create_comment_with_approval_status( true );
-
-		$comment  = get_comment( $_GET['replytocom'] );
-		$expected = 'Leave a Reply to ' . $comment->comment_author;
-		comment_form_title( false, false, false, self::$post_id );
-
-		$this->expectOutputString( $expected );
-	}
-
-	/**
-	 * @ticket 53962
-	 * @dataProvider data_should_not_output_the_author
+	 * @dataProvider data_parent_comments
 	 *
 	 * @param mixed $replytocom       The ID of the parent comment.
 	 * @param int   $comment_post_id  The post ID of the comment.
@@ -472,7 +446,7 @@ class Tests_Comment extends WP_UnitTestCase {
 	 *
 	 * @return array
 	 */
-	public function data_should_not_output_the_author() {
+	public function data_parent_comments() {
 		return array(
 			'an unapproved parent comment'                 => array(
 				'replytocom'      => $this->create_comment_with_approval_status( false ),

--- a/tests/phpunit/tests/comment.php
+++ b/tests/phpunit/tests/comment.php
@@ -382,7 +382,7 @@ class Tests_Comment extends WP_UnitTestCase {
 	 */
 	public function test_do_not_output_author_of_unapproved_comment() {
 		$_GET['replytocom'] = $this->create_unapproved_comment();
-		$expected = 'Leave a Reply';
+		$expected           = 'Leave a Reply';
 		comment_form_title( false, false, false );
 
 		$this->expectOutputString( $expected );
@@ -390,14 +390,14 @@ class Tests_Comment extends WP_UnitTestCase {
 
 	public function test_cannot_reply_to_unapproved_comment() {
 		$_GET['replytocom'] = $this->create_unapproved_comment();
-		$expected = "<input type='hidden' name='comment_post_ID' value='" . self::$post_id . "' id='comment_post_ID' />\n";
-		$actual = get_comment_id_fields( self::$post_id );
+		$expected           = "<input type='hidden' name='comment_post_ID' value='" . self::$post_id . "' id='comment_post_ID' />\n";
+		$actual             = get_comment_id_fields( self::$post_id );
 
 		$this->assertSame( $expected, $actual );
 	}
 
 	/**
-	 * Helper function to create an unapproved comment
+	 * Helper function to create an unapproved comment.
 	 *
 	 * @since 5.9.0
 	 * @access public

--- a/tests/phpunit/tests/comment.php
+++ b/tests/phpunit/tests/comment.php
@@ -399,6 +399,7 @@ class Tests_Comment extends WP_UnitTestCase {
 		$_GET['replytocom'] = $this->create_comment_with_approval_status( false );
 
 		$expected = "<input type='hidden' name='comment_post_ID' value='" . self::$post_id . "' id='comment_post_ID' />\n";
+		$expected .= "<input type='hidden' name='comment_parent' id='comment_parent' value='0' />\n";
 		$actual   = get_comment_id_fields( self::$post_id );
 
 		$this->assertSame( $expected, $actual );
@@ -413,6 +414,7 @@ class Tests_Comment extends WP_UnitTestCase {
 
 		$another_post = $this->factory->post->create();
 		$expected     = "<input type='hidden' name='comment_post_ID' value='" . $another_post . "' id='comment_post_ID' />\n";
+		$expected    .= "<input type='hidden' name='comment_parent' id='comment_parent' value='0' />\n";
 		$actual       = get_comment_id_fields( $another_post );
 
 		$this->assertSame( $expected, $actual );

--- a/tests/phpunit/tests/comment.php
+++ b/tests/phpunit/tests/comment.php
@@ -732,7 +732,8 @@ class Tests_Comment extends WP_UnitTestCase {
 	 *
 	 * @param int|bool|null $replytocom A comment ID (int), whether to generate an approved (true) or unapproved (false) comment,
 	 *                                  or null not to create a comment.
-	 * @param int|WP_Post   $post       Post ID or WP_Post object.
+	 * @param string|int    $post       The post the comment thread is being displayed for.
+	 *                                  Accepts 'POST_ID', 'POST', or an integer post ID.
 	 * @param int           $expected   The expected result.
 	 */
 	public function test_get_comment_reply_id( $replytocom, $post, $expected ) {
@@ -764,22 +765,22 @@ class Tests_Comment extends WP_UnitTestCase {
 		return array(
 			'no comment ID set ($_GET["replytocom"])'     => array(
 				'replytocom' => false,
-				'post'       => null,
+				'post'       => 0,
 				'expected'   => 0,
 			),
 			'a non-numeric comment ID'                    => array(
 				'replytocom' => 'three',
-				'post'       => null,
+				'post'       => 0,
 				'expected'   => 0,
 			),
 			'a non-existent comment ID'                   => array(
 				'replytocom' => -999999,
-				'post'       => null,
+				'post'       => 0,
 				'expected'   => 0,
 			),
 			'an unapproved comment'                       => array(
 				'replytocom' => false,
-				'post'       => null,
+				'post'       => 0,
 				'expected'   => 0,
 			),
 			'a post that does not match the parent'       => array(

--- a/tests/phpunit/tests/comment.php
+++ b/tests/phpunit/tests/comment.php
@@ -384,9 +384,9 @@ class Tests_Comment extends WP_UnitTestCase {
 		// Must be set for `get_comment_id_fields()`.
 		$_GET['replytocom'] = $this->create_comment_with_approval_status( true );
 
-		$expected           = "<input type='hidden' name='comment_post_ID' value='" . self::$post_id . "' id='comment_post_ID' />\n";
-		$expected          .= "<input type='hidden' name='comment_parent' id='comment_parent' value='" . $_GET['replytocom'] . "' />\n";
-		$actual             = get_comment_id_fields( self::$post_id );
+		$expected  = "<input type='hidden' name='comment_post_ID' value='" . self::$post_id . "' id='comment_post_ID' />\n";
+		$expected .= "<input type='hidden' name='comment_parent' id='comment_parent' value='" . $_GET['replytocom'] . "' />\n";
+		$actual    = get_comment_id_fields( self::$post_id );
 
 		$this->assertSame( $expected, $actual );
 	}
@@ -398,8 +398,8 @@ class Tests_Comment extends WP_UnitTestCase {
 		// Must be set for `get_comment_id_fields()`.
 		$_GET['replytocom'] = $this->create_comment_with_approval_status( false );
 
-		$expected           = "<input type='hidden' name='comment_post_ID' value='" . self::$post_id . "' id='comment_post_ID' />\n";
-		$actual             = get_comment_id_fields( self::$post_id );
+		$expected = "<input type='hidden' name='comment_post_ID' value='" . self::$post_id . "' id='comment_post_ID' />\n";
+		$actual   = get_comment_id_fields( self::$post_id );
 
 		$this->assertSame( $expected, $actual );
 	}
@@ -411,9 +411,9 @@ class Tests_Comment extends WP_UnitTestCase {
 		// Must be set for `get_comment_id_fields()`.
 		$_GET['replytocom'] = $this->create_comment_with_approval_status( true );
 
-		$another_post       = $this->factory->post->create();
-		$expected           = "<input type='hidden' name='comment_post_ID' value='" . $another_post . "' id='comment_post_ID' />\n";
-		$actual             = get_comment_id_fields( $another_post );
+		$another_post = $this->factory->post->create();
+		$expected     = "<input type='hidden' name='comment_post_ID' value='" . $another_post . "' id='comment_post_ID' />\n";
+		$actual       = get_comment_id_fields( $another_post );
 
 		$this->assertSame( $expected, $actual );
 	}
@@ -425,8 +425,8 @@ class Tests_Comment extends WP_UnitTestCase {
 		// Must be set for `comment_form_title()`.
 		$_GET['replytocom'] = $this->create_comment_with_approval_status( true );
 
-		$comment            = get_comment( $_GET['replytocom'] );
-		$expected           = 'Leave a Reply to ' . $comment->comment_author;
+		$comment  = get_comment( $_GET['replytocom'] );
+		$expected = 'Leave a Reply to ' . $comment->comment_author;
 		comment_form_title( false, false, false );
 
 		$this->expectOutputString( $expected );
@@ -439,7 +439,7 @@ class Tests_Comment extends WP_UnitTestCase {
 		// Must be set for `comment_form_title()`.
 		$_GET['replytocom'] = $this->create_comment_with_approval_status( false );
 
-		$expected           = 'Leave a Reply';
+		$expected = 'Leave a Reply';
 		comment_form_title( false, false, false );
 
 		$this->expectOutputString( $expected );

--- a/tests/phpunit/tests/comment.php
+++ b/tests/phpunit/tests/comment.php
@@ -408,7 +408,7 @@ class Tests_Comment extends WP_UnitTestCase {
 			array(
 				'comment_post_ID'  => self::$post_id,
 				'comment_approved' => 0,
-			),
+			)
 		);
 	}
 

--- a/tests/phpunit/tests/comment/wpHandleCommentSubmission.php
+++ b/tests/phpunit/tests/comment/wpHandleCommentSubmission.php
@@ -882,4 +882,136 @@ class Tests_Comment_wpHandleCommentSubmission extends WP_UnitTestCase {
 		$this->assertNotWPError( $second_comment );
 		$this->assertEquals( self::$post->ID, $second_comment->comment_post_ID );
 	}
+
+	/**
+	 * Tests that wp_handle_comment_submission() only allows replying to
+	 * an approved parent comment.
+	 *
+	 * @ticket 53962
+	 *
+	 * @dataProvider data_should_only_allow_replying_to_an_approved_parent_comment
+	 *
+	 * @param int $approved Whether the parent comment is approved.
+	 */
+	public function test_should_only_allow_replying_to_an_approved_parent_comment( $approved ) {
+		$user = self::factory()->user->create_and_get(
+			array(
+				'user_url' => 'http://user.example.org',
+			)
+		);
+
+		wp_set_current_user( $user->ID );
+
+		$comment_parent = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => self::$post->ID,
+				'comment_approved' => $approved,
+			)
+		);
+
+		$comment = wp_handle_comment_submission(
+			array(
+				'comment_post_ID'      => self::$post->ID,
+				'comment_author'       => 'A comment author',
+				'comment_author_email' => 'comment_author@example.org',
+				'comment'              => 'Howdy, comment!',
+				'comment_parent'       => $comment_parent,
+			)
+		);
+
+		if ( $approved ) {
+			$this->assertInstanceOf(
+				'WP_Comment',
+				$comment,
+				'The comment was not submitted.'
+			);
+		} else {
+			$this->assertWPError( $comment, 'The comment was submitted.' );
+			$this->assertSame(
+				'comment_reply_to_unapproved_comment',
+				$comment->get_error_code(),
+				'The wrong error code was returned.'
+			);
+		}
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_should_only_allow_replying_to_an_approved_parent_comment() {
+		return array(
+			'an approved parent comment'   => array( 'approved' => 1 ),
+			'an unapproved parent comment' => array( 'approved' => 0 ),
+		);
+	}
+
+	/**
+	 * Tests that wp_handle_comment_submission() only allows replying to
+	 * an existing parent comment.
+	 *
+	 * @ticket 53962
+	 *
+	 * @dataProvider data_should_only_allow_replying_to_an_existing_parent_comment
+	 *
+	 * @param bool $exists Whether the parent comment exists.
+	 */
+	public function test_should_only_allow_replying_to_an_existing_parent_comment( $exists ) {
+		$user = self::factory()->user->create_and_get(
+			array(
+				'user_url' => 'http://user.example.org',
+			)
+		);
+
+		wp_set_current_user( $user->ID );
+
+		$parent_comment = -99999;
+
+		if ( $exists ) {
+			$parent_comment = self::factory()->comment->create(
+				array(
+					'comment_post_ID'  => self::$post->ID,
+					'comment_approved' => 1,
+				)
+			);
+		}
+
+		$comment = wp_handle_comment_submission(
+			array(
+				'comment_post_ID'      => self::$post->ID,
+				'comment_author'       => 'A comment author',
+				'comment_author_email' => 'comment_author@example.org',
+				'comment'              => 'Howdy, comment!',
+				'comment_parent'       => $parent_comment,
+			)
+		);
+
+		if ( $exists ) {
+			$this->assertInstanceOf(
+				'WP_Comment',
+				$comment,
+				'The comment was not submitted.'
+			);
+		} else {
+			$this->assertWPError( $comment, 'The comment was submitted.' );
+			$this->assertSame(
+				'comment_reply_to_unapproved_comment',
+				$comment->get_error_code(),
+				'The wrong error code was returned.'
+			);
+		}
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_should_only_allow_replying_to_an_existing_parent_comment() {
+		return array(
+			'an existing parent comment'    => array( 'exists' => true ),
+			'a non-existent parent comment' => array( 'exists' => false ),
+		);
+	}
 }

--- a/tests/phpunit/tests/comment/wpHandleCommentSubmission.php
+++ b/tests/phpunit/tests/comment/wpHandleCommentSubmission.php
@@ -894,13 +894,7 @@ class Tests_Comment_wpHandleCommentSubmission extends WP_UnitTestCase {
 	 * @param int $approved Whether the parent comment is approved.
 	 */
 	public function test_should_only_allow_replying_to_an_approved_parent_comment( $approved ) {
-		$user = self::factory()->user->create_and_get(
-			array(
-				'user_url' => 'http://user.example.org',
-			)
-		);
-
-		wp_set_current_user( $user->ID );
+		wp_set_current_user( self::$editor_id );
 
 		$comment_parent = self::factory()->comment->create(
 			array(
@@ -958,13 +952,7 @@ class Tests_Comment_wpHandleCommentSubmission extends WP_UnitTestCase {
 	 * @param bool $exists Whether the parent comment exists.
 	 */
 	public function test_should_only_allow_replying_to_an_existing_parent_comment( $exists ) {
-		$user = self::factory()->user->create_and_get(
-			array(
-				'user_url' => 'http://user.example.org',
-			)
-		);
-
-		wp_set_current_user( $user->ID );
+		wp_set_current_user( self::$editor_id );
 
 		$parent_comment = -99999;
 


### PR DESCRIPTION
`comment_form_title()` and `get_comment_id_fields()` allow replies to unapproved comments via `?replytocom=[comment-id]#respond`.

This patch checks that the comment has been approved before outputting the comment's `$author` and the `comment_parent` hidden field.

Trac ticket: https://core.trac.wordpress.org/ticket/53962
