### PR TITLE
Change Requests class names to the correct case.

### DIFF
--- a/src/wp-includes/Requests/Ipv6.php
+++ b/src/wp-includes/Requests/Ipv6.php
@@ -90,7 +90,7 @@ final class Ipv6 {
 	 * Example:  FF01:0:0:0:0:0:0:101   ->  FF01::101
 	 *           0:0:0:0:0:0:0:1        ->  ::1
 	 *
-	 * @see \WpOrg\Requests\IPv6::uncompress()
+	 * @see \WpOrg\Requests\Ipv6::uncompress()
 	 *
 	 * @param string $ip An IPv6 address
 	 * @return string The compressed IPv6 address

--- a/src/wp-includes/Requests/Ipv6.php
+++ b/src/wp-includes/Requests/Ipv6.php
@@ -90,7 +90,6 @@ final class Ipv6 {
 	 * Example:  FF01:0:0:0:0:0:0:101   ->  FF01::101
 	 *           0:0:0:0:0:0:0:1        ->  ::1
 	 *
-	 * @see \WpOrg\Requests\Ipv6::uncompress()
 	 *
 	 * @param string $ip An IPv6 address
 	 * @return string The compressed IPv6 address

--- a/src/wp-includes/Requests/Iri.php
+++ b/src/wp-includes/Requests/Iri.php
@@ -53,7 +53,7 @@ use WpOrg\Requests\Utility\InputValidator;
  * @link http://hg.gsnedders.com/iri/
  *
  * @property string $iri IRI we're working with
- * @property-read string $uri IRI in URI form, {@see \WpOrg\Requests\IRI::to_uri()}
+ * @property-read string $uri IRI in URI form, {@see \WpOrg\Requests\Iri::to_uri()}
  * @property string $scheme Scheme part of the IRI
  * @property string $authority Authority part, formatted for a URI (userinfo + host + port)
  * @property string $iauthority Authority part of the IRI (userinfo + host + port)
@@ -1000,7 +1000,7 @@ class Iri {
 	/**
 	 * Convert an IRI to a URI (or parts thereof)
 	 *
-	 * @param string|bool $iri IRI to convert (or false from {@see \WpOrg\Requests\IRI::get_iri()})
+	 * @param string|bool $iri IRI to convert (or false from {@see \WpOrg\Requests\Iri::get_iri()})
 	 * @return string|false URI if IRI is valid, false otherwise.
 	 */
 	protected function to_uri($iri) {

--- a/src/wp-includes/Requests/Iri.php
+++ b/src/wp-includes/Requests/Iri.php
@@ -53,7 +53,6 @@ use WpOrg\Requests\Utility\InputValidator;
  * @link http://hg.gsnedders.com/iri/
  *
  * @property string $iri IRI we're working with
- * @property-read string $uri IRI in URI form, {@see \WpOrg\Requests\Iri::to_uri()}
  * @property string $scheme Scheme part of the IRI
  * @property string $authority Authority part, formatted for a URI (userinfo + host + port)
  * @property string $iauthority Authority part of the IRI (userinfo + host + port)
@@ -1000,7 +999,6 @@ class Iri {
 	/**
 	 * Convert an IRI to a URI (or parts thereof)
 	 *
-	 * @param string|bool $iri IRI to convert (or false from {@see \WpOrg\Requests\Iri::get_iri()})
 	 * @return string|false URI if IRI is valid, false otherwise.
 	 */
 	protected function to_uri($iri) {

--- a/src/wp-includes/Requests/Proxy/Http.php
+++ b/src/wp-includes/Requests/Proxy/Http.php
@@ -92,10 +92,10 @@ final class Http implements Proxy {
 	 * Register the necessary callbacks
 	 *
 	 * @since 1.6
-	 * @see \WpOrg\Requests\Proxy\HTTP::curl_before_send()
-	 * @see \WpOrg\Requests\Proxy\HTTP::fsockopen_remote_socket()
-	 * @see \WpOrg\Requests\Proxy\HTTP::fsockopen_remote_host_path()
-	 * @see \WpOrg\Requests\Proxy\HTTP::fsockopen_header()
+	 * @see \WpOrg\Requests\Proxy\Http::curl_before_send()
+	 * @see \WpOrg\Requests\Proxy\Http::fsockopen_remote_socket()
+	 * @see \WpOrg\Requests\Proxy\Http::fsockopen_remote_host_path()
+	 * @see \WpOrg\Requests\Proxy\Http::fsockopen_header()
 	 * @param \WpOrg\Requests\Hooks $hooks Hook system
 	 */
 	public function register(Hooks $hooks) {

--- a/src/wp-includes/Requests/Proxy/Http.php
+++ b/src/wp-includes/Requests/Proxy/Http.php
@@ -92,10 +92,6 @@ final class Http implements Proxy {
 	 * Register the necessary callbacks
 	 *
 	 * @since 1.6
-	 * @see \WpOrg\Requests\Proxy\Http::curl_before_send()
-	 * @see \WpOrg\Requests\Proxy\Http::fsockopen_remote_socket()
-	 * @see \WpOrg\Requests\Proxy\Http::fsockopen_remote_host_path()
-	 * @see \WpOrg\Requests\Proxy\Http::fsockopen_header()
 	 * @param \WpOrg\Requests\Hooks $hooks Hook system
 	 */
 	public function register(Hooks $hooks) {

--- a/src/wp-includes/class-wp-http.php
+++ b/src/wp-includes/class-wp-http.php
@@ -378,7 +378,7 @@ class WP_Http {
 		// Check for proxies.
 		$proxy = new WP_HTTP_Proxy();
 		if ( $proxy->is_enabled() && $proxy->send_through_proxy( $url ) ) {
-			$options['proxy'] = new WpOrg\Requests\Proxy\HTTP( $proxy->host() . ':' . $proxy->port() );
+			$options['proxy'] = new WpOrg\Requests\Proxy\Http( $proxy->host() . ':' . $proxy->port() );
 
 			if ( $proxy->use_authentication() ) {
 				$options['proxy']->use_authentication = true;


### PR DESCRIPTION
This PR changes:
- `WpOrg\Requests\Proxy\HTTP` to `WpOrg\Requests\Proxy\Http`.
- `WpOrg\Requests\IPv6` to `WpOrg\Requests\Ipv6`.
- `WpOrg\Requests\IRI` to `WpOrg\Requests\Iri`.

Trac ticket: https://core.trac.wordpress.org/ticket/54562
