### PR TITLE
More accurate "fixed" Slack notifications

### DIFF
--- a/.github/workflows/slack-notifications.yml
+++ b/.github/workflows/slack-notifications.yml
@@ -52,9 +52,8 @@ jobs:
   # submit data to Slack webhook URLs configured to post messages.
   #
   # Performs the following steps:
-  # - Retrieves the workflow ID (if necessary).
-  # - Retrieves the workflow URL (if necessary).
-  # - Retrieves the previous workflow run and stores its conclusion.
+  # - Retrieves the current workflow run.
+  # - Determine the conclusion of the previous workflow run or run attempt.
   # - Sets the previous conclusion as an output.
   # - Prepares the commit message.
   # - Constructs and stores a message payload as an output.
@@ -123,7 +122,6 @@ jobs:
             // Can't determine previous workflow conclusion.
             return 'unknown';
 
-
       - name: Store previous conclusion as an output
         id: previous-conclusion
         run: echo "::set-output name=previous_conclusion::${{ steps.previous-attempt-result.outputs.result }}"
@@ -176,7 +174,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: [ prepare ]
-    if: ${{ contains( fromJson( '["failure", "none"]' ), needs.prepare.outputs.previous_conclusion ) && ( github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' || inputs.calling_status == 'success' ) && success() }}
+    if: ${{ contains( fromJson( '["failure", "cancelled", "none"]' ), needs.prepare.outputs.previous_conclusion ) && ( github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' || inputs.calling_status == 'success' ) && success() }}
 
     steps:
       - name: Post failure notifications to Slack

--- a/.github/workflows/slack-notifications.yml
+++ b/.github/workflows/slack-notifications.yml
@@ -80,19 +80,49 @@ jobs:
               run_id: ${{ github.run_id }},
             });
 
-            // The first workflow run attempt does not have a previous attempt.
-            if ( workflow_run.data.run_attempt == 1 ) {
+            // When a workflow has been restarted to fix a failure, check the previous run attempt.
+            if ( workflow_run.data.run_attempt > 1 ) {
+              const previous_run = await github.rest.actions.getWorkflowRunAttempt({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: ${{ github.run_id }},
+                attempt_number: workflow_run.data.run_attempt - 1
+              });
+
+              return previous_run.data.conclusion;
+            }
+
+            let workflow_id = '';
+            if ( ${{ github.event_name == 'workflow_run' }} ) {
+              workflow_id = '${{ github.event.workflow_run.workflow_id }}';
+            } else {
+              workflow_id = workflow_run.data.workflow_id;
+            }
+
+            // Otherwise, check the previous workflow run.
+            const previous_runs = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: workflow_id,
+              branch: '${{ env.CURRENT_BRANCH }}',
+              exclude_pull_requests: true,
+            });
+
+            // This is the first workflow run for this branch or tag.
+            if ( previous_runs.data.workflow_runs.length == 0 ) {
               return 'none';
             }
 
-            const previous_run = await github.rest.actions.getWorkflowRunAttempt({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: ${{ github.run_id }},
-              attempt_number: workflow_run.data.run_attempt - 1
-            });
+            // Find the workflow run for the commit that immediately preceded this one.
+            for ( let i = 0; i < previous_runs.data.workflow_runs.length; i++ ) {
+              if ( previous_runs.data.workflow_runs[ i ].run_number == workflow_run.data.run_number ) {
+                return previous_runs.data.workflow_runs[ i + 1 ].conclusion;
+              }
+            }
 
-            return previous_run.data.conclusion;
+            // Can't determine previous workflow conclusion.
+            return 'unknown';
+
 
       - name: Store previous conclusion as an output
         id: previous-conclusion
@@ -146,7 +176,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: [ prepare ]
-    if: ${{ needs.prepare.outputs.previous_conclusion == 'failure' && ( github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' || inputs.calling_status == 'success' ) && success() }}
+    if: ${{ contains( fromJson( '["failure", "none"]' ), needs.prepare.outputs.previous_conclusion ) && ( github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' || inputs.calling_status == 'success' ) && success() }}
 
     steps:
       - name: Post failure notifications to Slack

--- a/.github/workflows/slack-notifications.yml
+++ b/.github/workflows/slack-notifications.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Get the workflow ID
         id: current-workflow-id
         if: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
-        uses: actions/github-script@441359b1a30438de65712c2fbca0abe4816fa667 # v5.0.0
+        uses: actions/github-script@9ac08808f993958e9de277fe43a64532a609130e # v6.0.0
         with:
           script: |
             const workflow_run = await github.rest.actions.getWorkflowRun({
@@ -108,7 +108,7 @@ jobs:
 
       - name: Get the commit message
         id: current-commit-message
-        uses: actions/github-script@441359b1a30438de65712c2fbca0abe4816fa667 # v5.0.0
+        uses: actions/github-script@9ac08808f993958e9de277fe43a64532a609130e # v6.0.0
         if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
         with:
           script: |
@@ -142,7 +142,7 @@ jobs:
 
     steps:
       - name: Post failure notifications to Slack
-        uses: slackapi/slack-github-action@410ae57cff5c6b682b106440be0e6c7eb8c98c9d # v1.16.0
+        uses: slackapi/slack-github-action@16b6c78ee73689a627b65332b34e5d409c7299da # v1.18.0
         with:
           payload: ${{ needs.prepare.outputs.payload }}
         env:
@@ -158,7 +158,7 @@ jobs:
 
     steps:
       - name: Post failure notifications to Slack
-        uses: slackapi/slack-github-action@410ae57cff5c6b682b106440be0e6c7eb8c98c9d # v1.16.0
+        uses: slackapi/slack-github-action@16b6c78ee73689a627b65332b34e5d409c7299da # v1.18.0
         with:
           payload: ${{ needs.prepare.outputs.payload }}
         env:
@@ -174,7 +174,7 @@ jobs:
 
     steps:
       - name: Post success notifications to Slack
-        uses: slackapi/slack-github-action@410ae57cff5c6b682b106440be0e6c7eb8c98c9d # v1.16.0
+        uses: slackapi/slack-github-action@16b6c78ee73689a627b65332b34e5d409c7299da # v1.18.0
         with:
           payload: ${{ needs.prepare.outputs.payload }}
         env:
@@ -190,7 +190,7 @@ jobs:
 
     steps:
       - name: Post cancelled notifications to Slack
-        uses: slackapi/slack-github-action@410ae57cff5c6b682b106440be0e6c7eb8c98c9d # v1.16.0
+        uses: slackapi/slack-github-action@16b6c78ee73689a627b65332b34e5d409c7299da # v1.18.0
         with:
           payload: ${{ needs.prepare.outputs.payload }}
         env:

--- a/.github/workflows/slack-notifications.yml
+++ b/.github/workflows/slack-notifications.yml
@@ -68,7 +68,7 @@ jobs:
       payload: ${{ steps.create-payload.outputs.payload }}
 
     steps:
-      - name: Get the workflow ID
+      - name: Determine the status of the previous attempt
         id: previous-attempt-result
         if: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
         uses: actions/github-script@9ac08808f993958e9de277fe43a64532a609130e # v6.0.0

--- a/.github/workflows/slack-notifications.yml
+++ b/.github/workflows/slack-notifications.yml
@@ -69,7 +69,7 @@ jobs:
 
     steps:
       - name: Get the workflow ID
-        id: current-workflow-id
+        id: previous-attempt-result
         if: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
         uses: actions/github-script@9ac08808f993958e9de277fe43a64532a609130e # v6.0.0
         with:
@@ -79,32 +79,24 @@ jobs:
               repo: context.repo.repo,
               run_id: ${{ github.run_id }},
             });
-            return workflow_run.data.workflow_id;
 
-      - name: Get details about the previous workflow run
-        id: previous-result
-        uses: actions/github-script@441359b1a30438de65712c2fbca0abe4816fa667 # v5.0.0
-        with:
-          script: |
-            const previous_runs = await github.rest.actions.listWorkflowRuns({
+            // The first workflow run attempt does not have a previous attempt.
+            if ( workflow_run.data.run_attempt == 1 ) {
+              return 'none';
+            }
+
+            const previous_run = await github.rest.actions.getWorkflowRunAttempt({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              workflow_id: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.workflow_id || steps.current-workflow-id.outputs.result }},
-              branch: '${{ env.CURRENT_BRANCH }}',
-              per_page: 1,
-              page: 2,
+              run_id: ${{ github.run_id }},
+              attempt_number: workflow_run.data.run_attempt - 1
             });
 
-            if ( previous_runs.data.total_count > 0 ) {
-              return previous_runs.data.workflow_runs[0].conclusion;
-            } else {
-              // Use failure so all first time runs for a branch or tag are reported to Slack.
-              return 'failure';
-            }
+            return previous_run.data.conclusion;
 
       - name: Store previous conclusion as an output
         id: previous-conclusion
-        run: echo "::set-output name=previous_conclusion::${{ steps.previous-result.outputs.result }}"
+        run: echo "::set-output name=previous_conclusion::${{ steps.previous-attempt-result.outputs.result }}"
 
       - name: Get the commit message
         id: current-commit-message


### PR DESCRIPTION
This attempts to improve how the Slack Notifications workflow checks the previous outcome of a workflow run.

Actions now have "run attempts" for workflow runs, and this information is returned in a `getWorkflowRun()` check. This `run_attempt` number can be used to determine if a previous attempt has been made, and if so, the status can be grabbed.

Currently, the results for re-running failed workflows are not shared in Slack.

This will also improve the accuracy of the these fixed notifications when there are other commits happening in close proximity by checking for the workflow run immediately preceding the current one.

And finally, this will  also fix the issue where an error is encountered when running a workflow for the first time on a new branch or tag.

Trac ticket: https://core.trac.wordpress.org/ticket/54742.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
