### PR TITLE
Fix can_compress_scripts not autoload causing extra DB query on every request

### DIFF
--- a/src/wp-admin/includes/schema.php
+++ b/src/wp-admin/includes/schema.php
@@ -549,8 +549,10 @@ function populate_options( array $options = array() ) {
 
 	// 3.3.0
 	if ( ! is_multisite() ) {
-		$defaults['initial_db_version'] = ! empty( $wp_current_db_version ) && $wp_current_db_version < $wp_db_version
+		$defaults['initial_db_version']   = ! empty( $wp_current_db_version ) && $wp_current_db_version < $wp_db_version
 			? $wp_current_db_version : $wp_db_version;
+		// 6.0.0
+		$defaults['can_compress_scripts'] = 0;
 	}
 
 	// 3.0.0 multisite.
@@ -664,7 +666,6 @@ function populate_options( array $options = array() ) {
 		'rich_editing',
 		'autosave_interval',
 		'deactivated_plugins',
-		'can_compress_scripts',
 		'page_uris',
 		'update_core',
 		'update_plugins',

--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -845,6 +845,10 @@ function upgrade_all() {
 		upgrade_590();
 	}
 
+	if ( $wp_current_db_version < 52448 ) {
+		upgrade_600();
+	}
+	
 	maybe_disable_link_manager();
 
 	maybe_disable_automattic_widgets();
@@ -2279,6 +2283,25 @@ function upgrade_590() {
 			$crons = array_filter( $crons );
 			_set_cron_array( $crons );
 		}
+	}
+}
+
+/**
+ * Executes changes made in WordPress 5.9.0.
+ *
+ * @ignore
+ * @since 5.9.0
+ *
+ * @global int $wp_current_db_version The old (current) database version.
+ */
+function upgrade_600() {
+	global $wp_current_db_version;
+
+	if ( ! is_multisite() ) {
+		// Replace non-autoload option can_compress_scripts with autoload option, see #55270
+		$can_compress_scripts = get_option( 'can_compress_scripts' ) ? 1 : 0 ;
+		delete_option( 'can_compress_scripts' );
+		add_option( 'can_compress_scripts', $can_compress_scripts );
 	}
 }
 

--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -848,7 +848,7 @@ function upgrade_all() {
 	if ( $wp_current_db_version < 52448 ) {
 		upgrade_600();
 	}
-	
+
 	maybe_disable_link_manager();
 
 	maybe_disable_automattic_widgets();
@@ -2295,7 +2295,7 @@ function upgrade_590() {
 function upgrade_600() {
 	if ( ! is_multisite() ) {
 		// Replace non-autoload option can_compress_scripts with autoload option, see #55270
-		$can_compress_scripts = get_option( 'can_compress_scripts' ) ? 1 : 0 ;
+		$can_compress_scripts = get_option( 'can_compress_scripts' ) ? 1 : 0;
 		delete_option( 'can_compress_scripts' );
 		add_option( 'can_compress_scripts', $can_compress_scripts );
 	}

--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -2287,16 +2287,12 @@ function upgrade_590() {
 }
 
 /**
- * Executes changes made in WordPress 5.9.0.
+ * Executes changes made in WordPress 6.0.0.
  *
  * @ignore
- * @since 5.9.0
- *
- * @global int $wp_current_db_version The old (current) database version.
+ * @since 6.0.0
  */
 function upgrade_600() {
-	global $wp_current_db_version;
-
 	if ( ! is_multisite() ) {
 		// Replace non-autoload option can_compress_scripts with autoload option, see #55270
 		$can_compress_scripts = get_option( 'can_compress_scripts' ) ? 1 : 0 ;


### PR DESCRIPTION
The option can_compress_scripts not being among the autoload options creates an extra DB query on every (front-end and admin) request:

`
SELECT option_value FROM wp_options WHERE option_name = 'can_compress_scripts' LIMIT 1
`

Trac ticket: https://core.trac.wordpress.org/ticket/55270

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
