### PR TITLE
changing customizer preview link label

### DIFF
--- a/src/wp-includes/customize/class-wp-customize-nav-menu-item-control.php
+++ b/src/wp-includes/customize/class-wp-customize-nav-menu-item-control.php
@@ -147,11 +147,8 @@ class WP_Customize_Nav_Menu_Item_Control extends WP_Customize_Control {
 
 			<div class="menu-item-actions description-thin submitbox">
 				<# if ( ( 'post_type' === data.item_type || 'taxonomy' === data.item_type ) && '' !== data.original_title ) { #>
-				<p class="link-to-original">
-					<?php
-						/* translators: Nav menu item original title. %s: Original title. */
-						printf( __( 'Original: %s' ), '<a class="original-link" href="{{ data.url }}">{{ data.original_title }}</a>' );
-					?>
+				<p class="link-to-original">								
+					<a class="original-link" href="{{ data.url }}"><?php _e('View Page') ?></a>
 				</p>
 				<# } #>
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

have changed the block from PHP to HTML. But the element selectors like class remains the the same as you can see on line number 150. If that needs to be changed. I can do that no problem.

Trac ticket: https://core.trac.wordpress.org/ticket/37417

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
