### PR TITLE
Fix/updates backups timeout

### DIFF
--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -859,7 +859,9 @@ class WP_Upgrader {
 
 		// Clean up the backup kept in the temp-backup directory.
 		if ( ! empty( $options['hook_extra']['temp_backup'] ) ) {
-			$this->delete_temp_backup( $options['hook_extra']['temp_backup'] );
+			add_action( 'shutdown', function() use ( $options ) {
+				$this->delete_temp_backup( $options['hook_extra']['temp_backup'] );
+			} );
 		}
 
 		if ( ! $options['is_multi'] ) {

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -843,7 +843,9 @@ class WP_Upgrader {
 		$this->skin->set_result( $result );
 		if ( is_wp_error( $result ) ) {
 			if ( ! empty( $options['hook_extra']['temp_backup'] ) ) {
-				$this->restore_temp_backup( $options['hook_extra']['temp_backup'] );
+				add_action( 'shutdown', function() use ( $options ) {
+					$this->restore_temp_backup( $options['hook_extra']['temp_backup'] );
+				} );
 			}
 			$this->skin->error( $result );
 


### PR DESCRIPTION
Fixes PHP timeouts by moving the backup deletion & restore to the `shutdown` action.
Processes running on `shutdown` are immune to PHP timeouts, so moving them there allows them to run _after_ the main process, without affecting the update.

Trac ticket: https://core.trac.wordpress.org/ticket/54166#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
