### PR TITLE
Allow to install/activate themes/plugin which require the next WordPress version [5.9 branch]

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -8342,11 +8342,18 @@ function clean_dirsize_cache( $path ) {
  *
  * @since 5.2.0
  *
+ * @global string $wp_version WordPress version.
+ *
  * @param string $required Minimum required WordPress version.
  * @return bool True if required version is compatible or empty, false if not.
  */
 function is_wp_version_compatible( $required ) {
-	return empty( $required ) || version_compare( get_bloginfo( 'version' ), $required, '>=' );
+	global $wp_version;
+
+	// Strip off any -alpha, -RC, -beta, -src suffixes.
+	list( $version ) = explode( '-', $wp_version );
+
+	return empty( $required ) || version_compare( $version, $required, '>=' );
 }
 
 /**

--- a/tests/phpunit/tests/theme.php
+++ b/tests/phpunit/tests/theme.php
@@ -261,7 +261,6 @@ class Tests_Theme extends WP_UnitTestCase {
 	 * @expectedDeprecated get_current_theme
 	 */
 	public function test_switch_theme() {
-		$this->expectException( 'WPDieException' );
 		$themes = get_themes();
 
 		// Switch to each theme in sequence.
@@ -721,7 +720,6 @@ class Tests_Theme extends WP_UnitTestCase {
 	 * }
 	 */
 	public function test_block_theme_has_default_support( $support ) {
-		$this->expectException( 'WPDieException' );
 		$this->helper_requires_block_theme();
 
 		$support_data     = array_values( $support );
@@ -826,7 +824,6 @@ class Tests_Theme extends WP_UnitTestCase {
 	 * @covers ::wp_should_load_separate_core_block_assets
 	 */
 	public function test_block_theme_should_load_separate_core_block_assets_by_default() {
-		$this->expectException( 'WPDieException' );
 		$this->helper_requires_block_theme();
 
 		add_filter( 'should_load_separate_core_block_assets', '__return_false' );


### PR DESCRIPTION
https://github.com/WordPress/wordpress-develop/pull/2211 for the 5.9 branch to test the revert.

Trac ticket: https://core.trac.wordpress.org/ticket/54882

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
