### PR TITLE
Update Gallery block unit tests to new gallery format with nested Image blocks

### DIFF
--- a/tests/phpunit/data/blocks/fixtures/core__gallery.html
+++ b/tests/phpunit/data/blocks/fixtures/core__gallery.html
@@ -1,14 +1,15 @@
-<!-- wp:core/gallery -->
-<ul class="wp-block-gallery columns-2 is-cropped">
-	<li class="blocks-gallery-item">
-		<figure>
-			<img src="https://cldup.com/uuUqE_dXzy.jpg" alt="title" />
-		</figure>
-	</li>
-	<li class="blocks-gallery-item">
-		<figure>
-			<img src="http://google.com/hi.png" alt="title" />
-		</figure>
-	</li>
-</ul>
-<!-- /wp:core/gallery -->
+<!-- wp:gallery {"linkTo":"none","className":"columns-2"} -->
+<figure class="wp-block-gallery has-nested-images columns-default is-cropped columns-2">
+	<!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
+	<figure class="wp-block-image size-large">
+		<img src="https://cldup.com/uuUqE_dXzy.jpg" alt="Image gallery image" />
+	</figure>
+	<!-- /wp:image -->
+
+	<!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
+	<figure class="wp-block-image size-large">
+		<img src="http://google.com/hi.png" alt="Image gallery image" />
+	</figure>
+	<!-- /wp:image -->
+</figure>
+<!-- /wp:gallery -->

--- a/tests/phpunit/data/blocks/fixtures/core__gallery.json
+++ b/tests/phpunit/data/blocks/fixtures/core__gallery.json
@@ -1,25 +1,44 @@
 [
-    {
-        "clientId": "_clientId_0",
-        "name": "core/gallery",
-        "isValid": true,
-        "attributes": {
-            "images": [
-                {
-                    "url": "https://cldup.com/uuUqE_dXzy.jpg",
-                    "alt": "title",
-                    "caption": ""
-                },
-                {
-                    "url": "http://google.com/hi.png",
-                    "alt": "title",
-                    "caption": ""
-                }
-            ],
-            "imageCrop": true,
-            "linkTo": "none"
-        },
-        "innerBlocks": [],
-        "originalContent": "<ul class=\"wp-block-gallery columns-2 is-cropped\">\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"http://google.com/hi.png\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n</ul>"
-    }
+	{
+		"name": "core/gallery",
+		"isValid": true,
+		"attributes": {
+			"images": [],
+			"ids": [],
+			"shortCodeTransforms": [],
+			"caption": "",
+			"imageCrop": true,
+			"fixedHeight": true,
+			"linkTo": "none",
+			"sizeSlug": "large",
+			"allowResize": false,
+			"className": "columns-2"
+		},
+		"innerBlocks": [
+			{
+				"name": "core/image",
+				"isValid": true,
+				"attributes": {
+					"url": "https://cldup.com/uuUqE_dXzy.jpg",
+					"alt": "Image gallery image",
+					"caption": "",
+					"sizeSlug": "large",
+					"linkDestination": "none"
+				},
+				"innerBlocks": []
+			},
+			{
+				"name": "core/image",
+				"isValid": true,
+				"attributes": {
+					"url": "http://google.com/hi.png",
+					"alt": "Image gallery image",
+					"caption": "",
+					"sizeSlug": "large",
+					"linkDestination": "none"
+				},
+				"innerBlocks": []
+			}
+		]
+	}
 ]

--- a/tests/phpunit/data/blocks/fixtures/core__gallery.parsed.json
+++ b/tests/phpunit/data/blocks/fixtures/core__gallery.parsed.json
@@ -39,5 +39,14 @@
 			null,
 			"\n</figure>\n"
 		]
-	}
+	},
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n",
+        "innerContent": [
+            "\n"
+        ]
+    }
 ]

--- a/tests/phpunit/data/blocks/fixtures/core__gallery.parsed.json
+++ b/tests/phpunit/data/blocks/fixtures/core__gallery.parsed.json
@@ -13,9 +13,9 @@
 					"linkDestination": "none"
 				},
 				"innerBlocks": [],
