### PR TITLE
#54895 - Hide mobile button labels but keep it visible for screen readers.

### DIFF
--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -795,7 +795,17 @@ html:lang(he-il) .rtl #wpadminbar * {
 	}
 
 	#wpadminbar .ab-label {
-		display: none;
+		border: 0;
+		clip: rect(1px, 1px, 1px, 1px);
+		-webkit-clip-path: inset(50%);
+		clip-path: inset(50%);
+		height: 1px;
+		margin: -1px;
+		overflow: hidden;
+		padding: 0;
+		position: absolute;
+		width: 1px;
+		word-wrap: normal !important;
 	}
 
 	#wpadminbar .menupop li:hover > .ab-sub-wrapper,


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/54895

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
