### PR TITLE
Add Filter in wp_http_validate_url to control which ports are allowed for remote requests

### DIFF
--- a/src/wp-includes/http.php
+++ b/src/wp-includes/http.php
@@ -581,7 +581,21 @@ function wp_http_validate_url( $url ) {
 	}
 
 	$port = $parsed_url['port'];
-	if ( 80 === $port || 443 === $port || 8080 === $port ) {
+
+
+	/**
+	 * Controls list of ports considered safe in HTTP Api
+	 *
+	 * Allows to change and allow external requests for the HTTP request.
+	 *
+	 * @since 5.9.0
+	 *
+	 * @param array  $allowed_porst Array of integers for valid ports
+	 * @param string $host     Host name of the requested URL.
+	 * @param string $url      Requested URL.
+	 */
+	$allowed_ports = apply_filters( 'http_allowed_safe_ports', array( 80, 443, 8080 ), $host, $url );
+	if ( in_array( $port, $allowed_ports, true ) ){
 		return $url;
 	}
 


### PR DESCRIPTION


By default we only allow ports 80, 443, and 8080 to be used for (safe) remote requests. This adds a way to change these hardcode ports so we can better control which ports are allowed or not.

Trac ticket: https://core.trac.wordpress.org/ticket/54331
