### PR TITLE
Fix comments odd / even instabilities (test leaks) - Trac 54725

### DIFF
--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -187,6 +187,12 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 		remove_filter( 'wp_die_handler', array( $this, 'get_wp_die_handler' ) );
 		$this->_restore_hooks();
 		wp_set_current_user( 0 );
+
+		// Reset comments globals.
+		$comment_globals = array( 'comment_alt', 'comment_depth', 'comment_thread_alt' );
+		foreach ( $comment_globals as $global ) {
+			$GLOBALS[ $global ] = null;
+		}
 	}
 
 	/**

--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -174,6 +174,12 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 			$GLOBALS[ $global ] = null;
 		}
 
+		// Reset comment globals.
+		$comment_globals = array( 'comment_alt', 'comment_depth', 'comment_thread_alt' );
+		foreach ( $comment_globals as $global ) {
+			$GLOBALS[ $global ] = null;
+		}
+
 		/*
 		 * Reset $wp_sitemap global so that sitemap-related dynamic $wp->public_query_vars
 		 * are added when the next test runs.
@@ -187,12 +193,6 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 		remove_filter( 'wp_die_handler', array( $this, 'get_wp_die_handler' ) );
 		$this->_restore_hooks();
 		wp_set_current_user( 0 );
-
-		// Reset comments globals.
-		$comment_globals = array( 'comment_alt', 'comment_depth', 'comment_thread_alt' );
-		foreach ( $comment_globals as $global ) {
-			$GLOBALS[ $global ] = null;
-		}
 	}
 
 	/**

--- a/tests/phpunit/tests/blocks/renderCommentTemplate.php
+++ b/tests/phpunit/tests/blocks/renderCommentTemplate.php
@@ -109,7 +109,6 @@ class Tests_Blocks_RenderReusableCommentTemplate extends WP_UnitTestCase {
 			),
 			build_comment_query_vars_from_block( $block )
 		);
-		update_option( 'page_comments', true );
 	}
 
 	/**
@@ -187,9 +186,6 @@ class Tests_Blocks_RenderReusableCommentTemplate extends WP_UnitTestCase {
 			),
 			build_comment_query_vars_from_block( $block )
 		);
-
-		update_option( 'comments_per_page', $comments_per_page );
-		update_option( 'default_comments_page', $default_comments_page );
 	}
 
 

--- a/tests/phpunit/tests/blocks/renderCommentTemplate.php
+++ b/tests/phpunit/tests/blocks/renderCommentTemplate.php
@@ -308,7 +308,7 @@ class Tests_Blocks_RenderReusableCommentTemplate extends WP_UnitTestCase {
 			'',
 			<<<END
 				<ol class="wp-block-comment-template">
-					<li id="comment-{$top_level_ids[0]}" class="comment odd alt thread-odd thread-alt depth-1">
+					<li id="comment-{$top_level_ids[0]}" class="comment even thread-even depth-1">
 						<div class="wp-block-comment-author-name">
 							<a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >
 								Test
@@ -318,7 +318,7 @@ class Tests_Blocks_RenderReusableCommentTemplate extends WP_UnitTestCase {
 							<p>Hello world</p>
 						</div>
 						<ol>
-							<li id="comment-{$first_level_ids[0]}" class="comment even depth-2">
+							<li id="comment-{$first_level_ids[0]}" class="comment odd alt depth-2">
 								<div class="wp-block-comment-author-name">
 									<a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >
 										Test
@@ -328,7 +328,7 @@ class Tests_Blocks_RenderReusableCommentTemplate extends WP_UnitTestCase {
 									<p>Hello world</p>
 								</div>
 								<ol>
-									<li id="comment-{$second_level_ids[0]}" class="comment odd alt depth-3">
+									<li id="comment-{$second_level_ids[0]}" class="comment even depth-3">
 										<div class="wp-block-comment-author-name">
 											<a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >
 												Test
@@ -340,7 +340,7 @@ class Tests_Blocks_RenderReusableCommentTemplate extends WP_UnitTestCase {
 									</li>
 								</ol>
 							</li>
-							<li id="comment-{$first_level_ids[1]}" class="comment even depth-2">
+							<li id="comment-{$first_level_ids[1]}" class="comment odd alt depth-2">
 								<div class="wp-block-comment-author-name">
 									<a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >
 										Test
@@ -390,7 +390,7 @@ END
 		$expected_content = "<p>Paragraph One</p>\n<p>P2L1<br />\nP2L2</p>\n<p><a href=\"https://example.com/\" rel=\"nofollow ugc\">https://example.com/</a></p>\n";
 
 		$this->assertSame(
-			'<ol class="wp-block-comment-template"><li id="comment-' . self::$comment_ids[0] . '" class="comment odd alt thread-even depth-1"><div class="wp-block-comment-content">' . $expected_content . '</div></li></ol>',
+			'<ol class="wp-block-comment-template"><li id="comment-' . self::$comment_ids[0] . '" class="comment even thread-even depth-1"><div class="wp-block-comment-content">' . $expected_content . '</div></li></ol>',
 			$block->render()
 		);
 	}
@@ -475,7 +475,7 @@ END
 		add_filter( 'wp_get_current_commenter', $commenter_filter );
 
 		$this->assertSame(
-			'<ol class="wp-block-comment-template"><li id="comment-' . self::$comment_ids[0] . '" class="comment even thread-odd thread-alt depth-1"><div class="wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content"><p>Hello world</p></div></li><li id="comment-' . $unapproved_comment[0] . '" class="comment odd alt thread-even depth-1"><div class="wp-block-comment-author-name">Visitor</div><div class="wp-block-comment-content"><p><em class="comment-awaiting-moderation">Your comment is awaiting moderation.</em></p>Hi there! My comment needs moderation.</div></li></ol>',
+			'<ol class="wp-block-comment-template"><li id="comment-' . self::$comment_ids[0] . '" class="comment even thread-even depth-1"><div class="wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content"><p>Hello world</p></div></li><li id="comment-' . $unapproved_comment[0] . '" class="comment odd alt thread-odd thread-alt depth-1"><div class="wp-block-comment-author-name">Visitor</div><div class="wp-block-comment-content"><p><em class="comment-awaiting-moderation">Your comment is awaiting moderation.</em></p>Hi there! My comment needs moderation.</div></li></ol>',
 			str_replace( array( "\n", "\t" ), '', $block->render() ),
 			'Should include unapproved comments when filter applied'
 		);
@@ -484,7 +484,7 @@ END
 
 		// Test it again and ensure the unmoderated comment doesn't leak out.
 		$this->assertSame(
-			'<ol class="wp-block-comment-template"><li id="comment-' . self::$comment_ids[0] . '" class="comment even thread-odd thread-alt depth-1"><div class="wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content"><p>Hello world</p></div></li></ol>',
+			'<ol class="wp-block-comment-template"><li id="comment-' . self::$comment_ids[0] . '" class="comment even thread-even depth-1"><div class="wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content"><p>Hello world</p></div></li></ol>',
 			str_replace( array( "\n", "\t" ), '', $block->render() ),
 			'Should not include any unapproved comments after removing filter'
 		);

--- a/tests/phpunit/tests/blocks/renderCommentTemplate.php
+++ b/tests/phpunit/tests/blocks/renderCommentTemplate.php
@@ -19,6 +19,7 @@ class Tests_Blocks_RenderReusableCommentTemplate extends WP_UnitTestCase {
 	private static $custom_post;
 	private static $comment_ids;
 	private static $per_page = 5;
+
 	/**
 	 * Array of the comments options and their original values.
 	 * Used to rest the options after each test.

--- a/tests/phpunit/tests/blocks/renderCommentTemplate.php
+++ b/tests/phpunit/tests/blocks/renderCommentTemplate.php
@@ -22,7 +22,7 @@ class Tests_Blocks_RenderReusableCommentTemplate extends WP_UnitTestCase {
 
 	/**
 	 * Array of the comments options and their original values.
-	 * Used to rest the options after each test.
+	 * Used to reset the options after each test.
 	 *
 	 * @var array
 	 */

