### PR TITLE
PHP 8.2 | Tests_Media_getPostGalleries: remove dynamic properties

### DIFF
--- a/tests/phpunit/tests/media/getPostGalleries.php
+++ b/tests/phpunit/tests/media/getPostGalleries.php
@@ -4,16 +4,13 @@
  *
  * @covers ::get_post_galleries
  */
-class Tests_Functions_getPostGalleries extends WP_UnitTestCase {
+class Tests_Media_getPostGalleries extends WP_UnitTestCase {
 
-	public function set_up() {
-		parent::set_up();
-		$this->img_meta = array(
-			'width'  => 100,
-			'height' => 100,
-			'sizes'  => '',
-		);
-	}
+	const IMG_META = array(
+		'width'  => 100,
+		'height' => 100,
+		'sizes'  => '',
+	);
 
 	/**
 	 * Tests that an empty array is returned for a post that does not exist.
@@ -569,7 +566,7 @@ BLOB;
 					'post_type'      => 'attachment',
 				)
 			);
-			$metadata      = array_merge( array( 'file' => "image$i.jpg" ), $this->img_meta );
+			$metadata      = array_merge( array( 'file' => "image$i.jpg" ), self::IMG_META );
 			wp_update_attachment_metadata( $attachment_id, $metadata );
 			$ids[]      = $attachment_id;
 			$url        = 'http://' . WP_TESTS_DOMAIN . '/wp-content/uploads/' . "image$i.jpg";
@@ -658,7 +655,7 @@ BLOB;
 				'post_type'      => 'attachment',
 			)
 		);
-		$metadata       = array_merge( array( 'file' => 'image1.jpg' ), $this->img_meta );
+		$metadata       = array_merge( array( 'file' => 'image1.jpg' ), self::IMG_META );
 		$url            = 'http://' . WP_TESTS_DOMAIN . '/wp-content/uploads/' . 'image1.jpg';
 		$global_post_id = $this->factory->post->create(
 			array(
@@ -838,7 +835,7 @@ BLOB;
 					'post_type'      => 'attachment',
 				)
 			);
-			$metadata      = array_merge( array( 'file' => "image$i.jpg" ), $this->img_meta );
+			$metadata      = array_merge( array( 'file' => "image$i.jpg" ), self::IMG_META );
 			wp_update_attachment_metadata( $attachment_id, $metadata );
 			$ids[]      = $attachment_id;
 			$url        = 'http://' . WP_TESTS_DOMAIN . '/wp-content/uploads/' . "image$i.jpg";
@@ -902,7 +899,7 @@ BLOB;
 					'post_type'      => 'attachment',
 				)
 			);
-			$metadata      = array_merge( array( 'file' => "image$i.jpg" ), $this->img_meta );
+			$metadata      = array_merge( array( 'file' => "image$i.jpg" ), self::IMG_META );
 			wp_update_attachment_metadata( $attachment_id, $metadata );
 			$ids[]      = $attachment_id;
 			$url        = 'http://' . WP_TESTS_DOMAIN . '/wp-content/uploads/' . "image$i.jpg";


### PR DESCRIPTION
Dynamic (non-explicitly declared) properties are deprecated as of PHP 8.2 and are expected to become a fatal error in PHP 9.0.

In this particular case, the test class contains a `set_up()` method which sets the `$img_meta` property, which is _used_ by the tests, but never _changed_ by the tests.

In other words, setting this property in the `set_up()` is an unnecessary overhead and the property should be changed to a class constant.

Includes fixing up the test class name.


Trac ticket: https://core.trac.wordpress.org/ticket/56033

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
