### PR TITLE
Fix template resolution to give precedence to child theme PHP templates over parent theme block templates with equal specificity

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -289,11 +289,12 @@ function _get_block_template_file( $template_type, $slug ) {
  * @access private
  * @since 5.9.0
  *
- * @param string $template_type wp_template or wp_template_part.
+ * @param string $template_type   wp_template or wp_template_part.
+ * @param array  $candidate_slugs If specified, only consider files that match slugs in this array.
  *
  * @return array Template.
  */
-function _get_block_templates_files( $template_type ) {
+function _get_block_templates_files( $template_type, $candidate_slugs ) {
 	if ( 'wp_template' !== $template_type && 'wp_template_part' !== $template_type ) {
 		return null;
 	}
@@ -315,6 +316,11 @@ function _get_block_templates_files( $template_type ) {
 				// Subtract ending '.html'.
 				-5
 			);
+
+			if ( ! empty( $candidate_slugs ) && ! in_array( $template_slug, $candidate_slugs, true ) ) {
+				continue;
+			}
+
 			$new_template_item = array(
 				'slug'  => $template_slug,
 				'path'  => $template_file,
@@ -646,7 +652,8 @@ function get_block_templates( $query = array(), $template_type = 'wp_template' )
 	}
 
 	if ( ! isset( $query['wp_id'] ) ) {
-		$template_files = _get_block_templates_files( $template_type );
+		$slug__in = isset( $query['slug__in'] ) ? $query['slug__in'] : null;
+		$template_files = _get_block_templates_files( $template_type, $slug__in );
 		foreach ( $template_files as $template_file ) {
 			$template = _build_block_template_result_from_file( $template_file, $template_type );
 

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -686,7 +686,7 @@ function get_block_templates( $query = array(), $template_type = 'wp_template' )
 			);
 			$fits_area_query =
 				! isset( $query['area'] ) || $template_file['area'] === $query['area'];
-			$should_include  = $is_not_custom && $fits_slug_query && $fits_area_query;
+			$should_include  = $is_not_custom && $fits_area_query;
 			if ( $should_include ) {
 				$query_result[] = $template;
 			}

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -600,6 +600,7 @@ function get_block_templates( $query = array(), $template_type = 'wp_template' )
 	}
 
 	$post_type     = isset( $query['post_type'] ) ? $query['post_type'] : '';
+	$theme         = isset( $query['theme'] ) ? $query['theme'] : wp_get_theme()->get_stylesheet();
 	$wp_query_args = array(
 		'post_status'    => array( 'auto-draft', 'draft', 'publish' ),
 		'post_type'      => $template_type,
@@ -609,7 +610,7 @@ function get_block_templates( $query = array(), $template_type = 'wp_template' )
 			array(
 				'taxonomy' => 'wp_theme',
 				'field'    => 'name',
-				'terms'    => wp_get_theme()->get_stylesheet(),
+				'terms'    => $theme,
 			),
 		),
 	);
@@ -651,17 +652,20 @@ function get_block_templates( $query = array(), $template_type = 'wp_template' )
 	}
 
 	if ( ! isset( $query['wp_id'] ) ) {
+		$parent_theme  = wp_get_theme( $theme )->get_template();
+		$parent_theme  = isset( $parent_theme ) ? $parent_theme : $theme;
+
 		$themes = array_unique(
-			array( get_stylesheet(), get_template() )
+			array( $theme, $parent_theme )
 		);
 
 		$slug__in = isset( $query['slug__in'] ) ? $query['slug__in'] : null;
 
 		$template_files = array();
-		foreach ( $themes as $theme ) {
+		foreach ( $themes as $theme_slug ) {
 			$template_files = array_merge(
 				$template_files,
-				_get_block_templates_files( $template_type, $theme, $slug__in )
+				_get_block_templates_files( $template_type, $theme_slug, $slug__in )
 			);
 		}
 

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -570,6 +570,7 @@ function _build_block_template_result_from_post( $post ) {
  *     @type int    $wp_id     Post ID of customized template.
  *     @type string $area      A 'wp_template_part_area' taxonomy value to filter by (for wp_template_part template type only).
  *     @type string $post_type Post type to get the templates for.
+ *     @type string $theme     Theme in which to look for template files.
  * }
  * @param array $template_type wp_template or wp_template_part.
  *

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -673,8 +673,6 @@ function get_block_templates( $query = array(), $template_type = 'wp_template' )
 				array_column( $query_result, 'id' ),
 				true
 			);
-			$fits_slug_query =
-				! isset( $query['slug__in'] ) || in_array( $template_file['slug'], $query['slug__in'], true );
 			$fits_area_query =
 				! isset( $query['area'] ) || $template_file['area'] === $query['area'];
 			$should_include  = $is_not_custom && $fits_slug_query && $fits_area_query;

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -655,7 +655,7 @@ function get_block_templates( $query = array(), $template_type = 'wp_template' )
 			array( get_stylesheet(), get_template() )
 		);
 
-		$slug__in       = isset( $query['slug__in'] ) ? $query['slug__in'] : null;
+		$slug__in = isset( $query['slug__in'] ) ? $query['slug__in'] : null;
 
 		$template_files = array();
 		foreach ( $themes as $theme ) {

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -317,7 +317,7 @@ function _get_block_templates_files( $template_type, $theme, $candidate_slugs ) 
 			-5
 		);
 
-		if ( ! empty( $candidate_slugs ) && ! in_array( $template_slug, $candidate_slugs, true ) ) {
+		if ( isset( $candidate_slugs ) && ! in_array( $template_slug, $candidate_slugs, true ) ) {
 			continue;
 		}
 

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -592,6 +592,7 @@ function get_block_templates( $query = array(), $template_type = 'wp_template' )
 	 *     @type array  $slug__in List of slugs to include.
 	 *     @type int    $wp_id Post ID of customized template.
 	 *     @type string $post_type Post type to get the templates for.
+	 *     @type string $theme Theme in which to look for template files.
 	 * }
 	 * @param array $template_type wp_template or wp_template_part.
 	 */

--- a/src/wp-includes/block-template.php
+++ b/src/wp-includes/block-template.php
@@ -45,7 +45,7 @@ function locate_block_template( $template, $type, array $templates ) {
 		$templates = array_slice( $templates, 0, $index + 1 );
 	}
 
-	$block_template = resolve_block_template( $type, $templates );
+	$block_template = resolve_block_template( $type, $templates, $template );
 
 	if ( $block_template ) {
 		if ( empty( $block_template->content ) && is_user_logged_in() ) {
@@ -97,7 +97,7 @@ function locate_block_template( $template, $type, array $templates ) {
  * @param string[] $template_hierarchy The current template hierarchy, ordered by priority.
  * @return WP_Block_Template|null template A template object, or null if none could be found.
  */
-function resolve_block_template( $template_type, $template_hierarchy ) {
+function resolve_block_template( $template_type, $template_hierarchy, $fallback_template ) {
 	if ( ! $template_type ) {
 		return null;
 	}
@@ -116,7 +116,7 @@ function resolve_block_template( $template_type, $template_hierarchy ) {
 		'theme'    => wp_get_theme()->get_stylesheet(),
 		'slug__in' => $slugs,
 	);
-	$templates = get_block_templates( $query );
+	$templates = get_block_templates( $query, 'wp_template', $fallback_template );
 
 	// Order these templates per slug priority.
 	// Build map of template slugs to their priority in the current hierarchy.

--- a/tests/phpunit/tests/block-template.php
+++ b/tests/phpunit/tests/block-template.php
@@ -89,6 +89,7 @@ class Tests_Block_Template extends WP_UnitTestCase {
 	 * otherwise equal specificity.
 	 *
 	 * Covers https://github.com/WordPress/gutenberg/pull/31123.
+	 * Covers https://core.trac.wordpress.org/ticket/54515.
 	 *
 	 */
 	function test_child_theme_php_template_takes_precedence_over_equally_specific_parent_theme_block_template() {

--- a/tests/phpunit/tests/block-template.php
+++ b/tests/phpunit/tests/block-template.php
@@ -92,13 +92,6 @@ class Tests_Block_Template extends WP_UnitTestCase {
 	 *
 	 */
 	function test_child_theme_php_template_takes_precedence_over_equally_specific_parent_theme_block_template() {
-		/**
-		 * @todo This test is currently marked as skipped, since it wouldn't pass. Turns out that in Gutenberg,
-		 * it only passed due to a erroneous test setup.
-		 * For details, see https://github.com/WordPress/wordpress-develop/pull/1920#issuecomment-975929818.
-		 */
-		$this->markTestSkipped( 'The block template resolution algorithm needs fixing in order for this test to pass.' );
-
 		switch_theme( 'block-theme-child' );
 
 		$page_slug_template      = 'page-home.php';


### PR DESCRIPTION
WIP. Description of the issue (as found in the corresponding Trac ticket) below:

---

When a theme has a PHP template of a certain specificity (e.g. `page-home.php`), and it happens to be a child theme of another theme which has a block template for the same specificity (e.g. `page-home.html`), WordPress will currently pick the parent theme’s block template over the child theme's PHP template to render the page.

This is a regression. If the PHP and block template have equal specificity, the child theme's template should be used. This issue was fixed before in https://github.com/WordPress/gutenberg/pull/31123. The relevant logic has since been modified and eventually [backported to Core](https://github.com/WordPress/wordpress-develop/pull/1796) , so the fix now needs to happen in Core (plus GB's [pre-WP-5.9 compat layer](https://github.com/WordPress/gutenberg/tree/3633b1758be0840f017e9407463a231689c49e3d/lib/compat/wordpress-5.9), but that's somewhat secondary).

We have a [unit test for this](https://github.com/WordPress/wordpress-develop/blob/21a7515fdb28ee10aa2f831d6d5786a6518283c9/tests/phpunit/tests/block-template.php#L86-L114) (but obviously had to disable it). The unit test existed in Gutenberg before but didn’t fail there due to a faulty test setup. In fact, the issue was only found while [backporting](https://github.com/WordPress/wordpress-develop/pull/1920#issuecomment-975929818) the unit test.

Trac ticket: https://core.trac.wordpress.org/ticket/54515

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
