### PR TITLE
Introduce `WP_List_Table::get_views_links()`.

### DIFF
--- a/src/wp-admin/includes/class-wp-comments-list-table.php
+++ b/src/wp-admin/includes/class-wp-comments-list-table.php
@@ -293,12 +293,6 @@ class WP_Comments_List_Table extends WP_List_Table {
 		}
 
 		foreach ( $stati as $status => $label ) {
-			$current_link_attributes = '';
-
-			if ( $status === $comment_status ) {
-				$current_link_attributes = ' class="current" aria-current="page"';
-			}
-
 			if ( 'mine' === $status ) {
 				$current_user_id    = get_current_user_id();
 				$num_comments->mine = get_comments(
@@ -329,14 +323,18 @@ class WP_Comments_List_Table extends WP_List_Table {
 				$link = add_query_arg( 's', esc_attr( wp_unslash( $_REQUEST['s'] ) ), $link );
 			*/
 
-			$status_links[ $status ] = "<a href='$link'$current_link_attributes>" . sprintf(
-				translate_nooped_plural( $label, $num_comments->$status ),
-				sprintf(
-					'<span class="%s-count">%s</span>',
-					( 'moderated' === $status ) ? 'pending' : $status,
-					number_format_i18n( $num_comments->$status )
-				)
-			) . '</a>';
+			$status_links[ $status ] = array(
+				'url'     => esc_url( $link ),
+				'label'   => sprintf(
+					translate_nooped_plural( $label, $num_comments->$status ),
+					sprintf(
+						'<span class="%s-count">%s</span>',
+						( 'moderated' === $status ) ? 'pending' : $status,
+						number_format_i18n( $num_comments->$status )
+					)
+				),
+				'current' => $status === $comment_status,
+			);
 		}
 
 		/**
@@ -348,7 +346,7 @@ class WP_Comments_List_Table extends WP_List_Table {
 		 * @param string[] $status_links An associative array of fully-formed comment status links. Includes 'All', 'Mine',
 		 *                              'Pending', 'Approved', 'Spam', and 'Trash'.
 		 */
-		return apply_filters( 'comment_status_links', $status_links );
+		return apply_filters( 'comment_status_links', $this->get_views_links( $status_links ) );
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-list-table.php
+++ b/src/wp-admin/includes/class-wp-list-table.php
@@ -1527,12 +1527,12 @@ class WP_List_Table {
 	 * @return array An array of link markup. Keys match the $link_data input array.
 	 */
 	protected function get_views_links( $link_data = array() ) {
-		if ( ! $link_data || ! is_array( $link_data ) ) {
+		if ( ! is_array( $link_data ) ) {
 			_doing_it_wrong(
 				__METHOD__,
 				sprintf(
 					/* translators: %s: The $link_data argument. */
-					__( 'The <code>%s</code> argument must be a non-empty array.' ),
+					__( 'The <code>%s</code> argument must be an array.' ),
 					'$link_data'
 				),
 				'6.1.0'

--- a/src/wp-admin/includes/class-wp-list-table.php
+++ b/src/wp-admin/includes/class-wp-list-table.php
@@ -1513,6 +1513,78 @@ class WP_List_Table {
 	}
 
 	/**
+	 * Generates views links.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param array $link_data {
+	 *     An array of link data.
+	 *
+	 *     @type string $url     The link URL.
+	 *     @type string $label   The link label.
+	 *     @type bool   $current Optional. Whether this is the currently selected view.
+	 * }
+	 * @return array An array of link markup. Keys match the $link_data input array.
+	 */
+	protected function get_views_links( $link_data = array() ) {
+		if ( ! $link_data || ! is_array( $link_data ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				sprintf(
+					/* translators: %s: The $link_data argument. */
+					__( 'The <code>%s</code> argument must be a non-empty array.' ),
+					'$link_data'
+				),
+				'6.1.0'
+			);
+
+			return array( '' );
+		}
+
+		$views_links = array();
+		foreach ( $link_data as $view => $link ) {
+			if ( ! isset( $link['url'] ) || ! is_string( $link['url'] ) || '' === trim( $link['url'] ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					sprintf(
+						/* translators: %1$s: The argument name. %2$s: The view name. */
+						__( 'The <code>%1$s</code> argument must be a non-empty string for <code>%2$s</code>.' ),
+						'url',
+						$view
+					),
+					'6.1.0'
+				);
+
+				continue;
+			}
+
+			if ( ! isset( $link['label'] ) || ! is_string( $link['label'] ) || '' === trim( $link['label'] ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					sprintf(
+						/* translators: %1$s: The argument name. %2$s: The view name. */
+						__( 'The <code>%1$s</code> argument must be a non-empty string for <code>%2$s</code>.' ),
+						'label',
+						$view
+					),
+					'6.1.0'
+				);
+
+				continue;
+			}
+
+			$views_links[ $view ] = sprintf(
+				'<a href="%s"%s>%s</a>',
+				$link['url'],
+				isset( $link['current'] ) && true === $link['current'] ? ' class="current" aria-current="page"' : '',
+				$link['label']
+			);
+		}
+
+		return $views_links;
+	}
+
+	/**
 	 * Sends required variables to JavaScript land.
 	 *
 	 * @since 3.1.0

--- a/src/wp-admin/includes/class-wp-list-table.php
+++ b/src/wp-admin/includes/class-wp-list-table.php
@@ -1550,7 +1550,7 @@ class WP_List_Table {
 						/* translators: %1$s: The argument name. %2$s: The view name. */
 						__( 'The <code>%1$s</code> argument must be a non-empty string for <code>%2$s</code>.' ),
 						'url',
-						$view
+						esc_html( $view )
 					),
 					'6.1.0'
 				);
@@ -1565,7 +1565,7 @@ class WP_List_Table {
 						/* translators: %1$s: The argument name. %2$s: The view name. */
 						__( 'The <code>%1$s</code> argument must be a non-empty string for <code>%2$s</code>.' ),
 						'label',
-						$view
+						esc_html( $view )
 					),
 					'6.1.0'
 				);
@@ -1575,7 +1575,7 @@ class WP_List_Table {
 
 			$views_links[ $view ] = sprintf(
 				'<a href="%s"%s>%s</a>',
-				$link['url'],
+				esc_url( $link['url'] ),
 				isset( $link['current'] ) && true === $link['current'] ? ' class="current" aria-current="page"' : '',
 				$link['label']
 			);

--- a/src/wp-admin/includes/class-wp-list-table.php
+++ b/src/wp-admin/includes/class-wp-list-table.php
@@ -1543,7 +1543,7 @@ class WP_List_Table {
 
 		$views_links = array();
 		foreach ( $link_data as $view => $link ) {
-			if ( ! isset( $link['url'] ) || ! is_string( $link['url'] ) || '' === trim( $link['url'] ) ) {
+			if ( empty( $link['url'] ) || ! is_string( $link['url'] ) || '' === trim( $link['url'] ) ) {
 				_doing_it_wrong(
 					__METHOD__,
 					sprintf(
@@ -1558,7 +1558,7 @@ class WP_List_Table {
 				continue;
 			}
 
-			if ( ! isset( $link['label'] ) || ! is_string( $link['label'] ) || '' === trim( $link['label'] ) ) {
+			if ( empty( $link['label'] ) || ! is_string( $link['label'] ) || '' === trim( $link['label'] ) ) {
 				_doing_it_wrong(
 					__METHOD__,
 					sprintf(

--- a/src/wp-admin/includes/class-wp-ms-sites-list-table.php
+++ b/src/wp-admin/includes/class-wp-ms-sites-list-table.php
@@ -262,23 +262,19 @@ class WP_MS_Sites_List_Table extends WP_List_Table {
 		$url              = 'sites.php';
 
 		foreach ( $statuses as $status => $label_count ) {
-			$current_link_attributes = $requested_status === $status || ( '' === $requested_status && 'all' === $status )
-				? ' class="current" aria-current="page"'
-				: '';
 			if ( (int) $counts[ $status ] > 0 ) {
 				$label    = sprintf( translate_nooped_plural( $label_count, $counts[ $status ] ), number_format_i18n( $counts[ $status ] ) );
 				$full_url = 'all' === $status ? $url : add_query_arg( 'status', $status, $url );
 
-				$view_links[ $status ] = sprintf(
-					'<a href="%1$s"%2$s>%3$s</a>',
-					esc_url( $full_url ),
-					$current_link_attributes,
-					$label
+				$view_links[ $status ] = array(
+					'url'     => esc_url( $full_url ),
+					'label'   => $label,
+					'current' => $requested_status === $status || ( '' === $requested_status && 'all' === $status ),
 				);
 			}
 		}
 
-		return $view_links;
+		return $this->get_views_links( $view_links );
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-ms-themes-list-table.php
+++ b/src/wp-admin/includes/class-wp-ms-themes-list-table.php
@@ -444,16 +444,15 @@ class WP_MS_Themes_List_Table extends WP_List_Table {
 			}
 
 			if ( 'search' !== $type ) {
-				$status_links[ $type ] = sprintf(
-					"<a href='%s'%s>%s</a>",
-					esc_url( add_query_arg( 'theme_status', $type, $url ) ),
-					( $type === $status ) ? ' class="current" aria-current="page"' : '',
-					sprintf( $text, number_format_i18n( $count ) )
+				$status_links[ $type ] = array(
+					'url'     => esc_url( add_query_arg( 'theme_status', $type, $url ) ),
+					'label'   => sprintf( $text, number_format_i18n( $count ) ),
+					'current' => $type === $status,
 				);
 			}
 		}
 
-		return $status_links;
+		return $this->get_views_links( $status_links );
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-ms-users-list-table.php
+++ b/src/wp-admin/includes/class-wp-ms-users-list-table.php
@@ -137,13 +137,10 @@ class WP_MS_Users_List_Table extends WP_List_Table {
 		$super_admins = get_super_admins();
 		$total_admins = count( $super_admins );
 
-		$current_link_attributes = 'super' !== $role ? ' class="current" aria-current="page"' : '';
-		$role_links              = array();
-		$role_links['all']       = sprintf(
-			'<a href="%s"%s>%s</a>',
-			network_admin_url( 'users.php' ),
-			$current_link_attributes,
-			sprintf(
+		$role_links        = array();
+		$role_links['all'] = array(
+			'url'     => network_admin_url( 'users.php' ),
+			'label'   => sprintf(
 				/* translators: Number of users. */
 				_nx(
 					'All <span class="count">(%s)</span>',
@@ -152,14 +149,13 @@ class WP_MS_Users_List_Table extends WP_List_Table {
 					'users'
 				),
 				number_format_i18n( $total_users )
-			)
+			),
+			'current' => 'super' !== $role,
 		);
-		$current_link_attributes = 'super' === $role ? ' class="current" aria-current="page"' : '';
-		$role_links['super']     = sprintf(
-			'<a href="%s"%s>%s</a>',
-			network_admin_url( 'users.php?role=super' ),
-			$current_link_attributes,
-			sprintf(
+
+		$role_links['super'] = array(
+			'url'     => network_admin_url( 'users.php?role=super' ),
+			'label'   => sprintf(
 				/* translators: Number of users. */
 				_n(
 					'Super Admin <span class="count">(%s)</span>',
@@ -167,10 +163,11 @@ class WP_MS_Users_List_Table extends WP_List_Table {
 					$total_admins
 				),
 				number_format_i18n( $total_admins )
-			)
+			),
+			'current' => 'super' === $role,
 		);
 
-		return $role_links;
+		return $this->get_views_links( $role_links );
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-plugin-install-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugin-install-list-table.php
@@ -310,14 +310,16 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 
 		$display_tabs = array();
 		foreach ( (array) $tabs as $action => $text ) {
-			$current_link_attributes                     = ( $action === $tab ) ? ' class="current" aria-current="page"' : '';
-			$href                                        = self_admin_url( 'plugin-install.php?tab=' . $action );
-			$display_tabs[ 'plugin-install-' . $action ] = "<a href='$href'$current_link_attributes>$text</a>";
+			$display_tabs[ 'plugin-install-' . $action ] = array(
+				'url'     => self_admin_url( 'plugin-install.php?tab=' . $action ),
+				'label'   => $text,
+				'current' => $action === $tab,
+			);
 		}
 		// No longer a real tab.
 		unset( $display_tabs['plugin-install-upload'] );
 
-		return $display_tabs;
+		return $this->get_views_links( $display_tabs );
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -576,16 +576,15 @@ class WP_Plugins_List_Table extends WP_List_Table {
 			}
 
 			if ( 'search' !== $type ) {
-				$status_links[ $type ] = sprintf(
-					"<a href='%s'%s>%s</a>",
-					add_query_arg( 'plugin_status', $type, 'plugins.php' ),
-					( $type === $status ) ? ' class="current" aria-current="page"' : '',
-					sprintf( $text, number_format_i18n( $count ) )
+				$status_links[ $type ] = array(
+					'url'     => add_query_arg( 'plugin_status', $type, 'plugins.php' ),
+					'label'   => sprintf( $text, number_format_i18n( $count ) ),
+					'current' => $type === $status,
 				);
 			}
 		}
 
-		return $status_links;
+		return $this->get_views_links( $status_links );
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -331,14 +331,14 @@ class WP_Posts_List_Table extends WP_List_Table {
 				number_format_i18n( $this->user_posts_count )
 			);
 
-			$mine = $this->get_edit_link( $mine_args, $mine_inner_html, $class );
+			$mine = array(
+				'url'     => esc_url( add_query_arg( $mine_args, 'edit.php' ) ),
+				'label'   => $mine_inner_html,
+				'current' => isset( $_GET['author'] ) && ( $current_user_id === (int) $_GET['author'] ),
+			);
 
 			$all_args['all_posts'] = 1;
 			$class                 = '';
-		}
-
-		if ( empty( $class ) && ( $this->is_base_request() || isset( $_REQUEST['all_posts'] ) ) ) {
-			$class = 'current';
 		}
 
 		$all_inner_html = sprintf(
@@ -352,7 +352,11 @@ class WP_Posts_List_Table extends WP_List_Table {
 			number_format_i18n( $total_posts )
 		);
 
-		$status_links['all'] = $this->get_edit_link( $all_args, $all_inner_html, $class );
+		$status_links['all'] = array(
+			'url'     => esc_url( add_query_arg( $all_args, 'edit.php' ) ),
+			'label'   => $all_inner_html,
+			'current' => empty( $class ) && ( $this->is_base_request() || isset( $_REQUEST['all_posts'] ) ),
+		);
 
 		if ( $mine ) {
 			$status_links['mine'] = $mine;
@@ -381,7 +385,11 @@ class WP_Posts_List_Table extends WP_List_Table {
 				number_format_i18n( $num_posts->$status_name )
 			);
 
-			$status_links[ $status_name ] = $this->get_edit_link( $status_args, $status_label, $class );
+			$status_links[ $status_name ] = array(
+				'url'     => esc_url( add_query_arg( $status_args, 'edit.php' ) ),
+				'label'   => $status_label,
+				'current' => isset( $_REQUEST['post_status'] ) && $status_name === $_REQUEST['post_status'],
+			);
 		}
 
 		if ( ! empty( $this->sticky_posts_count ) ) {
@@ -404,7 +412,11 @@ class WP_Posts_List_Table extends WP_List_Table {
 			);
 
 			$sticky_link = array(
-				'sticky' => $this->get_edit_link( $sticky_args, $sticky_inner_html, $class ),
+				'sticky' => array(
+					'url'     => esc_url( add_query_arg( $sticky_args, 'edit.php' ) ),
+					'label'   => $sticky_inner_html,
+					'current' => ! empty( $_REQUEST['show_sticky'] ),
+				),
 			);
 
 			// Sticky comes after Publish, or if not listed, after All.
@@ -412,7 +424,7 @@ class WP_Posts_List_Table extends WP_List_Table {
 			$status_links = array_merge( array_slice( $status_links, 0, $split ), $sticky_link, array_slice( $status_links, $split ) );
 		}
 
-		return $status_links;
+		return $this->get_views_links( $status_links );
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-privacy-requests-table.php
+++ b/src/wp-admin/includes/class-wp-privacy-requests-table.php
@@ -153,8 +153,7 @@ abstract class WP_Privacy_Requests_Table extends WP_List_Table {
 		// Normalized admin URL.
 		$admin_url = $this->get_admin_url();
 
-		$current_link_attributes = empty( $current_status ) ? ' class="current" aria-current="page"' : '';
-		$status_label            = sprintf(
+		$status_label = sprintf(
 			/* translators: %s: Number of requests. */
 			_nx(
 				'All <span class="count">(%s)</span>',
@@ -165,11 +164,10 @@ abstract class WP_Privacy_Requests_Table extends WP_List_Table {
 			number_format_i18n( $total_requests )
 		);
 
-		$views['all'] = sprintf(
-			'<a href="%s"%s>%s</a>',
-			esc_url( $admin_url ),
-			$current_link_attributes,
-			$status_label
+		$views['all'] = array(
+			'url'     => esc_url( $admin_url ),
+			'label'   => $status_label,
+			'current' => empty( $current_status ),
 		);
 
 		foreach ( $statuses as $status => $label ) {
@@ -178,8 +176,7 @@ abstract class WP_Privacy_Requests_Table extends WP_List_Table {
 				continue;
 			}
 
-			$current_link_attributes = $status === $current_status ? ' class="current" aria-current="page"' : '';
-			$total_status_requests   = absint( $counts->{$status} );
+			$total_status_requests = absint( $counts->{$status} );
 
 			if ( ! $total_status_requests ) {
 				continue;
@@ -192,15 +189,14 @@ abstract class WP_Privacy_Requests_Table extends WP_List_Table {
 
 			$status_link = add_query_arg( 'filter-status', $status, $admin_url );
 
-			$views[ $status ] = sprintf(
-				'<a href="%s"%s>%s</a>',
-				esc_url( $status_link ),
-				$current_link_attributes,
-				$status_label
+			$views[ $status ] = array(
+				'url'     => esc_url( $status_link ),
+				'label'   => $status_label,
+				'current' => $status === $current_status,
 			);
 		}
 
-		return $views;
+		return $this->get_views_links( $views );
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-theme-install-list-table.php
+++ b/src/wp-admin/includes/class-wp-theme-install-list-table.php
@@ -186,12 +186,14 @@ class WP_Theme_Install_List_Table extends WP_Themes_List_Table {
 
 		$display_tabs = array();
 		foreach ( (array) $tabs as $action => $text ) {
-			$current_link_attributes                    = ( $action === $tab ) ? ' class="current" aria-current="page"' : '';
-			$href                                       = self_admin_url( 'theme-install.php?tab=' . $action );
-			$display_tabs[ 'theme-install-' . $action ] = "<a href='$href'$current_link_attributes>$text</a>";
+			$display_tabs[ 'theme-install-' . $action ] = array(
+				'url'     => self_admin_url( 'theme-install.php?tab=' . $action ),
+				'label'   => $text,
+				'current' => $action === $tab,
+			);
 		}
 
-		return $display_tabs;
+		return $this->get_views_links( $display_tabs );
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-users-list-table.php
+++ b/src/wp-admin/includes/class-wp-users-list-table.php
@@ -185,10 +185,9 @@ class WP_Users_List_Table extends WP_List_Table {
 			$url = 'users.php';
 		}
 
-		$role_links              = array();
-		$avail_roles             = array();
-		$all_text                = __( 'All' );
-		$current_link_attributes = empty( $role ) ? ' class="current" aria-current="page"' : '';
+		$role_links  = array();
+		$avail_roles = array();
+		$all_text    = __( 'All' );
 
 		if ( $count_users ) {
 			if ( $this->is_site_users ) {
@@ -215,17 +214,15 @@ class WP_Users_List_Table extends WP_List_Table {
 			);
 		}
 
-		$role_links['all'] = sprintf( '<a href="%s"%s>%s</a>', $url, $current_link_attributes, $all_text );
+		$role_links['all'] = array(
+			'url'     => $url,
+			'label'   => $all_text,
+			'current' => empty( $role ),
+		);
 
 		foreach ( $wp_roles->get_names() as $this_role => $name ) {
 			if ( $count_users && ! isset( $avail_roles[ $this_role ] ) ) {
 				continue;
-			}
-
-			$current_link_attributes = '';
-
-			if ( $this_role === $role ) {
-				$current_link_attributes = ' class="current" aria-current="page"';
 			}
 
 			$name = translate_user_role( $name );
@@ -238,16 +235,14 @@ class WP_Users_List_Table extends WP_List_Table {
 				);
 			}
 
-			$role_links[ $this_role ] = "<a href='" . esc_url( add_query_arg( 'role', $this_role, $url ) ) . "'$current_link_attributes>$name</a>";
+			$role_links[ $this_role ] = array(
+				'url'     => esc_url( add_query_arg( 'role', $this_role, $url ) ),
+				'label'   => $name,
+				'current' => $this_role === $role,
+			);
 		}
 
 		if ( ! empty( $avail_roles['none'] ) ) {
-
-			$current_link_attributes = '';
-
-			if ( 'none' === $role ) {
-				$current_link_attributes = ' class="current" aria-current="page"';
-			}
 
 			$name = __( 'No role' );
 			$name = sprintf(
@@ -257,10 +252,14 @@ class WP_Users_List_Table extends WP_List_Table {
 				number_format_i18n( $avail_roles['none'] )
 			);
 
-			$role_links['none'] = "<a href='" . esc_url( add_query_arg( 'role', 'none', $url ) ) . "'$current_link_attributes>$name</a>";
+			$role_links['none'] = array(
+				'url'     => esc_url( add_query_arg( 'role', 'none', $url ) ),
+				'label'   => $name,
+				'current' => 'none' === $role,
+			);
 		}
 
-		return $role_links;
+		return $this->get_views_links( $role_links );
 	}
 
 	/**

--- a/tests/phpunit/tests/admin/wpCommentsListTable.php
+++ b/tests/phpunit/tests/admin/wpCommentsListTable.php
@@ -204,12 +204,12 @@ OPTIONS;
 		$this->table->prepare_items();
 
 		$expected = array(
-			'all'       => '<a href=\'http://example.org/wp-admin/edit-comments.php?comment_status=all\' class="current" aria-current="page">All <span class="count">(<span class="all-count">0</span>)</span></a>',
-			'mine'      => '<a href=\'http://example.org/wp-admin/edit-comments.php?comment_status=mine&user_id=0\'>Mine <span class="count">(<span class="mine-count">0</span>)</span></a>',
-			'moderated' => '<a href=\'http://example.org/wp-admin/edit-comments.php?comment_status=moderated\'>Pending <span class="count">(<span class="pending-count">0</span>)</span></a>',
-			'approved'  => '<a href=\'http://example.org/wp-admin/edit-comments.php?comment_status=approved\'>Approved <span class="count">(<span class="approved-count">0</span>)</span></a>',
-			'spam'      => '<a href=\'http://example.org/wp-admin/edit-comments.php?comment_status=spam\'>Spam <span class="count">(<span class="spam-count">0</span>)</span></a>',
-			'trash'     => '<a href=\'http://example.org/wp-admin/edit-comments.php?comment_status=trash\'>Trash <span class="count">(<span class="trash-count">0</span>)</span></a>',
+			'all'       => '<a href="http://example.org/wp-admin/edit-comments.php?comment_status=all" class="current" aria-current="page">All <span class="count">(<span class="all-count">0</span>)</span></a>',
+			'mine'      => '<a href="http://example.org/wp-admin/edit-comments.php?comment_status=mine&user_id=0">Mine <span class="count">(<span class="mine-count">0</span>)</span></a>',
+			'moderated' => '<a href="http://example.org/wp-admin/edit-comments.php?comment_status=moderated">Pending <span class="count">(<span class="pending-count">0</span>)</span></a>',
+			'approved'  => '<a href="http://example.org/wp-admin/edit-comments.php?comment_status=approved">Approved <span class="count">(<span class="approved-count">0</span>)</span></a>',
+			'spam'      => '<a href="http://example.org/wp-admin/edit-comments.php?comment_status=spam">Spam <span class="count">(<span class="spam-count">0</span>)</span></a>',
+			'trash'     => '<a href="http://example.org/wp-admin/edit-comments.php?comment_status=trash">Trash <span class="count">(<span class="trash-count">0</span>)</span></a>',
 		);
 		$this->assertSame( $expected, $this->table->get_views() );
 	}

--- a/tests/phpunit/tests/admin/wpCommentsListTable.php
+++ b/tests/phpunit/tests/admin/wpCommentsListTable.php
@@ -205,7 +205,7 @@ OPTIONS;
 
 		$expected = array(
 			'all'       => '<a href="http://example.org/wp-admin/edit-comments.php?comment_status=all" class="current" aria-current="page">All <span class="count">(<span class="all-count">0</span>)</span></a>',
-			'mine'      => '<a href="http://example.org/wp-admin/edit-comments.php?comment_status=mine&user_id=0">Mine <span class="count">(<span class="mine-count">0</span>)</span></a>',
+			'mine'      => '<a href="http://example.org/wp-admin/edit-comments.php?comment_status=mine&#038;user_id=0">Mine <span class="count">(<span class="mine-count">0</span>)</span></a>',
 			'moderated' => '<a href="http://example.org/wp-admin/edit-comments.php?comment_status=moderated">Pending <span class="count">(<span class="pending-count">0</span>)</span></a>',
 			'approved'  => '<a href="http://example.org/wp-admin/edit-comments.php?comment_status=approved">Approved <span class="count">(<span class="approved-count">0</span>)</span></a>',
 			'spam'      => '<a href="http://example.org/wp-admin/edit-comments.php?comment_status=spam">Spam <span class="count">(<span class="spam-count">0</span>)</span></a>',

--- a/tests/phpunit/tests/admin/wpCommentsListTable.php
+++ b/tests/phpunit/tests/admin/wpCommentsListTable.php
@@ -195,4 +195,23 @@ OPTIONS;
 		$this->assertStringContainsString( 'column-date sorted desc', $output, 'Mismatch of CSS classes for the comment date column.' );
 	}
 
+	/**
+	 * @ticket 42066
+	 *
+	 * @covers WP_Comments_List_Table::get_views
+	 */
+	public function test_get_views_should_return_views_by_default() {
+		$this->table->prepare_items();
+
+		$expected = array(
+			'all'       => '<a href=\'http://example.org/wp-admin/edit-comments.php?comment_status=all\' class="current" aria-current="page">All <span class="count">(<span class="all-count">0</span>)</span></a>',
+			'mine'      => '<a href=\'http://example.org/wp-admin/edit-comments.php?comment_status=mine&user_id=0\'>Mine <span class="count">(<span class="mine-count">0</span>)</span></a>',
+			'moderated' => '<a href=\'http://example.org/wp-admin/edit-comments.php?comment_status=moderated\'>Pending <span class="count">(<span class="pending-count">0</span>)</span></a>',
+			'approved'  => '<a href=\'http://example.org/wp-admin/edit-comments.php?comment_status=approved\'>Approved <span class="count">(<span class="approved-count">0</span>)</span></a>',
+			'spam'      => '<a href=\'http://example.org/wp-admin/edit-comments.php?comment_status=spam\'>Spam <span class="count">(<span class="spam-count">0</span>)</span></a>',
+			'trash'     => '<a href=\'http://example.org/wp-admin/edit-comments.php?comment_status=trash\'>Trash <span class="count">(<span class="trash-count">0</span>)</span></a>',
+		);
+		$this->assertSame( $expected, $this->table->get_views() );
+	}
+
 }

--- a/tests/phpunit/tests/admin/wpListTable.php
+++ b/tests/phpunit/tests/admin/wpListTable.php
@@ -124,23 +124,23 @@ class Tests_Admin_WpListTable extends WP_UnitTestCase {
 	}
 
 	/**
-		 * Tests the "get_views_links()" method.
-		 *
-		 * @ticket 42066
-		 *
-		 * @covers WP_List_Table::get_views_links
-		 *
-		 * @dataProvider data_get_views_links
-		 *
-		 * @param array $link_data {
-		 *     An array of link data.
-		 *
-		 *     @type string $url     The link URL.
-		 *     @type string $label   The link label.
-		 *     @type bool   $current Optional. Whether this is the currently selected view.
-		 * }
-		 * @param array $expected
-		 */
+	 * Tests the "get_views_links()" method.
+	 *
+	 * @ticket 42066
+	 *
+	 * @covers WP_List_Table::get_views_links
+	 *
+	 * @dataProvider data_get_views_links
+	 *
+	 * @param array $link_data {
+	 *     An array of link data.
+	 *
+	 *     @type string $url     The link URL.
+	 *     @type string $label   The link label.
+	 *     @type bool   $current Optional. Whether this is the currently selected view.
+	 * }
+	 * @param array $expected
+	 */
 	public function test_get_views_links( $link_data, $expected ) {
 		$get_views_links = new ReflectionMethod( self::$list_table, 'get_views_links' );
 		$get_views_links->setAccessible( true );

--- a/tests/phpunit/tests/admin/wpListTable.php
+++ b/tests/phpunit/tests/admin/wpListTable.php
@@ -8,6 +8,24 @@
 class Tests_Admin_WpListTable extends WP_UnitTestCase {
 
 	/**
+	 * List table.
+	 *
+	 * @var WP_List_Table $list_table
+	 */
+	protected static $list_table;
+
+	public static function set_up_before_class() {
+		global $hook_suffix;
+
+		parent::set_up_before_class();
+
+		require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
+
+		$hook_suffix      = '_wp_tests';
+		self::$list_table = new WP_List_Table();
+	}
+
+	/**
 	 * Tests that `WP_List_Table::get_column_info()` only adds the primary
 	 * column header when necessary.
 	 *
@@ -103,5 +121,227 @@ class Tests_Admin_WpListTable extends WP_UnitTestCase {
 		$datasets['WP_Plugins_List_Table - three columns']['expected_hook_count']   = 0;
 
 		return $datasets;
+	}
+
+	/**
+		 * Tests the "get_views_links()" method.
+		 *
+		 * @ticket 42066
+		 *
+		 * @covers WP_List_Table::get_views_links
+		 *
+		 * @dataProvider data_get_views_links
+		 *
+		 * @param array $link_data {
+		 *     An array of link data.
+		 *
+		 *     @type string $url     The link URL.
+		 *     @type string $label   The link label.
+		 *     @type bool   $current Optional. Whether this is the currently selected view.
+		 * }
+		 * @param array $expected
+		 */
+	public function test_get_views_links( $link_data, $expected ) {
+		$get_views_links = new ReflectionMethod( self::$list_table, 'get_views_links' );
+		$get_views_links->setAccessible( true );
+
+		$actual = $get_views_links->invokeArgs( self::$list_table, array( $link_data ) );
+
+		$this->assertSameSetsWithIndex( $expected, $actual );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_get_views_links() {
+		return array(
+			'one "current" link'                           => array(
+				'link_data' => array(
+					'all'       => array(
+						'url'     => 'https://example.org/',
+						'label'   => 'All',
+						'current' => true,
+					),
+					'activated' => array(
+						'url'     => add_query_arg( 'status', 'activated', 'https://example.org/' ),
+						'label'   => 'Activated',
+						'current' => false,
+					),
+				),
+				'expected'  => array(
+					'all'       => '<a href="https://example.org/" class="current" aria-current="page">All</a>',
+					'activated' => '<a href="https://example.org/?status=activated">Activated</a>',
+				),
+			),
+			'two "current" links'                          => array(
+				'link_data' => array(
+					'all'       => array(
+						'url'     => 'https://example.org/',
+						'label'   => 'All',
+						'current' => true,
+					),
+					'activated' => array(
+						'url'     => add_query_arg( 'status', 'activated', 'https://example.org/' ),
+						'label'   => 'Activated',
+						'current' => true,
+					),
+				),
+				'expected'  => array(
+					'all'       => '<a href="https://example.org/" class="current" aria-current="page">All</a>',
+					'activated' => '<a href="https://example.org/?status=activated" class="current" aria-current="page">Activated</a>',
+				),
+			),
+			'one "current" link and one without "current" key' => array(
+				'link_data' => array(
+					'all'       => array(
+						'url'     => 'https://example.org/',
+						'label'   => 'All',
+						'current' => true,
+					),
+					'activated' => array(
+						'url'   => add_query_arg( 'status', 'activated', 'https://example.org/' ),
+						'label' => 'Activated',
+					),
+				),
+				'expected'  => array(
+					'all'       => '<a href="https://example.org/" class="current" aria-current="page">All</a>',
+					'activated' => '<a href="https://example.org/?status=activated">Activated</a>',
+				),
+			),
+			'one "current" link with escapable characters' => array(
+				'link_data' => array(
+					'all'       => array(
+						'url'     => 'https://example.org/',
+						'label'   => 'All',
+						'current' => true,
+					),
+					'activated' => array(
+						'url'     => add_query_arg(
+							array(
+								'status' => 'activated',
+								'sort'   => 'desc',
+							),
+							'https://example.org/'
+						),
+						'label'   => 'Activated',
+						'current' => false,
+					),
+				),
+				'expected'  => array(
+					'all'       => '<a href="https://example.org/" class="current" aria-current="page">All</a>',
+					'activated' => '<a href="https://example.org/?status=activated&#038;sort=desc">Activated</a>',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Tests that "get_views_links()" throws a _doing_it_wrong().
+	 *
+	 * @ticket 42066
+	 *
+	 * @covers WP_List_Table::get_views_links
+	 *
+	 * @expectedIncorrectUsage WP_List_Table::get_views_links
+	 *
+	 * @dataProvider data_get_views_links_doing_it_wrong
+	 *
+	 * @param array $link_data {
+	 *     An array of link data.
+	 *
+	 *     @type string $url     The link URL.
+	 *     @type string $label   The link label.
+	 *     @type bool   $current Optional. Whether this is the currently selected view.
+	 * }
+	 */
+	public function test_get_views_links_doing_it_wrong( $link_data ) {
+		$get_views_links = new ReflectionMethod( self::$list_table, 'get_views_links' );
+		$get_views_links->setAccessible( true );
+		$get_views_links->invokeArgs( self::$list_table, array( $link_data ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_get_views_links_doing_it_wrong() {
+		return array(
+			'non-array $link_data'               => array(
+				'link_data' => 'https://example.org, All, class="current" aria-current="page"',
+			),
+			'a link with no URL'                 => array(
+				'link_data' => array(
+					'all' => array(
+						'label'   => 'All',
+						'current' => true,
+					),
+				),
+			),
+			'a link with an empty URL'           => array(
+				'link_data' => array(
+					'all' => array(
+						'url'     => '',
+						'label'   => 'All',
+						'current' => true,
+					),
+				),
+			),
+			'a link with a URL of only spaces'   => array(
+				'link_data' => array(
+					'all' => array(
+						'url'     => '  ',
+						'label'   => 'All',
+						'current' => true,
+					),
+				),
+			),
+			'a link with a non-string URL'       => array(
+				'link_data' => array(
+					'all' => array(
+						'url'     => array(),
+						'label'   => 'All',
+						'current' => true,
+					),
+				),
+			),
+			'a link with no label'               => array(
+				'link_data' => array(
+					'all' => array(
+						'url'     => 'https://example.org/',
+						'current' => true,
+					),
+				),
+			),
+			'a link with an empty label'         => array(
+				'link_data' => array(
+					'all' => array(
+						'url'     => 'https://example.org/',
+						'label'   => '',
+						'current' => true,
+					),
+				),
+			),
+			'a link with a label of only spaces' => array(
+				'link_data' => array(
+					'all' => array(
+						'url'     => 'https://example.org/',
+						'label'   => '  ',
+						'current' => true,
+					),
+				),
+			),
+			'a link with a non-string label'     => array(
+				'link_data' => array(
+					'all' => array(
+						'url'     => 'https://example.org/',
+						'label'   => array(),
+						'current' => true,
+					),
+				),
+			),
+		);
 	}
 }

--- a/tests/phpunit/tests/admin/wpPluginInstallListTable.php
+++ b/tests/phpunit/tests/admin/wpPluginInstallListTable.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @group admin
+ *
+ * @covers WP_Plugin_Install_List_Table
+ */
+class Tests_Admin_wpPluginInstallListTable extends WP_UnitTestCase {
+	/**
+	 * @var WP_Plugin_Install_List_Table
+	 */
+	public $table = false;
+
+	public function set_up() {
+		parent::set_up();
+		$this->table = _get_list_table( 'WP_Plugin_Install_List_Table', array( 'screen' => 'plugin-install' ) );
+	}
+
+	/**
+	 * @ticket 42066
+	 *
+	 * @covers WP_Plugin_Install_List_Table::get_views
+	 */
+	public function test_get_views_should_return_no_views_by_default() {
+		$this->assertSame( array(), $this->table->get_views() );
+	}
+}

--- a/tests/phpunit/tests/admin/wpPluginsListTable.php
+++ b/tests/phpunit/tests/admin/wpPluginsListTable.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * @group admin
+ *
+ * @covers WP_Plugins_List_Table
+ */
+class Tests_Admin_wpPluginsListTable extends WP_UnitTestCase {
+	/**
+	 * @var WP_Plugins_List_Table
+	 */
+	public $table = false;
+
+	public function set_up() {
+		parent::set_up();
+		$this->table = _get_list_table( 'WP_Plugins_List_Table', array( 'screen' => 'plugins' ) );
+	}
+
+	/**
+	 * @ticket 42066
+	 *
+	 * @covers WP_Plugins_List_Table::get_views
+	 */
+	public function test_get_views_should_return_views_by_default() {
+		global $totals;
+
+		$totals_backup = $totals;
+		$totals        = array(
+			'all'                  => 45,
+			'active'               => 1,
+			'recently_activated'   => 2,
+			'inactive'             => 3,
+			'mustuse'              => 4,
+			'dropins'              => 5,
+			'paused'               => 6,
+			'upgrade'              => 7,
+			'auto-update-enabled'  => 8,
+			'auto-update-disabled' => 9,
+		);
+
+		$expected = array(
+			'all'                  => '<a href=\'plugins.php?plugin_status=all\' class="current" aria-current="page">All <span class="count">(45)</span></a>',
+			'active'               => '<a href=\'plugins.php?plugin_status=active\'>Active <span class="count">(1)</span></a>',
+			'recently_activated'   => '<a href=\'plugins.php?plugin_status=recently_activated\'>Recently Active <span class="count">(2)</span></a>',
+			'inactive'             => '<a href=\'plugins.php?plugin_status=inactive\'>Inactive <span class="count">(3)</span></a>',
+			'mustuse'              => '<a href=\'plugins.php?plugin_status=mustuse\'>Must-Use <span class="count">(4)</span></a>',
+			'dropins'              => '<a href=\'plugins.php?plugin_status=dropins\'>Drop-ins <span class="count">(5)</span></a>',
+			'paused'               => '<a href=\'plugins.php?plugin_status=paused\'>Paused <span class="count">(6)</span></a>',
+			'upgrade'              => '<a href=\'plugins.php?plugin_status=upgrade\'>Update Available <span class="count">(7)</span></a>',
+			'auto-update-enabled'  => '<a href=\'plugins.php?plugin_status=auto-update-enabled\'>Auto-updates Enabled <span class="count">(8)</span></a>',
+			'auto-update-disabled' => '<a href=\'plugins.php?plugin_status=auto-update-disabled\'>Auto-updates Disabled <span class="count">(9)</span></a>',
+		);
+
+		$actual = $this->table->get_views();
+		$totals = $totals_backup;
+
+		$this->assertSame( $expected, $actual );
+	}
+}

--- a/tests/phpunit/tests/admin/wpPluginsListTable.php
+++ b/tests/phpunit/tests/admin/wpPluginsListTable.php
@@ -39,16 +39,16 @@ class Tests_Admin_wpPluginsListTable extends WP_UnitTestCase {
 		);
 
 		$expected = array(
-			'all'                  => '<a href=\'plugins.php?plugin_status=all\' class="current" aria-current="page">All <span class="count">(45)</span></a>',
-			'active'               => '<a href=\'plugins.php?plugin_status=active\'>Active <span class="count">(1)</span></a>',
-			'recently_activated'   => '<a href=\'plugins.php?plugin_status=recently_activated\'>Recently Active <span class="count">(2)</span></a>',
-			'inactive'             => '<a href=\'plugins.php?plugin_status=inactive\'>Inactive <span class="count">(3)</span></a>',
-			'mustuse'              => '<a href=\'plugins.php?plugin_status=mustuse\'>Must-Use <span class="count">(4)</span></a>',
-			'dropins'              => '<a href=\'plugins.php?plugin_status=dropins\'>Drop-ins <span class="count">(5)</span></a>',
-			'paused'               => '<a href=\'plugins.php?plugin_status=paused\'>Paused <span class="count">(6)</span></a>',
-			'upgrade'              => '<a href=\'plugins.php?plugin_status=upgrade\'>Update Available <span class="count">(7)</span></a>',
-			'auto-update-enabled'  => '<a href=\'plugins.php?plugin_status=auto-update-enabled\'>Auto-updates Enabled <span class="count">(8)</span></a>',
-			'auto-update-disabled' => '<a href=\'plugins.php?plugin_status=auto-update-disabled\'>Auto-updates Disabled <span class="count">(9)</span></a>',
+			'all'                  => '<a href="plugins.php?plugin_status=all" class="current" aria-current="page">All <span class="count">(45)</span></a>',
+			'active'               => '<a href="plugins.php?plugin_status=active">Active <span class="count">(1)</span></a>',
+			'recently_activated'   => '<a href="plugins.php?plugin_status=recently_activated">Recently Active <span class="count">(2)</span></a>',
+			'inactive'             => '<a href="plugins.php?plugin_status=inactive">Inactive <span class="count">(3)</span></a>',
+			'mustuse'              => '<a href="plugins.php?plugin_status=mustuse">Must-Use <span class="count">(4)</span></a>',
+			'dropins'              => '<a href="plugins.php?plugin_status=dropins">Drop-ins <span class="count">(5)</span></a>',
+			'paused'               => '<a href="plugins.php?plugin_status=paused">Paused <span class="count">(6)</span></a>',
+			'upgrade'              => '<a href="plugins.php?plugin_status=upgrade">Update Available <span class="count">(7)</span></a>',
+			'auto-update-enabled'  => '<a href="plugins.php?plugin_status=auto-update-enabled">Auto-updates Enabled <span class="count">(8)</span></a>',
+			'auto-update-disabled' => '<a href="plugins.php?plugin_status=auto-update-disabled">Auto-updates Disabled <span class="count">(9)</span></a>',
 		);
 
 		$actual = $this->table->get_views();

--- a/tests/phpunit/tests/admin/wpPostCommentsListTable.php
+++ b/tests/phpunit/tests/admin/wpPostCommentsListTable.php
@@ -27,7 +27,7 @@ class Tests_Admin_wpPostCommentsListTable extends WP_UnitTestCase {
 
 		$expected = array(
 			'all'       => '<a href="http://example.org/wp-admin/edit-comments.php?comment_status=all" class="current" aria-current="page">All <span class="count">(<span class="all-count">0</span>)</span></a>',
-			'mine'      => '<a href="http://example.org/wp-admin/edit-comments.php?comment_status=mine&user_id=0">Mine <span class="count">(<span class="mine-count">0</span>)</span></a>',
+			'mine'      => '<a href="http://example.org/wp-admin/edit-comments.php?comment_status=mine&#038;user_id=0">Mine <span class="count">(<span class="mine-count">0</span>)</span></a>',
 			'moderated' => '<a href="http://example.org/wp-admin/edit-comments.php?comment_status=moderated">Pending <span class="count">(<span class="pending-count">0</span>)</span></a>',
 			'approved'  => '<a href="http://example.org/wp-admin/edit-comments.php?comment_status=approved">Approved <span class="count">(<span class="approved-count">0</span>)</span></a>',
 			'spam'      => '<a href="http://example.org/wp-admin/edit-comments.php?comment_status=spam">Spam <span class="count">(<span class="spam-count">0</span>)</span></a>',

--- a/tests/phpunit/tests/admin/wpPostCommentsListTable.php
+++ b/tests/phpunit/tests/admin/wpPostCommentsListTable.php
@@ -26,12 +26,12 @@ class Tests_Admin_wpPostCommentsListTable extends WP_UnitTestCase {
 		$this->table->prepare_items();
 
 		$expected = array(
-			'all'       => '<a href=\'http://example.org/wp-admin/edit-comments.php?comment_status=all\' class="current" aria-current="page">All <span class="count">(<span class="all-count">0</span>)</span></a>',
-			'mine'      => '<a href=\'http://example.org/wp-admin/edit-comments.php?comment_status=mine&user_id=0\'>Mine <span class="count">(<span class="mine-count">0</span>)</span></a>',
-			'moderated' => '<a href=\'http://example.org/wp-admin/edit-comments.php?comment_status=moderated\'>Pending <span class="count">(<span class="pending-count">0</span>)</span></a>',
-			'approved'  => '<a href=\'http://example.org/wp-admin/edit-comments.php?comment_status=approved\'>Approved <span class="count">(<span class="approved-count">0</span>)</span></a>',
-			'spam'      => '<a href=\'http://example.org/wp-admin/edit-comments.php?comment_status=spam\'>Spam <span class="count">(<span class="spam-count">0</span>)</span></a>',
-			'trash'     => '<a href=\'http://example.org/wp-admin/edit-comments.php?comment_status=trash\'>Trash <span class="count">(<span class="trash-count">0</span>)</span></a>',
+			'all'       => '<a href="http://example.org/wp-admin/edit-comments.php?comment_status=all" class="current" aria-current="page">All <span class="count">(<span class="all-count">0</span>)</span></a>',
+			'mine'      => '<a href="http://example.org/wp-admin/edit-comments.php?comment_status=mine&user_id=0">Mine <span class="count">(<span class="mine-count">0</span>)</span></a>',
+			'moderated' => '<a href="http://example.org/wp-admin/edit-comments.php?comment_status=moderated">Pending <span class="count">(<span class="pending-count">0</span>)</span></a>',
+			'approved'  => '<a href="http://example.org/wp-admin/edit-comments.php?comment_status=approved">Approved <span class="count">(<span class="approved-count">0</span>)</span></a>',
+			'spam'      => '<a href="http://example.org/wp-admin/edit-comments.php?comment_status=spam">Spam <span class="count">(<span class="spam-count">0</span>)</span></a>',
+			'trash'     => '<a href="http://example.org/wp-admin/edit-comments.php?comment_status=trash">Trash <span class="count">(<span class="trash-count">0</span>)</span></a>',
 		);
 		$this->assertSame( $expected, $this->table->get_views() );
 	}

--- a/tests/phpunit/tests/admin/wpPostCommentsListTable.php
+++ b/tests/phpunit/tests/admin/wpPostCommentsListTable.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @group admin
+ *
+ * @covers WP_Post_Comments_List_Table
+ */
+class Tests_Admin_wpPostCommentsListTable extends WP_UnitTestCase {
+
+	/**
+	 * @var WP_Post_Comments_List_Table
+	 */
+	protected $table;
+
+	function set_up() {
+		parent::set_up();
+		$this->table = _get_list_table( 'WP_Post_Comments_List_Table', array( 'screen' => 'edit-post-comments' ) );
+	}
+
+	/**
+	 * @ticket 42066
+	 *
+	 * @covers WP_Post_Comments_List_Table::get_views
+	 */
+	public function test_get_views_should_return_views_by_default() {
+		$this->table->prepare_items();
+
+		$expected = array(
+			'all'       => '<a href=\'http://example.org/wp-admin/edit-comments.php?comment_status=all\' class="current" aria-current="page">All <span class="count">(<span class="all-count">0</span>)</span></a>',
+			'mine'      => '<a href=\'http://example.org/wp-admin/edit-comments.php?comment_status=mine&user_id=0\'>Mine <span class="count">(<span class="mine-count">0</span>)</span></a>',
+			'moderated' => '<a href=\'http://example.org/wp-admin/edit-comments.php?comment_status=moderated\'>Pending <span class="count">(<span class="pending-count">0</span>)</span></a>',
+			'approved'  => '<a href=\'http://example.org/wp-admin/edit-comments.php?comment_status=approved\'>Approved <span class="count">(<span class="approved-count">0</span>)</span></a>',
+			'spam'      => '<a href=\'http://example.org/wp-admin/edit-comments.php?comment_status=spam\'>Spam <span class="count">(<span class="spam-count">0</span>)</span></a>',
+			'trash'     => '<a href=\'http://example.org/wp-admin/edit-comments.php?comment_status=trash\'>Trash <span class="count">(<span class="trash-count">0</span>)</span></a>',
+		);
+		$this->assertSame( $expected, $this->table->get_views() );
+	}
+
+}

--- a/tests/phpunit/tests/admin/wpPostsListTable.php
+++ b/tests/phpunit/tests/admin/wpPostsListTable.php
@@ -319,4 +319,26 @@ class Tests_Admin_wpPostsListTable extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( 'id="delete_all"', $output );
 	}
 
+	/**
+	 * @ticket 42066
+	 *
+	 * @covers WP_Posts_List_Table::get_views
+	 */
+	public function test_get_views_should_return_views_by_default() {
+		global $avail_post_stati;
+
+		$avail_post_stati_backup = $avail_post_stati;
+		$avail_post_stati        = get_available_post_statuses();
+
+		$actual           = $this->table->get_views();
+		$avail_post_stati = $avail_post_stati_backup;
+
+		$expected = array(
+			'all'     => '<a href="edit.php?post_type=page">All <span class="count">(38)</span></a>',
+			'publish' => '<a href="edit.php?post_status=publish&#038;post_type=page">Published <span class="count">(38)</span></a>',
+		);
+
+		$this->assertSame( $expected, $actual );
+	}
+
 }

--- a/tests/phpunit/tests/admin/wpPrivacyRequestsTable.php
+++ b/tests/phpunit/tests/admin/wpPrivacyRequestsTable.php
@@ -198,4 +198,17 @@ class Tests_Admin_wpPrivacyRequestsTable extends WP_UnitTestCase {
 			),
 		);
 	}
+
+	/**
+	 * @ticket 42066
+	 *
+	 * @covers WP_Privacy_Requests_List_Table::get_views
+	 */
+	public function test_get_views_should_return_views_by_default() {
+		$expected = array(
+			'all' => '<a href="http://example.org/wp-admin/export-personal-data.php" class="current" aria-current="page">All <span class="count">(0)</span></a>',
+		);
+
+		$this->assertSame( $expected, $this->get_mocked_class_instance()->get_views() );
+	}
 }

--- a/tests/phpunit/tests/admin/wpThemeInstallListTable.php
+++ b/tests/phpunit/tests/admin/wpThemeInstallListTable.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @group admin
+ *
+ * @covers WP_Theme_Install_List_Table
+ */
+class Tests_Admin_wpThemeInstallListTable extends WP_UnitTestCase {
+	/**
+	 * @var WP_Theme_Install_List_Table
+	 */
+	public $table = false;
+
+	public function set_up() {
+		parent::set_up();
+		$this->table = _get_list_table( 'WP_Theme_Install_List_Table', array( 'screen' => 'theme-install' ) );
+	}
+
+	/**
+	 * @ticket 42066
+	 *
+	 * @covers WP_Theme_Install_List_Table::get_views
+	 */
+	public function test_get_views_should_return_no_views_by_default() {
+		$this->assertSame( array(), $this->table->get_views() );
+	}
+}

--- a/tests/phpunit/tests/admin/wpUsersListTable.php
+++ b/tests/phpunit/tests/admin/wpUsersListTable.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @group admin
+ *
+ * @covers WP_Users_List_Table
+ */
+class Tests_Admin_wpUsersListTable extends WP_UnitTestCase {
+	/**
+	 * @var WP_Users_List_Table
+	 */
+	public $table = false;
+
+	public function set_up() {
+		parent::set_up();
+		$this->table = _get_list_table( 'WP_Users_List_Table', array( 'screen' => 'users' ) );
+	}
+
+	/**
+	 * @ticket 42066
+	 *
+	 * @covers WP_Users_List_Table::get_views
+	 */
+	public function test_get_views_should_return_views_by_default() {
+		$expected = array(
+			'all'           => '<a href="users.php" class="current" aria-current="page">All <span class="count">(1)</span></a>',
+			'administrator' => '<a href=\'users.php?role=administrator\'>Administrator <span class="count">(1)</span></a>',
+		);
+
+		$this->assertSame( $expected, $this->table->get_views() );
+	}
+}

--- a/tests/phpunit/tests/admin/wpUsersListTable.php
+++ b/tests/phpunit/tests/admin/wpUsersListTable.php
@@ -24,7 +24,7 @@ class Tests_Admin_wpUsersListTable extends WP_UnitTestCase {
 	public function test_get_views_should_return_views_by_default() {
 		$expected = array(
 			'all'           => '<a href="users.php" class="current" aria-current="page">All <span class="count">(1)</span></a>',
-			'administrator' => '<a href=\'users.php?role=administrator\'>Administrator <span class="count">(1)</span></a>',
+			'administrator' => '<a href="users.php?role=administrator">Administrator <span class="count">(1)</span></a>',
 		);
 
 		$this->assertSame( $expected, $this->table->get_views() );

--- a/tests/phpunit/tests/multisite/wpMsSitesListTable.php
+++ b/tests/phpunit/tests/multisite/wpMsSitesListTable.php
@@ -230,5 +230,17 @@ if ( is_multisite() ) :
 
 			$this->assertSameSets( $expected, $items );
 		}
+
+		/**
+		 * @ticket 42066
+		 */
+		public function test_get_views_should_return_views_by_default() {
+			$expected = array(
+				'all'    => '<a href="sites.php" class="current" aria-current="page">All <span class="count">(14)</span></a>',
+				'public' => '<a href="sites.php?status=public">Public <span class="count">(14)</span></a>',
+			);
+
+			$this->assertSame( $expected, $this->table->get_views() );
+		}
 	}
 endif;

--- a/tests/phpunit/tests/multisite/wpMsThemesListTable.php
+++ b/tests/phpunit/tests/multisite/wpMsThemesListTable.php
@@ -109,13 +109,13 @@ if ( is_multisite() ) :
 			);
 
 			$expected = array(
-				'all'                  => '<a href=\'themes.php?theme_status=all\' class="current" aria-current="page">All <span class="count">(21)</span></a>',
-				'enabled'              => '<a href=\'themes.php?theme_status=enabled\'>Enabled <span class="count">(1)</span></a>',
-				'disabled'             => '<a href=\'themes.php?theme_status=disabled\'>Disabled <span class="count">(2)</span></a>',
-				'upgrade'              => '<a href=\'themes.php?theme_status=upgrade\'>Update Available <span class="count">(3)</span></a>',
-				'broken'               => '<a href=\'themes.php?theme_status=broken\'>Broken <span class="count">(4)</span></a>',
-				'auto-update-enabled'  => '<a href=\'themes.php?theme_status=auto-update-enabled\'>Auto-updates Enabled <span class="count">(5)</span></a>',
-				'auto-update-disabled' => '<a href=\'themes.php?theme_status=auto-update-disabled\'>Auto-updates Disabled <span class="count">(6)</span></a>',
+				'all'                  => '<a href="themes.php?theme_status=all" class="current" aria-current="page">All <span class="count">(21)</span></a>',
+				'enabled'              => '<a href="themes.php?theme_status=enabled">Enabled <span class="count">(1)</span></a>',
+				'disabled'             => '<a href="themes.php?theme_status=disabled">Disabled <span class="count">(2)</span></a>',
+				'upgrade'              => '<a href="themes.php?theme_status=upgrade">Update Available <span class="count">(3)</span></a>',
+				'broken'               => '<a href="themes.php?theme_status=broken">Broken <span class="count">(4)</span></a>',
+				'auto-update-enabled'  => '<a href="themes.php?theme_status=auto-update-enabled">Auto-updates Enabled <span class="count">(5)</span></a>',
+				'auto-update-disabled' => '<a href="themes.php?theme_status=auto-update-disabled">Auto-updates Disabled <span class="count">(6)</span></a>',
 			);
 
 			$actual = $this->table->get_views();

--- a/tests/phpunit/tests/multisite/wpMsThemesListTable.php
+++ b/tests/phpunit/tests/multisite/wpMsThemesListTable.php
@@ -1,127 +1,125 @@
 <?php
 
-if ( is_multisite() ) :
+/**
+ * @group ms-required
+ * @group admin
+ * @group network-admin
+ *
+ * @covers WP_MS_Themes_List_Table
+ */
+class Tests_Multisite_wpMsThemesListTable extends WP_UnitTestCase {
+	protected static $site_ids;
 
 	/**
-	 * @group admin
-	 * @group network-admin
-	 *
-	 * @covers WP_MS_Themes_List_Table
+	 * @var WP_MS_Themes_List_Table
 	 */
-	class Tests_Multisite_wpMsThemesListTable extends WP_UnitTestCase {
-		protected static $site_ids;
+	public $table = false;
 
-		/**
-		 * @var WP_MS_Themes_List_Table
-		 */
-		public $table = false;
+	public function set_up() {
+		parent::set_up();
+		$this->table = _get_list_table( 'WP_MS_Themes_List_Table', array( 'screen' => 'ms-themes' ) );
+	}
 
-		public function set_up() {
-			parent::set_up();
-			$this->table = _get_list_table( 'WP_MS_Themes_List_Table', array( 'screen' => 'ms-themes' ) );
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$site_ids = array(
+			'wordpress.org/'          => array(
+				'domain' => 'wordpress.org',
+				'path'   => '/',
+			),
+			'wordpress.org/foo/'      => array(
+				'domain' => 'wordpress.org',
+				'path'   => '/foo/',
+			),
+			'wordpress.org/foo/bar/'  => array(
+				'domain' => 'wordpress.org',
+				'path'   => '/foo/bar/',
+			),
+			'wordpress.org/afoo/'     => array(
+				'domain' => 'wordpress.org',
+				'path'   => '/afoo/',
+			),
+			'make.wordpress.org/'     => array(
+				'domain' => 'make.wordpress.org',
+				'path'   => '/',
+			),
+			'make.wordpress.org/foo/' => array(
+				'domain' => 'make.wordpress.org',
+				'path'   => '/foo/',
+			),
+			'www.w.org/'              => array(
+				'domain' => 'www.w.org',
+				'path'   => '/',
+			),
+			'www.w.org/foo/'          => array(
+				'domain' => 'www.w.org',
+				'path'   => '/foo/',
+			),
+			'www.w.org/foo/bar/'      => array(
+				'domain' => 'www.w.org',
+				'path'   => '/foo/bar/',
+			),
+			'test.example.org/'       => array(
+				'domain' => 'test.example.org',
+				'path'   => '/',
+			),
+			'test2.example.org/'      => array(
+				'domain' => 'test2.example.org',
+				'path'   => '/',
+			),
+			'test3.example.org/zig/'  => array(
+				'domain' => 'test3.example.org',
+				'path'   => '/zig/',
+			),
+			'atest.example.org/'      => array(
+				'domain' => 'atest.example.org',
+				'path'   => '/',
+			),
+		);
+
+		foreach ( self::$site_ids as &$id ) {
+			$id = $factory->blog->create( $id );
 		}
+		unset( $id );
+	}
 
-		public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
-			self::$site_ids = array(
-				'wordpress.org/'          => array(
-					'domain' => 'wordpress.org',
-					'path'   => '/',
-				),
-				'wordpress.org/foo/'      => array(
-					'domain' => 'wordpress.org',
-					'path'   => '/foo/',
-				),
-				'wordpress.org/foo/bar/'  => array(
-					'domain' => 'wordpress.org',
-					'path'   => '/foo/bar/',
-				),
-				'wordpress.org/afoo/'     => array(
-					'domain' => 'wordpress.org',
-					'path'   => '/afoo/',
-				),
-				'make.wordpress.org/'     => array(
-					'domain' => 'make.wordpress.org',
-					'path'   => '/',
-				),
-				'make.wordpress.org/foo/' => array(
-					'domain' => 'make.wordpress.org',
-					'path'   => '/foo/',
-				),
-				'www.w.org/'              => array(
-					'domain' => 'www.w.org',
-					'path'   => '/',
-				),
-				'www.w.org/foo/'          => array(
-					'domain' => 'www.w.org',
-					'path'   => '/foo/',
-				),
-				'www.w.org/foo/bar/'      => array(
-					'domain' => 'www.w.org',
-					'path'   => '/foo/bar/',
-				),
-				'test.example.org/'       => array(
-					'domain' => 'test.example.org',
-					'path'   => '/',
-				),
-				'test2.example.org/'      => array(
-					'domain' => 'test2.example.org',
-					'path'   => '/',
-				),
-				'test3.example.org/zig/'  => array(
-					'domain' => 'test3.example.org',
-					'path'   => '/zig/',
-				),
-				'atest.example.org/'      => array(
-					'domain' => 'atest.example.org',
-					'path'   => '/',
-				),
-			);
-
-			foreach ( self::$site_ids as &$id ) {
-				$id = $factory->blog->create( $id );
-			}
-			unset( $id );
-		}
-
-		public static function wpTearDownAfterClass() {
-			foreach ( self::$site_ids as $site_id ) {
-				wp_delete_site( $site_id );
-			}
-		}
-
-		/**
-		 * @ticket 42066
-		 *
-		 * @covers WP_MS_Themes_List_Table::get_views
-		 */
-		public function test_get_views_should_return_views_by_default() {
-			global $totals;
-
-			$totals_backup = $totals;
-			$totals        = array(
-				'all'                  => 21,
-				'enabled'              => 1,
-				'disabled'             => 2,
-				'upgrade'              => 3,
-				'broken'               => 4,
-				'auto-update-enabled'  => 5,
-				'auto-update-disabled' => 6,
-			);
-
-			$expected = array(
-				'all'                  => '<a href="themes.php?theme_status=all" class="current" aria-current="page">All <span class="count">(21)</span></a>',
-				'enabled'              => '<a href="themes.php?theme_status=enabled">Enabled <span class="count">(1)</span></a>',
-				'disabled'             => '<a href="themes.php?theme_status=disabled">Disabled <span class="count">(2)</span></a>',
-				'upgrade'              => '<a href="themes.php?theme_status=upgrade">Update Available <span class="count">(3)</span></a>',
-				'broken'               => '<a href="themes.php?theme_status=broken">Broken <span class="count">(4)</span></a>',
-				'auto-update-enabled'  => '<a href="themes.php?theme_status=auto-update-enabled">Auto-updates Enabled <span class="count">(5)</span></a>',
-				'auto-update-disabled' => '<a href="themes.php?theme_status=auto-update-disabled">Auto-updates Disabled <span class="count">(6)</span></a>',
-			);
-
-			$actual = $this->table->get_views();
-			$totals = $totals_backup;
-
-			$this->assertSame( $expected, $actual );
+	public static function wpTearDownAfterClass() {
+		foreach ( self::$site_ids as $site_id ) {
+			wp_delete_site( $site_id );
 		}
 	}
-endif;
+
+	/**
+	 * @ticket 42066
+	 *
+	 * @covers WP_MS_Themes_List_Table::get_views
+	 */
+	public function test_get_views_should_return_views_by_default() {
+		global $totals;
+
+		$totals_backup = $totals;
+		$totals        = array(
+			'all'                  => 21,
+			'enabled'              => 1,
+			'disabled'             => 2,
+			'upgrade'              => 3,
+			'broken'               => 4,
+			'auto-update-enabled'  => 5,
+			'auto-update-disabled' => 6,
+		);
+
+		$expected = array(
+			'all'                  => '<a href="themes.php?theme_status=all" class="current" aria-current="page">All <span class="count">(21)</span></a>',
+			'enabled'              => '<a href="themes.php?theme_status=enabled">Enabled <span class="count">(1)</span></a>',
+			'disabled'             => '<a href="themes.php?theme_status=disabled">Disabled <span class="count">(2)</span></a>',
+			'upgrade'              => '<a href="themes.php?theme_status=upgrade">Update Available <span class="count">(3)</span></a>',
+			'broken'               => '<a href="themes.php?theme_status=broken">Broken <span class="count">(4)</span></a>',
+			'auto-update-enabled'  => '<a href="themes.php?theme_status=auto-update-enabled">Auto-updates Enabled <span class="count">(5)</span></a>',
+			'auto-update-disabled' => '<a href="themes.php?theme_status=auto-update-disabled">Auto-updates Disabled <span class="count">(6)</span></a>',
+		);
+
+		$actual = $this->table->get_views();
+		$totals = $totals_backup;
+
+		$this->assertSame( $expected, $actual );
+	}
+}

--- a/tests/phpunit/tests/multisite/wpMsThemesListTable.php
+++ b/tests/phpunit/tests/multisite/wpMsThemesListTable.php
@@ -1,0 +1,127 @@
+<?php
+
+if ( is_multisite() ) :
+
+	/**
+	 * @group admin
+	 * @group network-admin
+	 *
+	 * @covers WP_MS_Themes_List_Table
+	 */
+	class Tests_Multisite_wpMsThemesListTable extends WP_UnitTestCase {
+		protected static $site_ids;
+
+		/**
+		 * @var WP_MS_Themes_List_Table
+		 */
+		public $table = false;
+
+		public function set_up() {
+			parent::set_up();
+			$this->table = _get_list_table( 'WP_MS_Themes_List_Table', array( 'screen' => 'ms-themes' ) );
+		}
+
+		public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+			self::$site_ids = array(
+				'wordpress.org/'          => array(
+					'domain' => 'wordpress.org',
+					'path'   => '/',
+				),
+				'wordpress.org/foo/'      => array(
+					'domain' => 'wordpress.org',
+					'path'   => '/foo/',
+				),
+				'wordpress.org/foo/bar/'  => array(
+					'domain' => 'wordpress.org',
+					'path'   => '/foo/bar/',
+				),
+				'wordpress.org/afoo/'     => array(
+					'domain' => 'wordpress.org',
+					'path'   => '/afoo/',
+				),
+				'make.wordpress.org/'     => array(
+					'domain' => 'make.wordpress.org',
+					'path'   => '/',
+				),
+				'make.wordpress.org/foo/' => array(
+					'domain' => 'make.wordpress.org',
+					'path'   => '/foo/',
+				),
+				'www.w.org/'              => array(
+					'domain' => 'www.w.org',
+					'path'   => '/',
+				),
+				'www.w.org/foo/'          => array(
+					'domain' => 'www.w.org',
+					'path'   => '/foo/',
+				),
+				'www.w.org/foo/bar/'      => array(
+					'domain' => 'www.w.org',
+					'path'   => '/foo/bar/',
+				),
+				'test.example.org/'       => array(
+					'domain' => 'test.example.org',
+					'path'   => '/',
+				),
+				'test2.example.org/'      => array(
+					'domain' => 'test2.example.org',
+					'path'   => '/',
+				),
+				'test3.example.org/zig/'  => array(
+					'domain' => 'test3.example.org',
+					'path'   => '/zig/',
+				),
+				'atest.example.org/'      => array(
+					'domain' => 'atest.example.org',
+					'path'   => '/',
+				),
+			);
+
+			foreach ( self::$site_ids as &$id ) {
+				$id = $factory->blog->create( $id );
+			}
+			unset( $id );
+		}
+
+		public static function wpTearDownAfterClass() {
+			foreach ( self::$site_ids as $site_id ) {
+				wp_delete_site( $site_id );
+			}
+		}
+
+		/**
+		 * @ticket 42066
+		 *
+		 * @covers WP_MS_Themes_List_Table::get_views
+		 */
+		public function test_get_views_should_return_views_by_default() {
+			global $totals;
+
+			$totals_backup = $totals;
+			$totals        = array(
+				'all'                  => 21,
+				'enabled'              => 1,
+				'disabled'             => 2,
+				'upgrade'              => 3,
+				'broken'               => 4,
+				'auto-update-enabled'  => 5,
+				'auto-update-disabled' => 6,
+			);
+
+			$expected = array(
+				'all'                  => '<a href=\'themes.php?theme_status=all\' class="current" aria-current="page">All <span class="count">(21)</span></a>',
+				'enabled'              => '<a href=\'themes.php?theme_status=enabled\'>Enabled <span class="count">(1)</span></a>',
+				'disabled'             => '<a href=\'themes.php?theme_status=disabled\'>Disabled <span class="count">(2)</span></a>',
+				'upgrade'              => '<a href=\'themes.php?theme_status=upgrade\'>Update Available <span class="count">(3)</span></a>',
+				'broken'               => '<a href=\'themes.php?theme_status=broken\'>Broken <span class="count">(4)</span></a>',
+				'auto-update-enabled'  => '<a href=\'themes.php?theme_status=auto-update-enabled\'>Auto-updates Enabled <span class="count">(5)</span></a>',
+				'auto-update-disabled' => '<a href=\'themes.php?theme_status=auto-update-disabled\'>Auto-updates Disabled <span class="count">(6)</span></a>',
+			);
+
+			$actual = $this->table->get_views();
+			$totals = $totals_backup;
+
+			$this->assertSame( $expected, $actual );
+		}
+	}
+endif;

--- a/tests/phpunit/tests/multisite/wpMsUsersListTable.php
+++ b/tests/phpunit/tests/multisite/wpMsUsersListTable.php
@@ -95,9 +95,12 @@ if ( is_multisite() ) :
 		 * @covers WP_MS_Users_List_Table::get_views
 		 */
 		public function test_get_views_should_return_views_by_default() {
+			$all   = get_user_count();
+			$super = count( get_super_admins() );
+
 			$expected = array(
-				'all'   => '<a href="http://example.org/wp-admin/network/users.php" class="current" aria-current="page">All <span class="count">(1)</span></a>',
-				'super' => '<a href="http://example.org/wp-admin/network/users.php?role=super">Super Admin <span class="count">(1)</span></a>',
+				'all'   => '<a href="http://example.org/wp-admin/network/users.php" class="current" aria-current="page">All <span class="count">(' . $all . ')</span></a>',
+				'super' => '<a href="http://example.org/wp-admin/network/users.php?role=super">Super Admin <span class="count">(' . $super . ')</span></a>',
 			);
 
 			$this->assertSame( $expected, $this->table->get_views() );

--- a/tests/phpunit/tests/multisite/wpMsUsersListTable.php
+++ b/tests/phpunit/tests/multisite/wpMsUsersListTable.php
@@ -1,109 +1,107 @@
 <?php
 
-if ( is_multisite() ) :
+/**
+ * @group admin
+ * @group network-admin
+ * @group ms-required
+ *
+ * @covers WP_MS_Users_List_Table
+ */
+class Tests_Multisite_wpMsUsersListTable extends WP_UnitTestCase {
+	protected static $site_ids;
 
 	/**
-	 * @group admin
-	 * @group network-admin
-	 *
-	 * @covers WP_MS_Users_List_Table
+	 * @var WP_MS_Users_List_Table
 	 */
-	class Tests_Multisite_wpMsUsersListTable extends WP_UnitTestCase {
-		protected static $site_ids;
+	public $table = false;
 
-		/**
-		 * @var WP_MS_Users_List_Table
-		 */
-		public $table = false;
+	public function set_up() {
+		parent::set_up();
+		$this->table = _get_list_table( 'WP_MS_Users_List_Table', array( 'screen' => 'ms-users' ) );
+	}
 
-		public function set_up() {
-			parent::set_up();
-			$this->table = _get_list_table( 'WP_MS_Users_List_Table', array( 'screen' => 'ms-users' ) );
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$site_ids = array(
+			'wordpress.org/'          => array(
+				'domain' => 'wordpress.org',
+				'path'   => '/',
+			),
+			'wordpress.org/foo/'      => array(
+				'domain' => 'wordpress.org',
+				'path'   => '/foo/',
+			),
+			'wordpress.org/foo/bar/'  => array(
+				'domain' => 'wordpress.org',
+				'path'   => '/foo/bar/',
+			),
+			'wordpress.org/afoo/'     => array(
+				'domain' => 'wordpress.org',
+				'path'   => '/afoo/',
+			),
+			'make.wordpress.org/'     => array(
+				'domain' => 'make.wordpress.org',
+				'path'   => '/',
+			),
+			'make.wordpress.org/foo/' => array(
+				'domain' => 'make.wordpress.org',
+				'path'   => '/foo/',
+			),
+			'www.w.org/'              => array(
+				'domain' => 'www.w.org',
+				'path'   => '/',
+			),
+			'www.w.org/foo/'          => array(
+				'domain' => 'www.w.org',
+				'path'   => '/foo/',
+			),
+			'www.w.org/foo/bar/'      => array(
+				'domain' => 'www.w.org',
+				'path'   => '/foo/bar/',
+			),
+			'test.example.org/'       => array(
+				'domain' => 'test.example.org',
+				'path'   => '/',
+			),
+			'test2.example.org/'      => array(
+				'domain' => 'test2.example.org',
+				'path'   => '/',
+			),
+			'test3.example.org/zig/'  => array(
+				'domain' => 'test3.example.org',
+				'path'   => '/zig/',
+			),
+			'atest.example.org/'      => array(
+				'domain' => 'atest.example.org',
+				'path'   => '/',
+			),
+		);
+
+		foreach ( self::$site_ids as &$id ) {
+			$id = $factory->blog->create( $id );
 		}
+		unset( $id );
+	}
 
-		public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
-			self::$site_ids = array(
-				'wordpress.org/'          => array(
-					'domain' => 'wordpress.org',
-					'path'   => '/',
-				),
-				'wordpress.org/foo/'      => array(
-					'domain' => 'wordpress.org',
-					'path'   => '/foo/',
-				),
-				'wordpress.org/foo/bar/'  => array(
-					'domain' => 'wordpress.org',
-					'path'   => '/foo/bar/',
-				),
-				'wordpress.org/afoo/'     => array(
-					'domain' => 'wordpress.org',
-					'path'   => '/afoo/',
-				),
-				'make.wordpress.org/'     => array(
-					'domain' => 'make.wordpress.org',
-					'path'   => '/',
-				),
-				'make.wordpress.org/foo/' => array(
-					'domain' => 'make.wordpress.org',
-					'path'   => '/foo/',
-				),
-				'www.w.org/'              => array(
-					'domain' => 'www.w.org',
-					'path'   => '/',
-				),
-				'www.w.org/foo/'          => array(
-					'domain' => 'www.w.org',
-					'path'   => '/foo/',
-				),
-				'www.w.org/foo/bar/'      => array(
-					'domain' => 'www.w.org',
-					'path'   => '/foo/bar/',
-				),
-				'test.example.org/'       => array(
-					'domain' => 'test.example.org',
-					'path'   => '/',
-				),
-				'test2.example.org/'      => array(
-					'domain' => 'test2.example.org',
-					'path'   => '/',
-				),
-				'test3.example.org/zig/'  => array(
-					'domain' => 'test3.example.org',
-					'path'   => '/zig/',
-				),
-				'atest.example.org/'      => array(
-					'domain' => 'atest.example.org',
-					'path'   => '/',
-				),
-			);
-
-			foreach ( self::$site_ids as &$id ) {
-				$id = $factory->blog->create( $id );
-			}
-			unset( $id );
-		}
-
-		public static function wpTearDownAfterClass() {
-			foreach ( self::$site_ids as $site_id ) {
-				wp_delete_site( $site_id );
-			}
-		}
-
-		/**
-		 * @ticket 42066
-		 *
-		 * @covers WP_MS_Users_List_Table::get_views
-		 */
-		public function test_get_views_should_return_views_by_default() {
-			$all   = get_user_count();
-			$super = count( get_super_admins() );
-
-			$expected = array(
-				'all'   => '<a href="http://example.org/wp-admin/network/users.php" class="current" aria-current="page">All <span class="count">(' . $all . ')</span></a>',
-				'super' => '<a href="http://example.org/wp-admin/network/users.php?role=super">Super Admin <span class="count">(' . $super . ')</span></a>',
-			);
-
-			$this->assertSame( $expected, $this->table->get_views() );
+	public static function wpTearDownAfterClass() {
+		foreach ( self::$site_ids as $site_id ) {
+			wp_delete_site( $site_id );
 		}
 	}
-endif;
+
+	/**
+	 * @ticket 42066
+	 *
+	 * @covers WP_MS_Users_List_Table::get_views
+	 */
+	public function test_get_views_should_return_views_by_default() {
+		$all   = get_user_count();
+		$super = count( get_super_admins() );
+
+		$expected = array(
+			'all'   => '<a href="http://example.org/wp-admin/network/users.php" class="current" aria-current="page">All <span class="count">(' . $all . ')</span></a>',
+			'super' => '<a href="http://example.org/wp-admin/network/users.php?role=super">Super Admin <span class="count">(' . $super . ')</span></a>',
+		);
+
+		$this->assertSame( $expected, $this->table->get_views() );
+	}
+}

--- a/tests/phpunit/tests/multisite/wpMsUsersListTable.php
+++ b/tests/phpunit/tests/multisite/wpMsUsersListTable.php
@@ -1,0 +1,106 @@
+<?php
+
+if ( is_multisite() ) :
+
+	/**
+	 * @group admin
+	 * @group network-admin
+	 *
+	 * @covers WP_MS_Users_List_Table
+	 */
+	class Tests_Multisite_wpMsUsersListTable extends WP_UnitTestCase {
+		protected static $site_ids;
+
+		/**
+		 * @var WP_MS_Users_List_Table
+		 */
+		public $table = false;
+
+		public function set_up() {
+			parent::set_up();
+			$this->table = _get_list_table( 'WP_MS_Users_List_Table', array( 'screen' => 'ms-users' ) );
+		}
+
+		public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+			self::$site_ids = array(
+				'wordpress.org/'          => array(
+					'domain' => 'wordpress.org',
+					'path'   => '/',
+				),
+				'wordpress.org/foo/'      => array(
+					'domain' => 'wordpress.org',
+					'path'   => '/foo/',
+				),
+				'wordpress.org/foo/bar/'  => array(
+					'domain' => 'wordpress.org',
+					'path'   => '/foo/bar/',
+				),
+				'wordpress.org/afoo/'     => array(
+					'domain' => 'wordpress.org',
+					'path'   => '/afoo/',
+				),
+				'make.wordpress.org/'     => array(
+					'domain' => 'make.wordpress.org',
+					'path'   => '/',
+				),
+				'make.wordpress.org/foo/' => array(
+					'domain' => 'make.wordpress.org',
+					'path'   => '/foo/',
+				),
+				'www.w.org/'              => array(
+					'domain' => 'www.w.org',
+					'path'   => '/',
+				),
+				'www.w.org/foo/'          => array(
+					'domain' => 'www.w.org',
+					'path'   => '/foo/',
+				),
+				'www.w.org/foo/bar/'      => array(
+					'domain' => 'www.w.org',
+					'path'   => '/foo/bar/',
+				),
+				'test.example.org/'       => array(
+					'domain' => 'test.example.org',
+					'path'   => '/',
+				),
+				'test2.example.org/'      => array(
+					'domain' => 'test2.example.org',
+					'path'   => '/',
+				),
+				'test3.example.org/zig/'  => array(
+					'domain' => 'test3.example.org',
+					'path'   => '/zig/',
+				),
+				'atest.example.org/'      => array(
+					'domain' => 'atest.example.org',
+					'path'   => '/',
+				),
+			);
+
+			foreach ( self::$site_ids as &$id ) {
+				$id = $factory->blog->create( $id );
+			}
+			unset( $id );
+		}
+
+		public static function wpTearDownAfterClass() {
+			foreach ( self::$site_ids as $site_id ) {
+				wp_delete_site( $site_id );
+			}
+		}
+
+		/**
+		 * @ticket 42066
+		 *
+		 * @covers WP_MS_Users_List_Table::get_views
+		 */
+		public function test_get_views_should_return_views_by_default() {
+			$expected = array(
+				'all'   => '<a href="http://example.org/wp-admin/network/users.php" class="current" aria-current="page">All <span class="count">(1)</span></a>',
+				'super' => '<a href="http://example.org/wp-admin/network/users.php?role=super">Super Admin <span class="count">(1)</span></a>',
+			);
+
+			$this->assertSame( $expected, $this->table->get_views() );
+		}
+	}
+endif;


### PR DESCRIPTION
This PR introduces `WP_List_Table::get_views_links()` to abstract the link markup generation for list tables.

Includes PHPUnit tests with full line/branch coverage.

Trac ticket: https://core.trac.wordpress.org/ticket/42066