### PR TITLE
PHP 8.2 | Services_JSON: explicitly declare all properties

### DIFF
--- a/src/wp-includes/class-json.php
+++ b/src/wp-includes/class-json.php
@@ -122,6 +122,13 @@ define('SERVICES_JSON_USE_TO_JSON', 64);
 class Services_JSON
 {
    /**
+    * Object behavior flags.
+    *
+    * @var int
+    */
+   public $use;
+
+   /**
     * constructs a new JSON instance
     *
     * @deprecated 5.3.0 Use the PHP native JSON extension instead.


### PR DESCRIPTION
Dynamic (non-explicitly declared) properties are deprecated as of PHP 8.2 and are expected to become a fatal error in PHP 9.0.

There are a number of ways to mitigate this:
* If it's an accidental typo for a declared property: fix the typo.
* For known properties: declare them on the class.
* For unknown properties: add the magic `__get()`, `__set()` et al methods to the class or let the class extend `stdClass` which has highly optimized versions of these magic methods build in.
* For unknown _use of_ dynamic properties, the `#[AllowDynamicProperties]` attribute can be added to the class. The attribute will automatically be inherited by child classes.

In this case, the `$use` property, as set in the class constructor, falls in the "known property" category.

Refs:
* https://wiki.php.net/rfc/deprecate_dynamic_properties

Trac ticket: https://core.trac.wordpress.org/ticket/56033

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
