### PR TITLE
Update theme URI

### DIFF
--- a/src/wp-content/themes/twentytwentytwo/style.css
+++ b/src/wp-content/themes/twentytwentytwo/style.css
@@ -1,6 +1,6 @@
 /*
 Theme Name: Twenty Twenty-Two
-Theme URI: https://github.com/wordpress/twentytwentytwo/
+Theme URI: https://wordpress.org/themes/twentytwentytwo/
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Built on a solidly designed foundation, Twenty Twenty-Two embraces the idea that everyone deserves a truly unique website. The theme’s subtle styles are inspired by the diversity and versatility of birds: its typography is lightweight yet strong, its color palette is drawn from nature, and its layout elements sit gently on the page. The true richness of Twenty Twenty-Two lies in its opportunity for customization. The theme is built to take advantage of the Full Site Editing features introduced in WordPress 5.9, which means that colors, typography, and the layout of every single page on your site can be customized to suit your vision. It also includes dozens of block patterns, opening the door to a wide range of professionally designed layouts in just a few clicks. Whether you’re building a single-page website, a blog, a business website, or a portfolio, Twenty Twenty-Two will help you create a site that is uniquely yours.


### PR DESCRIPTION
The current theme URI is GitHub. This PR will change it to org link.

Core ticket: https://core.trac.wordpress.org/ticket/55018