### PR TITLE
Backport functions required by Comment Query Loop and related blocks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7750,7 +7750,7 @@
 		},
 		"browserify-aes": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+			"resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
 			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
 			"dev": true,
 			"requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7750,7 +7750,7 @@
 		},
 		"browserify-aes": {
 			"version": "1.2.0",
-			"resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
 			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
 			"dev": true,
 			"requires": {

--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -396,6 +396,23 @@ function get_block_editor_settings( array $custom_settings, $block_editor_contex
 
 	$editor_settings['localAutosaveInterval'] = 15;
 
+	$editor_settings['__experimentalDiscussionSettings'] = array(
+		'commentOrder'        => get_option( 'comment_order' ),
+		'commentsPerPage'     => get_option( 'comments_per_page' ),
+		'defaultCommentsPage' => get_option( 'default_comments_page' ),
+		'pageComments'        => get_option( 'page_comments' ),
+		'threadComments'      => get_option( 'thread_comments' ),
+		'threadCommentsDepth' => get_option( 'thread_comments_depth' ),
+		'avatarURL'           => get_avatar_url(
+			'',
+			array(
+				'size'          => 96,
+				'force_default' => true,
+				'default'       => get_option( 'avatar_default' ),
+			)
+		),
+	);
+
 	/**
 	 * Filters the settings to pass to the block editor for all editor type.
 	 *

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1358,3 +1358,153 @@ function _wp_multiple_block_styles( $metadata ) {
 	return $metadata;
 }
 add_filter( 'block_type_metadata', '_wp_multiple_block_styles' );
+
+/**
+ * Helper function that constructs a comment query vars array from the passed
+ * block properties.
+ *
+ * It's used with the Comment Query Loop inner blocks.
+ *
+ * @since 6.0.0
+ *
+ * @param WP_Block $block Block instance.
+ *
+ * @return array Returns the comment query parameters to use with the
+ * WP_Comment_Query constructor.
+ */
+function build_comment_query_vars_from_block( $block ) {
+
+	$comment_args = array(
+		'orderby'                   => 'comment_date_gmt',
+		'order'                     => 'ASC',
+		'status'                    => 'approve',
+		'no_found_rows'             => false,
+		'update_comment_meta_cache' => false, // We lazy-load comment meta for performance.
+	);
+
+	if ( ! empty( $block->context['postId'] ) ) {
+		$comment_args['post_id'] = (int) $block->context['postId'];
+	}
+
+	if ( get_option( 'thread_comments' ) ) {
+		$comment_args['hierarchical'] = 'threaded';
+	} else {
+		$comment_args['hierarchical'] = false;
+	}
+
+	$per_page     = get_option( 'comments_per_page' );
+	$default_page = get_option( 'default_comments_page' );
+
+	if ( $per_page > 0 ) {
+		$comment_args['number'] = $per_page;
+
+		$page = (int) get_query_var( 'cpage' );
+		if ( $page ) {
+			$comment_args['paged'] = $page;
+		} elseif ( 'oldest' === $default_page ) {
+			$comment_args['paged'] = 1;
+		} elseif ( 'newest' === $default_page ) {
+			$comment_args['paged'] = (int) ( new WP_Comment_Query( $comment_args ) )->max_num_pages;
+		}
+		// Set the `cpage` query var to ensure the previous and next pagination links are correct
+		// when inheriting the Discussion Settings.
+		if ( 0 === $page && isset( $comment_args['paged'] ) && $comment_args['paged'] > 0 ) {
+			set_query_var( 'cpage', $comment_args['paged'] );
+		}
+	}
+
+	return $comment_args;
+}
+
+/**
+ * Helper function that returns the proper pagination arrow html for
+ * `CommentsPaginationNext` and `CommentsPaginationPrevious` blocks based on the
+ * provided `paginationArrow` from `CommentsPagination` context.
+ *
+ * It's used in CommentsPaginationNext and CommentsPaginationPrevious blocks.
+ *
+ * @since 6.0.0
+ *
+ * @param WP_Block $block           Block instance.
+ * @param string   $pagination_type Type of the arrow we will be rendering.
+ *                                  Default 'next'. Accepts 'next' or 'previous'.
+ *
+ * @return string|null Returns the constructed WP_Query arguments.
+ */
+function get_comments_pagination_arrow( $block, $pagination_type = 'next' ) {
+	$arrow_map = array(
+		'none'    => '',
+		'arrow'   => array(
+			'next'     => '→',
+			'previous' => '←',
+		),
+		'chevron' => array(
+			'next'     => '»',
+			'previous' => '«',
+		),
+	);
+	if ( ! empty( $block->context['comments/paginationArrow'] ) && ! empty( $arrow_map[ $block->context['comments/paginationArrow'] ][ $pagination_type ] ) ) {
+		$arrow_attribute = $block->context['comments/paginationArrow'];
+		$arrow           = $arrow_map[ $block->context['comments/paginationArrow'] ][ $pagination_type ];
+		$arrow_classes   = "wp-block-comments-pagination-$pagination_type-arrow is-arrow-$arrow_attribute";
+		return "<span class='$arrow_classes'>$arrow</span>";
+	}
+	return null;
+}
+
+/**
+ * Workaround for getting discussion settings as block editor settings
+ * so any user can access to them without needing to be an admin.
+ *
+ * @since 6.0.0
+ *
+ * @param array $settings Default editor settings.
+ *
+ * @return array Filtered editor settings.
+ */
+function extend_block_editor_settings_with_discussion_settings( $settings ) {
+
+	$settings['__experimentalDiscussionSettings'] = array(
+		'commentOrder'        => get_option( 'comment_order' ),
+		'commentsPerPage'     => get_option( 'comments_per_page' ),
+		'defaultCommentsPage' => get_option( 'default_comments_page' ),
+		'pageComments'        => get_option( 'page_comments' ),
+		'threadComments'      => get_option( 'thread_comments' ),
+		'threadCommentsDepth' => get_option( 'thread_comments_depth' ),
+		'avatarURL'           => get_avatar_url(
+			'',
+			array(
+				'size'          => 96,
+				'force_default' => true,
+				'default'       => get_option( 'avatar_default' ),
+			)
+		),
+	);
+
+	return $settings;
+}
+add_filter( 'block_editor_settings_all', 'extend_block_editor_settings_with_discussion_settings' );
+
+/**
+ * Mark the `children` attr of comments as embeddable so they can be included in
+ * REST API responses without additional requests.
+ *
+ * @since 6.0.0
+ *
+ * @return void
+ */
+function gutenberg_rest_comment_set_children_as_embeddable() {
+	add_filter(
+		'rest_prepare_comment',
+		function ( $response ) {
+			$links = $response->get_links();
+			if ( isset( $links['children'] ) ) {
+				$href = $links['children'][0]['href'];
+				$response->remove_link( 'children', $href );
+				$response->add_link( 'children', $href, array( 'embeddable' => true ) );
+			}
+			return $response;
+		}
+	);
+}
+add_action( 'rest_api_init', 'gutenberg_rest_comment_set_children_as_embeddable' );

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1451,27 +1451,3 @@ function get_comments_pagination_arrow( $block, $pagination_type = 'next' ) {
 	}
 	return null;
 }
-
-/**
- * Mark the `children` attr of comments as embeddable so they can be included in
- * REST API responses without additional requests.
- *
- * @since 6.0.0
- *
- * @return void
- */
-function gutenberg_rest_comment_set_children_as_embeddable() {
-	add_filter(
-		'rest_prepare_comment',
-		function ( $response ) {
-			$links = $response->get_links();
-			if ( isset( $links['children'] ) ) {
-				$href = $links['children'][0]['href'];
-				$response->remove_link( 'children', $href );
-				$response->add_link( 'children', $href, array( 'embeddable' => true ) );
-			}
-			return $response;
-		}
-	);
-}
-add_action( 'rest_api_init', 'gutenberg_rest_comment_set_children_as_embeddable' );

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1453,39 +1453,6 @@ function get_comments_pagination_arrow( $block, $pagination_type = 'next' ) {
 }
 
 /**
- * Workaround for getting discussion settings as block editor settings
- * so any user can access to them without needing to be an admin.
- *
- * @since 6.0.0
- *
- * @param array $settings Default editor settings.
- *
- * @return array Filtered editor settings.
- */
-function extend_block_editor_settings_with_discussion_settings( $settings ) {
-
-	$settings['__experimentalDiscussionSettings'] = array(
-		'commentOrder'        => get_option( 'comment_order' ),
-		'commentsPerPage'     => get_option( 'comments_per_page' ),
-		'defaultCommentsPage' => get_option( 'default_comments_page' ),
-		'pageComments'        => get_option( 'page_comments' ),
-		'threadComments'      => get_option( 'thread_comments' ),
-		'threadCommentsDepth' => get_option( 'thread_comments_depth' ),
-		'avatarURL'           => get_avatar_url(
-			'',
-			array(
-				'size'          => 96,
-				'force_default' => true,
-				'default'       => get_option( 'avatar_default' ),
-			)
-		),
-	);
-
-	return $settings;
-}
-add_filter( 'block_editor_settings_all', 'extend_block_editor_settings_with_discussion_settings' );
-
-/**
  * Mark the `children` attr of comments as embeddable so they can be included in
  * REST API responses without additional requests.
  *

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
@@ -1196,7 +1196,8 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			$rest_url = add_query_arg( $args, rest_url( $this->namespace . '/' . $this->rest_base ) );
 
 			$links['children'] = array(
-				'href' => $rest_url,
+				'href'     => $rest_url,
+				'embedded' => true,
 			);
 		}
 

--- a/tests/phpunit/tests/block-library/commentTemplate.php
+++ b/tests/phpunit/tests/block-library/commentTemplate.php
@@ -20,8 +20,8 @@ class Test_Block_Library_CommentTemplate extends WP_UnitTestCase {
 	private static $comment_ids;
 	private static $per_page = 5;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		update_option( 'page_comments', true );
 		update_option( 'comments_per_page', self::$per_page );

--- a/tests/phpunit/tests/block-library/commentTemplate.php
+++ b/tests/phpunit/tests/block-library/commentTemplate.php
@@ -117,7 +117,7 @@ class Test_Block_Library_CommentTemplate extends WP_UnitTestCase {
 		// Here we use the function prefixed with 'gutenberg_*' because it's added
 		// in the build step.
 		$this->assertEquals(
-			gutenberg_render_block_core_comment_template( null, null, $block ),
+			render_block_core_comment_template( null, null, $block ),
 			'<ol ><li><div class="wp-block-comment-author-name">Test</div><div class="wp-block-comment-content">Hello world</div></li></ol>'
 		);
 	}
@@ -164,7 +164,7 @@ class Test_Block_Library_CommentTemplate extends WP_UnitTestCase {
 		);
 
 		$this->assertEquals(
-			gutenberg_render_block_core_comment_template( null, null, $block ),
+			render_block_core_comment_template( null, null, $block ),
 			'<ol ><li><div class="wp-block-comment-author-name">Test</div><div class="wp-block-comment-content">Hello world</div><ol><li><div class="wp-block-comment-author-name">Test</div><div class="wp-block-comment-content">Hello world</div><ol><li><div class="wp-block-comment-author-name">Test</div><div class="wp-block-comment-content">Hello world</div></li></ol></li></ol></li></ol>'
 		);
 	}

--- a/tests/phpunit/tests/block-library/commentTemplate.php
+++ b/tests/phpunit/tests/block-library/commentTemplate.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ * Comment Template block tests
+ *
+ * @package WordPress
+ * @subpackage Block Library
+ * @since 6.0.0
+ */
+
+/**
+ * Tests for the Comment Template block.
+ *
+ * @since 6.0.0
+ *
+ * @group block-library
+ */
+class Test_Block_Library_CommentTemplate extends WP_UnitTestCase {
+
+	private static $custom_post;
+	private static $comment_ids;
+	private static $per_page = 5;
+
+	public function setUp() {
+		parent::setUp();
+
+		update_option( 'page_comments', true );
+		update_option( 'comments_per_page', self::$per_page );
+		update_option( 'comment_order', 'ASC' );
+
+		self::$custom_post = self::factory()->post->create_and_get(
+			array(
+				'post_type'    => 'dogs',
+				'post_status'  => 'publish',
+				'post_name'    => 'metaldog',
+				'post_title'   => 'Metal Dog',
+				'post_content' => 'Metal Dog content',
+				'post_excerpt' => 'Metal Dog',
+			)
+		);
+
+		self::$comment_ids = self::factory()->comment->create_post_comments(
+			self::$custom_post->ID,
+			1,
+			array(
+				'comment_author'       => 'Test',
+				'comment_author_email' => 'test@example.org',
+				'comment_content'      => 'Hello world',
+			)
+		);
+	}
+
+	function test_build_comment_query_vars_from_block_with_context() {
+		$parsed_blocks = parse_blocks(
+			'<!-- wp:comment-template --><!-- wp:comment-author-name /--><!-- wp:comment-content /--><!-- /wp:comment-template -->'
+		);
+
+		$block = new WP_Block(
+			$parsed_blocks[0],
+			array(
+				'postId' => self::$custom_post->ID,
+			)
+		);
+
+		$this->assertEquals(
+			build_comment_query_vars_from_block( $block ),
+			array(
+				'orderby'                   => 'comment_date_gmt',
+				'order'                     => 'ASC',
+				'status'                    => 'approve',
+				'no_found_rows'             => false,
+				'update_comment_meta_cache' => false,
+				'post_id'                   => self::$custom_post->ID,
+				'hierarchical'              => 'threaded',
+				'number'                    => 5,
+				'paged'                     => 1,
+			)
+		);
+	}
+
+	function test_build_comment_query_vars_from_block_no_context() {
+		$parsed_blocks = parse_blocks(
+			'<!-- wp:comment-template --><!-- wp:comment-author-name /--><!-- wp:comment-content /--><!-- /wp:comment-template -->'
+		);
+
+		$block = new WP_Block( $parsed_blocks[0] );
+
+		$this->assertEquals(
+			build_comment_query_vars_from_block( $block ),
+			array(
+				'orderby'                   => 'comment_date_gmt',
+				'order'                     => 'ASC',
+				'status'                    => 'approve',
+				'no_found_rows'             => false,
+				'update_comment_meta_cache' => false,
+				'hierarchical'              => 'threaded',
+				'number'                    => 5,
+				'paged'                     => 1,
+			)
+		);
+	}
+
+	/**
+	 * Test rendering a single comment
+	 */
+	function test_rendering_comment_template() {
+		$parsed_blocks = parse_blocks(
+			'<!-- wp:comment-template --><!-- wp:comment-author-name /--><!-- wp:comment-content /--><!-- /wp:comment-template -->'
+		);
+
+		$block = new WP_Block(
+			$parsed_blocks[0],
+			array(
+				'postId' => self::$custom_post->ID,
+			)
+		);
+
+		// Here we use the function prefixed with 'gutenberg_*' because it's added
+		// in the build step.
+		$this->assertEquals(
+			gutenberg_render_block_core_comment_template( null, null, $block ),
+			'<ol ><li><div class="wp-block-comment-author-name">Test</div><div class="wp-block-comment-content">Hello world</div></li></ol>'
+		);
+	}
+
+	/**
+	 * Test rendering 3 nested comments:
+	 *
+	 * └─ comment 1
+	 *    └─ comment 2
+	 *       └─ comment 3
+	 */
+	function test_rendering_comment_template_nested() {
+		$nested_comment_ids = self::factory()->comment->create_post_comments(
+			self::$custom_post->ID,
+			1,
+			array(
+				'comment_parent'       => self::$comment_ids[0],
+				'comment_author'       => 'Test',
+				'comment_author_email' => 'test@example.org',
+				'comment_content'      => 'Hello world',
+			)
+		);
+
+		self::factory()->comment->create_post_comments(
+			self::$custom_post->ID,
+			1,
+			array(
+				'comment_parent'       => $nested_comment_ids[0],
+				'comment_author'       => 'Test',
+				'comment_author_email' => 'test@example.org',
+				'comment_content'      => 'Hello world',
+			)
+		);
+
+		$parsed_blocks = parse_blocks(
+			'<!-- wp:comment-template --><!-- wp:comment-author-name /--><!-- wp:comment-content /--><!-- /wp:comment-template -->'
+		);
+
+		$block = new WP_Block(
+			$parsed_blocks[0],
+			array(
+				'postId' => self::$custom_post->ID,
+			)
+		);
+
+		$this->assertEquals(
+			gutenberg_render_block_core_comment_template( null, null, $block ),
+			'<ol ><li><div class="wp-block-comment-author-name">Test</div><div class="wp-block-comment-content">Hello world</div><ol><li><div class="wp-block-comment-author-name">Test</div><div class="wp-block-comment-content">Hello world</div><ol><li><div class="wp-block-comment-author-name">Test</div><div class="wp-block-comment-content">Hello world</div></li></ol></li></ol></li></ol>'
+		);
+	}
+	/**
+	 * Test that both "Older Comments" and "Newer Comments" are displayed in the correct order
+	 * inside the Comment Query Loop when we enable pagination on Discussion Settings.
+	 * In order to do that, it should exist a query var 'cpage' set with the $comment_args['paged'] value.
+	 */
+	function test_build_comment_query_vars_from_block_sets_cpage_var() {
+
+		// This could be any number, we set a fixed one instead of a random for better performance.
+		$comment_query_max_num_pages = 5;
+		// We substract 1 because we created 1 comment at the beggining.
+		$post_comments_numbers = ( self::$per_page * $comment_query_max_num_pages ) - 1;
+		self::factory()->comment->create_post_comments(
+			self::$custom_post->ID,
+			$post_comments_numbers,
+			array(
+				'comment_author'       => 'Test',
+				'comment_author_email' => 'test@example.org',
+				'comment_content'      => 'Hello world',
+			)
+		);
+		$parsed_blocks = parse_blocks(
+			'<!-- wp:comment-template --><!-- wp:comment-author-name /--><!-- wp:comment-content /--><!-- /wp:comment-template -->'
+		);
+
+		$block  = new WP_Block(
+			$parsed_blocks[0],
+			array(
+				'postId'           => self::$custom_post->ID,
+				'comments/inherit' => true,
+			)
+		);
+		$actual = build_comment_query_vars_from_block( $block );
+		$this->assertEquals( $actual['paged'], $comment_query_max_num_pages );
+		$this->assertEquals( get_query_var( 'cpage' ), $comment_query_max_num_pages );
+	}
+}

--- a/tests/phpunit/tests/block-library/commentTemplate.php
+++ b/tests/phpunit/tests/block-library/commentTemplate.php
@@ -62,7 +62,6 @@ class Test_Block_Library_CommentTemplate extends WP_UnitTestCase {
 		);
 
 		$this->assertEquals(
-			build_comment_query_vars_from_block( $block ),
 			array(
 				'orderby'                   => 'comment_date_gmt',
 				'order'                     => 'ASC',
@@ -73,7 +72,8 @@ class Test_Block_Library_CommentTemplate extends WP_UnitTestCase {
 				'hierarchical'              => 'threaded',
 				'number'                    => 5,
 				'paged'                     => 1,
-			)
+			),
+			build_comment_query_vars_from_block( $block )
 		);
 	}
 
@@ -85,7 +85,6 @@ class Test_Block_Library_CommentTemplate extends WP_UnitTestCase {
 		$block = new WP_Block( $parsed_blocks[0] );
 
 		$this->assertEquals(
-			build_comment_query_vars_from_block( $block ),
 			array(
 				'orderby'                   => 'comment_date_gmt',
 				'order'                     => 'ASC',
@@ -95,7 +94,8 @@ class Test_Block_Library_CommentTemplate extends WP_UnitTestCase {
 				'hierarchical'              => 'threaded',
 				'number'                    => 5,
 				'paged'                     => 1,
-			)
+			),
+			build_comment_query_vars_from_block( $block )
 		);
 	}
 
@@ -117,8 +117,8 @@ class Test_Block_Library_CommentTemplate extends WP_UnitTestCase {
 		// Here we use the function prefixed with 'gutenberg_*' because it's added
 		// in the build step.
 		$this->assertEquals(
-			render_block_core_comment_template( null, null, $block ),
-			'<ol ><li><div class="wp-block-comment-author-name">Test</div><div class="wp-block-comment-content">Hello world</div></li></ol>'
+			'<ol ><li><div class="wp-block-comment-author-name">Test</div><div class="wp-block-comment-content">Hello world</div></li></ol>',
+			render_block_core_comment_template( null, null, $block )
 		);
 	}
 
@@ -164,8 +164,8 @@ class Test_Block_Library_CommentTemplate extends WP_UnitTestCase {
 		);
 
 		$this->assertEquals(
-			render_block_core_comment_template( null, null, $block ),
-			'<ol ><li><div class="wp-block-comment-author-name">Test</div><div class="wp-block-comment-content">Hello world</div><ol><li><div class="wp-block-comment-author-name">Test</div><div class="wp-block-comment-content">Hello world</div><ol><li><div class="wp-block-comment-author-name">Test</div><div class="wp-block-comment-content">Hello world</div></li></ol></li></ol></li></ol>'
+			'<ol ><li><div class="wp-block-comment-author-name">Test</div><div class="wp-block-comment-content">Hello world</div><ol><li><div class="wp-block-comment-author-name">Test</div><div class="wp-block-comment-content">Hello world</div><ol><li><div class="wp-block-comment-author-name">Test</div><div class="wp-block-comment-content">Hello world</div></li></ol></li></ol></li></ol>',
+			render_block_core_comment_template( null, null, $block )
 		);
 	}
 	/**
@@ -200,7 +200,7 @@ class Test_Block_Library_CommentTemplate extends WP_UnitTestCase {
 			)
 		);
 		$actual = build_comment_query_vars_from_block( $block );
-		$this->assertEquals( $actual['paged'], $comment_query_max_num_pages );
-		$this->assertEquals( get_query_var( 'cpage' ), $comment_query_max_num_pages );
+		$this->assertEquals( $comment_query_max_num_pages, $actual['paged'] );
+		$this->assertEquals( $comment_query_max_num_pages, get_query_var( 'cpage' ) );
 	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Backport changes from Gutenberg to add functions required by Comment Query Loop and related blocks.

From [`/lib/compat/wordpress-6.0/blocks.php`](https://github.com/WordPress/gutenberg/blob/6f7c5b573a6023c2f2ce3eecd0d6b169ce4e964c/lib/compat/wordpress-6.0/blocks.php):

- [x] `build_comment_query_vars_from_block` function
- [x] `get_comments_pagination_arrow` function
- [x] `gutenberg_extend_block_editor_settings_with_discussion_settings` filter's callback
- [x] `gutenberg_rest_comment_set_children_as_embeddable` filter's callback

Tests:
- [ ] [`class-block-library-comment-template-test.php`](https://github.com/WordPress/gutenberg/blob/6a05ccc9a5b842b6e375ba6c1afbba8397abb7db/phpunit/class-block-library-comment-template-test.php) unit test

Also being tracked in https://github.com/WordPress/gutenberg/issues/39889.

Trac ticket: https://core.trac.wordpress.org/ticket/55505 and https://core.trac.wordpress.org/ticket/55567

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
