### PR TITLE
Avoid sending empty script translations

### DIFF
--- a/src/wp-includes/class.wp-scripts.php
+++ b/src/wp-includes/class.wp-scripts.php
@@ -599,8 +599,7 @@ class WP_Scripts extends WP_Dependencies {
 		$json_translations = load_script_textdomain( $handle, $domain, $path );
 
 		if ( ! $json_translations ) {
-			// Register empty locale data object to ensure the domain still exists.
-			$json_translations = '{ "locale_data": { "messages": { "": {} } } }';
+			return false;
 		}
 
 		$output = <<<JS

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -740,13 +740,6 @@ JS;
 		$expected .= "<script type='text/javascript' id='wp-i18n-js-after'>\n";
 		$expected .= "wp.i18n.setLocaleData( { 'text direction\u0004ltr': [ 'ltr' ] } );\n";
 		$expected .= "</script>\n";
-		$expected .= "<script type='text/javascript' id='wp-a11y-js-translations'>\n";
-		$expected .= "( function( domain, translations ) {\n";
-		$expected .= "	var localeData = translations.locale_data[ domain ] || translations.locale_data.messages;\n";
-		$expected .= "	localeData[\"\"].domain = domain;\n";
-		$expected .= "	wp.i18n.setLocaleData( localeData, domain );\n";
-		$expected .= "} )( \"default\", { \"locale_data\": { \"messages\": { \"\": {} } } } );\n";
-		$expected .= "</script>\n";
 		$expected .= "<script type='text/javascript' src='/wp-includes/js/dist/a11y{$suffix}.js' id='wp-a11y-js'></script>\n";
 		$expected .= "<script type='text/javascript' src='http://example2.com' id='test-example2-js'></script>\n";
 		$expected .= "<script type='text/javascript' id='test-example2-js-after'>\nconsole.log(\"after\");\n</script>\n";
@@ -993,7 +986,7 @@ JS;
 	}
 
 	/**
-	 * @ticket 45103
+	 * @ticket 55250
 	 */
 	public function test_wp_set_script_translations_when_translation_file_does_not_exist() {
 		wp_register_script( 'wp-i18n', '/wp-includes/js/dist/wp-i18n.js', array(), null );
@@ -1001,19 +994,6 @@ JS;
 		wp_set_script_translations( 'test-example', 'admin', DIR_TESTDATA . '/languages/' );
 
 		$expected  = "<script type='text/javascript' src='/wp-includes/js/dist/wp-i18n.js' id='wp-i18n-js'></script>\n";
-		$expected .= str_replace(
-			array(
-				'__DOMAIN__',
-				'__HANDLE__',
-				'__JSON_TRANSLATIONS__',
-			),
-			array(
-				'admin',
-				'test-example',
-				'{ "locale_data": { "messages": { "": {} } } }',
-			),
-			$this->wp_scripts_print_translations_output
-		);
 		$expected .= "<script type='text/javascript' src='/wp-admin/js/script.js' id='test-example-js'></script>\n";
 
 		$this->assertSameIgnoreEOL( $expected, get_echo( 'wp_print_scripts' ) );

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -986,6 +986,7 @@ JS;
 	}
 
 	/**
+	 * @ticket 45103
 	 * @ticket 55250
 	 */
 	public function test_wp_set_script_translations_when_translation_file_does_not_exist() {


### PR DESCRIPTION
Fixes https://core.trac.wordpress.org/ticket/55250

For every JS script enqueued, we generate an empty-ish translations script that doesn't add any translations:
```
<script id='react-js-translations'>
( function( domain, translations ) {
  var localeData = translations.locale_data[ domain ] || translations.locale_data.messages;
  localeData[""].domain = domain;
  wp.i18n.setLocaleData( localeData, domain );
}  )( "default", { "locale_data": { "messages": { "": {} } } } );
</script>
```
The only reason for that is to ensure that the `wp.i18n` library has a record for the domain in question (here `"default"`). But the `wp.i18n` library doesn't need that for `__( 'foo', 'domain' )` to work, and it never needed.

There might have been some confusion about the Jed library, whose `gettext` methods really would throw an exception if the domain wasn't initialized, but 1) `wp.i18n` always caught the exception and returned the original string intact, and 2) it's been using `tannin` instead of Jed for close to 4 years.

This patch removes these redundant scripts. On a big page (like `wp-admin/post.php` for block editor on a site with many plugins), there would be 90 of them.