### PR TITLE
Fix warning when retrieving the last author who edited current post.

### DIFF
--- a/src/wp-includes/author-template.php
+++ b/src/wp-includes/author-template.php
@@ -99,7 +99,7 @@ function get_the_modified_author() {
 		 *
 		 * @since 2.8.0
 		 *
-		 * @param string $display_name The author's display name.
+		 * @param string $display_name The author's display name, empty string if unkown.
 		 */
 		return apply_filters( 'the_modified_author', $last_user ? $last_user->display_name : '' );
 	}

--- a/src/wp-includes/author-template.php
+++ b/src/wp-includes/author-template.php
@@ -86,7 +86,7 @@ function the_author( $deprecated = '', $deprecated_echo = true ) {
  *
  * @since 2.8.0
  *
- * @return string|void The author's display name.
+ * @return string The author's display name, empty string if unkown.
  */
 function get_the_modified_author() {
 	$last_id = get_post_meta( get_post()->ID, '_edit_last', true );
@@ -101,7 +101,7 @@ function get_the_modified_author() {
 		 *
 		 * @param string $display_name The author's display name.
 		 */
-		return apply_filters( 'the_modified_author', $last_user->display_name );
+		return apply_filters( 'the_modified_author', $last_user ? $last_user->display_name : '' );
 	}
 }
 


### PR DESCRIPTION
A warning is thrown when retrieving the the last author that modified the post if that user was removed.

See https://core.trac.wordpress.org/ticket/55420

Trac ticket: [<!-- insert a link to the WordPress Trac ticket here -->](https://core.trac.wordpress.org/ticket/55420)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
