### PR TITLE
#54183 Update PHPUnit configuration schema files for PHPUnit 9.3

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <phpunit
-		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
-		bootstrap="tests/phpunit/includes/bootstrap.php"
-		backupGlobals="false"
-		colors="true"
-		beStrictAboutTestsThatDoNotTestAnything="true"
-		beStrictAboutOutputDuringTests="true"
-		>
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+	bootstrap="tests/phpunit/includes/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	beStrictAboutTestsThatDoNotTestAnything="true"
+	beStrictAboutOutputDuringTests="true"
+	>
 	<testsuites>
 		<!-- Default test suite to run all tests. -->
 		<testsuite name="default">
@@ -37,37 +37,37 @@
 		<include>
 			<directory suffix=".php">src</directory>
 		</include>
-			<exclude>
-				<!-- Third party library exclusions. -->
-				<directory suffix=".php">src/wp-includes/ID3</directory>
-				<directory suffix=".php">src/wp-includes/IXR</directory>
-				<directory suffix=".php">src/wp-includes/random_compat</directory>
-				<directory suffix=".php">src/wp-includes/PHPMailer</directory>
-				<directory suffix=".php">src/wp-includes/Requests</directory>
-				<directory suffix=".php">src/wp-includes/SimplePie</directory>
-				<directory suffix=".php">src/wp-includes/sodium_compat</directory>
-				<directory suffix=".php">src/wp-includes/Text</directory>
+		<exclude>
+			<!-- Third party library exclusions. -->
+			<directory suffix=".php">src/wp-includes/ID3</directory>
+			<directory suffix=".php">src/wp-includes/IXR</directory>
+			<directory suffix=".php">src/wp-includes/random_compat</directory>
+			<directory suffix=".php">src/wp-includes/PHPMailer</directory>
+			<directory suffix=".php">src/wp-includes/Requests</directory>
+			<directory suffix=".php">src/wp-includes/SimplePie</directory>
+			<directory suffix=".php">src/wp-includes/sodium_compat</directory>
+			<directory suffix=".php">src/wp-includes/Text</directory>
 
-				<!-- Plugins and themes. -->
-				<directory suffix=".php">src/wp-content/</directory>
+			<!-- Plugins and themes. -->
+			<directory suffix=".php">src/wp-content/</directory>
 
-				<file>src/wp-admin/includes/class-ftp*</file>
-				<file>src/wp-admin/includes/class-pclzip.php</file>
-				<file>src/wp-admin/includes/deprecated.php</file>
-				<file>src/wp-admin/includes/ms-deprecated.php</file>
+			<file>src/wp-admin/includes/class-ftp*</file>
+			<file>src/wp-admin/includes/class-pclzip.php</file>
+			<file>src/wp-admin/includes/deprecated.php</file>
+			<file>src/wp-admin/includes/ms-deprecated.php</file>
 
-				<file>src/wp-includes/atomlib.php</file>
-				<file>src/wp-includes/class-IXR.php</file>
-				<file>src/wp-includes/class-json.php</file>
-				<file>src/wp-includes/class-phpass.php</file>
-				<file>src/wp-includes/class-pop3.php</file>
-				<file>src/wp-includes/class-requests.php</file>
-				<file>src/wp-includes/class-simplepie.php</file>
-				<file>src/wp-includes/class-snoopy.php</file>
-				<file>src/wp-includes/deprecated.php</file>
-				<file>src/wp-includes/ms-deprecated.php</file>
-				<file>src/wp-includes/pluggable-deprecated.php</file>
-				<file>src/wp-includes/rss.php</file>
-			</exclude>
+			<file>src/wp-includes/atomlib.php</file>
+			<file>src/wp-includes/class-IXR.php</file>
+			<file>src/wp-includes/class-json.php</file>
+			<file>src/wp-includes/class-phpass.php</file>
+			<file>src/wp-includes/class-pop3.php</file>
+			<file>src/wp-includes/class-requests.php</file>
+			<file>src/wp-includes/class-simplepie.php</file>
+			<file>src/wp-includes/class-snoopy.php</file>
+			<file>src/wp-includes/deprecated.php</file>
+			<file>src/wp-includes/ms-deprecated.php</file>
+			<file>src/wp-includes/pluggable-deprecated.php</file>
+			<file>src/wp-includes/rss.php</file>
+		</exclude>
 	</coverage>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,7 @@
