### PR TITLE
WP_Test_REST_Widgets_Controller::set_up(): fix widget controller callback (Trac 53635)

### DIFF
--- a/tests/phpunit/tests/rest-api/rest-widgets-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-widgets-controller.php
@@ -109,10 +109,10 @@ class WP_Test_REST_Widgets_Controller extends WP_Test_REST_Controller_Testcase {
 			'testwidget',
 			'WP test widget',
 			static function () {
-				$settings = get_option( 'widget_testwidget' );
-
 				// check if anything's been sent.
 				if ( isset( $_POST['update_testwidget'] ) ) {
+					$settings = get_option( 'widget_testwidget', array() );
+
 					$settings['id']    = $_POST['test_id'];
 					$settings['title'] = $_POST['test_title'];
 


### PR DESCRIPTION
The `get_option()` function will return `false` for a widget which was not previously registered.

In PHP 8.1, this will lead to an `Automatic conversion of false to array is deprecated` notice.

This fixes the test callback to prevent this notice.

Trac ticket: https://core.trac.wordpress.org/ticket/53635

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
