### PR TITLE
Filter custom block templates with PHP

### DIFF
--- a/src/wp-includes/class-wp-theme.php
+++ b/src/wp-includes/class-wp-theme.php
@@ -1250,9 +1250,17 @@ final class WP_Theme implements ArrayAccess {
 			}
 
 			if ( current_theme_supports( 'block-templates' ) ) {
+				$block_templates = get_block_templates( array(), 'wp_template' );
 				foreach ( get_post_types( array( 'public' => true ) ) as $type ) {
-					$block_templates = get_block_templates( array( 'post_type' => $type ), 'wp_template' );
 					foreach ( $block_templates as $block_template ) {
+						if ( ! $block_template->is_custom ) {
+							continue;
+						}
+
+						if ( isset( $block_template->post_types ) && ! in_array( $type, $block_template->post_types, true ) ) {
+							continue;
+						}
+
 						$post_templates[ $type ][ $block_template->slug ] = $block_template->title;
 					}
 				}


### PR DESCRIPTION
Follow-up for #2020.

This method calls `get_block_templates` once and uses block template properties directly for filtering. This way, we can avoid hitting the database for each public post type.

The previous method is useful when we already know the current post type we request templates for, like when using REST API.

Trac ticket: https://core.trac.wordpress.org/ticket/54335

---
Cc @youknowriad @noisysocks @hellofromtonya 
