### PR TITLE
Update `copy_dir()` to initially try `rename()` instead of file copy

### DIFF
--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1870,6 +1870,7 @@ function copy_dir( $from, $to, $skip_list = array() ) {
 		return true;
 	}
 
+	$wp_filesystem->mkdir( $to );
 	$dirlist = $wp_filesystem->dirlist( $from );
 
 	if ( false === $dirlist ) {

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1865,6 +1865,11 @@ function _unzip_file_pclzip( $file, $to, $needed_dirs = array() ) {
 function copy_dir( $from, $to, $skip_list = array() ) {
 	global $wp_filesystem;
 
+	$wp_filesystem->rmdir( $to );
+	if ( rename( $from, $to ) ) {
+		return true;
+	}
+
 	$dirlist = $wp_filesystem->dirlist( $from );
 
 	if ( false === $dirlist ) {


### PR DESCRIPTION
<!-- Insert a description of your changes here -->
Updates `copy_dir()` to try a `rename()` before attempting to copy file by file. On large plugins with many files a file copy will result in a timeout on a slow system. The patch should revert to a file copy if the `rename()` fails.

I was able to timeout the installation of WooCommerce, Yoast SEO, and MailPoet on the Docker WP test env. With this patch each plugin installs fine.

Trac ticket: https://core.trac.wordpress.org/ticket/51857

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
