### PR TITLE
Replace `$(document).ready()` with recommended syntax.

### DIFF
--- a/src/js/_enqueues/admin/common.js
+++ b/src/js/_enqueues/admin/common.js
@@ -1727,7 +1727,7 @@ $( function() {
 			self.trigger();
 			$document.on( 'wp-window-resized.wp-responsive', this.trigger.bind( this ) );
 
-			// This needs to run later as UI Sortable may be initialized later on $(document).ready().
+			// This needs to run later as UI Sortable may be initialized when the document is ready.
 			$window.on( 'load.wp-responsive', this.maybeDisableSortables );
 			$document.on( 'postbox-toggled', this.maybeDisableSortables );
 

--- a/src/wp-admin/admin-header.php
+++ b/src/wp-admin/admin-header.php
@@ -97,7 +97,7 @@ wp_enqueue_script( 'svg-painter' );
 $admin_body_class = preg_replace( '/[^a-z0-9_-]+/i', '-', $hook_suffix );
 ?>
 <script type="text/javascript">
-addLoadEvent = function(func){if(typeof jQuery!=='undefined')jQuery(document).ready(func);else if(typeof wpOnload!=='function'){wpOnload=func;}else{var oldonload=wpOnload;wpOnload=function(){oldonload();func();}}};
+addLoadEvent = function(func){if(typeof jQuery!=='undefined')jQuery(function(){func();});else if(typeof wpOnload!=='function'){wpOnload=func;}else{var oldonload=wpOnload;wpOnload=function(){oldonload();func();}}};
 var ajaxurl = '<?php echo esc_js( admin_url( 'admin-ajax.php', 'relative' ) ); ?>',
 	pagenow = '<?php echo esc_js( $current_screen->id ); ?>',
 	typenow = '<?php echo esc_js( $current_screen->post_type ); ?>',

--- a/src/wp-admin/export.php
+++ b/src/wp-admin/export.php
@@ -27,7 +27,7 @@ $title = __( 'Export' );
 function export_add_js() {
 	?>
 <script type="text/javascript">
-	jQuery(document).ready(function($){
+	jQuery( function($) {
 		var form = $('#export-filters'),
 			filters = form.find('.export-filters');
 		filters.hide();
@@ -39,7 +39,7 @@ function export_add_js() {
 				case 'pages': $('#page-filters').slideDown(); break;
 			}
 		});
-	});
+	} );
 </script>
 	<?php
 }

--- a/src/wp-admin/includes/class-custom-image-header.php
+++ b/src/wp-admin/includes/class-custom-image-header.php
@@ -393,7 +393,7 @@ class Custom_Image_Header {
 		}
 	}
 
-	$(document).ready(function() {
+	$( function() {
 		var text_color = $('#text-color');
 		header_text_fields = $('.displaying-header-text');
 		text_color.wpColorPicker({
@@ -408,7 +408,7 @@ class Custom_Image_Header {
 		<?php if ( ! display_header_text() ) : ?>
 		toggle_text();
 		<?php endif; ?>
-	});
+	} );
 })(jQuery);
 </script>
 		<?php
@@ -430,7 +430,7 @@ class Custom_Image_Header {
 		jQuery( '#height' ).val(coords.h);
 	}
 
-	jQuery(document).ready(function() {
+	jQuery( function() {
 		var xinit = <?php echo absint( get_theme_support( 'custom-header', 'width' ) ); ?>;
 		var yinit = <?php echo absint( get_theme_support( 'custom-header', 'height' ) ); ?>;
 		var ratio = xinit / yinit;
@@ -485,7 +485,7 @@ class Custom_Image_Header {
 				jQuery('#height').val(c.height);
 			}
 		});
-	});
+	} );
 </script>
 		<?php
 	}

--- a/src/wp-admin/includes/class-wp-internal-pointers.php
+++ b/src/wp-admin/includes/class-wp-internal-pointers.php
@@ -140,7 +140,9 @@ final class WP_Internal_Pointers {
 			if ( options.position && options.position.defer_loading )
 				$(window).bind( 'load.wp-pointers', setup );
 			else
-				$(document).ready( setup );
+				$( function() {
+					setup();
+				} );
 
 		})( jQuery );
 		</script>

