### PR TITLE
GH Actions: always use --no-interaction for Composer

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -145,9 +145,9 @@ jobs:
 
           # Install using `composer update` as there is no `composer.lock` file.
           if [ ${{ env.LOCAL_PHP }} == '8.1-fpm' ]; then
-            docker-compose run --rm php composer update --ignore-platform-reqs
+            docker-compose run --rm php composer update --ignore-platform-reqs --no-interaction
           else
-            docker-compose run --rm php composer update
+            docker-compose run --rm php composer update --no-interaction
           fi
 
       - name: Docker debug information

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -108,7 +108,7 @@ jobs:
           docker-compose run --rm php composer --version
 
           # Install using `composer update` as there is no `composer.lock` file.
-          docker-compose run --rm php composer update
+          docker-compose run --rm php composer update --no-interaction
 
       - name: Docker debug information
         run: |


### PR DESCRIPTION
Adding `--no-interaction` to "plain" Composer commands to potentially prevent CI hanging if, for whatever reason, interaction would be needed in the future.

Trac ticket: https://core.trac.wordpress.org/ticket/54695

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
