### PR TITLE
Fix `stdClass::invoke()` warnings in REST API callback mocks (Trac 53844)

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -249,6 +249,7 @@
 				<element value="WP_REST_Test_Controller"/>
 				<element value="WP_Image_Editor_Mock"/>
 				<element value="WP_Filesystem_MockFS"/>
+				<element value="Mock_Invokable"/>
 				<element value="MockPHPMailer"/>
 				<element value="MockAction"/>
 				<element value="WP_Object_Cache"/>

--- a/tests/phpunit/includes/mock-invokable.php
+++ b/tests/phpunit/includes/mock-invokable.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * File for Mock_Invokable class.
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ */
+
+/**
+ * Class Mock_Invokable.
+ *
+ * This class is using to mock a class that has __invoke method.
+ */
+class Mock_Invokable {
+
+	public function __invoke() {}
+}

--- a/tests/phpunit/tests/rest-api/rest-request.php
+++ b/tests/phpunit/tests/rest-api/rest-request.php
@@ -18,6 +18,16 @@ class Tests_REST_Request extends WP_UnitTestCase {
 		$this->request = new WP_REST_Request();
 	}
 
+	/**
+	 * Called before setting up all tests.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		// Require files that need to load once.
+		require_once DIR_TESTROOT . '/includes/mock-invokable.php';
+	}
+
 	public function test_header() {
 		$value = 'application/x-wp-example';
 
@@ -1014,7 +1024,7 @@ class Tests_REST_Request extends WP_UnitTestCase {
 		$request->set_query_params( array( 'test' => 'value' ) );
 
 		$error    = new WP_Error( 'error_code', __( 'Error Message' ), array( 'status' => 400 ) );
-		$callback = $this->createPartialMock( 'stdClass', array( '__invoke' ) );
+		$callback = $this->createPartialMock( 'Mock_Invokable', array( '__invoke' ) );
 		$callback->expects( self::once() )->method( '__invoke' )->with( self::identicalTo( $request ) )->willReturn( $error );
 		$request->set_attributes(
 			array(
@@ -1038,7 +1048,7 @@ class Tests_REST_Request extends WP_UnitTestCase {
 		$request->set_query_params( array( 'test' => 'value' ) );
 
 		$error    = new WP_Error( 'error_code', __( 'Error Message' ), array( 'status' => 400 ) );
-		$callback = $this->createPartialMock( 'stdClass', array( '__invoke' ) );
+		$callback = $this->createPartialMock( 'Mock_Invokable', array( '__invoke' ) );
 		$callback->expects( self::once() )->method( '__invoke' )->with( self::identicalTo( $request ) )->willReturn( $error );
 		$request->set_attributes(
 			array(
@@ -1056,7 +1066,7 @@ class Tests_REST_Request extends WP_UnitTestCase {
 		$request = new WP_REST_Request();
 		$request->set_query_params( array( 'test' => 'value' ) );
 
-		$callback = $this->createPartialMock( 'stdClass', array( '__invoke' ) );
+		$callback = $this->createPartialMock( 'Mock_Invokable', array( '__invoke' ) );
 		$callback->expects( self::never() )->method( '__invoke' );
 		$request->set_attributes(
 			array(

--- a/tests/phpunit/tests/rest-api/rest-server.php
+++ b/tests/phpunit/tests/rest-api/rest-server.php
@@ -35,6 +35,16 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 		parent::tear_down();
 	}
 
+	/**
+	 * Called before setting up all tests.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		// Require files that need to load once.
+		require_once DIR_TESTROOT . '/includes/mock-invokable.php';
+	}
+
 	public function test_envelope() {
 		$data    = array(
 			'amount of arbitrary data' => 'alot',
@@ -1630,9 +1640,9 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 	 * @ticket 50244
 	 */
 	public function test_callbacks_are_not_executed_if_request_validation_fails() {
-		$callback = $this->createPartialMock( 'stdClass', array( '__invoke' ) );
+		$callback = $this->createPartialMock( 'Mock_Invokable', array( '__invoke' ) );
 		$callback->expects( self::never() )->method( '__invoke' );
-		$permission_callback = $this->createPartialMock( 'stdClass', array( '__invoke' ) );
+		$permission_callback = $this->createPartialMock( 'Mock_Invokable', array( '__invoke' ) );
 		$permission_callback->expects( self::never() )->method( '__invoke' );
 
 		register_rest_route(


### PR DESCRIPTION
Applies 53844.2.diff patch and adds the new mock class to skip the `WordPress.Files.Filename` phpcs sniff for its file naming.

Created the PR as a confidence check.

Trac ticket: https://core.trac.wordpress.org/ticket/53844

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
