### PR TITLE
Twenty Twenty Themes Separator Block Wide Line horizontally center align issue in editor patch refresh

### DIFF
--- a/src/wp-content/themes/twentytwenty/assets/css/editor-style-block-rtl.css
+++ b/src/wp-content/themes/twentytwenty/assets/css/editor-style-block-rtl.css
@@ -1392,8 +1392,8 @@ hr.wp-block-separator.is-style-dots::before {
 	}
 
 	hr.wp-block-separator.is-style-wide {
-		margin-right: -70px;
-		margin-left: -70px;
+		margin-right: auto;
+		margin-left: auto;
 	}
 
 
@@ -1430,8 +1430,8 @@ hr.wp-block-separator.is-style-dots::before {
 	/* BLOCK: SEPARATOR */
 
 	hr.wp-block-separator.is-style-wide {
-		margin-right: -150px;
-		margin-left: -150px;
+		margin-right: auto;
+		margin-left: auto;
 	}
 
 }
@@ -1465,8 +1465,8 @@ hr.wp-block-separator.is-style-dots::before {
 	/* BLOCK: SEPARATOR */
 
 	hr.wp-block-separator.is-style-wide {
-		margin-right: -200px;
-		margin-left: -200px;
+		margin-right: auto;
+		margin-left: auto;
 	}
 
 

--- a/src/wp-content/themes/twentytwenty/assets/css/editor-style-block.css
+++ b/src/wp-content/themes/twentytwenty/assets/css/editor-style-block.css
@@ -1392,8 +1392,8 @@ hr.wp-block-separator.is-style-dots::before {
 	}
 
 	hr.wp-block-separator.is-style-wide {
-		margin-left: -70px;
-		margin-right: -70px;
+		margin-left: auto;
+		margin-right: auto;
 	}
 
 
@@ -1430,8 +1430,8 @@ hr.wp-block-separator.is-style-dots::before {
 	/* BLOCK: SEPARATOR */
 
 	hr.wp-block-separator.is-style-wide {
-		margin-left: -150px;
-		margin-right: -150px;
+		margin-left: auto;
+		margin-right: auto;
 	}
 
 }
@@ -1465,8 +1465,8 @@ hr.wp-block-separator.is-style-dots::before {
 	/* BLOCK: SEPARATOR */
 
 	hr.wp-block-separator.is-style-wide {
-		margin-left: -200px;
-		margin-right: -200px;
+		margin-left: auto;
+		margin-right: auto;
 	}
 
 


### PR DESCRIPTION


Trac ticket: https://core.trac.wordpress.org/ticket/55896
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
