### PR TITLE
Fix `@property-read` notation type in `WP_Post`.

### DIFF
--- a/src/wp-includes/class-wp-post.php
+++ b/src/wp-includes/class-wp-post.php
@@ -14,9 +14,9 @@
  *
  * @property string $page_template
  *
- * @property-read int[]  $ancestors
- * @property-read int    $post_category
- * @property-read string $tag_input
+ * @property-read int[]    $ancestors
+ * @property-read int[]    $post_category
+ * @property-read string[] $tags_input
  */
 final class WP_Post {
 


### PR DESCRIPTION
fix type and name for `@property-read`.

Trac ticket: [#55785](https://core.trac.wordpress.org/ticket/55785)