### PR TITLE
Update jest-image-snapshot

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
 		"grunt-webpack": "^4.0.3",
 		"ink-docstrap": "1.3.2",
 		"install-changed": "1.1.0",
-		"jest-image-snapshot": "3.0.1",
+		"jest-image-snapshot": "4.5.1",
 		"matchdep": "~2.0.0",
 		"prettier": "npm:wp-prettier@2.0.5",
 		"qunit": "~2.17.2",


### PR DESCRIPTION
When installing node modules on macbook with m1 processor, I had problems with old jest-image-snapshot because it includes old puppeteer package.
Please update it to latest one.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
