### PR TITLE
TwentyNineteen: fix default presets in 5.9

### DIFF
--- a/src/wp-content/themes/twentynineteen/print.css
+++ b/src/wp-content/themes/twentynineteen/print.css
@@ -34,11 +34,13 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
   h1 {
     font-size: 24pt;
   }
+  .has-large-font-size {
+    --wp--preset--font-size--large: 14pt;
+  }
   h2,
   h3,
   h4,
   .has-regular-font-size,
-  .has-large-font-size,
   h2.author-title,
   p.author-bio,
   .comments-title, h3 {

--- a/src/wp-content/themes/twentynineteen/print.css
+++ b/src/wp-content/themes/twentynineteen/print.css
@@ -36,12 +36,12 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
   }
   .has-large-font-size {
     --wp--preset--font-size--large: 14pt;
-    font-size: 14pt;
   }
   h2,
   h3,
   h4,
   .has-regular-font-size,
+  .has-large-font-size,
   h2.author-title,
   p.author-bio,
   .comments-title, h3 {

--- a/src/wp-content/themes/twentynineteen/print.css
+++ b/src/wp-content/themes/twentynineteen/print.css
@@ -36,6 +36,7 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
   }
   .has-large-font-size {
     --wp--preset--font-size--large: 14pt;
+    font-size: 14pt;
   }
   h2,
   h3,

--- a/src/wp-content/themes/twentynineteen/print.scss
+++ b/src/wp-content/themes/twentynineteen/print.scss
@@ -46,6 +46,7 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
 
 	.has-large-font-size {
 		--wp--preset--font-size--large: 14pt;
+		font-size: 14pt;
 	}
 
 	h2,

--- a/src/wp-content/themes/twentynineteen/print.scss
+++ b/src/wp-content/themes/twentynineteen/print.scss
@@ -46,13 +46,13 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
 
 	.has-large-font-size {
 		--wp--preset--font-size--large: 14pt;
-		font-size: 14pt;
 	}
 
 	h2,
 	h3,
 	h4,
-	.has-regular-font-size, 
+	.has-regular-font-size,
+	.has-large-font-size,
 	h2.author-title, 
 	p.author-bio, 
 	.comments-title, h3 {

--- a/src/wp-content/themes/twentynineteen/print.scss
+++ b/src/wp-content/themes/twentynineteen/print.scss
@@ -44,11 +44,14 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
 		font-size: 24pt;
 	}
 
+	.has-large-font-size {
+		--wp--preset--font-size--large: 14pt;
+	}
+
 	h2,
 	h3,
 	h4,
 	.has-regular-font-size, 
-	.has-large-font-size, 
 	h2.author-title, 
 	p.author-bio, 
 	.comments-title, h3 {

--- a/src/wp-content/themes/twentynineteen/sass/blocks/_blocks.scss
+++ b/src/wp-content/themes/twentynineteen/sass/blocks/_blocks.scss
@@ -930,19 +930,19 @@
 
 	//! Font Sizes
 	.has-small-font-size {
-		font-size: $font__size-sm;
+		--wp--preset--font-size--small: $font__size-sm;
 	}
 
 	.has-normal-font-size {
-		font-size: $font__size-md;
+		--wp--preset--font-size--normal: $font__size-md;
 	}
 
 	.has-large-font-size {
-		font-size: $font__size-lg;
+		--wp--preset--font-size--large: $font__size-lg;
 	}
 
 	.has-huge-font-size {
-		font-size: $font__size-xl;
+		--wp--preset--font-size--huge: $font__size-xl;
 	}
 
 	//! Custom background colors

--- a/src/wp-content/themes/twentynineteen/sass/blocks/_blocks.scss
+++ b/src/wp-content/themes/twentynineteen/sass/blocks/_blocks.scss
@@ -446,13 +446,16 @@
 				margin-left: $size__spacing-unit;
 				margin-right: $size__spacing-unit;
 
+				&.has-white-color {
+					--wp--preset--color--white: inherit;
+				}
+
 				&.has-text-color p,
 				&.has-text-color a,
 				&.has-primary-color,
 				&.has-secondary-color,
 				&.has-dark-gray-color,
-				&.has-light-gray-color,
-				&.has-white-color {
+				&.has-light-gray-color {
 					color: inherit;
 				}
 
@@ -1004,7 +1007,7 @@
 
 	.has-white-background-color,
 	.wp-block-pullquote.is-style-solid-color.has-white-background-color {
-		background-color: #FFF;
+		--wp--preset--background-color--white: #FFF;
 	}
 
 	//! Custom foreground colors
@@ -1038,6 +1041,6 @@
 	.has-white-color,
 	.wp-block-pullquote blockquote.has-white-color,
 	.wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
-		color: #FFF;
+		--wp--preset--color--white: #FFF;
 	}
 }