-				"innerHTML": "\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"https://cldup.com/uuUqE_dXzy.jpg\"\n\t\t\talt=\"Image gallery image\"\n\t\t\t/>\n\t</figure>\n\t",
+				"innerHTML": "\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"Image gallery image\" />\n\t</figure>\n\t",
 				"innerContent": [
-					"\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"https://cldup.com/uuUqE_dXzy.jpg\"\n\t\t\talt=\"Image gallery image\"\n\t\t\t/>\n\t</figure>\n\t"
+					"\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"Image gallery image\" />\n\t</figure>\n\t"
 				]
 			},
 			{
@@ -25,15 +25,15 @@
 					"linkDestination": "none"
 				},
 				"innerBlocks": [],
-				"innerHTML": "\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"http://google.com/hi.png\"\n\t\t\talt=\"Image gallery image\"\n\t\t/>\n\t</figure>\n\t",
+				"innerHTML": "\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img src=\"http://google.com/hi.png\" alt=\"Image gallery image\" />\n\t</figure>\n\t",
 				"innerContent": [
-					"\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"http://google.com/hi.png\"\n\t\t\talt=\"Image gallery image\"\n\t\t\t/>\n\t</figure>\n\t"
+					"\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img src=\"http://google.com/hi.png\" alt=\"Image gallery image\" />\n\t</figure>\n\t"
 				]
 			}
 		],
-		"innerHTML": "\n<figure\n\tclass=\"wp-block-gallery has-nested-images columns-default is-cropped columns-2\"\n>\n\t\n\n\t\n</figure>\n",
+		"innerHTML": "\n<figure class=\"wp-block-gallery has-nested-images columns-default is-cropped columns-2\">\n\t\n\n\t\n</figure>\n",
 		"innerContent": [
-			"\n<figure\n\tclass=\"wp-block-gallery has-nested-images columns-default is-cropped columns-2\"\n>\n\t",
+			"\n<figure class=\"wp-block-gallery has-nested-images columns-default is-cropped columns-2\">\n\t",
 			null,
 			"\n\n\t",
 			null,
@@ -41,4 +41,3 @@
 		]
 	}
 ]
-

--- a/tests/phpunit/data/blocks/fixtures/core__gallery.parsed.json
+++ b/tests/phpunit/data/blocks/fixtures/core__gallery.parsed.json
@@ -1,20 +1,44 @@
 [
-    {
-        "blockName": "core/gallery",
-        "attrs": {},
-        "innerBlocks": [],
-        "innerHTML": "\n<ul class=\"wp-block-gallery columns-2 is-cropped\">\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"http://google.com/hi.png\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n</ul>\n",
-        "innerContent": [
-            "\n<ul class=\"wp-block-gallery columns-2 is-cropped\">\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"http://google.com/hi.png\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n</ul>\n"
-        ]
-    },
-    {
-        "blockName": null,
-        "attrs": {},
-        "innerBlocks": [],
-        "innerHTML": "\n",
-        "innerContent": [
-            "\n"
-        ]
-    }
+	{
+		"blockName": "core/gallery",
+		"attrs": {
+			"linkTo": "none",
+			"className": "columns-2"
+		},
+		"innerBlocks": [
+			{
+				"blockName": "core/image",
+				"attrs": {
+					"sizeSlug": "large",
+					"linkDestination": "none"
+				},
+				"innerBlocks": [],
+				"innerHTML": "\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"https://cldup.com/uuUqE_dXzy.jpg\"\n\t\t\talt=\"Image gallery image\"\n\t\t\t/>\n\t</figure>\n\t",
+				"innerContent": [
+					"\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"https://cldup.com/uuUqE_dXzy.jpg\"\n\t\t\talt=\"Image gallery image\"\n\t\t\t/>\n\t</figure>\n\t"
+				]
+			},
+			{
+				"blockName": "core/image",
+				"attrs": {
+					"sizeSlug": "large",
+					"linkDestination": "none"
+				},
+				"innerBlocks": [],
+				"innerHTML": "\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"http://google.com/hi.png\"\n\t\t\talt=\"Image gallery image\"\n\t\t/>\n\t</figure>\n\t",
+				"innerContent": [
+					"\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"http://google.com/hi.png\"\n\t\t\talt=\"Image gallery image\"\n\t\t\t/>\n\t</figure>\n\t"
+				]
+			}
+		],
+		"innerHTML": "\n<figure\n\tclass=\"wp-block-gallery has-nested-images columns-default is-cropped columns-2\"\n>\n\t\n\n\t\n</figure>\n",
+		"innerContent": [
+			"\n<figure\n\tclass=\"wp-block-gallery has-nested-images columns-default is-cropped columns-2\"\n>\n\t",
+			null,
+			"\n\n\t",
+			null,
+			"\n</figure>\n"
+		]
+	}
 ]
