### PR TITLE
PHP 8.2 | Tests_*_Slashes: remove dynamic properties

### DIFF
--- a/tests/phpunit/tests/attachment/slashes.php
+++ b/tests/phpunit/tests/attachment/slashes.php
@@ -6,6 +6,20 @@
  * @ticket 21767
  */
 class Tests_Attachment_Slashes extends WP_UnitTestCase {
+
+	/*
+	 * It is important to test with both even and odd numbered slashes,
+	 * as KSES does a strip-then-add slashes in some of its function calls.
+	 */
+
+	const SLASH_1 = 'String with 1 slash \\';
+	const SLASH_2 = 'String with 2 slashes \\\\';
+	const SLASH_3 = 'String with 3 slashes \\\\\\';
+	const SLASH_4 = 'String with 4 slashes \\\\\\\\';
+	const SLASH_5 = 'String with 5 slashes \\\\\\\\\\';
+	const SLASH_6 = 'String with 6 slashes \\\\\\\\\\\\';
+	const SLASH_7 = 'String with 7 slashes \\\\\\\\\\\\\\';
+
 	protected static $author_id;
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
@@ -16,16 +30,6 @@ class Tests_Attachment_Slashes extends WP_UnitTestCase {
 		parent::set_up();
 
 		wp_set_current_user( self::$author_id );
-
-		// It is important to test with both even and odd numbered slashes,
-		// as KSES does a strip-then-add slashes in some of its function calls.
-		$this->slash_1 = 'String with 1 slash \\';
-		$this->slash_2 = 'String with 2 slashes \\\\';
-		$this->slash_3 = 'String with 3 slashes \\\\\\';
-		$this->slash_4 = 'String with 4 slashes \\\\\\\\';
-		$this->slash_5 = 'String with 5 slashes \\\\\\\\\\';
-		$this->slash_6 = 'String with 6 slashes \\\\\\\\\\\\';
-		$this->slash_7 = 'String with 7 slashes \\\\\\\\\\\\\\';
 	}
 
 	/**
@@ -35,32 +39,32 @@ class Tests_Attachment_Slashes extends WP_UnitTestCase {
 		$post_id = wp_insert_attachment(
 			array(
 				'post_status'           => 'publish',
-				'post_title'            => $this->slash_1,
-				'post_content_filtered' => $this->slash_3,
-				'post_excerpt'          => $this->slash_5,
+				'post_title'            => self::SLASH_1,
+				'post_content_filtered' => self::SLASH_3,
+				'post_excerpt'          => self::SLASH_5,
 				'post_type'             => 'post',
 			)
 		);
 		$post    = get_post( $post_id );
 
-		$this->assertSame( wp_unslash( $this->slash_1 ), $post->post_title );
-		$this->assertSame( wp_unslash( $this->slash_3 ), $post->post_content_filtered );
-		$this->assertSame( wp_unslash( $this->slash_5 ), $post->post_excerpt );
+		$this->assertSame( wp_unslash( self::SLASH_1 ), $post->post_title );
+		$this->assertSame( wp_unslash( self::SLASH_3 ), $post->post_content_filtered );
+		$this->assertSame( wp_unslash( self::SLASH_5 ), $post->post_excerpt );
 
 		$post_id = wp_insert_attachment(
 			array(
 				'post_status'           => 'publish',
-				'post_title'            => $this->slash_2,
-				'post_content_filtered' => $this->slash_4,
-				'post_excerpt'          => $this->slash_6,
+				'post_title'            => self::SLASH_2,
+				'post_content_filtered' => self::SLASH_4,
+				'post_excerpt'          => self::SLASH_6,
 				'post_type'             => 'post',
 			)
 		);
 		$post    = get_post( $post_id );
 
-		$this->assertSame( wp_unslash( $this->slash_2 ), $post->post_title );
-		$this->assertSame( wp_unslash( $this->slash_4 ), $post->post_content_filtered );
-		$this->assertSame( wp_unslash( $this->slash_6 ), $post->post_excerpt );
+		$this->assertSame( wp_unslash( self::SLASH_2 ), $post->post_title );
+		$this->assertSame( wp_unslash( self::SLASH_4 ), $post->post_content_filtered );
+		$this->assertSame( wp_unslash( self::SLASH_6 ), $post->post_excerpt );
 	}
 
 }

--- a/tests/phpunit/tests/comment/slashes.php
+++ b/tests/phpunit/tests/comment/slashes.php
@@ -6,6 +6,20 @@
  * @ticket 21767
  */
 class Tests_Comment_Slashes extends WP_UnitTestCase {
+
+	/*
+	 * It is important to test with both even and odd numbered slashes,
+	 * as KSES does a strip-then-add slashes in some of its function calls.
+	 */
+
+	const SLASH_1 = 'String with 1 slash \\';
+	const SLASH_2 = 'String with 2 slashes \\\\';
+	const SLASH_3 = 'String with 3 slashes \\\\\\';
+	const SLASH_4 = 'String with 4 slashes \\\\\\\\';
+	const SLASH_5 = 'String with 5 slashes \\\\\\\\\\';
+	const SLASH_6 = 'String with 6 slashes \\\\\\\\\\\\';
+	const SLASH_7 = 'String with 7 slashes \\\\\\\\\\\\\\';
+
 	protected static $author_id;
 	protected static $post_id;
 
@@ -19,16 +33,6 @@ class Tests_Comment_Slashes extends WP_UnitTestCase {
 		parent::set_up();
 
 		wp_set_current_user( self::$author_id );
-
-		// It is important to test with both even and odd numbered slashes,
-		// as KSES does a strip-then-add slashes in some of its function calls.
-		$this->slash_1 = 'String with 1 slash \\';
-		$this->slash_2 = 'String with 2 slashes \\\\';
-		$this->slash_3 = 'String with 3 slashes \\\\\\';
-		$this->slash_4 = 'String with 4 slashes \\\\\\\\';
-		$this->slash_5 = 'String with 5 slashes \\\\\\\\\\';
-		$this->slash_6 = 'String with 6 slashes \\\\\\\\\\\\';
-		$this->slash_7 = 'String with 7 slashes \\\\\\\\\\\\\\';
 	}
 
 	/**
@@ -41,33 +45,33 @@ class Tests_Comment_Slashes extends WP_UnitTestCase {
 		// as slashes are not permitted in that data.
 		$data       = array(
 			'comment_post_ID'      => $post_id,
-			'comment_author'       => $this->slash_1,
+			'comment_author'       => self::SLASH_1,
 			'comment_author_url'   => '',
 			'comment_author_email' => '',
 			'comment_type'         => '',
-			'comment_content'      => $this->slash_7,
+			'comment_content'      => self::SLASH_7,
 		);
 		$comment_id = wp_new_comment( $data );
 
 		$comment = get_comment( $comment_id );
 
-		$this->assertSame( wp_unslash( $this->slash_1 ), $comment->comment_author );
-		$this->assertSame( wp_unslash( $this->slash_7 ), $comment->comment_content );
+		$this->assertSame( wp_unslash( self::SLASH_1 ), $comment->comment_author );
+		$this->assertSame( wp_unslash( self::SLASH_7 ), $comment->comment_content );
 
 		$data       = array(
 			'comment_post_ID'      => $post_id,
-			'comment_author'       => $this->slash_2,
+			'comment_author'       => self::SLASH_2,
 			'comment_author_url'   => '',
 			'comment_author_email' => '',
 			'comment_type'         => '',
-			'comment_content'      => $this->slash_4,
+			'comment_content'      => self::SLASH_4,
 		);
 		$comment_id = wp_new_comment( $data );
 
 		$comment = get_comment( $comment_id );
 
-		$this->assertSame( wp_unslash( $this->slash_2 ), $comment->comment_author );
-		$this->assertSame( wp_unslash( $this->slash_4 ), $comment->comment_content );
+		$this->assertSame( wp_unslash( self::SLASH_2 ), $comment->comment_author );
+		$this->assertSame( wp_unslash( self::SLASH_4 ), $comment->comment_content );
 	}
 
 	/**
@@ -86,34 +90,34 @@ class Tests_Comment_Slashes extends WP_UnitTestCase {
 		$_POST                            = array();
 		$_POST['comment_ID']              = $comment_id;
 		$_POST['comment_status']          = '';
-		$_POST['newcomment_author']       = $this->slash_1;
+		$_POST['newcomment_author']       = self::SLASH_1;
 		$_POST['newcomment_author_url']   = '';
 		$_POST['newcomment_author_email'] = '';
-		$_POST['content']                 = $this->slash_7;
+		$_POST['content']                 = self::SLASH_7;
 
 		$_POST = add_magic_quotes( $_POST ); // The edit_comment() function will strip slashes.
 
 		edit_comment();
 		$comment = get_comment( $comment_id );
 
-		$this->assertSame( $this->slash_1, $comment->comment_author );
-		$this->assertSame( $this->slash_7, $comment->comment_content );
+		$this->assertSame( self::SLASH_1, $comment->comment_author );
+		$this->assertSame( self::SLASH_7, $comment->comment_content );
 
 		$_POST                            = array();
 		$_POST['comment_ID']              = $comment_id;
 		$_POST['comment_status']          = '';
-		$_POST['newcomment_author']       = $this->slash_2;
+		$_POST['newcomment_author']       = self::SLASH_2;
 		$_POST['newcomment_author_url']   = '';
 		$_POST['newcomment_author_email'] = '';
-		$_POST['content']                 = $this->slash_4;
+		$_POST['content']                 = self::SLASH_4;
 
 		$_POST = add_magic_quotes( $_POST ); // The edit_comment() function will strip slashes.
 
 		edit_comment();
 		$comment = get_comment( $comment_id );
 
-		$this->assertSame( $this->slash_2, $comment->comment_author );
-		$this->assertSame( $this->slash_4, $comment->comment_content );
+		$this->assertSame( self::SLASH_2, $comment->comment_author );
+		$this->assertSame( self::SLASH_4, $comment->comment_content );
 	}
 
 	/**
@@ -125,26 +129,26 @@ class Tests_Comment_Slashes extends WP_UnitTestCase {
 		$comment_id = wp_insert_comment(
 			array(
 				'comment_post_ID' => $post_id,
-				'comment_author'  => $this->slash_1,
-				'comment_content' => $this->slash_7,
+				'comment_author'  => self::SLASH_1,
+				'comment_content' => self::SLASH_7,
 			)
 		);
 		$comment    = get_comment( $comment_id );
 
-		$this->assertSame( wp_unslash( $this->slash_1 ), $comment->comment_author );
-		$this->assertSame( wp_unslash( $this->slash_7 ), $comment->comment_content );
+		$this->assertSame( wp_unslash( self::SLASH_1 ), $comment->comment_author );
+		$this->assertSame( wp_unslash( self::SLASH_7 ), $comment->comment_content );
 
 		$comment_id = wp_insert_comment(
 			array(
 				'comment_post_ID' => $post_id,
-				'comment_author'  => $this->slash_2,
-				'comment_content' => $this->slash_4,
+				'comment_author'  => self::SLASH_2,
+				'comment_content' => self::SLASH_4,
 			)
 		);
 		$comment    = get_comment( $comment_id );
 
-		$this->assertSame( wp_unslash( $this->slash_2 ), $comment->comment_author );
-		$this->assertSame( wp_unslash( $this->slash_4 ), $comment->comment_content );
+		$this->assertSame( wp_unslash( self::SLASH_2 ), $comment->comment_author );
+		$this->assertSame( wp_unslash( self::SLASH_4 ), $comment->comment_content );
 	}
 
 	/**
@@ -161,26 +165,26 @@ class Tests_Comment_Slashes extends WP_UnitTestCase {
 		wp_update_comment(
 			array(
 				'comment_ID'      => $comment_id,
-				'comment_author'  => $this->slash_1,
-				'comment_content' => $this->slash_7,
+				'comment_author'  => self::SLASH_1,
+				'comment_content' => self::SLASH_7,
 			)
 		);
 		$comment = get_comment( $comment_id );
 
-		$this->assertSame( wp_unslash( $this->slash_1 ), $comment->comment_author );
-		$this->assertSame( wp_unslash( $this->slash_7 ), $comment->comment_content );
+		$this->assertSame( wp_unslash( self::SLASH_1 ), $comment->comment_author );
+		$this->assertSame( wp_unslash( self::SLASH_7 ), $comment->comment_content );
 
 		wp_update_comment(
 			array(
 				'comment_ID'      => $comment_id,
-				'comment_author'  => $this->slash_2,
-				'comment_content' => $this->slash_4,
+				'comment_author'  => self::SLASH_2,
+				'comment_content' => self::SLASH_4,
 			)
 		);
 		$comment = get_comment( $comment_id );
 
-		$this->assertSame( wp_unslash( $this->slash_2 ), $comment->comment_author );
-		$this->assertSame( wp_unslash( $this->slash_4 ), $comment->comment_content );
+		$this->assertSame( wp_unslash( self::SLASH_2 ), $comment->comment_author );
+		$this->assertSame( wp_unslash( self::SLASH_4 ), $comment->comment_content );
 	}
 
 }

--- a/tests/phpunit/tests/meta/slashes.php
+++ b/tests/phpunit/tests/meta/slashes.php
@@ -6,6 +6,15 @@
  * @ticket 21767
  */
 class Tests_Meta_Slashes extends WP_UnitTestCase {
+
+	const SLASH_1 = 'String with 1 slash \\';
+	const SLASH_2 = 'String with 2 slashes \\\\';
+	const SLASH_3 = 'String with 3 slashes \\\\\\';
+	const SLASH_4 = 'String with 4 slashes \\\\\\\\';
+	const SLASH_5 = 'String with 5 slashes \\\\\\\\\\';
+	const SLASH_6 = 'String with 6 slashes \\\\\\\\\\\\';
+	const SLASH_7 = 'String with 7 slashes \\\\\\\\\\\\\\';
+
 	protected static $editor_id;
 	protected static $post_id;
 	protected static $comment_id;
@@ -22,14 +31,6 @@ class Tests_Meta_Slashes extends WP_UnitTestCase {
 		parent::set_up();
 
 		wp_set_current_user( self::$editor_id );
-
-		$this->slash_1 = 'String with 1 slash \\';
-		$this->slash_2 = 'String with 2 slashes \\\\';
-		$this->slash_3 = 'String with 3 slashes \\\\\\';
-		$this->slash_4 = 'String with 4 slashes \\\\\\\\';
-		$this->slash_5 = 'String with 5 slashes \\\\\\\\\\';
-		$this->slash_6 = 'String with 6 slashes \\\\\\\\\\\\';
-		$this->slash_7 = 'String with 7 slashes \\\\\\\\\\\\\\';
 	}
 
 	/**
@@ -53,19 +54,19 @@ class Tests_Meta_Slashes extends WP_UnitTestCase {
 		$_POST['post_ID']       = $post_id;
 		$_POST['metakeyselect'] = '#NONE#';
 		$_POST['metakeyinput']  = 'slash_test_0';
-		$_POST['metavalue']     = $this->slash_6;
+		$_POST['metavalue']     = self::SLASH_6;
 		$_POST['meta']          = array(
 			$meta_1 => array(
 				'key'   => 'slash_test_1',
-				'value' => $this->slash_1,
+				'value' => self::SLASH_1,
 			),
 			$meta_2 => array(
 				'key'   => 'slash_test_2',
-				'value' => $this->slash_3,
+				'value' => self::SLASH_3,
 			),
 			$meta_3 => array(
 				'key'   => 'slash_test_3',
-				'value' => $this->slash_4,
+				'value' => self::SLASH_4,
 			),
 		);
 
@@ -74,28 +75,28 @@ class Tests_Meta_Slashes extends WP_UnitTestCase {
 		edit_post();
 		$post = get_post( $post_id );
 
-		$this->assertSame( $this->slash_6, get_post_meta( $post_id, 'slash_test_0', true ) );
-		$this->assertSame( $this->slash_1, get_post_meta( $post_id, 'slash_test_1', true ) );
-		$this->assertSame( $this->slash_3, get_post_meta( $post_id, 'slash_test_2', true ) );
-		$this->assertSame( $this->slash_4, get_post_meta( $post_id, 'slash_test_3', true ) );
+		$this->assertSame( self::SLASH_6, get_post_meta( $post_id, 'slash_test_0', true ) );
+		$this->assertSame( self::SLASH_1, get_post_meta( $post_id, 'slash_test_1', true ) );
+		$this->assertSame( self::SLASH_3, get_post_meta( $post_id, 'slash_test_2', true ) );
+		$this->assertSame( self::SLASH_4, get_post_meta( $post_id, 'slash_test_3', true ) );
 
 		$_POST                  = array();
 		$_POST['post_ID']       = $post_id;
 		$_POST['metakeyselect'] = '#NONE#';
 		$_POST['metakeyinput']  = 'slash_test_0';
-		$_POST['metavalue']     = $this->slash_7;
+		$_POST['metavalue']     = self::SLASH_7;
 		$_POST['meta']          = array(
 			$meta_1 => array(
 				'key'   => 'slash_test_1',
-				'value' => $this->slash_2,
+				'value' => self::SLASH_2,
 			),
 			$meta_2 => array(
 				'key'   => 'slash_test_2',
-				'value' => $this->slash_4,
+				'value' => self::SLASH_4,
 			),
 			$meta_3 => array(
 				'key'   => 'slash_test_3',
-				'value' => $this->slash_5,
+				'value' => self::SLASH_5,
 			),
 		);
 
@@ -104,9 +105,9 @@ class Tests_Meta_Slashes extends WP_UnitTestCase {
 		edit_post();
 		$post = get_post( $post_id );
 
-		$this->assertSame( $this->slash_2, get_post_meta( $post_id, 'slash_test_1', true ) );
-		$this->assertSame( $this->slash_4, get_post_meta( $post_id, 'slash_test_2', true ) );
-		$this->assertSame( $this->slash_5, get_post_meta( $post_id, 'slash_test_3', true ) );
+		$this->assertSame( self::SLASH_2, get_post_meta( $post_id, 'slash_test_1', true ) );
+		$this->assertSame( self::SLASH_4, get_post_meta( $post_id, 'slash_test_2', true ) );
+		$this->assertSame( self::SLASH_5, get_post_meta( $post_id, 'slash_test_3', true ) );
 	}
 
 	/**
@@ -115,13 +116,13 @@ class Tests_Meta_Slashes extends WP_UnitTestCase {
 	public function test_add_post_meta() {
 		$post_id = self::$post_id;
 
-		add_post_meta( $post_id, 'slash_test_1', addslashes( $this->slash_1 ) );
-		add_post_meta( $post_id, 'slash_test_2', addslashes( $this->slash_3 ) );
-		add_post_meta( $post_id, 'slash_test_3', addslashes( $this->slash_4 ) );
+		add_post_meta( $post_id, 'slash_test_1', addslashes( self::SLASH_1 ) );
+		add_post_meta( $post_id, 'slash_test_2', addslashes( self::SLASH_3 ) );
+		add_post_meta( $post_id, 'slash_test_3', addslashes( self::SLASH_4 ) );
 
-		$this->assertSame( $this->slash_1, get_post_meta( $post_id, 'slash_test_1', true ) );
-		$this->assertSame( $this->slash_3, get_post_meta( $post_id, 'slash_test_2', true ) );
-		$this->assertSame( $this->slash_4, get_post_meta( $post_id, 'slash_test_3', true ) );
+		$this->assertSame( self::SLASH_1, get_post_meta( $post_id, 'slash_test_1', true ) );
+		$this->assertSame( self::SLASH_3, get_post_meta( $post_id, 'slash_test_2', true ) );
+		$this->assertSame( self::SLASH_4, get_post_meta( $post_id, 'slash_test_3', true ) );
 	}
 
 	/**
@@ -130,13 +131,13 @@ class Tests_Meta_Slashes extends WP_UnitTestCase {
 	public function test_update_post_meta() {
 		$post_id = self::$post_id;
 
-		update_post_meta( $post_id, 'slash_test_1', addslashes( $this->slash_1 ) );
-		update_post_meta( $post_id, 'slash_test_2', addslashes( $this->slash_3 ) );
-		update_post_meta( $post_id, 'slash_test_3', addslashes( $this->slash_4 ) );
+		update_post_meta( $post_id, 'slash_test_1', addslashes( self::SLASH_1 ) );
+		update_post_meta( $post_id, 'slash_test_2', addslashes( self::SLASH_3 ) );
+		update_post_meta( $post_id, 'slash_test_3', addslashes( self::SLASH_4 ) );
 
-		$this->assertSame( $this->slash_1, get_post_meta( $post_id, 'slash_test_1', true ) );
-		$this->assertSame( $this->slash_3, get_post_meta( $post_id, 'slash_test_2', true ) );
-		$this->assertSame( $this->slash_4, get_post_meta( $post_id, 'slash_test_3', true ) );
+		$this->assertSame( self::SLASH_1, get_post_meta( $post_id, 'slash_test_1', true ) );
+		$this->assertSame( self::SLASH_3, get_post_meta( $post_id, 'slash_test_2', true ) );
+		$this->assertSame( self::SLASH_4, get_post_meta( $post_id, 'slash_test_3', true ) );
 	}
 
 	/**
@@ -145,21 +146,21 @@ class Tests_Meta_Slashes extends WP_UnitTestCase {
 	public function test_add_comment_meta() {
 		$comment_id = self::$comment_id;
 
-		add_comment_meta( $comment_id, 'slash_test_1', $this->slash_1 );
-		add_comment_meta( $comment_id, 'slash_test_2', $this->slash_3 );
-		add_comment_meta( $comment_id, 'slash_test_3', $this->slash_5 );
+		add_comment_meta( $comment_id, 'slash_test_1', self::SLASH_1 );
+		add_comment_meta( $comment_id, 'slash_test_2', self::SLASH_3 );
+		add_comment_meta( $comment_id, 'slash_test_3', self::SLASH_5 );
 
-		$this->assertSame( wp_unslash( $this->slash_1 ), get_comment_meta( $comment_id, 'slash_test_1', true ) );
-		$this->assertSame( wp_unslash( $this->slash_3 ), get_comment_meta( $comment_id, 'slash_test_2', true ) );
-		$this->assertSame( wp_unslash( $this->slash_5 ), get_comment_meta( $comment_id, 'slash_test_3', true ) );
+		$this->assertSame( wp_unslash( self::SLASH_1 ), get_comment_meta( $comment_id, 'slash_test_1', true ) );
+		$this->assertSame( wp_unslash( self::SLASH_3 ), get_comment_meta( $comment_id, 'slash_test_2', true ) );
+		$this->assertSame( wp_unslash( self::SLASH_5 ), get_comment_meta( $comment_id, 'slash_test_3', true ) );
 
-		add_comment_meta( $comment_id, 'slash_test_4', $this->slash_2 );
-		add_comment_meta( $comment_id, 'slash_test_5', $this->slash_4 );
-		add_comment_meta( $comment_id, 'slash_test_6', $this->slash_6 );
+		add_comment_meta( $comment_id, 'slash_test_4', self::SLASH_2 );
+		add_comment_meta( $comment_id, 'slash_test_5', self::SLASH_4 );
+		add_comment_meta( $comment_id, 'slash_test_6', self::SLASH_6 );
 
-		$this->assertSame( wp_unslash( $this->slash_2 ), get_comment_meta( $comment_id, 'slash_test_4', true ) );
-		$this->assertSame( wp_unslash( $this->slash_4 ), get_comment_meta( $comment_id, 'slash_test_5', true ) );
-		$this->assertSame( wp_unslash( $this->slash_6 ), get_comment_meta( $comment_id, 'slash_test_6', true ) );
+		$this->assertSame( wp_unslash( self::SLASH_2 ), get_comment_meta( $comment_id, 'slash_test_4', true ) );
+		$this->assertSame( wp_unslash( self::SLASH_4 ), get_comment_meta( $comment_id, 'slash_test_5', true ) );
+		$this->assertSame( wp_unslash( self::SLASH_6 ), get_comment_meta( $comment_id, 'slash_test_6', true ) );
 	}
 
 	/**
@@ -172,21 +173,21 @@ class Tests_Meta_Slashes extends WP_UnitTestCase {
 		add_comment_meta( $comment_id, 'slash_test_2', 'foo' );
 		add_comment_meta( $comment_id, 'slash_test_3', 'foo' );
 
-		update_comment_meta( $comment_id, 'slash_test_1', $this->slash_1 );
-		update_comment_meta( $comment_id, 'slash_test_2', $this->slash_3 );
-		update_comment_meta( $comment_id, 'slash_test_3', $this->slash_5 );
+		update_comment_meta( $comment_id, 'slash_test_1', self::SLASH_1 );
+		update_comment_meta( $comment_id, 'slash_test_2', self::SLASH_3 );
+		update_comment_meta( $comment_id, 'slash_test_3', self::SLASH_5 );
 
-		$this->assertSame( wp_unslash( $this->slash_1 ), get_comment_meta( $comment_id, 'slash_test_1', true ) );
-		$this->assertSame( wp_unslash( $this->slash_3 ), get_comment_meta( $comment_id, 'slash_test_2', true ) );
-		$this->assertSame( wp_unslash( $this->slash_5 ), get_comment_meta( $comment_id, 'slash_test_3', true ) );
+		$this->assertSame( wp_unslash( self::SLASH_1 ), get_comment_meta( $comment_id, 'slash_test_1', true ) );
+		$this->assertSame( wp_unslash( self::SLASH_3 ), get_comment_meta( $comment_id, 'slash_test_2', true ) );
+		$this->assertSame( wp_unslash( self::SLASH_5 ), get_comment_meta( $comment_id, 'slash_test_3', true ) );
 
-		update_comment_meta( $comment_id, 'slash_test_1', $this->slash_2 );
-		update_comment_meta( $comment_id, 'slash_test_2', $this->slash_4 );
-		update_comment_meta( $comment_id, 'slash_test_3', $this->slash_6 );
+		update_comment_meta( $comment_id, 'slash_test_1', self::SLASH_2 );
+		update_comment_meta( $comment_id, 'slash_test_2', self::SLASH_4 );
+		update_comment_meta( $comment_id, 'slash_test_3', self::SLASH_6 );
 
-		$this->assertSame( wp_unslash( $this->slash_2 ), get_comment_meta( $comment_id, 'slash_test_1', true ) );
-		$this->assertSame( wp_unslash( $this->slash_4 ), get_comment_meta( $comment_id, 'slash_test_2', true ) );
-		$this->assertSame( wp_unslash( $this->slash_6 ), get_comment_meta( $comment_id, 'slash_test_3', true ) );
+		$this->assertSame( wp_unslash( self::SLASH_2 ), get_comment_meta( $comment_id, 'slash_test_1', true ) );
+		$this->assertSame( wp_unslash( self::SLASH_4 ), get_comment_meta( $comment_id, 'slash_test_2', true ) );
+		$this->assertSame( wp_unslash( self::SLASH_6 ), get_comment_meta( $comment_id, 'slash_test_3', true ) );
 	}
 
 	/**
@@ -195,21 +196,21 @@ class Tests_Meta_Slashes extends WP_UnitTestCase {
 	public function test_add_user_meta() {
 		$user_id = self::$user_id;
 
-		add_user_meta( $user_id, 'slash_test_1', $this->slash_1 );
-		add_user_meta( $user_id, 'slash_test_2', $this->slash_3 );
-		add_user_meta( $user_id, 'slash_test_3', $this->slash_5 );
+		add_user_meta( $user_id, 'slash_test_1', self::SLASH_1 );
+		add_user_meta( $user_id, 'slash_test_2', self::SLASH_3 );
+		add_user_meta( $user_id, 'slash_test_3', self::SLASH_5 );
 
-		$this->assertSame( wp_unslash( $this->slash_1 ), get_user_meta( $user_id, 'slash_test_1', true ) );
-		$this->assertSame( wp_unslash( $this->slash_3 ), get_user_meta( $user_id, 'slash_test_2', true ) );
-		$this->assertSame( wp_unslash( $this->slash_5 ), get_user_meta( $user_id, 'slash_test_3', true ) );
+		$this->assertSame( wp_unslash( self::SLASH_1 ), get_user_meta( $user_id, 'slash_test_1', true ) );
+		$this->assertSame( wp_unslash( self::SLASH_3 ), get_user_meta( $user_id, 'slash_test_2', true ) );
+		$this->assertSame( wp_unslash( self::SLASH_5 ), get_user_meta( $user_id, 'slash_test_3', true ) );
 
-		add_user_meta( $user_id, 'slash_test_4', $this->slash_2 );
-		add_user_meta( $user_id, 'slash_test_5', $this->slash_4 );
-		add_user_meta( $user_id, 'slash_test_6', $this->slash_6 );
+		add_user_meta( $user_id, 'slash_test_4', self::SLASH_2 );
+		add_user_meta( $user_id, 'slash_test_5', self::SLASH_4 );
+		add_user_meta( $user_id, 'slash_test_6', self::SLASH_6 );
 
-		$this->assertSame( wp_unslash( $this->slash_2 ), get_user_meta( $user_id, 'slash_test_4', true ) );
-		$this->assertSame( wp_unslash( $this->slash_4 ), get_user_meta( $user_id, 'slash_test_5', true ) );
-		$this->assertSame( wp_unslash( $this->slash_6 ), get_user_meta( $user_id, 'slash_test_6', true ) );
+		$this->assertSame( wp_unslash( self::SLASH_2 ), get_user_meta( $user_id, 'slash_test_4', true ) );
+		$this->assertSame( wp_unslash( self::SLASH_4 ), get_user_meta( $user_id, 'slash_test_5', true ) );
+		$this->assertSame( wp_unslash( self::SLASH_6 ), get_user_meta( $user_id, 'slash_test_6', true ) );
 	}
 
 	/**
@@ -222,20 +223,20 @@ class Tests_Meta_Slashes extends WP_UnitTestCase {
 		add_user_meta( $user_id, 'slash_test_2', 'foo' );
 		add_user_meta( $user_id, 'slash_test_3', 'foo' );
 
-		update_user_meta( $user_id, 'slash_test_1', $this->slash_1 );
-		update_user_meta( $user_id, 'slash_test_2', $this->slash_3 );
-		update_user_meta( $user_id, 'slash_test_3', $this->slash_5 );
+		update_user_meta( $user_id, 'slash_test_1', self::SLASH_1 );
+		update_user_meta( $user_id, 'slash_test_2', self::SLASH_3 );
+		update_user_meta( $user_id, 'slash_test_3', self::SLASH_5 );
 
-		$this->assertSame( wp_unslash( $this->slash_1 ), get_user_meta( $user_id, 'slash_test_1', true ) );
-		$this->assertSame( wp_unslash( $this->slash_3 ), get_user_meta( $user_id, 'slash_test_2', true ) );
-		$this->assertSame( wp_unslash( $this->slash_5 ), get_user_meta( $user_id, 'slash_test_3', true ) );
+		$this->assertSame( wp_unslash( self::SLASH_1 ), get_user_meta( $user_id, 'slash_test_1', true ) );
+		$this->assertSame( wp_unslash( self::SLASH_3 ), get_user_meta( $user_id, 'slash_test_2', true ) );
+		$this->assertSame( wp_unslash( self::SLASH_5 ), get_user_meta( $user_id, 'slash_test_3', true ) );
 
-		update_user_meta( $user_id, 'slash_test_1', $this->slash_2 );
-		update_user_meta( $user_id, 'slash_test_2', $this->slash_4 );
-		update_user_meta( $user_id, 'slash_test_3', $this->slash_6 );
+		update_user_meta( $user_id, 'slash_test_1', self::SLASH_2 );
+		update_user_meta( $user_id, 'slash_test_2', self::SLASH_4 );
+		update_user_meta( $user_id, 'slash_test_3', self::SLASH_6 );
 
-		$this->assertSame( wp_unslash( $this->slash_2 ), get_user_meta( $user_id, 'slash_test_1', true ) );
-		$this->assertSame( wp_unslash( $this->slash_4 ), get_user_meta( $user_id, 'slash_test_2', true ) );
-		$this->assertSame( wp_unslash( $this->slash_6 ), get_user_meta( $user_id, 'slash_test_3', true ) );
+		$this->assertSame( wp_unslash( self::SLASH_2 ), get_user_meta( $user_id, 'slash_test_1', true ) );
+		$this->assertSame( wp_unslash( self::SLASH_4 ), get_user_meta( $user_id, 'slash_test_2', true ) );
+		$this->assertSame( wp_unslash( self::SLASH_6 ), get_user_meta( $user_id, 'slash_test_3', true ) );
 	}
 }

--- a/tests/phpunit/tests/option/slashes.php
+++ b/tests/phpunit/tests/option/slashes.php
@@ -7,33 +7,32 @@
  */
 class Tests_Option_Slashes extends WP_UnitTestCase {
 
-	public function set_up() {
-		parent::set_up();
+	/*
+	 * It is important to test with both even and odd numbered slashes,
+	 * as KSES does a strip-then-add slashes in some of its function calls.
+	 */
 
-		// It is important to test with both even and odd numbered slashes,
-		// as KSES does a strip-then-add slashes in some of its function calls.
-		$this->slash_1 = 'String with 1 slash \\';
-		$this->slash_2 = 'String with 2 slashes \\\\';
-		$this->slash_3 = 'String with 3 slashes \\\\\\';
-		$this->slash_4 = 'String with 4 slashes \\\\\\\\';
-		$this->slash_5 = 'String with 5 slashes \\\\\\\\\\';
-		$this->slash_6 = 'String with 6 slashes \\\\\\\\\\\\';
-		$this->slash_7 = 'String with 7 slashes \\\\\\\\\\\\\\';
-	}
+	const SLASH_1 = 'String with 1 slash \\';
+	const SLASH_2 = 'String with 2 slashes \\\\';
+	const SLASH_3 = 'String with 3 slashes \\\\\\';
+	const SLASH_4 = 'String with 4 slashes \\\\\\\\';
+	const SLASH_5 = 'String with 5 slashes \\\\\\\\\\';
+	const SLASH_6 = 'String with 6 slashes \\\\\\\\\\\\';
+	const SLASH_7 = 'String with 7 slashes \\\\\\\\\\\\\\';
 
 	/**
 	 * Tests the model function that expects un-slashed data
 	 */
 	public function test_add_option() {
-		add_option( 'slash_test_1', $this->slash_1 );
-		add_option( 'slash_test_2', $this->slash_2 );
-		add_option( 'slash_test_3', $this->slash_3 );
-		add_option( 'slash_test_4', $this->slash_4 );
+		add_option( 'slash_test_1', self::SLASH_1 );
+		add_option( 'slash_test_2', self::SLASH_2 );
+		add_option( 'slash_test_3', self::SLASH_3 );
+		add_option( 'slash_test_4', self::SLASH_4 );
 
-		$this->assertSame( $this->slash_1, get_option( 'slash_test_1' ) );
-		$this->assertSame( $this->slash_2, get_option( 'slash_test_2' ) );
-		$this->assertSame( $this->slash_3, get_option( 'slash_test_3' ) );
-		$this->assertSame( $this->slash_4, get_option( 'slash_test_4' ) );
+		$this->assertSame( self::SLASH_1, get_option( 'slash_test_1' ) );
+		$this->assertSame( self::SLASH_2, get_option( 'slash_test_2' ) );
+		$this->assertSame( self::SLASH_3, get_option( 'slash_test_3' ) );
+		$this->assertSame( self::SLASH_4, get_option( 'slash_test_4' ) );
 	}
 
 	/**
@@ -42,16 +41,16 @@ class Tests_Option_Slashes extends WP_UnitTestCase {
 	public function test_update_option() {
 		add_option( 'slash_test_5', 'foo' );
 
-		update_option( 'slash_test_5', $this->slash_1 );
-		$this->assertSame( $this->slash_1, get_option( 'slash_test_5' ) );
+		update_option( 'slash_test_5', self::SLASH_1 );
+		$this->assertSame( self::SLASH_1, get_option( 'slash_test_5' ) );
 
-		update_option( 'slash_test_5', $this->slash_2 );
-		$this->assertSame( $this->slash_2, get_option( 'slash_test_5' ) );
+		update_option( 'slash_test_5', self::SLASH_2 );
+		$this->assertSame( self::SLASH_2, get_option( 'slash_test_5' ) );
 
-		update_option( 'slash_test_5', $this->slash_3 );
-		$this->assertSame( $this->slash_3, get_option( 'slash_test_5' ) );
+		update_option( 'slash_test_5', self::SLASH_3 );
+		$this->assertSame( self::SLASH_3, get_option( 'slash_test_5' ) );
 
-		update_option( 'slash_test_5', $this->slash_4 );
-		$this->assertSame( $this->slash_4, get_option( 'slash_test_5' ) );
+		update_option( 'slash_test_5', self::SLASH_4 );
+		$this->assertSame( self::SLASH_4, get_option( 'slash_test_5' ) );
 	}
 }

--- a/tests/phpunit/tests/post/slashes.php
+++ b/tests/phpunit/tests/post/slashes.php
@@ -6,6 +6,20 @@
  * @ticket 21767
  */
 class Tests_Post_Slashes extends WP_UnitTestCase {
+
+	/*
+	 * It is important to test with both even and odd numbered slashes,
+	 * as KSES does a strip-then-add slashes in some of its function calls.
+	 */
+
+	const SLASH_1 = 'String with 1 slash \\';
+	const SLASH_2 = 'String with 2 slashes \\\\';
+	const SLASH_3 = 'String with 3 slashes \\\\\\';
+	const SLASH_4 = 'String with 4 slashes \\\\\\\\';
+	const SLASH_5 = 'String with 5 slashes \\\\\\\\\\';
+	const SLASH_6 = 'String with 6 slashes \\\\\\\\\\\\';
+	const SLASH_7 = 'String with 7 slashes \\\\\\\\\\\\\\';
+
 	protected static $author_id;
 	protected static $post_id;
 
@@ -18,16 +32,6 @@ class Tests_Post_Slashes extends WP_UnitTestCase {
 		parent::set_up();
 
 		wp_set_current_user( self::$author_id );
-
-		// It is important to test with both even and odd numbered slashes,
-		// as KSES does a strip-then-add slashes in some of its function calls.
-		$this->slash_1 = 'String with 1 slash \\';
-		$this->slash_2 = 'String with 2 slashes \\\\';
-		$this->slash_3 = 'String with 3 slashes \\\\\\';
-		$this->slash_4 = 'String with 4 slashes \\\\\\\\';
-		$this->slash_5 = 'String with 5 slashes \\\\\\\\\\';
-		$this->slash_6 = 'String with 6 slashes \\\\\\\\\\\\';
-		$this->slash_7 = 'String with 7 slashes \\\\\\\\\\\\\\';
 	}
 
 	/**
@@ -38,33 +42,33 @@ class Tests_Post_Slashes extends WP_UnitTestCase {
 
 		$_POST               = array();
 		$_POST['post_ID']    = $post_id;
-		$_POST['post_title'] = $this->slash_1;
-		$_POST['content']    = $this->slash_5;
-		$_POST['excerpt']    = $this->slash_7;
+		$_POST['post_title'] = self::SLASH_1;
+		$_POST['content']    = self::SLASH_5;
+		$_POST['excerpt']    = self::SLASH_7;
 
 		$_POST = add_magic_quotes( $_POST ); // The edit_post() function will strip slashes.
 
 		$post_id = edit_post();
 		$post    = get_post( $post_id );
 
-		$this->assertSame( $this->slash_1, $post->post_title );
-		$this->assertSame( $this->slash_5, $post->post_content );
-		$this->assertSame( $this->slash_7, $post->post_excerpt );
+		$this->assertSame( self::SLASH_1, $post->post_title );
+		$this->assertSame( self::SLASH_5, $post->post_content );
+		$this->assertSame( self::SLASH_7, $post->post_excerpt );
 
 		$_POST               = array();
 		$_POST['post_ID']    = $post_id;
-		$_POST['post_title'] = $this->slash_2;
-		$_POST['content']    = $this->slash_4;
-		$_POST['excerpt']    = $this->slash_6;
+		$_POST['post_title'] = self::SLASH_2;
+		$_POST['content']    = self::SLASH_4;
+		$_POST['excerpt']    = self::SLASH_6;
 
 		$_POST = add_magic_quotes( $_POST ); // The edit_post() function will strip slashes.
 
 		$post_id = edit_post();
 		$post    = get_post( $post_id );
 
-		$this->assertSame( $this->slash_2, $post->post_title );
-		$this->assertSame( $this->slash_4, $post->post_content );
-		$this->assertSame( $this->slash_6, $post->post_excerpt );
+		$this->assertSame( self::SLASH_2, $post->post_title );
+		$this->assertSame( self::SLASH_4, $post->post_content );
+		$this->assertSame( self::SLASH_6, $post->post_excerpt );
 	}
 
 	/**
@@ -74,33 +78,33 @@ class Tests_Post_Slashes extends WP_UnitTestCase {
 		$post_id = wp_insert_post(
 			array(
 				'post_status'  => 'publish',
-				'post_title'   => $this->slash_1,
-				'post_content' => $this->slash_3,
-				'post_excerpt' => $this->slash_5,
+				'post_title'   => self::SLASH_1,
+				'post_content' => self::SLASH_3,
+				'post_excerpt' => self::SLASH_5,
 				'post_type'    => 'post',
 				'slashed'      => false,
 			)
 		);
 		$post    = get_post( $post_id );
 
-		$this->assertSame( wp_unslash( $this->slash_1 ), $post->post_title );
-		$this->assertSame( wp_unslash( $this->slash_3 ), $post->post_content );
-		$this->assertSame( wp_unslash( $this->slash_5 ), $post->post_excerpt );
+		$this->assertSame( wp_unslash( self::SLASH_1 ), $post->post_title );
+		$this->assertSame( wp_unslash( self::SLASH_3 ), $post->post_content );
+		$this->assertSame( wp_unslash( self::SLASH_5 ), $post->post_excerpt );
 
 		$post_id = wp_insert_post(
 			array(
 				'post_status'  => 'publish',
-				'post_title'   => $this->slash_2,
-				'post_content' => $this->slash_4,
-				'post_excerpt' => $this->slash_6,
+				'post_title'   => self::SLASH_2,
+				'post_content' => self::SLASH_4,
+				'post_excerpt' => self::SLASH_6,
 				'post_type'    => 'post',
 			)
 		);
 		$post    = get_post( $post_id );
 
-		$this->assertSame( wp_unslash( $this->slash_2 ), $post->post_title );
-		$this->assertSame( wp_unslash( $this->slash_4 ), $post->post_content );
-		$this->assertSame( wp_unslash( $this->slash_6 ), $post->post_excerpt );
+		$this->assertSame( wp_unslash( self::SLASH_2 ), $post->post_title );
+		$this->assertSame( wp_unslash( self::SLASH_4 ), $post->post_content );
+		$this->assertSame( wp_unslash( self::SLASH_6 ), $post->post_excerpt );
 	}
 
 	/**
@@ -112,30 +116,30 @@ class Tests_Post_Slashes extends WP_UnitTestCase {
 		wp_update_post(
 			array(
 				'ID'           => $post_id,
-				'post_title'   => $this->slash_1,
-				'post_content' => $this->slash_3,
-				'post_excerpt' => $this->slash_5,
+				'post_title'   => self::SLASH_1,
+				'post_content' => self::SLASH_3,
+				'post_excerpt' => self::SLASH_5,
 			)
 		);
 		$post = get_post( $post_id );
 
-		$this->assertSame( wp_unslash( $this->slash_1 ), $post->post_title );
-		$this->assertSame( wp_unslash( $this->slash_3 ), $post->post_content );
-		$this->assertSame( wp_unslash( $this->slash_5 ), $post->post_excerpt );
+		$this->assertSame( wp_unslash( self::SLASH_1 ), $post->post_title );
+		$this->assertSame( wp_unslash( self::SLASH_3 ), $post->post_content );
+		$this->assertSame( wp_unslash( self::SLASH_5 ), $post->post_excerpt );
 
 		wp_update_post(
 			array(
 				'ID'           => $post_id,
-				'post_title'   => $this->slash_2,
-				'post_content' => $this->slash_4,
-				'post_excerpt' => $this->slash_6,
+				'post_title'   => self::SLASH_2,
+				'post_content' => self::SLASH_4,
+				'post_excerpt' => self::SLASH_6,
 			)
 		);
 		$post = get_post( $post_id );
 
-		$this->assertSame( wp_unslash( $this->slash_2 ), $post->post_title );
-		$this->assertSame( wp_unslash( $this->slash_4 ), $post->post_content );
-		$this->assertSame( wp_unslash( $this->slash_6 ), $post->post_excerpt );
+		$this->assertSame( wp_unslash( self::SLASH_2 ), $post->post_title );
+		$this->assertSame( wp_unslash( self::SLASH_4 ), $post->post_content );
+		$this->assertSame( wp_unslash( self::SLASH_6 ), $post->post_excerpt );
 	}
 
 	/**
@@ -143,9 +147,9 @@ class Tests_Post_Slashes extends WP_UnitTestCase {
 	 */
 	public function test_wp_trash_untrash() {
 		$post    = array(
-			'post_title'   => $this->slash_1,
-			'post_content' => $this->slash_3,
-			'post_excerpt' => $this->slash_5,
+			'post_title'   => self::SLASH_1,
+			'post_content' => self::SLASH_3,
+			'post_excerpt' => self::SLASH_5,
 		);
 		$post_id = wp_insert_post( wp_slash( $post ) );
 
@@ -154,17 +158,17 @@ class Tests_Post_Slashes extends WP_UnitTestCase {
 
 		$post = get_post( $post_id );
 
-		$this->assertSame( $this->slash_1, $post->post_title );
-		$this->assertSame( $this->slash_3, $post->post_content );
-		$this->assertSame( $this->slash_5, $post->post_excerpt );
+		$this->assertSame( self::SLASH_1, $post->post_title );
+		$this->assertSame( self::SLASH_3, $post->post_content );
+		$this->assertSame( self::SLASH_5, $post->post_excerpt );
 
 		$untrashed = wp_untrash_post( $post_id );
 		$this->assertNotEmpty( $untrashed );
 
 		$post = get_post( $post_id );
 
-		$this->assertSame( $this->slash_1, $post->post_title );
-		$this->assertSame( $this->slash_3, $post->post_content );
-		$this->assertSame( $this->slash_5, $post->post_excerpt );
+		$this->assertSame( self::SLASH_1, $post->post_title );
+		$this->assertSame( self::SLASH_3, $post->post_content );
+		$this->assertSame( self::SLASH_5, $post->post_excerpt );
 	}
 }

--- a/tests/phpunit/tests/term/slashes.php
+++ b/tests/phpunit/tests/term/slashes.php
@@ -6,6 +6,20 @@
  * @ticket 21767
  */
 class Tests_Term_Slashes extends WP_Ajax_UnitTestCase {
+
+	/*
+	 * It is important to test with both even and odd numbered slashes,
+	 * as KSES does a strip-then-add slashes in some of its function calls.
+	 */
+
+	const SLASH_1 = 'String with 1 slash \\';
+	const SLASH_2 = 'String with 2 slashes \\\\';
+	const SLASH_3 = 'String with 3 slashes \\\\\\';
+	const SLASH_4 = 'String with 4 slashes \\\\\\\\';
+	const SLASH_5 = 'String with 5 slashes \\\\\\\\\\';
+	const SLASH_6 = 'String with 6 slashes \\\\\\\\\\\\';
+	const SLASH_7 = 'String with 7 slashes \\\\\\\\\\\\\\';
+
 	protected static $author_id;
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
@@ -16,14 +30,6 @@ class Tests_Term_Slashes extends WP_Ajax_UnitTestCase {
 		parent::set_up();
 
 		wp_set_current_user( self::$author_id );
-
-		$this->slash_1 = 'String with 1 slash \\';
-		$this->slash_2 = 'String with 2 slashes \\\\';
-		$this->slash_3 = 'String with 3 slashes \\\\\\';
-		$this->slash_4 = 'String with 4 slashes \\\\\\\\';
-		$this->slash_5 = 'String with 5 slashes \\\\\\\\\\';
-		$this->slash_6 = 'String with 6 slashes \\\\\\\\\\\\';
-		$this->slash_7 = 'String with 7 slashes \\\\\\\\\\\\\\';
 	}
 
 	/**
@@ -36,40 +42,40 @@ class Tests_Term_Slashes extends WP_Ajax_UnitTestCase {
 		);
 		foreach ( $taxonomies as $taxonomy ) {
 			$insert = wp_insert_term(
-				$this->slash_1,
+				self::SLASH_1,
 				$taxonomy,
 				array(
 					'slug'        => 'slash_test_1_' . $taxonomy,
-					'description' => $this->slash_3,
+					'description' => self::SLASH_3,
 				)
 			);
 			$term   = get_term( $insert['term_id'], $taxonomy );
-			$this->assertSame( wp_unslash( $this->slash_1 ), $term->name );
-			$this->assertSame( wp_unslash( $this->slash_3 ), $term->description );
+			$this->assertSame( wp_unslash( self::SLASH_1 ), $term->name );
+			$this->assertSame( wp_unslash( self::SLASH_3 ), $term->description );
 
 			$insert = wp_insert_term(
-				$this->slash_3,
+				self::SLASH_3,
 				$taxonomy,
 				array(
 					'slug'        => 'slash_test_2_' . $taxonomy,
-					'description' => $this->slash_5,
+					'description' => self::SLASH_5,
 				)
 			);
 			$term   = get_term( $insert['term_id'], $taxonomy );
-			$this->assertSame( wp_unslash( $this->slash_3 ), $term->name );
-			$this->assertSame( wp_unslash( $this->slash_5 ), $term->description );
+			$this->assertSame( wp_unslash( self::SLASH_3 ), $term->name );
+			$this->assertSame( wp_unslash( self::SLASH_5 ), $term->description );
 
 			$insert = wp_insert_term(
-				$this->slash_2,
+				self::SLASH_2,
 				$taxonomy,
 				array(
 					'slug'        => 'slash_test_3_' . $taxonomy,
-					'description' => $this->slash_4,
+					'description' => self::SLASH_4,
 				)
 			);
 			$term   = get_term( $insert['term_id'], $taxonomy );
-			$this->assertSame( wp_unslash( $this->slash_2 ), $term->name );
-			$this->assertSame( wp_unslash( $this->slash_4 ), $term->description );
+			$this->assertSame( wp_unslash( self::SLASH_2 ), $term->name );
+			$this->assertSame( wp_unslash( self::SLASH_4 ), $term->description );
 		}
 	}
 
@@ -92,38 +98,38 @@ class Tests_Term_Slashes extends WP_Ajax_UnitTestCase {
 				$term_id,
 				$taxonomy,
 				array(
-					'name'        => $this->slash_1,
-					'description' => $this->slash_3,
+					'name'        => self::SLASH_1,
+					'description' => self::SLASH_3,
 				)
 			);
 
 			$term = get_term( $term_id, $taxonomy );
-			$this->assertSame( wp_unslash( $this->slash_1 ), $term->name );
-			$this->assertSame( wp_unslash( $this->slash_3 ), $term->description );
+			$this->assertSame( wp_unslash( self::SLASH_1 ), $term->name );
+			$this->assertSame( wp_unslash( self::SLASH_3 ), $term->description );
 
 			$update = wp_update_term(
 				$term_id,
 				$taxonomy,
 				array(
-					'name'        => $this->slash_3,
-					'description' => $this->slash_5,
+					'name'        => self::SLASH_3,
+					'description' => self::SLASH_5,
 				)
 			);
 			$term   = get_term( $term_id, $taxonomy );
-			$this->assertSame( wp_unslash( $this->slash_3 ), $term->name );
-			$this->assertSame( wp_unslash( $this->slash_5 ), $term->description );
+			$this->assertSame( wp_unslash( self::SLASH_3 ), $term->name );
+			$this->assertSame( wp_unslash( self::SLASH_5 ), $term->description );
 
 			$update = wp_update_term(
 				$term_id,
 				$taxonomy,
 				array(
-					'name'        => $this->slash_2,
-					'description' => $this->slash_4,
+					'name'        => self::SLASH_2,
+					'description' => self::SLASH_4,
 				)
 			);
 			$term   = get_term( $term_id, $taxonomy );
-			$this->assertSame( wp_unslash( $this->slash_2 ), $term->name );
-			$this->assertSame( wp_unslash( $this->slash_4 ), $term->description );
+			$this->assertSame( wp_unslash( self::SLASH_2 ), $term->name );
+			$this->assertSame( wp_unslash( self::SLASH_4 ), $term->description );
 		}
 	}
 }

--- a/tests/phpunit/tests/user/slashes.php
+++ b/tests/phpunit/tests/user/slashes.php
@@ -6,6 +6,20 @@
  * @ticket 21767
  */
 class Tests_User_Slashes extends WP_UnitTestCase {
+
+	/*
+	 * It is important to test with both even and odd numbered slashes,
+	 * as KSES does a strip-then-add slashes in some of its function calls.
+	 */
+
+	const SLASH_1 = 'String with 1 slash \\';
+	const SLASH_2 = 'String with 2 slashes \\\\';
+	const SLASH_3 = 'String with 3 slashes \\\\\\';
+	const SLASH_4 = 'String with 4 slashes \\\\\\\\';
+	const SLASH_5 = 'String with 5 slashes \\\\\\\\\\';
+	const SLASH_6 = 'String with 6 slashes \\\\\\\\\\\\';
+	const SLASH_7 = 'String with 7 slashes \\\\\\\\\\\\\\';
+
 	protected static $author_id;
 	protected static $user_id;
 
@@ -18,16 +32,6 @@ class Tests_User_Slashes extends WP_UnitTestCase {
 		parent::set_up();
 
 		wp_set_current_user( self::$author_id );
-
-		// It is important to test with both even and odd numbered slashes,
-		// as KSES does a strip-then-add slashes in some of its function calls.
-		$this->slash_1 = 'String with 1 slash \\';
-		$this->slash_2 = 'String with 2 slashes \\\\';
-		$this->slash_3 = 'String with 3 slashes \\\\\\';
-		$this->slash_4 = 'String with 4 slashes \\\\\\\\';
-		$this->slash_5 = 'String with 5 slashes \\\\\\\\\\';
-		$this->slash_6 = 'String with 6 slashes \\\\\\\\\\\\';
-		$this->slash_7 = 'String with 7 slashes \\\\\\\\\\\\\\';
 	}
 
 	/**
@@ -42,22 +46,22 @@ class Tests_User_Slashes extends WP_UnitTestCase {
 		$_POST['pass2']        = 'password';
 		$_POST['role']         = 'subscriber';
 		$_POST['email']        = 'user1@example.com';
-		$_POST['first_name']   = $this->slash_1;
-		$_POST['last_name']    = $this->slash_3;
-		$_POST['nickname']     = $this->slash_5;
-		$_POST['display_name'] = $this->slash_7;
-		$_POST['description']  = $this->slash_3;
+		$_POST['first_name']   = self::SLASH_1;
+		$_POST['last_name']    = self::SLASH_3;
+		$_POST['nickname']     = self::SLASH_5;
+		$_POST['display_name'] = self::SLASH_7;
+		$_POST['description']  = self::SLASH_3;
 
 		$_POST = add_magic_quotes( $_POST ); // The add_user() function will strip slashes.
 
 		$user_id = add_user();
 		$user    = get_user_to_edit( $user_id );
 
-		$this->assertSame( $this->slash_1, $user->first_name );
-		$this->assertSame( $this->slash_3, $user->last_name );
-		$this->assertSame( $this->slash_5, $user->nickname );
-		$this->assertSame( $this->slash_7, $user->display_name );
-		$this->assertSame( $this->slash_3, $user->description );
+		$this->assertSame( self::SLASH_1, $user->first_name );
+		$this->assertSame( self::SLASH_3, $user->last_name );
+		$this->assertSame( self::SLASH_5, $user->nickname );
+		$this->assertSame( self::SLASH_7, $user->display_name );
+		$this->assertSame( self::SLASH_3, $user->description );
 
 		$_POST                 = array();
 		$_GET                  = array();
@@ -67,22 +71,22 @@ class Tests_User_Slashes extends WP_UnitTestCase {
 		$_POST['pass2']        = 'password';
 		$_POST['role']         = 'subscriber';
 		$_POST['email']        = 'user2@example.com';
-		$_POST['first_name']   = $this->slash_2;
-		$_POST['last_name']    = $this->slash_4;
-		$_POST['nickname']     = $this->slash_6;
-		$_POST['display_name'] = $this->slash_2;
-		$_POST['description']  = $this->slash_4;
+		$_POST['first_name']   = self::SLASH_2;
+		$_POST['last_name']    = self::SLASH_4;
+		$_POST['nickname']     = self::SLASH_6;
+		$_POST['display_name'] = self::SLASH_2;
+		$_POST['description']  = self::SLASH_4;
 
 		$_POST = add_magic_quotes( $_POST ); // The add_user() function will strip slashes.
 
 		$user_id = add_user();
 		$user    = get_user_to_edit( $user_id );
 
-		$this->assertSame( $this->slash_2, $user->first_name );
-		$this->assertSame( $this->slash_4, $user->last_name );
-		$this->assertSame( $this->slash_6, $user->nickname );
-		$this->assertSame( $this->slash_2, $user->display_name );
-		$this->assertSame( $this->slash_4, $user->description );
+		$this->assertSame( self::SLASH_2, $user->first_name );
+		$this->assertSame( self::SLASH_4, $user->last_name );
+		$this->assertSame( self::SLASH_6, $user->nickname );
+		$this->assertSame( self::SLASH_2, $user->display_name );
+		$this->assertSame( self::SLASH_4, $user->description );
 	}
 
 	/**
@@ -96,44 +100,44 @@ class Tests_User_Slashes extends WP_UnitTestCase {
 		$_REQUEST              = array();
 		$_POST['role']         = 'subscriber';
 		$_POST['email']        = 'user1@example.com';
-		$_POST['first_name']   = $this->slash_1;
-		$_POST['last_name']    = $this->slash_3;
-		$_POST['nickname']     = $this->slash_5;
-		$_POST['display_name'] = $this->slash_7;
-		$_POST['description']  = $this->slash_3;
+		$_POST['first_name']   = self::SLASH_1;
+		$_POST['last_name']    = self::SLASH_3;
+		$_POST['nickname']     = self::SLASH_5;
+		$_POST['display_name'] = self::SLASH_7;
+		$_POST['description']  = self::SLASH_3;
 
 		$_POST = add_magic_quotes( $_POST ); // The edit_user() function will strip slashes.
 
 		$user_id = edit_user( $user_id );
 		$user    = get_user_to_edit( $user_id );
 
-		$this->assertSame( $this->slash_1, $user->first_name );
-		$this->assertSame( $this->slash_3, $user->last_name );
-		$this->assertSame( $this->slash_5, $user->nickname );
-		$this->assertSame( $this->slash_7, $user->display_name );
-		$this->assertSame( $this->slash_3, $user->description );
+		$this->assertSame( self::SLASH_1, $user->first_name );
+		$this->assertSame( self::SLASH_3, $user->last_name );
+		$this->assertSame( self::SLASH_5, $user->nickname );
+		$this->assertSame( self::SLASH_7, $user->display_name );
+		$this->assertSame( self::SLASH_3, $user->description );
 
 		$_POST                 = array();
 		$_GET                  = array();
 		$_REQUEST              = array();
 		$_POST['role']         = 'subscriber';
 		$_POST['email']        = 'user2@example.com';
-		$_POST['first_name']   = $this->slash_2;
-		$_POST['last_name']    = $this->slash_4;
-		$_POST['nickname']     = $this->slash_6;
-		$_POST['display_name'] = $this->slash_2;
-		$_POST['description']  = $this->slash_4;
+		$_POST['first_name']   = self::SLASH_2;
+		$_POST['last_name']    = self::SLASH_4;
+		$_POST['nickname']     = self::SLASH_6;
+		$_POST['display_name'] = self::SLASH_2;
+		$_POST['description']  = self::SLASH_4;
 
 		$_POST = add_magic_quotes( $_POST ); // The edit_user() function will strip slashes.
 
 		$user_id = edit_user( $user_id );
 		$user    = get_user_to_edit( $user_id );
 
-		$this->assertSame( $this->slash_2, $user->first_name );
-		$this->assertSame( $this->slash_4, $user->last_name );
-		$this->assertSame( $this->slash_6, $user->nickname );
-		$this->assertSame( $this->slash_2, $user->display_name );
-		$this->assertSame( $this->slash_4, $user->description );
+		$this->assertSame( self::SLASH_2, $user->first_name );
+		$this->assertSame( self::SLASH_4, $user->last_name );
+		$this->assertSame( self::SLASH_6, $user->nickname );
+		$this->assertSame( self::SLASH_2, $user->display_name );
+		$this->assertSame( self::SLASH_4, $user->description );
 	}
 
 	/**
@@ -145,42 +149,42 @@ class Tests_User_Slashes extends WP_UnitTestCase {
 				'user_login'   => 'slash_example_user_3',
 				'role'         => 'subscriber',
 				'email'        => 'user3@example.com',
-				'first_name'   => $this->slash_1,
-				'last_name'    => $this->slash_3,
-				'nickname'     => $this->slash_5,
-				'display_name' => $this->slash_7,
-				'description'  => $this->slash_3,
+				'first_name'   => self::SLASH_1,
+				'last_name'    => self::SLASH_3,
+				'nickname'     => self::SLASH_5,
+				'display_name' => self::SLASH_7,
+				'description'  => self::SLASH_3,
 				'user_pass'    => '',
 			)
 		);
 		$user    = get_user_to_edit( $user_id );
 
-		$this->assertSame( wp_unslash( $this->slash_1 ), $user->first_name );
-		$this->assertSame( wp_unslash( $this->slash_3 ), $user->last_name );
-		$this->assertSame( wp_unslash( $this->slash_5 ), $user->nickname );
-		$this->assertSame( wp_unslash( $this->slash_7 ), $user->display_name );
-		$this->assertSame( wp_unslash( $this->slash_3 ), $user->description );
+		$this->assertSame( wp_unslash( self::SLASH_1 ), $user->first_name );
+		$this->assertSame( wp_unslash( self::SLASH_3 ), $user->last_name );
+		$this->assertSame( wp_unslash( self::SLASH_5 ), $user->nickname );
+		$this->assertSame( wp_unslash( self::SLASH_7 ), $user->display_name );
+		$this->assertSame( wp_unslash( self::SLASH_3 ), $user->description );
 
 		$user_id = wp_insert_user(
 			array(
 				'user_login'   => 'slash_example_user_4',
 				'role'         => 'subscriber',
 				'email'        => 'user3@example.com',
-				'first_name'   => $this->slash_2,
-				'last_name'    => $this->slash_4,
-				'nickname'     => $this->slash_6,
-				'display_name' => $this->slash_2,
-				'description'  => $this->slash_4,
+				'first_name'   => self::SLASH_2,
+				'last_name'    => self::SLASH_4,
+				'nickname'     => self::SLASH_6,
+				'display_name' => self::SLASH_2,
+				'description'  => self::SLASH_4,
 				'user_pass'    => '',
 			)
 		);
 		$user    = get_user_to_edit( $user_id );
 
-		$this->assertSame( wp_unslash( $this->slash_2 ), $user->first_name );
-		$this->assertSame( wp_unslash( $this->slash_4 ), $user->last_name );
-		$this->assertSame( wp_unslash( $this->slash_6 ), $user->nickname );
-		$this->assertSame( wp_unslash( $this->slash_2 ), $user->display_name );
-		$this->assertSame( wp_unslash( $this->slash_4 ), $user->description );
+		$this->assertSame( wp_unslash( self::SLASH_2 ), $user->first_name );
+		$this->assertSame( wp_unslash( self::SLASH_4 ), $user->last_name );
+		$this->assertSame( wp_unslash( self::SLASH_6 ), $user->nickname );
+		$this->assertSame( wp_unslash( self::SLASH_2 ), $user->display_name );
+		$this->assertSame( wp_unslash( self::SLASH_4 ), $user->description );
 	}
 
 	/**
@@ -192,39 +196,39 @@ class Tests_User_Slashes extends WP_UnitTestCase {
 			array(
 				'ID'           => $user_id,
 				'role'         => 'subscriber',
-				'first_name'   => $this->slash_1,
-				'last_name'    => $this->slash_3,
-				'nickname'     => $this->slash_5,
-				'display_name' => $this->slash_7,
-				'description'  => $this->slash_3,
+				'first_name'   => self::SLASH_1,
+				'last_name'    => self::SLASH_3,
+				'nickname'     => self::SLASH_5,
+				'display_name' => self::SLASH_7,
+				'description'  => self::SLASH_3,
 			)
 		);
 		$user    = get_user_to_edit( $user_id );
 
-		$this->assertSame( wp_unslash( $this->slash_1 ), $user->first_name );
-		$this->assertSame( wp_unslash( $this->slash_3 ), $user->last_name );
-		$this->assertSame( wp_unslash( $this->slash_5 ), $user->nickname );
-		$this->assertSame( wp_unslash( $this->slash_7 ), $user->display_name );
-		$this->assertSame( wp_unslash( $this->slash_3 ), $user->description );
+		$this->assertSame( wp_unslash( self::SLASH_1 ), $user->first_name );
+		$this->assertSame( wp_unslash( self::SLASH_3 ), $user->last_name );
+		$this->assertSame( wp_unslash( self::SLASH_5 ), $user->nickname );
+		$this->assertSame( wp_unslash( self::SLASH_7 ), $user->display_name );
+		$this->assertSame( wp_unslash( self::SLASH_3 ), $user->description );
 
 		$user_id = wp_update_user(
 			array(
 				'ID'           => $user_id,
 				'role'         => 'subscriber',
-				'first_name'   => $this->slash_2,
-				'last_name'    => $this->slash_4,
-				'nickname'     => $this->slash_6,
-				'display_name' => $this->slash_2,
-				'description'  => $this->slash_4,
+				'first_name'   => self::SLASH_2,
+				'last_name'    => self::SLASH_4,
+				'nickname'     => self::SLASH_6,
+				'display_name' => self::SLASH_2,
+				'description'  => self::SLASH_4,
 			)
 		);
 		$user    = get_user_to_edit( $user_id );
 
-		$this->assertSame( wp_unslash( $this->slash_2 ), $user->first_name );
-		$this->assertSame( wp_unslash( $this->slash_4 ), $user->last_name );
-		$this->assertSame( wp_unslash( $this->slash_6 ), $user->nickname );
-		$this->assertSame( wp_unslash( $this->slash_2 ), $user->display_name );
-		$this->assertSame( wp_unslash( $this->slash_4 ), $user->description );
+		$this->assertSame( wp_unslash( self::SLASH_2 ), $user->first_name );
+		$this->assertSame( wp_unslash( self::SLASH_4 ), $user->last_name );
+		$this->assertSame( wp_unslash( self::SLASH_6 ), $user->nickname );
+		$this->assertSame( wp_unslash( self::SLASH_2 ), $user->display_name );
+		$this->assertSame( wp_unslash( self::SLASH_4 ), $user->description );
 	}
 
 }


### PR DESCRIPTION
Dynamic (non-explicitly declared) properties are deprecated as of PHP 8.2 and are expected to become a fatal error in PHP 9.0.

In this particular case, the test classes contain a `set_up()` method which sets a group of properties, which are _used_ by the tests, but the value of these properties are never _changed_ by the tests.

In other words, setting these properties in the `set_up()` is an unnecessary overhead and the properties should be changed to class constants.

Trac ticket: https://core.trac.wordpress.org/ticket/56033

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
