### PR TITLE
Strip object replacement character from slugs

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2329,6 +2329,8 @@ function sanitize_title_with_dashes( $title, $raw_title = '', $context = 'displa
 				'%e2%80%ad', // Left-to-right override.
 				'%e2%80%ae', // Right-to-left override.
 				'%ef%bb%bf', // Byte order mark.
+				// Object replacement character.
+				'%ef%bf%bc',
 			),
 			'',
 			$title

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2329,8 +2329,7 @@ function sanitize_title_with_dashes( $title, $raw_title = '', $context = 'displa
 				'%e2%80%ad', // Left-to-right override.
 				'%e2%80%ae', // Right-to-left override.
 				'%ef%bb%bf', // Byte order mark.
-				// Object replacement character.
-				'%ef%bf%bc',
+				'%ef%bf%bc', // Object replacement character.
 			),
 			'',
 			$title

--- a/tests/phpunit/tests/formatting/sanitizeTitleWithDashes.php
+++ b/tests/phpunit/tests/formatting/sanitizeTitleWithDashes.php
@@ -151,6 +151,7 @@ class Tests_Formatting_SanitizeTitleWithDashes extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 47912
+	 * @ticket 55117
 	 * @dataProvider data_removes_non_visible_characters_without_width
 	 *
 	 * @param string $title     The title to be sanitized.
@@ -179,6 +180,7 @@ class Tests_Formatting_SanitizeTitleWithDashes extends WP_UnitTestCase {
 			'only %e2%80%ad'     => array( '%e2%80%ad' ),
 			'only %e2%80%ae'     => array( '%e2%80%ae' ),
 			'only %ef%bb%bf'     => array( '%ef%bb%bf' ),
+			'only %ef%bf%bc'     => array( '%ef%bf%bc' ),
 
 			// Non-visible characters within the title.
 			'in middle of title' => array(
@@ -202,6 +204,7 @@ class Tests_Formatting_SanitizeTitleWithDashes extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 47912
+	 * @ticket 55117
 	 * @dataProvider data_non_visible_characters_without_width_when_not_save
 	 *
 	 * @param string $title     The title to be sanitized.
@@ -230,6 +233,7 @@ class Tests_Formatting_SanitizeTitleWithDashes extends WP_UnitTestCase {
 			'only %e2%80%ad'     => array( '%e2%80%ad', '%e2%80%ad' ),
 			'only %e2%80%ae'     => array( '%e2%80%ae', '%e2%80%ae' ),
 			'only %ef%bb%bf'     => array( '%ef%bb%bf', '%ef%bb%bf' ),
+			'only %ef%bf%bc'     => array( '%ef%bf%bc', '%ef%bf%bc' ),
 
 			// Non-visible characters within the title.
 			'in middle of title' => array(


### PR DESCRIPTION
Prevents [object replacement characters](https://apps.timwhitlock.info/unicode/inspect?s=%EF%BF%BC) from being added to slugs.

Trac ticket: https://core.trac.wordpress.org/ticket/55117

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