+

--- a/tests/phpunit/data/blocks/fixtures/core__gallery.serialized.html
+++ b/tests/phpunit/data/blocks/fixtures/core__gallery.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:gallery -->
-<ul class="wp-block-gallery columns-2 is-cropped"><li class="blocks-gallery-item"><figure><img src="https://cldup.com/uuUqE_dXzy.jpg" alt="title"/></figure></li><li class="blocks-gallery-item"><figure><img src="http://google.com/hi.png" alt="title"/></figure></li></ul>
+<!-- wp:gallery {"linkTo":"none","className":"columns-2"} -->
+<figure class="wp-block-gallery has-nested-images columns-default is-cropped columns-2"><!-- wp:image {"sizeSlug":"large","linkDestination":"none"} --><figure class="wp-block-image size-large"><img src="https://cldup.com/uuUqE_dXzy.jpg" alt="Image gallery image" /></figure><!-- /wp:image --><!-- wp:image {"sizeSlug":"large","linkDestination":"none"} --><figure class="wp-block-image size-large"><img src="http://google.com/hi.png" alt="Image gallery image" /></figure><!-- /wp:image --></figure>
 <!-- /wp:gallery -->

--- a/tests/phpunit/data/blocks/fixtures/core__gallery.server.html
+++ b/tests/phpunit/data/blocks/fixtures/core__gallery.server.html
@@ -1,11 +1,12 @@
-<figure
-	class="wp-container-1 wp-block-gallery-1 wp-block-gallery has-nested-images columns-default is-cropped columns-2"
->
+<figure class="wp-container-1 wp-block-gallery-1 wp-block-gallery has-nested-images columns-default is-cropped columns-2">
+
 	<figure class="wp-block-image size-large">
 		<img src="https://cldup.com/uuUqE_dXzy.jpg" alt="Image gallery image" />
 	</figure>
 
+
 	<figure class="wp-block-image size-large">
 		<img src="http://google.com/hi.png" alt="Image gallery image" />
 	</figure>
+
 </figure>

--- a/tests/phpunit/data/blocks/fixtures/core__gallery.server.html
+++ b/tests/phpunit/data/blocks/fixtures/core__gallery.server.html
@@ -1,12 +1,15 @@
-<figure class="wp-container-1 wp-block-gallery-1 wp-block-gallery has-nested-images columns-default is-cropped columns-2">
 
+<figure class="wp-container-1 wp-block-gallery-1 wp-block-gallery has-nested-images columns-default is-cropped columns-2">
+	
 	<figure class="wp-block-image size-large">
 		<img src="https://cldup.com/uuUqE_dXzy.jpg" alt="Image gallery image" />
 	</figure>
+	
 
-
+	
 	<figure class="wp-block-image size-large">
 		<img src="http://google.com/hi.png" alt="Image gallery image" />
 	</figure>
-
+	
 </figure>
+

--- a/tests/phpunit/data/blocks/fixtures/core__gallery.server.html
+++ b/tests/phpunit/data/blocks/fixtures/core__gallery.server.html
@@ -1,14 +1,11 @@
+<figure
+	class="wp-container-1 wp-block-gallery-1 wp-block-gallery has-nested-images columns-default is-cropped columns-2"
+>
+	<figure class="wp-block-image size-large">
+		<img src="https://cldup.com/uuUqE_dXzy.jpg" alt="Image gallery image" />
+	</figure>
 
-<ul class="wp-container-1 wp-block-gallery-1 wp-block-gallery columns-2 is-cropped">
-	<li class="blocks-gallery-item">
-		<figure>
-			<img src="https://cldup.com/uuUqE_dXzy.jpg" alt="title" />
-		</figure>
-	</li>
-	<li class="blocks-gallery-item">
-		<figure>
-			<img src="http://google.com/hi.png" alt="title" />
-		</figure>
-	</li>
-</ul>
-
+	<figure class="wp-block-image size-large">
+		<img src="http://google.com/hi.png" alt="Image gallery image" />
+	</figure>
+</figure>

