### PR TITLE
Template Editing Mode: Add missing template part areas

### DIFF
--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -229,7 +229,7 @@ if ( $is_new_post && ! isset( $editor_settings['template'] ) && 'post' === $post
 	}
 }
 
-if ( wp_is_block_theme() ) {
+if ( wp_is_block_theme() && $editor_settings['supportsTemplateMode'] ) {
 	$editor_settings['defaultTemplatePartAreas'] = get_allowed_block_template_part_areas();
 }
 

--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -229,6 +229,10 @@ if ( $is_new_post && ! isset( $editor_settings['template'] ) && 'post' === $post
 	}
 }
 
+if ( wp_is_block_theme() ) {
+	$editor_settings['defaultTemplatePartAreas'] = get_allowed_block_template_part_areas();
+}
+
 /**
  * Scripts
  */


### PR DESCRIPTION
Testing instructions can be found in the Trac ticket.

I've not added this setting to the `get_default_block_editor_settings` since Template Parts are only supported in the Template Editing Mode.

Gutenberg issue: https://github.com/WordPress/gutenberg/issues/37443
Trac ticket: https://core.trac.wordpress.org/ticket/54679

/cc @gziolo, @hellofromtonya

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
