### PR TITLE
Fix Widget Group markup

### DIFF
--- a/src/wp-includes/blocks/index.php
+++ b/src/wp-includes/blocks/index.php
@@ -48,6 +48,7 @@ require ABSPATH . WPINC . '/blocks/social-link.php';
 require ABSPATH . WPINC . '/blocks/tag-cloud.php';
 require ABSPATH . WPINC . '/blocks/template-part.php';
 require ABSPATH . WPINC . '/blocks/term-description.php';
+require ABSPATH . WPINC . '/blocks/widget-group.php';
 
 /**
  * Registers core block types using metadata files.

--- a/tests/phpunit/includes/functions.php
+++ b/tests/phpunit/includes/functions.php
@@ -346,5 +346,6 @@ function _unhook_block_registration() {
 	remove_action( 'init', 'register_block_core_template_part' );
 	remove_action( 'init', 'register_block_core_term_description' );
 	remove_action( 'init', 'register_core_block_types_from_metadata' );
+	remove_action( 'init', 'register_block_core_widget_group' );
 }
 tests_add_filter( 'init', '_unhook_block_registration', 1000 );


### PR DESCRIPTION
The Widget Group block was missing a `<div class="wp-widget-group__inner-blocks">` container when rendered on the frontend. This is because the block's PHP file was not included and so the block was defaulting to what is returned by the block's `save()` function.

To test:

1. Activate a classic theme.
1. Go to Appearance → Widgets.
1. Insert a Widget Group block.
1. Add some content into the group and set a title.
1. Save.
1. View the website frontend.
1. You should see `<div class="wp-widget-group__inner-blocks">` in the markup.

Trac ticket: https://core.trac.wordpress.org/ticket/55072

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
