### PR TITLE
clean_dirsize_cache() + recurse_dirsize(): fix Windows infinite loop + fix PHP 8.1 deprecation (Trac 52241)

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -8120,8 +8120,9 @@ function get_dirsize( $directory, $max_execution_time = null ) {
  * @param string       $directory          Full path of a directory.
  * @param string|array $exclude            Optional. Full path of a subdirectory to exclude from the total,
  *                                         or array of paths. Expected without trailing slash(es).
- * @param int          $max_execution_time Maximum time to run before giving up. In seconds. The timeout is global
- *                                         and is measured from the moment WordPress started to load.
+ * @param int          $max_execution_time Optional. Maximum time to run before giving up. In seconds.
+ *                                         The timeout is global and is measured from the moment
+ *                                         WordPress started to load.
  * @param array        $directory_cache    Optional. Array of cached directory paths.
  *
  * @return int|false|null Size in bytes if a valid directory. False if not. Null if timeout.
@@ -8194,7 +8195,9 @@ function recurse_dirsize( $directory, $exclude = null, $max_execution_time = nul
 						}
 					}
 
-					if ( $max_execution_time > 0 && microtime( true ) - WP_START_TIMESTAMP > $max_execution_time ) {
+					if ( $max_execution_time > 0
+						&& ( microtime( true ) - WP_START_TIMESTAMP ) > $max_execution_time
+					) {
 						// Time exceeded. Give up instead of risking a fatal timeout.
 						$size = null;
 						break;
@@ -8203,6 +8206,10 @@ function recurse_dirsize( $directory, $exclude = null, $max_execution_time = nul
 			}
 			closedir( $handle );
 		}
+	}
+
+	if ( ! is_array( $directory_cache ) ) {
+		$directory_cache = array();
 	}
 
 	$directory_cache[ $directory ] = $size;

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -8221,21 +8221,50 @@ function recurse_dirsize( $directory, $exclude = null, $max_execution_time = nul
  * Removes the current directory and all parent directories from the `dirsize_cache` transient.
  *
  * @since 5.6.0
+ * @since 5.9.0 Added input validation with a doing it wrong for invalid input.
  *
  * @param string $path Full path of a directory or file.
  */
 function clean_dirsize_cache( $path ) {
+	if ( ! is_string( $path ) || empty( $path ) ) {
+		_doing_it_wrong(
+			__FUNCTION__,
+			sprintf(
+				/* translators: 1: Function name, 2: A variable type, like "boolean" or "integer". */
+				__( '%1$s only accepts a non-empty path string, received %2$s.' ),
+				'<code>clean_dirsize_cache()</code>',
+				'<code>' . gettype( $path ) . '</code>'
+			),
+			'5.9.0'
+		);
+		return;
+	}
+
 	$directory_cache = get_transient( 'dirsize_cache' );
 
 	if ( empty( $directory_cache ) ) {
 		return;
 	}
 
-	$path = untrailingslashit( $path );
+	if ( strpos( $path, '/' ) === false
+		&& strpos( $path, '\\' ) === false
+	) {
+		unset( $directory_cache[ $path ] );
+		set_transient( 'dirsize_cache', $directory_cache );
+		return;
+	}
+
+	$last_path = null;
+	$path      = untrailingslashit( $path );
 	unset( $directory_cache[ $path ] );
 
-	while ( DIRECTORY_SEPARATOR !== $path && '.' !== $path && '..' !== $path ) {
-		$path = dirname( $path );
+	while ( $last_path !== $path
+		&& DIRECTORY_SEPARATOR !== $path
+		&& '.' !== $path
+		&& '..' !== $path
+	) {
+		$last_path = $path;
+		$path      = dirname( $path );
 		unset( $directory_cache[ $path ] );
 	}
 

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -6162,7 +6162,7 @@ function wp_delete_attachment( $post_id, $force_delete = false ) {
 	$backup_sizes = get_post_meta( $post->ID, '_wp_attachment_backup_sizes', true );
 	$file         = get_attached_file( $post_id );
 
-	if ( is_multisite() ) {
+	if ( is_multisite() && is_string( $file ) && ! empty( $file ) ) {
 		clean_dirsize_cache( $file );
 	}
 

--- a/tests/phpunit/tests/functions/cleanDirsizeCache.php
+++ b/tests/phpunit/tests/functions/cleanDirsizeCache.php
@@ -87,4 +87,38 @@ class Tests_Functions_CleanDirsizeCache extends WP_UnitTestCase {
 			'string' => array( 'size' => 42 ),
 		);
 	}
+
+	/**
+	 * Test the behaviour of the function when the transient doesn't exist.
+	 *
+	 * @ticket 52241
+	 * @ticket 53635
+	 *
+	 * @covers ::recurse_dirsize
+	 */
+	public function test_recurse_dirsize_without_transient() {
+		delete_transient( 'dirsize_cache' );
+
+		$size = recurse_dirsize( __DIR__ . '/fixtures' );
+
+		$this->assertGreaterThan( 10, $size );
+	}
+
+	/**
+	 * Test the behaviour of the function when the transient does exist, but is not an array.
+	 *
+	 * In particular, this tests that no PHP TypeErrors are being thrown.
+	 *
+	 * @ticket 52241
+	 * @ticket 53635
+	 *
+	 * @covers ::recurse_dirsize
+	 */
+	public function test_recurse_dirsize_with_invalid_transient() {
+		set_transient( 'dirsize_cache', 'this is not a valid transient for dirsize cache' );
+
+		$size = recurse_dirsize( __DIR__ . '/fixtures' );
+
+		$this->assertGreaterThan( 10, $size );
+	}
 }

--- a/tests/phpunit/tests/functions/cleanDirsizeCache.php
+++ b/tests/phpunit/tests/functions/cleanDirsizeCache.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * Tests specific to the directory size caching.
+ */
+class Tests_Functions_CleanDirsizeCache extends WP_UnitTestCase {
+
+	/**
+	 * Test the handling of invalid data passed as the $path parameter.
+	 *
+	 * @ticket 52241
+	 *
+	 * @covers ::clean_dirsize_cache
+	 *
+	 * @dataProvider data_clean_dirsize_cache_with_invalid_inputs
+	 *
+	 * @param mixed $path Path input to use in the test.
+	 */
+	public function test_clean_dirsize_cache_with_invalid_inputs( $path ) {
+		$this->setExpectedIncorrectUsage( 'clean_dirsize_cache' );
+
+		clean_dirsize_cache( $path );
+	}
+
+	/**
+	 * Data provider
+	 *
+	 * @return array
+	 */
+	public function data_clean_dirsize_cache_with_invalid_inputs() {
+		return array(
+			'null'         => array( null ),
+			'bool false'   => array( false ),
+			'empty string' => array( '' ),
+			'array'        => array( array( '.', './second/path/' ) ),
+		);
+	}
+
+	/**
+	 * Test the handling of a non-path text string passed as the $path parameter.
+	 *
+	 * @ticket 52241
+	 *
+	 * @covers ::clean_dirsize_cache
+	 *
+	 * @dataProvider data_clean_dirsize_cache_with_non_path_string
+	 *
+	 * @param string $path           Path input to use in the test.
+	 * @param int    $expected_count Expected number of paths in the cache after cleaning.
+	 */
+	public function test_clean_dirsize_cache_with_non_path_string( $path, $expected_count ) {
+		// Set the dirsize cache to our mock.
+		set_transient( 'dirsize_cache', $this->mock_dirsize_cache_with_non_path_string() );
+
+		clean_dirsize_cache( $path );
+
+		$cache = get_transient( 'dirsize_cache' );
+		$this->assertIsArray( $cache );
+		$this->assertCount( $expected_count, $cache );
+	}
+
+	/**
+	 * Data provider
+	 *
+	 * @return array
+	 */
+	public function data_clean_dirsize_cache_with_non_path_string() {
+		return array(
+			'single dot'                        => array(
+				'path'           => '.',
+				'expected_count' => 1,
+			),
+			'non-path'                          => array(
+				'path'           => 'string',
+				'expected_count' => 1,
+			),
+			'non-existant string, but non-path' => array(
+				'path'           => 'doesnotexist',
+				'expected_count' => 2,
+			),
+		);
+	}
+
+	private function mock_dirsize_cache_with_non_path_string() {
+		return array(
+			'.'      => array( 'size' => 50 ),
+			'string' => array( 'size' => 42 ),
+		);
+	}
+}

--- a/tests/phpunit/tests/functions/fixtures/dummy.txt
+++ b/tests/phpunit/tests/functions/fixtures/dummy.txt
@@ -1,0 +1,1 @@
+This is a dummy text file which is only used by the `Tests_Multisite_CleanDirsizeCache::test_recurse_dirsize_without_transient()` test.


### PR DESCRIPTION
### `clean_dirsize_cache()`: fix infinite loop on Windows

When the PHP native `dirname()` function is used on a Windows disk name - i.e. `C:\`-, it will return the same, i.e, it will return `C:\` again.
The `clean_dirsize_cache()` function didn't have guard clause against this, which meant that on Windows based systems and IIS servers, this function would result in WordPress getting stuck into an infinite loop.

The adjustment to the `while` part of the function fix this by checking if the return value of the `dirname()` function call is the same as the original path passed to `dirname()`, which effectively fixes the infinite loop.

As we were looking at this function now anyway, we also noticed a number of other improvements which were begging to be made and we have thus taken the liberty to make them.
1. Add input validation for the `$path` parameter to guard against invalid variable types being passed into the function.
2. Guard against an empty `$path` parameter, which would result in an infinite loop on both Windows as well as *nix based systems.

In both these cases, a "doing it wrong" will now be thrown.

3. When a non-empty string, which isn't a path would previously be passed, the `dirname()` function would transform that to a `.` and the `.` key in the transient cache would be cleared out.
This was a bug as there is no relation between a non-path string and the root directory of file system.

This bug has been fixed by checking that something could actually be a path and handling received non-empty, non-path input parameters in a special way, i.e only removing the cache key for the passed string and bowing out from further processing.

Unfortunately, no tests can be added to guard against the infinite loop.

For the other fixes, we have added appropriate unit tests.

### PHP 8.1: recurse_dirsize(): fix autovivification from false to array

> PHP natively allows for autovivification (auto-creation of arrays from falsey values). This feature is very useful and used in a lot of PHP projects, especially if the variable is undefined. However, there is a little oddity that allows creating an array from a `false` and `null` value.

The above quote is from the PHP 8.1 RFC and the (accepted) RFC changes the behaviour described above to deprecated auto creation of arrays from `false`. As it is deprecated, it _will_ still work for the time being, but as of PHP 9.0, this will become a Fatal Error, so we may as well fix it now.

The `recurse_dirsize()` function retrieves a transient and places it in the `$directory_cache` variable, but the `get_transient()` function in WP returns `false` when the transient doesn't exist, which subsequently can lead to the above mentioned deprecation notice.

By verifying that the `$directory_cache` variable is an array before assigning to it and initializing it to an empty array, if it's not, we prevent the deprecation notice, as well as harden the function against potentially corrupted transients where this transient would not return the expected array format, but some other variable type.

Includes adding dedicated unit tests for both the PHP 8.1 issue, as well as the hardening against corrupted transients.

Includes some girl-scouting: touching up a parameter description and some code layout.

Refs:
* https://wiki.php.net/rfc/autovivification_false
* https://developer.wordpress.org/reference/functions/get_transient/

###  `wp_delete_attachment()`: add safeguard for invalid return from `get_attached_file()`

The `get_attached_file()` function is supposed to return the path to the file, but could:
1. Return `false` if the file doesn't exist.
2. Return literally anything else, as a filter is being applied to the value on return.

As we've now put input validation in place on the `clean_dirsize_cache()` function, passing anything but a non-empty string to `clean_dirsize_cache()` will result in a "doing it wrong" error notice.

This was exposed by the `Tests_Post_GetPostStatus::wpSetUpBeforeClass()` method which started generating unexpected output (the doing it wrong message) during the test run.

While this indicates that there is a flaw in the mocking being done in the test suite, debugging that is outside of the scope of the current patch.

At the same time, as based on the above point, this _could_ potentially happen in a real-world situation as well, adding additional conditions to the `if` in the `wp_delete_attachment()` function before calling the `clean_dirsize_cache()` function, is warranted.

As there are no tests for the `wp_delete_attachment()` function at all at this time, we're not adding a test specifically for this change for now. This should however be addressed in the future, when tests will be added to cover the `wp_delete_attachment()` function completely.



Trac ticket: https://core.trac.wordpress.org/ticket/52241
Trac ticket: https://core.trac.wordpress.org/ticket/53635

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
