### PR TITLE
Trac:54637: ensure correct parameters type for exif_read_metadata filter

### DIFF
--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -763,6 +763,10 @@ function wp_read_image_metadata( $file ) {
 				$iptc = @iptcparse( $info['APP13'] );
 			}
 
+			if ( ! is_array( $iptc ) ) {
+				$iptc = array();
+			}
+
 			// Headline, "A brief synopsis of the caption".
 			if ( ! empty( $iptc['2#105'][0] ) ) {
 				$meta['title'] = trim( $iptc['2#105'][0] );
@@ -830,6 +834,10 @@ function wp_read_image_metadata( $file ) {
 		} else {
 			// phpcs:ignore WordPress.PHP.NoSilencedErrors -- Silencing notice and warning is intentional. See https://core.trac.wordpress.org/ticket/42480
 			$exif = @exif_read_data( $file );
+		}
+
+		if ( ! is_array( $exif ) ) {
+			$exif = array();
 		}
 
 		if ( ! empty( $exif['ImageDescription'] ) ) {


### PR DESCRIPTION
This PR addresses the issue when the `wp_read_image_metadata` hook receives incorrect (according to the documentation) arguments (`false` instead of `array`).

Trac ticket: https://core.trac.wordpress.org/ticket/54637

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
