### PR TITLE
Allow prevention of DB queries with get_option

### DIFF
--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -66,15 +66,16 @@
  *
  * @global wpdb $wpdb WordPress database abstraction object.
  *
- * @param string $option  Name of the option to retrieve. Expected to not be SQL-escaped.
- * @param mixed  $default Optional. Default value to return if the option does not exist.
+ * @param string  $option         Name of the option to retrieve. Expected to not be SQL-escaped.
+ * @param mixed   $default        Optional. Default value to return if the option does not exist.
+ * @param boolean $fallback_to_db Optional. Whether or not to use the database if the option isn't auto-loaded.
  * @return mixed Value of the option. A value of any type may be returned, including
  *               scalar (string, boolean, float, integer), null, array, object.
  *               Scalar and null values will be returned as strings as long as they originate
  *               from a database stored option value. If there is no option in the database,
  *               boolean `false` is returned.
  */
-function get_option( $option, $default = false ) {
+function get_option( $option, $default = false, $fallback_to_db = true ) {
 	global $wpdb;
 
 	if ( is_scalar( $option ) ) {
@@ -170,7 +171,7 @@ function get_option( $option, $default = false ) {
 		} else {
 			$value = wp_cache_get( $option, 'options' );
 
-			if ( false === $value ) {
+			if ( false === $value && $fallback_to_db ) {
 				$row = $wpdb->get_row( $wpdb->prepare( "SELECT option_value FROM $wpdb->options WHERE option_name = %s LIMIT 1", $option ) );
 
 				// Has to be get_row() instead of get_var() because of funkiness with 0, false, null values.
@@ -190,7 +191,7 @@ function get_option( $option, $default = false ) {
 				}
 			}
 		}
-	} else {
+	} elseif ( $fallback_to_db ) {
 		$suppress = $wpdb->suppress_errors();
 		$row      = $wpdb->get_row( $wpdb->prepare( "SELECT option_value FROM $wpdb->options WHERE option_name = %s LIMIT 1", $option ) );
 		$wpdb->suppress_errors( $suppress );
@@ -201,6 +202,9 @@ function get_option( $option, $default = false ) {
 			/** This filter is documented in wp-includes/option.php */
 			return apply_filters( "default_option_{$option}", $default, $option, $passed_default );
 		}
+	} else {
+		/** This filter is documented in wp-includes/option.php */
+		return apply_filters( "default_option_{$option}", $default, $option, $passed_default );
 	}
 
 	// If home is not set, use siteurl.


### PR DESCRIPTION
Most developers don't realize that when they use `get_option()` and the option doesn't exist or isn't auto-loaded, this causes a query to the database. This patch allows developers that want to prevent this from happening to prevent that.

This doesn't change any default behavior, but does allow adding a third parameter to prevent a fallback database query.

Trac ticket: [54459](https://core.trac.wordpress.org/ticket/54459)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
