### PR TITLE
Dashboard: Update the welcome panel to reflect color schemes

### DIFF
--- a/src/wp-admin/_index.php
+++ b/src/wp-admin/_index.php
@@ -181,7 +181,7 @@ if ( has_action( 'welcome_panel' ) && current_user_can( 'edit_theme_options' ) )
 	}
 	?>
 
-	<div id="welcome-panel" class="<?php echo esc_attr( $classes ); ?>">
+	<div id="welcome-panel" class="<?php echo esc_attr( $classes ); ?>" data-alt="<?php echo esc_attr( __( 'Balloon graphic, 5.9' ) ); ?>">
 		<?php wp_nonce_field( 'welcome-panel-nonce', 'welcomepanelnonce', false ); ?>
 		<a class="welcome-panel-close" href="<?php echo esc_url( admin_url( '?welcome=0' ) ); ?>" aria-label="<?php esc_attr_e( 'Dismiss the welcome panel' ); ?>"><?php _e( 'Dismiss' ); ?></a>
 		<?php

--- a/src/wp-admin/_index.php
+++ b/src/wp-admin/_index.php
@@ -181,7 +181,7 @@ if ( has_action( 'welcome_panel' ) && current_user_can( 'edit_theme_options' ) )
 	}
 	?>
 
-	<div id="welcome-panel" class="<?php echo esc_attr( $classes ); ?>" data-alt="<?php echo esc_attr( __( 'Balloon graphic, 5.9' ) ); ?>">
+	<div id="welcome-panel" class="<?php echo esc_attr( $classes ); ?>">
 		<?php wp_nonce_field( 'welcome-panel-nonce', 'welcomepanelnonce', false ); ?>
 		<a class="welcome-panel-close" href="<?php echo esc_url( admin_url( '?welcome=0' ) ); ?>" aria-label="<?php esc_attr_e( 'Dismiss the welcome panel' ); ?>"><?php _e( 'Dismiss' ); ?></a>
 		<?php

--- a/src/wp-admin/css/colors/_admin.scss
+++ b/src/wp-admin/css/colors/_admin.scss
@@ -781,3 +781,17 @@ div#wp-responsive-toggle a:before {
 		color: $link;
 	}
 }
+
+/* Welcome Panel */
+
+.welcome-panel {
+	background-color: $highlight-color;
+}
+
+[class*="welcome-panel-icon"] {
+	@if ( $scheme-name == "light" ) {
+		background-color: $icon-color;
+	} @else {
+		background-color: $base-color;
+	}
+}

--- a/src/wp-admin/css/colors/_variables.scss
+++ b/src/wp-admin/css/colors/_variables.scss
@@ -1,5 +1,6 @@
 // assign default value to all undefined variables
 
+$scheme-name: "default" !default;
 
 // core variables
 

--- a/src/wp-admin/css/colors/blue/colors.scss
+++ b/src/wp-admin/css/colors/blue/colors.scss
@@ -1,3 +1,4 @@
+$scheme-name: "blue";
 $base-color: #52accc;
 $icon-color: #e5f8ff;
 $highlight-color: #096484;

--- a/src/wp-admin/css/colors/coffee/colors.scss
+++ b/src/wp-admin/css/colors/coffee/colors.scss
@@ -1,3 +1,4 @@
+$scheme-name: "coffee";
 $base-color: #59524c;
 $highlight-color: #c7a589;
 $notification-color: #9ea476;

--- a/src/wp-admin/css/colors/ectoplasm/colors.scss
+++ b/src/wp-admin/css/colors/ectoplasm/colors.scss
@@ -1,3 +1,4 @@
+$scheme-name: "ectoplasm";
 $base-color: #523f6d;
 $icon-color: #ece6f6;
 $highlight-color: #a3b745;

--- a/src/wp-admin/css/colors/light/colors.scss
+++ b/src/wp-admin/css/colors/light/colors.scss
@@ -1,3 +1,4 @@
+$scheme-name: "light";
 $base-color: #e5e5e5;
 $icon-color: #999;
 $text-color: #333;

--- a/src/wp-admin/css/colors/midnight/colors.scss
+++ b/src/wp-admin/css/colors/midnight/colors.scss
@@ -1,3 +1,4 @@
+$scheme-name: "midnight";
 $base-color: #363b3f;
 $highlight-color: #e14d43;
 $notification-color: #69a8bb;

--- a/src/wp-admin/css/colors/modern/colors.scss
+++ b/src/wp-admin/css/colors/modern/colors.scss
@@ -1,3 +1,4 @@
+$scheme-name: "modern";
 $base-color: #1e1e1e;
 $highlight-color: #3858e9;
 $menu-submenu-focus-text: #33f078;

--- a/src/wp-admin/css/colors/ocean/colors.scss
+++ b/src/wp-admin/css/colors/ocean/colors.scss
@@ -1,3 +1,4 @@
+$scheme-name: "ocean";
 $base-color: #738e96;
 $icon-color: #f2fcff;
 $highlight-color: #9ebaa0;

