### PR TITLE
#55700: Move the Memcached container into the Docker Compose config

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -46,7 +46,6 @@ jobs:
   # - Installs Composer dependencies.
   # - Logs Docker debug information (about the Docker installation within the runner).
   # - Starts the WordPress Docker container.
-  # - Starts the Memcached server after the Docker network has been created (if desired).
   # - Logs general debug information about the runner.
   # - Logs the running Docker containers.
   # - Logs debug information from inside the WordPress Docker container.
@@ -158,13 +157,6 @@ jobs:
       - name: Start Docker environment
         run: |
           npm run env:start
-
-      # The memcached server needs to start after the Docker network has been set up with `npm run env:start`.
-      - name: Start the Memcached server.
-        if: ${{ matrix.memcached }}
-        run: |
-          cp tests/phpunit/includes/object-cache.php src/wp-content/object-cache.php
-          docker run --name memcached --net $(basename "$PWD")_wpdevnet -d memcached
 
       - name: General debug information
         run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,9 @@ services:
       - ./tools/local-env/php-config.ini:/usr/local/etc/php/conf.d/php-config.ini
       - ./:/var/www
 
+    # Copy or delete the Memcached dropin plugin file as appropriate.
+    command: /bin/sh -c "if [ $LOCAL_PHP_MEMCACHED = true ]; then cp -n /var/www/tests/phpunit/includes/object-cache.php /var/www/src/wp-content/object-cache.php; else rm -f /var/www/src/wp-content/object-cache.php; fi && exec php-fpm"
+
     depends_on:
       - mysql
 
@@ -103,6 +106,18 @@ services:
 
     extra_hosts:
       - localhost:host-gateway
+
+  ##
+  # The Memcached container.
+  ##
+  memcached:
+    image: memcached
+
+    networks:
+      - wpdevnet
+
+    ports:
+      - 11211:11211
 
 volumes:
   # So that sites aren't wiped every time containers are restarted, MySQL uses a persistent volume.

--- a/tools/local-env/scripts/start.js
+++ b/tools/local-env/scripts/start.js
@@ -9,7 +9,10 @@ if ( process.arch === 'arm64' ) {
 }
 
 // Start the local-env containers.
-execSync( 'docker-compose up -d wordpress-develop', { stdio: 'inherit' } );
+const containers = ( process.env.LOCAL_PHP_MEMCACHED === 'true' )
+	? 'wordpress-develop memcached'
+	: 'wordpress-develop';
+execSync( `docker-compose up -d -- ${containers}`, { stdio: 'inherit' } );
 
 // If Docker Toolbox is being used, we need to manually forward LOCAL_PORT to the Docker VM.
 if ( process.env.DOCKER_TOOLBOX_INSTALL_PATH ) {


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/55700

This moves the Memcached container into the Docker Compose config so it can be used with the local dev environment just by flipping the `LOCAL_PHP_MEMCACHED` environment variable value.

## Testing

Ensure Docker Desktop is running if necessary.

Test with the object cache enabled:

* In your `.env` file enable the memcached config via `LOCAL_PHP_MEMCACHED=true`
* Run `npm run env:restart`
* Confirm the `object-cache.php` drop-in is present on http://localhost:8889/wp-admin/plugins.php?plugin_status=dropins
* Use WP-CLI or a debugging plugin such as Query Monitor to confirm that the Memcached object cache is in use

Test with the object cache disabled:

* In your `.env` file disable the memcached config via `LOCAL_PHP_MEMCACHED=false`
* Run `npm run env:restart`
* Confirm the `object-cache.php` drop-in is no longer present on http://localhost:8889/wp-admin/plugins.php?plugin_status=dropins
* Use WP-CLI or a debugging plugin such as Query Monitor to confirm that the Memcached object cache is no longer in use
