### PR TITLE
PHP 8.2 | Theme Tests: remove/explicitly set dynamic properties

### DIFF
--- a/tests/phpunit/tests/admin/includesTheme.php
+++ b/tests/phpunit/tests/admin/includesTheme.php
@@ -4,12 +4,25 @@
  */
 class Tests_Admin_IncludesTheme extends WP_UnitTestCase {
 
+	/**
+	 * Theme root directory.
+	 *
+	 * @var string
+	 */
+	const THEME_ROOT = DIR_TESTDATA . '/themedir1';
+
+	/**
+	 * Original theme directory.
+	 *
+	 * @var string
+	 */
+	private $orig_theme_dir;
+
 	public function set_up() {
 		parent::set_up();
-		$this->theme_root = DIR_TESTDATA . '/themedir1';
 
 		$this->orig_theme_dir            = $GLOBALS['wp_theme_directories'];
-		$GLOBALS['wp_theme_directories'] = array( WP_CONTENT_DIR . '/themes', $this->theme_root );
+		$GLOBALS['wp_theme_directories'] = array( WP_CONTENT_DIR . '/themes', self::THEME_ROOT );
 
 		add_filter( 'theme_root', array( $this, 'filter_theme_root' ) );
 		add_filter( 'stylesheet_root', array( $this, 'filter_theme_root' ) );
@@ -33,7 +46,7 @@ class Tests_Admin_IncludesTheme extends WP_UnitTestCase {
 
 	// Replace the normal theme root directory with our premade test directory.
 	public function filter_theme_root( $dir ) {
-		return $this->theme_root;
+		return self::THEME_ROOT;
 	}
 
 	/**

--- a/tests/phpunit/tests/block-supports/layout.php
+++ b/tests/phpunit/tests/block-supports/layout.php
@@ -15,6 +15,21 @@
  * @group block-supports
  */
 class Test_Block_Supports_Layout extends WP_UnitTestCase {
+
+	/**
+	 * Theme root directory.
+	 *
+	 * @var string
+	 */
+	private $theme_root;
+
+	/**
+	 * Original theme directory.
+	 *
+	 * @var string
+	 */
+	private $orig_theme_dir;
+
 	function set_up() {
 		parent::set_up();
 		$this->theme_root     = realpath( DIR_TESTDATA . '/themedir1' );
@@ -28,7 +43,6 @@ class Test_Block_Supports_Layout extends WP_UnitTestCase {
 		add_filter( 'stylesheet_root', array( $this, 'filter_set_theme_root' ) );
 		add_filter( 'template_root', array( $this, 'filter_set_theme_root' ) );
 
-		$this->queries = array();
 		// Clear caches.
 		wp_clean_themes_cache();
 		unset( $GLOBALS['wp_themes'] );

--- a/tests/phpunit/tests/theme/themeDir.php
+++ b/tests/phpunit/tests/theme/themeDir.php
@@ -7,14 +7,27 @@
  */
 class Tests_Theme_ThemeDir extends WP_UnitTestCase {
 
+	/**
+	 * Theme root directory.
+	 *
+	 * @var string
+	 */
+	const THEME_ROOT = DIR_TESTDATA . '/themedir1';
+
+	/**
+	 * Original theme directory.
+	 *
+	 * @var string
+	 */
+	private $orig_theme_dir;
+
 	public function set_up() {
 		parent::set_up();
-		$this->theme_root = DIR_TESTDATA . '/themedir1';
 
 		$this->orig_theme_dir = $GLOBALS['wp_theme_directories'];
 
 		// /themes is necessary as theme.php functions assume /themes is the root if there is only one root.
-		$GLOBALS['wp_theme_directories'] = array( WP_CONTENT_DIR . '/themes', $this->theme_root );
+		$GLOBALS['wp_theme_directories'] = array( WP_CONTENT_DIR . '/themes', self::THEME_ROOT );
 
 		add_filter( 'theme_root', array( $this, 'filter_theme_root' ) );
 		add_filter( 'stylesheet_root', array( $this, 'filter_theme_root' ) );
@@ -33,7 +46,7 @@ class Tests_Theme_ThemeDir extends WP_UnitTestCase {
 
 	// Replace the normal theme root directory with our premade test directory.
 	public function filter_theme_root( $dir ) {
-		return $this->theme_root;
+		return self::THEME_ROOT;
 	}
 
 	/**
@@ -57,12 +70,12 @@ class Tests_Theme_ThemeDir extends WP_UnitTestCase {
 		$this->assertSame( 'default', $theme['Template'] );
 		$this->assertSame( 'default', $theme['Stylesheet'] );
 
-		$this->assertContains( $this->theme_root . '/default/functions.php', $theme['Template Files'] );
-		$this->assertContains( $this->theme_root . '/default/index.php', $theme['Template Files'] );
-		$this->assertContains( $this->theme_root . '/default/style.css', $theme['Stylesheet Files'] );
+		$this->assertContains( self::THEME_ROOT . '/default/functions.php', $theme['Template Files'] );
+		$this->assertContains( self::THEME_ROOT . '/default/index.php', $theme['Template Files'] );
+		$this->assertContains( self::THEME_ROOT . '/default/style.css', $theme['Stylesheet Files'] );
 
-		$this->assertSame( $this->theme_root . '/default', $theme['Template Dir'] );
-		$this->assertSame( $this->theme_root . '/default', $theme['Stylesheet Dir'] );
+		$this->assertSame( self::THEME_ROOT . '/default', $theme['Template Dir'] );
+		$this->assertSame( self::THEME_ROOT . '/default', $theme['Stylesheet Dir'] );
 		$this->assertSame( 'publish', $theme['Status'] );
 		$this->assertSame( '', $theme['Parent Theme'] );
 	}
@@ -88,15 +101,15 @@ class Tests_Theme_ThemeDir extends WP_UnitTestCase {
 
 		$template_files = $theme['Template Files'];
 
-		$this->assertSame( $this->theme_root . '/sandbox/functions.php', reset( $template_files ) );
-		$this->assertSame( $this->theme_root . '/sandbox/index.php', next( $template_files ) );
+		$this->assertSame( self::THEME_ROOT . '/sandbox/functions.php', reset( $template_files ) );
+		$this->assertSame( self::THEME_ROOT . '/sandbox/index.php', next( $template_files ) );
 
 		$stylesheet_files = $theme['Stylesheet Files'];
 
-		$this->assertSame( $this->theme_root . '/sandbox/style.css', reset( $stylesheet_files ) );
+		$this->assertSame( self::THEME_ROOT . '/sandbox/style.css', reset( $stylesheet_files ) );
 
-		$this->assertSame( $this->theme_root . '/sandbox', $theme['Template Dir'] );
-		$this->assertSame( $this->theme_root . '/sandbox', $theme['Stylesheet Dir'] );
+		$this->assertSame( self::THEME_ROOT . '/sandbox', $theme['Template Dir'] );
+		$this->assertSame( self::THEME_ROOT . '/sandbox', $theme['Stylesheet Dir'] );
 		$this->assertSame( 'publish', $theme['Status'] );
 		$this->assertSame( '', $theme['Parent Theme'] );
 
@@ -122,13 +135,13 @@ class Tests_Theme_ThemeDir extends WP_UnitTestCase {
 		$this->assertSame( '1.0', $theme['Version'] );
 		$this->assertSame( 'sandbox', $theme['Template'] );
 		$this->assertSame( 'stylesheetonly', $theme['Stylesheet'] );
-		$this->assertContains( $this->theme_root . '/sandbox/functions.php', $theme['Template Files'] );
-		$this->assertContains( $this->theme_root . '/sandbox/index.php', $theme['Template Files'] );
+		$this->assertContains( self::THEME_ROOT . '/sandbox/functions.php', $theme['Template Files'] );
+		$this->assertContains( self::THEME_ROOT . '/sandbox/index.php', $theme['Template Files'] );
 
-		$this->assertContains( $this->theme_root . '/stylesheetonly/style.css', $theme['Stylesheet Files'] );
+		$this->assertContains( self::THEME_ROOT . '/stylesheetonly/style.css', $theme['Stylesheet Files'] );
 
-		$this->assertSame( $this->theme_root . '/sandbox', $theme['Template Dir'] );
-		$this->assertSame( $this->theme_root . '/stylesheetonly', $theme['Stylesheet Dir'] );
+		$this->assertSame( self::THEME_ROOT . '/sandbox', $theme['Template Dir'] );
+		$this->assertSame( self::THEME_ROOT . '/stylesheetonly', $theme['Stylesheet Dir'] );
 		$this->assertSame( 'publish', $theme['Status'] );
 		$this->assertSame( 'Sandbox', $theme['Parent Theme'] );
 
@@ -142,7 +155,7 @@ class Tests_Theme_ThemeDir extends WP_UnitTestCase {
 
 		// Ignore themes in the default /themes directory.
 		foreach ( $themes as $theme_name => $theme ) {
-			if ( $theme->get_theme_root() !== $this->theme_root ) {
+			if ( $theme->get_theme_root() !== self::THEME_ROOT ) {
 				unset( $themes[ $theme_name ] );
 			}
 		}
@@ -197,7 +210,7 @@ class Tests_Theme_ThemeDir extends WP_UnitTestCase {
 	}
 
 	public function test_wp_get_theme_with_non_default_theme_root() {
-		$this->assertFalse( wp_get_theme( 'sandbox', $this->theme_root )->errors() );
+		$this->assertFalse( wp_get_theme( 'sandbox', self::THEME_ROOT )->errors() );
 		$this->assertFalse( wp_get_theme( 'sandbox' )->errors() );
 	}
 
@@ -211,7 +224,7 @@ class Tests_Theme_ThemeDir extends WP_UnitTestCase {
 		$this->assertNotEmpty( $theme );
 
 		$templates = $theme['Template Files'];
-		$this->assertContains( $this->theme_root . '/page-templates/template-top-level.php', $templates );
+		$this->assertContains( self::THEME_ROOT . '/page-templates/template-top-level.php', $templates );
 	}
 
 	/**
@@ -237,7 +250,7 @@ class Tests_Theme_ThemeDir extends WP_UnitTestCase {
 	 * @expectedDeprecated get_theme_data
 	 */
 	public function test_get_theme_data_subdir() {
-		$theme_data = get_theme_data( $this->theme_root . '/subdir/theme2/style.css' );
+		$theme_data = get_theme_data( self::THEME_ROOT . '/subdir/theme2/style.css' );
 
 		$this->assertSame( 'My Subdir Theme', $theme_data['Name'] );
 		$this->assertSame( 'http://example.org/', $theme_data['URI'] );

--- a/tests/phpunit/tests/theme/wpGetGlobalStylesheet.php
+++ b/tests/phpunit/tests/theme/wpGetGlobalStylesheet.php
@@ -7,6 +7,20 @@
  */
 class Tests_Theme_wpGetGlobalStylesheet extends WP_UnitTestCase {
 
+	/**
+	 * Theme root directory.
+	 *
+	 * @var string
+	 */
+	private $theme_root;
+
+	/**
+	 * Original theme directory.
+	 *
+	 * @var string
+	 */
+	private $orig_theme_dir;
+
 	public function set_up() {
 		parent::set_up();
 

--- a/tests/phpunit/tests/theme/wpTheme.php
+++ b/tests/phpunit/tests/theme/wpTheme.php
@@ -10,6 +10,20 @@
  */
 class Tests_Theme_wpTheme extends WP_UnitTestCase {
 
+	/**
+	 * Theme root directory.
+	 *
+	 * @var string
+	 */
+	private $theme_root;
+
+	/**
+	 * Original theme directory.
+	 *
+	 * @var string
+	 */
+	private $orig_theme_dir;
+
 	public function set_up() {
 		parent::set_up();
 		$this->theme_root = realpath( DIR_TESTDATA . '/themedir1' );

--- a/tests/phpunit/tests/theme/wpThemeJsonResolver.php
+++ b/tests/phpunit/tests/theme/wpThemeJsonResolver.php
@@ -12,6 +12,27 @@
  */
 class Tests_Theme_wpThemeJsonResolver extends WP_UnitTestCase {
 
+	/**
+	 * Theme root directory.
+	 *
+	 * @var string
+	 */
+	private $theme_root;
+
+	/**
+	 * Original theme directory.
+	 *
+	 * @var string
+	 */
+	private $orig_theme_dir;
+
+	/**
+	 * Queries.
+	 *
+	 * @var array
+	 */
+	private $queries = array();
+
 	public function set_up() {
 		parent::set_up();
 		$this->theme_root = realpath( DIR_TESTDATA . '/themedir1' );


### PR DESCRIPTION
Dynamic (non-explicitly declared) properties are deprecated as of PHP 8.2 and are expected to become a fatal error in PHP 9.0.

In this particular group of test files, the test classes contain a `set_up()` method which sets a few dynamic (not explicitly declared) properties.

For those properties which were set using a function call or variable access, the property has been explicitly declared on the class now.

For those properties which were set using a constant scalar expression and for which the value is not changed by any of the tests, the property setting has been removed in favour of declaring a class constant.

Includes removing one unused dynamic property declaration (`$this->queries` in `Test_Block_Supports_Layout`, probably copy/pasta from another test class).

Trac ticket: https://core.trac.wordpress.org/ticket/56033

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
