### PR TITLE
Refresh: Always allow accessing edit.php?post_type=wp_navigation page

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -520,6 +520,7 @@ function create_initial_post_types() {
 				'delete_others_posts'    => 'edit_theme_options',
 				'edit_private_posts'     => 'edit_theme_options',
 				'edit_published_posts'   => 'edit_theme_options',
+				'edit_posts'             => 'edit_theme_options',
 			),
 			'rest_base'             => 'navigation',
 			'rest_controller_class' => 'WP_REST_Posts_Controller',

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -503,7 +503,7 @@ function create_initial_post_types() {
 			'public'                => false,
 			'_builtin'              => true, /* internal use only. don't use this when registering your own post type. */
 			'has_archive'           => false,
-			'show_ui'               => wp_is_block_theme(),
+			'show_ui'               => true,
 			'show_in_menu'          => false,
 			'show_in_admin_bar'     => false,
 			'show_in_rest'          => true,


### PR DESCRIPTION
Adds a post type registration capabilities check to prevent non-admin users from accessing the Navigation Menus edit screen.

This change is in conjunction with [the original PR](https://github.com/WordPress/wordpress-develop/pull/2219) submitted by @noisysocks.

Trac ticket: https://core.trac.wordpress.org/ticket/54889

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
