### PR TITLE
WP 5.9 | WP_Block_Template: bug fix, explicitly declare properties

### DIFF
--- a/src/wp-includes/class-wp-block-template.php
+++ b/src/wp-includes/class-wp-block-template.php
@@ -129,4 +129,20 @@ class WP_Block_Template {
 	 * @var int
 	 */
 	public $author;
+
+	/**
+	 * Post types.
+	 *
+	 * @since 5.9.0
+	 * @var array
+	 */
+	public $post_types;
+
+	/**
+	 * Area.
+	 *
+	 * @since 5.9.0
+	 * @var string
+	 */
+	public $area;
 }


### PR DESCRIPTION
The `$post_types` and `$area` properties are being assigned to from the `_build_block_template_result_from_file()` and `_build_block_template_result_from_post()` functions, which were introduced in WP 5.9, but these properties do not explicitly exist on the `WP_Block_Template` class.

Trac ticket: https://core.trac.wordpress.org/ticket/54670

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
