### PR TITLE
imgAreaSelect: Fix doResize without initialized values

### DIFF
--- a/src/js/_enqueues/vendor/imgareaselect/jquery.imgareaselect.js
+++ b/src/js/_enqueues/vendor/imgareaselect/jquery.imgareaselect.js
@@ -430,6 +430,13 @@ $.imgAreaSelect = function (img, options) {
     function doUpdate(resetKeyPress) {
         adjust();
         update(resetKeyPress);
+        updateSelectionRelativeToParentElement();
+    }
+
+    /**
+     * Set the correct values of x1, y1, x2, and y2.
+     */
+    function updateSelectionRelativeToParentElement() {
         x1 = viewX(selection.x1); y1 = viewY(selection.y1);
         x2 = viewX(selection.x2); y2 = viewY(selection.y2);
     }
@@ -589,6 +596,14 @@ $.imgAreaSelect = function (img, options) {
      * aspect ratio
      */
     function doResize() {
+        /**
+         * Make sure x1, x2, y1, y2 are initialized to avoid the following calculation
+         * getting incorrect results.
+         */
+        if ( x1 == null || x2 == null || y1 == null || y2 == null ) {
+            updateSelectionRelativeToParentElement();
+        }
+
         /*
          * Make sure the top left corner of the selection area stays within
          * image boundaries (it might not if the image source was dynamically


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/54308#ticket

Fixes https://github.com/Automattic/wp-calypso/issues/52182

If the [doResize](https://github.com/WordPress/wordpress-develop/blob/968b3fc5a4aa9871ce8654b48502f8710fc804a1/src/js/_enqueues/vendor/imgareaselect/jquery.imgareaselect.js#L328) is called without initialized the x1, x2, y1 and y2 values, it causes [x1 is NaN](https://github.com/WordPress/wordpress-develop/blob/968b3fc5a4aa9871ce8654b48502f8710fc804a1/src/js/_enqueues/vendor/imgareaselect/jquery.imgareaselect.js#L597) and then the selection area would be wrong.

Why do `doResize` call at the beginning? As `imgAreaSelect` uses `Math.round` for calculation and the height/width of image is non-integer, it will make the following condition becomes true
```js
// If imgWidth is 1448.95, selection.x2 will be 1449 so that the doResize() is triggered before x1, x2, y1, y2 are initialized
if (selection.x2 > imgWidth || selection.y2 > imgHeight) {
  doResize();
}
```

Thus, https://github.com/WordPress/wordpress-develop/pull/1774 replacing `Math.round` with `Math.floor` fixes the issue.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
