### PR TITLE
PHP 8.2 | Test Utils: let Mockclass extend stdClass

### DIFF
--- a/tests/phpunit/includes/utils.php
+++ b/tests/phpunit/includes/utils.php
@@ -378,7 +378,7 @@ function gen_tests_array( $name, $array ) {
 /**
  * Use to create objects by yourself
  */
-class MockClass {}
+class MockClass extends stdClass {}
 
 /**
  * Drops all tables from the WordPress database


### PR DESCRIPTION
... to allow for arbitrary properties to be declared on it.

Alternatively, the `MockClass` could be deprecated altogether in favour of directly using `stdClass` in those places it is used.


Trac ticket: https://core.trac.wordpress.org/ticket/56033

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
