### PR TITLE
PHP 8.2 | WP_Test_REST_Pages_Controller: remove an unused dynamic property

### DIFF
--- a/tests/phpunit/tests/rest-api/rest-pages-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-pages-controller.php
@@ -27,7 +27,6 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 
 	public function set_up() {
 		parent::set_up();
-		$this->has_setup_template = false;
 		add_filter( 'theme_page_templates', array( $this, 'filter_theme_page_templates' ) );
 		// Re-register the route as we now have a template available.
 		$GLOBALS['wp_rest_server']->override_by_default = true;


### PR DESCRIPTION
Appears that the dynamically created `$has_setup_template` property isn't actually used.

It's unclear what the originally intention was, but as-is, it is undeclared and unused, so can be safely removed.

Trac ticket: https://core.trac.wordpress.org/ticket/56033

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
