### PR TITLE
add filter for $inner_blocks

### DIFF
--- a/src/wp-includes/blocks/navigation.php
+++ b/src/wp-includes/blocks/navigation.php
@@ -437,6 +437,14 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 		$inner_blocks = new WP_Block_List( $compacted_blocks, $attributes );
 	}
 
+	/**
+	 * Filter navigation block $inner_blocks.
+	 * Allows modification of a navigation block menu items.
+	 *
+	 * @param \WP_Block_List $inner_blocks
+	 */
+	$inner_blocks = apply_filters( 'render_block_core_navigation_inner_blocks', $inner_blocks );
+
 	// If there are no inner blocks then fallback to rendering an appropriate fallback.
 	if ( empty( $inner_blocks ) ) {
 		$is_fallback = true; // indicate we are rendering the fallback.


### PR DESCRIPTION
Add a filter to `wp-includes/blocks/navigation.php` to filter results of `$inner_blocks` allowing the modification of navigation block menu items.

Trac ticket: https://core.trac.wordpress.org/ticket/54684

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
