### PR TITLE
Update functions.php

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -5194,8 +5194,10 @@ function wp_widgets_add_menu() {
 	if ( ! current_theme_supports( 'widgets' ) ) {
 		return;
 	}
+	
+	$position = wp_is_block_theme() ? 8 : 7;
 
-	$submenu['themes.php'][7] = array( __( 'Widgets' ), 'edit_theme_options', 'widgets.php' );
+	$submenu['themes.php'][$position] = array( __( 'Widgets' ), 'edit_theme_options', 'widgets.php' );
 	ksort( $submenu['themes.php'], SORT_NUMERIC );
 }
 

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -5194,10 +5194,8 @@ function wp_widgets_add_menu() {
 	if ( ! current_theme_supports( 'widgets' ) ) {
 		return;
 	}
-	
-	$position = wp_is_block_theme() ? 8 : 7;
 
-	$submenu['themes.php'][$position] = array( __( 'Widgets' ), 'edit_theme_options', 'widgets.php' );
+	$submenu['themes.php'][8] = array( __( 'Widgets' ), 'edit_theme_options', 'widgets.php' );
 	ksort( $submenu['themes.php'], SORT_NUMERIC );
 }
 


### PR DESCRIPTION
In the last 5.9 version there is an issue related to admin panel's "Customize" sub-menu item for block based themes. The problem is that for block based themes the "Customize" sub-menu item position is 7 (for the old themes it is 6). However, "Widgets" sub-menu item is constantly registered in the exactly same 7th position and in case of block based themes, it overwrites "Customize" sub-menu item.

I've added a small tweak that will increase "Widgets" sub-menu item position by 1 ( will be 8 instead of 7 ) by checking if active theme is a block based one ( using native "wp_is_block_theme" function )

Trac ticket: https://core.trac.wordpress.org/ticket/54916

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
