### PR TITLE
PHP 8.2 | Tests_POMO_PO: remove dynamic properties

### DIFF
--- a/tests/phpunit/tests/pomo/po.php
+++ b/tests/phpunit/tests/pomo/po.php
@@ -5,17 +5,12 @@
  */
 class Tests_POMO_PO extends WP_UnitTestCase {
 
-	public static function set_up_before_class() {
-		parent::set_up_before_class();
-
-		require_once ABSPATH . '/wp-includes/pomo/po.php';
-	}
-
-	public function set_up() {
-		parent::set_up();
-
-		// Not so random wordpress.pot string -- multiple lines.
-		$this->mail    = 'Your new WordPress blog has been successfully set up at:
+	/**
+	 * Mail content.
+	 *
+	 * @var string
+	 */
+	const MAIL_TEXT = 'Your new WordPress blog has been successfully set up at:
 
 %1$s
 
@@ -29,8 +24,13 @@ We hope you enjoy your new blog. Thanks!
 --The WordPress Team
 http://wordpress.org/
 ';
-		$this->mail    = str_replace( "\r\n", "\n", $this->mail );
-		$this->po_mail = '""
+
+	/**
+	 * Mail content for translation readiness.
+	 *
+	 * @var string
+	 */
+	const PO_MAIL = '""
 "Your new WordPress blog has been successfully set up at:\n"
 "\n"
 "%1$s\n"
@@ -44,8 +44,11 @@ http://wordpress.org/
 "\n"
 "--The WordPress Team\n"
 "http://wordpress.org/\n"';
-		$this->a90     = str_repeat( 'a', 90 );
-		$this->po_a90  = "\"$this->a90\"";
+
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		require_once ABSPATH . '/wp-includes/pomo/po.php';
 	}
 
 	public function test_prepend_each_line() {
@@ -60,7 +63,9 @@ http://wordpress.org/
 		// Simple.
 		$this->assertSame( '"baba"', $po->poify( 'baba' ) );
 		// Long word.
-		$this->assertSame( $this->po_a90, $po->poify( $this->a90 ) );
+		$long_word    = str_repeat( 'a', 90 );
+		$po_long_word = "\"$long_word\"";
+		$this->assertSame( $po_long_word, $po->poify( $long_word ) );
 		// Tab.
 		$this->assertSame( '"ba\tba"', $po->poify( "ba\tba" ) );
 		// Do not add leading empty string of one-line string ending on a newline.
@@ -71,18 +76,24 @@ http://wordpress.org/
 		$src = 'Categories can be selectively converted to tags using the <a href="%s">category to tag converter</a>.';
 		$this->assertSame( '"Categories can be selectively converted to tags using the <a href=\\"%s\\">category to tag converter</a>."', $po->poify( $src ) );
 
-		$this->assertSameIgnoreEOL( $this->po_mail, $po->poify( $this->mail ) );
+		$mail = str_replace( "\r\n", "\n", self::MAIL_TEXT );
+		$this->assertSameIgnoreEOL( self::PO_MAIL, $po->poify( $mail ) );
 	}
 
 	public function test_unpoify() {
 		$po = new PO();
 		$this->assertSame( 'baba', $po->unpoify( '"baba"' ) );
 		$this->assertSame( "baba\ngugu", $po->unpoify( '"baba\n"' . "\t\t\t\n" . '"gugu"' ) );
-		$this->assertSame( $this->a90, $po->unpoify( $this->po_a90 ) );
+
+		$long_word    = str_repeat( 'a', 90 );
+		$po_long_word = "\"$long_word\"";
+		$this->assertSame( $long_word, $po->unpoify( $po_long_word ) );
 		$this->assertSame( '\\t\\n', $po->unpoify( '"\\\\t\\\\n"' ) );
 		// Wordwrapped.
 		$this->assertSame( 'babadyado', $po->unpoify( "\"\"\n\"baba\"\n\"dyado\"" ) );
-		$this->assertSameIgnoreEOL( $this->mail, $po->unpoify( $this->po_mail ) );
+
+		$mail = str_replace( "\r\n", "\n", self::MAIL_TEXT );
+		$this->assertSameIgnoreEOL( $mail, $po->unpoify( self::PO_MAIL ) );
 	}
 
 	public function test_export_entry() {


### PR DESCRIPTION
Dynamic (non-explicitly declared) properties are deprecated as of PHP 8.2 and are expected to become a fatal error in PHP 9.0.

In this particular case, the test class contains a `set_up()` method which sets properties only used by select tests, while the fixture method is being run for all tests.

There were a couple of ways this could be fixed:
* As the values do not change across tests, use `set_up_before_class()` to set (static) properties instead.
* For those values which are set up without a function call or variable interpolation, set the values in class constants.
* Or set these values as local variables for those tests which actually use them.

I've elected to use a combination of option 2 and 3.

I'd highly recommend for these tests to be revisited though as refactoring to use data providers would be a huge improvement (but is outside the scope of ticket 56033).

Trac ticket: https://core.trac.wordpress.org/ticket/56033

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
