### PR TITLE
Add new actions before and after loading the located template

### DIFF
--- a/src/wp-includes/template.php
+++ b/src/wp-includes/template.php
@@ -711,7 +711,25 @@ function locate_template( $template_names, $load = false, $require_once = true, 
 	}
 
 	if ( $load && '' !== $located ) {
+		/**
+		 * Fires before the located template is loaded
+		 *
+		 * @since 6.0.0
+		 *
+		 * @param string The template filename.
+		 */
+		do_action( 'before_load_template', $located );
+
 		load_template( $located, $require_once, $args );
+
+		/**
+		 * Fires after the located template is loaded
+		 *
+		 * @since 6.0.0
+		 *
+		 * @param string The template filename.
+		 */
+		do_action( 'after_load_template', $located );
 	}
 
 	return $located;

--- a/src/wp-includes/template.php
+++ b/src/wp-includes/template.php
@@ -716,9 +716,14 @@ function locate_template( $template_names, $load = false, $require_once = true, 
 		 *
 		 * @since 6.1.0
 		 *
-		 * @param string The template filename.
+		 * @param string       $located        The template filename.
+		 * @param string|array $template_names Template file(s) to search for, in order.
+		 * @param bool         $require_once   Whether to require_once or require. Has no effect if `$load` is false.
+		 *                                     Default true.
+		 * @param array        $args           Optional. Additional arguments passed to the template.
+		 *                                     Default empty array.
 		 */
-		do_action( 'wp_before_load_template', $located );
+		do_action( 'wp_before_load_template', $located, $template_names, $require_once, $args );
 
 		load_template( $located, $require_once, $args );
 
@@ -727,9 +732,14 @@ function locate_template( $template_names, $load = false, $require_once = true, 
 		 *
 		 * @since 6.1.0
 		 *
-		 * @param string The template filename.
+		 * @param string       $located        The template filename.
+		 * @param string|array $template_names Template file(s) to search for, in order.
+		 * @param bool         $require_once   Whether to require_once or require. Has no effect if `$load` is false.
+		 *                                     Default true.
+		 * @param array        $args           Optional. Additional arguments passed to the template.
+		 *                                     Default empty array.
 		 */
-		do_action( 'wp_after_load_template', $located );
+		do_action( 'wp_after_load_template', $located, $template_names, $require_once, $args );
 	}
 
 	return $located;

--- a/src/wp-includes/template.php
+++ b/src/wp-includes/template.php
@@ -712,24 +712,24 @@ function locate_template( $template_names, $load = false, $require_once = true, 
 
 	if ( $load && '' !== $located ) {
 		/**
-		 * Fires before the located template is loaded
+		 * Fires before the located template is loaded.
 		 *
 		 * @since 6.0.0
 		 *
 		 * @param string The template filename.
 		 */
-		do_action( 'before_load_template', $located );
+		do_action( 'wp_before_load_template', $located );
 
 		load_template( $located, $require_once, $args );
 
 		/**
-		 * Fires after the located template is loaded
+		 * Fires after the located template is loaded.
 		 *
 		 * @since 6.0.0
 		 *
 		 * @param string The template filename.
 		 */
-		do_action( 'after_load_template', $located );
+		do_action( 'wp_after_load_template', $located );
 	}
 
 	return $located;

--- a/src/wp-includes/template.php
+++ b/src/wp-includes/template.php
@@ -714,7 +714,7 @@ function locate_template( $template_names, $load = false, $require_once = true, 
 		/**
 		 * Fires before the located template is loaded.
 		 *
-		 * @since 6.0.0
+		 * @since 6.1.0
 		 *
 		 * @param string The template filename.
 		 */
@@ -725,7 +725,7 @@ function locate_template( $template_names, $load = false, $require_once = true, 
 		/**
 		 * Fires after the located template is loaded.
 		 *
-		 * @since 6.0.0
+		 * @since 6.1.0
 		 *
 		 * @param string The template filename.
 		 */


### PR DESCRIPTION
This patch adds new actions before and after loading the located template in `locate_template()`.

The template filename is passed as an additional parameter to the action, as that can be useful for callbacks on these hooks.

The hooks name and the `@since` value are suggestions, I couldn't find if there is a standard for hooks names in core, as there is some prefixed with `wp_`, and others that are not.

Trac ticket: https://core.trac.wordpress.org/ticket/54541

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
