### PR TITLE
Blocks: Add support for themes to block API v2 with assets in block.json

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -106,8 +106,9 @@ function register_block_script_handle( $metadata, $field_name ) {
 	$wpinc_path_norm  = wp_normalize_path( ABSPATH . WPINC );
 	$script_path_norm = wp_normalize_path( realpath( dirname( $metadata['file'] ) . '/' . $script_path ) );
 	$is_core_block    = isset( $metadata['file'] ) && 0 === strpos( $metadata['file'], $wpinc_path_norm );
-	$is_plugin_block  = strpos( $metadata['file'], 'wp-content/plugins' );
-	$is_theme_block   = strpos( $metadata['file'], 'wp-content/themes' );
+	$is_plugin_block  = isset( $metadata['file'] ) && strpos( $metadata['file'], 'wp-content/plugins' );
+	$is_theme_block   = isset( $metadata['file'] ) && strpos( $metadata['file'], 'wp-content/themes' );
+	$script_uri       = false;
 
 	if ( false !== $is_plugin_block ) {
 		$script_uri = plugins_url( $script_path, $metadata['file'] );
@@ -161,8 +162,9 @@ function register_block_style_handle( $metadata, $field_name ) {
 	}
 	$wpinc_path_norm = wp_normalize_path( ABSPATH . WPINC );
 	$is_core_block   = isset( $metadata['file'] ) && 0 === strpos( $metadata['file'], $wpinc_path_norm );
-	$is_plugin_block = strpos( $metadata['file'], 'wp-content/plugins' );
-	$is_theme_block  = strpos( $metadata['file'], 'wp-content/themes' );
+	$is_plugin_block = isset( $metadata['file'] ) && strpos( $metadata['file'], 'wp-content/plugins' );
+	$is_theme_block  = isset( $metadata['file'] ) && strpos( $metadata['file'], 'wp-content/themes' );
+	$style_uri       = false;
 
 	if ( $is_core_block && ! wp_should_load_separate_core_block_assets() ) {
 		return false;


### PR DESCRIPTION
**Issue**
When you register blocks with block.json in your theme, yo had a assets's URL error because use plugins_url() by default.

**Solution**
Modify register_block_script_handle()and register_block_style_handle()to validate path of assets and return this correctly.
In this way it adds support to register blocks from themes.

Trac ticket: #54647

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
