### PR TITLE
Preserve image attributes when cropping a custom logo image

### DIFF
--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3977,21 +3977,24 @@ function wp_ajax_crop_image() {
 			$image_type = ( $size ) ? $size['mime'] : 'image/jpeg';
 			/** @var WP_Post $original_attachment */
 			$original_attachment = get_post( $attachment_id );
-			$has_title           = mb_strlen( trim( $original_attachment->post_title ) ) > 0;
-			$has_description     = mb_strlen( trim( $original_attachment->post_content ) ) > 0;
+			$has_title           = '' !== trim( $original_attachment->post_title );
 
 			$object = array(
-				// Copy the image title attribute (post_content field) from the original image.
+				// Copy the image title attribute (post_title field) from the original image.
 				'post_title'     => $has_title ? $original_attachment->post_title : wp_basename( $cropped ),
-				// Copy the image description attribute (post_content field) from the original image.
-				'post_content'   => $has_description ? $original_attachment->post_content : $url,
+				'post_content'   => $url,
 				'post_mime_type' => $image_type,
 				'guid'           => $url,
 				'context'        => $context,
 			);
 
+			// Copy the image description attribute (post_content field) from the original image.
+			if ( '' !== trim( $original_attachment->post_content ) ) {
+				$object['post_content'] = $original_attachment->post_content;
+			}
+
 			// Copy the image caption attribute (post_excerpt field) from the original image.
-			if ( mb_strlen( trim( $original_attachment->post_excerpt ) ) ) {
+			if ( '' !== trim( $original_attachment->post_excerpt ) ) {
 				$object['post_excerpt'] = $original_attachment->post_excerpt;
 			}
 
@@ -3999,7 +4002,7 @@ function wp_ajax_crop_image() {
 			$metadata      = wp_generate_attachment_metadata( $attachment_id, $cropped );
 
 			// Copy the image alt text attribute from the original image.
-			if ( mb_strlen( trim( $original_attachment->_wp_attachment_image_alt ) ) ) {
+			if ( '' !== trim( $original_attachment->_wp_attachment_image_alt ) ) {
 				update_post_meta( $attachment_id, '_wp_attachment_image_alt', wp_slash( $original_attachment->_wp_attachment_image_alt ) );
 			}
 

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3980,12 +3980,11 @@ function wp_ajax_crop_image() {
 			// Get the original image's post to pre-populate the cropped image.
 			$original_attachment      = get_post( $attachment_id );
 			$sanitized_post_title     = sanitize_file_name( $original_attachment->post_title );
-			$attached_file_name       = pathinfo( $parent_basename, PATHINFO_FILENAME );
 			$use_original_title       = (
 				'' !== trim( $original_attachment->post_title ) &&
 				// Check if the original image's title was edited.
-				( $attached_file_name !== $sanitized_post_title ) &&
-				( $attached_file_name !== pathinfo( $sanitized_post_title, PATHINFO_FILENAME ) )
+				( $parent_basename !== $sanitized_post_title ) &&
+				( pathinfo( $parent_basename, PATHINFO_FILENAME ) !== $sanitized_post_title )
 			);
 			$use_original_description = ( '' !== trim( $original_attachment->post_content ) );
 

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3979,10 +3979,13 @@ function wp_ajax_crop_image() {
 
 			// Get the original image's post to pre-populate the cropped image.
 			$original_attachment      = get_post( $attachment_id );
+			$sanitized_post_title     = sanitize_file_name( $original_attachment->post_title );
+			$attached_file_name       = pathinfo( $parent_basename, PATHINFO_FILENAME );
 			$use_original_title       = (
 				'' !== trim( $original_attachment->post_title ) &&
 				// Check if the original image's title was edited.
-				pathinfo( $parent_basename, PATHINFO_FILENAME ) !== $original_attachment->post_title
+				( $attached_file_name !== $sanitized_post_title ) &&
+				( $attached_file_name !== pathinfo( $sanitized_post_title, PATHINFO_FILENAME ) )
 			);
 			$use_original_description = ( '' !== trim( $original_attachment->post_content ) );
 

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3977,23 +3977,18 @@ function wp_ajax_crop_image() {
 			$image_type = ( $size ) ? $size['mime'] : 'image/jpeg';
 			/** @var WP_Post $original_attachment */
 			$original_attachment = get_post( $attachment_id );
-			$has_custom_description = 0 < mb_strlen( trim( $original_attachment->post_title ) );
+			$has_content = 0 < mb_strlen( trim( $original_attachment->post_content ) );
 
 			$object = array(
-				// Copy the image description from the original image if it's defined.
-				'post_title'     => $has_custom_description ? $original_attachment->post_title : wp_basename( $cropped ),
-				'post_content'   => $url,
+				'post_title'     => wp_basename( $cropped ),
+				// Copy the image title (post_content field) from the original image.
+				'post_content'   => $has_content ? $original_attachment->post_content : $url,
 				'post_mime_type' => $image_type,
 				'guid'           => $url,
 				'context'        => $context,
 			);
 
-			// Copy the image title from the original image.
-			if ( mb_strlen( trim( $original_attachment->post_content ) ) ) {
-				$object['post_content'] = $original_attachment->post_content;
-			}
-
-			// Copy the image caption from the original image.
+			// Copy the image caption (post_excerpt field) from the original image.
 			if ( mb_strlen( trim( $original_attachment->post_excerpt ) ) ) {
 				$object['post_excerpt'] = $original_attachment->post_excerpt;
 			}

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3981,7 +3981,7 @@ function wp_ajax_crop_image() {
 			$original_attachment      = get_post( $attachment_id );
 			$sanitized_post_title     = sanitize_file_name( $original_attachment->post_title );
 			$use_original_title       = (
-				'' !== trim( $original_attachment->post_title ) &&
+				( '' !== trim( $original_attachment->post_title ) ) &&
 				/*
 				 * Check if the original image has a title other than the "filename" default,
 				 * meaning the image had a title when originally uploaded or its title was edited.

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3977,23 +3977,23 @@ function wp_ajax_crop_image() {
 			$image_type = ( $size ) ? $size['mime'] : 'image/jpeg';
 			/** @var WP_Post $original_attachment */
 			$original_attachment = get_post( $attachment_id );
+			$has_custom_description = 0 < mb_strlen( trim( $original_attachment->post_title ) );
 
 			$object = array(
-				'post_title'     => wp_basename( $cropped ),
+				// Copy the image description from the original image if it's defined.
+				'post_title'     => $has_custom_description ? $original_attachment->post_title : wp_basename( $cropped ),
 				'post_content'   => $url,
 				'post_mime_type' => $image_type,
 				'guid'           => $url,
 				'context'        => $context,
 			);
 
-			if ( mb_strlen( trim( $original_attachment->post_title ) ) ) {
-				$object['post_title'] = $original_attachment->post_title;
-			}
-
+			// Copy the image title from the original image.
 			if ( mb_strlen( trim( $original_attachment->post_content ) ) ) {
 				$object['post_content'] = $original_attachment->post_content;
 			}
 
+			// Copy the image caption from the original image.
 			if ( mb_strlen( trim( $original_attachment->post_excerpt ) ) ) {
 				$object['post_excerpt'] = $original_attachment->post_excerpt;
 			}
@@ -4001,7 +4001,7 @@ function wp_ajax_crop_image() {
 			$attachment_id = wp_insert_attachment( $object, $cropped );
 			$metadata      = wp_generate_attachment_metadata( $attachment_id, $cropped );
 
-			// Copy the image alt text from the edited image.
+			// Copy the image alt text from the original image.
 			if ( mb_strlen( trim( $original_attachment->_wp_attachment_image_alt ) ) ) {
 				update_post_meta( $attachment_id, '_wp_attachment_image_alt', wp_slash( $original_attachment->_wp_attachment_image_alt ) );
 			}

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3983,8 +3983,8 @@ function wp_ajax_crop_image() {
 			$use_original_title       = (
 				'' !== trim( $original_attachment->post_title ) &&
 				// Check if the original image's title was edited.
-				$parent_basename !== $sanitized_post_title &&
-				pathinfo( $parent_basename, PATHINFO_FILENAME ) !== $sanitized_post_title
+				( $parent_basename !== $sanitized_post_title ) &&
+				( pathinfo( $parent_basename, PATHINFO_FILENAME ) !== $sanitized_post_title )
 			);
 			$use_original_description = ( '' !== trim( $original_attachment->post_content ) );
 

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3982,7 +3982,10 @@ function wp_ajax_crop_image() {
 			$sanitized_post_title     = sanitize_file_name( $original_attachment->post_title );
 			$use_original_title       = (
 				'' !== trim( $original_attachment->post_title ) &&
-				// Check if the original image's title was edited.
+				/*
+				 * Check if the original image has a title other than the "filename" default,
+				 * meaning the image had a title when originally uploaded or its title was edited.
+				 */
 				( $parent_basename !== $sanitized_post_title ) &&
 				( pathinfo( $parent_basename, PATHINFO_FILENAME ) !== $sanitized_post_title )
 			);

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3986,15 +3986,15 @@ function wp_ajax_crop_image() {
 				'context'        => $context,
 			);
 
-			if ( trim( $attachment->post_title ) ) {
+			if ( 0 < mb_strlen( trim( $attachment->post_title ) ) ) {
 				$object['post_title'] = $attachment->post_title;
 			}
 
-			if ( trim( $attachment->post_content ) ) {
+			if ( 0 < mb_strlen( trim( $attachment->post_content ) ) ) {
 				$object['post_content'] = $attachment->post_content;
 			}
 
-			if ( trim( $attachment->post_excerpt )) {
+			if ( 0 < mb_strlen( trim( $attachment->post_excerpt ) ) ) {
 				$object['post_excerpt'] = $attachment->post_excerpt;
 			}
 

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3975,8 +3975,8 @@ function wp_ajax_crop_image() {
 
 			$size       = wp_getimagesize( $cropped );
 			$image_type = ( $size ) ? $size['mime'] : 'image/jpeg';
-			/** @var WP_Post $attachment */
-			$attachment = get_post( $attachment_id );
+			/** @var WP_Post $original_attachment */
+			$original_attachment = get_post( $attachment_id );
 
 			$object = array(
 				'post_title'     => wp_basename( $cropped ),
@@ -3986,20 +3986,27 @@ function wp_ajax_crop_image() {
 				'context'        => $context,
 			);
 
-			if ( 0 < mb_strlen( trim( $attachment->post_title ) ) ) {
-				$object['post_title'] = $attachment->post_title;
+			if ( 0 < mb_strlen( trim( $original_attachment->post_title ) ) ) {
+				$object['post_title'] = $original_attachment->post_title;
 			}
 
-			if ( 0 < mb_strlen( trim( $attachment->post_content ) ) ) {
-				$object['post_content'] = $attachment->post_content;
+			if ( 0 < mb_strlen( trim( $original_attachment->post_content ) ) ) {
+				$object['post_content'] = $original_attachment->post_content;
 			}
 
-			if ( 0 < mb_strlen( trim( $attachment->post_excerpt ) ) ) {
-				$object['post_excerpt'] = $attachment->post_excerpt;
+			if ( 0 < mb_strlen( trim( $original_attachment->post_excerpt ) ) ) {
+				$object['post_excerpt'] = $original_attachment->post_excerpt;
 			}
+
+			// Copy the image alt text from the edited image.
+			$image_alt = get_post_meta( $attachment_id, '_wp_attachment_image_alt', true );
 
 			$attachment_id = wp_insert_attachment( $object, $cropped );
 			$metadata      = wp_generate_attachment_metadata( $attachment_id, $cropped );
+
+			if ( 0 < mb_strlen( trim( $image_alt ) ) ) {
+				update_post_meta( $attachment_id, '_wp_attachment_image_alt', wp_slash( $image_alt ) );
+			}
 
 			/**
 			 * Filters the cropped image attachment metadata.

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3977,8 +3977,8 @@ function wp_ajax_crop_image() {
 			$image_type = ( $size ) ? $size['mime'] : 'image/jpeg';
 			/** @var WP_Post $original_attachment */
 			$original_attachment = get_post( $attachment_id );
-			$has_title           = 0 < mb_strlen( trim( $original_attachment->post_title ) );
-			$has_description     = 0 < mb_strlen( trim( $original_attachment->post_content ) );
+			$has_title           = mb_strlen( trim( $original_attachment->post_title ) ) > 0;
+			$has_description     = mb_strlen( trim( $original_attachment->post_content ) ) > 0;
 
 			$object = array(
 				// Copy the image title attribute (post_content field) from the original image.

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3983,8 +3983,8 @@ function wp_ajax_crop_image() {
 			$use_original_title       = (
 				'' !== trim( $original_attachment->post_title ) &&
 				// Check if the original image's title was edited.
-				( $parent_basename !== $sanitized_post_title ) &&
-				( pathinfo( $parent_basename, PATHINFO_FILENAME ) !== $sanitized_post_title )
+				$parent_basename !== $sanitized_post_title &&
+				pathinfo( $parent_basename, PATHINFO_FILENAME ) !== $sanitized_post_title
 			);
 			$use_original_description = ( '' !== trim( $original_attachment->post_content ) );
 

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3986,26 +3986,24 @@ function wp_ajax_crop_image() {
 				'context'        => $context,
 			);
 
-			if ( 0 < mb_strlen( trim( $original_attachment->post_title ) ) ) {
+			if ( mb_strlen( trim( $original_attachment->post_title ) ) ) {
 				$object['post_title'] = $original_attachment->post_title;
 			}
 
-			if ( 0 < mb_strlen( trim( $original_attachment->post_content ) ) ) {
+			if ( mb_strlen( trim( $original_attachment->post_content ) ) ) {
 				$object['post_content'] = $original_attachment->post_content;
 			}
 
-			if ( 0 < mb_strlen( trim( $original_attachment->post_excerpt ) ) ) {
+			if ( mb_strlen( trim( $original_attachment->post_excerpt ) ) ) {
 				$object['post_excerpt'] = $original_attachment->post_excerpt;
 			}
-
-			// Copy the image alt text from the edited image.
-			$image_alt = get_post_meta( $attachment_id, '_wp_attachment_image_alt', true );
 
 			$attachment_id = wp_insert_attachment( $object, $cropped );
 			$metadata      = wp_generate_attachment_metadata( $attachment_id, $cropped );
 
-			if ( 0 < mb_strlen( trim( $image_alt ) ) ) {
-				update_post_meta( $attachment_id, '_wp_attachment_image_alt', wp_slash( $image_alt ) );
+			// Copy the image alt text from the edited image.
+			if ( mb_strlen( trim( $original_attachment->_wp_attachment_image_alt ) ) ) {
+				update_post_meta( $attachment_id, '_wp_attachment_image_alt', wp_slash( $original_attachment->_wp_attachment_image_alt ) );
 			}
 
 			/**

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -4004,13 +4004,15 @@ function wp_ajax_crop_image() {
 				$object['post_excerpt'] = $original_attachment->post_excerpt;
 			}
 
-			$attachment_id = wp_insert_attachment( $object, $cropped );
-			$metadata      = wp_generate_attachment_metadata( $attachment_id, $cropped );
-
 			// Copy the image alt text attribute from the original image.
 			if ( '' !== trim( $original_attachment->_wp_attachment_image_alt ) ) {
-				update_post_meta( $attachment_id, '_wp_attachment_image_alt', wp_slash( $original_attachment->_wp_attachment_image_alt ) );
+				$object['meta_input'] = array(
+					'_wp_attachment_image_alt' => wp_slash( $original_attachment->_wp_attachment_image_alt ),
+				);
 			}
+
+			$attachment_id = wp_insert_attachment( $object, $cropped );
+			$metadata      = wp_generate_attachment_metadata( $attachment_id, $cropped );
 
 			/**
 			 * Filters the cropped image attachment metadata.

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3977,18 +3977,20 @@ function wp_ajax_crop_image() {
 			$image_type = ( $size ) ? $size['mime'] : 'image/jpeg';
 			/** @var WP_Post $original_attachment */
 			$original_attachment = get_post( $attachment_id );
-			$has_content = 0 < mb_strlen( trim( $original_attachment->post_content ) );
+			$has_title           = 0 < mb_strlen( trim( $original_attachment->post_title ) );
+			$has_description     = 0 < mb_strlen( trim( $original_attachment->post_content ) );
 
 			$object = array(
-				'post_title'     => wp_basename( $cropped ),
-				// Copy the image title (post_content field) from the original image.
-				'post_content'   => $has_content ? $original_attachment->post_content : $url,
+				// Copy the image title attribute (post_content field) from the original image.
+				'post_title'     => $has_title ? $original_attachment->post_title : wp_basename( $cropped ),
+				// Copy the image description attribute (post_content field) from the original image.
+				'post_content'   => $has_description ? $original_attachment->post_content : $url,
 				'post_mime_type' => $image_type,
 				'guid'           => $url,
 				'context'        => $context,
 			);
 
-			// Copy the image caption (post_excerpt field) from the original image.
+			// Copy the image caption attribute (post_excerpt field) from the original image.
 			if ( mb_strlen( trim( $original_attachment->post_excerpt ) ) ) {
 				$object['post_excerpt'] = $original_attachment->post_excerpt;
 			}
@@ -3996,7 +3998,7 @@ function wp_ajax_crop_image() {
 			$attachment_id = wp_insert_attachment( $object, $cropped );
 			$metadata      = wp_generate_attachment_metadata( $attachment_id, $cropped );
 
-			// Copy the image alt text from the original image.
+			// Copy the image alt text attribute from the original image.
 			if ( mb_strlen( trim( $original_attachment->_wp_attachment_image_alt ) ) ) {
 				update_post_meta( $attachment_id, '_wp_attachment_image_alt', wp_slash( $original_attachment->_wp_attachment_image_alt ) );
 			}

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3975,6 +3975,8 @@ function wp_ajax_crop_image() {
 
 			$size       = wp_getimagesize( $cropped );
 			$image_type = ( $size ) ? $size['mime'] : 'image/jpeg';
+			/** @var WP_Post $attachment */
+			$attachment = get_post( $attachment_id );
 
 			$object = array(
 				'post_title'     => wp_basename( $cropped ),
@@ -3983,6 +3985,18 @@ function wp_ajax_crop_image() {
 				'guid'           => $url,
 				'context'        => $context,
 			);
+
+			if ( trim( $attachment->post_title ) ) {
+				$object['post_title'] = $attachment->post_title;
+			}
+
+			if ( trim( $attachment->post_content ) ) {
+				$object['post_content'] = $attachment->post_content;
+			}
+
+			if ( trim( $attachment->post_excerpt )) {
+				$object['post_excerpt'] = $attachment->post_excerpt;
+			}
 
 			$attachment_id = wp_insert_attachment( $object, $cropped );
 			$metadata      = wp_generate_attachment_metadata( $attachment_id, $cropped );

--- a/tests/phpunit/tests/ajax/CropImage.php
+++ b/tests/phpunit/tests/ajax/CropImage.php
@@ -136,8 +136,6 @@ class Tests_Ajax_CropImage extends WP_Ajax_UnitTestCase {
 
 	/**
 	 * @param array $response Response to validate.
-	 *
-	 * @return void
 	 */
 	private function validate_response( $response ) {
 		$this->assertArrayHasKey( 'success', $response, 'Response array must contain "success" key.' );
@@ -149,8 +147,6 @@ class Tests_Ajax_CropImage extends WP_Ajax_UnitTestCase {
 	 * Prepares $_POST for crop-image ajax action.
 	 *
 	 * @param WP_Post $attachment
-	 *
-	 * @return void
 	 */
 	private function prepare_post( WP_Post $attachment ) {
 		$_POST = array(

--- a/tests/phpunit/tests/ajax/CropImage.php
+++ b/tests/phpunit/tests/ajax/CropImage.php
@@ -12,7 +12,133 @@ require_once ABSPATH . 'wp-admin/includes/ajax-actions.php';
  */
 class Tests_Ajax_CropImage extends WP_Ajax_UnitTestCase {
 
+	/**
+	 * @covers wp_ajax_crop_image
+	 * @covers wp_insert_attachment
+	 */
 	public function test_it_copies_metadata_from_original_image() {
-		$this->addToAssertionCount(1);
+
+		// Become an administrator.
+		$this->_setRole( 'administrator' );
+
+		$attachement = $this->create_attachment();
+
+		$_POST = array (
+			'wp_customize' => 'on',
+			'nonce' => wp_create_nonce('image_editor-' . $attachement->ID),
+			'id' => $attachement->ID,
+			'context' => 'custom_logo',
+			'cropDetails' =>
+				array (
+					'x1' => '0',
+					'y1' => '0',
+					'x2' => '100',
+					'y2' => '100',
+					'width' => '100',
+					'height' => '100',
+					'dst_width' => '100',
+					'dst_height' => '100',
+				),
+			'action' => 'crop-image',
+		);
+
+		// Make the request.
+		try {
+			$this->_handleAjax( 'crop-image' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+		}
+
+		$response = json_decode( $this->_last_response, true );
+		$this->assertArrayHasKey('success', $response);
+		$this->assertArrayHasKey('data', $response);
+		$this->assertNotEmpty($response['data']['id']);
+		$cropped_attachment = get_post($response['data']['id']);
+		$this->assertInstanceOf(WP_Post::class, $cropped_attachment);
+
+		$this->assertNotEmpty($attachement->post_title);
+		$this->assertNotEmpty($cropped_attachment->post_title);
+		$this->assertNotSame($attachement->post_title, $cropped_attachment->post_title);
+		$this->assertSame($attachement->post_content, $cropped_attachment->post_content);
+		$this->assertSame($attachement->post_excerpt, $cropped_attachment->post_excerpt);
+		$this->assertSame($attachement->_wp_attachment_image_alt, $cropped_attachment->_wp_attachment_image_alt);
+
+		wp_delete_attachment($cropped_attachment->ID, true);
+	}
+
+	public function test_it_doesnt_add_metadata_if_it_is_empty() {
+
+		// Become an administrator.
+		$this->_setRole( 'administrator' );
+
+		$attachement = $this->create_attachment(false);
+
+		$_POST = array (
+			'wp_customize' => 'on',
+			'nonce' => wp_create_nonce('image_editor-' . $attachement->ID),
+			'id' => $attachement->ID,
+			'context' => 'custom_logo',
+			'cropDetails' =>
+				array (
+					'x1' => '0',
+					'y1' => '0',
+					'x2' => '100',
+					'y2' => '100',
+					'width' => '100',
+					'height' => '100',
+					'dst_width' => '100',
+					'dst_height' => '100',
+				),
+			'action' => 'crop-image',
+		);
+
+		// Make the request.
+		try {
+			$this->_handleAjax( 'crop-image' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+		}
+
+		$response = json_decode( $this->_last_response, true );
+		$this->assertArrayHasKey('success', $response);
+		$this->assertArrayHasKey('data', $response);
+		$this->assertNotEmpty($response['data']['id']);
+		$cropped_attachment = get_post($response['data']['id']);
+		$this->assertInstanceOf(WP_Post::class, $cropped_attachment);
+
+		$this->assertNotEmpty($attachement->post_title);
+		$this->assertNotEmpty($cropped_attachment->post_title);
+		$this->assertNotSame($attachement->post_title, $cropped_attachment->post_title);
+		$this->assertEmpty($cropped_attachment->post_content);
+		$this->assertEmpty($cropped_attachment->post_excerpt);
+		$this->assertEmpty($cropped_attachment->_wp_attachment_image_alt);
+
+		wp_delete_attachment($cropped_attachment->ID, true);
+	}
+
+	/**
+	 * Creates attachment.
+	 *
+	 * @return WP_Post
+	 */
+	private function create_attachment($with_metadata = true)
+	{
+		$uniq_id = uniqid();
+		$object = array (
+			'post_title' => 'Title ' . $uniq_id,
+			'post_content' => $with_metadata ? 'Description ' . $uniq_id : '',
+			'post_mime_type' => 'image/jpg',
+			'guid' => 'http://localhost/foo.jpg',
+			'context' => 'custom-logo',
+			'post_excerpt' => $with_metadata ? 'Caption ' . $uniq_id : '',
+		);
+		$filename      = DIR_TESTDATA . '/images/test-image.jpg';
+		$attachment_id = wp_insert_attachment( $object, $filename );
+
+		if ( $with_metadata) {
+			update_post_meta( $attachment_id, '_wp_attachment_image_alt', wp_slash( 'Alt ' . $uniq_id ) );
+		}
+
+		return get_post( $attachment_id );
 	}
 }

--- a/tests/phpunit/tests/ajax/CropImage.php
+++ b/tests/phpunit/tests/ajax/CropImage.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Admin Ajax functions to be tested.
+ */
+require_once ABSPATH . 'wp-admin/includes/ajax-actions.php';
+
+/**
+ * Testing Add Meta AJAX functionality.
+ *
+ * @group ajax
+ */
+class Tests_Ajax_CropImage extends WP_Ajax_UnitTestCase {
+
+	public function test_it_copies_metadata_from_original_image() {
+		$this->addToAssertionCount(1);
+	}
+}

--- a/tests/phpunit/tests/ajax/CropImage.php
+++ b/tests/phpunit/tests/ajax/CropImage.php
@@ -4,6 +4,8 @@
  * Admin Ajax functions to be tested.
  */
 require_once ABSPATH . 'wp-admin/includes/ajax-actions.php';
+require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-base.php';
+require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-direct.php';
 
 /**
  * Testing Add Meta AJAX functionality.
@@ -21,111 +23,72 @@ class Tests_Ajax_CropImage extends WP_Ajax_UnitTestCase {
 		// Become an administrator.
 		$this->_setRole( 'administrator' );
 
-		$attachement = $this->create_attachment();
-
-		$_POST = array(
-			'wp_customize' => 'on',
-			'nonce'        => wp_create_nonce( 'image_editor-' . $attachement->ID ),
-			'id'           => $attachement->ID,
-			'context'      => 'custom_logo',
-			'cropDetails'  =>
-				array(
-					'x1'         => '0',
-					'y1'         => '0',
-					'x2'         => '100',
-					'y2'         => '100',
-					'width'      => '100',
-					'height'     => '100',
-					'dst_width'  => '100',
-					'dst_height' => '100',
-				),
-			'action'       => 'crop-image',
-		);
+		$attachment = $this->create_attachment();
+		$this->prepare_post( $attachment );
 
 		// Make the request.
 		try {
 			$this->_handleAjax( 'crop-image' );
 		} catch ( WPAjaxDieContinueException $e ) {
-			unset( $e );
 		}
 
 		$response = json_decode( $this->_last_response, true );
-		$this->assertArrayHasKey( 'success', $response );
-		$this->assertArrayHasKey( 'data', $response );
-		$this->assertNotEmpty( $response['data']['id'] );
+		$this->validate_response( $response );
+
 		$cropped_attachment = get_post( $response['data']['id'] );
 		$this->assertInstanceOf( WP_Post::class, $cropped_attachment );
-
-		$this->assertNotEmpty( $attachement->post_title );
+		$this->assertNotEmpty( $attachment->post_title );
 		$this->assertNotEmpty( $cropped_attachment->post_title );
-		$this->assertNotSame( $attachement->post_title, $cropped_attachment->post_title );
-		$this->assertSame( $attachement->post_content, $cropped_attachment->post_content );
-		$this->assertSame( $attachement->post_excerpt, $cropped_attachment->post_excerpt );
-		$this->assertSame( $attachement->_wp_attachment_image_alt, $cropped_attachment->_wp_attachment_image_alt );
+		$this->assertNotSame( $attachment->post_title, $cropped_attachment->post_title );
+		$this->assertSame( $attachment->post_content, $cropped_attachment->post_content );
+		$this->assertSame( $attachment->post_excerpt, $cropped_attachment->post_excerpt );
+		$this->assertSame( $attachment->_wp_attachment_image_alt, $cropped_attachment->_wp_attachment_image_alt );
 
-		wp_delete_post( $attachement->ID );
-		wp_delete_attachment( $cropped_attachment->ID, true );
-	}
-
-	public function test_it_doesnt_add_metadata_if_it_is_empty() {
-
-		// Become an administrator.
-		$this->_setRole( 'administrator' );
-
-		$attachement = $this->create_attachment( false );
-
-		$_POST = array(
-			'wp_customize' => 'on',
-			'nonce'        => wp_create_nonce( 'image_editor-' . $attachement->ID ),
-			'id'           => $attachement->ID,
-			'context'      => 'custom_logo',
-			'cropDetails'  =>
-				array(
-					'x1'         => '0',
-					'y1'         => '0',
-					'x2'         => '100',
-					'y2'         => '100',
-					'width'      => '100',
-					'height'     => '100',
-					'dst_width'  => '100',
-					'dst_height' => '100',
-				),
-			'action'       => 'crop-image',
-		);
-
-		// Make the request.
-		try {
-			$this->_handleAjax( 'crop-image' );
-		} catch ( WPAjaxDieContinueException $e ) {
-			unset( $e );
-		}
-
-		$response = json_decode( $this->_last_response, true );
-		$this->assertArrayHasKey( 'success', $response );
-		$this->assertArrayHasKey( 'data', $response );
-		$this->assertNotEmpty( $response['data']['id'] );
-		$cropped_attachment = get_post( $response['data']['id'] );
-		$this->assertInstanceOf( WP_Post::class, $cropped_attachment );
-
-		$this->assertNotEmpty( $attachement->post_title );
-		$this->assertNotEmpty( $cropped_attachment->post_title );
-		$this->assertNotSame( $attachement->post_title, $cropped_attachment->post_title );
-		$this->assertStringStartsWith( 'http', $cropped_attachment->post_content );
-		$this->assertEmpty( $cropped_attachment->post_excerpt );
-		$this->assertEmpty( $cropped_attachment->_wp_attachment_image_alt );
-
-		wp_delete_post( $attachement->ID );
+		wp_delete_attachment( $attachment->ID, true );
 		wp_delete_attachment( $cropped_attachment->ID, true );
 	}
 
 	/**
-	 * Creates attachment.
+	 * @covers wp_ajax_crop_image
+	 * @covers wp_insert_attachment
+	 */
+	public function test_it_doesnt_generate_new_metadata_if_metadata_is_empty() {
+		// Become an administrator.
+		$this->_setRole( 'administrator' );
+
+		$attachment = $this->create_attachment( false );
+		$this->prepare_post( $attachment );
+
+		// Make the request.
+		try {
+			$this->_handleAjax( 'crop-image' );
+		} catch ( WPAjaxDieContinueException $e ) {
+		}
+
+		$response = json_decode( $this->_last_response, true );
+		$this->validate_response( $response );
+
+		$cropped_attachment = get_post( $response['data']['id'] );
+		$this->assertInstanceOf( WP_Post::class, $cropped_attachment );
+		$this->assertNotEmpty( $attachment->post_title );
+		$this->assertNotEmpty( $cropped_attachment->post_title );
+		$this->assertNotSame( $attachment->post_title, $cropped_attachment->post_title );
+		$this->assertStringStartsWith( 'http', $cropped_attachment->post_content );
+		$this->assertEmpty( $cropped_attachment->post_excerpt );
+		$this->assertEmpty( $cropped_attachment->_wp_attachment_image_alt );
+
+		wp_delete_attachment( $attachment->ID, true );
+		wp_delete_attachment( $cropped_attachment->ID, true );
+	}
+
+	/**
+	 * Creates an attachment.
 	 *
 	 * @return WP_Post
 	 */
 	private function create_attachment( $with_metadata = true ) {
-		$uniq_id       = uniqid();
-		$object        = array(
+		$uniq_id = uniqid();
+		$object  = array(
 			'post_title'     => 'Title ' . $uniq_id,
 			'post_content'   => $with_metadata ? 'Description ' . $uniq_id : '',
 			'post_mime_type' => 'image/jpg',
@@ -133,13 +96,57 @@ class Tests_Ajax_CropImage extends WP_Ajax_UnitTestCase {
 			'context'        => 'custom-logo',
 			'post_excerpt'   => $with_metadata ? 'Caption ' . $uniq_id : '',
 		);
-		$filename      = DIR_TESTDATA . '/images/test-image.jpg';
-		$attachment_id = wp_insert_attachment( $object, $filename );
+
+		$test_file        = DIR_TESTDATA . '/images/test-image.jpg';
+		$upload_directory = wp_upload_dir();
+		$uploaded_file    = $upload_directory['path'] . '/' . $uniq_id . '.jpg';
+		$filesystem       = new WP_Filesystem_Direct( true );
+		$filesystem->copy( $test_file, $uploaded_file );
+		$attachment_id = wp_insert_attachment( $object, $uploaded_file );
 
 		if ( $with_metadata ) {
 			update_post_meta( $attachment_id, '_wp_attachment_image_alt', wp_slash( 'Alt ' . $uniq_id ) );
 		}
 
 		return get_post( $attachment_id );
+	}
+
+	/**
+	 * @param array $response Response to validate.
+	 *
+	 * @return void
+	 */
+	private function validate_response( $response ) {
+		$this->assertArrayHasKey( 'success', $response );
+		$this->assertArrayHasKey( 'data', $response );
+		$this->assertNotEmpty( $response['data']['id'] );
+	}
+
+	/**
+	 * Prepares $_POST for crop-image ajax action.
+	 *
+	 * @param WP_Post $attachment
+	 *
+	 * @return void
+	 */
+	private function prepare_post( WP_Post $attachment ) {
+		$_POST = array(
+			'wp_customize' => 'on',
+			'nonce'        => wp_create_nonce( 'image_editor-' . $attachment->ID ),
+			'id'           => $attachment->ID,
+			'context'      => 'custom_logo',
+			'cropDetails'  =>
+				array(
+					'x1'         => '0',
+					'y1'         => '0',
+					'x2'         => '100',
+					'y2'         => '100',
+					'width'      => '100',
+					'height'     => '100',
+					'dst_width'  => '100',
+					'dst_height' => '100',
+				),
+			'action'       => 'crop-image',
+		);
 	}
 }

--- a/tests/phpunit/tests/ajax/CropImage.php
+++ b/tests/phpunit/tests/ajax/CropImage.php
@@ -29,10 +29,6 @@ class Tests_Ajax_CropImage extends WP_Ajax_UnitTestCase {
 	 * @covers ::wp_ajax_crop_image
 	 */
 	public function test_it_copies_metadata_from_original_image() {
-
-		// Become an administrator.
-		$this->_setRole( 'administrator' );
-
 		$this->attachment = $this->create_attachment( true );
 		$this->prepare_post( $this->attachment );
 
@@ -63,9 +59,6 @@ class Tests_Ajax_CropImage extends WP_Ajax_UnitTestCase {
 	 * @covers ::wp_ajax_crop_image
 	 */
 	public function test_it_doesnt_generate_new_metadata_if_metadata_is_empty() {
-		// Become an administrator.
-		$this->_setRole( 'administrator' );
-
 		$this->attachment = $this->create_attachment( false );
 		$this->prepare_post( $this->attachment );
 
@@ -85,6 +78,13 @@ class Tests_Ajax_CropImage extends WP_Ajax_UnitTestCase {
 		$this->assertStringStartsWith( 'http', $this->cropped_attachment->post_content, 'post_content value should contain an URL if it\'s empty in the original attachment' );
 		$this->assertEmpty( $this->cropped_attachment->post_excerpt, 'post_excerpt value must be empty if it\'s empty in the original attachment' );
 		$this->assertEmpty( $this->cropped_attachment->_wp_attachment_image_alt, '_wp_attachment_image_alt value must be empty if it\'s empty in the original attachment' );
+	}
+
+	public function set_up() {
+		parent::set_up();
+
+		// Become an administrator.
+		$this->_setRole( 'administrator' );
 	}
 
 	/**

--- a/tests/phpunit/tests/ajax/CropImage.php
+++ b/tests/phpunit/tests/ajax/CropImage.php
@@ -11,6 +11,7 @@ require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-direct.php';
 /**
  * Class for testing ajax crop image functionality.
  *
+ * @covers ::wp_ajax_crop_image
  * @group ajax
  */
 class Tests_Ajax_CropImage extends WP_Ajax_UnitTestCase {
@@ -25,8 +26,6 @@ class Tests_Ajax_CropImage extends WP_Ajax_UnitTestCase {
 	 * Tests that attachment properties are copied over to the cropped image.
 	 *
 	 * @ticket 37750
-	 *
-	 * @covers ::wp_ajax_crop_image
 	 */
 	public function test_it_copies_metadata_from_original_image() {
 		$this->attachment = $this->create_attachment( true );
@@ -55,8 +54,6 @@ class Tests_Ajax_CropImage extends WP_Ajax_UnitTestCase {
 	 * Tests that attachment properties are not auto-generated if they are not defined for the original image.
 	 *
 	 * @ticket 37750
-	 *
-	 * @covers ::wp_ajax_crop_image
 	 */
 	public function test_it_doesnt_generate_new_metadata_if_metadata_is_empty() {
 		$this->attachment = $this->create_attachment( false );

--- a/tests/phpunit/tests/ajax/CropImage.php
+++ b/tests/phpunit/tests/ajax/CropImage.php
@@ -16,7 +16,6 @@ class Tests_Ajax_CropImage extends WP_Ajax_UnitTestCase {
 
 	/**
 	 * @covers wp_ajax_crop_image
-	 * @covers wp_insert_attachment
 	 */
 	public function test_it_copies_metadata_from_original_image() {
 
@@ -50,7 +49,6 @@ class Tests_Ajax_CropImage extends WP_Ajax_UnitTestCase {
 
 	/**
 	 * @covers wp_ajax_crop_image
-	 * @covers wp_insert_attachment
 	 */
 	public function test_it_doesnt_generate_new_metadata_if_metadata_is_empty() {
 		// Become an administrator.

--- a/tests/phpunit/tests/ajax/CropImage.php
+++ b/tests/phpunit/tests/ajax/CropImage.php
@@ -4,11 +4,12 @@
  * Admin Ajax functions to be tested.
  */
 require_once ABSPATH . 'wp-admin/includes/ajax-actions.php';
+
 require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-base.php';
 require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-direct.php';
 
 /**
- * Testing Add Meta AJAX functionality.
+ * Class for testing ajax crop image functionality.
  *
  * @group ajax
  */

--- a/tests/phpunit/tests/ajax/CropImage.php
+++ b/tests/phpunit/tests/ajax/CropImage.php
@@ -40,13 +40,13 @@ class Tests_Ajax_CropImage extends WP_Ajax_UnitTestCase {
 		$this->validate_response( $response );
 
 		$cropped_attachment = get_post( $response['data']['id'] );
-		$this->assertInstanceOf( WP_Post::class, $cropped_attachment );
-		$this->assertNotEmpty( $attachment->post_title );
-		$this->assertNotEmpty( $cropped_attachment->post_title );
-		$this->assertSame( $attachment->post_title, $cropped_attachment->post_title );
-		$this->assertSame( $attachment->post_content, $cropped_attachment->post_content );
-		$this->assertSame( $attachment->post_excerpt, $cropped_attachment->post_excerpt );
-		$this->assertSame( $attachment->_wp_attachment_image_alt, $cropped_attachment->_wp_attachment_image_alt );
+		$this->assertInstanceOf( WP_Post::class, $cropped_attachment, 'get_post function must return an instance of WP_Post class' );
+		$this->assertNotEmpty( $attachment->post_title, 'post_title value must not be empty for testing purposes' );
+		$this->assertNotEmpty( $cropped_attachment->post_title, 'post_title value must not be empty for testing purposes' );
+		$this->assertSame( $attachment->post_title, $cropped_attachment->post_title, 'post_title value should be copied over to the cropped attachment' );
+		$this->assertSame( $attachment->post_content, $cropped_attachment->post_content, 'post_content value should be copied over to the cropped attachment' );
+		$this->assertSame( $attachment->post_excerpt, $cropped_attachment->post_excerpt, 'post_excerpt value should be copied over to the cropped attachment' );
+		$this->assertSame( $attachment->_wp_attachment_image_alt, $cropped_attachment->_wp_attachment_image_alt, '_wp_attachment_image_alt value should be copied over to the cropped attachment' );
 
 		wp_delete_attachment( $attachment->ID, true );
 		wp_delete_attachment( $cropped_attachment->ID, true );
@@ -76,12 +76,12 @@ class Tests_Ajax_CropImage extends WP_Ajax_UnitTestCase {
 		$this->validate_response( $response );
 
 		$cropped_attachment = get_post( $response['data']['id'] );
-		$this->assertInstanceOf( WP_Post::class, $cropped_attachment );
-		$this->assertEmpty( $attachment->post_title );
-		$this->assertNotEmpty( $cropped_attachment->post_title );
-		$this->assertStringStartsWith( 'http', $cropped_attachment->post_content );
-		$this->assertEmpty( $cropped_attachment->post_excerpt );
-		$this->assertEmpty( $cropped_attachment->_wp_attachment_image_alt );
+		$this->assertInstanceOf( WP_Post::class, $cropped_attachment, 'get_post function must return an instance of WP_Post class' );
+		$this->assertEmpty( $attachment->post_title, 'post_title value must be empty for testing purposes' );
+		$this->assertNotEmpty( $cropped_attachment->post_title, 'post_title value must be auto-generated if it\'s empty in the original attachment' );
+		$this->assertStringStartsWith( 'http', $cropped_attachment->post_content, 'post_content value should contain an URL if it\'s empty in the original attachment' );
+		$this->assertEmpty( $cropped_attachment->post_excerpt, 'post_excerpt value must be empty if it\'s empty in the original attachment' );
+		$this->assertEmpty( $cropped_attachment->_wp_attachment_image_alt, '_wp_attachment_image_alt value must be empty if it\'s empty in the original attachment' );
 
 		wp_delete_attachment( $attachment->ID, true );
 		wp_delete_attachment( $cropped_attachment->ID, true );
@@ -123,9 +123,9 @@ class Tests_Ajax_CropImage extends WP_Ajax_UnitTestCase {
 	 * @return void
 	 */
 	private function validate_response( $response ) {
-		$this->assertArrayHasKey( 'success', $response );
-		$this->assertArrayHasKey( 'data', $response );
-		$this->assertNotEmpty( $response['data']['id'] );
+		$this->assertArrayHasKey( 'success', $response, 'Response array must contain "success" key.' );
+		$this->assertArrayHasKey( 'data', $response, 'Response array must contain "data" key.' );
+		$this->assertNotEmpty( $response['data']['id'], 'Response array must contain "ID" value of the post entity.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/ajax/CropImage.php
+++ b/tests/phpunit/tests/ajax/CropImage.php
@@ -23,7 +23,7 @@ class Tests_Ajax_CropImage extends WP_Ajax_UnitTestCase {
 		// Become an administrator.
 		$this->_setRole( 'administrator' );
 
-		$attachment = $this->create_attachment();
+		$attachment = $this->create_attachment( true );
 		$this->prepare_post( $attachment );
 
 		// Make the request.
@@ -39,7 +39,7 @@ class Tests_Ajax_CropImage extends WP_Ajax_UnitTestCase {
 		$this->assertInstanceOf( WP_Post::class, $cropped_attachment );
 		$this->assertNotEmpty( $attachment->post_title );
 		$this->assertNotEmpty( $cropped_attachment->post_title );
-		$this->assertNotSame( $attachment->post_title, $cropped_attachment->post_title );
+		$this->assertSame( $attachment->post_title, $cropped_attachment->post_title );
 		$this->assertSame( $attachment->post_content, $cropped_attachment->post_content );
 		$this->assertSame( $attachment->post_excerpt, $cropped_attachment->post_excerpt );
 		$this->assertSame( $attachment->_wp_attachment_image_alt, $cropped_attachment->_wp_attachment_image_alt );
@@ -70,9 +70,8 @@ class Tests_Ajax_CropImage extends WP_Ajax_UnitTestCase {
 
 		$cropped_attachment = get_post( $response['data']['id'] );
 		$this->assertInstanceOf( WP_Post::class, $cropped_attachment );
-		$this->assertNotEmpty( $attachment->post_title );
+		$this->assertEmpty( $attachment->post_title );
 		$this->assertNotEmpty( $cropped_attachment->post_title );
-		$this->assertNotSame( $attachment->post_title, $cropped_attachment->post_title );
 		$this->assertStringStartsWith( 'http', $cropped_attachment->post_content );
 		$this->assertEmpty( $cropped_attachment->post_excerpt );
 		$this->assertEmpty( $cropped_attachment->_wp_attachment_image_alt );
@@ -87,9 +86,9 @@ class Tests_Ajax_CropImage extends WP_Ajax_UnitTestCase {
 	 * @return WP_Post
 	 */
 	private function create_attachment( $with_metadata = true ) {
-		$uniq_id = uniqid();
+		$uniq_id = uniqid( 'crop-image-ajax-action-test-' );
 		$object  = array(
-			'post_title'     => 'Title ' . $uniq_id,
+			'post_title'     => $with_metadata ? 'Title ' . $uniq_id : '',
 			'post_content'   => $with_metadata ? 'Description ' . $uniq_id : '',
 			'post_mime_type' => 'image/jpg',
 			'guid'           => 'http://localhost/foo.jpg',

--- a/tests/phpunit/tests/ajax/CropImage.php
+++ b/tests/phpunit/tests/ajax/CropImage.php
@@ -23,23 +23,23 @@ class Tests_Ajax_CropImage extends WP_Ajax_UnitTestCase {
 
 		$attachement = $this->create_attachment();
 
-		$_POST = array (
+		$_POST = array(
 			'wp_customize' => 'on',
-			'nonce' => wp_create_nonce('image_editor-' . $attachement->ID),
-			'id' => $attachement->ID,
-			'context' => 'custom_logo',
-			'cropDetails' =>
-				array (
-					'x1' => '0',
-					'y1' => '0',
-					'x2' => '100',
-					'y2' => '100',
-					'width' => '100',
-					'height' => '100',
-					'dst_width' => '100',
+			'nonce'        => wp_create_nonce( 'image_editor-' . $attachement->ID ),
+			'id'           => $attachement->ID,
+			'context'      => 'custom_logo',
+			'cropDetails'  =>
+				array(
+					'x1'         => '0',
+					'y1'         => '0',
+					'x2'         => '100',
+					'y2'         => '100',
+					'width'      => '100',
+					'height'     => '100',
+					'dst_width'  => '100',
 					'dst_height' => '100',
 				),
-			'action' => 'crop-image',
+			'action'       => 'crop-image',
 		);
 
 		// Make the request.
@@ -50,20 +50,21 @@ class Tests_Ajax_CropImage extends WP_Ajax_UnitTestCase {
 		}
 
 		$response = json_decode( $this->_last_response, true );
-		$this->assertArrayHasKey('success', $response);
-		$this->assertArrayHasKey('data', $response);
-		$this->assertNotEmpty($response['data']['id']);
-		$cropped_attachment = get_post($response['data']['id']);
-		$this->assertInstanceOf(WP_Post::class, $cropped_attachment);
+		$this->assertArrayHasKey( 'success', $response );
+		$this->assertArrayHasKey( 'data', $response );
+		$this->assertNotEmpty( $response['data']['id'] );
+		$cropped_attachment = get_post( $response['data']['id'] );
+		$this->assertInstanceOf( WP_Post::class, $cropped_attachment );
 
-		$this->assertNotEmpty($attachement->post_title);
-		$this->assertNotEmpty($cropped_attachment->post_title);
-		$this->assertNotSame($attachement->post_title, $cropped_attachment->post_title);
-		$this->assertSame($attachement->post_content, $cropped_attachment->post_content);
-		$this->assertSame($attachement->post_excerpt, $cropped_attachment->post_excerpt);
-		$this->assertSame($attachement->_wp_attachment_image_alt, $cropped_attachment->_wp_attachment_image_alt);
+		$this->assertNotEmpty( $attachement->post_title );
+		$this->assertNotEmpty( $cropped_attachment->post_title );
+		$this->assertNotSame( $attachement->post_title, $cropped_attachment->post_title );
+		$this->assertSame( $attachement->post_content, $cropped_attachment->post_content );
+		$this->assertSame( $attachement->post_excerpt, $cropped_attachment->post_excerpt );
+		$this->assertSame( $attachement->_wp_attachment_image_alt, $cropped_attachment->_wp_attachment_image_alt );
 
-		wp_delete_attachment($cropped_attachment->ID, true);
+		wp_delete_post( $attachement->ID );
+		wp_delete_attachment( $cropped_attachment->ID, true );
 	}
 
 	public function test_it_doesnt_add_metadata_if_it_is_empty() {
@@ -71,25 +72,25 @@ class Tests_Ajax_CropImage extends WP_Ajax_UnitTestCase {
 		// Become an administrator.
 		$this->_setRole( 'administrator' );
 
-		$attachement = $this->create_attachment(false);
+		$attachement = $this->create_attachment( false );
 
-		$_POST = array (
+		$_POST = array(
 			'wp_customize' => 'on',
-			'nonce' => wp_create_nonce('image_editor-' . $attachement->ID),
-			'id' => $attachement->ID,
-			'context' => 'custom_logo',
-			'cropDetails' =>
-				array (
-					'x1' => '0',
-					'y1' => '0',
-					'x2' => '100',
-					'y2' => '100',
-					'width' => '100',
-					'height' => '100',
-					'dst_width' => '100',
+			'nonce'        => wp_create_nonce( 'image_editor-' . $attachement->ID ),
+			'id'           => $attachement->ID,
+			'context'      => 'custom_logo',
+			'cropDetails'  =>
+				array(
+					'x1'         => '0',
+					'y1'         => '0',
+					'x2'         => '100',
+					'y2'         => '100',
+					'width'      => '100',
+					'height'     => '100',
+					'dst_width'  => '100',
 					'dst_height' => '100',
 				),
-			'action' => 'crop-image',
+			'action'       => 'crop-image',
 		);
 
 		// Make the request.
@@ -100,20 +101,21 @@ class Tests_Ajax_CropImage extends WP_Ajax_UnitTestCase {
 		}
 
 		$response = json_decode( $this->_last_response, true );
-		$this->assertArrayHasKey('success', $response);
-		$this->assertArrayHasKey('data', $response);
-		$this->assertNotEmpty($response['data']['id']);
-		$cropped_attachment = get_post($response['data']['id']);
-		$this->assertInstanceOf(WP_Post::class, $cropped_attachment);
+		$this->assertArrayHasKey( 'success', $response );
+		$this->assertArrayHasKey( 'data', $response );
+		$this->assertNotEmpty( $response['data']['id'] );
+		$cropped_attachment = get_post( $response['data']['id'] );
+		$this->assertInstanceOf( WP_Post::class, $cropped_attachment );
 
-		$this->assertNotEmpty($attachement->post_title);
-		$this->assertNotEmpty($cropped_attachment->post_title);
-		$this->assertNotSame($attachement->post_title, $cropped_attachment->post_title);
-		$this->assertEmpty($cropped_attachment->post_content);
-		$this->assertEmpty($cropped_attachment->post_excerpt);
-		$this->assertEmpty($cropped_attachment->_wp_attachment_image_alt);
+		$this->assertNotEmpty( $attachement->post_title );
+		$this->assertNotEmpty( $cropped_attachment->post_title );
+		$this->assertNotSame( $attachement->post_title, $cropped_attachment->post_title );
+		$this->assertStringStartsWith( 'http', $cropped_attachment->post_content );
+		$this->assertEmpty( $cropped_attachment->post_excerpt );
+		$this->assertEmpty( $cropped_attachment->_wp_attachment_image_alt );
 
-		wp_delete_attachment($cropped_attachment->ID, true);
+		wp_delete_post( $attachement->ID );
+		wp_delete_attachment( $cropped_attachment->ID, true );
 	}
 
 	/**
@@ -121,21 +123,20 @@ class Tests_Ajax_CropImage extends WP_Ajax_UnitTestCase {
 	 *
 	 * @return WP_Post
 	 */
-	private function create_attachment($with_metadata = true)
-	{
-		$uniq_id = uniqid();
-		$object = array (
-			'post_title' => 'Title ' . $uniq_id,
-			'post_content' => $with_metadata ? 'Description ' . $uniq_id : '',
+	private function create_attachment( $with_metadata = true ) {
+		$uniq_id       = uniqid();
+		$object        = array(
+			'post_title'     => 'Title ' . $uniq_id,
+			'post_content'   => $with_metadata ? 'Description ' . $uniq_id : '',
 			'post_mime_type' => 'image/jpg',
-			'guid' => 'http://localhost/foo.jpg',
-			'context' => 'custom-logo',
-			'post_excerpt' => $with_metadata ? 'Caption ' . $uniq_id : '',
+			'guid'           => 'http://localhost/foo.jpg',
+			'context'        => 'custom-logo',
+			'post_excerpt'   => $with_metadata ? 'Caption ' . $uniq_id : '',
 		);
 		$filename      = DIR_TESTDATA . '/images/test-image.jpg';
 		$attachment_id = wp_insert_attachment( $object, $filename );
 
-		if ( $with_metadata) {
+		if ( $with_metadata ) {
 			update_post_meta( $attachment_id, '_wp_attachment_image_alt', wp_slash( 'Alt ' . $uniq_id ) );
 		}
 

--- a/tests/phpunit/tests/ajax/CropImage.php
+++ b/tests/phpunit/tests/ajax/CropImage.php
@@ -16,7 +16,11 @@ require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-direct.php';
 class Tests_Ajax_CropImage extends WP_Ajax_UnitTestCase {
 
 	/**
-	 * @covers wp_ajax_crop_image
+	 * Tests that attachment properties are copied over to the cropped image.
+	 *
+	 * @ticket 37750
+	 *
+	 * @covers ::wp_ajax_crop_image
 	 */
 	public function test_it_copies_metadata_from_original_image() {
 
@@ -49,7 +53,11 @@ class Tests_Ajax_CropImage extends WP_Ajax_UnitTestCase {
 	}
 
 	/**
-	 * @covers wp_ajax_crop_image
+	 * Tests that attachment properties are not auto-generated if they are not defined for the original image.
+	 *
+	 * @ticket 37750
+	 *
+	 * @covers ::wp_ajax_crop_image
 	 */
 	public function test_it_doesnt_generate_new_metadata_if_metadata_is_empty() {
 		// Become an administrator.

--- a/tests/phpunit/tests/ajax/wpAjaxCropImage.php
+++ b/tests/phpunit/tests/ajax/wpAjaxCropImage.php
@@ -11,10 +11,10 @@ require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-direct.php';
 /**
  * Class for testing ajax crop image functionality.
  *
- * @covers ::wp_ajax_crop_image
  * @group ajax
+ * @covers ::wp_ajax_crop_image
  */
-class Tests_Ajax_CropImage extends WP_Ajax_UnitTestCase {
+class Tests_Ajax_WpAjaxCropImage extends WP_Ajax_UnitTestCase {
 
 	/** @var WP_Post|null */
 	private $attachment;

--- a/tests/phpunit/tests/ajax/wpAjaxCropImage.php
+++ b/tests/phpunit/tests/ajax/wpAjaxCropImage.php
@@ -4,7 +4,6 @@
  * Admin Ajax functions to be tested.
  */
 require_once ABSPATH . 'wp-admin/includes/ajax-actions.php';
-
 require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-base.php';
 require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-direct.php';
 

--- a/tests/phpunit/tests/ajax/wpAjaxCropImage.php
+++ b/tests/phpunit/tests/ajax/wpAjaxCropImage.php
@@ -84,10 +84,14 @@ class Tests_Ajax_WpAjaxCropImage extends WP_Ajax_UnitTestCase {
 
 		$this->attachment = $this->make_attachment( true );
 		$filename         = $this->get_attachment_filename( $this->attachment );
-		$this->attachment = get_post( wp_update_post( array(
-			'ID'         => $this->attachment->ID,
-			'post_title' => $filename,
-		) ) );
+		$this->attachment = get_post(
+			wp_update_post(
+				array(
+					'ID'         => $this->attachment->ID,
+					'post_title' => $filename,
+				)
+			)
+		);
 
 		$this->prepare_post( $this->attachment );
 
@@ -99,7 +103,6 @@ class Tests_Ajax_WpAjaxCropImage extends WP_Ajax_UnitTestCase {
 
 		$response = json_decode( $this->_last_response, true );
 		$this->validate_response( $response );
-
 
 		$this->cropped_attachment = get_post( $response['data']['id'] );
 		$this->assertInstanceOf( WP_Post::class, $this->cropped_attachment, 'get_post function must return an instance of WP_Post class' );

--- a/tests/phpunit/tests/ajax/wpAjaxCropImage.php
+++ b/tests/phpunit/tests/ajax/wpAjaxCropImage.php
@@ -16,11 +16,36 @@ require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-direct.php';
  */
 class Tests_Ajax_WpAjaxCropImage extends WP_Ajax_UnitTestCase {
 
-	/** @var WP_Post|null */
+	/**
+	 * @var WP_Post|null
+	 */
 	private $attachment;
 
-	/** @var WP_Post|null */
+	/**
+	 * @var WP_Post|null
+	 */
 	private $cropped_attachment;
+
+	public function set_up() {
+		parent::set_up();
+
+		// Become an administrator.
+		$this->_setRole( 'administrator' );
+	}
+
+	public function tear_down() {
+		if ( $this->attachment instanceof WP_Post ) {
+			wp_delete_attachment( $this->attachment->ID, true );
+		}
+
+		if ( $this->cropped_attachment instanceof WP_Post ) {
+			wp_delete_attachment( $this->cropped_attachment->ID, true );
+		}
+		$this->attachment         = null;
+		$this->cropped_attachment = null;
+
+		parent::tear_down();
+	}
 
 	/**
 	 * Tests that attachment properties are copied over to the cropped image.
@@ -75,30 +100,6 @@ class Tests_Ajax_WpAjaxCropImage extends WP_Ajax_UnitTestCase {
 		$this->assertStringStartsWith( 'http', $this->cropped_attachment->post_content, 'post_content value should contain an URL if it\'s empty in the original attachment' );
 		$this->assertEmpty( $this->cropped_attachment->post_excerpt, 'post_excerpt value must be empty if it\'s empty in the original attachment' );
 		$this->assertEmpty( $this->cropped_attachment->_wp_attachment_image_alt, '_wp_attachment_image_alt value must be empty if it\'s empty in the original attachment' );
-	}
-
-	public function set_up() {
-		parent::set_up();
-
-		// Become an administrator.
-		$this->_setRole( 'administrator' );
-	}
-
-	/**
-	 * Deletes attachment files and post entities.
-	 */
-	public function tear_down() {
-		if ( $this->attachment instanceof WP_Post ) {
-			wp_delete_attachment( $this->attachment->ID, true );
-		}
-
-		if ( $this->cropped_attachment instanceof WP_Post ) {
-			wp_delete_attachment( $this->cropped_attachment->ID, true );
-		}
-		$this->attachment         = null;
-		$this->cropped_attachment = null;
-
-		parent::tear_down();
 	}
 
 	/**


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This PR aims to implement preserving attributes when cropping a custom logo image.

Steps to test this PR: https://core.trac.wordpress.org/ticket/37750#comment:26

Trac ticket: https://core.trac.wordpress.org/ticket/37750

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
