### PR TITLE
fix MockAction::get_call_count correct usage & for filters

### DIFF
--- a/tests/phpunit/includes/utils.php
+++ b/tests/phpunit/includes/utils.php
@@ -58,6 +58,7 @@ function strip_ws( $txt ) {
  *     add_action( 'foo', array( &$ma, 'action' ) );
  */
 class MockAction {
+	// stores all called actions/filters in an array, where `action`/`filter` is the callback and `tag` is the called hook
 	public $events;
 	public $debug;
 
@@ -168,12 +169,12 @@ class MockAction {
 		return $this->events;
 	}
 
-	// Return a count of the number of times the action was called since the last reset.
+	// Return a count of the number of times the action or filter ( = tag ) was called since the last reset.
 	function get_call_count( $tag = '' ) {
 		if ( $tag ) {
 			$count = 0;
 			foreach ( $this->events as $e ) {
-				if ( $e['action'] === $tag ) {
+				if ( $e['tag'] === $tag ) {
 					++$count;
 				}
 			}
@@ -182,7 +183,7 @@ class MockAction {
 		return count( $this->events );
 	}
 
-	// Return an array of the tags that triggered calls to this action.
+	// Return an array of the tags (actions or filters) that triggered calls to this action.
 	function get_tags() {
 		$out = array();
 		foreach ( $this->events as $e ) {

--- a/tests/phpunit/tests/rest-api/rest-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-controller.php
@@ -392,13 +392,13 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 
 		$controller->prepare_item_for_response( array(), $request );
 
-		$this->assertSame( 0, $listener->get_call_count( $method ) );
+		$this->assertSame( 0, $listener->get_call_count() );
 
 		$request->set_param( 'context', 'embed' );
 
 		$controller->prepare_item_for_response( array(), $request );
 
-		$this->assertGreaterThan( 0, $listener->get_call_count( $method ) );
+		$this->assertGreaterThan( 0, $listener->get_call_count() );
 	}
 
 	public function test_filtering_fields_for_response_by_context_returns_fields_with_no_context() {
@@ -426,7 +426,7 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 
 		$controller->prepare_item_for_response( array(), $request );
 
-		$this->assertGreaterThan( 0, $listener->get_call_count( $method ) );
+		$this->assertGreaterThan( 0, $listener->get_call_count() );
 	}
 
 	public function test_filtering_fields_for_response_by_context_returns_fields_with_no_schema() {
@@ -451,7 +451,7 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 
 		$controller->prepare_item_for_response( array(), $request );
 
-		$this->assertGreaterThan( 0, $listener->get_call_count( $method ) );
+		$this->assertGreaterThan( 0, $listener->get_call_count() );
 	}
 
 	/**
@@ -511,7 +511,7 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 
 		$controller->prepare_item_for_response( $item, $request );
 
-		$first_call_count = $listener->get_call_count( $method );
+		$first_call_count = $listener->get_call_count();
 
 		$this->assertGreaterThan( 0, $first_call_count );
 
@@ -519,13 +519,13 @@ class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 
 		$controller->prepare_item_for_response( $item, $request );
 
-		$this->assertSame( $first_call_count, $listener->get_call_count( $method ) );
+		$this->assertSame( $first_call_count, $listener->get_call_count() );
 
 		$request->set_param( '_fields', $field );
 
 		$controller->prepare_item_for_response( $item, $request );
 
-		$this->assertGreaterThan( $first_call_count, $listener->get_call_count( $method ) );
+		$this->assertGreaterThan( $first_call_count, $listener->get_call_count() );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Fixes `MockAction::get_call_count` for filters (`Undefined index` notice) and fix REST API tests to use function correctly

Trac ticket: [36786](https://core.trac.wordpress.org/ticket/36786)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
