### PR TITLE
Fix 55941 translate empty string

### DIFF
--- a/src/wp-includes/pomo/entry.php
+++ b/src/wp-includes/pomo/entry.php
@@ -89,7 +89,7 @@ if ( ! class_exists( 'Translation_Entry', false ) ) :
 		 * @return string|false The key or false if the entry is empty.
 		 */
 		public function key() {
-			if ( null === $this->singular || '' === $this->singular ) {
+			if ( null === $this->singular ) {
 				return false;
 			}
 

--- a/tests/phpunit/tests/pomo/translations.php
+++ b/tests/phpunit/tests/pomo/translations.php
@@ -127,4 +127,31 @@ class Tests_POMO_Translations extends WP_UnitTestCase {
 		$this->assertSame( '1', $domain->translate( '1' ) );
 	}
 
+	/**
+	 * @ticket 55941
+	 */
+	public function test_translate_falsy_key() {
+		$entry_empty = new Translation_Entry(
+			array(
+				'singular'     => '',
+				'translations' => array(
+					'',
+				),
+			)
+		);
+		$entry_zero  = new Translation_Entry(
+			array(
+				'singular'     => '0',
+				'translations' => array(
+					'0',
+				),
+			)
+		);
+		$po          = new Translations();
+		$po->add_entry( $entry_empty );
+		$po->add_entry( $entry_zero );
+
+		$this->assertSame( '', $po->translate( '' ) );
+		$this->assertSame( '0', $po->translate( '0' ) );
+	}
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/55941

- Do not return `false` when calling `key()` on an empty string translation entry.
- Add test accordingly.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
