### PR TITLE
Administration: Add ID to post list

### DIFF
--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -1412,6 +1412,8 @@ class WP_Posts_List_Table extends WP_List_Table {
 		$actions          = array();
 		$title            = _draft_or_post_title();
 
+		$actions['id'] = sprintf( __( 'ID: %d' ), $post->ID );
+
 		if ( $can_edit_post && 'trash' !== $post->post_status ) {
 			$actions['edit'] = sprintf(
 				'<a href="%s" aria-label="%s">%s</a>',


### PR DESCRIPTION
I often find myself looking for the post ID by hovering over the post link and checking the URL. This change would make it much more convenient to retrieve the post ID.

Trac ticket: https://core.trac.wordpress.org/ticket/53967

