### PR TITLE
Always allow accessing edit.php?post_type=wp_navigation page

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -503,7 +503,7 @@ function create_initial_post_types() {
 			'public'                => false,
 			'_builtin'              => true, /* internal use only. don't use this when registering your own post type. */
 			'has_archive'           => false,
-			'show_ui'               => wp_is_block_theme(),
+			'show_ui'               => true,
 			'show_in_menu'          => false,
 			'show_in_admin_bar'     => false,
 			'show_in_rest'          => true,


### PR DESCRIPTION
The Navigation block is supported in both block themes and classic themes, so it is incorrect to only allow access to
`edit.php?post_type=wp_navigation` when the current theme is a block theme.

This fixes a bug where clicking on 'Manage menus' in the toolbar of a Navigation block takes you an error page when running a classic theme.

Trac ticket: https://core.trac.wordpress.org/ticket/54889

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**