### PR TITLE
Fixes floating point to string conversion for X.0 version numbers (Trac 55667)

### DIFF
--- a/tests/phpunit/tests/basic.php
+++ b/tests/phpunit/tests/basic.php
@@ -24,7 +24,7 @@ class Tests_Basic extends WP_UnitTestCase {
 		$security = file_get_contents( dirname( ABSPATH ) . '/SECURITY.md' );
 		preg_match( '#\d.\d.x#', $security, $matches );
 		$current_version = substr( $GLOBALS['wp_version'], 0, 3 );
-		$latest_stable   = sprintf( '%s.x', (float) $current_version - 0.1 );
+		$latest_stable   = number_format( (float) $current_version - 0.1, 1 ) . '.x';
 		$this->assertSame( $latest_stable, trim( $matches[0] ), "SECURITY.md's version needs to be updated to $latest_stable." );
 	}
 

--- a/tests/phpunit/tests/basic.php
+++ b/tests/phpunit/tests/basic.php
@@ -25,7 +25,7 @@ class Tests_Basic extends WP_UnitTestCase {
 		preg_match( '#\d.\d.x#', $security, $matches );
 		$current_version = substr( $GLOBALS['wp_version'], 0, 3 );
 		$latest_stable   = sprintf( '%s.x', (float) $current_version - 0.1 );
-		// $this->assertSame( $latest_stable, trim( $matches[0] ), "SECURITY.md's version needs to be updated to $latest_stable." );
+		$this->assertSame( $latest_stable, trim( $matches[0] ), "SECURITY.md's version needs to be updated to $latest_stable." );
 	}
 
 	public function test_package_json() {


### PR DESCRIPTION
Uses `number_format()` after doing the floating point math to ensure the version is in X.X format.

See the problem in action here https://3v4l.org/928vf.

Using `number_format()` resolves the issue https://3v4l.org/M7Cb2.

Also reverts https://core.trac.wordpress.org/changeset/53346.

Trac ticket: https://core.trac.wordpress.org/ticket/55667

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
