### PR TITLE
Administration: Don't print the php-error body class for suppressed `E_WARNING` level errors

### DIFF
--- a/src/wp-admin/admin-header.php
+++ b/src/wp-admin/admin-header.php
@@ -216,6 +216,7 @@ if ( $error_get_last && WP_DEBUG && WP_DEBUG_DISPLAY && ini_get( 'display_errors
 	// Don't print the class for PHP notices in wp-config.php, as they happen before WP_DEBUG takes effect,
 	// and should not be displayed with the `error_reporting` level previously set in wp-load.php.
 	&& ( E_NOTICE !== $error_get_last['type'] || 'wp-config.php' !== wp_basename( $error_get_last['file'] ) )
+	&& ( E_WARNING !== $error_get_last['type'] )
 ) {
 	$admin_body_class .= ' php-error';
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/51383

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
