### PR TITLE
Customizer: Remove Menus panel when a theme does not support menus

### DIFF
--- a/src/wp-includes/class-wp-customize-panel.php
+++ b/src/wp-includes/class-wp-customize-panel.php
@@ -232,6 +232,7 @@ class WP_Customize_Panel {
 	 * feature support required by the panel.
 	 *
 	 * @since 4.0.0
+	 * @since 5.9.0 Method was marked non-final.
 	 *
 	 * @return bool False if theme doesn't support the panel or the user doesn't have the capability.
 	 */

--- a/src/wp-includes/class-wp-customize-panel.php
+++ b/src/wp-includes/class-wp-customize-panel.php
@@ -235,7 +235,7 @@ class WP_Customize_Panel {
 	 *
 	 * @return bool False if theme doesn't support the panel or the user doesn't have the capability.
 	 */
-	final public function check_capabilities() {
+	public function check_capabilities() {
 		if ( $this->capability && ! current_user_can( $this->capability ) ) {
 			return false;
 		}

--- a/src/wp-includes/class-wp-customize-widgets.php
+++ b/src/wp-includes/class-wp-customize-widgets.php
@@ -420,6 +420,7 @@ final class WP_Customize_Widgets {
 				'priority'                 => 110,
 				'active_callback'          => array( $this, 'is_panel_active' ),
 				'auto_expand_sole_section' => true,
+				'theme_supports'           => 'widgets',
 			)
 		);
 

--- a/src/wp-includes/class-wp-customize-widgets.php
+++ b/src/wp-includes/class-wp-customize-widgets.php
@@ -420,7 +420,6 @@ final class WP_Customize_Widgets {
 				'priority'                 => 110,
 				'active_callback'          => array( $this, 'is_panel_active' ),
 				'auto_expand_sole_section' => true,
-				'theme_supports'           => 'widgets',
 			)
 		);
 

--- a/src/wp-includes/customize/class-wp-customize-nav-menus-panel.php
+++ b/src/wp-includes/customize/class-wp-customize-nav-menus-panel.php
@@ -108,7 +108,7 @@ class WP_Customize_Nav_Menus_Panel extends WP_Customize_Panel {
 	 * @return bool False if theme doesn't support the panel or the user doesn't have the capability.
 	 */
 	public function check_capabilities() {
-		/* 
+		/*
 		 * WP_Customize_Panel::$theme_supports only supports checking one
 		 * theme_supports, so instead we override check_capabilities().
 		 */

--- a/src/wp-includes/customize/class-wp-customize-nav-menus-panel.php
+++ b/src/wp-includes/customize/class-wp-customize-nav-menus-panel.php
@@ -103,7 +103,7 @@ class WP_Customize_Nav_Menus_Panel extends WP_Customize_Panel {
 	 * Checks required user capabilities and whether the theme has the
 	 * feature support required by the panel.
 	 *
-	 * @since 4.0.0
+	 * @since 5.9.0
 	 *
 	 * @return bool False if theme doesn't support the panel or the user doesn't have the capability.
 	 */

--- a/src/wp-includes/customize/class-wp-customize-nav-menus-panel.php
+++ b/src/wp-includes/customize/class-wp-customize-nav-menus-panel.php
@@ -108,8 +108,10 @@ class WP_Customize_Nav_Menus_Panel extends WP_Customize_Panel {
 	 * @return bool False if theme doesn't support the panel or the user doesn't have the capability.
 	 */
 	public function check_capabilities() {
-		// WP_Customize_Panel::$theme_supports only supports checking one
-		// theme_supports, so instead we override check_capabilities().
+		/* 
+		 * WP_Customize_Panel::$theme_supports only supports checking one
+		 * theme_supports, so instead we override check_capabilities().
+		 */
 		if (
 			! current_theme_supports( 'menus' ) &&
 			! current_theme_supports( 'widgets' )

--- a/src/wp-includes/customize/class-wp-customize-nav-menus-panel.php
+++ b/src/wp-includes/customize/class-wp-customize-nav-menus-panel.php
@@ -98,4 +98,25 @@ class WP_Customize_Nav_Menus_Panel extends WP_Customize_Panel {
 		<li class="customize-control-title customize-section-title-nav_menus-heading"><?php _e( 'Menus' ); ?></li>
 		<?php
 	}
+
+	/**
+	 * Checks required user capabilities and whether the theme has the
+	 * feature support required by the panel.
+	 *
+	 * @since 4.0.0
+	 *
+	 * @return bool False if theme doesn't support the panel or the user doesn't have the capability.
+	 */
+	public function check_capabilities() {
+		// WP_Customize_Panel::$theme_supports only supports checking one
+		// theme_supports, so instead we override check_capabilities().
+		if (
+			! current_theme_supports( 'menus' ) &&
+			! current_theme_supports( 'widgets' )
+		) {
+			return false;
+		}
+
+		return parent::check_capabilities();
+	}
 }


### PR DESCRIPTION
By having `WP_Customize_Panel::check_capabilities()`, we can ensure that the _Menus_ panel is removed if a theme does not have support for `'menus'` nor `'widgets'`. (We show the _Menus_ panel when there is support for `'widgets'` so that one can use the Menu widget.)

This ensures that the _Menus_ panel does not appear when using a block theme, which is pretty confusing, as the Navigation block is intended to be the sole place for editing a site's navigation when using a block theme.

Trac ticket: https://core.trac.wordpress.org/ticket/54888

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
