### PR TITLE
Support bbPress and legacy template dependencies

### DIFF
--- a/src/wp-content/themes/twentytwentytwo/index.php
+++ b/src/wp-content/themes/twentytwentytwo/index.php
@@ -3,3 +3,5 @@
 // There is a core ticket discussing removing this requirement for block themes:
 // https://core.trac.wordpress.org/ticket/54272.
 
+// Support bbPress and other legacy templating plugins
+include ABSPATH . WPINC . '/template-canvas.php';


### PR DESCRIPTION
Allows compatibility with bbPress and other plugins that expect a theme/template engine to furnish, at the very least, a posts loop. 

Trac ticket: https://core.trac.wordpress.org/ticket/55660

