### PR TITLE
Don't output a cancel comment reply link if comments aren't threaded (Trac 37267)

### DIFF
--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -2538,11 +2538,13 @@ function comment_form( $args = array(), $post_id = null ) {
 
 		comment_form_title( $args['title_reply'], $args['title_reply_to'] );
 
-		echo $args['cancel_reply_before'];
+		if ( get_option( 'thread_comments' ) ) {
+			echo $args['cancel_reply_before'];
 
-		cancel_comment_reply_link( $args['cancel_reply_link'] );
+			cancel_comment_reply_link( $args['cancel_reply_link'] );
 
-		echo $args['cancel_reply_after'];
+			echo $args['cancel_reply_after'];
+		}
 
 		echo $args['title_reply_after'];
 

--- a/tests/phpunit/tests/comment/commentForm.php
+++ b/tests/phpunit/tests/comment/commentForm.php
@@ -1,9 +1,16 @@
 <?php
 
 /**
- * @group comment
+ * @group  comment
+ * @covers ::comment_form
  */
 class Tests_Comment_CommentForm extends WP_UnitTestCase {
+	public static $post_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$post_id = $factory->post->create();
+	}
+
 	public function test_default_markup_for_submit_button_and_wrapper() {
 		$p = self::factory()->post->create();
 
@@ -122,5 +129,27 @@ class Tests_Comment_CommentForm extends WP_UnitTestCase {
 		$form_without_aria = get_echo( 'comment_form', array( $args, $p ) );
 
 		$this->assertStringNotContainsString( 'aria-describedby="email-notes"', $form_without_aria );
+	}
+
+	/**
+	 * @ticket 32767
+	 */
+	public function test_when_thread_comments_enabled() {
+		update_option( 'thread_comments', true );
+
+		$form     = get_echo( 'comment_form', array( array(), self::$post_id ) );
+		$expected = '<a rel="nofollow" id="cancel-comment-reply-link" href="#respond" style="display:none;">Cancel reply</a>';
+		$this->assertStringContainsString( $expected, $form );
+	}
+
+	/**
+	 * @ticket 32767
+	 */
+	public function test_when_thread_comments_disabled() {
+		delete_option( 'thread_comments' );
+
+		$form     = get_echo( 'comment_form', array( array(), self::$post_id ) );
+		$expected = '<a rel="nofollow" id="cancel-comment-reply-link" href="#respond" style="display:none;">Cancel reply</a>';
+		$this->assertStringNotContainsString( $expected, $form );
 	}
 }


### PR DESCRIPTION
Applies 37267.2.diff patch and adds tests.

Trac ticket: https://core.trac.wordpress.org/ticket/37267

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
