### PR TITLE
Fix taxonomy term quick edit not saving if taxonomy has non-latin characters

### DIFF
--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -2097,13 +2097,6 @@ function wp_ajax_inline_save() {
 function wp_ajax_inline_save_tax() {
 	check_ajax_referer( 'taxinlineeditnonce', '_inline_edit' );
 
-	$taxonomy = sanitize_key( $_POST['taxonomy'] );
-	$tax      = get_taxonomy( $taxonomy );
-
-	if ( ! $tax ) {
-		wp_die( 0 );
-	}
-
 	if ( ! isset( $_POST['tax_ID'] ) || ! (int) $_POST['tax_ID'] ) {
 		wp_die( -1 );
 	}
@@ -2114,9 +2107,15 @@ function wp_ajax_inline_save_tax() {
 		wp_die( -1 );
 	}
 
+	// Get the tag just by ID, without the taxonomy argument and then get the taxonomy from the tag.
+	$tag = get_term( $id );
+	if ( ! $tag || is_wp_error( $tag ) ) {
+		wp_die( 0 );
+	}
+	$taxonomy = $tag->taxonomy;
+
 	$wp_list_table = _get_list_table( 'WP_Terms_List_Table', array( 'screen' => 'edit-' . $taxonomy ) );
 
-	$tag                  = get_term( $id, $taxonomy );
 	$_POST['description'] = $tag->description;
 
 	$updated = wp_update_term( $id, $taxonomy, $_POST );

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -2107,7 +2107,6 @@ function wp_ajax_inline_save_tax() {
 		wp_die( -1 );
 	}
 
-	// Get the tag just by ID, without the taxonomy argument and then get the taxonomy from the tag.
 	$tag = get_term( $id );
 	if ( ! $tag || is_wp_error( $tag ) ) {
 		wp_die( 0 );

--- a/tests/phpunit/tests/ajax/QuickEdit.php
+++ b/tests/phpunit/tests/ajax/QuickEdit.php
@@ -83,4 +83,81 @@ class Tests_Ajax_QuickEdit extends WP_Ajax_UnitTestCase {
 		$post_terms_2 = wp_get_object_terms( $post->ID, 'wptests_tax_2' );
 		$this->assertSameSets( array( $t2 ), wp_list_pluck( $post_terms_2, 'term_id' ) );
 	}
+
+	/**
+	 * @ticket 54521
+	 */
+	public function test_term_quick_edit() {
+
+		$taxonomy = 'wp_latin_tax';
+
+		register_taxonomy( $taxonomy, array( 'post' ) );
+
+		$term = self::factory()->term->create_and_get( array( 'taxonomy' => $taxonomy ) );
+
+		// Become an administrator.
+		$this->_setRole( 'administrator' );
+
+		// Set up a request.
+		$_POST['_inline_edit'] = wp_create_nonce( 'taxinlineeditnonce' );
+		$_POST['name']         = $term->name . '-updated';
+		$_POST['slug']         = $term->slug . '-updated';
+		$_POST['taxonomy']     = array( $taxonomy );
+		$_POST['post_type']    = 'post';
+		$_POST['tax_type']     = 'tag';
+		$_POST['tax_ID']       = $term->term_id;
+
+		// Make the request.
+		try {
+			$this->_handleAjax( 'inline-save-tax' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+		}
+
+		// Retrieve the updated term.
+		$updated_term = get_term( $term->term_id );
+
+		// Ensure that the previously fetched term and updated one have the same values.
+		$this->assertSame( $term->name . '-updated', $updated_term->name );
+		$this->assertSame( $term->slug . '-updated', $updated_term->slug );
+	}
+
+	/**
+	 * @ticket 54521
+	 */
+	public function test_term_quick_edit_non_latin_slug() {
+
+		$taxonomy = 'wp_ελληνικο_tax';
+
+		register_taxonomy( $taxonomy, array( 'post' ) );
+
+		$term = self::factory()->term->create_and_get( array( 'taxonomy' => $taxonomy ) );
+
+		// Become an administrator.
+		$this->_setRole( 'administrator' );
+
+		// Set up a request.
+		$_POST['_inline_edit'] = wp_create_nonce( 'taxinlineeditnonce' );
+		$_POST['name']         = $term->name . '-updated';
+		$_POST['slug']         = $term->slug . '-updated';
+		$_POST['taxonomy']     = array( $taxonomy );
+		$_POST['post_type']    = 'post';
+		$_POST['tax_type']     = 'tag';
+		$_POST['tax_ID']       = $term->term_id;
+
+		// Make the request.
+		try {
+			$this->_handleAjax( 'inline-save-tax' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+		}
+
+		// Retrieve the updated term.
+		$updated_term = get_term( $term->term_id );
+
+		// Ensure that the previously fetched term and updated one have the same values.
+		$this->assertSame( $term->name . '-updated', $updated_term->name );
+		$this->assertSame( $term->slug . '-updated', $updated_term->slug );
+	}
+
 }


### PR DESCRIPTION
WordPress allows taxonomies to be created with non-latin characters. 

Quick edit on terms that belong to those taxonomies, fail with an error `0`.

The issue started from this https://github.com/woocommerce/woocommerce/issues/31037 ticket.

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/54521

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
