### PR TITLE
Block Template Utils: Enable currently incomplete unit test

### DIFF
--- a/tests/phpunit/data/themedir1/block-theme/parts/small-header.html
+++ b/tests/phpunit/data/themedir1/block-theme/parts/small-header.html
@@ -1,0 +1,3 @@
+<!-- wp:paragraph -->
+<p>Small Header Template Part</p>
+<!-- /wp:paragraph -->

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -15,8 +15,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 	private static $template_part_post;
 
 	public static function wpSetUpBeforeClass() {
-		// We may need a block theme.
-		// switch_theme( 'tt1-blocks' );
+		switch_theme( 'block-theme' );
 
 		// Set up a template post corresponding to a different theme.
 		// We do this to ensure resolution and slug creation works as expected,
@@ -225,9 +224,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 	 * Should retrieve the template from the theme files.
 	 */
 	function test_get_block_template_from_file() {
-		$this->markTestIncomplete();
-		// Requires switching to a block theme.
-		/* $id       = get_stylesheet() . '//' . 'index';
+		$id       = get_stylesheet() . '//' . 'index';
 		$template = get_block_template( $id, 'wp_template' );
 		$this->assertSame( $id, $template->id );
 		$this->assertSame( get_stylesheet(), $template->theme );
@@ -237,16 +234,15 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		$this->assertSame( 'wp_template', $template->type );
 
 		// Test template parts.
-		$id       = get_stylesheet() . '//' . 'header';
+		$id       = get_stylesheet() . '//' . 'small-header';
 		$template = get_block_template( $id, 'wp_template_part' );
 		$this->assertSame( $id, $template->id );
 		$this->assertSame( get_stylesheet(), $template->theme );
-		$this->assertSame( 'header', $template->slug );
+		$this->assertSame( 'small-header', $template->slug );
 		$this->assertSame( 'publish', $template->status );
 		$this->assertSame( 'theme', $template->source );
 		$this->assertSame( 'wp_template_part', $template->type );
 		$this->assertSame( WP_TEMPLATE_PART_AREA_HEADER, $template->area );
-		*/
 	}
 
 	/**

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -13,10 +13,9 @@
 class Tests_Block_Template_Utils extends WP_UnitTestCase {
 	private static $post;
 	private static $template_part_post;
+	private static $test_theme = 'block-theme';
 
 	public static function wpSetUpBeforeClass() {
-		switch_theme( 'block-theme' );
-
 		// Set up a template post corresponding to a different theme.
 		// We do this to ensure resolution and slug creation works as expected,
 		// even with another post of that same name present for another theme.
@@ -44,12 +43,12 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 			'post_excerpt' => 'Description of my template',
 			'tax_input'    => array(
 				'wp_theme' => array(
-					get_stylesheet(),
+					self::$test_theme,
 				),
 			),
 		);
 		self::$post = self::factory()->post->create_and_get( $args );
-		wp_set_post_terms( self::$post->ID, get_stylesheet(), 'wp_theme' );
+		wp_set_post_terms( self::$post->ID, self::$test_theme, 'wp_theme' );
 
 		// Set up template part post.
 		$template_part_args       = array(
@@ -60,7 +59,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 			'post_excerpt' => 'Description of my template part',
 			'tax_input'    => array(
 				'wp_theme'              => array(
-					get_stylesheet(),
+					self::$test_theme,
 				),
 				'wp_template_part_area' => array(
 					WP_TEMPLATE_PART_AREA_HEADER,
@@ -69,7 +68,12 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		);
 		self::$template_part_post = self::factory()->post->create_and_get( $template_part_args );
 		wp_set_post_terms( self::$template_part_post->ID, WP_TEMPLATE_PART_AREA_HEADER, 'wp_template_part_area' );
-		wp_set_post_terms( self::$template_part_post->ID, get_stylesheet(), 'wp_theme' );
+		wp_set_post_terms( self::$template_part_post->ID, self::$test_theme, 'wp_theme' );
+	}
+
+	public function set_up() {
+		parent::set_up();
+		switch_theme( self::$test_theme );
 	}
 
 	public static function wpTearDownAfterClass() {


### PR DESCRIPTION
We currently have one Block Template Utils unit test [marked as incomplete](https://github.com/WordPress/wordpress-develop/blob/1db73227b6358e9d9e766f60d5d86696a48352f9/tests/phpunit/tests/block-template-utils.php#L224-L229), as it needs a block template theme, which at the time the test was backported from Gutenberg wasn't yet available.

We should enable it now that we have both Twenty Twenty Two and the `block-theme` and `block-theme-child` test fixture block template themes are available.

Trac ticket: https://core.trac.wordpress.org/ticket/54551

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
