### PR TITLE
Respect _fields query arg in preloaded requests

### DIFF
--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -2860,12 +2860,12 @@ function rest_preload_api_request( $memo, $path ) {
 	$response = rest_do_request( $request );
 	if ( 200 === $response->status ) {
 		$server = rest_get_server();
+		/** This filter is documented in wp-includes/rest-api/class-wp-rest-server.php */
+		$response = apply_filters( 'rest_post_dispatch', rest_ensure_response( $response ), $server, $request );
 		$embed  = $request->has_param( '_embed' ) ? rest_parse_embed_param( $request['_embed'] ) : false;
 		$data   = (array) $server->response_to_data( $response, $embed );
 
 		if ( 'OPTIONS' === $method ) {
-			$response = rest_send_allow_header( $response, $server, $request );
-
 			$memo[ $method ][ $path ] = array(
 				'body'    => $data,
 				'headers' => $response->headers,

--- a/tests/phpunit/tests/rest-api.php
+++ b/tests/phpunit/tests/rest-api.php
@@ -2490,4 +2490,32 @@ class Tests_REST_API extends WP_UnitTestCase {
 			array( '', array(), array() ),
 		);
 	}
+
+	/**
+	 * @ticket 55213
+	 */
+	public function test_rest_preload_api_request_fields() {
+		$preload_paths = array(
+			'/',
+			'/?_fields=description',
+		);
+
+		$preload_data = array_reduce(
+			$preload_paths,
+			'rest_preload_api_request',
+			array()
+		);
+
+		$this->assertSame( array_keys( $preload_data ), array( '/', '/?_fields=description' ) );
+
+		// Unfiltered request has all fields
+		$this->assertArrayHasKey( 'description', $preload_data['/']['body'] );
+		$this->assertArrayHasKey( 'routes', $preload_data['/']['body'] );
+
+		// Filtered request only has the desired fields + links
+		$this->assertSame(
+			array_keys( $preload_data['/?_fields=description']['body'] ),
+			array( 'description', '_links' )
+		);
+	}
 }


### PR DESCRIPTION
Fixes https://core.trac.wordpress.org/ticket/55213

Suppose a preloaded request includes a `_fields` query param that asks that only selected response fields are returned. You can add such a request with a filter:
```php
function add_filtered_index_request( $preload_paths ) {
  array_push( $preload_paths, '/?_fields=home,title' );
  return $preload_paths;
}
add_filter( 'block_editor_rest_api_preload_paths', 'add_filtered_index_request' );
```
However, you will discover that the `_fields` param is not respected and all fields are returned.

This is because the `rest_preload_api_request` doesn't call `rest_filter_response_fields` on the `response` object. For other requests this call happens inside the `rest_post_dispatch` filter, but this filter is not called when preloading responses.

This patch adds the `rest_post_dispatch` filter call after every preloaded response. This filter also calls the `rest_send_allow_header` function to add the `Allow` header, so we can also remove an explicit call when handling an `OPTIONS` request.

Calling the `rest_post_dispatch` filter should be perfectly fine because it's already called in all similar circumstances:
- when serving a normal REST request in `WP_REST_Server::serve_request`
- when performing a batched request in `WP_REST_Server::serve_batch_request_v1`
- when embedding links in `WP_REST_Server::embed_links`

One extra effect of this patch is that preloaded responses for `GET` requests will also include `headers`, while previously they would only include `body`, and `headers` would be present only for `OPTIONS` responses. Before:
```
{
  '/': {
    body: { home, title }
  },
  'OPTIONS': {
    '/': {
      body: { home, title },
      headers: { Allow }
    }
  }
}
```
After:
```
{
  '/': {
    body: { home, title },
    headers: { Allow }
  },
  'OPTIONS': {
    '/': {
      body: { home, title },
      headers: { Allow }
    }
  }
}
```
Including these headers is a good and desirable thing because it allows us to get rid of redundant OPTIONS request where we already have GET response. The GET response would now already contain the desired info about permissions. See also this discussion on a Gutenberg PR: https://github.com/WordPress/gutenberg/pull/38901#issuecomment-1044340843

In principle this patch is similar to what @TimothyBJacobs did some time ago for embeds: https://core.trac.wordpress.org/ticket/51722
