### PR TITLE
Fix PHP notice in comments_open() and pings_open() (Trac 54159)

### DIFF
--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -1241,7 +1241,7 @@ function comments_open( $post_id = null ) {
 	$_post = get_post( $post_id );
 
 	$post_id = $_post ? $_post->ID : 0;
-	$open    = ( 'open' === $_post->comment_status );
+	$open    = ( $_post && ( 'open' === $_post->comment_status ) );
 
 	/**
 	 * Filters whether the current post is open for comments.
@@ -1271,7 +1271,7 @@ function pings_open( $post_id = null ) {
 	$_post = get_post( $post_id );
 
 	$post_id = $_post ? $_post->ID : 0;
-	$open    = ( 'open' === $_post->ping_status );
+	$open    = ( $_post && ( 'open' === $_post->ping_status ) );
 
 	/**
 	 * Filters whether the current post is open for pings.

--- a/tests/phpunit/tests/comment/commentsOpen.php
+++ b/tests/phpunit/tests/comment/commentsOpen.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @group  comment
+ * @covers ::comments_open
+ */
+class Tests_Comment_CommentsOpen extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 54159
+	 */
+	public function test_post_does_not_exist() {
+		$this->assertFalse( comments_open( 99999 ) );
+	}
+
+	/**
+	 * @ticket 54159
+	 */
+	public function test_post_exist_status_open() {
+		$post = $this->factory->post->create_and_get();
+		$this->assertTrue( comments_open( $post ) );
+	}
+
+	/**
+	 * @ticket 54159
+	 */
+	public function test_post_exist_status_closed() {
+		$post                 = $this->factory->post->create_and_get();
+		$post->comment_status = 'closed';
+
+		$this->assertFalse( comments_open( $post ) );
+	}
+}

--- a/tests/phpunit/tests/comment/pingsOpen.php
+++ b/tests/phpunit/tests/comment/pingsOpen.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @group  comment
+ * @covers ::pings_open
+ */
+class Tests_Comment_PingsOpen extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 54159
+	 */
+	public function test_post_does_not_exist() {
+		$this->assertFalse( pings_open( 99999 ) );
+	}
+
+	/**
+	 * @ticket 54159
+	 */
+	public function test_post_exist_status_open() {
+		$post = $this->factory->post->create_and_get();
+		$this->assertTrue( pings_open( $post ) );
+	}
+
+	/**
+	 * @ticket 54159
+	 */
+	public function test_post_exist_status_closed() {
+		$post              = $this->factory->post->create_and_get();
+		$post->ping_status = 'closed';
+
+		$this->assertFalse( pings_open( $post ) );
+	}
+}


### PR DESCRIPTION
Adds unit tests for both functions. Confirms PHP notice.
Applies patch 54159.1.diff. Confirms notice is fixed.

Trac ticket: https://core.trac.wordpress.org/ticket/54159

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
