### PR TITLE
Add a `_doing_it_wrong()` to `WP_Block_Patterns_Registry::register()` when hooked but not on `init`.

### DIFF
--- a/src/wp-includes/class-wp-block-patterns-registry.php
+++ b/src/wp-includes/class-wp-block-patterns-registry.php
@@ -45,6 +45,7 @@ final class WP_Block_Patterns_Registry {
 	 * @since 5.8.0 Added support for the `blockTypes` property.
 	 * @since 6.1.0 Added support for the `postTypes` property.
 	 * @since 6.2.0 Added support for the `templateTypes` property.
+	 * @since 6.2.0 Added `_doing_it_wrong()` when hooked, but not on `init`.
 	 *
 	 * @param string $pattern_name       Block pattern name including namespace.
 	 * @param array  $pattern_properties {
@@ -83,6 +84,19 @@ final class WP_Block_Patterns_Registry {
 	 * @return bool True if the pattern was registered with success and false otherwise.
 	 */
 	public function register( $pattern_name, $pattern_properties ) {
+		if ( ! doing_action( 'init' ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				sprintf(
+					/* translators: %s: The "init" action hook. */
+					__( 'Block Pattern registration can only be hooked on the "%s" action hook.' ),
+					'init'
+				),
+				'6.2.0'
+			);
+			return false;
+		}
+
 		if ( ! isset( $pattern_name ) || ! is_string( $pattern_name ) ) {
 			_doing_it_wrong(
 				__METHOD__,

--- a/tests/phpunit/tests/blocks/wpBlockPatternsRegistry.php
+++ b/tests/phpunit/tests/blocks/wpBlockPatternsRegistry.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Tests for WP_Block_Patterns_Registry.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ * @since 6.2.0
+ *
+ * @group blocks
+ */
+class Tests_Blocks_wpBlockPatternsRegistry extends WP_UnitTestCase {
+	/**
+	 * Fake block patterns registry.
+	 *
+	 * @since 6.2.0
+	 * @var WP_Block_Patterns_Registry
+	 */
+	private $registry = null;
+
+	/**
+	 * Set up each test method.
+	 *
+	 * @since 6.2.0
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->registry = new WP_Block_Patterns_Registry();
+	}
+
+	/**
+	 * Tear down each test method.
+	 *
+	 * @since 6.2.0
+	 */
+	public function tear_down() {
+		$this->registry = null;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Tests that WP_Block_Patterns_Registry::register
+	 * throws a _doing_it_wrong() when expected.
+	 *
+	 * @ticket 55655
+	 *
+	 * @dataProvider data_register_should_throw_doing_it_wrong
+	 *
+	 * @covers WP_Block_Patterns_Registry::register
+	 * @covers ::register_block_pattern
+	 *
+	 * @expectedIncorrectUsage WP_Block_Patterns_Registry::register
+	 *
+	 * @param string $pattern_name       Block pattern name including namespace.
+	 * @param array  $pattern_properties List of properties for the block pattern.
+	 * @param string $hook               Optional. The name of the hook to use for registration. Default: 'init'.
+	 */
+	public function test_register_should_throw_doing_it_wrong( $pattern_name, $pattern_properties, $hook = 'init' ) {
+		add_action(
+			$hook,
+			function() use ( $pattern_name, $pattern_properties ) {
+				$this->assertFalse( $this->registry->register( $pattern_name, $pattern_properties ) );
+			}
+		);
+
+		do_action( $hook );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_register_should_throw_doing_it_wrong() {
+		return array(
+			'registration on a hook other than "init"' => array(
+				'pattern_name'       => 'wptests/custom-block-pattern',
+				'pattern_properties' => array(
+					'title'   => 'A custom block pattern',
+					'content' => '<!-- wp:paragraph --><p>This is a custom block pattern</p><!-- /wp:paragraph -->',
+				),
+				'hook'               => 'current_screen',
+			),
+		);
+	}
+}


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/55655