### PR TITLE
fix invalid key used in community events

### DIFF
--- a/src/wp-admin/includes/class-wp-community-events.php
+++ b/src/wp-admin/includes/class-wp-community-events.php
@@ -352,8 +352,12 @@ class WP_Community_Events {
 	 *                     on success, false on failure.
 	 */
 	public function get_cached_events() {
-		$cached_response = get_site_transient( $this->get_events_transient_key( $this->user_location ) );
+		$transient_key = $this->get_events_transient_key( $this->user_location );
+		if ( ! $transient_key ) {
+			return false;
+		}
 
+		$cached_response = get_site_transient( $transient_key );
 		if ( isset( $cached_response['events'] ) ) {
 			$cached_response['events'] = $this->trim_events( $cached_response['events'] );
 		}


### PR DESCRIPTION
Add check for false transient key, which is not a valid key.
There already is a check in the other place in this file where this is used. Added it in all places now.

Trac ticket: https://core.trac.wordpress.org/ticket/55888#ticket
