### PR TITLE
Ticket 53513

### DIFF
--- a/src/wp-includes/class-wp-http.php
+++ b/src/wp-includes/class-wp-http.php
@@ -375,6 +375,9 @@ class WP_Http {
 		 */
 		$options['verify'] = apply_filters( 'https_ssl_verify', $options['verify'], $url );
 
+		// HTTP protocol version.
+		$options['protocol_version'] = (float) $parsed_args['httpversion'];
+
 		// Check for proxies.
 		$proxy = new WP_HTTP_Proxy();
 		if ( $proxy->is_enabled() && $proxy->send_through_proxy( $url ) ) {

--- a/tests/phpunit/tests/http/base.php
+++ b/tests/phpunit/tests/http/base.php
@@ -513,5 +513,39 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 		$this->assertNotWPError( $res );
 	}
 
+	/**
+	 * @ticket 53513
+	 */
+	public function test_http_protocol_version_10() {
+		$url = 'http://example.org';
 
+		$response = wp_remote_head(
+			$url,
+			array(
+				'httpversion' => '1.0',
+			)
+		);
+
+		$this->skipTestOnTimeout( $response );
+
+		$this->assertSame( 1.0, $response['http_response']->get_response_object()->protocol_version );
+	}
+
+	/**
+	 * @ticket 53513
+	 */
+	public function test_http_protocol_version_11() {
+		$url = 'http://example.org';
+
+		$response = wp_remote_head(
+			$url,
+			array(
+				'httpversion' => '1.1',
+			)
+		);
+
+		$this->skipTestOnTimeout( $response );
+
+		$this->assertSame( 1.1, $response['http_response']->get_response_object()->protocol_version );
+	}
 }


### PR DESCRIPTION
Use proper option name when setting HTTP protocol version for external request made by Requests library. Include unit tests that fail on current trunk and pass when this PR is applied.

Trac ticket: https://core.trac.wordpress.org/ticket/53513