### PR TITLE
Update PHPCompatibilityWP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
 		"squizlabs/php_codesniffer": "3.6.0",
 		"wp-coding-standards/wpcs": "~2.3.0",
-		"phpcompatibility/phpcompatibility-wp": "~2.1.2",
+		"phpcompatibility/phpcompatibility-wp": "~2.1.3",
 		"yoast/phpunit-polyfills": "^1.0.1"
 	},
 	"config": {

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1384,7 +1384,6 @@ function verify_file_signature( $filename, $signatures, $filename_for_errors = f
 			),
 			array(
 				'php'    => phpversion(),
-				// phpcs:ignore PHPCompatibility.Constants.NewConstants.sodium_library_versionFound
 				'sodium' => defined( 'SODIUM_LIBRARY_VERSION' ) ? SODIUM_LIBRARY_VERSION : ( defined( 'ParagonIE_Sodium_Compat::VERSION_STRING' ) ? ParagonIE_Sodium_Compat::VERSION_STRING : false ),
 			)
 		);
@@ -1417,7 +1416,6 @@ function verify_file_signature( $filename, $signatures, $filename_for_errors = f
 				),
 				array(
 					'php'                => phpversion(),
-					// phpcs:ignore PHPCompatibility.Constants.NewConstants.sodium_library_versionFound
 					'sodium'             => defined( 'SODIUM_LIBRARY_VERSION' ) ? SODIUM_LIBRARY_VERSION : ( defined( 'ParagonIE_Sodium_Compat::VERSION_STRING' ) ? ParagonIE_Sodium_Compat::VERSION_STRING : false ),
 					'polyfill_is_fast'   => false,
 					'max_execution_time' => ini_get( 'max_execution_time' ),
@@ -1491,7 +1489,6 @@ function verify_file_signature( $filename, $signatures, $filename_for_errors = f
 			'skipped_key' => $skipped_key,
 			'skipped_sig' => $skipped_signature,
 			'php'         => phpversion(),
-			// phpcs:ignore PHPCompatibility.Constants.NewConstants.sodium_library_versionFound
 			'sodium'      => defined( 'SODIUM_LIBRARY_VERSION' ) ? SODIUM_LIBRARY_VERSION : ( defined( 'ParagonIE_Sodium_Compat::VERSION_STRING' ) ? ParagonIE_Sodium_Compat::VERSION_STRING : false ),
 		)
 	);

--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -947,7 +947,7 @@ function file_is_valid_image( $path ) {
  * @return bool True if suitable, false if not suitable.
  */
 function file_is_displayable_image( $path ) {
-	$displayable_image_types = array( IMAGETYPE_GIF, IMAGETYPE_JPEG, IMAGETYPE_PNG, IMAGETYPE_BMP, IMAGETYPE_ICO, IMAGETYPE_WEBP ); // phpcs:ignore PHPCompatibility.Constants.NewConstants.imagetype_webpFound
+	$displayable_image_types = array( IMAGETYPE_GIF, IMAGETYPE_JPEG, IMAGETYPE_PNG, IMAGETYPE_BMP, IMAGETYPE_ICO, IMAGETYPE_WEBP );
 
 	$info = wp_getimagesize( $path );
 	if ( empty( $info ) ) {

--- a/src/wp-includes/class-wp-image-editor-gd.php
+++ b/src/wp-includes/class-wp-image-editor-gd.php
@@ -70,7 +70,7 @@ class WP_Image_Editor_GD extends WP_Image_Editor {
 			case 'image/gif':
 				return ( $image_types & IMG_GIF ) != 0;
 			case 'image/webp':
-				return ( $image_types & IMG_WEBP ) != 0; // phpcs:ignore PHPCompatibility.Constants.NewConstants.img_webpFound
+				return ( $image_types & IMG_WEBP ) != 0;
 		}
 
 		return false;

--- a/src/wp-includes/compat.php
+++ b/src/wp-includes/compat.php
@@ -485,5 +485,5 @@ if ( ! defined( 'IMAGETYPE_WEBP' ) ) {
 
 // IMG_WEBP constant is only defined in PHP 7.0.10 or later.
 if ( ! defined( 'IMG_WEBP' ) ) {
-	define( 'IMG_WEBP', IMAGETYPE_WEBP ); // phpcs:ignore PHPCompatibility.Constants.NewConstants.imagetype_webpFound
+	define( 'IMG_WEBP', IMAGETYPE_WEBP );
 }

--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -3325,7 +3325,7 @@ function gd_edit_image_support($mime_type) {
 			case 'image/gif':
 				return (imagetypes() & IMG_GIF) != 0;
 			case 'image/webp':
-				return (imagetypes() & IMG_WEBP) != 0; // phpcs:ignore PHPCompatibility.Constants.NewConstants.img_webpFound
+				return (imagetypes() & IMG_WEBP) != 0;
 		}
 	} else {
 		switch( $mime_type ) {

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -5196,7 +5196,7 @@ function wp_getimagesize( $filename, array &$image_info = null ) {
 			return array(
 				$width,
 				$height,
-				IMAGETYPE_WEBP, // phpcs:ignore PHPCompatibility.Constants.NewConstants.imagetype_webpFound
+				IMAGETYPE_WEBP,
 				sprintf(
 					'width="%d" height="%d"',
 					$width,


### PR DESCRIPTION
... and remove redundant inline ignore comments for WP polyfilled functionality. The PHPCompatibilityWP ruleset explicitly excludes those polyfills, so they don't need to be annotated as ignored.

Ref:
* https://github.com/PHPCompatibility/PHPCompatibilityWP/releases/tag/2.1.3

Trac ticket: https://core.trac.wordpress.org/ticket/54711

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
