### PR TITLE
Improve cache key generation in WP_Comment_Query

### DIFF
--- a/src/wp-includes/class-wp-comment-query.php
+++ b/src/wp-includes/class-wp-comment-query.php
@@ -444,10 +444,12 @@ class WP_Comment_Query {
 
 		/*
 		 * Only use the args defined in the query_var_defaults to compute the key,
-		 * but ignore 'fields', which does not affect query results.
+		 * but ignore 'fields', 'update_comment_meta_cache', 'update_comment_post_cache' which does not affect query results.
 		 */
 		$_args = wp_array_slice_assoc( $this->query_vars, array_keys( $this->query_var_defaults ) );
 		unset( $_args['fields'] );
+		unset( $_args['update_comment_meta_cache'] );
+		unset( $_args['update_comment_post_cache'] );
 
 		$key          = md5( serialize( $_args ) );
 		$last_changed = wp_cache_get_last_changed( 'comment' );

--- a/src/wp-includes/class-wp-comment-query.php
+++ b/src/wp-includes/class-wp-comment-query.php
@@ -447,9 +447,7 @@ class WP_Comment_Query {
 		 * but ignore 'fields', 'update_comment_meta_cache', 'update_comment_post_cache' which does not affect query results.
 		 */
 		$_args = wp_array_slice_assoc( $this->query_vars, array_keys( $this->query_var_defaults ) );
-		unset( $_args['fields'] );
-		unset( $_args['update_comment_meta_cache'] );
-		unset( $_args['update_comment_post_cache'] );
+		unset( $_args['fields'], $_args['update_comment_meta_cache'], $_args['update_comment_post_cache'] );
 
 		$key          = md5( serialize( $_args ) );
 		$last_changed = wp_cache_get_last_changed( 'comment' );

--- a/tests/phpunit/tests/comment/query.php
+++ b/tests/phpunit/tests/comment/query.php
@@ -4946,8 +4946,6 @@ class Tests_Comment_Query extends WP_UnitTestCase {
 	 * @ticket 55460
 	 */
 	public function test_comment_cache_key_should_ignore_unset_params() {
-		global $wpdb;
-
 		$p = self::factory()->post->create();
 		$c = self::factory()->comment->create( array( 'comment_post_ID' => $p ) );
 
@@ -4961,33 +4959,13 @@ class Tests_Comment_Query extends WP_UnitTestCase {
 		$q1 = new WP_Comment_Query();
 		$q1->query( $_args );
 
-		$num_queries_all_args = $wpdb->num_queries;
+		$num_queries_all_args = get_num_queries();
 
-		// Unset 'fields'.
-		unset( $_args['fields'] );
+		// Ignore 'fields', 'update_comment_meta_cache', 'update_comment_post_cache'.
+		unset( $_args['fields'], $_args['update_comment_meta_cache'], $_args['update_comment_post_cache'] );
 		$q2 = new WP_Comment_Query();
 		$q2->query( $_args );
 
-		$num_queries_skip_fields = $wpdb->num_queries;
-
-		$this->assertSame( $num_queries_all_args, $num_queries_skip_fields );
-
-		// Unset 'update_comment_meta_cache'.
-		unset( $_args['update_comment_meta_cache'] );
-		$q3 = new WP_Comment_Query();
-		$q3->query( $_args );
-
-		$num_queries_skip_meta_cache = $wpdb->num_queries;
-
-		$this->assertSame( $num_queries_all_args, $num_queries_skip_meta_cache );
-
-		// Unset 'update_comment_post_cache'.
-		unset( $_args['update_comment_post_cache'] );
-		$q3 = new WP_Comment_Query();
-		$q3->query( $_args );
-
-		$num_queries_skip_post_cache = $wpdb->num_queries;
-
-		$this->assertSame( $num_queries_all_args, $num_queries_skip_post_cache );
+		$this->assertSame( $num_queries_all_args, get_num_queries() );
 	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/55460<!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
