### PR TITLE
Fix incorrect casing of patterns endpoint schema properties

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-patterns-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-patterns-controller.php
@@ -160,13 +160,13 @@ class WP_REST_Block_Patterns_Controller extends WP_REST_Controller {
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit', 'embed' ),
 				),
-				'viewport_Width' => array(
+				'viewport_width' => array(
 					'description' => __( 'The pattern viewport width for inserter preview.' ),
 					'type'        => 'number',
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit', 'embed' ),
 				),
-				'block_Types'    => array(
+				'block_types'    => array(
 					'description' => __( 'Block types that the pattern is intended to be used with.' ),
 					'type'        => 'array',
 					'readonly'    => true,


### PR DESCRIPTION
Fixes an issue introduced in https://github.com/WordPress/wordpress-develop/commit/bca9b6d9401b60dfe8fd86eeeeca68b1cad4d929.

A couple of the field names had incorrect casing which resulted in them not being returned by the REST API.

Trac ticket: https://core.trac.wordpress.org/ticket/55505

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
