### PR TITLE
REST API: Add missing options to the settings endpoint

### DIFF
--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -2236,7 +2236,7 @@ function register_initial_settings() {
 		'page_on_front',
 		array(
 			'show_in_rest' => true,
-			'type'         => 'number',
+			'type'         => 'integer',
 			'description'  => __( 'The ID of the page that should be displayed on the front page' ),
 		)
 	);
@@ -2246,7 +2246,7 @@ function register_initial_settings() {
 		'page_for_posts',
 		array(
 			'show_in_rest' => true,
-			'type'         => 'number',
+			'type'         => 'integer',
 			'description'  => __( 'The ID of the page that should display the latest posts' ),
 		)
 	);

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -2221,6 +2221,36 @@ function register_initial_settings() {
 	);
 
 	register_setting(
+		'reading',
+		'show_on_front',
+		array(
+			'show_in_rest' => true,
+			'type'         => 'string',
+			'description'  => __( 'What to show on the front page' ),
+		)
+	);
+
+	register_setting(
+		'reading',
+		'page_on_front',
+		array(
+			'show_in_rest' => true,
+			'type'         => 'number',
+			'description'  => __( 'The ID of the page that should be displayed on the front page' ),
+		)
+	);
+
+	register_setting(
+		'reading',
+		'page_for_posts',
+		array(
+			'show_in_rest' => true,
+			'type'         => 'number',
+			'description'  => __( 'The ID of the page that should display the latest posts' ),
+		)
+	);
+
+	register_setting(
 		'discussion',
 		'default_ping_status',
 		array(

--- a/tests/phpunit/tests/rest-api/rest-settings-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-settings-controller.php
@@ -111,7 +111,7 @@ class WP_Test_REST_Settings_Controller extends WP_Test_REST_Controller_Testcase 
 			'site_icon', // Registered in wp-includes/blocks/site-logo.php
 			'show_on_front',
 			'page_on_front',
-			'posts_per_page',
+			'page_for_posts',
 		);
 
 		if ( ! is_multisite() ) {

--- a/tests/phpunit/tests/rest-api/rest-settings-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-settings-controller.php
@@ -109,6 +109,9 @@ class WP_Test_REST_Settings_Controller extends WP_Test_REST_Controller_Testcase 
 			'default_ping_status',
 			'default_comment_status',
 			'site_icon', // Registered in wp-includes/blocks/site-logo.php
+			'show_on_front',
+			'page_on_front',
+			'posts_per_page',
 		);
 
 		if ( ! is_multisite() ) {

--- a/tests/phpunit/tests/rest-api/rest-settings-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-settings-controller.php
@@ -106,12 +106,12 @@ class WP_Test_REST_Settings_Controller extends WP_Test_REST_Controller_Testcase 
 			'default_category',
 			'default_post_format',
 			'posts_per_page',
-			'default_ping_status',
-			'default_comment_status',
-			'site_icon', // Registered in wp-includes/blocks/site-logo.php
 			'show_on_front',
 			'page_on_front',
 			'page_for_posts',
+			'default_ping_status',
+			'default_comment_status',
+			'site_icon', // Registered in wp-includes/blocks/site-logo.php
 		);
 
 		if ( ! is_multisite() ) {

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -9628,6 +9628,21 @@ mockedApiResponse.Schema = {
                             "type": "integer",
                             "required": false
                         },
+                        "show_on_front": {
+                            "description": "What to show on the front page",
+                            "type": "string",
+                            "required": false
+                        },
+                        "page_on_front": {
+                            "description": "The ID of the page that should be displayed on the front page",
+                            "type": "number",
+                            "required": false
+                        },
+                        "page_for_posts": {
+                            "description": "The ID of the page that should display the latest posts",
+                            "type": "number",
+                            "required": false
+                        },
                         "default_ping_status": {
                             "description": "Allow link notifications from other blogs (pingbacks and trackbacks) on new articles.",
                             "type": "string",
@@ -12283,6 +12298,9 @@ mockedApiResponse.settings = {
     "default_category": 1,
     "default_post_format": "0",
     "posts_per_page": 10,
+    "show_on_front": "posts",
+    "page_on_front": 0,
+    "page_for_posts": 0,
     "default_ping_status": "open",
     "default_comment_status": "open",
     "site_logo": null,

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -9635,12 +9635,12 @@ mockedApiResponse.Schema = {
                         },
                         "page_on_front": {
                             "description": "The ID of the page that should be displayed on the front page",
-                            "type": "number",
+                            "type": "integer",
                             "required": false
                         },
                         "page_for_posts": {
                             "description": "The ID of the page that should display the latest posts",
-                            "type": "number",
+                            "type": "integer",
                             "required": false
                         },
                         "default_ping_status": {


### PR DESCRIPTION
PR registers options for the settings endpoints. Unfortunately, we missed them during WP 6.0 backports - https://github.com/WordPress/gutenberg/pull/38607#issuecomment-1138526934.

## Testing Instructions
1. Open a Post or Page editor.
2. Run this snippet in the DevTools console - `wp.data.select('core').getEntityRecord( 'root', 'site' );`
3. Confirm newly registered settings are returned.

Trac ticket: https://core.trac.wordpress.org/ticket/56058

---
**This Pull Request is for code review only. Please keep all other discussions in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
