### PR TITLE
TwentyTwenty: make presets back compatible with older versions

### DIFF
--- a/src/wp-content/themes/twentytwenty/assets/css/editor-style-block-rtl.css
+++ b/src/wp-content/themes/twentytwenty/assets/css/editor-style-block-rtl.css
@@ -206,20 +206,24 @@ Inter variable font. Usage:
 /* GENERAL COLORS */
 
 .has-black-background-color {
+	--wp--preset--color--black: #000;
 	background-color: #000;
 	color: #fff;
 }
 
 .has-white-background-color {
+	--wp--preset--color--white: #fff;
 	background-color: #fff;
 	color: #000;
 }
 
 .has-black-color {
+	--wp--preset--color--black: #000;
 	color: #000;
 }
 
 .has-white-color {
+	--wp--preset--color--white: #fff;
 	color: #fff;
 }
 
@@ -352,19 +356,23 @@ Inter variable font. Usage:
 
 .editor-styles-wrapper p.has-small-font-size {
 	--wp--preset--font-size--small: 0.842em;
+	font-size: 0.842em;
 }
 
 .editor-styles-wrapper p.has-normal-font-size,
 .editor-styles-wrapper p.has-regular-font-size {
 	--wp--preset--font-size--normal: 1em;
+	font-size: 1em;
 }
 
 .editor-styles-wrapper p.has-medium-font-size {
 	--wp--preset--font-size--medium: 1.1em;
+	font-size: 1.1em;
 }
 
 .editor-styles-wrapper p.has-large-font-size {
 	--wp--preset--font-size--large: 1.25em;
+	font-size: 1.25em;
 }
 
 .editor-styles-wrapper p.has-larger-font-size {

--- a/src/wp-content/themes/twentytwenty/assets/css/editor-style-block.css
+++ b/src/wp-content/themes/twentytwenty/assets/css/editor-style-block.css
@@ -207,20 +207,24 @@ Inter variable font. Usage:
 
 .has-black-background-color {
 	--wp--preset--color--black: #000;
+	background-color: #000;
 	color: #fff;
 }
 
 .has-white-background-color {
 	--wp--preset--color--white: #fff;
+	background-color: #fff;
 	color: #000;
 }
 
 .has-black-color {
 	--wp--preset--color--black: #000;
+	color: #000;
 }
 
 .has-white-color {
 	--wp--preset--color--white: #fff;
+	color: #fff;
 }
 
 
@@ -352,19 +356,23 @@ Inter variable font. Usage:
 
 .editor-styles-wrapper p.has-small-font-size {
 	--wp--preset--font-size--small: 0.842em;
+	font-size: 0.842em;
 }
 
 .editor-styles-wrapper p.has-normal-font-size,
 .editor-styles-wrapper p.has-regular-font-size {
 	--wp--preset--font-size--normal: 1em;
+	font-size: 1em;
 }
 
 .editor-styles-wrapper p.has-medium-font-size {
 	--wp--preset--font-size--medium: 1.1em;
+	font-size: 1.1em;
 }
 
 .editor-styles-wrapper p.has-large-font-size {
 	--wp--preset--font-size--large: 1.25em;
+	font-size: 1.25em;
 }
 
 .editor-styles-wrapper p.has-larger-font-size {

--- a/src/wp-content/themes/twentytwenty/print.css
+++ b/src/wp-content/themes/twentytwenty/print.css
@@ -62,6 +62,12 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
     font-size: 20pt;
   }
 
+  .has-normal-font-size,
+  .has-large-font-size {
+    --wp--preset--font-size--large: 14pt;
+    --wp--preset--font-size--normal: 14pt;
+  }
+
   h2,
   h2.entry-title,
   h3,

--- a/src/wp-content/themes/twentytwenty/style-rtl.css
+++ b/src/wp-content/themes/twentytwenty/style-rtl.css
@@ -2837,20 +2837,24 @@ h2.entry-title {
 
 .entry-content .has-small-font-size {
 	--wp--preset--font-size--small: 0.842em;
+	font-size: 0.842em;
 }
 
 .entry-content .has-normal-font-size,
 .entry-content .has-regular-font-size {
 	--wp--preset--font-size--normal: 1em;
+	font-size: 1em;
 }
 
 .entry-content .has-medium-font-size {
 	--wp--preset--font-size--medium: 1.1em;
+	font-size: 1.1em;
 	line-height: 1.45;
 }
 
 .entry-content .has-large-font-size {
 	--wp--preset--font-size--large: 1.25em;
+	font-size: 1.25em;
 	line-height: 1.4;
 }
 

--- a/src/wp-content/themes/twentytwenty/style.css
+++ b/src/wp-content/themes/twentytwenty/style.css
@@ -2855,20 +2855,24 @@ h2.entry-title {
 
 .entry-content .has-small-font-size {
 	--wp--preset--font-size--small: 0.842em;
+	font-size: 0.842em;
 }
 
 .entry-content .has-normal-font-size,
 .entry-content .has-regular-font-size {
 	--wp--preset--font-size--normal: 1em;
+	font-size: 1em;
 }
 
 .entry-content .has-medium-font-size {
 	--wp--preset--font-size--medium: 1.1em;
+	font-size: 1.1em;
 	line-height: 1.45;
 }
 
 .entry-content .has-large-font-size {
 	--wp--preset--font-size--large: 1.25em;
+	font-size: 1.25em;
 	line-height: 1.4;
 }
 


### PR DESCRIPTION
Trac ticket https://core.trac.wordpress.org/ticket/54782
Follow-up to https://github.com/WordPress/wordpress-develop/pull/2130

WordPress 5.9 uses CSS Custom Properties to define the presets, and themes without a theme.json need to use them to set their value. However, the default themes need to work with older versions of WordPress that don't have the CSS Custom Properties, therefore we can't remove the existing regular CSS properties. This PR brings them back.

## How to test

Test this both in WordPress 5.9 and WordPress 5.7. In 5.9 the CSS Custom Properties are present for all themes and in 5.7 are not. This covers all the cases.

### Font sizes

- Use the TwentyTwenty theme.
- Create a post that contains 5 paragraphs with the following content:
  - Small (18)
  - Normal (21)
  - Default
  - Large (26.25)
  - Larger (32)
- To each paragraph apply the font size that corresponds to its content: apply `small` to the 1st paragraph, `normal` to the 2nd, nothing to the third, `large` to the 4th, and `larger` to the 5th.

The expected result is that the font size for each paragraph has the assigned value, both in the editor and front-end.

### Colors

- Use the TwentyTwenty theme.
- Create a post.
- Create a paragraph and apply custom color classes by pasting this text `has-white-background-color has-black-color` into the "Additional classes" text field of the "Advanced" section of the block sidebar.
- Create a new paragraph and apply custom color classes by pasting this text `has-black-background-color has-white-color` into the "Additional classes" text field of the "Advanced" section of the block sidebar.

Via the browser devtools make sure that the first paragraph's color is `rgb(0,0,0)` and its background is `rgb(255,255,255)`. The second paragraph should be the opposite.
