### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -39,6 +39,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # Runs PHP coding standards checks.
   #
@@ -161,6 +164,8 @@ jobs:
         run: git diff --exit-code
 
   slack-notifications:
+    permissions:
+      contents: none
     name: Slack Notifications
     uses: WordPress/wordpress-develop/.github/workflows/slack-notifications.yml@trunk
     needs: [ phpcs, jshint ]

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -27,6 +27,9 @@ concurrency:
 env:
   LOCAL_DIR: build
 
+permissions:
+  contents: read
+
 jobs:
   # Runs the end-to-end test suite.
   #
@@ -117,6 +120,8 @@ jobs:
         run: git diff --exit-code
 
   slack-notifications:
+    permissions:
+      contents: none
     name: Slack Notifications
     uses: WordPress/wordpress-develop/.github/workflows/slack-notifications.yml@trunk
     needs: [ e2e-tests ]

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -37,6 +37,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # Runs the QUnit tests for WordPress.
   #
@@ -86,6 +89,8 @@ jobs:
         run: git diff --exit-code
 
   slack-notifications:
+    permissions:
+      contents: none
     name: Slack Notifications
     uses: WordPress/wordpress-develop/.github/workflows/slack-notifications.yml@trunk
     needs: [ test-js ]

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -33,6 +33,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
 
   # Runs PHP compatibility testing.
@@ -101,6 +104,8 @@ jobs:
         run: git diff --exit-code
 
   slack-notifications:
+    permissions:
+      contents: none
     name: Slack Notifications
     uses: WordPress/wordpress-develop/.github/workflows/slack-notifications.yml@trunk
     needs: [ php-compatibility ]

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -31,6 +31,9 @@ env:
   LOCAL_PHP_MEMCACHED: ${{ false }}
   SLOW_TESTS: 'external-http,media,restapi'
 
+permissions:
+  contents: read
+
 jobs:
   # Runs the PHPUnit tests for WordPress.
   #
@@ -243,6 +246,8 @@ jobs:
         run: docker-compose run --rm -e WPT_REPORT_API_KEY -e WPT_PREPARE_DIR=/var/www -e WPT_TEST_DIR=/var/www php php test-runner/report.php
 
   slack-notifications:
+    permissions:
+      contents: none
     name: Slack Notifications
     uses: WordPress/wordpress-develop/.github/workflows/slack-notifications.yml@trunk
     needs: [ test-php ]

--- a/.github/workflows/slack-notifications.yml
+++ b/.github/workflows/slack-notifications.yml
@@ -164,6 +164,8 @@ jobs:
 
   # Posts notifications when a workflow fails.
   failure:
+    permissions:
+      contents: none
     name: Failure notifications
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -180,6 +182,8 @@ jobs:
 
   # Posts notifications the first time a workflow run succeeds after previously failing.
   fixed:
+    permissions:
+      contents: none
     name: Fixed notifications
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -196,6 +200,8 @@ jobs:
 
   # Posts notifications when a workflow is successful.
   success:
+    permissions:
+      contents: none
     name: Success notifications
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -212,6 +218,8 @@ jobs:
 
   # Posts notifications when a workflow is cancelled.
   cancelled:
+    permissions:
+      contents: none
     name: Cancelled notifications
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -21,6 +21,9 @@ env:
   LOCAL_PHP_XDEBUG: true
   LOCAL_PHP_MEMCACHED: ${{ false }}
 
+permissions:
+  contents: read
+
 jobs:
   # Sets up WordPress for testing or development use.
   #
@@ -170,6 +173,8 @@ jobs:
           flags: multisite,php
 
   slack-notifications:
+    permissions:
+      contents: none
     name: Slack Notifications
     uses: WordPress/wordpress-develop/.github/workflows/slack-notifications.yml@trunk
     needs: [ test-coverage-report ]

--- a/.github/workflows/test-npm.yml
+++ b/.github/workflows/test-npm.yml
@@ -33,6 +33,9 @@ concurrency:
 env:
   PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: ${{ true }}
 
+permissions:
+  contents: read
+
 jobs:
   # Verifies that installing NPM dependencies and building WordPress works as expected.
   #
@@ -156,6 +159,8 @@ jobs:
         run: git diff --exit-code
 
   slack-notifications:
+    permissions:
+      contents: none
     name: Slack Notifications
     uses: WordPress/wordpress-develop/.github/workflows/slack-notifications.yml@trunk
     needs: [ test-npm, test-npm-macos ]

--- a/.github/workflows/test-old-branches.yml
+++ b/.github/workflows/test-old-branches.yml
@@ -80,6 +80,8 @@ jobs:
             });
 
   slack-notifications:
+    permissions:
+      contents: none
     name: Slack Notifications
     uses: WordPress/wordpress-develop/.github/workflows/slack-notifications.yml@trunk
     needs: [ dispatch-workflows-for-old-branches ]


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
