### PR TITLE
Remove block patterns from server-generated settings

### DIFF
--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -202,8 +202,6 @@ $editor_settings = array(
 		'ajaxUrl'     => admin_url( 'admin-ajax.php' ),
 	),
 	'supportsLayout'                       => WP_Theme_JSON_Resolver::theme_has_support(),
-	'__experimentalBlockPatterns'          => WP_Block_Patterns_Registry::get_instance()->get_all_registered(),
-	'__experimentalBlockPatternCategories' => WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered(),
 	'supportsTemplateMode'                 => current_theme_supports( 'block-templates' ),
 
 	// Whether or not to load the 'postcustom' meta box is stored as a user meta

--- a/src/wp-admin/site-editor.php
+++ b/src/wp-admin/site-editor.php
@@ -67,8 +67,6 @@ $custom_settings      = array(
 	'defaultTemplateTypes'                 => $indexed_template_types,
 	'defaultTemplatePartAreas'             => get_allowed_block_template_part_areas(),
 	'__unstableHomeTemplate'               => $home_template,
-	'__experimentalBlockPatterns'          => WP_Block_Patterns_Registry::get_instance()->get_all_registered(),
-	'__experimentalBlockPatternCategories' => WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered(),
 );
 $editor_settings      = get_block_editor_settings( $custom_settings, $block_editor_context );
 


### PR DESCRIPTION
Backport of https://github.com/WordPress/gutenberg/pull/39185, namely the part where the `gutenberg_remove_block_patterns_settings` filter function removes the block patterns fields from settings.

Trac ticket: https://core.trac.wordpress.org/ticket/55505