### PR TITLE
The global stylesheet should be enqueued for all themes

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2307,10 +2307,6 @@ function wp_common_block_scripts_and_styles() {
  * @since 5.8.0
  */
 function wp_enqueue_global_styles() {
-	if ( ! WP_Theme_JSON_Resolver::theme_has_support() ) {
-		return;
-	}
-
 	$separate_assets = wp_should_load_separate_core_block_assets();
 
 	/*


### PR DESCRIPTION
Track ticket https://core.trac.wordpress.org/ticket/54781

For themes without theme.json support, we only enqueue the default styles provided by WordPress, such as the preset classes
(font sizes, colors, gradients). These classes should be always present as they may be used by old content and patterns.

For themes with theme.json support, we also enqueue the theme styles.

## More context

In WordPress 5.8 the preset classes (font sizes, colors, gradients) were provided via a CSS stylesheet that we enqueued to all themes plus the global stylesheet for the themes that supported `theme.json`. To avoid this duplication, in WordPress 5.9 the preset classes were removed from the common stylesheet (see https://github.com/WordPress/gutenberg/pull/35182 and https://github.com/WordPress/gutenberg/pull/34510) and are now provided by the global stylesheet, which is enabled to all themes as of https://github.com/WordPress/gutenberg/pull/34334

Related [devnote](https://make.wordpress.org/core/2022/01/08/updates-for-settings-styles-and-theme-json/), see "Changes to the global stylesheet" section.

## How to test

- Load the TwentyTwenty theme.
- Go to the front end and verify that there's a stylesheet called `global-styles-inline-css`.

