### PR TITLE
Implement a notification for block themes in the Customizer.

### DIFF
--- a/src/js/_enqueues/wp/customize/controls.js
+++ b/src/js/_enqueues/wp/customize/controls.js
@@ -8335,6 +8335,22 @@
 			}
 
 			/**
+			 * Displays a Site Editor notification when a block theme is activated.
+
+			 * @param {string} [notification] - A notification to display.
+			 *
+			 * @return {void}
+			 */
+			function addSiteEditorNotification( notification )
+			{
+				api.notifications.add( new api.Notification( 'site_editor_block_theme_notice', {
+					message: notification,
+					type: 'warning',
+					dismissible: false
+				} ) );
+			}
+
+			/**
 			 * Dismiss autosave.
 			 *
 			 * @return {void}
@@ -8407,6 +8423,9 @@
 			}
 			if ( api.settings.changeset.latestAutoDraftUuid || api.settings.changeset.hasAutosaveRevision ) {
 				addAutosaveRestoreNotification();
+			}
+			if (api.l10n.blockThemeNotification) {
+				addSiteEditorNotification(api.l10n.blockThemeNotification);
 			}
 		})();
 

--- a/src/js/_enqueues/wp/customize/controls.js
+++ b/src/js/_enqueues/wp/customize/controls.js
@@ -8345,7 +8345,7 @@
 			{
 				api.notifications.add( new api.Notification( 'site_editor_block_theme_notice', {
 					message: notification,
-					type: 'warning',
+					type: 'info',
 					dismissible: false,
 					render: function() {
 						var notification = api.Notification.prototype.render.call( this ),

--- a/src/js/_enqueues/wp/customize/controls.js
+++ b/src/js/_enqueues/wp/customize/controls.js
@@ -8424,7 +8424,8 @@
 			if ( api.settings.changeset.latestAutoDraftUuid || api.settings.changeset.hasAutosaveRevision ) {
 				addAutosaveRestoreNotification();
 			}
-			if (api.l10n.blockThemeNotification) {
+			var shouldDisplayBlockThemeNotification = !!parseInt($('#customize-info').data('block-theme'));
+			if (shouldDisplayBlockThemeNotification) {
 				addSiteEditorNotification(api.l10n.blockThemeNotification);
 			}
 		})();

--- a/src/js/_enqueues/wp/customize/controls.js
+++ b/src/js/_enqueues/wp/customize/controls.js
@@ -8346,7 +8346,18 @@
 				api.notifications.add( new api.Notification( 'site_editor_block_theme_notice', {
 					message: notification,
 					type: 'warning',
-					dismissible: false
+					dismissible: false,
+					render: function() {
+						var notification = api.Notification.prototype.render.call( this ),
+							button = notification.find( 'button.switch-to-editor' );
+
+						button.on( 'click', function( event ) {
+							event.preventDefault();
+							location.assign(button.data( 'action' ));
+						} );
+
+						return notification;
+					}
 				} ) );
 			}
 

--- a/src/js/_enqueues/wp/customize/controls.js
+++ b/src/js/_enqueues/wp/customize/controls.js
@@ -8424,7 +8424,7 @@
 			if ( api.settings.changeset.latestAutoDraftUuid || api.settings.changeset.hasAutosaveRevision ) {
 				addAutosaveRestoreNotification();
 			}
-			var shouldDisplayBlockThemeNotification = !! parseInt( $( '#customize-info' ).data( 'block-theme' ) );
+			var shouldDisplayBlockThemeNotification = !! parseInt( $( '#customize-info' ).data( 'block-theme' ), 10 );
 			if (shouldDisplayBlockThemeNotification) {
 				addSiteEditorNotification( api.l10n.blockThemeNotification );
 			}

--- a/src/js/_enqueues/wp/customize/controls.js
+++ b/src/js/_enqueues/wp/customize/controls.js
@@ -8353,7 +8353,7 @@
 
 						button.on( 'click', function( event ) {
 							event.preventDefault();
-							location.assign(button.data( 'action' ));
+							location.assign( button.data( 'action' ) );
 						} );
 
 						return notification;

--- a/src/js/_enqueues/wp/customize/controls.js
+++ b/src/js/_enqueues/wp/customize/controls.js
@@ -8424,9 +8424,9 @@
 			if ( api.settings.changeset.latestAutoDraftUuid || api.settings.changeset.hasAutosaveRevision ) {
 				addAutosaveRestoreNotification();
 			}
-			var shouldDisplayBlockThemeNotification = !!parseInt($('#customize-info').data('block-theme'));
+			var shouldDisplayBlockThemeNotification = !! parseInt( $( '#customize-info' ).data( 'block-theme' ) );
 			if (shouldDisplayBlockThemeNotification) {
-				addSiteEditorNotification(api.l10n.blockThemeNotification);
+				addSiteEditorNotification( api.l10n.blockThemeNotification );
 			}
 		})();
 

--- a/src/wp-admin/css/customize-controls.css
+++ b/src/wp-admin/css/customize-controls.css
@@ -1733,6 +1733,12 @@ p.customize-section-description {
 	font-weight: 400;
 }
 
+#customize-notifications-area .notification-message button.switch-to-editor {
+	display: block;
+	margin-top: 6px;
+	font-weight: 400;
+}
+
 #customize-theme-controls .control-panel-themes > .accordion-section-title:after {
 	display: none;
 }

--- a/src/wp-admin/customize.php
+++ b/src/wp-admin/customize.php
@@ -222,7 +222,7 @@ do_action( 'customize_controls_head' );
 				<ul></ul>
 			</div>
 			<div class="wp-full-overlay-sidebar-content" tabindex="-1">
-				<div id="customize-info" class="accordion-section customize-info">
+				<div id="customize-info" class="accordion-section customize-info" data-block-theme="<?php echo (int) wp_is_block_theme(); ?>">
 					<div class="accordion-section-title">
 						<span class="preview-notice">
 						<?php

--- a/src/wp-admin/customize.php
+++ b/src/wp-admin/customize.php
@@ -235,7 +235,7 @@ do_action( 'customize_controls_head' );
 					<div class="customize-panel-description">
 						<p>
 							<?php
-							_e( 'The Customizer allows you to preview changes to your site before publishing them. You can navigate to different pages on your site within the preview. Edit shortcuts are shown for some editable elements.' );
+							_e( 'The Customizer allows you to preview changes to your site before publishing them. You can navigate to different pages on your site within the preview. Edit shortcuts are shown for some editable elements. The Customizer is intended for use with non-block themes.' );
 							?>
 						</p>
 						<p>

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1221,11 +1221,11 @@ function wp_default_scripts( $scripts ) {
 			'publishSettings'         => __( 'Publish Settings' ),
 			'invalidDate'             => __( 'Invalid date.' ),
 			'invalidValue'            => __( 'Invalid value.' ),
-			'blockThemeNotification'  => wp_is_block_theme() ? sprintf(
-				__( 'To get the best customization experience from your block theme, use the <a href="%s">new Site Editor</a>.' ),
+			'blockThemeNotification'  => sprintf(
 				/* translators: %s: URL to the Site Editor admin screen. */
