### PR TITLE
Fix problematic error-handling in sanitize_option(): #53986

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -4878,7 +4878,7 @@ function sanitize_option( $option, $value ) {
 				$value = str_replace( 'http://', '', $value );
 			}
 
-			if ( 'permalink_structure' === $option && '' !== $value && ! preg_match( '/%[^\/%]+%/', $value ) ) {
+			if ( 'permalink_structure' === $option && null === $error && '' !== $value && ! preg_match( '/%[^\/%]+%/', $value ) ) {
 				$error = sprintf(
 					/* translators: %s: Documentation URL. */
 					__( 'A structure tag is required when using custom permalinks. <a href="%s">Learn more</a>' ),

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -4670,7 +4670,7 @@ function sanitize_option( $option, $value ) {
 	global $wpdb;
 
 	$original_value = $value;
-	$error          = '';
+	$error          = null;
 
 	switch ( $option ) {
 		case 'admin_email':
@@ -4907,7 +4907,7 @@ function sanitize_option( $option, $value ) {
 			break;
 	}
 
-	if ( ! empty( $error ) ) {
+	if ( null !== $error ) {
 		$value = get_option( $option );
 		if ( function_exists( 'add_settings_error' ) ) {
 			add_settings_error( $option, "invalid_{$option}", $error );

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -4908,6 +4908,11 @@ function sanitize_option( $option, $value ) {
 	}
 
 	if ( null !== $error ) {
+		if ( '' === $error && is_wp_error( $value ) ) {
+			/* translators: 1: Option name, 2: Error code. */
+			$error = sprintf( __( 'Could not sanitize the %1$s option. Error code: %2$s' ), $option, $value->get_error_code() );
+		}
+
 		$value = get_option( $option );
 		if ( function_exists( 'add_settings_error' ) ) {
 			add_settings_error( $option, "invalid_{$option}", $error );

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -2779,7 +2779,7 @@ class wpdb {
 		$table       = '`' . implode( '`.`', $table_parts ) . '`';
 		$results     = $this->get_results( "SHOW FULL COLUMNS FROM $table" );
 		if ( ! $results ) {
-			return new WP_Error( 'wpdb_get_table_charset_failure', 'Could not retrieve table charset.' );
+			return new WP_Error( 'wpdb_get_table_charset_failure', __( 'Could not retrieve table charset.' ) );
 		}
 
 		foreach ( $results as $column ) {
@@ -3221,7 +3221,7 @@ class wpdb {
 			$this->check_current_query = false;
 			$row                       = $this->get_row( 'SELECT ' . implode( ', ', $sql ), ARRAY_A );
 			if ( ! $row ) {
-				return new WP_Error( 'wpdb_strip_invalid_text_failure', 'Could not strip invalid text.' );
+				return new WP_Error( 'wpdb_strip_invalid_text_failure', __( 'Could not strip invalid text.' ) );
 			}
 
 			foreach ( array_keys( $data ) as $column ) {

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -2779,7 +2779,7 @@ class wpdb {
 		$table       = '`' . implode( '`.`', $table_parts ) . '`';
 		$results     = $this->get_results( "SHOW FULL COLUMNS FROM $table" );
 		if ( ! $results ) {
-			return new WP_Error( 'wpdb_get_table_charset_failure' );
+			return new WP_Error( 'wpdb_get_table_charset_failure', 'Could not retrieve table charset.' );
 		}
 
 		foreach ( $results as $column ) {
@@ -3221,7 +3221,7 @@ class wpdb {
 			$this->check_current_query = false;
 			$row                       = $this->get_row( 'SELECT ' . implode( ', ', $sql ), ARRAY_A );
 			if ( ! $row ) {
-				return new WP_Error( 'wpdb_strip_invalid_text_failure' );
+				return new WP_Error( 'wpdb_strip_invalid_text_failure', 'Could not strip invalid text.' );
 			}
 
 			foreach ( array_keys( $data ) as $column ) {

--- a/tests/phpunit/tests/option/sanitize-option.php
+++ b/tests/phpunit/tests/option/sanitize-option.php
@@ -155,6 +155,7 @@ class Tests_Sanitize_Option extends WP_UnitTestCase {
 			array( '/%postname%/', '/%postname%/', true ),
 			array( '/%year%/%monthnum%/%day%/%postname%/', '/%year%/%monthnum%/%day%/%postname%/', true ),
 			array( '/%year/%postname%/', '/%year/%postname%/', true ),
+			array( new WP_Error( 'wpdb_get_table_charset_failure' ), false, false ), // ticket 53986
 		);
 	}
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/53986

To prevent potential false-negatives, set `$error` to `null` initially - so we can better tell if it is ever changed during the sanitization (to be able to better react if an empty string is added to it).

Additionally, and mainly for the sake of the settings api at this point, add error messages to the `WP_Error`'s that were previously causing the issues here.