### PR TITLE
Fix TwentyTwenty font sizes & colors

### DIFF
--- a/src/wp-content/themes/twentytwenty/assets/css/editor-style-block-rtl.css
+++ b/src/wp-content/themes/twentytwenty/assets/css/editor-style-block-rtl.css
@@ -351,20 +351,20 @@ Inter variable font. Usage:
 }
 
 .editor-styles-wrapper p.has-small-font-size {
-	font-size: 0.842em;
+	--wp--preset--font-size--small: 0.842em;
 }
 
 .editor-styles-wrapper p.has-normal-font-size,
 .editor-styles-wrapper p.has-regular-font-size {
-	font-size: 1em;
+	--wp--preset--font-size--normal: 1em;
 }
 
 .editor-styles-wrapper p.has-medium-font-size {
-	font-size: 1.1em;
+	--wp--preset--font-size--medium: 1.1em;
 }
 
 .editor-styles-wrapper p.has-large-font-size {
-	font-size: 1.25em;
+	--wp--preset--font-size--large: 1.25em;
 }
 
 .editor-styles-wrapper p.has-larger-font-size {

--- a/src/wp-content/themes/twentytwenty/assets/css/editor-style-block.css
+++ b/src/wp-content/themes/twentytwenty/assets/css/editor-style-block.css
@@ -351,20 +351,20 @@ Inter variable font. Usage:
 }
 
 .editor-styles-wrapper p.has-small-font-size {
-	font-size: 0.842em;
+	--wp--preset--font-size--small: 0.842em;
 }
 
 .editor-styles-wrapper p.has-normal-font-size,
 .editor-styles-wrapper p.has-regular-font-size {
-	font-size: 1em;
+	--wp--preset--font-size--normal: 1em;
 }
 
 .editor-styles-wrapper p.has-medium-font-size {
-	font-size: 1.1em;
+	--wp--preset--font-size--medium: 1.1em;
 }
 
 .editor-styles-wrapper p.has-large-font-size {
-	font-size: 1.25em;
+	--wp--preset--font-size--large: 1.25em;
 }
 
 .editor-styles-wrapper p.has-larger-font-size {

--- a/src/wp-content/themes/twentytwenty/assets/css/editor-style-block.css
+++ b/src/wp-content/themes/twentytwenty/assets/css/editor-style-block.css
@@ -206,21 +206,21 @@ Inter variable font. Usage:
 /* GENERAL COLORS */
 
 .has-black-background-color {
-	background-color: #000;
+	--wp--preset--color--black: #000;
 	color: #fff;
 }
 
 .has-white-background-color {
-	background-color: #fff;
+	--wp--preset--color--white: #fff;
 	color: #000;
 }
 
 .has-black-color {
-	color: #000;
+	--wp--preset--color--black: #000;
 }
 
 .has-white-color {
-	color: #fff;
+	--wp--preset--color--white: #fff;
 }
 
 

--- a/src/wp-content/themes/twentytwenty/style-rtl.css
+++ b/src/wp-content/themes/twentytwenty/style-rtl.css
@@ -2836,21 +2836,21 @@ h2.entry-title {
 /* Block Font Sizes -------------------------- */
 
 .entry-content .has-small-font-size {
-	font-size: 0.842em;
+	--wp--preset--font-size--small: 0.842em;
 }
 
 .entry-content .has-normal-font-size,
 .entry-content .has-regular-font-size {
-	font-size: 1em;
+	--wp--preset--font-size--normal: 1em;
 }
 
 .entry-content .has-medium-font-size {
-	font-size: 1.1em;
+	--wp--preset--font-size--medium: 1.1em;
 	line-height: 1.45;
 }
 
 .entry-content .has-large-font-size {
-	font-size: 1.25em;
+	--wp--preset--font-size--large: 1.25em;
 	line-height: 1.4;
 }
 

--- a/src/wp-content/themes/twentytwenty/style.css
+++ b/src/wp-content/themes/twentytwenty/style.css
@@ -2854,21 +2854,21 @@ h2.entry-title {
 /* Block Font Sizes -------------------------- */
 
 .entry-content .has-small-font-size {
-	font-size: 0.842em;
+	--wp--preset--font-size--small: 0.842em;
 }
 
 .entry-content .has-normal-font-size,
 .entry-content .has-regular-font-size {
-	font-size: 1em;
+	--wp--preset--font-size--normal: 1em;
 }
 
 .entry-content .has-medium-font-size {
-	font-size: 1.1em;
+	--wp--preset--font-size--medium: 1.1em;
 	line-height: 1.45;
 }
 
 .entry-content .has-large-font-size {
-	font-size: 1.25em;
+	--wp--preset--font-size--large: 1.25em;
 	line-height: 1.4;
 }
 

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2307,10 +2307,6 @@ function wp_common_block_scripts_and_styles() {
  * @since 5.8.0
  */
 function wp_enqueue_global_styles() {
-	if ( ! WP_Theme_JSON_Resolver::theme_has_support() ) {
-		return;
-	}
-
 	$separate_assets = wp_should_load_separate_core_block_assets();
 
 	/*


### PR DESCRIPTION
Trac ticket https://core.trac.wordpress.org/ticket/54782
Depends on https://github.com/WordPress/wordpress-develop/pull/2129 and https://core.trac.wordpress.org/ticket/54781

## How to test

### Font sizes

- Apply on this branch the PR at https://github.com/WordPress/wordpress-develop/pull/2129 
- Use the TwentyTwenty theme.
- Create a post that contains 5 paragraphs with the following content:
  - Small (18)
  - Normal (21)
  - Default
  - Large (26.25)
  - Larger (32)
- To each paragraph apply the font size that corresponds to its content: apply `small` to the 1st paragraph, `normal` to the 2nd, nothing to the third, `large` to the 4th, and `larger` to the 5th.

The expected result is that the font size for each paragraph has the assigned value, both in the editor and front-end.

## Colors

- Apply on this branch the PR at https://github.com/WordPress/wordpress-develop/pull/2129 
- Use the TwentyTwenty theme.
- Create a post.
- Create a paragraph and apply custom color classes by pasting this text `has-white-background-color has-black-color` into the "Additional classes" text field of the "Advanced" section of the block sidebar.
- Create a new paragraph and apply custom color classes by pasting this text `has-black-background-color has-white-color` into the "Additional classes" text field of the "Advanced" section of the block sidebar.

Via the browser devtools make sure that the first paragraph's color is `rgb(0,0,0)` and its background is `rgb(255,255,255)`. The second paragraph should be the opposite.
