### PR TITLE
PHP 8.1 | img_caption_shortcode(): change default parameter value (Trac 53635)

### DIFF
--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -2097,10 +2097,10 @@ add_shortcode( 'caption', 'img_caption_shortcode' );
  *     @type string $caption    The caption text.
  *     @type string $class      Additional class name(s) added to the caption container.
  * }
- * @param string $content Shortcode content.
+ * @param string $content Shortcode content. Defaults to an empty string.
  * @return string HTML content to display the caption.
  */
-function img_caption_shortcode( $attr, $content = null ) {
+function img_caption_shortcode( $attr, $content = '' ) {
 	// New-style shortcode with the caption inside the shortcode with the link and image tags.
 	if ( ! isset( $attr['caption'] ) ) {
 		if ( preg_match( '#((?:<a [^>]+>\s*)?<img [^>]+>(?:\s*</a>)?)(.*)#is', $content, $matches ) ) {

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -84,7 +84,7 @@ CAP;
 
 	function test_img_caption_shortcode_with_empty_params() {
 		$result = img_caption_shortcode( array() );
-		$this->assertNull( $result );
+		$this->assertSame( '', $result );
 	}
 
 	/**
@@ -134,7 +134,7 @@ CAP;
 				'caption' => '',
 			)
 		);
-		$this->assertNull( $result );
+		$this->assertSame( '', $result );
 	}
 
 	/**


### PR DESCRIPTION
The `img_caption_shortcode()` method expects a string for the `$content` parameter and is expected to return a string as well.

However, the default value for the `$content` parameter was set to `null` and previously, if the `$content` parameter was not passed, the function would return `null`.

This to me seems more like a bug in the function declaration signature, than anything else, so I'm suggesting to update the default parameter value for `$content`  to an empty string.

This _does_ result in a minor/inconsequential BC break, in that the function will now return an empty string instead of `null` for that situation, but that seems _more correct_ than before and complies with the specification of the function in the docblock.

Tests which specifically tested for `null` being returned have been updated to expect an empty string.

Fixes a few notices in the existing test suite:
```
strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
```

Trac ticket: https://core.trac.wordpress.org/ticket/53635

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
