### PR TITLE
Comments: Indicate a comment author's registration status.

### DIFF
--- a/src/wp-admin/includes/class-wp-comments-list-table.php
+++ b/src/wp-admin/includes/class-wp-comments-list-table.php
@@ -942,9 +942,25 @@ class WP_Comments_List_Table extends WP_List_Table {
 			$author_url_display = wp_html_excerpt( $author_url_display, 49, '&hellip;' );
 		}
 
-		echo '<strong>';
-		comment_author( $comment );
-		echo '</strong><br />';
+		$author_name = get_comment_author( $comment );
+
+		if ( $comment->user_id ) {
+			$author_profile = admin_url( 'user-edit.php?user_id=' . $comment->user_id );
+
+			// Link the author's name to their profile page.
+			printf(
+				'<a href="%s"><strong>%s</strong></a><br />',
+				esc_attr( $author_profile ),
+				$author_name
+			);
+		} else {
+			// Indicate an unregistered author.
+			printf(
+				'<strong>%s</strong> (%s)<br />',
+				$author_name,
+				__( 'unregistered' )
+			);
+		}
 
 		if ( ! empty( $author_url_display ) ) {
 			// Print link to author URL, and disallow referrer information (without using target="_blank").

--- a/tests/phpunit/tests/admin/wpCommentsListTable.php
+++ b/tests/phpunit/tests/admin/wpCommentsListTable.php
@@ -195,4 +195,64 @@ OPTIONS;
 		$this->assertStringContainsString( 'column-date sorted desc', $output, 'Mismatch of CSS classes for the comment date column.' );
 	}
 
+	/**
+	 * @ticket 54473
+	 *
+	 * @covers WP_Comments_List_Table::column_author
+	 */
+	public function test_column_author_with_registered_author() {
+		$post_id = self::factory()->post->create();
+		$comment = self::factory()->comment->create_and_get(
+			array(
+				'comment_post_ID'  => $post_id,
+				'comment_approved' => '1',
+				'user_id'          => '1',
+			)
+		);
+
+		$output = get_echo( array( $this->table, 'column_author' ), array( $comment ) );
+
+		$this->assertStringStartsWith(
+			'<a href="',
+			$output,
+			"A registered author's name should be linked."
+		);
+
+		$this->assertStringNotContainsString(
+			'(unregistered)',
+			$output,
+			"(unregistered) followed the registered author's name."
+		);
+	}
+
+	/**
+	 * @ticket 54473
+	 *
+	 * @covers WP_Comments_List_Table::column_author
+	 */
+	public function test_column_author_with_unregistered_author() {
+		$post_id = self::factory()->post->create();
+		$comment = self::factory()->comment->create_and_get(
+			array(
+				'comment_post_ID'  => $post_id,
+				'comment_approved' => '1',
+				'user_id'          => '0',
+			)
+		);
+
+		$output = get_echo( array( $this->table, 'column_author' ), array( $comment ) );
+
+		$this->assertStringStartsNotWith(
+			'<a href="',
+			$output,
+			"An unregistered author's name should not be linked."
+		);
+
+		$this->assertStringContainsString(
+			'(unregistered)',
+			$output,
+			"(unregistered) did not follow the unregistered author's name."
+		);
+	}
+
 }


### PR DESCRIPTION
This PR:

- Links a registered author's name to their profile page.
- Adds `(unregistered)` after an unregistered author's name.
- Adds unit tests for the above.

![Before_After_54473](https://user-images.githubusercontent.com/79332690/142609759-e63879f2-5894-4ec7-b299-93f6302982d5.jpg)

Trac ticket: https://core.trac.wordpress.org/ticket/54473

