### PR TITLE
Safeguard site discovery against missing table errors

### DIFF
--- a/src/wp-includes/class-wp-network.php
+++ b/src/wp-includes/class-wp-network.php
@@ -284,8 +284,6 @@ class WP_Network {
 	 * @since 4.4.0
 	 */
 	private function _set_site_name() {
-		global $wpdb;
-
 		if ( ! empty( $this->site_name ) ) {
 			return;
 		}

--- a/src/wp-includes/class-wp-network.php
+++ b/src/wp-includes/class-wp-network.php
@@ -284,12 +284,15 @@ class WP_Network {
 	 * @since 4.4.0
 	 */
 	private function _set_site_name() {
+		global $wpdb;
+
 		if ( ! empty( $this->site_name ) ) {
 			return;
 		}
 
 		$default         = ucfirst( $this->domain );
-		$this->site_name = get_network_option( $this->id, 'site_name', $default );
+		$sitemeta        = ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $wpdb->esc_like( $wpdb->sitemeta ) ) ) !== null );
+		$this->site_name = $sitemeta ? get_network_option( $this->id, 'site_name', $default ) : $default;
 	}
 
 	/**

--- a/src/wp-includes/class-wp-network.php
+++ b/src/wp-includes/class-wp-network.php
@@ -291,8 +291,7 @@ class WP_Network {
 		}
 
 		$default         = ucfirst( $this->domain );
-		$sitemeta        = ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $wpdb->esc_like( $wpdb->sitemeta ) ) ) !== null );
-		$this->site_name = $sitemeta ? get_network_option( $this->id, 'site_name', $default ) : $default;
+		$this->site_name = get_network_option( $this->id, 'site_name', $default );
 	}
 
 	/**

--- a/src/wp-includes/class-wp-site-query.php
+++ b/src/wp-includes/class-wp-site-query.php
@@ -430,12 +430,6 @@ class WP_Site_Query {
 	protected function get_site_ids() {
 		global $wpdb;
 
-		$blogs_table = ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $wpdb->esc_like( $wpdb->blogs ) ) ) !== null );
-
-		if ( ! $blogs_table ) {
-			return [];
-		}
-
 		$order = $this->parse_order( $this->query_vars['order'] );
 
 		// Disable ORDER BY with 'none', an empty array, or boolean false.
@@ -692,12 +686,18 @@ class WP_Site_Query {
 		$this->request = "{$this->sql_clauses['select']} {$this->sql_clauses['from']} {$where} {$this->sql_clauses['groupby']} {$this->sql_clauses['orderby']} {$this->sql_clauses['limits']}";
 
 		if ( $this->query_vars['count'] ) {
-			return (int) $wpdb->get_var( $this->request );
+			$suppress = $wpdb->suppress_errors();
+			$result   = $wpdb->get_var( $this->request );
+			$wpdb->suppress_errors( $suppress );
+
+			return (int) $result;
 		}
 
+		$suppress = $wpdb->suppress_errors();
 		$site_ids = $wpdb->get_col( $this->request );
+		$wpdb->suppress_errors( $suppress );
 
-		return array_map( 'intval', $site_ids );
+		return is_array( $site_ids ) ? array_map( 'intval', $site_ids ) : array();
 	}
 
 	/**

--- a/src/wp-includes/class-wp-site-query.php
+++ b/src/wp-includes/class-wp-site-query.php
@@ -430,6 +430,12 @@ class WP_Site_Query {
 	protected function get_site_ids() {
 		global $wpdb;
 
+		$blogs_table = ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $wpdb->esc_like( $wpdb->blogs ) ) ) !== null );
+
+		if ( ! $blogs_table ) {
+			return [];
+		}
+
 		$order = $this->parse_order( $this->query_vars['order'] );
 
 		// Disable ORDER BY with 'none', an empty array, or boolean false.

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -1442,7 +1442,9 @@ function get_network_option( $network_id, $option, $default = false ) {
 		$value     = wp_cache_get( $cache_key, 'site-options' );
 
 		if ( ! isset( $value ) || false === $value ) {
-			$row = $wpdb->get_row( $wpdb->prepare( "SELECT meta_value FROM $wpdb->sitemeta WHERE meta_key = %s AND site_id = %d", $option, $network_id ) );
+			$suppress = $wpdb->suppress_errors();
+			$row      = $wpdb->get_row( $wpdb->prepare( "SELECT meta_value FROM $wpdb->sitemeta WHERE meta_key = %s AND site_id = %d", $option, $network_id ) );
+			$wpdb->suppress_errors( $suppress );
 
 			// Has to be get_row() instead of get_var() because of funkiness with 0, false, null values.
 			if ( is_object( $row ) ) {

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -2766,6 +2766,7 @@ class wpdb {
 			return $this->last_result[ $y ] ? $this->last_result[ $y ] : null;
 		} else {
 			$this->print_error( ' $db->get_row(string query, output type, int offset) -- Output type must be one of: OBJECT, ARRAY_A, ARRAY_N' );
+			return null;
 		}
 	}
 


### PR DESCRIPTION
This PR adds error suppression for WPDB to account for two cases where an empty site triggers WPDB errors even though the operation should be safe:
1. Missing `wp_blogs` table before enumerating site IDs;
2. Missing `wp_sitemeta` table before loading $site_name from DB.

This PR adds `$wpdb->suppress_errors()` around these two problematic queries to avoid showing said errors.

Also, the PR adds a missing `return` to `$wpdb->get_row()`.

Trac ticket: [#54801](https://core.trac.wordpress.org/ticket/54801)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
