### PR TITLE
PHP 8.2 | WP_Test_Stream: explicitly declare all properties

### DIFF
--- a/tests/phpunit/includes/class-wp-test-stream.php
+++ b/tests/phpunit/includes/class-wp-test-stream.php
@@ -31,6 +31,15 @@ class WP_Test_Stream {
 	public $data_ref;
 
 	/**
+	 * The current context.
+	 *
+	 * @link https://www.php.net/manual/en/class.streamwrapper.php
+	 *
+	 * @var resource|null
+	 */
+	public $context;
+
+	/**
 	 * Initializes internal state for reading the given URL.
 	 *
 	 * @param string $url A URL of the form "protocol://bucket/path".


### PR DESCRIPTION
Dynamic (non-explicitly declared) properties are deprecated as of PHP 8.2 and are expected to become a fatal error in PHP 9.0.

The `WP_Test_Stream` class is a stream wrapper for use in the tests and must comply with the PHP requirements for such stream wrappers.

In this case, the class did not declare the required `public` `$context` property, which led to deprecation notices about the property being dynamically created from the `Tests_Image_Editor_Imagick::test_streams()` and `Tests_Image_Meta::test_stream` tests.

Refs:
* https://www.php.net/manual/en/class.streamwrapper.php#streamwrapper.props

Trac ticket: https://core.trac.wordpress.org/ticket/56033

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
