### PR TITLE
Fix parameter types in docblocks

### DIFF
--- a/src/wp-admin/includes/translation-install.php
+++ b/src/wp-admin/includes/translation-install.php
@@ -14,7 +14,7 @@
  *
  * @param string       $type Type of translations. Accepts 'plugins', 'themes', 'core'.
  * @param array|object $args Translation API arguments. Optional.
- * @return object|WP_Error On success an object of translations, WP_Error on failure.
+ * @return array|WP_Error On success an associative array of translations, WP_Error on failure.
  */
 function translations_api( $type, $args = null ) {
 	// Include an unmodified $wp_version.
@@ -29,7 +29,7 @@ function translations_api( $type, $args = null ) {
 	 *
 	 * @since 4.0.0
 	 *
-	 * @param false|object $result The result object. Default false.
+	 * @param false|array $result The result array. Default false.
 	 * @param string       $type   The type of translations being requested.
 	 * @param object       $args   Translation API arguments.
 	 */
@@ -102,9 +102,9 @@ function translations_api( $type, $args = null ) {
 	 *
 	 * @since 4.0.0
 	 *
-	 * @param object|WP_Error $res  Response object or WP_Error.
-	 * @param string          $type The type of translations being requested.
-	 * @param object          $args Translation API arguments.
+	 * @param array|WP_Error $res  Response as an associative array or WP_Error.
+	 * @param string         $type The type of translations being requested.
+	 * @param object         $args Translation API arguments.
 	 */
 	return apply_filters( 'translations_api_result', $res, $type, $args );
 }


### PR DESCRIPTION
This PR fixes parameter/return value types for the `translations_api()` function and `translations_api` and `translations_api_result` hooks from `object` to `array`.

Trac ticket: [<!-- insert a link to the WordPress Trac ticket here -->](https://core.trac.wordpress.org/ticket/54959)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
