### PR TITLE
remove the cursor pointer rule for all <li>s in admin menu

### DIFF
--- a/src/wp-admin/css/admin-menu.css
+++ b/src/wp-admin/css/admin-menu.css
@@ -161,7 +161,6 @@
 #adminmenu li {
 	margin: 0;
 	padding: 0;
-	cursor: pointer;
 }
 
 #adminmenu a {


### PR DESCRIPTION
This patch removes the `cursor:pointer` rule on `#adminmenu li` rather than overriding it for `#adminmenu .submenu` as in the previous patch. 

This rule does not appear to need to be here since the cursor pointer changes for any anchor elements in the menu and the pointer on the li is the reported bug. So, unless this is here for a reason we can remove some code. Always prefer to solve issues by removing code rather than adding code. Looked back at the history and that has been there 9+ years, and I believe the admin has been refreshed at least once since then so I believe it to just be a legacy rule that really isn't needed.

Trac ticket: https://core.trac.wordpress.org/ticket/51551

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
