### PR TITLE
TWEAK: Stop get_comment_time() if null

### DIFF
--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -1034,15 +1034,21 @@ function comment_text( $comment_ID = 0, $args = array() ) {
  * Retrieves the comment time of the current comment.
  *
  * @since 1.5.0
+ * @since 4.4.0 Added the ability for `$comment_ID` to also accept a WP_Comment object.
  *
- * @param string $format    Optional. PHP time format. Defaults to the 'time_format' option.
- * @param bool   $gmt       Optional. Whether to use the GMT date. Default false.
- * @param bool   $translate Optional. Whether to translate the time (for use in feeds).
- *                          Default true.
+ * @param string         $format     Optional. PHP date format. Defaults to the 'time_format' option.
+ * @param bool           $gmt        Optional. Whether to use the GMT date. Default false.
+ * @param bool           $translate  Optional. Whether to translate the time (for use in feeds).
+ *                                   Default true.
+ * @param int|WP_Comment $comment_ID WP_Comment or ID of the comment for which to get the date.
  * @return string The formatted time.
  */
-function get_comment_time( $format = '', $gmt = false, $translate = true ) {
-	$comment = get_comment();
+function get_comment_time( $format = '', $gmt = false, $translate = true, $comment_ID = 0 ) {
+	$comment = get_comment( $comment_ID );
+
+	if ( null === $comment ) {
+		return '';
+	}
 
 	$comment_date = $gmt ? $comment->comment_date_gmt : $comment->comment_date;
 

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -1040,7 +1040,8 @@ function comment_text( $comment_ID = 0, $args = array() ) {
  * @param bool           $gmt        Optional. Whether to use the GMT date. Default false.
  * @param bool           $translate  Optional. Whether to translate the time (for use in feeds).
  *                                   Default true.
- * @param int|WP_Comment $comment_ID WP_Comment or ID of the comment for which to get the date.
+ * @param int|WP_Comment $comment_ID Optional. WP_Comment or ID of the comment for which to get the date.
+                                     Default is 0, or the global comment.
  * @return string The formatted time.
  */
 function get_comment_time( $format = '', $gmt = false, $translate = true, $comment_ID = 0 ) {

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -1041,7 +1041,7 @@ function comment_text( $comment_ID = 0, $args = array() ) {
  * @param bool           $translate  Optional. Whether to translate the time (for use in feeds).
  *                                   Default true.
  * @param int|WP_Comment $comment_ID Optional. WP_Comment or ID of the comment for which to get the date.
-                                     Default is 0, or the global comment.
+ *                                   Default is 0, or the global comment.
  * @return string The formatted time.
  */
 function get_comment_time( $format = '', $gmt = false, $translate = true, $comment_ID = 0 ) {

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -15,7 +15,7 @@
  * assumed.
  *
  * @since 1.5.0
- * @since 4.4.0 Added the ability for `$comment_ID` to also accept a WP_Comment object.
+ * @since 6.2.0 Added the ability for `$comment_ID` to also accept a WP_Comment object.
  *
  * @param int|WP_Comment $comment_ID Optional. WP_Comment or the ID of the comment for which to retrieve the author.
  *                                   Default current comment.

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -15,7 +15,7 @@
  * assumed.
  *
  * @since 1.5.0
- * @since 6.2.0 Added the ability for `$comment_ID` to also accept a WP_Comment object.
+ * @since 4.4.0 Added the ability for `$comment_ID` to also accept a WP_Comment object.
  *
  * @param int|WP_Comment $comment_ID Optional. WP_Comment or the ID of the comment for which to retrieve the author.
  *                                   Default current comment.

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -1034,7 +1034,7 @@ function comment_text( $comment_ID = 0, $args = array() ) {
  * Retrieves the comment time of the current comment.
  *
  * @since 1.5.0
- * @since 4.4.0 Added the ability for `$comment_ID` to also accept a WP_Comment object.
+ * @since 6.2.0 Added the ability for `$comment_ID` to also accept a WP_Comment object.
  *
  * @param string         $format     Optional. PHP date format. Defaults to the 'time_format' option.
  * @param bool           $gmt        Optional. Whether to use the GMT date. Default false.


### PR DESCRIPTION
Check if function get_comment_id is null before executing it.

Trac ticket: https://core.trac.wordpress.org/ticket/52322
