### PR TITLE
Block supports: add @covers annotation to block support tests for test coverage reports.

### DIFF
--- a/tests/phpunit/tests/block-supports/border.php
+++ b/tests/phpunit/tests/block-supports/border.php
@@ -3,9 +3,10 @@
  * @group block-supports
  */
 class Test_Block_Supports_Border extends WP_UnitTestCase {
-
 	/**
 	 * @ticket 55505
+	 *
+	 * @covers ::wp_apply_border_support
 	 */
 	function test_border_color_slug_with_numbers_is_kebab_cased_properly() {
 		$block_name = 'test/border-color-slug-with-numbers-is-kebab-cased-properly';
@@ -56,6 +57,8 @@ class Test_Block_Supports_Border extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 55505
+	 *
+	 * @covers ::wp_apply_border_support
 	 */
 	function test_border_with_skipped_serialization_block_supports() {
 		$block_name = 'test/border-with-skipped-serialization-block-supports';
@@ -101,6 +104,8 @@ class Test_Block_Supports_Border extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 55505
+	 *
+	 * @covers ::wp_apply_border_support
 	 */
 	function test_radius_with_individual_skipped_serialization_block_supports() {
 		$block_name = 'test/radius-with-individual-skipped-serialization-block-supports';

--- a/tests/phpunit/tests/block-supports/colors.php
+++ b/tests/phpunit/tests/block-supports/colors.php
@@ -3,7 +3,9 @@
  * @group block-supports
  */
 class Tests_Block_Supports_Colors extends WP_UnitTestCase {
-
+	/**
+	 * @covers ::wp_apply_colors_support
+	 */
 	function test_color_slugs_with_numbers_are_kebab_cased_properly() {
 		register_block_type(
 			'test/color-slug-with-numbers',
@@ -47,6 +49,8 @@ class Tests_Block_Supports_Colors extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 55505
+	 *
+	 * @covers ::wp_apply_colors_support
 	 */
 	function test_color_with_skipped_serialization_block_supports() {
 		$block_name = 'test/color-with-skipped-serialization-block-supports';
@@ -89,6 +93,8 @@ class Tests_Block_Supports_Colors extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 55505
+	 *
+	 * @covers ::wp_apply_colors_support
 	 */
 	function test_gradient_with_individual_skipped_serialization_block_supports() {
 		$block_name = 'test/gradient-with-individual-skipped-serialization-block-support';

--- a/tests/phpunit/tests/block-supports/colors.php
+++ b/tests/phpunit/tests/block-supports/colors.php
@@ -4,6 +4,8 @@
  */
 class Tests_Block_Supports_Colors extends WP_UnitTestCase {
 	/**
+	 * @ticket 54337
+	 *
 	 * @covers ::wp_apply_colors_support
 	 */
 	function test_color_slugs_with_numbers_are_kebab_cased_properly() {

--- a/tests/phpunit/tests/block-supports/elements.php
+++ b/tests/phpunit/tests/block-supports/elements.php
@@ -16,6 +16,8 @@ class Tests_Block_Supports_Elements extends WP_UnitTestCase {
 
 	/**
 	 * Test wp_render_elements_support() with a simple paragraph and link color preset.
+	 *
+	 * @covers ::wp_render_elements_support
 	 */
 	public function test_simple_paragraph_link_color() {
 		$result = self::make_unique_id_one(
@@ -45,6 +47,8 @@ class Tests_Block_Supports_Elements extends WP_UnitTestCase {
 
 	/**
 	 * Test wp_render_elements_support() with a paragraph containing a class.
+	 *
+	 * @covers ::wp_render_elements_support
 	 */
 	public function test_class_paragraph_link_color() {
 		$result = self::make_unique_id_one(
@@ -75,6 +79,8 @@ class Tests_Block_Supports_Elements extends WP_UnitTestCase {
 
 	/**
 	 * Test wp_render_elements_support() with a paragraph containing a anchor.
+	 *
+	 * @covers ::wp_render_elements_support
 	 */
 	public function test_anchor_paragraph_link_color() {
 		$result = self::make_unique_id_one(

--- a/tests/phpunit/tests/block-supports/elements.php
+++ b/tests/phpunit/tests/block-supports/elements.php
@@ -16,6 +16,7 @@ class Tests_Block_Supports_Elements extends WP_UnitTestCase {
 
 	/**
 	 * Test wp_render_elements_support() with a simple paragraph and link color preset.
+	 * @ticket 54337
 	 *
 	 * @covers ::wp_render_elements_support
 	 */
@@ -47,6 +48,7 @@ class Tests_Block_Supports_Elements extends WP_UnitTestCase {
 
 	/**
 	 * Test wp_render_elements_support() with a paragraph containing a class.
+	 * @ticket 54337
 	 *
 	 * @covers ::wp_render_elements_support
 	 */
@@ -79,6 +81,7 @@ class Tests_Block_Supports_Elements extends WP_UnitTestCase {
 
 	/**
 	 * Test wp_render_elements_support() with a paragraph containing a anchor.
+	 * @ticket 54337
 	 *
 	 * @covers ::wp_render_elements_support
 	 */

--- a/tests/phpunit/tests/block-supports/layout.php
+++ b/tests/phpunit/tests/block-supports/layout.php
@@ -53,6 +53,8 @@ class Test_Block_Supports_Layout extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 55505
+	 *
+	 * @covers ::wp_restore_image_outer_container
 	 */
 	function test_outer_container_not_restored_for_non_aligned_image_block_with_non_themejson_theme() {
 		// The "default" theme doesn't have theme.json support.
@@ -69,6 +71,8 @@ class Test_Block_Supports_Layout extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 55505
+	 *
+	 * @covers ::wp_restore_image_outer_container
 	 */
 	function test_outer_container_restored_for_aligned_image_block_with_non_themejson_theme() {
 		// The "default" theme doesn't have theme.json support.
@@ -85,6 +89,8 @@ class Test_Block_Supports_Layout extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 55505
+	 *
+	 * @covers ::wp_restore_image_outer_container
 	 *
 	 * @dataProvider data_block_image_html_restored_outer_container
 	 *
@@ -143,6 +149,8 @@ class Test_Block_Supports_Layout extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 55505
+	 *
+	 * @covers ::wp_restore_image_outer_container
 	 */
 	function test_outer_container_not_restored_for_aligned_image_block_with_themejson_theme() {
 		switch_theme( 'block-theme' );

--- a/tests/phpunit/tests/block-supports/spacing.php
+++ b/tests/phpunit/tests/block-supports/spacing.php
@@ -3,9 +3,10 @@
  * @group block-supports
  */
 class Test_Block_Supports_Spacing extends WP_UnitTestCase {
-
 	/**
 	 * @ticket 55505
+	 *
+	 * @covers ::wp_apply_spacing_support
 	 */
 	function test_spacing_style_is_applied() {
 		$block_name = 'test/spacing-style-is-applied';
@@ -55,6 +56,8 @@ class Test_Block_Supports_Spacing extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 55505
+	 *
+	 * @covers ::wp_apply_spacing_support
 	 */
 	function test_spacing_with_skipped_serialization_block_supports() {
 		$block_name = 'test/spacing-with-skipped-serialization-block-supports';
@@ -103,6 +106,8 @@ class Test_Block_Supports_Spacing extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 55505
+	 *
+	 * @covers ::wp_apply_spacing_support
 	 */
 	function test_margin_with_individual_skipped_serialization_block_supports() {
 		$block_name = 'test/margin-with-individual-skipped-serialization-block-supports';

--- a/tests/phpunit/tests/block-supports/typography.php
+++ b/tests/phpunit/tests/block-supports/typography.php
@@ -3,7 +3,9 @@
  * @group block-supports
  */
 class Tests_Block_Supports_Typography extends WP_UnitTestCase {
-
+	/**
+	 * @covers ::wp_apply_typography_support
+	 */
 	function test_font_size_slug_with_numbers_is_kebab_cased_properly() {
 		register_block_type(
 			'test/font-size-slug-with-numbers',
@@ -32,7 +34,9 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 		$this->assertSame( $expected, $actual );
 		unregister_block_type( 'test/font-size-slug-with-numbers' );
 	}
-
+	/**
+	 * @covers ::wp_apply_typography_support
+	 */
 	function test_font_family_with_legacy_inline_styles_using_a_value() {
 		$block_name = 'test/font-family-with-inline-styles-using-value';
 		register_block_type(
@@ -64,6 +68,8 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 55505
+	 *
+	 * @covers ::wp_apply_typography_support
 	 */
 	function test_typography_with_skipped_serialization_block_supports() {
 		$block_name = 'test/typography-with-skipped-serialization-block-supports';
@@ -109,6 +115,8 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 55505
+	 *
+	 * @covers ::wp_apply_typography_support
 	 */
 	function test_letter_spacing_with_individual_skipped_serialization_block_supports() {
 		$block_name = 'test/letter-spacing-with-individua-skipped-serialization-block-supports';
@@ -141,7 +149,9 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 		$this->assertSame( $expected, $actual );
 		unregister_block_type( $block_name );
 	}
-
+	/**
+	 * @covers ::wp_apply_typography_support
+	 */
 	function test_font_family_with_legacy_inline_styles_using_a_css_var() {
 		$block_name = 'test/font-family-with-inline-styles-using-css-var';
 		register_block_type(
@@ -170,7 +180,9 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 		$this->assertSame( $expected, $actual );
 		unregister_block_type( $block_name );
 	}
-
+	/**
+	 * @covers ::wp_apply_typography_support
+	 */
 	function test_font_family_with_class() {
 		$block_name = 'test/font-family-with-class';
 		register_block_type(

--- a/tests/phpunit/tests/block-supports/typography.php
+++ b/tests/phpunit/tests/block-supports/typography.php
@@ -4,6 +4,8 @@
  */
 class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 	/**
+	 * @ticket 54337
+	 *
 	 * @covers ::wp_apply_typography_support
 	 */
 	function test_font_size_slug_with_numbers_is_kebab_cased_properly() {
@@ -35,6 +37,8 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 		unregister_block_type( 'test/font-size-slug-with-numbers' );
 	}
 	/**
+	 * @ticket 54337
+	 *
 	 * @covers ::wp_apply_typography_support
 	 */
 	function test_font_family_with_legacy_inline_styles_using_a_value() {
@@ -150,6 +154,8 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 		unregister_block_type( $block_name );
 	}
 	/**
+	 * @ticket 54337
+	 *
 	 * @covers ::wp_apply_typography_support
 	 */
 	function test_font_family_with_legacy_inline_styles_using_a_css_var() {
@@ -181,6 +187,8 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 		unregister_block_type( $block_name );
 	}
 	/**
+	 * @ticket 54337
+	 *
 	 * @covers ::wp_apply_typography_support
 	 */
 	function test_font_family_with_class() {


### PR DESCRIPTION
Let's add `@covers` annotation to block support tests for test coverage reports! 👍 

Props [@antonvlasenko](https://profiles.wordpress.org/antonvlasenko)

Trac ticket: https://core.trac.wordpress.org/ticket/55505

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
