### PR TITLE
Fix deprecated usage of passing null to explode()

### DIFF
--- a/src/wp-includes/block-supports/layout.php
+++ b/src/wp-includes/block-supports/layout.php
@@ -46,8 +46,8 @@ function wp_get_layout_style( $selector, $layout, $has_block_gap_support = false
 
 	$style = '';
 	if ( 'default' === $layout_type ) {
-		$content_size = isset( $layout['contentSize'] ) ? $layout['contentSize'] : null;
-		$wide_size    = isset( $layout['wideSize'] ) ? $layout['wideSize'] : null;
+		$content_size = isset( $layout['contentSize'] ) ? $layout['contentSize'] : '';
+		$wide_size    = isset( $layout['wideSize'] ) ? $layout['wideSize'] : '';
 
 		$all_max_width_value  = $content_size ? $content_size : $wide_size;
 		$wide_max_width_value = $wide_size ? $wide_size : $content_size;


### PR DESCRIPTION
As of PHP 8.1, explode() does not permit null as its second argument. This results in warnings being spat out on every page because of a usage of this in `wp-includes/block-supports/layout.php`.

Trac ticket: https://core.trac.wordpress.org/ticket/53635

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
