### PR TITLE
Fix typo in home template description

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -119,7 +119,7 @@ function get_default_block_template_types() {
 		),
 		'home'           => array(
 			'title'       => _x( 'Home', 'Template name' ),
-			'description' => __( 'Displays as the site\'s home page, or as the Posts page when a static home page it set.' ),
+			'description' => __( 'Displays as the site\'s home page, or as the Posts page when a static home page isn\'t set.' ),
 		),
 		'front-page'     => array(
 			'title'       => _x( 'Front Page', 'Template name' ),


### PR DESCRIPTION
See [#54787](https://core.trac.wordpress.org/ticket/54787) (trac ticket), https://github.com/WordPress/gutenberg/pull/37843 (gutenberg ticket)

Fixes a typo in the home template description. To test:
1. Visit the site editor
2. Using the 'W' icon, open the sidebar
3. Select 'Templates'
4. Note that the description of the Home template has a typo ("it" at the end should be "isn't").