### PR TITLE
WP_REST_Global_Styles_Controller : fixing syntax to access object keys.

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-controller.php
@@ -263,15 +263,15 @@ class WP_REST_Global_Styles_Controller extends WP_REST_Controller {
 			}
 		}
 
-		if ( isset( $request['styles'] ) || isset( $request['settings'] ) ) {
+		if ( isset( $request->styles ) || isset( $request->settings ) ) {
 			$config = array();
-			if ( isset( $request['styles'] ) ) {
-				$config['styles'] = $request['styles'];
+			if ( isset( $request->styles ) ) {
+				$config['styles'] = $request->styles;
 			} elseif ( isset( $existing_config['styles'] ) ) {
 				$config['styles'] = $existing_config['styles'];
 			}
-			if ( isset( $request['settings'] ) ) {
-				$config['settings'] = $request['settings'];
+			if ( isset( $request->settings ) ) {
+				$config['settings'] = $request->settings;
 			} elseif ( isset( $existing_config['settings'] ) ) {
 				$config['settings'] = $existing_config['settings'];
 			}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
We are treating the $request variable as an array when it is an object, so we need to change the way we access their properties.

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->
https://core.trac.wordpress.org/ticket/55130#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
