### PR TITLE
Fix relative URLs for inlined stylesheets

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2740,6 +2740,7 @@ function wp_maybe_inline_styles() {
  *
  * @since 5.9.0
  * @access private
+ *
  * @param string $css            The CSS to make URLs relative to the WordPress installation.
  * @param string $stylesheet_url The URL to the stylesheet.
  *

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2738,8 +2738,8 @@ function wp_maybe_inline_styles() {
 /**
  * Make URLs relative to the WordPress installation.
  *
- * @since 5.8.2
- *
+ * @since 5.9.0
+ * @access private
  * @param string $css            The CSS to make URLs relative to the WordPress installation.
  * @param string $stylesheet_url The URL to the stylesheet.
  *

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2683,6 +2683,7 @@ function wp_maybe_inline_styles() {
 		if ( wp_styles()->get_data( $handle, 'path' ) && file_exists( $wp_styles->registered[ $handle ]->extra['path'] ) ) {
 			$styles[] = array(
 				'handle' => $handle,
+				'src'    => $wp_styles->registered[ $handle ]->src,
 				'path'   => $wp_styles->registered[ $handle ]->extra['path'],
 				'size'   => filesize( $wp_styles->registered[ $handle ]->extra['path'] ),
 			);
@@ -2716,6 +2717,31 @@ function wp_maybe_inline_styles() {
 
 			// Get the styles if we don't already have them.
 			$style['css'] = file_get_contents( $style['path'] );
+
+			// Check if the style contains relative URLs that need to be modified.
+			// URLs relative to the stylesheet's path should be converted to relative to the site's root.
+			$has_src_results = preg_match_all( '#url\s*\(\s*[\'"]?\s*([^\'"\)]+)#', $style['css'], $src_results );
+			if ( $has_src_results ) {
+				// Loop through the URLs to find relative ones.
+				foreach ( $src_results[1] as $src_index => $src_result ) {
+					// Skip if this is an absolute URL.
+					if ( 0 === strpos( $src_result, 'http' ) ) {
+						continue;
+					}
+
+					// Build the absolute URL.
+					$absolute_url = dirname( $style['src'] ) . '/' . ltrim( $src_result, './' );
+					// Convert to URL related to the site root.
+					$relative_url = wp_make_link_relative( $absolute_url );
+
+					// Replace the URL in the CSS.
+					$style['css'] = str_replace(
+						$src_results[0][ $src_index ],
+						str_replace( $src_result, $relative_url, $src_results[0][ $src_index ] ),
+						$style['css']
+					);
+				}
+			}
 
 			// Set `src` to `false` and add styles inline.
 			$wp_styles->registered[ $style['handle'] ]->src = false;

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2738,7 +2738,7 @@ function wp_maybe_inline_styles() {
 /**
  * Make URLs relative to the WordPress installation.
  *
- * @since 5.9.0
+ * @since 5.8.2
  *
  * @param string $css            The CSS to make URLs relative to the WordPress installation.
  * @param string $stylesheet_url The URL to the stylesheet.

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2720,7 +2720,7 @@ function wp_maybe_inline_styles() {
 
 			// Check if the style contains relative URLs that need to be modified.
 			// URLs relative to the stylesheet's path should be converted to relative to the site's root.
-			$style['css'] = _wp_make_css_links_relative( $style['css'], $style['src'] );
+			$style['css'] = _wp_normalize_relative_css_links( $style['css'], $style['src'] );
 
 			// Set `src` to `false` and add styles inline.
 			$wp_styles->registered[ $style['handle'] ]->src = false;
@@ -2751,7 +2751,7 @@ function _wp_normalize_relative_css_links( $css, $stylesheet_url ) {
 		// Loop through the URLs to find relative ones.
 		foreach ( $src_results[1] as $src_index => $src_result ) {
 			// Skip if this is an absolute URL.
-			if ( 0 === strpos( $src_result, 'http' ) ) {
+			if ( 0 === strpos( $src_result, 'http' ) || 0 === strpos( $src_result, '//' ) ) {
 				continue;
 			}
 

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2756,7 +2756,8 @@ function _wp_normalize_relative_css_links( $css, $stylesheet_url ) {
 			}
 
 			// Build the absolute URL.
-			$absolute_url = dirname( $stylesheet_url ) . '/' . ltrim( $src_result, './' );
+			$absolute_url = dirname( $stylesheet_url ) . '/' . $src_result;
+			$absolute_url = str_replace( '/./', '/', $absolute_url );
 			// Convert to URL related to the site root.
 			$relative_url = wp_make_link_relative( $absolute_url );
 

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2720,28 +2720,7 @@ function wp_maybe_inline_styles() {
 
 			// Check if the style contains relative URLs that need to be modified.
 			// URLs relative to the stylesheet's path should be converted to relative to the site's root.
-			$has_src_results = preg_match_all( '#url\s*\(\s*[\'"]?\s*([^\'"\)]+)#', $style['css'], $src_results );
-			if ( $has_src_results ) {
-				// Loop through the URLs to find relative ones.
-				foreach ( $src_results[1] as $src_index => $src_result ) {
-					// Skip if this is an absolute URL.
-					if ( 0 === strpos( $src_result, 'http' ) ) {
-						continue;
-					}
-
-					// Build the absolute URL.
-					$absolute_url = dirname( $style['src'] ) . '/' . ltrim( $src_result, './' );
-					// Convert to URL related to the site root.
-					$relative_url = wp_make_link_relative( $absolute_url );
-
-					// Replace the URL in the CSS.
-					$style['css'] = str_replace(
-						$src_results[0][ $src_index ],
-						str_replace( $src_result, $relative_url, $src_results[0][ $src_index ] ),
-						$style['css']
-					);
-				}
-			}
+			$style['css'] = _wp_make_css_links_relative( $style['css'], $style['src'] );
 
 			// Set `src` to `false` and add styles inline.
 			$wp_styles->registered[ $style['handle'] ]->src = false;
@@ -2754,6 +2733,43 @@ function wp_maybe_inline_styles() {
 			$total_inline_size += (int) $style['size'];
 		}
 	}
+}
+
+/**
+ * Make URLs relative to the WordPress installation.
+ *
+ * @since 5.9.0
+ *
+ * @param string $css            The CSS to make URLs relative to the WordPress installation.
+ * @param string $stylesheet_url The URL to the stylesheet.
+ *
+ * @return string The CSS with URLs made relative to the WordPress installation.
+ */
+function _wp_normalize_relative_css_links( $css, $stylesheet_url ) {
+	$has_src_results = preg_match_all( '#url\s*\(\s*[\'"]?\s*([^\'"\)]+)#', $css, $src_results );
+	if ( $has_src_results ) {
+		// Loop through the URLs to find relative ones.
+		foreach ( $src_results[1] as $src_index => $src_result ) {
+			// Skip if this is an absolute URL.
+			if ( 0 === strpos( $src_result, 'http' ) ) {
+				continue;
+			}
+
+			// Build the absolute URL.
+			$absolute_url = dirname( $stylesheet_url ) . '/' . ltrim( $src_result, './' );
+			// Convert to URL related to the site root.
+			$relative_url = wp_make_link_relative( $absolute_url );
+
+			// Replace the URL in the CSS.
+			$css = str_replace(
+				$src_results[0][ $src_index ],
+				str_replace( $src_result, $relative_url, $src_results[0][ $src_index ] ),
+				$css
+			);
+		}
+	}
+
+	return $css;
 }
 
 /**

--- a/tests/phpunit/tests/dependencies/styles.php
+++ b/tests/phpunit/tests/dependencies/styles.php
@@ -194,26 +194,47 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 	 *
 	 * @ticket 54243
 	 */
-	public function test_normalize_relative_css_links() {
-
-		$tests = array(
-			// Double quotes, same path.
-			'p {background:url( "image0.svg" );}'          => 'p {background:url( "/wp-content/themes/test/image0.svg" );}',
-			// Single quotes, same path, prefixed with "./".
-			'p {background-image: url(\'./image2.png\');}' => 'p {background-image: url(\'/wp-content/themes/test/image2.png\');}',
-			// Single quotes, one level up, prefixed with "../".
-			'p {background-image: url(\'../image1.jpg\');}' => 'p {background-image: url(\'/wp-content/themes/test/../image1.jpg\');}',
-			// External URLs, shouldn't change.
-			'p {background-image: url(\'http://foo.com/image2.png\');}' => 'p {background-image: url(\'http://foo.com/image2.png\');}',
-			'p {background-image: url( \'https://bar.com/image2.png\');}' => 'p {background-image: url( \'https://bar.com/image2.png\');}',
+	/**
+	 * @dataProvider data_normalize_relative_css_links
+	 *
+	 * @ticket 54243
+	 *
+	 * @covers ::_wp_normalize_relative_css_links
+	 *
+	 * @param string $css      Given CSS to test.
+	 * @param string $expected Expected result.
+	 */
+	public function test_normalize_relative_css_links( $css, $expected ) {
+		$this->assertSame(
+			$expected,
+			_wp_normalize_relative_css_links( $css, site_url( 'wp-content/themes/test/style.css' ) )
 		);
+	}
 
-		foreach ( $tests as $input => $expected ) {
-			$this->assertSame(
-				$expected,
-				_wp_normalize_relative_css_links( $input, site_url( 'wp-content/themes/test/style.css' ) )
-			);
-		}
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_normalize_relative_css_links() {
+		return array(
+			'Double quotes, same path'                     => array(
+				'css'      => 'p {background:url( "image0.svg" );}',
+				'expected' => 'p {background:url( "/wp-content/themes/test/image0.svg" );}',
+			),
+			'Single quotes, same path, prefixed with "./"' => array(
+				'css'      => 'p {background-image: url(\'./image2.png\');}',
+				'expected' => 'p {background-image: url(\'/wp-content/themes/test/image2.png\');}',
+			),
+			'Single quotes, one level up, prefixed with "../"' => array(
+				'css'      => 'p {background-image: url(\'../image1.jpg\');}',
+				'expected' => 'p {background-image: url(\'/wp-content/themes/test/../image1.jpg\');}',
+			),
+			'External URLs, shouldn\'t change'             => array(
+				'css'      => 'p {background-image: url(\'http://foo.com/image2.png\');}',
+				'expected' => 'p {background-image: url(\'http://foo.com/image2.png\');}',
+			),
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/dependencies/styles.php
+++ b/tests/phpunit/tests/dependencies/styles.php
@@ -192,9 +192,6 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 	/**
 	 * Test normalizing relative links in CSS.
 	 *
-	 * @ticket 54243
-	 */
-	/**
 	 * @dataProvider data_normalize_relative_css_links
 	 *
 	 * @ticket 54243

--- a/tests/phpunit/tests/dependencies/styles.php
+++ b/tests/phpunit/tests/dependencies/styles.php
@@ -198,13 +198,13 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 
 		$tests = array(
 			// Double quotes, same path.
-			'p {background:url( "image0.svg" );}'                         => 'p {background:url( "/wp-content/themes/test/image0.svg" );}',
+			'p {background:url( "image0.svg" );}'          => 'p {background:url( "/wp-content/themes/test/image0.svg" );}',
 			// Single quotes, same path, prefixed with "./".
-			'p {background-image: url(\'./image2.png\');}'                => 'p {background-image: url(\'/wp-content/themes/test/image2.png\');}',
+			'p {background-image: url(\'./image2.png\');}' => 'p {background-image: url(\'/wp-content/themes/test/image2.png\');}',
 			// Single quotes, one level up, prefixed with "../".
-			'p {background-image: url(\'../image1.jpg\');}'               => 'p {background-image: url(\'/wp-content/themes/test/../image1.jpg\');}',
+			'p {background-image: url(\'../image1.jpg\');}' => 'p {background-image: url(\'/wp-content/themes/test/../image1.jpg\');}',
 			// External URLs, shouldn't change.
-			'p {background-image: url(\'http://foo.com/image2.png\');}'   => 'p {background-image: url(\'http://foo.com/image2.png\');}',
+			'p {background-image: url(\'http://foo.com/image2.png\');}' => 'p {background-image: url(\'http://foo.com/image2.png\');}',
 			'p {background-image: url( \'https://bar.com/image2.png\');}' => 'p {background-image: url( \'https://bar.com/image2.png\');}',
 		);
 

--- a/tests/phpunit/tests/dependencies/styles.php
+++ b/tests/phpunit/tests/dependencies/styles.php
@@ -211,7 +211,7 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 		foreach ( $tests as $input => $expected ) {
 			$this->assertSame(
 				$expected,
-				_wp_normalize_relative_css_links( $input, site_url( 'wp-content/themes/test/style.css' ) ),
+				_wp_normalize_relative_css_links( $input, site_url( 'wp-content/themes/test/style.css' ) )
 			);
 		}
 	}

--- a/tests/phpunit/tests/dependencies/styles.php
+++ b/tests/phpunit/tests/dependencies/styles.php
@@ -190,6 +190,33 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test normalizing relative links in CSS.
+	 *
+	 * @ticket 54243
+	 */
+	public function test_normalize_relative_css_links() {
+
+		$tests = array(
+			// Double quotes, same path.
+			'p {background:url( "image0.svg" );}'                         => 'p {background:url( "/wp-content/themes/test/image0.svg" );}',
+			// Single quotes, same path, prefixed with "./".
+			'p {background-image: url(\'./image2.png\');}'                => 'p {background-image: url(\'/wp-content/themes/test/image2.png\');}',
+			// Single quotes, one level up, prefixed with "../".
+			'p {background-image: url(\'../image1.jpg\');}'               => 'p {background-image: url(\'/wp-content/themes/test/../image1.jpg\');}',
+			// External URLs, shouldn't change.
+			'p {background-image: url(\'http://foo.com/image2.png\');}'   => 'p {background-image: url(\'http://foo.com/image2.png\');}',
+			'p {background-image: url( \'https://bar.com/image2.png\');}' => 'p {background-image: url( \'https://bar.com/image2.png\');}',
+		);
+
+		foreach ( $tests as $input => $expected ) {
+			$this->assertSame(
+				$expected,
+				_wp_normalize_relative_css_links( $input, site_url( 'wp-content/themes/test/style.css' ) ),
+			);
+		}
+	}
+
+	/**
 	 * Test if multiple inline styles work
 	 *
 	 * @ticket 24813


### PR DESCRIPTION
When styles get inlined, relative URLs break.
The problem is that URLs inside CSS files are relative to the stylesheet's path, and when styles get inlined that relation is lost.
This PR fixes the issue by finding relative URLs which then get modified to be relative to the site's root.

Trac ticket: https://core.trac.wordpress.org/ticket/54243

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
