### PR TITLE
REST API: Move taxonomy link preparation to dedicated method

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-taxonomies-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-taxonomies-controller.php
@@ -434,9 +434,9 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 	 * @since 6.1.0
 	 *
 	 * @param @param WP_Taxonomy $taxonomy The taxonomy.
-	 * @return array[]
+	 * @return array Links for the given taxonomy.
 	 */
-	protected function prepare_links( WP_Taxonomy $taxonomy ) {
+	protected function prepare_links( $taxonomy ) {
 		return array(
 			'collection'              => array(
 				'href' => rest_url( sprintf( '%s/%s', $this->namespace, $this->rest_base ) ),

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-taxonomies-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-taxonomies-controller.php
@@ -272,16 +272,7 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 		// Wrap the data in a response object.
 		$response = rest_ensure_response( $data );
 
-		$response->add_links(
-			array(
-				'collection'              => array(
-					'href' => rest_url( sprintf( '%s/%s', $this->namespace, $this->rest_base ) ),
-				),
-				'https://api.w.org/items' => array(
-					'href' => rest_url( rest_get_route_for_taxonomy_items( $taxonomy->name ) ),
-				),
-			)
-		);
+		$response->add_links( $this->prepare_links( $taxonomy ) );
 
 		/**
 		 * Filters a taxonomy returned from the REST API.
@@ -435,6 +426,25 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 			'type'        => 'string',
 		);
 		return $new_params;
+	}
+
+	/**
+	 * Prepares links for the request.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param @param WP_Taxonomy $taxonomy The taxonomy.
+	 * @return array[]
+	 */
+	protected function prepare_links( WP_Taxonomy $taxonomy ) {
+		return array(
+			'collection'              => array(
+				'href' => rest_url( sprintf( '%s/%s', $this->namespace, $this->rest_base ) ),
+			),
+			'https://api.w.org/items' => array(
+				'href' => rest_url( rest_get_route_for_taxonomy_items( $taxonomy->name ) ),
+			),
+		);
 	}
 
 }


### PR DESCRIPTION
Split from https://github.com/WordPress/wordpress-develop/pull/2883.

Trac ticket: https://core.trac.wordpress.org/ticket/56020