--- a/src/wp-admin/includes/deprecated.php
+++ b/src/wp-admin/includes/deprecated.php
@@ -1507,7 +1507,7 @@ function post_form_autocomplete_off() {
 function options_permalink_add_js() {
 	?>
 	<script type="text/javascript">
-		jQuery(document).ready(function() {
+		jQuery( function() {
 			jQuery('.permalink-structure input:radio').change(function() {
 				if ( 'custom' == this.value )
 					return;
@@ -1516,7 +1516,7 @@ function options_permalink_add_js() {
 			jQuery( '#permalink_structure' ).on( 'click input', function() {
 				jQuery( '#custom_selection' ).prop( 'checked', true );
 			});
-		});
+		} );
 	</script>
 	<?php
 }

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -533,7 +533,7 @@ function wp_iframe( $content_func, ...$args ) {
 
 	?>
 	<script type="text/javascript">
-	addLoadEvent = function(func){if(typeof jQuery!=='undefined')jQuery(document).ready(func);else if(typeof wpOnload!=='function'){wpOnload=func;}else{var oldonload=wpOnload;wpOnload=function(){oldonload();func();}}};
+	addLoadEvent = function(func){if(typeof jQuery!=='undefined')jQuery(function(){func();});else if(typeof wpOnload!=='function'){wpOnload=func;}else{var oldonload=wpOnload;wpOnload=function(){oldonload();func();}}};
 	var ajaxurl = '<?php echo esc_js( admin_url( 'admin-ajax.php', 'relative' ) ); ?>', pagenow = 'media-upload-popup', adminpage = 'media-upload-popup',
 	isRtl = <?php echo (int) is_rtl(); ?>;
 	</script>
@@ -2501,11 +2501,11 @@ function media_upload_type_url_form( $type = null, $errors = null, $id = null ) 
 	}
 	};
 
-	jQuery(document).ready( function($) {
+	jQuery( function($) {
 		$('.media-types input').click( function() {
 			$('table.describe').toggleClass('not-image', $('#not-image').prop('checked') );
 		});
-	});
+	} );
 	</script>
 
 	<div id="media-items">

--- a/src/wp-admin/includes/meta-boxes.php
+++ b/src/wp-admin/includes/meta-boxes.php
@@ -865,7 +865,7 @@ function post_comment_meta_box( $post ) {
 		$hidden = get_hidden_meta_boxes( get_current_screen() );
 		if ( ! in_array( 'commentsdiv', $hidden, true ) ) {
 			?>
-			<script type="text/javascript">jQuery(document).ready(function(){commentsBox.get(<?php echo $total; ?>, 10);});</script>
+			<script type="text/javascript">jQuery(function(){commentsBox.get(<?php echo $total; ?>, 10);});</script>
 			<?php
 		}
 

--- a/src/wp-admin/includes/ms.php
+++ b/src/wp-admin/includes/ms.php
@@ -1010,7 +1010,7 @@ function confirm_delete_users( $users ) {
 function network_settings_add_js() {
 	?>
 <script type="text/javascript">
-jQuery(document).ready( function($) {
+jQuery( function($) {
 	var languageSelect = $( '#WPLANG' );
 	$( 'form' ).on( 'submit', function() {
 		// Don't show a spinner for English and installed languages,
@@ -1019,7 +1019,7 @@ jQuery(document).ready( function($) {
 			$( '#submit', this ).after( '<span class="spinner language-install-spinner is-active" />' );
 		}
 	});
-});
+} );
 </script>
 	<?php
 }

--- a/src/wp-admin/includes/options.php
+++ b/src/wp-admin/includes/options.php
@@ -34,7 +34,7 @@ function options_discussion_add_js() {
 function options_general_add_js() {
 	?>
 <script type="text/javascript">
-	jQuery(document).ready(function($){
+	jQuery( function($) {
 		var $siteName = $( '#wp-admin-bar-site-name' ).children( 'a' ).first(),
 			homeURL = ( <?php echo wp_json_encode( get_home_url() ); ?> || '' ).replace( /^(https?:\/\/)?(www\.)?/, '' );
 
@@ -96,7 +96,7 @@ function options_general_add_js() {
 				$( '#submit', this ).after( '<span class="spinner language-install-spinner is-active" />' );
 			}
 		});
-	});
+	} );
 </script>
 	<?php
 }
@@ -109,7 +109,7 @@ function options_general_add_js() {
 function options_reading_add_js() {
 	?>
 <script type="text/javascript">
-	jQuery(document).ready(function($){
+	jQuery( function($) {
 		var section = $('#front-static-pages'),
 			staticPage = section.find('input:radio[value="page"]'),
 			selects = section.find('select'),
@@ -118,7 +118,7 @@ function options_reading_add_js() {
 			};
 		check_disabled();
 		section.find( 'input:radio' ).on( 'change', check_disabled );
-	});
+	} );
 </script>
 	<?php
 }

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -2031,7 +2031,7 @@ function iframe_header( $title = '', $deprecated = false ) {
 	wp_enqueue_style( 'colors' );
 	?>
 <script type="text/javascript">
-addLoadEvent = function(func){if(typeof jQuery!=='undefined')jQuery(document).ready(func);else if(typeof wpOnload!=='function'){wpOnload=func;}else{var oldonload=wpOnload;wpOnload=function(){oldonload();func();}}};
+addLoadEvent = function(func){if(typeof jQuery!=='undefined')jQuery(function(){func();});else if(typeof wpOnload!=='function'){wpOnload=func;}else{var oldonload=wpOnload;wpOnload=function(){oldonload();func();}}};
 function tb_close(){var win=window.dialogArguments||opener||parent||top;win.tb_remove();}
 var ajaxurl = '<?php echo esc_js( admin_url( 'admin-ajax.php', 'relative' ) ); ?>',
 	pagenow = '<?php echo esc_js( $current_screen->id ); ?>',

--- a/src/wp-admin/includes/user.php
+++ b/src/wp-admin/includes/user.php
@@ -536,7 +536,7 @@ function default_password_nag() {
 function delete_users_add_js() {
 	?>
 <script>
-jQuery(document).ready( function($) {
+jQuery( function($) {
 	var submit = $('#submit').prop('disabled', true);
 	$('input[name="delete_option"]').one('change', function() {
 		submit.prop('disabled', false);
@@ -544,7 +544,7 @@ jQuery(document).ready( function($) {
 	$('#reassign_user').focus( function() {
 		$('#delete_option1').prop('checked', true).trigger('change');
 	});
-});
+} );
 </script>
 	<?php
 }

--- a/src/wp-content/themes/twentyeleven/inc/theme-options.js
+++ b/src/wp-content/themes/twentyeleven/inc/theme-options.js
@@ -7,7 +7,7 @@ var farbtastic;
 		$('#link-color-example').css('background-color', a);
 	};
 
-	$(document).ready( function() {
+	$( function() {
 		$('#default-color').wrapInner('<a href="#" />');
 
 		farbtastic = $.farbtastic('#colorPickerDiv', pickColor);
@@ -48,5 +48,5 @@ var farbtastic;
 
 			currentDefault.text( newDefault );
 		});
-	});
+	} );
 })(jQuery);

--- a/src/wp-content/themes/twentyeleven/js/showcase.js
+++ b/src/wp-content/themes/twentyeleven/js/showcase.js
@@ -1,5 +1,5 @@
 (function($) {
-	$(document).ready( function() {
+	$( function() {
 	    $('.feature-slider a').on( 'click', function(e) {
 	        $('.featured-posts section.featured-post').css({
 	            opacity: 0,
@@ -13,5 +13,5 @@
 	        $(this).addClass('active');
 	        e.preventDefault();
 	    });
-	});
+	} );
 })(jQuery);

--- a/src/wp-content/themes/twentyfifteen/js/functions.js
+++ b/src/wp-content/themes/twentyfifteen/js/functions.js
@@ -111,7 +111,7 @@
 		}
 	}
 
-	$( document ).ready( function() {
+	$( function() {
 		$body          = $( document.body );
 		$window        = $( window );
 		$sidebar       = $( '#sidebar' ).first();

--- a/src/wp-content/themes/twentyfourteen/js/featured-content-admin.js
+++ b/src/wp-content/themes/twentyfourteen/js/featured-content-admin.js
@@ -4,6 +4,6 @@
  */
 /* global ajaxurl:true */
 
-jQuery( document ).ready( function( $ ) {
+jQuery( function($) {
 	$( '#customize-control-featured-content-tag-name input' ).suggest( ajaxurl + '?action=ajax-tag-search&tax=post_tag', { delay: 500, minchars: 2 } );
-});
+} );

--- a/src/wp-content/themes/twentyseventeen/assets/js/global.js
+++ b/src/wp-content/themes/twentyseventeen/assets/js/global.js
@@ -178,7 +178,7 @@
 	}
 
 	// Fire on document ready.
-	$( document ).ready( function() {
+	$( function() {
 
 		// If navigation menu is present on page, setNavProps and adjustScrollClass.
 		if ( $navigation.length ) {
@@ -218,7 +218,7 @@
 		if ( true === supportsFixedBackground() ) {
 			document.documentElement.className += ' background-fixed';
 		}
-	});
+	} );
 
 	// If navigation menu is present on page, adjust it on scroll and screen resize.
 	if ( $navigation.length ) {

--- a/src/wp-content/themes/twentysixteen/js/functions.js
+++ b/src/wp-content/themes/twentysixteen/js/functions.js
@@ -191,7 +191,7 @@
 		} );
 	}
 
-	$( document ).ready( function() {
+	$( function() {
 		body = $( document.body );
 
 		$( window )

--- a/src/wp-content/themes/twentytwenty/assets/js/customize-preview.js
+++ b/src/wp-content/themes/twentytwenty/assets/js/customize-preview.js
@@ -186,7 +186,7 @@
 		stylesheet.html( styles );
 	}
 	// Generate styles on load. Handles page-changes on the preview pane.
-	$( document ).ready( function() {
+	$( function() {
 		twentyTwentyGenerateColorA11yPreviewStyles( 'content' );
 		twentyTwentyGenerateColorA11yPreviewStyles( 'header-footer' );
 	} );

--- a/src/wp-content/themes/twentytwenty/assets/js/customize.js
+++ b/src/wp-content/themes/twentytwenty/assets/js/customize.js
@@ -1,7 +1,7 @@
 /* global wp, jQuery */
 
 ( function( $, api ) {
-	$( document ).ready( function() {
+	$( function() {
 		// Make it possible to reset the color based on a radio input's value.
 		// `active` can be either `custom` or `default`.
 		api.control( 'accent_hue_active' ).setting.bind( function( active ) {

--- a/src/wp-includes/class-wp-embed.php
+++ b/src/wp-includes/class-wp-embed.php
@@ -88,9 +88,9 @@ class WP_Embed {
 		}
 		?>
 <script type="text/javascript">
-	jQuery(document).ready(function($){
+	jQuery( function($) {
 		$.get("<?php echo esc_url( admin_url( 'admin-ajax.php', 'relative' ) ) . '?action=oembed-cache&post=' . $post->ID; ?>");
-	});
+	} );
 </script>
 		<?php
 	}

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1816,7 +1816,7 @@ function wp_localize_jquery_ui_datepicker() {
 		)
 	);
 
-	wp_add_inline_script( 'jquery-ui-datepicker', "jQuery(document).ready(function(jQuery){jQuery.datepicker.setDefaults({$datepicker_defaults});});" );
+	wp_add_inline_script( 'jquery-ui-datepicker', "jQuery(function(jQuery){jQuery.datepicker.setDefaults({$datepicker_defaults});});" );
 }
 
 /**


### PR DESCRIPTION
This PR replaces variations of `$(document).ready()` and `jQuery(document).ready()` with the recommended syntax.

Below is a list of files that aren't modified in this PR and the reasoning.

Third-party dependencies:
- `src/js/_enqueues/vendor/mediaelement/mediaelement-and-player.js`
- `src/js/_enqueues/vendor/mediaelement/wp-playlist.js`
- `src/js/_enqueues/vendor/plupload/handlers.js`
- `src/js/_enqueues/vendor/swfupload/handlers.js`
- `src/js/_enqueues/vendor/swfupload/handlers.min.js`
- `src/js/_enqueues/vendor/thickbox/thickbox.js`

- `src/wp-includes/js/jquery/jquery.form.js` - Occurs in a comment with a URL that contains the old syntax.

Trac ticket: https://core.trac.wordpress.org/ticket/51519
