### PR TITLE
feat(email): disable email change notification to admin, #45359

### DIFF
--- a/src/wp-admin/options-general.php
+++ b/src/wp-admin/options-general.php
@@ -136,6 +136,14 @@ if ( $new_admin_email && get_option( 'admin_email' ) !== $new_admin_email ) :
 </td>
 </tr>
 
+<tr>
+<th scope="row"><?php _e( 'Disable User Password Change Notification' ); ?></th>
+<td> <fieldset><legend class="screen-reader-text"><span><?php _e( 'Disable User Password Change Notification' ); ?></span></legend><label for="disable_psw_change_email">
+<input name="disable_psw_change_email" type="checkbox" id="disable_psw_change_email" value="1" <?php checked( '1', get_option( 'disable_psw_change_email' ) ); ?> />
+	<?php _e( 'Otherwise the admin will receive an email notification of any user\'s password changed' ); ?></label>
+</fieldset></td>
+</tr>
+
 <?php if ( ! is_multisite() ) { ?>
 
 <tr>

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -2933,15 +2933,17 @@ function reset_password( $user, $new_pass ) {
 	wp_set_password( $new_pass, $user->ID );
 	update_user_meta( $user->ID, 'default_password_nag', false );
 
-	/**
-	 * Fires after the user's password is reset.
-	 *
-	 * @since 4.4.0
-	 *
-	 * @param WP_User $user     The user.
-	 * @param string  $new_pass New user password.
-	 */
-	do_action( 'after_password_reset', $user, $new_pass );
+	if ( ! get_option( 'disable_psw_change_email' ) ) {
+		/**
+		* Fires after the user's password is reset.
+		*
+		* @since 4.4.0
+		*
+		* @param WP_User $user     The user.
+		* @param string  $new_pass New user password.
+		*/
+		do_action( 'after_password_reset', $user, $new_pass );
+	}
 }
 
 /**


### PR DESCRIPTION
Disable the email notification when an user change the password to the admin with the settings in the General Settings page.

Probably need a better wording.

Trac ticket: https://core.trac.wordpress.org/ticket/45359

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
