### PR TITLE
Fix default theme supports

### DIFF
--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -514,6 +514,7 @@ add_action( 'init', 'wp_sitemaps_get_server' );
  */
 // Theme.
 add_action( 'setup_theme', 'create_initial_theme_features', 0 );
+add_action( 'setup_theme', '_add_default_theme_supports', 1 );
 add_action( 'wp_loaded', '_custom_header_background_just_in_time' );
 add_action( 'wp_head', '_custom_logo_header_styles' );
 add_action( 'plugins_loaded', '_wp_customize_include' );

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -4106,7 +4106,7 @@ function _add_default_theme_supports() {
 		add_theme_support( 'post-thumbnails' );
 		add_theme_support( 'responsive-embeds' );
 		add_theme_support( 'editor-styles' );
-		add_theme_support( 'html5', array( 'style', 'script' ) );
+		add_theme_support( 'html5', array( 'comment-form', 'comment-list', 'style', 'script' ) );
 		add_theme_support( 'automatic-feed-links' );
 		add_filter( 'should_load_separate_core_block_assets', '__return_true' );
 	}

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -4093,3 +4093,21 @@ function create_initial_theme_features() {
 function wp_is_block_theme() {
 	return wp_get_theme()->is_block_theme();
 }
+
+/**
+ * Adds default theme supports for block themes when the 'setup_theme' action
+ * fires.
+ *
+ * @since 5.9.0
+ * @access private
+ */
+function _add_default_theme_supports() {
+	if ( wp_is_block_theme() ) {
+		add_theme_support( 'post-thumbnails' );
+		add_theme_support( 'responsive-embeds' );
+		add_theme_support( 'editor-styles' );
+		add_theme_support( 'html5', array( 'style', 'script' ) );
+		add_theme_support( 'automatic-feed-links' );
+		add_filter( 'should_load_separate_core_block_assets', '__return_true' );
+	}
+}


### PR DESCRIPTION
By default, block themes should have a few theme supports enabled by default. These are: post-thumbnails, responsive-embeds, editor-styles, html5, automatic-feed-links.

This is a backport of https://github.com/WordPress/gutenberg/pull/35593.

Trac ticket: https://core.trac.wordpress.org/ticket/54597

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
