### PR TITLE
Fix ordering of loaded scripts when overriding default scripts

### DIFF
--- a/src/wp-includes/class.wp-scripts.php
+++ b/src/wp-includes/class.wp-scripts.php
@@ -327,7 +327,7 @@ class WP_Scripts extends WP_Dependencies {
 			 */
 			$srce = apply_filters( 'script_loader_src', $src, $handle );
 
-			if ( $this->in_default_dir( $srce ) && ( $before_handle || $after_handle || $translations ) ) {
+			if ( ! $this->in_default_dir( $srce ) || $before_handle || $after_handle || $translations ) {
 				$this->do_concat = false;
 
 				// Have to print the so-far concatenated scripts right away to maintain the right order.

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -741,9 +741,13 @@ JS;
 
 		$ver       = get_bloginfo( 'version' );
 		$suffix    = wp_scripts_get_suffix();
-		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=jquery-core,jquery-migrate,regenerator-runtime,wp-polyfill,wp-dom-ready,wp-hooks&amp;ver={$ver}'></script>\n";
+		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=jquery-core,jquery-migrate&amp;ver={$ver}'></script>\n";
 		$expected .= "<script type='text/javascript' id='test-example-js-before'>\nconsole.log(\"before\");\n</script>\n";
 		$expected .= "<script type='text/javascript' src='http://example.com' id='test-example-js'></script>\n";
+		$expected .= "<script type='text/javascript' src='/wp-includes/js/dist/vendor/regenerator-runtime.js' id='regenerator-runtime-js'></script>\n";
+		$expected .= "<script type='text/javascript' src='/wp-includes/js/dist/vendor/wp-polyfill.js' id='wp-polyfill-js'></script>\n";
+		$expected .= "<script type='text/javascript' src='/wp-includes/js/dist/dom-ready.js' id='wp-dom-ready-js'></script>\n";
+		$expected .= "<script type='text/javascript' src='/wp-includes/js/dist/hooks.js' id='wp-hooks-js'></script>\n";
 		$expected .= "<script type='text/javascript' src='/wp-includes/js/dist/i18n{$suffix}.js' id='wp-i18n-js'></script>\n";
 		$expected .= "<script type='text/javascript' id='wp-i18n-js-after'>\n";
 		$expected .= "wp.i18n.setLocaleData( { 'text direction\u0004ltr': [ 'ltr' ] } );\n";


### PR DESCRIPTION
Attempts to fix a bug where a script with a dependency could be loaded before the actual dependency:
```
wp_register_script( 'lib', '/plugins/lib.js', array(), null );
wp_enqueue_script( 'common', '/default/common.js', array( 'lib' ), null );
```
will load both scripts in wrong order:
```
<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&load[chunk_0]=common'></script>
<script type='text/javascript' src='/plugins/lib.js' id='lib-js'></script>
```
in case the dependency is not in the "default" scripts directory, e.g., when registered/overridden by a plugin.

The desired markup is this one:
```
<script type='text/javascript' src='/plugins/lib.js' id='lib-js'></script>
<script type='text/javascript' src='/default/common.js' id='common-js'></script>
```

The PR has several commits:
First, we refactor how the script output is checked in unit tests, without relying on implementation details. When `wp_print_scripts` executes a `$wp_scripts->do_items()` loop, the script tags are either printed directly with `echo`, or appended as strings to `$wp_scripts->concat` or `$wp_scripts->print_html`. In production there is always a `_print_scripts()` call at the end which flushes these accumulated strings, resulting in everything getting printed. Whether a script tag is printed in `wp_print_script` or later is an implementation detail that unit tests shouldn't rely on. But they do. The first commit fixes that.

Second, we're adding a unit test for the bug we're fixing.

Third, there is a fix for the bug, changing the condition for terminating concatenation.

Fourth, there is a unit test update for a change we don't really want, but is a consequence of the fix. When enqueuing two independent scripts with two independent dependencies:
```
wp_enqueue_script( 'example1', 'example1.com', array( 'lib1' ) );
wp_enqueue_script( 'example2', 'example2.com', array( 'lib2' ) );
```
the order of scripts used to be:
```
/wp-admin/load-scripts.php?load=lib1,lib2
http://example1.com
http://example2.com
```
Note that here `lib2` loads _before_ `example1`, although being enqueued only after it. It changes order, but it's OK because the deps tree is still respected, and the lib loading is nicely optimized.

But after this PR, this reordering is no longer allowed. The load order will be:
```
/wp-admin/load-scripts.php?load=lib1
http://example1.com
/wp-includes/js/dist/lib2.js
http://example2.com
```
This is unwanted effect, but I don't know how to fix it yet.