### PR TITLE
Add the ability to enqueue block scripts in footer via a new keys in block.json

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -66,13 +66,15 @@ function generate_block_asset_handle( $block_name, $field_name ) {
  * generated handle name. It returns unprocessed script handle otherwise.
  *
  * @since 5.5.0
+ * @since 5.9.0 Added `$enqueue_in_footer` parameter.
  *
- * @param array  $metadata   Block metadata.
- * @param string $field_name Field name to pick from metadata.
+ * @param array  $metadata          Block metadata.
+ * @param string $field_name        Field name to pick from metadata.
+ * @param bool   $enqueue_in_footer Whether to enqueue the script in footer or not.
  * @return string|false Script handle provided directly or created through
  *                      script's registration, or false on failure.
  */
-function register_block_script_handle( $metadata, $field_name ) {
+function register_block_script_handle( $metadata, $field_name, $enqueue_in_footer = false ) {
 	if ( empty( $metadata[ $field_name ] ) ) {
 		return false;
 	}
@@ -111,7 +113,7 @@ function register_block_script_handle( $metadata, $field_name ) {
 		$script_uri,
 		$script_dependencies,
 		isset( $script_asset['version'] ) ? $script_asset['version'] : false,
-		isset( $metadata['enqueueFooter'] ) ? boolval( $metadata['enqueueFooter'] ) : false
+		$enqueue_in_footer
 	);
 	if ( ! $result ) {
 		return false;
@@ -210,7 +212,8 @@ function get_block_metadata_i18n_schema() {
  *
  * @since 5.5.0
  * @since 5.7.0 Added support for `textdomain` field and i18n handling for all translatable fields.
- * @since 5.9.0 Added support for `variations` and `viewScript` fields.
+ * @since 5.9.0 Added support for `variations`, `viewScript`, 'enqueueEditorFooter' and 'enqueueScriptFooter'
+ *              fields.
  *
  * @param string $file_or_folder Path to the JSON file with metadata definition for
  *                               the block or path to the folder where the `block.json` file is located.
@@ -287,14 +290,16 @@ function register_block_type_from_metadata( $file_or_folder, $args = array() ) {
 	if ( ! empty( $metadata['editorScript'] ) ) {
 		$settings['editor_script'] = register_block_script_handle(
 			$metadata,
-			'editorScript'
+			'editorScript',
+			isset( $metadata['enqueueEditorFooter'] ) ? boolval( $metadata['enqueueEditorFooter'] ) : false
 		);
 	}
 
 	if ( ! empty( $metadata['script'] ) ) {
 		$settings['script'] = register_block_script_handle(
 			$metadata,
-			'script'
+			'script',
+			isset( $metadata['enqueueScriptFooter'] ) ? boolval( $metadata['enqueueScriptFooter'] ) : false
 		);
 	}
 

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -110,7 +110,8 @@ function register_block_script_handle( $metadata, $field_name ) {
 		$script_handle,
 		$script_uri,
 		$script_dependencies,
-		isset( $script_asset['version'] ) ? $script_asset['version'] : false
+		isset( $script_asset['version'] ) ? $script_asset['version'] : false,
+		isset( $metadata['enqueueFooter'] ) ? boolval( $metadata['enqueueFooter'] ) : false
 	);
 	if ( ! $result ) {
 		return false;


### PR DESCRIPTION
This PR accepts the new boolean keys `enqueueEditorFooter` and `enqueueScriptFooter` in `$metadata` to whether or not enqueue the script in footer.

**Usage**

Just add `enqueueScriptFooter: true` if you want to enqueue the `script` in the footer and/or `enqueueEditorFooter: true` for the editor-facing script in your `block.json`.

**Example `block.json`**

```js
{
	"apiVersion": 2,
	"name": "mico/block-example",
	"title": "Mico Test Block",
	"description": "Mico Test Block",
	"attributes": {
		"heading": {
			"type": "string",
			"default": ""
		}
	},
	"textdomain": "mico",
	"enqueueScriptFooter": true,
	"script": "file:./build/script.js",
        "enqueueEditorFooter": true,
        "editorScript": "file:./build/index.js"
}

```

Trac ticket: https://core.trac.wordpress.org/ticket/54018

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
