### PR TITLE
PHP 8.1 | Compat/_mb_substr(): fix passing null to non-nullable deprecation (Trac 53635 + 53363)

### DIFF
--- a/src/wp-includes/compat.php
+++ b/src/wp-includes/compat.php
@@ -79,6 +79,10 @@ endif;
  * @return string Extracted substring.
  */
 function _mb_substr( $str, $start, $length = null, $encoding = null ) {
+	if ( null === $str ) {
+		return '';
+	}
+
 	if ( null === $encoding ) {
 		$encoding = get_option( 'blog_charset' );
 	}

--- a/tests/phpunit/tests/compat.php
+++ b/tests/phpunit/tests/compat.php
@@ -2,131 +2,8 @@
 
 /**
  * @group compat
- * @group security-153
  */
 class Tests_Compat extends WP_UnitTestCase {
-
-	function utf8_substrings() {
-		return array(
-			// String, start, length, character_substring, byte_substring.
-			array( 'баба', 0, 3, 'баб', "б\xD0" ),
-			array( 'баба', 0, -1, 'баб', "баб\xD0" ),
-			array( 'баба', 1, null, 'аба', "\xB1аба" ),
-			array( 'баба', -3, null, 'аба', "\xB1а" ),
-			array( 'баба', -3, 2, 'аб', "\xB1\xD0" ),
-			array( 'баба', -1, 2, 'а', "\xB0" ),
-			array( 'I am your баба', 0, 11, 'I am your б', "I am your \xD0" ),
-		);
-	}
-
-	/**
-	 * @dataProvider utf8_substrings
-	 */
-	function test_mb_substr( $string, $start, $length, $expected_character_substring ) {
-		$this->assertSame( $expected_character_substring, _mb_substr( $string, $start, $length, 'UTF-8' ) );
-	}
-
-	/**
-	 * @dataProvider utf8_substrings
-	 */
-	function test_mb_substr_via_regex( $string, $start, $length, $expected_character_substring ) {
-		_wp_can_use_pcre_u( false );
-		$this->assertSame( $expected_character_substring, _mb_substr( $string, $start, $length, 'UTF-8' ) );
-		_wp_can_use_pcre_u( 'reset' );
-	}
-
-	/**
-	 * @dataProvider utf8_substrings
-	 */
-	function test_8bit_mb_substr( $string, $start, $length, $expected_character_substring, $expected_byte_substring ) {
-		$this->assertSame( $expected_byte_substring, _mb_substr( $string, $start, $length, '8bit' ) );
-	}
-
-	function test_mb_substr_phpcore() {
-		/* https://github.com/php/php-src/blob/php-5.6.8/ext/mbstring/tests/mb_substr_basic.phpt */
-		$string_ascii = 'ABCDEF';
-		$string_mb    = base64_decode( '5pel5pys6Kqe44OG44Kt44K544OI44Gn44GZ44CCMDEyMzTvvJXvvJbvvJfvvJjvvJnjgII=' );
-
-		$this->assertSame( 'DEF', _mb_substr( $string_ascii, 3 ) );
-		$this->assertSame( 'DEF', _mb_substr( $string_ascii, 3, 5, 'ISO-8859-1' ) );
-
-		// Specific latin-1 as that is the default the core PHP test operates under.
-		$this->assertSame( 'peacrOiqng==', base64_encode( _mb_substr( $string_mb, 2, 7, 'latin-1' ) ) );
-		$this->assertSame( '6Kqe44OG44Kt44K544OI44Gn44GZ', base64_encode( _mb_substr( $string_mb, 2, 7, 'utf-8' ) ) );
-
-		/* https://github.com/php/php-src/blob/php-5.6.8/ext/mbstring/tests/mb_substr_variation1.phpt */
-		$start     = 0;
-		$length    = 5;
-		$unset_var = 10;
-		unset( $unset_var );
-		$heredoc  = <<<EOT
-hello world
-EOT;
-		$inputs   = array(
-			0,
-			1,
-			12345,
-			-2345,
-			// Float data.
-			10.5,
-			-10.5,
-			12.3456789000e10,
-			12.3456789000E-10,
-			.5,
-			// Null data.
-			null,
-			null,
-			// Boolean data.
-			true,
-			false,
-			true,
-			false,
-			// Empty data.
-			'',
-			'',
-			// String data.
-			'string',
-			'string',
-			$heredoc,
-			// Object data.
-			new ClassA(),
-			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- intentionally undefined data
-			@$undefined_var,
-			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- intentionally unset data
-			@$unset_var,
-		);
-		$outputs  = array(
-			'0',
-			'1',
-			'12345',
-			'-2345',
-			'10.5',
-			'-10.5',
-			'12345',
-			'1.234',
-			'0.5',
-			'',
-			'',
-			'1',
-			'',
-			'1',
-			'',
-			'',
-			'',
-			'strin',
-			'strin',
-			'hello',
-			'Class',
-			'',
-			'',
-		);
-		$iterator = 0;
-		foreach ( $inputs as $input ) {
-			$this->assertSame( $outputs[ $iterator ], _mb_substr( $input, $start, $length ) );
-			$iterator++;
-		}
-
-	}
 
 	function test_hash_hmac_simple() {
 		$this->assertSame( '140d1cb79fa12e2a31f32d35ad0a2723', _hash_hmac( 'md5', 'simple', 'key' ) );
@@ -268,13 +145,6 @@ EOT;
 			array( 3.14, false ),
 			array( new stdClass(), false ),
 		);
-	}
-}
-
-/* used in test_mb_substr_phpcore */
-class ClassA {
-	public function __toString() {
-		return 'Class A object';
 	}
 }
 

