### PR TITLE
Register 'lock' attribute for every block on the server

### DIFF
--- a/.env
+++ b/.env
@@ -28,7 +28,7 @@ LOCAL_PHP_MEMCACHED=false
 #
 # Supported values are `mysql` and `mariadb`.
 ##
-LOCAL_DB_TYPE=mysql
+LOCAL_DB_TYPE=mariadb
 
 ##
 # The database version to use.
@@ -38,7 +38,7 @@ LOCAL_DB_TYPE=mysql
 # When using `mysql`, see https://hub.docker.com/_/mysql/ for valid versions.
 # When using `mariadb`, see https://hub.docker.com/_/mariadb for valid versions.
 ##
-LOCAL_DB_VERSION=5.7
+LOCAL_DB_VERSION=10
 
 # The debug settings to add to `wp-config.php`.
 LOCAL_WP_DEBUG=true

--- a/.env
+++ b/.env
@@ -28,7 +28,7 @@ LOCAL_PHP_MEMCACHED=false
 #
 # Supported values are `mysql` and `mariadb`.
 ##
-LOCAL_DB_TYPE=mariadb
+LOCAL_DB_TYPE=mysql
 
 ##
 # The database version to use.
@@ -38,7 +38,7 @@ LOCAL_DB_TYPE=mariadb
 # When using `mysql`, see https://hub.docker.com/_/mysql/ for valid versions.
 # When using `mariadb`, see https://hub.docker.com/_/mariadb for valid versions.
 ##
-LOCAL_DB_VERSION=10
+LOCAL_DB_VERSION=5.7
 
 # The debug settings to add to `wp-config.php`.
 LOCAL_WP_DEBUG=true

