### PR TITLE
PHP 8.2 | Tests_Comment_Walker: explicitly declare all properties

### DIFF
--- a/tests/phpunit/tests/comment/walker.php
+++ b/tests/phpunit/tests/comment/walker.php
@@ -5,6 +5,13 @@
  */
 class Tests_Comment_Walker extends WP_UnitTestCase {
 
+	/**
+	 * Comment Post ID.
+	 *
+	 * @var int
+	 */
+	private $post_id;
+
 	public function set_up() {
 		parent::set_up();
 
@@ -26,7 +33,7 @@ class Tests_Comment_Walker extends WP_UnitTestCase {
 		$comment_child  = get_comment( $comment_child );
 
 		$comment_walker   = new Walker_Comment();
-		$comment_callback = new Comment_Callback_Test( $this, $comment_walker );
+		$comment_callback = new Comment_Callback_Test_Helper( $this, $comment_walker );
 
 		wp_list_comments(
 			array(
@@ -47,7 +54,10 @@ class Tests_Comment_Walker extends WP_UnitTestCase {
 	}
 }
 
-class Comment_Callback_Test {
+class Comment_Callback_Test_Helper {
+	private $test_walker;
+	private $walker;
+
 	public function __construct( Tests_Comment_Walker $test_walker, Walker_Comment $walker ) {
 		$this->test_walker = $test_walker;
 		$this->walker      = $walker;


### PR DESCRIPTION
Dynamic (non-explicitly declared) properties are deprecated as of PHP 8.2 and are expected to become a fatal error in PHP 9.0.

In this test file, the `Tests_Comment_Walker::set_up()` method created a dynamic `$post_id` property, which should have been explicitly declared.
Along the same lines, the `Comment_Callback_Test::__construct()` method also assigned values to two undeclared properties.

Fixed now by explicitly declaring the properties in both classes.

Includes renaming the `Comment_Callback_Test` class to `Comment_Callback_Test_Helper` as this class does not contain any test method and it's only purpose is as a "helper" class for the `Tests_Comment_Walker::test_has_children()` test.

Trac ticket: https://core.trac.wordpress.org/ticket/56033

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
