### PR TITLE
Block supports: unregister block in PHP unit tests

### DIFF
--- a/tests/phpunit/tests/block-supports/border.php
+++ b/tests/phpunit/tests/block-supports/border.php
@@ -4,14 +4,30 @@
  */
 class Test_Block_Supports_Border extends WP_UnitTestCase {
 	/**
+	 * @var string|null
+	 */
+	private $test_block_name;
+
+	function set_up() {
+		parent::set_up();
+		$this->test_block_name = null;
+	}
+
+	function tear_down() {
+		unregister_block_type( $this->test_block_name );
+		$this->test_block_name = null;
+		parent::set_up();
+	}
+
+	/**
 	 * @ticket 55505
 	 *
 	 * @covers ::wp_apply_border_support
 	 */
 	function test_border_color_slug_with_numbers_is_kebab_cased_properly() {
-		$block_name = 'test/border-color-slug-with-numbers-is-kebab-cased-properly';
+		$this->test_block_name = 'test/border-color-slug-with-numbers-is-kebab-cased-properly';
 		register_block_type(
-			$block_name,
+			$this->test_block_name,
 			array(
 				'api_version' => 2,
 				'attributes'  => array(
@@ -33,7 +49,7 @@ class Test_Block_Supports_Border extends WP_UnitTestCase {
 			)
 		);
 		$registry   = WP_Block_Type_Registry::get_instance();
-		$block_type = $registry->get_registered( $block_name );
+		$block_type = $registry->get_registered( $this->test_block_name );
 		$block_atts = array(
 			'borderColor' => 'red',
 			'style'       => array(
@@ -52,7 +68,6 @@ class Test_Block_Supports_Border extends WP_UnitTestCase {
 		);
 
 		$this->assertSame( $expected, $actual );
-		unregister_block_type( $block_name );
 	}
 
 	/**
@@ -61,9 +76,9 @@ class Test_Block_Supports_Border extends WP_UnitTestCase {
 	 * @covers ::wp_apply_border_support
 	 */
 	function test_border_with_skipped_serialization_block_supports() {
-		$block_name = 'test/border-with-skipped-serialization-block-supports';
+		$this->test_block_name = 'test/border-with-skipped-serialization-block-supports';
 		register_block_type(
-			$block_name,
+			$this->test_block_name,
 			array(
 				'api_version' => 2,
 				'attributes'  => array(
@@ -83,7 +98,7 @@ class Test_Block_Supports_Border extends WP_UnitTestCase {
 			)
 		);
 		$registry   = WP_Block_Type_Registry::get_instance();
-		$block_type = $registry->get_registered( $block_name );
+		$block_type = $registry->get_registered( $this->test_block_name );
 		$block_atts = array(
 			'style' => array(
 				'border' => array(
@@ -99,7 +114,6 @@ class Test_Block_Supports_Border extends WP_UnitTestCase {
 		$expected = array();
 
 		$this->assertSame( $expected, $actual );
-		unregister_block_type( $block_name );
 	}
 
 	/**
@@ -108,9 +122,9 @@ class Test_Block_Supports_Border extends WP_UnitTestCase {
 	 * @covers ::wp_apply_border_support
 	 */
 	function test_radius_with_individual_skipped_serialization_block_supports() {
-		$block_name = 'test/radius-with-individual-skipped-serialization-block-supports';
+		$this->test_block_name = 'test/radius-with-individual-skipped-serialization-block-supports';
 		register_block_type(
-			$block_name,
+			$this->test_block_name,
 			array(
 				'api_version' => 2,
 				'attributes'  => array(
@@ -130,7 +144,7 @@ class Test_Block_Supports_Border extends WP_UnitTestCase {
 			)
 		);
 		$registry   = WP_Block_Type_Registry::get_instance();
-		$block_type = $registry->get_registered( $block_name );
+		$block_type = $registry->get_registered( $this->test_block_name );
 		$block_atts = array(
 			'style' => array(
 				'border' => array(
@@ -148,6 +162,5 @@ class Test_Block_Supports_Border extends WP_UnitTestCase {
 		);
 
 		$this->assertSame( $expected, $actual );
-		unregister_block_type( $block_name );
 	}
 }

--- a/tests/phpunit/tests/block-supports/colors.php
+++ b/tests/phpunit/tests/block-supports/colors.php
@@ -4,13 +4,30 @@
  */
 class Tests_Block_Supports_Colors extends WP_UnitTestCase {
 	/**
+	 * @var string|null
+	 */
+	private $test_block_name;
+
+	function set_up() {
+		parent::set_up();
+		$this->test_block_name = null;
+	}
+
+	function tear_down() {
+		unregister_block_type( $this->test_block_name );
+		$this->test_block_name = null;
+		parent::set_up();
+	}
+
+	/**
 	 * @ticket 54337
 	 *
 	 * @covers ::wp_apply_colors_support
 	 */
 	function test_color_slugs_with_numbers_are_kebab_cased_properly() {
+		$this->test_block_name = 'test/color-slug-with-numbers';
 		register_block_type(
-			'test/color-slug-with-numbers',
+			$this->test_block_name,
 			array(
 				'api_version' => 2,
 				'attributes'  => array(
@@ -34,7 +51,7 @@ class Tests_Block_Supports_Colors extends WP_UnitTestCase {
 			)
 		);
 		$registry   = WP_Block_Type_Registry::get_instance();
-		$block_type = $registry->get_registered( 'test/color-slug-with-numbers' );
+		$block_type = $registry->get_registered( $this->test_block_name );
 
 		$block_atts = array(
 			'textColor'       => 'fg1',
@@ -46,7 +63,6 @@ class Tests_Block_Supports_Colors extends WP_UnitTestCase {
 		$expected = array( 'class' => 'has-text-color has-fg-1-color has-background has-bg-2-background-color has-background has-gr-3-gradient-background' );
 
 		$this->assertSame( $expected, $actual );
-		unregister_block_type( 'test/color-slug-with-numbers' );
 	}
 
 	/**
@@ -55,9 +71,9 @@ class Tests_Block_Supports_Colors extends WP_UnitTestCase {
 	 * @covers ::wp_apply_colors_support
 	 */
 	function test_color_with_skipped_serialization_block_supports() {
-		$block_name = 'test/color-with-skipped-serialization-block-supports';
+		$this->test_block_name = 'test/color-with-skipped-serialization-block-supports';
 		register_block_type(
-			$block_name,
+			$this->test_block_name,
 			array(
 				'api_version' => 2,
 				'attributes'  => array(
@@ -76,7 +92,7 @@ class Tests_Block_Supports_Colors extends WP_UnitTestCase {
 		);
 
 		$registry   = WP_Block_Type_Registry::get_instance();
-		$block_type = $registry->get_registered( $block_name );
+		$block_type = $registry->get_registered( $this->test_block_name );
 		$block_atts = array(
 			'style' => array(
 				'color' => array(
@@ -90,7 +106,6 @@ class Tests_Block_Supports_Colors extends WP_UnitTestCase {
 		$expected = array();
 
 		$this->assertSame( $expected, $actual );
-		unregister_block_type( $block_name );
 	}
 
 	/**
@@ -99,9 +114,9 @@ class Tests_Block_Supports_Colors extends WP_UnitTestCase {
 	 * @covers ::wp_apply_colors_support
 	 */
 	function test_gradient_with_individual_skipped_serialization_block_supports() {
-		$block_name = 'test/gradient-with-individual-skipped-serialization-block-support';
+		$this->test_block_name = 'test/gradient-with-individual-skipped-serialization-block-support';
 		register_block_type(
-			$block_name,
+			$this->test_block_name,
 			array(
 				'api_version' => 2,
 				'attributes'  => array(
@@ -120,7 +135,7 @@ class Tests_Block_Supports_Colors extends WP_UnitTestCase {
 		);
 
 		$registry   = WP_Block_Type_Registry::get_instance();
-		$block_type = $registry->get_registered( $block_name );
+		$block_type = $registry->get_registered( $this->test_block_name );
 		$block_atts = array(
 			'style' => array(
 				'color' => array(
@@ -136,6 +151,5 @@ class Tests_Block_Supports_Colors extends WP_UnitTestCase {
 		);
 
 		$this->assertSame( $expected, $actual );
-		unregister_block_type( $block_name );
 	}
 }

--- a/tests/phpunit/tests/block-supports/spacing.php
+++ b/tests/phpunit/tests/block-supports/spacing.php
@@ -4,14 +4,30 @@
  */
 class Test_Block_Supports_Spacing extends WP_UnitTestCase {
 	/**
+	 * @var string|null
+	 */
+	private $test_block_name;
+
+	function set_up() {
+		parent::set_up();
+		$this->test_block_name = null;
+	}
+
+	function tear_down() {
+		unregister_block_type( $this->test_block_name );
+		$this->test_block_name = null;
+		parent::set_up();
+	}
+
+	/**
 	 * @ticket 55505
 	 *
 	 * @covers ::wp_apply_spacing_support
 	 */
 	function test_spacing_style_is_applied() {
-		$block_name = 'test/spacing-style-is-applied';
+		$this->test_block_name = 'test/spacing-style-is-applied';
 		register_block_type(
-			$block_name,
+			$this->test_block_name,
 			array(
 				'api_version' => 2,
 				'attributes'  => array(
@@ -29,7 +45,7 @@ class Test_Block_Supports_Spacing extends WP_UnitTestCase {
 			)
 		);
 		$registry   = WP_Block_Type_Registry::get_instance();
-		$block_type = $registry->get_registered( $block_name );
+		$block_type = $registry->get_registered( $this->test_block_name );
 		$block_atts = array(
 			'style' => array(
 				'spacing' => array(
@@ -51,7 +67,6 @@ class Test_Block_Supports_Spacing extends WP_UnitTestCase {
 		);
 
 		$this->assertSame( $expected, $actual );
-		unregister_block_type( $block_name );
 	}
 
 	/**
@@ -60,9 +75,9 @@ class Test_Block_Supports_Spacing extends WP_UnitTestCase {
 	 * @covers ::wp_apply_spacing_support
 	 */
 	function test_spacing_with_skipped_serialization_block_supports() {
-		$block_name = 'test/spacing-with-skipped-serialization-block-supports';
+		$this->test_block_name = 'test/spacing-with-skipped-serialization-block-supports';
 		register_block_type(
-			$block_name,
+			$this->test_block_name,
 			array(
 				'api_version' => 2,
 				'attributes'  => array(
@@ -81,7 +96,7 @@ class Test_Block_Supports_Spacing extends WP_UnitTestCase {
 			)
 		);
 		$registry   = WP_Block_Type_Registry::get_instance();
-		$block_type = $registry->get_registered( $block_name );
+		$block_type = $registry->get_registered( $this->test_block_name );
 		$block_atts = array(
 			'style' => array(
 				'spacing' => array(
@@ -101,7 +116,6 @@ class Test_Block_Supports_Spacing extends WP_UnitTestCase {
 		$expected = array();
 
 		$this->assertSame( $expected, $actual );
-		unregister_block_type( $block_name );
 	}
 
 	/**
@@ -110,9 +124,9 @@ class Test_Block_Supports_Spacing extends WP_UnitTestCase {
 	 * @covers ::wp_apply_spacing_support
 	 */
 	function test_margin_with_individual_skipped_serialization_block_supports() {
-		$block_name = 'test/margin-with-individual-skipped-serialization-block-supports';
+		$this->test_block_name = 'test/margin-with-individual-skipped-serialization-block-supports';
 		register_block_type(
-			$block_name,
+			$this->test_block_name,
 			array(
 				'api_version' => 2,
 				'attributes'  => array(
@@ -131,7 +145,7 @@ class Test_Block_Supports_Spacing extends WP_UnitTestCase {
 			)
 		);
 		$registry   = WP_Block_Type_Registry::get_instance();
-		$block_type = $registry->get_registered( $block_name );
+		$block_type = $registry->get_registered( $this->test_block_name );
 		$block_atts = array(
 			'style' => array(
 				'spacing' => array(
@@ -153,6 +167,5 @@ class Test_Block_Supports_Spacing extends WP_UnitTestCase {
 		);
 
 		$this->assertSame( $expected, $actual );
-		unregister_block_type( $block_name );
 	}
 }

--- a/tests/phpunit/tests/block-supports/typography.php
+++ b/tests/phpunit/tests/block-supports/typography.php
@@ -4,13 +4,30 @@
  */
 class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 	/**
+	 * @var string|null
+	 */
+	private $test_block_name;
+
+	function set_up() {
+		parent::set_up();
+		$this->test_block_name = null;
+	}
+
+	function tear_down() {
+		unregister_block_type( $this->test_block_name );
+		$this->test_block_name = null;
+		parent::set_up();
+	}
+
+	/**
 	 * @ticket 54337
 	 *
 	 * @covers ::wp_apply_typography_support
 	 */
 	function test_font_size_slug_with_numbers_is_kebab_cased_properly() {
+		$this->test_block_name = 'test/font-size-slug-with-numbers';
 		register_block_type(
-			'test/font-size-slug-with-numbers',
+			$this->test_block_name,
 			array(
 				'api_version' => 2,
 				'attributes'  => array(
@@ -26,7 +43,7 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 			)
 		);
 		$registry   = WP_Block_Type_Registry::get_instance();
-		$block_type = $registry->get_registered( 'test/font-size-slug-with-numbers' );
+		$block_type = $registry->get_registered( $this->test_block_name );
 
 		$block_atts = array( 'fontSize' => 'h1' );
 
@@ -34,7 +51,6 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 		$expected = array( 'class' => 'has-h-1-font-size' );
 
 		$this->assertSame( $expected, $actual );
-		unregister_block_type( 'test/font-size-slug-with-numbers' );
 	}
 	/**
 	 * @ticket 54337
@@ -42,9 +58,9 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 	 * @covers ::wp_apply_typography_support
 	 */
 	function test_font_family_with_legacy_inline_styles_using_a_value() {
-		$block_name = 'test/font-family-with-inline-styles-using-value';
+		$this->test_block_name = 'test/font-family-with-inline-styles-using-value';
 		register_block_type(
-			$block_name,
+			$this->test_block_name,
 			array(
 				'api_version' => 2,
 				'attributes'  => array(
@@ -60,14 +76,13 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 			)
 		);
 		$registry   = WP_Block_Type_Registry::get_instance();
-		$block_type = $registry->get_registered( $block_name );
+		$block_type = $registry->get_registered( $this->test_block_name );
 		$block_atts = array( 'style' => array( 'typography' => array( 'fontFamily' => 'serif' ) ) );
 
 		$actual   = wp_apply_typography_support( $block_type, $block_atts );
 		$expected = array( 'style' => 'font-family: serif;' );
 
 		$this->assertSame( $expected, $actual );
-		unregister_block_type( $block_name );
 	}
 
 	/**
@@ -76,9 +91,9 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 	 * @covers ::wp_apply_typography_support
 	 */
 	function test_typography_with_skipped_serialization_block_supports() {
-		$block_name = 'test/typography-with-skipped-serialization-block-supports';
+		$this->test_block_name = 'test/typography-with-skipped-serialization-block-supports';
 		register_block_type(
-			$block_name,
+			$this->test_block_name,
 			array(
 				'api_version' => 2,
 				'attributes'  => array(
@@ -98,7 +113,7 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 			)
 		);
 		$registry   = WP_Block_Type_Registry::get_instance();
-		$block_type = $registry->get_registered( $block_name );
+		$block_type = $registry->get_registered( $this->test_block_name );
 		$block_atts = array(
 			'style' => array(
 				'typography' => array(
@@ -114,7 +129,6 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 		$expected = array();
 
 		$this->assertSame( $expected, $actual );
-		unregister_block_type( $block_name );
 	}
 
 	/**
@@ -123,9 +137,9 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 	 * @covers ::wp_apply_typography_support
 	 */
 	function test_letter_spacing_with_individual_skipped_serialization_block_supports() {
-		$block_name = 'test/letter-spacing-with-individua-skipped-serialization-block-supports';
+		$this->test_block_name = 'test/letter-spacing-with-individua-skipped-serialization-block-supports';
 		register_block_type(
-			$block_name,
+			$this->test_block_name,
 			array(
 				'api_version' => 2,
 				'attributes'  => array(
@@ -144,14 +158,13 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 			)
 		);
 		$registry   = WP_Block_Type_Registry::get_instance();
-		$block_type = $registry->get_registered( $block_name );
+		$block_type = $registry->get_registered( $this->test_block_name );
 		$block_atts = array( 'style' => array( 'typography' => array( 'letterSpacing' => '22px' ) ) );
 
 		$actual   = wp_apply_typography_support( $block_type, $block_atts );
 		$expected = array();
 
 		$this->assertSame( $expected, $actual );
-		unregister_block_type( $block_name );
 	}
 	/**
 	 * @ticket 54337
@@ -159,9 +172,9 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 	 * @covers ::wp_apply_typography_support
 	 */
 	function test_font_family_with_legacy_inline_styles_using_a_css_var() {
-		$block_name = 'test/font-family-with-inline-styles-using-css-var';
+		$this->test_block_name = 'test/font-family-with-inline-styles-using-css-var';
 		register_block_type(
-			$block_name,
+			$this->test_block_name,
 			array(
 				'api_version' => 2,
 				'attributes'  => array(
@@ -177,14 +190,13 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 			)
 		);
 		$registry   = WP_Block_Type_Registry::get_instance();
-		$block_type = $registry->get_registered( $block_name );
+		$block_type = $registry->get_registered( $this->test_block_name );
 		$block_atts = array( 'style' => array( 'typography' => array( 'fontFamily' => 'var:preset|font-family|h1' ) ) );
 
 		$actual   = wp_apply_typography_support( $block_type, $block_atts );
 		$expected = array( 'style' => 'font-family: var(--wp--preset--font-family--h-1);' );
 
 		$this->assertSame( $expected, $actual );
-		unregister_block_type( $block_name );
 	}
 	/**
 	 * @ticket 54337
@@ -192,9 +204,9 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 	 * @covers ::wp_apply_typography_support
 	 */
 	function test_font_family_with_class() {
-		$block_name = 'test/font-family-with-class';
+		$this->test_block_name = 'test/font-family-with-class';
 		register_block_type(
-			$block_name,
+			$this->test_block_name,
 			array(
 				'api_version' => 2,
 				'attributes'  => array(
@@ -210,14 +222,13 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 			)
 		);
 		$registry   = WP_Block_Type_Registry::get_instance();
-		$block_type = $registry->get_registered( $block_name );
+		$block_type = $registry->get_registered( $this->test_block_name );
 		$block_atts = array( 'fontFamily' => 'h1' );
 
 		$actual   = wp_apply_typography_support( $block_type, $block_atts );
 		$expected = array( 'class' => 'has-h-1-font-family' );
 
 		$this->assertSame( $expected, $actual );
-		unregister_block_type( $block_name );
 	}
 
 }


### PR DESCRIPTION
Hello!

Let's unregister the block in the `tear_down` method. The block will be unregistered even if the test fails.

See discussion: https://github.com/WordPress/wordpress-develop/pull/2500#discussion_r844275468

Props @gziolo @anton-vlasenko

Corresponding Gutenberg PR:

- https://github.com/WordPress/gutenberg/pull/40239

Trac ticket: https://core.trac.wordpress.org/ticket/55505

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
