### PR TITLE
Add errors to $wpdb->last_error when value fails (Trac 32315)

### DIFF
--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -2545,11 +2545,19 @@ class wpdb {
 				}
 			}
 
-			$this->last_error = sprintf(
-				/* translators: %s Database field that where the error occurred. */
-				__( 'WordPress database error: Processing the value for the following field failed: %s. The supplied value may be too long or contained invalid data.' ),
-				implode( ', ', $problem_fields )
-			);
+			if ( 1 === count( $problem_fields ) ) {
+				$this->last_error = sprintf(
+					/* translators: %s Database field where the error occurred. */
+					__( 'WordPress database error: Processing the value for the following field failed: %s. The supplied value may be too long or contained invalid data.' ),
+					reset( $problem_fields )
+				);
+			} else {
+				$this->last_error = sprintf(
+					/* translators: %s Database fields where the error occurred. */
+					__( 'WordPress database error: Processing the value for the following fields failed: %s. The supplied value may be too long or contained invalid data.' ),
+					implode( ', ', $problem_fields )
+				);
+			}
 
 			return false;
 		}

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -2017,7 +2017,13 @@ class wpdb {
 			if ( $stripped_query !== $query ) {
 				$this->insert_id  = 0;
 				$this->last_query = $query;
-				$this->last_error = __( 'WordPress database error: Could not perform query because it contains invalid data.' );
+
+				if ( function_exists( '__' ) ) {
+					$this->last_error = __( 'WordPress database error: Could not perform query because it contains invalid data.' );
+				} else {
+					$this->last_error = 'WordPress database error: Could not perform query because it contains invalid data.';
+				}
+
 				return false;
 			}
 		}
@@ -2546,18 +2552,22 @@ class wpdb {
 			}
 
 			if ( 1 === count( $problem_fields ) ) {
-				$this->last_error = sprintf(
+				if ( function_exists( '__' ) ) {
 					/* translators: %s Database field where the error occurred. */
-					__( 'WordPress database error: Processing the value for the following field failed: %s. The supplied value may be too long or contained invalid data.' ),
-					reset( $problem_fields )
-				);
+					$message = __( 'WordPress database error: Processing the value for the following field failed: %s. The supplied value may be too long or contained invalid data.' );
+				} else {
+					$message = 'WordPress database error: Processing the value for the following field failed: %s. The supplied value may be too long or contained invalid data.';
+				}
 			} else {
-				$this->last_error = sprintf(
+				if ( function_exists( '__' ) ) {
 					/* translators: %s Database fields where the error occurred. */
-					__( 'WordPress database error: Processing the value for the following fields failed: %s. The supplied value may be too long or contained invalid data.' ),
-					implode( ', ', $problem_fields )
-				);
+					$message = __( 'WordPress database error: Processing the value for the following fields failed: %s. The supplied value may be too long or contained invalid data.' );
+				} else {
+					$message = 'WordPress database error: Processing the value for the following fields failed: %s. The supplied value may be too long or contained invalid data.';
+				}
 			}
+
+			$this->last_error = sprintf( $message, implode( ', ', $problem_fields ) );
 
 			return false;
 		}

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -2016,6 +2016,8 @@ class wpdb {
 			$this->flush();
 			if ( $stripped_query !== $query ) {
 				$this->insert_id = 0;
+				$this->last_query = $query;
+				$this->last_error = __( 'WordPress Database Error: Could not perform query because it contains invalid data.' );
 				return false;
 			}
 		}
@@ -2535,6 +2537,22 @@ class wpdb {
 		$converted_data = $this->strip_invalid_text( $data );
 
 		if ( $data !== $converted_data ) {
+
+			$problem_fields = array();
+			foreach ( $data as $field => $value ) {
+				if ( $value !== $converted_data[ $field ] ) {
+					$problem_fields[] = $field;
+				}
+			}
+
+			if ( count( $problem_fields ) === 1 ) {
+				$message = __( 'WordPress Database Error: Processing the value for the following field failed, the supplied value may have been too long or contained invalid data: %s.' );
+			} else {
+				$message = __( 'WordPress Database Error: Processing the values for the following fields failed, the supplied values may have been too long or contained invalid data: %s.' );
+			}
+
+			$this->last_error = sprintf( $message, implode( ', ', $problem_fields ) );
+
 			return false;
 		}
 

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -2015,9 +2015,9 @@ class wpdb {
 			// to flush again, just to make sure everything is clear.
 			$this->flush();
 			if ( $stripped_query !== $query ) {
-				$this->insert_id = 0;
+				$this->insert_id  = 0;
 				$this->last_query = $query;
-				$this->last_error = __( 'WordPress Database Error: Could not perform query because it contains invalid data.' );
+				$this->last_error = __( 'WordPress database error: Could not perform query because it contains invalid data.' );
 				return false;
 			}
 		}
@@ -2545,13 +2545,11 @@ class wpdb {
 				}
 			}
 
