### PR TITLE
Accessibility: Update WordPress version URL target

### DIFF
--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -306,7 +306,7 @@ function update_nag() {
 	if ( current_user_can( 'update_core' ) ) {
 		$msg = sprintf(
 			/* translators: 1: URL to WordPress release notes, 2: New WordPress version, 3: URL to network admin, 4: Accessibility text. */
-			__( '<a href="%1$s">WordPress %2$s</a> is available! <a href="%3$s" aria-label="%4$s">Please update now</a>.' ),
+			__( '<a href="%1$s" target="_blank" rel="noreferrer noopener">WordPress %2$s</a> is available! <a href="%3$s" aria-label="%4$s">Please update now</a>.' ),
 			$version_url,
 			$cur->current,
 			network_admin_url( 'update-core.php' ),
@@ -315,7 +315,7 @@ function update_nag() {
 	} else {
 		$msg = sprintf(
 			/* translators: 1: URL to WordPress release notes, 2: New WordPress version. */
-			__( '<a href="%1$s">WordPress %2$s</a> is available! Please notify the site administrator.' ),
+			__( '<a href="%1$s" target="_blank" rel="noreferrer noopener">WordPress %2$s</a> is available! Please notify the site administrator.' ),
 			$version_url,
 			$cur->current
 		);

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -306,7 +306,7 @@ function update_nag() {
 	if ( current_user_can( 'update_core' ) ) {
 		$msg = sprintf(
 			/* translators: 1: URL to WordPress release notes, 2: New WordPress version, 3: URL to network admin, 4: Accessibility text. */
-			__( '<a href="%1$s" target="_blank" rel="noreferrer noopener">WordPress %2$s</a> is available! <a href="%3$s" aria-label="%4$s">Please update now</a>.' ),
+			__( '<a href="%1$s" target="_blank">WordPress %2$s</a> is available! <a href="%3$s" aria-label="%4$s">Please update now</a>.' ),
 			$version_url,
 			$cur->current,
 			network_admin_url( 'update-core.php' ),
@@ -315,7 +315,7 @@ function update_nag() {
 	} else {
 		$msg = sprintf(
 			/* translators: 1: URL to WordPress release notes, 2: New WordPress version. */
-			__( '<a href="%1$s" target="_blank" rel="noreferrer noopener">WordPress %2$s</a> is available! Please notify the site administrator.' ),
+			__( '<a href="%1$s" target="_blank">WordPress %2$s</a> is available! Please notify the site administrator.' ),
 			$version_url,
 			$cur->current
 		);


### PR DESCRIPTION
It's always frustrating when the WordPress version URL opens up in the same tab; we can open the `$version_url` in a new tab by changing the target. It's a small change but will be helpful for some people.

Trac ticket: https://core.trac.wordpress.org/ticket/55308#ticket

 **This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**