### PR TITLE
Add missing flags in `theme.json`

### DIFF
--- a/src/wp-includes/theme.json
+++ b/src/wp-includes/theme.json
@@ -1,6 +1,7 @@
 {
 	"version": 2,
 	"settings": {
+		"appearanceTools": false,
 		"border": {
 			"color": false,
 			"radius": false,

--- a/src/wp-includes/theme.json
+++ b/src/wp-includes/theme.json
@@ -8,12 +8,12 @@
 			"width": false
 		},
 		"color": {
+			"background": true,
 			"custom": true,
 			"customDuotone": true,
  			"customGradient": true,
- 			"link": false,
-			"background": true,
-			"text": true,
+			"defaultGradients": true,
+			"defaultPalette": true,
 			"duotone": [
 				{
 					"name":  "Dark grayscale" ,
@@ -118,6 +118,7 @@
 					"slug": "midnight"
 				}
 			],
+			"link": false,
 			"palette": [
 				{
 					"name": "Black",
@@ -179,7 +180,8 @@
 					"slug": "vivid-purple",
 					"color": "#9b51e0"
 				}
-			]
+			],
+			"text": true
 		},
 		"spacing": {
 			"blockGap": null,
@@ -190,12 +192,6 @@
 		"typography": {
 			"customFontSize": true,
 			"dropCap": true,
-			"fontStyle": true,
-			"fontWeight": true,
-			"letterSpacing": true,
-			"lineHeight": false,
-			"textDecoration": true,
-			"textTransform": true,
 			"fontSizes": [
 				{
 					"name": "Small",
@@ -222,7 +218,13 @@
 					"slug": "huge",
 					"size": "42px"
 				}
-			]
+			],
+			"fontStyle": true,
+			"fontWeight": true,
+			"letterSpacing": true,
+			"lineHeight": false,
+			"textDecoration": true,
+			"textTransform": true
 		},
 		"blocks": {
 			"core/button": {


### PR DESCRIPTION
To be merged alongside https://github.com/WordPress/wordpress-develop/pull/1967

This PR does the following:

Add flag `appearanceTools`.

- It was part of https://github.com/WordPress/gutenberg/pull/36646 that is being backported at https://github.com/WordPress/wordpress-develop/pull/1967 but the `theme.json` changes are missing.

Add flags `defaultPalette` and `defaultGradients`.

- They were part of https://github.com/WordPress/gutenberg/pull/36622 that was backported at https://github.com/WordPress/wordpress-develop/pull/1928 but the `theme.json` changes were missed.

Sort keys alphabetically so it's easier to compare this with Gutenberg.

- Related Gutenberg PR https://github.com/WordPress/gutenberg/pull/36968