--- a/tests/phpunit/data/blocks/fixtures/core__gallery__columns.html
+++ b/tests/phpunit/data/blocks/fixtures/core__gallery__columns.html
@@ -1,14 +1,15 @@
-<!-- wp:core/gallery {"columns":1} -->
-<ul class="wp-block-gallery columns-1 is-cropped">
-	<li class="blocks-gallery-item">
-		<figure>
-			<img src="https://cldup.com/uuUqE_dXzy.jpg" alt="title" />
-		</figure>
-	</li>
-	<li class="blocks-gallery-item">
-		<figure>
-			<img src="http://google.com/hi.png" alt="title" />
-		</figure>
-	</li>
-</ul>
-<!-- /wp:core/gallery -->
+<!-- wp:gallery {"linkTo":"none","className":"columns-1"} -->
+<figure class="wp-block-gallery has-nested-images is-cropped columns-1" >
+	<!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
+	<figure class="wp-block-image size-large">
+		<img src="https://cldup.com/uuUqE_dXzy.jpg" alt="Image gallery image" />
+	</figure>
+	<!-- /wp:image -->
+
+	<!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
+	<figure class="wp-block-image size-large">
+		<img src="http://google.com/hi.png" alt="Image gallery image" />
+	</figure>
+	<!-- /wp:image -->
+</figure>
+<!-- /wp:gallery -->

--- a/tests/phpunit/data/blocks/fixtures/core__gallery__columns.json
+++ b/tests/phpunit/data/blocks/fixtures/core__gallery__columns.json
@@ -1,26 +1,45 @@
 [
-    {
-        "clientId": "_clientId_0",
-        "name": "core/gallery",
-        "isValid": true,
-        "attributes": {
-            "images": [
-                {
-                    "url": "https://cldup.com/uuUqE_dXzy.jpg",
-                    "alt": "title",
-                    "caption": ""
-                },
-                {
-                    "url": "http://google.com/hi.png",
-                    "alt": "title",
-                    "caption": ""
-                }
-            ],
-            "columns": 1,
-            "imageCrop": true,
-            "linkTo": "none"
-        },
-        "innerBlocks": [],
-        "originalContent": "<ul class=\"wp-block-gallery columns-1 is-cropped\">\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"http://google.com/hi.png\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n</ul>"
-    }
+	{
+		"name": "core/gallery",
+		"isValid": true,
+		"attributes": {
+			"images": [],
+			"ids": [],
+			"shortCodeTransforms": [],
+			"caption": "",
+			"imageCrop": true,
+			"fixedHeight": true,
+			"linkTo": "none",
+			"sizeSlug": "large",
+			"allowResize": false,
+			"className": "columns-1",
+            "columns": 1
+		},
+		"innerBlocks": [
+			{
+				"name": "core/image",
+				"isValid": true,
+				"attributes": {
+					"url": "https://cldup.com/uuUqE_dXzy.jpg",
+					"alt": "Image gallery image",
+					"caption": "",
+					"sizeSlug": "large",
+					"linkDestination": "none"
+				},
+				"innerBlocks": []
+			},
+			{
+				"name": "core/image",
+				"isValid": true,
+				"attributes": {
+					"url": "http://google.com/hi.png",
+					"alt": "Image gallery image",
+					"caption": "",
+					"sizeSlug": "large",
+					"linkDestination": "none"
+				},
+				"innerBlocks": []
+			}
+		]
+	}
 ]

--- a/tests/phpunit/data/blocks/fixtures/core__gallery__columns.parsed.json
+++ b/tests/phpunit/data/blocks/fixtures/core__gallery__columns.parsed.json
@@ -13,9 +13,9 @@
 					"linkDestination": "none"
 				},
 				"innerBlocks": [],
-				"innerHTML": "\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"https://cldup.com/uuUqE_dXzy.jpg\"\n\t\t\talt=\"Image gallery image\"\n\t\t\t/>\n\t</figure>\n\t",
+				"innerHTML": "\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"Image gallery image\" />\n\t</figure>\n\t",
 				"innerContent": [
-					"\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"https://cldup.com/uuUqE_dXzy.jpg\"\n\t\t\talt=\"Image gallery image\"\n\t\t\t/>\n\t</figure>\n\t"
+					"\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"Image gallery image\" />\n\t</figure>\n\t"
 				]
 			},
 			{
@@ -25,15 +25,15 @@
 					"linkDestination": "none"
 				},
 				"innerBlocks": [],
-				"innerHTML": "\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"http://google.com/hi.png\"\n\t\t\talt=\"Image gallery image\"\n\t\t/>\n\t</figure>\n\t",
+				"innerHTML": "\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img src=\"http://google.com/hi.png\" alt=\"Image gallery image\" />\n\t</figure>\n\t",
 				"innerContent": [
-					"\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"http://google.com/hi.png\"\n\t\t\talt=\"Image gallery image\"\n\t\t\t/>\n\t</figure>\n\t"
+					"\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img src=\"http://google.com/hi.png\" alt=\"Image gallery image\" />\n\t</figure>\n\t"
 				]
 			}
 		],
