### PR TITLE
REST API: Support subdirectory themes in the Themes controller.

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -16,6 +16,8 @@
  */
 class WP_REST_Themes_Controller extends WP_REST_Controller {
 
+	const PATTERN = '[^.\/]+(?:\/[^.\/]+)?';
+
 	/**
 	 * Constructor.
 	 *
@@ -50,7 +52,7 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/(?P<stylesheet>[\w-]+)',
+			sprintf( '/%s/(?P<stylesheet>%s)', $this->rest_base, self::PATTERN ),
 			array(
 				'args'   => array(
 					'stylesheet' => array(

--- a/tests/phpunit/tests/rest-api/rest-schema-setup.php
+++ b/tests/phpunit/tests/rest-api/rest-schema-setup.php
@@ -137,7 +137,7 @@ class WP_Test_REST_Schema_Initialization extends WP_Test_REST_TestCase {
 			'/wp/v2/templates/(?P<parent>[\d]+)/revisions',
 			'/wp/v2/templates/(?P<parent>[\d]+)/revisions/(?P<id>[\d]+)',
 			'/wp/v2/themes',
-			'/wp/v2/themes/(?P<stylesheet>[\w-]+)',
+			'/wp/v2/themes/(?P<stylesheet>[^.\/]+(?:\/[^.\/]+)?)',
 			'/wp/v2/plugins',
 			'/wp/v2/plugins/(?P<plugin>[^.\/]+(?:\/[^.\/]+)?)',
 			'/wp/v2/block-directory/search',

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -6708,7 +6708,7 @@ mockedApiResponse.Schema = {
                 "self": "http://example.org/index.php?rest_route=/wp/v2/themes"
             }
         },
-        "/wp/v2/themes/(?P<stylesheet>[\\w-]+)": {
+        "/wp/v2/themes/(?P<stylesheet>[^.\\/]+(?:\\/[^.\\/]+)?)": {
             "namespace": "wp/v2",
             "methods": [
                 "GET"


### PR DESCRIPTION
This allows for themes that are included inside of a subdirectory, for example subdir/my-theme, to be accessed via the single item route of the wp/v2/themes controller.

Fixes #35985.

Trac ticket: https://core.trac.wordpress.org/ticket/54349

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
