### PR TITLE
44441 | remove media image settings

### DIFF
--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -2700,3 +2700,57 @@ function _wp_block_editor_posts_page_notice() {
 		'after'
 	);
 }
+
+}
+
+/**
+ * Determine if Image Size settings should be displayed on the Media options page.
+ *
+ * The image size settings should not be displayed unless they have
+ * previously been edited. This value can be filtered.
+ *
+ * @since 6.0.0
+ *
+ * @return bool If the image size settings should be displayed.
+ */
+function wp_media_options_should_display_image_size_settings() {
+
+	// Hide the settings by default.
+	$should_display = false;
+
+	/*
+	 * Image size option names, along with default values.
+	 * @see wp-admin/includes/schema.php
+	 */
+	$image_sizes = array(
+		'large_size_h'     => 1024,
+		'large_size_w'     => 1024,
+		'medium_size_h'    => 300,
+		'medium_size_w'    => 300,
+		'thumbnail_size_h' => 150,
+		'thumbnail_size_w' => 150,
+		'thumbnail_crop'   => 1,
+	);
+
+	foreach ( $image_sizes as $label => $default ) {
+		$value = get_option( $label );
+		if ( intval( $value ) !== $default ) {
+			$should_display = true;
+			break;
+		}
+	}
+
+	/**
+	 * Filter if the image size settings should be displayed on the Media options page.
+	 *
+	 * If the default settings have not been edited, then hide these settings
+	 * from users. This filter allows developers to modify this value.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @param bool $should_display If the settings should be displayed.
+	 *
+	 * @return bool If the Media Settings page should display the Image Size settings.
+	 */
+	return apply_filters( 'wp_media_options_should_display_image_size_settings', $should_display );
+}

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -2701,8 +2701,6 @@ function _wp_block_editor_posts_page_notice() {
 	);
 }
 