--- a/src/wp-content/themes/twentynineteen/sass/blocks/_blocks.scss
+++ b/src/wp-content/themes/twentynineteen/sass/blocks/_blocks.scss
@@ -933,19 +933,19 @@
 
 	//! Font Sizes
 	.has-small-font-size {
-		--wp--preset--font-size--small: $font__size-sm;
+		--wp--preset--font-size--small: 0.88889em;//$font__size-sm;
 	}
 
 	.has-normal-font-size {
-		--wp--preset--font-size--normal: $font__size-md;
+		--wp--preset--font-size--normal: 1.125em;//$font__size-md;
 	}
 
 	.has-large-font-size {
-		--wp--preset--font-size--large: $font__size-lg;
+		--wp--preset--font-size--large: 1.6875em;//$font__size-lg;
 	}
 
 	.has-huge-font-size {
-		--wp--preset--font-size--huge: $font__size-xl;
+		--wp--preset--font-size--huge: 2.25em;//$font__size-xl;
 	}
 
 	//! Custom background colors

--- a/src/wp-content/themes/twentynineteen/sass/blocks/_blocks.scss
+++ b/src/wp-content/themes/twentynineteen/sass/blocks/_blocks.scss
@@ -448,6 +448,7 @@
 
 				&.has-white-color {
 					--wp--preset--color--white: inherit;
+					color: inherit;
 				}
 
 				&.has-text-color p,
@@ -933,19 +934,23 @@
 
 	//! Font Sizes
 	.has-small-font-size {
-		--wp--preset--font-size--small: 0.88889em;//$font__size-sm;
+		--wp--preset--font-size--small: 0.88889em;
+		font-size: $font__size-sm;
 	}
 
 	.has-normal-font-size {
-		--wp--preset--font-size--normal: 1.125em;//$font__size-md;
+		--wp--preset--font-size--normal: 1.125em;
+		font-size: $font__size-md;
 	}
 
 	.has-large-font-size {
-		--wp--preset--font-size--large: 1.6875em;//$font__size-lg;
+		--wp--preset--font-size--large: 1.6875em;
+		font-size: $font__size-lg;
 	}
 
 	.has-huge-font-size {
-		--wp--preset--font-size--huge: 2.25em;//$font__size-xl;
+		--wp--preset--font-size--huge: 2.25em;
+		font-size: $font__size-xl;
 	}
 
 	//! Custom background colors
@@ -1007,7 +1012,8 @@
 
 	.has-white-background-color,
 	.wp-block-pullquote.is-style-solid-color.has-white-background-color {
-		--wp--preset--background-color--white: #FFF;
+		--wp--preset--color--white: #FFF;
+		background-color: #FFF;
 	}
 
 	//! Custom foreground colors
@@ -1042,5 +1048,6 @@
 	.wp-block-pullquote blockquote.has-white-color,
 	.wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
 		--wp--preset--color--white: #FFF;
+		color: #FFF;
 	}
 }

--- a/src/wp-content/themes/twentynineteen/sass/blocks/_blocks.scss
+++ b/src/wp-content/themes/twentynineteen/sass/blocks/_blocks.scss
@@ -448,7 +448,6 @@
 
 				&.has-white-color {
 					--wp--preset--color--white: inherit;
-					color: inherit;
 				}
 
 				&.has-text-color p,
@@ -456,7 +455,8 @@
 				&.has-primary-color,
 				&.has-secondary-color,
 				&.has-dark-gray-color,
-				&.has-light-gray-color {
+				&.has-light-gray-color,
+				&.has-white-color {
 					color: inherit;
 				}
 

--- a/src/wp-content/themes/twentynineteen/sass/typography/_headings.scss
+++ b/src/wp-content/themes/twentynineteen/sass/typography/_headings.scss
@@ -83,8 +83,11 @@ h2 {
 	}
 }
 
+.has-large-font-size {
+	--wp--preset--font-size--large: $font__size-lg;
+}
+
 .has-regular-font-size,
