### PR TITLE
WP 5.8: fix test forward-compatibility layer

### DIFF
--- a/tests/phpunit/includes/phpunit7/testcase.php
+++ b/tests/phpunit/includes/phpunit7/testcase.php
@@ -46,30 +46,80 @@ class WP_UnitTestCase extends WP_UnitTestCase_Base {
 	use ExpectPHPException;
 
 	/**
-	 * Wrapper method for the `setUpBeforeClass()` method for forward-compatibility with WP 5.9.
+	 * Wrapper method for the `set_up_before_class()` method for forward-compatibility with WP 5.9.
 	 */
-	public static function set_up_before_class() {
-		static::setUpBeforeClass();
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		static::set_up_before_class();
 	}
 
 	/**
-	 * Wrapper method for the `tearDownAfterClass()` method for forward-compatibility with WP 5.9.
+	 * Wrapper method for the `tear_down_after_class()` method for forward-compatibility with WP 5.9.
 	 */
-	public static function tear_down_after_class() {
-		static::tearDownAfterClass();
+	public static function tearDownAfterClass() {
+		static::tear_down_after_class();
+		parent::tearDownAfterClass();
 	}
 
 	/**
-	 * Wrapper method for the `setUp()` method for forward-compatibility with WP 5.9.
+	 * Wrapper method for the `set_up()` method for forward-compatibility with WP 5.9.
 	 */
-	public function set_up() {
-		static::setUp();
+	public function setUp() {
+		parent::setUp();
+		$this->set_up();
 	}
 
 	/**
-	 * Wrapper method for the `tearDown()` method for forward-compatibility with WP 5.9.
+	 * Wrapper method for the `tear_down()` method for forward-compatibility with WP 5.9.
 	 */
-	public function tear_down() {
-		static::tearDown();
+	public function tearDown() {
+		$this->tear_down();
+		parent::tearDown();
 	}
+
+	/**
+	 * Wrapper method for the `assert_pre_conditions()` method for forward-compatibility with WP 5.9.
+	 */
+	protected function assertPreConditions() {
+		parent::assertPreConditions();
+		$this->assert_pre_conditions();
+	}
+
+	/**
+	 * Wrapper method for the `assert_post_conditions()` method for forward-compatibility with WP 5.9.
+	 */
+	protected function assertPostConditions() {
+		parent::assertPostConditions();
+		$this->assert_post_conditions();
+	}
+
+	/**
+	 * Placeholder method for forward-compatibility with WP 5.9.
+	 */
+	public static function set_up_before_class() {}
+
+	/**
+	 * Placeholder method for forward-compatibility with WP 5.9.
+	 */
+	public static function tear_down_after_class() {}
+
+	/**
+	 * Placeholder method for forward-compatibility with WP 5.9.
+	 */
+	protected function set_up() {}
+
+	/**
+	 * Placeholder method for forward-compatibility with WP 5.9.
+	 */
+	protected function tear_down() {}
+
+	/**
+	 * Placeholder method for forward-compatibility with WP 5.9.
+	 */
+	protected function assert_pre_conditions() {}
+
+	/**
+	 * Placeholder method for forward-compatibility with WP 5.9.
+	 */
+	protected function assert_post_conditions() {}
 }

--- a/tests/phpunit/includes/testcase.php
+++ b/tests/phpunit/includes/testcase.php
@@ -46,30 +46,80 @@ class WP_UnitTestCase extends WP_UnitTestCase_Base {
 	use ExpectPHPException;
 
 	/**
-	 * Wrapper method for the `setUpBeforeClass()` method for forward-compatibility with WP 5.9.
+	 * Wrapper method for the `set_up_before_class()` method for forward-compatibility with WP 5.9.
 	 */
-	public static function set_up_before_class() {
-		static::setUpBeforeClass();
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		static::set_up_before_class();
 	}
 
 	/**
-	 * Wrapper method for the `tearDownAfterClass()` method for forward-compatibility with WP 5.9.
+	 * Wrapper method for the `tear_down_after_class()` method for forward-compatibility with WP 5.9.
 	 */
-	public static function tear_down_after_class() {
-		static::tearDownAfterClass();
+	public static function tearDownAfterClass() {
+		static::tear_down_after_class();
+		parent::tearDownAfterClass();
 	}
 
 	/**
-	 * Wrapper method for the `setUp()` method for forward-compatibility with WP 5.9.
+	 * Wrapper method for the `set_up()` method for forward-compatibility with WP 5.9.
 	 */
-	public function set_up() {
-		static::setUp();
+	public function setUp() {
+		parent::setUp();
+		$this->set_up();
 	}
 
 	/**
-	 * Wrapper method for the `tearDown()` method for forward-compatibility with WP 5.9.
+	 * Wrapper method for the `tear_down()` method for forward-compatibility with WP 5.9.
 	 */
-	public function tear_down() {
-		static::tearDown();
+	public function tearDown() {
+		$this->tear_down();
+		parent::tearDown();
 	}
+
+	/**
+	 * Wrapper method for the `assert_pre_conditions()` method for forward-compatibility with WP 5.9.
+	 */
+	protected function assertPreConditions() {
+		parent::assertPreConditions();
+		$this->assert_pre_conditions();
+	}
+
+	/**
+	 * Wrapper method for the `assert_post_conditions()` method for forward-compatibility with WP 5.9.
+	 */
+	protected function assertPostConditions() {
+		parent::assertPostConditions();
+		$this->assert_post_conditions();
+	}
+
+	/**
+	 * Placeholder method for forward-compatibility with WP 5.9.
+	 */
+	public static function set_up_before_class() {}
+
+	/**
+	 * Placeholder method for forward-compatibility with WP 5.9.
+	 */
+	public static function tear_down_after_class() {}
+
+	/**
+	 * Placeholder method for forward-compatibility with WP 5.9.
+	 */
+	protected function set_up() {}
+
+	/**
+	 * Placeholder method for forward-compatibility with WP 5.9.
+	 */
+	protected function tear_down() {}
+
+	/**
+	 * Placeholder method for forward-compatibility with WP 5.9.
+	 */
+	protected function assert_pre_conditions() {}
+
+	/**
+	 * Placeholder method for forward-compatibility with WP 5.9.
+	 */
+	protected function assert_post_conditions() {}
 }


### PR DESCRIPTION
**Problem description:**
The test wrapper methods were not being called due to the names not being recognized as supported PHPUnit "hook" names for fixtures.

I've explored the following potential options to solve this:
1. Implement use of the PHPUnit Polyfills testcase.
    This would require a change in the TestCase inheritance order and - to be on the safe side - changing the fixture method names throughout the WP Core test suite.
    Such a change is larger than a helper backport warrants and is therefore not the preferred choice.
2. Using the PHPUnit natively supported `@beforeClass`, `@before`, `@after` and `@afterClass` annotations to wire in the snake_case methods to be recognized as "hook callbacks" by PHPUnit.
    I've investigated this option. Unfortunately, this would mean that the typical "parent" versus "child" method order for these methods would become reversed.
    For example, the typical run order for a `setUp()` method is: first run `parent::setUp()`, next run your own code (and the reverse for the tear downs, i.e. first run your own code, then run the `parent::tearDown()`).
    The annotations, however, reverse that order as for the `setUp()` methods, the (snake_case) method with the annotation would get called first and then the PHPUnit `setUp()` would get called after (and visa versa for teardown).
    As this could have unexpected side-effects, that option was discarded.
    Note: using the annotations in combination with calling the camelCase parent from within the annotated snake_case method would mean the camelCase parent method would be called twice, once at the start, once at the end of the sequence, which, again, could have unintented side-effects, so that's another reason not to use this option.
3. [CHOSEN SOLUTION] Adding extra camelCase wrappers to the `WP_UnitTestCase` to call the methods in the right order.
    By adding method overloads for the PHPUnit native camelCase fixture methods and letting those call the (camelCase) parent method first and only calling the snake_case fixture methods after, the snake_case methods can be supported and the typical run order safeguarded.
    As not all test classes will have declared snake_case fixture methods, the snake_case fixture methods are also declared in the `WP_UnitTestCase`. This prevents having to wrap these method calls in `method_exists()` conditions checking for the existence of the snake_case methods in an unknown Test child class. And with the normal inheritance rules in combination with calling the method using `static`, the right method will be called anyway without fatal "calling undeclared method" errors.
    Note: while it will be rare, there _may_ be cases where a test class does not adhere to the normal execution order for fixtures, i.e. for the setup methods, parent first, own code second; and for the teardown methods, own code first, parent second.
    For example a test class which has "some code - `parent::setUp()` call - some more code" in their `setUp()` method.
    In those (rare) cases, the execution order of the code will now be changed, which may have side-effects.
    A note to that effect will be added to the dev-note about the test changes.

Includes backporting wrappers for the `assertPreConditions()` and `assertPostConditions()` fixture methods. While rarely used, if we're doing an extra backport now anyway, we may as well make it feature complete for the fixture wrappers.


Trac ticket: https://core.trac.wordpress.org/ticket/53911

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
