### PR TITLE
[WIP] Fix CI for running tests on PHP 8.1 [51685] (Trac 53945)

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -191,41 +191,41 @@ jobs:
 
       - name: Run slow PHPUnit tests
         if: ${{ matrix.split_slow }}
-        run: npm run test:php-composer -- --verbose -c ${{ env.PHPUNIT_CONFIG }} --group ${{ env.SLOW_TESTS }}
+        run: node ./tools/local-env/scripts/docker.js run --rm phpunit php ./vendor/bin/phpunit --verbose -c ${{ env.PHPUNIT_CONFIG }} --group ${{ env.SLOW_TESTS }}
 
       - name: Run PHPUnit tests for single site excluding slow tests
         if: ${{ matrix.php < '7.0' && ! matrix.split_slow && ! matrix.multisite }}
-        run: npm run test:php-composer -- --verbose -c ${{ env.PHPUNIT_CONFIG }} --exclude-group ${{ env.SLOW_TESTS }},ajax,ms-files,ms-required
+        run: node ./tools/local-env/scripts/docker.js run --rm phpunit php ./vendor/bin/phpunit --verbose -c ${{ env.PHPUNIT_CONFIG }} --exclude-group ${{ env.SLOW_TESTS }},ajax,ms-files,ms-required
 
       - name: Run PHPUnit tests for Multisite excluding slow tests
         if: ${{ matrix.php < '7.0' && ! matrix.split_slow && matrix.multisite }}
-        run: npm run test:php-composer -- --verbose -c ${{ env.PHPUNIT_CONFIG }} --exclude-group ${{ env.SLOW_TESTS }},ajax,ms-files,ms-excluded,oembed-headers
+        run: node ./tools/local-env/scripts/docker.js run --rm phpunit php ./vendor/bin/phpunit --verbose -c ${{ env.PHPUNIT_CONFIG }} --exclude-group ${{ env.SLOW_TESTS }},ajax,ms-files,ms-excluded,oembed-headers
 
       - name: Run PHPUnit tests
         if: ${{ matrix.php >= '7.0' }}
         continue-on-error: ${{ matrix.php == '8.1' }}
-        run: npm run test:php-composer -- --verbose -c ${{ env.PHPUNIT_CONFIG }}
+        run: node ./tools/local-env/scripts/docker.js run --rm phpunit php ./vendor/bin/phpunit --verbose -c ${{ env.PHPUNIT_CONFIG }}
 
       - name: Run AJAX tests
         if: ${{ ! matrix.split_slow }}
         continue-on-error: ${{ matrix.php == '8.1' }}
-        run: npm run test:php-composer -- --verbose -c ${{ env.PHPUNIT_CONFIG }} --group ajax
+        run: node ./tools/local-env/scripts/docker.js run --rm phpunit php ./vendor/bin/phpunit --verbose -c ${{ env.PHPUNIT_CONFIG }} --group ajax
 
       - name: Run ms-files tests as a multisite install
         if: ${{ matrix.multisite && ! matrix.split_slow }}
         continue-on-error: ${{ matrix.php == '8.1' }}
-        run: npm run test:php-composer -- --verbose -c tests/phpunit/multisite.xml --group ms-files
+        run: node ./tools/local-env/scripts/docker.js run --rm phpunit php ./vendor/bin/phpunit --verbose -c tests/phpunit/multisite.xml --group ms-files
 
       - name: Run external HTTP tests
         if: ${{ ! matrix.multisite && ! matrix.split_slow }}
         continue-on-error: ${{ matrix.php == '8.1' }}
-        run: npm run test:php-composer -- --verbose -c phpunit.xml.dist --group external-http
+        run: node ./tools/local-env/scripts/docker.js run --rm phpunit php ./vendor/bin/phpunit --verbose -c phpunit.xml.dist --group external-http
 
       # __fakegroup__ is excluded to force PHPUnit to ignore the <exclude> settings in phpunit.xml.dist.
       - name: Run (xDebug) tests
         if: ${{ ! matrix.split_slow }}
         continue-on-error: ${{ matrix.php == '8.1' }}
-        run: LOCAL_PHP_XDEBUG=true npm run test:php-composer -- -v --group xdebug --exclude-group __fakegroup__
+        run: LOCAL_PHP_XDEBUG=true node ./tools/local-env/scripts/docker.js run --rm phpunit php ./vendor/bin/phpunit -v --group xdebug --exclude-group __fakegroup__
 
       - name: Ensure version-controlled files are not modified or deleted
         run: git diff --exit-code

--- a/tools/local-env/scripts/install.js
+++ b/tools/local-env/scripts/install.js
@@ -22,8 +22,6 @@ renameSync( 'src/wp-config.php', 'wp-config.php' );
 
 install_wp_importer();
 
-install_composer_dependencies();
-
 // Read in wp-tests-config-sample.php, edit it to work with our config, then write it to wp-tests-config.php.
 const testConfig = readFileSync( 'wp-tests-config-sample.php', 'utf8' )
 	.replace( 'youremptytestdbnamehere', 'wordpress_develop_tests' )
@@ -58,11 +56,4 @@ function install_wp_importer() {
 
 	execSync( `docker-compose exec -T php rm -rf ${testPluginDirectory}`, { stdio: 'inherit' } );
 	execSync( `docker-compose exec -T php git clone https://github.com/WordPress/wordpress-importer.git ${testPluginDirectory} --depth=1`, { stdio: 'inherit' } );
-}
-
-/**
- * Installs the Composer package dependencies within the Docker environment.
- */
-function install_composer_dependencies() {
-	execSync( `docker-compose run -T php composer update -W`, { stdio: 'inherit' } );
 }


### PR DESCRIPTION
Changeset [51685] broke the PHP 8.1 tests as it used `composer update` without `--ignore-platform-reqs` which caused the wrong version of PHPUnit to be installed/updated on PHP 8.1 runs. This happened due to 2 changes:

- `composer update` is run during `env:install` process
- `composer update` is run again each time `test:php-composer` run

Both of the changes were for local testing and not the CI. 

This PR fixes the CI while retaining the needed improvements for local testing when running `npm run test:php-composer` by:

- ~~Switches the CI to use the native `docker-compose run` instead of the npm script `test:php-composer`~~
- Replaces the npm script with the full node command
- Removes the `composer update` command from the `env:install` process

Trac ticket: https://core.trac.wordpress.org/ticket/53945

Props @binarykitten who helped me to identify why needed to use `node` instead of `docker-compose`. Why? The node command loads the `docker.js` file which loads the `.env` file. That `.env` includes the environment constants used in the yml configuration file.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
