### PR TITLE
Make touchstart events passive

### DIFF
--- a/src/js/_enqueues/lib/comment-reply.js
+++ b/src/js/_enqueues/lib/comment-reply.js
@@ -93,7 +93,7 @@ window.addComment = ( function( window ) {
 			return;
 		}
 
-		cancelElement.addEventListener( 'touchstart', cancelEvent );
+		cancelElement.addEventListener( 'touchstart', cancelEvent, { passive: true } );
 		cancelElement.addEventListener( 'click',      cancelEvent );
 
 		// Submit the comment form when the user types [Ctrl] or [Cmd] + [Enter].
@@ -117,7 +117,7 @@ window.addComment = ( function( window ) {
 		for ( var i = 0, l = links.length; i < l; i++ ) {
 			element = links[i];
 
-			element.addEventListener( 'touchstart', clickEvent );
+			element.addEventListener( 'touchstart', clickEvent, { passive: true } );
 			element.addEventListener( 'click',      clickEvent );
 		}
 	}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Brought to light by recent Lighthouse updates, we should make the `touchStart` events in our comment reply script passive.

See https://web.dev/uses-passive-event-listeners/ for background and explanation.

Trac ticket: https://core.trac.wordpress.org/ticket/55988

This might affect (and partially fix) https://core.trac.wordpress.org/ticket/46713

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
