### PR TITLE
#53981 The 'media_buttons' hook does not work for contributors.

### DIFF
--- a/src/wp-includes/class-wp-editor.php
+++ b/src/wp-includes/class-wp-editor.php
@@ -216,25 +216,36 @@ final class _WP_Editors {
 		if ( ! empty( $buttons ) || $set['media_buttons'] ) {
 			echo '<div id="wp-' . $editor_id_attr . '-editor-tools" class="wp-editor-tools hide-if-no-js">';
 
+			echo '<div id="wp-' . $editor_id_attr . '-media-buttons" class="wp-media-buttons">';
+
+			if ( ! function_exists( 'media_buttons' ) ) {
+				require ABSPATH . 'wp-admin/includes/media.php';
+			}
+
 			if ( $set['media_buttons'] ) {
 				self::$has_medialib = true;
 
-				if ( ! function_exists( 'media_buttons' ) ) {
-					require ABSPATH . 'wp-admin/includes/media.php';
-				}
-
-				echo '<div id="wp-' . $editor_id_attr . '-media-buttons" class="wp-media-buttons">';
-
 				/**
-				 * Fires after the default media button(s) are displayed.
+				 * Fires when the default media button(s) are displayed as long as
+				 * the $set['media_buttons'] argument is true.
 				 *
 				 * @since 2.5.0
 				 *
 				 * @param string $editor_id Unique editor identifier, e.g. 'content'.
 				 */
 				do_action( 'media_buttons', $editor_id );
-				echo "</div>\n";
 			}
+
+			/**
+			 * Fires directly after the media buttons are displayed.
+			 *
+			 * @since 5.8.0
+			 *
+			 * @param string $editor_id Unique editor identifier, e.g. 'content'.
+			 */
+			do_action( 'after_media_buttons', $editor_id );
+
+			echo "</div>\n";
 
 			echo '<div class="wp-editor-tabs">' . $buttons . "</div>\n";
 			echo "</div>\n";


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/53981#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
