### PR TITLE
PHP 8.2 | WP_SimplePie_File: explicitly declare WP specific property

### DIFF
--- a/src/wp-includes/class-wp-simplepie-file.php
+++ b/src/wp-includes/class-wp-simplepie-file.php
@@ -20,6 +20,13 @@
 class WP_SimplePie_File extends SimplePie_File {
 
 	/**
+	 * Timeout.
+	 *
+	 * @var int How long the connection should stay open in seconds.
+	 */
+	public $timeout = 10;
+
+	/**
 	 * Constructor.
 	 *
 	 * @since 2.8.0


### PR DESCRIPTION
Dynamic (non-explicitly declared) properties are deprecated as of PHP 8.2 and are expected to become a fatal error in PHP 9.0.

There are a number of ways to mitigate this:
* If it's an accidental typo for a declared property: fix the typo.
* For known properties: declare them on the class.
* For unknown properties: add the magic `__get()`, `__set()` et al methods to the class or let the class extend `stdClass` which has highly optimized versions of these magic methods build in.
* For unknown _use of_ dynamic properties, the `#[AllowDynamicProperties]` attribute can be added to the class. The attribute will automatically be inherited by child classes.

In this case, the `$timeout` property falls in the "known property" category.

Note: in contrast to the other properties being set in the constructor, this property is [not declared on the parent class](https://github.com/simplepie/simplepie/blob/22b8eb00f4f34761f8e2565f77a04fe8003c1e70/src/File.php#L59-L68), so not inherited.

Refs:
* https://wiki.php.net/rfc/deprecate_dynamic_properties

Trac ticket: https://core.trac.wordpress.org/ticket/56033

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
