### PR TITLE
updated doc block for $wp_version global variable.

### DIFF
--- a/src/wp-includes/version.php
+++ b/src/wp-includes/version.php
@@ -9,7 +9,7 @@
  */
 
 /**
- * The WordPress version string.
+ * The WordPress version string. Holds the current version number for WordPress Core, used to bust caches and to enable development mode for scripts when running from /src.
  *
  * @global string $wp_version
  */


### PR DESCRIPTION
Updated the doc block for $wp_version
Updated the doc block to "The WordPress version string. Holds the current version number for WordPress Core, used to bust caches and to enable development mode for scripts when running from /src."

Trac ticket: https://core.trac.wordpress.org/ticket/53413

File details
wp-includes/version.php line 12.

https://github.com/MuhammadFaizanHaidar/wordpress-develop/blob/master/src/wp-includes/version.php


