### PR TITLE
Coding Standards: Add visibility to methods in `src` directory.

### DIFF
--- a/src/wp-admin/includes/class-wp-debug-data.php
+++ b/src/wp-admin/includes/class-wp-debug-data.php
@@ -13,7 +13,7 @@ class WP_Debug_Data {
 	 *
 	 * @since 5.2.0
 	 */
-	static function check_for_updates() {
+	public static function check_for_updates() {
 		wp_version_check();
 		wp_update_plugins();
 		wp_update_themes();
@@ -32,7 +32,7 @@ class WP_Debug_Data {
 	 *
 	 * @return array The debug data for the site.
 	 */
-	static function debug_data() {
+	public static function debug_data() {
 		global $wpdb;
 
 		// Save few function calls.

--- a/src/wp-admin/includes/class-wp-site-health-auto-updates.php
+++ b/src/wp-admin/includes/class-wp-site-health-auto-updates.php
@@ -156,7 +156,7 @@ class WP_Site_Health_Auto_Updates {
 	 *
 	 * @return array|false The test results. False if the auto-updates failed.
 	 */
-	function test_if_failed_update() {
+	public function test_if_failed_update() {
 		$failed = get_site_option( 'auto_core_update_failed' );
 
 		if ( ! $failed ) {
@@ -272,7 +272,7 @@ class WP_Site_Health_Auto_Updates {
 	 *
 	 * @return array The test results.
 	 */
-	function test_check_wp_filesystem_method() {
+	public function test_check_wp_filesystem_method() {
 		// Make sure the `request_filesystem_credentials()` function is available during our REST API call.
 		if ( ! function_exists( 'request_filesystem_credentials' ) ) {
 			require_once ABSPATH . '/wp-admin/includes/file.php';
@@ -306,7 +306,7 @@ class WP_Site_Health_Auto_Updates {
 	 *
 	 * @return array|false The test results. False if they're not writeable.
 	 */
-	function test_all_files_writable() {
+	public function test_all_files_writable() {
 		global $wp_filesystem;
 
 		require ABSPATH . WPINC . '/version.php'; // $wp_version; // x.y.z
@@ -391,7 +391,7 @@ class WP_Site_Health_Auto_Updates {
 	 *
 	 * @return array|false The test results. False if it isn't a development version.
 	 */
-	function test_accepts_dev_updates() {
+	public function test_accepts_dev_updates() {
 		require ABSPATH . WPINC . '/version.php'; // $wp_version; // x.y.z
 		// Only for dev versions.
 		if ( false === strpos( $wp_version, '-' ) ) {
@@ -429,7 +429,7 @@ class WP_Site_Health_Auto_Updates {
 	 *
 	 * @return array The test results.
 	 */
-	function test_accepts_minor_updates() {
+	public function test_accepts_minor_updates() {
 		if ( defined( 'WP_AUTO_UPDATE_CORE' ) && false === WP_AUTO_UPDATE_CORE ) {
 			return array(
 				'description' => sprintf(

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -2767,7 +2767,7 @@ class WP_Site_Health {
 	 *
 	 * @return object The test results.
 	 */
-	function detect_plugin_theme_auto_update_issues() {
+	public function detect_plugin_theme_auto_update_issues() {
 		$mock_plugin = (object) array(
 			'id'            => 'w.org/plugins/a-fake-plugin',
 			'slug'          => 'a-fake-plugin',
@@ -2850,7 +2850,7 @@ class WP_Site_Health {
 	 *
 	 * @return object The test results.
 	 */
-	function can_perform_loopback() {
+	public function can_perform_loopback() {
 		$body    = array( 'site-health' => 'loopback-test' );
 		$cookies = wp_unslash( $_COOKIE );
 		$timeout = 10;

--- a/src/wp-content/themes/twentyeleven/inc/widgets.php
+++ b/src/wp-content/themes/twentyeleven/inc/widgets.php
@@ -17,7 +17,7 @@ class Twenty_Eleven_Ephemera_Widget extends WP_Widget {
 	 *
 	 * @since Twenty Eleven 2.2
 	 */
-	function __construct() {
+	public function __construct() {
 		parent::__construct(
 			'widget_twentyeleven_ephemera',
 			__( 'Twenty Eleven Ephemera', 'twentyeleven' ),
@@ -40,7 +40,7 @@ class Twenty_Eleven_Ephemera_Widget extends WP_Widget {
 	 * @since Twenty Eleven 1.0
 	 * @deprecated Twenty Eleven 2.2
 	 */
-	function Twenty_Eleven_Ephemera_Widget() {
+	public function Twenty_Eleven_Ephemera_Widget() {
 		self::__construct();
 	}
 
@@ -52,7 +52,7 @@ class Twenty_Eleven_Ephemera_Widget extends WP_Widget {
 	 * @param array $args     An array of standard parameters for widgets in this theme.
 	 * @param array $instance An array of settings for this widget instance.
 	 */
-	function widget( $args, $instance ) {
+	public function widget( $args, $instance ) {
 		$cache = wp_cache_get( 'widget_twentyeleven_ephemera', 'widget' );
 
 		if ( ! is_array( $cache ) ) {
@@ -158,7 +158,7 @@ class Twenty_Eleven_Ephemera_Widget extends WP_Widget {
 	 *
 	 * @since Twenty Eleven 1.0
 	 */
-	function update( $new_instance, $old_instance ) {
+	public function update( $new_instance, $old_instance ) {
 		$instance           = $old_instance;
 		$instance['title']  = strip_tags( $new_instance['title'] );
 		$instance['number'] = (int) $new_instance['number'];
@@ -177,7 +177,7 @@ class Twenty_Eleven_Ephemera_Widget extends WP_Widget {
 	 *
 	 * @since Twenty Eleven 1.0
 	 */
-	function flush_widget_cache() {
+	public function flush_widget_cache() {
 		wp_cache_delete( 'widget_twentyeleven_ephemera', 'widget' );
 	}
 
@@ -188,7 +188,7 @@ class Twenty_Eleven_Ephemera_Widget extends WP_Widget {
 	 *
 	 * @since Twenty Eleven 1.0
 	 */
-	function form( $instance ) {
+	public function form( $instance ) {
 		$title  = isset( $instance['title'] ) ? esc_attr( $instance['title'] ) : '';
 		$number = isset( $instance['number'] ) ? absint( $instance['number'] ) : 10;
 		?>

--- a/src/wp-content/themes/twentyfourteen/inc/widgets.php
+++ b/src/wp-content/themes/twentyfourteen/inc/widgets.php
@@ -269,7 +269,7 @@ class Twenty_Fourteen_Ephemera_Widget extends WP_Widget {
 	 * @param array $old_instance Original widget instance.
 	 * @return array Updated widget instance.
 	 */
-	function update( $new_instance, $old_instance ) {
+	public function update( $new_instance, $old_instance ) {
 		$old_instance['title']  = strip_tags( $new_instance['title'] );
 		$old_instance['number'] = empty( $new_instance['number'] ) ? 2 : absint( $new_instance['number'] );
 
@@ -287,7 +287,7 @@ class Twenty_Fourteen_Ephemera_Widget extends WP_Widget {
 	 *
 	 * @param array $instance
 	 */
-	function form( $instance ) {
+	public function form( $instance ) {
 		$title  = ! empty( $instance['title'] ) ? esc_attr( $instance['title'] ) : '';
 		$number = ! empty( $instance['number'] ) ? absint( $instance['number'] ) : 2;
 		$format = isset( $instance['format'] ) ? $instance['format'] : '';

--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -1185,7 +1185,7 @@ final class WP_Customize_Manager {
 	 *
 	 * @param array $starter_content Starter content. Defaults to `get_theme_starter_content()`.
 	 */
-	function import_theme_starter_content( $starter_content = array() ) {
+	public function import_theme_starter_content( $starter_content = array() ) {
 		if ( empty( $starter_content ) ) {
 			$starter_content = get_theme_starter_content();
 		}
@@ -2622,7 +2622,7 @@ final class WP_Customize_Manager {
 	 *
 	 * @return array|WP_Error Returns array on success and WP_Error with array data on error.
 	 */
-	function save_changeset_post( $args = array() ) {
+	public function save_changeset_post( $args = array() ) {
 
 		$args = array_merge(
 			array(

--- a/src/wp-includes/class-wp-customize-setting.php
+++ b/src/wp-includes/class-wp-customize-setting.php
@@ -268,7 +268,7 @@ class WP_Customize_Setting {
 	 * @since 4.5.0
 	 * @ignore
 	 */
-	static public function reset_aggregated_multidimensionals() {
+	public static function reset_aggregated_multidimensionals() {
 		self::$aggregated_multidimensionals = array();
 	}
 

--- a/src/wp-includes/pomo/entry.php
+++ b/src/wp-includes/pomo/entry.php
@@ -40,7 +40,7 @@ if ( ! class_exists( 'Translation_Entry', false ) ) :
 		 *  - references (array) -- places in the code this strings is used, in relative_to_root_path/file.php:linenum form
 		 *  - flags (array) -- flags like php-format
 		 */
-		function __construct( $args = array() ) {
+		public function __construct( $args = array() ) {
 			// If no singular -- empty object.
 			if ( ! isset( $args['singular'] ) ) {
 				return;
@@ -80,7 +80,7 @@ if ( ! class_exists( 'Translation_Entry', false ) ) :
 		 *
 		 * @return string|bool the key or false if the entry is empty
 		 */
-		function key() {
+		public function key() {
 			if ( null === $this->singular || '' === $this->singular ) {
 				return false;
 			}
@@ -96,7 +96,7 @@ if ( ! class_exists( 'Translation_Entry', false ) ) :
 		/**
 		 * @param object $other
 		 */
-		function merge_with( &$other ) {
+		public function merge_with( &$other ) {
 			$this->flags      = array_unique( array_merge( $this->flags, $other->flags ) );
 			$this->references = array_unique( array_merge( $this->references, $other->references ) );
 			if ( $this->extracted_comments != $other->extracted_comments ) {

--- a/src/wp-includes/pomo/mo.php
+++ b/src/wp-includes/pomo/mo.php
@@ -37,7 +37,7 @@ if ( ! class_exists( 'MO', false ) ) :
 		 * @param string $filename MO file to load
 		 * @return bool True if the import from file was successful, otherwise false.
 		 */
-		function import_from_file( $filename ) {
+		public function import_from_file( $filename ) {
 			$reader = new POMO_FileReader( $filename );
 
 			if ( ! $reader->is_resource() ) {
@@ -53,7 +53,7 @@ if ( ! class_exists( 'MO', false ) ) :
 		 * @param string $filename
 		 * @return bool
 		 */
-		function export_to_file( $filename ) {
+		public function export_to_file( $filename ) {
 			$fh = fopen( $filename, 'wb' );
 			if ( ! $fh ) {
 				return false;
@@ -66,7 +66,7 @@ if ( ! class_exists( 'MO', false ) ) :
 		/**
 		 * @return string|false
 		 */
-		function export() {
+		public function export() {
 			$tmp_fh = fopen( 'php://temp', 'r+' );
 			if ( ! $tmp_fh ) {
 				return false;
@@ -80,7 +80,7 @@ if ( ! class_exists( 'MO', false ) ) :
 		 * @param Translation_Entry $entry
 		 * @return bool
 		 */
-		function is_entry_good_for_export( $entry ) {
+		public function is_entry_good_for_export( $entry ) {
 			if ( empty( $entry->translations ) ) {
 				return false;
 			}
@@ -96,7 +96,7 @@ if ( ! class_exists( 'MO', false ) ) :
 		 * @param resource $fh
 		 * @return true
 		 */
-		function export_to_file_handle( $fh ) {
+		public function export_to_file_handle( $fh ) {
 			$entries = array_filter( $this->entries, array( $this, 'is_entry_good_for_export' ) );
 			ksort( $entries );
 			$magic                     = 0x950412de;
@@ -157,7 +157,7 @@ if ( ! class_exists( 'MO', false ) ) :
 		 * @param Translation_Entry $entry
 		 * @return string
 		 */
-		function export_original( $entry ) {
+		public function export_original( $entry ) {
 			// TODO: Warnings for control characters.
 			$exported = $entry->singular;
 			if ( $entry->is_plural ) {
@@ -173,7 +173,7 @@ if ( ! class_exists( 'MO', false ) ) :
 		 * @param Translation_Entry $entry
 		 * @return string
 		 */
-		function export_translations( $entry ) {
+		public function export_translations( $entry ) {
 			// TODO: Warnings for control characters.
 			return $entry->is_plural ? implode( "\0", $entry->translations ) : $entry->translations[0];
 		}
@@ -181,7 +181,7 @@ if ( ! class_exists( 'MO', false ) ) :
 		/**
 		 * @return string
 		 */
-		function export_headers() {
+		public function export_headers() {
 			$exported = '';
 			foreach ( $this->headers as $header => $value ) {
 				$exported .= "$header: $value\n";
@@ -193,7 +193,7 @@ if ( ! class_exists( 'MO', false ) ) :
 		 * @param int $magic
 		 * @return string|false
 		 */
-		function get_byteorder( $magic ) {
+		public function get_byteorder( $magic ) {
 			// The magic is 0x950412de.
 
 			// bug in PHP 5.0.2, see https://savannah.nongnu.org/bugs/?func=detailitem&item_id=10565
@@ -214,7 +214,7 @@ if ( ! class_exists( 'MO', false ) ) :
 		 * @param POMO_FileReader $reader
 		 * @return bool True if the import was successful, otherwise false.
 		 */
-		function import_from_reader( $reader ) {
+		public function import_from_reader( $reader ) {
 			$endian_string = MO::get_byteorder( $reader->readint32() );
 			if ( false === $endian_string ) {
 				return false;
@@ -311,7 +311,7 @@ if ( ! class_exists( 'MO', false ) ) :
 		 *  0x00 as a plural translations separator
 		 * @return Translation_Entry Entry instance.
 		 */
-		function &make_entry( $original, $translation ) {
+		public function &make_entry( $original, $translation ) {
 			$entry = new Translation_Entry();
 			// Look for context, separated by \4.
 			$parts = explode( "\4", $original );
@@ -335,14 +335,14 @@ if ( ! class_exists( 'MO', false ) ) :
 		 * @param int $count
 		 * @return string
 		 */
-		function select_plural_form( $count ) {
+		public function select_plural_form( $count ) {
 			return $this->gettext_select_plural_form( $count );
 		}
 
 		/**
 		 * @return int
 		 */
-		function get_plural_forms_count() {
+		public function get_plural_forms_count() {
 			return $this->_nplurals;
 		}
 	}

--- a/src/wp-includes/pomo/po.php
+++ b/src/wp-includes/pomo/po.php
@@ -36,7 +36,7 @@ if ( ! class_exists( 'PO', false ) ) :
 		 *
 		 * @return string msgid/msgstr PO entry for this PO file headers, doesn't contain newline at the end
 		 */
-		function export_headers() {
+		public function export_headers() {
 			$header_string = '';
 			foreach ( $this->headers as $header => $value ) {
 				$header_string .= "$header: $value\n";
@@ -55,7 +55,7 @@ if ( ! class_exists( 'PO', false ) ) :
 		 *
 		 * @return string sequence of mgsgid/msgstr PO strings, doesn't containt newline at the end
 		 */
-		function export_entries() {
+		public function export_entries() {
 			// TODO: Sorting.
 			return implode( "\n\n", array_map( array( 'PO', 'export_entry' ), $this->entries ) );
 		}
@@ -66,7 +66,7 @@ if ( ! class_exists( 'PO', false ) ) :
 		 * @param bool $include_headers whether to include the headers in the export
 		 * @return string ready for inclusion in PO file string for headers and all the enrtries
 		 */
-		function export( $include_headers = true ) {
+		public function export( $include_headers = true ) {
 			$res = '';
 			if ( $include_headers ) {
 				$res .= $this->export_headers();
@@ -83,7 +83,7 @@ if ( ! class_exists( 'PO', false ) ) :
 		 * @param bool   $include_headers Whether to include the headers in the export.
 		 * @return bool true on success, false on error
 		 */
-		function export_to_file( $filename, $include_headers = true ) {
+		public function export_to_file( $filename, $include_headers = true ) {
 			$fh = fopen( $filename, 'w' );
 			if ( false === $fh ) {
 				return false;
@@ -103,7 +103,7 @@ if ( ! class_exists( 'PO', false ) ) :
 		 *
 		 * @param string $text Text to include as a comment.
 		 */
-		function set_comment_before_headers( $text ) {
+		public function set_comment_before_headers( $text ) {
 			$this->comments_before_headers = $text;
 		}
 
@@ -293,7 +293,7 @@ if ( ! class_exists( 'PO', false ) ) :
 		 * @param string $filename
 		 * @return bool
 		 */
-		function import_from_file( $filename ) {
+		public function import_from_file( $filename ) {
 			$f = fopen( $filename, 'r' );
 			if ( ! $f ) {
 				return false;
@@ -335,7 +335,7 @@ if ( ! class_exists( 'PO', false ) ) :
 		 * @param int      $lineno
 		 * @return null|false|array
 		 */
-		function read_entry( $f, $lineno = 0 ) {
+		public function read_entry( $f, $lineno = 0 ) {
 			$entry = new Translation_Entry();
 			// Where were we in the last step.
 			// Can be: comment, msgctxt, msgid, msgid_plural, msgstr, msgstr_plural.
@@ -464,7 +464,7 @@ if ( ! class_exists( 'PO', false ) ) :
 		 * @param string   $action
 		 * @return bool
 		 */
-		function read_line( $f, $action = 'read' ) {
+		public function read_line( $f, $action = 'read' ) {
 			static $last_line     = '';
 			static $use_last_line = false;
 			if ( 'clear' === $action ) {
@@ -486,7 +486,7 @@ if ( ! class_exists( 'PO', false ) ) :
 		 * @param Translation_Entry $entry
 		 * @param string            $po_comment_line
 		 */
-		function add_comment_to_entry( &$entry, $po_comment_line ) {
+		public function add_comment_to_entry( &$entry, $po_comment_line ) {
 			$first_two = substr( $po_comment_line, 0, 2 );
 			$comment   = trim( substr( $po_comment_line, 2 ) );
 			if ( '#:' === $first_two ) {

--- a/src/wp-includes/pomo/streams.php
+++ b/src/wp-includes/pomo/streams.php
@@ -17,7 +17,7 @@ if ( ! class_exists( 'POMO_Reader', false ) ) :
 		/**
 		 * PHP5 constructor.
 		 */
-		function __construct() {
+		public function __construct() {
 			if ( function_exists( 'mb_substr' )
 				&& ( (int) ini_get( 'mbstring.func_overload' ) & 2 ) // phpcs:ignore PHPCompatibility.IniDirectives.RemovedIniDirectives.mbstring_func_overloadDeprecated
 			) {
@@ -46,7 +46,7 @@ if ( ! class_exists( 'POMO_Reader', false ) ) :
 		 *
 		 * @param string $endian Set the endianness of the file. Accepts 'big', or 'little'.
 		 */
-		function setEndian( $endian ) { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+		public function setEndian( $endian ) { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
 			$this->endian = $endian;
 		}
 
@@ -56,7 +56,7 @@ if ( ! class_exists( 'POMO_Reader', false ) ) :
 		 * @return mixed The integer, corresponding to the next 32 bits from
 		 *  the stream of false if there are not enough bytes or on error
 		 */
-		function readint32() {
+		public function readint32() {
 			$bytes = $this->read( 4 );
 			if ( 4 != $this->strlen( $bytes ) ) {
 				return false;
@@ -73,7 +73,7 @@ if ( ! class_exists( 'POMO_Reader', false ) ) :
 		 * @return mixed Array of integers or false if there isn't
 		 *  enough data or on error
 		 */
-		function readint32array( $count ) {
+		public function readint32array( $count ) {
 			$bytes = $this->read( 4 * $count );
 			if ( 4 * $count != $this->strlen( $bytes ) ) {
 				return false;
@@ -88,7 +88,7 @@ if ( ! class_exists( 'POMO_Reader', false ) ) :
 		 * @param int    $length
 		 * @return string
 		 */
-		function substr( $string, $start, $length ) {
+		public function substr( $string, $start, $length ) {
 			if ( $this->is_overloaded ) {
 				return mb_substr( $string, $start, $length, 'ascii' );
 			} else {
@@ -100,7 +100,7 @@ if ( ! class_exists( 'POMO_Reader', false ) ) :
 		 * @param string $string
 		 * @return int
 		 */
-		function strlen( $string ) {
+		public function strlen( $string ) {
 			if ( $this->is_overloaded ) {
 				return mb_strlen( $string, 'ascii' );
 			} else {
@@ -113,7 +113,7 @@ if ( ! class_exists( 'POMO_Reader', false ) ) :
 		 * @param int    $chunk_size
 		 * @return array
 		 */
-		function str_split( $string, $chunk_size ) {
+		public function str_split( $string, $chunk_size ) {
 			if ( ! function_exists( 'str_split' ) ) {
 				$length = $this->strlen( $string );
 				$out    = array();
@@ -129,21 +129,21 @@ if ( ! class_exists( 'POMO_Reader', false ) ) :
 		/**
 		 * @return int
 		 */
-		function pos() {
+		public function pos() {
 			return $this->_pos;
 		}
 
 		/**
 		 * @return true
 		 */
-		function is_resource() {
+		public function is_resource() {
 			return true;
 		}
 
 		/**
 		 * @return true
 		 */
-		function close() {
+		public function close() {
 			return true;
 		}
 	}
@@ -155,7 +155,7 @@ if ( ! class_exists( 'POMO_FileReader', false ) ) :
 		/**
 		 * @param string $filename
 		 */
-		function __construct( $filename ) {
+		public function __construct( $filename ) {
 			parent::__construct();
 			$this->_f = fopen( $filename, 'rb' );
 		}
@@ -176,7 +176,7 @@ if ( ! class_exists( 'POMO_FileReader', false ) ) :
 		 * @param int $bytes
 		 * @return string|false Returns read string, otherwise false.
 		 */
-		function read( $bytes ) {
+		public function read( $bytes ) {
 			return fread( $this->_f, $bytes );
 		}
 
@@ -184,7 +184,7 @@ if ( ! class_exists( 'POMO_FileReader', false ) ) :
 		 * @param int $pos
 		 * @return bool
 		 */
-		function seekto( $pos ) {
+		public function seekto( $pos ) {
 			if ( -1 == fseek( $this->_f, $pos, SEEK_SET ) ) {
 				return false;
 			}
@@ -195,28 +195,28 @@ if ( ! class_exists( 'POMO_FileReader', false ) ) :
 		/**
 		 * @return bool
 		 */
-		function is_resource() {
+		public function is_resource() {
 			return is_resource( $this->_f );
 		}
 
 		/**
 		 * @return bool
 		 */
-		function feof() {
+		public function feof() {
 			return feof( $this->_f );
 		}
 
 		/**
 		 * @return bool
 		 */
-		function close() {
+		public function close() {
 			return fclose( $this->_f );
 		}
 
 		/**
 		 * @return string
 		 */
-		function read_all() {
+		public function read_all() {
 			$all = '';
 			while ( ! $this->feof() ) {
 				$all .= $this->read( 4096 );
@@ -238,7 +238,7 @@ if ( ! class_exists( 'POMO_StringReader', false ) ) :
 		/**
 		 * PHP5 constructor.
 		 */
-		function __construct( $str = '' ) {
+		public function __construct( $str = '' ) {
 			parent::__construct();
 			$this->_str = $str;
 			$this->_pos = 0;
@@ -260,7 +260,7 @@ if ( ! class_exists( 'POMO_StringReader', false ) ) :
 		 * @param string $bytes
 		 * @return string
 		 */
-		function read( $bytes ) {
+		public function read( $bytes ) {
 			$data        = $this->substr( $this->_str, $this->_pos, $bytes );
 			$this->_pos += $bytes;
 			if ( $this->strlen( $this->_str ) < $this->_pos ) {
@@ -273,7 +273,7 @@ if ( ! class_exists( 'POMO_StringReader', false ) ) :
 		 * @param int $pos
 		 * @return int
 		 */
-		function seekto( $pos ) {
+		public function seekto( $pos ) {
 			$this->_pos = $pos;
 			if ( $this->strlen( $this->_str ) < $this->_pos ) {
 				$this->_pos = $this->strlen( $this->_str );
@@ -284,14 +284,14 @@ if ( ! class_exists( 'POMO_StringReader', false ) ) :
 		/**
 		 * @return int
 		 */
-		function length() {
+		public function length() {
 			return $this->strlen( $this->_str );
 		}
 
 		/**
 		 * @return string
 		 */
-		function read_all() {
+		public function read_all() {
 			return $this->substr( $this->_str, $this->_pos, $this->strlen( $this->_str ) );
 		}
 
@@ -306,7 +306,7 @@ if ( ! class_exists( 'POMO_CachedFileReader', false ) ) :
 		/**
 		 * PHP5 constructor.
 		 */
-		function __construct( $filename ) {
+		public function __construct( $filename ) {
 			parent::__construct();
 			$this->_str = file_get_contents( $filename );
 			if ( false === $this->_str ) {
@@ -348,7 +348,7 @@ if ( ! class_exists( 'POMO_CachedIntFileReader', false ) ) :
 		 *
 		 * @see POMO_CachedIntFileReader::__construct()
 		 */
-		function POMO_CachedIntFileReader( $filename ) {
+		public function POMO_CachedIntFileReader( $filename ) {
 			_deprecated_constructor( self::class, '5.4.0', static::class );
 			self::__construct( $filename );
 		}

--- a/src/wp-includes/pomo/translations.php
+++ b/src/wp-includes/pomo/translations.php
@@ -21,7 +21,7 @@ if ( ! class_exists( 'Translations', false ) ) :
 		 * @param array|Translation_Entry $entry
 		 * @return bool true on success, false if the entry doesn't have a key
 		 */
-		function add_entry( $entry ) {
+		public function add_entry( $entry ) {
 			if ( is_array( $entry ) ) {
 				$entry = new Translation_Entry( $entry );
 			}
@@ -37,7 +37,7 @@ if ( ! class_exists( 'Translations', false ) ) :
 		 * @param array|Translation_Entry $entry
 		 * @return bool
 		 */
-		function add_entry_or_merge( $entry ) {
+		public function add_entry_or_merge( $entry ) {
 			if ( is_array( $entry ) ) {
 				$entry = new Translation_Entry( $entry );
 			}
@@ -63,14 +63,14 @@ if ( ! class_exists( 'Translations', false ) ) :
 		 * @param string $header header name, without trailing :
 		 * @param string $value header value, without trailing \n
 		 */
-		function set_header( $header, $value ) {
+		public function set_header( $header, $value ) {
 			$this->headers[ $header ] = $value;
 		}
 
 		/**
 		 * @param array $headers
 		 */
-		function set_headers( $headers ) {
+		public function set_headers( $headers ) {
 			foreach ( $headers as $header => $value ) {
 				$this->set_header( $header, $value );
 			}
@@ -79,14 +79,14 @@ if ( ! class_exists( 'Translations', false ) ) :
 		/**
 		 * @param string $header
 		 */
-		function get_header( $header ) {
+		public function get_header( $header ) {
 			return isset( $this->headers[ $header ] ) ? $this->headers[ $header ] : false;
 		}
 
 		/**
 		 * @param Translation_Entry $entry
 		 */
-		function translate_entry( &$entry ) {
+		public function translate_entry( &$entry ) {
 			$key = $entry->key();
 			return isset( $this->entries[ $key ] ) ? $this->entries[ $key ] : false;
 		}
@@ -96,7 +96,7 @@ if ( ! class_exists( 'Translations', false ) ) :
 		 * @param string $context
 		 * @return string
 		 */
-		function translate( $singular, $context = null ) {
+		public function translate( $singular, $context = null ) {
 			$entry      = new Translation_Entry(
 				array(
 					'singular' => $singular,
@@ -118,14 +118,14 @@ if ( ! class_exists( 'Translations', false ) ) :
 		 *
 		 * @param int $count number of items
 		 */
-		function select_plural_form( $count ) {
+		public function select_plural_form( $count ) {
 			return 1 == $count ? 0 : 1;
 		}
 
 		/**
 		 * @return int
 		 */
-		function get_plural_forms_count() {
+		public function get_plural_forms_count() {
 			return 2;
 		}
 
@@ -135,7 +135,7 @@ if ( ! class_exists( 'Translations', false ) ) :
 		 * @param int    $count
 		 * @param string $context
 		 */
-		function translate_plural( $singular, $plural, $count, $context = null ) {
+		public function translate_plural( $singular, $plural, $count, $context = null ) {
 			$entry              = new Translation_Entry(
 				array(
 					'singular' => $singular,
@@ -161,7 +161,7 @@ if ( ! class_exists( 'Translations', false ) ) :
 		 * @param Object $other Another Translation object, whose translations will be merged in this one (passed by reference).
 		 * @return void
 		 */
-		function merge_with( &$other ) {
+		public function merge_with( &$other ) {
 			foreach ( $other->entries as $entry ) {
 				$this->entries[ $entry->key() ] = $entry;
 			}
@@ -170,7 +170,7 @@ if ( ! class_exists( 'Translations', false ) ) :
 		/**
 		 * @param object $other
 		 */
-		function merge_originals_with( &$other ) {
+		public function merge_originals_with( &$other ) {
 			foreach ( $other->entries as $entry ) {
 				if ( ! isset( $this->entries[ $entry->key() ] ) ) {
 					$this->entries[ $entry->key() ] = $entry;
@@ -190,7 +190,7 @@ if ( ! class_exists( 'Translations', false ) ) :
 		 *
 		 * @param int $count
 		 */
-		function gettext_select_plural_form( $count ) {
+		public function gettext_select_plural_form( $count ) {
 			if ( ! isset( $this->_gettext_select_plural_form ) || is_null( $this->_gettext_select_plural_form ) ) {
 				list( $nplurals, $expression )     = $this->nplurals_and_expression_from_header( $this->get_header( 'Plural-Forms' ) );
 				$this->_nplurals                   = $nplurals;
@@ -203,7 +203,7 @@ if ( ! class_exists( 'Translations', false ) ) :
 		 * @param string $header
 		 * @return array
 		 */
-		function nplurals_and_expression_from_header( $header ) {
+		public function nplurals_and_expression_from_header( $header ) {
 			if ( preg_match( '/^\s*nplurals\s*=\s*(\d+)\s*;\s+plural\s*=\s*(.+)$/', $header, $matches ) ) {
 				$nplurals   = (int) $matches[1];
 				$expression = trim( $matches[2] );
@@ -220,7 +220,7 @@ if ( ! class_exists( 'Translations', false ) ) :
 		 * @param int    $nplurals
 		 * @param string $expression
 		 */
-		function make_plural_form_function( $nplurals, $expression ) {
+		public function make_plural_form_function( $nplurals, $expression ) {
 			try {
 				$handler = new Plural_Forms( rtrim( $expression, ';' ) );
 				return array( $handler, 'get' );
@@ -237,7 +237,7 @@ if ( ! class_exists( 'Translations', false ) ) :
 		 * @param string $expression the expression without parentheses
 		 * @return string the expression with parentheses added
 		 */
-		function parenthesize_plural_exression( $expression ) {
+		public function parenthesize_plural_exression( $expression ) {
 			$expression .= ';';
 			$res         = '';
 			$depth       = 0;
@@ -266,7 +266,7 @@ if ( ! class_exists( 'Translations', false ) ) :
 		 * @param string $translation
 		 * @return array
 		 */
-		function make_headers( $translation ) {
+		public function make_headers( $translation ) {
 			$headers = array();
 			// Sometimes \n's are used instead of real new lines.
 			$translation = str_replace( '\n', "\n", $translation );
@@ -285,7 +285,7 @@ if ( ! class_exists( 'Translations', false ) ) :
 		 * @param string $header
 		 * @param string $value
 		 */
-		function set_header( $header, $value ) {
+		public function set_header( $header, $value ) {
 			parent::set_header( $header, $value );
 			if ( 'Plural-Forms' === $header ) {
 				list( $nplurals, $expression )     = $this->nplurals_and_expression_from_header( $this->get_header( 'Plural-Forms' ) );
@@ -304,7 +304,7 @@ if ( ! class_exists( 'NOOP_Translations', false ) ) :
 		public $entries = array();
 		public $headers = array();
 
-		function add_entry( $entry ) {
+		public function add_entry( $entry ) {
 			return true;
 		}
 
@@ -312,20 +312,20 @@ if ( ! class_exists( 'NOOP_Translations', false ) ) :
 		 * @param string $header
 		 * @param string $value
 		 */
-		function set_header( $header, $value ) {
+		public function set_header( $header, $value ) {
 		}
 
 		/**
 		 * @param array $headers
 		 */
-		function set_headers( $headers ) {
+		public function set_headers( $headers ) {
 		}
 
 		/**
 		 * @param string $header
 		 * @return false
 		 */
-		function get_header( $header ) {
+		public function get_header( $header ) {
 			return false;
 		}
 
@@ -333,7 +333,7 @@ if ( ! class_exists( 'NOOP_Translations', false ) ) :
 		 * @param Translation_Entry $entry
 		 * @return false
 		 */
-		function translate_entry( &$entry ) {
+		public function translate_entry( &$entry ) {
 			return false;
 		}
 
@@ -341,7 +341,7 @@ if ( ! class_exists( 'NOOP_Translations', false ) ) :
 		 * @param string $singular
 		 * @param string $context
 		 */
-		function translate( $singular, $context = null ) {
+		public function translate( $singular, $context = null ) {
 			return $singular;
 		}
 
@@ -349,14 +349,14 @@ if ( ! class_exists( 'NOOP_Translations', false ) ) :
 		 * @param int $count
 		 * @return bool
 		 */
-		function select_plural_form( $count ) {
+		public function select_plural_form( $count ) {
 			return 1 == $count ? 0 : 1;
 		}
 
 		/**
 		 * @return int
 		 */
-		function get_plural_forms_count() {
+		public function get_plural_forms_count() {
 			return 2;
 		}
 
@@ -366,14 +366,14 @@ if ( ! class_exists( 'NOOP_Translations', false ) ) :
 		 * @param int    $count
 		 * @param string $context
 		 */
-		function translate_plural( $singular, $plural, $count, $context = null ) {
+		public function translate_plural( $singular, $plural, $count, $context = null ) {
 			return 1 == $count ? $singular : $plural;
 		}
 
 		/**
 		 * @param object $other
 		 */
-		function merge_with( &$other ) {
+		public function merge_with( &$other ) {
 		}
 	}
 endif;

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -1216,7 +1216,7 @@ class wpdb {
 	 * @param string $string
 	 * @return string
 	 */
-	function _weak_escape( $string ) {
+	public function _weak_escape( $string ) {
 		if ( func_num_args() === 1 && function_exists( '_deprecated_function' ) ) {
 			_deprecated_function( __METHOD__, '3.6.0', 'wpdb::prepare() or esc_sql()' );
 		}
@@ -1234,7 +1234,7 @@ class wpdb {
 	 * @param string $string String to escape.
 	 * @return string Escaped string.
 	 */
-	function _real_escape( $string ) {
+	public function _real_escape( $string ) {
 		if ( ! is_scalar( $string ) ) {
 			return '';
 		}
@@ -2331,7 +2331,7 @@ class wpdb {
 	 *                             Default 'INSERT'.
 	 * @return int|false The number of rows affected, or false on error.
 	 */
-	function _insert_replace_helper( $table, $data, $format = null, $type = 'INSERT' ) {
+	public function _insert_replace_helper( $table, $data, $format = null, $type = 'INSERT' ) {
 		$this->insert_id = 0;
 
 		if ( ! in_array( strtoupper( $type ), array( 'REPLACE', 'INSERT' ), true ) ) {


### PR DESCRIPTION
Coding Standards: Add visibility to methods in `src` directory.

"Visibility should always be declared"
See: https://make.wordpress.org/core/2020/03/20/updating-the-coding-standards-for-modern-php/

This commit applies the following sniffs to files in `src`:
- Squiz.Scope.MethodScope
- PSR2.Methods.MethodDeclaration
- PSR2.Classes.PropertyDeclaration
- Squiz.WhiteSpace.ScopeKeywordSpacing

For all methods, these now indicate `public` visibility to avoid breaking backwards compatibility.

Trac ticket: https://core.trac.wordpress.org/ticket/54177
