### PR TITLE
declare $customize_url outside of conditional

### DIFF
--- a/src/wp-admin/menu.php
+++ b/src/wp-admin/menu.php
@@ -216,9 +216,10 @@ if ( wp_is_block_theme() ) {
 
 // Hide Customize link on block themes unless a plugin or theme is using
 // customize_register to add a setting.
+$customize_url = add_query_arg( 'return', urlencode( remove_query_arg( wp_removable_query_args(), wp_unslash( $_SERVER['REQUEST_URI'] ) ) ), 'customize.php' );
+
 if ( ! wp_is_block_theme() || has_action( 'customize_register' ) ) {
-	$customize_url = add_query_arg( 'return', urlencode( remove_query_arg( wp_removable_query_args(), wp_unslash( $_SERVER['REQUEST_URI'] ) ) ), 'customize.php' );
-	$position      = wp_is_block_theme() ? 7 : 6;
+	$position = wp_is_block_theme() ? 7 : 6;
 
 	$submenu['themes.php'][ $position ] = array( __( 'Customize' ), 'customize', esc_url( $customize_url ), '', 'hide-if-no-customize' );
 }
@@ -237,7 +238,7 @@ if ( current_theme_supports( 'custom-background' ) && current_user_can( 'customi
 	$submenu['themes.php'][20] = array( __( 'Background' ), $appearance_cap, esc_url( $customize_background_url ), '', 'hide-if-no-customize' );
 }
 
-	unset( $customize_url );
+unset( $customize_url );
 
 unset( $appearance_cap );
 


### PR DESCRIPTION
Currently a PHP notice for an undefined variable `$customize_url` is reported when a plugin adds `add_theme_support('custom_header')` and a block theme is the current theme.

<!-- Insert a description of your changes here -->
Define `$customize_url` at the beginning of the code section and outside of a conditional. That way it will be defined for all the conditionals.

`$customize_url` is unset after the conditionals are passed.

Trac ticket: https://core.trac.wordpress.org/ticket/54682

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
