### PR TITLE
Coding Standards: Add visibility to methods in `tests/phpunit/tests/` P-Q-R-S files.

### DIFF
--- a/tests/phpunit/tests/pomo/mo.php
+++ b/tests/phpunit/tests/pomo/mo.php
@@ -5,7 +5,7 @@
  */
 class Tests_POMO_MO extends WP_UnitTestCase {
 
-	function test_mo_simple() {
+	public function test_mo_simple() {
 		$mo = new MO();
 		$mo->import_from_file( DIR_TESTDATA . '/pomo/simple.mo' );
 		$this->assertSame(
@@ -20,7 +20,7 @@ class Tests_POMO_MO extends WP_UnitTestCase {
 		$this->assertSame( array( 'yes' ), $mo->entries["kuku\nruku"]->translations );
 	}
 
-	function test_mo_plural() {
+	public function test_mo_plural() {
 		$mo = new MO();
 		$mo->import_from_file( DIR_TESTDATA . '/pomo/plural.mo' );
 		$this->assertCount( 1, $mo->entries );
@@ -46,7 +46,7 @@ class Tests_POMO_MO extends WP_UnitTestCase {
 		$this->assertSame( 'twoey dragoney', $mo->translate_plural( 'one dragon', '%d dragons', -8 ) );
 	}
 
-	function test_mo_context() {
+	public function test_mo_context() {
 		$mo = new MO();
 		$mo->import_from_file( DIR_TESTDATA . '/pomo/context.mo' );
 		$this->assertCount( 2, $mo->entries );
@@ -73,7 +73,7 @@ class Tests_POMO_MO extends WP_UnitTestCase {
 
 	}
 
-	function test_translations_merge() {
+	public function test_translations_merge() {
 		$host = new Translations();
 		$host->add_entry( new Translation_Entry( array( 'singular' => 'pink' ) ) );
 		$host->add_entry( new Translation_Entry( array( 'singular' => 'green' ) ) );
@@ -85,7 +85,7 @@ class Tests_POMO_MO extends WP_UnitTestCase {
 		$this->assertSame( array(), array_diff( array( 'pink', 'green', 'red' ), array_keys( $host->entries ) ) );
 	}
 
-	function test_export_mo_file() {
+	public function test_export_mo_file() {
 		$entries              = array();
 		$entries[]            = new Translation_Entry(
 			array(
@@ -143,7 +143,7 @@ class Tests_POMO_MO extends WP_UnitTestCase {
 		}
 	}
 
-	function test_export_should_not_include_empty_translations() {
+	public function test_export_should_not_include_empty_translations() {
 		$entries = array();
 		$mo      = new MO;
 		$mo->add_entry(
@@ -162,7 +162,7 @@ class Tests_POMO_MO extends WP_UnitTestCase {
 		$this->assertCount( 0, $again->entries );
 	}
 
-	function test_nplurals_with_backslashn() {
+	public function test_nplurals_with_backslashn() {
 		$mo = new MO();
 		$mo->import_from_file( DIR_TESTDATA . '/pomo/bad_nplurals.mo' );
 		$this->assertSame( '%d foro', $mo->translate_plural( '%d forum', '%d forums', 1 ) );
@@ -170,14 +170,14 @@ class Tests_POMO_MO extends WP_UnitTestCase {
 		$this->assertSame( '%d foros', $mo->translate_plural( '%d forum', '%d forums', -1 ) );
 	}
 
-	function disabled_test_performance() {
+	public function disabled_test_performance() {
 		$start = microtime( true );
 		$mo    = new MO();
 		$mo->import_from_file( DIR_TESTDATA . '/pomo/de_DE-2.8.mo' );
 		// echo "\nPerformance: ".(microtime(true) - $start)."\n";
 	}
 
-	function test_overloaded_mb_functions() {
+	public function test_overloaded_mb_functions() {
 		if ( ( ini_get( 'mbstring.func_overload' ) & 2 ) === 0 ) {
 			$this->markTestSkipped( 'This test requires mbstring.func_overload to be enabled.' );
 		}
@@ -187,7 +187,7 @@ class Tests_POMO_MO extends WP_UnitTestCase {
 		$this->assertSame( array( 'Табло' ), $mo->entries['Dashboard']->translations );
 	}
 
-	function test_load_pot_file() {
+	public function test_load_pot_file() {
 		$mo = new MO();
 		$this->assertFalse( $mo->import_from_file( DIR_TESTDATA . '/pomo/mo.pot' ) );
 	}

--- a/tests/phpunit/tests/pomo/noopTranslations.php
+++ b/tests/phpunit/tests/pomo/noopTranslations.php
@@ -4,7 +4,7 @@
  * @group pomo
  */
 class Tests_POMO_NOOPTranslations extends WP_UnitTestCase {
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 		$this->noop         = new NOOP_Translations;
 		$this->entry        = new Translation_Entry( array( 'singular' => 'baba' ) );
@@ -17,31 +17,31 @@ class Tests_POMO_NOOPTranslations extends WP_UnitTestCase {
 		);
 	}
 
-	function test_get_header() {
+	public function test_get_header() {
 		$this->assertFalse( $this->noop->get_header( 'Content-Type' ) );
 	}
 
-	function test_add_entry() {
+	public function test_add_entry() {
 		$this->noop->add_entry( $this->entry );
 		$this->assertSame( array(), $this->noop->entries );
 	}
 
-	function test_set_header() {
+	public function test_set_header() {
 		$this->noop->set_header( 'header', 'value' );
 		$this->assertSame( array(), $this->noop->headers );
 	}
 
-	function test_translate_entry() {
+	public function test_translate_entry() {
 		$this->noop->add_entry( $this->entry );
 		$this->assertFalse( $this->noop->translate_entry( $this->entry ) );
 	}
 
-	function test_translate() {
+	public function test_translate() {
 		$this->noop->add_entry( $this->entry );
 		$this->assertSame( 'baba', $this->noop->translate( 'baba' ) );
 	}
 
-	function test_plural() {
+	public function test_plural() {
 		$this->noop->add_entry( $this->plural_entry );
 		$this->assertSame( 'dyado', $this->noop->translate_plural( 'dyado', 'dyados', 1 ) );
 		$this->assertSame( 'dyados', $this->noop->translate_plural( 'dyado', 'dyados', 11 ) );

--- a/tests/phpunit/tests/pomo/po.php
+++ b/tests/phpunit/tests/pomo/po.php
@@ -48,14 +48,14 @@ http://wordpress.org/
 		$this->po_a90  = "\"$this->a90\"";
 	}
 
-	function test_prepend_each_line() {
+	public function test_prepend_each_line() {
 		$po = new PO();
 		$this->assertSame( 'baba_', $po->prepend_each_line( '', 'baba_' ) );
 		$this->assertSame( 'baba_dyado', $po->prepend_each_line( 'dyado', 'baba_' ) );
 		$this->assertSame( "# baba\n# dyado\n# \n", $po->prepend_each_line( "baba\ndyado\n\n", '# ' ) );
 	}
 
-	function test_poify() {
+	public function test_poify() {
 		$po = new PO();
 		// Simple.
 		$this->assertSame( '"baba"', $po->poify( 'baba' ) );
@@ -74,7 +74,7 @@ http://wordpress.org/
 		$this->assertSameIgnoreEOL( $this->po_mail, $po->poify( $this->mail ) );
 	}
 
-	function test_unpoify() {
+	public function test_unpoify() {
 		$po = new PO();
 		$this->assertSame( 'baba', $po->unpoify( '"baba"' ) );
 		$this->assertSame( "baba\ngugu", $po->unpoify( '"baba\n"' . "\t\t\t\n" . '"gugu"' ) );
@@ -85,7 +85,7 @@ http://wordpress.org/
 		$this->assertSameIgnoreEOL( $this->mail, $po->unpoify( $this->po_mail ) );
 	}
 
-	function test_export_entry() {
+	public function test_export_entry() {
 		$po    = new PO();
 		$entry = new Translation_Entry( array( 'singular' => 'baba' ) );
 		$this->assertSame( "msgid \"baba\"\nmsgstr \"\"", $po->export_entry( $entry ) );
@@ -210,7 +210,7 @@ msgstr[2] "бабаяга"',
 		);
 	}
 
-	function test_export_entries() {
+	public function test_export_entries() {
 		$entry  = new Translation_Entry( array( 'singular' => 'baba' ) );
 		$entry2 = new Translation_Entry( array( 'singular' => 'dyado' ) );
 		$po     = new PO();
@@ -219,14 +219,14 @@ msgstr[2] "бабаяга"',
 		$this->assertSame( "msgid \"baba\"\nmsgstr \"\"\n\nmsgid \"dyado\"\nmsgstr \"\"", $po->export_entries() );
 	}
 
-	function test_export_headers() {
+	public function test_export_headers() {
 		$po = new PO();
 		$po->set_header( 'Project-Id-Version', 'WordPress 2.6-bleeding' );
 		$po->set_header( 'POT-Creation-Date', '2008-04-08 18:00+0000' );
 		$this->assertSame( "msgid \"\"\nmsgstr \"\"\n\"Project-Id-Version: WordPress 2.6-bleeding\\n\"\n\"POT-Creation-Date: 2008-04-08 18:00+0000\\n\"", $po->export_headers() );
 	}
 
-	function test_export() {
+	public function test_export() {
 		$po     = new PO();
 		$entry  = new Translation_Entry( array( 'singular' => 'baba' ) );
 		$entry2 = new Translation_Entry( array( 'singular' => 'dyado' ) );
@@ -239,7 +239,7 @@ msgstr[2] "бабаяга"',
 	}
 
 
-	function test_export_to_file() {
+	public function test_export_to_file() {
 		$po     = new PO();
 		$entry  = new Translation_Entry( array( 'singular' => 'baba' ) );
 		$entry2 = new Translation_Entry( array( 'singular' => 'dyado' ) );
@@ -257,7 +257,7 @@ msgstr[2] "бабаяга"',
 		$this->assertSame( $po->export(), file_get_contents( $temp_fn2 ) );
 	}
 
-	function test_import_from_file() {
+	public function test_import_from_file() {
 		$po  = new PO();
 		$res = $po->import_from_file( DIR_TESTDATA . '/pomo/simple.po' );
 		$this->assertTrue( $res );
@@ -316,12 +316,12 @@ msgstr[2] "бабаяга"',
 		$this->assertEquals( $end_quote_entry, $po->entries[ $end_quote_entry->key() ] );
 	}
 
-	function test_import_from_entry_file_should_give_false() {
+	public function test_import_from_entry_file_should_give_false() {
 		$po = new PO();
 		$this->assertFalse( $po->import_from_file( DIR_TESTDATA . '/pomo/empty.po' ) );
 	}
 
-	function test_import_from_file_with_windows_line_endings_should_work_as_with_unix_line_endings() {
+	public function test_import_from_file_with_windows_line_endings_should_work_as_with_unix_line_endings() {
 		$po = new PO();
 		$this->assertTrue( $po->import_from_file( DIR_TESTDATA . '/pomo/windows-line-endings.po' ) );
 		$this->assertCount( 1, $po->entries );

--- a/tests/phpunit/tests/pomo/translationEntry.php
+++ b/tests/phpunit/tests/pomo/translationEntry.php
@@ -5,7 +5,7 @@
  */
 class Tests_POMO_TranslationEntry extends WP_UnitTestCase {
 
-	function test_create_entry() {
+	public function test_create_entry() {
 		// No singular => empty object.
 		$entry = new Translation_Entry();
 		$this->assertNull( $entry->singular );
@@ -29,7 +29,7 @@ class Tests_POMO_TranslationEntry extends WP_UnitTestCase {
 		$this->assertSame( array(), $entry->flags );
 	}
 
-	function test_key() {
+	public function test_key() {
 		$entry_baba        = new Translation_Entry( array( 'singular' => 'baba' ) );
 		$entry_dyado       = new Translation_Entry( array( 'singular' => 'dyado' ) );
 		$entry_baba_ctxt   = new Translation_Entry(

--- a/tests/phpunit/tests/pomo/translations.php
+++ b/tests/phpunit/tests/pomo/translations.php
@@ -5,7 +5,7 @@
  */
 class Tests_POMO_Translations extends WP_UnitTestCase {
 
-	function test_add_entry() {
+	public function test_add_entry() {
 		$entry  = new Translation_Entry( array( 'singular' => 'baba' ) );
 		$entry2 = new Translation_Entry( array( 'singular' => 'dyado' ) );
 		$empty  = new Translation_Entry();
@@ -42,7 +42,7 @@ class Tests_POMO_Translations extends WP_UnitTestCase {
 		$this->assertSame( $entry->key(), $entries[0]->key() );
 	}
 
-	function test_translate() {
+	public function test_translate() {
 		$entry1 = new Translation_Entry(
 			array(
 				'singular'     => 'baba',
@@ -65,7 +65,7 @@ class Tests_POMO_Translations extends WP_UnitTestCase {
 		$this->assertSame( 'babaz', $domain->translate( 'babaz' ) );
 	}
 
-	function test_translate_plural() {
+	public function test_translate_plural() {
 		$entry_incomplete = new Translation_Entry(
 			array(
 				'singular'     => 'baba',
@@ -105,7 +105,7 @@ class Tests_POMO_Translations extends WP_UnitTestCase {
 		$this->assertSame( 'dyadoy', $domain->translate_plural( 'dyado', 'dyados', -18881 ) );
 	}
 
-	function test_digit_and_merge() {
+	public function test_digit_and_merge() {
 		$entry_digit_1 = new Translation_Entry(
 			array(
 				'singular'     => 1,

--- a/tests/phpunit/tests/post/attachments.php
+++ b/tests/phpunit/tests/post/attachments.php
@@ -7,13 +7,13 @@
  */
 class Tests_Post_Attachments extends WP_UnitTestCase {
 
-	function tear_down() {
+	public function tear_down() {
 		// Remove all uploads.
 		$this->remove_added_uploads();
 		parent::tear_down();
 	}
 
-	function test_insert_bogus_image() {
+	public function test_insert_bogus_image() {
 		$filename = rand_str() . '.jpg';
 		$contents = rand_str();
 
@@ -21,7 +21,7 @@ class Tests_Post_Attachments extends WP_UnitTestCase {
 		$this->assertEmpty( $upload['error'] );
 	}
 
-	function test_insert_image_no_thumb() {
+	public function test_insert_image_no_thumb() {
 
 		// This image is smaller than the thumbnail size so it won't have one.
 		$filename = ( DIR_TESTDATA . '/images/test-image.jpg' );
@@ -57,7 +57,7 @@ class Tests_Post_Attachments extends WP_UnitTestCase {
 	/**
 	 * @requires function imagejpeg
 	 */
-	function test_insert_image_thumb_only() {
+	public function test_insert_image_thumb_only() {
 		update_option( 'medium_size_w', 0 );
 		update_option( 'medium_size_h', 0 );
 
@@ -108,7 +108,7 @@ class Tests_Post_Attachments extends WP_UnitTestCase {
 	/**
 	 * @requires function imagejpeg
 	 */
-	function test_insert_image_medium_sizes() {
+	public function test_insert_image_medium_sizes() {
 		update_option( 'medium_size_w', 400 );
 		update_option( 'medium_size_h', 0 );
 
@@ -165,7 +165,7 @@ class Tests_Post_Attachments extends WP_UnitTestCase {
 	/**
 	 * @requires function imagejpeg
 	 */
-	function test_insert_image_delete() {
+	public function test_insert_image_delete() {
 		update_option( 'medium_size_w', 400 );
 		update_option( 'medium_size_h', 0 );
 
@@ -213,7 +213,7 @@ class Tests_Post_Attachments extends WP_UnitTestCase {
 	 * @ticket 18310
 	 * @ticket 21963
 	 */
-	function test_insert_image_without_guid() {
+	public function test_insert_image_without_guid() {
 		// This image is smaller than the thumbnail size so it won't have one.
 		$filename = ( DIR_TESTDATA . '/images/test-image.jpg' );
 		$contents = file_get_contents( $filename );
@@ -231,7 +231,7 @@ class Tests_Post_Attachments extends WP_UnitTestCase {
 	/**
 	 * @ticket 21963
 	 */
-	function test_update_attachment_fields() {
+	public function test_update_attachment_fields() {
 		$filename = ( DIR_TESTDATA . '/images/test-image.jpg' );
 		$contents = file_get_contents( $filename );
 
@@ -257,7 +257,7 @@ class Tests_Post_Attachments extends WP_UnitTestCase {
 	/**
 	 * @ticket 29646
 	 */
-	function test_update_orphan_attachment_parent() {
+	public function test_update_orphan_attachment_parent() {
 		$filename = ( DIR_TESTDATA . '/images/test-image.jpg' );
 		$contents = file_get_contents( $filename );
 

--- a/tests/phpunit/tests/post/filtering.php
+++ b/tests/phpunit/tests/post/filtering.php
@@ -10,20 +10,20 @@
  * @group formatting
  */
 class Tests_Post_Filtering extends WP_UnitTestCase {
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 		update_option( 'use_balanceTags', 1 );
 		kses_init_filters();
 
 	}
 
-	function tear_down() {
+	public function tear_down() {
 		kses_remove_filters();
 		parent::tear_down();
 	}
 
 	// A simple test to make sure unclosed tags are fixed.
-	function test_post_content_unknown_tag() {
+	public function test_post_content_unknown_tag() {
 
 		$content = <<<EOF
 <foobar>no such tag</foobar>
@@ -40,7 +40,7 @@ EOF;
 	}
 
 	// A simple test to make sure unbalanced tags are fixed.
-	function test_post_content_unbalanced_tag() {
+	public function test_post_content_unbalanced_tag() {
 
 		$content = <<<EOF
 <i>italics
@@ -57,7 +57,7 @@ EOF;
 	}
 
 	// Test KSES filtering of disallowed attribute.
-	function test_post_content_disallowed_attr() {
+	public function test_post_content_disallowed_attr() {
 
 		$content = <<<EOF
 <img src='foo' width='500' href='shlorp' />
@@ -78,7 +78,7 @@ EOF;
 	 *
 	 * @ticket 12394
 	 */
-	function test_post_content_xhtml_empty_elem() {
+	public function test_post_content_xhtml_empty_elem() {
 		$content = <<<EOF
 <img src='foo' width='500' height='300'/>
 EOF;
@@ -94,7 +94,7 @@ EOF;
 	}
 
 	// Make sure unbalanced tags are untouched when the balance option is off.
-	function test_post_content_nobalance_nextpage_more() {
+	public function test_post_content_nobalance_nextpage_more() {
 
 		update_option( 'use_balanceTags', 0 );
 

--- a/tests/phpunit/tests/post/formats.php
+++ b/tests/phpunit/tests/post/formats.php
@@ -4,7 +4,7 @@
  * @group post
  */
 class Tests_Post_Formats extends WP_UnitTestCase {
-	function test_set_get_post_format_for_post() {
+	public function test_set_get_post_format_for_post() {
 		$post_id = self::factory()->post->create();
 
 		$format = get_post_format( $post_id );
@@ -32,7 +32,7 @@ class Tests_Post_Formats extends WP_UnitTestCase {
 	/**
 	 * @ticket 22473
 	 */
-	function test_set_get_post_format_for_page() {
+	public function test_set_get_post_format_for_page() {
 		$post_id = self::factory()->post->create( array( 'post_type' => 'page' ) );
 
 		$format = get_post_format( $post_id );
@@ -64,7 +64,7 @@ class Tests_Post_Formats extends WP_UnitTestCase {
 		remove_post_type_support( 'page', 'post-formats' );
 	}
 
-	function test_has_format() {
+	public function test_has_format() {
 		$post_id = self::factory()->post->create();
 
 		$this->assertFalse( has_post_format( 'standard', $post_id ) );
@@ -93,7 +93,7 @@ class Tests_Post_Formats extends WP_UnitTestCase {
 	/**
 	 * @ticket 23570
 	 */
-	function test_get_url_in_content() {
+	public function test_get_url_in_content() {
 		$link                 = 'http://nytimes.com';
 		$commentary           = 'This is my favorite link';
 		$link_with_commentary = <<<DATA

--- a/tests/phpunit/tests/post/getPageUri.php
+++ b/tests/phpunit/tests/post/getPageUri.php
@@ -8,7 +8,7 @@ class Tests_Post_GetPageUri extends WP_UnitTestCase {
 	/**
 	 * @ticket 22883
 	 */
-	function test_get_page_uri_with_stdclass_post_object() {
+	public function test_get_page_uri_with_stdclass_post_object() {
 		$post_id = self::factory()->post->create( array( 'post_name' => 'get-page-uri-post-name' ) );
 
 		// Mimick an old stdClass post object, missing the ancestors field.
@@ -22,7 +22,7 @@ class Tests_Post_GetPageUri extends WP_UnitTestCase {
 	/**
 	 * @ticket 24491
 	 */
-	function test_get_page_uri_with_nonexistent_post() {
+	public function test_get_page_uri_with_nonexistent_post() {
 		global $wpdb;
 		$post_id = $wpdb->get_var( "SELECT MAX(ID) FROM $wpdb->posts" ) + 1;
 		$this->assertFalse( get_page_uri( $post_id ) );
@@ -31,7 +31,7 @@ class Tests_Post_GetPageUri extends WP_UnitTestCase {
 	/**
 	 * @ticket 15963
 	 */
-	function test_get_post_uri_check_orphan() {
+	public function test_get_post_uri_check_orphan() {
 		$parent_id = self::factory()->post->create( array( 'post_name' => 'parent' ) );
 		$child_id  = self::factory()->post->create(
 			array(
@@ -54,7 +54,7 @@ class Tests_Post_GetPageUri extends WP_UnitTestCase {
 	/**
 	 * @ticket 36174
 	 */
-	function test_get_page_uri_with_a_draft_parent_with_empty_slug() {
+	public function test_get_page_uri_with_a_draft_parent_with_empty_slug() {
 		$parent_id = self::factory()->post->create( array( 'post_name' => 'parent' ) );
 		$child_id  = self::factory()->post->create(
 			array(
@@ -77,7 +77,7 @@ class Tests_Post_GetPageUri extends WP_UnitTestCase {
 	/**
 	 * @ticket 26284
 	 */
-	function test_get_page_uri_without_argument() {
+	public function test_get_page_uri_without_argument() {
 		$post_id = self::factory()->post->create(
 			array(
 				'post_title' => 'Blood Orange announces summer tour dates',

--- a/tests/phpunit/tests/post/getPages.php
+++ b/tests/phpunit/tests/post/getPages.php
@@ -8,7 +8,7 @@ class Tests_Post_GetPages extends WP_UnitTestCase {
 	/**
 	 * @ticket 23167
 	 */
-	function test_get_pages_cache() {
+	public function test_get_pages_cache() {
 		global $wpdb;
 
 		self::factory()->post->create_many( 3, array( 'post_type' => 'page' ) );
@@ -249,7 +249,7 @@ class Tests_Post_GetPages extends WP_UnitTestCase {
 	/**
 	 * @ticket 20376
 	 */
-	function test_get_pages_meta() {
+	public function test_get_pages_meta() {
 		$posts = self::factory()->post->create_many( 3, array( 'post_type' => 'page' ) );
 		add_post_meta( $posts[0], 'some-meta-key', '0' );
 		add_post_meta( $posts[1], 'some-meta-key', '' );
@@ -283,7 +283,7 @@ class Tests_Post_GetPages extends WP_UnitTestCase {
 	/**
 	 * @ticket 22074
 	 */
-	function test_get_pages_include_exclude() {
+	public function test_get_pages_include_exclude() {
 		$page_ids = array();
 
 		foreach ( range( 1, 20 ) as $i ) {
@@ -309,7 +309,7 @@ class Tests_Post_GetPages extends WP_UnitTestCase {
 	/**
 	 * @ticket 9470
 	 */
-	function test_get_pages_parent() {
+	public function test_get_pages_parent() {
 		$page_id1 = self::factory()->post->create( array( 'post_type' => 'page' ) );
 		$page_id2 = self::factory()->post->create(
 			array(
@@ -367,7 +367,7 @@ class Tests_Post_GetPages extends WP_UnitTestCase {
 	/**
 	 * @ticket 22389
 	 */
-	function test_wp_dropdown_pages() {
+	public function test_wp_dropdown_pages() {
 		self::factory()->post->create_many( 5, array( 'post_type' => 'page' ) );
 
 		preg_match_all( '#<option#', wp_dropdown_pages( 'echo=0' ), $matches );
@@ -378,7 +378,7 @@ class Tests_Post_GetPages extends WP_UnitTestCase {
 	/**
 	 * @ticket 22208
 	 */
-	function test_get_chidren_fields_ids() {
+	public function test_get_chidren_fields_ids() {
 		$post_id   = self::factory()->post->create();
 		$child_ids = self::factory()->post->create_many( 5, array( 'post_parent' => $post_id ) );
 
@@ -394,7 +394,7 @@ class Tests_Post_GetPages extends WP_UnitTestCase {
 	/**
 	 * @ticket 25750
 	 */
-	function test_get_pages_hierarchical_and_no_parent() {
+	public function test_get_pages_hierarchical_and_no_parent() {
 		global $wpdb;
 		$page_1 = self::factory()->post->create( array( 'post_type' => 'page' ) );
 		$page_2 = self::factory()->post->create(
@@ -618,7 +618,7 @@ class Tests_Post_GetPages extends WP_UnitTestCase {
 
 	}
 
-	function test_wp_list_pages_classes() {
+	public function test_wp_list_pages_classes() {
 		$type = 'taco';
 		register_post_type(
 			$type,
@@ -651,7 +651,7 @@ class Tests_Post_GetPages extends WP_UnitTestCase {
 		_unregister_post_type( $type );
 	}
 
-	function test_exclude_tree() {
+	public function test_exclude_tree() {
 		$post_id1 = self::factory()->post->create( array( 'post_type' => 'page' ) );
 		$post_id2 = self::factory()->post->create(
 			array(
@@ -701,7 +701,7 @@ class Tests_Post_GetPages extends WP_UnitTestCase {
 	/**
 	 * @ticket 43514
 	 */
-	function test_get_pages_cache_empty() {
+	public function test_get_pages_cache_empty() {
 		global $wpdb;
 
 		wp_cache_delete( 'last_changed', 'posts' );

--- a/tests/phpunit/tests/post/isPostStatusViewable.php
+++ b/tests/phpunit/tests/post/isPostStatusViewable.php
@@ -10,7 +10,7 @@ class Tests_Post_IsPostStatusViewable extends WP_UnitTestCase {
 	 *
 	 * @global $wp_post_statuses
 	 */
-	static function wpTearDownAfterClass() {
+	public static function wpTearDownAfterClass() {
 		global $wp_post_statuses;
 		unset( $wp_post_statuses['wp_tests_ps'] );
 	}
@@ -105,7 +105,7 @@ class Tests_Post_IsPostStatusViewable extends WP_UnitTestCase {
 	 * @param mixed $status   Post status to check.
 	 * @param bool  $expected Expected viewable status.
 	 */
-	function test_built_unregistered_in_status_types( $status, $expected ) {
+	public function test_built_unregistered_in_status_types( $status, $expected ) {
 		// Test status passed as string.
 		$this->assertSame( $expected, is_post_status_viewable( $status ) );
 		// Test status passed as object.

--- a/tests/phpunit/tests/post/meta.php
+++ b/tests/phpunit/tests/post/meta.php
@@ -44,7 +44,7 @@ class Tests_Post_Meta extends WP_UnitTestCase {
 		self::delete_user( self::$author );
 	}
 
-	function test_unique_postmeta() {
+	public function test_unique_postmeta() {
 		// Add a unique post meta item.
 		$this->assertIsInt( add_post_meta( self::$post_id, 'unique', 'value', true ) );
 
@@ -67,7 +67,7 @@ class Tests_Post_Meta extends WP_UnitTestCase {
 
 	}
 
-	function test_nonunique_postmeta() {
+	public function test_nonunique_postmeta() {
 		// Add two non-unique post meta items.
 		$this->assertIsInt( add_post_meta( self::$post_id, 'nonunique', 'value' ) );
 		$this->assertIsInt( add_post_meta( self::$post_id, 'nonunique', 'another value' ) );
@@ -104,7 +104,7 @@ class Tests_Post_Meta extends WP_UnitTestCase {
 		$this->assertTrue( delete_post_meta_by_key( 'nonunique' ) );
 	}
 
-	function test_update_post_meta() {
+	public function test_update_post_meta() {
 		// Add a unique post meta item.
 		$this->assertIsInt( add_post_meta( self::$post_id, 'unique_update', 'value', true ) );
 
@@ -131,7 +131,7 @@ class Tests_Post_Meta extends WP_UnitTestCase {
 
 	}
 
-	function test_delete_post_meta() {
+	public function test_delete_post_meta() {
 		// Add two unique post meta items.
 		$this->assertIsInt( add_post_meta( self::$post_id, 'unique_delete', 'value', true ) );
 		$this->assertIsInt( add_post_meta( self::$post_id_2, 'unique_delete', 'value', true ) );
@@ -148,7 +148,7 @@ class Tests_Post_Meta extends WP_UnitTestCase {
 
 	}
 
-	function test_delete_post_meta_by_key() {
+	public function test_delete_post_meta_by_key() {
 		// Add two unique post meta items.
 		$this->assertIsInt( add_post_meta( self::$post_id, 'unique_delete_by_key', 'value', true ) );
 		$this->assertIsInt( add_post_meta( self::$post_id_2, 'unique_delete_by_key', 'value', true ) );
@@ -165,7 +165,7 @@ class Tests_Post_Meta extends WP_UnitTestCase {
 		$this->assertSame( '', get_post_meta( self::$post_id_2, 'unique_delete_by_key', true ) );
 	}
 
-	function test_get_post_meta_by_id() {
+	public function test_get_post_meta_by_id() {
 		$mid = add_post_meta( self::$post_id, 'get_post_meta_by_key', 'get_post_meta_by_key_value', true );
 		$this->assertIsInt( $mid );
 
@@ -185,7 +185,7 @@ class Tests_Post_Meta extends WP_UnitTestCase {
 		delete_metadata_by_mid( 'post', $mid );
 	}
 
-	function test_delete_meta() {
+	public function test_delete_meta() {
 		$mid = add_post_meta( self::$post_id, 'delete_meta', 'delete_meta_value', true );
 		$this->assertIsInt( $mid );
 
@@ -195,7 +195,7 @@ class Tests_Post_Meta extends WP_UnitTestCase {
 		$this->assertFalse( delete_meta( 123456789 ) );
 	}
 
-	function test_update_meta() {
+	public function test_update_meta() {
 		// Add a unique post meta item.
 		$mid1 = add_post_meta( self::$post_id, 'unique_update', 'value', true );
 		$this->assertIsInt( $mid1 );
@@ -233,7 +233,7 @@ class Tests_Post_Meta extends WP_UnitTestCase {
 	/**
 	 * @ticket 12860
 	 */
-	function test_funky_post_meta() {
+	public function test_funky_post_meta() {
 		$classy          = new StdClass();
 		$classy->ID      = 1;
 		$classy->stringy = 'I love slashes\\\\';

--- a/tests/phpunit/tests/post/nav-menu.php
+++ b/tests/phpunit/tests/post/nav-menu.php
@@ -505,19 +505,19 @@ class Tests_Post_Nav_Menu extends WP_UnitTestCase {
 		 * arguments are an object.
 		 */
 		// In function.
-		add_filter( 'pre_wp_nav_menu', array( $this, '_confirm_second_param_args_object' ), 10, 2 );
-		add_filter( 'wp_nav_menu_objects', array( $this, '_confirm_second_param_args_object' ), 10, 2 );
-		add_filter( 'wp_nav_menu_items', array( $this, '_confirm_second_param_args_object' ), 10, 2 );
+		add_filter( 'pre_wp_nav_menu', array( $this, 'confirm_second_param_args_object' ), 10, 2 );
+		add_filter( 'wp_nav_menu_objects', array( $this, 'confirm_second_param_args_object' ), 10, 2 );
+		add_filter( 'wp_nav_menu_items', array( $this, 'confirm_second_param_args_object' ), 10, 2 );
 
 		// In walker.
-		add_filter( 'nav_menu_item_args', array( $this, '_confirm_nav_menu_item_args_object' ) );
+		add_filter( 'nav_menu_item_args', array( $this, 'confirm_nav_menu_item_args_object' ) );
 
-		add_filter( 'nav_menu_css_class', array( $this, '_confirm_third_param_args_object' ), 10, 3 );
-		add_filter( 'nav_menu_item_id', array( $this, '_confirm_third_param_args_object' ), 10, 3 );
-		add_filter( 'nav_menu_link_attributes', array( $this, '_confirm_third_param_args_object' ), 10, 3 );
-		add_filter( 'nav_menu_item_title', array( $this, '_confirm_third_param_args_object' ), 10, 3 );
+		add_filter( 'nav_menu_css_class', array( $this, 'confirm_third_param_args_object' ), 10, 3 );
+		add_filter( 'nav_menu_item_id', array( $this, 'confirm_third_param_args_object' ), 10, 3 );
+		add_filter( 'nav_menu_link_attributes', array( $this, 'confirm_third_param_args_object' ), 10, 3 );
+		add_filter( 'nav_menu_item_title', array( $this, 'confirm_third_param_args_object' ), 10, 3 );
 
-		add_filter( 'walker_nav_menu_start_el', array( $this, '_confirm_forth_param_args_object' ), 10, 4 );
+		add_filter( 'walker_nav_menu_start_el', array( $this, 'confirm_forth_param_args_object' ), 10, 4 );
 
 		wp_nav_menu(
 			array(
@@ -531,41 +531,41 @@ class Tests_Post_Nav_Menu extends WP_UnitTestCase {
 		 * Remove test filters.
 		 */
 		// In function.
-		remove_filter( 'pre_wp_nav_menu', array( $this, '_confirm_second_param_args_object' ), 10, 2 );
-		remove_filter( 'wp_nav_menu_objects', array( $this, '_confirm_second_param_args_object' ), 10, 2 );
-		remove_filter( 'wp_nav_menu_items', array( $this, '_confirm_second_param_args_object' ), 10, 2 );
+		remove_filter( 'pre_wp_nav_menu', array( $this, 'confirm_second_param_args_object' ), 10, 2 );
+		remove_filter( 'wp_nav_menu_objects', array( $this, 'confirm_second_param_args_object' ), 10, 2 );
+		remove_filter( 'wp_nav_menu_items', array( $this, 'confirm_second_param_args_object' ), 10, 2 );
 
 		// In walker.
-		remove_filter( 'nav_menu_item_args', array( $this, '_confirm_nav_menu_item_args_object' ) );
+		remove_filter( 'nav_menu_item_args', array( $this, 'confirm_nav_menu_item_args_object' ) );
 
-		remove_filter( 'nav_menu_css_class', array( $this, '_confirm_third_param_args_object' ), 10, 3 );
-		remove_filter( 'nav_menu_item_id', array( $this, '_confirm_third_param_args_object' ), 10, 3 );
-		remove_filter( 'nav_menu_link_attributes', array( $this, '_confirm_third_param_args_object' ), 10, 3 );
-		remove_filter( 'nav_menu_item_title', array( $this, '_confirm_third_param_args_object' ), 10, 3 );
+		remove_filter( 'nav_menu_css_class', array( $this, 'confirm_third_param_args_object' ), 10, 3 );
+		remove_filter( 'nav_menu_item_id', array( $this, 'confirm_third_param_args_object' ), 10, 3 );
+		remove_filter( 'nav_menu_link_attributes', array( $this, 'confirm_third_param_args_object' ), 10, 3 );
+		remove_filter( 'nav_menu_item_title', array( $this, 'confirm_third_param_args_object' ), 10, 3 );
 
-		remove_filter( 'walker_nav_menu_start_el', array( $this, '_confirm_forth_param_args_object' ), 10, 4 );
+		remove_filter( 'walker_nav_menu_start_el', array( $this, 'confirm_forth_param_args_object' ), 10, 4 );
 
 	}
 
 	/**
 	 * Run tests required to confrim Walker_Nav_Menu receives an $args object.
 	 */
-	public function _confirm_nav_menu_item_args_object( $args ) {
+	public function confirm_nav_menu_item_args_object( $args ) {
 		$this->assertIsObject( $args );
 		return $args;
 	}
 
-	public function _confirm_second_param_args_object( $ignored_1, $args ) {
+	public function confirm_second_param_args_object( $ignored_1, $args ) {
 		$this->assertIsObject( $args );
 		return $ignored_1;
 	}
 
-	public function _confirm_third_param_args_object( $ignored_1, $ignored_2, $args ) {
+	public function confirm_third_param_args_object( $ignored_1, $ignored_2, $args ) {
 		$this->assertIsObject( $args );
 		return $ignored_1;
 	}
 
-	public function _confirm_forth_param_args_object( $ignored_1, $ignored_2, $ignored_3, $args ) {
+	public function confirm_forth_param_args_object( $ignored_1, $ignored_2, $ignored_3, $args ) {
 		$this->assertIsObject( $args );
 		return $ignored_1;
 	}

--- a/tests/phpunit/tests/post/nav-menu.php
+++ b/tests/phpunit/tests/post/nav-menu.php
@@ -9,7 +9,7 @@ class Tests_Post_Nav_Menu extends WP_UnitTestCase {
 	 */
 	public $menu_id;
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		$this->menu_id = wp_create_nav_menu( rand_str() );
@@ -43,7 +43,7 @@ class Tests_Post_Nav_Menu extends WP_UnitTestCase {
 		$this->assertStringStartsWith( '<ul', $menu );
 	}
 
-	function test_wp_get_associated_nav_menu_items() {
+	public function test_wp_get_associated_nav_menu_items() {
 		$tag_id    = self::factory()->tag->create();
 		$cat_id    = self::factory()->category->create();
 		$post_id   = self::factory()->post->create();
@@ -140,7 +140,7 @@ class Tests_Post_Nav_Menu extends WP_UnitTestCase {
 	/**
 	 * @ticket 27113
 	 */
-	function test_orphan_nav_menu_item() {
+	public function test_orphan_nav_menu_item() {
 
 		// Create an orphan nav menu item.
 		$custom_item_id = wp_update_nav_menu_item(
@@ -205,7 +205,7 @@ class Tests_Post_Nav_Menu extends WP_UnitTestCase {
 	/**
 	 * @ticket 13910
 	 */
-	function test_wp_get_nav_menu_name() {
+	public function test_wp_get_nav_menu_name() {
 		// Register a nav menu location.
 		register_nav_menu( 'primary', 'Primary Navigation' );
 
@@ -224,7 +224,7 @@ class Tests_Post_Nav_Menu extends WP_UnitTestCase {
 	/**
 	 * @ticket 29460
 	 */
-	function test_orderby_name_by_default() {
+	public function test_orderby_name_by_default() {
 		// We are going to create a random number of menus (min 2, max 10).
 		$menus_no = rand( 2, 10 );
 
@@ -253,7 +253,7 @@ class Tests_Post_Nav_Menu extends WP_UnitTestCase {
 	/**
 	 * @ticket 35324
 	 */
-	function test_wp_setup_nav_menu_item_for_post_type_archive() {
+	public function test_wp_setup_nav_menu_item_for_post_type_archive() {
 
 		$post_type_slug        = rand_str( 12 );
 		$post_type_description = rand_str();
@@ -286,7 +286,7 @@ class Tests_Post_Nav_Menu extends WP_UnitTestCase {
 	/**
 	 * @ticket 35324
 	 */
-	function test_wp_setup_nav_menu_item_for_post_type_archive_no_description() {
+	public function test_wp_setup_nav_menu_item_for_post_type_archive_no_description() {
 
 		$post_type_slug        = rand_str( 12 );
 		$post_type_description = '';
@@ -317,7 +317,7 @@ class Tests_Post_Nav_Menu extends WP_UnitTestCase {
 	/**
 	 * @ticket 35324
 	 */
-	function test_wp_setup_nav_menu_item_for_post_type_archive_custom_description() {
+	public function test_wp_setup_nav_menu_item_for_post_type_archive_custom_description() {
 
 		$post_type_slug        = rand_str( 12 );
 		$post_type_description = rand_str();
@@ -352,7 +352,7 @@ class Tests_Post_Nav_Menu extends WP_UnitTestCase {
 	/**
 	 * @ticket 35324
 	 */
-	function test_wp_setup_nav_menu_item_for_unknown_post_type_archive_no_description() {
+	public function test_wp_setup_nav_menu_item_for_unknown_post_type_archive_no_description() {
 
 		$post_type_slug = rand_str( 12 );
 
@@ -373,7 +373,7 @@ class Tests_Post_Nav_Menu extends WP_UnitTestCase {
 	/**
 	 * @ticket 19038
 	 */
-	function test_wp_setup_nav_menu_item_for_trashed_post() {
+	public function test_wp_setup_nav_menu_item_for_trashed_post() {
 		$post_id = self::factory()->post->create(
 			array(
 				'post_status' => 'trash',
@@ -399,7 +399,7 @@ class Tests_Post_Nav_Menu extends WP_UnitTestCase {
 	/**
 	 * @ticket 35206
 	 */
-	function test_wp_nav_menu_whitespace_options() {
+	public function test_wp_nav_menu_whitespace_options() {
 		$post_id1 = self::factory()->post->create();
 		$post_id2 = self::factory()->post->create();
 		$post_id3 = self::factory()->post->create();
@@ -486,7 +486,7 @@ class Tests_Post_Nav_Menu extends WP_UnitTestCase {
 	 *
 	 * @ticket 24587
 	 */
-	function test_wp_nav_menu_filters_are_passed_args_object() {
+	public function test_wp_nav_menu_filters_are_passed_args_object() {
 		$tag_id = self::factory()->tag->create();
 
 		$tag_insert = wp_update_nav_menu_item(
@@ -550,22 +550,22 @@ class Tests_Post_Nav_Menu extends WP_UnitTestCase {
 	/**
 	 * Run tests required to confrim Walker_Nav_Menu receives an $args object.
 	 */
-	function _confirm_nav_menu_item_args_object( $args ) {
+	public function _confirm_nav_menu_item_args_object( $args ) {
 		$this->assertIsObject( $args );
 		return $args;
 	}
 
-	function _confirm_second_param_args_object( $ignored_1, $args ) {
+	public function _confirm_second_param_args_object( $ignored_1, $args ) {
 		$this->assertIsObject( $args );
 		return $ignored_1;
 	}
 
-	function _confirm_third_param_args_object( $ignored_1, $ignored_2, $args ) {
+	public function _confirm_third_param_args_object( $ignored_1, $ignored_2, $args ) {
 		$this->assertIsObject( $args );
 		return $ignored_1;
 	}
 
-	function _confirm_forth_param_args_object( $ignored_1, $ignored_2, $ignored_3, $args ) {
+	public function _confirm_forth_param_args_object( $ignored_1, $ignored_2, $ignored_3, $args ) {
 		$this->assertIsObject( $args );
 		return $ignored_1;
 	}
@@ -574,7 +574,7 @@ class Tests_Post_Nav_Menu extends WP_UnitTestCase {
 	/**
 	 * @ticket 35272
 	 */
-	function test_no_front_page_class_applied() {
+	public function test_no_front_page_class_applied() {
 		$page_id = self::factory()->post->create(
 			array(
 				'post_type'  => 'page',
@@ -605,7 +605,7 @@ class Tests_Post_Nav_Menu extends WP_UnitTestCase {
 	/**
 	 * @ticket 35272
 	 */
-	function test_class_applied_to_front_page_item() {
+	public function test_class_applied_to_front_page_item() {
 		$page_id = self::factory()->post->create(
 			array(
 				'post_type'  => 'page',
@@ -638,7 +638,7 @@ class Tests_Post_Nav_Menu extends WP_UnitTestCase {
 	/**
 	 * @ticket 35272
 	 */
-	function test_class_not_applied_to_taxonomies_with_same_id_as_front_page_item() {
+	public function test_class_not_applied_to_taxonomies_with_same_id_as_front_page_item() {
 		global $wpdb;
 
 		$new_id = 35272;
@@ -681,7 +681,7 @@ class Tests_Post_Nav_Menu extends WP_UnitTestCase {
 	 *
 	 * @covers ::_wp_delete_customize_changeset_dependent_auto_drafts
 	 */
-	function test_wp_delete_customize_changeset_dependent_auto_drafts() {
+	public function test_wp_delete_customize_changeset_dependent_auto_drafts() {
 		$auto_draft_post_id = $this->factory()->post->create(
 			array(
 				'post_status' => 'auto-draft',
@@ -735,7 +735,7 @@ class Tests_Post_Nav_Menu extends WP_UnitTestCase {
 	/**
 	 * @ticket 39800
 	 */
-	function test_parent_ancestor_for_post_archive() {
+	public function test_parent_ancestor_for_post_archive() {
 
 		register_post_type(
 			'books',
@@ -821,7 +821,7 @@ class Tests_Post_Nav_Menu extends WP_UnitTestCase {
 	/**
 	 * Provides IRI matching data for _wp_menu_item_classes_by_context() test.
 	 */
-	function get_iri_current_menu_items() {
+	public function get_iri_current_menu_items() {
 		return array(
 			array( site_url( '/%D0%BF%D1%80%D0%B8%D0%B2%D0%B5%D1%82/' ) ),
 			array( site_url( '/%D0%BF%D1%80%D0%B8%D0%B2%D0%B5%D1%82' ) ),
@@ -836,7 +836,7 @@ class Tests_Post_Nav_Menu extends WP_UnitTestCase {
 	 * @ticket 43401
 	 * @dataProvider get_iri_current_menu_items
 	 */
-	function test_iri_current_menu_item( $custom_link, $current = true ) {
+	public function test_iri_current_menu_item( $custom_link, $current = true ) {
 		wp_update_nav_menu_item(
 			$this->menu_id,
 			0,
@@ -865,7 +865,7 @@ class Tests_Post_Nav_Menu extends WP_UnitTestCase {
 	 * @ticket 44005
 	 * @group privacy
 	 */
-	function test_no_privacy_policy_class_applied() {
+	public function test_no_privacy_policy_class_applied() {
 		$page_id = self::factory()->post->create(
 			array(
 				'post_type'  => 'page',
@@ -896,7 +896,7 @@ class Tests_Post_Nav_Menu extends WP_UnitTestCase {
 	 * @ticket 44005
 	 * @group privacy
 	 */
-	function test_class_applied_to_privacy_policy_page_item() {
+	public function test_class_applied_to_privacy_policy_page_item() {
 		$page_id = self::factory()->post->create(
 			array(
 				'post_type'  => 'page',
@@ -930,7 +930,7 @@ class Tests_Post_Nav_Menu extends WP_UnitTestCase {
 	 * @ticket 47723
 	 * @dataProvider data_trim_url_for_custom_item
 	 */
-	function test_trim_url_for_custom_item( $custom_url, $correct_url ) {
+	public function test_trim_url_for_custom_item( $custom_url, $correct_url ) {
 		$custom_item_id = wp_update_nav_menu_item(
 			$this->menu_id,
 			0,
@@ -949,7 +949,7 @@ class Tests_Post_Nav_Menu extends WP_UnitTestCase {
 	/**
 	 * Provides data for test_trim_url_for_custom_item().
 	 */
-	function data_trim_url_for_custom_item() {
+	public function data_trim_url_for_custom_item() {
 		return array(
 			array( 'https://wordpress.org ', 'https://wordpress.org' ),
 			array( ' https://wordpress.org', 'https://wordpress.org' ),
@@ -964,7 +964,7 @@ class Tests_Post_Nav_Menu extends WP_UnitTestCase {
 	 *
 	 * @ticket 48011
 	 */
-	function test_wp_update_nav_menu_item_with_special_characters_in_category_name() {
+	public function test_wp_update_nav_menu_item_with_special_characters_in_category_name() {
 		$category_name = 'Test Cat - \"Pre-Slashed\" Cat Name & >';
 
 		$category = self::factory()->category->create_and_get(
@@ -1001,7 +1001,7 @@ class Tests_Post_Nav_Menu extends WP_UnitTestCase {
 	 *
 	 * @ticket 52189
 	 */
-	function test_wp_update_nav_menu_item_with_post_date() {
+	public function test_wp_update_nav_menu_item_with_post_date() {
 		$post_date     = '2020-12-28 11:26:35';
 		$post_date_gmt = '2020-12-29 10:11:45';
 		$invalid_date  = '2020-12-41 14:15:27';

--- a/tests/phpunit/tests/post/objects.php
+++ b/tests/phpunit/tests/post/objects.php
@@ -5,7 +5,7 @@
  */
 class Tests_Post_Objects extends WP_UnitTestCase {
 
-	function test_get_post() {
+	public function test_get_post() {
 		$id = self::factory()->post->create();
 
 		$post = get_post( $id );
@@ -66,7 +66,7 @@ class Tests_Post_Objects extends WP_UnitTestCase {
 		$this->assertNull( get_post( false ) );
 	}
 
-	function test_get_post_ancestors() {
+	public function test_get_post_ancestors() {
 		$parent_id     = self::factory()->post->create();
 		$child_id      = self::factory()->post->create();
 		$grandchild_id = self::factory()->post->create();
@@ -101,14 +101,14 @@ class Tests_Post_Objects extends WP_UnitTestCase {
 	/**
 	 * @ticket 22882
 	 */
-	function test_get_post_ancestors_with_falsey_values() {
+	public function test_get_post_ancestors_with_falsey_values() {
 		foreach ( array( null, 0, false, '0', '' ) as $post_id ) {
 			$this->assertIsArray( get_post_ancestors( $post_id ) );
 			$this->assertSame( array(), get_post_ancestors( $post_id ) );
 		}
 	}
 
-	function test_get_post_category_property() {
+	public function test_get_post_category_property() {
 		$post_id = self::factory()->post->create();
 		$post    = get_post( $post_id );
 
@@ -127,7 +127,7 @@ class Tests_Post_Objects extends WP_UnitTestCase {
 		$this->assertSame( array( $term2['term_id'], $term3['term_id'], $term1['term_id'] ), $post['post_category'] );
 	}
 
-	function test_get_tags_input_property() {
+	public function test_get_tags_input_property() {
 		$post_id = self::factory()->post->create();
 		$post    = get_post( $post_id );
 
@@ -144,7 +144,7 @@ class Tests_Post_Objects extends WP_UnitTestCase {
 		$this->assertSame( array( 'Bar', 'Baz', 'Foo' ), $post['tags_input'] );
 	}
 
-	function test_get_page_template_property() {
+	public function test_get_page_template_property() {
 		$post_id = self::factory()->post->create();
 		$post    = get_post( $post_id );
 
@@ -157,7 +157,7 @@ class Tests_Post_Objects extends WP_UnitTestCase {
 		$this->assertSame( $template, $post->page_template );
 	}
 
-	function test_get_post_filter() {
+	public function test_get_post_filter() {
 		$post = get_post(
 			self::factory()->post->create(
 				array(
@@ -200,7 +200,7 @@ class Tests_Post_Objects extends WP_UnitTestCase {
 		}
 	}
 
-	function test_get_post_identity() {
+	public function test_get_post_identity() {
 		$post = get_post( self::factory()->post->create() );
 
 		$post->foo = 'bar';
@@ -209,7 +209,7 @@ class Tests_Post_Objects extends WP_UnitTestCase {
 		$this->assertSame( 'bar', get_post( $post, OBJECT, 'display' )->foo );
 	}
 
-	function test_get_post_array() {
+	public function test_get_post_array() {
 		$id = self::factory()->post->create();
 
 		$post = get_post( $id, ARRAY_A );
@@ -222,7 +222,7 @@ class Tests_Post_Objects extends WP_UnitTestCase {
 	/**
 	 * @ticket 22223
 	 */
-	function test_get_post_cache() {
+	public function test_get_post_cache() {
 		global $wpdb;
 
 		$id = self::factory()->post->create();

--- a/tests/phpunit/tests/post/output.php
+++ b/tests/phpunit/tests/post/output.php
@@ -10,8 +10,8 @@ class Tests_Post_Output extends WP_UnitTestCase {
 
 	public function set_up() {
 		parent::set_up();
-		add_shortcode( 'dumptag', array( $this, '_shortcode_dumptag' ) );
-		add_shortcode( 'paragraph', array( $this, '_shortcode_paragraph' ) );
+		add_shortcode( 'dumptag', array( $this, 'shortcode_dumptag' ) );
+		add_shortcode( 'paragraph', array( $this, 'shortcode_paragraph' ) );
 	}
 
 	public function tear_down() {
@@ -20,7 +20,7 @@ class Tests_Post_Output extends WP_UnitTestCase {
 		parent::tear_down();
 	}
 
-	public function _shortcode_dumptag( $atts ) {
+	public function shortcode_dumptag( $atts ) {
 		$out = '';
 		foreach ( $atts as $k => $v ) {
 			$out .= "$k = $v\n";
@@ -28,7 +28,7 @@ class Tests_Post_Output extends WP_UnitTestCase {
 		return $out;
 	}
 
-	public function _shortcode_paragraph( $atts, $content ) {
+	public function shortcode_paragraph( $atts, $content ) {
 		$processed_atts = shortcode_atts(
 			array(
 				'class' => 'graf',

--- a/tests/phpunit/tests/post/output.php
+++ b/tests/phpunit/tests/post/output.php
@@ -8,19 +8,19 @@
  */
 class Tests_Post_Output extends WP_UnitTestCase {
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 		add_shortcode( 'dumptag', array( $this, '_shortcode_dumptag' ) );
 		add_shortcode( 'paragraph', array( $this, '_shortcode_paragraph' ) );
 	}
 
-	function tear_down() {
+	public function tear_down() {
 		global $shortcode_tags;
 		unset( $shortcode_tags['dumptag'], $shortcode_tags['paragraph'] );
 		parent::tear_down();
 	}
 
-	function _shortcode_dumptag( $atts ) {
+	public function _shortcode_dumptag( $atts ) {
 		$out = '';
 		foreach ( $atts as $k => $v ) {
 			$out .= "$k = $v\n";
@@ -28,7 +28,7 @@ class Tests_Post_Output extends WP_UnitTestCase {
 		return $out;
 	}
 
-	function _shortcode_paragraph( $atts, $content ) {
+	public function _shortcode_paragraph( $atts, $content ) {
 		$processed_atts = shortcode_atts(
 			array(
 				'class' => 'graf',
@@ -39,7 +39,7 @@ class Tests_Post_Output extends WP_UnitTestCase {
 		return "<p class='{$processed_atts['class']}'>$content</p>\n";
 	}
 
-	function test_the_content() {
+	public function test_the_content() {
 		$post_content = <<<EOF
 <i>This is the excerpt.</i>
 <!--more-->
@@ -62,7 +62,7 @@ EOF;
 		$this->assertSame( strip_ws( $expected ), strip_ws( get_echo( 'the_content' ) ) );
 	}
 
-	function test_the_content_shortcode() {
+	public function test_the_content_shortcode() {
 		$post_content = <<<EOF
 [dumptag foo="bar" baz="123"]
 
@@ -90,7 +90,7 @@ EOF;
 		$this->assertSame( strip_ws( $expected ), strip_ws( get_echo( 'the_content' ) ) );
 	}
 
-	function test_the_content_shortcode_paragraph() {
+	public function test_the_content_shortcode_paragraph() {
 		$post_content = <<<EOF
 Graf by itself:
 
@@ -128,7 +128,7 @@ EOF;
 		$this->assertSame( strip_ws( $expected ), strip_ws( get_echo( 'the_content' ) ) );
 	}
 
-	function test_the_content_attribute_filtering() {
+	public function test_the_content_attribute_filtering() {
 		kses_init_filters();
 
 		// http://bpr3.org/?p=87
@@ -152,7 +152,7 @@ EOF;
 		kses_remove_filters();
 	}
 
-	function test_the_content_attribute_value_with_colon() {
+	public function test_the_content_attribute_value_with_colon() {
 		kses_init_filters();
 
 		// http://bpr3.org/?p=87

--- a/tests/phpunit/tests/post/query.php
+++ b/tests/phpunit/tests/post/query.php
@@ -8,7 +8,7 @@ class Tests_Post_Query extends WP_UnitTestCase {
 	/**
 	 * @group taxonomy
 	 */
-	function test_category__and_var() {
+	public function test_category__and_var() {
 		$q = new WP_Query();
 
 		$term_id  = self::factory()->category->create(
@@ -50,7 +50,7 @@ class Tests_Post_Query extends WP_UnitTestCase {
 	 * @ticket 28099
 	 * @group taxonomy
 	 */
-	function test_empty_category__in() {
+	public function test_empty_category__in() {
 		$cat_id  = self::factory()->category->create();
 		$post_id = self::factory()->post->create();
 		wp_set_post_categories( $post_id, $cat_id );
@@ -79,7 +79,7 @@ class Tests_Post_Query extends WP_UnitTestCase {
 	/**
 	 * @ticket 22448
 	 */
-	function test_the_posts_filter() {
+	public function test_the_posts_filter() {
 		// Create posts and clear their caches.
 		$post_ids = self::factory()->post->create_many( 4 );
 		foreach ( $post_ids as $post_id ) {
@@ -117,7 +117,7 @@ class Tests_Post_Query extends WP_UnitTestCase {
 	/**
 	 * Use with the_posts filter, appends a post and adds some custom data.
 	 */
-	function the_posts_filter( $posts ) {
+	public function the_posts_filter( $posts ) {
 		$posts[] = clone $posts[0];
 
 		// Add some custom data to each post.
@@ -128,7 +128,7 @@ class Tests_Post_Query extends WP_UnitTestCase {
 		return $posts;
 	}
 
-	function test_post__in_ordering() {
+	public function test_post__in_ordering() {
 		$post_id1 = self::factory()->post->create(
 			array(
 				'post_type'  => 'page',
@@ -210,7 +210,7 @@ class Tests_Post_Query extends WP_UnitTestCase {
 		$this->assertSame( $ordered, wp_list_pluck( $q->posts, 'ID' ) );
 	}
 
-	function test_post__in_attachment_ordering() {
+	public function test_post__in_attachment_ordering() {
 		$post_id    = self::factory()->post->create();
 		$att_ids    = array();
 		$file       = DIR_TESTDATA . '/images/canola.jpg';
@@ -308,7 +308,7 @@ class Tests_Post_Query extends WP_UnitTestCase {
 		$this->assertSame( $ordered, wp_list_pluck( $q->posts, 'post_name' ) );
 	}
 
-	function test_post_status() {
+	public function test_post_status() {
 		$statuses1 = get_post_stati();
 		$this->assertContains( 'auto-draft', $statuses1 );
 
@@ -331,7 +331,7 @@ class Tests_Post_Query extends WP_UnitTestCase {
 	/**
 	 * @ticket 17065
 	 */
-	function test_orderby_array() {
+	public function test_orderby_array() {
 		global $wpdb;
 
 		$q1 = new WP_Query(
@@ -367,7 +367,7 @@ class Tests_Post_Query extends WP_UnitTestCase {
 	/**
 	 * @ticket 17065
 	 */
-	function test_order() {
+	public function test_order() {
 		global $wpdb;
 
 		$q1 = new WP_Query(
@@ -407,7 +407,7 @@ class Tests_Post_Query extends WP_UnitTestCase {
 	/**
 	 * @ticket 29629
 	 */
-	function test_orderby() {
+	public function test_orderby() {
 		// 'rand' is a valid value.
 		$q = new WP_Query( array( 'orderby' => 'rand' ) );
 		$this->assertStringContainsString( 'ORDER BY RAND()', $q->request );

--- a/tests/phpunit/tests/post/revisions.php
+++ b/tests/phpunit/tests/post/revisions.php
@@ -15,7 +15,7 @@ class Tests_Post_Revisions extends WP_UnitTestCase {
 		self::$author_user_id = $factory->user->create( array( 'role' => 'author' ) );
 	}
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 		$this->post_type = rand_str( 20 );
 	}
@@ -26,7 +26,7 @@ class Tests_Post_Revisions extends WP_UnitTestCase {
 	 * @ticket 20982
 	 * @ticket 16215
 	 */
-	function test_revision_restore_updates_edit_last_post_meta() {
+	public function test_revision_restore_updates_edit_last_post_meta() {
 		// Create a post as Author.
 		wp_set_current_user( self::$author_user_id );
 		$post    = get_default_post_to_edit( 'post', true );
@@ -69,7 +69,7 @@ class Tests_Post_Revisions extends WP_UnitTestCase {
 	 * @ticket 7392
 	 * @ticket 9843
 	 */
-	function test_revision_dont_save_revision_if_unchanged() {
+	public function test_revision_dont_save_revision_if_unchanged() {
 		$post    = get_default_post_to_edit( 'post', true );
 		$post_id = $post->ID;
 
@@ -139,7 +139,7 @@ class Tests_Post_Revisions extends WP_UnitTestCase {
 	 * @ticket 7392
 	 * @ticket 9843
 	 */
-	function test_revision_force_save_revision_even_if_unchanged() {
+	public function test_revision_force_save_revision_even_if_unchanged() {
 		add_filter( 'wp_save_post_revision_check_for_changes', '__return_false' );
 
 		$post    = get_default_post_to_edit( 'post', true );
@@ -214,7 +214,7 @@ class Tests_Post_Revisions extends WP_UnitTestCase {
 	 *
 	 * @ticket 16847
 	 */
-	function test_revision_view_caps_post() {
+	public function test_revision_view_caps_post() {
 		$post_id = self::factory()->post->create(
 			array(
 				'post_type'   => 'post',
@@ -247,7 +247,7 @@ class Tests_Post_Revisions extends WP_UnitTestCase {
 	 *
 	 * @ticket 16847
 	 */
-	function test_revision_restore_caps_post() {
+	public function test_revision_restore_caps_post() {
 		$post_id = self::factory()->post->create(
 			array(
 				'post_type'   => 'post',
@@ -278,7 +278,7 @@ class Tests_Post_Revisions extends WP_UnitTestCase {
 	 *
 	 * @ticket 16847
 	 */
-	function test_revision_diff_caps_post() {
+	public function test_revision_diff_caps_post() {
 		$post_id = self::factory()->post->create(
 			array(
 				'post_type'   => 'post',
@@ -316,7 +316,7 @@ class Tests_Post_Revisions extends WP_UnitTestCase {
 	 *
 	 * @ticket 16847
 	 */
-	function test_revision_view_caps_cpt() {
+	public function test_revision_view_caps_cpt() {
 		register_post_type(
 			$this->post_type,
 			array(
@@ -358,7 +358,7 @@ class Tests_Post_Revisions extends WP_UnitTestCase {
 	 *
 	 * @ticket 16847
 	 */
-	function test_revision_restore_caps_cpt() {
+	public function test_revision_restore_caps_cpt() {
 		register_post_type(
 			$this->post_type,
 			array(
@@ -404,7 +404,7 @@ class Tests_Post_Revisions extends WP_UnitTestCase {
 	 *
 	 * @ticket 16847
 	 */
-	function test_revision_restore_caps_before_publish() {
+	public function test_revision_restore_caps_before_publish() {
 		register_post_type(
 			$this->post_type,
 			array(
@@ -464,7 +464,7 @@ class Tests_Post_Revisions extends WP_UnitTestCase {
 	 *
 	 * @ticket 16847
 	 */
-	function test_revision_diff_caps_cpt() {
+	public function test_revision_diff_caps_cpt() {
 		register_post_type(
 			$this->post_type,
 			array(
@@ -509,7 +509,7 @@ class Tests_Post_Revisions extends WP_UnitTestCase {
 	/**
 	 * @ticket 26042
 	 */
-	function test_wp_get_post_revisions_should_order_by_post_date() {
+	public function test_wp_get_post_revisions_should_order_by_post_date() {
 		global $wpdb;
 
 		$post = self::factory()->post->create_and_get(
@@ -545,7 +545,7 @@ class Tests_Post_Revisions extends WP_UnitTestCase {
 	/**
 	 * @ticket 26042
 	 */
-	function test_wp_get_post_revisions_should_order_by_ID_when_post_date_matches() {
+	public function test_wp_get_post_revisions_should_order_by_ID_when_post_date_matches() {
 		$post = self::factory()->post->create_and_get(
 			array(
 				'post_title'   => 'some-post',

--- a/tests/phpunit/tests/post/slashes.php
+++ b/tests/phpunit/tests/post/slashes.php
@@ -14,7 +14,7 @@ class Tests_Post_Slashes extends WP_UnitTestCase {
 		self::$post_id   = $factory->post->create();
 	}
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		wp_set_current_user( self::$author_id );
@@ -33,7 +33,7 @@ class Tests_Post_Slashes extends WP_UnitTestCase {
 	/**
 	 * Tests the controller function that expects slashed data.
 	 */
-	function test_edit_post() {
+	public function test_edit_post() {
 		$post_id = self::$post_id;
 
 		$_POST               = array();
@@ -70,7 +70,7 @@ class Tests_Post_Slashes extends WP_UnitTestCase {
 	/**
 	 * Tests the model function that expects slashed data.
 	 */
-	function test_wp_insert_post() {
+	public function test_wp_insert_post() {
 		$post_id = wp_insert_post(
 			array(
 				'post_status'  => 'publish',
@@ -106,7 +106,7 @@ class Tests_Post_Slashes extends WP_UnitTestCase {
 	/**
 	 * Tests the model function that expects slashed data.
 	 */
-	function test_wp_update_post() {
+	public function test_wp_update_post() {
 		$post_id = self::$post_id;
 
 		wp_update_post(
@@ -141,7 +141,7 @@ class Tests_Post_Slashes extends WP_UnitTestCase {
 	/**
 	 * @ticket 27550
 	 */
-	function test_wp_trash_untrash() {
+	public function test_wp_trash_untrash() {
 		$post    = array(
 			'post_title'   => $this->slash_1,
 			'post_content' => $this->slash_3,

--- a/tests/phpunit/tests/post/template.php
+++ b/tests/phpunit/tests/post/template.php
@@ -5,7 +5,7 @@
  */
 class Tests_Post_Template extends WP_UnitTestCase {
 
-	function test_wp_link_pages() {
+	public function test_wp_link_pages() {
 		$contents = array( 'One', 'Two', 'Three' );
 		$content  = implode( '<!--nextpage-->', $contents );
 		$post_id  = self::factory()->post->create( array( 'post_content' => $content ) );
@@ -131,7 +131,7 @@ class Tests_Post_Template extends WP_UnitTestCase {
 		$this->assertSame( $pagelink, $output );
 	}
 
-	function test_wp_dropdown_pages() {
+	public function test_wp_dropdown_pages() {
 		$none = wp_dropdown_pages( array( 'echo' => 0 ) );
 		$this->assertEmpty( $none );
 

--- a/tests/phpunit/tests/post/thumbnails.php
+++ b/tests/phpunit/tests/post/thumbnails.php
@@ -31,7 +31,7 @@ class Tests_Post_Thumbnail_Template extends WP_UnitTestCase {
 		parent::tear_down_after_class();
 	}
 
-	function test_has_post_thumbnail() {
+	public function test_has_post_thumbnail() {
 		$this->assertFalse( has_post_thumbnail( self::$post ) );
 		$this->assertFalse( has_post_thumbnail( self::$post->ID ) );
 		$this->assertFalse( has_post_thumbnail() );
@@ -53,7 +53,7 @@ class Tests_Post_Thumbnail_Template extends WP_UnitTestCase {
 		$this->assertTrue( has_post_thumbnail() );
 	}
 
-	function test_get_post_thumbnail_id() {
+	public function test_get_post_thumbnail_id() {
 		$this->assertSame( 0, get_post_thumbnail_id( self::$post ) );
 		$this->assertSame( 0, get_post_thumbnail_id( self::$post->ID ) );
 		$this->assertFalse( get_post_thumbnail_id() );
@@ -68,7 +68,7 @@ class Tests_Post_Thumbnail_Template extends WP_UnitTestCase {
 		$this->assertSame( self::$attachment_id, get_post_thumbnail_id() );
 	}
 
-	function test_update_post_thumbnail_cache() {
+	public function test_update_post_thumbnail_cache() {
 		set_post_thumbnail( self::$post, self::$attachment_id );
 
 		$query = new WP_Query(
@@ -89,7 +89,7 @@ class Tests_Post_Thumbnail_Template extends WP_UnitTestCase {
 	/**
 	 * @ticket 12235
 	 */
-	function test_get_the_post_thumbnail_caption() {
+	public function test_get_the_post_thumbnail_caption() {
 		$this->assertSame( '', get_the_post_thumbnail_caption() );
 
 		$caption = 'This is a caption.';
@@ -113,7 +113,7 @@ class Tests_Post_Thumbnail_Template extends WP_UnitTestCase {
 	/**
 	 * @ticket 12235
 	 */
-	function test_get_the_post_thumbnail_caption_empty() {
+	public function test_get_the_post_thumbnail_caption_empty() {
 		$post_id       = self::factory()->post->create();
 		$attachment_id = self::factory()->attachment->create_object(
 			'image.jpg',
@@ -133,7 +133,7 @@ class Tests_Post_Thumbnail_Template extends WP_UnitTestCase {
 	/**
 	 * @ticket 12235
 	 */
-	function test_the_post_thumbnail_caption() {
+	public function test_the_post_thumbnail_caption() {
 		$caption = 'This is a caption.';
 
 		$post_id       = self::factory()->post->create();
@@ -153,7 +153,7 @@ class Tests_Post_Thumbnail_Template extends WP_UnitTestCase {
 		the_post_thumbnail_caption( $post_id );
 	}
 
-	function test_get_the_post_thumbnail() {
+	public function test_get_the_post_thumbnail() {
 		$this->assertSame( '', get_the_post_thumbnail() );
 		$this->assertSame( '', get_the_post_thumbnail( self::$post ) );
 		set_post_thumbnail( self::$post, self::$attachment_id );
@@ -174,7 +174,7 @@ class Tests_Post_Thumbnail_Template extends WP_UnitTestCase {
 		$this->assertSame( $expected, get_the_post_thumbnail() );
 	}
 
-	function test_the_post_thumbnail() {
+	public function test_the_post_thumbnail() {
 
 		$this->expectOutputString( '' );
 		the_post_thumbnail();
@@ -202,7 +202,7 @@ class Tests_Post_Thumbnail_Template extends WP_UnitTestCase {
 	/**
 	 * @ticket 33070
 	 */
-	function test_get_the_post_thumbnail_url() {
+	public function test_get_the_post_thumbnail_url() {
 		$this->assertFalse( has_post_thumbnail( self::$post ) );
 		$this->assertFalse( get_the_post_thumbnail_url() );
 		$this->assertFalse( get_the_post_thumbnail_url( self::$post ) );
@@ -220,7 +220,7 @@ class Tests_Post_Thumbnail_Template extends WP_UnitTestCase {
 	/**
 	 * @ticket 33070
 	 */
-	function test_get_the_post_thumbnail_url_with_invalid_post() {
+	public function test_get_the_post_thumbnail_url_with_invalid_post() {
 		set_post_thumbnail( self::$post, self::$attachment_id );
 
 		$this->assertNotFalse( get_the_post_thumbnail_url( self::$post->ID ) );
@@ -234,7 +234,7 @@ class Tests_Post_Thumbnail_Template extends WP_UnitTestCase {
 	/**
 	 * @ticket 33070
 	 */
-	function test_the_post_thumbnail_url() {
+	public function test_the_post_thumbnail_url() {
 		$GLOBALS['post'] = self::$post;
 
 		$this->expectOutputString( '' );
@@ -249,7 +249,7 @@ class Tests_Post_Thumbnail_Template extends WP_UnitTestCase {
 	/**
 	 * @ticket 12922
 	 */
-	function test__wp_preview_post_thumbnail_filter() {
+	public function test__wp_preview_post_thumbnail_filter() {
 		$old_post = isset( $GLOBALS['post'] ) ? $GLOBALS['post'] : null;
 
 		$GLOBALS['post']           = self::$post;
@@ -269,7 +269,7 @@ class Tests_Post_Thumbnail_Template extends WP_UnitTestCase {
 	/**
 	 * @ticket 37697
 	 */
-	function test__wp_preview_post_thumbnail_filter_secondary_post() {
+	public function test__wp_preview_post_thumbnail_filter_secondary_post() {
 		$old_post = isset( $GLOBALS['post'] ) ? $GLOBALS['post'] : null;
 
 		$secondary_post = self::factory()->post->create(
@@ -295,7 +295,7 @@ class Tests_Post_Thumbnail_Template extends WP_UnitTestCase {
 	/**
 	 * @ticket 12922
 	 */
-	function test_insert_post_with_post_thumbnail() {
+	public function test_insert_post_with_post_thumbnail() {
 		$post_id = wp_insert_post(
 			array(
 				'ID'            => self::$post->ID,
@@ -326,7 +326,7 @@ class Tests_Post_Thumbnail_Template extends WP_UnitTestCase {
 	/**
 	 * @ticket 37658
 	 */
-	function test_insert_attachment_with_post_thumbnail() {
+	public function test_insert_attachment_with_post_thumbnail() {
 		// Audio files support featured images.
 		$post_id = wp_insert_post(
 			array(
@@ -365,7 +365,7 @@ class Tests_Post_Thumbnail_Template extends WP_UnitTestCase {
 	/**
 	 * @ticket 39030
 	 */
-	function test_post_thumbnail_size_filter_simple() {
+	public function test_post_thumbnail_size_filter_simple() {
 		$this->current_size_filter_data = 'medium';
 
 		add_filter( 'post_thumbnail_size', array( $this, 'filter_post_thumbnail_size' ), 10, 2 );
@@ -386,7 +386,7 @@ class Tests_Post_Thumbnail_Template extends WP_UnitTestCase {
 	 * @ticket 39030
 	 * @dataProvider data_post_thumbnail_size_filter_complex
 	 */
-	function test_post_thumbnail_size_filter_complex( $which_post, $expected ) {
+	public function test_post_thumbnail_size_filter_complex( $which_post, $expected ) {
 		$this->current_size_filter_data = array(
 			self::$post->ID           => 'medium',
 			self::$different_post->ID => 'thumbnail',
@@ -408,14 +408,14 @@ class Tests_Post_Thumbnail_Template extends WP_UnitTestCase {
 		$this->assertSame( $expected, $result );
 	}
 
-	function data_post_thumbnail_size_filter_complex() {
+	public function data_post_thumbnail_size_filter_complex() {
 		return array(
 			array( 0, 'medium' ),
 			array( 1, 'thumbnail' ),
 		);
 	}
 
-	function filter_post_thumbnail_size( $size, $post_id ) {
+	public function filter_post_thumbnail_size( $size, $post_id ) {
 		if ( is_array( $this->current_size_filter_data ) && isset( $this->current_size_filter_data[ $post_id ] ) ) {
 			return $this->current_size_filter_data[ $post_id ];
 		}
@@ -427,7 +427,7 @@ class Tests_Post_Thumbnail_Template extends WP_UnitTestCase {
 		return $size;
 	}
 
-	function filter_set_post_thumbnail_size_result( $html, $post_id, $post_thumbnail_id, $size ) {
+	public function filter_set_post_thumbnail_size_result( $html, $post_id, $post_thumbnail_id, $size ) {
 		$this->current_size_filter_result = $size;
 
 		return $html;

--- a/tests/phpunit/tests/post/types.php
+++ b/tests/phpunit/tests/post/types.php
@@ -18,13 +18,13 @@ class Tests_Post_Types extends WP_UnitTestCase {
 	 *
 	 * @since 4.5.0
 	 */
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		$this->post_type = rand_str( 20 );
 	}
 
-	function test_register_post_type() {
+	public function test_register_post_type() {
 		$this->assertNull( get_post_type_object( 'foo' ) );
 		register_post_type( 'foo' );
 
@@ -42,7 +42,7 @@ class Tests_Post_Types extends WP_UnitTestCase {
 	/**
 	 * @ticket 48558
 	 */
-	function test_register_post_type_return_value() {
+	public function test_register_post_type_return_value() {
 		$this->assertInstanceOf( 'WP_Post_Type', register_post_type( 'foo' ) );
 	}
 
@@ -51,7 +51,7 @@ class Tests_Post_Types extends WP_UnitTestCase {
 	 *
 	 * @expectedIncorrectUsage register_post_type
 	 */
-	function test_register_post_type_with_too_long_name() {
+	public function test_register_post_type_with_too_long_name() {
 		// Post type too long.
 		$this->assertInstanceOf( 'WP_Error', register_post_type( 'abcdefghijklmnopqrstuvwxyz0123456789' ) );
 	}
@@ -61,7 +61,7 @@ class Tests_Post_Types extends WP_UnitTestCase {
 	 *
 	 * @expectedIncorrectUsage register_post_type
 	 */
-	function test_register_post_type_with_empty_name() {
+	public function test_register_post_type_with_empty_name() {
 		// Post type too short.
 		$this->assertInstanceOf( 'WP_Error', register_post_type( '' ) );
 	}
@@ -70,7 +70,7 @@ class Tests_Post_Types extends WP_UnitTestCase {
 	 * @ticket 35985
 	 * @covers ::register_post_type
 	 */
-	function test_register_post_type_exclude_from_search_should_default_to_opposite_value_of_public() {
+	public function test_register_post_type_exclude_from_search_should_default_to_opposite_value_of_public() {
 		/*
 		 * 'public'              Default is false
 		 * 'exclude_from_search' Default is null (opposite 'public')
@@ -84,7 +84,7 @@ class Tests_Post_Types extends WP_UnitTestCase {
 	 * @ticket 35985
 	 * @covers ::register_post_type
 	 */
-	function test_register_post_type_publicly_queryable_should_default_to_value_of_public() {
+	public function test_register_post_type_publicly_queryable_should_default_to_value_of_public() {
 		/*
 		 * 'public'             Default is false
 		 * 'publicly_queryable' Default is null ('public')
@@ -98,7 +98,7 @@ class Tests_Post_Types extends WP_UnitTestCase {
 	 * @ticket 35985
 	 * @covers ::register_post_type
 	 */
-	function test_register_post_type_show_ui_should_default_to_value_of_public() {
+	public function test_register_post_type_show_ui_should_default_to_value_of_public() {
 		/*
 		 * 'public'  Default is false
 		 * 'show_ui' Default is null ('public')
@@ -112,7 +112,7 @@ class Tests_Post_Types extends WP_UnitTestCase {
 	 * @ticket 35985
 	 * @covers ::register_post_type
 	 */
-	function test_register_post_type_show_in_menu_should_default_to_value_of_show_ui() {
+	public function test_register_post_type_show_in_menu_should_default_to_value_of_show_ui() {
 		/*
 		 * 'public'      Default is false
 		 * 'show_ui'     Default is null ('public')
@@ -131,7 +131,7 @@ class Tests_Post_Types extends WP_UnitTestCase {
 	 * @ticket 35985
 	 * @covers ::register_post_type
 	 */
-	function test_register_post_type_show_in_nav_menus_should_default_to_value_of_public() {
+	public function test_register_post_type_show_in_nav_menus_should_default_to_value_of_public() {
 		/*
 		 * 'public'            Default is false
 		 * 'show_in_nav_menus' Default is null ('public')
@@ -145,7 +145,7 @@ class Tests_Post_Types extends WP_UnitTestCase {
 	 * @ticket 35985
 	 * @covers ::register_post_type
 	 */
-	function test_register_post_type_show_in_admin_bar_should_default_to_value_of_show_in_menu() {
+	public function test_register_post_type_show_in_admin_bar_should_default_to_value_of_show_in_menu() {
 		/*
 		 * 'public'            Default is false
 		 * 'show_in_menu'      Default is null ('show_ui' > 'public')
@@ -163,7 +163,7 @@ class Tests_Post_Types extends WP_UnitTestCase {
 		$this->assertSame( $public, $args->show_in_admin_bar );
 	}
 
-	function test_register_taxonomy_for_object_type() {
+	public function test_register_taxonomy_for_object_type() {
 		global $wp_taxonomies;
 
 		register_post_type( 'bar' );
@@ -185,12 +185,12 @@ class Tests_Post_Types extends WP_UnitTestCase {
 		_unregister_post_type( 'bar' );
 	}
 
-	function test_post_type_exists() {
+	public function test_post_type_exists() {
 		$this->assertFalse( post_type_exists( 'notaposttype' ) );
 		$this->assertTrue( post_type_exists( 'post' ) );
 	}
 
-	function test_post_type_supports() {
+	public function test_post_type_supports() {
 		$this->assertTrue( post_type_supports( 'post', 'post-formats' ) );
 		$this->assertFalse( post_type_supports( 'page', 'post-formats' ) );
 		$this->assertFalse( post_type_supports( 'notaposttype', 'post-formats' ) );
@@ -201,7 +201,7 @@ class Tests_Post_Types extends WP_UnitTestCase {
 	/**
 	 * @ticket 21586
 	 */
-	function test_post_type_with_no_support() {
+	public function test_post_type_with_no_support() {
 		register_post_type( 'foo', array( 'supports' => array() ) );
 		$this->assertTrue( post_type_supports( 'foo', 'editor' ) );
 		$this->assertTrue( post_type_supports( 'foo', 'title' ) );
@@ -216,7 +216,7 @@ class Tests_Post_Types extends WP_UnitTestCase {
 	/**
 	 * @ticket 23302
 	 */
-	function test_post_type_with_no_feed() {
+	public function test_post_type_with_no_feed() {
 		global $wp_rewrite;
 		$old_permastruct = get_option( 'permalink_structure' );
 		update_option( 'permalink_structure', '%postname%' );

--- a/tests/phpunit/tests/post/wpAfterInsertPost.php
+++ b/tests/phpunit/tests/post/wpAfterInsertPost.php
@@ -100,7 +100,7 @@ class Tests_Post_wpAfterInsertPost extends WP_UnitTestCase {
 	 * @param null|WP_Post $post_before Null for new posts, the WP_Post object prior
 	 *                                  to the update for updated posts.
 	 */
-	function action_wp_after_insert_post( $post_id, $post, $update, $post_before ) {
+	public function action_wp_after_insert_post( $post_id, $post, $update, $post_before ) {
 		self::$passed_post_title  = $post->post_title;
 		self::$passed_post_status = $post->post_status;
 

--- a/tests/phpunit/tests/post/wpInsertPost.php
+++ b/tests/phpunit/tests/post/wpInsertPost.php
@@ -29,7 +29,7 @@ class Tests_Post_wpInsertPost extends WP_UnitTestCase {
 		$role->add_cap( 'publish_unmapped_meta_caps' );
 	}
 
-	static function tear_down_after_class() {
+	public static function tear_down_after_class() {
 		$role = get_role( 'administrator' );
 		$role->remove_cap( 'publish_mapped_meta_caps' );
 		$role->remove_cap( 'publish_unmapped_meta_caps' );
@@ -37,7 +37,7 @@ class Tests_Post_wpInsertPost extends WP_UnitTestCase {
 		parent::tear_down_after_class();
 	}
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		register_post_type(
@@ -68,7 +68,7 @@ class Tests_Post_wpInsertPost extends WP_UnitTestCase {
 	/**
 	 * @ticket 11863
 	 */
-	function test_trashing_a_post_should_add_trashed_suffix_to_post_name() {
+	public function test_trashing_a_post_should_add_trashed_suffix_to_post_name() {
 		$trashed_about_page_id = self::factory()->post->create(
 			array(
 				'post_type'   => 'page',
@@ -99,7 +99,7 @@ class Tests_Post_wpInsertPost extends WP_UnitTestCase {
 	/**
 	 * @ticket 11863
 	 */
-	function test_trashed_posts_original_post_name_should_be_reassigned_after_untrashing() {
+	public function test_trashed_posts_original_post_name_should_be_reassigned_after_untrashing() {
 		$about_page_id = self::factory()->post->create(
 			array(
 				'post_type'   => 'page',
@@ -116,7 +116,7 @@ class Tests_Post_wpInsertPost extends WP_UnitTestCase {
 	/**
 	 * @ticket 11863
 	 */
-	function test_creating_a_new_post_should_add_trashed_suffix_to_post_name_of_trashed_posts_with_the_desired_slug() {
+	public function test_creating_a_new_post_should_add_trashed_suffix_to_post_name_of_trashed_posts_with_the_desired_slug() {
 		$trashed_about_page_id = self::factory()->post->create(
 			array(
 				'post_type'   => 'page',
@@ -140,7 +140,7 @@ class Tests_Post_wpInsertPost extends WP_UnitTestCase {
 	/**
 	 * @ticket 11863
 	 */
-	function test_untrashing_a_post_with_a_stored_desired_post_name_should_get_its_post_name_suffixed_if_another_post_has_taken_the_desired_post_name() {
+	public function test_untrashing_a_post_with_a_stored_desired_post_name_should_get_its_post_name_suffixed_if_another_post_has_taken_the_desired_post_name() {
 		$about_page_id = self::factory()->post->create(
 			array(
 				'post_type'   => 'page',
@@ -174,7 +174,7 @@ class Tests_Post_wpInsertPost extends WP_UnitTestCase {
 	 * @ticket 23022
 	 * @dataProvider data_various_post_statuses
 	 */
-	function test_untrashing_a_post_should_always_restore_it_to_draft_status( $post_status ) {
+	public function test_untrashing_a_post_should_always_restore_it_to_draft_status( $post_status ) {
 		$page_id = self::factory()->post->create(
 			array(
 				'post_type'   => 'page',
@@ -192,7 +192,7 @@ class Tests_Post_wpInsertPost extends WP_UnitTestCase {
 	 * @ticket 23022
 	 * @dataProvider data_various_post_statuses
 	 */
-	function test_wp_untrash_post_status_filter_restores_post_to_correct_status( $post_status ) {
+	public function test_wp_untrash_post_status_filter_restores_post_to_correct_status( $post_status ) {
 		add_filter( 'wp_untrash_post_status', 'wp_untrash_post_set_previous_status', 10, 3 );
 
 		$page_id = self::factory()->post->create(
@@ -215,7 +215,7 @@ class Tests_Post_wpInsertPost extends WP_UnitTestCase {
 	 *
 	 * @return array Array of test arguments.
 	 */
-	function data_various_post_types() {
+	public function data_various_post_types() {
 		return array(
 			array(
 				'mapped_meta_caps',
@@ -234,7 +234,7 @@ class Tests_Post_wpInsertPost extends WP_UnitTestCase {
 	 *
 	 * @return array Array of test arguments.
 	 */
-	function data_various_post_statuses() {
+	public function data_various_post_statuses() {
 		return array(
 			array(
 				'draft',
@@ -257,7 +257,7 @@ class Tests_Post_wpInsertPost extends WP_UnitTestCase {
 	 * @ticket 42464
 	 * @dataProvider data_various_post_types
 	 */
-	function test_contributor_cannot_set_post_slug( $post_type ) {
+	public function test_contributor_cannot_set_post_slug( $post_type ) {
 		wp_set_current_user( self::$user_ids['contributor'] );
 
 		$post_id = $this->factory()->post->create(
@@ -296,7 +296,7 @@ class Tests_Post_wpInsertPost extends WP_UnitTestCase {
 	 * @ticket 42464
 	 * @dataProvider data_various_post_types
 	 */
-	function test_administrator_can_set_post_slug( $post_type ) {
+	public function test_administrator_can_set_post_slug( $post_type ) {
 		wp_set_current_user( self::$user_ids['administrator'] );
 
 		$post_id = $this->factory()->post->create(
@@ -337,7 +337,7 @@ class Tests_Post_wpInsertPost extends WP_UnitTestCase {
 	 *
 	 * @ticket 42464
 	 */
-	function test_administrator_cannot_set_post_slug_on_post_type_they_cannot_publish() {
+	public function test_administrator_cannot_set_post_slug_on_post_type_they_cannot_publish() {
 		wp_set_current_user( self::$user_ids['administrator'] );
 
 		$post_id = $this->factory()->post->create(
@@ -373,7 +373,7 @@ class Tests_Post_wpInsertPost extends WP_UnitTestCase {
 	/**
 	 * @ticket 25347
 	 */
-	function test_scheduled_post_with_a_past_date_should_be_published() {
+	public function test_scheduled_post_with_a_past_date_should_be_published() {
 
 		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 

--- a/tests/phpunit/tests/post/wpListPages.php
+++ b/tests/phpunit/tests/post/wpListPages.php
@@ -115,7 +115,7 @@ class Tests_Post_wpListPages extends WP_UnitTestCase {
 		}
 	}
 
-	function test_wp_list_pages_default() {
+	public function test_wp_list_pages_default() {
 		$args = array(
 			'echo' => false,
 		);
@@ -146,7 +146,7 @@ class Tests_Post_wpListPages extends WP_UnitTestCase {
 		$this->assertSameIgnoreEOL( $expected, wp_list_pages( $args ) );
 	}
 
-	function test_wp_list_pages_depth() {
+	public function test_wp_list_pages_depth() {
 		$args = array(
 			'echo'  => false,
 			'depth' => 1,
@@ -160,7 +160,7 @@ class Tests_Post_wpListPages extends WP_UnitTestCase {
 		$this->assertSameIgnoreEOL( $expected, wp_list_pages( $args ) );
 	}
 
-	function test_wp_list_pages_show_date() {
+	public function test_wp_list_pages_show_date() {
 		$args = array(
 			'echo'      => false,
 			'depth'     => 1,
@@ -176,7 +176,7 @@ class Tests_Post_wpListPages extends WP_UnitTestCase {
 		$this->assertSameIgnoreEOL( $expected, wp_list_pages( $args ) );
 	}
 
-	function test_wp_list_pages_date_format() {
+	public function test_wp_list_pages_date_format() {
 		$args = array(
 			'echo'        => false,
 			'show_date'   => true,
@@ -210,7 +210,7 @@ class Tests_Post_wpListPages extends WP_UnitTestCase {
 		$this->assertSameIgnoreEOL( $expected, wp_list_pages( $args ) );
 	}
 
-	function test_wp_list_pages_child_of() {
+	public function test_wp_list_pages_child_of() {
 		$args = array(
 			'echo'     => false,
 			'child_of' => self::$parent_2,
@@ -224,7 +224,7 @@ class Tests_Post_wpListPages extends WP_UnitTestCase {
 		$this->assertSameIgnoreEOL( $expected, wp_list_pages( $args ) );
 	}
 
-	function test_wp_list_pages_exclude() {
+	public function test_wp_list_pages_exclude() {
 		$args = array(
 			'echo'    => false,
 			'exclude' => self::$parent_2,
@@ -252,7 +252,7 @@ class Tests_Post_wpListPages extends WP_UnitTestCase {
 		$this->assertSameIgnoreEOL( $expected, wp_list_pages( $args ) );
 	}
 
-	function test_wp_list_pages_title_li() {
+	public function test_wp_list_pages_title_li() {
 		$args = array(
 			'echo'     => false,
 			'depth'    => 1,
@@ -267,7 +267,7 @@ class Tests_Post_wpListPages extends WP_UnitTestCase {
 		$this->assertSameIgnoreEOL( $expected, wp_list_pages( $args ) );
 	}
 
-	function test_wp_list_pages_echo() {
+	public function test_wp_list_pages_echo() {
 		$args = array(
 			'echo'  => true,
 			'depth' => 1,
@@ -282,7 +282,7 @@ class Tests_Post_wpListPages extends WP_UnitTestCase {
 		wp_list_pages( $args );
 	}
 
-	function test_wp_list_pages_authors() {
+	public function test_wp_list_pages_authors() {
 		$args = array(
 			'echo'    => false,
 			'authors' => self::$author,
@@ -294,7 +294,7 @@ class Tests_Post_wpListPages extends WP_UnitTestCase {
 		$this->assertSameIgnoreEOL( $expected, wp_list_pages( $args ) );
 	}
 
-	function test_wp_list_pages_number() {
+	public function test_wp_list_pages_number() {
 		$args = array(
 			'echo'        => false,
 			'number'      => 1,
@@ -307,7 +307,7 @@ class Tests_Post_wpListPages extends WP_UnitTestCase {
 		$this->assertSameIgnoreEOL( $expected, wp_list_pages( $args ) );
 	}
 
-	function test_wp_list_pages_sort_column() {
+	public function test_wp_list_pages_sort_column() {
 		$args = array(
 			'echo'        => false,
 			'depth'       => 1,
@@ -323,7 +323,7 @@ class Tests_Post_wpListPages extends WP_UnitTestCase {
 		$this->assertSameIgnoreEOL( $expected, wp_list_pages( $args ) );
 	}
 
-	function test_wp_list_pages_link_before() {
+	public function test_wp_list_pages_link_before() {
 		$args = array(
 			'echo'        => false,
 			'link_before' => 'BEFORE',
@@ -355,7 +355,7 @@ class Tests_Post_wpListPages extends WP_UnitTestCase {
 		$this->assertSameIgnoreEOL( $expected, wp_list_pages( $args ) );
 	}
 
-	function test_wp_list_pages_link_after() {
+	public function test_wp_list_pages_link_after() {
 		$args = array(
 			'echo'       => false,
 			'link_after' => 'AFTER',
@@ -388,7 +388,7 @@ class Tests_Post_wpListPages extends WP_UnitTestCase {
 	}
 
 
-	function test_wp_list_pages_include() {
+	public function test_wp_list_pages_include() {
 		$args = array(
 			'echo'    => false,
 			'include' => self::$parent_1 . ',' . self::$parent_3,
@@ -401,7 +401,7 @@ class Tests_Post_wpListPages extends WP_UnitTestCase {
 		$this->assertSameIgnoreEOL( $expected, wp_list_pages( $args ) );
 	}
 
-	function test_wp_list_pages_exclude_tree() {
+	public function test_wp_list_pages_exclude_tree() {
 		$args = array(
 			'echo'         => false,
 			'exclude_tree' => self::$parent_2 . ',' . self::$parent_3,
@@ -419,7 +419,7 @@ class Tests_Post_wpListPages extends WP_UnitTestCase {
 		$this->assertSameIgnoreEOL( $expected, wp_list_pages( $args ) );
 	}
 
-	function test_wp_list_pages_discarded_whitespace() {
+	public function test_wp_list_pages_discarded_whitespace() {
 		$args = array(
 			'echo'         => false,
 			'item_spacing' => 'discard',

--- a/tests/phpunit/tests/post/wpPublishPost.php
+++ b/tests/phpunit/tests/post/wpPublishPost.php
@@ -26,7 +26,7 @@ class Tests_Post_wpPublishPost extends WP_UnitTestCase {
 	 *
 	 * @ticket 51292
 	 */
-	function test_wp_publish_post_respects_current_categories() {
+	public function test_wp_publish_post_respects_current_categories() {
 		$post_id     = self::$auto_draft_id;
 		$category_id = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
 		wp_set_post_categories( $post_id, $category_id );
@@ -47,7 +47,7 @@ class Tests_Post_wpPublishPost extends WP_UnitTestCase {
 	 * @covers ::wp_publish_post
 	 * @ticket 51292
 	 */
-	function test_wp_publish_post_adds_default_category() {
+	public function test_wp_publish_post_adds_default_category() {
 		$post_id = self::$auto_draft_id;
 
 		wp_publish_post( $post_id );
@@ -67,7 +67,7 @@ class Tests_Post_wpPublishPost extends WP_UnitTestCase {
 	 * @covers ::wp_publish_post
 	 * @ticket 51292
 	 */
-	function test_wp_publish_post_adds_default_category_when_tagged() {
+	public function test_wp_publish_post_adds_default_category_when_tagged() {
 		$post_id = self::$auto_draft_id;
 		$tag_id  = $this->factory->term->create( array( 'taxonomy' => 'post_tag' ) );
 		wp_set_post_tags( $post_id, array( $tag_id ) );
@@ -88,7 +88,7 @@ class Tests_Post_wpPublishPost extends WP_UnitTestCase {
 	 * @covers ::wp_publish_post
 	 * @ticket 51292
 	 */
-	function test_wp_publish_post_respects_current_terms() {
+	public function test_wp_publish_post_respects_current_terms() {
 		// Create custom taxonomy to test with.
 		register_taxonomy(
 			'tax_51292',
@@ -123,7 +123,7 @@ class Tests_Post_wpPublishPost extends WP_UnitTestCase {
 	 * @covers ::wp_publish_post
 	 * @ticket 51292
 	 */
-	function test_wp_publish_post_adds_default_term() {
+	public function test_wp_publish_post_adds_default_term() {
 		// Create custom taxonomy to test with.
 		register_taxonomy(
 			'tax_51292',

--- a/tests/phpunit/tests/post/wpUniquePostSlug.php
+++ b/tests/phpunit/tests/post/wpUniquePostSlug.php
@@ -92,7 +92,7 @@ class Tests_Post_wpUniquePostSlug extends WP_UnitTestCase {
 	/**
 	 * @ticket 18962
 	 */
-	function test_wp_unique_post_slug_with_hierarchy_and_attachments() {
+	public function test_wp_unique_post_slug_with_hierarchy_and_attachments() {
 		register_post_type( 'post-type-1', array( 'hierarchical' => true ) );
 
 		$args = array(

--- a/tests/phpunit/tests/query/conditionals.php
+++ b/tests/phpunit/tests/query/conditionals.php
@@ -14,7 +14,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	protected $page_ids;
 	protected $post_ids;
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		update_option( 'comments_per_page', 5 );
@@ -25,12 +25,12 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 		create_initial_taxonomies();
 	}
 
-	function test_home() {
+	public function test_home() {
 		$this->go_to( '/' );
 		$this->assertQueryTrue( 'is_home', 'is_front_page' );
 	}
 
-	function test_page_on_front() {
+	public function test_page_on_front() {
 		$page_on_front  = self::factory()->post->create(
 			array(
 				'post_type' => 'page',
@@ -56,18 +56,18 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 		delete_option( 'page_for_posts' );
 	}
 
-	function test_404() {
+	public function test_404() {
 		$this->go_to( '/notapage' );
 		$this->assertQueryTrue( 'is_404' );
 	}
 
-	function test_permalink() {
+	public function test_permalink() {
 		$post_id = self::factory()->post->create( array( 'post_title' => 'hello-world' ) );
 		$this->go_to( get_permalink( $post_id ) );
 		$this->assertQueryTrue( 'is_single', 'is_singular' );
 	}
 
-	function test_post_comments_feed() {
+	public function test_post_comments_feed() {
 		$post_id = self::factory()->post->create( array( 'post_title' => 'hello-world' ) );
 		self::factory()->comment->create_post_comments( $post_id, 2 );
 		$this->go_to( get_post_comments_feed_link( $post_id ) );
@@ -75,20 +75,20 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	}
 
 
-	function test_post_comments_feed_with_no_comments() {
+	public function test_post_comments_feed_with_no_comments() {
 		$post_id = self::factory()->post->create( array( 'post_title' => 'hello-world' ) );
 		$this->go_to( get_post_comments_feed_link( $post_id ) );
 		$this->assertQueryTrue( 'is_feed', 'is_single', 'is_singular', 'is_comment_feed' );
 	}
 
-	function test_attachment_comments_feed() {
+	public function test_attachment_comments_feed() {
 		$attachment_id = self::factory()->post->create( array( 'post_type' => 'attachment' ) );
 		self::factory()->comment->create_post_comments( $attachment_id, 2 );
 		$this->go_to( get_post_comments_feed_link( $attachment_id ) );
 		$this->assertQueryTrue( 'is_feed', 'is_attachment', 'is_single', 'is_singular', 'is_comment_feed' );
 	}
 
-	function test_page() {
+	public function test_page() {
 		$page_id = self::factory()->post->create(
 			array(
 				'post_type'  => 'page',
@@ -99,7 +99,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 		$this->assertQueryTrue( 'is_page', 'is_singular' );
 	}
 
-	function test_parent_page() {
+	public function test_parent_page() {
 		$page_id = self::factory()->post->create(
 			array(
 				'post_type'  => 'page',
@@ -111,7 +111,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 		$this->assertQueryTrue( 'is_page', 'is_singular' );
 	}
 
-	function test_child_page_1() {
+	public function test_child_page_1() {
 		$page_id = self::factory()->post->create(
 			array(
 				'post_type'  => 'page',
@@ -130,7 +130,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 		$this->assertQueryTrue( 'is_page', 'is_singular' );
 	}
 
-	function test_child_page_2() {
+	public function test_child_page_2() {
 		$page_id = self::factory()->post->create(
 			array(
 				'post_type'  => 'page',
@@ -157,7 +157,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	}
 
 	// '(about)/trackback/?$' => 'index.php?pagename=$matches[1]&tb=1'
-	function test_page_trackback() {
+	public function test_page_trackback() {
 		$page_ids   = array();
 		$page_id    = self::factory()->post->create(
 			array(
@@ -195,7 +195,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	}
 
 	// '(about)/feed/(feed|rdf|rss|rss2|atom)/?$' => 'index.php?pagename=$matches[1]&feed=$matches[2]'
-	function test_page_feed() {
+	public function test_page_feed() {
 		$page_ids   = array();
 		$page_id    = self::factory()->post->create(
 			array(
@@ -233,7 +233,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 		}
 	}
 
-	function test_page_feed_with_no_comments() {
+	public function test_page_feed_with_no_comments() {
 		$page_ids   = array();
 		$page_id    = self::factory()->post->create(
 			array(
@@ -271,7 +271,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	}
 
 	// '(about)/feed/(feed|rdf|rss|rss2|atom)/?$' => 'index.php?pagename=$matches[1]&feed=$matches[2]'
-	function test_page_feed_atom() {
+	public function test_page_feed_atom() {
 		$page_ids   = array();
 		$page_id    = self::factory()->post->create(
 			array(
@@ -311,7 +311,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	}
 
 	// '(about)/page/?([0-9]{1,})/?$' => 'index.php?pagename=$matches[1]&paged=$matches[2]'
-	function test_page_page_2() {
+	public function test_page_page_2() {
 		$page_id = self::factory()->post->create(
 			array(
 				'post_type'    => 'page',
@@ -330,7 +330,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	}
 
 	// '(about)/page/?([0-9]{1,})/?$' => 'index.php?pagename=$matches[1]&paged=$matches[2]'
-	function test_page_page_2_no_slash() {
+	public function test_page_page_2_no_slash() {
 		$page_id = self::factory()->post->create(
 			array(
 				'post_type'    => 'page',
@@ -349,7 +349,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	}
 
 	// '(about)(/[0-9]+)?/?$' => 'index.php?pagename=$matches[1]&page=$matches[2]'
-	function test_pagination_of_posts_page() {
+	public function test_pagination_of_posts_page() {
 		$page_id = self::factory()->post->create(
 			array(
 				'post_type'    => 'page',
@@ -380,7 +380,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 
 	// 'feed/(feed|rdf|rss|rss2|atom)/?$' => 'index.php?&feed=$matches[1]',
 	// '(feed|rdf|rss|rss2|atom)/?$' => 'index.php?&feed=$matches[1]',
-	function test_main_feed_2() {
+	public function test_main_feed_2() {
 		self::factory()->post->create(); // @test_404
 		$feeds = array( 'feed', 'rdf', 'rss', 'rss2', 'atom' );
 
@@ -398,7 +398,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 
 	}
 
-	function test_main_feed() {
+	public function test_main_feed() {
 		self::factory()->post->create(); // @test_404
 		$types = array( 'rss2', 'rss', 'atom' );
 		foreach ( $types as $type ) {
@@ -408,7 +408,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	}
 
 	// 'page/?([0-9]{1,})/?$' => 'index.php?&paged=$matches[1]',
-	function test_paged() {
+	public function test_paged() {
 		update_option( 'posts_per_page', 2 );
 		self::factory()->post->create_many( 5 );
 		for ( $i = 2; $i <= 3; $i++ ) {
@@ -419,7 +419,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 
 	// 'comments/feed/(feed|rdf|rss|rss2|atom)/?$' => 'index.php?&feed=$matches[1]&withcomments=1',
 	// 'comments/(feed|rdf|rss|rss2|atom)/?$' => 'index.php?&feed=$matches[1]&withcomments=1',
-	function test_main_comments_feed() {
+	public function test_main_comments_feed() {
 		$post_id = self::factory()->post->create( array( 'post_title' => 'hello-world' ) );
 		self::factory()->comment->create_post_comments( $post_id, 2 );
 
@@ -445,7 +445,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 
 	// 'search/(.+)/feed/(feed|rdf|rss|rss2|atom)/?$' => 'index.php?s=$matches[1]&feed=$matches[2]',
 	// 'search/(.+)/(feed|rdf|rss|rss2|atom)/?$' => 'index.php?s=$matches[1]&feed=$matches[2]',
-	function test_search_feed() {
+	public function test_search_feed() {
 		// Check the long form.
 		$types = array( 'feed', 'rdf', 'rss', 'rss2', 'atom' );
 		foreach ( $types as $type ) {
@@ -462,7 +462,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	}
 
 	// 'search/(.+)/page/?([0-9]{1,})/?$' => 'index.php?s=$matches[1]&paged=$matches[2]',
-	function test_search_paged() {
+	public function test_search_paged() {
 		update_option( 'posts_per_page', 2 );
 		self::factory()->post->create_many( 3, array( 'post_title' => 'test' ) );
 		$this->go_to( '/search/test/page/2/' );
@@ -470,7 +470,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	}
 
 	// 'search/(.+)/?$' => 'index.php?s=$matches[1]',
-	function test_search() {
+	public function test_search() {
 		$this->go_to( '/search/test/' );
 		$this->assertQueryTrue( 'is_search' );
 	}
@@ -478,14 +478,14 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	/**
 	 * @ticket 13961
 	 */
-	function test_search_encoded_chars() {
+	public function test_search_encoded_chars() {
 		$this->go_to( '/search/F%C3%BCnf%2Bbar/' );
 		$this->assertSame( get_query_var( 's' ), 'Fünf+bar' );
 	}
 
 	// 'category/(.+?)/feed/(feed|rdf|rss|rss2|atom)/?$' => 'index.php?category_name=$matches[1]&feed=$matches[2]',
 	// 'category/(.+?)/(feed|rdf|rss|rss2|atom)/?$' => 'index.php?category_name=$matches[1]&feed=$matches[2]',
-	function test_category_feed() {
+	public function test_category_feed() {
 		self::factory()->term->create(
 			array(
 				'name'     => 'cat-a',
@@ -509,7 +509,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	}
 
 	// 'category/(.+?)/page/?([0-9]{1,})/?$' => 'index.php?category_name=$matches[1]&paged=$matches[2]',
-	function test_category_paged() {
+	public function test_category_paged() {
 		update_option( 'posts_per_page', 2 );
 		self::factory()->post->create_many( 3 );
 		$this->go_to( '/category/uncategorized/page/2/' );
@@ -517,7 +517,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	}
 
 	// 'category/(.+?)/?$' => 'index.php?category_name=$matches[1]',
-	function test_category() {
+	public function test_category() {
 		self::factory()->term->create(
 			array(
 				'name'     => 'cat-a',
@@ -530,7 +530,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 
 	// 'tag/(.+?)/feed/(feed|rdf|rss|rss2|atom)/?$' => 'index.php?tag=$matches[1]&feed=$matches[2]',
 	// 'tag/(.+?)/(feed|rdf|rss|rss2|atom)/?$' => 'index.php?tag=$matches[1]&feed=$matches[2]',
-	function test_tag_feed() {
+	public function test_tag_feed() {
 		self::factory()->term->create(
 			array(
 				'name'     => 'tag-a',
@@ -553,7 +553,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	}
 
 	// 'tag/(.+?)/page/?([0-9]{1,})/?$' => 'index.php?tag=$matches[1]&paged=$matches[2]',
-	function test_tag_paged() {
+	public function test_tag_paged() {
 		update_option( 'posts_per_page', 2 );
 		$post_ids = self::factory()->post->create_many( 3 );
 		foreach ( $post_ids as $post_id ) {
@@ -564,7 +564,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	}
 
 	// 'tag/(.+?)/?$' => 'index.php?tag=$matches[1]',
-	function test_tag() {
+	public function test_tag() {
 		$term_id = self::factory()->term->create(
 			array(
 				'name'     => 'Tag Named A',
@@ -589,7 +589,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 
 	// 'author/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$' => 'index.php?author_name=$matches[1]&feed=$matches[2]',
 	// 'author/([^/]+)/(feed|rdf|rss|rss2|atom)/?$' => 'index.php?author_name=$matches[1]&feed=$matches[2]',
-	function test_author_feed() {
+	public function test_author_feed() {
 		self::factory()->user->create( array( 'user_login' => 'user-a' ) );
 		// Check the long form.
 		$types = array( 'feed', 'rdf', 'rss', 'rss2', 'atom' );
@@ -607,7 +607,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	}
 
 	// 'author/([^/]+)/page/?([0-9]{1,})/?$' => 'index.php?author_name=$matches[1]&paged=$matches[2]',
-	function test_author_paged() {
+	public function test_author_paged() {
 		update_option( 'posts_per_page', 2 );
 		$user_id = self::factory()->user->create( array( 'user_login' => 'user-a' ) );
 		self::factory()->post->create_many( 3, array( 'post_author' => $user_id ) );
@@ -616,14 +616,14 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	}
 
 	// 'author/([^/]+)/?$' => 'index.php?author_name=$matches[1]',
-	function test_author() {
+	public function test_author() {
 		$user_id = self::factory()->user->create( array( 'user_login' => 'user-a' ) );
 		self::factory()->post->create( array( 'post_author' => $user_id ) );
 		$this->go_to( '/author/user-a/' );
 		$this->assertQueryTrue( 'is_archive', 'is_author' );
 	}
 
-	function test_author_with_no_posts() {
+	public function test_author_with_no_posts() {
 		$user_id = self::factory()->user->create( array( 'user_login' => 'user-a' ) );
 		$this->go_to( '/author/user-a/' );
 		$this->assertQueryTrue( 'is_archive', 'is_author' );
@@ -631,7 +631,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 
 	// '([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/feed/(feed|rdf|rss|rss2|atom)/?$' => 'index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&feed=$matches[4]',
 	// '([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/(feed|rdf|rss|rss2|atom)/?$' => 'index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&feed=$matches[4]',
-	function test_ymd_feed() {
+	public function test_ymd_feed() {
 		self::factory()->post->create( array( 'post_date' => '2007-09-04 00:00:00' ) );
 		// Check the long form.
 		$types = array( 'feed', 'rdf', 'rss', 'rss2', 'atom' );
@@ -649,7 +649,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	}
 
 	// '([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/page/?([0-9]{1,})/?$' => 'index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&paged=$matches[4]',
-	function test_ymd_paged() {
+	public function test_ymd_paged() {
 		update_option( 'posts_per_page', 2 );
 		self::factory()->post->create_many( 3, array( 'post_date' => '2007-09-04 00:00:00' ) );
 		$this->go_to( '/2007/09/04/page/2/' );
@@ -657,7 +657,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	}
 
 	// '([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/?$' => 'index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]',
-	function test_ymd() {
+	public function test_ymd() {
 		self::factory()->post->create( array( 'post_date' => '2007-09-04 00:00:00' ) );
 		$this->go_to( '/2007/09/04/' );
 		$this->assertQueryTrue( 'is_archive', 'is_day', 'is_date' );
@@ -665,7 +665,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 
 	// '([0-9]{4})/([0-9]{1,2})/feed/(feed|rdf|rss|rss2|atom)/?$' => 'index.php?year=$matches[1]&monthnum=$matches[2]&feed=$matches[3]',
 	// '([0-9]{4})/([0-9]{1,2})/(feed|rdf|rss|rss2|atom)/?$' => 'index.php?year=$matches[1]&monthnum=$matches[2]&feed=$matches[3]',
-	function test_ym_feed() {
+	public function test_ym_feed() {
 		self::factory()->post->create( array( 'post_date' => '2007-09-04 00:00:00' ) );
 		// Check the long form.
 		$types = array( 'feed', 'rdf', 'rss', 'rss2', 'atom' );
@@ -683,7 +683,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	}
 
 	// '([0-9]{4})/([0-9]{1,2})/page/?([0-9]{1,})/?$' => 'index.php?year=$matches[1]&monthnum=$matches[2]&paged=$matches[3]',
-	function test_ym_paged() {
+	public function test_ym_paged() {
 		update_option( 'posts_per_page', 2 );
 		self::factory()->post->create_many( 3, array( 'post_date' => '2007-09-04 00:00:00' ) );
 		$this->go_to( '/2007/09/page/2/' );
@@ -691,7 +691,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	}
 
 	// '([0-9]{4})/([0-9]{1,2})/?$' => 'index.php?year=$matches[1]&monthnum=$matches[2]',
-	function test_ym() {
+	public function test_ym() {
 		self::factory()->post->create( array( 'post_date' => '2007-09-04 00:00:00' ) );
 		$this->go_to( '/2007/09/' );
 		$this->assertQueryTrue( 'is_archive', 'is_date', 'is_month' );
@@ -699,7 +699,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 
 	// '([0-9]{4})/feed/(feed|rdf|rss|rss2|atom)/?$' => 'index.php?year=$matches[1]&feed=$matches[2]',
 	// '([0-9]{4})/(feed|rdf|rss|rss2|atom)/?$' => 'index.php?year=$matches[1]&feed=$matches[2]',
-	function test_y_feed() {
+	public function test_y_feed() {
 		self::factory()->post->create( array( 'post_date' => '2007-09-04 00:00:00' ) );
 		// Check the long form.
 		$types = array( 'feed', 'rdf', 'rss', 'rss2', 'atom' );
@@ -717,7 +717,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	}
 
 	// '([0-9]{4})/page/?([0-9]{1,})/?$' => 'index.php?year=$matches[1]&paged=$matches[2]',
-	function test_y_paged() {
+	public function test_y_paged() {
 		update_option( 'posts_per_page', 2 );
 		self::factory()->post->create_many( 3, array( 'post_date' => '2007-09-04 00:00:00' ) );
 		$this->go_to( '/2007/page/2/' );
@@ -725,14 +725,14 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	}
 
 	// '([0-9]{4})/?$' => 'index.php?year=$matches[1]',
-	function test_y() {
+	public function test_y() {
 		self::factory()->post->create( array( 'post_date' => '2007-09-04 00:00:00' ) );
 		$this->go_to( '/2007/' );
 		$this->assertQueryTrue( 'is_archive', 'is_date', 'is_year' );
 	}
 
 	// '([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/([^/]+)/trackback/?$' => 'index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&name=$matches[4]&tb=1',
-	function test_post_trackback() {
+	public function test_post_trackback() {
 		$post_id   = self::factory()->post->create();
 		$permalink = get_permalink( $post_id );
 		$this->go_to( "{$permalink}trackback/" );
@@ -741,7 +741,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 
 	// '([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$' => 'index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&name=$matches[4]&feed=$matches[5]',
 	// '([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/([^/]+)/(feed|rdf|rss|rss2|atom)/?$' => 'index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&name=$matches[4]&feed=$matches[5]',
-	function test_post_comment_feed() {
+	public function test_post_comment_feed() {
 		$post_id   = self::factory()->post->create();
 		$permalink = get_permalink( $post_id );
 		// Check the long form.
@@ -760,7 +760,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	}
 
 	// '([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/([^/]+)(/[0-9]+)?/?$' => 'index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&name=$matches[4]&page=$matches[5]',
-	function test_post_paged_short() {
+	public function test_post_paged_short() {
 		$post_id = self::factory()->post->create(
 			array(
 				'post_date'    => '2007-09-04 00:00:00',
@@ -775,7 +775,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	}
 
 	// '[0-9]{4}/[0-9]{1,2}/[0-9]{1,2}/[^/]+/([^/]+)/?$' => 'index.php?attachment=$matches[1]',
-	function test_post_attachment() {
+	public function test_post_attachment() {
 		$post_id   = self::factory()->post->create( array( 'post_type' => 'attachment' ) );
 		$permalink = get_attachment_link( $post_id );
 		$this->go_to( $permalink );
@@ -793,7 +793,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	/**
 	 * @expectedIncorrectUsage WP_Date_Query
 	 */
-	function test_bad_dates() {
+	public function test_bad_dates() {
 		$this->go_to( '/2013/13/13/' );
 		$this->assertQueryTrue( 'is_404' );
 
@@ -801,7 +801,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 		$this->assertQueryTrue( 'is_404' );
 	}
 
-	function test_post_type_archive_with_tax_query() {
+	public function test_post_type_archive_with_tax_query() {
 		delete_option( 'rewrite_rules' );
 
 		$cpt_name = 'ptawtq';
@@ -832,7 +832,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 		remove_action( 'pre_get_posts', array( $this, 'pre_get_posts_with_tax_query' ) );
 	}
 
-	function pre_get_posts_with_tax_query( &$query ) {
+	public function pre_get_posts_with_tax_query( &$query ) {
 		$term = get_term_by( 'slug', 'tag-slug', 'post_tag' );
 		$query->set(
 			'tax_query',
@@ -846,7 +846,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 		);
 	}
 
-	function test_post_type_array() {
+	public function test_post_type_array() {
 		delete_option( 'rewrite_rules' );
 
 		$cpt_name = 'thearray';
@@ -874,11 +874,11 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 		remove_action( 'pre_get_posts', array( $this, 'pre_get_posts_with_type_array' ) );
 	}
 
-	function pre_get_posts_with_type_array( &$query ) {
+	public function pre_get_posts_with_type_array( &$query ) {
 		$query->set( 'post_type', array( 'post', 'thearray' ) );
 	}
 
-	function test_is_single() {
+	public function test_is_single() {
 		$post_id = self::factory()->post->create();
 		$this->go_to( "/?p=$post_id" );
 
@@ -898,7 +898,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	/**
 	 * @ticket 16802
 	 */
-	function test_is_single_with_parent() {
+	public function test_is_single_with_parent() {
 		// Use custom hierarchical post type.
 		$post_type = 'test_hierarchical';
 
@@ -1005,7 +1005,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	/**
 	 * @ticket 38225
 	 */
-	function test_is_single_with_attachment() {
+	public function test_is_single_with_attachment() {
 		$post_id = self::factory()->post->create();
 
 		$attachment_id = self::factory()->attachment->create_object(
@@ -1025,7 +1025,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 		$this->assertTrue( $q->is_attachment );
 	}
 
-	function test_is_page() {
+	public function test_is_page() {
 		$post_id = self::factory()->post->create( array( 'post_type' => 'page' ) );
 		$this->go_to( "/?page_id=$post_id" );
 
@@ -1045,7 +1045,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	/**
 	 * @ticket 16802
 	 */
-	function test_is_page_with_parent() {
+	public function test_is_page_with_parent() {
 		$parent_id = self::factory()->post->create(
 			array(
 				'post_type' => 'page',
@@ -1079,7 +1079,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 		$this->assertFalse( is_page( 'foo' ) );
 	}
 
-	function test_is_attachment() {
+	public function test_is_attachment() {
 		$post_id = self::factory()->post->create( array( 'post_type' => 'attachment' ) );
 		$this->go_to( "/?attachment_id=$post_id" );
 
@@ -1236,7 +1236,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 		$this->assertFalse( $q->is_page( $p2 ) );
 	}
 
-	function test_is_page_template() {
+	public function test_is_page_template() {
 		$post_id = self::factory()->post->create( array( 'post_type' => 'page' ) );
 		update_post_meta( $post_id, '_wp_page_template', 'example.php' );
 		$this->go_to( "/?page_id=$post_id" );
@@ -1246,7 +1246,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	/**
 	 * @ticket 31271
 	 */
-	function test_is_page_template_default() {
+	public function test_is_page_template_default() {
 		$post_id = self::factory()->post->create( array( 'post_type' => 'page' ) );
 		$this->go_to( "/?page_id=$post_id" );
 		$this->assertTrue( is_page_template( 'default' ) );
@@ -1256,7 +1256,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	/**
 	 * @ticket 31271
 	 */
-	function test_is_page_template_array() {
+	public function test_is_page_template_array() {
 		$post_id = self::factory()->post->create( array( 'post_type' => 'page' ) );
 		update_post_meta( $post_id, '_wp_page_template', 'example.php' );
 		$this->go_to( "/?page_id=$post_id" );
@@ -1267,7 +1267,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	/**
 	 * @ticket 18375
 	 */
-	function test_is_page_template_other_post_type() {
+	public function test_is_page_template_other_post_type() {
 		$post_id = self::factory()->post->create( array( 'post_type' => 'post' ) );
 		update_post_meta( $post_id, '_wp_page_template', 'example.php' );
 		$this->go_to( get_post_permalink( $post_id ) );
@@ -1278,7 +1278,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	/**
 	 * @ticket 39211
 	 */
-	function test_is_page_template_not_singular() {
+	public function test_is_page_template_not_singular() {
 		global $wpdb;
 
 		// We need a non-post that shares an ID with a post assigned a template.

--- a/tests/phpunit/tests/query/isTerm.php
+++ b/tests/phpunit/tests/query/isTerm.php
@@ -22,7 +22,7 @@ class Tests_Query_IsTerm extends WP_UnitTestCase {
 	protected $tag;
 	protected $tax;
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		$GLOBALS['wp_the_query'] = new WP_Query();
@@ -63,7 +63,7 @@ class Tests_Query_IsTerm extends WP_UnitTestCase {
 		add_action( 'pre_get_posts', array( $this, 'pre_get_posts_tax_category_tax_query' ) );
 	}
 
-	function test_tag_action_tax() {
+	public function test_tag_action_tax() {
 		// Tag with taxonomy added.
 		$this->go_to( home_url( '/tag/tag-slug/' ) );
 		$this->assertQueryTrue( 'is_tag', 'is_archive' );
@@ -74,7 +74,7 @@ class Tests_Query_IsTerm extends WP_UnitTestCase {
 		$this->assertEquals( get_queried_object(), $this->tag );
 	}
 
-	function test_tag_query_cat_action_tax() {
+	public function test_tag_query_cat_action_tax() {
 		// Tag + category with taxonomy added.
 		$this->go_to( home_url( "/tag/tag-slug/?cat=$this->cat_id" ) );
 		$this->assertQueryTrue( 'is_category', 'is_tag', 'is_archive' );
@@ -86,7 +86,7 @@ class Tests_Query_IsTerm extends WP_UnitTestCase {
 		$this->assertEquals( get_queried_object(), $this->cat );
 	}
 
-	function test_tag_query_cat_query_tax_action_tax() {
+	public function test_tag_query_cat_query_tax_action_tax() {
 		// Tag + category + tax with taxonomy added.
 		$this->go_to( home_url( "/tag/tag-slug/?cat=$this->cat_id&testtax=tax-slug2" ) );
 		$this->assertQueryTrue( 'is_category', 'is_tag', 'is_tax', 'is_archive' );
@@ -99,7 +99,7 @@ class Tests_Query_IsTerm extends WP_UnitTestCase {
 		$this->assertEquals( get_queried_object(), $this->cat );
 	}
 
-	function test_cat_action_tax() {
+	public function test_cat_action_tax() {
 		// Category with taxonomy added.
 		$this->go_to( home_url( '/category/cat-slug/' ) );
 		$this->assertQueryTrue( 'is_category', 'is_archive' );
@@ -113,7 +113,7 @@ class Tests_Query_IsTerm extends WP_UnitTestCase {
 	/**
 	 * @ticket 26627
 	 */
-	function test_cat_uncat_action_tax() {
+	public function test_cat_uncat_action_tax() {
 		// Category with taxonomy added.
 		add_action( 'pre_get_posts', array( $this, '_cat_uncat_action_tax' ), 11 );
 
@@ -128,7 +128,7 @@ class Tests_Query_IsTerm extends WP_UnitTestCase {
 		remove_action( 'pre_get_posts', array( $this, '_cat_uncat_action_tax' ), 11 );
 	}
 
-	function _cat_uncat_action_tax( &$query ) {
+	public function _cat_uncat_action_tax( &$query ) {
 		$this->assertTrue( $query->is_category() );
 		$this->assertTrue( $query->is_archive() );
 		$this->assertNotEmpty( $query->get( 'category_name' ) );
@@ -139,7 +139,7 @@ class Tests_Query_IsTerm extends WP_UnitTestCase {
 	/**
 	 * @ticket 26728
 	 */
-	function test_tax_action_tax() {
+	public function test_tax_action_tax() {
 		// Taxonomy with taxonomy added.
 		$this->go_to( home_url( '/testtax/tax-slug2/' ) );
 		$this->assertQueryTrue( 'is_tax', 'is_archive' );
@@ -149,7 +149,7 @@ class Tests_Query_IsTerm extends WP_UnitTestCase {
 		$this->assertEquals( get_queried_object(), get_term( $this->tax_id, 'testtax' ) );
 	}
 
-	function test_tax_query_tag_action_tax() {
+	public function test_tax_query_tag_action_tax() {
 		// Taxonomy + tag with taxonomy added.
 		$this->go_to( home_url( "/testtax/tax-slug2/?tag_id=$this->tag_id" ) );
 		$this->assertQueryTrue( 'is_tag', 'is_tax', 'is_archive' );
@@ -160,7 +160,7 @@ class Tests_Query_IsTerm extends WP_UnitTestCase {
 		$this->assertEquals( get_queried_object(), $this->tag );
 	}
 
-	function test_tax_query_cat_action_tax() {
+	public function test_tax_query_cat_action_tax() {
 		// Taxonomy + category with taxonomy added.
 		$this->go_to( home_url( "/testtax/tax-slug2/?cat=$this->cat_id" ) );
 		$this->assertQueryTrue( 'is_category', 'is_tax', 'is_archive' );
@@ -171,7 +171,7 @@ class Tests_Query_IsTerm extends WP_UnitTestCase {
 		$this->assertEquals( get_queried_object(), $this->cat );
 	}
 
-	function pre_get_posts_tax_category_tax_query( &$query ) {
+	public function pre_get_posts_tax_category_tax_query( &$query ) {
 		$query->set(
 			'tax_query',
 			array(

--- a/tests/phpunit/tests/query/isTerm.php
+++ b/tests/phpunit/tests/query/isTerm.php
@@ -115,7 +115,7 @@ class Tests_Query_IsTerm extends WP_UnitTestCase {
 	 */
 	public function test_cat_uncat_action_tax() {
 		// Category with taxonomy added.
-		add_action( 'pre_get_posts', array( $this, '_cat_uncat_action_tax' ), 11 );
+		add_action( 'pre_get_posts', array( $this, 'cat_uncat_action_tax' ), 11 );
 
 		$this->go_to( home_url( '/category/uncategorized/' ) );
 		$this->assertQueryTrue( 'is_category', 'is_archive' );
@@ -125,10 +125,10 @@ class Tests_Query_IsTerm extends WP_UnitTestCase {
 		$this->assertNotEmpty( get_query_var( 'term_id' ) );
 		$this->assertEquals( get_queried_object(), $this->uncat );
 
-		remove_action( 'pre_get_posts', array( $this, '_cat_uncat_action_tax' ), 11 );
+		remove_action( 'pre_get_posts', array( $this, 'cat_uncat_action_tax' ), 11 );
 	}
 
-	public function _cat_uncat_action_tax( &$query ) {
+	public function cat_uncat_action_tax( &$query ) {
 		$this->assertTrue( $query->is_category() );
 		$this->assertTrue( $query->is_archive() );
 		$this->assertNotEmpty( $query->get( 'category_name' ) );

--- a/tests/phpunit/tests/query/results.php
+++ b/tests/phpunit/tests/query/results.php
@@ -294,14 +294,14 @@ class Tests_Query_Results extends WP_UnitTestCase {
 		self::$post_ids[]   = self::$child_four;
 	}
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		unset( $this->q );
 		$this->q = new WP_Query();
 	}
 
-	function test_query_default() {
+	public function test_query_default() {
 		$posts = $this->q->query( '' );
 
 		// The output should be the most recent 10 posts as listed here.
@@ -321,7 +321,7 @@ class Tests_Query_Results extends WP_UnitTestCase {
 		$this->assertSame( $expected, wp_list_pluck( $posts, 'post_name' ) );
 	}
 
-	function test_query_tag_a() {
+	public function test_query_tag_a() {
 		$posts = $this->q->query( 'tag=tag-a' );
 
 		// There are 4 posts with Tag A.
@@ -332,7 +332,7 @@ class Tests_Query_Results extends WP_UnitTestCase {
 		$this->assertSame( 'tags-a-b-c', $posts[3]->post_name );
 	}
 
-	function test_query_tag_b() {
+	public function test_query_tag_b() {
 		$posts = $this->q->query( 'tag=tag-b' );
 
 		// There are 4 posts with Tag A.
@@ -346,7 +346,7 @@ class Tests_Query_Results extends WP_UnitTestCase {
 	/**
 	 * @ticket 21779
 	 */
-	function test_query_tag_nun() {
+	public function test_query_tag_nun() {
 		$posts = $this->q->query( 'tag=tag-נ' );
 
 		// There is 1 post with Tag נ.
@@ -354,7 +354,7 @@ class Tests_Query_Results extends WP_UnitTestCase {
 		$this->assertSame( 'tag-%d7%a0', $posts[0]->post_name );
 	}
 
-	function test_query_tag_id() {
+	public function test_query_tag_id() {
 		$tag   = tag_exists( 'tag-a' );
 		$posts = $this->q->query( 'tag_id=' . $tag['term_id'] );
 
@@ -366,7 +366,7 @@ class Tests_Query_Results extends WP_UnitTestCase {
 		$this->assertSame( 'tags-a-b-c', $posts[3]->post_name );
 	}
 
-	function test_query_tag_slug__in() {
+	public function test_query_tag_slug__in() {
 		$posts = $this->q->query( 'tag_slug__in[]=tag-b&tag_slug__in[]=tag-c' );
 
 		// There are 4 posts with either Tag B or Tag C.
@@ -380,7 +380,7 @@ class Tests_Query_Results extends WP_UnitTestCase {
 	}
 
 
-	function test_query_tag__in() {
+	public function test_query_tag__in() {
 		$tag_a = tag_exists( 'tag-a' );
 		$tag_b = tag_exists( 'tag-b' );
 		$posts = $this->q->query( 'tag__in[]=' . $tag_a['term_id'] . '&tag__in[]=' . $tag_b['term_id'] );
@@ -395,7 +395,7 @@ class Tests_Query_Results extends WP_UnitTestCase {
 		$this->assertSame( 'tags-a-b-c', $posts[5]->post_name );
 	}
 
-	function test_query_tag__not_in() {
+	public function test_query_tag__not_in() {
 		$tag_a = tag_exists( 'tag-a' );
 		$posts = $this->q->query( 'tag__not_in[]=' . $tag_a['term_id'] );
 
@@ -417,7 +417,7 @@ class Tests_Query_Results extends WP_UnitTestCase {
 		$this->assertSame( $expected, wp_list_pluck( $posts, 'post_name' ) );
 	}
 
-	function test_query_tag__in_but__not_in() {
+	public function test_query_tag__in_but__not_in() {
 		$tag_a = tag_exists( 'tag-a' );
 		$tag_b = tag_exists( 'tag-b' );
 		$posts = $this->q->query( 'tag__in[]=' . $tag_a['term_id'] . '&tag__not_in[]=' . $tag_b['term_id'] );
@@ -430,7 +430,7 @@ class Tests_Query_Results extends WP_UnitTestCase {
 
 
 
-	function test_query_category_name() {
+	public function test_query_category_name() {
 		$posts = $this->q->query( 'category_name=cat-a' );
 
 		// There are 4 posts with Cat A, we'll check for them by name.
@@ -441,7 +441,7 @@ class Tests_Query_Results extends WP_UnitTestCase {
 		$this->assertSame( 'cats-a-b-c', $posts[3]->post_name );
 	}
 
-	function test_query_cat() {
+	public function test_query_cat() {
 		$cat   = category_exists( 'cat-b' );
 		$posts = $this->q->query( "cat=$cat" );
 
@@ -453,7 +453,7 @@ class Tests_Query_Results extends WP_UnitTestCase {
 		$this->assertSame( 'cats-a-b-c', $posts[3]->post_name );
 	}
 
-	function test_query_posts_per_page() {
+	public function test_query_posts_per_page() {
 		$posts = $this->q->query( 'posts_per_page=5' );
 
 		$expected = array(
@@ -468,7 +468,7 @@ class Tests_Query_Results extends WP_UnitTestCase {
 		$this->assertSame( $expected, wp_list_pluck( $posts, 'post_name' ) );
 	}
 
-	function test_query_offset() {
+	public function test_query_offset() {
 		$posts = $this->q->query( 'offset=2' );
 
 		$expected = array(
@@ -488,7 +488,7 @@ class Tests_Query_Results extends WP_UnitTestCase {
 		$this->assertSame( $expected, wp_list_pluck( $posts, 'post_name' ) );
 	}
 
-	function test_query_paged() {
+	public function test_query_paged() {
 		$posts = $this->q->query( 'paged=2' );
 
 		$expected = array(
@@ -509,7 +509,7 @@ class Tests_Query_Results extends WP_UnitTestCase {
 		$this->assertSame( $expected, wp_list_pluck( $posts, 'post_name' ) );
 	}
 
-	function test_query_paged_and_posts_per_page() {
+	public function test_query_paged_and_posts_per_page() {
 		$posts = $this->q->query( 'paged=4&posts_per_page=4' );
 
 		$expected = array(
@@ -527,7 +527,7 @@ class Tests_Query_Results extends WP_UnitTestCase {
 	/**
 	 * @ticket 11056
 	 */
-	function test_query_post_parent__in() {
+	public function test_query_post_parent__in() {
 		// Query for first parent's children.
 		$posts = $this->q->query(
 			array(
@@ -594,7 +594,7 @@ class Tests_Query_Results extends WP_UnitTestCase {
 	/**
 	 * @ticket 11056
 	 */
-	function test_query_orderby_post_parent__in() {
+	public function test_query_orderby_post_parent__in() {
 		$posts = $this->q->query(
 			array(
 				'post_parent__in' => array( self::$parent_two, self::$parent_one ),
@@ -617,7 +617,7 @@ class Tests_Query_Results extends WP_UnitTestCase {
 	/**
 	 * @ticket 39055
 	 */
-	function test_query_orderby_post_parent__in_with_order_desc() {
+	public function test_query_orderby_post_parent__in_with_order_desc() {
 		$post_parent__in_array   = array( self::$parent_two, self::$parent_one );
 		$expected_returned_array = array( 'child-three', 'child-four', 'child-one', 'child-two' );
 
@@ -636,7 +636,7 @@ class Tests_Query_Results extends WP_UnitTestCase {
 	/**
 	 * @ticket 39055
 	 */
-	function test_query_orderby_post__in_with_no_order_specified() {
+	public function test_query_orderby_post__in_with_no_order_specified() {
 		$post__in_array          = array( self::$post_ids[2], self::$post_ids[0], self::$post_ids[1] );
 		$expected_returned_array = array( self::$post_ids[2], self::$post_ids[0], self::$post_ids[1] );
 
@@ -655,7 +655,7 @@ class Tests_Query_Results extends WP_UnitTestCase {
 	/**
 	 * @ticket 39055
 	 */
-	function test_query_orderby_post__in_with_order_asc() {
+	public function test_query_orderby_post__in_with_order_asc() {
 		$post__in_array          = array( self::$post_ids[2], self::$post_ids[0], self::$post_ids[1] );
 		$expected_returned_array = array( self::$post_ids[2], self::$post_ids[0], self::$post_ids[1] );
 
@@ -675,7 +675,7 @@ class Tests_Query_Results extends WP_UnitTestCase {
 	/**
 	 * @ticket 39055
 	 */
-	function test_query_orderby_post__in_with_order_desc() {
+	public function test_query_orderby_post__in_with_order_desc() {
 		$post__in_array          = array( self::$post_ids[1], self::$post_ids[2], self::$post_ids[0] );
 		$expected_returned_array = array( self::$post_ids[1], self::$post_ids[2], self::$post_ids[0] );
 
@@ -696,7 +696,7 @@ class Tests_Query_Results extends WP_UnitTestCase {
 	/**
 	 * @ticket 39055
 	 */
-	function test_query_orderby_post_name__in_with_order_asc() {
+	public function test_query_orderby_post_name__in_with_order_asc() {
 		$post_name__in_array = array( 'parent-two', 'parent-one', 'parent-three' );
 
 		$q = new WP_Query(
@@ -713,7 +713,7 @@ class Tests_Query_Results extends WP_UnitTestCase {
 	/**
 	 * @ticket 39055
 	 */
-	function test_query_orderby_post_name__in_with_order_desc() {
+	public function test_query_orderby_post_name__in_with_order_desc() {
 		$post_name__in_array = array( 'parent-two', 'parent-one', 'parent-three' );
 
 		$q = new WP_Query(
@@ -732,7 +732,7 @@ class Tests_Query_Results extends WP_UnitTestCase {
 	 * @ticket 27252
 	 * @ticket 31194
 	 */
-	function test_query_fields_integers() {
+	public function test_query_fields_integers() {
 
 		$parents = array(
 			(int) self::$parent_one,
@@ -774,7 +774,7 @@ class Tests_Query_Results extends WP_UnitTestCase {
 	/**
 	 * @ticket 28099
 	 */
-	function test_empty_post__in() {
+	public function test_empty_post__in() {
 		$posts1 = $this->q->query( array() );
 		$this->assertNotEmpty( $posts1 );
 		$posts2 = $this->q->query( array( 'post__in' => array() ) );
@@ -786,7 +786,7 @@ class Tests_Query_Results extends WP_UnitTestCase {
 	/**
 	 * @ticket 19198
 	 */
-	function test_exclude_from_search_empty() {
+	public function test_exclude_from_search_empty() {
 		global $wp_post_types;
 		foreach ( array_keys( $wp_post_types ) as $slug ) {
 			$wp_post_types[ $slug ]->exclude_from_search = true;
@@ -810,7 +810,7 @@ class Tests_Query_Results extends WP_UnitTestCase {
 	/**
 	 * @ticket 16854
 	 */
-	function test_query_author_vars() {
+	public function test_query_author_vars() {
 		$author_1 = self::factory()->user->create(
 			array(
 				'user_login' => 'author1',
@@ -982,7 +982,7 @@ class Tests_Query_Results extends WP_UnitTestCase {
 	/**
 	 * @ticket 10935
 	 */
-	function test_query_is_date() {
+	public function test_query_is_date() {
 		$this->q->query(
 			array(
 				'year'     => '2007',
@@ -1040,7 +1040,7 @@ class Tests_Query_Results extends WP_UnitTestCase {
 		$this->assertFalse( $this->q->is_year );
 	}
 
-	function test_perm_with_status_array() {
+	public function test_perm_with_status_array() {
 		global $wpdb;
 		$this->q->query(
 			array(
@@ -1059,7 +1059,7 @@ class Tests_Query_Results extends WP_UnitTestCase {
 	/**
 	 * @ticket 20308
 	 */
-	function test_post_password() {
+	public function test_post_password() {
 		$one   = (string) self::factory()->post->create( array( 'post_password' => '' ) );
 		$two   = (string) self::factory()->post->create( array( 'post_password' => 'burrito' ) );
 		$three = (string) self::factory()->post->create( array( 'post_password' => 'burrito' ) );
@@ -1150,7 +1150,7 @@ class Tests_Query_Results extends WP_UnitTestCase {
 	/**
 	 * @ticket 28611
 	 */
-	function test_duplicate_slug_in_hierarchical_post_type() {
+	public function test_duplicate_slug_in_hierarchical_post_type() {
 		register_post_type( 'handbook', array( 'hierarchical' => true ) );
 
 		$post_1 = self::factory()->post->create(
@@ -1185,7 +1185,7 @@ class Tests_Query_Results extends WP_UnitTestCase {
 	/**
 	 * @ticket 29615
 	 */
-	function test_child_post_in_hierarchical_post_type_with_default_permalinks() {
+	public function test_child_post_in_hierarchical_post_type_with_default_permalinks() {
 		register_post_type( 'handbook', array( 'hierarchical' => true ) );
 
 		$post_1 = self::factory()->post->create(
@@ -1213,7 +1213,7 @@ class Tests_Query_Results extends WP_UnitTestCase {
 		$this->assertCount( 1, $result );
 	}
 
-	function test_title() {
+	public function test_title() {
 		$title   = 'Tacos are Cool';
 		$post_id = self::factory()->post->create(
 			array(

--- a/tests/phpunit/tests/query/search.php
+++ b/tests/phpunit/tests/query/search.php
@@ -7,7 +7,7 @@ class Tests_Query_Search extends WP_UnitTestCase {
 	protected $q;
 	protected $post_type;
 
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		$this->post_type = rand_str( 12 );
@@ -16,13 +16,13 @@ class Tests_Query_Search extends WP_UnitTestCase {
 		$this->q = new WP_Query();
 	}
 
-	function tear_down() {
+	public function tear_down() {
 		unset( $this->q );
 
 		parent::tear_down();
 	}
 
-	function get_search_results( $terms ) {
+	private function get_search_results( $terms ) {
 		$args = http_build_query(
 			array(
 				's'         => $terms,
@@ -32,7 +32,7 @@ class Tests_Query_Search extends WP_UnitTestCase {
 		return $this->q->query( $args );
 	}
 
-	function test_search_order_title_relevance() {
+	public function test_search_order_title_relevance() {
 		foreach ( range( 1, 7 ) as $i ) {
 			self::factory()->post->create(
 				array(
@@ -52,14 +52,14 @@ class Tests_Query_Search extends WP_UnitTestCase {
 		$this->assertSame( $post_id, reset( $posts )->ID );
 	}
 
-	function test_search_terms_query_var() {
+	public function test_search_terms_query_var() {
 		$terms = 'This is a search term';
 		$query = new WP_Query( array( 's' => 'This is a search term' ) );
 		$this->assertNotEquals( explode( ' ', $terms ), $query->get( 'search_terms' ) );
 		$this->assertSame( array( 'search', 'term' ), $query->get( 'search_terms' ) );
 	}
 
-	function test_filter_stopwords() {
+	public function test_filter_stopwords() {
 		$terms = 'This is a search term';
 		add_filter( 'wp_search_stopwords', array( $this, 'filter_wp_search_stopwords' ) );
 		$query = new WP_Query( array( 's' => $terms ) );
@@ -69,14 +69,14 @@ class Tests_Query_Search extends WP_UnitTestCase {
 		$this->assertSame( array( 'This', 'is', 'search', 'term' ), $query->get( 'search_terms' ) );
 	}
 
-	function filter_wp_search_stopwords() {
+	public function filter_wp_search_stopwords() {
 		return array();
 	}
 
 	/**
 	 * @ticket 38099
 	 */
-	function test_disable_search_exclusion_prefix() {
+	public function test_disable_search_exclusion_prefix() {
 		$title = '-HYPHENATION_TEST';
 
 		// Create a post with a title which starts with a hyphen.
@@ -101,7 +101,7 @@ class Tests_Query_Search extends WP_UnitTestCase {
 	/**
 	 * @ticket 38099
 	 */
-	function test_change_search_exclusion_prefix() {
+	public function test_change_search_exclusion_prefix() {
 		$title = '#OCTOTHORPE_TEST';
 
 		// Create a post with a title that starts with a non-hyphen prefix.
@@ -124,7 +124,7 @@ class Tests_Query_Search extends WP_UnitTestCase {
 		$this->assertSame( array(), $found );
 	}
 
-	function filter_search_exclusion_prefix_octothorpe() {
+	public function filter_search_exclusion_prefix_octothorpe() {
 		return '#';
 	}
 

--- a/tests/phpunit/tests/query/setupPostdata.php
+++ b/tests/phpunit/tests/query/setupPostdata.php
@@ -387,7 +387,7 @@ class Tests_Query_SetupPostdata extends WP_UnitTestCase {
 	 * setup_postdata( $a_post ) followed by the_content() without updating global $post
 	 * should use the content of $a_post rather then the global post.
 	 */
-	function test_setup_postdata_with_the_content() {
+	public function test_setup_postdata_with_the_content() {
 		$post_id                   = self::factory()->post->create( array( 'post_content' => 'global post' ) );
 		$GLOBALS['post']           = get_post( $post_id );
 		$GLOBALS['wp_query']->post = $GLOBALS['post'];

--- a/tests/phpunit/tests/query/verboseRewriteRules.php
+++ b/tests/phpunit/tests/query/verboseRewriteRules.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/conditionals.php';
  * @group rewrite
  */
 class Tests_Query_VerbosePageRules extends Tests_Query_Conditionals {
-	function set_up() {
+	public function set_up() {
 		parent::set_up();
 
 		$this->set_permalink_structure( '/%category%/%year%/%postname%/' );

--- a/tests/phpunit/tests/rest-api/rest-users-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-users-controller.php
@@ -1224,7 +1224,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		}
 	}
 
-	function get_illegal_user_logins() {
+	public function get_illegal_user_logins() {
 		return array( 'nope' );
 	}
 

--- a/tests/phpunit/tests/sitemaps/functions.php
+++ b/tests/phpunit/tests/sitemaps/functions.php
@@ -96,7 +96,7 @@ class Tests_Sitemaps_Functions extends WP_UnitTestCase {
 	 *     @type string|false $4 Sitemap URL.
 	 * }
 	 */
-	function plain_permalinks_provider() {
+	public function plain_permalinks_provider() {
 		return array(
 			array( 'posts', 'post', 1, home_url( '/?sitemap=posts&sitemap-subtype=post&paged=1' ) ),
 			array( 'posts', 'post', 0, home_url( '/?sitemap=posts&sitemap-subtype=post&paged=1' ) ),
@@ -128,7 +128,7 @@ class Tests_Sitemaps_Functions extends WP_UnitTestCase {
 	 *     @type string|false $4 Sitemap URL.
 	 * }
 	 */
-	function pretty_permalinks_provider() {
+	public function pretty_permalinks_provider() {
 		return array(
 			array( 'posts', 'post', 1, home_url( '/wp-sitemap-posts-post-1.xml' ) ),
 			array( 'posts', 'post', 0, home_url( '/wp-sitemap-posts-post-1.xml' ) ),


### PR DESCRIPTION
Coding Standards: Add visibility to methods in `tests/phpunit/tests/` P-Q-R-S files.

"Visibility should always be declared"
See: https://make.wordpress.org/core/2020/03/20/updating-the-coding-standards-for-modern-php/

This commit applies the following sniffs to files in `tests/phpunit/tests` P-Q-R-S directories:
- Squiz.Scope.MethodScope
- PSR2.Methods.MethodDeclaration
- PSR2.Classes.PropertyDeclaration
- Squiz.WhiteSpace.ScopeKeywordSpacing

For most methods, these now indicate `public` visibility to avoid breaking backwards compatibility.
Any remaining methods now indicate `private` visibility where appropriate.

Additional fixups in this PR:
1. Methods touched by this PR have had unnecessary underscores removed from their names.

Trac ticket: https://core.trac.wordpress.org/ticket/54177