### PR TITLE
Add support for a "parents_first" argument in get_term_parents_list()

### DIFF
--- a/src/wp-includes/category-template.php
+++ b/src/wp-includes/category-template.php
@@ -1371,11 +1371,16 @@ function get_the_term_list( $post_id, $taxonomy, $before = '', $sep = '', $after
  * @param string|array $args {
  *     Array of optional arguments.
  *
- *     @type string $format    Use term names or slugs for display. Accepts 'name' or 'slug'.
- *                             Default 'name'.
- *     @type string $separator Separator for between the terms. Default '/'.
- *     @type bool   $link      Whether to format as a link. Default true.
- *     @type bool   $inclusive Include the term to get the parents for. Default true.
+ *     @type string $format        Use term names or slugs for display. Accepts 'name' or 'slug'.
+ *                                 Default 'name'.
+ *     @type string $separator     Separator for between the terms. Default '/'.
+ *     @type bool   $link          Whether to format as a link. Default true.
+ *     @type bool   $inclusive     Include the term to get the parents for. Default true.
+ *.    @type bool   $parents_first Order hierarchy for term names. If true, the terms
+ *                                 returned are ordered from parent to child.
+ *                                 If false, the terms returned are ordered
+ *                                 from child to parent.
+ *                                 Default is true. Accepts bool false|true.
  * }
  * @return string|WP_Error A list of term parents on success, WP_Error or empty string on failure.
  */
@@ -1398,11 +1403,12 @@ function get_term_parents_list( $term_id, $taxonomy, $args = array() ) {
 		'separator' => '/',
 		'link'      => true,
 		'inclusive' => true,
+		'parents_first' => true,
 	);
 
 	$args = wp_parse_args( $args, $defaults );
 
-	foreach ( array( 'link', 'inclusive' ) as $bool ) {
+	foreach ( array( 'link', 'inclusive', 'parents_first' ) as $bool ) {
 		$args[ $bool ] = wp_validate_boolean( $args[ $bool ] );
 	}
 
@@ -1411,8 +1417,12 @@ function get_term_parents_list( $term_id, $taxonomy, $args = array() ) {
 	if ( $args['inclusive'] ) {
 		array_unshift( $parents, $term_id );
 	}
+	
+	if ( $args['parents_first'] ) {
+ 		$parents = array_reverse( $parents );
+ 	}
 
-	foreach ( array_reverse( $parents ) as $term_id ) {
+	foreach ( $parents as $term_id ) {
 		$parent = get_term( $term_id, $taxonomy );
 		$name   = ( 'slug' === $args['format'] ) ? $parent->slug : $parent->name;
 


### PR DESCRIPTION
Order hierarchy for term names. If true, the terms returned are ordered from parent to child. If false, the terms returned are ordered from child to parent. Default is true. Accepts bool false|true.

Trac ticket: [<!-- insert a link to the WordPress Trac ticket here -->](https://core.trac.wordpress.org/ticket/53319)