### PR TITLE
Block Patterns: Update the value used for keywords.

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-pattern-directory-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-pattern-directory-controller.php
@@ -206,7 +206,7 @@ class WP_REST_Pattern_Directory_Controller extends WP_REST_Controller {
 			'title'          => sanitize_text_field( $raw_pattern->title->rendered ),
 			'content'        => wp_kses_post( $raw_pattern->pattern_content ),
 			'categories'     => array_map( 'sanitize_title', $raw_pattern->category_slugs ),
-			'keywords'       => array_map( 'sanitize_title', $raw_pattern->keyword_slugs ),
+			'keywords'       => array_map( 'sanitize_text_field', explode( ',', $raw_pattern->meta->wpop_keywords ) ),
 			'description'    => sanitize_text_field( $raw_pattern->meta->wpop_description ),
 			'viewport_width' => absint( $raw_pattern->meta->wpop_viewport_width ),
 		);
@@ -274,7 +274,7 @@ class WP_REST_Pattern_Directory_Controller extends WP_REST_Controller {
 				),
 
 				'keywords'       => array(
-					'description' => __( "The pattern's keyword slugs." ),
+					'description' => __( "The pattern's keywords." ),
 					'type'        => 'array',
 					'uniqueItems' => true,
 					'items'       => array( 'type' => 'string' ),

--- a/tests/phpunit/data/blocks/pattern-directory/browse-all.json
+++ b/tests/phpunit/data/blocks/pattern-directory/browse-all.json
@@ -9,6 +9,7 @@
 		"meta": {
 			"spay_email": "",
 			"wpop_description": "A heading preceded by a chapter number, and followed by a paragraph.",
+			"wpop_keywords": [],
 			"wpop_viewport_width": 1000
 		},
 		"category_slugs": [ "text" ],
@@ -25,6 +26,7 @@
 		"meta": {
 			"spay_email": "",
 			"wpop_description": "A large hero section with an example background image and a heading in the center.",
+			"wpop_keywords": [],
 			"wpop_viewport_width": 1000
 		},
 		"category_slugs": [ "header" ],
@@ -41,6 +43,7 @@
 		"meta": {
 			"spay_email": "",
 			"wpop_description": "A large hero section with a bright gradient background, a big heading and a filled button.",
+			"wpop_keywords": [],
 			"wpop_viewport_width": 1000
 		},
 		"category_slugs": [ "header" ],

--- a/tests/phpunit/data/blocks/pattern-directory/browse-all.json
+++ b/tests/phpunit/data/blocks/pattern-directory/browse-all.json
@@ -9,7 +9,7 @@
 		"meta": {
 			"spay_email": "",
 			"wpop_description": "A heading preceded by a chapter number, and followed by a paragraph.",
-			"wpop_keywords": [],
+			"wpop_keywords": "blog post",
 			"wpop_viewport_width": 1000
 		},
 		"category_slugs": [ "text" ],
@@ -26,7 +26,7 @@
 		"meta": {
 			"spay_email": "",
 			"wpop_description": "A large hero section with an example background image and a heading in the center.",
-			"wpop_keywords": [],
+			"wpop_keywords": "header, hero",
 			"wpop_viewport_width": 1000
 		},
 		"category_slugs": [ "header" ],
@@ -43,7 +43,7 @@
 		"meta": {
 			"spay_email": "",
 			"wpop_description": "A large hero section with a bright gradient background, a big heading and a filled button.",
-			"wpop_keywords": [],
+			"wpop_keywords": "call to action, hero section",
 			"wpop_viewport_width": 1000
 		},
 		"category_slugs": [ "header" ],

--- a/tests/phpunit/data/blocks/pattern-directory/browse-category-2.json
+++ b/tests/phpunit/data/blocks/pattern-directory/browse-category-2.json
@@ -9,7 +9,7 @@
 		"meta": {
 			"spay_email": "",
 			"wpop_description": "Three filled buttons with rounded corners, side by side.",
-			"wpop_keywords": [],
+			"wpop_keywords": "",
 			"wpop_viewport_width": 600
 		},
 		"category_slugs": [ "buttons" ],
@@ -26,7 +26,7 @@
 		"meta": {
 			"spay_email": "",
 			"wpop_description": "Two buttons, one filled and one outlined, side by side.",
-			"wpop_keywords": [],
+			"wpop_keywords": "",
 			"wpop_viewport_width": 500
 		},
 		"category_slugs": [ "buttons" ],

--- a/tests/phpunit/data/blocks/pattern-directory/browse-category-2.json
+++ b/tests/phpunit/data/blocks/pattern-directory/browse-category-2.json
@@ -9,6 +9,7 @@
 		"meta": {
 			"spay_email": "",
 			"wpop_description": "Three filled buttons with rounded corners, side by side.",
+			"wpop_keywords": [],
 			"wpop_viewport_width": 600
 		},
 		"category_slugs": [ "buttons" ],
@@ -25,6 +26,7 @@
 		"meta": {
 			"spay_email": "",
 			"wpop_description": "Two buttons, one filled and one outlined, side by side.",
+			"wpop_keywords": [],
 			"wpop_viewport_width": 500
 		},
 		"category_slugs": [ "buttons" ],

--- a/tests/phpunit/data/blocks/pattern-directory/browse-keyword-11.json
+++ b/tests/phpunit/data/blocks/pattern-directory/browse-keyword-11.json
@@ -9,6 +9,7 @@
 		"meta": {
 			"spay_email": "",
 			"wpop_description": "A heading preceded by a chapter number, and followed by a paragraph.",
+			"wpop_keywords": [],
 			"wpop_viewport_width": 1000
 		},
 		"category_slugs": [ "text" ],
@@ -25,6 +26,7 @@
 		"meta": {
 			"spay_email": "",
 			"wpop_description": "A large hero section with an example background image and a heading in the center.",
+			"wpop_keywords": [],
 			"wpop_viewport_width": 1000
 		},
 		"category_slugs": [ "header" ],
@@ -41,6 +43,7 @@
 		"meta": {
 			"spay_email": "",
 			"wpop_description": "A large hero section with a bright gradient background, a big heading and a filled button.",
+			"wpop_keywords": [],
 			"wpop_viewport_width": 1000
 		},
 		"category_slugs": [ "header" ],

--- a/tests/phpunit/data/blocks/pattern-directory/browse-keyword-11.json
+++ b/tests/phpunit/data/blocks/pattern-directory/browse-keyword-11.json
@@ -9,7 +9,7 @@
 		"meta": {
 			"spay_email": "",
 			"wpop_description": "A heading preceded by a chapter number, and followed by a paragraph.",
-			"wpop_keywords": [],
+			"wpop_keywords": "",
 			"wpop_viewport_width": 1000
 		},
 		"category_slugs": [ "text" ],
@@ -26,7 +26,7 @@
 		"meta": {
 			"spay_email": "",
 			"wpop_description": "A large hero section with an example background image and a heading in the center.",
-			"wpop_keywords": [],
+			"wpop_keywords": "",
 			"wpop_viewport_width": 1000
 		},
 		"category_slugs": [ "header" ],
@@ -43,7 +43,7 @@
 		"meta": {
 			"spay_email": "",
 			"wpop_description": "A large hero section with a bright gradient background, a big heading and a filled button.",
-			"wpop_keywords": [],
+			"wpop_keywords": "",
 			"wpop_viewport_width": 1000
 		},
 		"category_slugs": [ "header" ],

--- a/tests/phpunit/data/blocks/pattern-directory/search-button.json
+++ b/tests/phpunit/data/blocks/pattern-directory/search-button.json
@@ -9,7 +9,7 @@
 		"meta": {
 			"spay_email": "",
 			"wpop_description": "A large hero section with a bright gradient background, a big heading and a filled button.",
-			"wpop_keywords": [],
+			"wpop_keywords": "",
 			"wpop_viewport_width": 1000
 		},
 		"category_slugs": [ "header" ],
@@ -26,7 +26,7 @@
 		"meta": {
 			"spay_email": "",
 			"wpop_description": "Three small columns of text, each with an outlined button with rounded corners at the bottom.",
-			"wpop_keywords": [],
+			"wpop_keywords": "",
 			"wpop_viewport_width": 1000
 		},
 		"category_slugs": [ "columns" ],
@@ -43,7 +43,7 @@
 		"meta": {
 			"spay_email": "",
 			"wpop_description": "Three filled buttons with rounded corners, side by side.",
-			"wpop_keywords": [],
+			"wpop_keywords": "",
 			"wpop_viewport_width": 600
 		},
 		"category_slugs": [ "buttons" ],
@@ -60,7 +60,7 @@
 		"meta": {
 			"spay_email": "",
 			"wpop_description": "Two buttons, one filled and one outlined, side by side.",
-			"wpop_keywords": [],
+			"wpop_keywords": "",
 			"wpop_viewport_width": 500
 		},
 		"category_slugs": [ "buttons" ],

--- a/tests/phpunit/data/blocks/pattern-directory/search-button.json
+++ b/tests/phpunit/data/blocks/pattern-directory/search-button.json
@@ -9,6 +9,7 @@
 		"meta": {
 			"spay_email": "",
 			"wpop_description": "A large hero section with a bright gradient background, a big heading and a filled button.",
+			"wpop_keywords": [],
 			"wpop_viewport_width": 1000
 		},
 		"category_slugs": [ "header" ],
@@ -25,6 +26,7 @@
 		"meta": {
 			"spay_email": "",
 			"wpop_description": "Three small columns of text, each with an outlined button with rounded corners at the bottom.",
+			"wpop_keywords": [],
 			"wpop_viewport_width": 1000
 		},
 		"category_slugs": [ "columns" ],
@@ -41,6 +43,7 @@
 		"meta": {
 			"spay_email": "",
 			"wpop_description": "Three filled buttons with rounded corners, side by side.",
+			"wpop_keywords": [],
 			"wpop_viewport_width": 600
 		},
 		"category_slugs": [ "buttons" ],
@@ -57,6 +60,7 @@
 		"meta": {
 			"spay_email": "",
 			"wpop_description": "Two buttons, one filled and one outlined, side by side.",
+			"wpop_keywords": [],
 			"wpop_viewport_width": 500
 		},
 		"category_slugs": [ "buttons" ],

--- a/tests/phpunit/tests/rest-api/rest-pattern-directory-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-pattern-directory-controller.php
@@ -111,6 +111,9 @@ class WP_REST_Pattern_Directory_Controller_Test extends WP_Test_REST_Controller_
 		$this->assertGreaterThan( 0, count( $patterns ) );
 
 		array_walk( $patterns, array( $this, 'assertPatternMatchesSchema' ) );
+		$this->assertSame( array( 'blog post' ), $patterns[0]['keywords'] );
+		$this->assertSame( array( 'header', 'hero' ), $patterns[1]['keywords'] );
+		$this->assertSame( array( 'call to action', 'hero section' ), $patterns[2]['keywords'] );
 	}
 
 	/**
@@ -157,10 +160,6 @@ class WP_REST_Pattern_Directory_Controller_Test extends WP_Test_REST_Controller_
 		$this->assertGreaterThan( 0, count( $patterns ) );
 
 		array_walk( $patterns, array( $this, 'assertPatternMatchesSchema' ) );
-
-		foreach ( $patterns as $pattern ) {
-			$this->assertContains( 'core', $pattern['keywords'] );
-		}
 	}
 
 	/**


### PR DESCRIPTION
The property returned from the API for "keywords" has been updated from a taxonomy to meta value, so the `keyword_slugs` will not return the expected content. The correct property to use for this field is `meta.wpop_keywords`, which returns a single string with comma-separated keywords.

Note: I'm making this change here, rather than updating `keyword_slugs` in the wp.org API's response, because the keywords are not "slugs", they're regular human-readable phrases. That property was also used for the "core" keyword taxonomy term, which is a format we're not using anymore (see https://github.com/WordPress/pattern-directory/commit/69548ff1f0326c4fd4d9ea7390c48b6d9d227055). If it's preferred to update it in wp.org anyway, I can make that change.

**To test**

- Use a theme with a theme.json
- Add `heading-large-text-and-link` to the patterns list ([example](https://github.com/WordPress/gutenberg/blob/1050cfd8eb8b7b6a38610940992710700b93a33c/test/emptytheme/theme.json#L10))
- That pattern has the keyword "big text"
- Open the editor, open the inserter
- Try searching for "big text"
- The "Heading, large text, and link" pattern should appear

Trac ticket: https://core.trac.wordpress.org/ticket/56126

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
