### PR TITLE
6.0 Backport to add support for custom taxonomies filtering for Query Loop (from Gutenberg)

### DIFF
--- a/src/wp-includes/block-patterns.php
+++ b/src/wp-includes/block-patterns.php
@@ -127,3 +127,205 @@ function _load_remote_featured_patterns() {
 		}
 	}
 }
+
+/**
+ * Registers patterns from Pattern Directory provided by a theme's
+ * `theme.json` file.
+ *
+ * @since 6.0.0
+ * @access private
+ */
+function _register_remote_theme_patterns() {
+	if ( ! get_theme_support( 'core-block-patterns' ) ) {
+		return;
+	}
+
+	if ( ! apply_filters( 'should_load_remote_block_patterns', true ) ) {
+		return;
+	}
+
+	if ( ! WP_Theme_JSON_Resolver::theme_has_support() ) {
+		return;
+	}
+
+	$pattern_settings = WP_Theme_JSON_Resolver::get_theme_data()->get_patterns();
+	if ( empty( $pattern_settings ) ) {
+		return;
+	}
+
+	$request         = new WP_REST_Request( 'GET', '/wp/v2/pattern-directory/patterns' );
+	$request['slug'] = implode( ',', $pattern_settings );
+	$response        = rest_do_request( $request );
+	if ( $response->is_error() ) {
+		return;
+	}
+	$patterns          = $response->get_data();
+	$patterns_registry = WP_Block_Patterns_Registry::get_instance();
+	foreach ( $patterns as $pattern ) {
+		$pattern_name = sanitize_title( $pattern['title'] );
+		// Some patterns might be already registered as core patterns with the `core` prefix.
+		$is_registered = $patterns_registry->is_registered( $pattern_name ) || $patterns_registry->is_registered( "core/$pattern_name" );
+		if ( ! $is_registered ) {
+			register_block_pattern( $pattern_name, (array) $pattern );
+		}
+	}
+}
+
+/**
+ * Register any patterns that the active theme may provide under its
+ * `./patterns/` directory. Each pattern is defined as a PHP file and defines
+ * its metadata using plugin-style headers. The minimum required definition is:
+ *
+ *     /**
+ *      * Title: My Pattern
+ *      * Slug: my-theme/my-pattern
+ *      *
+ *
+ * The output of the PHP source corresponds to the content of the pattern, e.g.:
+ *
+ *     <main><p><?php echo "Hello"; ?></p></main>
+ *
+ * If applicable, this will collect from both parent and child theme.
+ *
+ * Other settable fields include:
+ *
+ *   - Description
+ *   - Viewport Width
+ *   - Categories       (comma-separated values)
+ *   - Keywords         (comma-separated values)
+ *   - Block Types      (comma-separated values)
+ *   - Inserter         (yes/no)
+ *
+ * @since 6.0.0
+ * @access private
+ */
+function _register_theme_block_patterns() {
+	$default_headers = array(
+		'title'         => 'Title',
+		'slug'          => 'Slug',
+		'description'   => 'Description',
+		'viewportWidth' => 'Viewport Width',
+		'categories'    => 'Categories',
+		'keywords'      => 'Keywords',
+		'blockTypes'    => 'Block Types',
+		'inserter'      => 'Inserter',
+	);
+
+	/*
+	 * Register patterns for the active theme. If the theme is a child theme,
+	 * let it override any patterns from the parent theme that shares the same slug.
+	 */
+	$themes     = array();
+	$stylesheet = get_stylesheet();
+	$template   = get_template();
+	if ( $stylesheet !== $template ) {
+		$themes[] = wp_get_theme( $stylesheet );
+	}
+	$themes[] = wp_get_theme( $template );
+
+	foreach ( $themes as $theme ) {
+		$dirpath = $theme->get_stylesheet_directory() . '/patterns/';
+		if ( file_exists( $dirpath ) ) {
+			$files = glob( $dirpath . '*.php' );
+			if ( $files ) {
+				foreach ( $files as $file ) {
+					$pattern_data = get_file_data( $file, $default_headers );
+
+					if ( empty( $pattern_data['slug'] ) ) {
+						trigger_error(
+							sprintf(
+								/* translators: %s: file name. */
+								__( 'Could not register file "%s" as a block pattern ("Slug" field missing)' ),
+								$file
+							)
+						);
+						continue;
+					}
+
+					if ( ! preg_match( '/^[A-z0-9\/_-]+$/', $pattern_data['slug'] ) ) {
+						trigger_error(
+							sprintf(
+								/* translators: %1s: file name; %2s: slug value found. */
+								__( 'Could not register file "%1$s" as a block pattern (invalid slug "%2$s")' ),
+								$file,
+								$pattern_data['slug']
+							)
+						);
+					}
+
+					if ( WP_Block_Patterns_Registry::get_instance()->is_registered( $pattern_data['slug'] ) ) {
+						continue;
+					}
+
+					// Title is a required property.
+					if ( ! $pattern_data['title'] ) {
+						trigger_error(
+							sprintf(
+								/* translators: %1s: file name; %2s: slug value found. */
+								__( 'Could not register file "%s" as a block pattern ("Title" field missing)' ),
+								$file
+							)
+						);
+						continue;
+					}
+
+					// For properties of type array, parse data as comma-separated.
+					foreach ( array( 'categories', 'keywords', 'blockTypes' ) as $property ) {
+						if ( ! empty( $pattern_data[ $property ] ) ) {
+							$pattern_data[ $property ] = array_filter(
+								preg_split(
+									'/[\s,]+/',
+									(string) $pattern_data[ $property ]
+								)
+							);
+						} else {
+							unset( $pattern_data[ $property ] );
+						}
+					}
+
+					// Parse properties of type int.
+					foreach ( array( 'viewportWidth' ) as $property ) {
+						if ( ! empty( $pattern_data[ $property ] ) ) {
+							$pattern_data[ $property ] = (int) $pattern_data[ $property ];
+						} else {
+							unset( $pattern_data[ $property ] );
+						}
+					}
+
+					// Parse properties of type bool.
+					foreach ( array( 'inserter' ) as $property ) {
+						if ( ! empty( $pattern_data[ $property ] ) ) {
+							$pattern_data[ $property ] = in_array(
+								strtolower( $pattern_data[ $property ] ),
+								array( 'yes', 'true' ),
+								true
+							);
+						} else {
+							unset( $pattern_data[ $property ] );
+						}
+					}
+
+					// Translate the pattern metadata.
+					$text_domain = $theme->get( 'TextDomain' );
+					//phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText, WordPress.WP.I18n.NonSingularStringLiteralContext, WordPress.WP.I18n.NonSingularStringLiteralDomain, WordPress.WP.I18n.LowLevelTranslationFunction
+					$pattern_data['title'] = translate_with_gettext_context( $pattern_data['title'], 'Pattern title', $text_domain );
+					if ( ! empty( $pattern_data['description'] ) ) {
+						//phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText, WordPress.WP.I18n.NonSingularStringLiteralContext, WordPress.WP.I18n.NonSingularStringLiteralDomain, WordPress.WP.I18n.LowLevelTranslationFunction
+						$pattern_data['description'] = translate_with_gettext_context( $pattern_data['description'], 'Pattern description', $text_domain );
+					}
+
+					// The actual pattern content is the output of the file.
+					ob_start();
+					include $file;
+					$pattern_data['content'] = ob_get_clean();
+					if ( ! $pattern_data['content'] ) {
+						continue;
+					}
+
+					register_block_pattern( $pattern_data['slug'], $pattern_data );
+				}
+			}
+		}
+	}
+}
+add_action( 'init', '_register_theme_block_patterns' );

