### PR TITLE
PHP 8.2 | Tests_WP_Customize_[Panel|Section]: remove an unused dynamic property

### DIFF
--- a/tests/phpunit/tests/customize/panel.php
+++ b/tests/phpunit/tests/customize/panel.php
@@ -17,7 +17,6 @@ class Tests_WP_Customize_Panel extends WP_UnitTestCase {
 		require_once ABSPATH . WPINC . '/class-wp-customize-manager.php';
 		$GLOBALS['wp_customize'] = new WP_Customize_Manager();
 		$this->manager           = $GLOBALS['wp_customize'];
-		$this->undefined         = new stdClass();
 	}
 
 	public function tear_down() {

--- a/tests/phpunit/tests/customize/section.php
+++ b/tests/phpunit/tests/customize/section.php
@@ -24,7 +24,6 @@ class Tests_WP_Customize_Section extends WP_UnitTestCase {
 		require_once ABSPATH . WPINC . '/class-wp-customize-manager.php';
 		$GLOBALS['wp_customize'] = new WP_Customize_Manager();
 		$this->manager           = $GLOBALS['wp_customize'];
-		$this->undefined         = new stdClass();
 	}
 
 	public function tear_down() {


### PR DESCRIPTION
Appears that the dynamically created `$undefined` property isn't actually used.

I wonder what the originally intention was of setting this property and if the property was maybe intended to be set on the `WP_Customize_Manager` object, but as-is, it is undeclared and unused, so can be safely removed.

Trac ticket: https://core.trac.wordpress.org/ticket/56033

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
