### PR TITLE
Add utility classnames back to blocks that have layout attributes specified

### DIFF
--- a/src/wp-includes/block-supports/layout.php
+++ b/src/wp-includes/block-supports/layout.php
@@ -141,6 +141,40 @@ function wp_get_layout_style( $selector, $layout, $has_block_gap_support = false
 }
 
 /**
+ * Generates the utility classnames for the given blocks layout attributes.
+ * This method was primarily added to reintroduce classnames that were removed
+ * in the 5.9 release (https://github.com/WordPress/gutenberg/issues/38719), rather
+ * than providing an extensive list of all possible layout classes. The plan is to
+ * have the style engine generate a more extensive list of utility classnames which
+ * will then replace this method.
+ *
+ * @param array $block_attributes Array of block attributes.
+ *
+ * @return array Array of CSS classname strings.
+ */
+function gutenberg_get_layout_classes( $block_attributes ) {
+	$class_names = array();
+
+	if ( empty( $block_attributes['layout'] ) ) {
+		return $class_names;
+	}
+
+	if ( ! empty( $block_attributes['layout']['orientation'] ) ) {
+		$class_names[] = 'is-' . sanitize_title( $block_attributes['layout']['orientation'] );
+	}
+
+	if ( ! empty( $block_attributes['layout']['justifyContent'] ) ) {
+		$class_names[] = 'is-content-justification-' . sanitize_title( $block_attributes['layout']['justifyContent'] );
+	}
+
+	if ( ! empty( $block_attributes['layout']['flexWrap'] ) && 'nowrap' === $block_attributes['layout']['flexWrap'] ) {
+		$class_names[] = 'is-nowrap';
+	}
+
+	return $class_names;
+}
+
+/**
  * Renders the layout config to the block wrapper.
  *
  * @since 5.8.0
@@ -170,8 +204,11 @@ function wp_render_layout_support_flag( $block_content, $block ) {
 		$used_layout = $default_layout;
 	}
 
-	$class_name = wp_unique_id( 'wp-container-' );
-	$gap_value  = _wp_array_get( $block, array( 'attrs', 'style', 'spacing', 'blockGap' ) );
+	$container_class = wp_unique_id( 'wp-container-' );
+	$class_names     = gutenberg_get_layout_classes( $block['attrs'] );
+	$class_names[]   = $container_class;
+
+	$gap_value = _wp_array_get( $block, array( 'attrs', 'style', 'spacing', 'blockGap' ) );
 	// Skip if gap value contains unsupported characters.
 	// Regex for CSS value borrowed from `safecss_filter_attr`, and used here
 	// because we only want to match against the value, not the CSS attribute.
@@ -188,12 +225,12 @@ function wp_render_layout_support_flag( $block_content, $block ) {
 	// If a block's block.json skips serialization for spacing or spacing.blockGap,
 	// don't apply the user-defined value to the styles.
 	$should_skip_gap_serialization = wp_should_skip_block_supports_serialization( $block_type, 'spacing', 'blockGap' );
-	$style                         = wp_get_layout_style( ".$class_name", $used_layout, $has_block_gap_support, $gap_value, $should_skip_gap_serialization, $fallback_gap_value );
+	$style                         = gutenberg_get_layout_style( ".$container_class", $used_layout, $has_block_gap_support, $gap_value, $should_skip_gap_serialization, $fallback_gap_value );
 	// This assumes the hook only applies to blocks with a single wrapper.
 	// I think this is a reasonable limitation for that particular hook.
 	$content = preg_replace(
 		'/' . preg_quote( 'class="', '/' ) . '/',
-		'class="' . esc_attr( $class_name ) . ' ',
+		'class="' . esc_attr( implode( ' ', $class_names ) ) . ' ',
 		$block_content,
 		1
 	);

--- a/src/wp-includes/block-supports/layout.php
+++ b/src/wp-includes/block-supports/layout.php
@@ -141,43 +141,6 @@ function wp_get_layout_style( $selector, $layout, $has_block_gap_support = false
 }
 
 /**
- * Generates classnames for block layout attributes.
- *
- * This method was added to reintroduce a small set of layout classnames that were
- * removed in the 5.9 release (https://github.com/WordPress/gutenberg/issues/38719). It is
- * not intended to provide an extended set of classes to match all block layout attributes
- * and should not be extended to do so. The plan is to have the new style engine
- * (https://github.com/WordPress/gutenberg/issues/38167) generate the full list of utility
- * classnames for a block which will then replace this method.
- *
- * @since 6.0.1
- *
- * @param array $block_attributes Array of block attributes.
- * @return array Array of CSS classname strings.
- */
-function wp_get_layout_classes( $block_attributes ) {
-	$class_names = array();
-
-	if ( empty( $block_attributes['layout'] ) ) {
-		return $class_names;
-	}
-
-	if ( ! empty( $block_attributes['layout']['orientation'] ) ) {
-		$class_names[] = 'is-' . sanitize_title( $block_attributes['layout']['orientation'] );
-	}
-
-	if ( ! empty( $block_attributes['layout']['justifyContent'] ) ) {
-		$class_names[] = 'is-content-justification-' . sanitize_title( $block_attributes['layout']['justifyContent'] );
-	}
-
-	if ( ! empty( $block_attributes['layout']['flexWrap'] ) && 'nowrap' === $block_attributes['layout']['flexWrap'] ) {
-		$class_names[] = 'is-nowrap';
-	}
-
-	return $class_names;
-}
-
-/**
  * Renders the layout config to the block wrapper.
  *
  * @since 5.8.0
@@ -207,9 +170,25 @@ function wp_render_layout_support_flag( $block_content, $block ) {
 		$used_layout = $default_layout;
 	}
 
+	$class_names     = array();
 	$container_class = wp_unique_id( 'wp-container-' );
-	$class_names     = wp_get_layout_classes( $block['attrs'] );
 	$class_names[]   = $container_class;
+
+	// The following section was added to reintroduce a small set of layout classnames that were
+	// removed in the 5.9 release (https://github.com/WordPress/gutenberg/issues/38719). It is
+	// not intended to provide an extended set of classes to match all block layout attributes
+	// here.
+	if ( ! empty( $block['attrs']['layout']['orientation'] ) ) {
+		$class_names[] = 'is-' . sanitize_title( $block['attrs']['layout']['orientation'] );
+	}
+
+	if ( ! empty( $block['attrs']['layout']['justifyContent'] ) ) {
+		$class_names[] = 'is-content-justification-' . sanitize_title( $block['attrs']['layout']['justifyContent'] );
+	}
+
+	if ( ! empty( $block['attrs']['layout']['flexWrap'] ) && 'nowrap' === $block['attrs']['layout']['flexWrap'] ) {
+		$class_names[] = 'is-nowrap';
+	}
 
 	$gap_value = _wp_array_get( $block, array( 'attrs', 'style', 'spacing', 'blockGap' ) );
 	// Skip if gap value contains unsupported characters.

--- a/src/wp-includes/block-supports/layout.php
+++ b/src/wp-includes/block-supports/layout.php
@@ -141,18 +141,21 @@ function wp_get_layout_style( $selector, $layout, $has_block_gap_support = false
 }
 
 /**
- * Generates the utility classnames for the given blocks layout attributes.
- * This method was primarily added to reintroduce classnames that were removed
- * in the 5.9 release (https://github.com/WordPress/gutenberg/issues/38719), rather
- * than providing an extensive list of all possible layout classes. The plan is to
- * have the style engine generate a more extensive list of utility classnames which
- * will then replace this method.
+ * Generates classnames for block layout attributes.
+ *
+ * This method was added to reintroduce a small set of layout classnames that were
+ * removed in the 5.9 release (https://github.com/WordPress/gutenberg/issues/38719). It is
+ * not intended to provide an extended set of classes to match all block layout attributes
+ * and should not be extended to do so. The plan is to have the new style engine
+ * (https://github.com/WordPress/gutenberg/issues/38167) generate the full list of utility
+ * classnames for a block which will then replace this method.
+ *
+ * @since 6.0.1
  *
  * @param array $block_attributes Array of block attributes.
- *
  * @return array Array of CSS classname strings.
  */