+<?xml version="1.0"?>
 <phpunit
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/9.2/phpunit.xsd"
+		xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
 		bootstrap="tests/phpunit/includes/bootstrap.php"
 		backupGlobals="false"
 		colors="true"
@@ -27,14 +28,15 @@
 		</exclude>
 	</groups>
 	<logging>
-		<log type="junit" target="tests/phpunit/build/logs/junit.xml" />
+		<junit outputFile="tests/phpunit/build/logs/junit.xml"/>
 	</logging>
 	<php>
-		<const name="WP_RUN_CORE_TESTS" value="1" />
+		<const name="WP_RUN_CORE_TESTS" value="1"/>
 	</php>
-	<filter>
-		<whitelist addUncoveredFilesFromWhitelist="true">
+	<coverage includeUncoveredFiles="true">
+		<include>
 			<directory suffix=".php">src</directory>
+		</include>
 			<exclude>
 				<!-- Third party library exclusions. -->
 				<directory suffix=".php">src/wp-includes/ID3</directory>
@@ -67,6 +69,5 @@
 				<file>src/wp-includes/pluggable-deprecated.php</file>
 				<file>src/wp-includes/rss.php</file>
 			</exclude>
-		</whitelist>
-	</filter>
+	</coverage>
 </phpunit>

--- a/tests/phpunit/multisite.xml
+++ b/tests/phpunit/multisite.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0"?>
 <phpunit
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/9.2/phpunit.xsd"
+		xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
 		bootstrap="includes/bootstrap.php"
 		backupGlobals="false"
 		colors="true"
@@ -8,8 +9,8 @@
 		beStrictAboutOutputDuringTests="true"
 		>
 	<php>
-		<const name="WP_TESTS_MULTISITE" value="1" />
-		<const name="WP_RUN_CORE_TESTS" value="1" />
+		<const name="WP_TESTS_MULTISITE" value="1"/>
+		<const name="WP_RUN_CORE_TESTS" value="1"/>
 	</php>
 	<testsuites>
 		<!-- Default test suite to run all tests. -->
@@ -31,9 +32,10 @@
 			<group>oembed-headers</group>
 		</exclude>
 	</groups>
-	<filter>
-		<whitelist addUncoveredFilesFromWhitelist="true">
+	<coverage includeUncoveredFiles="true">
+		<include>
 			<directory suffix=".php">../../src</directory>
+		</include>
 			<exclude>
 				<!-- Third party library exclusions. -->
 				<directory suffix=".php">../../src/wp-includes/ID3</directory>
@@ -66,6 +68,5 @@
 				<file>../../src/wp-includes/pluggable-deprecated.php</file>
 				<file>../../src/wp-includes/rss.php</file>
 			</exclude>
-		</whitelist>
-	</filter>
+	</coverage>
 </phpunit>

--- a/tests/phpunit/multisite.xml
+++ b/tests/phpunit/multisite.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <phpunit
-		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
-		bootstrap="includes/bootstrap.php"
-		backupGlobals="false"
-		colors="true"
-		beStrictAboutTestsThatDoNotTestAnything="true"
-		beStrictAboutOutputDuringTests="true"
-		>
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+	bootstrap="includes/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	beStrictAboutTestsThatDoNotTestAnything="true"
+	beStrictAboutOutputDuringTests="true"
+	>
 	<php>
 		<const name="WP_TESTS_MULTISITE" value="1"/>
 		<const name="WP_RUN_CORE_TESTS" value="1"/>
@@ -36,37 +36,37 @@
 		<include>
 			<directory suffix=".php">../../src</directory>
 		</include>
