### PR TITLE
Coding Standards: Add visibility to methods in `tests/phpunit/tests/` E-F-G-H files.

### DIFF
--- a/tests/phpunit/tests/external-http/basic.php
+++ b/tests/phpunit/tests/external-http/basic.php
@@ -9,7 +9,7 @@ class Tests_External_HTTP_Basic extends WP_UnitTestCase {
 	 * @covers ::wp_remote_retrieve_response_code
 	 * @covers ::wp_remote_retrieve_body
 	 */
-	function test_readme() {
+	public function test_readme() {
 		// This test is designed to only run on trunk/master.
 		$this->skipOnAutomatedBranches();
 

--- a/tests/phpunit/tests/feed/atom.php
+++ b/tests/phpunit/tests/feed/atom.php
@@ -66,7 +66,7 @@ class Tests_Feed_Atom extends WP_UnitTestCase {
 	/**
 	 * This is a bit of a hack used to buffer feed content.
 	 */
-	function do_atom() {
+	private function do_atom() {
 		ob_start();
 		// Nasty hack! In the future it would better to leverage do_feed( 'atom' ).
 		global $post;
@@ -85,7 +85,7 @@ class Tests_Feed_Atom extends WP_UnitTestCase {
 	 * Test the <feed> element to make sure its present and populated
 	 * with the expected child elements and attributes.
 	 */
-	function test_feed_element() {
+	public function test_feed_element() {
 		$this->go_to( '/?feed=atom' );
 		$feed = $this->do_atom();
 		$xml  = xml_to_array( $feed );
@@ -129,7 +129,7 @@ class Tests_Feed_Atom extends WP_UnitTestCase {
 	/**
 	 * Validate <entry> child elements.
 	 */
-	function test_entry_elements() {
+	public function test_entry_elements() {
 		$this->go_to( '/?feed=atom' );
 		$feed = $this->do_atom();
 		$xml  = xml_to_array( $feed );
@@ -209,7 +209,7 @@ class Tests_Feed_Atom extends WP_UnitTestCase {
 	/**
 	 * @ticket 33591
 	 */
-	function test_atom_enclosure_with_extended_url_length_type_parsing() {
+	public function test_atom_enclosure_with_extended_url_length_type_parsing() {
 		$enclosures = array(
 			array(
 				// URL, length, type.

--- a/tests/phpunit/tests/feed/rss2.php
+++ b/tests/phpunit/tests/feed/rss2.php
@@ -78,7 +78,7 @@ class Tests_Feed_RSS2 extends WP_UnitTestCase {
 	/**
 	 * This is a bit of a hack used to buffer feed content.
 	 */
-	function do_rss2() {
+	private function do_rss2() {
 		ob_start();
 		// Nasty hack! In the future it would better to leverage do_feed( 'rss2' ).
 		global $post;
@@ -97,7 +97,7 @@ class Tests_Feed_RSS2 extends WP_UnitTestCase {
 	 * Test the <rss> element to make sure its present and populated
 	 * with the expected child elements and attributes.
 	 */
-	function test_rss_element() {
+	public function test_rss_element() {
 		$this->go_to( '/?feed=rss2' );
 		$feed = $this->do_rss2();
 		$xml  = xml_to_array( $feed );
@@ -122,7 +122,7 @@ class Tests_Feed_RSS2 extends WP_UnitTestCase {
 	 *
 	 * @return [type] [description]
 	 */
-	function test_channel_element() {
+	public function test_channel_element() {
 		$this->go_to( '/?feed=rss2' );
 		$feed = $this->do_rss2();
 		$xml  = xml_to_array( $feed );
@@ -152,7 +152,7 @@ class Tests_Feed_RSS2 extends WP_UnitTestCase {
 	 *
 	 * @ticket 39141
 	 */
-	function test_channel_pubdate_element_translated() {
+	public function test_channel_pubdate_element_translated() {
 		$original_locale = $GLOBALS['wp_locale'];
 		/* @var WP_Locale $locale */
 		$locale = clone $GLOBALS['wp_locale'];
@@ -175,7 +175,7 @@ class Tests_Feed_RSS2 extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( 'Tue_Translated', $pubdate[0]['content'] );
 	}
 
-	function test_item_elements() {
+	public function test_item_elements() {
 		$this->go_to( '/?feed=rss2' );
 		$feed = $this->do_rss2();
 		$xml  = xml_to_array( $feed );
@@ -266,7 +266,7 @@ class Tests_Feed_RSS2 extends WP_UnitTestCase {
 	/**
 	 * @ticket 9134
 	 */
-	function test_items_comments_closed() {
+	public function test_items_comments_closed() {
 		add_filter( 'comments_open', '__return_false' );
 
 		$this->go_to( '/?feed=rss2' );
@@ -301,7 +301,7 @@ class Tests_Feed_RSS2 extends WP_UnitTestCase {
 	 *
 	 * @ticket 30210
 	 */
-	function test_valid_home_feed_endpoint() {
+	public function test_valid_home_feed_endpoint() {
 		// An example of a valid home feed endpoint.
 		$this->go_to( 'feed/' );
 
@@ -329,7 +329,7 @@ class Tests_Feed_RSS2 extends WP_UnitTestCase {
 	 *
 	 * @ticket 30210
 	 */
-	function test_valid_taxonomy_feed_endpoint() {
+	public function test_valid_taxonomy_feed_endpoint() {
 		// An example of an valid taxonomy feed endpoint.
 		$this->go_to( 'category/foo/feed/' );
 
@@ -357,7 +357,7 @@ class Tests_Feed_RSS2 extends WP_UnitTestCase {
 	 *
 	 * @ticket 30210
 	 */
-	function test_valid_main_comment_feed_endpoint() {
+	public function test_valid_main_comment_feed_endpoint() {
 		// Generate a bunch of comments.
 		foreach ( self::$posts as $post ) {
 			self::factory()->comment->create_post_comments( $post, 3 );
@@ -390,7 +390,7 @@ class Tests_Feed_RSS2 extends WP_UnitTestCase {
 	 *
 	 * @ticket 30210
 	 */
-	function test_valid_archive_feed_endpoint() {
+	public function test_valid_archive_feed_endpoint() {
 		// An example of an valid date archive feed endpoint.
 		$this->go_to( '2003/05/27/feed/' );
 
@@ -418,7 +418,7 @@ class Tests_Feed_RSS2 extends WP_UnitTestCase {
 	 *
 	 * @ticket 30210
 	 */
-	function test_valid_single_post_comment_feed_endpoint() {
+	public function test_valid_single_post_comment_feed_endpoint() {
 		// An example of an valid date archive feed endpoint.
 		$this->go_to( get_post_comments_feed_link( self::$posts[0] ) );
 
@@ -446,7 +446,7 @@ class Tests_Feed_RSS2 extends WP_UnitTestCase {
 	 *
 	 * @ticket 30210
 	 */
-	function test_valid_search_feed_endpoint() {
+	public function test_valid_search_feed_endpoint() {
 		// An example of an valid search feed endpoint.
 		$this->go_to( '?s=Lorem&feed=rss' );
 

--- a/tests/phpunit/tests/filesystem/base.php
+++ b/tests/phpunit/tests/filesystem/base.php
@@ -4,14 +4,14 @@
  * This class is designed to make use of MockFS, a Virtual in-memory filesystem compatible with WP_Filesystem
  */
 abstract class WP_Filesystem_UnitTestCase extends WP_UnitTestCase {
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 		add_filter( 'filesystem_method_file', array( $this, 'filter_abstraction_file' ) );
 		add_filter( 'filesystem_method', array( $this, 'filter_fs_method' ) );
 		WP_Filesystem();
 	}
 
-	function tear_down() {
+	public function tear_down() {
 		global $wp_filesystem;
 		remove_filter( 'filesystem_method_file', array( $this, 'filter_abstraction_file' ) );
 		remove_filter( 'filesystem_method', array( $this, 'filter_fs_method' ) );
@@ -20,14 +20,14 @@ abstract class WP_Filesystem_UnitTestCase extends WP_UnitTestCase {
 		parent::tear_down();
 	}
 
-	function filter_fs_method( $method ) {
+	public function filter_fs_method( $method ) {
 		return 'MockFS';
 	}
-	function filter_abstraction_file( $file ) {
+	public function filter_abstraction_file( $file ) {
 		return dirname( dirname( __DIR__ ) ) . '/includes/mock-fs.php';
 	}
 
-	function test_is_MockFS_sane() {
+	public function test_is_MockFS_sane() {
 		global $wp_filesystem;
 		$this->assertInstanceOf( 'WP_Filesystem_MockFS', $wp_filesystem );
 

--- a/tests/phpunit/tests/filesystem/findFolder.php
+++ b/tests/phpunit/tests/filesystem/findFolder.php
@@ -8,7 +8,7 @@ require_once __DIR__ . '/base.php';
  */
 class WP_Filesystem_Find_Folder_Test extends WP_Filesystem_UnitTestCase {
 
-	function test_ftp_has_root_access() {
+	public function test_ftp_has_root_access() {
 		global $wp_filesystem;
 		$fs = $wp_filesystem;
 		$fs->init(
@@ -27,7 +27,7 @@ class WP_Filesystem_Find_Folder_Test extends WP_Filesystem_UnitTestCase {
 
 	}
 
-	function test_sibling_wordpress_in_subdir() {
+	public function test_sibling_wordpress_in_subdir() {
 		global $wp_filesystem;
 		$fs = $wp_filesystem;
 		$fs->init(
@@ -57,7 +57,7 @@ class WP_Filesystem_Find_Folder_Test extends WP_Filesystem_UnitTestCase {
 	 * example.com at /
 	 * wp.example.com at /wp.example.com/wordpress/
 	 */
-	function test_subdir_of_another() {
+	public function test_subdir_of_another() {
 		global $wp_filesystem;
 		$fs = $wp_filesystem;
 		$fs->init(
@@ -84,7 +84,7 @@ class WP_Filesystem_Find_Folder_Test extends WP_Filesystem_UnitTestCase {
 	 *
 	 * @ticket 20934
 	 */
-	function test_multiple_tokens_in_path1() {
+	public function test_multiple_tokens_in_path1() {
 		global $wp_filesystem;
 		$fs = $wp_filesystem;
 		$fs->init(

--- a/tests/phpunit/tests/formatting/balanceTags.php
+++ b/tests/phpunit/tests/formatting/balanceTags.php
@@ -5,7 +5,7 @@
  */
 class Tests_Formatting_BalanceTags extends WP_UnitTestCase {
 
-	function nestable_tags() {
+	public function nestable_tags() {
 		return array(
 			array( 'blockquote' ),
 			array( 'div' ),
@@ -16,7 +16,7 @@ class Tests_Formatting_BalanceTags extends WP_UnitTestCase {
 	}
 
 	// This is a complete(?) listing of valid single/self-closing tags.
-	function single_tags() {
+	public function single_tags() {
 		return array(
 			array( 'area' ),
 			array( 'base' ),
@@ -37,7 +37,7 @@ class Tests_Formatting_BalanceTags extends WP_UnitTestCase {
 		);
 	}
 
-	function supported_traditional_tag_names() {
+	public function supported_traditional_tag_names() {
 		return array(
 			array( 'a' ),
 			array( 'div' ),
@@ -49,7 +49,7 @@ class Tests_Formatting_BalanceTags extends WP_UnitTestCase {
 		);
 	}
 
-	function supported_custom_element_tag_names() {
+	public function supported_custom_element_tag_names() {
 		return array(
 			array( 'custom-element' ),
 			array( 'my-custom-element' ),
@@ -61,7 +61,7 @@ class Tests_Formatting_BalanceTags extends WP_UnitTestCase {
 		);
 	}
 
-	function invalid_tag_names() {
+	public function invalid_tag_names() {
 		return array(
 			array( '<0-day>inside', '&lt;0-day>inside' ), // Can't start with a number - handled by the "<3" fix.
 			array( '<UPPERCASE-TAG>inside', '<UPPERCASE-TAG>inside' ), // Custom elements cannot be uppercase.
@@ -73,7 +73,7 @@ class Tests_Formatting_BalanceTags extends WP_UnitTestCase {
 	 *
 	 * @see https://w3c.github.io/webcomponents/spec/custom/#valid-custom-element-name
 	 */
-	function unsupported_valid_tag_names() {
+	public function unsupported_valid_tag_names() {
 		return array(
 			// We don't allow ending in a dash.
 			array( '<what->inside' ),
@@ -133,7 +133,7 @@ class Tests_Formatting_BalanceTags extends WP_UnitTestCase {
 	 *
 	 * @see https://w3c.github.io/webcomponents/spec/custom/#valid-custom-element-name
 	 */
-	function supported_invalid_tag_names() {
+	public function supported_invalid_tag_names() {
 		return array(
 			// Reserved names for custom elements.
 			array( 'annotation-xml' ),
@@ -151,7 +151,7 @@ class Tests_Formatting_BalanceTags extends WP_UnitTestCase {
 	 * @ticket 47014
 	 * @dataProvider supported_traditional_tag_names
 	 */
-	function test_detects_traditional_tag_names( $tag ) {
+	public function test_detects_traditional_tag_names( $tag ) {
 		$normalized = strtolower( $tag );
 
 		$this->assertSame( "<$normalized>inside</$normalized>", balanceTags( "<$tag>inside", true ) );
@@ -161,7 +161,7 @@ class Tests_Formatting_BalanceTags extends WP_UnitTestCase {
 	 * @ticket 47014
 	 * @dataProvider supported_custom_element_tag_names
 	 */
-	function test_detects_supported_custom_element_tag_names( $tag ) {
+	public function test_detects_supported_custom_element_tag_names( $tag ) {
 		$this->assertSame( "<$tag>inside</$tag>", balanceTags( "<$tag>inside", true ) );
 	}
 
@@ -169,7 +169,7 @@ class Tests_Formatting_BalanceTags extends WP_UnitTestCase {
 	 * @ticket 47014
 	 * @dataProvider invalid_tag_names
 	 */
-	function test_ignores_invalid_tag_names( $input, $output ) {
+	public function test_ignores_invalid_tag_names( $input, $output ) {
 		$this->assertSame( $output, balanceTags( $input, true ) );
 	}
 
@@ -177,7 +177,7 @@ class Tests_Formatting_BalanceTags extends WP_UnitTestCase {
 	 * @ticket 47014
 	 * @dataProvider unsupported_valid_tag_names
 	 */
-	function test_ignores_unsupported_custom_tag_names( $tag ) {
+	public function test_ignores_unsupported_custom_tag_names( $tag ) {
 		$this->assertSame( "<$tag>inside", balanceTags( "<$tag>inside", true ) );
 	}
 
@@ -185,7 +185,7 @@ class Tests_Formatting_BalanceTags extends WP_UnitTestCase {
 	 * @ticket 47014
 	 * @dataProvider supported_invalid_tag_names
 	 */
-	function test_detects_supported_invalid_tag_names( $tag ) {
+	public function test_detects_supported_invalid_tag_names( $tag ) {
 		$this->assertSame( "<$tag>inside</$tag>", balanceTags( "<$tag>inside", true ) );
 	}
 
@@ -195,7 +195,7 @@ class Tests_Formatting_BalanceTags extends WP_UnitTestCase {
 	 * @ticket 1597
 	 * @dataProvider single_tags
 	 */
-	function test_selfcloses_unclosed_known_single_tags( $tag ) {
+	public function test_selfcloses_unclosed_known_single_tags( $tag ) {
 		$this->assertSame( "<$tag />", balanceTags( "<$tag>", true ) );
 	}
 
@@ -206,14 +206,14 @@ class Tests_Formatting_BalanceTags extends WP_UnitTestCase {
 	 * @ticket 1597
 	 * @dataProvider single_tags
 	 */
-	function test_selfcloses_known_single_tags_having_closing_tag( $tag ) {
+	public function test_selfcloses_known_single_tags_having_closing_tag( $tag ) {
 		$this->assertSame( "<$tag />", balanceTags( "<$tag></$tag>", true ) );
 	}
 
 	/**
 	 * @ticket 1597
 	 */
-	function test_closes_unknown_single_tags_with_closing_tag() {
+	public function test_closes_unknown_single_tags_with_closing_tag() {
 
 		$inputs   = array(
 			'<strong/>',
@@ -236,7 +236,7 @@ class Tests_Formatting_BalanceTags extends WP_UnitTestCase {
 		}
 	}
 
-	function test_closes_unclosed_single_tags_having_attributes() {
+	public function test_closes_unclosed_single_tags_having_attributes() {
 		$inputs   = array(
 			'<img src="/images/example.png">',
 			'<input type="text" name="example">',
@@ -251,7 +251,7 @@ class Tests_Formatting_BalanceTags extends WP_UnitTestCase {
 		}
 	}
 
-	function test_allows_validly_closed_single_tags() {
+	public function test_allows_validly_closed_single_tags() {
 		$inputs = array(
 			'<br />',
 			'<hr />',
@@ -267,7 +267,7 @@ class Tests_Formatting_BalanceTags extends WP_UnitTestCase {
 	/**
 	 * @dataProvider nestable_tags
 	 */
-	function test_balances_nestable_tags( $tag ) {
+	public function test_balances_nestable_tags( $tag ) {
 		$inputs   = array(
 			"<$tag>Test<$tag>Test</$tag>",
 			"<$tag><$tag>Test",
@@ -284,7 +284,7 @@ class Tests_Formatting_BalanceTags extends WP_UnitTestCase {
 		}
 	}
 
-	function test_allows_adjacent_nestable_tags() {
+	public function test_allows_adjacent_nestable_tags() {
 		$inputs = array(
 			'<blockquote><blockquote>Example quote</blockquote></blockquote>',
 			'<div class="container"><div>This is allowed></div></div>',
@@ -301,12 +301,12 @@ class Tests_Formatting_BalanceTags extends WP_UnitTestCase {
 	/**
 	 * @ticket 20401
 	 */
-	function test_allows_immediately_nested_object_tags() {
+	public function test_allows_immediately_nested_object_tags() {
 		$object = '<object id="obj1"><param name="param1"/><object id="obj2"><param name="param2"/></object></object>';
 		$this->assertSame( $object, balanceTags( $object, true ) );
 	}
 
-	function test_balances_nested_non_nestable_tags() {
+	public function test_balances_nested_non_nestable_tags() {
 		$inputs   = array(
 			'<b><b>This is bold</b></b>',
 			'<b>Some text here <b>This is bold</b></b>',
@@ -321,7 +321,7 @@ class Tests_Formatting_BalanceTags extends WP_UnitTestCase {
 		}
 	}
 
-	function test_fixes_improper_closing_tag_sequence() {
+	public function test_fixes_improper_closing_tag_sequence() {
 		$inputs   = array(
 			'<p>Here is a <strong class="part">bold <em>and emphasis</p></em></strong>',
 			'<ul><li>Aaa</li><li>Bbb</ul></li>',
@@ -336,7 +336,7 @@ class Tests_Formatting_BalanceTags extends WP_UnitTestCase {
 		}
 	}
 
-	function test_adds_missing_closing_tags() {
+	public function test_adds_missing_closing_tags() {
 		$inputs   = array(
 			'<b><i>Test</b>',
 			'<p>Test',
@@ -357,7 +357,7 @@ class Tests_Formatting_BalanceTags extends WP_UnitTestCase {
 		}
 	}
 
-	function test_removes_extraneous_closing_tags() {
+	public function test_removes_extraneous_closing_tags() {
 		$inputs   = array(
 			'<b>Test</b></b>',
 			'<div>Test</div></div><div>Test',

--- a/tests/phpunit/tests/formatting/capitalPDangit.php
+++ b/tests/phpunit/tests/formatting/capitalPDangit.php
@@ -5,7 +5,7 @@
  * @group formatting
  */
 class Tests_Formatting_CapitalPDangit extends WP_UnitTestCase {
-	function test_esc_attr_quotes() {
+	public function test_esc_attr_quotes() {
 		global $wp_current_filter;
 		$this->assertSame( 'Something about WordPress', capital_P_dangit( 'Something about Wordpress' ) );
 		$this->assertSame( 'Something about (WordPress', capital_P_dangit( 'Something about (Wordpress' ) );

--- a/tests/phpunit/tests/formatting/cleanPre.php
+++ b/tests/phpunit/tests/formatting/cleanPre.php
@@ -9,14 +9,14 @@
  */
 class Tests_Formatting_CleanPre extends WP_UnitTestCase {
 
-	function test_removes_self_closing_br_with_space() {
+	public function test_removes_self_closing_br_with_space() {
 		$source = 'a b c\n<br />sldfj<br />';
 		$res    = 'a b c\nsldfj';
 
 		$this->assertSame( $res, clean_pre( $source ) );
 	}
 
-	function test_removes_self_closing_br_without_space() {
+	public function test_removes_self_closing_br_without_space() {
 		$source = 'a b c\n<br/>sldfj<br/>';
 		$res    = 'a b c\nsldfj';
 		$this->assertSame( $res, clean_pre( $source ) );
@@ -26,13 +26,13 @@ class Tests_Formatting_CleanPre extends WP_UnitTestCase {
 	// <br> is changed to <br /> elsewhere. Left in because
 	// that replacement shouldn't happen (what if you want
 	// HTML 4 output?).
-	function test_removes_html_br() {
+	public function test_removes_html_br() {
 		$source = 'a b c\n<br>sldfj<br>';
 		$res    = 'a b c\nsldfj';
 		$this->assertSame( $res, clean_pre( $source ) );
 	}
 
-	function test_removes_p() {
+	public function test_removes_p() {
 		$source = "<p>isn't this exciting!</p><p>oh indeed!</p>";
 		$res    = "\nisn't this exciting!\noh indeed!";
 		$this->assertSame( $res, clean_pre( $source ) );

--- a/tests/phpunit/tests/formatting/convertInvalidEntries.php
+++ b/tests/phpunit/tests/formatting/convertInvalidEntries.php
@@ -4,7 +4,7 @@
  * @group formatting
  */
 class Tests_Formatting_ConvertInvalidEntities extends WP_UnitTestCase {
-	function test_replaces_windows1252_entities_with_unicode_ones() {
+	public function test_replaces_windows1252_entities_with_unicode_ones() {
 		$input  = '&#130;&#131;&#132;&#133;&#134;&#135;&#136;&#137;&#138;&#139;&#140;&#145;&#146;&#147;&#148;&#149;&#150;&#151;&#152;&#153;&#154;&#155;&#156;&#159;';
 		$output = '&#8218;&#402;&#8222;&#8230;&#8224;&#8225;&#710;&#8240;&#352;&#8249;&#338;&#8216;&#8217;&#8220;&#8221;&#8226;&#8211;&#8212;&#732;&#8482;&#353;&#8250;&#339;&#376;';
 		$this->assertSame( $output, convert_invalid_entities( $input ) );
@@ -13,13 +13,13 @@ class Tests_Formatting_ConvertInvalidEntities extends WP_UnitTestCase {
 	/**
 	 * @ticket 20503
 	 */
-	function test_replaces_latin_letter_z_with_caron() {
+	public function test_replaces_latin_letter_z_with_caron() {
 		$input  = '&#142;&#158;';
 		$output = '&#381;&#382;';
 		$this->assertSame( $output, convert_invalid_entities( $input ) );
 	}
 
-	function test_escapes_lone_ampersands() {
+	public function test_escapes_lone_ampersands() {
 		$this->assertSame( 'at&#038;t', convert_chars( 'at&t' ) );
 	}
 }

--- a/tests/phpunit/tests/formatting/convertSmilies.php
+++ b/tests/phpunit/tests/formatting/convertSmilies.php
@@ -48,7 +48,7 @@ class Tests_Formatting_ConvertSmilies extends WP_UnitTestCase {
 	 * Basic Validation Test to confirm that smilies are converted to image
 	 * when use_smilies = 1 and not when use_smilies = 0
 	 */
-	function test_convert_standard_smilies( $in_txt, $converted_txt ) {
+	public function test_convert_standard_smilies( $in_txt, $converted_txt ) {
 		// Standard smilies, use_smilies: ON.
 		update_option( 'use_smilies', 1 );
 
@@ -91,7 +91,7 @@ class Tests_Formatting_ConvertSmilies extends WP_UnitTestCase {
 	 *
 	 * Validate Custom Smilies are converted to images when use_smilies = 1
 	 */
-	function test_convert_custom_smilies( $in_txt, $converted_txt ) {
+	public function test_convert_custom_smilies( $in_txt, $converted_txt ) {
 		global $wpsmiliestrans;
 
 		// Custom smilies, use_smilies: ON.
@@ -299,7 +299,7 @@ class Tests_Formatting_ConvertSmilies extends WP_UnitTestCase {
 	 * @ticket 22692
 	 * @dataProvider get_spaces_around_smilies
 	 */
-	function test_spaces_around_smilies( $in_txt, $converted_txt ) {
+	public function test_spaces_around_smilies( $in_txt, $converted_txt ) {
 		// Standard smilies, use_smilies: ON.
 		update_option( 'use_smilies', 1 );
 

--- a/tests/phpunit/tests/formatting/date.php
+++ b/tests/phpunit/tests/formatting/date.php
@@ -11,7 +11,7 @@ class Tests_Formatting_Date extends WP_UnitTestCase {
 	 *
 	 * @ticket 20328
 	 */
-	function test_get_date_from_gmt_outside_of_dst() {
+	public function test_get_date_from_gmt_outside_of_dst() {
 		update_option( 'timezone_string', 'Europe/London' );
 		$local = '2012-01-01 12:34:56';
 		$gmt   = $local;
@@ -23,7 +23,7 @@ class Tests_Formatting_Date extends WP_UnitTestCase {
 	 *
 	 * @ticket 20328
 	 */
-	function test_get_date_from_gmt_during_dst() {
+	public function test_get_date_from_gmt_during_dst() {
 		update_option( 'timezone_string', 'Europe/London' );
 		$gmt   = '2012-06-01 12:34:56';
 		$local = '2012-06-01 13:34:56';
@@ -33,7 +33,7 @@ class Tests_Formatting_Date extends WP_UnitTestCase {
 	/**
 	 * @ticket 20328
 	 */
-	function test_get_gmt_from_date_outside_of_dst() {
+	public function test_get_gmt_from_date_outside_of_dst() {
 		update_option( 'timezone_string', 'Europe/London' );
 		$local = '2012-01-01 12:34:56';
 		$gmt   = $local;
@@ -43,7 +43,7 @@ class Tests_Formatting_Date extends WP_UnitTestCase {
 	/**
 	 * @ticket 20328
 	 */
-	function test_get_gmt_from_date_during_dst() {
+	public function test_get_gmt_from_date_during_dst() {
 		update_option( 'timezone_string', 'Europe/London' );
 		$local = '2012-06-01 12:34:56';
 		$gmt   = '2012-06-01 11:34:56';
@@ -53,7 +53,7 @@ class Tests_Formatting_Date extends WP_UnitTestCase {
 	/**
 	 * @ticket 34279
 	 */
-	function test_get_date_and_time_from_gmt_no_timezone() {
+	public function test_get_date_and_time_from_gmt_no_timezone() {
 		$local = '2012-01-01 12:34:56';
 		$gmt   = $local;
 		$this->assertSame( $gmt, get_date_from_gmt( $local ) );
@@ -62,7 +62,7 @@ class Tests_Formatting_Date extends WP_UnitTestCase {
 	/**
 	 * @ticket 34279
 	 */
-	function test_get_gmt_from_date_no_timezone() {
+	public function test_get_gmt_from_date_no_timezone() {
 		$gmt  = '2012-12-01 00:00:00';
 		$date = '2012-12-01';
 		$this->assertSame( $gmt, get_gmt_from_date( $date ) );
@@ -71,7 +71,7 @@ class Tests_Formatting_Date extends WP_UnitTestCase {
 	/**
 	 * @ticket 34279
 	 */
-	function test_get_gmt_from_date_short_date() {
+	public function test_get_gmt_from_date_short_date() {
 		update_option( 'timezone_string', 'Europe/London' );
 		$local = '2012-12-01';
 		$gmt   = '2012-12-01 00:00:00';
@@ -81,7 +81,7 @@ class Tests_Formatting_Date extends WP_UnitTestCase {
 	/**
 	 * @ticket 34279
 	 */
-	function test_get_gmt_from_date_string_date() {
+	public function test_get_gmt_from_date_string_date() {
 		update_option( 'timezone_string', 'Europe/London' );
 		$local = 'now';
 		$gmt   = gmdate( 'Y-m-d H:i:s' );
@@ -91,7 +91,7 @@ class Tests_Formatting_Date extends WP_UnitTestCase {
 	/**
 	 * @ticket 34279
 	 */
-	function test_get_gmt_from_date_string_date_no_timezone() {
+	public function test_get_gmt_from_date_string_date_no_timezone() {
 		$local = 'now';
 		$gmt   = gmdate( 'Y-m-d H:i:s' );
 		$this->assertEqualsWithDelta( strtotime( $gmt ), strtotime( get_gmt_from_date( $local ) ), 2, 'The dates should be equal' );

--- a/tests/phpunit/tests/formatting/ent2ncr.php
+++ b/tests/phpunit/tests/formatting/ent2ncr.php
@@ -7,7 +7,7 @@ class Tests_Formatting_Ent2ncr extends WP_UnitTestCase {
 	/**
 	 * @dataProvider entities
 	 */
-	function test_converts_named_entities_to_numeric_character_references( $entity, $ncr ) {
+	public function test_converts_named_entities_to_numeric_character_references( $entity, $ncr ) {
 		$entity = '&' . $entity . ';';
 		$ncr    = '&#' . $ncr . ';';
 		$this->assertSame( $ncr, ent2ncr( $entity ), $entity );
@@ -17,7 +17,7 @@ class Tests_Formatting_Ent2ncr extends WP_UnitTestCase {
 	 * Get test data from files, one test per line.
 	 * Comments start with "###".
 	 */
-	function entities() {
+	public function entities() {
 		$entities      = file( DIR_TESTDATA . '/formatting/entities.txt' );
 		$data_provided = array();
 		foreach ( $entities as $line ) {

--- a/tests/phpunit/tests/formatting/escAttr.php
+++ b/tests/phpunit/tests/formatting/escAttr.php
@@ -4,7 +4,7 @@
  * @group formatting
  */
 class Tests_Formatting_EscAttr extends WP_UnitTestCase {
-	function test_esc_attr_quotes() {
+	public function test_esc_attr_quotes() {
 		$attr = '"double quotes"';
 		$this->assertSame( '&quot;double quotes&quot;', esc_attr( $attr ) );
 
@@ -25,7 +25,7 @@ class Tests_Formatting_EscAttr extends WP_UnitTestCase {
 		$this->assertSame( '&#039;mixed&#039; &quot;quotes&quot;', esc_attr( esc_attr( $attr ) ) );
 	}
 
-	function test_esc_attr_amp() {
+	public function test_esc_attr_amp() {
 		$out = esc_attr( 'foo & bar &baz; &nbsp;' );
 		$this->assertSame( 'foo &amp; bar &amp;baz; &nbsp;', $out );
 	}

--- a/tests/phpunit/tests/formatting/escHtml.php
+++ b/tests/phpunit/tests/formatting/escHtml.php
@@ -4,7 +4,7 @@
  * @group formatting
  */
 class Tests_Formatting_EscHtml extends WP_UnitTestCase {
-	function test_esc_html_basics() {
+	public function test_esc_html_basics() {
 		// Simple string.
 		$html = 'The quick brown fox.';
 		$this->assertSame( $html, esc_html( $html ) );
@@ -20,19 +20,19 @@ class Tests_Formatting_EscHtml extends WP_UnitTestCase {
 		$this->assertSame( $escaped, esc_html( $html ) );
 	}
 
-	function test_escapes_ampersands() {
+	public function test_escapes_ampersands() {
 		$source = 'penn & teller & at&t';
 		$res    = 'penn &amp; teller &amp; at&amp;t';
 		$this->assertSame( $res, esc_html( $source ) );
 	}
 
-	function test_escapes_greater_and_less_than() {
+	public function test_escapes_greater_and_less_than() {
 		$source = 'this > that < that <randomhtml />';
 		$res    = 'this &gt; that &lt; that &lt;randomhtml /&gt;';
 		$this->assertSame( $res, esc_html( $source ) );
 	}
 
-	function test_ignores_existing_entities() {
+	public function test_ignores_existing_entities() {
 		$source = '&#038; &#x00A3; &#x22; &amp;';
 		$res    = '&#038; &#xA3; &#x22; &amp;';
 		$this->assertSame( $res, esc_html( $source ) );

--- a/tests/phpunit/tests/formatting/escJs.php
+++ b/tests/phpunit/tests/formatting/escJs.php
@@ -4,41 +4,41 @@
  * @group formatting
  */
 class Tests_Formatting_EscJs extends WP_UnitTestCase {
-	function test_js_escape_simple() {
+	public function test_js_escape_simple() {
 		$out = esc_js( 'foo bar baz();' );
 		$this->assertSame( 'foo bar baz();', $out );
 	}
 
-	function test_js_escape_quotes() {
+	public function test_js_escape_quotes() {
 		$out = esc_js( 'foo "bar" \'baz\'' );
 		// Does it make any sense to change " into &quot;?  Why not \"?
 		$this->assertSame( "foo &quot;bar&quot; \'baz\'", $out );
 	}
 
-	function test_js_escape_backslash() {
+	public function test_js_escape_backslash() {
 		$bs  = '\\';
 		$out = esc_js( 'foo ' . $bs . 't bar ' . $bs . $bs . ' baz' );
 		// \t becomes t - bug?
 		$this->assertSame( 'foo t bar ' . $bs . $bs . ' baz', $out );
 	}
 
-	function test_js_escape_amp() {
+	public function test_js_escape_amp() {
 		$out = esc_js( 'foo & bar &baz; &nbsp;' );
 		$this->assertSame( 'foo &amp; bar &amp;baz; &nbsp;', $out );
 	}
 
-	function test_js_escape_quote_entity() {
+	public function test_js_escape_quote_entity() {
 		$out = esc_js( 'foo &#x27; bar &#39; baz &#x26;' );
 		$this->assertSame( "foo \\' bar \\' baz &#x26;", $out );
 	}
 
-	function test_js_no_carriage_return() {
+	public function test_js_no_carriage_return() {
 		$out = esc_js( "foo\rbar\nbaz\r" );
 		// \r is stripped.
 		$this->assertSame( "foobar\\nbaz", $out );
 	}
 
-	function test_js_escape_rn() {
+	public function test_js_escape_rn() {
 		$out = esc_js( "foo\r\nbar\nbaz\r\n" );
 		// \r is stripped.
 		$this->assertSame( "foo\\nbar\\nbaz\\n", $out );

--- a/tests/phpunit/tests/formatting/escTextarea.php
+++ b/tests/phpunit/tests/formatting/escTextarea.php
@@ -5,7 +5,7 @@
  */
 class Tests_Formatting_EscTextarea extends WP_UnitTestCase {
 
-	function _charset_iso_8859_1() {
+	public function _charset_iso_8859_1() {
 		return 'iso-8859-1';
 	}
 
@@ -13,21 +13,21 @@ class Tests_Formatting_EscTextarea extends WP_UnitTestCase {
 	 * Only fails in PHP 5.4 onwards
 	 * @ticket 23688
 	 */
-	function test_esc_textarea_charset_iso_8859_1() {
+	public function test_esc_textarea_charset_iso_8859_1() {
 		add_filter( 'pre_option_blog_charset', array( $this, '_charset_iso_8859_1' ) );
 		$iso8859_1 = 'Fran' . chr( 135 ) . 'ais';
 		$this->assertSame( $iso8859_1, esc_textarea( $iso8859_1 ) );
 		remove_filter( 'pre_option_blog_charset', array( $this, '_charset_iso_8859_1' ) );
 	}
 
-	function _charset_utf_8() {
+	public function _charset_utf_8() {
 		return 'UTF-8';
 	}
 
 	/*
 	 * @ticket 23688
 	 */
-	function test_esc_textarea_charset_utf_8() {
+	public function test_esc_textarea_charset_utf_8() {
 		add_filter( 'pre_option_blog_charset', array( $this, '_charset_utf_8' ) );
 		$utf8 = 'Fran' . chr( 195 ) . chr( 167 ) . 'ais';
 		$this->assertSame( $utf8, esc_textarea( $utf8 ) );

--- a/tests/phpunit/tests/formatting/escTextarea.php
+++ b/tests/phpunit/tests/formatting/escTextarea.php
@@ -5,7 +5,7 @@
  */
 class Tests_Formatting_EscTextarea extends WP_UnitTestCase {
 
-	public function _charset_iso_8859_1() {
+	public function charset_iso_8859_1() {
 		return 'iso-8859-1';
 	}
 
@@ -14,13 +14,13 @@ class Tests_Formatting_EscTextarea extends WP_UnitTestCase {
 	 * @ticket 23688
 	 */
 	public function test_esc_textarea_charset_iso_8859_1() {
-		add_filter( 'pre_option_blog_charset', array( $this, '_charset_iso_8859_1' ) );
+		add_filter( 'pre_option_blog_charset', array( $this, 'charset_iso_8859_1' ) );
 		$iso8859_1 = 'Fran' . chr( 135 ) . 'ais';
 		$this->assertSame( $iso8859_1, esc_textarea( $iso8859_1 ) );
-		remove_filter( 'pre_option_blog_charset', array( $this, '_charset_iso_8859_1' ) );
+		remove_filter( 'pre_option_blog_charset', array( $this, 'charset_iso_8859_1' ) );
 	}
 
-	public function _charset_utf_8() {
+	public function charset_utf_8() {
 		return 'UTF-8';
 	}
 
@@ -28,9 +28,9 @@ class Tests_Formatting_EscTextarea extends WP_UnitTestCase {
 	 * @ticket 23688
 	 */
 	public function test_esc_textarea_charset_utf_8() {
-		add_filter( 'pre_option_blog_charset', array( $this, '_charset_utf_8' ) );
+		add_filter( 'pre_option_blog_charset', array( $this, 'charset_utf_8' ) );
 		$utf8 = 'Fran' . chr( 195 ) . chr( 167 ) . 'ais';
 		$this->assertSame( $utf8, esc_textarea( $utf8 ) );
-		remove_filter( 'pre_option_blog_charset', array( $this, '_charset_utf_8' ) );
+		remove_filter( 'pre_option_blog_charset', array( $this, 'charset_utf_8' ) );
 	}
 }

--- a/tests/phpunit/tests/formatting/escUrl.php
+++ b/tests/phpunit/tests/formatting/escUrl.php
@@ -8,7 +8,7 @@ class Tests_Formatting_EscUrl extends WP_UnitTestCase {
 	/**
 	 * @ticket 23605
 	 */
-	function test_spaces() {
+	public function test_spaces() {
 		$this->assertSame( 'http://example.com/Mr%20WordPress', esc_url( 'http://example.com/Mr WordPress' ) );
 		$this->assertSame( 'http://example.com/Mr%20WordPress', esc_url( 'http://example.com/Mr%20WordPress' ) );
 		$this->assertSame( 'http://example.com/Mr%20%20WordPress', esc_url( 'http://example.com/Mr%20%20WordPress' ) );
@@ -19,7 +19,7 @@ class Tests_Formatting_EscUrl extends WP_UnitTestCase {
 		$this->assertSame( 'http://example.com/?foo=one%20two%20three&#038;bar=four', esc_url( 'http://example.com/?foo=one%20two%20three&bar=four' ) );
 	}
 
-	function test_bad_characters() {
+	public function test_bad_characters() {
 		$this->assertSame( 'http://example.com/watchthelinefeedgo', esc_url( 'http://example.com/watchthelinefeed%0Ago' ) );
 		$this->assertSame( 'http://example.com/watchthelinefeedgo', esc_url( 'http://example.com/watchthelinefeed%0ago' ) );
 		$this->assertSame( 'http://example.com/watchthecarriagereturngo', esc_url( 'http://example.com/watchthecarriagereturn%0Dgo' ) );
@@ -33,14 +33,14 @@ class Tests_Formatting_EscUrl extends WP_UnitTestCase {
 		$this->assertSame( 'http://example.com/', esc_url( 'http://example.com/%0%0%0ADa' ) );
 	}
 
-	function test_relative() {
+	public function test_relative() {
 		$this->assertSame( '/example.php', esc_url( '/example.php' ) );
 		$this->assertSame( 'example.php', esc_url( 'example.php' ) );
 		$this->assertSame( '#fragment', esc_url( '#fragment' ) );
 		$this->assertSame( '?foo=bar', esc_url( '?foo=bar' ) );
 	}
 
-	function test_all_url_parts() {
+	public function test_all_url_parts() {
 		$url = 'https://user:pass@host.example.com:1234/path;p=1?query=2&r[]=3#fragment';
 
 		$this->assertSame(
@@ -60,7 +60,7 @@ class Tests_Formatting_EscUrl extends WP_UnitTestCase {
 		$this->assertSame( 'https://user:pass@host.example.com:1234/path;p=1?query=2&#038;r%5B%5D=3#fragment', esc_url( $url ) );
 	}
 
-	function test_bare() {
+	public function test_bare() {
 		$this->assertSame( 'http://example.com?foo', esc_url( 'example.com?foo' ) );
 		$this->assertSame( 'http://example.com', esc_url( 'example.com' ) );
 		$this->assertSame( 'http://localhost', esc_url( 'localhost' ) );
@@ -68,7 +68,7 @@ class Tests_Formatting_EscUrl extends WP_UnitTestCase {
 		$this->assertSame( 'http://баба.org/баба', esc_url( 'баба.org/баба' ) );
 	}
 
-	function test_encoding() {
+	public function test_encoding() {
 		$this->assertSame( 'http://example.com?foo=1&bar=2', esc_url_raw( 'http://example.com?foo=1&bar=2' ) );
 		$this->assertSame( 'http://example.com?foo=1&amp;bar=2', esc_url_raw( 'http://example.com?foo=1&amp;bar=2' ) );
 		$this->assertSame( 'http://example.com?foo=1&#038;bar=2', esc_url_raw( 'http://example.com?foo=1&#038;bar=2' ) );
@@ -81,7 +81,7 @@ class Tests_Formatting_EscUrl extends WP_UnitTestCase {
 		$this->assertSame( "http://example.com?url={$param}", esc_url( "http://example.com?url={$param}" ) );
 	}
 
-	function test_protocol() {
+	public function test_protocol() {
 		$this->assertSame( 'http://example.com', esc_url( 'http://example.com' ) );
 		$this->assertSame( '', esc_url( 'nasty://example.com/' ) );
 		$this->assertSame(
@@ -146,23 +146,23 @@ class Tests_Formatting_EscUrl extends WP_UnitTestCase {
 	/**
 	 * @ticket 23187
 	 */
-	function test_protocol_case() {
+	public function test_protocol_case() {
 		$this->assertSame( 'http://example.com', esc_url( 'HTTP://example.com' ) );
 		$this->assertSame( 'http://example.com', esc_url( 'Http://example.com' ) );
 	}
 
-	function test_display_extras() {
+	public function test_display_extras() {
 		$this->assertSame( 'http://example.com/&#039;quoted&#039;', esc_url( 'http://example.com/\'quoted\'' ) );
 		$this->assertSame( 'http://example.com/\'quoted\'', esc_url( 'http://example.com/\'quoted\'', null, 'notdisplay' ) );
 	}
 
-	function test_non_ascii() {
+	public function test_non_ascii() {
 		$this->assertSame( 'http://example.org/баба', esc_url( 'http://example.org/баба' ) );
 		$this->assertSame( 'http://баба.org/баба', esc_url( 'http://баба.org/баба' ) );
 		$this->assertSame( 'http://müller.com/', esc_url( 'http://müller.com/' ) );
 	}
 
-	function test_feed() {
+	public function test_feed() {
 		$this->assertSame( '', esc_url( 'feed:javascript:alert(1)' ) );
 		$this->assertSame( '', esc_url( 'feed:javascript:feed:alert(1)' ) );
 		$this->assertSame( '', esc_url( 'feed:feed:javascript:alert(1)' ) );
@@ -173,7 +173,7 @@ class Tests_Formatting_EscUrl extends WP_UnitTestCase {
 	/**
 	 * @ticket 16859
 	 */
-	function test_square_brackets() {
+	public function test_square_brackets() {
 		$this->assertSame( '/example.php?one%5B%5D=two', esc_url( '/example.php?one[]=two' ) );
 		$this->assertSame( '?foo%5Bbar%5D=baz', esc_url( '?foo[bar]=baz' ) );
 		$this->assertSame( '//example.com/?foo%5Bbar%5D=baz', esc_url( '//example.com/?foo[bar]=baz' ) );
@@ -188,7 +188,7 @@ class Tests_Formatting_EscUrl extends WP_UnitTestCase {
 	/**
 	 * Courtesy of http://blog.lunatech.com/2009/02/03/what-every-web-developer-must-know-about-url-encoding
 	 */
-	function test_reserved_characters() {
+	public function test_reserved_characters() {
 		$url = "http://example.com/:@-._~!$&'()*+,=;:@-._~!$&'()*+,=:@-._~!$&'()*+,==?/?:@-._~!$%27()*+,;=/?:@-._~!$%27()*+,;==#/?:@-._~!$&'()*+,;=";
 		$this->assertSame( $url, esc_url_raw( $url ) );
 	}
@@ -196,14 +196,14 @@ class Tests_Formatting_EscUrl extends WP_UnitTestCase {
 	/**
 	 * @ticket 21974
 	 */
-	function test_protocol_relative_with_colon() {
+	public function test_protocol_relative_with_colon() {
 		$this->assertSame( '//example.com/foo?foo=abc:def', esc_url( '//example.com/foo?foo=abc:def' ) );
 	}
 
 	/**
 	 * @ticket 31632
 	 */
-	function test_mailto_with_newline() {
+	public function test_mailto_with_newline() {
 		$body       = <<<EOT
 Hi there,
 
@@ -218,7 +218,7 @@ EOT;
 	/**
 	 * @ticket 31632
 	 */
-	function test_mailto_in_http_url_with_newline() {
+	public function test_mailto_in_http_url_with_newline() {
 		$body       = <<<EOT
 Hi there,
 
@@ -233,7 +233,7 @@ EOT;
 	/**
 	 * @ticket 23605
 	 */
-	function test_mailto_with_spaces() {
+	public function test_mailto_with_spaces() {
 		$body = 'Hi there, I thought you might want to sign up for this newsletter';
 
 		$email_link = 'mailto:?body=' . $body;
@@ -244,14 +244,14 @@ EOT;
 	/**
 	 * @ticket 28015
 	 */
-	function test_invalid_charaters() {
+	public function test_invalid_charaters() {
 		$this->assertEmpty( esc_url_raw( '"^<>{}`' ) );
 	}
 
 	/**
 	 * @ticket 34202
 	 */
-	function test_ipv6_hosts() {
+	public function test_ipv6_hosts() {
 		$this->assertSame( '//[::127.0.0.1]', esc_url( '//[::127.0.0.1]' ) );
 		$this->assertSame( 'http://[::FFFF::127.0.0.1]', esc_url( 'http://[::FFFF::127.0.0.1]' ) );
 		$this->assertSame( 'http://[::127.0.0.1]', esc_url( 'http://[::127.0.0.1]' ) );

--- a/tests/phpunit/tests/formatting/excerptRemoveBlocks.php
+++ b/tests/phpunit/tests/formatting/excerptRemoveBlocks.php
@@ -50,7 +50,7 @@ class Tests_Formatting_ExcerptRemoveBlocks extends WP_UnitTestCase {
 	 *
 	 * @return string Block output.
 	 */
-	function render_fake_block() {
+	public function render_fake_block() {
 		return get_the_excerpt( self::$post_id );
 	}
 
@@ -59,7 +59,7 @@ class Tests_Formatting_ExcerptRemoveBlocks extends WP_UnitTestCase {
 	 *
 	 * @since 5.2.0
 	 */
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 		self::$post_id = $this->factory()->post->create(
 			array(
@@ -80,7 +80,7 @@ class Tests_Formatting_ExcerptRemoveBlocks extends WP_UnitTestCase {
 	 *
 	 * @since 5.2.0
 	 */
-	function tear_down() {
+	public function tear_down() {
 		$registry = WP_Block_Type_Registry::get_instance();
 		$registry->unregister( 'core/fake' );
 
@@ -92,7 +92,7 @@ class Tests_Formatting_ExcerptRemoveBlocks extends WP_UnitTestCase {
 	 *
 	 * @ticket 46133
 	 */
-	function test_excerpt_remove_blocks() {
+	public function test_excerpt_remove_blocks() {
 		// Simple dynamic block..
 		$content = '<!-- wp:core/block /-->';
 
@@ -117,7 +117,7 @@ class Tests_Formatting_ExcerptRemoveBlocks extends WP_UnitTestCase {
 	 *
 	 * @ticket 46133
 	 */
-	function test_excerpt_infinite_loop() {
+	public function test_excerpt_infinite_loop() {
 		$query = new WP_Query(
 			array(
 				'post__in' => array( self::$post_id ),

--- a/tests/phpunit/tests/formatting/getBloginfo.php
+++ b/tests/phpunit/tests/formatting/getBloginfo.php
@@ -9,7 +9,7 @@ class Tests_Formatting_GetBloginfo extends WP_UnitTestCase {
 	 * @dataProvider locales
 	 * @ticket 28303
 	 */
-	function test_get_bloginfo_language( $test_locale, $expected ) {
+	public function test_get_bloginfo_language( $test_locale, $expected ) {
 		global $locale;
 
 		$old_locale = $locale;
@@ -20,7 +20,7 @@ class Tests_Formatting_GetBloginfo extends WP_UnitTestCase {
 		$locale = $old_locale;
 	}
 
-	function locales() {
+	public function locales() {
 		return array(
 			// Locale, language code.
 			array( 'en_US', 'en-US' ),
@@ -36,7 +36,7 @@ class Tests_Formatting_GetBloginfo extends WP_UnitTestCase {
 	/**
 	 * @ticket 27942
 	 */
-	function test_bloginfo_sanitize_option() {
+	public function test_bloginfo_sanitize_option() {
 		$old_values = array(
 			'blogname'        => get_option( 'blogname' ),
 			'blogdescription' => get_option( 'blogdescription' ),

--- a/tests/phpunit/tests/formatting/getUrlInContent.php
+++ b/tests/phpunit/tests/formatting/getUrlInContent.php
@@ -44,7 +44,7 @@ class Tests_Formatting_GetUrlInContent extends WP_UnitTestCase {
 	 *
 	 * @dataProvider get_input_output
 	 */
-	function test_get_url_in_content( $in_str, $exp_str ) {
+	public function test_get_url_in_content( $in_str, $exp_str ) {
 		$this->assertSame( $exp_str, get_url_in_content( $in_str ) );
 	}
 }

--- a/tests/phpunit/tests/formatting/humanTimeDiff.php
+++ b/tests/phpunit/tests/formatting/humanTimeDiff.php
@@ -11,13 +11,13 @@ class Tests_Formatting_HumanTimeDiff extends WP_UnitTestCase {
 	 * @ticket 38773
 	 * @dataProvider data_test_human_time_diff
 	 */
-	function test_human_time_diff( $expected, $stopdate, $message ) {
+	public function test_human_time_diff( $expected, $stopdate, $message ) {
 		$startdate = new DateTime( '2016-01-01 12:00:00' );
 		$this->assertSame( $expected, human_time_diff( $startdate->format( 'U' ), $stopdate->format( 'U' ) ), $message );
 	}
 
 	// Data for test_human_time_diff.
-	function data_test_human_time_diff() {
+	public function data_test_human_time_diff() {
 		return array(
 			array(
 				'37 seconds',

--- a/tests/phpunit/tests/formatting/isEmail.php
+++ b/tests/phpunit/tests/formatting/isEmail.php
@@ -4,7 +4,7 @@
  * @group formatting
  */
 class Tests_Formatting_IsEmail extends WP_UnitTestCase {
-	function test_returns_the_email_address_if_it_is_valid() {
+	public function test_returns_the_email_address_if_it_is_valid() {
 		$data = array(
 			'bob@example.com',
 			'phil@example.info',
@@ -18,7 +18,7 @@ class Tests_Formatting_IsEmail extends WP_UnitTestCase {
 		}
 	}
 
-	function test_returns_false_if_given_an_invalid_email_address() {
+	public function test_returns_false_if_given_an_invalid_email_address() {
 		$data = array(
 			'khaaaaaaaaaaaaaaan!',
 			'http://bob.example.com/',

--- a/tests/phpunit/tests/formatting/likeEscape.php
+++ b/tests/phpunit/tests/formatting/likeEscape.php
@@ -8,7 +8,7 @@ class Tests_Formatting_LikeEscape extends WP_UnitTestCase {
 	 * @ticket 10041
 	 * @expectedDeprecated like_escape
 	 */
-	function test_like_escape() {
+	public function test_like_escape() {
 
 		$inputs   = array(
 			'howdy%',              // Single percent.

--- a/tests/phpunit/tests/formatting/linksAddTarget.php
+++ b/tests/phpunit/tests/formatting/linksAddTarget.php
@@ -96,7 +96,7 @@ class Tests_Formatting_LinksAddTarget extends WP_UnitTestCase {
 	 *
 	 * @dataProvider get_input_output
 	 */
-	function test_normalize_whitespace( $content, $target, $tags, $exp_str ) {
+	public function test_normalize_whitespace( $content, $target, $tags, $exp_str ) {
 		if ( true === is_null( $target ) ) {
 			$this->assertSame( $exp_str, links_add_target( $content ) );
 		} elseif ( true === is_null( $tags ) ) {

--- a/tests/phpunit/tests/formatting/makeClickable.php
+++ b/tests/phpunit/tests/formatting/makeClickable.php
@@ -4,12 +4,12 @@
  * @group formatting
  */
 class Tests_Formatting_MakeClickable extends WP_UnitTestCase {
-	function test_mailto_xss() {
+	public function test_mailto_xss() {
 		$in = 'testzzz@"STYLE="behavior:url(\'#default#time2\')"onBegin="alert(\'refresh-XSS\')"';
 		$this->assertSame( $in, make_clickable( $in ) );
 	}
 
-	function test_valid_mailto() {
+	public function test_valid_mailto() {
 		$valid_emails = array(
 			'foo@example.com',
 			'foo.bar@example.com',
@@ -22,7 +22,7 @@ class Tests_Formatting_MakeClickable extends WP_UnitTestCase {
 		}
 	}
 
-	function test_invalid_mailto() {
+	public function test_invalid_mailto() {
 		$invalid_emails = array(
 			'foo',
 			'foo@',
@@ -40,7 +40,7 @@ class Tests_Formatting_MakeClickable extends WP_UnitTestCase {
 	 * Tests that make_clickable() will not link trailing periods, commas,
 	 * and (semi-)colons in URLs with protocol (i.e. http://wordpress.org).
 	 */
-	function test_strip_trailing_with_protocol() {
+	public function test_strip_trailing_with_protocol() {
 		$urls_before   = array(
 			'http://wordpress.org/hello.html',
 			'There was a spoon named http://wordpress.org. Alice!',
@@ -67,7 +67,7 @@ class Tests_Formatting_MakeClickable extends WP_UnitTestCase {
 	 * Tests that make_clickable() will not link trailing periods, commas,
 	 * and (semi-)colons in URLs with protocol (i.e. http://wordpress.org).
 	 */
-	function test_strip_trailing_with_protocol_nothing_afterwards() {
+	public function test_strip_trailing_with_protocol_nothing_afterwards() {
 		$urls_before   = array(
 			'http://wordpress.org/hello.html',
 			'There was a spoon named http://wordpress.org.',
@@ -96,7 +96,7 @@ class Tests_Formatting_MakeClickable extends WP_UnitTestCase {
 	 * Tests that make_clickable() will not link trailing periods, commas,
 	 * and (semi-)colons in URLs without protocol (i.e. www.wordpress.org).
 	 */
-	function test_strip_trailing_without_protocol() {
+	public function test_strip_trailing_without_protocol() {
 		$urls_before   = array(
 			'www.wordpress.org',
 			'There was a spoon named www.wordpress.org. Alice!',
@@ -123,7 +123,7 @@ class Tests_Formatting_MakeClickable extends WP_UnitTestCase {
 	 * Tests that make_clickable() will not link trailing periods, commas,
 	 * and (semi-)colons in URLs without protocol (i.e. www.wordpress.org).
 	 */
-	function test_strip_trailing_without_protocol_nothing_afterwards() {
+	public function test_strip_trailing_without_protocol_nothing_afterwards() {
 		$urls_before   = array(
 			'www.wordpress.org',
 			'There was a spoon named www.wordpress.org.',
@@ -149,7 +149,7 @@ class Tests_Formatting_MakeClickable extends WP_UnitTestCase {
 	/**
 	 * @ticket 4570
 	 */
-	function test_iri() {
+	public function test_iri() {
 		$urls_before   = array(
 			'http://www.詹姆斯.com/',
 			'http://bg.wikipedia.org/Баба',
@@ -168,7 +168,7 @@ class Tests_Formatting_MakeClickable extends WP_UnitTestCase {
 	/**
 	 * @ticket 10990
 	 */
-	function test_brackets_in_urls() {
+	public function test_brackets_in_urls() {
 		$urls_before   = array(
 			'http://en.wikipedia.org/wiki/PC_Tools_(Central_Point_Software)',
 			'(http://en.wikipedia.org/wiki/PC_Tools_(Central_Point_Software))',
@@ -207,7 +207,7 @@ class Tests_Formatting_MakeClickable extends WP_UnitTestCase {
 	 *
 	 * @ticket 11211
 	 */
-	function test_real_world_examples() {
+	public function test_real_world_examples() {
 		$urls_before   = array(
 			'Example: WordPress, test (some text), I love example.com (http://example.org), it is brilliant',
 			'Example: WordPress, test (some text), I love example.com (http://example.com), it is brilliant',
@@ -228,7 +228,7 @@ class Tests_Formatting_MakeClickable extends WP_UnitTestCase {
 	/**
 	 * @ticket 14993
 	 */
-	function test_twitter_hash_bang() {
+	public function test_twitter_hash_bang() {
 		$urls_before   = array(
 			'http://twitter.com/#!/wordpress/status/25907440233',
 			'This is a really good tweet http://twitter.com/#!/wordpress/status/25907440233 !',
@@ -244,7 +244,7 @@ class Tests_Formatting_MakeClickable extends WP_UnitTestCase {
 		}
 	}
 
-	function test_wrapped_in_angles() {
+	public function test_wrapped_in_angles() {
 		$before   = array(
 			'URL wrapped in angle brackets <http://example.com/>',
 			'URL wrapped in angle brackets with padding < http://example.com/ >',
@@ -260,7 +260,7 @@ class Tests_Formatting_MakeClickable extends WP_UnitTestCase {
 		}
 	}
 
-	function test_preceded_by_punctuation() {
+	public function test_preceded_by_punctuation() {
 		$before   = array(
 			'Comma then URL,http://example.com/',
 			'Period then URL.http://example.com/',
@@ -282,7 +282,7 @@ class Tests_Formatting_MakeClickable extends WP_UnitTestCase {
 		}
 	}
 
-	function test_dont_break_attributes() {
+	public function test_dont_break_attributes() {
 		$urls_before   = array(
 			"<img src='http://trunk.domain/wp-includes/images/smilies/icon_smile.gif' alt=':)' class='wp-smiley'>",
 			"(<img src='http://trunk.domain/wp-includes/images/smilies/icon_smile.gif' alt=':)' class='wp-smiley'>)",
@@ -309,7 +309,7 @@ class Tests_Formatting_MakeClickable extends WP_UnitTestCase {
 	/**
 	 * @ticket 23756
 	 */
-	function test_no_links_inside_pre_or_code() {
+	public function test_no_links_inside_pre_or_code() {
 		$before = array(
 			'<pre>http://wordpress.org</pre>',
 			'<code>http://wordpress.org</code>',
@@ -350,7 +350,7 @@ class Tests_Formatting_MakeClickable extends WP_UnitTestCase {
 	/**
 	 * @ticket 16892
 	 */
-	function test_click_inside_html() {
+	public function test_click_inside_html() {
 		$urls_before   = array(
 			'<span>http://example.com</span>',
 			'<p>http://example.com/</p>',
@@ -364,7 +364,7 @@ class Tests_Formatting_MakeClickable extends WP_UnitTestCase {
 		}
 	}
 
-	function test_no_links_within_links() {
+	public function test_no_links_within_links() {
 		$in = array(
 			'Some text with a link <a href="http://example.com">http://example.com</a>',
 			// '<a href="http://wordpress.org">This is already a link www.wordpress.org</a>', // Fails in 3.3.1 too.
@@ -377,7 +377,7 @@ class Tests_Formatting_MakeClickable extends WP_UnitTestCase {
 	/**
 	 * @ticket 16892
 	 */
-	function test_no_segfault() {
+	public function test_no_segfault() {
 		$in  = str_repeat( 'http://example.com/2011/03/18/post-title/', 256 );
 		$out = make_clickable( $in );
 		$this->assertSame( $in, $out );
@@ -386,7 +386,7 @@ class Tests_Formatting_MakeClickable extends WP_UnitTestCase {
 	/**
 	 * @ticket 19028
 	 */
-	function test_line_break_in_existing_clickable_link() {
+	public function test_line_break_in_existing_clickable_link() {
 		$html = "<a
 				  href='mailto:someone@example.com'>someone@example.com</a>";
 		$this->assertSame( $html, make_clickable( $html ) );

--- a/tests/phpunit/tests/formatting/normalizeWhitespace.php
+++ b/tests/phpunit/tests/formatting/normalizeWhitespace.php
@@ -46,7 +46,7 @@ class Tests_Formatting_NormalizeWhitespace extends WP_UnitTestCase {
 	 *
 	 * @dataProvider get_input_output
 	 */
-	function test_normalize_whitespace( $in_str, $exp_str ) {
+	public function test_normalize_whitespace( $in_str, $exp_str ) {
 		$this->assertSame( $exp_str, normalize_whitespace( $in_str ) );
 	}
 }

--- a/tests/phpunit/tests/formatting/redirect.php
+++ b/tests/phpunit/tests/formatting/redirect.php
@@ -6,12 +6,12 @@
  * @group redirect
  */
 class Tests_Formatting_Redirect extends WP_UnitTestCase {
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 		add_filter( 'home_url', array( $this, 'home_url' ) );
 	}
 
-	function home_url() {
+	public function home_url() {
 		return 'http://example.com/';
 	}
 
@@ -41,7 +41,7 @@ class Tests_Formatting_Redirect extends WP_UnitTestCase {
 		);
 	}
 
-	function test_wp_sanitize_redirect() {
+	public function test_wp_sanitize_redirect() {
 		$this->assertSame( 'http://example.com/watchthelinefeedgo', wp_sanitize_redirect( 'http://example.com/watchthelinefeed%0Ago' ) );
 		$this->assertSame( 'http://example.com/watchthelinefeedgo', wp_sanitize_redirect( 'http://example.com/watchthelinefeed%0ago' ) );
 		$this->assertSame( 'http://example.com/watchthecarriagereturngo', wp_sanitize_redirect( 'http://example.com/watchthecarriagereturn%0Dgo' ) );
@@ -60,7 +60,7 @@ class Tests_Formatting_Redirect extends WP_UnitTestCase {
 	/**
 	 * @ticket 36998
 	 */
-	function test_wp_sanitize_redirect_should_encode_spaces() {
+	public function test_wp_sanitize_redirect_should_encode_spaces() {
 		$this->assertSame( 'http://example.com/test%20spaces', wp_sanitize_redirect( 'http://example.com/test%20spaces' ) );
 		$this->assertSame( 'http://example.com/test%20spaces%20in%20url', wp_sanitize_redirect( 'http://example.com/test spaces in url' ) );
 	}
@@ -68,18 +68,18 @@ class Tests_Formatting_Redirect extends WP_UnitTestCase {
 	/**
 	 * @dataProvider valid_url_provider
 	 */
-	function test_wp_validate_redirect_valid_url( $url, $expected ) {
+	public function test_wp_validate_redirect_valid_url( $url, $expected ) {
 		$this->assertSame( $expected, wp_validate_redirect( $url ) );
 	}
 
 	/**
 	 * @dataProvider invalid_url_provider
 	 */
-	function test_wp_validate_redirect_invalid_url( $url ) {
+	public function test_wp_validate_redirect_invalid_url( $url ) {
 		$this->assertEquals( false, wp_validate_redirect( $url, false ) );
 	}
 
-	function valid_url_provider() {
+	public function valid_url_provider() {
 		return array(
 			array( 'http://example.com', 'http://example.com' ),
 			array( 'http://example.com/', 'http://example.com/' ),
@@ -95,7 +95,7 @@ class Tests_Formatting_Redirect extends WP_UnitTestCase {
 		);
 	}
 
-	function invalid_url_provider() {
+	public function invalid_url_provider() {
 		return array(
 			// parse_url() fails.
 			array( '' ),
@@ -167,7 +167,7 @@ class Tests_Formatting_Redirect extends WP_UnitTestCase {
 	 * @ticket 47980
 	 * @dataProvider relative_url_provider
 	 */
-	function test_wp_validate_redirect_relative_url( $current_uri, $url, $expected ) {
+	public function test_wp_validate_redirect_relative_url( $current_uri, $url, $expected ) {
 		// Backup the global.
 		$unset = false;
 		if ( ! isset( $_SERVER['REQUEST_URI'] ) ) {
@@ -198,7 +198,7 @@ class Tests_Formatting_Redirect extends WP_UnitTestCase {
 	 *      string Expected destination.
 	 * }
 	 */
-	function relative_url_provider() {
+	public function relative_url_provider() {
 		return array(
 			array(
 				'/',

--- a/tests/phpunit/tests/formatting/removeAccents.php
+++ b/tests/phpunit/tests/formatting/removeAccents.php
@@ -80,7 +80,7 @@ class Tests_Formatting_RemoveAccents extends WP_UnitTestCase {
 		$this->assertSame( 'aaeiouuAEIOUU', remove_accents( 'aɑeiouüAEIOUÜ' ) );
 	}
 
-	function _remove_accents_germanic_umlauts_cb() {
+	public function _remove_accents_germanic_umlauts_cb() {
 		return 'de_DE';
 	}
 

--- a/tests/phpunit/tests/formatting/removeAccents.php
+++ b/tests/phpunit/tests/formatting/removeAccents.php
@@ -80,7 +80,7 @@ class Tests_Formatting_RemoveAccents extends WP_UnitTestCase {
 		$this->assertSame( 'aaeiouuAEIOUU', remove_accents( 'aɑeiouüAEIOUÜ' ) );
 	}
 
-	public function _remove_accents_germanic_umlauts_cb() {
+	public function remove_accents_germanic_umlauts_cb() {
 		return 'de_DE';
 	}
 
@@ -88,14 +88,14 @@ class Tests_Formatting_RemoveAccents extends WP_UnitTestCase {
 	 * @ticket 3782
 	 */
 	public function test_remove_accents_germanic_umlauts() {
-		add_filter( 'locale', array( $this, '_remove_accents_germanic_umlauts_cb' ) );
+		add_filter( 'locale', array( $this, 'remove_accents_germanic_umlauts_cb' ) );
 
 		$this->assertSame( 'AeOeUeaeoeuess', remove_accents( 'ÄÖÜäöüß' ) );
 
-		remove_filter( 'locale', array( $this, '_remove_accents_germanic_umlauts_cb' ) );
+		remove_filter( 'locale', array( $this, 'remove_accents_germanic_umlauts_cb' ) );
 	}
 
-	public function _set_locale_to_danish() {
+	public function set_locale_to_danish() {
 		return 'da_DK';
 	}
 
@@ -103,14 +103,14 @@ class Tests_Formatting_RemoveAccents extends WP_UnitTestCase {
 	 * @ticket 23907
 	 */
 	public function test_remove_danish_accents() {
-		add_filter( 'locale', array( $this, '_set_locale_to_danish' ) );
+		add_filter( 'locale', array( $this, 'set_locale_to_danish' ) );
 
 		$this->assertSame( 'AeOeAaaeoeaa', remove_accents( 'ÆØÅæøå' ) );
 
-		remove_filter( 'locale', array( $this, '_set_locale_to_danish' ) );
+		remove_filter( 'locale', array( $this, 'set_locale_to_danish' ) );
 	}
 
-	public function _set_locale_to_catalan() {
+	public function set_locale_to_catalan() {
 		return 'ca';
 	}
 
@@ -118,16 +118,16 @@ class Tests_Formatting_RemoveAccents extends WP_UnitTestCase {
 	 * @ticket 37086
 	 */
 	public function test_remove_catalan_middot() {
-		add_filter( 'locale', array( $this, '_set_locale_to_catalan' ) );
+		add_filter( 'locale', array( $this, 'set_locale_to_catalan' ) );
 
 		$this->assertSame( 'allallalla', remove_accents( 'al·lallaŀla' ) );
 
-		remove_filter( 'locale', array( $this, '_set_locale_to_catalan' ) );
+		remove_filter( 'locale', array( $this, 'set_locale_to_catalan' ) );
 
 		$this->assertSame( 'al·lallalla', remove_accents( 'al·lallaŀla' ) );
 	}
 
-	public function _set_locale_to_serbian() {
+	public function set_locale_to_serbian() {
 		return 'sr_RS';
 	}
 
@@ -135,11 +135,11 @@ class Tests_Formatting_RemoveAccents extends WP_UnitTestCase {
 	 * @ticket 38078
 	 */
 	public function test_transcribe_serbian_crossed_d() {
-		add_filter( 'locale', array( $this, '_set_locale_to_serbian' ) );
+		add_filter( 'locale', array( $this, 'set_locale_to_serbian' ) );
 
 		$this->assertSame( 'DJdj', remove_accents( 'Đđ' ) );
 
-		remove_filter( 'locale', array( $this, '_set_locale_to_serbian' ) );
+		remove_filter( 'locale', array( $this, 'set_locale_to_serbian' ) );
 
 		$this->assertSame( 'Dd', remove_accents( 'Đđ' ) );
 	}

--- a/tests/phpunit/tests/formatting/sanitizeFileName.php
+++ b/tests/phpunit/tests/formatting/sanitizeFileName.php
@@ -4,13 +4,13 @@
  * @group formatting
  */
 class Tests_Formatting_SanitizeFileName extends WP_UnitTestCase {
-	function test_munges_extensions() {
+	public function test_munges_extensions() {
 		// r17990
 		$file_name = sanitize_file_name( 'test.phtml.txt' );
 		$this->assertSame( 'test.phtml_.txt', $file_name );
 	}
 
-	function test_removes_special_chars() {
+	public function test_removes_special_chars() {
 		$special_chars = array( '?', '[', ']', '/', '\\', '=', '<', '>', ':', ';', ',', "'", '"', '&', '$', '#', '*', '(', ')', '|', '~', '`', '!', '{', '}', '%', '+', '’', '«', '»', '”', '“', chr( 0 ) );
 		$string        = 'test';
 		foreach ( $special_chars as $char ) {
@@ -23,7 +23,7 @@ class Tests_Formatting_SanitizeFileName extends WP_UnitTestCase {
 	/**
 	 * @ticket 22363
 	 */
-	function test_removes_accents() {
+	public function test_removes_accents() {
 		$in  = 'àáâãäåæçèéêëìíîïñòóôõöøùúûüýÿ';
 		$out = 'aaaaaaaeceeeeiiiinoooooouuuuyy';
 		$this->assertSame( $out, sanitize_file_name( $in ) );
@@ -34,7 +34,7 @@ class Tests_Formatting_SanitizeFileName extends WP_UnitTestCase {
 	 *
 	 * @ticket 16330
 	 */
-	function test_replaces_spaces() {
+	public function test_replaces_spaces() {
 		$urls = array(
 			'unencoded space.png'  => 'unencoded-space.png',
 			'encoded-space.jpg'    => 'encoded-space.jpg',
@@ -47,15 +47,15 @@ class Tests_Formatting_SanitizeFileName extends WP_UnitTestCase {
 		}
 	}
 
-	function test_replaces_any_number_of_hyphens_with_one_hyphen() {
+	public function test_replaces_any_number_of_hyphens_with_one_hyphen() {
 		$this->assertSame( 'a-t-t', sanitize_file_name( 'a----t----t' ) );
 	}
 
-	function test_trims_trailing_hyphens() {
+	public function test_trims_trailing_hyphens() {
 		$this->assertSame( 'a-t-t', sanitize_file_name( 'a----t----t----' ) );
 	}
 
-	function test_replaces_any_amount_of_whitespace_with_one_hyphen() {
+	public function test_replaces_any_amount_of_whitespace_with_one_hyphen() {
 		$this->assertSame( 'a-t', sanitize_file_name( 'a          t' ) );
 		$this->assertSame( 'a-t', sanitize_file_name( "a    \n\n\nt" ) );
 	}
@@ -63,17 +63,17 @@ class Tests_Formatting_SanitizeFileName extends WP_UnitTestCase {
 	/**
 	 * @ticket 16226
 	 */
-	function test_replaces_percent_sign() {
+	public function test_replaces_percent_sign() {
 		$this->assertSame( 'a22b.jpg', sanitize_file_name( 'a%22b.jpg' ) );
 	}
 
-	function test_replaces_unnamed_file_extensions() {
+	public function test_replaces_unnamed_file_extensions() {
 		// Test filenames with both supported and unsupported extensions.
 		$this->assertSame( 'unnamed-file.exe', sanitize_file_name( '_.exe' ) );
 		$this->assertSame( 'unnamed-file.jpg', sanitize_file_name( '_.jpg' ) );
 	}
 
-	function test_replaces_unnamed_file_extensionless() {
+	public function test_replaces_unnamed_file_extensionless() {
 		// Test a filenames that becomes extensionless.
 		$this->assertSame( 'no-extension', sanitize_file_name( '_.no-extension' ) );
 	}
@@ -81,11 +81,11 @@ class Tests_Formatting_SanitizeFileName extends WP_UnitTestCase {
 	/**
 	 * @dataProvider data_wp_filenames
 	 */
-	function test_replaces_invalid_utf8_characters( $input, $expected ) {
+	public function test_replaces_invalid_utf8_characters( $input, $expected ) {
 		$this->assertSame( $expected, sanitize_file_name( $input ) );
 	}
 
-	function data_wp_filenames() {
+	public function data_wp_filenames() {
 		return array(
 			array( urldecode( '%B1myfile.png' ), 'myfile.png' ),
 			array( urldecode( '%B1myfile' ), 'myfile' ),

--- a/tests/phpunit/tests/formatting/sanitizeMimeType.php
+++ b/tests/phpunit/tests/formatting/sanitizeMimeType.php
@@ -8,7 +8,7 @@ class Tests_Formatting_SanitizeMimeType extends WP_UnitTestCase {
 	/**
 	 * @ticket 17855
 	 */
-	function test_sanitize_valid_mime_type() {
+	public function test_sanitize_valid_mime_type() {
 		$inputs = array(
 			'application/atom+xml',
 			'application/EDI-X12',

--- a/tests/phpunit/tests/formatting/sanitizeOrderby.php
+++ b/tests/phpunit/tests/formatting/sanitizeOrderby.php
@@ -9,10 +9,10 @@ class Tests_Formatting_SanitizeOrderby extends WP_UnitTestCase {
 	 * @covers ::sanitize_sql_orderby
 	 * @dataProvider valid_orderbys
 	 */
-	function test_valid( $orderby ) {
+	public function test_valid( $orderby ) {
 		$this->assertSame( $orderby, sanitize_sql_orderby( $orderby ) );
 	}
-	function valid_orderbys() {
+	public function valid_orderbys() {
 		return array(
 			array( '1' ),
 			array( '1 ASC' ),
@@ -36,10 +36,10 @@ class Tests_Formatting_SanitizeOrderby extends WP_UnitTestCase {
 	 * @covers ::sanitize_sql_orderby
 	 * @dataProvider invalid_orderbys
 	 */
-	function test_invalid( $orderby ) {
+	public function test_invalid( $orderby ) {
 		$this->assertFalse( sanitize_sql_orderby( $orderby ) );
 	}
-	function invalid_orderbys() {
+	public function invalid_orderbys() {
 		return array(
 			array( '' ),
 			array( '1 2' ),

--- a/tests/phpunit/tests/formatting/sanitizePost.php
+++ b/tests/phpunit/tests/formatting/sanitizePost.php
@@ -8,7 +8,7 @@ class Tests_Formatting_SanitizePost extends WP_UnitTestCase {
 	/**
 	 * @ticket 22324
 	 */
-	function test_int_fields() {
+	public function test_int_fields() {
 		$post       = self::factory()->post->create_and_get();
 		$int_fields = array(
 			'ID'            => 'integer',

--- a/tests/phpunit/tests/formatting/sanitizeTextField.php
+++ b/tests/phpunit/tests/formatting/sanitizeTextField.php
@@ -4,7 +4,7 @@
  * @group formatting
  */
 class Tests_Formatting_SanitizeTextField extends WP_UnitTestCase {
-	function data_sanitize_text_field() {
+	public function data_sanitize_text_field() {
 		return array(
 			array(
 				'оРангутанг', // Ensure UTF-8 text is safe. The Р is D0 A0 and A0 is the non-breaking space.
@@ -128,7 +128,7 @@ class Tests_Formatting_SanitizeTextField extends WP_UnitTestCase {
 	 * @ticket 32257
 	 * @dataProvider data_sanitize_text_field
 	 */
-	function test_sanitize_text_field( $string, $expected ) {
+	public function test_sanitize_text_field( $string, $expected ) {
 		if ( is_array( $expected ) ) {
 			$expected_oneline   = $expected['oneline'];
 			$expected_multiline = $expected['multiline'];

--- a/tests/phpunit/tests/formatting/sanitizeTitle.php
+++ b/tests/phpunit/tests/formatting/sanitizeTitle.php
@@ -4,13 +4,13 @@
  * @group formatting
  */
 class Tests_Formatting_SanitizeTitle extends WP_UnitTestCase {
-	function test_strips_html() {
+	public function test_strips_html() {
 		$input    = 'Captain <strong>Awesome</strong>';
 		$expected = 'captain-awesome';
 		$this->assertSame( $expected, sanitize_title( $input ) );
 	}
 
-	function test_titles_sanitized_to_nothing_are_replaced_with_optional_fallback() {
+	public function test_titles_sanitized_to_nothing_are_replaced_with_optional_fallback() {
 		$input    = '<strong></strong>';
 		$fallback = 'Captain Awesome';
 		$this->assertSame( $fallback, sanitize_title( $input, $fallback ) );

--- a/tests/phpunit/tests/formatting/sanitizeTitleWithDashes.php
+++ b/tests/phpunit/tests/formatting/sanitizeTitleWithDashes.php
@@ -4,34 +4,34 @@
  * @group formatting
  */
 class Tests_Formatting_SanitizeTitleWithDashes extends WP_UnitTestCase {
-	function test_strips_html() {
+	public function test_strips_html() {
 		$input    = 'Captain <strong>Awesome</strong>';
 		$expected = 'captain-awesome';
 		$this->assertSame( $expected, sanitize_title_with_dashes( $input ) );
 	}
 
-	function test_strips_unencoded_percent_signs() {
+	public function test_strips_unencoded_percent_signs() {
 		$this->assertSame( 'fran%c3%a7ois', sanitize_title_with_dashes( 'fran%c3%a7%ois' ) );
 	}
 
-	function test_makes_title_lowercase() {
+	public function test_makes_title_lowercase() {
 		$this->assertSame( 'abc', sanitize_title_with_dashes( 'ABC' ) );
 	}
 
-	function test_replaces_any_amount_of_whitespace_with_one_hyphen() {
+	public function test_replaces_any_amount_of_whitespace_with_one_hyphen() {
 		$this->assertSame( 'a-t', sanitize_title_with_dashes( 'a          t' ) );
 		$this->assertSame( 'a-t', sanitize_title_with_dashes( "a    \n\n\nt" ) );
 	}
 
-	function test_replaces_any_number_of_hyphens_with_one_hyphen() {
+	public function test_replaces_any_number_of_hyphens_with_one_hyphen() {
 		$this->assertSame( 'a-t-t', sanitize_title_with_dashes( 'a----t----t' ) );
 	}
 
-	function test_trims_trailing_hyphens() {
+	public function test_trims_trailing_hyphens() {
 		$this->assertSame( 'a-t-t', sanitize_title_with_dashes( 'a----t----t----' ) );
 	}
 
-	function test_handles_non_entity_ampersands() {
+	public function test_handles_non_entity_ampersands() {
 		$this->assertSame( 'penn-teller-bull', sanitize_title_with_dashes( 'penn & teller bull' ) );
 	}
 
@@ -59,18 +59,18 @@ class Tests_Formatting_SanitizeTitleWithDashes extends WP_UnitTestCase {
 		$this->assertSame( 'onetwo', sanitize_title_with_dashes( 'One&Two', '', 'save' ) );
 	}
 
-	function test_replaces_nbsp() {
+	public function test_replaces_nbsp() {
 		$this->assertSame( 'dont-break-the-space', sanitize_title_with_dashes( "don't break the space", '', 'save' ) );
 	}
 
 	/**
 	 * @ticket 31790
 	 */
-	function test_replaces_nbsp_entities() {
+	public function test_replaces_nbsp_entities() {
 		$this->assertSame( 'dont-break-the-space', sanitize_title_with_dashes( "don't&nbsp;break&#160;the&nbsp;space", '', 'save' ) );
 	}
 
-	function test_replaces_ndash_mdash() {
+	public function test_replaces_ndash_mdash() {
 		$this->assertSame( 'do-the-dash', sanitize_title_with_dashes( 'Do – the Dash', '', 'save' ) );
 		$this->assertSame( 'do-the-dash', sanitize_title_with_dashes( 'Do the — Dash', '', 'save' ) );
 	}
@@ -78,22 +78,22 @@ class Tests_Formatting_SanitizeTitleWithDashes extends WP_UnitTestCase {
 	/**
 	 * @ticket 31790
 	 */
-	function test_replaces_ndash_mdash_entities() {
+	public function test_replaces_ndash_mdash_entities() {
 		$this->assertSame( 'do-the-dash', sanitize_title_with_dashes( 'Do &ndash; the &#8211; Dash', '', 'save' ) );
 		$this->assertSame( 'do-the-dash', sanitize_title_with_dashes( 'Do &mdash; the &#8212; Dash', '', 'save' ) );
 	}
 
-	function test_replaces_iexcel_iquest() {
+	public function test_replaces_iexcel_iquest() {
 		$this->assertSame( 'just-a-slug', sanitize_title_with_dashes( 'Just ¡a Slug', '', 'save' ) );
 		$this->assertSame( 'just-a-slug', sanitize_title_with_dashes( 'Just a Slug¿', '', 'save' ) );
 	}
 
-	function test_replaces_angle_quotes() {
+	public function test_replaces_angle_quotes() {
 		$this->assertSame( 'just-a-slug', sanitize_title_with_dashes( '‹Just a Slug›', '', 'save' ) );
 		$this->assertSame( 'just-a-slug', sanitize_title_with_dashes( '«Just a Slug»', '', 'save' ) );
 	}
 
-	function test_replaces_curly_quotes() {
+	public function test_replaces_curly_quotes() {
 		$this->assertSame( 'hey-its-curly-joe', sanitize_title_with_dashes( 'Hey its “Curly Joe”', '', 'save' ) );
 		$this->assertSame( 'hey-its-curly-joe', sanitize_title_with_dashes( 'Hey its ‘Curly Joe’', '', 'save' ) );
 		$this->assertSame( 'hey-its-curly-joe', sanitize_title_with_dashes( 'Hey its „Curly Joe“', '', 'save' ) );
@@ -104,11 +104,11 @@ class Tests_Formatting_SanitizeTitleWithDashes extends WP_UnitTestCase {
 	/**
 	 * @ticket 49791
 	 */
-	function test_replaces_bullet() {
+	public function test_replaces_bullet() {
 		$this->assertSame( 'fancy-title-amazing', sanitize_title_with_dashes( 'Fancy Title • Amazing', '', 'save' ) );
 	}
 
-	function test_replaces_copy_reg_deg_trade() {
+	public function test_replaces_copy_reg_deg_trade() {
 		$this->assertSame( 'just-a-slug', sanitize_title_with_dashes( 'Just © a Slug', '', 'save' ) );
 		$this->assertSame( 'just-a-slug', sanitize_title_with_dashes( '® Just a Slug', '', 'save' ) );
 		$this->assertSame( 'just-a-slug', sanitize_title_with_dashes( 'Just a ° Slug', '', 'save' ) );
@@ -118,7 +118,7 @@ class Tests_Formatting_SanitizeTitleWithDashes extends WP_UnitTestCase {
 	/**
 	 * @ticket 10792
 	 */
-	function test_replaces_forward_slash() {
+	public function test_replaces_forward_slash() {
 		$this->assertSame( 'songs-by-lennon-mccartney', sanitize_title_with_dashes( 'songs by Lennon/McCartney', '', 'save' ) );
 		$this->assertSame( 'songs-by-lennon-mccartney', sanitize_title_with_dashes( 'songs by Lennon//McCartney', '', 'save' ) );
 		$this->assertSame( 'songs-by-lennon-mccartney', sanitize_title_with_dashes( 'songs by Lennon///McCartney', '', 'save' ) );
@@ -129,21 +129,21 @@ class Tests_Formatting_SanitizeTitleWithDashes extends WP_UnitTestCase {
 	/**
 	 * @ticket 19820
 	 */
-	function test_replaces_multiply_sign() {
+	public function test_replaces_multiply_sign() {
 		$this->assertSame( '6x7-is-42', sanitize_title_with_dashes( '6×7 is 42', '', 'save' ) );
 	}
 
 	/**
 	 * @ticket 20772
 	 */
-	function test_replaces_standalone_diacritic() {
+	public function test_replaces_standalone_diacritic() {
 		$this->assertSame( 'aaaa', sanitize_title_with_dashes( 'āáǎà', '', 'save' ) );
 	}
 
 	/**
 	 * @ticket 22395
 	 */
-	function test_replaces_acute_accents() {
+	public function test_replaces_acute_accents() {
 		$this->assertSame( 'aaaa', sanitize_title_with_dashes( 'ááa´aˊ', '', 'save' ) );
 	}
 

--- a/tests/phpunit/tests/formatting/sanitizeTrackbackUrls.php
+++ b/tests/phpunit/tests/formatting/sanitizeTrackbackUrls.php
@@ -8,11 +8,11 @@ class Tests_Formatting_SanitizeTrackbackUrls extends WP_UnitTestCase {
 	 * @ticket 21624
 	 * @dataProvider breaks
 	 */
-	function test_sanitize_trackback_urls_with_multiple_urls( $break ) {
+	public function test_sanitize_trackback_urls_with_multiple_urls( $break ) {
 		$this->assertSame( "http://example.com\nhttp://example.org", sanitize_trackback_urls( "http://example.com{$break}http://example.org" ) );
 	}
 
-	function breaks() {
+	public function breaks() {
 		return array(
 			array( "\r\n\t " ),
 			array( "\r" ),

--- a/tests/phpunit/tests/formatting/sanitizeUser.php
+++ b/tests/phpunit/tests/formatting/sanitizeUser.php
@@ -4,7 +4,7 @@
  * @group formatting
  */
 class Tests_Formatting_SanitizeUser extends WP_UnitTestCase {
-	function test_strips_html() {
+	public function test_strips_html() {
 		$input    = 'Captain <strong>Awesome</strong>';
 		$expected = is_multisite() ? 'captain awesome' : 'Captain Awesome';
 		$this->assertSame( $expected, sanitize_user( $input ) );
@@ -32,11 +32,11 @@ class Tests_Formatting_SanitizeUser extends WP_UnitTestCase {
 		$this->assertSame( $expected, sanitize_user( 'AT&amp;T Test;' ) );
 	}
 
-	function test_strips_percent_encoded_octets() {
+	public function test_strips_percent_encoded_octets() {
 		$expected = is_multisite() ? 'franois' : 'Franois';
 		$this->assertSame( $expected, sanitize_user( 'Fran%c3%a7ois' ) );
 	}
-	function test_optional_strict_mode_reduces_to_safe_ascii_subset() {
+	public function test_optional_strict_mode_reduces_to_safe_ascii_subset() {
 		$this->assertSame( 'abc', sanitize_user( '()~ab~ˆcˆ!', true ) );
 	}
 }

--- a/tests/phpunit/tests/formatting/seemsUtf8.php
+++ b/tests/phpunit/tests/formatting/seemsUtf8.php
@@ -10,12 +10,12 @@ class Tests_Formatting_SeemsUtf8 extends WP_UnitTestCase {
 	 *
 	 * @dataProvider utf8_strings
 	 */
-	function test_returns_true_for_utf8_strings( $utf8_string ) {
+	public function test_returns_true_for_utf8_strings( $utf8_string ) {
 		// From http://www.i18nguy.com/unicode-example.html
 		$this->assertTrue( seems_utf8( $utf8_string ) );
 	}
 
-	function utf8_strings() {
+	public function utf8_strings() {
 		$utf8_strings = file( DIR_TESTDATA . '/formatting/utf-8/utf-8.txt' );
 		foreach ( $utf8_strings as &$string ) {
 			$string = (array) trim( $string );
@@ -27,11 +27,11 @@ class Tests_Formatting_SeemsUtf8 extends WP_UnitTestCase {
 	/**
 	 * @dataProvider big5_strings
 	 */
-	function test_returns_false_for_non_utf8_strings( $big5_string ) {
+	public function test_returns_false_for_non_utf8_strings( $big5_string ) {
 		$this->assertFalse( seems_utf8( $big5_string ) );
 	}
 
-	function big5_strings() {
+	public function big5_strings() {
 		// Get data from formatting/big5.txt.
 		$big5_strings = file( DIR_TESTDATA . '/formatting/big5.txt' );
 		foreach ( $big5_strings as &$string ) {

--- a/tests/phpunit/tests/formatting/slashit.php
+++ b/tests/phpunit/tests/formatting/slashit.php
@@ -4,19 +4,19 @@
  * @group formatting
  */
 class Tests_Formatting_Slashit extends WP_UnitTestCase {
-	function test_backslashes_middle_numbers() {
+	public function test_backslashes_middle_numbers() {
 		$this->assertSame( "\\a-!9\\a943\\b\\c", backslashit( 'a-!9a943bc' ) );
 	}
 
-	function test_backslashes_alphas() {
+	public function test_backslashes_alphas() {
 		$this->assertSame( "\\a943\\b\\c", backslashit( 'a943bc' ) );
 	}
 
-	function test_double_backslashes_leading_numbers() {
+	public function test_double_backslashes_leading_numbers() {
 		$this->assertSame( '\\\\95', backslashit( '95' ) );
 	}
 
-	function test_removes_trailing_slashes() {
+	public function test_removes_trailing_slashes() {
 		$this->assertSame( 'a', untrailingslashit( 'a/' ) );
 		$this->assertSame( 'a', untrailingslashit( 'a////' ) );
 	}
@@ -24,7 +24,7 @@ class Tests_Formatting_Slashit extends WP_UnitTestCase {
 	/**
 	 * @ticket 22267
 	 */
-	function test_removes_trailing_backslashes() {
+	public function test_removes_trailing_backslashes() {
 		$this->assertSame( 'a', untrailingslashit( 'a\\' ) );
 		$this->assertSame( 'a', untrailingslashit( 'a\\\\\\\\' ) );
 	}
@@ -32,23 +32,23 @@ class Tests_Formatting_Slashit extends WP_UnitTestCase {
 	/**
 	 * @ticket 22267
 	 */
-	function test_removes_trailing_mixed_slashes() {
+	public function test_removes_trailing_mixed_slashes() {
 		$this->assertSame( 'a', untrailingslashit( 'a/\\' ) );
 		$this->assertSame( 'a', untrailingslashit( 'a\\/\\///\\\\//' ) );
 	}
 
-	function test_adds_trailing_slash() {
+	public function test_adds_trailing_slash() {
 		$this->assertSame( 'a/', trailingslashit( 'a' ) );
 	}
 
-	function test_does_not_add_trailing_slash_if_one_exists() {
+	public function test_does_not_add_trailing_slash_if_one_exists() {
 		$this->assertSame( 'a/', trailingslashit( 'a/' ) );
 	}
 
 	/**
 	 * @ticket 22267
 	 */
-	function test_converts_trailing_backslash_to_slash_if_one_exists() {
+	public function test_converts_trailing_backslash_to_slash_if_one_exists() {
 		$this->assertSame( 'a/', trailingslashit( 'a\\' ) );
 	}
 }

--- a/tests/phpunit/tests/formatting/stripslashesDeep.php
+++ b/tests/phpunit/tests/formatting/stripslashesDeep.php
@@ -8,7 +8,7 @@ class Tests_Formatting_StripslashesDeep extends WP_UnitTestCase {
 	/**
 	 * @ticket 18026
 	 */
-	function test_preserves_original_datatype() {
+	public function test_preserves_original_datatype() {
 
 		$this->assertTrue( stripslashes_deep( true ) );
 		$this->assertFalse( stripslashes_deep( false ) );
@@ -31,7 +31,7 @@ class Tests_Formatting_StripslashesDeep extends WP_UnitTestCase {
 		$this->assertSame( $obj, stripslashes_deep( $obj ) );
 	}
 
-	function test_strips_slashes() {
+	public function test_strips_slashes() {
 		$old = "I can\'t see, isn\'t that it?";
 		$new = "I can't see, isn't that it?";
 		$this->assertSame( $new, stripslashes_deep( $old ) );
@@ -46,7 +46,7 @@ class Tests_Formatting_StripslashesDeep extends WP_UnitTestCase {
 		$this->assertEquals( $obj_new, stripslashes_deep( $obj_old ) );
 	}
 
-	function test_permits_escaped_slash() {
+	public function test_permits_escaped_slash() {
 		$txt = "I can't see, isn\'t that it?";
 		$this->assertSame( $txt, stripslashes_deep( "I can\'t see, isn\\\'t that it?" ) );
 		$this->assertSame( $txt, stripslashes_deep( "I can\'t see, isn\\\\\'t that it?" ) );

--- a/tests/phpunit/tests/formatting/urlShorten.php
+++ b/tests/phpunit/tests/formatting/urlShorten.php
@@ -4,7 +4,7 @@
  * @group formatting
  */
 class Tests_Formatting_UrlShorten extends WP_UnitTestCase {
-	function test_url_shorten() {
+	public function test_url_shorten() {
 		$tests = array(
 			'wordpress\.org/about/philosophy'            => 'wordpress\.org/about/philosophy', // No longer strips slashes.
 			'wordpress.org/about/philosophy'             => 'wordpress.org/about/philosophy',

--- a/tests/phpunit/tests/formatting/utf8UriEncode.php
+++ b/tests/phpunit/tests/formatting/utf8UriEncode.php
@@ -11,19 +11,19 @@ class Tests_Formatting_Utf8UriEncode extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data
 	 */
-	function test_percent_encodes_non_reserved_characters( $utf8, $urlencoded ) {
+	public function test_percent_encodes_non_reserved_characters( $utf8, $urlencoded ) {
 		$this->assertSame( $urlencoded, utf8_uri_encode( $utf8 ) );
 	}
 
 	/**
 	 * @dataProvider data
 	 */
-	function test_output_is_not_longer_than_optional_length_argument( $utf8, $unused_for_this_test ) {
+	public function test_output_is_not_longer_than_optional_length_argument( $utf8, $unused_for_this_test ) {
 		$max_length = 30;
 		$this->assertTrue( strlen( utf8_uri_encode( $utf8, $max_length ) ) <= $max_length );
 	}
 
-	function data() {
+	public function data() {
 		$utf8_urls     = file( DIR_TESTDATA . '/formatting/utf-8/utf-8.txt' );
 		$urlencoded    = file( DIR_TESTDATA . '/formatting/utf-8/urlencoded.txt' );
 		$data_provided = array();

--- a/tests/phpunit/tests/formatting/wpAutop.php
+++ b/tests/phpunit/tests/formatting/wpAutop.php
@@ -8,7 +8,7 @@ class Tests_Formatting_wpAutop extends WP_UnitTestCase {
 	/**
 	 * @ticket 11008
 	 */
-	function test_first_post() {
+	public function test_first_post() {
 		$expected  = '<p>Welcome to WordPress!  This post contains important information.  After you read it, you can make it private to hide it from visitors but still have the information handy for future reference.</p>
 <p>First things first:</p>
 <ul>
@@ -282,7 +282,7 @@ Paragraph two.';
 	 *
 	 * @ticket 27268
 	 */
-	function test_that_wpautop_treats_block_level_elements_as_blocks() {
+	public function test_that_wpautop_treats_block_level_elements_as_blocks() {
 		$blocks = array(
 			'table',
 			'thead',
@@ -376,7 +376,7 @@ Paragraph two.';
 	 *
 	 * @ticket 27268
 	 */
-	function test_that_wpautop_does_not_wrap_blockquotes_but_does_autop_their_contents() {
+	public function test_that_wpautop_does_not_wrap_blockquotes_but_does_autop_their_contents() {
 		$content  = '<blockquote>foo</blockquote>';
 		$expected = '<blockquote><p>foo</p></blockquote>';
 
@@ -388,7 +388,7 @@ Paragraph two.';
 	 *
 	 * @ticket 27268
 	 */
-	function test_that_wpautop_treats_inline_elements_as_inline() {
+	public function test_that_wpautop_treats_inline_elements_as_inline() {
 		$inlines = array(
 			'a',
 			'em',
@@ -438,11 +438,11 @@ Paragraph two.';
 	 * @ticket 33106
 	 * @dataProvider data_element_sanity
 	 */
-	function test_element_sanity( $input, $output ) {
+	public function test_element_sanity( $input, $output ) {
 		return $this->assertSame( $output, wpautop( $input ) );
 	}
 
-	function data_element_sanity() {
+	public function data_element_sanity() {
 		return array(
 			array(
 				"Hello <a\nhref='world'>",
@@ -490,7 +490,7 @@ Paragraph two.';
 	 *
 	 * @ticket 33377
 	 */
-	function test_that_wpautop_skips_line_breaks_after_br() {
+	public function test_that_wpautop_skips_line_breaks_after_br() {
 		$content = '
 line 1<br>
 line 2<br/>
@@ -513,7 +513,7 @@ line 5</p>';
 	 *
 	 * @ticket 33377
 	 */
-	function test_that_wpautop_adds_a_paragraph_after_multiple_br() {
+	public function test_that_wpautop_adds_a_paragraph_after_multiple_br() {
 		$content = '
 line 1<br>
 <br/>
@@ -531,7 +531,7 @@ line 2<br/>
 	/**
 	 * @ticket 4857
 	 */
-	function test_that_text_before_blocks_is_peed() {
+	public function test_that_text_before_blocks_is_peed() {
 		$content  = 'a<div>b</div>';
 		$expected = "<p>a</p>\n<div>b</div>";
 
@@ -546,7 +546,7 @@ line 2<br/>
 	 *
 	 * @ticket 39307
 	 */
-	function test_that_wpautop_does_not_add_extra_closing_p_in_figure() {
+	public function test_that_wpautop_does_not_add_extra_closing_p_in_figure() {
 		$content1  = '<figure><img src="example.jpg" /><figcaption>Caption</figcaption></figure>';
 		$expected1 = $content1;
 
@@ -565,7 +565,7 @@ line 2<br/>
 	/**
 	 * @ticket 14674
 	 */
-	function test_the_hr_is_not_peed() {
+	public function test_the_hr_is_not_peed() {
 		$content  = 'paragraph1<hr>paragraph2';
 		$expected = "<p>paragraph1</p>\n<hr>\n<p>paragraph2</p>";
 
@@ -577,7 +577,7 @@ line 2<br/>
 	 *
 	 * @ticket 9437
 	 */
-	function test_that_wpautop_ignores_inline_svgs() {
+	public function test_that_wpautop_ignores_inline_svgs() {
 		$content =
 			'<svg xmlns="http://www.w3.org/2000/svg">
 				<circle cx="50" cy="50" r="30" fill="blue">
@@ -595,7 +595,7 @@ line 2<br/>
 	 *
 	 * @ticket 9437
 	 */
-	function test_that_wpautop_ignores_inline_scripts() {
+	public function test_that_wpautop_ignores_inline_scripts() {
 		$content =
 			'<script type="text/javascript">
 				var dummy = 1;

--- a/tests/phpunit/tests/formatting/wpBasename.php
+++ b/tests/phpunit/tests/formatting/wpBasename.php
@@ -5,14 +5,14 @@
  */
 class Tests_Formatting_wpBasename extends WP_UnitTestCase {
 
-	function test_wp_basename_unix() {
+	public function test_wp_basename_unix() {
 		$this->assertSame(
 			'file',
 			wp_basename( '/home/test/file' )
 		);
 	}
 
-	function test_wp_basename_unix_utf8_support() {
+	public function test_wp_basename_unix_utf8_support() {
 		$this->assertSame(
 			'žluťoučký kůň.txt',
 			wp_basename( '/test/žluťoučký kůň.txt' )
@@ -22,7 +22,7 @@ class Tests_Formatting_wpBasename extends WP_UnitTestCase {
 	/**
 	 * @ticket 22138
 	 */
-	function test_wp_basename_windows() {
+	public function test_wp_basename_windows() {
 		$this->assertSame(
 			'file.txt',
 			wp_basename( 'C:\Documents and Settings\User\file.txt' )
@@ -32,7 +32,7 @@ class Tests_Formatting_wpBasename extends WP_UnitTestCase {
 	/**
 	 * @ticket 22138
 	 */
-	function test_wp_basename_windows_utf8_support() {
+	public function test_wp_basename_windows_utf8_support() {
 		$this->assertSame(
 			'щипцы.txt',
 			wp_basename( 'C:\test\щипцы.txt' )

--- a/tests/phpunit/tests/formatting/wpHtmlExcerpt.php
+++ b/tests/phpunit/tests/formatting/wpHtmlExcerpt.php
@@ -4,13 +4,13 @@
  * @group formatting
  */
 class Tests_Formatting_wpHtmlExcerpt extends WP_UnitTestCase {
-	function test_simple() {
+	public function test_simple() {
 		$this->assertSame( 'Baba', wp_html_excerpt( 'Baba told me not to come', 4 ) );
 	}
-	function test_html() {
+	public function test_html() {
 		$this->assertSame( 'Baba', wp_html_excerpt( "<a href='http://baba.net/'>Baba</a> told me not to come", 4 ) );
 	}
-	function test_entities() {
+	public function test_entities() {
 		$this->assertSame( 'Baba', wp_html_excerpt( 'Baba &amp; Dyado', 8 ) );
 		$this->assertSame( 'Baba', wp_html_excerpt( 'Baba &#038; Dyado', 8 ) );
 		$this->assertSame( 'Baba &amp; D', wp_html_excerpt( 'Baba &amp; Dyado', 12 ) );

--- a/tests/phpunit/tests/formatting/wpHtmlSplit.php
+++ b/tests/phpunit/tests/formatting/wpHtmlSplit.php
@@ -10,11 +10,11 @@ class Tests_Formatting_wpHtmlSplit extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_basic_features
 	 */
-	function test_basic_features( $input, $output ) {
+	public function test_basic_features( $input, $output ) {
 		return $this->assertSame( $output, wp_html_split( $input ) );
 	}
 
-	function data_basic_features() {
+	public function data_basic_features() {
 		return array(
 			array(
 				'abcd efgh',
@@ -40,13 +40,13 @@ class Tests_Formatting_wpHtmlSplit extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_whole_posts
 	 */
-	function test_pcre_performance( $input ) {
+	public function test_pcre_performance( $input ) {
 		$regex  = get_html_split_regex();
 		$result = benchmark_pcre_backtracking( $regex, $input, 'split' );
 		return $this->assertLessThan( 200, $result );
 	}
 
-	function data_whole_posts() {
+	public function data_whole_posts() {
 		require_once DIR_TESTDATA . '/formatting/whole-posts.php';
 		return data_whole_posts();
 	}

--- a/tests/phpunit/tests/formatting/wpHtmleditPre.php
+++ b/tests/phpunit/tests/formatting/wpHtmleditPre.php
@@ -6,7 +6,7 @@
  */
 class Tests_Formatting_wpHtmleditPre extends WP_UnitTestCase {
 
-	public function _charset_iso_8859_1() {
+	public function charset_iso_8859_1() {
 		return 'iso-8859-1';
 	}
 
@@ -15,13 +15,13 @@ class Tests_Formatting_wpHtmleditPre extends WP_UnitTestCase {
 	 * @ticket 23688
 	 */
 	public function test_wp_htmledit_pre_charset_iso_8859_1() {
-		add_filter( 'pre_option_blog_charset', array( $this, '_charset_iso_8859_1' ) );
+		add_filter( 'pre_option_blog_charset', array( $this, 'charset_iso_8859_1' ) );
 		$iso8859_1 = 'Fran' . chr( 135 ) . 'ais';
 		$this->assertSame( $iso8859_1, wp_htmledit_pre( $iso8859_1 ) );
-		remove_filter( 'pre_option_blog_charset', array( $this, '_charset_iso_8859_1' ) );
+		remove_filter( 'pre_option_blog_charset', array( $this, 'charset_iso_8859_1' ) );
 	}
 
-	public function _charset_utf_8() {
+	public function charset_utf_8() {
 		return 'UTF-8';
 	}
 
@@ -29,9 +29,9 @@ class Tests_Formatting_wpHtmleditPre extends WP_UnitTestCase {
 	 * @ticket 23688
 	 */
 	public function test_wp_htmledit_pre_charset_utf_8() {
-		add_filter( 'pre_option_blog_charset', array( $this, '_charset_utf_8' ) );
+		add_filter( 'pre_option_blog_charset', array( $this, 'charset_utf_8' ) );
 		$utf8 = 'Fran' . chr( 195 ) . chr( 167 ) . 'ais';
 		$this->assertSame( $utf8, wp_htmledit_pre( $utf8 ) );
-		remove_filter( 'pre_option_blog_charset', array( $this, '_charset_utf_8' ) );
+		remove_filter( 'pre_option_blog_charset', array( $this, 'charset_utf_8' ) );
 	}
 }

--- a/tests/phpunit/tests/formatting/wpHtmleditPre.php
+++ b/tests/phpunit/tests/formatting/wpHtmleditPre.php
@@ -6,7 +6,7 @@
  */
 class Tests_Formatting_wpHtmleditPre extends WP_UnitTestCase {
 
-	function _charset_iso_8859_1() {
+	public function _charset_iso_8859_1() {
 		return 'iso-8859-1';
 	}
 
@@ -14,21 +14,21 @@ class Tests_Formatting_wpHtmleditPre extends WP_UnitTestCase {
 	 * Only fails in PHP 5.4 onwards
 	 * @ticket 23688
 	 */
-	function test_wp_htmledit_pre_charset_iso_8859_1() {
+	public function test_wp_htmledit_pre_charset_iso_8859_1() {
 		add_filter( 'pre_option_blog_charset', array( $this, '_charset_iso_8859_1' ) );
 		$iso8859_1 = 'Fran' . chr( 135 ) . 'ais';
 		$this->assertSame( $iso8859_1, wp_htmledit_pre( $iso8859_1 ) );
 		remove_filter( 'pre_option_blog_charset', array( $this, '_charset_iso_8859_1' ) );
 	}
 
-	function _charset_utf_8() {
+	public function _charset_utf_8() {
 		return 'UTF-8';
 	}
 
 	/*
 	 * @ticket 23688
 	 */
-	function test_wp_htmledit_pre_charset_utf_8() {
+	public function test_wp_htmledit_pre_charset_utf_8() {
 		add_filter( 'pre_option_blog_charset', array( $this, '_charset_utf_8' ) );
 		$utf8 = 'Fran' . chr( 195 ) . chr( 167 ) . 'ais';
 		$this->assertSame( $utf8, wp_htmledit_pre( $utf8 ) );

--- a/tests/phpunit/tests/formatting/wpIsoDescrambler.php
+++ b/tests/phpunit/tests/formatting/wpIsoDescrambler.php
@@ -8,7 +8,7 @@ class Tests_Formatting_wpIsoDescrambler extends WP_UnitTestCase {
 	 * Decodes text in RFC2047 "Q"-encoding, e.g.
 	 * =?iso-8859-1?q?this=20is=20some=20text?=
 	*/
-	function test_decodes_iso_8859_1_rfc2047_q_encoding() {
+	public function test_decodes_iso_8859_1_rfc2047_q_encoding() {
 		$this->assertSame( 'this is some text', wp_iso_descrambler( '=?iso-8859-1?q?this=20is=20some=20text?=' ) );
 	}
 }

--- a/tests/phpunit/tests/formatting/wpMakeLinkRelative.php
+++ b/tests/phpunit/tests/formatting/wpMakeLinkRelative.php
@@ -38,7 +38,7 @@ class Tests_Formatting_wpMakeLinkRelative extends WP_UnitTestCase {
 	/**
 	 * @ticket 26819
 	 */
-	function test_wp_make_link_relative_with_no_path() {
+	public function test_wp_make_link_relative_with_no_path() {
 		$link          = 'http://example.com';
 		$relative_link = wp_make_link_relative( $link );
 		$this->assertSame( '', $relative_link );

--- a/tests/phpunit/tests/formatting/wpReplaceInHtmlTags.php
+++ b/tests/phpunit/tests/formatting/wpReplaceInHtmlTags.php
@@ -9,11 +9,11 @@ class Tests_Formatting_wpReplaceInHtmlTags extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_wp_replace_in_html_tags
 	 */
-	function test_wp_replace_in_html_tags( $input, $output ) {
+	public function test_wp_replace_in_html_tags( $input, $output ) {
 		return $this->assertSame( $output, wp_replace_in_html_tags( $input, array( "\n" => ' ' ) ) );
 	}
 
-	function data_wp_replace_in_html_tags() {
+	public function data_wp_replace_in_html_tags() {
 		return array(
 			array(
 				"Hello \n World",

--- a/tests/phpunit/tests/formatting/wpRicheditPre.php
+++ b/tests/phpunit/tests/formatting/wpRicheditPre.php
@@ -6,7 +6,7 @@
  */
 class Tests_Formatting_wpRicheditPre extends WP_UnitTestCase {
 
-	public function _charset_iso_8859_1() {
+	public function charset_iso_8859_1() {
 		return 'iso-8859-1';
 	}
 
@@ -15,13 +15,13 @@ class Tests_Formatting_wpRicheditPre extends WP_UnitTestCase {
 	 * @ticket 23688
 	 */
 	public function test_wp_richedit_pre_charset_iso_8859_1() {
-		add_filter( 'pre_option_blog_charset', array( $this, '_charset_iso_8859_1' ) );
+		add_filter( 'pre_option_blog_charset', array( $this, 'charset_iso_8859_1' ) );
 		$iso8859_1 = 'Fran' . chr( 135 ) . 'ais';
 		$this->assertSame( '&lt;p&gt;' . $iso8859_1 . "&lt;/p&gt;\n", wp_richedit_pre( $iso8859_1 ) );
-		remove_filter( 'pre_option_blog_charset', array( $this, '_charset_iso_8859_1' ) );
+		remove_filter( 'pre_option_blog_charset', array( $this, 'charset_iso_8859_1' ) );
 	}
 
-	public function _charset_utf_8() {
+	public function charset_utf_8() {
 		return 'UTF-8';
 	}
 
@@ -29,9 +29,9 @@ class Tests_Formatting_wpRicheditPre extends WP_UnitTestCase {
 	 * @ticket 23688
 	 */
 	public function test_wp_richedit_pre_charset_utf_8() {
-		add_filter( 'pre_option_blog_charset', array( $this, '_charset_utf_8' ) );
+		add_filter( 'pre_option_blog_charset', array( $this, 'charset_utf_8' ) );
 		$utf8 = 'Fran' . chr( 195 ) . chr( 167 ) . 'ais';
 		$this->assertSame( '&lt;p&gt;' . $utf8 . "&lt;/p&gt;\n", wp_richedit_pre( $utf8 ) );
-		remove_filter( 'pre_option_blog_charset', array( $this, '_charset_utf_8' ) );
+		remove_filter( 'pre_option_blog_charset', array( $this, 'charset_utf_8' ) );
 	}
 }

--- a/tests/phpunit/tests/formatting/wpRicheditPre.php
+++ b/tests/phpunit/tests/formatting/wpRicheditPre.php
@@ -6,7 +6,7 @@
  */
 class Tests_Formatting_wpRicheditPre extends WP_UnitTestCase {
 
-	function _charset_iso_8859_1() {
+	public function _charset_iso_8859_1() {
 		return 'iso-8859-1';
 	}
 
@@ -14,21 +14,21 @@ class Tests_Formatting_wpRicheditPre extends WP_UnitTestCase {
 	 * Only fails in PHP 5.4 onwards
 	 * @ticket 23688
 	 */
-	function test_wp_richedit_pre_charset_iso_8859_1() {
+	public function test_wp_richedit_pre_charset_iso_8859_1() {
 		add_filter( 'pre_option_blog_charset', array( $this, '_charset_iso_8859_1' ) );
 		$iso8859_1 = 'Fran' . chr( 135 ) . 'ais';
 		$this->assertSame( '&lt;p&gt;' . $iso8859_1 . "&lt;/p&gt;\n", wp_richedit_pre( $iso8859_1 ) );
 		remove_filter( 'pre_option_blog_charset', array( $this, '_charset_iso_8859_1' ) );
 	}
 
-	function _charset_utf_8() {
+	public function _charset_utf_8() {
 		return 'UTF-8';
 	}
 
 	/*
 	 * @ticket 23688
 	 */
-	function test_wp_richedit_pre_charset_utf_8() {
+	public function test_wp_richedit_pre_charset_utf_8() {
 		add_filter( 'pre_option_blog_charset', array( $this, '_charset_utf_8' ) );
 		$utf8 = 'Fran' . chr( 195 ) . chr( 167 ) . 'ais';
 		$this->assertSame( '&lt;p&gt;' . $utf8 . "&lt;/p&gt;\n", wp_richedit_pre( $utf8 ) );

--- a/tests/phpunit/tests/formatting/wpSlash.php
+++ b/tests/phpunit/tests/formatting/wpSlash.php
@@ -54,7 +54,7 @@ class Tests_Formatting_wpSlash extends WP_UnitTestCase {
 	/**
 	 * @ticket 24106
 	 */
-	function test_adds_slashes() {
+	public function test_adds_slashes() {
 		$old = "I can't see, isn't that it?";
 		$new = "I can\'t see, isn\'t that it?";
 		$this->assertSame( $new, wp_slash( $old ) );
@@ -66,7 +66,7 @@ class Tests_Formatting_wpSlash extends WP_UnitTestCase {
 	/**
 	 * @ticket 24106
 	 */
-	function test_preserves_original_datatype() {
+	public function test_preserves_original_datatype() {
 
 		$this->assertTrue( wp_slash( true ) );
 		$this->assertFalse( wp_slash( false ) );
@@ -92,7 +92,7 @@ class Tests_Formatting_wpSlash extends WP_UnitTestCase {
 	/**
 	 * @ticket 24106
 	 */
-	function test_add_even_more_slashes() {
+	public function test_add_even_more_slashes() {
 		$old = 'single\\slash double\\\\slash triple\\\\\\slash';
 		$new = 'single\\\\slash double\\\\\\\\slash triple\\\\\\\\\\\\slash';
 		$this->assertSame( $new, wp_slash( $old ) );

--- a/tests/phpunit/tests/formatting/wpSpecialchars.php
+++ b/tests/phpunit/tests/formatting/wpSpecialchars.php
@@ -4,7 +4,7 @@
  * @group formatting
  */
 class Tests_Formatting_wpSpecialchars extends WP_UnitTestCase {
-	function test_wp_specialchars_basics() {
+	public function test_wp_specialchars_basics() {
 		$html = '&amp;&lt;hello world&gt;';
 		$this->assertSame( $html, _wp_specialchars( $html ) );
 
@@ -12,7 +12,7 @@ class Tests_Formatting_wpSpecialchars extends WP_UnitTestCase {
 		$this->assertSame( $double, _wp_specialchars( $html, ENT_NOQUOTES, false, true ) );
 	}
 
-	function test_allowed_entity_names() {
+	public function test_allowed_entity_names() {
 		global $allowedentitynames;
 
 		// Allowed entities should be unchanged.
@@ -26,7 +26,7 @@ class Tests_Formatting_wpSpecialchars extends WP_UnitTestCase {
 		}
 	}
 
-	function test_not_allowed_entity_names() {
+	public function test_not_allowed_entity_names() {
 		$ents = array( 'iacut', 'aposs', 'pos', 'apo', 'apo?', 'apo.*', '.*apo.*', 'apos ', ' apos', ' apos ' );
 
 		foreach ( $ents as $ent ) {
@@ -36,7 +36,7 @@ class Tests_Formatting_wpSpecialchars extends WP_UnitTestCase {
 		}
 	}
 
-	function test_optionally_escapes_quotes() {
+	public function test_optionally_escapes_quotes() {
 		$source = "\"'hello!'\"";
 		$this->assertSame( '"&#039;hello!&#039;"', _wp_specialchars( $source, 'single' ) );
 		$this->assertSame( "&quot;'hello!'&quot;", _wp_specialchars( $source, 'double' ) );
@@ -50,11 +50,11 @@ class Tests_Formatting_wpSpecialchars extends WP_UnitTestCase {
 	 * @ticket 17780
 	 * @dataProvider data_double_encoding
 	 */
-	function test_double_encoding( $input, $output ) {
+	public function test_double_encoding( $input, $output ) {
 		return $this->assertSame( $output, _wp_specialchars( $input, ENT_NOQUOTES, false, true ) );
 	}
 
-	function data_double_encoding() {
+	public function data_double_encoding() {
 		return array(
 			array(
 				'This & that, this &amp; that, &#8212; &quot; &QUOT; &Uacute; &nbsp; &#34; &#034; &#0034; &#x00022; &#x22; &dollar; &times;',
@@ -77,11 +77,11 @@ class Tests_Formatting_wpSpecialchars extends WP_UnitTestCase {
 	 * @ticket 17780
 	 * @dataProvider data_no_double_encoding
 	 */
-	function test_no_double_encoding( $input, $output ) {
+	public function test_no_double_encoding( $input, $output ) {
 		return $this->assertSame( $output, _wp_specialchars( $input, ENT_NOQUOTES, false, false ) );
 	}
 
-	function data_no_double_encoding() {
+	public function data_no_double_encoding() {
 		return array(
 			array(
 				'This & that, this &amp; that, &#8212; &quot; &QUOT; &Uacute; &nbsp; &#34; &#034; &#0034; &#x00022; &#x22; &dollar; &times;',

--- a/tests/phpunit/tests/formatting/wpStripAllTags.php
+++ b/tests/phpunit/tests/formatting/wpStripAllTags.php
@@ -6,7 +6,7 @@
  */
 class Tests_Formatting_wpStripAllTags extends WP_UnitTestCase {
 
-	function test_wp_strip_all_tags() {
+	public function test_wp_strip_all_tags() {
 
 		$text = 'lorem<br />ipsum';
 		$this->assertSame( 'loremipsum', wp_strip_all_tags( $text ) );

--- a/tests/phpunit/tests/formatting/wpTexturize.php
+++ b/tests/phpunit/tests/formatting/wpTexturize.php
@@ -4,12 +4,12 @@
  * @group formatting
  */
 class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
-	function test_dashes() {
+	public function test_dashes() {
 		$this->assertSame( 'Hey &#8212; boo?', wptexturize( 'Hey -- boo?' ) );
 		$this->assertSame( '<a href="http://xx--xx">Hey &#8212; boo?</a>', wptexturize( '<a href="http://xx--xx">Hey -- boo?</a>' ) );
 	}
 
-	function test_disable() {
+	public function test_disable() {
 		$this->assertSame( '<pre>---&</pre>', wptexturize( '<pre>---&</pre>' ) );
 		$this->assertSame( '<pre><code></code>--&</pre>', wptexturize( '<pre><code></code>--&</pre>' ) );
 
@@ -35,7 +35,7 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 	/**
 	 * @ticket 1418
 	 */
-	function test_bracketed_quotes_1418() {
+	public function test_bracketed_quotes_1418() {
 		$this->assertSame( '(&#8220;test&#8221;)', wptexturize( '("test")' ) );
 		$this->assertSame( '(&#8216;test&#8217;)', wptexturize( "('test')" ) );
 		$this->assertSame( '(&#8217;twas)', wptexturize( "('twas)" ) );
@@ -44,14 +44,14 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 	/**
 	 * @ticket 3810
 	 */
-	function test_bracketed_quotes_3810() {
+	public function test_bracketed_quotes_3810() {
 		$this->assertSame( 'A dog (&#8220;Hubertus&#8221;) was sent out.', wptexturize( 'A dog ("Hubertus") was sent out.' ) );
 	}
 
 	/**
 	 * @ticket 4539
 	 */
-	function test_basic_quotes() {
+	public function test_basic_quotes() {
 		$this->assertSame( 'test&#8217;s', wptexturize( 'test\'s' ) );
 
 		$this->assertSame( '&#8216;quoted&#8217;', wptexturize( '\'quoted\'' ) );
@@ -74,7 +74,7 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 	 * @ticket 4539
 	 * @ticket 15241
 	 */
-	function test_full_sentences_with_unmatched_single_quotes() {
+	public function test_full_sentences_with_unmatched_single_quotes() {
 		$this->assertSame(
 			'That means every moment you&#8217;re working on something without it being in the public it&#8217;s actually dying.',
 			wptexturize( "That means every moment you're working on something without it being in the public it's actually dying." )
@@ -84,7 +84,7 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 	/**
 	 * @ticket 4539
 	 */
-	function test_quotes() {
+	public function test_quotes() {
 		$this->assertSame( '&#8220;Quoted String&#8221;', wptexturize( '"Quoted String"' ) );
 		// $this->assertSame( 'Here is &#8220;<a href="http://example.com">a test with a link</a>&#8221;', wptexturize( 'Here is "<a href="http://example.com">a test with a link</a>"' ) );
 		// $this->assertSame( 'Here is &#8220;<a href="http://example.com">a test with a link and a period</a>&#8221;.', wptexturize( 'Here is "<a href="http://example.com">a test with a link and a period</a>".' ) );
@@ -103,7 +103,7 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 	/**
 	 * @ticket 4539
 	 */
-	function test_quotes_before_s() {
+	public function test_quotes_before_s() {
 		$this->assertSame( 'test&#8217;s', wptexturize( "test's" ) );
 		$this->assertSame( '&#8216;test&#8217;s', wptexturize( "'test's" ) );
 		$this->assertSame( '&#8216;test&#8217;s&#8217;', wptexturize( "'test's'" ) );
@@ -114,7 +114,7 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 	/**
 	 * @ticket 4539
 	 */
-	function test_quotes_before_numbers() {
+	public function test_quotes_before_numbers() {
 		$this->assertSame( 'Class of &#8217;99', wptexturize( "Class of '99" ) );
 		$this->assertSame( 'Class of &#8217;99&#8217;s', wptexturize( "Class of '99's" ) );
 		$this->assertSame( '&#8216;Class of &#8217;99&#8217;', wptexturize( "'Class of '99'" ) );
@@ -141,7 +141,7 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 		$this->assertSame( '}&#8221;Class of &#8217;99&#8243;{', wptexturize( "}\"Class of '99\"{" ) );
 	}
 
-	function test_quotes_after_numbers() {
+	public function test_quotes_after_numbers() {
 		$this->assertSame( 'Class of &#8217;99', wptexturize( "Class of '99" ) );
 	}
 
@@ -149,17 +149,17 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 	 * @ticket 4539
 	 * @ticket 15241
 	 */
-	function test_other_html() {
+	public function test_other_html() {
 		$this->assertSame( '&#8216;<strong>', wptexturize( "'<strong>" ) );
 		// $this->assertSame( '&#8216;<strong>Quoted Text</strong>&#8217;,', wptexturize( "'<strong>Quoted Text</strong>'," ) );
 		// $this->assertSame( '&#8220;<strong>Quoted Text</strong>&#8221;,', wptexturize( '"<strong>Quoted Text</strong>",' ) );
 	}
 
-	function test_x() {
+	public function test_x() {
 		$this->assertSame( '14&#215;24', wptexturize( '14x24' ) );
 	}
 
-	function test_minutes_seconds() {
+	public function test_minutes_seconds() {
 		$this->assertSame( '9&#8242;', wptexturize( '9\'' ) );
 		$this->assertSame( '9&#8243;', wptexturize( '9"' ) );
 
@@ -173,7 +173,7 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 	/**
 	 * @ticket 8775
 	 */
-	function test_wptexturize_quotes_around_numbers() {
+	public function test_wptexturize_quotes_around_numbers() {
 		$this->assertSame( '&#8220;12345&#8221;', wptexturize( '"12345"' ) );
 		$this->assertSame( '&#8216;12345&#8217;', wptexturize( '\'12345\'' ) );
 		$this->assertSame( '&#8220;a 9&#8242; plus a &#8216;9&#8217;, maybe a 9&#8242; &#8216;9&#8217;&#8221;', wptexturize( '"a 9\' plus a \'9\', maybe a 9\' \'9\'"' ) );
@@ -183,7 +183,7 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 	/**
 	 * @ticket 8912
 	 */
-	function test_wptexturize_html_comments() {
+	public function test_wptexturize_html_comments() {
 		$this->assertSame( '<!--[if !IE]>--><!--<![endif]-->', wptexturize( '<!--[if !IE]>--><!--<![endif]-->' ) );
 		$this->assertSame( '<!--[if !IE]>"a 9\' plus a \'9\', maybe a 9\' \'9\' "<![endif]-->', wptexturize( '<!--[if !IE]>"a 9\' plus a \'9\', maybe a 9\' \'9\' "<![endif]-->' ) );
 		$this->assertSame( '<ul><li>Hello.</li><!--<li>Goodbye.</li>--></ul>', wptexturize( '<ul><li>Hello.</li><!--<li>Goodbye.</li>--></ul>' ) );
@@ -193,7 +193,7 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 	 * @ticket 4539
 	 * @ticket 15241
 	 */
-	function test_entity_quote_cuddling() {
+	public function test_entity_quote_cuddling() {
 		$this->assertSame( '&nbsp;&#8220;Testing&#8221;', wptexturize( '&nbsp;"Testing"' ) );
 		// $this->assertSame( '&#38;&#8220;Testing&#8221;', wptexturize( '&#38;"Testing"' ) );
 	}
@@ -201,14 +201,14 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 	/**
 	 * @ticket 22823
 	 */
-	function test_apostrophes_before_primes() {
+	public function test_apostrophes_before_primes() {
 		$this->assertSame( 'WordPress 3.5&#8217;s release date', wptexturize( "WordPress 3.5's release date" ) );
 	}
 
 	/**
 	 * @ticket 23185
 	 */
-	function test_spaces_around_hyphens() {
+	public function test_spaces_around_hyphens() {
 		$nbsp = "\xC2\xA0";
 
 		$this->assertSame( ' &#8211; ', wptexturize( ' - ' ) );
@@ -231,7 +231,7 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 	/**
 	 * @ticket 31030
 	 */
-	function test_hyphens_at_start_and_end() {
+	public function test_hyphens_at_start_and_end() {
 		$this->assertSame( '&#8211; ', wptexturize( '- ' ) );
 		$this->assertSame( '&#8211; &#8211;', wptexturize( '- -' ) );
 		$this->assertSame( ' &#8211;', wptexturize( ' -' ) );
@@ -248,7 +248,7 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 	 *
 	 * @ticket 22692
 	 */
-	function test_spaces_around_quotes_never() {
+	public function test_spaces_around_quotes_never() {
 		$nbsp = "\xC2\xA0";
 
 		$problem_input  = "$nbsp\"A";
@@ -265,11 +265,11 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 	 * @ticket 22692
 	 * @dataProvider data_spaces_around_quotes
 	 */
-	function test_spaces_around_quotes( $input, $output ) {
+	public function test_spaces_around_quotes( $input, $output ) {
 		return $this->assertSame( $output, wptexturize( $input ) );
 	}
 
-	function data_spaces_around_quotes() {
+	public function data_spaces_around_quotes() {
 		$nbsp = "\xC2\xA0";
 		$pi   = "\xCE\xA0";
 
@@ -321,11 +321,11 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 	 * @ticket 22692
 	 * @dataProvider data_apos_before_digits
 	 */
-	function test_apos_before_digits( $input, $output ) {
+	public function test_apos_before_digits( $input, $output ) {
 		return $this->assertSame( $output, wptexturize( $input ) );
 	}
 
-	function data_apos_before_digits() {
+	public function data_apos_before_digits() {
 		return array(
 			array(
 				"word '99 word",
@@ -362,11 +362,11 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 	 * @ticket 22692
 	 * @dataProvider data_opening_single_quote
 	 */
-	function test_opening_single_quote( $input, $output ) {
+	public function test_opening_single_quote( $input, $output ) {
 		return $this->assertSame( $output, wptexturize( $input ) );
 	}
 
-	function data_opening_single_quote() {
+	public function data_opening_single_quote() {
 		return array(
 			array(
 				"word 'word word",
@@ -491,11 +491,11 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 	 * @ticket 22692
 	 * @dataProvider data_double_prime
 	 */
-	function test_double_prime( $input, $output ) {
+	public function test_double_prime( $input, $output ) {
 		return $this->assertSame( $output, wptexturize( $input ) );
 	}
 
-	function data_double_prime() {
+	public function data_double_prime() {
 		return array(
 			array(
 				'word 99" word',
@@ -524,11 +524,11 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 	 * @ticket 22692
 	 * @dataProvider data_single_prime
 	 */
-	function test_single_prime( $input, $output ) {
+	public function test_single_prime( $input, $output ) {
 		return $this->assertSame( $output, wptexturize( $input ) );
 	}
 
-	function data_single_prime() {
+	public function data_single_prime() {
 		return array(
 			array(
 				"word 99' word",
@@ -557,11 +557,11 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 	 * @ticket 22692
 	 * @dataProvider data_contractions
 	 */
-	function test_contractions( $input, $output ) {
+	public function test_contractions( $input, $output ) {
 		return $this->assertSame( $output, wptexturize( $input ) );
 	}
 
-	function data_contractions() {
+	public function data_contractions() {
 		return array(
 			array(
 				"word word's word",
@@ -598,11 +598,11 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 	 * @ticket 22692
 	 * @dataProvider data_opening_quote
 	 */
-	function test_opening_quote( $input, $output ) {
+	public function test_opening_quote( $input, $output ) {
 		return $this->assertSame( $output, wptexturize( $input ) );
 	}
 
-	function data_opening_quote() {
+	public function data_opening_quote() {
 		return array(
 			array(
 				'word "word word',
@@ -675,11 +675,11 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 	 * @ticket 22692
 	 * @dataProvider data_closing_quote
 	 */
-	function test_closing_quote( $input, $output ) {
+	public function test_closing_quote( $input, $output ) {
 		return $this->assertSame( $output, wptexturize( $input ) );
 	}
 
-	function data_closing_quote() {
+	public function data_closing_quote() {
 		return array(
 			array(
 				'word word" word',
@@ -764,11 +764,11 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 	 * @ticket 22692
 	 * @dataProvider data_closing_single_quote
 	 */
-	function test_closing_single_quote( $input, $output ) {
+	public function test_closing_single_quote( $input, $output ) {
 		return $this->assertSame( $output, wptexturize( $input ) );
 	}
 
-	function data_closing_single_quote() {
+	public function data_closing_single_quote() {
 		return array(
 			array(
 				"word word' word",
@@ -854,11 +854,11 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 	 * @ticket 30445
 	 * @dataProvider data_multiplication
 	 */
-	function test_multiplication( $input, $output ) {
+	public function test_multiplication( $input, $output ) {
 		return $this->assertSame( $output, wptexturize( $input ) );
 	}
 
-	function data_multiplication() {
+	public function data_multiplication() {
 		return array(
 			array(
 				'9x9',
@@ -904,11 +904,11 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 	 * @ticket 22692
 	 * @dataProvider data_ampersand
 	 */
-	function test_ampersand( $input, $output ) {
+	public function test_ampersand( $input, $output ) {
 		return $this->assertSame( $output, wptexturize( $input ) );
 	}
 
-	function data_ampersand() {
+	public function data_ampersand() {
 		return array(
 			array(
 				'word & word',
@@ -969,11 +969,11 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 	 * @ticket 22692
 	 * @dataProvider data_cockney
 	 */
-	function test_cockney( $input, $output ) {
+	public function test_cockney( $input, $output ) {
 		return $this->assertSame( $output, wptexturize( $input ) );
 	}
 
-	function data_cockney() {
+	public function data_cockney() {
 		return array(
 			array(
 				"word 'tain't word",
@@ -1030,11 +1030,11 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 	 * @ticket 22692
 	 * @dataProvider data_smart_dashes
 	 */
-	function test_smart_dashes( $input, $output ) {
+	public function test_smart_dashes( $input, $output ) {
 		return $this->assertSame( $output, wptexturize( $input ) );
 	}
 
-	function data_smart_dashes() {
+	public function data_smart_dashes() {
 		return array(
 			array(
 				'word --- word',
@@ -1083,11 +1083,11 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 	 * @ticket 22692
 	 * @dataProvider data_misc_static_replacements
 	 */
-	function test_misc_static_replacements( $input, $output ) {
+	public function test_misc_static_replacements( $input, $output ) {
 		return $this->assertSame( $output, wptexturize( $input ) );
 	}
 
-	function data_misc_static_replacements() {
+	public function data_misc_static_replacements() {
 		return array(
 			array(
 				'word ... word',
@@ -1138,11 +1138,11 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 	 * @ticket 8775
 	 * @dataProvider data_quoted_numbers
 	 */
-	function test_quoted_numbers( $input, $output ) {
+	public function test_quoted_numbers( $input, $output ) {
 		return $this->assertSame( $output, wptexturize( $input ) );
 	}
 
-	function data_quoted_numbers() {
+	public function data_quoted_numbers() {
 		return array(
 			array(
 				'word "42.00" word',
@@ -1189,11 +1189,11 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 	 * @ticket 20342
 	 * @dataProvider data_quotes_and_dashes
 	 */
-	function test_quotes_and_dashes( $input, $output ) {
+	public function test_quotes_and_dashes( $input, $output ) {
 		return $this->assertSame( $output, wptexturize( $input ) );
 	}
 
-	function data_quotes_and_dashes() {
+	public function data_quotes_and_dashes() {
 		return array(
 			array(
 				'word---"quote"',
@@ -1252,11 +1252,11 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 	 * @ticket 12690
 	 * @dataProvider data_tag_avoidance
 	 */
-	function test_tag_avoidance( $input, $output ) {
+	public function test_tag_avoidance( $input, $output ) {
 		return $this->assertSame( $output, wptexturize( $input ) );
 	}
 
-	function data_tag_avoidance() {
+	public function data_tag_avoidance() {
 		return array(
 			array(
 				'[ ... ]',
@@ -1475,11 +1475,11 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 	 * @ticket 26850
 	 * @dataProvider data_year_abbr
 	 */
-	function test_year_abbr( $input, $output ) {
+	public function test_year_abbr( $input, $output ) {
 		return $this->assertSame( $output, wptexturize( $input ) );
 	}
 
-	function data_year_abbr() {
+	public function data_year_abbr() {
 		return array(
 			array(
 				"word '99 word",
@@ -1564,7 +1564,7 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 	 * @ticket 27426
 	 * @dataProvider data_translate
 	 */
-	function test_translate( $input, $output ) {
+	public function test_translate( $input, $output ) {
 		add_filter( 'gettext_with_context', array( $this, 'filter_translate' ), 10, 4 );
 
 		$result = wptexturize( $input, true );
@@ -1575,7 +1575,7 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 		return $this->assertSame( $output, $result );
 	}
 
-	function filter_translate( $translations, $text, $context, $domain ) {
+	public function filter_translate( $translations, $text, $context, $domain ) {
 		switch ( $text ) {
 			case '&#8211;':
 				return '!endash!';
@@ -1604,7 +1604,7 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 		}
 	}
 
-	function data_translate() {
+	public function data_translate() {
 		return array(
 			array(
 				"word '99 word",
@@ -1791,11 +1791,11 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 	 * @ticket 28483
 	 * @dataProvider data_element_stack
 	 */
-	function test_element_stack( $input, $output ) {
+	public function test_element_stack( $input, $output ) {
 		return $this->assertSame( $output, wptexturize( $input ) );
 	}
 
-	function data_element_stack() {
+	public function data_element_stack() {
 		return array(
 			array(
 				'<span>hello</code>---</span>',
@@ -1842,7 +1842,7 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 	 * @ticket 29557
 	 * @dataProvider data_unregistered_shortcodes
 	 */
-	function test_unregistered_shortcodes( $input, $output ) {
+	public function test_unregistered_shortcodes( $input, $output ) {
 		add_filter( 'no_texturize_shortcodes', array( $this, 'filter_shortcodes' ), 10, 1 );
 
 		$output = $this->assertSame( $output, wptexturize( $input ) );
@@ -1851,12 +1851,12 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 		return $output;
 	}
 
-	function filter_shortcodes( $disabled ) {
+	public function filter_shortcodes( $disabled ) {
 		$disabled[] = 'audio';
 		return $disabled;
 	}
 
-	function data_unregistered_shortcodes() {
+	public function data_unregistered_shortcodes() {
 		return array(
 			array(
 				'[a]a--b[audio]---[/audio]a--b[/a]',
@@ -1927,11 +1927,11 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 	 * @ticket 29256
 	 * @dataProvider data_primes_vs_quotes
 	 */
-	function test_primes_vs_quotes( $input, $output ) {
+	public function test_primes_vs_quotes( $input, $output ) {
 		return $this->assertSame( $output, wptexturize( $input ) );
 	}
 
-	function data_primes_vs_quotes() {
+	public function data_primes_vs_quotes() {
 		return array(
 			array(
 				"George's porch is 99' long.",
@@ -1989,7 +1989,7 @@ String with a number followed by a single quote &#8216;Expendables 3&#8217; vest
 	 * @ticket 29256
 	 * @dataProvider data_primes_quotes_translation
 	 */
-	function test_primes_quotes_translation( $input, $output ) {
+	public function test_primes_quotes_translation( $input, $output ) {
 		add_filter( 'gettext_with_context', array( $this, 'filter_translate2' ), 10, 4 );
 
 		$result = wptexturize( $input, true );
@@ -2000,7 +2000,7 @@ String with a number followed by a single quote &#8216;Expendables 3&#8217; vest
 		return $this->assertSame( $output, $result );
 	}
 
-	function filter_translate2( $translations, $text, $context, $domain ) {
+	public function filter_translate2( $translations, $text, $context, $domain ) {
 		switch ( $text ) {
 			case '&#8211;':
 				return '!endash!';
@@ -2027,7 +2027,7 @@ String with a number followed by a single quote &#8216;Expendables 3&#8217; vest
 		}
 	}
 
-	function data_primes_quotes_translation() {
+	public function data_primes_quotes_translation() {
 		return array(
 			array(
 				"George's porch is 99' long.",
@@ -2082,7 +2082,7 @@ String with a number followed by a single quote !q1!Expendables 3!q1! vestibulum
 	 *
 	 * @dataProvider data_whole_posts
 	 */
-	function test_pcre_performance( $input ) {
+	public function test_pcre_performance( $input ) {
 		global $shortcode_tags;
 
 		// With shortcodes disabled.
@@ -2102,11 +2102,11 @@ String with a number followed by a single quote !q1!Expendables 3!q1! vestibulum
 	 *
 	 * @ticket 35864
 	 */
-	function test_trailing_less_than() {
+	public function test_trailing_less_than() {
 		$this->assertSame( 'F&#8211;oo<', wptexturize( 'F--oo<', true ) );
 	}
 
-	function data_whole_posts() {
+	public function data_whole_posts() {
 		require_once DIR_TESTDATA . '/formatting/whole-posts.php';
 		return data_whole_posts();
 	}

--- a/tests/phpunit/tests/formatting/wpTrimWords.php
+++ b/tests/phpunit/tests/formatting/wpTrimWords.php
@@ -14,22 +14,22 @@ class Tests_Formatting_wpTrimWords extends WP_UnitTestCase {
 	 */
 	private $long_text = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce varius lacinia vehicula. Etiam sapien risus, ultricies ac posuere eu, convallis sit amet augue. Pellentesque urna massa, lacinia vel iaculis eget, bibendum in mauris. Aenean eleifend pulvinar ligula, a convallis eros gravida non. Suspendisse potenti. Pellentesque et odio tortor. In vulputate pellentesque libero, sed dapibus velit mollis viverra. Pellentesque id urna euismod dolor cursus sagittis.';
 
-	function test_trims_to_55_by_default() {
+	public function test_trims_to_55_by_default() {
 		$trimmed = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce varius lacinia vehicula. Etiam sapien risus, ultricies ac posuere eu, convallis sit amet augue. Pellentesque urna massa, lacinia vel iaculis eget, bibendum in mauris. Aenean eleifend pulvinar ligula, a convallis eros gravida non. Suspendisse potenti. Pellentesque et odio tortor. In vulputate pellentesque libero, sed dapibus velit&hellip;';
 		$this->assertSame( $trimmed, wp_trim_words( $this->long_text ) );
 	}
 
-	function test_trims_to_10() {
+	public function test_trims_to_10() {
 		$trimmed = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce varius&hellip;';
 		$this->assertSame( $trimmed, wp_trim_words( $this->long_text, 10 ) );
 	}
 
-	function test_trims_to_5_and_uses_custom_more() {
+	public function test_trims_to_5_and_uses_custom_more() {
 		$trimmed = 'Lorem ipsum dolor sit amet,[...] Read on!';
 		$this->assertSame( $trimmed, wp_trim_words( $this->long_text, 5, '[...] Read on!' ) );
 	}
 
-	function test_strips_tags_before_trimming() {
+	public function test_strips_tags_before_trimming() {
 		$text    = 'This text contains a <a href="http://wordpress.org"> link </a> to WordPress.org!';
 		$trimmed = 'This text contains a link&hellip;';
 		$this->assertSame( $trimmed, wp_trim_words( $text, 5 ) );
@@ -38,7 +38,7 @@ class Tests_Formatting_wpTrimWords extends WP_UnitTestCase {
 	/**
 	 * @ticket 18726
 	 */
-	function test_strips_script_and_style_content() {
+	public function test_strips_script_and_style_content() {
 		$trimmed = 'This text contains. It should go.';
 
 		$text = 'This text contains<script>alert(" JavaScript");</script>. It should go.';
@@ -48,7 +48,7 @@ class Tests_Formatting_wpTrimWords extends WP_UnitTestCase {
 		$this->assertSame( $trimmed, wp_trim_words( $text ) );
 	}
 
-	function test_doesnt_trim_short_text() {
+	public function test_doesnt_trim_short_text() {
 		$text = 'This is some short text.';
 		$this->assertSame( $text, wp_trim_words( $text ) );
 	}
@@ -56,7 +56,7 @@ class Tests_Formatting_wpTrimWords extends WP_UnitTestCase {
 	/**
 	 * @ticket 44541
 	 */
-	function test_trims_to_20_counted_by_chars() {
+	public function test_trims_to_20_counted_by_chars() {
 		switch_to_locale( 'ja_JP' );
 		$expected = substr( $this->long_text, 0, 20 ) . '&hellip;';
 		$actual   = wp_trim_words( $this->long_text, 20 );
@@ -67,7 +67,7 @@ class Tests_Formatting_wpTrimWords extends WP_UnitTestCase {
 	/**
 	 * @ticket 44541
 	 */
-	function test_trims_to_20_counted_by_chars_with_double_width_chars() {
+	public function test_trims_to_20_counted_by_chars_with_double_width_chars() {
 		switch_to_locale( 'ja_JP' );
 		$text     = str_repeat( 'あ', 100 );
 		$expected = str_repeat( 'あ', 19 ) . '&hellip;';
@@ -79,7 +79,7 @@ class Tests_Formatting_wpTrimWords extends WP_UnitTestCase {
 	/**
 	 * @ticket 47867
 	 */
-	function test_works_with_non_numeric_num_words() {
+	public function test_works_with_non_numeric_num_words() {
 		$this->assertSame( '', wp_trim_words( $this->long_text, '', '' ) );
 		$this->assertSame( '', wp_trim_words( $this->long_text, 'abc', '' ) );
 		$this->assertSame( '', wp_trim_words( $this->long_text, null, '' ) );

--- a/tests/phpunit/tests/formatting/zeroise.php
+++ b/tests/phpunit/tests/formatting/zeroise.php
@@ -4,11 +4,11 @@
  * @group formatting
  */
 class Tests_Formatting_Zeroise extends WP_UnitTestCase {
-	function test_pads_with_leading_zeroes() {
+	public function test_pads_with_leading_zeroes() {
 		$this->assertSame( '00005', zeroise( 5, 5 ) );
 	}
 
-	function test_does_nothing_if_input_is_already_longer() {
+	public function test_does_nothing_if_input_is_already_longer() {
 		$this->assertSame( '5000000', zeroise( 5000000, 2 ) );
 	}
 }

--- a/tests/phpunit/tests/functions/addMagicQuotes.php
+++ b/tests/phpunit/tests/functions/addMagicQuotes.php
@@ -15,7 +15,7 @@ class Tests_Functions_AddMagicQuotes extends WP_UnitTestCase {
 	 * @param array $test_array Test value.
 	 * @param array $expected   Expected return value.
 	 */
-	function test_add_magic_quotes( $test_array, $expected ) {
+	public function test_add_magic_quotes( $test_array, $expected ) {
 		$this->assertSame( $expected, add_magic_quotes( $test_array ) );
 	}
 

--- a/tests/phpunit/tests/functions/allowedProtocols.php
+++ b/tests/phpunit/tests/functions/allowedProtocols.php
@@ -10,11 +10,11 @@ class Tests_Functions_AllowedProtocols extends WP_UnitTestCase {
 	/**
 	 * @ticket 19354
 	 */
-	function test_data_is_not_an_allowed_protocol() {
+	public function test_data_is_not_an_allowed_protocol() {
 		$this->assertNotContains( 'data', wp_allowed_protocols() );
 	}
 
-	function test_allowed_protocol_has_an_example() {
+	public function test_allowed_protocol_has_an_example() {
 		$example_protocols = array();
 		foreach ( $this->data_example_urls() as $example ) {
 			$example_protocols[] = $example[0];
@@ -29,7 +29,7 @@ class Tests_Functions_AllowedProtocols extends WP_UnitTestCase {
 	 * @param string The scheme.
 	 * @param string Example URL.
 	 */
-	function test_allowed_protocols( $protocol, $url ) {
+	public function test_allowed_protocols( $protocol, $url ) {
 		$this->assertSame( $url, esc_url( $url, $protocol ) );
 		$this->assertSame( $url, esc_url( $url, wp_allowed_protocols() ) );
 	}
@@ -37,7 +37,7 @@ class Tests_Functions_AllowedProtocols extends WP_UnitTestCase {
 	/**
 	 * @link http://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml
 	 */
-	function data_example_urls() {
+	public function data_example_urls() {
 		return array(
 			array( 'http', 'http://example.com' ),                                 // RFC7230
 			array( 'https', 'https://example.com' ),                               // RFC7230

--- a/tests/phpunit/tests/functions/canonicalCharset.php
+++ b/tests/phpunit/tests/functions/canonicalCharset.php
@@ -55,7 +55,7 @@ class Tests_Functions_CanonicalCharset extends WP_UnitTestCase {
 	 *
 	 * @covers ::get_option
 	 */
-	function test_update_option_blog_charset() {
+	public function test_update_option_blog_charset() {
 		$orig_blog_charset = get_option( 'blog_charset' );
 
 		update_option( 'blog_charset', 'utf8' );

--- a/tests/phpunit/tests/functions/pluginBasename.php
+++ b/tests/phpunit/tests/functions/pluginBasename.php
@@ -37,7 +37,7 @@ class Tests_Functions_PluginBasename extends WP_UnitTestCase {
 	/**
 	 * @ticket 29154
 	 */
-	function test_return_correct_basename_for_symlinked_plugins() {
+	public function test_return_correct_basename_for_symlinked_plugins() {
 		global $wp_plugin_paths;
 
 		$wp_plugin_paths = array(
@@ -51,7 +51,7 @@ class Tests_Functions_PluginBasename extends WP_UnitTestCase {
 	/**
 	 * @ticket 28441
 	 */
-	function test_return_correct_basename_for_symlinked_plugins_with_path_conflicts() {
+	public function test_return_correct_basename_for_symlinked_plugins_with_path_conflicts() {
 		global $wp_plugin_paths;
 
 		$wp_plugin_paths = array(

--- a/tests/phpunit/tests/functions/wpAuthCheck.php
+++ b/tests/phpunit/tests/functions/wpAuthCheck.php
@@ -14,7 +14,7 @@ class Tests_Functions_wpAuthCheck extends WP_UnitTestCase {
 	 *
 	 * @ticket 41860
 	 */
-	function test_wp_auth_check_user_not_logged_in() {
+	public function test_wp_auth_check_user_not_logged_in() {
 		$expected = array(
 			'wp-auth-check' => false,
 		);
@@ -28,7 +28,7 @@ class Tests_Functions_wpAuthCheck extends WP_UnitTestCase {
 	 *
 	 * @ticket 41860
 	 */
-	function test_wp_auth_check_user_logged_in() {
+	public function test_wp_auth_check_user_logged_in() {
 		// Log user in.
 		wp_set_current_user( 1 );
 
@@ -45,7 +45,7 @@ class Tests_Functions_wpAuthCheck extends WP_UnitTestCase {
 	 *
 	 * @ticket 41860
 	 */
-	function test_wp_auth_check_user_logged_in_login_grace_period_set() {
+	public function test_wp_auth_check_user_logged_in_login_grace_period_set() {
 		// Log user in.
 		wp_set_current_user( 1 );
 

--- a/tests/phpunit/tests/functions/wpGetArchives.php
+++ b/tests/phpunit/tests/functions/wpGetArchives.php
@@ -9,7 +9,7 @@ class Tests_Functions_wpGetArchives extends WP_UnitTestCase {
 	protected $month_url;
 	protected $year_url;
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		$this->month_url = get_month_link( gmdate( 'Y' ), gmdate( 'm' ) );
@@ -26,12 +26,12 @@ class Tests_Functions_wpGetArchives extends WP_UnitTestCase {
 		);
 	}
 
-	function test_wp_get_archives_default() {
+	public function test_wp_get_archives_default() {
 		$expected['default'] = "<li><a href='" . $this->month_url . "'>" . gmdate( 'F Y' ) . '</a></li>';
 		$this->assertSame( $expected['default'], trim( wp_get_archives( array( 'echo' => false ) ) ) );
 	}
 
-	function test_wp_get_archives_type() {
+	public function test_wp_get_archives_type() {
 		$expected['type'] = "<li><a href='" . $this->year_url . "'>" . gmdate( 'Y' ) . '</a></li>';
 		$this->assertSame(
 			$expected['type'],
@@ -46,7 +46,7 @@ class Tests_Functions_wpGetArchives extends WP_UnitTestCase {
 		);
 	}
 
-	function test_wp_get_archives_limit() {
+	public function test_wp_get_archives_limit() {
 		$ids = array_slice( array_reverse( self::$post_ids ), 0, 5 );
 
 		$link1 = get_permalink( $ids[0] );
@@ -82,7 +82,7 @@ EOF;
 		);
 	}
 
-	function test_wp_get_archives_format() {
+	public function test_wp_get_archives_format() {
 		$expected['format'] = "<option value='" . $this->month_url . "'> " . gmdate( 'F Y' ) . ' </option>';
 		$this->assertSame(
 			$expected['format'],
@@ -97,7 +97,7 @@ EOF;
 		);
 	}
 
-	function test_wp_get_archives_before_and_after() {
+	public function test_wp_get_archives_before_and_after() {
 		$expected['before_and_after'] = "<div><a href='" . $this->month_url . "'>" . gmdate( 'F Y' ) . '</a></div>';
 		$this->assertSame(
 			$expected['before_and_after'],
@@ -114,7 +114,7 @@ EOF;
 		);
 	}
 
-	function test_wp_get_archives_show_post_count() {
+	public function test_wp_get_archives_show_post_count() {
 		$expected['show_post_count'] = "<li><a href='" . $this->month_url . "'>" . gmdate( 'F Y' ) . '</a>&nbsp;(8)</li>';
 		$this->assertSame(
 			$expected['show_post_count'],
@@ -129,13 +129,13 @@ EOF;
 		);
 	}
 
-	function test_wp_get_archives_echo() {
+	public function test_wp_get_archives_echo() {
 		$expected['echo'] = "\t<li><a href='" . $this->month_url . "'>" . gmdate( 'F Y' ) . '</a></li>' . "\n";
 		$this->expectOutputString( $expected['echo'] );
 		wp_get_archives( array( 'echo' => true ) );
 	}
 
-	function test_wp_get_archives_order() {
+	public function test_wp_get_archives_order() {
 		self::factory()->post->create(
 			array(
 				'post_type'   => 'post',
@@ -182,7 +182,7 @@ EOF;
 	/**
 	 * @ticket 21596
 	 */
-	function test_wp_get_archives_post_type() {
+	public function test_wp_get_archives_post_type() {
 		register_post_type( 'taco', array( 'public' => true ) );
 
 		self::factory()->post->create(

--- a/tests/phpunit/tests/functions/wpValidateBoolean.php
+++ b/tests/phpunit/tests/functions/wpValidateBoolean.php
@@ -12,7 +12,7 @@ class Tests_Functions_wpValidateBoolean extends WP_UnitTestCase {
 	 *
 	 * @return array
 	 */
-	function data_provider() {
+	public function data_provider() {
 			$std = new \stdClass();
 
 			return array(

--- a/tests/phpunit/tests/general/paginateLinks.php
+++ b/tests/phpunit/tests/general/paginateLinks.php
@@ -9,13 +9,13 @@ class Tests_General_PaginateLinks extends WP_UnitTestCase {
 
 	private $i18n_count = 0;
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		$this->go_to( home_url( '/' ) );
 	}
 
-	function test_defaults() {
+	public function test_defaults() {
 		$page2  = get_pagenum_link( 2 );
 		$page3  = get_pagenum_link( 3 );
 		$page50 = get_pagenum_link( 50 );
@@ -33,7 +33,7 @@ EXPECTED;
 		$this->assertSameIgnoreEOL( $expected, $links );
 	}
 
-	function test_format() {
+	public function test_format() {
 		$page2  = home_url( '/page/2/' );
 		$page3  = home_url( '/page/3/' );
 		$page50 = home_url( '/page/50/' );
@@ -56,7 +56,7 @@ EXPECTED;
 		$this->assertSameIgnoreEOL( $expected, $links );
 	}
 
-	function test_prev_next_false() {
+	public function test_prev_next_false() {
 		$home   = home_url( '/' );
 		$page3  = get_pagenum_link( 3 );
 		$page4  = get_pagenum_link( 4 );
@@ -81,7 +81,7 @@ EXPECTED;
 		$this->assertSameIgnoreEOL( $expected, $links );
 	}
 
-	function test_prev_next_true() {
+	public function test_prev_next_true() {
 		$home   = home_url( '/' );
 		$page3  = get_pagenum_link( 3 );
 		$page4  = get_pagenum_link( 4 );
@@ -108,14 +108,14 @@ EXPECTED;
 		$this->assertSameIgnoreEOL( $expected, $links );
 	}
 
-	function increment_i18n_count() {
+	public function increment_i18n_count() {
 		$this->i18n_count += 1;
 	}
 
 	/**
 	 * @ticket 25735
 	 */
-	function test_paginate_links_number_format() {
+	public function test_paginate_links_number_format() {
 		$this->i18n_count = 0;
 		add_filter( 'number_format_i18n', array( $this, 'increment_i18n_count' ) );
 		paginate_links(
@@ -137,7 +137,7 @@ EXPECTED;
 	/**
 	 * @ticket 24606
 	 */
-	function test_paginate_links_base_value() {
+	public function test_paginate_links_base_value() {
 
 		// Current page: 2.
 		$links = paginate_links(
@@ -205,7 +205,7 @@ EXPECTED;
 		$this->assertSame( get_pagenum_link( 2 ), $href );
 	}
 
-	function add_query_arg( $url ) {
+	public function add_query_arg( $url ) {
 		return add_query_arg(
 			array(
 				'foo' => 'bar',
@@ -218,7 +218,7 @@ EXPECTED;
 	/**
 	 * @ticket 29636
 	 */
-	function test_paginate_links_query_args() {
+	public function test_paginate_links_query_args() {
 		add_filter( 'get_pagenum_link', array( $this, 'add_query_arg' ) );
 		$links = paginate_links(
 			array(
@@ -256,7 +256,7 @@ EXPECTED;
 	/**
 	 * @ticket 30831
 	 */
-	function test_paginate_links_with_custom_query_args() {
+	public function test_paginate_links_with_custom_query_args() {
 		add_filter( 'get_pagenum_link', array( $this, 'add_query_arg' ) );
 		$links = paginate_links(
 			array(

--- a/tests/phpunit/tests/general/template.php
+++ b/tests/phpunit/tests/general/template.php
@@ -17,13 +17,13 @@ class Tests_General_Template extends WP_UnitTestCase {
 	public $custom_logo_id;
 	public $custom_logo_url;
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		$this->wp_site_icon = new WP_Site_Icon();
 	}
 
-	function tear_down() {
+	public function tear_down() {
 		global $wp_customize;
 		$this->_remove_custom_logo();
 		$this->_remove_site_icon();
@@ -37,7 +37,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 * @covers ::get_site_icon_url
 	 * @requires function imagejpeg
 	 */
-	function test_get_site_icon_url() {
+	public function test_get_site_icon_url() {
 		$this->assertEmpty( get_site_icon_url() );
 
 		$this->_set_site_icon();
@@ -52,7 +52,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 * @covers ::site_icon_url
 	 * @requires function imagejpeg
 	 */
-	function test_site_icon_url() {
+	public function test_site_icon_url() {
 		$this->expectOutputString( '' );
 		site_icon_url();
 
@@ -66,7 +66,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 * @covers ::has_site_icon
 	 * @requires function imagejpeg
 	 */
-	function test_has_site_icon() {
+	public function test_has_site_icon() {
 		$this->assertFalse( has_site_icon() );
 
 		$this->_set_site_icon();
@@ -82,7 +82,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 * @group ms-required
 	 * @covers ::has_site_icon
 	 */
-	function test_has_site_icon_returns_true_when_called_for_other_site_with_site_icon_set() {
+	public function test_has_site_icon_returns_true_when_called_for_other_site_with_site_icon_set() {
 		$blog_id = $this->factory->blog->create();
 		switch_to_blog( $blog_id );
 		$this->_set_site_icon();
@@ -97,7 +97,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 * @group ms-required
 	 * @covers ::has_site_icon
 	 */
-	function test_has_site_icon_returns_false_when_called_for_other_site_without_site_icon_set() {
+	public function test_has_site_icon_returns_false_when_called_for_other_site_without_site_icon_set() {
 		$blog_id = $this->factory->blog->create();
 
 		$this->assertFalse( has_site_icon( $blog_id ) );
@@ -108,7 +108,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 * @covers ::wp_site_icon
 	 * @requires function imagejpeg
 	 */
-	function test_wp_site_icon() {
+	public function test_wp_site_icon() {
 		$this->expectOutputString( '' );
 		wp_site_icon();
 
@@ -131,7 +131,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 * @covers ::wp_site_icon
 	 * @requires function imagejpeg
 	 */
-	function test_wp_site_icon_with_filter() {
+	public function test_wp_site_icon_with_filter() {
 		$this->expectOutputString( '' );
 		wp_site_icon();
 
@@ -157,7 +157,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 * @group site_icon
 	 * @covers ::wp_site_icon
 	 */
-	function test_customize_preview_wp_site_icon_empty() {
+	public function test_customize_preview_wp_site_icon_empty() {
 		global $wp_customize;
 		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
 
@@ -175,7 +175,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 * @group site_icon
 	 * @covers ::wp_site_icon
 	 */
-	function test_customize_preview_wp_site_icon_dirty() {
+	public function test_customize_preview_wp_site_icon_dirty() {
 		global $wp_customize;
 		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
 
@@ -207,7 +207,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 * @param $meta_tags
 	 * @return array
 	 */
-	function _custom_site_icon_meta_tag( $meta_tags ) {
+	public function _custom_site_icon_meta_tag( $meta_tags ) {
 		$meta_tags[] = sprintf( '<link rel="apple-touch-icon" sizes="150x150" href="%s" />', esc_url( get_site_icon_url( 150 ) ) );
 
 		return $meta_tags;
@@ -218,7 +218,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 *
 	 * @since 4.3.0
 	 */
-	function _set_site_icon() {
+	private function _set_site_icon() {
 		if ( ! $this->site_icon_id ) {
 			add_filter( 'intermediate_image_sizes_advanced', array( $this->wp_site_icon, 'additional_sizes' ) );
 			$this->_insert_attachment();
@@ -233,7 +233,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 *
 	 * @since 4.3.0
 	 */
-	function _remove_site_icon() {
+	private function _remove_site_icon() {
 		delete_option( 'site_icon' );
 	}
 
@@ -242,7 +242,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 *
 	 * @since 4.3.0
 	 */
-	function _insert_attachment() {
+	private function _insert_attachment() {
 		$filename = DIR_TESTDATA . '/images/test-image.jpg';
 		$contents = file_get_contents( $filename );
 
@@ -260,7 +260,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 *
 	 * @since 4.5.0
 	 */
-	function test_has_custom_logo() {
+	public function test_has_custom_logo() {
 		$this->assertFalse( has_custom_logo() );
 
 		$this->_set_custom_logo();
@@ -276,7 +276,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 * @group ms-required
 	 * @covers ::has_custom_logo
 	 */
-	function test_has_custom_logo_returns_true_when_called_for_other_site_with_custom_logo_set() {
+	public function test_has_custom_logo_returns_true_when_called_for_other_site_with_custom_logo_set() {
 		$blog_id = $this->factory->blog->create();
 		switch_to_blog( $blog_id );
 		$this->_set_custom_logo();
@@ -291,7 +291,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 * @group ms-required
 	 * @covers ::has_custom_logo
 	 */
-	function test_has_custom_logo_returns_false_when_called_for_other_site_without_custom_logo_set() {
+	public function test_has_custom_logo_returns_false_when_called_for_other_site_without_custom_logo_set() {
 		$blog_id = $this->factory->blog->create();
 
 		$this->assertFalse( has_custom_logo( $blog_id ) );
@@ -303,7 +303,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 *
 	 * @since 4.5.0
 	 */
-	function test_get_custom_logo() {
+	public function test_get_custom_logo() {
 		$this->assertEmpty( get_custom_logo() );
 
 		$this->_set_custom_logo();
@@ -321,7 +321,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 * @group ms-required
 	 * @covers ::get_custom_logo
 	 */
-	function test_get_custom_logo_returns_logo_when_called_for_other_site_with_custom_logo_set() {
+	public function test_get_custom_logo_returns_logo_when_called_for_other_site_with_custom_logo_set() {
 		$blog_id = $this->factory->blog->create();
 		switch_to_blog( $blog_id );
 
@@ -352,7 +352,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 *
 	 * @since 4.5.0
 	 */
-	function test_the_custom_logo() {
+	public function test_the_custom_logo() {
 		$this->expectOutputString( '' );
 		the_custom_logo();
 
@@ -380,7 +380,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 * @group custom_logo
 	 * @covers ::the_custom_logo
 	 */
-	function test_the_custom_logo_with_alt() {
+	public function test_the_custom_logo_with_alt() {
 		$this->_set_custom_logo();
 
 		$image_alt = 'My alt attribute';
@@ -406,7 +406,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 *
 	 * @since 4.5.0
 	 */
-	function _set_custom_logo() {
+	private function _set_custom_logo() {
 		if ( ! $this->custom_logo_id ) {
 			$this->_insert_custom_logo();
 		}
@@ -419,7 +419,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 *
 	 * @since 4.5.0
 	 */
-	function _remove_custom_logo() {
+	private function _remove_custom_logo() {
 		remove_theme_mod( 'custom_logo' );
 	}
 
@@ -428,7 +428,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 *
 	 * @since 4.5.0
 	 */
-	function _insert_custom_logo() {
+	private function _insert_custom_logo() {
 		$filename = DIR_TESTDATA . '/images/test-image.jpg';
 		$contents = file_get_contents( $filename );
 		$upload   = wp_upload_bits( wp_basename( $filename ), null, $contents );
@@ -444,7 +444,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 * @group ms-required
 	 * @covers ::get_site_icon_url
 	 */
-	function test_get_site_icon_url_preserves_switched_state() {
+	public function test_get_site_icon_url_preserves_switched_state() {
 		$blog_id = $this->factory->blog->create();
 		switch_to_blog( $blog_id );
 
@@ -464,7 +464,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 * @group ms-required
 	 * @covers ::has_custom_logo
 	 */
-	function test_has_custom_logo_preserves_switched_state() {
+	public function test_has_custom_logo_preserves_switched_state() {
 		$blog_id = $this->factory->blog->create();
 		switch_to_blog( $blog_id );
 
@@ -484,7 +484,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 * @group ms-required
 	 * @covers ::get_custom_logo
 	 */
-	function test_get_custom_logo_preserves_switched_state() {
+	public function test_get_custom_logo_preserves_switched_state() {
 		$blog_id = $this->factory->blog->create();
 		switch_to_blog( $blog_id );
 
@@ -504,7 +504,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 *
 	 * @covers ::get_header
 	 */
-	function test_get_header_returns_nothing_on_success() {
+	public function test_get_header_returns_nothing_on_success() {
 		$this->expectOutputRegex( '/Header/' );
 
 		// The `get_header()` function must not return anything
@@ -517,7 +517,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 *
 	 * @covers ::get_footer
 	 */
-	function test_get_footer_returns_nothing_on_success() {
+	public function test_get_footer_returns_nothing_on_success() {
 		$this->expectOutputRegex( '/Footer/' );
 
 		// The `get_footer()` function must not return anything
@@ -530,7 +530,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 *
 	 * @covers ::get_sidebar
 	 */
-	function test_get_sidebar_returns_nothing_on_success() {
+	public function test_get_sidebar_returns_nothing_on_success() {
 		$this->expectOutputRegex( '/Sidebar/' );
 
 		// The `get_sidebar()` function must not return anything
@@ -543,7 +543,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 *
 	 * @covers ::get_template_part
 	 */
-	function test_get_template_part_returns_nothing_on_success() {
+	public function test_get_template_part_returns_nothing_on_success() {
 		$this->expectOutputRegex( '/Template Part/' );
 
 		// The `get_template_part()` function must not return anything
@@ -556,7 +556,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 *
 	 * @covers ::get_template_part
 	 */
-	function test_get_template_part_returns_false_on_failure() {
+	public function test_get_template_part_returns_false_on_failure() {
 		$this->assertFalse( get_template_part( 'non-existing-template' ) );
 	}
 
@@ -565,7 +565,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 *
 	 * @covers ::get_template_part
 	 */
-	function test_get_template_part_passes_arguments_to_template() {
+	public function test_get_template_part_passes_arguments_to_template() {
 		$this->expectOutputRegex( '/{"foo":"baz"}/' );
 
 		get_template_part( 'template', 'part', array( 'foo' => 'baz' ) );
@@ -576,7 +576,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 *
 	 * @covers ::get_the_archive_title
 	 */
-	function test_get_the_archive_title_is_correct_for_author_queries() {
+	public function test_get_the_archive_title_is_correct_for_author_queries() {
 		$user_with_posts    = $this->factory()->user->create_and_get(
 			array(
 				'role' => 'author',

--- a/tests/phpunit/tests/general/template.php
+++ b/tests/phpunit/tests/general/template.php
@@ -25,8 +25,8 @@ class Tests_General_Template extends WP_UnitTestCase {
 
 	public function tear_down() {
 		global $wp_customize;
-		$this->_remove_custom_logo();
-		$this->_remove_site_icon();
+		$this->remove_custom_logo();
+		$this->remove_site_icon();
 		$wp_customize = null;
 
 		parent::tear_down();
@@ -40,10 +40,10 @@ class Tests_General_Template extends WP_UnitTestCase {
 	public function test_get_site_icon_url() {
 		$this->assertEmpty( get_site_icon_url() );
 
-		$this->_set_site_icon();
+		$this->set_site_icon();
 		$this->assertSame( $this->site_icon_url, get_site_icon_url() );
 
-		$this->_remove_site_icon();
+		$this->remove_site_icon();
 		$this->assertEmpty( get_site_icon_url() );
 	}
 
@@ -56,7 +56,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 		$this->expectOutputString( '' );
 		site_icon_url();
 
-		$this->_set_site_icon();
+		$this->set_site_icon();
 		$this->expectOutputString( $this->site_icon_url );
 		site_icon_url();
 	}
@@ -69,10 +69,10 @@ class Tests_General_Template extends WP_UnitTestCase {
 	public function test_has_site_icon() {
 		$this->assertFalse( has_site_icon() );
 
-		$this->_set_site_icon();
+		$this->set_site_icon();
 		$this->assertTrue( has_site_icon() );
 
-		$this->_remove_site_icon();
+		$this->remove_site_icon();
 		$this->assertFalse( has_site_icon() );
 	}
 
@@ -85,7 +85,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	public function test_has_site_icon_returns_true_when_called_for_other_site_with_site_icon_set() {
 		$blog_id = $this->factory->blog->create();
 		switch_to_blog( $blog_id );
-		$this->_set_site_icon();
+		$this->set_site_icon();
 		restore_current_blog();
 
 		$this->assertTrue( has_site_icon( $blog_id ) );
@@ -112,7 +112,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 		$this->expectOutputString( '' );
 		wp_site_icon();
 
-		$this->_set_site_icon();
+		$this->set_site_icon();
 		$output = array(
 			sprintf( '<link rel="icon" href="%s" sizes="32x32" />', esc_url( get_site_icon_url( 32 ) ) ),
 			sprintf( '<link rel="icon" href="%s" sizes="192x192" />', esc_url( get_site_icon_url( 192 ) ) ),
@@ -135,7 +135,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 		$this->expectOutputString( '' );
 		wp_site_icon();
 
-		$this->_set_site_icon();
+		$this->set_site_icon();
 		$output = array(
 			sprintf( '<link rel="icon" href="%s" sizes="32x32" />', esc_url( get_site_icon_url( 32 ) ) ),
 			sprintf( '<link rel="icon" href="%s" sizes="192x192" />', esc_url( get_site_icon_url( 192 ) ) ),
@@ -147,9 +147,9 @@ class Tests_General_Template extends WP_UnitTestCase {
 		$output = implode( "\n", $output );
 
 		$this->expectOutputString( $output );
-		add_filter( 'site_icon_meta_tags', array( $this, '_custom_site_icon_meta_tag' ) );
+		add_filter( 'site_icon_meta_tags', array( $this, 'custom_site_icon_meta_tag' ) );
 		wp_site_icon();
-		remove_filter( 'site_icon_meta_tags', array( $this, '_custom_site_icon_meta_tag' ) );
+		remove_filter( 'site_icon_meta_tags', array( $this, 'custom_site_icon_meta_tag' ) );
 	}
 
 	/**
@@ -184,7 +184,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 		$wp_customize->register_controls();
 		$wp_customize->start_previewing_theme();
 
-		$attachment_id = $this->_insert_attachment();
+		$attachment_id = $this->insert_attachment();
 		$wp_customize->set_post_value( 'site_icon', $attachment_id );
 		$wp_customize->get_setting( 'site_icon' )->preview();
 		$output = array(
@@ -207,7 +207,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 * @param $meta_tags
 	 * @return array
 	 */
-	public function _custom_site_icon_meta_tag( $meta_tags ) {
+	public function custom_site_icon_meta_tag( $meta_tags ) {
 		$meta_tags[] = sprintf( '<link rel="apple-touch-icon" sizes="150x150" href="%s" />', esc_url( get_site_icon_url( 150 ) ) );
 
 		return $meta_tags;
@@ -218,10 +218,10 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 *
 	 * @since 4.3.0
 	 */
-	private function _set_site_icon() {
+	private function set_site_icon() {
 		if ( ! $this->site_icon_id ) {
 			add_filter( 'intermediate_image_sizes_advanced', array( $this->wp_site_icon, 'additional_sizes' ) );
-			$this->_insert_attachment();
+			$this->insert_attachment();
 			remove_filter( 'intermediate_image_sizes_advanced', array( $this->wp_site_icon, 'additional_sizes' ) );
 		}
 
@@ -233,7 +233,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 *
 	 * @since 4.3.0
 	 */
-	private function _remove_site_icon() {
+	private function remove_site_icon() {
 		delete_option( 'site_icon' );
 	}
 
@@ -242,7 +242,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 *
 	 * @since 4.3.0
 	 */
-	private function _insert_attachment() {
+	private function insert_attachment() {
 		$filename = DIR_TESTDATA . '/images/test-image.jpg';
 		$contents = file_get_contents( $filename );
 
@@ -263,10 +263,10 @@ class Tests_General_Template extends WP_UnitTestCase {
 	public function test_has_custom_logo() {
 		$this->assertFalse( has_custom_logo() );
 
-		$this->_set_custom_logo();
+		$this->set_custom_logo();
 		$this->assertTrue( has_custom_logo() );
 
-		$this->_remove_custom_logo();
+		$this->remove_custom_logo();
 		$this->assertFalse( has_custom_logo() );
 	}
 
@@ -279,7 +279,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	public function test_has_custom_logo_returns_true_when_called_for_other_site_with_custom_logo_set() {
 		$blog_id = $this->factory->blog->create();
 		switch_to_blog( $blog_id );
-		$this->_set_custom_logo();
+		$this->set_custom_logo();
 		restore_current_blog();
 
 		$this->assertTrue( has_custom_logo( $blog_id ) );
@@ -306,12 +306,12 @@ class Tests_General_Template extends WP_UnitTestCase {
 	public function test_get_custom_logo() {
 		$this->assertEmpty( get_custom_logo() );
 
-		$this->_set_custom_logo();
+		$this->set_custom_logo();
 		$custom_logo = get_custom_logo();
 		$this->assertNotEmpty( $custom_logo );
 		$this->assertIsString( $custom_logo );
 
-		$this->_remove_custom_logo();
+		$this->remove_custom_logo();
 		$this->assertEmpty( get_custom_logo() );
 	}
 
@@ -325,7 +325,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 		$blog_id = $this->factory->blog->create();
 		switch_to_blog( $blog_id );
 
-		$this->_set_custom_logo();
+		$this->set_custom_logo();
 
 		$custom_logo_attr = array(
 			'class'   => 'custom-logo',
@@ -356,7 +356,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 		$this->expectOutputString( '' );
 		the_custom_logo();
 
-		$this->_set_custom_logo();
+		$this->set_custom_logo();
 
 		$custom_logo_attr = array(
 			'class'   => 'custom-logo',
@@ -381,7 +381,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 * @covers ::the_custom_logo
 	 */
 	public function test_the_custom_logo_with_alt() {
-		$this->_set_custom_logo();
+		$this->set_custom_logo();
 
 		$image_alt = 'My alt attribute';
 
@@ -406,9 +406,9 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 *
 	 * @since 4.5.0
 	 */
-	private function _set_custom_logo() {
+	private function set_custom_logo() {
 		if ( ! $this->custom_logo_id ) {
-			$this->_insert_custom_logo();
+			$this->insert_custom_logo();
 		}
 
 		set_theme_mod( 'custom_logo', $this->custom_logo_id );
@@ -419,7 +419,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 *
 	 * @since 4.5.0
 	 */
-	private function _remove_custom_logo() {
+	private function remove_custom_logo() {
 		remove_theme_mod( 'custom_logo' );
 	}
 
@@ -428,7 +428,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 *
 	 * @since 4.5.0
 	 */
-	private function _insert_custom_logo() {
+	private function insert_custom_logo() {
 		$filename = DIR_TESTDATA . '/images/test-image.jpg';
 		$contents = file_get_contents( $filename );
 		$upload   = wp_upload_bits( wp_basename( $filename ), null, $contents );

--- a/tests/phpunit/tests/general/wpGetArchives.php
+++ b/tests/phpunit/tests/general/wpGetArchives.php
@@ -6,7 +6,7 @@
  * @covers ::wp_get_archives
  */
 class Tests_General_wpGetArchives extends WP_UnitTestCase {
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		wp_cache_delete( 'last_changed', 'posts' );
@@ -15,7 +15,7 @@ class Tests_General_wpGetArchives extends WP_UnitTestCase {
 	/**
 	 * @ticket 23206
 	 */
-	function test_get_archives_cache() {
+	public function test_get_archives_cache() {
 		global $wpdb;
 
 		self::factory()->post->create_many( 3, array( 'post_type' => 'post' ) );

--- a/tests/phpunit/tests/general/wpGetDocumentTitle.php
+++ b/tests/phpunit/tests/general/wpGetDocumentTitle.php
@@ -46,14 +46,14 @@ class Tests_General_wpGetDocumentTitle extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		add_action( 'after_setup_theme', array( $this, '_add_title_tag_support' ) );
+		add_action( 'after_setup_theme', array( $this, 'add_title_tag_support' ) );
 
 		$this->blog_name = get_option( 'blogname' );
 
 		setup_postdata( get_post( self::$post_id ) );
 	}
 
-	public function _add_title_tag_support() {
+	public function add_title_tag_support() {
 		add_theme_support( 'title-tag' );
 	}
 
@@ -76,12 +76,12 @@ class Tests_General_wpGetDocumentTitle extends WP_UnitTestCase {
 	public function test_short_circuiting_title() {
 		$this->go_to( '/' );
 
-		add_filter( 'pre_get_document_title', array( $this, '_short_circuit_title' ) );
+		add_filter( 'pre_get_document_title', array( $this, 'short_circuit_title' ) );
 
 		$this->assertSame( 'A Wild Title', wp_get_document_title() );
 	}
 
-	public function _short_circuit_title( $title ) {
+	public function short_circuit_title( $title ) {
 		return 'A Wild Title';
 	}
 
@@ -96,7 +96,7 @@ class Tests_General_wpGetDocumentTitle extends WP_UnitTestCase {
 				)
 			)
 		);
-		add_filter( 'document_title_parts', array( $this, '_front_page_title_parts' ) );
+		add_filter( 'document_title_parts', array( $this, 'front_page_title_parts' ) );
 
 		$this->go_to( '/' );
 		$this->assertSame( sprintf( '%s &#8211; Just another WordPress site', $this->blog_name ), wp_get_document_title() );
@@ -107,7 +107,7 @@ class Tests_General_wpGetDocumentTitle extends WP_UnitTestCase {
 		$this->assertSame( sprintf( '%s &#8211; Just another WordPress site', $this->blog_name ), wp_get_document_title() );
 	}
 
-	public function _front_page_title_parts( $parts ) {
+	public function front_page_title_parts( $parts ) {
 		$this->assertArrayHasKey( 'title', $parts );
 		$this->assertArrayHasKey( 'tagline', $parts );
 		$this->assertArrayNotHasKey( 'site', $parts );
@@ -133,12 +133,12 @@ class Tests_General_wpGetDocumentTitle extends WP_UnitTestCase {
 	public function test_paged_title() {
 		$this->go_to( '?page=4' );
 
-		add_filter( 'document_title_parts', array( $this, '_paged_title_parts' ) );
+		add_filter( 'document_title_parts', array( $this, 'paged_title_parts' ) );
 
 		$this->assertSame( sprintf( '%s &#8211; Page 4 &#8211; Just another WordPress site', $this->blog_name ), wp_get_document_title() );
 	}
 
-	public function _paged_title_parts( $parts ) {
+	public function paged_title_parts( $parts ) {
 		$this->assertArrayHasKey( 'page', $parts );
 		$this->assertArrayHasKey( 'title', $parts );
 		$this->assertArrayHasKey( 'tagline', $parts );
@@ -150,12 +150,12 @@ class Tests_General_wpGetDocumentTitle extends WP_UnitTestCase {
 	public function test_singular_title() {
 		$this->go_to( '?p=' . self::$post_id );
 
-		add_filter( 'document_title_parts', array( $this, '_singular_title_parts' ) );
+		add_filter( 'document_title_parts', array( $this, 'singular_title_parts' ) );
 
 		$this->assertSame( sprintf( 'test_title &#8211; %s', $this->blog_name ), wp_get_document_title() );
 	}
 
-	public function _singular_title_parts( $parts ) {
+	public function singular_title_parts( $parts ) {
 		$this->assertArrayHasKey( 'site', $parts );
 		$this->assertArrayHasKey( 'title', $parts );
 		$this->assertArrayNotHasKey( 'tagline', $parts );
@@ -231,12 +231,12 @@ class Tests_General_wpGetDocumentTitle extends WP_UnitTestCase {
 	public function test_paged_post_title() {
 		$this->go_to( '?paged=4&p=' . self::$post_id );
 
-		add_filter( 'title_tag_parts', array( $this, '_paged_post_title_parts' ) );
+		add_filter( 'title_tag_parts', array( $this, 'paged_post_title_parts' ) );
 
 		$this->assertSame( sprintf( 'test_title &#8211; Page 4 &#8211; %s', $this->blog_name ), wp_get_document_title() );
 	}
 
-	public function _paged_post_title_parts( $parts ) {
+	public function paged_post_title_parts( $parts ) {
 		$this->assertArrayHasKey( 'page', $parts );
 		$this->assertArrayHasKey( 'site', $parts );
 		$this->assertArrayHasKey( 'title', $parts );
@@ -248,12 +248,12 @@ class Tests_General_wpGetDocumentTitle extends WP_UnitTestCase {
 	public function test_rearrange_title_parts() {
 		$this->go_to( '?p=' . self::$post_id );
 
-		add_filter( 'document_title_parts', array( $this, '_rearrange_title_parts' ) );
+		add_filter( 'document_title_parts', array( $this, 'rearrange_title_parts' ) );
 
 		$this->assertSame( sprintf( '%s &#8211; test_title', $this->blog_name ), wp_get_document_title() );
 	}
 
-	public function _rearrange_title_parts( $parts ) {
+	public function rearrange_title_parts( $parts ) {
 		$parts = array(
 			$parts['site'],
 			$parts['title'],
@@ -265,12 +265,12 @@ class Tests_General_wpGetDocumentTitle extends WP_UnitTestCase {
 	public function test_change_title_separator() {
 		$this->go_to( '?p=' . self::$post_id );
 
-		add_filter( 'document_title_separator', array( $this, '_change_title_separator' ) );
+		add_filter( 'document_title_separator', array( $this, 'change_title_separator' ) );
 
 		$this->assertSame( sprintf( 'test_title %%%% %s', $this->blog_name ), wp_get_document_title() );
 	}
 
-	public function _change_title_separator( $sep ) {
+	public function change_title_separator( $sep ) {
 		return '%%';
 	}
 }

--- a/tests/phpunit/tests/general/wpGetDocumentTitle.php
+++ b/tests/phpunit/tests/general/wpGetDocumentTitle.php
@@ -43,7 +43,7 @@ class Tests_General_wpGetDocumentTitle extends WP_UnitTestCase {
 		);
 	}
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		add_action( 'after_setup_theme', array( $this, '_add_title_tag_support' ) );
@@ -53,18 +53,18 @@ class Tests_General_wpGetDocumentTitle extends WP_UnitTestCase {
 		setup_postdata( get_post( self::$post_id ) );
 	}
 
-	function _add_title_tag_support() {
+	public function _add_title_tag_support() {
 		add_theme_support( 'title-tag' );
 	}
 
-	function test__wp_render_title_tag() {
+	public function test__wp_render_title_tag() {
 		$this->go_to( '/' );
 
 		$this->expectOutputString( sprintf( "<title>%s &#8211; %s</title>\n", $this->blog_name, get_option( 'blogdescription' ) ) );
 		_wp_render_title_tag();
 	}
 
-	function test__wp_render_title_no_theme_support() {
+	public function test__wp_render_title_no_theme_support() {
 		$this->go_to( '/' );
 
 		remove_theme_support( 'title-tag' );
@@ -73,7 +73,7 @@ class Tests_General_wpGetDocumentTitle extends WP_UnitTestCase {
 		_wp_render_title_tag();
 	}
 
-	function test_short_circuiting_title() {
+	public function test_short_circuiting_title() {
 		$this->go_to( '/' );
 
 		add_filter( 'pre_get_document_title', array( $this, '_short_circuit_title' ) );
@@ -81,11 +81,11 @@ class Tests_General_wpGetDocumentTitle extends WP_UnitTestCase {
 		$this->assertSame( 'A Wild Title', wp_get_document_title() );
 	}
 
-	function _short_circuit_title( $title ) {
+	public function _short_circuit_title( $title ) {
 		return 'A Wild Title';
 	}
 
-	function test_front_page_title() {
+	public function test_front_page_title() {
 		update_option( 'show_on_front', 'page' );
 		update_option(
 			'page_on_front',
@@ -107,7 +107,7 @@ class Tests_General_wpGetDocumentTitle extends WP_UnitTestCase {
 		$this->assertSame( sprintf( '%s &#8211; Just another WordPress site', $this->blog_name ), wp_get_document_title() );
 	}
 
-	function _front_page_title_parts( $parts ) {
+	public function _front_page_title_parts( $parts ) {
 		$this->assertArrayHasKey( 'title', $parts );
 		$this->assertArrayHasKey( 'tagline', $parts );
 		$this->assertArrayNotHasKey( 'site', $parts );
@@ -115,7 +115,7 @@ class Tests_General_wpGetDocumentTitle extends WP_UnitTestCase {
 		return $parts;
 	}
 
-	function test_home_title() {
+	public function test_home_title() {
 		$blog_page_id = $this->factory->post->create(
 			array(
 				'post_title' => 'blog-page',
@@ -130,7 +130,7 @@ class Tests_General_wpGetDocumentTitle extends WP_UnitTestCase {
 		$this->assertSame( sprintf( 'blog-page &#8211; %s', $this->blog_name ), wp_get_document_title() );
 	}
 
-	function test_paged_title() {
+	public function test_paged_title() {
 		$this->go_to( '?page=4' );
 
 		add_filter( 'document_title_parts', array( $this, '_paged_title_parts' ) );
@@ -138,7 +138,7 @@ class Tests_General_wpGetDocumentTitle extends WP_UnitTestCase {
 		$this->assertSame( sprintf( '%s &#8211; Page 4 &#8211; Just another WordPress site', $this->blog_name ), wp_get_document_title() );
 	}
 
-	function _paged_title_parts( $parts ) {
+	public function _paged_title_parts( $parts ) {
 		$this->assertArrayHasKey( 'page', $parts );
 		$this->assertArrayHasKey( 'title', $parts );
 		$this->assertArrayHasKey( 'tagline', $parts );
@@ -147,7 +147,7 @@ class Tests_General_wpGetDocumentTitle extends WP_UnitTestCase {
 		return $parts;
 	}
 
-	function test_singular_title() {
+	public function test_singular_title() {
 		$this->go_to( '?p=' . self::$post_id );
 
 		add_filter( 'document_title_parts', array( $this, '_singular_title_parts' ) );
@@ -155,7 +155,7 @@ class Tests_General_wpGetDocumentTitle extends WP_UnitTestCase {
 		$this->assertSame( sprintf( 'test_title &#8211; %s', $this->blog_name ), wp_get_document_title() );
 	}
 
-	function _singular_title_parts( $parts ) {
+	public function _singular_title_parts( $parts ) {
 		$this->assertArrayHasKey( 'site', $parts );
 		$this->assertArrayHasKey( 'title', $parts );
 		$this->assertArrayNotHasKey( 'tagline', $parts );
@@ -163,25 +163,25 @@ class Tests_General_wpGetDocumentTitle extends WP_UnitTestCase {
 		return $parts;
 	}
 
-	function test_category_title() {
+	public function test_category_title() {
 		$this->go_to( '?cat=' . self::$category_id );
 
 		$this->assertSame( sprintf( 'test_category &#8211; %s', $this->blog_name ), wp_get_document_title() );
 	}
 
-	function test_search_title() {
+	public function test_search_title() {
 		$this->go_to( '?s=test_title' );
 
 		$this->assertSame( sprintf( 'Search Results for &#8220;test_title&#8221; &#8211; %s', $this->blog_name ), wp_get_document_title() );
 	}
 
-	function test_author_title() {
+	public function test_author_title() {
 		$this->go_to( '?author=' . self::$author_id );
 
 		$this->assertSame( sprintf( 'test_author &#8211; %s', $this->blog_name ), wp_get_document_title() );
 	}
 
-	function test_post_type_archive_title() {
+	public function test_post_type_archive_title() {
 		register_post_type(
 			'cpt',
 			array(
@@ -204,31 +204,31 @@ class Tests_General_wpGetDocumentTitle extends WP_UnitTestCase {
 		$this->assertSame( sprintf( 'test_cpt &#8211; %s', $this->blog_name ), wp_get_document_title() );
 	}
 
-	function test_year_title() {
+	public function test_year_title() {
 		$this->go_to( '?year=2015' );
 
 		$this->assertSame( sprintf( '2015 &#8211; %s', $this->blog_name ), wp_get_document_title() );
 	}
 
-	function test_month_title() {
+	public function test_month_title() {
 		$this->go_to( '?monthnum=09' );
 
 		$this->assertSame( sprintf( 'September 2015 &#8211; %s', $this->blog_name ), wp_get_document_title() );
 	}
 
-	function test_day_title() {
+	public function test_day_title() {
 		$this->go_to( '?day=22' );
 
 		$this->assertSame( sprintf( 'September 22, 2015 &#8211; %s', $this->blog_name ), wp_get_document_title() );
 	}
 
-	function test_404_title() {
+	public function test_404_title() {
 		$this->go_to( '?m=404' );
 
 		$this->assertSame( sprintf( 'Page not found &#8211; %s', $this->blog_name ), wp_get_document_title() );
 	}
 
-	function test_paged_post_title() {
+	public function test_paged_post_title() {
 		$this->go_to( '?paged=4&p=' . self::$post_id );
 
 		add_filter( 'title_tag_parts', array( $this, '_paged_post_title_parts' ) );
@@ -236,7 +236,7 @@ class Tests_General_wpGetDocumentTitle extends WP_UnitTestCase {
 		$this->assertSame( sprintf( 'test_title &#8211; Page 4 &#8211; %s', $this->blog_name ), wp_get_document_title() );
 	}
 
-	function _paged_post_title_parts( $parts ) {
+	public function _paged_post_title_parts( $parts ) {
 		$this->assertArrayHasKey( 'page', $parts );
 		$this->assertArrayHasKey( 'site', $parts );
 		$this->assertArrayHasKey( 'title', $parts );
@@ -245,7 +245,7 @@ class Tests_General_wpGetDocumentTitle extends WP_UnitTestCase {
 		return $parts;
 	}
 
-	function test_rearrange_title_parts() {
+	public function test_rearrange_title_parts() {
 		$this->go_to( '?p=' . self::$post_id );
 
 		add_filter( 'document_title_parts', array( $this, '_rearrange_title_parts' ) );
@@ -253,7 +253,7 @@ class Tests_General_wpGetDocumentTitle extends WP_UnitTestCase {
 		$this->assertSame( sprintf( '%s &#8211; test_title', $this->blog_name ), wp_get_document_title() );
 	}
 
-	function _rearrange_title_parts( $parts ) {
+	public function _rearrange_title_parts( $parts ) {
 		$parts = array(
 			$parts['site'],
 			$parts['title'],
@@ -262,7 +262,7 @@ class Tests_General_wpGetDocumentTitle extends WP_UnitTestCase {
 		return $parts;
 	}
 
-	function test_change_title_separator() {
+	public function test_change_title_separator() {
 		$this->go_to( '?p=' . self::$post_id );
 
 		add_filter( 'document_title_separator', array( $this, '_change_title_separator' ) );
@@ -270,7 +270,7 @@ class Tests_General_wpGetDocumentTitle extends WP_UnitTestCase {
 		$this->assertSame( sprintf( 'test_title %%%% %s', $this->blog_name ), wp_get_document_title() );
 	}
 
-	function _change_title_separator( $sep ) {
+	public function _change_title_separator( $sep ) {
 		return '%%';
 	}
 }

--- a/tests/phpunit/tests/general/wpResourceHints.php
+++ b/tests/phpunit/tests/general/wpResourceHints.php
@@ -44,16 +44,16 @@ class Tests_General_wpResourceHints extends WP_UnitTestCase {
 					"<link rel='dns-prefetch' href='//google.com' />\n" .
 					"<link rel='dns-prefetch' href='//make.wordpress.org' />\n";
 
-		add_filter( 'wp_resource_hints', array( $this, '_add_dns_prefetch_domains' ), 10, 2 );
+		add_filter( 'wp_resource_hints', array( $this, 'add_dns_prefetch_domains' ), 10, 2 );
 
 		$actual = get_echo( 'wp_resource_hints' );
 
-		remove_filter( 'wp_resource_hints', array( $this, '_add_dns_prefetch_domains' ) );
+		remove_filter( 'wp_resource_hints', array( $this, 'add_dns_prefetch_domains' ) );
 
 		$this->assertSame( $expected, $actual );
 	}
 
-	public function _add_dns_prefetch_domains( $hints, $method ) {
+	public function add_dns_prefetch_domains( $hints, $method ) {
 		if ( 'dns-prefetch' === $method ) {
 			$hints[] = 'http://wordpress.org';
 			$hints[] = 'https://wordpress.org';
@@ -76,16 +76,16 @@ class Tests_General_wpResourceHints extends WP_UnitTestCase {
 					"<link rel='preconnect' href='http://google.com' />\n" .
 					"<link rel='preconnect' href='http://w.org' />\n";
 
-		add_filter( 'wp_resource_hints', array( $this, '_add_preconnect_domains' ), 10, 2 );
+		add_filter( 'wp_resource_hints', array( $this, 'add_preconnect_domains' ), 10, 2 );
 
 		$actual = get_echo( 'wp_resource_hints' );
 
-		remove_filter( 'wp_resource_hints', array( $this, '_add_preconnect_domains' ) );
+		remove_filter( 'wp_resource_hints', array( $this, 'add_preconnect_domains' ) );
 
 		$this->assertSame( $expected, $actual );
 	}
 
-	public function _add_preconnect_domains( $hints, $method ) {
+	public function add_preconnect_domains( $hints, $method ) {
 		if ( 'preconnect' === $method ) {
 			$hints[] = '//wordpress.org';
 			$hints[] = 'https://make.wordpress.org';
@@ -103,16 +103,16 @@ class Tests_General_wpResourceHints extends WP_UnitTestCase {
 					"<link rel='prerender' href='http://jobs.wordpress.net' />\n" .
 					"<link rel='prerender' href='//core.trac.wordpress.org' />\n";
 
-		add_filter( 'wp_resource_hints', array( $this, '_add_prerender_urls' ), 10, 2 );
+		add_filter( 'wp_resource_hints', array( $this, 'add_prerender_urls' ), 10, 2 );
 
 		$actual = get_echo( 'wp_resource_hints' );
 
-		remove_filter( 'wp_resource_hints', array( $this, '_add_prerender_urls' ) );
+		remove_filter( 'wp_resource_hints', array( $this, 'add_prerender_urls' ) );
 
 		$this->assertSame( $expected, $actual );
 	}
 
-	public function _add_prerender_urls( $hints, $method ) {
+	public function add_prerender_urls( $hints, $method ) {
 		if ( 'prerender' === $method ) {
 			$hints[] = 'https://make.wordpress.org/great-again';
 			$hints[] = 'http://jobs.wordpress.net';
@@ -127,16 +127,16 @@ class Tests_General_wpResourceHints extends WP_UnitTestCase {
 		$expected = "<link rel='dns-prefetch' href='//s.w.org' />\n" .
 					"<link rel='dns-prefetch' href='//make.wordpress.org' />\n";
 
-		add_filter( 'wp_resource_hints', array( $this, '_add_dns_prefetch_long_urls' ), 10, 2 );
+		add_filter( 'wp_resource_hints', array( $this, 'add_dns_prefetch_long_urls' ), 10, 2 );
 
 		$actual = get_echo( 'wp_resource_hints' );
 
-		remove_filter( 'wp_resource_hints', array( $this, '_add_dns_prefetch_long_urls' ) );
+		remove_filter( 'wp_resource_hints', array( $this, 'add_dns_prefetch_long_urls' ) );
 
 		$this->assertSame( $expected, $actual );
 	}
 
-	public function _add_dns_prefetch_long_urls( $hints, $method ) {
+	public function add_dns_prefetch_long_urls( $hints, $method ) {
 		if ( 'dns-prefetch' === $method ) {
 			$hints[] = 'http://make.wordpress.org/wp-includes/css/editor.css';
 		}
@@ -218,19 +218,19 @@ class Tests_General_wpResourceHints extends WP_UnitTestCase {
 		$expected = "<link rel='dns-prefetch' href='//s.w.org' />\n";
 
 		// Errant colon.
-		add_filter( 'wp_resource_hints', array( $this, '_add_malformed_url_errant_colon' ), 10, 2 );
+		add_filter( 'wp_resource_hints', array( $this, 'add_malformed_url_errant_colon' ), 10, 2 );
 		$actual = get_echo( 'wp_resource_hints' );
-		remove_filter( 'wp_resource_hints', array( $this, '_add_malformed_url_errant_colon' ) );
+		remove_filter( 'wp_resource_hints', array( $this, 'add_malformed_url_errant_colon' ) );
 		$this->assertSame( $expected, $actual );
 
 		// Unsupported Scheme.
-		add_filter( 'wp_resource_hints', array( $this, '_add_malformed_url_unsupported_scheme' ), 10, 2 );
+		add_filter( 'wp_resource_hints', array( $this, 'add_malformed_url_unsupported_scheme' ), 10, 2 );
 		$actual = get_echo( 'wp_resource_hints' );
-		remove_filter( 'wp_resource_hints', array( $this, '_add_malformed_url_unsupported_scheme' ) );
+		remove_filter( 'wp_resource_hints', array( $this, 'add_malformed_url_unsupported_scheme' ) );
 		$this->assertSame( $expected, $actual );
 	}
 
-	public function _add_malformed_url_errant_colon( $hints, $method ) {
+	public function add_malformed_url_errant_colon( $hints, $method ) {
 		if ( 'preconnect' === $method ) {
 			$hints[] = '://core.trac.wordpress.org/ticket/37652';
 		}
@@ -238,7 +238,7 @@ class Tests_General_wpResourceHints extends WP_UnitTestCase {
 		return $hints;
 	}
 
-	public function _add_malformed_url_unsupported_scheme( $hints, $method ) {
+	public function add_malformed_url_unsupported_scheme( $hints, $method ) {
 		if ( 'preconnect' === $method ) {
 			$hints[] = 'git://develop.git.wordpress.org/';
 		}
@@ -256,16 +256,16 @@ class Tests_General_wpResourceHints extends WP_UnitTestCase {
 					"<link crossorigin='use-credentials' as='style' href='https://example.com/foo.css' rel='prefetch' />\n" .
 					"<link href='http://wordpress.org' rel='prerender' />\n";
 
-		add_filter( 'wp_resource_hints', array( $this, '_add_url_with_attributes' ), 10, 2 );
+		add_filter( 'wp_resource_hints', array( $this, 'add_url_with_attributes' ), 10, 2 );
 
 		$actual = get_echo( 'wp_resource_hints' );
 
-		remove_filter( 'wp_resource_hints', array( $this, '_add_url_with_attributes' ) );
+		remove_filter( 'wp_resource_hints', array( $this, 'add_url_with_attributes' ) );
 
 		$this->assertSame( $expected, $actual );
 	}
 
-	public function _add_url_with_attributes( $hints, $method ) {
+	public function add_url_with_attributes( $hints, $method ) {
 		// Ignore hints with missing href attributes.
 		$hints[] = array(
 			'rel' => 'foo',

--- a/tests/phpunit/tests/general/wpResourceHints.php
+++ b/tests/phpunit/tests/general/wpResourceHints.php
@@ -10,7 +10,7 @@ class Tests_General_wpResourceHints extends WP_UnitTestCase {
 	private $old_wp_scripts;
 	private $old_wp_styles;
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 		$this->old_wp_scripts = isset( $GLOBALS['wp_scripts'] ) ? $GLOBALS['wp_scripts'] : null;
 		$this->old_wp_styles  = isset( $GLOBALS['wp_styles'] ) ? $GLOBALS['wp_styles'] : null;
@@ -24,13 +24,13 @@ class Tests_General_wpResourceHints extends WP_UnitTestCase {
 		$GLOBALS['wp_styles']->default_version  = get_bloginfo( 'version' );
 	}
 
-	function tear_down() {
+	public function tear_down() {
 		$GLOBALS['wp_scripts'] = $this->old_wp_scripts;
 		$GLOBALS['wp_styles']  = $this->old_wp_styles;
 		parent::tear_down();
 	}
 
-	function test_should_have_defaults_on_frontend() {
+	public function test_should_have_defaults_on_frontend() {
 		$expected = "<link rel='dns-prefetch' href='//s.w.org' />\n";
 
 		$this->expectOutputString( $expected );
@@ -38,7 +38,7 @@ class Tests_General_wpResourceHints extends WP_UnitTestCase {
 		wp_resource_hints();
 	}
 
-	function test_dns_prefetching() {
+	public function test_dns_prefetching() {
 		$expected = "<link rel='dns-prefetch' href='//s.w.org' />\n" .
 					"<link rel='dns-prefetch' href='//wordpress.org' />\n" .
 					"<link rel='dns-prefetch' href='//google.com' />\n" .
@@ -53,7 +53,7 @@ class Tests_General_wpResourceHints extends WP_UnitTestCase {
 		$this->assertSame( $expected, $actual );
 	}
 
-	function _add_dns_prefetch_domains( $hints, $method ) {
+	public function _add_dns_prefetch_domains( $hints, $method ) {
 		if ( 'dns-prefetch' === $method ) {
 			$hints[] = 'http://wordpress.org';
 			$hints[] = 'https://wordpress.org';
@@ -69,7 +69,7 @@ class Tests_General_wpResourceHints extends WP_UnitTestCase {
 	/**
 	 * @ticket 37652
 	 */
-	function test_preconnect() {
+	public function test_preconnect() {
 		$expected = "<link rel='dns-prefetch' href='//s.w.org' />\n" .
 					"<link rel='preconnect' href='//wordpress.org' />\n" .
 					"<link rel='preconnect' href='https://make.wordpress.org' />\n" .
@@ -85,7 +85,7 @@ class Tests_General_wpResourceHints extends WP_UnitTestCase {
 		$this->assertSame( $expected, $actual );
 	}
 
-	function _add_preconnect_domains( $hints, $method ) {
+	public function _add_preconnect_domains( $hints, $method ) {
 		if ( 'preconnect' === $method ) {
 			$hints[] = '//wordpress.org';
 			$hints[] = 'https://make.wordpress.org';
@@ -97,7 +97,7 @@ class Tests_General_wpResourceHints extends WP_UnitTestCase {
 		return $hints;
 	}
 
-	function test_prerender() {
+	public function test_prerender() {
 		$expected = "<link rel='dns-prefetch' href='//s.w.org' />\n" .
 					"<link rel='prerender' href='https://make.wordpress.org/great-again' />\n" .
 					"<link rel='prerender' href='http://jobs.wordpress.net' />\n" .
@@ -112,7 +112,7 @@ class Tests_General_wpResourceHints extends WP_UnitTestCase {
 		$this->assertSame( $expected, $actual );
 	}
 
-	function _add_prerender_urls( $hints, $method ) {
+	public function _add_prerender_urls( $hints, $method ) {
 		if ( 'prerender' === $method ) {
 			$hints[] = 'https://make.wordpress.org/great-again';
 			$hints[] = 'http://jobs.wordpress.net';
@@ -123,7 +123,7 @@ class Tests_General_wpResourceHints extends WP_UnitTestCase {
 		return $hints;
 	}
 
-	function test_parse_url_dns_prefetch() {
+	public function test_parse_url_dns_prefetch() {
 		$expected = "<link rel='dns-prefetch' href='//s.w.org' />\n" .
 					"<link rel='dns-prefetch' href='//make.wordpress.org' />\n";
 
@@ -136,7 +136,7 @@ class Tests_General_wpResourceHints extends WP_UnitTestCase {
 		$this->assertSame( $expected, $actual );
 	}
 
-	function _add_dns_prefetch_long_urls( $hints, $method ) {
+	public function _add_dns_prefetch_long_urls( $hints, $method ) {
 		if ( 'dns-prefetch' === $method ) {
 			$hints[] = 'http://make.wordpress.org/wp-includes/css/editor.css';
 		}
@@ -144,7 +144,7 @@ class Tests_General_wpResourceHints extends WP_UnitTestCase {
 		return $hints;
 	}
 
-	function test_dns_prefetch_styles() {
+	public function test_dns_prefetch_styles() {
 		$expected = "<link rel='dns-prefetch' href='//fonts.googleapis.com' />\n" .
 					"<link rel='dns-prefetch' href='//s.w.org' />\n";
 
@@ -163,7 +163,7 @@ class Tests_General_wpResourceHints extends WP_UnitTestCase {
 
 	}
 
-	function test_dns_prefetch_scripts() {
+	public function test_dns_prefetch_scripts() {
 		$expected = "<link rel='dns-prefetch' href='//fonts.googleapis.com' />\n" .
 					"<link rel='dns-prefetch' href='//s.w.org' />\n";
 
@@ -184,7 +184,7 @@ class Tests_General_wpResourceHints extends WP_UnitTestCase {
 	/**
 	 * @ticket 37385
 	 */
-	function test_dns_prefetch_scripts_does_not_include_registered_only() {
+	public function test_dns_prefetch_scripts_does_not_include_registered_only() {
 		$expected   = "<link rel='dns-prefetch' href='//s.w.org' />\n";
 		$unexpected = "<link rel='dns-prefetch' href='//wordpress.org' />\n";
 
@@ -201,7 +201,7 @@ class Tests_General_wpResourceHints extends WP_UnitTestCase {
 	/**
 	 * @ticket 37502
 	 */
-	function test_deregistered_scripts_are_ignored() {
+	public function test_deregistered_scripts_are_ignored() {
 		$expected = "<link rel='dns-prefetch' href='//s.w.org' />\n";
 
 		wp_enqueue_script( 'test-script', 'http://example.org/script.js' );
@@ -214,7 +214,7 @@ class Tests_General_wpResourceHints extends WP_UnitTestCase {
 	/**
 	 * @ticket 37652
 	 */
-	function test_malformed_urls() {
+	public function test_malformed_urls() {
 		$expected = "<link rel='dns-prefetch' href='//s.w.org' />\n";
 
 		// Errant colon.
@@ -230,7 +230,7 @@ class Tests_General_wpResourceHints extends WP_UnitTestCase {
 		$this->assertSame( $expected, $actual );
 	}
 
-	function _add_malformed_url_errant_colon( $hints, $method ) {
+	public function _add_malformed_url_errant_colon( $hints, $method ) {
 		if ( 'preconnect' === $method ) {
 			$hints[] = '://core.trac.wordpress.org/ticket/37652';
 		}
@@ -238,7 +238,7 @@ class Tests_General_wpResourceHints extends WP_UnitTestCase {
 		return $hints;
 	}
 
-	function _add_malformed_url_unsupported_scheme( $hints, $method ) {
+	public function _add_malformed_url_unsupported_scheme( $hints, $method ) {
 		if ( 'preconnect' === $method ) {
 			$hints[] = 'git://develop.git.wordpress.org/';
 		}
@@ -249,7 +249,7 @@ class Tests_General_wpResourceHints extends WP_UnitTestCase {
 	/**
 	 * @ticket 38121
 	 */
-	function test_custom_attributes() {
+	public function test_custom_attributes() {
 		$expected = "<link rel='dns-prefetch' href='//s.w.org' />\n" .
 					"<link rel='preconnect' href='https://make.wordpress.org' />\n" .
 					"<link crossorigin as='image' pr='0.5' href='https://example.com/foo.jpeg' rel='prefetch' />\n" .
@@ -265,7 +265,7 @@ class Tests_General_wpResourceHints extends WP_UnitTestCase {
 		$this->assertSame( $expected, $actual );
 	}
 
-	function _add_url_with_attributes( $hints, $method ) {
+	public function _add_url_with_attributes( $hints, $method ) {
 		// Ignore hints with missing href attributes.
 		$hints[] = array(
 			'rel' => 'foo',

--- a/tests/phpunit/tests/http/base.php
+++ b/tests/phpunit/tests/http/base.php
@@ -17,7 +17,7 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 
 	protected $http_request_args;
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		$class = 'WP_Http_' . ucfirst( $this->transport );
@@ -34,7 +34,7 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 		}
 	}
 
-	function filter_http_request_args( array $args ) {
+	public function filter_http_request_args( array $args ) {
 		$this->http_request_args = $args;
 		return $args;
 	}
@@ -42,7 +42,7 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 	/**
 	 * @covers ::wp_remote_request
 	 */
-	function test_redirect_on_301() {
+	public function test_redirect_on_301() {
 		// 5 : 5 & 301.
 		$res = wp_remote_request( $this->redirection_script . '?code=301&rt=' . 5, array( 'redirection' => 5 ) );
 
@@ -54,7 +54,7 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 	/**
 	 * @covers ::wp_remote_request
 	 */
-	function test_redirect_on_302() {
+	public function test_redirect_on_302() {
 		// 5 : 5 & 302.
 		$res = wp_remote_request( $this->redirection_script . '?code=302&rt=' . 5, array( 'redirection' => 5 ) );
 
@@ -68,7 +68,7 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 	 *
 	 * @covers ::wp_remote_request
 	 */
-	function test_redirect_on_301_no_redirect() {
+	public function test_redirect_on_301_no_redirect() {
 		// 5 > 0 & 301.
 		$res = wp_remote_request( $this->redirection_script . '?code=301&rt=' . 5, array( 'redirection' => 0 ) );
 
@@ -82,7 +82,7 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 	 *
 	 * @covers ::wp_remote_request
 	 */
-	function test_redirect_on_302_no_redirect() {
+	public function test_redirect_on_302_no_redirect() {
 		// 5 > 0 & 302.
 		$res = wp_remote_request( $this->redirection_script . '?code=302&rt=' . 5, array( 'redirection' => 0 ) );
 
@@ -94,7 +94,7 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 	/**
 	 * @covers ::wp_remote_request
 	 */
-	function test_redirections_equal() {
+	public function test_redirections_equal() {
 		// 5 - 5.
 		$res = wp_remote_request( $this->redirection_script . '?rt=' . 5, array( 'redirection' => 5 ) );
 
@@ -106,7 +106,7 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 	/**
 	 * @covers ::wp_remote_request
 	 */
-	function test_no_head_redirections() {
+	public function test_no_head_redirections() {
 		// No redirections on HEAD request.
 		$res = wp_remote_request( $this->redirection_script . '?code=302&rt=' . 1, array( 'method' => 'HEAD' ) );
 
@@ -120,7 +120,7 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 	 *
 	 * @covers ::wp_remote_request
 	 */
-	function test_redirect_on_head() {
+	public function test_redirect_on_head() {
 		// Redirections on HEAD request when Requested.
 		$res = wp_remote_request(
 			$this->redirection_script . '?rt=' . 5,
@@ -138,7 +138,7 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 	/**
 	 * @covers ::wp_remote_request
 	 */
-	function test_redirections_greater() {
+	public function test_redirections_greater() {
 		// 10 > 5.
 		$res = wp_remote_request( $this->redirection_script . '?rt=' . 10, array( 'redirection' => 5 ) );
 
@@ -149,7 +149,7 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 	/**
 	 * @covers ::wp_remote_request
 	 */
-	function test_redirections_greater_edgecase() {
+	public function test_redirections_greater_edgecase() {
 		// 6 > 5 (close edge case).
 		$res = wp_remote_request( $this->redirection_script . '?rt=' . 6, array( 'redirection' => 5 ) );
 
@@ -160,7 +160,7 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 	/**
 	 * @covers ::wp_remote_request
 	 */
-	function test_redirections_less_edgecase() {
+	public function test_redirections_less_edgecase() {
 		// 4 < 5 (close edge case).
 		$res = wp_remote_request( $this->redirection_script . '?rt=' . 4, array( 'redirection' => 5 ) );
 
@@ -173,7 +173,7 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 	 *
 	 * @covers ::wp_remote_request
 	 */
-	function test_redirections_zero_redirections_specified() {
+	public function test_redirections_zero_redirections_specified() {
 		// 0 redirections asked for, should return the document?
 		$res = wp_remote_request( $this->redirection_script . '?code=302&rt=' . 5, array( 'redirection' => 0 ) );
 
@@ -189,7 +189,7 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 	 *
 	 * @covers ::wp_remote_request
 	 */
-	function test_location_header_on_201() {
+	public function test_location_header_on_201() {
 		// Prints PASS on initial load, FAIL if the client follows the specified redirection.
 		$res = wp_remote_request( $this->redirection_script . '?201-location=true' );
 
@@ -206,7 +206,7 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 	 * @covers ::wp_remote_request
 	 * @covers ::wp_remote_retrieve_body
 	 */
-	function test_no_redirection_on_PUT() {
+	public function test_no_redirection_on_PUT() {
 		$url = 'http://api.wordpress.org/core/tests/1.0/redirection.php?201-location=1';
 
 		// Test 301 - POST to POST.
@@ -228,7 +228,7 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 	 *
 	 * @covers ::wp_remote_request
 	 */
-	function test_send_headers() {
+	public function test_send_headers() {
 		// Test that the headers sent are received by the server.
 		$headers = array(
 			'test1' => 'test',
@@ -263,7 +263,7 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 	/**
 	 * @covers ::wp_remote_request
 	 */
-	function test_file_stream() {
+	public function test_file_stream() {
 		$url  = $this->file_stream_url;
 		$size = 153204;
 		$res  = wp_remote_request(
@@ -293,7 +293,7 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 	 *
 	 * @covers ::wp_remote_request
 	 */
-	function test_file_stream_limited_size() {
+	public function test_file_stream_limited_size() {
 		$url  = $this->file_stream_url;
 		$size = 10000;
 		$res  = wp_remote_request(
@@ -324,7 +324,7 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 	 *
 	 * @covers ::wp_remote_request
 	 */
-	function test_request_limited_size() {
+	public function test_request_limited_size() {
 		$url  = $this->file_stream_url;
 		$size = 10000;
 
@@ -351,7 +351,7 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 	 * @covers ::wp_remote_post
 	 * @covers ::wp_remote_retrieve_body
 	 */
-	function test_post_redirect_to_method_300( $response_code, $method ) {
+	public function test_post_redirect_to_method_300( $response_code, $method ) {
 		$url = 'http://api.wordpress.org/core/tests/1.0/redirection.php?post-redirect-to-method=1';
 
 		$res = wp_remote_post( add_query_arg( 'response_code', $response_code, $url ), array( 'timeout' => 30 ) );
@@ -393,7 +393,7 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 	 * @covers ::wp_remote_get
 	 * @covers ::wp_remote_retrieve_body
 	 */
-	function test_ip_url_with_host_header() {
+	public function test_ip_url_with_host_header() {
 		$ip   = gethostbyname( 'api.wordpress.org' );
 		$url  = 'http://' . $ip . '/core/tests/1.0/redirection.php?print-pass=1';
 		$args = array(
@@ -418,7 +418,7 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 	 *
 	 * @covers ::wp_remote_head
 	 */
-	function test_https_url_without_ssl_verification() {
+	public function test_https_url_without_ssl_verification() {
 		$url  = 'https://wordpress.org/';
 		$args = array(
 			'sslverify' => false,
@@ -445,7 +445,7 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 	 * @covers ::wp_remote_get
 	 * @covers ::wp_remote_retrieve_body
 	 */
-	function test_multiple_location_headers() {
+	public function test_multiple_location_headers() {
 		$url = 'http://api.wordpress.org/core/tests/1.0/redirection.php?multiple-location-headers=1';
 		$res = wp_remote_head( $url, array( 'timeout' => 30 ) );
 
@@ -468,7 +468,7 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 	 * @covers ::wp_remote_get
 	 * @covers ::wp_remote_retrieve_body
 	 */
-	function test_cookie_handling() {
+	public function test_cookie_handling() {
 		$url = 'http://api.wordpress.org/core/tests/1.0/redirection.php?cookie-test=1';
 
 		$res = wp_remote_get( $url );
@@ -485,7 +485,7 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 	 *
 	 * @covers ::wp_remote_get
 	 */
-	function test_ssl() {
+	public function test_ssl() {
 		if ( ! wp_http_supports( array( 'ssl' ) ) ) {
 			$this->fail( 'This installation of PHP does not support SSL.' );
 		}
@@ -501,7 +501,7 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 	 *
 	 * @covers ::wp_remote_request
 	 */
-	function test_url_with_double_slashes_path() {
+	public function test_url_with_double_slashes_path() {
 		$url = $this->redirection_script . '?rt=' . 0;
 
 		$path = parse_url( $url, PHP_URL_PATH );

--- a/tests/phpunit/tests/http/functions.php
+++ b/tests/phpunit/tests/http/functions.php
@@ -9,7 +9,7 @@ class Tests_HTTP_Functions extends WP_UnitTestCase {
 	/**
 	 * @covers ::wp_remote_head
 	 */
-	function test_head_request() {
+	public function test_head_request() {
 		// This URL gives a direct 200 response.
 		$url      = 'https://asdftestblog1.files.wordpress.com/2007/09/2007-06-30-dsc_4700-1.jpg';
 		$response = wp_remote_head( $url );
@@ -28,7 +28,7 @@ class Tests_HTTP_Functions extends WP_UnitTestCase {
 	/**
 	 * @covers ::wp_remote_head
 	 */
-	function test_head_redirect() {
+	public function test_head_redirect() {
 		// This URL will 301 redirect.
 		$url      = 'https://asdftestblog1.wordpress.com/files/2007/09/2007-06-30-dsc_4700-1.jpg';
 		$response = wp_remote_head( $url );
@@ -40,7 +40,7 @@ class Tests_HTTP_Functions extends WP_UnitTestCase {
 	/**
 	 * @covers ::wp_remote_head
 	 */
-	function test_head_404() {
+	public function test_head_404() {
 		$url      = 'https://asdftestblog1.files.wordpress.com/2007/09/awefasdfawef.jpg';
 		$response = wp_remote_head( $url );
 
@@ -53,7 +53,7 @@ class Tests_HTTP_Functions extends WP_UnitTestCase {
 	 * @covers ::wp_remote_retrieve_headers
 	 * @covers ::wp_remote_retrieve_response_code
 	 */
-	function test_get_request() {
+	public function test_get_request() {
 		$url = 'https://asdftestblog1.files.wordpress.com/2007/09/2007-06-30-dsc_4700-1.jpg';
 
 		$response = wp_remote_get( $url );
@@ -75,7 +75,7 @@ class Tests_HTTP_Functions extends WP_UnitTestCase {
 	 * @covers ::wp_remote_retrieve_headers
 	 * @covers ::wp_remote_retrieve_response_code
 	 */
-	function test_get_redirect() {
+	public function test_get_redirect() {
 		// This will redirect to asdftestblog1.files.wordpress.com.
 		$url = 'https://asdftestblog1.wordpress.com/files/2007/09/2007-06-30-dsc_4700-1.jpg';
 
@@ -94,7 +94,7 @@ class Tests_HTTP_Functions extends WP_UnitTestCase {
 	/**
 	 * @covers ::wp_remote_get
 	 */
-	function test_get_redirect_limit_exceeded() {
+	public function test_get_redirect_limit_exceeded() {
 		// This will redirect to asdftestblog1.files.wordpress.com.
 		$url = 'https://asdftestblog1.wordpress.com/files/2007/09/2007-06-30-dsc_4700-1.jpg';
 
@@ -113,7 +113,7 @@ class Tests_HTTP_Functions extends WP_UnitTestCase {
 	 * @covers ::wp_remote_retrieve_cookie
 	 * @covers ::wp_remote_retrieve_cookie_value
 	 */
-	function test_get_response_cookies() {
+	public function test_get_response_cookies() {
 		$url = 'https://login.wordpress.org/wp-login.php';
 
 		$response = wp_remote_head( $url );
@@ -146,7 +146,7 @@ class Tests_HTTP_Functions extends WP_UnitTestCase {
 	 * @covers ::wp_remote_retrieve_cookies
 	 * @covers ::wp_remote_retrieve_cookie
 	 */
-	function test_get_response_cookies_with_wp_http_cookie_object() {
+	public function test_get_response_cookies_with_wp_http_cookie_object() {
 		$url = 'http://example.org';
 
 		$response = wp_remote_get(
@@ -182,7 +182,7 @@ class Tests_HTTP_Functions extends WP_UnitTestCase {
 	 * @covers ::wp_remote_retrieve_cookies
 	 * @covers ::wp_remote_retrieve_cookie
 	 */
-	function test_get_response_cookies_with_name_value_array() {
+	public function test_get_response_cookies_with_name_value_array() {
 		$url = 'http://example.org';
 
 		$response = wp_remote_get(
@@ -214,7 +214,7 @@ class Tests_HTTP_Functions extends WP_UnitTestCase {
 	 * @covers ::wp_remote_retrieve_cookie
 	 * @covers WP_Http
 	 */
-	function test_get_cookie_host_only() {
+	public function test_get_cookie_host_only() {
 		// Emulate WP_Http::request() internals.
 		$requests_response = new Requests_Response();
 

--- a/tests/phpunit/tests/http/http.php
+++ b/tests/phpunit/tests/http/http.php
@@ -13,12 +13,12 @@ class Tests_HTTP_HTTP extends WP_UnitTestCase {
 	 *
 	 * @covers WP_Http::make_absolute_url
 	 */
-	function test_make_absolute_url( $relative_url, $absolute_url, $expected ) {
+	public function test_make_absolute_url( $relative_url, $absolute_url, $expected ) {
 		$actual = WP_Http::make_absolute_url( $relative_url, $absolute_url );
 		$this->assertSame( $expected, $actual );
 	}
 
-	function make_absolute_url_testcases() {
+	public function make_absolute_url_testcases() {
 		// 0: The Location header, 1: The current URL, 3: The expected URL.
 		return array(
 			// Absolute URL provided.
@@ -74,12 +74,12 @@ class Tests_HTTP_HTTP extends WP_UnitTestCase {
 	 *
 	 * @covers ::wp_parse_url
 	 */
-	function test_wp_parse_url( $url, $expected ) {
+	public function test_wp_parse_url( $url, $expected ) {
 		$actual = wp_parse_url( $url );
 		$this->assertSame( $expected, $actual );
 	}
 
-	function parse_url_testcases() {
+	public function parse_url_testcases() {
 		// 0: The URL, 1: The expected resulting structure.
 		return array(
 			array(
@@ -187,7 +187,7 @@ class Tests_HTTP_HTTP extends WP_UnitTestCase {
 	 *
 	 * @covers ::wp_parse_url
 	 */
-	function test_wp_parse_url_with_default_component() {
+	public function test_wp_parse_url_with_default_component() {
 		$actual = wp_parse_url( self::FULL_TEST_URL, -1 );
 		$this->assertSame(
 			array(
@@ -211,12 +211,12 @@ class Tests_HTTP_HTTP extends WP_UnitTestCase {
 	 *
 	 * @covers ::wp_parse_url
 	 */
-	function test_wp_parse_url_with_component( $url, $component, $expected ) {
+	public function test_wp_parse_url_with_component( $url, $component, $expected ) {
 		$actual = wp_parse_url( $url, $component );
 		$this->assertSame( $expected, $actual );
 	}
 
-	function parse_url_component_testcases() {
+	public function parse_url_component_testcases() {
 		// 0: The URL, 1: The requested component, 2: The expected resulting structure.
 		return array(
 			array( self::FULL_TEST_URL, PHP_URL_SCHEME, 'http' ),
@@ -328,13 +328,13 @@ class Tests_HTTP_HTTP extends WP_UnitTestCase {
 	 * @covers ::wp_parse_url
 	 * @covers ::_get_component_from_parsed_url_array
 	 */
-	function test_get_component_from_parsed_url_array( $url, $component, $expected ) {
+	public function test_get_component_from_parsed_url_array( $url, $component, $expected ) {
 		$parts  = wp_parse_url( $url );
 		$actual = _get_component_from_parsed_url_array( $parts, $component );
 		$this->assertSame( $expected, $actual );
 	}
 
-	function get_component_from_parsed_url_array_testcases() {
+	public function get_component_from_parsed_url_array_testcases() {
 		// 0: A URL, 1: PHP URL constant, 2: The expected result.
 		return array(
 			array(
@@ -369,12 +369,12 @@ class Tests_HTTP_HTTP extends WP_UnitTestCase {
 	 *
 	 * @covers ::_wp_translate_php_url_constant_to_key
 	 */
-	function test_wp_translate_php_url_constant_to_key( $input, $expected ) {
+	public function test_wp_translate_php_url_constant_to_key( $input, $expected ) {
 		$actual = _wp_translate_php_url_constant_to_key( $input );
 		$this->assertSame( $expected, $actual );
 	}
 
-	function wp_translate_php_url_constant_to_key_testcases() {
+	public function wp_translate_php_url_constant_to_key_testcases() {
 		// 0: PHP URL constant, 1: The expected result.
 		return array(
 			array( PHP_URL_SCHEME, 'scheme' ),

--- a/tests/phpunit/tests/http/wpRemoteRetrieveHeaders.php
+++ b/tests/phpunit/tests/http/wpRemoteRetrieveHeaders.php
@@ -9,7 +9,7 @@ class Tests_HTTP_wpRemoteRetrieveHeaders extends WP_UnitTestCase {
 	/**
 	 * Valid response
 	 */
-	function test_remote_retrieve_headers_valid_response() {
+	public function test_remote_retrieve_headers_valid_response() {
 		$headers  = 'headers_data';
 		$response = array( 'headers' => $headers );
 
@@ -20,7 +20,7 @@ class Tests_HTTP_wpRemoteRetrieveHeaders extends WP_UnitTestCase {
 	/**
 	 * Response is a WP_Error
 	 */
-	function test_remote_retrieve_headers_is_error() {
+	public function test_remote_retrieve_headers_is_error() {
 		$response = new WP_Error( 'Some error' );
 
 		$result = wp_remote_retrieve_headers( $response );
@@ -30,7 +30,7 @@ class Tests_HTTP_wpRemoteRetrieveHeaders extends WP_UnitTestCase {
 	/**
 	 * Response does not contain 'headers'
 	 */
-	function test_remote_retrieve_headers_invalid_response() {
+	public function test_remote_retrieve_headers_invalid_response() {
 		$response = array( 'no_headers' => 'set' );
 
 		$result = wp_remote_retrieve_headers( $response );


### PR DESCRIPTION
Coding Standards: Add visibility to methods in `tests/phpunit/tests/` E-F-G-H files.

"Visibility should always be declared"
See: https://make.wordpress.org/core/2020/03/20/updating-the-coding-standards-for-modern-php/

This commit applies the following sniffs to files in `tests/phpunit/tests` E-F-G-H directories:
- Squiz.Scope.MethodScope
- PSR2.Methods.MethodDeclaration
- PSR2.Classes.PropertyDeclaration
- Squiz.WhiteSpace.ScopeKeywordSpacing

For most methods, these now indicate `public` visibility to avoid breaking backwards compatibility.
Any remaining methods now indicate `private` visibility where appropriate.

Additional fixups in this PR:
1. Methods touched by this PR have had unnecessary underscores removed from their names.

Trac ticket: https://core.trac.wordpress.org/ticket/54177