### PR TITLE
Set key to empty string when not a scalar type in sanitize_key(). Trac 54160

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2132,19 +2132,17 @@ function sanitize_user( $username, $strict = false ) {
  *
  * @since 3.0.0
  *
- * @param string $key String key
- * @return string Sanitized key
+ * @param string $key String key.
+ * @return string Sanitized key.
  */
 function sanitize_key( $key ) {
 	$raw_key = $key;
 
-	if ( ! is_string( $key ) ) {
-		$key = '';
-	}
-
-	if ( '' !== $key ) {
+	if ( is_scalar( $key ) ) {
 		$key = strtolower( $key );
 		$key = preg_replace( '/[^a-z0-9_\-]/', '', $key );
+	} else {
+		$key = '';
 	}
 
 	/**

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2136,13 +2136,11 @@ function sanitize_user( $username, $strict = false ) {
  * @return string Sanitized key.
  */
 function sanitize_key( $key ) {
-	$raw_key = $key;
+	$sanitized_key = '';
 
 	if ( is_scalar( $key ) ) {
-		$key = strtolower( $key );
-		$key = preg_replace( '/[^a-z0-9_\-]/', '', $key );
-	} else {
-		$key = '';
+		$sanitized_key = strtolower( $key );
+		$sanitized_key = preg_replace( '/[^a-z0-9_\-]/', '', $sanitized_key );
 	}
 
 	/**
@@ -2150,10 +2148,10 @@ function sanitize_key( $key ) {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param string $key     Sanitized key.
-	 * @param string $raw_key The key prior to sanitization.
+	 * @param string $sanitized_key Sanitized key.
+	 * @param string $key           The key prior to sanitization.
 	 */
-	return apply_filters( 'sanitize_key', $key, $raw_key );
+	return apply_filters( 'sanitize_key', $sanitized_key, $key );
 }
 
 /**

--- a/tests/phpunit/tests/formatting/sanitizeKey.php
+++ b/tests/phpunit/tests/formatting/sanitizeKey.php
@@ -7,36 +7,25 @@
 class Tests_Formatting_SanitizeKey extends WP_UnitTestCase {
 
 	/**
-	 * @ticket 54160
+	 * @ticket       54160
 	 * @dataProvider data_sanitize_key
 	 *
-	 * @param mixed $key       The key to sanitize.
-	 * @param mixed $expected  The expected value.
+	 * @param string $key      The key to sanitize.
+	 * @param string $expected The expected value.
 	 */
 	public function test_sanitize_key( $key, $expected ) {
 		$this->assertSame( $expected, sanitize_key( $key ) );
 	}
 
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
 	public function data_sanitize_key() {
 		return array(
 			'an empty string key'            => array(
 				'key'      => '',
-				'expected' => '',
-			),
-			'a null key'                     => array(
-				'key'      => null,
-				'expected' => '',
-			),
-			'an int 0 key'                   => array(
-				'key'      => 0,
-				'expected' => '',
-			),
-			'a true key'                     => array(
-				'key'      => true,
-				'expected' => '',
-			),
-			'an array key'                   => array(
-				'key'      => array( 'Howdy, admin!' ),
 				'expected' => '',
 			),
 			'a lowercase key with commas'    => array(
@@ -71,6 +60,76 @@ class Tests_Formatting_SanitizeKey extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket       54160
+	 * @dataProvider data_sanitize_key_nonstring_scalar
+	 *
+	 * @param mixed  $key      The key to sanitize.
+	 * @param string $expected The expected value.
+	 */
+	public function test_sanitize_key_nonstring_scalar( $key, $expected ) {
+		$this->assertSame( $expected, sanitize_key( $key ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_sanitize_key_nonstring_scalar() {
+		return array(
+			'integer type'  => array(
+				'key'      => 0,
+				'expected' => '0',
+			),
+			'boolean true'  => array(
+				'key'      => true,
+				'expected' => '1',
+			),
+			'boolean false' => array(
+				'key'      => false,
+				'expected' => '',
+			),
+			'float type'    => array(
+				'key'      => 0.123,
+				'expected' => '0123',
+			),
+		);
+	}
+
+	/**
+	 * @ticket       54160
+	 * @dataProvider data_sanitize_key_with_non_scalars
+	 *
+	 * @param mixed $key      The key to sanitize.
+	 * @param mixed $expected The expected value.
+	 */
+	public function test_sanitize_key_with_non_scalars( $key, $expected ) {
+		$this->assertSame( $expected, sanitize_key( $key ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_sanitize_key_with_non_scalars() {
+		return array(
+			'array type' => array(
+				'key'      => array( 'key' ),
+				'expected' => '',
+			),
+			'null'       => array(
+				'key'      => null,
+				'expected' => '',
+			),
+			'object'     => array(
+				'key'      => new stdClass(),
+				'expected' => '',
+			),
+		);
+	}
+
+	/**
 	 * @ticket 54160
 	 *
 	 * @covers WP_Hook::sanitize_key
@@ -80,7 +139,7 @@ class Tests_Formatting_SanitizeKey extends WP_UnitTestCase {
 
 		add_filter(
 			'sanitize_key',
-			static function( $key ) {
+			static function ( $key ) {
 				return 'Howdy, admin!';
 			}
 		);

--- a/tests/phpunit/tests/formatting/sanitizeKey.php
+++ b/tests/phpunit/tests/formatting/sanitizeKey.php
@@ -100,11 +100,20 @@ class Tests_Formatting_SanitizeKey extends WP_UnitTestCase {
 	 * @ticket       54160
 	 * @dataProvider data_sanitize_key_with_non_scalars
 	 *
-	 * @param mixed $key      The key to sanitize.
-	 * @param mixed $expected The expected value.
+	 * @param mixed $nonscalar_key A non-scalar data type given as a key.
 	 */
-	public function test_sanitize_key_with_non_scalars( $key, $expected ) {
-		$this->assertSame( $expected, sanitize_key( $key ) );
+	public function test_sanitize_key_with_non_scalars( $nonscalar_key ) {
+		add_filter(
+			'sanitize_key',
+			function ( $sanitized_key, $key ) use ( $nonscalar_key ) {
+				$this->assertEmpty( $sanitized_key, 'Empty string not passed as first filtered argument' );
+				$this->assertSame( $nonscalar_key, $key, 'Given unsanitized key not passed as second filtered argument' );
+				return $sanitized_key;
+			},
+			10,
+			2
+		);
+		$this->assertEmpty( sanitize_key( $nonscalar_key ), 'Non-scalar key did not return empty string' );
 	}
 
 	/**
@@ -127,23 +136,5 @@ class Tests_Formatting_SanitizeKey extends WP_UnitTestCase {
 				'expected' => '',
 			),
 		);
-	}
-
-	/**
-	 * @ticket 54160
-	 *
-	 * @covers WP_Hook::sanitize_key
-	 */
-	public function test_filter_sanitize_key() {
-		$key = 'Howdy, admin!';
-
-		add_filter(
-			'sanitize_key',
-			static function ( $key ) {
-				return 'Howdy, admin!';
-			}
-		);
-
-		$this->assertSame( $key, sanitize_key( $key ) );
 	}
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/54160

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
