### PR TITLE
PHP 8.2 | WP_UnitTestCase_Base: explicitly set dynamic property

### DIFF
--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -23,6 +23,15 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 	protected static $hooks_saved = array();
 	protected static $ignore_files;
 
+	/**
+	 * Directory list.
+	 *
+	 * Set by the scandir() method and used by the delete_folders() method.
+	 *
+	 * @var array
+	 */
+	private $matched_dirs = array();
+
 	public function __isset( $name ) {
 		return 'factory' === $name;
 	}

--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -23,15 +23,6 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 	protected static $hooks_saved = array();
 	protected static $ignore_files;
 
-	/**
-	 * Directory list.
-	 *
-	 * Set by the scandir() method and used by the delete_folders() method.
-	 *
-	 * @var array
-	 */
-	private $matched_dirs = array();
-
 	public function __isset( $name ) {
 		return 'factory' === $name;
 	}
@@ -1430,35 +1421,45 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 	 * @param string $path Path to the directory to scan.
 	 */
 	public function delete_folders( $path ) {
-		$this->matched_dirs = array();
 		if ( ! is_dir( $path ) ) {
 			return;
 		}
 
-		$this->scandir( $path );
-		foreach ( array_reverse( $this->matched_dirs ) as $dir ) {
+		$matched_dirs = $this->scandir( $path );
+		foreach ( array_reverse( $matched_dirs ) as $dir ) {
 			rmdir( $dir );
 		}
 		rmdir( $path );
 	}
 
 	/**
-	 * Retrieves all directories contained inside a directory and stores them in the `$matched_dirs` property.
+	 * Retrieves all directories contained inside a directory.
 	 * Hidden directories are ignored.
 	 *
 	 * This is a helper for the `delete_folders()` method.
 	 *
 	 * @since 4.1.0
+	 * @since 6.1.0 No longer sets a (dynamic) property to keep track of the directories,
+	 *              but returns an array of the directories instead.
 	 *
 	 * @param string $dir Path to the directory to scan.
+	 * @return array List of directories.
 	 */
 	public function scandir( $dir ) {
+		$matched_dirs = array();
 		foreach ( scandir( $dir ) as $path ) {
 			if ( 0 !== strpos( $path, '.' ) && is_dir( $dir . '/' . $path ) ) {
-				$this->matched_dirs[] = $dir . '/' . $path;
-				$this->scandir( $dir . '/' . $path );
+				$matched_dirs[] = array( $dir . '/' . $path );
+				$matched_dirs[] = $this->scandir( $dir . '/' . $path );
 			}
 		}
+
+		// Compatibility check for PHP < 7.4, where array_merge() expects at least one array. See: https://3v4l.org/BIQMA
+		if ( array() === $matched_dirs ) {
+			return array();
+		}
+
+		return array_merge( ...$matched_dirs );
 	}
 
 	/**


### PR DESCRIPTION
Dynamic (non-explicitly declared) properties are deprecated as of PHP 8.2 and are expected to become a fatal error in PHP 9.0.

In this particular case, the `scandir()` method sets a dynamic property, which is subsequently used in the `delete_folders()` method.
Explicitly declaring the property fixes the PHP 8.2 incompatibility.

---

Having said that.... IMO this is not the right solution, but solving this properly could be considered a breaking change as these methods are both `public` and in the abstract base class for all tests.

Note: within the WP Core test suite, these methods are _only_ used in the `Tests_Multisite_GetSpaceUsed` test class.

The "proper" solution, IMO, would be as follows:
1. Change the `scandir()` method to return an array of the found directories. The `delete_folders()` method then would just need to use the return value and would not need access to the property either.
    I imagine this was previously not done due to the person writing the code being uncomfortable with recursive functions, but it is perfectly possible to do so and would get rid of the unnecessary property.
    The method is currently a `void` method and sets the property.
2. Move both methods to the `Tests_Multisite_GetSpaceUsed` test class as clearly they are not needed elsewhere.

Even just implementing step 1 would already be a good improvement and would still leave these methods available to future and/or external integration tests.

I'm happy to convert this PR to the proper solution, but would like a second opinion first. /cc @johnbillion 

---

Added a second commit:

### PHP 8.2 | WP_UnitTestCase_Base: minor refactor to remove need for $matched_dirs property

Follow-up to the earlier commit which explicitly declared the `$matched_dirs` property.

This commit implements the additional recommendation to remove the need for the - previously dynamic - property completely.

Effectively, this changes the `WP_UnitTestCase_Base::scandir()` method to return an array with matched directories instead of setting the property by using recursion in the method itself in an optimized manner.

Note the `array_merge()` not being in the loop itself, but at the very end of the function. This is for performance reasons.
See https://github.com/dseguy/clearPHP/blob/master/rules/no-array_merge-in-loop.md for a more detailed explanation of this.

I have verified in detail that the actual results of the previous version of this method and this version match, even when the paths passed are more complex and have deeper nested subdirectories.

---


Trac ticket: https://core.trac.wordpress.org/ticket/56033

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
