### PR TITLE
Add author support to templates and template parts

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -503,6 +503,9 @@ function _build_block_template_result_from_post( $post ) {
 	$has_theme_file = wp_get_theme()->get_stylesheet() === $theme &&
 		null !== _get_block_template_file( $post->post_type, $post->post_name );
 
+
+	$origin = get_post_meta( $post->ID, 'origin', true );
+
 	$template                 = new WP_Block_Template();
 	$template->wp_id          = $post->ID;
 	$template->id             = $theme . '//' . $post->post_name;
@@ -510,6 +513,7 @@ function _build_block_template_result_from_post( $post ) {
 	$template->content        = $post->post_content;
 	$template->slug           = $post->post_name;
 	$template->source         = 'custom';
+	$template->origin         = ! empty( $origin ) ? $origin : null;
 	$template->type           = $post->post_type;
 	$template->description    = $post->post_excerpt;
 	$template->title          = $post->post_title;

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -503,7 +503,6 @@ function _build_block_template_result_from_post( $post ) {
 	$has_theme_file = wp_get_theme()->get_stylesheet() === $theme &&
 		null !== _get_block_template_file( $post->post_type, $post->post_name );
 
-
 	$origin = get_post_meta( $post->ID, 'origin', true );
 
 	$template                 = new WP_Block_Template();
@@ -520,7 +519,7 @@ function _build_block_template_result_from_post( $post ) {
 	$template->status         = $post->post_status;
 	$template->has_theme_file = $has_theme_file;
 	$template->is_custom      = true;
-	$template->post_author    = $post->post_author;
+	$template->author         = $post->post_author;
 
 	if ( 'wp_template' === $post->post_type && isset( $default_template_types[ $template->slug ] ) ) {
 		$template->is_custom = false;

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -516,6 +516,7 @@ function _build_block_template_result_from_post( $post ) {
 	$template->status         = $post->post_status;
 	$template->has_theme_file = $has_theme_file;
 	$template->is_custom      = true;
+	$template->post_author    = $post->post_author;
 
 	if ( 'wp_template' === $post->post_type && isset( $default_template_types[ $template->slug ] ) ) {
 		$template->is_custom = false;

--- a/src/wp-includes/class-wp-block-template.php
+++ b/src/wp-includes/class-wp-block-template.php
@@ -78,6 +78,17 @@ class WP_Block_Template {
 	 */
 	public $source = 'theme';
 
+
+	/**
+	 * Origin of the content when the content has been customized.
+	 * When customized, origin takes on the value of source and source becomes
+	 * 'custom'.
+	 *
+	 * @since 5.9.0
+	 * @var string
+	 */
+	public $origin;
+
 	/**
 	 * Post Id.
 	 *

--- a/src/wp-includes/class-wp-block-template.php
+++ b/src/wp-includes/class-wp-block-template.php
@@ -69,6 +69,7 @@ class WP_Block_Template {
 	 */
 	public $description = '';
 
+
 	/**
 	 * Source of the content. `theme` and `custom` is used for now.
 	 *
@@ -109,4 +110,12 @@ class WP_Block_Template {
 	 * @var bool
 	 */
 	public $is_custom = true;
+
+	/**
+	 * Author.
+	 *
+	 * @since 5.9.0
+	 * @var int
+	 */
+	public $post_author = 0;
 }

--- a/src/wp-includes/class-wp-block-template.php
+++ b/src/wp-includes/class-wp-block-template.php
@@ -69,7 +69,6 @@ class WP_Block_Template {
 	 */
 	public $description = '';
 
-
 	/**
 	 * Source of the content. `theme` and `custom` is used for now.
 	 *
@@ -77,7 +76,6 @@ class WP_Block_Template {
 	 * @var string
 	 */
 	public $source = 'theme';
-
 
 	/**
 	 * Origin of the content when the content has been customized.

--- a/src/wp-includes/class-wp-block-template.php
+++ b/src/wp-includes/class-wp-block-template.php
@@ -125,8 +125,10 @@ class WP_Block_Template {
 	/**
 	 * Author.
 	 *
+	 * A value of 0 means no author.
+	 *
 	 * @since 5.9.0
 	 * @var int
 	 */
-	public $post_author = 0;
+	public $author;
 }

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -384,6 +384,7 @@ function create_initial_post_types() {
 				'excerpt',
 				'editor',
 				'revisions',
+				'author',
 			),
 		)
 	);
@@ -442,6 +443,7 @@ function create_initial_post_types() {
 				'excerpt',
 				'editor',
 				'revisions',
+				'author',
 			),
 		)
 	);

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
@@ -244,6 +244,10 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 
 		$changes = $this->prepare_item_for_database( $request );
 
+		if ( is_wp_error( $changes ) ) {
+			return $changes;
+		}
+
 		if ( 'custom' === $template->source ) {
 			$result = wp_update_post( wp_slash( (array) $changes ), true );
 		} else {
@@ -294,6 +298,11 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 	 */
 	public function create_item( $request ) {
 		$prepared_post            = $this->prepare_item_for_database( $request );
+
+		if ( is_wp_error( $prepared_post ) ) {
+			return $prepared_post;
+		}
+
 		$prepared_post->post_name = $request['slug'];
 		$post_id                  = wp_insert_post( wp_slash( (array) $prepared_post ), true );
 		if ( is_wp_error( $post_id ) ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
@@ -461,6 +461,24 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 			}
 		}
 
+		if ( ! empty( $request['author'] ) ) {
+			$post_author = (int) $request['author'];
+
+			if ( get_current_user_id() !== $post_author ) {
+				$user_obj = get_userdata( $post_author );
+
+				if ( ! $user_obj ) {
+					return new WP_Error(
+						'rest_invalid_author',
+						__( 'Invalid author ID.' ),
+						array( 'status' => 400 )
+					);
+				}
+			}
+
+			$changes->post_author = $post_author;
+		}
+
 		return $changes;
 	}
 
@@ -545,6 +563,10 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 
 		if ( rest_is_field_included( 'has_theme_file', $fields ) ) {
 			$data['has_theme_file'] = (bool) $template->has_theme_file;
+		}
+
+		if ( rest_is_field_included( 'author', $fields ) ) {
+			$data['author'] = (int) $template->post_author;
 		}
 
 		if ( rest_is_field_included( 'area', $fields ) && 'wp_template_part' === $template->type ) {
@@ -757,6 +779,11 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 					'type'        => 'bool',
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
+				),
+				'author' => array (
+					'description' => __( 'The ID for the author of the template.' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit', 'embed' ),
 				),
 			),
 		);

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
@@ -780,7 +780,7 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'author' => array (
+				'author' => array(
 					'description' => __( 'The ID for the author of the template.' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit', 'embed' ),

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
@@ -432,7 +432,7 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 				'wp_theme' => $template->theme,
 			);
 			$changes->meta_input  = array(
-				'origin' => $template->source
+				'origin' => $template->source,
 			);
 		} else {
 			$changes->post_name   = $template->slug;

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
@@ -422,6 +422,9 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 			$changes->tax_input   = array(
 				'wp_theme' => $template->theme,
 			);
+			$changes->meta_input  = array(
+				'origin' => $template->source
+			);
 		} else {
 			$changes->post_name   = $template->slug;
 			$changes->ID          = $template->wp_id;
@@ -526,6 +529,10 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 
 		if ( rest_is_field_included( 'source', $fields ) ) {
 			$data['source'] = $template->source;
+		}
+
+		if ( rest_is_field_included( 'origin', $fields ) ) {
+			$data['origin'] = $template->origin;
 		}
 
 		if ( rest_is_field_included( 'type', $fields ) ) {
@@ -713,6 +720,12 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 				),
 				'source'         => array(
 					'description' => __( 'Source of template' ),
+					'type'        => 'string',
+					'context'     => array( 'embed', 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'origin'         => array(
+					'description' => __( 'Source of a customized template' ),
 					'type'        => 'string',
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
@@ -582,7 +582,7 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 		}
 
 		if ( rest_is_field_included( 'author', $fields ) ) {
-			$data['author'] = (int) $template->post_author;
+			$data['author'] = (int) $template->author;
 		}
 
 		if ( rest_is_field_included( 'area', $fields ) && 'wp_template_part' === $template->type ) {

--- a/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
+++ b/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
@@ -102,6 +102,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 				'status'         => 'publish',
 				'wp_id'          => self::$post->ID,
 				'has_theme_file' => false,
+				'author'         => 0,
 			),
 			$this->find_and_normalize_template_by_id( $data, 'default//my_template' )
 		);
@@ -143,6 +144,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 				'status'         => 'publish',
 				'wp_id'          => self::$post->ID,
 				'has_theme_file' => false,
+				'author'         => 0,
 			),
 			$data
 		);
@@ -161,6 +163,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 				'description' => 'Just a description',
 				'title'       => 'My Template',
 				'content'     => 'Content',
+				'author'      => self::$admin_id,
 			)
 		);
 		$response = rest_get_server()->dispatch( $request );
@@ -185,6 +188,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 				),
 				'status'         => 'publish',
 				'has_theme_file' => false,
