### PR TITLE
PHP 8.2 | Tests_File: remove dynamic properties

### DIFF
--- a/tests/phpunit/tests/file.php
+++ b/tests/phpunit/tests/file.php
@@ -5,12 +5,14 @@
  */
 class Tests_File extends WP_UnitTestCase {
 
+	const BADCHARS = '"\'[]*&?$';
+
+	private $dir;
+
 	public function set_up() {
 		parent::set_up();
 
 		$this->dir = untrailingslashit( get_temp_dir() );
-
-		$this->badchars = '"\'[]*&?$';
 	}
 
 	/**
@@ -137,7 +139,7 @@ class Tests_File extends WP_UnitTestCase {
 
 	public function test_unique_filename_is_sanitized() {
 		$name     = __FUNCTION__;
-		$filename = wp_unique_filename( $this->dir, $name . $this->badchars . '.txt' );
+		$filename = wp_unique_filename( $this->dir, $name . self::BADCHARS . '.txt' );
 
 		// Make sure the bad characters were all stripped out.
 		$this->assertSame( $name . '.txt', $filename );


### PR DESCRIPTION
Dynamic (non-explicitly declared) properties are deprecated as of PHP 8.2 and are expected to become a fatal error in PHP 9.0.

In this case, as the `$badchars` property never changes, declaring this as a class constant is the sensible option.

As for the `$dir` property (which cannot be turned into a constant due to the function call), this is used in multiple tests, so making this property explicit makes sense.

Trac ticket: https://core.trac.wordpress.org/ticket/56033

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
