### PR TITLE
Lower the priority of the gallery gap css 

### DIFF
--- a/src/wp-includes/blocks/gallery.php
+++ b/src/wp-includes/blocks/gallery.php
@@ -86,7 +86,8 @@ function block_core_gallery_render( $attributes, $content ) {
 		'wp_footer',
 		function () use ( $style ) {
 			echo '<style> ' . $style . '</style>';
-		}
+		},
+		11
 	);
 	return $content;
 }


### PR DESCRIPTION
Fixes the order that the Gallery gap CSS is enqueued so it is not overwritten by layout CSS in non block themes.

[Merged into Gutenberg trunk ](https://github.com/WordPress/gutenberg/pull/41423) and adding here for backporting to WP 6.0.1

### Testing

- In a non-block theme, add a custom CSS var or --wp--style--gallery-gap-default: 37px;
- Add a Gallery and check in the frontend that the gap is set to 37px
- Also try and block theme and make sure gap still works as expected

