### PR TITLE
Fix PHP Notice Undefined index: 00 in wp_title() (Trac 31521)

### DIFF
--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -1378,10 +1378,9 @@ function wp_title( $sep = '&raquo;', $display = true, $seplocation = '' ) {
 		$my_year  = substr( $m, 0, 4 );
 		$my_month = substr( $m, 4, 2 );
 		$my_day   = (int) substr( $m, 6, 2 );
-		$title    =
-				$my_year .
-				( '' !== $my_month ? $t_sep . $wp_locale->get_month( $my_month ) : '' ) .
-				( $my_day ? $t_sep . $my_day : '' );
+		$title    = $my_year .
+			( '' !== $my_month ? $t_sep . $wp_locale->get_month( $my_month ) : '' ) .
+			( $my_day ? $t_sep . $my_day : '' );
 	}
 
 	// If there's a year.

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -1379,7 +1379,7 @@ function wp_title( $sep = '&raquo;', $display = true, $seplocation = '' ) {
 		$my_month = substr( $m, 4, 2 );
 		$my_day   = (int) substr( $m, 6, 2 );
 		$title    = $my_year .
-			( '' !== $my_month ? $t_sep . $wp_locale->get_month( $my_month ) : '' ) .
+			( $my_month ? $t_sep . $wp_locale->get_month( $my_month ) : '' ) .
 			( $my_day ? $t_sep . $my_day : '' );
 	}
 

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -1376,9 +1376,12 @@ function wp_title( $sep = '&raquo;', $display = true, $seplocation = '' ) {
 	// If there's a month.
 	if ( is_archive() && ! empty( $m ) ) {
 		$my_year  = substr( $m, 0, 4 );
-		$my_month = $wp_locale->get_month( substr( $m, 4, 2 ) );
+		$my_month = substr( $m, 4, 2 );
 		$my_day   = (int) substr( $m, 6, 2 );
-		$title    = $my_year . ( $my_month ? $t_sep . $my_month : '' ) . ( $my_day ? $t_sep . $my_day : '' );
+		$title    =
+				$my_year .
+				( '' !== $my_month ? $t_sep . $wp_locale->get_month( $my_month ) : '' ) .
+				( $my_day ? $t_sep . $my_day : '' );
 	}
 
 	// If there's a year.

--- a/tests/phpunit/tests/general/wpTitle.php
+++ b/tests/phpunit/tests/general/wpTitle.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * @group general
+ * @group template
+ * @covers ::wp_title
+ */
+class Tests_General_WpTitle extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 31521
+	 *
+	 * @dataProvider data_wp_title_archive
+	 */
+	public function test_wp_title_archive( $query, $expected ) {
+		self::factory()->post->create(
+			array(
+				'post_status' => 'publish',
+				'post_title'  => 'Test Post',
+				'post_type'   => 'post',
+				'post_date'   => '2021-11-01 18:52:17',
+			)
+		);
+		$this->go_to( '?m=' . $query );
+
+		$this->assertSame( $expected, wp_title( '&raquo;', false ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_wp_title_archive() {
+		return array(
+			'year with posts'                => array(
+				'query'    => '2021',
+				'expected' => ' &raquo; 2021',
+			),
+			'year without posts'             => array(
+				'query'    => '1910',
+				'expected' => ' &raquo; Page not found',
+			),
+			'year and month with posts'      => array(
+				'query'    => '202111',
+				'expected' => ' &raquo; 2021 &raquo; November',
+			),
+			'year and month without posts'   => array(
+				'query'    => '202101',
+				'expected' => ' &raquo; Page not found',
+			),
+			'year, month, day with posts'    => array(
+				'query'    => '20211101',
+				'expected' => ' &raquo; 2021 &raquo; November &raquo; 1',
+			),
+			'year, month, day without posts' => array(
+				'query'    => '20210101',
+				'expected' => ' &raquo; Page not found',
+			),
+		);
+	}
+}


### PR DESCRIPTION
Adds tests to first validate the bug exists (test fail when the fix is not applied).

Fix (applies 31521.4.diff patch):
* Move `substr()` to assign to the variable `$my_month` as it can return an empty string.
* If a month was found (not an empty string), then pass it to `$wp_locale->get_month()`.

Makes the long concatenated title string multiline for readability.

Trac ticket: https://core.trac.wordpress.org/ticket/31521

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
