### PR TITLE
Fixed Comment Form Post Comment Button Font Family

### DIFF
--- a/src/wp-content/themes/twentytwentytwo/style.css
+++ b/src/wp-content/themes/twentytwentytwo/style.css
@@ -82,6 +82,9 @@ a:active {
 .wp-block-button__link:hover {
 	opacity: 0.90;
 }
+.wp-block-button__link{
+	font-family: var(--wp--preset--font-family--system-font);
+}
 
 /*
  * Alignment styles.


### PR DESCRIPTION
In TT2 theme, the font of the Post Comment button of the comment form in the single post is different than others.  Added a CSS code to fix that.

Trac ticket: https://core.trac.wordpress.org/ticket/55590

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
