### PR TITLE
Fix styles for nested elements (link color)

### DIFF
--- a/tests/phpunit/tests/block-supports/elements.php
+++ b/tests/phpunit/tests/block-supports/elements.php
@@ -11,7 +11,7 @@ class Tests_Block_Supports_Elements extends WP_UnitTestCase {
 	 * @return string                String where the unique id classes were replaced with "wp-elements-1".
 	 */
 	private static function make_unique_id_one( $string ) {
-		return preg_replace( '/wp-elements-\d+/', 'wp-elements-1', $string );
+		return preg_replace( '/wp-elements-[a-zA-Z0-9]+/', 'wp-elements-1', $string );
 	}
 
 	/**


### PR DESCRIPTION
Backports https://github.com/WordPress/gutenberg/pull/37728
Trac ticket https://core.trac.wordpress.org/ticket/55567

This fixes an issue by which link color behaves differently in the editor and front end.

Step by step reproduction instructions:

- Create a group block and set the link color to red.
- Create a paragraph block and set the link color to purple.

The expected result is that both editor and front end show the paragraph link color as purple.
