### PR TITLE
Check both parent and child themes in theme_has_support

### DIFF
--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -364,8 +364,8 @@ class WP_Theme_JSON_Resolver {
 	public static function theme_has_support() {
 		if ( ! isset( self::$theme_has_support ) ) {
 			self::$theme_has_support = (
-				is_readable( get_stylesheet_directory() . '/theme.json' ) ||
-				is_readable( get_template_directory() . '/theme.json' )
+				is_readable( self::get_file_path_from_theme( 'theme.json' ) ) ||
+				is_readable( self::get_file_path_from_theme( 'theme.json', true ) )
 			);
 		}
 

--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -363,7 +363,10 @@ class WP_Theme_JSON_Resolver {
 	 */
 	public static function theme_has_support() {
 		if ( ! isset( self::$theme_has_support ) ) {
-			self::$theme_has_support = is_readable( self::get_file_path_from_theme( 'theme.json' ) );
+			self::$theme_has_support = (
+				is_readable( get_stylesheet_directory() . '/theme.json' ) ||
+				is_readable( get_template_directory() . '/theme.json' )
+			);
 		}
 
 		return self::$theme_has_support;


### PR DESCRIPTION
The current method was only checking the stylesheet directory for the `theme.json` existence. PR updates logic to check both parent and child themes.

/cc @desrosj @hellofromtonya 

Trac ticket: https://core.trac.wordpress.org/ticket/54401

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
