### PR TITLE
Editor: Explicitly load remote block patterns

### DIFF
--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -28,6 +28,10 @@ $block_editor_context = new WP_Block_Editor_Context( array( 'post' => $post ) );
 $current_screen = get_current_screen();
 $current_screen->is_block_editor( true );
 
+// Load block patterns from w.org.
+_load_remote_block_patterns();
+_load_remote_featured_patterns();
+
 // Default to is-fullscreen-mode to avoid jumps in the UI.
 add_filter(
 	'admin_body_class',

--- a/src/wp-admin/site-editor.php
+++ b/src/wp-admin/site-editor.php
@@ -31,6 +31,10 @@ $parent_file = 'themes.php';
 $current_screen = get_current_screen();
 $current_screen->is_block_editor( true );
 
+// Load block patterns from w.org.
+_load_remote_block_patterns();
+_load_remote_featured_patterns();
+
 // Default to is-fullscreen-mode to avoid jumps in the UI.
 add_filter(
 	'admin_body_class',

--- a/src/wp-includes/block-patterns.php
+++ b/src/wp-includes/block-patterns.php
@@ -48,12 +48,13 @@ function _register_core_block_patterns_and_categories() {
  * Register Core's official patterns from wordpress.org/patterns.
  *
  * @since 5.8.0
+ * @since 5.9.0 The $current_screen argument was removed.
  *
- * @param WP_Screen $current_screen The screen that the current request was triggered from.
+ * @param WP_Screen $deprecated Unused. Formerly the screen that the current request was triggered from.
  */
-function _load_remote_block_patterns( $current_screen ) {
-	if ( ! $current_screen->is_block_editor ) {
-		return;
+function _load_remote_block_patterns( $deprecated = null ) {
+	if ( ! empty( $deprecated ) ) {
+		_deprecated_argument( __FUNCTION__, '5.9.0' );
 	}
 
 	$supports_core_patterns = get_theme_support( 'core-block-patterns' );
@@ -88,14 +89,8 @@ function _load_remote_block_patterns( $current_screen ) {
  * Register `Featured` (category) patterns from wordpress.org/patterns.
  *
  * @since 5.9.0
- *
- * @param WP_Screen $current_screen The screen that the current request was triggered from.
  */
-function _load_remote_featured_patterns( $current_screen ) {
-	if ( ! $current_screen->is_block_editor ) {
-		return;
-	}
-
+function _load_remote_featured_patterns() {
 	$supports_core_patterns = get_theme_support( 'core-block-patterns' );
 
 	/** This filter is documented in wp-includes/block-patterns.php */

--- a/src/wp-includes/block-patterns.php
+++ b/src/wp-includes/block-patterns.php
@@ -55,6 +55,10 @@ function _register_core_block_patterns_and_categories() {
 function _load_remote_block_patterns( $deprecated = null ) {
 	if ( ! empty( $deprecated ) ) {
 		_deprecated_argument( __FUNCTION__, '5.9.0' );
+		$current_screen = $deprecated;
+		if ( ! $current_screen->is_block_editor ) {
+			return;
+		}
 	}
 
 	$supports_core_patterns = get_theme_support( 'core-block-patterns' );

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -332,8 +332,6 @@ add_action( 'wp_footer', 'wp_print_footer_scripts', 20 );
 add_action( 'template_redirect', 'wp_shortlink_header', 11, 0 );
 add_action( 'wp_print_footer_scripts', '_wp_footer_scripts' );
 add_action( 'init', '_register_core_block_patterns_and_categories' );
-add_action( 'current_screen', '_load_remote_block_patterns' );
-add_action( 'current_screen', '_load_remote_featured_patterns' );
 add_action( 'init', 'check_theme_switched', 99 );
 add_action( 'init', array( 'WP_Block_Supports', 'init' ), 22 );
 add_action( 'switch_theme', array( 'WP_Theme_JSON_Resolver', 'clean_cached_data' ) );


### PR DESCRIPTION
Load any remote block patterns from w.org explicitly instead of using the `current_screen` filter. The `current_screen` filter is unreliable as, in many cases e.g. the Site Editor, `$current_scren->is_block_editor` is not set until after the filter is executed.

Trac ticket: https://core.trac.wordpress.org/ticket/54806

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
