### PR TITLE
Fix the filter wp_sitemaps_taxonomies_entry passing term ID

### DIFF
--- a/src/wp-includes/sitemaps/providers/class-wp-sitemaps-taxonomies.php
+++ b/src/wp-includes/sitemaps/providers/class-wp-sitemaps-taxonomies.php
@@ -118,6 +118,7 @@ class WP_Sitemaps_Taxonomies extends WP_Sitemaps_Provider {
 				 * Filters the sitemap entry for an individual term.
 				 *
 				 * @since 5.5.0
+				 * @since 6.0.0 Added fourth argument for the term object.
 				 *
 				 * @param array   $sitemap_entry Sitemap entry for the term.
 				 * @param int     $term_id       Term ID.

--- a/src/wp-includes/sitemaps/providers/class-wp-sitemaps-taxonomies.php
+++ b/src/wp-includes/sitemaps/providers/class-wp-sitemaps-taxonomies.php
@@ -120,10 +120,11 @@ class WP_Sitemaps_Taxonomies extends WP_Sitemaps_Provider {
 				 * @since 5.5.0
 				 *
 				 * @param array   $sitemap_entry Sitemap entry for the term.
-				 * @param WP_Term $term          Term object.
+				 * @param int     $term_id       Term ID.
 				 * @param string  $taxonomy      Taxonomy name.
+				 * @param WP_Term $term          Term object.
 				 */
-				$sitemap_entry = apply_filters( 'wp_sitemaps_taxonomies_entry', $sitemap_entry, $term, $taxonomy );
+				$sitemap_entry = apply_filters( 'wp_sitemaps_taxonomies_entry', $sitemap_entry, $term->term_id, $taxonomy, $term );
 				$url_list[]    = $sitemap_entry;
 			}
 		}

--- a/src/wp-includes/sitemaps/providers/class-wp-sitemaps-taxonomies.php
+++ b/src/wp-includes/sitemaps/providers/class-wp-sitemaps-taxonomies.php
@@ -97,6 +97,7 @@ class WP_Sitemaps_Taxonomies extends WP_Sitemaps_Provider {
 		$offset = ( $page_num - 1 ) * wp_sitemaps_get_max_urls( $this->object_type );
 
 		$args           = $this->get_taxonomies_query_args( $taxonomy );
+		$args['fields'] = 'all';
 		$args['offset'] = $offset;
 
 		$taxonomy_terms = new WP_Term_Query( $args );
@@ -194,7 +195,6 @@ class WP_Sitemaps_Taxonomies extends WP_Sitemaps_Provider {
 		$args = apply_filters(
 			'wp_sitemaps_taxonomies_query_args',
 			array(
-				'fields'                 => 'ids',
 				'taxonomy'               => $taxonomy,
 				'orderby'                => 'term_order',
 				'number'                 => wp_sitemaps_get_max_urls( $this->object_type ),


### PR DESCRIPTION
Force fields=all for the WP_Term_Query to make sure the wp_sitemaps_taxonomies_entry filter passes a WP_Term instead of the (unexpected) term ID.

Trac ticket: https://core.trac.wordpress.org/ticket/55239

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
