### PR TITLE
Try deprecating non-WP_Widget widgets

### DIFF
--- a/src/wp-includes/class-wp-dynamic-widget.php
+++ b/src/wp-includes/class-wp-dynamic-widget.php
@@ -1,7 +1,7 @@
 <?php
 
 class WP_Dynamic_Widget extends WP_Widget {
-	public $display_callback = null;
+	public $widget_callback = null;
 
 	public $update_callback = null;
 
@@ -11,15 +11,15 @@ class WP_Dynamic_Widget extends WP_Widget {
 		parent::__construct( $id_base, '' );
 	}
 
-	public function _get_display_callback() {
-		return $this->display_callback ?? parent::_get_display_callback();
+	public function widget( $args, $instance ) {
+		call_user_func( $this->widget_callback, $args, $instance );
 	}
 
-	public function _get_update_callback() {
-		return $this->update_callback ?? parent::_get_update_callback();
+	public function update( $new_instance, $old_instance ) {
+		return call_user_func( $this->update_callback, $new_instance, $old_instance );
 	}
 
-	public function _get_form_callback() {
-		return $this->form_callback ?? parent::_get_form_callback();
+	public function form( $instance ) {
+		return call_user_func( $this->form_callback, $instance );
 	}
 }

--- a/src/wp-includes/class-wp-dynamic-widget.php
+++ b/src/wp-includes/class-wp-dynamic-widget.php
@@ -1,0 +1,25 @@
+<?php
+
+class WP_Dynamic_Widget extends WP_Widget {
+	public $display_callback = null;
+
+	public $update_callback = null;
+
+	public $form_callback = null;
+
+	public function __construct( $id_base ) {
+		parent::__construct( $id_base, '' );
+	}
+
+	public function _get_display_callback() {
+		return $this->display_callback ?? parent::_get_display_callback();
+	}
+
+	public function _get_update_callback() {
+		return $this->update_callback ?? parent::_get_update_callback();
+	}
+
+	public function _get_form_callback() {
+		return $this->form_callback ?? parent::_get_form_callback();
+	}
+}

--- a/src/wp-includes/class-wp-widget.php
+++ b/src/wp-includes/class-wp-widget.php
@@ -564,7 +564,7 @@ class WP_Widget {
 	 *                    compared to other instances of the same class. Default -1.
 	 */
 	public function _register_one( $number = -1 ) {
-		wp_register_sidebar_widget(
+		_register_widget_display_callback(
 			$this->id,
 			$this->name,
 			$this->_get_display_callback(),

--- a/src/wp-includes/widgets.php
+++ b/src/wp-includes/widgets.php
@@ -421,15 +421,15 @@ function wp_register_sidebar_widget( $id, $name, $output_callback, $options = ar
 		$wp_widget_factory->register( $widget_object );
 	}
 
-	$widget_object->name             = $name;
-	$widget_object->option_name      = 'dynamic_widget_' . $id_base;
-	$widget_object->widget_options   = $options;
-	$widget_object->display_callback = function( $args ) use ( $output_callback, $params ) {
+	$widget_object->name            = $name;
+	$widget_object->option_name     = 'sidebar_widget_' . $id_base;
+	$widget_object->widget_options  = array_merge( $widget_object->widget_options, $options );
+	$widget_object->widget_callback = function( $args, $instance ) use ( $output_callback, $params ) {
 		call_user_func_array( $output_callback, array_merge( array( $args ), $params ) );
 	};
 
 	if ( did_action( 'widgets_init' ) ) {
-		$widget_object->_register(); // TODO: Ensure we're not calling twice?
+		$widget_object->_register();
 	}
 }
 
@@ -583,17 +583,18 @@ function wp_register_widget_control( $id, $name, $control_callback, $options = a
 	}
 
 	$widget_object->name            = $name;
-	$widget_object->option_name     = 'dynamic_widget_' . $id_base;
-	$widget_object->control_options = $options;
-	$widget_object->update_callback = function() use ( $control_callback, $params ) {
+	$widget_object->option_name     = 'sidebar_widget_' . $id_base;
+	$widget_object->control_options = array_merge( $widget_object->control_options, $options );
+	$widget_object->update_callback = function( $new_instance, $old_instance ) use ( $control_callback, $params ) {
 		call_user_func_array( $control_callback, $params );
+		return $new_instance;
 	};
-	$widget_object->form_callback   = function() use ( $control_callback, $params ) {
+	$widget_object->form_callback   = function( $instance ) use ( $control_callback, $params ) {
 		call_user_func_array( $control_callback, $params );
 	};
 
 	if ( did_action( 'widgets_init' ) ) {
-		$widget_object->_register(); // TODO: Ensure we're not calling twice?
+		$widget_object->_register(); // TODO: Don't call twice? (First call is in wp_register_sidebar_widget().)
 	}
 }
 

--- a/src/wp-includes/widgets.php
+++ b/src/wp-includes/widgets.php
@@ -415,6 +415,19 @@ function wp_register_sidebar_widget( $id, $name, $output_callback, $options = ar
 	$defaults = array( 'classname' => $output_callback );
 	$options  = wp_parse_args( $options, $defaults );
 
+	// Convert 'classname' to a string in the same manner that dynamic_sidebar()
+	// does it. Non-string classnames aren't supported by WP_Widget.
+	$classname = '';
+	foreach ( (array) $options['classname'] as $cn ) {
+		if ( is_string( $cn ) ) {
+			$classname .= '_' . $cn;
+		} elseif ( is_object( $cn ) ) {
+			$classname .= '_' . get_class( $cn );
+		}
+	}
+	$classname            = ltrim( $classname, '_' );
+	$options['classname'] = $classname;
+
 	$widget_object = $wp_widget_factory->get_widget_object( $id_base );
 	if ( ! $widget_object ) {
 		$widget_object = new WP_Dynamic_Widget( $id_base );

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -244,6 +244,7 @@ require ABSPATH . WPINC . '/class-wp-http-requests-hooks.php';
 require ABSPATH . WPINC . '/widgets.php';
 require ABSPATH . WPINC . '/class-wp-widget.php';
 require ABSPATH . WPINC . '/class-wp-widget-factory.php';
+require ABSPATH . WPINC . '/class-wp-dynamic-widget.php';
 require ABSPATH . WPINC . '/nav-menu-template.php';
 require ABSPATH . WPINC . '/nav-menu.php';
 require ABSPATH . WPINC . '/admin-bar.php';


### PR DESCRIPTION
Just playing around with how we could potentially deprecate widgets that don't extend `WP_Widget`. Need to do some more thinking and testing.

Trac ticket:

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
