### PR TITLE
Allow `post_comments_feed_link` to disable feed output

### DIFF
--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -3165,7 +3165,7 @@ function feed_links_extra( $args = array() ) {
 		$href  = get_search_feed_link();
 	}
 
-	if ( isset( $title ) && isset( $href ) ) {
+	if ( ! empty( $title ) && ! empty( $href ) ) {
 		echo '<link rel="alternate" type="' . feed_content_type() . '" title="' . esc_attr( $title ) . '" href="' . esc_url( $href ) . '" />' . "\n";
 	}
 }


### PR DESCRIPTION
Using `add_filter( 'post_comments_feed_link', '__return_false');` one would expect to disable "Comment feeds".
It's not the case, because `$x = false; isset($x) === true;`

Trac ticket: 54802