### PR TITLE
Backport Duotone fixes for 5.9.1

### DIFF
--- a/src/wp-includes/block-supports/duotone.php
+++ b/src/wp-includes/block-supports/duotone.php
@@ -489,88 +489,16 @@ function wp_register_duotone_support( $block_type ) {
  * reference the rendered SVG.
  *
  * @since 5.9.0
- * @access private
-
+ * @deprecated 5.9.1 Use `wp_get_duotone_filter_property` introduced in 5.9.1.
+ *
+ * @see wp_get_duotone_filter_property()
+ *
  * @param array $preset Duotone preset value as seen in theme.json.
  * @return string Duotone CSS filter property.
  */
 function wp_render_duotone_filter_preset( $preset ) {
-	$duotone_id     = $preset['slug'];
-	$duotone_colors = $preset['colors'];
-	$filter_id      = 'wp-duotone-' . $duotone_id;
-	$duotone_values = array(
-		'r' => array(),
-		'g' => array(),
-		'b' => array(),
-		'a' => array(),
-	);
-	foreach ( $duotone_colors as $color_str ) {
-		$color = wp_tinycolor_string_to_rgb( $color_str );
-
-		$duotone_values['r'][] = $color['r'] / 255;
-		$duotone_values['g'][] = $color['g'] / 255;
-		$duotone_values['b'][] = $color['b'] / 255;
-		$duotone_values['a'][] = $color['a'];
-	}
-
-	ob_start();
-
-	?>
-
-	<svg
-		xmlns="http://www.w3.org/2000/svg"
-		viewBox="0 0 0 0"
-		width="0"
-		height="0"
-		focusable="false"
-		role="none"
-		style="visibility: hidden; position: absolute; left: -9999px; overflow: hidden;"
-	>
-		<defs>
-			<filter id="<?php echo esc_attr( $filter_id ); ?>">
-				<feColorMatrix
-					color-interpolation-filters="sRGB"
-					type="matrix"
-					values="
-						.299 .587 .114 0 0
-						.299 .587 .114 0 0
-						.299 .587 .114 0 0
-						.299 .587 .114 0 0
-					"
-				/>
-				<feComponentTransfer color-interpolation-filters="sRGB" >
-					<feFuncR type="table" tableValues="<?php echo esc_attr( implode( ' ', $duotone_values['r'] ) ); ?>" />
-					<feFuncG type="table" tableValues="<?php echo esc_attr( implode( ' ', $duotone_values['g'] ) ); ?>" />
-					<feFuncB type="table" tableValues="<?php echo esc_attr( implode( ' ', $duotone_values['b'] ) ); ?>" />
-					<feFuncA type="table" tableValues="<?php echo esc_attr( implode( ' ', $duotone_values['a'] ) ); ?>" />
-				</feComponentTransfer>
-				<feComposite in2="SourceGraphic" operator="in" />
-			</filter>
-		</defs>
-	</svg>
-
-	<?php
-
-	$svg = ob_get_clean();
-
-	if ( ! defined( 'SCRIPT_DEBUG' ) || ! SCRIPT_DEBUG ) {
-		// Clean up the whitespace.
-		$svg = preg_replace( "/[\r\n\t ]+/", ' ', $svg );
-		$svg = preg_replace( '/> </', '><', $svg );
-		$svg = trim( $svg );
-	}
-
-	add_action(
-		// Safari doesn't render SVG filters defined in data URIs,
-		// and SVG filters won't render in the head of a document,
-		// so the next best place to put the SVG is in the footer.
-		is_admin() ? 'admin_footer' : 'wp_footer',
-		function () use ( $svg ) {
-			echo $svg;
-		}
-	);
-
-	return "url('#" . $filter_id . "')";
+	_deprecated_function( __FUNCTION__, '5.9.1', 'wp_get_duotone_filter_property()' );
+	return wp_get_duotone_filter_property( $preset );
 }
 
 /**

--- a/src/wp-includes/block-supports/duotone.php
+++ b/src/wp-includes/block-supports/duotone.php
@@ -602,7 +602,7 @@ add_filter( 'render_block', 'wp_render_duotone_support', 10, 2 );
  * but it should be rendered in the same location as those to satisfy
  * Safari's rendering quirks.
  *
- * @since 5.9.0
+ * @since 5.9.1
  */
 function wp_global_styles_render_svg_filters() {
 	$filters = wp_get_global_styles_svg_filters();

--- a/src/wp-includes/block-supports/duotone.php
+++ b/src/wp-includes/block-supports/duotone.php
@@ -554,17 +554,23 @@ function wp_render_duotone_support( $block_content, $block ) {
 	wp_add_inline_style( $filter_id, $filter_style );
 	wp_enqueue_style( $filter_id );
 
-	// Render any custom filter the user may have added.
 	add_action(
-		// There are a couple of known rendering quirks in Safari.
-		// 1. Filters won't render at all when the SVG is in the head of
-		// the document.
-		// 2. Filters display incorrectly when the SVG is defined after
-		// where the filter is used in the document, so the footer does
-		// not work.
-		'wp_body_open',
-		static function () use ( $filter_svg ) {
+		'wp_footer',
+		static function () use ( $filter_svg, $selector ) {
 			echo $filter_svg;
+
+			// Safari renders elements incorrectly on first paint when the SVG
+			// filter comes after the content that it is filtering, so we force
+			// a repaint with a WebKit hack which solves the issue.
+			global $is_safari;
+			if ( $is_safari ) {
+				printf(
+					// Simply accessing el.offsetHeight flushes layout and style
+					// changes in WebKit without having to wait for setTimeout.
+					'<script>( function() { var el = document.querySelector( %s ); var display = el.style.display; el.style.display = "none"; el.offsetHeight; el.style.display = display; } )();</script>',
+					wp_json_encode( $selector )
+				);
+			}
 		}
 	);
 

--- a/src/wp-includes/block-supports/duotone.php
+++ b/src/wp-includes/block-supports/duotone.php
@@ -362,6 +362,10 @@ function wp_tinycolor_string_to_rgb( $color_str ) {
  * @return string        Duotone filter CSS id.
  */
 function wp_get_duotone_filter_id( $preset ) {
+	if ( ! isset( $preset['slug'] ) ) {
+		return '';
+	}
+
 	return 'wp-duotone-' . $preset['slug'];
 }
 

--- a/src/wp-includes/block-supports/duotone.php
+++ b/src/wp-includes/block-supports/duotone.php
@@ -559,9 +559,11 @@ function wp_render_duotone_support( $block_content, $block ) {
 		static function () use ( $filter_svg, $selector ) {
 			echo $filter_svg;
 
-			// Safari renders elements incorrectly on first paint when the SVG
-			// filter comes after the content that it is filtering, so we force
-			// a repaint with a WebKit hack which solves the issue.
+			/*
+			 * Safari renders elements incorrectly on first paint when the SVG
+			 * filter comes after the content that it is filtering, so we force
+			 * a repaint with a WebKit hack which solves the issue.
+			 */
 			global $is_safari;
 			if ( $is_safari ) {
 				printf(

--- a/src/wp-includes/block-supports/duotone.php
+++ b/src/wp-includes/block-supports/duotone.php
@@ -401,6 +401,10 @@ function wp_get_duotone_filter_svg( $preset ) {
 		'b' => array(),
 		'a' => array(),
 	);
+	if ( ! isset( $preset['colors'] || ! is_array( $preset['colors'] ) ) {
+		$preset['colors'] = array();
+	}
+	
 	foreach ( $preset['colors'] as $color_str ) {
 		$color = wp_tinycolor_string_to_rgb( $color_str );
 

--- a/src/wp-includes/block-supports/duotone.php
+++ b/src/wp-includes/block-supports/duotone.php
@@ -493,23 +493,6 @@ function wp_register_duotone_support( $block_type ) {
 }
 
 /**
- * Renders the duotone filter SVG and returns the CSS filter property to
- * reference the rendered SVG.
- *
- * @since 5.9.0
- * @deprecated 5.9.1 Use `wp_get_duotone_filter_property` introduced in 5.9.1.
- *
- * @see wp_get_duotone_filter_property()
- *
- * @param array $preset Duotone preset value as seen in theme.json.
- * @return string Duotone CSS filter property.
- */
-function wp_render_duotone_filter_preset( $preset ) {
-	_deprecated_function( __FUNCTION__, '5.9.1', 'wp_get_duotone_filter_property()' );
-	return wp_get_duotone_filter_property( $preset );
-}
-
-/**
  * Render out the duotone stylesheet and SVG.
  *
  * @since 5.8.0

--- a/src/wp-includes/block-supports/duotone.php
+++ b/src/wp-includes/block-supports/duotone.php
@@ -386,7 +386,7 @@ function wp_get_duotone_filter_property( $preset ) {
 /**
  * Returns the duotone filter SVG string for the preset.
  *
- * @since 5.9.0
+ * @since 5.9.1
  * @access private
  *
  * @param  array $preset Duotone preset value as seen in theme.json.

--- a/src/wp-includes/block-supports/duotone.php
+++ b/src/wp-includes/block-supports/duotone.php
@@ -401,10 +401,10 @@ function wp_get_duotone_filter_svg( $preset ) {
 		'b' => array(),
 		'a' => array(),
 	);
-	if ( ! isset( $preset['colors'] || ! is_array( $preset['colors'] ) ) {
+	if ( ! isset( $preset['colors'] ) || ! is_array( $preset['colors'] ) ) {
 		$preset['colors'] = array();
 	}
-	
+
 	foreach ( $preset['colors'] as $color_str ) {
 		$color = wp_tinycolor_string_to_rgb( $color_str );
 

--- a/src/wp-includes/block-supports/duotone.php
+++ b/src/wp-includes/block-supports/duotone.php
@@ -355,7 +355,7 @@ function wp_tinycolor_string_to_rgb( $color_str ) {
 /**
  * Returns the prefixed id for the duotone filter for use as a CSS id.
  *
- * @since 5.9.0
+ * @since 5.9.1
  * @access private
  *
  * @param  array $preset Duotone preset value as seen in theme.json.

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -1577,7 +1577,7 @@ class WP_Theme_JSON {
 	/**
 	 * Converts all filter (duotone) presets into SVGs.
 	 *
-	 * @since 5.9.0
+	 * @since 5.9.1
 	 *
 	 * @param array $origins List of origins to process.
 	 * @return string SVG filters.

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -132,7 +132,7 @@ class WP_Theme_JSON {
 			'path'              => array( 'color', 'duotone' ),
 			'override'          => true,
 			'use_default_names' => false,
-			'value_func'        => 'wp_render_duotone_filter_preset',
+			'value_func'        => 'wp_get_duotone_filter_property',
 			'css_vars'          => '--wp--preset--duotone--$slug',
 			'classes'           => array(),
 			'properties'        => array( 'filter' ),
@@ -1572,6 +1572,40 @@ class WP_Theme_JSON {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Converts all filter (duotone) presets into SVGs.
+	 *
+	 * @since 5.9.0
+	 *
+	 * @param array $origins List of origins to process.
+	 * @return string SVG filters.
+	 */
+	public function get_svg_filters( $origins ) {
+		$blocks_metadata = static::get_blocks_metadata();
+		$setting_nodes   = static::get_setting_nodes( $this->theme_json, $blocks_metadata );
+
+		foreach ( $setting_nodes as $metadata ) {
+			$node = _wp_array_get( $this->theme_json, $metadata['path'], array() );
+			if ( empty( $node['color']['duotone'] ) ) {
+				continue;
+			}
+
+			$duotone_presets = $node['color']['duotone'];
+
+			$filters = '';
+			foreach ( $origins as $origin ) {
+				if ( ! isset( $duotone_presets[ $origin ] ) ) {
+					continue;
+				}
+				foreach ( $duotone_presets[ $origin ] as $duotone_preset ) {
+					$filters .= wp_get_duotone_filter_svg( $duotone_preset );
+				}
+			}
+		}
+
+		return $filters;
 	}
 
 	/**

--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -4208,3 +4208,20 @@ function _excerpt_render_inner_columns_blocks( $columns, $allowed_blocks ) {
 	_deprecated_function( __FUNCTION__, '5.8.0', '_excerpt_render_inner_blocks()' );
 	return _excerpt_render_inner_blocks( $columns, $allowed_blocks );
 }
+
+/**
+ * Renders the duotone filter SVG and returns the CSS filter property to
+ * reference the rendered SVG.
+ *
+ * @since 5.9.0
+ * @deprecated 5.9.1 Use `wp_get_duotone_filter_property` introduced in 5.9.1.
+ *
+ * @see wp_get_duotone_filter_property()
+ *
+ * @param array $preset Duotone preset value as seen in theme.json.
+ * @return string Duotone CSS filter property.
+ */
+function wp_render_duotone_filter_preset( $preset ) {
+	_deprecated_function( __FUNCTION__, '5.9.1', 'wp_get_duotone_filter_property()' );
+	return wp_get_duotone_filter_property( $preset );
+}

--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -154,6 +154,8 @@ function wp_get_global_stylesheet( $types = array() ) {
 /**
  * Returns a string containing the SVGs to be referenced as filters (duotone).
  *
+ * @since 5.9.0
+ *
  * @return string
  */
 function wp_get_global_styles_svg_filters() {

--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -154,7 +154,7 @@ function wp_get_global_stylesheet( $types = array() ) {
 /**
  * Returns a string containing the SVGs to be referenced as filters (duotone).
  *
- * @since 5.9.0
+ * @since 5.9.1
  *
  * @return string
  */

--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -150,3 +150,43 @@ function wp_get_global_stylesheet( $types = array() ) {
 
 	return $stylesheet;
 }
+
+/**
+ * Returns a string containing the SVGs to be referenced as filters (duotone).
+ *
+ * @return string
+ */
+function wp_get_global_styles_svg_filters() {
+	// Return cached value if it can be used and exists.
+	// It's cached by theme to make sure that theme switching clears the cache.
+	$can_use_cached = (
+		( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) &&
+		( ! defined( 'SCRIPT_DEBUG' ) || ! SCRIPT_DEBUG ) &&
+		( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) &&
+		! is_admin()
+	);
+	$transient_name = 'global_styles_svg_filters_' . get_stylesheet();
+	if ( $can_use_cached ) {
+		$cached = get_transient( $transient_name );
+		if ( $cached ) {
+			return $cached;
+		}
+	}
+
+	$supports_theme_json = WP_Theme_JSON_Resolver::theme_has_support();
+
+	$origins = array( 'default', 'theme', 'custom' );
+	if ( ! $supports_theme_json ) {
+		$origins = array( 'default' );
+	}
+
+	$tree = WP_Theme_JSON_Resolver::get_merged_data();
+	$svgs = $tree->get_svg_filters( $origins );
+
+	if ( $can_use_cached ) {
+		// Cache for a minute, same as wp_get_global_stylesheet.
+		set_transient( $transient_name, $svgs, MINUTE_IN_SECONDS );
+	}
+
+	return $svgs;
+}


### PR DESCRIPTION
This is a backporting patch for the following Gutenberg PRs:

* https://github.com/WordPress/gutenberg/pull/36236
* https://github.com/WordPress/gutenberg/pull/37954
* https://github.com/WordPress/gutenberg/pull/38442

Props @ajlende, @scruffian

Trac ticket: https://core.trac.wordpress.org/ticket/55179

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
