### PR TITLE
Check for int in menu priority

### DIFF
--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -1339,7 +1339,7 @@ function add_menu_page( $page_title, $menu_title, $capability, $menu_slug, $func
 				),
 				'6.0.0'
 			);
-			// Check if the position is non-string(i.e. float) and convert it to string.
+			// If the position is not a string (i.e. float), convert it to string.
 			if ( ! is_string( $position ) ) {
 				$position = (string) $position;
 			}

--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -1329,6 +1329,21 @@ function add_menu_page( $page_title, $menu_title, $capability, $menu_slug, $func
 		$position            = $position + substr( base_convert( md5( $menu_slug . $menu_title ), 16, 10 ), -5 ) * 0.00001;
 		$menu[ "$position" ] = $new_menu;
 	} else {
+		if ( ! is_int( $position ) ) {
+			_doing_it_wrong(
+				__FUNCTION__,
+				sprintf(
+				/* translators: %s: add_submenu_page() */
+					__( 'The seventh parameter passed to %s should be an integer representing menu position.' ),
+					'<code>add_menu_page()</code>'
+				),
+				'6.0.0'
+			);
+			// Check if the position is non-string(i.e. float) and convert it to string.
+			if ( ! is_string( $position ) ) {
+				$position = (string) $position;
+			}
+		}
 		$menu[ $position ] = $new_menu;
 	}
 

--- a/tests/phpunit/tests/admin/includesPlugin.php
+++ b/tests/phpunit/tests/admin/includesPlugin.php
@@ -352,7 +352,7 @@ class Tests_Admin_IncludesPlugin extends WP_UnitTestCase {
 		// Verify the menu was inserted.
 		$this->assertSame( 'main_slug', $menu[1][2] );
 		// Verify the menu was inserted correctly on passing float as position.
-		$this->assertSame( 'main1_slug', $menu[1.5][2] );
+		$this->assertSame( 'main1_slug', $menu[ 1.5 ][2] );
 	}
 
 	public function test_is_plugin_active_true() {

--- a/tests/phpunit/tests/admin/includesPlugin.php
+++ b/tests/phpunit/tests/admin/includesPlugin.php
@@ -296,11 +296,11 @@ class Tests_Admin_IncludesPlugin extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Passing a string as position will fail.
+	 * Passing a string as position will fail in submenu.
 	 *
 	 * @ticket 48599
 	 */
-	public function test_passing_string_as_position_fires_doing_it_wrong() {
+	public function test_passing_string_as_position_fires_doing_it_wrong_submenu() {
 		$this->setExpectedIncorrectUsage( 'add_submenu_page' );
 		global $submenu, $menu;
 
@@ -322,6 +322,37 @@ class Tests_Admin_IncludesPlugin extends WP_UnitTestCase {
 
 		// Verify the menu was inserted at the expected position.
 		$this->assertSame( 'submenu_page_1', $submenu['main_slug'][1][2] );
+	}
+
+	/**
+	 * Passing a string as position will fail in menu.
+	 *
+	 * @ticket 48599
+	 */
+	public function test_passing_string_as_position_fires_doing_it_wrong_menu() {
+		$this->setExpectedIncorrectUsage( 'add_menu_page' );
+		global $submenu, $menu;
+
+		// Reset menus.
+		$submenu      = array();
+		$menu         = array();
+		$current_user = get_current_user_id();
+		$admin_user   = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_user );
+		set_current_screen( 'dashboard' );
+
+		// Setup a menu with some items.
+		add_menu_page( 'Main Menu', 'Main Menu', 'manage_options', 'main_slug', 'main_page_callback', 'icon_url', '1' );
+		add_menu_page( 'Main Menu 1', 'Main Menu 1', 'manage_options', 'main1_slug', 'main1_page_callback', 'icon_url1', 1.5 );
+
+		// Clean up the temporary user.
+		wp_set_current_user( $current_user );
+		wp_delete_user( $admin_user );
+
+		// Verify the menu was inserted.
+		$this->assertSame( 'main_slug', $menu[1][2] );
+		// Verify the menu was inserted correctly on passing float as position.
+		$this->assertSame( 'main1_slug', $menu[1.5][2] );
 	}
 
 	public function test_is_plugin_active_true() {

--- a/tests/phpunit/tests/admin/includesPlugin.php
+++ b/tests/phpunit/tests/admin/includesPlugin.php
@@ -352,7 +352,7 @@ class Tests_Admin_IncludesPlugin extends WP_UnitTestCase {
 		// Verify the menu was inserted.
 		$this->assertSame( 'main_slug', $menu[1][2] );
 		// Verify the menu was inserted correctly on passing float as position.
-		$this->assertSame( 'main1_slug', $menu[ 1.5 ][2] );
+		$this->assertSame( 'main1_slug', $menu['1.5'][2] );
 	}
 
 	public function test_is_plugin_active_true() {


### PR DESCRIPTION
It will throw error with _doing_it_wrong if the typeof position is not
int.
Additionally, if the type of position is float, it will conver it to
string instead of typecasting it down to int which can cause override.

Fixes #54798, #40927

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: [https://core.trac.wordpress.org/ticket/54798](https://core.trac.wordpress.org/ticket/54798)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
