### PR TITLE
Code Modernization: Silence the deprecation warning for missing return type in `src/wp-includes/Requests/Cookie/Jar.php`.

### DIFF
--- a/src/wp-includes/Requests/Cookie/Jar.php
+++ b/src/wp-includes/Requests/Cookie/Jar.php
@@ -60,6 +60,7 @@ class Requests_Cookie_Jar implements ArrayAccess, IteratorAggregate {
 	 * @param string $key Item key
 	 * @return boolean Does the item exist?
 	 */
+	#[ReturnTypeWillChange]
 	public function offsetExists($key) {
 		return isset($this->cookies[$key]);
 	}
@@ -70,6 +71,7 @@ class Requests_Cookie_Jar implements ArrayAccess, IteratorAggregate {
 	 * @param string $key Item key
 	 * @return string|null Item value (null if offsetExists is false)
 	 */
+	#[ReturnTypeWillChange]
 	public function offsetGet($key) {
 		if (!isset($this->cookies[$key])) {
 			return null;
@@ -86,6 +88,7 @@ class Requests_Cookie_Jar implements ArrayAccess, IteratorAggregate {
 	 * @param string $key Item name
 	 * @param string $value Item value
 	 */
+	#[ReturnTypeWillChange]
 	public function offsetSet($key, $value) {
 		if ($key === null) {
 			throw new Requests_Exception('Object is a dictionary, not a list', 'invalidset');
@@ -99,6 +102,7 @@ class Requests_Cookie_Jar implements ArrayAccess, IteratorAggregate {
 	 *
 	 * @param string $key
 	 */
+	#[ReturnTypeWillChange]
 	public function offsetUnset($key) {
 		unset($this->cookies[$key]);
 	}
@@ -108,6 +112,7 @@ class Requests_Cookie_Jar implements ArrayAccess, IteratorAggregate {
 	 *
 	 * @return ArrayIterator
 	 */
+	#[ReturnTypeWillChange]
 	public function getIterator() {
 		return new ArrayIterator($this->cookies);
 	}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
This fixes the "Deprecated: Return type of `Requests_Cookie_Jar::offsetExists()` should be compatible with `ArrayAccess::offsetExists(): bool`" and similar warnings on PHP 8.1.

PHP native interfaces now have declared return types and methods in classes implementing these interfaces need to either have the return type declared (in a covariant compatible manner with the PHP native interface method declaration), or need to silence the deprecation warning using the `#[ReturnTypeWillChange]` attribute.

Trac ticket: https://core.trac.wordpress.org/ticket/53635

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
