### PR TITLE
Backport "Migrate post editor editorMode to use preferences store and remove localAutosaveInterval preference #39180"

### DIFF
--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -394,6 +394,8 @@ function get_block_editor_settings( array $custom_settings, $block_editor_contex
 		unset( $editor_settings['__experimentalFeatures']['spacing']['padding'] );
 	}
 
+	$editor_settings['localAutosaveInterval'] = 15;
+
 	/**
 	 * Filters the settings to pass to the block editor for all editor type.
 	 *


### PR DESCRIPTION
Gutenberg plugin migration to WordPress 6.0 also being tracked in https://github.com/WordPress/gutenberg/issues/39889.

This diff moves the localAutosaveInterval editor setting to the preference store introduced in Gutenberg 12.9.0 to WordPress 6.0

Original Pull Request: https://github.com/WordPress/gutenberg/pull/39180

In summary:

Trac ticket: https://core.trac.wordpress.org/ticket/55505

cc @talldan @noisysocks @michalczaplinski who worked on the original Gutenberg PR