### PR TITLE
translate_smiley(): Guard against non-array `$matches`.

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -3351,7 +3351,7 @@ function wp_remove_targeted_link_rel_filters() {
 function translate_smiley( $matches ) {
 	global $wpsmiliestrans;
 
-	if ( count( $matches ) == 0 ) {
+	if ( ! is_array( $matches ) || count( $matches ) == 0 ) {
 		return '';
 	}
 

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -3351,7 +3351,7 @@ function wp_remove_targeted_link_rel_filters() {
 function translate_smiley( $matches ) {
 	global $wpsmiliestrans;
 
-	if ( ! is_array( $matches ) || count( $matches ) == 0 ) {
+	if ( ! is_array( $matches ) || count( $matches ) === 0 ) {
 		return '';
 	}
 

--- a/tests/phpunit/tests/formatting/translateSmiley.php
+++ b/tests/phpunit/tests/formatting/translateSmiley.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @group formatting
+ * @group emoji
+ *
+ * @covers ::translate_smiley
+ */
+class Tests_Formatting_TranslateSmiley extends WP_UnitTestCase {
+	/**
+	 * @dataProvider data_translate_smiley_should_return_empty_string
+	 *
+	 * @ticket 54827
+	 *
+	 * @param string $smiley A string to be translated.
+	 */
+	public function test_translate_smiley_should_return_empty_string( $smiley ) {
+		$this->assertSame( '', translate_smiley( $smiley ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_translate_smiley_should_return_empty_string() {
+		return array(
+			'empty string' => array( 'smiley' => '' ),
+			'null'         => array( 'smiley' => null ),
+		);
+	}
+}


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/54827
