### PR TITLE
`theme.json`: add `title` key to i18n schema

### DIFF
--- a/src/wp-includes/theme-i18n.json
+++ b/src/wp-includes/theme-i18n.json
@@ -1,4 +1,5 @@
 {
+	"title": "Style variation name",
 	"settings": {
 		"typography": {
 				"fontSizes": [


### PR DESCRIPTION
Trac ticket https://core.trac.wordpress.org/ticket/55495
This PR ports the related Gutenberg PR at https://github.com/WordPress/gutenberg/pull/39936

## What?

This PR adds `title` as a new key to translate from a `theme.json` file. It's necessary to fix the wp-cli i18n-command tests at https://github.com/wp-cli/i18n-command/pull/306

## Why?

The `title` key from a style variation is shown to the user, hence, it needs to be translatable.

## How?

By adding the key to the i18n schema we allow the i18n-command from the wp-cli to pick it up. See https://github.com/wp-cli/i18n-command/pull/306 Though the wp-cli uses the schema from WordPress `trunk` so we also need to port the changes there.

## Testing Instructions

This PR only prepares the code for the wp-cli to pick up translations, so there's nothing to test other than verifying that it doesn't  break anything. This is what I did:

- Go to "Settings > General" and set the language to Spanish.
- Use TwentyTwentyTwo.
- Load the site editor.
- Verify that the color palettes names show up in Spanish (go to "Global Styles > Colors > Palette"  and hover over the color circles.

