### PR TITLE
KSES: allow port numbers in pdf object url

### DIFF
--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -2591,21 +2591,23 @@ function _wp_add_global_attributes( $value ) {
  * @param string $url The URL to check.
  * @return bool True if the URL is safe, false otherwise.
  */
-function _wp_kses_allow_pdf_objects( $value ) {
+function _wp_kses_allow_pdf_objects( $url ) {
 	// We're not interested in URLs that contain query strings or fragments.
-	if ( strpos( $value, '?' ) !== false || strpos( $value, '#' ) !== false ) {
+	if ( strpos( $url, '?' ) !== false || strpos( $url, '#' ) !== false ) {
 		return false;
 	}
 
 	// If it doesn't have a PDF extension, it's not safe.
-	if ( 0 !== substr_compare( $value, '.pdf', -4, 4, true ) ) {
+	if ( 0 !== substr_compare( $url, '.pdf', -4, 4, true ) ) {
 		return false;
 	}
 
 	// If the URL host matches the current site's media URL, it's safe.
 	$upload_info = wp_upload_dir( null, false );
-	$upload_host = wp_parse_url( $upload_info['url'], PHP_URL_HOST );
-	if ( 0 === strpos( $value, "http://$upload_host/" ) || 0 === strpos( $value, "https://$upload_host/" ) ) {
+	$parsed_url  = wp_parse_url( $upload_info['url'] );
+	$upload_host = $parsed_url['host'];
+	$upload_port = $parsed_url['port'] ? ':' . $parsed_url['port'] : '';
+	if ( 0 === strpos( $url, "http://$upload_host$upload_port/" ) || 0 === strpos( $url, "https://$upload_host$upload_port/" ) ) {
 		return true;
 	}
 

--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -2606,7 +2606,7 @@ function _wp_kses_allow_pdf_objects( $url ) {
 	$upload_info = wp_upload_dir( null, false );
 	$parsed_url  = wp_parse_url( $upload_info['url'] );
 	$upload_host = $parsed_url['host'];
-	$upload_port = $parsed_url['port'] ? ':' . $parsed_url['port'] : '';
+	$upload_port = isset( $parsed_url['port'] ) ? ':' . $parsed_url['port'] : '';
 	if ( 0 === strpos( $url, "http://$upload_host$upload_port/" ) || 0 === strpos( $url, "https://$upload_host$upload_port/" ) ) {
 		return true;
 	}

--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -2605,7 +2605,7 @@ function _wp_kses_allow_pdf_objects( $url ) {
 	// If the URL host matches the current site's media URL, it's safe.
 	$upload_info = wp_upload_dir( null, false );
 	$parsed_url  = wp_parse_url( $upload_info['url'] );
-	$upload_host = $parsed_url['host'];
+	$upload_host = isset( $parsed_url['host'] ) ? $parsed_url['host'] : '';
 	$upload_port = isset( $parsed_url['port'] ) ? ':' . $parsed_url['port'] : '';
 	if ( 0 === strpos( $url, "http://$upload_host$upload_port/" ) || 0 === strpos( $url, "https://$upload_host$upload_port/" ) ) {
 		return true;

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -1596,6 +1596,10 @@ EOF;
 				'<object type="application/pdf" data="/cat/foo.pdf" />',
 				'',
 			),
+			'url with port number-like path'          => array(
+				'<object type="application/pdf" data="https://example.org/cat:8888/foo.pdf" />',
+				'<object type="application/pdf" data="https://example.org/cat:8888/foo.pdf" />',
+			),
 		);
 	}
 
@@ -1626,10 +1630,6 @@ EOF;
 			'url with port number and http protocol' => array(
 				'<object type="application/pdf" data="http://example.org:8888/cat/foo.pdf" />',
 				'<object type="application/pdf" data="http://example.org:8888/cat/foo.pdf" />',
-			),
-			'url with port number-like path'         => array(
-				'<object type="application/pdf" data="https://example.org/cat:8888/foo.pdf" />',
-				'<object type="application/pdf" data="https://example.org/cat:8888/foo.pdf" />',
 			),
 		);
 	}

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -1600,11 +1600,11 @@ EOF;
 				'<object type="application/pdf" data="/cat/foo.pdf" />',
 				'',
 			),
-			'url with port number'                     => array(
+			'url with port number'                    => array(
 				'<object type="application/pdf" data="https://example.org:8888/cat/foo.pdf" />',
 				'<object type="application/pdf" data="https://example.org:8888/cat/foo.pdf" />',
 			),
-			'url with port number-like path'           => array(
+			'url with port number-like path'          => array(
 				'<object type="application/pdf" data="https://example.org/cat:8888/foo.pdf" />',
 				'<object type="application/pdf" data="https://example.org/cat:8888/foo.pdf" />',
 			),

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -1631,6 +1631,14 @@ EOF;
 				'<object type="application/pdf" data="http://example.org:8888/cat/foo.pdf" />',
 				'<object type="application/pdf" data="http://example.org:8888/cat/foo.pdf" />',
 			),
+			'url with wrong protocol'                => array(
+				'<object type="application/pdf" data="http://example.org:3333/cat/foo.pdf" />',
+				'',
+			),
+			'url with without protocol'              => array(
+				'<object type="application/pdf" data="http://example.org/cat/foo.pdf" />',
+				'',
+			),
 		);
 	}
 

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -1596,6 +1596,18 @@ EOF;
 				'<object type="application/pdf" data="/cat/foo.pdf" />',
 				'',
 			),
+			'relative url'                            => array(
+				'<object type="application/pdf" data="/cat/foo.pdf" />',
+				'',
+			),
+			'url with port number'                     => array(
+				'<object type="application/pdf" data="https://example.org:8888/cat/foo.pdf" />',
+				'<object type="application/pdf" data="https://example.org:8888/cat/foo.pdf" />',
+			),
+			'url with port number-like path'           => array(
+				'<object type="application/pdf" data="https://example.org/cat:8888/foo.pdf" />',
+				'<object type="application/pdf" data="https://example.org/cat:8888/foo.pdf" />',
+			),
 		);
 	}
 

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -1596,10 +1596,6 @@ EOF;
 				'<object type="application/pdf" data="/cat/foo.pdf" />',
 				'',
 			),
