### PR TITLE
#54168 Change Button to Input in media uploader

### DIFF
--- a/src/js/media/views/uploader/inline.js
+++ b/src/js/media/views/uploader/inline.js
@@ -106,16 +106,21 @@ UploaderInline = View.extend(/** @lends wp.media.view.UploaderInline.prototype *
 			$placeholder;
 
 		if ( this.controller.uploader ) {
-			$placeholder = this.$('.browser');
+			$placeholder = this.$('.browser-container');
 
 			// Check if we've already replaced the placeholder.
 			if ( $placeholder[0] === $browser[0] ) {
 				return;
 			}
 
-			$browser.detach().text( $placeholder.text() );
-			$browser[0].className = $placeholder[0].className;
-			$browser[0].setAttribute( 'aria-labelledby', $browser[0].id + ' ' + $placeholder[0].getAttribute('aria-labelledby') );
+			var browserLabel = $placeholder.find( 'label' );
+			var browserInput = $placeholder.find( 'input' );
+
+			browserLabel.attr( 'for', $browser[0].id );
+			browserInput.attr( 'id', $browser[0].id );
+			$browser.removeAttr( 'id' );
+
+			$browser.append( browserLabel ).append( browserInput );
 			$placeholder.replaceWith( $browser.show() );
 		}
 

--- a/src/js/media/views/uploader/window.js
+++ b/src/js/media/views/uploader/window.js
@@ -27,7 +27,7 @@ UploaderWindow = wp.media.View.extend(/** @lends wp.media.view.UploaderWindow.pr
 	initialize: function() {
 		var uploader;
 
-		this.$browser = $( '<button type="button" class="browser" />' ).hide().appendTo( 'body' );
+		this.$browser = $( '<div class="browser-container">' ).hide().appendTo( 'body' );
 
 		uploader = this.options.uploader = _.defaults( this.options.uploader || {}, {
 			dropzone:  this.$el,

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -2246,7 +2246,7 @@ function media_upload_form( $errors = null ) {
 		<div class="drag-drop-inside">
 		<p class="drag-drop-info"><?php _e( 'Drop files to upload' ); ?></p>
 		<p><?php _ex( 'or', 'Uploader: Drop files here - or - Select Files' ); ?></p>
-		<p class="drag-drop-buttons"><input id="plupload-browse-button" type="button" value="<?php esc_attr_e( 'Select Files' ); ?>" class="button" /></p>
+		<p class="drag-drop-buttons"><label for="plupload-browse-button" id="plupload-browse-label" class="button button-hero"><?php esc_html_e( 'Select Files' ); ?></label><input id="plupload-browse-button" type="file" class="screen-reader-text" aria-labelledby="plupload-browse-label post-upload-info" /></p>
 		</div>
 	</div>
 	<?php
@@ -2288,7 +2288,7 @@ function media_upload_form( $errors = null ) {
 	?>
 	</div>
 
-<p class="max-upload-size">
+<p class="max-upload-size" id="post-upload-info">
 	<?php
 	/* translators: %s: Maximum allowed file size. */
 	printf( __( 'Maximum upload file size: %s.' ), esc_html( size_format( $max_upload_size ) ) );

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -3238,7 +3238,6 @@ function edit_form_image_editor( $post ) {
 			)
 		);
 
-
 		?>
 		</p>
 	<?php endif; ?>

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -3238,6 +3238,7 @@ function edit_form_image_editor( $post ) {
 			)
 		);
 
+
 		?>
 		</p>
 	<?php endif; ?>

--- a/src/wp-includes/css/buttons.css
+++ b/src/wp-includes/css/buttons.css
@@ -133,6 +133,9 @@ TABLE OF CONTENTS:
 	color: #0a4b78;
 }
 
+/* Support focus state on label designed as button in media uploader. */
+.drag-drop-inside p.drag-drop-buttons:focus-within label.button,
+.uploader-inline-content div.browser-container:focus-within label.button,
 .wp-core-ui .button.focus,
 .wp-core-ui .button:focus,
 .wp-core-ui .button-secondary:focus {

--- a/src/wp-includes/media-template.php
+++ b/src/wp-includes/media-template.php
@@ -252,7 +252,10 @@ function wp_print_media_templates() {
 			<div class="upload-ui">
 				<h2 class="upload-instructions drop-instructions"><?php _e( 'Drop files to upload' ); ?></h2>
 				<p class="upload-instructions drop-instructions"><?php _ex( 'or', 'Uploader: Drop files here - or - Select Files' ); ?></p>
-				<button type="button" class="browser button button-hero" aria-labelledby="post-upload-info"><?php _e( 'Select Files' ); ?></button>
+				<div class="browser-container">
+					<label class="button button-hero"><?php esc_html_e( 'Select Files' ); ?></label>
+					<input type="file" class="browser screen-reader-text" aria-describedby="post-upload-info">
+				</div>
 			</div>
 
 			<div class="upload-inline-status"></div>


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->
https://core.trac.wordpress.org/ticket/54168
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
