### PR TITLE
Add unit tests for `feed_links_extra()`.

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -941,8 +941,13 @@ class WP_Query {
 				$this->is_author = true;
 			}
 
-			if ( ! empty( $qv['post_type'] ) && ! is_array( $qv['post_type'] ) ) {
-				$post_type_obj = get_post_type_object( $qv['post_type'] );
+			if ( ! empty( $qv['post_type'] ) ) {
+				if ( is_array( $qv['post_type'] ) ) {
+					$post_type_obj = get_post_type_object( reset( $qv['post_type'] ) );
+				} else {
+					$post_type_obj = get_post_type_object( $qv['post_type'] );
+				}
+
 				if ( ! empty( $post_type_obj->has_archive ) ) {
 					$this->is_post_type_archive = true;
 				}

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -941,13 +941,8 @@ class WP_Query {
 				$this->is_author = true;
 			}
 
-			if ( ! empty( $qv['post_type'] ) ) {
-				if ( is_array( $qv['post_type'] ) ) {
-					$post_type_obj = get_post_type_object( reset( $qv['post_type'] ) );
-				} else {
-					$post_type_obj = get_post_type_object( $qv['post_type'] );
-				}
-
+			if ( ! empty( $qv['post_type'] ) && ! is_array( $qv['post_type'] ) ) {
+				$post_type_obj = get_post_type_object( $qv['post_type'] );
 				if ( ! empty( $post_type_obj->has_archive ) ) {
 					$this->is_post_type_archive = true;
 				}

--- a/tests/phpunit/tests/general/feedLinksExtra.php
+++ b/tests/phpunit/tests/general/feedLinksExtra.php
@@ -91,6 +91,27 @@ class Tests_General_FeedLinksExtra extends WP_UnitTestCase {
 		// Post type.
 		self::$post_type = 'cpt_feed_links_extra';
 
+		register_taxonomy(
+			self::$tax_id,
+			self::$post_type,
+			array(
+				'labels' => array(
+					'name'          => 'Taxonomy Terms',
+					'singular_name' => 'Taxonomy Term',
+				),
+			)
+		);
+
+		register_post_type(
+			self::$post_type,
+			array(
+				'public'      => true,
+				'has_archive' => true,
+				'taxonomies'  => array( self::$tax_id ),
+				'labels'      => array( 'name' => 'CPT for feed_links_extra()' ),
+			)
+		);
+
 		// Posts.
 		self::$post_no_comment_id = $factory->post->create(
 			array( 'post_title' => 'Post with no comments' )
@@ -106,6 +127,15 @@ class Tests_General_FeedLinksExtra extends WP_UnitTestCase {
 				'comment_post_ID' => self::$post_with_comment_id,
 			)
 		);
+
+		self::$post_with_cpt_id = $factory->post->create(
+			array(
+				'post_title' => 'Post with a custom post type',
+				'post_type'  => self::$post_type,
+			)
+		);
+
+		wp_set_object_terms( self::$post_with_cpt_id, 'tax_term', self::$tax_id );
 	}
 
 	public function set_up() {
@@ -131,22 +161,6 @@ class Tests_General_FeedLinksExtra extends WP_UnitTestCase {
 				'labels'      => array( 'name' => 'CPT for feed_links_extra()' ),
 			)
 		);
-
-		self::$post_with_cpt = $this->factory->post->create(
-			array(
-				'post_title' => 'Post with a custom post type',
-				'post_type'  => self::$post_type,
-			)
-		);
-
-		wp_set_object_terms( self::$post_with_cpt, 'tax_term', self::$tax );
-	}
-
-	public function tear_down() {
-		parent::tear_down();
-
-		_unregister_taxonomy( self::$tax );
-		_unregister_post_type( self::$post_type );
 	}
 
 	/**

--- a/tests/phpunit/tests/general/feedLinksExtra.php
+++ b/tests/phpunit/tests/general/feedLinksExtra.php
@@ -402,7 +402,7 @@ class Tests_General_FeedLinksExtra extends WP_UnitTestCase {
 	 *
 	 * @ticket 54713
 	 *
-	 * @param $type The name of the test class property containing the object ID.
+	 * @param string $type The name of the test class property containing the object ID.
 	 * @return string The permalink.
 	 */
 	private function helper_get_the_permalink( $type ) {

--- a/tests/phpunit/tests/general/feedLinksExtra.php
+++ b/tests/phpunit/tests/general/feedLinksExtra.php
@@ -427,6 +427,22 @@ class Tests_General_FeedLinksExtra extends WP_UnitTestCase {
 	/**
 	 * @ticket 54713
 	 */
+	public function test_feed_links_extra_should_handle_an_array_of_post_types() {
+		$permalink = home_url( '?post_type[]=' . self::$post_type . '&post_type[]=post' );
+		$this->go_to( $permalink );
+
+		$expected = sprintf(
+			'<link rel="alternate" type="application/rss+xml" title="%s" href="%s" />' . "\n",
+			'Test Blog &raquo; CPT for feed_links_extra() Feed',
+			home_url( '?post_type=' . self::$post_type . '&#038;feed=rss2' )
+		);
+
+		$this->assertSame( $expected, get_echo( 'feed_links_extra' ) );
+	}
+
+	/**
+	 * @ticket 54713
+	 */
 	public function test_feed_links_extra_should_respect_feed_type() {
 		add_filter(
 			'default_feed',

--- a/tests/phpunit/tests/general/feedLinksExtra.php
+++ b/tests/phpunit/tests/general/feedLinksExtra.php
@@ -67,6 +67,7 @@ class Tests_General_FeedLinksExtra extends WP_UnitTestCase {
 	protected static $post_with_cpt_id;
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		// Author.
 		self::$author_id = $factory->user->create(
 			array(
 				'user_login' => 'author_feed_links_extra',
@@ -74,20 +75,23 @@ class Tests_General_FeedLinksExtra extends WP_UnitTestCase {
 			)
 		);
 
+		// Category.
 		self::$category_id = $factory->category->create(
 			array( 'name' => 'cat_feed_links_extra' )
 		);
 
+		// Tag.
 		self::$tag_id = $factory->tag->create(
 			array( 'name' => 'tag_feed_links_extra' )
 		);
 
+		// Taxonomy.
 		self::$tax_id = 'tax_feed_links_extra';
 
-		/** Post type */
+		// Post type.
 		self::$post_type = 'cpt_feed_links_extra';
 
-		/** Posts */
+		// Posts.
 		self::$post_no_comment_id = $factory->post->create(
 			array( 'post_title' => 'Post with no comments' )
 		);

--- a/tests/phpunit/tests/general/feedLinksExtra.php
+++ b/tests/phpunit/tests/general/feedLinksExtra.php
@@ -10,53 +10,96 @@
  * @covers ::feed_links_extra
  */
 class Tests_General_FeedLinksExtra extends WP_UnitTestCase {
-	protected static $author;
-	protected static $category;
-	protected static $tag;
-	protected static $tax;
+	/**
+	 * Author ID.
+	 *
+	 * @var int
+	 */
+	protected static $author_id;
+
+	/**
+	 * Category ID.
+	 *
+	 * @var int
+	 */
+	protected static $category_id;
+
+	/**
+	 * Tag ID.
+	 *
+	 * @var int
+	 */
+	protected static $tag_id;
+
+	/**
+	 * Taxonomy ID.
+	 *
+	 * @var int
+	 */
+	protected static $tax_id;
+
+	/**
+	 * Post Type.
+	 *
+	 * @var string
+	 */
 	protected static $post_type;
-	protected static $post_no_comment;
-	protected static $post_with_comment;
-	protected static $post_with_cpt;
+
+	/**
+	 * The ID of a post with no comment.
+	 *
+	 * @var int
+	 */
+	protected static $post_no_comment_id;
+
+	/**
+	 * The ID of a post with a comment.
+	 *
+	 * @var int
+	 */
+	protected static $post_with_comment_id;
+
+	/**
+	 * The ID of a post with a custom post type.
+	 *
+	 * @var int
+	 */
+	protected static $post_with_cpt_id;
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
-		/** Author */
-		self::$author = $factory->user->create(
+		self::$author_id = $factory->user->create(
 			array(
 				'user_login' => 'author_feed_links_extra',
 				'role'       => 'administrator',
 			)
 		);
 
-		/** Category */
-		self::$category = $factory->category->create(
+		self::$category_id = $factory->category->create(
 			array( 'name' => 'cat_feed_links_extra' )
 		);
 
-		/** Tag */
-		self::$tag = $factory->tag->create(
+		self::$tag_id = $factory->tag->create(
 			array( 'name' => 'tag_feed_links_extra' )
 		);
 
-		/** Taxonomy */
-		self::$tax = 'tax_feed_links_extra';
+		self::$tax_id = 'tax_feed_links_extra';
 
 		/** Post type */
 		self::$post_type = 'cpt_feed_links_extra';
 
 		/** Posts */
-		self::$post_no_comment = $factory->post->create(
+		self::$post_no_comment_id = $factory->post->create(
 			array( 'post_title' => 'Post with no comments' )
 		);
 
-		self::$post_with_comment = $factory->post->create(
+		self::$post_with_comment_id = $factory->post->create(
 			array( 'post_title' => 'Post with a comment' )
 		);
 
 		$factory->comment->create(
 			array(
-				'comment_author'  => self::$author,
-				'comment_post_ID' => self::$post_with_comment,
+				'comment_author'  => self::$author_id,
+				'comment_post_ID' => self::$post_with_comment_id,
 			)
 		);
 	}
@@ -65,7 +108,7 @@ class Tests_General_FeedLinksExtra extends WP_UnitTestCase {
 		parent::set_up();
 
 		register_taxonomy(
-			self::$tax,
+			self::$tax_id,
 			self::$post_type,
 			array(
 				'labels' => array(
@@ -80,7 +123,7 @@ class Tests_General_FeedLinksExtra extends WP_UnitTestCase {
 			array(
 				'public'      => true,
 				'has_archive' => true,
-				'taxonomies'  => array( self::$tax ),
+				'taxonomies'  => array( self::$tax_id ),
 				'labels'      => array( 'name' => 'CPT for feed_links_extra()' ),
 			)
 		);
@@ -346,11 +389,11 @@ class Tests_General_FeedLinksExtra extends WP_UnitTestCase {
 	 */
 	private function helper_get_the_permalink( $type ) {
 		if ( 'category' === $type || 'tag' === $type ) {
-			return get_term_link( self::$$type );
+			return get_term_link( self::${$type . '_id'} );
 		}
 
 		if ( 'tax' === $type ) {
-			return get_term_link( 'tax_term', self::$tax );
+			return get_term_link( 'tax_term', self::$tax_id );
 		}
 
 		if ( 'post_type' === $type ) {
@@ -358,14 +401,14 @@ class Tests_General_FeedLinksExtra extends WP_UnitTestCase {
 		}
 
 		if ( 'author' === $type ) {
-			return get_author_posts_url( self::$author );
+			return get_author_posts_url( self::$author_id );
 		}
 
 		if ( 'search' === $type ) {
 			return home_url( '?s=Search' );
 		}
 
-		return get_the_permalink( self::$$type );
+		return get_the_permalink( self::${$type . '_id'} );
 	}
 
 	/**
@@ -375,11 +418,11 @@ class Tests_General_FeedLinksExtra extends WP_UnitTestCase {
 		add_filter( 'comments_open', '__return_true' );
 		add_filter( 'pings_open', '__return_false' );
 
-		$this->go_to( get_the_permalink( self::$post_no_comment ) );
+		$this->go_to( get_the_permalink( self::$post_no_comment_id ) );
 
 		$expected  = '<link rel="alternate" type="application/rss+xml"';
 		$expected .= ' title="Test Blog &raquo; Post with no comments Comments Feed"';
-		$expected .= ' href="http://example.org/?feed=rss2&#038;p=' . self::$post_no_comment . '" />' . "\n";
+		$expected .= ' href="http://example.org/?feed=rss2&#038;p=' . self::$post_no_comment_id . '" />' . "\n";
 		$this->assertSame( $expected, get_echo( 'feed_links_extra' ) );
 	}
 
@@ -390,11 +433,11 @@ class Tests_General_FeedLinksExtra extends WP_UnitTestCase {
 		add_filter( 'pings_open', '__return_true' );
 		add_filter( 'comments_open', '__return_false' );
 
-		$this->go_to( get_the_permalink( self::$post_no_comment ) );
+		$this->go_to( get_the_permalink( self::$post_no_comment_id ) );
 
 		$expected  = '<link rel="alternate" type="application/rss+xml"';
 		$expected .= ' title="Test Blog &raquo; Post with no comments Comments Feed"';
-		$expected .= ' href="http://example.org/?feed=rss2&#038;p=' . self::$post_no_comment . '" />' . "\n";
+		$expected .= ' href="http://example.org/?feed=rss2&#038;p=' . self::$post_no_comment_id . '" />' . "\n";
 		$this->assertSame( $expected, get_echo( 'feed_links_extra' ) );
 	}
 
@@ -405,11 +448,11 @@ class Tests_General_FeedLinksExtra extends WP_UnitTestCase {
 		add_filter( 'pings_open', '__return_false' );
 		add_filter( 'comments_open', '__return_false' );
 
-		$this->go_to( get_the_permalink( self::$post_with_comment ) );
+		$this->go_to( get_the_permalink( self::$post_with_comment_id ) );
 
 		$expected  = '<link rel="alternate" type="application/rss+xml"';
 		$expected .= ' title="Test Blog &raquo; Post with a comment Comments Feed"';
-		$expected .= ' href="http://example.org/?feed=rss2&#038;p=' . self::$post_with_comment . '" />' . "\n";
+		$expected .= ' href="http://example.org/?feed=rss2&#038;p=' . self::$post_with_comment_id . '" />' . "\n";
 		$this->assertSame( $expected, get_echo( 'feed_links_extra' ) );
 	}
 
@@ -420,7 +463,7 @@ class Tests_General_FeedLinksExtra extends WP_UnitTestCase {
 		add_filter( 'comments_open', '__return_false' );
 		add_filter( 'pings_open', '__return_false' );
 
-		$this->go_to( get_the_permalink( self::$post_no_comment ) );
+		$this->go_to( get_the_permalink( self::$post_no_comment_id ) );
 		$this->assertEmpty( get_echo( 'feed_links_extra' ) );
 	}
 
@@ -458,11 +501,11 @@ class Tests_General_FeedLinksExtra extends WP_UnitTestCase {
 			}
 		);
 
-		$this->go_to( get_the_permalink( self::$post_with_comment ) );
+		$this->go_to( get_the_permalink( self::$post_with_comment_id ) );
 
 		$expected  = '<link rel="alternate" type="testing/foo"';
 		$expected .= ' title="Test Blog &raquo; Post with a comment Comments Feed"';
-		$expected .= ' href="http://example.org/?feed=foo&#038;p=' . self::$post_with_comment . '" />' . "\n";
+		$expected .= ' href="http://example.org/?feed=foo&#038;p=' . self::$post_with_comment_id . '" />' . "\n";
 		$this->assertSame( $expected, get_echo( 'feed_links_extra' ) );
 	}
 }

--- a/tests/phpunit/tests/general/feedLinksExtra.php
+++ b/tests/phpunit/tests/general/feedLinksExtra.php
@@ -1,0 +1,452 @@
+<?php
+/**
+ * Test feed_links_extra().
+ *
+ * @ticket 54713
+ *
+ * @group general
+ * @group template
+ *
+ * @covers ::feed_links_extra
+ */
+class Tests_General_FeedLinksExtra extends WP_UnitTestCase {
+	protected static $author;
+	protected static $category;
+	protected static $tag;
+	protected static $tax;
+	protected static $post_type;
+	protected static $post_no_comment;
+	protected static $post_with_comment;
+	protected static $post_with_cpt;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		/** Author */
+		self::$author = $factory->user->create(
+			array(
+				'user_login' => 'author_feed_links_extra',
+				'role'       => 'administrator',
+			)
+		);
+
+		/** Category */
+		self::$category = $factory->category->create(
+			array( 'name' => 'cat_feed_links_extra' )
+		);
+
+		/** Tag */
+		self::$tag = $factory->tag->create(
+			array( 'name' => 'tag_feed_links_extra' )
+		);
+
+		/** Taxonomy */
+		self::$tax = 'tax_feed_links_extra';
+
+		/** Post type */
+		self::$post_type = 'cpt_feed_links_extra';
+
+		/** Posts */
+		self::$post_no_comment = $factory->post->create(
+			array( 'post_title' => 'Post with no comments' )
+		);
+
+		self::$post_with_comment = $factory->post->create(
+			array( 'post_title' => 'Post with a comment' )
+		);
+
+		$factory->comment->create(
+			array(
+				'comment_author'  => self::$author,
+				'comment_post_ID' => self::$post_with_comment,
+			)
+		);
+	}
+
+	public function set_up() {
+		parent::set_up();
+
+		register_taxonomy(
+			self::$tax,
+			self::$post_type,
+			array(
+				'labels' => array(
+					'name'          => 'Taxonomy Terms',
+					'singular_name' => 'Taxonomy Term',
+				),
+			)
+		);
+
+		register_post_type(
+			self::$post_type,
+			array(
+				'public'      => true,
+				'has_archive' => true,
+				'taxonomies'  => array( self::$tax ),
+				'labels'      => array( 'name' => 'CPT for feed_links_extra()' ),
+			)
+		);
+
+		self::$post_with_cpt = $this->factory->post->create(
+			array(
+				'post_title' => 'Post with a custom post type',
+				'post_type'  => self::$post_type,
+			)
+		);
+
+		wp_set_object_terms( self::$post_with_cpt, 'tax_term', self::$tax );
+	}
+
+	public function tear_down() {
+		parent::tear_down();
+
+		_unregister_taxonomy( self::$tax );
+		_unregister_post_type( self::$post_type );
+	}
+
+	/**
+	 * @dataProvider data_feed_links_extra
+	 * @ticket 54713
+	 *
+	 * @param string $title     The expected title.
+	 * @param string $type      The name of the test class property containing the object ID.
+	 * @param array  $args {
+	 *        Optional arguments. Default empty.
+	 *
+	 *        @type string $separator     The separator between blog name and feed type.
+	 *        @type string $singletitle   The title of the comments feed.
+	 *        @type string $cattitle      The title of the category feed.
+	 *        @type string $tagtitle      The title of the tag feed.
+	 *        @type string $taxtitle      The title of the taxonomy feed.
+	 *        @type string $authortitle   The title of the author feed.
+	 *        @type string $searchtitle   The title of the search feed.
+	 *        @type string $posttypetitle The title of the post type feed.
+	 * }
+	 */
+	public function test_feed_links_extra( $title, $type, array $args = array() ) {
+		$permalink = $this->helper_get_the_permalink( $type );
+		$this->go_to( $permalink );
+
+		$expected = '';
+
+		if ( '' !== $title ) {
+			if ( 'post_type' === $type || 'search' === $type ) {
+				$feed_link = $permalink . '&#038;feed=rss2';
+			} else {
+				$feed_link = str_replace( '?', '?feed=rss2&#038;', $permalink );
+			}
+
+			$expected = sprintf(
+				'<link rel="alternate" type="application/rss+xml" title="%s" href="%s" />' . "\n",
+				esc_attr( $title ),
+				esc_url( $feed_link )
+			);
+		}
+
+		$this->assertSame( $expected, get_echo( 'feed_links_extra', array( $args ) ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_feed_links_extra() {
+		return array(
+			'a post with a comment'                        => array(
+				'title' => 'Test Blog &raquo; Post with a comment Comments Feed',
+				'type'  => 'post_with_comment',
+			),
+			'a post with a comment and a custom separator' => array(
+				'title' => 'Test Blog // Post with a comment Comments Feed',
+				'type'  => 'post_with_comment',
+				'args'  => array(
+					'separator' => '//',
+				),
+			),
+			'a post with a comment and a custom title'     => array(
+				'title' => 'Custom Title for Singular Feed',
+				'type'  => 'post_with_comment',
+				'args'  => array(
+					'singletitle' => 'Custom Title for Singular Feed',
+				),
+			),
+			'a post with a comment, a custom separator and a custom title' => array(
+				'title' => 'Test Blog // Custom Title for Singular Feed',
+				'type'  => 'post_with_comment',
+				'args'  => array(
+					'separator'   => '//',
+					'singletitle' => '%1$s %2$s Custom Title for Singular Feed',
+				),
+			),
+			'a custom post type'                           => array(
+				'title' => 'Test Blog &raquo; CPT for feed_links_extra() Feed',
+				'type'  => 'post_type',
+			),
+			'a custom post type and a custom separator'    => array(
+				'title' => 'Test Blog // CPT for feed_links_extra() Feed',
+				'type'  => 'post_type',
+				'args'  => array(
+					'separator' => '//',
+				),
+			),
+			'a custom post type and a custom title'        => array(
+				'title' => 'Custom Title for CPT Feed',
+				'type'  => 'post_type',
+				'args'  => array(
+					'posttypetitle' => 'Custom Title for CPT Feed',
+				),
+			),
+			'a custom post type, a custom separator and a custom title' => array(
+				'title' => 'Test Blog // Custom Title for CPT Feed',
+				'type'  => 'post_type',
+				'args'  => array(
+					'separator'     => '//',
+					'posttypetitle' => '%1$s %2$s Custom Title for CPT Feed',
+				),
+			),
+			'a category'                                   => array(
+				'title' => 'Test Blog &raquo; cat_feed_links_extra Category Feed',
+				'type'  => 'category',
+			),
+			'a category and a custom separator'            => array(
+				'title' => 'Test Blog // cat_feed_links_extra Category Feed',
+				'type'  => 'category',
+				'args'  => array(
+					'separator' => '//',
+				),
+			),
+			'a category and a custom title'                => array(
+				'title' => 'Custom Title for Category Feed',
+				'type'  => 'category',
+				'args'  => array(
+					'cattitle' => 'Custom Title for Category Feed',
+				),
+			),
+			'a category, a custom separator and a custom title' => array(
+				'title' => 'Test Blog // Custom Title for Category Feed',
+				'type'  => 'category',
+				'args'  => array(
+					'separator' => '//',
+					'cattitle'  => '%1$s %2$s Custom Title for Category Feed',
+				),
+			),
+			'a tag'                                        => array(
+				'title' => 'Test Blog &raquo; tag_feed_links_extra Tag Feed',
+				'type'  => 'tag',
+			),
+			'a tag and a custom separator'                 => array(
+				'title' => 'Test Blog // tag_feed_links_extra Tag Feed',
+				'type'  => 'tag',
+				'args'  => array(
+					'separator' => '//',
+				),
+			),
+			'a tag and a custom title'                     => array(
+				'title' => 'Custom Title for Tag Feed',
+				'type'  => 'tag',
+				'args'  => array(
+					'tagtitle' => 'Custom Title for Tag Feed',
+				),
+			),
+			'a tag, a custom separator and a custom title' => array(
+				'title' => 'Test Blog // Custom Title for Tag Feed',
+				'type'  => 'tag',
+				'args'  => array(
+					'separator' => '//',
+					'tagtitle'  => '%1$s %2$s Custom Title for Tag Feed',
+				),
+			),
+			'a taxonomy'                                   => array(
+				'title' => 'Test Blog &raquo; tax_term Taxonomy Term Feed',
+				'type'  => 'tax',
+			),
+			'a taxonomy and a custom separator'            => array(
+				'title' => 'Test Blog // tax_term Taxonomy Term Feed',
+				'type'  => 'tax',
+				'args'  => array(
+					'separator' => '//',
+				),
+			),
+			'a taxonomy and a custom title'                => array(
+				'title' => 'Custom Title for Taxonomy Feed',
+				'type'  => 'tax',
+				'args'  => array(
+					'taxtitle' => 'Custom Title for Taxonomy Feed',
+				),
+			),
+			'a taxonomy, a custom separator and a custom title' => array(
+				'title' => 'Test Blog // Custom Title for Taxonomy Feed',
+				'type'  => 'tax',
+				'args'  => array(
+					'separator' => '//',
+					'taxtitle'  => '%1$s %2$s Custom Title for Taxonomy Feed',
+				),
+			),
+			'an author'                                    => array(
+				'title' => 'Test Blog &raquo; Posts by author_feed_links_extra Feed',
+				'type'  => 'author',
+			),
+			'an author and a custom separator'             => array(
+				'title' => 'Test Blog // Posts by author_feed_links_extra Feed',
+				'type'  => 'author',
+				'args'  => array(
+					'separator' => '//',
+				),
+			),
+			'an author and a custom title'                 => array(
+				'title' => 'Custom Title for Author Feed',
+				'type'  => 'author',
+				'args'  => array(
+					'authortitle' => 'Custom Title for Author Feed',
+				),
+			),
+			'an author, a custom separator and a custom title' => array(
+				'title' => 'Test Blog // Custom Title for Author Feed',
+				'type'  => 'author',
+				'args'  => array(
+					'separator'   => '//',
+					'authortitle' => '%1$s %2$s Custom Title for Author Feed',
+				),
+			),
+			'search results'                               => array(
+				'title' => 'Test Blog &raquo; Search Results for &#8220;Search&#8221; Feed',
+				'type'  => 'search',
+			),
+			'search results and a custom separator'        => array(
+				'title' => 'Test Blog // Search Results for &#8220;Search&#8221; Feed',
+				'type'  => 'search',
+				'args'  => array(
+					'separator' => '//',
+				),
+			),
+			'search results and a custom title'            => array(
+				'title' => 'Custom Title for Search Feed',
+				'type'  => 'search',
+				'args'  => array(
+					'searchtitle' => 'Custom Title for Search Feed',
+				),
+			),
+			'search results, a custom separator and a custom title' => array(
+				'title' => 'Test Blog // Custom Title for Search Feed',
+				'type'  => 'search',
+				'args'  => array(
+					'separator'   => '//',
+					'searchtitle' => '%1$s %2$s Custom Title for Search Feed',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Helper function to get the permalink based on type.
+	 *
+	 * @ticket 54713
+	 *
+	 * @param $type The name of the test class property containing the object ID.
+	 * @return string The permalink.
+	 */
+	private function helper_get_the_permalink( $type ) {
+		if ( 'category' === $type || 'tag' === $type ) {
+			return get_term_link( self::$$type );
+		}
+
+		if ( 'tax' === $type ) {
+			return get_term_link( 'tax_term', self::$tax );
+		}
+
+		if ( 'post_type' === $type ) {
+			return get_post_type_archive_link( self::$post_type );
+		}
+
+		if ( 'author' === $type ) {
+			return get_author_posts_url( self::$author );
+		}
+
+		if ( 'search' === $type ) {
+			return home_url( '?s=Search' );
+		}
+
+		return get_the_permalink( self::$$type );
+	}
+
+	/**
+	 * @ticket 54713
+	 */
+	public function test_feed_links_extra_should_respect_comments_open() {
+		add_filter( 'comments_open', '__return_true' );
+		add_filter( 'pings_open', '__return_false' );
+
+		$this->go_to( get_the_permalink( self::$post_no_comment ) );
+
+		$expected  = '<link rel="alternate" type="application/rss+xml"';
+		$expected .= ' title="Test Blog &raquo; Post with no comments Comments Feed"';
+		$expected .= ' href="http://example.org/?feed=rss2&#038;p=' . self::$post_no_comment . '" />' . "\n";
+		$this->assertSame( $expected, get_echo( 'feed_links_extra' ) );
+	}
+
+	/**
+	 * @ticket 54713
+	 */
+	public function test_feed_links_extra_should_respect_pings_open() {
+		add_filter( 'pings_open', '__return_true' );
+		add_filter( 'comments_open', '__return_false' );
+
+		$this->go_to( get_the_permalink( self::$post_no_comment ) );
+
+		$expected  = '<link rel="alternate" type="application/rss+xml"';
+		$expected .= ' title="Test Blog &raquo; Post with no comments Comments Feed"';
+		$expected .= ' href="http://example.org/?feed=rss2&#038;p=' . self::$post_no_comment . '" />' . "\n";
+		$this->assertSame( $expected, get_echo( 'feed_links_extra' ) );
+	}
+
+	/**
+	 * @ticket 54713
+	 */
+	public function test_feed_links_extra_should_respect_post_comment_count() {
+		add_filter( 'pings_open', '__return_false' );
+		add_filter( 'comments_open', '__return_false' );
+
+		$this->go_to( get_the_permalink( self::$post_with_comment ) );
+
+		$expected  = '<link rel="alternate" type="application/rss+xml"';
+		$expected .= ' title="Test Blog &raquo; Post with a comment Comments Feed"';
+		$expected .= ' href="http://example.org/?feed=rss2&#038;p=' . self::$post_with_comment . '" />' . "\n";
+		$this->assertSame( $expected, get_echo( 'feed_links_extra' ) );
+	}
+
+	/**
+	 * @ticket 54713
+	 */
+	public function test_feed_links_extra_should_return_empty_when_comments_and_pings_are_closed_and_post_has_no_comments() {
+		add_filter( 'comments_open', '__return_false' );
+		add_filter( 'pings_open', '__return_false' );
+
+		$this->go_to( get_the_permalink( self::$post_no_comment ) );
+		$this->assertEmpty( get_echo( 'feed_links_extra' ) );
+	}
+
+	/**
+	 * @ticket 54713
+	 */
+	public function test_feed_links_extra_should_respect_feed_type() {
+		add_filter(
+			'default_feed',
+			static function() {
+				return 'foo';
+			}
+		);
+
+		add_filter(
+			'feed_content_type',
+			static function() {
+				return 'testing/foo';
+			}
+		);
+
+		$this->go_to( get_the_permalink( self::$post_with_comment ) );
+
+		$expected  = '<link rel="alternate" type="testing/foo"';
+		$expected .= ' title="Test Blog &raquo; Post with a comment Comments Feed"';
+		$expected .= ' href="http://example.org/?feed=foo&#038;p=' . self::$post_with_comment . '" />' . "\n";
+		$this->assertSame( $expected, get_echo( 'feed_links_extra' ) );
+	}
+}

--- a/tests/phpunit/tests/general/feedLinksExtra.php
+++ b/tests/phpunit/tests/general/feedLinksExtra.php
@@ -488,22 +488,6 @@ class Tests_General_FeedLinksExtra extends WP_UnitTestCase {
 	/**
 	 * @ticket 54713
 	 */
-	public function test_feed_links_extra_should_handle_an_array_of_post_types() {
-		$permalink = home_url( '?post_type[]=' . self::$post_type . '&post_type[]=post' );
-		$this->go_to( $permalink );
-
-		$expected = sprintf(
-			'<link rel="alternate" type="application/rss+xml" title="%s" href="%s" />' . "\n",
-			'Test Blog &raquo; CPT for feed_links_extra() Feed',
-			home_url( '?post_type=' . self::$post_type . '&#038;feed=rss2' )
-		);
-
-		$this->assertSame( $expected, get_echo( 'feed_links_extra' ) );
-	}
-
-	/**
-	 * @ticket 54713
-	 */
 	public function test_feed_links_extra_should_respect_feed_type() {
 		add_filter(
 			'default_feed',


### PR DESCRIPTION
This PR achieves 100% line/branch coverage for `feed_links_extra()`.

One source change was made in `WP_Query`:
- `WP_Query` previously did not set `is_post_type_archive` to `true` when an array of post types was supplied.
- Other areas of the codebase, including areas in `WP_Query`, handle a post type array using `reset()`.
- This PR uses the same approach.

Commits have been separated for easier review and cherry-picking. If there are any concerns about changing source in `WP_Query` this late in the release cycle, the first commit of this PR can still go into `5.9` as it only contains unit tests. This will increase the stability of Core in `5.9` and facilitate already planned changes to `feed_links_extra()` in `6.0`, for which I've also written unit tests for inclusion when we branch `6.0`.

Trac ticket: https://core.trac.wordpress.org/ticket/54713