### PR TITLE
Add `wp_create_links()` general purpose function.

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -8449,3 +8449,138 @@ function wp_recursive_ksort( &$array ) {
 	}
 	ksort( $array );
 }
+
+/**
+ * Creates an array of link markup.
+ *
+ * @since 6.2.0
+ *
+ * @param array $link_data  {
+ *     The data for the links. The key for each link will be preserved.
+ *
+ *     @type string $url         Optional. The link's URL. Default: '#'
+ *     @type string $label       Optional. The link's label. Can include markup.
+ *                               Default: 'Link $key' if numeric, otherwise '$key'.
+ *     @type bool   $current     Optional. Whether the URL is the current URL.
+ *                               If true, will apply:
+ *                               `aria-current='page'` and `class="current"`
+ *     @type array  $attributes  Optional. An associative array of additional attributes
+ *                               in 'attribute' => 'value' format.
+ * }
+ *
+ * @return array An array containing markup for each link.
+ */
+function wp_create_links( array $link_data ) {
+	$links = array();
+
+	foreach ( $link_data as $key => $link ) {
+		$is_anchor = ! empty( $link['attributes']['name'] );
+
+		if ( ! $is_anchor ) {
+			// Default to #.
+			if ( empty( $link['url'] ) || ! is_string( $link['url'] ) || '' === trim( $link['url'] ) ) {
+				$link['url'] = '#';
+			}
+
+			// When no label exists, use the key.
+			if ( empty( $link['label'] ) || ! is_string( $link['label'] ) || '' === trim( $link['label'] ) ) {
+				/* translators: The link key. */
+				$link['label'] = ! is_numeric( $key ) ? $key : sprintf( __( 'Link %s' ), $key );
+			}
+		}
+
+		if ( ! empty( $link['current'] ) ) {
+			if ( empty( $link['attributes']['aria-current'] ) ) {
+				$link['attributes']['aria-current'] = 'page';
+			}
+
+			/**
+			 * Filters the class for the current link.
+			 *
+			 * @since 6.2.0
+			 *
+			 * @param string $key  The link's key.
+			 * @param string $link The link's data.
+			 */
+			$current_class = apply_filters( 'wp_create_links_current_class', 'current', $key, $link );
+
+			// Apply or append the current class.
+			if ( is_string( $current_class ) && '' !== trim( $current_class ) ) {
+				if ( empty( $link['attributes']['class'] ) ) {
+					$link['attributes']['class'] = $current_class;
+				} elseif ( is_string( $link['attributes']['class'] ) ) {
+					$link['attributes']['class'] .= ' ' . $current_class;
+				} else {
+					// Fall back to only the current class otherwise.
+					$link['attributes']['class'] = $current_class;
+				}
+			} else {
+				// Fall back to default class.
+				$link['attributes']['class'] = 'current';
+			}
+		}
+
+		$attributes = array();
+
+		if ( ! empty( $link['attributes'] ) ) {
+			foreach ( $link['attributes'] as $attribute => $value ) {
+				// Skip invalid attributes.
+				if ( ! is_string( $attribute ) || '' === trim( $attribute ) ) {
+					continue;
+				}
+
+				// Skip a duplicate 'href' attribute.
+				if ( 'href' === $attribute ) {
+					continue;
+				}
+
+				// Skip non-scalar or INF values.
+				if ( ! is_scalar( $value ) || INF === $value ) {
+					continue;
+				}
+
+				// Boolean attribute set to `true`.
+				if ( true === $value ) {
+					$attributes[ $attribute ] = esc_attr( $attribute );
+					continue;
+				}
+
+				// Skip boolean attributes set to `false` or `null`.
+				if ( false === $value || null === $value ) {
+					continue;
+				}
+
+				// Convert raw numbers to strings.
+				if ( is_int( $value ) || is_float( $value ) ) {
+					$value = (string) $value;
+				}
+
+				$attributes[ $attribute ] = sprintf(
+					'%s="%s"',
+					esc_attr( $attribute ),
+					esc_attr( $value )
+				);
+			}
+		}
+
+		// Collapse attributes to a string.
+		if ( ! empty( $attributes ) ) {
+			sort( $attributes );
+
+			$attributes = implode( ' ', $attributes );
+
+			if ( ! $is_anchor ) {
+				$attributes = ' ' . $attributes;
+			}
+		} else {
+			$attributes = '';
+		}
+
+		$url   = $is_anchor ? '' : 'href="' . esc_url( $link['url'] ) . '"';
+		$label = empty( $link['label'] ) ? '' : $link['label'];
+
+		$links[ $key ] = sprintf( '<a %s%s>%s</a>', $url, $attributes, $label );
+	}
+
+	return $links;
+}

