### PR TITLE
WP Admin menu overlap issue fix

### DIFF
--- a/src/js/_enqueues/admin/common.js
+++ b/src/js/_enqueues/admin/common.js
@@ -931,7 +931,7 @@ $( function() {
 			adjustment = maxtop;
 		}
 
-		if ( adjustment > 1 ) {
+		if ( adjustment > 1 && $window.width() > 783 ) {
 			$submenu.css( 'margin-top', '-' + adjustment + 'px' );
 		} else {
 			$submenu.css( 'margin-top', '' );

--- a/src/js/_enqueues/admin/common.js
+++ b/src/js/_enqueues/admin/common.js
@@ -931,7 +931,7 @@ $( function() {
 			adjustment = maxtop;
 		}
 
-		if ( adjustment > 1 && $window.width() > 783 ) {
+		if ( adjustment > 1 && $window.width() > 782 ) {
 			$submenu.css( 'margin-top', '-' + adjustment + 'px' );
 		} else {
 			$submenu.css( 'margin-top', '' );


### PR DESCRIPTION
Fixes # [32747](https://core.trac.wordpress.org/ticket/32747)

In this PR, Fix WP Admin Menu & Submenu overlap issue fix

**how to reproduce this issue.**
1. resize the browser to be as short/small as in the screenshot.
2. visit wp-admin
3. click the hamburger icon in the admin bar to reveal admin menus
4. click parent menus such as the "appearance" menu to view the sub-menus.

![wp-menu-overlap](https://user-images.githubusercontent.com/52179233/159660790-c3a9a586-a9c6-406d-aefb-38f1e71e0fdb.png)