--- a/tests/phpunit/tests/compat.php
+++ b/tests/phpunit/tests/compat.php
@@ -6,77 +6,6 @@
 class Tests_Compat extends WP_UnitTestCase {
 
 	/**
-	 * Test that is_countable() is always available (either from PHP or WP).
-	 *
-	 * @ticket 43583
-	 */
-	function test_is_countable_availability() {
-		$this->assertTrue( function_exists( 'is_countable' ) );
-	}
-
-	/**
-	 * Test is_countable() polyfill.
-	 *
-	 * @ticket 43583
-	 *
-	 * @dataProvider countable_variable_test_data
-	 *
-	 * @param mixed $variable     Variable to check.
-	 * @param bool  $is_countable The expected return value of PHP 7.3 is_countable() function.
-	 */
-	function test_is_countable_functionality( $variable, $is_countable ) {
-		$this->assertSame( is_countable( $variable ), $is_countable );
-	}
-
-	/**
-	 * Data provider for test_is_countable_functionality().
-	 *
-	 * @ticket 43583
-	 *
-	 * @return array {
-	 *     @type array {
-	 *         @type mixed $variable     Variable to check.
-	 *         @type bool  $is_countable The expected return value of PHP 7.3 is_countable() function.
-	 *     }
-	 * }
-	 */
-	public function countable_variable_test_data() {
-		return array(
-			array( true, false ),
-			array( new stdClass(), false ),
-			array( new ArrayIteratorFake(), true ),
-			array( new CountableFake(), true ),
-			array( 16, false ),
-			array( null, false ),
-			array( array( 1, 2, 3 ), true ),
-			array( (array) 1, true ),
-			array( (object) array( 'foo', 'bar', 'baz' ), false ),
-		);
-	}
-
-	/**
-	 * Test is_countable() polyfill for ResourceBundle.
-	 *
-	 * @ticket 43583
-	 *
-	 * @requires extension intl
-	 */
-	function test_is_countable_ResourceBundle() {
-		$this->assertTrue( is_countable( new ResourceBundle( 'en', null ) ) );
-	}
-
-	/**
-	 * Test is_countable() polyfill for SimpleXMLElement.
-	 *
-	 * @ticket 43583
-	 *
-	 * @requires extension simplexml
-	 */
-	function test_is_countable_SimpleXMLElement() {
-		$this->assertTrue( is_countable( new SimpleXMLElement( '<xml><tag>1</tag><tag>2</tag></xml>' ) ) );
-	}
-
-	/**
 	 * Test that is_iterable() is always available (either from PHP or WP).
 	 *
 	 * @ticket 43619
@@ -120,15 +49,5 @@ class Tests_Compat extends WP_UnitTestCase {
 			array( 3.14, false ),
 			array( new stdClass(), false ),
 		);
-	}
-}
-
-class ArrayIteratorFake extends ArrayIterator {
-}
-
-class CountableFake implements Countable {
-	#[ReturnTypeWillChange]
-	public function count() {
-		return 16;
 	}
 }

--- a/tests/phpunit/tests/compat.php
+++ b/tests/phpunit/tests/compat.php
@@ -5,16 +5,6 @@
  */
 class Tests_Compat extends WP_UnitTestCase {
 
-	function test_json_encode_decode() {
-		$this->expectDeprecation();
-
-		require_once ABSPATH . WPINC . '/class-json.php';
-		$json = new Services_JSON();
-		// Super basic test to verify Services_JSON is intact and working.
-		$this->assertSame( '["foo"]', $json->encodeUnsafe( array( 'foo' ) ) );
-		$this->assertSame( array( 'foo' ), $json->decode( '["foo"]' ) );
-	}
-
 	/**
 	 * Test that is_countable() is always available (either from PHP or WP).
 	 *

--- a/tests/phpunit/tests/compat.php
+++ b/tests/phpunit/tests/compat.php
@@ -5,19 +5,6 @@
  * @group security-153
  */
 class Tests_Compat extends WP_UnitTestCase {
-	function utf8_string_lengths() {
-		return array(
-			// String, character_length, byte_length.
-			array( 'баба', 4, 8 ),
-			array( 'баб', 3, 6 ),
-			array( 'I am your б', 11, 12 ),
-			array( '1111111111', 10, 10 ),
-			array( '²²²²²²²²²²', 10, 20 ),
-			array( '３３３３３３３３３３', 10, 30 ),
-			array( '𝟜𝟜𝟜𝟜𝟜𝟜𝟜𝟜𝟜𝟜', 10, 40 ),
-			array( '1²３𝟜1²３𝟜1²３𝟜', 12, 30 ),
-		);
-	}
 
 	function utf8_substrings() {
 		return array(
@@ -30,29 +17,6 @@ class Tests_Compat extends WP_UnitTestCase {
 			array( 'баба', -1, 2, 'а', "\xB0" ),
 			array( 'I am your баба', 0, 11, 'I am your б', "I am your \xD0" ),
 		);
-	}
-
-	/**
-	 * @dataProvider utf8_string_lengths
-	 */
-	function test_mb_strlen( $string, $expected_character_length ) {
-		$this->assertSame( $expected_character_length, _mb_strlen( $string, 'UTF-8' ) );
-	}
-
-	/**
-	 * @dataProvider utf8_string_lengths
-	 */
-	function test_mb_strlen_via_regex( $string, $expected_character_length ) {
-		_wp_can_use_pcre_u( false );
-		$this->assertSame( $expected_character_length, _mb_strlen( $string, 'UTF-8' ) );
-		_wp_can_use_pcre_u( 'reset' );
-	}
-
-	/**
-	 * @dataProvider utf8_string_lengths
-	 */
-	function test_8bit_mb_strlen( $string, $expected_character_length, $expected_byte_length ) {
-		$this->assertSame( $expected_byte_length, _mb_strlen( $string, '8bit' ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/compat.php
+++ b/tests/phpunit/tests/compat.php
@@ -5,21 +5,6 @@
  */
 class Tests_Compat extends WP_UnitTestCase {
 
-	function test_hash_hmac_simple() {
-		$this->assertSame( '140d1cb79fa12e2a31f32d35ad0a2723', _hash_hmac( 'md5', 'simple', 'key' ) );
-		$this->assertSame( '993003b95758e0ac2eba451a4c5877eb1bb7b92a', _hash_hmac( 'sha1', 'simple', 'key' ) );
-	}
-
-	function test_hash_hmac_padding() {
-		$this->assertSame( '3c1399103807cf12ec38228614416a8c', _hash_hmac( 'md5', 'simple', '65 character key 65 character key 65 character key 65 character k' ) );
-		$this->assertSame( '4428826d20003e309d6c2a6515891370daf184ea', _hash_hmac( 'sha1', 'simple', '65 character key 65 character key 65 character key 65 character k' ) );
-	}
-
-	function test_hash_hmac_output() {
-		$this->assertSame( array( 1 => '140d1cb79fa12e2a31f32d35ad0a2723' ), unpack( 'H32', _hash_hmac( 'md5', 'simple', 'key', true ) ) );
-		$this->assertSame( array( 1 => '993003b95758e0ac2eba451a4c5877eb1bb7b92a' ), unpack( 'H40', _hash_hmac( 'sha1', 'simple', 'key', true ) ) );
-	}
-
 	function test_json_encode_decode() {
 		$this->expectDeprecation();
 

--- a/tests/phpunit/tests/compat/hashHmac.php
+++ b/tests/phpunit/tests/compat/hashHmac.php
@@ -2,21 +2,64 @@
 
 /**
  * @group compat
+ *
+ * @covers ::hash_hmac
+ * @covers ::_hash_hmac
  */
 class Tests_Compat_hashHmac extends WP_UnitTestCase {
 
-	function test_hash_hmac_simple() {
-		$this->assertSame( '140d1cb79fa12e2a31f32d35ad0a2723', _hash_hmac( 'md5', 'simple', 'key' ) );
-		$this->assertSame( '993003b95758e0ac2eba451a4c5877eb1bb7b92a', _hash_hmac( 'sha1', 'simple', 'key' ) );
+	/**
+	 * Test that hash_hmac() is always available (either from PHP or WP).
+	 */
+	public function test_hash_hmac_availability() {
+		$this->assertTrue( function_exists( 'hash_hmac' ) );
 	}
 
-	function test_hash_hmac_padding() {
-		$this->assertSame( '3c1399103807cf12ec38228614416a8c', _hash_hmac( 'md5', 'simple', '65 character key 65 character key 65 character key 65 character k' ) );
-		$this->assertSame( '4428826d20003e309d6c2a6515891370daf184ea', _hash_hmac( 'sha1', 'simple', '65 character key 65 character key 65 character key 65 character k' ) );
+	public function test_hash_hmac_simple() {
+		$data = 'simple';
+		$key  = 'key';
+
+		$this->assertSame(
+			'140d1cb79fa12e2a31f32d35ad0a2723',
+			_hash_hmac( 'md5', $data, $key ),
+			'MD5 hash does not match'
+		);
+		$this->assertSame(
+			'993003b95758e0ac2eba451a4c5877eb1bb7b92a',
+			_hash_hmac( 'sha1', $data, $key ),
+			'sha1 hash does not match'
+		);
 	}
 
-	function test_hash_hmac_output() {
-		$this->assertSame( array( 1 => '140d1cb79fa12e2a31f32d35ad0a2723' ), unpack( 'H32', _hash_hmac( 'md5', 'simple', 'key', true ) ) );
-		$this->assertSame( array( 1 => '993003b95758e0ac2eba451a4c5877eb1bb7b92a' ), unpack( 'H40', _hash_hmac( 'sha1', 'simple', 'key', true ) ) );
+	public function test_hash_hmac_padding() {
+		$data = 'simple';
+		$key  = '65 character key 65 character key 65 character key 65 character k';
+
+		$this->assertSame(
+			'3c1399103807cf12ec38228614416a8c',
+			_hash_hmac( 'md5', $data, $key ),
+			'MD5 hash does not match'
+		);
+		$this->assertSame(
+			'4428826d20003e309d6c2a6515891370daf184ea',
+			_hash_hmac( 'sha1', $data, $key ),
+			'sha1 hash does not match'
+		);
+	}
+
+	public function test_hash_hmac_output() {
+		$data = 'simple';
+		$key  = 'key';
+
+		$this->assertSame(
+			array( 1 => '140d1cb79fa12e2a31f32d35ad0a2723' ),
+			unpack( 'H32', _hash_hmac( 'md5', $data, $key, true ) ),
+			'unpacked MD5 hash does not match'
+		);
+		$this->assertSame(
+			array( 1 => '993003b95758e0ac2eba451a4c5877eb1bb7b92a' ),
+			unpack( 'H40', _hash_hmac( 'sha1', $data, $key, true ) ),
+			'unpacked sha1 hash does not match'
+		);
 	}
 }

--- a/tests/phpunit/tests/compat/hashHmac.php
+++ b/tests/phpunit/tests/compat/hashHmac.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @group compat
+ */
+class Tests_Compat_hashHmac extends WP_UnitTestCase {
+
+	function test_hash_hmac_simple() {
+		$this->assertSame( '140d1cb79fa12e2a31f32d35ad0a2723', _hash_hmac( 'md5', 'simple', 'key' ) );
+		$this->assertSame( '993003b95758e0ac2eba451a4c5877eb1bb7b92a', _hash_hmac( 'sha1', 'simple', 'key' ) );
+	}
+
+	function test_hash_hmac_padding() {
+		$this->assertSame( '3c1399103807cf12ec38228614416a8c', _hash_hmac( 'md5', 'simple', '65 character key 65 character key 65 character key 65 character k' ) );
+		$this->assertSame( '4428826d20003e309d6c2a6515891370daf184ea', _hash_hmac( 'sha1', 'simple', '65 character key 65 character key 65 character key 65 character k' ) );
+	}
+
+	function test_hash_hmac_output() {
+		$this->assertSame( array( 1 => '140d1cb79fa12e2a31f32d35ad0a2723' ), unpack( 'H32', _hash_hmac( 'md5', 'simple', 'key', true ) ) );
+		$this->assertSame( array( 1 => '993003b95758e0ac2eba451a4c5877eb1bb7b92a' ), unpack( 'H40', _hash_hmac( 'sha1', 'simple', 'key', true ) ) );
+	}
+}

--- a/tests/phpunit/tests/compat/isCountable.php
+++ b/tests/phpunit/tests/compat/isCountable.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * @group compat
+ */
+class Tests_Compat_isCountable extends WP_UnitTestCase {
+
+	/**
+	 * Test that is_countable() is always available (either from PHP or WP).
+	 *
+	 * @ticket 43583
+	 */
+	function test_is_countable_availability() {
+		$this->assertTrue( function_exists( 'is_countable' ) );
+	}
+
+	/**
+	 * Test is_countable() polyfill.
+	 *
+	 * @ticket 43583
+	 *
+	 * @dataProvider countable_variable_test_data
+	 *
+	 * @param mixed $variable     Variable to check.
+	 * @param bool  $is_countable The expected return value of PHP 7.3 is_countable() function.
+	 */
+	function test_is_countable_functionality( $variable, $is_countable ) {
+		$this->assertSame( is_countable( $variable ), $is_countable );
+	}
+
+	/**
+	 * Data provider for test_is_countable_functionality().
+	 *
+	 * @ticket 43583
+	 *
+	 * @return array {
+	 *     @type array {
+	 *         @type mixed $variable     Variable to check.
+	 *         @type bool  $is_countable The expected return value of PHP 7.3 is_countable() function.
+	 *     }
+	 * }
+	 */
+	public function countable_variable_test_data() {
+		return array(
+			array( true, false ),
+			array( new stdClass(), false ),
+			array( new ArrayIteratorFake(), true ),
+			array( new CountableFake(), true ),
+			array( 16, false ),
+			array( null, false ),
+			array( array( 1, 2, 3 ), true ),
+			array( (array) 1, true ),
+			array( (object) array( 'foo', 'bar', 'baz' ), false ),
+		);
+	}
+
+	/**
+	 * Test is_countable() polyfill for ResourceBundle.
+	 *
+	 * @ticket 43583
+	 *
+	 * @requires extension intl
+	 */
+	function test_is_countable_ResourceBundle() {
+		$this->assertTrue( is_countable( new ResourceBundle( 'en', null ) ) );
+	}
+
+	/**
+	 * Test is_countable() polyfill for SimpleXMLElement.
+	 *
+	 * @ticket 43583
+	 *
+	 * @requires extension simplexml
+	 */
+	function test_is_countable_SimpleXMLElement() {
+		$this->assertTrue( is_countable( new SimpleXMLElement( '<xml><tag>1</tag><tag>2</tag></xml>' ) ) );
+	}
+}
+
+class ArrayIteratorFake extends ArrayIterator {
+}
+
+class CountableFake implements Countable {
+	#[ReturnTypeWillChange]
+	public function count() {
+		return 16;
+	}
+}

--- a/tests/phpunit/tests/compat/isCountable.php
+++ b/tests/phpunit/tests/compat/isCountable.php
@@ -2,6 +2,8 @@
 
 /**
  * @group compat
+ *
+ * @covers ::is_countable
  */
 class Tests_Compat_isCountable extends WP_UnitTestCase {
 
@@ -10,7 +12,7 @@ class Tests_Compat_isCountable extends WP_UnitTestCase {
 	 *
 	 * @ticket 43583
 	 */
-	function test_is_countable_availability() {
+	public function test_is_countable_availability() {
 		$this->assertTrue( function_exists( 'is_countable' ) );
 	}
 
@@ -19,13 +21,13 @@ class Tests_Compat_isCountable extends WP_UnitTestCase {
 	 *
 	 * @ticket 43583
 	 *
-	 * @dataProvider countable_variable_test_data
+	 * @dataProvider data_is_countable_functionality
 	 *
 	 * @param mixed $variable     Variable to check.
 	 * @param bool  $is_countable The expected return value of PHP 7.3 is_countable() function.
 	 */
-	function test_is_countable_functionality( $variable, $is_countable ) {
-		$this->assertSame( is_countable( $variable ), $is_countable );
+	public function test_is_countable_functionality( $variable, $is_countable ) {
+		$this->assertSame( $is_countable, is_countable( $variable ) );
 	}
 
 	/**
@@ -40,17 +42,44 @@ class Tests_Compat_isCountable extends WP_UnitTestCase {
 	 *     }
 	 * }
 	 */
-	public function countable_variable_test_data() {
+	public function data_is_countable_functionality() {
 		return array(
-			array( true, false ),
-			array( new stdClass(), false ),
-			array( new ArrayIteratorFake(), true ),
-			array( new CountableFake(), true ),
-			array( 16, false ),
-			array( null, false ),
-			array( array( 1, 2, 3 ), true ),
-			array( (array) 1, true ),
-			array( (object) array( 'foo', 'bar', 'baz' ), false ),
+			'boolean true'                     => array(
+				'variable'     => true,
+				'is_countable' => false,
+			),
+			'plain stdClass object'            => array(
+				'variable'     => new stdClass(),
+				'is_countable' => false,
+			),
+			'Array iterator object'            => array(
+				'variable'     => new ArrayIteratorFakeForIsCountable(),
+				'is_countable' => true,
+			),
+			'Countable object'                 => array(
+				'variable'     => new CountableFakeForIsCountable(),
+				'is_countable' => true,
+			),
+			'integer 16'                       => array(
+				'variable'     => 16,
+				'is_countable' => false,
+			),
+			'null'                             => array(
+				'variable'     => null,
+				'is_countable' => false,
+			),
+			'non-empty array, 3 items'         => array(
+				'variable'     => array( 1, 2, 3 ),
+				'is_countable' => true,
+			),
+			'non-empty array, 1 item via cast' => array(
+				'variable'     => (array) 1,
+				'is_countable' => true,
+			),
+			'array cast to object'             => array(
+				'variable'     => (object) array( 'foo', 'bar', 'baz' ),
+				'is_countable' => false,
+			),
 		);
 	}
 
@@ -61,7 +90,7 @@ class Tests_Compat_isCountable extends WP_UnitTestCase {
 	 *
 	 * @requires extension intl
 	 */
-	function test_is_countable_ResourceBundle() {
+	public function test_is_countable_ResourceBundle() {
 		$this->assertTrue( is_countable( new ResourceBundle( 'en', null ) ) );
 	}
 
@@ -72,15 +101,15 @@ class Tests_Compat_isCountable extends WP_UnitTestCase {
 	 *
 	 * @requires extension simplexml
 	 */
-	function test_is_countable_SimpleXMLElement() {
+	public function test_is_countable_SimpleXMLElement() {
 		$this->assertTrue( is_countable( new SimpleXMLElement( '<xml><tag>1</tag><tag>2</tag></xml>' ) ) );
 	}
 }
 
-class ArrayIteratorFake extends ArrayIterator {
+class ArrayIteratorFakeForIsCountable extends ArrayIterator {
 }
 
-class CountableFake implements Countable {
+class CountableFakeForIsCountable implements Countable {
 	#[ReturnTypeWillChange]
 	public function count() {
 		return 16;

--- a/tests/phpunit/tests/compat/isIterable.php
+++ b/tests/phpunit/tests/compat/isIterable.php
@@ -3,7 +3,7 @@
 /**
  * @group compat
  */
-class Tests_Compat extends WP_UnitTestCase {
+class Tests_Compat_isIterable extends WP_UnitTestCase {
 
 	/**
 	 * Test that is_iterable() is always available (either from PHP or WP).

--- a/tests/phpunit/tests/compat/isIterable.php
+++ b/tests/phpunit/tests/compat/isIterable.php
@@ -2,6 +2,8 @@
 
 /**
  * @group compat
+ *
+ * @covers ::is_iterable
  */
 class Tests_Compat_isIterable extends WP_UnitTestCase {
 
@@ -10,7 +12,7 @@ class Tests_Compat_isIterable extends WP_UnitTestCase {
 	 *
 	 * @ticket 43619
 	 */
-	function test_is_iterable_availability() {
+	public function test_is_iterable_availability() {
 		$this->assertTrue( function_exists( 'is_iterable' ) );
 	}
 
@@ -19,13 +21,13 @@ class Tests_Compat_isIterable extends WP_UnitTestCase {
 	 *
 	 * @ticket 43619
 	 *
-	 * @dataProvider iterable_variable_test_data
+	 * @dataProvider data_is_iterable_functionality
 	 *
 	 * @param mixed $variable    Variable to check.
 	 * @param bool  $is_iterable The expected return value of PHP 7.1 is_iterable() function.
 	 */
-	function test_is_iterable_functionality( $variable, $is_iterable ) {
-		$this->assertSame( is_iterable( $variable ), $is_iterable );
+	public function test_is_iterable_functionality( $variable, $is_iterable ) {
+		$this->assertSame( $is_iterable, is_iterable( $variable ) );
 	}
 
 	/**
@@ -40,14 +42,36 @@ class Tests_Compat_isIterable extends WP_UnitTestCase {
 	 *     }
 	 * }
 	 */
-	public function iterable_variable_test_data() {
+	public function data_is_iterable_functionality() {
 		return array(
-			array( array(), true ),
-			array( array( 1, 2, 3 ), true ),
-			array( new ArrayIterator( array( 1, 2, 3 ) ), true ),
-			array( 1, false ),
-			array( 3.14, false ),
-			array( new stdClass(), false ),
+			'empty array'           => array(
+				'variable'    => array(),
+				'is_iterable' => true,
+			),
+			'non-empty array'       => array(
+				'variable'    => array( 1, 2, 3 ),
+				'is_iterable' => true,
+			),
+			'Iterator object'       => array(
+				'variable'    => new ArrayIterator( array( 1, 2, 3 ) ),
+				'is_iterable' => true,
+			),
+			'null'                  => array(
+				'variable'    => null,
+				'is_iterable' => false,
+			),
+			'integer 1'             => array(
+				'variable'    => 1,
+				'is_iterable' => false,
+			),
+			'float 3.14'            => array(
+				'variable'    => 3.14,
+				'is_iterable' => false,
+			),
+			'plain stdClass object' => array(
+				'variable'    => new stdClass(),
+				'is_iterable' => false,
+			),
 		);
 	}
 }

--- a/tests/phpunit/tests/compat/jsonEncodeDecode.php
+++ b/tests/phpunit/tests/compat/jsonEncodeDecode.php
@@ -2,16 +2,19 @@
 
 /**
  * @group compat
+ *
+ * @covers Services_JSON
  */
 class Tests_Compat_jsonEncodeDecode extends WP_UnitTestCase {
 
-	function test_json_encode_decode() {
+	public function test_json_encode_decode() {
 		$this->expectDeprecation();
 
 		require_once ABSPATH . WPINC . '/class-json.php';
 		$json = new Services_JSON();
+
 		// Super basic test to verify Services_JSON is intact and working.
-		$this->assertSame( '["foo"]', $json->encodeUnsafe( array( 'foo' ) ) );
-		$this->assertSame( array( 'foo' ), $json->decode( '["foo"]' ) );
+		$this->assertSame( '["foo"]', $json->encodeUnsafe( array( 'foo' ) ), 'encodeUnsafe() did not return expected output' );
+		$this->assertSame( array( 'foo' ), $json->decode( '["foo"]' ), 'decode() did not return expected output' );
 	}
 }

--- a/tests/phpunit/tests/compat/jsonEncodeDecode.php
+++ b/tests/phpunit/tests/compat/jsonEncodeDecode.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @group compat
+ */
+class Tests_Compat_jsonEncodeDecode extends WP_UnitTestCase {
+
+	function test_json_encode_decode() {
+		$this->expectDeprecation();
+
+		require_once ABSPATH . WPINC . '/class-json.php';
+		$json = new Services_JSON();
+		// Super basic test to verify Services_JSON is intact and working.
+		$this->assertSame( '["foo"]', $json->encodeUnsafe( array( 'foo' ) ) );
+		$this->assertSame( array( 'foo' ), $json->decode( '["foo"]' ) );
+	}
+}

--- a/tests/phpunit/tests/compat/mbStrlen.php
+++ b/tests/phpunit/tests/compat/mbStrlen.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @group compat
+ * @group security-153
+ */
+class Tests_Compat_mbStrlen extends WP_UnitTestCase {
+
+	function utf8_string_lengths() {
+		return array(
+			// String, character_length, byte_length.
+			array( 'баба', 4, 8 ),
+			array( 'баб', 3, 6 ),
+			array( 'I am your б', 11, 12 ),
+			array( '1111111111', 10, 10 ),
+			array( '²²²²²²²²²²', 10, 20 ),
+			array( '３３３３３３３３３３', 10, 30 ),
+			array( '𝟜𝟜𝟜𝟜𝟜𝟜𝟜𝟜𝟜𝟜', 10, 40 ),
+			array( '1²３𝟜1²３𝟜1²３𝟜', 12, 30 ),
+		);
+	}
+
+	/**
+	 * @dataProvider utf8_string_lengths
+	 */
+	function test_mb_strlen( $string, $expected_character_length ) {
+		$this->assertSame( $expected_character_length, _mb_strlen( $string, 'UTF-8' ) );
+	}
+
+	/**
+	 * @dataProvider utf8_string_lengths
+	 */
+	function test_mb_strlen_via_regex( $string, $expected_character_length ) {
+		_wp_can_use_pcre_u( false );
+		$this->assertSame( $expected_character_length, _mb_strlen( $string, 'UTF-8' ) );
+		_wp_can_use_pcre_u( 'reset' );
+	}
+
+	/**
+	 * @dataProvider utf8_string_lengths
+	 */
+	function test_8bit_mb_strlen( $string, $expected_character_length, $expected_byte_length ) {
+		$this->assertSame( $expected_byte_length, _mb_strlen( $string, '8bit' ) );
+	}
+}

--- a/tests/phpunit/tests/compat/mbStrlen.php
+++ b/tests/phpunit/tests/compat/mbStrlen.php
@@ -3,34 +3,30 @@
 /**
  * @group compat
  * @group security-153
+ *
+ * @covers ::mb_strlen
+ * @covers ::_mb_strlen
  */
 class Tests_Compat_mbStrlen extends WP_UnitTestCase {
 
-	function utf8_string_lengths() {
-		return array(
-			// String, character_length, byte_length.
-			array( 'баба', 4, 8 ),
-			array( 'баб', 3, 6 ),
-			array( 'I am your б', 11, 12 ),
-			array( '1111111111', 10, 10 ),
-			array( '²²²²²²²²²²', 10, 20 ),
-			array( '３３３３３３３３３３', 10, 30 ),
-			array( '𝟜𝟜𝟜𝟜𝟜𝟜𝟜𝟜𝟜𝟜', 10, 40 ),
-			array( '1²３𝟜1²３𝟜1²３𝟜', 12, 30 ),
-		);
+	/**
+	 * Test that mb_strlen() is always available (either from PHP or WP).
+	 */
+	public function test_mb_strlen_availability() {
+		$this->assertTrue( function_exists( 'mb_strlen' ) );
 	}
 
 	/**
 	 * @dataProvider utf8_string_lengths
 	 */
-	function test_mb_strlen( $string, $expected_character_length ) {
+	public function test_mb_strlen( $string, $expected_character_length ) {
 		$this->assertSame( $expected_character_length, _mb_strlen( $string, 'UTF-8' ) );
 	}
 
 	/**
 	 * @dataProvider utf8_string_lengths
 	 */
-	function test_mb_strlen_via_regex( $string, $expected_character_length ) {
+	public function test_mb_strlen_via_regex( $string, $expected_character_length ) {
 		_wp_can_use_pcre_u( false );
 		$this->assertSame( $expected_character_length, _mb_strlen( $string, 'UTF-8' ) );
 		_wp_can_use_pcre_u( 'reset' );
@@ -39,7 +35,57 @@ class Tests_Compat_mbStrlen extends WP_UnitTestCase {
 	/**
 	 * @dataProvider utf8_string_lengths
 	 */
-	function test_8bit_mb_strlen( $string, $expected_character_length, $expected_byte_length ) {
+	public function test_8bit_mb_strlen( $string, $expected_character_length, $expected_byte_length ) {
 		$this->assertSame( $expected_byte_length, _mb_strlen( $string, '8bit' ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function utf8_string_lengths() {
+		return array(
+			array(
+				'string'                    => 'баба',
+				'expected_character_length' => 4,
+				'expected_byte_length'      => 8,
+			),
+			array(
+				'string'                    => 'баб',
+				'expected_character_length' => 3,
+				'expected_byte_length'      => 6,
+			),
+			array(
+				'string'                    => 'I am your б',
+				'expected_character_length' => 11,
+				'expected_byte_length'      => 12,
+			),
+			array(
+				'string'                    => '1111111111',
+				'expected_character_length' => 10,
+				'expected_byte_length'      => 10,
+			),
+			array(
+				'string'                    => '²²²²²²²²²²',
+				'expected_character_length' => 10,
+				'expected_byte_length'      => 20,
+			),
+			array(
+				'string'                    => '３３３３３３３３３３',
+				'expected_character_length' => 10,
+				'expected_byte_length'      => 30,
+			),
+			array(
+				'string'                    => '𝟜𝟜𝟜𝟜𝟜𝟜𝟜𝟜𝟜𝟜',
+				'expected_character_length' => 10,
+				'expected_byte_length'      => 40,
+			),
+			array(
+				'string'                    => '1²３𝟜1²３𝟜1²３𝟜',
+				'expected_character_length' => 12,
+				'expected_byte_length'      => 30,
+			),
+		);
 	}
 }

--- a/tests/phpunit/tests/compat/mbSubstr.php
+++ b/tests/phpunit/tests/compat/mbSubstr.php
@@ -3,33 +3,30 @@
 /**
  * @group compat
  * @group security-153
+ *
+ * @covers ::mb_substr
+ * @covers ::_mb_substr
  */
 class Tests_Compat_mbSubstr extends WP_UnitTestCase {
 
-	function utf8_substrings() {
-		return array(
-			// String, start, length, character_substring, byte_substring.
-			array( 'баба', 0, 3, 'баб', "б\xD0" ),
-			array( 'баба', 0, -1, 'баб', "баб\xD0" ),
-			array( 'баба', 1, null, 'аба', "\xB1аба" ),
-			array( 'баба', -3, null, 'аба', "\xB1а" ),
-			array( 'баба', -3, 2, 'аб', "\xB1\xD0" ),
-			array( 'баба', -1, 2, 'а', "\xB0" ),
-			array( 'I am your баба', 0, 11, 'I am your б', "I am your \xD0" ),
-		);
+	/**
+	 * Test that mb_substr() is always available (either from PHP or WP).
+	 */
+	public function test_mb_substr_availability() {
+		$this->assertTrue( function_exists( 'mb_substr' ) );
 	}
 
 	/**
 	 * @dataProvider utf8_substrings
 	 */
-	function test_mb_substr( $string, $start, $length, $expected_character_substring ) {
+	public function test_mb_substr( $string, $start, $length, $expected_character_substring ) {
 		$this->assertSame( $expected_character_substring, _mb_substr( $string, $start, $length, 'UTF-8' ) );
 	}
 
 	/**
 	 * @dataProvider utf8_substrings
 	 */
-	function test_mb_substr_via_regex( $string, $start, $length, $expected_character_substring ) {
+	public function test_mb_substr_via_regex( $string, $start, $length, $expected_character_substring ) {
 		_wp_can_use_pcre_u( false );
 		$this->assertSame( $expected_character_substring, _mb_substr( $string, $start, $length, 'UTF-8' ) );
 		_wp_can_use_pcre_u( 'reset' );
@@ -38,100 +35,207 @@ class Tests_Compat_mbSubstr extends WP_UnitTestCase {
 	/**
 	 * @dataProvider utf8_substrings
 	 */
-	function test_8bit_mb_substr( $string, $start, $length, $expected_character_substring, $expected_byte_substring ) {
+	public function test_8bit_mb_substr( $string, $start, $length, $expected_character_substring, $expected_byte_substring ) {
 		$this->assertSame( $expected_byte_substring, _mb_substr( $string, $start, $length, '8bit' ) );
 	}
 
-	function test_mb_substr_phpcore() {
-		/* https://github.com/php/php-src/blob/php-5.6.8/ext/mbstring/tests/mb_substr_basic.phpt */
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function utf8_substrings() {
+		return array(
+			array(
+				'string'                       => 'баба',
+				'start'                        => 0,
+				'length'                       => 3,
+				'expected_character_substring' => 'баб',
+				'expected_byte_substring'      => "б\xD0",
+			),
+			array(
+				'string'                       => 'баба',
+				'start'                        => 0,
+				'length'                       => -1,
+				'expected_character_substring' => 'баб',
+				'expected_byte_substring'      => "баб\xD0",
+			),
+			array(
+				'string'                       => 'баба',
+				'start'                        => 1,
+				'length'                       => null,
+				'expected_character_substring' => 'аба',
+				'expected_byte_substring'      => "\xB1аба",
+			),
+			array(
+				'string'                       => 'баба',
+				'start'                        => -3,
+				'length'                       => null,
+				'expected_character_substring' => 'аба',
+				'expected_byte_substring'      => "\xB1а",
+			),
+			array(
+				'string'                       => 'баба',
+				'start'                        => -3,
+				'length'                       => 2,
+				'expected_character_substring' => 'аб',
+				'expected_byte_substring'      => "\xB1\xD0",
+			),
+			array(
+				'string'                       => 'баба',
+				'start'                        => -1,
+				'length'                       => 2,
+				'expected_character_substring' => 'а',
+				'expected_byte_substring'      => "\xB0",
+			),
+			array(
+				'string'                       => 'I am your баба',
+				'start'                        => 0,
+				'length'                       => 11,
+				'expected_character_substring' => 'I am your б',
+				'expected_byte_substring'      => "I am your \xD0",
+			),
+		);
+	}
+
+	/**
+	 * @link https://github.com/php/php-src/blob/php-5.6.8/ext/mbstring/tests/mb_substr_basic.phpt
+	 */
+	public function test_mb_substr_phpcore_basic() {
 		$string_ascii = 'ABCDEF';
 		$string_mb    = base64_decode( '5pel5pys6Kqe44OG44Kt44K544OI44Gn44GZ44CCMDEyMzTvvJXvvJbvvJfvvJjvvJnjgII=' );
 
-		$this->assertSame( 'DEF', _mb_substr( $string_ascii, 3 ) );
-		$this->assertSame( 'DEF', _mb_substr( $string_ascii, 3, 5, 'ISO-8859-1' ) );
+		$this->assertSame(
+			'DEF',
+			_mb_substr( $string_ascii, 3 ),
+			'Substring does not match expected for offset 3'
+		);
+		$this->assertSame(
+			'DEF',
+			_mb_substr( $string_ascii, 3, 5, 'ISO-8859-1' ),
+			'Substring does not match expected for offset 3, length 5, with iso charset'
+		);
 
 		// Specific latin-1 as that is the default the core PHP test operates under.
-		$this->assertSame( 'peacrOiqng==', base64_encode( _mb_substr( $string_mb, 2, 7, 'latin-1' ) ) );
-		$this->assertSame( '6Kqe44OG44Kt44K544OI44Gn44GZ', base64_encode( _mb_substr( $string_mb, 2, 7, 'utf-8' ) ) );
+		$this->assertSame(
+			'peacrOiqng==',
+			base64_encode( _mb_substr( $string_mb, 2, 7, 'latin-1' ) ),
+			'Substring does not match expected for offset 2, length 7, with latin-1 charset'
+		);
+		$this->assertSame(
+			'6Kqe44OG44Kt44K544OI44Gn44GZ',
+			base64_encode( _mb_substr( $string_mb, 2, 7, 'utf-8' ) ),
+			'Substring does not match expected for offset 2, length 7, with utf-8 charset'
+		);
+	}
 
-		/* https://github.com/php/php-src/blob/php-5.6.8/ext/mbstring/tests/mb_substr_variation1.phpt */
-		$start     = 0;
-		$length    = 5;
-		$unset_var = 10;
-		unset( $unset_var );
-		$heredoc  = <<<EOT
+	/**
+	 * @link https://github.com/php/php-src/blob/php-5.6.8/ext/mbstring/tests/mb_substr_variation1.phpt
+	 *
+	 * @dataProvider data_mb_substr_phpcore_input_type_handling
+	 *
+	 * @param mixed  $input    Input to pass to the function.
+	 * @param string $expected Expected function output.
+	 */
+	public function test_mb_substr_phpcore_input_type_handling( $input, $expected ) {
+		$start  = 0;
+		$length = 5;
+
+		$this->assertSame( $expected, _mb_substr( $input, $start, $length ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_mb_substr_phpcore_input_type_handling() {
+		$heredoc = <<<EOT
 hello world
 EOT;
-		$inputs   = array(
-			0,
-			1,
-			12345,
-			-2345,
-			// Float data.
-			10.5,
-			-10.5,
-			12.3456789000e10,
-			12.3456789000E-10,
-			.5,
-			// Null data.
-			null,
-			null,
-			// Boolean data.
-			true,
-			false,
-			true,
-			false,
-			// Empty data.
-			'',
-			'',
-			// String data.
-			'string',
-			'string',
-			$heredoc,
-			// Object data.
-			new ClassA(),
-			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- intentionally undefined data
-			@$undefined_var,
-			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- intentionally unset data
-			@$unset_var,
-		);
-		$outputs  = array(
-			'0',
-			'1',
-			'12345',
-			'-2345',
-			'10.5',
-			'-10.5',
-			'12345',
-			'1.234',
-			'0.5',
-			'',
-			'',
-			'1',
-			'',
-			'1',
-			'',
-			'',
-			'',
-			'strin',
-			'strin',
-			'hello',
-			'Class',
-			'',
-			'',
-		);
-		$iterator = 0;
-		foreach ( $inputs as $input ) {
-			$this->assertSame( $outputs[ $iterator ], _mb_substr( $input, $start, $length ) );
-			$iterator++;
-		}
 
+		return array(
+			'integer zero'                   => array(
+				'input'    => 0,
+				'expected' => '0',
+			),
+			'integer 1'                      => array(
+				'input'    => 1,
+				'expected' => '1',
+			),
+			'positive integer'               => array(
+				'input'    => 12345,
+				'expected' => '12345',
+			),
+			'negative integer'               => array(
+				'input'    => -2345,
+				'expected' => '-2345',
+			),
+			// Float data.
+			'positive float with fraction'   => array(
+				'input'    => 10.5,
+				'expected' => '10.5',
+			),
+			'negative float with fraction'   => array(
+				'input'    => -10.5,
+				'expected' => '-10.5',
+			),
+			'float scientific whole number'  => array(
+				'input'    => 12.3456789000e10,
+				'expected' => '12345',
+			),
+			'float scientific with fraction' => array(
+				'input'    => 12.3456789000E-10,
+				'expected' => '1.234',
+			),
+			'float, fraction only'           => array(
+				'input'    => .5,
+				'expected' => '0.5',
+			),
+			// Null data.
+			'null'                           => array(
+				'input'    => null,
+				'expected' => '',
+			),
+			// Boolean data.
+			'boolean true'                   => array(
+				'input'    => true,
+				'expected' => '1',
+			),
+			'boolean false'                  => array(
+				'input'    => false,
+				'expected' => '',
+			),
+			// Empty data.
+			'empty string'                   => array(
+				'input'    => '',
+				'expected' => '',
+			),
+			// String data.
+			'double quoted string'           => array(
+				'input'    => "string'",
+				'expected' => 'strin',
+			),
+			'single quoted string'           => array(
+				'input'    => 'string',
+				'expected' => 'strin',
+			),
+			'heredoc string'                 => array(
+				'input'    => $heredoc,
+				'expected' => 'hello',
+			),
+			// Object data.
+			'object with __toString method'  => array(
+				'input'    => new ClassWithToStringForMbSubstr(),
+				'expected' => 'Class',
+			),
+		);
 	}
 }
 
-/* used in test_mb_substr_phpcore */
-class ClassA {
+/* used in data_mb_substr_phpcore_input_type_handling() */
+class ClassWithToStringForMbSubstr {
 	public function __toString() {
-		return 'Class A object';
+		return 'Class object';
 	}
 }

--- a/tests/phpunit/tests/compat/mbSubstr.php
+++ b/tests/phpunit/tests/compat/mbSubstr.php
@@ -1,0 +1,137 @@
+<?php
+
+/**
+ * @group compat
+ * @group security-153
+ */
+class Tests_Compat_mbSubstr extends WP_UnitTestCase {
+
+	function utf8_substrings() {
+		return array(
+			// String, start, length, character_substring, byte_substring.
+			array( 'баба', 0, 3, 'баб', "б\xD0" ),
+			array( 'баба', 0, -1, 'баб', "баб\xD0" ),
+			array( 'баба', 1, null, 'аба', "\xB1аба" ),
+			array( 'баба', -3, null, 'аба', "\xB1а" ),
+			array( 'баба', -3, 2, 'аб', "\xB1\xD0" ),
+			array( 'баба', -1, 2, 'а', "\xB0" ),
+			array( 'I am your баба', 0, 11, 'I am your б', "I am your \xD0" ),
+		);
+	}
+
+	/**
+	 * @dataProvider utf8_substrings
+	 */
+	function test_mb_substr( $string, $start, $length, $expected_character_substring ) {
+		$this->assertSame( $expected_character_substring, _mb_substr( $string, $start, $length, 'UTF-8' ) );
+	}
+
+	/**
+	 * @dataProvider utf8_substrings
+	 */
+	function test_mb_substr_via_regex( $string, $start, $length, $expected_character_substring ) {
+		_wp_can_use_pcre_u( false );
+		$this->assertSame( $expected_character_substring, _mb_substr( $string, $start, $length, 'UTF-8' ) );
+		_wp_can_use_pcre_u( 'reset' );
+	}
+
+	/**
+	 * @dataProvider utf8_substrings
+	 */
+	function test_8bit_mb_substr( $string, $start, $length, $expected_character_substring, $expected_byte_substring ) {
+		$this->assertSame( $expected_byte_substring, _mb_substr( $string, $start, $length, '8bit' ) );
+	}
+
+	function test_mb_substr_phpcore() {
+		/* https://github.com/php/php-src/blob/php-5.6.8/ext/mbstring/tests/mb_substr_basic.phpt */
+		$string_ascii = 'ABCDEF';
+		$string_mb    = base64_decode( '5pel5pys6Kqe44OG44Kt44K544OI44Gn44GZ44CCMDEyMzTvvJXvvJbvvJfvvJjvvJnjgII=' );
+
+		$this->assertSame( 'DEF', _mb_substr( $string_ascii, 3 ) );
+		$this->assertSame( 'DEF', _mb_substr( $string_ascii, 3, 5, 'ISO-8859-1' ) );
+
+		// Specific latin-1 as that is the default the core PHP test operates under.
+		$this->assertSame( 'peacrOiqng==', base64_encode( _mb_substr( $string_mb, 2, 7, 'latin-1' ) ) );
+		$this->assertSame( '6Kqe44OG44Kt44K544OI44Gn44GZ', base64_encode( _mb_substr( $string_mb, 2, 7, 'utf-8' ) ) );
+
+		/* https://github.com/php/php-src/blob/php-5.6.8/ext/mbstring/tests/mb_substr_variation1.phpt */
+		$start     = 0;
+		$length    = 5;
+		$unset_var = 10;
+		unset( $unset_var );
+		$heredoc  = <<<EOT
+hello world
+EOT;
+		$inputs   = array(
+			0,
+			1,
+			12345,
+			-2345,
+			// Float data.
+			10.5,
+			-10.5,
+			12.3456789000e10,
+			12.3456789000E-10,
+			.5,
+			// Null data.
+			null,
+			null,
+			// Boolean data.
+			true,
+			false,
+			true,
+			false,
+			// Empty data.
+			'',
+			'',
+			// String data.
+			'string',
+			'string',
+			$heredoc,
+			// Object data.
+			new ClassA(),
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- intentionally undefined data
+			@$undefined_var,
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- intentionally unset data
+			@$unset_var,
+		);
+		$outputs  = array(
+			'0',
+			'1',
+			'12345',
+			'-2345',
+			'10.5',
+			'-10.5',
+			'12345',
+			'1.234',
+			'0.5',
+			'',
+			'',
+			'1',
+			'',
+			'1',
+			'',
+			'',
+			'',
+			'strin',
+			'strin',
+			'hello',
+			'Class',
+			'',
+			'',
+		);
+		$iterator = 0;
+		foreach ( $inputs as $input ) {
+			$this->assertSame( $outputs[ $iterator ], _mb_substr( $input, $start, $length ) );
+			$iterator++;
+		}
+
+	}
+}
+
+/* used in test_mb_substr_phpcore */
+class ClassA {
+	public function __toString() {
+		return 'Class A object';
+	}
+}


### PR DESCRIPTION
👉🏻 This PR will be easiest to review by examining the individual commits in the order they are lined up in.

This commit splits the tests in the `tests/phpunit/tests/compat.php` file up into individual test classes for each function being tested.

The tests have been reviewed for typical test issues and those issues have been fixed in each test class.
Fixes are along the lines of:
* Adding `@covers` tags.
* Adding visibility modifiers to all methods.
* Adding function availability test.
* Where relevant, fixing the assertion parameter order.
* Where relevant, reworking a test to use a data provider.
* Where relevant, renaming data provider methods to have a more obvious link to the test it applies to.
* Making data providers more readable by adding keys within the data sets and often also updating them to named data sets.
* Making the actual test code more readable by using descriptive variables and multi-line function calls.
* Adding the `$message` parameter to all assertions when a test method contains more than one assertion.
* Adding/removing data sets in data providers.
* Renaming fixture classes to more unique names.

One of the tests was causing errors in PHP 8.1. A fix for this is included in a separate commit.

### PHP 8.1 | Compat/_mb_substr(): fix passing null to non-nullable deprecation

On PHP 8.1, the `_mb_substr()` function would throw a `preg_match_all(): Passing null to parameter #2 ($subject) of type string is deprecated` notice when passed `null`.

To maintain the same behaviour as before, let's just bow out early when `$str` is passed as `null` as the outcome will, in that case, only ever be an empty string.

Note: this does mean that the `_mb_substr()` function now has a subtle difference in behaviour compared to the PHP native `mb_substr()` function as the latter *will* throw the deprecation notice.

The existing tests for the compat function already cover this issue.



Trac ticket: https://core.trac.wordpress.org/ticket/53635
Trac ticket: https://core.trac.wordpress.org/ticket/53363

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
