### PR TITLE
Flush object cache groups

### DIFF
--- a/src/wp-includes/cache-compat.php
+++ b/src/wp-includes/cache-compat.php
@@ -146,7 +146,7 @@ if ( ! function_exists( 'wp_cache_flush_group' ) ) :
 	/**
 	 * Removes all cache items in a group, if the object cache implementation supports it.
 	 * Before calling this method, always check for group flushing support using the
-	 * `WP_OBJECT_CACHE_SUPPORTS_GROUP_FLUSH` constant.
+	 * `wp_cache_supports_group_flush()` method.
 	 *
 	 * @since 6.1.0
 	 *

--- a/src/wp-includes/cache-compat.php
+++ b/src/wp-includes/cache-compat.php
@@ -153,7 +153,7 @@ if ( ! function_exists( 'wp_cache_flush_group' ) ) :
 	 * @see WP_Object_Cache::flush_group()
 	 * @global WP_Object_Cache $wp_object_cache Object cache global instance.
 	 *
-	 * @param string|array $group name(s) of group to remove from cache.
+	 * @param string $group Name of group to remove from cache.
 	 * @return bool True if group was flushed, false otherwise.
 	 */
 	function wp_cache_flush_group( $group ) {

--- a/src/wp-includes/cache-compat.php
+++ b/src/wp-includes/cache-compat.php
@@ -157,6 +157,8 @@ if ( ! function_exists( 'wp_cache_flush_group' ) ) :
 	 * @return bool|array|WP_Error Bool or array of bool if array passed, WP_Error if not supported.
 	 */
 	function wp_cache_flush_group( $group ) {
+		global $wp_object_cache;
+
 		if ( ! wp_cache_supports_group_flush() ) {
 			$error = new WP_Error( 'unsupported', __( 'Your object cache implementation does not support flushing individual groups.' ) );
 

--- a/src/wp-includes/cache-compat.php
+++ b/src/wp-includes/cache-compat.php
@@ -154,17 +154,19 @@ if ( ! function_exists( 'wp_cache_flush_group' ) ) :
 	 * @global WP_Object_Cache $wp_object_cache Object cache global instance.
 	 *
 	 * @param string|array $group name(s) of group to remove from cache.
-	 * @return bool|array|WP_Error Bool or array of bool if array passed, WP_Error if not supported.
+	 * @return bool True if group was flushed, false otherwise.
 	 */
 	function wp_cache_flush_group( $group ) {
 		global $wp_object_cache;
 
 		if ( ! wp_cache_supports_group_flush() ) {
-			$error = new WP_Error( 'unsupported', __( 'Your object cache implementation does not support flushing individual groups.' ) );
+			_doing_it_wrong(
+				__FUNCTION__,
+				__( 'Your object cache implementation does not support flushing individual groups.' ),
+				'6.1.0'
+			);
 
-			_doing_it_wrong( __FUNCTION__, $error->get_error_message(), '6.1.0' );
-
-			return $error;
+			return false;
 		}
 
 		return $wp_object_cache->flush_group( $group );

--- a/src/wp-includes/cache-compat.php
+++ b/src/wp-includes/cache-compat.php
@@ -157,7 +157,7 @@ if ( ! function_exists( 'wp_cache_flush_group' ) ) :
 	 * @return bool|array|WP_Error Bool or array of bool if array passed, WP_Error if not supported.
 	 */
 	function wp_cache_flush_group( $group ) {
-		if ( ! defined( 'WP_OBJECT_CACHE_SUPPORTS_GROUP_FLUSH' ) || ! WP_OBJECT_CACHE_SUPPORTS_GROUP_FLUSH ) {
+		if ( ! wp_cache_supports_group_flush() ) {
 			$error = new WP_Error( 'unsupported', __( 'Your object cache implementation does not support flushing individual groups.' ) );
 
 			_doing_it_wrong( __FUNCTION__, $error->get_error_message(), '6.1.0' );
@@ -166,5 +166,20 @@ if ( ! function_exists( 'wp_cache_flush_group' ) ) :
 		}
 
 		return $wp_object_cache->flush_group( $group );
+	}
+endif;
+
+if ( ! function_exists( 'wp_cache_supports_group_flush' ) ) :
+	/**
+	 * Whether the object cache implementation supports flushing individual cache groups.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @see WP_Object_Cache::flush_group()
+	 *
+	 * @return bool True if group flushing is supported, false otherwise.
+	 */
+	function wp_cache_supports_group_flush() {
+		return false;
 	}
 endif;

--- a/src/wp-includes/cache-compat.php
+++ b/src/wp-includes/cache-compat.php
@@ -141,3 +141,30 @@ if ( ! function_exists( 'wp_cache_flush_runtime' ) ) :
 		return wp_using_ext_object_cache() ? false : wp_cache_flush();
 	}
 endif;
+
+if ( ! function_exists( 'wp_cache_flush_group' ) ) :
+	/**
+	 * Removes all cache items in a group, if the object cache implementation supports it.
+	 * Before calling this method, always check for group flushing support using the
+	 * `WP_OBJECT_CACHE_SUPPORTS_GROUP_FLUSH` constant.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @see WP_Object_Cache::flush_group()
+	 * @global WP_Object_Cache $wp_object_cache Object cache global instance.
+	 *
+	 * @param string|array $group name(s) of group to remove from cache.
+	 * @return bool|array|WP_Error Bool or array of bool if array passed, WP_Error if not supported.
+	 */
+	function wp_cache_flush_group( $group ) {
+		if ( ! defined( 'WP_OBJECT_CACHE_SUPPORTS_GROUP_FLUSH' ) || ! WP_OBJECT_CACHE_SUPPORTS_GROUP_FLUSH ) {
+			$error = new WP_Error( 'unsupported', __( 'Your object cache implementation does not support flushing individual groups.' ) );
+
+			_doing_it_wrong( __FUNCTION__, $error->get_error_message(), '6.1.0' );
+
+			return $error;
+		}
+
+		return $wp_object_cache->flush_group( $group );
+	}
+endif;

--- a/src/wp-includes/cache.php
+++ b/src/wp-includes/cache.php
@@ -312,7 +312,10 @@ function wp_cache_flush_group( $group ) {
 
 	// if group is an array loop and call each key in the array
 	if ( is_array( $group ) ) {
-		return array_map( 'wp_cache_flush_group', array_values( $group ) );
+		return array_combine(
+			array_values( $group ),
+			array_map( 'wp_cache_flush_group', array_values( $group ) )
+		);
 	}
 
 	return $wp_object_cache->flush_group( $group );

--- a/src/wp-includes/cache.php
+++ b/src/wp-includes/cache.php
@@ -12,6 +12,13 @@
 require_once ABSPATH . WPINC . '/class-wp-object-cache.php';
 
 /**
+  * Indicate that this object cache implementation supports group flushing.
+  *
+  * @since 6.1.0
+  */
+define( 'WP_OBJECT_CACHE_SUPPORTS_GROUP_FLUSH', true );
+
+/**
  * Sets up Object Cache Global and assigns it.
  *
  * @since 2.0.0
@@ -130,6 +137,30 @@ function wp_cache_set_multiple( array $data, $group = '', $expire = 0 ) {
 	global $wp_object_cache;
 
 	return $wp_object_cache->set_multiple( $data, $group, $expire );
+}
+
+/**
+ * Removes all cache items in a group, if the object cache implementation supports it.
+ * Before calling this method, always check for group flushing support using the
+ * `WP_OBJECT_CACHE_SUPPORTS_GROUP_FLUSH` constant.
+ *
+ * @since 6.1.0
+ *
+ * @see WP_Object_Cache::flush_group()
+ * @global WP_Object_Cache $wp_object_cache Object cache global instance.
+ *
+ * @param string|array $group name(s) of group to remove from cache.
+ * @return bool|array|WP_Error Bool or array of bool if array passed, WP_Error if not supported.
+ */
+function wp_cache_flush_group( $group ) {
+	global $wp_object_cache;
+
+	// if group is an array loop and call each key in the array
+	if ( is_array( $group ) ) {
+		return array_map( 'wp_cache_flush_group', array_values( $group ) );
+	}
+
+	return $wp_object_cache->flush_group( $group );
 }
 
 /**

--- a/src/wp-includes/cache.php
+++ b/src/wp-includes/cache.php
@@ -310,7 +310,7 @@ function wp_cache_flush_runtime() {
 function wp_cache_flush_group( $group ) {
 	global $wp_object_cache;
 
-	// if group is an array loop and call each key in the array
+	// if group is an array, loop and call each group in the array
 	if ( is_array( $group ) ) {
 		return array_combine(
 			array_values( $group ),

--- a/src/wp-includes/cache.php
+++ b/src/wp-includes/cache.php
@@ -146,30 +146,6 @@ function wp_cache_set_multiple( array $data, $group = '', $expire = 0 ) {
 }
 
 /**
- * Removes all cache items in a group, if the object cache implementation supports it.
- * Before calling this method, always check for group flushing support using the
- * `WP_OBJECT_CACHE_SUPPORTS_GROUP_FLUSH` constant.
- *
- * @since 6.1.0
- *
- * @see WP_Object_Cache::flush_group()
- * @global WP_Object_Cache $wp_object_cache Object cache global instance.
- *
- * @param string|array $group name(s) of group to remove from cache.
- * @return bool|array|WP_Error Bool or array of bool if array passed, WP_Error if not supported.
- */
-function wp_cache_flush_group( $group ) {
-	global $wp_object_cache;
-
-	// if group is an array loop and call each key in the array
-	if ( is_array( $group ) ) {
-		return array_map( 'wp_cache_flush_group', array_values( $group ) );
-	}
-
-	return $wp_object_cache->flush_group( $group );
-}
-
-/**
  * Retrieves the cache contents from the cache by key and group.
  *
  * @since 2.0.0
@@ -316,6 +292,30 @@ function wp_cache_flush() {
  */
 function wp_cache_flush_runtime() {
 	return wp_cache_flush();
+}
+
+/**
+ * Removes all cache items in a group, if the object cache implementation supports it.
+ * Before calling this method, always check for group flushing support using the
+ * `wp_cache_supports_group_flush()` method.
+ *
+ * @since 6.1.0
+ *
+ * @see WP_Object_Cache::flush_group()
+ * @global WP_Object_Cache $wp_object_cache Object cache global instance.
+ *
+ * @param string|array $group name(s) of group to remove from cache.
+ * @return bool|array|WP_Error Bool or array of bool if array passed, WP_Error if not supported.
+ */
+function wp_cache_flush_group( $group ) {
+	global $wp_object_cache;
+
+	// if group is an array loop and call each key in the array
+	if ( is_array( $group ) ) {
+		return array_map( 'wp_cache_flush_group', array_values( $group ) );
+	}
+
+	return $wp_object_cache->flush_group( $group );
 }
 
 /**

--- a/src/wp-includes/cache.php
+++ b/src/wp-includes/cache.php
@@ -12,13 +12,6 @@
 require_once ABSPATH . WPINC . '/class-wp-object-cache.php';
 
 /**
-  * Indicate that this object cache implementation supports group flushing.
-  *
-  * @since 6.1.0
-  */
-define( 'WP_OBJECT_CACHE_SUPPORTS_GROUP_FLUSH', true );
-
-/**
  * Sets up Object Cache Global and assigns it.
  *
  * @since 2.0.0
@@ -27,6 +20,19 @@ define( 'WP_OBJECT_CACHE_SUPPORTS_GROUP_FLUSH', true );
  */
 function wp_cache_init() {
 	$GLOBALS['wp_object_cache'] = new WP_Object_Cache();
+}
+
+/**
+ * Whether the object cache implementation supports flushing individual cache groups.
+ *
+ * @since 6.1.0
+ *
+ * @see WP_Object_Cache::flush_group()
+ *
+ * @return bool True if group flushing is supported, false otherwise.
+ */
+function wp_cache_supports_group_flush() {
+	return false;
 }
 
 /**

--- a/src/wp-includes/cache.php
+++ b/src/wp-includes/cache.php
@@ -32,7 +32,7 @@ function wp_cache_init() {
  * @return bool True if group flushing is supported, false otherwise.
  */
 function wp_cache_supports_group_flush() {
-	return false;
+	return true;
 }
 
 /**

--- a/src/wp-includes/cache.php
+++ b/src/wp-includes/cache.php
@@ -304,19 +304,11 @@ function wp_cache_flush_runtime() {
  * @see WP_Object_Cache::flush_group()
  * @global WP_Object_Cache $wp_object_cache Object cache global instance.
  *
- * @param string|array $group name(s) of group to remove from cache.
+ * @param string $group Name of group to remove from cache.
  * @return bool True if group was flushed, false otherwise.
  */
 function wp_cache_flush_group( $group ) {
 	global $wp_object_cache;
-
-	// if group is an array, loop and call each group in the array
-	if ( is_array( $group ) ) {
-		return array_combine(
-			array_values( $group ),
-			array_map( 'wp_cache_flush_group', array_values( $group ) )
-		);
-	}
 
 	return $wp_object_cache->flush_group( $group );
 }

--- a/src/wp-includes/cache.php
+++ b/src/wp-includes/cache.php
@@ -305,7 +305,7 @@ function wp_cache_flush_runtime() {
  * @global WP_Object_Cache $wp_object_cache Object cache global instance.
  *
  * @param string|array $group name(s) of group to remove from cache.
- * @return bool|array|WP_Error Bool or array of bool if array passed, WP_Error if not supported.
+ * @return bool True if group was flushed, false otherwise.
  */
 function wp_cache_flush_group( $group ) {
 	global $wp_object_cache;

--- a/src/wp-includes/class-wp-object-cache.php
+++ b/src/wp-includes/class-wp-object-cache.php
@@ -295,6 +295,7 @@ class WP_Object_Cache {
 	 *
 	 * @since 6.1.0
 	 *
+	 * @param string $group Name of group to remove from cache.
 	 * @return true Always returns true.
 	 */
 	public function flush_group( $group ) {

--- a/src/wp-includes/class-wp-object-cache.php
+++ b/src/wp-includes/class-wp-object-cache.php
@@ -291,6 +291,19 @@ class WP_Object_Cache {
 	}
 
 	/**
+	 * Removes all cache items in a group.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @return true Always returns true.
+	 */
+	public function flush_group( $group ) {
+		unset( $this->cache[ $group ] );
+
+		return true;
+	}
+
+	/**
 	 * Retrieves the cache contents, if it exists.
 	 *
 	 * The contents will be first attempted to be retrieved by searching by the

--- a/tests/phpunit/includes/object-cache.php
+++ b/tests/phpunit/includes/object-cache.php
@@ -1,5 +1,12 @@
 <?php
 /**
+ * Indicate that this object cache implementation does not support group flushing.
+ *
+ * @since 6.1.0
+ */
+define( 'WP_OBJECT_CACHE_SUPPORTS_GROUP_FLUSH', false );
+
+/**
  * Adds a value to cache.
  *
  * If the specified key already exists, the value is not stored and the function

--- a/tests/phpunit/includes/object-cache.php
+++ b/tests/phpunit/includes/object-cache.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Indicate that this object cache implementation does not support group flushing.
- *
- * @since 6.1.0
- */
-define( 'WP_OBJECT_CACHE_SUPPORTS_GROUP_FLUSH', false );
 
 /**
  * Adds a value to cache.
@@ -740,7 +734,6 @@ function wp_cache_switch_to_blog( $blog_id ) {
 	return $wp_object_cache->switch_to_blog( $blog_id );
 }
 
-
 /**
  * Sets up Object Cache Global and assigns it.
  *
@@ -750,6 +743,17 @@ function wp_cache_switch_to_blog( $blog_id ) {
 function wp_cache_init() {
 	global $wp_object_cache;
 	$wp_object_cache = new WP_Object_Cache();
+}
+
+/**
+ * Whether the object cache implementation supports flushing individual cache groups.
+ *
+ * @since 6.1.0
+ *
+ * @return bool True if group flushing is supported, false otherwise.
+ */
+function wp_cache_supports_group_flush() {
+	return false;
 }
 
 /**

--- a/tests/phpunit/includes/object-cache.php
+++ b/tests/phpunit/includes/object-cache.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Adds a value to cache.
  *
@@ -733,6 +732,7 @@ function wp_cache_switch_to_blog( $blog_id ) {
 	global $wp_object_cache;
 	return $wp_object_cache->switch_to_blog( $blog_id );
 }
+
 
 /**
  * Sets up Object Cache Global and assigns it.

--- a/tests/phpunit/tests/cache.php
+++ b/tests/phpunit/tests/cache.php
@@ -460,7 +460,7 @@ class Tests_Cache extends WP_UnitTestCase {
 
 		if ( wp_using_ext_object_cache() ) {
 			$this->assertWPError( $results );
-		    $this->assertSame( 'unsupported', $results->get_error_code() );
+			$this->assertSame( 'unsupported', $results->get_error_code() );
 		} else {
 			$this->assertIsArray( $results );
 			$this->assertCount( 2, $results );

--- a/tests/phpunit/tests/cache.php
+++ b/tests/phpunit/tests/cache.php
@@ -415,4 +415,58 @@ class Tests_Cache extends WP_UnitTestCase {
 
 		$this->assertSame( $expected, $found );
 	}
+
+	/**
+	 * @ticket 4476
+	 * @ticket 9773
+	 *
+	 * test wp_cache_flush_group
+	 *
+	 * @covers ::wp_cache_flush_group
+	 */
+	public function test_wp_cache_flush_group() {
+		$key = 'my-key';
+		$val = 'my-val';
+
+		wp_cache_set( $key, $val, 'group-test' );
+		wp_cache_set( $key, $val, 'group-kept' );
+		$this->assertSame( $val, wp_cache_get( $key, 'group-test' ), 'test_wp_cache_flush_group: group-test should contain my-val' );
+
+		$results = wp_cache_flush_group( 'group-test' );
+		$this->assertTrue( $results );
+		$this->assertFalse( wp_cache_get( $key, 'group-test' ), 'test_wp_cache_flush_group: group-test should return false' );
+		$this->assertSame( $val, wp_cache_get( $key, 'group-kept' ), 'test_wp_cache_flush_group: group-kept should still contain my-val' );
+	}
+
+	/**
+	 * @ticket 4476
+	 * @ticket 9773
+	 *
+	 * test wp_cache_flush_group with an array of groups
+	 *
+	 * @covers ::wp_cache_flush_groups
+	 */
+	public function test_wp_cache_flush_groups() {
+		$key = 'my-key';
+		$val = 'my-val';
+
+		wp_cache_set( $key, $val, 'group-test' );
+		wp_cache_set( $key, $val, 'group-test2' );
+		wp_cache_set( $key, $val, 'group-kept' );
+		$this->assertSame( $val, wp_cache_get( $key, 'group-test' ), 'test_wp_cache_flush_groups: group-test should contain my-val' );
+		$this->assertSame( $val, wp_cache_get( $key, 'group-test2' ), 'test_wp_cache_flush_groups: group-test2 should contain my-val' );
+
+		$results = wp_cache_flush_group( array( 'group-test', 'group-test2' ) );
+
+		if ( wp_using_ext_object_cache() ) {
+			$this->assertWPError( $results );
+		    $this->assertSame( 'unsupported', $results->get_error_code() );
+		} else {
+			$this->assertIsArray( $results );
+			$this->assertCount( 2, $results );
+			$this->assertFalse( wp_cache_get( $key, 'group-test' ), 'test_wp_cache_flush_groups: group-test should return false' );
+			$this->assertFalse( wp_cache_get( $key, 'group-test2' ), 'test_wp_cache_flush_groups: group-test2 should return false' );
+			$this->assertSame( $val, wp_cache_get( $key, 'group-kept' ), 'test_wp_cache_flush_groups: group-kept should still contain my-val' );
+		}
+	}
 }

--- a/tests/phpunit/tests/cache.php
+++ b/tests/phpunit/tests/cache.php
@@ -447,40 +447,4 @@ class Tests_Cache extends WP_UnitTestCase {
 			$this->assertSame( $val, wp_cache_get( $key, 'group-kept' ), 'test_wp_cache_flush_group: group-kept should still contain my-val' );
 		}
 	}
-
-	/**
-	 * @ticket 4476
-	 * @ticket 9773
-	 *
-	 * test wp_cache_flush_group with an array of groups
-	 *
-	 * @covers ::wp_cache_flush_groups
-	 */
-	public function test_wp_cache_flush_groups() {
-		$key = 'my-key';
-		$val = 'my-val';
-
-		wp_cache_set( $key, $val, 'group-test' );
-		wp_cache_set( $key, $val, 'group-test2' );
-		wp_cache_set( $key, $val, 'group-kept' );
-
-		$this->assertSame( $val, wp_cache_get( $key, 'group-test' ), 'test_wp_cache_flush_groups: group-test should contain my-val' );
-		$this->assertSame( $val, wp_cache_get( $key, 'group-test2' ), 'test_wp_cache_flush_groups: group-test2 should contain my-val' );
-
-		if ( wp_using_ext_object_cache() ) {
-			$this->setExpectedIncorrectUsage( 'wp_cache_flush_group' );
-		}
-
-		$results = wp_cache_flush_group( array( 'group-test', 'group-test2' ) );
-
-		if ( wp_using_ext_object_cache() ) {
-			$this->assertFalse( $results );
-		} else {
-			$this->assertIsArray( $results );
-			$this->assertCount( 2, $results );
-			$this->assertFalse( wp_cache_get( $key, 'group-test' ), 'test_wp_cache_flush_groups: group-test should return false' );
-			$this->assertFalse( wp_cache_get( $key, 'group-test2' ), 'test_wp_cache_flush_groups: group-test2 should return false' );
-			$this->assertSame( $val, wp_cache_get( $key, 'group-kept' ), 'test_wp_cache_flush_groups: group-kept should still contain my-val' );
-		}
-	}
 }

--- a/tests/phpunit/tests/cache.php
+++ b/tests/phpunit/tests/cache.php
@@ -430,12 +430,23 @@ class Tests_Cache extends WP_UnitTestCase {
 
 		wp_cache_set( $key, $val, 'group-test' );
 		wp_cache_set( $key, $val, 'group-kept' );
+
 		$this->assertSame( $val, wp_cache_get( $key, 'group-test' ), 'test_wp_cache_flush_group: group-test should contain my-val' );
 
+		if ( wp_using_ext_object_cache() ) {
+			$this->setExpectedIncorrectUsage( 'wp_cache_flush_group' );
+		}
+
 		$results = wp_cache_flush_group( 'group-test' );
-		$this->assertTrue( $results );
-		$this->assertFalse( wp_cache_get( $key, 'group-test' ), 'test_wp_cache_flush_group: group-test should return false' );
-		$this->assertSame( $val, wp_cache_get( $key, 'group-kept' ), 'test_wp_cache_flush_group: group-kept should still contain my-val' );
+
+		if ( wp_using_ext_object_cache() ) {
+			$this->assertWPError( $results );
+			$this->assertSame( 'unsupported', $results->get_error_code() );
+		} else {
+			$this->assertTrue( $results );
+			$this->assertFalse( wp_cache_get( $key, 'group-test' ), 'test_wp_cache_flush_group: group-test should return false' );
+			$this->assertSame( $val, wp_cache_get( $key, 'group-kept' ), 'test_wp_cache_flush_group: group-kept should still contain my-val' );
+		}
 	}
 
 	/**
@@ -453,8 +464,13 @@ class Tests_Cache extends WP_UnitTestCase {
 		wp_cache_set( $key, $val, 'group-test' );
 		wp_cache_set( $key, $val, 'group-test2' );
 		wp_cache_set( $key, $val, 'group-kept' );
+
 		$this->assertSame( $val, wp_cache_get( $key, 'group-test' ), 'test_wp_cache_flush_groups: group-test should contain my-val' );
 		$this->assertSame( $val, wp_cache_get( $key, 'group-test2' ), 'test_wp_cache_flush_groups: group-test2 should contain my-val' );
+
+		if ( wp_using_ext_object_cache() ) {
+			$this->setExpectedIncorrectUsage( 'wp_cache_flush_group' );
+		}
 
 		$results = wp_cache_flush_group( array( 'group-test', 'group-test2' ) );
 

--- a/tests/phpunit/tests/cache.php
+++ b/tests/phpunit/tests/cache.php
@@ -440,8 +440,7 @@ class Tests_Cache extends WP_UnitTestCase {
 		$results = wp_cache_flush_group( 'group-test' );
 
 		if ( wp_using_ext_object_cache() ) {
-			$this->assertWPError( $results );
-			$this->assertSame( 'unsupported', $results->get_error_code() );
+			$this->assertFalse( $results );
 		} else {
 			$this->assertTrue( $results );
 			$this->assertFalse( wp_cache_get( $key, 'group-test' ), 'test_wp_cache_flush_group: group-test should return false' );
@@ -475,8 +474,7 @@ class Tests_Cache extends WP_UnitTestCase {
 		$results = wp_cache_flush_group( array( 'group-test', 'group-test2' ) );
 
 		if ( wp_using_ext_object_cache() ) {
-			$this->assertWPError( $results );
-			$this->assertSame( 'unsupported', $results->get_error_code() );
+			$this->assertFalse( $results );
 		} else {
 			$this->assertIsArray( $results );
 			$this->assertCount( 2, $results );

--- a/tests/phpunit/tests/pluggable.php
+++ b/tests/phpunit/tests/pluggable.php
@@ -268,6 +268,7 @@ class Tests_Pluggable extends WP_UnitTestCase {
 
 					// wp-includes/cache.php:
 					'wp_cache_init'                      => array(),
+					'wp_cache_supports_group_flush'      => array(),
 					'wp_cache_add'                       => array(
 						'key',
 						'data',
@@ -327,12 +328,12 @@ class Tests_Pluggable extends WP_UnitTestCase {
 					),
 					'wp_cache_flush'                     => array(),
 					'wp_cache_flush_runtime'             => array(),
+					'wp_cache_flush_group'               => array( 'group' ),
 					'wp_cache_close'                     => array(),
 					'wp_cache_add_global_groups'         => array( 'groups' ),
 					'wp_cache_add_non_persistent_groups' => array( 'groups' ),
 					'wp_cache_switch_to_blog'            => array( 'blog_id' ),
 					'wp_cache_reset'                     => array(),
-					'wp_cache_flush_group'               => array( 'group' ),
 				)
 			);
 		}

--- a/tests/phpunit/tests/pluggable.php
+++ b/tests/phpunit/tests/pluggable.php
@@ -332,6 +332,7 @@ class Tests_Pluggable extends WP_UnitTestCase {
 					'wp_cache_add_non_persistent_groups' => array( 'groups' ),
 					'wp_cache_switch_to_blog'            => array( 'blog_id' ),
 					'wp_cache_reset'                     => array(),
+					'wp_cache_flush_group'               => array( 'group' ),
 				)
 			);
 		}


### PR DESCRIPTION
Replacement for #2368.

Resolves [WordPress/performance#38](https://github.com/WordPress/performance/issues/38).

Trac ticket: https://core.trac.wordpress.org/ticket/4476

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
