### PR TITLE
Fix undefined `script_uri` variable notice

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -113,13 +113,11 @@ function register_block_script_handle( $metadata, $field_name ) {
 	$is_core_block    = isset( $metadata['file'] ) && 0 === strpos( $metadata['file'], $wpinc_path_norm );
 	$is_theme_block   = 0 === strpos( $script_path_norm, $theme_path_norm );
 
-	$script_uri;
+	$script_uri = plugins_url( $script_path, $metadata['file'] );
 	if ( $is_core_block ) {
 		$script_uri = includes_url( str_replace( $wpinc_path_norm, '', $script_path_norm ) );
 	} elseif ( $is_theme_block ) {
 		$script_uri = get_theme_file_uri( str_replace( $theme_path_norm, '', $script_path_norm ) );
-	} else {
-		$script_uri = plugins_url( $script_path, $metadata['file'] );
 	}
 
 	$script_asset        = require $script_asset_path;


### PR DESCRIPTION
The editor noticed this issue while I was browsing the `blocks.php` file. PHP considers variables undefined until a value is assigned (or the `global` keyword is used).

The updated logic matches the one used in `register_block_style_handle`.

It was introduced in https://core.trac.wordpress.org/changeset/53091.

Trac ticket: https://core.trac.wordpress.org/ticket/55567

Cc @gziolo, @peterwilsoncc.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
