### PR TITLE
Implement a preloader.

### DIFF
--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -1786,12 +1786,35 @@ function preload_outgoing_version_files( $wp_base, array $preload_paths, $skip_p
 	$errors = new WP_Error();
 
 	// Preload files.
+	$dangerous_paths = array( '', '.', '/' );
+
 	foreach ( $preload_paths as $path ) {
+		if ( ! is_string( $path ) ) {
+			$errors->add(
+				'invalid_path',
+				/* translators: %s: The invalid path. */
+				sprintf( __( '%s is not a valid path.' ), print_r( $path, true ) )
+			);
+			continue;
+		}
+
+		if ( in_array( trim( $path ), $dangerous_paths, true ) ) {
+			$errors->add(
+				'dangerous_path',
+				/* translators: %s: The path to the file or directory. */
+				sprintf( __( '%s is a dangerous path.' ), $path )
+			);
+			continue;
+		}
+
 		$fullpath = trailingslashit( $wp_base ) . $path;
 
 		if ( ! $wp_filesystem->exists( $fullpath ) ) {
-			/* translators: %s: The path to the file or directory. */
-			$errors->add( 'path_does_not_exist', sprintf( __( '%s does not exist.' ), $fullpath ) );
+			$errors->add(
+				'path_does_not_exist',
+				/* translators: %s: The path to the file or directory. */
+				sprintf( __( '%s does not exist.' ), $fullpath )
+			);
 			continue;
 		}
 
@@ -1834,8 +1857,11 @@ function preload_outgoing_version_files( $wp_base, array $preload_paths, $skip_p
 		}
 
 		if ( ! str_ends_with( $fullpath, '.php' ) ) {
-			/* translators: %s: The path to the file. */
-			$errors->add( 'bad_file', sprintf( __( '%s is not a PHP file.' ), $path ) );
+			$errors->add(
+				'bad_file',
+				/* translators: %s: The path to the file. */
+				sprintf( __( '%s is not a PHP file.' ), $path )
+			);
 			continue;
 		}
 

--- a/tests/phpunit/data/classes/sample_1/class-sample-one.php
+++ b/tests/phpunit/data/classes/sample_1/class-sample-one.php
@@ -1,0 +1,13 @@
+<?php
+
+class Sample_One {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {}
+
+}
+
+// Define global for use in tests.
+global $sample_one;
+$sample_one = new Sample_One();

--- a/tests/phpunit/data/classes/sample_2/class-sample-two.php
+++ b/tests/phpunit/data/classes/sample_2/class-sample-two.php
@@ -1,0 +1,13 @@
+<?php
+
+class Sample_Two {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {}
+
+}
+
+// Define global for use in tests.
+global $sample_two;
+$sample_two = new Sample_Two();

--- a/tests/phpunit/data/classes/sample_3/class-sample-three.php
+++ b/tests/phpunit/data/classes/sample_3/class-sample-three.php
@@ -1,0 +1,13 @@
+<?php
+
+class Sample_Three {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {}
+
+}
+
+// Define global for use in tests.
+global $sample_three;
+$sample_three = new Sample_Three();

--- a/tests/phpunit/data/classes/sample_4/class-sample-four.php
+++ b/tests/phpunit/data/classes/sample_4/class-sample-four.php
@@ -1,0 +1,13 @@
+<?php
+
+class Sample_Four {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {}
+
+}
+
+// Define global for use in tests.
+global $sample_four;
+$sample_four = new Sample_Four();

--- a/tests/phpunit/data/classes/sample_4/subdir/class-sample-four-subdir.php
+++ b/tests/phpunit/data/classes/sample_4/subdir/class-sample-four-subdir.php
@@ -1,0 +1,13 @@
+<?php
+
+class Sample_Four_Subdir {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {}
+
+}
+
+// Define global for use in tests.
+global $sample_four_subdir;
+$sample_four_subdir = new Sample_Four_Subdir();

--- a/tests/phpunit/data/classes/sample_5/class-sample-five.php
+++ b/tests/phpunit/data/classes/sample_5/class-sample-five.php
@@ -1,0 +1,13 @@
+<?php
+
+class Sample_Five {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {}
+
+}
+
+// Define global for use in tests.
+global $sample_five;
+$sample_five = new Sample_Five();

--- a/tests/phpunit/data/classes/sample_6/class-sample-six.php
+++ b/tests/phpunit/data/classes/sample_6/class-sample-six.php
@@ -1,0 +1,13 @@
+<?php
+
+class Sample_Six {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {}
+
+}
+
+// Define global for use in tests.
+global $sample_six;
+$sample_six = new Sample_Six();

--- a/tests/phpunit/data/classes/sample_7/class-sample-seven.php
+++ b/tests/phpunit/data/classes/sample_7/class-sample-seven.php
@@ -1,0 +1,13 @@
+<?php
+
+class Sample_Seven {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {}
+
+}
+
+// Define global for use in tests.
+global $sample_seven;
+$sample_seven = new Sample_Seven();

--- a/tests/phpunit/data/classes/sample_7/subdir/class-sample-seven-subdir.php
+++ b/tests/phpunit/data/classes/sample_7/subdir/class-sample-seven-subdir.php
@@ -1,0 +1,13 @@
+<?php
+
+class Sample_Seven_Subdir {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {}
+
+}
+
+// Define global for use in tests.
+global $sample_seven_subdir;
+$sample_seven_subdir = new Sample_Seven_Subdir();

--- a/tests/phpunit/data/classes/sample_8/class-sample-eight.php
+++ b/tests/phpunit/data/classes/sample_8/class-sample-eight.php
@@ -1,0 +1,13 @@
+<?php
+
+class Sample_Eight {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {}
+
+}
+
+// Define global for use in tests.
+global $sample_eight;
+$sample_eight = new Sample_Eight();

--- a/tests/phpunit/data/classes/sample_8/subdir/class-sample-eight-subdir.php
+++ b/tests/phpunit/data/classes/sample_8/subdir/class-sample-eight-subdir.php
@@ -1,0 +1,13 @@
+<?php
+
+class Sample_Eight_Subdir {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {}
+
+}
+
+// Define global for use in tests.
+global $sample_eight_subdir;
+$sample_eight_subdir = new Sample_Eight_Subdir();

--- a/tests/phpunit/tests/functions/preloadOutgoingVersionFiles.php
+++ b/tests/phpunit/tests/functions/preloadOutgoingVersionFiles.php
@@ -240,7 +240,7 @@ class Tests_Functions_PreloadOutgoingVersionFiles extends WP_UnitTestCase {
 	 */
 	public function data_preload_outgoing_version_files_returns_wp_error() {
 		return array(
-			'no filesystem -> fs_unavailable' => array(
+			'no filesystem -> fs_unavailable'   => array(
 				'args' => array(
 					'wp_base'       => DIR_TESTDATA,
 					'preload_paths' => array(),
@@ -248,7 +248,7 @@ class Tests_Functions_PreloadOutgoingVersionFiles extends WP_UnitTestCase {
 					'expected'      => 'fs_unavailable',
 				),
 			),
-			'no preload paths -> empty_paths' => array(
+			'no preload paths -> empty_paths'   => array(
 				'args' => array(
 					'wp_base'       => DIR_TESTDATA,
 					'preload_paths' => array(),
@@ -272,12 +272,36 @@ class Tests_Functions_PreloadOutgoingVersionFiles extends WP_UnitTestCase {
 					'expected'      => 'path_does_not_exist',
 				),
 			),
-			'a non-PHP file -> bad_file'      => array(
+			'a non-PHP file -> bad_file'        => array(
 				'args' => array(
 					'wp_base'       => ABSPATH,
 					'preload_paths' => array( 'readme.html' ),
 					'wp_filesystem' => 'WP_Filesystem_Direct',
 					'expected'      => 'bad_file',
+				),
+			),
+			'an empty string -> dangerous_path' => array(
+				'args' => array(
+					'wp_base'       => ABSPATH,
+					'preload_paths' => array( '' ),
+					'wp_filesystem' => 'WP_Filesystem_Direct',
+					'expected'      => 'dangerous_path',
+				),
+			),
+			'a period -> dangerous_path'        => array(
+				'args' => array(
+					'wp_base'       => ABSPATH,
+					'preload_paths' => array( '.' ),
+					'wp_filesystem' => 'WP_Filesystem_Direct',
+					'expected'      => 'dangerous_path',
+				),
+			),
+			'a forward slash -> dangerous_path' => array(
+				'args' => array(
+					'wp_base'       => ABSPATH,
+					'preload_paths' => array( '/' ),
+					'wp_filesystem' => 'WP_Filesystem_Direct',
+					'expected'      => 'dangerous_path',
 				),
 			),
 		);

--- a/tests/phpunit/tests/functions/preloadOutgoingVersionFiles.php
+++ b/tests/phpunit/tests/functions/preloadOutgoingVersionFiles.php
@@ -304,6 +304,14 @@ class Tests_Functions_PreloadOutgoingVersionFiles extends WP_UnitTestCase {
 					'expected'      => 'dangerous_path',
 				),
 			),
+			'an `array` path -> invalid_path'   => array(
+				'args' => array(
+					'wp_base'       => ABSPATH,
+					'preload_paths' => array( array() ),
+					'wp_filesystem' => 'WP_Filesystem_Direct',
+					'expected'      => 'invalid_path',
+				),
+			),
 		);
 	}
 }

--- a/tests/phpunit/tests/functions/preloadOutgoingVersionFiles.php
+++ b/tests/phpunit/tests/functions/preloadOutgoingVersionFiles.php
@@ -31,6 +31,8 @@ class Tests_Functions_PreloadOutgoingVersionFiles extends WP_UnitTestCase {
 	public function test_preload_outgoing_version_files( array $args ) {
 		global $wp_filesystem, $wp_version, ${ $args['to_preload'] };
 
+		$actual_wp_version = $wp_version;
+
 		if ( isset( $args['wp_filesystem'] ) ) {
 			$wp_filesystem = $args['wp_filesystem'];
 
@@ -44,6 +46,8 @@ class Tests_Functions_PreloadOutgoingVersionFiles extends WP_UnitTestCase {
 		}
 
 		preload_outgoing_version_files( $args['wp_base'], $args['preload_paths'] );
+		$wp_version = $actual_wp_version;
+
 		$this->assertIsObject( ${ $args['to_preload'] }, "{$args['to_preload']} was not preloaded." );
 	}
 
@@ -60,14 +64,15 @@ class Tests_Functions_PreloadOutgoingVersionFiles extends WP_UnitTestCase {
 					'wp_filesystem' => 'WP_Filesystem_Direct',
 					'preload_paths' => array( 'classes/sample_1/class-sample-one.php' ),
 					'to_preload'    => 'sample_one',
+					'wp_filesystem' => 'WP_Filesystem_Direct',
 				),
 			),
 			'a directory path' => array(
 				'args' => array(
 					'wp_base'       => DIR_TESTDATA,
-					'wp_filesystem' => 'WP_Filesystem_Direct',
 					'preload_paths' => array( 'classes/sample_2/' ),
 					'to_preload'    => 'sample_two',
+					'wp_filesystem' => 'WP_Filesystem_Direct',
 				),
 			),
 		);
@@ -91,6 +96,8 @@ class Tests_Functions_PreloadOutgoingVersionFiles extends WP_UnitTestCase {
 	public function test_preload_outgoing_version_files_skips( array $args ) {
 		global $wp_filesystem, $wp_version, ${ $args['to_preload'] };
 
+		$actual_wp_version = $wp_version;
+
 		if ( isset( $args['wp_filesystem'] ) ) {
 			$wp_filesystem = $args['wp_filesystem'];
 
@@ -104,6 +111,8 @@ class Tests_Functions_PreloadOutgoingVersionFiles extends WP_UnitTestCase {
 		}
 
 		preload_outgoing_version_files( $args['wp_base'], $args['preload_paths'], $args['skip_preload_paths'] );
+		$wp_version = $actual_wp_version;
+
 		$this->assertIsNotObject( ${ $args['to_preload'] }, "{$args['to_preload']} was preloaded." );
 	}
 
@@ -115,40 +124,61 @@ class Tests_Functions_PreloadOutgoingVersionFiles extends WP_UnitTestCase {
 	 */
 	public function data_preload_outgoing_version_files_skips() {
 		return array(
-			'no version check and a file path'      => array(
+			'no version check and a file path'         => array(
 				'args' => array(
 					'wp_base'            => DIR_TESTDATA,
 					'wp_filesystem'      => 'WP_Filesystem_Direct',
 					'preload_paths'      => array( 'classes/sample_3/class-sample-three.php' ),
 					'skip_preload_paths' => array( array( 'classes/sample_3/class-sample-three.php' ) ),
 					'to_preload'         => 'sample_three',
+					'wp_filesystem'      => 'WP_Filesystem_Direct',
 				),
 			),
-			'no version check and a directory path' => array(
+			'no version check and a directory path'    => array(
 				'args' => array(
 					'wp_base'            => DIR_TESTDATA,
-					'wp_filesystem'      => 'WP_Filesystem_Direct',
 					'preload_paths'      => array( 'classes/sample_4/' ),
 					'skip_preload_paths' => array( array( 'classes/sample_4/class-sample-four.php' ) ),
 					'to_preload'         => 'sample_four',
+					'wp_filesystem'      => 'WP_Filesystem_Direct',
 				),
 			),
-			'a version check and a file path'       => array(
+			'a version check and a file path'          => array(
 				'args' => array(
 					'wp_base'            => DIR_TESTDATA,
 					'wp_filesystem'      => 'WP_Filesystem_Direct',
 					'preload_paths'      => array( 'classes/sample_5/class-sample-five.php' ),
 					'skip_preload_paths' => array( array( 'classes/sample_5/class-sample-five.php', '5.8.2', '>' ) ),
 					'to_preload'         => 'sample_five',
+					'wp_filesystem'      => 'WP_Filesystem_Direct',
 				),
 			),
-			'a version check and a directory path'  => array(
+			'a version check and a directory path'     => array(
 				'args' => array(
 					'wp_base'            => DIR_TESTDATA,
-					'wp_filesystem'      => 'WP_Filesystem_Direct',
 					'preload_paths'      => array( 'classes/sample_6/' ),
 					'skip_preload_paths' => array( array( 'classes/sample_6/class-sample-six.php', '5.8.2', '>' ) ),
 					'to_preload'         => 'sample_six',
+					'wp_filesystem'      => 'WP_Filesystem_Direct',
+				),
+			),
+			'no version check and a subdirectory path' => array(
+				'args' => array(
+					'wp_base'            => DIR_TESTDATA,
+					'preload_paths'      => array( 'classes/sample_7/' ),
+					'skip_preload_paths' => array( array( 'classes/sample_7/subdir' ) ),
+					'to_preload'         => 'sample_seven_subdir',
+					'wp_filesystem'      => 'WP_Filesystem_Direct',
+				),
+			),
+			'a version check and a subdirectory path'  => array(
+				'args' => array(
+					'wp_base'            => DIR_TESTDATA,
+					'preload_paths'      => array( 'classes/sample_8/' ),
+					'wp_version'         => '4.6.0',
+					'skip_preload_paths' => array( array( 'classes/sample_8/subdir', '5.8.2', '<' ) ),
+					'to_preload'         => 'sample_eight_subdir',
+					'wp_filesystem'      => 'WP_Filesystem_Direct',
 				),
 			),
 		);
@@ -173,6 +203,8 @@ class Tests_Functions_PreloadOutgoingVersionFiles extends WP_UnitTestCase {
 	public function test_preload_outgoing_version_files_returns_wp_error( array $args ) {
 		global $wp_filesystem, $wp_version;
 
+		$actual_wp_version = $wp_version;
+
 		if ( isset( $args['wp_filesystem'] ) ) {
 			$wp_filesystem = $args['wp_filesystem'];
 
@@ -185,7 +217,8 @@ class Tests_Functions_PreloadOutgoingVersionFiles extends WP_UnitTestCase {
 			$wp_version = $args['wp_version'];
 		}
 
-		$actual = preload_outgoing_version_files( $args['wp_base'], $args['preload_paths'] );
+		$actual     = preload_outgoing_version_files( $args['wp_base'], $args['preload_paths'] );
+		$wp_version = $actual_wp_version;
 
 		$this->assertInstanceOf(
 			'WP_Error',
@@ -210,40 +243,40 @@ class Tests_Functions_PreloadOutgoingVersionFiles extends WP_UnitTestCase {
 			'no filesystem -> fs_unavailable' => array(
 				'args' => array(
 					'wp_base'       => DIR_TESTDATA,
-					'wp_filesystem' => '',
 					'preload_paths' => array(),
+					'wp_filesystem' => '',
 					'expected'      => 'fs_unavailable',
 				),
 			),
 			'no preload paths -> empty_paths' => array(
 				'args' => array(
 					'wp_base'       => DIR_TESTDATA,
-					'wp_filesystem' => 'WP_Filesystem_Direct',
 					'preload_paths' => array(),
+					'wp_filesystem' => 'WP_Filesystem_Direct',
 					'expected'      => 'empty_paths',
 				),
 			),
 			'file path that does not exist -> path_does_not_exist' => array(
 				'args' => array(
 					'wp_base'       => DIR_TESTDATA,
-					'wp_filesystem' => 'WP_Filesystem_Direct',
 					'preload_paths' => array( 'classes/sample_0/class-sample-zero.php' ),
+					'wp_filesystem' => 'WP_Filesystem_Direct',
 					'expected'      => 'path_does_not_exist',
 				),
 			),
 			'directory path that does not exist -> path_does_not_exist' => array(
 				'args' => array(
 					'wp_base'       => DIR_TESTDATA,
-					'wp_filesystem' => 'WP_Filesystem_Direct',
 					'preload_paths' => array( 'classes/sample_0/' ),
+					'wp_filesystem' => 'WP_Filesystem_Direct',
 					'expected'      => 'path_does_not_exist',
 				),
 			),
 			'a non-PHP file -> bad_file'      => array(
 				'args' => array(
 					'wp_base'       => ABSPATH,
-					'wp_filesystem' => 'WP_Filesystem_Direct',
 					'preload_paths' => array( 'readme.html' ),
+					'wp_filesystem' => 'WP_Filesystem_Direct',
 					'expected'      => 'bad_file',
 				),
 			),

--- a/tests/phpunit/tests/functions/preloadOutgoingVersionFiles.php
+++ b/tests/phpunit/tests/functions/preloadOutgoingVersionFiles.php
@@ -1,0 +1,252 @@
+<?php
+
+/**
+ * @group upgrade
+ *
+ * @covers ::preload_outgoing_version_files
+ */
+class Tests_Functions_PreloadOutgoingVersionFiles extends WP_UnitTestCase {
+
+	public static function wpSetUpBeforeClass() {
+		require_once ABSPATH . '/wp-admin/includes/class-wp-filesystem-base.php';
+		require_once ABSPATH . '/wp-admin/includes/class-wp-filesystem-direct.php';
+		require_once ABSPATH . '/wp-admin/includes/update-core.php';
+	}
+
+	/**
+	 * @ticket
+	 * @dataProvider data_preload_outgoing_version_files
+	 *
+	 * @global $wp_filesystem  The filesystem.
+	 * @global $wp_version     The WordPress version.
+	 *
+	 * @param array $args {
+	 *     @type string $wp_base             Base path of the WordPress installation.
+	 *     @type array  $preload_paths       An array of paths to preload, relative to $wp_base.
+	 *     @type array  $skip_preload_paths  An array of paths to skip when preloading, relative to $wp_base.
+	 *     @type mixed  $wp_filesystem       The filesystem.
+	 *     @type string $wp_version          The WordPress version.
+	 * }
+	 */
+	public function test_preload_outgoing_version_files( array $args ) {
+		global $wp_filesystem, $wp_version, ${ $args['to_preload'] };
+
+		if ( isset( $args['wp_filesystem'] ) ) {
+			$wp_filesystem = $args['wp_filesystem'];
+
+			if ( str_starts_with( $wp_filesystem, 'WP_Filesystem' ) ) {
+				$wp_filesystem = new $args['wp_filesystem']( '' );
+			}
+		}
+
+		if ( isset( $args['wp_version'] ) ) {
+			$wp_version = $args['wp_version'];
+		}
+
+		preload_outgoing_version_files( $args['wp_base'], $args['preload_paths'] );
+		$this->assertIsObject( ${ $args['to_preload'] }, "{$args['to_preload']} was not preloaded." );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_preload_outgoing_version_files() {
+		return array(
+			'a file path'      => array(
+				'args' => array(
+					'wp_base'       => DIR_TESTDATA,
+					'wp_filesystem' => 'WP_Filesystem_Direct',
+					'preload_paths' => array( 'classes/sample_1/class-sample-one.php' ),
+					'to_preload'    => 'sample_one',
+				),
+			),
+			'a directory path' => array(
+				'args' => array(
+					'wp_base'       => DIR_TESTDATA,
+					'wp_filesystem' => 'WP_Filesystem_Direct',
+					'preload_paths' => array( 'classes/sample_2/' ),
+					'to_preload'    => 'sample_two',
+				),
+			),
+		);
+	}
+
+	/**
+	 * @ticket
+	 * @dataProvider data_preload_outgoing_version_files_skips
+	 *
+	 * @global $wp_filesystem  The filesystem.
+	 * @global $wp_version     The WordPress version.
+	 *
+	 * @param array $args {
+	 *     @type string $wp_base             Base path of the WordPress installation.
+	 *     @type array  $preload_paths       An array of paths to preload, relative to $wp_base.
+	 *     @type array  $skip_preload_paths  An array of paths to skip when preloading, relative to $wp_base.
+	 *     @type mixed  $wp_filesystem       The filesystem.
+	 *     @type string $wp_version          The WordPress version.
+	 * }
+	 */
+	public function test_preload_outgoing_version_files_skips( array $args ) {
+		global $wp_filesystem, $wp_version, ${ $args['to_preload'] };
+
+		if ( isset( $args['wp_filesystem'] ) ) {
+			$wp_filesystem = $args['wp_filesystem'];
+
+			if ( str_starts_with( $wp_filesystem, 'WP_Filesystem' ) ) {
+				$wp_filesystem = new $args['wp_filesystem']( '' );
+			}
+		}
+
+		if ( isset( $args['wp_version'] ) ) {
+			$wp_version = $args['wp_version'];
+		}
+
+		preload_outgoing_version_files( $args['wp_base'], $args['preload_paths'], $args['skip_preload_paths'] );
+		$this->assertIsNotObject( ${ $args['to_preload'] }, "{$args['to_preload']} was preloaded." );
+	}
+
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_preload_outgoing_version_files_skips() {
+		return array(
+			'no version check and a file path'      => array(
+				'args' => array(
+					'wp_base'            => DIR_TESTDATA,
+					'wp_filesystem'      => 'WP_Filesystem_Direct',
+					'preload_paths'      => array( 'classes/sample_3/class-sample-three.php' ),
+					'skip_preload_paths' => array( array( 'classes/sample_3/class-sample-three.php' ) ),
+					'to_preload'         => 'sample_three',
+				),
+			),
+			'no version check and a directory path' => array(
+				'args' => array(
+					'wp_base'            => DIR_TESTDATA,
+					'wp_filesystem'      => 'WP_Filesystem_Direct',
+					'preload_paths'      => array( 'classes/sample_4/' ),
+					'skip_preload_paths' => array( array( 'classes/sample_4/class-sample-four.php' ) ),
+					'to_preload'         => 'sample_four',
+				),
+			),
+			'a version check and a file path'       => array(
+				'args' => array(
+					'wp_base'            => DIR_TESTDATA,
+					'wp_filesystem'      => 'WP_Filesystem_Direct',
+					'preload_paths'      => array( 'classes/sample_5/class-sample-five.php' ),
+					'skip_preload_paths' => array( array( 'classes/sample_5/class-sample-five.php', '5.8.2', '>' ) ),
+					'to_preload'         => 'sample_five',
+				),
+			),
+			'a version check and a directory path'  => array(
+				'args' => array(
+					'wp_base'            => DIR_TESTDATA,
+					'wp_filesystem'      => 'WP_Filesystem_Direct',
+					'preload_paths'      => array( 'classes/sample_6/' ),
+					'skip_preload_paths' => array( array( 'classes/sample_6/class-sample-six.php', '5.8.2', '>' ) ),
+					'to_preload'         => 'sample_six',
+				),
+			),
+		);
+	}
+
+	/**
+	 * @ticket
+	 * @dataProvider data_preload_outgoing_version_files_returns_wp_error
+	 *
+	 * @global $wp_filesystem  The filesystem.
+	 * @global $wp_version     The WordPress version.
+	 *
+	 * @param array $args {
+	 *     @type string $wp_base             Base path of the WordPress installation.
+	 *     @type array  $preload_paths       An array of paths to preload, relative to $wp_base.
+	 *     @type array  $skip_preload_paths  An array of paths to skip when preloading, relative to $wp_base.
+	 *     @type mixed  $wp_filesystem       The filesystem.
+	 *     @type string $wp_version          The WordPress version.
+	 *     @type string $expected            The expected error code.
+	 * }
+	 */
+	public function test_preload_outgoing_version_files_returns_wp_error( array $args ) {
+		global $wp_filesystem, $wp_version;
+
+		if ( isset( $args['wp_filesystem'] ) ) {
+			$wp_filesystem = $args['wp_filesystem'];
+
+			if ( str_starts_with( $wp_filesystem, 'WP_Filesystem' ) ) {
+				$wp_filesystem = new $args['wp_filesystem']( '' );
+			}
+		}
+
+		if ( isset( $args['wp_version'] ) ) {
+			$wp_version = $args['wp_version'];
+		}
+
+		$actual = preload_outgoing_version_files( $args['wp_base'], $args['preload_paths'] );
+
+		$this->assertInstanceOf(
+			'WP_Error',
+			$actual,
+			'Did not return a WP_Error object.'
+		);
+
+		$this->assertSame(
+			$args['expected'],
+			$actual->get_error_codes()[0],
+			"Did not return error: '{$args['expected']}'"
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_preload_outgoing_version_files_returns_wp_error() {
+		return array(
+			'no filesystem -> fs_unavailable' => array(
+				'args' => array(
+					'wp_base'       => DIR_TESTDATA,
+					'wp_filesystem' => '',
+					'preload_paths' => array(),
+					'expected'      => 'fs_unavailable',
+				),
+			),
+			'no preload paths -> empty_paths' => array(
+				'args' => array(
+					'wp_base'       => DIR_TESTDATA,
+					'wp_filesystem' => 'WP_Filesystem_Direct',
+					'preload_paths' => array(),
+					'expected'      => 'empty_paths',
+				),
+			),
+			'file path that does not exist -> path_does_not_exist' => array(
+				'args' => array(
+					'wp_base'       => DIR_TESTDATA,
+					'wp_filesystem' => 'WP_Filesystem_Direct',
+					'preload_paths' => array( 'classes/sample_0/class-sample-zero.php' ),
+					'expected'      => 'path_does_not_exist',
+				),
+			),
+			'directory path that does not exist -> path_does_not_exist' => array(
+				'args' => array(
+					'wp_base'       => DIR_TESTDATA,
+					'wp_filesystem' => 'WP_Filesystem_Direct',
+					'preload_paths' => array( 'classes/sample_0/' ),
+					'expected'      => 'path_does_not_exist',
+				),
+			),
+			'a non-PHP file -> bad_file'      => array(
+				'args' => array(
+					'wp_base'       => ABSPATH,
+					'wp_filesystem' => 'WP_Filesystem_Direct',
+					'preload_paths' => array( 'readme.html' ),
+					'expected'      => 'bad_file',
+				),
+			),
+		);
+	}
+}


### PR DESCRIPTION
This PR implements a preloader for the upgrade process.

- This is set to preload the `wp-includes/Requests` directory.
- This is set to skip preloading `wp-includes/Requests/Autoload.php` on WP < 5.9.
- These are in place as examples but should be part of the overall audit.

**Source**
- [x] Allow preloading files.
- [x] Allow recursively preloading directories.
- [x] Allow skipping files from preloading.
- [ ] Identify additional functionality that may be needed. Please identify in a review for discussion.
- [ ] Identify additional functionality that may be helpful. Please suggest in a review for discussion.
- [ ] Audit additional files needed by the upgrader.
- [ ] Add the additional paths to the preloader, skipping individual files where necessary.

**Tests**
- [x] Add initial tests.
- [ ] If necessary, review the sample files implementation for an alternative.
- [ ] Add more tests.
- [ ] Manual testing.
- [ ] Review documentation.

Trac ticket: https://core.trac.wordpress.org/ticket/54589
