### PR TITLE
Only list the custom block templates in the list of available templates per post type

### DIFF
--- a/src/wp-includes/class-wp-theme.php
+++ b/src/wp-includes/class-wp-theme.php
@@ -1250,8 +1250,8 @@ final class WP_Theme implements ArrayAccess {
 			}
 
 			if ( current_theme_supports( 'block-templates' ) ) {
-				$block_templates = get_block_templates( array(), 'wp_template' );
 				foreach ( get_post_types( array( 'public' => true ) ) as $type ) {
+					$block_templates = get_block_templates( array( 'post_type' => $type ), 'wp_template' );
 					foreach ( $block_templates as $block_template ) {
 						$post_templates[ $type ][ $block_template->slug ] = $block_template->title;
 					}


### PR DESCRIPTION
This backports a change that was missed during the initial backports related to the templates list shown in the post editor. 
It's a change from the following Gutenberg PR https://github.com/WordPress/gutenberg/pull/35802

Trac ticket: https://core.trac.wordpress.org/ticket/54335

**Testing instructions**

 Make sure the post editor only shows custom page templates in the template list and not hierarchy templates (index, single...)

cc @Mamaduka