### PR TITLE
Handle WP_Themes::get_files for non-existent themes

### DIFF
--- a/src/wp-includes/class-wp-theme.php
+++ b/src/wp-includes/class-wp-theme.php
@@ -1209,7 +1209,7 @@ final class WP_Theme implements ArrayAccess {
 			$files += (array) self::scandir( $this->get_template_directory(), $type, $depth );
 		}
 
-		return $files;
+		return array_filter( $files );
 	}
 
 	/**

--- a/tests/phpunit/tests/theme/wpTheme.php
+++ b/tests/phpunit/tests/theme/wpTheme.php
@@ -262,7 +262,7 @@ class Tests_Theme_wpTheme extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test get_files.
+	 * Test get_files for an existing theme.
 	 *
 	 * @ticket 53599
 	 */
@@ -278,7 +278,7 @@ class Tests_Theme_wpTheme extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test get_files for a non-existent theme.
+	 * Test get_files for a non-existing theme.
 	 *
 	 * @ticket 53599
 	 */

--- a/tests/phpunit/tests/theme/wpTheme.php
+++ b/tests/phpunit/tests/theme/wpTheme.php
@@ -262,6 +262,35 @@ class Tests_Theme_wpTheme extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test get_files.
+	 *
+	 * @ticket 53599
+	 */
+	public function test_get_files_theme() {
+		$theme = new WP_Theme( 'theme1', $this->theme_root );
+		$files = $theme->get_files();
+
+		$this->assertIsArray( $files );
+		$this->assertCount( 3, $files );
+		$this->assertArrayHasKey( 'functions.php', $files );
+		$this->assertArrayHasKey( 'index.php', $files );
+		$this->assertArrayHasKey( 'style.css', $files );
+	}
+
+	/**
+	 * Test get_files for a non-existent theme.
+	 *
+	 * @ticket 53599
+	 */
+	public function test_get_files_nonexistent_theme() {
+		$theme = new WP_Theme( 'nonexistent', $this->theme_root );
+		$files = $theme->get_files();
+
+		$this->assertIsArray( $files );
+		$this->assertEmpty( $files );
+	}
+
+	/**
 	 * Data provider.
 	 *
 	 * @return array


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

This PR changes the get_files method to not return `false` values in the array of files and adds tests for this case. 

Trac ticket: https://core.trac.wordpress.org/ticket/53599

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