-}
-
 /**
  * Determine if Image Size settings should be displayed on the Media options page.
  *

--- a/src/wp-admin/options-media.php
+++ b/src/wp-admin/options-media.php
@@ -52,48 +52,53 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 <form action="options.php" method="post">
 <?php settings_fields( 'media' ); ?>
 
-<h2 class="title"><?php _e( 'Image sizes' ); ?></h2>
-<p><?php _e( 'The sizes listed below determine the maximum dimensions in pixels to use when adding an image to the Media Library.' ); ?></p>
+<?php if ( true === wp_media_options_should_display_image_size_settings() ) : ?>
+	<h2 class="title"><?php _e( 'Image sizes' ); ?></h2>
+	<p><?php _e( 'The sizes listed below determine the maximum dimensions in pixels to use when adding an image to the Media Library.' ); ?></p>
 
-<table class="form-table" role="presentation">
-<tr>
-<th scope="row"><?php _e( 'Thumbnail size' ); ?></th>
-<td><fieldset><legend class="screen-reader-text"><span><?php _e( 'Thumbnail size' ); ?></span></legend>
-<label for="thumbnail_size_w"><?php _e( 'Width' ); ?></label>
-<input name="thumbnail_size_w" type="number" step="1" min="0" id="thumbnail_size_w" value="<?php form_option( 'thumbnail_size_w' ); ?>" class="small-text" />
-<br />
-<label for="thumbnail_size_h"><?php _e( 'Height' ); ?></label>
-<input name="thumbnail_size_h" type="number" step="1" min="0" id="thumbnail_size_h" value="<?php form_option( 'thumbnail_size_h' ); ?>" class="small-text" />
-</fieldset>
-<input name="thumbnail_crop" type="checkbox" id="thumbnail_crop" value="1" <?php checked( '1', get_option( 'thumbnail_crop' ) ); ?>/>
-<label for="thumbnail_crop"><?php _e( 'Crop thumbnail to exact dimensions (normally thumbnails are proportional)' ); ?></label>
-</td>
-</tr>
+	<table class="form-table" role="presentation">
+	<tr>
+	<th scope="row"><?php _e( 'Thumbnail size' ); ?></th>
+	<td><fieldset><legend class="screen-reader-text"><span><?php _e( 'Thumbnail size' ); ?></span></legend>
+	<label for="thumbnail_size_w"><?php _e( 'Width' ); ?></label>
+	<input name="thumbnail_size_w" type="number" step="1" min="0" id="thumbnail_size_w" value="<?php form_option( 'thumbnail_size_w' ); ?>" class="small-text" />
+	<br />
+	<label for="thumbnail_size_h"><?php _e( 'Height' ); ?></label>
+	<input name="thumbnail_size_h" type="number" step="1" min="0" id="thumbnail_size_h" value="<?php form_option( 'thumbnail_size_h' ); ?>" class="small-text" />
+	</fieldset>
+	<input name="thumbnail_crop" type="checkbox" id="thumbnail_crop" value="1" <?php checked( '1', get_option( 'thumbnail_crop' ) ); ?>/>
+	<label for="thumbnail_crop"><?php _e( 'Crop thumbnail to exact dimensions (normally thumbnails are proportional)' ); ?></label>
+	</td>
+	</tr>
 
-<tr>
-<th scope="row"><?php _e( 'Medium size' ); ?></th>
-<td><fieldset><legend class="screen-reader-text"><span><?php _e( 'Medium size' ); ?></span></legend>
-<label for="medium_size_w"><?php _e( 'Max Width' ); ?></label>
-<input name="medium_size_w" type="number" step="1" min="0" id="medium_size_w" value="<?php form_option( 'medium_size_w' ); ?>" class="small-text" />
-<br />
-<label for="medium_size_h"><?php _e( 'Max Height' ); ?></label>
-<input name="medium_size_h" type="number" step="1" min="0" id="medium_size_h" value="<?php form_option( 'medium_size_h' ); ?>" class="small-text" />
-</fieldset></td>
-</tr>
+	<tr>
+	<th scope="row"><?php _e( 'Medium size' ); ?></th>
+	<td><fieldset><legend class="screen-reader-text"><span><?php _e( 'Medium size' ); ?></span></legend>
+	<label for="medium_size_w"><?php _e( 'Max Width' ); ?></label>
+	<input name="medium_size_w" type="number" step="1" min="0" id="medium_size_w" value="<?php form_option( 'medium_size_w' ); ?>" class="small-text" />
+	<br />
+	<label for="medium_size_h"><?php _e( 'Max Height' ); ?></label>
+	<input name="medium_size_h" type="number" step="1" min="0" id="medium_size_h" value="<?php form_option( 'medium_size_h' ); ?>" class="small-text" />
+	</fieldset></td>
+	</tr>
 
-<tr>
-<th scope="row"><?php _e( 'Large size' ); ?></th>
-<td><fieldset><legend class="screen-reader-text"><span><?php _e( 'Large size' ); ?></span></legend>
-<label for="large_size_w"><?php _e( 'Max Width' ); ?></label>
-<input name="large_size_w" type="number" step="1" min="0" id="large_size_w" value="<?php form_option( 'large_size_w' ); ?>" class="small-text" />
-<br />
-<label for="large_size_h"><?php _e( 'Max Height' ); ?></label>
-<input name="large_size_h" type="number" step="1" min="0" id="large_size_h" value="<?php form_option( 'large_size_h' ); ?>" class="small-text" />
-</fieldset></td>
-</tr>
-
-<?php do_settings_fields( 'media', 'default' ); ?>
-</table>
+	<tr>
+	<th scope="row"><?php _e( 'Large size' ); ?></th>
+	<td><fieldset><legend class="screen-reader-text"><span><?php _e( 'Large size' ); ?></span></legend>
+	<label for="large_size_w"><?php _e( 'Max Width' ); ?></label>
+	<input name="large_size_w" type="number" step="1" min="0" id="large_size_w" value="<?php form_option( 'large_size_w' ); ?>" class="small-text" />
+	<br />
+	<label for="large_size_h"><?php _e( 'Max Height' ); ?></label>
+	<input name="large_size_h" type="number" step="1" min="0" id="large_size_h" value="<?php form_option( 'large_size_h' ); ?>" class="small-text" />
+	</fieldset></td>
+	</tr>
+	<?php do_settings_fields( 'media', 'default' ); ?>
+	</table>
+<?php else : ?>
+	<table class="form-table" role="presentation">
+		<?php do_settings_fields( 'media', 'default' ); ?>
+	</table>
+<?php endif; ?>
 
 <?php
 /**


### PR DESCRIPTION
Removes admin Media Image size settings.  Includes new filter to allow devs to override this feature and display the settings.

Trac ticket: https://core.trac.wordpress.org/ticket/44441

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
