### PR TITLE
Change location of block support styles in wp_head

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2926,8 +2926,8 @@ function wp_enqueue_global_styles_css_custom_properties() {
  *
  * For block themes, it's loaded in the head.
  * For classic ones, it's loaded in the body
- * because the wp_head action (and wp_enqueue_scripts)
- * happens before the render_block.
+ * because the wp_head action happens before
+ * the render_block.
  *
  * @link https://core.trac.wordpress.org/ticket/53494.
  *
@@ -2936,7 +2936,7 @@ function wp_enqueue_global_styles_css_custom_properties() {
 function wp_enqueue_block_support_styles( $style ) {
 	$action_hook_name = 'wp_footer';
 	if ( wp_is_block_theme() ) {
-		$action_hook_name = 'wp_enqueue_scripts';
+		$action_hook_name = 'wp_head';
 	}
 	add_action(
 		$action_hook_name,


### PR DESCRIPTION
Backports changes from https://github.com/WordPress/gutenberg/pull/39164.

Props @ndiego, @alexstine, @c4rl0sbr4v0

Trac ticket:  https://core.trac.wordpress.org/ticket/55474

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
