### PR TITLE
Always use the amd64 images for MariaDB and MySQL

### DIFF
--- a/.env
+++ b/.env
@@ -35,8 +35,8 @@ LOCAL_DB_TYPE=mysql
 #
 # Defaults to 5.7 with the assumption that LOCAL_DB_TYPE is set to `mysql` above.
 #
-# When using `mysql`, see https://hub.docker.com/_/mysql/ for valid versions.
-# When using `mariadb`, see https://hub.docker.com/_/mariadb for valid versions.
+# When using `mysql`, see https://hub.docker.com/r/amd64/mysql for valid versions.
+# When using `mariadb`, see https://hub.docker.com/r/amd64/mariadb for valid versions.
 ##
 LOCAL_DB_VERSION=5.7
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
   # The MySQL container.
   ##
   mysql:
-    image: ${LOCAL_DB_TYPE-mysql}:${LOCAL_DB_VERSION-latest}
+    image: amd64/${LOCAL_DB_TYPE-mysql}:${LOCAL_DB_VERSION-latest}
 
     networks:
       - wpdevnet

--- a/tools/local-env/scripts/docker.js
+++ b/tools/local-env/scripts/docker.js
@@ -4,9 +4,5 @@ const { execSync } = require( 'child_process' );
 
 dotenvExpand.expand( dotenv.config() );
 
-if ( process.arch === 'arm64' ) {
-	process.env.LOCAL_DB_TYPE = `amd64/${process.env.LOCAL_DB_TYPE}`;
-}
-
 // Execute any docker-compose command passed to this script.
 execSync( 'docker-compose ' + process.argv.slice( 2 ).join( ' ' ), { stdio: 'inherit' } );

--- a/tools/local-env/scripts/install.js
+++ b/tools/local-env/scripts/install.js
@@ -6,10 +6,6 @@ const { renameSync, readFileSync, writeFileSync } = require( 'fs' );
 
 dotenvExpand.expand( dotenv.config() );
 
-if ( process.arch === 'arm64' ) {
-	process.env.LOCAL_DB_TYPE = `amd64/${process.env.LOCAL_DB_TYPE}`;
-}
-
 // Create wp-config.php.
 wp_cli( 'config create --dbname=wordpress_develop --dbuser=root --dbpass=password --dbhost=mysql --path=/var/www/src --force' );
 

--- a/tools/local-env/scripts/start.js
+++ b/tools/local-env/scripts/start.js
@@ -4,10 +4,6 @@ const { execSync } = require( 'child_process' );
 
 dotenvExpand.expand( dotenv.config() );
 
-if ( process.arch === 'arm64' ) {
-	process.env.LOCAL_DB_TYPE = `amd64/${process.env.LOCAL_DB_TYPE}`;
-}
-
 // Start the local-env containers.
 execSync( 'docker-compose up -d wordpress-develop', { stdio: 'inherit' } );
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/56528

Usage of the `amd64/mysql` and `amd64/mariadb` official images from Docker was introduced in https://core.trac.wordpress.org/ticket/52356 as they are compatible with an x64 container running on a host machine using ARM64 architecture (ie. Apple M1 machines).

However they're also compatible with an x64 host machine which should mean they can be used by default instead of only when the host uses ARM64. This allows some image juggling to be removed.

## Testing if you have an existing environment

* Ensure Docker Desktop is running if necessary
* While still on your current branch (eg. `trunk`) run `npm run env:stop`
* Checkout the branch for this PR
* Run `npm run env:start`
* Run some tests that use the database container, eg. `npm run test:php`

## Testing from scratch

* Ensure Docker Desktop is running if necessary
* Run:  
  ```
  npm install
  npm run build:dev
  npm run env:start
  npm run env:install
  ```
* Run some tests that use the database container, eg. `npm run test:php`

## Todo:

* [x] Test on x64 Intel Mac
* [x] Test on ARM64 M1 Mac
* [x] Test on x64 Linux (GitHub Actions)
* [x] Test on x64 Windows