-			'relative url'                            => array(
-				'<object type="application/pdf" data="/cat/foo.pdf" />',
-				'',
-			),
 		);
 	}
 

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -1634,6 +1634,9 @@ EOF;
 		);
 	}
 
+	/**
+	 * Filter upload directory for tests using port number.
+	 */
 	public function wp_kses_upload_dir_filter( $param ) {
 		$param['port'] = 8888;
 		return $param;

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -1600,7 +1600,7 @@ EOF;
 	}
 
 	/**
-	 * Test that uploaded object tags with port numbers in the URL.
+	 * Test that object tags are allowed when there is a port number in the URL.
 	 *
 	 * @ticket 54261
 	 *

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -1631,11 +1631,11 @@ EOF;
 				'<object type="application/pdf" data="http://example.org:8888/cat/foo.pdf" />',
 				'<object type="application/pdf" data="http://example.org:8888/cat/foo.pdf" />',
 			),
-			'url with wrong protocol'                => array(
+			'url with wrong port number'             => array(
 				'<object type="application/pdf" data="http://example.org:3333/cat/foo.pdf" />',
 				'',
 			),
-			'url without protocol'                   => array(
+			'url without port number'                => array(
 				'<object type="application/pdf" data="http://example.org/cat/foo.pdf" />',
 				'',
 			),

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -1636,9 +1636,13 @@ EOF;
 
 	/**
 	 * Filter upload directory for tests using port number.
+	 *
+	 * @param  array $param See wp_upload_dir()
+	 * @return array        $param with a modified `url`.
 	 */
 	public function wp_kses_upload_dir_filter( $param ) {
-		$param['port'] = 8888;
+		$url_with_port_number = is_string( $param['url'] ) ? str_replace( 'example.org', 'example.org:8888', $param['url'] ) : $param['url'];
+		$param['url'] = $url_with_port_number;
 		return $param;
 	}
 

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -1600,15 +1600,48 @@ EOF;
 				'<object type="application/pdf" data="/cat/foo.pdf" />',
 				'',
 			),
