### PR TITLE
Prevent styles from being added in the site editor

### DIFF
--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -379,36 +379,37 @@ function get_block_editor_settings( array $custom_settings, $block_editor_contex
 	);
 
 	$global_styles = array();
-	$presets       = array(
-		array(
-			'css'            => 'variables',
-			'__unstableType' => 'presets',
-		),
-		array(
-			'css'            => 'presets',
-			'__unstableType' => 'presets',
-		),
-	);
-	foreach ( $presets as $preset_style ) {
-		$actual_css = wp_get_global_stylesheet( array( $preset_style['css'] ) );
-		if ( '' !== $actual_css ) {
-			$preset_style['css'] = $actual_css;
-			$global_styles[]     = $preset_style;
-		}
-	}
-
-	if ( WP_Theme_JSON_Resolver::theme_has_support() ) {
-		$block_classes = array(
-			'css'            => 'styles',
-			'__unstableType' => 'theme',
+	if ( ! empty( $block_editor_context->post ) ) {
+		$presets       = array(
+			array(
+				'css'            => 'variables',
+				'__unstableType' => 'presets',
+			),
+			array(
+				'css'            => 'presets',
+				'__unstableType' => 'presets',
+			),
 		);
-		$actual_css    = wp_get_global_stylesheet( array( $block_classes['css'] ) );
-		if ( '' !== $actual_css ) {
-			$block_classes['css'] = $actual_css;
-			$global_styles[]      = $block_classes;
+		foreach ( $presets as $preset_style ) {
+			$actual_css = wp_get_global_stylesheet( array( $preset_style['css'] ) );
+			if ( '' !== $actual_css ) {
+				$preset_style['css'] = $actual_css;
+				$global_styles[]     = $preset_style;
+			}
+		}
+
+		if ( WP_Theme_JSON_Resolver::theme_has_support() ) {
+			$block_classes = array(
+				'css'            => 'styles',
+				'__unstableType' => 'theme',
+			);
+			$actual_css    = wp_get_global_stylesheet( array( $block_classes['css'] ) );
+			if ( '' !== $actual_css ) {
+				$block_classes['css'] = $actual_css;
+				$global_styles[]      = $block_classes;
+			}
 		}
 	}
-
 	$editor_settings['styles'] = array_merge( $global_styles, get_block_editor_theme_styles() );
 
 	$editor_settings['__experimentalFeatures'] = wp_get_global_settings();

--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -381,12 +381,14 @@ function get_block_editor_settings( array $custom_settings, $block_editor_contex
 	$global_styles = array();
 	$presets       = array(
 		array(
-			'css'            => 'variables',
-			'__unstableType' => 'presets',
+			'css'              => 'variables',
+			'__unstableType'   => 'presets',
+			'__unstableSource' => 'theme_json',
 		),
 		array(
-			'css'            => 'presets',
-			'__unstableType' => 'presets',
+			'css'              => 'presets',
+			'__unstableType'   => 'presets',
+			'__unstableSource' => 'theme_json',
 		),
 	);
 	foreach ( $presets as $preset_style ) {
@@ -399,8 +401,9 @@ function get_block_editor_settings( array $custom_settings, $block_editor_contex
 
 	if ( WP_Theme_JSON_Resolver::theme_has_support() ) {
 		$block_classes = array(
-			'css'            => 'styles',
-			'__unstableType' => 'theme',
+			'css'              => 'styles',
+			'__unstableType'   => 'styles',
+			'__unstableSource' => 'theme_json',
 		);
 		$actual_css    = wp_get_global_stylesheet( array( $block_classes['css'] ) );
 		if ( '' !== $actual_css ) {
@@ -626,17 +629,19 @@ function get_block_editor_theme_styles() {
 				$response = wp_remote_get( $style );
 				if ( ! is_wp_error( $response ) ) {
 					$styles[] = array(
-						'css'            => wp_remote_retrieve_body( $response ),
-						'__unstableType' => 'theme',
+						'css'              => wp_remote_retrieve_body( $response ),
+						'__unstableType'   => 'styles',
+						'__unstableSource' => 'css',
 					);
 				}
 			} else {
 				$file = get_theme_file_path( $style );
 				if ( is_file( $file ) ) {
 					$styles[] = array(
-						'css'            => file_get_contents( $file ),
-						'baseURL'        => get_theme_file_uri( $style ),
-						'__unstableType' => 'theme',
+						'css'              => file_get_contents( $file ),
+						'baseURL'          => get_theme_file_uri( $style ),
+						'__unstableType'   => 'styles',
+						'__unstableSource' => 'css',
 					);
 				}
 			}

--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -381,14 +381,14 @@ function get_block_editor_settings( array $custom_settings, $block_editor_contex
 	$global_styles = array();
 	$presets       = array(
 		array(
-			'css'              => 'variables',
-			'__unstableType'   => 'presets',
-			'__unstableSource' => 'theme_json',
+			'css'            => 'variables',
+			'__unstableType' => 'presets',
+			'isGlobalStyles' => true,
 		),
 		array(
-			'css'              => 'presets',
-			'__unstableType'   => 'presets',
-			'__unstableSource' => 'theme_json',
+			'css'            => 'presets',
+			'__unstableType' => 'presets',
+			'isGlobalStyles' => true,
 		),
 	);
 	foreach ( $presets as $preset_style ) {
@@ -401,9 +401,9 @@ function get_block_editor_settings( array $custom_settings, $block_editor_contex
 
 	if ( WP_Theme_JSON_Resolver::theme_has_support() ) {
 		$block_classes = array(
-			'css'              => 'styles',
-			'__unstableType'   => 'styles',
-			'__unstableSource' => 'theme_json',
+			'css'            => 'styles',
+			'__unstableType' => 'theme',
+			'isGlobalStyles' => true,
 		);
 		$actual_css    = wp_get_global_stylesheet( array( $block_classes['css'] ) );
 		if ( '' !== $actual_css ) {
@@ -629,19 +629,19 @@ function get_block_editor_theme_styles() {
 				$response = wp_remote_get( $style );
 				if ( ! is_wp_error( $response ) ) {
 					$styles[] = array(
-						'css'              => wp_remote_retrieve_body( $response ),
-						'__unstableType'   => 'styles',
-						'__unstableSource' => 'css',
+						'css'            => wp_remote_retrieve_body( $response ),
+						'__unstableType' => 'theme',
+						'isGlobalStyles' => false,
 					);
 				}
 			} else {
 				$file = get_theme_file_path( $style );
 				if ( is_file( $file ) ) {
 					$styles[] = array(
-						'css'              => file_get_contents( $file ),
-						'baseURL'          => get_theme_file_uri( $style ),
-						'__unstableType'   => 'styles',
-						'__unstableSource' => 'css',
+						'css'            => file_get_contents( $file ),
+						'baseURL'        => get_theme_file_uri( $style ),
+						'__unstableType' => 'theme',
+						'isGlobalStyles' => false,
 					);
 				}
 			}

--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -379,37 +379,36 @@ function get_block_editor_settings( array $custom_settings, $block_editor_contex
 	);
 
 	$global_styles = array();
-	if ( ! empty( $block_editor_context->post ) ) {
-		$presets       = array(
-			array(
-				'css'            => 'variables',
-				'__unstableType' => 'presets',
-			),
-			array(
-				'css'            => 'presets',
-				'__unstableType' => 'presets',
-			),
-		);
-		foreach ( $presets as $preset_style ) {
-			$actual_css = wp_get_global_stylesheet( array( $preset_style['css'] ) );
-			if ( '' !== $actual_css ) {
-				$preset_style['css'] = $actual_css;
-				$global_styles[]     = $preset_style;
-			}
-		}
-
-		if ( WP_Theme_JSON_Resolver::theme_has_support() ) {
-			$block_classes = array(
-				'css'            => 'styles',
-				'__unstableType' => 'theme',
-			);
-			$actual_css    = wp_get_global_stylesheet( array( $block_classes['css'] ) );
-			if ( '' !== $actual_css ) {
-				$block_classes['css'] = $actual_css;
-				$global_styles[]      = $block_classes;
-			}
+	$presets       = array(
+		array(
+			'css'            => 'variables',
+			'__unstableType' => 'presets',
+		),
+		array(
+			'css'            => 'presets',
+			'__unstableType' => 'presets',
+		),
+	);
+	foreach ( $presets as $preset_style ) {
+		$actual_css = wp_get_global_stylesheet( array( $preset_style['css'] ) );
+		if ( '' !== $actual_css ) {
+			$preset_style['css'] = $actual_css;
+			$global_styles[]     = $preset_style;
 		}
 	}
+
+	if ( WP_Theme_JSON_Resolver::theme_has_support() ) {
+		$block_classes = array(
+			'css'            => 'styles',
+			'__unstableType' => 'theme',
+		);
+		$actual_css    = wp_get_global_stylesheet( array( $block_classes['css'] ) );
+		if ( '' !== $actual_css ) {
+			$block_classes['css'] = $actual_css;
+			$global_styles[]      = $block_classes;
+		}
+	}
+
 	$editor_settings['styles'] = array_merge( $global_styles, get_block_editor_theme_styles() );
 
 	$editor_settings['__experimentalFeatures'] = wp_get_global_settings();


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/55567

## What?

This PR fixes a bug by whiche the global styles are enqueued twice in the site editor.

## Why?

The site editor, unlike other editors, generates the styles coming from global styles (presets, styles) dynamically in the client. This is because the user can modify any value that we need to consolidate (merge core, theme, and user style preferences). We don't want to have the global styles twice, as it introduces subtle bugs.

## How?

This PR tags styles to be removed with the `isGlobalStyles: true` flag.

The styles sent by the server to the client end up in the `block-editor` store, to be found at `settings.styles`. By doing this, we leverage the existing mechanism in the site editor to recalculate the global styles upon user changes.

These are the styles before this PR:

![Captura de ecrã de 2022-04-12 14-28-20](https://user-images.githubusercontent.com/583546/162963190-c96f67e7-c8ca-4dd2-8c7b-579781b72bc5.png)

And after this PR:

![Captura de ecrã de 2022-04-12 14-25-46](https://user-images.githubusercontent.com/583546/162963163-416ed0fa-5e30-45f6-b45c-5c6f114bc31e.png)

Note how the first 3 styles are no longer in the store.

## Testing Instructions

Use this branch and verify that the block editor store has only 3 styles after this PR (would have 6 before).

Do some random manual test: add some block and set some preset values (colors, font sizes) as block styles and make sure they still work. Set some global styles and verify they work.
