### PR TITLE
Replace phpversion() calls with PHP_VERSION constant

### DIFF
--- a/src/wp-admin/includes/class-plugin-installer-skin.php
+++ b/src/wp-admin/includes/class-plugin-installer-skin.php
@@ -266,7 +266,7 @@ class Plugin_Installer_Skin extends WP_Upgrader_Skin {
 			$error = sprintf(
 				/* translators: 1: Current PHP version, 2: Version required by the uploaded plugin. */
 				__( 'The PHP version on your server is %1$s, however the uploaded plugin requires %2$s.' ),
-				phpversion(),
+				PHP_VERSION,
 				$requires_php
 			);
 

--- a/src/wp-admin/includes/class-plugin-upgrader.php
+++ b/src/wp-admin/includes/class-plugin-upgrader.php
@@ -447,7 +447,7 @@ class Plugin_Upgrader extends WP_Upgrader {
 			$error = sprintf(
 				/* translators: 1: Current PHP version, 2: Version required by the uploaded plugin. */
 				__( 'The PHP version on your server is %1$s, however the uploaded plugin requires %2$s.' ),
-				phpversion(),
+				PHP_VERSION,
 				$requires_php
 			);
 

--- a/src/wp-admin/includes/class-theme-installer-skin.php
+++ b/src/wp-admin/includes/class-theme-installer-skin.php
@@ -301,7 +301,7 @@ class Theme_Installer_Skin extends WP_Upgrader_Skin {
 			$error = sprintf(
 				/* translators: 1: Current PHP version, 2: Version required by the uploaded theme. */
 				__( 'The PHP version on your server is %1$s, however the uploaded theme requires %2$s.' ),
-				phpversion(),
+				PHP_VERSION,
 				$requires_php
 			);
 

--- a/src/wp-admin/includes/class-theme-upgrader.php
+++ b/src/wp-admin/includes/class-theme-upgrader.php
@@ -586,7 +586,7 @@ class Theme_Upgrader extends WP_Upgrader {
 			$error = sprintf(
 				/* translators: 1: Current PHP version, 2: Version required by the uploaded theme. */
 				__( 'The PHP version on your server is %1$s, however the uploaded theme requires %2$s.' ),
-				phpversion(),
+				PHP_VERSION,
 				$requires_php
 			);
 

--- a/src/wp-admin/includes/class-wp-automatic-updater.php
+++ b/src/wp-admin/includes/class-wp-automatic-updater.php
@@ -222,7 +222,7 @@ class WP_Automatic_Updater {
 		if ( 'core' === $type ) {
 			global $wpdb;
 
-			$php_compat = version_compare( phpversion(), $item->php_version, '>=' );
+			$php_compat = version_compare( PHP_VERSION, $item->php_version, '>=' );
 			if ( file_exists( WP_CONTENT_DIR . '/db.php' ) && empty( $wpdb->is_mysql ) ) {
 				$mysql_compat = true;
 			} else {
@@ -236,7 +236,7 @@ class WP_Automatic_Updater {
 
 		// If updating a plugin or theme, ensure the minimum PHP version requirements are satisfied.
 		if ( in_array( $type, array( 'plugin', 'theme' ), true ) ) {
-			if ( ! empty( $item->requires_php ) && version_compare( phpversion(), $item->requires_php, '<' ) ) {
+			if ( ! empty( $item->requires_php ) && version_compare( PHP_VERSION, $item->requires_php, '<' ) ) {
 				return false;
 			}
 		}

--- a/src/wp-admin/includes/class-wp-debug-data.php
+++ b/src/wp-admin/includes/class-wp-debug-data.php
@@ -677,8 +677,8 @@ class WP_Debug_Data {
 			$server_architecture = 'unknown';
 		}
 
-		if ( function_exists( 'phpversion' ) ) {
-			$php_version_debug = phpversion();
+		if ( defined( 'PHP_VERSION' ) ) {
+			$php_version_debug = PHP_VERSION;
 			// Whether PHP supports 64-bit.
 			$php64bit = ( PHP_INT_SIZE * 8 === 64 );
 

--- a/src/wp-admin/includes/class-wp-debug-data.php
+++ b/src/wp-admin/includes/class-wp-debug-data.php
@@ -677,23 +677,18 @@ class WP_Debug_Data {
 			$server_architecture = 'unknown';
 		}
 
-		if ( defined( 'PHP_VERSION' ) ) {
-			$php_version_debug = PHP_VERSION;
-			// Whether PHP supports 64-bit.
-			$php64bit = ( PHP_INT_SIZE * 8 === 64 );
+		$php_version_debug = PHP_VERSION;
+		// Whether PHP supports 64-bit.
+		$php64bit = ( PHP_INT_SIZE * 8 === 64 );
 
-			$php_version = sprintf(
-				'%s %s',
-				$php_version_debug,
-				( $php64bit ? __( '(Supports 64bit values)' ) : __( '(Does not support 64bit values)' ) )
-			);
+		$php_version = sprintf(
+			'%s %s',
+			$php_version_debug,
+			( $php64bit ? __( '(Supports 64bit values)' ) : __( '(Does not support 64bit values)' ) )
+		);
 
-			if ( $php64bit ) {
-				$php_version_debug .= ' 64bit';
-			}
-		} else {
-			$php_version       = __( 'Unable to determine PHP version' );
-			$php_version_debug = 'unknown';
+		if ( $php64bit ) {
+			$php_version_debug .= ' 64bit';
 		}
 
 		if ( function_exists( 'php_sapi_name' ) ) {

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1385,7 +1385,7 @@ function verify_file_signature( $filename, $signatures, $filename_for_errors = f
 				'<span class="code">' . esc_html( $filename_for_errors ) . '</span>'
 			),
 			array(
-				'php'    => phpversion(),
+				'php'    => PHP_VERSION,
 				'sodium' => defined( 'SODIUM_LIBRARY_VERSION' ) ? SODIUM_LIBRARY_VERSION : ( defined( 'ParagonIE_Sodium_Compat::VERSION_STRING' ) ? ParagonIE_Sodium_Compat::VERSION_STRING : false ),
 			)
 		);
@@ -1420,7 +1420,7 @@ function verify_file_signature( $filename, $signatures, $filename_for_errors = f
 					'<span class="code">' . esc_html( $filename_for_errors ) . '</span>'
 				),
 				array(
-					'php'                => phpversion(),
+					'php'                => PHP_VERSION,
 					'sodium'             => defined( 'SODIUM_LIBRARY_VERSION' ) ? SODIUM_LIBRARY_VERSION : ( defined( 'ParagonIE_Sodium_Compat::VERSION_STRING' ) ? ParagonIE_Sodium_Compat::VERSION_STRING : false ),
 					'polyfill_is_fast'   => false,
 					'max_execution_time' => ini_get( 'max_execution_time' ),
@@ -1493,7 +1493,7 @@ function verify_file_signature( $filename, $signatures, $filename_for_errors = f
 			'hash'        => bin2hex( $file_hash ),
 			'skipped_key' => $skipped_key,
 			'skipped_sig' => $skipped_signature,
-			'php'         => phpversion(),
+			'php'         => PHP_VERSION,
 			'sodium'      => defined( 'SODIUM_LIBRARY_VERSION' ) ? SODIUM_LIBRARY_VERSION : ( defined( 'ParagonIE_Sodium_Compat::VERSION_STRING' ) ? ParagonIE_Sodium_Compat::VERSION_STRING : false ),
 		)
 	);

--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -1524,7 +1524,7 @@ function _wp_privacy_settings_filter_draft_page_titles( $title, $page ) {
  * @return array|false Array of PHP version data. False on failure.
  */
 function wp_check_php_version() {
-	$version = phpversion();
+	$version = PHP_VERSION;
 	$key     = md5( $version );
 
 	$response = get_site_transient( 'php_check_' . $key );

--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -1150,7 +1150,7 @@ function validate_plugin_requirements( $plugin ) {
 				/* translators: 1: Current WordPress version, 2: Current PHP version, 3: Plugin name, 4: Required WordPress version, 5: Required PHP version. */
 				_x( '<strong>Error:</strong> Current versions of WordPress (%1$s) and PHP (%2$s) do not meet minimum requirements for %3$s. The plugin requires WordPress %4$s and PHP %5$s.', 'plugin' ),
 				get_bloginfo( 'version' ),
-				phpversion(),
+				PHP_VERSION,
 				$plugin_headers['Name'],
 				$requirements['requires'],
 				$requirements['requires_php']
@@ -1162,7 +1162,7 @@ function validate_plugin_requirements( $plugin ) {
 			'<p>' . sprintf(
 				/* translators: 1: Current PHP version, 2: Plugin name, 3: Required PHP version. */
 				_x( '<strong>Error:</strong> Current PHP version (%1$s) does not meet minimum requirements for %2$s. The plugin requires PHP %3$s.', 'plugin' ),
-				phpversion(),
+				PHP_VERSION,
 				$plugin_headers['Name'],
 				$requirements['requires_php']
 			) . $php_update_message . '</p>'

--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -1012,7 +1012,7 @@ function update_core( $from, $to ) {
 	require WP_CONTENT_DIR . '/upgrade/version-current.php';
 	$wp_filesystem->delete( $versions_file );
 
-	$php_version       = phpversion();
+	$php_version       = PHP_VERSION;
 	$mysql_version     = $wpdb->db_version();
 	$old_wp_version    = $GLOBALS['wp_version']; // The version of WordPress we're updating from.
 	$development_build = ( false !== strpos( $old_wp_version . $wp_version, '-' ) ); // A dash in the version indicates a development release.

--- a/src/wp-admin/install.php
+++ b/src/wp-admin/install.php
@@ -228,7 +228,7 @@ if ( is_blog_installed() ) {
  */
 global $wp_version, $required_php_version, $required_mysql_version;
 
-$php_version   = phpversion();
+$php_version   = PHP_VERSION;
 $mysql_version = $wpdb->db_version();
 $php_compat    = version_compare( $php_version, $required_php_version, '>=' );
 $mysql_compat  = version_compare( $mysql_version, $required_mysql_version, '>=' ) || file_exists( WP_CONTENT_DIR . '/db.php' );

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -59,7 +59,7 @@ function list_core_update( $update ) {
 
 	$message       = '';
 	$form_action   = 'update-core.php?action=do-core-upgrade';
-	$php_version   = phpversion();
+	$php_version   = PHP_VERSION;
 	$mysql_version = $wpdb->db_version();
 	$show_buttons  = true;
 

--- a/src/wp-admin/upgrade.php
+++ b/src/wp-admin/upgrade.php
@@ -44,7 +44,7 @@ global $wp_version, $required_php_version, $required_mysql_version;
 
 $step = (int) $step;
 
-$php_version   = phpversion();
+$php_version   = PHP_VERSION;
 $mysql_version = $wpdb->db_version();
 $php_compat    = version_compare( $php_version, $required_php_version, '>=' );
 if ( file_exists( WP_CONTENT_DIR . '/db.php' ) && empty( $wpdb->is_mysql ) ) {

--- a/src/wp-cron.php
+++ b/src/wp-cron.php
@@ -19,7 +19,7 @@
 ignore_user_abort( true );
 
 /* Don't make the request block till we finish, if possible. */
-if ( function_exists( 'fastcgi_finish_request' ) && version_compare( phpversion(), '7.0.16', '>=' ) ) {
+if ( PHP_VERSION_ID >= 70016 && function_exists( 'fastcgi_finish_request' ) ) {
 	if ( ! headers_sent() ) {
 		header( 'Expires: Wed, 11 Jan 1984 05:00:00 GMT' );
 		header( 'Cache-Control: no-cache, must-revalidate, max-age=0' );

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -8422,7 +8422,7 @@ function is_wp_version_compatible( $required ) {
  * @return bool True if required version is compatible or empty, false if not.
  */
 function is_php_version_compatible( $required ) {
-	return empty( $required ) || version_compare( phpversion(), $required, '>=' );
+	return empty( $required ) || version_compare( PHP_VERSION, $required, '>=' );
 }
 
 /**

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -143,7 +143,7 @@ function wp_populate_basic_auth_from_authorization_header() {
  */
 function wp_check_php_mysql_versions() {
 	global $required_php_version, $wp_version;
-	$php_version = phpversion();
+	$php_version = PHP_VERSION;
 
 	if ( version_compare( $required_php_version, $php_version, '>' ) ) {
 		$protocol = wp_get_server_protocol();

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -32,7 +32,7 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 
 	// Include an unmodified $wp_version.
 	require ABSPATH . WPINC . '/version.php';
-	$php_version = phpversion();
+	$php_version = PHP_VERSION;
 
 	$current      = get_site_transient( 'update_core' );
 	$translations = wp_get_installed_translations( 'core' );

--- a/tests/phpunit/tests/functions/isPhpVersionCompatible.php
+++ b/tests/phpunit/tests/functions/isPhpVersionCompatible.php
@@ -27,7 +27,7 @@ class Tests_Functions_IsPhpVersionCompatible extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function data_is_php_version_compatible() {
-		$php_version = phpversion();
+		$php_version = PHP_VERSION;
 
 		$version_parts  = explode( '.', $php_version );
 		$lower_version  = $version_parts;

--- a/tests/phpunit/tests/load/wpIsIniValueChangeable.php
+++ b/tests/phpunit/tests/load/wpIsIniValueChangeable.php
@@ -40,7 +40,7 @@ class Tests_Load_wpIsIniValueChangeable extends WP_UnitTestCase {
 			array( 'upload_tmp_dir', false ), // PHP_INI_SYSTEM.
 		);
 
-		if ( extension_loaded( 'Tidy' ) && version_compare( PHP_VERSION, '7.0.0', '>' ) ) {
+		if ( extension_loaded( 'Tidy' ) && PHP_VERSION_ID > 70000 ) {
 			$array[] = array( 'tidy.clean_output', true ); // PHP_INI_USER.
 		}
 

--- a/tests/phpunit/tests/load/wpIsIniValueChangeable.php
+++ b/tests/phpunit/tests/load/wpIsIniValueChangeable.php
@@ -40,7 +40,7 @@ class Tests_Load_wpIsIniValueChangeable extends WP_UnitTestCase {
 			array( 'upload_tmp_dir', false ), // PHP_INI_SYSTEM.
 		);
 
-		if ( extension_loaded( 'Tidy' ) && PHP_VERSION_ID > 70000 ) {
+		if ( PHP_VERSION_ID > 70000 && extension_loaded( 'Tidy' ) ) {
 			$array[] = array( 'tidy.clean_output', true ); // PHP_INI_USER.
 		}
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/55680#ticket

We use several `phpversion()` function calls in WordPress core, which I propose to be replaced with `PHP_VERSION` constants.

`phpversion()` return value and `PHP_VERSION` constant value are identical, but the former is about 3 times slower because it is a function call compared to a direct constant value lookup.

Simple benchmark:

```php

$start = microtime(true);
for ($i = 0; $i < 1000000; $i++) {phpversion();}
echo microtime(true) - $start;

echo "\r\n";

$start = microtime(true);
for ($i = 0; $i < 1000000; $i++) {PHP_VERSION;}
echo microtime(true) - $start;

```
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
