### PR TITLE
Fix sanitize_file_name() to replace '%20' with '-' (Trac 50855)

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2017,8 +2017,8 @@ function sanitize_file_name( $filename ) {
 	 */
 	$special_chars = apply_filters( 'sanitize_file_name_chars', $special_chars, $filename_raw );
 
-	$filename = str_replace( $special_chars, '', $filename );
 	$filename = str_replace( array( '%20', '+' ), '-', $filename );
+	$filename = str_replace( $special_chars, '', $filename );
 	$filename = preg_replace( '/[\r\n\t -]+/', '-', $filename );
 	$filename = trim( $filename, '.-_' );
 

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2017,8 +2017,9 @@ function sanitize_file_name( $filename ) {
 	 */
 	$special_chars = apply_filters( 'sanitize_file_name_chars', $special_chars, $filename_raw );
 
-	$filename = str_replace( array( '%20', '+' ), '-', $filename );
+	$filename = str_replace( '%20', '-', $filename );
 	$filename = str_replace( $special_chars, '', $filename );
+	$filename = str_replace( '+', '-', $filename );
 	$filename = preg_replace( '/[\r\n\t -]+/', '-', $filename );
 	$filename = trim( $filename, '.-_' );
 

--- a/tests/phpunit/tests/formatting/sanitizeFileName.php
+++ b/tests/phpunit/tests/formatting/sanitizeFileName.php
@@ -17,7 +17,7 @@ class Tests_Formatting_SanitizeFileName extends WP_UnitTestCase {
 			$string .= $char;
 		}
 		$string .= 'test';
-		$this->assertSame( 'testtest', sanitize_file_name( $string ) );
+		$this->assertSame( 'test-test', sanitize_file_name( $string ) );
 	}
 
 	/**
@@ -38,8 +38,8 @@ class Tests_Formatting_SanitizeFileName extends WP_UnitTestCase {
 		$urls = array(
 			'unencoded space.png'  => 'unencoded-space.png',
 			'encoded-space.jpg'    => 'encoded-space.jpg',
-			'plus+space.jpg'       => 'plusspace.jpg',
-			'multi %20 +space.png' => 'multi-20-space.png',
+			'plus+space.jpg'       => 'plus-space.jpg',
+			'multi %20 +space.png' => 'multi-space.png',
 		);
 
 		foreach ( $urls as $test => $expected ) {

--- a/tests/phpunit/tests/formatting/sanitizeFileName.php
+++ b/tests/phpunit/tests/formatting/sanitizeFileName.php
@@ -32,19 +32,41 @@ class Tests_Formatting_SanitizeFileName extends WP_UnitTestCase {
 	/**
 	 * Test that spaces are correctly replaced with dashes.
 	 *
+	 * @dataProvider data_replaces_spaces
+	 *
 	 * @ticket 16330
+	 * @ticket 50855
+	 *
+	 * @param string $filename Filename to sanitize.
+	 * @param string $expected Expected result.
 	 */
-	public function test_replaces_spaces() {
-		$urls = array(
-			'unencoded space.png'  => 'unencoded-space.png',
-			'encoded-space.jpg'    => 'encoded-space.jpg',
-			'plus+space.jpg'       => 'plusspace.jpg',
-			'multi %20 +space.png' => 'multi-space.png',
-		);
+	public function test_replaces_spaces( $filename, $expected ) {
+		$this->assertSame( $expected, sanitize_file_name( $filename ) );
+	}
 
-		foreach ( $urls as $test => $expected ) {
-			$this->assertSame( $expected, sanitize_file_name( $test ) );
-		}
+	public function data_replaces_spaces() {
+		return array(
+			'unencoded space'  => array(
+				'filename' => 'unencoded space.png',
+				'expected' => 'unencoded-space.png',
+			),
+			'encoded-space'    => array(
+				'filename' => 'encoded-space.jpg',
+				'expected' => 'encoded-space.jpg',
+			),
+			'encoded-space'    => array(
+				'filename' => 'plus+space.jpg',
+				'expected' => 'plusspace.jpg',
+			),
+			'muliple %20'      => array(
+				'filename' => 'test%20test%20test%20.png',
+				'expected' => 'test-test-test-.png',
+			),
+			'multi %20 +space' => array(
+				'filename' => 'multi %20 +space.png',
+				'expected' => 'multi-space.png',
+			),
+		);
 	}
 
 	public function test_replaces_any_number_of_hyphens_with_one_hyphen() {

--- a/tests/phpunit/tests/formatting/sanitizeFileName.php
+++ b/tests/phpunit/tests/formatting/sanitizeFileName.php
@@ -17,7 +17,7 @@ class Tests_Formatting_SanitizeFileName extends WP_UnitTestCase {
 			$string .= $char;
 		}
 		$string .= 'test';
-		$this->assertSame( 'test-test', sanitize_file_name( $string ) );
+		$this->assertSame( 'testtest', sanitize_file_name( $string ) );
 	}
 
 	/**
@@ -38,7 +38,7 @@ class Tests_Formatting_SanitizeFileName extends WP_UnitTestCase {
 		$urls = array(
 			'unencoded space.png'  => 'unencoded-space.png',
 			'encoded-space.jpg'    => 'encoded-space.jpg',
-			'plus+space.jpg'       => 'plus-space.jpg',
+			'plus+space.jpg'       => 'plusspace.jpg',
 			'multi %20 +space.png' => 'multi-space.png',
 		);
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/50855

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
