### PR TITLE
Add `Update URI` header to `WP_Theme`.

### DIFF
--- a/src/wp-includes/class-wp-theme.php
+++ b/src/wp-includes/class-wp-theme.php
@@ -23,7 +23,7 @@ final class WP_Theme implements ArrayAccess {
 	 *
 	 * @since 3.4.0
 	 * @since 5.4.0 Added `Requires at least` and `Requires PHP` headers.
-	 * @since 6.1.0 Added support for `Update URI` header.
+	 * @since 6.1.0 Added `Update URI` header.
 	 * @var string[]
 	 */
 	private static $file_headers = array(
@@ -847,7 +847,8 @@ final class WP_Theme implements ArrayAccess {
 	 * @since 6.1.0 Added support for `Update URI` header.
 	 *
 	 * @param string $header Theme header. Accepts 'Name', 'Description', 'Author', 'Version',
-	 *                       'ThemeURI', 'AuthorURI', 'Status', 'Tags', 'RequiresWP', 'RequiresPHP'.
+	 *                       'ThemeURI', 'AuthorURI', 'Status', 'Tags', 'RequiresWP', 'RequiresPHP'
+	 *                       'UpdateURI'.
 	 * @param string $value  Value to sanitize.
 	 * @return string|array An array for Tags header, string otherwise.
 	 */

--- a/src/wp-includes/class-wp-theme.php
+++ b/src/wp-includes/class-wp-theme.php
@@ -844,6 +844,7 @@ final class WP_Theme implements ArrayAccess {
 	 *
 	 * @since 3.4.0
 	 * @since 5.4.0 Added support for `Requires at least` and `Requires PHP` headers.
+	 * @since 6.1.0 Added support for `Update URI` header.
 	 *
 	 * @param string $header Theme header. Accepts 'Name', 'Description', 'Author', 'Version',
 	 *                       'ThemeURI', 'AuthorURI', 'Status', 'Tags', 'RequiresWP', 'RequiresPHP'.

--- a/src/wp-includes/class-wp-theme.php
+++ b/src/wp-includes/class-wp-theme.php
@@ -23,6 +23,7 @@ final class WP_Theme implements ArrayAccess {
 	 *
 	 * @since 3.4.0
 	 * @since 5.4.0 Added `Requires at least` and `Requires PHP` headers.
+	 * @since 6.0.0 Added support for `Update URI` header.
 	 * @var string[]
 	 */
 	private static $file_headers = array(
@@ -39,6 +40,7 @@ final class WP_Theme implements ArrayAccess {
 		'DomainPath'  => 'Domain Path',
 		'RequiresWP'  => 'Requires at least',
 		'RequiresPHP' => 'Requires PHP',
+		'UpdateURI'   => 'Update URI',
 	);
 
 	/**
@@ -894,6 +896,7 @@ final class WP_Theme implements ArrayAccess {
 			case 'Version':
 			case 'RequiresWP':
 			case 'RequiresPHP':
+			case 'UpdateURI':
 				$value = strip_tags( $value );
 				break;
 		}

--- a/src/wp-includes/class-wp-theme.php
+++ b/src/wp-includes/class-wp-theme.php
@@ -23,7 +23,7 @@ final class WP_Theme implements ArrayAccess {
 	 *
 	 * @since 3.4.0
 	 * @since 5.4.0 Added `Requires at least` and `Requires PHP` headers.
-	 * @since 6.0.0 Added support for `Update URI` header.
+	 * @since 6.1.0 Added support for `Update URI` header.
 	 * @var string[]
 	 */
 	private static $file_headers = array(

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -469,7 +469,7 @@ function wp_update_plugins( $extra_stats = array() ) {
 		 * }
 		 * @param array       $plugin_data      Plugin headers.
 		 * @param string      $plugin_file      Plugin filename.
-		 * @param array       $locales          Installed locales to look translations for.
+		 * @param array       $locales          Installed locales to look up translations for.
 		 */
 		$update = apply_filters( "update_plugins_{$hostname}", false, $plugin_data, $plugin_file, $locales );
 
@@ -766,7 +766,7 @@ function wp_update_themes( $extra_stats = array() ) {
 			continue;
 		}
 
-		// These should remain constant.
+		// This should remain constant.
 		$update->id = $theme_data['UpdateURI'];
 
 		// WordPress needs the version field specified as 'new_version'.

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -751,7 +751,7 @@ function wp_update_themes( $extra_stats = array() ) {
 		 * }
 		 * @param array       $theme_data       Theme headers.
 		 * @param string      $theme_stylesheet Theme stylesheet.
-		 * @param array       $locales          Installed locales to look translations for.
+		 * @param array       $locales          Installed locales to look up translations for.
 		 */
 		$update = apply_filters( "update_themes_{$hostname}", false, $theme_data, $theme_stylesheet, $locales );
 

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -723,7 +723,7 @@ function wp_update_themes( $extra_stats = array() ) {
 		 * The dynamic portion of the hook name, `$hostname`, refers to the hostname
 		 * of the URI specified in the `Update URI` header field.
 		 *
-		 * @since 6.0.0
+		 * @since 6.1.0
 		 *
 		 * @param array|false $update {
 		 *     The theme update data with the latest details. Default false.

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -577,6 +577,7 @@ function wp_update_themes( $extra_stats = array() ) {
 			'Version'    => $theme->get( 'Version' ),
 			'Author'     => $theme->get( 'Author' ),
 			'Author URI' => $theme->get( 'AuthorURI' ),
+			'UpdateURI'  => $theme->get( 'UpdateURI' ),
 			'Template'   => $theme->get_template(),
 			'Stylesheet' => $theme->get_stylesheet(),
 		);
@@ -706,6 +707,92 @@ function wp_update_themes( $extra_stats = array() ) {
 		$new_update->response     = $response['themes'];
 		$new_update->no_update    = $response['no_update'];
 		$new_update->translations = $response['translations'];
+	}
+
+	// Support updates for any themes using the `Update URI` header field.
+	foreach ( $themes as $theme_stylesheet => $theme_data ) {
+		if ( ! $theme_data['UpdateURI'] || isset( $new_update->response[ $theme_stylesheet ] ) ) {
+			continue;
+		}
+
+		$hostname = wp_parse_url( esc_url_raw( $theme_data['UpdateURI'] ), PHP_URL_HOST );
+
+		/**
+		 * Filters the update response for a given theme hostname.
+		 *
+		 * The dynamic portion of the hook name, `$hostname`, refers to the hostname
+		 * of the URI specified in the `Update URI` header field.
+		 *
+		 * @since 6.0.0
+		 *
+		 * @param array|false $update {
+		 *     The theme update data with the latest details. Default false.
+		 *
+		 *     @type string $id           Optional. ID of the theme for update purposes, should be a URI
+		 *                                specified in the `Update URI` header field.
+		 *     @type string $theme        Directory name of the theme.
+		 *     @type string $version      The version of the theme.
+		 *     @type string $url          The URL for details of the theme.
+		 *     @type string $package      Optional. The update ZIP for the theme.
+		 *     @type string $tested       Optional. The version of WordPress the theme is tested against.
+		 *     @type string $requires_php Optional. The version of PHP which the theme requires.
+		 *     @type bool   $autoupdate   Optional. Whether the theme should automatically update.
+		 *     @type array  $translations {
+		 *         Optional. List of translation updates for the theme.
+		 *
+		 *         @type string $language   The language the translation update is for.
+		 *         @type string $version    The version of the theme this translation is for.
+		 *                                  This is not the version of the language file.
+		 *         @type string $updated    The update timestamp of the translation file.
+		 *                                  Should be a date in the `YYYY-MM-DD HH:MM:SS` format.
+		 *         @type string $package    The ZIP location containing the translation update.
+		 *         @type string $autoupdate Whether the translation should be automatically installed.
+		 *     }
+		 * }
+		 * @param array       $theme_data       Theme headers.
+		 * @param string      $theme_stylesheet Theme stylesheet.
+		 * @param array       $locales          Installed locales to look translations for.
+		 */
+		$update = apply_filters( "update_themes_{$hostname}", false, $theme_data, $theme_stylesheet, $locales );
+
+		if ( ! $update ) {
+			continue;
+		}
+
+		$update = (object) $update;
+
+		// Is it valid? We require at least a version.
+		if ( ! isset( $update->version ) ) {
+			continue;
+		}
+
+		// These should remain constant.
+		$update->id = $theme_data['UpdateURI'];
+
+		// WordPress needs the version field specified as 'new_version'.
+		if ( ! isset( $update->new_version ) ) {
+			$update->new_version = $update->version;
+		}
+
+		// Handle any translation updates.
+		if ( ! empty( $update->translations ) ) {
+			foreach ( $update->translations as $translation ) {
+				if ( isset( $translation['language'], $translation['package'] ) ) {
+					$translation['type'] = 'theme';
+					$translation['slug'] = isset( $update->theme ) ? $update->theme : $update->id;
+
+					$new_update->translations[] = $translation;
+				}
+			}
+		}
+
+		unset( $new_update->no_update[ $theme_stylesheet ], $new_update->response[ $theme_stylesheet ] );
+
+		if ( version_compare( $update->new_version, $theme_data['Version'], '>' ) ) {
+			$new_update->response[ $theme_stylesheet ] = (array) $update;
+		} else {
+			$new_update->no_update[ $theme_stylesheet ] = (array) $update;
+		}
 	}
 
 	set_site_transient( 'update_themes', $new_update );

--- a/tests/phpunit/data/themedir1/update-uri-theme/index.php
+++ b/tests/phpunit/data/themedir1/update-uri-theme/index.php
@@ -1,0 +1,4 @@
+<?php
+/**
+ * A theme with the Update URI header.
+ */

--- a/tests/phpunit/data/themedir1/update-uri-theme/style.css
+++ b/tests/phpunit/data/themedir1/update-uri-theme/style.css
@@ -1,5 +1,5 @@
 /*
-Theme Name:  A theme with the Update URI header.
+Theme Name:  A theme with the Update URI header
 Theme URI:   http://example.com/
 Description: This theme has the Update URI header.
 Version:     6.1

--- a/tests/phpunit/data/themedir1/update-uri-theme/style.css
+++ b/tests/phpunit/data/themedir1/update-uri-theme/style.css
@@ -1,0 +1,9 @@
+/*
+Theme Name:  A theme with the Update URI header.
+Theme URI:   http://example.com/
+Description: This theme has the Update URI header.
+Version:     6.1
+Author:      WordPress Contributors
+Author URI:  http://example.net/
+Update URI:  http://example.org/update-uri-theme/
+*/

--- a/tests/phpunit/tests/theme/themeDir.php
+++ b/tests/phpunit/tests/theme/themeDir.php
@@ -149,7 +149,6 @@ class Tests_Theme_ThemeDir extends WP_UnitTestCase {
 
 		$theme_names = array_keys( $themes );
 		$expected    = array(
-			'A theme with the Update URI header.',
 			'WordPress Default',
 			'Sandbox',
 			'Stylesheet Only',
@@ -168,6 +167,7 @@ class Tests_Theme_ThemeDir extends WP_UnitTestCase {
 			'Block Theme [1.0.0] in subdirectory',
 			'Webfonts theme',
 			'Empty `fontFace` in theme.json - no webfonts defined',
+			'A theme with the Update URI header',
 		);
 
 		sort( $theme_names );

--- a/tests/phpunit/tests/theme/themeDir.php
+++ b/tests/phpunit/tests/theme/themeDir.php
@@ -149,6 +149,7 @@ class Tests_Theme_ThemeDir extends WP_UnitTestCase {
 
 		$theme_names = array_keys( $themes );
 		$expected    = array(
+			'A theme with the Update URI header.',
 			'WordPress Default',
 			'Sandbox',
 			'Stylesheet Only',

--- a/tests/phpunit/tests/theme/wpTheme.php
+++ b/tests/phpunit/tests/theme/wpTheme.php
@@ -382,4 +382,51 @@ class Tests_Theme_wpTheme extends WP_UnitTestCase {
 			),
 		);
 	}
+
+	/**
+	 * Tests that the UpdateURI header is retrieved.
+	 *
+	 * @ticket 14179
+	 *
+	 * @covers WP_Theme::get
+	 */
+	public function test_theme_get_update_uri_header() {
+		$theme = new WP_Theme( 'update-uri-theme', $this->theme_root );
+
+		$this->assertTrue(
+			$theme->exists(),
+			'The update-uri-theme does not exist'
+		);
+
+		$update_uri = $theme->get( 'UpdateURI' );
+
+		$this->assertIsString(
+			$update_uri,
+			'The UpdateURI header was not returned as a string'
+		);
+
+		$this->assertSame(
+			'http://example.org/update-uri-theme/',
+			$update_uri,
+			'The UpdateURI header did not match the expected value'
+		);
+	}
+
+	/**
+	 * Tests that WP_Theme::sanitize_header() strips tags from
+	 * the UpdateURI header.
+	 *
+	 * @ticket 14179
+	 *
+	 * @covers WP_Theme::sanitize_header
+	 */
+	public function test_should_strip_tags_from_update_uri_header() {
+		$theme           = new WP_Theme( 'twentytwentytwo', $this->theme_root );
+		$sanitize_header = new ReflectionMethod( $theme, 'sanitize_header' );
+		$sanitize_header->setAccessible( true );
+
+		$actual = $sanitize_header->invoke( $theme, 'UpdateURI', '<?php?><a href="http://example.org">http://example.org</a>' );
+
+		$this->assertSame( 'http://example.org', $actual );
+	}
 }


### PR DESCRIPTION
This PR:

- [x] Applies [14179-UpdateURI-header-refresh.diff](https://core.trac.wordpress.org/attachment/ticket/14179/14179-UpdateURI-header-refresh.diff).
- [x] Updates `@since` tags.
- [x] Adds unit tests.
- [x] Updates the description of `$locales`.

Trac ticket: https://core.trac.wordpress.org/ticket/14179