### PR TITLE
Increment `theme.json` version to `3`

### DIFF
--- a/src/wp-includes/class-wp-theme-json-schema.php
+++ b/src/wp-includes/class-wp-theme-json-schema.php
@@ -50,6 +50,10 @@ class WP_Theme_JSON_Schema {
 			$theme_json = self::migrate_v1_to_v2( $theme_json );
 		}
 
+		if ( 2 === $theme_json['version'] ) {
+			$theme_json['version'] = 3;
+		}
+
 		return $theme_json;
 	}
 

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -382,9 +382,10 @@ class WP_Theme_JSON {
 	 *
 	 * @since 5.8.0
 	 * @since 5.9.0 Changed value from 1 to 2.
+	 * @since 6.0.0 Changes value from 2 to 3.
 	 * @var int
 	 */
-	const LATEST_SCHEMA = 2;
+	const LATEST_SCHEMA = 3;
 
 	/**
 	 * Constructor.

--- a/src/wp-includes/theme.json
+++ b/src/wp-includes/theme.json
@@ -1,5 +1,5 @@
 {
-	"version": 2,
+	"version": 3,
 	"settings": {
 		"appearanceTools": false,
 		"border": {

--- a/tests/phpunit/tests/rest-api/rest-global-styles-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-global-styles-controller.php
@@ -470,7 +470,7 @@ class WP_REST_Global_Styles_Controller_Test extends WP_Test_REST_Controller_Test
 		$data     = $response->get_data();
 		$expected = array(
 			array(
-				'version'  => 2,
+				'version'  => WP_Theme_JSON::LATEST_SCHEMA,
 				'settings' => array(
 					'color' => array(
 						'palette' => array(

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -2366,7 +2366,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 
 		$actual   = $theme_json->get_raw_data();
 		$expected = array(
-			'version' => 2,
+			'version' => WP_Theme_JSON::LATEST_SCHEMA,
 			'styles'  => array(
 				'spacing' => array(
 					'blockGap' => 'valid value',
@@ -2435,7 +2435,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 		$theme->merge( $user );
 		$actual   = $theme->get_data();
 		$expected = array(
-			'version'  => 2,
+			'version'  => WP_Theme_JSON::LATEST_SCHEMA,
 			'settings' => array(
 				'color' => array(
 					'palette' => array(
@@ -2490,7 +2490,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 
 		$actual   = $theme->get_data();
 		$expected = array(
-			'version'  => 2,
+			'version'  => WP_Theme_JSON::LATEST_SCHEMA,
 			'settings' => array(
 				'color' => array(
 					'palette' => array(
@@ -2541,7 +2541,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 
 		$actual   = $user->get_data();
 		$expected = array(
-			'version'  => 2,
+			'version'  => WP_Theme_JSON::LATEST_SCHEMA,
 			'settings' => array(
 				'color' => array(
 					'palette' => array(
@@ -2574,7 +2574,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 			'theme'
 		);
 		$actual_v2   = $theme_v2->get_data();
-		$expected_v2 = array( 'version' => 2 );
+		$expected_v2 = array( 'version' => WP_Theme_JSON::LATEST_SCHEMA );
 		$this->assertEqualSetsWithIndex( $expected_v2, $actual_v2 );
 
 		$theme_v1    = new WP_Theme_JSON(
@@ -2584,7 +2584,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 			'theme'
 		);
 		$actual_v1   = $theme_v1->get_data();
-		$expected_v1 = array( 'version' => 2 );
+		$expected_v1 = array( 'version' => WP_Theme_JSON::LATEST_SCHEMA );
 		$this->assertEqualSetsWithIndex( $expected_v1, $actual_v1 );
 	}
 
@@ -2608,7 +2608,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 
 		$actual   = $theme->get_data();
 		$expected = array(
-			'version'  => 2,
+			'version'  => WP_Theme_JSON::LATEST_SCHEMA,
 			'settings' => array(
 				'appearanceTools' => true,
 				'blocks'          => array(


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/55505
Related Gutenberg PR https://github.com/WordPress/gutenberg/pull/40232

This PR increments the `theme.json` version in use, to signal it follows the schema to be published with WordPress 6.0.

There's no modifications or removals in the existing schema, only additions:

- `title` top-level key
- `patterns` top-level key
- `settings.color.defaultDuotone` setting key

The behavior is the same as before, this serves to semantically mark the new files. This version change will be documented in the block editor handbook as well with a PR sent to the Gutenberg repository.