### PR TITLE
Mock remote request in restapi to prevent timeouts when hitting api.wordpress.org endpoint.

### DIFF
--- a/tests/phpunit/tests/rest-api/rest-block-directory-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-block-directory-controller.php
@@ -69,6 +69,25 @@ class WP_REST_Block_Directory_Controller_Test extends WP_Test_REST_Controller_Te
 	 */
 	public function test_get_items() {
 		wp_set_current_user( self::$admin_id );
+		add_filter(
+			'pre_http_request',
+			static function() {
+				/*
+				 * Mocks the request to:
+				 * https://api.wordpress.org/plugins/info/1.2/?action=query_plugins&request%5Bblock%5D=foo&request%5Bper_page%5D=10&request%5Bpage%5D=1&request%5Blocale%5D=en_US&request%5Bwp_version%5D=5.9
+				 */
+				return array(
+					'headers'  => array(),
+					'response' => array(
+						'code'    => 200,
+						'message' => 'OK',
+					),
+					'body'     => '{"info":{"page":1,"pages":0,"results":0},"plugins":[]}',
+					'cookies'  => array(),
+					'filename' => null,
+				);
+			}
+		);
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/block-directory/search' );
 		$request->set_query_params( array( 'term' => 'foo' ) );

--- a/tests/phpunit/tests/rest-api/rest-plugins-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-plugins-controller.php
@@ -546,8 +546,26 @@ class WP_REST_Plugins_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	 */
 	public function test_create_item_unknown_plugin() {
 		wp_set_current_user( self::$super_admin );
+		add_filter(
+			'pre_http_request',
+			static function() {
+				/*
+				 * Mocks the request to:
+				 * https://api.wordpress.org/plugins/info/1.2/?action=plugin_information&request%5Bslug%5D=alex-says-this-block-definitely-doesnt-exist&request%5Bfields%5D%5Bsections%5D=0&request%5Bfields%5D%5Blanguage_packs%5D=1&request%5Blocale%5D=en_US&request%5Bwp_version%5D=5.9
+				 */
+				return array(
+					'headers'  => array(),
+					'response' => array(
+						'code'    => 404,
+						'message' => 'Not Found',
+					),
+					'body'     => '{"error":"Plugin not found."}',
+					'cookies'  => array(),
+					'filename' => null,
+				);
+			}
+		);
 
-		// This will hit the live API.
 		$request = new WP_REST_Request( 'POST', self::BASE );
 		$request->set_body_params( array( 'slug' => 'alex-says-this-block-definitely-doesnt-exist' ) );
 		$response = rest_do_request( $request );


### PR DESCRIPTION
Recent timeout failures ([see this job](https://github.com/WordPress/wordpress-develop/actions/runs/1447262178)) are due to remote requests not being mocked. This patch mocks the specific failing tests, though each test will need to be investigated separately for mocking strategy.

Trac ticket: https://core.trac.wordpress.org/ticket/54420

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
