### PR TITLE
Fix: esc_xml escapes valid XML that is empty()

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -4639,11 +4639,11 @@ EOF;
 	$safe_text = (string) preg_replace_callback(
 		$regex,
 		static function( $matches ) {
-			if ( ! $matches[0] ) {
+			if ( ! isset( $matches[0] ) ) {
 				return '';
 			}
 
-			if ( ! empty( $matches['non_cdata'] ) ) {
+			if ( isset( $matches['non_cdata'] ) ) {
 				// escape HTML entities in the non-CDATA Section.
 				return _wp_specialchars( $matches['non_cdata'], ENT_XML1 );
 			}

--- a/tests/phpunit/tests/formatting/escXml.php
+++ b/tests/phpunit/tests/formatting/escXml.php
@@ -42,6 +42,11 @@ class Tests_Formatting_EscXml extends WP_UnitTestCase {
 				"SELECT meta_key, meta_value FROM wp_trunk_sitemeta WHERE meta_key IN ('site_name', 'siteurl', 'active_sitewide_plugins', '_site_transient_timeout_theme_roots', '_site_transient_theme_roots', 'site_admins', 'can_compress_scripts', 'global_terms_enabled') AND site_id = 1",
 				'SELECT meta_key, meta_value FROM wp_trunk_sitemeta WHERE meta_key IN (&apos;site_name&apos;, &apos;siteurl&apos;, &apos;active_sitewide_plugins&apos;, &apos;_site_transient_timeout_theme_roots&apos;, &apos;_site_transient_theme_roots&apos;, &apos;site_admins&apos;, &apos;can_compress_scripts&apos;, &apos;global_terms_enabled&apos;) AND site_id = 1',
 			),
+			// Zero string.
+			array(
+				'0',
+				'0',
+			),
 		);
 	}
 


### PR DESCRIPTION
Replaced two `empty()`-checks with `isset()` to cover values that are not `''` but `empty()` like `'0'`, `0` or `false`.

Trac ticket: https://core.trac.wordpress.org/ticket/55399

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
