### PR TITLE
Editor: Return block patterns to server-generated settings

### DIFF
--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -188,28 +188,38 @@ if ( $user_id ) {
 $body_placeholder = apply_filters( 'write_your_story', __( 'Type / to choose a block' ), $post );
 
 $editor_settings = array(
-	'availableTemplates'                   => $available_templates,
-	'disablePostFormats'                   => ! current_theme_supports( 'post-formats' ),
+	'availableTemplates'   => $available_templates,
+	'disablePostFormats'   => ! current_theme_supports( 'post-formats' ),
 	/** This filter is documented in wp-admin/edit-form-advanced.php */
-	'titlePlaceholder'                     => apply_filters( 'enter_title_here', __( 'Add title' ), $post ),
-	'bodyPlaceholder'                      => $body_placeholder,
-	'autosaveInterval'                     => AUTOSAVE_INTERVAL,
-	'richEditingEnabled'                   => user_can_richedit(),
-	'postLock'                             => $lock_details,
-	'postLockUtils'                        => array(
+	'titlePlaceholder'     => apply_filters( 'enter_title_here', __( 'Add title' ), $post ),
+	'bodyPlaceholder'      => $body_placeholder,
+	'autosaveInterval'     => AUTOSAVE_INTERVAL,
+	'richEditingEnabled'   => user_can_richedit(),
+	'postLock'             => $lock_details,
+	'postLockUtils'        => array(
 		'nonce'       => wp_create_nonce( 'lock-post_' . $post->ID ),
 		'unlockNonce' => wp_create_nonce( 'update-post_' . $post->ID ),
 		'ajaxUrl'     => admin_url( 'admin-ajax.php' ),
 	),
-	'supportsLayout'                       => WP_Theme_JSON_Resolver::theme_has_support(),
-	'__experimentalBlockPatterns'          => WP_Block_Patterns_Registry::get_instance()->get_all_registered( true ),
-	'__experimentalBlockPatternCategories' => WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered( true ),
-	'supportsTemplateMode'                 => current_theme_supports( 'block-templates' ),
+	'supportsLayout'       => WP_Theme_JSON_Resolver::theme_has_support(),
+	'supportsTemplateMode' => current_theme_supports( 'block-templates' ),
 
 	// Whether or not to load the 'postcustom' meta box is stored as a user meta
 	// field so that we're not always loading its assets.
-	'enableCustomFields'                   => (bool) get_user_meta( get_current_user_id(), 'enable_custom_fields', true ),
+	'enableCustomFields'   => (bool) get_user_meta( get_current_user_id(), 'enable_custom_fields', true ),
 );
+
+/**
+ * Filter to enable adding non-REST block patterns to editor settings.
+ *
+ * @since 6.0.0
+ *
+ * @param bool $should_add_to_settings
+ */
+if ( apply_filters( 'should_add_block_patterns_to_editor_settings', false ) ) {
+	$editor_settings['__experimentalBlockPatterns']          = WP_Block_Patterns_Registry::get_instance()->get_all_registered( true );
+	$editor_settings['__experimentalBlockPatternCategories'] = WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered( true );
+}
 
 $autosave = wp_get_post_autosave( $post->ID );
 if ( $autosave ) {

--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -188,25 +188,27 @@ if ( $user_id ) {
 $body_placeholder = apply_filters( 'write_your_story', __( 'Type / to choose a block' ), $post );
 
 $editor_settings = array(
-	'availableTemplates'   => $available_templates,
-	'disablePostFormats'   => ! current_theme_supports( 'post-formats' ),
+	'availableTemplates'                   => $available_templates,
+	'disablePostFormats'                   => ! current_theme_supports( 'post-formats' ),
 	/** This filter is documented in wp-admin/edit-form-advanced.php */
-	'titlePlaceholder'     => apply_filters( 'enter_title_here', __( 'Add title' ), $post ),
-	'bodyPlaceholder'      => $body_placeholder,
-	'autosaveInterval'     => AUTOSAVE_INTERVAL,
-	'richEditingEnabled'   => user_can_richedit(),
-	'postLock'             => $lock_details,
-	'postLockUtils'        => array(
+	'titlePlaceholder'                     => apply_filters( 'enter_title_here', __( 'Add title' ), $post ),
+	'bodyPlaceholder'                      => $body_placeholder,
+	'autosaveInterval'                     => AUTOSAVE_INTERVAL,
+	'richEditingEnabled'                   => user_can_richedit(),
+	'postLock'                             => $lock_details,
+	'postLockUtils'                        => array(
 		'nonce'       => wp_create_nonce( 'lock-post_' . $post->ID ),
 		'unlockNonce' => wp_create_nonce( 'update-post_' . $post->ID ),
 		'ajaxUrl'     => admin_url( 'admin-ajax.php' ),
 	),
-	'supportsLayout'       => WP_Theme_JSON_Resolver::theme_has_support(),
-	'supportsTemplateMode' => current_theme_supports( 'block-templates' ),
+	'supportsLayout'                       => WP_Theme_JSON_Resolver::theme_has_support(),
+	'__experimentalBlockPatterns'          => WP_Block_Patterns_Registry::get_instance()->get_all_registered(),
+	'__experimentalBlockPatternCategories' => WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered(),
+	'supportsTemplateMode'                 => current_theme_supports( 'block-templates' ),
 
 	// Whether or not to load the 'postcustom' meta box is stored as a user meta
 	// field so that we're not always loading its assets.
-	'enableCustomFields'   => (bool) get_user_meta( get_current_user_id(), 'enable_custom_fields', true ),
+	'enableCustomFields'                   => (bool) get_user_meta( get_current_user_id(), 'enable_custom_fields', true ),
 );
 
 $autosave = wp_get_post_autosave( $post->ID );

--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -209,17 +209,9 @@ $editor_settings = array(
 	'enableCustomFields'   => (bool) get_user_meta( get_current_user_id(), 'enable_custom_fields', true ),
 );
 
-/**
- * Filter to enable adding non-REST block patterns to editor settings.
- *
- * @since 6.0.0
- *
- * @param bool $should_add_to_settings
- */
-if ( apply_filters( 'should_add_block_patterns_to_editor_settings', false ) ) {
-	$editor_settings['__experimentalBlockPatterns']          = WP_Block_Patterns_Registry::get_instance()->get_all_registered( true );
-	$editor_settings['__experimentalBlockPatternCategories'] = WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered( true );
-}
+// Add additional back-compat patterns registered by `current_screen` et al.
+$editor_settings['__experimentalAdditionalBlockPatterns']          = WP_Block_Patterns_Registry::get_instance()->get_all_registered( true );
+$editor_settings['__experimentalAdditionalBlockPatternCategories'] = WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered( true );
 
 $autosave = wp_get_post_autosave( $post->ID );
 if ( $autosave ) {

--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -202,8 +202,8 @@ $editor_settings = array(
 		'ajaxUrl'     => admin_url( 'admin-ajax.php' ),
 	),
 	'supportsLayout'                       => WP_Theme_JSON_Resolver::theme_has_support(),
-	'__experimentalBlockPatterns'          => WP_Block_Patterns_Registry::get_instance()->get_all_registered(),
-	'__experimentalBlockPatternCategories' => WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered(),
+	'__experimentalBlockPatterns'          => WP_Block_Patterns_Registry::get_instance()->get_all_registered( true ),
+	'__experimentalBlockPatternCategories' => WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered( true ),
 	'supportsTemplateMode'                 => current_theme_supports( 'block-templates' ),
 
 	// Whether or not to load the 'postcustom' meta box is stored as a user meta

--- a/src/wp-admin/site-editor.php
+++ b/src/wp-admin/site-editor.php
@@ -67,8 +67,8 @@ $custom_settings      = array(
 	'defaultTemplateTypes'                 => $indexed_template_types,
 	'defaultTemplatePartAreas'             => get_allowed_block_template_part_areas(),
 	'__unstableHomeTemplate'               => $home_template,
-	'__experimentalBlockPatterns'          => WP_Block_Patterns_Registry::get_instance()->get_all_registered(),
-	'__experimentalBlockPatternCategories' => WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered(),
+	'__experimentalBlockPatterns'          => WP_Block_Patterns_Registry::get_instance()->get_all_registered( true ),
+	'__experimentalBlockPatternCategories' => WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered( true ),
 );
 $editor_settings      = get_block_editor_settings( $custom_settings, $block_editor_context );
 

--- a/src/wp-admin/site-editor.php
+++ b/src/wp-admin/site-editor.php
@@ -61,15 +61,19 @@ foreach ( get_default_block_template_types() as $slug => $template_type ) {
 
 $block_editor_context = new WP_Block_Editor_Context( array( 'name' => 'core/edit-site' ) );
 $custom_settings      = array(
-	'siteUrl'                              => site_url(),
-	'postsPerPage'                         => get_option( 'posts_per_page' ),
-	'styles'                               => get_block_editor_theme_styles(),
-	'defaultTemplateTypes'                 => $indexed_template_types,
-	'defaultTemplatePartAreas'             => get_allowed_block_template_part_areas(),
-	'__unstableHomeTemplate'               => $home_template,
-	'__experimentalBlockPatterns'          => WP_Block_Patterns_Registry::get_instance()->get_all_registered( true ),
-	'__experimentalBlockPatternCategories' => WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered( true ),
+	'siteUrl'                  => site_url(),
+	'postsPerPage'             => get_option( 'posts_per_page' ),
+	'styles'                   => get_block_editor_theme_styles(),
+	'defaultTemplateTypes'     => $indexed_template_types,
+	'defaultTemplatePartAreas' => get_allowed_block_template_part_areas(),
+	'__unstableHomeTemplate'   => $home_template,
 );
+
+if ( apply_filters( 'should_add_block_patterns_to_editor_settings', false ) ) {
+	$custom_settings['__experimentalBlockPatterns']          = WP_Block_Patterns_Registry::get_instance()->get_all_registered( true );
+	$custom_settings['__experimentalBlockPatternCategories'] = WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered( true );
+}
+
 $editor_settings      = get_block_editor_settings( $custom_settings, $block_editor_context );
 
 if ( isset( $_GET['postType'] ) && ! isset( $_GET['postId'] ) ) {

--- a/src/wp-admin/site-editor.php
+++ b/src/wp-admin/site-editor.php
@@ -61,12 +61,14 @@ foreach ( get_default_block_template_types() as $slug => $template_type ) {
 
 $block_editor_context = new WP_Block_Editor_Context( array( 'name' => 'core/edit-site' ) );
 $custom_settings      = array(
-	'siteUrl'                  => site_url(),
-	'postsPerPage'             => get_option( 'posts_per_page' ),
-	'styles'                   => get_block_editor_theme_styles(),
-	'defaultTemplateTypes'     => $indexed_template_types,
-	'defaultTemplatePartAreas' => get_allowed_block_template_part_areas(),
-	'__unstableHomeTemplate'   => $home_template,
+	'siteUrl'                              => site_url(),
+	'postsPerPage'                         => get_option( 'posts_per_page' ),
+	'styles'                               => get_block_editor_theme_styles(),
+	'defaultTemplateTypes'                 => $indexed_template_types,
+	'defaultTemplatePartAreas'             => get_allowed_block_template_part_areas(),
+	'__unstableHomeTemplate'               => $home_template,
+	'__experimentalBlockPatterns'          => WP_Block_Patterns_Registry::get_instance()->get_all_registered(),
+	'__experimentalBlockPatternCategories' => WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered(),
 );
 $editor_settings      = get_block_editor_settings( $custom_settings, $block_editor_context );
 

--- a/src/wp-admin/site-editor.php
+++ b/src/wp-admin/site-editor.php
@@ -69,10 +69,9 @@ $custom_settings      = array(
 	'__unstableHomeTemplate'   => $home_template,
 );
 
-if ( apply_filters( 'should_add_block_patterns_to_editor_settings', false ) ) {
-	$custom_settings['__experimentalBlockPatterns']          = WP_Block_Patterns_Registry::get_instance()->get_all_registered( true );
-	$custom_settings['__experimentalBlockPatternCategories'] = WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered( true );
-}
+// Add additional back-compat patterns registered by `current_screen` et al.
+$custom_settings['__experimentalAdditionalBlockPatterns']          = WP_Block_Patterns_Registry::get_instance()->get_all_registered( true );
+$custom_settings['__experimentalAdditionalBlockPatternCategories'] = WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered( true );
 
 $editor_settings      = get_block_editor_settings( $custom_settings, $block_editor_context );
 

--- a/src/wp-includes/class-wp-block-pattern-categories-registry.php
+++ b/src/wp-includes/class-wp-block-pattern-categories-registry.php
@@ -20,6 +20,14 @@ final class WP_Block_Pattern_Categories_Registry {
 	private $registered_categories = array();
 
 	/**
+	 * Pattern categories registered outside the `init` action.
+	 *
+	 * @since 6.0.0
+	 * @var array[]
+	 */
+	private $registered_categories_outside_init = array();
+
+	/**
 	 * Container for the main instance of the class.
 	 *
 	 * @since 5.5.0
@@ -50,10 +58,19 @@ final class WP_Block_Pattern_Categories_Registry {
 			return false;
 		}
 
-		$this->registered_categories[ $category_name ] = array_merge(
+		$category = array_merge(
 			array( 'name' => $category_name ),
 			$category_properties
 		);
+
+		$this->registered_categories[ $category_name ] = $category;
+
+		// If the category is registered inside an action other than `init`, store it
+		// also to a dedicated array. Used to detect deprecated registrations inside
+		// `admin_init` or `current_screen`.
+		if ( current_action() && 'init' !== current_action() ) {
+			$this->registered_categories_outside_init[ $category_name ] = $category;
+		}
 
 		return true;
 	}
@@ -78,6 +95,7 @@ final class WP_Block_Pattern_Categories_Registry {
 		}
 
 		unset( $this->registered_categories[ $category_name ] );
+		unset( $this->registered_categories_outside_init[ $category_name ] );
 
 		return true;
 	}
@@ -103,10 +121,15 @@ final class WP_Block_Pattern_Categories_Registry {
 	 *
 	 * @since 5.5.0
 	 *
+	 * @param bool $outside_init_only Return only categories registered outside the `init` action.
 	 * @return array[] Array of arrays containing the registered pattern categories properties.
 	 */
-	public function get_all_registered() {
-		return array_values( $this->registered_categories );
+	public function get_all_registered( $outside_init_only = false ) {
+		return array_values(
+			$outside_init_only
+				? $this->registered_categories_outside_init
+				: $this->registered_categories
+		);
 	}
 
 	/**

--- a/src/wp-includes/class-wp-block-patterns-registry.php
+++ b/src/wp-includes/class-wp-block-patterns-registry.php
@@ -22,6 +22,14 @@ final class WP_Block_Patterns_Registry {
 	private $registered_patterns = array();
 
 	/**
+	 * Patterns registered outside the `init` action.
+	 *
+	 * @since 6.0.0
+	 * @var array[]
+	 */
+	private $registered_patterns_outside_init = array();
+
+	/**
 	 * Container for the main instance of the class.
 	 *
 	 * @since 5.5.0
@@ -92,10 +100,18 @@ final class WP_Block_Patterns_Registry {
 			return false;
 		}
 
-		$this->registered_patterns[ $pattern_name ] = array_merge(
+		$pattern = array_merge(
 			$pattern_properties,
 			array( 'name' => $pattern_name )
 		);
+		$this->registered_patterns[ $pattern_name ] = $pattern;
+
+		// If the pattern is registered inside an action other than `init`, store it
+		// also to a dedicated array. Used to detect deprecated registrations inside
+		// `admin_init` or `current_screen`.
+		if ( current_action() && 'init' !== current_action() ) {
+			$this->registered_patterns_outside_init[ $pattern_name ] = $pattern;
+		}
 
 		return true;
 	}
@@ -120,6 +136,7 @@ final class WP_Block_Patterns_Registry {
 		}
 
 		unset( $this->registered_patterns[ $pattern_name ] );
+		unset( $this->registered_patterns_outside_init[ $pattern_name ] );
 
 		return true;
 	}
@@ -145,11 +162,16 @@ final class WP_Block_Patterns_Registry {
 	 *
 	 * @since 5.5.0
 	 *
+	 * @param bool $outside_init_only Return only patterns registered outside the `init` action.
 	 * @return array[] Array of arrays containing the registered block patterns properties,
 	 *                 and per style.
 	 */
-	public function get_all_registered() {
-		return array_values( $this->registered_patterns );
+	public function get_all_registered( $outside_init_only = false ) {
+		return array_values(
+			$outside_init_only
+				? $this->registered_patterns_outside_init
+				: $this->registered_patterns
+		);
 	}
 
 	/**


### PR DESCRIPTION
This reverts commit 31c2639b80cf532abe2506c0a20c2ddd61ca71fc.

As a companion to Gutenberg https://github.com/WordPress/gutenberg/pull/40818, start adding `__experimentaBlockPatterns` and `__experimentalBlockPatternCategories` to server-generated editor settings. That makes sure that patterns registered in `admin_init` or `current_screen` are not lost.

Fixes https://github.com/WordPress/gutenberg/issues/40736

Trac ticket: https://core.trac.wordpress.org/ticket/55567