### PR TITLE
PHP 8.1 | WP_Comment_Query::get_comment_ids(): fix null to non-nullable deprecation (Trac 53635)

### DIFF
--- a/src/wp-includes/class-wp-comment-query.php
+++ b/src/wp-includes/class-wp-comment-query.php
@@ -801,7 +801,7 @@ class WP_Comment_Query {
 		}
 
 		// Falsey search strings are ignored.
-		if ( strlen( $this->query_vars['search'] ) ) {
+		if ( isset( $this->query_vars['search'] ) && strlen( $this->query_vars['search'] ) ) {
 			$search_sql = $this->get_search_sql(
 				$this->query_vars['search'],
 				array( 'comment_author', 'comment_author_email', 'comment_author_url', 'comment_author_IP', 'comment_content' )


### PR DESCRIPTION
The `WP_Comment_Query::get_comment_ids()` method is supposed to handle `null` as a search query, but was throwing a `strlen(): Passing null to parameter #1 ($string) of type string is deprecated` notice on PHP 8.1.

Discovered via and already covered via the pre-existing `Tests_Comment_Query::test_search_null_should_be_ignored()` test method.

Trac ticket: https://core.trac.wordpress.org/ticket/53635

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
