### PR TITLE
Bypass media months filter

### DIFF
--- a/src/js/media/views/attachments/browser.js
+++ b/src/js/media/views/attachments/browser.js
@@ -240,19 +240,22 @@ AttachmentsBrowser = View.extend(/** @lends wp.media.view.AttachmentsBrowser.pro
 				priority: -90
 			}).render() );
 
-			// DateFilter is a <select>, a visually hidden label element needs to be rendered before.
-			this.toolbar.set( 'dateFilterLabel', new wp.media.view.Label({
-				value: l10n.filterByDate,
-				attributes: {
-					'for': 'media-attachment-date-filters'
-				},
-				priority: -75
-			}).render() );
-			this.toolbar.set( 'dateFilter', new wp.media.view.DateFilter({
-				controller: this.controller,
-				model:      this.collection.props,
-				priority: -75
-			}).render() );
+			if (showMonths) {
+				// DateFilter is a <select>, a visually hidden label element needs to be rendered before.
+				this.toolbar.set( 'dateFilterLabel', new wp.media.view.Label({
+					value: l10n.filterByDate,
+					attributes: {
+						'for': 'media-attachment-date-filters'
+					},
+					priority: -75
+				}).render() );
+				this.toolbar.set( 'dateFilter', new wp.media.view.DateFilter({
+					controller: this.controller,
+					model:      this.collection.props,
+					priority: -75
+				}).render() );
+			}
+			
 
 			// BulkSelection is a <div> with subviews, including screen reader text.
 			this.toolbar.set( 'selectModeToggleButton', new wp.media.view.SelectModeToggleButton({
@@ -361,7 +364,7 @@ AttachmentsBrowser = View.extend(/** @lends wp.media.view.AttachmentsBrowser.pro
 				}).render() );
 			}
 
-		} else if ( this.options.date ) {
+		} else if ( showMonths && this.options.date ) {
 			// DateFilter is a <select>, a visually hidden label element needs to be rendered before.
 			this.toolbar.set( 'dateFilterLabel', new wp.media.view.Label({
 				value: l10n.filterByDate,

--- a/src/js/media/views/attachments/browser.js
+++ b/src/js/media/views/attachments/browser.js
@@ -1,5 +1,6 @@
 var View = wp.media.View,
 	mediaTrash = wp.media.view.settings.mediaTrash,
+	showMonths = wp.media.view.settings.showMonths,
 	l10n = wp.media.view.l10n,
 	$ = jQuery,
 	AttachmentsBrowser,

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -4368,7 +4368,7 @@ function wp_enqueue_media( $args = array() ) {
 	 * @since 4.7.4
 	 *
 	 * @link https://core.trac.wordpress.org/ticket/31071
-	 * 
+	 *
 	 * @link https://core.trac.wordpress.org/ticket/41675
 	 *
 	 * @param array|null $months An array of objects with `month` and `year`
@@ -4377,7 +4377,7 @@ function wp_enqueue_media( $args = array() ) {
 	 */
 	$show_months_select = apply_filters( 'show_media_library_months_select', true );
 	$months = apply_filters( 'media_library_months_with_files', null );
-	if ( $show_months_select === true ) {
+	if ( true === $show_months_select ) {
 		if ( ! is_array( $months ) ) {
 			$months = $wpdb->get_results(
 				$wpdb->prepare(

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -4357,9 +4357,10 @@ function wp_enqueue_media( $args = array() ) {
 	}
 
 	/**
-	 * Allows overriding the list of months displayed in the media library.
+	 * Allows overriding or hiding the list of months select in the media library.
 	 *
-	 * By default (if this filter does not return an array), a query will be
+	 * By default (if the select hasn't been disabled by show_media_library_months_select
+	 * and if this media_library_months_with_files does not return an array), a query will be
 	 * run to determine the months that have media items.  This query can be
 	 * expensive for large media libraries, so it may be desirable for sites to
 	 * override this behavior.
@@ -4367,32 +4368,38 @@ function wp_enqueue_media( $args = array() ) {
 	 * @since 4.7.4
 	 *
 	 * @link https://core.trac.wordpress.org/ticket/31071
+	 * 
+	 * @link https://core.trac.wordpress.org/ticket/41675
 	 *
 	 * @param array|null $months An array of objects with `month` and `year`
 	 *                           properties, or `null` (or any other non-array value)
 	 *                           for default behavior.
 	 */
+	$show_months_select = apply_filters( 'show_media_library_months_select', true );
+ 	$months = null;
 	$months = apply_filters( 'media_library_months_with_files', null );
-	if ( ! is_array( $months ) ) {
-		$months = $wpdb->get_results(
-			$wpdb->prepare(
-				"
-			SELECT DISTINCT YEAR( post_date ) AS year, MONTH( post_date ) AS month
-			FROM $wpdb->posts
-			WHERE post_type = %s
-			ORDER BY post_date DESC
-		",
-				'attachment'
-			)
-		);
-	}
-	foreach ( $months as $month_year ) {
-		$month_year->text = sprintf(
-			/* translators: 1: Month, 2: Year. */
-			__( '%1$s %2$d' ),
-			$wp_locale->get_month( $month_year->month ),
-			$month_year->year
-		);
+	if ( $show_months_select === true ) {
+		if ( ! is_array( $months ) ) {
+			$months = $wpdb->get_results(
+				$wpdb->prepare(
+					"
+				SELECT DISTINCT YEAR( post_date ) AS year, MONTH( post_date ) AS month
+				FROM $wpdb->posts
+				WHERE post_type = %s
+				ORDER BY post_date DESC
+			",
+					'attachment'
+				)
+			);
+		}
+		foreach ( $months as $month_year ) {
+			$month_year->text = sprintf(
+				/* translators: 1: Month, 2: Year. */
+				__( '%1$s %2$d' ),
+				$wp_locale->get_month( $month_year->month ),
+				$month_year->year
+			);
+		}
 	}
 
 	/**
@@ -4426,6 +4433,7 @@ function wp_enqueue_media( $args = array() ) {
 		'embedMimes'        => $ext_mimes,
 		'contentWidth'      => $content_width,
 		'months'            => $months,
+		'showMonths'        => $show_months_select,
 		'mediaTrash'        => MEDIA_TRASH ? 1 : 0,
 		'infiniteScrolling' => ( $infinite_scrolling ) ? 1 : 0,
 	);

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -4376,7 +4376,6 @@ function wp_enqueue_media( $args = array() ) {
 	 *                           for default behavior.
 	 */
 	$show_months_select = apply_filters( 'show_media_library_months_select', true );
- 	$months = null;
 	$months = apply_filters( 'media_library_months_with_files', null );
 	if ( $show_months_select === true ) {
 		if ( ! is_array( $months ) ) {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Added filter to remove media month filter select in media modal.

Props to @thijsoo, @teunvgisteren and @timkersten655

Trac ticket: https://core.trac.wordpress.org/ticket/41675

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
