### PR TITLE
PHP 8.1: wp-login: prevent unnecessary function call (Trac 53635)

### DIFF
--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -1267,7 +1267,10 @@ switch ( $action ) {
 				$errors->add( 'enter_recovery_mode', __( 'Recovery Mode Initialized. Please log in to continue.' ), 'message' );
 			} elseif ( isset( $_GET['redirect_to'] ) && false !== strpos( $_GET['redirect_to'], 'wp-admin/authorize-application.php' ) ) {
 				$query_component = wp_parse_url( $_GET['redirect_to'], PHP_URL_QUERY );
-				parse_str( $query_component, $query );
+				$query           = array();
+				if ( $query_component ) {
+					parse_str( $query_component, $query );
+				}
 
 				if ( ! empty( $query['app_name'] ) ) {
 					/* translators: 1: Website name, 2: Application name. */


### PR DESCRIPTION
... which could be passing `null` onto a context which doesn't allow for `null` due to the output of `wp_parse_url()` with the `$component` parameter potentially being `null`.

> This patch was discussed in detail during the Sept 3rd livestream.

Trac ticket: https://core.trac.wordpress.org/ticket/53635

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
