### PR TITLE
Remove experimental-link-color dependancy in global styles

### DIFF
--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -104,7 +104,6 @@ function wp_get_global_stylesheet( $types = array() ) {
 	}
 
 	$supports_theme_json = WP_Theme_JSON_Resolver::theme_has_support();
-	$supports_link_color = get_theme_support( 'experimental-link-color' );
 	if ( empty( $types ) && ! $supports_theme_json ) {
 		$types = array( 'variables', 'presets' );
 	} elseif ( empty( $types ) ) {
@@ -112,12 +111,8 @@ function wp_get_global_stylesheet( $types = array() ) {
 	}
 
 	$origins = array( 'default', 'theme', 'custom' );
-	if ( ! $supports_theme_json && ! $supports_link_color ) {
-		// In this case we only enqueue the core presets (CSS Custom Properties + the classes).
-		$origins = array( 'default' );
-	} elseif ( ! $supports_theme_json && $supports_link_color ) {
-		// For the legacy link color feature to work, the CSS Custom Properties
-		// should be in scope (either the core or the theme ones).
+	if ( ! $supports_theme_json ) {
+		// For themes without theme.json ensure theme variables are merged with default.
 		$origins = array( 'default', 'theme' );
 	}
 


### PR DESCRIPTION
Since 5.9 it appears that fonts and colours defined in `theme.json` will correctly override the default values of `--wp--preset--` variables, however those defined via `add_theme_support` are not, and so the default values are still being used.

This is being triggered by whether or not a theme calls `add_theme_support( 'experimental-link-color' )`

A simple way to test what's going on here:

1. Open a blank install with the Twenty-Twenty-One theme installed.
2. Create a new page and add paragraph text with the font size set to `large` and set the background color to `black`
3. Open `functions.php` and edit `line 170` to change the large font size, and then edit `line 203` to change the black color and save.

**Result:** Paragraph text correctly reflects changes made to font size and color.

4. Open `functions.php` and delete `line 333: add_theme_support( 'experimental-link-color' );`

**Result:** Font size and color fallback to WP default values.

**Expected behaviour:** Font sizes and colors set via `add_theme_support` should continue to work as pre 5.9 without the need to add `add_theme_support( 'experimental-link-color' );` or `theme.json`

This PR removes `experimental-link-color` dependancy in `wp-includes/global-styles-and-settings.php` for themes to be able to update `--wp--preset` variables without the need to setup `theme.json` or add theme support for an experimental feature.

Trac ticket: https://core.trac.wordpress.org/ticket/54954
