### PR TITLE
General: Add functions to display or retrieve required fields indicator and message.

### DIFF
--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -1698,8 +1698,7 @@ function get_media_item( $attachment_id, $args = null ) {
 		<tr><td colspan='2' class='imgedit-response' id='imgedit-response-$post->ID'></td></tr>\n
 		<tr><td style='display:none' colspan='2' class='image-editor' id='image-editor-$post->ID'></td></tr>\n
 		<tr><td colspan='2'><p class='media-types media-types-required-info'>" .
-			/* translators: %s: Asterisk symbol (*). */
-			sprintf( __( 'Required fields are marked %s' ), '<span class="required">*</span>' ) .
+			wp_required_field_message( '' ) .
 		"</p></td></tr>\n";
 
 	$defaults = array(
@@ -1779,7 +1778,7 @@ function get_media_item( $attachment_id, $args = null ) {
 			continue;
 		}
 
-		$required      = $field['required'] ? '<span class="required">*</span>' : '';
+		$required      = $field['required'] ? wp_required_field_indicator( '' ) : '';
 		$required_attr = $field['required'] ? ' required' : '';
 		$class         = $id;
 		$class        .= $field['required'] ? ' form-required' : '';
@@ -1970,7 +1969,7 @@ function get_compat_media_markup( $attachment_id, $args = null ) {
 		}
 
 		$readonly      = ! $user_can_edit && ! empty( $field['taxonomy'] ) ? " readonly='readonly' " : '';
-		$required      = $field['required'] ? '<span class="required">*</span>' : '';
+		$required      = $field['required'] ? wp_required_field_indicator( '' ) : '';
 		$required_attr = $field['required'] ? ' required' : '';
 		$class         = 'compat-field-' . $id;
 		$class        .= $field['required'] ? ' form-required' : '';
@@ -2026,8 +2025,7 @@ function get_compat_media_markup( $attachment_id, $args = null ) {
 
 	if ( $item ) {
 		$item = '<p class="media-types media-types-required-info">' .
-			/* translators: %s: Asterisk symbol (*). */
-			sprintf( __( 'Required fields are marked %s' ), '<span class="required">*</span>' ) .
+			wp_required_field_message( '' ) .
 			'</p>' .
 			'<table class="compat-attachment-fields">' . $item . '</table>';
 	}
@@ -2924,13 +2922,12 @@ function wp_media_insert_url_form( $default_view = 'image' ) {
 	return '
 	<p class="media-types"><label><input type="radio" name="media_type" value="image" id="image-only"' . checked( 'image-only', $view, false ) . ' /> ' . __( 'Image' ) . '</label> &nbsp; &nbsp; <label><input type="radio" name="media_type" value="generic" id="not-image"' . checked( 'not-image', $view, false ) . ' /> ' . __( 'Audio, Video, or Other File' ) . '</label></p>
 	<p class="media-types media-types-required-info">' .
-		/* translators: %s: Asterisk symbol (*). */
-		sprintf( __( 'Required fields are marked %s' ), '<span class="required">*</span>' ) .
+		wp_required_field_message( '' ) .
 	'</p>
 	<table class="describe ' . $table_class . '"><tbody>
 		<tr>
 			<th scope="row" class="label" style="width:130px;">
-				<label for="src"><span class="alignleft">' . __( 'URL' ) . '</span> <span class="required">*</span></label>
+				<label for="src"><span class="alignleft">' . __( 'URL' ) . '</span>' . wp_required_field_indicator() . '</label>
 				<span class="alignright" id="status_img"></span>
 			</th>
 			<td class="field"><input id="src" name="src" value="" type="text" required onblur="addExtImage.getImageData()" /></td>
@@ -2938,7 +2935,7 @@ function wp_media_insert_url_form( $default_view = 'image' ) {
 
 		<tr>
 			<th scope="row" class="label">
-				<label for="title"><span class="alignleft">' . __( 'Title' ) . '</span> <span class="required">*</span></label>
+				<label for="title"><span class="alignleft">' . __( 'Title' ) . '</span>' . wp_required_field_indicator() . '</label>
 			</th>
 			<td class="field"><input id="title" name="title" value="" type="text" required /></td>
 		</tr>
@@ -2947,7 +2944,7 @@ function wp_media_insert_url_form( $default_view = 'image' ) {
 
 		<tr class="image-only">
 			<th scope="row" class="label">
-				<label for="alt"><span class="alignleft">' . __( 'Alternative Text' ) . '</span></label>
+				<label for="alt"><span class="alignleft">' . __( 'Alternative Text' ) . '</span>' . wp_required_field_indicator() . '</label>
 			</th>
 			<td class="field"><input id="alt" name="alt" value="" type="text" required />
 			<p class="help">' . __( 'Alt text for the image, e.g. &#8220;The Mona Lisa&#8221;' ) . '</p></td>

--- a/src/wp-admin/network/site-new.php
+++ b/src/wp-admin/network/site-new.php
@@ -198,7 +198,12 @@ if ( ! empty( $messages ) ) {
 <?php wp_nonce_field( 'add-blog', '_wpnonce_add-blog' ); ?>
 	<table class="form-table" role="presentation">
 		<tr class="form-field form-required">
-			<th scope="row"><label for="site-address"><?php _e( 'Site Address (URL)' ); wp_required_field_indicator( ' ', true ); ?></label></th>
+			<th scope="row"><label for="site-address">
+			<?php
+				_e( 'Site Address (URL)' );
+				wp_required_field_indicator( ' ', true );
+			?>
+			</label></th>
 			<td>
 			<?php if ( is_subdomain_install() ) { ?>
 				<input name="blog[domain]" type="text" class="regular-text ltr" id="site-address" aria-describedby="site-address-desc" autocapitalize="none" autocorrect="off" required /><span class="no-break">.<?php echo preg_replace( '|^www\.|', '', get_network()->domain ); ?></span>
@@ -214,7 +219,12 @@ if ( ! empty( $messages ) ) {
 			</td>
 		</tr>
 		<tr class="form-field form-required">
-			<th scope="row"><label for="site-title"><?php _e( 'Site Title' ); wp_required_field_indicator( ' ', true ); ?></label></th>
+			<th scope="row"><label for="site-title">
+			<?php
+				_e( 'Site Title' );
+				wp_required_field_indicator( ' ', true );
+			?>
+			</label></th>
 			<td><input name="blog[title]" type="text" class="regular-text" id="site-title" required /></td>
 		</tr>
 		<?php
@@ -249,7 +259,12 @@ if ( ! empty( $messages ) ) {
 			</tr>
 		<?php endif; // Languages. ?>
 		<tr class="form-field form-required">
-			<th scope="row"><label for="admin-email"><?php _e( 'Admin Email' ); wp_required_field_indicator( ' ', true ); ?></label></th>
+			<th scope="row"><label for="admin-email">
+			<?php
+				_e( 'Admin Email' );
+				wp_required_field_indicator( ' ', true );
+			?>
+			</label></th>
 			<td><input name="blog[email]" type="email" class="regular-text wp-suggest-user" id="admin-email" data-autocomplete-type="search" data-autocomplete-field="user_email" aria-describedby="site-admin-email" required /></td>
 		</tr>
 		<tr class="form-field">

--- a/src/wp-admin/network/site-new.php
+++ b/src/wp-admin/network/site-new.php
@@ -193,20 +193,12 @@ if ( ! empty( $messages ) ) {
 	}
 }
 ?>
-<p>
-<?php
-printf(
-	/* translators: %s: Asterisk symbol (*). */
-	__( 'Required fields are marked %s' ),
-	'<span class="required">*</span>'
-);
-?>
-</p>
+<p><?php wp_required_field_message( '', true ); ?></p>
 <form method="post" action="<?php echo esc_url( network_admin_url( 'site-new.php?action=add-site' ) ); ?>" novalidate="novalidate">
 <?php wp_nonce_field( 'add-blog', '_wpnonce_add-blog' ); ?>
 	<table class="form-table" role="presentation">
 		<tr class="form-field form-required">
-			<th scope="row"><label for="site-address"><?php _e( 'Site Address (URL)' ); ?> <span class="required">*</span></label></th>
+			<th scope="row"><label for="site-address"><?php _e( 'Site Address (URL)' ); wp_required_field_indicator( ' ', true ); ?></label></th>
 			<td>
 			<?php if ( is_subdomain_install() ) { ?>
 				<input name="blog[domain]" type="text" class="regular-text ltr" id="site-address" aria-describedby="site-address-desc" autocapitalize="none" autocorrect="off" required /><span class="no-break">.<?php echo preg_replace( '|^www\.|', '', get_network()->domain ); ?></span>
@@ -222,7 +214,7 @@ printf(
 			</td>
 		</tr>
 		<tr class="form-field form-required">
-			<th scope="row"><label for="site-title"><?php _e( 'Site Title' ); ?> <span class="required">*</span></label></th>
+			<th scope="row"><label for="site-title"><?php _e( 'Site Title' ); wp_required_field_indicator( ' ', true ); ?></label></th>
 			<td><input name="blog[title]" type="text" class="regular-text" id="site-title" required /></td>
 		</tr>
 		<?php
@@ -257,7 +249,7 @@ printf(
 			</tr>
 		<?php endif; // Languages. ?>
 		<tr class="form-field form-required">
-			<th scope="row"><label for="admin-email"><?php _e( 'Admin Email' ); ?> <span class="required">*</span></label></th>
+			<th scope="row"><label for="admin-email"><?php _e( 'Admin Email' ); wp_required_field_indicator( ' ', true ); ?></label></th>
 			<td><input name="blog[email]" type="email" class="regular-text wp-suggest-user" id="admin-email" data-autocomplete-type="search" data-autocomplete-field="user_email" aria-describedby="site-admin-email" required /></td>
 		</tr>
 		<tr class="form-field">

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -2359,8 +2359,9 @@ function comment_form( $args = array(), $post_id = null ) {
 	$required_attribute = ( $html5 ? ' required' : ' required="required"' );
 	$checked_attribute  = ( $html5 ? ' checked' : ' checked="checked"' );
 
-	// Identify required fields visually.
-	$required_indicator = ' <span class="required" aria-hidden="true">*</span>';
+	// Identify required fields visually and create a message about the indicator.
+	$required_indicator = wp_required_field_indicator();
+	$required_text      = wp_required_field_message();
 
 	$fields = array(
 		'author' => sprintf(
@@ -2424,12 +2425,6 @@ function comment_form( $args = array(), $post_id = null ) {
 			$args['fields']['cookies'] = $fields['cookies'];
 		}
 	}
-
-	$required_text = sprintf(
-		/* translators: %s: Asterisk symbol (*). */
-		' <span class="required-field-message" aria-hidden="true">' . __( 'Required fields are marked %s' ) . '</span>',
-		trim( $required_indicator )
-	);
 
 	/**
 	 * Filters the default comment form fields.

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -8474,7 +8474,7 @@ function wp_required_field_indicator( $space_before = ' ', $display = false ) {
 	$indicator = sprintf(
 		'%1$s<span class="required" aria-hidden="true">%2$s</span>',
 		esc_html( $space_before ),
-		esc_html( $glyph ),
+		esc_html( $glyph )
 	);
 
 	if ( ! $display ) {
@@ -8497,11 +8497,11 @@ function wp_required_field_message( $space_before = ' ', $echo = false ) {
 		'%1$s<span class="required-field-message" aria-hidden="true">%2$s</span>',
 		esc_html( $space_before ),
 		/* translators: %s: Asterisk symbol (*). */
-		sprintf( __( 'Required fields are marked %s' ), wp_required_field_indicator( '' ) ),
+		sprintf( __( 'Required fields are marked %s' ), wp_required_field_indicator( '' ) )
 	);
 
 	if ( ! $display ) {
-		return $messages;
+		return $message;
 	}
 	echo $message;
 }

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -8458,3 +8458,50 @@ function wp_recursive_ksort( &$array ) {
 	}
 	ksort( $array );
 }
+
+/**
+ * Assigns a visual indicator for required form fields.
+ *
+ * @since 6.1.0
+ *
+ * @param string $space_before Space character, entity or empty string to add before glyph. Default ' '.
+ * @param bool   $display      Whether to output the result or instead return it. Default false.
+ * @return string Indicator glyph wrapped in a `span` tag.
+ */
+function wp_required_field_indicator( $space_before = ' ', $display = false ) {
+	/* translators: Character to identify required form fields. */
+	$glyph     = __( '*' );
+	$indicator = sprintf(
+		'%1$s<span class="required" aria-hidden="true">%2$s</span>',
+		esc_html( $space_before ),
+		esc_html( $glyph ),
+	);
+
+	if ( ! $display ) {
+		return $indicator;
+	}
+	echo $indicator;
+}
+
+/**
+ * Creates a message to explain required form fields.
+ *
+ * @since 6.1.0
+ *
+ * @param string $space_before Space character, entity or empty string to add before glyph. Default ' '.
+ * @param bool   $display      Whether to output the result or instead return it. Default false.
+ * @return string Message text and glyph wrapped in a `span` tag.
+ */
+function wp_required_field_message( $space_before = ' ', $echo = false ) {
+	$message = sprintf(
+		'%1$s<span class="required-field-message" aria-hidden="true">%2$s</span>',
+		esc_html( $space_before ),
+		/* translators: %s: Asterisk symbol (*). */
+		sprintf( __( 'Required fields are marked %s' ), wp_required_field_indicator( '' ) ),
+	);
+
+	if ( ! $display ) {
+		return $messages;
+	}
+	echo $message;
+}

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -8492,7 +8492,7 @@ function wp_required_field_indicator( $space_before = ' ', $display = false ) {
  * @param bool   $display      Whether to output the result or instead return it. Default false.
  * @return string Message text and glyph wrapped in a `span` tag.
  */
-function wp_required_field_message( $space_before = ' ', $echo = false ) {
+function wp_required_field_message( $space_before = ' ', $display = false ) {
 	$message = sprintf(
 		'%1$s<span class="required-field-message" aria-hidden="true">%2$s</span>',
 		esc_html( $space_before ),


### PR DESCRIPTION
Fixing WPCS and PHP compatibility errors found in #2819, plus correcting the `$message` variable name

Trac ticket: https://core.trac.wordpress.org/ticket/54394

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
