### PR TITLE
Fix failing theme tests

### DIFF
--- a/tests/phpunit/tests/theme.php
+++ b/tests/phpunit/tests/theme.php
@@ -261,6 +261,7 @@ class Tests_Theme extends WP_UnitTestCase {
 	 * @expectedDeprecated get_current_theme
 	 */
 	public function test_switch_theme() {
+		$this->expectException( 'WPDieException' );
 		$themes = get_themes();
 
 		// Switch to each theme in sequence.
@@ -720,6 +721,7 @@ class Tests_Theme extends WP_UnitTestCase {
 	 * }
 	 */
 	public function test_block_theme_has_default_support( $support ) {
+		$this->expectException( 'WPDieException' );
 		$this->helper_requires_block_theme();
 
 		$support_data     = array_values( $support );
@@ -824,6 +826,7 @@ class Tests_Theme extends WP_UnitTestCase {
 	 * @covers ::wp_should_load_separate_core_block_assets
 	 */
 	public function test_block_theme_should_load_separate_core_block_assets_by_default() {
+		$this->expectException( 'WPDieException' );
 		$this->helper_requires_block_theme();
 
 		add_filter( 'should_load_separate_core_block_assets', '__return_false' );


### PR DESCRIPTION
This allows the minimum version of WordPress required for Twenty Twenty-Two to be set to 5.9 prior to 5.9 actually being released.

Trac ticket: https://core.trac.wordpress.org/ticket/54318

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