+				__( 'To get the best customization experience from your block theme, use the <a href="%s">new Site Editor</a>.' ),
 				esc_url( admin_url( 'site-editor.php' ) )
-			) : '',
+			),
 		)
 	);
 	$scripts->add( 'customize-selective-refresh', "/wp-includes/js/customize-selective-refresh$suffix.js", array( 'jquery', 'wp-util', 'customize-preview' ), false, 1 );

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1221,6 +1221,11 @@ function wp_default_scripts( $scripts ) {
 			'publishSettings'         => __( 'Publish Settings' ),
 			'invalidDate'             => __( 'Invalid date.' ),
 			'invalidValue'            => __( 'Invalid value.' ),
+			'blockThemeNotification'  => wp_is_block_theme() ? sprintf(
+				__( 'To get the best customization experience from your block theme, use the <a href="%s">new Site Editor</a>.' ),
+				/* translators: %s: URL to the Site Editor admin screen. */
+				esc_url( admin_url( 'site-editor.php' ) )
+			) : '',
 		)
 	);
 	$scripts->add( 'customize-selective-refresh', "/wp-includes/js/customize-selective-refresh$suffix.js", array( 'jquery', 'wp-util', 'customize-preview' ), false, 1 );

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1154,7 +1154,7 @@ function wp_default_scripts( $scripts ) {
 	$scripts->add( 'customize-models', '/wp-includes/js/customize-models.js', array( 'underscore', 'backbone' ), false, 1 );
 	$scripts->add( 'customize-views', '/wp-includes/js/customize-views.js', array( 'jquery', 'underscore', 'imgareaselect', 'customize-models', 'media-editor', 'media-views' ), false, 1 );
 	$scripts->add( 'customize-controls', "/wp-admin/js/customize-controls$suffix.js", array( 'customize-base', 'wp-a11y', 'wp-util', 'jquery-ui-core' ), false, 1 );
-	$switch_to_site_editor_label = __('Switch to Site Editor');
+	$switch_to_site_editor_label = __( 'Switch to Site Editor' );
 	did_action( 'init' ) && $scripts->localize(
 		'customize-controls',
 		'_wpCustomizeControlsL10n',
@@ -1224,11 +1224,11 @@ function wp_default_scripts( $scripts ) {
 			'invalidValue'            => __( 'Invalid value.' ),
 			'blockThemeNotification'  => sprintf(
 				/* translators: 1. %s: URL to the Site Editor admin screen, 2: "Switch to Site Editor" button placeholder. */
-				__( 'To get the best customization experience from your block theme, use the Site Editor. <a href="%s" target="_blank">Tell me more</a>. %s' ),
+				__( 'To get the best customization experience from your block theme, use the Site Editor. <a href="%1$s" target="_blank">Tell me more</a>. %2$s' ),
 				'https://wordpress.org/support/article/site-editor/',
 				sprintf(
-					/* translators: 1. %s: URL to the Site Editor admin screen, 2. %s: Label for the button that takes a user to the Site Editor admin screen, 3: Same as the previous item. */
-					'<button type="button" data-action="%s" class="button switch-to-editor" aria-label="%s">%s</button>',
+					/* translators: 1. %s: URL to the Site Editor admin screen, 2. %s: Label for the button that takes a user to the Site Editor admin screen, 3: Same as the previous placeholder. */
+					'<button type="button" data-action="%1$s" class="button switch-to-editor" aria-label="%2$s">%3$s</button>',
 					esc_url( admin_url( 'site-editor.php' ) ),
 					$switch_to_site_editor_label,
 					$switch_to_site_editor_label

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1154,6 +1154,7 @@ function wp_default_scripts( $scripts ) {
 	$scripts->add( 'customize-models', '/wp-includes/js/customize-models.js', array( 'underscore', 'backbone' ), false, 1 );
 	$scripts->add( 'customize-views', '/wp-includes/js/customize-views.js', array( 'jquery', 'underscore', 'imgareaselect', 'customize-models', 'media-editor', 'media-views' ), false, 1 );
 	$scripts->add( 'customize-controls', "/wp-admin/js/customize-controls$suffix.js", array( 'customize-base', 'wp-a11y', 'wp-util', 'jquery-ui-core' ), false, 1 );
+	$switch_to_site_editor_label = __('Switch to Site Editor');
 	did_action( 'init' ) && $scripts->localize(
 		'customize-controls',
 		'_wpCustomizeControlsL10n',
@@ -1225,8 +1226,13 @@ function wp_default_scripts( $scripts ) {
 				/* translators: 1. %s: URL to the Site Editor admin screen, 2: "Switch to Site Editor" button placeholder. */
 				__( 'To get the best customization experience from your block theme, use the Site Editor. <a href="%s" target="_blank">Tell me more</a>. %s' ),
 				'https://wordpress.org/support/article/site-editor/',
-				/* translators: Button that takes a user to the Site Editor admin screen. */
-				sprintf( '<button type="button" class="button switch-to-editor" aria-label="%s">%s</button>', __('Switch to Site Editor') )
+				sprintf(
+					/* translators: 1. %s: URL to the Site Editor admin screen, 2. %s: Label for the button that takes a user to the Site Editor admin screen, 3: Same as the previous item. */
+					'<button type="button" data-action="%s" class="button switch-to-editor" aria-label="%s">%s</button>',
+					esc_url( admin_url( 'site-editor.php' ) ),
+					$switch_to_site_editor_label,
+					$switch_to_site_editor_label
+				)
 			),
 		)
 	);

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1223,7 +1223,7 @@ function wp_default_scripts( $scripts ) {
 			'invalidValue'            => __( 'Invalid value.' ),
 			'blockThemeNotification'  => sprintf(
 				/* translators: %s: URL to the Site Editor admin screen. */
-				__( 'To get the best customization experience from your block theme, use the <a href="%s">new Site Editor</a>.' ),
+				__( 'To get the best customization experience from your block theme, use the <a href="%s">Site Editor</a>.' ),
 				esc_url( admin_url( 'site-editor.php' ) )
 			),
 		)

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1154,7 +1154,7 @@ function wp_default_scripts( $scripts ) {
 	$scripts->add( 'customize-models', '/wp-includes/js/customize-models.js', array( 'underscore', 'backbone' ), false, 1 );
 	$scripts->add( 'customize-views', '/wp-includes/js/customize-views.js', array( 'jquery', 'underscore', 'imgareaselect', 'customize-models', 'media-editor', 'media-views' ), false, 1 );
 	$scripts->add( 'customize-controls', "/wp-admin/js/customize-controls$suffix.js", array( 'customize-base', 'wp-a11y', 'wp-util', 'jquery-ui-core' ), false, 1 );
-	$switch_to_site_editor_label = __( 'Switch to Site Editor' );
+	$switch_to_site_editor_label = __( 'Use Site Editor' );
 	did_action( 'init' ) && $scripts->localize(
 		'customize-controls',
 		'_wpCustomizeControlsL10n',
@@ -1224,7 +1224,7 @@ function wp_default_scripts( $scripts ) {
 			'invalidValue'            => __( 'Invalid value.' ),
 			'blockThemeNotification'  => sprintf(
 				/* translators: 1. %s: URL to the localized version of the https://wordpress.org/support/article/site-editor/ page, 2: "Switch to Site Editor" button placeholder. */
-				__( 'To get the best customization experience from your block theme, use the Site Editor. <a href="%1$s" target="_blank">Tell me more</a>. %2$s' ),
+				__( 'Hurray! Your theme supports Full Site Editing with blocks. <a href="%1$s" target="_blank">Tell me more</a>. %2$s' ),
 				__( 'https://wordpress.org/support/article/site-editor/' ),
 				sprintf(
 					/* translators: 1. %s: URL to the Site Editor admin screen, 2. %s: Label for the button that takes a user to the Site Editor admin screen, 3: Same as the previous placeholder. */

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1223,9 +1223,9 @@ function wp_default_scripts( $scripts ) {
 			'invalidDate'             => __( 'Invalid date.' ),
 			'invalidValue'            => __( 'Invalid value.' ),
 			'blockThemeNotification'  => sprintf(
-				/* translators: 1. %s: URL to the Site Editor admin screen, 2: "Switch to Site Editor" button placeholder. */
+				/* translators: 1. %s: URL to the localized version of the https://wordpress.org/support/article/site-editor/ page, 2: "Switch to Site Editor" button placeholder. */
 				__( 'To get the best customization experience from your block theme, use the Site Editor. <a href="%1$s" target="_blank">Tell me more</a>. %2$s' ),
-				'https://wordpress.org/support/article/site-editor/',
+				__( 'https://wordpress.org/support/article/site-editor/' ),
 				sprintf(
 					/* translators: 1. %s: URL to the Site Editor admin screen, 2. %s: Label for the button that takes a user to the Site Editor admin screen, 3: Same as the previous placeholder. */
 					'<button type="button" data-action="%1$s" class="button switch-to-editor" aria-label="%2$s">%3$s</button>',

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1222,9 +1222,11 @@ function wp_default_scripts( $scripts ) {
 			'invalidDate'             => __( 'Invalid date.' ),
 			'invalidValue'            => __( 'Invalid value.' ),
 			'blockThemeNotification'  => sprintf(
-				/* translators: %s: URL to the Site Editor admin screen. */
-				__( 'To get the best customization experience from your block theme, use the <a href="%s">Site Editor</a>.' ),
-				esc_url( admin_url( 'site-editor.php' ) )
+				/* translators: 1. %s: URL to the Site Editor admin screen, 2: "Switch to Site Editor" button placeholder. */
+				__( 'To get the best customization experience from your block theme, use the Site Editor. <a href="%s" target="_blank">Tell me more</a>. %s' ),
+				'https://wordpress.org/support/article/site-editor/',
+				/* translators: Button that takes a user to the Site Editor admin screen. */
+				sprintf( '<button type="button" class="button switch-to-editor" aria-label="%s">%s</button>', __('Switch to Site Editor') )
 			),
 		)
 	);


### PR DESCRIPTION
We must warn users that block themes are supposed to be edited with the Site Editor.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/54939

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
