### PR TITLE
New function: `wp_get_post_revisions_url()`

### DIFF
--- a/src/wp-includes/revision.php
+++ b/src/wp-includes/revision.php
@@ -517,6 +517,40 @@ function wp_get_post_revisions( $post_id = 0, $args = null ) {
 }
 
 /**
+ * Returns the url for viewing and potentially restoring revisions of a given post.
+ *
+ * @since 5.9.0
+ *
+ * @param int|WP_Post $post_id Optional. Post ID or WP_Post object. Default is global `$post`.
+ * @return null|string The URL for editing revisions on the given post, otherwise null.
+ */
+function wp_get_post_revisions_url( $post_id = 0 ) {
+	$post = get_post( $post_id );
+
+	if ( ! $post instanceof WP_Post ) {
+		return null;
+	}
+
+	// If the post is a revision, return early.
+	if ( 'revision' === $post->post_type ) {
+		return get_edit_post_link( $post );
+	}
+
+	if ( ! wp_revisions_enabled( $post ) ) {
+		return null;
+	}
+
+	$revisions = wp_get_post_revisions( $post->ID, array( 'posts_per_page' => 1 ) );
+
+	if ( 0 === sizeof( $revisions ) ) {
+		return null;
+	}
+
+	$revision = reset( $revisions );
+	return get_edit_post_link( $revision );
+}
+
+/**
  * Determine if revisions are enabled for a given post.
  *
  * @since 3.6.0

--- a/src/wp-includes/revision.php
+++ b/src/wp-includes/revision.php
@@ -542,7 +542,7 @@ function wp_get_post_revisions_url( $post_id = 0 ) {
 
 	$revisions = wp_get_post_revisions( $post->ID, array( 'posts_per_page' => 1 ) );
 
-	if ( 0 === sizeof( $revisions ) ) {
+	if ( 0 === count( $revisions ) ) {
 		return null;
 	}
 


### PR DESCRIPTION
`wp_get_post_revisions_url()` gets a link to revisions for a given post.

Trac ticket: https://core.trac.wordpress.org/ticket/39062
