### PR TITLE
TwentyFifteen: Fix button outlines for WP 5.9

### DIFF
--- a/src/wp-content/themes/twentyfifteen/css/blocks.css
+++ b/src/wp-content/themes/twentyfifteen/css/blocks.css
@@ -395,6 +395,10 @@ p.has-drop-cap:not(:focus)::first-letter {
 	vertical-align: baseline;
 }
 
+.entry-content .wp-block-button .wp-block-button__link {
+	border: 2px solid;
+}
+
 .entry-content .wp-block-button:not(.is-style-outline) .wp-block-button__link {
 	border: 0;
 }


### PR DESCRIPTION
Fix button outlines for WP 5.9 (TwentyFifteen)
Trac ticket: https://core.trac.wordpress.org/ticket/54919