### PR TITLE
`_wp_normalize_relative_css_links()`: Do not normalize a HTML ID.

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2770,7 +2770,7 @@ function _wp_normalize_relative_css_links( $css, $stylesheet_url ) {
 				continue;
 			}
 
-			// Skip if the URL is a HTML ID.
+			// Skip if the URL is an HTML ID.
 			if ( str_starts_with( $src_result, '#' ) ) {
 				continue;
 			}

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2770,6 +2770,11 @@ function _wp_normalize_relative_css_links( $css, $stylesheet_url ) {
 				continue;
 			}
 
+			// Skip if the URL is a HTML ID.
+			if ( str_starts_with( $src_result, '#' ) ) {
+				continue;
+			}
+
 			// Build the absolute URL.
 			$absolute_url = dirname( $stylesheet_url ) . '/' . $src_result;
 			$absolute_url = str_replace( '/./', '/', $absolute_url );

--- a/tests/phpunit/tests/dependencies/styles.php
+++ b/tests/phpunit/tests/dependencies/styles.php
@@ -232,7 +232,7 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 				'css'      => 'p {background-image: url(\'http://foo.com/image2.png\');}',
 				'expected' => 'p {background-image: url(\'http://foo.com/image2.png\');}',
 			),
-			'a HTML ID'                                    => array(
+			'An HTML ID'                                    => array(
 				'css'      => 'clip-path: url(#image1);',
 				'expected' => 'clip-path: url(#image1);',
 			),

--- a/tests/phpunit/tests/dependencies/styles.php
+++ b/tests/phpunit/tests/dependencies/styles.php
@@ -195,6 +195,7 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 	 * @dataProvider data_normalize_relative_css_links
 	 *
 	 * @ticket 54243
+	 * @ticket 54922
 	 *
 	 * @covers ::_wp_normalize_relative_css_links
 	 *

--- a/tests/phpunit/tests/dependencies/styles.php
+++ b/tests/phpunit/tests/dependencies/styles.php
@@ -231,6 +231,10 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 				'css'      => 'p {background-image: url(\'http://foo.com/image2.png\');}',
 				'expected' => 'p {background-image: url(\'http://foo.com/image2.png\');}',
 			),
+			'a HTML ID'                                    => array(
+				'css'      => 'clip-path: url(#image1);',
+				'expected' => 'clip-path: url(#image1);',
+			),
 		);
 	}
 

--- a/tests/phpunit/tests/dependencies/styles.php
+++ b/tests/phpunit/tests/dependencies/styles.php
@@ -232,7 +232,7 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 				'css'      => 'p {background-image: url(\'http://foo.com/image2.png\');}',
 				'expected' => 'p {background-image: url(\'http://foo.com/image2.png\');}',
 			),
-			'An HTML ID'                                    => array(
+			'An HTML ID'                                   => array(
 				'css'      => 'clip-path: url(#image1);',
 				'expected' => 'clip-path: url(#image1);',
 			),


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/54922