### PR TITLE
Use correct default value for JavaScript translations path

### DIFF
--- a/src/wp-includes/class-wp-dependency.php
+++ b/src/wp-includes/class-wp-dependency.php
@@ -125,7 +125,7 @@ class _WP_Dependency {
 	 * @param string $path   Optional. The full file path to the directory containing translation files.
 	 * @return bool False if $domain is not a string, true otherwise.
 	 */
-	public function set_translations( $domain, $path = null ) {
+	public function set_translations( $domain, $path = '' ) {
 		if ( ! is_string( $domain ) ) {
 			return false;
 		}

--- a/src/wp-includes/class.wp-scripts.php
+++ b/src/wp-includes/class.wp-scripts.php
@@ -568,7 +568,7 @@ class WP_Scripts extends WP_Dependencies {
 	 * @param string $path   Optional. The full file path to the directory containing translation files.
 	 * @return bool True if the text domain was registered, false if not.
 	 */
-	public function set_translations( $handle, $domain = 'default', $path = null ) {
+	public function set_translations( $handle, $domain = 'default', $path = '' ) {
 		if ( ! isset( $this->registered[ $handle ] ) ) {
 			return false;
 		}
@@ -600,7 +600,11 @@ class WP_Scripts extends WP_Dependencies {
 		}
 
 		$domain = $this->registered[ $handle ]->textdomain;
-		$path   = $this->registered[ $handle ]->translations_path;
+		$path   = '';
+
+		if ( isset( $this->registered[ $handle ]->translations_path ) ) {
+			$path = $this->registered[ $handle ]->translations_path;
+		}
 
 		$json_translations = load_script_textdomain( $handle, $domain, $path );
 

--- a/src/wp-includes/functions.wp-scripts.php
+++ b/src/wp-includes/functions.wp-scripts.php
@@ -237,7 +237,7 @@ function wp_localize_script( $handle, $object_name, $l10n ) {
  * @param string $path   Optional. The full file path to the directory containing translation files.
  * @return bool True if the text domain was successfully localized, false otherwise.
  */
-function wp_set_script_translations( $handle, $domain = 'default', $path = null ) {
+function wp_set_script_translations( $handle, $domain = 'default', $path = '' ) {
 	global $wp_scripts;
 
 	if ( ! ( $wp_scripts instanceof WP_Scripts ) ) {

--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -1008,7 +1008,7 @@ function load_child_theme_textdomain( $domain, $path = false ) {
  * @return string|false The translated strings in JSON encoding on success,
  *                      false if the script textdomain could not be loaded.
  */
-function load_script_textdomain( $handle, $domain = 'default', $path = null ) {
+function load_script_textdomain( $handle, $domain = 'default', $path = '' ) {
 	$wp_scripts = wp_scripts();
 
 	if ( ! isset( $wp_scripts->registered[ $handle ] ) ) {


### PR DESCRIPTION
Based on https://core.trac.wordpress.org/attachment/ticket/53635/53635-09-script-translations.patch.

Trac ticket: https://core.trac.wordpress.org/ticket/55967

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