--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -366,7 +366,7 @@ class WP_Block_Type {
 		$args['name'] = $this->name;
 
 		// Setup attributes if needed.
-		if ( ! isset( $args['attributes'] ) ) {
+		if ( ! isset( $args['attributes'] ) || ! is_array( $args['attributes'] ) ) {
 			$args['attributes'] = array();
 		}
 

--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -366,14 +366,14 @@ class WP_Block_Type {
 		$args['name'] = $this->name;
 
 		// Setup attributes if needed.
-		if ( ! is_array( $this->attributes ) ) {
-			$this->attributes = array();
+		if ( ! isset( $args['attributes'] ) ) {
+			$args['attributes'] = array();
 		}
 
 		// Register core attributes.
 		foreach ( static::GLOBAL_ATTRIBUTES as $attr_key => $attr_schema ) {
-			if ( ! array_key_exists( $attr_key, $this->attributes ) ) {
-				$this->attributes[ $attr_key ] = $attr_schema;
+			if ( ! array_key_exists( $attr_key, $args['attributes'] ) ) {
+				$args['attributes'][ $attr_key ] = $attr_schema;
 			}
 		}
 

--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -380,7 +380,7 @@ class WP_Block_Type {
 		}
 
 		// Setup attributes if needed.
-		if ( ! $this->attributes ) {
+		if ( ! is_array( $this->attributes ) ) {
 			$this->attributes = array();
 		}
 

--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -210,7 +210,7 @@ class WP_Block_Type {
 	 * @since 6.0.0
 	 * @var array
 	 */
-	const CORE_ATTRIBUTES = array(
+	const GLOBAL_ATTRIBUTES = array(
 		'lock' => array( 'type' => 'object' ),
 	);
 
@@ -365,6 +365,18 @@ class WP_Block_Type {
 
 		$args['name'] = $this->name;
 
+		// Setup attributes if needed.
+		if ( ! is_array( $this->attributes ) ) {
+			$this->attributes = array();
+		}
+
+		// Register core attributes.
+		foreach ( static::GLOBAL_ATTRIBUTES as $attr_key => $attr_schema ) {
+			if ( ! array_key_exists( $attr_key, $this->attributes ) ) {
+				$this->attributes[ $attr_key ] = $attr_schema;
+			}
+		}
+
 		/**
 		 * Filters the arguments for registering a block type.
 		 *
@@ -377,18 +389,6 @@ class WP_Block_Type {
 
 		foreach ( $args as $property_name => $property_value ) {
 			$this->$property_name = $property_value;
-		}
-
-		// Setup attributes if needed.
-		if ( ! is_array( $this->attributes ) ) {
-			$this->attributes = array();
-		}
-
-		// Register core attributes.
-		foreach ( static::CORE_ATTRIBUTES as $attr_key => $attr_schema ) {
-			if ( ! array_key_exists( $attr_key, $this->attributes ) ) {
-				$this->attributes[ $attr_key ] = $attr_schema;
-			}
 		}
 	}
 

--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -205,6 +205,16 @@ class WP_Block_Type {
 	public $style = null;
 
 	/**
+	 * Attributes supported by every block.
+	 *
+	 * @since 6.0.0
+	 * @var array
+	 */
+	const CORE_ATTRIBUTES = array(
+		'lock' => array( 'type' => 'object' ),
+	);
+
+	/**
 	 * Constructor.
 	 *
 	 * Will populate object properties from the provided arguments.
@@ -367,6 +377,18 @@ class WP_Block_Type {
 
 		foreach ( $args as $property_name => $property_value ) {
 			$this->$property_name = $property_value;
+		}
+
+		// Setup attributes if needed.
+		if ( ! $this->attributes ) {
+			$this->attributes = array();
+		}
+
+		// Register core attributes.
+		foreach ( static::CORE_ATTRIBUTES as $attr_key => $attr_schema ) {
+			if ( ! array_key_exists( $attr_key, $this->attributes ) ) {
+				$this->attributes[ $attr_key ] = $attr_schema;
+			}
 		}
 	}
 

--- a/tests/phpunit/tests/admin/includesPost.php
+++ b/tests/phpunit/tests/admin/includesPost.php
@@ -844,7 +844,7 @@ class Tests_Admin_IncludesPost extends WP_UnitTestCase {
 				'title'       => '',
 				'description' => '',
 				'icon'        => 'text',
-				'attributes' => array(
+				'attributes'  => array(
 					'lock' => array( 'type' => 'object' ),
 				),
 				'usesContext' => array(),

--- a/tests/phpunit/tests/admin/includesPost.php
+++ b/tests/phpunit/tests/admin/includesPost.php
@@ -844,6 +844,9 @@ class Tests_Admin_IncludesPost extends WP_UnitTestCase {
 				'title'       => '',
 				'description' => '',
 				'icon'        => 'text',
+				'attributes' => array(
+					'lock' => array( 'type' => 'object' ),
+				),
 				'usesContext' => array(),
 				'category'    => 'common',
 				'styles'      => array(),

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -392,6 +392,7 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 					'source'   => 'html',
 					'selector' => '.message',
 				),
+				'lock' => array( 'type' => 'object' ),
 			),
 			$result->attributes
 		);

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -392,7 +392,7 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 					'source'   => 'html',
 					'selector' => '.message',
 				),
-				'lock' => array( 'type' => 'object' ),
+				'lock'    => array( 'type' => 'object' ),
 			),
 			$result->attributes
 		);

--- a/tests/phpunit/tests/blocks/wpBlock.php
+++ b/tests/phpunit/tests/blocks/wpBlock.php
@@ -82,7 +82,7 @@ class Tests_Blocks_wpBlock extends WP_UnitTestCase {
 		$block        = new WP_Block( $parsed_block, $context, $this->registry );
 
 		$this->assertInstanceOf( WP_Block_Type::class, $block->block_type );
-		$this->assertSame(
+		$this->assertSameSetsWithIndex(
 			array(
 				'defaulted' => array(
 					'type'    => 'number',

--- a/tests/phpunit/tests/blocks/wpBlock.php
+++ b/tests/phpunit/tests/blocks/wpBlock.php
@@ -88,7 +88,7 @@ class Tests_Blocks_wpBlock extends WP_UnitTestCase {
 					'type'    => 'number',
 					'default' => 10,
 				),
-				'lock' => array( 'type' => 'object' ),
+				'lock'      => array( 'type' => 'object' ),
 			),
 			$block->block_type->attributes
 		);

--- a/tests/phpunit/tests/blocks/wpBlock.php
+++ b/tests/phpunit/tests/blocks/wpBlock.php
@@ -83,7 +83,13 @@ class Tests_Blocks_wpBlock extends WP_UnitTestCase {
 
 		$this->assertInstanceOf( WP_Block_Type::class, $block->block_type );
 		$this->assertSame(
-			$block_type_settings['attributes'],
+			array(
+				'defaulted' => array(
+					'type'    => 'number',
+					'default' => 10,
+				),
+				'lock' => array( 'type' => 'object' ),
+			),
 			$block->block_type->attributes
 		);
 	}

--- a/tests/phpunit/tests/blocks/wpBlockType.php
+++ b/tests/phpunit/tests/blocks/wpBlockType.php
@@ -99,6 +99,10 @@ class Tests_Blocks_wpBlockType extends WP_UnitTestCase {
 		);
 	}
 
+	/*
+	 * @ticket 55567
+	 * @covers WP_Block_Type::set_props
+	 */
 	public function test_core_attributes_matches_custom() {
 		$block_type = new WP_Block_Type(
 			'core/fake',

--- a/tests/phpunit/tests/blocks/wpBlockType.php
+++ b/tests/phpunit/tests/blocks/wpBlockType.php
@@ -84,10 +84,14 @@ class Tests_Blocks_wpBlockType extends WP_UnitTestCase {
 		$this->assertSame( $args['foo'], $block_type->foo );
 	}
 
+	/*
+	 * @ticket 55567
+	 * @covers WP_Block_Type::set_props
+	 */
 	public function test_core_attributes() {
 		$block_type = new WP_Block_Type( 'core/fake', array() );
 
-		$this->assertEquals(
+		$this->assertSameSetsWithIndex(
 			array(
 				'lock' => array( 'type' => 'object' ),
 			),
@@ -108,7 +112,7 @@ class Tests_Blocks_wpBlockType extends WP_UnitTestCase {
 		);
 
 		// Backward compatibility: Don't override attributes with the same name.
-		$this->assertEquals(
+		$this->assertSameSetsWithIndex(
 			array(
 				'lock' => array( 'type' => 'string' ),
 			),

--- a/tests/phpunit/tests/blocks/wpBlockType.php
+++ b/tests/phpunit/tests/blocks/wpBlockType.php
@@ -84,6 +84,38 @@ class Tests_Blocks_wpBlockType extends WP_UnitTestCase {
 		$this->assertSame( $args['foo'], $block_type->foo );
 	}
 
+	public function test_core_attributes() {
+		$block_type = new WP_Block_Type( 'core/fake', array() );
+
+		$this->assertEquals(
+			array(
+				'lock' => array( 'type' => 'object' ),
+			),
+			$block_type->attributes
+		);
+	}
+
+	public function test_core_attributes_matches_custom() {
+		$block_type = new WP_Block_Type(
+			'core/fake',
+			array(
+				'attributes' => array(
+					'lock' => array(
+						'type' => 'string',
+					),
+				),
+			)
+		);
+
+		// Backward compatibility: Don't override attributes with the same name.
+		$this->assertEquals(
+			array(
+				'lock' => array( 'type' => 'string' ),
+			),
+			$block_type->attributes
+		);
+	}
+
 	/**
 	 * @ticket 45097
 	 */

--- a/tests/phpunit/tests/rest-api/rest-block-type-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-block-type-controller.php
@@ -243,7 +243,9 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$this->assertNull( $data['editor_style'] );
 		$this->assertNull( $data['style'] );
 		$this->assertSameSets( array(), $data['provides_context'] );
-		$this->assertSameSets( array(), $data['attributes'] );
+		$this->assertSameSets( array(
+			'lock' => array( 'type' => 'object' )
+		), $data['attributes'] );
 		$this->assertSameSets( array( 'invalid_uses_context' ), $data['uses_context'] );
 		$this->assertSameSets( array( 'invalid_keywords' ), $data['keywords'] );
 		$this->assertSameSets( array( 'invalid_parent' ), $data['parent'] );
@@ -299,7 +301,9 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$this->assertNull( $data['view_script'] );
 		$this->assertNull( $data['editor_style'] );
 		$this->assertNull( $data['style'] );
-		$this->assertSameSets( array(), $data['attributes'] );
+		$this->assertSameSets( array(
+			'lock' => array( 'type' => 'object' )
+		), $data['attributes'] );
 		$this->assertSameSets( array(), $data['provides_context'] );
 		$this->assertSameSets( array(), $data['uses_context'] );
 		$this->assertSameSets( array(), $data['keywords'] );

--- a/tests/phpunit/tests/rest-api/rest-block-type-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-block-type-controller.php
@@ -243,7 +243,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$this->assertNull( $data['editor_style'] );
 		$this->assertNull( $data['style'] );
 		$this->assertSameSets( array(), $data['provides_context'] );
-		$this->assertSameSets(
+		$this->assertSameSetsWithIndex(
 			array(
 				'lock' => array( 'type' => 'object' ),
 			),
@@ -304,7 +304,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$this->assertNull( $data['view_script'] );
 		$this->assertNull( $data['editor_style'] );
 		$this->assertNull( $data['style'] );
-		$this->assertSameSets(
+		$this->assertSameSetsWithIndex(
 			array(
 				'lock' => array( 'type' => 'object' ),
 			),

--- a/tests/phpunit/tests/rest-api/rest-block-type-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-block-type-controller.php
@@ -243,9 +243,12 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$this->assertNull( $data['editor_style'] );
 		$this->assertNull( $data['style'] );
 		$this->assertSameSets( array(), $data['provides_context'] );
-		$this->assertSameSets( array(
-			'lock' => array( 'type' => 'object' )
-		), $data['attributes'] );
+		$this->assertSameSets(
+			array(
+				'lock' => array( 'type' => 'object' ),
+			),
+			$data['attributes']
+		);
 		$this->assertSameSets( array( 'invalid_uses_context' ), $data['uses_context'] );
 		$this->assertSameSets( array( 'invalid_keywords' ), $data['keywords'] );
 		$this->assertSameSets( array( 'invalid_parent' ), $data['parent'] );
@@ -301,9 +304,12 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$this->assertNull( $data['view_script'] );
 		$this->assertNull( $data['editor_style'] );
 		$this->assertNull( $data['style'] );
-		$this->assertSameSets( array(
-			'lock' => array( 'type' => 'object' )
-		), $data['attributes'] );
+		$this->assertSameSets(
+			array(
+				'lock' => array( 'type' => 'object' ),
+			),
+			$data['attributes']
+		);
 		$this->assertSameSets( array(), $data['provides_context'] );
 		$this->assertSameSets( array(), $data['uses_context'] );
 		$this->assertSameSets( array(), $data['keywords'] );


### PR DESCRIPTION
Backports changes from https://github.com/WordPress/gutenberg/pull/40468.

The `lock` attribute needs to be supported by every block, but currently, it is only done on the client site. As a result, it was causing block rendered API requests to fail when blocks are locked.

PR updates the `WP_Block_Type` class to handle built-in/core attribute registration.

Trac ticket: https://core.trac.wordpress.org/ticket/55567

cc @gziolo, @hellofromtonya

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
