### PR TITLE
PHP 8.2 | Tests: explicitly declare all properties created in set_up()

### DIFF
--- a/tests/phpunit/tests/canonical/https.php
+++ b/tests/phpunit/tests/canonical/https.php
@@ -6,6 +6,21 @@
  * @group query
  */
 class Tests_Canonical_HTTPS extends WP_Canonical_UnitTestCase {
+
+	/**
+	 * Dummy HTTP URL.
+	 *
+	 * @var string
+	 */
+	private $http = '';
+
+	/**
+	 * Dummy HTTPS URL.
+	 *
+	 * @var string
+	 */
+	private $https = '';
+
 	public function set_up() {
 		parent::set_up();
 

--- a/tests/phpunit/tests/customize/manager.php
+++ b/tests/phpunit/tests/customize/manager.php
@@ -41,6 +41,20 @@ class Tests_WP_Customize_Manager extends WP_UnitTestCase {
 	protected static $subscriber_user_id;
 
 	/**
+	 * Path to test file 1.
+	 *
+	 * @var string
+	 */
+	private $test_file;
+
+	/**
+	 * Path to test file 2.
+	 *
+	 * @var string
+	 */
+	private $test_file2;
+
+	/**
 	 * Set up before class.
 	 *
 	 * @param WP_UnitTest_Factory $factory Factory.

--- a/tests/phpunit/tests/feed/atom.php
+++ b/tests/phpunit/tests/feed/atom.php
@@ -13,6 +13,9 @@ class Tests_Feed_Atom extends WP_UnitTestCase {
 	public static $posts;
 	public static $category;
 
+	private $post_count;
+	private $excerpt_only;
+
 	/**
 	 * Setup a new user and attribute some posts.
 	 */

--- a/tests/phpunit/tests/feed/rss2.php
+++ b/tests/phpunit/tests/feed/rss2.php
@@ -14,6 +14,9 @@ class Tests_Feed_RSS2 extends WP_UnitTestCase {
 	public static $category;
 	public static $post_date;
 
+	private $post_count;
+	private $excerpt_only;
+
 	/**
 	 * Setup a new user and attribute some posts.
 	 */

--- a/tests/phpunit/tests/includes/factory.php
+++ b/tests/phpunit/tests/includes/factory.php
@@ -1,6 +1,12 @@
 <?php
 
 class TestFactoryFor extends WP_UnitTestCase {
+
+	/**
+	 * @var WP_UnitTest_Factory_For_Term
+	 */
+	private $category_factory;
+
 	public function set_up() {
 		parent::set_up();
 		$this->category_factory = new WP_UnitTest_Factory_For_Term( null, 'category' );

--- a/tests/phpunit/tests/menu/walker-nav-menu-edit.php
+++ b/tests/phpunit/tests/menu/walker-nav-menu-edit.php
@@ -5,6 +5,12 @@
  * @group walker
  */
 class Tests_Menu_Walker_Nav_Menu_Edit extends WP_UnitTestCase {
+
+	/**
+	 * @var \Walker_Nav_Menu_Edit
+	 */
+	private $walker;
+
 	protected $_wp_nav_menu_max_depth;
 
 	public function set_up() {

--- a/tests/phpunit/tests/menu/walker-nav-menu.php
+++ b/tests/phpunit/tests/menu/walker-nav-menu.php
@@ -11,6 +11,13 @@ class Tests_Menu_Walker_Nav_Menu extends WP_UnitTestCase {
 	public $walker;
 
 	/**
+	 * Original nav menu max depth.
+	 *
+	 * @var int
+	 */
+	private $orig_wp_nav_menu_max_depth;
+
+	/**
 	 * Setup.
 	 */
 	public function set_up() {
@@ -22,7 +29,7 @@ class Tests_Menu_Walker_Nav_Menu extends WP_UnitTestCase {
 		require_once ABSPATH . 'wp-includes/class-walker-nav-menu.php';
 		$this->walker = new Walker_Nav_Menu();
 
-		$this->_wp_nav_menu_max_depth = $_wp_nav_menu_max_depth;
+		$this->orig_wp_nav_menu_max_depth = $_wp_nav_menu_max_depth;
 	}
 
 	/**
@@ -31,7 +38,7 @@ class Tests_Menu_Walker_Nav_Menu extends WP_UnitTestCase {
 	public function tear_down() {
 		global $_wp_nav_menu_max_depth;
 
-		$_wp_nav_menu_max_depth = $this->_wp_nav_menu_max_depth;
+		$_wp_nav_menu_max_depth = $this->orig_wp_nav_menu_max_depth;
 		parent::tear_down();
 	}
 

--- a/tests/phpunit/tests/meta.php
+++ b/tests/phpunit/tests/meta.php
@@ -6,6 +6,14 @@
 class Tests_Meta extends WP_UnitTestCase {
 	protected $updated_mids = array();
 
+	/**
+	 * @var \WP_User
+	 */
+	private $author;
+
+	private $meta_id;
+	private $delete_meta_id;
+
 	public function set_up() {
 		parent::set_up();
 		$this->author         = new WP_User( self::factory()->user->create( array( 'role' => 'author' ) ) );

--- a/tests/phpunit/tests/pomo/noopTranslations.php
+++ b/tests/phpunit/tests/pomo/noopTranslations.php
@@ -4,6 +4,28 @@
  * @group pomo
  */
 class Tests_POMO_NOOPTranslations extends WP_UnitTestCase {
+
+	/**
+	 * NOOP translations object.
+	 *
+	 * @var NOOP_Translations
+	 */
+	private $noop;
+
+	/**
+	 * Single translation entry object.
+	 *
+	 * @var Translation_Entry
+	 */
+	private $entry;
+
+	/**
+	 * Multi translation entries object.
+	 *
+	 * @var Translation_Entry
+	 */
+	private $plural_entry;
+
 	public function set_up() {
 		parent::set_up();
 		$this->noop         = new NOOP_Translations;

--- a/tests/phpunit/tests/post.php
+++ b/tests/phpunit/tests/post.php
@@ -9,6 +9,8 @@ class Tests_Post extends WP_UnitTestCase {
 	protected static $editor_id;
 	protected static $grammarian_id;
 
+	private $post_ids = array();
+
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		self::$editor_id = $factory->user->create( array( 'role' => 'editor' ) );
 

--- a/tests/phpunit/tests/privacy/wpPrivacyGeneratePersonalDataExportFile.php
+++ b/tests/phpunit/tests/privacy/wpPrivacyGeneratePersonalDataExportFile.php
@@ -45,6 +45,13 @@ class Tests_Privacy_wpPrivacyGeneratePersonalDataExportFile extends WP_UnitTestC
 	public static $exports_dir;
 
 	/**
+	 * Original error level.
+	 *
+	 * @var int
+	 */
+	private $orig_error_level;
+
+	/**
 	 * Create fixtures that are shared by multiple test cases.
 	 *
 	 * @since 5.2.0
@@ -79,8 +86,8 @@ class Tests_Privacy_wpPrivacyGeneratePersonalDataExportFile extends WP_UnitTestC
 		add_action( 'wp_privacy_personal_data_export_file_created', array( $this, 'action_wp_privacy_personal_data_export_file_created' ) );
 
 		// Suppress warnings from "Cannot modify header information - headers already sent by".
-		$this->_error_level = error_reporting();
-		error_reporting( $this->_error_level & ~E_WARNING );
+		$this->orig_error_level = error_reporting();
+		error_reporting( $this->orig_error_level & ~E_WARNING );
 	}
 
 	/**
@@ -92,7 +99,7 @@ class Tests_Privacy_wpPrivacyGeneratePersonalDataExportFile extends WP_UnitTestC
 	 */
 	public function tear_down() {
 		$this->remove_exports_dir();
-		error_reporting( $this->_error_level );
+		error_reporting( $this->orig_error_level );
 		parent::tear_down();
 	}
 

--- a/tests/phpunit/tests/privacy/wpPrivacyProcessPersonalDataExportPage.php
+++ b/tests/phpunit/tests/privacy/wpPrivacyProcessPersonalDataExportPage.php
@@ -141,6 +141,13 @@ class Tests_Privacy_wpPrivacyProcessPersonalDataExportPage extends WP_UnitTestCa
 	public $_export_data_grouped_fetched_within_callback;
 
 	/**
+	 * Original error level.
+	 *
+	 * @var int
+	 */
+	private $orig_error_level;
+
+	/**
 	 * Create user request fixtures shared by test methods.
 	 *
 	 * @since 5.2.0
@@ -209,8 +216,8 @@ class Tests_Privacy_wpPrivacyProcessPersonalDataExportPage extends WP_UnitTestCa
 		add_filter( 'wp_die_ajax_handler', array( $this, 'get_wp_die_handler' ), 1, 1 );
 
 		// Suppress warnings from "Cannot modify header information - headers already sent by".
-		$this->_error_level = error_reporting();
-		error_reporting( $this->_error_level & ~E_WARNING );
+		$this->orig_error_level = error_reporting();
+		error_reporting( $this->orig_error_level & ~E_WARNING );
 	}
 
 	/**
@@ -219,7 +226,7 @@ class Tests_Privacy_wpPrivacyProcessPersonalDataExportPage extends WP_UnitTestCa
 	 * @since 5.2.0
 	 */
 	public function tear_down() {
-		error_reporting( $this->_error_level );
+		error_reporting( $this->orig_error_level );
 
 		parent::tear_down();
 	}

--- a/tests/phpunit/tests/rest-api/rest-autosaves-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-autosaves-controller.php
@@ -25,6 +25,8 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 	protected static $child_page_id;
 	protected static $child_draft_page_id;
 
+	private $post_autosave;
+
 	protected function set_post_data( $args = array() ) {
 		$defaults = array(
 			'title'   => 'Post Title',

--- a/tests/phpunit/tests/rest-api/rest-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-controller.php
@@ -11,6 +11,11 @@
  */
 class WP_Test_REST_Controller extends WP_Test_REST_TestCase {
 
+	/**
+	 * @var WP_REST_Request
+	 */
+	private $request;
+
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		// Load the WP_REST_Test_Controller class if not already loaded.
 		require_once __DIR__ . '/rest-test-controller.php';

--- a/tests/phpunit/tests/rest-api/rest-revisions-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-revisions-controller.php
@@ -16,6 +16,15 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 	protected static $editor_id;
 	protected static $contributor_id;
 
+	private $total_revisions;
+	private $revisions;
+	private $revision_1;
+	private $revision_id1;
+	private $revision_2;
+	private $revision_id2;
+	private $revision_3;
+	private $revision_id3;
+
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		self::$post_id = $factory->post->create();
 		self::$page_id = $factory->post->create( array( 'post_type' => 'page' ) );

--- a/tests/phpunit/tests/rest-api/rest-settings-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-settings-controller.php
@@ -14,6 +14,11 @@ class WP_Test_REST_Settings_Controller extends WP_Test_REST_Controller_Testcase 
 	protected static $administrator;
 	protected static $author;
 
+	/**
+	 * @var WP_REST_Settings_Controller
+	 */
+	private $endpoint;
+
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		self::$administrator = $factory->user->create(
 			array(

--- a/tests/phpunit/tests/rest-api/rest-users-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-users-controller.php
@@ -25,6 +25,11 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 
 	protected static $site;
 
+	/**
+	 * @var WP_REST_Users_Controller
+	 */
+	private $endpoint;
+
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		self::$superadmin   = $factory->user->create(
 			array(

--- a/tests/phpunit/tests/rewrite/numericSlugs.php
+++ b/tests/phpunit/tests/rewrite/numericSlugs.php
@@ -6,6 +6,7 @@
  */
 class Tests_Rewrite_NumericSlugs extends WP_UnitTestCase {
 	private $old_current_user;
+	private $author_id;
 
 	public function set_up() {
 		parent::set_up();

--- a/tests/phpunit/tests/shortcode.php
+++ b/tests/phpunit/tests/shortcode.php
@@ -6,6 +6,14 @@ class Tests_Shortcode extends WP_UnitTestCase {
 
 	protected $shortcodes = array( 'test-shortcode-tag', 'footag', 'bartag', 'baztag', 'dumptag', 'hyphen', 'hyphen-foo', 'hyphen-foo-bar', 'url', 'img' );
 
+	private $atts    = null;
+	private $content = null;
+	private $tagname = null;
+
+	private $filter_atts_out   = null;
+	private $filter_atts_pairs = null;
+	private $filter_atts_atts  = null;
+
 	public function set_up() {
 		parent::set_up();
 
@@ -13,10 +21,12 @@ class Tests_Shortcode extends WP_UnitTestCase {
 			add_shortcode( $shortcode, array( $this, 'shortcode_' . str_replace( '-', '_', $shortcode ) ) );
 		}
 
-		$this->atts    = null;
-		$this->content = null;
-		$this->tagname = null;
-
+		$this->atts              = null;
+		$this->content           = null;
+		$this->tagname           = null;
+		$this->filter_atts_out   = null;
+		$this->filter_atts_pairs = null;
+		$this->filter_atts_atts  = null;
 	}
 
 	public function tear_down() {

--- a/tests/phpunit/tests/theme/customHeader.php
+++ b/tests/phpunit/tests/theme/customHeader.php
@@ -8,6 +8,8 @@ class Tests_Theme_CustomHeader extends WP_UnitTestCase {
 
 	protected static $header_video_id;
 
+	private $customize_manager = null;
+
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		self::$post = self::factory()->post->create(
 			array(

--- a/tests/phpunit/tests/user/session.php
+++ b/tests/phpunit/tests/user/session.php
@@ -7,6 +7,11 @@
  */
 class Tests_User_Session extends WP_UnitTestCase {
 
+	/**
+	 * @var WP_User_Meta_Session_Tokens
+	 */
+	private $manager;
+
 	public function set_up() {
 		parent::set_up();
 		remove_all_filters( 'session_token_manager' );

--- a/tests/phpunit/tests/walker.php
+++ b/tests/phpunit/tests/walker.php
@@ -8,6 +8,11 @@
  */
 class Tests_Walker extends WP_UnitTestCase {
 
+	/**
+	 * @var Walker
+	 */
+	private $walker;
+
 	public function set_up() {
 		parent::set_up();
 


### PR DESCRIPTION
Dynamic (non-explicitly declared) properties are deprecated as of PHP 8.2 and are expected to become a fatal error in PHP 9.0.

In each of the cases included in this PR, one or more properties are dynamically created in the `set_up()` method of the test class.

This commit explicitly declares these properties.

As these properties are being declared on test classes, I'm making them all `private`.
Even though the original dynamic property was `public`, this should not be considered a BC break as this only involves test classes.

Notes:
* As these properties receive assignments during test runs or a one-time assignment, but the assignment uses a function call or variable access, these properties can't be changed to class constants, but they should be declared explicitly as properties on the class.
* In `Tests_Theme_CustomHeader`, I've given the `$customize_manager` property a default value of `null`, same as it was already being reset to `null` in the `tear_down()` method.
* In `Tests_Privacy_wpPrivacyProcessPersonalDataExportPage` and the `Tests_Privacy_wpPrivacyGeneratePersonalDataExportFile` classes, the property name had a leading `_` underscore. This is an outdated PHP 4 practice to indicate a `private` property. As PHP 4 is no longer supported, I have renamed the property to `$orig_error_level`.
* Along the same lines, in `Tests_Menu_Walker_Nav_Menu`, the property name also had a leading `_` underscore. I have renamed the property to `$orig_wp_nav_menu_max_depth`.
* In the `Tests_Shortcode` class, three properties were already being (re)set in the `set_up()` method, while three others were being set for most tests via the `shortcode_test_shortcode_tag()` method or in the tests themselves.
    I've now made sure that all six properties are given their initial `null` value in the `set_up()` method and are explicitly declared.

Additionally:
* In the `Tests_User_Session` class, the `set_up()` method is incorrect. No assertions should be executed in fixture methods, but the `set_up()` method contains two assertions.
    I've not addressed this as this is outside the scope of this PR, but this should be addressed at a later point in time.

Trac ticket: https://core.trac.wordpress.org/ticket/56033

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
