### PR TITLE
Avoid PHP Warnings & invalid return values in `wp_list_pluck()`.

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -5176,6 +5176,10 @@ function wp_list_filter( $list, $args = array(), $operator = 'AND' ) {
  *               `$list` will be preserved in the results.
  */
 function wp_list_pluck( $list, $field, $index_key = null ) {
+	if ( ! is_array( $list ) ) {
+		return array();
+	}
+
 	$util = new WP_List_Util( $list );
 
 	return $util->pluck( $field, $index_key );


### PR DESCRIPTION
This matches the behaviour of `wp_filter_object_list()`, `wp_list_filter()`, and `wp_list_sort()`. `wp_list_pluck()` was the only function related to `WP_List_Util` that doesn't validate the input.

Trac Ticket: https://core.trac.wordpress.org/ticket/54751