### PR TITLE
Update WP_Block_Patterns_Registry::register() docs to include the blockTypes property

### DIFF
--- a/src/wp-includes/class-wp-block-patterns-registry.php
+++ b/src/wp-includes/class-wp-block-patterns-registry.php
@@ -33,6 +33,7 @@ final class WP_Block_Patterns_Registry {
 	 * Registers a block pattern.
 	 *
 	 * @since 5.5.0
+	 * @since 5.8.0 Added support for the `blockTypes` property.
 	 *
 	 * @param string $pattern_name       Block pattern name including namespace.
 	 * @param array  $pattern_properties {
@@ -51,6 +52,13 @@ final class WP_Block_Patterns_Registry {
 	 *                                 patterns. Block patterns can be shown on multiple categories.
 	 *                                 A category must be registered separately in order to be used
 	 *                                 here.
+	 *     @type array  $blockTypes    Optional. A list of block names including namespace that could use
+	 *                                 the block pattern in certain contexts (placeholder, transforms).
+	 *                                 The block pattern is available in the block editor inserter
+	 *                                 regardless of this list of block names.
+	 *                                 Certain blocks support further specificity besides the block name
+	 *                                 (e.g. for `core/template-part` you can specify areas
+	 *                                 like `core/template-part/header` or `core/template-part/footer`).
 	 *     @type array  $keywords      Optional. A list of aliases or keywords that help users discover the
 	 *                                 pattern while searching.
 	 * }


### PR DESCRIPTION
Since WordPress 5.8, block patterns can declare a `blockTypes` property to allow blocks to use those patterns in other contexts, besides the inserter. The `WP_Block_Patterns_Registry::register()` function is missing the documentation about this.

Trac ticket: https://core.trac.wordpress.org/ticket/55303

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
