### PR TITLE
PHP 8.2 | WP_Ajax_Upgrader_Skin: explicitely declare properties

### DIFF
--- a/src/wp-admin/includes/class-bulk-plugin-upgrader-skin.php
+++ b/src/wp-admin/includes/class-bulk-plugin-upgrader-skin.php
@@ -16,7 +16,16 @@
  * @see Bulk_Upgrader_Skin
  */
 class Bulk_Plugin_Upgrader_Skin extends Bulk_Upgrader_Skin {
-	public $plugin_info = array(); // Plugin_Upgrader::bulk_upgrade() will fill this in.
+
+	/**
+	 * Plugin info.
+	 *
+	 * The `Plugin_Upgrader::bulk_upgrade()` method will fill this in with info
+	 * retrieved from the `get_plugin_data()` function.
+	 *
+	 * @var array Plugin data. Values will be empty if not supplied by the plugin.
+	 */
+	public $plugin_info = array();
 
 	public function add_strings() {
 		parent::add_strings();

--- a/src/wp-admin/includes/class-bulk-theme-upgrader-skin.php
+++ b/src/wp-admin/includes/class-bulk-theme-upgrader-skin.php
@@ -16,7 +16,17 @@
  * @see Bulk_Upgrader_Skin
  */
 class Bulk_Theme_Upgrader_Skin extends Bulk_Upgrader_Skin {
-	public $theme_info = array(); // Theme_Upgrader::bulk_upgrade() will fill this in.
+
+	/**
+	 * Theme info.
+	 *
+	 * The `Theme_Upgrader::bulk_upgrade()` method will fill this in with info
+	 * retrieved from the `Theme_Upgrader::theme_info()` method, which
+	 * in turn calls the `wp_get_theme()` function.
+	 *
+	 * @var WP_Theme|false The theme's info object, or false.
+	 */
+	public $theme_info = false;
 
 	public function add_strings() {
 		parent::add_strings();

--- a/src/wp-admin/includes/class-wp-ajax-upgrader-skin.php
+++ b/src/wp-admin/includes/class-wp-ajax-upgrader-skin.php
@@ -19,6 +19,27 @@
 class WP_Ajax_Upgrader_Skin extends Automatic_Upgrader_Skin {
 
 	/**
+	 * Plugin info.
+	 *
+	 * The `Plugin_Upgrader::bulk_upgrade()` method will fill this in with info
+	 * retrieved from the `get_plugin_data()` function.
+	 *
+	 * @var array Plugin data. Values will be empty if not supplied by the plugin.
+	 */
+	public $plugin_info = array();
+
+	/**
+	 * Theme info.
+	 *
+	 * The `Theme_Upgrader::bulk_upgrade()` method will fill this in with info
+	 * retrieved from the `Theme_Upgrader::theme_info()` method, which
+	 * in turn calls the `wp_get_theme()` function.
+	 *
+	 * @var WP_Theme|false The theme's info object, or false.
+	 */
+	public $theme_info = false;
+
+	/**
 	 * Holds the WP_Error object.
 	 *
 	 * @since 4.6.0


### PR DESCRIPTION
Dynamic (non-explicitly declared) properties are deprecated as of PHP 8.2 and are expected to become a fatal error in PHP 9.0.

In this case, the `$plugin_info` and `$theme_info` are set in the `Plugin_Upgrader::bulk_upgrade()` and the `Theme_Upgrader::bulk_upgrade()` specifically.

The [`Bulk_Plugin_Upgrader_Skin` class](https://github.com/WordPress/wordpress-develop/blob/14a468294f10bf8d4ca1aee6551e9b3f02144b77/src/wp-admin/includes/class-bulk-plugin-upgrader-skin.php#L19) and the [`Bulk_Theme_Upgrader_Skin` class](https://github.com/WordPress/wordpress-develop/blob/14a468294f10bf8d4ca1aee6551e9b3f02144b77/src/wp-admin/includes/class-bulk-theme-upgrader-skin.php#L19) both already allow for this, but the [`wp_ajax_update_plugin()`](https://github.com/WordPress/wordpress-develop/blob/14a468294f10bf8d4ca1aee6551e9b3f02144b77/src/wp-admin/includes/ajax-actions.php#L4547) method and the [`wp_ajax_update_theme()`](https://github.com/WordPress/wordpress-develop/blob/14a468294f10bf8d4ca1aee6551e9b3f02144b77/src/wp-admin/includes/ajax-actions.php#L4267) method also call the `*_Upgrader::bulk_upgrade()` methods, so the `WP_Ajax_Upgrader_Skin` also needs to have these properties explicitly declared.

Includes adding proper docblocks to the pre-existing properties in the `Bulk_Plugin_Upgrader_Skin` and the `Bulk_Theme_Upgrader_Skin` classes.

Trac ticket: https://core.trac.wordpress.org/ticket/56033

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
