### PR TITLE
Twenty Seventeen: Remove box-shadow from linked images

### DIFF
--- a/src/wp-content/themes/twentyseventeen/assets/css/blocks.css
+++ b/src/wp-content/themes/twentyseventeen/assets/css/blocks.css
@@ -60,6 +60,12 @@ p.has-drop-cap:not(:focus)::first-letter {
 	margin-left: 1.5em;
 }
 
+.wp-block-image a,
+.wp-block-image a:hover,
+.wp-block-image a:focus {
+	box-shadow: none;
+}
+
 /* Gallery */
 
 .wp-block-gallery {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This fixes a small bug in the Twenty Seventeen theme, where transparent linked images were showing a bottom border incorrectly (via a box-shadow).

This has previously been fixed over in the themes repo, so this PR replicates the fix in Core.

Original themes issue: https://github.com/Automattic/themes/issues/5018

Trac ticket: https://core.trac.wordpress.org/ticket/55141

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
