### PR TITLE
Update preload paths for post, site and widgets editors

### DIFF
--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -57,13 +57,20 @@ $rest_path = rest_get_route_for_post( $post );
 
 // Preload common data.
 $preload_paths = array(
-	'/wp/v2/types?context=edit',
-	'/wp/v2/taxonomies?context=edit',
-	'/wp/v2/themes?status=active',
+	'/wp/v2/types?context=view',
+	'/wp/v2/taxonomies?context=view',
+	add_query_arg(
+		array(
+			'context' => 'edit',
+			'per_page' => -1,
+		),
+		rest_get_route_for_post_type_items( 'wp_block' )
+	),
 	add_query_arg( 'context', 'edit', $rest_path ),
 	sprintf( '/wp/v2/types/%s?context=edit', $post_type ),
 	'/wp/v2/users/me',
 	array( rest_get_route_for_post_type_items( 'attachment' ), 'OPTIONS' ),
+	array( rest_get_route_for_post_type_items( 'page' ), 'OPTIONS' ),
 	array( rest_get_route_for_post_type_items( 'wp_block' ), 'OPTIONS' ),
 	sprintf( '%s/autosaves?context=edit', $rest_path ),
 	'/wp/v2/settings',

--- a/src/wp-admin/site-editor.php
+++ b/src/wp-admin/site-editor.php
@@ -72,17 +72,11 @@ $active_global_styles_id = WP_Theme_JSON_Resolver::get_user_global_styles_post_i
 $active_theme            = wp_get_theme()->get_stylesheet();
 $preload_paths           = array(
 	array( '/wp/v2/media', 'OPTIONS' ),
-	'/wp/v2/types?context=edit',
+	'/wp/v2/types?context=view',
 	'/wp/v2/types/wp_template?context=edit',
 	'/wp/v2/types/wp_template-part?context=edit',
-	'/wp/v2/taxonomies?context=edit',
-	'/wp/v2/pages?context=edit',
-	'/wp/v2/categories?context=edit',
-	'/wp/v2/posts?context=edit',
-	'/wp/v2/tags?context=edit',
 	'/wp/v2/templates?context=edit&per_page=-1',
 	'/wp/v2/template-parts?context=edit&per_page=-1',
-	'/wp/v2/settings',
 	'/wp/v2/themes?context=edit&status=active',
 	'/wp/v2/global-styles/' . $active_global_styles_id . '?context=edit',
 	'/wp/v2/global-styles/' . $active_global_styles_id,

--- a/src/wp-admin/widgets-form-blocks.php
+++ b/src/wp-admin/widgets-form-blocks.php
@@ -19,6 +19,7 @@ $block_editor_context = new WP_Block_Editor_Context( array( 'name' => 'core/edit
 
 $preload_paths = array(
 	array( rest_get_route_for_post_type_items( 'attachment' ), 'OPTIONS' ),
+	'/wp/v2/widget-types?context=edit&per_page=-1',
 	'/wp/v2/sidebars?context=edit&per_page=-1',
 	'/wp/v2/widgets?context=edit&per_page=-1&_embed=about',
 );


### PR DESCRIPTION
Changes the REST endpoints that get preloaded when displaying a page for post, site and widgets editor, so that they are in sync with what the latest version of Gutenberg to be shipped with Core 6.0 really requests.

This patch finished backport of the [`gutenberg_optimize_preload_paths`](https://github.com/WordPress/gutenberg/blob/trunk/lib/compat/wordpress-6.0/edit-form-blocks.php#L14) filter in Gutenberg, and that filter can be removed after this is merged. Trac ticket: https://core.trac.wordpress.org/ticket/55505

**Post Editor**
The `types` and `taxonomies` requests have `context` changed from `edit` to `view`, because these requests were modified in https://github.com/WordPress/gutenberg/pull/37685.

Adding two new preloads: list of reusable blocks (`wp_block` post type, loaded from `/wp/v2/blocks`) and permissions for creating pages (`OPTIONS /wp/v2/pages`). Both requests are made in the `useBlockEditorSettings` hook, at the top of the post editor React tree.

**Site Editor**
Like in Post Editor, modify the `types` request `context` from `edit` to `view`.

The `taxonomies` preload, together with four other ones, can be removed because the Site Editor doesn't request that data.

Site Editor also doesn't need to preload `/wp/v2/settings`. These are used only in specialized blocks like Site Title, and by the `useTitle` hook which is by no means on critical path.

**Widgets Editor**
Adds a preload for the `/wp/v2/widget-types` endpoint requested by the `registerLegacyWidgetVariations` called during initialization.