-			if ( count( $problem_fields ) === 1 ) {
-				$message = __( 'WordPress Database Error: Processing the value for the following field failed, the supplied value may have been too long or contained invalid data: %s.' );
-			} else {
-				$message = __( 'WordPress Database Error: Processing the values for the following fields failed, the supplied values may have been too long or contained invalid data: %s.' );
-			}
-
-			$this->last_error = sprintf( $message, implode( ', ', $problem_fields ) );
+			$this->last_error = sprintf(
+				/* translators: %s Database field that where the error occurred. */
+				__( 'WordPress database error: Processing the value for the following field failed: %s. The supplied value may be too long or contained invalid data.' ),
+				implode( ', ', $problem_fields )
+			);
 
 			return false;
 		}

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -2554,16 +2554,16 @@ class wpdb {
 			if ( 1 === count( $problem_fields ) ) {
 				if ( function_exists( '__' ) ) {
 					/* translators: %s Database field where the error occurred. */
-					$message = __( 'WordPress database error: Processing the value for the following field failed: %s. The supplied value may be too long or contained invalid data.' );
+					$message = __( 'WordPress database error: Processing the value for the following field failed: %s. The supplied value may be too long or contains invalid data.' );
 				} else {
-					$message = 'WordPress database error: Processing the value for the following field failed: %s. The supplied value may be too long or contained invalid data.';
+					$message = 'WordPress database error: Processing the value for the following field failed: %s. The supplied value may be too long or contains invalid data.';
 				}
 			} else {
 				if ( function_exists( '__' ) ) {
 					/* translators: %s Database fields where the error occurred. */
-					$message = __( 'WordPress database error: Processing the value for the following fields failed: %s. The supplied value may be too long or contained invalid data.' );
+					$message = __( 'WordPress database error: Processing the value for the following fields failed: %s. The supplied value may be too long or contains invalid data.' );
 				} else {
-					$message = 'WordPress database error: Processing the value for the following fields failed: %s. The supplied value may be too long or contained invalid data.';
+					$message = 'WordPress database error: Processing the value for the following fields failed: %s. The supplied value may be too long or contains invalid data.';
 				}
 			}
 

--- a/tests/phpunit/tests/db.php
+++ b/tests/phpunit/tests/db.php
@@ -1190,8 +1190,9 @@ class Tests_DB extends WP_UnitTestCase {
 	 */
 	private function get_db_error_value_too_long( $errored_fields ) {
 		return sprintf(
-			'WordPress database error: Processing the value for the following field failed: %s. ' .
+			'WordPress database error: Processing the value for the following field%s failed: %s. ' .
 			'The supplied value may be too long or contained invalid data.',
+			str_contains( $errored_fields, ', ' ) ? 's' : '',
 			$errored_fields
 		);
 	}

--- a/tests/phpunit/tests/db.php
+++ b/tests/phpunit/tests/db.php
@@ -1191,7 +1191,7 @@ class Tests_DB extends WP_UnitTestCase {
 	private function get_db_error_value_too_long( $errored_fields ) {
 		return sprintf(
 			'WordPress database error: Processing the value for the following field%s failed: %s. ' .
-			'The supplied value may be too long or contained invalid data.',
+			'The supplied value may be too long or contains invalid data.',
 			str_contains( $errored_fields, ', ' ) ? 's' : '',
 			$errored_fields
 		);


### PR DESCRIPTION
Using patch 32315.3.diff, this PR includes the following improvements:

* Formatting for wpcs
* Moved the field names after the failed sentence, instead of at the end, i.e. for better understanding
* Streamlined the tests to avoid duplication
* Updated tests to latest standards including visibility, docblock, `@covers`, named keys/args in data sets, organization

Note: The original patch (used in this PR) meets the requirements identified by @dd32 and @pento including:

* Capture the error in `$wpdb->last_query` (rather than silently failing)
* Let `$wpdb` continue to abort

Trac ticket: https://core.trac.wordpress.org/ticket/32315

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
