### PR TITLE
Move blogname validation to wpmu_validate_new_blogname

### DIFF
--- a/src/wp-signup.php
+++ b/src/wp-signup.php
@@ -968,7 +968,10 @@ if ( 'none' === $active_signup ) {
 			break;
 		case 'default':
 		default:
+			$newblogname_validation = wpmu_validate_new_blogname( $newblogname );
+
 			$user_email = isset( $_POST['user_email'] ) ? $_POST['user_email'] : '';
+
 			/**
 			 * Fires when the site sign-up form is sent.
 			 *
@@ -976,7 +979,7 @@ if ( 'none' === $active_signup ) {
 			 */
 			do_action( 'preprocess_signup_form' );
 			if ( is_user_logged_in() && ( 'all' === $active_signup || 'blog' === $active_signup ) ) {
-				signup_another_blog( $newblogname );
+				signup_another_blog( $newblogname, '', $newblogname_validation );
 			} elseif ( ! is_user_logged_in() && ( 'all' === $active_signup || 'user' === $active_signup ) ) {
 				signup_user( $newblogname, $user_email );
 			} elseif ( ! is_user_logged_in() && ( 'blog' === $active_signup ) ) {
@@ -985,7 +988,7 @@ if ( 'none' === $active_signup ) {
 				_e( 'You are logged in already. No need to register again!' );
 			}
 
-			if ( $newblogname ) {
+			if ( $newblogname && ! $newblogname_validation->has_errors() ) {
 				$newblog = get_blogaddress_by_name( $newblogname );
 
 				if ( 'blog' === $active_signup || 'all' === $active_signup ) {

--- a/tests/phpunit/tests/multisite/wpmuValidateBlogSignup.php
+++ b/tests/phpunit/tests/multisite/wpmuValidateBlogSignup.php
@@ -54,6 +54,14 @@ if ( is_multisite() ) :
 		 * @dataProvider data_validate_blogname
 		 */
 		public function test_validate_blogname( $blog_name, $error_message ) {
+			$result = wpmu_validate_new_blogname( $blog_name, 'Foo Site Title', get_userdata( self::$super_admin_id ) );
+			$this->assertContains( 'blogname', $result->get_error_codes(), $error_message );
+		}
+
+		/**
+		 * @dataProvider data_validate_blogname
+		 */
+		public function test_validate_blogname_during_signup( $blog_name, $error_message ) {
 			$result = wpmu_validate_blog_signup( $blog_name, 'Foo Site Title', get_userdata( self::$super_admin_id ) );
 			$this->assertContains( 'blogname', $result['errors']->get_error_codes(), $error_message );
 		}


### PR DESCRIPTION
This PR aims to fix the problem outlined in ticket 53355 but also validates the field right away, so if a name of an existing blog is sent via the query string, the user will see an error in the first page load.

Trac ticket: https://core.trac.wordpress.org/ticket/53355