### PR TITLE
[WIP] call render_block instead of directly WP_Block::render for inner blocks

### DIFF
--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -206,9 +206,12 @@ class WP_Block {
 		if ( ! $options['dynamic'] || empty( $this->block_type->skip_inner_blocks ) ) {
 			$index = 0;
 			foreach ( $this->inner_content as $chunk ) {
-				$block_content .= is_string( $chunk ) ?
-					$chunk :
-					$this->inner_blocks[ $index++ ]->render();
+				if ( is_string( $chunk ) ) {
+					$block_content .= $chunk;
+				} else {
+					$block_content .= render_block( $this->inner_blocks[ $index ]->parsed_block );
+					$index++;
+				}
 			}
 		}
 

--- a/tests/phpunit/tests/blocks/wpBlock.php
+++ b/tests/phpunit/tests/blocks/wpBlock.php
@@ -414,6 +414,45 @@ class Tests_Blocks_wpBlock extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 51612
+	 */
+	public function test_calls_block_filters_for_inner_blocks() {
+		$pre_render_callback = new MockAction();
+		$render_block_data_callback = new MockAction();
+		$render_block_context_callback = new MockAction();
+
+		$this->registry->register(
+			'core/outer',
+			array(
+				'render_callback' => function( $block_attributes, $content ) {
+					return $content;
+				},
+			)
+		);
+		$this->registry->register(
+			'core/inner',
+			array(
+				'render_callback' => function() {
+					return 'b';
+				},
+			)
+		);
+
+		$parsed_blocks = parse_blocks( '<!-- wp:outer -->a<!-- wp:inner /-->c<!-- /wp:outer -->' );
+		$parsed_block  = $parsed_blocks[0];
+
+		add_filter( 'pre_render_block', array( $pre_render_callback, 'filter' ) );
+		add_filter( 'render_block_data', array( $render_block_data_callback, 'filter' ) );
+		add_filter( 'render_block_context', array( $render_block_context_callback, 'filter' ) );
+
+		render_block($parsed_block);
+
+		$this->assertSame( 2, $pre_render_callback->get_call_count() );
+		$this->assertSame( 2, $render_block_data_callback->get_call_count() );
+		$this->assertSame( 2, $render_block_context_callback->get_call_count() );
+	}
+
+	/**
 	 * @ticket 52991
 	 */
 	public function test_build_query_vars_from_query_block() {

--- a/tests/phpunit/tests/blocks/wpBlock.php
+++ b/tests/phpunit/tests/blocks/wpBlock.php
@@ -417,8 +417,8 @@ class Tests_Blocks_wpBlock extends WP_UnitTestCase {
 	 * @ticket 51612
 	 */
 	public function test_calls_block_filters_for_inner_blocks() {
-		$pre_render_callback = new MockAction();
-		$render_block_data_callback = new MockAction();
+		$pre_render_callback           = new MockAction();
+		$render_block_data_callback    = new MockAction();
 		$render_block_context_callback = new MockAction();
 
 		$this->registry->register(
@@ -445,7 +445,7 @@ class Tests_Blocks_wpBlock extends WP_UnitTestCase {
 		add_filter( 'render_block_data', array( $render_block_data_callback, 'filter' ) );
 		add_filter( 'render_block_context', array( $render_block_context_callback, 'filter' ) );
 
-		render_block($parsed_block);
+		render_block( $parsed_block );
 
 		$this->assertSame( 2, $pre_render_callback->get_call_count() );
 		$this->assertSame( 2, $render_block_data_callback->get_call_count() );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Changes `WP_Block::render` to use `render_block` for inner blocks instead of `WP_Block::render` directly. 
Added a test to ensure all related block filters now run for inner blocks as well. 
Breaks some block tests ❗

Trac ticket: [#51612](https://core.trac.wordpress.org/ticket/51612)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
