### PR TITLE
Add extra check while in loggedout state login form

### DIFF
--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -1367,7 +1367,7 @@ switch ( $action ) {
 
 		$rememberme = ! empty( $_POST['rememberme'] );
 
-		if ( $errors->has_errors() && !empty( $_GET['loggedout'] ) == false ) {
+		if ( $errors->has_errors() && ! empty( $_GET['loggedout'] ) == false ) {
 			$aria_describedby_error = ' aria-describedby="login_error"';
 		} else {
 			$aria_describedby_error = '';

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -1367,7 +1367,7 @@ switch ( $action ) {
 
 		$rememberme = ! empty( $_POST['rememberme'] );
 
-		if ( $errors->has_errors() ) {
+		if ( $errors->has_errors() && !empty( $_GET['loggedout'] ) == false ) {
 			$aria_describedby_error = ' aria-describedby="login_error"';
 		} else {
 			$aria_describedby_error = '';

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -1367,7 +1367,7 @@ switch ( $action ) {
 
 		$rememberme = ! empty( $_POST['rememberme'] );
 
-		if ( $errors->has_errors() && ! empty( $_GET['loggedout'] ) == false ) {
+		if ( $errors->has_errors() && empty( $_GET['loggedout'] ) ) {
 			$aria_describedby_error = ' aria-describedby="login_error"';
 		} else {
 			$aria_describedby_error = '';


### PR DESCRIPTION
Adds an extra check preventing the input fields from having an aria described of login_errors while you just loggedout of your website.  

Trac ticket: [54483](https://core.trac.wordpress.org/ticket/54483)
