### PR TITLE
Fix `npm install` on Apple Silicon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5876,10 +5876,13 @@
 			"dev": true
 		},
 		"agent-base": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
-			"integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
-			"dev": true
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"dev": true,
+			"requires": {
+				"debug": "4"
+			}
 		},
 		"airbnb-prop-types": {
 			"version": "2.16.0",
@@ -13617,14 +13620,14 @@
 			}
 		},
 		"grunt-contrib-qunit": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/grunt-contrib-qunit/-/grunt-contrib-qunit-5.1.1.tgz",
-			"integrity": "sha512-W1V+55kWF8TARdCDWEwzrbAoielwqrKKppiTwnu3N2kMa73oQIlKNQOnOq32tzruXdTDZX4B5yYustfNp3bdRA==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/grunt-contrib-qunit/-/grunt-contrib-qunit-6.0.0.tgz",
+			"integrity": "sha512-FoEkMkrAUhvdwx7inxF1vQ8MoMIqUY8k9QrvQonMcHpJdHr+cfJ5CGTpf+26GPx9ub+SbkgcICOEUaY8LQgb7w==",
 			"dev": true,
 			"requires": {
 				"eventemitter2": "^6.4.2",
 				"p-each-series": "^2.1.0",
-				"puppeteer": "^5.0.0"
+				"puppeteer": "^9.0.0"
 			},
 			"dependencies": {
 				"eventemitter2": {
@@ -14440,12 +14443,12 @@
 			"dev": true
 		},
 		"https-proxy-agent": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
-			"integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+			"integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
 			"dev": true,
 			"requires": {
-				"agent-base": "5",
+				"agent-base": "6",
 				"debug": "4"
 			}
 		},
@@ -21407,19 +21410,19 @@
 			"dev": true
 		},
 		"puppeteer": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-5.5.0.tgz",
-			"integrity": "sha512-OM8ZvTXAhfgFA7wBIIGlPQzvyEETzDjeRa4mZRCRHxYL+GNH5WAuYUQdja3rpWZvkX/JKqmuVgbsxDNsDFjMEg==",
+			"version": "9.1.1",
+			"resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-9.1.1.tgz",
+			"integrity": "sha512-W+nOulP2tYd/ZG99WuZC/I5ljjQQ7EUw/jQGcIb9eu8mDlZxNY2SgcJXTLG9h5gRvqA3uJOe4hZXYsd3EqioMw==",
 			"dev": true,
 			"requires": {
 				"debug": "^4.1.0",
-				"devtools-protocol": "0.0.818844",
+				"devtools-protocol": "0.0.869402",
 				"extract-zip": "^2.0.0",
-				"https-proxy-agent": "^4.0.0",
+				"https-proxy-agent": "^5.0.0",
 				"node-fetch": "^2.6.1",
 				"pkg-dir": "^4.2.0",
 				"progress": "^2.0.1",
-				"proxy-from-env": "^1.0.0",
+				"proxy-from-env": "^1.1.0",
 				"rimraf": "^3.0.2",
 				"tar-fs": "^2.0.0",
 				"unbzip2-stream": "^1.3.3",
@@ -21427,9 +21430,9 @@
 			},
 			"dependencies": {
 				"devtools-protocol": {
-					"version": "0.0.818844",
-					"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.818844.tgz",
-					"integrity": "sha512-AD1hi7iVJ8OD0aMLQU5VK0XH9LDlA1+BcPIgrAxPfaibx2DbWucuyOhc4oyQCbnvDDO68nN6/LcKfqTP343Jjg==",
+					"version": "0.0.869402",
+					"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.869402.tgz",
+					"integrity": "sha512-VvlVYY+VDJe639yHs5PHISzdWTLL3Aw8rO4cvUtwvoxFd6FHbE4OpHHcde52M6096uYYazAmd4l0o5VuFRO2WA==",
 					"dev": true
 				},
 				"find-up": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		"grunt-contrib-cssmin": "~4.0.0",
 		"grunt-contrib-imagemin": "~4.0.0",
 		"grunt-contrib-jshint": "3.1.1",
-		"grunt-contrib-qunit": "^5.1.1",
+		"grunt-contrib-qunit": "~6.0.0",
 		"grunt-contrib-uglify": "~5.0.1",
 		"grunt-contrib-watch": "~1.1.0",
 		"grunt-file-append": "0.0.7",


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/52690

There is a brand new version `grunt-contrib-qunit` that resolves the issue with Puppeteer's installation.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