--- a/tests/phpunit/tests/functions/wpCreateLinks.php
+++ b/tests/phpunit/tests/functions/wpCreateLinks.php
@@ -1,0 +1,600 @@
+<?php
+/**
+ * Tests for the wp_create_links function.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Tests for the wp_create_links function.
+ *
+ * @since 6.2.0
+ *
+ * @group functions.php
+ *
+ * @covers ::wp_create_links
+ */
+class Tests_Functions_WpCreateLinks extends WP_UnitTestCase {
+
+	/**
+	 * Tests that an empty array returns the same.
+	 *
+	 * @ticket 42066
+	 */
+	public function test_should_return_empty_array() {
+		$actual = wp_create_links( array() );
+		$this->assertIsArray( $actual, 'wp_create_links did not return an array' );
+		$this->assertEmpty( $actual, 'wp_create_links did not return an empty array' );
+	}
+
+	/**
+	 * Tests that the expected link markup is created.
+	 *
+	 * @ticket 42066
+	 *
+	 * @dataProvider data_should_return_link_markup
+	 *
+	 * @param array $expected  The expected array of link markup.
+	 * @param array $link_data An array of data for the links.
+	 */
+	public function test_should_return_link_markup( $expected, $link_data ) {
+		$actual = wp_create_links( $link_data );
+		$this->assertSameSetsWithIndex( $expected, $actual );
+	}
+
+	/**
+	 * Data provider for test_should_return_link_markup().
+	 *
+	 * @return array[]
+	 */
+	public function data_should_return_link_markup() {
+		return array(
+			'a link data array with only keys'            => array(
+				'expected'  => array(
+					'Home'    => '<a href="#">Home</a>',
+					'About'   => '<a href="#">About</a>',
+					'Contact' => '<a href="#">Contact</a>',
+				),
+				'link_data' => array(
+					'Home'    => null,
+					'About'   => null,
+					'Contact' => null,
+				),
+			),
+			'a link with an empty url'                    => array(
+				'expected'  => array(
+					'one' => '<a href="#">Link One</a>',
+				),
+				'link_data' => array(
+					'one' => array(
+						'url'   => '',
+						'label' => 'Link One',
+					),
+				),
+			),
+			'a link with only /'                          => array(
+				'expected'  => array(
+					'Home' => '<a href="/">Home</a>',
+				),
+				'link_data' => array(
+					'Home' => array(
+						'url' => '/',
+					),
+				),
+			),
+			'a link with only #'                          => array(
+				'expected'  => array(
+					'home' => '<a href="#">Link One</a>',
+				),
+				'link_data' => array(
+					'home' => array(
+						'url'   => '#',
+						'label' => 'Link One',
+					),
+				),
+			),
+			'non-string url'                              => array(
+				'expected'  => array(
+					'home' => '<a href="#">home</a>',
+				),
+				'link_data' => array(
+					'home' => array(
+						'url' => array( 'http://example.com' ),
+					),
+				),
+			),
+			'url with only spaces'                        => array(
+				'expected'  => array(
+					'home' => '<a href="#">home</a>',
+				),
+				'link_data' => array(
+					'home' => array(
+						'url' => '  ',
+					),
+				),
+			),
+			'a link with no label'                        => array(
+				'expected'  => array(
+					'<a href="#">Link 0</a>',
+				),
+				'link_data' => array(
+					array(
+						'url' => '#',
+					),
+				),
+			),
+			'a link with no label and a key'              => array(
+				'expected'  => array(
+					'home' => '<a href="#">home</a>',
+				),
+				'link_data' => array(
+					'home' => array(
+						'url' => '#',
+					),
+				),
+			),
+			'a link with an invalid class (object array)' => array(
+				'expected'  => array(
+					'home' => '<a href="#">home</a>',
+				),
+				'link_data' => array(
+					'home' => array(
+						'url'        => '#',
+						'attributes' => array(
+							'class' => array(
+								(object) array( 'additional-class' ),
+							),
+						),
+					),
+				),
+			),
+			'an in-page anchor'                           => array(
+				'expected'  => array(
+					'<a name="contact"></a>',
+				),
+				'link_data' => array(
+					array(
+						'attributes' => array(
+							'name' => 'contact',
+						),
+					),
+				),
+			),
+			'an in-page anchor with a class'              => array(
+				'expected'  => array(
+					'<a class="anchor-link" name="contact"></a>',
+				),
+				'link_data' => array(
+					array(
+						'attributes' => array(
+							'name'  => 'contact',
+							'class' => 'anchor-link',
+						),
+					),
+				),
+			),
+			'one link with no attributes'                 => array(
+				'expected'  => array(
+					'one' => '<a href="https://example.org">Link One</a>',
+				),
+				'link_data' => array(
+					'one' => array(
+						'url'   => 'https://example.org',
+						'label' => 'Link One',
+					),
+				),
+			),
+			'two links with no attributes'                => array(
+				'expected'  => array(
+					'one' => '<a href="https://example.org">Link One</a>',
+					'two' => '<a href="https://example.com">Link Two</a>',
+				),
+				'link_data' => array(
+					'one' => array(
+						'url'   => 'https://example.org',
+						'label' => 'Link One',
+					),
+					'two' => array(
+						'url'   => 'https://example.com',
+						'label' => 'Link Two',
+					),
+				),
+			),
+			'links with numeric keys'                     => array(
+				'expected'  => array(
+					'<a href="https://example.org">Link One</a>',
+					'<a href="https://example.com">Link Two</a>',
+				),
+				'link_data' => array(
+					array(
+						'url'   => 'https://example.org',
+						'label' => 'Link One',
+					),
+					array(
+						'url'   => 'https://example.com',
+						'label' => 'Link Two',
+					),
+				),
+			),
+			'links with attribute/value pairs'            => array(
+				'expected'  => array(
+					'<a href="https://example.org" target="_blank">Link One</a>',
+					'<a href="https://example.com" rel="me">Link Two</a>',
+				),
+				'link_data' => array(
+					array(
+						'url'        => 'https://example.org',
+						'label'      => 'Link One',
+						'attributes' => array(
+							'target' => '_blank',
+						),
+					),
+					array(
+						'url'        => 'https://example.com',
+						'label'      => 'Link Two',
+						'attributes' => array(
+							'rel' => 'me',
+						),
+					),
+				),
+			),
+			'links with int and float attribute values'   => array(
+				'expected'  => array(
+					'<a href="https://example.org" data-count="1">Link One</a>',
+					'<a href="https://example.com" data-count="1.05">Link Two</a>',
+				),
+				'link_data' => array(
+					array(
+						'url'        => 'https://example.org',
+						'label'      => 'Link One',
+						'attributes' => array(
+							'data-count' => 1,
+						),
+					),
+					array(
+						'url'        => 'https://example.com',
+						'label'      => 'Link Two',
+						'attributes' => array(
+							'data-count' => 1.05,
+						),
+					),
+				),
+			),
+			'a link with a boolean attribute (true)'      => array(
+				'expected'  => array(
+					'<a href="https://example.org" hidden>Link One</a>',
+				),
+				'link_data' => array(
+					array(
+						'url'        => 'https://example.org',
+						'label'      => 'Link One',
+						'attributes' => array(
+							'hidden' => true,
+						),
+					),
+				),
+			),
+			'a link with a boolean attribute (false)'     => array(
+				'expected'  => array(
+					'<a href="https://example.org">Link One</a>',
+				),
+				'link_data' => array(
+					array(
+						'url'        => 'https://example.org',
+						'label'      => 'Link One',
+						'attributes' => array(
+							'hidden' => false,
+						),
+					),
+				),
+			),
+			'a link with an attribute/value pair and a boolean attribute' => array(
+				'expected'  => array(
+					'<a href="https://example.org" class="menu-link" hidden>Link One</a>',
+				),
+				'link_data' => array(
+					array(
+						'url'        => 'https://example.org',
+						'label'      => 'Link One',
+						'attributes' => array(
+							'class'  => 'menu-link',
+							'hidden' => true,
+						),
+					),
+				),
+			),
+			'a link with an ARIA attribute'               => array(
+				'expected'  => array(
+					'<a href="https://example.org" aria-label="Visit Link One">Link One</a>',
+				),
+				'link_data' => array(
+					array(
+						'url'        => 'https://example.org',
+						'label'      => 'Link One',
+						'attributes' => array(
+							'aria-label' => 'Visit Link One',
+						),
+					),
+				),
+			),
+			'a link to the current page'                  => array(
+				'expected'  => array(
+					'<a href="https://example.org" aria-current="page" class="current">Link One</a>',
+				),
+				'link_data' => array(
+					array(
+						'url'     => 'https://example.org',
+						'label'   => 'Link One',
+						'current' => true,
+					),
+				),
+			),
+			'a link to the current page with a class'     => array(
+				'expected'  => array(
+					'<a href="https://example.org" aria-current="page" class="menu-link current">Link One</a>',
+				),
+				'link_data' => array(
+					array(
+						'url'        => 'https://example.org',
+						'label'      => 'Link One',
+						'current'    => true,
+						'attributes' => array(
+							'class' => 'menu-link',
+						),
+					),
+				),
+			),
+			'a link to the current page with a class and a boolean attribute' => array(
+				'expected'  => array(
+					'<a href="https://example.org" aria-current="page" class="menu-link current" hidden>Link One</a>',
+				),
+				'link_data' => array(
+					array(
+						'url'        => 'https://example.org',
+						'label'      => 'Link One',
+						'current'    => true,
+						'attributes' => array(
+							'class'  => 'menu-link',
+							'hidden' => true,
+						),
+					),
+				),
+			),
+			'a link to the current page and another link, both keyed and with a class and a boolean attribute' => array(
+				'expected'  => array(
+					'one' => '<a href="https://example.org" class="menu-link" hidden>Link One</a>',
+					'two' => '<a href="https://example.com" aria-current="page" class="menu-link current" hidden>Link Two</a>',
+				),
+				'link_data' => array(
+					'one' => array(
+						'url'        => 'https://example.org',
+						'label'      => 'Link One',
+						'attributes' => array(
+							'class'  => 'menu-link',
+							'hidden' => true,
+						),
+					),
+					'two' => array(
+						'url'        => 'https://example.com',
+						'label'      => 'Link Two',
+						'current'    => true,
+						'attributes' => array(
+							'class'  => 'menu-link',
+							'hidden' => true,
+						),
+					),
+				),
+			),
+			'a url and a href attribute'                  => array(
+				'expected'  => array(
+					'home' => '<a href="https://example.org">Home</a>',
+				),
+				'link_data' => array(
+					'home' => array(
+						'url'        => 'https://example.org',
+						'label'      => 'Home',
+						'attributes' => array(
+							'href' => 'https://example.com',
+						),
+					),
+				),
+			),
+			'an array value'                              => array(
+				'expected'  => array(
+					'home' => '<a href="http://example.com">Home</a>',
+				),
+				'link_data' => array(
+					'home' => array(
+						'url'        => 'http://example.com',
+						'label'      => 'Home',
+						'attributes' => array(
+							'rel' => array( 'me', 'noreferrer' ),
+						),
+					),
+				),
+			),
+			'an invalid attribute (int)'                  => array(
+				'expected'  => array(
+					'home' => '<a href="http://example.com">Home</a>',
+				),
+				'link_data' => array(
+					'home' => array(
+						'url'        => 'http://example.com',
+						'label'      => 'Home',
+						'attributes' => array(
+							'value',
+						),
+					),
+				),
+			),
+			'an invalid attribute (empty string)'         => array(
+				'expected'  => array(
+					'home' => '<a href="http://example.com">Home</a>',
+				),
+				'link_data' => array(
+					'home' => array(
+						'url'        => 'http://example.com',
+						'label'      => 'Home',
+						'attributes' => array(
+							'' => 'value',
+						),
+					),
+				),
+			),
+			'an invalid value (object)'                   => array(
+				'expected'  => array(
+					'home' => '<a href="http://example.com">Home</a>',
+				),
+				'link_data' => array(
+					'home' => array(
+						'url'        => 'http://example.com',
+						'label'      => 'Home',
+						'attributes' => array(
+							'rel' => (object) array( 'me', 'noreferrer' ),
+						),
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Test the `wp_create_links_current_class` filter.
+	 *
+	 * @ticket 42066
+	 *
+	 * @dataProvider data_should_filter_current_class
+	 *
+	 * @param mixed $custom_class The custom class(es) to use.
+	 * @param array $expected     An array of link markup.
+	 * @param array $link_data    An array of link data.
+	 */
+	public function test_should_filter_current_class( $custom_class, $expected, $link_data ) {
+		add_filter(
+			'wp_create_links_current_class',
+			static function() use ( $custom_class ) {
+				return $custom_class;
+			}
+		);
+
+		$this->assertSameSetsWithIndex( $expected, wp_create_links( $link_data ) );
+	}
+
+	/**
+	 * Data provider for test_should_filter_current_class().
+	 *
+	 * @return array[]
+	 */
+	public function data_should_filter_current_class() {
+		return array(
+			'an invalid custom current class and no additional classes' => array(
+				'custom_class' => array(
+					'custom-current-class',
+				),
+				'expected'     => array(
+					'home' => '<a href="#" aria-current="page" class="current">home</a>',
+				),
+				'link_data'    => array(
+					'home' => array(
+						'current' => true,
+					),
+				),
+			),
+			'a custom current class and no additional classes' => array(
+				'custom_class' => 'custom-current-class',
+				'expected'     => array(
+					'home' => '<a href="#" aria-current="page" class="custom-current-class">home</a>',
+				),
+				'link_data'    => array(
+					'home' => array(
+						'current' => true,
+					),
+				),
+			),
+			'a custom current class and an additional class' => array(
+				'custom_class' => 'custom-current-class',
+				'expected'     => array(
+					'home' => '<a href="#" aria-current="page" class="additional-class custom-current-class">home</a>',
+				),
+				'link_data'    => array(
+					'home' => array(
+						'current'    => true,
+						'attributes' => array(
+							'class' => 'additional-class',
+						),
+					),
+				),
+			),
+			'a custom current class and two additional classes (string)' => array(
+				'custom_class' => 'custom-current-class',
+				'expected'     => array(
+					'home' => '<a href="#" aria-current="page" class="additional-class-1 additional-class-2 custom-current-class">home</a>',
+				),
+				'link_data'    => array(
+					'home' => array(
+						'current'    => true,
+						'attributes' => array(
+							'class' => 'additional-class-1 additional-class-2',
+						),
+					),
+				),
+			),
+			'a custom current class and two additional invalid classes (array)' => array(
+				'custom_class' => 'custom-current-class',
+				'expected'     => array(
+					'home' => '<a href="#" aria-current="page" class="custom-current-class">home</a>',
+				),
+				'link_data'    => array(
+					'home' => array(
+						'current'    => true,
+						'attributes' => array(
+							'class' => array(
+								'additional-class-1',
+								'additional-class-2',
+							),
+						),
+					),
+				),
+			),
+			'two invalid custom classes (array) and two additional classes (array)' => array(
+				'custom_class' => array(
+					'custom-current-class-1',
+					'custom-current-class-2',
+				),
+				'expected'     => array(
+					'home' => '<a href="#" aria-current="page" class="current">home</a>',
+				),
+				'link_data'    => array(
+					'home' => array(
+						'current'    => true,
+						'attributes' => array(
+							'class' => array(
+								'additional-class-1',
+								'additional-class-2',
+							),
+						),
+					),
+				),
+			),
+			'two invalid custom classes (array) and an additional invalid class (object)' => array(
+				'custom_class' => array(
+					'custom-current-class-1',
+					'custom-current-class-2',
+				),
+				'expected'     => array(
+					'home' => '<a href="#" aria-current="page" class="current">home</a>',
+				),
+				'link_data'    => array(
+					'home' => array(
+						'current'    => true,
+						'attributes' => array(
+							'class' => array(
+								(object) array( 'additional-class' ),
+							),
+						),
+					),
+				),
+			),
+		);
+	}
+}


### PR DESCRIPTION
This PR adds the `wp_create_links()` function.

This is a general purpose function that converts an array of link data into an array of link markup.

This originated from a desire to abstract the link generation for List tables, but it became apparent that this function has much wider potential than in List tables alone. It can be used for any collection of links.

- [x] Accepts an array of arrays containing the data for each link.
- [x] Retains the keys of the array for convenient selection of individual links.
- [x] Handles links with no URL (Defaults to '#').
- [x] Handles links with only '#' anchors.
- [x] Handles relative links.
- [x] Handles links with no Label (Defaults to 'Link i' or the key).
- [x] Handles in-page anchors (Does not add a `href` or Label).
- [x] Handles attribute/value pairs.
- [x] Handles boolean attributes.
- [x] Adds `aria-current="page"` and a `current` class when `is_current` is `true`.
- [x] Allows filtering the current class via the `wp_create_links_current_class` filter.
- [x] Allows for HTML to be used in the `label` (e.g. images, submenus, etc.).
- [x] Has unit tests.
- [x] Unit tests achieve full line/branch coverage.

Example: Creating links from an array of link data.

Given this link data array from any source (think manually typed, retrieved from the database, or converted from JSON):
```php
$link_data = array(
	'home' => array(
		'url'   => '/',
		'label' => 'Home',
	),
	'about' => array(
		'url'        => '/about',
		'label'      => 'About',
		'is_current' => true,
	),
	'wporg' => array(
		'url'        => 'https://www.wordpress.org',
		'label'      => 'WP.org',
		'attributes' => array(
			'class'  => 'external-link',
			'target' => '_blank',
		),
	),
	'profile' => array(
		'url'        => '/profile',
		'label'      => '<img src="https://www.example.org/images/profile.png">',
		'attributes' => array(
			'hidden' => true, // ! is_user_logged_in()
		),
	),
	'contact' => array(
		'label'      => 'Contact',
		'attributes' => array(
			'name' => 'contact',
		),
	),
);
```

Pass this to `wp_create_links()` and output it:
```php
$links = wp_create_links( $link_data );

echo implode( '', $links );
```

Output:
```html
<a href="https://www.example.org/">Home</a>
<a href="https://www.example.org/about" aria-current="page" class="current">About</a>
<a href="https://www.wordpress.org" class="external-link" target="_blank">WP.org</a>
<a href="https://www.example.org/profile" hidden><img src="https://www.example.org/images/profile.png"></a>
<a name="contact">Contact</a>
```

See the tests for further example usage.