### PR TITLE
Convert emoticons that are followed by punctuation.

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -4707,7 +4707,7 @@ function smilies_init() {
 		// New subpattern?
 		if ( $firstchar != $subchar ) {
 			if ( '' !== $subchar ) {
-				$wp_smiliessearch .= ')(?=' . $spaces . '|$)';  // End previous "subpattern".
+				$wp_smiliessearch .= ')(?=[^a-zA-Z0-9\:]|$)';  // End previous "subpattern".
 				$wp_smiliessearch .= '|(?<=' . $spaces . '|^)'; // Begin another "subpattern".
 			}
 			$subchar           = $firstchar;


### PR DESCRIPTION
Previously, the conversion process only looked for matches that were followed by `[\r\n\t ]|\xC2\xA0|&nbsp;`.

This change converts all matches that are not followed by alphanumeric characters or `:`.

- [x] Support emoticons followed by punctuation.
- [ ] Add unit tests.

Trac ticket: