### PR TITLE
Add `block-templates` and `wp_is_block_theme()` check to `get_query_template()`.

### DIFF
--- a/src/wp-includes/template.php
+++ b/src/wp-includes/template.php
@@ -63,7 +63,9 @@ function get_query_template( $type, $templates = array() ) {
 
 	$template = locate_template( $templates );
 
-	$template = locate_block_template( $template, $type, $templates );
+	if ( wp_is_block_theme() ) {
+		$template = locate_block_template( $template, $type, $templates );
+	}
 
 	/**
 	 * Filters the path of the queried template by type.

--- a/src/wp-includes/template.php
+++ b/src/wp-includes/template.php
@@ -63,7 +63,7 @@ function get_query_template( $type, $templates = array() ) {
 
 	$template = locate_template( $templates );
 
-	if ( wp_is_block_theme() ) {
+	if ( get_theme_support( 'block-templates' ) || wp_is_block_theme() ) {
 		$template = locate_block_template( $template, $type, $templates );
 	}
 


### PR DESCRIPTION
Check that the theme supports `block-templates` or is a block theme before calling `locate_block_template()` in `get_query_template()`.

This change:
- improves performance for classic themes by removing unnecessary database queries.
- fixes an issue where a classic theme would show "Empty template: Index" on the frontend when an empty `(block-)templates/index.html` file exists.

Trac ticket: https://core.trac.wordpress.org/ticket/54844
