### PR TITLE
 PHP 8.1: (get|add|update|delete)_option: fix null to non-nullable deprecations (Trac 53635)

### DIFF
--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -77,7 +77,10 @@
 function get_option( $option, $default = false ) {
 	global $wpdb;
 
-	$option = trim( $option );
+	if ( is_scalar( $option ) ) {
+		$option = trim( $option );
+	}
+
 	if ( empty( $option ) ) {
 		return false;
 	}
@@ -378,7 +381,10 @@ function wp_load_core_site_options( $network_id = null ) {
 function update_option( $option, $value, $autoload = null ) {
 	global $wpdb;
 
-	$option = trim( $option );
+	if ( is_scalar( $option ) ) {
+		$option = trim( $option );
+	}
+
 	if ( empty( $option ) ) {
 		return false;
 	}
@@ -565,7 +571,10 @@ function add_option( $option, $value = '', $deprecated = '', $autoload = 'yes' )
 		_deprecated_argument( __FUNCTION__, '2.3.0' );
 	}
 
-	$option = trim( $option );
+	if ( is_scalar( $option ) ) {
+		$option = trim( $option );
+	}
+
 	if ( empty( $option ) ) {
 		return false;
 	}
@@ -687,7 +696,10 @@ function add_option( $option, $value = '', $deprecated = '', $autoload = 'yes' )
 function delete_option( $option ) {
 	global $wpdb;
 
-	$option = trim( $option );
+	if ( is_scalar( $option ) ) {
+		$option = trim( $option );
+	}
+
 	if ( empty( $option ) ) {
 		return false;
 	}

--- a/tests/phpunit/tests/option/option.php
+++ b/tests/phpunit/tests/option/option.php
@@ -149,6 +149,66 @@ class Tests_Option_Option extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 53635
+	 *
+	 * @dataProvider data_valid_but_undesired_option_names
+	 *
+	 * @param mixed $option_name Option name.
+	 */
+	public function test_get_option_valid_but_undesired_option_names( $option_name ) {
+		$this->assertFalse( get_option( $option_name ) );
+	}
+
+	/**
+	 * @ticket 53635
+	 *
+	 * @dataProvider data_valid_but_undesired_option_names
+	 *
+	 * @param mixed $option_name Option name.
+	 */
+	public function test_add_option_valid_but_undesired_option_names( $option_name ) {
+		$this->assertTrue( add_option( $option_name, '' ) );
+	}
+
+	/**
+	 * @ticket 53635
+	 *
+	 * @dataProvider data_valid_but_undesired_option_names
+	 *
+	 * @param mixed $option_name Option name.
+	 */
+	public function test_update_option_valid_but_undesired_option_names( $option_name ) {
+		$this->assertTrue( update_option( $option_name, '' ) );
+	}
+
+	/**
+	 * @ticket 53635
+	 *
+	 * @dataProvider data_valid_but_undesired_option_names
+	 *
+	 * @param mixed $option_name Option name.
+	 */
+	public function test_delete_option_valid_but_undesired_option_names( $option_name ) {
+		$this->assertFalse( delete_option( $option_name ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_valid_but_undesired_option_names() {
+		return array(
+			'string 123'   => array( '123' ),
+			'integer 123'  => array( 123 ),
+			'integer -123' => array( -123 ),
+			'float 12.3'   => array( 12.3 ),
+			'float -1.23'  => array( -1.23 ),
+			'boolean true' => array( true ),
+		);
+	}
+
+	/**
 	 * @ticket 23289
 	 */
 	function test_special_option_name_alloption() {

--- a/tests/phpunit/tests/option/option.php
+++ b/tests/phpunit/tests/option/option.php
@@ -142,6 +142,7 @@ class Tests_Option_Option extends WP_UnitTestCase {
 			'string 0'            => array( '0' ),
 			'string single space' => array( ' ' ),
 			'integer 0'           => array( 0 ),
+			'float 0.0'           => array( 0.0 ),
 			'boolean false'       => array( false ),
 			'null'                => array( null ),
 		);

--- a/tests/phpunit/tests/option/option.php
+++ b/tests/phpunit/tests/option/option.php
@@ -89,14 +89,62 @@ class Tests_Option_Option extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 23289
+	 *
+	 * @dataProvider data_bad_option_names
+	 *
+	 * @param mixed $option_name Option name.
 	 */
-	function test_bad_option_names() {
-		foreach ( array( '', '0', ' ', 0, false, null ) as $empty ) {
-			$this->assertFalse( get_option( $empty ) );
-			$this->assertFalse( add_option( $empty, '' ) );
-			$this->assertFalse( update_option( $empty, '' ) );
-			$this->assertFalse( delete_option( $empty ) );
-		}
+	public function test_get_option_bad_option_name( $option_name ) {
+		$this->assertFalse( get_option( $option_name ) );
+	}
+
+	/**
+	 * @ticket 23289
+	 *
+	 * @dataProvider data_bad_option_names
+	 *
+	 * @param mixed $option_name Option name.
+	 */
+	public function test_add_option_bad_option_name( $option_name ) {
+		$this->assertFalse( add_option( $option_name, '' ) );
+	}
+
+	/**
+	 * @ticket 23289
+	 *
+	 * @dataProvider data_bad_option_names
+	 *
+	 * @param mixed $option_name Option name.
+	 */
+	public function test_update_option_bad_option_name( $option_name ) {
+		$this->assertFalse( update_option( $option_name, '' ) );
+	}
+
+	/**
+	 * @ticket 23289
+	 *
+	 * @dataProvider data_bad_option_names
+	 *
+	 * @param mixed $option_name Option name.
+	 */
+	public function test_delete_option_bad_option_name( $option_name ) {
+		$this->assertFalse( delete_option( $option_name ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_bad_option_names() {
+		return array(
+			'empty string'        => array( '' ),
+			'string 0'            => array( '0' ),
+			'string single space' => array( ' ' ),
+			'integer 0'           => array( 0 ),
+			'boolean false'       => array( false ),
+			'null'                => array( null ),
+		);
 	}
 
 	/**


### PR DESCRIPTION
### Tests_Option_Option::test_bad_option_names(): rework to data provider

* Rework the test method to use a data provider with named data sets instead of a `foreach()`.
* Add method visibility modifiers.
* Add the `$message` parameter for each assertion.

### Tests_Option_Option::test_bad_option_names(): add one extra test case

### Tests_Option_Option: add tests for valid, but undesired option names

... to safeguard against regressions which a potential fix to the base issue may cause.

### PHP 8.1: (get|add|update|delete)_option: fix null to non-nullable deprecations

In all four of the `get_option()`, `add_option()`, `update_option()` and `delete_option()` functions, the `$option` parameter is passed to the PHP native `trim()` function without prior validation.

In PHP 8.1, this could lead to a `trim(): Passing null to parameter #1 ($string) of type string is deprecated` for each of these methods.

`trim()` expects a text string and is only useful when _passed_ a text string as no other variable type can contain whitespace.
At the same time, `trim()` will always return a `string`, which means that in practice for any non-string values passed, it would effectively function as a type cast to string.

Fixed now by verifying that the `$option` is a scalar before processing it with `trim()`. This maintains the "type cast" behaviour, while still preventing the PHP deprecation if the `$option` name would be `null`.

This issue is already covered by the existing `Tests_Option_Option::test_bad_option_names()` test group and the new `test_valid_but_undesired_option_names()` tests.



Trac ticket: https://core.trac.wordpress.org/ticket/53635

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