-.has-large-font-size,
 .comments-title,
 h3 {
 	font-size: $font__size-lg;
@@ -110,11 +113,14 @@ h5 {
 	font-size: $font__size-sm;
 }
 
+.has-small-font-size {
+	--wp--preset--font-size--smal: $font__size-xs;
+}
+
 .entry-meta,
 .entry-footer,
 .discussion-meta-info,
 .site-info,
-.has-small-font-size,
 .comment-reply-link,
 .comment-metadata,
 .comment-notes,

--- a/src/wp-content/themes/twentynineteen/sass/typography/_headings.scss
+++ b/src/wp-content/themes/twentynineteen/sass/typography/_headings.scss
@@ -84,7 +84,7 @@ h2 {
 }
 
 .has-large-font-size {
-	--wp--preset--font-size--large: $font__size-lg;
+	--wp--preset--font-size--large: 1.6875em;//$font__size-lg;
 }
 
 .has-regular-font-size,
@@ -114,7 +114,7 @@ h5 {
 }
 
 .has-small-font-size {
-	--wp--preset--font-size--small: $font__size-xs;
+	--wp--preset--font-size--small: 0.71111em;//$font__size-xs;
 }
 
 .entry-meta,

--- a/src/wp-content/themes/twentynineteen/sass/typography/_headings.scss
+++ b/src/wp-content/themes/twentynineteen/sass/typography/_headings.scss
@@ -84,7 +84,8 @@ h2 {
 }
 
 .has-large-font-size {
-	--wp--preset--font-size--large: 1.6875em;//$font__size-lg;
+	--wp--preset--font-size--large: 1.6875em;
+	font-size: $font__size-lg;
 }
 
 .has-regular-font-size,
@@ -114,7 +115,8 @@ h5 {
 }
 
 .has-small-font-size {
-	--wp--preset--font-size--small: 0.71111em;//$font__size-xs;
+	--wp--preset--font-size--small: 0.71111em;
+	font-size: $font__size-xs;
 }
 
 .entry-meta,

--- a/src/wp-content/themes/twentynineteen/sass/typography/_headings.scss
+++ b/src/wp-content/themes/twentynineteen/sass/typography/_headings.scss
@@ -85,10 +85,10 @@ h2 {
 
 .has-large-font-size {
 	--wp--preset--font-size--large: 1.6875em;
-	font-size: $font__size-lg;
 }
 
 .has-regular-font-size,
+.has-large-font-size,
 .comments-title,
 h3 {
 	font-size: $font__size-lg;
@@ -116,13 +116,13 @@ h5 {
 
 .has-small-font-size {
 	--wp--preset--font-size--small: 0.71111em;
-	font-size: $font__size-xs;
 }
 
 .entry-meta,
 .entry-footer,
 .discussion-meta-info,
 .site-info,
+.has-small-font-size,
 .comment-reply-link,
 .comment-metadata,
 .comment-notes,

--- a/src/wp-content/themes/twentynineteen/sass/typography/_headings.scss
+++ b/src/wp-content/themes/twentynineteen/sass/typography/_headings.scss
@@ -114,7 +114,7 @@ h5 {
 }
 
 .has-small-font-size {
-	--wp--preset--font-size--smal: $font__size-xs;
+	--wp--preset--font-size--small: $font__size-xs;
 }
 
 .entry-meta,

--- a/src/wp-content/themes/twentynineteen/style-editor.css
+++ b/src/wp-content/themes/twentynineteen/style-editor.css
@@ -581,6 +581,22 @@ h6:lang(vi), figcaption:lang(vi),
 }
 
 /** === Editor Frame === */
+.has-small-font-size {
+  --wp--preset--font-size--small: $font__size-sm;
+}
+
+.has-normal-font-size {
+  --wp--preset--font-size--normal: $font__size-md;
+}
+
+.has-large-font-size {
+  --wp--preset--font-size--large: $font__size-lg;
+}
+
+.has-huge-font-size {
+  --wp--preset--font-size--huge: $font__size-xl;
+}
+
 body .wp-block[data-align="full"],
 body .wp-block.alignfull {
   max-width: calc(100% + 16px);

--- a/src/wp-content/themes/twentynineteen/style-editor.css
+++ b/src/wp-content/themes/twentynineteen/style-editor.css
@@ -583,18 +583,22 @@ h6:lang(vi), figcaption:lang(vi),
 /** === Editor Frame === */
 .has-small-font-size {
   --wp--preset--font-size--small: 19.5px;
+  font-size: 0.88889em;
 }
 
 .has-normal-font-size {
   --wp--preset--font-size--normal: 22px;
+  font-size: 1.125em;
 }
 
 .has-large-font-size {
   --wp--preset--font-size--large: 36.5px;
+  font-size: 1.6875em;
 }
 
 .has-huge-font-size {
   --wp--preset--font-size--huge: 49.5px;
+  font-size: 2.25em;
 }
 
 body .wp-block[data-align="full"],

--- a/src/wp-content/themes/twentynineteen/style-editor.css
+++ b/src/wp-content/themes/twentynineteen/style-editor.css
@@ -582,22 +582,22 @@ h6:lang(vi), figcaption:lang(vi),
 
 /** === Editor Frame === */
 .has-small-font-size {
-  --wp--preset--font-size--small: 19.5px;
+  --wp--preset--font-size--small: 0.88889em;
   font-size: 0.88889em;
 }
 
 .has-normal-font-size {
-  --wp--preset--font-size--normal: 22px;
+  --wp--preset--font-size--normal: 1.125em;
   font-size: 1.125em;
 }
 
 .has-large-font-size {
-  --wp--preset--font-size--large: 36.5px;
+  --wp--preset--font-size--large: 1.6875em;
   font-size: 1.6875em;
 }
 
 .has-huge-font-size {
-  --wp--preset--font-size--huge: 49.5px;
+  --wp--preset--font-size--huge: 2.25em;
   font-size: 2.25em;
 }
 

--- a/src/wp-content/themes/twentynineteen/style-editor.css
+++ b/src/wp-content/themes/twentynineteen/style-editor.css
@@ -582,19 +582,19 @@ h6:lang(vi), figcaption:lang(vi),
 
 /** === Editor Frame === */
 .has-small-font-size {
-  --wp--preset--font-size--small: $font__size-sm;
+  --wp--preset--font-size--small: 19.5px;
 }
 
 .has-normal-font-size {
-  --wp--preset--font-size--normal: $font__size-md;
+  --wp--preset--font-size--normal: 22px;
 }
 
 .has-large-font-size {
-  --wp--preset--font-size--large: $font__size-lg;
+  --wp--preset--font-size--large: 36.5px;
 }
 
 .has-huge-font-size {
-  --wp--preset--font-size--huge: $font__size-xl;
+  --wp--preset--font-size--huge: 49.5px;
 }
 
 body .wp-block[data-align="full"],

--- a/src/wp-content/themes/twentynineteen/style-editor.scss
+++ b/src/wp-content/themes/twentynineteen/style-editor.scss
@@ -10,22 +10,22 @@ Twenty Nineteen Editor Styles
 /** === Editor Frame === */
 
 .has-small-font-size {
-	--wp--preset--font-size--small: 19.5px;
+	--wp--preset--font-size--small: 0.88889em;
 	font-size: $font__size-sm;
 }
 
 .has-normal-font-size {
-	--wp--preset--font-size--normal: 22px;
+	--wp--preset--font-size--normal: 1.125em;
 	font-size: $font__size-md;
 }
 
 .has-large-font-size {
-	--wp--preset--font-size--large: 36.5px;
+	--wp--preset--font-size--large: 1.6875em;
 	font-size: $font__size-lg;
 }
 
 .has-huge-font-size {
-	--wp--preset--font-size--huge: 49.5px;
+	--wp--preset--font-size--huge: 2.25em;
 	font-size: $font__size-xl;
 }
 

--- a/src/wp-content/themes/twentynineteen/style-editor.scss
+++ b/src/wp-content/themes/twentynineteen/style-editor.scss
@@ -9,6 +9,22 @@ Twenty Nineteen Editor Styles
 
 /** === Editor Frame === */
 
+.has-small-font-size {
+	--wp--preset--font-size--small: $font__size-sm;
+}
+
+.has-normal-font-size {
+	--wp--preset--font-size--normal: $font__size-md;
+}
+
+.has-large-font-size {
+	--wp--preset--font-size--large: $font__size-lg;
+}
+
+.has-huge-font-size {
+	--wp--preset--font-size--huge: $font__size-xl;
+}
+
 body {
 
 	.wp-block[data-align="full"],

--- a/src/wp-content/themes/twentynineteen/style-editor.scss
+++ b/src/wp-content/themes/twentynineteen/style-editor.scss
@@ -10,19 +10,19 @@ Twenty Nineteen Editor Styles
 /** === Editor Frame === */
 
 .has-small-font-size {
-	--wp--preset--font-size--small: $font__size-sm;
+	--wp--preset--font-size--small: 19.5px;//$font__size-sm;
 }
 
 .has-normal-font-size {
-	--wp--preset--font-size--normal: $font__size-md;
+	--wp--preset--font-size--normal: 22px;//$font__size-md;
 }
 
 .has-large-font-size {
-	--wp--preset--font-size--large: $font__size-lg;
+	--wp--preset--font-size--large: 36.5px;//$font__size-lg;
 }
 
 .has-huge-font-size {
-	--wp--preset--font-size--huge: $font__size-xl;
+	--wp--preset--font-size--huge: 49.5px;//$font__size-xl;
 }
 
 body {

--- a/src/wp-content/themes/twentynineteen/style-editor.scss
+++ b/src/wp-content/themes/twentynineteen/style-editor.scss
@@ -10,19 +10,23 @@ Twenty Nineteen Editor Styles
 /** === Editor Frame === */
 
 .has-small-font-size {
-	--wp--preset--font-size--small: 19.5px;//$font__size-sm;
+	--wp--preset--font-size--small: 19.5px;
+	font-size: $font__size-sm;
 }
 
 .has-normal-font-size {
-	--wp--preset--font-size--normal: 22px;//$font__size-md;
+	--wp--preset--font-size--normal: 22px;
+	font-size: $font__size-md;
 }
 
 .has-large-font-size {
-	--wp--preset--font-size--large: 36.5px;//$font__size-lg;
+	--wp--preset--font-size--large: 36.5px;
+	font-size: $font__size-lg;
 }
 
 .has-huge-font-size {
-	--wp--preset--font-size--huge: 49.5px;//$font__size-xl;
+	--wp--preset--font-size--huge: 49.5px;
+	font-size: $font__size-xl;
 }
 
 body {

--- a/src/wp-content/themes/twentynineteen/style-rtl.css
+++ b/src/wp-content/themes/twentynineteen/style-rtl.css
@@ -5,6 +5,7 @@ Theme URI: https://wordpress.org/themes/twentynineteen/
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Our 2019 default theme is designed to show off the power of the block editor. It features custom styles for all the default blocks, and is built so that what you see in the editor looks like what you'll see on your website. Twenty Nineteen is designed to be adaptable to a wide range of websites, whether you’re running a photo blog, launching a new business, or supporting a non-profit. Featuring ample whitespace and modern sans-serif headlines paired with classic serif body text, it's built to be beautiful on all screen sizes.
+Tested up to: 5.9
 Requires at least: 4.9.6
 Requires PHP: 5.2.4
 Version: 2.1

--- a/src/wp-content/themes/twentynineteen/style-rtl.css
+++ b/src/wp-content/themes/twentynineteen/style-rtl.css
@@ -5,7 +5,6 @@ Theme URI: https://wordpress.org/themes/twentynineteen/
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Our 2019 default theme is designed to show off the power of the block editor. It features custom styles for all the default blocks, and is built so that what you see in the editor looks like what you'll see on your website. Twenty Nineteen is designed to be adaptable to a wide range of websites, whether you’re running a photo blog, launching a new business, or supporting a non-profit. Featuring ample whitespace and modern sans-serif headlines paired with classic serif body text, it's built to be beautiful on all screen sizes.
-Tested up to: 5.9
 Requires at least: 4.9.6
 Requires PHP: 5.2.4
 Version: 2.1
@@ -2333,8 +2332,11 @@ h2 {
   }
 }
 
+.has-large-font-size {
+  --wp--preset--font-size--large: $font__size-lg;
+}
+
 .has-regular-font-size,
-.has-large-font-size,
 .comments-title,
 h3 {
   font-size: 1.6875em;
@@ -2360,11 +2362,14 @@ h5 {
   font-size: 0.88889em;
 }
 
+.has-small-font-size {
+  --wp--preset--font-size--smal: $font__size-xs;
+}
+
 .entry-meta,
 .entry-footer,
 .discussion-meta-info,
 .site-info,
-.has-small-font-size,
 .comment-reply-link,
 .comment-metadata,
 .comment-notes,
@@ -5760,8 +5765,12 @@ body.page .main-navigation {
   margin-left: 1rem;
 }
 
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
+  --wp--preset--color--white: inherit;
+}
+
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color p,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color {
   color: inherit;
 }
 
@@ -6283,19 +6292,19 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .has-small-font-size {
-  font-size: 0.88889em;
+  --wp--preset--font-size--small: $font__size-sm;
 }
 
 .entry .entry-content .has-normal-font-size {
-  font-size: 1.125em;
+  --wp--preset--font-size--normal: $font__size-md;
 }
 
 .entry .entry-content .has-large-font-size {
-  font-size: 1.6875em;
+  --wp--preset--font-size--large: $font__size-lg;
 }
 
 .entry .entry-content .has-huge-font-size {
-  font-size: 2.25em;
+  --wp--preset--font-size--huge: $font__size-xl;
 }
 
 .entry .entry-content .has-primary-background-color,
@@ -6410,7 +6419,7 @@ body.page .main-navigation {
 .entry .entry-content .has-white-color,
 .entry .entry-content .wp-block-pullquote blockquote.has-white-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
-  color: #FFF;
+  --wp--preset--color--white: #FFF;
 }
 
 /* Media */

--- a/src/wp-content/themes/twentynineteen/style-rtl.css
+++ b/src/wp-content/themes/twentynineteen/style-rtl.css
@@ -2363,7 +2363,7 @@ h5 {
 }
 
 .has-small-font-size {
-  --wp--preset--font-size--smal: $font__size-xs;
+  --wp--preset--font-size--small: $font__size-xs;
 }
 
 .entry-meta,

--- a/src/wp-content/themes/twentynineteen/style-rtl.css
+++ b/src/wp-content/themes/twentynineteen/style-rtl.css
@@ -6386,7 +6386,7 @@ body.page .main-navigation {
 
 .entry .entry-content .has-white-background-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color.has-white-background-color {
-  background-color: #FFF;
+  --wp--preset--background-color--white: #FFF;
 }
 
 .entry .entry-content .has-primary-color,

--- a/src/wp-content/themes/twentynineteen/style-rtl.css
+++ b/src/wp-content/themes/twentynineteen/style-rtl.css
@@ -2333,7 +2333,7 @@ h2 {
 }
 
 .has-large-font-size {
-  --wp--preset--font-size--large: $font__size-lg;
+  --wp--preset--font-size--large: 1.6875em;
 }
 
 .has-regular-font-size,
@@ -2363,7 +2363,7 @@ h5 {
 }
 
 .has-small-font-size {
-  --wp--preset--font-size--small: $font__size-xs;
+  --wp--preset--font-size--small: 0.71111em;
 }
 
 .entry-meta,
@@ -6292,19 +6292,19 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .has-small-font-size {
-  --wp--preset--font-size--small: $font__size-sm;
+  --wp--preset--font-size--small: 0.88889em;
 }
 
 .entry .entry-content .has-normal-font-size {
-  --wp--preset--font-size--normal: $font__size-md;
+  --wp--preset--font-size--normal: 1.125em;
 }
 
 .entry .entry-content .has-large-font-size {
-  --wp--preset--font-size--large: $font__size-lg;
+  --wp--preset--font-size--large: 1.6875em;
 }
 
 .entry .entry-content .has-huge-font-size {
-  --wp--preset--font-size--huge: $font__size-xl;
+  --wp--preset--font-size--huge: 2.25em;
 }
 
 .entry .entry-content .has-primary-background-color,

--- a/src/wp-content/themes/twentynineteen/style-rtl.css
+++ b/src/wp-content/themes/twentynineteen/style-rtl.css
@@ -2335,6 +2335,7 @@ h2 {
 
 .has-large-font-size {
   --wp--preset--font-size--large: 1.6875em;
+  font-size: 1.6875em;
 }
 
 .has-regular-font-size,
@@ -2365,6 +2366,7 @@ h5 {
 
 .has-small-font-size {
   --wp--preset--font-size--small: 0.71111em;
+  font-size: 0.71111em;
 }
 
 .entry-meta,
@@ -5768,6 +5770,7 @@ body.page .main-navigation {
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
   --wp--preset--color--white: inherit;
+  color: inherit;
 }
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color p,
@@ -6294,18 +6297,22 @@ body.page .main-navigation {
 
 .entry .entry-content .has-small-font-size {
   --wp--preset--font-size--small: 0.88889em;
+  font-size: 0.88889em;
 }
 
 .entry .entry-content .has-normal-font-size {
   --wp--preset--font-size--normal: 1.125em;
+  font-size: 1.125em;
 }
 
 .entry .entry-content .has-large-font-size {
   --wp--preset--font-size--large: 1.6875em;
+  font-size: 1.6875em;
 }
 
 .entry .entry-content .has-huge-font-size {
   --wp--preset--font-size--huge: 2.25em;
+  font-size: 2.25em;
 }
 
 .entry .entry-content .has-primary-background-color,
@@ -6387,7 +6394,8 @@ body.page .main-navigation {
 
 .entry .entry-content .has-white-background-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color.has-white-background-color {
-  --wp--preset--background-color--white: #FFF;
+  --wp--preset--color--white: #FFF;
+  background-color: #FFF;
 }
 
 .entry .entry-content .has-primary-color,
@@ -6421,6 +6429,7 @@ body.page .main-navigation {
 .entry .entry-content .wp-block-pullquote blockquote.has-white-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
   --wp--preset--color--white: #FFF;
+  color: #FFF;
 }
 
 /* Media */

--- a/src/wp-content/themes/twentynineteen/style-rtl.css
+++ b/src/wp-content/themes/twentynineteen/style-rtl.css
@@ -2335,10 +2335,10 @@ h2 {
 
 .has-large-font-size {
   --wp--preset--font-size--large: 1.6875em;
-  font-size: 1.6875em;
 }
 
 .has-regular-font-size,
+.has-large-font-size,
 .comments-title,
 h3 {
   font-size: 1.6875em;
@@ -2366,13 +2366,13 @@ h5 {
 
 .has-small-font-size {
   --wp--preset--font-size--small: 0.71111em;
-  font-size: 0.71111em;
 }
 
 .entry-meta,
 .entry-footer,
 .discussion-meta-info,
 .site-info,
+.has-small-font-size,
 .comment-reply-link,
 .comment-metadata,
 .comment-notes,
@@ -5770,11 +5770,10 @@ body.page .main-navigation {
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
   --wp--preset--color--white: inherit;
-  color: inherit;
 }
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color p,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
   color: inherit;
 }
 

--- a/src/wp-content/themes/twentynineteen/style.css
+++ b/src/wp-content/themes/twentynineteen/style.css
@@ -5,6 +5,7 @@ Theme URI: https://wordpress.org/themes/twentynineteen/
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Our 2019 default theme is designed to show off the power of the block editor. It features custom styles for all the default blocks, and is built so that what you see in the editor looks like what you'll see on your website. Twenty Nineteen is designed to be adaptable to a wide range of websites, whether you’re running a photo blog, launching a new business, or supporting a non-profit. Featuring ample whitespace and modern sans-serif headlines paired with classic serif body text, it's built to be beautiful on all screen sizes.
+Tested up to: 5.9
 Requires at least: 4.9.6
 Requires PHP: 5.2.4
 Version: 2.1

--- a/src/wp-content/themes/twentynineteen/style.css
+++ b/src/wp-content/themes/twentynineteen/style.css
@@ -5,7 +5,6 @@ Theme URI: https://wordpress.org/themes/twentynineteen/
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Our 2019 default theme is designed to show off the power of the block editor. It features custom styles for all the default blocks, and is built so that what you see in the editor looks like what you'll see on your website. Twenty Nineteen is designed to be adaptable to a wide range of websites, whether you’re running a photo blog, launching a new business, or supporting a non-profit. Featuring ample whitespace and modern sans-serif headlines paired with classic serif body text, it's built to be beautiful on all screen sizes.
-Tested up to: 5.9
 Requires at least: 4.9.6
 Requires PHP: 5.2.4
 Version: 2.1
@@ -2333,8 +2332,11 @@ h2 {
   }
 }
 
+.has-large-font-size {
+  --wp--preset--font-size--large: $font__size-lg;
+}
+
 .has-regular-font-size,
-.has-large-font-size,
 .comments-title,
 h3 {
   font-size: 1.6875em;
@@ -2360,11 +2362,14 @@ h5 {
   font-size: 0.88889em;
 }
 
+.has-small-font-size {
+  --wp--preset--font-size--smal: $font__size-xs;
+}
+
 .entry-meta,
 .entry-footer,
 .discussion-meta-info,
 .site-info,
-.has-small-font-size,
 .comment-reply-link,
 .comment-metadata,
 .comment-notes,
@@ -6295,19 +6300,19 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .has-small-font-size {
-  font-size: 0.88889em;
+  --wp--preset--font-size--small: $font__size-sm;
 }
 
 .entry .entry-content .has-normal-font-size {
-  font-size: 1.125em;
+  --wp--preset--font-size--normal: $font__size-md;
 }
 
 .entry .entry-content .has-large-font-size {
-  font-size: 1.6875em;
+  --wp--preset--font-size--large: $font__size-lg;
 }
 
 .entry .entry-content .has-huge-font-size {
-  font-size: 2.25em;
+  --wp--preset--font-size--huge: $font__size-xl;
 }
 
 .entry .entry-content .has-primary-background-color,

--- a/src/wp-content/themes/twentynineteen/style.css
+++ b/src/wp-content/themes/twentynineteen/style.css
@@ -2363,7 +2363,7 @@ h5 {
 }
 
 .has-small-font-size {
-  --wp--preset--font-size--smal: $font__size-xs;
+  --wp--preset--font-size--small: $font__size-xs;
 }
 
 .entry-meta,

--- a/src/wp-content/themes/twentynineteen/style.css
+++ b/src/wp-content/themes/twentynineteen/style.css
@@ -5777,8 +5777,12 @@ body.page .main-navigation {
   margin-right: 1rem;
 }
 
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
+  --wp--preset--color--white: inherit;
+}
+
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color p,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color {
   color: inherit;
 }
 
@@ -6394,7 +6398,7 @@ body.page .main-navigation {
 
 .entry .entry-content .has-white-background-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color.has-white-background-color {
-  background-color: #FFF;
+  --wp--preset--background-color--white: #FFF;
 }
 
 .entry .entry-content .has-primary-color,
@@ -6427,7 +6431,7 @@ body.page .main-navigation {
 .entry .entry-content .has-white-color,
 .entry .entry-content .wp-block-pullquote blockquote.has-white-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
-  color: #FFF;
+  --wp--preset--color--white: #FFF;
 }
 
 /* Media */

--- a/src/wp-content/themes/twentynineteen/style.css
+++ b/src/wp-content/themes/twentynineteen/style.css
@@ -2335,6 +2335,7 @@ h2 {
 
 .has-large-font-size {
   --wp--preset--font-size--large: 1.6875em;
+  font-size: 1.6875em;
 }
 
 .has-regular-font-size,
@@ -2365,6 +2366,7 @@ h5 {
 
 .has-small-font-size {
   --wp--preset--font-size--small: 0.71111em;
+  font-size: 0.71111em;
 }
 
 .entry-meta,
@@ -5780,6 +5782,7 @@ body.page .main-navigation {
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
   --wp--preset--color--white: inherit;
+  color: inherit;
 }
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color p,
@@ -6306,18 +6309,22 @@ body.page .main-navigation {
 
 .entry .entry-content .has-small-font-size {
   --wp--preset--font-size--small: 0.88889em;
+  font-size: 0.88889em;
 }
 
 .entry .entry-content .has-normal-font-size {
   --wp--preset--font-size--normal: 1.125em;
+  font-size: 1.125em;
 }
 
 .entry .entry-content .has-large-font-size {
   --wp--preset--font-size--large: 1.6875em;
+  font-size: 1.6875em;
 }
 
 .entry .entry-content .has-huge-font-size {
   --wp--preset--font-size--huge: 2.25em;
+  font-size: 2.25em;
 }
 
 .entry .entry-content .has-primary-background-color,
@@ -6399,7 +6406,8 @@ body.page .main-navigation {
 
 .entry .entry-content .has-white-background-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color.has-white-background-color {
-  --wp--preset--background-color--white: #FFF;
+  --wp--preset--color--white: #FFF;
+  background-color: #FFF;
 }
 
 .entry .entry-content .has-primary-color,
@@ -6433,6 +6441,7 @@ body.page .main-navigation {
 .entry .entry-content .wp-block-pullquote blockquote.has-white-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
   --wp--preset--color--white: #FFF;
+  color: #FFF;
 }
 
 /* Media */

--- a/src/wp-content/themes/twentynineteen/style.css
+++ b/src/wp-content/themes/twentynineteen/style.css
@@ -2333,7 +2333,7 @@ h2 {
 }
 
 .has-large-font-size {
-  --wp--preset--font-size--large: $font__size-lg;
+  --wp--preset--font-size--large: 1.6875em;
 }
 
 .has-regular-font-size,
@@ -2363,7 +2363,7 @@ h5 {
 }
 
 .has-small-font-size {
-  --wp--preset--font-size--small: $font__size-xs;
+  --wp--preset--font-size--small: 0.71111em;
 }
 
 .entry-meta,
@@ -6304,19 +6304,19 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .has-small-font-size {
-  --wp--preset--font-size--small: $font__size-sm;
+  --wp--preset--font-size--small: 0.88889em;
 }
 
 .entry .entry-content .has-normal-font-size {
-  --wp--preset--font-size--normal: $font__size-md;
+  --wp--preset--font-size--normal: 1.125em;
 }
 
 .entry .entry-content .has-large-font-size {
-  --wp--preset--font-size--large: $font__size-lg;
+  --wp--preset--font-size--large: 1.6875em;
 }
 
 .entry .entry-content .has-huge-font-size {
-  --wp--preset--font-size--huge: $font__size-xl;
+  --wp--preset--font-size--huge: 2.25em;
 }
 
 .entry .entry-content .has-primary-background-color,

--- a/src/wp-content/themes/twentynineteen/style.css
+++ b/src/wp-content/themes/twentynineteen/style.css
@@ -2335,10 +2335,10 @@ h2 {
 
 .has-large-font-size {
   --wp--preset--font-size--large: 1.6875em;
-  font-size: 1.6875em;
 }
 
 .has-regular-font-size,
+.has-large-font-size,
 .comments-title,
 h3 {
   font-size: 1.6875em;
@@ -2366,13 +2366,13 @@ h5 {
 
 .has-small-font-size {
   --wp--preset--font-size--small: 0.71111em;
-  font-size: 0.71111em;
 }
 
 .entry-meta,
 .entry-footer,
 .discussion-meta-info,
 .site-info,
+.has-small-font-size,
 .comment-reply-link,
 .comment-metadata,
 .comment-notes,
@@ -5782,11 +5782,10 @@ body.page .main-navigation {
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
   --wp--preset--color--white: inherit;
-  color: inherit;
 }
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color p,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
   color: inherit;
 }
 

--- a/src/wp-content/themes/twentynineteen/style.scss
+++ b/src/wp-content/themes/twentynineteen/style.scss
@@ -4,6 +4,7 @@ Theme URI: https://wordpress.org/themes/twentynineteen/
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Our 2019 default theme is designed to show off the power of the block editor. It features custom styles for all the default blocks, and is built so that what you see in the editor looks like what you'll see on your website. Twenty Nineteen is designed to be adaptable to a wide range of websites, whether you’re running a photo blog, launching a new business, or supporting a non-profit. Featuring ample whitespace and modern sans-serif headlines paired with classic serif body text, it's built to be beautiful on all screen sizes.
+Tested up to: 5.9
 Requires at least: 4.9.6
 Requires PHP: 5.2.4
 Version: 2.1


### PR DESCRIPTION
Trac ticket https://core.trac.wordpress.org/ticket/54782
Related https://github.com/WordPress/wordpress-develop/pull/2130 and https://github.com/WordPress/wordpress-develop/pull/2154

WordPress 5.9 uses CSS Custom Properties to define the presets, and themes without a theme.json need to use them to set their value.

## How to test

Test this both in WordPress 5.9 and WordPress 5.7. In 5.9 the CSS Custom Properties are present for all themes and in 5.7 are not. This covers all the cases.

- Use the TwentyNineteen theme.
- Create a post that contains 5 paragraphs with the following content:
  - Small (19.5)
  - Normal (22)
  - Default
  - Large (36.5)
  - Huge (49.5)
- To each paragraph apply the font size that corresponds to its content: apply `small` to the 1st paragraph, `normal` to the 2nd, nothing to the third, `large` to the 4th, and `huge` to the 5th.

The expected result is that the font size for each paragraph has the assigned value, both in the editor and front-end.

## TODO

- [x] ~There's an issue in compiling the SASS variable into values when it's used by a CSS Custom Property.~ Solved this issue by using the raw values directly. The issue is bigger than this PR: the existing config/utils to process CSS don't compile CSS Custom Properties. I've tried to update it to do it gets complicated quickly and would require wide testing.
- [x] ~Figure out why `Tested up to: 5.9` is removed when running `npm run build`.~ Fixed at https://github.com/WordPress/wordpress-develop/pull/2140/commits/54d062c1a4eba1ee91615f5e233f1e3a09401fff
