### PR TITLE
Removes installing Composer dependencies from install.js (Trac 53945)

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
 		"env:logs": "node ./tools/local-env/scripts/docker.js logs",
 		"env:pull": "node ./tools/local-env/scripts/docker.js pull",
 		"test:php": "node ./tools/local-env/scripts/docker.js run -T php composer update -W && node ./tools/local-env/scripts/docker.js run --rm phpunit phpunit",
-		"test:php-composer": "node ./tools/local-env/scripts/docker.js run -T php composer update -W && node ./tools/local-env/scripts/docker.js run --rm phpunit php ./vendor/bin/phpunit",
+		"test:php-composer": "node ./tools/local-env/scripts/docker.js run --rm phpunit php ./vendor/bin/phpunit",
 		"test:e2e": "node ./tests/e2e/run-tests.js",
 		"wp-packages-update": "wp-scripts packages-update"
 	}

--- a/tools/local-env/scripts/install.js
+++ b/tools/local-env/scripts/install.js
@@ -22,8 +22,6 @@ renameSync( 'src/wp-config.php', 'wp-config.php' );
 
 install_wp_importer();
 
-install_composer_dependencies();
-
 // Read in wp-tests-config-sample.php, edit it to work with our config, then write it to wp-tests-config.php.
 const testConfig = readFileSync( 'wp-tests-config-sample.php', 'utf8' )
 	.replace( 'youremptytestdbnamehere', 'wordpress_develop_tests' )
@@ -58,11 +56,4 @@ function install_wp_importer() {
 
 	execSync( `docker-compose exec -T php rm -rf ${testPluginDirectory}`, { stdio: 'inherit' } );
 	execSync( `docker-compose exec -T php git clone https://github.com/WordPress/wordpress-importer.git ${testPluginDirectory} --depth=1`, { stdio: 'inherit' } );
-}
-
-/**
- * Installs the Composer package dependencies within the Docker environment.
- */
-function install_composer_dependencies() {
-	execSync( `docker-compose run -T php composer update -W`, { stdio: 'inherit' } );
 }


### PR DESCRIPTION
In [51685] added `install_composer_dependencies()` to `tools/local-env/scripts/install.js` to handle installing the
Composer dependencies during the npm installation workflow.

However, testers doing manual testing do not need these dependencies installed. This addition added extra and
unnecessary step up time for contributors.

By removing the installation of the Composer dependencies from the npm installation process, the dependencies will be installed when needed, i.e. when running `npm run test:php`.

This also fixes the introduced problem that broke running tests on PHP 8.1.

Trac ticket: https://core.trac.wordpress.org/ticket/53945

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
