### PR TITLE
Added new `wp_read_audio_metadata` filter

### DIFF
--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -3697,7 +3697,7 @@ function wp_read_audio_metadata( $file ) {
 
 	wp_add_id3_tag_data( $metadata, $data );
 
-	return $metadata;
+	return apply_filters( 'wp_read_audio_metadata', $metadata, $file, $data );
 }
 
 /**

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -3697,19 +3697,22 @@ function wp_read_audio_metadata( $file ) {
 
 	wp_add_id3_tag_data( $metadata, $data );
 
+	$file_format = isset( $metadata['fileformat'] ) ? $metadata['fileformat'] : null;
+
 	/**
 	 * Filters the array of metadata retrieved from an audio file.
 	 *
 	 * In core, usually this selection is what is stored.
 	 * More complete data can be parsed from the `$data` parameter.
 	 *
-	 * @since 6.0.1
+	 * @since 6.1.0
 	 *
-	 * @param array  $metadata    Filtered Audio metadata.
-	 * @param string $file        Path to audio file.
-	 * @param array  $data        Raw metadata from getID3.
+	 * @param array  $metadata       Filtered Audio metadata.
+	 * @param string $file           Path to audio file.
+	 * @param string $file_format    File format of audio, as analyzed by getID3.
+	 * @param array  $data           Raw metadata from getID3.
 	 */
-	return apply_filters( 'wp_read_audio_metadata', $metadata, $file, $data );
+	return apply_filters( 'wp_read_audio_metadata', $metadata, $file, $file_format, $data );
 }
 
 /**

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -3697,6 +3697,18 @@ function wp_read_audio_metadata( $file ) {
 
 	wp_add_id3_tag_data( $metadata, $data );
 
+	/**
+	 * Filters the array of metadata retrieved from an audio file.
+	 *
+	 * In core, usually this selection is what is stored.
+	 * More complete data can be parsed from the `$data` parameter.
+	 *
+	 * @since 6.0.1
+	 *
+	 * @param array  $metadata    Filtered Audio metadata.
+	 * @param string $file        Path to audio file.
+	 * @param array  $data        Raw metadata from getID3.
+	 */
 	return apply_filters( 'wp_read_audio_metadata', $metadata, $file, $data );
 }
 


### PR DESCRIPTION
At the moment, the function `wp_read_audio_metadata()` is returning the `$metadata` extracted from an uploaded audio file without applying any filter to it. In addition to the limitations that this poses (e.g. third-party plugins may want/need to attach additional properties to the `$metadata` array by pulling them from the `$data` array), the missing filter also seems to be in contrast and inconsistent with the corresponding `wp_read_image_metadata()` and `wp_read_video_metadata()` functions, which both filter the file `$metadata` array before returning it ([here](https://core.trac.wordpress.org/browser/trunk/src/wp-admin/includes/image.php#L945) for images and [here](https://core.trac.wordpress.org/browser/trunk/src/wp-admin/includes/media.php#L3633) for videos).

This could easily be fixed by simply replacing [line 3700](https://core.trac.wordpress.org/browser/trunk/src/wp-admin/includes/media.php#L3700):
```
return $metadata;
```
with
```
return apply_filters( 'wp_read_audio_metadata', $metadata, $file, $data );
```

There are so many properties stored in the ID3 tag that the `getID3()` class is already extracting from the uploaded file but WordPress simply leaves behind that this filter is very much needed and is perfectly consistent with what WordPress already has for images and videos, including its hook name.

Trac ticket: [https://core.trac.wordpress.org/ticket/55828](https://core.trac.wordpress.org/ticket/55828)