### PR TITLE
fix fatal error in the block-styles API

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2448,7 +2448,7 @@ function enqueue_block_styles_assets() {
 				if ( wp_should_load_separate_core_block_assets() ) {
 					add_filter(
 						'render_block',
-						function( $html, $block ) use ( $style_properties ) {
+						function( $html ) use ( $style_properties ) {
 							wp_enqueue_style( $style_properties['style_handle'] );
 							return $html;
 						}


### PR DESCRIPTION
Fixes issue reported in https://github.com/WordPress/gutenberg/issues/35912 

Trac ticket: https://core.trac.wordpress.org/ticket/54323

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
