### PR TITLE
Fix backward compatibility of get_term_feed_link()

### DIFF
--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -931,12 +931,11 @@ function get_category_feed_link( $cat, $feed = '' ) {
 function get_term_feed_link( $term, $taxonomy = '', $feed = '' ) {
 	if ( ! is_object( $term ) ) {
 		$term     = (int) $term;
-		$taxonomy = 'category';
-	} elseif ( ! $term instanceof WP_Term ) {
-		$taxonomy = $term->taxonomy;
 	}
 
 	$term = get_term( $term, $taxonomy );
+
+	$taxonomy = $term->taxonomy;
 
 	if ( empty( $term ) || is_wp_error( $term ) ) {
 		return false;

--- a/tests/phpunit/tests/term/getTermLink.php
+++ b/tests/phpunit/tests/term/getTermLink.php
@@ -271,6 +271,7 @@ class Tests_Term_GetTermLink extends WP_UnitTestCase {
 	 * @ticket 50225
 	 *
 	 * @param string $taxonomy Taxonomy been tested (used for index of term keys).
+	 * @param bool   $use_id   When true, pass term ID. Else, skip the test.
 	 */
 	public function test_get_term_feed_link_backward_compatibility( $taxonomy, $use_id ) {
 		if ( $use_id ) {

--- a/tests/phpunit/tests/term/getTermLink.php
+++ b/tests/phpunit/tests/term/getTermLink.php
@@ -266,6 +266,27 @@ class Tests_Term_GetTermLink extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @dataProvider data_get_term_link
+	 *
+	 * @ticket 50225
+	 *
+	 * @param string $taxonomy Taxonomy been tested (used for index of term keys).
+	 */
+	public function test_get_term_feed_link_backward_compatibility( $taxonomy, $use_id ) {
+		if ( $use_id ) {
+			$term = $this->get_term( $taxonomy, $use_id );
+
+			$term_feed_link = get_term_feed_link( $term, $taxonomy );
+			$this->assertIsString( $term_feed_link );
+
+			$term_feed_link = get_term_feed_link( $term, '' );
+			$this->assertIsString( $term_feed_link );
+		} else {
+			$this->markTestSkipped( 'This test requires to pass an id to get_term_feed_link()' );
+		}
+	}
+
+	/**
 	 * Data provider.
 	 *
 	 * @return array


### PR DESCRIPTION
## Problem

Backward compatibility is broken since WordPress 5.9-alpha because `get_term_feed_link()` doesn't honor the `$taxonomy` parameter anymore. See https://github.com/WordPress/wordpress-develop/blob/a8485376d27b5b3348a68963f6fd38200b6e64cf/src/wp-includes/link-template.php#L925-L926

For instance, given a post tag term, `get_term_feed_link( $term_id, 'post_tag' )` returns `false` now.

## Changes

Don't use `category` as default taxonomy when passing a term ID.
As the `WP_Term` object is retrieved later, use this to get the taxonomy.


Trac ticket: https://core.trac.wordpress.org/ticket/50225