### PR TITLE
#53331 Twenty Twenty-One: Update primary-navigation.js

### DIFF
--- a/src/wp-content/themes/twentytwentyone/assets/js/primary-navigation.js
+++ b/src/wp-content/themes/twentytwentyone/assets/js/primary-navigation.js
@@ -172,20 +172,18 @@ function twentytwentyoneExpandSubMenu( el ) { // jshint ignore:line
 		 *
 		 * @since Twenty Twenty-One 1.1
 		 */
-		document.addEventListener( 'click', function( event ) {
-			if ( document.getElementById( 'site-navigation' ).contains( event.target ) ) {
-				// If target onclick is <a> with # within the href attribute
-				if ( event.target.hash && event.target.hash.includes( '#' ) ) {
-					wrapper.classList.remove( id + '-navigation-open', 'lock-scrolling' );
-					twentytwentyoneToggleAriaExpanded( mobileButton );
-					// Wait 550 and scroll to the anchor.
-					setTimeout(function () {
-						var anchor = document.getElementById(event.target.hash.slice(1));
-						if ( anchor ) {
-							anchor.scrollIntoView();
-						}
-					}, 550);
-				}
+		document.getElementById( 'site-navigation' ).addEventListener( 'click', function( event ) {
+			// If target onclick is <a> with # within the href attribute
+			if ( event.target.hash ) {
+				wrapper.classList.remove( id + '-navigation-open', 'lock-scrolling' );
+				twentytwentyoneToggleAriaExpanded( mobileButton );
+				// Wait 550 and scroll to the anchor.
+				setTimeout(function () {
+					var anchor = document.getElementById(event.target.hash.slice(1));
+					if ( anchor ) {
+						anchor.scrollIntoView();
+					}
+				}, 550);
 			}
 		} );
 

--- a/src/wp-content/themes/twentytwentyone/assets/js/primary-navigation.js
+++ b/src/wp-content/themes/twentytwentyone/assets/js/primary-navigation.js
@@ -173,17 +173,19 @@ function twentytwentyoneExpandSubMenu( el ) { // jshint ignore:line
 		 * @since Twenty Twenty-One 1.1
 		 */
 		document.addEventListener( 'click', function( event ) {
-			// If target onclick is <a> with # within the href attribute
-			if ( event.target.hash && event.target.hash.includes( '#' ) ) {
-				wrapper.classList.remove( id + '-navigation-open', 'lock-scrolling' );
-				twentytwentyoneToggleAriaExpanded( mobileButton );
-				// Wait 550 and scroll to the anchor.
-				setTimeout(function () {
-					var anchor = document.getElementById(event.target.hash.slice(1));
-					if ( anchor ) {
-						anchor.scrollIntoView();
-					}
-				}, 550);
+			if ( document.getElementById( 'site-navigation' ).contains( event.target ) ) {
+				// If target onclick is <a> with # within the href attribute
+				if ( event.target.hash && event.target.hash.includes( '#' ) ) {
+					wrapper.classList.remove( id + '-navigation-open', 'lock-scrolling' );
+					twentytwentyoneToggleAriaExpanded( mobileButton );
+					// Wait 550 and scroll to the anchor.
+					setTimeout(function () {
+						var anchor = document.getElementById(event.target.hash.slice(1));
+						if ( anchor ) {
+							anchor.scrollIntoView();
+						}
+					}, 550);
+				}
 			}
 		} );
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
In Twenty Twenty-One, there is a bug where clicking on an anchor link in the content changes the state of the button that opens and closes the responsive menu.

This PR adds a conditional to check if the clicked anchor link is inside the primary navigation menu (ID site-navigation).
This is to prevent content anchor links from changing the state of the button.

Known limitations: The state of the button is not reset when the browser is resized.
If a menu anchor link is first clicked while on desktop width, and the browser width is reduced, the menu button will show the text "Close" even though the menu is not opened.

Trac ticket: https://core.trac.wordpress.org/ticket/53331

Testing instructions:

1. In the WordPress admin backend, navigate to Appearance > Menus.
2. Select a menu that shows in the "Primary Menu" Display Location. If there is no new menu, create a new one and assign it to the "Primary Menu" under Display Location.
3. Under the "Add menu items" section, expand the sub-section "Custom Links".
4. In the field URL, add something like #test.
5. In the Field Link Text add something like "Sample Link".
6. Click the Button Add To Menu to add the item to your menu.
7.  Click Save Menu which should be on the right near the bottom.
8. Create a new post or page. In the content, add text with an anchor link such as #test2.
9. Go to the front of the website and open the post or page that you created.
10. Reduce the browser window width until the button that opens the responsive menu shows.
11. Click on the anchor link in the content.
12. Confirm that the menu button does not change visually.
13. Open the primary menu in the header. Click on the Sample Link menu item you created in step 5.
14. Confirm that the menu closes.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
