### PR TITLE
Make block type aware of `ancestor` prop

### DIFF
--- a/src/wp-admin/includes/post.php
+++ b/src/wp-admin/includes/post.php
@@ -2232,6 +2232,7 @@ function get_block_editor_server_block_settings() {
 		'styles'           => 'styles',
 		'textdomain'       => 'textdomain',
 		'parent'           => 'parent',
+		'ancestor'         => 'ancestor',
 		'keywords'         => 'keywords',
 		'example'          => 'example',
 		'variations'       => 'variations',

--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -59,9 +59,10 @@ class WP_Block_Type {
 	public $parent = null;
 
 	/**
-	 * Setting ancestor makes a block available inside the specified
-	 * block types at any position of the ancestor block subtree.
+	 * Setting ancestor makes a block available only inside the specified
+	 * block types at any position of the ancestor's block subtree.
 	 *
+	 * @since 6.0.0
 	 * @var array|null
 	 */
 	public $ancestor = null;
@@ -215,6 +216,7 @@ class WP_Block_Type {
 	 * @since 5.6.0 Added the `api_version` property.
 	 * @since 5.8.0 Added the `variations` property.
 	 * @since 5.9.0 Added the `view_script` property.
+	 * @since 6.0.0 Added the `ancestor` property.
 	 *
 	 * @see register_block_type()
 	 *
@@ -229,8 +231,8 @@ class WP_Block_Type {
 	 *                                           search interfaces to arrange block types by category.
 	 *     @type array|null    $parent           Setting parent lets a block require that it is only
 	 *                                           available when nested within the specified blocks.
-	 *     @type array|null    $ancestor         Setting ancestor makes a block available inside the specified
-	 *                                           block types at any position of the ancestor block subtree.
+	 *     @type array|null    $ancestor         Setting ancestor makes a block available only inside the specified
+	 *                                           block types at any position of the ancestor's block subtree.
 	 *     @type string|null   $icon             Block type icon.
 	 *     @type string        $description      A detailed block type description.
 	 *     @type string[]      $keywords         Additional keywords to produce block type as

--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -59,6 +59,14 @@ class WP_Block_Type {
 	public $parent = null;
 
 	/**
+	 * Setting ancestor makes a block available inside the specified
+	 * block types at any position of the ancestor block subtree.
+	 *
+	 * @var array|null
+	 */
+	public $ancestor = null;
+
+	/**
 	 * Block type icon.
 	 *
 	 * @since 5.5.0
@@ -221,6 +229,8 @@ class WP_Block_Type {
 	 *                                           search interfaces to arrange block types by category.
 	 *     @type array|null    $parent           Setting parent lets a block require that it is only
 	 *                                           available when nested within the specified blocks.
+	 *     @type array|null    $ancestor         Setting ancestor makes a block available inside the specified
+	 *                                           block types at any position of the ancestor block subtree.
 	 *     @type string|null   $icon             Block type icon.
 	 *     @type string        $description      A detailed block type description.
 	 *     @type string[]      $keywords         Additional keywords to produce block type as

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
@@ -266,6 +266,7 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 			'category',
 			'keywords',
 			'parent',
+			'ancestor',
 			'provides_context',
 			'uses_context',
 			'supports',
@@ -637,6 +638,16 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 				),
 				'parent'           => array(
 					'description' => __( 'Parent blocks.' ),
+					'type'        => array( 'array', 'null' ),
+					'items'       => array(
+						'type' => 'string',
+					),
+					'default'     => null,
+					'context'     => array( 'embed', 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'ancestor'           => array(
+					'description' => __( 'Ancestor blocks.' ),
 					'type'        => array( 'array', 'null' ),
 					'items'       => array(
 						'type' => 'string',

--- a/tests/phpunit/tests/admin/includesPost.php
+++ b/tests/phpunit/tests/admin/includesPost.php
@@ -828,6 +828,7 @@ class Tests_Admin_IncludesPost extends WP_UnitTestCase {
 			'icon'            => 'text',
 			'category'        => 'common',
 			'render_callback' => 'foo',
+			'ancestor'        => array( 'core/test-ancestor' ),
 		);
 
 		register_block_type( $name, $settings );
@@ -846,6 +847,7 @@ class Tests_Admin_IncludesPost extends WP_UnitTestCase {
 				'usesContext' => array(),
 				'category'    => 'common',
 				'styles'      => array(),
+				'ancestor'    => array( 'core/test-ancestor' ),
 				'keywords'    => array(),
 				'variations'  => array(),
 			),

--- a/tests/phpunit/tests/rest-api/rest-block-type-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-block-type-controller.php
@@ -221,6 +221,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			'keywords'         => 'invalid_keywords',
 			'example'          => 'invalid_example',
 			'parent'           => 'invalid_parent',
+			'ancestor'         => 'invalid_ancestor',
 			'supports'         => 'invalid_supports',
 			'styles'           => 'invalid_styles',
 			'render_callback'  => 'invalid_callback',
@@ -246,6 +247,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$this->assertSameSets( array( 'invalid_uses_context' ), $data['uses_context'] );
 		$this->assertSameSets( array( 'invalid_keywords' ), $data['keywords'] );
 		$this->assertSameSets( array( 'invalid_parent' ), $data['parent'] );
+		$this->assertSameSets( array( 'invalid_ancestor' ), $data['ancestor'] );
 		$this->assertSameSets( array(), $data['supports'] );
 		$this->assertSameSets( array(), $data['styles'] );
 		$this->assertNull( $data['example'] );
@@ -275,6 +277,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			'style'            => false,
 			'keywords'         => false,
 			'parent'           => false,
+			'ancestor'         => false,
 			'supports'         => false,
 			'styles'           => false,
 			'render_callback'  => false,
@@ -301,6 +304,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$this->assertSameSets( array(), $data['uses_context'] );
 		$this->assertSameSets( array(), $data['keywords'] );
 		$this->assertSameSets( array(), $data['parent'] );
+		$this->assertSameSets( array(), $data['ancestor'] );
 		$this->assertSameSets( array(), $data['supports'] );
 		$this->assertSameSets( array(), $data['styles'] );
 		$this->assertNull( $data['example'] );

--- a/tests/phpunit/tests/rest-api/rest-block-type-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-block-type-controller.php
@@ -378,7 +378,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$response   = rest_get_server()->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertCount( 22, $properties );
+		$this->assertCount( 23, $properties );
 		$this->assertArrayHasKey( 'api_version', $properties );
 		$this->assertArrayHasKey( 'title', $properties );
 		$this->assertArrayHasKey( 'icon', $properties );
@@ -401,6 +401,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( 'uses_context', $properties );
 		$this->assertArrayHasKey( 'provides_context', $properties );
 		$this->assertArrayHasKey( 'variations', $properties );
+		$this->assertArrayHasKey( 'ancestor', $properties );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This simple PR adds support for the new `ancestor` property, making the `WP_Block_Type` class aware of it and exposing it from the [`block-types`](https://developer.wordpress.org/rest-api/reference/block-types/) REST API endpoint and the [`get_block_editor_server_block_settings`](https://developer.wordpress.org/reference/functions/get_block_editor_server_block_settings/) function.

The property was recently added to the block.json schema (see https://github.com/WordPress/gutenberg/pull/39894).

Trac ticket: https://core.trac.wordpress.org/ticket/55531#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
