### PR TITLE
#46748

### DIFF
--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -204,7 +204,7 @@ function wp_authenticate_email_password( $user, $email, $password ) {
 		return $user;
 	}
 
-	if ( is_wp_error( $user ) && ! filter_var( $email, FILTER_VALIDATE_EMAIL ) ) {
+	if ( is_wp_error( $user ) ) {
 		return $user;
 	}
 

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -126,11 +126,11 @@ function wp_authenticate_username_password( $user, $username, $password ) {
 		return $user;
 	}
 
-	if ( empty( $username ) || empty( $password ) ) {
-		if ( is_wp_error( $user ) ) {
-			return $user;
-		}
+	if ( is_wp_error( $user ) ) {
+		return $user;
+	}
 
+	if ( empty( $username ) || empty( $password ) ) {
 		$error = new WP_Error();
 
 		if ( empty( $username ) ) {
@@ -204,11 +204,11 @@ function wp_authenticate_email_password( $user, $email, $password ) {
 		return $user;
 	}
 
-	if ( empty( $email ) || empty( $password ) ) {
-		if ( is_wp_error( $user ) ) {
-			return $user;
-		}
+	if ( is_wp_error( $user ) && ! filter_var( $email, FILTER_VALIDATE_EMAIL ) ) {
+		return $user;
+	}
 
+	if ( empty( $email ) || empty( $password ) ) {
 		$error = new WP_Error();
 
 		if ( empty( $email ) ) {
@@ -277,6 +277,10 @@ function wp_authenticate_cookie( $user, $username, $password ) {
 		return $user;
 	}
 
+	if ( is_wp_error( $user ) ) {
+		return $user;
+	}
+
 	if ( empty( $username ) && empty( $password ) ) {
 		$user_id = wp_validate_auth_cookie();
 		if ( $user_id ) {
@@ -315,6 +319,10 @@ function wp_authenticate_cookie( $user, $username, $password ) {
  */
 function wp_authenticate_application_password( $input_user, $username, $password ) {
 	if ( $input_user instanceof WP_User ) {
+		return $input_user;
+	}
+
+	if ( is_wp_error( $input_user ) ) {
 		return $input_user;
 	}
 

--- a/tests/phpunit/tests/auth.php
+++ b/tests/phpunit/tests/auth.php
@@ -669,6 +669,13 @@ class Tests_Auth extends WP_UnitTestCase {
 		}
 	}
 
+	public function data_application_passwords_can_use_capability_checks_to_determine_feature_availability() {
+		return array(
+			'allowed'     => array( 'editor', true ),
+			'not allowed' => array( 'subscriber', false ),
+		);
+	}
+
 	/**
 	 * @ticket 46748
 	 */

--- a/tests/phpunit/tests/auth.php
+++ b/tests/phpunit/tests/auth.php
@@ -669,10 +669,19 @@ class Tests_Auth extends WP_UnitTestCase {
 		}
 	}
 
-	public function data_application_passwords_can_use_capability_checks_to_determine_feature_availability() {
-		return array(
-			'allowed'     => array( 'editor', true ),
-			'not allowed' => array( 'subscriber', false ),
-		);
+	/**
+	 * @ticket 46748
+	 */
+	public function test_authenticate_filter_with_low_priority_prohibits_login() {
+		$callback = static function() {
+			return new WP_Error();
+		};
+		add_filter( 'authenticate', $callback, 5 );
+
+		$actual = wp_authenticate( $this->user->user_login, 'password' );
+
+		remove_filter( 'authenticate', $callback, 5 );
+
+		$this->assertInstanceOf( 'WP_Error', $actual );
 	}
 }

--- a/tests/phpunit/tests/user/wpAuthenticateApplicationPassword.php
+++ b/tests/phpunit/tests/user/wpAuthenticateApplicationPassword.php
@@ -18,24 +18,8 @@ class Tests_User_WpAuthenticateApplicationPassword extends WP_UnitTestCase {
 		);
 	}
 
-	public function tear_down() {
-		if ( $this->admin_user instanceof WP_User ) {
-			if ( is_multisite() ) {
-				wp_delete_user( $this->admin_user->data->ID );
-			} else {
-				wp_delete_user( $this->admin_user->ID );
-			}
-		}
-
-		remove_filter(
-			'wp_authenticate_user',
-			array( $this, 'callback_returns_wp_error' )
-		);
-	}
-
 	/**
-	 * Tests that a WP_User object is returned for a user
-	 * that is already logged in.
+	 * @ticket 46748
 	 */
 	public function test_returns_logged_in_user() {
 		$actual = wp_authenticate_application_password( $this->admin_user, 'admin', 'password' );
@@ -43,9 +27,9 @@ class Tests_User_WpAuthenticateApplicationPassword extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that wp_authenticate_application_password returns a WP_Error object.
-	 *
 	 * @dataProvider data_returns_wp_error
+	 *
+	 * @ticket 46748
 	 *
 	 * @param WP_User|WP_Error|null $user      The user object, a WP Error or null. Default null.
 	 * @param string                $username  The username to try to authenticate.

--- a/tests/phpunit/tests/user/wpAuthenticateApplicationPassword.php
+++ b/tests/phpunit/tests/user/wpAuthenticateApplicationPassword.php
@@ -18,9 +18,6 @@ class Tests_User_WpAuthenticateApplicationPassword extends WP_UnitTestCase {
 		);
 	}
 
-	/**
-	 * @ticket 46748
-	 */
 	public function test_returns_logged_in_user() {
 		$actual = wp_authenticate_application_password( $this->admin_user, 'admin', 'password' );
 		$this->assertInstanceOf( 'WP_User', $actual );
@@ -28,8 +25,6 @@ class Tests_User_WpAuthenticateApplicationPassword extends WP_UnitTestCase {
 
 	/**
 	 * @dataProvider data_returns_wp_error
-	 *
-	 * @ticket 46748
 	 *
 	 * @param WP_User|WP_Error|null $user      The user object, a WP Error or null. Default null.
 	 * @param string                $username  The username to try to authenticate.

--- a/tests/phpunit/tests/user/wpAuthenticateApplicationPassword.php
+++ b/tests/phpunit/tests/user/wpAuthenticateApplicationPassword.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * @group user
+ *
+ * @covers ::wp_authenticate_application_password
+ */
+class Tests_User_WpAuthenticateApplicationPassword extends WP_UnitTestCase {
+	protected $admin_user;
+
+	public function set_up() {
+		$this->admin_user = $this->factory->user->create_and_get(
+			array(
+				'role'       => 'administrator',
+				'user_login' => 'admin1',
+				'user_pass'  => 'password',
+			)
+		);
+	}
+
+	public function tear_down() {
+		if ( $this->admin_user instanceof WP_User ) {
+			if ( is_multisite() ) {
+				wp_delete_user( $this->admin_user->data->ID );
+			} else {
+				wp_delete_user( $this->admin_user->ID );
+			}
+		}
+
+		remove_filter(
+			'wp_authenticate_user',
+			array( $this, 'callback_returns_wp_error' )
+		);
+	}
+
+	/**
+	 * Tests that a WP_User object is returned for a user
+	 * that is already logged in.
+	 */
+	public function test_returns_logged_in_user() {
+		$actual = wp_authenticate_application_password( $this->admin_user, 'admin', 'password' );
+		$this->assertInstanceOf( 'WP_User', $actual );
+	}
+
+	/**
+	 * Tests that wp_authenticate_application_password returns a WP_Error object.
+	 *
+	 * @dataProvider data_returns_wp_error
+	 *
+	 * @param WP_User|WP_Error|null $user      The user object, a WP Error or null. Default null.
+	 * @param string                $username  The username to try to authenticate.
+	 * @param string                $password  The password to try to authenticate.
+	 * @param array                 $errors    An array of expected error keys.
+	 */
+	public function test_returns_wp_error( $user, $username, $password, $errors ) {
+		update_network_option( null, 'using_application_passwords', true );
+		$actual = wp_authenticate_application_password( $user, $username, $password );
+
+		$this->assertInstanceOf(
+			'WP_Error',
+			$actual,
+			'Did not return an error.'
+		);
+
+		$this->assertSameSetsWithIndex(
+			$errors,
+			array_keys( $actual->errors ),
+			'Did not return the expected errors.'
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_returns_wp_error() {
+		return array(
+			'a WP_Error object' => array(
+				'user'     => new WP_Error( 'custom_wp_error' ),
+				'username' => 'admin1',
+				'password' => 'password',
+				'errors'   => array( 'custom_wp_error' ),
+			),
+		);
+	}
+
+}

--- a/tests/phpunit/tests/user/wpAuthenticateUsernamePassword.php
+++ b/tests/phpunit/tests/user/wpAuthenticateUsernamePassword.php
@@ -18,24 +18,8 @@ class Tests_User_WpAuthenticateUsernamePassword extends WP_UnitTestCase {
 		);
 	}
 
-	public function tear_down() {
-		if ( $this->admin_user instanceof WP_User ) {
-			if ( is_multisite() ) {
-				wp_delete_user( $this->admin_user->data->ID );
-			} else {
-				wp_delete_user( $this->admin_user->ID );
-			}
-		}
-
-		remove_filter(
-			'wp_authenticate_user',
-			array( $this, 'callback_returns_wp_error' )
-		);
-	}
-
 	/**
-	 * Tests that a WP_User object is returned for a user
-	 * that is already logged in.
+	 *  @ticket 46748
 	 */
 	public function test_returns_logged_in_user() {
 		$actual = wp_authenticate_username_password( $this->admin_user, 'admin', 'password' );
@@ -43,9 +27,9 @@ class Tests_User_WpAuthenticateUsernamePassword extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that wp_authenticate_username_password returns a WP_Error object.
-	 *
 	 * @dataProvider data_returns_wp_error
+	 *
+	 * @ticket 46748
 	 *
 	 * @param WP_User|WP_Error|null $user      The user object, a WP Error or null. Default null.
 	 * @param string                $username  The username to try to authenticate.
@@ -118,25 +102,23 @@ class Tests_User_WpAuthenticateUsernamePassword extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that the wp_authenticate_user filter is applied.
+	 * @ticket 46748
 	 */
 	public function test_applies_filter_wp_authenticate_user() {
-		add_filter(
-			'wp_authenticate_user',
-			array( $this, 'callback_returns_wp_error' )
-		);
+		$callback = static function() {
+			return new WP_Error();
+		};
+		add_filter( 'wp_authenticate_user', $callback );
 
 		$actual = wp_authenticate_username_password( null, 'admin1', 'password' );
+
+		remove_filter( 'wp_authenticate_user', $callback );
+
 		$this->assertInstanceOf( 'WP_Error', $actual );
 	}
 
-	public function callback_returns_wp_error( $user ) {
-		return new WP_Error();
-	}
-
 	/**
-	 * Tests that a WP_User object is returned when the correct username and
-	 * password are supplied.
+	 * @ticket 46748
 	 */
 	public function test_returns_user_with_correct_username_and_password() {
 		$actual = wp_authenticate_username_password( null, 'admin1', 'password' );

--- a/tests/phpunit/tests/user/wpAuthenticateUsernamePassword.php
+++ b/tests/phpunit/tests/user/wpAuthenticateUsernamePassword.php
@@ -1,0 +1,146 @@
+<?php
+
+/**
+ * @group user
+ *
+ * @covers ::wp_authenticate_username_password
+ */
+class Tests_User_WpAuthenticateUsernamePassword extends WP_UnitTestCase {
+	protected $admin_user;
+
+	public function set_up() {
+		$this->admin_user = $this->factory->user->create_and_get(
+			array(
+				'role'       => 'administrator',
+				'user_login' => 'admin1',
+				'user_pass'  => 'password',
+			)
+		);
+	}
+
+	public function tear_down() {
+		if ( $this->admin_user instanceof WP_User ) {
+			if ( is_multisite() ) {
+				wp_delete_user( $this->admin_user->data->ID );
+			} else {
+				wp_delete_user( $this->admin_user->ID );
+			}
+		}
+
+		remove_filter(
+			'wp_authenticate_user',
+			array( $this, 'callback_returns_wp_error' )
+		);
+	}
+
+	/**
+	 * Tests that a WP_User object is returned for a user
+	 * that is already logged in.
+	 */
+	public function test_returns_logged_in_user() {
+		$actual = wp_authenticate_username_password( $this->admin_user, 'admin', 'password' );
+		$this->assertInstanceOf( 'WP_User', $actual );
+	}
+
+	/**
+	 * Tests that wp_authenticate_username_password returns a WP_Error object.
+	 *
+	 * @dataProvider data_returns_wp_error
+	 *
+	 * @param WP_User|WP_Error|null $user      The user object, a WP Error or null. Default null.
+	 * @param string                $username  The username to try to authenticate.
+	 * @param string                $password  The password to try to authenticate.
+	 * @param array                 $errors    An array of expected error keys.
+	 */
+	public function test_returns_wp_error( $user, $username, $password, $errors ) {
+		$actual = wp_authenticate_username_password( $user, $username, $password );
+
+		$this->assertInstanceOf(
+			'WP_Error',
+			$actual,
+			'Did not return an error.'
+		);
+
+		$this->assertSameSetsWithIndex(
+			$errors,
+			array_keys( $actual->errors ),
+			'Did not return the expected errors.'
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_returns_wp_error() {
+		return array(
+			'a WP_Error object'              => array(
+				'user'     => new WP_Error( 'custom_wp_error' ),
+				'username' => 'admin1',
+				'password' => 'password',
+				'errors'   => array( 'custom_wp_error' ),
+			),
+			'no username'                    => array(
+				'user'     => null,
+				'username' => '',
+				'password' => 'password',
+				'errors'   => array( 'empty_username' ),
+			),
+			'no password'                    => array(
+				'user'     => null,
+				'username' => 'admin1',
+				'password' => '',
+				'errors'   => array( 'empty_password' ),
+			),
+			'no username or password'        => array(
+				'user'     => null,
+				'username' => '',
+				'password' => '',
+				'errors'   => array(
+					'empty_username',
+					'empty_password',
+				),
+			),
+			'a username that does not exist' => array(
+				'user'     => null,
+				'username' => '1nimda',
+				'password' => 'password',
+				'errors'   => array( 'invalid_username' ),
+			),
+			'incorrect password'             => array(
+				'user'     => null,
+				'username' => 'admin1',
+				'password' => 'password1',
+				'errors'   => array( 'incorrect_password' ),
+			),
+		);
+	}
+
+	/**
+	 * Tests that the wp_authenticate_user filter is applied.
+	 */
+	public function test_applies_filter_wp_authenticate_user() {
+		add_filter(
+			'wp_authenticate_user',
+			array( $this, 'callback_returns_wp_error' )
+		);
+
+		$actual = wp_authenticate_username_password( null, 'admin1', 'password' );
+		$this->assertInstanceOf( 'WP_Error', $actual );
+	}
+
+	public function callback_returns_wp_error( $user ) {
+		return new WP_Error();
+	}
+
+	/**
+	 * Tests that a WP_User object is returned when the correct username and
+	 * password are supplied.
+	 */
+	public function test_returns_user_with_correct_username_and_password() {
+		$actual = wp_authenticate_username_password( null, 'admin1', 'password' );
+		$this->assertInstanceOf( 'WP_User', $actual );
+	}
+
+}

--- a/tests/phpunit/tests/user/wpAuthenticateUsernamePassword.php
+++ b/tests/phpunit/tests/user/wpAuthenticateUsernamePassword.php
@@ -18,9 +18,6 @@ class Tests_User_WpAuthenticateUsernamePassword extends WP_UnitTestCase {
 		);
 	}
 
-	/**
-	 *  @ticket 46748
-	 */
 	public function test_returns_logged_in_user() {
 		$actual = wp_authenticate_username_password( $this->admin_user, 'admin', 'password' );
 		$this->assertInstanceOf( 'WP_User', $actual );
@@ -28,8 +25,6 @@ class Tests_User_WpAuthenticateUsernamePassword extends WP_UnitTestCase {
 
 	/**
 	 * @dataProvider data_returns_wp_error
-	 *
-	 * @ticket 46748
 	 *
 	 * @param WP_User|WP_Error|null $user      The user object, a WP Error or null. Default null.
 	 * @param string                $username  The username to try to authenticate.
@@ -104,7 +99,7 @@ class Tests_User_WpAuthenticateUsernamePassword extends WP_UnitTestCase {
 	/**
 	 * @ticket 46748
 	 */
-	public function test_applies_filter_wp_authenticate_user() {
+	public function test_filter_with_less_than_20_prohibits_logging_in() {
 		$callback = static function() {
 			return new WP_Error();
 		};
@@ -117,9 +112,6 @@ class Tests_User_WpAuthenticateUsernamePassword extends WP_UnitTestCase {
 		$this->assertInstanceOf( 'WP_Error', $actual );
 	}
 
-	/**
-	 * @ticket 46748
-	 */
 	public function test_returns_user_with_correct_username_and_password() {
 		$actual = wp_authenticate_username_password( null, 'admin1', 'password' );
 		$this->assertInstanceOf( 'WP_User', $actual );


### PR DESCRIPTION
This PR:
- Adds the changes from the existing patch on the ticket.
- Adds unit tests for `wp_authenticate_username_password()` with 100% line coverage.
- Adds partial unit tests for `wp_authenticate_application_password()`.

Trac ticket: https://core.trac.wordpress.org/ticket/46748