### PR TITLE
Code Modernization: Avoid passing null to parameter 2 of `http_build_query()`

### DIFF
--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -120,7 +120,7 @@ function find_core_auto_update() {
  * @return array|false An array of checksums on success, false on failure.
  */
 function get_core_checksums( $version, $locale ) {
-	$http_url = 'http://api.wordpress.org/core/checksums/1.0/?' . http_build_query( compact( 'version', 'locale' ), null, '&' );
+	$http_url = 'http://api.wordpress.org/core/checksums/1.0/?' . http_build_query( compact( 'version', 'locale' ), '', '&' );
 	$url      = $http_url;
 
 	$ssl = wp_http_supports( array( 'ssl' ) );

--- a/src/wp-includes/Requests/Transport/cURL.php
+++ b/src/wp-includes/Requests/Transport/cURL.php
@@ -342,7 +342,7 @@ class Requests_Transport_cURL implements Requests_Transport {
 				$data = '';
 			}
 			elseif (!is_string($data)) {
-				$data = http_build_query($data, null, '&');
+				$data = http_build_query($data, '', '&');
 			}
 		}
 

--- a/src/wp-includes/Requests/Transport/cURL.php
+++ b/src/wp-includes/Requests/Transport/cURL.php
@@ -342,7 +342,7 @@ class Requests_Transport_cURL implements Requests_Transport {
 				$data = '';
 			}
 			elseif (!is_string($data)) {
-				$data = http_build_query($data, '', '&');
+				$data = http_build_query($data, null, '&');
 			}
 		}
 

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -143,7 +143,7 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 		$query['channel'] = WP_AUTO_UPDATE_CORE;
 	}
 
-	$url      = 'http://api.wordpress.org/core/version-check/1.7/?' . http_build_query( $query, null, '&' );
+	$url      = 'http://api.wordpress.org/core/version-check/1.7/?' . http_build_query( $query, '', '&' );
 	$http_url = $url;
 	$ssl      = wp_http_supports( array( 'ssl' ) );
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

This fixes the "Deprecated: http_build_query(): Passing null to parameter #2 ($numeric_prefix) of type string is deprecated" warning on PHP 8.1.

PHP has started requiring that built-in method arguments that are not explicitly declared as nullable may no longer be passed null. The correct value for the `$numeric_prefix` parameter to `http_build_query()` is an empty string.

Trac ticket: https://core.trac.wordpress.org/ticket/53635

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
