### PR TITLE
PHP 8.2 | WP_Test_REST_Posts_Controller: fix dynamic properties

### DIFF
--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -115,6 +115,14 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		add_filter( 'posts_clauses', array( $this, 'save_posts_clauses' ), 10, 2 );
 	}
 
+	public function tear_down() {
+		if ( isset( $this->attachment_id ) ) {
+			$this->remove_added_uploads();
+		}
+
+		parent::tear_down();
+	}
+
 	public function wpSetUpBeforeRequest( $result, $server, $request ) {
 		$this->posts_clauses = array();
 		return $result;
@@ -5275,14 +5283,6 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 			$post->post_name,
 			'The post slug was not set to "sample-slug-2"'
 		);
-	}
-
-	public function tear_down() {
-		if ( isset( $this->attachment_id ) ) {
-			$this->remove_added_uploads();
-		}
-
-		parent::tear_down();
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -26,6 +26,8 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	protected $forbidden_cat;
 	protected $posts_clauses;
 
+	private $attachments_created = false;
+
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		self::$post_id = $factory->post->create();
 
@@ -116,8 +118,9 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function tear_down() {
-		if ( isset( $this->attachment_id ) ) {
+		if ( true === $this->attachments_created ) {
 			$this->remove_added_uploads();
+			$this->attachments_created = false;
 		}
 
 		parent::tear_down();
@@ -2779,8 +2782,8 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 
 	public function test_create_update_post_with_featured_media() {
 
-		$file                = DIR_TESTDATA . '/images/canola.jpg';
-		$this->attachment_id = $this->factory->attachment->create_object(
+		$file          = DIR_TESTDATA . '/images/canola.jpg';
+		$attachment_id = $this->factory->attachment->create_object(
 			$file,
 			0,
 			array(
@@ -2789,20 +2792,22 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 			)
 		);
 
+		$this->attachments_created = true;
+
 		wp_set_current_user( self::$editor_id );
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/posts' );
 		$params  = $this->set_post_data(
 			array(
-				'featured_media' => $this->attachment_id,
+				'featured_media' => $attachment_id,
 			)
 		);
 		$request->set_body_params( $params );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 		$new_post = get_post( $data['id'] );
-		$this->assertSame( $this->attachment_id, $data['featured_media'] );
-		$this->assertSame( $this->attachment_id, (int) get_post_thumbnail_id( $new_post->ID ) );
+		$this->assertSame( $attachment_id, $data['featured_media'] );
+		$this->assertSame( $attachment_id, (int) get_post_thumbnail_id( $new_post->ID ) );
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/posts/' . $new_post->ID );
 		$params  = $this->set_post_data(


### PR DESCRIPTION
### WP_Test_REST_Posts_Controller: move tear_down() method

... up to be directly below the `set_up()` method.

### PHP 8.2 | WP_Test_REST_Posts_Controller: fix dynamic properties

Dynamic (non-explicitly declared) properties are deprecated as of PHP 8.2 and are expected to become a fatal error in PHP 9.0.

In this particular case, the `test_create_update_post_with_featured_media()` method creates an attachment and writes the ID of the attachment to a dynamic (undeclared) property to be used as a flag to determine whether attachments need to be cleaned after the test in the `tear_down()` method.

As the actual _value_ of the property is irrelevant for the cleaning up and the property is realistically being used as a "flag", I'd like to suggest fixing this as follows:
* Have an actual "flag" property declared with a descriptive name - `$attachments_created` - to make the code in the `tear_down()` more easily understandable.
* As for the actual ID of the attachment, save that to a test method local variable as that's the only place it has any relevance.

Trac ticket: https://core.trac.wordpress.org/ticket/56033

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
