### PR TITLE
Allow `wp_enqueue_script()` before `wp_register_script()` to work

### DIFF
--- a/src/wp-includes/class.wp-dependencies.php
+++ b/src/wp-includes/class.wp-dependencies.php
@@ -97,7 +97,7 @@ class WP_Dependencies {
 	/**
 	 * List of assets enqueued before details were registered.
 	 *
-	 * @since 5.9.9
+	 * @since 5.9.0
 	 *
 	 * @var array
 	 */

--- a/src/wp-includes/class.wp-dependencies.php
+++ b/src/wp-includes/class.wp-dependencies.php
@@ -95,6 +95,15 @@ class WP_Dependencies {
 	private $all_queued_deps;
 
 	/**
+	 * List of assets enqueued before details were registered.
+	 *
+	 * @since 9.9.9
+	 *
+	 * @var array
+	 */
+	private $queued_before_register = [];
+
+	/**
 	 * Processes the items and dependencies.
 	 *
 	 * Processes the items passed to it or the queue, and their dependencies.
@@ -248,6 +257,19 @@ class WP_Dependencies {
 			return false;
 		}
 		$this->registered[ $handle ] = new _WP_Dependency( $handle, $src, $deps, $ver, $args );
+
+		// If the item was enqueued before the details were registered, enqueue it now.
+		if ( array_key_exists( $handle, $this->queued_before_register ) ) {
+
+			if ( ! is_null( $this->queued_before_register[ $handle ] ) ) {
+				$this->enqueue( $handle . '?' . $this->queued_before_register[ $handle ] );
+			} else {
+				$this->enqueue( $handle );
+			}
+
+			unset( $this->queued_before_register[ $handle ] );
+		}
+
 		return true;
 	}
 
@@ -334,6 +356,12 @@ class WP_Dependencies {
 				if ( isset( $handle[1] ) ) {
 					$this->args[ $handle[0] ] = $handle[1];
 				}
+			} else if ( ! isset( $this->registered[ $handle[0] ] ) ) {
+				$this->queued_before_register[ $handle[0] ] = null; // $args
+
+				if ( isset( $handle[1] ) ) {
+					$this->queued_before_register[ $handle[0] ] = $handle[1];
+				}
 			}
 		}
 	}
@@ -360,6 +388,8 @@ class WP_Dependencies {
 
 				unset( $this->queue[ $key ] );
 				unset( $this->args[ $handle[0] ] );
+			} else if ( isset( $this->queued_before_register[ $handle[0] ] ) ) {
+				unset( $this->queued_before_register[ $handle[0] ] );
 			}
 		}
 	}

--- a/src/wp-includes/class.wp-dependencies.php
+++ b/src/wp-includes/class.wp-dependencies.php
@@ -97,7 +97,7 @@ class WP_Dependencies {
 	/**
 	 * List of assets enqueued before details were registered.
 	 *
-	 * @since 9.9.9
+	 * @since 5.9.9
 	 *
 	 * @var array
 	 */

--- a/src/wp-includes/class.wp-dependencies.php
+++ b/src/wp-includes/class.wp-dependencies.php
@@ -388,7 +388,7 @@ class WP_Dependencies {
 
 				unset( $this->queue[ $key ] );
 				unset( $this->args[ $handle[0] ] );
-			} else if ( isset( $this->queued_before_register[ $handle[0] ] ) ) {
+			} else if ( array_key_exists( $handle[0], $this->queued_before_register ) ) {
 				unset( $this->queued_before_register[ $handle[0] ] );
 			}
 		}

--- a/src/wp-includes/class.wp-dependencies.php
+++ b/src/wp-includes/class.wp-dependencies.php
@@ -101,7 +101,7 @@ class WP_Dependencies {
 	 *
 	 * @var array
 	 */
-	private $queued_before_register = [];
+	private $queued_before_register = array();
 
 	/**
 	 * Processes the items and dependencies.

--- a/tests/phpunit/tests/dependencies.php
+++ b/tests/phpunit/tests/dependencies.php
@@ -136,4 +136,18 @@ class Tests_Dependencies extends WP_UnitTestCase {
 		$this->assertFalse( $dep->query( 'one' ) );
 
 	}
+
+	function test_enqueue_before_register() {
+		$dep = new WP_Dependencies;
+
+		$this->assertArrayNotHasKey( $dep->registered, 'one' );
+
+		$dep->enqueue( 'one' );
+
+		$this->assertArrayNotHasKey( $dep->queue, 'one' );
+
+		$this->assertTrue( $dep->add( 'one', '' ) );
+
+		$this->assertArrayHasKey( $dep->queue, 'one' );
+	}
 }

--- a/tests/phpunit/tests/dependencies.php
+++ b/tests/phpunit/tests/dependencies.php
@@ -144,10 +144,10 @@ class Tests_Dependencies extends WP_UnitTestCase {
 
 		$dep->enqueue( 'one' );
 
-		$this->assertArrayNotHasKey( 'one', $dep->queue );
+		$this->assertNotContains( 'one', $dep->queue );
 
 		$this->assertTrue( $dep->add( 'one', '' ) );
 
-		$this->assertArrayHasKey( 'one', $dep->queue );
+		$this->assertContains( 'one', $dep->queue );
 	}
 }

--- a/tests/phpunit/tests/dependencies.php
+++ b/tests/phpunit/tests/dependencies.php
@@ -140,14 +140,14 @@ class Tests_Dependencies extends WP_UnitTestCase {
 	function test_enqueue_before_register() {
 		$dep = new WP_Dependencies;
 
-		$this->assertArrayNotHasKey( $dep->registered, 'one' );
+		$this->assertArrayNotHasKey( 'one', $dep->registered );
 
 		$dep->enqueue( 'one' );
 
-		$this->assertArrayNotHasKey( $dep->queue, 'one' );
+		$this->assertArrayNotHasKey( 'one', $dep->queue );
 
 		$this->assertTrue( $dep->add( 'one', '' ) );
 
-		$this->assertArrayHasKey( $dep->queue, 'one' );
+		$this->assertArrayHasKey( 'one', $dep->queue );
 	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/54529

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
