### PR TITLE
Media: Fix warning on post thumbnails lazyload due to a wrong regex.

### DIFF
--- a/src/wp-includes/post-thumbnail-template.php
+++ b/src/wp-includes/post-thumbnail-template.php
@@ -195,7 +195,7 @@ function get_the_post_thumbnail( $post = null, $size = 'post-thumbnail', $attr =
 			$attr = array( 'loading' => $loading );
 		} elseif ( is_array( $attr ) && ! array_key_exists( 'loading', $attr ) ) {
 			$attr['loading'] = $loading;
-		} elseif ( is_string( $attr ) && ! preg_match( '/(^|&)loading=', $attr ) ) {
+		} elseif ( is_string( $attr ) && ! preg_match( '/(^|&)loading=/', $attr ) ) {
 			$attr .= '&loading=' . $loading;
 		}
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/54815

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
