### PR TITLE
Editor: Prevent frontend assets from being enqueued in block editor

### DIFF
--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -425,7 +425,9 @@ function get_block_editor_settings( array $custom_settings, $block_editor_contex
  *
  * @since 5.8.0
  *
- * @global WP_Post $post Global post object.
+ * @global WP_Post    $post       Global post object.
+ * @global WP_Scripts $wp_scripts The WP_Scripts object for printing scripts.
+ * @global WP_Styles  $wp_styles  The WP_Styles object for printing styles.
  *
  * @param string[]                $preload_paths        List of paths to preload.
  * @param WP_Block_Editor_Context $block_editor_context The current block editor context.
@@ -433,7 +435,7 @@ function get_block_editor_settings( array $custom_settings, $block_editor_contex
  * @return void
  */
 function block_editor_rest_api_preload( array $preload_paths, $block_editor_context ) {
-	global $post;
+	global $post, $wp_scripts, $wp_styles;
 
 	/**
 	 * Filters the array of REST API paths that will be used to preloaded common data for the block editor.
@@ -467,11 +469,15 @@ function block_editor_rest_api_preload( array $preload_paths, $block_editor_cont
 	}
 
 	/*
-	 * Ensure the global $post remains the same after API data is preloaded.
+	 * Ensure the global $post, $wp_scripts, and $wp_styles remain the same after
+	 * API data is preloaded.
 	 * Because API preloading can call the_content and other filters, plugins
-	 * can unexpectedly modify $post.
+	 * can unexpectedly modify the global post or enqueue assets which are not intended
+	 * for the block editor.
 	 */
 	$backup_global_post = ! empty( $post ) ? clone $post : $post;
+	$backup_wp_scripts  = ! empty( $wp_scripts ) ? clone $wp_scripts : $wp_scripts;
+	$backup_wp_styles   = ! empty( $wp_styles ) ? clone $wp_styles : $wp_styles;
 
 	foreach ( $preload_paths as &$path ) {
 		if ( is_string( $path ) && ! str_starts_with( $path, '/' ) ) {
@@ -480,7 +486,7 @@ function block_editor_rest_api_preload( array $preload_paths, $block_editor_cont
 		}
 
 		if ( is_array( $path ) && is_string( $path[0] ) && ! str_starts_with( $path[0], '/' ) ) {
-				$path[0] = '/' . $path[0];
+			$path[0] = '/' . $path[0];
 		}
 	}
 
@@ -492,8 +498,10 @@ function block_editor_rest_api_preload( array $preload_paths, $block_editor_cont
 		array()
 	);
 
-	// Restore the global $post as it was before API preloading.
-	$post = $backup_global_post;
+	// Restore the global $post, $wp_scripts, and $wp_styles as they were before API preloading.
+	$post       = $backup_global_post;
+	$wp_scripts = $backup_wp_scripts;
+	$wp_styles  = $backup_wp_styles;
 
 	wp_add_inline_script(
 		'wp-api-fetch',


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/issues/33542

Due to the REST API preloading we may enqueue alot of assets in the editor which are only intended for the frontend. By resetting the globals for scripts/styles we can prevent this. 

Trac ticket: https://core.trac.wordpress.org/ticket/55151

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
