### PR TITLE
fix/54880: Removed documentation for link_updated field from wp_insert_link()

### DIFF
--- a/src/wp-admin/includes/bookmark.php
+++ b/src/wp-admin/includes/bookmark.php
@@ -163,7 +163,6 @@ function get_link_to_edit( $link ) {
  *     @type string $link_visible     Optional. 'Y' means visible, anything else means not.
  *     @type int    $link_owner       Optional. A user ID.
  *     @type int    $link_rating      Optional. A rating for the link.
- *     @type string $link_updated     Optional. When the link was last updated.
  *     @type string $link_rel         Optional. A relationship of the link to you.
  *     @type string $link_notes       Optional. An extended description of or notes on the link.
  *     @type string $link_rss         Optional. A URL of an associated RSS feed.


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
Removed documentation for `link_updated` field from Docblock of `wp_insert_link()`

Trac ticket: https://core.trac.wordpress.org/ticket/54880

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
