### PR TITLE
PHP 8.2 | Tests: explicitly declare all properties

### DIFF
--- a/tests/phpunit/tests/actions.php
+++ b/tests/phpunit/tests/actions.php
@@ -8,6 +8,35 @@
 class Tests_Actions extends WP_UnitTestCase {
 
 	/**
+	 * Flag to keep track whether a certain filter has been applied.
+	 *
+	 * Used in the `test_doing_filter_real()` test method.
+	 *
+	 * @var bool
+	 */
+	private $apply_testing_filter = false;
+
+	/**
+	 * Flag to keep track whether a certain filter has been applied.
+	 *
+	 * Used in the `test_doing_filter_real()` test method.
+	 *
+	 * @var bool
+	 */
+	private $apply_testing_nested_filter = false;
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down() {
+		// Make sure potentially changed properties are reverted to their default value.
+		$this->apply_testing_filter        = false;
+		$this->apply_testing_nested_filter = false;
+
+		parent::tear_down();
+	}
+
+	/**
 	 * @covers ::do_action
 	 */
 	public function test_simple_action() {

--- a/tests/phpunit/tests/admin/wpPrivacyRequestsTable.php
+++ b/tests/phpunit/tests/admin/wpPrivacyRequestsTable.php
@@ -16,6 +16,25 @@
  * @since 5.1.0
  */
 class Tests_Admin_wpPrivacyRequestsTable extends WP_UnitTestCase {
+
+	/**
+	 * Temporary storage for SQL to allow a filter to access it.
+	 *
+	 * Used in the `test_columns_should_be_sortable()` test method.
+	 *
+	 * @var string
+	 */
+	private $sql;
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down() {
+		unset( $this->sql );
+
+		parent::tear_down();
+	}
+
 	/**
 	 * Get instance for mocked class.
 	 *

--- a/tests/phpunit/tests/comment/query.php
+++ b/tests/phpunit/tests/comment/query.php
@@ -9,8 +9,24 @@ class Tests_Comment_Query extends WP_UnitTestCase {
 	protected static $post_id;
 	protected $comment_id;
 
+	/**
+	 * Temporary storage for comment exclusions to allow a filter to access these.
+	 *
+	 * Used in the following tests:
+	 * - `test_comment_clauses_prepend_callback_should_be_respected_when_filling_descendants()`
+	 * - `test_comment_clauses_append_callback_should_be_respected_when_filling_descendants()`
+	 *
+	 * @var array
+	 */
+	private $to_exclude;
+
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		self::$post_id = $factory->post->create();
+	}
+
+	public function tear_down() {
+		unset( $this->to_exclude );
+		parent::tear_down();
 	}
 
 	/**
@@ -4301,8 +4317,6 @@ class Tests_Comment_Query extends WP_UnitTestCase {
 		);
 		remove_filter( 'comments_clauses', array( $this, 'prepend_exclusions' ) );
 
-		unset( $this->to_exclude );
-
 		$this->assertEqualSets( array( $top_level_0, $child1_of_0, $top_level_comments[0], $top_level_comments[2] ), wp_list_pluck( $q->comments, 'comment_ID' ) );
 	}
 
@@ -4359,8 +4373,6 @@ class Tests_Comment_Query extends WP_UnitTestCase {
 			)
 		);
 		remove_filter( 'comments_clauses', array( $this, 'append_exclusions' ) );
-
-		unset( $this->to_exclude );
 
 		$this->assertEqualSets( array( $top_level_0, $child1_of_0, $top_level_comments[0], $top_level_comments[2] ), wp_list_pluck( $q->comments, 'comment_ID' ) );
 	}

--- a/tests/phpunit/tests/hooks/addFilter.php
+++ b/tests/phpunit/tests/hooks/addFilter.php
@@ -11,6 +11,23 @@ class Tests_Hooks_AddFilter extends WP_UnitTestCase {
 
 	public $hook;
 
+	/**
+	 * Temporary storage for action output.
+	 *
+	 * Used in the following tests:
+	 * - `test_remove_and_add_action()`
+	 * - `test_remove_and_add_last_action()`
+	 * - `test_remove_and_recurse_and_add_action()`
+	 *
+	 * @var array
+	 */
+	private $action_output = '';
+
+	public function tear_down() {
+		$this->action_output = '';
+		parent::tear_down();
+	}
+
 	public function test_add_filter_with_function() {
 		$callback      = '__return_null';
 		$hook          = new WP_Hook();
@@ -202,8 +219,7 @@ class Tests_Hooks_AddFilter extends WP_UnitTestCase {
 	}
 
 	public function test_remove_and_add_action() {
-		$this->hook          = new WP_Hook();
-		$this->action_output = '';
+		$this->hook = new WP_Hook();
 
 		$this->hook->add_filter( 'remove_and_add_action', '__return_empty_string', 10, 0 );
 
@@ -217,8 +233,7 @@ class Tests_Hooks_AddFilter extends WP_UnitTestCase {
 	}
 
 	public function test_remove_and_add_last_action() {
-		$this->hook          = new WP_Hook();
-		$this->action_output = '';
+		$this->hook = new WP_Hook();
 
 		$this->hook->add_filter( 'remove_and_add_action', '__return_empty_string', 10, 0 );
 
@@ -232,8 +247,7 @@ class Tests_Hooks_AddFilter extends WP_UnitTestCase {
 	}
 
 	public function test_remove_and_recurse_and_add_action() {
-		$this->hook          = new WP_Hook();
-		$this->action_output = '';
+		$this->hook = new WP_Hook();
 
 		$this->hook->add_filter( 'remove_and_add_action', '__return_empty_string', 10, 0 );
 

--- a/tests/phpunit/tests/post/query.php
+++ b/tests/phpunit/tests/post/query.php
@@ -5,6 +5,25 @@
  * @group post
  */
 class Tests_Post_Query extends WP_UnitTestCase {
+
+	/**
+	 * Temporary storage for a post ID for tests using filter callbacks.
+	 *
+	 * Used in the `test_posts_pre_query_filter_should_respect_set_found_posts()` method.
+	 *
+	 * @var int
+	 */
+	private $post_id;
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down() {
+		unset( $this->post_id );
+
+		parent::tear_down();
+	}
+
 	/**
 	 * @group taxonomy
 	 */
@@ -729,7 +748,7 @@ class Tests_Post_Query extends WP_UnitTestCase {
 	 * @ticket 42469
 	 */
 	public function test_found_posts_should_be_integer_not_string() {
-		$this->post_id = self::factory()->post->create();
+		$post_id = self::factory()->post->create();
 
 		$q = new WP_Query(
 			array(
@@ -744,7 +763,7 @@ class Tests_Post_Query extends WP_UnitTestCase {
 	 * @ticket 42469
 	 */
 	public function test_found_posts_should_be_integer_even_if_found_posts_filter_returns_string_value() {
-		$this->post_id = self::factory()->post->create();
+		$post_id = self::factory()->post->create();
 
 		add_filter( 'found_posts', '__return_empty_string' );
 

--- a/tests/phpunit/tests/rewrite.php
+++ b/tests/phpunit/tests/rewrite.php
@@ -8,6 +8,15 @@
 class Tests_Rewrite extends WP_UnitTestCase {
 	private $home_url;
 
+	/**
+	 * Temporary storage for blog id for use with filters.
+	 *
+	 * Used in the `test_url_to_postid_of_http_site_when_current_site_uses_https()` method.
+	 *
+	 * @var int
+	 */
+	private $blog_id_35531;
+
 	public function set_up() {
 		parent::set_up();
 
@@ -22,6 +31,7 @@ class Tests_Rewrite extends WP_UnitTestCase {
 		$wp_rewrite->init();
 
 		update_option( 'home', $this->home_url );
+		unset( $this->blog_id_35531 );
 		parent::tear_down();
 	}
 

--- a/tests/phpunit/tests/term/query.php
+++ b/tests/phpunit/tests/term/query.php
@@ -4,6 +4,27 @@
  * @group taxonomy
  */
 class Tests_Term_Query extends WP_UnitTestCase {
+
+	/**
+	 * Temporary storage for a term ID for tests using filter callbacks.
+	 *
+	 * Used in the following tests:
+	 * - `test_null_term_object_should_be_discarded()`
+	 * - `test_error_term_object_should_be_discarded()`
+	 *
+	 * @var int
+	 */
+	private $term_id;
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down() {
+		unset( $this->term_id );
+
+		parent::tear_down();
+	}
+
 	/**
 	 * @ticket 37545
 	 */

--- a/tests/phpunit/tests/term/wpGetObjectTerms.php
+++ b/tests/phpunit/tests/term/wpGetObjectTerms.php
@@ -7,9 +7,27 @@
 class Tests_Term_WpGetObjectTerms extends WP_UnitTestCase {
 	private $taxonomy = 'wptests_tax';
 
+	/**
+	 * Temporary storage for taxonomies for tests using filter callbacks.
+	 *
+	 * Used in the `test_taxonomies_passed_to_wp_get_object_terms_filter_should_be_quoted()` method.
+	 *
+	 * @var array
+	 */
+	private $taxonomies;
+
 	public function set_up() {
 		parent::set_up();
 		register_taxonomy( 'wptests_tax', 'post' );
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down() {
+		unset( $this->taxonomies );
+
+		parent::tear_down();
 	}
 
 	public function test_get_object_terms_by_slug() {

--- a/tests/phpunit/tests/user/capabilities.php
+++ b/tests/phpunit/tests/user/capabilities.php
@@ -30,6 +30,15 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 	 */
 	protected static $block_id;
 
+	/**
+	 * Temporary storage for roles for tests using filter callbacks.
+	 *
+	 * Used in the `test_wp_roles_init_action()` method.
+	 *
+	 * @var array
+	 */
+	private $role_test_wp_roles_init;
+
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		self::$users       = array(
 			'anonymous'     => new WP_User( 0 ),
@@ -58,6 +67,15 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 		// Keep track of users we create.
 		$this->flush_roles();
 
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down() {
+		unset( $this->role_test_wp_roles_init );
+
+		parent::tear_down();
 	}
 
 	public static function wpTearDownAfterClass() {
@@ -1996,13 +2014,11 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 
 	}
 
-
-	protected $_role_test_wp_roles_role;
 	/**
 	 * @ticket 23016
 	 */
 	public function test_wp_roles_init_action() {
-		$this->_role_test_wp_roles_init = array(
+		$this->role_test_wp_roles_init = array(
 			'role' => 'test_wp_roles_init',
 			'info' => array(
 				'name'         => 'Test WP Roles Init',
@@ -2015,16 +2031,16 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 
 		remove_action( 'wp_roles_init', array( $this, '_hook_wp_roles_init' ) );
 
-		$expected = new WP_Role( $this->_role_test_wp_roles_init['role'], $this->_role_test_wp_roles_init['info']['capabilities'] );
+		$expected = new WP_Role( $this->role_test_wp_roles_init['role'], $this->role_test_wp_roles_init['info']['capabilities'] );
 
-		$role = $wp_roles->get_role( $this->_role_test_wp_roles_init['role'] );
+		$role = $wp_roles->get_role( $this->role_test_wp_roles_init['role'] );
 
 		$this->assertEquals( $expected, $role );
-		$this->assertContains( $this->_role_test_wp_roles_init['info']['name'], $wp_roles->role_names );
+		$this->assertContains( $this->role_test_wp_roles_init['info']['name'], $wp_roles->role_names );
 	}
 
 	public function _hook_wp_roles_init( $wp_roles ) {
-		$wp_roles->add_role( $this->_role_test_wp_roles_init['role'], $this->_role_test_wp_roles_init['info']['name'], $this->_role_test_wp_roles_init['info']['capabilities'] );
+		$wp_roles->add_role( $this->role_test_wp_roles_init['role'], $this->role_test_wp_roles_init['info']['name'], $this->role_test_wp_roles_init['info']['capabilities'] );
 	}
 
 	/**


### PR DESCRIPTION
Dynamic (non-explicitly declared) properties are deprecated as of PHP 8.2 and are expected to become a fatal error in PHP 9.0.

In each of the cases included in this PR, one or more individual tests set a property to allow a filter/action access to certain information.

This commit:
* Explicitly declares these properties and documents in which tests they are being used.
* Add a reset to the default value of the property to a pre-existing `tear_down()` method or adds that method specifically for that purpose.
    This ensures that tests can not accidentally "taint" each other.

As these properties are being declared on test classes, I'm making them all `private`.
Even though the original dynamic property was `public`, this should not be considered a BC break as this only involves test classes.

Includes:
* In the `Tests_Post_Query` class, there were two tests assigning a value to an undeclared `$post_id` property, but subsequently not using the property, so those assignments should have been to a local variable (if they should be assignments at all).
* In the `Test_User_Capabilities` class, the property name had a leading `_` underscore. This is an outdated PHP 4 practice to indicate a `private` property. As PHP 4 is no longer supported, I have removed the leading underscore from the property name.
* In the `Tests_User_Capabilities` class, an unused `$_role_test_wp_roles_role` property was declared somewhere in the middle of the class. I have removed this property.
    This was probably intended to be the declaration of the `$_role_test_wp_roles_init` property, but then the name used in the assignments was changed, but the property declaration name was not.

Trac ticket: https://core.trac.wordpress.org/ticket/56033

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
