### PR TITLE
POC for multi-mime support

### DIFF
--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -444,7 +444,6 @@ function _wp_make_subsizes( $new_sizes, $file, $image_meta, $attachment_id ) {
 	$output_mime_types = apply_filters( 'wp_mime_output_types', array( 'image/jpeg' ), $file );
 	$additional_mime_sizes = array();
 	foreach ( $output_mime_types as $mime_type ) {
-
 		if ( method_exists( $editor, 'make_subsize' ) ) {
 			foreach ( $new_sizes as $new_size_name => $new_size_data ) {
 				$new_size_meta = $editor->make_subsize( $new_size_data, $mime_type );
@@ -453,10 +452,11 @@ function _wp_make_subsizes( $new_sizes, $file, $image_meta, $attachment_id ) {
 					// TODO: Log errors.
 				} else {
 					// Save the size meta value.
-					$image_meta['sizes'][ $new_size_name ] = $new_size_meta;
 					if ( $mime_type !== $file_mime_type ) {
 						$new_meta_name = $new_size_name . '_' . str_replace( '/', '_', $mime_type );
 						$image_meta['sizes'][ $new_meta_name ] = $new_size_meta;
+					} else {
+						$image_meta['sizes'][ $new_size_name ] = $new_size_meta;
 					}
 					wp_update_attachment_metadata( $attachment_id, $image_meta );
 				}

--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -441,7 +441,7 @@ function _wp_make_subsizes( $new_sizes, $file, $image_meta, $attachment_id ) {
 		}
 	}
 
-	$output_mime_types = apply_filters( 'wp_mime_output_types', array( 'image/jpeg' ), $file );
+	$output_mime_types = apply_filters( 'wp_mime_output_types', array( $file_mime_type ), $file );
 	$additional_mime_sizes = array();
 	foreach ( $output_mime_types as $mime_type ) {
 		if ( method_exists( $editor, 'make_subsize' ) ) {

--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -425,7 +425,7 @@ function _wp_make_subsizes( $new_sizes, $file, $image_meta, $attachment_id ) {
 	$new_sizes = array_filter( array_merge( $priority, $new_sizes ) );
 
 	$editor = wp_get_image_editor( $file );
-	$file_mime_type = wp_get_image_mime( $file );
+	$file_mime_type = wp_get_image_mime( $file ) || 'image/jpeg';
 
 	if ( is_wp_error( $editor ) ) {
 		// The image cannot be edited.
@@ -453,11 +453,10 @@ function _wp_make_subsizes( $new_sizes, $file, $image_meta, $attachment_id ) {
 				} else {
 					// Save the size meta value.
 					if ( $mime_type !== $file_mime_type ) {
-						$new_meta_name = $new_size_name . '_' . str_replace( '/', '_', $mime_type );
-						$image_meta['sizes'][ $new_meta_name ] = $new_size_meta;
-					} else {
-						$image_meta['sizes'][ $new_size_name ] = $new_size_meta;
+						$new_size_name = $new_size_name . '_' . str_replace( '/', '_', $mime_type );
 					}
+					$image_meta['sizes'][ $new_size_name ] = $new_size_meta;
+
 					wp_update_attachment_metadata( $attachment_id, $image_meta );
 				}
 			}

--- a/src/wp-includes/class-wp-image-editor-gd.php
+++ b/src/wp-includes/class-wp-image-editor-gd.php
@@ -241,13 +241,14 @@ class WP_Image_Editor_GD extends WP_Image_Editor {
 	 *         @type bool $crop   Optional. Whether to crop the image. Default false.
 	 *     }
 	 * }
+	 * @param string $mime_type Optional. The mime-type. Default null. Added in 6.0.
 	 * @return array An array of resized images' metadata by size.
 	 */
-	public function multi_resize( $sizes ) {
+	public function multi_resize( $sizes, $mime_type = null ) {
 		$metadata = array();
 
 		foreach ( $sizes as $size => $size_data ) {
-			$meta = $this->make_subsize( $size_data );
+			$meta = $this->make_subsize( $size_data, $mime_type );
 
 			if ( ! is_wp_error( $meta ) ) {
 				$metadata[ $size ] = $meta;
@@ -269,10 +270,11 @@ class WP_Image_Editor_GD extends WP_Image_Editor {
 	 *     @type int  $height The maximum height in pixels.
 	 *     @type bool $crop   Whether to crop the image to exact dimensions.
 	 * }
+	 * @param string $mime_type Optional. The mime-type. Default null. Added in 6.0.
 	 * @return array|WP_Error The image data array for inclusion in the `sizes` array in the image meta,
 	 *                        WP_Error object on error.
 	 */
-	public function make_subsize( $size_data ) {
+	public function make_subsize( $size_data, $mime_type = null ) {
 		if ( ! isset( $size_data['width'] ) && ! isset( $size_data['height'] ) ) {
 			return new WP_Error( 'image_subsize_create_error', __( 'Cannot resize the image. Both width and height are not set.' ) );
 		}
@@ -296,7 +298,7 @@ class WP_Image_Editor_GD extends WP_Image_Editor {
 		if ( is_wp_error( $resized ) ) {
 			$saved = $resized;
 		} else {
-			$saved = $this->_save( $resized );
+			$saved = $this->_save( $resized, null, $mime_type );
 			imagedestroy( $resized );
 		}
 

--- a/src/wp-includes/class-wp-image-editor-imagick.php
+++ b/src/wp-includes/class-wp-image-editor-imagick.php
@@ -452,13 +452,14 @@ class WP_Image_Editor_Imagick extends WP_Image_Editor {
 	 *         @type bool $crop   Optional. Whether to crop the image. Default false.
 	 *     }
 	 * }
+	 * @param string $mime_type Optional. The mime-type. Default null. Added in 6.0.
 	 * @return array An array of resized images' metadata by size.
 	 */
-	public function multi_resize( $sizes ) {
+	public function multi_resize( $sizes, $mime_type = null ) {
 		$metadata = array();
 
 		foreach ( $sizes as $size => $size_data ) {
-			$meta = $this->make_subsize( $size_data );
+			$meta = $this->make_subsize( $size_data, $mime_type );
 
 			if ( ! is_wp_error( $meta ) ) {
 				$metadata[ $size ] = $meta;
@@ -480,10 +481,11 @@ class WP_Image_Editor_Imagick extends WP_Image_Editor {
 	 *     @type int  $height The maximum height in pixels.
 	 *     @type bool $crop   Whether to crop the image to exact dimensions.
 	 * }
+	 * @param string $mime_type Optional. The mime-type. Default null. Added in 6.0.
 	 * @return array|WP_Error The image data array for inclusion in the `sizes` array in the image meta,
 	 *                        WP_Error object on error.
 	 */
-	public function make_subsize( $size_data ) {
+	public function make_subsize( $size_data, $mime_type = null ) {
 		if ( ! isset( $size_data['width'] ) && ! isset( $size_data['height'] ) ) {
 			return new WP_Error( 'image_subsize_create_error', __( 'Cannot resize the image. Both width and height are not set.' ) );
 		}
@@ -508,7 +510,7 @@ class WP_Image_Editor_Imagick extends WP_Image_Editor {
 		if ( is_wp_error( $resized ) ) {
 			$saved = $resized;
 		} else {
-			$saved = $this->_save( $this->image );
+			$saved = $this->_save( $this->image, null, $mime_type );
 
 			$this->image->clear();
 			$this->image->destroy();

--- a/src/wp-includes/class-wp-image-editor.php
+++ b/src/wp-includes/class-wp-image-editor.php
@@ -115,9 +115,10 @@ abstract class WP_Image_Editor {
 	 *         @type bool $crop   Optional. Whether to crop the image. Default false.
 	 *     }
 	 * }
+	 * @param string $mime_type Optional. The mime-type. Default null. Added in 6.0.
 	 * @return array An array of resized images metadata by size.
 	 */
-	abstract public function multi_resize( $sizes );
+	abstract public function multi_resize( $sizes, $mime_type = null );
 
 	/**
 	 * Crops Image.

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -1236,12 +1236,13 @@ function wp_get_attachment_image_srcset( $attachment_id, $size = 'medium', $imag
  *     @type int $0 The width in pixels.
  *     @type int $1 The height in pixels.
  * }
- * @param string $image_src     The 'src' of the image.
- * @param array  $image_meta    The image meta data as returned by 'wp_get_attachment_metadata()'.
+ * @param string $image_src               The 'src' of the image.
+ * @param array  $image_meta              The image meta data as returned by 'wp_get_attachment_metadata()'.
  * @param int    $attachment_id Optional. The image attachment ID. Default 0.
+ * @param string $mime_type Optional.     The mime-type to use for srcset. Default null. Added in 6.0.
  * @return string|false The 'srcset' attribute value. False on error or when only one source exists.
  */
-function wp_calculate_image_srcset( $size_array, $image_src, $image_meta, $attachment_id = 0 ) {
+function wp_calculate_image_srcset( $size_array, $image_src, $image_meta, $attachment_id = 0, $mime_type = false ) {
 	/**
 	 * Let plugins pre-filter the image meta to be able to fix inconsistencies in the stored data.
 	 *
@@ -1264,6 +1265,13 @@ function wp_calculate_image_srcset( $size_array, $image_src, $image_meta, $attac
 	}
 
 	$image_sizes = $image_meta['sizes'];
+
+	// Only include a single mime type in the srcset. Uses the passed mime_type,
+	// Or the original file mime type if mime_type is not passed.
+	if ( ! $mime_type ) {
+		$mime_type = wp_get_image_mime( wp_get_original_image_path( $attachment_id ) );
+	}
+	$image_sizes = array_filter( $image_sizes, function( $size ) use ( $mime_type ) { return $size['mime-type'] == $mime_type; } );
 
 	// Get the width and height of the image.
 	$image_width  = (int) $size_array[0];


### PR DESCRIPTION
This POC enables multiple mime output support.

To test, install this mini plugin that adds `images/webp` to the output formats using the new `image_editor_output_formats` filter:

https://gist.github.com/adamsilverstein/7b9a294f6bdb58a2bcd0d5ee47ec3860

After uploading a large image, WordPress will generate image sub sizes for all sizes in each mime type returned from the `image_editor_output_formats` filter.  Better name suggestions for the filter welcome!

* The `image_editor_output_formats` value should is a mime-type keyed array, so each input type can have one or more output types. this can essentially replace `image_editor_output_format` and would enable control of output for each upload format

* `wp_calculate_image_srcset` now takes a mime type parameter (falling back to the original image mime type). a `picture` element implementation can call this function repeatedly for each mime type source definition. for now, output only uses this default mime type.
 

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
