### PR TITLE
Fix `.block-editor-writing-flow` selector in Twenty Nineteen

### DIFF
--- a/src/wp-content/themes/twentynineteen/style-editor.css
+++ b/src/wp-content/themes/twentynineteen/style-editor.css
@@ -605,6 +605,7 @@ body .wp-block.aligncenter {
 }
 
 @media only screen and (min-width: 768px) {
+  body.block-editor-writing-flow,
   body .block-editor-writing-flow {
     max-width: 80%;
     margin: 0 10%;

--- a/src/wp-content/themes/twentynineteen/style-editor.scss
+++ b/src/wp-content/themes/twentynineteen/style-editor.scss
@@ -36,6 +36,7 @@ body {
 
 	@include media(tablet) {
 
+		&.block-editor-writing-flow,
 		.block-editor-writing-flow {
 			max-width: 80%;
 			margin: 0 10%;


### PR DESCRIPTION
Apply `max-width` and margin when `block-editor-writing-flow` and `editor-styles-wrapper` classes are on the same element.

Trac ticket: https://core.trac.wordpress.org/ticket/54169

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
