### PR TITLE
PHP 8.1 | WP_Http::normalize_cookies(): fix "passing null to non-nullable" deprecation notices (Trac 53635)

### DIFF
--- a/src/wp-includes/class-http.php
+++ b/src/wp-includes/class-http.php
@@ -459,7 +459,13 @@ class WP_Http {
 
 		foreach ( $cookies as $name => $value ) {
 			if ( $value instanceof WP_Http_Cookie ) {
-				$cookie_jar[ $value->name ] = new Requests_Cookie( $value->name, $value->value, $value->get_attributes(), array( 'host-only' => $value->host_only ) );
+				$attributes                 = array_filter(
+					$value->get_attributes(),
+					static function( $attr ) {
+						return null !== $attr;
+					}
+				);
+				$cookie_jar[ $value->name ] = new Requests_Cookie( $value->name, $value->value, $attributes, array( 'host-only' => $value->host_only ) );
 			} elseif ( is_scalar( $value ) ) {
 				$cookie_jar[ $name ] = new Requests_Cookie( $name, $value );
 			}


### PR DESCRIPTION
The `Requests_Cookie` class expects valid - non-`null` - attributes to be passed, either as an array or as a `Requests_Utility_CaseInsensitiveDictionary` object.

However, the `WP_Http_Cookie::get_attributes()` explicitly sets the `expires`, `path` and `domain` index keys in an array with values which _may_ be `null`. This will cause `strtotime(): Passing null to parameter #1 ($datetime) of type string is deprecated`-like errors when the attributes are passed to the `Requests_Cookie` class.

Note: a `null` value for `path` would generate a similar deprecation notice, but for the `preg_match()` function.

Fixed by using `array_filter()` on the attributes to explicitly filter out `null` values before passing the attributes to `Requests_Cookie`.

Note: I'm chosing to explicitly only filter `null` values. Using `array_filter()` without a callback would filter out all "empty" values, but that may also remove values which are explicitly set to `false` or `0`, which may be valid values.

Fixes two errors in the `external-http` group in the WordPress Core test suite:
```
1) Tests_HTTP_Functions::test_get_response_cookies_with_wp_http_cookie_object
strtotime(): Passing null to parameter #1 ($datetime) of type string is deprecated

/var/www/src/wp-includes/Requests/Cookie.php:268
/var/www/src/wp-includes/Requests/Cookie.php:237
/var/www/src/wp-includes/Requests/Cookie.php:90
/var/www/src/wp-includes/class-http.php:460
/var/www/src/wp-includes/class-http.php:349
/var/www/src/wp-includes/class-http.php:624
/var/www/src/wp-includes/http.php:162
/var/www/tests/phpunit/tests/http/functions.php:156

2) Tests_HTTP_Functions::test_get_cookie_host_only
strtotime(): Passing null to parameter #1 ($datetime) of type string is deprecated

/var/www/src/wp-includes/Requests/Cookie.php:268
/var/www/src/wp-includes/Requests/Cookie.php:237
/var/www/src/wp-includes/Requests/Cookie.php:90
/var/www/src/wp-includes/class-http.php:460
/var/www/tests/phpunit/tests/http/functions.php:235
```


Trac ticket: https://core.trac.wordpress.org/ticket/53635

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
