### PR TITLE
Fix hiding playlist buttons from Add Media modal dialog

### DIFF
--- a/src/wp-includes/css/media-views.css
+++ b/src/wp-includes/css/media-views.css
@@ -653,6 +653,10 @@
 	outline: 1px solid transparent;
 }
 
+.media-menu .media-menu-item.hidden {
+	display: none;
+}
+
 .media-menu .separator {
 	height: 0;
 	margin: 12px 20px;


### PR DESCRIPTION
### How to reproduce

On a fresh installation of WordPress 5.9.2 with [Classic Editor](https://wordpress.org/plugins/classic-editor/) plugin enabled, add the following lines to the default theme's `functions.php`:

```php
add_filter('media_library_show_audio_playlist', '__return_false');
add_filter('media_library_show_video_playlist', '__return_false');
```

Then go to `/wp-admin/post-new.php` and click the Add Media button.

These filters are supposed to allow hiding the [Create Audio Playlist](https://developer.wordpress.org/reference/hooks/media_library_show_audio_playlist/) and [Create Video Playlist](https://developer.wordpress.org/reference/hooks/media_library_show_video_playlist/) buttons, which is not the case. The buttons are still visible in the Add Media modal dialog.

Workarounds include filtering `media_view_strings` instead, or enqueing additional styles to hide the buttons.

The discussion at Ticket 43009 focuses on the behavior *after* uploading an audio/video file rather than the initial state, hence the new ticket.

### Reason

✅ **PHP:** [wp_enqueue_media](https://developer.wordpress.org/reference/functions/wp_enqueue_media/) function sets `attachmentCounts` according to the filter results.

✅ **JavaScript:** `menuItemVisibility` function is called, which adds `hidden` class to the elements.

❌ CSS: In `media-views.css`, `.media-menu .media-menu-item` selector wins over `.media-frame .hidden`, setting the elements' `display` property to `block` instead of `none`.

### Proposed fix

Since there are similar rules of higher specificity (e.g. `.attachments-browser .uploader-inline.hidden`, `.media-embed .setting input.hidden`) in the same CSS file, I thought adding the following rule would be appropriate:

```css
.media-menu .media-menu-item.hidden {
	display: none;
}
```

Trac ticket: https://core.trac.wordpress.org/ticket/55465

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**