### PR TITLE
PHP 8.1: WP_Meta_Query::get_sql_for_clause(): fix null to non-nullable deprecations (Trac 53635)

### DIFF
--- a/src/wp-includes/class-wp-meta-query.php
+++ b/src/wp-includes/class-wp-meta-query.php
@@ -691,7 +691,7 @@ class WP_Meta_Query {
 				if ( ! is_array( $meta_value ) ) {
 					$meta_value = preg_split( '/[,\s]+/', $meta_value );
 				}
-			} else {
+			} elseif ( is_string( $meta_value ) ) {
 				$meta_value = trim( $meta_value );
 			}
 


### PR DESCRIPTION
In the `WP_Meta_Query::get_sql_for_clause()`, the `'value'` index from a meta query array is passed to the PHP native `trim()` function without prior validation.

In PHP 8.1, this could lead to a `trim(): Passing null to parameter #1 ($string) of type string is deprecated` notice.

`trim()` expects a text string and is only useful when _passed_ a text string as no other variable type can contain whitespace.

Fixed now by verifying that the _value_ is a string before processing it with `trim()`.

This issue is already covered by the existing `Tests_Meta_Query::test_null_value_sql()` and the `Tests_Meta_Query::test_convert_null_value_to_empty_string(0` tests.

Trac ticket: https://core.trac.wordpress.org/ticket/53635

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
