### PR TITLE
Script Loader: Improvements to the load block support styles mechanism.

### DIFF
--- a/src/wp-includes/block-supports/elements.php
+++ b/src/wp-includes/block-supports/elements.php
@@ -68,7 +68,7 @@ function wp_render_elements_support( $block_content, $block ) {
 		$content              = substr_replace( $block_content, ' class="' . $class_name . '"', $first_element_offset + strlen( $first_element ) - 1, 0 );
 	}
 
-	wp_enqueue_block_support( $style );
+	wp_enqueue_block_support_styles( $style );
 
 	return $content;
 }

--- a/src/wp-includes/block-supports/layout.php
+++ b/src/wp-includes/block-supports/layout.php
@@ -175,7 +175,7 @@ function wp_render_layout_support_flag( $block_content, $block ) {
 		1
 	);
 
-	wp_enqueue_block_support( $style );
+	wp_enqueue_block_support_styles( $style );
 
 	return $content;
 }

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1332,29 +1332,3 @@ function _wp_multiple_block_styles( $metadata ) {
 	return $metadata;
 }
 add_filter( 'block_type_metadata', '_wp_multiple_block_styles' );
-
-/**
- * This function takes care of adding inline styles
- * in the proper place, depending on the theme in use.
- *
- * For block themes, it's loaded in the head.
- * For classic ones, it's loaded in the body
- * because the wp_head action (and wp_enqueue_scripts)
- * happens before the render_block.
- *
- * See https://core.trac.wordpress.org/ticket/53494.
- *
- * @param string $style String containing the CSS styles to be added.
- */
-function wp_enqueue_block_support( $style ) {
-	$action_hook_name = 'wp_footer';
-	if ( wp_is_block_theme() ) {
-		$action_hook_name = 'wp_enqueue_scripts';
-	}
-	add_action(
-		$action_hook_name,
-		function () use ( $style ) {
-			echo "<style>$style</style>\n";
-		}
-	);
-}

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2883,3 +2883,31 @@ function wp_enqueue_global_styles_css_custom_properties() {
 	wp_add_inline_style( 'global-styles-css-custom-properties', wp_get_global_stylesheet( array( 'variables' ) ) );
 	wp_enqueue_style( 'global-styles-css-custom-properties' );
 }
+
+/**
+ * This function takes care of adding inline styles
+ * in the proper place, depending on the theme in use.
+ *
+ * @since 5.9.1
+ *
+ * For block themes, it's loaded in the head.
+ * For classic ones, it's loaded in the body
+ * because the wp_head action (and wp_enqueue_scripts)
+ * happens before the render_block.
+ *
+ * @link https://core.trac.wordpress.org/ticket/53494.
+ *
+ * @param string $style String containing the CSS styles to be added.
+ */
+function wp_enqueue_block_support_styles( $style ) {
+	$action_hook_name = 'wp_footer';
+	if ( wp_is_block_theme() ) {
+		$action_hook_name = 'wp_enqueue_scripts';
+	}
+	add_action(
+		$action_hook_name,
+		static function () use ( $style ) {
+			echo "<style>$style</style>\n";
+		}
+	);
+}


### PR DESCRIPTION
Applies feedback to https://github.com/WordPress/wordpress-develop/pull/2323

This commit applies feedback given to commit 52741. It changes the new function name, the file where it is located, and improves its documentation and marks.

Follow-up to [52741].
Props hellofromtonya, swissspidy, oandregal.
See #55148.