### PR TITLE
PHP 8.2 | WP_Test_REST_Users_Controller: remove dynamic properties

### DIFF
--- a/tests/phpunit/tests/rest-api/rest-users-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-users-controller.php
@@ -1109,27 +1109,27 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_get_item_published_author_post() {
-		$this->author_id = $this->factory->user->create(
+		$author_id = $this->factory->user->create(
 			array(
 				'role' => 'author',
 			)
 		);
 
-		$this->post_id = $this->factory->post->create(
+		$post_id = $this->factory->post->create(
 			array(
-				'post_author' => $this->author_id,
+				'post_author' => $author_id,
 			)
 		);
 
 		wp_set_current_user( 0 );
 
-		$request  = new WP_REST_Request( 'GET', sprintf( '/wp/v2/users/%d', $this->author_id ) );
+		$request  = new WP_REST_Request( 'GET', sprintf( '/wp/v2/users/%d', $author_id ) );
 		$response = rest_get_server()->dispatch( $request );
 		$this->check_get_user_response( $response, 'embed' );
 	}
 
 	public function test_get_item_published_author_pages() {
-		$this->author_id = $this->factory->user->create(
+		$author_id = $this->factory->user->create(
 			array(
 				'role' => 'author',
 			)
@@ -1137,13 +1137,13 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 
 		wp_set_current_user( 0 );
 
-		$request  = new WP_REST_Request( 'GET', sprintf( '/wp/v2/users/%d', $this->author_id ) );
+		$request  = new WP_REST_Request( 'GET', sprintf( '/wp/v2/users/%d', $author_id ) );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertSame( 401, $response->get_status() );
 
-		$this->post_id = $this->factory->post->create(
+		$post_id = $this->factory->post->create(
 			array(
-				'post_author' => $this->author_id,
+				'post_author' => $author_id,
 				'post_type'   => 'page',
 			)
 		);
@@ -1164,21 +1164,21 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_get_item_published_author_wrong_context() {
-		$this->author_id = $this->factory->user->create(
+		$author_id = $this->factory->user->create(
 			array(
 				'role' => 'author',
 			)
 		);
 
-		$this->post_id = $this->factory->post->create(
+		$post_id = $this->factory->post->create(
 			array(
-				'post_author' => $this->author_id,
+				'post_author' => $author_id,
 			)
 		);
 
 		wp_set_current_user( 0 );
 
-		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/users/%d', $this->author_id ) );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/users/%d', $author_id ) );
 		$request->set_param( 'context', 'edit' );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertErrorResponse( 'rest_user_cannot_view', $response, 401 );


### PR DESCRIPTION
Dynamic (non-explicitly declared) properties are deprecated as of PHP 8.2 and are expected to become a fatal error in PHP 9.0.

In these particular cases, individual tests set a couple of properties (`$author_id`, `$post_id`), which are never used outside of the context of the test in which they are created.

In other words: these should never have been properties, but should be test local variables instead.

Trac ticket: https://core.trac.wordpress.org/ticket/56033

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
