### PR TITLE
Swap `bind` for `on`.

### DIFF
--- a/src/js/_enqueues/vendor/plupload/handlers.js
+++ b/src/js/_enqueues/vendor/plupload/handlers.js
@@ -399,7 +399,7 @@ jQuery( document ).ready( function( $ ) {
 	var tryAgainCount = {};
 	var tryAgain;
 
-	$( '.media-upload-form' ).bind( 'click.uploader', function( e ) {
+	$( '.media-upload-form' ).on( 'click.uploader', function( e ) {
 		var target = $( e.target ), tr, c;
 
 		if ( target.is( 'input[type="radio"]' ) ) { // Remember the last used image size and alignment.
@@ -557,7 +557,7 @@ jQuery( document ).ready( function( $ ) {
 	uploader_init = function() {
 		uploader = new plupload.Uploader( wpUploaderInit );
 
-		$( '#image_resize' ).bind( 'change', function() {
+		$( '#image_resize' ).on( 'change', function() {
 			var arg = $( this ).prop( 'checked' );
 
 			setResize( arg );


### PR DESCRIPTION
Remove deprecated jQuery function `bind`, replace with `on`, in handlers.js.

Trac ticket: https://core.trac.wordpress.org/ticket/51812

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
