### PR TITLE
Include plugin URLs in auto-update email notifications

### DIFF
--- a/src/wp-admin/includes/class-wp-automatic-updater.php
+++ b/src/wp-admin/includes/class-wp-automatic-updater.php
@@ -1159,8 +1159,9 @@ class WP_Automatic_Updater {
 				$body[] = __( 'These plugins are now up to date:' );
 
 				foreach ( $successful_updates['plugin'] as $item ) {
+					$body_message = '';
 					if ( $item->item->current_version ) {
-						$body[] = sprintf(
+						$body_message = sprintf(
 							/* translators: 1: Plugin name, 2: Current version number, 3: New version number. */
 							__( '- %1$s (from version %2$s to %3$s)' ),
 							$item->name,
@@ -1168,13 +1169,17 @@ class WP_Automatic_Updater {
 							$item->item->new_version
 						);
 					} else {
-						$body[] = sprintf(
+						$body_message = sprintf(
 							/* translators: 1: Plugin name, 2: Version number. */
 							__( '- %1$s version %2$s' ),
 							$item->name,
 							$item->item->new_version
 						);
 					}
+					if ( $item->item->url ) {
+						$body_message .= sprintf( ': %s', esc_url( $item->item->url ) );
+					}
+					$body[] = $body_message;
 
 					unset( $past_failure_emails[ $item->item->plugin ] );
 				}

--- a/src/wp-admin/includes/class-wp-automatic-updater.php
+++ b/src/wp-admin/includes/class-wp-automatic-updater.php
@@ -1098,8 +1098,9 @@ class WP_Automatic_Updater {
 				$body[] = __( 'These plugins failed to update:' );
 
 				foreach ( $failed_updates['plugin'] as $item ) {
+					$body_message = '';
 					if ( $item->item->current_version ) {
-						$body[] = sprintf(
+						$body_message .= sprintf(
 							/* translators: 1: Plugin name, 2: Current version number, 3: New version number. */
 							__( '- %1$s (from version %2$s to %3$s)' ),
 							$item->name,
@@ -1107,13 +1108,18 @@ class WP_Automatic_Updater {
 							$item->item->new_version
 						);
 					} else {
-						$body[] = sprintf(
+						$body_message .= sprintf(
 							/* translators: 1: Plugin name, 2: Version number. */
 							__( '- %1$s version %2$s' ),
 							$item->name,
 							$item->item->new_version
 						);
 					}
+
+					if ( $item->item->url ) {
+						$body_message .= sprintf( ': %s', esc_url( $item->item->url ) );
+					}
+					$body[] = $body_message;
 
 					$past_failure_emails[ $item->item->plugin ] = $item->item->new_version;
 				}
@@ -1161,7 +1167,7 @@ class WP_Automatic_Updater {
 				foreach ( $successful_updates['plugin'] as $item ) {
 					$body_message = '';
 					if ( $item->item->current_version ) {
-						$body_message = sprintf(
+						$body_message .= sprintf(
 							/* translators: 1: Plugin name, 2: Current version number, 3: New version number. */
 							__( '- %1$s (from version %2$s to %3$s)' ),
 							$item->name,
@@ -1169,7 +1175,7 @@ class WP_Automatic_Updater {
 							$item->item->new_version
 						);
 					} else {
-						$body_message = sprintf(
+						$body_message .= sprintf(
 							/* translators: 1: Plugin name, 2: Version number. */
 							__( '- %1$s version %2$s' ),
 							$item->name,


### PR DESCRIPTION
This PR adjusts the logic for generating the description of plugins that were updated, or that failed to update, as included in the notification email sent to site admins after an update run has completed. 

Specifically, it appends a link to the plugin's main URL (as defined in plugin header metadata fetched by `get_plugin_data()`) so that a user can track down more information about the plugin, changelog, and support options.

Trac ticket: https://core.trac.wordpress.org/ticket/53049

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
