### PR TITLE
WP_Theme_JSON::get_svg_filters() - initialize filters variable outside the loop

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -1598,6 +1598,7 @@ class WP_Theme_JSON {
 		$blocks_metadata = static::get_blocks_metadata();
 		$setting_nodes   = static::get_setting_nodes( $this->theme_json, $blocks_metadata );
 
+		$filters = '';
 		foreach ( $setting_nodes as $metadata ) {
 			$node = _wp_array_get( $this->theme_json, $metadata['path'], array() );
 			if ( empty( $node['color']['duotone'] ) ) {
@@ -1606,7 +1607,6 @@ class WP_Theme_JSON {
 
 			$duotone_presets = $node['color']['duotone'];
 
-			$filters = '';
 			foreach ( $origins as $origin ) {
 				if ( ! isset( $duotone_presets[ $origin ] ) ) {
 					continue;


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/55234#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
