### PR TITLE
Help/About: Ensure header images from previous versions are not cached

### DIFF
--- a/src/wp-admin/css/about.css
+++ b/src/wp-admin/css/about.css
@@ -606,7 +606,7 @@
 	position: relative;
 	margin-bottom: var(--gap);
 	padding-top: 0;
-	background: var(--subtle-background) url('../images/about-header-about.svg') no-repeat;
+	background: var(--subtle-background) url('../images/about-header-about.svg?ver=6.0') no-repeat;
 	background-size: var(--about-header-bg-width) var(--about-header-bg-height);
 	background-position: right var(--about-header-bg-offset-inline) center;
 }
@@ -616,7 +616,7 @@
 	--about-header-image-height: 470px;
 	--about-header-bg-offset-inline: calc(var(--gap) * -4);
 
-	background-image: url('../images/about-header-credits.svg');
+	background-image: url('../images/about-header-credits.svg?ver=6.0');
 	background-position: right var(--about-header-bg-offset-inline) top var(--gap);
 }
 
@@ -625,7 +625,7 @@
 	--about-header-image-height: 498px;
 	--about-header-bg-offset-inline: var(--gap);
 
-	background-image: url('../images/about-header-freedoms.svg');
+	background-image: url('../images/about-header-freedoms.svg?ver=6.0');
 	background-position: right var(--about-header-bg-offset-inline) top calc(var(--gap) * 4);
 }
 
@@ -634,7 +634,7 @@
 	--about-header-image-height: 361px;
 	--about-header-bg-offset-inline: var(--gap);
 
-	background-image: url('../images/about-header-privacy.svg');
+	background-image: url('../images/about-header-privacy.svg?ver=6.0');
 	background-position: right var(--about-header-bg-offset-inline) top var(--gap);
 }
 


### PR DESCRIPTION
This appends the version to the header image URLs. It uses the major version only, since these images will not change in minor releases. This uses the same approach that was proposed in https://github.com/WordPress/wordpress-develop/pull/2686.

Trac ticket: https://core.trac.wordpress.org/ticket/55750

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
