### PR TITLE
PHP 8.1 | WP_UnitTestCase_Base::assertSameIgnoreEOL(): fix null handling and general bugginess (Trac 53635 + 53363)

### DIFF
--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -724,24 +724,36 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 	 * @since 5.8.0 Added support for nested arrays.
 	 * @since 5.9.0 Added the `$message` parameter.
 	 *
-	 * @param string|array $expected The expected value.
-	 * @param string|array $actual   The actual value.
-	 * @param string       $message  Optional. Message to display when the assertion fails.
+	 * @param mixed  $expected The expected value.
+	 * @param mixed  $actual   The actual value.
+	 * @param string $message  Optional. Message to display when the assertion fails.
 	 */
 	public function assertSameIgnoreEOL( $expected, $actual, $message = '' ) {
-		$expected = map_deep(
-			$expected,
-			static function ( $value ) {
-				return str_replace( "\r\n", "\n", $value );
-			}
-		);
+		if ( null !== $expected ) {
+			$expected = map_deep(
+				$expected,
+				static function ( $value ) {
+					if ( is_string( $value ) ) {
+						return str_replace( "\r\n", "\n", $value );
+					}
 
-		$actual = map_deep(
-			$actual,
-			static function ( $value ) {
-				return str_replace( "\r\n", "\n", $value );
-			}
-		);
+					return $value;
+				}
+			);
+		}
+
+		if ( null !== $actual ) {
+			$actual = map_deep(
+				$actual,
+				static function ( $value ) {
+					if ( is_string( $value ) ) {
+						return str_replace( "\r\n", "\n", $value );
+					}
+
+					return $value;
+				}
+			);
+		}
 
 		$this->assertSame( $expected, $actual, $message );
 	}
@@ -753,8 +765,8 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 	 * @since 5.6.0 Turned into an alias for `::assertSameIgnoreEOL()`.
 	 * @since 5.9.0 Added the `$message` parameter.
 	 *
-	 * @param string $expected The expected value.
-	 * @param string $actual   The actual value.
+	 * @param mixed  $expected The expected value.
+	 * @param mixed  $actual   The actual value.
 	 * @param string $message  Optional. Message to display when the assertion fails.
 	 */
 	public function assertEqualsIgnoreEOL( $expected, $actual, $message = '' ) {


### PR DESCRIPTION
Okay, so this one takes a little explaining.

Basically, the whole `assertSameIgnoreEOL()` assertion was fundamentally flawed. The assertion contends that it checks that the expected and actual values are of the same type and value, but the reality was very different.

* The function uses `map_deep()` to potentially handle all sorts of inputs.
* `map_deep()` handles arrays and objects with special casing, but will call the callback on everything else without further distinction.
* The callback used passes the expected/actual value on to the `str_replace()` function to remove potential new line differences.
* And the `str_replace()` function will - with a non-array input for the `$subject` - always return a string.
* The output of these calls to `map_deep()` will therefore have "normalized" _all properties_ in objects, _all values_ in arrays and _all non-object, non-array values_ to strings.
* And a call to `assertSame()` will therefore NEVER do a proper type check as the type of all input has already, unintentionally, been "normalized" to string.

Aside from this clear flaw in the design of the assertion, PHP 8.1 now exposes a further issue as a `null` value for an object property, an array value or a plain value, will now yield a ` str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated` notice.

To fix both these issues, the fix in this PR ensures that the call to `str_replace()` will now only be made if the input is a text string.
All other values passed to the callback are left in their original type.

This ensures that a proper value AND type comparison can be done as well as prevents the PHP 8.1 deprecation notices.

Includes adjusting the method documentation for both this method and the `assertEqualsIgnoreEOL()` alias method to document that the `$expected` and `$actual` parameters can be of any type.

Ref:
* https://developer.wordpress.org/reference/functions/map_deep/
* https://www.php.net/manual/en/function.str-replace.php

👉🏻 **Note: I'm fully aware that this change _may_ cause existing tests using these assertions to fail. (all the more reason to run this PR through GH) If any tests _would_ fail those tests should be investigated and fixed. Those failures should not be a reason for not accepting this patch.**


Trac ticket: https://core.trac.wordpress.org/ticket/53635
Trac ticket: https://core.trac.wordpress.org/ticket/53363

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