--- a/src/wp-admin/css/colors/sunrise/colors.scss
+++ b/src/wp-admin/css/colors/sunrise/colors.scss
@@ -1,3 +1,4 @@
+$scheme-name: "sunrise";
 $base-color: #cf4944;
 $highlight-color: #dd823b;
 $notification-color: #ccaf0b;

--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -168,6 +168,13 @@
 	text-decoration: none;
 }
 
+.welcome-panel-header a:focus,
+.welcome-panel .welcome-panel-close:focus {
+	outline-color: currentColor;
+	outline-offset: 1px;
+	box-shadow: none;
+}
+
 .welcome-panel-header p {
 	margin: 0.5em 0 0;
 	font-size: 20px;

--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -123,7 +123,7 @@
 }
 
 .welcome-panel::before {
-	content: "";
+	content: attr(data-alt);
 	position: absolute;
 	top: -16px;
 	right: 96px;

--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -123,7 +123,7 @@
 }
 
 .welcome-panel::before {
-	content: attr(data-alt);
+	content: "";
 	position: absolute;
 	top: -16px;
 	right: 96px;

--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -115,10 +115,9 @@
 	position: relative;
 	overflow: auto;
 	margin: 16px 0;
-	background: #3858e9 url(../images/about-texture.png) center repeat;
+	background: #2271b1 url(../images/about-texture.png) center repeat;
 	background-size: 500px 500px;
 	background-blend-mode: overlay;
-	color: #fff;
 	font-size: 14px;
 	line-height: 1.3;
 }
@@ -148,16 +147,25 @@
 	font-size: 20px;
 	font-weight: 400;
 	line-height: 1.4;
-	color: #fff;
-}
-
-.welcome-panel a {
-	color: #fff;
 }
 
 .welcome-panel p {
 	font-size: inherit;
 	line-height: inherit;
+}
+
+.welcome-panel-header {
+	color: #fff;
+}
+
+.welcome-panel-header a {
+	color: #fff;
+}
+
+.welcome-panel-header a:focus,
+.welcome-panel-header a:hover {
+	color: #f5e6ab;
+	text-decoration: none;
 }
 
 .welcome-panel-header p {
@@ -183,6 +191,10 @@
 	transition: all .1s ease-in-out;
 	content: '\f335';
 	font-size: 24px;
+	color: #fff;
+}
+
+.welcome-panel .welcome-panel-close {
 	color: #fff;
 }
 
@@ -230,13 +242,13 @@
 	grid-template-columns: repeat(3, 1fr);
 	gap: 32px;
 	align-self: flex-end;
-	background: #3858e9;
+	background: #fff;
 }
 
 [class*="welcome-panel-icon"] {
 	height: 60px;
 	width: 60px;
-	background-color: #1d35b4;
+	background-color: #1d2327;
 	background-position: center;
 	background-size: 24px 24px;
 	background-repeat: no-repeat;


### PR DESCRIPTION
This PR uses the first styles in [comment:54](https://core.trac.wordpress.org/ticket/54489#comment:54), using the highlight color for the background.

It also adds the suggested "alt text" for the balloons, which ends up adding a new string to be translated, so that will either need to be communicated to translators, or scrapped until a point release (since we're past hard string freeze).

| | | |
|---|---|---|
| ![dashboard-blue](https://user-images.githubusercontent.com/541093/148623437-8755dc26-a8c3-4405-b69d-7a01cd7e9daf.png) | ![dashboard-coffee](https://user-images.githubusercontent.com/541093/148623438-9c0f5c42-5140-4cb3-9061-4b1047d59166.png) | ![dashboard-ectoplasm](https://user-images.githubusercontent.com/541093/148623440-3a0d2c3d-ef66-4dd4-9f71-2d06fb9f409d.png) |
| ![dashboard-fresh](https://user-images.githubusercontent.com/541093/148623441-bc070034-48ca-42d4-828b-aaf10cda7c54.png) | ![dashboard-light](https://user-images.githubusercontent.com/541093/148623442-e8d2654f-623f-4473-8e90-95eb1171ebed.png) | ![dashboard-midnight](https://user-images.githubusercontent.com/541093/148623443-1b4a421c-6730-4819-b898-2d886811225c.png) |
| ![dashboard-modern](https://user-images.githubusercontent.com/541093/148623446-7571a94f-f9a9-4d6a-9ee9-cbddc6c9f503.png) | ![dashboard-ocean](https://user-images.githubusercontent.com/541093/148623448-0a8389d2-33d8-420a-8ec9-e5846aa27b43.png) | ![dashboard-sunrise](https://user-images.githubusercontent.com/541093/148623449-39761946-825c-4b56-9fb8-a8cf3770fbbf.png) |

Trac ticket: https://core.trac.wordpress.org/ticket/54489

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
