### PR TITLE
Cast dir name to string when assigning to stylesheet property in WP_Theme constructor

### DIFF
--- a/src/wp-includes/class-wp-theme.php
+++ b/src/wp-includes/class-wp-theme.php
@@ -230,7 +230,7 @@ final class WP_Theme implements ArrayAccess {
 		}
 
 		$this->theme_root = $theme_root;
-		$this->stylesheet = $theme_dir;
+		$this->stylesheet = (string) $theme_dir;
 
 		// Correct a situation where the theme is 'some-directory/some-theme' but 'some-directory' was passed in as part of the theme root instead.
 		if ( ! in_array( $theme_root, (array) $wp_theme_directories, true )

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -81,7 +81,7 @@ function wp_get_themes( $args = array() ) {
 		if ( isset( $_themes[ $theme_root['theme_root'] . '/' . $theme ] ) ) {
 			$themes[ $theme ] = $_themes[ $theme_root['theme_root'] . '/' . $theme ];
 		} else {
-			$themes[ $theme ] = new WP_Theme( $theme, $theme_root['theme_root'] );
+			$themes[ $theme ] = new WP_Theme( (string) $theme, $theme_root['theme_root'] );
 
 			$_themes[ $theme_root['theme_root'] . '/' . $theme ] = $themes[ $theme ];
 		}

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -81,7 +81,7 @@ function wp_get_themes( $args = array() ) {
 		if ( isset( $_themes[ $theme_root['theme_root'] . '/' . $theme ] ) ) {
 			$themes[ $theme ] = $_themes[ $theme_root['theme_root'] . '/' . $theme ];
 		} else {
-			$themes[ $theme ] = new WP_Theme( (string) $theme, $theme_root['theme_root'] );
+			$themes[ $theme ] = new WP_Theme( $theme, $theme_root['theme_root'] );
 
 			$_themes[ $theme_root['theme_root'] . '/' . $theme ] = $themes[ $theme ];
 		}

--- a/tests/phpunit/tests/theme/wpTheme.php
+++ b/tests/phpunit/tests/theme/wpTheme.php
@@ -116,6 +116,17 @@ class Tests_Theme_wpTheme extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 54645
+	 */
+	public function test_new_WP_Theme_numerical() {
+		$theme = new WP_Theme( 1234, $this->theme_root );
+
+		// Important.
+		$this->assertSame( '1234', $theme->get_stylesheet() );
+		$this->assertSame( '1234', $theme->get_template() );
+	}
+
+	/**
 	 * @ticket 21969
 	 */
 	public function test_theme_uris_with_spaces() {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Cast dir name to string when assigning to stylesheet property in WP_Theme constructor, allowing to have numerical dirnames for themes.

Trac ticket: https://core.trac.wordpress.org/ticket/54645

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
