### PR TITLE
Site Editor: Resolve homepage template on server-side

### DIFF
--- a/src/wp-admin/site-editor.php
+++ b/src/wp-admin/site-editor.php
@@ -23,6 +23,20 @@ if ( ! wp_is_block_theme() ) {
 	wp_die( __( 'The theme you are currently using is not compatible with Full Site Editing.' ) );
 }
 
+/**
+ * Do a server-side redirection if missing `postType` and `postId`
+ * query args when visiting Site Editor.
+ */
+$home_template = _resolve_home_block_template();
+if ( $home_template && empty( $_GET['postType'] ) && empty( $_GET['postId'] ) ) {
+	$redirect_url = add_query_arg(
+		$home_template,
+		admin_url( 'site-editor.php' )
+	);
+	wp_safe_redirect( $redirect_url );
+	exit;
+}
+
 // Used in the HTML title tag.
 $title       = __( 'Editor (beta)' );
 $parent_file = 'themes.php';
@@ -56,6 +70,7 @@ $custom_settings      = array(
 	'styles'                               => get_block_editor_theme_styles(),
 	'defaultTemplateTypes'                 => $indexed_template_types,
 	'defaultTemplatePartAreas'             => get_allowed_block_template_part_areas(),
+	'__unstableHomeTemplate'               => $home_template,
 	'__experimentalBlockPatterns'          => WP_Block_Patterns_Registry::get_instance()->get_all_registered(),
 	'__experimentalBlockPatternCategories' => WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered(),
 );

--- a/src/wp-includes/block-template.php
+++ b/src/wp-includes/block-template.php
@@ -331,3 +331,35 @@ function _resolve_template_for_new_post( $wp_query ) {
 		$wp_query->set( 'post_status', 'auto-draft' );
 	}
 }
+
+/**
+ * Return the correct template for the site's home page.
+ *
+ * @access private
+ * @since 6.0.0
+ *
+ * @return array|null A template object, or null if none could be found
+ */
+function _resolve_home_block_template() {
+	$show_on_front = get_option( 'show_on_front' );
+	$front_page_id = get_option( 'page_on_front' );
+
+	if ( 'page' === $show_on_front && $front_page_id ) {
+		return array(
+			'postType' => 'page',
+			'postId'   => $front_page_id,
+		);
+	}
+
+	$hierarchy = array( 'front-page', 'home', 'index' );
+	$template  = resolve_block_template( 'home', $hierarchy, '' );
+
+	if ( ! $template ) {
+		return null;
+	}
+
+	return array(
+		'postType' => 'wp_template',
+		'postId'   => $template->id,
+	);
+}

--- a/tests/phpunit/tests/block-template.php
+++ b/tests/phpunit/tests/block-template.php
@@ -188,4 +188,34 @@ class Tests_Block_Template extends WP_UnitTestCase {
 		$resolved_template_path = locate_block_template( '', 'search', array() );
 		$this->assertSame( '', $resolved_template_path );
 	}
+
+	/**
+	 * Covers: https://github.com/WordPress/gutenberg/pull/38817.
+	 */
+	public function test_resolve_home_block_template_default_hierarchy() {
+		$template = _resolve_home_block_template();
+
+		$this->assertSame( 'wp_template', $template['postType'] );
+		$this->assertSame( get_stylesheet() . '//index', $template['postId'] );
+	}
+
+	public function test_resolve_home_block_template_static_homepage() {
+		$post_id = self::factory()->post->create( array( 'post_type' => 'page' ) );
+		update_option( 'show_on_front', 'page' );
+		update_option( 'page_on_front', $post_id );
+
+		$template = _resolve_home_block_template();
+
+		$this->assertSame( 'page', $template['postType'] );
+		$this->assertSame( $post_id, $template['postId'] );
+
+		delete_option( 'show_on_front', 'page' );
+	}
+
+	public function test_resolve_home_block_template_no_resolution() {
+		switch_theme( 'stylesheetonly' );
+		$template = _resolve_home_block_template();
+
+		$this->assertNull( $template );
+	}
 }


### PR DESCRIPTION
Backports change from Gutenberg to support server-side home template resolution in the Site Editor.

Original PR https://github.com/WordPress/gutenberg/pull/38817

Trac ticket: https://core.trac.wordpress.org/ticket/55505

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
