### PR TITLE
jQuery UI: Update to 1.13.0

### DIFF
--- a/src/js/_enqueues/vendor/jquery/ui/accordion.js
+++ b/src/js/_enqueues/vendor/jquery/ui/accordion.js
@@ -1,5 +1,5 @@
 /*!
- * jQuery UI Accordion 1.13.0-rc.2
+ * jQuery UI Accordion 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors
@@ -37,7 +37,7 @@
 "use strict";
 
 return $.widget( "ui.accordion", {
-	version: "1.13.0-rc.2",
+	version: "1.13.0",
 	options: {
 		active: 0,
 		animate: {},

--- a/src/js/_enqueues/vendor/jquery/ui/autocomplete.js
+++ b/src/js/_enqueues/vendor/jquery/ui/autocomplete.js
@@ -1,5 +1,5 @@
 /*!
- * jQuery UI Autocomplete 1.13.0-rc.2
+ * jQuery UI Autocomplete 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors
@@ -36,7 +36,7 @@
 "use strict";
 
 $.widget( "ui.autocomplete", {
-	version: "1.13.0-rc.2",
+	version: "1.13.0",
 	defaultElement: "<input>",
 	options: {
 		appendTo: null,

--- a/src/js/_enqueues/vendor/jquery/ui/button.js
+++ b/src/js/_enqueues/vendor/jquery/ui/button.js
@@ -1,5 +1,5 @@
 /*!
- * jQuery UI Button 1.13.0-rc.2
+ * jQuery UI Button 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors
@@ -41,7 +41,7 @@
 "use strict";
 
 $.widget( "ui.button", {
-	version: "1.13.0-rc.2",
+	version: "1.13.0",
 	defaultElement: "<button>",
 	options: {
 		classes: {

--- a/src/js/_enqueues/vendor/jquery/ui/checkboxradio.js
+++ b/src/js/_enqueues/vendor/jquery/ui/checkboxradio.js
@@ -1,5 +1,5 @@
 /*!
- * jQuery UI Checkboxradio 1.13.0-rc.2
+ * jQuery UI Checkboxradio 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors
@@ -36,7 +36,7 @@
 "use strict";
 
 $.widget( "ui.checkboxradio", [ $.ui.formResetMixin, {
-	version: "1.13.0-rc.2",
+	version: "1.13.0",
 	options: {
 		disabled: null,
 		label: null,

--- a/src/js/_enqueues/vendor/jquery/ui/controlgroup.js
+++ b/src/js/_enqueues/vendor/jquery/ui/controlgroup.js
@@ -1,5 +1,5 @@
 /*!
- * jQuery UI Controlgroup 1.13.0-rc.2
+ * jQuery UI Controlgroup 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors
@@ -37,7 +37,7 @@
 var controlgroupCornerRegex = /ui-corner-([a-z]){2,6}/g;
 
 return $.widget( "ui.controlgroup", {
-	version: "1.13.0-rc.2",
+	version: "1.13.0",
 	defaultElement: "<div>",
 	options: {
 		direction: "horizontal",

--- a/src/js/_enqueues/vendor/jquery/ui/core.js
+++ b/src/js/_enqueues/vendor/jquery/ui/core.js
@@ -1,4 +1,4 @@
-/*! jQuery UI - v1.13.0-rc.2 - 2021-09-05
+/*! jQuery UI - v1.13.0 - 2021-10-07
 * http://jqueryui.com
 * Includes: data.js, disable-selection.js, escape-selector.js, focusable.js, form-reset-mixin.js, form.js, ie.js, jquery-1-7.js, keycode.js, labels.js, plugin.js, position.js, safe-active-element.js, safe-blur.js, scroll-parent.js, tabbable.js, unique-id.js, version.js, widget.js
 * Copyright jQuery Foundation and other contributors; Licensed  */
@@ -20,11 +20,11 @@
 // Source: version.js
 $.ui = $.ui || {};
 
