### PR TITLE
Add figure as a directly nestable element to force_balance_tags

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2480,9 +2480,9 @@ function force_balance_tags( $text ) {
 	$tagqueue  = '';
 	$newtext   = '';
 	// Known single-entity/self-closing tags.
-	$single_tags = array( 'area', 'base', 'basefont', 'br', 'col', 'command', 'embed', 'frame', 'hr', 'img', 'input', 'isindex', 'link', 'meta', 'param', 'source' );
+	$single_tags = array( 'area', 'base', 'basefont', 'br', 'col', 'command', 'embed', 'frame', 'hr', 'img', 'input', 'isindex', 'link', 'meta', 'param', 'source', 'track', 'wbr' );
 	// Tags that can be immediately nested within themselves.
-	$nestable_tags = array( 'blockquote', 'div', 'figure', 'object', 'q', 'span' );
+	$nestable_tags = array( 'article', 'aside', 'blockquote', 'details', 'div', 'figure', 'object', 'q', 'section', 'span' );
 
 	// WP bug fix for comments - in case you REALLY meant to type '< !--'.
 	$text = str_replace( '< !--', '<    !--', $text );

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2482,7 +2482,7 @@ function force_balance_tags( $text ) {
 	// Known single-entity/self-closing tags.
 	$single_tags = array( 'area', 'base', 'basefont', 'br', 'col', 'command', 'embed', 'frame', 'hr', 'img', 'input', 'isindex', 'link', 'meta', 'param', 'source' );
 	// Tags that can be immediately nested within themselves.
-	$nestable_tags = array( 'blockquote', 'div', 'object', 'q', 'span' );
+	$nestable_tags = array( 'blockquote', 'div', 'figure', 'object', 'q', 'span' );
 
 	// WP bug fix for comments - in case you REALLY meant to type '< !--'.
 	$text = str_replace( '< !--', '<    !--', $text );

--- a/tests/phpunit/tests/formatting/balanceTags.php
+++ b/tests/phpunit/tests/formatting/balanceTags.php
@@ -7,11 +7,15 @@ class Tests_Formatting_BalanceTags extends WP_UnitTestCase {
 
 	function nestable_tags() {
 		return array(
+			array( 'article' ),
+			array( 'aside' ),
 			array( 'blockquote' ),
+			array( 'details' ),
 			array( 'div' ),
 			array( 'figure' ),
 			array( 'object' ),
 			array( 'q' ),
+			array( 'section' ),
 			array( 'span' ),
 		);
 	}
@@ -35,6 +39,8 @@ class Tests_Formatting_BalanceTags extends WP_UnitTestCase {
 			array( 'meta' ),
 			array( 'param' ),
 			array( 'source' ),
+			array( 'track' ),
+			array( 'wbr' ),
 		);
 	}
 

--- a/tests/phpunit/tests/formatting/balanceTags.php
+++ b/tests/phpunit/tests/formatting/balanceTags.php
@@ -9,6 +9,7 @@ class Tests_Formatting_BalanceTags extends WP_UnitTestCase {
 		return array(
 			array( 'blockquote' ),
 			array( 'div' ),
+			array( 'figure' ),
 			array( 'object' ),
 			array( 'q' ),
 			array( 'span' ),


### PR DESCRIPTION
### Description

The refactored gallery block uses a nested <figure><figure></figure></figure> structure, as recommended by w3c for image collections.

If a site has the use_balanceTags option set to 1, then the Gallery block breaks on save as force_balance_tags restructures it from `<figure><figure></figure></figure>` to `<figure></figure><figure></figure>`.

This PR adds figure as as a directly nestable element, which it is under the current html specs.

### Testing

- Set the use_balanceTags option to 1 in a dev site
- Install latest version of the gutenberg plugin and turn on the gallery experiment under the gutenberg experiments menu
- Add a gallery block with several images and save the post and reload and notice that the block is now invalid
- Apply this patch to local dev site an add a new gallery block and this time you should be able to save and reload the post

Trac ticket: https://core.trac.wordpress.org/ticket/54130

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
