### PR TITLE
Bring infinite scroll setting into the JS function (Trac 53765)

### DIFF
--- a/src/js/media/controllers/featured-image.js
+++ b/src/js/media/controllers/featured-image.js
@@ -108,6 +108,7 @@ FeaturedImage = Library.extend(/** @lends wp.media.controller.FeaturedImage.prot
 		var selection = this.get('selection'),
 			library = this.get('library'),
 			id = wp.media.view.settings.post.featuredImageId,
+			infiniteScrolling = wp.media.view.settings.infiniteScrolling,
 			attachment;
 
 		if ( '' !== id && -1 !== id ) {
@@ -117,7 +118,7 @@ FeaturedImage = Library.extend(/** @lends wp.media.controller.FeaturedImage.prot
 
 		selection.reset( attachment ? [ attachment ] : [] );
 
-		if ( ! infinite_scrolling && library.hasMore() ) {
+		if ( ! infiniteScrolling && library.hasMore() ) {
 			library.more();
 		}
 	}

--- a/src/js/media/controllers/replace-image.js
+++ b/src/js/media/controllers/replace-image.js
@@ -105,7 +105,7 @@ ReplaceImage = Library.extend(/** @lends wp.media.controller.ReplaceImage.protot
 
 		selection.reset( attachment ? [ attachment ] : [] );
 
-		if ( ! infiniteScrolling && library.getTotalAttachments() == 0 && library.hasMore() ) {
+		if ( ! infiniteScrolling && library.getTotalAttachments() === 0 && library.hasMore() ) {
 			library.more();
 		}
 	}

--- a/src/js/media/controllers/replace-image.js
+++ b/src/js/media/controllers/replace-image.js
@@ -100,11 +100,12 @@ ReplaceImage = Library.extend(/** @lends wp.media.controller.ReplaceImage.protot
 	updateSelection: function() {
 		var selection = this.get('selection'),
 			library = this.get('library'),
-			attachment = this.image.attachment;
+			attachment = this.image.attachment,
+			infiniteScrolling = wp.media.view.settings.infiniteScrolling;
 
 		selection.reset( attachment ? [ attachment ] : [] );
 
-		if ( ! infinite_scrolling && library.getTotalAttachments() == 0 && library.hasMore() ) {
+		if ( ! infiniteScrolling && library.getTotalAttachments() == 0 && library.hasMore() ) {
 			library.more();
 		}
 	}


### PR DESCRIPTION
Follow-up to [52287](https://core.trac.wordpress.org/changeset/52287) which brings the global infinite scroll setting into the functions and changes from snake_case to camelCase for consistency and JS coding standards.

Trac ticket: https://core.trac.wordpress.org/ticket/53765

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
