### PR TITLE
Feeds: Remove reference to `wp-atom.php` in Atom feeds `xml:base`

### DIFF
--- a/src/wp-includes/feed-atom.php
+++ b/src/wp-includes/feed-atom.php
@@ -17,7 +17,6 @@ do_action( 'rss_tag_pre', 'atom' );
 	xmlns="http://www.w3.org/2005/Atom"
 	xmlns:thr="http://purl.org/syndication/thread/1.0"
 	xml:lang="<?php bloginfo_rss( 'language' ); ?>"
-	xml:base="<?php bloginfo_rss( 'url' ); ?>/wp-atom.php"
 	<?php
 	/**
 	 * Fires at end of the Atom feed root to add namespaces.

--- a/tests/phpunit/tests/feed/atom.php
+++ b/tests/phpunit/tests/feed/atom.php
@@ -99,7 +99,6 @@ class Tests_Feed_Atom extends WP_UnitTestCase {
 		// Verify attributes.
 		$this->assertSame( 'http://www.w3.org/2005/Atom', $atom[0]['attributes']['xmlns'] );
 		$this->assertSame( 'http://purl.org/syndication/thread/1.0', $atom[0]['attributes']['xmlns:thr'] );
-		$this->assertSame( site_url( '/wp-atom.php' ), $atom[0]['attributes']['xml:base'] );
 
 		// Verify the <feed> element is present and contains a <title> child element.
 		$title = xml_find( $xml, 'feed', 'title' );


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/47955

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
