### PR TITLE
Default palette & gradients are opt-out for themes with `theme.json`

### DIFF
--- a/src/wp-includes/theme.json
+++ b/src/wp-includes/theme.json
@@ -8,11 +8,13 @@
 			"width": false
 		},
 		"color": {
+			"background": true,
 			"custom": true,
 			"customDuotone": true,
  			"customGradient": true,
+			"defaultPalette": true,
+			"defaultGradients": true,
  			"link": false,
-			"background": true,
 			"text": true,
 			"duotone": [
 				{


### PR DESCRIPTION
I've noticed that we've missed backporting some changes from https://github.com/WordPress/gutenberg/pull/36622 in this backport https://github.com/WordPress/wordpress-develop/pull/1928 

Specifically, we've missed the changes to WordPress core `theme.json` file, which includes the defaults. As a result, themes with `theme.json` won't see the default palette & gradients.

## How to test

- Use the TwentyTwentyTwo theme.
- Go to the post editor and add a paragraph.
- Open the block inspector and the color panel.

The expected result is that the color panel shows colors from the default and theme palettes. In `trunk` it only shows the theme palette.