+				'author'         => self::$admin_id,
 			),
 			$data
 		);
@@ -207,6 +211,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 				'content'     => array(
 					'raw' => 'Content',
 				),
+				'author'      => self::$admin_id,
 			)
 		);
 		$response = rest_get_server()->dispatch( $request );
@@ -231,9 +236,26 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 				),
 				'status'         => 'publish',
 				'has_theme_file' => false,
+				'author'         => self::$admin_id,
 			),
 			$data
 		);
+	}
+
+	public function test_create_item_invalid_author() {
+		wp_set_current_user( self::$admin_id );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/templates' );
+		$request->set_body_params(
+			array(
+				'slug'        => 'my_custom_template_invalid_author',
+				'description' => 'Just a description',
+				'title'       => 'My Template',
+				'content'     => 'Content',
+				'author'      => -999,
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'rest_invalid_author', $response, 400 );
 	}
 
 	/**
@@ -370,7 +392,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 		$response   = rest_get_server()->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertCount( 11, $properties );
+		$this->assertCount( 12, $properties );
 		$this->assertArrayHasKey( 'id', $properties );
 		$this->assertArrayHasKey( 'description', $properties );
 		$this->assertArrayHasKey( 'slug', $properties );
@@ -383,6 +405,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 		$this->assertArrayHasKey( 'status', $properties );
 		$this->assertArrayHasKey( 'wp_id', $properties );
 		$this->assertArrayHasKey( 'has_theme_file', $properties );
+		$this->assertArrayHasKey( 'author', $properties );
 	}
 
 	protected function find_and_normalize_template_by_id( $templates, $id ) {

--- a/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
+++ b/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
@@ -254,7 +254,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 				'description' => 'Just a description',
 				'title'       => 'My Template',
 				'content'     => 'Content',
-				'author'      => 99999,
+				'author'      => -1,
 			)
 		);
 		$response = rest_get_server()->dispatch( $request );

--- a/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
+++ b/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
@@ -53,7 +53,6 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 		wp_delete_post( self::$post->ID );
 	}
 
-
 	public function test_register_routes() {
 		$routes = rest_get_server()->get_routes();
 		$this->assertArrayHasKey( '/wp/v2/templates', $routes );
@@ -93,6 +92,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 				'theme'          => 'default',
 				'slug'           => 'my_template',
 				'source'         => 'custom',
+				'origin'         => null,
 				'type'           => 'wp_template',
 				'description'    => 'Description of my template.',
 				'title'          => array(
@@ -135,6 +135,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 				'theme'          => 'default',
 				'slug'           => 'my_template',
 				'source'         => 'custom',
+				'origin'         => null,
 				'type'           => 'wp_template',
 				'description'    => 'Description of my template.',
 				'title'          => array(
@@ -180,6 +181,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 				),
 				'slug'           => 'my_custom_template',
 				'source'         => 'custom',
+				'origin'         => null,
 				'type'           => 'wp_template',
 				'description'    => 'Just a description',
 				'title'          => array(
@@ -228,6 +230,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 				),
 				'slug'           => 'my_custom_template_raw',
 				'source'         => 'custom',
+				'origin'         => null,
 				'type'           => 'wp_template',
 				'description'    => 'Just a description',
 				'title'          => array(
@@ -251,7 +254,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 				'description' => 'Just a description',
 				'title'       => 'My Template',
 				'content'     => 'Content',
-				'author'      => -999,
+				'author'      => 99999,
 			)
 		);
 		$response = rest_get_server()->dispatch( $request );
@@ -392,13 +395,14 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 		$response   = rest_get_server()->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertCount( 12, $properties );
+		$this->assertCount( 13, $properties );
 		$this->assertArrayHasKey( 'id', $properties );
 		$this->assertArrayHasKey( 'description', $properties );
 		$this->assertArrayHasKey( 'slug', $properties );
 		$this->assertArrayHasKey( 'theme', $properties );
 		$this->assertArrayHasKey( 'type', $properties );
 		$this->assertArrayHasKey( 'source', $properties );
+		$this->assertArrayHasKey( 'origin', $properties );
 		$this->assertArrayHasKey( 'content', $properties );
 		$this->assertArrayHasKey( 'title', $properties );
 		$this->assertArrayHasKey( 'description', $properties );

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -5117,6 +5117,11 @@ mockedApiResponse.Schema = {
                                 "private"
                             ],
                             "required": false
+                        },
+                        "author": {
+                            "description": "The ID for the author of the template.",
+                            "type": "integer",
+                            "required": false
                         }
                     }
                 }
@@ -5261,6 +5266,11 @@ mockedApiResponse.Schema = {
                                 "pending",
                                 "private"
                             ],
+                            "required": false
+                        },
+                        "author": {
+                            "description": "The ID for the author of the template.",
+                            "type": "integer",
                             "required": false
                         }
                     }
@@ -5571,6 +5581,11 @@ mockedApiResponse.Schema = {
                                 "private"
                             ],
                             "required": false
+                        },
+                        "author": {
+                            "description": "The ID for the author of the template.",
+                            "type": "integer",
+                            "required": false
                         }
                     }
                 }
@@ -5750,6 +5765,11 @@ mockedApiResponse.Schema = {
                             ],
                             "required": false
                         },
+                        "author": {
+                            "description": "The ID for the author of the template.",
+                            "type": "integer",
+                            "required": false
+                        },
                         "area": {
                             "description": "Where the template part is intended for use (header, footer, etc.)",
                             "type": "string",
@@ -5898,6 +5918,11 @@ mockedApiResponse.Schema = {
                                 "pending",
                                 "private"
                             ],
+                            "required": false
+                        },
+                        "author": {
+                            "description": "The ID for the author of the template.",
+                            "type": "integer",
                             "required": false
                         },
                         "area": {
@@ -6212,6 +6237,11 @@ mockedApiResponse.Schema = {
                                 "pending",
                                 "private"
                             ],
+                            "required": false
+                        },
+                        "author": {
+                            "description": "The ID for the author of the template.",
+                            "type": "integer",
                             "required": false
                         },
                         "area": {


### PR DESCRIPTION
Related - https://github.com/WordPress/gutenberg/pull/36763

Adds support for two new REST API fields for the templates controller to meet the requirements here - https://github.com/WordPress/gutenberg/issues/36597#issuecomment-973893084

It adds:
- `author`. When a user creates a complete new template (or template part) the author is now stored. The author can then be shown in the list of templates.
- `origin`. When a file template is customized and a post template created, this stores what the original 'source' of that template was (usually either 'theme' or 'plugin').

I'll leave a disclaimer that making these kind of changes is not my strength, so this could do with some critique.

To test the full feature here you need both WordPress and Gutenberg dev environments, with this checked out for the WordPress dev environment and https://github.com/WordPress/gutenberg/pull/36763 checked for the gutenberg environment.

### Testing steps 
1. Visit `wp-admin/themes.php?page=gutenberg-edit-site&postType=wp_template_part`
2. Click Add new and name the template part
3. Go back to `wp-admin/themes.php?page=gutenberg-edit-site&postType=wp_template_part`
4. Your author should show up in the Added By column for the newly created template part

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
