### PR TITLE
Backport more Comments blocks unit tests

### DIFF
--- a/tests/phpunit/tests/blocks/renderCommentTemplate.php
+++ b/tests/phpunit/tests/blocks/renderCommentTemplate.php
@@ -308,6 +308,8 @@ END
 
 	/**
 	 * Test that line and paragraph breaks are converted to HTML tags in a comment.
+	 *
+	 * @ticket 55643
 	 */
 	function test_render_block_core_comment_content_converts_to_html() {
 		$comment_id  = self::$comment_ids[0];
@@ -381,6 +383,8 @@ END
 
 	/**
 	 * Test rendering an unapproved comment preview.
+	 *
+	 * @ticket 55643
 	 */
 	function test_rendering_comment_template_unmoderated_preview() {
 		$parsed_blocks = parse_blocks(

--- a/tests/phpunit/tests/blocks/renderCommentTemplate.php
+++ b/tests/phpunit/tests/blocks/renderCommentTemplate.php
@@ -416,7 +416,8 @@ END
 
 		$this->assertSame(
 			'<ol class="wp-block-comment-template"><li id="comment-' . self::$comment_ids[0] . '" class="comment even thread-odd thread-alt depth-1"><div class="wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content"><p>Hello world</p></div></li><li id="comment-' . $unapproved_comment[0] . '" class="comment odd alt thread-even depth-1"><div class="wp-block-comment-author-name">Visitor</div><div class="wp-block-comment-content"><p><em class="comment-awaiting-moderation">Your comment is awaiting moderation.</em></p>Hi there! My comment needs moderation.</div></li></ol>',
-			str_replace( array( "\n", "\t" ), '', $block->render() )
+			str_replace( array( "\n", "\t" ), '', $block->render() ),
+			'Should include unapproved comments when filter applied.' 
 		);
 
 		remove_filter( 'wp_get_current_commenter', $commenter_filter );
@@ -424,7 +425,8 @@ END
 		// Test it again and ensure the unmoderated comment doesn't leak out.
 		$this->assertSame(
 			'<ol class="wp-block-comment-template"><li id="comment-' . self::$comment_ids[0] . '" class="comment even thread-odd thread-alt depth-1"><div class="wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content"><p>Hello world</p></div></li></ol>',
-			str_replace( array( "\n", "\t" ), '', $block->render() )
+			str_replace( array( "\n", "\t" ), '', $block->render() ),
+			'Should not include any unapproved comments after removing filter' 
 		);
 	}
 }

--- a/tests/phpunit/tests/blocks/renderCommentTemplate.php
+++ b/tests/phpunit/tests/blocks/renderCommentTemplate.php
@@ -421,7 +421,7 @@ END
 		$this->assertSame(
 			'<ol class="wp-block-comment-template"><li id="comment-' . self::$comment_ids[0] . '" class="comment even thread-odd thread-alt depth-1"><div class="wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content"><p>Hello world</p></div></li><li id="comment-' . $unapproved_comment[0] . '" class="comment odd alt thread-even depth-1"><div class="wp-block-comment-author-name">Visitor</div><div class="wp-block-comment-content"><p><em class="comment-awaiting-moderation">Your comment is awaiting moderation.</em></p>Hi there! My comment needs moderation.</div></li></ol>',
 			str_replace( array( "\n", "\t" ), '', $block->render() ),
-			'Should include unapproved comments when filter applied.' 
+			'Should include unapproved comments when filter applied'
 		);
 
 		remove_filter( 'wp_get_current_commenter', $commenter_filter );
@@ -430,7 +430,7 @@ END
 		$this->assertSame(
 			'<ol class="wp-block-comment-template"><li id="comment-' . self::$comment_ids[0] . '" class="comment even thread-odd thread-alt depth-1"><div class="wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content"><p>Hello world</p></div></li></ol>',
 			str_replace( array( "\n", "\t" ), '', $block->render() ),
-			'Should not include any unapproved comments after removing filter' 
+			'Should not include any unapproved comments after removing filter'
 		);
 	}
 }

