### PR TITLE
wp_check_filetype allows filename to not end in extension

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -2945,7 +2945,7 @@ function wp_check_filetype( $filename, $mimes = null ) {
 	$ext  = false;
 
 	foreach ( $mimes as $ext_preg => $mime_match ) {
-		$ext_preg = '!\.(' . $ext_preg . ')$!i';
+		$ext_preg = '!\.(' . $ext_preg . ')(.*)$!i';
 		if ( preg_match( $ext_preg, $filename, $ext_matches ) ) {
 			$type = $mime_match;
 			$ext  = $ext_matches[1];


### PR DESCRIPTION
wp_check_filetype now works when filename does not end in extension.

Used when a filename came from a URI and contains query strings.



Trac ticket: https://core.trac.wordpress.org/ticket/54244