### PR TITLE
Theme JSON: add global block gap css vars

### DIFF
--- a/src/wp-content/themes/twentytwentytwo/theme.json
+++ b/src/wp-content/themes/twentytwentytwo/theme.json
@@ -36,32 +36,50 @@
 		"color": {
 			"duotone": [
 				{
-					"colors": [ "#000000", "#ffffff" ],
+					"colors": [
+						"#000000",
+						"#ffffff"
+					],
 					"slug": "foreground-and-background",
 					"name": "Foreground and background"
 				},
 				{
-					"colors": [ "#000000", "#ffe2c7" ],
+					"colors": [
+						"#000000",
+						"#ffe2c7"
+					],
 					"slug": "foreground-and-secondary",
 					"name": "Foreground and secondary"
 				},
 				{
-					"colors": [ "#000000", "#f6f6f6" ],
+					"colors": [
+						"#000000",
+						"#f6f6f6"
+					],
 					"slug": "foreground-and-tertiary",
 					"name": "Foreground and tertiary"
 				},
 				{
-					"colors": [ "#1a4548", "#ffffff" ],
+					"colors": [
+						"#1a4548",
+						"#ffffff"
+					],
 					"slug": "primary-and-background",
 					"name": "Primary and background"
 				},
 				{
-					"colors": [ "#1a4548", "#ffe2c7" ],
+					"colors": [
+						"#1a4548",
+						"#ffe2c7"
+					],
 					"slug": "primary-and-secondary",
 					"name": "Primary and secondary"
 				},
 				{
-					"colors": [ "#1a4548", "#f6f6f6" ],
+					"colors": [
+						"#1a4548",
+						"#f6f6f6"
+					],
 					"slug": "primary-and-tertiary",
 					"name": "Primary and tertiary"
 				}
@@ -330,7 +348,10 @@
 			}
 		},
 		"spacing": {
-			"blockGap": "1.5rem"
+			"blockGap": {
+				"row": "1.5em",
+				"column": "1.5em"
+			}
 		},
 		"typography": {
 			"fontFamily": "var(--wp--preset--font-family--system-font)",

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -201,14 +201,6 @@ class WP_Theme_JSON {
 	);
 
 	/**
-	 * Presets are a set of values that serve
-	 * to bootstrap some top-level styles: spacing, etc.
-	 */
-	const STYLE_DECLARATION_TRANSFORMS = array(
-		'--wp--style--block-gap' => array(),
-	);
-
-	/**
 	 * Protected style properties.
 	 *
 	 * These style properties are only rendered if a setting enables it
@@ -799,14 +791,17 @@ class WP_Theme_JSON {
 						'name'  => '--wp--style--block-gap',
 						'value' => $declarations_block_gap['--wp--style--block-gap']['value'],
 					);
-					$gap_values = explode( ' ', $declarations_block_gap['--wp--style--block-gap']['value'] );
+					// @TODO what if the shorthand value is something like "calc(100% - 20px)"
+					// Do we need to regex the values?
+					// I don't think we should care about short hand here, and assume that theme.json users will split according to row and column.
+					//$gap_values = explode( ' ', $declarations_block_gap['--wp--style--block-gap']['value'] );
 					$declarations[] = array(
 						'name'  => '--wp--style--block-gap-row',
-						'value' => $gap_values[0],
+						'value' => $declarations_block_gap['--wp--style--block-gap']['value'],
 					);
 					$declarations[] = array(
 						'name'  => '--wp--style--block-gap-column',
-						'value' => isset( $gap_values[1] ) ? $gap_values[1] : $gap_values[0],
+						'value' => $declarations_block_gap['--wp--style--block-gap']['value'],
 					);
 				}
 
@@ -1332,9 +1327,6 @@ class WP_Theme_JSON {
 			if ( $has_missing_value || is_array( $value ) ) {
 				continue;
 			}
-
-			// @TODO we could use the $css_property as a key and update $declarations accordingly
-
 
 			$declarations[] = array(
 				'name'  => $css_property,

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -785,30 +785,40 @@ class WP_Theme_JSON {
 				}
 			}
 
+			// @TODO how to better extract this?
 			if ( ! empty( $declarations_block_gap ) ) {
 				if ( isset( $declarations_block_gap['--wp--style--block-gap'] ) ) {
 					$declarations[] = array(
 						'name'  => '--wp--style--block-gap',
 						'value' => $declarations_block_gap['--wp--style--block-gap']['value'],
 					);
-					// @TODO what if the shorthand value is something like "calc(100% - 20px)"
-					// Do we need to regex the values?
-					// I don't think we should care about short hand here, and assume that theme.json users will split according to row and column.
-					//$gap_values = explode( ' ', $declarations_block_gap['--wp--style--block-gap']['value'] );
-					$declarations[] = array(
-						'name'  => '--wp--style--block-gap-row',
-						'value' => $declarations_block_gap['--wp--style--block-gap']['value'],
-					);
-					$declarations[] = array(
-						'name'  => '--wp--style--block-gap-column',
-						'value' => $declarations_block_gap['--wp--style--block-gap']['value'],
-					);
+					// @TODO what if the shorthand value is something like "calc(100% - 20px)"??
+					// Or should we regex and enforce only number + unit??
+					if ( preg_match( '/^([\d\.]+[a-z%]+[\s]{0,1}){1,2}/', $declarations_block_gap['--wp--style--block-gap']['value'] ) ) {
+						$gap_values = explode( ' ', $declarations_block_gap['--wp--style--block-gap']['value'] );
+						$declarations[] = array(
+							'name'  => '--wp--style--block-gap-row',
+							'value' => $gap_values[0],
+						);
+						$declarations[] = array(
+							'name'  => '--wp--style--block-gap-column',
+							'value' => isset( $gap_values[1] ) ? $gap_values[1] : $gap_values[0],
+						);
+					}
 				}
 
 				if ( isset( $declarations_block_gap['--wp--style--block-gap-row'] ) && isset( $declarations_block_gap['--wp--style--block-gap-column'] ) ) {
 					$declarations[] = array(
 						'name'  => '--wp--style--block-gap',
 						'value' => $declarations_block_gap['--wp--style--block-gap-row']['value'] . ' ' . $declarations_block_gap['--wp--style--block-gap-column']['value'],
+					);
+					$declarations[] = array(
+						'name'  => '--wp--style--block-gap-row',
+						'value' => $declarations_block_gap['--wp--style--block-gap-row']['value'],
+					);
+					$declarations[] = array(
+						'name'  => '--wp--style--block-gap-column',
+						'value' => $declarations_block_gap['--wp--style--block-gap-column']['value'],
 					);
 				}
 			}


### PR DESCRIPTION
Initial commit to test how and where to manipulate the style declarations for block gap.

See: https://github.com/WordPress/gutenberg/pull/35454

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
