### PR TITLE
Remove escaped ampersands from wp_user-settings

### DIFF
--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -1088,10 +1088,11 @@ function wp_user_settings() {
 	$settings = (string) get_user_option( 'user-settings', $user_id );
 
 	if ( isset( $_COOKIE[ 'wp-settings-' . $user_id ] ) ) {
-		$cookie = preg_replace( '/[^A-Za-z0-9=&_]/', '', $_COOKIE[ 'wp-settings-' . $user_id ] );
-
 		// Remove escaped ampersands
-		$cookie = preg_replace( '/&(amp)+/', '&', $cookie );
+		$cookie = preg_replace( '/&(amp)+;/', '&', $_COOKIE[ 'wp-settings-' . $user_id ] );
+
+		// Sanitize cookie
+		$cookie = preg_replace( '/[^A-Za-z0-9=&_]/', '',  $cookie );
 
 		// No change or both empty.
 		if ( $cookie == $settings ) {

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -1090,6 +1090,9 @@ function wp_user_settings() {
 	if ( isset( $_COOKIE[ 'wp-settings-' . $user_id ] ) ) {
 		$cookie = preg_replace( '/[^A-Za-z0-9=&_]/', '', $_COOKIE[ 'wp-settings-' . $user_id ] );
 
+		// Remove escaped ampersands
+		$cookie = preg_replace( '/&(amp)+/', '&', $cookie );
+
 		// No change or both empty.
 		if ( $cookie == $settings ) {
 			return;

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -1092,7 +1092,7 @@ function wp_user_settings() {
 		$cookie = preg_replace( '/&(amp)+;/', '&', $_COOKIE[ 'wp-settings-' . $user_id ] );
 
 		// Sanitize cookie
-		$cookie = preg_replace( '/[^A-Za-z0-9=&_]/', '',  $cookie );
+		$cookie = preg_replace( '/[^A-Za-z0-9=&_]/', '', $cookie );
 
 		// No change or both empty.
 		if ( $cookie == $settings ) {

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -1088,8 +1088,8 @@ function wp_user_settings() {
 	$settings = (string) get_user_option( 'user-settings', $user_id );
 
 	if ( isset( $_COOKIE[ 'wp-settings-' . $user_id ] ) ) {
-		// Remove escaped ampersands
-		$cookie = preg_replace( '/&(amp)+;/', '&', $_COOKIE[ 'wp-settings-' . $user_id ] );
+		// Replace escaped ampersands
+		$cookie = str_replace( $_COOKIE[ 'wp-settings-' . $user_id ], '&amp;', '&' );
 
 		// Sanitize cookie
 		$cookie = preg_replace( '/[^A-Za-z0-9=&_]/', '', $cookie );


### PR DESCRIPTION
Ampersands (&) are being double escaped in wp_user-settings.  This bug fix adds a regular expression to remove escaped ampersands from wp_user-settings.

I am replacing escaped ampersands before sanitizing the cookie value, so any values starting with "amp" are not accidentally removed.  This does mean, that this "fix" won't correct already corrupted data.

Trac ticket: https://core.trac.wordpress.org/ticket/55456

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
