### PR TITLE
Make `?_wp-find-template=true` work for new posts

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -185,6 +185,20 @@ function get_default_block_template_types() {
 }
 
 /**
+ * Return a list of all overrideable default template type slugs.
+ *
+ * @see get_query_template
+ *
+ * @access private
+ * @since 5.9.0
+ *
+ * @return string[] List of all overrideable default template type slugs.
+ */
+function _get_template_type_slugs() {
+	return array_keys( get_default_block_template_types() );
+}
+
+/**
  * Checks whether the input 'area' is a supported value.
  * Returns the input if supported, otherwise returns the 'uncategorized' value.
  *

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -185,20 +185,6 @@ function get_default_block_template_types() {
 }
 
 /**
- * Return a list of all overrideable default template type slugs.
- *
- * @see get_query_template
- *
- * @access private
- * @since 5.9.0
- *
- * @return string[] List of all overrideable default template type slugs.
- */
-function _get_template_type_slugs() {
-	return array_keys( get_default_block_template_types() );
-}
-
-/**
  * Checks whether the input 'area' is a supported value.
  * Returns the input if supported, otherwise returns the 'uncategorized' value.
  *

--- a/src/wp-includes/block-template.php
+++ b/src/wp-includes/block-template.php
@@ -29,8 +29,6 @@ function _add_template_loader_filters() {
 	}
 }
 
-add_action( 'wp_loaded', '_add_template_loader_filters' );
-
 /**
  * Find a block template with equal or higher specificity than a given PHP template file.
  *

--- a/src/wp-includes/block-template.php
+++ b/src/wp-includes/block-template.php
@@ -16,7 +16,8 @@ function _add_template_loader_filters() {
 		return;
 	}
 
-	foreach ( _get_template_type_slugs() as $template_type ) {
+	$template_types = array_keys( get_default_block_template_types() );
+	foreach ( $template_types as $template_type ) {
 		if ( 'embed' === $template_type ) { // Skip 'embed' for now because it is not a regular template type.
 			continue;
 		}

--- a/src/wp-includes/block-template.php
+++ b/src/wp-includes/block-template.php
@@ -6,6 +6,31 @@
  */
 
 /**
+ * Adds necessary filters to use 'wp_template' posts instead of theme template files.
+ *
+ * @since 5.9.0
+ */
+function add_template_loader_filters() {
+	if ( ! current_theme_supports( 'block-templates' ) ) {
+		return;
+	}
+
+	foreach ( _get_template_type_slugs() as $template_type ) {
+		if ( 'embed' === $template_type ) { // Skip 'embed' for now because it is not a regular template type.
+			continue;
+		}
+		add_filter( str_replace( '-', '', $template_type ) . '_template', 'locate_block_template', 20, 3 );
+	}
+
+	// Request to resolve a template.
+	if ( isset( $_GET['_wp-find-template'] ) ) {
+		add_filter( 'pre_get_posts', '_resolve_template_for_new_post' );
+	}
+}
+
+add_action( 'wp_loaded', 'add_template_loader_filters' );
+
+/**
  * Find a block template with equal or higher specificity than a given PHP template file.
  *
  * Internally, this communicates the block content that needs to be used by the template canvas through a global variable.
@@ -226,4 +251,36 @@ function _block_template_render_without_post_block_context( $context ) {
 	}
 
 	return $context;
+}
+
+/**
+ * Sets the current WP_Query to return auto-draft posts.
+ *
+ * The auto-draft status indicates a new post, so allow the the WP_Query instance to
+ * return an auto-draft post for template resolution when editing a new post.
+ *
+ * @since 5.9.0
+ *
+ * @param WP_Query $wp_query Current WP_Query instance, passed by reference.
+ * @return void
+ */
+function _resolve_template_for_new_post( $wp_query ) {
+	remove_filter( 'pre_get_posts', '_resolve_template_for_new_post' );
+
+	// Pages.
+	$page_id = isset( $wp_query->query['page_id'] ) ? $wp_query->query['page_id'] : null;
+
+	// Posts, including custom post types.
+	$p = isset( $wp_query->query['p'] ) ? $wp_query->query['p'] : null;
+
+	$post_id = $page_id ? $page_id : $p;
+	$post    = get_post( $post_id );
+
+	if (
+		$post &&
+		'auto-draft' === $post->post_status &&
+		current_user_can( 'edit_post', $post->ID )
+	) {
+		$wp_query->set( 'post_status', 'auto-draft' );
+	}
 }

