### PR TITLE
Added guard condition to is_main_query

### DIFF
--- a/src/wp-includes/query.php
+++ b/src/wp-includes/query.php
@@ -902,7 +902,7 @@ function is_main_query() {
 	global $wp_query;
 
 	if ( ! isset( $wp_query ) ) {
-		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), '3.1.0' );
+		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), '6.1.0' );
 		return false;
 	}
 

--- a/src/wp-includes/query.php
+++ b/src/wp-includes/query.php
@@ -901,6 +901,11 @@ function is_embed() {
 function is_main_query() {
 	global $wp_query;
 
+    if ( ! isset( $wp_query ) ) {
+		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), '3.1.0' );
+		return false;
+	}
+
 	if ( 'pre_get_posts' === current_filter() ) {
 		_doing_it_wrong(
 			__FUNCTION__,

--- a/src/wp-includes/query.php
+++ b/src/wp-includes/query.php
@@ -901,7 +901,7 @@ function is_embed() {
 function is_main_query() {
 	global $wp_query;
 
-    if ( ! isset( $wp_query ) ) {
+	if ( ! isset( $wp_query ) ) {
 		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), '3.1.0' );
 		return false;
 	}

--- a/tests/phpunit/tests/query/conditionals.php
+++ b/tests/phpunit/tests/query/conditionals.php
@@ -1616,4 +1616,14 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 		$this->assertQueryTrue( 'is_page', 'is_singular', 'is_privacy_policy' );
 	}
 
+	/**
+	 * @ticket 55104
+	 * @expectedIncorrectUsage is_main_query
+	 */
+	public function test_is_main_query_returns_false_if_wp_query_is_not_set() {
+		unset( $GLOBALS['wp_query'] );
+
+		$this->assertFalse( is_main_query() );
+	}
+
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Added guard condition on $wp_query to is_main_query 

Props to @thijsoo, @teunvgisteren and @timkersten655

Trac ticket: https://core.trac.wordpress.org/ticket/55104

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
