### PR TITLE
add filter to WP_Block_List constructor

### DIFF
--- a/src/wp-includes/class-wp-block-list.php
+++ b/src/wp-includes/class-wp-block-list.php
@@ -59,7 +59,7 @@ class WP_Block_List implements Iterator, ArrayAccess, Countable {
 		/**
 		 * Filters blocks passed to WP_Block_List constructor.
 		 *
-		 * @since x.x.x
+		 * @since 5.9.0
 		 * @param array[]|WP_Block[] $blocks Array of parsed block data, or block instances.
 		 */
 		$this->blocks            = apply_filters( 'block_list_blocks', $blocks );

--- a/src/wp-includes/class-wp-block-list.php
+++ b/src/wp-includes/class-wp-block-list.php
@@ -56,7 +56,13 @@ class WP_Block_List implements Iterator, ArrayAccess, Countable {
 			$registry = WP_Block_Type_Registry::get_instance();
 		}
 
-		$this->blocks            = $blocks;
+		/**
+		 * Filters blocks passed to WP_Block_List constructor.
+		 *
+		 * @since x.x.x
+		 * @param array[]|WP_Block[] $blocks Array of parsed block data, or block instances.
+		 */
+		$this->blocks            = apply_filters( 'block_list_blocks', $blocks );
 		$this->available_context = $available_context;
 		$this->registry          = $registry;
 	}


### PR DESCRIPTION
<!-- Insert a description of your changes here -->
Add a filter to the WP_Block_List class constructor to enable modification of the passed blocks. This would allow simpler modification of block menu items from the navigation block.

Trac ticket: https://core.trac.wordpress.org/ticket/54684

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
