### PR TITLE
pomo/streams: use stream_get_contents() in read_all()

### DIFF
--- a/src/wp-admin/includes/class-wp-filesystem-direct.php
+++ b/src/wp-admin/includes/class-wp-filesystem-direct.php
@@ -606,10 +606,6 @@ class WP_Filesystem_Direct extends WP_Filesystem_Base {
 			$limit_file = false;
 		}
 
-		if ( ! $this->is_dir( $path ) || ! $this->is_readable( $path ) ) {
-			return false;
-		}
-
 		$dir = dir( $path );
 
 		if ( ! $dir ) {

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -3227,12 +3227,7 @@ function wp_get_image_mime( $file ) {
 			return $mime;
 		}
 
-		$handle = fopen( $file, 'rb' );
-		if ( false === $handle ) {
-			return false;
-		}
-
-		$magic = fread( $handle, 12 );
+		$magic = file_get_contents( $file, false, null, 0, 12 );
 		if ( false === $magic ) {
 			return false;
 		}
@@ -3251,8 +3246,6 @@ function wp_get_image_mime( $file ) {
 		) {
 			$mime = 'image/webp';
 		}
-
-		fclose( $handle );
 	} catch ( Exception $e ) {
 		$mime = false;
 	}

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -6528,16 +6528,10 @@ function wp_scheduled_delete() {
  * @return string[] Array of file header values keyed by header name.
  */
 function get_file_data( $file, $default_headers, $context = '' ) {
-	// We don't need to write to the file, so just open for reading.
-	$fp = fopen( $file, 'r' );
+	// Pull only the first 8 KB of the file in.
+	$file_data = file_get_contents( $file, false, null, 0, 8192 );
 
-	if ( $fp ) {
-		// Pull only the first 8 KB of the file in.
-		$file_data = fread( $fp, 8 * KB_IN_BYTES );
-
-		// PHP will close file handle, but we are good citizens.
-		fclose( $fp );
-	} else {
+	if ( false === $file_data ) {
 		$file_data = '';
 	}
 

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -5133,11 +5133,8 @@ function wp_get_webp_info( $filename ) {
 	}
 
 	try {
-		$handle = fopen( $filename, 'rb' );
-		if ( $handle ) {
-			$magic = fread( $handle, 40 );
-			fclose( $handle );
-
+		$magic = file_get_contents( $filename, false, null, 0, 40 );
+		if ( false !== $magic ) {
 			// Make sure we got enough bytes.
 			if ( strlen( $magic ) < 40 ) {
 				return compact( 'width', 'height', 'type' );

--- a/src/wp-includes/pomo/streams.php
+++ b/src/wp-includes/pomo/streams.php
@@ -217,11 +217,7 @@ if ( ! class_exists( 'POMO_FileReader', false ) ) :
 		 * @return string
 		 */
 		public function read_all() {
-			$all = '';
-			while ( ! $this->feof() ) {
-				$all .= $this->read( 4096 );
-			}
-			return $all;
+			return stream_get_contents( $this->_f );
 		}
 	}
 endif;


### PR DESCRIPTION
stream_get_contents() is faster, because the PHP core can decide how
to best read the reamining file; it could decide to issue just one
read() call or mmap() the file first.

The old chunk size of 4 kB was rather clumsy, because it is smaller
than PHP's default stream buffer size of 8 kB.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/55069

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