-function gutenberg_get_layout_classes( $block_attributes ) {
+function wp_get_layout_classes( $block_attributes ) {
 	$class_names = array();
 
 	if ( empty( $block_attributes['layout'] ) ) {
@@ -205,7 +208,7 @@ function wp_render_layout_support_flag( $block_content, $block ) {
 	}
 
 	$container_class = wp_unique_id( 'wp-container-' );
-	$class_names     = gutenberg_get_layout_classes( $block['attrs'] );
+	$class_names     = wp_get_layout_classes( $block['attrs'] );
 	$class_names[]   = $container_class;
 
 	$gap_value = _wp_array_get( $block, array( 'attrs', 'style', 'spacing', 'blockGap' ) );
@@ -225,7 +228,7 @@ function wp_render_layout_support_flag( $block_content, $block ) {
 	// If a block's block.json skips serialization for spacing or spacing.blockGap,
 	// don't apply the user-defined value to the styles.
 	$should_skip_gap_serialization = wp_should_skip_block_supports_serialization( $block_type, 'spacing', 'blockGap' );
-	$style                         = gutenberg_get_layout_style( ".$container_class", $used_layout, $has_block_gap_support, $gap_value, $should_skip_gap_serialization, $fallback_gap_value );
+	$style                         = wp_get_layout_style( ".$container_class", $used_layout, $has_block_gap_support, $gap_value, $should_skip_gap_serialization, $fallback_gap_value );
 	// This assumes the hook only applies to blocks with a single wrapper.
 	// I think this is a reasonable limitation for that particular hook.
 	$content = preg_replace(


### PR DESCRIPTION
## What?
Add several layout utility classnames to blocks that have layout attributes specified

## Why?
[In 5.9 these utility classnames were removed](https://github.com/WordPress/gutenberg/issues/38719) which removed the ability for theme/plugin authors to assign their own custom CSS related to specific layout selections. This was mostly related to the Button block

## How?
Adds these classes dynamically based on attributes, rather than saving them to the serialized content

## Testing Instructions

- Add a Buttons block with one child Button block
- On parent Buttons block set alignment to centre and turn off the wrapping option
- Check that `is-content-justification-center` and `is-nowrap` classes are added in editor and frontend

## Screenshots or screencast 
<img width="571" alt="Screen Shot 2022-06-02 at 11 17 33 AM" src="https://user-images.githubusercontent.com/3629020/171517150-cb77fac2-0b2d-4a57-98ef-984e2f1bd558.png">

Trac ticket: https://core.trac.wordpress.org/ticket/56058