### PR TITLE
added new css styles related with equal headings

### DIFF
--- a/src/wp-content/themes/twentyfifteen/style.css
+++ b/src/wp-content/themes/twentyfifteen/style.css
@@ -3374,12 +3374,19 @@ p > video {
 	}
 
 	.entry-content h5,
-	.entry-content h6,
 	.entry-summary h5,
-	.entry-summary h6,
 	.page-content h5,
+	.comment-content h5 {
+		font-size: 18px;
+		font-size: 1.8rem;
+		line-height: 1.2353;
+		margin-top: 3.1111em;
+    	margin-bottom: 1.5556em;
+	}
+
+	.entry-content h6,
+	.entry-summary h6,
 	.page-content h6,
-	.comment-content h5,
 	.comment-content h6 {
 		font-size: 17px;
 		font-size: 1.7rem;
@@ -3948,18 +3955,25 @@ p > video {
 	}
 
 	.entry-content h5,
-	.entry-content h6,
 	.entry-summary h5,
-	.entry-summary h6,
 	.page-content h5,
-	.page-content h6,
-	.comment-content h5,
-	.comment-content h6 {
-		font-size: 19px;
-		font-size: 1.9rem;
+	.comment-content h5 {
+		font-size: 20px;
+		font-size: 2rem;
 		line-height: 1.2632;
-		margin-top: 3.3684em;
-		margin-bottom: 1.6842em;
+		margin-top: 3.2em;
+		margin-bottom: 1.6em;
+	}
+
+	.entry-content h6,
+	.entry-summary h6,
+	.page-content h6,
+	.comment-content h6 {
+		font-size: 18px;
+		font-size: 1.8rem;
+		line-height: 1.2632;
+		margin-top: 3.5555em;
+		margin-bottom: 1.7775em;
 	}
 
 	.entry-content .more-link:after,
@@ -4621,12 +4635,19 @@ p > video {
 	}
 
 	.entry-content h5,
-	.entry-content h6,
 	.entry-summary h5,
-	.entry-summary h6,
 	.page-content h5,
+	.comment-content h5 {
+		font-size: 16px;
+		font-size: 1.6rem;
+		line-height: 1.2;
+		margin-top: 3em;
+		margin-bottom: 1.5em;
+	}
+
+	.entry-content h6,
+	.entry-summary h6,
 	.page-content h6,
-	.comment-content h5,
 	.comment-content h6 {
 		font-size: 15px;
 		font-size: 1.5rem;
@@ -5204,12 +5225,20 @@ p > video {
 	}
 
 	.entry-content h5,
-	.entry-content h6,
 	.entry-summary h5,
-	.entry-summary h6,
 	.page-content h5,
+	.comment-content h5{
+		font-size: 18px;
+		font-size: 1.75rem;
+		line-height: 1.375;
+		margin-top: 3.2em;
+		margin-bottom: 1.6em;
+	}
+
+	
+	.entry-content h6,
+	.entry-summary h6,
 	.page-content h6,
-	.comment-content h5,
 	.comment-content h6 {
 		font-size: 17px;
 		font-size: 1.7rem;
@@ -5217,6 +5246,7 @@ p > video {
 		margin-top: 3.2941em;
 		margin-bottom: 1.6471em;
 	}
+
 
 	.entry-content .more-link:after,
 	.entry-summary .more-link:after {
@@ -5759,18 +5789,25 @@ p > video {
 	}
 
 	.entry-content h5,
-	.entry-content h6,
 	.entry-summary h5,
-	.entry-summary h6,
 	.page-content h5,
+	.comment-content h5{
+		font-size: 20px;
+		font-size: 2rem;
+		line-height: 1.375;
+		margin-top: 3.2em;
+		margin-bottom: 1.6em;
+	}
+	
+	.entry-content h6,
+	.entry-summary h6,
 	.page-content h6,
-	.comment-content h5,
 	.comment-content h6 {
-		font-size: 19px;
-		font-size: 1.9rem;
-		line-height: 1.2632;
-		margin-top: 3.3684em;
-		margin-bottom: 1.6842em;
+		font-size: 18px;
+		font-size: 1.8rem;
+    	line-height: 1.2632;
+    	margin-top: 3.5555em;
+    	margin-bottom: 1.7775em;
 	}
 
 	.entry-content .more-link:after,


### PR DESCRIPTION
To be more easy to show you the result of my changes I added in a custom post 3 heading with h4, h5, and h6 HTML tag. The following changes are: 
* for media query min-width: 77.5em: I had to change the font-size to h6 HTML too because the values of h4 and h6 don't give us a big range to we can find suitable value for h5 tag. The result is: https://ibb.co/fkf01QP ;
* for media query min-width: 68.75em: the change here is for h5 tag and the result now has to have this look https://ibb.co/w6hRxg0;
* for media query min-width: 59.6875em: the change here is only in h5 tag. The result is: https://ibb.co/HCBFLLM ;
* for media query min-width: 55em: I had to change the font-size to h6 HTML too like in the media query 68.75em because the values of h4 and h6 don't give us again a big range to we can find suitable value for h5 tag. The result is: https://ibb.co/dDXh2KC ;
* for media query min-width: 46.25em: the change for this query is in h5 HTML tag only and this is the result https://ibb.co/LNJ0YSv .

Trac ticket: https://core.trac.wordpress.org/ticket/52028