### PR TITLE
Handle network_home_url without host

### DIFF
--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -378,12 +378,15 @@ if ( ! function_exists( 'wp_mail' ) ) :
 		 */
 		if ( ! isset( $from_email ) ) {
 			// Get the site domain and get rid of www.
-			$sitename = wp_parse_url( network_home_url(), PHP_URL_HOST );
-			if ( 'www.' === substr( $sitename, 0, 4 ) ) {
-				$sitename = substr( $sitename, 4 );
-			}
+			$sitename   = wp_parse_url( network_home_url(), PHP_URL_HOST );
+			$from_email = 'wordpress@';
+			if ( null !== $sitename ) {
+				if ( 'www.' === substr( $sitename, 0, 4 ) ) {
+					$sitename = substr( $sitename, 4 );
+				}
 
-			$from_email = 'wordpress@' . $sitename;
+				$from_email .= $sitename;
+			}
 		}
 
 		/**

--- a/tests/phpunit/tests/mail.php
+++ b/tests/phpunit/tests/mail.php
@@ -226,6 +226,38 @@ class Tests_Mail extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that an invalid home url caused the mail sending to fail and not to error out on a PHP 8.1 error.
+	 *
+	 * @ticket 54730
+	 */
+	public function test_wp_mail_with_empty_home_url_will_fail() {
+		$to      = 'address@tld.com';
+		$subject = 'Testing';
+		$message = 'Test Message';
+
+		// Multi-site test runs.
+		add_filter(
+			'network_home_url',
+			function( $url ) {
+				return '';
+			}
+		);
+
+		// Single-site test runs.
+		add_filter(
+			'home_url',
+			function( $url ) {
+				return '';
+			}
+		);
+
+		$success = wp_mail( $to, $subject, $message );
+
+		$this->assertFalse( $success, 'wp_mail should have returned false' );
+		$this->assertGreaterThan( 0, did_action( 'wp_mail_failed' ), 'wp_mail_failed action was not called' );
+	}
+
+	/**
 	 * @ticket 30266
 	 */
 	public function test_wp_mail_with_valid_content_type_header() {


### PR DESCRIPTION
This makes sure that `wp_mail` will not run into a PHP 8.1 null to non-nullable deprecation error when `network_home_url` returns an invalid url. I focussed on keeping the old implementation 100% intact to ensure that any functions hooked into the `wp_mail_from` filter and relying a potentially invalid from address won't be affected.

Trac ticket: https://core.trac.wordpress.org/ticket/54730

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
