### PR TITLE
Remove usage of strtotime from image metadata use (and fix undefined offset error from wp_exif_date2ts)

### DIFF
--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -843,7 +843,7 @@ function wp_read_image_metadata( $file ) {
 		}
 		if ( empty( $meta['created_timestamp'] ) && ! empty( $exif['DateTimeDigitized'] ) ) {
 			$timezone = null;
-			if ( ! empty( $exif'UndefinedTag:0x9012'] ) ) {
+			if ( ! empty( $exif['UndefinedTag:0x9012'] ) ) {
                                 $timezone = $exif['UndefinedTag:0x9012'];
 			}
 


### PR DESCRIPTION
I believe @dshanke's PR Wordpress/wordpress-develop#495 also fixes https://core.trac.wordpress.org/ticket/48204 but there is a syntax error.

Trac ticket: https://core.trac.wordpress.org/ticket/48204

### Original PR description:

> This patch removes uses of strtotime from image metadata functions, replacing them with the DateTime class. It introduces a new wp_exif_datetime function that can be used for this. wp_exif_date2ts if now a wrapper around it that generates a timestamp for backcompat only. It replaces the use of the old function in the read metadata functionality and to ensure timezone is respected, stores as a new property the full datetime with timezone.
>
> Trac ticket: https://core.trac.wordpress.org/ticket/49413

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
