### PR TITLE
Templates Controller: Fix slug pattern to allow 404 templates

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
@@ -781,7 +781,7 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'required'    => true,
 					'minLength'   => 1,
-					'pattern'     => '[a-zA-Z_\-]+',
+					'pattern'     => '[a-zA-Z0-9_\-]+',
 				),
 				'theme'          => array(
 					'description' => __( 'Theme identifier for the template.' ),

--- a/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
+++ b/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
@@ -390,6 +390,52 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 	}
 
 	/**
+	 * @ticket 54680
+	 * @covers WP_REST_Templates_Controller::create_item
+	 * @covers WP_REST_Templates_Controller::get_item_schema
+	 */
+	public function test_create_item_with_numeric_slug() {
+		wp_set_current_user( self::$admin_id );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/templates' );
+		$request->set_body_params(
+			array(
+				'slug'        => '404',
+				'description' => 'Template shown when no content is found.',
+				'title'       => '404',
+				'author'      => self::$admin_id,
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		unset( $data['_links'] );
+		unset( $data['wp_id'] );
+
+		$this->assertSame(
+			array(
+				'id'             => 'default//404',
+				'theme'          => 'default',
+				'content'        => array(
+					'raw' => '',
+				),
+				'slug'           => '404',
+				'source'         => 'custom',
+				'origin'         => null,
+				'type'           => 'wp_template',
+				'description'    => 'Template shown when no content is found.',
+				'title'          => array(
+					'raw'      => '404',
+					'rendered' => '404',
+				),
+				'status'         => 'publish',
+				'has_theme_file' => false,
+				'is_custom'      => false,
+				'author'         => self::$admin_id,
+			),
+			$data
+		);
+	}
+
+	/**
 	 * @ticket 54422
 	 * @covers WP_REST_Templates_Controller::create_item
 	 */

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -5035,7 +5035,7 @@ mockedApiResponse.Schema = {
                             "description": "Unique slug identifying the template.",
                             "type": "string",
                             "minLength": 1,
-                            "pattern": "[a-zA-Z_\\-]+",
+                            "pattern": "[a-zA-Z0-9_\\-]+",
                             "required": true
                         },
                         "theme": {
@@ -5189,7 +5189,7 @@ mockedApiResponse.Schema = {
                             "description": "Unique slug identifying the template.",
                             "type": "string",
                             "minLength": 1,
-                            "pattern": "[a-zA-Z_\\-]+",
+                            "pattern": "[a-zA-Z0-9_\\-]+",
                             "required": false
                         },
                         "theme": {
@@ -5503,7 +5503,7 @@ mockedApiResponse.Schema = {
                             "description": "Unique slug identifying the template.",
                             "type": "string",
                             "minLength": 1,
-                            "pattern": "[a-zA-Z_\\-]+",
+                            "pattern": "[a-zA-Z0-9_\\-]+",
                             "required": false
                         },
                         "theme": {
@@ -5682,7 +5682,7 @@ mockedApiResponse.Schema = {
                             "description": "Unique slug identifying the template.",
                             "type": "string",
                             "minLength": 1,
-                            "pattern": "[a-zA-Z_\\-]+",
+                            "pattern": "[a-zA-Z0-9_\\-]+",
                             "required": true
                         },
                         "theme": {
@@ -5841,7 +5841,7 @@ mockedApiResponse.Schema = {
                             "description": "Unique slug identifying the template.",
                             "type": "string",
                             "minLength": 1,
-                            "pattern": "[a-zA-Z_\\-]+",
+                            "pattern": "[a-zA-Z0-9_\\-]+",
                             "required": false
                         },
                         "theme": {
@@ -6160,7 +6160,7 @@ mockedApiResponse.Schema = {
                             "description": "Unique slug identifying the template.",
                             "type": "string",
                             "minLength": 1,
-                            "pattern": "[a-zA-Z_\\-]+",
+                            "pattern": "[a-zA-Z0-9_\\-]+",
                             "required": false
                         },
                         "theme": {


### PR DESCRIPTION
Backport of https://github.com/WordPress/gutenberg/pull/37579. Props @PatelUtkarsh.

Quoting https://github.com/WordPress/gutenberg/pull/37579:

> ## Description
> Adding 404 template from `/wp-admin/site-editor.php?postType=wp_template` causes 400 with `rest_invalid_pattern`
>
> ## How has this been tested?
> - Theme without 404 templates.
> - Open `/wp-admin/site-editor.php?postType=wp_template`
> - Add new 404 templates.
> - Used nightly WordPress build to test this.
>
> ## Screenshots
> Bug: 
>
> https://user-images.githubusercontent.com/5015489/147066116-2e23ff30-0dd7-45d3-a40a-510ef06156e2.mp4

Trac ticket: https://core.trac.wordpress.org/ticket/54680

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
