### PR TITLE
Coding Standards: Add visibility to methods in `tests/phpunit/tests/` i-L-M-O files.

### DIFF
--- a/tests/phpunit/tests/image/dimensions.php
+++ b/tests/phpunit/tests/image/dimensions.php
@@ -6,7 +6,7 @@
  * @group upload
  */
 class Tests_Image_Dimensions extends WP_UnitTestCase {
-	function test_400x400_no_crop() {
+	public function test_400x400_no_crop() {
 		// Landscape: resize 640x480 to fit 400x400: 400x300.
 		$out = image_resize_dimensions( 640, 480, 400, 400, false );
 		// dst_x, dst_y, src_x, src_y, dst_w, dst_h, src_w, src_h.
@@ -18,7 +18,7 @@ class Tests_Image_Dimensions extends WP_UnitTestCase {
 		$this->assertSame( array( 0, 0, 0, 0, 300, 400, 480, 640 ), $out );
 	}
 
-	function test_400x0_no_crop() {
+	public function test_400x0_no_crop() {
 		// Landscape: resize 640x480 to fit 400w: 400x300.
 		$out = image_resize_dimensions( 640, 480, 400, 0, false );
 		// dst_x, dst_y, src_x, src_y, dst_w, dst_h, src_w, src_h.
@@ -30,7 +30,7 @@ class Tests_Image_Dimensions extends WP_UnitTestCase {
 		$this->assertSame( array( 0, 0, 0, 0, 400, 533, 480, 640 ), $out );
 	}
 
-	function test_0x400_no_crop() {
+	public function test_0x400_no_crop() {
 		// Landscape: resize 640x480 to fit 400h: 533x400.
 		$out = image_resize_dimensions( 640, 480, 0, 400, false );
 		// dst_x, dst_y, src_x, src_y, dst_w, dst_h, src_w, src_h.
@@ -42,7 +42,7 @@ class Tests_Image_Dimensions extends WP_UnitTestCase {
 		$this->assertSame( array( 0, 0, 0, 0, 300, 400, 480, 640 ), $out );
 	}
 
-	function test_800x800_no_crop() {
+	public function test_800x800_no_crop() {
 		// Landscape: resize 640x480 to fit 800x800.
 		$out = image_resize_dimensions( 640, 480, 800, 800, false );
 		// dst_x, dst_y, src_x, src_y, dst_w, dst_h, src_w, src_h.
@@ -54,7 +54,7 @@ class Tests_Image_Dimensions extends WP_UnitTestCase {
 		$this->assertFalse( $out );
 	}
 
-	function test_800x0_no_crop() {
+	public function test_800x0_no_crop() {
 		// Landscape: resize 640x480 to fit 800w.
 		$out = image_resize_dimensions( 640, 480, 800, 0, false );
 		// dst_x, dst_y, src_x, src_y, dst_w, dst_h, src_w, src_h.
@@ -66,7 +66,7 @@ class Tests_Image_Dimensions extends WP_UnitTestCase {
 		$this->assertFalse( $out );
 	}
 
-	function test_0x800_no_crop() {
+	public function test_0x800_no_crop() {
 		// Landscape: resize 640x480 to fit 800h.
 		$out = image_resize_dimensions( 640, 480, 0, 800, false );
 		// dst_x, dst_y, src_x, src_y, dst_w, dst_h, src_w, src_h.
@@ -80,7 +80,7 @@ class Tests_Image_Dimensions extends WP_UnitTestCase {
 
 	// Cropped versions.
 
-	function test_400x400_crop() {
+	public function test_400x400_crop() {
 		// Landscape: crop 640x480 to fit 400x400: 400x400 taken from a 480x480 crop at (80. 0).
 		$out = image_resize_dimensions( 640, 480, 400, 400, true );
 		// dst_x, dst_y, src_x, src_y, dst_w, dst_h, src_w, src_h.
@@ -92,7 +92,7 @@ class Tests_Image_Dimensions extends WP_UnitTestCase {
 		$this->assertSame( array( 0, 0, 0, 80, 400, 400, 480, 480 ), $out );
 	}
 
-	function test_400x0_crop() {
+	public function test_400x0_crop() {
 		// Landscape: resize 640x480 to fit 400w: 400x300.
 		$out = image_resize_dimensions( 640, 480, 400, 0, true );
 		// dst_x, dst_y, src_x, src_y, dst_w, dst_h, src_w, src_h.
@@ -104,7 +104,7 @@ class Tests_Image_Dimensions extends WP_UnitTestCase {
 		$this->assertSame( array( 0, 0, 0, 0, 400, 533, 480, 640 ), $out );
 	}
 
-	function test_0x400_crop() {
+	public function test_0x400_crop() {
 		// Landscape: resize 640x480 to fit 400h: 533x400.
 		$out = image_resize_dimensions( 640, 480, 0, 400, true );
 		// dst_x, dst_y, src_x, src_y, dst_w, dst_h, src_w, src_h.
@@ -116,7 +116,7 @@ class Tests_Image_Dimensions extends WP_UnitTestCase {
 		$this->assertSame( array( 0, 0, 0, 0, 300, 400, 480, 640 ), $out );
 	}
 
-	function test_400x500_crop() {
+	public function test_400x500_crop() {
 		// Landscape: crop 640x480 to fit 400x500: 400x400 taken from a 480x480 crop at (80. 0).
 		$out = image_resize_dimensions( 640, 480, 400, 500, true );
 		// dst_x, dst_y, src_x, src_y, dst_w, dst_h, src_w, src_h.
@@ -128,7 +128,7 @@ class Tests_Image_Dimensions extends WP_UnitTestCase {
 		$this->assertSame( array( 0, 0, 0, 20, 400, 500, 480, 600 ), $out );
 	}
 
-	function test_640x480() {
+	public function test_640x480() {
 		// Crop 640x480 to fit 640x480 (no change).
 		$out = image_resize_dimensions( 640, 480, 640, 480, true );
 		$this->assertFalse( $out );
@@ -156,7 +156,7 @@ class Tests_Image_Dimensions extends WP_UnitTestCase {
 	/**
 	 * @ticket 19393
 	 */
-	function test_crop_anchors() {
+	public function test_crop_anchors() {
 		// Landscape: crop 640x480 to fit 400x500: 400x400 taken from a 480x480 crop.
 		// src_x = 0 (left), src_y = 0 (top).
 		$out = image_resize_dimensions( 640, 480, 400, 500, array( 'left', 'top' ) );

--- a/tests/phpunit/tests/image/functions.php
+++ b/tests/phpunit/tests/image/functions.php
@@ -45,7 +45,7 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 		return $mime_type;
 	}
 
-	function test_is_image_positive() {
+	public function test_is_image_positive() {
 		// These are all image files recognized by PHP.
 		$files = array(
 			'test-image-cmyk.jpg',
@@ -75,7 +75,7 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 		}
 	}
 
-	function test_is_image_negative() {
+	public function test_is_image_negative() {
 		// These are actually image files but aren't recognized or usable by PHP.
 		$files = array(
 			'test-image.pct',
@@ -88,7 +88,7 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 		}
 	}
 
-	function test_is_displayable_image_positive() {
+	public function test_is_displayable_image_positive() {
 		// These are all usable in typical web browsers.
 		$files = array(
 			'test-image.gif',
@@ -122,7 +122,7 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 		}
 	}
 
-	function test_is_displayable_image_negative() {
+	public function test_is_displayable_image_negative() {
 		// These are image files but aren't suitable for web pages because of compatibility or size issues.
 		$files = array(
 			// 'test-image-cmyk.jpg',      Allowed in r9727.
@@ -147,7 +147,7 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 	/**
 	 * @ticket 50833
 	 */
-	function test_is_gd_image_invalid_types() {
+	public function test_is_gd_image_invalid_types() {
 		$this->assertFalse( is_gd_image( new stdClass() ) );
 		$this->assertFalse( is_gd_image( array() ) );
 		$this->assertFalse( is_gd_image( null ) );
@@ -161,7 +161,7 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 	 * @ticket 50833
 	 * @requires extension gd
 	 */
-	function test_is_gd_image_valid_types() {
+	public function test_is_gd_image_valid_types() {
 		$this->assertTrue( is_gd_image( imagecreate( 5, 5 ) ) );
 	}
 
@@ -426,7 +426,7 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 		$this->assertInstanceOf( 'WP_Error', $file );
 	}
 
-	function mock_image_editor( $editors ) {
+	public function mock_image_editor( $editors ) {
 		return array( 'WP_Image_Editor_Mock' );
 	}
 
@@ -638,7 +638,7 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 		}
 	}
 
-	function filter_fallback_intermediate_image_sizes( $fallback_sizes, $metadata ) {
+	public function filter_fallback_intermediate_image_sizes( $fallback_sizes, $metadata ) {
 		// Add the 'test-size' to the list of fallback sizes.
 		$fallback_sizes[] = 'test-size';
 

--- a/tests/phpunit/tests/image/header.php
+++ b/tests/phpunit/tests/image/header.php
@@ -8,12 +8,12 @@ require_once ABSPATH . 'wp-admin/includes/class-custom-image-header.php';
 class Tests_Image_Header extends WP_UnitTestCase {
 	public $custom_image_header;
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 		$this->custom_image_header = new Custom_Image_Header( '__return_null' );
 	}
 
-	function test_header_image_has_correct_dimensions_with_max_width() {
+	public function test_header_image_has_correct_dimensions_with_max_width() {
 		global $_wp_theme_features;
 
 		$_wp_theme_features['custom-header'][0]['max-width']   = 1600;
@@ -33,7 +33,7 @@ class Tests_Image_Header extends WP_UnitTestCase {
 
 	}
 
-	function test_header_image_has_correct_dimensions_with_fixed() {
+	public function test_header_image_has_correct_dimensions_with_fixed() {
 		global $_wp_theme_features;
 
 		unset( $_wp_theme_features['custom-header'][0]['max-width'] );
@@ -53,7 +53,7 @@ class Tests_Image_Header extends WP_UnitTestCase {
 
 	}
 
-	function test_header_image_has_correct_dimensions_with_flex_height() {
+	public function test_header_image_has_correct_dimensions_with_flex_height() {
 		global $_wp_theme_features;
 
 		unset( $_wp_theme_features['custom-header'][0]['max-width'] );
@@ -73,7 +73,7 @@ class Tests_Image_Header extends WP_UnitTestCase {
 
 	}
 
-	function test_header_image_has_correct_dimensions_with_flex_width() {
+	public function test_header_image_has_correct_dimensions_with_flex_width() {
 		global $_wp_theme_features;
 
 		unset( $_wp_theme_features['custom-header'][0]['max-width'] );
@@ -93,7 +93,7 @@ class Tests_Image_Header extends WP_UnitTestCase {
 
 	}
 
-	function test_header_image_has_correct_dimensions_with_flex_width_and_height() {
+	public function test_header_image_has_correct_dimensions_with_flex_width_and_height() {
 		global $_wp_theme_features;
 
 		$_wp_theme_features['custom-header'][0]['max-width']   = 1800;
@@ -113,7 +113,7 @@ class Tests_Image_Header extends WP_UnitTestCase {
 
 	}
 
-	function test_create_attachment_object() {
+	public function test_create_attachment_object() {
 		$id = wp_insert_attachment(
 			array(
 				'post_status' => 'publish',
@@ -132,7 +132,7 @@ class Tests_Image_Header extends WP_UnitTestCase {
 		$this->assertSame( 'image/jpeg', $object['post_mime_type'] );
 	}
 
-	function test_insert_cropped_attachment() {
+	public function test_insert_cropped_attachment() {
 		$id = wp_insert_attachment(
 			array(
 				'post_status' => 'publish',
@@ -154,7 +154,7 @@ class Tests_Image_Header extends WP_UnitTestCase {
 	/**
 	 * @ticket 21819
 	 */
-	function test_check_get_previous_crop() {
+	public function test_check_get_previous_crop() {
 		$id = wp_insert_attachment(
 			array(
 				'post_status' => 'publish',

--- a/tests/phpunit/tests/image/intermediateSize.php
+++ b/tests/phpunit/tests/image/intermediateSize.php
@@ -5,7 +5,7 @@
  * @group upload
  */
 class Tests_Image_Intermediate_Size extends WP_UnitTestCase {
-	function tear_down() {
+	public function tear_down() {
 		$this->remove_added_uploads();
 
 		remove_image_size( 'test-size' );
@@ -22,7 +22,7 @@ class Tests_Image_Intermediate_Size extends WP_UnitTestCase {
 		return parent::_make_attachment( $upload, $parent_post_id );
 	}
 
-	function test_make_intermediate_size_no_size() {
+	public function test_make_intermediate_size_no_size() {
 		$image = image_make_intermediate_size( DIR_TESTDATA . '/images/a2-small.jpg', 0, 0, false );
 
 		$this->assertFalse( $image );
@@ -31,7 +31,7 @@ class Tests_Image_Intermediate_Size extends WP_UnitTestCase {
 	/**
 	 * @requires function imagejpeg
 	 */
-	function test_make_intermediate_size_width() {
+	public function test_make_intermediate_size_width() {
 		$image = image_make_intermediate_size( DIR_TESTDATA . '/images/a2-small.jpg', 100, 0, false );
 
 		$this->assertIsArray( $image );
@@ -40,7 +40,7 @@ class Tests_Image_Intermediate_Size extends WP_UnitTestCase {
 	/**
 	 * @requires function imagejpeg
 	 */
-	function test_make_intermediate_size_height() {
+	public function test_make_intermediate_size_height() {
 		$image = image_make_intermediate_size( DIR_TESTDATA . '/images/a2-small.jpg', 0, 75, false );
 
 		$this->assertIsArray( $image );
@@ -49,7 +49,7 @@ class Tests_Image_Intermediate_Size extends WP_UnitTestCase {
 	/**
 	 * @requires function imagejpeg
 	 */
-	function test_make_intermediate_size_successful() {
+	public function test_make_intermediate_size_successful() {
 		$image = image_make_intermediate_size( DIR_TESTDATA . '/images/a2-small.jpg', 100, 75, true );
 
 		unlink( DIR_TESTDATA . '/images/a2-small-100x75.jpg' );
@@ -66,7 +66,7 @@ class Tests_Image_Intermediate_Size extends WP_UnitTestCase {
 	 * @ticket 52867
 	 * @requires function imagejpeg
 	 */
-	function test_image_editor_output_format_filter() {
+	public function test_image_editor_output_format_filter() {
 		add_filter(
 			'image_editor_output_format',
 			static function() {
@@ -92,7 +92,7 @@ class Tests_Image_Intermediate_Size extends WP_UnitTestCase {
 	 * @ticket 17626
 	 * @requires function imagejpeg
 	 */
-	function test_get_intermediate_sizes_by_name() {
+	public function test_get_intermediate_sizes_by_name() {
 		add_image_size( 'test-size', 330, 220, true );
 
 		$file = DIR_TESTDATA . '/images/waffles.jpg';
@@ -113,7 +113,7 @@ class Tests_Image_Intermediate_Size extends WP_UnitTestCase {
 	 * @ticket 17626
 	 * @requires function imagejpeg
 	 */
-	function test_get_intermediate_sizes_by_array_exact() {
+	public function test_get_intermediate_sizes_by_array_exact() {
 		// Only one dimention match shouldn't return false positive (see: #17626).
 		add_image_size( 'test-size', 330, 220, true );
 		add_image_size( 'false-height', 330, 400, true );
@@ -135,7 +135,7 @@ class Tests_Image_Intermediate_Size extends WP_UnitTestCase {
 	 * @ticket 17626
 	 * @requires function imagejpeg
 	 */
-	function test_get_intermediate_sizes_by_array_nearest() {
+	public function test_get_intermediate_sizes_by_array_nearest() {
 		// If an exact size is not found, it should be returned.
 		// If not, find nearest size that is larger (see: #17626).
 		add_image_size( 'test-size', 450, 300, true );
@@ -158,7 +158,7 @@ class Tests_Image_Intermediate_Size extends WP_UnitTestCase {
 	 * @ticket 17626
 	 * @requires function imagejpeg
 	 */
-	function test_get_intermediate_sizes_by_array_nearest_false() {
+	public function test_get_intermediate_sizes_by_array_nearest_false() {
 		// If an exact size is not found, it should be returned.
 		// If not, find nearest size that is larger, otherwise return false (see: #17626).
 		add_image_size( 'false-height', 330, 100, true );
@@ -180,7 +180,7 @@ class Tests_Image_Intermediate_Size extends WP_UnitTestCase {
 	 * @ticket 17626
 	 * @requires function imagejpeg
 	 */
-	function test_get_intermediate_sizes_by_array_zero_height() {
+	public function test_get_intermediate_sizes_by_array_zero_height() {
 		// Generate random width.
 		$random_w = rand( 300, 400 );
 
@@ -209,7 +209,7 @@ class Tests_Image_Intermediate_Size extends WP_UnitTestCase {
 	 * @ticket 34087
 	 * @requires function imagejpeg
 	 */
-	function test_get_intermediate_sizes_by_array_zero_width() {
+	public function test_get_intermediate_sizes_by_array_zero_width() {
 		// 202 is the smallest height that will trigger a miss for 'false-height'.
 		$height = 202;
 

--- a/tests/phpunit/tests/image/meta.php
+++ b/tests/phpunit/tests/image/meta.php
@@ -28,7 +28,7 @@ class Tests_Image_Meta extends WP_UnitTestCase {
 		stream_wrapper_unregister( 'testimagemeta' );
 	}
 
-	function test_exif_d70() {
+	public function test_exif_d70() {
 		// Exif from a Nikon D70.
 		$out = wp_read_image_metadata( DIR_TESTDATA . '/images/2004-07-22-DSC_0008.jpg' );
 
@@ -44,7 +44,7 @@ class Tests_Image_Meta extends WP_UnitTestCase {
 		$this->assertSame( '', $out['title'] );
 	}
 
-	function test_exif_d70_mf() {
+	public function test_exif_d70_mf() {
 		// Exif from a Nikon D70 - manual focus lens, so some data is unavailable.
 		$out = wp_read_image_metadata( DIR_TESTDATA . '/images/2007-06-17DSC_4173.JPG' );
 
@@ -61,7 +61,7 @@ class Tests_Image_Meta extends WP_UnitTestCase {
 		// $this->assertSame( array( 'Flowers' ), $out['keywords'] );
 	}
 
-	function test_exif_d70_iptc() {
+	public function test_exif_d70_iptc() {
 		// Exif from a Nikon D70 with IPTC data added later.
 		$out = wp_read_image_metadata( DIR_TESTDATA . '/images/2004-07-22-DSC_0007.jpg' );
 
@@ -77,7 +77,7 @@ class Tests_Image_Meta extends WP_UnitTestCase {
 		$this->assertSame( 'IPTC Headline', $out['title'] );
 	}
 
-	function test_exif_fuji() {
+	public function test_exif_fuji() {
 		// Exif from a Fuji FinePix S5600 (thanks Mark).
 		$out = wp_read_image_metadata( DIR_TESTDATA . '/images/a2-small.jpg' );
 
@@ -97,7 +97,7 @@ class Tests_Image_Meta extends WP_UnitTestCase {
 	/**
 	 * @ticket 6571
 	 */
-	function test_exif_error() {
+	public function test_exif_error() {
 		// https://core.trac.wordpress.org/ticket/6571
 		// This triggers a warning mesage when reading the Exif block.
 		$out = wp_read_image_metadata( DIR_TESTDATA . '/images/waffles.jpg' );
@@ -114,7 +114,7 @@ class Tests_Image_Meta extends WP_UnitTestCase {
 		$this->assertSame( '', $out['title'] );
 	}
 
-	function test_exif_no_data() {
+	public function test_exif_no_data() {
 		// No Exif data in this image (from burningwell.org).
 		$out = wp_read_image_metadata( DIR_TESTDATA . '/images/canola.jpg' );
 
@@ -133,7 +133,7 @@ class Tests_Image_Meta extends WP_UnitTestCase {
 	/**
 	 * @ticket 9417
 	 */
-	function test_utf8_iptc_tags() {
+	public function test_utf8_iptc_tags() {
 		// Trilingual UTF-8 text in the ITPC caption-abstract field.
 		$out = wp_read_image_metadata( DIR_TESTDATA . '/images/test-image-iptc.jpg' );
 

--- a/tests/phpunit/tests/image/resize.php
+++ b/tests/phpunit/tests/image/resize.php
@@ -20,7 +20,7 @@ abstract class WP_Tests_Image_Resize_UnitTestCase extends WP_Image_UnitTestCase 
 		return array( $this->editor_engine );
 	}
 
-	function test_resize_jpg() {
+	public function test_resize_jpg() {
 		$image = $this->resize_helper( DIR_TESTDATA . '/images/test-image.jpg', 25, 25 );
 
 		$this->assertSame( 'test-image-25x25.jpg', wp_basename( $image ) );
@@ -32,7 +32,7 @@ abstract class WP_Tests_Image_Resize_UnitTestCase extends WP_Image_UnitTestCase 
 		unlink( $image );
 	}
 
-	function test_resize_png() {
+	public function test_resize_png() {
 		$image = $this->resize_helper( DIR_TESTDATA . '/images/test-image.png', 25, 25 );
 
 		if ( ! is_string( $image ) ) {  // WP_Error, stop GLib-GObject-CRITICAL assertion.
@@ -48,7 +48,7 @@ abstract class WP_Tests_Image_Resize_UnitTestCase extends WP_Image_UnitTestCase 
 		unlink( $image );
 	}
 
-	function test_resize_gif() {
+	public function test_resize_gif() {
 		$image = $this->resize_helper( DIR_TESTDATA . '/images/test-image.gif', 25, 25 );
 
 		if ( ! is_string( $image ) ) {  // WP_Error, stop GLib-GObject-CRITICAL assertion.
@@ -64,7 +64,7 @@ abstract class WP_Tests_Image_Resize_UnitTestCase extends WP_Image_UnitTestCase 
 		unlink( $image );
 	}
 
-	function test_resize_webp() {
+	public function test_resize_webp() {
 		$file   = DIR_TESTDATA . '/images/test-image.webp';
 		$editor = wp_get_image_editor( $file );
 
@@ -82,7 +82,7 @@ abstract class WP_Tests_Image_Resize_UnitTestCase extends WP_Image_UnitTestCase 
 		unlink( $image );
 	}
 
-	function test_resize_larger() {
+	public function test_resize_larger() {
 		// image_resize() should refuse to make an image larger.
 		$image = $this->resize_helper( DIR_TESTDATA . '/images/test-image.jpg', 100, 100 );
 
@@ -90,7 +90,7 @@ abstract class WP_Tests_Image_Resize_UnitTestCase extends WP_Image_UnitTestCase 
 		$this->assertSame( 'error_getting_dimensions', $image->get_error_code() );
 	}
 
-	function test_resize_thumb_128x96() {
+	public function test_resize_thumb_128x96() {
 		$image = $this->resize_helper( DIR_TESTDATA . '/images/2007-06-17DSC_4173.JPG', 128, 96 );
 
 		$this->assertSame( '2007-06-17DSC_4173-64x96.jpg', wp_basename( $image ) );
@@ -102,7 +102,7 @@ abstract class WP_Tests_Image_Resize_UnitTestCase extends WP_Image_UnitTestCase 
 		unlink( $image );
 	}
 
-	function test_resize_thumb_128x0() {
+	public function test_resize_thumb_128x0() {
 		$image = $this->resize_helper( DIR_TESTDATA . '/images/2007-06-17DSC_4173.JPG', 128, 0 );
 
 		$this->assertSame( '2007-06-17DSC_4173-128x193.jpg', wp_basename( $image ) );
@@ -114,7 +114,7 @@ abstract class WP_Tests_Image_Resize_UnitTestCase extends WP_Image_UnitTestCase 
 		unlink( $image );
 	}
 
-	function test_resize_thumb_0x96() {
+	public function test_resize_thumb_0x96() {
 		$image = $this->resize_helper( DIR_TESTDATA . '/images/2007-06-17DSC_4173.JPG', 0, 96 );
 
 		$this->assertSame( '2007-06-17DSC_4173-64x96.jpg', wp_basename( $image ) );
@@ -126,7 +126,7 @@ abstract class WP_Tests_Image_Resize_UnitTestCase extends WP_Image_UnitTestCase 
 		unlink( $image );
 	}
 
-	function test_resize_thumb_150x150_crop() {
+	public function test_resize_thumb_150x150_crop() {
 		$image = $this->resize_helper( DIR_TESTDATA . '/images/2007-06-17DSC_4173.JPG', 150, 150, true );
 
 		$this->assertSame( '2007-06-17DSC_4173-150x150.jpg', wp_basename( $image ) );
@@ -138,7 +138,7 @@ abstract class WP_Tests_Image_Resize_UnitTestCase extends WP_Image_UnitTestCase 
 		unlink( $image );
 	}
 
-	function test_resize_thumb_150x100_crop() {
+	public function test_resize_thumb_150x100_crop() {
 		$image = $this->resize_helper( DIR_TESTDATA . '/images/2007-06-17DSC_4173.JPG', 150, 100, true );
 
 		$this->assertSame( '2007-06-17DSC_4173-150x100.jpg', wp_basename( $image ) );
@@ -150,7 +150,7 @@ abstract class WP_Tests_Image_Resize_UnitTestCase extends WP_Image_UnitTestCase 
 		unlink( $image );
 	}
 
-	function test_resize_thumb_50x150_crop() {
+	public function test_resize_thumb_50x150_crop() {
 		$image = $this->resize_helper( DIR_TESTDATA . '/images/2007-06-17DSC_4173.JPG', 50, 150, true );
 
 		$this->assertSame( '2007-06-17DSC_4173-50x150.jpg', wp_basename( $image ) );

--- a/tests/phpunit/tests/image/siteIcon.php
+++ b/tests/phpunit/tests/image/siteIcon.php
@@ -19,12 +19,12 @@ class Tests_WP_Site_Icon extends WP_UnitTestCase {
 	}
 
 	public function tear_down() {
-		$this->_remove_custom_logo();
+		$this->remove_custom_logo();
 		$this->remove_added_uploads();
 		parent::tear_down();
 	}
 
-	private function _remove_custom_logo() {
+	private function remove_custom_logo() {
 		remove_theme_mod( 'custom_logo' );
 	}
 
@@ -40,7 +40,7 @@ class Tests_WP_Site_Icon extends WP_UnitTestCase {
 	}
 
 	public function test_intermediate_image_sizes_with_filter() {
-		add_filter( 'site_icon_image_sizes', array( $this, '_custom_test_sizes' ) );
+		add_filter( 'site_icon_image_sizes', array( $this, 'custom_test_sizes' ) );
 		$image_sizes = $this->wp_site_icon->intermediate_image_sizes( array() );
 
 		$sizes = array();
@@ -57,7 +57,7 @@ class Tests_WP_Site_Icon extends WP_UnitTestCase {
 		// Remove custom size.
 		unset( $this->wp_site_icon->site_icon_sizes[ array_search( 321, $this->wp_site_icon->site_icon_sizes, true ) ] );
 		// Remove the filter we added.
-		remove_filter( 'site_icon_image_sizes', array( $this, '_custom_test_sizes' ) );
+		remove_filter( 'site_icon_image_sizes', array( $this, 'custom_test_sizes' ) );
 	}
 
 	public function test_additional_sizes() {
@@ -76,7 +76,7 @@ class Tests_WP_Site_Icon extends WP_UnitTestCase {
 	}
 
 	public function test_additional_sizes_with_filter() {
-		add_filter( 'site_icon_image_sizes', array( $this, '_custom_test_sizes' ) );
+		add_filter( 'site_icon_image_sizes', array( $this, 'custom_test_sizes' ) );
 		$image_sizes = $this->wp_site_icon->additional_sizes( array() );
 
 		$sizes = array();
@@ -99,7 +99,7 @@ class Tests_WP_Site_Icon extends WP_UnitTestCase {
 	}
 
 	public function test_create_attachment_object() {
-		$attachment_id = $this->_insert_attachment();
+		$attachment_id = $this->insert_attachment();
 		$parent_url    = get_post( $attachment_id )->guid;
 		$cropped       = str_replace( wp_basename( $parent_url ), 'cropped-test-image.jpg', $parent_url );
 
@@ -113,7 +113,7 @@ class Tests_WP_Site_Icon extends WP_UnitTestCase {
 	}
 
 	public function test_insert_cropped_attachment() {
-		$attachment_id = $this->_insert_attachment();
+		$attachment_id = $this->insert_attachment();
 		$parent_url    = get_post( $attachment_id )->guid;
 		$cropped       = str_replace( wp_basename( $parent_url ), 'cropped-test-image.jpg', $parent_url );
 
@@ -125,7 +125,7 @@ class Tests_WP_Site_Icon extends WP_UnitTestCase {
 	}
 
 	public function test_delete_attachment_data() {
-		$attachment_id = $this->_insert_attachment();
+		$attachment_id = $this->insert_attachment();
 		update_option( 'site_icon', $attachment_id );
 
 		wp_delete_attachment( $attachment_id, true );
@@ -137,7 +137,7 @@ class Tests_WP_Site_Icon extends WP_UnitTestCase {
 	 * @ticket 34368
 	 */
 	public function test_get_post_metadata() {
-		$attachment_id = $this->_insert_attachment();
+		$attachment_id = $this->insert_attachment();
 		update_option( 'site_icon', $attachment_id );
 
 		$this->wp_site_icon->get_post_metadata( '', $attachment_id, '_some_post_meta', true );
@@ -149,13 +149,13 @@ class Tests_WP_Site_Icon extends WP_UnitTestCase {
 		wp_delete_attachment( $attachment_id, true );
 	}
 
-	public function _custom_test_sizes( $sizes ) {
+	public function custom_test_sizes( $sizes ) {
 		$sizes[] = 321;
 
 		return $sizes;
 	}
 
-	private function _insert_attachment() {
+	private function insert_attachment() {
 		if ( $this->attachment_id ) {
 			return $this->attachment_id;
 		}

--- a/tests/phpunit/tests/image/siteIcon.php
+++ b/tests/phpunit/tests/image/siteIcon.php
@@ -12,23 +12,23 @@ class Tests_WP_Site_Icon extends WP_UnitTestCase {
 
 	public $attachment_id = 0;
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		$this->wp_site_icon = new WP_Site_Icon();
 	}
 
-	function tear_down() {
+	public function tear_down() {
 		$this->_remove_custom_logo();
 		$this->remove_added_uploads();
 		parent::tear_down();
 	}
 
-	function _remove_custom_logo() {
+	private function _remove_custom_logo() {
 		remove_theme_mod( 'custom_logo' );
 	}
 
-	function test_intermediate_image_sizes() {
+	public function test_intermediate_image_sizes() {
 		$image_sizes = $this->wp_site_icon->intermediate_image_sizes( array() );
 
 		$sizes = array();
@@ -39,7 +39,7 @@ class Tests_WP_Site_Icon extends WP_UnitTestCase {
 		$this->assertSame( $sizes, $image_sizes );
 	}
 
-	function test_intermediate_image_sizes_with_filter() {
+	public function test_intermediate_image_sizes_with_filter() {
 		add_filter( 'site_icon_image_sizes', array( $this, '_custom_test_sizes' ) );
 		$image_sizes = $this->wp_site_icon->intermediate_image_sizes( array() );
 
@@ -60,7 +60,7 @@ class Tests_WP_Site_Icon extends WP_UnitTestCase {
 		remove_filter( 'site_icon_image_sizes', array( $this, '_custom_test_sizes' ) );
 	}
 
-	function test_additional_sizes() {
+	public function test_additional_sizes() {
 		$image_sizes = $this->wp_site_icon->additional_sizes( array() );
 
 		$sizes = array();
@@ -75,7 +75,7 @@ class Tests_WP_Site_Icon extends WP_UnitTestCase {
 		$this->assertSame( $sizes, $image_sizes );
 	}
 
-	function test_additional_sizes_with_filter() {
+	public function test_additional_sizes_with_filter() {
 		add_filter( 'site_icon_image_sizes', array( $this, '_custom_test_sizes' ) );
 		$image_sizes = $this->wp_site_icon->additional_sizes( array() );
 
@@ -98,7 +98,7 @@ class Tests_WP_Site_Icon extends WP_UnitTestCase {
 		unset( $this->wp_site_icon->site_icon_sizes[ array_search( 321, $this->wp_site_icon->site_icon_sizes, true ) ] );
 	}
 
-	function test_create_attachment_object() {
+	public function test_create_attachment_object() {
 		$attachment_id = $this->_insert_attachment();
 		$parent_url    = get_post( $attachment_id )->guid;
 		$cropped       = str_replace( wp_basename( $parent_url ), 'cropped-test-image.jpg', $parent_url );
@@ -112,7 +112,7 @@ class Tests_WP_Site_Icon extends WP_UnitTestCase {
 		$this->assertSame( $object['guid'], $cropped );
 	}
 
-	function test_insert_cropped_attachment() {
+	public function test_insert_cropped_attachment() {
 		$attachment_id = $this->_insert_attachment();
 		$parent_url    = get_post( $attachment_id )->guid;
 		$cropped       = str_replace( wp_basename( $parent_url ), 'cropped-test-image.jpg', $parent_url );
@@ -124,7 +124,7 @@ class Tests_WP_Site_Icon extends WP_UnitTestCase {
 		$this->assertGreaterThan( 0, $cropped_id );
 	}
 
-	function test_delete_attachment_data() {
+	public function test_delete_attachment_data() {
 		$attachment_id = $this->_insert_attachment();
 		update_option( 'site_icon', $attachment_id );
 
@@ -136,7 +136,7 @@ class Tests_WP_Site_Icon extends WP_UnitTestCase {
 	/**
 	 * @ticket 34368
 	 */
-	function test_get_post_metadata() {
+	public function test_get_post_metadata() {
 		$attachment_id = $this->_insert_attachment();
 		update_option( 'site_icon', $attachment_id );
 
@@ -149,13 +149,13 @@ class Tests_WP_Site_Icon extends WP_UnitTestCase {
 		wp_delete_attachment( $attachment_id, true );
 	}
 
-	function _custom_test_sizes( $sizes ) {
+	public function _custom_test_sizes( $sizes ) {
 		$sizes[] = 321;
 
 		return $sizes;
 	}
 
-	function _insert_attachment() {
+	private function _insert_attachment() {
 		if ( $this->attachment_id ) {
 			return $this->attachment_id;
 		}

--- a/tests/phpunit/tests/image/size.php
+++ b/tests/phpunit/tests/image/size.php
@@ -7,7 +7,7 @@
  */
 class Tests_Image_Size extends WP_UnitTestCase {
 
-	function test_constrain_dims_zero() {
+	public function test_constrain_dims_zero() {
 		// No constraint - should have no effect.
 		$out = wp_constrain_dimensions( 640, 480, 0, 0 );
 		$this->assertSame( array( 640, 480 ), $out );
@@ -22,7 +22,7 @@ class Tests_Image_Size extends WP_UnitTestCase {
 		$this->assertSame( array( 118, 177 ), $out );
 	}
 
-	function test_constrain_dims_smaller() {
+	public function test_constrain_dims_smaller() {
 		// Image size is smaller than the constraint - no effect.
 		$out = wp_constrain_dimensions( 500, 600, 1024, 768 );
 		$this->assertSame( array( 500, 600 ), $out );
@@ -34,7 +34,7 @@ class Tests_Image_Size extends WP_UnitTestCase {
 		$this->assertSame( array( 500, 600 ), $out );
 	}
 
-	function test_constrain_dims_equal() {
+	public function test_constrain_dims_equal() {
 		// Image size is equal to the constraint - no effect.
 		$out = wp_constrain_dimensions( 1024, 768, 1024, 768 );
 		$this->assertSame( array( 1024, 768 ), $out );
@@ -46,7 +46,7 @@ class Tests_Image_Size extends WP_UnitTestCase {
 		$this->assertSame( array( 1024, 768 ), $out );
 	}
 
-	function test_constrain_dims_larger() {
+	public function test_constrain_dims_larger() {
 		// Image size is larger than the constraint - result should be constrained.
 		$out = wp_constrain_dimensions( 1024, 768, 500, 600 );
 		$this->assertSame( array( 500, 375 ), $out );
@@ -68,7 +68,7 @@ class Tests_Image_Size extends WP_UnitTestCase {
 		$this->assertSame( array( 200, 533 ), $out );
 	}
 
-	function test_constrain_dims_boundary() {
+	public function test_constrain_dims_boundary() {
 		// One dimension is larger than the constraint, one smaller - result should be constrained.
 		$out = wp_constrain_dimensions( 1024, 768, 500, 800 );
 		$this->assertSame( array( 500, 375 ), $out );
@@ -87,7 +87,7 @@ class Tests_Image_Size extends WP_UnitTestCase {
 	/**
 	 * @expectedDeprecated wp_shrink_dimensions
 	 */
-	function test_shrink_dimensions_default() {
+	public function test_shrink_dimensions_default() {
 		$out = wp_shrink_dimensions( 640, 480 );
 		$this->assertSame( array( 128, 96 ), $out );
 
@@ -98,7 +98,7 @@ class Tests_Image_Size extends WP_UnitTestCase {
 	/**
 	 * @expectedDeprecated wp_shrink_dimensions
 	 */
-	function test_shrink_dimensions_smaller() {
+	public function test_shrink_dimensions_smaller() {
 		// Image size is smaller than the constraint - no effect.
 		$out = wp_shrink_dimensions( 500, 600, 1024, 768 );
 		$this->assertSame( array( 500, 600 ), $out );
@@ -110,7 +110,7 @@ class Tests_Image_Size extends WP_UnitTestCase {
 	/**
 	 * @expectedDeprecated wp_shrink_dimensions
 	 */
-	function test_shrink_dimensions_equal() {
+	public function test_shrink_dimensions_equal() {
 		// Image size is equal to the constraint - no effect.
 		$out = wp_shrink_dimensions( 500, 600, 500, 600 );
 		$this->assertSame( array( 500, 600 ), $out );
@@ -122,7 +122,7 @@ class Tests_Image_Size extends WP_UnitTestCase {
 	/**
 	 * @expectedDeprecated wp_shrink_dimensions
 	 */
-	function test_shrink_dimensions_larger() {
+	public function test_shrink_dimensions_larger() {
 		// Image size is larger than the constraint - result should be constrained.
 		$out = wp_shrink_dimensions( 1024, 768, 500, 600 );
 		$this->assertSame( array( 500, 375 ), $out );
@@ -134,7 +134,7 @@ class Tests_Image_Size extends WP_UnitTestCase {
 	/**
 	 * @expectedDeprecated wp_shrink_dimensions
 	 */
-	function test_shrink_dimensions_boundary() {
+	public function test_shrink_dimensions_boundary() {
 		// One dimension is larger than the constraint, one smaller - result should be constrained.
 		$out = wp_shrink_dimensions( 1024, 768, 500, 800 );
 		$this->assertSame( array( 500, 375 ), $out );
@@ -150,7 +150,7 @@ class Tests_Image_Size extends WP_UnitTestCase {
 		$this->assertSame( array( 525, 700 ), $out );
 	}
 
-	function test_constrain_size_for_editor_thumb() {
+	public function test_constrain_size_for_editor_thumb() {
 		$out = image_constrain_size_for_editor( 600, 400, 'thumb' );
 		$this->assertSame( array( 150, 100 ), $out );
 
@@ -158,7 +158,7 @@ class Tests_Image_Size extends WP_UnitTestCase {
 		$this->assertSame( array( 64, 64 ), $out );
 	}
 
-	function test_constrain_size_for_editor_medium() {
+	public function test_constrain_size_for_editor_medium() {
 		// Default max width is 500, no constraint on height.
 		global $content_width;
 
@@ -185,7 +185,7 @@ class Tests_Image_Size extends WP_UnitTestCase {
 		$content_width = $_content_width;
 	}
 
-	function test_constrain_size_for_editor_full() {
+	public function test_constrain_size_for_editor_full() {
 		global $content_width;
 
 		$_content_width = $content_width;

--- a/tests/phpunit/tests/import/import.php
+++ b/tests/phpunit/tests/import/import.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/base.php';
  * @group import
  */
 class Tests_Import_Import extends WP_Import_UnitTestCase {
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		if ( ! defined( 'WP_IMPORTING' ) ) {
@@ -33,7 +33,7 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 		}
 	}
 
-	function test_small_import() {
+	public function test_small_import() {
 		global $wpdb;
 
 		$authors = array(
@@ -201,7 +201,7 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 		$this->assertCount( 1, $cats );
 	}
 
-	function test_double_import() {
+	public function test_double_import() {
 		$authors = array(
 			'admin'  => false,
 			'editor' => false,
@@ -242,7 +242,7 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 		$this->assertSame( 1, $comment_count->total_comments );
 	}
 
-	function test_ordering_of_importers() {
+	public function test_ordering_of_importers() {
 		global $wp_importers;
 		$_wp_importers = $wp_importers; // Preserve global state.
 		$wp_importers  = array(

--- a/tests/phpunit/tests/import/parser.php
+++ b/tests/phpunit/tests/import/parser.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/base.php';
  * @group import
  */
 class Tests_Import_Parser extends WP_Import_UnitTestCase {
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		if ( ! defined( 'WP_IMPORTING' ) ) {
@@ -24,7 +24,7 @@ class Tests_Import_Parser extends WP_Import_UnitTestCase {
 		require_once DIR_TESTDATA . '/plugins/wordpress-importer/wordpress-importer.php';
 	}
 
-	function test_malformed_wxr() {
+	public function test_malformed_wxr() {
 		$file = DIR_TESTDATA . '/export/malformed.xml';
 
 		// Regex based parser cannot detect malformed XML.
@@ -36,7 +36,7 @@ class Tests_Import_Parser extends WP_Import_UnitTestCase {
 		}
 	}
 
-	function test_invalid_wxr() {
+	public function test_invalid_wxr() {
 		$f1 = DIR_TESTDATA . '/export/missing-version-tag.xml';
 		$f2 = DIR_TESTDATA . '/export/invalid-version-tag.xml';
 
@@ -50,7 +50,7 @@ class Tests_Import_Parser extends WP_Import_UnitTestCase {
 		}
 	}
 
-	function test_wxr_version_1_1() {
+	public function test_wxr_version_1_1() {
 		$file = DIR_TESTDATA . '/export/valid-wxr-1.1.xml';
 
 		foreach ( array( 'WXR_Parser_SimpleXML', 'WXR_Parser_XML', 'WXR_Parser_Regex' ) as $p ) {
@@ -143,7 +143,7 @@ class Tests_Import_Parser extends WP_Import_UnitTestCase {
 		}
 	}
 
-	function test_wxr_version_1_0() {
+	public function test_wxr_version_1_0() {
 		$file = DIR_TESTDATA . '/export/valid-wxr-1.0.xml';
 
 		foreach ( array( 'WXR_Parser_SimpleXML', 'WXR_Parser_XML', 'WXR_Parser_Regex' ) as $p ) {
@@ -237,7 +237,7 @@ class Tests_Import_Parser extends WP_Import_UnitTestCase {
 	 *
 	 * @link https://core.trac.wordpress.org/ticket/15203
 	 */
-	function test_escaped_cdata_closing_sequence() {
+	public function test_escaped_cdata_closing_sequence() {
 		$file = DIR_TESTDATA . '/export/crazy-cdata-escaped.xml';
 
 		foreach ( array( 'WXR_Parser_SimpleXML', 'WXR_Parser_XML', 'WXR_Parser_Regex' ) as $p ) {
@@ -270,7 +270,7 @@ class Tests_Import_Parser extends WP_Import_UnitTestCase {
 	 * Ensure that the regex parser can still parse invalid CDATA blocks (i.e. those
 	 * with "]]>" unescaped within a CDATA section).
 	 */
-	function test_unescaped_cdata_closing_sequence() {
+	public function test_unescaped_cdata_closing_sequence() {
 		$file = DIR_TESTDATA . '/export/crazy-cdata.xml';
 
 		$parser = new WXR_Parser_Regex;

--- a/tests/phpunit/tests/import/postmeta.php
+++ b/tests/phpunit/tests/import/postmeta.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/base.php';
  * @group import
  */
 class Tests_Import_Postmeta extends WP_Import_UnitTestCase {
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		if ( ! defined( 'WP_IMPORTING' ) ) {
@@ -24,14 +24,14 @@ class Tests_Import_Postmeta extends WP_Import_UnitTestCase {
 		require_once DIR_TESTDATA . '/plugins/wordpress-importer/wordpress-importer.php';
 	}
 
-	function test_serialized_postmeta_no_cdata() {
+	public function test_serialized_postmeta_no_cdata() {
 		$this->_import_wp( DIR_TESTDATA . '/export/test-serialized-postmeta-no-cdata.xml', array( 'johncoswell' => 'john' ) );
 		$expected['special_post_title'] = 'A special title';
 		$expected['is_calendar']        = '';
 		$this->assertSame( $expected, get_post_meta( 122, 'post-options', true ) );
 	}
 
-	function test_utw_postmeta() {
+	public function test_utw_postmeta() {
 		$this->_import_wp( DIR_TESTDATA . '/export/test-utw-post-meta-import.xml', array( 'johncoswell' => 'john' ) );
 
 		$classy      = new StdClass();
@@ -80,7 +80,7 @@ class Tests_Import_Postmeta extends WP_Import_UnitTestCase {
 	/**
 	 * @ticket 9633
 	 */
-	function test_serialized_postmeta_with_cdata() {
+	public function test_serialized_postmeta_with_cdata() {
 		$this->_import_wp( DIR_TESTDATA . '/export/test-serialized-postmeta-with-cdata.xml', array( 'johncoswell' => 'johncoswell' ) );
 
 		// HTML in the CDATA should work with old WordPress version.
@@ -94,7 +94,7 @@ class Tests_Import_Postmeta extends WP_Import_UnitTestCase {
 	/**
 	 * @ticket 11574
 	 */
-	function test_serialized_postmeta_with_evil_stuff_in_cdata() {
+	public function test_serialized_postmeta_with_evil_stuff_in_cdata() {
 		$this->_import_wp( DIR_TESTDATA . '/export/test-serialized-postmeta-with-cdata.xml', array( 'johncoswell' => 'johncoswell' ) );
 		// Evil content in the CDATA.
 		$this->assertSame( '<wp:meta_value>evil</wp:meta_value>', get_post_meta( 10, 'evil', true ) );

--- a/tests/phpunit/tests/includes/factory.php
+++ b/tests/phpunit/tests/includes/factory.php
@@ -1,28 +1,28 @@
 <?php
 
 class TestFactoryFor extends WP_UnitTestCase {
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 		$this->category_factory = new WP_UnitTest_Factory_For_Term( null, 'category' );
 	}
 
-	function test_create_creates_a_category() {
+	public function test_create_creates_a_category() {
 		$id = $this->category_factory->create();
 		$this->assertTrue( (bool) get_term_by( 'id', $id, 'category' ) );
 	}
 
-	function test_get_object_by_id_gets_an_object() {
+	public function test_get_object_by_id_gets_an_object() {
 		$id = $this->category_factory->create();
 		$this->assertTrue( (bool) $this->category_factory->get_object_by_id( $id ) );
 	}
 
-	function test_get_object_by_id_gets_an_object_with_the_same_name() {
+	public function test_get_object_by_id_gets_an_object_with_the_same_name() {
 		$id     = $this->category_factory->create( array( 'name' => 'Boo' ) );
 		$object = $this->category_factory->get_object_by_id( $id );
 		$this->assertSame( 'Boo', $object->name );
 	}
 
-	function test_the_taxonomy_argument_overrules_the_factory_taxonomy() {
+	public function test_the_taxonomy_argument_overrules_the_factory_taxonomy() {
 		$term_factory = new WP_UnitTest_Factory_For_term( null, 'category' );
 		$id           = $term_factory->create( array( 'taxonomy' => 'post_tag' ) );
 		$term         = get_term( $id, 'post_tag' );

--- a/tests/phpunit/tests/includes/helpers.php
+++ b/tests/phpunit/tests/includes/helpers.php
@@ -7,7 +7,7 @@ class Tests_TestHelpers extends WP_UnitTestCase {
 	/**
 	 * @ticket 30522
 	 */
-	function data_assertSameSets() {
+	public function data_assertSameSets() {
 		return array(
 			array(
 				array( 1, 2, 3 ), // Test expected.
@@ -51,7 +51,7 @@ class Tests_TestHelpers extends WP_UnitTestCase {
 	 * @dataProvider data_assertSameSets
 	 * @ticket 30522
 	 */
-	function test_assertSameSets( $expected, $actual, $exception ) {
+	public function test_assertSameSets( $expected, $actual, $exception ) {
 		if ( $exception ) {
 			try {
 				$this->assertSameSets( $expected, $actual );
@@ -68,7 +68,7 @@ class Tests_TestHelpers extends WP_UnitTestCase {
 	/**
 	 * @ticket 30522
 	 */
-	function data_assertSameSetsWithIndex() {
+	public function data_assertSameSetsWithIndex() {
 		return array(
 			array(
 				array( 1, 2, 3 ), // Test expected.
@@ -207,7 +207,7 @@ class Tests_TestHelpers extends WP_UnitTestCase {
 	 * @dataProvider data_assertSameSetsWithIndex
 	 * @ticket 30522
 	 */
-	function test_assertSameSetsWithIndex( $expected, $actual, $exception ) {
+	public function test_assertSameSetsWithIndex( $expected, $actual, $exception ) {
 		if ( $exception ) {
 			try {
 				$this->assertSameSetsWithIndex( $expected, $actual );

--- a/tests/phpunit/tests/l10n/loadTextdomain.php
+++ b/tests/phpunit/tests/l10n/loadTextdomain.php
@@ -125,9 +125,9 @@ class Tests_L10n_LoadTextdomain extends WP_UnitTestCase {
 	}
 
 	public function test_override_load_textdomain_non_existent_mofile() {
-		add_filter( 'override_load_textdomain', array( $this, '_override_load_textdomain_filter' ), 10, 3 );
+		add_filter( 'override_load_textdomain', array( $this, 'override_load_textdomain_filter' ), 10, 3 );
 		$load_textdomain = load_textdomain( 'wp-tests-domain', WP_LANG_DIR . '/non-existent-file.mo' );
-		remove_filter( 'override_load_textdomain', array( $this, '_override_load_textdomain_filter' ) );
+		remove_filter( 'override_load_textdomain', array( $this, 'override_load_textdomain_filter' ) );
 
 		$is_textdomain_loaded = is_textdomain_loaded( 'wp-tests-domain' );
 		unload_textdomain( 'wp-tests-domain' );
@@ -139,9 +139,9 @@ class Tests_L10n_LoadTextdomain extends WP_UnitTestCase {
 	}
 
 	public function test_override_load_textdomain_custom_mofile() {
-		add_filter( 'override_load_textdomain', array( $this, '_override_load_textdomain_filter' ), 10, 3 );
+		add_filter( 'override_load_textdomain', array( $this, 'override_load_textdomain_filter' ), 10, 3 );
 		$load_textdomain = load_textdomain( 'wp-tests-domain', WP_LANG_DIR . '/plugins/internationalized-plugin-de_DE.mo' );
-		remove_filter( 'override_load_textdomain', array( $this, '_override_load_textdomain_filter' ) );
+		remove_filter( 'override_load_textdomain', array( $this, 'override_load_textdomain_filter' ) );
 
 		$is_textdomain_loaded = is_textdomain_loaded( 'wp-tests-domain' );
 		unload_textdomain( 'wp-tests-domain' );
@@ -158,7 +158,7 @@ class Tests_L10n_LoadTextdomain extends WP_UnitTestCase {
 	 * @param string $file     Path to the MO file.
 	 * @return bool
 	 */
-	public function _override_load_textdomain_filter( $override, $domain, $file ) {
+	public function override_load_textdomain_filter( $override, $domain, $file ) {
 		global $l10n;
 
 		if ( ! is_readable( $file ) ) {

--- a/tests/phpunit/tests/l10n/loadTextdomain.php
+++ b/tests/phpunit/tests/l10n/loadTextdomain.php
@@ -109,13 +109,13 @@ class Tests_L10n_LoadTextdomain extends WP_UnitTestCase {
 	/**
 	 * @ticket 21319
 	 */
-	function test_is_textdomain_is_not_loaded_after_gettext_call_with_no_translations() {
+	public function test_is_textdomain_is_not_loaded_after_gettext_call_with_no_translations() {
 		$this->assertFalse( is_textdomain_loaded( 'wp-tests-domain' ) );
 		__( 'just some string', 'wp-tests-domain' );
 		$this->assertFalse( is_textdomain_loaded( 'wp-tests-domain' ) );
 	}
 
-	function test_override_load_textdomain_noop() {
+	public function test_override_load_textdomain_noop() {
 		add_filter( 'override_load_textdomain', '__return_true' );
 		$load_textdomain = load_textdomain( 'wp-tests-domain', DIR_TESTDATA . '/non-existent-file' );
 		remove_filter( 'override_load_textdomain', '__return_true' );
@@ -124,7 +124,7 @@ class Tests_L10n_LoadTextdomain extends WP_UnitTestCase {
 		$this->assertFalse( is_textdomain_loaded( 'wp-tests-domain' ) );
 	}
 
-	function test_override_load_textdomain_non_existent_mofile() {
+	public function test_override_load_textdomain_non_existent_mofile() {
 		add_filter( 'override_load_textdomain', array( $this, '_override_load_textdomain_filter' ), 10, 3 );
 		$load_textdomain = load_textdomain( 'wp-tests-domain', WP_LANG_DIR . '/non-existent-file.mo' );
 		remove_filter( 'override_load_textdomain', array( $this, '_override_load_textdomain_filter' ) );
@@ -138,7 +138,7 @@ class Tests_L10n_LoadTextdomain extends WP_UnitTestCase {
 		$this->assertFalse( $is_textdomain_loaded_after );
 	}
 
-	function test_override_load_textdomain_custom_mofile() {
+	public function test_override_load_textdomain_custom_mofile() {
 		add_filter( 'override_load_textdomain', array( $this, '_override_load_textdomain_filter' ), 10, 3 );
 		$load_textdomain = load_textdomain( 'wp-tests-domain', WP_LANG_DIR . '/plugins/internationalized-plugin-de_DE.mo' );
 		remove_filter( 'override_load_textdomain', array( $this, '_override_load_textdomain_filter' ) );
@@ -158,7 +158,7 @@ class Tests_L10n_LoadTextdomain extends WP_UnitTestCase {
 	 * @param string $file     Path to the MO file.
 	 * @return bool
 	 */
-	function _override_load_textdomain_filter( $override, $domain, $file ) {
+	public function _override_load_textdomain_filter( $override, $domain, $file ) {
 		global $l10n;
 
 		if ( ! is_readable( $file ) ) {

--- a/tests/phpunit/tests/l10n/translateSettingsUsingI18nSchema.php
+++ b/tests/phpunit/tests/l10n/translateSettingsUsingI18nSchema.php
@@ -10,14 +10,14 @@ class Tests_L10n_TranslateSettingsUsingI18nSchema extends WP_UnitTestCase {
 	 *
 	 * @return string
 	 */
-	function filter_set_locale_to_polish() {
+	public function filter_set_locale_to_polish() {
 		return 'pl_PL';
 	}
 
 	/**
 	 * @ticket 53238
 	 */
-	function test_translate_settings_using_i18n_schema() {
+	public function test_translate_settings_using_i18n_schema() {
 		$textdomain = 'notice';
 
 		add_filter( 'locale', array( $this, 'filter_set_locale_to_polish' ) );

--- a/tests/phpunit/tests/link/getAdjacentPost.php
+++ b/tests/phpunit/tests/link/getAdjacentPost.php
@@ -89,7 +89,7 @@ class Tests_Link_GetAdjacentPost extends WP_UnitTestCase {
 	/**
 	 * @ticket 22112
 	 */
-	function test_get_adjacent_post_exclude_self_term() {
+	public function test_get_adjacent_post_exclude_self_term() {
 		// Bump term_taxonomy to mimic shared term offsets.
 		global $wpdb;
 		$wpdb->insert(

--- a/tests/phpunit/tests/load/wpConvertHrToBytes.php
+++ b/tests/phpunit/tests/load/wpConvertHrToBytes.php
@@ -17,7 +17,7 @@ class Tests_Load_wpConvertHrToBytes extends WP_UnitTestCase {
 	 * @param int|string $value    The value passed to wp_convert_hr_to_bytes().
 	 * @param int        $expected The expected output of wp_convert_hr_to_bytes().
 	 */
-	function test_wp_convert_hr_to_bytes( $value, $expected ) {
+	public function test_wp_convert_hr_to_bytes( $value, $expected ) {
 		$this->assertSame( $expected, wp_convert_hr_to_bytes( $value ) );
 	}
 
@@ -31,7 +31,7 @@ class Tests_Load_wpConvertHrToBytes extends WP_UnitTestCase {
 	 *     }
 	 * }
 	 */
-	function data_wp_convert_hr_to_bytes() {
+	public function data_wp_convert_hr_to_bytes() {
 		$array = array(
 			// Integer input.
 			array( -1, -1 ), // = no memory limit.

--- a/tests/phpunit/tests/load/wpIsIniValueChangeable.php
+++ b/tests/phpunit/tests/load/wpIsIniValueChangeable.php
@@ -18,7 +18,7 @@ class Tests_Load_wpIsIniValueChangeable extends WP_UnitTestCase {
 	 * @param string $setting  The setting passed to wp_is_ini_value_changeable().
 	 * @param bool   $expected The expected output of wp_convert_hr_to_bytes().
 	 */
-	function test_wp_is_ini_value_changeable( $setting, $expected ) {
+	public function test_wp_is_ini_value_changeable( $setting, $expected ) {
 		$this->assertSame( $expected, wp_is_ini_value_changeable( $setting ) );
 	}
 
@@ -32,7 +32,7 @@ class Tests_Load_wpIsIniValueChangeable extends WP_UnitTestCase {
 	 *     }
 	 * }
 	 */
-	function data_wp_is_ini_value_changeable() {
+	public function data_wp_is_ini_value_changeable() {
 		$array = array(
 			array( 'memory_limit', true ), // PHP_INI_ALL.
 			array( 'log_errors', true ), // PHP_INI_ALL.

--- a/tests/phpunit/tests/media/getAdjacentImageLink.php
+++ b/tests/phpunit/tests/media/getAdjacentImageLink.php
@@ -18,7 +18,7 @@ class Tests_Media_GetAdjacentImageLink extends WP_Test_Adjacent_Image_Link_TestC
 	 *
 	 * @dataProvider data_get_adjacent_image_link
 	 */
-	function test_get_adjacent_image_link( $current_attachment_index, $expected_attachment_index, $expected, array $args = array() ) {
+	public function test_get_adjacent_image_link( $current_attachment_index, $expected_attachment_index, $expected, array $args = array() ) {
 		list( $expected, $args ) = $this->setup_test_scenario( $current_attachment_index, $expected_attachment_index, $expected, $args );
 
 		$actual = get_adjacent_image_link( ...$args );

--- a/tests/phpunit/tests/media/getNextImageLink.php
+++ b/tests/phpunit/tests/media/getNextImageLink.php
@@ -17,7 +17,7 @@ class Tests_Media_GetNextImageLink extends WP_Test_Adjacent_Image_Link_TestCase 
 	 *
 	 * @dataProvider data_get_next_image_link
 	 */
-	function test_get_next_image_link( $current_attachment_index, $expected_attachment_index, $expected, array $args = array() ) {
+	public function test_get_next_image_link( $current_attachment_index, $expected_attachment_index, $expected, array $args = array() ) {
 		list( $expected, $args ) = $this->setup_test_scenario( $current_attachment_index, $expected_attachment_index, $expected, $args );
 
 		$actual = get_next_image_link( ...$args );

--- a/tests/phpunit/tests/media/getPreviousImageLink.php
+++ b/tests/phpunit/tests/media/getPreviousImageLink.php
@@ -17,7 +17,7 @@ class Tests_Media_GetPreviousImageLink extends WP_Test_Adjacent_Image_Link_TestC
 	 *
 	 * @dataProvider data_get_previous_image_link
 	 */
-	function test_get_previous_image_link( $current_attachment_index, $expected_attachment_index, $expected, array $args = array() ) {
+	public function test_get_previous_image_link( $current_attachment_index, $expected_attachment_index, $expected, array $args = array() ) {
 		list( $expected, $args ) = $this->setup_test_scenario( $current_attachment_index, $expected_attachment_index, $expected, $args );
 
 		$actual = get_previous_image_link( ...$args );

--- a/tests/phpunit/tests/media/nextImageLink.php
+++ b/tests/phpunit/tests/media/nextImageLink.php
@@ -17,7 +17,7 @@ class Tests_Media_NextImageLink extends WP_Test_Adjacent_Image_Link_TestCase {
 	 *
 	 * @dataProvider data_next_image_link
 	 */
-	function test_next_image_link( $current_attachment_index, $expected_attachment_index, $expected, array $args = array() ) {
+	public function test_next_image_link( $current_attachment_index, $expected_attachment_index, $expected, array $args = array() ) {
 		list( $expected, $args ) = $this->setup_test_scenario( $current_attachment_index, $expected_attachment_index, $expected, $args );
 
 		$this->expectOutputString( $expected );

--- a/tests/phpunit/tests/media/previousImageLink.php
+++ b/tests/phpunit/tests/media/previousImageLink.php
@@ -17,7 +17,7 @@ class Tests_Media_PreviousImageLink extends WP_Test_Adjacent_Image_Link_TestCase
 	 *
 	 * @dataProvider data_previous_image_link
 	 */
-	function test_previous_image_link( $current_attachment_index, $expected_attachment_index, $expected, array $args = array() ) {
+	public function test_previous_image_link( $current_attachment_index, $expected_attachment_index, $expected, array $args = array() ) {
 		list( $expected, $args ) = $this->setup_test_scenario( $current_attachment_index, $expected_attachment_index, $expected, $args );
 
 		$this->expectOutputString( $expected );

--- a/tests/phpunit/tests/menu/nav-menu.php
+++ b/tests/phpunit/tests/menu/nav-menu.php
@@ -8,7 +8,7 @@ class Tests_Nav_Menu_Theme_Change extends WP_UnitTestCase {
 	/**
 	 * Set up.
 	 */
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		// Unregister all nav menu locations.
@@ -22,7 +22,7 @@ class Tests_Nav_Menu_Theme_Change extends WP_UnitTestCase {
 	 *
 	 * @param array $locations Location slugs.
 	 */
-	function register_nav_menu_locations( $locations ) {
+	private function register_nav_menu_locations( $locations ) {
 		foreach ( $locations as $location ) {
 			register_nav_menu( $location, ucfirst( $location ) );
 		}
@@ -33,7 +33,7 @@ class Tests_Nav_Menu_Theme_Change extends WP_UnitTestCase {
 	 *
 	 * @covers ::wp_map_nav_menu_locations
 	 */
-	function test_one_location_each() {
+	public function test_one_location_each() {
 		$this->register_nav_menu_locations( array( 'primary' ) );
 		$prev_theme_nav_menu_locations     = array(
 			'unique-slug' => 1,
@@ -52,7 +52,7 @@ class Tests_Nav_Menu_Theme_Change extends WP_UnitTestCase {
 	 *
 	 * @covers ::wp_map_nav_menu_locations
 	 */
-	function test_filter_registered_locations() {
+	public function test_filter_registered_locations() {
 		$this->register_nav_menu_locations( array( 'primary', 'secondary' ) );
 		$prev_theme_nav_menu_locations     = array(
 			'primary'   => 1,
@@ -74,7 +74,7 @@ class Tests_Nav_Menu_Theme_Change extends WP_UnitTestCase {
 	 *
 	 * @covers ::wp_map_nav_menu_locations
 	 */
-	function test_locations_with_same_slug() {
+	public function test_locations_with_same_slug() {
 		$this->register_nav_menu_locations( array( 'primary', 'secondary' ) );
 		$prev_theme_nav_menu_locations = array(
 			'primary'   => 1,
@@ -93,7 +93,7 @@ class Tests_Nav_Menu_Theme_Change extends WP_UnitTestCase {
 	 *
 	 * @covers ::wp_map_nav_menu_locations
 	 */
-	function test_new_theme_previously_active() {
+	public function test_new_theme_previously_active() {
 		$this->register_nav_menu_locations( array( 'primary' ) );
 
 		$prev_theme_nav_menu_locations = array(
@@ -117,7 +117,7 @@ class Tests_Nav_Menu_Theme_Change extends WP_UnitTestCase {
 	 *
 	 * @covers ::wp_map_nav_menu_locations
 	 */
-	function test_location_guessing() {
+	public function test_location_guessing() {
 		$this->register_nav_menu_locations( array( 'primary', 'secondary' ) );
 
 		$prev_theme_nav_menu_locations = array(
@@ -140,7 +140,7 @@ class Tests_Nav_Menu_Theme_Change extends WP_UnitTestCase {
 	 *
 	 * @covers ::wp_map_nav_menu_locations
 	 */
-	function test_location_guessing_one_menu_per_group() {
+	public function test_location_guessing_one_menu_per_group() {
 		$this->register_nav_menu_locations( array( 'primary' ) );
 		$prev_theme_nav_menu_locations = array(
 			'top-menu'  => 1,
@@ -161,7 +161,7 @@ class Tests_Nav_Menu_Theme_Change extends WP_UnitTestCase {
 	 *
 	 * @covers ::wp_map_nav_menu_locations
 	 */
-	function test_location_guessing_one_menu_per_location() {
+	public function test_location_guessing_one_menu_per_location() {
 		$this->register_nav_menu_locations( array( 'primary', 'main' ) );
 
 		$prev_theme_nav_menu_locations = array(
@@ -186,7 +186,7 @@ class Tests_Nav_Menu_Theme_Change extends WP_UnitTestCase {
 	 *
 	 * @covers ::wp_map_nav_menu_locations
 	 */
-	function test_numerical_locations() {
+	public function test_numerical_locations() {
 		$this->register_nav_menu_locations( array( 'primary', 1 ) );
 
 		$prev_theme_nav_menu_locations = array(

--- a/tests/phpunit/tests/menu/walker-nav-menu-edit.php
+++ b/tests/phpunit/tests/menu/walker-nav-menu-edit.php
@@ -7,7 +7,7 @@
 class Tests_Menu_Walker_Nav_Menu_Edit extends WP_UnitTestCase {
 	protected $_wp_nav_menu_max_depth;
 
-	function set_up() {
+	public function set_up() {
 		global $_wp_nav_menu_max_depth;
 
 		parent::set_up();
@@ -20,7 +20,7 @@ class Tests_Menu_Walker_Nav_Menu_Edit extends WP_UnitTestCase {
 		$this->_wp_nav_menu_max_depth = $_wp_nav_menu_max_depth;
 	}
 
-	function tear_down() {
+	public function tear_down() {
 		global $_wp_nav_menu_max_depth;
 
 		$_wp_nav_menu_max_depth = $this->_wp_nav_menu_max_depth;
@@ -31,7 +31,7 @@ class Tests_Menu_Walker_Nav_Menu_Edit extends WP_UnitTestCase {
 	/**
 	 * @ticket 36729
 	 */
-	function test_original_title_prefix_should_not_be_shown_if_empty() {
+	public function test_original_title_prefix_should_not_be_shown_if_empty() {
 		$expected = '';
 
 		$post_id = $this->factory->post->create();

--- a/tests/phpunit/tests/meta/slashes.php
+++ b/tests/phpunit/tests/meta/slashes.php
@@ -18,7 +18,7 @@ class Tests_Meta_Slashes extends WP_UnitTestCase {
 		self::$user_id    = $factory->user->create();
 	}
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		wp_set_current_user( self::$editor_id );
@@ -35,7 +35,7 @@ class Tests_Meta_Slashes extends WP_UnitTestCase {
 	/**
 	 * Tests the controller function that expects slashed data.
 	 */
-	function test_edit_post() {
+	public function test_edit_post() {
 		$post_id = self::$post_id;
 
 		if ( function_exists( 'wp_add_post_meta' ) ) {
@@ -112,7 +112,7 @@ class Tests_Meta_Slashes extends WP_UnitTestCase {
 	/**
 	 * Tests the legacy model function that expects slashed data.
 	 */
-	function test_add_post_meta() {
+	public function test_add_post_meta() {
 		$post_id = self::$post_id;
 
 		add_post_meta( $post_id, 'slash_test_1', addslashes( $this->slash_1 ) );
@@ -127,7 +127,7 @@ class Tests_Meta_Slashes extends WP_UnitTestCase {
 	/**
 	 * Tests the legacy model function that expects slashed data.
 	 */
-	function test_update_post_meta() {
+	public function test_update_post_meta() {
 		$post_id = self::$post_id;
 
 		update_post_meta( $post_id, 'slash_test_1', addslashes( $this->slash_1 ) );
@@ -142,7 +142,7 @@ class Tests_Meta_Slashes extends WP_UnitTestCase {
 	/**
 	 * Tests the model function that expects slashed data.
 	 */
-	function test_add_comment_meta() {
+	public function test_add_comment_meta() {
 		$comment_id = self::$comment_id;
 
 		add_comment_meta( $comment_id, 'slash_test_1', $this->slash_1 );
@@ -165,7 +165,7 @@ class Tests_Meta_Slashes extends WP_UnitTestCase {
 	/**
 	 * Tests the model function that expects slashed data.
 	 */
-	function test_update_comment_meta() {
+	public function test_update_comment_meta() {
 		$comment_id = self::$comment_id;
 
 		add_comment_meta( $comment_id, 'slash_test_1', 'foo' );
@@ -192,7 +192,7 @@ class Tests_Meta_Slashes extends WP_UnitTestCase {
 	/**
 	 * Tests the model function that expects slashed data.
 	 */
-	function test_add_user_meta() {
+	public function test_add_user_meta() {
 		$user_id = self::$user_id;
 
 		add_user_meta( $user_id, 'slash_test_1', $this->slash_1 );
@@ -215,7 +215,7 @@ class Tests_Meta_Slashes extends WP_UnitTestCase {
 	/**
 	 * Tests the model function that expects slashed data.
 	 */
-	function test_update_user_meta() {
+	public function test_update_user_meta() {
 		$user_id = self::$user_id;
 
 		add_user_meta( $user_id, 'slash_test_1', 'foo' );

--- a/tests/phpunit/tests/multisite/bootstrap.php
+++ b/tests/phpunit/tests/multisite/bootstrap.php
@@ -123,7 +123,7 @@ if ( is_multisite() ) :
 		 * @param string $path         The requested path.
 		 * @param string $message      The message to pass for failed tests.
 		 */
-		function test_get_network_by_path( $expected_key, $domain, $path, $message ) {
+		public function test_get_network_by_path( $expected_key, $domain, $path, $message ) {
 			$network = get_network_by_path( $domain, $path );
 			$this->assertSame( self::$network_ids[ $expected_key ], $network->id, $message );
 		}
@@ -255,7 +255,7 @@ if ( is_multisite() ) :
 		 * @param string $domain      The requested domain.
 		 * @param string $path        The requested path.
 		 */
-		function test_multisite_bootstrap( $site_key, $network_key, $domain, $path ) {
+		public function test_multisite_bootstrap( $site_key, $network_key, $domain, $path ) {
 			global $current_blog;
 
 			$expected = array(

--- a/tests/phpunit/tests/multisite/cleanDirsizeCache.php
+++ b/tests/phpunit/tests/multisite/cleanDirsizeCache.php
@@ -34,7 +34,7 @@ if ( is_multisite() ) :
 			delete_transient( 'dirsize_cache' );
 
 			// Set the dirsize cache to our mock.
-			set_transient( 'dirsize_cache', $this->_get_mock_dirsize_cache_for_site( $blog_id ) );
+			set_transient( 'dirsize_cache', $this->get_mock_dirsize_cache_for_site( $blog_id ) );
 
 			$upload_dir = wp_upload_dir();
 
@@ -86,7 +86,7 @@ if ( is_multisite() ) :
 			delete_transient( 'dirsize_cache' );
 
 			// Set the dirsize cache to our mock.
-			set_transient( 'dirsize_cache', $this->_get_mock_dirsize_cache_for_site( $blog_id ) );
+			set_transient( 'dirsize_cache', $this->get_mock_dirsize_cache_for_site( $blog_id ) );
 
 			$this->assertArrayHasKey( $cache_key_prefix . '/1/1', get_transient( 'dirsize_cache' ) );
 			$this->assertArrayHasKey( $cache_key_prefix . '/2/1', get_transient( 'dirsize_cache' ) );
@@ -134,7 +134,7 @@ if ( is_multisite() ) :
 			delete_transient( 'dirsize_cache' );
 
 			// Set the dirsize cache to our mock.
-			set_transient( 'dirsize_cache', $this->_get_mock_dirsize_cache_for_site( $blog_id ) );
+			set_transient( 'dirsize_cache', $this->get_mock_dirsize_cache_for_site( $blog_id ) );
 
 			$this->assertArrayHasKey( $cache_key_prefix . '/1/1', get_transient( 'dirsize_cache' ) );
 			$this->assertArrayHasKey( $cache_key_prefix . '/2/1', get_transient( 'dirsize_cache' ) );
@@ -207,19 +207,19 @@ if ( is_multisite() ) :
 		 * @ticket 19879
 		 */
 		public function test_pre_recurse_dirsize_filter() {
-			add_filter( 'pre_recurse_dirsize', array( $this, '_filter_pre_recurse_dirsize' ) );
+			add_filter( 'pre_recurse_dirsize', array( $this, 'filter_pre_recurse_dirsize' ) );
 
 			$upload_dir = wp_upload_dir();
 			$this->assertSame( 1042, recurse_dirsize( $upload_dir['path'] ) );
 
-			remove_filter( 'pre_recurse_dirsize', array( $this, '_filter_pre_recurse_dirsize' ) );
+			remove_filter( 'pre_recurse_dirsize', array( $this, 'filter_pre_recurse_dirsize' ) );
 		}
 
-		public function _filter_pre_recurse_dirsize() {
+		public function filter_pre_recurse_dirsize() {
 			return 1042;
 		}
 
-		private function _get_mock_dirsize_cache_for_site( $site_id ) {
+		private function get_mock_dirsize_cache_for_site( $site_id ) {
 			$prefix = wp_upload_dir()['basedir'];
 
 			return array(
@@ -258,7 +258,7 @@ if ( is_multisite() ) :
 			delete_transient( 'dirsize_cache' );
 
 			// Set the dirsize cache to our mock.
-			set_transient( 'dirsize_cache', $this->_get_mock_5_5_dirsize_cache( $blog_id ) );
+			set_transient( 'dirsize_cache', $this->get_mock_5_5_dirsize_cache( $blog_id ) );
 
 			$upload_dir = wp_upload_dir();
 
@@ -281,7 +281,7 @@ if ( is_multisite() ) :
 			delete_transient( 'dirsize_cache' );
 
 			// Set the dirsize cache to our mock.
-			set_transient( 'dirsize_cache', $this->_get_mock_5_5_dirsize_cache( $blog_id ) );
+			set_transient( 'dirsize_cache', $this->get_mock_5_5_dirsize_cache( $blog_id ) );
 
 			/*
 			 * Now that the folder exists, the old cached value should be overwritten
@@ -300,7 +300,7 @@ if ( is_multisite() ) :
 			restore_current_blog();
 		}
 
-		private function _get_mock_5_5_dirsize_cache( $site_id ) {
+		private function get_mock_5_5_dirsize_cache( $site_id ) {
 			$prefix = untrailingslashit( wp_upload_dir()['basedir'] );
 
 			return array(

--- a/tests/phpunit/tests/multisite/cleanDirsizeCache.php
+++ b/tests/phpunit/tests/multisite/cleanDirsizeCache.php
@@ -15,7 +15,7 @@ if ( is_multisite() ) :
 		 *
 		 * @ticket 19879
 		 */
-		function test_get_dirsize_cache_in_recurse_dirsize_mock() {
+		public function test_get_dirsize_cache_in_recurse_dirsize_mock() {
 			$blog_id = self::factory()->blog->create();
 			switch_to_blog( $blog_id );
 
@@ -64,7 +64,7 @@ if ( is_multisite() ) :
 		 *
 		 * @ticket 19879
 		 */
-		function test_clean_dirsize_cache_file_input_mock() {
+		public function test_clean_dirsize_cache_file_input_mock() {
 			$blog_id = self::factory()->blog->create();
 			switch_to_blog( $blog_id );
 
@@ -112,7 +112,7 @@ if ( is_multisite() ) :
 		 *
 		 * @ticket 19879
 		 */
-		function test_clean_dirsize_cache_folder_input_mock() {
+		public function test_clean_dirsize_cache_folder_input_mock() {
 			$blog_id = self::factory()->blog->create();
 			switch_to_blog( $blog_id );
 
@@ -160,7 +160,7 @@ if ( is_multisite() ) :
 		 *
 		 * @ticket 19879
 		 */
-		function test_get_dirsize_cache_in_recurse_dirsize_upload() {
+		public function test_get_dirsize_cache_in_recurse_dirsize_upload() {
 			$blog_id = self::factory()->blog->create();
 			switch_to_blog( $blog_id );
 
@@ -206,7 +206,7 @@ if ( is_multisite() ) :
 		 *
 		 * @ticket 19879
 		 */
-		function test_pre_recurse_dirsize_filter() {
+		public function test_pre_recurse_dirsize_filter() {
 			add_filter( 'pre_recurse_dirsize', array( $this, '_filter_pre_recurse_dirsize' ) );
 
 			$upload_dir = wp_upload_dir();
@@ -215,11 +215,11 @@ if ( is_multisite() ) :
 			remove_filter( 'pre_recurse_dirsize', array( $this, '_filter_pre_recurse_dirsize' ) );
 		}
 
-		function _filter_pre_recurse_dirsize() {
+		public function _filter_pre_recurse_dirsize() {
 			return 1042;
 		}
 
-		function _get_mock_dirsize_cache_for_site( $site_id ) {
+		private function _get_mock_dirsize_cache_for_site( $site_id ) {
 			$prefix = wp_upload_dir()['basedir'];
 
 			return array(
@@ -239,7 +239,7 @@ if ( is_multisite() ) :
 		 *
 		 * @ticket 51913
 		 */
-		function test_5_5_transient_structure_compat() {
+		public function test_5_5_transient_structure_compat() {
 			$blog_id = self::factory()->blog->create();
 			switch_to_blog( $blog_id );
 
@@ -300,7 +300,7 @@ if ( is_multisite() ) :
 			restore_current_blog();
 		}
 
-		function _get_mock_5_5_dirsize_cache( $site_id ) {
+		private function _get_mock_5_5_dirsize_cache( $site_id ) {
 			$prefix = untrailingslashit( wp_upload_dir()['basedir'] );
 
 			return array(

--- a/tests/phpunit/tests/multisite/getSpaceUsed.php
+++ b/tests/phpunit/tests/multisite/getSpaceUsed.php
@@ -77,14 +77,14 @@ if ( is_multisite() ) :
 		}
 
 		public function test_get_space_used_pre_get_spaced_used_filter() {
-			add_filter( 'pre_get_space_used', array( $this, '_filter_space_used' ) );
+			add_filter( 'pre_get_space_used', array( $this, 'filter_space_used' ) );
 
 			$this->assertSame( 300, get_space_used() );
 
-			remove_filter( 'pre_get_space_used', array( $this, '_filter_space_used' ) );
+			remove_filter( 'pre_get_space_used', array( $this, 'filter_space_used' ) );
 		}
 
-		public function _filter_space_used() {
+		public function filter_space_used() {
 			return 300;
 		}
 	}

--- a/tests/phpunit/tests/multisite/getSpaceUsed.php
+++ b/tests/phpunit/tests/multisite/getSpaceUsed.php
@@ -8,7 +8,7 @@ if ( is_multisite() ) :
 	 */
 	class Tests_Multisite_GetSpaceUsed extends WP_UnitTestCase {
 
-		function test_get_space_used_switched_site() {
+		public function test_get_space_used_switched_site() {
 			$blog_id = self::factory()->blog->create();
 			switch_to_blog( $blog_id );
 
@@ -42,7 +42,7 @@ if ( is_multisite() ) :
 		 * Directories of sub sites on a network should not count against the same spaced used total for
 		 * the main site.
 		 */
-		function test_get_space_used_main_site() {
+		public function test_get_space_used_main_site() {
 			$space_used = get_space_used();
 
 			$blog_id = self::factory()->blog->create();
@@ -76,7 +76,7 @@ if ( is_multisite() ) :
 			restore_current_blog();
 		}
 
-		function test_get_space_used_pre_get_spaced_used_filter() {
+		public function test_get_space_used_pre_get_spaced_used_filter() {
 			add_filter( 'pre_get_space_used', array( $this, '_filter_space_used' ) );
 
 			$this->assertSame( 300, get_space_used() );
@@ -84,7 +84,7 @@ if ( is_multisite() ) :
 			remove_filter( 'pre_get_space_used', array( $this, '_filter_space_used' ) );
 		}
 
-		function _filter_space_used() {
+		public function _filter_space_used() {
 			return 300;
 		}
 	}

--- a/tests/phpunit/tests/multisite/isUploadSpaceAvailable.php
+++ b/tests/phpunit/tests/multisite/isUploadSpaceAvailable.php
@@ -25,9 +25,9 @@ if ( is_multisite() ) :
 			delete_option( 'blog_upload_space' );
 			delete_site_option( 'blog_upload_space' );
 
-			add_filter( 'pre_get_space_used', array( $this, '_filter_space_used_small' ) );
+			add_filter( 'pre_get_space_used', array( $this, 'filter_space_used_small' ) );
 			$available = is_upload_space_available();
-			remove_filter( 'pre_get_space_used', array( $this, '_filter_space_used_small' ) );
+			remove_filter( 'pre_get_space_used', array( $this, 'filter_space_used_small' ) );
 
 			$this->assertTrue( $available );
 		}
@@ -36,9 +36,9 @@ if ( is_multisite() ) :
 			update_site_option( 'blog_upload_space', 10 );
 			update_site_option( 'upload_space_check_disabled', true );
 
-			add_filter( 'pre_get_space_used', array( $this, '_filter_space_used_large' ) );
+			add_filter( 'pre_get_space_used', array( $this, 'filter_space_used_large' ) );
 			$available = is_upload_space_available();
-			remove_filter( 'pre_get_space_used', array( $this, '_filter_space_used_large' ) );
+			remove_filter( 'pre_get_space_used', array( $this, 'filter_space_used_large' ) );
 
 			$this->assertTrue( $available );
 		}
@@ -46,9 +46,9 @@ if ( is_multisite() ) :
 		public function test_is_upload_space_available_space_used_is_less_then_allowed() {
 			update_option( 'blog_upload_space', 350 );
 
-			add_filter( 'pre_get_space_used', array( $this, '_filter_space_used_small' ) );
+			add_filter( 'pre_get_space_used', array( $this, 'filter_space_used_small' ) );
 			$available = is_upload_space_available();
-			remove_filter( 'pre_get_space_used', array( $this, '_filter_space_used_small' ) );
+			remove_filter( 'pre_get_space_used', array( $this, 'filter_space_used_small' ) );
 
 			$this->assertTrue( $available );
 		}
@@ -56,9 +56,9 @@ if ( is_multisite() ) :
 		public function test_is_upload_space_available_space_used_is_more_than_allowed() {
 			update_option( 'blog_upload_space', 350 );
 
-			add_filter( 'pre_get_space_used', array( $this, '_filter_space_used_large' ) );
+			add_filter( 'pre_get_space_used', array( $this, 'filter_space_used_large' ) );
 			$available = is_upload_space_available();
-			remove_filter( 'pre_get_space_used', array( $this, '_filter_space_used_large' ) );
+			remove_filter( 'pre_get_space_used', array( $this, 'filter_space_used_large' ) );
 
 			$this->assertFalse( $available );
 		}
@@ -70,9 +70,9 @@ if ( is_multisite() ) :
 		public function test_is_upload_space_available_upload_space_0_defaults_to_100() {
 			update_option( 'blog_upload_space', 0 );
 
-			add_filter( 'pre_get_space_used', array( $this, '_filter_space_used_small' ) );
+			add_filter( 'pre_get_space_used', array( $this, 'filter_space_used_small' ) );
 			$available = is_upload_space_available();
-			remove_filter( 'pre_get_space_used', array( $this, '_filter_space_used_small' ) );
+			remove_filter( 'pre_get_space_used', array( $this, 'filter_space_used_small' ) );
 
 			$this->assertFalse( $available );
 		}
@@ -80,18 +80,18 @@ if ( is_multisite() ) :
 		public function test_is_upload_space_available_upload_space_negative() {
 			update_site_option( 'blog_upload_space', -1 );
 
-			add_filter( 'pre_get_space_used', array( $this, '_filter_space_used_small' ) );
+			add_filter( 'pre_get_space_used', array( $this, 'filter_space_used_small' ) );
 			$available = is_upload_space_available();
-			remove_filter( 'pre_get_space_used', array( $this, '_filter_space_used_small' ) );
+			remove_filter( 'pre_get_space_used', array( $this, 'filter_space_used_small' ) );
 
 			$this->assertFalse( $available );
 		}
 
-		public function _filter_space_used_large() {
+		public function filter_space_used_large() {
 			return 10000000;
 		}
 
-		public function _filter_space_used_small() {
+		public function filter_space_used_small() {
 			return 10;
 		}
 	}

--- a/tests/phpunit/tests/multisite/isUploadSpaceAvailable.php
+++ b/tests/phpunit/tests/multisite/isUploadSpaceAvailable.php
@@ -53,7 +53,7 @@ if ( is_multisite() ) :
 			$this->assertTrue( $available );
 		}
 
-		function test_is_upload_space_available_space_used_is_more_than_allowed() {
+		public function test_is_upload_space_available_space_used_is_more_than_allowed() {
 			update_option( 'blog_upload_space', 350 );
 
 			add_filter( 'pre_get_space_used', array( $this, '_filter_space_used_large' ) );
@@ -67,7 +67,7 @@ if ( is_multisite() ) :
 		 * More comprehensive testing a 0 condition is handled in the tests
 		 * for `get_space_allowed()`. We cover one scenario here.
 		 */
-		function test_is_upload_space_available_upload_space_0_defaults_to_100() {
+		public function test_is_upload_space_available_upload_space_0_defaults_to_100() {
 			update_option( 'blog_upload_space', 0 );
 
 			add_filter( 'pre_get_space_used', array( $this, '_filter_space_used_small' ) );
@@ -77,7 +77,7 @@ if ( is_multisite() ) :
 			$this->assertFalse( $available );
 		}
 
-		function test_is_upload_space_available_upload_space_negative() {
+		public function test_is_upload_space_available_upload_space_negative() {
 			update_site_option( 'blog_upload_space', -1 );
 
 			add_filter( 'pre_get_space_used', array( $this, '_filter_space_used_small' ) );
@@ -87,11 +87,11 @@ if ( is_multisite() ) :
 			$this->assertFalse( $available );
 		}
 
-		function _filter_space_used_large() {
+		public function _filter_space_used_large() {
 			return 10000000;
 		}
 
-		function _filter_space_used_small() {
+		public function _filter_space_used_small() {
 			return 10;
 		}
 	}

--- a/tests/phpunit/tests/multisite/msFilesRewriting.php
+++ b/tests/phpunit/tests/multisite/msFilesRewriting.php
@@ -13,13 +13,13 @@ if ( is_multisite() ) :
 	 */
 	class Tests_Multisite_msFilesRewriting extends WP_UnitTestCase {
 
-		function set_up() {
+		public function set_up() {
 			parent::set_up();
 			update_site_option( 'ms_files_rewriting', 1 );
 			ms_upload_constants();
 		}
 
-		function test_switch_upload_dir() {
+		public function test_switch_upload_dir() {
 			$this->assertTrue( is_main_site() );
 
 			$site = get_current_site();
@@ -48,7 +48,7 @@ if ( is_multisite() ) :
 		 * that site should be removed. When wpmu_delete_blog() is run a second time, nothing
 		 * should change with upload directories.
 		 */
-		function test_upload_directories_after_multiple_wpmu_delete_blog_with_ms_files() {
+		public function test_upload_directories_after_multiple_wpmu_delete_blog_with_ms_files() {
 			$filename = __FUNCTION__ . '.jpg';
 			$contents = __FUNCTION__ . '_contents';
 

--- a/tests/phpunit/tests/multisite/network.php
+++ b/tests/phpunit/tests/multisite/network.php
@@ -116,12 +116,12 @@ if ( is_multisite() ) :
 		}
 
 		public function test_get_main_network_id_filtered() {
-			add_filter( 'get_main_network_id', array( $this, '_get_main_network_id' ) );
+			add_filter( 'get_main_network_id', array( $this, 'get_main_network_id' ) );
 			$this->assertSame( 3, get_main_network_id() );
-			remove_filter( 'get_main_network_id', array( $this, '_get_main_network_id' ) );
+			remove_filter( 'get_main_network_id', array( $this, 'get_main_network_id' ) );
 		}
 
-		public function _get_main_network_id() {
+		public function get_main_network_id() {
 			return 3;
 		}
 
@@ -262,7 +262,7 @@ if ( is_multisite() ) :
 			$active_plugins = wp_get_active_network_plugins();
 			$this->assertSame( array(), $active_plugins );
 
-			add_action( 'deactivated_plugin', array( $this, '_helper_deactivate_hook' ) );
+			add_action( 'deactivated_plugin', array( $this, 'helper_deactivate_hook' ) );
 
 			// Activate the plugin sitewide.
 			activate_plugin( $path, '', true ); // Enable the plugin for all sites in the network.
@@ -315,7 +315,7 @@ if ( is_multisite() ) :
 			$this->assertFalse( is_plugin_active_for_network( 'hello.php' ) );
 		}
 
-		public function _helper_deactivate_hook() {
+		public function helper_deactivate_hook() {
 			$this->plugin_hook_count++;
 		}
 

--- a/tests/phpunit/tests/multisite/network.php
+++ b/tests/phpunit/tests/multisite/network.php
@@ -14,7 +14,7 @@ if ( is_multisite() ) :
 		protected static $different_network_id;
 		protected static $different_site_ids = array();
 
-		function tear_down() {
+		public function tear_down() {
 			global $current_site;
 			$current_site->id = 1;
 			parent::tear_down();
@@ -67,7 +67,7 @@ if ( is_multisite() ) :
 		/**
 		 * By default, only one network exists and has a network ID of 1.
 		 */
-		function test_get_main_network_id_default() {
+		public function test_get_main_network_id_default() {
 			$this->assertSame( 1, get_main_network_id() );
 		}
 
@@ -75,7 +75,7 @@ if ( is_multisite() ) :
 		 * If a second network is created, network ID 1 should still be returned
 		 * as the main network ID.
 		 */
-		function test_get_main_network_id_two_networks() {
+		public function test_get_main_network_id_two_networks() {
 			self::factory()->network->create();
 
 			$this->assertSame( 1, get_main_network_id() );
@@ -85,7 +85,7 @@ if ( is_multisite() ) :
 		 * When the `$current_site` global is populated with another network, the
 		 * main network should still return as 1.
 		 */
-		function test_get_main_network_id_after_network_switch() {
+		public function test_get_main_network_id_after_network_switch() {
 			global $current_site;
 
 			$id = self::factory()->network->create();
@@ -102,7 +102,7 @@ if ( is_multisite() ) :
 		 * @todo In the future, we'll have a smarter way of deleting a network. For now,
 		 * fake the process with UPDATE queries.
 		 */
-		function test_get_main_network_id_after_network_delete() {
+		public function test_get_main_network_id_after_network_delete() {
 			global $wpdb, $current_site;
 
 			$temp_id = self::$different_network_id + 1;
@@ -115,20 +115,20 @@ if ( is_multisite() ) :
 			$this->assertSame( self::$different_network_id, $main_network_id );
 		}
 
-		function test_get_main_network_id_filtered() {
+		public function test_get_main_network_id_filtered() {
 			add_filter( 'get_main_network_id', array( $this, '_get_main_network_id' ) );
 			$this->assertSame( 3, get_main_network_id() );
 			remove_filter( 'get_main_network_id', array( $this, '_get_main_network_id' ) );
 		}
 
-		function _get_main_network_id() {
+		public function _get_main_network_id() {
 			return 3;
 		}
 
 		/**
 		 * @ticket 37050
 		 */
-		function test_wp_network_object_id_property_is_int() {
+		public function test_wp_network_object_id_property_is_int() {
 			$id = self::factory()->network->create();
 
 			$network = WP_Network::get_instance( $id );
@@ -225,7 +225,7 @@ if ( is_multisite() ) :
 		/**
 		 * @ticket 22917
 		 */
-		function test_enable_live_network_user_counts_filter() {
+		public function test_enable_live_network_user_counts_filter() {
 			// False for large networks by default.
 			add_filter( 'enable_live_network_counts', '__return_false' );
 
@@ -254,7 +254,7 @@ if ( is_multisite() ) :
 			remove_filter( 'enable_live_network_counts', '__return_true' );
 		}
 
-		function test_active_network_plugins() {
+		public function test_active_network_plugins() {
 			$path = 'hello.php';
 
 			// Local activate, should be invisible for the network.
@@ -285,7 +285,7 @@ if ( is_multisite() ) :
 		/**
 		 * @ticket 28651
 		 */
-		function test_duplicate_network_active_plugin() {
+		public function test_duplicate_network_active_plugin() {
 			$path = 'hello.php';
 			$mock = new MockAction();
 			add_action( 'activate_' . $path, array( $mock, 'action' ) );
@@ -305,21 +305,21 @@ if ( is_multisite() ) :
 			remove_action( 'activate_' . $path, array( $mock, 'action' ) );
 		}
 
-		function test_is_plugin_active_for_network_true() {
+		public function test_is_plugin_active_for_network_true() {
 			activate_plugin( 'hello.php', '', true );
 			$this->assertTrue( is_plugin_active_for_network( 'hello.php' ) );
 		}
 
-		function test_is_plugin_active_for_network_false() {
+		public function test_is_plugin_active_for_network_false() {
 			deactivate_plugins( 'hello.php', false, true );
 			$this->assertFalse( is_plugin_active_for_network( 'hello.php' ) );
 		}
 
-		function _helper_deactivate_hook() {
+		public function _helper_deactivate_hook() {
 			$this->plugin_hook_count++;
 		}
 
-		function test_get_user_count() {
+		public function test_get_user_count() {
 			// Refresh the cache.
 			wp_update_network_counts();
 			$start_count = get_user_count();
@@ -338,7 +338,7 @@ if ( is_multisite() ) :
 			remove_filter( 'enable_live_network_counts', '__return_false' );
 		}
 
-		function test_wp_schedule_update_network_counts() {
+		public function test_wp_schedule_update_network_counts() {
 			$this->assertFalse( wp_next_scheduled( 'update_network_counts' ) );
 
 			// We can't use wp_schedule_update_network_counts() because WP_INSTALLING is set.
@@ -350,7 +350,7 @@ if ( is_multisite() ) :
 		/**
 		 * @expectedDeprecated get_dashboard_blog
 		 */
-		function test_get_dashboard_blog() {
+		public function test_get_dashboard_blog() {
 			// If there is no dashboard blog set, current blog is used.
 			$dashboard_blog = get_dashboard_blog();
 			$this->assertEquals( 1, $dashboard_blog->blog_id );
@@ -368,7 +368,7 @@ if ( is_multisite() ) :
 		/**
 		 * @ticket 37528
 		 */
-		function test_wp_update_network_site_counts() {
+		public function test_wp_update_network_site_counts() {
 			update_network_option( null, 'blog_count', 40 );
 
 			$expected = get_sites(
@@ -390,7 +390,7 @@ if ( is_multisite() ) :
 		/**
 		 * @ticket 37528
 		 */
-		function test_wp_update_network_site_counts_on_different_network() {
+		public function test_wp_update_network_site_counts_on_different_network() {
 			update_network_option( self::$different_network_id, 'blog_count', 40 );
 
 			wp_update_network_site_counts( self::$different_network_id );

--- a/tests/phpunit/tests/multisite/site.php
+++ b/tests/phpunit/tests/multisite/site.php
@@ -415,7 +415,7 @@ if ( is_multisite() ) :
 		/**
 		 * Provide a counter to determine that hooks are firing when intended.
 		 */
-		public function _action_counter_cb() {
+		public function action_counter_cb() {
 			global $test_action_counter;
 			$test_action_counter++;
 		}
@@ -471,7 +471,7 @@ if ( is_multisite() ) :
 			$blog_id = self::factory()->blog->create();
 			update_blog_details( $blog_id, array( 'spam' => 1 ) );
 
-			add_action( 'make_ham_blog', array( $this, '_action_counter_cb' ), 10 );
+			add_action( 'make_ham_blog', array( $this, 'action_counter_cb' ), 10 );
 			update_blog_status( $blog_id, 'spam', 0 );
 			$blog = get_site( $blog_id );
 
@@ -485,7 +485,7 @@ if ( is_multisite() ) :
 			$this->assertSame( '0', $blog->spam );
 			$this->assertSame( 1, $test_action_counter );
 
-			remove_action( 'make_ham_blog', array( $this, '_action_counter_cb' ), 10 );
+			remove_action( 'make_ham_blog', array( $this, 'action_counter_cb' ), 10 );
 		}
 
 		public function test_content_from_spam_blog_is_not_available() {
@@ -524,7 +524,7 @@ if ( is_multisite() ) :
 
 			$blog_id = self::factory()->blog->create();
 
-			add_action( 'make_spam_blog', array( $this, '_action_counter_cb' ), 10 );
+			add_action( 'make_spam_blog', array( $this, 'action_counter_cb' ), 10 );
 			update_blog_status( $blog_id, 'spam', 1 );
 			$blog = get_site( $blog_id );
 
@@ -538,7 +538,7 @@ if ( is_multisite() ) :
 			$this->assertSame( '1', $blog->spam );
 			$this->assertSame( 1, $test_action_counter );
 
-			remove_action( 'make_spam_blog', array( $this, '_action_counter_cb' ), 10 );
+			remove_action( 'make_spam_blog', array( $this, 'action_counter_cb' ), 10 );
 		}
 
 		public function test_update_blog_status_archive_blog_action() {
@@ -547,7 +547,7 @@ if ( is_multisite() ) :
 
 			$blog_id = self::factory()->blog->create();
 
-			add_action( 'archive_blog', array( $this, '_action_counter_cb' ), 10 );
+			add_action( 'archive_blog', array( $this, 'action_counter_cb' ), 10 );
 			update_blog_status( $blog_id, 'archived', 1 );
 			$blog = get_site( $blog_id );
 
@@ -561,7 +561,7 @@ if ( is_multisite() ) :
 			$this->assertSame( '1', $blog->archived );
 			$this->assertSame( 1, $test_action_counter );
 
-			remove_action( 'archive_blog', array( $this, '_action_counter_cb' ), 10 );
+			remove_action( 'archive_blog', array( $this, 'action_counter_cb' ), 10 );
 		}
 
 		public function test_update_blog_status_unarchive_blog_action() {
@@ -571,7 +571,7 @@ if ( is_multisite() ) :
 			$blog_id = self::factory()->blog->create();
 			update_blog_details( $blog_id, array( 'archived' => 1 ) );
 
-			add_action( 'unarchive_blog', array( $this, '_action_counter_cb' ), 10 );
+			add_action( 'unarchive_blog', array( $this, 'action_counter_cb' ), 10 );
 			update_blog_status( $blog_id, 'archived', 0 );
 			$blog = get_site( $blog_id );
 
@@ -584,7 +584,7 @@ if ( is_multisite() ) :
 			$this->assertSame( '0', $blog->archived );
 			$this->assertSame( 1, $test_action_counter );
 
-			remove_action( 'unarchive_blog', array( $this, '_action_counter_cb' ), 10 );
+			remove_action( 'unarchive_blog', array( $this, 'action_counter_cb' ), 10 );
 		}
 
 		public function test_update_blog_status_make_delete_blog_action() {
@@ -593,7 +593,7 @@ if ( is_multisite() ) :
 
 			$blog_id = self::factory()->blog->create();
 
-			add_action( 'make_delete_blog', array( $this, '_action_counter_cb' ), 10 );
+			add_action( 'make_delete_blog', array( $this, 'action_counter_cb' ), 10 );
 			update_blog_status( $blog_id, 'deleted', 1 );
 			$blog = get_site( $blog_id );
 
@@ -607,7 +607,7 @@ if ( is_multisite() ) :
 			$this->assertSame( '1', $blog->deleted );
 			$this->assertSame( 1, $test_action_counter );
 
-			remove_action( 'make_delete_blog', array( $this, '_action_counter_cb' ), 10 );
+			remove_action( 'make_delete_blog', array( $this, 'action_counter_cb' ), 10 );
 		}
 
 		public function test_update_blog_status_make_undelete_blog_action() {
@@ -617,7 +617,7 @@ if ( is_multisite() ) :
 			$blog_id = self::factory()->blog->create();
 			update_blog_details( $blog_id, array( 'deleted' => 1 ) );
 
-			add_action( 'make_undelete_blog', array( $this, '_action_counter_cb' ), 10 );
+			add_action( 'make_undelete_blog', array( $this, 'action_counter_cb' ), 10 );
 			update_blog_status( $blog_id, 'deleted', 0 );
 			$blog = get_site( $blog_id );
 
@@ -631,7 +631,7 @@ if ( is_multisite() ) :
 			$this->assertSame( '0', $blog->deleted );
 			$this->assertSame( 1, $test_action_counter );
 
-			remove_action( 'make_undelete_blog', array( $this, '_action_counter_cb' ), 10 );
+			remove_action( 'make_undelete_blog', array( $this, 'action_counter_cb' ), 10 );
 		}
 
 		public function test_update_blog_status_mature_blog_action() {
@@ -640,7 +640,7 @@ if ( is_multisite() ) :
 
 			$blog_id = self::factory()->blog->create();
 
-			add_action( 'mature_blog', array( $this, '_action_counter_cb' ), 10 );
+			add_action( 'mature_blog', array( $this, 'action_counter_cb' ), 10 );
 			update_blog_status( $blog_id, 'mature', 1 );
 			$blog = get_site( $blog_id );
 
@@ -654,7 +654,7 @@ if ( is_multisite() ) :
 			$this->assertSame( '1', $blog->mature );
 			$this->assertSame( 1, $test_action_counter );
 
-			remove_action( 'mature_blog', array( $this, '_action_counter_cb' ), 10 );
+			remove_action( 'mature_blog', array( $this, 'action_counter_cb' ), 10 );
 		}
 
 		public function test_update_blog_status_unmature_blog_action() {
@@ -664,7 +664,7 @@ if ( is_multisite() ) :
 			$blog_id = self::factory()->blog->create();
 			update_blog_details( $blog_id, array( 'mature' => 1 ) );
 
-			add_action( 'unmature_blog', array( $this, '_action_counter_cb' ), 10 );
+			add_action( 'unmature_blog', array( $this, 'action_counter_cb' ), 10 );
 			update_blog_status( $blog_id, 'mature', 0 );
 
 			$blog = get_site( $blog_id );
@@ -678,7 +678,7 @@ if ( is_multisite() ) :
 			$this->assertSame( '0', $blog->mature );
 			$this->assertSame( 1, $test_action_counter );
 
-			remove_action( 'unmature_blog', array( $this, '_action_counter_cb' ), 10 );
+			remove_action( 'unmature_blog', array( $this, 'action_counter_cb' ), 10 );
 		}
 
 		public function test_update_blog_status_update_blog_public_action() {
@@ -687,7 +687,7 @@ if ( is_multisite() ) :
 
 			$blog_id = self::factory()->blog->create();
 
-			add_action( 'update_blog_public', array( $this, '_action_counter_cb' ), 10 );
+			add_action( 'update_blog_public', array( $this, 'action_counter_cb' ), 10 );
 			update_blog_status( $blog_id, 'public', 0 );
 
 			$blog = get_site( $blog_id );
@@ -701,7 +701,7 @@ if ( is_multisite() ) :
 			$this->assertSame( '0', $blog->public );
 			$this->assertSame( 1, $test_action_counter );
 
-			remove_action( 'update_blog_public', array( $this, '_action_counter_cb' ), 10 );
+			remove_action( 'update_blog_public', array( $this, 'action_counter_cb' ), 10 );
 		}
 
 		/**
@@ -899,7 +899,7 @@ if ( is_multisite() ) :
 		 * Added as a callback to the domain_exists filter to provide manual results for
 		 * the testing of the filter and for a test which does not need the database.
 		 */
-		public function _domain_exists_cb( $exists, $domain, $path, $site_id ) {
+		public function domain_exists_cb( $exists, $domain, $path, $site_id ) {
 			if ( 'foo' === $domain && 'bar/' === $path ) {
 				return 1234;
 			} else {
@@ -934,9 +934,9 @@ if ( is_multisite() ) :
 		}
 
 		public function test_domain_filtered_to_exist() {
-			add_filter( 'domain_exists', array( $this, '_domain_exists_cb' ), 10, 4 );
+			add_filter( 'domain_exists', array( $this, 'domain_exists_cb' ), 10, 4 );
 			$exists = domain_exists( 'foo', 'bar' );
-			remove_filter( 'domain_exists', array( $this, '_domain_exists_cb' ), 10, 4 );
+			remove_filter( 'domain_exists', array( $this, 'domain_exists_cb' ), 10, 4 );
 			$this->assertSame( 1234, $exists );
 		}
 
@@ -945,10 +945,10 @@ if ( is_multisite() ) :
 		 * value with or without the slash should result in the same return value.
 		 */
 		public function test_slashed_path_in_domain_exists() {
-			add_filter( 'domain_exists', array( $this, '_domain_exists_cb' ), 10, 4 );
+			add_filter( 'domain_exists', array( $this, 'domain_exists_cb' ), 10, 4 );
 			$exists1 = domain_exists( 'foo', 'bar' );
 			$exists2 = domain_exists( 'foo', 'bar/' );
-			remove_filter( 'domain_exists', array( $this, '_domain_exists_cb' ), 10, 4 );
+			remove_filter( 'domain_exists', array( $this, 'domain_exists_cb' ), 10, 4 );
 
 			// Make sure the same result is returned with or without a trailing slash.
 			$this->assertSame( $exists1, $exists2 );

--- a/tests/phpunit/tests/multisite/site.php
+++ b/tests/phpunit/tests/multisite/site.php
@@ -17,13 +17,13 @@ if ( is_multisite() ) :
 		protected static $site_ids;
 		protected static $uninitialized_site_id;
 
-		function set_up() {
+		public function set_up() {
 			global $wpdb;
 			parent::set_up();
 			$this->suppress = $wpdb->suppress_errors();
 		}
 
-		function tear_down() {
+		public function tear_down() {
 			global $wpdb;
 			$wpdb->suppress_errors( $this->suppress );
 			parent::tear_down();
@@ -88,7 +88,7 @@ if ( is_multisite() ) :
 			}
 		}
 
-		function test_switch_restore_blog() {
+		public function test_switch_restore_blog() {
 			global $_wp_switched_stack, $wpdb;
 
 			$this->assertSame( array(), $_wp_switched_stack );
@@ -136,7 +136,7 @@ if ( is_multisite() ) :
 		/**
 		 * Test the cache keys and database tables setup through the creation of a site.
 		 */
-		function test_created_site_details() {
+		public function test_created_site_details() {
 			global $wpdb;
 
 			$blog_id = self::factory()->blog->create();
@@ -221,7 +221,7 @@ if ( is_multisite() ) :
 		/**
 		 * When a site is flagged as 'deleted', its data should be cleared from cache.
 		 */
-		function test_data_in_cache_after_wpmu_delete_blog_drop_false() {
+		public function test_data_in_cache_after_wpmu_delete_blog_drop_false() {
 			$blog_id = self::factory()->blog->create();
 
 			$details = get_blog_details( $blog_id, false );
@@ -239,7 +239,7 @@ if ( is_multisite() ) :
 		/**
 		 * When a site is flagged as 'deleted', its data should remain in the database.
 		 */
-		function test_data_in_tables_after_wpmu_delete_blog_drop_false() {
+		public function test_data_in_tables_after_wpmu_delete_blog_drop_false() {
 			global $wpdb;
 
 			$blog_id = self::factory()->blog->create();
@@ -262,7 +262,7 @@ if ( is_multisite() ) :
 		/**
 		 * When a site is fully deleted, its data should be cleared from cache.
 		 */
-		function test_data_in_cache_after_wpmu_delete_blog_drop_true() {
+		public function test_data_in_cache_after_wpmu_delete_blog_drop_true() {
 			$blog_id = self::factory()->blog->create();
 
 			$details = get_blog_details( $blog_id, false );
@@ -280,7 +280,7 @@ if ( is_multisite() ) :
 		/**
 		 * When a site is fully deleted, its data should be removed from the database.
 		 */
-		function test_data_in_tables_after_wpmu_delete_blog_drop_true() {
+		public function test_data_in_tables_after_wpmu_delete_blog_drop_true() {
 			global $wpdb;
 
 			$blog_id = self::factory()->blog->create();
@@ -303,7 +303,7 @@ if ( is_multisite() ) :
 		/**
 		 * When the main site of a network is fully deleted, its data should be cleared from cache.
 		 */
-		function test_data_in_cache_after_wpmu_delete_blog_main_site_drop_true() {
+		public function test_data_in_cache_after_wpmu_delete_blog_main_site_drop_true() {
 			$blog_id = 1; // The main site in our test suite has an ID of 1.
 
 			$details = get_blog_details( $blog_id, false );
@@ -321,7 +321,7 @@ if ( is_multisite() ) :
 		/**
 		 * When the main site of a network is fully deleted, its data should remain in the database.
 		 */
-		function test_data_in_tables_after_wpmu_delete_blog_main_site_drop_true() {
+		public function test_data_in_tables_after_wpmu_delete_blog_main_site_drop_true() {
 			global $wpdb;
 
 			$blog_id = 1; // The main site in our test suite has an ID of 1.
@@ -344,7 +344,7 @@ if ( is_multisite() ) :
 		/**
 		 * The site count of a network should change when a site is flagged as 'deleted'.
 		 */
-		function test_network_count_after_wpmu_delete_blog_drop_false() {
+		public function test_network_count_after_wpmu_delete_blog_drop_false() {
 			$blog_id = self::factory()->blog->create();
 
 			// Delete the site without forcing a table drop.
@@ -358,7 +358,7 @@ if ( is_multisite() ) :
 		/**
 		 * The site count of a network should change when a site is fully deleted.
 		 */
-		function test_blog_count_after_wpmu_delete_blog_drop_true() {
+		public function test_blog_count_after_wpmu_delete_blog_drop_true() {
 			$blog_id = self::factory()->blog->create();
 
 			// Delete the site and force a table drop.
@@ -374,7 +374,7 @@ if ( is_multisite() ) :
 		 * that site should be removed. When wpmu_delete_blog() is run a second time, nothing
 		 * should change with upload directories.
 		 */
-		function test_upload_directories_after_multiple_wpmu_delete_blog() {
+		public function test_upload_directories_after_multiple_wpmu_delete_blog() {
 			$filename = __FUNCTION__ . '.jpg';
 			$contents = __FUNCTION__ . '_contents';
 
@@ -400,7 +400,7 @@ if ( is_multisite() ) :
 			$this->assertFileDoesNotExist( $file2['file'] );
 		}
 
-		function test_wpmu_update_blogs_date() {
+		public function test_wpmu_update_blogs_date() {
 			global $wpdb;
 
 			wpmu_update_blogs_date();
@@ -415,7 +415,7 @@ if ( is_multisite() ) :
 		/**
 		 * Provide a counter to determine that hooks are firing when intended.
 		 */
-		function _action_counter_cb() {
+		public function _action_counter_cb() {
 			global $test_action_counter;
 			$test_action_counter++;
 		}
@@ -425,7 +425,7 @@ if ( is_multisite() ) :
 		 *
 		 * @ticket 23405
 		 */
-		function test_get_blog_details_when_site_does_not_exist() {
+		public function test_get_blog_details_when_site_does_not_exist() {
 			// Create an unused site so that we can then assume an invalid site ID.
 			$blog_id = self::factory()->blog->create();
 			$blog_id++;
@@ -451,7 +451,7 @@ if ( is_multisite() ) :
 		/**
 		 * Updating a field returns the sme value that was passed.
 		 */
-		function test_update_blog_status() {
+		public function test_update_blog_status() {
 			$result = update_blog_status( 1, 'spam', 0 );
 			$this->assertSame( 0, $result );
 		}
@@ -459,12 +459,12 @@ if ( is_multisite() ) :
 		/**
 		 * Updating an invalid field returns the same value that was passed.
 		 */
-		function test_update_blog_status_invalid_status() {
+		public function test_update_blog_status_invalid_status() {
 			$result = update_blog_status( 1, 'doesnotexist', 'invalid' );
 			$this->assertSame( 'invalid', $result );
 		}
 
-		function test_update_blog_status_make_ham_blog_action() {
+		public function test_update_blog_status_make_ham_blog_action() {
 			global $test_action_counter;
 			$test_action_counter = 0;
 
@@ -488,7 +488,7 @@ if ( is_multisite() ) :
 			remove_action( 'make_ham_blog', array( $this, '_action_counter_cb' ), 10 );
 		}
 
-		function test_content_from_spam_blog_is_not_available() {
+		public function test_content_from_spam_blog_is_not_available() {
 			$spam_blog_id = self::factory()->blog->create();
 			switch_to_blog( $spam_blog_id );
 			$post_data      = array(
@@ -518,7 +518,7 @@ if ( is_multisite() ) :
 			$this->assertStringNotContainsString( "src=\"{$spam_embed_url}#?", $content );
 		}
 
-		function test_update_blog_status_make_spam_blog_action() {
+		public function test_update_blog_status_make_spam_blog_action() {
 			global $test_action_counter;
 			$test_action_counter = 0;
 
@@ -541,7 +541,7 @@ if ( is_multisite() ) :
 			remove_action( 'make_spam_blog', array( $this, '_action_counter_cb' ), 10 );
 		}
 
-		function test_update_blog_status_archive_blog_action() {
+		public function test_update_blog_status_archive_blog_action() {
 			global $test_action_counter;
 			$test_action_counter = 0;
 
@@ -564,7 +564,7 @@ if ( is_multisite() ) :
 			remove_action( 'archive_blog', array( $this, '_action_counter_cb' ), 10 );
 		}
 
-		function test_update_blog_status_unarchive_blog_action() {
+		public function test_update_blog_status_unarchive_blog_action() {
 			global $test_action_counter;
 			$test_action_counter = 0;
 
@@ -587,7 +587,7 @@ if ( is_multisite() ) :
 			remove_action( 'unarchive_blog', array( $this, '_action_counter_cb' ), 10 );
 		}
 
-		function test_update_blog_status_make_delete_blog_action() {
+		public function test_update_blog_status_make_delete_blog_action() {
 			global $test_action_counter;
 			$test_action_counter = 0;
 
@@ -610,7 +610,7 @@ if ( is_multisite() ) :
 			remove_action( 'make_delete_blog', array( $this, '_action_counter_cb' ), 10 );
 		}
 
-		function test_update_blog_status_make_undelete_blog_action() {
+		public function test_update_blog_status_make_undelete_blog_action() {
 			global $test_action_counter;
 			$test_action_counter = 0;
 
@@ -634,7 +634,7 @@ if ( is_multisite() ) :
 			remove_action( 'make_undelete_blog', array( $this, '_action_counter_cb' ), 10 );
 		}
 
-		function test_update_blog_status_mature_blog_action() {
+		public function test_update_blog_status_mature_blog_action() {
 			global $test_action_counter;
 			$test_action_counter = 0;
 
@@ -657,7 +657,7 @@ if ( is_multisite() ) :
 			remove_action( 'mature_blog', array( $this, '_action_counter_cb' ), 10 );
 		}
 
-		function test_update_blog_status_unmature_blog_action() {
+		public function test_update_blog_status_unmature_blog_action() {
 			global $test_action_counter;
 			$test_action_counter = 0;
 
@@ -681,7 +681,7 @@ if ( is_multisite() ) :
 			remove_action( 'unmature_blog', array( $this, '_action_counter_cb' ), 10 );
 		}
 
-		function test_update_blog_status_update_blog_public_action() {
+		public function test_update_blog_status_update_blog_public_action() {
 			global $test_action_counter;
 			$test_action_counter = 0;
 
@@ -707,7 +707,7 @@ if ( is_multisite() ) :
 		/**
 		 * @ticket 27952
 		 */
-		function test_posts_count() {
+		public function test_posts_count() {
 			self::factory()->post->create();
 			$post2 = self::factory()->post->create();
 			$this->assertSame( 2, get_site()->post_count );
@@ -719,7 +719,7 @@ if ( is_multisite() ) :
 		/**
 		 * @ticket 26410
 		 */
-		function test_blog_details_cache_invalidation() {
+		public function test_blog_details_cache_invalidation() {
 			update_option( 'blogname', 'foo' );
 			$details = get_site( get_current_blog_id() );
 			$this->assertSame( 'foo', $details->blogname );
@@ -733,7 +733,7 @@ if ( is_multisite() ) :
 		 * Test the original and cached responses for a created and then deleted site when
 		 * the blog ID is requested through get_blog_id_from_url().
 		 */
-		function test_get_blog_id_from_url() {
+		public function test_get_blog_id_from_url() {
 			$blog_id = self::factory()->blog->create();
 			$details = get_site( $blog_id );
 			$key     = md5( $details->domain . $details->path );
@@ -746,7 +746,7 @@ if ( is_multisite() ) :
 		/**
 		 * Test the case insensitivity of the site lookup.
 		 */
-		function test_get_blog_id_from_url_is_case_insensitive() {
+		public function test_get_blog_id_from_url_is_case_insensitive() {
 			$blog_id = self::factory()->blog->create(
 				array(
 					'domain' => 'example.com',
@@ -761,7 +761,7 @@ if ( is_multisite() ) :
 		/**
 		 * Test the first and cached responses for a site that does not exist.
 		 */
-		function test_get_blog_id_from_url_that_does_not_exist() {
+		public function test_get_blog_id_from_url_that_does_not_exist() {
 			$blog_id = self::factory()->blog->create( array( 'path' => '/xyz' ) );
 			$details = get_site( $blog_id );
 
@@ -773,7 +773,7 @@ if ( is_multisite() ) :
 		 * A blog ID is still available if only the `deleted` flag is set for a site. The same
 		 * behavior would be expected if passing `false` explicitly to `wpmu_delete_blog()`.
 		 */
-		function test_get_blog_id_from_url_with_deleted_flag() {
+		public function test_get_blog_id_from_url_with_deleted_flag() {
 			$blog_id = self::factory()->blog->create();
 			$details = get_site( $blog_id );
 			$key     = md5( $details->domain . $details->path );
@@ -787,7 +787,7 @@ if ( is_multisite() ) :
 		 * When deleted with the drop parameter as true, the cache will first be false, then set to
 		 * -1 after an attempt at `get_blog_id_from_url()` is made.
 		 */
-		function test_get_blog_id_from_url_after_dropped() {
+		public function test_get_blog_id_from_url_after_dropped() {
 			$blog_id = self::factory()->blog->create();
 			$details = get_site( $blog_id );
 			$key     = md5( $details->domain . $details->path );
@@ -801,7 +801,7 @@ if ( is_multisite() ) :
 		/**
 		 * Test with default parameter of site_id as null.
 		 */
-		function test_is_main_site() {
+		public function test_is_main_site() {
 			$this->assertTrue( is_main_site() );
 		}
 
@@ -809,14 +809,14 @@ if ( is_multisite() ) :
 		 * Test with a site id of get_current_blog_id(), which should be the same as the
 		 * default parameter tested above.
 		 */
-		function test_current_blog_id_is_main_site() {
+		public function test_current_blog_id_is_main_site() {
 			$this->assertTrue( is_main_site( get_current_blog_id() ) );
 		}
 
 		/**
 		 * Test with a site ID other than the main site to ensure a false response.
 		 */
-		function test_is_main_site_is_false_with_other_blog_id() {
+		public function test_is_main_site_is_false_with_other_blog_id() {
 			$blog_id = self::factory()->blog->create();
 
 			$this->assertFalse( is_main_site( $blog_id ) );
@@ -825,7 +825,7 @@ if ( is_multisite() ) :
 		/**
 		 * Test with no passed ID after switching to another site ID.
 		 */
-		function test_is_main_site_is_false_after_switch_to_blog() {
+		public function test_is_main_site_is_false_after_switch_to_blog() {
 			$blog_id = self::factory()->blog->create();
 			switch_to_blog( $blog_id );
 
@@ -834,7 +834,7 @@ if ( is_multisite() ) :
 			restore_current_blog();
 		}
 
-		function test_switch_upload_dir() {
+		public function test_switch_upload_dir() {
 			$this->assertTrue( is_main_site() );
 
 			$site = get_current_site();
@@ -867,7 +867,7 @@ if ( is_multisite() ) :
 		 * Test the primary purpose of get_blog_post(), to retrieve a post from
 		 * another site on the network.
 		 */
-		function test_get_blog_post_from_another_site_on_network() {
+		public function test_get_blog_post_from_another_site_on_network() {
 			$blog_id = self::factory()->blog->create();
 			$post_id = self::factory()->post->create(); // Create a post on the primary site, ID 1.
 			$post    = get_post( $post_id );
@@ -882,7 +882,7 @@ if ( is_multisite() ) :
 		/**
 		 * If get_blog_post() is used on the same site, it should still work.
 		 */
-		function test_get_blog_post_from_same_site() {
+		public function test_get_blog_post_from_same_site() {
 			$post_id = self::factory()->post->create();
 
 			$this->assertEquals( get_blog_post( 1, $post_id ), get_post( $post_id ) );
@@ -891,7 +891,7 @@ if ( is_multisite() ) :
 		/**
 		 * A null response should be returned if an invalid post is requested.
 		 */
-		function test_get_blog_post_invalid_returns_null() {
+		public function test_get_blog_post_invalid_returns_null() {
 			$this->assertNull( get_blog_post( 1, 999999 ) );
 		}
 
@@ -899,7 +899,7 @@ if ( is_multisite() ) :
 		 * Added as a callback to the domain_exists filter to provide manual results for
 		 * the testing of the filter and for a test which does not need the database.
 		 */
-		function _domain_exists_cb( $exists, $domain, $path, $site_id ) {
+		public function _domain_exists_cb( $exists, $domain, $path, $site_id ) {
 			if ( 'foo' === $domain && 'bar/' === $path ) {
 				return 1234;
 			} else {
@@ -907,13 +907,13 @@ if ( is_multisite() ) :
 			}
 		}
 
-		function test_domain_exists_with_default_site_id() {
+		public function test_domain_exists_with_default_site_id() {
 			$details = get_site( 1 );
 
 			$this->assertSame( 1, domain_exists( $details->domain, $details->path ) );
 		}
 
-		function test_domain_exists_with_specified_site_id() {
+		public function test_domain_exists_with_specified_site_id() {
 			$details = get_site( 1 );
 
 			$this->assertSame( 1, domain_exists( $details->domain, $details->path, $details->site_id ) );
@@ -923,17 +923,17 @@ if ( is_multisite() ) :
 		 * When the domain is valid, but the resulting site does not belong to the specified network,
 		 * it is marked as not existing.
 		 */
-		function test_domain_does_not_exist_with_invalid_site_id() {
+		public function test_domain_does_not_exist_with_invalid_site_id() {
 			$details = get_site( 1 );
 
 			$this->assertNull( domain_exists( $details->domain, $details->path, 999 ) );
 		}
 
-		function test_invalid_domain_does_not_exist_with_default_site_id() {
+		public function test_invalid_domain_does_not_exist_with_default_site_id() {
 			$this->assertNull( domain_exists( 'foo', 'bar' ) );
 		}
 
-		function test_domain_filtered_to_exist() {
+		public function test_domain_filtered_to_exist() {
 			add_filter( 'domain_exists', array( $this, '_domain_exists_cb' ), 10, 4 );
 			$exists = domain_exists( 'foo', 'bar' );
 			remove_filter( 'domain_exists', array( $this, '_domain_exists_cb' ), 10, 4 );
@@ -944,7 +944,7 @@ if ( is_multisite() ) :
 		 * When a path is passed to domain_exists, it is immediately trailing slashed. A path
 		 * value with or without the slash should result in the same return value.
 		 */
-		function test_slashed_path_in_domain_exists() {
+		public function test_slashed_path_in_domain_exists() {
 			add_filter( 'domain_exists', array( $this, '_domain_exists_cb' ), 10, 4 );
 			$exists1 = domain_exists( 'foo', 'bar' );
 			$exists2 = domain_exists( 'foo', 'bar/' );
@@ -957,7 +957,7 @@ if ( is_multisite() ) :
 		/**
 		 * Tests returning an address for a given valid ID.
 		 */
-		function test_get_blogaddress_by_id_with_valid_id() {
+		public function test_get_blogaddress_by_id_with_valid_id() {
 			$blogaddress = get_blogaddress_by_id( 1 );
 			$this->assertSame( 'http://' . WP_TESTS_DOMAIN . '/', $blogaddress );
 		}
@@ -965,7 +965,7 @@ if ( is_multisite() ) :
 		/**
 		 * Tests returning the appropriate response for a invalid id given.
 		 */
-		function test_get_blogaddress_by_id_with_invalid_id() {
+		public function test_get_blogaddress_by_id_with_invalid_id() {
 			$blogaddress = get_blogaddress_by_id( 42 );
 			$this->assertSame( '', $blogaddress );
 		}
@@ -973,7 +973,7 @@ if ( is_multisite() ) :
 		/**
 		 * @ticket 14867
 		 */
-		function test_get_blogaddress_by_id_scheme_reflects_blog_scheme() {
+		public function test_get_blogaddress_by_id_scheme_reflects_blog_scheme() {
 			$blog = self::factory()->blog->create();
 
 			$this->assertSame( 'http', parse_url( get_blogaddress_by_id( $blog ), PHP_URL_SCHEME ) );
@@ -986,7 +986,7 @@ if ( is_multisite() ) :
 		/**
 		 * @ticket 14867
 		 */
-		function test_get_blogaddress_by_id_scheme_is_unaffected_by_request() {
+		public function test_get_blogaddress_by_id_scheme_is_unaffected_by_request() {
 			$blog = self::factory()->blog->create();
 
 			$this->assertFalse( is_ssl() );
@@ -1005,7 +1005,7 @@ if ( is_multisite() ) :
 		 * @ticket 33620
 		 * @dataProvider data_new_blog_url_schemes
 		 */
-		function test_new_blog_url_schemes( $home_scheme, $siteurl_scheme, $force_ssl_admin ) {
+		public function test_new_blog_url_schemes( $home_scheme, $siteurl_scheme, $force_ssl_admin ) {
 			$current_site = get_current_site();
 
 			$home    = get_option( 'home' );
@@ -1031,7 +1031,7 @@ if ( is_multisite() ) :
 			$this->assertSame( $siteurl_scheme, parse_url( get_blog_option( $new, 'siteurl' ), PHP_URL_SCHEME ) );
 		}
 
-		function data_new_blog_url_schemes() {
+		public function data_new_blog_url_schemes() {
 			return array(
 				array(
 					'https',
@@ -1064,7 +1064,7 @@ if ( is_multisite() ) :
 		/**
 		 * @ticket 36918
 		 */
-		function test_new_blog_locale() {
+		public function test_new_blog_locale() {
 			$current_site = get_current_site();
 
 			add_filter( 'sanitize_option_WPLANG', array( $this, 'filter_allow_unavailable_languages' ), 10, 3 );
@@ -1099,7 +1099,7 @@ if ( is_multisite() ) :
 		/**
 		 * @ticket 40503
 		 */
-		function test_different_network_language() {
+		public function test_different_network_language() {
 			$network = get_network( self::$network_ids['make.wordpress.org/'] );
 
 			add_filter( 'sanitize_option_WPLANG', array( $this, 'filter_allow_unavailable_languages' ), 10, 3 );
@@ -1120,7 +1120,7 @@ if ( is_multisite() ) :
 		 * @param string $original_value The original value passed to the function.
 		 * @return string The orginal value.
 		 */
-		function filter_allow_unavailable_languages( $value, $option, $original_value ) {
+		public function filter_allow_unavailable_languages( $value, $option, $original_value ) {
 			return $original_value;
 		}
 

--- a/tests/phpunit/tests/multisite/updateBlogDetails.php
+++ b/tests/phpunit/tests/multisite/updateBlogDetails.php
@@ -11,7 +11,7 @@ if ( is_multisite() ) :
 		 * If `update_blog_details()` is called with any kind of empty arguments, it
 		 * should return false.
 		 */
-		function test_update_blog_details_with_empty_args() {
+		public function test_update_blog_details_with_empty_args() {
 			$result = update_blog_details( 1, array() );
 			$this->assertFalse( $result );
 		}
@@ -19,12 +19,12 @@ if ( is_multisite() ) :
 		/**
 		 * If the ID passed is not that of a current site, we should expect false.
 		 */
-		function test_update_blog_details_invalid_blog_id() {
+		public function test_update_blog_details_invalid_blog_id() {
 			$result = update_blog_details( 999, array( 'domain' => 'example.com' ) );
 			$this->assertFalse( $result );
 		}
 
-		function test_update_blog_details() {
+		public function test_update_blog_details() {
 			$blog_id = self::factory()->blog->create();
 
 			$result = update_blog_details(
@@ -101,7 +101,7 @@ if ( is_multisite() ) :
 		/**
 		 * Provide a counter to determine that hooks are firing when intended.
 		 */
-		function _action_counter_cb() {
+		public function _action_counter_cb() {
 			global $test_action_counter;
 			$test_action_counter++;
 		}

--- a/tests/phpunit/tests/multisite/updateBlogDetails.php
+++ b/tests/phpunit/tests/multisite/updateBlogDetails.php
@@ -66,7 +66,7 @@ if ( is_multisite() ) :
 				update_blog_details( $blog_id, array( $flag => '1' ) );
 			}
 
-			add_action( $hook, array( $this, '_action_counter_cb' ), 10 );
+			add_action( $hook, array( $this, 'action_counter_cb' ), 10 );
 
 			update_blog_details( $blog_id, array( $flag => $flag_value ) );
 			$blog = get_site( $blog_id );
@@ -82,7 +82,7 @@ if ( is_multisite() ) :
 			// The hook attached to this flag should not have fired again.
 			$this->assertSame( 1, $test_action_counter );
 
-			remove_action( $hook, array( $this, '_action_counter_cb' ), 10 );
+			remove_action( $hook, array( $this, 'action_counter_cb' ), 10 );
 		}
 
 		public function data_flag_hooks() {
@@ -101,7 +101,7 @@ if ( is_multisite() ) :
 		/**
 		 * Provide a counter to determine that hooks are firing when intended.
 		 */
-		public function _action_counter_cb() {
+		public function action_counter_cb() {
 			global $test_action_counter;
 			$test_action_counter++;
 		}

--- a/tests/phpunit/tests/multisite/wpMsSitesListTable.php
+++ b/tests/phpunit/tests/multisite/wpMsSitesListTable.php
@@ -14,7 +14,7 @@ if ( is_multisite() ) :
 		 */
 		public $table = false;
 
-		function set_up() {
+		public function set_up() {
 			parent::set_up();
 			$this->table = _get_list_table( 'WP_MS_Sites_List_Table', array( 'screen' => 'ms-sites' ) );
 		}

--- a/tests/phpunit/tests/oembed/controller.php
+++ b/tests/phpunit/tests/oembed/controller.php
@@ -175,7 +175,7 @@ class Test_oEmbed_Controller extends WP_UnitTestCase {
 		return $data;
 	}
 
-	function test_wp_oembed_ensure_format() {
+	public function test_wp_oembed_ensure_format() {
 		$this->assertSame( 'json', wp_oembed_ensure_format( 'json' ) );
 		$this->assertSame( 'xml', wp_oembed_ensure_format( 'xml' ) );
 		$this->assertSame( 'json', wp_oembed_ensure_format( 123 ) );
@@ -183,7 +183,7 @@ class Test_oEmbed_Controller extends WP_UnitTestCase {
 		$this->assertSame( 'json', wp_oembed_ensure_format( array() ) );
 	}
 
-	function test_oembed_create_xml() {
+	public function test_oembed_create_xml() {
 		$actual = _oembed_create_xml(
 			array(
 				'foo'  => 'bar',
@@ -260,7 +260,7 @@ class Test_oEmbed_Controller extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'args', $proxy_route[0] );
 	}
 
-	function test_request_with_wrong_method() {
+	public function test_request_with_wrong_method() {
 		$request = new WP_REST_Request( 'POST', '/oembed/1.0/embed' );
 
 		$response = rest_get_server()->dispatch( $request );
@@ -269,7 +269,7 @@ class Test_oEmbed_Controller extends WP_UnitTestCase {
 		$this->assertSame( 'rest_no_route', $data['code'] );
 	}
 
-	function test_request_without_url_param() {
+	public function test_request_without_url_param() {
 		$request = new WP_REST_Request( 'GET', '/oembed/1.0/embed' );
 
 		$response = rest_get_server()->dispatch( $request );
@@ -279,7 +279,7 @@ class Test_oEmbed_Controller extends WP_UnitTestCase {
 		$this->assertSame( 'url', $data['data']['params'][0] );
 	}
 
-	function test_request_with_bad_url() {
+	public function test_request_with_bad_url() {
 		$request = new WP_REST_Request( 'GET', '/oembed/1.0/embed' );
 		$request->set_param( 'url', 'http://google.com/' );
 
@@ -289,7 +289,7 @@ class Test_oEmbed_Controller extends WP_UnitTestCase {
 		$this->assertSame( 'oembed_invalid_url', $data['code'] );
 	}
 
-	function test_request_invalid_format() {
+	public function test_request_invalid_format() {
 		$post_id = $this->factory()->post->create();
 
 		$request = new WP_REST_Request( 'GET', '/oembed/1.0/embed' );
@@ -303,7 +303,7 @@ class Test_oEmbed_Controller extends WP_UnitTestCase {
 		$this->assertNotEmpty( $data );
 	}
 
-	function test_request_json() {
+	public function test_request_json() {
 		$user = self::factory()->user->create_and_get(
 			array(
 				'display_name' => 'John Doe',
@@ -348,7 +348,7 @@ class Test_oEmbed_Controller extends WP_UnitTestCase {
 	/**
 	 * @ticket 34971
 	 */
-	function test_request_static_front_page() {
+	public function test_request_static_front_page() {
 		$post = self::factory()->post->create_and_get(
 			array(
 				'post_title' => 'Front page',
@@ -390,7 +390,7 @@ class Test_oEmbed_Controller extends WP_UnitTestCase {
 		update_option( 'show_on_front', 'posts' );
 	}
 
-	function test_request_xml() {
+	public function test_request_xml() {
 		$user = self::factory()->user->create_and_get(
 			array(
 				'display_name' => 'John Doe',
@@ -437,7 +437,7 @@ class Test_oEmbed_Controller extends WP_UnitTestCase {
 	 * @group multisite
 	 * @group ms-required
 	 */
-	function test_request_ms_child_in_root_blog() {
+	public function test_request_ms_child_in_root_blog() {
 		$child = self::factory()->blog->create();
 		switch_to_blog( $child );
 
@@ -460,7 +460,7 @@ class Test_oEmbed_Controller extends WP_UnitTestCase {
 		restore_current_blog();
 	}
 
-	function test_rest_pre_serve_request() {
+	public function test_rest_pre_serve_request() {
 		$user = $this->factory()->user->create_and_get(
 			array(
 				'display_name' => 'John Doe',
@@ -484,7 +484,7 @@ class Test_oEmbed_Controller extends WP_UnitTestCase {
 		$this->assertInstanceOf( 'SimpleXMLElement', $xml );
 	}
 
-	function test_rest_pre_serve_request_wrong_format() {
+	public function test_rest_pre_serve_request_wrong_format() {
 		$post = $this->factory()->post->create_and_get();
 
 		$request = new WP_REST_Request( 'GET', '/oembed/1.0/embed' );
@@ -496,7 +496,7 @@ class Test_oEmbed_Controller extends WP_UnitTestCase {
 		$this->assertTrue( _oembed_rest_pre_serve_request( true, $response, $request, rest_get_server() ) );
 	}
 
-	function test_rest_pre_serve_request_wrong_method() {
+	public function test_rest_pre_serve_request_wrong_method() {
 		$post = $this->factory()->post->create_and_get();
 
 		$request = new WP_REST_Request( 'HEAD', '/oembed/1.0/embed' );
@@ -508,7 +508,7 @@ class Test_oEmbed_Controller extends WP_UnitTestCase {
 		$this->assertTrue( _oembed_rest_pre_serve_request( true, $response, $request, rest_get_server() ) );
 	}
 
-	function test_get_oembed_endpoint_url() {
+	public function test_get_oembed_endpoint_url() {
 		$this->assertSame( home_url() . '/index.php?rest_route=/oembed/1.0/embed', get_oembed_endpoint_url() );
 		$this->assertSame( home_url() . '/index.php?rest_route=/oembed/1.0/embed', get_oembed_endpoint_url( '', 'json' ) );
 		$this->assertSame( home_url() . '/index.php?rest_route=/oembed/1.0/embed', get_oembed_endpoint_url( '', 'xml' ) );
@@ -521,7 +521,7 @@ class Test_oEmbed_Controller extends WP_UnitTestCase {
 		$this->assertSame( home_url() . '/index.php?rest_route=%2Foembed%2F1.0%2Fembed&url=' . $url_encoded . '&format=xml', get_oembed_endpoint_url( $url, 'xml' ) );
 	}
 
-	function test_get_oembed_endpoint_url_pretty_permalinks() {
+	public function test_get_oembed_endpoint_url_pretty_permalinks() {
 		update_option( 'permalink_structure', '/%postname%' );
 
 		$this->assertSame( home_url() . '/wp-json/oembed/1.0/embed', get_oembed_endpoint_url() );
@@ -674,7 +674,7 @@ class Test_oEmbed_Controller extends WP_UnitTestCase {
 	/**
 	 * @ticket 45142
 	 */
-	function test_proxy_with_internal_url() {
+	public function test_proxy_with_internal_url() {
 		wp_set_current_user( self::$editor );
 
 		$user = self::factory()->user->create_and_get(
@@ -722,7 +722,7 @@ class Test_oEmbed_Controller extends WP_UnitTestCase {
 	/**
 	 * @ticket 45142
 	 */
-	function test_proxy_with_static_front_page_url() {
+	public function test_proxy_with_static_front_page_url() {
 		wp_set_current_user( self::$editor );
 
 		$post = self::factory()->post->create_and_get(

--- a/tests/phpunit/tests/oembed/discovery.php
+++ b/tests/phpunit/tests/oembed/discovery.php
@@ -4,11 +4,11 @@
  * @group oembed
  */
 class Tests_oEmbed_Discovery extends WP_UnitTestCase {
-	function test_add_oembed_discovery_links_non_singular() {
+	public function test_add_oembed_discovery_links_non_singular() {
 		$this->assertSame( '', get_echo( 'wp_oembed_add_discovery_links' ) );
 	}
 
-	function test_add_oembed_discovery_links_front_page() {
+	public function test_add_oembed_discovery_links_front_page() {
 		$this->go_to( home_url() );
 		$this->assertSame( '', get_echo( 'wp_oembed_add_discovery_links' ) );
 		$this->assertSame( 0, url_to_postid( home_url() ) );
@@ -17,7 +17,7 @@ class Tests_oEmbed_Discovery extends WP_UnitTestCase {
 	/**
 	 * @ticket 34971
 	 */
-	function test_add_oembed_discovery_links_static_front_page() {
+	public function test_add_oembed_discovery_links_static_front_page() {
 		update_option( 'show_on_front', 'page' );
 		update_option(
 			'page_on_front',
@@ -40,7 +40,7 @@ class Tests_oEmbed_Discovery extends WP_UnitTestCase {
 		update_option( 'show_on_front', 'posts' );
 	}
 
-	function test_add_oembed_discovery_links_to_post() {
+	public function test_add_oembed_discovery_links_to_post() {
 		$post_id = self::factory()->post->create();
 		$this->go_to( get_permalink( $post_id ) );
 		$this->assertQueryTrue( 'is_single', 'is_singular' );
@@ -51,7 +51,7 @@ class Tests_oEmbed_Discovery extends WP_UnitTestCase {
 		$this->assertSame( $expected, get_echo( 'wp_oembed_add_discovery_links' ) );
 	}
 
-	function test_add_oembed_discovery_links_to_page() {
+	public function test_add_oembed_discovery_links_to_page() {
 		$post_id = self::factory()->post->create(
 			array(
 				'post_type' => 'page',
@@ -66,7 +66,7 @@ class Tests_oEmbed_Discovery extends WP_UnitTestCase {
 		$this->assertSame( $expected, get_echo( 'wp_oembed_add_discovery_links' ) );
 	}
 
-	function test_add_oembed_discovery_links_to_attachment() {
+	public function test_add_oembed_discovery_links_to_attachment() {
 		$post_id       = self::factory()->post->create();
 		$file          = DIR_TESTDATA . '/images/canola.jpg';
 		$attachment_id = self::factory()->attachment->create_object(

--- a/tests/phpunit/tests/oembed/filterResult.php
+++ b/tests/phpunit/tests/oembed/filterResult.php
@@ -4,7 +4,7 @@
  * @group oembed
  */
 class Tests_Filter_oEmbed_Result extends WP_UnitTestCase {
-	function test_filter_oembed_result_trusted_malicious_iframe() {
+	public function test_filter_oembed_result_trusted_malicious_iframe() {
 		$html = '<p></p><iframe onload="alert(1)"></iframe>';
 
 		$actual = wp_filter_oembed_result( $html, (object) array( 'type' => 'rich' ), 'https://www.youtube.com/watch?v=72xdCU__XCk' );
@@ -12,7 +12,7 @@ class Tests_Filter_oEmbed_Result extends WP_UnitTestCase {
 		$this->assertSame( $html, $actual );
 	}
 
-	function test_filter_oembed_result_with_untrusted_provider() {
+	public function test_filter_oembed_result_with_untrusted_provider() {
 		$html   = '<p></p><iframe onload="alert(1)" src="http://example.com/sample-page/"></iframe>';
 		$actual = wp_filter_oembed_result( $html, (object) array( 'type' => 'rich' ), 'http://example.com/sample-page/' );
 
@@ -24,14 +24,14 @@ class Tests_Filter_oEmbed_Result extends WP_UnitTestCase {
 		$this->assertSame( $matches[1], $matches[2] );
 	}
 
-	function test_filter_oembed_result_only_one_iframe_is_allowed() {
+	public function test_filter_oembed_result_only_one_iframe_is_allowed() {
 		$html   = '<div><iframe></iframe><iframe></iframe><p></p></div>';
 		$actual = wp_filter_oembed_result( $html, (object) array( 'type' => 'rich' ), '' );
 
 		$this->assertSame( '<iframe class="wp-embedded-content" sandbox="allow-scripts" security="restricted"></iframe>', $actual );
 	}
 
-	function test_filter_oembed_result_with_newlines() {
+	public function test_filter_oembed_result_with_newlines() {
 		$html = <<<EOD
 <script>var = 1;</script>
 <iframe></iframe>
@@ -44,7 +44,7 @@ EOD;
 		$this->assertSame( '<iframe class="wp-embedded-content" sandbox="allow-scripts" security="restricted"></iframe>', $actual );
 	}
 
-	function test_filter_oembed_result_without_iframe() {
+	public function test_filter_oembed_result_without_iframe() {
 		$html   = '<span>Hello</span><p>World</p>';
 		$actual = wp_filter_oembed_result( $html, (object) array( 'type' => 'rich' ), '' );
 
@@ -56,7 +56,7 @@ EOD;
 		$this->assertFalse( $actual );
 	}
 
-	function test_filter_oembed_result_secret_param_available() {
+	public function test_filter_oembed_result_secret_param_available() {
 		$html   = '<iframe src="https://wordpress.org"></iframe>';
 		$actual = wp_filter_oembed_result( $html, (object) array( 'type' => 'rich' ), '' );
 
@@ -68,25 +68,25 @@ EOD;
 		$this->assertSame( $matches[1], $matches[2] );
 	}
 
-	function test_filter_oembed_result_wrong_type_provided() {
+	public function test_filter_oembed_result_wrong_type_provided() {
 		$actual = wp_filter_oembed_result( 'some string', (object) array( 'type' => 'link' ), '' );
 
 		$this->assertSame( 'some string', $actual );
 	}
 
-	function test_filter_oembed_result_invalid_result() {
+	public function test_filter_oembed_result_invalid_result() {
 		$this->assertFalse( wp_filter_oembed_result( false, (object) array( 'type' => 'rich' ), '' ) );
 		$this->assertFalse( wp_filter_oembed_result( '', (object) array( 'type' => 'rich' ), '' ) );
 	}
 
-	function test_filter_oembed_result_blockquote_adds_style_to_iframe() {
+	public function test_filter_oembed_result_blockquote_adds_style_to_iframe() {
 		$html   = '<blockquote></blockquote><iframe></iframe>';
 		$actual = wp_filter_oembed_result( $html, (object) array( 'type' => 'rich' ), '' );
 
 		$this->assertSame( '<blockquote class="wp-embedded-content"></blockquote><iframe class="wp-embedded-content" sandbox="allow-scripts" security="restricted" style="position: absolute; clip: rect(1px, 1px, 1px, 1px);"></iframe>', $actual );
 	}
 
-	function test_filter_oembed_result_allowed_html() {
+	public function test_filter_oembed_result_allowed_html() {
 		$html   = '<blockquote class="foo" id="bar"><strong><a href="" target=""></a></strong></blockquote><iframe></iframe>';
 		$actual = wp_filter_oembed_result( $html, (object) array( 'type' => 'rich' ), '' );
 
@@ -130,7 +130,7 @@ EOD;
 	/**
 	 * @group feed
 	 */
-	function test_filter_feed_content() {
+	public function test_filter_feed_content() {
 		$html   = '<blockquote></blockquote><iframe></iframe>';
 		$actual = _oembed_filter_feed_content( wp_filter_oembed_result( $html, (object) array( 'type' => 'rich' ), '' ) );
 

--- a/tests/phpunit/tests/oembed/getResponseData.php
+++ b/tests/phpunit/tests/oembed/getResponseData.php
@@ -12,11 +12,11 @@ class Tests_oEmbed_Response_Data extends WP_UnitTestCase {
 		self::touch( ABSPATH . WPINC . '/js/wp-embed.js' );
 	}
 
-	function test_get_oembed_response_data_non_existent_post() {
+	public function test_get_oembed_response_data_non_existent_post() {
 		$this->assertFalse( get_oembed_response_data( 0, 100 ) );
 	}
 
-	function test_get_oembed_response_data() {
+	public function test_get_oembed_response_data() {
 		$post = self::factory()->post->create_and_get(
 			array(
 				'post_title' => 'Some Post',
@@ -45,7 +45,7 @@ class Tests_oEmbed_Response_Data extends WP_UnitTestCase {
 	/**
 	 * Test get_oembed_response_data with an author.
 	 */
-	function test_get_oembed_response_data_author() {
+	public function test_get_oembed_response_data_author() {
 		$user_id = self::factory()->user->create(
 			array(
 				'display_name' => 'John Doe',
@@ -78,7 +78,7 @@ class Tests_oEmbed_Response_Data extends WP_UnitTestCase {
 		);
 	}
 
-	function test_get_oembed_response_link() {
+	public function test_get_oembed_response_link() {
 		remove_filter( 'oembed_response_data', 'get_oembed_response_data_rich' );
 
 		$post = self::factory()->post->create_and_get(
@@ -105,7 +105,7 @@ class Tests_oEmbed_Response_Data extends WP_UnitTestCase {
 		add_filter( 'oembed_response_data', 'get_oembed_response_data_rich', 10, 4 );
 	}
 
-	function test_get_oembed_response_data_with_draft_post() {
+	public function test_get_oembed_response_data_with_draft_post() {
 		$post = self::factory()->post->create_and_get(
 			array(
 				'post_status' => 'draft',
@@ -115,7 +115,7 @@ class Tests_oEmbed_Response_Data extends WP_UnitTestCase {
 		$this->assertFalse( get_oembed_response_data( $post, 100 ) );
 	}
 
-	function test_get_oembed_response_data_with_scheduled_post() {
+	public function test_get_oembed_response_data_with_scheduled_post() {
 		$post = self::factory()->post->create_and_get(
 			array(
 				'post_status' => 'future',
@@ -126,7 +126,7 @@ class Tests_oEmbed_Response_Data extends WP_UnitTestCase {
 		$this->assertFalse( get_oembed_response_data( $post, 100 ) );
 	}
 
-	function test_get_oembed_response_data_with_private_post() {
+	public function test_get_oembed_response_data_with_private_post() {
 		$post = self::factory()->post->create_and_get(
 			array(
 				'post_status' => 'private',
@@ -139,7 +139,7 @@ class Tests_oEmbed_Response_Data extends WP_UnitTestCase {
 	/**
 	 * @ticket 47574
 	 */
-	function test_get_oembed_response_data_with_public_true_custom_post_status() {
+	public function test_get_oembed_response_data_with_public_true_custom_post_status() {
 		// Custom status with 'public' => true.
 		register_post_status( 'public', array( 'public' => true ) );
 
@@ -155,7 +155,7 @@ class Tests_oEmbed_Response_Data extends WP_UnitTestCase {
 	/**
 	 * @ticket 47574
 	 */
-	function test_get_oembed_response_data_with_public_false_custom_post_status() {
+	public function test_get_oembed_response_data_with_public_false_custom_post_status() {
 		// Custom status with 'public' => false.
 		register_post_status( 'private_foo', array( 'public' => false ) );
 
@@ -171,7 +171,7 @@ class Tests_oEmbed_Response_Data extends WP_UnitTestCase {
 	/**
 	 * @ticket 47574
 	 */
-	function test_get_oembed_response_data_with_unregistered_custom_post_status() {
+	public function test_get_oembed_response_data_with_unregistered_custom_post_status() {
 		$post = self::factory()->post->create_and_get(
 			array(
 				'post_status' => 'unknown_foo',
@@ -181,7 +181,7 @@ class Tests_oEmbed_Response_Data extends WP_UnitTestCase {
 		$this->assertFalse( get_oembed_response_data( $post, 100 ) );
 	}
 
-	function test_get_oembed_response_data_maxwidth_too_high() {
+	public function test_get_oembed_response_data_maxwidth_too_high() {
 		$post = self::factory()->post->create_and_get();
 
 		$data = get_oembed_response_data( $post, 1000 );
@@ -190,7 +190,7 @@ class Tests_oEmbed_Response_Data extends WP_UnitTestCase {
 		$this->assertSame( 338, $data['height'] );
 	}
 
-	function test_get_oembed_response_data_maxwidth_too_low() {
+	public function test_get_oembed_response_data_maxwidth_too_low() {
 		$post = self::factory()->post->create_and_get();
 
 		$data = get_oembed_response_data( $post, 100 );
@@ -199,7 +199,7 @@ class Tests_oEmbed_Response_Data extends WP_UnitTestCase {
 		$this->assertSame( 200, $data['height'] );
 	}
 
-	function test_get_oembed_response_data_maxwidth_invalid() {
+	public function test_get_oembed_response_data_maxwidth_invalid() {
 		$post = self::factory()->post->create_and_get();
 
 		$data = get_oembed_response_data( $post, '400;" DROP TABLES' );
@@ -213,7 +213,7 @@ class Tests_oEmbed_Response_Data extends WP_UnitTestCase {
 		$this->assertSame( 200, $data['height'] );
 	}
 
-	function test_get_oembed_response_data_with_thumbnail() {
+	public function test_get_oembed_response_data_with_thumbnail() {
 		$post          = self::factory()->post->create_and_get();
 		$file          = DIR_TESTDATA . '/images/canola.jpg';
 		$attachment_id = self::factory()->attachment->create_object(
@@ -233,7 +233,7 @@ class Tests_oEmbed_Response_Data extends WP_UnitTestCase {
 		$this->assertTrue( 400 >= $data['thumbnail_width'] );
 	}
 
-	function test_get_oembed_response_data_for_attachment() {
+	public function test_get_oembed_response_data_for_attachment() {
 		$parent = self::factory()->post->create();
 		$file   = DIR_TESTDATA . '/images/canola.jpg';
 		$post   = self::factory()->attachment->create_object(

--- a/tests/phpunit/tests/oembed/headers.php
+++ b/tests/phpunit/tests/oembed/headers.php
@@ -12,7 +12,7 @@ class Tests_oEmbed_HTTP_Headers extends WP_UnitTestCase {
 	/**
 	 * @requires function xdebug_get_headers
 	 */
-	function test_rest_pre_serve_request_headers() {
+	public function test_rest_pre_serve_request_headers() {
 		$post = $this->factory()->post->create_and_get(
 			array(
 				'post_title' => 'Hello World',

--- a/tests/phpunit/tests/oembed/postEmbedUrl.php
+++ b/tests/phpunit/tests/oembed/postEmbedUrl.php
@@ -4,12 +4,12 @@
  * @group oembed
  */
 class Tests_Post_Embed_URL extends WP_UnitTestCase {
-	function test_non_existent_post() {
+	public function test_non_existent_post() {
 		$embed_url = get_post_embed_url( 0 );
 		$this->assertFalse( $embed_url );
 	}
 
-	function test_with_pretty_permalinks() {
+	public function test_with_pretty_permalinks() {
 		$this->set_permalink_structure( '/%postname%' );
 
 		$post_id   = self::factory()->post->create();
@@ -19,7 +19,7 @@ class Tests_Post_Embed_URL extends WP_UnitTestCase {
 		$this->assertSame( $permalink . '/embed', $embed_url );
 	}
 
-	function test_with_ugly_permalinks() {
+	public function test_with_ugly_permalinks() {
 		$post_id   = self::factory()->post->create();
 		$permalink = get_permalink( $post_id );
 		$embed_url = get_post_embed_url( $post_id );
@@ -30,7 +30,7 @@ class Tests_Post_Embed_URL extends WP_UnitTestCase {
 	/**
 	 * @ticket 34971
 	 */
-	function test_static_front_page() {
+	public function test_static_front_page() {
 		$this->set_permalink_structure( '/%postname%/' );
 
 		$post_id = self::factory()->post->create( array( 'post_type' => 'page' ) );
@@ -48,7 +48,7 @@ class Tests_Post_Embed_URL extends WP_UnitTestCase {
 	/**
 	 * @ticket 34971
 	 */
-	function test_static_front_page_with_ugly_permalinks() {
+	public function test_static_front_page_with_ugly_permalinks() {
 		$post_id = self::factory()->post->create( array( 'post_type' => 'page' ) );
 
 		update_option( 'show_on_front', 'page' );
@@ -64,7 +64,7 @@ class Tests_Post_Embed_URL extends WP_UnitTestCase {
 	/**
 	 * @ticket 34971
 	 */
-	function test_page_conflicts_with_embed_slug() {
+	public function test_page_conflicts_with_embed_slug() {
 		$this->set_permalink_structure( '/%postname%/' );
 
 		$parent_page = self::factory()->post->create( array( 'post_type' => 'page' ) );
@@ -86,7 +86,7 @@ class Tests_Post_Embed_URL extends WP_UnitTestCase {
 	/**
 	 * @ticket 34971
 	 */
-	function test_static_front_page_conflicts_with_embed_slug() {
+	public function test_static_front_page_conflicts_with_embed_slug() {
 		$this->set_permalink_structure( '/%postname%/' );
 
 		// Create a post with the 'embed' post_name.

--- a/tests/phpunit/tests/oembed/template.php
+++ b/tests/phpunit/tests/oembed/template.php
@@ -4,7 +4,7 @@
  * @group oembed
  */
 class Tests_Embed_Template extends WP_UnitTestCase {
-	function test_oembed_output_post() {
+	public function test_oembed_output_post() {
 		$user = self::factory()->user->create_and_get(
 			array(
 				'display_name' => 'John Doe',
@@ -36,7 +36,7 @@ class Tests_Embed_Template extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'Hello World', $actual );
 	}
 
-	function test_oembed_output_post_with_thumbnail() {
+	public function test_oembed_output_post_with_thumbnail() {
 		$post_id       = self::factory()->post->create(
 			array(
 				'post_title'   => 'Hello World',
@@ -69,7 +69,7 @@ class Tests_Embed_Template extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'canola.jpg', $actual );
 	}
 
-	function test_oembed_output_404() {
+	public function test_oembed_output_404() {
 		$this->go_to( home_url( '/?p=123&embed=true' ) );
 		$GLOBALS['wp_query']->query_vars['embed'] = true;
 
@@ -84,7 +84,7 @@ class Tests_Embed_Template extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'That embed can&#8217;t be found.', $actual );
 	}
 
-	function test_oembed_output_attachment() {
+	public function test_oembed_output_attachment() {
 		$post          = self::factory()->post->create_and_get();
 		$file          = DIR_TESTDATA . '/images/canola.jpg';
 		$attachment_id = self::factory()->attachment->create_object(
@@ -113,7 +113,7 @@ class Tests_Embed_Template extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'canola.jpg', $actual );
 	}
 
-	function test_oembed_output_draft_post() {
+	public function test_oembed_output_draft_post() {
 		$post_id = self::factory()->post->create(
 			array(
 				'post_title'   => 'Hello World',
@@ -136,7 +136,7 @@ class Tests_Embed_Template extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'That embed can&#8217;t be found.', $actual );
 	}
 
-	function test_oembed_output_scheduled_post() {
+	public function test_oembed_output_scheduled_post() {
 		$post_id = self::factory()->post->create(
 			array(
 				'post_title'   => 'Hello World',
@@ -160,7 +160,7 @@ class Tests_Embed_Template extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'That embed can&#8217;t be found.', $actual );
 	}
 
-	function test_oembed_output_private_post() {
+	public function test_oembed_output_private_post() {
 		$post_id = self::factory()->post->create(
 			array(
 				'post_title'   => 'Hello World',
@@ -183,7 +183,7 @@ class Tests_Embed_Template extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'That embed can&#8217;t be found.', $actual );
 	}
 
-	function test_oembed_output_private_post_with_permissions() {
+	public function test_oembed_output_private_post_with_permissions() {
 		$user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
 		wp_set_current_user( $user_id );
 
@@ -211,13 +211,13 @@ class Tests_Embed_Template extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'Hello World', $actual );
 	}
 
-	function test_wp_embed_excerpt_more_no_embed() {
+	public function test_wp_embed_excerpt_more_no_embed() {
 		$GLOBALS['wp_query'] = new WP_Query();
 
 		$this->assertSame( 'foo bar', wp_embed_excerpt_more( 'foo bar' ) );
 	}
 
-	function test_wp_embed_excerpt_more() {
+	public function test_wp_embed_excerpt_more() {
 		$post_id = self::factory()->post->create(
 			array(
 				'post_title'   => 'Foo Bar',
@@ -239,7 +239,7 @@ class Tests_Embed_Template extends WP_UnitTestCase {
 		$this->assertSame( $expected, $actual );
 	}
 
-	function test_is_embed_post() {
+	public function test_is_embed_post() {
 		$this->assertFalse( is_embed() );
 
 		$post_id = self::factory()->post->create();
@@ -247,7 +247,7 @@ class Tests_Embed_Template extends WP_UnitTestCase {
 		$this->assertTrue( is_embed() );
 	}
 
-	function test_is_embed_attachment() {
+	public function test_is_embed_attachment() {
 		$post_id       = self::factory()->post->create();
 		$file          = DIR_TESTDATA . '/images/canola.jpg';
 		$attachment_id = self::factory()->attachment->create_object(
@@ -261,17 +261,17 @@ class Tests_Embed_Template extends WP_UnitTestCase {
 		$this->assertTrue( is_embed() );
 	}
 
-	function test_is_embed_404() {
+	public function test_is_embed_404() {
 		$this->go_to( home_url( '/?p=12345&embed=true' ) );
 		$this->assertTrue( is_embed() );
 	}
 
-	function test_get_post_embed_html_non_existent_post() {
+	public function test_get_post_embed_html_non_existent_post() {
 		$this->assertFalse( get_post_embed_html( 200, 200, 0 ) );
 		$this->assertFalse( get_post_embed_html( 200, 200 ) );
 	}
 
-	function test_get_post_embed_html() {
+	public function test_get_post_embed_html() {
 		$post_id = self::factory()->post->create();
 		$title   = esc_attr(
 			sprintf(
@@ -286,7 +286,7 @@ class Tests_Embed_Template extends WP_UnitTestCase {
 		$this->assertStringEndsWith( $expected, get_post_embed_html( 200, 200, $post_id ) );
 	}
 
-	function test_add_host_js() {
+	public function test_add_host_js() {
 		wp_oembed_add_host_js();
 
 		$this->assertTrue( wp_script_is( 'wp-embed' ) );
@@ -299,7 +299,7 @@ class Tests_Embed_Template extends WP_UnitTestCase {
 	 *
 	 * @ticket 34698
 	 */
-	function test_js_no_ampersands() {
+	public function test_js_no_ampersands() {
 		$this->assertStringNotContainsString( '&', file_get_contents( ABSPATH . WPINC . '/js/wp-embed.js' ) );
 	}
 }

--- a/tests/phpunit/tests/option/multisite.php
+++ b/tests/phpunit/tests/option/multisite.php
@@ -11,7 +11,7 @@ if ( is_multisite() ) :
 	 */
 	class Tests_Multisite_Option extends WP_UnitTestCase {
 
-		function test_from_same_site() {
+		public function test_from_same_site() {
 			$key    = __FUNCTION__ . '_1';
 			$key2   = __FUNCTION__ . '_2';
 			$value  = __FUNCTION__ . '_val1';
@@ -48,7 +48,7 @@ if ( is_multisite() ) :
 			$this->assertFalse( get_option( $key2 ) );                    // Check get_option().
 		}
 
-		function test_from_same_site_with_null_blog_id() {
+		public function test_from_same_site_with_null_blog_id() {
 			$key    = __FUNCTION__ . '_1';
 			$key2   = __FUNCTION__ . '_2';
 			$value  = __FUNCTION__ . '_val1';
@@ -84,7 +84,7 @@ if ( is_multisite() ) :
 			$this->assertFalse( get_option( $key2 ) );                       // Check get_option().
 		}
 
-		function test_with_another_site() {
+		public function test_with_another_site() {
 			$user_id = self::factory()->user->create();
 			$this->assertIsInt( $user_id );
 
@@ -134,7 +134,7 @@ if ( is_multisite() ) :
 		/**
 		 * @group multisite
 		 */
-		function test_site_notoptions() {
+		public function test_site_notoptions() {
 			$network_id     = get_current_network_id();
 			$notoptions_key = "{$network_id}:notoptions";
 
@@ -151,7 +151,7 @@ if ( is_multisite() ) :
 			$this->assertNotEmpty( $notoptions1 );
 		}
 
-		function test_users_can_register_signup_filter() {
+		public function test_users_can_register_signup_filter() {
 
 			$registration = get_site_option( 'registration' );
 			$this->assertFalse( users_can_register_signup_filter() );
@@ -169,12 +169,12 @@ if ( is_multisite() ) :
 		/**
 		 * @dataProvider data_illegal_names
 		 */
-		function test_sanitize_network_option_illegal_names( $option_value, $sanitized_option_value ) {
+		public function test_sanitize_network_option_illegal_names( $option_value, $sanitized_option_value ) {
 			update_site_option( 'illegal_names', $option_value );
 			$this->assertSame( $sanitized_option_value, get_site_option( 'illegal_names' ) );
 		}
 
-		function data_illegal_names() {
+		public function data_illegal_names() {
 			return array(
 				array( array( '', 'Woo', '' ), array( 'Woo' ) ),
 				array( 'foo bar', array( 'foo', 'bar' ) ),
@@ -188,7 +188,7 @@ if ( is_multisite() ) :
 		 * @param $option_value
 		 * @param $sanitized_option_value
 		 */
-		function test_sanitize_network_option_limited_email_domains( $option_value, $sanitized_option_value ) {
+		public function test_sanitize_network_option_limited_email_domains( $option_value, $sanitized_option_value ) {
 			update_site_option( 'limited_email_domains', $option_value );
 			$this->assertSame( $sanitized_option_value, get_site_option( 'limited_email_domains' ) );
 		}
@@ -199,12 +199,12 @@ if ( is_multisite() ) :
 		 * @param $option_value
 		 * @param $sanitized_option_value
 		 */
-		function test_sanitize_network_option_banned_email_domains( $option_value, $sanitized_option_value ) {
+		public function test_sanitize_network_option_banned_email_domains( $option_value, $sanitized_option_value ) {
 			update_site_option( 'banned_email_domains', $option_value );
 			$this->assertSame( $sanitized_option_value, get_site_option( 'banned_email_domains' ) );
 		}
 
-		function data_email_domains() {
+		public function data_email_domains() {
 			return array(
 				array( array( 'woo', '', 'boo.com', 'foo.net.biz..' ), array( 'woo', 'boo.com' ) ),
 				array( "foo\nbar", array( 'foo', 'bar' ) ),

--- a/tests/phpunit/tests/option/networkOption.php
+++ b/tests/phpunit/tests/option/networkOption.php
@@ -15,7 +15,7 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 	/**
 	 * @group ms-required
 	 */
-	function test_add_network_option_not_available_on_other_network() {
+	public function test_add_network_option_not_available_on_other_network() {
 		$id     = self::factory()->network->create();
 		$option = __FUNCTION__;
 		$value  = __FUNCTION__;
@@ -27,7 +27,7 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 	/**
 	 * @group ms-required
 	 */
-	function test_add_network_option_available_on_same_network() {
+	public function test_add_network_option_available_on_same_network() {
 		$id     = self::factory()->network->create();
 		$option = __FUNCTION__;
 		$value  = __FUNCTION__;
@@ -39,7 +39,7 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 	/**
 	 * @group ms-required
 	 */
-	function test_delete_network_option_on_only_one_network() {
+	public function test_delete_network_option_on_only_one_network() {
 		$id     = self::factory()->network->create();
 		$option = __FUNCTION__;
 		$value  = __FUNCTION__;
@@ -84,7 +84,7 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 	 * @param $network_id
 	 * @param $expected_response
 	 */
-	function test_add_network_option_network_id_parameter( $network_id, $expected_response ) {
+	public function test_add_network_option_network_id_parameter( $network_id, $expected_response ) {
 		$option = rand_str();
 		$value  = rand_str();
 
@@ -97,13 +97,13 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 	 * @param $network_id
 	 * @param $expected_response
 	 */
-	function test_get_network_option_network_id_parameter( $network_id, $expected_response ) {
+	public function test_get_network_option_network_id_parameter( $network_id, $expected_response ) {
 		$option = rand_str();
 
 		$this->assertSame( $expected_response, get_network_option( $network_id, $option, true ) );
 	}
 
-	function data_network_id_parameter() {
+	public function data_network_id_parameter() {
 		return array(
 			// Numeric values should always be accepted.
 			array( 1, true ),

--- a/tests/phpunit/tests/option/option.php
+++ b/tests/phpunit/tests/option/option.php
@@ -5,11 +5,11 @@
  */
 class Tests_Option_Option extends WP_UnitTestCase {
 
-	function __return_foo() {
+	public function __return_foo() {
 		return 'foo';
 	}
 
-	function test_the_basics() {
+	public function test_the_basics() {
 		$key    = 'key1';
 		$key2   = 'key2';
 		$value  = 'value1';
@@ -34,7 +34,7 @@ class Tests_Option_Option extends WP_UnitTestCase {
 		$this->assertFalse( get_option( $key2 ) );
 	}
 
-	function test_default_filter() {
+	public function test_default_filter() {
 		$value = 'value';
 
 		$this->assertFalse( get_option( 'doesnotexist' ) );
@@ -71,7 +71,7 @@ class Tests_Option_Option extends WP_UnitTestCase {
 		$this->assertSame( 'bar', get_option( 'doesnotexist' ) );
 	}
 
-	function test_serialized_data() {
+	public function test_serialized_data() {
 		$key   = __FUNCTION__;
 		$value = array(
 			'foo' => true,
@@ -211,7 +211,7 @@ class Tests_Option_Option extends WP_UnitTestCase {
 	/**
 	 * @ticket 23289
 	 */
-	function test_special_option_name_alloption() {
+	public function test_special_option_name_alloption() {
 		$this->expectException( 'WPDieException' );
 		delete_option( 'alloptions' );
 	}
@@ -219,12 +219,12 @@ class Tests_Option_Option extends WP_UnitTestCase {
 	/**
 	 * @ticket 23289
 	 */
-	function test_special_option_name_notoptions() {
+	public function test_special_option_name_notoptions() {
 		$this->expectException( 'WPDieException' );
 		delete_option( 'notoptions' );
 	}
 
-	function data_option_autoloading() {
+	public function data_option_autoloading() {
 		return array(
 			array( 'autoload_yes', 'yes', 'yes' ),
 			array( 'autoload_true', true, 'yes' ),
@@ -241,7 +241,7 @@ class Tests_Option_Option extends WP_UnitTestCase {
 	 * @ticket 31119
 	 * @dataProvider data_option_autoloading
 	 */
-	function test_option_autoloading( $name, $autoload_value, $expected ) {
+	public function test_option_autoloading( $name, $autoload_value, $expected ) {
 		global $wpdb;
 		$added = add_option( $name, 'Autoload test', '', $autoload_value );
 		$this->assertTrue( $added );

--- a/tests/phpunit/tests/option/siteOption.php
+++ b/tests/phpunit/tests/option/siteOption.php
@@ -4,15 +4,15 @@
  * @group option
  */
 class Tests_Option_SiteOption extends WP_UnitTestCase {
-	function __return_foo() {
+	public function __return_foo() {
 		return 'foo';
 	}
 
-	function test_get_site_option_returns_false_if_option_does_not_exist() {
+	public function test_get_site_option_returns_false_if_option_does_not_exist() {
 		$this->assertFalse( get_site_option( 'doesnotexist' ) );
 	}
 
-	function test_get_site_option_returns_false_after_deletion() {
+	public function test_get_site_option_returns_false_after_deletion() {
 		$key   = __FUNCTION__;
 		$value = __FUNCTION__;
 		add_site_option( $key, $value );
@@ -20,14 +20,14 @@ class Tests_Option_SiteOption extends WP_UnitTestCase {
 		$this->assertFalse( get_site_option( $key ) );
 	}
 
-	function test_get_site_option_returns_value() {
+	public function test_get_site_option_returns_value() {
 		$key   = __FUNCTION__;
 		$value = __FUNCTION__;
 		add_site_option( $key, $value );
 		$this->assertSame( $value, get_site_option( $key ) );
 	}
 
-	function test_get_site_option_returns_updated_value() {
+	public function test_get_site_option_returns_updated_value() {
 		$key       = __FUNCTION__;
 		$value     = __FUNCTION__ . '_1';
 		$new_value = __FUNCTION__ . '_2';
@@ -36,32 +36,32 @@ class Tests_Option_SiteOption extends WP_UnitTestCase {
 		$this->assertSame( $new_value, get_site_option( $key ) );
 	}
 
-	function test_get_site_option_does_not_exist_returns_filtered_default_with_no_default_provided() {
+	public function test_get_site_option_does_not_exist_returns_filtered_default_with_no_default_provided() {
 		add_filter( 'default_site_option_doesnotexist', array( $this, '__return_foo' ) );
 		$site_option = get_site_option( 'doesnotexist' );
 		remove_filter( 'default_site_option_doesnotexist', array( $this, '__return_foo' ) );
 		$this->assertSame( 'foo', $site_option );
 	}
 
-	function test_get_site_option_does_not_exist_returns_filtered_default_with_default_provided() {
+	public function test_get_site_option_does_not_exist_returns_filtered_default_with_default_provided() {
 		add_filter( 'default_site_option_doesnotexist', array( $this, '__return_foo' ) );
 		$site_option = get_site_option( 'doesnotexist', 'bar' );
 		remove_filter( 'default_site_option_doesnotexist', array( $this, '__return_foo' ) );
 		$this->assertSame( 'foo', $site_option );
 	}
 
-	function test_get_site_option_does_not_exist_returns_provided_default() {
+	public function test_get_site_option_does_not_exist_returns_provided_default() {
 		$this->assertSame( 'bar', get_site_option( 'doesnotexist', 'bar' ) );
 	}
 
-	function test_get_site_option_exists_does_not_return_provided_default() {
+	public function test_get_site_option_exists_does_not_return_provided_default() {
 		$key   = __FUNCTION__;
 		$value = __FUNCTION__;
 		add_site_option( $key, $value );
 		$this->assertSame( $value, get_site_option( $key, 'foo' ) );
 	}
 
-	function test_get_site_option_exists_does_not_return_filtered_default() {
+	public function test_get_site_option_exists_does_not_return_filtered_default() {
 		$key   = __FUNCTION__;
 		$value = __FUNCTION__;
 		add_site_option( $key, $value );
@@ -71,27 +71,27 @@ class Tests_Option_SiteOption extends WP_UnitTestCase {
 		$this->assertSame( $value, $site_option );
 	}
 
-	function test_add_site_option_returns_true_for_new_option() {
+	public function test_add_site_option_returns_true_for_new_option() {
 		$key   = __FUNCTION__;
 		$value = __FUNCTION__;
 		$this->assertTrue( add_site_option( $key, $value ) );
 	}
 
-	function test_add_site_option_returns_false_for_existing_option() {
+	public function test_add_site_option_returns_false_for_existing_option() {
 		$key   = __FUNCTION__;
 		$value = __FUNCTION__;
 		add_site_option( $key, $value );
 		$this->assertFalse( add_site_option( $key, $value ) );
 	}
 
-	function test_update_site_option_returns_false_for_same_value() {
+	public function test_update_site_option_returns_false_for_same_value() {
 		$key   = __FUNCTION__;
 		$value = __FUNCTION__;
 		add_site_option( $key, $value );
 		$this->assertFalse( update_site_option( $key, $value ) );
 	}
 
-	function test_update_site_option_returns_true_for_new_value() {
+	public function test_update_site_option_returns_true_for_new_value() {
 		$key       = 'key';
 		$value     = 'value1';
 		$new_value = 'value2';
@@ -99,14 +99,14 @@ class Tests_Option_SiteOption extends WP_UnitTestCase {
 		$this->assertTrue( update_site_option( $key, $new_value ) );
 	}
 
-	function test_delete_site_option_returns_true_if_option_exists() {
+	public function test_delete_site_option_returns_true_if_option_exists() {
 		$key   = __FUNCTION__;
 		$value = __FUNCTION__;
 		add_site_option( $key, $value );
 		$this->assertTrue( delete_site_option( $key ) );
 	}
 
-	function test_delete_site_option_returns_false_if_option_does_not_exist() {
+	public function test_delete_site_option_returns_false_if_option_does_not_exist() {
 		$key   = __FUNCTION__;
 		$value = __FUNCTION__;
 		add_site_option( $key, $value );
@@ -114,7 +114,7 @@ class Tests_Option_SiteOption extends WP_UnitTestCase {
 		$this->assertFalse( delete_site_option( $key ) );
 	}
 
-	function test_site_option_add_and_get_serialized_array() {
+	public function test_site_option_add_and_get_serialized_array() {
 		$key   = __FUNCTION__;
 		$value = array(
 			'foo' => true,
@@ -124,7 +124,7 @@ class Tests_Option_SiteOption extends WP_UnitTestCase {
 		$this->assertSame( $value, get_site_option( $key ) );
 	}
 
-	function test_site_option_add_and_get_serialized_object() {
+	public function test_site_option_add_and_get_serialized_object() {
 		$key        = __FUNCTION__;
 		$value      = new stdClass();
 		$value->foo = true;
@@ -138,7 +138,7 @@ class Tests_Option_SiteOption extends WP_UnitTestCase {
 	 *
 	 * @ticket 15497
 	 */
-	function test_update_adds_falsey_value() {
+	public function test_update_adds_falsey_value() {
 		$key   = __FUNCTION__;
 		$value = 0;
 
@@ -153,7 +153,7 @@ class Tests_Option_SiteOption extends WP_UnitTestCase {
 	 *
 	 * @ticket 18955
 	 */
-	function test_get_doesnt_cache_default_value() {
+	public function test_get_doesnt_cache_default_value() {
 		$option  = __FUNCTION__;
 		$default = 'a default';
 

--- a/tests/phpunit/tests/option/siteTransient.php
+++ b/tests/phpunit/tests/option/siteTransient.php
@@ -13,7 +13,7 @@ class Tests_Option_SiteTransient extends WP_UnitTestCase {
 		}
 	}
 
-	function test_the_basics() {
+	public function test_the_basics() {
 		$key    = 'key1';
 		$value  = 'value1';
 		$value2 = 'value2';
@@ -29,7 +29,7 @@ class Tests_Option_SiteTransient extends WP_UnitTestCase {
 		$this->assertFalse( delete_site_transient( $key ) );
 	}
 
-	function test_serialized_data() {
+	public function test_serialized_data() {
 		$key   = __FUNCTION__;
 		$value = array(
 			'foo' => true,

--- a/tests/phpunit/tests/option/slashes.php
+++ b/tests/phpunit/tests/option/slashes.php
@@ -7,7 +7,7 @@
  */
 class Tests_Option_Slashes extends WP_UnitTestCase {
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		// It is important to test with both even and odd numbered slashes,
@@ -24,7 +24,7 @@ class Tests_Option_Slashes extends WP_UnitTestCase {
 	/**
 	 * Tests the model function that expects un-slashed data
 	 */
-	function test_add_option() {
+	public function test_add_option() {
 		add_option( 'slash_test_1', $this->slash_1 );
 		add_option( 'slash_test_2', $this->slash_2 );
 		add_option( 'slash_test_3', $this->slash_3 );
@@ -39,7 +39,7 @@ class Tests_Option_Slashes extends WP_UnitTestCase {
 	/**
 	 * Tests the model function that expects un-slashed data
 	 */
-	function test_update_option() {
+	public function test_update_option() {
 		add_option( 'slash_test_5', 'foo' );
 
 		update_option( 'slash_test_5', $this->slash_1 );

--- a/tests/phpunit/tests/option/themeMods.php
+++ b/tests/phpunit/tests/option/themeMods.php
@@ -5,15 +5,15 @@
  */
 class Tests_Option_Theme_Mods extends WP_UnitTestCase {
 
-	function test_theme_mod_default() {
+	public function test_theme_mod_default() {
 		$this->assertFalse( get_theme_mod( 'non_existent' ) );
 	}
 
-	function test_theme_mod_defined_default() {
+	public function test_theme_mod_defined_default() {
 		$this->assertSame( 'default', get_theme_mod( 'non_existent', 'default' ) );
 	}
 
-	function test_theme_mod_set() {
+	public function test_theme_mod_set() {
 		$expected = 'value';
 		set_theme_mod( 'test_name', $expected );
 		$this->assertSame( $expected, get_theme_mod( 'test_name' ) );
@@ -22,20 +22,20 @@ class Tests_Option_Theme_Mods extends WP_UnitTestCase {
 	/**
 	 * @ticket 51423
 	 */
-	function test_theme_mod_set_with_invalid_theme_mods_option() {
+	public function test_theme_mod_set_with_invalid_theme_mods_option() {
 		$theme_slug = get_option( 'stylesheet' );
 		update_option( 'theme_mods_' . $theme_slug, '' );
 		self::test_theme_mod_set();
 	}
 
-	function test_theme_mod_update() {
+	public function test_theme_mod_update() {
 		set_theme_mod( 'test_update', 'first_value' );
 		$expected = 'updated_value';
 		set_theme_mod( 'test_update', $expected );
 		$this->assertSame( $expected, get_theme_mod( 'test_update' ) );
 	}
 
-	function test_theme_mod_remove() {
+	public function test_theme_mod_remove() {
 		set_theme_mod( 'test_remove', 'value' );
 		remove_theme_mod( 'test_remove' );
 		$this->assertFalse( get_theme_mod( 'test_remove' ) );
@@ -46,11 +46,11 @@ class Tests_Option_Theme_Mods extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_theme_mod_default_value_with_percent_symbols
 	 */
-	function test_theme_mod_default_value_with_percent_symbols( $default, $expected ) {
+	public function test_theme_mod_default_value_with_percent_symbols( $default, $expected ) {
 		$this->assertSame( $expected, get_theme_mod( 'test_name', $default ) );
 	}
 
-	function data_theme_mod_default_value_with_percent_symbols() {
+	public function data_theme_mod_default_value_with_percent_symbols() {
 		return array(
 			array(
 				'100%',

--- a/tests/phpunit/tests/option/transient.php
+++ b/tests/phpunit/tests/option/transient.php
@@ -13,7 +13,7 @@ class Tests_Option_Transient extends WP_UnitTestCase {
 		}
 	}
 
-	function test_the_basics() {
+	public function test_the_basics() {
 		$key    = 'key1';
 		$value  = 'value1';
 		$value2 = 'value2';
@@ -29,7 +29,7 @@ class Tests_Option_Transient extends WP_UnitTestCase {
 		$this->assertFalse( delete_transient( $key ) );
 	}
 
-	function test_serialized_data() {
+	public function test_serialized_data() {
 		$key   = rand_str();
 		$value = array(
 			'foo' => true,
@@ -48,7 +48,7 @@ class Tests_Option_Transient extends WP_UnitTestCase {
 	/**
 	 * @ticket 22807
 	 */
-	function test_transient_data_with_timeout() {
+	public function test_transient_data_with_timeout() {
 		$key   = rand_str();
 		$value = rand_str();
 
@@ -69,7 +69,7 @@ class Tests_Option_Transient extends WP_UnitTestCase {
 	/**
 	 * @ticket 22807
 	 */
-	function test_transient_add_timeout() {
+	public function test_transient_add_timeout() {
 		$key    = rand_str();
 		$value  = rand_str();
 		$value2 = rand_str();
@@ -92,7 +92,7 @@ class Tests_Option_Transient extends WP_UnitTestCase {
 	 *
 	 * @ticket 30380
 	 */
-	function test_nonexistent_key_dont_delete_if_false() {
+	public function test_nonexistent_key_dont_delete_if_false() {
 		// Create a bogus a transient.
 		$key = 'test_transient';
 		set_transient( $key, 'test', 60 * 10 );
@@ -120,7 +120,7 @@ class Tests_Option_Transient extends WP_UnitTestCase {
 	/**
 	 * @ticket 30380
 	 */
-	function test_nonexistent_key_old_timeout() {
+	public function test_nonexistent_key_old_timeout() {
 		// Create a transient.
 		$key = 'test_transient';
 		set_transient( $key, 'test', 60 * 10 );

--- a/tests/phpunit/tests/option/userSettings.php
+++ b/tests/phpunit/tests/option/userSettings.php
@@ -1,8 +1,11 @@
 <?php
+/**
+ * @group 123456
+ */
 class Tests_User_Settings extends WP_UnitTestCase {
 	protected $user_id;
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		$this->user_id = self::factory()->user->create(
@@ -14,13 +17,13 @@ class Tests_User_Settings extends WP_UnitTestCase {
 		wp_set_current_user( $this->user_id );
 	}
 
-	function tear_down() {
+	public function tear_down() {
 		unset( $GLOBALS['_updated_user_settings'] );
 
 		parent::tear_down();
 	}
 
-	function test_set_user_setting() {
+	public function test_set_user_setting() {
 		$foo = get_user_setting( 'foo' );
 
 		$this->assertEmpty( $foo );
@@ -30,7 +33,7 @@ class Tests_User_Settings extends WP_UnitTestCase {
 		$this->assertSame( 'bar', get_user_setting( 'foo' ) );
 	}
 
-	function test_set_user_setting_dashes() {
+	public function test_set_user_setting_dashes() {
 		$foo = get_user_setting( 'foo' );
 
 		$this->assertEmpty( $foo );
@@ -40,7 +43,7 @@ class Tests_User_Settings extends WP_UnitTestCase {
 		$this->assertSame( 'foo-bar-baz', get_user_setting( 'foo' ) );
 	}
 
-	function test_set_user_setting_strip_asterisks() {
+	public function test_set_user_setting_strip_asterisks() {
 		$foo = get_user_setting( 'foo' );
 
 		$this->assertEmpty( $foo );
@@ -51,7 +54,7 @@ class Tests_User_Settings extends WP_UnitTestCase {
 	}
 
 	// set_user_setting() bails if `headers_sent()` is true.
-	function set_user_setting( $name, $value ) {
+	private function set_user_setting( $name, $value ) {
 		$all_user_settings          = get_all_user_settings();
 		$all_user_settings[ $name ] = $value;
 

--- a/tests/phpunit/tests/option/wpLoadAllOptions.php
+++ b/tests/phpunit/tests/option/wpLoadAllOptions.php
@@ -7,26 +7,26 @@
 class Tests_Option_WP_Load_Alloptions extends WP_UnitTestCase {
 	protected $alloptions = null;
 
-	function tear_down() {
+	public function tear_down() {
 		$this->alloptions = null;
 		parent::tear_down();
 	}
 
-	function test_if_alloptions_is_cached() {
+	public function test_if_alloptions_is_cached() {
 		$this->assertNotEmpty( wp_cache_get( 'alloptions', 'options' ) );
 	}
 
 	/**
 	 * @depends test_if_alloptions_is_cached
 	 */
-	function test_if_cached_alloptions_is_deleted() {
+	public function test_if_cached_alloptions_is_deleted() {
 		$this->assertTrue( wp_cache_delete( 'alloptions', 'options' ) );
 	}
 
 	/**
 	 * @depends test_if_alloptions_is_cached
 	 */
-	function test_if_alloptions_are_retrieved_from_cache() {
+	public function test_if_alloptions_are_retrieved_from_cache() {
 		global $wpdb;
 		$before = $wpdb->num_queries;
 		wp_load_alloptions();
@@ -39,7 +39,7 @@ class Tests_Option_WP_Load_Alloptions extends WP_UnitTestCase {
 	/**
 	 * @depends test_if_cached_alloptions_is_deleted
 	 */
-	function test_if_alloptions_are_retrieved_from_database() {
+	public function test_if_alloptions_are_retrieved_from_database() {
 		global $wpdb;
 
 		// Delete the existing cache first.
@@ -56,7 +56,7 @@ class Tests_Option_WP_Load_Alloptions extends WP_UnitTestCase {
 	/**
 	 * @depends test_if_cached_alloptions_is_deleted
 	 */
-	function test_filter_pre_cache_alloptions_is_called() {
+	public function test_filter_pre_cache_alloptions_is_called() {
 		$temp = wp_installing();
 
 		/**
@@ -82,7 +82,7 @@ class Tests_Option_WP_Load_Alloptions extends WP_UnitTestCase {
 	/**
 	 * @depends test_if_alloptions_is_cached
 	 */
-	function test_filter_pre_cache_alloptions_is_not_called() {
+	public function test_filter_pre_cache_alloptions_is_not_called() {
 		$temp = wp_installing();
 
 		/**
@@ -103,7 +103,7 @@ class Tests_Option_WP_Load_Alloptions extends WP_UnitTestCase {
 		$this->assertNull( $this->alloptions );
 	}
 
-	function return_pre_cache_filter( $alloptions ) {
+	public function return_pre_cache_filter( $alloptions ) {
 		$this->alloptions = $alloptions;
 		return $this->alloptions;
 	}


### PR DESCRIPTION
Coding Standards: Add visibility to methods in `tests/phpunit/tests/` i-L-M-O files.

"Visibility should always be declared"
See: https://make.wordpress.org/core/2020/03/20/updating-the-coding-standards-for-modern-php/

This commit applies the following sniffs to files in `tests/phpunit/tests` i-L-M-O directories:
- Squiz.Scope.MethodScope
- PSR2.Methods.MethodDeclaration
- PSR2.Classes.PropertyDeclaration
- Squiz.WhiteSpace.ScopeKeywordSpacing

For most methods, these now indicate `public` visibility to avoid breaking backwards compatibility.
Any remaining methods now indicate `private` visibility where appropriate.

Additional fixups in this PR:
1. Methods touched by this PR have had unnecessary underscores removed from their names.

Trac ticket: https://core.trac.wordpress.org/ticket/54177