### PR TITLE
Temporarily skip test for MariaDB version due to 10.2 EOL.

### DIFF
--- a/tests/phpunit/tests/external-http/basic.php
+++ b/tests/phpunit/tests/external-http/basic.php
@@ -63,6 +63,13 @@ class Tests_External_HTTP_Basic extends WP_UnitTestCase {
 	 * @covers ::wp_remote_retrieve_body
 	 */
 	public function test_readme_mariadb_version() {
+		/*
+		 * Temporary skip as MariaDB 10.2 is EOL as of 23 May 2022.
+		 * See Trac #55791 and meta #6322.
+		 * Once the version is bumped, revert this change.
+		 */
+		$this->markTestSkipped( 'Temporarily skip due to MariaDB 10.2 now EOL as of 23 May 2022. Remove this skip once version is bumped.' );
+
 		// This test is designed to only run on trunk.
 		$this->skipOnAutomatedBranches();
 


### PR DESCRIPTION
Temporarily skip the MariaDB version test due to 10.2 no longer being supported (EOL) as of 23 May 2022.

Trac ticket: https://core.trac.wordpress.org/ticket/55791

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
