### PR TITLE
add safety checks

### DIFF
--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -624,7 +624,7 @@ class WP_Upgrader {
 		}
 
 		// Move new version of item into place.
-		$result = move_dir( $source, $remote_destination );
+		$result = move_dir( $source, $remote_destination, $remote_source );
 		if ( is_wp_error( $result ) ) {
 			if ( $args['clear_working'] ) {
 				$wp_filesystem->delete( $remote_source, true );

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -1043,7 +1043,7 @@ class WP_Upgrader {
 		}
 
 		// Move to the temp-backup directory.
-		if ( ! $wp_filesystem->move( $src, $dest, true ) ) {
+		if ( ! move_dir( $src, $dest ) ) {
 			return new WP_Error( 'fs_temp_backup_move', $this->strings['temp_backup_move_failed'] );
 		}
 
@@ -1077,7 +1077,7 @@ class WP_Upgrader {
 			}
 
 			// Move it.
-			if ( ! $wp_filesystem->move( $src, $dest, true ) ) {
+			if ( ! move_dir( $src, $dest ) ) {
 				return new WP_Error( 'fs_temp_backup_delete', $this->strings['temp_backup_restore_failed'] );
 			}
 		}

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1934,12 +1934,18 @@ function copy_dir( $from, $to, $skip_list = array() ) {
 function move_dir( $from, $to ) {
 	global $wp_filesystem;
 
-	$wp_filesystem->rmdir( $to );
-	if ( @rename( $from, $to ) ) {
-		return true;
+	if ( 'direct' === $wp_filesystem->method ) {
+		$wp_filesystem->rmdir( $to );
+		if ( @rename( $from, $to ) ) {
+			return true;
+		}
 	}
 
-	$wp_filesystem->mkdir( $to );
+	if ( ! $wp_filesystem->is_dir( $to ) ) {
+		if ( ! $wp_filesystem->mkdir( $to, FS_CHMOD_DIR ) ) {
+			return new WP_Error( 'mkdir_failed_copy_dir', __( 'Could not create directory.' ), $to );
+		}
+	}
 	$result = copy_dir( $from, $to );
 
 	return $result;

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1929,7 +1929,8 @@ function copy_dir( $from, $to, $skip_list = array() ) {
  *
  * @param string $from        Source directory.
  * @param string $to          Destination directory.
- * @param string $working_dir Remote file source directory.
+ * @param string $working_dir Remote file source directory. Optional.
+ *
  * @return true|WP_Error True on success, WP_Error on failure.
  */
 function move_dir( $from, $to, $working_dir = '' ) {

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1943,7 +1943,7 @@ function move_dir( $from, $to ) {
 
 	if ( ! $wp_filesystem->is_dir( $to ) ) {
 		if ( ! $wp_filesystem->mkdir( $to, FS_CHMOD_DIR ) ) {
-			return new WP_Error( 'mkdir_failed_copy_dir', __( 'Could not create directory.' ), $to );
+			return new WP_Error( 'mkdir_failed_move_dir', __( 'Could not create directory.' ), $to );
 		}
 	}
 	$result = copy_dir( $from, $to );

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1927,11 +1927,12 @@ function copy_dir( $from, $to, $skip_list = array() ) {
  *
  * @global WP_Filesystem_Base $wp_filesystem WordPress filesystem subclass.
  *
- * @param string $from Source directory.
- * @param string $to   Destination directory.
+ * @param string $from        Source directory.
+ * @param string $to          Destination directory.
+ * @param string $working_dir Remote file source directory.
  * @return true|WP_Error True on success, WP_Error on failure.
  */
-function move_dir( $from, $to ) {
+function move_dir( $from, $to, $working_dir = '' ) {
 	global $wp_filesystem;
 
 	if ( 'direct' === $wp_filesystem->method ) {
@@ -1943,10 +1944,21 @@ function move_dir( $from, $to ) {
 
 	if ( ! $wp_filesystem->is_dir( $to ) ) {
 		if ( ! $wp_filesystem->mkdir( $to, FS_CHMOD_DIR ) ) {
+
+			// Clear the working folder?
+			if ( ! empty( $working_dir ) ) {
+				$wp_filesystem->delete( $working_dir );
+			}
+
 			return new WP_Error( 'mkdir_failed_move_dir', __( 'Could not create directory.' ), $to );
 		}
 	}
 	$result = copy_dir( $from, $to );
+
+	// Clear the working folder?
+	if ( ! empty( $working_dir ) ) {
+		$wp_filesystem->delete( $working_dir );
+	}
 
 	return $result;
 }

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1948,7 +1948,7 @@ function move_dir( $from, $to, $working_dir = '' ) {
 
 			// Clear the working folder?
 			if ( ! empty( $working_dir ) ) {
-				$wp_filesystem->delete( $working_dir );
+				$wp_filesystem->delete( $working_dir, true );
 			}
 
 			return new WP_Error( 'mkdir_failed_move_dir', __( 'Could not create directory.' ), $to );
@@ -1958,7 +1958,7 @@ function move_dir( $from, $to, $working_dir = '' ) {
 
 	// Clear the working folder?
 	if ( ! empty( $working_dir ) ) {
-		$wp_filesystem->delete( $working_dir );
+		$wp_filesystem->delete( $working_dir, true );
 	}
 
 	return $result;


### PR DESCRIPTION
Update for r51899 to address issues, https://core.trac.wordpress.org/ticket/54166#comment:20

- Add check for direct PHP flle access and only use `rename()` if true.
- More consistent behavior for fallback to `copy_dir()`

Trac ticket: https://core.trac.wordpress.org/ticket/54166

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
