### PR TITLE
Build/Test Tools: Replace some instances of `assertEquals()`.

### DIFF
--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -1127,23 +1127,6 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 	}
 
 	/**
-	 * A wrapper method for assertEquals() to indicate known, acceptable usage of assertEquals()
-	 * when comparing arrays that contain an object.
-	 *
-	 * This gives a more accurate picture of `assertEquals()` usage that needs to be reviewed with
-	 * each release.
-	 *
-	 * @since 6.1.0
-	 *
-	 * @param array  $expected Expected array containing an object.
-	 * @param array  $actual   Array to check containing an object.
-	 * @param string $message  Optional. Message to display when the assertion fails.
-	 */
-	public function assertArrayEqualsWithObject( $expected, $actual, $message = '' ) {
-		$this->assertEquals( $expected, $actual, $message );
-	}
-
-	/**
 	 * Helper function to convert a single-level array containing text strings to a named data provider.
 	 *
 	 * The value of the data set will also be used as the name of the data set.

--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -1102,6 +1102,31 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 	}
 
 	/**
+	 * A wrapper method for assertEquals() to indicate known, acceptable usage of assertEquals()
+	 * when comparing objects.
+	 *
+	 * This gives a more accurate picture of `assertEquals()` usage that needs to be reviewed with
+	 * each release.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param object $expected Expected object.
+	 * @param object $actual   Object to check.
+	 * @param string $message  Optional. Message to display when the assertion fails.
+	 */
+	public function assertSimilarObject( $expected, $actual, $message = '' ) {
+		$this->assertIsObject( $expected, $message . ' Expected value is not an object.' );
+		$this->assertIsObject( $actual, $message . ' Value under test is not an object.' );
+		$this->assertInstanceOf(
+			get_class( $expected ),
+			$actual,
+			$message . ' Value under test is not the same type of object as the expected value.'
+		);
+
+		$this->assertEquals( $expected, $actual, $message );
+	}
+
+	/**
 	 * Helper function to convert a single-level array containing text strings to a named data provider.
 	 *
 	 * The value of the data set will also be used as the name of the data set.

--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -1127,6 +1127,23 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 	}
 
 	/**
+	 * A wrapper method for assertEquals() to indicate known, acceptable usage of assertEquals()
+	 * when comparing arrays that contain an object.
+	 *
+	 * This gives a more accurate picture of `assertEquals()` usage that needs to be reviewed with
+	 * each release.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param array  $expected Expected array containing an object.
+	 * @param array  $actual   Array to check containing an object.
+	 * @param string $message  Optional. Message to display when the assertion fails.
+	 */
+	public function assertArrayEqualsWithObject( $expected, $actual, $message = '' ) {
+		$this->assertEquals( $expected, $actual, $message );
+	}
+
+	/**
 	 * Helper function to convert a single-level array containing text strings to a named data provider.
 	 *
 	 * The value of the data set will also be used as the name of the data set.

--- a/tests/phpunit/tests/admin/includesComment.php
+++ b/tests/phpunit/tests/admin/includesComment.php
@@ -52,7 +52,7 @@ class Tests_Admin_IncludesComment extends WP_UnitTestCase {
 	 */
 	public function test_must_match_date_and_author() {
 		$this->assertNull( comment_exists( 1, '2004-01-02 12:00:00' ) );
-		$this->assertEquals( self::$post_id, comment_exists( 1, '2014-05-06 12:00:00' ) );
+		$this->assertSame( (string) self::$post_id, comment_exists( 1, '2014-05-06 12:00:00' ) );
 	}
 
 	/**
@@ -61,7 +61,7 @@ class Tests_Admin_IncludesComment extends WP_UnitTestCase {
 	 * @covers ::comment_exists
 	 */
 	public function test_default_value_of_timezone_should_be_blog() {
-		$this->assertEquals( self::$post_id, comment_exists( 1, '2014-05-06 12:00:00' ) );
+		$this->assertSame( (string) self::$post_id, comment_exists( 1, '2014-05-06 12:00:00' ) );
 	}
 
 	/**
@@ -70,7 +70,7 @@ class Tests_Admin_IncludesComment extends WP_UnitTestCase {
 	 * @covers ::comment_exists
 	 */
 	public function test_should_respect_timezone_blog() {
-		$this->assertEquals( self::$post_id, comment_exists( 1, '2014-05-06 12:00:00', 'blog' ) );
+		$this->assertSame( (string) self::$post_id, comment_exists( 1, '2014-05-06 12:00:00', 'blog' ) );
 	}
 
 	/**
@@ -79,7 +79,7 @@ class Tests_Admin_IncludesComment extends WP_UnitTestCase {
 	 * @covers ::comment_exists
 	 */
 	public function test_should_respect_timezone_gmt() {
-		$this->assertEquals( self::$post_id, comment_exists( 1, '2014-05-06 07:00:00', 'gmt' ) );
+		$this->assertSame( (string) self::$post_id, comment_exists( 1, '2014-05-06 07:00:00', 'gmt' ) );
 	}
 
 	/**
@@ -88,6 +88,6 @@ class Tests_Admin_IncludesComment extends WP_UnitTestCase {
 	 * @covers ::comment_exists
 	 */
 	public function test_invalid_timezone_should_fall_back_on_blog() {
-		$this->assertEquals( self::$post_id, comment_exists( 1, '2014-05-06 12:00:00', 'not_a_valid_value' ) );
+		$this->assertSame( (string) self::$post_id, comment_exists( 1, '2014-05-06 12:00:00', 'not_a_valid_value' ) );
 	}
 }

