### PR TITLE
Tests_Image_Functions: various improvements to the tests (Trac 54725)

### DIFF
--- a/src/wp-admin/includes/image-edit.php
+++ b/src/wp-admin/includes/image-edit.php
@@ -351,12 +351,17 @@ function wp_stream_image( $image, $mime_type, $attachment_id ) {
  * Saves image to file.
  *
  * @since 2.9.0
+ * @since 3.5.0 The `$image` parameter now expects a WP_Image_Editor instance.
  *
  * @param string          $filename  Name of the file to be saved.
  * @param WP_Image_Editor $image     The image editor instance.
  * @param string          $mime_type The mime type of the image.
  * @param int             $post_id   Attachment post ID.
- * @return bool True on success, false on failure.
+ * @return array|WP_Error|bool Returns array{'path'=>string, 'file'=>string, 'width'=>int, 'height'=>int, 'mime-type'=>string}
+ *                             or WP_Error when the file failed to save.
+ *                             When the function is called with a deprecated value for the $image parameter, i.e
+ *                             a non-WP_Image_Editor image resource or GdImage instance, the function will
+ *                             return true on success, false on failure.
  */
 function wp_save_image_file( $filename, $image, $mime_type, $post_id ) {
 	if ( $image instanceof WP_Image_Editor ) {

--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -878,6 +878,35 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 	}
 
 	/**
+	 * Helper function to convert a single-level array containing text strings to a named data provider.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @param array $input Input array.
+	 * @return array Array which is usable as a test data provider with named data sets.
+	 */
+	public static function text_array_to_dataprovider( $input ) {
+		$data = array();
+		foreach ( $input as $value ) {
+			if ( ! is_string( $value ) ) {
+				throw new Exception(
+					'All values in the input array should be text strings. Fix the input data.'
+				);
+			}
+
+			if ( isset( $data[ $value ] ) ) {
+				throw new Exception(
+					"Attempting to add a duplicate data set for value $value to the data provider. Fix the input data."
+				);
+			}
+
+			$data[ $value ] = array( $value );
+		}
+
+		return $data;
+	}
+
+	/**
 	 * Sets the global state to as if a given URL has been requested.
 	 *
 	 * This sets:

--- a/tests/phpunit/tests/image/functions.php
+++ b/tests/phpunit/tests/image/functions.php
@@ -63,7 +63,24 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 		return $mime_type;
 	}
 
-	public function test_is_image_positive() {
+	/**
+	 * @dataProvider data_is_image_positive
+	 *
+	 * @covers ::file_is_valid_image
+	 * @covers ::wp_getimagesize
+	 *
+	 * @param string $file File name.
+	 */
+	public function test_is_image_positive( $file ) {
+		$this->assertTrue( file_is_valid_image( DIR_TESTDATA . '/images/' . $file ), "file_is_valid_image($file) should return true" );
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function data_is_image_positive() {
 		// These are all image files recognized by PHP.
 		$files = array(
 			'test-image-cmyk.jpg',
@@ -81,16 +98,10 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 			'webp-lossless.webp',
 			'webp-lossy.webp',
 			'webp-transparent.webp',
+			'test-image.ico',
 		);
 
-		// IMAGETYPE_ICO is only defined in PHP 5.3+.
-		if ( defined( 'IMAGETYPE_ICO' ) ) {
-			$files[] = 'test-image.ico';
-		}
-
-		foreach ( $files as $file ) {
-			$this->assertTrue( file_is_valid_image( DIR_TESTDATA . '/images/' . $file ), "file_is_valid_image($file) should return true" );
-		}
+		return $this->text_array_to_dataprovider( $files );
 	}
 
 	public function test_is_image_negative() {

--- a/tests/phpunit/tests/image/functions.php
+++ b/tests/phpunit/tests/image/functions.php
@@ -132,12 +132,29 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 		return $this->text_array_to_dataprovider( $files );
 	}
 
-	public function test_is_displayable_image_positive() {
+	/**
+	 * @dataProvider data_is_displayable_image_positive
+	 *
+	 * @covers ::file_is_displayable_image
+	 *
+	 * @param string $file File name.
+	 */
+	public function test_is_displayable_image_positive( $file ) {
+		$this->assertTrue( file_is_displayable_image( DIR_TESTDATA . '/images/' . $file ), "file_is_valid_image($file) should return true" );
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function data_is_displayable_image_positive() {
 		// These are all usable in typical web browsers.
 		$files = array(
 			'test-image.gif',
 			'test-image.png',
 			'test-image.jpg',
+			'test-image.ico',
 		);
 
 		// Add WebP images if the image editor supports them.
@@ -145,25 +162,13 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 		$editor = wp_get_image_editor( $file );
 
 		if ( ! is_wp_error( $editor ) && $editor->supports_mime_type( 'image/webp' ) ) {
-			$files = array_merge(
-				$files,
-				array(
-					'webp-animated.webp',
-					'webp-lossless.webp',
-					'webp-lossy.webp',
-					'webp-transparent.webp',
-				)
-			);
+			$files[] = 'webp-animated.webp';
+			$files[] = 'webp-lossless.webp';
+			$files[] = 'webp-lossy.webp';
+			$files[] = 'webp-transparent.webp';
 		}
 
-		// IMAGETYPE_ICO is only defined in PHP 5.3+.
-		if ( defined( 'IMAGETYPE_ICO' ) ) {
-			$files[] = 'test-image.ico';
-		}
-
-		foreach ( $files as $file ) {
-			$this->assertTrue( file_is_displayable_image( DIR_TESTDATA . '/images/' . $file ), "file_is_valid_image($file) should return true" );
-		}
+		return $this->text_array_to_dataprovider( $files );
 	}
 
 	public function test_is_displayable_image_negative() {

--- a/tests/phpunit/tests/image/functions.php
+++ b/tests/phpunit/tests/image/functions.php
@@ -55,6 +55,9 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 		$mime_type = '';
 var_dump(mime_content_type( $filename ));
 var_dump(image_type_to_mime_type( getimagesize( $filename )[2] ) );
+$finfo     = new finfo();
+var_dump($finfo->file( $filename, FILEINFO_MIME ));
+var_dump($finfo->file( $filename, FILEINFO_MIME_TYPE ));
 		if ( function_exists( 'mime_content_type' ) ) {
 			// Fileinfo extension is available.
 			return mime_content_type( $filename );
@@ -66,7 +69,6 @@ var_dump(image_type_to_mime_type( getimagesize( $filename )[2] ) );
 		}
 /*
 		if ( extension_loaded( 'fileinfo' ) ) {
-			$finfo     = new finfo();
 			$mime_type = $finfo->file( $filename, FILEINFO_MIME ); // If anything this should be changed to FILEINFO_MIME_TYPE
 		}
 		if ( false !== strpos( $mime_type, ';' ) ) {
@@ -279,6 +281,8 @@ var_dump(image_type_to_mime_type( getimagesize( $filename )[2] ) );
 
 		$file = wp_tempnam();
 		$ret  = wp_save_image_file( $file, $img, $mime_type, 1 );
+var_dump($file);
+var_dump($ret);
 
 		$this->assertNotEmpty( $ret, 'Image failed to save - "empty" response returned' );
 		$this->assertNotWPError( $ret, 'Image failed to save - WP Error returned' );
@@ -290,13 +294,13 @@ var_dump(image_type_to_mime_type( getimagesize( $filename )[2] ) );
 			$real_mime_type = image_type_to_mime_type( $image_info[2] );
 		}
 
-		$this->assertSame( $mime_type, $real_mime_type, 'Mime type of the saved image does not match' );
+//		$this->assertSame( $mime_type, $real_mime_type, 'Mime type of the saved image does not match' );
 //		$this->assertSame( $mime_type, mime_content_type( $ret['path'] ), 'Mime type of the saved image does not match' );
-//		$this->assertSame( $mime_type, $this->get_mime_type( $ret['path'] ), 'Mime type of the saved image does not match' );
+		$this->assertSame( $mime_type, $this->get_mime_type( $ret['path'] ), 'Mime type of the saved image does not match' );
 
 		// Clean up.
-		unlink( $file );
-		unlink( $ret['path'] );
+//		unlink( $file );
+//		unlink( $ret['path'] );
 		unset( $img );
 	}
 

--- a/tests/phpunit/tests/image/functions.php
+++ b/tests/phpunit/tests/image/functions.php
@@ -171,7 +171,23 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 		return $this->text_array_to_dataprovider( $files );
 	}
 
-	public function test_is_displayable_image_negative() {
+	/**
+	 * @dataProvider data_is_displayable_image_negative
+	 *
+	 * @covers ::file_is_displayable_image
+	 *
+	 * @param string $file File name.
+	 */
+	public function test_is_displayable_image_negative( $file ) {
+		$this->assertFalse( file_is_displayable_image( DIR_TESTDATA . '/images/' . $file ), "file_is_valid_image($file) should return false" );
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function data_is_displayable_image_negative() {
 		// These are image files but aren't suitable for web pages because of compatibility or size issues.
 		$files = array(
 			// 'test-image-cmyk.jpg',      Allowed in r9727.
@@ -187,9 +203,7 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 			'test-image-zip.tiff',
 		);
 
-		foreach ( $files as $file ) {
-			$this->assertFalse( file_is_displayable_image( DIR_TESTDATA . '/images/' . $file ), "file_is_valid_image($file) should return false" );
-		}
+		return $this->text_array_to_dataprovider( $files );
 	}
 
 	/**

--- a/tests/phpunit/tests/image/functions.php
+++ b/tests/phpunit/tests/image/functions.php
@@ -104,7 +104,24 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 		return $this->text_array_to_dataprovider( $files );
 	}
 
-	public function test_is_image_negative() {
+	/**
+	 * @dataProvider data_is_image_negative
+	 *
+	 * @covers ::file_is_valid_image
+	 * @covers ::wp_getimagesize
+	 *
+	 * @param string $file File name.
+	 */
+	public function test_is_image_negative( $file ) {
+		$this->assertFalse( file_is_valid_image( DIR_TESTDATA . '/images/' . $file ), "file_is_valid_image($file) should return false" );
+	}
+
+	/**
+	 * Data Provider.
+	 *
+	 * @return array
+	 */
+	public function data_is_image_negative() {
 		// These are actually image files but aren't recognized or usable by PHP.
 		$files = array(
 			'test-image.pct',
@@ -112,9 +129,7 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 			'test-image.sgi',
 		);
 
-		foreach ( $files as $file ) {
-			$this->assertFalse( file_is_valid_image( DIR_TESTDATA . '/images/' . $file ), "file_is_valid_image($file) should return false" );
-		}
+		return $this->text_array_to_dataprovider( $files );
 	}
 
 	public function test_is_displayable_image_positive() {

--- a/tests/phpunit/tests/image/functions.php
+++ b/tests/phpunit/tests/image/functions.php
@@ -28,6 +28,28 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Get the available image editor engine class(es).
+	 *
+	 * @return string[] Available image editor classes; empty array when none are available.
+	 */
+	private function get_image_editor_engine_classes() {
+		$classes = array( 'WP_Image_Editor_GD', 'WP_Image_Editor_Imagick' );
+
+		foreach ( $classes as $key => $class ) {
+			if ( ! call_user_func( array( $class, 'test' ) ) ) {
+				// If the image editor isn't available, skip it.
+				unset( $classes[ $key ] );
+			}
+		}
+
+		if ( empty( $classes ) ) {
+			$this->markTestSkipped( 'Image editor engines WP_Image_Editor_GD and WP_Image_Editor_Imagick are not supported on this system.' );
+		}
+
+		return $classes;
+	}
+
+	/**
 	 * Get the MIME type of a file
 	 *
 	 * @param string $filename
@@ -321,28 +343,6 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Get the available image editor engine class(es).
-	 *
-	 * @return string[] Available image editor classes; empty array when none are avaialble.
-	 */
-	private function get_image_editor_engine_classes() {
-		$classes = array( 'WP_Image_Editor_GD', 'WP_Image_Editor_Imagick' );
-
-		foreach ( $classes as $key => $class ) {
-			if ( ! call_user_func( array( $class, 'test' ) ) ) {
-				// If the image editor isn't available, skip it.
-				unset( $classes[ $key ] );
-			}
-		}
-
-		if ( empty( $classes ) ) {
-			$this->markTestSkipped( 'Image editor engines WP_Image_Editor_GD and WP_Image_Editor_Imagick are not supported on this system.' );
-		}
-
-		return $classes;
-	}
-
-	/**
 	 * @ticket 55403
 	 */
 	public function test_wp_crop_image_with_filtered_extension() {
@@ -446,10 +446,6 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 		$this->assertInstanceOf( 'WP_Error', $file );
 	}
 
-	public function mock_image_editor( $editors ) {
-		return array( 'WP_Image_Editor_Mock' );
-	}
-
 	/**
 	 * @ticket 23325
 	 */
@@ -470,6 +466,13 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 
 		remove_filter( 'wp_image_editors', array( $this, 'mock_image_editor' ) );
 		WP_Image_Editor_Mock::$save_return = array();
+	}
+
+	/**
+	 * @see test_wp_crop_image_error_on_saving()
+	 */
+	public function mock_image_editor( $editors ) {
+		return array( 'WP_Image_Editor_Mock' );
 	}
 
 	/**

--- a/tests/phpunit/tests/image/functions.php
+++ b/tests/phpunit/tests/image/functions.php
@@ -493,6 +493,7 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers   ::wp_crop_image
 	 * @requires function imagejpeg
 	 */
 	public function test_wp_crop_image_file() {
@@ -505,17 +506,20 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 			100,
 			100
 		);
-		$this->assertNotWPError( $file );
-		$this->assertFileExists( $file );
+		$this->assertNotWPError( $file, 'Cropping the image resulted in a WP_Error' );
+		$this->assertFileExists( $file, "The file $file does not exist" );
+
 		$image = wp_get_image_editor( $file );
 		$size  = $image->get_size();
-		$this->assertSame( 100, $size['height'] );
-		$this->assertSame( 100, $size['width'] );
+
+		$this->assertSame( 100, $size['height'], 'Cropped image height does not match expectation' );
+		$this->assertSame( 100, $size['width'], 'Cropped image width does not match expectation' );
 
 		unlink( $file );
 	}
 
 	/**
+	 * @covers   ::wp_crop_image
 	 * @requires function imagejpeg
 	 * @requires extension openssl
 	 */
@@ -536,16 +540,21 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 			$this->markTestSkipped( 'Tests_Image_Functions::test_wp_crop_image_url() cannot access remote image.' );
 		}
 
-		$this->assertNotWPError( $file );
-		$this->assertFileExists( $file );
+		$this->assertNotWPError( $file, 'Cropping the image resulted in a WP_Error' );
+		$this->assertFileExists( $file, "The file $file does not exist" );
+
 		$image = wp_get_image_editor( $file );
 		$size  = $image->get_size();
-		$this->assertSame( 100, $size['height'] );
-		$this->assertSame( 100, $size['width'] );
+
+		$this->assertSame( 100, $size['height'], 'Cropped image height does not match expectation' );
+		$this->assertSame( 100, $size['width'], 'Cropped image width does not match expectation' );
 
 		unlink( $file );
 	}
 
+	/**
+	 * @covers ::wp_crop_image
+	 */
 	public function test_wp_crop_image_file_not_exist() {
 		$file = wp_crop_image(
 			DIR_TESTDATA . '/images/canoladoesnotexist.jpg',
@@ -560,6 +569,7 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers ::wp_crop_image
 	 * @requires extension openssl
 	 */
 	public function test_wp_crop_image_url_not_exist() {
@@ -576,6 +586,7 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers ::wp_crop_image
 	 * @ticket 23325
 	 */
 	public function test_wp_crop_image_error_on_saving() {

--- a/tests/phpunit/tests/image/functions.php
+++ b/tests/phpunit/tests/image/functions.php
@@ -42,10 +42,6 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 			}
 		}
 
-		if ( empty( $classes ) ) {
-			$this->markTestSkipped( 'Image editor engines WP_Image_Editor_GD and WP_Image_Editor_Imagick are not supported on this system.' );
-		}
-
 		return $classes;
 	}
 


### PR DESCRIPTION
Started this branch to debug a couple of tests (webp related) which are failing on PHP 5.6 when NOT run inside the Docker container, using a standard PHP 5.6 install.

This generally would indicate a missing `@requires` tag or missing skip condition.

I've done a large test refactor for that particular test class as nearly all methods were testing using `foreach()` loops instead of data providers, so it was impossible to see what was really failing.

While looking into this I found the following curiousities:
1. A function which was changed in WP 3.5.0 `wp_save_image_file()`, apparently also changed return type - from `bool` to `array|WP_Error` (BC-break anyone ?) -, but the documentation does not reflect that.
    * Does nobody use the function ?
    * Or if they do, how can it be that nobody noticed this in 25 major releases ?
2. The failing tests are in part not actually testing what they should be testing and if tested this way, there seems to be some dependency on a particular (not necessarily standard) PHP compilation. I haven't been able to track down the exact difference or rather how to detect the difference, but the result is the failing tests.

Note: the last commit is very much WIP/debugging. The commits before that are valid improvements which can be (and should be) committed anyway.

Trac ticket: https://core.trac.wordpress.org/ticket/55652

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
