### PR TITLE
Patterns REST API: Add 'inserter' to the schema

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-patterns-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-patterns-controller.php
@@ -115,6 +115,7 @@ class WP_REST_Block_Patterns_Controller extends WP_REST_Controller {
 			'categories'    => 'categories',
 			'keywords'      => 'keywords',
 			'content'       => 'content',
+			'inserter'      => 'inserter',
 		);
 		$data   = array();
 		foreach ( $keys as $item_key => $rest_key ) {
@@ -187,6 +188,12 @@ class WP_REST_Block_Patterns_Controller extends WP_REST_Controller {
 				'content'        => array(
 					'description' => __( 'The pattern content.' ),
 					'type'        => 'string',
+					'readonly'    => true,
+					'context'     => array( 'view', 'edit', 'embed' ),
+				),
+				'inserter'       => array(
+					'description' => __( 'Determines whether the pattern is visible in inserter.', 'gutenberg' ),
+					'type'        => 'boolean',
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit', 'embed' ),
 				),

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-patterns-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-patterns-controller.php
@@ -192,7 +192,7 @@ class WP_REST_Block_Patterns_Controller extends WP_REST_Controller {
 					'context'     => array( 'view', 'edit', 'embed' ),
 				),
 				'inserter'       => array(
-					'description' => __( 'Determines whether the pattern is visible in inserter.', 'gutenberg' ),
+					'description' => __( 'Determines whether the pattern is visible in inserter.' ),
 					'type'        => 'boolean',
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit', 'embed' ),


### PR DESCRIPTION
Backports changes from https://github.com/WordPress/gutenberg/pull/40416

> Adds the missing `inserter` field to the Patterns item schema.
> Currently, this field is omitted from the response, and patterns that should be hidden in the inserter are visible.

Props, @ndiego, for discovering a bug and testing the fix.

Trac ticket: https://core.trac.wordpress.org/ticket/55567

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
