### PR TITLE
Create move_dir() and use rename first

### DIFF
--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -623,8 +623,8 @@ class WP_Upgrader {
 			}
 		}
 
-		// Copy new version of item into place.
-		$result = copy_dir( $source, $remote_destination );
+		// Move new version of item into place.
+		$result = move_dir( $source, $remote_destination );
 		if ( is_wp_error( $result ) ) {
 			if ( $args['clear_working'] ) {
 				$wp_filesystem->delete( $remote_source, true );

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1918,6 +1918,34 @@ function copy_dir( $from, $to, $skip_list = array() ) {
 }
 
 /**
+ * Moves a directory from one location to another via rename().
+ * Fallback to copy_dir().
+ *
+ * Assumes that WP_Filesystem() has already been called and setup.
+ *
+ * @since 5.9.0
+ *
+ * @global WP_Filesystem_Base $wp_filesystem WordPress filesystem subclass.
+ *
+ * @param string   $from      Source directory.
+ * @param string   $to        Destination directory.
+ * @return true|WP_Error True on success, WP_Error on failure.
+ */
+function move_dir( $from, $to ) {
+	global $wp_filesystem;
+
+	$wp_filesystem->rmdir( $to );
+	if ( @rename( $from, $to ) ) {
+		return true;
+	}
+
+	$wp_filesystem->mkdir( $to );
+	$result = copy_dir( $from, $to );
+
+	return $result;
+}
+
+/**
  * Initializes and connects the WordPress Filesystem Abstraction classes.
  *
  * This function will include the chosen transport and attempt connecting.


### PR DESCRIPTION

<!-- Insert a description of your changes here -->
Add a `move_dir()` function for use in WP_Upgrader instead of `copy_dir()`. There seem to be timeout issues in slower systems like Vagrant or the WP Docker test env with installation or update of large plugins like WooCommerce, Yoast SEO, or MailPoet.

This new function attempts a `rename()` and falls back to the previous `copy_dir()`.

Trac ticket: https://core.trac.wordpress.org/ticket/54166

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
