### PR TITLE
Append `wp-embed` inline script to `get_post_embed_html()` instead of prepending it to fix regex parsing problem in `wp_filter_oembed_result()`

### DIFF
--- a/src/wp-includes/embed.php
+++ b/src/wp-includes/embed.php
@@ -471,11 +471,7 @@ function get_post_embed_html( $width, $height, $post = null ) {
 	$secret     = wp_generate_password( 10, false );
 	$embed_url .= "#?secret={$secret}";
 
-	$output = wp_get_inline_script_tag(
-		file_get_contents( ABSPATH . WPINC . '/js/wp-embed' . wp_scripts_get_suffix() . '.js' )
-	);
-
-	$output .= sprintf(
+	$output = sprintf(
 		'<blockquote class="wp-embedded-content" data-secret="%1$s"><a href="%2$s">%3$s</a></blockquote>',
 		esc_attr( $secret ),
 		esc_url( get_permalink( $post ) ),
@@ -496,6 +492,15 @@ function get_post_embed_html( $width, $height, $post = null ) {
 			)
 		),
 		esc_attr( $secret )
+	);
+
+	// Note that the script must be placed after the <blockquote> and <iframe> due to a regexp parsing issue in
+	// `wp_filter_oembed_result()`. Because of the regex pattern starts with `|(<blockquote>.*?</blockquote>)?.*|`
+	// wherein the <blockquote> is marked as being optional, if it is not at the beginning of the string then the group
+	// will fail to match and everything will be matched by `.*` and not included in the group. This regex issue goes
+	// back to WordPress 4.4, so in order to not break older installs this script must come at the end.
+	$output .= wp_get_inline_script_tag(
+		file_get_contents( ABSPATH . WPINC . '/js/wp-embed' . wp_scripts_get_suffix() . '.js' )
 	);
 
 	/**

--- a/src/wp-includes/embed.php
+++ b/src/wp-includes/embed.php
@@ -374,7 +374,7 @@ function wp_oembed_add_host_js() {
  * @return string Embed markup (without modifications).
  */
 function wp_maybe_enqueue_oembed_host_js( $html ) {
-	if ( preg_match( '/<blockquote\s[^>]*wp-embedded-content/', $html ) ) {
+	if ( preg_match( '/<blockquote\s[^>]*?wp-embedded-content/', $html ) ) {
 		wp_enqueue_script( 'wp-embed' );
 	}
 	return $html;

--- a/tests/phpunit/tests/oembed/template.php
+++ b/tests/phpunit/tests/oembed/template.php
@@ -300,7 +300,9 @@ class Tests_Embed_Template extends WP_UnitTestCase {
 		$actual   = get_post_embed_html( 200, 200, $post_id );
 		$actual   = preg_replace( '/secret=("?)\w+\1/', 'secret=__SECRET__', $actual );
 
-		$this->assertStringEndsWith( $expected, $actual );
+		$this->assertStringStartsWith( '<blockquote class="wp-embedded-content" data-secret=__SECRET__>', $actual );
+		$this->assertStringContainsString( $expected, $actual );
+		$this->assertStringEndsWith( '</script>', trim( $actual ) );
 	}
 
 	/** @covers ::wp_oembed_add_host_js() */


### PR DESCRIPTION
In testing post embeds from a site running trunk, I was surprised to find that `wp_filter_oembed_result()` was no longer able to parse out the `<blockquote>` here:

https://github.com/WordPress/wordpress-develop/blob/1e6bede076285c9fbafad7ce5a3cb4b1d153e56b/src/wp-includes/embed.php#L919-L924

As of #1745, `get_post_embed_html()` prepends the `wp-embed` script before the `<blockquote>` the resulting markup looks like this:

```html
<script>...</script>
<blockquote><a href="https://make.wordpress.org/core/2021/10/12/proposal-for-a-performance-team/">Proposal for a Performance team</a></blockquote><iframe title="&#8220;Proposal for a Performance team&#8221; &#8212; Make WordPress Core" src="https://make.wordpress.org/core/2021/10/12/proposal-for-a-performance-team/embed/#?secret=U4GcbJWnud" width="500" height="282" frameborder="0" marginwidth="0" marginheight="0" scrolling="no"></iframe>
```

After `wp_kses()` strips out the `<script>` and `</script>`, we're left with the raw script text contents preceding the initial `<blockquote>` (here `...`). 

Given the regex `|(<blockquote>.*?</blockquote>)?.*(<iframe.*?></iframe>)|ms`, the initial group is marked as optional so if it is not at the very beginning of the string (as it isn't here), then any initial text followed by anything including a `<blockquote>` will be matched by `.*` which is not a group, until ultimately only the `<iframe>` gets matched:

[![image](https://user-images.githubusercontent.com/134745/141609075-8911cc9a-c33e-4372-b455-94507e32e0a9.png)](https://regexr.com/69f4v)

The effect then that the `<blockquote>` is not included in the response as a fallback, and instead the rendered HTML is just:

```html
<p><iframe class="wp-embedded-content" sandbox="allow-scripts" security="restricted" title="&#8220;Embeds Changes in WordPress 4.5&#8221; &#8212; Make WordPress Core" src="https://make.wordpress.org/core/2016/03/11/embeds-changes-in-wordpress-4-5/embed/#?secret=erWLJU2ZRi#?secret=EI7GbHNMoS" data-secret="EI7GbHNMoS" width="600" height="338" frameborder="0" marginwidth="0" marginheight="0" scrolling="no"></iframe></p>
```

When it should rather be:

```html
<blockquote class="wp-embedded-content" data-secret="P6BHfgvygr"><p><a href="https://make.wordpress.org/core/2016/03/11/embeds-changes-in-wordpress-4-5/">Embeds Changes in WordPress 4.5</a></p></blockquote>
<p><iframe class="wp-embedded-content" sandbox="allow-scripts" security="restricted" style="position: absolute; clip: rect(1px, 1px, 1px, 1px);" title="&#8220;Embeds Changes in WordPress 4.5&#8221; &#8212; Make WordPress Core" src="https://make.wordpress.org/core/2016/03/11/embeds-changes-in-wordpress-4-5/embed/#?secret=f1CCnegK47#?secret=P6BHfgvygr" data-secret="P6BHfgvygr" width="600" height="338" frameborder="0" marginwidth="0" marginheight="0" scrolling="no"></iframe>
```

Simply appending `wp-embed` fixes the regex parsing problem.

Trac ticket: https://core.trac.wordpress.org/ticket/44632

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
