### PR TITLE
Optimize preload paths for post and site editors

### DIFF
--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -57,16 +57,16 @@ $rest_path = rest_get_route_for_post( $post );
 
 // Preload common data.
 $preload_paths = array(
-	'/',
 	'/wp/v2/types?context=edit',
-	'/wp/v2/taxonomies?per_page=-1&context=edit',
+	'/wp/v2/taxonomies?context=edit',
 	'/wp/v2/themes?status=active',
 	add_query_arg( 'context', 'edit', $rest_path ),
 	sprintf( '/wp/v2/types/%s?context=edit', $post_type ),
-	sprintf( '/wp/v2/users/me?post_type=%s&context=edit', $post_type ),
+	'/wp/v2/users/me',
 	array( rest_get_route_for_post_type_items( 'attachment' ), 'OPTIONS' ),
 	array( rest_get_route_for_post_type_items( 'wp_block' ), 'OPTIONS' ),
 	sprintf( '%s/autosaves?context=edit', $rest_path ),
+	'/wp/v2/settings',
 );
 
 block_editor_rest_api_preload( $preload_paths, $block_editor_context );

--- a/src/wp-admin/site-editor.php
+++ b/src/wp-admin/site-editor.php
@@ -72,7 +72,6 @@ $active_global_styles_id = WP_Theme_JSON_Resolver::get_user_global_styles_post_i
 $active_theme            = wp_get_theme()->get_stylesheet();
 $preload_paths           = array(
 	array( '/wp/v2/media', 'OPTIONS' ),
-	'/',
 	'/wp/v2/types?context=edit',
 	'/wp/v2/types/wp_template?context=edit',
 	'/wp/v2/types/wp_template-part?context=edit',


### PR DESCRIPTION
This patch optimizes preload paths in post and site editor so that they match the real requests:
- remove the `/` preload as the payload is very big and the response is not needed on any critical path
- modify the preloaded path for `/wp/v2/taxonomies` so that it corresponds to what `loadTaxonomyEntities` requests. After Gutenberg version that ships the https://github.com/WordPress/gutenberg/pull/37685 patch is merged to core, these preloads will need to be further modified to use `context=view` instead of `context=edit`.
- modify the `/wp/v2/users/me` path so that it matches the real request (no query params)
- add a preload of `/wp/v2/settings` because it's requested on critical path (editor boot). Site editor already preloads this, we're just adding it to the post editor.

This is companion to Gutenberg PR https://github.com/WordPress/gutenberg/pull/39256 which introduces compat code to modify the preload paths with a filter, when a Gutenberg plugin is active.

Fixes https://core.trac.wordpress.org/ticket/55337