### PR TITLE
Add missing periods to user edit screens

### DIFF
--- a/src/wp-admin/user-edit.php
+++ b/src/wp-admin/user-edit.php
@@ -267,7 +267,7 @@ switch ( $action ) {
 		<th scope="row"><?php _e( 'Visual Editor' ); ?></th>
 		<td>
 			<label for="rich_editing"><input name="rich_editing" type="checkbox" id="rich_editing" value="false" <?php checked( 'false', $profileuser->rich_editing ); ?> />
-				<?php _e( 'Disable the visual editor when writing' ); ?>
+				<?php _e( 'Disable the visual editor when writing.' ); ?>
 			</label>
 		</td>
 	</tr>
@@ -290,7 +290,7 @@ switch ( $action ) {
 		<th scope="row"><?php _e( 'Syntax Highlighting' ); ?></th>
 		<td>
 			<label for="syntax_highlighting"><input name="syntax_highlighting" type="checkbox" id="syntax_highlighting" value="false" <?php checked( 'false', $profileuser->syntax_highlighting ); ?> />
-				<?php _e( 'Disable syntax highlighting when editing code' ); ?>
+				<?php _e( 'Disable syntax highlighting when editing code.' ); ?>
 			</label>
 		</td>
 	</tr>
@@ -336,7 +336,7 @@ switch ( $action ) {
 		<td>
 			<label for="admin_bar_front">
 				<input name="admin_bar_front" type="checkbox" id="admin_bar_front" value="1"<?php checked( _get_admin_bar_pref( 'front', $profileuser->ID ) ); ?> />
-				<?php _e( 'Show Toolbar when viewing site' ); ?>
+				<?php _e( 'Show Toolbar when viewing site.' ); ?>
 			</label><br />
 		</td>
 	</tr>


### PR DESCRIPTION
Adds periods to the end of labels on user edit screens for consistency.


![Screen Shot 2021-11-15 at 12 20 59 PM](https://user-images.githubusercontent.com/66798/141833994-d180a596-d1c7-4f7a-9a6e-059f34174367.png)

Trac ticket: [#48221](https://core.trac.wordpress.org/ticket/48221)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