--- a/tests/phpunit/tests/blocks/renderCommentTemplate.php
+++ b/tests/phpunit/tests/blocks/renderCommentTemplate.php
@@ -19,13 +19,45 @@ class Tests_Blocks_RenderReusableCommentTemplate extends WP_UnitTestCase {
 	private static $custom_post;
 	private static $comment_ids;
 	private static $per_page = 5;
+	/**
+	 * Array of the comments options and their original values.
+	 * Used to rest the options after each test.
+	 *
+	 * @var array
+	 */
+	private static $original_options;
+
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		// Store the original option values.
+		$options = array(
+			'comment_order',
+			'comments_per_page',
+			'default_comments_page',
+			'page_comments',
+			'previous_default_page',
+			'thread_comments_depth',
+		);
+		foreach ( $options as $option ) {
+			static::$original_options[ $option ] = get_option( $option );
+		}
+	}
+
+	public function tear_down() {
+		// Reset the comment options to their original values.
+		foreach ( static::$original_options as $option => $original_value ) {
+			update_option( $option, $original_value );
+		}
+
+		parent::tear_down();
+	}
 
 	public function set_up() {
 		parent::set_up();
 
 		update_option( 'page_comments', true );
 		update_option( 'comments_per_page', self::$per_page );
-		update_option( 'comment_order', 'ASC' );
 
 		self::$custom_post = self::factory()->post->create_and_get(
 			array(


### PR DESCRIPTION
The odd / even class attribute global variables are causing issues in comments tests when a new test is added or an existing test is modified. To stabilize the odd / even comment tests, the comment global variables are added to the base test class' `tear_down()` using the same patterns as the other global resets. This change ensures each comment test starts at the same state. In doing so, the expected  odd / even class attributes are no longer affected by previous tests, i.e. test leaks.

Adding this to a 6.0 test improvement ticket for backport to 6.0-branch since this issue was identified in the 6.0 cycle.

Trac ticket: https://core.trac.wordpress.org/ticket/54725

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