-$.ui.version = "1.13.0-rc.2";
+$.ui.version = "1.13.0";
 
 // Source: data.js
 /*!
- * jQuery UI :data 1.13.0-rc.2
+ * jQuery UI :data 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors
@@ -53,7 +53,7 @@ $.extend( $.expr.pseudos, {
 
 // Source: disable-selection.js
 /*!
- * jQuery UI Disable Selection 1.13.0-rc.2
+ * jQuery UI Disable Selection 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors
@@ -87,7 +87,7 @@ $.fn.extend( {
 
 // Source: focusable.js
 /*!
- * jQuery UI Focusable 1.13.0-rc.2
+ * jQuery UI Focusable 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors
@@ -165,7 +165,7 @@ $.fn._form = function() {
 
 // Source: form-reset-mixin.js
 /*!
- * jQuery UI Form Reset Mixin 1.13.0-rc.2
+ * jQuery UI Form Reset Mixin 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors
@@ -230,7 +230,7 @@ $.ui.ie = !!/msie [\w.]+/.exec( navigator.userAgent.toLowerCase() );
 
 // Source: jquery-patch.js
 /*!
- * jQuery UI Support for jQuery core 1.8.x and newer 1.13.0-rc.2
+ * jQuery UI Support for jQuery core 1.8.x and newer 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors
@@ -304,7 +304,7 @@ if ( !$.fn.even || !$.fn.odd ) {
 
 // Source: keycode.js
 /*!
- * jQuery UI Keycode 1.13.0-rc.2
+ * jQuery UI Keycode 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors
@@ -338,7 +338,7 @@ $.ui.keyCode = {
 
 // Source: labels.js
 /*!
- * jQuery UI Labels 1.13.0-rc.2
+ * jQuery UI Labels 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors
@@ -424,7 +424,7 @@ $.ui.plugin = {
 
 // Source: position.js
 /*!
- * jQuery UI Position 1.13.0-rc.2
+ * jQuery UI Position 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors
@@ -957,7 +957,7 @@ $.ui.safeBlur = function( element ) {
 
 // Source: scroll-parent.js
 /*!
- * jQuery UI Scroll Parent 1.13.0-rc.2
+ * jQuery UI Scroll Parent 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors
@@ -990,7 +990,7 @@ $.fn.scrollParent = function( includeHidden ) {
 
 // Source: tabbable.js
 /*!
- * jQuery UI Tabbable 1.13.0-rc.2
+ * jQuery UI Tabbable 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors
@@ -1013,7 +1013,7 @@ $.extend( $.expr.pseudos, {
 
 // Source: unique-id.js
 /*!
- * jQuery UI Unique ID 1.13.0-rc.2
+ * jQuery UI Unique ID 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors
@@ -1050,7 +1050,7 @@ $.fn.extend( {
 
 // Source: widget.js
 /*!
- * jQuery UI Widget 1.13.0-rc.2
+ * jQuery UI Widget 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors

--- a/src/js/_enqueues/vendor/jquery/ui/datepicker.js
+++ b/src/js/_enqueues/vendor/jquery/ui/datepicker.js
@@ -1,6 +1,6 @@
 /* eslint-disable max-len, camelcase */
 /*!
- * jQuery UI Datepicker 1.13.0-rc.2
+ * jQuery UI Datepicker 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors
@@ -35,7 +35,7 @@
 } )( function( $ ) {
 "use strict";
 
-$.extend( $.ui, { datepicker: { version: "1.13.0-rc.2" } } );
+$.extend( $.ui, { datepicker: { version: "1.13.0" } } );
 
 var datepicker_instActive;
 
@@ -2232,7 +2232,7 @@ $.fn.datepicker = function( options ) {
 $.datepicker = new Datepicker(); // singleton instance
 $.datepicker.initialized = false;
 $.datepicker.uuid = new Date().getTime();
-$.datepicker.version = "1.13.0-rc.2";
+$.datepicker.version = "1.13.0";
 
 return $.datepicker;
 

--- a/src/js/_enqueues/vendor/jquery/ui/dialog.js
+++ b/src/js/_enqueues/vendor/jquery/ui/dialog.js
@@ -1,5 +1,5 @@
 /*!
- * jQuery UI Dialog 1.13.0-rc.2
+ * jQuery UI Dialog 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors
@@ -39,7 +39,7 @@
 "use strict";
 
 $.widget( "ui.dialog", {
-	version: "1.13.0-rc.2",
+	version: "1.13.0",
 	options: {
 		appendTo: "body",
 		autoOpen: true,

--- a/src/js/_enqueues/vendor/jquery/ui/draggable.js
+++ b/src/js/_enqueues/vendor/jquery/ui/draggable.js
@@ -1,5 +1,5 @@
 /*!
- * jQuery UI Draggable 1.13.0-rc.2
+ * jQuery UI Draggable 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors
@@ -34,7 +34,7 @@
 "use strict";
 
 $.widget( "ui.draggable", $.ui.mouse, {
-	version: "1.13.0-rc.2",
+	version: "1.13.0",
 	widgetEventPrefix: "drag",
 	options: {
 		addClasses: true,

--- a/src/js/_enqueues/vendor/jquery/ui/droppable.js
+++ b/src/js/_enqueues/vendor/jquery/ui/droppable.js
@@ -1,5 +1,5 @@
 /*!
- * jQuery UI Droppable 1.13.0-rc.2
+ * jQuery UI Droppable 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors
@@ -34,7 +34,7 @@
 "use strict";
 
 $.widget( "ui.droppable", {
-	version: "1.13.0-rc.2",
+	version: "1.13.0",
 	widgetEventPrefix: "drop",
 	options: {
 		accept: "*",

--- a/src/js/_enqueues/vendor/jquery/ui/effect-blind.js
+++ b/src/js/_enqueues/vendor/jquery/ui/effect-blind.js
@@ -1,5 +1,5 @@
 /*!
- * jQuery UI Effects Blind 1.13.0-rc.2
+ * jQuery UI Effects Blind 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors

--- a/src/js/_enqueues/vendor/jquery/ui/effect-bounce.js
+++ b/src/js/_enqueues/vendor/jquery/ui/effect-bounce.js
@@ -1,5 +1,5 @@
 /*!
- * jQuery UI Effects Bounce 1.13.0-rc.2
+ * jQuery UI Effects Bounce 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors

--- a/src/js/_enqueues/vendor/jquery/ui/effect-clip.js
+++ b/src/js/_enqueues/vendor/jquery/ui/effect-clip.js
@@ -1,5 +1,5 @@
 /*!
- * jQuery UI Effects Clip 1.13.0-rc.2
+ * jQuery UI Effects Clip 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors

--- a/src/js/_enqueues/vendor/jquery/ui/effect-drop.js
+++ b/src/js/_enqueues/vendor/jquery/ui/effect-drop.js
@@ -1,5 +1,5 @@
 /*!
- * jQuery UI Effects Drop 1.13.0-rc.2
+ * jQuery UI Effects Drop 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors

--- a/src/js/_enqueues/vendor/jquery/ui/effect-explode.js
+++ b/src/js/_enqueues/vendor/jquery/ui/effect-explode.js
@@ -1,5 +1,5 @@
 /*!
- * jQuery UI Effects Explode 1.13.0-rc.2
+ * jQuery UI Effects Explode 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors

--- a/src/js/_enqueues/vendor/jquery/ui/effect-fade.js
+++ b/src/js/_enqueues/vendor/jquery/ui/effect-fade.js
@@ -1,5 +1,5 @@
 /*!
- * jQuery UI Effects Fade 1.13.0-rc.2
+ * jQuery UI Effects Fade 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors

--- a/src/js/_enqueues/vendor/jquery/ui/effect-fold.js
+++ b/src/js/_enqueues/vendor/jquery/ui/effect-fold.js
@@ -1,5 +1,5 @@
 /*!
- * jQuery UI Effects Fold 1.13.0-rc.2
+ * jQuery UI Effects Fold 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors

--- a/src/js/_enqueues/vendor/jquery/ui/effect-highlight.js
+++ b/src/js/_enqueues/vendor/jquery/ui/effect-highlight.js
@@ -1,5 +1,5 @@
 /*!
- * jQuery UI Effects Highlight 1.13.0-rc.2
+ * jQuery UI Effects Highlight 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors

--- a/src/js/_enqueues/vendor/jquery/ui/effect-puff.js
+++ b/src/js/_enqueues/vendor/jquery/ui/effect-puff.js
@@ -1,5 +1,5 @@
 /*!
- * jQuery UI Effects Puff 1.13.0-rc.2
+ * jQuery UI Effects Puff 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors

--- a/src/js/_enqueues/vendor/jquery/ui/effect-pulsate.js
+++ b/src/js/_enqueues/vendor/jquery/ui/effect-pulsate.js
@@ -1,5 +1,5 @@
 /*!
- * jQuery UI Effects Pulsate 1.13.0-rc.2
+ * jQuery UI Effects Pulsate 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors

--- a/src/js/_enqueues/vendor/jquery/ui/effect-scale.js
+++ b/src/js/_enqueues/vendor/jquery/ui/effect-scale.js
@@ -1,5 +1,5 @@
 /*!
- * jQuery UI Effects Scale 1.13.0-rc.2
+ * jQuery UI Effects Scale 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors

--- a/src/js/_enqueues/vendor/jquery/ui/effect-shake.js
+++ b/src/js/_enqueues/vendor/jquery/ui/effect-shake.js
@@ -1,5 +1,5 @@
 /*!
- * jQuery UI Effects Shake 1.13.0-rc.2
+ * jQuery UI Effects Shake 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors

--- a/src/js/_enqueues/vendor/jquery/ui/effect-size.js
+++ b/src/js/_enqueues/vendor/jquery/ui/effect-size.js
@@ -1,5 +1,5 @@
 /*!
- * jQuery UI Effects Size 1.13.0-rc.2
+ * jQuery UI Effects Size 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors

--- a/src/js/_enqueues/vendor/jquery/ui/effect-slide.js
+++ b/src/js/_enqueues/vendor/jquery/ui/effect-slide.js
@@ -1,5 +1,5 @@
 /*!
- * jQuery UI Effects Slide 1.13.0-rc.2
+ * jQuery UI Effects Slide 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors

--- a/src/js/_enqueues/vendor/jquery/ui/effect-transfer.js
+++ b/src/js/_enqueues/vendor/jquery/ui/effect-transfer.js
@@ -1,5 +1,5 @@
 /*!
- * jQuery UI Effects Transfer 1.13.0-rc.2
+ * jQuery UI Effects Transfer 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors

--- a/src/js/_enqueues/vendor/jquery/ui/effect.js
+++ b/src/js/_enqueues/vendor/jquery/ui/effect.js
@@ -1,5 +1,5 @@
 /*!
- * jQuery UI Effects 1.13.0-rc.2
+ * jQuery UI Effects 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors
@@ -32,7 +32,7 @@
 
 // Include version.js
 $.ui = $.ui || {};
-$.ui.version = "1.13.0-rc.2";
+$.ui.version = "1.13.0";
 
 // Source: jquery-var-for-color.js
 // Create a local jQuery because jQuery Color relies on it and the
@@ -1119,7 +1119,7 @@ if ( $.uiBackCompat !== false ) {
 }
 
 $.extend( $.effects, {
-	version: "1.13.0-rc.2",
+	version: "1.13.0",
 
 	define: function( name, mode, effect ) {
 		if ( !effect ) {

--- a/src/js/_enqueues/vendor/jquery/ui/menu.js
+++ b/src/js/_enqueues/vendor/jquery/ui/menu.js
@@ -1,5 +1,5 @@
 /*!
- * jQuery UI Menu 1.13.0-rc.2
+ * jQuery UI Menu 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors
@@ -35,7 +35,7 @@
 "use strict";
 
 return $.widget( "ui.menu", {
-	version: "1.13.0-rc.2",
+	version: "1.13.0",
 	defaultElement: "<ul>",
 	delay: 300,
 	options: {

--- a/src/js/_enqueues/vendor/jquery/ui/mouse.js
+++ b/src/js/_enqueues/vendor/jquery/ui/mouse.js
@@ -1,5 +1,5 @@
 /*!
- * jQuery UI Mouse 1.13.0-rc.2
+ * jQuery UI Mouse 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors
@@ -36,7 +36,7 @@ $( document ).on( "mouseup", function() {
 } );
 
 return $.widget( "ui.mouse", {
-	version: "1.13.0-rc.2",
+	version: "1.13.0",
 	options: {
 		cancel: "input, textarea, button, select, option",
 		distance: 1,

--- a/src/js/_enqueues/vendor/jquery/ui/progressbar.js
+++ b/src/js/_enqueues/vendor/jquery/ui/progressbar.js
@@ -1,5 +1,5 @@
 /*!
- * jQuery UI Progressbar 1.13.0-rc.2
+ * jQuery UI Progressbar 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors
@@ -37,7 +37,7 @@
 "use strict";
 
 return $.widget( "ui.progressbar", {
-	version: "1.13.0-rc.2",
+	version: "1.13.0",
 	options: {
 		classes: {
 			"ui-progressbar": "ui-corner-all",

--- a/src/js/_enqueues/vendor/jquery/ui/resizable.js
+++ b/src/js/_enqueues/vendor/jquery/ui/resizable.js
@@ -1,5 +1,5 @@
 /*!
- * jQuery UI Resizable 1.13.0-rc.2
+ * jQuery UI Resizable 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors
@@ -36,7 +36,7 @@
 "use strict";
 
 $.widget( "ui.resizable", $.ui.mouse, {
-	version: "1.13.0-rc.2",
+	version: "1.13.0",
 	widgetEventPrefix: "resize",
 	options: {
 		alsoResize: false,

--- a/src/js/_enqueues/vendor/jquery/ui/selectable.js
+++ b/src/js/_enqueues/vendor/jquery/ui/selectable.js
@@ -1,5 +1,5 @@
 /*!
- * jQuery UI Selectable 1.13.0-rc.2
+ * jQuery UI Selectable 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors
@@ -34,7 +34,7 @@
 "use strict";
 
 return $.widget( "ui.selectable", $.ui.mouse, {
-	version: "1.13.0-rc.2",
+	version: "1.13.0",
 	options: {
 		appendTo: "body",
 		autoRefresh: true,

--- a/src/js/_enqueues/vendor/jquery/ui/selectmenu.js
+++ b/src/js/_enqueues/vendor/jquery/ui/selectmenu.js
@@ -1,5 +1,5 @@
 /*!
- * jQuery UI Selectmenu 1.13.0-rc.2
+ * jQuery UI Selectmenu 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors
@@ -38,7 +38,7 @@
 "use strict";
 
 return $.widget( "ui.selectmenu", [ $.ui.formResetMixin, {
-	version: "1.13.0-rc.2",
+	version: "1.13.0",
 	defaultElement: "<select>",
 	options: {
 		appendTo: null,

--- a/src/js/_enqueues/vendor/jquery/ui/slider.js
+++ b/src/js/_enqueues/vendor/jquery/ui/slider.js
@@ -1,5 +1,5 @@
 /*!
- * jQuery UI Slider 1.13.0-rc.2
+ * jQuery UI Slider 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors
@@ -36,7 +36,7 @@
 "use strict";
 
 return $.widget( "ui.slider", $.ui.mouse, {
-	version: "1.13.0-rc.2",
+	version: "1.13.0",
 	widgetEventPrefix: "slide",
 
 	options: {

--- a/src/js/_enqueues/vendor/jquery/ui/sortable.js
+++ b/src/js/_enqueues/vendor/jquery/ui/sortable.js
@@ -1,5 +1,5 @@
 /*!
- * jQuery UI Sortable 1.13.0-rc.2
+ * jQuery UI Sortable 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors
@@ -34,7 +34,7 @@
 "use strict";
 
 return $.widget( "ui.sortable", $.ui.mouse, {
-	version: "1.13.0-rc.2",
+	version: "1.13.0",
 	widgetEventPrefix: "sort",
 	ready: false,
 	options: {

--- a/src/js/_enqueues/vendor/jquery/ui/spinner.js
+++ b/src/js/_enqueues/vendor/jquery/ui/spinner.js
@@ -1,5 +1,5 @@
 /*!
- * jQuery UI Spinner 1.13.0-rc.2
+ * jQuery UI Spinner 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors
@@ -47,7 +47,7 @@ function spinnerModifier( fn ) {
 }
 
 $.widget( "ui.spinner", {
-	version: "1.13.0-rc.2",
+	version: "1.13.0",
 	defaultElement: "<input>",
 	widgetEventPrefix: "spin",
 	options: {

--- a/src/js/_enqueues/vendor/jquery/ui/tabs.js
+++ b/src/js/_enqueues/vendor/jquery/ui/tabs.js
@@ -1,5 +1,5 @@
 /*!
- * jQuery UI Tabs 1.13.0-rc.2
+ * jQuery UI Tabs 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors
@@ -35,7 +35,7 @@
 "use strict";
 
 $.widget( "ui.tabs", {
-	version: "1.13.0-rc.2",
+	version: "1.13.0",
 	delay: 300,
 	options: {
 		active: null,

--- a/src/js/_enqueues/vendor/jquery/ui/tooltip.js
+++ b/src/js/_enqueues/vendor/jquery/ui/tooltip.js
@@ -1,5 +1,5 @@
 /*!
- * jQuery UI Tooltip 1.13.0-rc.2
+ * jQuery UI Tooltip 1.13.0
  * http://jqueryui.com
  *
  * Copyright jQuery Foundation and other contributors
@@ -35,7 +35,7 @@
 "use strict";
 
 $.widget( "ui.tooltip", {
-	version: "1.13.0-rc.2",
+	version: "1.13.0",
 	options: {
 		classes: {
 			"ui-tooltip": "ui-corner-all ui-widget-shadow"

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -756,55 +756,55 @@ function wp_default_scripts( $scripts ) {
 	// In order to keep backwards compatibility, and to keep the optimized loading,
 	// the source files were flattened and included with some modifications for AMD loading.
 	// A notable change is that 'jquery-ui-core' now contains 'jquery-ui-position' and 'jquery-ui-widget'.
-	$scripts->add( 'jquery-ui-core', "/wp-includes/js/jquery/ui/core$suffix.js", array( 'jquery' ), '1.13.0-rc.2', 1 );
-	$scripts->add( 'jquery-effects-core', "/wp-includes/js/jquery/ui/effect$suffix.js", array( 'jquery' ), '1.13.0-rc.2', 1 );
+	$scripts->add( 'jquery-ui-core', "/wp-includes/js/jquery/ui/core$suffix.js", array( 'jquery' ), '1.13.0', 1 );
+	$scripts->add( 'jquery-effects-core', "/wp-includes/js/jquery/ui/effect$suffix.js", array( 'jquery' ), '1.13.0', 1 );
 
-	$scripts->add( 'jquery-effects-blind', "/wp-includes/js/jquery/ui/effect-blind$suffix.js", array( 'jquery-effects-core' ), '1.13.0-rc.2', 1 );
-	$scripts->add( 'jquery-effects-bounce', "/wp-includes/js/jquery/ui/effect-bounce$suffix.js", array( 'jquery-effects-core' ), '1.13.0-rc.2', 1 );
-	$scripts->add( 'jquery-effects-clip', "/wp-includes/js/jquery/ui/effect-clip$suffix.js", array( 'jquery-effects-core' ), '1.13.0-rc.2', 1 );
-	$scripts->add( 'jquery-effects-drop', "/wp-includes/js/jquery/ui/effect-drop$suffix.js", array( 'jquery-effects-core' ), '1.13.0-rc.2', 1 );
-	$scripts->add( 'jquery-effects-explode', "/wp-includes/js/jquery/ui/effect-explode$suffix.js", array( 'jquery-effects-core' ), '1.13.0-rc.2', 1 );
-	$scripts->add( 'jquery-effects-fade', "/wp-includes/js/jquery/ui/effect-fade$suffix.js", array( 'jquery-effects-core' ), '1.13.0-rc.2', 1 );
-	$scripts->add( 'jquery-effects-fold', "/wp-includes/js/jquery/ui/effect-fold$suffix.js", array( 'jquery-effects-core' ), '1.13.0-rc.2', 1 );
-	$scripts->add( 'jquery-effects-highlight', "/wp-includes/js/jquery/ui/effect-highlight$suffix.js", array( 'jquery-effects-core' ), '1.13.0-rc.2', 1 );
-	$scripts->add( 'jquery-effects-puff', "/wp-includes/js/jquery/ui/effect-puff$suffix.js", array( 'jquery-effects-core', 'jquery-effects-scale' ), '1.13.0-rc.2', 1 );
-	$scripts->add( 'jquery-effects-pulsate', "/wp-includes/js/jquery/ui/effect-pulsate$suffix.js", array( 'jquery-effects-core' ), '1.13.0-rc.2', 1 );
-	$scripts->add( 'jquery-effects-scale', "/wp-includes/js/jquery/ui/effect-scale$suffix.js", array( 'jquery-effects-core', 'jquery-effects-size' ), '1.13.0-rc.2', 1 );
-	$scripts->add( 'jquery-effects-shake', "/wp-includes/js/jquery/ui/effect-shake$suffix.js", array( 'jquery-effects-core' ), '1.13.0-rc.2', 1 );
-	$scripts->add( 'jquery-effects-size', "/wp-includes/js/jquery/ui/effect-size$suffix.js", array( 'jquery-effects-core' ), '1.13.0-rc.2', 1 );
-	$scripts->add( 'jquery-effects-slide', "/wp-includes/js/jquery/ui/effect-slide$suffix.js", array( 'jquery-effects-core' ), '1.13.0-rc.2', 1 );
-	$scripts->add( 'jquery-effects-transfer', "/wp-includes/js/jquery/ui/effect-transfer$suffix.js", array( 'jquery-effects-core' ), '1.13.0-rc.2', 1 );
+	$scripts->add( 'jquery-effects-blind', "/wp-includes/js/jquery/ui/effect-blind$suffix.js", array( 'jquery-effects-core' ), '1.13.0', 1 );
+	$scripts->add( 'jquery-effects-bounce', "/wp-includes/js/jquery/ui/effect-bounce$suffix.js", array( 'jquery-effects-core' ), '1.13.0', 1 );
+	$scripts->add( 'jquery-effects-clip', "/wp-includes/js/jquery/ui/effect-clip$suffix.js", array( 'jquery-effects-core' ), '1.13.0', 1 );
+	$scripts->add( 'jquery-effects-drop', "/wp-includes/js/jquery/ui/effect-drop$suffix.js", array( 'jquery-effects-core' ), '1.13.0', 1 );
+	$scripts->add( 'jquery-effects-explode', "/wp-includes/js/jquery/ui/effect-explode$suffix.js", array( 'jquery-effects-core' ), '1.13.0', 1 );
+	$scripts->add( 'jquery-effects-fade', "/wp-includes/js/jquery/ui/effect-fade$suffix.js", array( 'jquery-effects-core' ), '1.13.0', 1 );
+	$scripts->add( 'jquery-effects-fold', "/wp-includes/js/jquery/ui/effect-fold$suffix.js", array( 'jquery-effects-core' ), '1.13.0', 1 );
+	$scripts->add( 'jquery-effects-highlight', "/wp-includes/js/jquery/ui/effect-highlight$suffix.js", array( 'jquery-effects-core' ), '1.13.0', 1 );
+	$scripts->add( 'jquery-effects-puff', "/wp-includes/js/jquery/ui/effect-puff$suffix.js", array( 'jquery-effects-core', 'jquery-effects-scale' ), '1.13.0', 1 );
+	$scripts->add( 'jquery-effects-pulsate', "/wp-includes/js/jquery/ui/effect-pulsate$suffix.js", array( 'jquery-effects-core' ), '1.13.0', 1 );
+	$scripts->add( 'jquery-effects-scale', "/wp-includes/js/jquery/ui/effect-scale$suffix.js", array( 'jquery-effects-core', 'jquery-effects-size' ), '1.13.0', 1 );
+	$scripts->add( 'jquery-effects-shake', "/wp-includes/js/jquery/ui/effect-shake$suffix.js", array( 'jquery-effects-core' ), '1.13.0', 1 );
+	$scripts->add( 'jquery-effects-size', "/wp-includes/js/jquery/ui/effect-size$suffix.js", array( 'jquery-effects-core' ), '1.13.0', 1 );
+	$scripts->add( 'jquery-effects-slide', "/wp-includes/js/jquery/ui/effect-slide$suffix.js", array( 'jquery-effects-core' ), '1.13.0', 1 );
+	$scripts->add( 'jquery-effects-transfer', "/wp-includes/js/jquery/ui/effect-transfer$suffix.js", array( 'jquery-effects-core' ), '1.13.0', 1 );
 
 	// Widgets
-	$scripts->add( 'jquery-ui-accordion', "/wp-includes/js/jquery/ui/accordion$suffix.js", array( 'jquery-ui-core' ), '1.13.0-rc.2', 1 );
-	$scripts->add( 'jquery-ui-autocomplete', "/wp-includes/js/jquery/ui/autocomplete$suffix.js", array( 'jquery-ui-menu', 'wp-a11y' ), '1.13.0-rc.2', 1 );
-	$scripts->add( 'jquery-ui-button', "/wp-includes/js/jquery/ui/button$suffix.js", array( 'jquery-ui-core', 'jquery-ui-controlgroup', 'jquery-ui-checkboxradio' ), '1.13.0-rc.2', 1 );
-	$scripts->add( 'jquery-ui-datepicker', "/wp-includes/js/jquery/ui/datepicker$suffix.js", array( 'jquery-ui-core' ), '1.13.0-rc.2', 1 );
-	$scripts->add( 'jquery-ui-dialog', "/wp-includes/js/jquery/ui/dialog$suffix.js", array( 'jquery-ui-resizable', 'jquery-ui-draggable', 'jquery-ui-button' ), '1.13.0-rc.2', 1 );
-	$scripts->add( 'jquery-ui-menu', "/wp-includes/js/jquery/ui/menu$suffix.js", array( 'jquery-ui-core' ), '1.13.0-rc.2', 1 );
-	$scripts->add( 'jquery-ui-mouse', "/wp-includes/js/jquery/ui/mouse$suffix.js", array( 'jquery-ui-core' ), '1.13.0-rc.2', 1 );
-	$scripts->add( 'jquery-ui-progressbar', "/wp-includes/js/jquery/ui/progressbar$suffix.js", array( 'jquery-ui-core' ), '1.13.0-rc.2', 1 );
-	$scripts->add( 'jquery-ui-selectmenu', "/wp-includes/js/jquery/ui/selectmenu$suffix.js", array( 'jquery-ui-menu' ), '1.13.0-rc.2', 1 );
-	$scripts->add( 'jquery-ui-slider', "/wp-includes/js/jquery/ui/slider$suffix.js", array( 'jquery-ui-mouse' ), '1.13.0-rc.2', 1 );
-	$scripts->add( 'jquery-ui-spinner', "/wp-includes/js/jquery/ui/spinner$suffix.js", array( 'jquery-ui-button' ), '1.13.0-rc.2', 1 );
-	$scripts->add( 'jquery-ui-tabs', "/wp-includes/js/jquery/ui/tabs$suffix.js", array( 'jquery-ui-core' ), '1.13.0-rc.2', 1 );
-	$scripts->add( 'jquery-ui-tooltip', "/wp-includes/js/jquery/ui/tooltip$suffix.js", array( 'jquery-ui-core' ), '1.13.0-rc.2', 1 );
+	$scripts->add( 'jquery-ui-accordion', "/wp-includes/js/jquery/ui/accordion$suffix.js", array( 'jquery-ui-core' ), '1.13.0', 1 );
+	$scripts->add( 'jquery-ui-autocomplete', "/wp-includes/js/jquery/ui/autocomplete$suffix.js", array( 'jquery-ui-menu', 'wp-a11y' ), '1.13.0', 1 );
+	$scripts->add( 'jquery-ui-button', "/wp-includes/js/jquery/ui/button$suffix.js", array( 'jquery-ui-core', 'jquery-ui-controlgroup', 'jquery-ui-checkboxradio' ), '1.13.0', 1 );
+	$scripts->add( 'jquery-ui-datepicker', "/wp-includes/js/jquery/ui/datepicker$suffix.js", array( 'jquery-ui-core' ), '1.13.0', 1 );
+	$scripts->add( 'jquery-ui-dialog', "/wp-includes/js/jquery/ui/dialog$suffix.js", array( 'jquery-ui-resizable', 'jquery-ui-draggable', 'jquery-ui-button' ), '1.13.0', 1 );
+	$scripts->add( 'jquery-ui-menu', "/wp-includes/js/jquery/ui/menu$suffix.js", array( 'jquery-ui-core' ), '1.13.0', 1 );
+	$scripts->add( 'jquery-ui-mouse', "/wp-includes/js/jquery/ui/mouse$suffix.js", array( 'jquery-ui-core' ), '1.13.0', 1 );
+	$scripts->add( 'jquery-ui-progressbar', "/wp-includes/js/jquery/ui/progressbar$suffix.js", array( 'jquery-ui-core' ), '1.13.0', 1 );
+	$scripts->add( 'jquery-ui-selectmenu', "/wp-includes/js/jquery/ui/selectmenu$suffix.js", array( 'jquery-ui-menu' ), '1.13.0', 1 );
+	$scripts->add( 'jquery-ui-slider', "/wp-includes/js/jquery/ui/slider$suffix.js", array( 'jquery-ui-mouse' ), '1.13.0', 1 );
+	$scripts->add( 'jquery-ui-spinner', "/wp-includes/js/jquery/ui/spinner$suffix.js", array( 'jquery-ui-button' ), '1.13.0', 1 );
+	$scripts->add( 'jquery-ui-tabs', "/wp-includes/js/jquery/ui/tabs$suffix.js", array( 'jquery-ui-core' ), '1.13.0', 1 );
+	$scripts->add( 'jquery-ui-tooltip', "/wp-includes/js/jquery/ui/tooltip$suffix.js", array( 'jquery-ui-core' ), '1.13.0', 1 );
 
 	// New in 1.12.1
-	$scripts->add( 'jquery-ui-checkboxradio', "/wp-includes/js/jquery/ui/checkboxradio$suffix.js", array( 'jquery-ui-core' ), '1.13.0-rc.2', 1 );
-	$scripts->add( 'jquery-ui-controlgroup', "/wp-includes/js/jquery/ui/controlgroup$suffix.js", array( 'jquery-ui-core' ), '1.13.0-rc.2', 1 );
+	$scripts->add( 'jquery-ui-checkboxradio', "/wp-includes/js/jquery/ui/checkboxradio$suffix.js", array( 'jquery-ui-core' ), '1.13.0', 1 );
+	$scripts->add( 'jquery-ui-controlgroup', "/wp-includes/js/jquery/ui/controlgroup$suffix.js", array( 'jquery-ui-core' ), '1.13.0', 1 );
 
 	// Interactions
-	$scripts->add( 'jquery-ui-draggable', "/wp-includes/js/jquery/ui/draggable$suffix.js", array( 'jquery-ui-mouse' ), '1.13.0-rc.2', 1 );
-	$scripts->add( 'jquery-ui-droppable', "/wp-includes/js/jquery/ui/droppable$suffix.js", array( 'jquery-ui-draggable' ), '1.13.0-rc.2', 1 );
-	$scripts->add( 'jquery-ui-resizable', "/wp-includes/js/jquery/ui/resizable$suffix.js", array( 'jquery-ui-mouse' ), '1.13.0-rc.2', 1 );
-	$scripts->add( 'jquery-ui-selectable', "/wp-includes/js/jquery/ui/selectable$suffix.js", array( 'jquery-ui-mouse' ), '1.13.0-rc.2', 1 );
-	$scripts->add( 'jquery-ui-sortable', "/wp-includes/js/jquery/ui/sortable$suffix.js", array( 'jquery-ui-mouse' ), '1.13.0-rc.2', 1 );
+	$scripts->add( 'jquery-ui-draggable', "/wp-includes/js/jquery/ui/draggable$suffix.js", array( 'jquery-ui-mouse' ), '1.13.0', 1 );
+	$scripts->add( 'jquery-ui-droppable', "/wp-includes/js/jquery/ui/droppable$suffix.js", array( 'jquery-ui-draggable' ), '1.13.0', 1 );
+	$scripts->add( 'jquery-ui-resizable', "/wp-includes/js/jquery/ui/resizable$suffix.js", array( 'jquery-ui-mouse' ), '1.13.0', 1 );
+	$scripts->add( 'jquery-ui-selectable', "/wp-includes/js/jquery/ui/selectable$suffix.js", array( 'jquery-ui-mouse' ), '1.13.0', 1 );
+	$scripts->add( 'jquery-ui-sortable', "/wp-includes/js/jquery/ui/sortable$suffix.js", array( 'jquery-ui-mouse' ), '1.13.0', 1 );
 
 	// As of 1.12.1 `jquery-ui-position` and `jquery-ui-widget` are part of `jquery-ui-core`.
 	// Listed here for back-compat.
-	$scripts->add( 'jquery-ui-position', false, array( 'jquery-ui-core' ), '1.13.0-rc.2', 1 );
-	$scripts->add( 'jquery-ui-widget', false, array( 'jquery-ui-core' ), '1.13.0-rc.2', 1 );
+	$scripts->add( 'jquery-ui-position', false, array( 'jquery-ui-core' ), '1.13.0', 1 );
+	$scripts->add( 'jquery-ui-widget', false, array( 'jquery-ui-core' ), '1.13.0', 1 );
 
 	// Strings for 'jquery-ui-autocomplete' live region messages.
 	did_action( 'init' ) && $scripts->localize(


### PR DESCRIPTION
Update jQuery UI to 1.13.0.

There are virtually no changes to the js since 1.13.0-rc.2 except the version strings.

Trac ticket: https://core.trac.wordpress.org/ticket/52163

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
