### PR TITLE
[Try] Route based on REQUEST_URI, only falling back to PATH_INFO if we absolutely have to

### DIFF
--- a/src/wp-includes/class-wp.php
+++ b/src/wp-includes/class-wp.php
@@ -892,7 +892,7 @@ function prepare_request_uri() {
  * @return mixed|null
  */
 function get_urlencoded_prefix( $string, $prefix ) {
-	if ( ! str_starts_with( rawurldecode( $string ), $prefix ) ) {
+	if ( ! str_starts_with( rawurldecode( $string ), $prefix ? $prefix . '' : '' ) ) {
 		return null;
 	}
 

--- a/src/wp-includes/class-wp.php
+++ b/src/wp-includes/class-wp.php
@@ -183,7 +183,7 @@ class WP {
 			 * For path info requests, this leaves us with the requesting filename, if any.
 			 * For 404 requests, this leaves us with the requested permalink.
 			 */
-			$req_uri  = str_replace( $pathinfo, '', $req_uri );
+			$req_uri  = prepare_path_info();
 			$req_uri  = trim( $req_uri, '/' );
 			$pathinfo = trim( $pathinfo, '/' );
 			$self     = trim( $self, '/' );
@@ -206,7 +206,7 @@ class WP {
 					$req_uri = '';
 				}
 			}
-			$requested_path = ltrim( prepare_path_info(), '/' );
+			$requested_path = $req_uri;
 			$requested_file = $req_uri;
 
 			$this->request = $requested_path;


### PR DESCRIPTION
Related to https://github.com/WordPress/gutenberg/pull/36881.

This is an attempt at bringing [`preparePathInfo()` from Symfony HTTP Request component](https://github.com/symfony/symfony/blob/859a752d1276c1042040248b2bedd075390da469/src/Symfony/Component/HttpFoundation/Request.php#L1028) into WP Routing so that it doesn't have to rely on PATH_INFO so extensively.

cc @TimothyBJacobs 