### PR TITLE
Always load global styles in head for block themes

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2307,7 +2307,9 @@ function wp_common_block_scripts_and_styles() {
  * @since 5.8.0
  */
 function wp_enqueue_global_styles() {
-	$separate_assets = wp_should_load_separate_core_block_assets();
+	$separate_assets  = wp_should_load_separate_core_block_assets();
+	$is_block_theme   = wp_is_block_theme();
+	$is_classic_theme = ! $is_block_theme;
 
 	/*
 	 * Global styles should be printed in the head when loading all styles combined.
@@ -2315,7 +2317,11 @@ function wp_enqueue_global_styles() {
 	 *
 	 * See https://core.trac.wordpress.org/ticket/53494.
 	 */
-	if ( ( ! $separate_assets && doing_action( 'wp_footer' ) ) || ( $separate_assets && doing_action( 'wp_enqueue_scripts' ) ) ) {
+	if (
+		( $is_block_theme && doing_action( 'wp_footer' ) ) ||
+		( $is_classic_theme && doing_action( 'wp_footer' ) && ! $separate_assets ) ||
+		( $is_classic_theme && doing_action( 'wp_enqueue_scripts' ) && $separate_assets )
+	) {
 		return;
 	}
 


### PR DESCRIPTION
Trac ticket https://core.trac.wordpress.org/ticket/55148
Backports https://github.com/WordPress/gutenberg/pull/38745

In the linked trac ticket we added some logic to load the global stylesheet in the bottom of `<body>` for classic themes that opted-in into loading individual block styles instead of a single stylesheet for them all. At the time, block themes always loaded the global stylesheet in the `<head>`.

When block themes landed in core during the WordPress 5.9 this logic wasn't updated to consider them, hence the global stylesheet loaded in the `<body>` for them. This PR fixes this.

## How to test

- Block theme: load a site using TwentyTwentyTwo and verify that the `global-styles-inline-css` embedded stylesheet is loaded in the `<head>`.
- Classic theme that doesn't opt in into `should_load_separate_core_block_assets`: load a site using TwentyTwenty and verify that the `global-styles-inline-css` embedded stylesheet is loaded in the `<head>`.
- Classic theme that opts-in into `should_load_separate_core_block_assets`:
  - Use TwentyTwenty.
  - Add `add_filter( 'should_load_separate_core_block_assets', '__return_true' );` to its `functions.php`.
  - Load the site and verify that the `global-styles-inline-css` is loaded at the bottom of the `<body>`.
