### PR TITLE
Upgrades tests for changeset 51855 (Trac 51147)

### DIFF
--- a/tests/phpunit/tests/multisite/msPermalinkCollision.php
+++ b/tests/phpunit/tests/multisite/msPermalinkCollision.php
@@ -66,7 +66,7 @@ if ( is_multisite() ) :
 		}
 
 		public function test_avoid_blog_page_permalink_collision_renames_post_name() {
-			$this->assertNotEquals( self::$post_and_blog_path, self::$root_page->post_name );
+			$this->assertNotSame( self::$post_and_blog_path, self::$root_page->post_name );
 		}
 
 		/**
@@ -75,7 +75,7 @@ if ( is_multisite() ) :
 		 * @ticket 51147
 		 */
 		public function test_avoid_blog_page_permalink_collision_doesnt_rename_child_pages() {
-			$this->assertEquals( self::$post_and_blog_path, self::$child_page->post_name );
+			$this->assertSame( self::$post_and_blog_path, self::$child_page->post_name );
 		}
 	}
 

--- a/tests/phpunit/tests/multisite/msPermalinkCollision.php
+++ b/tests/phpunit/tests/multisite/msPermalinkCollision.php
@@ -43,18 +43,6 @@ if ( is_multisite() ) :
 			);
 		}
 
-		public function setUp() {
-			global $wpdb;
-			parent::setUp();
-			$this->suppress = $wpdb->suppress_errors();
-		}
-
-		public function tearDown() {
-			global $wpdb;
-			$wpdb->suppress_errors( $this->suppress );
-			parent::tearDown();
-		}
-
 		/**
 		 * Delete blog and pages we created.
 		 */
@@ -63,6 +51,18 @@ if ( is_multisite() ) :
 
 			wp_delete_post( self::$root_page->ID );
 			wp_delete_post( self::$child_page->ID );
+		}
+
+		public function set_up() {
+			global $wpdb;
+			parent::set_up();
+			$this->suppress = $wpdb->suppress_errors();
+		}
+
+		public function tear_down() {
+			global $wpdb;
+			$wpdb->suppress_errors( $this->suppress );
+			parent::tear_down();
 		}
 
 		public function test_avoid_blog_page_permalink_collision_renames_post_name() {


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/51147

For commit message:

Build/Test Tools: Upgrades `Tests_Multisite_MS_Permalink_Collision` fixture methods and strict assertion.

Improvements include:
- Upgrades the test fixture methods to the new snake_case
- Reorders the fixture methods for consistency
- Uses strict assertions of `assertSame` and `assertNotSame`

Follow-up to [51855-51856].

Props hellofromTonya.
See #51147.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
