### PR TITLE
Allow plugins to disable backdating uploads for certain types of posts

### DIFF
--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -290,12 +290,24 @@ function media_send_to_editor( $html ) {
  * @return int|WP_Error ID of the attachment or a WP_Error object on failure.
  */
 function media_handle_upload( $file_id, $post_id, $post_data = array(), $overrides = array( 'test_form' => false ) ) {
-	$time = current_time( 'mysql' );
-	$post = get_post( $post_id );
+	$time                = current_time( 'mysql' );
+	$post                = get_post( $post_id );
 	$has_valid_post_date = $post && substr( $post->post_date, 0, 4 ) > 0;
 
 	// The post date doesn't usually matter for pages, so don't backdate this upload.
 	if ( $has_valid_post_date && 'page' !== $post->post_type ) {
+		/**
+		 * Filters whether an uploaded file should be backdated.
+		 *
+		 * This could be useful for "regular" posts, but some users might want to disable this feature
+		 * for custom post type entities.
+		 *
+		 * @since 6.1.0
+		 *
+		 * @param bool         $should_backdate_media_upload Whether the uploaded file should be backdated. Default true.
+		 * @param WP_Post|null $post                         Post entity.
+		 * @param string       $file                         Index of the `$_FILES` array that the file was sent.
+		 */
 		if ( apply_filters( 'should_backdate_media_upload', true, $post, $file_id ) ) {
 			$time = $post->post_date;
 		}

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -296,7 +296,7 @@ function media_handle_upload( $file_id, $post_id, $post_data = array(), $overrid
 	if ( $post ) {
 		// The post date doesn't usually matter for pages, so don't backdate this upload.
 		if ( 'page' !== $post->post_type && substr( $post->post_date, 0, 4 ) > 0 ) {
-			if ( apply_filters( 'should_backdate_media_upload', true, $post ) ) {
+			if ( apply_filters( 'should_backdate_media_upload', true, $post, $file_id ) ) {
 				$time = $post->post_date;
 			}
 		}

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -296,7 +296,9 @@ function media_handle_upload( $file_id, $post_id, $post_data = array(), $overrid
 	if ( $post ) {
 		// The post date doesn't usually matter for pages, so don't backdate this upload.
 		if ( 'page' !== $post->post_type && substr( $post->post_date, 0, 4 ) > 0 ) {
-			$time = $post->post_date;
+			if ( apply_filters( 'should_backdate_media_upload', true, $post ) ) {
+				$time = $post->post_date;
+			}
 		}
 	}
 

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -292,13 +292,12 @@ function media_send_to_editor( $html ) {
 function media_handle_upload( $file_id, $post_id, $post_data = array(), $overrides = array( 'test_form' => false ) ) {
 	$time = current_time( 'mysql' );
 	$post = get_post( $post_id );
+	$has_valid_post_date = $post && substr( $post->post_date, 0, 4 ) > 0;
 
-	if ( $post ) {
-		// The post date doesn't usually matter for pages, so don't backdate this upload.
-		if ( 'page' !== $post->post_type && substr( $post->post_date, 0, 4 ) > 0 ) {
-			if ( apply_filters( 'should_backdate_media_upload', true, $post, $file_id ) ) {
-				$time = $post->post_date;
-			}
+	// The post date doesn't usually matter for pages, so don't backdate this upload.
+	if ( $has_valid_post_date && 'page' !== $post->post_type ) {
+		if ( apply_filters( 'should_backdate_media_upload', true, $post, $file_id ) ) {
+			$time = $post->post_date;
 		}
 	}
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This PR aims to allow plugins to disable backdating for certain type of posts.

Trac ticket: https://core.trac.wordpress.org/ticket/47726

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
