### PR TITLE
Add rel="noopener" to output of wp_list_bookmarks() when target is set.

### DIFF
--- a/src/wp-includes/bookmark-template.php
+++ b/src/wp-includes/bookmark-template.php
@@ -105,7 +105,7 @@ function _walk_bookmarks( $bookmarks, $args = '' ) {
 
 		$target = $bookmark->link_target;
 		if ( '' !== $target ) {
-			if ( ! empty( $rel ) ) {
+			if ( is_string( $rel ) && '' !== $rel ) {
 				$rels   = explode( ' ', $rel );
 
 				if ( false === in_array( 'noopener', $rels, true ) ) {

--- a/src/wp-includes/bookmark-template.php
+++ b/src/wp-includes/bookmark-template.php
@@ -108,10 +108,10 @@ function _walk_bookmarks( $bookmarks, $args = '' ) {
 			if ( is_string( $rel ) && '' !== $rel ) {
 				$rels   = explode( ' ', $rel );
 
-				if ( false === in_array( 'noopener', $rels, true ) ) {
+				if ( in_array( 'noopener', $rels, true ) ) {
 					$rels[] = 'noopener';
+					$rel     = implode( ' ', $rels );
 				}
-				$rel    = implode( ' ', $rels );
 			} else {
 				$rel = 'noopener';
 			}

--- a/src/wp-includes/bookmark-template.php
+++ b/src/wp-includes/bookmark-template.php
@@ -106,7 +106,7 @@ function _walk_bookmarks( $bookmarks, $args = '' ) {
 		$target = $bookmark->link_target;
 		if ( '' !== $target ) {
 			if ( is_string( $rel ) && '' !== $rel ) {
-				if ( ! str_contains( $rels, 'noopener' ) ) {
+				if ( ! str_contains( $rel, 'noopener' ) ) {
 					$rel = trim( $rel ) . ' noopener';
 				}
 			} else {

--- a/src/wp-includes/bookmark-template.php
+++ b/src/wp-includes/bookmark-template.php
@@ -106,11 +106,8 @@ function _walk_bookmarks( $bookmarks, $args = '' ) {
 		$target = $bookmark->link_target;
 		if ( '' !== $target ) {
 			if ( is_string( $rel ) && '' !== $rel ) {
-				$rels   = explode( ' ', $rel );
-
-				if ( in_array( 'noopener', $rels, true ) ) {
-					$rels[] = 'noopener';
-					$rel     = implode( ' ', $rels );
+				if ( ! str_contains( $rels, 'noopener' ) ) {
+					$rel = trim( $rel ) . ' noopener';
 				}
 			} else {
 				$rel = 'noopener';

--- a/src/wp-includes/bookmark-template.php
+++ b/src/wp-includes/bookmark-template.php
@@ -102,13 +102,27 @@ function _walk_bookmarks( $bookmarks, $args = '' ) {
 			$title = ' title="' . $title . '"';
 		}
 		$rel = $bookmark->link_rel;
+
+		$target = $bookmark->link_target;
+		if ( '' !== $target ) {
+			if ( ! empty( $rel ) ) {
+				$rels   = explode( ' ', $rel );
+
+				if ( false === in_array( 'noopener', $rels, true ) ) {
+					$rels[] = 'noopener';
+				}
+				$rel    = implode( ' ', $rels );
+			} else {
+				$rel = 'noopener';
+			}
+
+			$target = ' target="' . $target . '"';
+		}
+
 		if ( '' !== $rel ) {
 			$rel = ' rel="' . esc_attr( $rel ) . '"';
 		}
-		$target = $bookmark->link_target;
-		if ( '' !== $target ) {
-			$target = ' target="' . $target . '"';
-		}
+
 		$output .= '<a href="' . $the_link . '"' . $rel . $title . $target . '>';
 
 		$output .= $parsed_args['link_before'];

--- a/tests/phpunit/tests/bookmark/wpListBookmarks.php
+++ b/tests/phpunit/tests/bookmark/wpListBookmarks.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * Test wp_list_bookmarks().
+ *
+ * @group bookmark
+ * @covers ::wp_list_bookmarks
+ */
+class Tests_Functions_wpListBookmarks extends WP_UnitTestCase {
+
+	/**
+	 * Test that wp_list_bookmarks adds "noopener" to the "rel" attribute.
+	 *
+	 * @dataProvider data_wp_list_bookmarks_adds_noopener
+	 *
+	 * @ticket 53839
+	 *
+	 * @param array $args The arguments to create the bookmark.
+	 */
+	public function test_wp_list_bookmarks_adds_noopener( $args ) {
+		$bookmark = self::factory()->bookmark->create( $args );
+		$this->assertStringContainsString( 'noopener', wp_list_bookmarks( 'echo=0' ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_wp_list_bookmarks_adds_noopener() {
+		return array(
+			'target as "_blank"'                         => array(
+				'args' => array(
+					'link_name'   => 'With _blank',
+					'link_url'    => 'https://www.wordpress.org',
+					'link_target' => '_blank',
+				),
+			),
+			'target as "_blank" and a link relationship' => array(
+				'args' => array(
+					'link_name'   => 'With _blank and a link relationship',
+					'link_url'    => 'https://www.wordpress.org',
+					'link_target' => '_blank',
+					'rel'         => 'me',
+				),
+			),
+			'target as "_top"'                           => array(
+				'args' => array(
+					'link_name'   => 'With _top',
+					'link_url'    => 'https://www.wordpress.org',
+					'link_target' => '_top',
+				),
+			),
+			'target as "_top" and a link relationship'   => array(
+				'args' => array(
+					'link_name'   => 'With _top and a link relationship',
+					'link_url'    => 'https://www.wordpress.org',
+					'link_target' => '_top',
+					'rel'         => 'me',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Test that wp_list_bookmarks does not add "noopener" to the "rel" attribute.
+	 *
+	 * @dataProvider data_wp_list_bookmarks_does_not_add_noopener
+	 *
+	 * @ticket 53839
+	 *
+	 * @param array $args The arguments to create the bookmark.
+	 */
+	public function test_wp_list_bookmarks_does_not_add_noopener( $args ) {
+		$bookmark = self::factory()->bookmark->create( $args );
+		$this->assertStringNotContainsString( 'noopener', wp_list_bookmarks( 'echo=0' ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_wp_list_bookmarks_does_not_add_noopener() {
+		return array(
+			'target as "_none"'                         => array(
+				'args' => array(
+					'link_name'   => 'With _blank',
+					'link_url'    => 'https://www.wordpress.org',
+					'link_target' => '_none',
+				),
+			),
+			'target as "_none" and a link relationship' => array(
+				'args' => array(
+					'link_name'   => 'With _blank and a link relationship',
+					'link_url'    => 'https://www.wordpress.org',
+					'link_target' => '_none',
+					'rel'         => 'me',
+				),
+			),
+		);
+	}
+}


### PR DESCRIPTION
To help aid in hardening WordPress and the web as a whole, it became a best practice to add "noopener" to the `rel` attribute for links that have a target.

This updates `wp_list_bookmarks()` so that it now adds "noopener" to the `rel` attribute when the link's target is set.

Trac ticket: https://core.trac.wordpress.org/ticket/53839
