### PR TITLE
Add accessible labels to pagination links

### DIFF
--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -4208,6 +4208,7 @@ function paginate_links( $args = '' ) {
 		'add_fragment'       => '',
 		'before_page_number' => '',
 		'after_page_number'  => '',
+		'links_aria_label'   => __( 'Page' ),
 	);
 
 	$args = wp_parse_args( $args, $defaults );
@@ -4263,7 +4264,7 @@ function paginate_links( $args = '' ) {
 		$link .= $args['add_fragment'];
 
 		$page_links[] = sprintf(
-			'<a class="prev page-numbers" href="%s">%s</a>',
+			'<a class="prev page-numbers" href="%s" aria-label="%s">%s</a>',
 			/**
 			 * Filters the paginated links for the given archive pages.
 			 *
@@ -4272,6 +4273,7 @@ function paginate_links( $args = '' ) {
 			 * @param string $link The paginated link URL.
 			 */
 			esc_url( apply_filters( 'paginate_links', $link ) ),
+			esc_attr( $args['prev_text'] . ' ' . $args['links_aria_label'] ),
 			$args['prev_text']
 		);
 	endif;
@@ -4295,9 +4297,10 @@ function paginate_links( $args = '' ) {
 				$link .= $args['add_fragment'];
 
 				$page_links[] = sprintf(
-					'<a class="page-numbers" href="%s">%s</a>',
+					'<a class="page-numbers" href="%s" aria-label="%s">%s</a>',
 					/** This filter is documented in wp-includes/general-template.php */
 					esc_url( apply_filters( 'paginate_links', $link ) ),
+					esc_attr( $args['links_aria_label'] . ' ' . number_format_i18n( $n ) ),
 					$args['before_page_number'] . number_format_i18n( $n ) . $args['after_page_number']
 				);
 
@@ -4319,9 +4322,10 @@ function paginate_links( $args = '' ) {
 		$link .= $args['add_fragment'];
 
 		$page_links[] = sprintf(
-			'<a class="next page-numbers" href="%s">%s</a>',
+			'<a class="next page-numbers" href="%s" aria-label="%s">%s</a>',
 			/** This filter is documented in wp-includes/general-template.php */
 			esc_url( apply_filters( 'paginate_links', $link ) ),
+			esc_attr( $args['next_text'] . ' ' . $args['links_aria_label'] ),
 			$args['next_text']
 		);
 	endif;


### PR DESCRIPTION
Create a new default $arg in `paginate_links` and use `aria-label` to provide context to page links for better accessibility.

Trac ticket: https://core.trac.wordpress.org/ticket/54260#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
