### PR TITLE
Media: Remove attachment_fields_to_save and deprecate image_attachment_fields_to_save()

### DIFF
--- a/src/wp-admin/includes/admin-filters.php
+++ b/src/wp-admin/includes/admin-filters.php
@@ -31,8 +31,6 @@ add_filter( 'async_upload_audio', 'get_media_item', 10, 2 );
 add_filter( 'async_upload_video', 'get_media_item', 10, 2 );
 add_filter( 'async_upload_file', 'get_media_item', 10, 2 );
 
-add_filter( 'attachment_fields_to_save', 'image_attachment_fields_to_save', 10, 2 );
-
 add_filter( 'media_upload_gallery', 'media_upload_gallery' );
 add_filter( 'media_upload_library', 'media_upload_library' );
 

--- a/src/wp-admin/includes/deprecated.php
+++ b/src/wp-admin/includes/deprecated.php
@@ -1569,7 +1569,7 @@ function _wp_privacy_requests_screen_options() {
 }
 
 /**
- * Was used to filter input from media_upload_form_handler() and assigns a default
+ * Was used to filter input from media_upload_form_handler() and to assign a default
  * post_title from the file name if none supplied.
  *
  * @since 2.5.0
@@ -1577,7 +1577,7 @@ function _wp_privacy_requests_screen_options() {
  *
  * @param array $post       The WP_Post attachment object converted to an array.
  * @param array $attachment An array of attachment metadata.
- * @return array Attachment post object.
+ * @return array Attachment post object converted to an array.
  */
 function image_attachment_fields_to_save( $post, $attachment ) {
 	_deprecated_function( __FUNCTION__, '6.0.0' );

--- a/src/wp-admin/includes/deprecated.php
+++ b/src/wp-admin/includes/deprecated.php
@@ -1567,3 +1567,20 @@ class WP_Privacy_Data_Removal_Requests_Table extends WP_Privacy_Data_Removal_Req
 function _wp_privacy_requests_screen_options() {
 	_deprecated_function( __FUNCTION__, '5.3.0' );
 }
+
+/**
+ * Was used to filter input from media_upload_form_handler() and assigns a default
+ * post_title from the file name if none supplied.
+ *
+ * @since 2.5.0
+ * @deprecated 6.0.0
+ *
+ * @param array $post       The WP_Post attachment object converted to an array.
+ * @param array $attachment An array of attachment metadata.
+ * @return array Attachment post object.
+ */
+function image_attachment_fields_to_save( $post, $attachment ) {
+	_deprecated_function( __FUNCTION__, '6.0.0' );
+
+	return $post;
+}

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -1322,31 +1322,6 @@ function media_post_single_attachment_fields_to_edit( $form_fields, $post ) {
 }
 
 /**
- * Filters input from media_upload_form_handler() and assigns a default
- * post_title from the file name if none supplied.
- *
- * Illustrates the use of the {@see 'attachment_fields_to_save'} filter
- * which can be used to add default values to any field before saving to DB.
- *
- * @since 2.5.0
- *
- * @param array $post       The WP_Post attachment object converted to an array.
- * @param array $attachment An array of attachment metadata.
- * @return array Filtered attachment post object.
- */
-function image_attachment_fields_to_save( $post, $attachment ) {
-	if ( 'image' === substr( $post['post_mime_type'], 0, 5 ) ) {
-		if ( strlen( trim( $post['post_title'] ) ) == 0 ) {
-			$attachment_url                           = ( isset( $post['attachment_url'] ) ) ? $post['attachment_url'] : $post['guid'];
-			$post['post_title']                       = preg_replace( '/\.\w+$/', '', wp_basename( $attachment_url ) );
-			$post['errors']['post_title']['errors'][] = __( 'Empty Title filled from filename.' );
-		}
-	}
-
-	return $post;
-}
-
-/**
  * Retrieves the media element HTML to send to the editor.
  *
  * @since 2.5.0


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/39108

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
