### PR TITLE
Avoids performance issue caused by getting site icon for every site to display in admin bar.

### DIFF
--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -614,7 +614,7 @@ function wp_admin_bar_my_sites_menu( $wp_admin_bar ) {
 	foreach ( (array) $wp_admin_bar->user->blogs as $blog ) {
 		switch_to_blog( $blog->userblog_id );
 
-		if ( has_site_icon() ) {
+		if ( apply_filters( 'show_site_icons_in_toolbar', true ) && has_site_icon() ) {
 			$blavatar = sprintf(
 				'<img class="blavatar" src="%s" srcset="%s 2x" alt="" width="16" height="16" />',
 				esc_url( get_site_icon_url( 16 ) ),


### PR DESCRIPTION
This avoids performance issue caused by having to get the site icon three times, which has a huge negative impact in multisite networks.

Trac ticket: [#54447](https://core.trac.wordpress.org/ticket/54447)