-			'url with port number'                    => array(
+		);
+	}
+
+	/**
+	 * Test that uploaded object tags with port numbers in the URL.
+	 *
+	 * @ticket 54261
+	 *
+	 * @dataProvider data_wp_kses_object_data_url_with_port_number_allowed
+	 *
+	 * @param string $html     A string of HTML to test.
+	 * @param string $expected The expected result from KSES.
+	 */
+	function test_wp_kses_object_data_url_with_port_number_allowed( $html, $expected ) {
+		add_filter( 'upload_dir', array( $this, 'wp_kses_upload_dir_filter' ), 10, 2 );
+		$this->assertSame( $expected, wp_kses_post( $html ) );
+		remove_filter( 'upload_dir', array( $this, 'wp_kses_upload_dir_filter' ), 10, 2 );
+	}
+
+	/**
+	 * Data provider for test_wp_kses_object_data_url_with_port_number_allowed().
+	 */
+	function data_wp_kses_object_data_url_with_port_number_allowed() {
+		return array(
+			'url with port number'                   => array(
 				'<object type="application/pdf" data="https://example.org:8888/cat/foo.pdf" />',
 				'<object type="application/pdf" data="https://example.org:8888/cat/foo.pdf" />',
 			),
-			'url with port number-like path'          => array(
+			'url with port number and http protocol' => array(
+				'<object type="application/pdf" data="http://example.org:8888/cat/foo.pdf" />',
+				'<object type="application/pdf" data="http://example.org:8888/cat/foo.pdf" />',
+			),
+			'url with port number-like path'         => array(
 				'<object type="application/pdf" data="https://example.org/cat:8888/foo.pdf" />',
 				'<object type="application/pdf" data="https://example.org/cat:8888/foo.pdf" />',
 			),
 		);
+	}
+
+	public function wp_kses_upload_dir_filter( $param ) {
+		$param['port'] = 8888;
+		return $param;
 	}
 
 	/**

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -1642,7 +1642,7 @@ EOF;
 	 */
 	public function wp_kses_upload_dir_filter( $param ) {
 		$url_with_port_number = is_string( $param['url'] ) ? str_replace( 'example.org', 'example.org:8888', $param['url'] ) : $param['url'];
-		$param['url'] = $url_with_port_number;
+		$param['url']         = $url_with_port_number;
 		return $param;
 	}
 

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -1635,7 +1635,7 @@ EOF;
 				'<object type="application/pdf" data="http://example.org:3333/cat/foo.pdf" />',
 				'',
 			),
-			'url with without protocol'              => array(
+			'url without protocol'                   => array(
 				'<object type="application/pdf" data="http://example.org/cat/foo.pdf" />',
 				'',
 			),

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -1612,7 +1612,6 @@ EOF;
 	function test_wp_kses_object_data_url_with_port_number_allowed( $html, $expected ) {
 		add_filter( 'upload_dir', array( $this, 'wp_kses_upload_dir_filter' ), 10, 2 );
 		$this->assertSame( $expected, wp_kses_post( $html ) );
-		remove_filter( 'upload_dir', array( $this, 'wp_kses_upload_dir_filter' ), 10, 2 );
 	}
 
 	/**


### PR DESCRIPTION
This patch tests a way to cater for port numbers in pdf `$url` argument.
Renaming `$value` to `$url` to match PHP doc comment.

See comment https://core.trac.wordpress.org/ticket/54261#comment:15

Trac ticket: https://core.trac.wordpress.org/ticket/54261




---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
