### PR TITLE
adding $allowedxmlnamedentities to global

### DIFF
--- a/src/wp-includes/functions.wp-scripts.php
+++ b/src/wp-includes/functions.wp-scripts.php
@@ -186,7 +186,7 @@ function wp_register_script( $handle, $src, $deps = array(), $ver = false, $in_f
 /**
  * Localize a script.
  *
- * Works only if the script has already been added.
+ * Works only if the script has already been registered.
  *
  * Accepts an associative array $l10n and creates a JavaScript object:
  *
@@ -224,7 +224,7 @@ function wp_localize_script( $handle, $object_name, $l10n ) {
 /**
  * Sets translated strings for a script.
  *
- * Works only if the script has already been added.
+ * Works only if the script has already been registered.
  *
  * @see WP_Scripts::set_translations()
  * @global WP_Scripts $wp_scripts The WP_Scripts object for printing scripts.
@@ -402,7 +402,7 @@ function wp_script_is( $handle, $list = 'enqueued' ) {
 /**
  * Add metadata to a script.
  *
- * Works only if the script has already been added.
+ * Works only if the script has already been registered.
  *
  * Possible values for $key and $value:
  * 'conditional' string Comments for IE 6, lte IE 7, etc.

--- a/src/wp-includes/functions.wp-styles.php
+++ b/src/wp-includes/functions.wp-styles.php
@@ -217,7 +217,7 @@ function wp_style_is( $handle, $list = 'enqueued' ) {
 /**
  * Add metadata to a CSS stylesheet.
  *
- * Works only if the stylesheet has already been added.
+ * Works only if the stylesheet has already been registered.
  *
  * Possible values for $key and $value:
  * 'conditional' string      Comments for IE 6, lte IE 7 etc.

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -11,12 +11,13 @@ class Tests_Kses extends WP_UnitTestCase {
 	 * Test callback for `wp_kses_normalize_entities()` regular expression.
 	 *
 	 * @dataProvider  data_wp_kses_xml_named_entities
-	 * @covers ::wp_kses_xml_named_entities
+	 *
 	 * @ticket 54060
 	 *
-	 * @param array  $input     Expected input.
-	 * @param string $expected  Expected output.
-	 * @return void
+	 * @covers ::wp_kses_xml_named_entities
+	 *
+	 * @param array  $input     The input to wp_kses_xml_named_entities.
+	 * @param string $expected  The expected output.
 	 */
 	public function test_wp_kses_xml_named_entities( $input, $expected ) {
 		$this->assertSame( $expected, wp_kses_xml_named_entities( $input ) );
@@ -31,24 +32,86 @@ class Tests_Kses extends WP_UnitTestCase {
 		return array(
 
 			// null value testing.
-			'null'       => array( '', '' ),
+			'null'       => array(
+				'input'    => '',
+				'expected' => '',
+			),
 
 			// null array value testing.
-			'null array' => array( array( '', '' ), '' ),
+			'null array' => array(
+				'input'    => array( '', '' ),
+				'expected' => '',
+			),
 
 			// $allowedxmlnamedentities values testing.
-			'amp'        => array( array( '', 'amp' ), '&amp;' ),
-			'lt'         => array( array( '', 'lt' ), '&lt;' ),
-			'gt'         => array( array( '', 'gt' ), '&gt;' ),
+			'amp'        => array(
+				'input'    => array( '', 'amp' ),
+				'expected' => '&amp;',
+			),
+			'lt'         => array(
+				'input'    => array( '', 'lt' ),
+				'expected' => '&lt;',
+			),
+			'gt'         => array(
+				'input'    => array( '', 'gt' ),
+				'expected' => '&gt;',
+			),
 
 			// $allowedentitynames values testing.
-			'nbsp'       => array( array( '', 'nbsp' ), html_entity_decode( '&nbsp;', ENT_HTML5 ) ),
-			'iexcl'      => array( array( '', 'iexcl' ), html_entity_decode( '&iexcl;', ENT_HTML5 ) ),
-			'cent'       => array( array( '', 'cent' ), html_entity_decode( '&cent;', ENT_HTML5 ) ),
+			'nbsp'       => array(
+				'input'    => array( '', 'nbsp' ),
+				'expected' => utf8_encode( chr( 160 ) ),
+			),
+			'iexcl'      => array(
+				'input'    => array( '', 'iexcl' ),
+				'expected' => '¡',
+			),
+			'cent'       => array(
+				'input'    => array( '', 'cent' ),
+				'expected' => '¢',
+			),
 
 			// some other value testing.
-			'test'       => array( array( '', 'test' ), '&amp;test;' ),
+			'test'       => array(
+				'input'    => array( '', 'test' ),
+				'expected' => '&amp;test;',
+			),
 
+		);
+	}
+
+	/**
+	 * Tests that a kses global is defined.
+	 *
+	 * @dataProvider data_kses_global_is_defined
+	 *
+	 * @ticket 54060
+	 *
+	 * @param string $global  The name of the global variable.
+	 */
+	public function test_kses_global_is_defined( $global ) {
+		$this->assertArrayHasKey( $global, $GLOBALS );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_kses_global_is_defined() {
+		return array(
+			'allowedposttags'         => array(
+				'global' => 'allowedposttags',
+			),
+			'allowedtags'             => array(
+				'global' => 'allowedtags',
+			),
+			'allowedentitynames'      => array(
+				'global' => 'allowedentitynames',
+			),
+			'allowedxmlnamedentities' => array(
+				'global' => 'allowedxmlnamedentities',
+			),
 		);
 	}
 

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -11,7 +11,7 @@ class Tests_Kses extends WP_UnitTestCase {
 	 * Test callback for `wp_kses_normalize_entities()` regular expression.
 	 *
 	 * @dataProvider  data_wp_kses_xml_named_entities
-	 *
+	 * @covers ::wp_kses_xml_named_entities
 	 * @ticket 54060
 	 *
 	 * @param array  $input     Expected input.

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -6,7 +6,54 @@
  * @group kses
  */
 class Tests_Kses extends WP_UnitTestCase {
+	
+	/**
+	 * Test callback for `wp_kses_normalize_entities()` regular expression.
+	 *
+	 * @dataProvider  data_wp_kses_xml_named_entities
+	 *
+	 * @ticket 54060
+	 *
+	 * @param array  $input     Expected input.
+	 * @param string $expected  Expected output.
+	 * @return void
+	 */
+	public function test_wp_kses_xml_named_entities( $input, $expected ) {
 
+		$this->assertSame( $expected, wp_kses_xml_named_entities( $input ) );
+
+	}
+
+	/**
+	 * Data provider testing kses named entities.
+	 *
+	 * @return array Nested array of input, expected pairs.
+	 */
+	public function data_wp_kses_xml_named_entities() {
+		return array(
+
+			// null value testing.
+			'null'       => array( '', '' ),
+
+			// null array value testing.
+			'null array' => array( array( '', '' ), '' ),
+
+			// $allowedxmlnamedentities values testing.
+			'amp'        => array( array( '', 'amp' ), '&amp;' ),
+			'lt'         => array( array( '', 'lt' ), '&lt;' ),
+			'gt'         => array( array( '', 'gt' ), '&gt;' ),
+
+			// $allowedentitynames values testing.
+			'nbsp'       => array( array( '', 'nbsp' ), html_entity_decode( '&nbsp;', ENT_HTML5 ) ),
+			'iexcl'      => array( array( '', 'iexcl' ), html_entity_decode( '&iexcl;', ENT_HTML5 ) ),
+			'cent'       => array( array( '', 'cent' ), html_entity_decode( '&cent;', ENT_HTML5 ) ),
+
+			// some other value testing.
+			'test'       => array( array( '', 'test' ), '&amp;test;' ),
+
+		);
+	}
+	
 	/**
 	 * @dataProvider data_wp_filter_post_kses_address
 	 * @ticket 20210

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -6,7 +6,7 @@
  * @group kses
  */
 class Tests_Kses extends WP_UnitTestCase {
-	
+
 	/**
 	 * Test callback for `wp_kses_normalize_entities()` regular expression.
 	 *
@@ -19,9 +19,7 @@ class Tests_Kses extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_wp_kses_xml_named_entities( $input, $expected ) {
-
 		$this->assertSame( $expected, wp_kses_xml_named_entities( $input ) );
-
 	}
 
 	/**
@@ -53,7 +51,7 @@ class Tests_Kses extends WP_UnitTestCase {
 
 		);
 	}
-	
+
 	/**
 	 * @dataProvider data_wp_filter_post_kses_address
 	 * @ticket 20210


### PR DESCRIPTION
This PR should address a naming mismatch and make the `$allowedxmlnamedentities` referenced on the kses.php file a global variable


Trac ticket: https://core.trac.wordpress.org/ticket/54060
