### PR TITLE
rewrite of FTP exists()

### DIFF
--- a/src/wp-admin/includes/class-wp-filesystem-ftpext.php
+++ b/src/wp-admin/includes/class-wp-filesystem-ftpext.php
@@ -512,6 +512,7 @@ class WP_Filesystem_FTPext extends WP_Filesystem_Base {
 	 * Gets the file size (in bytes).
 	 *
 	 * @since 2.5.0
+	 * @since 6.0.0 Update for proper return values.
 	 *
 	 * @param string $file Path to file.
 	 * @return int Size of the file in bytes on success, -1 on failure.

--- a/src/wp-admin/includes/class-wp-filesystem-ftpext.php
+++ b/src/wp-admin/includes/class-wp-filesystem-ftpext.php
@@ -412,18 +412,20 @@ class WP_Filesystem_FTPext extends WP_Filesystem_Base {
 	 * Checks if a file or directory exists.
 	 *
 	 * @since 2.5.0
+	 * @since 6.0.0 Rewrite using 'ftp_size' instead of 'ftp_nlist'.
 	 *
-	 * @param string $file Path to file or directory.
-	 * @return bool Whether $file exists or not.
+	 * @param string $file   Path to file or directory.
+	 * @return bool|WP_Error Whether $file exists or not.
 	 */
 	public function exists( $file ) {
-		$list = ftp_nlist( $this->link, $file );
-
-		if ( empty( $list ) && $this->is_dir( $file ) ) {
-			return true; // File is an empty directory.
+		if ( $this->is_dir( $file ) ) {
+			return true;
 		}
-
-		return ! empty( $list ); // Empty list = no file, so invert.
+		if ( function_exists( 'ftp_size' ) ) {
+			return -1 !== ftp_size( $this->link, $file );
+		} else {
+			return new WP_Error( 'ftp_size_not_exists', __( 'ftp_size function does not exist on server.' ) );
+		}
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-filesystem-ftpext.php
+++ b/src/wp-admin/includes/class-wp-filesystem-ftpext.php
@@ -518,7 +518,7 @@ class WP_Filesystem_FTPext extends WP_Filesystem_Base {
 	 * @return int Size of the file in bytes on success, -1 on failure.
 	 */
 	public function size( $file ) {
-		return -1 !== ftp_size( $this->link, $file );
+		return ftp_size( $this->link, $file );
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-filesystem-ftpext.php
+++ b/src/wp-admin/includes/class-wp-filesystem-ftpext.php
@@ -412,20 +412,20 @@ class WP_Filesystem_FTPext extends WP_Filesystem_Base {
 	 * Checks if a file or directory exists.
 	 *
 	 * @since 2.5.0
-	 * @since 6.0.0 Rewrite using 'ftp_size' instead of 'ftp_nlist'.
+	 * @since 6.0.0 Rewrite using file size.
 	 *
-	 * @param string $file   Path to file or directory.
-	 * @return bool|WP_Error Whether $file exists or not.
+	 * @param string $file Path to file or directory.
+	 * @return bool        Whether $file exists or not.
 	 */
 	public function exists( $file ) {
 		if ( $this->is_dir( $file ) ) {
 			return true;
 		}
-		if ( function_exists( 'ftp_size' ) ) {
-			return -1 !== ftp_size( $this->link, $file );
-		} else {
-			return new WP_Error( 'ftp_size_not_exists', __( 'ftp_size function does not exist on server.' ) );
+		if ( is_callable( 'ftp_size' ) ) {
+			return $this->size( $file );
 		}
+
+		return false;
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-filesystem-ftpext.php
+++ b/src/wp-admin/includes/class-wp-filesystem-ftpext.php
@@ -421,11 +421,8 @@ class WP_Filesystem_FTPext extends WP_Filesystem_Base {
 		if ( $this->is_dir( $file ) ) {
 			return true;
 		}
-		if ( is_callable( 'ftp_size' ) ) {
-			return -1 !== $this->size( $file );
-		}
 
-		return false;
+		return -1 !== $this->size( $file );
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-filesystem-ftpext.php
+++ b/src/wp-admin/includes/class-wp-filesystem-ftpext.php
@@ -415,7 +415,7 @@ class WP_Filesystem_FTPext extends WP_Filesystem_Base {
 	 * @since 6.0.0 Rewrite using file size.
 	 *
 	 * @param string $file Path to file or directory.
-	 * @return bool        Whether $file exists or not.
+	 * @return bool Whether $file exists or not.
 	 */
 	public function exists( $file ) {
 		if ( $this->is_dir( $file ) ) {

--- a/src/wp-admin/includes/class-wp-filesystem-ftpext.php
+++ b/src/wp-admin/includes/class-wp-filesystem-ftpext.php
@@ -412,7 +412,7 @@ class WP_Filesystem_FTPext extends WP_Filesystem_Base {
 	 * Checks if a file or directory exists.
 	 *
 	 * @since 2.5.0
-	 * @since 6.0.0 Rewrite using ftp_rawlist, uses 'LIST' on FTP server
+	 * @since 6.1.0 Rewrite using ftp_rawlist, uses 'LIST' on FTP server
 	 *              takes file path or directory path as parameter.
 	 *
 	 * @param string $file Path to file or directory.
@@ -510,7 +510,7 @@ class WP_Filesystem_FTPext extends WP_Filesystem_Base {
 	 * Gets the file size (in bytes).
 	 *
 	 * @since 2.5.0
-	 * @since 6.0.0 Update for proper return values.
+	 * @since 6.1.0 Update for proper return values.
 	 *
 	 * @param string $file Path to file.
 	 * @return int Size of the file in bytes on success, -1 on failure.

--- a/src/wp-admin/includes/class-wp-filesystem-ftpext.php
+++ b/src/wp-admin/includes/class-wp-filesystem-ftpext.php
@@ -412,7 +412,7 @@ class WP_Filesystem_FTPext extends WP_Filesystem_Base {
 	 * Checks if a file or directory exists.
 	 *
 	 * @since 2.5.0
-	 * @since 6.0.0 Rewrite using file size.
+	 * @since 6.0.0 Rewrite using file size, ftp_nlist as fallback.
 	 *
 	 * @param string $file Path to file or directory.
 	 * @return bool Whether $file exists or not.
@@ -422,7 +422,17 @@ class WP_Filesystem_FTPext extends WP_Filesystem_Base {
 			return true;
 		}
 
-		return -1 !== $this->size( $file );
+		// Use the ftp "SIZE" command, if available.
+		if ( -1 !== ftp_size( $this->link, __FILE__ ) ) {
+			return -1 !== ftp_size( $this->link, $file );
+		}
+
+		// Run NLST on the directory.
+		// TODO: Add support for hidden files.
+		$dir   = wp_normalize_path( dirname( $file ) );
+		$files = ftp_nlist( $this->link, $dir );
+
+		return $files && in_array( $file, $files, true );
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-filesystem-ftpext.php
+++ b/src/wp-admin/includes/class-wp-filesystem-ftpext.php
@@ -412,7 +412,8 @@ class WP_Filesystem_FTPext extends WP_Filesystem_Base {
 	 * Checks if a file or directory exists.
 	 *
 	 * @since 2.5.0
-	 * @since 6.0.0 Rewrite using file size, ftp_nlist as fallback.
+	 * @since 6.0.0 Rewrite using ftp_rawlist, uses 'LIST' on FTP server
+	 *              takes file path or directory path as parameter.
 	 *
 	 * @param string $file Path to file or directory.
 	 * @return bool Whether $file exists or not.
@@ -422,17 +423,7 @@ class WP_Filesystem_FTPext extends WP_Filesystem_Base {
 			return true;
 		}
 
-		// Use the ftp "SIZE" command, if available.
-		if ( -1 !== ftp_size( $this->link, __FILE__ ) ) {
-			return -1 !== ftp_size( $this->link, $file );
-		}
-
-		// Run NLST on the directory.
-		// TODO: Add support for hidden files.
-		$dir   = wp_normalize_path( dirname( $file ) );
-		$files = ftp_nlist( $this->link, $dir );
-
-		return $files && in_array( $file, $files, true );
+		return ! empty( ftp_rawlist( $this->link, $file ) );
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-filesystem-ftpext.php
+++ b/src/wp-admin/includes/class-wp-filesystem-ftpext.php
@@ -422,7 +422,7 @@ class WP_Filesystem_FTPext extends WP_Filesystem_Base {
 			return true;
 		}
 		if ( is_callable( 'ftp_size' ) ) {
-			return $this->size( $file );
+			return -1 !== $this->size( $file );
 		}
 
 		return false;

--- a/src/wp-admin/includes/class-wp-filesystem-ftpext.php
+++ b/src/wp-admin/includes/class-wp-filesystem-ftpext.php
@@ -514,10 +514,10 @@ class WP_Filesystem_FTPext extends WP_Filesystem_Base {
 	 * @since 2.5.0
 	 *
 	 * @param string $file Path to file.
-	 * @return int|false Size of the file in bytes on success, false on failure.
+	 * @return int Size of the file in bytes on success, -1 on failure.
 	 */
 	public function size( $file ) {
-		return ftp_size( $this->link, $file );
+		return -1 !== ftp_size( $this->link, $file );
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-filesystem-ftpsockets.php
+++ b/src/wp-admin/includes/class-wp-filesystem-ftpsockets.php
@@ -414,19 +414,17 @@ class WP_Filesystem_ftpsockets extends WP_Filesystem_Base {
 	 * Checks if a file or directory exists.
 	 *
 	 * @since 2.5.0
+	 * @since 6.0.0 Use file size.
 	 *
 	 * @param string $file Path to file or directory.
 	 * @return bool Whether $file exists or not.
 	 */
 	public function exists( $file ) {
-		$list = $this->ftp->nlist( $file );
-
-		if ( empty( $list ) && $this->is_dir( $file ) ) {
+		if ( $this->is_dir( $file ) ) {
 			return true; // File is an empty directory.
 		}
 
-		return ! empty( $list ); // Empty list = no file, so invert.
-		// Return $this->ftp->is_exists($file); has issues with ABOR+426 responses on the ncFTPd server.
+		return 0 > $this->size( $file );
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-filesystem-ftpsockets.php
+++ b/src/wp-admin/includes/class-wp-filesystem-ftpsockets.php
@@ -414,7 +414,7 @@ class WP_Filesystem_ftpsockets extends WP_Filesystem_Base {
 	 * Checks if a file or directory exists.
 	 *
 	 * @since 2.5.0
-	 * @since 6.0.0 Rewrite using file size.
+	 * @since 6.1.0 Rewrite using file size.
 	 *
 	 * @param string $file Path to file or directory.
 	 * @return bool Whether $file exists or not.

--- a/src/wp-admin/includes/class-wp-filesystem-ftpsockets.php
+++ b/src/wp-admin/includes/class-wp-filesystem-ftpsockets.php
@@ -424,7 +424,7 @@ class WP_Filesystem_ftpsockets extends WP_Filesystem_Base {
 			return true;
 		}
 
-		return 0 > $this->size( $file );
+		return 0 < (int) $this->size( $file );
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-filesystem-ftpsockets.php
+++ b/src/wp-admin/includes/class-wp-filesystem-ftpsockets.php
@@ -423,8 +423,9 @@ class WP_Filesystem_ftpsockets extends WP_Filesystem_Base {
 		if ( $this->is_dir( $file ) ) {
 			return true;
 		}
+		$size = $this->size( $file );
 
-		return 0 < (int) $this->size( $file );
+		return false !== $size && is_numeric( $size );
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-filesystem-ftpsockets.php
+++ b/src/wp-admin/includes/class-wp-filesystem-ftpsockets.php
@@ -414,7 +414,7 @@ class WP_Filesystem_ftpsockets extends WP_Filesystem_Base {
 	 * Checks if a file or directory exists.
 	 *
 	 * @since 2.5.0
-	 * @since 6.0.0 Use file size.
+	 * @since 6.0.0 Rewrite using file size.
 	 *
 	 * @param string $file Path to file or directory.
 	 * @return bool Whether $file exists or not.

--- a/src/wp-admin/includes/class-wp-filesystem-ftpsockets.php
+++ b/src/wp-admin/includes/class-wp-filesystem-ftpsockets.php
@@ -414,7 +414,7 @@ class WP_Filesystem_ftpsockets extends WP_Filesystem_Base {
 	 * Checks if a file or directory exists.
 	 *
 	 * @since 2.5.0
-	 * @since 6.0.0 Rewrite using file size.
+	 * @since 6.0.0 Rewrite using file_exists in class ftp.
 	 *
 	 * @param string $file Path to file or directory.
 	 * @return bool Whether $file exists or not.
@@ -424,7 +424,7 @@ class WP_Filesystem_ftpsockets extends WP_Filesystem_Base {
 			return true;
 		}
 
-		return is_numeric( $this->size( $file ) );
+		return $this->ftp->file_exists( $file );
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-filesystem-ftpsockets.php
+++ b/src/wp-admin/includes/class-wp-filesystem-ftpsockets.php
@@ -421,7 +421,7 @@ class WP_Filesystem_ftpsockets extends WP_Filesystem_Base {
 	 */
 	public function exists( $file ) {
 		if ( $this->is_dir( $file ) ) {
-			return true; // File is an empty directory.
+			return true;
 		}
 
 		return 0 > $this->size( $file );

--- a/src/wp-admin/includes/class-wp-filesystem-ftpsockets.php
+++ b/src/wp-admin/includes/class-wp-filesystem-ftpsockets.php
@@ -414,7 +414,7 @@ class WP_Filesystem_ftpsockets extends WP_Filesystem_Base {
 	 * Checks if a file or directory exists.
 	 *
 	 * @since 2.5.0
-	 * @since 6.0.0 Rewrite using file_exists in class ftp.
+	 * @since 6.0.0 Rewrite using file size.
 	 *
 	 * @param string $file Path to file or directory.
 	 * @return bool Whether $file exists or not.
@@ -424,7 +424,7 @@ class WP_Filesystem_ftpsockets extends WP_Filesystem_Base {
 			return true;
 		}
 
-		return $this->ftp->file_exists( $file );
+		return is_numeric( $this->size( $file ) );
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-filesystem-ftpsockets.php
+++ b/src/wp-admin/includes/class-wp-filesystem-ftpsockets.php
@@ -423,9 +423,8 @@ class WP_Filesystem_ftpsockets extends WP_Filesystem_Base {
 		if ( $this->is_dir( $file ) ) {
 			return true;
 		}
-		$size = $this->size( $file );
 
-		return false !== $size && is_numeric( $size );
+		return is_numeric( $this->size( $file ) );
 	}
 
 	/**


### PR DESCRIPTION
WP FTP file checking is currently base upon `ftp_nlist`. This function can be problematic at scale with a directory containing a large number of files. There also exists an issue using it with ftpsockets.

This PR rewrites the FTP `exists()` functions to utilize a more efficient and stable check.

Trac ticket: https://core.trac.wordpress.org/ticket/51170

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
