### PR TITLE
Added tests for Referer functions

### DIFF
--- a/tests/phpunit/tests/functions/wpGetRawReferer.php
+++ b/tests/phpunit/tests/functions/wpGetRawReferer.php
@@ -14,7 +14,6 @@ class Tests_Functions_wpGetRawReferer extends WP_UnitTestCase {
 	 * @ticket 55729
 	 */
 	public function test_wp_get_original__wp_http_referer_referer() {
-
 		$_REQUEST['_wp_http_referer'] = 'http://_wp_http_referer.com';
 		$this->assertSame( 'http://_wp_http_referer.com', wp_get_raw_referer(), '$_REQUEST["_wp_http_referer"] set' );
 	}

--- a/tests/phpunit/tests/functions/wpGetRawReferer.php
+++ b/tests/phpunit/tests/functions/wpGetRawReferer.php
@@ -36,6 +36,7 @@ class Tests_Functions_wpGetRawReferer extends WP_UnitTestCase {
 		$_SERVER['HTTP_REFERER']      = 'http://NotUSED.com';
 		$this->assertSame( 'http://_wp_http_referer.com', wp_get_raw_referer(), 'Both set should use _wp_http_referer' );
 	}
+
 	/**
 	 * @ticket 55729
 	 */

--- a/tests/phpunit/tests/functions/wpGetRawReferer.php
+++ b/tests/phpunit/tests/functions/wpGetRawReferer.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Tests for the wp_referer_field() function.
+ *
+ * @since 6.0.0
+ *
+ * @group functions.php
+ * @covers ::wp_get_raw_referer
+ */
+class Tests_Functions_wpGetRawReferer extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 55729
+	 */
+	public function test_wp_get_original__wp_http_referer_referer() {
+
+		$_REQUEST['_wp_http_referer'] = 'http://_wp_http_referer.com';
+		$this->assertSame( 'http://_wp_http_referer.com', wp_get_raw_referer(), '$_REQUEST["_wp_http_referer"] set' );
+	}
+
+	/**
+	 * @ticket 55729
+	 */
+	public function test_wp_get_original_HTTP_REFERER_referer() {
+
+		$_SERVER['HTTP_REFERER'] = 'http://referer.com';
+		$this->assertSame( 'http://referer.com', wp_get_raw_referer(), '$_REQUEST["HTTP_REFERER"] set' );
+	}
+
+	/**
+	 * @ticket 55729
+	 */
+	public function test_wp_get_original_both_set_referer() {
+
+		$_REQUEST['_wp_http_referer'] = 'http://_wp_http_referer.com';
+		$_SERVER['HTTP_REFERER']      = 'http://NotUSED.com';
+		$this->assertSame( 'http://_wp_http_referer.com', wp_get_raw_referer(), 'Both set should use _wp_http_referer' );
+	}
+	/**
+	 * @ticket 55729
+	 */
+	public function test_wp_get_original_no_referer() {
+
+		$this->assertFalse( wp_get_raw_referer(), 'no referer set' );
+	}
+}

