### PR TITLE
Normalize to Unicode NFC encoding before converting accent characters

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -1597,6 +1597,11 @@ function remove_accents( $string, $locale = '' ) {
 	}
 
 	if ( seems_utf8( $string ) ) {
+		if ( function_exists( 'normalizer_normalize' ) ) {
+			if ( ! normalizer_is_normalized( $string, Normalizer::FORM_C ) ) {
+				$string = normalizer_normalize( $string, Normalizer::FORM_C );
+			}
+		}
 		$chars = array(
 			// Decompositions for Latin-1 Supplement.
 			'ª' => 'a',

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -1584,6 +1584,7 @@ function utf8_uri_encode( $utf8_string, $length = 0, $encode_ascii_characters = 
  * @since 4.8.0 Added locale support for `bs_BA`.
  * @since 5.7.0 Added locale support for `de_AT`.
  * @since 6.0.0 Added the `$locale` parameter.
+ * @since 6.1.0 Added Unicode NFC encoding normalization support.
  *
  * @param string $string Text that might have accent characters.
  * @param string $locale Optional. The locale to use for accent removal. Some character

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -1598,6 +1598,8 @@ function remove_accents( $string, $locale = '' ) {
 	}
 
 	if ( seems_utf8( $string ) ) {
+		// Unicode sequence normalization from NFD (Normalization Form Decomposed)
+		// to NFC (Normalization Form [Pre]Composed), the encoding used in this function.
 		if ( function_exists( 'normalizer_normalize' ) ) {
 			if ( ! normalizer_is_normalized( $string, Normalizer::FORM_C ) ) {
 				$string = normalizer_normalize( $string, Normalizer::FORM_C );

--- a/tests/phpunit/tests/formatting/removeAccents.php
+++ b/tests/phpunit/tests/formatting/removeAccents.php
@@ -118,6 +118,8 @@ class Tests_Formatting_RemoveAccents extends WP_UnitTestCase {
 	 *
 	 * For more information on Unicode normalization, see
 	 *   https://unicode.org/faq/normalization.html.
+	 *
+	 * @requires extension intl
 	 */
 	public function test_remove_accents_latin1_supplement_nfd_encoding() {
 		$input  = 'ªºÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõöøùúûüýþÿ';

--- a/tests/phpunit/tests/formatting/removeAccents.php
+++ b/tests/phpunit/tests/formatting/removeAccents.php
@@ -109,4 +109,20 @@ class Tests_Formatting_RemoveAccents extends WP_UnitTestCase {
 		$this->assertSame( 'DJdj', remove_accents( 'Đđ', 'sr_RS' ) );
 		$this->assertSame( 'Dd', remove_accents( 'Đđ' ) );
 	}
+
+	/**
+	 * @ticket 24661
+	 *
+	 * Tests Unicode sequence normalization from NFD (Normalization Form Decomposed)
+	 *   to NFC (Normalization Form [Pre]Composed), the encoding used in `remove_accents()`.
+	 *
+	 * For more information on Unicode normalization, see
+	 *   https://unicode.org/faq/normalization.html.
+	 */
+	public function test_remove_accents_latin1_supplement_nfd_encoding() {
+		$input  = 'ªºÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõöøùúûüýþÿ';
+		$output = 'aoAAAAAAAECEEEEIIIIDNOOOOOOUUUUYTHsaaaaaaaeceeeeiiiidnoooooouuuuythy';
+
+		$this->assertSame( $output, remove_accents( $input ), 'remove_accents replaces Latin-1 Supplement with NFD encoding' );
+	}
 }

--- a/tests/phpunit/tests/formatting/removeAccents.php
+++ b/tests/phpunit/tests/formatting/removeAccents.php
@@ -2,6 +2,7 @@
 
 /**
  * @group formatting
+ * @covers ::remove_accents
  */
 class Tests_Formatting_RemoveAccents extends WP_UnitTestCase {
 	public function test_remove_accents_simple() {


### PR DESCRIPTION
Refresh of [previous patch for #24661](https://core.trac.wordpress.org/attachment/ticket/24661/normalize_before_removing_accents.patch), with addition of unit test to convert NFD-encoded strings.

Trac ticket: https://core.trac.wordpress.org/ticket/24661

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
