### PR TITLE
Update `caniuse-lite` browsers list to 1.0.30001312

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -148,12 +148,6 @@
 						"picocolors": "^1.0.0"
 					}
 				},
-				"caniuse-lite": {
-					"version": "1.0.30001291",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001291.tgz",
-					"integrity": "sha512-roMV5V0HNGgJ88s42eE70sstqGW/gwFndosYrikHthw98N5tLnOTxFqMLQjZVRxTWFlJ4rn+MsgXrR7MDPY4jA==",
-					"dev": true
-				},
 				"electron-to-chromium": {
 					"version": "1.4.25",
 					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.25.tgz",
@@ -3688,12 +3682,6 @@
 						"picocolors": "^1.0.0"
 					}
 				},
-				"caniuse-lite": {
-					"version": "1.0.30001291",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001291.tgz",
-					"integrity": "sha512-roMV5V0HNGgJ88s42eE70sstqGW/gwFndosYrikHthw98N5tLnOTxFqMLQjZVRxTWFlJ4rn+MsgXrR7MDPY4jA==",
-					"dev": true
-				},
 				"electron-to-chromium": {
 					"version": "1.4.25",
 					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.25.tgz",
@@ -4646,12 +4634,6 @@
 						"picocolors": "^1.0.0"
 					}
 				},
-				"caniuse-lite": {
-					"version": "1.0.30001300",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001300.tgz",
-					"integrity": "sha512-cVjiJHWGcNlJi8TZVKNMnvMid3Z3TTdDHmLDzlOdIiZq138Exvo0G+G0wTdVYolxKb4AYwC+38pxodiInVtJSA==",
-					"dev": true
-				},
 				"electron-to-chromium": {
 					"version": "1.4.47",
 					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.47.tgz",
@@ -4960,12 +4942,6 @@
 						"node-releases": "^2.0.1",
 						"picocolors": "^1.0.0"
 					}
-				},
-				"caniuse-lite": {
-					"version": "1.0.30001300",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001300.tgz",
-					"integrity": "sha512-cVjiJHWGcNlJi8TZVKNMnvMid3Z3TTdDHmLDzlOdIiZq138Exvo0G+G0wTdVYolxKb4AYwC+38pxodiInVtJSA==",
-					"dev": true
 				},
 				"commander": {
 					"version": "7.2.0",
@@ -8145,9 +8121,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001245",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001245.tgz",
-			"integrity": "sha512-768fM9j1PKXpOCKws6eTo3RHmvTUsG9UrpT4WoREFeZgJBTi4/X9g565azS/rVUGtqb8nt7FjLeF5u4kukERnA==",
+			"version": "1.0.30001312",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
+			"integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==",
 			"dev": true
 		},
 		"capture-exit": {
@@ -9158,12 +9134,6 @@
 						"node-releases": "^2.0.1",
 						"picocolors": "^1.0.0"
 					}
-				},
-				"caniuse-lite": {
-					"version": "1.0.30001291",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001291.tgz",
-					"integrity": "sha512-roMV5V0HNGgJ88s42eE70sstqGW/gwFndosYrikHthw98N5tLnOTxFqMLQjZVRxTWFlJ4rn+MsgXrR7MDPY4jA==",
-					"dev": true
 				},
 				"electron-to-chromium": {
 					"version": "1.4.25",


### PR DESCRIPTION
Updates the `browserslist` DB in `package-lock.json` via command:

```
npx browserslist@latest --update-db
```

Result is addition of `caniuse-lite` **1.0.30001312**, and removal of versions **1.0.30001245, 1.0.30001291, and 1.0.30001300**.

Trac ticket: https://core.trac.wordpress.org/ticket/53685

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