--- a/tests/phpunit/tests/functions/wpGetReferer.php
+++ b/tests/phpunit/tests/functions/wpGetReferer.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * Tests for the wp_referer_field() function.
+ *
+ * @since 6.0.0
+ *
+ * @group functions.php
+ * @covers ::wp_get_referer
+ */
+class Tests_Functions_wpGetReferer extends WP_UnitTestCase {
+	public function set_up() {
+		parent::set_up();
+		add_filter( 'home_url', array( $this, 'home_url' ) );
+	}
+
+	public function home_url() {
+
+		return 'http://example.com/';
+	}
+
+	/**
+	 * @ticket 55729
+	 */
+	public function test_wp_get_referer__wp_http_referer_referer() {
+
+		$_REQUEST['_wp_http_referer'] = 'http://example.com';
+		$this->assertSame( 'http://example.com',   wp_get_referer(), '$_REQUEST["_wp_http_referer"] set but no $_REQUEST["REQUEST_URI"] set' );
+	}
+
+	/**
+	 * @ticket 55729
+	 */
+	public function test_wp_get_referer_HTTP_REFERER_referer() {
+
+		$_SERVER['HTTP_REFERER'] = 'http://example.com';
+		$this->assertSame( 'http://example.com', wp_get_referer(), '$_REQUEST["HTTP_REFERER"] set but no $_REQUEST["REQUEST_URI"] set' );
+	}
+
+	/**
+	 * @ticket 55729
+	 */
+	public function test_wp_get_referer_HTTP_REFERER_referer_set_to_XX() {
+
+		$_SERVER['HTTP_REFERER'] = 'http://xxxx.com';
+		$this->assertFalse( wp_get_referer(), '$_REQUEST["HTTP_REFERER"] set but not $_REQUEST["HTTP_REFERER"] set to the current home_url' );
+	}
+	/**
+	 * @ticket 55729
+	 */
+	public function test_wp_get_referer_both_set_referer() {
+
+		$_REQUEST['_wp_http_referer'] = 'http://example.com';
+		$_SERVER['HTTP_REFERER']      = 'http://NotUSED.com';
+		$this->assertSame( 'http://example.com',  wp_get_referer(), 'Both set should use _wp_http_referer but no $_REQUEST["REQUEST_URI"] set' );
+	}
+	/**
+	 * @ticket 55729
+	 */
+	public function test_wp_get_referer_no_referer() {
+
+		$this->assertFalse( wp_get_referer(), 'no referer set' );
+	}
+}

--- a/tests/phpunit/tests/functions/wpGetReferer.php
+++ b/tests/phpunit/tests/functions/wpGetReferer.php
@@ -25,7 +25,7 @@ class Tests_Functions_wpGetReferer extends WP_UnitTestCase {
 	public function test_wp_get_referer__wp_http_referer_referer() {
 
 		$_REQUEST['_wp_http_referer'] = 'http://example.com';
-		$this->assertSame( 'http://example.com',   wp_get_referer(), '$_REQUEST["_wp_http_referer"] set but no $_REQUEST["REQUEST_URI"] set' );
+		$this->assertSame( 'http://example.com', wp_get_referer(), '$_REQUEST["_wp_http_referer"] set but no $_REQUEST["REQUEST_URI"] set' );
 	}
 
 	/**
@@ -52,7 +52,7 @@ class Tests_Functions_wpGetReferer extends WP_UnitTestCase {
 
 		$_REQUEST['_wp_http_referer'] = 'http://example.com';
 		$_SERVER['HTTP_REFERER']      = 'http://NotUSED.com';
-		$this->assertSame( 'http://example.com',  wp_get_referer(), 'Both set should use _wp_http_referer but no $_REQUEST["REQUEST_URI"] set' );
+		$this->assertSame( 'http://example.com', wp_get_referer(), 'Both set should use _wp_http_referer but no $_REQUEST["REQUEST_URI"] set' );
 	}
 	/**
 	 * @ticket 55729

--- a/tests/phpunit/tests/functions/wpOriginalReferer.php
+++ b/tests/phpunit/tests/functions/wpOriginalReferer.php
@@ -31,7 +31,7 @@ class Tests_Functions_wpOriginalReferer extends WP_UnitTestCase {
 	 */
 	public function test_wp_get_original_referer() {
 
-		$_REQUEST['_wp_original_http_referer'] = 'http://_wp_original_http_referer.com';
-		$this->assertSame( 'http://_wp_original_http_referer.com', wp_get_original_referer(), '_wp_original_http_referer set' );
+		$_REQUEST['_wp_original_http_referer'] = 'http://example.com';
+		$this->assertSame( 'http://example.com', wp_get_original_referer(), '_wp_original_http_referer set' );
 	}
 }

