### PR TITLE
Remove the `Live Preview` link when installing block-based themes from a zip archive

### DIFF
--- a/src/wp-admin/includes/class-theme-installer-skin.php
+++ b/src/wp-admin/includes/class-theme-installer-skin.php
@@ -115,7 +115,7 @@ class Theme_Installer_Skin extends WP_Upgrader_Skin {
 
 		$install_actions = array();
 
-		if ( current_user_can( 'edit_theme_options' ) && current_user_can( 'customize' ) && ! $theme_info->is_block_theme()) {
+		if ( current_user_can( 'edit_theme_options' ) && current_user_can( 'customize' ) && ! $theme_info->is_block_theme() ) {
 			$customize_url = add_query_arg(
 				array(
 					'theme'  => urlencode( $stylesheet ),

--- a/src/wp-admin/includes/class-theme-installer-skin.php
+++ b/src/wp-admin/includes/class-theme-installer-skin.php
@@ -94,6 +94,7 @@ class Theme_Installer_Skin extends WP_Upgrader_Skin {
 			return;
 		}
 
+		/** @var WP_Theme|false $theme_info */
 		$theme_info = $this->upgrader->theme_info();
 		if ( empty( $theme_info ) ) {
 			return;
@@ -115,7 +116,7 @@ class Theme_Installer_Skin extends WP_Upgrader_Skin {
 
 		$install_actions = array();
 
-		if ( current_user_can( 'edit_theme_options' ) && current_user_can( 'customize' ) ) {
+		if ( current_user_can( 'edit_theme_options' ) && current_user_can( 'customize' ) && ! $theme_info->is_block_theme()) {
 			$customize_url = add_query_arg(
 				array(
 					'theme'  => urlencode( $stylesheet ),

--- a/src/wp-admin/includes/class-theme-installer-skin.php
+++ b/src/wp-admin/includes/class-theme-installer-skin.php
@@ -94,7 +94,6 @@ class Theme_Installer_Skin extends WP_Upgrader_Skin {
 			return;
 		}
 
-		/** @var WP_Theme|false $theme_info */
 		$theme_info = $this->upgrader->theme_info();
 		if ( empty( $theme_info ) ) {
 			return;


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This PR aims to remove the "Live Preview" link when installing block-based themes from a zip archive.

Trac ticket: https://core.trac.wordpress.org/ticket/54578

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
