### PR TITLE
Twenty Nineteen: Add font-smoothing styles to editor

### DIFF
--- a/src/wp-content/themes/twentynineteen/style-editor.css
+++ b/src/wp-content/themes/twentynineteen/style-editor.css
@@ -659,6 +659,8 @@ body .wp-block.aligncenter {
 
 /** === Base Typography === */
 body {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
   font-size: 22px;
   font-family: "NonBreakingSpaceOverride", "Hoefler Text", Garamond, "Times New Roman", serif;
   line-height: 1.8;

--- a/src/wp-content/themes/twentynineteen/style-editor.scss
+++ b/src/wp-content/themes/twentynineteen/style-editor.scss
@@ -94,6 +94,8 @@ body {
 /** === Base Typography === */
 
 body {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
 	font-size: $font__size_base;
 	@include font-family( $font__body );
 	line-height: $font__line-height-body;


### PR DESCRIPTION
Applies to `.editor-styles-wrapper` in block editor

Trac ticket: https://core.trac.wordpress.org/ticket/45909

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
