### PR TITLE
Move dir, lang, xml:lang to global attributes in kses

### DIFF
--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -2501,6 +2501,7 @@ function safecss_filter_attr( $css, $deprecated = '' ) {
  *
  * @since 3.5.0
  * @since 5.0.0 Add support for `data-*` wildcard attributes.
+ * @since 6.0.0 Add `dir`, `lang`, and `xml:lang` to global attributes.
  * @access private
  * @ignore
  *

--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -82,15 +82,9 @@ if ( ! CUSTOM_TAGS ) {
 		),
 		'article'    => array(
 			'align'    => true,
-			'dir'      => true,
-			'lang'     => true,
-			'xml:lang' => true,
 		),
 		'aside'      => array(
 			'align'    => true,
-			'dir'      => true,
-			'lang'     => true,
-			'xml:lang' => true,
 		),
 		'audio'      => array(
 			'autoplay' => true,
@@ -107,8 +101,6 @@ if ( ! CUSTOM_TAGS ) {
 		'big'        => array(),
 		'blockquote' => array(
 			'cite'     => true,
-			'lang'     => true,
-			'xml:lang' => true,
 		),
 		'br'         => array(),
 		'button'     => array(
@@ -122,7 +114,6 @@ if ( ! CUSTOM_TAGS ) {
 		),
 		'cite'       => array(
 			'dir'  => true,
-			'lang' => true,
 		),
 		'code'       => array(),
 		'col'        => array(
@@ -150,15 +141,9 @@ if ( ! CUSTOM_TAGS ) {
 		'details'    => array(
 			'align'    => true,
 			'dir'      => true,
-			'lang'     => true,
-			'open'     => true,
-			'xml:lang' => true,
 		),
 		'div'        => array(
 			'align'    => true,
-			'dir'      => true,
-			'lang'     => true,
-			'xml:lang' => true,
 		),
 		'dl'         => array(),
 		'dt'         => array(),
@@ -166,15 +151,9 @@ if ( ! CUSTOM_TAGS ) {
 		'fieldset'   => array(),
 		'figure'     => array(
 			'align'    => true,
-			'dir'      => true,
-			'lang'     => true,
-			'xml:lang' => true,
 		),
 		'figcaption' => array(
 			'align'    => true,
-			'dir'      => true,
-			'lang'     => true,
-			'xml:lang' => true,
 		),
 		'font'       => array(
 			'color' => true,
@@ -183,9 +162,6 @@ if ( ! CUSTOM_TAGS ) {
 		),
 		'footer'     => array(
 			'align'    => true,
-			'dir'      => true,
-			'lang'     => true,
-			'xml:lang' => true,
 		),
 		'h1'         => array(
 			'align' => true,
@@ -207,15 +183,9 @@ if ( ! CUSTOM_TAGS ) {
 		),
 		'header'     => array(
 			'align'    => true,
-			'dir'      => true,
-			'lang'     => true,
-			'xml:lang' => true,
 		),
 		'hgroup'     => array(
 			'align'    => true,
-			'dir'      => true,
-			'lang'     => true,
-			'xml:lang' => true,
 		),
 		'hr'         => array(
 			'align'   => true,
@@ -254,9 +224,6 @@ if ( ! CUSTOM_TAGS ) {
 		),
 		'main'       => array(
 			'align'    => true,
-			'dir'      => true,
-			'lang'     => true,
-			'xml:lang' => true,
 		),
 		'map'        => array(
 			'name' => true,
@@ -267,9 +234,6 @@ if ( ! CUSTOM_TAGS ) {
 		),
 		'nav'        => array(
 			'align'    => true,
-			'dir'      => true,
-			'lang'     => true,
-			'xml:lang' => true,
 		),
 		'object'     => array(
 			'data' => array(
@@ -283,9 +247,6 @@ if ( ! CUSTOM_TAGS ) {
 		),
 		'p'          => array(
 			'align'    => true,
-			'dir'      => true,
-			'lang'     => true,
-			'xml:lang' => true,
 		),
 		'pre'        => array(
 			'width' => true,
@@ -296,16 +257,10 @@ if ( ! CUSTOM_TAGS ) {
 		's'          => array(),
 		'samp'       => array(),
 		'span'       => array(
-			'dir'      => true,
 			'align'    => true,
-			'lang'     => true,
-			'xml:lang' => true,
 		),
 		'section'    => array(
 			'align'    => true,
-			'dir'      => true,
-			'lang'     => true,
-			'xml:lang' => true,
 		),
 		'small'      => array(),
 		'strike'     => array(),
@@ -313,9 +268,6 @@ if ( ! CUSTOM_TAGS ) {
 		'sub'        => array(),
 		'summary'    => array(
 			'align'    => true,
-			'dir'      => true,
-			'lang'     => true,
-			'xml:lang' => true,
 		),
 		'sup'        => array(),
 		'table'      => array(
@@ -2563,7 +2515,10 @@ function _wp_add_global_attributes( $value ) {
 		'aria-labelledby'  => true,
 		'aria-hidden'      => true,
 		'class'            => true,
+		'dir'              => true,
 		'id'               => true,
+		'lang'             => true,
+		'xml:lang'         => true,
 		'style'            => true,
 		'title'            => true,
 		'role'             => true,

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -494,9 +494,12 @@ EOF;
 
 		foreach ( $tags as $tag ) {
 			$this->assertTrue( $tag['class'] );
+			$this->assertTrue( $tag['dir'] );
 			$this->assertTrue( $tag['id'] );
+			$this->assertTrue( $tag['lang'] );
 			$this->assertTrue( $tag['style'] );
 			$this->assertTrue( $tag['title'] );
+			$this->assertTrue( $tag['xml:lang'] );
 		}
 
 		$this->assertSame( $allowedtags, wp_kses_allowed_html( 'data' ) );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

This PR moves `dir`, `lang`, and `xml:lang` attributes into the global attributes in kses so that they can be used with any tag as specified in the HTML standard.

Trac ticket: https://core.trac.wordpress.org/ticket/54699 <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
