### PR TITLE
Add missing phpunit tests to renderCommentTemplate

### DIFF
--- a/tests/phpunit/tests/blocks/renderCommentTemplate.php
+++ b/tests/phpunit/tests/blocks/renderCommentTemplate.php
@@ -44,9 +44,37 @@ class Tests_Blocks_RenderReusableCommentTemplate extends WP_UnitTestCase {
 			array(
 				'comment_author'       => 'Test',
 				'comment_author_email' => 'test@example.org',
+				'comment_author_url'   => 'http://example.com/author-url/',
 				'comment_content'      => 'Hello world',
 			)
 		);
+	}
+
+	function test_build_comment_query_vars_from_block_with_context_no_pagination() {
+		update_option( 'page_comments', false );
+		$parsed_blocks = parse_blocks(
+			'<!-- wp:comment-template --><!-- wp:comment-author-name /--><!-- wp:comment-content /--><!-- /wp:comment-template -->'
+		);
+
+		$block = new WP_Block(
+			$parsed_blocks[0],
+			array(
+				'postId' => self::$custom_post->ID,
+			)
+		);
+
+		$this->assertEquals(
+			build_comment_query_vars_from_block( $block ),
+			array(
+				'orderby'       => 'comment_date_gmt',
+				'order'         => 'ASC',
+				'status'        => 'approve',
+				'no_found_rows' => false,
+				'post_id'       => self::$custom_post->ID,
+				'hierarchical'  => 'threaded',
+			)
+		);
+		update_option( 'page_comments', true );
 	}
 
 	/**
@@ -106,6 +134,75 @@ class Tests_Blocks_RenderReusableCommentTemplate extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test rendering a single comment
+	 */
+	function test_rendering_comment_template() {
+		$parsed_blocks = parse_blocks(
+			'<!-- wp:comment-template --><!-- wp:comment-author-name /--><!-- wp:comment-content /--><!-- /wp:comment-template -->'
+		);
+
+		$block = new WP_Block(
+			$parsed_blocks[0],
+			array(
+				'postId' => self::$custom_post->ID,
+			)
+		);
+
+		$this->assertEquals(
+			'<ol class="wp-block-comment-template"><li id="comment-' . self::$comment_ids[0] . '" class="comment even thread-even depth-1"><div class="has-small-font-size wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content">Hello world</div></li></ol>',
+			$block->render()
+		);
+	}
+
+	/**
+	 * Test rendering 3 nested comments:
+	 *
+	 * └─ comment 1
+	 *    └─ comment 2
+	 *       └─ comment 3
+	 */
+	function test_rendering_comment_template_nested() {
+		$first_level_ids = self::factory()->comment->create_post_comments(
+			self::$custom_post->ID,
+			1,
+			array(
+				'comment_parent'       => self::$comment_ids[0],
+				'comment_author'       => 'Test',
+				'comment_author_email' => 'test@example.org',
+				'comment_author_url'   => 'http://example.com/author-url/',
+				'comment_content'      => 'Hello world',
+			)
+		);
+
+		$second_level_ids = self::factory()->comment->create_post_comments(
+			self::$custom_post->ID,
+			1,
+			array(
+				'comment_parent'       => $first_level_ids[0],
+				'comment_author'       => 'Test',
+				'comment_author_email' => 'test@example.org',
+				'comment_author_url'   => 'http://example.com/author-url/',
+				'comment_content'      => 'Hello world',
+			)
+		);
+
+		$parsed_blocks = parse_blocks(
+			'<!-- wp:comment-template --><!-- wp:comment-author-name /--><!-- wp:comment-content /--><!-- /wp:comment-template -->'
+		);
+
+		$block = new WP_Block(
+			$parsed_blocks[0],
+			array(
+				'postId' => self::$custom_post->ID,
+			)
+		);
+
+		$this->assertEquals(
+			'<ol class="wp-block-comment-template"><li id="comment-' . self::$comment_ids[0] . '" class="comment odd alt thread-odd thread-alt depth-1"><div class="has-small-font-size wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content">Hello world</div><ol><li id="comment-' . $first_level_ids[0] . '" class="comment even depth-2"><div class="has-small-font-size wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content">Hello world</div><ol><li id="comment-' . $second_level_ids[0] . '" class="comment odd alt depth-3"><div class="has-small-font-size wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content">Hello world</div></li></ol></li></ol></li></ol>',
+			$block->render()
+		);
+	}
+	/**
 	 * Test that both "Older Comments" and "Newer Comments" are displayed in the correct order
 	 * inside the Comment Query Loop when we enable pagination on Discussion Settings.
 	 * In order to do that, it should exist a query var 'cpage' set with the $comment_args['paged'] value.
@@ -117,7 +214,7 @@ class Tests_Blocks_RenderReusableCommentTemplate extends WP_UnitTestCase {
 
 		// This could be any number, we set a fixed one instead of a random for better performance.
 		$comment_query_max_num_pages = 5;
-		// We subtract 1 because we created 1 comment at the beginning.
+		// We substract 1 because we created 1 comment at the beggining.
 		$post_comments_numbers = ( self::$per_page * $comment_query_max_num_pages ) - 1;
 		self::factory()->comment->create_post_comments(
 			self::$custom_post->ID,
@@ -125,6 +222,7 @@ class Tests_Blocks_RenderReusableCommentTemplate extends WP_UnitTestCase {
 			array(
 				'comment_author'       => 'Test',
 				'comment_author_email' => 'test@example.org',
+				'comment_author_url'   => 'http://example.com/author-url/',
 				'comment_content'      => 'Hello world',
 			)
 		);

--- a/tests/phpunit/tests/blocks/renderCommentTemplate.php
+++ b/tests/phpunit/tests/blocks/renderCommentTemplate.php
@@ -214,7 +214,7 @@ class Tests_Blocks_RenderReusableCommentTemplate extends WP_UnitTestCase {
 
 		// This could be any number, we set a fixed one instead of a random for better performance.
 		$comment_query_max_num_pages = 5;
-		// We substract 1 because we created 1 comment at the beggining.
+		// We substract 1 because we created 1 comment at the beginning.
 		$post_comments_numbers = ( self::$per_page * $comment_query_max_num_pages ) - 1;
 		self::factory()->comment->create_post_comments(
 			self::$custom_post->ID,


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->
Finish the backport of the Comment blocks, adding the remaining unit tests that were not included previously. I also backported some minor changes that were made in Gutenberg.

This is a follow up of #2543

Trac ticket: https://core.trac.wordpress.org/ticket/55567

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
