### PR TITLE
[#56039] Classic Editor: Current selection is not preserved when switching Visual to Text editor

### DIFF
--- a/src/js/_enqueues/wp/editor/base.js
+++ b/src/js/_enqueues/wp/editor/base.js
@@ -772,11 +772,11 @@ window.wp = window.wp || {};
 			endElement.remove();
 
 			var startRegex = new RegExp(
-				'<span[^>]*\\s*class="mce_SELRES_start"[^>]+>\\s*' + selectionID + '[^<]*<\\/span>(\\s*)'
+				'<span[^>]*\\s*class="mce_SELRES_start"[^>]*>\\s*' + selectionID + '[^<]*<\\/span>(\\s*)'
 			);
 
 			var endRegex = new RegExp(
-				'(\\s*)<span[^>]*\\s*class="mce_SELRES_end"[^>]+>\\s*' + selectionID + '[^<]*<\\/span>'
+				'(\\s*)<span[^>]*\\s*class="mce_SELRES_end"[^>]*>\\s*' + selectionID + '[^<]*<\\/span>'
 			);
 
 			var startMatch = content.match( startRegex ),


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/56039

# Problem
In some cases (when formatting HTML attributes is disabled), the current selection when switching Visual to Text editor is not preserved. The selected text gets unselected and the editor does not jump to the previous selection position.
This is because the regular expression is not appropriate.

Line 774 in `wp-admin/editor.js`
The regular expression to find the selection position is:
```
var startRegex = new RegExp(
  '<span[^>]*\\s*class="mce_SELRES_start"[^>]+>\\s*' + selectionID + '[^<]*<\\/span>(\\s*)'
);
```
This works well with:
`<span class="mce_SELRES_start" style="display: inline-block; ...">`
However, it does not work when "class" is the last attribute:
`<span style="display: inline-block; ..." class="mce_SELRES_start">`

# Solution
Changing +(1 or more) to *(0 or more) in the regular expression makes it work.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
