### PR TITLE
#54275 Need to remove some empty html element (span)

### DIFF
--- a/src/wp-admin/includes/credits.php
+++ b/src/wp-admin/includes/credits.php
@@ -154,7 +154,7 @@ function wp_credits_section_list( $credits = array(), $slug = '' ) {
 				$data2x = get_avatar_data( $person_data[1] . '@md5.gravatar.com', array( 'size' => $size * 2 ) );
 				echo '<span class="wp-person-avatar"><img src="' . esc_url( $data['url'] ) . '" srcset="' . esc_url( $data2x['url'] ) . ' 2x" class="gravatar" alt="" /></span>' . "\n";
 				echo esc_html( $person_data[0] ) . "</a>\n\t";
-				if ( ! $compact ) {
+				if ( ! $compact && ! empty( $person_data[3] ) ) {
 					// phpcs:ignore WordPress.WP.I18n.LowLevelTranslationFunction,WordPress.WP.I18n.NonSingularStringLiteralText
 					echo '<span class="title">' . translate( $person_data[3] ) . "</span>\n";
 				}


### PR DESCRIPTION
In credits.php file, during show core contributors there are some empty span element which is not necessary to generate.
During showing core contribution it's accessing $person_data[3] without any checking. Not every contributor has a title so in some cases, $person_data[3] returns an empty string. In that case, It's not necessary to print empty strings into the span element.
See the screenshot below to understand it properly.

Trac ticket: https://core.trac.wordpress.org/ticket/54275