### PR TITLE
Twenty Twenty-One: Support custom colors in the template editor

### DIFF
--- a/src/wp-content/themes/twentytwentyone/assets/js/editor-dark-mode-support.js
+++ b/src/wp-content/themes/twentytwentyone/assets/js/editor-dark-mode-support.js
@@ -17,13 +17,14 @@ if ( document.body.classList.contains( 'twentytwentyone-supports-dark-theme' ) )
  */
 function twentytwentyoneDarkModeEditorInit( attempt ) {
 	var container = document.querySelector( '.block-editor__typewriter' ),
+		template_editor_container = document.querySelector( '[name=editor-canvas]' ),
 		maxAttempts = 8;
 
 	// Set the initial attempt if it's undefined.
 	attempt = attempt || 0;
 
 	if ( twentytwentyoneIsDarkMode() ) {
-		if ( null === container ) {
+		if ( null === container && null === template_editor_container ) {
 			// Try again.
 			if ( attempt < maxAttempts ) {
 				setTimeout(
@@ -39,6 +40,12 @@ function twentytwentyoneDarkModeEditorInit( attempt ) {
 
 		document.body.classList.add( 'is-dark-theme' );
 		document.documentElement.classList.add( 'is-dark-theme' );
-		container.classList.add( 'is-dark-theme' );
+		if ( container) {
+			container.classList.add( 'is-dark-theme' );
+		}
+		if ( template_editor_container ) {
+			var template_editor_body = template_editor_container.contentWindow.document.querySelector( '.editor-styles-wrapper' );
+			template_editor_body ? template_editor_body.classList.add( 'is-dark-theme' ) : '';
+		}
 	}
 }

--- a/src/wp-content/themes/twentytwentyone/classes/class-twenty-twenty-one-custom-colors.php
+++ b/src/wp-content/themes/twentytwentyone/classes/class-twenty-twenty-one-custom-colors.php
@@ -22,6 +22,9 @@ class Twenty_Twenty_One_Custom_Colors {
 		// Enqueue color variables for customizer & frontend.
 		add_action( 'wp_enqueue_scripts', array( $this, 'custom_color_variables' ) );
 
+		// Add color variables to the template-editor.
+		add_action( 'block_editor_settings_all', array( $this, 'template_editor_custom_color_variables' ) );
+
 		// Enqueue color variables for editor.
 		add_action( 'enqueue_block_editor_assets', array( $this, 'editor_custom_color_variables' ) );
 
@@ -109,6 +112,36 @@ class Twenty_Twenty_One_Custom_Colors {
 			wp_add_inline_style( 'twenty-twenty-one-custom-color-overrides', $this->generate_custom_color_variables( 'editor' ) );
 		}
 	}
+
+	/**
+	 * Template editor custom color variables.
+	 *
+	 * @since Twenty Twenty-One 1.5
+	 *
+	 * @return array $settings Block editor settings.
+	 */
+	public function template_editor_custom_color_variables( $settings ) {
+		$background_color = get_theme_mod( 'background_color', 'D1E4DD' );
+
+		if ( 'd1e4dd' !== strtolower( $background_color ) ) {
+
+			$settings['styles'][] = array( 'css' =>
+				'body{ --global--color-background: #' . $background_color . ';
+				--global--color-primary: ' . $this->custom_get_readable_color( $background_color ) . ';
+				--global--color-secondary: ' . $this->custom_get_readable_color( $background_color ) . ';
+				--button--color-background: ' . $this->custom_get_readable_color( $background_color ) . ';
+				--button--color-text-hover: ' . $this->custom_get_readable_color( $background_color ) . ';
+				}'
+			);
+
+			if ( '#fff' === $this->custom_get_readable_color( $background_color ) ) {
+				$settings['styles'][] = array( 'css' => 'body{ --table--stripes-border-color: rgba(240, 240, 240, 0.15); --table--stripes-background-color: rgba(240, 240, 240, 0.15);}' );
+			}
+		}
+
+		return $settings;
+	}
+
 
 	/**
 	 * Get luminance from a HEX color.

--- a/src/wp-content/themes/twentytwentyone/classes/class-twenty-twenty-one-dark-mode.php
+++ b/src/wp-content/themes/twentytwentyone/classes/class-twenty-twenty-one-dark-mode.php
@@ -19,6 +19,9 @@ class Twenty_Twenty_One_Dark_Mode {
 	 */
 	public function __construct() {
 
+		// Enqueue color variables for the template-editor.
+		add_action( 'block_editor_settings_all', array( $this, 'template_editor_custom_color_variables' ) );
+
 		// Enqueue assets for the block-editor.
 		add_action( 'enqueue_block_editor_assets', array( $this, 'editor_custom_color_variables' ) );
 
@@ -79,6 +82,23 @@ class Twenty_Twenty_One_Dark_Mode {
 			'1.0.0',
 			true
 		);
+	}
+
+	/**
+	 * Template editor custom color variables.
+	 *
+	 * @since Twenty Twenty-One 1.5
+	 *
+	 * @return array $settings Block editor settings.
+	 */
+	public function template_editor_custom_color_variables( $settings ) {
+		$background_color            = get_theme_mod( 'background_color', 'D1E4DD' );
+		$should_respect_color_scheme = get_theme_mod( 'respect_user_color_preference', false );
+		if ( $should_respect_color_scheme && Twenty_Twenty_One_Custom_Colors::get_relative_luminance_from_hex( $background_color ) > 127 ) {
+			// If dark mode is toggled on, use the dark CSS properties.
+			$settings['styles'][] = array( 'css' => 'body.is-dark-theme{ --global--color-background: var(--global--color-dark-gray); --global--color-primary: var(--global--color-light-gray); --global--color-secondary: var(--global--color-light-gray); --button--color-text: var(--global--color-background); --button--color-text-hover: var(--global--color-secondary); --button--color-text-active: var(--global--color-secondary); --button--color-background: var(--global--color-secondary); --button--color-background-active: var(--global--color-background); --global--color-border: #9ea1a7; --table--stripes-border-color: rgba(240, 240, 240, 0.15); --table--stripes-background-color: rgba(240, 240, 240, 0.15); } body:not(is-dark-theme){ --global--color-background: #' . $background_color . '; }' );
+		}
+		return $settings;
 	}
 
 	/**


### PR DESCRIPTION
Supports custom colors in the template editor using `block_editor_settings_all`.
Adds the `is-dark-theme` CSS class to the body of the template editor iframe.

This fixes an issue where the background color selected in the customizer did not display in the template editor,
with or without dark mode enabled.

Relies on https://github.com/WordPress/wordpress-develop/pull/1455
_The colors will not display correctly without 1455._

What is left to do:
- Add a version check to avoid problems for versions below WordPress 5.8.
- Fix any coding standard issues and optimizations.
- Testing
- Add props to ellatrix :)


Trac ticket: https://core.trac.wordpress.org/ticket/53564

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
