### PR TITLE
Fix translation string wording

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-post-types-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-post-types-controller.php
@@ -368,7 +368,7 @@ class WP_REST_Post_Types_Controller extends WP_REST_Controller {
 							'type'        => 'boolean',
 						),
 						'show_in_nav_menus' => array(
-							'description' => __( 'Whether to make the post type is available for selection in navigation menus.' ),
+							'description' => __( 'Whether to make the post type available for selection in navigation menus.' ),
 							'type'        => 'boolean',
 						),
 					),


### PR DESCRIPTION
The below string needs improvement:
**_Whether to make the post type ~is~ available for selection in navigation menus._**

Suggestion:
**_Whether to make the post type available for selection in navigation menus._**


Trac ticket: https://core.trac.wordpress.org/ticket/55340
