### PR TITLE
Add wp_after_tag_search filter

### DIFF
--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -171,7 +171,7 @@ function wp_ajax_ajax_tag_search() {
 	 * @param WP_Taxonomy $tax     The taxonomy object.
 	 * @param string      $s       The search term.
 	 */
-	$results = apply_filters( 'wp_after_tag_search', $results, $tax, $s );
+	$results = apply_filters( 'ajax_term_search_results', $results, $tax, $s );
 
 	echo implode( "\n", $results );
 	wp_die();

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -162,7 +162,15 @@ function wp_ajax_ajax_tag_search() {
 		)
 	);
 
-	$results = apply_filters( 'wp_after_tag_search', $results );
+	/**
+	 * Filters the tag results.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param array       $results  The terms array.
+	 * @param WP_Taxonomy $taxonomy The taxonomy object.
+	 * @param string      $s        The search term.
+	 */
 	$results = apply_filters( 'wp_after_tag_search', $results, $taxonomy, $s );
 
 	echo implode( "\n", $results );

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -167,7 +167,7 @@ function wp_ajax_ajax_tag_search() {
 	 *
 	 * @since 6.1.0
 	 *
-	 * @param array       $results The terms array.
+	 * @param string[]    $results Array of term names.
 	 * @param WP_Taxonomy $tax     The taxonomy object.
 	 * @param string      $s       The search term.
 	 */

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -163,6 +163,7 @@ function wp_ajax_ajax_tag_search() {
 	);
 
 	$results = apply_filters( 'wp_after_tag_search', $results );
+	$results = apply_filters( 'wp_after_tag_search', $results, $taxonomy, $s );
 
 	echo implode( "\n", $results );
 	wp_die();

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -163,7 +163,7 @@ function wp_ajax_ajax_tag_search() {
 	);
 
 	/**
-	 * Filters the tag results.
+	 * Filters the Ajax term search results.
 	 *
 	 * @since 6.1.0
 	 *

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -167,11 +167,11 @@ function wp_ajax_ajax_tag_search() {
 	 *
 	 * @since 6.1.0
 	 *
-	 * @param array       $results  The terms array.
-	 * @param WP_Taxonomy $taxonomy The taxonomy object.
-	 * @param string      $s        The search term.
+	 * @param array       $results The terms array.
+	 * @param WP_Taxonomy $tax     The taxonomy object.
+	 * @param string      $s       The search term.
 	 */
-	$results = apply_filters( 'wp_after_tag_search', $results, $taxonomy, $s );
+	$results = apply_filters( 'wp_after_tag_search', $results, $tax, $s );
 
 	echo implode( "\n", $results );
 	wp_die();

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -162,6 +162,8 @@ function wp_ajax_ajax_tag_search() {
 		)
 	);
 
+	$results = apply_filters( 'wp_after_tag_search', $results );
+
 	echo implode( "\n", $results );
 	wp_die();
 }

--- a/tests/phpunit/tests/ajax/TagSearch.php
+++ b/tests/phpunit/tests/ajax/TagSearch.php
@@ -187,7 +187,7 @@ class Tests_Ajax_TagSearch extends WP_Ajax_UnitTestCase {
 		}
 
 		// Ensure we found the right match.
-		$this->assertSame( $this->_last_response, 'chattels' );
+		$this->assertSame( 'wp_after_tag_search was applied', $this->_last_response );
 	}
 
 }

