### PR TITLE
[Patterns]: Update Query Loop patterns with less posts per page

### DIFF
--- a/src/wp-includes/block-patterns/query-grid-posts.php
+++ b/src/wp-includes/block-patterns/query-grid-posts.php
@@ -9,7 +9,7 @@ return array(
 	'title'      => _x( 'Grid', 'Block pattern title' ),
 	'blockTypes' => array( 'core/query' ),
 	'categories' => array( 'query' ),
-	'content'    => '<!-- wp:query {"query":{"perPage":6,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"displayLayout":{"type":"flex","columns":3}} -->
+	'content'    => '<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"displayLayout":{"type":"flex","columns":3}} -->
 					<div class="wp-block-query">
 					<!-- wp:post-template -->
 					<!-- wp:group {"style":{"spacing":{"padding":{"top":"30px","right":"30px","bottom":"30px","left":"30px"}}},"layout":{"inherit":false}} -->

--- a/src/wp-includes/block-patterns/query-medium-posts.php
+++ b/src/wp-includes/block-patterns/query-medium-posts.php
@@ -9,7 +9,7 @@ return array(
 	'title'      => _x( 'Image at left', 'Block pattern title' ),
 	'blockTypes' => array( 'core/query' ),
 	'categories' => array( 'query' ),
-	'content'    => '<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
+	'content'    => '<!-- wp:query {"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
 					<div class="wp-block-query">
 					<!-- wp:post-template -->
 					<!-- wp:columns {"align":"wide"} -->

--- a/src/wp-includes/block-patterns/query-small-posts.php
+++ b/src/wp-includes/block-patterns/query-small-posts.php
@@ -9,7 +9,7 @@ return array(
 	'title'      => _x( 'Small image and title', 'Block pattern title' ),
 	'blockTypes' => array( 'core/query' ),
 	'categories' => array( 'query' ),
-	'content'    => '<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
+	'content'    => '<!-- wp:query {"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
 					<div class="wp-block-query">
 					<!-- wp:post-template -->
 					<!-- wp:columns {"verticalAlignment":"center"} -->

--- a/src/wp-includes/block-patterns/query-standard-posts.php
+++ b/src/wp-includes/block-patterns/query-standard-posts.php
@@ -9,7 +9,7 @@ return array(
 	'title'      => _x( 'Standard', 'Block pattern title' ),
 	'blockTypes' => array( 'core/query' ),
 	'categories' => array( 'query' ),
-	'content'    => '<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
+	'content'    => '<!-- wp:query {"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
 					<div class="wp-block-query">
 					<!-- wp:post-template -->
 					<!-- wp:post-title {"isLink":true} /-->


### PR DESCRIPTION


Trac ticket: https://core.trac.wordpress.org/ticket/54639

I think we need to 'lighten' the Query Loop patterns regarding the number of posts it previews. The point of a pattern is to showcase some design and with some pre-selected blocks(the inner Post blocks, etc..). It's already opinionated about the number of posts, so we could just show the minimum number required to make the pattern show its point.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
