### PR TITLE
Ensure that a single image or iframe within content blob is only handled once in `wp_filter_content_tags()`

### DIFF
--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -1857,6 +1857,10 @@ function wp_filter_content_tags( $content, $context = null ) {
 			if ( $filtered_image !== $match[0] ) {
 				$content = str_replace( $match[0], $filtered_image, $content );
 			}
+
+			// Unset image lookup to not run the same logic again unnecessarily if the same image tag is used more than
+			// once in the same blob of content.
+			unset( $images[ $match[0] ] );
 		}
 
 		// Filter an iframe match.
@@ -1871,6 +1875,10 @@ function wp_filter_content_tags( $content, $context = null ) {
 			if ( $filtered_iframe !== $match[0] ) {
 				$content = str_replace( $match[0], $filtered_iframe, $content );
 			}
+
+			// Unset iframe lookup to not run the same logic again unnecessarily if the same iframe tag is used more
+			// than once in the same blob of content.
+			unset( $iframes[ $match[0] ] );
 		}
 	}
 

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -1858,8 +1858,10 @@ function wp_filter_content_tags( $content, $context = null ) {
 				$content = str_replace( $match[0], $filtered_image, $content );
 			}
 
-			// Unset image lookup to not run the same logic again unnecessarily if the same image tag is used more than
-			// once in the same blob of content.
+			/*
+			 * Unset image lookup to not run the same logic again unnecessarily if the same image tag is used more than
+			 * once in the same blob of content.
+			 */
 			unset( $images[ $match[0] ] );
 		}
 
@@ -1876,8 +1878,10 @@ function wp_filter_content_tags( $content, $context = null ) {
 				$content = str_replace( $match[0], $filtered_iframe, $content );
 			}
 
-			// Unset iframe lookup to not run the same logic again unnecessarily if the same iframe tag is used more
-			// than once in the same blob of content.
+			/*
+			 * Unset iframe lookup to not run the same logic again unnecessarily if the same iframe tag is used more
+			 * than once in the same blob of content.
+			 */
 			unset( $iframes[ $match[0] ] );
 		}
 	}

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -2354,8 +2354,8 @@ EOF;
 		$content = "$img\n$img";
 
 		add_filter( 'wp_img_tag_add_loading_attr', '__return_false' );
-        add_filter( 'wp_img_tag_add_width_and_height_attr', '__return_false' );
-        add_filter( 'wp_img_tag_add_srcset_and_sizes_attr', '__return_false' );
+		add_filter( 'wp_img_tag_add_width_and_height_attr', '__return_false' );
+		add_filter( 'wp_img_tag_add_srcset_and_sizes_attr', '__return_false' );
 
 		add_filter(
 			'wp_content_img_tag',

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -2307,6 +2307,7 @@ EOF;
 
 	/**
 	 * @ticket 55510
+	 * @covers ::wp_filter_content_tags
 	 */
 	public function test_wp_filter_content_tags_handles_duplicate_img_and_iframe_tags_once() {
 		$img     = get_image_tag( self::$large_id, '', '', '', 'large' );
@@ -2329,6 +2330,7 @@ EOF;
 
 	/**
 	 * @ticket 55510
+	 * @covers ::wp_filter_content_tags
 	 */
 	public function test_wp_filter_content_tags_filter_with_identical_image_tags_custom_attributes() {
 		$img     = get_image_tag( self::$large_id, '', '', '', 'large' );
@@ -2348,6 +2350,7 @@ EOF;
 
 	/**
 	 * @ticket 55510
+	 * @covers ::wp_filter_content_tags
 	 */
 	public function test_wp_filter_content_tags_filter_with_identical_image_tags_disabled_core_filters() {
 		$img     = get_image_tag( self::$large_id, '', '', '', 'large' );

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -2304,6 +2304,70 @@ EOF;
 		wp_filter_content_tags( $img_tag_1 );
 		$this->assertSame( 1, $filter->get_call_count() );
 	}
+
+	/**
+	 * @ticket 55510
+	 */
+	public function test_wp_filter_content_tags_handles_duplicate_img_and_iframe_tags_once() {
+		$img     = get_image_tag( self::$large_id, '', '', '', 'large' );
+		$iframe  = '<iframe src="https://www.example.com" width="640" height="360"></iframe>';
+		$content = "$img\n$img\n$iframe\n$iframe";
+
+		// Record how often one of the available img and iframe filters is run.
+		// Both images and iframes support lazy-loading, so that's why this is used here.
+		$img_filter = new MockAction();
+		add_filter( 'wp_img_tag_add_loading_attr', array( &$img_filter, 'filter' ) );
+		$iframe_filter = new MockAction();
+		add_filter( 'wp_iframe_tag_add_loading_attr', array( &$iframe_filter, 'filter' ) );
+
+		// Ensure the img and iframe filters only ran once because the content is a single duplicated img tag and a
+		// single duplicate iframe tag.
+		wp_filter_content_tags( $content );
+		$this->assertSame( 1, $img_filter->get_call_count() );
+		$this->assertSame( 1, $iframe_filter->get_call_count() );
+	}
+
+	/**
+	 * @ticket 55510
+	 */
+	public function test_wp_filter_content_tags_filter_with_identical_image_tags_custom_attributes() {
+		$img     = get_image_tag( self::$large_id, '', '', '', 'large' );
+		$img     = str_replace( '<img ', '<img srcset="custom" sizes="custom" loading="custom" ', $img );
+		$content = "$img\n$img";
+
+		add_filter(
+			'wp_content_img_tag',
+			function( $filtered_image ) {
+				return "<span>$filtered_image</span>";
+			}
+		);
+
+		// Ensure there is no duplicate <span> wrapping the image.
+		$this->assertStringNotContainsString( '<span><span><img ', wp_filter_content_tags( $content ) );
+	}
+
+	/**
+	 * @ticket 55510
+	 */
+	public function test_wp_filter_content_tags_filter_with_identical_image_tags_disabled_core_filters() {
+		$img     = get_image_tag( self::$large_id, '', '', '', 'large' );
+		$content = "$img\n$img";
+
+		add_filter( 'wp_img_tag_add_loading_attr', '__return_false' );
+        add_filter( 'wp_img_tag_add_width_and_height_attr', '__return_false' );
+        add_filter( 'wp_img_tag_add_srcset_and_sizes_attr', '__return_false' );
+
+		add_filter(
+			'wp_content_img_tag',
+			function( $filtered_image ) {
+				return "<span>$filtered_image</span>";
+			}
+		);
+
+		// Ensure the output has both instances of the image wrapped with a single <span>.
+		$this->assertSame( "<span>$img</span>\n<span>$img</span>", wp_filter_content_tags( $content ) );
+	}
+
 	/**
 	 * @ticket 33641
 	 * @ticket 34528


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

* Unsets lookup key for images and iframes after processing one, so that the respective image/iframe doesn't get processed again.
* Depending on how the filters are used, this is at least a performance enhancement, but can also fix a bug where a filter would unexpectedly modify a tag multiple times.

Trac ticket: https://core.trac.wordpress.org/ticket/55510

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