--- a/tests/phpunit/tests/ajax/TagSearch.php
+++ b/tests/phpunit/tests/ajax/TagSearch.php
@@ -181,7 +181,7 @@ class Tests_Ajax_TagSearch extends WP_Ajax_UnitTestCase {
 
 		// Make the request.
 		try {
-			$this->_handleAjax( 'ajax-tag-search' );
+			$this->_handleAjax( 'ajax-tag-search', $_GET['tax'], $_GET['q'] );
 		} catch ( WPAjaxDieContinueException $e ) {
 			unset( $e );
 		}

--- a/tests/phpunit/tests/ajax/TagSearch.php
+++ b/tests/phpunit/tests/ajax/TagSearch.php
@@ -171,7 +171,7 @@ class Tests_Ajax_TagSearch extends WP_Ajax_UnitTestCase {
 		$_GET['tax'] = 'post_tag';
 		$_GET['q']   = 'chat';
 
-		// Add the after_tag_search filter.
+		// Add the wp_after_tag_search filter.
 		add_filter(
 			'wp_after_tag_search',
 			static function( $results, $tax, $s ) {

--- a/tests/phpunit/tests/ajax/TagSearch.php
+++ b/tests/phpunit/tests/ajax/TagSearch.php
@@ -162,7 +162,7 @@ class Tests_Ajax_TagSearch extends WP_Ajax_UnitTestCase {
 	 * @ticket 55606
 	 * @covers ::wp_ajax_ajax_tag_search
 	 */
-	public function test_after_tag_search_filter() {
+	public function test_wp_after_tag_search_filter() {
 
 		// Become an administrator.
 		$this->_setRole( 'administrator' );

--- a/tests/phpunit/tests/ajax/TagSearch.php
+++ b/tests/phpunit/tests/ajax/TagSearch.php
@@ -157,12 +157,12 @@ class Tests_Ajax_TagSearch extends WP_Ajax_UnitTestCase {
 	}
 
 	/**
-	 * Test the after_tag_search filter
+	 * Test the ajax_term_search_results filter
 	 *
 	 * @ticket 55606
-	 * @covers ::wp_ajax_ajax_tag_search
+	 * @covers ::ajax_term_search_results
 	 */
-	public function test_wp_after_tag_search_filter() {
+	public function test_ajax_term_search_results_filter() {
 
 		// Become an administrator.
 		$this->_setRole( 'administrator' );
@@ -171,11 +171,11 @@ class Tests_Ajax_TagSearch extends WP_Ajax_UnitTestCase {
 		$_GET['tax'] = 'post_tag';
 		$_GET['q']   = 'chat';
 
-		// Add the wp_after_tag_search filter.
+		// Add the ajax_term_search_results filter.
 		add_filter(
-			'wp_after_tag_search',
+			'ajax_term_search_results',
 			static function( $results, $tax, $s ) {
-				return array( 'wp_after_tag_search was applied' );
+				return array( 'ajax_term_search_results was applied' );
 			},
 			10,
 			3
@@ -189,7 +189,7 @@ class Tests_Ajax_TagSearch extends WP_Ajax_UnitTestCase {
 		}
 
 		// Ensure we found the right match.
-		$this->assertSame( 'wp_after_tag_search was applied', $this->_last_response );
+		$this->assertSame( 'ajax_term_search_results was applied', $this->_last_response );
 	}
 
 }

--- a/tests/phpunit/tests/ajax/TagSearch.php
+++ b/tests/phpunit/tests/ajax/TagSearch.php
@@ -156,4 +156,38 @@ class Tests_Ajax_TagSearch extends WP_Ajax_UnitTestCase {
 		$this->_handleAjax( 'ajax-tag-search' );
 	}
 
+	/**
+	 * Test the after_tag_search filter
+	 *
+	 * @ticket 55606
+	 * @covers ::wp_ajax_ajax_tag_search
+	 */
+	public function test_after_tag_search_filter() {
+
+		// Become an administrator.
+		$this->_setRole( 'administrator' );
+
+		// Set up a default request.
+		$_GET['tax'] = 'post_tag';
+		$_GET['q']   = 'chat';
+
+		// Add the after_tag_search filter.
+		add_filter(
+			'wp_after_tag_search',
+			static function( $results, $tax, $s ) {
+				return array( 'wp_after_tag_search was applied' );
+			}
+		);
+
+		// Make the request.
+		try {
+			$this->_handleAjax( 'ajax-tag-search' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+		}
+
+		// Ensure we found the right match.
+		$this->assertSame( $this->_last_response, 'chattels' );
+	}
+
 }

--- a/tests/phpunit/tests/ajax/TagSearch.php
+++ b/tests/phpunit/tests/ajax/TagSearch.php
@@ -176,7 +176,9 @@ class Tests_Ajax_TagSearch extends WP_Ajax_UnitTestCase {
 			'wp_after_tag_search',
 			static function( $results, $tax, $s ) {
 				return array( 'wp_after_tag_search was applied' );
-			}
+			},
+			10,
+			3
 		);
 
 		// Make the request.

--- a/tests/phpunit/tests/ajax/TagSearch.php
+++ b/tests/phpunit/tests/ajax/TagSearch.php
@@ -160,7 +160,6 @@ class Tests_Ajax_TagSearch extends WP_Ajax_UnitTestCase {
 	 * Test the ajax_term_search_results filter
 	 *
 	 * @ticket 55606
-	 * @covers ::ajax_term_search_results
 	 */
 	public function test_ajax_term_search_results_filter() {
 


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/55606

I want to create a plugin which suggests existing tags, if they are similar to existing tags. For this I want to hook into the term results, but it seems there is no way to. This filter should solve that.

![image](https://user-images.githubusercontent.com/45571053/164680781-c672910a-969a-44e4-9bf6-898447b74ca1.png)