### PR TITLE
Improves plural wpdb error message (Trac 32315)

### DIFF
--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -2018,11 +2018,11 @@ class wpdb {
 				$this->insert_id  = 0;
 				$this->last_query = $query;
 
-				if ( function_exists( '__' ) ) {
-					$this->last_error = __( 'WordPress database error: Could not perform query because it contains invalid data.' );
-				} else {
-					$this->last_error = 'WordPress database error: Could not perform query because it contains invalid data.';
+				if ( ! function_exists( '__' ) ) {
+					wp_load_translations_early();
 				}
+
+				$this->last_error = __( 'WordPress database error: Could not perform query because it contains invalid data.' );
 
 				return false;
 			}
@@ -2551,20 +2551,16 @@ class wpdb {
 				}
 			}
 
+			if ( ! function_exists( '__' ) ) {
+				wp_load_translations_early();
+			}
+
 			if ( 1 === count( $problem_fields ) ) {
-				if ( function_exists( '__' ) ) {
-					/* translators: %s Database field where the error occurred. */
-					$message = __( 'WordPress database error: Processing the value for the following field failed: %s. The supplied value may be too long or contains invalid data.' );
-				} else {
-					$message = 'WordPress database error: Processing the value for the following field failed: %s. The supplied value may be too long or contains invalid data.';
-				}
+				/* translators: %s Database field where the error occurred. */
+				$message = __( 'WordPress database error: Processing the value for the following field failed: %s. The supplied value may be too long or contains invalid data.' );
 			} else {
-				if ( function_exists( '__' ) ) {
-					/* translators: %s Database fields where the error occurred. */
-					$message = __( 'WordPress database error: Processing the values for the following fields failed: %s. The supplied values may be too long or contain invalid data.' );
-				} else {
-					$message = 'WordPress database error: Processing the values for the following fields failed: %s. The supplied values may be too long or contain invalid data.';
-				}
+				/* translators: %s Database fields where the error occurred. */
+				$message = __( 'WordPress database error: Processing the values for the following fields failed: %s. The supplied values may be too long or contain invalid data.' );
 			}
 
 			$this->last_error = sprintf( $message, implode( ', ', $problem_fields ) );

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -2553,7 +2553,7 @@ class wpdb {
 
 			if ( 1 === count( $problem_fields ) ) {
 				$this->last_error = sprintf(
-					/* translators: %s Database field where the error occurred. */
+					/* translators: %s: Database field where the error occurred. */
 					__( 'WordPress database error: Processing the value for the following field failed: %s. The supplied value may be too long or contains invalid data.' ),
 					reset( $problem_fields )
 				);

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -2559,7 +2559,7 @@ class wpdb {
 				);
 			} else {
 				$this->last_error = sprintf(
-					/* translators: %s Database fields where the error occurred. */
+					/* translators: %s: Database fields where the error occurred. */
 					__( 'WordPress database error: Processing the values for the following fields failed: %s. The supplied values may be too long or contain invalid data.' ),
 					implode( ', ', $problem_fields )
 				);

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -2556,14 +2556,18 @@ class wpdb {
 			}
 
 			if ( 1 === count( $problem_fields ) ) {
-				/* translators: %s Database field where the error occurred. */
-				$message = __( 'WordPress database error: Processing the value for the following field failed: %s. The supplied value may be too long or contains invalid data.' );
+				$this->last_error = sprintf(
+					/* translators: %s Database field where the error occurred. */
+					__( 'WordPress database error: Processing the value for the following field failed: %s. The supplied value may be too long or contains invalid data.' ),
+					reset( $problem_fields )
+				);
 			} else {
-				/* translators: %s Database fields where the error occurred. */
-				$message = __( 'WordPress database error: Processing the values for the following fields failed: %s. The supplied values may be too long or contain invalid data.' );
+				$this->last_error = sprintf(
+					/* translators: %s Database fields where the error occurred. */
+					__( 'WordPress database error: Processing the values for the following fields failed: %s. The supplied values may be too long or contain invalid data.' ),
+					implode( ', ', $problem_fields )
+				);
 			}
-
-			$this->last_error = sprintf( $message, implode( ', ', $problem_fields ) );
 
 			return false;
 		}

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -2018,9 +2018,7 @@ class wpdb {
 				$this->insert_id  = 0;
 				$this->last_query = $query;
 
-				if ( ! function_exists( '__' ) ) {
-					wp_load_translations_early();
-				}
+				wp_load_translations_early();
 
 				$this->last_error = __( 'WordPress database error: Could not perform query because it contains invalid data.' );
 
@@ -2551,9 +2549,7 @@ class wpdb {
 				}
 			}
 
-			if ( ! function_exists( '__' ) ) {
-				wp_load_translations_early();
-			}
+			wp_load_translations_early();
 
 			if ( 1 === count( $problem_fields ) ) {
 				$this->last_error = sprintf(

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -2561,9 +2561,9 @@ class wpdb {
 			} else {
 				if ( function_exists( '__' ) ) {
 					/* translators: %s Database fields where the error occurred. */
-					$message = __( 'WordPress database error: Processing the value for the following fields failed: %s. The supplied value may be too long or contains invalid data.' );
+					$message = __( 'WordPress database error: Processing the values for the following fields failed: %s. The supplied values may be too long or contain invalid data.' );
 				} else {
-					$message = 'WordPress database error: Processing the value for the following fields failed: %s. The supplied value may be too long or contains invalid data.';
+					$message = 'WordPress database error: Processing the values for the following fields failed: %s. The supplied values may be too long or contain invalid data.';
 				}
 			}
 

--- a/tests/phpunit/tests/db.php
+++ b/tests/phpunit/tests/db.php
@@ -1189,10 +1189,16 @@ class Tests_DB extends WP_UnitTestCase {
 	 * @param string $errored_fields Expected fields in the error message.
 	 */
 	private function get_db_error_value_too_long( $errored_fields ) {
+		if ( str_contains( $errored_fields, ', ' ) ) {
+			return sprintf(
+				'WordPress database error: Processing the values for the following fields failed: %s. ' .
+				'The supplied values may be too long or contain invalid data.',
+				$errored_fields
+			);
+		}
 		return sprintf(
-			'WordPress database error: Processing the value for the following field%s failed: %s. ' .
+			'WordPress database error: Processing the value for the following field failed: %s. ' .
 			'The supplied value may be too long or contains invalid data.',
-			str_contains( $errored_fields, ', ' ) ? 's' : '',
 			$errored_fields
 		);
 	}


### PR DESCRIPTION
As a follow-up to changeset https://core.trac.wordpress.org/changeset/52176, this PR improves the plural  error message, i.e. error for multiple fields.

Also gets rid of the `function_exists()` guards by first checking if `__()` does not exist and then invoking `wp_load_translations_early()`.

Trac ticket: https://core.trac.wordpress.org/ticket/32315

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
