### PR TITLE
Use menu_title as image icon alt text

### DIFF
--- a/src/wp-admin/menu-header.php
+++ b/src/wp-admin/menu-header.php
@@ -123,7 +123,7 @@ function _wp_menu_output( $menu, $submenu, $submenu_as_parent = true ) {
 		 * as special cases.
 		 */
 		if ( ! empty( $item[6] ) ) {
-			$img = '<img src="' . $item[6] . '" alt="" />';
+			$img = '<img src="' . $item[6] . '" alt="' . $item[0] . '" />';
 
 			if ( 'none' === $item[6] || 'div' === $item[6] ) {
 				$img = '<br />';


### PR DESCRIPTION
Use menu_title as image icon alt text instead of hardcoded empty alt text

Trac ticket: https://core.trac.wordpress.org/ticket/55391

