### PR TITLE
Enable `coverage` mode for xDebug in the local Docker environment

### DIFF
--- a/.env
+++ b/.env
@@ -17,8 +17,19 @@ LOCAL_DIR=src
 # The PHP version to use. Valid options are 'latest', and '{version}-fpm'.
 LOCAL_PHP=latest
 
-# Whether or not to enable XDebug.
+# Whether or not to enable Xdebug.
 LOCAL_PHP_XDEBUG=false
+
+##
+# The Xdebug features to enable.
+#
+# By default, the following features are enabled in the local environment:
+# - Development helpers (`develop`).
+# - Step debugging (`debug`).
+#
+# For a full list of accepted values, see https://xdebug.org/docs/all_settings#mode.
+##
+LOCAL_PHP_XDEBUG_MODE=develop,debug
 
 # Whether or not to enable Memcached.
 LOCAL_PHP_MEMCACHED=false

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -10,6 +10,16 @@ on:
       - 'docker-compose.yml'
       - 'phpunit.xml.dist'
       - 'tests/phpunit/multisite.xml'
+  pull_request:
+    branches:
+      - trunk
+      - '3.[89]'
+      - '[4-9].[0-9]'
+    paths:
+      - '.github/workflows/test-coverage.yml'
+      - 'docker-compose.yml'
+      - 'phpunit.xml.dist'
+      - 'tests/phpunit/multisite.xml'
   # Once daily at 00:00 UTC.
   schedule:
     - cron: '0 0 * * *'
@@ -151,7 +161,7 @@ jobs:
         run: git diff --exit-code
 
       - name: Upload single site report to Codecov
-        if: ${{ ! matrix.multisite }}
+        if: ${{ ! matrix.multisite && github.event_name != 'pull_request' }}
         uses: codecov/codecov-action@e3c560433a6cc60aec8812599b7844a7b4fa0d71 # v3.0.0
         with:
           file: wp-code-coverage-single-clover-${{ github.sha }}.xml
@@ -165,7 +175,7 @@ jobs:
         run: git diff --exit-code
 
       - name: Upload multisite report to Codecov
-        if: ${{ matrix.multisite }}
+        if: ${{ matrix.multisite && github.event_name != 'pull_request' }}
         uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # v2.1.0
         with:
           file: wp-code-coverage-multisite-clover-${{ github.sha }}.xml

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -7,6 +7,7 @@ on:
       - trunk
     paths:
       - '.github/workflows/test-coverage.yml'
+      - 'docker-compose.yml'
       - 'phpunit.xml.dist'
       - 'tests/phpunit/multisite.xml'
   # Once daily at 00:00 UTC.

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -13,8 +13,6 @@ on:
   pull_request:
     branches:
       - trunk
-      - '3.[89]'
-      - '[4-9].[0-9]'
     paths:
       - '.github/workflows/test-coverage.yml'
       - 'docker-compose.yml'

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -20,6 +20,7 @@ env:
   PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: ${{ true }}
   LOCAL_PHP: '7.4-fpm'
   LOCAL_PHP_XDEBUG: true
+  LOCAL_PHP_XDEBUG_MODE: 'coverage'
   LOCAL_PHP_MEMCACHED: ${{ false }}
 
 jobs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
 
     environment:
       - LOCAL_PHP_XDEBUG=${LOCAL_PHP_XDEBUG-false}
-      - XDEBUG_MODE=${LOCAL_PHP_XDEBUG_MODE-develop,coverage}
+      - XDEBUG_MODE=${LOCAL_PHP_XDEBUG_MODE-develop,debug}
       - LOCAL_PHP_MEMCACHED=${LOCAL_PHP_MEMCACHED-false}
       - PHP_FPM_UID=${PHP_FPM_UID-1000}
       - PHP_FPM_GID=${PHP_FPM_GID-1000}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
 
     environment:
       - LOCAL_PHP_XDEBUG=${LOCAL_PHP_XDEBUG-false}
+      - XDEBUG_MODE=${LOCAL_PHP_XDEBUG_MODE-develop,coverage}
       - LOCAL_PHP_MEMCACHED=${LOCAL_PHP_MEMCACHED-false}
       - PHP_FPM_UID=${PHP_FPM_UID-1000}
       - PHP_FPM_GID=${PHP_FPM_GID-1000}


### PR DESCRIPTION
This enables the `coverage` mode for xDebug in the local Docker environment in addition to the default mode of `develop` by passing the `XDEBUG_MODE` environment variable to the container.

This environment variable takes precedent, but does not change the value of `xdebug.mode`. For more information, see the [xDebug documentation about modes](https://xdebug.org/docs/all_settings#mode).

The xDebug mode can be overridden using the new `LOCAL_PHP_XDEBUG_MODE` environment variable on someone's machine, allowing contributors to change the active modes as desired.

This also adds the `docker-compose.yml` file to the list of paths that trigger the Code Coverage Report workflow. Changes to this file could potentially change the output of tests based on how the environment is configured. Running this workflow when this file is changed will help confirm changes do not introduce problems.

Trac ticket: https://core.trac.wordpress.org/ticket/56022

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
