### PR TITLE
Removing PHP4 backward compatibility in do_action()

### DIFF
--- a/src/wp-includes/plugin.php
+++ b/src/wp-includes/plugin.php
@@ -466,9 +466,6 @@ function do_action( $hook_name, ...$arg ) {
 
 	if ( empty( $arg ) ) {
 		$arg[] = '';
-	} elseif ( is_array( $arg[0] ) && 1 === count( $arg[0] ) && isset( $arg[0][0] ) && is_object( $arg[0][0] ) ) {
-		// Backward compatibility for PHP4-style passing of `array( &$this )` as action `$arg`.
-		$arg[0] = $arg[0][0];
 	}
 
 	$wp_filter[ $hook_name ]->do_action( $arg );


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/55133

Removing the PHP4 backward-compatibility in the do_action() function to avoid unexpected behaviour where the first argument is an array of a single object, as it's currently flattened and become a variable containing the single object.

Trac ticket: [[<!-- insert a link to the WordPress Trac ticket here -->](https://core.trac.wordpress.org/ticket/55133)](https://core.trac.wordpress.org/ticket/55133)
