### PR TITLE
Fix PHP warning in `WP_REST_Global_Styles_Controller` if no `styles` exist in theme.json

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-controller.php
@@ -563,8 +563,10 @@ class WP_REST_Global_Styles_Controller extends WP_REST_Controller {
 		}
 
 		if ( rest_is_field_included( 'styles', $fields ) ) {
-			$raw_data       = $theme->get_raw_data();
-			$data['styles'] = isset( $raw_data['styles'] ) ? $raw_data['styles'] : array();
+			$raw_data = $theme->get_raw_data();
+			if ( isset( $raw_data['styles'] ) ) {
+				$data['styles'] = $raw_data['styles'];
+			}
 		}
 
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-controller.php
@@ -563,7 +563,8 @@ class WP_REST_Global_Styles_Controller extends WP_REST_Controller {
 		}
 
 		if ( rest_is_field_included( 'styles', $fields ) ) {
-			$data['styles'] = $theme->get_raw_data()['styles'];
+			$raw_data       = $theme->get_raw_data();
+			$data['styles'] = isset( $raw_data['styles'] ) ? $raw_data['styles'] : array();
 		}
 
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';


### PR DESCRIPTION

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/54900

During this [GB PR](https://github.com/WordPress/gutenberg/pull/38124) I noticed a PHP warning in WP_REST_Global_Styles_Controller where we are assuming that every theme.json has styles property, which is not always the case.
It's fixed in GB now, but we should add this to 5.9 next minor release.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
