### PR TITLE
#55702: Run the PHP container with PID > 1 so Ctrl+C works correctly

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,9 @@ services:
     depends_on:
       - mysql
 
+    # The init directive ensures the command runs with a PID > 1, so Ctrl+C works correctly.
+    init: true
+
   ##
   # The MySQL container.
   ##


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/55702