### PR TITLE
Make Composer invisible to contributors when using npm Docker local environment (Trac 53945)

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,8 +170,8 @@
 		"env:cli": "node ./tools/local-env/scripts/docker.js run cli",
 		"env:logs": "node ./tools/local-env/scripts/docker.js logs",
 		"env:pull": "node ./tools/local-env/scripts/docker.js pull",
-		"test:php": "node ./tools/local-env/scripts/docker.js run --rm phpunit phpunit",
-		"test:php-composer": "node ./tools/local-env/scripts/docker.js run --rm phpunit php ./vendor/bin/phpunit",
+		"test:php": "node ./tools/local-env/scripts/docker.js run -T php composer update -W && node ./tools/local-env/scripts/docker.js run --rm phpunit phpunit",
+		"test:php-composer": "node ./tools/local-env/scripts/docker.js run -T php composer update -W && node ./tools/local-env/scripts/docker.js run --rm phpunit php ./vendor/bin/phpunit",
 		"test:e2e": "node ./tests/e2e/run-tests.js",
 		"wp-packages-update": "wp-scripts packages-update"
 	}

--- a/tools/local-env/scripts/install.js
+++ b/tools/local-env/scripts/install.js
@@ -22,6 +22,8 @@ renameSync( 'src/wp-config.php', 'wp-config.php' );
 
 install_wp_importer();
 
+install_composer_dependencies();
+
 // Read in wp-tests-config-sample.php, edit it to work with our config, then write it to wp-tests-config.php.
 const testConfig = readFileSync( 'wp-tests-config-sample.php', 'utf8' )
 	.replace( 'youremptytestdbnamehere', 'wordpress_develop_tests' )
@@ -56,4 +58,11 @@ function install_wp_importer() {
 
 	execSync( `docker-compose exec -T php rm -rf ${testPluginDirectory}`, { stdio: 'inherit' } );
 	execSync( `docker-compose exec -T php git clone https://github.com/WordPress/wordpress-importer.git ${testPluginDirectory} --depth=1`, { stdio: 'inherit' } );
+}
+
+/**
+ * Installs the Composer package dependencies within the Docker environment.
+ */
+function install_composer_dependencies() {
+	execSync( `docker-compose run -T php composer update -W`, { stdio: 'inherit' } );
 }


### PR DESCRIPTION
As agreed to during a [live mob working session](https://core.trac.wordpress.org/ticket/53945#comment:8), this PR achieves the following:

- Installs the Composer package dependencies within the Docker environment as part of the installation process.
- Ensures these deps are installed when running `npm run test:php`  or `npm run test:php-composer`, i.e. runs `composer update -W` to guard for scenario where contributor removes the `vendor` and/or `composer.lock` file.

## Notes

For cascading `composer update` command within the `npm run test:php-composer` and `npm run test:php` script commands, the proposed `run -rm composer update -W` worked but outputs the following messages in the command-line:

```
Run a one-off command on a service.

For example:

    $ docker-compose run web python manage.py shell

By default, linked services will be started, unless they are already
running. If you do not want to start linked services, use
`docker-compose run --no-deps SERVICE COMMAND [ARGS...]`.

Usage:
    run [options] [-v VOLUME...] [-p PORT...] [-e KEY=VAL...] [-l KEY=VALUE...] [--]
        SERVICE [COMMAND] [ARGS...]
```

As this message could confuse contributors, this PR switches to using the same command as in the `install.js` script: 

```
run -T php composer update -W
```

Using this command also works but without the above `Run a one-off command on a service.` notification.

## Testing Scenarios

Testing scenarios and instructions are found in the [Trac ticket here](https://core.trac.wordpress.org/ticket/53945#comment:10).

Trac ticket: https://core.trac.wordpress.org/ticket/53945

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