-		"innerHTML": "\n<figure\n\tclass=\"wp-block-gallery has-nested-images columns-default is-cropped columns-2\"\n>\n\t\n\n\t\n</figure>\n",
+		"innerHTML": "\n<figure class=\"wp-block-gallery has-nested-images is-cropped columns-1\" >\n\t\n\n\t\n</figure>\n",
 		"innerContent": [
-			"\n<figure\n\tclass=\"wp-block-gallery has-nested-images is-cropped columns-1\"\n>\n\t",
+			"\n<figure class=\"wp-block-gallery has-nested-images is-cropped columns-1\" >\n\t",
 			null,
 			"\n\n\t",
 			null,
@@ -41,4 +41,3 @@
 		]
 	}
 ]
-

--- a/tests/phpunit/data/blocks/fixtures/core__gallery__columns.parsed.json
+++ b/tests/phpunit/data/blocks/fixtures/core__gallery__columns.parsed.json
@@ -39,5 +39,14 @@
 			null,
 			"\n</figure>\n"
 		]
-	}
+	},
+    {
+        "blockName": null,
+        "attrs": {},
+        "innerBlocks": [],
+        "innerHTML": "\n",
+        "innerContent": [
+            "\n"
+        ]
+    }
 ]

--- a/tests/phpunit/data/blocks/fixtures/core__gallery__columns.parsed.json
+++ b/tests/phpunit/data/blocks/fixtures/core__gallery__columns.parsed.json
@@ -1,22 +1,44 @@
 [
-    {
-        "blockName": "core/gallery",
-        "attrs": {
-            "columns": 1
-        },
-        "innerBlocks": [],
-        "innerHTML": "\n<ul class=\"wp-block-gallery columns-1 is-cropped\">\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"http://google.com/hi.png\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n</ul>\n",
-        "innerContent": [
-            "\n<ul class=\"wp-block-gallery columns-1 is-cropped\">\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"https://cldup.com/uuUqE_dXzy.jpg\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n\t<li class=\"blocks-gallery-item\">\n\t\t<figure>\n\t\t\t<img src=\"http://google.com/hi.png\" alt=\"title\" />\n\t\t</figure>\n\t</li>\n</ul>\n"
-        ]
-    },
-    {
-        "blockName": null,
-        "attrs": {},
-        "innerBlocks": [],
-        "innerHTML": "\n",
-        "innerContent": [
-            "\n"
-        ]
-    }
+	{
+		"blockName": "core/gallery",
+		"attrs": {
+			"linkTo": "none",
+			"className": "columns-1"
+		},
+		"innerBlocks": [
+			{
+				"blockName": "core/image",
+				"attrs": {
+					"sizeSlug": "large",
+					"linkDestination": "none"
+				},
+				"innerBlocks": [],
+				"innerHTML": "\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"https://cldup.com/uuUqE_dXzy.jpg\"\n\t\t\talt=\"Image gallery image\"\n\t\t\t/>\n\t</figure>\n\t",
+				"innerContent": [
+					"\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"https://cldup.com/uuUqE_dXzy.jpg\"\n\t\t\talt=\"Image gallery image\"\n\t\t\t/>\n\t</figure>\n\t"
+				]
+			},
+			{
+				"blockName": "core/image",
+				"attrs": {
+					"sizeSlug": "large",
+					"linkDestination": "none"
+				},
+				"innerBlocks": [],
+				"innerHTML": "\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"http://google.com/hi.png\"\n\t\t\talt=\"Image gallery image\"\n\t\t/>\n\t</figure>\n\t",
+				"innerContent": [
+					"\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"http://google.com/hi.png\"\n\t\t\talt=\"Image gallery image\"\n\t\t\t/>\n\t</figure>\n\t"
+				]
+			}
+		],
+		"innerHTML": "\n<figure\n\tclass=\"wp-block-gallery has-nested-images columns-default is-cropped columns-2\"\n>\n\t\n\n\t\n</figure>\n",
+		"innerContent": [
+			"\n<figure\n\tclass=\"wp-block-gallery has-nested-images is-cropped columns-1\"\n>\n\t",
+			null,
+			"\n\n\t",
+			null,
+			"\n</figure>\n"
+		]
+	}
 ]
