### PR TITLE
Fix template descriptions not showing up in the site editor

### DIFF
--- a/src/wp-admin/site-editor.php
+++ b/src/wp-admin/site-editor.php
@@ -37,12 +37,18 @@ add_filter(
 	}
 );
 
+$indexed_template_types = array();
+foreach ( get_default_block_template_types() as $slug => $template_type ) {
+	$template_type['slug']    = (string) $slug;
+	$indexed_template_types[] = $template_type;
+}
+
 $block_editor_context = new WP_Block_Editor_Context();
 $custom_settings      = array(
 	'siteUrl'                              => site_url(),
 	'postsPerPage'                         => get_option( 'posts_per_page' ),
 	'styles'                               => get_block_editor_theme_styles(),
-	'defaultTemplateTypes'                 => get_default_block_template_types(),
+	'defaultTemplateTypes'                 => $indexed_template_types,
 	'defaultTemplatePartAreas'             => get_allowed_block_template_part_areas(),
 	'__experimentalBlockPatterns'          => WP_Block_Patterns_Registry::get_instance()->get_all_registered(),
 	'__experimentalBlockPatternCategories' => WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered(),


### PR DESCRIPTION
There was a difference between the initialization of the site editor between Gutenberg plugin and Core. This PRs brings syncs both which fixes the template description in the site editor.

Trac ticket: https://core.trac.wordpress.org/ticket/54337

**Testing instructions**

 - Open the site editor
 - Click the template title
 - The template description should be visible.