--- a/tests/phpunit/tests/functions/wpOriginalReferer.php
+++ b/tests/phpunit/tests/functions/wpOriginalReferer.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Tests for the wp_referer_field() function.
+ *
+ * @since 6.0.0
+ *
+ * @group functions.php
+ * @covers ::wp_get_original_referer
+ */
+class Tests_Functions_wpOriginalReferer extends WP_UnitTestCase {
+	public function set_up() {
+		parent::set_up();
+		add_filter( 'home_url', array( $this, 'home_url' ) );
+	}
+
+	public function home_url() {
+
+		return 'http://example.com/';
+	}
+	/**
+	 * @ticket 55729
+	 */
+	public function test_wp_get_original_referer_not_set() {
+
+		$this->assertSame( false, wp_get_original_referer(), '_wp_original_http_referer not set' );
+	}
+
+	/**
+	 * @ticket 55729
+	 */
+	public function test_wp_get_original_referer() {
+
+		$_REQUEST['_wp_original_http_referer'] = 'http://_wp_original_http_referer.com';
+		$this->assertSame( 'http://_wp_original_http_referer.com', wp_get_original_referer(), '_wp_original_http_referer set' );
+	}
+}

--- a/tests/phpunit/tests/functions/wpOriginalRefererField.php
+++ b/tests/phpunit/tests/functions/wpOriginalRefererField.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Tests for the wp_referer_field() function.
+ *
+ * @since 6.0.0
+ *
+ * @group functions.php
+ * @covers ::wp_referer_field
+ */
+class Tests_Functions_wpOriginalRefererField extends WP_UnitTestCase {
+	public function set_up() {
+		parent::set_up();
+		add_filter( 'home_url', array( $this, 'home_url' ) );
+	}
+
+	public function home_url() {
+		return 'http://example.com/';
+	}
+
+	/**
+	 * @ticket 55578
+	 */
+	public function test_wp_referer_field() {
+
+		$_REQUEST['_wp_original_http_referer'] = 'http://example.com/test/';
+		wp_original_referer_field();
+		$this->expectOutputString( '<input type="hidden" name="_wp_original_http_referer" value="http://example.com/test/" />' );
+	}
+
+	/**
+	 * @ticket 55578
+	 */
+	public function test_wp_referer_field_return() {
+
+		$_REQUEST['_wp_original_http_referer'] = 'http://example.com/test/';
+
+		$this->assertSame( '<input type="hidden" name="_wp_http_referer" value="http://example.com/test/" />', wp_original_referer_field( false ) );
+	}
+
+	/**
+	 * @ticket 55578
+	 */
+	public function test_wp_referer_field_return_previous() {
+
+		$_REQUEST['_wp_original_http_referer'] = 'http://example.com/test/';
+
+		$this->assertSame( '<input type="hidden" name="_wp_http_referer" value="http://example.com/test/" />', wp_original_referer_field( false, 'previous' ) );
+	}
+}

--- a/tests/phpunit/tests/functions/wpOriginalRefererField.php
+++ b/tests/phpunit/tests/functions/wpOriginalRefererField.php
@@ -35,7 +35,7 @@ class Tests_Functions_wpOriginalRefererField extends WP_UnitTestCase {
 
 		$_REQUEST['_wp_original_http_referer'] = 'http://example.com/test/';
 
-		$this->assertSame( '<input type="hidden" name="_wp_http_referer" value="http://example.com/test/" />', wp_original_referer_field( false ) );
+		$this->assertSame( '<input type="hidden" name="_wp_original_http_referer" value="http://example.com/test/" />', wp_original_referer_field( false ) );
 	}
 
 	/**
@@ -45,6 +45,6 @@ class Tests_Functions_wpOriginalRefererField extends WP_UnitTestCase {
 
 		$_REQUEST['_wp_original_http_referer'] = 'http://example.com/test/';
 
-		$this->assertSame( '<input type="hidden" name="_wp_http_referer" value="http://example.com/test/" />', wp_original_referer_field( false, 'previous' ) );
+		$this->assertSame( '<input type="hidden" name="_wp_original_http_referer" value="http://example.com/test/" />', wp_original_referer_field( false, 'previous' ) );
 	}
 }


### PR DESCRIPTION
Just tests for wp_get_raw_referer(), wp_get_referer(), wp_get_original_referer() and wp_original_referer_field()

Trac ticket: https://core.trac.wordpress.org/ticket/55729

