### PR TITLE
Strong tags forgotten for warnings

### DIFF
--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -1321,7 +1321,7 @@ function wp_ajax_replyto_comment( $action ) {
 	}
 
 	if ( '' === $comment_content ) {
-		wp_die( __( '<strong>Error:</strong> Please type your comment text.' ) );
+		wp_die( __( 'Please type your comment text.' ) );
 	}
 
 	$comment_parent = 0;

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -1291,7 +1291,7 @@ function wp_ajax_replyto_comment( $action ) {
 	if ( empty( $post->post_status ) ) {
 		wp_die( 1 );
 	} elseif ( in_array( $post->post_status, array( 'draft', 'pending', 'trash' ), true ) ) {
-		wp_die( __( 'Error: You cannot reply to a comment on a draft post.' ) );
+		wp_die( __( '<strong>Error:</strong> You cannot reply to a comment on a draft post.' ) );
 	}
 
 	$user = wp_get_current_user();
@@ -1321,7 +1321,7 @@ function wp_ajax_replyto_comment( $action ) {
 	}
 
 	if ( '' === $comment_content ) {
-		wp_die( __( 'Error: Please type your comment text.' ) );
+		wp_die( __( '<strong>Error:</strong> Please type your comment text.' ) );
 	}
 
 	$comment_parent = 0;

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -1291,7 +1291,7 @@ function wp_ajax_replyto_comment( $action ) {
 	if ( empty( $post->post_status ) ) {
 		wp_die( 1 );
 	} elseif ( in_array( $post->post_status, array( 'draft', 'pending', 'trash' ), true ) ) {
-		wp_die( __( '<strong>Error:</strong> You cannot reply to a comment on a draft post.' ) );
+		wp_die( __( 'You cannot reply to a comment on a draft post.' ) );
 	}
 
 	$user = wp_get_current_user();

--- a/src/wp-admin/options-permalink.php
+++ b/src/wp-admin/options-permalink.php
@@ -368,7 +368,7 @@ printf( __( 'If you like, you may enter custom structures for your category and 
 				<?php
 				printf(
 					/* translators: 1: web.config, 2: Documentation URL, 3: Ctrl + A, 4: ⌘ + A, 5: Element code. */
-					__( 'Error: Your %1$s file is not <a href="%2$s">writable</a>, so updating it automatically was not possible. This is the URL rewrite rule you should have in your %1$s file. Click in the field and press %3$s (or %4$s on Mac) to select all. Then insert this rule inside of the %5$s element in %1$s file.' ),
+					__( '<strong>Error:</strong> Your %1$s file is not <a href="%2$s">writable</a>, so updating it automatically was not possible. This is the URL rewrite rule you should have in your %1$s file. Click in the field and press %3$s (or %4$s on Mac) to select all. Then insert this rule inside of the %5$s element in %1$s file.' ),
 					'<code>web.config</code>',
 					__( 'https://wordpress.org/support/article/changing-file-permissions/' ),
 					'<kbd>Ctrl + A</kbd>',

--- a/src/wp-admin/options-permalink.php
+++ b/src/wp-admin/options-permalink.php
@@ -395,7 +395,7 @@ printf( __( 'If you like, you may enter custom structures for your category and 
 			<?php
 			printf(
 				/* translators: 1: Documentation URL, 2: web.config, 3: Ctrl + A, 4: ⌘ + A */
-				__( 'Error: The root directory of your site is not <a href="%1$s">writable</a>, so creating a file automatically was not possible. This is the URL rewrite rule you should have in your %2$s file. Create a new file called %2$s in the root directory of your site. Click in the field and press %3$s (or %4$s on Mac) to select all. Then insert this code into the %2$s file.' ),
+				__( '<strong>Error:</strong> The root directory of your site is not <a href="%1$s">writable</a>, so creating a file automatically was not possible. This is the URL rewrite rule you should have in your %2$s file. Create a new file called %2$s in the root directory of your site. Click in the field and press %3$s (or %4$s on Mac) to select all. Then insert this code into the %2$s file.' ),
 				__( 'https://wordpress.org/support/article/changing-file-permissions/' ),
 				'<code>web.config</code>',
 				'<kbd>Ctrl + A</kbd>',
@@ -426,7 +426,7 @@ else :
 		<?php
 		printf(
 			/* translators: 1: .htaccess, 2: Documentation URL, 3: Ctrl + A, 4: ⌘ + A */
-			__( 'Error: Your %1$s file is not <a href="%2$s">writable</a>, so updating it automatically was not possible. These are the mod_rewrite rules you should have in your %1$s file. Click in the field and press %3$s (or %4$s on Mac) to select all.' ),
+			__( '<strong>Error:</strong> Your %1$s file is not <a href="%2$s">writable</a>, so updating it automatically was not possible. These are the mod_rewrite rules you should have in your %1$s file. Click in the field and press %3$s (or %4$s on Mac) to select all.' ),
 			'<code>.htaccess</code>',
 			__( 'https://wordpress.org/support/article/changing-file-permissions/' ),
 			'<kbd>Ctrl + A</kbd>',


### PR DESCRIPTION
During development of 6.0, a trac ticket of mine was fixed. This was adding strong tags in warnings. Yet, during translation I found two others. 

Trac ticket: (https://core.trac.wordpress.org/ticket/54437)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
