### PR TITLE
Allow blocks to set their own gap in theme.json

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -198,7 +198,7 @@ class WP_Theme_JSON {
 		'padding-right'              => array( 'spacing', 'padding', 'right' ),
 		'padding-bottom'             => array( 'spacing', 'padding', 'bottom' ),
 		'padding-left'               => array( 'spacing', 'padding', 'left' ),
-		'--wp--style--block-gap'     => array( 'spacing', 'blockGap' ),
+		'gap'                        => array( 'spacing', 'blockGap' ),
 		'text-decoration'            => array( 'typography', 'textDecoration' ),
 		'text-transform'             => array( 'typography', 'textTransform' ),
 		'filter'                     => array( 'filter', 'duotone' ),
@@ -317,7 +317,7 @@ class WP_Theme_JSON {
 		'spacing'    => array(
 			'margin'   => null,
 			'padding'  => null,
-			'blockGap' => 'top',
+			'blockGap' => null,
 		),
 		'typography' => array(
 			'fontFamily'     => null,
@@ -826,6 +826,7 @@ class WP_Theme_JSON {
 
 				$has_block_gap_support = _wp_array_get( $this->theme_json, array( 'settings', 'spacing', 'blockGap' ) ) !== null;
 				if ( $has_block_gap_support ) {
+					$block_rules .= 'body { --wp--style--block-gap: ' . _wp_array_get( $this->theme_json, array( 'styles', 'spacing', 'blockGap' ) ) . ';}';
 					$block_rules .= '.wp-site-blocks > * { margin-top: 0; margin-bottom: 0; }';
 					$block_rules .= '.wp-site-blocks > * + * { margin-top: var( --wp--style--block-gap ); }';
 				}


### PR DESCRIPTION
This is an update to https://github.com/WordPress/gutenberg/pull/37360 which attempts to allow blocks to still set their own values for `gap` while still using the `--wp--style--block-gap` variable at the root level.

To test, use a theme that sets a custom blockGap for a block (for example Skatepark has a custom blockGap for the navigation block). Check that:

- The navigation block uses the custom gap specified in theme.json
- The `--wp--style--block-gap` is still defined
- Try setting a custom gap on a columns block and confirm that the space between blocks isn't affected (https://github.com/WordPress/gutenberg/issues/36521).

