### PR TITLE
Regenerate PHP packages in the sync-gutenberg-packages task 

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1219,6 +1219,14 @@ module.exports = function(grunt) {
 	] );
 
 	grunt.registerTask( 'sync-gutenberg-packages', function() {
+		if ( ! grunt.option( 'dev' ) ) {
+			console.log( 'You must manually pass the --dev flag to the sync-gutenberg-packages task as follows:' );
+			console.log( 'npx grunt sync-gutenberg-packages --dev' );
+			console.log( 'Otherwise the webpack build tasks are executed in the production mode and do not ');
+			console.log( 'regenerate the src/wp-includes/assets/script-loader-packages.php.' );
+			process.exit( 0 );
+		}
+
 		/*
 		 * Browserlist database should be updated when the packages are
 		 * being updated to their latest version in the trunk branch.
@@ -1249,11 +1257,7 @@ module.exports = function(grunt) {
 		 */
 		grunt.task.run( 'wp-packages:refresh-deps' );
 
-		grunt.task.run( 'build' );
-
 		// Build the files stored in the src/ directory.
-		// Set the --dev option to true
-		grunt.option( 'dev', true );
 		grunt.task.run( 'build' );
 	} );
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1250,7 +1250,9 @@ module.exports = function(grunt) {
 		grunt.task.run( 'build' );
 
 		// Build the files stored in the src/ directory.
-		grunt.task.run( 'build:dev' );
+		// Set the --dev option to true
+		grunt.option( 'dev', true );
+		grunt.task.run( 'build' );
 	} );
 
 	grunt.renameTask( 'watch', '_watch' );

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1227,24 +1227,22 @@ module.exports = function(grunt) {
 			process.exit( 0 );
 		}
 
-		/*
-		 * Browserlist database should be updated when the packages are
-		 * being updated to their latest version in the trunk branch.
-		 *
-		 * It should not happen during the patch releases. Otherwise,
-		 * we'd be changing the supported browsers of a WP release on patch release.
-		 *
-		 * For more context, see:
-		 *
-		 * https://github.com/WordPress/gutenberg/issues/33344
-		 * https://core.trac.wordpress.org/ticket/55559
-		 */
-		const distTag = grunt.option('dist-tag') || 'latest';
-		const currentBranch = spawn( 'git', [ 'branch', '--show-current' ], {
-			cwd: __dirname,
-		} ).stdout.toString().trim();
-
-		if ( distTag === 'latest' && currentBranch === 'trunk' ) {
+		if ( grunt.option( 'update-browserlist' ) ) {
+			/*
+			 * Updating the browserlist database is opt-in and up to the release lead.
+			 *
+			 * Browserlist database should be updated:
+			 * - In each release cycle up until RC1
+			 * - If Webpack throws a warning about an outdated database
+			 *
+			 * It should not be updated:
+			 * - After the RC1
+			 * - When backporting fixes to older WordPress releases.
+			 *
+			 * For more context, see:
+			 * https://github.com/WordPress/wordpress-develop/pull/2621#discussion_r859840515
+			 * https://core.trac.wordpress.org/ticket/55559
+			 */
 			grunt.task.run( 'browserslist:update' );
 		}
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1247,6 +1247,8 @@ module.exports = function(grunt) {
 		 */
 		grunt.task.run( 'wp-packages:refresh-deps' );
 
+		grunt.task.run( 'build' );
+
 		// Build the files stored in the src/ directory.
 		grunt.task.run( 'build:dev' );
 	} );

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1219,22 +1219,24 @@ module.exports = function(grunt) {
 	] );
 
 	grunt.registerTask( 'sync-gutenberg-packages', function() {
-		if ( grunt.option( 'update-browserlist' ) ) {
-			/*
-			 * Updating the browserlist database is opt-in and up to the release lead.
-			 *
-			 * Browserlist database should be updated:
-			 * - In each release cycle up until RC1
-			 * - If Webpack throws a warning about an outdated database
-			 *
-			 * It should not be updated:
-			 * - After the RC1
-			 * - When backporting fixes to older WordPress releases.
-			 *
-			 * For more context, see:
-			 * https://github.com/WordPress/wordpress-develop/pull/2621#discussion_r859840515
-			 * https://core.trac.wordpress.org/ticket/55559
-			 */
+		/*
+		 * Browserlist database should be updated when the packages are
+		 * being updated to their latest version in the trunk branch.
+		 *
+		 * It should not happen during the patch releases. Otherwise,
+		 * we'd be changing the supported browsers of a WP release on patch release.
+		 *
+		 * For more context, see:
+		 *
+		 * https://github.com/WordPress/gutenberg/issues/33344
+		 * https://core.trac.wordpress.org/ticket/55559
+		 */
+		const distTag = grunt.option('dist-tag') || 'latest';
+		const currentBranch = spawn( 'git', [ 'branch', '--show-current' ], {
+			cwd: __dirname,
+		} ).stdout.toString().trim();
+
+		if ( distTag === 'latest' && currentBranch === 'trunk' ) {
 			grunt.task.run( 'browserslist:update' );
 		}
 

--- a/package.json
+++ b/package.json
@@ -175,6 +175,6 @@
 		"test:php": "node ./tools/local-env/scripts/docker.js run -T php composer update -W && node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit",
 		"test:e2e": "node ./tests/e2e/run-tests.js",
 		"test:visual": "node ./tests/visual-regression/run-tests.js",
-		"sync-gutenberg-packages": "grunt sync-gutenberg-packages"
+		"sync-gutenberg-packages": "grunt sync-gutenberg-packages --dev"
 	}
 }


### PR DESCRIPTION
## What problem does this PR solve?

The `npx sync-gutenberg-packages` command introduced in https://github.com/WordPress/wordpress-develop/pull/2621 does not regenerate the `script-loader-packages.php` file.

This PR makes it run `npm run build` to regenerate that file.

Let's test it on Tuesday when releasing RC2 @gziolo 