+

--- a/tests/phpunit/data/blocks/fixtures/core__gallery__columns.serialized.html
+++ b/tests/phpunit/data/blocks/fixtures/core__gallery__columns.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:gallery {"columns":1} -->
-<ul class="wp-block-gallery columns-1 is-cropped"><li class="blocks-gallery-item"><figure><img src="https://cldup.com/uuUqE_dXzy.jpg" alt="title"/></figure></li><li class="blocks-gallery-item"><figure><img src="http://google.com/hi.png" alt="title"/></figure></li></ul>
+<!-- wp:gallery {"linkTo":"none","className":"columns-1"} -->
+<figure class="wp-block-gallery has-nested-images is-cropped columns-1"><!-- wp:image {"sizeSlug":"large","linkDestination":"none"} --><figure class="wp-block-image size-large"><img src="https://cldup.com/uuUqE_dXzy.jpg" alt="Image gallery image" /></figure><!-- /wp:image --><!-- wp:image {"sizeSlug":"large","linkDestination":"none"} --><figure class="wp-block-image size-large"><img src="http://google.com/hi.png" alt="Image gallery image" /></figure><!-- /wp:image --></figure>
 <!-- /wp:gallery -->

--- a/tests/phpunit/data/blocks/fixtures/core__gallery__columns.server.html
+++ b/tests/phpunit/data/blocks/fixtures/core__gallery__columns.server.html
@@ -1,6 +1,5 @@
-<figure
-	class="wp-container-1 wp-block-gallery-1 wp-block-gallery has-nested-images is-cropped columns-1"
->
+<figure class="wp-container-1 wp-block-gallery-1 wp-block-gallery has-nested-images is-cropped columns-1" >
+
 	<figure class="wp-block-image size-large">
 		<img src="https://cldup.com/uuUqE_dXzy.jpg" alt="Image gallery image" />
 	</figure>
@@ -8,4 +7,5 @@
 	<figure class="wp-block-image size-large">
 		<img src="http://google.com/hi.png" alt="Image gallery image" />
 	</figure>
+
 </figure>

--- a/tests/phpunit/data/blocks/fixtures/core__gallery__columns.server.html
+++ b/tests/phpunit/data/blocks/fixtures/core__gallery__columns.server.html
@@ -1,14 +1,11 @@
+<figure
+	class="wp-container-1 wp-block-gallery-1 wp-block-gallery has-nested-images is-cropped columns-1"
+>
+	<figure class="wp-block-image size-large">
+		<img src="https://cldup.com/uuUqE_dXzy.jpg" alt="Image gallery image" />
+	</figure>
 
-<ul class="wp-container-1 wp-block-gallery-1 wp-block-gallery columns-1 is-cropped">
-	<li class="blocks-gallery-item">
-		<figure>
-			<img src="https://cldup.com/uuUqE_dXzy.jpg" alt="title" />
-		</figure>
-	</li>
-	<li class="blocks-gallery-item">
-		<figure>
-			<img src="http://google.com/hi.png" alt="title" />
-		</figure>
-	</li>
-</ul>
-
+	<figure class="wp-block-image size-large">
+		<img src="http://google.com/hi.png" alt="Image gallery image" />
+	</figure>
+</figure>

--- a/tests/phpunit/data/blocks/fixtures/core__gallery__columns.server.html
+++ b/tests/phpunit/data/blocks/fixtures/core__gallery__columns.server.html
@@ -1,11 +1,15 @@
-<figure class="wp-container-1 wp-block-gallery-1 wp-block-gallery has-nested-images is-cropped columns-1" >
 
+<figure class="wp-container-1 wp-block-gallery-1 wp-block-gallery has-nested-images is-cropped columns-1" >
+	
 	<figure class="wp-block-image size-large">
 		<img src="https://cldup.com/uuUqE_dXzy.jpg" alt="Image gallery image" />
 	</figure>
+	
 
+	
 	<figure class="wp-block-image size-large">
 		<img src="http://google.com/hi.png" alt="Image gallery image" />
 	</figure>
-
+	
 </figure>
+


### PR DESCRIPTION
The Gallery block unit tests still use the old format, so this PR updates it to the new format that uses nested Image blocks.
---
Fixes: https://core.trac.wordpress.org/ticket/55571
## To test

Run:

- `npm run test:php -- --filter Tests_Blocks_wpBlockParser`
- `npm run test:php -- --filter Tests_Blocks_Render`

**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