--- a/src/wp-includes/block-template.php
+++ b/src/wp-includes/block-template.php
@@ -8,8 +8,8 @@
 /**
  * Adds necessary filters to use 'wp_template' posts instead of theme template files.
  *
-  * @access private
-  * @since 5.9.0
+ * @access private
+ * @since 5.9.0
  */
 function _add_template_loader_filters() {
 	if ( ! current_theme_supports( 'block-templates' ) ) {

--- a/src/wp-includes/block-template.php
+++ b/src/wp-includes/block-template.php
@@ -8,9 +8,10 @@
 /**
  * Adds necessary filters to use 'wp_template' posts instead of theme template files.
  *
- * @since 5.9.0
+  * @access private
+  * @since 5.9.0
  */
-function add_template_loader_filters() {
+function _add_template_loader_filters() {
 	if ( ! current_theme_supports( 'block-templates' ) ) {
 		return;
 	}
@@ -28,7 +29,7 @@ function add_template_loader_filters() {
 	}
 }
 
-add_action( 'wp_loaded', 'add_template_loader_filters' );
+add_action( 'wp_loaded', '_add_template_loader_filters' );
 
 /**
  * Find a block template with equal or higher specificity than a given PHP template file.
@@ -259,10 +260,10 @@ function _block_template_render_without_post_block_context( $context ) {
  * The auto-draft status indicates a new post, so allow the the WP_Query instance to
  * return an auto-draft post for template resolution when editing a new post.
  *
+ * @access private
  * @since 5.9.0
  *
  * @param WP_Query $wp_query Current WP_Query instance, passed by reference.
- * @return void
  */
 function _resolve_template_for_new_post( $wp_query ) {
 	remove_filter( 'pre_get_posts', '_resolve_template_for_new_post' );

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -680,5 +680,6 @@ add_filter( 'pre_wp_unique_post_slug', 'wp_filter_wp_template_unique_post_slug',
 add_action( 'save_post_wp_template_part', 'wp_set_unique_slug_on_create_template_part' );
 add_action( 'wp_footer', 'the_block_template_skip_link' );
 add_action( 'setup_theme', 'wp_enable_block_templates' );
+add_action( 'wp_loaded', '_add_template_loader_filters' );
 
 unset( $filter, $action );


### PR DESCRIPTION
### Description

Originally reported in https://github.com/WordPress/gutenberg/issues/36986.

If you create a new post (Posts → Add New) and open the Network tab in DevTools you'll see a request made to `?_wp-find-template=true` with a 404 error.

This causes some unexpected behaviour in the post editor, described in the issue above.

As @noisysocks correctly suspected in https://core.trac.wordpress.org/ticket/54553, this is because of a missing filter that calls `locate_block_template` upon `wp_loaded`.

The fix is to basically backport https://github.com/WordPress/gutenberg/pull/32442, which only made it into Gutenberg briefly after the custom block templates for pages infrastructure was backported to Core (https://github.com/WordPress/wordpress-develop/pull/1267).

### Testing instructions

Verify that https://github.com/WordPress/gutenberg/issues/36986 is fixed.

### Potential Follow-up

It'd be nice if we could add some test coverage for this, e.g. a test that `GET`s `/?p=123&_wp-find-template=true` (where `123` is the ID of a new auto-draft). Not sure if there's prior art for this, so it could be a bit complex to do.

---

Trac ticket: https://core.trac.wordpress.org/ticket/54553

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
