### PR TITLE
Fixes incorrect data URI normalization.

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2775,6 +2775,11 @@ function _wp_normalize_relative_css_links( $css, $stylesheet_url ) {
 				continue;
 			}
 
+			// Skip if the URL is a data URI.
+			if ( str_starts_with( $src_result, 'data:' ) ) {
+				continue;
+			}
+
 			// Build the absolute URL.
 			$absolute_url = dirname( $stylesheet_url ) . '/' . $src_result;
 			$absolute_url = str_replace( '/./', '/', $absolute_url );

--- a/tests/phpunit/tests/dependencies/styles.php
+++ b/tests/phpunit/tests/dependencies/styles.php
@@ -236,6 +236,10 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 				'css'      => 'clip-path: url(#image1);',
 				'expected' => 'clip-path: url(#image1);',
 			),
+			'Data URIs, shouldn\'t change'                 => array(
+				'css'      => 'img {mask-image: url(\'data:image/svg+xml;utf8,<svg></svg>\');}',
+				'expected' => 'img {mask-image: url(\'data:image/svg+xml;utf8,<svg></svg>\');}',
+			),
 		);
 	}
 


### PR DESCRIPTION
This fixes the incorrect normalization of data URIs in `_wp_normalize_relative_css_links` by skipping data URIs altogether.

Trac ticket: https://core.trac.wordpress.org/ticket/55177