### PR TITLE
#56011 - add plain styles to blockquote block in Twenty Twenty theme

### DIFF
--- a/src/wp-content/themes/twentytwenty/assets/css/editor-style-block-rtl.css
+++ b/src/wp-content/themes/twentytwenty/assets/css/editor-style-block-rtl.css
@@ -634,6 +634,11 @@ hr.wp-block-separator.is-style-dots::before {
 	padding: 5px 20px 5px 0;
 }
 
+.editor-styles-wrapper blockquote.is-style-plain {
+	border-width: 0;
+	padding: 5px 0 5px 0;
+}
+
 .editor-styles-wrapper .wp-block-quote.has-text-align-center,
 .editor-styles-wrapper .wp-block-quote[style*="text-align:center"],
 .editor-styles-wrapper .wp-block-quote[style*="text-align: center"] {

--- a/src/wp-content/themes/twentytwenty/assets/css/editor-style-block.css
+++ b/src/wp-content/themes/twentytwenty/assets/css/editor-style-block.css
@@ -634,6 +634,11 @@ hr.wp-block-separator.is-style-dots::before {
 	padding: 5px 0 5px 20px;
 }
 
+.editor-styles-wrapper blockquote.is-style-plain {
+	border-width: 0;
+	padding: 5px 0 5px 0;
+}
+
 .editor-styles-wrapper .wp-block-quote.has-text-align-center,
 .editor-styles-wrapper .wp-block-quote[style*="text-align:center"],
 .editor-styles-wrapper .wp-block-quote[style*="text-align: center"] {

--- a/src/wp-content/themes/twentytwenty/assets/css/editor-style-classic-rtl.css
+++ b/src/wp-content/themes/twentytwenty/assets/css/editor-style-classic-rtl.css
@@ -252,6 +252,11 @@ body#tinymce.wp-editor.content blockquote {
 	padding: 0.25em 1em 0.25em 0;
 }
 
+body#tinymce.wp-editor.content blockquote.is-style-plain {
+	border-right: 0;
+	padding: 0.25em 0 0.25em 0;
+}
+
 body#tinymce.wp-editor.content blockquote p {
 	font-style: normal;
 	font-weight: 400;

--- a/src/wp-content/themes/twentytwenty/assets/css/editor-style-classic.css
+++ b/src/wp-content/themes/twentytwenty/assets/css/editor-style-classic.css
@@ -252,6 +252,11 @@ body#tinymce.wp-editor.content blockquote {
 	padding: 0.25em 0 0.25em 1em;
 }
 
+body#tinymce.wp-editor.content blockquote.is-style-plain {
+	border-left: 0;
+	padding: 0.25em 0 0.25em 0;
+}
+
 body#tinymce.wp-editor.content blockquote p {
 	font-style: normal;
 	font-weight: 400;

--- a/src/wp-content/themes/twentytwenty/style-rtl.css
+++ b/src/wp-content/themes/twentytwenty/style-rtl.css
@@ -548,6 +548,11 @@ blockquote {
 	padding: 0.5rem 0 0.5rem 2rem;
 }
 
+blockquote.is-style-plain {
+	border-width: 0;
+	padding: 0.5rem 0 0.5rem 0;
+}
+
 cite {
 	color: #6d6d6d;
 	font-size: 1.4rem;

--- a/src/wp-content/themes/twentytwenty/style.css
+++ b/src/wp-content/themes/twentytwenty/style.css
@@ -552,6 +552,14 @@ blockquote {
 	padding: 0.5rem 0 0.5rem 2rem;
 }
 
+blockquote.is-style-plain {
+	/*rtl:ignore*/
+	border-width: 0;
+
+	/*rtl:ignore*/
+	padding: 0.5rem 0 0.5rem 0;
+}
+
 cite {
 	color: #6d6d6d;
 	font-size: 1.4rem;


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Adding missing styles for block style `plain`.

Trac ticket: https://core.trac.wordpress.org/ticket/56011

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
