### PR TITLE
Remove "we" language from Permalinks error messages

### DIFF
--- a/src/wp-admin/options-permalink.php
+++ b/src/wp-admin/options-permalink.php
@@ -368,7 +368,7 @@ printf( __( 'If you like, you may enter custom structures for your category and 
 				<?php
 				printf(
 					/* translators: 1: web.config, 2: Documentation URL, 3: Ctrl + A, 4: ⌘ + A, 5: Element code. */
-					__( 'If your %1$s file was <a href="%2$s">writable</a>, we could do this automatically, but it is not so this is the url rewrite rule you should have in your %1$s file. Click in the field and press %3$s (or %4$s on Mac) to select all. Then insert this rule inside of the %5$s element in %1$s file.' ),
+					__( 'Error: Your %1$s file is not <a href="%2$s">writable</a>, so updating it automatically was not possible. This is the URL rewrite rule you should have in your %1$s file. Click in the field and press %3$s (or %4$s on Mac) to select all. Then insert this rule inside of the %5$s element in %1$s file.' ),
 					'<code>web.config</code>',
 					__( 'https://wordpress.org/support/article/changing-file-permissions/' ),
 					'<kbd>Ctrl + A</kbd>',
@@ -385,7 +385,7 @@ printf( __( 'If you like, you may enter custom structures for your category and 
 				<?php
 				printf(
 					/* translators: %s: web.config */
-					__( 'If you temporarily make your %s file writable for us to generate rewrite rules automatically, do not forget to revert the permissions after rule has been saved.' ),
+					__( 'If you temporarily make your %s file writable to generate rewrite rules automatically, do not forget to revert the permissions after the rule has been saved.' ),
 					'<code>web.config</code>'
 				);
 				?>
@@ -395,7 +395,7 @@ printf( __( 'If you like, you may enter custom structures for your category and 
 			<?php
 			printf(
 				/* translators: 1: Documentation URL, 2: web.config, 3: Ctrl + A, 4: ⌘ + A */
-				__( 'If the root directory of your site was <a href="%1$s">writable</a>, we could do this automatically, but it is not so this is the url rewrite rule you should have in your %2$s file. Create a new file, called %2$s in the root directory of your site. Click in the field and press %3$s (or %4$s on Mac) to select all. Then insert this code into the %2$s file.' ),
+				__( 'Error: The root directory of your site is not <a href="%1$s">writable</a>, so creating a file automatically was not possible. This is the URL rewrite rule you should have in your %2$s file. Create a new file called %2$s in the root directory of your site. Click in the field and press %3$s (or %4$s on Mac) to select all. Then insert this code into the %2$s file.' ),
 				__( 'https://wordpress.org/support/article/changing-file-permissions/' ),
 				'<code>web.config</code>',
 				'<kbd>Ctrl + A</kbd>',
@@ -411,7 +411,7 @@ printf( __( 'If you like, you may enter custom structures for your category and 
 			<?php
 			printf(
 				/* translators: %s: web.config */
-				__( 'If you temporarily make your site&#8217;s root directory writable for us to generate the %s file automatically, do not forget to revert the permissions after the file has been created.' ),
+				__( 'If you temporarily make your site&#8217;s root directory writable to generate the %s file automatically, do not forget to revert the permissions after the file has been created.' ),
 				'<code>web.config</code>'
 			);
 			?>
@@ -426,7 +426,7 @@ else :
 		<?php
 		printf(
 			/* translators: 1: .htaccess, 2: Documentation URL, 3: Ctrl + A, 4: ⌘ + A */
-			__( 'If your %1$s file was <a href="%2$s">writable</a>, we could do this automatically, but it is not so these are the mod_rewrite rules you should have in your %1$s file. Click in the field and press %3$s (or %4$s on Mac) to select all.' ),
+			__( 'Error: Your %1$s file is not <a href="%2$s">writable</a>, so updating it automatically was not possible. These are the mod_rewrite rules you should have in your %1$s file. Click in the field and press %3$s (or %4$s on Mac) to select all.' ),
 			'<code>.htaccess</code>',
 			__( 'https://wordpress.org/support/article/changing-file-permissions/' ),
 			'<kbd>Ctrl + A</kbd>',


### PR DESCRIPTION
- Add "Error:" prefix to the first message in each situation.
- Split the first sentence into two, rephrasing it without "we" language.
- Capitalize "URL" in two of the messages.
- Remove "for us" from the two messages about making the file or directory temporarily writable, and add "the" before "rule" in the `web.config` message.

Trac ticket: https://core.trac.wordpress.org/ticket/53141

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**