### PR TITLE
Backward compatibility for the sanitize_key function

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2132,11 +2132,15 @@ function sanitize_user( $username, $strict = false ) {
  *
  * @since 3.0.0
  *
- * @param int|float|string $key String key
+ * @param string $key String key
  * @return string Sanitized key
  */
 function sanitize_key( $key ) {
 	$raw_key = $key;
+
+	if ( ! is_string( $key ) ) {
+		_deprecated_argument( __FUNCTION__, '5.9', 'The `sanitize_key` function supports only the `string` type for the `$key` argument.' );
+	}
 
 	if ( is_array( $key ) || is_object( $key ) ) {
 		$key = '';

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2132,13 +2132,13 @@ function sanitize_user( $username, $strict = false ) {
  *
  * @since 3.0.0
  *
- * @param string $key String key
+ * @param int|float|string $key String key
  * @return string Sanitized key
  */
 function sanitize_key( $key ) {
 	$raw_key = $key;
 
-	if ( ! is_string( $key ) ) {
+	if ( is_array( $key ) || is_object( $key ) ) {
 		$key = '';
 	}
 

--- a/tests/phpunit/tests/formatting/sanitizeKey.php
+++ b/tests/phpunit/tests/formatting/sanitizeKey.php
@@ -29,7 +29,15 @@ class Tests_Formatting_SanitizeKey extends WP_UnitTestCase {
 			),
 			'an int 0 key'                   => array(
 				'key'      => 0,
-				'expected' => '',
+				'expected' => '0',
+			),
+			'an int 345 key'                 => array(
+				'key'      => 345,
+				'expected' => '345',
+			),
+			'a float 1.345 key'              => array(
+				'key'      => 1.345,
+				'expected' => '1345',
 			),
 			'a true key'                     => array(
 				'key'      => true,

--- a/tests/phpunit/tests/formatting/sanitizeKey.php
+++ b/tests/phpunit/tests/formatting/sanitizeKey.php
@@ -41,7 +41,7 @@ class Tests_Formatting_SanitizeKey extends WP_UnitTestCase {
 			),
 			'a true key'                     => array(
 				'key'      => true,
-				'expected' => '',
+				'expected' => '1',
 			),
 			'an array key'                   => array(
 				'key'      => array( 'Howdy, admin!' ),


### PR DESCRIPTION
I fixed the `sanitize_key` function due to backward compatibility with oldest WordPress versions.

Trac ticket: [<!-- insert a link to the WordPress Trac ticket here -->](https://core.trac.wordpress.org/ticket/54160)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
