### PR TITLE
PHP 8.2 | Tests_Media: remove dynamic properties + minor test improvements

### DIFF
--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -5,6 +5,25 @@
  * @group shortcode
  */
 class Tests_Media extends WP_UnitTestCase {
+
+	const CAPTION           = 'A simple caption.';
+	const ALTERNATE_CAPTION = 'Alternate caption.';
+
+	const HTML_CONTENT = <<<'CAP'
+A <strong class='classy'>bolded</strong> <em>caption</em> with a <a href="#">link</a>.
+CAP;
+	const IMG_CONTENT  = <<<'CAP'
+<img src="pic.jpg" id='anId' alt="pic"/>
+CAP;
+
+	const IMG_NAME = 'image.jpg';
+	const IMG_URL  = 'http://' . WP_TESTS_DOMAIN . '/wp-content/uploads/' . self::IMG_NAME;
+	const IMG_META = array(
+		'width'  => 100,
+		'height' => 100,
+		'sizes'  => '',
+	);
+
 	protected static $large_id;
 	protected static $_sizes;
 	protected static $large_filename = 'test-image-large.jpg';
@@ -56,26 +75,6 @@ class Tests_Media extends WP_UnitTestCase {
 		parent::tear_down_after_class();
 	}
 
-	public function set_up() {
-		parent::set_up();
-		$this->caption           = 'A simple caption.';
-		$this->alternate_caption = 'Alternate caption.';
-		$this->html_content      = <<<CAP
-A <strong class='classy'>bolded</strong> <em>caption</em> with a <a href="#">link</a>.
-CAP;
-		$this->img_content       = <<<CAP
-<img src="pic.jpg" id='anId' alt="pic"/>
-CAP;
-		$this->img_name          = 'image.jpg';
-		$this->img_url           = 'http://' . WP_TESTS_DOMAIN . '/wp-content/uploads/' . $this->img_name;
-		$this->img_html          = '<img src="' . $this->img_url . '"/>';
-		$this->img_meta          = array(
-			'width'  => 100,
-			'height' => 100,
-			'sizes'  => '',
-		);
-	}
-
 	public function test_img_caption_shortcode_added() {
 		global $shortcode_tags;
 		$this->assertSame( 'img_caption_shortcode', $shortcode_tags['caption'] );
@@ -91,8 +90,8 @@ CAP;
 	 * @ticket 33981
 	 */
 	public function test_img_caption_shortcode_with_empty_params_but_content() {
-		$result = img_caption_shortcode( array(), $this->caption );
-		$this->assertSame( $this->caption, $result );
+		$result = img_caption_shortcode( array(), self::CAPTION );
+		$this->assertSame( self::CAPTION, $result );
 	}
 
 	/**
@@ -101,15 +100,15 @@ CAP;
 	public function test_img_caption_shortcode_short_circuit_filter() {
 		add_filter( 'img_caption_shortcode', array( $this, 'return_alt_caption' ) );
 
-		$result = img_caption_shortcode( array(), $this->caption );
-		$this->assertSame( $this->alternate_caption, $result );
+		$result = img_caption_shortcode( array(), self::CAPTION );
+		$this->assertSame( self::ALTERNATE_CAPTION, $result );
 	}
 
 	/**
 	 * Filter used in test_img_caption_shortcode_short_circuit_filter()
 	 */
 	public function return_alt_caption() {
-		return $this->alternate_caption;
+		return self::ALTERNATE_CAPTION;
 	}
 
 	/**
@@ -120,9 +119,9 @@ CAP;
 			array(
 				'width' => 0,
 			),
-			$this->caption
+			self::CAPTION
 		);
-		$this->assertSame( $this->caption, $result );
+		$this->assertSame( self::CAPTION, $result );
 	}
 
 	/**
@@ -145,22 +144,22 @@ CAP;
 			array(
 				'caption' => '',
 			),
-			$this->caption
+			self::CAPTION
 		);
-		$this->assertSame( $this->caption, $result );
+		$this->assertSame( self::CAPTION, $result );
 	}
 
 	public function test_img_caption_shortcode_with_old_format() {
 		$result = img_caption_shortcode(
 			array(
 				'width'   => 20,
-				'caption' => $this->caption,
+				'caption' => self::CAPTION,
 			)
 		);
 
 		$this->assertSame( 2, preg_match_all( '/wp-caption/', $result, $_r ) );
 		$this->assertSame( 1, preg_match_all( '/alignnone/', $result, $_r ) );
-		$this->assertSame( 1, preg_match_all( "/{$this->caption}/", $result, $_r ) );
+		$this->assertSame( 1, preg_match_all( '/' . self::CAPTION . '/', $result, $_r ) );
 
 		if ( current_theme_supports( 'html5', 'caption' ) ) {
 			$this->assertSame( 1, preg_match_all( '/width: 20/', $result, $_r ) );
@@ -173,14 +172,14 @@ CAP;
 		$result = img_caption_shortcode(
 			array(
 				'width'   => 20,
-				'caption' => $this->caption,
+				'caption' => self::CAPTION,
 				'id'      => '"myId',
 				'align'   => '&myAlignment',
 			)
 		);
 		$this->assertSame( 1, preg_match_all( '/wp-caption &amp;myAlignment/', $result, $_r ) );
 		$this->assertSame( 1, preg_match_all( '/id="myId"/', $result, $_r ) );
-		$this->assertSame( 1, preg_match_all( "/{$this->caption}/", $result, $_r ) );
+		$this->assertSame( 1, preg_match_all( '/' . self::CAPTION . '/', $result, $_r ) );
 	}
 
 	public function test_img_caption_shortcode_with_old_format_and_class() {
@@ -188,7 +187,7 @@ CAP;
 			array(
 				'width'   => 20,
 				'class'   => 'some-class another-class',
-				'caption' => $this->caption,
+				'caption' => self::CAPTION,
 			)
 		);
 		$this->assertSame( 1, preg_match_all( '/wp-caption alignnone some-class another-class/', $result, $_r ) );
@@ -199,10 +198,10 @@ CAP;
 		$result   = img_caption_shortcode(
 			array(
 				'width'   => 20,
-				'caption' => $this->html_content,
+				'caption' => self::HTML_CONTENT,
 			)
 		);
-		$our_preg = preg_quote( $this->html_content );
+		$our_preg = preg_quote( self::HTML_CONTENT );
 
 		$this->assertSame( 1, preg_match_all( "~{$our_preg}~", $result, $_r ) );
 	}
@@ -210,36 +209,36 @@ CAP;
 	public function test_new_img_caption_shortcode_new_format() {
 		$result       = img_caption_shortcode(
 			array( 'width' => 20 ),
-			$this->img_content . $this->html_content
+			self::IMG_CONTENT . self::HTML_CONTENT
 		);
-		$img_preg     = preg_quote( $this->img_content );
-		$content_preg = preg_quote( $this->html_content );
+		$img_preg     = preg_quote( self::IMG_CONTENT );
+		$content_preg = preg_quote( self::HTML_CONTENT );
 
 		$this->assertSame( 1, preg_match_all( "~{$img_preg}.*wp-caption-text~", $result, $_r ) );
 		$this->assertSame( 1, preg_match_all( "~wp-caption-text.*{$content_preg}~", $result, $_r ) );
 	}
 
 	public function test_new_img_caption_shortcode_new_format_and_linked_image() {
-		$linked_image = "<a href='#'>{$this->img_content}</a>";
+		$linked_image = "<a href='#'>" . self::IMG_CONTENT . '</a>';
 		$result       = img_caption_shortcode(
 			array( 'width' => 20 ),
-			$linked_image . $this->html_content
+			$linked_image . self::HTML_CONTENT
 		);
 		$img_preg     = preg_quote( $linked_image );
-		$content_preg = preg_quote( $this->html_content );
+		$content_preg = preg_quote( self::HTML_CONTENT );
 
 		$this->assertSame( 1, preg_match_all( "~{$img_preg}.*wp-caption-text~", $result, $_r ) );
 		$this->assertSame( 1, preg_match_all( "~wp-caption-text.*{$content_preg}~", $result, $_r ) );
 	}
 
 	public function test_new_img_caption_shortcode_new_format_and_linked_image_with_newline() {
-		$linked_image = "<a href='#'>{$this->img_content}</a>";
+		$linked_image = "<a href='#'>" . self::IMG_CONTENT . '</a>';
 		$result       = img_caption_shortcode(
 			array( 'width' => 20 ),
-			$linked_image . "\n\n" . $this->html_content
+			$linked_image . "\n\n" . self::HTML_CONTENT
 		);
 		$img_preg     = preg_quote( $linked_image );
-		$content_preg = preg_quote( $this->html_content );
+		$content_preg = preg_quote( self::HTML_CONTENT );
 
 		$this->assertSame( 1, preg_match_all( "~{$img_preg}.*wp-caption-text~", $result, $_r ) );
 		$this->assertSame( 1, preg_match_all( "~wp-caption-text.*{$content_preg}~", $result, $_r ) );
@@ -254,7 +253,7 @@ CAP;
 				'width' => 20,
 				'id'    => 'myId',
 			),
-			$this->img_content . $this->html_content
+			self::IMG_CONTENT . self::HTML_CONTENT
 		);
 
 		$this->assertSame( 1, preg_match_all( '/aria-describedby="caption-myId"/', $result, $_r ) );
@@ -494,7 +493,7 @@ https://w.org</a>',
 	public function test_get_attached_images() {
 		$post_id       = self::factory()->post->create();
 		$attachment_id = self::factory()->attachment->create_object(
-			$this->img_name,
+			self::IMG_NAME,
 			$post_id,
 			array(
 				'post_mime_type' => 'image/jpeg',
@@ -521,7 +520,7 @@ https://w.org</a>',
 					'post_type'      => 'attachment',
 				)
 			);
-			$metadata      = array_merge( array( 'file' => "image$i.jpg" ), $this->img_meta );
+			$metadata      = array_merge( array( 'file' => "image$i.jpg" ), self::IMG_META );
 			wp_update_attachment_metadata( $attachment_id, $metadata );
 			$ids1[]      = $attachment_id;
 			$ids1_srcs[] = 'http://' . WP_TESTS_DOMAIN . '/wp-content/uploads/' . "image$i.jpg";
@@ -538,7 +537,7 @@ https://w.org</a>',
 					'post_type'      => 'attachment',
 				)
 			);
-			$metadata      = array_merge( array( 'file' => "image$i.jpg" ), $this->img_meta );
+			$metadata      = array_merge( array( 'file' => "image$i.jpg" ), self::IMG_META );
 			wp_update_attachment_metadata( $attachment_id, $metadata );
 			$ids2[]      = $attachment_id;
 			$ids2_srcs[] = 'http://' . WP_TESTS_DOMAIN . '/wp-content/uploads/' . "image$i.jpg";
@@ -572,7 +571,7 @@ BLOB;
 					'post_type'      => 'attachment',
 				)
 			);
-			$metadata      = array_merge( array( 'file' => "image$i.jpg" ), $this->img_meta );
+			$metadata      = array_merge( array( 'file' => "image$i.jpg" ), self::IMG_META );
 			wp_update_attachment_metadata( $attachment_id, $metadata );
 			$ids1[]      = $attachment_id;
 			$ids1_srcs[] = 'http://' . WP_TESTS_DOMAIN . '/wp-content/uploads/' . "image$i.jpg";
@@ -589,7 +588,7 @@ BLOB;
 					'post_type'      => 'attachment',
 				)
 			);
-			$metadata      = array_merge( array( 'file' => "image$i.jpg" ), $this->img_meta );
+			$metadata      = array_merge( array( 'file' => "image$i.jpg" ), self::IMG_META );
 			wp_update_attachment_metadata( $attachment_id, $metadata );
 			$ids2[]      = $attachment_id;
 			$ids2_srcs[] = 'http://' . WP_TESTS_DOMAIN . '/wp-content/uploads/' . "image$i.jpg";
@@ -622,7 +621,7 @@ BLOB;
 				"image$i.jpg",
 				0
 			);
-			$metadata      = array_merge( array( 'file' => "image$i.jpg" ), $this->img_meta );
+			$metadata      = array_merge( array( 'file' => "image$i.jpg" ), self::IMG_META );
 			wp_update_attachment_metadata( $attachment_id, $metadata );
 			$ids[]      = $attachment_id;
 			$url        = 'http://' . WP_TESTS_DOMAIN . '/wp-content/uploads/' . "image$i.jpg";
@@ -660,7 +659,7 @@ BLOB;
 				"image$i.jpg",
 				0
 			);
-			$metadata      = array_merge( array( 'file' => "image$i.jpg" ), $this->img_meta );
+			$metadata      = array_merge( array( 'file' => "image$i.jpg" ), self::IMG_META );
 			wp_update_attachment_metadata( $attachment_id, $metadata );
 			$ids[]      = $attachment_id;
 			$url        = 'http://' . WP_TESTS_DOMAIN . '/wp-content/uploads/' . "image$i.jpg";
@@ -702,7 +701,7 @@ BLOB;
 					'post_type'      => 'attachment',
 				)
 			);
-			$metadata      = array_merge( array( 'file' => "image$i.jpg" ), $this->img_meta );
+			$metadata      = array_merge( array( 'file' => "image$i.jpg" ), self::IMG_META );
 			wp_update_attachment_metadata( $attachment_id, $metadata );
 			$ids[]      = $attachment_id;
 			$url        = 'http://' . WP_TESTS_DOMAIN . '/wp-content/uploads/' . "image$i.jpg";
@@ -745,7 +744,7 @@ BLOB;
 					'post_type'      => 'attachment',
 				)
 			);
-			$metadata      = array_merge( array( 'file' => "image$i.jpg" ), $this->img_meta );
+			$metadata      = array_merge( array( 'file' => "image$i.jpg" ), self::IMG_META );
 			wp_update_attachment_metadata( $attachment_id, $metadata );
 			$ids[]      = $attachment_id;
 			$url        = 'http://' . WP_TESTS_DOMAIN . '/wp-content/uploads/' . "image$i.jpg";
@@ -788,7 +787,7 @@ BLOB;
 					'post_type'      => 'attachment',
 				)
 			);
-			$metadata      = array_merge( array( 'file' => "image$i.jpg" ), $this->img_meta );
+			$metadata      = array_merge( array( 'file' => "image$i.jpg" ), self::IMG_META );
 			wp_update_attachment_metadata( $attachment_id, $metadata );
 			$ids[]      = $attachment_id;
 			$url        = 'http://' . WP_TESTS_DOMAIN . '/wp-content/uploads/' . "image$i.jpg";
@@ -1181,7 +1180,7 @@ VIDEO;
 	 * @ticket 30346
 	 */
 	public function test_attachment_url_to_postid() {
-		$image_path    = '2014/11/' . $this->img_name;
+		$image_path    = '2014/11/' . self::IMG_NAME;
 		$attachment_id = self::factory()->attachment->create_object(
 			$image_path,
 			0,
@@ -1199,7 +1198,7 @@ VIDEO;
 	 * @ticket 33109
 	 */
 	public function test_attachment_url_to_postid_with_different_scheme() {
-		$image_path    = '2014/11/' . $this->img_name;
+		$image_path    = '2014/11/' . self::IMG_NAME;
 		$attachment_id = self::factory()->attachment->create_object(
 			$image_path,
 			0,
@@ -1217,7 +1216,7 @@ VIDEO;
 	 * @ticket 39768
 	 */
 	public function test_attachment_url_to_postid_should_be_case_sensitive() {
-		$image_path_lower_case    = '2014/11/' . $this->img_name;
+		$image_path_lower_case    = '2014/11/' . self::IMG_NAME;
 		$attachment_id_lower_case = self::factory()->attachment->create_object(
 			$image_path_lower_case,
 			0,
@@ -1227,7 +1226,7 @@ VIDEO;
 			)
 		);
 
-		$image_path_upper_case    = '2014/11/' . ucfirst( $this->img_name );
+		$image_path_upper_case    = '2014/11/' . ucfirst( self::IMG_NAME );
 		$attachment_id_upper_case = self::factory()->attachment->create_object(
 			$image_path_upper_case,
 			0,
@@ -1242,7 +1241,7 @@ VIDEO;
 	}
 
 	public function test_attachment_url_to_postid_filtered() {
-		$image_path    = '2014/11/' . $this->img_name;
+		$image_path    = '2014/11/' . self::IMG_NAME;
 		$attachment_id = self::factory()->attachment->create_object(
 			$image_path,
 			0,
@@ -1532,7 +1531,7 @@ EOF;
 
 		$post_id       = self::factory()->post->create();
 		$attachment_id = self::factory()->attachment->create_object(
-			$this->img_name,
+			self::IMG_NAME,
 			$post_id,
 			array(
 				'post_mime_type' => 'image/jpeg',
@@ -1555,7 +1554,7 @@ EOF;
 
 		$post_id       = self::factory()->post->create();
 		$attachment_id = self::factory()->attachment->create_object(
-			$this->img_name,
+			self::IMG_NAME,
 			$post_id,
 			array(
 				'post_mime_type' => 'image/jpeg',
@@ -1575,7 +1574,7 @@ EOF;
 	public function test_wp_get_attachment_caption_empty() {
 		$post_id       = self::factory()->post->create();
 		$attachment_id = self::factory()->attachment->create_object(
-			$this->img_name,
+			self::IMG_NAME,
 			$post_id,
 			array(
 				'post_mime_type' => 'image/jpeg',
@@ -3333,7 +3332,7 @@ EOF;
 	 */
 	public function test_wp_image_file_matches_image_meta_invalid_meta() {
 		$image_meta = ''; // Attachment is not an image.
-		$image_src  = $this->img_url;
+		$image_src  = self::IMG_URL;
 
 		$this->assertFalse( wp_image_file_matches_image_meta( $image_src, $image_meta ) );
 	}
@@ -3343,7 +3342,7 @@ EOF;
 	 */
 	public function test_wp_image_file_matches_image_meta_different_meta() {
 		$image_meta = wp_get_attachment_metadata( self::$large_id );
-		$image_src  = $this->img_url; // Different image.
+		$image_src  = self::IMG_URL; // Different image.
 
 		$this->assertFalse( wp_image_file_matches_image_meta( $image_src, $image_meta ) );
 	}

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -157,14 +157,14 @@ CAP;
 			)
 		);
 
-		$this->assertSame( 2, preg_match_all( '/wp-caption/', $result, $_r ) );
-		$this->assertSame( 1, preg_match_all( '/alignnone/', $result, $_r ) );
-		$this->assertSame( 1, preg_match_all( '/' . self::CAPTION . '/', $result, $_r ) );
+		$this->assertSame( 2, substr_count( $result, 'wp-caption' ) );
+		$this->assertSame( 1, substr_count( $result, 'alignnone' ) );
+		$this->assertSame( 1, substr_count( $result, self::CAPTION ) );
 
 		if ( current_theme_supports( 'html5', 'caption' ) ) {
-			$this->assertSame( 1, preg_match_all( '/width: 20/', $result, $_r ) );
+			$this->assertSame( 1, substr_count( $result, 'width: 20' ) );
 		} else {
-			$this->assertSame( 1, preg_match_all( '/width: 30/', $result, $_r ) );
+			$this->assertSame( 1, substr_count( $result, 'width: 30' ) );
 		}
 	}
 
@@ -177,9 +177,9 @@ CAP;
 				'align'   => '&myAlignment',
 			)
 		);
-		$this->assertSame( 1, preg_match_all( '/wp-caption &amp;myAlignment/', $result, $_r ) );
-		$this->assertSame( 1, preg_match_all( '/id="myId"/', $result, $_r ) );
-		$this->assertSame( 1, preg_match_all( '/' . self::CAPTION . '/', $result, $_r ) );
+		$this->assertSame( 1, substr_count( $result, 'wp-caption &amp;myAlignment' ) );
+		$this->assertSame( 1, substr_count( $result, 'id="myId"' ) );
+		$this->assertSame( 1, substr_count( $result, self::CAPTION ) );
 	}
 
 	public function test_img_caption_shortcode_with_old_format_and_class() {
@@ -190,20 +190,19 @@ CAP;
 				'caption' => self::CAPTION,
 			)
 		);
-		$this->assertSame( 1, preg_match_all( '/wp-caption alignnone some-class another-class/', $result, $_r ) );
+		$this->assertSame( 1, substr_count( $result, 'wp-caption alignnone some-class another-class' ) );
 
 	}
 
 	public function test_new_img_caption_shortcode_with_html_caption() {
-		$result   = img_caption_shortcode(
+		$result = img_caption_shortcode(
 			array(
 				'width'   => 20,
 				'caption' => self::HTML_CONTENT,
 			)
 		);
-		$our_preg = preg_quote( self::HTML_CONTENT );
 
-		$this->assertSame( 1, preg_match_all( "~{$our_preg}~", $result, $_r ) );
+		$this->assertSame( 1, substr_count( $result, self::HTML_CONTENT ) );
 	}
 
 	public function test_new_img_caption_shortcode_new_format() {
@@ -256,7 +255,7 @@ CAP;
 			self::IMG_CONTENT . self::HTML_CONTENT
 		);
 
-		$this->assertSame( 1, preg_match_all( '/aria-describedby="caption-myId"/', $result, $_r ) );
+		$this->assertSame( 1, substr_count( $result, 'aria-describedby="caption-myId"' ) );
 	}
 
 	public function test_add_remove_oembed_provider() {

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -213,8 +213,8 @@ CAP;
 		$img_preg     = preg_quote( self::IMG_CONTENT );
 		$content_preg = preg_quote( self::HTML_CONTENT );
 
-		$this->assertSame( 1, preg_match_all( "~{$img_preg}.*wp-caption-text~", $result, $_r ) );
-		$this->assertSame( 1, preg_match_all( "~wp-caption-text.*{$content_preg}~", $result, $_r ) );
+		$this->assertSame( 1, preg_match_all( "~{$img_preg}.*wp-caption-text~", $result ) );
+		$this->assertSame( 1, preg_match_all( "~wp-caption-text.*{$content_preg}~", $result ) );
 	}
 
 	public function test_new_img_caption_shortcode_new_format_and_linked_image() {
@@ -226,8 +226,8 @@ CAP;
 		$img_preg     = preg_quote( $linked_image );
 		$content_preg = preg_quote( self::HTML_CONTENT );
 
-		$this->assertSame( 1, preg_match_all( "~{$img_preg}.*wp-caption-text~", $result, $_r ) );
-		$this->assertSame( 1, preg_match_all( "~wp-caption-text.*{$content_preg}~", $result, $_r ) );
+		$this->assertSame( 1, preg_match_all( "~{$img_preg}.*wp-caption-text~", $result ) );
+		$this->assertSame( 1, preg_match_all( "~wp-caption-text.*{$content_preg}~", $result ) );
 	}
 
 	public function test_new_img_caption_shortcode_new_format_and_linked_image_with_newline() {
@@ -239,8 +239,8 @@ CAP;
 		$img_preg     = preg_quote( $linked_image );
 		$content_preg = preg_quote( self::HTML_CONTENT );
 
-		$this->assertSame( 1, preg_match_all( "~{$img_preg}.*wp-caption-text~", $result, $_r ) );
-		$this->assertSame( 1, preg_match_all( "~wp-caption-text.*{$content_preg}~", $result, $_r ) );
+		$this->assertSame( 1, preg_match_all( "~{$img_preg}.*wp-caption-text~", $result ) );
+		$this->assertSame( 1, preg_match_all( "~wp-caption-text.*{$content_preg}~", $result ) );
 	}
 
 	/**


### PR DESCRIPTION
### PHP 8.2 | Tests_Media: remove dynamic properties

Dynamic (non-explicitly declared) properties are deprecated as of PHP 8.2 and are expected to become a fatal error in PHP 9.0.

In this particular case, the test class contains a `set_up()` method which sets a group of properties, which are _used_ by the tests, but never _changed_ by the tests.

In other words, setting these properties in the `set_up()` is an unnecessary overhead and the properties should be changed to class constants.

Notes:
* As the `$img_html` property which was previously being set, is not actually used in any of the tests, that property has not been converted to a constant.
* The values which were previously being set using a heredoc, now use a nowdoc (supported since PHP 5.3), as they don't contain any interpolation.
* The use of constant scalar expressions (`IMG_URL`) and constant arrays (`IMG_META`) in class constants is supported since PHP 5.6.

Trac ticket: https://core.trac.wordpress.org/ticket/56033

### Tests_Media: simplify some assertions

A number of assertions are checking for the number of times a hard-coded substring existed in a larger `$haystack`.

These assertions were using `preg_match_all()` to do so, but without actually using a regex.

In these cases, it is more performant (and simpler) to use the PHP native `substr_count()` function, which will yield the same result, without the overhead of regex parsing.

Ref: https://www.php.net/manual/en/function.substr-count.php

### Tests_Media: simplify some function calls

The remaining assertions using `preg_match_all()` do actually pass a regex, but the third parameter `$matches` is never used.

This third parameter became optional in PHP 5.4, so we may as well remove it.

Ref: https://www.php.net/manual/en/function.preg-match-all.php

Trac ticket: https://core.trac.wordpress.org/ticket/55652 (last two commits) 

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
