### PR TITLE
PHP 8.2 | POMO_Reader et al: explicitly declare all properties

### DIFF
--- a/src/wp-includes/pomo/streams.php
+++ b/src/wp-includes/pomo/streams.php
@@ -12,7 +12,8 @@ if ( ! class_exists( 'POMO_Reader', false ) ) :
 	class POMO_Reader {
 
 		public $endian = 'little';
-		public $_post  = '';
+		public $_pos;
+		public $is_overloaded;
 
 		/**
 		 * PHP5 constructor.
@@ -151,6 +152,13 @@ endif;
 
 if ( ! class_exists( 'POMO_FileReader', false ) ) :
 	class POMO_FileReader extends POMO_Reader {
+
+		/**
+		 * File pointer resource.
+		 *
+		 * @var resource|false
+		 */
+		public $_f;
 
 		/**
 		 * @param string $filename


### PR DESCRIPTION
Dynamic (non-explicitly declared) properties are deprecated as of PHP 8.2 and are expected to become a fatal error in PHP 9.0.

There are a number of ways to mitigate this:
* If it's an accidental typo for a declared property: fix the typo.
* For known properties: declare them on the class.
* For unknown properties: add the magic `__get()`, `__set()` et al methods to the class or let the class extend `stdClass` which has highly optimized versions of these magic methods build in.
* For unknown _use of_ dynamic properties, the `#[AllowDynamicProperties]` attribute can be added to the class. The attribute will automatically be inherited by child classes.

In this case, the `$is_overloaded` property and the `$_f` property fall in the "known property" category.
In both cases, these are being set in the `__construct()` method of the class they apply to.

The `$_post` property appears to be a typo however. The `$_post` property looks to be unused, while there is an integer `$_pos` ("position") property, which is used throughout the class and used by the child classes, which is not declared.

Refs:
* https://wiki.php.net/rfc/deprecate_dynamic_properties

Trac ticket: https://core.trac.wordpress.org/ticket/56033

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
