### PR TITLE
Load block support styles in the head for block themes

### DIFF
--- a/src/wp-includes/block-supports/elements.php
+++ b/src/wp-includes/block-supports/elements.php
@@ -46,7 +46,7 @@ function wp_render_elements_support( $block_content, $block ) {
 	}
 	$link_color_declaration = esc_html( safecss_filter_attr( "color: $link_color" ) );
 
-	$style = "<style>.$class_name a{" . $link_color_declaration . ";}</style>\n";
+	$style = ".$class_name a{" . $link_color_declaration . ';}';
 
 	// Like the layout hook this assumes the hook only applies to blocks with a single wrapper.
 	// Retrieve the opening tag of the first HTML element.
@@ -68,17 +68,7 @@ function wp_render_elements_support( $block_content, $block ) {
 		$content              = substr_replace( $block_content, ' class="' . $class_name . '"', $first_element_offset + strlen( $first_element ) - 1, 0 );
 	}
 
-	/*
-	 * Ideally styles should be loaded in the head, but blocks may be parsed
-	 * after that, so loading in the footer for now.
-	 * See https://core.trac.wordpress.org/ticket/53494.
-	 */
-	add_action(
-		'wp_footer',
-		static function () use ( $style ) {
-			echo $style;
-		}
-	);
+	wp_enqueue_block_support( $style );
 
 	return $content;
 }

--- a/src/wp-includes/block-supports/layout.php
+++ b/src/wp-includes/block-supports/layout.php
@@ -175,17 +175,7 @@ function wp_render_layout_support_flag( $block_content, $block ) {
 		1
 	);
 
-	/*
-	 * Ideally styles should be loaded in the head, but blocks may be parsed
-	 * after that, so loading in the footer for now.
-	 * See https://core.trac.wordpress.org/ticket/53494.
-	 */
-	add_action(
-		'wp_footer',
-		static function () use ( $style ) {
-			echo '<style>' . $style . '</style>';
-		}
-	);
+	wp_enqueue_block_support( $style );
 
 	return $content;
 }

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1332,3 +1332,29 @@ function _wp_multiple_block_styles( $metadata ) {
 	return $metadata;
 }
 add_filter( 'block_type_metadata', '_wp_multiple_block_styles' );
+
+/**
+ * This function takes care of adding inline styles
+ * in the proper place, depending on the theme in use.
+ *
+ * For block themes, it's loaded in the head.
+ * For classic ones, it's loaded in the body
+ * because the wp_head action (and wp_enqueue_scripts)
+ * happens before the render_block.
+ *
+ * See https://core.trac.wordpress.org/ticket/53494.
+ *
+ * @param string $style String containing the CSS styles to be added.
+ */
+function wp_enqueue_block_support( $style ) {
+	$action_hook_name = 'wp_footer';
+	if ( wp_is_block_theme() ) {
+		$action_hook_name = 'wp_enqueue_scripts';
+	}
+	add_action(
+		$action_hook_name,
+		function () use ( $style ) {
+			echo "<style>$style</style>\n";
+		}
+	);
+}


### PR DESCRIPTION
Part of https://core.trac.wordpress.org/ticket/55148
Backports https://github.com/WordPress/gutenberg/pull/38750

The dynamic block styles for layout and elements should be loaded in the `<head>` for block themes. While that should also be the case for classic themes, the current mechanism we use (`render_block`) does not allow us to do that, hence, this PR doesn't change anything for them and will be loaded the `<body>`.

## How to test

Block theme in WordPress 5.9:

- Use TwentyTwentyTwo and load the front end.
- Verify the embedded styles for elements (`.wp-elements-UUID ...`) and layout (`.wp-container-UUUID ...`) are loaded in the `<head>`.

Classic theme in WordPress 5.9:

- Use TwentyTwenty and load the front end.
- Verify the embedded styles for elements (`.wp-elements-UUID ...`) and layout (`.wp-container-UUUID ...`) are loaded in the `<body>`.
