### PR TITLE
PHP 8.2 | Tests_Post_Revisions: remove dynamic properties

### DIFF
--- a/tests/phpunit/tests/post/revisions.php
+++ b/tests/phpunit/tests/post/revisions.php
@@ -5,6 +5,9 @@
  * @group revision
  */
 class Tests_Post_Revisions extends WP_UnitTestCase {
+
+	const POST_TYPE = 'test-revision';
+
 	protected static $admin_user_id;
 	protected static $editor_user_id;
 	protected static $author_user_id;
@@ -13,11 +16,6 @@ class Tests_Post_Revisions extends WP_UnitTestCase {
 		self::$admin_user_id  = $factory->user->create( array( 'role' => 'administrator' ) );
 		self::$editor_user_id = $factory->user->create( array( 'role' => 'editor' ) );
 		self::$author_user_id = $factory->user->create( array( 'role' => 'author' ) );
-	}
-
-	public function set_up() {
-		parent::set_up();
-		$this->post_type = 'test-revision';
 	}
 
 	/**
@@ -318,7 +316,7 @@ class Tests_Post_Revisions extends WP_UnitTestCase {
 	 */
 	public function test_revision_view_caps_cpt() {
 		register_post_type(
-			$this->post_type,
+			self::POST_TYPE,
 			array(
 				'capability_type' => 'event',
 				'map_meta_cap'    => true,
@@ -328,7 +326,7 @@ class Tests_Post_Revisions extends WP_UnitTestCase {
 
 		$post_id = self::factory()->post->create(
 			array(
-				'post_type'   => $this->post_type,
+				'post_type'   => self::POST_TYPE,
 				'post_author' => self::$editor_user_id,
 			)
 		);
@@ -360,7 +358,7 @@ class Tests_Post_Revisions extends WP_UnitTestCase {
 	 */
 	public function test_revision_restore_caps_cpt() {
 		register_post_type(
-			$this->post_type,
+			self::POST_TYPE,
 			array(
 				'capability_type' => 'event',
 				'map_meta_cap'    => true,
@@ -375,7 +373,7 @@ class Tests_Post_Revisions extends WP_UnitTestCase {
 		// Create a post as Editor.
 		$post_id = self::factory()->post->create(
 			array(
-				'post_type'   => $this->post_type,
+				'post_type'   => self::POST_TYPE,
 				'post_author' => self::$editor_user_id,
 			)
 		);
@@ -406,7 +404,7 @@ class Tests_Post_Revisions extends WP_UnitTestCase {
 	 */
 	public function test_revision_restore_caps_before_publish() {
 		register_post_type(
-			$this->post_type,
+			self::POST_TYPE,
 			array(
 				'capability_type' => 'post',
 				'capabilities'    => array(
@@ -424,7 +422,7 @@ class Tests_Post_Revisions extends WP_UnitTestCase {
 
 		$post_id = self::factory()->post->create(
 			array(
-				'post_type'   => $this->post_type,
+				'post_type'   => self::POST_TYPE,
 				'post_status' => 'draft',
 			)
 		);
@@ -466,7 +464,7 @@ class Tests_Post_Revisions extends WP_UnitTestCase {
 	 */
 	public function test_revision_diff_caps_cpt() {
 		register_post_type(
-			$this->post_type,
+			self::POST_TYPE,
 			array(
 				'capability_type' => 'event',
 				'map_meta_cap'    => true,
@@ -476,7 +474,7 @@ class Tests_Post_Revisions extends WP_UnitTestCase {
 
 		$post_id = self::factory()->post->create(
 			array(
-				'post_type'   => $this->post_type,
+				'post_type'   => self::POST_TYPE,
 				'post_author' => self::$editor_user_id,
 			)
 		);


### PR DESCRIPTION
Dynamic (non-explicitly declared) properties are deprecated as of PHP 8.2 and are expected to become a fatal error in PHP 9.0.

In this particular case, the test class contains a `set_up()` method which sets the `$post_type` property, which is _used_ by the tests, but never _changed_ by the tests.

In other words, setting this property in the `set_up()` is an unnecessary overhead and the property should be changed to a class constant.

Trac ticket: https://core.trac.wordpress.org/ticket/56033

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
