### PR TITLE
adds the 'extra_email_me_fields' action to the email me whenever fieldset

### DIFF
--- a/src/wp-admin/options-discussion.php
+++ b/src/wp-admin/options-discussion.php
@@ -164,16 +164,20 @@ printf( __( 'Comments should be displayed with the %s comments at the top of eac
 </fieldset></td>
 </tr>
 <tr>
-<th scope="row"><?php _e( 'Email me whenever' ); ?></th>
-<td><fieldset><legend class="screen-reader-text"><span><?php _e( 'Email me whenever' ); ?></span></legend>
-<label for="comments_notify">
-<input name="comments_notify" type="checkbox" id="comments_notify" value="1" <?php checked( '1', get_option( 'comments_notify' ) ); ?> />
-<?php _e( 'Anyone posts a comment' ); ?> </label>
-<br />
-<label for="moderation_notify">
-<input name="moderation_notify" type="checkbox" id="moderation_notify" value="1" <?php checked( '1', get_option( 'moderation_notify' ) ); ?> />
-<?php _e( 'A comment is held for moderation' ); ?> </label>
-</fieldset></td>
+	<th scope="row"><?php _e( 'Email me whenever' ); ?></th>
+	<td>
+		<fieldset>
+			<legend class="screen-reader-text"><span><?php _e( 'Email me whenever' ); ?></span></legend>
+			<label for="comments_notify">
+			<input name="comments_notify" type="checkbox" id="comments_notify" value="1" <?php checked( '1', get_option( 'comments_notify' ) ); ?> />
+			<?php _e( 'Anyone posts a comment' ); ?> </label>
+			<br />
+			<label for="moderation_notify">
+			<input name="moderation_notify" type="checkbox" id="moderation_notify" value="1" <?php checked( '1', get_option( 'moderation_notify' ) ); ?> />
+			<?php _e( 'A comment is held for moderation' ); ?> </label>
+			<?php do_action( 'extra_email_me_fields' ); ?>
+		</fieldset>
+	</td>
 </tr>
 <tr>
 <th scope="row"><?php _e( 'Before a comment appears' ); ?></th>


### PR DESCRIPTION
This will add an add_action to the `email me whenever` fieldset on the discussion page.

Trac ticket: https://core.trac.wordpress.org/ticket/53639

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
