### PR TITLE
Load the global styles before the theme styles in the editor

### DIFF
--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -187,7 +187,6 @@ $editor_settings = array(
 	'titlePlaceholder'                     => apply_filters( 'enter_title_here', __( 'Add title' ), $post ),
 	'bodyPlaceholder'                      => $body_placeholder,
 	'autosaveInterval'                     => AUTOSAVE_INTERVAL,
-	'styles'                               => get_block_editor_theme_styles(),
 	'richEditingEnabled'                   => user_can_richedit(),
 	'postLock'                             => $lock_details,
 	'postLockUtils'                        => array(

--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -307,7 +307,8 @@ function get_block_editor_settings( array $custom_settings, $block_editor_contex
 		$custom_settings
 	);
 
-	$presets = array(
+	$global_styles = array();
+	$presets       = array(
 		array(
 			'css'            => 'variables',
 			'__unstableType' => 'presets',
@@ -320,8 +321,8 @@ function get_block_editor_settings( array $custom_settings, $block_editor_contex
 	foreach ( $presets as $preset_style ) {
 		$actual_css = wp_get_global_stylesheet( array( $preset_style['css'] ) );
 		if ( '' !== $actual_css ) {
-			$preset_style['css']         = $actual_css;
-			$editor_settings['styles'][] = $preset_style;
+			$preset_style['css'] = $actual_css;
+			$global_styles[]     = $preset_style;
 		}
 	}
 
@@ -332,10 +333,12 @@ function get_block_editor_settings( array $custom_settings, $block_editor_contex
 		);
 		$actual_css    = wp_get_global_stylesheet( array( $block_classes['css'] ) );
 		if ( '' !== $actual_css ) {
-			$block_classes['css']        = $actual_css;
-			$editor_settings['styles'][] = $block_classes;
+			$block_classes['css'] = $actual_css;
+			$global_styles[]      = $block_classes;
 		}
 	}
+
+	$editor_settings['styles'] = array_merge( $global_styles, get_block_editor_theme_styles() );
 
 	$editor_settings['__experimentalFeatures'] = wp_get_global_settings();
 	// These settings may need to be updated based on data coming from theme.json sources.


### PR DESCRIPTION
Fixes https://core.trac.wordpress.org/ticket/55188
Related Gutenberg PR https://github.com/WordPress/gutenberg/pull/37885

This follows what we do in the front-end, where theme styles are loaded after global styles by default.

## How to test

- Use empty theme and apply the patch below via `git apply <file.patch>`:

<details>
<summary>Patch for empty theme</summary>
<p>

```
diff --git a/emptytheme/functions.php b/emptytheme/functions.php
index 5ee5593..a50baf4 100644
--- a/emptytheme/functions.php
+++ b/emptytheme/functions.php
@@ -6,8 +6,17 @@ if ( ! function_exists( 'emptytheme_support' ) ) :
 		// Adding support for core block visual styles.
 		add_theme_support( 'wp-block-styles' );
 
+		register_block_style(
+			'core/group',
+			array(
+				'name'  => 'background-color-hotpink',
+				'label' => 'BG Hotpink'
+			)
+		);
+
 		// Enqueue editor styles.
 		add_editor_style( 'style.css' );
+
 	}
 	add_action( 'after_setup_theme', 'emptytheme_support' );
 endif;
diff --git a/emptytheme/style.css b/emptytheme/style.css
index c10d92f..0dc53b7 100644
--- a/emptytheme/style.css
+++ b/emptytheme/style.css
@@ -14,3 +14,6 @@ Text Domain: emptytheme
 Emptytheme WordPress Theme, (C) 2021 WordPress.org
 Emptytheme is distributed under the terms of the GNU GPL.
 */
+.is-style-background-color-hotpink {
+    background-color: hotpink;
+}
\ No newline at end of file
diff --git a/emptytheme/theme.json b/emptytheme/theme.json
index 46b0979..1925b81 100644
--- a/emptytheme/theme.json
+++ b/emptytheme/theme.json
@@ -6,5 +6,14 @@
 			"contentSize": "840px",
 			"wideSize": "1100px"
 		}
+	},
+	"styles": {
+		"blocks": {
+			"core/group": {
+				"color": {
+					"background": "green"
+				}
+			}
+		}
 	}
 }
```

</p>
</details>

- Go to the editor and create a group block. Verify background color of the block is green.
- Go to the block sidebar and select the "BG Hotpink" style. Verify the background color of the block is now hotpink.