### PR TITLE
Move admin hooks to `admin-filters.php`

### DIFF
--- a/src/wp-admin/includes/admin-filters.php
+++ b/src/wp-admin/includes/admin-filters.php
@@ -12,6 +12,7 @@ add_action( 'admin_page_access_denied', 'wp_link_manager_disabled_message' );
 
 // Dashboard hooks.
 add_action( 'activity_box_end', 'wp_dashboard_quota' );
+add_action( 'welcome_panel', 'wp_welcome_panel' );
 
 // Media hooks.
 add_action( 'attachment_submitbox_misc_actions', 'attachment_submitbox_metadata' );
@@ -36,14 +37,18 @@ add_filter( 'media_upload_library', 'media_upload_library' );
 
 add_filter( 'media_upload_tabs', 'update_gallery_tab' );
 
+// Admin color schemes.
+add_action( 'admin_head', 'wp_color_scheme_settings' );
+add_action( 'admin_color_scheme_picker', 'admin_color_scheme_picker' );
+
 // Misc hooks.
 add_action( 'admin_init', 'wp_admin_headers' );
 add_action( 'login_init', 'wp_admin_headers' );
 add_action( 'admin_head', 'wp_admin_canonical_url' );
-add_action( 'admin_head', 'wp_color_scheme_settings' );
 add_action( 'admin_head', 'wp_site_icon' );
 add_action( 'admin_head', 'wp_admin_viewport_meta' );
 add_action( 'customize_controls_head', 'wp_admin_viewport_meta' );
+add_filter( 'nav_menu_meta_box_object', '_wp_nav_menu_meta_box_object' );
 
 // Prerendering.
 if ( ! is_customize_preview() ) {
@@ -69,6 +74,10 @@ add_filter( 'wp_refresh_nonces', 'wp_refresh_post_nonces', 10, 3 );
 add_filter( 'wp_refresh_nonces', 'wp_refresh_heartbeat_nonces' );
 
 add_filter( 'heartbeat_settings', 'wp_heartbeat_set_suspension' );
+
+add_action( 'use_block_editor_for_post_type', '_disable_block_editor_for_navigation_post_type', 10, 2 );
+add_action( 'edit_form_after_title', '_disable_content_editor_for_navigation_post_type' );
+add_action( 'edit_form_after_editor', '_enable_content_editor_for_navigation_post_type' );
 
 // Nav Menu hooks.
 add_action( 'admin_head-nav-menus.php', '_wp_delete_orphaned_draft_menu_items' );

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -7,12 +7,13 @@
  * give you the priority for which to use to remove the
  * hook.
  *
- * Not all of the default hooks are found in default-filters.php
+ * Not all of the default hooks are found in this file.
+ * For instance, administration related hooks are located in
+ * wp-admin/includes/admin-filters.php.
  *
- * Please note that this file registers default hooks only.
- * If your hook should only be called from a specific context
- * (e.g., admin area or multisite environment), please move
- * it to a more appropriate file instead.
+ * If a hook should only be called from a specific context
+ * (admin area, multisite environment…), please move it
+ * to a more appropriate file instead.
  *
  * @package WordPress
  */

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -10,9 +10,9 @@
  * Not all of the default hooks are found in default-filters.php
  *
  * Please note that this file registers default hooks only.
- * If your hook has to be called from some specific context
+ * If your hook should only be called from a specific context
  * (e.g., admin area or multisite environment), please move
- * it to a more appropriate file.
+ * it to a more appropriate file instead.
  *
  * @package WordPress
  */

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -293,7 +293,6 @@ add_filter( 'comments_open', '_close_comments_for_old_post', 10, 2 );
 add_filter( 'pings_open', '_close_comments_for_old_post', 10, 2 );
 add_filter( 'editable_slug', 'urldecode' );
 add_filter( 'editable_slug', 'esc_textarea' );
-add_filter( 'nav_menu_meta_box_object', '_wp_nav_menu_meta_box_object' );
 add_filter( 'pingback_ping_source_uri', 'pingback_ping_source_uri' );
 add_filter( 'xmlrpc_pingback_error', 'xmlrpc_pingback_error' );
 add_filter( 'title_save_pre', 'trim' );
@@ -413,7 +412,6 @@ add_action( 'transition_post_status', '_transition_post_status', 5, 3 );
 add_action( 'transition_post_status', '_update_term_count_on_transition_post_status', 10, 3 );
 add_action( 'comment_form', 'wp_comment_form_unfiltered_html_nonce' );
 add_action( 'admin_init', 'send_frame_options_header', 10, 0 );
-add_action( 'welcome_panel', 'wp_welcome_panel' );
 
 // Privacy.
 add_action( 'user_request_action_confirmed', '_wp_privacy_account_request_confirmed' );
@@ -462,7 +460,6 @@ add_filter( 'pre_option_gmt_offset', 'wp_timezone_override_offset' );
 
 // Admin color schemes.
 add_action( 'admin_init', 'register_admin_color_schemes', 1 );
-add_action( 'admin_color_scheme_picker', 'admin_color_scheme_picker' );
 
 // If the upgrade hasn't run yet, assume link manager is used.
 add_filter( 'default_option_link_manager_enabled', '__return_true' );
@@ -590,10 +587,6 @@ add_filter( 'style_loader_src', 'wp_style_loader_src', 10, 2 );
 
 add_action( 'wp_head', 'wp_maybe_inline_styles', 1 ); // Run for styles enqueued in <head>.
 add_action( 'wp_footer', 'wp_maybe_inline_styles', 1 ); // Run for late-loaded styles in the footer.
-
-add_action( 'use_block_editor_for_post_type', '_disable_block_editor_for_navigation_post_type', 10, 2 );
-add_action( 'edit_form_after_title', '_disable_content_editor_for_navigation_post_type' );
-add_action( 'edit_form_after_editor', '_enable_content_editor_for_navigation_post_type' );
 
 /*
  * Disable "Post Attributes" for wp_navigation post type. The attributes are

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -9,6 +9,11 @@
  *
  * Not all of the default hooks are found in default-filters.php
  *
+ * Please note that this file registers default hooks only.
+ * If your hook has to be called from some specific context
+ * (e.g., admin area or multisite environment), please move
+ * it to a more appropriate file.
+ *
  * @package WordPress
  */
 


### PR DESCRIPTION
This PR aims to move admin hooks to admin-filters.php.
These hooks are not supposed to be used from a non-admin context.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/54795

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
