### PR TITLE
Update the global styles controller to match Gutenberg's version

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-controller.php
@@ -582,9 +582,7 @@ class WP_REST_Global_Styles_Controller extends WP_REST_Controller {
 
 		if ( rest_is_field_included( 'styles', $fields ) ) {
 			$raw_data = $theme->get_raw_data();
-			if ( isset( $raw_data['styles'] ) ) {
-				$data['styles'] = $raw_data['styles'];
-			}
+			$data['styles'] = isset( $raw_data['styles'] ) ? $raw_data['styles'] : array();
 		}
 
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';


### PR DESCRIPTION
I compared the global styles controller between Gutenberg and Core, and there's just this small difference that's left.

Trac ticket: https://core.trac.wordpress.org/ticket/55505