### PR TITLE
Env start displays local url

### DIFF
--- a/tools/local-env/scripts/start.js
+++ b/tools/local-env/scripts/start.js
@@ -8,9 +8,9 @@ dotenvExpand( dotenv.config() );
 execSync( 'docker-compose up -d wordpress-develop', { stdio: 'inherit' } );
 
 console.log(
-    `------------------------------------------------------
-WordPress Develop now running on http://127.0.0.1:${ process.env.LOCAL_PORT }
-------------------------------------------------------`
+    `-------------------------------------------
+wp-env now running on http://127.0.0.1:${ process.env.LOCAL_PORT }
+-------------------------------------------`
 );
 
 

--- a/tools/local-env/scripts/start.js
+++ b/tools/local-env/scripts/start.js
@@ -7,6 +7,13 @@ dotenvExpand( dotenv.config() );
 // Start the local-env containers.
 execSync( 'docker-compose up -d wordpress-develop', { stdio: 'inherit' } );
 
+console.log(
+    `------------------------------------------------------
+WordPress Develop now running on http://127.0.0.1:${ process.env.LOCAL_PORT }
+------------------------------------------------------`
+);
+
+
 // If Docker Toolbox is being used, we need to manually forward LOCAL_PORT to the Docker VM.
 if ( process.env.DOCKER_TOOLBOX_INSTALL_PATH ) {
 	// VBoxManage is added to the PATH on every platform except Windows.


### PR DESCRIPTION


In an effort to make the wp-env tools a wee bit friendly to new devs I’ve added a `console.log` to echo the local URL when running `env:start`

`http://127.0.0.1:` is hard-coded, the port number is added using the variable `process.env.LOCAL_PORT`

On my machine the console output looks like this:
```
$ npm run env:start                                                      

> WordPress@5.9.0 env:start
> node ./tools/local-env/scripts/start.js

Starting wordpress-develop_mysql_1 ... done
Starting wordpress-develop_php_1   ... done
Starting wordpress-develop_wordpress-develop_1 ... done
-------------------------------------------
wp-env now running on http://127.0.0.1:8889
-------------------------------------------
```


Trac ticket: https://core.trac.wordpress.org/ticket/54095#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
