### PR TITLE
fix: increase the H5 font size on theme Twenty Fifteen

### DIFF
--- a/src/wp-content/themes/twentyfifteen/css/editor-blocks.css
+++ b/src/wp-content/themes/twentyfifteen/css/editor-blocks.css
@@ -227,7 +227,7 @@ Description: Used to style blocks in the editor.
 	.edit-post-visual-editor .editor-block-list__block h5 {
 		font-size: 16px;
 		line-height: 1.25;
-		padding: 0.8125em 1.625em;
+		padding: 0.8125em 0 1.625em;
 	}
 
 	.edit-post-visual-editor .editor-block-list__block h6 {

--- a/src/wp-content/themes/twentyfifteen/css/editor-blocks.css
+++ b/src/wp-content/themes/twentyfifteen/css/editor-blocks.css
@@ -121,10 +121,15 @@ Description: Used to style blocks in the editor.
 	.edit-post-visual-editor .editor-block-list__block h4 {
 		font-size: 20px;
 		line-height: 1.4;
-		padding: .7em 0 0.35em;
+		padding: 0.7em 0 0.35em;
 	}
 
-	.edit-post-visual-editor .editor-block-list__block h5,
+	.edit-post-visual-editor .editor-block-list__block h5 {
+		font-size: 18px;
+		line-height: 1.3333;
+		padding: 1.3em 0 0.65em;
+	}
+
 	.edit-post-visual-editor .editor-block-list__block h6 {
 		font-size: 17px;
 		line-height: 1.2353;
@@ -169,7 +174,12 @@ Description: Used to style blocks in the editor.
 		padding: 0.75em 0 0.35em;
 	}
 
-	.edit-post-visual-editor .editor-block-list__block h5,
+	.edit-post-visual-editor .editor-block-list__block h5 {
+		font-size: 20px;
+		line-height: 1.4;
+		padding: 0.7em 0 0.35em;
+	}
+
 	.edit-post-visual-editor .editor-block-list__block h6 {
 		font-size: 19px;
 		line-height: 1.2632;
@@ -214,7 +224,12 @@ Description: Used to style blocks in the editor.
 		padding: 0.65em 0 0.3em;
 	}
 
-	.edit-post-visual-editor .editor-block-list__block h5,
+	.edit-post-visual-editor .editor-block-list__block h5 {
+		font-size: 16px;
+		line-height: 1.25;
+		padding: 0.8125em 1.625em;
+	}
+
 	.edit-post-visual-editor .editor-block-list__block h6 {
 		font-size: 15px;
 		line-height: 1.2;
@@ -259,7 +274,12 @@ Description: Used to style blocks in the editor.
 		padding: 0.7em 0 0.35em;
 	}
 
-	.edit-post-visual-editor .editor-block-list__block h5,
+	.edit-post-visual-editor .editor-block-list__block h5 {
+		font-size: 18px;
+		line-height: 1.3333;
+		padding: 0.65em 0 0.3em;
+	}
+
 	.edit-post-visual-editor .editor-block-list__block h6 {
 		font-size: 17px;
 		line-height: 1.2353;
@@ -292,7 +312,12 @@ Description: Used to style blocks in the editor.
 		padding: 0.75em 0 0.35em;
 	}
 
-	.edit-post-visual-editor .editor-block-list__block h5,
+	.edit-post-visual-editor .editor-block-list__block h5 {
+		font-size: 20px;
+		line-height: 1.4;
+		padding: 0.7em 0 0.35em;
+	}
+
 	.edit-post-visual-editor .editor-block-list__block h6 {
 		font-size: 19px;
 		line-height: 1.2632;

--- a/src/wp-content/themes/twentyfifteen/css/editor-blocks.css
+++ b/src/wp-content/themes/twentyfifteen/css/editor-blocks.css
@@ -227,7 +227,7 @@ Description: Used to style blocks in the editor.
 	.edit-post-visual-editor .editor-block-list__block h5 {
 		font-size: 16px;
 		line-height: 1.25;
-		padding: 0.8125em 0 1.625em;
+		padding: 0.875em 0 0.4375em;
 	}
 
 	.edit-post-visual-editor .editor-block-list__block h6 {

--- a/src/wp-content/themes/twentyfifteen/css/editor-style.css
+++ b/src/wp-content/themes/twentyfifteen/css/editor-style.css
@@ -69,7 +69,13 @@ h4 {
 	line-height: 1.4;
 }
 
-h5,
+h5 {
+	font-size: 18px;
+	letter-spacing: 0.1em;
+	line-height: 1.3333;
+	text-transform: uppercase;
+}
+
 h6 {
 	font-size: 17px;
 	letter-spacing: 0.1em;

--- a/src/wp-content/themes/twentyfifteen/css/ie.css
+++ b/src/wp-content/themes/twentyfifteen/css/ie.css
@@ -510,12 +510,18 @@ img.aligncenter {
 }
 
 .entry-content h5,
-.entry-content h6,
 .entry-summary h5,
-.entry-summary h6,
 .page-content h5,
+.comment-content h5 {
+	font-size: 20px;
+	line-height: 1.4;
+	margin-top: 2.8em;
+	margin-bottom: 1.4em;
+}
+
+.entry-content h6,
+.entry-summary h6,
 .page-content h6,
-.comment-content h5,
 .comment-content h6 {
 	font-size: 19px;
 	line-height: 1.2632;

--- a/src/wp-content/themes/twentyfifteen/style.css
+++ b/src/wp-content/themes/twentyfifteen/style.css
@@ -3374,12 +3374,19 @@ p > video {
 	}
 
 	.entry-content h5,
-	.entry-content h6,
 	.entry-summary h5,
-	.entry-summary h6,
 	.page-content h5,
+	.comment-content h5 {
+		font-size: 18px;
+		font-size: 1.8rem;
+		line-height: 1.3333;
+		margin-top: 2.6667em;
+		margin-bottom: 1.3333em;
+	}
+
+	.entry-content h6,
+	.entry-summary h6,
 	.page-content h6,
-	.comment-content h5,
 	.comment-content h6 {
 		font-size: 17px;
 		font-size: 1.7rem;
@@ -3948,12 +3955,19 @@ p > video {
 	}
 
 	.entry-content h5,
-	.entry-content h6,
 	.entry-summary h5,
-	.entry-summary h6,
 	.page-content h5,
+	.comment-content h5 {
+		font-size: 20px;
+		font-size: 2rem;
+		line-height: 1.4;
+		margin-top: 2.8em;
+		margin-bottom: 1.4em;
+	}
+
+	.entry-content h6,
+	.entry-summary h6,
 	.page-content h6,
-	.comment-content h5,
 	.comment-content h6 {
 		font-size: 19px;
 		font-size: 1.9rem;
@@ -4621,12 +4635,19 @@ p > video {
 	}
 
 	.entry-content h5,
-	.entry-content h6,
 	.entry-summary h5,
-	.entry-summary h6,
 	.page-content h5,
+	.comment-content h5 {
+		font-size: 16px;
+		font-size: 1.6rem;
+		line-height: 1.25;
+		margin-top: 3.25em;
+		margin-bottom: 1.625em;
+	}
+
+	.entry-content h6,
+	.entry-summary h6,
 	.page-content h6,
-	.comment-content h5,
 	.comment-content h6 {
 		font-size: 15px;
 		font-size: 1.5rem;
@@ -5204,12 +5225,19 @@ p > video {
 	}
 
 	.entry-content h5,
-	.entry-content h6,
 	.entry-summary h5,
-	.entry-summary h6,
 	.page-content h5,
+	.comment-content h5 {
+		font-size: 18px;
+		font-size: 1.8rem;
+		line-height: 1.3333;
+		margin-top: 2.6667em;
+		margin-bottom: 1.3333em;
+	}
+
+	.entry-content h6,
+	.entry-summary h6,
 	.page-content h6,
-	.comment-content h5,
 	.comment-content h6 {
 		font-size: 17px;
 		font-size: 1.7rem;
@@ -5759,12 +5787,19 @@ p > video {
 	}
 
 	.entry-content h5,
-	.entry-content h6,
 	.entry-summary h5,
-	.entry-summary h6,
 	.page-content h5,
+	.comment-content h5 {
+		font-size: 20px;
+		font-size: 2rem;
+		line-height: 1.4;
+		margin-top: 2.8em;
+		margin-bottom: 1.4em;
+	}
+
+	.entry-content h6,
+	.entry-summary h6,
 	.page-content h6,
-	.comment-content h5,
 	.comment-content h6 {
 		font-size: 19px;
 		font-size: 1.9rem;


### PR DESCRIPTION
# How
I increased 1px to all the H5 font sizes on theme Twenty Fifteen. I think it got a little bit different between the H5 and H6 font sizes.

# Testing Instructions
## Active the `Twenty Fifteen` theme
<img width="1439" alt="截圖 2022-04-02 下午4 55 12" src="https://user-images.githubusercontent.com/33183531/161375675-348a26bd-0379-488a-be94-88692dcda180.png">

## Open the editor and use H4 (20px), H5 (18px), H6 (17px)
<img width="1406" alt="image" src="https://user-images.githubusercontent.com/33183531/161375799-9f6de6e1-f4a2-420b-8a78-673840a14621.png">



Trac ticket: https://core.trac.wordpress.org/ticket/52028