### PR TITLE
Patterns: Fix core 'Featured' pattern category registration

### DIFF
--- a/src/wp-includes/block-patterns.php
+++ b/src/wp-includes/block-patterns.php
@@ -38,6 +38,7 @@ function _register_core_block_patterns_and_categories() {
 
 	register_block_pattern_category( 'buttons', array( 'label' => _x( 'Buttons', 'Block pattern category' ) ) );
 	register_block_pattern_category( 'columns', array( 'label' => _x( 'Columns', 'Block pattern category' ) ) );
+	register_block_pattern_category( 'featured', array( 'label' => _x( 'Featured', 'Block pattern category' ) ) );
 	register_block_pattern_category( 'gallery', array( 'label' => _x( 'Gallery', 'Block pattern category' ) ) );
 	register_block_pattern_category( 'header', array( 'label' => _x( 'Headers', 'Block pattern category' ) ) );
 	register_block_pattern_category( 'text', array( 'label' => _x( 'Text', 'Block pattern category' ) ) );
@@ -102,10 +103,6 @@ function _load_remote_featured_patterns() {
 
 	if ( ! $should_load_remote || ! $supports_core_patterns ) {
 		return;
-	}
-
-	if ( ! WP_Block_Pattern_Categories_Registry::get_instance()->is_registered( 'featured' ) ) {
-		register_block_pattern_category( 'featured', array( 'label' => __( 'Featured' ) ) );
 	}
 
 	$request         = new WP_REST_Request( 'GET', '/wp/v2/pattern-directory/patterns' );


### PR DESCRIPTION
Backports changes from https://github.com/WordPress/gutenberg/pull/40650.

Patch fixes regression introduced in a807e86391817a45dd82f54bef234be1a28d4c6d, and moves core "Featured" pattern category registraion from `_load_remote_featured_patterns` into `_register_core_block_patterns_and_categories`

## Testing Instructions
1. Activate the 2016 theme or any theme that doesn't register Featured pattern categories.
2. Open a Post or Page.
3. Open Block inserter -> Patterns Tab
4. Confirm that the "Featured" patterns category is registered.

Trac ticket: https://core.trac.wordpress.org/ticket/55567

cc @gziolo, @hellofromtonya

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
