### PR TITLE
Importer plugin's unit tests fail with "return type should be compatible" error

### DIFF
--- a/src/wp-includes/Requests/Cookie/Jar.php
+++ b/src/wp-includes/Requests/Cookie/Jar.php
@@ -60,6 +60,7 @@ class Requests_Cookie_Jar implements ArrayAccess, IteratorAggregate {
 	 * @param string $key Item key
 	 * @return boolean Does the item exist?
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetExists($key) {
 		return isset($this->cookies[$key]);
 	}
@@ -70,6 +71,7 @@ class Requests_Cookie_Jar implements ArrayAccess, IteratorAggregate {
 	 * @param string $key Item key
 	 * @return string|null Item value (null if offsetExists is false)
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetGet($key) {
 		if (!isset($this->cookies[$key])) {
 			return null;
@@ -86,6 +88,7 @@ class Requests_Cookie_Jar implements ArrayAccess, IteratorAggregate {
 	 * @param string $key Item name
 	 * @param string $value Item value
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetSet($key, $value) {
 		if ($key === null) {
 			throw new Requests_Exception('Object is a dictionary, not a list', 'invalidset');
@@ -99,6 +102,7 @@ class Requests_Cookie_Jar implements ArrayAccess, IteratorAggregate {
 	 *
 	 * @param string $key
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetUnset($key) {
 		unset($this->cookies[$key]);
 	}
@@ -108,6 +112,7 @@ class Requests_Cookie_Jar implements ArrayAccess, IteratorAggregate {
 	 *
 	 * @return ArrayIterator
 	 */
+	#[\ReturnTypeWillChange]
 	public function getIterator() {
 		return new ArrayIterator($this->cookies);
 	}

--- a/src/wp-includes/Requests/Utility/CaseInsensitiveDictionary.php
+++ b/src/wp-includes/Requests/Utility/CaseInsensitiveDictionary.php
@@ -37,6 +37,7 @@ class Requests_Utility_CaseInsensitiveDictionary implements ArrayAccess, Iterato
 	 * @param string $key Item key
 	 * @return boolean Does the item exist?
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetExists($key) {
 		$key = strtolower($key);
 		return isset($this->data[$key]);
@@ -48,6 +49,7 @@ class Requests_Utility_CaseInsensitiveDictionary implements ArrayAccess, Iterato
 	 * @param string $key Item key
 	 * @return string|null Item value (null if offsetExists is false)
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetGet($key) {
 		$key = strtolower($key);
 		if (!isset($this->data[$key])) {
@@ -65,6 +67,7 @@ class Requests_Utility_CaseInsensitiveDictionary implements ArrayAccess, Iterato
 	 * @param string $key Item name
 	 * @param string $value Item value
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetSet($key, $value) {
 		if ($key === null) {
 			throw new Requests_Exception('Object is a dictionary, not a list', 'invalidset');
@@ -79,6 +82,7 @@ class Requests_Utility_CaseInsensitiveDictionary implements ArrayAccess, Iterato
 	 *
 	 * @param string $key
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetUnset($key) {
 		unset($this->data[strtolower($key)]);
 	}
@@ -88,6 +92,7 @@ class Requests_Utility_CaseInsensitiveDictionary implements ArrayAccess, Iterato
 	 *
 	 * @return ArrayIterator
 	 */
+	#[\ReturnTypeWillChange]
 	public function getIterator() {
 		return new ArrayIterator($this->data);
 	}


### PR DESCRIPTION
This PR aims to fix failing unit test that are shipped with the WordPress importer plugin.
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/56219#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
