### PR TITLE
Correctly allow a term of slug of (string) '0'.

### DIFF
--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -2325,6 +2325,9 @@ function wp_insert_term( $term, $taxonomy, $args = array() ) {
 	// Coerce null description to strings, to avoid database errors.
 	$args['description'] = (string) $args['description'];
 
+	// Store a slug of '0' before sanitizing
+	$slug_is_0_string = '0' === $args['slug'];
+
 	$args = sanitize_term( $args, $taxonomy, 'db' );
 
 	// expected_slashed ($name)
@@ -2332,7 +2335,7 @@ function wp_insert_term( $term, $taxonomy, $args = array() ) {
 	$description = wp_unslash( $args['description'] );
 	$parent      = (int) $args['parent'];
 
-	$slug_provided = ! empty( $args['slug'] );
+	$slug_provided = ! empty( $args['slug'] ) || $slug_is_0_string;
 	if ( ! $slug_provided ) {
 		$slug = sanitize_title( $name );
 	} else {
@@ -3103,7 +3106,7 @@ function wp_update_term( $term_id, $taxonomy, $args = array() ) {
 	}
 
 	$empty_slug = false;
-	if ( empty( $args['slug'] ) ) {
+	if ( empty( $args['slug'] ) && '0' !== $args['slug'] ) {
 		$empty_slug = true;
 		$slug       = sanitize_title( $name );
 	} else {
@@ -3199,7 +3202,7 @@ function wp_update_term( $term_id, $taxonomy, $args = array() ) {
 
 	$wpdb->update( $wpdb->terms, $data, compact( 'term_id' ) );
 
-	if ( empty( $slug ) ) {
+	if ( empty( $slug ) && '0' !== $slug ) {
 		$slug = sanitize_title( $name, $term_id );
 		$wpdb->update( $wpdb->terms, compact( 'slug' ), compact( 'term_id' ) );
 	}

--- a/tests/phpunit/tests/term/wpInsertTerm.php
+++ b/tests/phpunit/tests/term/wpInsertTerm.php
@@ -182,6 +182,25 @@ class Tests_Term_WpInsertTerm extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 39678
+	 */
+	public function test_wp_insert_term_slug_0_string() {
+		register_taxonomy( 'wptests_tax', 'post' );
+		$found = wp_insert_term(
+			'Quality',
+			'wptests_tax',
+			array(
+				'slug' => '0',
+			)
+		);
+
+		$term = get_term( $found['term_id'], 'wptests_tax' );
+		_unregister_taxonomy( 'wptests_tax' );
+
+		$this->assertSame( '0', $term->slug );
+	}
+
+	/**
 	 * @ticket 17689
 	 */
 	public function test_wp_insert_term_duplicate_name() {

--- a/tests/phpunit/tests/term/wpUpdateTerm.php
+++ b/tests/phpunit/tests/term/wpUpdateTerm.php
@@ -185,6 +185,30 @@ class Tests_Term_WpUpdateTerm extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 39678
+	 */
+	public function test_wp_update_term_slug_set_slug_as_0_string() {
+		register_taxonomy( 'wptests_tax', 'post' );
+		$t = self::factory()->term->create(
+			array(
+				'taxonomy' => 'wptests_tax',
+			)
+		);
+
+		$found = wp_update_term(
+			$t,
+			'wptests_tax',
+			array(
+				'slug' => '0',
+			)
+		);
+
+		$term = get_term( $t, 'wptests_tax' );
+		$this->assertSame( '0', $term->slug );
+		_unregister_taxonomy( 'wptests_tax' );
+	}
+
+	/**
 	 * @ticket 5809
 	 */
 	public function test_wp_update_term_should_not_create_duplicate_slugs_within_the_same_taxonomy() {


### PR DESCRIPTION
`wp_insert_term()` and `wp_update_term()` did not allow a term to be given a slug of `(string) '0'`.

This was due to:
1. Sanitizing the provided value; this would turn `(int) 0` into `(string) '0'`.
2. Using `empty()` to check for an empty value; this returns `true` for `(string) '0'`.

This gave a false sense of security, as it correctly captured a disallowed value of `(int) 0` and generated a slug from the term name. Unfortunately, this process also incorrectly prevented a value of `(string) '0'`, which the docs suggest is an allowed value.

This patch:
1. Stores whether or not the slug was `(string) '0'` prior to sanitization and adds this to an existing conditional (only in one case).
2. Adds additional checks for `'0' === $args['slug']`, `'0' !== $slug`, etc. as needed.
3. Adds unit tests for `wp_insert_term()` and `wp_update_term()`.

Trac ticket: https://core.trac.wordpress.org/ticket/39678
