### PR TITLE
Add WP_Block_Editor_Context::$name

### DIFF
--- a/src/wp-admin/site-editor.php
+++ b/src/wp-admin/site-editor.php
@@ -49,7 +49,7 @@ foreach ( get_default_block_template_types() as $slug => $template_type ) {
 	$indexed_template_types[] = $template_type;
 }
 
-$block_editor_context = new WP_Block_Editor_Context();
+$block_editor_context = new WP_Block_Editor_Context( array( 'type' => 'site' ) );
 $custom_settings      = array(
 	'siteUrl'                              => site_url(),
 	'postsPerPage'                         => get_option( 'posts_per_page' ),

--- a/src/wp-admin/site-editor.php
+++ b/src/wp-admin/site-editor.php
@@ -49,7 +49,7 @@ foreach ( get_default_block_template_types() as $slug => $template_type ) {
 	$indexed_template_types[] = $template_type;
 }
 
-$block_editor_context = new WP_Block_Editor_Context( array( 'type' => 'site' ) );
+$block_editor_context = new WP_Block_Editor_Context( array( 'name' => 'core/edit-site' ) );
 $custom_settings      = array(
 	'siteUrl'                              => site_url(),
 	'postsPerPage'                         => get_option( 'posts_per_page' ),

--- a/src/wp-admin/widgets-form-blocks.php
+++ b/src/wp-admin/widgets-form-blocks.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 $current_screen = get_current_screen();
 $current_screen->is_block_editor( true );
 
-$block_editor_context = new WP_Block_Editor_Context();
+$block_editor_context = new WP_Block_Editor_Context( array( 'type' => 'widgets' ) );
 
 $preload_paths = array(
 	array( rest_get_route_for_post_type_items( 'attachment' ), 'OPTIONS' ),

--- a/src/wp-admin/widgets-form-blocks.php
+++ b/src/wp-admin/widgets-form-blocks.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 $current_screen = get_current_screen();
 $current_screen->is_block_editor( true );
 
-$block_editor_context = new WP_Block_Editor_Context( array( 'type' => 'widgets' ) );
+$block_editor_context = new WP_Block_Editor_Context( array( 'name' => 'core/edit-widgets' ) );
 
 $preload_paths = array(
 	array( rest_get_route_for_post_type_items( 'attachment' ), 'OPTIONS' ),

--- a/src/wp-includes/class-wp-block-editor-context.php
+++ b/src/wp-includes/class-wp-block-editor-context.php
@@ -7,27 +7,26 @@
  */
 
 /**
- * Contains information about a block editor being rendered. For example, which
- * type of editor it is or what post is being edited.
+ * Contains information about a block editor being rendered.
  *
  * @since 5.8.0
  */
 final class WP_Block_Editor_Context {
 	/**
-	 * String that identifies which type of block editor is being rendered. Can
-	 * be one of:
+	 * String that identifies the block editor being rendered. Can be one of:
 	 *
-	 * - `'post'`    - The post editor, at `/wp-admin/edit.php`.
-	 * - `'widgets'` - The widgets editor, at `/wp-admin/widgets.php` or `/wp-admin/customize.php`.
-	 * - `'site'`    - The site editor, at `/wp-admin/site-editor.php`.
+	 * - `'core/edit-post'`         - The post editor at `/wp-admin/edit.php`.
+	 * - `'core/edit-widgets'`      - The widgets editor at `/wp-admin/widgets.php`.
+	 * - `'core/customize-widgets'` - The widgets editor at `/wp-admin/customize.php`.
+	 * - `'core/edit-site'`         - The site editor at `/wp-admin/site-editor.php`.
 	 *
-	 * Defaults to 'post'.
+	 * Defaults to 'core/edit-post'.
 	 *
 	 * @since 6.0.0
 	 *
 	 * @var string
 	 */
-	public $type = 'post';
+	public $name = 'core/edit-post';
 
 	/**
 	 * The post being edited by the block editor. Optional.
@@ -39,16 +38,6 @@ final class WP_Block_Editor_Context {
 	public $post = null;
 
 	/**
-	 * Whether the block editor is rendered within the Customizer at
-	 * `/wp-admin/customize.php`. Defaults to `false`.
-	 *
-	 * @since 6.0.0
-	 *
-	 * @var bool
-	 */
-	public $is_customizer = false;
-
-	/**
 	 * Constructor.
 	 *
 	 * Populates optional properties for a given block editor context.
@@ -58,14 +47,11 @@ final class WP_Block_Editor_Context {
 	 * @param array $settings The list of optional settings to expose in a given context.
 	 */
 	public function __construct( array $settings = array() ) {
-		if ( isset( $settings['type'] ) ) {
-			$this->type = $settings['type'];
+		if ( isset( $settings['name'] ) ) {
+			$this->name = $settings['name'];
 		}
 		if ( isset( $settings['post'] ) ) {
 			$this->post = $settings['post'];
-		}
-		if ( isset( $settings['is_customizer'] ) ) {
-			$this->is_customizer = $settings['is_customizer'];
 		}
 	}
 }

--- a/src/wp-includes/class-wp-block-editor-context.php
+++ b/src/wp-includes/class-wp-block-editor-context.php
@@ -7,23 +7,46 @@
  */
 
 /**
- * Class representing a current block editor context.
- *
- * The expectation is that block editor can have a different set
- * of requirements on every screen where it is used. This class
- * allows to define supporting settings that can be used with filters.
+ * Contains information about a block editor being rendered. For example, which
+ * type of editor it is or what post is being edited.
  *
  * @since 5.8.0
  */
 final class WP_Block_Editor_Context {
 	/**
-	 * Post being edited. Optional.
+	 * String that identifies which type of block editor is being rendered. Can
+	 * be one of:
+	 *
+	 * - `'post'`    - The post editor, at `/wp-admin/edit.php`.
+	 * - `'widgets'` - The widgets editor, at `/wp-admin/widgets.php` or `/wp-admin/customize.php`.
+	 * - `'site'`    - The site editor, at `/wp-admin/site-editor.php`.
+	 *
+	 * Defaults to 'post'.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @var string
+	 */
+	public $type = 'post';
+
+	/**
+	 * The post being edited by the block editor. Optional.
 	 *
 	 * @since 5.8.0
 	 *
 	 * @var WP_Post|null
 	 */
 	public $post = null;
+
+	/**
+	 * Whether the block editor is rendered within the Customizer at
+	 * `/wp-admin/customize.php`. Defaults to `false`.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @var bool
+	 */
+	public $is_customizer = false;
 
 	/**
 	 * Constructor.
@@ -35,8 +58,14 @@ final class WP_Block_Editor_Context {
 	 * @param array $settings The list of optional settings to expose in a given context.
 	 */
 	public function __construct( array $settings = array() ) {
+		if ( isset( $settings['type'] ) ) {
+			$this->type = $settings['type'];
+		}
 		if ( isset( $settings['post'] ) ) {
 			$this->post = $settings['post'];
+		}
+		if ( isset( $settings['is_customizer'] ) ) {
+			$this->is_customizer = $settings['is_customizer'];
 		}
 	}
 }

--- a/src/wp-includes/class-wp-customize-widgets.php
+++ b/src/wp-includes/class-wp-customize-widgets.php
@@ -838,7 +838,12 @@ final class WP_Customize_Widgets {
 		 */
 
 		if ( wp_use_widgets_block_editor() ) {
-			$block_editor_context = new WP_Block_Editor_Context();
+			$block_editor_context = new WP_Block_Editor_Context(
+				array(
+					'type'          => 'widgets',
+					'is_customizer' => true,
+				)
+			);
 
 			$editor_settings = get_block_editor_settings(
 				get_legacy_widget_block_editor_settings(),

--- a/src/wp-includes/class-wp-customize-widgets.php
+++ b/src/wp-includes/class-wp-customize-widgets.php
@@ -840,8 +840,7 @@ final class WP_Customize_Widgets {
 		if ( wp_use_widgets_block_editor() ) {
 			$block_editor_context = new WP_Block_Editor_Context(
 				array(
-					'type'          => 'widgets',
-					'is_customizer' => true,
+					'name' => 'core/customize-widgets',
 				)
 			);
 

--- a/tests/phpunit/tests/blocks/editor.php
+++ b/tests/phpunit/tests/blocks/editor.php
@@ -80,7 +80,9 @@ class Tests_Blocks_Editor extends WP_UnitTestCase {
 	public function test_block_editor_context_no_settings() {
 		$context = new WP_Block_Editor_Context();
 
+		$this->assertSame( 'post', $context->type );
 		$this->assertNull( $context->post );
+		$this->assertFalse( $context->is_customizer );
 	}
 
 	/**
@@ -89,7 +91,47 @@ class Tests_Blocks_Editor extends WP_UnitTestCase {
 	public function test_block_editor_context_post() {
 		$context = new WP_Block_Editor_Context( array( 'post' => get_post() ) );
 
+		$this->assertSame( 'post', $context->type );
 		$this->assertSame( get_post(), $context->post );
+		$this->assertFalse( $context->is_customizer );
+	}
+
+	/**
+	 * @ticket
+	 */
+	public function test_block_editor_context_widgets() {
+		$context = new WP_Block_Editor_Context( array( 'type' => 'widgets' ) );
+
+		$this->assertSame( 'widgets', $context->type );
+		$this->assertNull( $context->post );
+		$this->assertFalse( $context->is_customizer );
+	}
+
+	/**
+	 * @ticket
+	 */
+	public function test_block_editor_context_widgets_customizer() {
+		$context = new WP_Block_Editor_Context(
+			array(
+				'type'          => 'widgets',
+				'is_customizer' => true,
+			)
+		);
+
+		$this->assertSame( 'widgets', $context->type );
+		$this->assertNull( $context->post );
+		$this->assertTrue( $context->is_customizer );
+	}
+
+	/**
+	 * @ticket
+	 */
+	public function test_block_editor_context_site() {
+		$context = new WP_Block_Editor_Context( array( 'type' => 'site' ) );
+
+		$this->assertSame( 'site', $context->type );
+		$this->assertNull( $context->post );
+		$this->assertFalse( $context->is_customizer );
 	}
 
 	/**

--- a/tests/phpunit/tests/blocks/editor.php
+++ b/tests/phpunit/tests/blocks/editor.php
@@ -80,9 +80,8 @@ class Tests_Blocks_Editor extends WP_UnitTestCase {
 	public function test_block_editor_context_no_settings() {
 		$context = new WP_Block_Editor_Context();
 
-		$this->assertSame( 'post', $context->type );
+		$this->assertSame( 'core/edit-post', $context->name );
 		$this->assertNull( $context->post );
-		$this->assertFalse( $context->is_customizer );
 	}
 
 	/**
@@ -91,47 +90,38 @@ class Tests_Blocks_Editor extends WP_UnitTestCase {
 	public function test_block_editor_context_post() {
 		$context = new WP_Block_Editor_Context( array( 'post' => get_post() ) );
 
-		$this->assertSame( 'post', $context->type );
+		$this->assertSame( 'core/edit-post', $context->name );
 		$this->assertSame( get_post(), $context->post );
-		$this->assertFalse( $context->is_customizer );
 	}
 
 	/**
 	 * @ticket 55301
 	 */
 	public function test_block_editor_context_widgets() {
-		$context = new WP_Block_Editor_Context( array( 'type' => 'widgets' ) );
+		$context = new WP_Block_Editor_Context( array( 'name' => 'core/edit-widgets' ) );
 
-		$this->assertSame( 'widgets', $context->type );
+		$this->assertSame( 'core/edit-widgets', $context->name );
 		$this->assertNull( $context->post );
-		$this->assertFalse( $context->is_customizer );
 	}
 
 	/**
 	 * @ticket 55301
 	 */
 	public function test_block_editor_context_widgets_customizer() {
-		$context = new WP_Block_Editor_Context(
-			array(
-				'type'          => 'widgets',
-				'is_customizer' => true,
-			)
-		);
+		$context = new WP_Block_Editor_Context( array( 'name' => 'core/customize-widgets' ) );
 
-		$this->assertSame( 'widgets', $context->type );
+		$this->assertSame( 'core/customize-widgets', $context->name );
 		$this->assertNull( $context->post );
-		$this->assertTrue( $context->is_customizer );
 	}
 
 	/**
 	 * @ticket 55301
 	 */
 	public function test_block_editor_context_site() {
-		$context = new WP_Block_Editor_Context( array( 'type' => 'site' ) );
+		$context = new WP_Block_Editor_Context( array( 'name' => 'core/edit-site' ) );
 
-		$this->assertSame( 'site', $context->type );
+		$this->assertSame( 'core/edit-site', $context->name );
 		$this->assertNull( $context->post );
-		$this->assertFalse( $context->is_customizer );
 	}
 
 	/**

--- a/tests/phpunit/tests/blocks/editor.php
+++ b/tests/phpunit/tests/blocks/editor.php
@@ -97,7 +97,7 @@ class Tests_Blocks_Editor extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket
+	 * @ticket 55301
 	 */
 	public function test_block_editor_context_widgets() {
 		$context = new WP_Block_Editor_Context( array( 'type' => 'widgets' ) );
@@ -108,7 +108,7 @@ class Tests_Blocks_Editor extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket
+	 * @ticket 55301
 	 */
 	public function test_block_editor_context_widgets_customizer() {
 		$context = new WP_Block_Editor_Context(
@@ -124,7 +124,7 @@ class Tests_Blocks_Editor extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket
+	 * @ticket 55301
 	 */
 	public function test_block_editor_context_site() {
 		$context = new WP_Block_Editor_Context( array( 'type' => 'site' ) );


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/55301
Original Gutenberg issue: https://github.com/WordPress/gutenberg/issues/28517

### What this is

Adds new `WP_Block_Editor_Context::$type` and `WP_Block_Editor_Context::$is_customizer` fields. This allows plugin developers to tell which block editor is being loaded when using filters such as `allowed_block_types_all` and `block_editor_rest_api_preload_paths`.

### How to test

Here's some code you can put into e.g. `wp-content/mu-plugins/allowed-blocks.php`:

```php
add_filter(
	'allowed_block_types_all',
	function( $allowed_block_types, $block_editor_context ) {
		if ( 'core/edit-site' === $block_editor_context->name ) {
			return array( 'core/paragraph' );
		}
		if ( 'core/edit-widgets' === $block_editor_context->name ) {
			return array( 'core/heading' );
		}
		if ( 'core/customize-widgets' === $block_editor_context->name ) {
			return array( 'core/image' );
		}
		if ( 'core/edit-post' === $block_editor_context->name ) {
			return array( 'core/separator' );
		}
		return $allowed_block_types;
	},
	10,
	2
);
```

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
