### PR TITLE
Fix inclusion of `wp-embed-template` script and style when `SCRIPT_DEBUG` is off

### DIFF
--- a/src/wp-includes/embed.php
+++ b/src/wp-includes/embed.php
@@ -1042,27 +1042,10 @@ function enqueue_embed_scripts() {
  */
 function print_embed_styles() {
 	$type_attr = current_theme_supports( 'html5', 'style' ) ? '' : ' type="text/css"';
+	$suffix    = SCRIPT_DEBUG ? '' : '.min';
 	?>
 	<style<?php echo $type_attr; ?>>
-	<?php
-	if ( SCRIPT_DEBUG ) {
-		readfile( ABSPATH . WPINC . '/css/wp-embed-template.css' );
-	} else {
-		/*
-		 * If you're looking at a src version of this file, you'll see an "include"
-		 * statement below. This is used by the `npm run build` process to directly
-		 * include a minified version of wp-oembed-embed.css, instead of using the
-		 * readfile() method from above.
-		 *
-		 * If you're looking at a build version of this file, you'll see a string of
-		 * minified CSS. If you need to debug it, please turn on SCRIPT_DEBUG
-		 * and edit wp-embed-template.css directly.
-		 */
-		?>
-			include "css/wp-embed-template.min.css"
-		<?php
-	}
-	?>
+		<?php echo file_get_contents( ABSPATH . WPINC . "/css/wp-embed-template$suffix.css" ); ?>
 	</style>
 	<?php
 }
@@ -1073,30 +1056,9 @@ function print_embed_styles() {
  * @since 4.4.0
  */
 function print_embed_scripts() {
-	$type_attr = current_theme_supports( 'html5', 'script' ) ? '' : ' type="text/javascript"';
-	?>
-	<script<?php echo $type_attr; ?>>
-	<?php
-	if ( SCRIPT_DEBUG ) {
-		readfile( ABSPATH . WPINC . '/js/wp-embed-template.js' );
-	} else {
-		/*
-		 * If you're looking at a src version of this file, you'll see an "include"
-		 * statement below. This is used by the `npm run build` process to directly
-		 * include a minified version of wp-embed-template.js, instead of using the
-		 * readfile() method from above.
-		 *
-		 * If you're looking at a build version of this file, you'll see a string of
-		 * minified JavaScript. If you need to debug it, please turn on SCRIPT_DEBUG
-		 * and edit wp-embed-template.js directly.
-		 */
-		?>
-			include "js/wp-embed-template.min.js"
-		<?php
-	}
-	?>
-	</script>
-	<?php
+	wp_print_inline_script_tag(
+		file_get_contents( sprintf( ABSPATH . WPINC . '/js/wp-embed-template' . wp_scripts_get_suffix() . '.js' ) )
+	);
 }
 
 /**

--- a/src/wp-includes/embed.php
+++ b/src/wp-includes/embed.php
@@ -472,7 +472,7 @@ function get_post_embed_html( $width, $height, $post = null ) {
 	$embed_url .= "#?secret={$secret}";
 
 	$output = wp_get_inline_script_tag(
-		file_get_contents( sprintf( ABSPATH . WPINC . '/js/wp-embed' . wp_scripts_get_suffix() . '.js' ) )
+		file_get_contents( ABSPATH . WPINC . '/js/wp-embed' . wp_scripts_get_suffix() . '.js' )
 	);
 
 	$output .= sprintf(
@@ -1057,7 +1057,7 @@ function print_embed_styles() {
  */
 function print_embed_scripts() {
 	wp_print_inline_script_tag(
-		file_get_contents( sprintf( ABSPATH . WPINC . '/js/wp-embed-template' . wp_scripts_get_suffix() . '.js' ) )
+		file_get_contents( ABSPATH . WPINC . '/js/wp-embed-template' . wp_scripts_get_suffix() . '.js' )
 	);
 }
 


### PR DESCRIPTION
This fixes something I neglected in https://github.com/WordPress/wordpress-develop/pull/1745 when I removed the use of `grunt-include` to do the script injection. I failed to see that it was also being used in `print_embed_styles()` and `print_embed_scripts()` to include `wp-embed-template.min.css` and `wp-embed-template.min.js` respectively when `SCRIPT_DEBUG` is off. The result was the embed template erroneously serving:

```html
<style>
include "css/wp-embed-template.min.css"
</style>
...
<script>
include "js/wp-embed-template.min.js"
</script>
```

This naturally caused a JS syntax error, as well as broken styling.

With the changes in this PR, when `SCRIPT_DEBUG` is enabled or disabled, the result is:

Before | After
-------|-------
<img width="640" alt="before" src="https://user-images.githubusercontent.com/134745/141595658-6b34eb9d-909e-4848-a52d-a60a62ad07ac.png"> | <img width="624" alt="after" src="https://user-images.githubusercontent.com/134745/141595663-bd861607-4a8a-4717-b993-935740fbd4d9.png">



Trac ticket: https://core.trac.wordpress.org/ticket/44632

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
