### PR TITLE
add_query_arg function doesn't remove the empty '?' when an anchor exists (Trac 44499)

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -1169,6 +1169,7 @@ function add_query_arg( ...$args ) {
 	$ret = preg_replace( '#=(&|$)#', '$1', $ret );
 	$ret = $protocol . $base . $ret . $frag;
 	$ret = rtrim( $ret, '?' );
+	$ret = str_replace( '?#', '#', $ret );
 	return $ret;
 }
 

--- a/tests/phpunit/tests/functions.php
+++ b/tests/phpunit/tests/functions.php
@@ -679,8 +679,8 @@ class Tests_Functions extends WP_UnitTestCase {
 	 * @param string $url      Url to test.
 	 * @param string $expected Expected URL.
 	 */
-	public function test_add_query_arg_removes_question_mark( $url, $expected ) {
-		$this->assertSame( $expected, add_query_arg( 'param', false, $url ) );
+	public function test_add_query_arg_removes_question_mark( $url, $expected, $key = 'param', $value = false ) {
+		$this->assertSame( $expected, add_query_arg( $key, $value, $url ) );
 	}
 
 	/**
@@ -690,24 +690,37 @@ class Tests_Functions extends WP_UnitTestCase {
 	 */
 	public function data_add_query_arg_removes_question_mark() {
 		return array(
-			'anchor'                                => array(
+			'anchor'                                     => array(
 				'url'      => 'http://example.org?#anchor',
 				'expected' => 'http://example.org#anchor',
 			),
-			'/ then anchor'                         => array(
+			'/ then anchor'                              => array(
 				'url'      => 'http://example.org/?#anchor',
 				'expected' => 'http://example.org/#anchor',
 			),
-			'invalid query param and anchor'        => array(
+			'invalid query param and anchor'             => array(
 				'url'      => 'http://example.org?param=value#anchor',
 				'expected' => 'http://example.org#anchor',
 			),
-			'/ then invalid query param and anchor' => array(
+			'/ then invalid query param and anchor'      => array(
 				'url'      => 'http://example.org/?param=value#anchor',
 				'expected' => 'http://example.org/#anchor',
 			),
+			'?#anchor when adding valid key/value args'  => array(
+				'url'      => 'http://example.org?#anchor',
+				'expected' => 'http://example.org?foo=bar#anchor',
+				'key'      => 'foo',
+				'value'    => 'bar',
+			),
+			'/?#anchor when adding valid key/value args' => array(
+				'url'      => 'http://example.org/?#anchor',
+				'expected' => 'http://example.org/?foo=bar#anchor',
+				'key'      => 'foo',
+				'value'    => 'bar',
+			),
 		);
 	}
+
 	/**
 	 * @ticket 21594
 	 */

--- a/tests/phpunit/tests/functions.php
+++ b/tests/phpunit/tests/functions.php
@@ -666,6 +666,49 @@ class Tests_Functions extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that add_query_arg removes the question mark when
+	 * a parameter is set to false.
+	 *
+	 * @dataProvider data_add_query_arg_removes_question_mark
+	 *
+	 * @ticket 44499
+	 * @group  add_query_arg
+	 *
+	 * @covers ::add_query_arg
+	 *
+	 * @param string $url      Url to test.
+	 * @param string $expected Expected URL.
+	 */
+	public function test_add_query_arg_removes_question_mark( $url, $expected ) {
+		$this->assertSame( $expected, add_query_arg( 'param', false, $url ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_add_query_arg_removes_question_mark() {
+		return array(
+			'anchor'                                => array(
+				'url'      => 'http://example.org?#anchor',
+				'expected' => 'http://example.org#anchor',
+			),
+			'/ then anchor'                         => array(
+				'url'      => 'http://example.org/?#anchor',
+				'expected' => 'http://example.org/#anchor',
+			),
+			'invalid query param and anchor'        => array(
+				'url'      => 'http://example.org?param=value#anchor',
+				'expected' => 'http://example.org#anchor',
+			),
+			'/ then invalid query param and anchor' => array(
+				'url'      => 'http://example.org/?param=value#anchor',
+				'expected' => 'http://example.org/#anchor',
+			),
+		);
+	}
+	/**
 	 * @ticket 21594
 	 */
 	public function test_get_allowed_mime_types() {


### PR DESCRIPTION
Applies patch 44499.1.diff.
Adds more test datasets.

Trac ticket: https://core.trac.wordpress.org/ticket/44499

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
