### PR TITLE
Customizer: Do not close section if we detect that a block editor instance is open

### DIFF
--- a/src/js/_enqueues/wp/customize/controls.js
+++ b/src/js/_enqueues/wp/customize/controls.js
@@ -8461,6 +8461,11 @@
 				return;
 			}
 
+			// abort if we're inside of a block editor instance
+			if ( event.target.closest( '.block-editor-writing-flow' ) !== null || event.target.closest( '.block-editor-block-list__block-popover' ) !== null ) {
+				return;
+			}
+
 			// Check for expanded expandable controls (e.g. widgets and nav menus items), sections, and panels.
 			api.control.each( function( control ) {
 				if ( control.expanded && control.expanded() && _.isFunction( control.collapse ) ) {


### PR DESCRIPTION
Fixes https://core.trac.wordpress.org/ticket/54030

When editing a widget in /wp-admin/customize.php?return=%2Fwp-admin%2Fwidgets.php using the widget block editor, try pressing "esc". The customizer panel is closed regardless of if the block editor has focus or not.

Instead of having the block editor stop propagation of key events, let's make the customizer aware of block editor instances and avoid firing keyboard shortcuts if an editor instance has focus.

#### Before

https://user-images.githubusercontent.com/1270189/131191958-30bd5984-d5ba-4b61-a67d-a02534f3026a.mp4

#### After

https://user-images.githubusercontent.com/1270189/131191962-cd5f54c1-04fe-4867-b810-c94e223733d6.mp4

### Testing Instructions

- Checkout this branch
- Activate the 2020 theme and enable the Gutenberg plugin
- Visit  /wp-admin/customize.php?return=%2Fwp-admin%2Fwidgets.php
- Add a widget, and a block like a paragraph
- Press <kbd>esc</kbd>
- Verify that the block editor goes into navigator mode and that the customizer panel does not close
