### PR TITLE
Add: get_query_pagination_arrow function to core.

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1146,3 +1146,37 @@ function build_query_vars_from_query_block( $block, $page ) {
 	}
 	return $query;
 }
+
+/**
+ * Helper function that returns the proper pagination arrow html for
+ * `QueryPaginationNext` and `QueryPaginationPrevious` blocks based
+ * on the provided `paginationArrow` from `QueryPagination` context.
+ *
+ * It's used in QueryPaginationNext and QueryPaginationPrevious blocks.
+ *
+ * @param WP_Block $block   Block instance.
+ * @param boolean  $is_next Flag for hanlding `next/previous` blocks.
+ *
+ * @return string|null Returns the constructed WP_Query arguments.
+ */
+function get_query_pagination_arrow( $block, $is_next ) {
+	$arrow_map = array(
+		'none'    => '',
+		'arrow'   => array(
+			'next'     => '→',
+			'previous' => '←',
+		),
+		'chevron' => array(
+			'next'     => '»',
+			'previous' => '«',
+		),
+	);
+	if ( ! empty( $block->context['paginationArrow'] ) && array_key_exists( $block->context['paginationArrow'], $arrow_map ) && ! empty( $arrow_map[ $block->context['paginationArrow'] ] ) ) {
+		$pagination_type = $is_next ? 'next' : 'previous';
+		$arrow_attribute = $block->context['paginationArrow'];
+		$arrow           = $arrow_map[ $block->context['paginationArrow'] ][ $pagination_type ];
+		$arrow_classes   = "wp-block-query-pagination-$pagination_type-arrow is-arrow-$arrow_attribute";
+		return "<span class='$arrow_classes'>$arrow</span>";
+	}
+	return null;
+}


### PR DESCRIPTION
Fixes a crash that is happening when using an FSE theme:
```
Fatal error: Uncaught Error: Call to undefined function get_query_pagination_arrow()
in wp-includes/blocks/query-pagination-previous.php on line 24
```