### PR TITLE
TwentyTwenty: Fix button outlines for WP 5.9

### DIFF
--- a/src/wp-content/themes/twentytwenty/style.css
+++ b/src/wp-content/themes/twentytwenty/style.css
@@ -3034,6 +3034,7 @@ h2.entry-title {
 
 .is-style-outline .wp-block-button__link {
 	padding: calc(1.1em - 0.2rem) calc(1.44em - 0.2rem);
+	border: 2px solid;
 }
 
 /* Block: Columns ---------------------------- */


### PR DESCRIPTION
Fix button outlines for WP 5.9

Trac ticket: https://core.trac.wordpress.org/ticket/54919
