### PR TITLE
Copy changes for theme export back to core

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -911,7 +911,7 @@ function block_footer_area() {
  * @return Bool Whether this file is in an ignored directory.
  */
 function wp_is_theme_directory_ignored( $path ) {
-	$directories_to_ignore = array( '.git', 'node_modules', 'vendor' );
+	$directories_to_ignore = array( '.svn', '.git', '.hg', '.bzr', 'node_modules', 'vendor' );
 	foreach ( $directories_to_ignore as $directory ) {
 		if ( strpos( $path, $directory ) === 0 ) {
 			return true;

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -119,11 +119,11 @@ function get_default_block_template_types() {
 		),
 		'home'           => array(
 			'title'       => _x( 'Home', 'Template name' ),
-			'description' => __( 'Displays as the site\'s home page, or as the Posts page when a static home page isn\'t set.' ),
+			'description' => __( 'Displays posts on the homepage, or on the Posts page if a static homepage is set.' ),
 		),
 		'front-page'     => array(
 			'title'       => _x( 'Front Page', 'Template name' ),
-			'description' => __( 'Displays as the site\'s home page.' ),
+			'description' => __( 'Displays the homepage.' ),
 		),
 		'singular'       => array(
 			'title'       => _x( 'Singular', 'Template name' ),
@@ -162,12 +162,12 @@ function get_default_block_template_types() {
 			'description' => __( 'Displays latest posts with a single post tag.' ),
 		),
 		'attachment'     => array(
-			'title'       => __( 'Attachment' ),
+			'title'       => __( 'Media' ),
 			'description' => __( 'Displays individual media items or attachments.' ),
 		),
 		'search'         => array(
 			'title'       => _x( 'Search', 'Template name' ),
-			'description' => __( 'Template used to display search results.' ),
+			'description' => __( 'Displays search results.' ),
 		),
 		'privacy-policy' => array(
 			'title'       => __( 'Privacy Policy' ),
@@ -903,11 +903,31 @@ function block_footer_area() {
 }
 
 /**
+ * Filters theme directories that should be ignored during export.
+ *
+ * @since 6.0.0
+ *
+ * @param string $path The path of the file in the theme.
+ * @return Bool Whether this file is in an ignored directory.
+ */
+function wp_is_theme_directory_ignored( $path ) {
+	$directories_to_ignore = array( '.git', 'node_modules', 'vendor' );
+	foreach ( $directories_to_ignore as $directory ) {
+		if ( strpos( $path, $directory ) === 0 ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
  * Creates an export of the current templates and
  * template parts from the site editor at the
  * specified path in a ZIP file.
  *
  * @since 5.9.0
+ * @since 6.0.0 Adds the whole theme to the export archive.
  *
  * @return WP_Error|string Path of the ZIP file or error on failure.
  */
@@ -916,17 +936,40 @@ function wp_generate_block_templates_export_file() {
 		return new WP_Error( 'missing_zip_package', __( 'Zip Export not supported.' ) );
 	}
 
-	$obscura  = wp_generate_password( 12, false, false );
-	$filename = get_temp_dir() . 'edit-site-export-' . $obscura . '.zip';
+	$obscura    = wp_generate_password( 12, false, false );
+	$theme_name = wp_get_theme()->get( 'TextDomain' );
+	$filename   = get_temp_dir() . $theme_name . $obscura . '.zip';
 
 	$zip = new ZipArchive();
-	if ( true !== $zip->open( $filename, ZipArchive::CREATE ) ) {
+	if ( true !== $zip->open( $filename, ZipArchive::CREATE | ZipArchive::OVERWRITE ) ) {
 		return new WP_Error( 'unable_to_create_zip', __( 'Unable to open export file (archive) for writing.' ) );
 	}
 
-	$zip->addEmptyDir( 'theme' );
-	$zip->addEmptyDir( 'theme/templates' );
-	$zip->addEmptyDir( 'theme/parts' );
+	$zip->addEmptyDir( 'templates' );
+	$zip->addEmptyDir( 'parts' );
+
+	// Get path of the theme.
+	$theme_path = wp_normalize_path( get_stylesheet_directory() );
+
+	// Create recursive directory iterator.
+	$theme_files = new RecursiveIteratorIterator(
+		new RecursiveDirectoryIterator( $theme_path ),
+		RecursiveIteratorIterator::LEAVES_ONLY
+	);
+
+	// Make a copy of the current theme.
+	foreach ( $theme_files as $file ) {
+		// Skip directories as they are added automatically.
+		if ( ! $file->isDir() ) {
+			// Get real and relative path for current file.
+			$file_path     = wp_normalize_path( $file );
+			$relative_path = substr( $file_path, strlen( $theme_path ) + 1 );
+
+			if ( ! wp_is_theme_directory_ignored( $relative_path ) ) {
+				$zip->addFile( $file_path, $relative_path );
+			}
+		}
+	}
 
 	// Load templates into the zip file.
 	$templates = get_block_templates();
@@ -934,7 +977,7 @@ function wp_generate_block_templates_export_file() {
 		$template->content = _remove_theme_attribute_in_block_template_content( $template->content );
 
 		$zip->addFromString(
-			'theme/templates/' . $template->slug . '.html',
+			'templates/' . $template->slug . '.html',
 			$template->content
 		);
 	}
@@ -943,10 +986,36 @@ function wp_generate_block_templates_export_file() {
 	$template_parts = get_block_templates( array(), 'wp_template_part' );
 	foreach ( $template_parts as $template_part ) {
 		$zip->addFromString(
-			'theme/parts/' . $template_part->slug . '.html',
+			'parts/' . $template_part->slug . '.html',
 			$template_part->content
 		);
 	}
+
+	// Load theme.json into the zip file.
+	$tree = WP_Theme_JSON_Resolver::get_theme_data( array(), array( 'with_supports' => false ) );
+	// Merge with user data.
+	$tree->merge( WP_Theme_JSON_Resolver::get_user_data() );
+
+	$theme_json_raw = $tree->get_data();
+	// If a version is defined, add a schema.
+	if ( $theme_json_raw['version'] ) {
+		global $wp_version;
+		$theme_json_version = 'wp/' . substr( $wp_version, 0, 3 );
+		$schema         = array( '$schema' => 'https://schemas.wp.org/' . $theme_json_version . '/theme.json' );
+		$theme_json_raw = array_merge( $schema, $theme_json_raw );
+	}
+
+	// Convert to a string.
+	$theme_json_encoded = wp_json_encode( $theme_json_raw, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+
+	// Replace 4 spaces with a tab.
+	$theme_json_tabbed = preg_replace( '~(?:^|\G)\h{4}~m', "\t", $theme_json_encoded );
+
+	// Add the theme.json file to the zip.
+	$zip->addFromString(
+		'theme.json',
+		$theme_json_tabbed
+	);
 
 	// Save changes to the zip file.
 	$zip->close();

--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -154,13 +154,15 @@ class WP_Theme_JSON_Resolver {
 	 * @since 6.0.0 Adds a second parameter to allow the theme data to be returned without theme supports.
 	 *
 	 * @param array $deprecated Deprecated. Not used.
-	 * @param array $settings Contains a key called with_supports to determine whether to include theme supports in the data.
+	 * @param array $options Contains a key called with_supports to determine whether to include theme supports in the data.
 	 * @return WP_Theme_JSON Entity that holds theme data.
 	 */
-	public static function get_theme_data( $deprecated = array(), $settings = array( 'with_supports' => true ) ) {
+	public static function get_theme_data( $deprecated = array(), $options = array() ) {
 		if ( ! empty( $deprecated ) ) {
 			_deprecated_argument( __METHOD__, '5.9.0' );
 		}
+
+		$options = wp_parse_args( $options, array( 'with_supports' => true ) );
 
 		if ( null === static::$theme ) {
 			$theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json' ) );
@@ -180,7 +182,7 @@ class WP_Theme_JSON_Resolver {
 			}
 		}
 
-		if ( ! $settings['with_supports'] ) {
+		if ( ! $options['with_supports'] ) {
 			return static::$theme;
 		}
 

--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -159,7 +159,7 @@ class WP_Theme_JSON_Resolver {
 	 */
 	public static function get_theme_data( $deprecated = array(), $settings = array( 'with_supports' => true ) ) {
 		if ( ! empty( $deprecated ) ) {
-			_deprecated_argument( __METHOD__, '5.9' );
+			_deprecated_argument( __METHOD__, '5.9.0' );
 		}
 
 		if ( null === static::$theme ) {

--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -151,14 +151,17 @@ class WP_Theme_JSON_Resolver {
 	 *
 	 * @since 5.8.0
 	 * @since 5.9.0 Theme supports have been inlined and the `$theme_support_data` argument removed.
+	 * @since 6.0.0 Adds a second parameter to allow the theme data to be returned without theme supports.
 	 *
 	 * @param array $deprecated Deprecated. Not used.
+	 * @param array $settings Contains a key called with_supports to determine whether to include theme supports in the data.
 	 * @return WP_Theme_JSON Entity that holds theme data.
 	 */
-	public static function get_theme_data( $deprecated = array() ) {
+	public static function get_theme_data( $deprecated = array(), $settings = array( 'with_supports' => true ) ) {
 		if ( ! empty( $deprecated ) ) {
-			_deprecated_argument( __METHOD__, '5.9.0' );
+			_deprecated_argument( __METHOD__, '5.9' );
 		}
+
 		if ( null === static::$theme ) {
 			$theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json' ) );
 			$theme_json_data = static::translate( $theme_json_data, wp_get_theme()->get( 'TextDomain' ) );
@@ -175,6 +178,10 @@ class WP_Theme_JSON_Resolver {
 				$parent_theme->merge( static::$theme );
 				static::$theme = $parent_theme;
 			}
+		}
+
+		if ( ! $settings['with_supports'] ) {
+			return static::$theme;
 		}
 
 		/*
@@ -208,6 +215,9 @@ class WP_Theme_JSON_Resolver {
 				$default_gradients = true;
 			}
 			$theme_support_data['settings']['color']['defaultGradients'] = $default_gradients;
+
+			// Classic themes without a theme.json don't support global duotone.
+			$theme_support_data['settings']['color']['defaultDuotone'] = false;
 		}
 		$with_theme_supports = new WP_Theme_JSON( $theme_support_data );
 		$with_theme_supports->merge( static::$theme );
@@ -477,4 +487,5 @@ class WP_Theme_JSON_Resolver {
 		}
 		return $variations;
 	}
+
 }

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -2013,7 +2013,7 @@ class WP_Theme_JSON {
 			if ( ! isset( $theme_settings['settings']['spacing'] ) ) {
 				$theme_settings['settings']['spacing'] = array();
 			}
-		$theme_settings['settings']['spacing']['units'] = ( true === $settings['enableCustomUnits'] ) ?
+			$theme_settings['settings']['spacing']['units'] = ( true === $settings['enableCustomUnits'] ) ?
 			array( 'px', 'em', 'rem', 'vh', 'vw', '%' ) :
 			$settings['enableCustomUnits'];
 	}

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -1684,8 +1684,8 @@ class WP_Theme_JSON {
 	 * @deprecated 6.0.0 Use {@see 'get_metadata_boolean'} instead.
 	 *
 	 * @param array      $theme_json The theme.json like structure to inspect.
-	 * @param array      $path Path to inspect.
-	 * @param bool|array $override Data to compute whether to override the preset.
+	 * @param array      $path       Path to inspect.
+	 * @param bool|array $override   Data to compute whether to override the preset.
 	 * @return boolean
 	 */
 	protected static function should_override_preset( $theme_json, $path, $override ) {

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -2014,194 +2014,194 @@ class WP_Theme_JSON {
 				$theme_settings['settings']['spacing'] = array();
 			}
 			$theme_settings['settings']['spacing']['units'] = ( true === $settings['enableCustomUnits'] ) ?
-			array( 'px', 'em', 'rem', 'vh', 'vw', '%' ) :
-			$settings['enableCustomUnits'];
-	}
-
-	if ( isset( $settings['colors'] ) ) {
-		if ( ! isset( $theme_settings['settings']['color'] ) ) {
-			$theme_settings['settings']['color'] = array();
+				array( 'px', 'em', 'rem', 'vh', 'vw', '%' ) :
+				$settings['enableCustomUnits'];
 		}
-		$theme_settings['settings']['color']['palette'] = $settings['colors'];
-	}
 
-	if ( isset( $settings['gradients'] ) ) {
-		if ( ! isset( $theme_settings['settings']['color'] ) ) {
-			$theme_settings['settings']['color'] = array();
-		}
-		$theme_settings['settings']['color']['gradients'] = $settings['gradients'];
-	}
-
-	if ( isset( $settings['fontSizes'] ) ) {
-		$font_sizes = $settings['fontSizes'];
-		// Back-compatibility for presets without units.
-		foreach ( $font_sizes as $key => $font_size ) {
-			if ( is_numeric( $font_size['size'] ) ) {
-				$font_sizes[ $key ]['size'] = $font_size['size'] . 'px';
+		if ( isset( $settings['colors'] ) ) {
+			if ( ! isset( $theme_settings['settings']['color'] ) ) {
+				$theme_settings['settings']['color'] = array();
 			}
+			$theme_settings['settings']['color']['palette'] = $settings['colors'];
 		}
-		if ( ! isset( $theme_settings['settings']['typography'] ) ) {
-			$theme_settings['settings']['typography'] = array();
+
+		if ( isset( $settings['gradients'] ) ) {
+			if ( ! isset( $theme_settings['settings']['color'] ) ) {
+				$theme_settings['settings']['color'] = array();
+			}
+			$theme_settings['settings']['color']['gradients'] = $settings['gradients'];
 		}
-		$theme_settings['settings']['typography']['fontSizes'] = $font_sizes;
-	}
 
-	if ( isset( $settings['enableCustomSpacing'] ) ) {
-		if ( ! isset( $theme_settings['settings']['spacing'] ) ) {
-			$theme_settings['settings']['spacing'] = array();
+		if ( isset( $settings['fontSizes'] ) ) {
+			$font_sizes = $settings['fontSizes'];
+			// Back-compatibility for presets without units.
+			foreach ( $font_sizes as $key => $font_size ) {
+				if ( is_numeric( $font_size['size'] ) ) {
+					$font_sizes[ $key ]['size'] = $font_size['size'] . 'px';
+				}
+			}
+			if ( ! isset( $theme_settings['settings']['typography'] ) ) {
+				$theme_settings['settings']['typography'] = array();
+			}
+			$theme_settings['settings']['typography']['fontSizes'] = $font_sizes;
 		}
-		$theme_settings['settings']['spacing']['padding'] = $settings['enableCustomSpacing'];
+
+		if ( isset( $settings['enableCustomSpacing'] ) ) {
+			if ( ! isset( $theme_settings['settings']['spacing'] ) ) {
+				$theme_settings['settings']['spacing'] = array();
+			}
+			$theme_settings['settings']['spacing']['padding'] = $settings['enableCustomSpacing'];
+		}
+
+		return $theme_settings;
 	}
-
-	return $theme_settings;
-}
-
-/**
- * Returns the current theme's wanted patterns(slugs) to be
- * registered from Pattern Directory.
- *
- * @since 6.0.0
- *
- * @return array
- */
-public function get_patterns() {
-	if ( isset( $this->theme_json['patterns'] ) && is_array( $this->theme_json['patterns'] ) ) {
-		return $this->theme_json['patterns'];
-	}
-	return array();
-}
-
-/**
- * Returns a valid theme.json as provided by a theme.
- *
- * Unlike get_raw_data() this returns the presets flattened,
- * as provided by a theme. This also uses appearanceTools
- * instead of their opt-ins if all of them are true.
- *
- * @since 6.0.0
- *
- * @return array
- */
-public function get_data() {
-	$output = $this->theme_json;
-	$nodes  = static::get_setting_nodes( $output );
 
 	/**
-	 * Flatten the theme & custom origins into a single one.
+	 * Returns the current theme's wanted patterns(slugs) to be
+	 * registered from Pattern Directory.
 	 *
-	 * For example, the following:
+	 * @since 6.0.0
 	 *
-	 * {
-	 *   "settings": {
-	 *     "color": {
-	 *       "palette": {
-	 *         "theme": [ {} ],
-	 *         "custom": [ {} ]
-	 *       }
-	 *     }
-	 *   }
-	 * }
-	 *
-	 * will be converted to:
-	 *
-	 * {
-	 *   "settings": {
-	 *     "color": {
-	 *       "palette": [ {} ]
-	 *     }
-	 *   }
-	 * }
+	 * @return array
 	 */
-	foreach ( $nodes as $node ) {
-		foreach ( static::PRESETS_METADATA as $preset_metadata ) {
-			$path   = array_merge( $node['path'], $preset_metadata['path'] );
-			$preset = _wp_array_get( $output, $path, null );
-			if ( null === $preset ) {
-				continue;
-			}
-
-			$items = array();
-			if ( isset( $preset['theme'] ) ) {
-				foreach ( $preset['theme'] as $item ) {
-					$slug = $item['slug'];
-					unset( $item['slug'] );
-					$items[ $slug ] = $item;
-				}
-			}
-			if ( isset( $preset['custom'] ) ) {
-				foreach ( $preset['custom'] as $item ) {
-					$slug = $item['slug'];
-					unset( $item['slug'] );
-					$items[ $slug ] = $item;
-				}
-			}
-			$flattened_preset = array();
-			foreach ( $items as $slug => $value ) {
-				$flattened_preset[] = array_merge( array( 'slug' => $slug ), $value );
-			}
-			_wp_array_set( $output, $path, $flattened_preset );
+	public function get_patterns() {
+		if ( isset( $this->theme_json['patterns'] ) && is_array( $this->theme_json['patterns'] ) ) {
+			return $this->theme_json['patterns'];
 		}
+		return array();
 	}
 
-	// If all of the static::APPEARANCE_TOOLS_OPT_INS are true,
-	// this code unsets them and sets 'appearanceTools' instead.
-	foreach ( $nodes as $node ) {
-		$all_opt_ins_are_set = true;
-		foreach ( static::APPEARANCE_TOOLS_OPT_INS as $opt_in_path ) {
-			$full_path = array_merge( $node['path'], $opt_in_path );
-			// Use "unset prop" as a marker instead of "null" because
-			// "null" can be a valid value for some props (e.g. blockGap).
-			$opt_in_value = _wp_array_get( $output, $full_path, 'unset prop' );
-			if ( 'unset prop' === $opt_in_value ) {
-				$all_opt_ins_are_set = false;
-				break;
+	/**
+	 * Returns a valid theme.json as provided by a theme.
+	 *
+	 * Unlike get_raw_data() this returns the presets flattened,
+	 * as provided by a theme. This also uses appearanceTools
+	 * instead of their opt-ins if all of them are true.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @return array
+	 */
+	public function get_data() {
+		$output = $this->theme_json;
+		$nodes  = static::get_setting_nodes( $output );
+
+		/**
+		 * Flatten the theme & custom origins into a single one.
+		 *
+		 * For example, the following:
+		 *
+		 * {
+		 *   "settings": {
+		 *     "color": {
+		 *       "palette": {
+		 *         "theme": [ {} ],
+		 *         "custom": [ {} ]
+		 *       }
+		 *     }
+		 *   }
+		 * }
+		 *
+		 * will be converted to:
+		 *
+		 * {
+		 *   "settings": {
+		 *     "color": {
+		 *       "palette": [ {} ]
+		 *     }
+		 *   }
+		 * }
+		 */
+		foreach ( $nodes as $node ) {
+			foreach ( static::PRESETS_METADATA as $preset_metadata ) {
+				$path   = array_merge( $node['path'], $preset_metadata['path'] );
+				$preset = _wp_array_get( $output, $path, null );
+				if ( null === $preset ) {
+					continue;
+				}
+
+				$items = array();
+				if ( isset( $preset['theme'] ) ) {
+					foreach ( $preset['theme'] as $item ) {
+						$slug = $item['slug'];
+						unset( $item['slug'] );
+						$items[ $slug ] = $item;
+					}
+				}
+				if ( isset( $preset['custom'] ) ) {
+					foreach ( $preset['custom'] as $item ) {
+						$slug = $item['slug'];
+						unset( $item['slug'] );
+						$items[ $slug ] = $item;
+					}
+				}
+				$flattened_preset = array();
+				foreach ( $items as $slug => $value ) {
+					$flattened_preset[] = array_merge( array( 'slug' => $slug ), $value );
+				}
+				_wp_array_set( $output, $path, $flattened_preset );
 			}
 		}
 
-		if ( $all_opt_ins_are_set ) {
-			_wp_array_set( $output, array_merge( $node['path'], array( 'appearanceTools' ) ), true );
+		// If all of the static::APPEARANCE_TOOLS_OPT_INS are true,
+		// this code unsets them and sets 'appearanceTools' instead.
+		foreach ( $nodes as $node ) {
+			$all_opt_ins_are_set = true;
 			foreach ( static::APPEARANCE_TOOLS_OPT_INS as $opt_in_path ) {
 				$full_path = array_merge( $node['path'], $opt_in_path );
 				// Use "unset prop" as a marker instead of "null" because
 				// "null" can be a valid value for some props (e.g. blockGap).
 				$opt_in_value = _wp_array_get( $output, $full_path, 'unset prop' );
-				if ( true !== $opt_in_value ) {
-					continue;
+				if ( 'unset prop' === $opt_in_value ) {
+					$all_opt_ins_are_set = false;
+					break;
 				}
+			}
 
-				// The following could be improved to be path independent.
-				// At the moment it relies on a couple of assumptions:
-				//
-				// - all opt-ins having a path of size 2.
-				// - there's two sources of settings: the top-level and the block-level.
-				if (
-					( 1 === count( $node['path'] ) ) &&
-					( 'settings' === $node['path'][0] )
-				) {
-					// Top-level settings.
-					unset( $output['settings'][ $opt_in_path[0] ][ $opt_in_path[1] ] );
-					if ( empty( $output['settings'][ $opt_in_path[0] ] ) ) {
-						unset( $output['settings'][ $opt_in_path[0] ] );
+			if ( $all_opt_ins_are_set ) {
+				_wp_array_set( $output, array_merge( $node['path'], array( 'appearanceTools' ) ), true );
+				foreach ( static::APPEARANCE_TOOLS_OPT_INS as $opt_in_path ) {
+					$full_path = array_merge( $node['path'], $opt_in_path );
+					// Use "unset prop" as a marker instead of "null" because
+					// "null" can be a valid value for some props (e.g. blockGap).
+					$opt_in_value = _wp_array_get( $output, $full_path, 'unset prop' );
+					if ( true !== $opt_in_value ) {
+						continue;
 					}
-				} elseif (
-					( 3 === count( $node['path'] ) ) &&
-					( 'settings' === $node['path'][0] ) &&
-					( 'blocks' === $node['path'][1] )
-				) {
-					// Block-level settings.
-					$block_name = $node['path'][2];
-					unset( $output['settings']['blocks'][ $block_name ][ $opt_in_path[0] ][ $opt_in_path[1] ] );
-					if ( empty( $output['settings']['blocks'][ $block_name ][ $opt_in_path[0] ] ) ) {
-						unset( $output['settings']['blocks'][ $block_name ][ $opt_in_path[0] ] );
+
+					// The following could be improved to be path independent.
+					// At the moment it relies on a couple of assumptions:
+					//
+					// - all opt-ins having a path of size 2.
+					// - there's two sources of settings: the top-level and the block-level.
+					if (
+						( 1 === count( $node['path'] ) ) &&
+						( 'settings' === $node['path'][0] )
+					) {
+						// Top-level settings.
+						unset( $output['settings'][ $opt_in_path[0] ][ $opt_in_path[1] ] );
+						if ( empty( $output['settings'][ $opt_in_path[0] ] ) ) {
+							unset( $output['settings'][ $opt_in_path[0] ] );
+						}
+					} elseif (
+						( 3 === count( $node['path'] ) ) &&
+						( 'settings' === $node['path'][0] ) &&
+						( 'blocks' === $node['path'][1] )
+					) {
+						// Block-level settings.
+						$block_name = $node['path'][2];
+						unset( $output['settings']['blocks'][ $block_name ][ $opt_in_path[0] ][ $opt_in_path[1] ] );
+						if ( empty( $output['settings']['blocks'][ $block_name ][ $opt_in_path[0] ] ) ) {
+							unset( $output['settings']['blocks'][ $block_name ][ $opt_in_path[0] ] );
+						}
 					}
 				}
 			}
 		}
-	}
 
-	wp_recursive_ksort( $output );
+		wp_recursive_ksort( $output );
 
-	return $output;
+		return $output;
 	}
 
 }

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -2079,7 +2079,7 @@ class WP_Theme_JSON {
 	 *
 	 * @since 6.0.0
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	public function get_patterns() {
 		if ( isset( $this->theme_json['patterns'] ) && is_array( $this->theme_json['patterns'] ) ) {

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -1667,6 +1667,7 @@ class WP_Theme_JSON {
 	 * Returns whether a presets should be overridden or not.
 	 *
 	 * @since 5.9.0
+	 * @deprecated 6.0.0 Use {@see 'get_metadata_boolean'} instead.
 	 *
 	 * @param array      $theme_json The theme.json like structure to inspect.
 	 * @param array      $path Path to inspect.
@@ -1674,6 +1675,8 @@ class WP_Theme_JSON {
 	 * @return boolean
 	 */
 	protected static function should_override_preset( $theme_json, $path, $override ) {
+		_deprecated_function( __METHOD__, '6.0.0' );
+
 		if ( is_bool( $override ) ) {
 			return $override;
 		}

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -2091,9 +2091,8 @@ class WP_Theme_JSON {
 	/**
 	 * Returns a valid theme.json as provided by a theme.
 	 *
-	 * Unlike get_raw_data() this returns the presets flattened,
-	 * as provided by a theme. This also uses appearanceTools
-	 * instead of their opt-ins if all of them are true.
+	 * Unlike get_raw_data() this returns the presets flattened, as provided by a theme.
+	 * This also uses appearanceTools instead of their opt-ins if all of them are true.
 	 *
 	 * @since 6.0.0
 	 *

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -105,6 +105,13 @@ class WP_Theme_JSON {
 	 * - properties       => array of CSS properties to be used by kses to
 	 *                       validate the content of each preset
 	 *                       by means of the remove_insecure_properties method.
+	 *
+	 * @since 5.8.0
+	 * @since 5.9.0 Added the `color.duotone` and `typography.fontFamilies` presets,
+	 *              `use_default_names` preset key, and simplified the metadata structure.
+	 * @since 6.0.0 Replaced `override` with `prevent_override` and updated the
+	 *              `prevent_overried` value for `color.duotone` to use `color.defaultDuotone`.
+	 * @var array
 	 */
 	const PRESETS_METADATA = array(
 		array(
@@ -245,6 +252,7 @@ class WP_Theme_JSON {
 	 * @since 5.9.0 Renamed from `ALLOWED_SETTINGS` to `VALID_SETTINGS`,
 	 *              added new properties for `border`, `color`, `spacing`,
 	 *              and `typography`, and renamed others according to the new schema.
+	 * @since 6.0.0 Added `color.defaultDuotone`.
 	 * @var array
 	 */
 	const VALID_SETTINGS = array(
@@ -351,6 +359,12 @@ class WP_Theme_JSON {
 		'h6'   => 'h6',
 	);
 
+	/**
+	 * Options that settings.appearanceTools enables.
+	 *
+	 * @since 6.0.0
+	 * @var array
+	 */
 	const APPEARANCE_TOOLS_OPT_INS = array(
 		array( 'border', 'color' ),
 		array( 'border', 'radius' ),

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -1550,7 +1550,7 @@ class WP_Theme_JSON {
 
 		if ( is_array( $path ) ) {
 			$value = _wp_array_get( $data, $path );
-			if ( isset( $value ) ) {
+			if ( null !== $value ) {
 				return $value;
 			}
 		}

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -74,41 +74,42 @@ class WP_Theme_JSON {
 	 *
 	 * This contains the necessary metadata to process them:
 	 *
-	 * - path              => where to find the preset within the settings section
-	 * - override          => whether a theme preset with the same slug as a default preset
-	 *                        can override it
+	 * - path             => Where to find the preset within the settings section.
+	 * - prevent_override => Disables override of default presets by theme presets.
+	 *                       The relationship between whether to override the defaults
+	 *                       and whether the defaults are enabled is inverse:
+	 *                         - If defaults are enabled  => theme presets should not be overriden
+	 *                         - If defaults are disabled => theme presets should be overriden
+	 *                       For example, a theme sets defaultPalette to false,
+	 *                       making the default palette hidden from the user.
+	 *                       In that case, we want all the theme presets to be present,
+	 *                       so they should override the defaults by setting this false.
 	 * - use_default_names => whether to use the default names
-	 * - value_key         => the key that represents the value
-	 * - value_func        => optionally, instead of value_key, a function to generate
-	 *                        the value that takes a preset as an argument
-	 *                        (either value_key or value_func should be present)
-	 * - css_vars          => template string to use in generating the CSS Custom Property.
-	 *                        Example output: "--wp--preset--duotone--blue: <value>" will generate
-	 *                        as many CSS Custom Properties as presets defined
-	 *                        substituting the $slug for the slug's value for each preset value.
-	 * - classes           => array containing a structure with the classes to
-	 *                        generate for the presets, where for each array item
-	 *                        the key is the class name and the value the property name.
-	 *                        The "$slug" substring will be replaced by the slug of each preset.
-	 *                        For example:
-	 *                        'classes' => array(
-	 *                           '.has-$slug-color'            => 'color',
-	 *                           '.has-$slug-background-color' => 'background-color',
-	 *                           '.has-$slug-border-color'     => 'border-color',
-	 *                        )
-	 * - properties        => array of CSS properties to be used by kses to
-	 *                        validate the content of each preset
-	 *                        by means of the remove_insecure_properties method.
-	 *
-	 * @since 5.8.0
-	 * @since 5.9.0 Added the `color.duotone` and `typography.fontFamilies` presets,
-	 *              `use_default_names` preset key, and simplified the metadata structure.
-	 * @var array
+	 * - value_key        => the key that represents the value
+	 * - value_func       => optionally, instead of value_key, a function to generate
+	 *                       the value that takes a preset as an argument
+	 *                       (either value_key or value_func should be present)
+	 * - css_vars         => template string to use in generating the CSS Custom Property.
+	 *                       Example output: "--wp--preset--duotone--blue: <value>" will generate as many CSS Custom Properties as presets defined
+	 *                       substituting the $slug for the slug's value for each preset value.
+	 * - classes          => array containing a structure with the classes to
+	 *                       generate for the presets, where for each array item
+	 *                       the key is the class name and the value the property name.
+	 *                       The "$slug" substring will be replaced by the slug of each preset.
+	 *                       For example:
+	 *                       'classes' => array(
+	 *                         '.has-$slug-color'            => 'color',
+	 *                         '.has-$slug-background-color' => 'background-color',
+	 *                         '.has-$slug-border-color'     => 'border-color',
+	 *                       )
+	 * - properties       => array of CSS properties to be used by kses to
+	 *                       validate the content of each preset
+	 *                       by means of the remove_insecure_properties method.
 	 */
 	const PRESETS_METADATA = array(
 		array(
 			'path'              => array( 'color', 'palette' ),
-			'override'          => array( 'color', 'defaultPalette' ),
+			'prevent_override'  => array( 'color', 'defaultPalette' ),
 			'use_default_names' => false,
 			'value_key'         => 'color',
 			'css_vars'          => '--wp--preset--color--$slug',
@@ -121,7 +122,7 @@ class WP_Theme_JSON {
 		),
 		array(
 			'path'              => array( 'color', 'gradients' ),
-			'override'          => array( 'color', 'defaultGradients' ),
+			'prevent_override'  => array( 'color', 'defaultGradients' ),
 			'use_default_names' => false,
 			'value_key'         => 'gradient',
 			'css_vars'          => '--wp--preset--gradient--$slug',
@@ -130,7 +131,7 @@ class WP_Theme_JSON {
 		),
 		array(
 			'path'              => array( 'color', 'duotone' ),
-			'override'          => true,
+			'prevent_override'  => array( 'color', 'defaultDuotone' ),
 			'use_default_names' => false,
 			'value_func'        => 'wp_get_duotone_filter_property',
 			'css_vars'          => '--wp--preset--duotone--$slug',
@@ -139,7 +140,7 @@ class WP_Theme_JSON {
 		),
 		array(
 			'path'              => array( 'typography', 'fontSizes' ),
-			'override'          => true,
+			'prevent_override'  => false,
 			'use_default_names' => true,
 			'value_key'         => 'size',
 			'css_vars'          => '--wp--preset--font-size--$slug',
@@ -148,7 +149,7 @@ class WP_Theme_JSON {
 		),
 		array(
 			'path'              => array( 'typography', 'fontFamilies' ),
-			'override'          => true,
+			'prevent_override'  => false,
 			'use_default_names' => false,
 			'value_key'         => 'fontFamily',
 			'css_vars'          => '--wp--preset--font-family--$slug',
@@ -229,10 +230,12 @@ class WP_Theme_JSON {
 	 */
 	const VALID_TOP_LEVEL_KEYS = array(
 		'customTemplates',
+		'patterns',
 		'settings',
 		'styles',
 		'templateParts',
 		'version',
+		'title',
 	);
 
 	/**
@@ -257,6 +260,7 @@ class WP_Theme_JSON {
 			'custom'           => null,
 			'customDuotone'    => null,
 			'customGradient'   => null,
+			'defaultDuotone'   => null,
 			'defaultGradients' => null,
 			'defaultPalette'   => null,
 			'duotone'          => null,
@@ -347,6 +351,18 @@ class WP_Theme_JSON {
 		'h6'   => 'h6',
 	);
 
+	const APPEARANCE_TOOLS_OPT_INS = array(
+		array( 'border', 'color' ),
+		array( 'border', 'radius' ),
+		array( 'border', 'style' ),
+		array( 'border', 'width' ),
+		array( 'color', 'link' ),
+		array( 'spacing', 'blockGap' ),
+		array( 'spacing', 'margin' ),
+		array( 'spacing', 'padding' ),
+		array( 'typography', 'lineHeight' ),
+	);
+
 	/**
 	 * The latest version of the schema in use.
 	 *
@@ -429,19 +445,7 @@ class WP_Theme_JSON {
 	 * @param array $context The context to which the settings belong.
 	 */
 	protected static function do_opt_in_into_settings( &$context ) {
-		$to_opt_in = array(
-			array( 'border', 'color' ),
-			array( 'border', 'radius' ),
-			array( 'border', 'style' ),
-			array( 'border', 'width' ),
-			array( 'color', 'link' ),
-			array( 'spacing', 'blockGap' ),
-			array( 'spacing', 'margin' ),
-			array( 'spacing', 'padding' ),
-			array( 'typography', 'lineHeight' ),
-		);
-
-		foreach ( $to_opt_in as $path ) {
+		foreach ( static::APPEARANCE_TOOLS_OPT_INS as $path ) {
 			// Use "unset prop" as a marker instead of "null" because
 			// "null" can be a valid value for some props (e.g. blockGap).
 			if ( 'unset prop' === _wp_array_get( $context, $path, 'unset prop' ) ) {
@@ -830,8 +834,8 @@ class WP_Theme_JSON {
 
 				$has_block_gap_support = _wp_array_get( $this->theme_json, array( 'settings', 'spacing', 'blockGap' ) ) !== null;
 				if ( $has_block_gap_support ) {
-					$block_rules .= '.wp-site-blocks > * { margin-top: 0; margin-bottom: 0; }';
-					$block_rules .= '.wp-site-blocks > * + * { margin-top: var( --wp--style--block-gap ); }';
+					$block_rules .= '.wp-site-blocks > * { margin-block-start: 0; margin-block-end: 0; }';
+					$block_rules .= '.wp-site-blocks > * + * { margin-block-start: var( --wp--style--block-gap ); }';
 				}
 			}
 		}
@@ -1502,6 +1506,45 @@ class WP_Theme_JSON {
 	}
 
 	/**
+	 * For metadata values that can either be booleans or paths to booleans, gets the value.
+	 *
+	 * ```php
+	 * $data = array(
+	 *   'color' => array(
+	 *     'defaultPalette' => true
+	 *   )
+	 * );
+	 *
+	 * static::get_metadata_boolean( $data, false );
+	 * // => false
+	 *
+	 * static::get_metadata_boolean( $data, array( 'color', 'defaultPalette' ) );
+	 * // => true
+	 * ```
+	 *
+	 * @since 6.0.0
+	 *
+	 * @param array      $data The data to inspect.
+	 * @param bool|array $path Boolean or path to a boolean.
+	 * @param bool       $default Default value if the referenced path is missing.
+	 * @return boolean
+	 */
+	protected static function get_metadata_boolean( $data, $path, $default = false ) {
+		if ( is_bool( $path ) ) {
+			return $path;
+		}
+
+		if ( is_array( $path ) ) {
+			$value = _wp_array_get( $data, $path );
+			if ( isset( $value ) ) {
+				return $value;
+			}
+		}
+
+		return $default;
+	}
+
+	/**
 	 * Merge new incoming data.
 	 *
 	 * @since 5.8.0
@@ -1550,7 +1593,7 @@ class WP_Theme_JSON {
 
 			// Replace the presets.
 			foreach ( static::PRESETS_METADATA as $preset ) {
-				$override_preset = static::should_override_preset( $this->theme_json, $node['path'], $preset['override'] );
+				$override_preset = ! static::get_metadata_boolean( $this->theme_json['settings'], $preset['prevent_override'], true );
 
 				foreach ( static::VALID_ORIGINS as $origin ) {
 					$base_path = array_merge( $node['path'], $preset['path'] );
@@ -2011,6 +2054,152 @@ class WP_Theme_JSON {
 		}
 
 		return $theme_settings;
+	}
+
+	/**
+	 * Returns the current theme's wanted patterns(slugs) to be
+	 * registered from Pattern Directory.
+	 *
+	 * @return array
+	 */
+	public function get_patterns() {
+		if ( isset( $this->theme_json['patterns'] ) && is_array( $this->theme_json['patterns'] ) ) {
+			return $this->theme_json['patterns'];
+		}
+		return array();
+	}
+
+	/**
+	 * Returns a valid theme.json as provided by a theme.
+	 *
+	 * Unlike get_raw_data() this returns the presets flattened,
+	 * as provided by a theme. This also uses appearanceTools
+	 * instead of their opt-ins if all of them are true.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @return array
+	 */
+	public function get_data() {
+		$output = $this->theme_json;
+		$nodes  = static::get_setting_nodes( $output );
+
+		/**
+		 * Flatten the theme & custom origins into a single one.
+		 *
+		 * For example, the following:
+		 *
+		 * {
+		 *   "settings": {
+		 *     "color": {
+		 *       "palette": {
+		 *         "theme": [ {} ],
+		 *         "custom": [ {} ]
+		 *       }
+		 *     }
+		 *   }
+		 * }
+		 *
+		 * will be converted to:
+		 *
+		 * {
+		 *   "settings": {
+		 *     "color": {
+		 *       "palette": [ {} ]
+		 *     }
+		 *   }
+		 * }
+		 */
+		foreach ( $nodes as $node ) {
+			foreach ( static::PRESETS_METADATA as $preset_metadata ) {
+				$path   = array_merge( $node['path'], $preset_metadata['path'] );
+				$preset = _wp_array_get( $output, $path, null );
+				if ( null === $preset ) {
+					continue;
+				}
+
+				$items = array();
+				if ( isset( $preset['theme'] ) ) {
+					foreach ( $preset['theme'] as $item ) {
+						$slug = $item['slug'];
+						unset( $item['slug'] );
+						$items[ $slug ] = $item;
+					}
+				}
+				if ( isset( $preset['custom'] ) ) {
+					foreach ( $preset['custom'] as $item ) {
+						$slug = $item['slug'];
+						unset( $item['slug'] );
+						$items[ $slug ] = $item;
+					}
+				}
+				$flattened_preset = array();
+				foreach ( $items as $slug => $value ) {
+					$flattened_preset[] = array_merge( array( 'slug' => $slug ), $value );
+				}
+				_wp_array_set( $output, $path, $flattened_preset );
+			}
+		}
+
+		// If all of the static::APPEARANCE_TOOLS_OPT_INS are true,
+		// this code unsets them and sets 'appearanceTools' instead.
+		foreach ( $nodes as $node ) {
+			$all_opt_ins_are_set = true;
+			foreach ( static::APPEARANCE_TOOLS_OPT_INS as $opt_in_path ) {
+				$full_path = array_merge( $node['path'], $opt_in_path );
+				// Use "unset prop" as a marker instead of "null" because
+				// "null" can be a valid value for some props (e.g. blockGap).
+				$opt_in_value = _wp_array_get( $output, $full_path, 'unset prop' );
+				if ( 'unset prop' === $opt_in_value ) {
+					$all_opt_ins_are_set = false;
+					break;
+				}
+			}
+
+			if ( $all_opt_ins_are_set ) {
+				_wp_array_set( $output, array_merge( $node['path'], array( 'appearanceTools' ) ), true );
+				foreach ( static::APPEARANCE_TOOLS_OPT_INS as $opt_in_path ) {
+					$full_path = array_merge( $node['path'], $opt_in_path );
+					// Use "unset prop" as a marker instead of "null" because
+					// "null" can be a valid value for some props (e.g. blockGap).
+					$opt_in_value = _wp_array_get( $output, $full_path, 'unset prop' );
+					if ( true !== $opt_in_value ) {
+						continue;
+					}
+
+					// The following could be improved to be path independent.
+					// At the moment it relies on a couple of assumptions:
+					//
+					// - all opt-ins having a path of size 2.
+					// - there's two sources of settings: the top-level and the block-level.
+					if (
+						( 1 === count( $node['path'] ) ) &&
+						( 'settings' === $node['path'][0] )
+					) {
+						// Top-level settings.
+						unset( $output['settings'][ $opt_in_path[0] ][ $opt_in_path[1] ] );
+						if ( empty( $output['settings'][ $opt_in_path[0] ] ) ) {
+							unset( $output['settings'][ $opt_in_path[0] ] );
+						}
+					} elseif (
+						( 3 === count( $node['path'] ) ) &&
+						( 'settings' === $node['path'][0] ) &&
+						( 'blocks' === $node['path'][1] )
+					) {
+						// Block-level settings.
+						$block_name = $node['path'][2];
+						unset( $output['settings']['blocks'][ $block_name ][ $opt_in_path[0] ][ $opt_in_path[1] ] );
+						if ( empty( $output['settings']['blocks'][ $block_name ][ $opt_in_path[0] ] ) ) {
+							unset( $output['settings']['blocks'][ $block_name ][ $opt_in_path[0] ] );
+						}
+					}
+				}
+			}
+		}
+
+		wp_recursive_ksort( $output );
+
+		return $output;
 	}
 
 }

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -1689,7 +1689,7 @@ class WP_Theme_JSON {
 	 * @return boolean
 	 */
 	protected static function should_override_preset( $theme_json, $path, $override ) {
-		_deprecated_function( __METHOD__, '6.0.0' );
+		_deprecated_function( __METHOD__, '6.0.0', 'get_metadata_boolean' );
 
 		if ( is_bool( $override ) ) {
 			return $override;

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -8440,3 +8440,21 @@ function is_php_version_compatible( $required ) {
 function wp_fuzzy_number_match( $expected, $actual, $precision = 1 ) {
 	return abs( (float) $expected - (float) $actual ) <= $precision;
 }
+
+/**
+ * Sorts the keys of an array alphabetically.
+ * The array is passed by reference so it doesn't get returned
+ * which mimics the behaviour of ksort.
+ *
+ * @since 6.0.0
+ *
+ * @param array $array The array to sort, passed by reference.
+ */
+function wp_recursive_ksort( &$array ) {
+	foreach ( $array as &$value ) {
+		if ( is_array( $value ) ) {
+			wp_recursive_ksort( $value );
+		}
+	}
+	ksort( $array );
+}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-edit-site-export-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-edit-site-export-controller.php
@@ -53,15 +53,15 @@ class WP_REST_Edit_Site_Export_Controller extends WP_REST_Controller {
 	 * @return WP_Error|true True if the request has access, or WP_Error object.
 	 */
 	public function permissions_check() {
-		if ( ! current_user_can( 'edit_theme_options' ) ) {
-			return new WP_Error(
-				'rest_cannot_export_templates',
-				__( 'Sorry, you are not allowed to export templates and template parts.' ),
-				array( 'status' => rest_authorization_required_code() )
-			);
+		if ( current_user_can( 'edit_theme_options' ) ) {
+			return true;
 		}
 
-		return true;
+		return new WP_Error(
+			'rest_cannot_export_templates',
+			__( 'Sorry, you are not allowed to export templates and template parts.' ),
+			array( 'status' => rest_authorization_required_code() )
+		);
 	}
 
 	/**
@@ -82,8 +82,9 @@ class WP_REST_Edit_Site_Export_Controller extends WP_REST_Controller {
 			return $filename;
 		}
 
+		$theme_name = wp_get_theme()->get( 'TextDomain' );
 		header( 'Content-Type: application/zip' );
-		header( 'Content-Disposition: attachment; filename=edit-site-export.zip' );
+		header( 'Content-Disposition: attachment; filename=' . $theme_name . '.zip' );
 		header( 'Content-Length: ' . filesize( $filename ) );
 		flush();
 		readfile( $filename );

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -357,7 +357,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		// Open ZIP file and make sure the directories exist.
 		$zip = new ZipArchive();
 		$zip->open( $filename );
-		$has_theme_json                = $zip->locateName( 'theme.json' ) !== false;
+		$has_theme_json               = $zip->locateName( 'theme.json' ) !== false;
 		$has_block_templates_dir      = $zip->locateName( 'templates/' ) !== false;
 		$has_block_template_parts_dir = $zip->locateName( 'parts/' ) !== false;
 		$this->assertTrue( $has_theme_json, 'theme.json exists' );

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -357,10 +357,10 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		// Open ZIP file and make sure the directories exist.
 		$zip = new ZipArchive();
 		$zip->open( $filename );
-		$has_theme_dir                = $zip->locateName( 'theme/' ) !== false;
-		$has_block_templates_dir      = $zip->locateName( 'theme/templates/' ) !== false;
-		$has_block_template_parts_dir = $zip->locateName( 'theme/parts/' ) !== false;
-		$this->assertTrue( $has_theme_dir, 'theme directory exists' );
+		$has_theme_json                = $zip->locateName( 'theme.json' ) !== false;
+		$has_block_templates_dir      = $zip->locateName( 'templates/' ) !== false;
+		$has_block_template_parts_dir = $zip->locateName( 'parts/' ) !== false;
+		$this->assertTrue( $has_theme_json, 'theme.json exists' );
 		$this->assertTrue( $has_block_templates_dir, 'theme/templates directory exists' );
 		$this->assertTrue( $has_block_template_parts_dir, 'theme/parts directory exists' );
 

--- a/tests/phpunit/tests/functions.php
+++ b/tests/phpunit/tests/functions.php
@@ -2173,4 +2173,87 @@ class Tests_Functions extends WP_UnitTestCase {
 
 		$this->assertEquals( 111, wp_filesize( $file ) );
 	}
+
+	function test_wp_recursive_ksort() {
+		// Create an array to test.
+		$theme_json = array(
+			'version'  => 1,
+			'settings' => array(
+				'typography' => array(
+					'fontFamilies' => array(
+						'fontFamily' => 'DM Sans, sans-serif',
+						'slug'       => 'dm-sans',
+						'name'       => 'DM Sans',
+					),
+				),
+				'color'      => array(
+					'palette' => array(
+						array(
+							'slug'  => 'foreground',
+							'color' => '#242321',
+							'name'  => 'Foreground',
+						),
+						array(
+							'slug'  => 'background',
+							'color' => '#FCFBF8',
+							'name'  => 'Background',
+						),
+						array(
+							'slug'  => 'primary',
+							'color' => '#71706E',
+							'name'  => 'Primary',
+						),
+						array(
+							'slug'  => 'tertiary',
+							'color' => '#CFCFCF',
+							'name'  => 'Tertiary',
+						),
+					),
+				),
+			),
+		);
+
+		// Sort the array.
+		wp_recursive_ksort( $theme_json );
+
+		// Expected result.
+		$expected_theme_json = array(
+			'settings' => array(
+				'color'      => array(
+					'palette' => array(
+						array(
+							'color' => '#242321',
+							'name'  => 'Foreground',
+							'slug'  => 'foreground',
+						),
+						array(
+							'color' => '#FCFBF8',
+							'name'  => 'Background',
+							'slug'  => 'background',
+						),
+						array(
+							'color' => '#71706E',
+							'name'  => 'Primary',
+							'slug'  => 'primary',
+						),
+						array(
+							'color' => '#CFCFCF',
+							'name'  => 'Tertiary',
+							'slug'  => 'tertiary',
+						),
+					),
+				),
+				'typography' => array(
+					'fontFamilies' => array(
+						'fontFamily' => 'DM Sans, sans-serif',
+						'name'       => 'DM Sans',
+						'slug'       => 'dm-sans',
+					),
+				),
+			),
+			'version'  => 1,
+		);
+		$this->assertEquals( $theme_json, $expected_theme_json );
+	}
+
 }

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -2385,7 +2385,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 	}
 
 	function test_export_data() {
-		$theme = new WP_Theme_JSON_Gutenberg(
+		$theme = new WP_Theme_JSON(
 			array(
 				'version'  => 2,
 				'settings' => array(
@@ -2406,7 +2406,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 				),
 			)
 		);
-		$user  = new WP_Theme_JSON_Gutenberg(
+		$user  = new WP_Theme_JSON(
 			array(
 				'version'  => 2,
 				'settings' => array(
@@ -2460,7 +2460,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 	}
 
 	function test_export_data_deals_with_empty_user_data() {
-		$theme = new WP_Theme_JSON_Gutenberg(
+		$theme = new WP_Theme_JSON(
 			array(
 				'version'  => 2,
 				'settings' => array(
@@ -2507,7 +2507,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 	}
 
 	function test_export_data_deals_with_empty_theme_data() {
-		$user = new WP_Theme_JSON_Gutenberg(
+		$user = new WP_Theme_JSON(
 			array(
 				'version'  => 2,
 				'settings' => array(
@@ -2555,7 +2555,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 	}
 
 	function test_export_data_deals_with_empty_data() {
-		$theme_v2    = new WP_Theme_JSON_Gutenberg(
+		$theme_v2    = new WP_Theme_JSON(
 			array(
 				'version' => 2,
 			),
@@ -2565,7 +2565,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 		$expected_v2 = array( 'version' => 2 );
 		$this->assertEqualSetsWithIndex( $expected_v2, $actual_v2 );
 
-		$theme_v1    = new WP_Theme_JSON_Gutenberg(
+		$theme_v1    = new WP_Theme_JSON(
 			array(
 				'version' => 1,
 			),
@@ -2577,7 +2577,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 	}
 
 	function test_export_data_sets_appearance_tools() {
-		$theme = new WP_Theme_JSON_Gutenberg(
+		$theme = new WP_Theme_JSON(
 			array(
 				'version'  => 2,
 				'settings' => array(

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -2384,4 +2384,227 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 		$this->assertEqualSetsWithIndex( $expected, $actual );
 	}
 
+	function test_export_data() {
+		$theme = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => 2,
+				'settings' => array(
+					'color' => array(
+						'palette' => array(
+							array(
+								'slug'  => 'white',
+								'color' => 'white',
+								'label' => 'White',
+							),
+							array(
+								'slug'  => 'black',
+								'color' => 'black',
+								'label' => 'Black',
+							),
+						),
+					),
+				),
+			)
+		);
+		$user  = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => 2,
+				'settings' => array(
+					'color' => array(
+						'palette' => array(
+							array(
+								'slug'  => 'white',
+								'color' => '#fff',
+								'label' => 'User White',
+							),
+							array(
+								'slug'  => 'hotpink',
+								'color' => 'hotpink',
+								'label' => 'hotpink',
+							),
+						),
+					),
+				),
+			),
+			'custom'
+		);
+
+		$theme->merge( $user );
+		$actual   = $theme->get_data();
+		$expected = array(
+			'version'  => 2,
+			'settings' => array(
+				'color' => array(
+					'palette' => array(
+						array(
+							'slug'  => 'white',
+							'color' => '#fff',
+							'label' => 'User White',
+						),
+						array(
+							'slug'  => 'black',
+							'color' => 'black',
+							'label' => 'Black',
+						),
+						array(
+							'slug'  => 'hotpink',
+							'color' => 'hotpink',
+							'label' => 'hotpink',
+						),
+					),
+				),
+			),
+		);
+
+		$this->assertEqualSetsWithIndex( $expected, $actual );
+	}
+
+	function test_export_data_deals_with_empty_user_data() {
+		$theme = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => 2,
+				'settings' => array(
+					'color' => array(
+						'palette' => array(
+							array(
+								'slug'  => 'white',
+								'color' => 'white',
+								'label' => 'White',
+							),
+							array(
+								'slug'  => 'black',
+								'color' => 'black',
+								'label' => 'Black',
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$actual   = $theme->get_data();
+		$expected = array(
+			'version'  => 2,
+			'settings' => array(
+				'color' => array(
+					'palette' => array(
+						array(
+							'slug'  => 'white',
+							'color' => 'white',
+							'label' => 'White',
+						),
+						array(
+							'slug'  => 'black',
+							'color' => 'black',
+							'label' => 'Black',
+						),
+					),
+				),
+			),
+		);
+
+		$this->assertEqualSetsWithIndex( $expected, $actual );
+	}
+
+	function test_export_data_deals_with_empty_theme_data() {
+		$user = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => 2,
+				'settings' => array(
+					'color' => array(
+						'palette' => array(
+							array(
+								'slug'  => 'white',
+								'color' => '#fff',
+								'label' => 'User White',
+							),
+							array(
+								'slug'  => 'hotpink',
+								'color' => 'hotpink',
+								'label' => 'hotpink',
+							),
+						),
+					),
+				),
+			),
+			'custom'
+		);
+
+		$actual   = $user->get_data();
+		$expected = array(
+			'version'  => 2,
+			'settings' => array(
+				'color' => array(
+					'palette' => array(
+						array(
+							'slug'  => 'white',
+							'color' => '#fff',
+							'label' => 'User White',
+						),
+						array(
+							'slug'  => 'hotpink',
+							'color' => 'hotpink',
+							'label' => 'hotpink',
+						),
+					),
+				),
+			),
+		);
+
+		$this->assertEqualSetsWithIndex( $expected, $actual );
+	}
+
+	function test_export_data_deals_with_empty_data() {
+		$theme_v2    = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => 2,
+			),
+			'theme'
+		);
+		$actual_v2   = $theme_v2->get_data();
+		$expected_v2 = array( 'version' => 2 );
+		$this->assertEqualSetsWithIndex( $expected_v2, $actual_v2 );
+
+		$theme_v1    = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => 1,
+			),
+			'theme'
+		);
+		$actual_v1   = $theme_v1->get_data();
+		$expected_v1 = array( 'version' => 2 );
+		$this->assertEqualSetsWithIndex( $expected_v1, $actual_v1 );
+	}
+
+	function test_export_data_sets_appearance_tools() {
+		$theme = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => 2,
+				'settings' => array(
+					'appearanceTools' => true,
+					'blocks'          => array(
+						'core/paragraph' => array(
+							'appearanceTools' => true,
+						),
+					),
+				),
+			)
+		);
+
+		$actual   = $theme->get_data();
+		$expected = array(
+			'version'  => 2,
+			'settings' => array(
+				'appearanceTools' => true,
+				'blocks'          => array(
+					'core/paragraph' => array(
+						'appearanceTools' => true,
+					),
+				),
+			),
+		);
+
+		$this->assertEqualSetsWithIndex( $expected, $actual );
+	}
+
 }

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -423,9 +423,9 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 			)
 		);
 
-		$expected = 'body { margin: 0; }body{--wp--style--block-gap: 1em;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-site-blocks > * { margin-top: 0; margin-bottom: 0; }.wp-site-blocks > * + * { margin-top: var( --wp--style--block-gap ); }';
-		$this->assertSame( $expected, $theme_json->get_stylesheet() );
-		$this->assertSame( $expected, $theme_json->get_stylesheet( array( 'styles' ) ) );
+		$expected = 'body { margin: 0; }body{--wp--style--block-gap: 1em;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-site-blocks > * { margin-block-start: 0; margin-block-end: 0; }.wp-site-blocks > * + * { margin-block-start: var( --wp--style--block-gap ); }';
+		$this->assertEquals( $expected, $theme_json->get_stylesheet() );
+		$this->assertEquals( $expected, $theme_json->get_stylesheet( array( 'styles' ) ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -553,13 +553,13 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 		);
 
 		$variables = 'body{--wp--preset--color--grey: grey;--wp--preset--font-family--small: 14px;--wp--preset--font-family--big: 41px;}.wp-block-group{--wp--custom--base-font: 16;--wp--custom--line-height--small: 1.2;--wp--custom--line-height--medium: 1.4;--wp--custom--line-height--large: 1.8;}';
-		$styles    = 'body { margin: 0; }body{color: var(--wp--preset--color--grey);}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-site-blocks > * { margin-top: 0; margin-bottom: 0; }.wp-site-blocks > * + * { margin-top: var( --wp--style--block-gap ); }a{background-color: #333;color: #111;}.wp-block-group{border-radius: 10px;padding: 24px;}.wp-block-group a{color: #111;}h1,h2,h3,h4,h5,h6{color: #123456;}h1 a,h2 a,h3 a,h4 a,h5 a,h6 a{background-color: #333;color: #111;font-size: 60px;}.wp-block-post-date{color: #123456;}.wp-block-post-date a{background-color: #777;color: #555;}.wp-block-image{border-top-left-radius: 10px;border-bottom-right-radius: 1em;margin-bottom: 30px;}';
+		$styles    = 'body { margin: 0; }body{color: var(--wp--preset--color--grey);}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-site-blocks > * { margin-block-start: 0; margin-block-end: 0; }.wp-site-blocks > * + * { margin-block-start: var( --wp--style--block-gap ); }a{background-color: #333;color: #111;}.wp-block-group{border-radius: 10px;padding: 24px;}.wp-block-group a{color: #111;}h1,h2,h3,h4,h5,h6{color: #123456;}h1 a,h2 a,h3 a,h4 a,h5 a,h6 a{background-color: #333;color: #111;font-size: 60px;}.wp-block-post-date{color: #123456;}.wp-block-post-date a{background-color: #777;color: #555;}.wp-block-image{border-top-left-radius: 10px;border-bottom-right-radius: 1em;margin-bottom: 30px;}';
 		$presets   = '.has-grey-color{color: var(--wp--preset--color--grey) !important;}.has-grey-background-color{background-color: var(--wp--preset--color--grey) !important;}.has-grey-border-color{border-color: var(--wp--preset--color--grey) !important;}.has-small-font-family{font-family: var(--wp--preset--font-family--small) !important;}.has-big-font-family{font-family: var(--wp--preset--font-family--big) !important;}';
 		$all       = $variables . $styles . $presets;
-		$this->assertSame( $all, $theme_json->get_stylesheet() );
-		$this->assertSame( $styles, $theme_json->get_stylesheet( array( 'styles' ) ) );
-		$this->assertSame( $presets, $theme_json->get_stylesheet( array( 'presets' ) ) );
-		$this->assertSame( $variables, $theme_json->get_stylesheet( array( 'variables' ) ) );
+		$this->assertEquals( $all, $theme_json->get_stylesheet() );
+		$this->assertEquals( $styles, $theme_json->get_stylesheet( array( 'styles' ) ) );
+		$this->assertEquals( $presets, $theme_json->get_stylesheet( array( 'presets' ) ) );
+		$this->assertEquals( $variables, $theme_json->get_stylesheet( array( 'variables' ) ) );
 	}
 
 	/**


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/39889

This bring across changes to theme export functionality, and related code, and tests.

Includes also changes from https://github.com/WordPress/gutenberg/pull/38132.

Trac ticket: https://core.trac.wordpress.org/ticket/55505