### PR TITLE
Auto-enable block templates supports for block themes

### DIFF
--- a/src/wp-includes/theme-templates.php
+++ b/src/wp-includes/theme-templates.php
@@ -211,7 +211,7 @@ function the_block_template_skip_link() {
  * @since 5.8.0
  */
 function wp_enable_block_templates() {
-	if ( WP_Theme_JSON_Resolver::theme_has_support() ) {
+	if ( wp_is_block_theme() || WP_Theme_JSON_Resolver::theme_has_support() ) {
 		add_theme_support( 'block-templates' );
 	}
 }


### PR DESCRIPTION
Block themes without theme.json file didn't have block templates support enabled in Core by default while they did with the Gutenberg plugin, this fixes that.

Trac ticket: https://core.trac.wordpress.org/ticket/54335
