### PR TITLE
PHP 8.1 | wpdb::_real_escape(): fix "passing null to non-nullable" deprecation notices (Trac 53635)

### DIFF
--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -1158,7 +1158,7 @@ class wpdb {
 	 * @return string Escaped string.
 	 */
 	function _real_escape( $string ) {
-		if ( ! is_scalar( $string ) && ! is_null( $string ) ) {
+		if ( ! is_scalar( $string ) ) {
 			return '';
 		}
 

--- a/tests/phpunit/tests/db/realEscape.php
+++ b/tests/phpunit/tests/db/realEscape.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * Test WPDB _real_escape() method.
+ *
+ * @group  wpdb
+ * @covers wpdb::_real_escape
+ */
+class Tests_DB_RealEscape extends WP_UnitTestCase {
+
+	/**
+	 * Test that various types of input passed to `wpdb::_real_escape()` are handled correctly.
+	 *
+	 * Note: this test does not test the actual escaping or other logic in the function.
+	 * It just and only tests and documents how the function handles various input types.
+	 *
+	 * @ticket 53635
+	 *
+	 * @dataProvider data_real_escape_input_type_handling
+	 *
+	 * @param mixed  $input    The input to escape.
+	 * @param string $expected The expected function output.
+	 */
+	function test_real_escape_input_type_handling( $input, $expected ) {
+		global $wpdb;
+
+		$this->assertSame( $expected, $wpdb->_real_escape( $input ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @var array
+	 */
+	public function data_real_escape_input_type_handling() {
+		return array(
+			'null'             => array(
+				'input'    => null,
+				'expected' => '',
+			),
+			'boolean false'    => array(
+				'input'    => false,
+				'expected' => '',
+			),
+			'boolean true'     => array(
+				'input'    => true,
+				'expected' => '1',
+			),
+			'integer zero'     => array(
+				'input'    => 0,
+				'expected' => '0',
+			),
+			'negative integer' => array(
+				'input'    => -1327,
+				'expected' => '-1327',
+			),
+			'positive integer' => array(
+				'input'    => 47896,
+				'expected' => '47896',
+			),
+			'float zero'       => array(
+				'input'    => 0.0,
+				'expected' => '0',
+			),
+			'positive float'   => array(
+				'input'    => 25.52,
+				'expected' => '25.52',
+			),
+			'simple string'    => array(
+				'input'    => 'foobar',
+				'expected' => 'foobar',
+			),
+			'empty array'      => array(
+				'input'    => array(),
+				'expected' => '',
+			),
+			'non-empty array'  => array(
+				'input'    => array( 1, 2, 3 ),
+				'expected' => '',
+			),
+			'simple object'    => array(
+				'input'    => new stdClass(),
+				'expected' => '',
+			),
+		);
+	}
+}


### PR DESCRIPTION
### Tests: add a dedicated test file for the wpdb::_real_escape() method

### PHP 8.1 | wpdb::_real_escape(): fix "passing null to non-nullable" deprecation notices

The PHP native `mysqli_real_escape_string()` function expects to be passed a string as the second parameter and this is not a nullable parameter.
Passing `null` to it will result in a `mysqli_real_escape_string(): Passing null to parameter #2 ($string) of type string is deprecated` notice on PHP 8.1.

Previously, an input type check was put in place to prevent fatal errors on PHP 8.0 when an array, object or resource was passed. Changeset [48980].

A `null` value was explicitly excluded from that check, even though a `null` value being passed would only ever result in an empty string anyway.

This commit changes the previous input type check to also bow out early for `null` values and to automatically return an empty string for those.

Refs:
* https://www.php.net/manual/en/mysqli.real-escape-string.php
* https://wiki.php.net/rfc/deprecate_null_to_scalar_internal_arg



Trac ticket: https://core.trac.wordpress.org/ticket/53635

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
