### PR TITLE
PHP 8.1 | term_exists(): fix null to non-nullable deprecation (Trac 53635)

### DIFF
--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -1480,6 +1480,10 @@ function unregister_term_meta( $taxonomy, $meta_key ) {
 function term_exists( $term, $taxonomy = '', $parent = null ) {
 	global $wpdb;
 
+	if ( null === $term ) {
+		return null;
+	}
+
 	$select     = "SELECT term_id FROM $wpdb->terms as t WHERE ";
 	$tax_select = "SELECT tt.term_id, tt.term_taxonomy_id FROM $wpdb->terms AS t INNER JOIN $wpdb->term_taxonomy as tt ON tt.term_id = t.term_id WHERE ";
 


### PR DESCRIPTION
The `term_exists()` function expects a string or an integer for the `$term` parameter, but did not do any input validation.

One of the pre-existing test cases, passed `null` to the function, leading to a `trim(): Passing null to parameter #1 ($string) of type string is deprecated` notice on PHP 8.1.

Fixed now by doing a cursory check on the variable at the start of the function and bowing out early in case the `$term` is `null`.

Side-note: this function should in all reality be refactored/rewritten to two or three different functions, as the number of different return types for this function introduces a high risk of failure into any code using this function.

The issue was discovered via and is already covered by the `Tests_TermExists::test_term_exists_unknown()` test method.

Trac ticket: https://core.trac.wordpress.org/ticket/53635

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
