### PR TITLE
Add wp_after_insert_post call in template controller.

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
@@ -248,10 +248,11 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 
 		if ( 'custom' === $template->source ) {
 			$update = true;
-			$result = wp_update_post( wp_slash( (array) $changes ), true );
+			$result = wp_update_post( wp_slash( (array) $changes ), false );
 		} else {
 			$update = false;
-			$result = wp_insert_post( wp_slash( (array) $changes ), true );
+			$post_before = null;
+			$result = wp_insert_post( wp_slash( (array) $changes ), false );
 		}
 
 		if ( is_wp_error( $result ) ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
@@ -250,9 +250,9 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 			$update = true;
 			$result = wp_update_post( wp_slash( (array) $changes ), false );
 		} else {
-			$update = false;
+			$update      = false;
 			$post_before = null;
-			$result = wp_insert_post( wp_slash( (array) $changes ), false );
+			$result      = wp_insert_post( wp_slash( (array) $changes ), false );
 		}
 
 		if ( is_wp_error( $result ) ) {
@@ -269,7 +269,7 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 		if ( is_wp_error( $fields_update ) ) {
 			return $fields_update;
 		}
-		
+
 		$request->set_param( 'context', 'edit' );
 
 		$post = get_post( $template->wp_id );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/54498
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
