### PR TITLE
KSES: use PHP 8 string methods

### DIFF
--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -2593,12 +2593,12 @@ function _wp_add_global_attributes( $value ) {
  */
 function _wp_kses_allow_pdf_objects( $url ) {
 	// We're not interested in URLs that contain query strings or fragments.
-	if ( strpos( $url, '?' ) !== false || strpos( $url, '#' ) !== false ) {
+	if ( str_contains( $url, '?' ) || str_contains( $url, '#' ) ) {
 		return false;
 	}
 
 	// If it doesn't have a PDF extension, it's not safe.
-	if ( 0 !== substr_compare( $url, '.pdf', -4, 4, true ) ) {
+	if ( ! str_ends_with( $url, '.pdf' ) ) {
 		return false;
 	}
 
@@ -2607,7 +2607,7 @@ function _wp_kses_allow_pdf_objects( $url ) {
 	$parsed_url  = wp_parse_url( $upload_info['url'] );
 	$upload_host = isset( $parsed_url['host'] ) ? $parsed_url['host'] : '';
 	$upload_port = isset( $parsed_url['port'] ) ? ':' . $parsed_url['port'] : '';
-	if ( 0 === strpos( $url, "http://$upload_host$upload_port/" ) || 0 === strpos( $url, "https://$upload_host$upload_port/" ) ) {
+	if ( str_starts_with( $url, "http://$upload_host$upload_port/" ) || str_starts_with( $url, "https://$upload_host$upload_port/" ) ) {
 		return true;
 	}
 

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -1592,6 +1592,10 @@ EOF;
 				'<object type="application/pdf" data="//example.org/foo.pdf" />',
 				'',
 			),
+			'invalid protocol'                        => array(
+				'<object type="application/pdf" data="ftp://example.org/foo.pdf" />',
+				'',
+			),
 			'relative url'                            => array(
 				'<object type="application/pdf" data="/cat/foo.pdf" />',
 				'',


### PR DESCRIPTION
Implementing @TobiasBg's [suggestion](https://core.trac.wordpress.org/ticket/54261#comment:28):

> As it's a new function in WP 5.9, _wp_kses_allow_pdf_objects() could make use of the PHP 8 (but polyfilled via [52039] and [52040] in WP 5.9) str_contains() and str_ends_with() functions.

Also adding an invalid protocol test.

Trac ticket (comment): https://core.trac.wordpress.org/ticket/54261#comment:28

The tests in [tests/kses.php](https://github.com/ramonjd/wordpress-develop/blob/cbea717875e7bc67af2259157b1fcfd0eee38116/tests/phpunit/tests/kses.php) should pass.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
