### PR TITLE
Fixes and improves `wp_list_bookmarks()` tests (Trac 53839)

### DIFF
--- a/tests/phpunit/tests/bookmark/wpListBookmarks.php
+++ b/tests/phpunit/tests/bookmark/wpListBookmarks.php
@@ -15,11 +15,12 @@ class Tests_Functions_wpListBookmarks extends WP_UnitTestCase {
 	 *
 	 * @ticket 53839
 	 *
-	 * @param array $args The arguments to create the bookmark.
+	 * @param array $args      The arguments to create the bookmark.
+	 * @param string $expected Expected string to test.
 	 */
-	public function test_wp_list_bookmarks_adds_noopener( $args ) {
-		$bookmark = self::factory()->bookmark->create( $args );
-		$this->assertStringContainsString( 'noopener', wp_list_bookmarks( 'echo=0' ) );
+	public function test_wp_list_bookmarks_adds_noopener( $args, $expected ) {
+		self::factory()->bookmark->create( $args );
+		$this->assertStringContainsString( $expected, wp_list_bookmarks( 'echo=0' ) );
 	}
 
 	/**
@@ -30,34 +31,38 @@ class Tests_Functions_wpListBookmarks extends WP_UnitTestCase {
 	public function data_wp_list_bookmarks_adds_noopener() {
 		return array(
 			'target as "_blank"'                         => array(
-				'args' => array(
+				'args'     => array(
 					'link_name'   => 'With _blank',
 					'link_url'    => 'https://www.wordpress.org',
 					'link_target' => '_blank',
 				),
+				'expected' => 'rel="noopener"',
 			),
 			'target as "_blank" and a link relationship' => array(
-				'args' => array(
+				'args'     => array(
 					'link_name'   => 'With _blank and a link relationship',
 					'link_url'    => 'https://www.wordpress.org',
 					'link_target' => '_blank',
-					'rel'         => 'me',
+					'link_rel'    => 'me',
 				),
+				'expected' => 'rel="me noopener"',
 			),
 			'target as "_top"'                           => array(
-				'args' => array(
+				'args'     => array(
 					'link_name'   => 'With _top',
 					'link_url'    => 'https://www.wordpress.org',
 					'link_target' => '_top',
 				),
+				'expected' => 'rel="noopener"',
 			),
 			'target as "_top" and a link relationship'   => array(
-				'args' => array(
+				'args'     => array(
 					'link_name'   => 'With _top and a link relationship',
 					'link_url'    => 'https://www.wordpress.org',
 					'link_target' => '_top',
-					'rel'         => 'me',
+					'link_rel'    => 'me',
 				),
+				'expected' => 'rel="me noopener"',
 			),
 		);
 	}
@@ -72,7 +77,7 @@ class Tests_Functions_wpListBookmarks extends WP_UnitTestCase {
 	 * @param array $args The arguments to create the bookmark.
 	 */
 	public function test_wp_list_bookmarks_does_not_add_noopener( $args ) {
-		$bookmark = self::factory()->bookmark->create( $args );
+		self::factory()->bookmark->create( $args );
 		$this->assertStringNotContainsString( 'noopener', wp_list_bookmarks( 'echo=0' ) );
 	}
 
@@ -95,7 +100,7 @@ class Tests_Functions_wpListBookmarks extends WP_UnitTestCase {
 					'link_name'   => 'With _blank and a link relationship',
 					'link_url'    => 'https://www.wordpress.org',
 					'link_target' => '_none',
-					'rel'         => 'me',
+					'link_rel'    => 'me',
 				),
 			),
 		);


### PR DESCRIPTION
Combines patch https://core.trac.wordpress.org/attachment/ticket/53839/53839-2.diff with existing tests by:

- Changing `rel` to `link_rel` in args
- Adding `$expected` string in the `test_wp_list_bookmarks_adds_noopener()` test (which replaces the new `test_wp_list_bookmarks_adds_noopener_keep_original()` test in the 53839-2.diff patch

Props @david.binda.

Trac ticket: https://core.trac.wordpress.org/ticket/53839

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
