### PR TITLE
Unable to pass _embed param to enveloped REST API requests

### DIFF
--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -731,7 +731,7 @@ class WP_REST_Server {
 	 * data instead.
 	 *
 	 * @since 4.4.0
-	 * @since 5.9.0 The $embed parameter can now contain a list of link relations to include
+	 * @since 6.0.0 The $embed parameter can now contain a list of link relations to include
 	 *
 	 * @param WP_REST_Response $response Response object.
 	 * @param bool|string[]    $embed    Whether to embed all links, a filtered list of link relations, or no links.

--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -438,7 +438,8 @@ class WP_REST_Server {
 
 		// Wrap the response in an envelope if asked for.
 		if ( isset( $_GET['_envelope'] ) ) {
-			$result = $this->envelope_response( $result, isset( $_GET['_embed'] ) );
+			$embed  = isset( $_GET['_embed'] ) ? rest_parse_embed_param( $_GET['_embed'] ) : false;
+			$result = $this->envelope_response( $result, $embed );
 		}
 
 		// Send extra data from response objects.
@@ -730,9 +731,10 @@ class WP_REST_Server {
 	 * data instead.
 	 *
 	 * @since 4.4.0
+	 * @since 5.9.0 The $embed parameter can now contain a list of link relations to include
 	 *
 	 * @param WP_REST_Response $response Response object.
-	 * @param bool             $embed    Whether links should be embedded.
+	 * @param bool|string[]    $embed    Whether to embed all links, a filtered list of link relations, or no links.
 	 * @return WP_REST_Response New response with wrapped data
 	 */
 	public function envelope_response( $response, $embed ) {

--- a/tests/phpunit/tests/rest-api/rest-server.php
+++ b/tests/phpunit/tests/rest-api/rest-server.php
@@ -78,7 +78,7 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 	}
 
 	/**
-	 * @dataProvider data_embed_params
+	 * @dataProvider data_envelope_params
 	 * @ticket 54015
 	 */
 	public function test_envelope_param( $_embed ) {
@@ -114,7 +114,7 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 		$envelope_response = rest_get_server()->envelope_response( $response, $embed );
 
 		// The envelope should still be a response, but with defaults.
-		$this->assertInstanceOf( 'WP_REST_Response', $envelope_response );
+		$this->assertInstanceOf( WP_REST_Response::class, $envelope_response );
 		$this->assertSame( 200, $envelope_response->get_status() );
 		$this->assertEmpty( $envelope_response->get_headers() );
 		$this->assertEmpty( $envelope_response->get_links() );
@@ -2235,7 +2235,7 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 	 *
 	 * @return array
 	 */
-	public function data_embed_params() {
+	public function data_envelope_params() {
 		return array(
 			array( '1' ),
 			array( 'true' ),

--- a/tests/phpunit/tests/rest-api/rest-server.php
+++ b/tests/phpunit/tests/rest-api/rest-server.php
@@ -77,6 +77,62 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 		$this->assertSame( $headers, $enveloped['headers'] );
 	}
 
+	/**
+	 * @dataProvider data_embed_params
+	 * @ticket 54015
+	 */
+	public function test_envelope_param( $_embed ) {
+		// Register our testing route.
+		rest_get_server()->register_route(
+			'test',
+			'/test/embeddable',
+			array(
+				'methods'  => 'GET',
+				'callback' => array( $this, 'embedded_response_callback' ),
+			)
+		);
+		$data    = array(
+			'amount of arbitrary data' => 'alot',
+		);
+		$status  = 987;
+		$headers = array(
+			'Arbitrary-Header' => 'value',
+			'Multiple'         => 'maybe, yes',
+		);
+
+		$response = new WP_REST_Response( $data, $status );
+		$response->header( 'Arbitrary-Header', 'value' );
+
+		// Check header concatenation as well.
+		$response->header( 'Multiple', 'maybe' );
+		$response->header( 'Multiple', 'yes', false );
+
+		// All others should be embedded.
+		$response->add_link( 'alternate', rest_url( '/test/embeddable' ), array( 'embeddable' => true ) );
+
+		$embed             = rest_parse_embed_param( $_embed );
+		$envelope_response = rest_get_server()->envelope_response( $response, $embed );
+
+		// The envelope should still be a response, but with defaults.
+		$this->assertInstanceOf( 'WP_REST_Response', $envelope_response );
+		$this->assertSame( 200, $envelope_response->get_status() );
+		$this->assertEmpty( $envelope_response->get_headers() );
+		$this->assertEmpty( $envelope_response->get_links() );
+
+		$enveloped = $envelope_response->get_data();
+
+		$this->assertArrayHasKey( 'body', $enveloped );
+		$this->assertArrayHasKey( '_links', $enveloped['body'] );
+		$this->assertArrayHasKey( '_embedded', $enveloped['body'] );
+		$this->assertArrayHasKey( 'alternate', $enveloped['body']['_embedded'] );
+
+		$alternate = $enveloped['body']['_embedded']['alternate'];
+		$this->assertCount( 1, $alternate );
+
+		$this->assertSame( $status, $enveloped['status'] );
+		$this->assertSame( $headers, $enveloped['headers'] );
+	}
+
 	public function test_default_param() {
 
 		register_rest_route(
@@ -2172,5 +2228,20 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 		$result  = rest_get_server()->serve_request( '/' );
 
 		return rest_get_server()->sent_headers;
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_embed_params() {
+		return array(
+			array( '1' ),
+			array( 'true' ),
+			array( false ),
+			array( 'alternate' ),
+			array( array( 'alternate' ) ),
+		);
 	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/54015

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
