### PR TITLE
Correct the order of expected and actual parameters when used in assertions

### DIFF
--- a/tests/phpunit/tests/db/charset.php
+++ b/tests/phpunit/tests/db/charset.php
@@ -767,10 +767,10 @@ class Tests_DB_Charset extends WP_UnitTestCase {
 		self::$_wpdb->query( $create );
 
 		$charset = self::$_wpdb->get_table_charset( $table );
-		$this->assertSame( $charset, $expected_charset );
+		$this->assertSame( $expected_charset, $charset );
 
 		$charset = self::$_wpdb->get_table_charset( strtoupper( $table ) );
-		$this->assertSame( $charset, $expected_charset );
+		$this->assertSame( $expected_charset, $charset );
 
 		self::$_wpdb->query( $drop );
 	}

--- a/tests/phpunit/tests/image/editor.php
+++ b/tests/phpunit/tests/image/editor.php
@@ -297,7 +297,7 @@ class Tests_Image_Editor extends WP_Image_UnitTestCase {
 		}
 
 		$file_data = wp_get_webp_info( $file );
-		$this->assertSame( $file_data, $expected );
+		$this->assertSame( $expected, $file_data );
 	}
 
 	/**

--- a/tests/phpunit/tests/image/functions.php
+++ b/tests/phpunit/tests/image/functions.php
@@ -626,7 +626,7 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 
 		$metadata = wp_generate_attachment_metadata( $attachment_id, $test_file );
 		$this->assertArrayHasKey( 'test-size', $metadata['sizes'], 'The `test-size` was not added to the metadata.' );
-		$this->assertSame( $metadata['sizes']['test-size'], $expected );
+		$this->assertSame( $expected, $metadata['sizes']['test-size'] );
 
 		remove_image_size( 'test-size' );
 		remove_filter( 'fallback_intermediate_image_sizes', array( $this, 'filter_fallback_intermediate_image_sizes' ), 10 );

--- a/tests/phpunit/tests/l10n/loadTextdomainJustInTime.php
+++ b/tests/phpunit/tests/l10n/loadTextdomainJustInTime.php
@@ -69,13 +69,13 @@ class Tests_L10n_LoadTextdomainJustInTime extends WP_UnitTestCase {
 		require_once DIR_TESTDATA . '/plugins/internationalized-plugin.php';
 
 		$is_textdomain_loaded_before = is_textdomain_loaded( 'internationalized-plugin' );
-		$expected_output             = i18n_plugin_test();
+		$actual_output               = i18n_plugin_test();
 		$is_textdomain_loaded_after  = is_textdomain_loaded( 'internationalized-plugin' );
 
 		remove_filter( 'locale', array( $this, 'filter_set_locale_to_german' ) );
 
 		$this->assertFalse( $is_textdomain_loaded_before );
-		$this->assertSame( 'Das ist ein Dummy Plugin', $expected_output );
+		$this->assertSame( 'Das ist ein Dummy Plugin', $actual_output );
 		$this->assertTrue( $is_textdomain_loaded_after );
 	}
 
@@ -90,13 +90,13 @@ class Tests_L10n_LoadTextdomainJustInTime extends WP_UnitTestCase {
 		require_once get_stylesheet_directory() . '/functions.php';
 
 		$is_textdomain_loaded_before = is_textdomain_loaded( 'internationalized-theme' );
-		$expected_output             = i18n_theme_test();
+		$actual_output               = i18n_theme_test();
 		$is_textdomain_loaded_after  = is_textdomain_loaded( 'internationalized-theme' );
 
 		remove_filter( 'locale', array( $this, 'filter_set_locale_to_german' ) );
 
 		$this->assertFalse( $is_textdomain_loaded_before );
-		$this->assertSame( 'Das ist ein Dummy Theme', $expected_output );
+		$this->assertSame( 'Das ist ein Dummy Theme', $actual_output );
 		$this->assertTrue( $is_textdomain_loaded_after );
 	}
 
@@ -121,34 +121,34 @@ class Tests_L10n_LoadTextdomainJustInTime extends WP_UnitTestCase {
 
 		require_once DIR_TESTDATA . '/plugins/internationalized-plugin.php';
 
-		$expected_output_before      = i18n_plugin_test();
+		$actual_output_before        = i18n_plugin_test();
 		$is_textdomain_loaded_before = is_textdomain_loaded( 'internationalized-plugin' );
 
 		unload_textdomain( 'internationalized-plugin' );
 		remove_filter( 'locale', array( $this, 'filter_set_locale_to_german' ) );
 
-		$expected_output_after      = i18n_plugin_test();
+		$actual_output_after        = i18n_plugin_test();
 		$is_textdomain_loaded_after = is_textdomain_loaded( 'internationalized-plugin' );
 
 		add_filter( 'locale', array( $this, 'filter_set_locale_to_german' ) );
 		load_textdomain( 'internationalized-plugin', WP_LANG_DIR . '/plugins/internationalized-plugin-de_DE.mo' );
 
-		$expected_output_final      = i18n_plugin_test();
+		$actual_output_final        = i18n_plugin_test();
 		$is_textdomain_loaded_final = is_textdomain_loaded( 'internationalized-plugin' );
 
 		unload_textdomain( 'internationalized-plugin' );
 		remove_filter( 'locale', array( $this, 'filter_set_locale_to_german' ) );
 
 		// Text domain loaded just in time.
-		$this->assertSame( 'Das ist ein Dummy Plugin', $expected_output_before );
+		$this->assertSame( 'Das ist ein Dummy Plugin', $actual_output_before );
 		$this->assertTrue( $is_textdomain_loaded_before );
 
 		// Text domain unloaded.
-		$this->assertSame( 'This is a dummy plugin', $expected_output_after );
+		$this->assertSame( 'This is a dummy plugin', $actual_output_after );
 		$this->assertFalse( $is_textdomain_loaded_after );
 
 		// Text domain loaded manually again.
-		$this->assertSame( 'Das ist ein Dummy Plugin', $expected_output_final );
+		$this->assertSame( 'Das ist ein Dummy Plugin', $actual_output_final );
 		$this->assertTrue( $is_textdomain_loaded_final );
 	}
 
@@ -159,10 +159,10 @@ class Tests_L10n_LoadTextdomainJustInTime extends WP_UnitTestCase {
 		require_once DIR_TESTDATA . '/plugins/internationalized-plugin.php';
 
 		switch_to_locale( 'de_DE' );
-		$expected = i18n_plugin_test();
+		$actual = i18n_plugin_test();
 		restore_previous_locale();
 
-		$this->assertSame( 'Das ist ein Dummy Plugin', $expected );
+		$this->assertSame( 'Das ist ein Dummy Plugin', $actual );
 	}
 
 	/**
@@ -172,15 +172,15 @@ class Tests_L10n_LoadTextdomainJustInTime extends WP_UnitTestCase {
 		require_once DIR_TESTDATA . '/plugins/internationalized-plugin.php';
 
 		switch_to_locale( 'de_DE' );
-		$expected_de_de = i18n_plugin_test();
+		$actual_de_de = i18n_plugin_test();
 
 		switch_to_locale( 'es_ES' );
-		$expected_es_es = i18n_plugin_test();
+		$actual_es_es = i18n_plugin_test();
 
 		restore_current_locale();
 
-		$this->assertSame( 'Das ist ein Dummy Plugin', $expected_de_de );
-		$this->assertSame( 'This is a dummy plugin', $expected_es_es );
+		$this->assertSame( 'Das ist ein Dummy Plugin', $actual_de_de );
+		$this->assertSame( 'This is a dummy plugin', $actual_es_es );
 	}
 
 	/**
@@ -192,12 +192,12 @@ class Tests_L10n_LoadTextdomainJustInTime extends WP_UnitTestCase {
 		require_once get_stylesheet_directory() . '/functions.php';
 
 		switch_to_locale( 'de_DE' );
-		$expected = i18n_theme_test();
+		$actual = i18n_theme_test();
 		restore_previous_locale();
 
 		switch_theme( WP_DEFAULT_THEME );
 
-		$this->assertSame( 'Das ist ein Dummy Theme', $expected );
+		$this->assertSame( 'Das ist ein Dummy Theme', $actual );
 	}
 
 	/**
@@ -209,9 +209,9 @@ class Tests_L10n_LoadTextdomainJustInTime extends WP_UnitTestCase {
 		set_current_screen( 'dashboard' );
 		wp_set_current_user( self::$user_id );
 
-		$expected = i18n_plugin_test();
+		$actual = i18n_plugin_test();
 
-		$this->assertSame( 'Das ist ein Dummy Plugin', $expected );
+		$this->assertSame( 'Das ist ein Dummy Plugin', $actual );
 	}
 
 	/**
@@ -224,11 +224,11 @@ class Tests_L10n_LoadTextdomainJustInTime extends WP_UnitTestCase {
 
 		require_once get_stylesheet_directory() . '/functions.php';
 
-		$expected = i18n_theme_test();
+		$actual = i18n_theme_test();
 
 		switch_theme( WP_DEFAULT_THEME );
 
-		$this->assertSame( 'Das ist ein Dummy Theme', $expected );
+		$this->assertSame( 'Das ist ein Dummy Theme', $actual );
 	}
 
 	/**

--- a/tests/phpunit/tests/l10n/wpLocaleSwitcher.php
+++ b/tests/phpunit/tests/l10n/wpLocaleSwitcher.php
@@ -372,14 +372,14 @@ class Tests_L10n_wpLocaleSwitcher extends WP_UnitTestCase {
 		switch_to_locale( 'de_DE' );
 		switch_to_locale( $site_locale );
 
-		$expected = i18n_plugin_test();
+		$actual = i18n_plugin_test();
 
 		restore_current_locale();
 
 		$wp_locale_switcher = $locale_switcher;
 
 		$this->assertSame( 'en_US', get_locale() );
-		$this->assertSame( 'This is a dummy plugin', $expected );
+		$this->assertSame( 'This is a dummy plugin', $actual );
 	}
 
 	public function filter_locale() {

--- a/tests/phpunit/tests/menu/walker-nav-menu.php
+++ b/tests/phpunit/tests/menu/walker-nav-menu.php
@@ -41,7 +41,7 @@ class Tests_Menu_Walker_Nav_Menu extends WP_UnitTestCase {
 	 * @ticket 43290
 	 */
 	public function test_noopener_no_referrer_for_target_blank() {
-		$expected   = '';
+		$actual     = '';
 		$post_id    = $this->factory->post->create();
 		$post_title = get_the_title( $post_id );
 
@@ -61,9 +61,9 @@ class Tests_Menu_Walker_Nav_Menu extends WP_UnitTestCase {
 			'link_after'  => '',
 		);
 
-		$this->walker->start_el( $expected, (object) $item, 0, (object) $args );
+		$this->walker->start_el( $actual, (object) $item, 0, (object) $args );
 
-		$this->assertSame( "<li id=\"menu-item-{$post_id}\" class=\"menu-item-{$post_id}\"><a target=\"_blank\" rel=\"noopener\">{$post_title}</a>", $expected );
+		$this->assertSame( "<li id=\"menu-item-{$post_id}\" class=\"menu-item-{$post_id}\"><a target=\"_blank\" rel=\"noopener\">{$post_title}</a>", $actual );
 	}
 
 	/**

--- a/tests/phpunit/tests/meta/registerMeta.php
+++ b/tests/phpunit/tests/meta/registerMeta.php
@@ -179,7 +179,7 @@ class Tests_Meta_Register_Meta extends WP_UnitTestCase {
 				),
 			),
 		);
-		$this->assertSame( $actual, $expected );
+		$this->assertSame( $expected, $actual );
 	}
 
 	public function test_register_meta_with_current_sanitize_callback_returns_true() {
@@ -521,11 +521,11 @@ class Tests_Meta_Register_Meta extends WP_UnitTestCase {
 		$object_property_name = $object_type . '_id';
 		$object_id            = self::$$object_property_name;
 		$default_value        = get_metadata_default( $object_type, $object_id, $meta_key, $single );
-		$this->assertSame( $default_value, $expected );
+		$this->assertSame( $expected, $default_value );
 
 		// Check for default value.
 		$value = get_metadata( $object_type, $object_id, $meta_key, $single );
-		$this->assertSame( $value, $expected );
+		$this->assertSame( $expected, $value );
 
 		// Set value to check default is not being returned by mistake.
 		$meta_value = 'dibble';
@@ -536,7 +536,7 @@ class Tests_Meta_Register_Meta extends WP_UnitTestCase {
 		// Delete meta, make sure the default is returned.
 		delete_metadata( $object_type, $object_id, $meta_key );
 		$value = get_metadata( $object_type, $object_id, $meta_key, $single );
-		$this->assertSame( $value, $expected );
+		$this->assertSame( $expected, $value );
 
 		// Set other meta key, to make sure other keys are not effects.
 		$meta_value = 'hibble';
@@ -568,7 +568,7 @@ class Tests_Meta_Register_Meta extends WP_UnitTestCase {
 		$object_property_name = $object_type . '_id';
 		$object_id            = self::$$object_property_name;
 		$default_value        = get_metadata_default( $object_type, $object_id, $meta_key, $single );
-		$this->assertSame( $default_value, $expected );
+		$this->assertSame( $expected, $default_value );
 	}
 
 	public function filter_get_object_subtype_for_customtype( $subtype, $object_id ) {

--- a/tests/phpunit/tests/post/nav-menu.php
+++ b/tests/phpunit/tests/post/nav-menu.php
@@ -247,7 +247,7 @@ class Tests_Post_Nav_Menu extends WP_UnitTestCase {
 		// And this is what we got when calling wp_get_nav_menus().
 		$nav_menus_names = wp_list_pluck( wp_get_nav_menus(), 'name' );
 
-		$this->assertSame( $nav_menus_names, $expected_nav_menus_names );
+		$this->assertSame( $expected_nav_menus_names, $nav_menus_names );
 	}
 
 	/**

--- a/tests/phpunit/tests/query/commentCount.php
+++ b/tests/phpunit/tests/query/commentCount.php
@@ -81,7 +81,7 @@ class Tests_Query_CommentCount extends WP_UnitTestCase {
 
 		$expected = self::$post_ids[4];
 
-		$this->assertSameSets( $found_post_ids, $expected );
+		$this->assertSameSets( $expected, $found_post_ids );
 	}
 
 	public function test_operator_greater_than() {
@@ -99,7 +99,7 @@ class Tests_Query_CommentCount extends WP_UnitTestCase {
 
 		$expected = self::$post_ids[5];
 
-		$this->assertSameSets( $found_post_ids, $expected );
+		$this->assertSameSets( $expected, $found_post_ids );
 	}
 
 	public function test_operator_greater_than_no_results() {
@@ -117,7 +117,7 @@ class Tests_Query_CommentCount extends WP_UnitTestCase {
 
 		$expected = array();
 
-		$this->assertSameSets( $found_post_ids, $expected );
+		$this->assertSameSets( $expected, $found_post_ids );
 	}
 	public function test_operator_less_than() {
 		$args = array(
@@ -143,7 +143,7 @@ class Tests_Query_CommentCount extends WP_UnitTestCase {
 			$expected[] = $expected_id;
 		}
 
-		$this->assertSameSets( $found_post_ids, $expected );
+		$this->assertSameSets( $expected, $found_post_ids );
 	}
 
 	public function test_operator_less_than_no_results() {
@@ -161,7 +161,7 @@ class Tests_Query_CommentCount extends WP_UnitTestCase {
 
 		$expected = array();
 
-		$this->assertSameSets( $found_post_ids, $expected );
+		$this->assertSameSets( $expected, $found_post_ids );
 	}
 
 
@@ -189,7 +189,7 @@ class Tests_Query_CommentCount extends WP_UnitTestCase {
 			$expected[] = $expected_id;
 		}
 
-		$this->assertSameSets( $found_post_ids, $expected );
+		$this->assertSameSets( $expected, $found_post_ids );
 
 	}
 	public function test_operator_equal_or_greater_than() {
@@ -213,7 +213,7 @@ class Tests_Query_CommentCount extends WP_UnitTestCase {
 			$expected[] = $expected_id;
 		}
 
-		$this->assertSameSets( $found_post_ids, $expected );
+		$this->assertSameSets( $expected, $found_post_ids );
 	}
 
 	public function test_operator_equal_or_greater_than_no_results() {
@@ -231,7 +231,7 @@ class Tests_Query_CommentCount extends WP_UnitTestCase {
 
 		$expected = array();
 
-		$this->assertSameSets( $found_post_ids, $expected );
+		$this->assertSameSets( $expected, $found_post_ids );
 	}
 
 	public function test_operator_equal_or_less_than() {
@@ -255,7 +255,7 @@ class Tests_Query_CommentCount extends WP_UnitTestCase {
 			$expected[] = $expected_id;
 		}
 
-		$this->assertSameSets( $found_post_ids, $expected );
+		$this->assertSameSets( $expected, $found_post_ids );
 	}
 
 	public function test_operator_equal_or_less_than_no_results() {
@@ -273,7 +273,7 @@ class Tests_Query_CommentCount extends WP_UnitTestCase {
 
 		$expected = array();
 
-		$this->assertSameSets( $found_post_ids, $expected );
+		$this->assertSameSets( $expected, $found_post_ids );
 	}
 
 	public function test_invalid_operator_should_fall_back_on_equals() {
@@ -294,7 +294,7 @@ class Tests_Query_CommentCount extends WP_UnitTestCase {
 			$expected[] = $expected_id;
 		}
 
-		$this->assertSameSets( $found_post_ids, $expected );
+		$this->assertSameSets( $expected, $found_post_ids );
 	}
 
 	public function test_wrong_count_no_results() {
@@ -312,7 +312,7 @@ class Tests_Query_CommentCount extends WP_UnitTestCase {
 
 		$expected = array();
 
-		$this->assertSameSets( $found_post_ids, $expected );
+		$this->assertSameSets( $expected, $found_post_ids );
 	}
 
 	public function test_no_operator_no_results() {
@@ -329,7 +329,7 @@ class Tests_Query_CommentCount extends WP_UnitTestCase {
 
 		$expected = self::$post_ids[5];
 
-		$this->assertSameSets( $found_post_ids, $expected );
+		$this->assertSameSets( $expected, $found_post_ids );
 	}
 
 	public function test_empty_non_numeric_string_should_be_ignored() {
@@ -353,7 +353,7 @@ class Tests_Query_CommentCount extends WP_UnitTestCase {
 			$expected[] = $expected_id;
 		}
 
-		$this->assertSameSets( $found_post_ids, $expected );
+		$this->assertSameSets( $expected, $found_post_ids );
 	}
 
 	public function test_simple_count() {
@@ -368,7 +368,7 @@ class Tests_Query_CommentCount extends WP_UnitTestCase {
 
 		$expected = self::$post_ids[5];
 
-		$this->assertSameSets( $found_post_ids, $expected );
+		$this->assertSameSets( $expected, $found_post_ids );
 	}
 }
 

--- a/tests/phpunit/tests/rest-api/wpRestMenuItemsController.php
+++ b/tests/phpunit/tests/rest-api/wpRestMenuItemsController.php
@@ -392,7 +392,7 @@ class Tests_REST_WpRestMenuItemsController extends WP_Test_REST_Post_Type_Contro
 			$expected[] = $i;
 			$actual[]   = $data['menu_order'];
 		}
-		$this->assertSame( $actual, $expected );
+		$this->assertSame( $expected, $actual );
 	}
 
 	/**

--- a/tests/phpunit/tests/widgets/wpWidgetCustomHtml.php
+++ b/tests/phpunit/tests/widgets/wpWidgetCustomHtml.php
@@ -185,7 +185,7 @@ class Tests_Widgets_wpWidgetCustomHtml extends WP_UnitTestCase {
 			'content' => $instance['content'],
 		);
 		$result   = $widget->update( $instance, array() );
-		$this->assertSame( $result, $expected );
+		$this->assertSame( $expected, $result );
 
 		// Make sure KSES is applying as expected.
 		add_filter( 'map_meta_cap', array( $this, 'grant_unfiltered_html_cap' ), 10, 2 );
@@ -193,7 +193,7 @@ class Tests_Widgets_wpWidgetCustomHtml extends WP_UnitTestCase {
 		$instance['content'] = '<script>alert( "Howdy!" );</script>';
 		$expected['content'] = $instance['content'];
 		$result              = $widget->update( $instance, array() );
-		$this->assertSame( $result, $expected );
+		$this->assertSame( $expected, $result );
 		remove_filter( 'map_meta_cap', array( $this, 'grant_unfiltered_html_cap' ) );
 
 		add_filter( 'map_meta_cap', array( $this, 'revoke_unfiltered_html_cap' ), 10, 2 );
@@ -201,7 +201,7 @@ class Tests_Widgets_wpWidgetCustomHtml extends WP_UnitTestCase {
 		$instance['content'] = '<script>alert( "Howdy!" );</script>';
 		$expected['content'] = wp_kses_post( $instance['content'] );
 		$result              = $widget->update( $instance, array() );
-		$this->assertSame( $result, $expected );
+		$this->assertSame( $expected, $result );
 		remove_filter( 'map_meta_cap', array( $this, 'revoke_unfiltered_html_cap' ), 10 );
 	}
 

--- a/tests/phpunit/tests/widgets/wpWidgetMedia.php
+++ b/tests/phpunit/tests/widgets/wpWidgetMedia.php
@@ -244,7 +244,7 @@ class Tests_Widgets_wpWidgetMedia extends WP_UnitTestCase {
 			'attachment_id' => 1,
 		);
 		$result   = $widget->update( $expected, $instance );
-		$this->assertSame( $result, $expected );
+		$this->assertSame( $expected, $result );
 
 		// Should filter invalid attachment ID.
 		$result = $widget->update(
@@ -260,7 +260,7 @@ class Tests_Widgets_wpWidgetMedia extends WP_UnitTestCase {
 			'url' => 'https://example.org',
 		);
 		$result   = $widget->update( $expected, $instance );
-		$this->assertSame( $result, $expected );
+		$this->assertSame( $expected, $result );
 
 		// Should filter invalid attachment url.
 		$result = $widget->update(
@@ -276,7 +276,7 @@ class Tests_Widgets_wpWidgetMedia extends WP_UnitTestCase {
 			'title' => 'What a title',
 		);
 		$result   = $widget->update( $expected, $instance );
-		$this->assertSame( $result, $expected );
+		$this->assertSame( $expected, $result );
 
 		// Should filter invalid attachment title.
 		$result = $widget->update(

--- a/tests/phpunit/tests/widgets/wpWidgetMediaAudio.php
+++ b/tests/phpunit/tests/widgets/wpWidgetMediaAudio.php
@@ -125,7 +125,7 @@ class Tests_Widgets_wpWidgetMediaAudio extends WP_UnitTestCase {
 			'attachment_id' => 1,
 		);
 		$result   = $widget->update( $expected, $instance );
-		$this->assertSame( $result, $expected );
+		$this->assertSame( $expected, $result );
 
 		// Should filter invalid attachment ID.
 		$result = $widget->update(
@@ -141,7 +141,7 @@ class Tests_Widgets_wpWidgetMediaAudio extends WP_UnitTestCase {
 			'url' => 'https://chickenandribs.org',
 		);
 		$result   = $widget->update( $expected, $instance );
-		$this->assertSame( $result, $expected );
+		$this->assertSame( $expected, $result );
 
 		// Should filter invalid attachment url.
 		$result = $widget->update(
@@ -158,7 +158,7 @@ class Tests_Widgets_wpWidgetMediaAudio extends WP_UnitTestCase {
 			'loop' => true,
 		);
 		$result   = $widget->update( $expected, $instance );
-		$this->assertSame( $result, $expected );
+		$this->assertSame( $expected, $result );
 
 		// Should filter invalid loop setting.
 		$result = $widget->update(
@@ -174,7 +174,7 @@ class Tests_Widgets_wpWidgetMediaAudio extends WP_UnitTestCase {
 			'title' => 'An audio sample of parrots',
 		);
 		$result   = $widget->update( $expected, $instance );
-		$this->assertSame( $result, $expected );
+		$this->assertSame( $expected, $result );
 
 		// Should filter invalid attachment title.
 		$result = $widget->update(
@@ -190,7 +190,7 @@ class Tests_Widgets_wpWidgetMediaAudio extends WP_UnitTestCase {
 			'preload' => 'none',
 		);
 		$result   = $widget->update( $expected, $instance );
-		$this->assertSame( $result, $expected );
+		$this->assertSame( $expected, $result );
 
 		// Should filter invalid preload setting.
 		$result = $widget->update(

--- a/tests/phpunit/tests/widgets/wpWidgetMediaImage.php
+++ b/tests/phpunit/tests/widgets/wpWidgetMediaImage.php
@@ -132,7 +132,7 @@ class Tests_Widgets_wpWidgetMediaImage extends WP_UnitTestCase {
 			'attachment_id' => 1,
 		);
 		$result   = $widget->update( $expected, $instance );
-		$this->assertSame( $result, $expected );
+		$this->assertSame( $expected, $result );
 
 		// Should filter invalid attachment ID.
 		$result = $widget->update(
@@ -148,7 +148,7 @@ class Tests_Widgets_wpWidgetMediaImage extends WP_UnitTestCase {
 			'url' => 'https://example.org',
 		);
 		$result   = $widget->update( $expected, $instance );
-		$this->assertSame( $result, $expected );
+		$this->assertSame( $expected, $result );
 
 		// Should filter invalid attachment url.
 		$result = $widget->update(
@@ -165,7 +165,7 @@ class Tests_Widgets_wpWidgetMediaImage extends WP_UnitTestCase {
 			'title' => 'What a title',
 		);
 		$result   = $widget->update( $expected, $instance );
-		$this->assertSame( $result, $expected );
+		$this->assertSame( $expected, $result );
 
 		// Should filter invalid attachment title.
 		$result = $widget->update(
@@ -181,7 +181,7 @@ class Tests_Widgets_wpWidgetMediaImage extends WP_UnitTestCase {
 			'size' => 'thumbnail',
 		);
 		$result   = $widget->update( $expected, $instance );
-		$this->assertSame( $result, $expected );
+		$this->assertSame( $expected, $result );
 
 		// Should filter invalid image size.
 		$result = $widget->update(
@@ -197,7 +197,7 @@ class Tests_Widgets_wpWidgetMediaImage extends WP_UnitTestCase {
 			'width' => 300,
 		);
 		$result   = $widget->update( $expected, $instance );
-		$this->assertSame( $result, $expected );
+		$this->assertSame( $expected, $result );
 
 		// Should filter invalid image width.
 		$result = $widget->update(
@@ -213,7 +213,7 @@ class Tests_Widgets_wpWidgetMediaImage extends WP_UnitTestCase {
 			'height' => 200,
 		);
 		$result   = $widget->update( $expected, $instance );
-		$this->assertSame( $result, $expected );
+		$this->assertSame( $expected, $result );
 
 		// Should filter invalid image height.
 		$result = $widget->update(
@@ -229,7 +229,7 @@ class Tests_Widgets_wpWidgetMediaImage extends WP_UnitTestCase {
 			'caption' => 'A caption with <a href="#">link</a>',
 		);
 		$result   = $widget->update( $expected, $instance );
-		$this->assertSame( $result, $expected );
+		$this->assertSame( $expected, $result );
 
 		// Should filter invalid image caption.
 		$result = $widget->update(
@@ -250,7 +250,7 @@ class Tests_Widgets_wpWidgetMediaImage extends WP_UnitTestCase {
 			'alt' => 'A water tower',
 		);
 		$result   = $widget->update( $expected, $instance );
-		$this->assertSame( $result, $expected );
+		$this->assertSame( $expected, $result );
 
 		// Should filter invalid alt text.
 		$result = $widget->update(
@@ -271,7 +271,7 @@ class Tests_Widgets_wpWidgetMediaImage extends WP_UnitTestCase {
 			'link_type' => 'file',
 		);
 		$result   = $widget->update( $expected, $instance );
-		$this->assertSame( $result, $expected );
+		$this->assertSame( $expected, $result );
 
 		// Should filter invalid link type.
 		$result = $widget->update(
@@ -287,7 +287,7 @@ class Tests_Widgets_wpWidgetMediaImage extends WP_UnitTestCase {
 			'link_url' => 'https://example.org',
 		);
 		$result   = $widget->update( $expected, $instance );
-		$this->assertSame( $result, $expected );
+		$this->assertSame( $expected, $result );
 
 		// Should filter invalid link url.
 		$result = $widget->update(
@@ -304,7 +304,7 @@ class Tests_Widgets_wpWidgetMediaImage extends WP_UnitTestCase {
 			'image_classes' => 'A water tower',
 		);
 		$result   = $widget->update( $expected, $instance );
-		$this->assertSame( $result, $expected );
+		$this->assertSame( $expected, $result );
 
 		// Should filter invalid image classes.
 		$result = $widget->update(
@@ -325,7 +325,7 @@ class Tests_Widgets_wpWidgetMediaImage extends WP_UnitTestCase {
 			'link_classes' => 'A water tower',
 		);
 		$result   = $widget->update( $expected, $instance );
-		$this->assertSame( $result, $expected );
+		$this->assertSame( $expected, $result );
 
 		// Should filter invalid link classes.
 		$result = $widget->update(
@@ -346,7 +346,7 @@ class Tests_Widgets_wpWidgetMediaImage extends WP_UnitTestCase {
 			'link_rel' => 'previous',
 		);
 		$result   = $widget->update( $expected, $instance );
-		$this->assertSame( $result, $expected );
+		$this->assertSame( $expected, $result );
 
 		// Should filter invalid rel text.
 		$result = $widget->update(
@@ -367,7 +367,7 @@ class Tests_Widgets_wpWidgetMediaImage extends WP_UnitTestCase {
 			'link_target_blank' => false,
 		);
 		$result   = $widget->update( $expected, $instance );
-		$this->assertSame( $result, $expected );
+		$this->assertSame( $expected, $result );
 
 		// Should filter invalid  link target.
 		$result = $widget->update(
@@ -383,7 +383,7 @@ class Tests_Widgets_wpWidgetMediaImage extends WP_UnitTestCase {
 			'image_title' => 'What a title',
 		);
 		$result   = $widget->update( $expected, $instance );
-		$this->assertSame( $result, $expected );
+		$this->assertSame( $expected, $result );
 
 		// Should filter invalid image title.
 		$result = $widget->update(

--- a/tests/phpunit/tests/widgets/wpWidgetMediaVideo.php
+++ b/tests/phpunit/tests/widgets/wpWidgetMediaVideo.php
@@ -126,7 +126,7 @@ class Tests_Widgets_wpWidgetMediaVideo extends WP_UnitTestCase {
 			'attachment_id' => 1,
 		);
 		$result   = $widget->update( $expected, $instance );
-		$this->assertSame( $result, $expected );
+		$this->assertSame( $expected, $result );
 
 		// Should filter invalid attachment ID.
 		$result = $widget->update(
@@ -142,7 +142,7 @@ class Tests_Widgets_wpWidgetMediaVideo extends WP_UnitTestCase {
 			'url' => 'https://chickenandribs.org',
 		);
 		$result   = $widget->update( $expected, $instance );
-		$this->assertSame( $result, $expected );
+		$this->assertSame( $expected, $result );
 
 		// Should filter invalid attachment url.
 		$result = $widget->update(
@@ -159,7 +159,7 @@ class Tests_Widgets_wpWidgetMediaVideo extends WP_UnitTestCase {
 			'loop' => true,
 		);
 		$result   = $widget->update( $expected, $instance );
-		$this->assertSame( $result, $expected );
+		$this->assertSame( $expected, $result );
 
 		// Should filter invalid loop setting.
 		$result = $widget->update(
@@ -175,7 +175,7 @@ class Tests_Widgets_wpWidgetMediaVideo extends WP_UnitTestCase {
 			'title' => 'A video of goats',
 		);
 		$result   = $widget->update( $expected, $instance );
-		$this->assertSame( $result, $expected );
+		$this->assertSame( $expected, $result );
 
 		// Should filter invalid attachment title.
 		$result = $widget->update(
@@ -191,7 +191,7 @@ class Tests_Widgets_wpWidgetMediaVideo extends WP_UnitTestCase {
 			'preload' => 'none',
 		);
 		$result   = $widget->update( $expected, $instance );
-		$this->assertSame( $result, $expected );
+		$this->assertSame( $expected, $result );
 
 		// Should filter invalid preload setting.
 		$result = $widget->update(


### PR DESCRIPTION
This corrects the order of the expected and actual parameters when used in assertions so if/when they fail the failure message is correct.

Trac ticket: https://core.trac.wordpress.org/ticket/53363