### PR TITLE
Rename variables used in wpautop and related tests.

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -433,171 +433,171 @@ function _wptexturize_pushpop_element( $text, &$stack, $disabled_elements ) {
  *
  * @since 0.71
  *
- * @param string $pee The text which has to be formatted.
- * @param bool   $br  Optional. If set, this will convert all remaining line breaks
- *                    after paragraphing. Line breaks within `<script>`, `<style>`,
- *                    and `<svg>` tags are not affected. Default true.
+ * @param string $text The text which has to be formatted.
+ * @param bool   $br   Optional. If set, this will convert all remaining line breaks
+ *                     after paragraphing. Line breaks within `<script>`, `<style>`,
+ *                     and `<svg>` tags are not affected. Default true.
  * @return string Text which has been converted into correct paragraph tags.
  */
-function wpautop( $pee, $br = true ) {
+function wpautop( $text, $br = true ) {
 	$pre_tags = array();
 
-	if ( trim( $pee ) === '' ) {
+	if ( trim( $text ) === '' ) {
 		return '';
 	}
 
 	// Just to make things a little easier, pad the end.
-	$pee = $pee . "\n";
+	$text = $text . "\n";
 
 	/*
 	 * Pre tags shouldn't be touched by autop.
 	 * Replace pre tags with placeholders and bring them back after autop.
 	 */
-	if ( strpos( $pee, '<pre' ) !== false ) {
-		$pee_parts = explode( '</pre>', $pee );
-		$last_pee  = array_pop( $pee_parts );
-		$pee       = '';
-		$i         = 0;
+	if ( strpos( $text, '<pre' ) !== false ) {
+		$text_parts = explode( '</pre>', $text );
+		$last_part  = array_pop( $text_parts );
+		$text       = '';
+		$i          = 0;
 
-		foreach ( $pee_parts as $pee_part ) {
-			$start = strpos( $pee_part, '<pre' );
+		foreach ( $text_parts as $text_part ) {
+			$start = strpos( $text_part, '<pre' );
 
 			// Malformed HTML?
 			if ( false === $start ) {
-				$pee .= $pee_part;
+				$text .= $text_part;
 				continue;
 			}
 
 			$name              = "<pre wp-pre-tag-$i></pre>";
-			$pre_tags[ $name ] = substr( $pee_part, $start ) . '</pre>';
+			$pre_tags[ $name ] = substr( $text_part, $start ) . '</pre>';
 
-			$pee .= substr( $pee_part, 0, $start ) . $name;
+			$text .= substr( $text_part, 0, $start ) . $name;
 			$i++;
 		}
 
-		$pee .= $last_pee;
+		$text .= $last_part;
 	}
 	// Change multiple <br>'s into two line breaks, which will turn into paragraphs.
-	$pee = preg_replace( '|<br\s*/?>\s*<br\s*/?>|', "\n\n", $pee );
+	$text = preg_replace( '|<br\s*/?>\s*<br\s*/?>|', "\n\n", $text );
 
 	$allblocks = '(?:table|thead|tfoot|caption|col|colgroup|tbody|tr|td|th|div|dl|dd|dt|ul|ol|li|pre|form|map|area|blockquote|address|math|style|p|h[1-6]|hr|fieldset|legend|section|article|aside|hgroup|header|footer|nav|figure|figcaption|details|menu|summary)';
 
 	// Add a double line break above block-level opening tags.
-	$pee = preg_replace( '!(<' . $allblocks . '[\s/>])!', "\n\n$1", $pee );
+	$text = preg_replace( '!(<' . $allblocks . '[\s/>])!', "\n\n$1", $text );
 
 	// Add a double line break below block-level closing tags.
-	$pee = preg_replace( '!(</' . $allblocks . '>)!', "$1\n\n", $pee );
+	$text = preg_replace( '!(</' . $allblocks . '>)!', "$1\n\n", $text );
 
 	// Add a double line break after hr tags, which are self closing.
-	$pee = preg_replace( '!(<hr\s*?/?>)!', "$1\n\n", $pee );
+	$text = preg_replace( '!(<hr\s*?/?>)!', "$1\n\n", $text );
 
 	// Standardize newline characters to "\n".
-	$pee = str_replace( array( "\r\n", "\r" ), "\n", $pee );
+	$text = str_replace( array( "\r\n", "\r" ), "\n", $text );
 
 	// Find newlines in all elements and add placeholders.
-	$pee = wp_replace_in_html_tags( $pee, array( "\n" => ' <!-- wpnl --> ' ) );
+	$text = wp_replace_in_html_tags( $text, array( "\n" => ' <!-- wpnl --> ' ) );
 
 	// Collapse line breaks before and after <option> elements so they don't get autop'd.
-	if ( strpos( $pee, '<option' ) !== false ) {
-		$pee = preg_replace( '|\s*<option|', '<option', $pee );
-		$pee = preg_replace( '|</option>\s*|', '</option>', $pee );
+	if ( strpos( $text, '<option' ) !== false ) {
+		$text = preg_replace( '|\s*<option|', '<option', $text );
+		$text = preg_replace( '|</option>\s*|', '</option>', $text );
 	}
 
 	/*
 	 * Collapse line breaks inside <object> elements, before <param> and <embed> elements
 	 * so they don't get autop'd.
 	 */
-	if ( strpos( $pee, '</object>' ) !== false ) {
-		$pee = preg_replace( '|(<object[^>]*>)\s*|', '$1', $pee );
-		$pee = preg_replace( '|\s*</object>|', '</object>', $pee );
-		$pee = preg_replace( '%\s*(</?(?:param|embed)[^>]*>)\s*%', '$1', $pee );
+	if ( strpos( $text, '</object>' ) !== false ) {
+		$text = preg_replace( '|(<object[^>]*>)\s*|', '$1', $text );
+		$text = preg_replace( '|\s*</object>|', '</object>', $text );
+		$text = preg_replace( '%\s*(</?(?:param|embed)[^>]*>)\s*%', '$1', $text );
 	}
 
 	/*
 	 * Collapse line breaks inside <audio> and <video> elements,
 	 * before and after <source> and <track> elements.
 	 */
-	if ( strpos( $pee, '<source' ) !== false || strpos( $pee, '<track' ) !== false ) {
-		$pee = preg_replace( '%([<\[](?:audio|video)[^>\]]*[>\]])\s*%', '$1', $pee );
-		$pee = preg_replace( '%\s*([<\[]/(?:audio|video)[>\]])%', '$1', $pee );
-		$pee = preg_replace( '%\s*(<(?:source|track)[^>]*>)\s*%', '$1', $pee );
+	if ( strpos( $text, '<source' ) !== false || strpos( $text, '<track' ) !== false ) {
+		$text = preg_replace( '%([<\[](?:audio|video)[^>\]]*[>\]])\s*%', '$1', $text );
+		$text = preg_replace( '%\s*([<\[]/(?:audio|video)[>\]])%', '$1', $text );
+		$text = preg_replace( '%\s*(<(?:source|track)[^>]*>)\s*%', '$1', $text );
 	}
 
 	// Collapse line breaks before and after <figcaption> elements.
-	if ( strpos( $pee, '<figcaption' ) !== false ) {
-		$pee = preg_replace( '|\s*(<figcaption[^>]*>)|', '$1', $pee );
-		$pee = preg_replace( '|</figcaption>\s*|', '</figcaption>', $pee );
+	if ( strpos( $text, '<figcaption' ) !== false ) {
+		$text = preg_replace( '|\s*(<figcaption[^>]*>)|', '$1', $text );
+		$text = preg_replace( '|</figcaption>\s*|', '</figcaption>', $text );
 	}
 
 	// Remove more than two contiguous line breaks.
-	$pee = preg_replace( "/\n\n+/", "\n\n", $pee );
+	$text = preg_replace( "/\n\n+/", "\n\n", $text );
 
 	// Split up the contents into an array of strings, separated by double line breaks.
-	$pees = preg_split( '/\n\s*\n/', $pee, -1, PREG_SPLIT_NO_EMPTY );
+	$paragraphs = preg_split( '/\n\s*\n/', $text, -1, PREG_SPLIT_NO_EMPTY );
 
-	// Reset $pee prior to rebuilding.
-	$pee = '';
+	// Reset $text prior to rebuilding.
+	$text = '';
 
 	// Rebuild the content as a string, wrapping every bit with a <p>.
-	foreach ( $pees as $tinkle ) {
-		$pee .= '<p>' . trim( $tinkle, "\n" ) . "</p>\n";
+	foreach ( $paragraphs as $paragraph ) {
+		$text .= '<p>' . trim( $paragraph, "\n" ) . "</p>\n";
 	}
 
 	// Under certain strange conditions it could create a P of entirely whitespace.
-	$pee = preg_replace( '|<p>\s*</p>|', '', $pee );
+	$text = preg_replace( '|<p>\s*</p>|', '', $text );
 
 	// Add a closing <p> inside <div>, <address>, or <form> tag if missing.
-	$pee = preg_replace( '!<p>([^<]+)</(div|address|form)>!', '<p>$1</p></$2>', $pee );
+	$text = preg_replace( '!<p>([^<]+)</(div|address|form)>!', '<p>$1</p></$2>', $text );
 
 	// If an opening or closing block element tag is wrapped in a <p>, unwrap it.
-	$pee = preg_replace( '!<p>\s*(</?' . $allblocks . '[^>]*>)\s*</p>!', '$1', $pee );
+	$text = preg_replace( '!<p>\s*(</?' . $allblocks . '[^>]*>)\s*</p>!', '$1', $text );
 
 	// In some cases <li> may get wrapped in <p>, fix them.
-	$pee = preg_replace( '|<p>(<li.+?)</p>|', '$1', $pee );
+	$text = preg_replace( '|<p>(<li.+?)</p>|', '$1', $text );
 
 	// If a <blockquote> is wrapped with a <p>, move it inside the <blockquote>.
-	$pee = preg_replace( '|<p><blockquote([^>]*)>|i', '<blockquote$1><p>', $pee );
-	$pee = str_replace( '</blockquote></p>', '</p></blockquote>', $pee );
+	$text = preg_replace( '|<p><blockquote([^>]*)>|i', '<blockquote$1><p>', $text );
+	$text = str_replace( '</blockquote></p>', '</p></blockquote>', $text );
 
 	// If an opening or closing block element tag is preceded by an opening <p> tag, remove it.
-	$pee = preg_replace( '!<p>\s*(</?' . $allblocks . '[^>]*>)!', '$1', $pee );
+	$text = preg_replace( '!<p>\s*(</?' . $allblocks . '[^>]*>)!', '$1', $text );
 
 	// If an opening or closing block element tag is followed by a closing <p> tag, remove it.
-	$pee = preg_replace( '!(</?' . $allblocks . '[^>]*>)\s*</p>!', '$1', $pee );
+	$text = preg_replace( '!(</?' . $allblocks . '[^>]*>)\s*</p>!', '$1', $text );
 
 	// Optionally insert line breaks.
 	if ( $br ) {
 		// Replace newlines that shouldn't be touched with a placeholder.
-		$pee = preg_replace_callback( '/<(script|style|svg).*?<\/\\1>/s', '_autop_newline_preservation_helper', $pee );
+		$text = preg_replace_callback( '/<(script|style|svg).*?<\/\\1>/s', '_autop_newline_preservation_helper', $text );
 
 		// Normalize <br>
-		$pee = str_replace( array( '<br>', '<br/>' ), '<br />', $pee );
+		$text = str_replace( array( '<br>', '<br/>' ), '<br />', $text );
 
 		// Replace any new line characters that aren't preceded by a <br /> with a <br />.
-		$pee = preg_replace( '|(?<!<br />)\s*\n|', "<br />\n", $pee );
+		$text = preg_replace( '|(?<!<br />)\s*\n|', "<br />\n", $text );
 
 		// Replace newline placeholders with newlines.
-		$pee = str_replace( '<WPPreserveNewline />', "\n", $pee );
+		$text = str_replace( '<WPPreserveNewline />', "\n", $text );
 	}
 
 	// If a <br /> tag is after an opening or closing block tag, remove it.
-	$pee = preg_replace( '!(</?' . $allblocks . '[^>]*>)\s*<br />!', '$1', $pee );
+	$text = preg_replace( '!(</?' . $allblocks . '[^>]*>)\s*<br />!', '$1', $text );
 
 	// If a <br /> tag is before a subset of opening or closing block tags, remove it.
-	$pee = preg_replace( '!<br />(\s*</?(?:p|li|div|dl|dd|dt|th|pre|td|ul|ol)[^>]*>)!', '$1', $pee );
-	$pee = preg_replace( "|\n</p>$|", '</p>', $pee );
+	$text = preg_replace( '!<br />(\s*</?(?:p|li|div|dl|dd|dt|th|pre|td|ul|ol)[^>]*>)!', '$1', $text );
+	$text = preg_replace( "|\n</p>$|", '</p>', $text );
 
 	// Replace placeholder <pre> tags with their original content.
 	if ( ! empty( $pre_tags ) ) {
-		$pee = str_replace( array_keys( $pre_tags ), array_values( $pre_tags ), $pee );
+		$text = str_replace( array_keys( $pre_tags ), array_values( $pre_tags ), $text );
 	}
 
 	// Restore newlines in all elements.
-	if ( false !== strpos( $pee, '<!-- wpnl -->' ) ) {
-		$pee = str_replace( array( ' <!-- wpnl --> ', '<!-- wpnl -->' ), "\n", $pee );
+	if ( false !== strpos( $text, '<!-- wpnl -->' ) ) {
+		$text = str_replace( array( ' <!-- wpnl --> ', '<!-- wpnl -->' ), "\n", $text );
 	}
 
-	return $pee;
+	return $text;
 }
 
 /**
@@ -814,14 +814,14 @@ function _autop_newline_preservation_helper( $matches ) {
  *
  * @global array $shortcode_tags
  *
- * @param string $pee The content.
+ * @param string $text The content.
  * @return string The filtered content.
  */
-function shortcode_unautop( $pee ) {
+function shortcode_unautop( $text ) {
 	global $shortcode_tags;
 
 	if ( empty( $shortcode_tags ) || ! is_array( $shortcode_tags ) ) {
-		return $pee;
+		return $text;
 	}
 
 	$tagregexp = implode( '|', array_map( 'preg_quote', array_keys( $shortcode_tags ) ) );
@@ -861,7 +861,7 @@ function shortcode_unautop( $pee ) {
 		. '/';
 	// phpcs:enable
 
-	return preg_replace( $pattern, '$1', $pee );
+	return preg_replace( $pattern, '$1', $text );
 }
 
 /**

--- a/tests/phpunit/tests/formatting/wpAutop.php
+++ b/tests/phpunit/tests/formatting/wpAutop.php
@@ -531,7 +531,7 @@ line 2<br/>
 	/**
 	 * @ticket 4857
 	 */
-	public function test_that_text_before_blocks_is_peed() {
+	public function test_that_text_before_blocks_is_wrapped_in_a_paragraph() {
 		$content  = 'a<div>b</div>';
 		$expected = "<p>a</p>\n<div>b</div>";
 
@@ -565,7 +565,7 @@ line 2<br/>
 	/**
 	 * @ticket 14674
 	 */
-	public function test_the_hr_is_not_peed() {
+	public function test_the_hr_is_not_wrapped_in_a_paragraph() {
 		$content  = 'paragraph1<hr>paragraph2';
 		$expected = "<p>paragraph1</p>\n<hr>\n<p>paragraph2</p>";
 


### PR DESCRIPTION
Updates phpunit test names to reflect variable name updates originally proposed by @ricomoorman and later amended by @peterwilsoncc via https://github.com/WordPress/wordpress-develop/pull/2215.

This change is in conjunction with the above PR submitted by @peterwilsoncc.

See https://core.trac.wordpress.org/ticket/25615.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