--- a/tests/phpunit/tests/blocks/renderCommentTemplate.php
+++ b/tests/phpunit/tests/blocks/renderCommentTemplate.php
@@ -205,9 +205,8 @@ class Tests_Blocks_RenderReusableCommentTemplate extends WP_UnitTestCase {
 	 *
 	 * └─ comment 1
 	 *    └─ comment 2
-	 *       └─ comment 3
 	 *       └─ comment 4
-	 *    └─ comment 5
+	 *    └─ comment 3
 	 *
 	 * @ticket 55567
 	 */
@@ -308,6 +307,37 @@ END
 	}
 
 	/**
+	 * Test that line and paragraph breaks are converted to HTML tags in a comment.
+	 */
+	function test_render_block_core_comment_content_converts_to_html() {
+		$comment_id  = self::$comment_ids[0];
+		$new_content = "Paragraph One\n\nP2L1\nP2L2\n\nhttps://example.com/";
+		self::factory()->comment->update_object(
+			$comment_id,
+			array( 'comment_content' => $new_content )
+		);
+
+		$parsed_blocks = parse_blocks(
+			'<!-- wp:comment-template --><!-- wp:comment-content /--><!-- /wp:comment-template -->'
+		);
+
+		$block = new WP_Block(
+			$parsed_blocks[0],
+			array(
+				'postId'           => self::$custom_post->ID,
+				'comments/inherit' => true,
+			)
+		);
+
+		$expected_content = "<p>Paragraph One</p>\n<p>P2L1<br />\nP2L2</p>\n<p><a href=\"https://example.com/\" rel=\"nofollow ugc\">https://example.com/</a></p>\n";
+
+		$this->assertSame(
+			'<ol class="wp-block-comment-template"><li id="comment-' . self::$comment_ids[0] . '" class="comment odd alt thread-even depth-1"><div class="wp-block-comment-content">' . $expected_content . '</div></li></ol>',
+			$block->render()
+		);
+	}
+
+	/**
 	 * Test that unapproved comments are included if it is a preview.
 	 *
 	 * @ticket 55634
@@ -346,6 +376,55 @@ END
 				'number'             => 5,
 				'paged'              => 1,
 			)
+		);
+	}
+
+	/**
+	 * Test rendering an unapproved comment preview.
+	 */
+	function test_rendering_comment_template_unmoderated_preview() {
+		$parsed_blocks = parse_blocks(
+			'<!-- wp:comment-template --><!-- wp:comment-author-name /--><!-- wp:comment-content /--><!-- /wp:comment-template -->'
+		);
+
+		$unapproved_comment = self::factory()->comment->create_post_comments(
+			self::$custom_post->ID,
+			1,
+			array(
+				'comment_author'       => 'Visitor',
+				'comment_author_email' => 'unapproved@example.org',
+				'comment_author_url'   => 'http://example.com/unapproved/',
+				'comment_content'      => 'Hi there! My comment needs moderation.',
+				'comment_approved'     => 0,
+			)
+		);
+
+		$block = new WP_Block(
+			$parsed_blocks[0],
+			array(
+				'postId' => self::$custom_post->ID,
+			)
+		);
+
+		$commenter_filter = function () {
+			return array(
+				'comment_author_email' => 'unapproved@example.org',
+			);
+		};
+
+		add_filter( 'wp_get_current_commenter', $commenter_filter );
+
+		$this->assertSame(
+			'<ol class="wp-block-comment-template"><li id="comment-' . self::$comment_ids[0] . '" class="comment even thread-odd thread-alt depth-1"><div class="wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content"><p>Hello world</p></div></li><li id="comment-' . $unapproved_comment[0] . '" class="comment odd alt thread-even depth-1"><div class="wp-block-comment-author-name">Visitor</div><div class="wp-block-comment-content"><p><em class="comment-awaiting-moderation">Your comment is awaiting moderation.</em></p>Hi there! My comment needs moderation.</div></li></ol>',
+			str_replace( array( "\n", "\t" ), '', $block->render() )
+		);
+
+		remove_filter( 'wp_get_current_commenter', $commenter_filter );
+
+		// Test it again and ensure the unmoderated comment doesn't leak out.
+		$this->assertSame(
+			'<ol class="wp-block-comment-template"><li id="comment-' . self::$comment_ids[0] . '" class="comment even thread-odd thread-alt depth-1"><div class="wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content"><p>Hello world</p></div></li></ol>',
+			str_replace( array( "\n", "\t" ), '', $block->render() )
 		);
 	}
 }

--- a/tests/phpunit/tests/blocks/renderCommentTemplate.php
+++ b/tests/phpunit/tests/blocks/renderCommentTemplate.php
@@ -406,7 +406,7 @@ END
 			)
 		);
 
-		$commenter_filter = function () {
+		$commenter_filter = static function () {
 			return array(
 				'comment_author_email' => 'unapproved@example.org',
 			);


### PR DESCRIPTION
I rebased @DAreRodz' #2649 since a few of its changes have been [merged](https://github.com/WordPress/wordpress-develop/pull/2649#issuecomment-1113949397) into `trunk` (https://github.com/WordPress/wordpress-develop/commit/80fd6c30f6b5df690731275e973caa7c19bf4e53).

See https://github.com/WordPress/wordpress-develop/pull/2649#issuecomment-1114874483 for more context.

Trac ticket: https://core.trac.wordpress.org/ticket/55643

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
