### PR TITLE
Deactivates Gutenberg plugin version is <= 11.8.2.

### DIFF
--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -1688,26 +1688,13 @@ function _upgrade_440_force_deactivate_incompatible_plugins() {
 }
 
 /**
+ * @access private
  * @ignore
  * @since 5.8.0
  */
 function _upgrade_580_force_deactivate_incompatible_plugins() {
 	if ( defined( 'GUTENBERG_VERSION' ) && version_compare( GUTENBERG_VERSION, '10.7', '<=' ) ) {
-		$deactivated_gutenberg['gutenberg'] = array(
-			'plugin_name'         => 'Gutenberg',
-			'version_deactivated' => GUTENBERG_VERSION,
-			'version_compatible'  => '10.8',
-		);
-		if ( is_plugin_active_for_network( 'gutenberg/gutenberg.php' ) ) {
-			$deactivated_plugins = get_site_option( 'wp_force_deactivated_plugins', array() );
-			$deactivated_plugins = array_merge( $deactivated_plugins, $deactivated_gutenberg );
-			update_site_option( 'wp_force_deactivated_plugins', $deactivated_plugins );
-		} else {
-			$deactivated_plugins = get_option( 'wp_force_deactivated_plugins', array() );
-			$deactivated_plugins = array_merge( $deactivated_plugins, $deactivated_gutenberg );
-			update_option( 'wp_force_deactivated_plugins', $deactivated_plugins );
-		}
-		deactivate_plugins( array( 'gutenberg/gutenberg.php' ), true );
+		_deactivate_gutenberg_when_incompatible_with_wp( '10.8' );
 	}
 }
 
