### PR TITLE
Check whether WP is still installing before accessing site option `can_compress_scripts`

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2229,6 +2229,8 @@ function script_concat_settings() {
 
 	$compressed_output = ( ini_get( 'zlib.output_compression' ) || 'ob_gzhandler' === ini_get( 'output_handler' ) );
 
+	$can_compress_scripts = ! wp_installing() && get_site_option( 'can_compress_scripts' );
+
 	if ( ! isset( $concatenate_scripts ) ) {
 		$concatenate_scripts = defined( 'CONCATENATE_SCRIPTS' ) ? CONCATENATE_SCRIPTS : true;
 		if ( ( ! is_admin() && ! did_action( 'login_init' ) ) || ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ) {
@@ -2238,14 +2240,14 @@ function script_concat_settings() {
 
 	if ( ! isset( $compress_scripts ) ) {
 		$compress_scripts = defined( 'COMPRESS_SCRIPTS' ) ? COMPRESS_SCRIPTS : true;
-		if ( $compress_scripts && ( ! get_site_option( 'can_compress_scripts' ) || $compressed_output ) ) {
+		if ( $compress_scripts && ( ! $can_compress_scripts || $compressed_output ) ) {
 			$compress_scripts = false;
 		}
 	}
 
 	if ( ! isset( $compress_css ) ) {
 		$compress_css = defined( 'COMPRESS_CSS' ) ? COMPRESS_CSS : true;
-		if ( $compress_css && ( ! get_site_option( 'can_compress_scripts' ) || $compressed_output ) ) {
+		if ( $compress_css && ( ! $can_compress_scripts || $compressed_output ) ) {
 			$compress_css = false;
 		}
 	}


### PR DESCRIPTION
When installing a multisite, there is a potential access to a non-existent database table that needs to be skipped to avoid warnings/errors.

```
001 Scenario: Install WordPress multisite with existing multisite constants in wp-config file                                                                         # features/core-install.feature:204
      When I run `wp core multisite-install --url=foobar.org --title=Test --admin_user=wpcli --admin_email=admin@example.com --admin_password=password --skip-config` # features/core-install.feature:226
        $ wp core multisite-install --url=foobar.org --title=Test --admin_user=wpcli --admin_email=admin@example.com --admin_password=password --skip-config
        WP-CLI test suite: Sent email to admin@example.com.
        Created single site database tables.
        Set up multisite database tables.
        Success: Network installed. Don't forget to set up rewrite rules (and a .htaccess file, if using Apache).

        WordPress database error Table 'wp_cli_test.wp_sitemeta' doesn't exist for query SELECT meta_value FROM wp_sitemeta WHERE meta_key = 'can_compress_scripts' AND site_id = 1 made by require_once('vendor/wp-cli/wp-cli/php/wp-cli.php'), WP_CLI\bootstrap, WP_CLI\Bootstrap\LaunchRunner->process, WP_CLI\Runner->start, WP_CLI\Runner->load_wordpress, require('wp-settings.php'), do_action('init'), WP_Hook->do_action, WP_Hook->apply_filters, register_block_core_file, register_block_type_from_metadata, register_block_script_handle, wp_register_script, wp_scripts, WP_Scripts->__construct, WP_Scripts->init, do_action_ref_array('wp_default_scripts'), WP_Hook->do_action, WP_Hook->apply_filters, wp_default_packages, wp_register_tinymce_scripts, script_concat_settings, get_site_option, get_network_option
        cwd: /tmp/wp-cli-test-run--61ba15774b81d8.03513765/
        run time: 1.1995339393616
        exit status: 0 (RuntimeException)
```

The problem comes from the `script_concat_settings()` function (triggered by `'wp_default_scripts'` => `wp_register_tinymce_scripts()`), which tries to retrieve the site option `'can_compress_scripts'`.

This PR adapts the code so that it first checks whether WP is installing before trying to retrieve the site option. During WP installation, script compression defaults to false.

This PR also optimizes the check by storing the DB request, instead of executing it twice.

Trac ticket: https://core.trac.wordpress.org/ticket/54634

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
