### PR TITLE
Update spacer block markup in patterns/templates registered by Twenty Twenty-Two and Core

### DIFF
--- a/src/wp-content/themes/twentytwentytwo/inc/patterns/footer-about-title-logo.php
+++ b/src/wp-content/themes/twentytwentytwo/inc/patterns/footer-about-title-logo.php
@@ -17,7 +17,7 @@ return array(
 					<p class="has-small-font-size">' . esc_html__( 'We are a rogue collective of bird watchers. We’ve been known to sneak through fences, climb perimeter walls, and generally trespass in order to observe the rarest of birds.', 'twentytwentytwo' ) . '</p>
 					<!-- /wp:paragraph -->
 
-					<!-- wp:spacer {"height":180} -->
+					<!-- wp:spacer {"height":"180px"} -->
 					<div style="height:180px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 

--- a/src/wp-content/themes/twentytwentytwo/inc/patterns/footer-blog.php
+++ b/src/wp-content/themes/twentytwentytwo/inc/patterns/footer-blog.php
@@ -35,7 +35,7 @@ return array(
 					<!-- /wp:column --></div>
 					<!-- /wp:columns -->
 
-					<!-- wp:spacer {"height":50} -->
+					<!-- wp:spacer {"height":"50px"} -->
 					<div style="height:50px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 

--- a/src/wp-content/themes/twentytwentytwo/inc/patterns/footer-navigation-copyright.php
+++ b/src/wp-content/themes/twentytwentytwo/inc/patterns/footer-navigation-copyright.php
@@ -12,7 +12,7 @@ return array(
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
 					<!-- /wp:navigation -->
 
-					<!-- wp:spacer {"height":50} -->
+					<!-- wp:spacer {"height":"50px"} -->
 					<div style="height:50px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 

--- a/src/wp-content/themes/twentytwentytwo/inc/patterns/footer-social-copyright.php
+++ b/src/wp-content/themes/twentytwentytwo/inc/patterns/footer-social-copyright.php
@@ -16,7 +16,7 @@ return array(
 					<!-- wp:social-link {"url":"#","service":"instagram"} /--></ul>
 					<!-- /wp:social-links -->
 
-					<!-- wp:spacer {"height":50} -->
+					<!-- wp:spacer {"height":"50px"} -->
 					<div style="height:50px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 

--- a/src/wp-content/themes/twentytwentytwo/inc/patterns/general-large-list-names.php
+++ b/src/wp-content/themes/twentytwentytwo/inc/patterns/general-large-list-names.php
@@ -13,7 +13,7 @@ return array(
 					<!-- /wp:group -->
 
 					<!-- wp:group {"align":"wide"} -->
-					<div class="wp-block-group alignwide"><!-- wp:spacer {"height":32} -->
+					<div class="wp-block-group alignwide"><!-- wp:spacer {"height":"32px"} -->
 					<div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 
@@ -21,7 +21,7 @@ return array(
 					<p class="has-x-large-font-size" style="font-weight:300">' . esc_html__( 'Jesús Rodriguez, Doug Stilton, Emery Driscoll, Megan Perry, Rowan Price, Angelo Tso, Edward Stilton, Amy Jensen, Boston Bell, Shay Ford, Lee Cunningham, Evelynn Ray, Landen Reese, Ewan Hart, Jenna Chan, Phoenix Murray, Mel Saunders, Aldo Davidson, Zain Hall.', 'twentytwentytwo' ) . '</p>
 					<!-- /wp:paragraph -->
 
-					<!-- wp:spacer {"height":32} -->
+					<!-- wp:spacer {"height":"32px"} -->
 					<div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 

--- a/src/wp-content/themes/twentytwentytwo/inc/patterns/general-list-events.php
+++ b/src/wp-content/themes/twentytwentytwo/inc/patterns/general-list-events.php
@@ -11,7 +11,7 @@ return array(
 					<h2 class="alignwide" style="font-size:clamp(3.25rem, 8vw, 6.25rem);line-height:1.15;margin-bottom:2rem"><em>' . esc_html__( 'Speaker Series', 'twentytwentytwo' ) . '</em></h2>
 					<!-- /wp:heading -->
 
-					<!-- wp:spacer {"height":32} -->
+					<!-- wp:spacer {"height":"32px"} -->
 					<div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 
@@ -115,7 +115,7 @@ return array(
 					<hr class="wp-block-separator alignwide has-text-color has-background has-background-background-color has-background-color is-style-wide"/>
 					<!-- /wp:separator -->
 
-					<!-- wp:spacer {"height":32} -->
+					<!-- wp:spacer {"height":"32px"} -->
 					<div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 

--- a/src/wp-content/themes/twentytwentytwo/inc/patterns/general-pricing-table.php
+++ b/src/wp-content/themes/twentytwentytwo/inc/patterns/general-pricing-table.php
@@ -29,7 +29,7 @@ return array(
 					<!-- /wp:button --></div>
 					<!-- /wp:buttons -->
 
-					<!-- wp:spacer {"height":16} -->
+					<!-- wp:spacer {"height":"16px"} -->
 					<div style="height:16px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer --></div>
 					<!-- /wp:column -->
@@ -57,7 +57,7 @@ return array(
 					<!-- /wp:button --></div>
 					<!-- /wp:buttons -->
 
-					<!-- wp:spacer {"height":16} -->
+					<!-- wp:spacer {"height":"16px"} -->
 					<div style="height:16px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer --></div>
 					<!-- /wp:column -->
@@ -85,7 +85,7 @@ return array(
 					<!-- /wp:button --></div>
 					<!-- /wp:buttons -->
 
-					<!-- wp:spacer {"height":16} -->
+					<!-- wp:spacer {"height":"16px"} -->
 					<div style="height:16px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer --></div>
 					<!-- /wp:column --></div>

--- a/src/wp-content/themes/twentytwentytwo/inc/patterns/general-two-images-text.php
+++ b/src/wp-content/themes/twentytwentytwo/inc/patterns/general-two-images-text.php
@@ -17,7 +17,7 @@ return array(
 					<figure class="wp-block-image size-large"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/bird-on-green.jpg" alt="' . esc_attr__( 'Illustration of a bird flying.', 'twentytwentytwo' ) . '"/></figure>
 					<!-- /wp:image -->
 
-					<!-- wp:spacer {"height":30} -->
+					<!-- wp:spacer {"height":"30px"} -->
 					<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 
@@ -29,11 +29,11 @@ return array(
 					<p>' . wp_kses_post( __( 'May 14th, 2022 @ 7:00PM<br>The Vintagé Theater,<br>245 Arden Rd.<br>Gardenville, NH', 'twentytwentytwo' ) ) . '</p>
 					<!-- /wp:paragraph -->
 
-					<!-- wp:spacer {"height":8} -->
+					<!-- wp:spacer {"height":"8px"} -->
 					<div style="height:8px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 
-					<!-- wp:spacer {"height":10} -->
+					<!-- wp:spacer {"height":"10px"} -->
 					<div style="height:10px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 

--- a/src/wp-content/themes/twentytwentytwo/inc/patterns/general-video-header-details.php
+++ b/src/wp-content/themes/twentytwentytwo/inc/patterns/general-video-header-details.php
@@ -11,7 +11,7 @@ return array(
 					<h1 class="alignwide" id="warble-a-film-about-hobbyist-bird-watchers-1" style="font-size:clamp(3rem, 6vw, 4.5rem)">' . wp_kses_post( __( '<em>Warble</em>, a film about <br>hobbyist bird watchers.', 'twentytwentytwo' ) ) . '</h1>
 					<!-- /wp:heading -->
 
-					<!-- wp:spacer {"height":32} -->
+					<!-- wp:spacer {"height":"32px"} -->
 					<div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 
@@ -19,7 +19,7 @@ return array(
 					<figure class="wp-block-video alignwide"><video controls src="' . esc_url( get_template_directory_uri() ) . '/assets/videos/birds.mp4"></video></figure>
 					<!-- /wp:video -->
 
-					<!-- wp:spacer {"height":32} -->
+					<!-- wp:spacer {"height":"32px"} -->
 					<div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 

--- a/src/wp-content/themes/twentytwentytwo/inc/patterns/general-wide-image-intro-buttons.php
+++ b/src/wp-content/themes/twentytwentytwo/inc/patterns/general-wide-image-intro-buttons.php
@@ -22,7 +22,7 @@ return array(
 				<p>' . esc_html__( 'A film about hobbyist bird watchers, a catalog of different birds, paired with the noises they make. Each bird is listed by their scientific name so things seem more official.', 'twentytwentytwo' ) . '</p>
 				<!-- /wp:paragraph -->
 
-				<!-- wp:spacer {"height":20} -->
+				<!-- wp:spacer {"height":"20px"} -->
 				<div style="height:20px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 

--- a/src/wp-content/themes/twentytwentytwo/inc/patterns/header-image-background.php
+++ b/src/wp-content/themes/twentytwentytwo/inc/patterns/header-image-background.php
@@ -16,7 +16,7 @@ return array(
 					<!-- /wp:navigation --></div>
 					<!-- /wp:group -->
 
-					<!-- wp:spacer {"height":500} -->
+					<!-- wp:spacer {"height":"500px"} -->
 					<div style="height:500px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer --></div></div>
 					<!-- /wp:cover --></div>

--- a/src/wp-content/themes/twentytwentytwo/inc/patterns/header-large-dark.php
+++ b/src/wp-content/themes/twentytwentytwo/inc/patterns/header-large-dark.php
@@ -28,7 +28,7 @@ return array(
 					<!-- wp:image {"align":"full","sizeSlug":"full","linkDestination":"none"} -->
 					<figure class="wp-block-image alignfull size-full"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/flight-path-on-transparent-c.png" alt="' . esc_attr__( 'Illustration of a bird flying.', 'twentytwentytwo' ) . '"/></figure>
 					<!-- /wp:image --></div>
-					<!-- /wp:group --><!-- wp:spacer {"height":66} -->
+					<!-- /wp:group --><!-- wp:spacer {"height":"66px"} -->
 					<div style="height:66px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->',
 );

--- a/src/wp-content/themes/twentytwentytwo/inc/patterns/header-small-dark.php
+++ b/src/wp-content/themes/twentytwentytwo/inc/patterns/header-small-dark.php
@@ -25,7 +25,7 @@ return array(
 					<figure class="wp-block-image alignwide size-full"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/flight-path-on-transparent-d.png" alt="' . esc_attr__( 'Illustration of a bird flying.', 'twentytwentytwo' ) . '"/></figure>
 					<!-- /wp:image --></div>
 					<!-- /wp:group -->
-					<!-- wp:spacer {"height":66} -->
+					<!-- wp:spacer {"height":"66px"} -->
 					<div style="height:66px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->',
 );

--- a/src/wp-content/themes/twentytwentytwo/inc/patterns/header-stacked.php
+++ b/src/wp-content/themes/twentytwentytwo/inc/patterns/header-stacked.php
@@ -10,13 +10,13 @@ return array(
 					<div class="wp-block-group alignfull"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"var(--wp--custom--spacing--large, 8rem)","top":"var(--wp--custom--spacing--small, 1.25rem)"}}}} -->
 					<div class="wp-block-group alignwide" style="padding-top:var(--wp--custom--spacing--small, 1.25rem);padding-bottom:var(--wp--custom--spacing--large, 8rem)"><!-- wp:site-logo {"align":"center","width":128} /-->
 
-					<!-- wp:spacer {"height":10} -->
+					<!-- wp:spacer {"height":"10px"} -->
 					<div style="height:10px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 
 					<!-- wp:site-title {"textAlign":"center","style":{"typography":{"fontStyle":"normal","fontWeight":"400","textTransform":"uppercase"}}} /-->
 
-					<!-- wp:spacer {"height":10} -->
+					<!-- wp:spacer {"height":"10px"} -->
 					<div style="height:10px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 

--- a/src/wp-content/themes/twentytwentytwo/inc/patterns/page-about-large-image-and-buttons.php
+++ b/src/wp-content/themes/twentytwentytwo/inc/patterns/page-about-large-image-and-buttons.php
@@ -62,7 +62,7 @@ return array(
 					<!-- /wp:column --></div>
 					<!-- /wp:columns -->
 
-					<!-- wp:spacer {"height":50} -->
+					<!-- wp:spacer {"height":"50px"} -->
 					<div style="height:50px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 

--- a/src/wp-content/themes/twentytwentytwo/inc/patterns/page-about-links-dark.php
+++ b/src/wp-content/themes/twentytwentytwo/inc/patterns/page-about-links-dark.php
@@ -17,7 +17,7 @@ return array(
 					<h2 class="has-text-align-left" style="font-size:var(--wp--custom--typography--font-size--huge, clamp(2.25rem, 4vw, 2.75rem))">' . esc_html__( 'A trouble of hummingbirds', 'twentytwentytwo' ) . '</h2>
 					<!-- /wp:heading -->
 
-					<!-- wp:spacer {"height":40} -->
+					<!-- wp:spacer {"height":"40px"} -->
 					<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 

--- a/src/wp-content/themes/twentytwentytwo/inc/patterns/page-about-links.php
+++ b/src/wp-content/themes/twentytwentytwo/inc/patterns/page-about-links.php
@@ -21,7 +21,7 @@ return array(
 					<p class="has-text-align-center">' . esc_html__( 'A podcast about birds', 'twentytwentytwo' ) . '</p>
 					<!-- /wp:paragraph -->
 
-					<!-- wp:spacer {"height":40} -->
+					<!-- wp:spacer {"height":"40px"} -->
 					<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 
@@ -48,7 +48,7 @@ return array(
 					<!-- /wp:buttons --></div>
 					<!-- /wp:group -->
 
-					<!-- wp:spacer {"height":40} -->
+					<!-- wp:spacer {"height":"40px"} -->
 					<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 

--- a/src/wp-content/themes/twentytwentytwo/inc/patterns/page-about-media-left.php
+++ b/src/wp-content/themes/twentytwentytwo/inc/patterns/page-about-media-left.php
@@ -6,7 +6,7 @@ return array(
 	'title'      => __( 'About page with media on the left', 'twentytwentytwo' ),
 	'categories' => array( 'pages' ),
 	'content'    => '<!-- wp:media-text {"align":"full","mediaType":"image","imageFill":true,"focalPoint":{"x":"0.63","y":"0.16"},"backgroundColor":"foreground","className":"alignfull is-image-fill has-background-color has-text-color has-background has-link-color"} -->
-					<div class="wp-block-media-text alignfull is-stacked-on-mobile is-image-fill has-background-color has-text-color has-background has-link-color has-foreground-background-color has-background"><figure class="wp-block-media-text__media" style="background-image:url(' . esc_url( get_template_directory_uri() ) . '/assets/images/bird-on-salmon.jpg);background-position:63% 16%"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/bird-on-salmon.jpg" alt="' . esc_attr__( 'Image of a bird on a branch', 'twentytwentytwo' ) . '"/></figure><div class="wp-block-media-text__content"><!-- wp:spacer {"height":32} -->
+					<div class="wp-block-media-text alignfull is-stacked-on-mobile is-image-fill has-background-color has-text-color has-background has-link-color has-foreground-background-color has-background"><figure class="wp-block-media-text__media" style="background-image:url(' . esc_url( get_template_directory_uri() ) . '/assets/images/bird-on-salmon.jpg);background-position:63% 16%"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/bird-on-salmon.jpg" alt="' . esc_attr__( 'Image of a bird on a branch', 'twentytwentytwo' ) . '"/></figure><div class="wp-block-media-text__content"><!-- wp:spacer {"height":"32px"} -->
 					<div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 
@@ -21,7 +21,7 @@ return array(
 					<p style="line-height:1.6">' . esc_html__( 'Oh hello. My name’s Doug, and you’ve found your way to my website. I’m an avid bird watcher, and I also broadcast my own radio show on Tuesday evenings at 11PM EDT.', 'twentytwentytwo' ) . '</p>
 					<!-- /wp:paragraph -->
 
-					<!-- wp:spacer {"height":40} -->
+					<!-- wp:spacer {"height":"40px"} -->
 					<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 
@@ -34,7 +34,7 @@ return array(
 					<!-- /wp:social-links --></div>
 					<!-- /wp:group -->
 
-					<!-- wp:spacer {"height":32} -->
+					<!-- wp:spacer {"height":"32px"} -->
 					<div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer --></div></div>
 					<!-- /wp:media-text -->',

--- a/src/wp-content/themes/twentytwentytwo/inc/patterns/page-about-media-right.php
+++ b/src/wp-content/themes/twentytwentytwo/inc/patterns/page-about-media-right.php
@@ -6,7 +6,7 @@ return array(
 	'title'      => __( 'About page with media on the right', 'twentytwentytwo' ),
 	'categories' => array( 'pages' ),
 	'content'    => '<!-- wp:media-text {"align":"full","mediaPosition":"right","mediaLink":"' . esc_url( get_template_directory_uri() ) . '/assets/images/bird-on-black.jpg","mediaType":"image","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"backgroundColor":"foreground","textColor":"background"} -->
-				<div class="wp-block-media-text alignfull has-media-on-the-right is-stacked-on-mobile has-background-color has-foreground-background-color has-text-color has-background has-link-color"><figure class="wp-block-media-text__media"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/bird-on-black.jpg" alt="' . esc_attr__( 'An image of a bird flying', 'twentytwentytwo' ) . '"/></figure><div class="wp-block-media-text__content"><!-- wp:spacer {"height":32} -->
+				<div class="wp-block-media-text alignfull has-media-on-the-right is-stacked-on-mobile has-background-color has-foreground-background-color has-text-color has-background has-link-color"><figure class="wp-block-media-text__media"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/bird-on-black.jpg" alt="' . esc_attr__( 'An image of a bird flying', 'twentytwentytwo' ) . '"/></figure><div class="wp-block-media-text__content"><!-- wp:spacer {"height":"32px"} -->
 					<div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 					<!-- wp:site-logo {"width":60} /-->
@@ -20,7 +20,7 @@ return array(
 					<p style="line-height:1.6">' . esc_html__( 'Oh hello. My name’s Emery, and you’ve found your way to my website. I’m an avid bird watcher, and I also broadcast my own radio show on Tuesday evenings at 11PM EDT.', 'twentytwentytwo' ) . '</p>
 					<!-- /wp:paragraph -->
 
-					<!-- wp:spacer {"height":40} -->
+					<!-- wp:spacer {"height":"40px"} -->
 					<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 
@@ -33,7 +33,7 @@ return array(
 					<!-- /wp:social-links --></div>
 					<!-- /wp:group --></div>
 
-					<!-- wp:spacer {"height":32} -->
+					<!-- wp:spacer {"height":"32px"} -->
 					<div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer --></div>
 					<!-- /wp:media-text -->',

--- a/src/wp-content/themes/twentytwentytwo/inc/patterns/page-about-simple-dark.php
+++ b/src/wp-content/themes/twentytwentytwo/inc/patterns/page-about-simple-dark.php
@@ -6,7 +6,7 @@ return array(
 	'title'      => __( 'Simple dark about page', 'twentytwentytwo' ),
 	'categories' => array( 'pages' ),
 	'content'    => '<!-- wp:cover {"overlayColor":"foreground","minHeight":100,"minHeightUnit":"vh","contentPosition":"center center","align":"full","style":{"spacing":{"padding":{"top":"max(1.25rem, 8vw)","right":"max(1.25rem, 8vw)","bottom":"max(1.25rem, 8vw)","left":"max(1.25rem, 8vw)"}}}} -->
-					<div class="wp-block-cover alignfull has-foreground-background-color has-background-dim" style="padding-top:max(1.25rem, 8vw);padding-right:max(1.25rem, 8vw);padding-bottom:max(1.25rem, 8vw);padding-left:max(1.25rem, 8vw);min-height:100vh"><div class="wp-block-cover__inner-container"><!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"},"overlayMenu":"always"} -->
+					<div class="wp-block-cover alignfull is-light" style="padding-top:max(1.25rem, 8vw);padding-right:max(1.25rem, 8vw);padding-bottom:max(1.25rem, 8vw);padding-left:max(1.25rem, 8vw);min-height:100vh"><span aria-hidden="true" class="has-foreground-background-color has-background-dim-100 wp-block-cover__gradient-background has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"},"overlayMenu":"always"} -->
 					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
 					<!-- /wp:navigation -->
 
@@ -22,7 +22,7 @@ return array(
 					<p style="line-height:1.6">' . esc_html__( 'Oh hello. My name’s Jesús, and you’ve found your way to my website. I’m an avid bird watcher, and I also broadcast my own radio show on Tuesday evenings at 11PM EDT.', 'twentytwentytwo' ) . '</p>
 					<!-- /wp:paragraph -->
 
-					<!-- wp:spacer {"height":40} -->
+					<!-- wp:spacer {"height":"40px"} -->
 					<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 

--- a/src/wp-content/themes/twentytwentytwo/inc/patterns/page-about-solid-color.php
+++ b/src/wp-content/themes/twentytwentytwo/inc/patterns/page-about-solid-color.php
@@ -8,13 +8,13 @@ return array(
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"1.25rem","right":"1.25rem","bottom":"1.25rem","left":"1.25rem"}}}} -->
 					<div class="wp-block-group alignfull" style="padding-top:1.25rem;padding-right:1.25rem;padding-bottom:1.25rem;padding-left:1.25rem"><!-- wp:cover {"overlayColor":"secondary","minHeight":80,"minHeightUnit":"vh","isDark":false,"align":"full"} -->
 					<div class="wp-block-cover alignfull is-light" style="min-height:80vh"><span aria-hidden="true" class="has-secondary-background-color has-background-dim-100 wp-block-cover__gradient-background has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"layout":{"inherit":false,"contentSize":"400px"}} -->
-					<div class="wp-block-group"><!-- wp:spacer {"height":64} -->
+					<div class="wp-block-group"><!-- wp:spacer {"height":"64px"} -->
 					<div style="height:64px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer --><!-- wp:heading {"style":{"typography":{"lineHeight":"1","textTransform":"uppercase","fontSize":"clamp(2.75rem, 6vw, 3.25rem)"}}} -->
 					<h2 id="edvard-smith" style="font-size:clamp(2.75rem, 6vw, 3.25rem);line-height:1;text-transform:uppercase">' . wp_kses_post( __( 'Edvard<br>Smith', 'twentytwentytwo' ) ) . '</h2>
 					<!-- /wp:heading -->
 
-					<!-- wp:spacer {"height":8} -->
+					<!-- wp:spacer {"height":"8px"} -->
 					<div style="height:8px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 
@@ -22,7 +22,7 @@ return array(
 					<p class="has-small-font-size">' . esc_html__( 'Oh hello. My name’s Edvard, and you’ve found your way to my website. I’m an avid bird watcher, and I also broadcast my own radio show every Tuesday evening at 11PM EDT. Listen in sometime!', 'twentytwentytwo' ) . '</p>
 					<!-- /wp:paragraph -->
 
-					<!-- wp:spacer {"height":8} -->
+					<!-- wp:spacer {"height":"8px"} -->
 					<div style="height:8px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 
@@ -32,7 +32,7 @@ return array(
 					<!-- wp:social-link {"url":"#","service":"twitter"} /-->
 
 					<!-- wp:social-link {"url":"#","service":"instagram"} /--></ul>
-					<!-- /wp:social-links --><!-- wp:spacer {"height":64} -->
+					<!-- /wp:social-links --><!-- wp:spacer {"height":"64px"} -->
 					<div style="height:64px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer --></div>
 					<!-- /wp:group --></div></div>

--- a/src/wp-content/themes/twentytwentytwo/inc/patterns/page-layout-image-text-and-video.php
+++ b/src/wp-content/themes/twentytwentytwo/inc/patterns/page-layout-image-text-and-video.php
@@ -11,7 +11,7 @@ return array(
 					<h1 class="alignwide" style="font-size:clamp(3rem, 6vw, 4.5rem)">' . wp_kses_post( __( '<em>Warble</em>, a film about <br>hobbyist bird watchers.', 'twentytwentytwo' ) ) . '</h1>
 					<!-- /wp:heading -->
 
-					<!-- wp:spacer {"height":50} -->
+					<!-- wp:spacer {"height":"50px"} -->
 					<div style="height:50px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 

--- a/src/wp-content/themes/twentytwentytwo/inc/patterns/page-layout-two-columns.php
+++ b/src/wp-content/themes/twentytwentytwo/inc/patterns/page-layout-two-columns.php
@@ -10,7 +10,7 @@ return array(
 					<h1 class="alignwide" style="font-size:clamp(4rem, 15vw, 12.5rem);font-weight:200;line-height:1">' . wp_kses_post( __( '<em>Goldfinch </em><br><em>&amp; Sparrow</em>', 'twentytwentytwo' ) ) . '</h1>
 					<!-- /wp:heading -->
 
-					<!-- wp:spacer {"height":50} -->
+					<!-- wp:spacer {"height":"50px"} -->
 					<div style="height:50px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 

--- a/src/wp-content/themes/twentytwentytwo/inc/patterns/page-sidebar-blog-posts-right.php
+++ b/src/wp-content/themes/twentytwentytwo/inc/patterns/page-sidebar-blog-posts-right.php
@@ -16,7 +16,7 @@ return array(
 					<!-- /wp:navigation --></div>
 					<!-- /wp:group -->
 
-					<!-- wp:spacer {"height":64} -->
+					<!-- wp:spacer {"height":"64px"} -->
 					<div style="height:64px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 
@@ -38,7 +38,7 @@ return array(
 					<!-- wp:post-terms {"term":"post_tag","fontSize":"small"} /--></div>
 					<!-- /wp:group -->
 
-					<!-- wp:spacer {"height":64} -->
+					<!-- wp:spacer {"height":"64px"} -->
 					<div style="height:64px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 					<!-- /wp:post-template -->
@@ -58,7 +58,7 @@ return array(
 					<figure class="wp-block-image size-large"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/flight-path-on-salmon.jpg" alt="' . esc_attr__( 'Illustration of a flying bird.', 'twentytwentytwo' ) . '"/></figure>
 					<!-- /wp:image -->
 
-					<!-- wp:spacer {"height":4} -->
+					<!-- wp:spacer {"height":"4px"} -->
 					<div style="height:4px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 
@@ -66,7 +66,7 @@ return array(
 
 					<!-- wp:site-tagline /-->
 
-					<!-- wp:spacer {"height":16} -->
+					<!-- wp:spacer {"height":"16px"} -->
 					<div style="height:16px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 

--- a/src/wp-content/themes/twentytwentytwo/inc/patterns/page-sidebar-blog-posts.php
+++ b/src/wp-content/themes/twentytwentytwo/inc/patterns/page-sidebar-blog-posts.php
@@ -12,13 +12,13 @@ return array(
 					<div class="wp-block-cover is-light" style="min-height:400px"><span aria-hidden="true" class="has-secondary-background-color has-background-dim-100 wp-block-cover__gradient-background has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:site-logo {"align":"center","width":60} /--></div></div>
 					<!-- /wp:cover -->
 
-					<!-- wp:spacer {"height":40} -->
+					<!-- wp:spacer {"height":"40px"} -->
 					<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 
 					<!-- wp:site-tagline {"fontSize":"small"} /-->
 
-					<!-- wp:spacer {"height":32} -->
+					<!-- wp:spacer {"height":"32px"} -->
 					<div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 
@@ -26,7 +26,7 @@ return array(
 					<hr class="wp-block-separator has-text-color has-background has-foreground-background-color has-foreground-color is-style-wide"/>
 					<!-- /wp:separator -->
 
-					<!-- wp:spacer {"height":32} -->
+					<!-- wp:spacer {"height":"32px"} -->
 					<div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 
@@ -34,7 +34,7 @@ return array(
 					<!-- wp:page-list /-->
 					<!-- /wp:navigation -->
 
-					<!-- wp:spacer {"height":32} -->
+					<!-- wp:spacer {"height":"32px"} -->
 					<div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 
@@ -60,7 +60,7 @@ return array(
 					<!-- wp:post-terms {"term":"post_tag","fontSize":"small"} /--></div>
 					<!-- /wp:group -->
 
-					<!-- wp:spacer {"height":128} -->
+					<!-- wp:spacer {"height":"128px"} -->
 					<div style="height:128px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 					<!-- /wp:post-template -->

--- a/src/wp-content/themes/twentytwentytwo/inc/patterns/page-sidebar-grid-posts.php
+++ b/src/wp-content/themes/twentytwentytwo/inc/patterns/page-sidebar-grid-posts.php
@@ -12,7 +12,7 @@ return array(
 
 					<!-- wp:site-tagline {"fontSize":"small"} /-->
 
-					<!-- wp:spacer {"height":32} -->
+					<!-- wp:spacer {"height":"32px"} -->
 					<div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 
@@ -20,7 +20,7 @@ return array(
 					<hr class="wp-block-separator has-text-color has-background has-foreground-background-color has-foreground-color is-style-wide"/>
 					<!-- /wp:separator -->
 
-					<!-- wp:spacer {"height":16} -->
+					<!-- wp:spacer {"height":"16px"} -->
 					<div style="height:16px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 
@@ -28,7 +28,7 @@ return array(
 					<!-- wp:page-list /-->
 					<!-- /wp:navigation -->
 
-					<!-- wp:spacer {"height":16} -->
+					<!-- wp:spacer {"height":"16px"} -->
 					<div style="height:16px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 
@@ -36,15 +36,15 @@ return array(
 					<hr class="wp-block-separator has-text-color has-background has-foreground-background-color has-foreground-color is-style-wide"/>
 					<!-- /wp:separator -->
 
-					<!-- wp:spacer {"height":16} -->
+					<!-- wp:spacer {"height":"16px"} -->
 					<div style="height:16px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 
-					<!-- wp:spacer {"height":16} -->
+					<!-- wp:spacer {"height":"16px"} -->
 					<div style="height:16px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 
-					<!-- wp:site-logo {"width":60} /--></div>
+					<!-- wp:site-logo {"width":"60px"} /--></div>
 					<!-- /wp:column -->
 
 					<!-- wp:column {"width":"70%"} -->

--- a/src/wp-content/themes/twentytwentytwo/inc/patterns/page-sidebar-poster.php
+++ b/src/wp-content/themes/twentytwentytwo/inc/patterns/page-sidebar-poster.php
@@ -32,7 +32,7 @@ return array(
 					<figure class="wp-block-image size-full is-resized"><img src="' . esc_url( get_template_directory_uri() ) . '/assets/images/icon-binoculars.png" alt="' . esc_attr__( 'An icon representing binoculars.', 'twentytwentytwo' ) . '" width="100" height="47"/></figure>
 					<!-- /wp:image -->
 
-					<!-- wp:spacer {"height":16} -->
+					<!-- wp:spacer {"height":"16px"} -->
 					<div style="height:16px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 
@@ -44,7 +44,7 @@ return array(
 					<p>' . esc_html__( 'February, 12 2021', 'twentytwentytwo' ) . '</p>
 					<!-- /wp:paragraph -->
 
-					<!-- wp:spacer {"height":16} -->
+					<!-- wp:spacer {"height":"16px"} -->
 					<div style="height:16px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 
@@ -56,7 +56,7 @@ return array(
 					<p>' . wp_kses_post( __( 'The Grand Theater<br>154 Eastern Avenue<br>Maryland NY, 12345', 'twentytwentytwo' ) ) . '</p>
 					<!-- /wp:paragraph -->
 
-					<!-- wp:spacer {"height":16} -->
+					<!-- wp:spacer {"height":"16px"} -->
 					<div style="height:16px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer --></div>
 					<!-- /wp:column --></div>

--- a/src/wp-content/themes/twentytwentytwo/inc/patterns/query-default.php
+++ b/src/wp-content/themes/twentytwentytwo/inc/patterns/query-default.php
@@ -25,7 +25,7 @@ return array(
 					<!-- /wp:column --></div>
 					<!-- /wp:columns -->
 
-					<!-- wp:spacer {"height":16} -->
+					<!-- wp:spacer {"height":"16px"} -->
 					<div style="height:16px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 
@@ -33,7 +33,7 @@ return array(
 					<hr class="wp-block-separator alignwide is-style-wide"/>
 					<!-- /wp:separator -->
 
-					<!-- wp:spacer {"height":16} -->
+					<!-- wp:spacer {"height":"16px"} -->
 					<div style="height:16px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer --></div>
 					<!-- /wp:group -->

--- a/src/wp-content/themes/twentytwentytwo/inc/patterns/query-irregular-grid.php
+++ b/src/wp-content/themes/twentytwentytwo/inc/patterns/query-irregular-grid.php
@@ -25,7 +25,7 @@ return array(
 					<!-- wp:column -->
 					<div class="wp-block-column"><!-- wp:query {"query":{"offset":"1","postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":"1"},"displayLayout":{"type":"list","columns":3},"align":"wide","layout":{"inherit":true}} -->
 					<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->
-					<!-- wp:spacer {"height":64} -->
+					<!-- wp:spacer {"height":"64px"} -->
 					<div style="height:64px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 
@@ -43,7 +43,7 @@ return array(
 					<!-- wp:column -->
 					<div class="wp-block-column"><!-- wp:query {"query":{"offset":"2","postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":"1"},"displayLayout":{"type":"list","columns":3},"align":"wide","layout":{"inherit":true}} -->
 					<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->
-					<!-- wp:spacer {"height":128} -->
+					<!-- wp:spacer {"height":"128px"} -->
 					<div style="height:128px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 
@@ -77,7 +77,7 @@ return array(
 					<!-- wp:column -->
 					<div class="wp-block-column"><!-- wp:query {"query":{"offset":"4","postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":"1"},"displayLayout":{"type":"list","columns":3},"align":"wide","layout":{"inherit":true}} -->
 					<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->
-					<!-- wp:spacer {"height":96} -->
+					<!-- wp:spacer {"height":"96px"} -->
 					<div style="height:96px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 
@@ -95,7 +95,7 @@ return array(
 					<!-- wp:column -->
 					<div class="wp-block-column"><!-- wp:query {"query":{"offset":"5","postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":"1"},"displayLayout":{"type":"list","columns":3},"align":"wide","layout":{"inherit":true}} -->
 					<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->
-					<!-- wp:spacer {"height":160} -->
+					<!-- wp:spacer {"height":"160px"} -->
 					<div style="height:160px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 
@@ -115,7 +115,7 @@ return array(
 					<div class="wp-block-columns alignwide"><!-- wp:column -->
 					<div class="wp-block-column"><!-- wp:query {"query":{"offset":"6","postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":"1"},"displayLayout":{"type":"list","columns":3},"align":"wide","layout":{"inherit":true}} -->
 					<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->
-					<!-- wp:spacer {"height":32} -->
+					<!-- wp:spacer {"height":"32px"} -->
 					<div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 
@@ -133,7 +133,7 @@ return array(
 					<!-- wp:column -->
 					<div class="wp-block-column"><!-- wp:query {"query":{"offset":"7","postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":"1"},"displayLayout":{"type":"list","columns":3},"align":"wide","layout":{"inherit":true}} -->
 					<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->
-					<!-- wp:spacer {"height":160} -->
+					<!-- wp:spacer {"height":"160px"} -->
 					<div style="height:160px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 
@@ -151,7 +151,7 @@ return array(
 					<!-- wp:column -->
 					<div class="wp-block-column"><!-- wp:query {"query":{"offset":"8","postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":"1"},"displayLayout":{"type":"list","columns":3},"align":"wide","layout":{"inherit":true}} -->
 					<div class="wp-block-query alignwide"><!-- wp:post-template {"align":"wide"} -->
-					<!-- wp:spacer {"height":96} -->
+					<!-- wp:spacer {"height":"96px"} -->
 					<div style="height:96px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 

--- a/src/wp-content/themes/twentytwentytwo/inc/patterns/query-simple-blog.php
+++ b/src/wp-content/themes/twentytwentytwo/inc/patterns/query-simple-blog.php
@@ -22,7 +22,7 @@ return array(
 					<!-- wp:post-terms {"term":"post_tag","fontSize":"small"} /--></div>
 					<!-- /wp:group -->
 
-					<!-- wp:spacer {"height":128} -->
+					<!-- wp:spacer {"height":"128px"} -->
 					<div style="height:128px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 					<!-- /wp:post-template -->

--- a/src/wp-content/themes/twentytwentytwo/parts/header-large-dark.html
+++ b/src/wp-content/themes/twentytwentytwo/parts/header-large-dark.html
@@ -2,6 +2,6 @@
 <div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:0px;padding-bottom:var(--wp--custom--spacing--large, 8rem)"><!-- wp:template-part {"slug":"header","tagName":"header","align":"wide"} /-->
 
 <!-- wp:pattern {"slug":"twentytwentytwo/hidden-heading-and-bird"} /--></div>
-<!-- /wp:group --><!-- wp:spacer {"height":66} -->
+<!-- /wp:group --><!-- wp:spacer {"height":"66px"} -->
 <div style="height:66px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->

--- a/src/wp-content/themes/twentytwentytwo/parts/header-small-dark.html
+++ b/src/wp-content/themes/twentytwentytwo/parts/header-small-dark.html
@@ -2,6 +2,6 @@
 <div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:0px;padding-bottom:0px"><!-- wp:template-part {"slug":"header","tagName":"header","align":"wide"} /-->
 
 <!-- wp:pattern {"slug":"twentytwentytwo/hidden-bird"} /--></div>
-<!-- /wp:group --><!-- wp:spacer {"height":66} -->
+<!-- /wp:group --><!-- wp:spacer {"height":"66px"} -->
 <div style="height:66px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->

--- a/src/wp-content/themes/twentytwentytwo/templates/archive.html
+++ b/src/wp-content/themes/twentytwentytwo/templates/archive.html
@@ -21,7 +21,7 @@
 <!-- /wp:column --></div>
 <!-- /wp:columns -->
 
-<!-- wp:spacer {"height":112} -->
+<!-- wp:spacer {"height":"112px"} -->
 <div style="height:112px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 <!-- /wp:post-template -->

--- a/src/wp-content/themes/twentytwentytwo/templates/home.html
+++ b/src/wp-content/themes/twentytwentytwo/templates/home.html
@@ -19,7 +19,7 @@
 <!-- /wp:column --></div>
 <!-- /wp:columns -->
 
-<!-- wp:spacer {"height":112} -->
+<!-- wp:spacer {"height":"112px"} -->
 <div style="height:112px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer --></div>
 <!-- /wp:group -->

--- a/src/wp-content/themes/twentytwentytwo/templates/index.html
+++ b/src/wp-content/themes/twentytwentytwo/templates/index.html
@@ -19,7 +19,7 @@
 <!-- /wp:column --></div>
 <!-- /wp:columns -->
 
-<!-- wp:spacer {"height":112} -->
+<!-- wp:spacer {"height":"112px"} -->
 <div style="height:112px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer --></div>
 <!-- /wp:group -->

--- a/src/wp-content/themes/twentytwentytwo/templates/page.html
+++ b/src/wp-content/themes/twentytwentytwo/templates/page.html
@@ -11,7 +11,7 @@
 <!-- /wp:separator --></div>
 <!-- /wp:group -->
 
-<!-- wp:spacer {"height":32} -->
+<!-- wp:spacer {"height":"32px"} -->
 <div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 

--- a/src/wp-content/themes/twentytwentytwo/templates/search.html
+++ b/src/wp-content/themes/twentytwentytwo/templates/search.html
@@ -23,7 +23,7 @@
 <!-- /wp:column --></div>
 <!-- /wp:columns -->
 
-<!-- wp:spacer {"height":112} -->
+<!-- wp:spacer {"height":"112px"} -->
 <div style="height:112px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer --></div>
 <!-- /wp:group -->

--- a/src/wp-content/themes/twentytwentytwo/templates/single-no-separators.html
+++ b/src/wp-content/themes/twentytwentytwo/templates/single-no-separators.html
@@ -9,7 +9,7 @@
 
 <!-- wp:post-content {"layout":{"inherit":true}} /-->
 
-<!-- wp:spacer {"height":32} -->
+<!-- wp:spacer {"height":"32px"} -->
 <div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
@@ -24,7 +24,7 @@
 <!-- wp:post-terms {"term":"post_tag","fontSize":"small"} /--></div>
 <!-- /wp:group -->
 
-<!-- wp:spacer {"height":32} -->
+<!-- wp:spacer {"height":"32px"} -->
 <div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 

--- a/src/wp-content/themes/twentytwentytwo/templates/single.html
+++ b/src/wp-content/themes/twentytwentytwo/templates/single.html
@@ -11,13 +11,13 @@
 <!-- /wp:separator --></div>
 <!-- /wp:group -->
 
-<!-- wp:spacer {"height":32} -->
+<!-- wp:spacer {"height":"32px"} -->
 <div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
 <!-- wp:post-content {"layout":{"inherit":true}} /-->
 
-<!-- wp:spacer {"height":32} -->
+<!-- wp:spacer {"height":"32px"} -->
 <div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
@@ -32,7 +32,7 @@
 <!-- wp:post-terms {"term":"post_tag","fontSize":"small"} /--></div>
 <!-- /wp:group -->
 
-<!-- wp:spacer {"height":32} -->
+<!-- wp:spacer {"height":"32px"} -->
 <div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 

--- a/src/wp-includes/block-patterns/query-offset-posts.php
+++ b/src/wp-includes/block-patterns/query-offset-posts.php
@@ -17,7 +17,7 @@ return array(
 					<!-- wp:post-featured-image /-->
 					<!-- wp:post-title /-->
 					<!-- wp:post-date /-->
-					<!-- wp:spacer {"height":200} -->
+					<!-- wp:spacer {"height":"200px"} -->
 					<div style="height:200px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 					<!-- /wp:post-template --></div>
@@ -26,7 +26,7 @@ return array(
 					<!-- wp:column {"width":"50%"} -->
 					<div class="wp-block-column" style="flex-basis:50%"><!-- wp:query {"query":{"perPage":2,"pages":0,"offset":2,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"displayLayout":{"type":"list"}} -->
 					<div class="wp-block-query"><!-- wp:post-template -->
-					<!-- wp:spacer {"height":200} -->
+					<!-- wp:spacer {"height":"200px"} -->
 					<div style="height:200px" aria-hidden="true" class="wp-block-spacer"></div>
 					<!-- /wp:spacer -->
 					<!-- wp:post-featured-image /-->


### PR DESCRIPTION
The Twenty Twenty-Two theme registers block patterns and templates that contain deprecated markup for `core/spacer` blocks. They specify `height` attribute as a number (`"height":50`) instead of a string that includes units (`"height":"50px"`). Because of that, the block parser reports a lot of depreciations in browser console, like:

<img width="633" alt="Screenshot 2022-03-17 at 9 55 43" src="https://user-images.githubusercontent.com/664258/158774209-fa4fe6fc-1573-40c7-95b7-f2520510d856.png">

The spacer format change was introduced in this PR: https://github.com/WordPress/gutenberg/pull/36186

I'm also updating the `core/query-offset-posts` pattern registered by Core itself, not by a theme. And one instance of `core/cover` block which also had deprecated markup.

I'm updating only code that doesn't support WordPress versions older than 5.9, i.e., Core and the Twenty Twenty-Two theme. Other themes, like Twenty Thirteen, also register patterns with deprecated markup, but these also support older versions of WordPress, which wouldn't be able to parse the new format.

Fixes https://core.trac.wordpress.org/ticket/55410