### PR TITLE
Revert infinite scroll and library.more changes (Trac 53765)

### DIFF
--- a/src/js/media/controllers/featured-image.js
+++ b/src/js/media/controllers/featured-image.js
@@ -106,7 +106,6 @@ FeaturedImage = Library.extend(/** @lends wp.media.controller.FeaturedImage.prot
 	 */
 	updateSelection: function() {
 		var selection = this.get('selection'),
-			library = this.get('library'),
 			id = wp.media.view.settings.post.featuredImageId,
 			attachment;
 
@@ -116,10 +115,6 @@ FeaturedImage = Library.extend(/** @lends wp.media.controller.FeaturedImage.prot
 		}
 
 		selection.reset( attachment ? [ attachment ] : [] );
-
-		if ( library.hasMore() ) {
-			library.more();
-		}
 	}
 });
 

--- a/src/js/media/controllers/featured-image.js
+++ b/src/js/media/controllers/featured-image.js
@@ -108,7 +108,6 @@ FeaturedImage = Library.extend(/** @lends wp.media.controller.FeaturedImage.prot
 		var selection = this.get('selection'),
 			library = this.get('library'),
 			id = wp.media.view.settings.post.featuredImageId,
-			infiniteScrolling = wp.media.view.settings.infiniteScrolling,
 			attachment;
 
 		if ( '' !== id && -1 !== id ) {
@@ -118,7 +117,7 @@ FeaturedImage = Library.extend(/** @lends wp.media.controller.FeaturedImage.prot
 
 		selection.reset( attachment ? [ attachment ] : [] );
 
-		if ( ! infiniteScrolling && library.hasMore() ) {
+		if ( ! infinite_scrolling && library.hasMore() ) {
 			library.more();
 		}
 	}

--- a/src/js/media/controllers/featured-image.js
+++ b/src/js/media/controllers/featured-image.js
@@ -117,7 +117,7 @@ FeaturedImage = Library.extend(/** @lends wp.media.controller.FeaturedImage.prot
 
 		selection.reset( attachment ? [ attachment ] : [] );
 
-		if ( ! infinite_scrolling && library.hasMore() ) {
+		if ( library.hasMore() ) {
 			library.more();
 		}
 	}

--- a/src/js/media/controllers/replace-image.js
+++ b/src/js/media/controllers/replace-image.js
@@ -90,8 +90,18 @@ ReplaceImage = Library.extend(/** @lends wp.media.controller.ReplaceImage.protot
 	 * @since 3.9.0
 	 */
 	activate: function() {
-		this.updateSelection();
+		this.frame.on( 'content:render:browse', this.updateSelection, this );
+
 		Library.prototype.activate.apply( this, arguments );
+	},
+
+	/**
+	 * @since 5.9.0
+	 */
+	deactivate: function() {
+		this.frame.off( 'content:render:browse', this.updateSelection, this );
+
+		Library.prototype.deactivate.apply( this, arguments );
 	},
 
 	/**

--- a/src/js/media/controllers/replace-image.js
+++ b/src/js/media/controllers/replace-image.js
@@ -104,7 +104,7 @@ ReplaceImage = Library.extend(/** @lends wp.media.controller.ReplaceImage.protot
 
 		selection.reset( attachment ? [ attachment ] : [] );
 
-		if ( ! infinite_scrolling && library.getTotalAttachments() == 0 && library.hasMore() ) {
+		if ( library.hasMore() ) {
 			library.more();
 		}
 	}

--- a/src/js/media/controllers/replace-image.js
+++ b/src/js/media/controllers/replace-image.js
@@ -99,14 +99,9 @@ ReplaceImage = Library.extend(/** @lends wp.media.controller.ReplaceImage.protot
 	 */
 	updateSelection: function() {
 		var selection = this.get('selection'),
-			library = this.get('library'),
 			attachment = this.image.attachment;
 
 		selection.reset( attachment ? [ attachment ] : [] );
-
-		if ( library.hasMore() ) {
-			library.more();
-		}
 	}
 });
 

--- a/src/js/media/controllers/replace-image.js
+++ b/src/js/media/controllers/replace-image.js
@@ -100,12 +100,11 @@ ReplaceImage = Library.extend(/** @lends wp.media.controller.ReplaceImage.protot
 	updateSelection: function() {
 		var selection = this.get('selection'),
 			library = this.get('library'),
-			attachment = this.image.attachment,
-			infiniteScrolling = wp.media.view.settings.infiniteScrolling;
+			attachment = this.image.attachment;
 
 		selection.reset( attachment ? [ attachment ] : [] );
 
-		if ( ! infiniteScrolling && library.getTotalAttachments() === 0 && library.hasMore() ) {
+		if ( ! infinite_scrolling && library.getTotalAttachments() == 0 && library.hasMore() ) {
 			library.more();
 		}
 	}


### PR DESCRIPTION
Reverts [52287-52288]
Partial revert of [52167] - reverts the `library.more()` logic

Trac ticket: https://core.trac.wordpress.org/ticket/53765

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
