### PR TITLE
[Twenty Twenty-Two] Restore custom padding for group blocks with a background color

### DIFF
--- a/src/wp-content/themes/twentytwentytwo/style.css
+++ b/src/wp-content/themes/twentytwentytwo/style.css
@@ -99,6 +99,7 @@ a:active {
 body > .is-root-container,
 .edit-post-visual-editor__post-title-wrapper,
 .wp-block-group.alignfull,
+.wp-block-group.has-background,
 .wp-block-cover.alignfull,
 .is-root-container .wp-block[data-align="full"] > .wp-block-group,
 .is-root-container .wp-block[data-align="full"] > .wp-block-cover {


### PR DESCRIPTION
Restores the padding rule removed in https://github.com/WordPress/wordpress-develop/pull/2281. 

---

**Site Editor**

Before|After
---|---
<img width="1440" alt="before-site-editor" src="https://user-images.githubusercontent.com/1202812/152797344-95568916-74a9-48bb-9c90-db4516f8902a.png">|<img width="1440" alt="after-site-editor" src="https://user-images.githubusercontent.com/1202812/152797347-5f7be620-516b-47ed-937d-db5d403eb812.png">

**Post/Page Editor**

Before|After
---|---
<img width="1440" alt="before-post-editor" src="https://user-images.githubusercontent.com/1202812/152797323-d84d407c-39f2-47fc-b3ac-b0b30c8dc058.png">|<img width="1440" alt="after-post-editor" src="https://user-images.githubusercontent.com/1202812/152797324-163b6e1e-d837-4c06-82fd-ccb5dacae998.png">

Trac ticket: https://core.trac.wordpress.org/ticket/55103

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