--- a/src/wp-includes/block-patterns.php
+++ b/src/wp-includes/block-patterns.php
@@ -12,7 +12,7 @@ add_theme_support( 'core-block-patterns' );
  * Registers the core block patterns and categories.
  *
  * @since 5.5.0
- * @private
+ * @access private
  */
 function _register_core_block_patterns_and_categories() {
 	$should_register_core_patterns = get_theme_support( 'core-block-patterns' );

--- a/src/wp-includes/block-patterns/query-grid-posts.php
+++ b/src/wp-includes/block-patterns/query-grid-posts.php
@@ -9,7 +9,7 @@ return array(
 	'title'      => _x( 'Grid', 'Block pattern title' ),
 	'blockTypes' => array( 'core/query' ),
 	'categories' => array( 'query' ),
-	'content'    => '<!-- wp:query {"query":{"perPage":6,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"displayLayout":{"type":"flex","columns":3}} -->
+	'content'    => '<!-- wp:query {"query":{"perPage":6,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"displayLayout":{"type":"flex","columns":3}} -->
 					<div class="wp-block-query">
 					<!-- wp:post-template -->
 					<!-- wp:group {"style":{"spacing":{"padding":{"top":"30px","right":"30px","bottom":"30px","left":"30px"}}},"layout":{"inherit":false}} -->

--- a/src/wp-includes/block-patterns/query-large-title-posts.php
+++ b/src/wp-includes/block-patterns/query-large-title-posts.php
@@ -10,7 +10,7 @@ return array(
 	'blockTypes' => array( 'core/query' ),
 	'categories' => array( 'query' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"100px","right":"100px","bottom":"100px","left":"100px"}},"color":{"text":"#ffffff","background":"#000000"}}} -->
-					<div class="wp-block-group alignfull has-text-color has-background" style="background-color:#000000;color:#ffffff;padding-top:100px;padding-right:100px;padding-bottom:100px;padding-left:100px"><!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
+					<div class="wp-block-group alignfull has-text-color has-background" style="background-color:#000000;color:#ffffff;padding-top:100px;padding-right:100px;padding-bottom:100px;padding-left:100px"><!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
 					<div class="wp-block-query"><!-- wp:post-template -->
 					<!-- wp:separator {"customColor":"#ffffff","align":"wide","className":"is-style-wide"} -->
 					<hr class="wp-block-separator alignwide has-text-color has-background is-style-wide" style="background-color:#ffffff;color:#ffffff"/>

