### PR TITLE
Remove the `workflow_run` event from the Slack workflow.

### DIFF
--- a/.github/workflows/slack-notifications.yml
+++ b/.github/workflows/slack-notifications.yml
@@ -6,22 +6,6 @@
 name: Slack Notifications
 
 on:
-  workflow_run:
-    workflows:
-      - Code Coverage Report
-      - Coding Standards
-      - End-to-end Tests
-      - JavaScript Tests
-      - PHP Compatibility
-      - PHPUnit Tests
-      - Test NPM
-      - Test old branches
-    types:
-      - completed
-    branches:
-      - '[3-4].[0-9]'
-      - '5.[0-8]'
-
   workflow_call:
     inputs:
       calling_status:
@@ -43,7 +27,7 @@ on:
         required: true
 
 env:
-  CURRENT_BRANCH: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref_name }}
+  CURRENT_BRANCH: ${{ github.ref_name }}
 
 jobs:
   # Gathers the details needed for Slack notifications.
@@ -61,7 +45,7 @@ jobs:
     name: Prepare notifications
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: ${{ github.repository == 'WordPress/wordpress-develop' && github.event.workflow_run.event != 'pull_request' }}
+    if: ${{ github.repository == 'WordPress/wordpress-develop' }}
     outputs:
       previous_conclusion: ${{ steps.previous-conclusion.outputs.previous_conclusion }}
       payload: ${{ steps.create-payload.outputs.payload }}
@@ -155,14 +139,14 @@ jobs:
         id: commit-message
         run: |
           COMMIT_MESSAGE=$(cat <<'EOF' | awk 'NR==1' | sed 's/`/\\`/g' | sed 's/\"/\\\\\\"/g' | sed 's/\$/\\$/g'
-          ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_commit.message || ( github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' ) && fromJson( steps.current-commit-message.outputs.result ) || github.event.head_commit.message }}
+          ${{ ( github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' ) && fromJson( steps.current-commit-message.outputs.result ) || github.event.head_commit.message }}
           EOF
           )
           echo "::set-output name=commit_message_escaped::${COMMIT_MESSAGE}"
 
       - name: Construct payload and store as an output
         id: create-payload
-        run: echo "::set-output name=payload::{\"workflow_name\":\"${{ github.event_name == 'workflow_run' && github.event.workflow_run.name || github.workflow }}\",\"ref_name\":\"${{ env.CURRENT_BRANCH }}\",\"run_url\":\"https://github.com/WordPress/wordpress-develop/actions/runs/${{ github.event_name == 'workflow_run' && github.event.workflow_run.id || github.run_id }}/attempts/${{ github.event_name == 'workflow_run' && github.event.workflow_run.run_attempt || github.run_attempt }}\",\"commit_message\":\"${{ steps.commit-message.outputs.commit_message_escaped }}\"}"
+        run: echo "::set-output name=payload::{\"workflow_name\":\"${{ github.workflow }}\",\"ref_name\":\"${{ env.CURRENT_BRANCH }}\",\"run_url\":\"https://github.com/WordPress/wordpress-develop/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}\",\"commit_message\":\"${{ steps.commit-message.outputs.commit_message_escaped }}\"}"
 
   # Posts notifications when a workflow fails.
   failure:
@@ -170,7 +154,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: [ prepare ]
-    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'failure' || inputs.calling_status == 'failure' || failure() }}
+    if: ${{ inputs.calling_status == 'failure' || failure() }}
 
     steps:
       - name: Post failure notifications to Slack
@@ -186,7 +170,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: [ prepare ]
-    if: ${{ contains( fromJson( '["failure", "cancelled", "none"]' ), needs.prepare.outputs.previous_conclusion ) && ( github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' || inputs.calling_status == 'success' ) && success() }}
+    if: ${{ contains( fromJson( '["failure", "cancelled", "none"]' ), needs.prepare.outputs.previous_conclusion ) && inputs.calling_status == 'success' && success() }}
 
     steps:
       - name: Post failure notifications to Slack
@@ -202,7 +186,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: [ prepare ]
-    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' || inputs.calling_status == 'success' && success() }}
+    if: ${{ inputs.calling_status == 'success' && success() }}
 
     steps:
       - name: Post success notifications to Slack
@@ -218,7 +202,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: [ prepare ]
-    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'cancelled' || inputs.calling_status == 'cancelled' || cancelled() }}
+    if: ${{ inputs.calling_status == 'cancelled' || cancelled() }}
 
     steps:
       - name: Post cancelled notifications to Slack

--- a/.github/workflows/slack-notifications.yml
+++ b/.github/workflows/slack-notifications.yml
@@ -45,7 +45,7 @@ jobs:
     name: Prepare notifications
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: ${{ github.repository == 'WordPress/wordpress-develop' }}
+    if: ${{ github.repository == 'WordPress/wordpress-develop' && github.event.workflow_run.event != 'pull_request' }}
     outputs:
       previous_conclusion: ${{ steps.previous-conclusion.outputs.previous_conclusion }}
       payload: ${{ steps.create-payload.outputs.payload }}
@@ -53,7 +53,6 @@ jobs:
     steps:
       - name: Determine the status of the previous attempt
         id: previous-attempt-result
-        if: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
         uses: actions/github-script@7a5c598405937d486b0331594b5da2b14db670da # v6.1.0
         with:
           script: |

--- a/.github/workflows/slack-notifications.yml
+++ b/.github/workflows/slack-notifications.yml
@@ -74,12 +74,7 @@ jobs:
               return previous_run.data.conclusion;
             }
 
-            let workflow_id = '';
-            if ( ${{ github.event_name == 'workflow_run' }} ) {
-              workflow_id = '${{ github.event.workflow_run.workflow_id }}';
-            } else {
-              workflow_id = workflow_run.data.workflow_id;
-            }
+            let workflow_id = workflow_run.data.workflow_id;
 
             // Otherwise, check the previous workflow run.
             const previous_runs = await github.rest.actions.listWorkflowRuns({

--- a/.github/workflows/slack-notifications.yml
+++ b/.github/workflows/slack-notifications.yml
@@ -74,13 +74,11 @@ jobs:
               return previous_run.data.conclusion;
             }
 
-            let workflow_id = workflow_run.data.workflow_id;
-
             // Otherwise, check the previous workflow run.
             const previous_runs = await github.rest.actions.listWorkflowRuns({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              workflow_id: workflow_id,
+              workflow_id: workflow_run.data.workflow_id,
               branch: '${{ env.CURRENT_BRANCH }}',
               exclude_pull_requests: true,
             });


### PR DESCRIPTION
This removes the `workflow_run` event and any related logic from the Slack workflow. The changes required to use the workflow as a callable one in older branches are staged and ready to go. This will avoid having to create a separate workflow run to send Slack notifications for older branches.

Trac ticket: https://core.trac.wordpress.org/ticket/56095

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
