### PR TITLE
Tests: Use stricter assertions in comment template tests

### DIFF
--- a/tests/phpunit/tests/blocks/renderCommentTemplate.php
+++ b/tests/phpunit/tests/blocks/renderCommentTemplate.php
@@ -66,7 +66,7 @@ class Tests_Blocks_RenderReusableCommentTemplate extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertEquals(
+		$this->assertSameSetsWithIndex(
 			array(
 				'orderby'       => 'comment_date_gmt',
 				'order'         => 'ASC',
@@ -123,7 +123,7 @@ class Tests_Blocks_RenderReusableCommentTemplate extends WP_UnitTestCase {
 
 		$block = new WP_Block( $parsed_blocks[0] );
 
-		$this->assertEquals(
+		$this->assertSameSetsWithIndex(
 			array(
 				'orderby'       => 'comment_date_gmt',
 				'order'         => 'ASC',
@@ -421,8 +421,7 @@ END
 
 		add_filter( 'wp_get_current_commenter', $commenter_filter );
 
-		$this->assertEquals(
-			build_comment_query_vars_from_block( $block ),
+		$this->assertSameSetsWithIndex(
 			array(
 				'orderby'            => 'comment_date_gmt',
 				'order'              => 'ASC',
@@ -433,7 +432,8 @@ END
 				'hierarchical'       => 'threaded',
 				'number'             => 5,
 				'paged'              => 1,
-			)
+			),
+			build_comment_query_vars_from_block( $block )
 		);
 	}
 


### PR DESCRIPTION
Comments blocks unit tests have been [backported](https://github.com/WordPress/wordpress-develop/blob/a80c501fb7cb18d05a6923b8c98296011cc66378/tests/phpunit/tests/blocks/renderCommentTemplate.php), from Gutenberg, except for some [very minor differences](https://github.com/WordPress/gutenberg/pull/40739#issuecomment-1122276905).

This PR carries over those remaining changes, allowing us to remove the unit tests from GB (https://github.com/WordPress/gutenberg/pull/40965).

Trac ticket: https://core.trac.wordpress.org/ticket/55708

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
