### PR TITLE
Block supports: migrate spacing, border, color, dimensions, elements and typography and associated tests.

### DIFF
--- a/src/wp-includes/block-supports/border.php
+++ b/src/wp-includes/block-supports/border.php
@@ -50,7 +50,7 @@ function wp_register_border_support( $block_type ) {
  * @return array Border CSS classes and inline styles.
  */
 function wp_apply_border_support( $block_type, $block_attributes ) {
-	if ( wp_skip_border_serialization( $block_type ) ) {
+	if ( wp_should_skip_block_supports_serialization( $block_type, 'border' ) ) {
 		return array();
 	}
 
@@ -60,7 +60,8 @@ function wp_apply_border_support( $block_type, $block_attributes ) {
 	// Border radius.
 	if (
 		wp_has_border_feature_support( $block_type, 'radius' ) &&
-		isset( $block_attributes['style']['border']['radius'] )
+		isset( $block_attributes['style']['border']['radius'] ) &&
+		! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'radius' )
 	) {
 		$border_radius = $block_attributes['style']['border']['radius'];
 
@@ -84,7 +85,8 @@ function wp_apply_border_support( $block_type, $block_attributes ) {
 	// Border style.
 	if (
 		wp_has_border_feature_support( $block_type, 'style' ) &&
-		isset( $block_attributes['style']['border']['style'] )
+		isset( $block_attributes['style']['border']['style'] ) &&
+		! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'style' )
 	) {
 		$border_style = $block_attributes['style']['border']['style'];
 		$styles[]     = sprintf( 'border-style: %s;', $border_style );
@@ -93,7 +95,8 @@ function wp_apply_border_support( $block_type, $block_attributes ) {
 	// Border width.
 	if (
 		wp_has_border_feature_support( $block_type, 'width' ) &&
-		isset( $block_attributes['style']['border']['width'] )
+		isset( $block_attributes['style']['border']['width'] ) &&
+		! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'width' )
 	) {
 		$border_width = $block_attributes['style']['border']['width'];
 
@@ -106,7 +109,10 @@ function wp_apply_border_support( $block_type, $block_attributes ) {
 	}
 
 	// Border color.
-	if ( wp_has_border_feature_support( $block_type, 'color' ) ) {
+	if (
+		wp_has_border_feature_support( $block_type, 'color' ) &&
+		! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'color' )
+	) {
 		$has_named_border_color  = array_key_exists( 'borderColor', $block_attributes );
 		$has_custom_border_color = isset( $block_attributes['style']['border']['color'] );
 
@@ -134,25 +140,6 @@ function wp_apply_border_support( $block_type, $block_attributes ) {
 	}
 
 	return $attributes;
-}
-
-/**
- * Checks whether serialization of the current block's border properties should
- * occur.
- *
- * @since 5.8.0
- * @access private
- *
- * @param WP_Block_Type $block_type Block type.
- * @return bool Whether serialization of the current block's border properties
- *              should occur.
- */
-function wp_skip_border_serialization( $block_type ) {
-	$border_support = _wp_array_get( $block_type->supports, array( '__experimentalBorder' ), false );
-
-	return is_array( $border_support ) &&
-		array_key_exists( '__experimentalSkipSerialization', $border_support ) &&
-		$border_support['__experimentalSkipSerialization'];
 }
 
 /**

--- a/src/wp-includes/block-supports/colors.php
+++ b/src/wp-includes/block-supports/colors.php
@@ -75,8 +75,7 @@ function wp_apply_colors_support( $block_type, $block_attributes ) {
 
 	if (
 		is_array( $color_support ) &&
-		array_key_exists( '__experimentalSkipSerialization', $color_support ) &&
-		$color_support['__experimentalSkipSerialization']
+		wp_should_skip_block_supports_serialization( $block_type, 'color' )
 	) {
 		return array();
 	}
@@ -89,7 +88,7 @@ function wp_apply_colors_support( $block_type, $block_attributes ) {
 
 	// Text colors.
 	// Check support for text colors.
-	if ( $has_text_colors_support ) {
+	if ( $has_text_colors_support && ! wp_should_skip_block_supports_serialization( $block_type, 'color', 'text' ) ) {
 		$has_named_text_color  = array_key_exists( 'textColor', $block_attributes );
 		$has_custom_text_color = isset( $block_attributes['style']['color']['text'] );
 
@@ -106,7 +105,7 @@ function wp_apply_colors_support( $block_type, $block_attributes ) {
 	}
 
 	// Background colors.
-	if ( $has_background_colors_support ) {
+	if ( $has_background_colors_support && ! wp_should_skip_block_supports_serialization( $block_type, 'color', 'background' ) ) {
 		$has_named_background_color  = array_key_exists( 'backgroundColor', $block_attributes );
 		$has_custom_background_color = isset( $block_attributes['style']['color']['background'] );
 
@@ -123,7 +122,7 @@ function wp_apply_colors_support( $block_type, $block_attributes ) {
 	}
 
 	// Gradients.
-	if ( $has_gradients_support ) {
+	if ( $has_gradients_support && ! wp_should_skip_block_supports_serialization( $block_type, 'color', 'gradients' ) ) {
 		$has_named_gradient  = array_key_exists( 'gradient', $block_attributes );
 		$has_custom_gradient = isset( $block_attributes['style']['color']['gradient'] );
 

--- a/src/wp-includes/block-supports/dimensions.php
+++ b/src/wp-includes/block-supports/dimensions.php
@@ -4,7 +4,7 @@
  *
  * This does not include the `spacing` block support even though that visually
  * appears under the "Dimensions" panel in the editor. It remains in its
- * original `spacing.php` file for backwards compatibility.
+ * original `spacing.php` file for compatibility with core.
  *
  * @package WordPress
  * @since 5.9.0
@@ -51,7 +51,7 @@ function wp_register_dimensions_support( $block_type ) {
  * @return array Block dimensions CSS classes and inline styles.
  */
 function wp_apply_dimensions_support( $block_type, $block_attributes ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-	if ( wp_skip_dimensions_serialization( $block_type ) ) {
+	if ( wp_should_skip_block_supports_serialization( $block_type, '__experimentalDimensions' ) ) {
 		return array();
 	}
 
@@ -61,23 +61,6 @@ function wp_apply_dimensions_support( $block_type, $block_attributes ) { // phpc
 	// Width support to be added in near future.
 
 	return empty( $styles ) ? array() : array( 'style' => implode( ' ', $styles ) );
-}
-
-/**
- * Checks whether serialization of the current block's dimensions properties
- * should occur.
- *
- * @since 5.9.0
- * @access private
- *
- * @param WP_Block_type $block_type Block type.
- * @return bool Whether to serialize spacing support styles & classes.
- */
-function wp_skip_dimensions_serialization( $block_type ) {
-	$dimensions_support = _wp_array_get( $block_type->supports, array( '__experimentalDimensions' ), false );
-	return is_array( $dimensions_support ) &&
-		array_key_exists( '__experimentalSkipSerialization', $dimensions_support ) &&
-		$dimensions_support['__experimentalSkipSerialization'];
 }
 
 // Register the block support.

--- a/src/wp-includes/block-supports/elements.php
+++ b/src/wp-includes/block-supports/elements.php
@@ -21,6 +21,13 @@ function wp_render_elements_support( $block_content, $block ) {
 		return $block_content;
 	}
 
+	$block_type                    = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
+	$skip_link_color_serialization = wp_should_skip_block_supports_serialization( $block_type, 'color', 'link' );
+
+	if ( $skip_link_color_serialization ) {
+		return $block_content;
+	}
+
 	$link_color = null;
 	if ( ! empty( $block['attrs'] ) ) {
 		$link_color = _wp_array_get( $block['attrs'], array( 'style', 'elements', 'link', 'color', 'text' ), null );

--- a/src/wp-includes/block-supports/spacing.php
+++ b/src/wp-includes/block-supports/spacing.php
@@ -44,15 +44,17 @@ function wp_register_spacing_support( $block_type ) {
  * @return array Block spacing CSS classes and inline styles.
  */
 function wp_apply_spacing_support( $block_type, $block_attributes ) {
-	if ( wp_skip_spacing_serialization( $block_type ) ) {
+	if ( wp_should_skip_block_supports_serialization( $block_type, 'spacing' ) ) {
 		return array();
 	}
 
 	$has_padding_support = block_has_support( $block_type, array( 'spacing', 'padding' ), false );
 	$has_margin_support  = block_has_support( $block_type, array( 'spacing', 'margin' ), false );
+	$skip_padding        = wp_should_skip_block_supports_serialization( $block_type, 'spacing', 'padding' );
+	$skip_margin         = wp_should_skip_block_supports_serialization( $block_type, 'spacing', 'margin' );
 	$styles              = array();
 
-	if ( $has_padding_support ) {
+	if ( $has_padding_support && ! $skip_padding ) {
 		$padding_value = _wp_array_get( $block_attributes, array( 'style', 'spacing', 'padding' ), null );
 		if ( is_array( $padding_value ) ) {
 			foreach ( $padding_value as $key => $value ) {
@@ -63,7 +65,7 @@ function wp_apply_spacing_support( $block_type, $block_attributes ) {
 		}
 	}
 
-	if ( $has_margin_support ) {
+	if ( $has_margin_support && ! $skip_margin ) {
 		$margin_value = _wp_array_get( $block_attributes, array( 'style', 'spacing', 'margin' ), null );
 		if ( is_array( $margin_value ) ) {
 			foreach ( $margin_value as $key => $value ) {
@@ -75,24 +77,6 @@ function wp_apply_spacing_support( $block_type, $block_attributes ) {
 	}
 
 	return empty( $styles ) ? array() : array( 'style' => implode( ' ', $styles ) );
-}
-
-/**
- * Checks whether serialization of the current block's spacing properties should
- * occur.
- *
- * @since 5.9.0
- * @access private
- *
- * @param WP_Block_Type $block_type Block type.
- * @return bool Whether to serialize spacing support styles & classes.
- */
-function wp_skip_spacing_serialization( $block_type ) {
-	$spacing_support = _wp_array_get( $block_type->supports, array( 'spacing' ), false );
-
-	return is_array( $spacing_support ) &&
-		array_key_exists( '__experimentalSkipSerialization', $spacing_support ) &&
-		$spacing_support['__experimentalSkipSerialization'];
 }
 
 // Register the block support.

--- a/src/wp-includes/block-supports/typography.php
+++ b/src/wp-includes/block-supports/typography.php
@@ -81,8 +81,7 @@ function wp_apply_typography_support( $block_type, $block_attributes ) {
 		return array();
 	}
 
-	$skip_typography_serialization = _wp_array_get( $typography_supports, array( '__experimentalSkipSerialization' ), false );
-	if ( $skip_typography_serialization ) {
+	if ( wp_should_skip_block_supports_serialization( $block_type, 'typography' ) ) {
 		return array();
 	}
 
@@ -99,7 +98,7 @@ function wp_apply_typography_support( $block_type, $block_attributes ) {
 	$has_text_decoration_support = _wp_array_get( $typography_supports, array( '__experimentalTextDecoration' ), false );
 	$has_text_transform_support  = _wp_array_get( $typography_supports, array( '__experimentalTextTransform' ), false );
 
-	if ( $has_font_size_support ) {
+	if ( $has_font_size_support && ! wp_should_skip_block_supports_serialization( $block_type, 'typography', 'fontSize' ) ) {
 		$has_named_font_size  = array_key_exists( 'fontSize', $block_attributes );
 		$has_custom_font_size = isset( $block_attributes['style']['typography']['fontSize'] );
 
@@ -110,7 +109,7 @@ function wp_apply_typography_support( $block_type, $block_attributes ) {
 		}
 	}
 
-	if ( $has_font_family_support ) {
+	if ( $has_font_family_support && ! wp_should_skip_block_supports_serialization( $block_type, 'typography', 'fontFamily' ) ) {
 		$has_named_font_family  = array_key_exists( 'fontFamily', $block_attributes );
 		$has_custom_font_family = isset( $block_attributes['style']['typography']['fontFamily'] );
 
@@ -129,42 +128,42 @@ function wp_apply_typography_support( $block_type, $block_attributes ) {
 		}
 	}
 
-	if ( $has_font_style_support ) {
+	if ( $has_font_style_support && ! wp_should_skip_block_supports_serialization( $block_type, 'typography', 'fontStyle' ) ) {
 		$font_style = wp_typography_get_css_variable_inline_style( $block_attributes, 'fontStyle', 'font-style' );
 		if ( $font_style ) {
 			$styles[] = $font_style;
 		}
 	}
 
-	if ( $has_font_weight_support ) {
+	if ( $has_font_weight_support && ! wp_should_skip_block_supports_serialization( $block_type, 'typography', 'fontWeight' ) ) {
 		$font_weight = wp_typography_get_css_variable_inline_style( $block_attributes, 'fontWeight', 'font-weight' );
 		if ( $font_weight ) {
 			$styles[] = $font_weight;
 		}
 	}
 
-	if ( $has_line_height_support ) {
+	if ( $has_line_height_support && ! wp_should_skip_block_supports_serialization( $block_type, 'typography', 'lineHeight' ) ) {
 		$has_line_height = isset( $block_attributes['style']['typography']['lineHeight'] );
 		if ( $has_line_height ) {
 			$styles[] = sprintf( 'line-height: %s;', $block_attributes['style']['typography']['lineHeight'] );
 		}
 	}
 
-	if ( $has_text_decoration_support ) {
+	if ( $has_text_decoration_support && ! wp_should_skip_block_supports_serialization( $block_type, 'typography', 'textDecoration' ) ) {
 		$text_decoration_style = wp_typography_get_css_variable_inline_style( $block_attributes, 'textDecoration', 'text-decoration' );
 		if ( $text_decoration_style ) {
 			$styles[] = $text_decoration_style;
 		}
 	}
 
-	if ( $has_text_transform_support ) {
+	if ( $has_text_transform_support && ! wp_should_skip_block_supports_serialization( $block_type, 'typography', 'textTransform' ) ) {
 		$text_transform_style = wp_typography_get_css_variable_inline_style( $block_attributes, 'textTransform', 'text-transform' );
 		if ( $text_transform_style ) {
 			$styles[] = $text_transform_style;
 		}
 	}
 
-	if ( $has_letter_spacing_support ) {
+	if ( $has_letter_spacing_support && ! wp_should_skip_block_supports_serialization( $block_type, 'typography', 'letterSpacing' ) ) {
 		$letter_spacing_style = wp_typography_get_css_variable_inline_style( $block_attributes, 'letterSpacing', 'letter-spacing' );
 		if ( $letter_spacing_style ) {
 			$styles[] = $letter_spacing_style;

--- a/src/wp-includes/block-supports/utils.php
+++ b/src/wp-includes/block-supports/utils.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Block support utility functions.
+ *
+ * @package WordPress
+ * @since 6.0
+ */
+
+/**
+ * Checks whether serialization of the current block's supported properties
+ * should occur.
+ *
+ * @since 6.0
+ * @access private
+ *
+ * @param WP_Block_Type $block_type  Block type.
+ * @param string        $feature_set Name of block support feature set..
+ * @param string        $feature     Optional name of individual feature to check.
+ *
+ * @return boolean Whether to serialize block support styles & classes.
+ */
+function wp_should_skip_block_supports_serialization( $block_type, $feature_set, $feature = null ) {
+	if ( ! is_object( $block_type ) || ! $feature_set ) {
+		return false;
+	}
+
+	$path               = array( $feature_set, '__experimentalSkipSerialization' );
+	$skip_serialization = _wp_array_get( $block_type->supports, $path, false );
+
+	if ( is_array( $skip_serialization ) ) {
+		return in_array( $feature, $skip_serialization, true );
+	}
+
+	return $skip_serialization;
+}

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -317,6 +317,7 @@ require ABSPATH . WPINC . '/blocks/index.php';
 require ABSPATH . WPINC . '/block-editor.php';
 require ABSPATH . WPINC . '/block-patterns.php';
 require ABSPATH . WPINC . '/class-wp-block-supports.php';
+require ABSPATH . WPINC . '/block-supports/utils.php';
 require ABSPATH . WPINC . '/block-supports/align.php';
 require ABSPATH . WPINC . '/block-supports/border.php';
 require ABSPATH . WPINC . '/block-supports/colors.php';

--- a/tests/phpunit/tests/block-supports/border.php
+++ b/tests/phpunit/tests/block-supports/border.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * @group block-supports
+ */
+class Test_Block_Supports_Border extends WP_UnitTestCase {
+
+	function test_border_color_slug_with_numbers_is_kebab_cased_properly() {
+		$block_name = 'test/border-color-slug-with-numbers-is-kebab-cased-properly';
+		register_block_type(
+			$block_name,
+			array(
+				'api_version' => 2,
+				'attributes'  => array(
+					'borderColor' => array(
+						'type' => 'string',
+					),
+					'style'       => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array(
+					'__experimentalBorder' => array(
+						'color'  => true,
+						'radius' => true,
+						'width'  => true,
+						'style'  => true,
+					),
+				),
+			)
+		);
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$block_type = $registry->get_registered( $block_name );
+		$block_atts = array(
+			'borderColor' => 'red',
+			'style'       => array(
+				'border' => array(
+					'radius' => '10px',
+					'width'  => '1px',
+					'style'  => 'dashed',
+				),
+			),
+		);
+
+		$actual   = wp_apply_border_support( $block_type, $block_atts );
+		$expected = array(
+			'class' => 'has-border-color has-red-border-color',
+			'style' => 'border-radius: 10px; border-style: dashed; border-width: 1px;',
+		);
+
+		$this->assertSame( $expected, $actual );
+		unregister_block_type( $block_name );
+	}
+
+	function test_border_with_skipped_serialization_block_supports() {
+		$block_name = 'test/border-with-skipped-serialization-block-supports';
+		register_block_type(
+			$block_name,
+			array(
+				'api_version' => 2,
+				'attributes'  => array(
+					'style' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array(
+					'__experimentalBorder' => array(
+						'color'                           => true,
+						'radius'                          => true,
+						'width'                           => true,
+						'style'                           => true,
+						'__experimentalSkipSerialization' => true,
+					),
+				),
+			)
+		);
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$block_type = $registry->get_registered( $block_name );
+		$block_atts = array(
+			'style' => array(
+				'border' => array(
+					'color'  => '#eeeeee',
+					'width'  => '1px',
+					'style'  => 'dotted',
+					'radius' => '10px',
+				),
+			),
+		);
+
+		$actual   = wp_apply_border_support( $block_type, $block_atts );
+		$expected = array();
+
+		$this->assertSame( $expected, $actual );
+		unregister_block_type( $block_name );
+	}
+
+	function test_radius_with_individual_skipped_serialization_block_supports() {
+		$block_name = 'test/radius-with-individual-skipped-serialization-block-supports';
+		register_block_type(
+			$block_name,
+			array(
+				'api_version' => 2,
+				'attributes'  => array(
+					'style' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array(
+					'__experimentalBorder' => array(
+						'color'                           => true,
+						'radius'                          => true,
+						'width'                           => true,
+						'style'                           => true,
+						'__experimentalSkipSerialization' => array( 'radius', 'color' ),
+					),
+				),
+			)
+		);
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$block_type = $registry->get_registered( $block_name );
+		$block_atts = array(
+			'style' => array(
+				'border' => array(
+					'color'  => '#eeeeee',
+					'width'  => '1px',
+					'style'  => 'dotted',
+					'radius' => '10px',
+				),
+			),
+		);
+
+		$actual   = wp_apply_border_support( $block_type, $block_atts );
+		$expected = array(
+			'style' => 'border-style: dotted; border-width: 1px;',
+		);
+
+		$this->assertSame( $expected, $actual );
+		unregister_block_type( $block_name );
+	}
+}

--- a/tests/phpunit/tests/block-supports/colors.php
+++ b/tests/phpunit/tests/block-supports/colors.php
@@ -44,4 +44,84 @@ class Tests_Block_Supports_Colors extends WP_UnitTestCase {
 		$this->assertSame( $expected, $actual );
 		unregister_block_type( 'test/color-slug-with-numbers' );
 	}
+
+	function test_color_with_skipped_serialization_block_supports() {
+		$block_name = 'test/color-with-skipped-serialization-block-supports';
+		register_block_type(
+			$block_name,
+			array(
+				'api_version' => 2,
+				'attributes'  => array(
+					'style' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array(
+					'color' => array(
+						'text'                            => true,
+						'gradients'                       => true,
+						'__experimentalSkipSerialization' => true,
+					),
+				),
+			)
+		);
+
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$block_type = $registry->get_registered( $block_name );
+		$block_atts = array(
+			'style' => array(
+				'color' => array(
+					'text'     => '#d92828',
+					'gradient' => 'linear-gradient(135deg,rgb(6,147,227) 0%,rgb(223,13,13) 46%,rgb(155,81,224) 100%)',
+				),
+			),
+		);
+
+		$actual   = wp_apply_colors_support( $block_type, $block_atts );
+		$expected = array();
+
+		$this->assertSame( $expected, $actual );
+		unregister_block_type( $block_name );
+	}
+
+	function test_gradient_with_individual_skipped_serialization_block_supports() {
+		$block_name = 'test/gradient-with-individual-skipped-serialization-block-support';
+		register_block_type(
+			$block_name,
+			array(
+				'api_version' => 2,
+				'attributes'  => array(
+					'style' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array(
+					'color' => array(
+						'text'                            => true,
+						'gradients'                       => true,
+						'__experimentalSkipSerialization' => array( 'gradients' ),
+					),
+				),
+			)
+		);
+
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$block_type = $registry->get_registered( $block_name );
+		$block_atts = array(
+			'style' => array(
+				'color' => array(
+					'text' => '#d92828',
+				),
+			),
+		);
+
+		$actual   = wp_apply_colors_support( $block_type, $block_atts );
+		$expected = array(
+			'class' => 'has-text-color',
+			'style' => 'color: #d92828;',
+		);
+
+		$this->assertSame( $expected, $actual );
+		unregister_block_type( $block_name );
+	}
 }

--- a/tests/phpunit/tests/block-supports/spacing.php
+++ b/tests/phpunit/tests/block-supports/spacing.php
@@ -2,7 +2,7 @@
 /**
  * @group block-supports
  */
-class WP_Block_Supports_Spacing_Test extends WP_UnitTestCase {
+class Test_Block_Supports_Spacing extends WP_UnitTestCase {
 
 	function test_spacing_style_is_applied() {
 		$block_name = 'test/spacing-style-is-applied';

--- a/tests/phpunit/tests/block-supports/spacing.php
+++ b/tests/phpunit/tests/block-supports/spacing.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * @group block-supports
+ */
+class WP_Block_Supports_Spacing_Test extends WP_UnitTestCase {
+
+	function test_spacing_style_is_applied() {
+		$block_name = 'test/spacing-style-is-applied';
+		register_block_type(
+			$block_name,
+			array(
+				'api_version' => 2,
+				'attributes'  => array(
+					'style' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array(
+					'spacing' => array(
+						'margin'   => true,
+						'padding'  => true,
+						'blockGap' => true,
+					),
+				),
+			)
+		);
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$block_type = $registry->get_registered( $block_name );
+		$block_atts = array(
+			'style' => array(
+				'spacing' => array(
+					'margin'   => array(
+						'top'    => '1px',
+						'right'  => '2px',
+						'bottom' => '3px',
+						'left'   => '4px',
+					),
+					'padding'  => '111px',
+					'blockGap' => '2em',
+				),
+			),
+		);
+
+		$actual   = wp_apply_spacing_support( $block_type, $block_atts );
+		$expected = array(
+			'style' => 'padding: 111px; margin-top: 1px; margin-right: 2px; margin-bottom: 3px; margin-left: 4px;',
+		);
+
+		$this->assertSame( $expected, $actual );
+		unregister_block_type( $block_name );
+	}
+
+	function test_spacing_with_skipped_serialization_block_supports() {
+		$block_name = 'test/spacing-with-skipped-serialization-block-supports';
+		register_block_type(
+			$block_name,
+			array(
+				'api_version' => 2,
+				'attributes'  => array(
+					'style' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array(
+					'spacing' => array(
+						'margin'                          => true,
+						'padding'                         => true,
+						'blockGap'                        => true,
+						'__experimentalSkipSerialization' => true,
+					),
+				),
+			)
+		);
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$block_type = $registry->get_registered( $block_name );
+		$block_atts = array(
+			'style' => array(
+				'spacing' => array(
+					'margin'   => array(
+						'top'    => '1px',
+						'right'  => '2px',
+						'bottom' => '3px',
+						'left'   => '4px',
+					),
+					'padding'  => '111px',
+					'blockGap' => '2em',
+				),
+			),
+		);
+
+		$actual   = wp_apply_spacing_support( $block_type, $block_atts );
+		$expected = array();
+
+		$this->assertSame( $expected, $actual );
+		unregister_block_type( $block_name );
+	}
+
+	function test_margin_with_individual_skipped_serialization_block_supports() {
+		$block_name = 'test/margin-with-individual-skipped-serialization-block-supports';
+		register_block_type(
+			$block_name,
+			array(
+				'api_version' => 2,
+				'attributes'  => array(
+					'style' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array(
+					'spacing' => array(
+						'margin'                          => true,
+						'padding'                         => true,
+						'blockGap'                        => true,
+						'__experimentalSkipSerialization' => array( 'margin' ),
+					),
+				),
+			)
+		);
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$block_type = $registry->get_registered( $block_name );
+		$block_atts = array(
+			'style' => array(
+				'spacing' => array(
+					'padding'  => array(
+						'top'    => '1px',
+						'right'  => '2px',
+						'bottom' => '3px',
+						'left'   => '4px',
+					),
+					'margin'   => '111px',
+					'blockGap' => '2em',
+				),
+			),
+		);
+
+		$actual   = wp_apply_spacing_support( $block_type, $block_atts );
+		$expected = array(
+			'style' => 'padding-top: 1px; padding-right: 2px; padding-bottom: 3px; padding-left: 4px;',
+		);
+
+		$this->assertSame( $expected, $actual );
+		unregister_block_type( $block_name );
+	}
+}

--- a/tests/phpunit/tests/block-supports/typography.php
+++ b/tests/phpunit/tests/block-supports/typography.php
@@ -62,6 +62,80 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 		unregister_block_type( $block_name );
 	}
 
+	function test_typography_with_skipped_serialization_block_supports() {
+		$block_name = 'test/typography-with-skipped-serialization-block-supports';
+		register_block_type(
+			$block_name,
+			array(
+				'api_version' => 2,
+				'attributes'  => array(
+					'style' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array(
+					'typography' => array(
+						'fontSize'                        => true,
+						'lineHeight'                      => true,
+						'__experimentalFontFamily'        => true,
+						'__experimentalLetterSpacing'     => true,
+						'__experimentalSkipSerialization' => true,
+					),
+				),
+			)
+		);
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$block_type = $registry->get_registered( $block_name );
+		$block_atts = array(
+			'style' => array(
+				'typography' => array(
+					'fontSize'      => 'serif',
+					'lineHeight'    => 'serif',
+					'fontFamily'    => '22px',
+					'letterSpacing' => '22px',
+				),
+			),
+		);
+
+		$actual   = wp_apply_typography_support( $block_type, $block_atts );
+		$expected = array();
+
+		$this->assertSame( $expected, $actual );
+		unregister_block_type( $block_name );
+	}
+
+	function test_letter_spacing_with_individual_skipped_serialization_block_supports() {
+		$block_name = 'test/letter-spacing-with-individua-skipped-serialization-block-supports';
+		register_block_type(
+			$block_name,
+			array(
+				'api_version' => 2,
+				'attributes'  => array(
+					'style' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array(
+					'typography' => array(
+						'__experimentalLetterSpacing'     => true,
+						'__experimentalSkipSerialization' => array(
+							'letterSpacing',
+						),
+					),
+				),
+			)
+		);
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$block_type = $registry->get_registered( $block_name );
+		$block_atts = array( 'style' => array( 'typography' => array( 'letterSpacing' => '22px' ) ) );
+
+		$actual   = wp_apply_typography_support( $block_type, $block_atts );
+		$expected = array();
+
+		$this->assertSame( $expected, $actual );
+		unregister_block_type( $block_name );
+	}
+
 	function test_font_family_with_legacy_inline_styles_using_a_css_var() {
 		$block_name = 'test/font-family-with-inline-styles-using-css-var';
 		register_block_type(


### PR DESCRIPTION

Gutenberg plugin migration to WordPress 6.0 also being tracked in https://github.com/WordPress/gutenberg/issues/39889.

This diff migrates block support spacing, border, color, dimensions, elements and typography and associated tests from Gutenberg 12.9.0 to WordPress 6.0

The goal is to include the latest plugin, while skipping the Style Engine integration, which only features in `spacing.php`. The Style Engine class doesn't bring any new functionality - it's more of a first iteration in a set of long-term changes.

In summary:

- Include individual serialization changes from https://github.com/WordPress/gutenberg/commit/6de16981c7fef3db7cc4a9d6cfcb0ad85c916c62
- Skip Style Engine integration from https://github.com/WordPress/gutenberg/commit/44925a947fde29feaab512e0adf4291272209d59`


Trac ticket: https://core.trac.wordpress.org/ticket/55505

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
