### PR TITLE
Cache global stylesheet by theme key

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2300,8 +2300,9 @@ function wp_enqueue_global_styles() {
 	);
 
 	$stylesheet = null;
+	$transient_name = 'global_styles_' . get_stylesheet();
 	if ( $can_use_cache ) {
-		$cache = get_transient( 'global_styles' );
+		$cache = get_transient( $transient_name );
 		if ( $cache ) {
 			$stylesheet = $cache;
 		}
@@ -2313,7 +2314,7 @@ function wp_enqueue_global_styles() {
 		$stylesheet = $theme_json->get_stylesheet();
 
 		if ( $can_use_cache ) {
-			set_transient( 'global_styles', $stylesheet, MINUTE_IN_SECONDS );
+			set_transient( $transient_name, $stylesheet, MINUTE_IN_SECONDS );
 		}
 	}
 


### PR DESCRIPTION
Ticket: https://core.trac.wordpress.org/ticket/53175

Props to @dd32 

Global styles are used in a few different contexts (front, editor, customizer, the theme directory). In the last two contexts, it's important that switching themes immediately refreshes the global stylesheet, to avoid situations in which the styles of the previous theme load with the new one. This was brought up at https://github.com/WordPress/gutenberg/issues/34531 (customizer) and at https://meta.trac.wordpress.org/ticket/5818 (theme directory).

This PR makes sure the stylesheet is regenerated upon switching themes.
