### PR TITLE
Remove loading remote patterns from editor pages

### DIFF
--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -28,10 +28,6 @@ $block_editor_context = new WP_Block_Editor_Context( array( 'post' => $post ) );
 $current_screen = get_current_screen();
 $current_screen->is_block_editor( true );
 
-// Load block patterns from w.org.
-_load_remote_block_patterns();
-_load_remote_featured_patterns();
-
 // Default to is-fullscreen-mode to avoid jumps in the UI.
 add_filter(
 	'admin_body_class',

--- a/src/wp-admin/site-editor.php
+++ b/src/wp-admin/site-editor.php
@@ -31,10 +31,6 @@ $parent_file = 'themes.php';
 $current_screen = get_current_screen();
 $current_screen->is_block_editor( true );
 
-// Load block patterns from w.org.
-_load_remote_block_patterns();
-_load_remote_featured_patterns();
-
 // Default to is-fullscreen-mode to avoid jumps in the UI.
 add_filter(
 	'admin_body_class',


### PR DESCRIPTION
Stops loading remote patterns on the post editor and site editor pages. The only place to load remote patterns is going to be the `/wp/v2/block-patterns/patterns` REST endpoint handler.

This patch does backport of the [gutenberg_disable_load_remote_patterns](https://github.com/WordPress/gutenberg/blob/trunk/lib/compat/wordpress-6.0/edit-form-blocks.php#L60) filter in Gutenberg, and that filter can be removed after this is merged.

Trac ticket: https://core.trac.wordpress.org/ticket/55505