-			<exclude>
-				<!-- Third party library exclusions. -->
-				<directory suffix=".php">../../src/wp-includes/ID3</directory>
-				<directory suffix=".php">../../src/wp-includes/IXR</directory>
-				<directory suffix=".php">../../src/wp-includes/random_compat</directory>
-				<directory suffix=".php">../../src/wp-includes/PHPMailer</directory>
-				<directory suffix=".php">../../src/wp-includes/Requests</directory>
-				<directory suffix=".php">../../src/wp-includes/SimplePie</directory>
-				<directory suffix=".php">../../src/wp-includes/sodium_compat</directory>
-				<directory suffix=".php">../../src/wp-includes/Text</directory>
+		<exclude>
+			<!-- Third party library exclusions. -->
+			<directory suffix=".php">../../src/wp-includes/ID3</directory>
+			<directory suffix=".php">../../src/wp-includes/IXR</directory>
+			<directory suffix=".php">../../src/wp-includes/random_compat</directory>
+			<directory suffix=".php">../../src/wp-includes/PHPMailer</directory>
+			<directory suffix=".php">../../src/wp-includes/Requests</directory>
+			<directory suffix=".php">../../src/wp-includes/SimplePie</directory>
+			<directory suffix=".php">../../src/wp-includes/sodium_compat</directory>
+			<directory suffix=".php">../../src/wp-includes/Text</directory>
 
-				<!-- Plugins and themes. -->
-				<directory suffix=".php">../../src/wp-content/</directory>
+			<!-- Plugins and themes. -->
+			<directory suffix=".php">../../src/wp-content/</directory>
 
-				<file>../../src/wp-admin/includes/class-ftp*</file>
-				<file>../../src/wp-admin/includes/class-pclzip.php</file>
-				<file>../../src/wp-admin/includes/deprecated.php</file>
-				<file>../../src/wp-admin/includes/ms-deprecated.php</file>
+			<file>../../src/wp-admin/includes/class-ftp*</file>
+			<file>../../src/wp-admin/includes/class-pclzip.php</file>
+			<file>../../src/wp-admin/includes/deprecated.php</file>
+			<file>../../src/wp-admin/includes/ms-deprecated.php</file>
 
-				<file>../../src/wp-includes/atomlib.php</file>
-				<file>../../src/wp-includes/class-IXR.php</file>
-				<file>../../src/wp-includes/class-json.php</file>
-				<file>../../src/wp-includes/class-phpass.php</file>
-				<file>../../src/wp-includes/class-pop3.php</file>
-				<file>../../src/wp-includes/class-requests.php</file>
-				<file>../../src/wp-includes/class-simplepie.php</file>
-				<file>../../src/wp-includes/class-snoopy.php</file>
-				<file>../../src/wp-includes/deprecated.php</file>
-				<file>../../src/wp-includes/ms-deprecated.php</file>
-				<file>../../src/wp-includes/pluggable-deprecated.php</file>
-				<file>../../src/wp-includes/rss.php</file>
-			</exclude>
+			<file>../../src/wp-includes/atomlib.php</file>
+			<file>../../src/wp-includes/class-IXR.php</file>
+			<file>../../src/wp-includes/class-json.php</file>
+			<file>../../src/wp-includes/class-phpass.php</file>
+			<file>../../src/wp-includes/class-pop3.php</file>
+			<file>../../src/wp-includes/class-requests.php</file>
+			<file>../../src/wp-includes/class-simplepie.php</file>
+			<file>../../src/wp-includes/class-snoopy.php</file>
+			<file>../../src/wp-includes/deprecated.php</file>
+			<file>../../src/wp-includes/ms-deprecated.php</file>
+			<file>../../src/wp-includes/pluggable-deprecated.php</file>
+			<file>../../src/wp-includes/rss.php</file>
+		</exclude>
 	</coverage>
 </phpunit>


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/54183

Whilst running PHPUnit locally I noticed this message from PHPUnit 9.3:

> Warning:       Your XML configuration validates against a deprecated schema.
> Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

I broke down the commits in this PR to aid code-review, one commit for each PHPUnit XML file, and additional commits for white-space cleanup.


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
