### PR TITLE
Tests/bootstrap: Add support to read `WP_TESTS_PHPUNIT_POLYFILLS_PATH` from environment variables

### DIFF
--- a/tests/phpunit/includes/bootstrap.php
+++ b/tests/phpunit/includes/bootstrap.php
@@ -71,8 +71,8 @@ if ( version_compare( $phpunit_version, '5.7.21', '<' ) ) {
  *   - Add a `yoast/phpunit-polyfills` (dev) requirement to the plugin/theme's own `composer.json` file.
  *   - And then:
  *     - Either load the PHPUnit Polyfills autoload file prior to running the WP core bootstrap file.
- *     - Or declare a `WP_TESTS_PHPUNIT_POLYFILLS_PATH` constant containing the absolute path to the
- *       root directory of the PHPUnit Polyfills installation.
+ *     - Or declare a `WP_TESTS_PHPUNIT_POLYFILLS_PATH` constant or set `WP_TESTS_PHPUNIT_POLYFILLS_PATH` environment variable
+ *       containing the absolute path to the root directory of the PHPUnit Polyfills installation.
  *       If the constant is used, it is strongly recommended to declare this constant in the plugin/theme's
  *       own test bootstrap file.
  *       The constant MUST be declared prior to calling this file.
@@ -83,9 +83,9 @@ if ( ! class_exists( 'Yoast\PHPUnitPolyfills\Autoload' ) ) {
 	$phpunit_polyfills_error      = false;
 
 	// Define WP_TESTS_PHPUNIT_POLYFILLS_PATH if set as environment variable.
-	$phpunit_polyfills_path = getenv( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' );
-	if ( $phpunit_polyfills_path ) {
-		define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', $phpunit_polyfills_path );
+	$phpunit_polyfills_path_env = getenv( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' );
+	if ( $phpunit_polyfills_path_env ) {
+		define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', $phpunit_polyfills_path_env );
 	}
 
 	// Allow for a custom installation location to be provided for plugin/theme integration tests.

--- a/tests/phpunit/includes/bootstrap.php
+++ b/tests/phpunit/includes/bootstrap.php
@@ -82,6 +82,12 @@ if ( ! class_exists( 'Yoast\PHPUnitPolyfills\Autoload' ) ) {
 	$phpunit_polyfills_autoloader = dirname( dirname( dirname( __DIR__ ) ) ) . '/vendor/yoast/phpunit-polyfills/phpunitpolyfills-autoload.php';
 	$phpunit_polyfills_error      = false;
 
+	// Define WP_TESTS_PHPUNIT_POLYFILLS_PATH if set as environment variable.
+	$phpunit_polyfills_path = getenv( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' );
+	if ( $phpunit_polyfills_path ) {
+		define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', $phpunit_polyfills_path );
+	}
+
 	// Allow for a custom installation location to be provided for plugin/theme integration tests.
 	if ( defined( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' ) ) {
 		$phpunit_polyfills_path = WP_TESTS_PHPUNIT_POLYFILLS_PATH;


### PR DESCRIPTION
This PR adds support to read the WP_TESTS_PHPUNIT_POLYFILLS_PATH from an environment variable.

Currently one has to define the `WP_TESTS_PHPUNIT_POLYFILLS_PATH` as a PHP constant.

Adding support for reading this from an environment variable would allow setup-php GitHub Action to set this variable.

Trac ticket: https://core.trac.wordpress.org/ticket/54470

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
