### PR TITLE
50814: adding an error message when a subsite is not updated

### DIFF
--- a/src/wp-admin/network/site-info.php
+++ b/src/wp-admin/network/site-info.php
@@ -159,7 +159,7 @@ network_edit_site_nav(
 
 if ( ! empty( $messages ) ) {
 	foreach ( $messages as $msg ) {
-		echo '<div id="message" class="updated '. $message_class .' is-dismissible"><p>' . $msg . '</p></div>';
+		echo '<div id="message" class="updated ' . $message_class . ' is-dismissible"><p>' . $msg . '</p></div>';
 	}
 }
 ?>


### PR DESCRIPTION
Here I'm adding a new class for the dashboard notice class, as we have "notice" even if the update fails.
In addition to that adding a new check if `update_blog_details()` returns, as it's returning only `false`.

I guess the code would need some refactoring and we can place a few `apply_filters()` for future extendibility, but wanted to share the first version first.

Trac ticket: https://core.trac.wordpress.org/ticket/50814