### PR TITLE
Updated safecss_filter_attr function's doc block

### DIFF
--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -2152,6 +2152,16 @@ function kses_init() {
  * Filters an inline style attribute and removes disallowed rules.
  *
  * @since 2.8.1
+ * @since 4.4.0 Added support for `min-height`, `max-height`, `min-width`, and `max-width`.
+ * @since 4.6.0 Added support for `list-style-type`.
+ * @since 5.0.0 Added support for `background-image`.
+ * @since 5.1.0 Added support for `text-transform`.
+ * @since 5.2.0 Added support for `background-position` and `grid-template-columns`.
+ * @since 5.3.0 Added support for `grid`, `flex` and `column` layout properties.
+ *              Extend `background-*` support of individual properties.
+ * @since 5.3.1 Added support for gradient backgrounds.
+ * @since 5.7.1 Added support for `object-position`.
+ * @since 5.8.0 Added support for `calc()` and `var()` values.
  *
  * @param string $css        A string of CSS rules.
  * @param string $deprecated Not used.
@@ -2173,16 +2183,6 @@ function safecss_filter_attr( $css, $deprecated = '' ) {
 	 * Filters list of allowed CSS attributes.
 	 *
 	 * @since 2.8.1
-	 * @since 4.4.0 Added support for `min-height`, `max-height`, `min-width`, and `max-width`.
-	 * @since 4.6.0 Added support for `list-style-type`.
-	 * @since 5.0.0 Added support for `background-image`.
-	 * @since 5.1.0 Added support for `text-transform`.
-	 * @since 5.2.0 Added support for `background-position` and `grid-template-columns`.
-	 * @since 5.3.0 Added support for `grid`, `flex` and `column` layout properties.
-	 *              Extend `background-*` support of individual properties.
-	 * @since 5.3.1 Added support for gradient backgrounds.
-	 * @since 5.7.1 Added support for `object-position`.
-	 * @since 5.8.0 Added support for `calc()` and `var()` values.
 	 *
 	 * @param string[] $attr Array of allowed CSS attributes.
 	 */


### PR DESCRIPTION
Updated safecss_filter_attr function's doc block.
Shifted the updates for this function from 'safe_style_css' filter doc block to the  safecss_filter_attr function's doc block.

Trac ticket: https://core.trac.wordpress.org/ticket/53731

File details
wp-includes/wp-includes/kses.php line 2152.
wp-includes/wp-includes/kses.php line 2183.
https://github.com/MuhammadFaizanHaidar/wordpress-develop/blob/master/src/wp-includes/kses.php