### PR TITLE
Customizer: Remove Widgets panel if current theme doesn't support 'widgets'

### DIFF
--- a/src/wp-includes/class-wp-customize-widgets.php
+++ b/src/wp-includes/class-wp-customize-widgets.php
@@ -420,6 +420,7 @@ final class WP_Customize_Widgets {
 				'priority'                 => 110,
 				'active_callback'          => array( $this, 'is_panel_active' ),
 				'auto_expand_sole_section' => true,
+				'theme_supports'           => 'widgets',
 			)
 		);
 


### PR DESCRIPTION
Split out from https://github.com/WordPress/wordpress-develop/pull/2217.

Let's only commit this change in `trunk` since it's only for consistency and so doesn't need to go into WP 5.9.

Trac ticket: https://github.com/WordPress/wordpress-develop/pull/2217

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**