### PR TITLE
Add: wp_global_styles custom post type.

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -365,6 +365,33 @@ function create_initial_post_types() {
 		)
 	);
 
+	register_post_type(
+		'wp_global_styles',
+		array(
+			'label'        => __( 'Global Styles', 'gutenberg' ),
+			'description'  => 'CPT to store user design tokens',
+			'public'       => false,
+			'show_ui'      => false,
+			'show_in_rest' => false,
+			'rewrite'      => false,
+			'capabilities' => array(
+				'read'                   => 'edit_theme_options',
+				'create_posts'           => 'edit_theme_options',
+				'edit_posts'             => 'edit_theme_options',
+				'edit_published_posts'   => 'edit_theme_options',
+				'delete_published_posts' => 'edit_theme_options',
+				'edit_others_posts'      => 'edit_theme_options',
+				'delete_others_posts'    => 'edit_theme_options',
+			),
+			'map_meta_cap' => true,
+			'supports'     => array(
+				'title',
+				'editor',
+				'revisions',
+			),
+		)
+	);
+
 	register_post_status(
 		'publish',
 		array(

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -175,7 +175,7 @@ function create_initial_taxonomies() {
 
 	register_taxonomy(
 		'wp_theme',
-		array( 'wp_template' ),
+		array( 'wp_template', 'wp_global_styles' ),
 		array(
 			'public'            => false,
 			'hierarchical'      => false,


### PR DESCRIPTION
This PR just adds the wp_global_styles custom post type following the same approach used to add other core custom post types and wp_theme taxonomy to include the wp_global_styles post type.

Thw post type is registered in the same way it is on the plugin we just adapt the location for the core.