@@ -1717,23 +1704,34 @@ function _upgrade_580_force_deactivate_incompatible_plugins() {
  * @since 5.9.0
  */
 function _upgrade_590_force_deactivate_incompatible_plugins() {
-	if ( defined( 'GUTENBERG_VERSION' ) &&
-		 version_compare( GUTENBERG_VERSION, '11.8.2', '<=' )
-	) {
-		$deactivated_gutenberg['gutenberg'] = array(
-			'plugin_name'         => 'Gutenberg',
-			'version_deactivated' => GUTENBERG_VERSION,
-			'version_compatible'  => '11.9',
-		);
-		if ( is_plugin_active_for_network( 'gutenberg/gutenberg.php' ) ) {
-			$deactivated_plugins = get_site_option( 'wp_force_deactivated_plugins', array() );
-			$deactivated_plugins = array_merge( $deactivated_plugins, $deactivated_gutenberg );
-			update_site_option( 'wp_force_deactivated_plugins', $deactivated_plugins );
-		} else {
-			$deactivated_plugins = get_option( 'wp_force_deactivated_plugins', array() );
-			$deactivated_plugins = array_merge( $deactivated_plugins, $deactivated_gutenberg );
-			update_option( 'wp_force_deactivated_plugins', $deactivated_plugins );
-		}
-		deactivate_plugins( array( 'gutenberg/gutenberg.php' ), true );
+	if ( defined( 'GUTENBERG_VERSION' ) && version_compare( GUTENBERG_VERSION, '11.8.2', '<=' ) ) {
+		_deactivate_gutenberg_when_incompatible_with_wp( '11.9' );
 	}
+}
+
+/**
+ * Deactivates the Gutenberg plugin when its version is incompatible.
+ *
+ * @access private
+ * @ignore
+ * @since 5.9.0
+ *
+ * @param string $compatible_version The version of Gutenberg plugin that is compatible.
+ */
+function _deactivate_gutenberg_when_incompatible_with_wp( $compatible_version ) {
+	$deactivated_gutenberg['gutenberg'] = array(
+		'plugin_name'         => 'Gutenberg',
+		'version_deactivated' => GUTENBERG_VERSION,
+		'version_compatible'  => $compatible_version,
+	);
+	if ( is_plugin_active_for_network( 'gutenberg/gutenberg.php' ) ) {
+		$deactivated_plugins = get_site_option( 'wp_force_deactivated_plugins', array() );
+		$deactivated_plugins = array_merge( $deactivated_plugins, $deactivated_gutenberg );
+		update_site_option( 'wp_force_deactivated_plugins', $deactivated_plugins );
+	} else {
+		$deactivated_plugins = get_option( 'wp_force_deactivated_plugins', array() );
+		$deactivated_plugins = array_merge( $deactivated_plugins, $deactivated_gutenberg );
+		update_option( 'wp_force_deactivated_plugins', $deactivated_plugins );
+	}
+	deactivate_plugins( array( 'gutenberg/gutenberg.php' ), true );
 }

--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -1401,6 +1401,9 @@ function update_core( $from, $to ) {
 	// Deactivate the Gutenberg plugin if its version is 10.7 or lower.
 	_upgrade_580_force_deactivate_incompatible_plugins();
 
+	// Deactivate the Gutenberg plugin if its version is 11.8.2 or lower.
+	_upgrade_590_force_deactivate_incompatible_plugins();
+
 	// Upgrade DB with separate request.
 	/** This filter is documented in wp-admin/includes/update-core.php */
 	apply_filters( 'update_feedback', __( 'Upgrading database&#8230;' ) );
@@ -1694,6 +1697,33 @@ function _upgrade_580_force_deactivate_incompatible_plugins() {
 			'plugin_name'         => 'Gutenberg',
 			'version_deactivated' => GUTENBERG_VERSION,
 			'version_compatible'  => '10.8',
+		);
+		if ( is_plugin_active_for_network( 'gutenberg/gutenberg.php' ) ) {
+			$deactivated_plugins = get_site_option( 'wp_force_deactivated_plugins', array() );
+			$deactivated_plugins = array_merge( $deactivated_plugins, $deactivated_gutenberg );
+			update_site_option( 'wp_force_deactivated_plugins', $deactivated_plugins );
+		} else {
+			$deactivated_plugins = get_option( 'wp_force_deactivated_plugins', array() );
+			$deactivated_plugins = array_merge( $deactivated_plugins, $deactivated_gutenberg );
+			update_option( 'wp_force_deactivated_plugins', $deactivated_plugins );
+		}
+		deactivate_plugins( array( 'gutenberg/gutenberg.php' ), true );
+	}
+}
+
+/**
+ * @access private
+ * @ignore
+ * @since 5.9.0
+ */
+function _upgrade_590_force_deactivate_incompatible_plugins() {
+	if ( defined( 'GUTENBERG_VERSION' ) &&
+		 version_compare( GUTENBERG_VERSION, '11.8.2', '<=' )
+	) {
+		$deactivated_gutenberg['gutenberg'] = array(
+			'plugin_name'         => 'Gutenberg',
+			'version_deactivated' => GUTENBERG_VERSION,
+			'version_compatible'  => '11.9',
 		);
 		if ( is_plugin_active_for_network( 'gutenberg/gutenberg.php' ) ) {
 			$deactivated_plugins = get_site_option( 'wp_force_deactivated_plugins', array() );

--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -1704,7 +1704,7 @@ function _upgrade_580_force_deactivate_incompatible_plugins() {
  * @since 5.9.0
  */
 function _upgrade_590_force_deactivate_incompatible_plugins() {
-	if ( defined( 'GUTENBERG_VERSION' ) && version_compare( GUTENBERG_VERSION, '11.8.2', '<=' ) ) {
+	if ( defined( 'GUTENBERG_VERSION' ) && version_compare( GUTENBERG_VERSION, '11.8', '<=' ) ) {
 		_deactivate_gutenberg_when_incompatible_with_wp( '11.9' );
 	}
 }

--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -1401,7 +1401,7 @@ function update_core( $from, $to ) {
 	// Deactivate the Gutenberg plugin if its version is 10.7 or lower.
 	_upgrade_580_force_deactivate_incompatible_plugins();
 
-	// Deactivate the Gutenberg plugin if its version is 11.8.2 or lower.
+	// Deactivate the Gutenberg plugin if its version is 11.8 or lower.
 	_upgrade_590_force_deactivate_incompatible_plugins();
 
 	// Upgrade DB with separate request.


### PR DESCRIPTION
Uses the same strategy from WordPress 5.8 release to deactivate the Gutenberg plugin if its version is incompatible with 5.9. 

Incompatible version is 11.8.
Compatible version set to 11.9.

https://3v4l.org/rh94P

As this is likely needed from release-to-release, refactored the code from 5.8 to a private core function for use in 5.8, 5.9, and future major releases.

Trac ticket: https://core.trac.wordpress.org/ticket/54405

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