--- a/tests/phpunit/tests/admin/includesPost.php
+++ b/tests/phpunit/tests/admin/includesPost.php
@@ -705,7 +705,7 @@ class Tests_Admin_IncludesPost extends WP_UnitTestCase {
 		add_filter(
 			'get_sample_permalink',
 			function( $permalink, $post_id, $title, $name, $post ) use ( $post_original ) {
-				$this->assertEquals( $post_original, $post, 'Modified post object passed to get_sample_permalink filter.' );
+				$this->assertSimilarObject( $post_original, $post, 'Modified post object passed to get_sample_permalink filter.' );
 				return $permalink;
 			},
 			10,
@@ -713,7 +713,7 @@ class Tests_Admin_IncludesPost extends WP_UnitTestCase {
 		);
 
 		get_sample_permalink( $post );
-		$this->assertEquals( $post_original, $post, 'get_sample_permalink() modifies the post object.' );
+		$this->assertSimilarObject( $post_original, $post, 'get_sample_permalink() modifies the post object.' );
 	}
 
 	public function test_post_exists_should_match_title() {

--- a/tests/phpunit/tests/admin/includesPost.php
+++ b/tests/phpunit/tests/admin/includesPost.php
@@ -253,7 +253,7 @@ class Tests_Admin_IncludesPost extends WP_UnitTestCase {
 
 		// Check that the first post's values don't stomp the second post.
 		$this->assertSame( 'draft', $post->post_status );
-		$this->assertEquals( self::$author_ids[1], $post->post_author );
+		$this->assertSame( (string) self::$author_ids[1], $post->post_author );
 		$this->assertSame( 'closed', $post->comment_status );
 		$this->assertSame( 'closed', $post->ping_status );
 	}

--- a/tests/phpunit/tests/admin/includesUser.php
+++ b/tests/phpunit/tests/admin/includesUser.php
@@ -17,7 +17,7 @@ class Tests_Admin_IncludesUser extends WP_UnitTestCase {
 
 		if ( $error_code ) {
 			$this->assertWPError( $error );
-			$this->assertEquals( $error_code, $error->get_error_code() );
+			$this->assertSame( $error_code, $error->get_error_code() );
 		} else {
 			$this->assertNotWPError( $error );
 		}

--- a/tests/phpunit/tests/ajax/Autosave.php
+++ b/tests/phpunit/tests/ajax/Autosave.php
@@ -97,7 +97,7 @@ class Tests_Ajax_Autosave extends WP_Ajax_UnitTestCase {
 		wp_set_current_user( self::$admin_id );
 
 		// Ensure post is locked.
-		$this->assertEquals( self::$editor_id, wp_check_post_lock( self::$post_id ) );
+		$this->assertSame( (string) self::$editor_id, wp_check_post_lock( self::$post_id ) );
 
 		// Set up the $_POST request.
 		$md5   = md5( uniqid() );

--- a/tests/phpunit/tests/ajax/CustomizeManager.php
+++ b/tests/phpunit/tests/ajax/CustomizeManager.php
@@ -132,7 +132,7 @@ class Tests_Ajax_CustomizeManager extends WP_Ajax_UnitTestCase {
 			$exception = $e;
 		}
 		$this->assertNotEmpty( $e );
-		$this->assertEquals( -1, $e->getMessage() );
+		$this->assertSame( '-1', $e->getMessage() );
 
 		// Not called setup_theme.
 		wp_set_current_user( self::$admin_user_id );

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -208,7 +208,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 	 * @dataProvider data_remove_theme_attribute_in_block_template_content
 	 */
 	function test_remove_theme_attribute_in_block_template_content( $template_content, $expected ) {
-		$this->assertEquals( $expected, _remove_theme_attribute_in_block_template_content( $template_content ) );
+		$this->assertSame( $expected, _remove_theme_attribute_in_block_template_content( $template_content ) );
 	}
 
 	function data_remove_theme_attribute_in_block_template_content() {

--- a/tests/phpunit/tests/blocks/wpBlockType.php
+++ b/tests/phpunit/tests/blocks/wpBlockType.php
@@ -240,7 +240,7 @@ class Tests_Blocks_wpBlockType extends WP_UnitTestCase {
 
 		$prepared_attributes = $block_type->prepare_attributes_for_render( $attributes );
 
-		$this->assertEquals(
+		$this->assertSameSetsWithIndex(
 			array(
 				'correct'            => 'include',
 				/* wrongType */

--- a/tests/phpunit/tests/bookmark/getBookmark.php
+++ b/tests/phpunit/tests/bookmark/getBookmark.php
@@ -143,7 +143,7 @@ class Tests_Bookmark_GetBookmark extends WP_UnitTestCase {
 
 		// Check the bookmark was cached.
 		$actual_cache = wp_cache_get( $bookmark->link_id, 'bookmark' );
-		$this->assertEquals( $bookmark, $actual_cache );
+		$this->assertSimilarObject( $bookmark, $actual_cache );
 	}
 
 	/**
@@ -228,18 +228,18 @@ class Tests_Bookmark_GetBookmark extends WP_UnitTestCase {
 		$actual_bookmark = get_bookmark( ...$args );
 
 		/*
-		 * For non-array output type, use assertEquals(). Why? The object pulled from the cache
+		 * For non-array output type, use assertSimilarObject(). Why? The object pulled from the cache
 		 * will have the same property values but will be a different object than the expected object.
 		 */
 		if ( is_object( $expected ) ) {
-			$this->assertEquals( $expected, $actual_bookmark );
+			$this->assertSimilarObject( $expected, $actual_bookmark );
 		} else {
 			$this->assertSameSets( $expected, $actual_bookmark );
 		}
 
 		// Check the bookmark was cached.
 		$actual_cache = wp_cache_get( self::$bookmark->link_id, 'bookmark' );
-		$this->assertEquals( self::$bookmark, $actual_cache );
+		$this->assertSimilarObject( self::$bookmark, $actual_cache );
 	}
 
 	/**
@@ -286,18 +286,18 @@ class Tests_Bookmark_GetBookmark extends WP_UnitTestCase {
 		$actual_bookmark = get_bookmark( ...$args );
 
 		/*
-		 * For non-array output type, use assertEquals(). Why? The object pulled from the database
+		 * For non-array output type, use assertSimilarObject(). Why? The object pulled from the database
 		 * will have the same property values but will be a different object than the expected object.
 		 */
 		if ( is_object( $expected ) ) {
-			$this->assertEquals( $expected, $actual_bookmark );
+			$this->assertSimilarObject( $expected, $actual_bookmark );
 		} else {
 			$this->assertSameSets( $expected, $actual_bookmark );
 		}
 
 		// Check the bookmark was cached.
 		$actual_cache = wp_cache_get( self::$bookmark->link_id, 'bookmark' );
-		$this->assertEquals( self::$bookmark, $actual_cache );
+		$this->assertSimilarObject( self::$bookmark, $actual_cache );
 	}
 
 	/**

--- a/tests/phpunit/tests/cache.php
+++ b/tests/phpunit/tests/cache.php
@@ -403,7 +403,7 @@ class Tests_Cache extends WP_UnitTestCase {
 			// External caches will contain property values that contain non-matching resource IDs.
 			$this->assertInstanceOf( 'WP_Object_Cache', $wp_object_cache );
 		} else {
-			$this->assertEquals( $wp_object_cache, $new_blank_cache_object );
+			$this->assertSimilarObject( $wp_object_cache, $new_blank_cache_object );
 		}
 	}
 

--- a/tests/phpunit/tests/comment-submission.php
+++ b/tests/phpunit/tests/comment-submission.php
@@ -1009,6 +1009,6 @@ class Tests_Comment_Submission extends WP_UnitTestCase {
 		$second_comment  = wp_handle_comment_submission( $data );
 
 		$this->assertNotWPError( $second_comment );
-		$this->assertEquals( self::$post->ID, $second_comment->comment_post_ID );
+		$this->assertSame( (string) self::$post->ID, $second_comment->comment_post_ID );
 	}
 }

--- a/tests/phpunit/tests/comment.php
+++ b/tests/phpunit/tests/comment.php
@@ -220,46 +220,46 @@ class Tests_Comment extends WP_UnitTestCase {
 	 * @covers ::get_approved_comments
 	 */
 	public function test_get_approved_comments() {
-		$ca1 = self::factory()->comment->create(
+		$ca1 = (string) self::factory()->comment->create(
 			array(
 				'comment_post_ID'  => self::$post_id,
 				'comment_approved' => '1',
 			)
 		);
-		$ca2 = self::factory()->comment->create(
+		$ca2 = (string) self::factory()->comment->create(
 			array(
 				'comment_post_ID'  => self::$post_id,
 				'comment_approved' => '1',
 			)
 		);
-		$ca3 = self::factory()->comment->create(
+		$ca3 = (string) self::factory()->comment->create(
 			array(
 				'comment_post_ID'  => self::$post_id,
 				'comment_approved' => '0',
 			)
 		);
-		$c2  = self::factory()->comment->create(
+		$c2  = (string) self::factory()->comment->create(
 			array(
 				'comment_post_ID'  => self::$post_id,
 				'comment_approved' => '1',
 				'comment_type'     => 'pingback',
 			)
 		);
-		$c3  = self::factory()->comment->create(
+		$c3  = (string) self::factory()->comment->create(
 			array(
 				'comment_post_ID'  => self::$post_id,
 				'comment_approved' => '1',
 				'comment_type'     => 'trackback',
 			)
 		);
-		$c4  = self::factory()->comment->create(
+		$c4  = (string) self::factory()->comment->create(
 			array(
 				'comment_post_ID'  => self::$post_id,
 				'comment_approved' => '1',
 				'comment_type'     => 'mario',
 			)
 		);
-		$c5  = self::factory()->comment->create(
+		$c5  = (string) self::factory()->comment->create(
 			array(
 				'comment_post_ID'  => self::$post_id,
 				'comment_approved' => '1',
@@ -270,7 +270,7 @@ class Tests_Comment extends WP_UnitTestCase {
 		$found = get_approved_comments( self::$post_id );
 
 		// All comment types will be returned.
-		$this->assertEquals( array( $ca1, $ca2, $c2, $c3, $c4, $c5 ), wp_list_pluck( $found, 'comment_ID' ) );
+		$this->assertSame( array( $ca1, $ca2, $c2, $c3, $c4, $c5 ), wp_list_pluck( $found, 'comment_ID' ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/comment.php
+++ b/tests/phpunit/tests/comment.php
@@ -58,7 +58,7 @@ class Tests_Comment extends WP_UnitTestCase {
 		$this->assertSame( 1, $result );
 
 		$comment = get_comment( $comments[0] );
-		$this->assertEquals( $comments[1], $comment->comment_parent );
+		$this->assertSame( (string) $comments[1], $comment->comment_parent );
 
 		$result = wp_update_comment(
 			array(
@@ -76,7 +76,7 @@ class Tests_Comment extends WP_UnitTestCase {
 		);
 
 		$comment = get_comment( $comments[0] );
-		$this->assertEquals( $post2->ID, $comment->comment_post_ID );
+		$this->assertSame( (string) $post2->ID, $comment->comment_post_ID );
 	}
 
 	/**
@@ -135,7 +135,7 @@ class Tests_Comment extends WP_UnitTestCase {
 		);
 
 		$comment = get_comment( $comment_id );
-		$this->assertEquals( 1, $comment->user_id );
+		$this->assertSame( '1', $comment->user_id );
 	}
 
 	/**

--- a/tests/phpunit/tests/comment/getCommentsPagesCount.php
+++ b/tests/phpunit/tests/comment/getCommentsPagesCount.php
@@ -174,9 +174,9 @@ class Tests_Comment_GetCommentsPagesCount extends WP_UnitTestCase {
 
 		$wp_query->max_num_comment_pages = 7;
 
-		$this->assertEquals( 7, get_comment_pages_count() );
-		$this->assertEquals( 7, get_comment_pages_count( null, null, null ) );
-		$this->assertEquals( 0, get_comment_pages_count( array(), null, null ) );
+		$this->assertSame( 7, get_comment_pages_count() );
+		$this->assertSame( 7, get_comment_pages_count( null, null, null ) );
+		$this->assertSame( 0, get_comment_pages_count( array(), null, null ) );
 
 		$wp_query->max_num_comment_pages = $org_max_num_comment_pages;
 	}

--- a/tests/phpunit/tests/comment/query.php
+++ b/tests/phpunit/tests/comment/query.php
@@ -3584,7 +3584,7 @@ class Tests_Comment_Query extends WP_UnitTestCase {
 		$query2 = new WP_Comment_Query( array( 'status' => 'all' ) );
 		$this->assertNotEmpty( $query2->query_vars );
 		$this->assertNotEmpty( $query2->comments );
-		$this->assertArrayEqualsWithObject( $query2->comments, $query1->get_comments() );
+		$this->assertEqualSets( $query2->comments, $query1->get_comments() );
 	}
 
 	/**

--- a/tests/phpunit/tests/comment/query.php
+++ b/tests/phpunit/tests/comment/query.php
@@ -1381,7 +1381,7 @@ class Tests_Comment_Query extends WP_UnitTestCase {
 		$comments = get_comments( array( 'post_id' => $post_id ) );
 		$this->assertCount( $limit, $comments );
 		foreach ( $comments as $comment ) {
-			$this->assertEquals( $post_id, $comment->comment_post_ID );
+			$this->assertSame( (string) $post_id, $comment->comment_post_ID );
 		}
 
 		$post_id2 = self::factory()->post->create();
@@ -1390,7 +1390,7 @@ class Tests_Comment_Query extends WP_UnitTestCase {
 		$comments = get_comments( array( 'post_id' => $post_id2 ) );
 		$this->assertCount( $limit, $comments );
 		foreach ( $comments as $comment ) {
-			$this->assertEquals( $post_id2, $comment->comment_post_ID );
+			$this->assertSame( (string) $post_id2, $comment->comment_post_ID );
 		}
 
 		$post_id3 = self::factory()->post->create();
@@ -1399,7 +1399,7 @@ class Tests_Comment_Query extends WP_UnitTestCase {
 		$comments = get_comments( array( 'post_id' => $post_id3 ) );
 		$this->assertCount( $limit, $comments );
 		foreach ( $comments as $comment ) {
-			$this->assertEquals( $post_id3, $comment->comment_post_ID );
+			$this->assertSame( (string) $post_id3, $comment->comment_post_ID );
 		}
 
 		$comments = get_comments(
@@ -1410,7 +1410,7 @@ class Tests_Comment_Query extends WP_UnitTestCase {
 		);
 		$this->assertCount( $limit, $comments );
 		foreach ( $comments as $comment ) {
-			$this->assertEquals( $post_id3, $comment->comment_post_ID );
+			$this->assertSame( (string) $post_id3, $comment->comment_post_ID );
 		}
 
 		$comments = get_comments(
@@ -1425,7 +1425,7 @@ class Tests_Comment_Query extends WP_UnitTestCase {
 		$comments = get_comments( array( 'post_id' => $post_id3 ) );
 		$this->assertCount( $limit * 2, $comments );
 		foreach ( $comments as $comment ) {
-			$this->assertEquals( $post_id3, $comment->comment_post_ID );
+			$this->assertSame( (string) $post_id3, $comment->comment_post_ID );
 		}
 	}
 
@@ -1453,8 +1453,8 @@ class Tests_Comment_Query extends WP_UnitTestCase {
 			)
 		);
 		$this->assertCount( 2, $comments );
-		$this->assertEquals( $comment_id2, $comments[0]->comment_ID );
-		$this->assertEquals( $comment_id, $comments[1]->comment_ID );
+		$this->assertSame( (string) $comment_id2, $comments[0]->comment_ID );
+		$this->assertSame( (string) $comment_id, $comments[1]->comment_ID );
 
 		$comments = get_comments(
 			array(
@@ -1463,8 +1463,8 @@ class Tests_Comment_Query extends WP_UnitTestCase {
 			)
 		);
 		$this->assertCount( 2, $comments );
-		$this->assertEquals( $comment_id2, $comments[0]->comment_ID );
-		$this->assertEquals( $comment_id, $comments[1]->comment_ID );
+		$this->assertSame( (string) $comment_id2, $comments[0]->comment_ID );
+		$this->assertSame( (string) $comment_id, $comments[1]->comment_ID );
 
 		$comments = get_comments(
 			array(
@@ -1474,8 +1474,8 @@ class Tests_Comment_Query extends WP_UnitTestCase {
 			)
 		);
 		$this->assertCount( 2, $comments );
-		$this->assertEquals( $comment_id, $comments[0]->comment_ID );
-		$this->assertEquals( $comment_id2, $comments[1]->comment_ID );
+		$this->assertSame( (string) $comment_id, $comments[0]->comment_ID );
+		$this->assertSame( (string) $comment_id2, $comments[1]->comment_ID );
 
 		$comments = get_comments(
 			array(
@@ -1485,8 +1485,8 @@ class Tests_Comment_Query extends WP_UnitTestCase {
 			)
 		);
 		$this->assertCount( 2, $comments );
-		$this->assertEquals( $comment_id, $comments[0]->comment_ID );
-		$this->assertEquals( $comment_id2, $comments[1]->comment_ID );
+		$this->assertSame( (string) $comment_id, $comments[0]->comment_ID );
+		$this->assertSame( (string) $comment_id2, $comments[1]->comment_ID );
 
 		$comments = get_comments(
 			array(
@@ -1733,8 +1733,8 @@ class Tests_Comment_Query extends WP_UnitTestCase {
 		);
 
 		$this->assertCount( 2, $comments );
-		$this->assertEquals( $users[0], $comments[0]->user_id );
-		$this->assertEquals( $users[0], $comments[1]->user_id );
+		$this->assertSame( (string) $users[0], $comments[0]->user_id );
+		$this->assertSame( (string) $users[0], $comments[1]->user_id );
 
 		$comments = get_comments(
 			array(
@@ -1745,9 +1745,9 @@ class Tests_Comment_Query extends WP_UnitTestCase {
 		);
 
 		$this->assertCount( 3, $comments );
-		$this->assertEquals( $users[0], $comments[0]->user_id );
-		$this->assertEquals( $users[0], $comments[1]->user_id );
-		$this->assertEquals( $users[1], $comments[2]->user_id );
+		$this->assertSame( (string) $users[0], $comments[0]->user_id );
+		$this->assertSame( (string) $users[0], $comments[1]->user_id );
+		$this->assertSame( (string) $users[1], $comments[2]->user_id );
 
 	}
 

--- a/tests/phpunit/tests/comment/query.php
+++ b/tests/phpunit/tests/comment/query.php
@@ -3584,7 +3584,7 @@ class Tests_Comment_Query extends WP_UnitTestCase {
 		$query2 = new WP_Comment_Query( array( 'status' => 'all' ) );
 		$this->assertNotEmpty( $query2->query_vars );
 		$this->assertNotEmpty( $query2->comments );
-		$this->assertEquals( $query2->comments, $query1->get_comments() );
+		$this->assertArrayEqualsWithObject( $query2->comments, $query1->get_comments() );
 	}
 
 	/**

--- a/tests/phpunit/tests/comment/query.php
+++ b/tests/phpunit/tests/comment/query.php
@@ -1494,7 +1494,7 @@ class Tests_Comment_Query extends WP_UnitTestCase {
 				'orderby'    => array( 'key' ),
 			)
 		);
-		$this->assertEquals( array( $comment_id3, $comment_id ), wp_list_pluck( $comments, 'comment_ID' ) );
+		$this->assertSameSetsWithIndex( array( (string) $comment_id3, (string) $comment_id ), wp_list_pluck( $comments, 'comment_ID' ) );
 
 		$comments = get_comments(
 			array(
@@ -1502,7 +1502,7 @@ class Tests_Comment_Query extends WP_UnitTestCase {
 				'orderby'    => array( 'meta_value' ),
 			)
 		);
-		$this->assertEquals( array( $comment_id3, $comment_id ), wp_list_pluck( $comments, 'comment_ID' ) );
+		$this->assertSameSetsWithIndex( array( (string) $comment_id3, (string) $comment_id ), wp_list_pluck( $comments, 'comment_ID' ) );
 
 		// 'value1' is present on two different keys for $comment_id,
 		// yet we should get only one instance of that comment in the results.
@@ -3021,8 +3021,10 @@ class Tests_Comment_Query extends WP_UnitTestCase {
 			)
 		);
 
+		$comments = array_map( 'strval', $comments );
+
 		// $comments is ASC by default.
-		$this->assertEquals( $comments, wp_list_pluck( $found, 'comment_ID' ) );
+		$this->assertSameSetsWithIndex( $comments, wp_list_pluck( $found, 'comment_ID' ) );
 	}
 
 	/**
@@ -3048,10 +3050,12 @@ class Tests_Comment_Query extends WP_UnitTestCase {
 			)
 		);
 
+		$comments = array_map( 'strval', $comments );
+
 		// $comments is ASC by default.
 		rsort( $comments );
 
-		$this->assertEquals( $comments, wp_list_pluck( $found, 'comment_ID' ) );
+		$this->assertSameSetsWithIndex( $comments, wp_list_pluck( $found, 'comment_ID' ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/comment/query.php
+++ b/tests/phpunit/tests/comment/query.php
@@ -4021,7 +4021,7 @@ class Tests_Comment_Query extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertEquals( 3, $q->found_comments );
+		$this->assertSame( 3, $q->found_comments );
 		$this->assertEquals( 2, $q->max_num_pages );
 	}
 

--- a/tests/phpunit/tests/comment/wpComment.php
+++ b/tests/phpunit/tests/comment/wpComment.php
@@ -31,9 +31,10 @@ class Tests_Term_WpComment extends WP_UnitTestCase {
 	 * @ticket 37738
 	 */
 	public function test_get_instance_should_work_for_numeric_string() {
-		$found = WP_Comment::get_instance( (string) self::$comment_id );
+		$expected = (string) self::$comment_id;
+		$found    = WP_Comment::get_instance( $expected );
 
-		$this->assertEquals( self::$comment_id, $found->comment_ID );
+		$this->assertSame( $expected, $found->comment_ID );
 	}
 
 	/**
@@ -60,6 +61,6 @@ class Tests_Term_WpComment extends WP_UnitTestCase {
 	public function test_get_instance_should_succeed_for_float_that_is_equal_to_post_id() {
 		$found = WP_Comment::get_instance( 1.0 );
 
-		$this->assertEquals( 1, $found->comment_ID );
+		$this->assertSame( '1', $found->comment_ID );
 	}
 }

--- a/tests/phpunit/tests/cron.php
+++ b/tests/phpunit/tests/cron.php
@@ -576,7 +576,7 @@ class Tests_Cron extends WP_UnitTestCase {
 			'args'      => array(),
 		);
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertSimilarObject( $expected, $actual );
 		$this->assertSame( $expected->timestamp, $actual2 );
 	}
 
@@ -625,13 +625,13 @@ class Tests_Cron extends WP_UnitTestCase {
 		wp_schedule_single_event( $ts_next, $hook, $args );
 
 		// Late running, timestamp specified.
-		$this->assertEquals( $expected1, wp_get_scheduled_event( $hook, $args, $ts_late ) );
+		$this->assertSimilarObject( $expected1, wp_get_scheduled_event( $hook, $args, $ts_late ) );
 
 		// Next running, timestamp specified.
-		$this->assertEquals( $expected2, wp_get_scheduled_event( $hook, $args, $ts_next ) );
+		$this->assertSimilarObject( $expected2, wp_get_scheduled_event( $hook, $args, $ts_next ) );
 
 		// Next running, no timestamp specified.
-		$this->assertEquals( $expected2, wp_get_scheduled_event( $hook, $args ) );
+		$this->assertSimilarObject( $expected2, wp_get_scheduled_event( $hook, $args ) );
 	}
 
 	/**
@@ -674,13 +674,13 @@ class Tests_Cron extends WP_UnitTestCase {
 		wp_schedule_event( $ts_next, $schedule, $hook, $args );
 
 		// Late running, timestamp specified.
-		$this->assertEquals( $expected1, wp_get_scheduled_event( $hook, $args, $ts_late ) );
+		$this->assertSimilarObject( $expected1, wp_get_scheduled_event( $hook, $args, $ts_late ) );
 
 		// Next running, timestamp specified.
-		$this->assertEquals( $expected2, wp_get_scheduled_event( $hook, $args, $ts_next ) );
+		$this->assertSimilarObject( $expected2, wp_get_scheduled_event( $hook, $args, $ts_next ) );
 
 		// Next running, no timestamp specified.
-		$this->assertEquals( $expected2, wp_get_scheduled_event( $hook, $args ) );
+		$this->assertSimilarObject( $expected2, wp_get_scheduled_event( $hook, $args ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/customize/manager.php
+++ b/tests/phpunit/tests/customize/manager.php
@@ -2533,10 +2533,10 @@ class Tests_WP_Customize_Manager extends WP_UnitTestCase {
 		$this->assertSame( $default_value, $this->manager->post_value( $setting, $default_value ) );
 		$this->assertSame( $default_value, $setting->post_value( $default_value ) );
 
-		$post_value = '42';
-		$this->manager->set_post_value( 'numeric', $post_value );
-		$this->assertEquals( $post_value, $this->manager->post_value( $setting, $default_value ) );
-		$this->assertEquals( $post_value, $setting->post_value( $default_value ) );
+		$post_value = 42;
+		$this->manager->set_post_value( 'numeric', (string) $post_value );
+		$this->assertSame( $post_value, $this->manager->post_value( $setting, $default_value ) );
+		$this->assertSame( $post_value, $setting->post_value( $default_value ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/customize/nav-menu-item-setting.php
+++ b/tests/phpunit/tests/customize/nav-menu-item-setting.php
@@ -617,9 +617,9 @@ class Test_WP_Customize_Nav_Menu_Item_Setting extends WP_UnitTestCase {
 		$post          = get_post( $nav_menu_item_id );
 		$nav_menu_item = wp_setup_nav_menu_item( clone $post );
 
-		$this->assertEquals( $expected_sanitized['object_id'], $nav_menu_item->object_id );
+		$this->assertSame( (string) $expected_sanitized['object_id'], $nav_menu_item->object_id );
 		$this->assertSame( $expected_sanitized['object'], $nav_menu_item->object );
-		$this->assertEquals( $expected_sanitized['menu_item_parent'], $nav_menu_item->menu_item_parent );
+		$this->assertSame( (string) $expected_sanitized['menu_item_parent'], $nav_menu_item->menu_item_parent );
 		$this->assertSame( $expected_sanitized['position'], $post->menu_order );
 		$this->assertSame( $expected_sanitized['type'], $nav_menu_item->type );
 		$this->assertSame( $expected_sanitized['title'], $post->post_title );
@@ -683,7 +683,7 @@ class Test_WP_Customize_Nav_Menu_Item_Setting extends WP_UnitTestCase {
 		$post_value['post_status'] = $post_value['status'];
 		unset( $post_value['status'] );
 		foreach ( $post_value as $key => $value ) {
-			$this->assertEquals( $value, $updated_item->$key, "Key $key mismatch" );
+			$this->assertSame( (string) $value, $updated_item->$key, "Key $key mismatch" );
 		}
 
 		// Verify the Ajax responses is being amended.
@@ -756,7 +756,10 @@ class Test_WP_Customize_Nav_Menu_Item_Setting extends WP_UnitTestCase {
 		$post_value['menu_order'] = $post_value['position'];
 		unset( $post_value['position'] );
 		foreach ( $post_value as $key => $value ) {
-			$this->assertEquals( $value, $last_item->$key, "Mismatch for $key property." );
+			if ( is_string( $last_item->$key ) ) {
+				$value = (string) $value;
+			}
+			$this->assertSame( $value, $last_item->$key, "Mismatch for $key property." );
 		}
 
 		// Verify the Ajax responses is being amended.

--- a/tests/phpunit/tests/customize/nav-menu-item-setting.php
+++ b/tests/phpunit/tests/customize/nav-menu-item-setting.php
@@ -175,7 +175,7 @@ class Test_WP_Customize_Nav_Menu_Item_Setting extends WP_UnitTestCase {
 		$value = $setting->value();
 		$this->assertSame( $menu_item->title, $value['title'] );
 		$this->assertSame( $menu_item->type, $value['type'] );
-		$this->assertEquals( $menu_item->object_id, $value['object_id'] );
+		$this->assertSame( (int) $menu_item->object_id, $value['object_id'] );
 		$this->assertSame( $menu_id, $value['nav_menu_term_id'] );
 		$this->assertSame( 'Hello World', $value['original_title'] );
 
@@ -258,7 +258,7 @@ class Test_WP_Customize_Nav_Menu_Item_Setting extends WP_UnitTestCase {
 		$value = $setting->value();
 		$this->assertSame( $menu_item->title, $value['title'] );
 		$this->assertSame( $menu_item->type, $value['type'] );
-		$this->assertEquals( $menu_item->object_id, $value['object_id'] );
+		$this->assertSame( (int) $menu_item->object_id, $value['object_id'] );
 		$this->assertSame( $menu_id, $value['nav_menu_term_id'] );
 		$this->assertSame( 'Salutations', $value['original_title'] );
 	}

--- a/tests/phpunit/tests/customize/nav-menu-setting.php
+++ b/tests/phpunit/tests/customize/nav-menu-setting.php
@@ -216,7 +216,7 @@ class Test_WP_Customize_Nav_Menu_Setting extends WP_UnitTestCase {
 		$this->assertSameSets( $value, wp_array_slice_assoc( $term, array_keys( $value ) ) );
 
 		$menu_object = wp_get_nav_menu_object( $menu_id );
-		$this->assertEquals( (object) $term, $menu_object );
+		$this->assertSimilarObject( (object) $term, $menu_object );
 		$this->assertSame( $post_value['name'], $menu_object->name );
 
 		$nav_menu_options = get_option( 'nav_menu_options', array( 'auto_add' => array() ) );
@@ -261,7 +261,7 @@ class Test_WP_Customize_Nav_Menu_Setting extends WP_UnitTestCase {
 		$this->assertSame( $menu_id, $term['term_taxonomy_id'] );
 
 		$menu_object = wp_get_nav_menu_object( $menu_id );
-		$this->assertEquals( (object) $term, $menu_object );
+		$this->assertSimilarObject( (object) $term, $menu_object );
 		$this->assertSame( $post_value['name'], $menu_object->name );
 
 		$nav_menu_options = $this->get_nav_menu_items_option();

--- a/tests/phpunit/tests/customize/selective-refresh-ajax.php
+++ b/tests/phpunit/tests/customize/selective-refresh-ajax.php
@@ -188,8 +188,6 @@ class Test_WP_Customize_Selective_Refresh_Ajax extends WP_UnitTestCase {
 			)
 		);
 
-		$count_customize_render_partials_before = has_action( 'customize_render_partials_before' );
-		$count_customize_render_partials_after  = has_action( 'customize_render_partials_after' );
 		ob_start();
 		try {
 			$this->expected_partial_ids = array( 'foo' );
@@ -200,8 +198,8 @@ class Test_WP_Customize_Selective_Refresh_Ajax extends WP_UnitTestCase {
 		} catch ( WPDieException $e ) {
 			$this->assertSame( '', $e->getMessage() );
 		}
-		$this->assertEquals( $count_customize_render_partials_before + 1, has_action( 'customize_render_partials_before' ) );
-		$this->assertEquals( $count_customize_render_partials_after + 1, has_action( 'customize_render_partials_after' ) );
+		$this->assertTrue( has_action( 'customize_render_partials_before' ) );
+		$this->assertTrue( has_action( 'customize_render_partials_after' ) );
 		$output = json_decode( ob_get_clean(), true );
 		$this->assertSame( array( false ), $output['data']['contents']['foo'] );
 	}
@@ -326,8 +324,6 @@ class Test_WP_Customize_Selective_Refresh_Ajax extends WP_UnitTestCase {
 			)
 		);
 
-		$count_customize_render_partials_before = has_action( 'customize_render_partials_before' );
-		$count_customize_render_partials_after  = has_action( 'customize_render_partials_after' );
 		ob_start();
 		try {
 			$this->expected_partial_ids = array( 'test_blogname' );
@@ -338,8 +334,8 @@ class Test_WP_Customize_Selective_Refresh_Ajax extends WP_UnitTestCase {
 		} catch ( WPDieException $e ) {
 			$this->assertSame( '', $e->getMessage() );
 		}
-		$this->assertEquals( $count_customize_render_partials_before + 1, has_action( 'customize_render_partials_before' ) );
-		$this->assertEquals( $count_customize_render_partials_after + 1, has_action( 'customize_render_partials_after' ) );
+		$this->assertTrue( has_action( 'customize_render_partials_before' ) );
+		$this->assertTrue( has_action( 'customize_render_partials_after' ) );
 		$output = json_decode( ob_get_clean(), true );
 		$this->assertSame( array( get_bloginfo( 'name', 'display' ) ), $output['data']['contents']['test_blogname'] );
 		$this->assertArrayHasKey( 'setting_validities', $output['data'] );
@@ -435,8 +431,6 @@ class Test_WP_Customize_Selective_Refresh_Ajax extends WP_UnitTestCase {
 			)
 		);
 
-		$count_customize_render_partials_before = has_action( 'customize_render_partials_before' );
-		$count_customize_render_partials_after  = has_action( 'customize_render_partials_after' );
 		ob_start();
 		try {
 			$this->expected_partial_ids = array( 'test_dynamic_blogname' );
@@ -447,8 +441,8 @@ class Test_WP_Customize_Selective_Refresh_Ajax extends WP_UnitTestCase {
 		} catch ( WPDieException $e ) {
 			$this->assertSame( '', $e->getMessage() );
 		}
-		$this->assertEquals( $count_customize_render_partials_before + 1, has_action( 'customize_render_partials_before' ) );
-		$this->assertEquals( $count_customize_render_partials_after + 1, has_action( 'customize_render_partials_after' ) );
+		$this->assertTrue( has_action( 'customize_render_partials_before' ) );
+		$this->assertTrue( has_action( 'customize_render_partials_after' ) );
 		$output = json_decode( ob_get_clean(), true );
 		$this->assertSame( array( get_bloginfo( 'name', 'display' ) ), $output['data']['contents']['test_dynamic_blogname'] );
 	}
@@ -487,8 +481,6 @@ class Test_WP_Customize_Selective_Refresh_Ajax extends WP_UnitTestCase {
 			)
 		);
 
-		$count_customize_render_partials_before = has_action( 'customize_render_partials_before' );
-		$count_customize_render_partials_after  = has_action( 'customize_render_partials_after' );
 		ob_start();
 		try {
 			$this->expected_partial_ids = array( 'test_blogname', 'test_blogdescription' );
@@ -499,8 +491,8 @@ class Test_WP_Customize_Selective_Refresh_Ajax extends WP_UnitTestCase {
 		} catch ( WPDieException $e ) {
 			$this->assertSame( '', $e->getMessage() );
 		}
-		$this->assertEquals( $count_customize_render_partials_before + 1, has_action( 'customize_render_partials_before' ) );
-		$this->assertEquals( $count_customize_render_partials_after + 1, has_action( 'customize_render_partials_after' ) );
+		$this->assertTrue( has_action( 'customize_render_partials_before' ) );
+		$this->assertTrue( has_action( 'customize_render_partials_after' ) );
 		$output = json_decode( ob_get_clean(), true );
 		$this->assertSame( array( get_bloginfo( 'name', 'display' ) ), $output['data']['contents']['test_blogname'] );
 		$this->assertSame( array_fill( 0, 2, get_bloginfo( 'description', 'display' ) ), $output['data']['contents']['test_blogdescription'] );

--- a/tests/phpunit/tests/customize/widgets.php
+++ b/tests/phpunit/tests/customize/widgets.php
@@ -500,7 +500,7 @@ class Tests_WP_Customize_Widgets extends WP_UnitTestCase {
 		$this->assertSame( '', $sanitized_for_js['title'] );
 		$this->assertTrue( $sanitized_for_js['is_widget_customizer_js_value'] );
 		$this->assertArrayHasKey( 'instance_hash_key', $sanitized_for_js );
-		$this->assertEquals( (object) $block_instance, $sanitized_for_js['raw_instance'] );
+		$this->assertSimilarObject( (object) $block_instance, $sanitized_for_js['raw_instance'] );
 
 		$unsanitized_from_js = $this->manager->widgets->sanitize_widget_instance( $sanitized_for_js );
 		$this->assertSame( $unsanitized_from_js, $block_instance );

--- a/tests/phpunit/tests/dbdelta.php
+++ b/tests/phpunit/tests/dbdelta.php
@@ -358,7 +358,7 @@ class Tests_dbDelta extends WP_UnitTestCase {
 			$column => $value,
 		);
 
-		$this->assertEquals( $expected, $table_row );
+		$this->assertSimilarObject( $expected, $table_row );
 	}
 
 	/**

--- a/tests/phpunit/tests/feed/atom.php
+++ b/tests/phpunit/tests/feed/atom.php
@@ -286,7 +286,7 @@ class Tests_Feed_Atom extends WP_UnitTestCase {
 			foreach ( (array) $links as $link ) {
 				if ( 'enclosure' === $link['attributes']['rel'] ) {
 					$this->assertSame( $enclosures[ $i ]['expected']['href'], $link['attributes']['href'] );
-					$this->assertEquals( $enclosures[ $i ]['expected']['length'], $link['attributes']['length'] );
+					$this->assertSame( (string) $enclosures[ $i ]['expected']['length'], $link['attributes']['length'] );
 					$this->assertSame( $enclosures[ $i ]['expected']['type'], $link['attributes']['type'] );
 					$i++;
 				}

--- a/tests/phpunit/tests/formatting/mapDeep.php
+++ b/tests/phpunit/tests/formatting/mapDeep.php
@@ -49,7 +49,7 @@ class Tests_Formatting_MapDeep extends WP_UnitTestCase {
 	}
 
 	public function test_map_deep_should_map_each_object_element_of_an_array() {
-		$this->assertEquals(
+		$this->assertEqualSets(
 			array(
 				'var0' => 'ababa',
 				'var1' => (object) array(

--- a/tests/phpunit/tests/formatting/mapDeep.php
+++ b/tests/phpunit/tests/formatting/mapDeep.php
@@ -77,7 +77,7 @@ class Tests_Formatting_MapDeep extends WP_UnitTestCase {
 	}
 
 	public function test_map_deep_should_map_each_property_of_an_object() {
-		$this->assertEquals(
+		$this->assertSimilarObject(
 			(object) array(
 				'var0' => 'ababa',
 				'var1' => 'xbaba',
@@ -93,7 +93,7 @@ class Tests_Formatting_MapDeep extends WP_UnitTestCase {
 	}
 
 	public function test_map_deep_should_map_each_array_property_of_an_object() {
-		$this->assertEquals(
+		$this->assertSimilarObject(
 			(object) array(
 				'var0' => 'ababa',
 				'var1' => array(
@@ -113,7 +113,7 @@ class Tests_Formatting_MapDeep extends WP_UnitTestCase {
 	}
 
 	public function test_map_deep_should_map_each_object_property_of_an_object() {
-		$this->assertEquals(
+		$this->assertSimilarObject(
 			(object) array(
 				'var0' => 'ababa',
 				'var1' => (object) array(
@@ -141,7 +141,7 @@ class Tests_Formatting_MapDeep extends WP_UnitTestCase {
 			'var0' => &$object_a->var0,
 			'var1' => 'x',
 		);
-		$this->assertEquals(
+		$this->assertSimilarObject(
 			(object) array(
 				'var0' => 'ababa',
 				'var1' => 'xbaba',

--- a/tests/phpunit/tests/formatting/redirect.php
+++ b/tests/phpunit/tests/formatting/redirect.php
@@ -85,9 +85,12 @@ class Tests_Formatting_Redirect extends WP_UnitTestCase {
 	 * @dataProvider invalid_url_provider
 	 *
 	 * @covers ::wp_validate_redirect
+	 *
+	 * @param $url       The URL to test against.
+	 * @param $expected  Optional. The expected result. Default: false.
 	 */
-	public function test_wp_validate_redirect_invalid_url( $url ) {
-		$this->assertEquals( false, wp_validate_redirect( $url, false ) );
+	public function test_wp_validate_redirect_invalid_url( $url, $expected = false ) {
+		$this->assertSame( $expected, wp_validate_redirect( $url, false ) );
 	}
 
 	public function valid_url_provider() {
@@ -109,7 +112,7 @@ class Tests_Formatting_Redirect extends WP_UnitTestCase {
 	public function invalid_url_provider() {
 		return array(
 			// parse_url() fails.
-			array( '' ),
+			array( '', '' ),
 			array( 'http://:' ),
 
 			// Non-safelisted domain.

--- a/tests/phpunit/tests/formatting/stripslashesDeep.php
+++ b/tests/phpunit/tests/formatting/stripslashesDeep.php
@@ -45,7 +45,7 @@ class Tests_Formatting_StripslashesDeep extends WP_UnitTestCase {
 		$obj_old->a = $old;
 		$obj_new    = new stdClass;
 		$obj_new->a = $new;
-		$this->assertEquals( $obj_new, stripslashes_deep( $obj_old ) );
+		$this->assertSimilarObject( $obj_new, stripslashes_deep( $obj_old ) );
 	}
 
 	public function test_permits_escaped_slash() {

--- a/tests/phpunit/tests/functions.php
+++ b/tests/phpunit/tests/functions.php
@@ -1177,7 +1177,7 @@ class Tests_Functions extends WP_UnitTestCase {
 		$this->assertIsString( $date_return, 'The date return must be a string' );
 		$this->assertNotEmpty( $date_return, 'The date return could not be an empty string' );
 		$this->assertSame( $expected, $date_return, 'The date does not match' );
-		$this->assertEquals( new DateTime( $expected ), new DateTime( $date_return ), 'The date is not the same after the call method' );
+		$this->assertSimilarObject( new DateTime( $expected ), new DateTime( $date_return ), 'The date is not the same after the call method' );
 	}
 
 	public function datetime_provider() {
@@ -2072,7 +2072,7 @@ class Tests_Functions extends WP_UnitTestCase {
 	 */
 	function test_wp_filesize_with_nonexistent_file() {
 		$file = 'nonexistent/file.jpg';
-		$this->assertEquals( 0, wp_filesize( $file ) );
+		$this->assertSame( 0, wp_filesize( $file ) );
 	}
 
 	/**
@@ -2082,7 +2082,7 @@ class Tests_Functions extends WP_UnitTestCase {
 	function test_wp_filesize() {
 		$file = DIR_TESTDATA . '/images/test-image-upside-down.jpg';
 
-		$this->assertEquals( filesize( $file ), wp_filesize( $file ) );
+		$this->assertSame( filesize( $file ), wp_filesize( $file ) );
 
 		$filter = function() {
 			return 999;
@@ -2090,7 +2090,7 @@ class Tests_Functions extends WP_UnitTestCase {
 
 		add_filter( 'wp_filesize', $filter );
 
-		$this->assertEquals( 999, wp_filesize( $file ) );
+		$this->assertSame( 999, wp_filesize( $file ) );
 
 		$pre_filter = function() {
 			return 111;
@@ -2098,7 +2098,7 @@ class Tests_Functions extends WP_UnitTestCase {
 
 		add_filter( 'pre_wp_filesize', $pre_filter );
 
-		$this->assertEquals( 111, wp_filesize( $file ) );
+		$this->assertSame( 111, wp_filesize( $file ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/functions.php
+++ b/tests/phpunit/tests/functions.php
@@ -2184,7 +2184,7 @@ class Tests_Functions extends WP_UnitTestCase {
 			),
 			'version'  => 1,
 		);
-		$this->assertEquals( $theme_json, $expected_theme_json );
+		$this->assertSameSetsWithIndex( $theme_json, $expected_theme_json );
 	}
 
 }

--- a/tests/phpunit/tests/functions.php
+++ b/tests/phpunit/tests/functions.php
@@ -1244,7 +1244,7 @@ class Tests_Functions extends WP_UnitTestCase {
 
 		$this->assertSame( $ini_limit_before, $ini_limit_after );
 		$this->assertFalse( $raised_limit );
-		$this->assertEquals( WP_MAX_MEMORY_LIMIT, $ini_limit_after );
+		$this->assertSame( (string) WP_MAX_MEMORY_LIMIT, $ini_limit_after );
 	}
 
 	/**

--- a/tests/phpunit/tests/functions.php
+++ b/tests/phpunit/tests/functions.php
@@ -2056,9 +2056,9 @@ class Tests_Functions extends WP_UnitTestCase {
 	 * @ticket 53668
 	 */
 	public function test_wp_get_default_extension_for_mime_type() {
-		$this->assertEquals( 'jpg', wp_get_default_extension_for_mime_type( 'image/jpeg' ), 'jpg not returned as default extension for "image/jpeg"' );
+		$this->assertSame( 'jpg', wp_get_default_extension_for_mime_type( 'image/jpeg' ), 'jpg not returned as default extension for "image/jpeg"' );
 		$this->assertNotEquals( 'jpeg', wp_get_default_extension_for_mime_type( 'image/jpeg' ), 'jpeg should not be returned as default extension for "image/jpeg"' );
-		$this->assertEquals( 'png', wp_get_default_extension_for_mime_type( 'image/png' ), 'png not returned as default extension for "image/png"' );
+		$this->assertSame( 'png', wp_get_default_extension_for_mime_type( 'image/png' ), 'png not returned as default extension for "image/png"' );
 		$this->assertFalse( wp_get_default_extension_for_mime_type( 'wibble/wobble' ), 'false not returned for unrecognized mime type' );
 		$this->assertFalse( wp_get_default_extension_for_mime_type( '' ), 'false not returned when empty string as mime type supplied' );
 		$this->assertFalse( wp_get_default_extension_for_mime_type( '   ' ), 'false not returned when empty string as mime type supplied' );

--- a/tests/phpunit/tests/functions/maybeSerialize.php
+++ b/tests/phpunit/tests/functions/maybeSerialize.php
@@ -43,7 +43,7 @@ class Tests_Functions_MaybeSerialize extends WP_UnitTestCase {
 		}
 
 		if ( is_object( $expected ) ) {
-			$this->assertEquals( $expected, maybe_unserialize( $value ) );
+			$this->assertSimilarObject( $expected, maybe_unserialize( $value ) );
 		} else {
 			$this->assertSame( $expected, maybe_unserialize( $value ) );
 		}

--- a/tests/phpunit/tests/http/base.php
+++ b/tests/phpunit/tests/http/base.php
@@ -283,7 +283,7 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 		$this->skipTestOnTimeout( $res );
 		$this->assertNotWPError( $res );
 		$this->assertSame( '', $res['body'] ); // The body should be empty.
-		$this->assertEquals( $size, $res['headers']['content-length'] );   // Check the headers are returned (and the size is the same).
+		$this->assertSame( (string) $size, $res['headers']['content-length'] );   // Check the headers are returned (and the size is the same).
 		$this->assertSame( $size, $filesize ); // Check that the file is written to disk correctly without any extra characters.
 		$this->assertStringStartsWith( get_temp_dir(), $res['filename'] ); // Check it's saving within the temp directory.
 	}

--- a/tests/phpunit/tests/image/meta.php
+++ b/tests/phpunit/tests/image/meta.php
@@ -32,15 +32,15 @@ class Tests_Image_Meta extends WP_UnitTestCase {
 		// Exif from a Nikon D70.
 		$out = wp_read_image_metadata( DIR_TESTDATA . '/images/2004-07-22-DSC_0008.jpg' );
 
-		$this->assertEquals( 6.3, $out['aperture'], 'Aperture value not equivalent' );
+		$this->assertSame( '6.3', $out['aperture'], 'Aperture value not equivalent' );
 		$this->assertSame( '', $out['credit'], 'Credit value not the same' );
 		$this->assertSame( 'NIKON D70', $out['camera'], 'Camera value not the same' );
 		$this->assertSame( '', $out['caption'], 'Caption value not the same' );
-		$this->assertEquals( strtotime( '2004-07-22 17:14:59' ), $out['created_timestamp'], 'Timestamp value not equivalent' );
+		$this->assertSame( (string) strtotime( '2004-07-22 17:14:59' ), $out['created_timestamp'], 'Timestamp value not equivalent' );
 		$this->assertSame( '', $out['copyright'], 'Copyright value not the same' );
-		$this->assertEquals( 27, $out['focal_length'], 'Focal length value not equivalent' );
-		$this->assertEquals( 400, $out['iso'], 'Iso value not equivalent' );
-		$this->assertEquals( 1 / 40, $out['shutter_speed'], 'Shutter speed value not equivalent' );
+		$this->assertSame( '27', $out['focal_length'], 'Focal length value not equivalent' );
+		$this->assertSame( '400', $out['iso'], 'Iso value not equivalent' );
+		$this->assertSame( (string) ( 1 / 40 ), $out['shutter_speed'], 'Shutter speed value not equivalent' );
 		$this->assertSame( '', $out['title'], 'Title value not the same' );
 	}
 
@@ -52,11 +52,11 @@ class Tests_Image_Meta extends WP_UnitTestCase {
 		$this->assertSame( '', $out['credit'], 'Credit value not the same' );
 		$this->assertSame( 'NIKON D70', $out['camera'], 'Camera value not the same' );
 		$this->assertSame( '', $out['caption'], 'Caption value not the same' );
-		$this->assertEquals( strtotime( '2007-06-17 21:18:00' ), $out['created_timestamp'], 'Timestamp value not equivalent' );
+		$this->assertSame( (string) strtotime( '2007-06-17 21:18:00' ), $out['created_timestamp'], 'Timestamp value not equivalent' );
 		$this->assertSame( '', $out['copyright'], 'Copyright value not the same' );
-		$this->assertEquals( 0, $out['focal_length'], 'Focal length value not equivalent' );
-		$this->assertEquals( 0, $out['iso'], 'Iso value not equivalent' ); // Interesting - a Nikon bug?
-		$this->assertEquals( 1 / 500, $out['shutter_speed'], 'Shutter speed value not equivalent' );
+		$this->assertSame( '0', $out['focal_length'], 'Focal length value not equivalent' );
+		$this->assertSame( '0', $out['iso'], 'Iso value not equivalent' ); // Interesting - a Nikon bug?
+		$this->assertSame( (string) ( 1 / 500 ), $out['shutter_speed'], 'Shutter speed value not equivalent' );
 		$this->assertSame( '', $out['title'], 'Title value not the same' );
 		// $this->assertSame( array( 'Flowers' ), $out['keywords'] );
 	}
@@ -65,15 +65,15 @@ class Tests_Image_Meta extends WP_UnitTestCase {
 		// Exif from a Nikon D70 with IPTC data added later.
 		$out = wp_read_image_metadata( DIR_TESTDATA . '/images/2004-07-22-DSC_0007.jpg' );
 
-		$this->assertEquals( 6.3, $out['aperture'], 'Aperture value not equivalent' );
+		$this->assertSame( '6.3', $out['aperture'], 'Aperture value not equivalent' );
 		$this->assertSame( 'IPTC Creator', $out['credit'], 'Credit value not the same' );
 		$this->assertSame( 'NIKON D70', $out['camera'], 'Camera value not the same' );
 		$this->assertSame( 'IPTC Caption', $out['caption'], 'Caption value not the same' );
-		$this->assertEquals( strtotime( '2004-07-22 17:14:35' ), $out['created_timestamp'], 'Timestamp value not equivalent' );
+		$this->assertSame( (string) strtotime( '2004-07-22 17:14:35' ), $out['created_timestamp'], 'Timestamp value not equivalent' );
 		$this->assertSame( 'IPTC Copyright', $out['copyright'], 'Copyright value not the same' );
-		$this->assertEquals( 18, $out['focal_length'], 'Focal length value not equivalent' );
-		$this->assertEquals( 200, $out['iso'], 'Iso value not equivalent' );
-		$this->assertEquals( 1 / 25, $out['shutter_speed'], 'Shutter speed value not equivalent' );
+		$this->assertSame( '18', $out['focal_length'], 'Focal length value not equivalent' );
+		$this->assertSame( '200', $out['iso'], 'Iso value not equivalent' );
+		$this->assertSame( (string) ( 1 / 25 ), $out['shutter_speed'], 'Shutter speed value not equivalent' );
 		$this->assertSame( 'IPTC Headline', $out['title'], 'Title value not the same' );
 	}
 
@@ -81,15 +81,15 @@ class Tests_Image_Meta extends WP_UnitTestCase {
 		// Exif from a Fuji FinePix S5600 (thanks Mark).
 		$out = wp_read_image_metadata( DIR_TESTDATA . '/images/a2-small.jpg' );
 
-		$this->assertEquals( 4.5, $out['aperture'], 'Aperture value not equivalent' );
+		$this->assertSame( '4.5', $out['aperture'], 'Aperture value not equivalent' );
 		$this->assertSame( '', $out['credit'], 'Credit value not the same' );
 		$this->assertSame( 'FinePix S5600', $out['camera'], 'Camera value not the same' );
 		$this->assertSame( '', $out['caption'], 'Caption value not the same' );
-		$this->assertEquals( strtotime( '2007-09-03 10:17:03' ), $out['created_timestamp'], 'Timestamp value not equivalent' );
+		$this->assertSame( (string) strtotime( '2007-09-03 10:17:03' ), $out['created_timestamp'], 'Timestamp value not equivalent' );
 		$this->assertSame( '', $out['copyright'], 'Copyright value not the same' );
-		$this->assertEquals( 6.3, $out['focal_length'], 'Focal length value not equivalent' );
-		$this->assertEquals( 64, $out['iso'], 'Iso value not equivalent' );
-		$this->assertEquals( 1 / 320, $out['shutter_speed'], 'Shutter speed value not equivalent' );
+		$this->assertSame( '6.3', $out['focal_length'], 'Focal length value not equivalent' );
+		$this->assertSame( '64', $out['iso'], 'Iso value not equivalent' );
+		$this->assertSame( (string) ( 1 / 320 ), $out['shutter_speed'], 'Shutter speed value not equivalent' );
 		$this->assertSame( '', $out['title'], 'Title value not the same' );
 	}
 
@@ -101,15 +101,15 @@ class Tests_Image_Meta extends WP_UnitTestCase {
 		// This triggers a warning mesage when reading the Exif block.
 		$out = wp_read_image_metadata( DIR_TESTDATA . '/images/waffles.jpg' );
 
-		$this->assertEquals( 0, $out['aperture'], 'Aperture value not equivalent' );
+		$this->assertSame( '0', $out['aperture'], 'Aperture value not equivalent' );
 		$this->assertSame( '', $out['credit'], 'Credit value not the same' );
 		$this->assertSame( '', $out['camera'], 'Camera value not the same' );
 		$this->assertSame( '', $out['caption'], 'Caption value not the same' );
-		$this->assertEquals( 0, $out['created_timestamp'], 'Timestamp value not equivalent' );
+		$this->assertSame( '0', $out['created_timestamp'], 'Timestamp value not equivalent' );
 		$this->assertSame( '', $out['copyright'], 'Copyright value not the same' );
-		$this->assertEquals( 0, $out['focal_length'], 'Focal length value not equivalent' );
-		$this->assertEquals( 0, $out['iso'], 'Iso value not equivalent' );
-		$this->assertEquals( 0, $out['shutter_speed'], 'Shutter speed value not equivalent' );
+		$this->assertSame( '0', $out['focal_length'], 'Focal length value not equivalent' );
+		$this->assertSame( '0', $out['iso'], 'Iso value not equivalent' );
+		$this->assertSame( '0', $out['shutter_speed'], 'Shutter speed value not equivalent' );
 		$this->assertSame( '', $out['title'], 'Title value not the same' );
 	}
 
@@ -117,15 +117,15 @@ class Tests_Image_Meta extends WP_UnitTestCase {
 		// No Exif data in this image (from burningwell.org).
 		$out = wp_read_image_metadata( DIR_TESTDATA . '/images/canola.jpg' );
 
-		$this->assertEquals( 0, $out['aperture'], 'Aperture value not equivalent' );
+		$this->assertSame( '0', $out['aperture'], 'Aperture value not equivalent' );
 		$this->assertSame( '', $out['credit'], 'Credit value not the same' );
 		$this->assertSame( '', $out['camera'], 'Camera value not the same' );
 		$this->assertSame( '', $out['caption'], 'Caption value not the same' );
-		$this->assertEquals( 0, $out['created_timestamp'], 'Timestamp value not equivalent' );
+		$this->assertSame( '0', $out['created_timestamp'], 'Timestamp value not equivalent' );
 		$this->assertSame( '', $out['copyright'], 'Copyright value not the same' );
-		$this->assertEquals( 0, $out['focal_length'], 'Focal length value not equivalent' );
-		$this->assertEquals( 0, $out['iso'], 'Iso value not equivalent' );
-		$this->assertEquals( 0, $out['shutter_speed'], 'Shutter speed value not equivalent' );
+		$this->assertSame( '0', $out['focal_length'], 'Focal length value not equivalent' );
+		$this->assertSame( '0', $out['iso'], 'Iso value not equivalent' );
+		$this->assertSame( '0', $out['shutter_speed'], 'Shutter speed value not equivalent' );
 		$this->assertSame( '', $out['title'], 'Title value not the same' );
 	}
 
@@ -158,13 +158,13 @@ class Tests_Image_Meta extends WP_UnitTestCase {
 		$this->assertSame( 'Photoshop Author', $out['credit'], 'Credit value not the same' );
 		$this->assertSame( 'DMC-LX2', $out['camera'], 'Camera value not the same' );
 		$this->assertSame( 'Photoshop Description', $out['caption'], 'Caption value not the same' );
-		$this->assertEquals( 1306315327, $out['created_timestamp'], 'Timestamp value not equivalent' );
+		$this->assertSame( '1306315327', $out['created_timestamp'], 'Timestamp value not equivalent' );
 		$this->assertSame( 'Photoshop Copyrright Notice', $out['copyright'], 'Copyright value not the same' );
 		$this->assertSame( '6.3', $out['focal_length'], 'Focal length value not the same' );
 		$this->assertSame( '100', $out['iso'], 'Iso value not the same' );
 		$this->assertSame( '0.0025', $out['shutter_speed'], 'Shutter speed value not the same' );
 		$this->assertSame( 'Photoshop Document Ttitle', $out['title'], 'Title value not the same' );
-		$this->assertEquals( 1, $out['orientation'], 'Orientation value not equivalent' );
+		$this->assertSame( '1', $out['orientation'], 'Orientation value not equivalent' );
 		$this->assertSame( array( 'beach', 'baywatch', 'LA', 'sunset' ), $out['keywords'], 'Keywords not the same' );
 	}
 
@@ -246,15 +246,15 @@ class Tests_Image_Meta extends WP_UnitTestCase {
 		// Unexpected Exif data: FNumber is "0/0", aperture should be 0.
 		$out = wp_read_image_metadata( DIR_TESTDATA . '/images/sugarloaf-mountain.jpg' );
 
-		$this->assertEquals( 0, $out['aperture'], 'Aperture value not equivalent' );
+		$this->assertSame( '0', $out['aperture'], 'Aperture value not equivalent' );
 		$this->assertSame( '', $out['credit'], 'Credit value not the same' );
 		$this->assertSame( 'X-T1', $out['camera'], 'Camera value not the same' );
 		$this->assertSame( '', $out['caption'], 'Caption value not the same' );
-		$this->assertEquals( 0, $out['created_timestamp'], 'Timestamp value not equivalent' );
+		$this->assertSame( '0', $out['created_timestamp'], 'Timestamp value not equivalent' );
 		$this->assertSame( '', $out['copyright'], 'Copyright value not the same' );
-		$this->assertEquals( 50, $out['focal_length'], 'Focal length value not equivalent' );
-		$this->assertEquals( 200, $out['iso'], 'Iso value not equivalent' );
-		$this->assertEquals( 2, $out['shutter_speed'], 'Shutter speed value not equivalent' );
+		$this->assertSame( '50', $out['focal_length'], 'Focal length value not equivalent' );
+		$this->assertSame( '200', $out['iso'], 'Iso value not equivalent' );
+		$this->assertSame( '2', $out['shutter_speed'], 'Shutter speed value not equivalent' );
 		$this->assertSame( 'Sugarloaf Panorama', $out['title'], 'Title value not the same' );
 	}
 }

--- a/tests/phpunit/tests/import/import.php
+++ b/tests/phpunit/tests/import/import.php
@@ -62,8 +62,8 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 		$this->assertSame( 'author@example.org', $author->user_email );
 
 		// Check that terms were imported correctly.
-		$this->assertEquals( 30, wp_count_terms( array( 'taxonomy' => 'category' ) ) );
-		$this->assertEquals( 3, wp_count_terms( array( 'taxonomy' => 'post_tag' ) ) );
+		$this->assertSame( '30', wp_count_terms( array( 'taxonomy' => 'category' ) ) );
+		$this->assertSame( '3', wp_count_terms( array( 'taxonomy' => 'post_tag' ) ) );
 		$foo = get_term_by( 'slug', 'foo', 'category' );
 		$this->assertSame( 0, $foo->parent );
 		$bar     = get_term_by( 'slug', 'bar', 'category' );
@@ -72,11 +72,11 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 
 		// Check that posts/pages were imported correctly.
 		$post_count = wp_count_posts( 'post' );
-		$this->assertEquals( 5, $post_count->publish );
-		$this->assertEquals( 1, $post_count->private );
+		$this->assertSame( '5', $post_count->publish );
+		$this->assertSame( '1', $post_count->private );
 		$page_count = wp_count_posts( 'page' );
-		$this->assertEquals( 4, $page_count->publish );
-		$this->assertEquals( 1, $page_count->draft );
+		$this->assertSame( '4', $page_count->publish );
+		$this->assertSame( '1', $page_count->draft );
 		$comment_count = wp_count_comments();
 		$this->assertSame( 1, $comment_count->total_comments );
 
@@ -93,7 +93,7 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 		$post = $posts[0];
 		$this->assertSame( 'Many Categories', $post->post_title );
 		$this->assertSame( 'many-categories', $post->post_name );
-		$this->assertEquals( $admin->ID, $post->post_author );
+		$this->assertSame( (string) $admin->ID, $post->post_author );
 		$this->assertSame( 'post', $post->post_type );
 		$this->assertSame( 'publish', $post->post_status );
 		$this->assertSame( 0, $post->post_parent );
@@ -103,7 +103,7 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 		$post = $posts[1];
 		$this->assertSame( 'Non-standard post format', $post->post_title );
 		$this->assertSame( 'non-standard-post-format', $post->post_name );
-		$this->assertEquals( $admin->ID, $post->post_author );
+		$this->assertSame( (string) $admin->ID, $post->post_author );
 		$this->assertSame( 'post', $post->post_type );
 		$this->assertSame( 'publish', $post->post_status );
 		$this->assertSame( 0, $post->post_parent );
@@ -114,7 +114,7 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 		$post = $posts[2];
 		$this->assertSame( 'Top-level Foo', $post->post_title );
 		$this->assertSame( 'top-level-foo', $post->post_name );
-		$this->assertEquals( $admin->ID, $post->post_author );
+		$this->assertSame( (string) $admin->ID, $post->post_author );
 		$this->assertSame( 'post', $post->post_type );
 		$this->assertSame( 'publish', $post->post_status );
 		$this->assertSame( 0, $post->post_parent );
@@ -125,7 +125,7 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 		$post = $posts[3];
 		$this->assertSame( 'Foo-child', $post->post_title );
 		$this->assertSame( 'foo-child', $post->post_name );
-		$this->assertEquals( $editor->ID, $post->post_author );
+		$this->assertSame( (string) $editor->ID, $post->post_author );
 		$this->assertSame( 'post', $post->post_type );
 		$this->assertSame( 'publish', $post->post_status );
 		$this->assertSame( 0, $post->post_parent );
@@ -136,7 +136,7 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 		$post = $posts[4];
 		$this->assertSame( 'Private Post', $post->post_title );
 		$this->assertSame( 'private-post', $post->post_name );
-		$this->assertEquals( $admin->ID, $post->post_author );
+		$this->assertSame( (string) $admin->ID, $post->post_author );
 		$this->assertSame( 'post', $post->post_type );
 		$this->assertSame( 'private', $post->post_status );
 		$this->assertSame( 0, $post->post_parent );
@@ -151,7 +151,7 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 		$post = $posts[5];
 		$this->assertSame( '1-col page', $post->post_title );
 		$this->assertSame( '1-col-page', $post->post_name );
-		$this->assertEquals( $admin->ID, $post->post_author );
+		$this->assertSame( (string) $admin->ID, $post->post_author );
 		$this->assertSame( 'page', $post->post_type );
 		$this->assertSame( 'publish', $post->post_status );
 		$this->assertSame( 0, $post->post_parent );
@@ -160,7 +160,7 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 		$post = $posts[6];
 		$this->assertSame( 'Draft Page', $post->post_title );
 		$this->assertSame( '', $post->post_name );
-		$this->assertEquals( $admin->ID, $post->post_author );
+		$this->assertSame( (string) $admin->ID, $post->post_author );
 		$this->assertSame( 'page', $post->post_type );
 		$this->assertSame( 'draft', $post->post_status );
 		$this->assertSame( 0, $post->post_parent );
@@ -169,7 +169,7 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 		$post = $posts[7];
 		$this->assertSame( 'Parent Page', $post->post_title );
 		$this->assertSame( 'parent-page', $post->post_name );
-		$this->assertEquals( $admin->ID, $post->post_author );
+		$this->assertSame( (string) $admin->ID, $post->post_author );
 		$this->assertSame( 'page', $post->post_type );
 		$this->assertSame( 'publish', $post->post_status );
 		$this->assertSame( 0, $post->post_parent );
@@ -178,7 +178,7 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 		$post = $posts[8];
 		$this->assertSame( 'Child Page', $post->post_title );
 		$this->assertSame( 'child-page', $post->post_name );
-		$this->assertEquals( $admin->ID, $post->post_author );
+		$this->assertSame( (string) $admin->ID, $post->post_author );
 		$this->assertSame( 'page', $post->post_type );
 		$this->assertSame( 'publish', $post->post_status );
 		$this->assertSame( $posts[7]->ID, $post->post_parent );
@@ -187,7 +187,7 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 		$post = $posts[9];
 		$this->assertSame( 'Sample Page', $post->post_title );
 		$this->assertSame( 'sample-page', $post->post_name );
-		$this->assertEquals( $admin->ID, $post->post_author );
+		$this->assertSame( (string) $admin->ID, $post->post_author );
 		$this->assertSame( 'page', $post->post_type );
 		$this->assertSame( 'publish', $post->post_status );
 		$this->assertSame( 0, $post->post_parent );
@@ -196,7 +196,7 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 		$post = $posts[10];
 		$this->assertSame( 'Hello world!', $post->post_title );
 		$this->assertSame( 'hello-world', $post->post_name );
-		$this->assertEquals( $author->ID, $post->post_author );
+		$this->assertSame( (string) $author->ID, $post->post_author );
 		$this->assertSame( 'post', $post->post_type );
 		$this->assertSame( 'publish', $post->post_status );
 		$this->assertSame( 0, $post->post_parent );
@@ -230,8 +230,8 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 		$this->assertSame( 'author', $author->user_login );
 		$this->assertSame( 'author@example.org', $author->user_email );
 
-		$this->assertEquals( 30, wp_count_terms( array( 'taxonomy' => 'category' ) ) );
-		$this->assertEquals( 3, wp_count_terms( array( 'taxonomy' => 'post_tag' ) ) );
+		$this->assertSame( '30', wp_count_terms( array( 'taxonomy' => 'category' ) ) );
+		$this->assertSame( '3', wp_count_terms( array( 'taxonomy' => 'post_tag' ) ) );
 		$foo = get_term_by( 'slug', 'foo', 'category' );
 		$this->assertSame( 0, $foo->parent );
 		$bar     = get_term_by( 'slug', 'bar', 'category' );
@@ -239,11 +239,11 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 		$this->assertSame( $bar->term_id, $foo_bar->parent );
 
 		$post_count = wp_count_posts( 'post' );
-		$this->assertEquals( 5, $post_count->publish );
-		$this->assertEquals( 1, $post_count->private );
+		$this->assertSame( '5', $post_count->publish );
+		$this->assertSame( '1', $post_count->private );
 		$page_count = wp_count_posts( 'page' );
-		$this->assertEquals( 4, $page_count->publish );
-		$this->assertEquals( 1, $page_count->draft );
+		$this->assertSame( '4', $page_count->publish );
+		$this->assertSame( '1', $page_count->draft );
 		$comment_count = wp_count_comments();
 		$this->assertSame( 1, $comment_count->total_comments );
 	}

--- a/tests/phpunit/tests/import/parser.php
+++ b/tests/phpunit/tests/import/parser.php
@@ -74,7 +74,7 @@ class Tests_Import_Parser extends WP_Import_UnitTestCase {
 
 			$this->assertIsArray( $result, $message );
 			$this->assertSame( 'http://localhost/', $result['base_url'], $message );
-			$this->assertEquals(
+			$this->assertEqualSetsWithIndex(
 				array(
 					'author_id'           => 2,
 					'author_login'        => 'john',
@@ -86,7 +86,7 @@ class Tests_Import_Parser extends WP_Import_UnitTestCase {
 				$result['authors']['john'],
 				$message
 			);
-			$this->assertEquals(
+			$this->assertEqualSetsWithIndex(
 				array(
 					'term_id'              => 3,
 					'category_nicename'    => 'alpha',
@@ -97,7 +97,7 @@ class Tests_Import_Parser extends WP_Import_UnitTestCase {
 				$result['categories'][0],
 				$message
 			);
-			$this->assertEquals(
+			$this->assertEqualSetsWithIndex(
 				array(
 					'term_id'         => 22,
 					'tag_slug'        => 'clippable',
@@ -107,7 +107,7 @@ class Tests_Import_Parser extends WP_Import_UnitTestCase {
 				$result['tags'][0],
 				$message
 			);
-			$this->assertEquals(
+			$this->assertEqualSetsWithIndex(
 				array(
 					'term_id'          => 40,
 					'term_taxonomy'    => 'post_tax',
@@ -123,7 +123,7 @@ class Tests_Import_Parser extends WP_Import_UnitTestCase {
 			$this->assertCount( 2, $result['posts'], $message );
 			$this->assertCount( 19, $result['posts'][0], $message );
 			$this->assertCount( 18, $result['posts'][1], $message );
-			$this->assertEquals(
+			$this->assertEqualSetsWithIndex(
 				array(
 					array(
 						'name'   => 'alpha',

--- a/tests/phpunit/tests/import/postmeta.php
+++ b/tests/phpunit/tests/import/postmeta.php
@@ -76,7 +76,7 @@ class Tests_Import_Postmeta extends WP_Import_UnitTestCase {
 		$classy->tag = 'wscript';
 		$expected[]  = $classy;
 
-		$this->assertEquals( $expected, get_post_meta( 150, 'test', true ) );
+		$this->assertArrayEqualsWithObject( $expected, get_post_meta( 150, 'test', true ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/import/postmeta.php
+++ b/tests/phpunit/tests/import/postmeta.php
@@ -76,7 +76,7 @@ class Tests_Import_Postmeta extends WP_Import_UnitTestCase {
 		$classy->tag = 'wscript';
 		$expected[]  = $classy;
 
-		$this->assertArrayEqualsWithObject( $expected, get_post_meta( 150, 'test', true ) );
+		$this->assertEqualSets( $expected, get_post_meta( 150, 'test', true ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/link/getAdjacentPost.php
+++ b/tests/phpunit/tests/link/getAdjacentPost.php
@@ -70,20 +70,20 @@ class Tests_Link_GetAdjacentPost extends WP_UnitTestCase {
 		// Test normal boundary post.
 		$this->go_to( get_permalink( $post_two->ID ) );
 
-		$this->assertSimilarObject( array( $post_one ), get_boundary_post( false, '', true ) );
-		$this->assertSimilarObject( array( $post_four ), get_boundary_post( false, '', false ) );
+		$this->assertEqualSets( array( $post_one ), get_boundary_post( false, '', true ) );
+		$this->assertEqualSets( array( $post_four ), get_boundary_post( false, '', false ) );
 
 		// Test category boundary post.
 		$this->go_to( get_permalink( $post_one->ID ) );
 
-		$this->assertSimilarObject( array( $post_one ), get_boundary_post( true, '', true, 'category' ) );
-		$this->assertSimilarObject( array( $post_three ), get_boundary_post( true, '', false, 'category' ) );
+		$this->assertEqualSets( array( $post_one ), get_boundary_post( true, '', true, 'category' ) );
+		$this->assertEqualSets( array( $post_three ), get_boundary_post( true, '', false, 'category' ) );
 
 		// Test tag boundary post.
 		$this->go_to( get_permalink( $post_two->ID ) );
 
-		$this->assertSimilarObject( array( $post_two ), get_boundary_post( true, '', true, 'post_tag' ) );
-		$this->assertSimilarObject( array( $post_four ), get_boundary_post( true, '', false, 'post_tag' ) );
+		$this->assertEqualSets( array( $post_two ), get_boundary_post( true, '', true, 'post_tag' ) );
+		$this->assertEqualSets( array( $post_four ), get_boundary_post( true, '', false, 'post_tag' ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/link/getAdjacentPost.php
+++ b/tests/phpunit/tests/link/getAdjacentPost.php
@@ -49,8 +49,8 @@ class Tests_Link_GetAdjacentPost extends WP_UnitTestCase {
 		// Test normal post adjacency.
 		$this->go_to( get_permalink( $post_two->ID ) );
 
-		$this->assertEquals( $post_one, get_adjacent_post( false, '', true ) );
-		$this->assertEquals( $post_three, get_adjacent_post( false, '', false ) );
+		$this->assertSimilarObject( $post_one, get_adjacent_post( false, '', true ) );
+		$this->assertSimilarObject( $post_three, get_adjacent_post( false, '', false ) );
 
 		$this->assertNotEquals( $post_two, get_adjacent_post( false, '', true ) );
 		$this->assertNotEquals( $post_two, get_adjacent_post( false, '', false ) );
@@ -59,31 +59,31 @@ class Tests_Link_GetAdjacentPost extends WP_UnitTestCase {
 		$this->go_to( get_permalink( $post_one->ID ) );
 
 		$this->assertSame( '', get_adjacent_post( true, '', true, 'category' ) );
-		$this->assertEquals( $post_three, get_adjacent_post( true, '', false, 'category' ) );
+		$this->assertSimilarObject( $post_three, get_adjacent_post( true, '', false, 'category' ) );
 
 		// Test tag adjacency.
 		$this->go_to( get_permalink( $post_two->ID ) );
 
 		$this->assertSame( '', get_adjacent_post( true, '', true, 'post_tag' ) );
-		$this->assertEquals( $post_four, get_adjacent_post( true, '', false, 'post_tag' ) );
+		$this->assertSimilarObject( $post_four, get_adjacent_post( true, '', false, 'post_tag' ) );
 
 		// Test normal boundary post.
 		$this->go_to( get_permalink( $post_two->ID ) );
 
-		$this->assertEquals( array( $post_one ), get_boundary_post( false, '', true ) );
-		$this->assertEquals( array( $post_four ), get_boundary_post( false, '', false ) );
+		$this->assertSimilarObject( array( $post_one ), get_boundary_post( false, '', true ) );
+		$this->assertSimilarObject( array( $post_four ), get_boundary_post( false, '', false ) );
 
 		// Test category boundary post.
 		$this->go_to( get_permalink( $post_one->ID ) );
 
-		$this->assertEquals( array( $post_one ), get_boundary_post( true, '', true, 'category' ) );
-		$this->assertEquals( array( $post_three ), get_boundary_post( true, '', false, 'category' ) );
+		$this->assertSimilarObject( array( $post_one ), get_boundary_post( true, '', true, 'category' ) );
+		$this->assertSimilarObject( array( $post_three ), get_boundary_post( true, '', false, 'category' ) );
 
 		// Test tag boundary post.
 		$this->go_to( get_permalink( $post_two->ID ) );
 
-		$this->assertEquals( array( $post_two ), get_boundary_post( true, '', true, 'post_tag' ) );
-		$this->assertEquals( array( $post_four ), get_boundary_post( true, '', false, 'post_tag' ) );
+		$this->assertSimilarObject( array( $post_two ), get_boundary_post( true, '', true, 'post_tag' ) );
+		$this->assertSimilarObject( array( $post_four ), get_boundary_post( true, '', false, 'post_tag' ) );
 	}
 
 	/**
@@ -146,30 +146,30 @@ class Tests_Link_GetAdjacentPost extends WP_UnitTestCase {
 
 		// First post.
 		$this->go_to( get_permalink( $one ) );
-		$this->assertEquals( $two, get_adjacent_post( false, array(), false ) );
-		$this->assertEquals( $three, get_adjacent_post( true, array(), false ) );
-		$this->assertEquals( $two, get_adjacent_post( false, array( $exclude ), false ) );
-		$this->assertEquals( $four, get_adjacent_post( true, array( $exclude ), false ) );
+		$this->assertSimilarObject( $two, get_adjacent_post( false, array(), false ) );
+		$this->assertSimilarObject( $three, get_adjacent_post( true, array(), false ) );
+		$this->assertSimilarObject( $two, get_adjacent_post( false, array( $exclude ), false ) );
+		$this->assertSimilarObject( $four, get_adjacent_post( true, array( $exclude ), false ) );
 		$this->assertEmpty( get_adjacent_post( false, array(), true ) );
 
 		// Fourth post.
 		$this->go_to( get_permalink( $four ) );
-		$this->assertEquals( $five, get_adjacent_post( false, array(), false ) );
-		$this->assertEquals( $five, get_adjacent_post( true, array(), false ) );
+		$this->assertSimilarObject( $five, get_adjacent_post( false, array(), false ) );
+		$this->assertSimilarObject( $five, get_adjacent_post( true, array(), false ) );
 		$this->assertEmpty( get_adjacent_post( false, array( $exclude ), false ) );
 		$this->assertEmpty( get_adjacent_post( true, array( $exclude ), false ) );
 
-		$this->assertEquals( $three, get_adjacent_post( false, array(), true ) );
-		$this->assertEquals( $three, get_adjacent_post( true, array(), true ) );
-		$this->assertEquals( $two, get_adjacent_post( false, array( $exclude ), true ) );
+		$this->assertSimilarObject( $three, get_adjacent_post( false, array(), true ) );
+		$this->assertSimilarObject( $three, get_adjacent_post( true, array(), true ) );
+		$this->assertSimilarObject( $two, get_adjacent_post( false, array( $exclude ), true ) );
 		$this->assertEmpty( get_adjacent_post( true, array( $exclude ), true ) );
 
 		// Last post.
 		$this->go_to( get_permalink( $five ) );
-		$this->assertEquals( $four, get_adjacent_post( false, array(), true ) );
-		$this->assertEquals( $four, get_adjacent_post( true, array(), true ) );
-		$this->assertEquals( $four, get_adjacent_post( false, array( $exclude ), true ) );
-		$this->assertEquals( $four, get_adjacent_post( true, array( $exclude ), true ) );
+		$this->assertSimilarObject( $four, get_adjacent_post( false, array(), true ) );
+		$this->assertSimilarObject( $four, get_adjacent_post( true, array(), true ) );
+		$this->assertSimilarObject( $four, get_adjacent_post( false, array( $exclude ), true ) );
+		$this->assertSimilarObject( $four, get_adjacent_post( true, array( $exclude ), true ) );
 		$this->assertEmpty( get_adjacent_post( false, array(), false ) );
 	}
 

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -501,7 +501,7 @@ https://w.org</a>',
 		);
 
 		$images = get_attached_media( 'image', $post_id );
-		$this->assertArrayEqualsWithObject( $images, array( $attachment_id => get_post( $attachment_id ) ) );
+		$this->assertEqualSets( $images, array( $attachment_id => get_post( $attachment_id ) ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -501,7 +501,7 @@ https://w.org</a>',
 		);
 
 		$images = get_attached_media( 'image', $post_id );
-		$this->assertEquals( $images, array( $attachment_id => get_post( $attachment_id ) ) );
+		$this->assertArrayEqualsWithObject( $images, array( $attachment_id => get_post( $attachment_id ) ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/multisite/bootstrap.php
+++ b/tests/phpunit/tests/multisite/bootstrap.php
@@ -207,7 +207,7 @@ if ( is_multisite() ) :
 			$site = get_site_by_path( $domain, $path, $segments );
 
 			if ( $expected_key ) {
-				$this->assertEquals( self::$site_ids[ $expected_key ], $site->blog_id );
+				$this->assertSame( (string) self::$site_ids[ $expected_key ], $site->blog_id );
 			} else {
 				$this->assertFalse( $site );
 			}

--- a/tests/phpunit/tests/multisite/getBlogDetails.php
+++ b/tests/phpunit/tests/multisite/getBlogDetails.php
@@ -61,7 +61,7 @@ if ( is_multisite() ) :
 			}
 
 			$site = get_blog_details( 'foo' );
-			$this->assertEquals( self::$site_ids[ 'foo.' . WP_TESTS_DOMAIN . '/' ], $site->blog_id );
+			$this->assertSame( self::$site_ids[ 'foo.' . WP_TESTS_DOMAIN . '/' ], $site->blog_id );
 		}
 
 		public function test_get_blog_details_with_invalid_site_name_string() {

--- a/tests/phpunit/tests/multisite/getBlogDetails.php
+++ b/tests/phpunit/tests/multisite/getBlogDetails.php
@@ -43,7 +43,7 @@ if ( is_multisite() ) :
 
 		public function test_get_blog_details_with_no_arguments_returns_current_site() {
 			$site = get_blog_details();
-			$this->assertEquals( get_current_blog_id(), $site->blog_id );
+			$this->assertSame( (string) get_current_blog_id(), $site->blog_id );
 		}
 
 		public function test_get_blog_details_with_site_name_string_subdirectory() {
@@ -52,7 +52,7 @@ if ( is_multisite() ) :
 			}
 
 			$site = get_blog_details( 'foo' );
-			$this->assertEquals( self::$site_ids[ WP_TESTS_DOMAIN . '/foo/' ], $site->blog_id );
+			$this->assertSame( (string) self::$site_ids[ WP_TESTS_DOMAIN . '/foo/' ], $site->blog_id );
 		}
 
 		public function test_get_blog_details_with_site_name_string_subdomain() {
@@ -71,7 +71,7 @@ if ( is_multisite() ) :
 
 		public function test_get_blog_details_with_site_id_int() {
 			$site = get_blog_details( self::$site_ids['wordpress.org/'] );
-			$this->assertEquals( self::$site_ids['wordpress.org/'], $site->blog_id );
+			$this->assertSame( (string) self::$site_ids['wordpress.org/'], $site->blog_id );
 		}
 
 		public function test_get_blog_details_with_invalid_site_id_int() {
@@ -81,7 +81,7 @@ if ( is_multisite() ) :
 
 		public function test_get_blog_details_with_blog_id_in_fields() {
 			$site = get_blog_details( array( 'blog_id' => self::$site_ids['wordpress.org/'] ) );
-			$this->assertEquals( self::$site_ids['wordpress.org/'], $site->blog_id );
+			$this->assertSame( (string) self::$site_ids['wordpress.org/'], $site->blog_id );
 		}
 
 		public function test_get_blog_details_with_invalid_blog_id_in_fields() {
@@ -96,7 +96,7 @@ if ( is_multisite() ) :
 					'path'   => '/',
 				)
 			);
-			$this->assertEquals( self::$site_ids['wordpress.org/'], $site->blog_id );
+			$this->assertSame( (string) self::$site_ids['wordpress.org/'], $site->blog_id );
 		}
 
 		public function test_get_blog_details_with_domain_and_invalid_path_in_fields() {

--- a/tests/phpunit/tests/multisite/network.php
+++ b/tests/phpunit/tests/multisite/network.php
@@ -202,10 +202,8 @@ if ( is_multisite() ) :
 
 			$site_count = get_blog_count( self::$different_network_id );
 
-			$this->assertEquals( count( self::$different_site_ids ), $site_count );
+			$this->assertSame( count( self::$different_site_ids ), $site_count );
 		}
-
-
 
 		public function test_active_network_plugins() {
 			$path = 'hello.php';
@@ -287,7 +285,7 @@ if ( is_multisite() ) :
 		public function test_get_dashboard_blog() {
 			// If there is no dashboard blog set, current blog is used.
 			$dashboard_blog = get_dashboard_blog();
-			$this->assertEquals( 1, $dashboard_blog->blog_id );
+			$this->assertSame( '1', $dashboard_blog->blog_id );
 
 			$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
 			$blog_id = self::factory()->blog->create( array( 'user_id' => $user_id ) );
@@ -296,7 +294,7 @@ if ( is_multisite() ) :
 			// Set the dashboard blog to another one.
 			update_site_option( 'dashboard_blog', $blog_id );
 			$dashboard_blog = get_dashboard_blog();
-			$this->assertEquals( $blog_id, $dashboard_blog->blog_id );
+			$this->assertSame( (string) $blog_id, $dashboard_blog->blog_id );
 		}
 
 		/**

--- a/tests/phpunit/tests/multisite/network.php
+++ b/tests/phpunit/tests/multisite/network.php
@@ -171,7 +171,7 @@ if ( is_multisite() ) :
 			}
 			wp_update_network_counts();
 
-			$this->assertEquals( $site_count_start, $actual );
+			$this->assertSame( $site_count_start, $actual );
 		}
 
 		/**
@@ -191,7 +191,7 @@ if ( is_multisite() ) :
 			}
 			wp_update_network_counts();
 
-			$this->assertEquals( $site_count_start + 1, $actual );
+			$this->assertSame( $site_count_start + 1, $actual );
 		}
 
 		/**

--- a/tests/phpunit/tests/multisite/site.php
+++ b/tests/phpunit/tests/multisite/site.php
@@ -150,7 +150,7 @@ if ( is_multisite() ) :
 			// Combine domain and path for a site specific cache key.
 			$key = md5( $details->domain . $details->path );
 
-			$this->assertEquals( $details, wp_cache_get( $blog_id . 'short', 'blog-details' ) );
+			$this->assertSimilarObject( $details, wp_cache_get( $blog_id . 'short', 'blog-details' ) );
 
 			// get_blogaddress_by_name().
 			$this->assertSame( 'http://' . $details->domain . $details->path, get_blogaddress_by_name( trim( $details->path, '/' ) ) );
@@ -161,8 +161,8 @@ if ( is_multisite() ) :
 
 			// $get_all = true, populate the full blog-details cache and the blog slug lookup cache.
 			$details = get_blog_details( $blog_id, true );
-			$this->assertEquals( $details, wp_cache_get( $blog_id, 'blog-details' ) );
-			$this->assertEquals( $details, wp_cache_get( $key, 'blog-lookup' ) );
+			$this->assertSimilarObject( $details, wp_cache_get( $blog_id, 'blog-details' ) );
+			$this->assertSimilarObject( $details, wp_cache_get( $key, 'blog-lookup' ) );
 
 			// Check existence of each database table for the created site.
 			foreach ( $wpdb->tables( 'blog', false ) as $table ) {
@@ -445,7 +445,7 @@ if ( is_multisite() ) :
 			$blog = get_blog_details( $blog_id );
 
 			// When the cache is refreshed, it should now equal the site data.
-			$this->assertEquals( $blog, wp_cache_get( $blog_id, 'blog-details' ) );
+			$this->assertSimilarObject( $blog, wp_cache_get( $blog_id, 'blog-details' ) );
 		}
 
 		/**
@@ -874,7 +874,7 @@ if ( is_multisite() ) :
 			switch_to_blog( $blog_id );
 
 			// The post created and retrieved on the main site should match the one retrieved "remotely".
-			$this->assertEquals( $post, get_blog_post( 1, $post_id ) );
+			$this->assertSimilarObject( $post, get_blog_post( 1, $post_id ) );
 
 			restore_current_blog();
 		}
@@ -885,7 +885,7 @@ if ( is_multisite() ) :
 		public function test_get_blog_post_from_same_site() {
 			$post_id = self::factory()->post->create();
 
-			$this->assertEquals( get_blog_post( 1, $post_id ), get_post( $post_id ) );
+			$this->assertSimilarObject( get_blog_post( 1, $post_id ), get_post( $post_id ) );
 		}
 
 		/**

--- a/tests/phpunit/tests/multisite/site.php
+++ b/tests/phpunit/tests/multisite/site.php
@@ -1333,7 +1333,10 @@ if ( is_multisite() ) :
 
 			$site = get_site( $site_id );
 			foreach ( $expected_data as $key => $value ) {
-				$this->assertEquals( $value, $site->$key );
+				if ( is_string( $site->$key ) ) {
+					$value = (string) $value;
+				}
+				$this->assertSame( $value, $site->$key );
 			}
 		}
 
@@ -1470,7 +1473,10 @@ if ( is_multisite() ) :
 			$new_site = get_site( $site_id );
 			foreach ( $new_site->to_array() as $key => $value ) {
 				if ( isset( $expected_data[ $key ] ) ) {
-					$this->assertEquals( $expected_data[ $key ], $value );
+					if ( is_string( $value ) ) {
+						$expected_data[ $key ] = (string) $expected_data[ $key ];
+					}
+					$this->assertSame( $expected_data[ $key ], $value );
 				} elseif ( 'last_updated' === $key ) {
 					$this->assertTrue( $old_site->last_updated <= $value );
 				} else {
@@ -1555,9 +1561,9 @@ if ( is_multisite() ) :
 			$result = wp_update_site( $site_id, array( 'public' => 1 ) );
 			$site3  = get_site( $site_id );
 
-			$this->assertEquals( 1, $site1->public );
-			$this->assertEquals( 0, $site2->public );
-			$this->assertEquals( 1, $site3->public );
+			$this->assertSame( '1', $site1->public );
+			$this->assertSame( '0', $site2->public );
+			$this->assertSame( '1', $site3->public );
 		}
 
 		/**
@@ -2457,17 +2463,18 @@ if ( is_multisite() ) :
 		 */
 		public function test_get_site_not_found_cache_clear() {
 			$new_site_id = $this->_get_next_site_id();
+			$expected    = (string) $new_site_id;
 			$this->assertNull( get_site( $new_site_id ) );
 
 			$new_site = self::factory()->blog->create_and_get();
 
 			// Double-check we got the ID of the new site correct.
-			$this->assertEquals( $new_site_id, $new_site->blog_id );
+			$this->assertSame( $expected, $new_site->blog_id );
 
 			// Verify that if we fetch the site now, it's no longer false.
 			$fetched_site = get_site( $new_site_id );
 			$this->assertInstanceOf( 'WP_Site', $fetched_site );
-			$this->assertEquals( $new_site_id, $fetched_site->blog_id );
+			$this->assertSame( $expected, $fetched_site->blog_id );
 
 		}
 

--- a/tests/phpunit/tests/multisite/site.php
+++ b/tests/phpunit/tests/multisite/site.php
@@ -2439,7 +2439,7 @@ if ( is_multisite() ) :
 
 			wpmu_create_blog( 'testsite1.example.org', '/new-blog/', 'New Blog', get_current_user_id(), $meta, 1 );
 
-			$this->assertEquals( $expected_meta, $this->wp_initialize_site_meta );
+			$this->assertSameSetsWithIndex( $expected_meta, $this->wp_initialize_site_meta );
 
 			$this->wp_initialize_site_meta = array();
 		}
@@ -2541,8 +2541,8 @@ if ( is_multisite() ) :
 					),
 					array(
 						'public' => 0,
-						'WPLANG' => 'en_US',
 						'foo'    => 'bar',
+						'WPLANG' => 'en_US',
 					),
 				),
 			);

--- a/tests/phpunit/tests/multisite/updatePostsCount.php
+++ b/tests/phpunit/tests/multisite/updatePostsCount.php
@@ -36,7 +36,7 @@ if ( is_multisite() ) :
 			 * Check that _update_posts_count_on_transition_post_status() is called on that filter which then calls
 			 * update_posts_count to update the count.
 			 */
-			$this->assertEquals( $current_post_count + 1, (int) get_option( 'post_count' ), 'post added' );
+			$this->assertSame( $current_post_count + 1, (int) get_option( 'post_count' ), 'post added' );
 
 			wp_delete_post( $post_id );
 
@@ -46,7 +46,7 @@ if ( is_multisite() ) :
 			 * Check that _update_posts_count_on_delete() is called on that filter which then calls update_posts_count
 			 * to update the count.
 			 */
-			$this->assertEquals( $current_post_count, (int) get_option( 'post_count' ), 'post deleted' );
+			$this->assertSame( $current_post_count, (int) get_option( 'post_count' ), 'post deleted' );
 
 			restore_current_blog();
 

--- a/tests/phpunit/tests/oembed/controller.php
+++ b/tests/phpunit/tests/oembed/controller.php
@@ -606,8 +606,8 @@ class Test_oEmbed_Controller extends WP_UnitTestCase {
 		$this->assertIsObject( $data );
 		$this->assertSame( 'YouTube', $data->provider_name );
 		$this->assertSame( 'https://i.ytimg.com/vi/' . self::YOUTUBE_VIDEO_ID . '/hqdefault.jpg', $data->thumbnail_url );
-		$this->assertEquals( $data->width, $request['maxwidth'] );
-		$this->assertEquals( $data->height, $request['maxheight'] );
+		$this->assertSame( (int) $data->width, $request['maxwidth'] );
+		$this->assertSame( (int) $data->height, $request['maxheight'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/option/networkOption.php
+++ b/tests/phpunit/tests/option/networkOption.php
@@ -176,7 +176,7 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 		$this->assertIsInt( add_metadata( 'site', $network_id, $option, $funky_meta, true ) );
 
 		// Check they exists.
-		$this->assertArrayEqualsWithObject( $funky_meta, get_network_option( $network_id, $option ) );
+		$this->assertEqualSets( $funky_meta, get_network_option( $network_id, $option ) );
 	}
 
 	/**
@@ -279,7 +279,7 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 		);
 
 		add_metadata( 'site', $network_id, $option, $array_w_object, true );
-		$this->assertArrayEqualsWithObject( $array_w_object, get_network_option( $network_id, $option ) );
+		$this->assertEqualSets( $array_w_object, get_network_option( $network_id, $option ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/option/networkOption.php
+++ b/tests/phpunit/tests/option/networkOption.php
@@ -190,7 +190,7 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 		add_metadata( 'site', $network_id, $option, 'monday', true );
 		add_metadata( 'site', $network_id, $option, 'tuesday', true );
 		add_metadata( 'site', $network_id, $option, 'wednesday', true );
-		$this->assertEquals( 'monday', get_network_option( $network_id, $option, true ) );
+		$this->assertSame( 'monday', get_network_option( $network_id, $option, true ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/option/networkOption.php
+++ b/tests/phpunit/tests/option/networkOption.php
@@ -176,7 +176,7 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 		$this->assertIsInt( add_metadata( 'site', $network_id, $option, $funky_meta, true ) );
 
 		// Check they exists.
-		$this->assertEquals( $funky_meta, get_network_option( $network_id, $option ) );
+		$this->assertArrayEqualsWithObject( $funky_meta, get_network_option( $network_id, $option ) );
 	}
 
 	/**
@@ -279,7 +279,7 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 		);
 
 		add_metadata( 'site', $network_id, $option, $array_w_object, true );
-		$this->assertEquals( $array_w_object, get_network_option( $network_id, $option ) );
+		$this->assertArrayEqualsWithObject( $array_w_object, get_network_option( $network_id, $option ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/option/option.php
+++ b/tests/phpunit/tests/option/option.php
@@ -118,7 +118,7 @@ class Tests_Option_Option extends WP_UnitTestCase {
 
 		$value = (object) $value;
 		$this->assertTrue( update_option( $key, $value ) );
-		$this->assertEquals( $value, get_option( $key ) );
+		$this->assertSimilarObject( $value, get_option( $key ) );
 		$this->assertTrue( delete_option( $key ) );
 	}
 

--- a/tests/phpunit/tests/option/sanitizeOption.php
+++ b/tests/phpunit/tests/option/sanitizeOption.php
@@ -156,7 +156,7 @@ class Tests_Option_SanitizeOption extends WP_UnitTestCase {
 			$this->assertSame( 'invalid_permalink_structure', $errors[0]['code'] );
 		}
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertSame( $expected, $actual );
 	}
 
 	public function permalink_structure_provider() {

--- a/tests/phpunit/tests/option/sanitizeOption.php
+++ b/tests/phpunit/tests/option/sanitizeOption.php
@@ -156,6 +156,10 @@ class Tests_Option_SanitizeOption extends WP_UnitTestCase {
 			$this->assertSame( 'invalid_permalink_structure', $errors[0]['code'] );
 		}
 
+		if ( is_multisite() && false === $expected ) {
+			$expected = '';
+		}
+
 		$this->assertSame( $expected, $actual );
 	}
 

--- a/tests/phpunit/tests/option/siteOption.php
+++ b/tests/phpunit/tests/option/siteOption.php
@@ -213,12 +213,12 @@ class Tests_Option_SiteOption extends WP_UnitTestCase {
 	 */
 	public function test_update_adds_falsey_value() {
 		$key   = __FUNCTION__;
-		$value = 0;
+		$value = '0';
 
 		delete_site_option( $key );
 		$this->assertTrue( update_site_option( $key, $value ) );
 		$this->flush_cache(); // Ensure we're getting the value from the DB.
-		$this->assertEquals( $value, get_site_option( $key ) );
+		$this->assertSame( $value, get_site_option( $key ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/option/siteOption.php
+++ b/tests/phpunit/tests/option/siteOption.php
@@ -200,7 +200,7 @@ class Tests_Option_SiteOption extends WP_UnitTestCase {
 		$value->foo = true;
 		$value->bar = true;
 		add_site_option( $key, $value );
-		$this->assertEquals( $value, get_site_option( $key ) );
+		$this->assertSimilarObject( $value, get_site_option( $key ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/option/siteTransient.php
+++ b/tests/phpunit/tests/option/siteTransient.php
@@ -51,7 +51,7 @@ class Tests_Option_SiteTransient extends WP_UnitTestCase {
 
 		$value = (object) $value;
 		$this->assertTrue( set_site_transient( $key, $value ) );
-		$this->assertEquals( $value, get_site_transient( $key ) );
+		$this->assertSimilarObject( $value, get_site_transient( $key ) );
 		$this->assertTrue( delete_site_transient( $key ) );
 	}
 

--- a/tests/phpunit/tests/option/transient.php
+++ b/tests/phpunit/tests/option/transient.php
@@ -51,7 +51,7 @@ class Tests_Option_Transient extends WP_UnitTestCase {
 
 		$value = (object) $value;
 		$this->assertTrue( set_transient( $key, $value ) );
-		$this->assertEquals( $value, get_transient( $key ) );
+		$this->assertSimilarObject( $value, get_transient( $key ) );
 		$this->assertTrue( delete_transient( $key ) );
 	}
 

--- a/tests/phpunit/tests/pomo/mo.php
+++ b/tests/phpunit/tests/pomo/mo.php
@@ -58,7 +58,7 @@ class Tests_POMO_MO extends WP_UnitTestCase {
 				'context'      => 'dragonland',
 			)
 		);
-		$this->assertEquals( $plural_entry, $mo->entries[ $plural_entry->key() ] );
+		$this->assertSimilarObject( $plural_entry, $mo->entries[ $plural_entry->key() ] );
 		$this->assertSame( 'dragonland', $mo->entries[ $plural_entry->key() ]->context );
 
 		$single_entry = new Translation_Entry(
@@ -68,7 +68,7 @@ class Tests_POMO_MO extends WP_UnitTestCase {
 				'context'      => 'not so dragon',
 			)
 		);
-		$this->assertEquals( $single_entry, $mo->entries[ $single_entry->key() ] );
+		$this->assertSimilarObject( $single_entry, $mo->entries[ $single_entry->key() ] );
 		$this->assertSame( 'not so dragon', $mo->entries[ $single_entry->key() ]->context );
 
 	}
@@ -139,7 +139,7 @@ class Tests_POMO_MO extends WP_UnitTestCase {
 
 		$this->assertSame( count( $entries ), count( $again->entries ) );
 		foreach ( $entries as $entry ) {
-			$this->assertEquals( $entry, $again->entries[ $entry->key() ] );
+			$this->assertSimilarObject( $entry, $again->entries[ $entry->key() ] );
 		}
 	}
 

--- a/tests/phpunit/tests/pomo/po.php
+++ b/tests/phpunit/tests/pomo/po.php
@@ -282,7 +282,7 @@ msgstr[2] "бабаяга"',
 		);
 
 		$simple_entry = new Translation_Entry( array( 'singular' => 'moon' ) );
-		$this->assertEquals( $simple_entry, $po->entries[ $simple_entry->key() ] );
+		$this->assertSimilarObject( $simple_entry, $po->entries[ $simple_entry->key() ] );
 
 		$all_types_entry = new Translation_Entry(
 			array(
@@ -292,7 +292,7 @@ msgstr[2] "бабаяга"',
 				'translations' => array( 'ztrut0', 'ztrut1', 'ztrut2' ),
 			)
 		);
-		$this->assertEquals( $all_types_entry, $po->entries[ $all_types_entry->key() ] );
+		$this->assertSimilarObject( $all_types_entry, $po->entries[ $all_types_entry->key() ] );
 
 		$multiple_line_entry = new Translation_Entry(
 			array(
@@ -300,7 +300,7 @@ msgstr[2] "бабаяга"',
 				'translations' => array( "baba\ndyadogugu" ),
 			)
 		);
-		$this->assertEquals( $multiple_line_entry, $po->entries[ $multiple_line_entry->key() ] );
+		$this->assertSimilarObject( $multiple_line_entry, $po->entries[ $multiple_line_entry->key() ] );
 
 		$multiple_line_all_types_entry = new Translation_Entry(
 			array(
@@ -310,7 +310,7 @@ msgstr[2] "бабаяга"',
 				'translations' => array( 'translation0', 'translation1', 'translation2' ),
 			)
 		);
-		$this->assertEquals( $multiple_line_all_types_entry, $po->entries[ $multiple_line_all_types_entry->key() ] );
+		$this->assertSimilarObject( $multiple_line_all_types_entry, $po->entries[ $multiple_line_all_types_entry->key() ] );
 
 		$comments_entry = new Translation_Entry(
 			array(
@@ -321,10 +321,10 @@ msgstr[2] "бабаяга"',
 				'flags'               => array( 'fuzzy' ),
 			)
 		);
-		$this->assertEquals( $comments_entry, $po->entries[ $comments_entry->key() ] );
+		$this->assertSimilarObject( $comments_entry, $po->entries[ $comments_entry->key() ] );
 
 		$end_quote_entry = new Translation_Entry( array( 'singular' => 'a"' ) );
-		$this->assertEquals( $end_quote_entry, $po->entries[ $end_quote_entry->key() ] );
+		$this->assertSimilarObject( $end_quote_entry, $po->entries[ $end_quote_entry->key() ] );
 	}
 
 	public function test_import_from_entry_file_should_give_false() {

--- a/tests/phpunit/tests/post.php
+++ b/tests/phpunit/tests/post.php
@@ -154,7 +154,7 @@ class Tests_Post extends WP_UnitTestCase {
 		);
 
 		$count = wp_count_posts( $post_type, 'readable' );
-		$this->assertEquals( 1, $count->publish );
+		$this->assertSame( '1', $count->publish );
 
 		_unregister_post_type( $post_type );
 		$count = wp_count_posts( $post_type, 'readable' );
@@ -173,12 +173,12 @@ class Tests_Post extends WP_UnitTestCase {
 		);
 
 		$count1 = wp_count_posts( $post_type, 'readable' );
-		$this->assertEquals( 3, $count1->publish );
+		$this->assertSame( '3', $count1->publish );
 
 		add_filter( 'wp_count_posts', array( $this, 'filter_wp_count_posts' ) );
 		$count2 = wp_count_posts( $post_type, 'readable' );
 		remove_filter( 'wp_count_posts', array( $this, 'filter_wp_count_posts' ) );
-		$this->assertEquals( 2, $count2->publish );
+		$this->assertSame( 2, $count2->publish );
 	}
 
 	public function filter_wp_count_posts( $counts ) {
@@ -201,8 +201,8 @@ class Tests_Post extends WP_UnitTestCase {
 		$this->assertNotEquals( 'publish', $post->post_status );
 
 		$after_draft_counts = wp_count_posts();
-		$this->assertEquals( 1, $after_draft_counts->draft );
-		$this->assertEquals( 2, $after_draft_counts->publish );
+		$this->assertSame( '1', $after_draft_counts->draft );
+		$this->assertSame( '2', $after_draft_counts->publish );
 		$this->assertNotEquals( $initial_counts->publish, $after_draft_counts->publish );
 	}
 
@@ -219,8 +219,8 @@ class Tests_Post extends WP_UnitTestCase {
 		$this->assertNotEquals( 'publish', $post->post_status );
 
 		$after_trash_counts = wp_count_posts();
-		$this->assertEquals( 1, $after_trash_counts->trash );
-		$this->assertEquals( 2, $after_trash_counts->publish );
+		$this->assertSame( '1', $after_trash_counts->trash );
+		$this->assertSame( '2', $after_trash_counts->publish );
 		$this->assertNotEquals( $initial_counts->publish, $after_trash_counts->publish );
 	}
 

--- a/tests/phpunit/tests/post.php
+++ b/tests/phpunit/tests/post.php
@@ -158,7 +158,7 @@ class Tests_Post extends WP_UnitTestCase {
 
 		_unregister_post_type( $post_type );
 		$count = wp_count_posts( $post_type, 'readable' );
-		$this->assertEquals( new stdClass, $count );
+		$this->assertSimilarObject( new stdClass, $count );
 	}
 
 	public function test_wp_count_posts_filtered() {

--- a/tests/phpunit/tests/post/getPageByPath.php
+++ b/tests/phpunit/tests/post/getPageByPath.php
@@ -38,10 +38,10 @@ class Tests_Post_GetPageByPath extends WP_UnitTestCase {
 		$this->assertSame( 'some-page', $page->post_name );
 
 		// get_page_by_path() should return a post of the requested type before returning an attachment.
-		$this->assertEquals( $page, get_page_by_path( 'some-page' ) );
+		$this->assertSimilarObject( $page, get_page_by_path( 'some-page' ) );
 
 		// Make sure get_page_by_path() will still select an attachment when a post of the requested type doesn't exist.
-		$this->assertEquals( $other_att, get_page_by_path( 'some-other-page' ) );
+		$this->assertSimilarObject( $other_att, get_page_by_path( 'some-other-page' ) );
 	}
 
 	public function test_should_match_top_level_page() {

--- a/tests/phpunit/tests/post/getPageByTitle.php
+++ b/tests/phpunit/tests/post/getPageByTitle.php
@@ -57,9 +57,9 @@ class Tests_Post_GetPageByTitle extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertEquals( $page, get_page_by_title( 'some-page' ), 'should return a post of the requested type before returning an attachment.' );
+		$this->assertSimilarObject( $page, get_page_by_title( 'some-page' ), 'should return a post of the requested type before returning an attachment.' );
 
-		$this->assertEquals( $attachment, get_page_by_title( 'some-other-page', OBJECT, 'attachment' ), "will still select an attachment when a post of the requested type doesn't exist." );
+		$this->assertSimilarObject( $attachment, get_page_by_title( 'some-other-page', OBJECT, 'attachment' ), "will still select an attachment when a post of the requested type doesn't exist." );
 	}
 
 	/**

--- a/tests/phpunit/tests/post/getPages.php
+++ b/tests/phpunit/tests/post/getPages.php
@@ -424,7 +424,7 @@ class Tests_Post_GetPages extends WP_UnitTestCase {
 			)
 		);
 		// Confirm the defaults.
-		$this->assertArrayEqualsWithObject( $pages, $pages_default_args );
+		$this->assertEqualSets( $pages, $pages_default_args );
 
 		/*
 		 * Here's the tree we are testing:
@@ -468,7 +468,7 @@ class Tests_Post_GetPages extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertArrayEqualsWithObject( $pages, $default_args );
+		$this->assertEqualSets( $pages, $default_args );
 
 		/*
 		 * Page tree:

--- a/tests/phpunit/tests/post/getPages.php
+++ b/tests/phpunit/tests/post/getPages.php
@@ -424,7 +424,7 @@ class Tests_Post_GetPages extends WP_UnitTestCase {
 			)
 		);
 		// Confirm the defaults.
-		$this->assertEquals( $pages, $pages_default_args );
+		$this->assertArrayEqualsWithObject( $pages, $pages_default_args );
 
 		/*
 		 * Here's the tree we are testing:
@@ -468,7 +468,7 @@ class Tests_Post_GetPages extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertEquals( $pages, $default_args );
+		$this->assertArrayEqualsWithObject( $pages, $default_args );
 
 		/*
 		 * Page tree:

--- a/tests/phpunit/tests/post/meta.php
+++ b/tests/phpunit/tests/post/meta.php
@@ -174,14 +174,14 @@ class Tests_Post_Meta extends WP_UnitTestCase {
 		$mobj->post_id    = self::$post_id;
 		$mobj->meta_key   = 'get_post_meta_by_key';
 		$mobj->meta_value = 'get_post_meta_by_key_value';
-		$this->assertEquals( $mobj, get_post_meta_by_id( $mid ) );
+		$this->assertSimilarObject( $mobj, get_post_meta_by_id( $mid ) );
 		delete_metadata_by_mid( 'post', $mid );
 
 		$mid = add_post_meta( self::$post_id, 'get_post_meta_by_key', array( 'foo', 'bar' ), true );
 		$this->assertIsInt( $mid );
 		$mobj->meta_id    = $mid;
 		$mobj->meta_value = array( 'foo', 'bar' );
-		$this->assertEquals( $mobj, get_post_meta_by_id( $mid ) );
+		$this->assertSimilarObject( $mobj, get_post_meta_by_id( $mid ) );
 		delete_metadata_by_mid( 'post', $mid );
 	}
 
@@ -248,7 +248,7 @@ class Tests_Post_Meta extends WP_UnitTestCase {
 		$this->assertIsInt( add_post_meta( self::$post_id, 'test_funky_post_meta', $funky_meta, true ) );
 
 		// Check it exists.
-		$this->assertEquals( $funky_meta, get_post_meta( self::$post_id, 'test_funky_post_meta', true ) );
+		$this->assertSimilarObject( $funky_meta, get_post_meta( self::$post_id, 'test_funky_post_meta', true ) );
 
 	}
 

--- a/tests/phpunit/tests/post/meta.php
+++ b/tests/phpunit/tests/post/meta.php
@@ -248,7 +248,7 @@ class Tests_Post_Meta extends WP_UnitTestCase {
 		$this->assertIsInt( add_post_meta( self::$post_id, 'test_funky_post_meta', $funky_meta, true ) );
 
 		// Check it exists.
-		$this->assertSimilarObject( $funky_meta, get_post_meta( self::$post_id, 'test_funky_post_meta', true ) );
+		$this->assertEqualSets( $funky_meta, get_post_meta( self::$post_id, 'test_funky_post_meta', true ) );
 
 	}
 

--- a/tests/phpunit/tests/post/nav-menu.php
+++ b/tests/phpunit/tests/post/nav-menu.php
@@ -199,7 +199,7 @@ class Tests_Post_Nav_Menu extends WP_UnitTestCase {
 
 		$menu_items = wp_get_nav_menu_items( $this->menu_id );
 		$this->assertSame( $term->name, $menu_items[0]->title );
-		$this->assertEquals( $t, $menu_items[0]->object_id );
+		$this->assertSame( (string) $t, $menu_items[0]->object_id );
 	}
 
 	/**

--- a/tests/phpunit/tests/post/objects.php
+++ b/tests/phpunit/tests/post/objects.php
@@ -114,7 +114,7 @@ class Tests_Post_Objects extends WP_UnitTestCase {
 
 		$this->assertIsArray( $post->post_category );
 		$this->assertCount( 1, $post->post_category );
-		$this->assertEquals( get_option( 'default_category' ), $post->post_category[0] );
+		$this->assertSame( (int) get_option( 'default_category' ), $post->post_category[0] );
 		$term1 = wp_insert_term( 'Foo', 'category' );
 		$term2 = wp_insert_term( 'Bar', 'category' );
 		$term3 = wp_insert_term( 'Baz', 'category' );

--- a/tests/phpunit/tests/post/revisions.php
+++ b/tests/phpunit/tests/post/revisions.php
@@ -55,12 +55,12 @@ class Tests_Post_Revisions extends WP_UnitTestCase {
 		$lastrevision = end( $revisions );
 		$this->assertSame( 'I cant spel werds.', $lastrevision->post_content );
 		// #16215
-		$this->assertEquals( self::$author_user_id, $lastrevision->post_author );
+		$this->assertSame( (string) self::$author_user_id, $lastrevision->post_author );
 
 		wp_restore_post_revision( $lastrevision->ID );
 
 		// Is post_meta correctly set to revision author after restoring user?
-		$this->assertEquals( self::$admin_user_id, get_post_meta( $post_id, '_edit_last', true ) );
+		$this->assertSame( (string) self::$admin_user_id, get_post_meta( $post_id, '_edit_last', true ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/post/thumbnails.php
+++ b/tests/phpunit/tests/post/thumbnails.php
@@ -263,7 +263,7 @@ class Tests_Post_Thumbnail_Template extends WP_UnitTestCase {
 		unset( $_REQUEST['_thumbnail_id'] );
 		unset( $_REQUEST['preview_id'] );
 
-		$this->assertEquals( self::$attachment_id, $result );
+		$this->assertSame( (string) self::$attachment_id, $result );
 	}
 
 	/**

--- a/tests/phpunit/tests/post/types.php
+++ b/tests/phpunit/tests/post/types.php
@@ -275,7 +275,7 @@ class Tests_Post_Types extends WP_UnitTestCase {
 
 		$after = get_post_type_object( 'foo' )->labels;
 
-		$this->assertEquals( $before, $after );
+		$this->assertSimilarObject( $before, $after );
 
 		_unregister_post_type( 'foo' );
 	}

--- a/tests/phpunit/tests/post/wpCountAttachments.php
+++ b/tests/phpunit/tests/post/wpCountAttachments.php
@@ -28,6 +28,6 @@ class Tests_Post_wpCountAttachments extends WP_UnitTestCase {
 		$expected = wp_count_attachments( $mime_type );
 		$actual   = wp_cache_get( $cache_key, 'counts' );
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertArrayEqualsWithObject( $expected, $actual );
 	}
 }

--- a/tests/phpunit/tests/post/wpCountAttachments.php
+++ b/tests/phpunit/tests/post/wpCountAttachments.php
@@ -28,6 +28,6 @@ class Tests_Post_wpCountAttachments extends WP_UnitTestCase {
 		$expected = wp_count_attachments( $mime_type );
 		$actual   = wp_cache_get( $cache_key, 'counts' );
 
-		$this->assertArrayEqualsWithObject( $expected, $actual );
+		$this->assertSimilarObject( $expected, $actual );
 	}
 }

--- a/tests/phpunit/tests/post/wpInsertPost.php
+++ b/tests/phpunit/tests/post/wpInsertPost.php
@@ -128,7 +128,7 @@ class Tests_Post_wpInsertPost extends WP_UnitTestCase {
 		$this->assertSame( $data['post_content'], $post->post_content );
 		$this->assertSame( $data['post_title'], $post->post_title );
 		$this->assertSame( $data['post_status'], $post->post_status );
-		$this->assertEquals( $data['post_author'], $post->post_author );
+		$this->assertSame( (string) $data['post_author'], $post->post_author );
 
 		// Test cache state.
 		$post_cache = wp_cache_get( $post_id, 'posts' );
@@ -677,7 +677,7 @@ class Tests_Post_wpInsertPost extends WP_UnitTestCase {
 		$this->assertGreaterThan( 0, $post_id );
 
 		$post = get_post( $post_id );
-		$this->assertEquals( self::$user_ids['editor'], $post->post_author );
+		$this->assertSame( (string) self::$user_ids['editor'], $post->post_author );
 		$this->assertSame( $title, $post->post_title );
 	}
 
@@ -789,7 +789,7 @@ class Tests_Post_wpInsertPost extends WP_UnitTestCase {
 	public function test_wp_insert_post_author_zero() {
 		$post_id = self::factory()->post->create( array( 'post_author' => 0 ) );
 
-		$this->assertEquals( 0, get_post( $post_id )->post_author );
+		$this->assertSame( '0', get_post( $post_id )->post_author );
 	}
 
 	/**
@@ -800,7 +800,7 @@ class Tests_Post_wpInsertPost extends WP_UnitTestCase {
 
 		$post_id = self::factory()->post->create( array( 'post_author' => null ) );
 
-		$this->assertEquals( self::$user_ids['editor'], get_post( $post_id )->post_author );
+		$this->assertSame( (string) self::$user_ids['editor'], get_post( $post_id )->post_author );
 	}
 
 	/**

--- a/tests/phpunit/tests/post/wpInsertPost.php
+++ b/tests/phpunit/tests/post/wpInsertPost.php
@@ -900,7 +900,7 @@ class Tests_Post_wpInsertPost extends WP_UnitTestCase {
 		// Validate that the term got assigned.
 		$assigned_terms = wp_get_object_terms( array( $post_id ), array( 'category' ), array() );
 		$this->assertCount( 1, $assigned_terms );
-		$this->assertEquals( $term_id, $assigned_terms[0]->term_id );
+		$this->assertSame( $term_id, $assigned_terms[0]->term_id );
 
 		// Update the post with no changes.
 		$post = get_post( $post_id );
@@ -909,7 +909,7 @@ class Tests_Post_wpInsertPost extends WP_UnitTestCase {
 		// Validate the term is still assigned.
 		$assigned_terms = wp_get_object_terms( array( $post_id ), array( 'category' ), array() );
 		$this->assertCount( 1, $assigned_terms );
-		$this->assertEquals( $term_id, $assigned_terms[0]->term_id );
+		$this->assertSame( $term_id, $assigned_terms[0]->term_id );
 
 		// Remove the term from the post.
 		$post->post_category = array();

--- a/tests/phpunit/tests/post/wpInsertPost.php
+++ b/tests/phpunit/tests/post/wpInsertPost.php
@@ -918,7 +918,7 @@ class Tests_Post_wpInsertPost extends WP_UnitTestCase {
 
 		// Validate that the post has had the default category assigned again.
 		$this->assertCount( 1, $assigned_terms );
-		$this->assertEquals( get_option( 'default_category' ), $assigned_terms[0]->term_id );
+		$this->assertSame( (int) get_option( 'default_category' ), $assigned_terms[0]->term_id );
 	}
 
 	/**

--- a/tests/phpunit/tests/query.php
+++ b/tests/phpunit/tests/query.php
@@ -73,7 +73,7 @@ class Tests_Query extends WP_UnitTestCase {
 		$this->assertNotEmpty( get_query_var( 'tag' ) );
 		$this->assertEmpty( get_query_var( 'tax_query' ) );
 		$this->assertCount( 1, get_query_var( 'tag_slug__in' ) );
-		$this->assertEquals( get_queried_object(), $tag );
+		$this->assertSimilarObject( get_queried_object(), $tag );
 
 		remove_action( 'pre_get_posts', array( $this, 'tag_queried_object' ), 11 );
 	}
@@ -84,7 +84,7 @@ class Tests_Query extends WP_UnitTestCase {
 		$this->assertTrue( $query->is_archive() );
 		$this->assertNotEmpty( $query->get( 'tag' ) );
 		$this->assertCount( 1, $query->get( 'tag_slug__in' ) );
-		$this->assertEquals( $query->get_queried_object(), $tag );
+		$this->assertSimilarObject( $query->get_queried_object(), $tag );
 	}
 
 	/**

--- a/tests/phpunit/tests/query/cacheResults.php
+++ b/tests/phpunit/tests/query/cacheResults.php
@@ -650,7 +650,7 @@ class Test_Query_CacheResults extends WP_UnitTestCase {
 		$this->assertTrue( $query2->have_comments() );
 
 		$feed_comment = $query1->next_comment();
-		$this->assertEquals( $comment_id, $feed_comment->comment_ID );
+		$this->assertSame( (string) $comment_id, $feed_comment->comment_ID );
 	}
 
 	/**

--- a/tests/phpunit/tests/query/date.php
+++ b/tests/phpunit/tests/query/date.php
@@ -298,7 +298,7 @@ class Tests_Query_Date extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertEquals( $expected, $posts );
+		$this->assertArrayEqualsWithObject( $expected, $posts );
 	}
 
 	public function test_simple_monthnum_expecting_results() {

--- a/tests/phpunit/tests/query/date.php
+++ b/tests/phpunit/tests/query/date.php
@@ -298,7 +298,7 @@ class Tests_Query_Date extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertArrayEqualsWithObject( $expected, $posts );
+		$this->assertEqualSets( $expected, $posts );
 	}
 
 	public function test_simple_monthnum_expecting_results() {

--- a/tests/phpunit/tests/query/generatePostdata.php
+++ b/tests/phpunit/tests/query/generatePostdata.php
@@ -53,7 +53,7 @@ class Tests_Query_GeneratePostdata extends WP_UnitTestCase {
 		$data = generate_postdata( $p );
 
 		$this->assertNotEmpty( $data['authordata'] );
-		$this->assertEquals( $u, $data['authordata'] );
+		$this->assertSimilarObject( $u, $data['authordata'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/query/isTerm.php
+++ b/tests/phpunit/tests/query/isTerm.php
@@ -71,7 +71,7 @@ class Tests_Query_IsTerm extends WP_UnitTestCase {
 		$this->assertNotEmpty( get_query_var( 'taxonomy' ) );
 		$this->assertNotEmpty( get_query_var( 'term_id' ) );
 		$this->assertNotEmpty( get_query_var( 'tag_id' ) );
-		$this->assertEquals( get_queried_object(), $this->tag );
+		$this->assertSimilarObject( get_queried_object(), $this->tag );
 	}
 
 	public function test_tag_query_cat_action_tax() {
@@ -83,7 +83,7 @@ class Tests_Query_IsTerm extends WP_UnitTestCase {
 		$this->assertNotEmpty( get_query_var( 'term_id' ) );
 		$this->assertNotEmpty( get_query_var( 'cat' ) );
 		$this->assertNotEmpty( get_query_var( 'tag_id' ) );
-		$this->assertEquals( get_queried_object(), $this->cat );
+		$this->assertSimilarObject( get_queried_object(), $this->cat );
 	}
 
 	public function test_tag_query_cat_query_tax_action_tax() {
@@ -96,7 +96,7 @@ class Tests_Query_IsTerm extends WP_UnitTestCase {
 		$this->assertNotEmpty( get_query_var( 'cat' ) );
 		$this->assertNotEmpty( get_query_var( 'tag_id' ) );
 		$this->assertNotEmpty( get_query_var( 'testtax' ) );
-		$this->assertEquals( get_queried_object(), $this->cat );
+		$this->assertSimilarObject( get_queried_object(), $this->cat );
 	}
 
 	public function test_cat_action_tax() {
@@ -107,7 +107,7 @@ class Tests_Query_IsTerm extends WP_UnitTestCase {
 		$this->assertNotEmpty( get_query_var( 'tax_query' ) );
 		$this->assertNotEmpty( get_query_var( 'taxonomy' ) );
 		$this->assertNotEmpty( get_query_var( 'term_id' ) );
-		$this->assertEquals( get_queried_object(), $this->cat );
+		$this->assertSimilarObject( get_queried_object(), $this->cat );
 	}
 
 	/**
@@ -123,7 +123,7 @@ class Tests_Query_IsTerm extends WP_UnitTestCase {
 		$this->assertNotEmpty( get_query_var( 'tax_query' ) );
 		$this->assertNotEmpty( get_query_var( 'taxonomy' ) );
 		$this->assertNotEmpty( get_query_var( 'term_id' ) );
-		$this->assertEquals( get_queried_object(), $this->uncat );
+		$this->assertSimilarObject( get_queried_object(), $this->uncat );
 
 		remove_action( 'pre_get_posts', array( $this, 'cat_uncat_action_tax' ), 11 );
 	}
@@ -133,7 +133,7 @@ class Tests_Query_IsTerm extends WP_UnitTestCase {
 		$this->assertTrue( $query->is_archive() );
 		$this->assertNotEmpty( $query->get( 'category_name' ) );
 		$this->assertNotEmpty( $query->get( 'tax_query' ) );
-		$this->assertEquals( $query->get_queried_object(), $this->uncat );
+		$this->assertSimilarObject( $query->get_queried_object(), $this->uncat );
 	}
 
 	/**
@@ -146,7 +146,7 @@ class Tests_Query_IsTerm extends WP_UnitTestCase {
 		$this->assertNotEmpty( get_query_var( 'tax_query' ) );
 		$this->assertNotEmpty( get_query_var( 'taxonomy' ) );
 		$this->assertNotEmpty( get_query_var( 'term_id' ) );
-		$this->assertEquals( get_queried_object(), get_term( $this->tax_id, 'testtax' ) );
+		$this->assertSimilarObject( get_queried_object(), get_term( $this->tax_id, 'testtax' ) );
 	}
 
 	public function test_tax_query_tag_action_tax() {
@@ -157,7 +157,7 @@ class Tests_Query_IsTerm extends WP_UnitTestCase {
 		$this->assertNotEmpty( get_query_var( 'taxonomy' ) );
 		$this->assertNotEmpty( get_query_var( 'term_id' ) );
 		$this->assertNotEmpty( get_query_var( 'tag_id' ) );
-		$this->assertEquals( get_queried_object(), $this->tag );
+		$this->assertSimilarObject( get_queried_object(), $this->tag );
 	}
 
 	public function test_tax_query_cat_action_tax() {
@@ -168,7 +168,7 @@ class Tests_Query_IsTerm extends WP_UnitTestCase {
 		$this->assertNotEmpty( get_query_var( 'taxonomy' ) );
 		$this->assertNotEmpty( get_query_var( 'term_id' ) );
 		$this->assertNotEmpty( get_query_var( 'cat' ) );
-		$this->assertEquals( get_queried_object(), $this->cat );
+		$this->assertSimilarObject( get_queried_object(), $this->cat );
 	}
 
 	public function pre_get_posts_tax_category_tax_query( &$query ) {
@@ -209,7 +209,7 @@ class Tests_Query_IsTerm extends WP_UnitTestCase {
 
 		$expected = get_term( $this->tax_id, 'testtax' );
 
-		$this->assertEquals( $expected, $object );
+		$this->assertSimilarObject( $expected, $object );
 	}
 
 	/**

--- a/tests/phpunit/tests/query/results.php
+++ b/tests/phpunit/tests/query/results.php
@@ -1263,6 +1263,6 @@ class Tests_Query_Results extends WP_UnitTestCase {
 		$this->assertTrue( $this->q->have_comments() );
 
 		$feed_comment = $this->q->next_comment();
-		$this->assertEquals( $comment_id, $feed_comment->comment_ID );
+		$this->assertSame( (string) $comment_id, $feed_comment->comment_ID );
 	}
 }

--- a/tests/phpunit/tests/query/results.php
+++ b/tests/phpunit/tests/query/results.php
@@ -1060,9 +1060,9 @@ class Tests_Query_Results extends WP_UnitTestCase {
 	 * @ticket 20308
 	 */
 	public function test_post_password() {
-		$one   = (string) self::factory()->post->create( array( 'post_password' => '' ) );
-		$two   = (string) self::factory()->post->create( array( 'post_password' => 'burrito' ) );
-		$three = (string) self::factory()->post->create( array( 'post_password' => 'burrito' ) );
+		$one   = self::factory()->post->create( array( 'post_password' => '' ) );
+		$two   = self::factory()->post->create( array( 'post_password' => 'burrito' ) );
+		$three = self::factory()->post->create( array( 'post_password' => 'burrito' ) );
 
 		$args = array(
 			'post__in' => array( $one, $two, $three ),
@@ -1070,13 +1070,13 @@ class Tests_Query_Results extends WP_UnitTestCase {
 		);
 
 		$result1 = $this->q->query( array_merge( $args, array( 'has_password' => true ) ) );
-		$this->assertEqualSets( array( $two, $three ), $result1 );
+		$this->assertSameSetsWithIndex( array( $two, $three ), $result1 );
 		$result2 = $this->q->query( array_merge( $args, array( 'has_password' => false ) ) );
-		$this->assertEquals( array( $one ), $result2 );
+		$this->assertSameSetsWithIndex( array( $one ), $result2 );
 
 		// This is equivalent to not passing it at all.
 		$result3 = $this->q->query( array_merge( $args, array( 'has_password' => null ) ) );
-		$this->assertEqualSets( array( $one, $two, $three ), $result3 );
+		$this->assertSameSets( array( $one, $two, $three ), $result3 );
 
 		// If both arguments are passed, only post_password is considered.
 		$result4 = $this->q->query(
@@ -1088,7 +1088,7 @@ class Tests_Query_Results extends WP_UnitTestCase {
 				)
 			)
 		);
-		$this->assertEquals( array( $one ), $result4 );
+		$this->assertSameSetsWithIndex( array( $one ), $result4 );
 		$result5 = $this->q->query(
 			array_merge(
 				$args,
@@ -1098,7 +1098,7 @@ class Tests_Query_Results extends WP_UnitTestCase {
 				)
 			)
 		);
-		$this->assertEquals( array( $one ), $result5 );
+		$this->assertSameSetsWithIndex( array( $one ), $result5 );
 		$result6 = $this->q->query(
 			array_merge(
 				$args,
@@ -1108,7 +1108,7 @@ class Tests_Query_Results extends WP_UnitTestCase {
 				)
 			)
 		);
-		$this->assertEquals( array( $one ), $result6 );
+		$this->assertSameSetsWithIndex( array( $one ), $result6 );
 
 		$result7 = $this->q->query(
 			array_merge(
@@ -1119,7 +1119,7 @@ class Tests_Query_Results extends WP_UnitTestCase {
 				)
 			)
 		);
-		$this->assertEqualSets( array( $two, $three ), $result7 );
+		$this->assertSameSetsWithIndex( array( $two, $three ), $result7 );
 		$result8 = $this->q->query(
 			array_merge(
 				$args,
@@ -1129,7 +1129,7 @@ class Tests_Query_Results extends WP_UnitTestCase {
 				)
 			)
 		);
-		$this->assertEqualSets( array( $two, $three ), $result8 );
+		$this->assertSameSetsWithIndex( array( $two, $three ), $result8 );
 		$result9 = $this->q->query(
 			array_merge(
 				$args,
@@ -1139,12 +1139,12 @@ class Tests_Query_Results extends WP_UnitTestCase {
 				)
 			)
 		);
-		$this->assertEqualSets( array( $two, $three ), $result9 );
+		$this->assertSameSetsWithIndex( array( $two, $three ), $result9 );
 
 		$result10 = $this->q->query( array_merge( $args, array( 'post_password' => '' ) ) );
-		$this->assertEquals( array( $one ), $result10 );
+		$this->assertSameSetsWithIndex( array( $one ), $result10 );
 		$result11 = $this->q->query( array_merge( $args, array( 'post_password' => 'burrito' ) ) );
-		$this->assertEqualSets( array( $two, $three ), $result11 );
+		$this->assertSameSetsWithIndex( array( $two, $three ), $result11 );
 	}
 
 	/**

--- a/tests/phpunit/tests/query/setupPostdata.php
+++ b/tests/phpunit/tests/query/setupPostdata.php
@@ -64,7 +64,7 @@ class Tests_Query_SetupPostdata extends WP_UnitTestCase {
 		setup_postdata( $p );
 
 		$this->assertNotEmpty( $GLOBALS['authordata'] );
-		$this->assertEquals( $u, $GLOBALS['authordata'] );
+		$this->assertSimilarObject( $u, $GLOBALS['authordata'] );
 	}
 
 	public function test_currentday() {
@@ -111,7 +111,7 @@ class Tests_Query_SetupPostdata extends WP_UnitTestCase {
 
 		// Main loop.
 		$this->assertSame( $post1->ID, $GLOBALS['id'] );
-		$this->assertEquals( get_userdata( $users[0] ), $GLOBALS['authordata'] );
+		$this->assertSimilarObject( get_userdata( $users[0] ), $GLOBALS['authordata'] );
 		$this->assertSame( '02.02.12', $GLOBALS['currentday'] );
 		$this->assertSame( '02', $GLOBALS['currentmonth'] );
 
@@ -127,7 +127,7 @@ class Tests_Query_SetupPostdata extends WP_UnitTestCase {
 
 				// Should refer to the current loop.
 				$this->assertSame( $post2->ID, $GLOBALS['id'] );
-				$this->assertEquals( get_userdata( $users[1] ), $GLOBALS['authordata'] );
+				$this->assertSimilarObject( get_userdata( $users[1] ), $GLOBALS['authordata'] );
 				$this->assertSame( '03.03.13', $GLOBALS['currentday'] );
 				$this->assertSame( '03', $GLOBALS['currentmonth'] );
 			}
@@ -136,7 +136,7 @@ class Tests_Query_SetupPostdata extends WP_UnitTestCase {
 
 		// Should be reset to main loop.
 		$this->assertSame( $post1->ID, $GLOBALS['id'] );
-		$this->assertEquals( get_userdata( $users[0] ), $GLOBALS['authordata'] );
+		$this->assertSimilarObject( get_userdata( $users[0] ), $GLOBALS['authordata'] );
 		$this->assertSame( '02.02.12', $GLOBALS['currentday'] );
 		$this->assertSame( '02', $GLOBALS['currentmonth'] );
 	}

--- a/tests/phpunit/tests/rest-api.php
+++ b/tests/phpunit/tests/rest-api.php
@@ -876,7 +876,10 @@ class Tests_REST_API extends WP_UnitTestCase {
 	 * @dataProvider rest_date_provider
 	 */
 	public function test_rest_parse_date( $string, $value ) {
-		$this->assertEquals( $value, rest_parse_date( $string ) );
+		if ( ! is_bool( $value ) ) {
+			$value = (int) $value;
+		}
+		$this->assertSame( $value, rest_parse_date( $string ) );
 	}
 
 	public function rest_date_force_utc_provider() {

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -2163,7 +2163,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 
 		$this->assertStringEndsWith( '-edited.jpg', $item['media_details']['file'] );
 		$this->assertArrayHasKey( 'parent_image', $item['media_details'] );
-		$this->assertEquals( $attachment, $item['media_details']['parent_image']['attachment_id'] );
+		$this->assertSame( (string) $attachment, $item['media_details']['parent_image']['attachment_id'] );
 		$this->assertStringContainsString( 'canola', $item['media_details']['parent_image']['file'] );
 	}
 
@@ -2206,7 +2206,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 
 		$this->assertStringEndsWith( '-edited.jpg', $item['media_details']['file'] );
 		$this->assertArrayHasKey( 'parent_image', $item['media_details'] );
-		$this->assertEquals( $attachment, $item['media_details']['parent_image']['attachment_id'] );
+		$this->assertSame( (string) $attachment, $item['media_details']['parent_image']['attachment_id'] );
 		$this->assertStringContainsString( 'canola', $item['media_details']['parent_image']['file'] );
 	}
 

--- a/tests/phpunit/tests/rest-api/rest-autosaves-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-autosaves-controller.php
@@ -531,7 +531,7 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 			$links = $response['_links'];
 		}
 
-		$this->assertEquals( $autosave->post_author, $response['author'] );
+		$this->assertSame( (int) $autosave->post_author, $response['author'] );
 
 		$rendered_content = apply_filters( 'the_content', $autosave->post_content );
 		$this->assertSame( $rendered_content, $response['content']['rendered'] );

--- a/tests/phpunit/tests/rest-api/rest-block-renderer-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-block-renderer-controller.php
@@ -386,7 +386,7 @@ class REST_Block_Renderer_Controller_Test extends WP_Test_REST_Controller_Testca
 		$data = $response->get_data();
 
 		$this->assertSame( $defaults, json_decode( $data['rendered'], true ) );
-		$this->assertEquals(
+		$this->assertSimilarObject(
 			json_decode( $block_type->render( $defaults ) ),
 			json_decode( $data['rendered'] )
 		);
@@ -421,7 +421,7 @@ class REST_Block_Renderer_Controller_Test extends WP_Test_REST_Controller_Testca
 		$data = $response->get_data();
 
 		$this->assertSame( $expected_attributes, json_decode( $data['rendered'], true ) );
-		$this->assertEquals(
+		$this->assertSimilarObject(
 			json_decode( $block_type->render( $attributes ), true ),
 			json_decode( $data['rendered'], true )
 		);

--- a/tests/phpunit/tests/rest-api/rest-block-renderer-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-block-renderer-controller.php
@@ -421,7 +421,7 @@ class REST_Block_Renderer_Controller_Test extends WP_Test_REST_Controller_Testca
 		$data = $response->get_data();
 
 		$this->assertSame( $expected_attributes, json_decode( $data['rendered'], true ) );
-		$this->assertSimilarObject(
+		$this->assertEqualSetsWithIndex(
 			json_decode( $block_type->render( $attributes ), true ),
 			json_decode( $data['rendered'], true )
 		);

--- a/tests/phpunit/tests/rest-api/rest-comments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-comments-controller.php
@@ -2433,7 +2433,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$comment = $response->get_data();
 		$updated = get_comment( $comment_id );
 		$this->assertSame( 'approved', $comment['status'] );
-		$this->assertEquals( 1, $updated->comment_approved );
+		$this->assertSame( '1', $updated->comment_approved );
 	}
 
 	public function test_update_comment_field_does_not_use_default_values() {
@@ -2461,7 +2461,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$comment = $response->get_data();
 		$updated = get_comment( $comment_id );
 		$this->assertSame( 'approved', $comment['status'] );
-		$this->assertEquals( 1, $updated->comment_approved );
+		$this->assertSame( '1', $updated->comment_approved );
 		$this->assertSame( 'some content', $updated->comment_content );
 	}
 
@@ -3233,7 +3233,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 
 		wp_set_current_user( 1 );
 		rest_get_server()->dispatch( $request );
-		$this->assertEquals( 123, get_comment_meta( self::$approved_id, 'my_custom_int', true ) );
+		$this->assertSame( '123', get_comment_meta( self::$approved_id, 'my_custom_int', true ) );
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
 		$request->set_body_params(
@@ -3247,7 +3247,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 
 		$response = rest_get_server()->dispatch( $request );
 
-		$this->assertEquals( 123, $response->data['my_custom_int'] );
+		$this->assertSame( '123', $response->data['my_custom_int'] );
 
 		global $wp_rest_additional_fields;
 		$wp_rest_additional_fields = array();

--- a/tests/phpunit/tests/rest-api/rest-comments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-comments-controller.php
@@ -3304,10 +3304,10 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	protected function check_comment_data( $data, $context, $links ) {
 		$comment = get_comment( $data['id'] );
 
-		$this->assertEquals( $comment->comment_ID, $data['id'] );
-		$this->assertEquals( $comment->comment_post_ID, $data['post'] );
-		$this->assertEquals( $comment->comment_parent, $data['parent'] );
-		$this->assertEquals( $comment->user_id, $data['author'] );
+		$this->assertSame( (int) $comment->comment_ID, $data['id'] );
+		$this->assertSame( (int) $comment->comment_post_ID, $data['post'] );
+		$this->assertSame( (int) $comment->comment_parent, $data['parent'] );
+		$this->assertSame( (int) $comment->user_id, $data['author'] );
 		$this->assertSame( $comment->comment_author, $data['author_name'] );
 		$this->assertSame( $comment->comment_author_url, $data['author_url'] );
 		$this->assertSame( wpautop( $comment->comment_content ), $data['content']['rendered'] );

--- a/tests/phpunit/tests/rest-api/rest-global-styles-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-global-styles-controller.php
@@ -409,7 +409,7 @@ class WP_REST_Global_Styles_Controller_Test extends WP_Test_REST_Controller_Test
 		);
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
-		$this->assertEquals( 'My new global styles title', $data['title']['raw'] );
+		$this->assertSame( 'My new global styles title', $data['title']['raw'] );
 	}
 
 

--- a/tests/phpunit/tests/rest-api/rest-global-styles-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-global-styles-controller.php
@@ -371,7 +371,7 @@ class WP_REST_Global_Styles_Controller_Test extends WP_Test_REST_Controller_Test
 		$data     = $response->get_data();
 		$links    = $response->get_links();
 
-		$this->assertEquals(
+		$this->assertArrayEqualsWithObject(
 			array(
 				'id'       => self::$global_styles_id,
 				'title'    => array(

--- a/tests/phpunit/tests/rest-api/rest-global-styles-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-global-styles-controller.php
@@ -371,7 +371,7 @@ class WP_REST_Global_Styles_Controller_Test extends WP_Test_REST_Controller_Test
 		$data     = $response->get_data();
 		$links    = $response->get_links();
 
-		$this->assertArrayEqualsWithObject(
+		$this->assertEqualSets(
 			array(
 				'id'       => self::$global_styles_id,
 				'title'    => array(

--- a/tests/phpunit/tests/rest-api/rest-post-meta-fields.php
+++ b/tests/phpunit/tests/rest-api/rest-post-meta-fields.php
@@ -846,7 +846,7 @@ class WP_Test_REST_Post_Meta_Fields extends WP_Test_REST_TestCase {
 		$meta = get_post_meta( self::$post_id, 'test_custom_schema', false );
 		$this->assertNotEmpty( $meta );
 		$this->assertCount( 1, $meta );
-		$this->assertEquals( 3, $meta[0] );
+		$this->assertSame( '3', $meta[0] );
 
 		$data = $response->get_data();
 		$meta = (array) $data['meta'];
@@ -875,7 +875,7 @@ class WP_Test_REST_Post_Meta_Fields extends WP_Test_REST_TestCase {
 		$meta = get_post_meta( self::$post_id, 'test_custom_schema_multi', false );
 		$this->assertNotEmpty( $meta );
 		$this->assertCount( 1, $meta );
-		$this->assertEquals( 2, $meta[0] );
+		$this->assertSame( '2', $meta[0] );
 
 		// Add another value.
 		$data = array(

--- a/tests/phpunit/tests/rest-api/rest-post-meta-fields.php
+++ b/tests/phpunit/tests/rest-api/rest-post-meta-fields.php
@@ -2797,7 +2797,7 @@ class WP_Test_REST_Post_Meta_Fields extends WP_Test_REST_TestCase {
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertSame( 200, $response->get_status() );
-		$this->assertEquals( array( 0 ), $response->get_data()['meta']['multi_boolean'] );
+		$this->assertSameSetsWithIndex( array( false ), $response->get_data()['meta']['multi_boolean'] );
 
 		$this->assertFalse( get_metadata_by_mid( 'post', $mid1 ) );
 		$this->assertNotFalse( get_metadata_by_mid( 'post', $mid2 ) );

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -4479,7 +4479,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		);
 
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertEquals( 123, get_post_meta( $post_id, 'my_custom_int', true ) );
+		$this->assertSame( '123', get_post_meta( $post_id, 'my_custom_int', true ) );
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/posts' );
 		$request->set_body_params(
@@ -4491,7 +4491,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 
 		$response = rest_get_server()->dispatch( $request );
 
-		$this->assertEquals( 123, $response->data['my_custom_int'] );
+		$this->assertSame( '123', $response->data['my_custom_int'] );
 
 		global $wp_rest_additional_fields;
 		$wp_rest_additional_fields = array();

--- a/tests/phpunit/tests/rest-api/rest-revisions-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-revisions-controller.php
@@ -419,7 +419,7 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 			$links = $response['_links'];
 		}
 
-		$this->assertEquals( $revision->post_author, $response['author'] );
+		$this->assertSame( (int) $revision->post_author, $response['author'] );
 
 		$rendered_content = apply_filters( 'the_content', $revision->post_content );
 		$this->assertSame( $rendered_content, $response['content']['rendered'] );

--- a/tests/phpunit/tests/rest-api/rest-schema-sanitization.php
+++ b/tests/phpunit/tests/rest-api/rest-schema-sanitization.php
@@ -15,11 +15,11 @@ class WP_Test_REST_Schema_Sanitization extends WP_UnitTestCase {
 		$schema = array(
 			'type' => 'number',
 		);
-		$this->assertEquals( 1, rest_sanitize_value_from_schema( 1, $schema ) );
+		$this->assertSame( 1.0, rest_sanitize_value_from_schema( 1, $schema ) );
 		$this->assertSame( 1.10, rest_sanitize_value_from_schema( '1.10', $schema ) );
-		$this->assertEquals( 1, rest_sanitize_value_from_schema( '1abc', $schema ) );
-		$this->assertEquals( 0, rest_sanitize_value_from_schema( 'abc', $schema ) );
-		$this->assertEquals( 0, rest_sanitize_value_from_schema( array(), $schema ) );
+		$this->assertSame( 1.0, rest_sanitize_value_from_schema( '1abc', $schema ) );
+		$this->assertSame( 0.0, rest_sanitize_value_from_schema( 'abc', $schema ) );
+		$this->assertSame( 0.0, rest_sanitize_value_from_schema( array(), $schema ) );
 	}
 
 	public function test_type_integer() {
@@ -113,8 +113,8 @@ class WP_Test_REST_Schema_Sanitization extends WP_UnitTestCase {
 				'type' => 'number',
 			),
 		);
-		$this->assertEquals( array( 1 ), rest_sanitize_value_from_schema( array( 1 ), $schema ) );
-		$this->assertEquals( array( 1 ), rest_sanitize_value_from_schema( array( '1' ), $schema ) );
+		$this->assertSameSetsWithIndex( array( 1.0 ), rest_sanitize_value_from_schema( array( 1 ), $schema ) );
+		$this->assertSameSetsWithIndex( array( 1.0 ), rest_sanitize_value_from_schema( array( '1' ), $schema ) );
 	}
 
 	public function test_type_array_nested() {
@@ -127,8 +127,8 @@ class WP_Test_REST_Schema_Sanitization extends WP_UnitTestCase {
 				),
 			),
 		);
-		$this->assertEquals( array( array( 1 ), array( 2 ) ), rest_sanitize_value_from_schema( array( array( 1 ), array( 2 ) ), $schema ) );
-		$this->assertEquals( array( array( 1 ), array( 2 ) ), rest_sanitize_value_from_schema( array( array( '1' ), array( '2' ) ), $schema ) );
+		$this->assertSameSetsWithIndex( array( array( 1.0 ), array( 2.0 ) ), rest_sanitize_value_from_schema( array( array( 1 ), array( 2 ) ), $schema ) );
+		$this->assertSameSetsWithIndex( array( array( 1.0 ), array( 2.0 ) ), rest_sanitize_value_from_schema( array( array( '1' ), array( '2' ) ), $schema ) );
 	}
 
 	public function test_type_array_as_csv() {
@@ -138,9 +138,9 @@ class WP_Test_REST_Schema_Sanitization extends WP_UnitTestCase {
 				'type' => 'number',
 			),
 		);
-		$this->assertEquals( array( 1, 2 ), rest_sanitize_value_from_schema( '1,2', $schema ) );
-		$this->assertEquals( array( 1, 2, 0 ), rest_sanitize_value_from_schema( '1,2,a', $schema ) );
-		$this->assertEquals( array( 1, 2 ), rest_sanitize_value_from_schema( '1,2,', $schema ) );
+		$this->assertSameSetsWithIndex( array( 1.0, 2.0 ), rest_sanitize_value_from_schema( '1,2', $schema ) );
+		$this->assertSameSetsWithIndex( array( 1.0, 2.0, 0.0 ), rest_sanitize_value_from_schema( '1,2,a', $schema ) );
+		$this->assertSameSetsWithIndex( array( 1.0, 2.0 ), rest_sanitize_value_from_schema( '1,2,', $schema ) );
 	}
 
 	public function test_type_array_with_enum() {
@@ -196,11 +196,11 @@ class WP_Test_REST_Schema_Sanitization extends WP_UnitTestCase {
 				),
 			),
 		);
-		$this->assertEquals( array( 'a' => 1 ), rest_sanitize_value_from_schema( array( 'a' => 1 ), $schema ) );
-		$this->assertEquals( array( 'a' => 1 ), rest_sanitize_value_from_schema( array( 'a' => '1' ), $schema ) );
-		$this->assertEquals(
+		$this->assertSameSetsWithIndex( array( 'a' => 1.0 ), rest_sanitize_value_from_schema( array( 'a' => 1 ), $schema ) );
+		$this->assertSameSetsWithIndex( array( 'a' => 1.0 ), rest_sanitize_value_from_schema( array( 'a' => '1' ), $schema ) );
+		$this->assertSameSetsWithIndex(
 			array(
-				'a' => 1,
+				'a' => 1.0,
 				'b' => 1,
 			),
 			rest_sanitize_value_from_schema(
@@ -223,10 +223,10 @@ class WP_Test_REST_Schema_Sanitization extends WP_UnitTestCase {
 			),
 			'additionalProperties' => false,
 		);
-		$this->assertEquals( array( 'a' => 1 ), rest_sanitize_value_from_schema( array( 'a' => 1 ), $schema ) );
-		$this->assertEquals( array( 'a' => 1 ), rest_sanitize_value_from_schema( array( 'a' => '1' ), $schema ) );
-		$this->assertEquals(
-			array( 'a' => 1 ),
+		$this->assertSameSetsWithIndex( array( 'a' => 1.0 ), rest_sanitize_value_from_schema( array( 'a' => 1 ), $schema ) );
+		$this->assertSameSetsWithIndex( array( 'a' => 1.0 ), rest_sanitize_value_from_schema( array( 'a' => '1' ), $schema ) );
+		$this->assertSameSetsWithIndex(
+			array( 'a' => 1.0 ),
 			rest_sanitize_value_from_schema(
 				array(
 					'a' => '1',
@@ -347,11 +347,11 @@ class WP_Test_REST_Schema_Sanitization extends WP_UnitTestCase {
 			),
 		);
 
-		$this->assertEquals(
+		$this->assertSameSetsWithIndex(
 			array(
 				'a' => array(
-					'b' => 1,
-					'c' => 3,
+					'b' => 1.0,
+					'c' => 3.0,
 				),
 			),
 			rest_sanitize_value_from_schema(
@@ -364,11 +364,11 @@ class WP_Test_REST_Schema_Sanitization extends WP_UnitTestCase {
 				$schema
 			)
 		);
-		$this->assertEquals(
+		$this->assertSameSetsWithIndex(
 			array(
 				'a' => array(
-					'b' => 1,
-					'c' => 3,
+					'b' => 1.0,
+					'c' => 3.0,
 					'd' => '1',
 				),
 				'b' => 1,
@@ -397,7 +397,7 @@ class WP_Test_REST_Schema_Sanitization extends WP_UnitTestCase {
 				),
 			),
 		);
-		$this->assertEquals( array( 'a' => 1 ), rest_sanitize_value_from_schema( (object) array( 'a' => '1' ), $schema ) );
+		$this->assertSameSetsWithIndex( array( 'a' => 1.0 ), rest_sanitize_value_from_schema( (object) array( 'a' => '1' ), $schema ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/rest-server.php
+++ b/tests/phpunit/tests/rest-api/rest-server.php
@@ -177,7 +177,7 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 		$request->set_query_params( array( 'foo' => 123 ) );
 		$response = rest_get_server()->dispatch( $request );
 
-		$this->assertEquals( '123', $request['foo'] );
+		$this->assertSame( 123, $request['foo'] );
 	}
 
 	public function test_optional_param() {

--- a/tests/phpunit/tests/rest-api/rest-site-health-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-site-health-controller.php
@@ -116,12 +116,12 @@ class WP_Test_REST_Site_Health_Controller extends WP_Test_REST_TestCase {
 		$this->assertCount( 1, $route );
 
 		$route = current( $route );
-		$this->assertEquals(
+		$this->assertSame(
 			array( WP_REST_Server::READABLE => true ),
 			$route['methods']
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			'test_page_cache',
 			$route['callback'][1]
 		);

--- a/tests/phpunit/tests/rest-api/rest-term-meta-fields.php
+++ b/tests/phpunit/tests/rest-api/rest-term-meta-fields.php
@@ -793,7 +793,7 @@ class WP_Test_REST_Term_Meta_Fields extends WP_Test_REST_TestCase {
 		$meta = get_term_meta( self::$category_id, 'test_custom_schema', false );
 		$this->assertNotEmpty( $meta );
 		$this->assertCount( 1, $meta );
-		$this->assertEquals( 3, $meta[0] );
+		$this->assertSame( '3', $meta[0] );
 
 		$data = $response->get_data();
 		$meta = (array) $data['meta'];
@@ -822,7 +822,7 @@ class WP_Test_REST_Term_Meta_Fields extends WP_Test_REST_TestCase {
 		$meta = get_term_meta( self::$category_id, 'test_custom_schema_multi', false );
 		$this->assertNotEmpty( $meta );
 		$this->assertCount( 1, $meta );
-		$this->assertEquals( 2, $meta[0] );
+		$this->assertSame( '2', $meta[0] );
 
 		// Add another value.
 		$data = array(

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -628,7 +628,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$result   = $response->get_data();
 		$this->assertArrayHasKey( 'theme_supports', $result[0] );
 		$this->assertArrayHasKey( 'editor-font-sizes', $result[0]['theme_supports'] );
-		$this->assertEquals( array( $tiny ), $result[0]['theme_supports']['editor-font-sizes'] );
+		$this->assertEqualSetsWithIndex( array( $tiny ), $result[0]['theme_supports']['editor-font-sizes'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/rest-users-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-users-controller.php
@@ -1048,8 +1048,8 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		} else {
 			$data = $response->get_data();
 
-			$this->assertEquals( $data['capabilities'], new stdClass() );
-			$this->assertEquals( $data['extra_capabilities'], new stdClass() );
+			$this->assertSimilarObject( $data['capabilities'], new stdClass() );
+			$this->assertSimilarObject( $data['extra_capabilities'], new stdClass() );
 		}
 	}
 
@@ -3097,8 +3097,8 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 			$this->assertSame( $user->last_name, $data['last_name'] );
 			$this->assertSame( $user->nickname, $data['nickname'] );
 			$this->assertSame( $user->user_email, $data['email'] );
-			$this->assertEquals( (object) $user->allcaps, $data['capabilities'] );
-			$this->assertEquals( (object) $user->caps, $data['extra_capabilities'] );
+			$this->assertSimilarObject( (object) $user->allcaps, $data['capabilities'] );
+			$this->assertSimilarObject( (object) $user->caps, $data['extra_capabilities'] );
 			$this->assertSame( gmdate( 'c', strtotime( $user->user_registered ) ), $data['registered_date'] );
 			$this->assertSame( $user->user_login, $data['username'] );
 			$this->assertSame( $user->roles, $data['roles'] );

--- a/tests/phpunit/tests/rest-api/rest-users-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-users-controller.php
@@ -2506,7 +2506,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 
 		// Sanity check to ensure the factory created the post correctly.
 		$post = get_post( $test_post );
-		$this->assertEquals( $user_id, $post->post_author );
+		$this->assertSame( (string) $user_id, $post->post_author );
 
 		wp_set_current_user( self::$user );
 
@@ -2526,7 +2526,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 
 		// Check that the post has been updated correctly.
 		$post = get_post( $test_post );
-		$this->assertEquals( $reassign_id, $post->post_author );
+		$this->assertSame( (string) $reassign_id, $post->post_author );
 	}
 
 	public function test_delete_user_invalid_reassign_id() {
@@ -2674,7 +2674,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		}
 
 		$test_post = get_post( $test_post );
-		$this->assertEquals( 0, $test_post->post_author );
+		$this->assertSame( '0', $test_post->post_author );
 	}
 
 	public function test_get_item_schema() {
@@ -2767,7 +2767,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 			)
 		);
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertEquals( 123, get_user_meta( 1, 'my_custom_int', true ) );
+		$this->assertSame( '123', get_user_meta( 1, 'my_custom_int', true ) );
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/users' );
 		$request->set_body_params(
@@ -2779,7 +2779,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 			)
 		);
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertEquals( 123, $response->data['my_custom_int'] );
+		$this->assertSame( '123', $response->data['my_custom_int'] );
 
 		global $wp_rest_additional_fields;
 		$wp_rest_additional_fields = array();

--- a/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
+++ b/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
@@ -343,7 +343,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 	 */
 	public function test_sanitize_template_id( $input_id, $sanitized_id ) {
 		$endpoint = new WP_REST_Templates_Controller( 'wp_template' );
-		$this->assertEquals(
+		$this->assertSame(
 			$sanitized_id,
 			$endpoint->_sanitize_template_id( $input_id )
 		);

--- a/tests/phpunit/tests/style-engine/wpStyleEngineCssRulesStore.php
+++ b/tests/phpunit/tests/style-engine/wpStyleEngineCssRulesStore.php
@@ -88,7 +88,7 @@ class Tests_Style_Engine_wpStyleEngineCSSRulesStore extends WP_UnitTestCase {
 		$burrito_store    = WP_Style_Engine_CSS_Rules_Store::get_store( 'burrito' );
 		$quesadilla_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'quesadilla' );
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'burrito'    => $burrito_store,
 				'quesadilla' => $quesadilla_store,
@@ -108,7 +108,7 @@ class Tests_Style_Engine_wpStyleEngineCSSRulesStore extends WP_UnitTestCase {
 		$dolmades_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'dolmades' );
 		$tzatziki_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'tzatziki' );
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'dolmades' => $dolmades_store,
 				'tzatziki' => $tzatziki_store,
@@ -119,7 +119,7 @@ class Tests_Style_Engine_wpStyleEngineCSSRulesStore extends WP_UnitTestCase {
 
 		WP_Style_Engine_CSS_Rules_Store::remove_all_stores();
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(),
 			WP_Style_Engine_CSS_Rules_Store::get_stores(),
 			'Return value of get_stores() is not an empty array after remove_all_stores() called.'

--- a/tests/phpunit/tests/taxonomy.php
+++ b/tests/phpunit/tests/taxonomy.php
@@ -352,13 +352,13 @@ class Tests_Taxonomy extends WP_UnitTestCase {
 		for ( $i = 0; $i < 3; $i++ ) {
 			$post_id = self::factory()->post->create();
 			wp_set_post_tags( $post_id, array( $tag_id ) );
-			$posts_with_tag[] = $post_id;
+			$posts_with_tag[] = (string) $post_id;
 		}
 
 		for ( $i = 0; $i < 3; $i++ ) {
 			$post_id = self::factory()->post->create();
 			wp_set_post_categories( $post_id, array( $cat_id ) );
-			$posts_with_category[] = $post_id;
+			$posts_with_category[] = (string) $post_id;
 		}
 
 		for ( $i = 0; $i < 3; $i++ ) {
@@ -367,10 +367,10 @@ class Tests_Taxonomy extends WP_UnitTestCase {
 
 		$posts_with_terms = array_merge( $posts_with_tag, $posts_with_category );
 
-		$this->assertEquals( $posts_with_tag, get_objects_in_term( $tag_id, 'post_tag' ) );
-		$this->assertEquals( $posts_with_category, get_objects_in_term( $cat_id, 'category' ) );
-		$this->assertEquals( $posts_with_terms, get_objects_in_term( array( $tag_id, $cat_id ), array( 'post_tag', 'category' ) ) );
-		$this->assertEquals( array_reverse( $posts_with_tag ), get_objects_in_term( $tag_id, 'post_tag', array( 'order' => 'desc' ) ) );
+		$this->assertSameSetsWithIndex( $posts_with_tag, get_objects_in_term( $tag_id, 'post_tag' ) );
+		$this->assertSameSetsWithIndex( $posts_with_category, get_objects_in_term( $cat_id, 'category' ) );
+		$this->assertSameSetsWithIndex( $posts_with_terms, get_objects_in_term( array( $tag_id, $cat_id ), array( 'post_tag', 'category' ) ) );
+		$this->assertSameSetsWithIndex( array_reverse( $posts_with_tag ), get_objects_in_term( $tag_id, 'post_tag', array( 'order' => 'desc' ) ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/term.php
+++ b/tests/phpunit/tests/term.php
@@ -92,8 +92,7 @@ class Tests_Term extends WP_UnitTestCase {
 		// Legacy usage should not trigger deprecated notice.
 		$count        = wp_count_terms( array( 'taxonomy' => 'post_tag' ) );
 		$legacy_count = wp_count_terms( 'post_tag' );
-		$this->assertEquals( 5, $count );
-		$this->assertEquals( $count, $legacy_count );
+		$this->assertSame( $count, $legacy_count );
 	}
 
 	/**
@@ -169,7 +168,7 @@ class Tests_Term extends WP_UnitTestCase {
 		$this->assertTrue( wp_delete_category( $t ) );
 		$this->assertNull( term_exists( $term ) );
 		$this->assertNull( term_exists( $t ) );
-		$this->assertEquals( $initial_count, wp_count_terms( array( 'taxonomy' => 'category' ) ) );
+		$this->assertSame( $initial_count, wp_count_terms( array( 'taxonomy' => 'category' ) ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/term.php
+++ b/tests/phpunit/tests/term.php
@@ -60,7 +60,7 @@ class Tests_Term extends WP_UnitTestCase {
 		// Clean up.
 		$deleted = wp_delete_term( $t['term_id'], $this->taxonomy );
 
-		$this->assertEquals( $t['term_id'], $exists );
+		$this->assertSame( (string) $t['term_id'], $exists );
 		$this->assertTrue( $deleted );
 	}
 
@@ -75,7 +75,7 @@ class Tests_Term extends WP_UnitTestCase {
 			)
 		);
 		// There are 5 posts, all Uncategorized.
-		$this->assertEquals( 1, $count );
+		$this->assertSame( '1', $count );
 	}
 
 	/**
@@ -86,12 +86,13 @@ class Tests_Term extends WP_UnitTestCase {
 
 		// Counts all terms (1 default category, 5 tags).
 		$count = wp_count_terms();
-		$this->assertEquals( 6, $count );
+		$this->assertSame( '6', $count );
 
 		// Counts only tags (5), with both current and legacy signature.
 		// Legacy usage should not trigger deprecated notice.
 		$count        = wp_count_terms( array( 'taxonomy' => 'post_tag' ) );
 		$legacy_count = wp_count_terms( 'post_tag' );
+		$this->assertSame( '5', $count );
 		$this->assertSame( $count, $legacy_count );
 	}
 
@@ -158,7 +159,7 @@ class Tests_Term extends WP_UnitTestCase {
 		$this->assertIsNumeric( $t );
 		$this->assertNotWPError( $t );
 		$this->assertGreaterThan( 0, $t );
-		$this->assertEquals( $initial_count + 1, wp_count_terms( array( 'taxonomy' => 'category' ) ) );
+		$this->assertSame( (string) ( $initial_count + 1 ), wp_count_terms( array( 'taxonomy' => 'category' ) ) );
 
 		// Make sure the term exists.
 		$this->assertGreaterThan( 0, term_exists( $term ) );

--- a/tests/phpunit/tests/term.php
+++ b/tests/phpunit/tests/term.php
@@ -181,7 +181,7 @@ class Tests_Term extends WP_UnitTestCase {
 
 		$this->assertIsArray( $post->post_category );
 		$this->assertCount( 1, $post->post_category );
-		$this->assertEquals( get_option( 'default_category' ), $post->post_category[0] );
+		$this->assertSame( (int) get_option( 'default_category' ), $post->post_category[0] );
 
 		$term1 = wp_insert_term( 'Foo', 'category' );
 		$term2 = wp_insert_term( 'Bar', 'category' );
@@ -204,11 +204,11 @@ class Tests_Term extends WP_UnitTestCase {
 
 		wp_set_post_categories( $post_id, array(), true );
 		$this->assertCount( 1, $post->post_category );
-		$this->assertEquals( get_option( 'default_category' ), $post->post_category[0] );
+		$this->assertSame( (int) get_option( 'default_category' ), $post->post_category[0] );
 
 		wp_set_post_categories( $post_id, array() );
 		$this->assertCount( 1, $post->post_category );
-		$this->assertEquals( get_option( 'default_category' ), $post->post_category[0] );
+		$this->assertSame( (int) get_option( 'default_category' ), $post->post_category[0] );
 	}
 
 	/**
@@ -222,7 +222,7 @@ class Tests_Term extends WP_UnitTestCase {
 		$post_id = self::factory()->post->create( array( 'post_type' => 'cpt' ) );
 		$post    = get_post( $post_id );
 
-		$this->assertEquals( get_option( 'default_category' ), $post->post_category[0] );
+		$this->assertSame( (int) get_option( 'default_category' ), $post->post_category[0] );
 
 		$term = wp_insert_term( 'Foo', 'category' );
 
@@ -230,7 +230,7 @@ class Tests_Term extends WP_UnitTestCase {
 		$this->assertSame( $term['term_id'], $post->post_category[0] );
 
 		wp_set_post_categories( $post_id, array() );
-		$this->assertEquals( get_option( 'default_category' ), $post->post_category[0] );
+		$this->assertSame( (int) get_option( 'default_category' ), $post->post_category[0] );
 
 		remove_filter( 'default_category_post_types', array( $this, 'filter_default_category_post_types' ) );
 	}

--- a/tests/phpunit/tests/term.php
+++ b/tests/phpunit/tests/term.php
@@ -262,7 +262,7 @@ class Tests_Term extends WP_UnitTestCase {
 		$post_id  = self::$post_ids[0];
 		$expected = wp_set_object_terms( $post_id, $name, 'category', false );
 		$actual   = wp_set_object_terms( $post_id, $name, 'category', false );
-		$this->assertArrayEqualsWithObject( $expected, $actual );
+		$this->assertEqualSets( $expected, $actual );
 	}
 
 	/**

--- a/tests/phpunit/tests/term.php
+++ b/tests/phpunit/tests/term.php
@@ -262,7 +262,7 @@ class Tests_Term extends WP_UnitTestCase {
 		$post_id  = self::$post_ids[0];
 		$expected = wp_set_object_terms( $post_id, $name, 'category', false );
 		$actual   = wp_set_object_terms( $post_id, $name, 'category', false );
-		$this->assertEquals( $expected, $actual );
+		$this->assertArrayEqualsWithObject( $expected, $actual );
 	}
 
 	/**

--- a/tests/phpunit/tests/term/cache.php
+++ b/tests/phpunit/tests/term/cache.php
@@ -154,7 +154,7 @@ class Tests_Term_Cache extends WP_UnitTestCase {
 
 		// No new queries should have fired.
 		$this->assertSame( $num_queries + 1, $wpdb->num_queries );
-		$this->assertEquals( $term_object, $term_object_2 );
+		$this->assertSimilarObject( $term_object, $term_object_2 );
 	}
 
 	public function test_get_term_by_should_update_term_cache_when_passed_a_valid_term_identifier() {
@@ -183,7 +183,7 @@ class Tests_Term_Cache extends WP_UnitTestCase {
 
 		// No new queries should have fired.
 		$this->assertSame( $num_queries + 1, $wpdb->num_queries );
-		$this->assertEquals( $term_object, $term_object_2 );
+		$this->assertSimilarObject( $term_object, $term_object_2 );
 	}
 
 	/**
@@ -265,7 +265,7 @@ class Tests_Term_Cache extends WP_UnitTestCase {
 		$this->assertSame( 'Taco', $term->name );
 		$this->assertSame( $num_queries, $wpdb->num_queries );
 
-		$this->assertEquals( get_term( $term_id, 'post_tag' ), $term );
+		$this->assertSimilarObject( get_term( $term_id, 'post_tag' ), $term );
 		$this->assertSame( $num_queries, $wpdb->num_queries );
 	}
 
@@ -332,7 +332,7 @@ class Tests_Term_Cache extends WP_UnitTestCase {
 		$term = get_term_by( 'name', 'Burrito', 'post_tag' );
 		$this->assertSame( $num_queries, $wpdb->num_queries );
 
-		$this->assertEquals( get_term( $term_id, 'post_tag' ), $term );
+		$this->assertSimilarObject( get_term( $term_id, 'post_tag' ), $term );
 		$this->assertSame( $num_queries, $wpdb->num_queries );
 	}
 
@@ -394,7 +394,7 @@ class Tests_Term_Cache extends WP_UnitTestCase {
 		// Verify the term is cached.
 		$term2 = get_term_by( 'name', 'Burrito', 'post_tag' );
 		$this->assertSame( $num_queries, $wpdb->num_queries );
-		$this->assertEquals( $term1, $term2 );
+		$this->assertSimilarObject( $term1, $term2 );
 
 		$suspend = wp_suspend_cache_invalidation();
 
@@ -405,7 +405,7 @@ class Tests_Term_Cache extends WP_UnitTestCase {
 		// Verify that the cached term still matches the initial cached term.
 		$term3 = get_term_by( 'name', 'Burrito', 'post_tag' );
 		$this->assertSame( $num_queries, $wpdb->num_queries );
-		$this->assertEquals( $term1, $term3 );
+		$this->assertSimilarObject( $term1, $term3 );
 
 		// Verify that last changed has not been updated as part of an invalidation routine.
 		$this->assertSame( $last_changed, wp_cache_get( 'last_changed', 'terms' ) );

--- a/tests/phpunit/tests/term/categoryExists.php
+++ b/tests/phpunit/tests/term/categoryExists.php
@@ -20,7 +20,7 @@ class Tests_Term_CategoryExists extends WP_UnitTestCase {
 
 		$found = category_exists( 'Foo', 0 );
 
-		$this->assertEquals( $found, $c3 );
+		$this->assertSame( (string) $c3, $found );
 	}
 
 	/**
@@ -43,7 +43,7 @@ class Tests_Term_CategoryExists extends WP_UnitTestCase {
 
 		$found = category_exists( 'Foo' );
 
-		$this->assertEquals( $found, $c2 );
+		$this->assertSame( (string) $c2, $found );
 	}
 
 	/**
@@ -66,7 +66,7 @@ class Tests_Term_CategoryExists extends WP_UnitTestCase {
 
 		$found = category_exists( 'Foo' );
 
-		$this->assertEquals( $found, $c2 );
+		$this->assertSame( (string) $c2, $found );
 	}
 
 	/**
@@ -88,6 +88,6 @@ class Tests_Term_CategoryExists extends WP_UnitTestCase {
 
 		$found = category_exists( 'Foo', $c1 );
 
-		$this->assertEquals( $found, $c2 );
+		$this->assertSame( (string) $c2, $found );
 	}
 }

--- a/tests/phpunit/tests/term/getTerm.php
+++ b/tests/phpunit/tests/term/getTerm.php
@@ -94,7 +94,7 @@ class Tests_Term_GetTerm extends WP_UnitTestCase {
 		// Second call shouldn't require a database query.
 		$term_b = get_term( $t, 'wptests_tax' );
 		$this->assertSame( $num_queries, $wpdb->num_queries );
-		$this->assertEquals( $term_a, $term_b );
+		$this->assertSimilarObject( $term_a, $term_b );
 	}
 
 	public function test_output_object() {

--- a/tests/phpunit/tests/term/getTermBy.php
+++ b/tests/phpunit/tests/term/getTermBy.php
@@ -10,19 +10,19 @@ class Tests_Term_GetTermBy extends WP_UnitTestCase {
 	public function test_get_term_by_slug() {
 		$term1 = wp_insert_term( 'Foo', 'category', array( 'slug' => 'foo' ) );
 		$term2 = get_term_by( 'slug', 'foo', 'category' );
-		$this->assertEquals( get_term( $term1['term_id'], 'category' ), $term2 );
+		$this->assertSimilarObject( get_term( $term1['term_id'], 'category' ), $term2 );
 	}
 
 	public function test_get_term_by_name() {
 		$term1 = wp_insert_term( 'Foo', 'category', array( 'slug' => 'foo' ) );
 		$term2 = get_term_by( 'name', 'Foo', 'category' );
-		$this->assertEquals( get_term( $term1['term_id'], 'category' ), $term2 );
+		$this->assertSimilarObject( get_term( $term1['term_id'], 'category' ), $term2 );
 	}
 
 	public function test_get_term_by_id() {
 		$term1 = wp_insert_term( 'Foo', 'category', array( 'slug' => 'foo' ) );
 		$term2 = get_term_by( 'id', $term1['term_id'], 'category' );
-		$this->assertEquals( get_term( $term1['term_id'], 'category' ), $term2 );
+		$this->assertSimilarObject( get_term( $term1['term_id'], 'category' ), $term2 );
 	}
 
 	/**
@@ -31,7 +31,7 @@ class Tests_Term_GetTermBy extends WP_UnitTestCase {
 	public function test_get_term_by_term_id() {
 		$term1 = wp_insert_term( 'Foo', 'category', array( 'slug' => 'foo' ) );
 		$term2 = get_term_by( 'term_id', $term1['term_id'], 'category' );
-		$this->assertEquals( get_term( $term1['term_id'], 'category' ), $term2 );
+		$this->assertSimilarObject( get_term( $term1['term_id'], 'category' ), $term2 );
 	}
 
 	/**
@@ -40,7 +40,7 @@ class Tests_Term_GetTermBy extends WP_UnitTestCase {
 	public function test_get_term_by_uppercase_id() {
 		$term1 = wp_insert_term( 'Foo', 'category', array( 'slug' => 'foo' ) );
 		$term2 = get_term_by( 'ID', $term1['term_id'], 'category' );
-		$this->assertEquals( get_term( $term1['term_id'], 'category' ), $term2 );
+		$this->assertSimilarObject( get_term( $term1['term_id'], 'category' ), $term2 );
 	}
 
 	/**
@@ -49,7 +49,7 @@ class Tests_Term_GetTermBy extends WP_UnitTestCase {
 	public function test_get_term_by_tt_id() {
 		$term1 = wp_insert_term( 'Foo', 'category' );
 		$term2 = get_term_by( 'term_taxonomy_id', $term1['term_taxonomy_id'], 'category' );
-		$this->assertEquals( get_term( $term1['term_id'], 'category' ), $term2 );
+		$this->assertSimilarObject( get_term( $term1['term_id'], 'category' ), $term2 );
 	}
 
 	public function test_get_term_by_unknown() {

--- a/tests/phpunit/tests/term/getTerms.php
+++ b/tests/phpunit/tests/term/getTerms.php
@@ -255,7 +255,7 @@ class Tests_Term_getTerms extends WP_UnitTestCase {
 				'fields'     => 'id=>parent',
 			)
 		);
-		$this->assertEquals(
+		$this->assertSameSetsWithIndex(
 			array(
 				$term_id1 => 0,
 				$term_id2 => $term_id1,

--- a/tests/phpunit/tests/term/getTerms.php
+++ b/tests/phpunit/tests/term/getTerms.php
@@ -1505,7 +1505,7 @@ class Tests_Term_getTerms extends WP_UnitTestCase {
 
 		_unregister_taxonomy( 'hierarchical_fields' );
 
-		$this->assertEquals( 5, $found );
+		$this->assertSame( '5', $found );
 	}
 
 	public function test_get_terms_hierarchical_tax_hide_empty_true_fields_count() {
@@ -1526,7 +1526,7 @@ class Tests_Term_getTerms extends WP_UnitTestCase {
 		_unregister_taxonomy( 'hierarchical_fields' );
 
 		// When using 'fields=count', 'hierarchical' is forced to false.
-		$this->assertEquals( 2, $found );
+		$this->assertSame( '2', $found );
 	}
 
 	public function test_get_terms_hierarchical_tax_hide_empty_true_fields_count_hierarchical_false() {
@@ -1547,7 +1547,7 @@ class Tests_Term_getTerms extends WP_UnitTestCase {
 
 		_unregister_taxonomy( 'hierarchical_fields' );
 
-		$this->assertEquals( 2, $found );
+		$this->assertSame( '2', $found );
 	}
 
 	public function test_get_terms_hierarchical_tax_hide_empty_false_fields_idparent() {

--- a/tests/phpunit/tests/term/getTerms.php
+++ b/tests/phpunit/tests/term/getTerms.php
@@ -288,7 +288,7 @@ class Tests_Term_getTerms extends WP_UnitTestCase {
 				'fields'     => 'id=>name',
 			)
 		);
-		$this->assertEquals(
+		$this->assertSameSetsWithIndex(
 			array(
 				$term_id1 => 'WOO!',
 				$term_id2 => 'HOO!',
@@ -303,7 +303,7 @@ class Tests_Term_getTerms extends WP_UnitTestCase {
 				'fields'     => 'id=>slug',
 			)
 		);
-		$this->assertEquals(
+		$this->assertSameSetsWithIndex(
 			array(
 				$term_id1 => 'woo',
 				$term_id2 => 'hoo',

--- a/tests/phpunit/tests/term/meta.php
+++ b/tests/phpunit/tests/term/meta.php
@@ -460,13 +460,13 @@ class Tests_Term_Meta extends WP_UnitTestCase {
 		$expected = array(
 			'meta_key'   => 'foo',
 			'meta_value' => 'bar',
-			'meta_id'    => $term_meta_id,
-			'term_id'    => $t,
+			'meta_id'    => (string) $term_meta_id,
+			'term_id'    => (string) $t,
 		);
 
 		$found = $meta[0];
 
-		$this->assertEquals( $expected, $found );
+		$this->assertSameSetsWithIndex( $expected, $found );
 	}
 
 	/**

--- a/tests/phpunit/tests/term/query.php
+++ b/tests/phpunit/tests/term/query.php
@@ -242,7 +242,7 @@ class Tests_Term_Query extends WP_UnitTestCase {
 		);
 		$terms = $query->get_terms();
 
-		$this->assertEquals( array( $t1, $t2 ), $terms );
+		$this->assertArrayEqualsWithObject( array( $t1, $t2 ), $terms );
 	}
 
 	/**

--- a/tests/phpunit/tests/term/query.php
+++ b/tests/phpunit/tests/term/query.php
@@ -242,7 +242,7 @@ class Tests_Term_Query extends WP_UnitTestCase {
 		);
 		$terms = $query->get_terms();
 
-		$this->assertArrayEqualsWithObject( array( $t1, $t2 ), $terms );
+		$this->assertEqualSets( array( $t1, $t2 ), $terms );
 	}
 
 	/**

--- a/tests/phpunit/tests/term/query.php
+++ b/tests/phpunit/tests/term/query.php
@@ -430,7 +430,7 @@ class Tests_Term_Query extends WP_UnitTestCase {
 			)
 		);
 		$count = $query->get_terms();
-		$this->assertEquals( 2, $count );
+		$this->assertSame( '2', $count );
 
 		$num_queries = $wpdb->num_queries;
 
@@ -442,7 +442,7 @@ class Tests_Term_Query extends WP_UnitTestCase {
 			)
 		);
 		$count = $query->get_terms();
-		$this->assertEquals( 2, $count );
+		$this->assertSame( '2', $count );
 		$this->assertSame( $num_queries, $wpdb->num_queries );
 	}
 
@@ -463,7 +463,7 @@ class Tests_Term_Query extends WP_UnitTestCase {
 			)
 		);
 		$count = $query->get_terms();
-		$this->assertEquals( 2, $count );
+		$this->assertSame( '2', $count );
 
 		wp_delete_term( $terms[0], 'wptests_tax_1' );
 
@@ -475,7 +475,7 @@ class Tests_Term_Query extends WP_UnitTestCase {
 			)
 		);
 		$count = $query->get_terms();
-		$this->assertEquals( 1, $count );
+		$this->assertSame( '1', $count );
 	}
 
 	/**

--- a/tests/phpunit/tests/term/splitSharedTerm.php
+++ b/tests/phpunit/tests/term/splitSharedTerm.php
@@ -223,11 +223,11 @@ class Tests_Term_SplitSharedTerm extends WP_UnitTestCase {
 				'menu-item-status'    => 'publish',
 			)
 		);
-		$this->assertEquals( $t1['term_id'], get_post_meta( $cat_menu_item, '_menu_item_object_id', true ) );
+		$this->assertSame( (string) $t1['term_id'], get_post_meta( $cat_menu_item, '_menu_item_object_id', true ) );
 
 		$new_term_id = _split_shared_term( $t1['term_id'], $t1['term_taxonomy_id'] );
 		$this->assertNotEquals( $new_term_id, $t1['term_id'] );
-		$this->assertEquals( $new_term_id, get_post_meta( $cat_menu_item, '_menu_item_object_id', true ) );
+		$this->assertSame( (string) $new_term_id, get_post_meta( $cat_menu_item, '_menu_item_object_id', true ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/term/taxQuery.php
+++ b/tests/phpunit/tests/term/taxQuery.php
@@ -262,7 +262,7 @@ class Tests_Term_Tax_Query extends WP_UnitTestCase {
 		);
 		$tq->transform_query( $tq->queries[0], 'term_taxonomy_id' );
 
-		$this->assertEquals( $tt_ids, $tq->queries[0]['terms'] );
+		$this->assertEqualSets( $tt_ids, $tq->queries[0]['terms'] );
 		$this->assertSame( 'term_taxonomy_id', $tq->queries[0]['field'] );
 	}
 

--- a/tests/phpunit/tests/term/taxQuery.php
+++ b/tests/phpunit/tests/term/taxQuery.php
@@ -59,7 +59,7 @@ class Tests_Term_Tax_Query extends WP_UnitTestCase {
 			'operator'         => 'IN',
 		);
 
-		$this->assertEquals( $expected, $tq->queries[0] );
+		$this->assertSameSetsWithIndex( $expected, $tq->queries[0] );
 	}
 
 	public function test_construct_fill_missing_query_params_merge_with_passed_values() {
@@ -82,7 +82,7 @@ class Tests_Term_Tax_Query extends WP_UnitTestCase {
 			'foo'              => 'bar',
 		);
 
-		$this->assertEquals( $expected, $tq->queries[0] );
+		$this->assertSameSetsWithIndex( $expected, $tq->queries[0] );
 	}
 
 	public function test_construct_cast_terms_to_array() {

--- a/tests/phpunit/tests/term/termExists.php
+++ b/tests/phpunit/tests/term/termExists.php
@@ -16,7 +16,7 @@ class Tests_TermExists extends WP_UnitTestCase {
 		);
 
 		$found = term_exists( (int) $t, 'post_tag' );
-		$this->assertEquals( $t, $found['term_id'] );
+		$this->assertSame( (string) $t, $found['term_id'] );
 	}
 
 	public function test_term_exists_term_int_taxonomy_nonempty_term_does_not_exist() {
@@ -41,7 +41,7 @@ class Tests_TermExists extends WP_UnitTestCase {
 		);
 
 		$found = term_exists( (int) $t, 'post_tag' );
-		$this->assertEquals( $t, $found['term_id'] );
+		$this->assertSame( (string) $t, $found['term_id'] );
 	}
 
 	public function test_term_exists_term_int_taxonomy_empty_term_does_not_exist() {
@@ -57,7 +57,7 @@ class Tests_TermExists extends WP_UnitTestCase {
 		);
 
 		$found = term_exists( 'I \"love\" WordPress\\\'s taxonomy system' );
-		$this->assertEquals( $t, $found );
+		$this->assertSame( (string) $t, $found );
 	}
 
 	public function test_term_exists_trim_term() {
@@ -69,7 +69,7 @@ class Tests_TermExists extends WP_UnitTestCase {
 		);
 
 		$found = term_exists( '  foo  ' );
-		$this->assertEquals( $t, $found );
+		$this->assertSame( (string) $t, $found );
 	}
 
 	public function test_term_exists_term_trimmed_to_empty_string() {
@@ -117,7 +117,7 @@ class Tests_TermExists extends WP_UnitTestCase {
 		_unregister_taxonomy( 'foo' );
 
 		$this->assertIsArray( $found );
-		$this->assertEquals( $t, $found['term_id'] );
+		$this->assertSame( (string) $t, $found['term_id'] );
 	}
 
 	/**
@@ -181,7 +181,7 @@ class Tests_TermExists extends WP_UnitTestCase {
 		_unregister_taxonomy( 'foo' );
 
 		$this->assertIsArray( $found );
-		$this->assertEquals( $t, $found['term_id'] );
+		$this->assertSame( (string) $t, $found['term_id'] );
 	}
 
 	public function test_term_exists_taxonomy_nonempty_parent_empty_match_slug() {
@@ -199,7 +199,7 @@ class Tests_TermExists extends WP_UnitTestCase {
 		_unregister_taxonomy( 'foo' );
 
 		$this->assertIsArray( $found );
-		$this->assertEquals( $t, $found['term_id'] );
+		$this->assertSame( (string) $t, $found['term_id'] );
 	}
 
 	public function test_term_exists_taxonomy_nonempty_parent_empty_match_name() {
@@ -217,7 +217,7 @@ class Tests_TermExists extends WP_UnitTestCase {
 		_unregister_taxonomy( 'foo' );
 
 		$this->assertIsArray( $found );
-		$this->assertEquals( $t, $found['term_id'] );
+		$this->assertSame( (string) $t, $found['term_id'] );
 	}
 
 	public function test_term_exists_taxonomy_empty_parent_empty_match_slug() {
@@ -235,7 +235,7 @@ class Tests_TermExists extends WP_UnitTestCase {
 		_unregister_taxonomy( 'foo' );
 
 		$this->assertIsString( $found );
-		$this->assertEquals( $t, $found );
+		$this->assertSame( (string) $t, $found );
 	}
 
 	public function test_term_exists_taxonomy_empty_parent_empty_match_name() {
@@ -253,7 +253,7 @@ class Tests_TermExists extends WP_UnitTestCase {
 		_unregister_taxonomy( 'foo' );
 
 		$this->assertIsString( $found );
-		$this->assertEquals( $t, $found );
+		$this->assertSame( (string) $t, $found );
 	}
 
 	public function test_term_exists_known() {
@@ -263,8 +263,8 @@ class Tests_TermExists extends WP_UnitTestCase {
 		$term = __FUNCTION__;
 		$t    = wp_insert_term( $term, 'wptests_tax' );
 		$this->assertIsArray( $t );
-		$this->assertEquals( $t['term_id'], term_exists( $t['term_id'] ) );
-		$this->assertEquals( $t['term_id'], term_exists( $term ) );
+		$this->assertSame( (string) $t['term_id'], term_exists( $t['term_id'] ) );
+		$this->assertSame( (string) $t['term_id'], term_exists( $term ) );
 
 		// Clean up.
 		$this->assertTrue( wp_delete_term( $t['term_id'], 'wptests_tax' ) );
@@ -285,7 +285,7 @@ class Tests_TermExists extends WP_UnitTestCase {
 				'taxonomy' => 'wptests_tax',
 			)
 		);
-		$this->assertEquals( $t, term_exists( $t ) );
+		$this->assertSame( (string) $t, term_exists( $t ) );
 		$this->assertTrue( wp_delete_term( $t, 'wptests_tax' ) );
 		$this->assertNull( term_exists( $t ) );
 
@@ -307,7 +307,7 @@ class Tests_TermExists extends WP_UnitTestCase {
 				'taxonomy' => 'wptests_tax',
 			)
 		);
-		$this->assertEquals( $t, term_exists( $slug ) );
+		$this->assertSame( (string) $t, term_exists( $slug ) );
 		$this->assertTrue( wp_delete_term( $t, 'wptests_tax' ) );
 		$this->assertNull( term_exists( $slug ) );
 
@@ -330,9 +330,9 @@ class Tests_TermExists extends WP_UnitTestCase {
 				'taxonomy' => 'wptests_tax',
 			)
 		);
-		$this->assertEquals( $t, term_exists( $slug ) );
+		$this->assertSame( (string) $t, term_exists( $slug ) );
 		$num_queries = $wpdb->num_queries;
-		$this->assertEquals( $t, term_exists( $slug ) );
+		$this->assertSame( (string) $t, term_exists( $slug ) );
 		$this->assertSame( $num_queries, $wpdb->num_queries );
 
 		$this->assertTrue( wp_delete_term( $t, 'wptests_tax' ) );
@@ -361,9 +361,9 @@ class Tests_TermExists extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertEquals( $t, term_exists( $slug ) );
+		$this->assertSame( (string) $t, term_exists( $slug ) );
 		$num_queries = $wpdb->num_queries;
-		$this->assertEquals( $t, term_exists( $slug ) );
+		$this->assertSame( (string) $t, term_exists( $slug ) );
 		$this->assertSame( $num_queries + 1, $wpdb->num_queries );
 		wp_suspend_cache_invalidation( false );
 

--- a/tests/phpunit/tests/term/wpInsertTerm.php
+++ b/tests/phpunit/tests/term/wpInsertTerm.php
@@ -780,8 +780,8 @@ class Tests_Term_WpInsertTerm extends WP_UnitTestCase {
 		$this->assertNotEmpty( $found['term_id'] );
 		$this->assertNotEmpty( $found['term_taxonomy_id'] );
 		$this->assertNotEmpty( $term_by_id );
-		$this->assertEquals( $term_by_id, $term_by_slug );
-		$this->assertEquals( $term_by_id, $term_by_ttid );
+		$this->assertSimilarObject( $term_by_id, $term_by_slug );
+		$this->assertSimilarObject( $term_by_id, $term_by_ttid );
 	}
 
 	public function test_wp_insert_term_should_clean_term_cache() {

--- a/tests/phpunit/tests/term/wpInsertTerm.php
+++ b/tests/phpunit/tests/term/wpInsertTerm.php
@@ -31,7 +31,7 @@ class Tests_Term_WpInsertTerm extends WP_UnitTestCase {
 		$this->assertNotWPError( $t );
 		$this->assertGreaterThan( 0, $t['term_id'] );
 		$this->assertGreaterThan( 0, $t['term_taxonomy_id'] );
-		$this->assertEquals( $initial_count + 1, wp_count_terms( array( 'taxonomy' => $taxonomy ) ) );
+		$this->assertSame( (string) ( $initial_count + 1 ), wp_count_terms( array( 'taxonomy' => $taxonomy ) ) );
 
 		// Make sure the term exists.
 		$this->assertGreaterThan( 0, term_exists( $term ) );

--- a/tests/phpunit/tests/term/wpInsertTerm.php
+++ b/tests/phpunit/tests/term/wpInsertTerm.php
@@ -906,7 +906,7 @@ class Tests_Term_WpInsertTerm extends WP_UnitTestCase {
 		// Pesky string $this->assertIsInt( $tt_id );
 		$this->assertSame( $term, $deleted_term->term_id );
 		$this->assertSame( $taxonomy, $deleted_term->taxonomy );
-		$this->assertEquals( $tt_id, $deleted_term->term_taxonomy_id );
+		$this->assertSame( (int) $tt_id, $deleted_term->term_taxonomy_id );
 		$this->assertEmpty( $object_ids );
 	}
 

--- a/tests/phpunit/tests/term/wpSetObjectTerms.php
+++ b/tests/phpunit/tests/term/wpSetObjectTerms.php
@@ -341,7 +341,7 @@ class Tests_Term_WpSetObjectTerms extends WP_UnitTestCase {
 		$this->assertSame( $terms_2, $terms );
 
 		// Make sure the term taxonomy ID for 'bar' matches.
-		$this->assertEquals( $tt_1[1], $tt_2[0] );
+		$this->assertSame( (string) $tt_1[1], $tt_2[0] );
 
 	}
 

--- a/tests/phpunit/tests/term/wpUpdateTerm.php
+++ b/tests/phpunit/tests/term/wpUpdateTerm.php
@@ -616,8 +616,8 @@ class Tests_Term_WpUpdateTerm extends WP_UnitTestCase {
 		$this->assertNotEmpty( $found['term_id'] );
 		$this->assertNotEmpty( $found['term_taxonomy_id'] );
 		$this->assertNotEmpty( $term_by_id );
-		$this->assertEquals( $term_by_id, $term_by_slug );
-		$this->assertEquals( $term_by_id, $term_by_ttid );
+		$this->assertSimilarObject( $term_by_id, $term_by_slug );
+		$this->assertSimilarObject( $term_by_id, $term_by_ttid );
 	}
 
 	/**

--- a/tests/phpunit/tests/theme.php
+++ b/tests/phpunit/tests/theme.php
@@ -63,7 +63,7 @@ class Tests_Theme extends WP_UnitTestCase {
 
 		$single_theme = wp_get_theme( $this->theme_slug );
 		$this->assertSame( $single_theme->get( 'Name' ), $themes[ $this->theme_slug ]->get( 'Name' ) );
-		$this->assertEquals( $themes[ $this->theme_slug ], $single_theme );
+		$this->assertSimilarObject( $themes[ $this->theme_slug ], $single_theme );
 	}
 
 	/**
@@ -103,7 +103,7 @@ class Tests_Theme extends WP_UnitTestCase {
 			$_theme = wp_get_theme( $theme->get_stylesheet() );
 			// This primes internal WP_Theme caches for the next assertion (headers_sanitized, textdomain_loaded).
 			$this->assertSame( $theme->get( 'Name' ), $_theme->get( 'Name' ) );
-			$this->assertEquals( $theme, $_theme );
+			$this->assertSimilarObject( $theme, $_theme );
 		}
 	}
 

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -676,6 +676,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 			'.has-grey-color{color: var(--wp--preset--color--grey) !important;}.has-dark-grey-color{color: var(--wp--preset--color--dark-grey) !important;}.has-light-grey-color{color: var(--wp--preset--color--light-grey) !important;}.has-white-2-black-color{color: var(--wp--preset--color--white-2-black) !important;}.has-grey-background-color{background-color: var(--wp--preset--color--grey) !important;}.has-dark-grey-background-color{background-color: var(--wp--preset--color--dark-grey) !important;}.has-light-grey-background-color{background-color: var(--wp--preset--color--light-grey) !important;}.has-white-2-black-background-color{background-color: var(--wp--preset--color--white-2-black) !important;}.has-grey-border-color{border-color: var(--wp--preset--color--grey) !important;}.has-dark-grey-border-color{border-color: var(--wp--preset--color--dark-grey) !important;}.has-light-grey-border-color{border-color: var(--wp--preset--color--light-grey) !important;}.has-white-2-black-border-color{border-color: var(--wp--preset--color--white-2-black) !important;}',
 			$theme_json->get_stylesheet( array( 'presets' ) )
 		);
+
 		$this->assertSame(
 			'body{--wp--preset--color--grey: grey;--wp--preset--color--dark-grey: grey;--wp--preset--color--light-grey: grey;--wp--preset--color--white-2-black: grey;--wp--custom--white-2-black: value;}',
 			$theme_json->get_stylesheet( array( 'variables' ) )
@@ -3305,7 +3306,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 			'default'
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			'body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-site-blocks > * { margin-block-start: 0; margin-block-end: 0; }.wp-site-blocks > * + * { margin-block-start: 1rem; }body { --wp--style--block-gap: 1rem; }body .is-layout-flow > *{margin-block-start: 0;margin-block-end: 0;}body .is-layout-flow > * + *{margin-block-start: 1rem;margin-block-end: 0;}body .is-layout-flex{gap: 1rem;}body .is-layout-flow > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}body .is-layout-flow > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}body .is-layout-flow > .aligncenter{margin-left: auto !important;margin-right: auto !important;}body .is-layout-flex{display: flex;}body .is-layout-flex{flex-wrap: wrap;align-items: center;}.wp-block-post-content{color: gray;}.wp-block-social-links.is-layout-flow > *{margin-block-start: 0;margin-block-end: 0;}.wp-block-social-links.is-layout-flow > * + *{margin-block-start: 0;margin-block-end: 0;}.wp-block-social-links.is-layout-flex{gap: 0;}.wp-block-buttons.is-layout-flow > *{margin-block-start: 0;margin-block-end: 0;}.wp-block-buttons.is-layout-flow > * + *{margin-block-start: 0;margin-block-end: 0;}.wp-block-buttons.is-layout-flex{gap: 0;}',
 			$theme_json->get_stylesheet()
 		);

--- a/tests/phpunit/tests/theme/wpThemeJsonResolver.php
+++ b/tests/phpunit/tests/theme/wpThemeJsonResolver.php
@@ -366,7 +366,7 @@ class Tests_Theme_wpThemeJsonResolver extends WP_UnitTestCase {
 			WP_Theme_JSON_Resolver::clean_cached_data();
 		}
 		$query_count = count( $this->queries ) - $query_count;
-		$this->assertEquals( 0, $query_count, 'Unexpected SQL queries detected for the wp_global_style post type' );
+		$this->assertSame( 0, $query_count, 'Unexpected SQL queries detected for the wp_global_style post type' );
 
 		$user_cpt = WP_Theme_JSON_Resolver::get_user_data_from_wp_global_styles( $theme );
 		$this->assertEmpty( $user_cpt );
@@ -381,7 +381,7 @@ class Tests_Theme_wpThemeJsonResolver extends WP_UnitTestCase {
 			$this->assertSameSets( $user_cpt, $new_user_cpt );
 		}
 		$query_count = count( $this->queries ) - $query_count;
-		$this->assertEquals( 0, $query_count, 'Unexpected SQL queries detected for the wp_global_style post type' );
+		$this->assertSame( 0, $query_count, 'Unexpected SQL queries detected for the wp_global_style post type' );
 		remove_filter( 'query', array( $this, 'filter_db_query' ) );
 	}
 

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -307,7 +307,7 @@ class Tests_User extends WP_UnitTestCase {
 			$user = new WP_User( $user_id );
 
 			$this->assertTrue( isset( $user->user_level ) );
-			$this->assertEquals( $level, $user->user_level );
+			$this->assertSame( (string) $level, $user->user_level );
 		}
 	}
 
@@ -354,7 +354,7 @@ class Tests_User extends WP_UnitTestCase {
 		$user = new WP_User( self::$author_id );
 		$this->assertSame( 'author_login', $user->get( 'user_login' ) );
 		$this->assertSame( 'author@email.com', $user->get( 'user_email' ) );
-		$this->assertEquals( 0, $user->get( 'use_ssl' ) );
+		$this->assertSame( '0', $user->get( 'use_ssl' ) );
 		$this->assertSame( '', $user->get( 'field_that_does_not_exist' ) );
 
 		update_user_meta( self::$author_id, 'dashed-key', 'abcdefg' );
@@ -422,7 +422,7 @@ class Tests_User extends WP_UnitTestCase {
 
 		$user = new WP_User( self::$author_id );
 		foreach ( $user_data as $key => $value ) {
-			$this->assertEquals( $value, $user->get( $key ), $key );
+			$this->assertSame( (string) $value, $user->get( $key ), $key );
 		}
 	}
 
@@ -511,7 +511,7 @@ class Tests_User extends WP_UnitTestCase {
 	public function test_user_get_data_by_id() {
 		$user = WP_User::get_data_by( 'id', self::$author_id );
 		$this->assertInstanceOf( 'stdClass', $user );
-		$this->assertEquals( self::$author_id, $user->ID );
+		$this->assertSame( (string) self::$author_id, $user->ID );
 
 		// @ticket 23480
 		$user1 = WP_User::get_data_by( 'id', -1 );
@@ -541,7 +541,7 @@ class Tests_User extends WP_UnitTestCase {
 	 */
 	public function test_user_get_data_by_ID_should_alias_to_id() {
 		$user = WP_User::get_data_by( 'ID', self::$author_id );
-		$this->assertEquals( self::$author_id, $user->ID );
+		$this->assertSame( (string) self::$author_id, $user->ID );
 	}
 
 	/**
@@ -560,21 +560,21 @@ class Tests_User extends WP_UnitTestCase {
 
 		wp_set_current_user( self::$author_id );
 		$counts = count_many_users_posts( array( self::$author_id, $user_id_b ), 'post', false );
-		$this->assertEquals( 1, $counts[ self::$author_id ] );
-		$this->assertEquals( 1, $counts[ $user_id_b ] );
+		$this->assertSame( '1', $counts[ self::$author_id ] );
+		$this->assertSame( '1', $counts[ $user_id_b ] );
 
 		$counts = count_many_users_posts( array( self::$author_id, $user_id_b ), 'post', true );
-		$this->assertEquals( 1, $counts[ self::$author_id ] );
-		$this->assertEquals( 1, $counts[ $user_id_b ] );
+		$this->assertSame( '1', $counts[ self::$author_id ] );
+		$this->assertSame( '1', $counts[ $user_id_b ] );
 
 		wp_set_current_user( $user_id_b );
 		$counts = count_many_users_posts( array( self::$author_id, $user_id_b ), 'post', false );
-		$this->assertEquals( 1, $counts[ self::$author_id ] );
-		$this->assertEquals( 2, $counts[ $user_id_b ] );
+		$this->assertSame( '1', $counts[ self::$author_id ] );
+		$this->assertSame( '2', $counts[ $user_id_b ] );
 
 		$counts = count_many_users_posts( array( self::$author_id, $user_id_b ), 'post', true );
-		$this->assertEquals( 1, $counts[ self::$author_id ] );
-		$this->assertEquals( 1, $counts[ $user_id_b ] );
+		$this->assertSame( '1', $counts[ self::$author_id ] );
+		$this->assertSame( '1', $counts[ $user_id_b ] );
 	}
 
 	/**
@@ -1068,7 +1068,7 @@ class Tests_User extends WP_UnitTestCase {
 		$updated_user = get_userdata( $u );
 
 		$this->assertFalse( wp_cache_get( $user->user_nicename, 'userslugs' ) );
-		$this->assertEquals( $u, wp_cache_get( $updated_user->user_nicename, 'userslugs' ) );
+		$this->assertSame( (string) $u, wp_cache_get( $updated_user->user_nicename, 'userslugs' ) );
 	}
 
 	public function test_changing_email_invalidates_password_reset_key() {

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -192,7 +192,15 @@ class Tests_User extends WP_UnitTestCase {
 		$user = new WP_User( self::$author_id );
 
 		foreach ( $user->data as $key => $data ) {
-			$this->assertEquals( $data, $user->$key );
+			if ( is_string( $user->$key ) ) {
+				$data = (string) $data;
+			}
+
+			if ( is_int( $user->$key ) ) {
+				$data = (int) $data;
+			}
+
+			$this->assertSame( $data, $user->$key );
 		}
 
 		$this->assertTrue( isset( $user->$key ) );

--- a/tests/phpunit/tests/user/author.php
+++ b/tests/phpunit/tests/user/author.php
@@ -80,7 +80,7 @@ class Tests_User_Author_Template extends WP_UnitTestCase {
 		// Test with no global post, result should be 0 because no author is found.
 		$this->assertSame( 0, get_the_author_posts() );
 		$GLOBALS['post'] = self::$post_id;
-		$this->assertEquals( 1, get_the_author_posts() );
+		$this->assertSame( '1', get_the_author_posts() );
 	}
 
 	/**
@@ -98,7 +98,7 @@ class Tests_User_Author_Template extends WP_UnitTestCase {
 		);
 		$GLOBALS['post'] = $cpt_ids[0];
 
-		$this->assertEquals( 2, get_the_author_posts() );
+		$this->assertSame( '2', get_the_author_posts() );
 
 		_unregister_post_type( 'wptests_pt' );
 	}

--- a/tests/phpunit/tests/user/capabilities.php
+++ b/tests/phpunit/tests/user/capabilities.php
@@ -2490,7 +2490,7 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 
 		$role = $wp_roles->get_role( $this->role_test_wp_roles_init['role'] );
 
-		$this->assertEquals( $expected, $role );
+		$this->assertSimilarObject( $expected, $role );
 		$this->assertContains( $this->role_test_wp_roles_init['info']['name'], $wp_roles->role_names );
 	}
 

--- a/tests/phpunit/tests/user/capabilities.php
+++ b/tests/phpunit/tests/user/capabilities.php
@@ -1621,7 +1621,7 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 		$this->assertTrue( $user->exists(), "Problem getting user $id" );
 
 		// Author = user level 2.
-		$this->assertEquals( 2, $user->user_level );
+		$this->assertSame( '2', $user->user_level );
 
 		// They get promoted to editor - level should get bumped to 7.
 		$user->set_role( 'editor' );

--- a/tests/phpunit/tests/user/countUserPosts.php
+++ b/tests/phpunit/tests/user/countUserPosts.php
@@ -59,34 +59,34 @@ class Tests_User_CountUserPosts extends WP_UnitTestCase {
 	}
 
 	public function test_count_user_posts_post_type_should_default_to_post() {
-		$this->assertEquals( 4, count_user_posts( self::$user_id ) );
+		$this->assertSame( '4', count_user_posts( self::$user_id ) );
 	}
 
 	/**
 	 * @ticket 21364
 	 */
 	public function test_count_user_posts_post_type_post() {
-		$this->assertEquals( 4, count_user_posts( self::$user_id, 'post' ) );
+		$this->assertSame( '4', count_user_posts( self::$user_id, 'post' ) );
 	}
 
 	/**
 	 * @ticket 21364
 	 */
 	public function test_count_user_posts_post_type_cpt() {
-		$this->assertEquals( 3, count_user_posts( self::$user_id, 'wptests_pt' ) );
+		$this->assertSame( '3', count_user_posts( self::$user_id, 'wptests_pt' ) );
 	}
 
 	/**
 	 * @ticket 32243
 	 */
 	public function test_count_user_posts_with_multiple_post_types() {
-		$this->assertEquals( 7, count_user_posts( self::$user_id, array( 'wptests_pt', 'post' ) ) );
+		$this->assertSame( '7', count_user_posts( self::$user_id, array( 'wptests_pt', 'post' ) ) );
 	}
 
 	/**
 	 * @ticket 32243
 	 */
 	public function test_count_user_posts_should_ignore_non_existent_post_types() {
-		$this->assertEquals( 4, count_user_posts( self::$user_id, array( 'foo', 'post' ) ) );
+		$this->assertSame( '4', count_user_posts( self::$user_id, array( 'foo', 'post' ) ) );
 	}
 }

--- a/tests/phpunit/tests/user/countUsers.php
+++ b/tests/phpunit/tests/user/countUsers.php
@@ -53,7 +53,7 @@ class Tests_User_CountUsers extends WP_UnitTestCase {
 		$count = count_users( $strategy );
 
 		$this->assertSame( 8, $count['total_users'] );
-		$this->assertEquals(
+		$this->assertSameSetsWithIndex(
 			array(
 				'administrator' => 2,
 				'editor'        => 1,
@@ -133,7 +133,7 @@ class Tests_User_CountUsers extends WP_UnitTestCase {
 		$count = count_users( $strategy );
 
 		$this->assertSame( 8, $count['total_users'] );
-		$this->assertEquals(
+		$this->assertSameSetsWithIndex(
 			array(
 				'administrator' => 2,
 				'editor'        => 1,
@@ -151,7 +151,7 @@ class Tests_User_CountUsers extends WP_UnitTestCase {
 		restore_current_blog();
 
 		$this->assertSame( 2, $count['total_users'] );
-		$this->assertEquals(
+		$this->assertSameSetsWithIndex(
 			array(
 				'administrator' => 1,
 				'editor'        => 1,
@@ -166,7 +166,7 @@ class Tests_User_CountUsers extends WP_UnitTestCase {
 		restore_current_blog();
 
 		$this->assertSame( 2, $count['total_users'] );
-		$this->assertEquals(
+		$this->assertSameSetsWithIndex(
 			array(
 				'administrator' => 1,
 				'contributor'   => 1,
@@ -239,7 +239,7 @@ class Tests_User_CountUsers extends WP_UnitTestCase {
 		$count = count_users( $strategy );
 
 		$this->assertSame( 3, $count['total_users'] );
-		$this->assertEquals(
+		$this->assertSameSetsWithIndex(
 			array(
 				'administrator' => 2,
 				'editor'        => 1,

--- a/tests/phpunit/tests/user/multisite.php
+++ b/tests/phpunit/tests/user/multisite.php
@@ -22,7 +22,7 @@ if ( is_multisite() ) :
 			$post = get_post( $post_id );
 
 			$this->assertNotEquals( $user1->ID, $post->post_author );
-			$this->assertEquals( $user2->ID, $post->post_author );
+			$this->assertSame( (string) $user2->ID, $post->post_author );
 		}
 
 		/**
@@ -81,9 +81,9 @@ if ( is_multisite() ) :
 			$this->assertSame( $blog_ids, $blog_ids_of_user );
 
 			// Check if sites are flagged as expected.
-			$this->assertEquals( 1, $blogs_of_user[ $blog_ids[0] ]->spam );
-			$this->assertEquals( 1, $blogs_of_user[ $blog_ids[1] ]->archived );
-			$this->assertEquals( 1, $blogs_of_user[ $blog_ids[2] ]->deleted );
+			$this->assertSame( '1', $blogs_of_user[ $blog_ids[0] ]->spam );
+			$this->assertSame( '1', $blogs_of_user[ $blog_ids[1] ]->archived );
+			$this->assertSame( '1', $blogs_of_user[ $blog_ids[2] ]->deleted );
 
 			unset( $blog_ids[0] );
 			unset( $blog_ids[1] );

--- a/tests/phpunit/tests/user/query.php
+++ b/tests/phpunit/tests/user/query.php
@@ -222,9 +222,14 @@ class Tests_User_Query extends WP_UnitTestCase {
 			)
 		);
 
-		$expected = array( self::$author_ids[3], self::$author_ids[1], self::$author_ids[0], self::$author_ids[2] );
+		$expected = array(
+			(string) self::$author_ids[3],
+			(string) self::$author_ids[1],
+			(string) self::$author_ids[0],
+			(string) self::$author_ids[2],
+		);
 
-		$this->assertEquals( $expected, $q->get_results() );
+		$this->assertSameSetsWithIndex( $expected, $q->get_results() );
 	}
 
 	/**
@@ -244,9 +249,13 @@ class Tests_User_Query extends WP_UnitTestCase {
 			)
 		);
 
-		$expected = array( self::$author_ids[1], self::$author_ids[2], self::$author_ids[0] );
+		$expected = array(
+			(string) self::$author_ids[1],
+			(string) self::$author_ids[2],
+			(string) self::$author_ids[0],
+		);
 
-		$this->assertEquals( $expected, $q->get_results() );
+		$this->assertSameSetsWithIndex( $expected, $q->get_results() );
 	}
 
 	/**
@@ -266,9 +275,13 @@ class Tests_User_Query extends WP_UnitTestCase {
 			)
 		);
 
-		$expected = array( self::$author_ids[1], self::$author_ids[2], self::$author_ids[0] );
+		$expected = array(
+			(string) self::$author_ids[1],
+			(string) self::$author_ids[2],
+			(string) self::$author_ids[0],
+		);
 
-		$this->assertEquals( $expected, $q->get_results() );
+		$this->assertSameSetsWithIndex( $expected, $q->get_results() );
 	}
 
 	/**
@@ -293,7 +306,13 @@ class Tests_User_Query extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertEquals( array( self::$author_ids[1], self::$author_ids[2], self::$author_ids[0] ), $q->results );
+		$expected = array(
+			(string) self::$author_ids[1],
+			(string) self::$author_ids[2],
+			(string) self::$author_ids[0],
+		);
+
+		$this->assertSameSetsWithIndex( $expected, $q->results );
 	}
 
 	/**
@@ -336,7 +355,13 @@ class Tests_User_Query extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertEquals( array( $u3, $u1, $u2 ), $q->results );
+		$expected = array(
+			(string) $u3,
+			(string) $u1,
+			(string) $u2,
+		);
+
+		$this->assertSameSetsWithIndex( $expected, $q->results );
 	}
 
 	/**
@@ -370,7 +395,13 @@ class Tests_User_Query extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertEquals( array( self::$author_ids[2], self::$author_ids[0], self::$author_ids[1] ), $q->results );
+		$expected = array(
+			(string) self::$author_ids[2],
+			(string) self::$author_ids[0],
+			(string) self::$author_ids[1],
+		);
+
+		$this->assertSameSetsWithIndex( $expected, $q->results );
 	}
 
 	/**
@@ -403,8 +434,13 @@ class Tests_User_Query extends WP_UnitTestCase {
 		$expected_orderby = 'ORDER BY FIELD( ' . $wpdb->users . '.ID, ' . self::$author_ids[1] . ',' . self::$author_ids[0] . ',' . self::$author_ids[3] . ' )';
 		$this->assertStringContainsString( $expected_orderby, $q->query_orderby );
 
-		// assertEquals() respects order but ignores type (get_results() returns numeric strings).
-		$this->assertEquals( array( self::$author_ids[1], self::$author_ids[0], self::$author_ids[3] ), $q->get_results() );
+		$expected = array(
+			(string) self::$author_ids[1],
+			(string) self::$author_ids[0],
+			(string) self::$author_ids[3],
+		);
+
+		$this->assertSameSetsWithIndex( $expected, $q->get_results() );
 	}
 
 	/**
@@ -424,8 +460,13 @@ class Tests_User_Query extends WP_UnitTestCase {
 		$expected_orderby = 'ORDER BY FIELD( ' . $wpdb->users . '.ID, ' . self::$author_ids[1] . ',' . self::$author_ids[0] . ',' . self::$author_ids[3] . ' )';
 		$this->assertStringContainsString( $expected_orderby, $q->query_orderby );
 
-		// assertEquals() respects order but ignores type (get_results() returns numeric strings).
-		$this->assertEquals( array( self::$author_ids[1], self::$author_ids[0], self::$author_ids[3] ), $q->get_results() );
+		$expected = array(
+			(string) self::$author_ids[1],
+			(string) self::$author_ids[0],
+			(string) self::$author_ids[3],
+		);
+
+		$this->assertSameSetsWithIndex( $expected, $q->get_results() );
 	}
 
 	/**
@@ -643,7 +684,12 @@ class Tests_User_Query extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertEquals( array( self::$author_ids[0], self::$author_ids[1] ), $query->get_results() );
+		$expected = array(
+			(string) self::$author_ids[0],
+			(string) self::$author_ids[1],
+		);
+
+		$this->assertSameSetsWithIndex( $expected, $query->get_results() );
 	}
 
 	public function test_roles_and_caps_should_be_populated_for_default_value_of_blog_id() {
@@ -1305,7 +1351,12 @@ class Tests_User_Query extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertEquals( array( self::$contrib_id, self::$editor_ids[2] ), $q->results );
+		$expected = array(
+			(string) self::$contrib_id,
+			(string) self::$editor_ids[2],
+		);
+
+		$this->assertSameSetsWithIndex( $expected, $q->results );
 	}
 
 	/**
@@ -1685,7 +1736,7 @@ class Tests_User_Query extends WP_UnitTestCase {
 		$ids = $q->get_results();
 
 		// Must include user that has the same string in display_name.
-		$this->assertEquals( array( $new_user1 ), $ids );
+		$this->assertSameSetsWithIndex( array( (string) $new_user1 ), $ids );
 	}
 
 	/**

--- a/tests/phpunit/tests/user/query.php
+++ b/tests/phpunit/tests/user/query.php
@@ -52,7 +52,7 @@ class Tests_User_Query extends WP_UnitTestCase {
 	public function test_get_and_set() {
 		$users = new WP_User_Query();
 
-		$this->assertEquals( '', $users->get( 'fields' ) );
+		$this->assertNull( $users->get( 'fields' ) );
 		if ( isset( $users->query_vars['fields'] ) ) {
 			$this->assertSame( '', $users->query_vars['fields'] );
 		}
@@ -582,7 +582,7 @@ class Tests_User_Query extends WP_UnitTestCase {
 		// All values get reset.
 		$query->prepare_query( array( 'fields' => 'all' ) );
 		$this->assertEmpty( $query->query_limit );
-		$this->assertEquals( '', $query->query_limit );
+		$this->assertNull( $query->query_limit );
 		$_query_vars = $query->query_vars;
 
 		$query->prepare_query();

--- a/tests/phpunit/tests/user/updateUserCaches.php
+++ b/tests/phpunit/tests/user/updateUserCaches.php
@@ -12,7 +12,7 @@ class Tests_User_UpdateUserCaches extends WP_UnitTestCase {
 
 		update_user_caches( $raw_userdata );
 
-		$this->assertEquals( $raw_userdata, wp_cache_get( $u, 'users' ) );
+		$this->assertSimilarObject( $raw_userdata, wp_cache_get( $u, 'users' ) );
 	}
 
 	public function test_should_store_user_id_in_userlogins_bucket() {
@@ -65,6 +65,6 @@ class Tests_User_UpdateUserCaches extends WP_UnitTestCase {
 
 		$cached = wp_cache_get( $u, 'users' );
 		$this->assertNotInstanceOf( 'WP_User', $cached );
-		$this->assertEquals( $raw_userdata, $cached );
+		$this->assertSimilarObject( $raw_userdata, $cached );
 	}
 }

--- a/tests/phpunit/tests/user/wpDeleteUser.php
+++ b/tests/phpunit/tests/user/wpDeleteUser.php
@@ -121,7 +121,7 @@ class Tests_User_wpDeleteUser extends WP_UnitTestCase {
 		wp_delete_user( $user_id, $reassign );
 
 		$post = get_post( $post_id );
-		$this->assertEquals( $reassign, $post->post_author );
+		$this->assertSame( (string) $reassign, $post->post_author );
 	}
 
 	/**

--- a/tests/phpunit/tests/user/wpGetUsersWithNoRole.php
+++ b/tests/phpunit/tests/user/wpGetUsersWithNoRole.php
@@ -35,10 +35,10 @@ class Tests_User_wpGetUsersWithNoRole extends WP_UnitTestCase {
 		// Test users.
 		$users = wp_get_users_with_no_role();
 
-		$this->assertEquals(
+		$this->assertSameSetsWithIndex(
 			array(
-				$nobody,
-				$nobody_else,
+				(string) $nobody,
+				(string) $nobody_else,
 			),
 			$users
 		);

--- a/tests/phpunit/tests/widgets.php
+++ b/tests/phpunit/tests/widgets.php
@@ -1274,10 +1274,10 @@ class Tests_Widgets extends WP_UnitTestCase {
 		$new_next_theme_sidebars = wp_map_sidebars_widgets( $prev_theme_sidebars );
 
 		$expected_sidebars = array(
-			'primary'             => 1,
 			'wp_inactive_widgets' => array(),
+			'primary'             => 1,
 		);
-		$this->assertEquals( $expected_sidebars, $new_next_theme_sidebars );
+		$this->assertSameSetsWithIndex( $expected_sidebars, $new_next_theme_sidebars );
 	}
 
 	/**
@@ -1295,7 +1295,7 @@ class Tests_Widgets extends WP_UnitTestCase {
 
 		$new_next_theme_sidebars = wp_map_sidebars_widgets( $prev_theme_sidebars );
 
-		$this->assertEquals( $prev_theme_sidebars, $new_next_theme_sidebars );
+		$this->assertSameSetsWithIndex( $prev_theme_sidebars, $new_next_theme_sidebars );
 	}
 
 	/**
@@ -1318,7 +1318,7 @@ class Tests_Widgets extends WP_UnitTestCase {
 			'secondary'           => array(),
 			'wp_inactive_widgets' => array(),
 		);
-		$this->assertEquals( $expected_sidebars, $new_next_theme_sidebars );
+		$this->assertSameSetsWithIndex( $expected_sidebars, $new_next_theme_sidebars );
 	}
 
 	/**
@@ -1362,6 +1362,6 @@ class Tests_Widgets extends WP_UnitTestCase {
 			'primary'             => array(),
 			'wp_inactive_widgets' => array(),
 		);
-		$this->assertEquals( $expected_sidebars, $new_next_theme_sidebars );
+		$this->assertSameSetsWithIndex( $expected_sidebars, $new_next_theme_sidebars );
 	}
 }

--- a/tests/phpunit/tests/widgets/wpWidgetMedia.php
+++ b/tests/phpunit/tests/widgets/wpWidgetMedia.php
@@ -343,7 +343,7 @@ class Tests_Widgets_wpWidgetMedia extends WP_UnitTestCase {
 		$this->widget_instance_filter_args = array();
 		$widget->widget( $args, $instance );
 		$this->assertCount( 3, $this->widget_instance_filter_args );
-		$this->assertEquals( $instance, $this->widget_instance_filter_args[0] );
+		$this->assertSameSetsWithIndex( $instance, $this->widget_instance_filter_args[0] );
 		$this->assertSame( $args, $this->widget_instance_filter_args[1] );
 		$this->assertSame( $widget, $this->widget_instance_filter_args[2] );
 		$output = ob_get_clean();

--- a/tests/phpunit/tests/xmlrpc/mw/editPost.php
+++ b/tests/phpunit/tests/xmlrpc/mw/editPost.php
@@ -88,7 +88,7 @@ class Tests_XMLRPC_mw_editPost extends WP_XMLRPC_UnitTestCase {
 		$this->assertTrue( $result );
 
 		$out = get_post( $post_id );
-		$this->assertEquals( $author_id, $out->post_author );
+		$this->assertSame( (string) $author_id, $out->post_author );
 	}
 
 	public function test_incapable_reassign_author() {
@@ -107,7 +107,7 @@ class Tests_XMLRPC_mw_editPost extends WP_XMLRPC_UnitTestCase {
 		$this->assertSame( 401, $result->code );
 
 		$out = get_post( $post_id );
-		$this->assertEquals( $contributor_id, $out->post_author );
+		$this->assertSame( (string) $contributor_id, $out->post_author );
 	}
 
 	/**
@@ -129,7 +129,7 @@ class Tests_XMLRPC_mw_editPost extends WP_XMLRPC_UnitTestCase {
 		$this->assertTrue( $result );
 
 		$out = get_post( $post_id );
-		$this->assertEquals( $editor_id, $out->post_author );
+		$this->assertSame( (string) $editor_id, $out->post_author );
 	}
 
 	/**
@@ -156,13 +156,13 @@ class Tests_XMLRPC_mw_editPost extends WP_XMLRPC_UnitTestCase {
 		$post2  = array( 'wp_post_thumbnail' => $attachment_id );
 		$result = $this->myxmlrpcserver->mw_editPost( array( $post_id, 'author', 'author', $post2 ) );
 		$this->assertNotIXRError( $result );
-		$this->assertEquals( $attachment_id, get_post_meta( $post_id, '_thumbnail_id', true ) );
+		$this->assertSame( (string) $attachment_id, get_post_meta( $post_id, '_thumbnail_id', true ) );
 
 		// Edit the post without supplying a post_thumbnail and check that it didn't change.
 		$post3  = array( 'post_content' => 'Updated post' );
 		$result = $this->myxmlrpcserver->mw_editPost( array( $post_id, 'author', 'author', $post3 ) );
 		$this->assertNotIXRError( $result );
-		$this->assertEquals( $attachment_id, get_post_meta( $post_id, '_thumbnail_id', true ) );
+		$this->assertSame( (string) $attachment_id, get_post_meta( $post_id, '_thumbnail_id', true ) );
 
 		// Create another attachment.
 		$attachment2_id = self::factory()->attachment->create_upload_object( $filename, $post_id );
@@ -171,7 +171,7 @@ class Tests_XMLRPC_mw_editPost extends WP_XMLRPC_UnitTestCase {
 		$post4  = array( 'wp_post_thumbnail' => $attachment2_id );
 		$result = $this->myxmlrpcserver->mw_editPost( array( $post_id, 'author', 'author', $post4 ) );
 		$this->assertNotIXRError( $result );
-		$this->assertEquals( $attachment2_id, get_post_meta( $post_id, '_thumbnail_id', true ) );
+		$this->assertSame( (string) $attachment2_id, get_post_meta( $post_id, '_thumbnail_id', true ) );
 
 		// Unset the post's post_thumbnail.
 		$post5  = array( 'wp_post_thumbnail' => '' );

--- a/tests/phpunit/tests/xmlrpc/mw/newPost.php
+++ b/tests/phpunit/tests/xmlrpc/mw/newPost.php
@@ -124,7 +124,7 @@ class Tests_XMLRPC_mw_newPost extends WP_XMLRPC_UnitTestCase {
 		$this->assertStringMatchesFormat( '%d', $result );
 
 		$out = get_post( $result );
-		$this->assertEquals( $my_author_id, $out->post_author );
+		$this->assertSame( (string) $my_author_id, $out->post_author );
 		$this->assertSame( 'Test', $out->post_title );
 	}
 
@@ -146,7 +146,7 @@ class Tests_XMLRPC_mw_newPost extends WP_XMLRPC_UnitTestCase {
 		);
 		$result = $this->myxmlrpcserver->mw_newPost( array( 1, 'author', 'author', $post ) );
 		$this->assertNotIXRError( $result );
-		$this->assertEquals( $attachment_id, get_post_meta( $result, '_thumbnail_id', true ) );
+		$this->assertSame( (string) $attachment_id, get_post_meta( $result, '_thumbnail_id', true ) );
 
 		remove_theme_support( 'post-thumbnails' );
 	}

--- a/tests/phpunit/tests/xmlrpc/wp/editPost.php
+++ b/tests/phpunit/tests/xmlrpc/wp/editPost.php
@@ -88,7 +88,7 @@ class Tests_XMLRPC_wp_editPost extends WP_XMLRPC_UnitTestCase {
 		$this->assertTrue( $result );
 
 		$out = get_post( $post_id );
-		$this->assertEquals( $author_id, $out->post_author );
+		$this->assertSame( (string) $author_id, $out->post_author );
 	}
 
 	public function test_incapable_reassign_author() {
@@ -107,7 +107,7 @@ class Tests_XMLRPC_wp_editPost extends WP_XMLRPC_UnitTestCase {
 		$this->assertSame( 401, $result->code );
 
 		$out = get_post( $post_id );
-		$this->assertEquals( $contributor_id, $out->post_author );
+		$this->assertSame( (string) $contributor_id, $out->post_author );
 	}
 
 	/**
@@ -129,7 +129,7 @@ class Tests_XMLRPC_wp_editPost extends WP_XMLRPC_UnitTestCase {
 		$this->assertTrue( $result );
 
 		$out = get_post( $post_id );
-		$this->assertEquals( $editor_id, $out->post_author );
+		$this->assertSame( (string) $editor_id, $out->post_author );
 	}
 
 	/**
@@ -156,20 +156,20 @@ class Tests_XMLRPC_wp_editPost extends WP_XMLRPC_UnitTestCase {
 		$post2  = array( 'post_thumbnail' => $attachment_id );
 		$result = $this->myxmlrpcserver->wp_editPost( array( 1, 'author', 'author', $post_id, $post2 ) );
 		$this->assertNotIXRError( $result );
-		$this->assertEquals( $attachment_id, get_post_meta( $post_id, '_thumbnail_id', true ) );
+		$this->assertSame( (string) $attachment_id, get_post_meta( $post_id, '_thumbnail_id', true ) );
 
 		// Fetch the post to verify that it appears.
 		$result = $this->myxmlrpcserver->wp_getPost( array( 1, 'author', 'author', $post_id ) );
 		$this->assertNotIXRError( $result );
 		$this->assertArrayHasKey( 'post_thumbnail', $result );
 		$this->assertIsArray( $result['post_thumbnail'] );
-		$this->assertEquals( $attachment_id, $result['post_thumbnail']['attachment_id'] );
+		$this->assertSame( (string) $attachment_id, $result['post_thumbnail']['attachment_id'] );
 
 		// Edit the post without supplying a post_thumbnail and check that it didn't change.
 		$post3  = array( 'post_content' => 'Updated post' );
 		$result = $this->myxmlrpcserver->wp_editPost( array( 1, 'author', 'author', $post_id, $post3 ) );
 		$this->assertNotIXRError( $result );
-		$this->assertEquals( $attachment_id, get_post_meta( $post_id, '_thumbnail_id', true ) );
+		$this->assertSame( (string) $attachment_id, get_post_meta( $post_id, '_thumbnail_id', true ) );
 
 		// Create another attachment.
 		$attachment2_id = self::factory()->attachment->create_upload_object( $filename, $post_id );
@@ -178,7 +178,7 @@ class Tests_XMLRPC_wp_editPost extends WP_XMLRPC_UnitTestCase {
 		$post4  = array( 'post_thumbnail' => $attachment2_id );
 		$result = $this->myxmlrpcserver->wp_editPost( array( 1, 'author', 'author', $post_id, $post4 ) );
 		$this->assertNotIXRError( $result );
-		$this->assertEquals( $attachment2_id, get_post_meta( $post_id, '_thumbnail_id', true ) );
+		$this->assertSame( (string) $attachment2_id, get_post_meta( $post_id, '_thumbnail_id', true ) );
 
 		// Unset the post's post_thumbnail.
 		$post5  = array( 'post_thumbnail' => '' );

--- a/tests/phpunit/tests/xmlrpc/wp/editTerm.php
+++ b/tests/phpunit/tests/xmlrpc/wp/editTerm.php
@@ -158,7 +158,7 @@ class Tests_XMLRPC_wp_editTerm extends WP_XMLRPC_UnitTestCase {
 		$this->assertIsBool( $result );
 
 		$term = get_term( self::$child_term, 'category' );
-		$this->assertEquals( '0', $term->parent );
+		$this->assertSame( 0, $term->parent );
 	}
 
 	public function test_parent_invalid() {

--- a/tests/phpunit/tests/xmlrpc/wp/getComment.php
+++ b/tests/phpunit/tests/xmlrpc/wp/getComment.php
@@ -74,10 +74,10 @@ class Tests_XMLRPC_wp_getComment extends WP_XMLRPC_UnitTestCase {
 		$this->assertStringMatchesFormat( '%d', $result['comment_id'] );
 		$this->assertStringMatchesFormat( '%d', $result['parent'] );
 		$this->assertStringMatchesFormat( '%d', $result['post_id'] );
-		$this->assertEquals( self::$parent_comment_id, $result['comment_id'] );
-		$this->assertEquals( 0, $result['parent'] );
+		$this->assertSame( (string) self::$parent_comment_id, $result['comment_id'] );
+		$this->assertSame( '0', $result['parent'] );
 		$this->assertSame( self::$parent_comment_data['comment_content'], $result['content'] );
-		$this->assertEquals( self::$post_id, $result['post_id'] );
+		$this->assertSame( (string) self::$post_id, $result['post_id'] );
 		$this->assertSame( self::$parent_comment_data['comment_author'], $result['author'] );
 		$this->assertSame( self::$parent_comment_data['comment_author_url'], $result['author_url'] );
 		$this->assertSame( self::$parent_comment_data['comment_author_email'], $result['author_email'] );
@@ -89,8 +89,8 @@ class Tests_XMLRPC_wp_getComment extends WP_XMLRPC_UnitTestCase {
 		$result = $this->myxmlrpcserver->wp_getComment( array( 1, 'editor', 'editor', self::$child_comment_id ) );
 		$this->assertNotIXRError( $result );
 
-		$this->assertEquals( self::$child_comment_id, $result['comment_id'] );
-		$this->assertEquals( self::$parent_comment_id, $result['parent'] );
+		$this->assertSame( (string) self::$child_comment_id, $result['comment_id'] );
+		$this->assertSame( (string) self::$parent_comment_id, $result['parent'] );
 	}
 
 	public function test_invalid_id() {

--- a/tests/phpunit/tests/xmlrpc/wp/getComments.php
+++ b/tests/phpunit/tests/xmlrpc/wp/getComments.php
@@ -54,7 +54,7 @@ class Tests_XMLRPC_wp_getComments extends WP_XMLRPC_UnitTestCase {
 		$this->assertNotIXRError( $results );
 
 		foreach ( $results as $result ) {
-			$this->assertEquals( $this->post_id, $result['post_id'] );
+			$this->assertSame( (string) $this->post_id, $result['post_id'] );
 		}
 	}
 

--- a/tests/phpunit/tests/xmlrpc/wp/getPost.php
+++ b/tests/phpunit/tests/xmlrpc/wp/getPost.php
@@ -72,9 +72,9 @@ class Tests_XMLRPC_wp_getPost extends WP_XMLRPC_UnitTestCase {
 		$this->assertSame( $this->post_data['post_excerpt'], $result['post_excerpt'] );
 		$this->assertSame( $this->post_data['post_content'], $result['post_content'] );
 		$this->assertSame( url_to_postid( $result['link'] ), $this->post_id );
-		$this->assertEquals( $this->post_custom_field['id'], $result['custom_fields'][0]['id'] );
+		$this->assertSame( (string) $this->post_custom_field['id'], $result['custom_fields'][0]['id'] );
 		$this->assertSame( $this->post_custom_field['key'], $result['custom_fields'][0]['key'] );
-		$this->assertEquals( $this->post_custom_field['value'], $result['custom_fields'][0]['value'] );
+		$this->assertSame( (string) $this->post_custom_field['value'], $result['custom_fields'][0]['value'] );
 
 		remove_theme_support( 'post-thumbnails' );
 	}
@@ -144,7 +144,7 @@ class Tests_XMLRPC_wp_getPost extends WP_XMLRPC_UnitTestCase {
 		$this->assertIsString( $result['post_mime_type'] );
 
 		$this->assertSame( 'page', $result['post_type'] );
-		$this->assertEquals( $parent_page_id, $result['post_parent'] );
+		$this->assertSame( (string) $parent_page_id, $result['post_parent'] );
 		$this->assertSame( 2, $result['menu_order'] );
 	}
 }

--- a/tests/phpunit/tests/xmlrpc/wp/getPosts.php
+++ b/tests/phpunit/tests/xmlrpc/wp/getPosts.php
@@ -118,7 +118,7 @@ class Tests_XMLRPC_wp_getPosts extends WP_XMLRPC_UnitTestCase {
 		$results3 = $this->myxmlrpcserver->wp_getPosts( array( 1, 'editor', 'editor', $filter3 ) );
 		$this->assertNotIXRError( $results3 );
 		$this->assertCount( 1, $results3 );
-		$this->assertEquals( $post->ID, $results3[0]['post_id'] );
+		$this->assertSame( (string) $post->ID, $results3[0]['post_id'] );
 
 		_unregister_post_type( $cpt_name );
 	}

--- a/tests/phpunit/tests/xmlrpc/wp/getProfile.php
+++ b/tests/phpunit/tests/xmlrpc/wp/getProfile.php
@@ -17,7 +17,7 @@ class Tests_XMLRPC_wp_getProfile extends WP_XMLRPC_UnitTestCase {
 
 		$result = $this->myxmlrpcserver->wp_getProfile( array( 1, 'subscriber', 'subscriber' ) );
 		$this->assertNotIXRError( $result );
-		$this->assertEquals( $subscriber_id, $result['user_id'] );
+		$this->assertSame( (string) $subscriber_id, $result['user_id'] );
 		$this->assertContains( 'subscriber', $result['roles'] );
 	}
 
@@ -26,7 +26,7 @@ class Tests_XMLRPC_wp_getProfile extends WP_XMLRPC_UnitTestCase {
 
 		$result = $this->myxmlrpcserver->wp_getProfile( array( 1, 'administrator', 'administrator' ) );
 		$this->assertNotIXRError( $result );
-		$this->assertEquals( $administrator_id, $result['user_id'] );
+		$this->assertSame( (string) $administrator_id, $result['user_id'] );
 		$this->assertContains( 'administrator', $result['roles'] );
 	}
 
@@ -37,7 +37,7 @@ class Tests_XMLRPC_wp_getProfile extends WP_XMLRPC_UnitTestCase {
 
 		$result = $this->myxmlrpcserver->wp_getProfile( array( 1, 'editor', 'editor', $fields ) );
 		$this->assertNotIXRError( $result );
-		$this->assertEquals( $editor_id, $result['user_id'] );
+		$this->assertSame( (string) $editor_id, $result['user_id'] );
 
 		$expected_fields = array( 'user_id', 'email', 'bio' );
 		$keys            = array_keys( $result );

--- a/tests/phpunit/tests/xmlrpc/wp/getTerm.php
+++ b/tests/phpunit/tests/xmlrpc/wp/getTerm.php
@@ -73,10 +73,18 @@ class Tests_XMLRPC_wp_getTerm extends WP_XMLRPC_UnitTestCase {
 		$term                  = get_term( self::$term_id, 'category', ARRAY_A );
 		$term['custom_fields'] = array();
 
+		// Cast ints to string for strict comparison.
+		foreach ( $term as $k => &$part ) {
+			if ( 'count' !== $k && is_int( $part ) ) {
+				$part = (string) $part;
+			}
+		}
+		unset( $part );
+
 		$result = $this->myxmlrpcserver->wp_getTerm( array( 1, 'editor', 'editor', 'category', self::$term_id ) );
 
 		$this->assertNotIXRError( $result );
-		$this->assertEquals( $result, $term );
+		$this->assertSameSetsWithIndex( $term, $result );
 
 		// Check data types.
 		$this->assertIsString( $result['name'] );

--- a/tests/phpunit/tests/xmlrpc/wp/getTerms.php
+++ b/tests/phpunit/tests/xmlrpc/wp/getTerms.php
@@ -134,7 +134,7 @@ class Tests_XMLRPC_wp_getTerms extends WP_XMLRPC_UnitTestCase {
 		$this->make_user_by_role( 'editor' );
 
 		$name    = __FUNCTION__;
-		$name_id = wp_create_category( $name );
+		$name_id = (string) wp_create_category( $name );
 
 		// Search by full name.
 		$filter  = array( 'search' => $name );
@@ -142,7 +142,7 @@ class Tests_XMLRPC_wp_getTerms extends WP_XMLRPC_UnitTestCase {
 		$this->assertNotIXRError( $results );
 		$this->assertCount( 1, $results );
 		$this->assertSame( $name, $results[0]['name'] );
-		$this->assertEquals( $name_id, $results[0]['term_id'] );
+		$this->assertSame( $name_id, $results[0]['term_id'] );
 
 		// Search by partial name.
 		$filter   = array( 'search' => substr( $name, 0, 10 ) );
@@ -150,6 +150,6 @@ class Tests_XMLRPC_wp_getTerms extends WP_XMLRPC_UnitTestCase {
 		$this->assertNotIXRError( $results2 );
 		$this->assertCount( 1, $results2 );
 		$this->assertSame( $name, $results2[0]['name'] );
-		$this->assertEquals( $name_id, $results2[0]['term_id'] );
+		$this->assertSame( $name_id, $results2[0]['term_id'] );
 	}
 }

--- a/tests/phpunit/tests/xmlrpc/wp/getUser.php
+++ b/tests/phpunit/tests/xmlrpc/wp/getUser.php
@@ -43,7 +43,7 @@ class Tests_XMLRPC_wp_getUser extends WP_XMLRPC_UnitTestCase {
 
 		$result = $this->myxmlrpcserver->wp_getUser( array( 1, 'subscriber', 'subscriber', $subscriber_id ) );
 		$this->assertNotIXRError( $result );
-		$this->assertEquals( $subscriber_id, $result['user_id'] );
+		$this->assertSame( (string) $subscriber_id, $result['user_id'] );
 	}
 
 	public function test_valid_user() {
@@ -84,7 +84,7 @@ class Tests_XMLRPC_wp_getUser extends WP_XMLRPC_UnitTestCase {
 		$this->assertIsArray( $result['roles'] );
 
 		// Check expected values.
-		$this->assertEquals( $user_id, $result['user_id'] );
+		$this->assertSame( (string) $user_id, $result['user_id'] );
 		$this->assertSame( $user_data['user_login'], $result['username'] );
 		$this->assertSame( $user_data['first_name'], $result['first_name'] );
 		$this->assertSame( $user_data['last_name'], $result['last_name'] );
@@ -106,7 +106,7 @@ class Tests_XMLRPC_wp_getUser extends WP_XMLRPC_UnitTestCase {
 
 		$result = $this->myxmlrpcserver->wp_getUser( array( 1, 'administrator', 'administrator', $editor_id, array() ) );
 		$this->assertNotIXRError( $result );
-		$this->assertEquals( $editor_id, $result['user_id'] );
+		$this->assertSame( (string) $editor_id, $result['user_id'] );
 
 		$expected_fields = array( 'user_id' );
 		$this->assertSame( $expected_fields, array_keys( $result ) );
@@ -117,7 +117,7 @@ class Tests_XMLRPC_wp_getUser extends WP_XMLRPC_UnitTestCase {
 
 		$result = $this->myxmlrpcserver->wp_getUser( array( 1, 'administrator', 'administrator', $editor_id, array( 'basic' ) ) );
 		$this->assertNotIXRError( $result );
-		$this->assertEquals( $editor_id, $result['user_id'] );
+		$this->assertSame( (string) $editor_id, $result['user_id'] );
 
 		$expected_fields = array( 'user_id', 'username', 'email', 'registered', 'display_name', 'nicename' );
 		$keys            = array_keys( $result );
@@ -133,7 +133,7 @@ class Tests_XMLRPC_wp_getUser extends WP_XMLRPC_UnitTestCase {
 
 		$result = $this->myxmlrpcserver->wp_getUser( array( 1, 'administrator', 'administrator', $editor_id, $fields ) );
 		$this->assertNotIXRError( $result );
-		$this->assertEquals( $editor_id, $result['user_id'] );
+		$this->assertSame( (string) $editor_id, $result['user_id'] );
 
 		$expected_fields = array( 'user_id', 'email', 'bio' );
 		$keys            = array_keys( $result );

--- a/tests/phpunit/tests/xmlrpc/wp/getUsers.php
+++ b/tests/phpunit/tests/xmlrpc/wp/getUsers.php
@@ -70,7 +70,7 @@ class Tests_XMLRPC_wp_getUsers extends WP_XMLRPC_UnitTestCase {
 		$results = $this->myxmlrpcserver->wp_getUsers( array( 1, 'administrator', 'administrator', $filter ) );
 		$this->assertNotIXRError( $results );
 		$this->assertCount( 1, $results );
-		$this->assertEquals( $editor_id, $results[0]['user_id'] );
+		$this->assertSame( (string) $editor_id, $results[0]['user_id'] );
 
 		// Test 'authors', which should return all non-subscribers.
 		$filter2  = array( 'who' => 'authors' );

--- a/tests/phpunit/tests/xmlrpc/wp/newPost.php
+++ b/tests/phpunit/tests/xmlrpc/wp/newPost.php
@@ -238,7 +238,7 @@ class Tests_XMLRPC_wp_newPost extends WP_XMLRPC_UnitTestCase {
 		);
 		$result = $this->myxmlrpcserver->wp_newPost( array( 1, 'editor', 'editor', $post ) );
 		$this->assertNotIXRError( $result );
-		$this->assertEquals( '', get_post_format( $result ) );
+		$this->assertFalse( get_post_format( $result ) );
 	}
 
 	public function test_invalid_taxonomy() {

--- a/tests/phpunit/tests/xmlrpc/wp/newPost.php
+++ b/tests/phpunit/tests/xmlrpc/wp/newPost.php
@@ -141,7 +141,7 @@ class Tests_XMLRPC_wp_newPost extends WP_XMLRPC_UnitTestCase {
 		$this->assertStringMatchesFormat( '%d', $result );
 
 		$out = get_post( $result );
-		$this->assertEquals( $my_author_id, $out->post_author );
+		$this->assertSame( (string) $my_author_id, $out->post_author );
 		$this->assertSame( 'Test', $out->post_title );
 	}
 
@@ -163,7 +163,7 @@ class Tests_XMLRPC_wp_newPost extends WP_XMLRPC_UnitTestCase {
 		);
 		$result = $this->myxmlrpcserver->wp_newPost( array( 1, 'author', 'author', $post ) );
 		$this->assertNotIXRError( $result );
-		$this->assertEquals( $attachment_id, get_post_meta( $result, '_thumbnail_id', true ) );
+		$this->assertSame( (string) $attachment_id, get_post_meta( $result, '_thumbnail_id', true ) );
 
 		remove_theme_support( 'post-thumbnails' );
 	}


### PR DESCRIPTION
This PR replaces `assertEquals()` with more appropriate, stricter assertions where possible and without making any changes to source.

For easier reviewing, commits have been separated based on the replacement assertion and any additional changes required to implement the stricter assertion.

Trac ticket:
https://core.trac.wordpress.org/ticket/63169
https://core.trac.wordpress.org/ticket/62278
https://core.trac.wordpress.org/ticket/61573
https://core.trac.wordpress.org/ticket/60706
https://core.trac.wordpress.org/ticket/59655
https://core.trac.wordpress.org/ticket/55654
https://core.trac.wordpress.org/ticket/54726
https://core.trac.wordpress.org/ticket/63169