--- a/src/wp-includes/block-patterns/query-medium-posts.php
+++ b/src/wp-includes/block-patterns/query-medium-posts.php
@@ -9,7 +9,7 @@ return array(
 	'title'      => _x( 'Image at left', 'Block pattern title' ),
 	'blockTypes' => array( 'core/query' ),
 	'categories' => array( 'query' ),
-	'content'    => '<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
+	'content'    => '<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
 					<div class="wp-block-query">
 					<!-- wp:post-template -->
 					<!-- wp:columns {"align":"wide"} -->

--- a/src/wp-includes/block-patterns/query-offset-posts.php
+++ b/src/wp-includes/block-patterns/query-offset-posts.php
@@ -12,7 +12,7 @@ return array(
 	'content'    => '<!-- wp:group {"style":{"spacing":{"padding":{"top":"30px","right":"30px","bottom":"30px","left":"30px"}}},"layout":{"inherit":false}} -->
 					<div class="wp-block-group" style="padding-top:30px;padding-right:30px;padding-bottom:30px;padding-left:30px"><!-- wp:columns -->
 					<div class="wp-block-columns"><!-- wp:column {"width":"50%"} -->
-					<div class="wp-block-column" style="flex-basis:50%"><!-- wp:query {"query":{"perPage":2,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"displayLayout":{"type":"list"}} -->
+					<div class="wp-block-column" style="flex-basis:50%"><!-- wp:query {"query":{"perPage":2,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"displayLayout":{"type":"list"}} -->
 					<div class="wp-block-query"><!-- wp:post-template -->
 					<!-- wp:post-featured-image /-->
 					<!-- wp:post-title /-->
@@ -24,7 +24,7 @@ return array(
 					<!-- /wp:query --></div>
 					<!-- /wp:column -->
 					<!-- wp:column {"width":"50%"} -->
-					<div class="wp-block-column" style="flex-basis:50%"><!-- wp:query {"query":{"perPage":2,"pages":0,"offset":2,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"displayLayout":{"type":"list"}} -->
+					<div class="wp-block-column" style="flex-basis:50%"><!-- wp:query {"query":{"perPage":2,"pages":0,"offset":2,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"displayLayout":{"type":"list"}} -->
 					<div class="wp-block-query"><!-- wp:post-template -->
 					<!-- wp:spacer {"height":200} -->
 					<div style="height:200px" aria-hidden="true" class="wp-block-spacer"></div>

--- a/src/wp-includes/block-patterns/query-small-posts.php
+++ b/src/wp-includes/block-patterns/query-small-posts.php
@@ -9,7 +9,7 @@ return array(
 	'title'      => _x( 'Small image and title', 'Block pattern title' ),
 	'blockTypes' => array( 'core/query' ),
 	'categories' => array( 'query' ),
-	'content'    => '<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
+	'content'    => '<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
 					<div class="wp-block-query">
 					<!-- wp:post-template -->
 					<!-- wp:columns {"verticalAlignment":"center"} -->

--- a/src/wp-includes/block-patterns/query-standard-posts.php
+++ b/src/wp-includes/block-patterns/query-standard-posts.php
@@ -9,7 +9,7 @@ return array(
 	'title'      => _x( 'Standard', 'Block pattern title' ),
 	'blockTypes' => array( 'core/query' ),
 	'categories' => array( 'query' ),
-	'content'    => '<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
+	'content'    => '<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
 					<div class="wp-block-query">
 					<!-- wp:post-template -->
 					<!-- wp:post-title {"isLink":true} /-->

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -939,9 +939,8 @@ function do_blocks( $content ) {
  * If do_blocks() needs to remove wpautop() from the `the_content` filter, this re-adds it afterwards,
  * for subsequent `the_content` usage.
  *
- * @access private
- *
  * @since 5.0.0
+ * @access private 
  *
  * @param string $content The post content running through this filter.
  * @return string The unmodified content.

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1126,15 +1126,39 @@ function build_query_vars_from_query_block( $block, $page ) {
 			$query['offset']         = ( $per_page * ( $page - 1 ) ) + $offset;
 			$query['posts_per_page'] = $per_page;
 		}
-		if ( ! empty( $block->context['query']['categoryIds'] ) ) {
-			$term_ids              = array_map( 'intval', $block->context['query']['categoryIds'] );
-			$term_ids              = array_filter( $term_ids );
-			$query['category__in'] = $term_ids;
+		// Migrate `categoryIds` and `tagIds` to `tax_query` for backwards compatibility.
+		if ( ! empty( $block->context['query']['categoryIds'] ) || ! empty( $block->context['query']['tagIds'] ) ) {
+			$tax_query = array();
+			if ( ! empty( $block->context['query']['categoryIds'] ) ) {
+				$tax_query[] = array(
+					'taxonomy'         => 'category',
+					'terms'            => $block->context['query']['categoryIds'],
+					'include_children' => false,
+				);
+			}
+			if ( ! empty( $block->context['query']['tagIds'] ) ) {
+				$tax_query[] = array(
+					'taxonomy'         => 'post_tag',
+					'terms'            => $block->context['query']['tagIds'],
+					'include_children' => false,
+				);
+			}
+			$query['tax_query'] = $tax_query;
 		}
-		if ( ! empty( $block->context['query']['tagIds'] ) ) {
-			$term_ids         = array_map( 'intval', $block->context['query']['tagIds'] );
-			$term_ids         = array_filter( $term_ids );
-			$query['tag__in'] = $term_ids;
+		if ( ! empty( $block->context['query']['taxQuery'] ) ) {
+			$query['tax_query'] = array();
+			foreach ( $block->context['query']['taxQuery'] as $taxonomy => $terms ) {
+				if ( ! empty( $terms ) ) {
+					$term_ids = array_map( 'intval', $terms );
+					$term_ids = array_filter( $term_ids );
+
+					$query['tax_query'][] = array(
+						'taxonomy'         => $taxonomy,
+						'terms'            => $terms,
+						'include_children' => false,
+					);
+				}
+			}
 		}
 		if (
 			isset( $block->context['query']['order'] ) &&

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1132,14 +1132,14 @@ function build_query_vars_from_query_block( $block, $page ) {
 			if ( ! empty( $block->context['query']['categoryIds'] ) ) {
 				$tax_query[] = array(
 					'taxonomy'         => 'category',
-					'terms'            => $block->context['query']['categoryIds'],
+					'terms'            => array_filter( array_map( 'intval', $block->context['query']['categoryIds'] ) ),
 					'include_children' => false,
 				);
 			}
 			if ( ! empty( $block->context['query']['tagIds'] ) ) {
 				$tax_query[] = array(
 					'taxonomy'         => 'post_tag',
-					'terms'            => $block->context['query']['tagIds'],
+					'terms'            => array_filter( array_map( 'intval', $block->context['query']['tagIds'] ) ),
 					'include_children' => false,
 				);
 			}
@@ -1148,13 +1148,10 @@ function build_query_vars_from_query_block( $block, $page ) {
 		if ( ! empty( $block->context['query']['taxQuery'] ) ) {
 			$query['tax_query'] = array();
 			foreach ( $block->context['query']['taxQuery'] as $taxonomy => $terms ) {
-				if ( ! empty( $terms ) ) {
-					$term_ids = array_map( 'intval', $terms );
-					$term_ids = array_filter( $term_ids );
-
+				if ( is_taxonomy_viewable( $taxonomy ) && ! empty( $terms ) ) {
 					$query['tax_query'][] = array(
 						'taxonomy'         => $taxonomy,
-						'terms'            => $terms,
+						'terms'            => array_filter( array_map( 'intval', $terms ) ),
 						'include_children' => false,
 					);
 				}

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -940,7 +940,7 @@ function do_blocks( $content ) {
  * for subsequent `the_content` usage.
  *
  * @since 5.0.0
- * @access private 
+ * @access private
  *
  * @param string $content The post content running through this filter.
  * @return string The unmodified content.

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -760,6 +760,21 @@ class WP_Theme_JSON {
 	}
 
 	/**
+	 * Returns the current theme's wanted patterns(slugs) to be registered from
+	 * Pattern Directory.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @return array Array of patterns if configured, else empty array.
+	 */
+	public function get_patterns() {
+		if ( isset( $this->theme_json['patterns'] ) && is_array( $this->theme_json['patterns'] ) ) {
+			return $this->theme_json['patterns'];
+		}
+		return array();
+	}
+
+	/**
 	 * Converts each style section into a list of rulesets
 	 * containing the block styles to be appended to the stylesheet.
 	 *

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -337,6 +337,14 @@ function create_initial_rest_routes() {
 	$controller = new WP_REST_Pattern_Directory_Controller();
 	$controller->register_routes();
 
+	// Block Patterns.
+	$controller = new WP_REST_Block_Patterns_Controller();
+	$controller->register_routes();
+
+	// Block Pattern Categories.
+	$controller = new WP_REST_Block_Pattern_Categories_Controller();
+	$controller->register_routes();
+
 	// Site Health.
 	$site_health = WP_Site_Health::get_instance();
 	$controller  = new WP_REST_Site_Health_Controller( $site_health );

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-pattern-categories-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-pattern-categories-controller.php
@@ -22,7 +22,7 @@ class WP_REST_Block_Pattern_Categories_Controller extends WP_REST_Controller {
 	 * @since 6.0.0
 	 */
 	public function __construct() {
-		$this->namespace = '__experimental';
+		$this->namespace = 'wp/v2';
 		$this->rest_base = 'block-patterns/categories';
 	}
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-pattern-categories-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-pattern-categories-controller.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * REST API: WP_REST_Block_Pattern_Catergories_Controller class
+ *
+ * @package    WordPress
+ * @subpackage REST_API
+ * @since      6.0.0
+ */
+
+/**
+ * Core class used to access block pattern categories via the REST API.
+ *
+ * @since 6.0.0
+ *
+ * @see WP_REST_Controller
+ */
+class WP_REST_Block_Pattern_Categories_Controller extends WP_REST_Controller {
+
+	/**
+	 * Constructs the controller.
+	 *
+	 * @since 6.0.0
+	 */
+	public function __construct() {
+		$this->namespace = '__experimental';
+		$this->rest_base = 'block-patterns/categories';
+	}
+
+	/**
+	 * Registers the routes for the objects of the controller.
+	 *
+	 * @since 6.0.0
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Checks whether a given request has permission to read block patterns.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
+	 */
+	public function get_items_permissions_check( $request ) {
+		if ( current_user_can( 'edit_posts' ) ) {
+			return true;
+		}
+
+		foreach ( get_post_types( array( 'show_in_rest' => true ), 'objects' ) as $post_type ) {
+			if ( current_user_can( $post_type->cap->edit_posts ) ) {
+				return true;
+			}
+		}
+
+		return new WP_Error(
+			'rest_cannot_view',
+			__( 'Sorry, you are not allowed to view the registered block pattern categories.' ),
+			array( 'status' => rest_authorization_required_code() )
+		);
+	}
+
+	/**
+	 * Retrieves all block pattern categories.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|WP_REST_Response Response object on success, or WP_Error object on failure.
+	 */
+	public function get_items( $request ) {
+		$response   = array();
+		$categories = WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered();
+		foreach ( $categories as $category ) {
+			$prepared_category = $this->prepare_item_for_response( $category, $request );
+			$response[]        = $this->prepare_response_for_collection( $prepared_category );
+		}
+
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Prepare a raw block pattern category before it gets output in a REST API response.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @param object          $item    Raw category as registered, before any changes.
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function prepare_item_for_response( $item, $request ) {
+		$fields = $this->get_fields_for_response( $request );
+		$keys   = array( 'name', 'label' );
+		$data   = array();
+		foreach ( $keys as $key ) {
+			if ( rest_is_field_included( $key, $fields ) ) {
+				$data[ $key ] = $item[ $key ];
+			}
+		}
+
+		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$data    = $this->add_additional_fields_to_object( $data, $request );
+		$data    = $this->filter_response_by_context( $data, $context );
+
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Retrieves the block pattern category schema, conforming to JSON Schema.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @return array Item schema data.
+	 */
+	public function get_item_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'block-pattern-category',
+			'type'       => 'object',
+			'properties' => array(
+				'name'  => array(
+					'description' => __( 'The category name.' ),
+					'type'        => 'string',
+					'readonly'    => true,
+					'context'     => array( 'view', 'embed' ),
+				),
+				'label' => array(
+					'description' => __( 'The category label, in human readable format.' ),
+					'type'        => 'string',
+					'readonly'    => true,
+					'context'     => array( 'view', 'embed' ),
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-patterns-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-patterns-controller.php
@@ -22,7 +22,7 @@ class WP_REST_Block_Patterns_Controller extends WP_REST_Controller {
 	 * @since 6.0.0
 	 */
 	public function __construct() {
-		$this->namespace = '__experimental';
+		$this->namespace = 'wp/v2';
 		$this->rest_base = 'block-patterns/patterns';
 	}
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-patterns-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-patterns-controller.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * REST API: WP_REST_Block_Patterns_Controller class
+ *
+ * @package    WordPress
+ * @subpackage REST_API
+ * @since      6.0.0
+ */
+
+/**
+ * Core class used to access block patterns via the REST API.
+ *
+ * @since 6.0.0
+ *
+ * @see WP_REST_Controller
+ */
+class WP_REST_Block_Patterns_Controller extends WP_REST_Controller {
+
+	/**
+	 * Constructs the controller.
+	 *
+	 * @since 6.0.0
+	 */
+	public function __construct() {
+		$this->namespace = '__experimental';
+		$this->rest_base = 'block-patterns/patterns';
+	}
+
+	/**
+	 * Registers the routes for the objects of the controller.
+	 *
+	 * @since 6.0.0
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Checks whether a given request has permission to read block patterns.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
+	 */
+	public function get_items_permissions_check( $request ) {
+		if ( current_user_can( 'edit_posts' ) ) {
+			return true;
+		}
+
+		foreach ( get_post_types( array( 'show_in_rest' => true ), 'objects' ) as $post_type ) {
+			if ( current_user_can( $post_type->cap->edit_posts ) ) {
+				return true;
+			}
+		}
+
+		return new WP_Error(
+			'rest_cannot_view',
+			__( 'Sorry, you are not allowed to view the registered block patterns.' ),
+			array( 'status' => rest_authorization_required_code() )
+		);
+	}
+
+	/**
+	 * Retrieves all block patterns.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function get_items( $request ) {
+		// Load block patterns from w.org.
+		_load_remote_block_patterns(); // Patterns with the `core` keyword.
+		_load_remote_featured_patterns(); // Patterns in the `featured` category.
+		_register_remote_theme_patterns(); // Patterns requested by current theme.
+
+		$response = array();
+		$patterns = WP_Block_Patterns_Registry::get_instance()->get_all_registered();
+		foreach ( $patterns as $pattern ) {
+			$prepared_pattern = $this->prepare_item_for_response( $pattern, $request );
+			$response[]       = $this->prepare_response_for_collection( $prepared_pattern );
+		}
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Prepare a raw block pattern before it gets output in a REST API response.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @param object          $item    Raw pattern as registered, before any changes.
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function prepare_item_for_response( $item, $request ) {
+		$fields = $this->get_fields_for_response( $request );
+		$keys   = array(
+			'name',
+			'title',
+			'description',
+			'viewportWidth',
+			'blockTypes',
+			'categories',
+			'keywords',
+			'content',
+		);
+		$data   = array();
+		foreach ( $keys as $key ) {
+			if ( isset( $item[ $key ] ) && rest_is_field_included( $key, $fields ) ) {
+				$data[ $key ] = $item[ $key ];
+			}
+		}
+
+		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$data    = $this->add_additional_fields_to_object( $data, $request );
+		$data    = $this->filter_response_by_context( $data, $context );
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Retrieves the block pattern schema, conforming to JSON Schema.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @return array Item schema data.
+	 */
+	public function get_item_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'block-pattern',
+			'type'       => 'object',
+			'properties' => array(
+				'name'          => array(
+					'description' => __( 'The pattern name.' ),
+					'type'        => 'string',
+					'readonly'    => true,
+					'context'     => array( 'view', 'embed' ),
+				),
+				'title'         => array(
+					'description' => __( 'The pattern title, in human readable format.' ),
+					'type'        => 'string',
+					'readonly'    => true,
+					'context'     => array( 'view', 'embed' ),
+				),
+				'description'   => array(
+					'description' => __( 'The pattern detailed description.' ),
+					'type'        => 'string',
+					'readonly'    => true,
+					'context'     => array( 'view', 'embed' ),
+				),
+				'viewportWidth' => array(
+					'description' => __( 'The pattern viewport width for inserter preview.' ),
+					'type'        => 'number',
+					'readonly'    => true,
+					'context'     => array( 'view', 'embed' ),
+				),
+				'blockTypes'    => array(
+					'description' => __( 'Block types that the pattern is intended to be used with.' ),
+					'type'        => 'array',
+					'readonly'    => true,
+					'context'     => array( 'view', 'embed' ),
+				),
+				'categories'    => array(
+					'description' => __( 'The pattern category slugs.' ),
+					'type'        => 'array',
+					'readonly'    => true,
+					'context'     => array( 'view', 'embed' ),
+				),
+				'keywords'      => array(
+					'description' => __( 'The pattern keywords.' ),
+					'type'        => 'array',
+					'readonly'    => true,
+					'context'     => array( 'view', 'embed' ),
+				),
+				'content'       => array(
+					'description' => __( 'The pattern content.' ),
+					'type'        => 'string',
+					'readonly'    => true,
+					'context'     => array( 'view', 'embed' ),
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-pattern-directory-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-pattern-directory-controller.php
@@ -80,6 +80,7 @@ class WP_REST_Pattern_Directory_Controller extends WP_REST_Controller {
 	 * Search and retrieve block patterns metadata
 	 *
 	 * @since 5.8.0
+	 * @since 6.0.0 Added 'slug' to request.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
@@ -100,6 +101,7 @@ class WP_REST_Pattern_Directory_Controller extends WP_REST_Controller {
 		$category_id = $request['category'];
 		$keyword_id  = $request['keyword'];
 		$search_term = $request['search'];
+		$slug        = $request['slug'];
 
 		if ( $category_id ) {
 			$query_args['pattern-categories'] = $category_id;
@@ -111,6 +113,10 @@ class WP_REST_Pattern_Directory_Controller extends WP_REST_Controller {
 
 		if ( $search_term ) {
 			$query_args['search'] = $search_term;
+		}
+
+		if ( $slug ) {
+			$query_args['slug'] = $slug;
 		}
 
 		/*
@@ -159,7 +165,7 @@ class WP_REST_Pattern_Directory_Controller extends WP_REST_Controller {
 				$raw_patterns = new WP_Error(
 					'pattern_api_failed',
 					sprintf(
-					/* translators: %s: Support forums URL. */
+						/* translators: %s: Support forums URL. */
 						__( 'An unexpected error occurred. Something may be wrong with WordPress.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href="%s">support forums</a>.' ),
 						__( 'https://wordpress.org/support/forums/' )
 					),

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -277,6 +277,8 @@ require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-plugins-controller.
 require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-block-directory-controller.php';
 require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-edit-site-export-controller.php';
 require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-pattern-directory-controller.php';
+require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-block-patterns-controller.php';
+require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-block-pattern-categories-controller.php';
 require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-application-passwords-controller.php';
 require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-site-health-controller.php';
 require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-sidebars-controller.php';

--- a/tests/phpunit/tests/blocks/wpBlock.php
+++ b/tests/phpunit/tests/blocks/wpBlock.php
@@ -439,12 +439,22 @@ class Tests_Blocks_wpBlock extends WP_UnitTestCase {
 		$this->assertSame(
 			$query,
 			array(
-				'post_type'    => 'page',
-				'order'        => 'DESC',
-				'orderby'      => 'title',
-				'post__not_in' => array( 1, 2 ),
-				'category__in' => array( 56 ),
-				'tag__in'      => array( 3, 11, 10 ),
+				'post_type'        => 'page',
+				'order'            => 'DESC',
+				'orderby'          => 'title',
+				'post__not_in'     => array( 1, 2 ),
+				'tax_query'        => array(
+					array(
+						'taxonomy'         => 'category',
+						'terms'            => array( 56 ),
+						'include_children' => false,
+					),
+					array(
+						'taxonomy'         => 'post_tag',
+						'terms'            => array( 3, 11, 10 ),
+						'include_children' => false,
+					),
+				),
 			)
 		);
 	}

--- a/tests/phpunit/tests/blocks/wpBlock.php
+++ b/tests/phpunit/tests/blocks/wpBlock.php
@@ -439,11 +439,11 @@ class Tests_Blocks_wpBlock extends WP_UnitTestCase {
 		$this->assertSame(
 			$query,
 			array(
-				'post_type'        => 'page',
-				'order'            => 'DESC',
-				'orderby'          => 'title',
-				'post__not_in'     => array( 1, 2 ),
-				'tax_query'        => array(
+				'post_type'    => 'page',
+				'order'        => 'DESC',
+				'orderby'      => 'title',
+				'post__not_in' => array( 1, 2 ),
+				'tax_query'    => array(
 					array(
 						'taxonomy'         => 'category',
 						'terms'            => array( 56 ),

--- a/tests/phpunit/tests/rest-api/rest-schema-setup.php
+++ b/tests/phpunit/tests/rest-api/rest-schema-setup.php
@@ -160,6 +160,8 @@ class WP_Test_REST_Schema_Initialization extends WP_Test_REST_TestCase {
 			'/wp/v2/plugins',
 			'/wp/v2/plugins/(?P<plugin>[^.\/]+(?:\/[^.\/]+)?)',
 			'/wp/v2/block-directory/search',
+			'/wp/v2/block-patterns/categories',
+			'/wp/v2/block-patterns/patterns',
 			'/wp/v2/sidebars',
 			'/wp/v2/sidebars/(?P<id>[\w-]+)',
 			'/wp/v2/widget-types',

--- a/tests/phpunit/tests/rest-api/wpRestBlockPatternCategoriesController.php
+++ b/tests/phpunit/tests/rest-api/wpRestBlockPatternCategoriesController.php
@@ -43,7 +43,7 @@ class Tests_REST_WpRestBlockPatternCategoriesController extends WP_Test_REST_Con
 	 *
 	 * @var string
 	 */
-	const REQUEST_ROUTE = '/__experimental/block-patterns/categories';
+	const REQUEST_ROUTE = '/wp/v2/block-patterns/categories';
 
 	/**
 	 * Set up class test fixtures.

--- a/tests/phpunit/tests/rest-api/wpRestBlockPatternCategoriesController.php
+++ b/tests/phpunit/tests/rest-api/wpRestBlockPatternCategoriesController.php
@@ -37,6 +37,15 @@ class Tests_REST_WpRestBlockPatternCategoriesController extends WP_Test_REST_Con
 	protected static $orig_registry;
 
 	/**
+	 * Instance of the reflected `instance` property.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @var ReflectionProperty
+	 */
+	private static $registry_instance_property;
+
+	/**
 	 * The REST API route.
 	 *
 	 * @since 6.0.0
@@ -56,11 +65,11 @@ class Tests_REST_WpRestBlockPatternCategoriesController extends WP_Test_REST_Con
 		self::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
 
 		// Setup an empty testing instance of `WP_Block_Pattern_Categories_Registry` and save the original.
-		$reflection = new ReflectionClass( 'WP_Block_Pattern_Categories_Registry' );
-		$reflection->getProperty( 'instance' )->setAccessible( true );
-		self::$orig_registry = $reflection->getStaticPropertyValue( 'instance' );
-		$test_registry       = new WP_Block_Pattern_Categories_Registry();
-		$reflection->setStaticPropertyValue( 'instance', $test_registry );
+		self::$orig_registry              = WP_Block_Pattern_Categories_Registry::get_instance();
+		self::$registry_instance_property = new ReflectionProperty( 'WP_Block_Pattern_Categories_Registry', 'instance' );
+		self::$registry_instance_property->setAccessible( true );
+		$test_registry = new WP_Block_Pattern_Categories_Registry();
+		self::$registry_instance_property->setValue( $test_registry );
 
 		// Register some categories in the test registry.
 		$test_registry->register( 'test', array( 'label' => 'Test' ) );
@@ -71,8 +80,10 @@ class Tests_REST_WpRestBlockPatternCategoriesController extends WP_Test_REST_Con
 		self::delete_user( self::$admin_id );
 
 		// Restore the original registry instance.
-		$reflection = new ReflectionClass( 'WP_Block_Pattern_Categories_Registry' );
-		$reflection->setStaticPropertyValue( 'instance', self::$orig_registry );
+		self::$registry_instance_property->setValue( self::$orig_registry );
+		self::$registry_instance_property->setAccessible( false );
+		self::$registry_instance_property = null;
+		self::$orig_registry              = null;
 	}
 
 	public function set_up() {

--- a/tests/phpunit/tests/rest-api/wpRestBlockPatternCategoriesController.php
+++ b/tests/phpunit/tests/rest-api/wpRestBlockPatternCategoriesController.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Unit tests covering WP_Block_Pattern_Categories_Registry functionality.
+ *
+ * @package    WordPress
+ * @subpackage REST_API
+ * @since      6.0.0
+ */
+
+/**
+ * Tests for REST API for Block Pattern Categories Registry.
+ *
+ * @since 6.0.0
+ *
+ * @covers WP_REST_Block_Pattern_Categories_Controller
+ *
+ * @group restapi
+ */
+class Tests_REST_WpRestBlockPatternCategoriesController extends WP_Test_REST_Controller_Testcase {
+
+	/**
+	 * Admin user ID.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @var int
+	 */
+	protected static $admin_id;
+
+	/**
+	 * Original instance of WP_Block_Patterns_Registry.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @var WP_Block_Patterns_Registry
+	 */
+	protected static $orig_registry;
+
+	/**
+	 * The REST API route.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @var string
+	 */
+	const REQUEST_ROUTE = '/__experimental/block-patterns/categories';
+
+	/**
+	 * Set up class test fixtures.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @param WP_UnitTest_Factory $factory WordPress unit test factory.
+	 */
+	public static function wpSetupBeforeClass( $factory ) {
+		self::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
+
+		// Setup an empty testing instance of `WP_Block_Pattern_Categories_Registry` and save the original.
+		$reflection = new ReflectionClass( 'WP_Block_Pattern_Categories_Registry' );
+		$reflection->getProperty( 'instance' )->setAccessible( true );
+		self::$orig_registry = $reflection->getStaticPropertyValue( 'instance' );
+		$test_registry       = new WP_Block_Pattern_Categories_Registry();
+		$reflection->setStaticPropertyValue( 'instance', $test_registry );
+
+		// Register some categories in the test registry.
+		$test_registry->register( 'test', array( 'label' => 'Test' ) );
+		$test_registry->register( 'query', array( 'label' => 'Query' ) );
+	}
+
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$admin_id );
+
+		// Restore the original registry instance.
+		$reflection = new ReflectionClass( 'WP_Block_Pattern_Categories_Registry' );
+		$reflection->setStaticPropertyValue( 'instance', self::$orig_registry );
+	}
+
+	public function set_up() {
+		parent::set_up();
+
+		switch_theme( 'emptytheme' );
+	}
+
+	public function test_register_routes() {
+		$routes = rest_get_server()->get_routes();
+		$this->assertArrayHasKey( static::REQUEST_ROUTE, $routes );
+	}
+
+	public function test_get_items() {
+		wp_set_current_user( self::$admin_id );
+
+		$expected_names  = array( 'test', 'query' );
+		$expected_fields = array( 'name', 'label' );
+
+		$request            = new WP_REST_Request( 'GET', static::REQUEST_ROUTE );
+		$request['_fields'] = 'name,label';
+		$response           = rest_get_server()->dispatch( $request );
+		$data               = $response->get_data();
+
+		$this->assertCount( count( $expected_names ), $data );
+		foreach ( $data as $idx => $item ) {
+			$this->assertSame( $expected_names[ $idx ], $item['name'] );
+			$this->assertSame( $expected_fields, array_keys( $item ) );
+		}
+	}
+
+	public function test_context_param() {
+		$this->markTestSkipped( 'Controller does not use context_param.' );
+	}
+
+	public function test_get_item() {
+		$this->markTestSkipped( 'Controller does not have get_item route.' );
+	}
+
+	public function test_create_item() {
+		$this->markTestSkipped( 'Controller does not have create_item route.' );
+	}
+
+	public function test_update_item() {
+		$this->markTestSkipped( 'Controller does not have update_item route.' );
+	}
+
+	public function test_delete_item() {
+		$this->markTestSkipped( 'Controller does not have delete_item route.' );
+	}
+
+	public function test_prepare_item() {
+		$this->markTestSkipped( 'Controller does not have prepare_item route.' );
+	}
+
+	public function test_get_item_schema() {
+		$this->markTestSkipped( 'Controller does not have get_item_schema route.' );
+	}
+}

--- a/tests/phpunit/tests/rest-api/wpRestBlockPatternsController.php
+++ b/tests/phpunit/tests/rest-api/wpRestBlockPatternsController.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Unit tests covering WP_REST_Block_Patterns_Controller functionality.
+ *
+ * @package    WordPress
+ * @subpackage REST_API
+ * @since      6.0.0
+ */
+
+/**
+ * Tests for REST API for Block Patterns.
+ *
+ * @since 6.0.0
+ *
+ * @covers WP_REST_Block_Patterns_Controller
+ *
+ * @group restapi
+ */
+class Tests_REST_WpRestBlockPatternsController extends WP_Test_REST_Controller_Testcase {
+
+	/**
+	 * Admin user ID.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @var int
+	 */
+	protected static $admin_id;
+
+	/**
+	 * Original instance of WP_Block_Patterns_Registry.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @var WP_Block_Patterns_Registry
+	 */
+	protected static $orig_registry;
+
+	/**
+	 * The REST API route.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @var string
+	 */
+	const REQUEST_ROUTE = '/__experimental/block-patterns/patterns';
+
+	/**
+	 * Set up class test fixtures.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @param WP_UnitTest_Factory $factory WordPress unit test factory.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
+
+		// Setup an empty testing instance of `WP_Block_Patterns_Registry` and save the original.
+		$reflection = new ReflectionClass( 'WP_Block_Patterns_Registry' );
+		$reflection->getProperty( 'instance' )->setAccessible( true );
+		self::$orig_registry = $reflection->getStaticPropertyValue( 'instance' );
+		$test_registry       = new WP_Block_Patterns_Registry();
+		$reflection->setStaticPropertyValue( 'instance', $test_registry );
+
+		// Register some patterns in the test registry.
+		$test_registry->register(
+			'test/one',
+			array(
+				'title'         => 'Pattern One',
+				'categories'    => array( 'test' ),
+				'viewportWidth' => 1440,
+				'content'       => '<!-- wp:heading {"level":1} --><h1>One</h1><!-- /wp:heading -->',
+			)
+		);
+
+		$test_registry->register(
+			'test/two',
+			array(
+				'title'      => 'Pattern Two',
+				'categories' => array( 'test' ),
+				'content'    => '<!-- wp:paragraph --><p>Two</p><!-- /wp:paragraph -->',
+			)
+		);
+	}
+
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$admin_id );
+
+		// Restore the original registry instance.
+		$reflection = new ReflectionClass( 'WP_Block_Patterns_Registry' );
+		$reflection->setStaticPropertyValue( 'instance', self::$orig_registry );
+	}
+
+	public function set_up() {
+		parent::set_up();
+
+		switch_theme( 'emptytheme' );
+	}
+
+	public function test_register_routes() {
+		$routes = rest_get_server()->get_routes();
+		$this->assertArrayHasKey( static::REQUEST_ROUTE, $routes );
+
+	}
+
+	public function test_get_items() {
+		wp_set_current_user( self::$admin_id );
+
+		$expected_names  = array( 'test/one', 'test/two' );
+		$expected_fields = array( 'name', 'content' );
+
+		$request            = new WP_REST_Request( 'GET', static::REQUEST_ROUTE );
+		$request['_fields'] = 'name,content';
+		$response           = rest_get_server()->dispatch( $request );
+		$data               = $response->get_data();
+
+		$this->assertCount( count( $expected_names ), $data );
+		foreach ( $data as $idx => $item ) {
+			$this->assertSame( $expected_names[ $idx ], $item['name'] );
+			$this->assertSame( $expected_fields, array_keys( $item ) );
+		}
+	}
+
+	public function test_context_param() {
+		$this->markTestSkipped( 'Controller does not use context_param.' );
+	}
+
+	public function test_get_item() {
+		$this->markTestSkipped( 'Controller does not have get_item route.' );
+	}
+
+	public function test_create_item() {
+		$this->markTestSkipped( 'Controller does not have create_item route.' );
+	}
+
+	public function test_update_item() {
+		$this->markTestSkipped( 'Controller does not have update_item route.' );
+	}
+
+	public function test_delete_item() {
+		$this->markTestSkipped( 'Controller does not have delete_item route.' );
+	}
+
+	public function test_prepare_item() {
+		$this->markTestSkipped( 'Controller does not have prepare_item route.' );
+	}
+
+	public function test_get_item_schema() {
+		$this->markTestSkipped( 'Controller does not have get_item_schema route.' );
+	}
+}

--- a/tests/phpunit/tests/rest-api/wpRestBlockPatternsController.php
+++ b/tests/phpunit/tests/rest-api/wpRestBlockPatternsController.php
@@ -37,6 +37,15 @@ class Tests_REST_WpRestBlockPatternsController extends WP_Test_REST_Controller_T
 	protected static $orig_registry;
 
 	/**
+	 * Instance of the reflected `instance` property.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @var ReflectionProperty
+	 */
+	private static $registry_instance_property;
+
+	/**
 	 * The REST API route.
 	 *
 	 * @since 6.0.0
@@ -56,11 +65,11 @@ class Tests_REST_WpRestBlockPatternsController extends WP_Test_REST_Controller_T
 		self::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
 
 		// Setup an empty testing instance of `WP_Block_Patterns_Registry` and save the original.
-		$reflection = new ReflectionClass( 'WP_Block_Patterns_Registry' );
-		$reflection->getProperty( 'instance' )->setAccessible( true );
-		self::$orig_registry = $reflection->getStaticPropertyValue( 'instance' );
-		$test_registry       = new WP_Block_Patterns_Registry();
-		$reflection->setStaticPropertyValue( 'instance', $test_registry );
+		self::$orig_registry              = WP_Block_Patterns_Registry::get_instance();
+		self::$registry_instance_property = new ReflectionProperty( 'WP_Block_Patterns_Registry', 'instance' );
+		self::$registry_instance_property->setAccessible( true );
+		$test_registry = new WP_Block_Pattern_Categories_Registry();
+		self::$registry_instance_property->setValue( $test_registry );
 
 		// Register some patterns in the test registry.
 		$test_registry->register(
@@ -87,8 +96,10 @@ class Tests_REST_WpRestBlockPatternsController extends WP_Test_REST_Controller_T
 		self::delete_user( self::$admin_id );
 
 		// Restore the original registry instance.
-		$reflection = new ReflectionClass( 'WP_Block_Patterns_Registry' );
-		$reflection->setStaticPropertyValue( 'instance', self::$orig_registry );
+		self::$registry_instance_property->setValue( self::$orig_registry );
+		self::$registry_instance_property->setAccessible( false );
+		self::$registry_instance_property = null;
+		self::$orig_registry              = null;
 	}
 
 	public function set_up() {

--- a/tests/phpunit/tests/rest-api/wpRestBlockPatternsController.php
+++ b/tests/phpunit/tests/rest-api/wpRestBlockPatternsController.php
@@ -116,19 +116,29 @@ class Tests_REST_WpRestBlockPatternsController extends WP_Test_REST_Controller_T
 	public function test_get_items() {
 		wp_set_current_user( self::$admin_id );
 
-		$expected_names  = array( 'test/one', 'test/two' );
-		$expected_fields = array( 'name', 'content' );
-
 		$request            = new WP_REST_Request( 'GET', static::REQUEST_ROUTE );
 		$request['_fields'] = 'name,content';
 		$response           = rest_get_server()->dispatch( $request );
 		$data               = $response->get_data();
 
-		$this->assertCount( count( $expected_names ), $data );
-		foreach ( $data as $idx => $item ) {
-			$this->assertSame( $expected_names[ $idx ], $item['name'] );
-			$this->assertSame( $expected_fields, array_keys( $item ) );
-		}
+		$this->assertIsArray( $data, 'WP_REST_Block_Patterns_Controller::get_items() should return an array' );
+		$this->assertGreaterThanOrEqual( 2, count( $data ), 'WP_REST_Block_Patterns_Controller::get_items() should return at least 2 items' );
+		$this->assertSame(
+			array(
+				'name'    => 'test/one',
+				'content' => '<!-- wp:heading {"level":1} --><h1>One</h1><!-- /wp:heading -->',
+			),
+			$data[0],
+			'WP_REST_Block_Patterns_Controller::get_items() should return test/one'
+		);
+		$this->assertSame(
+			array(
+				'name'    => 'test/two',
+				'content' => '<!-- wp:paragraph --><p>Two</p><!-- /wp:paragraph -->',
+			),
+			$data[1],
+			'WP_REST_Block_Patterns_Controller::get_items() should return test/two'
+		);
 	}
 
 	public function test_context_param() {

--- a/tests/phpunit/tests/rest-api/wpRestBlockPatternsController.php
+++ b/tests/phpunit/tests/rest-api/wpRestBlockPatternsController.php
@@ -43,7 +43,7 @@ class Tests_REST_WpRestBlockPatternsController extends WP_Test_REST_Controller_T
 	 *
 	 * @var string
 	 */
-	const REQUEST_ROUTE = '/__experimental/block-patterns/patterns';
+	const REQUEST_ROUTE = '/wp/v2/block-patterns/patterns';
 
 	/**
 	 * Set up class test fixtures.
@@ -100,7 +100,6 @@ class Tests_REST_WpRestBlockPatternsController extends WP_Test_REST_Controller_T
 	public function test_register_routes() {
 		$routes = rest_get_server()->get_routes();
 		$this->assertArrayHasKey( static::REQUEST_ROUTE, $routes );
-
 	}
 
 	public function test_get_items() {

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -10376,6 +10376,48 @@ mockedApiResponse.Schema = {
                 ]
             }
         },
+        "/wp/v2/block-patterns/patterns": {
+            "namespace": "wp/v2",
+            "methods": [
+                "GET"
+            ],
+            "endpoints": [
+                {
+                    "methods": [
+                        "GET"
+                    ],
+                    "args": []
+                }
+            ],
+            "_links": {
+                "self": [
+                    {
+                        "href": "http://example.org/index.php?rest_route=/wp/v2/block-patterns/patterns"
+                    }
+                ]
+            }
+        },
+        "/wp/v2/block-patterns/categories": {
+            "namespace": "wp/v2",
+            "methods": [
+                "GET"
+            ],
+            "endpoints": [
+                {
+                    "methods": [
+                        "GET"
+                    ],
+                    "args": []
+                }
+            ],
+            "_links": {
+                "self": [
+                    {
+                        "href": "http://example.org/index.php?rest_route=/wp/v2/block-patterns/categories"
+                    }
+                ]
+            }
+        },
         "/wp-site-health/v1": {
             "namespace": "wp-site-health/v1",
             "methods": [


### PR DESCRIPTION
Backports changes from Gutenberg to add support for custom taxonomies filtering [Block Library - Query Loop].

- [X] [`lib/compat/wordpress-6.0/blocks.php`](https://github.com/WordPress/gutenberg/blob/trunk/lib/compat/wordpress-6.0/blocks.php)
- [x] [`lib/compat/wordpress-6.0/block-patterns.php`](https://github.com/WordPress/gutenberg/blob/trunk/lib/compat/wordpress-6.0/block-patterns.php)
- [X] [`lib/compat/wordpress-6.0/block-patterns-update.php`](https://github.com/WordPress/gutenberg/blob/trunk/lib/compat/wordpress-6.0/block-patterns-update.php)
- [x] [`lib/compat/wordpress-6.0/class-wp-rest-block-pattern-categories-controller.php`](https://github.com/WordPress/gutenberg/blob/trunk/lib/compat/wordpress-6.0/class-wp-rest-block-pattern-categories-controller.php)
- [x] [`lib/compat/wordpress-6.0/class-wp-rest-block-patterns-controller.php`](https://github.com/WordPress/gutenberg/blob/trunk/lib/compat/wordpress-6.0/class-wp-rest-block-patterns-controller.php)
- [x] [`lib/compat/wordpress-6.0/class-wp-rest-block-patterns-controller.php`](https://github.com/WordPress/gutenberg/blob/trunk/lib/compat/wordpress-6.0/class-wp-rest-pattern-directory-controller.php)
- [X] `phpunit/class-wp-rest-block-pattern-categories-controller-test.php`
- [X] `phpunit/class-wp-rest-block-patterns-controller-test.php`
- [X] `lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php` `WP_Theme_JSON:: get_patterns()`

Also being tracked in [this Gutenberg issue](https://github.com/WordPress/gutenberg/issues/39889).

Trac ticket: https://core.trac.wordpress.org/ticket/55505

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
