### PR TITLE
Backport: Fix post lock data inconsistencies

### DIFF
--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -151,9 +151,9 @@ if ( $user_id ) {
 	if ( $locked ) {
 		$user         = get_userdata( $user_id );
 		$user_details = array(
-			'name' => $user->display_name,
+			'avatar' => get_avatar_url( $user_id, array( 'size' => 128 ) ),
+			'name'   => $user->display_name,
 		);
-		$avatar       = get_avatar_url( $user_id, array( 'size' => 64 ) );
 	}
 
 	$lock_details = array(

--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -1137,6 +1137,7 @@ function wp_check_locked_posts( $response, $data, $screen_id ) {
 
 				if ( $user && current_user_can( 'edit_post', $post_id ) ) {
 					$send = array(
+						'name' => $user->display_name,
 						/* translators: %s: User's display name. */
 						'text' => sprintf( __( '%s is currently editing' ), $user->display_name ),
 					);


### PR DESCRIPTION
PR is backporting fixes introduced in https://github.com/WordPress/gutenberg/pull/37914.

Changes include:
* Add missing user avatar to block editor lock data.
* Provide user's display name via Heartbeat API check.

## Testing instructions
Create two admin user accounts. Save a post as one user, then log in as the other user in an incognito mode and load the same post.

- Modal should display user avatar.
- Switch back to the initial browser window and for a heartbeat to update post lock, which might take little time.
- Confirm that message includes the user display name. **Note:** This will only work after package updates.

Trac ticket: https://core.trac.wordpress.org/ticket/55238

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
