### PR TITLE
Coding Standards: Add visibility to methods in `tests/phpunit/includes/` directory.

### DIFF
--- a/tests/phpunit/includes/bootstrap.php
+++ b/tests/phpunit/includes/bootstrap.php
@@ -340,7 +340,7 @@ require __DIR__ . '/class-wp-sitemaps-large-test-provider.php';
  */
 class WP_PHPUnit_Util_Getopt {
 
-	function __construct( $argv ) {
+	public function __construct( $argv ) {
 		$skipped_groups = array(
 			'ajax'          => true,
 			'ms-files'      => true,

--- a/tests/phpunit/includes/mock-fs.php
+++ b/tests/phpunit/includes/mock-fs.php
@@ -13,14 +13,14 @@ class WP_Filesystem_MockFS extends WP_Filesystem_Base {
 	public $errors  = array();
 	public $method  = 'MockFS';
 
-	function __construct() {}
+	public function __construct() {}
 
-	function connect() {
+	public function connect() {
 		return true;
 	}
 
 	// Copy of core's function, but accepts a path.
-	function abspath( $path = false ) {
+	public function abspath( $path = false ) {
 		if ( ! $path ) {
 			$path = ABSPATH;
 		}
@@ -40,7 +40,7 @@ class WP_Filesystem_MockFS extends WP_Filesystem_Base {
 	 * Sets initial filesystem environment and/or clears the current environment.
 	 * Can also be passed the initial filesystem to be setup which is passed to self::setfs()
 	 */
-	function init( $paths = '', $home_dir = '/' ) {
+	public function init( $paths = '', $home_dir = '/' ) {
 		$this->fs     = new MockFS_Directory_Node( '/' );
 		$this->fs_map = array(
 			'/' => $this->fs,
@@ -53,7 +53,7 @@ class WP_Filesystem_MockFS extends WP_Filesystem_Base {
 	/**
 	 * "Bulk Loads" a filesystem into the internal virtual filesystem
 	 */
-	function setfs( $paths ) {
+	public function setfs( $paths ) {
 		if ( ! is_array( $paths ) ) {
 			$paths = explode( "\n", $paths );
 		}
@@ -93,7 +93,7 @@ class WP_Filesystem_MockFS extends WP_Filesystem_Base {
 
 	// Here starteth the WP_Filesystem functions.
 
-	function mkdir( $path, /* Optional args are ignored */ $chmod = false, $chown = false, $chgrp = false ) {
+	public function mkdir( $path, /* Optional args are ignored */ $chmod = false, $chown = false, $chgrp = false ) {
 		$path = trailingslashit( $path );
 
 		$parent_node = $this->locate_parent_node( $path );
@@ -114,7 +114,7 @@ class WP_Filesystem_MockFS extends WP_Filesystem_Base {
 		return true;
 	}
 
-	function put_contents( $path, $contents = '', $mode = null ) {
+	public function put_contents( $path, $contents = '', $mode = null ) {
 		if ( ! $this->is_dir( dirname( $path ) ) ) {
 			$this->mkdir( dirname( $path ) );
 		}
@@ -126,18 +126,18 @@ class WP_Filesystem_MockFS extends WP_Filesystem_Base {
 		$this->fs_map[ $path ]               = $new_file;
 	}
 
-	function get_contents( $file ) {
+	public function get_contents( $file ) {
 		if ( ! $this->is_file( $file ) ) {
 			return false;
 		}
 		return $this->fs_map[ $file ]->contents;
 	}
 
-	function cwd() {
+	public function cwd() {
 		return $this->cwd->path;
 	}
 
-	function chdir( $path ) {
+	public function chdir( $path ) {
 		if ( ! isset( $this->fs_map[ $path ] ) ) {
 			return false;
 		}
@@ -146,21 +146,21 @@ class WP_Filesystem_MockFS extends WP_Filesystem_Base {
 		return true;
 	}
 
-	function exists( $path ) {
+	public function exists( $path ) {
 		return isset( $this->fs_map[ $path ] ) || isset( $this->fs_map[ trailingslashit( $path ) ] );
 	}
 
-	function is_file( $file ) {
+	public function is_file( $file ) {
 		return isset( $this->fs_map[ $file ] ) && $this->fs_map[ $file ]->is_file();
 	}
 
-	function is_dir( $path ) {
+	public function is_dir( $path ) {
 		$path = trailingslashit( $path );
 
 		return isset( $this->fs_map[ $path ] ) && $this->fs_map[ $path ]->is_dir();
 	}
 
-	function dirlist( $path = '.', $include_hidden = true, $recursive = false ) {
+	public function dirlist( $path = '.', $include_hidden = true, $recursive = false ) {
 
 		if ( empty( $path ) || '.' === $path ) {
 			$path = $this->cwd();
@@ -214,16 +214,16 @@ class MockFS_Node {
 	public $type; // The type of the entry 'f' for file, 'd' for directory.
 	public $path; // The full path to the entry.
 
-	function __construct( $path ) {
+	public function __construct( $path ) {
 		$this->path = $path;
 		$this->name = basename( $path );
 	}
 
-	function is_file() {
+	public function is_file() {
 		return 'f' === $this->type;
 	}
 
-	function is_dir() {
+	public function is_dir() {
 		return 'd' === $this->type;
 	}
 }
@@ -237,7 +237,7 @@ class MockFS_File_Node extends MockFS_Node {
 	public $type     = 'f';
 	public $contents = ''; // The contents of the file.
 
-	function __construct( $path, $contents = '' ) {
+	public function __construct( $path, $contents = '' ) {
 		parent::__construct( $path );
 		$this->contents = $contents;
 	}

--- a/tests/phpunit/includes/mock-mailer.php
+++ b/tests/phpunit/includes/mock-mailer.php
@@ -5,7 +5,7 @@ require_once ABSPATH . 'wp-includes/PHPMailer/Exception.php';
 class MockPHPMailer extends PHPMailer\PHPMailer\PHPMailer {
 	public $mock_sent = array();
 
-	function preSend() {
+	public function preSend() {
 		$this->Encoding = '8bit';
 		return parent::preSend();
 	}
@@ -13,7 +13,7 @@ class MockPHPMailer extends PHPMailer\PHPMailer\PHPMailer {
 	/**
 	 * Override postSend() so mail isn't actually sent.
 	 */
-	function postSend() {
+	public function postSend() {
 		$this->mock_sent[] = array(
 			'to'      => $this->to,
 			'cc'      => $this->cc,

--- a/tests/phpunit/includes/testcase-xmlrpc.php
+++ b/tests/phpunit/includes/testcase-xmlrpc.php
@@ -6,7 +6,7 @@ require_once ABSPATH . WPINC . '/class-wp-xmlrpc-server.php';
 abstract class WP_XMLRPC_UnitTestCase extends WP_UnitTestCase {
 	protected $myxmlrpcserver;
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		add_filter( 'pre_option_enable_xmlrpc', '__return_true' );
@@ -14,7 +14,7 @@ abstract class WP_XMLRPC_UnitTestCase extends WP_UnitTestCase {
 		$this->myxmlrpcserver = new wp_xmlrpc_server();
 	}
 
-	function tear_down() {
+	public function tear_down() {
 		remove_filter( 'pre_option_enable_xmlrpc', '__return_true' );
 
 		$this->remove_added_uploads();

--- a/tests/phpunit/includes/utils.php
+++ b/tests/phpunit/includes/utils.php
@@ -64,16 +64,16 @@ class MockAction {
 	/**
 	 * PHP5 constructor.
 	 */
-	function __construct( $debug = 0 ) {
+	public function __construct( $debug = 0 ) {
 		$this->reset();
 		$this->debug = $debug;
 	}
 
-	function reset() {
+	public function reset() {
 		$this->events = array();
 	}
 
-	function current_filter() {
+	public function current_filter() {
 		if ( is_callable( 'current_filter' ) ) {
 			return current_filter();
 		}
@@ -81,7 +81,7 @@ class MockAction {
 		return end( $wp_actions );
 	}
 
-	function action( $arg ) {
+	public function action( $arg ) {
 		if ( $this->debug ) {
 			dmp( __FUNCTION__, $this->current_filter() );
 		}
@@ -94,7 +94,7 @@ class MockAction {
 		return $arg;
 	}
 
-	function action2( $arg ) {
+	public function action2( $arg ) {
 		if ( $this->debug ) {
 			dmp( __FUNCTION__, $this->current_filter() );
 		}
@@ -108,7 +108,7 @@ class MockAction {
 		return $arg;
 	}
 
-	function filter( $arg ) {
+	public function filter( $arg ) {
 		if ( $this->debug ) {
 			dmp( __FUNCTION__, $this->current_filter() );
 		}
@@ -122,7 +122,7 @@ class MockAction {
 		return $arg;
 	}
 
-	function filter2( $arg ) {
+	public function filter2( $arg ) {
 		if ( $this->debug ) {
 			dmp( __FUNCTION__, $this->current_filter() );
 		}
@@ -136,7 +136,7 @@ class MockAction {
 		return $arg;
 	}
 
-	function filter_append( $arg ) {
+	public function filter_append( $arg ) {
 		if ( $this->debug ) {
 			dmp( __FUNCTION__, $this->current_filter() );
 		}
@@ -150,7 +150,7 @@ class MockAction {
 		return $arg . '_append';
 	}
 
-	function filterall( $tag, ...$args ) {
+	public function filterall( $tag, ...$args ) {
 		// This one doesn't return the result, so it's safe to use with the new 'all' filter.
 		if ( $this->debug ) {
 			dmp( __FUNCTION__, $this->current_filter() );
@@ -164,12 +164,12 @@ class MockAction {
 	}
 
 	// Return a list of all the actions, tags and args.
-	function get_events() {
+	public function get_events() {
 		return $this->events;
 	}
 
 	// Return a count of the number of times the action was called since the last reset.
-	function get_call_count( $tag = '' ) {
+	public function get_call_count( $tag = '' ) {
 		if ( $tag ) {
 			$count = 0;
 			foreach ( $this->events as $e ) {
@@ -183,7 +183,7 @@ class MockAction {
 	}
 
 	// Return an array of the tags that triggered calls to this action.
-	function get_tags() {
+	public function get_tags() {
 		$out = array();
 		foreach ( $this->events as $e ) {
 			$out[] = $e['tag'];
@@ -192,7 +192,7 @@ class MockAction {
 	}
 
 	// Return an array of args passed in calls to this action.
-	function get_args() {
+	public function get_args() {
 		$out = array();
 		foreach ( $this->events as $e ) {
 			$out[] = $e['args'];
@@ -210,7 +210,7 @@ class TestXMLParser {
 	/**
 	 * PHP5 constructor.
 	 */
-	function __construct( $in ) {
+	public function __construct( $in ) {
 		$this->xml = xml_parser_create();
 		xml_set_object( $this->xml, $this );
 		xml_parser_set_option( $this->xml, XML_OPTION_CASE_FOLDING, 0 );
@@ -219,7 +219,7 @@ class TestXMLParser {
 		$this->parse( $in );
 	}
 
-	function parse( $in ) {
+	public function parse( $in ) {
 		$parse = xml_parse( $this->xml, $in, true );
 		if ( ! $parse ) {
 			trigger_error(
@@ -235,14 +235,14 @@ class TestXMLParser {
 		return true;
 	}
 
-	function start_handler( $parser, $name, $attributes ) {
+	public function start_handler( $parser, $name, $attributes ) {
 		$data['name'] = $name;
 		if ( $attributes ) {
 			$data['attributes'] = $attributes; }
 		$this->data[] = $data;
 	}
 
-	function data_handler( $parser, $data ) {
+	public function data_handler( $parser, $data ) {
 		$index = count( $this->data ) - 1;
 
 		if ( ! isset( $this->data[ $index ]['content'] ) ) {
@@ -251,7 +251,7 @@ class TestXMLParser {
 		$this->data[ $index ]['content'] .= $data;
 	}
 
-	function end_handler( $parser, $name ) {
+	public function end_handler( $parser, $name ) {
 		if ( count( $this->data ) > 1 ) {
 			$data                            = array_pop( $this->data );
 			$index                           = count( $this->data ) - 1;


### PR DESCRIPTION
Coding Standards: Add visibility to methods in `tests/phpunit/includes/` directory.

"Visibility should always be declared"
See: https://make.wordpress.org/core/2020/03/20/updating-the-coding-standards-for-modern-php/

This commit applies the following sniffs to files in `tests/phpunit/includes/`:
- Squiz.Scope.MethodScope
- PSR2.Methods.MethodDeclaration
- PSR2.Classes.PropertyDeclaration
- Squiz.WhiteSpace.ScopeKeywordSpacing

For all methods, these now indicate `public` visibility to avoid breaking backwards compatibility.

Trac ticket: https://core.trac.wordpress.org/ticket/54177