### PR TITLE
Add a check for `plugins` parent folder.

### DIFF
--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -1025,6 +1025,17 @@ class WP_Upgrader {
 			return false;
 		}
 
+		/**
+		 * Skip any plugin that has "." as its slug.
+		 * A slug of "." will result in a `$src` value ending in a period.
+		 *
+		 * On Windows, this will cause the 'plugins' folder to be moved,
+		 * and will cause a failure when attempting to call `mkdir()`.
+		 */
+		if ( '.' === $args['slug'] ) {
+			return false;
+		}
+
 		$dest_dir = $wp_filesystem->wp_content_dir() . 'upgrade/temp-backup/';
 		// Create the temp-backup directory if it doesn't exist.
 		if ( (


### PR DESCRIPTION
Older versions of `Hello Dolly` are stored in `wp-content/plugins/hello.php`.

[[51815](https://core.trac.wordpress.org/changeset/51815)] introduced the creation of a temporary backup of plugins before updating.

The `move()` (and later, `move_dir()`) call) uses a `$src` parameter.
For `Hello Dolly`, this is `<path>/wp-contents/plugins/.` - note the period at the end.
For users on Linux and Mac, this doesn't appear to cause any problems.
However, on Windows, the move causes the `plugins` folder to be moved.

This PR negates the move if the plugin is in the `plugins` directory.
N.B. All plugins should be in their own directory (i.e. `wp-content/plugins/<plugin_dir>`), so this shouldn't cause any failures for other plugins. This is specifically to fix a Windows issue when updating older plugins that were stored directly in the `wp-content/plugins` directory.

Trac ticket: https://core.trac.wordpress.org/ticket/54543
