### PR TITLE
Fix template resolution to give precedence to child theme PHP templates over parent theme block templates with equal specificity (alternative approach)

### DIFF
--- a/src/wp-includes/block-template.php
+++ b/src/wp-includes/block-template.php
@@ -160,7 +160,7 @@ function resolve_block_template( $template_type, $template_hierarchy, $fallback_
 			// -- not its parent -- once we edit it and store it to the DB as a wp_template CPT.)
 			// Instead, we use _get_block_template_file() to locate the block template file.
 			$template_file = _get_block_template_file( 'wp_template', $fallback_template_slug );
-			if ( get_template() === $template_file['theme'] ) {
+			if ( $template_file && get_template() === $template_file['theme'] ) {
 				// The block template is part of the parent theme, so we
 				// have to give precedence to the child theme's PHP template.
 				array_shift( $templates );

--- a/src/wp-includes/block-template.php
+++ b/src/wp-includes/block-template.php
@@ -96,7 +96,7 @@ function locate_block_template( $template, $type, array $templates ) {
  *
  * @param string   $template_type      The current template type.
  * @param string[] $template_hierarchy The current template hierarchy, ordered by priority.
- * @param string   $fallback_template  A PHP fallback template to use if no block matching template is found.
+ * @param string   $fallback_template  A PHP fallback template to use if no matching block template is found.
  * @return WP_Block_Template|null template A template object, or null if none could be found.
  */
 function resolve_block_template( $template_type, $template_hierarchy, $fallback_template ) {

--- a/src/wp-includes/block-template.php
+++ b/src/wp-includes/block-template.php
@@ -45,7 +45,7 @@ function locate_block_template( $template, $type, array $templates ) {
 		$templates = array_slice( $templates, 0, $index + 1 );
 	}
 
-	$block_template = resolve_block_template( $type, $templates );
+	$block_template = resolve_block_template( $type, $templates, $template );
 
 	if ( $block_template ) {
 		if ( empty( $block_template->content ) && is_user_logged_in() ) {
@@ -92,12 +92,14 @@ function locate_block_template( $template, $type, array $templates ) {
  *
  * @access private
  * @since 5.8.0
+ * @since 5.9.0 Added the `$fallback_template` parameter.
  *
  * @param string   $template_type      The current template type.
  * @param string[] $template_hierarchy The current template hierarchy, ordered by priority.
+ * @param string   $fallback_template  A PHP fallback template to use if no block matching template is found.
  * @return WP_Block_Template|null template A template object, or null if none could be found.
  */
-function resolve_block_template( $template_type, $template_hierarchy ) {
+function resolve_block_template( $template_type, $template_hierarchy, $fallback_template ) {
 	if ( ! $template_type ) {
 		return null;
 	}
@@ -128,6 +130,43 @@ function resolve_block_template( $template_type, $template_hierarchy ) {
 			return $slug_priorities[ $template_a->slug ] - $slug_priorities[ $template_b->slug ];
 		}
 	);
+
+	$theme_base_path        = get_stylesheet_directory() . DIRECTORY_SEPARATOR;
+	$parent_theme_base_path = get_template_directory() . DIRECTORY_SEPARATOR;
+
+	// Is the current theme a child theme, and is the PHP fallback template part of it?
+	if (
+		strpos( $fallback_template, $theme_base_path ) === 0 &&
+		strpos( $fallback_template, $parent_theme_base_path ) === false
+	) {
+		$fallback_template_slug = substr(
+			$fallback_template,
+			// Starting position of slug.
+			strpos( $fallback_template, $theme_base_path ) + strlen( $theme_base_path ),
+			// Remove '.php' suffix.
+			-4
+		);
+
+		// Is our candidate block template's slug identical to our PHP fallback template's?
+		if (
+			count( $templates ) &&
+			$fallback_template_slug === $templates[0]->slug &&
+			'theme' === $templates[0]->source
+		) {
+			// Unfortunately, we cannot trust $templates[0]->theme, since it will always
+			// be set to the current theme's slug by _build_block_template_result_from_file(),
+			// even if the block template is really coming from the current theme's parent.
+			// (The reason for this is that we want it to be associated with the current theme
+			// -- not its parent -- once we edit it and store it to the DB as a wp_template CPT.)
+			// Instead, we use _get_block_template_file() to locate the block template file.
+			$template_file = _get_block_template_file( 'wp_template', $fallback_template_slug );
+			if ( get_template() === $template_file['theme'] ) {
+				// The block template is part of the parent theme, so we
+				// have to give precedence to the child theme's PHP template.
+				array_shift( $templates );
+			}
+		}
+	}
 
 	return count( $templates ) ? $templates[0] : null;
 }

--- a/tests/phpunit/tests/block-template.php
+++ b/tests/phpunit/tests/block-template.php
@@ -89,6 +89,7 @@ class Tests_Block_Template extends WP_UnitTestCase {
 	 * otherwise equal specificity.
 	 *
 	 * Covers https://github.com/WordPress/gutenberg/pull/31123.
+	 * Covers https://core.trac.wordpress.org/ticket/54515.
 	 *
 	 */
 	function test_child_theme_php_template_takes_precedence_over_equally_specific_parent_theme_block_template() {

--- a/tests/phpunit/tests/block-template.php
+++ b/tests/phpunit/tests/block-template.php
@@ -92,13 +92,6 @@ class Tests_Block_Template extends WP_UnitTestCase {
 	 *
 	 */
 	function test_child_theme_php_template_takes_precedence_over_equally_specific_parent_theme_block_template() {
-		/**
-		 * @todo This test is currently marked as skipped, since it wouldn't pass. Turns out that in Gutenberg,
-		 * it only passed due to a erroneous test setup.
-		 * For details, see https://github.com/WordPress/wordpress-develop/pull/1920#issuecomment-975929818.
-		 */
-		$this->markTestSkipped( 'The block template resolution algorithm needs fixing in order for this test to pass.' );
-
 		switch_theme( 'block-theme-child' );
 
 		$page_slug_template      = 'page-home.php';


### PR DESCRIPTION
Alternative approach to #1961. For a general idea of the challenges that a solution to this issue faces, and some design choices, see the code comments in the diff.

Make sure to smoke test with an FSE theme.

Description of the issue (as found in the corresponding Trac ticket) below:

---

When a theme has a PHP template of a certain specificity (e.g. `page-home.php`), and it happens to be a child theme of another theme which has a block template for the same specificity (e.g. `page-home.html`), WordPress will currently pick the parent theme’s block template over the child theme's PHP template to render the page.

This is a regression. If the PHP and block template have equal specificity, the child theme's template should be used. This issue was fixed before in https://github.com/WordPress/gutenberg/pull/31123. The relevant logic has since been modified and eventually [backported to Core](https://github.com/WordPress/wordpress-develop/pull/1796) , so the fix now needs to happen in Core (plus GB's [pre-WP-5.9 compat layer](https://github.com/WordPress/gutenberg/tree/3633b1758be0840f017e9407463a231689c49e3d/lib/compat/wordpress-5.9), but that's somewhat secondary).

We have a [unit test for this](https://github.com/WordPress/wordpress-develop/blob/21a7515fdb28ee10aa2f831d6d5786a6518283c9/tests/phpunit/tests/block-template.php#L86-L114) (but obviously had to disable it). The unit test existed in Gutenberg before but didn’t fail there due to a faulty test setup. In fact, the issue was only found while [backporting](https://github.com/WordPress/wordpress-develop/pull/1920#issuecomment-975929818) the unit test.

Trac ticket: https://core.trac.wordpress.org/ticket/54515

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
