### PR TITLE
Fixed link validation in the TinyMCE editor.

### DIFF
--- a/src/js/_enqueues/vendor/tinymce/plugins/wplink/plugin.js
+++ b/src/js/_enqueues/vendor/tinymce/plugins/wplink/plugin.js
@@ -161,7 +161,7 @@
 
 			hasLinkError = false;
 
-			if ( /^http/i.test( href ) && ( ! urlRegex1.test( href ) || ! urlRegex2.test( href ) ) ) {
+			if ( ( /^http/i.test( href ) && ( ! urlRegex1.test( href ) ) || ! urlRegex2.test( href ) ) ) {
 				hasLinkError = true;
 				$link.attr( 'data-wplink-url-error', 'true' );
 				speak( editor.translate( 'Warning: the link has been inserted but may have errors. Please test it.' ), 'assertive' );

--- a/src/js/_enqueues/vendor/tinymce/plugins/wplink/plugin.js
+++ b/src/js/_enqueues/vendor/tinymce/plugins/wplink/plugin.js
@@ -161,7 +161,11 @@
 
 			hasLinkError = false;
 
-			if ( ( /^http/i.test( href ) && ( ! urlRegex1.test( href ) ) || ! urlRegex2.test( href ) ) ) {
+			var isLink = ( /^http/i.test( href ) && ( urlRegex1.test( href ) && urlRegex2.test( href ) ) );
+			var isEmail = emailRegex.test( href );
+			var isFtp = /^ftp:/i.test( href );
+
+			if ( ! isLink && ! isEmail && ! isFtp ) {
 				hasLinkError = true;
 				$link.attr( 'data-wplink-url-error', 'true' );
 				speak( editor.translate( 'Warning: the link has been inserted but may have errors. Please test it.' ), 'assertive' );

--- a/src/js/_enqueues/vendor/tinymce/plugins/wplink/plugin.js
+++ b/src/js/_enqueues/vendor/tinymce/plugins/wplink/plugin.js
@@ -165,7 +165,7 @@
 			var isEmail = emailRegex.test( href );
 			var isFtp = /^ftp:/i.test( href );
 
-			if ( ! isLink && ! isEmail && ! isFtp ) {
+			if ( ! ( isLink || isEmail || isFtp ) ) {
 				hasLinkError = true;
 				$link.attr( 'data-wplink-url-error', 'true' );
 				speak( editor.translate( 'Warning: the link has been inserted but may have errors. Please test it.' ), 'assertive' );


### PR DESCRIPTION
Fixes to the link validation in the TinyMCE editor.

The Link Checker tool in did not correctly validate the Protocol in the links, allowing anything to be written before the "://" part of the link without displaying it as invalid (e.g. _qwerty://www.google.com_).

The validation should now mark as invalid anything that is not a _http(s)://_, _mailto:_ or _ftp://_ link.

Trac ticket: https://core.trac.wordpress.org/ticket/37758