### PR TITLE
PHP 8.1 | wp_privacy_anonymize_ip(): fix null to non-nullable deprecation (Trac 53635)

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -7618,6 +7618,10 @@ All at ###SITENAME###
  * @return string  The anonymized IP address.
  */
 function wp_privacy_anonymize_ip( $ip_addr, $ipv6_fallback = false ) {
+	if ( empty( $ip_addr ) ) {
+		return '0.0.0.0';
+	}
+
 	// Detect what kind of IP address this is.
 	$ip_prefix = '';
 	$is_ipv6   = substr_count( $ip_addr, ':' ) > 1;

--- a/tests/phpunit/tests/functions/anonymization.php
+++ b/tests/phpunit/tests/functions/anonymization.php
@@ -26,6 +26,8 @@ class Tests_Functions_Anonymization extends WP_UnitTestCase {
 	 * @ticket 41083
 	 * @ticket 43545
 	 *
+	 * @covers ::wp_privacy_anonymize_ip
+	 *
 	 * @param string $raw_ip          Raw IP address.
 	 * @param string $expected_result Expected result.
 	 */
@@ -54,6 +56,22 @@ class Tests_Functions_Anonymization extends WP_UnitTestCase {
 			// Invalid IP.
 			array(
 				null,
+				'0.0.0.0',
+			),
+			array(
+				false,
+				'0.0.0.0',
+			),
+			array(
+				true,
+				'0.0.0.0',
+			),
+			array(
+				0,
+				'0.0.0.0',
+			),
+			array(
+				1,
 				'0.0.0.0',
 			),
 			array(
@@ -165,6 +183,8 @@ class Tests_Functions_Anonymization extends WP_UnitTestCase {
 	 * @ticket 43545
 	 * @requires function inet_ntop
 	 * @requires function inet_pton
+	 *
+	 * @covers ::wp_privacy_anonymize_ip
 	 *
 	 * @param string $raw_ip          Raw IP address.
 	 * @param string $expected_result Expected result.


### PR DESCRIPTION
### Tests_Functions_Anonymization: add a few more invalid IP test cases

... and add extra `@covers` tag for the two functions which are testing the `wp_privacy_anonymize_ip()` function.
(At class level, the `wp_privacy_anonymize_data()` is set as covered).

### PHP 8.1 | wp_privacy_anonymize_ip(): fix null to non-nullable deprecation

The `wp_privacy_anonymize_ip()` function expects a string for the `$ip_addr` parameter, but did not do any input validation.

One of the pre-existing test cases, passed `null` to the function, leading to a `substr_count(): Passing null to parameter #1 ($haystack) of type string is deprecated` notice on PHP 8.1.

Fixed now by doing a cursory check on the variable at the start of the function and bowing out early for a number of cases (`null`, `false`, `0`, `''`) which would all result in the same `0.0.0.0` output anyway.



Trac ticket: https://core.trac.wordpress.org/ticket/53635

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
