### PR TITLE
Make block themes fully support HTML5 by default.

### DIFF
--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -4181,7 +4181,7 @@ function _add_default_theme_supports() {
 	add_theme_support( 'post-thumbnails' );
 	add_theme_support( 'responsive-embeds' );
 	add_theme_support( 'editor-styles' );
-	add_theme_support( 'html5', array( 'comment-form', 'comment-list', 'style', 'script' ) );
+	add_theme_support( 'html5', array( 'comment-form', 'comment-list', 'search-form', 'gallery', 'caption', 'style', 'script' ) );
 	add_theme_support( 'automatic-feed-links' );
 
 	add_filter( 'should_load_separate_core_block_assets', '__return_true' );

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -4182,8 +4182,9 @@ function _add_default_theme_supports() {
 	add_theme_support( 'responsive-embeds' );
 	add_theme_support( 'editor-styles' );
 	/*
-	 * Make block themes support HTML5 by default for all non-block content.
-	 * Blocks contain their own markup, which is HTML5.
+	 * Makes block themes support HTML5 by default for the comment block and search form
+	 * (which use default template functions) and `[caption]` and `[gallery]` shortcodes. 
+	 * Other blocks contain their own HTML5 markup.
 	 */
 	add_theme_support( 'html5', array( 'comment-form', 'comment-list', 'search-form', 'gallery', 'caption', 'style', 'script' ) );
 	add_theme_support( 'automatic-feed-links' );

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -4181,6 +4181,10 @@ function _add_default_theme_supports() {
 	add_theme_support( 'post-thumbnails' );
 	add_theme_support( 'responsive-embeds' );
 	add_theme_support( 'editor-styles' );
+	/*
+	 * Make block themes support HTML5 by default for all non-block content.
+	 * Blocks contain their own markup, which is HTML5.
+	 */
 	add_theme_support( 'html5', array( 'comment-form', 'comment-list', 'search-form', 'gallery', 'caption', 'style', 'script' ) );
 	add_theme_support( 'automatic-feed-links' );
 

--- a/tests/phpunit/tests/theme.php
+++ b/tests/phpunit/tests/theme.php
@@ -763,6 +763,36 @@ class Tests_Theme extends WP_UnitTestCase {
 					'feature' => 'editor-styles',
 				),
 			),
+			'html5: comment-list'  => array(
+				'support' => array(
+					'feature'     => 'html5',
+					'sub_feature' => 'comment-list',
+				),
+			),
+			'html5: comment-form'  => array(
+				'support' => array(
+					'feature'     => 'html5',
+					'sub_feature' => 'comment-form',
+				),
+			),
+			'html5: search-form'   => array(
+				'support' => array(
+					'feature'     => 'html5',
+					'sub_feature' => 'search-form',
+				),
+			),
+			'html5: gallery'       => array(
+				'support' => array(
+					'feature'     => 'html5',
+					'sub_feature' => 'gallery',
+				),
+			),
+			'html5: caption'       => array(
+				'support' => array(
+					'feature'     => 'html5',
+					'sub_feature' => 'caption',
+				),
+			),
 			'html5: style'         => array(
 				'support' => array(
 					'feature'     => 'html5',

--- a/tests/phpunit/tests/theme.php
+++ b/tests/phpunit/tests/theme.php
@@ -706,6 +706,8 @@ class Tests_Theme extends WP_UnitTestCase {
 	 * Tests that block themes support a feature by default.
 	 *
 	 * @ticket 54597
+	 * @ticket 54731
+	 *
 	 * @dataProvider data_block_theme_has_default_support
 	 *
 	 * @covers ::_add_default_theme_supports


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/54731
