### PR TITLE
Encodes ending '.' for user login (Trac 42957)

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -8333,3 +8333,35 @@ function is_php_version_compatible( $required ) {
 function wp_fuzzy_number_match( $expected, $actual, $precision = 1 ) {
 	return abs( (float) $expected - (float) $actual ) <= $precision;
 }
+
+/**
+ * Replaces periods with encoded entities in URLs.
+ *
+ * If the URL ends with a period, replace it with %2E to avoid
+ * misinterpretation from some email clients.
+ *
+ * @since 5.9.0
+ *
+ * @param string $url The URL to encode.
+ * @return string The new encoded URL.
+ */
+function wp_url_encode_ending_period( $url ) {
+	if ( ! is_string( $url ) ) {
+		return '';
+	}
+
+	$url = trim( $url );
+	if ( '' === $url ) {
+		return '';
+	}
+
+	$url = rawurlencode( $url );
+
+	// If the URL ends in a period, replace it with %2E.
+	if ( str_ends_with( $url, '.' ) ) {
+		$url  = substr( $url, 0, strlen( $url ) - 1 );
+		$url .= '%2E';
+	}
+
+	return $url;
+}

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -2108,7 +2108,7 @@ if ( ! function_exists( 'wp_new_user_notification' ) ) :
 		/* translators: %s: User login. */
 		$message  = sprintf( __( 'Username: %s' ), $user->user_login ) . "\r\n\r\n";
 		$message .= __( 'To set your password, visit the following address:' ) . "\r\n\r\n";
-		$message .= network_site_url( "wp-login.php?action=rp&key=$key&login=" . rawurlencode( $user->user_login ), 'login' ) . "\r\n\r\n";
+		$message .= network_site_url( "wp-login.php?action=rp&key=$key&login=" . wp_url_encode_ending_period( $user->user_login ), 'login' ) . "\r\n\r\n";
 
 		$message .= wp_login_url() . "\r\n";
 

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -2969,7 +2969,7 @@ function retrieve_password( $user_login = null ) {
 	$message .= sprintf( __( 'Username: %s' ), $user_login ) . "\r\n\r\n";
 	$message .= __( 'If this was a mistake, ignore this email and nothing will happen.' ) . "\r\n\r\n";
 	$message .= __( 'To reset your password, visit the following address:' ) . "\r\n\r\n";
-	$message .= network_site_url( "wp-login.php?action=rp&key=$key&login=" . rawurlencode( $user_login ), 'login' ) . '&wp_lang=' . $locale . "\r\n\r\n";
+	$message .= network_site_url( "wp-login.php?action=rp&key=$key&login=" . wp_url_encode_ending_period( $user_login ), 'login' ) . '&wp_lang=' . $locale . "\r\n\r\n";
 
 	if ( ! is_user_logged_in() ) {
 		$requester_ip = $_SERVER['REMOTE_ADDR'];

--- a/tests/phpunit/tests/functions/wpUrlEncodeEndingPeriod.php
+++ b/tests/phpunit/tests/functions/wpUrlEncodeEndingPeriod.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * Tests for wp_url_encode_ending_period()
+ *
+ * @group  functions.php
+ * @covers ::wp_url_encode_ending_period
+ */
+class Tests_Functions_WpUrlEncodeEndingPeriod extends WP_UnitTestCase {
+
+	/**
+	 * @dataProvider data_wp_url_encode_ending_period
+	 *
+	 * @ticket 42957
+	 *
+	 * @param string $url      URL to test.
+	 * @param string $expected Expected result.
+	 */
+	public function test_wp_url_encode_ending_period( $url, $expected ) {
+		$this->assertSame( $expected, wp_url_encode_ending_period( $url ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_wp_url_encode_ending_period() {
+		return array(
+			'empty string'            => array(
+				'input'    => '',
+				'expected' => '',
+			),
+			'.'                       => array(
+				'input'    => '.',
+				'expected' => '%2E',
+			),
+			'. with space after'      => array(
+				'input'    => '. ',
+				'expected' => '%2E',
+			),
+			'..'                      => array(
+				'input'    => '..',
+				'expected' => '.%2E',
+			),
+			'. with space after'      => array(
+				'input'    => '..  ',
+				'expected' => '.%2E',
+			),
+			'...'                     => array(
+				'input'    => '...',
+				'expected' => '..%2E',
+			),
+			'starts with .'           => array(
+				'input'    => '.username',
+				'expected' => '.username',
+			),
+			'ends with .'             => array(
+				'input'    => 'username.',
+				'expected' => 'username%2E',
+			),
+			'ends with spaces and .'  => array(
+				'input'    => 'username .',
+				'expected' => 'username%20%2E',
+			),
+			'. in the middle'         => array(
+				'input'    => 'user.name',
+				'expected' => 'user.name',
+			),
+			'. in middle with spaces' => array(
+				'input'    => 'user . name',
+				'expected' => 'user%20.%20name',
+			),
+			'no . with a space'       => array(
+				'input'    => 'user name',
+				'expected' => 'user%20name',
+			),
+			'. in middle and end'     => array(
+				'input'    => 'user.name.',
+				'expected' => 'user.name%2E',
+			),
+		);
+	}
+}


### PR DESCRIPTION
Supersedes PR #1095 which was based on `master` instead of `trunk`. `trunk` has the polyfill and latest updates.

Trac ticket: https://core.trac.wordpress.org/ticket/42957

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
