### PR TITLE
Adding '%i' placeholder support

### DIFF
--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -1561,7 +1561,7 @@ class wpdb {
 					__( 'Arguments (%s) cannot be used for both String and Identifier escaping.' ),
 					implode( ', ', $dual_use )
 				),
-				'6.0.0'
+				'6.1.0'
 			);
 
 			return;

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -1543,11 +1543,17 @@ class wpdb {
 		}
 		$query = $new_query . $split_query[ $key - 2 ]; // Replace $query; and add remaining $query characters, or index 0 if there were no placeholders.
 
-		if ( count( array_intersect( $arg_identifiers, $arg_strings ) ) ) {
+		$dual_use = array_intersect( $arg_identifiers, $arg_strings );
+		if ( count( $dual_use ) ) {
+
 			wp_load_translations_early();
 			_doing_it_wrong(
 				'wpdb::prepare',
-				__( 'You cannot use an argument for a string and an identifier.' ),
+				sprintf(
+					/* translators: %s: A comma separated list of arguments found to be a problem. */
+					__( 'Arguments (%s) cannot be used for both String and Identifier escaping.' ),
+					implode( ', ', $dual_use )
+				),
 				'6.0.0'
 			);
 

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -3849,7 +3849,15 @@ class wpdb {
 	}
 
 	/**
-	 * Determines if a database supports a particular feature.
+	 * Determine DB or WPDB support for a particular feature.
+	 *
+	 * Capability sniffs for the database server and current version of wpdb.
+	 *
+	 * Database sniffs test based on the version of MySQL the site is using.
+	 *
+	 * WPDB sniffs are added as new features are introduced to allow theme and plugin
+	 * developers to determine feature support. This is to account for drop-ins which may
+	 * introduce feature support at a different time to WordPress.
 	 *
 	 * @since 2.7.0
 	 * @since 4.1.0 Added support for the 'utf8mb4' feature.

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -667,7 +667,7 @@ class wpdb {
 	 * So there may need to be a `_doing_it_wrong()` phase, after we know everyone can use Identifier
 	 * placeholders (%i), but before this feature is disabled or removed.
 	 *
-	 * @since 6.0.0
+	 * @since 6.1.0
 	 * @var bool
 	 */
 	private $allow_unsafe_unquoted_parameters = true;
@@ -1378,7 +1378,7 @@ class wpdb {
 	/**
 	 * Escapes an identifier for a MySQL database (e.g. table/field names).
 	 *
-	 * @since 6.0.0
+	 * @since 6.1.0
 	 *
 	 * @param string $identifier Identifier to escape.
 	 * @return string Escaped Identifier
@@ -1396,7 +1396,7 @@ class wpdb {
 	 * - To quote the identifier itself, then you need to double the character, e.g. `a``b`
 	 *
 	 * @link https://dev.mysql.com/doc/refman/8.0/en/identifiers.html
-	 * @since 6.0.0
+	 * @since 6.1.0
 	 * @access private
 	 *
 	 * @param string $identifier Identifier to escape.
@@ -1440,7 +1440,7 @@ class wpdb {
 	 * @since 5.3.0 Formalized the existing and already documented `...$args` parameter
 	 *              by updating the function signature. The second parameter was changed
 	 *              from `$args` to `...$args`.
-	 * @since 6.0.0 Added '%i' for Identifiers, e.g. table or field names.
+	 * @since 6.1.0 Added '%i' for Identifiers, e.g. table or field names.
 	 *              Check support via `wpdb::has_cap( 'identifier_placeholders' )`
 	 *              This preserves compatibility with sprinf, as the C version uses %d and $i
 	 *              as a signed integer, whereas PHP only supports %d.
@@ -3876,7 +3876,7 @@ class wpdb {
 	 * @since 2.7.0
 	 * @since 4.1.0 Added support for the 'utf8mb4' feature.
 	 * @since 4.6.0 Added support for the 'utf8mb4_520' feature.
-	 * @since 6.0.0 Added support for the 'identifier_placeholders' feature.
+	 * @since 6.1.0 Added support for the 'identifier_placeholders' feature.
 	 *
 	 * @see wpdb::db_version()
 	 *
@@ -3917,7 +3917,7 @@ class wpdb {
 				}
 			case 'utf8mb4_520': // @since 4.6.0
 				return version_compare( $version, '5.6', '>=' );
-			case 'identifier_placeholders': // @since 6.0.0, wpdb::prepare() supports identifiers via '%i' - e.g. table/field names.
+			case 'identifier_placeholders': // @since 6.1.0, wpdb::prepare() supports identifiers via '%i' - e.g. table/field names.
 				return true;
 		}
 

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -1526,7 +1526,7 @@ class wpdb {
 				} else {
 					$arg_identifiers[] = $arg_id;
 				}
-			} elseif ( 's' === $type ) {
+			} elseif ( 'd' !== $type && 'F' !== $type ) { // i.e. ('s' === $type), where 'd' and 'F' keeps $placeholder unchanged, and we ensure string escaping is used as a safe default (e.g. even if 'x').
 				$argnum_pos = strpos( $format, '$' );
 				if ( false !== $argnum_pos ) {
 					$arg_strings[] = ( intval( substr( $format, 0, $argnum_pos ) ) - 1 );
@@ -1534,7 +1534,7 @@ class wpdb {
 				if ( true !== $this->allow_unsafe_unquoted_parameters || '' === $format ) { // Unquoted strings for backwards compatibility (dangerous).
 					$placeholder = "'%" . $format . "s'";
 				}
-			} // elseif ( 'd' === $type || 'F' === $type ), nothing needs to be done (keep $placeholder)
+			}
 
 			$new_query .= $split_query[ $key - 2 ] . $split_query[ $key - 1 ] . $placeholder; // Glue (-2), any leading characters (-1), then the new $placeholder.
 

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -1518,14 +1518,16 @@ class wpdb {
 
 			if ( 'i' === $type ) {
 				$placeholder = '`%' . $format . 's`';
-				if ( ( $pos = strpos( $format, '$' ) ) !== false ) { // Using a simple strpos() due to previous checking (e.g. $allowed_format).
-					$arg_identifiers[] = ( intval( substr( $format, 0, $pos ) ) - 1 ); // sprintf argnum starts at 1, $arg_id from 0.
+				$argnum_pos  = strpos( $format, '$' ); // Using a simple strpos() due to previous checking (e.g. $allowed_format).
+				if ( false !== $argnum_pos ) {
+					$arg_identifiers[] = ( intval( substr( $format, 0, $argnum_pos ) ) - 1 ); // sprintf argnum starts at 1, $arg_id from 0.
 				} else {
 					$arg_identifiers[] = $arg_id;
 				}
 			} elseif ( 's' === $type ) {
-				if ( ( $pos = strpos( $format, '$' ) ) !== false ) {
-					$arg_strings[] = ( intval( substr( $format, 0, $pos ) ) - 1 );
+				$argnum_pos = strpos( $format, '$' );
+				if ( false !== $argnum_pos ) {
+					$arg_strings[] = ( intval( substr( $format, 0, $argnum_pos ) ) - 1 );
 				}
 				if ( true !== $this->allow_unsafe_unquoted_parameters || '' === $format ) { // Unquoted strings for backwards compatibility (dangerous).
 					$placeholder = "'%" . $format . "s'";

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -1536,7 +1536,7 @@ class wpdb {
 				}
 			} // elseif ( 'd' === $type || 'F' === $type ), nothing needs to be done (keep $placeholder)
 
-			$new_query .= $split_query[ $key - 2 ] . $split_query[ $key - 1 ] . $placeholder; // Glue (-2), any prefix characters (-1), then the new $placeholder.
+			$new_query .= $split_query[ $key - 2 ] . $split_query[ $key - 1 ] . $placeholder; // Glue (-2), any leading characters (-1), then the new $placeholder.
 
 			$key += 3;
 			$arg_id++;

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -1550,7 +1550,7 @@ class wpdb {
 			_doing_it_wrong(
 				'wpdb::prepare',
 				sprintf(
-					/* translators: %s: A comma separated list of arguments found to be a problem. */
+					/* translators: %s: A comma-separated list of arguments found to be a problem. */
 					__( 'Arguments (%s) cannot be used for both String and Identifier escaping.' ),
 					implode( ', ', $dual_use )
 				),

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -1373,6 +1373,7 @@ class wpdb {
 	 * @since 6.0.0
 	 *
 	 * @param string $identifier Identifier to escape.
+	 * @return string Escaped Identifier
 	 */
 	public function escape_identifier( $identifier ) {
 		return '`' . $this->_escape_identifier_value( $identifier ) . '`';
@@ -1391,6 +1392,7 @@ class wpdb {
 	 * @access private
 	 *
 	 * @param string $identifier Identifier to escape.
+	 * @return string Escaped Identifier
 	 */
 	private function _escape_identifier_value( $identifier ) {
 		return str_replace( '`', '``', $identifier );
@@ -1534,8 +1536,7 @@ class wpdb {
 				}
 			} // elseif ( 'd' === $type || 'F' === $type ), nothing needs to be done (keep $placeholder)
 
-			$new_query .= $split_query[ $key - 2 ] . $split_query[ $key - 1 ] . $placeholder;
-				// Glue (-2), any prefix characters (-1), then the new $placeholder.
+			$new_query .= $split_query[ $key - 2 ] . $split_query[ $key - 1 ] . $placeholder; // Glue (-2), any prefix characters (-1), then the new $placeholder.
 
 			$key += 3;
 			$arg_id++;

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -3861,7 +3861,7 @@ class wpdb {
 	 * @param string $db_cap The feature to check for. Accepts 'collation', 'group_concat',
 	 *                       'subqueries', 'set_charset', 'utf8mb4', 'utf8mb4_520',
 	 *                       or 'identifier_placeholders'.
-	 * @return int|false Whether the database feature is supported, false otherwise.
+	 * @return bool True when the database feature is supported, false otherwise.
 	 */
 	public function has_cap( $db_cap ) {
 		$version = $this->db_version();

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -1518,14 +1518,14 @@ class wpdb {
 
 			if ( 'i' === $type ) {
 				$placeholder = '`%' . $format . 's`';
-				if ( strpos( $format, '$' ) !== false ) { // Using a simple strpos() due to previous checking (e.g. $allowed_format).
-					$arg_identifiers[] = intval( substr( $format, 1 ) );
+				if ( ( $pos = strpos( $format, '$' ) ) !== false ) { // Using a simple strpos() due to previous checking (e.g. $allowed_format).
+					$arg_identifiers[] = ( intval( substr( $format, 0, $pos ) ) - 1 ); // sprintf argnum starts at 1, $arg_id from 0.
 				} else {
 					$arg_identifiers[] = $arg_id;
 				}
 			} elseif ( 's' === $type ) {
-				if ( strpos( $format, '$' ) !== false ) {
-					$arg_strings[] = intval( substr( $format, 1 ) );
+				if ( ( $pos = strpos( $format, '$' ) ) !== false ) {
+					$arg_strings[] = ( intval( substr( $format, 0, $pos ) ) - 1 );
 				}
 				if ( true !== $this->allow_unsafe_unquoted_parameters || '' === $format ) { // Unquoted strings for backwards compatibility (dangerous).
 					$placeholder = "'%" . $format . "s'";

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -1423,7 +1423,7 @@ class wpdb {
 	 * @since 5.3.0 Formalized the existing and already documented `...$args` parameter
 	 *              by updating the function signature. The second parameter was changed
 	 *              from `$args` to `...$args`.
-	 * @since 6.0.0 Added %i for Identifiers, e.g. table or field names.
+	 * @since 6.0.0 Added '%i' for Identifiers, e.g. table or field names.
 	 *              Check support via `wpdb::has_cap( 'identifier_placeholders' )`
 	 *              This preserves compatibility with sprinf, as the C version uses %d and $i
 	 *              as a signed integer, whereas PHP only supports %d.
@@ -3895,7 +3895,7 @@ class wpdb {
 				}
 			case 'utf8mb4_520': // @since 4.6.0
 				return version_compare( $version, '5.6', '>=' );
-			case 'identifier_placeholders': // @since 6.0.0, wpdb::prepare() supports identifiers via %i (e.g. table/field names).
+			case 'identifier_placeholders': // @since 6.0.0, wpdb::prepare() supports identifiers via '%i' - e.g. table/field names.
 				return true;
 		}
 

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -54,15 +54,6 @@ define( 'ARRAY_N', 'ARRAY_N' );
 class wpdb {
 
 	/**
-	 * Version number, to check what features are available.
-	 *
-	 * @since 6.0.0 - V2: wbdb::prepare() supports Identifiers via 'SELECT * FROM %i', and Variadics via 'IN (%...d)'
-	 *
-	 * @var int
-	 */
-	public $version = 2;
-
-	/**
 	 * Whether to show SQL/DB errors.
 	 *
 	 * Default is to show errors if both WP_DEBUG and WP_DEBUG_DISPLAY evaluate to true.
@@ -1433,6 +1424,7 @@ class wpdb {
 	 *              by updating the function signature. The second parameter was changed
 	 *              from `$args` to `...$args`.
 	 * @since 6.0.0 Added %i for Identifiers, e.g. table or field names.
+	 *              Check support via `wpdb::has_cap( 'identifier_placeholders' )`
 	 *              This preserves compatibility with sprinf, as the C version uses %d and $i
 	 *              as a signed integer, whereas PHP only supports %d.
 	 *
@@ -3862,11 +3854,13 @@ class wpdb {
 	 * @since 2.7.0
 	 * @since 4.1.0 Added support for the 'utf8mb4' feature.
 	 * @since 4.6.0 Added support for the 'utf8mb4_520' feature.
+	 * @since 6.0.0 Added support for the 'identifier_placeholders' feature.
 	 *
 	 * @see wpdb::db_version()
 	 *
 	 * @param string $db_cap The feature to check for. Accepts 'collation', 'group_concat',
-	 *                       'subqueries', 'set_charset', 'utf8mb4', or 'utf8mb4_520'.
+	 *                       'subqueries', 'set_charset', 'utf8mb4', 'utf8mb4_520',
+	 *                       or 'identifier_placeholders'.
 	 * @return int|false Whether the database feature is supported, false otherwise.
 	 */
 	public function has_cap( $db_cap ) {
@@ -3901,6 +3895,8 @@ class wpdb {
 				}
 			case 'utf8mb4_520': // @since 4.6.0
 				return version_compare( $version, '5.6', '>=' );
+			case 'identifier_placeholders': // @since 6.0.0, wpdb::prepare() supports identifiers via %i (e.g. table/field names).
+				return true;
 		}
 
 		return false;

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -662,7 +662,7 @@ class wpdb {
 	 * @since 6.0.0
 	 * @var bool
 	 */
-	public $unsafe_unquoted_parameters = true;
+	public $allow_unsafe_unquoted_parameters = true;
 
 	/**
 	 * Whether to use mysqli over mysql. Default false.
@@ -1527,7 +1527,7 @@ class wpdb {
 				if ( strpos( $format, '$' ) !== false ) {
 					$arg_strings[] = intval( substr( $format, 1 ) );
 				}
-				if ( true !== $this->unsafe_unquoted_parameters || '' === $format ) { // Unquoted strings for backwards compatibility (dangerous).
+				if ( true !== $this->allow_unsafe_unquoted_parameters || '' === $format ) { // Unquoted strings for backwards compatibility (dangerous).
 					$placeholder = "'%" . $format . "s'";
 				}
 			} // elseif ( 'd' === $type || 'F' === $type ), nothing needs to be done (keep $placeholder)

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -1494,7 +1494,7 @@ class wpdb {
 		$placeholder_count = ( ( $split_query_count - 1 ) / 3 ); // Split always returns with 1 value before the first placeholder (even with $query = "%s"), then 3 additional values per placeholder.
 
 		// If args were passed as an array (as in vsprintf), move them up.
-		$passed_as_array = ( isset( $args[0] ) && is_array( $args[0] ) && count( $args ) === 1 );
+		$passed_as_array = ( isset( $args[0] ) && is_array( $args[0] ) && 1 === count( $args ) );
 		if ( $passed_as_array ) {
 			$args = $args[0];
 		}

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -1499,7 +1499,6 @@ class wpdb {
 		$arg_identifiers = array();
 		$arg_strings     = array();
 		while ( $key < $split_query_count ) {
-
 			$placeholder = $split_query[ $key ];
 
 			$format = substr( $placeholder, 1, -1 );
@@ -1532,13 +1531,11 @@ class wpdb {
 
 			$key += 3;
 			$arg_id++;
-
 		}
 		$query = $new_query . $split_query[ $key - 2 ]; // Replace $query; and add remaining $query characters, or index 0 if there were no placeholders.
 
 		$dual_use = array_intersect( $arg_identifiers, $arg_strings );
 		if ( count( $dual_use ) ) {
-
 			wp_load_translations_early();
 			_doing_it_wrong(
 				'wpdb::prepare',

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -657,7 +657,7 @@ class wpdb {
 	 * Backwards compatibility, where wpdb::prepare() would not quote string placeholders with formatting.
 	 * They were used in the middle of longer strings, or as table name placeholders.
 	 * But they are risky, e.g. forgetting to add the quotes:
-	 *   $sql = $wpdb->prepare('WHERE id = %s id = %5s OR id = %3$s', ['id', 'id', 'id']);
+	 *   $sql = $wpdb->prepare('WHERE (id = %s) OR (id = %1s) OR (id = %3$s)', ['id', 'id', 'id']);
 	 *
 	 * @since 6.0.0
 	 * @var bool

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -1379,11 +1379,14 @@ class wpdb {
 	}
 
 	/**
-	 * Escapes an identifier value, but does not add the quote marks itself.
-	 * https://dev.mysql.com/doc/refman/8.0/en/identifiers.html
-	 *   Permitted characters in quoted identifiers include the full Unicode Basic Multilingual Plane (BMP), except U+0000
-	 *   To quote the identifier itself, then you need to double the character, e.g. `a``b`
+	 * Escapes an identifier value.
 	 *
+	 * Escapes an identifier value without adding the surrounding quotes. 
+	 * 
+	 * - Permitted characters in quoted identifiers include the full Unicode Basic Multilingual Plane (BMP), except U+0000
+	 * - To quote the identifier itself, then you need to double the character, e.g. `a``b`
+	 *
+	 * @link https://dev.mysql.com/doc/refman/8.0/en/identifiers.html
 	 * @since 6.0.0
 	 *
 	 * @param string $identifier Identifier to escape.

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -1381,8 +1381,8 @@ class wpdb {
 	/**
 	 * Escapes an identifier value.
 	 *
-	 * Escapes an identifier value without adding the surrounding quotes. 
-	 * 
+	 * Escapes an identifier value without adding the surrounding quotes.
+	 *
 	 * - Permitted characters in quoted identifiers include the full Unicode Basic Multilingual Plane (BMP), except U+0000
 	 * - To quote the identifier itself, then you need to double the character, e.g. `a``b`
 	 *

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -656,11 +656,13 @@ class wpdb {
 	/**
 	 * Backwards compatibility, where wpdb::prepare() would not quote string placeholders with formatting.
 	 * They were used in the middle of longer strings, or as table name placeholders.
+	 * But they are risky, e.g. forgetting to add the quotes:
+	 *   $sql = $wpdb->prepare('WHERE id = %s id = %5s OR id = %3$s', ['id', 'id', 'id']);
 	 *
 	 * @since 6.0.0
 	 * @var bool
 	 */
-	private $unsafe_unquoted_parameters = true;
+	public $unsafe_unquoted_parameters = true;
 
 	/**
 	 * Whether to use mysqli over mysql. Default false.

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -1543,7 +1543,7 @@ class wpdb {
 			wp_load_translations_early();
 			_doing_it_wrong(
 				'wpdb::prepare',
-				__( 'You cannot use a an argument for a string and an identifier.' ),
+				__( 'You cannot use an argument for a string and an identifier.' ),
 				'6.0.0'
 			);
 

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -1388,6 +1388,7 @@ class wpdb {
 	 *
 	 * @link https://dev.mysql.com/doc/refman/8.0/en/identifiers.html
 	 * @since 6.0.0
+	 * @access private
 	 *
 	 * @param string $identifier Identifier to escape.
 	 */

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -1516,23 +1516,21 @@ class wpdb {
 				$placeholder = '%' . $format . $type;
 			}
 
-			if ( 'd' === $type || 'F' === $type ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedIf
-				// Keep $placeholder.
-			} elseif ( 'i' === $type ) {
+			if ( 'i' === $type ) {
 				$placeholder = '`%' . $format . 's`';
 				if ( strpos( $format, '$' ) !== false ) { // Using a simple strpos() due to previous checking (e.g. $allowed_format).
 					$arg_identifiers[] = intval( substr( $format, 1 ) );
 				} else {
 					$arg_identifiers[] = $arg_id;
 				}
-			} else { // 's' === $type
+			} elseif ( 's' === $type ) {
 				if ( strpos( $format, '$' ) !== false ) {
 					$arg_strings[] = intval( substr( $format, 1 ) );
 				}
 				if ( true !== $this->unsafe_unquoted_parameters || '' === $format ) { // Unquoted strings for backwards compatibility (dangerous).
 					$placeholder = "'%" . $format . "s'";
 				}
-			}
+			} // elseif ( 'd' === $type || 'F' === $type ), nothing needs to be done (keep $placeholder)
 
 			$new_query .= $split_query[ $key - 2 ] . $split_query[ $key - 1 ] . $placeholder;
 				// Glue (-2), any prefix characters (-1), then the new $placeholder.

--- a/tests/phpunit/tests/db.php
+++ b/tests/phpunit/tests/db.php
@@ -506,9 +506,11 @@ class Tests_DB extends WP_UnitTestCase {
 		$this->assertTrue( $wpdb->has_cap( 'collation' ) );
 		$this->assertTrue( $wpdb->has_cap( 'group_concat' ) );
 		$this->assertTrue( $wpdb->has_cap( 'subqueries' ) );
+		$this->assertTrue( $wpdb->has_cap( 'identifier_placeholders' ) );
 		$this->assertTrue( $wpdb->has_cap( 'COLLATION' ) );
 		$this->assertTrue( $wpdb->has_cap( 'GROUP_CONCAT' ) );
 		$this->assertTrue( $wpdb->has_cap( 'SUBQUERIES' ) );
+		$this->assertTrue( $wpdb->has_cap( 'IDENTIFIER_PLACEHOLDERS' ) );
 		$this->assertSame(
 			version_compare( $wpdb->db_version(), '5.0.7', '>=' ),
 			$wpdb->has_cap( 'set_charset' )

--- a/tests/phpunit/tests/db.php
+++ b/tests/phpunit/tests/db.php
@@ -49,20 +49,6 @@ class Tests_DB extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test Version number is accessible
-	 *
-	 * Make sure $wpdb->version is available for plugins to check what features are available.
-	 *
-	 * @global mixed $wpdb
-	 *
-	 * @ticket 52506
-	 */
-	public function test_version() {
-		global $wpdb;
-		$this->assertGreaterThan( 1, $wpdb->version );
-	}
-
-	/**
 	 * Test that WPDB will reconnect when the DB link dies
 	 *
 	 * @ticket 5932

--- a/tests/phpunit/tests/db.php
+++ b/tests/phpunit/tests/db.php
@@ -1792,6 +1792,12 @@ class Tests_DB extends WP_UnitTestCase {
 				'WHERE ``` AND true -- `` = 321;', // Won't run (SQL parse error: "Unclosed quote").
 			),
 			array(
+				'WHERE %2$i = %1$d;',
+				array( '1', 'two' ),
+				false,
+				'WHERE `two` = 1;',
+			),
+			array(
 				'WHERE \'%i\' = 1 AND "%i" = 2 AND `%i` = 3 AND ``%i`` = 4 AND %15i = 5',
 				array( 'my_field1', 'my_field2', 'my_field3', 'my_field4', 'my_field5' ),
 				false,

--- a/tests/phpunit/tests/db.php
+++ b/tests/phpunit/tests/db.php
@@ -1778,8 +1778,8 @@ class Tests_DB extends WP_UnitTestCase {
 				'WHERE \'`my_field1`\' = 1 AND "`my_field2`" = 2 AND ``my_field3`` = 3 AND `      my_field4` = 4', // Does not remove any existing quotes, always adds it's own (safer).
 			),
 			array(
-				'WHERE %i LIKE %1$s LIMIT 1',
-				array( 'field -- ', false ),
+				'WHERE id = %d AND %i LIKE %2$s LIMIT 1',
+				array( 123, 'field -- ', false ),
 				true, // Incorrect usage.
 				null, // Should be rejected, otherwise the `%1$s` could use Identifier escaping, e.g. 'WHERE `field -- ` LIKE field --  LIMIT 1' (thanks @vortfu).
 			),

--- a/tests/phpunit/tests/db.php
+++ b/tests/phpunit/tests/db.php
@@ -1772,10 +1772,10 @@ class Tests_DB extends WP_UnitTestCase {
 				"WHERE `evil_{$wpdb->placeholder_escape()}s_field` = 321;",
 			),
 			array(
-				'WHERE \'%i\' = 1 AND "%i" = 2 AND `%i` = 3 AND %15i = 4',
-				array( 'my_field1', 'my_field2', 'my_field3', 'my_field4' ),
+				'WHERE \'%i\' = 1 AND "%i" = 2 AND `%i` = 3 AND ``%i`` = 4 AND %15i = 5',
+				array( 'my_field1', 'my_field2', 'my_field3', 'my_field4', 'my_field5' ),
 				false,
-				'WHERE \'`my_field1`\' = 1 AND "`my_field2`" = 2 AND ``my_field3`` = 3 AND `      my_field4` = 4', // Does not remove any existing quotes, always adds it's own (safer).
+				'WHERE \'`my_field1`\' = 1 AND "`my_field2`" = 2 AND ``my_field3`` = 3 AND ```my_field4``` = 4 AND `      my_field5` = 5', // Does not remove any existing quotes, always adds it's own (safer).
 			),
 			array(
 				'WHERE id = %d AND %i LIKE %2$s LIMIT 1',

--- a/tests/phpunit/tests/db.php
+++ b/tests/phpunit/tests/db.php
@@ -53,6 +53,8 @@ class Tests_DB extends WP_UnitTestCase {
 	 *
 	 * Make sure $wpdb->version is available for plugins to check what features are available.
 	 *
+	 * @global mixed $wpdb
+	 *
 	 * @ticket 52506
 	 */
 	public function test_version() {

--- a/tests/phpunit/tests/db.php
+++ b/tests/phpunit/tests/db.php
@@ -1792,6 +1792,30 @@ class Tests_DB extends WP_UnitTestCase {
 		);
 	}
 
+	public function test_allow_unsafe_unquoted_parameters() {
+		global $wpdb;
+
+		$sql    = 'WHERE (%i = %s) OR (%10i = %10s) OR (%5$i = %6$s)';
+		$values = array( 'field_a', 'string_a', 'field_b', 'string_b', 'field_c', 'string_c' );
+
+		$default = $wpdb->allow_unsafe_unquoted_parameters;
+
+		$wpdb->allow_unsafe_unquoted_parameters = true;
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$part = $wpdb->prepare( $sql, $values );
+		$this->assertSame( 'WHERE (`field_a` = \'string_a\') OR (`   field_b` =   string_b) OR (`field_c` = string_c)', $part ); // Unsafe, unquoted parameters.
+
+		$wpdb->allow_unsafe_unquoted_parameters = false;
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$part = $wpdb->prepare( $sql, $values );
+		$this->assertSame( 'WHERE (`field_a` = \'string_a\') OR (`   field_b` = \'  string_b\') OR (`field_c` = \'string_c\')', $part );
+
+		$wpdb->allow_unsafe_unquoted_parameters = $default;
+
+	}
+
 	/**
 	 * @dataProvider data_escape_and_prepare
 	 */

--- a/tests/phpunit/tests/db.php
+++ b/tests/phpunit/tests/db.php
@@ -1772,6 +1772,36 @@ class Tests_DB extends WP_UnitTestCase {
 				"WHERE `evil_{$wpdb->placeholder_escape()}s_field` = 321;",
 			),
 			array(
+				'WHERE %i = %d;',
+				array( 'value`', 321 ),
+				false,
+				'WHERE `value``` = 321;',
+			),
+			array(
+				'WHERE `%i = %d;',
+				array( ' AND evil_value', 321 ),
+				false,
+				'WHERE `` AND evil_value` = 321;', // Won't run (SQL parse error: "Unclosed quote").
+			),
+			array(
+				'WHERE %i` = %d;',
+				array( 'evil_value -- ', 321 ),
+				false,
+				'WHERE `evil_value -- `` = 321;', // Won't run (SQL parse error: "Unclosed quote").
+			),
+			array(
+				'WHERE `%i`` = %d;',
+				array( ' AND true -- ', 321 ),
+				false,
+				'WHERE `` AND true -- ``` = 321;', // Won't run (Unknown column '').
+			),
+			array(
+				'WHERE ``%i` = %d;',
+				array( ' AND true -- ', 321 ),
+				false,
+				'WHERE ``` AND true -- `` = 321;', // Won't run (SQL parse error: "Unclosed quote").
+			),
+			array(
 				'WHERE \'%i\' = 1 AND "%i" = 2 AND `%i` = 3 AND ``%i`` = 4 AND %15i = 5',
 				array( 'my_field1', 'my_field2', 'my_field3', 'my_field4', 'my_field5' ),
 				false,

--- a/tests/phpunit/tests/db.php
+++ b/tests/phpunit/tests/db.php
@@ -1742,6 +1742,36 @@ class Tests_DB extends WP_UnitTestCase {
 				'WHERE `evil_``_field` = 321;', // To quote the identifier itself, then you need to double the character, e.g. `a``b`.
 			),
 			array(
+				'WHERE %i = %d;',
+				array( 'evil_````````_field', 321 ),
+				false,
+				'WHERE `evil_````````````````_field` = 321;',
+			),
+			array(
+				'WHERE %i = %d;',
+				array( '``evil_field``', 321 ),
+				false,
+				'WHERE `````evil_field````` = 321;',
+			),
+			array(
+				'WHERE %i = %d;',
+				array( 'evil\'field', 321 ),
+				false,
+				'WHERE `evil\'field` = 321;',
+			),
+			array(
+				'WHERE %i = %d;',
+				array( 'evil_\``_field', 321 ),
+				false,
+				'WHERE `evil_\````_field` = 321;',
+			),
+			array(
+				'WHERE %i = %d;',
+				array( 'evil_%s_field', 321 ),
+				false,
+				"WHERE `evil_{$wpdb->placeholder_escape()}s_field` = 321;",
+			),
+			array(
 				'WHERE \'%i\' = 1 AND "%i" = 2 AND `%i` = 3 AND %15i = 4',
 				array( 'my_field1', 'my_field2', 'my_field3', 'my_field4' ),
 				false,

--- a/tests/phpunit/tests/db.php
+++ b/tests/phpunit/tests/db.php
@@ -1751,13 +1751,13 @@ class Tests_DB extends WP_UnitTestCase {
 				'WHERE %i LIKE %1$s LIMIT 1',
 				array( 'field -- ', false ),
 				true, // Incorrect usage.
-				NULL, // Should be rejected, otherwise the `%1$s` could use Identifier escaping, e.g. 'WHERE `field -- ` LIKE field --  LIMIT 1' (thanks @vortfu).
+				null, // Should be rejected, otherwise the `%1$s` could use Identifier escaping, e.g. 'WHERE `field -- ` LIKE field --  LIMIT 1' (thanks @vortfu).
 			),
 			array(
 				'WHERE %i LIKE %s LIMIT 1',
 				array( "field' -- ", "field' -- " ),
 				false,
-				"WHERE `field' -- ` LIKE 'field\' -- ' LIMIT 1", // In contrast to the above, Identifier vs String escaping is used
+				"WHERE `field' -- ` LIKE 'field\' -- ' LIMIT 1", // In contrast to the above, Identifier vs String escaping is used.
 			),
 		);
 	}

--- a/tests/phpunit/tests/db.php
+++ b/tests/phpunit/tests/db.php
@@ -1747,6 +1747,18 @@ class Tests_DB extends WP_UnitTestCase {
 				false,
 				'WHERE \'`my_field1`\' = 1 AND "`my_field2`" = 2 AND ``my_field3`` = 3 AND `      my_field4` = 4', // Does not remove any existing quotes, always adds it's own (safer).
 			),
+			array(
+				'WHERE %i LIKE %1$s LIMIT 1',
+				array( "field -- ", false ),
+				true, // Incorrect usage.
+				NULL, // Should be rejected, otherwise the `%1$s` could use Identifier escaping, e.g. 'WHERE `field -- ` LIKE field --  LIMIT 1' (thanks @vortfu).
+			),
+			array(
+				'WHERE %i LIKE %s LIMIT 1',
+				array( "field' -- ", "field' -- " ),
+				false,
+				"WHERE `field' -- ` LIKE 'field\' -- ' LIMIT 1", // In contrast to the above, Identifier vs String escaping is used
+			),
 		);
 	}
 

--- a/tests/phpunit/tests/db.php
+++ b/tests/phpunit/tests/db.php
@@ -49,6 +49,18 @@ class Tests_DB extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test Version number is accessible
+	 *
+	 * Make sure $wpdb->version is available for plugins to check what features are available.
+	 *
+	 * @ticket 52506
+	 */
+	public function test_version() {
+		global $wpdb;
+		$this->assertGreaterThan( 1, $wpdb->version );
+	}
+
+	/**
 	 * Test that WPDB will reconnect when the DB link dies
 	 *
 	 * @ticket 5932
@@ -1716,6 +1728,24 @@ class Tests_DB extends WP_UnitTestCase {
 				array( 'hello', 'foo' ),
 				false,
 				"'hello' 'foo##'",
+			),
+			array(
+				'SELECT * FROM %i WHERE %i = %d;',
+				array( 'my_table', 'my_field', 321 ),
+				false,
+				'SELECT * FROM `my_table` WHERE `my_field` = 321;',
+			),
+			array(
+				'WHERE %i = %d;',
+				array( 'evil_`_field', 321 ),
+				false,
+				'WHERE `evil_``_field` = 321;', // To quote the identifier itself, then you need to double the character, e.g. `a``b`.
+			),
+			array(
+				'WHERE \'%i\' = 1 AND "%i" = 2 AND `%i` = 3 AND %15i = 4',
+				array( 'my_field1', 'my_field2', 'my_field3', 'my_field4' ),
+				false,
+				'WHERE \'`my_field1`\' = 1 AND "`my_field2`" = 2 AND ``my_field3`` = 3 AND `      my_field4` = 4', // Does not remove any existing quotes, always adds it's own (safer).
 			),
 		);
 	}

--- a/tests/phpunit/tests/db.php
+++ b/tests/phpunit/tests/db.php
@@ -1749,7 +1749,7 @@ class Tests_DB extends WP_UnitTestCase {
 			),
 			array(
 				'WHERE %i LIKE %1$s LIMIT 1',
-				array( "field -- ", false ),
+				array( 'field -- ', false ),
 				true, // Incorrect usage.
 				NULL, // Should be rejected, otherwise the `%1$s` could use Identifier escaping, e.g. 'WHERE `field -- ` LIKE field --  LIMIT 1' (thanks @vortfu).
 			),


### PR DESCRIPTION
Update $wpdb->prepare() so it can support identifiers (e.g. table/field names).

Trac ticket: https://core.trac.wordpress.org/ticket/52506

This uses most of [Pull Request #2191](https://github.com/WordPress/wordpress-develop/pull/2191), which includes support for `IN()`, but is done separately so the individual parts can be discussed.