### PR TITLE
Add fragment support to `WP_Http::make_absolute_url()`.

### DIFF
--- a/src/wp-includes/class-wp-http.php
+++ b/src/wp-includes/class-wp-http.php
@@ -1013,6 +1013,11 @@ class WP_Http {
 			$path .= '?' . $relative_url_parts['query'];
 		}
 
+		// Add the fragment.
+		if ( ! empty( $relative_url_parts['fragment'] ) ) {
+			$path .= '#' . $relative_url_parts['fragment'];
+		}
+
 		return $absolute_path . '/' . ltrim( $path, '/' );
 	}
 

--- a/tests/phpunit/tests/http/http.php
+++ b/tests/phpunit/tests/http/http.php
@@ -9,6 +9,7 @@ class Tests_HTTP_HTTP extends WP_UnitTestCase {
 	const FULL_TEST_URL = 'http://username:password@host.name:9090/path?arg1=value1&arg2=value2#anchor';
 
 	/**
+	 * @ticket 24976
 	 * @ticket 56231
 	 *
 	 * @dataProvider make_absolute_url_testcases

--- a/tests/phpunit/tests/http/http.php
+++ b/tests/phpunit/tests/http/http.php
@@ -9,6 +9,8 @@ class Tests_HTTP_HTTP extends WP_UnitTestCase {
 	const FULL_TEST_URL = 'http://username:password@host.name:9090/path?arg1=value1&arg2=value2#anchor';
 
 	/**
+	 * @ticket 56231
+	 *
 	 * @dataProvider make_absolute_url_testcases
 	 *
 	 * @covers WP_Http::make_absolute_url
@@ -66,6 +68,12 @@ class Tests_HTTP_HTTP extends WP_UnitTestCase {
 
 			// Schemeless URL's (not valid in HTTP Headers, but may be used elsewhere).
 			array( '//example.com/sub/', 'https://example.net', 'https://example.com/sub/' ),
+
+			// URLs with fragments.
+			array( '/path#frag', 'http://example.org/', 'http://example.org/path#frag' ),
+			array( '/path/#frag', 'http://example.org/', 'http://example.org/path/#frag' ),
+			array( '/path#frag&ment=1', 'http://example.org/', 'http://example.org/path#frag&ment=1' ),
+			array( '/path?query=string#frag', 'http://example.org/', 'http://example.org/path?query=string#frag' ),
 		);
 	}
 

--- a/tests/phpunit/tests/http/http.php
+++ b/tests/phpunit/tests/http/http.php
@@ -9,7 +9,7 @@ class Tests_HTTP_HTTP extends WP_UnitTestCase {
 	const FULL_TEST_URL = 'http://username:password@host.name:9090/path?arg1=value1&arg2=value2#anchor';
 
 	/**
-	 * @since 3.7.0 Test method introduced.
+	 * @ticket 20434
 	 * @ticket 56231
 	 *
 	 * @dataProvider make_absolute_url_testcases

--- a/tests/phpunit/tests/http/http.php
+++ b/tests/phpunit/tests/http/http.php
@@ -9,7 +9,8 @@ class Tests_HTTP_HTTP extends WP_UnitTestCase {
 	const FULL_TEST_URL = 'http://username:password@host.name:9090/path?arg1=value1&arg2=value2#anchor';
 
 	/**
-	 * @ticket 24976
+	 * @since 3.7.0 Test method introduced.
+	 *
 	 * @ticket 56231
 	 *
 	 * @dataProvider make_absolute_url_testcases

--- a/tests/phpunit/tests/http/http.php
+++ b/tests/phpunit/tests/http/http.php
@@ -75,6 +75,7 @@ class Tests_HTTP_HTTP extends WP_UnitTestCase {
 			array( '/path/#frag', 'http://example.org/', 'http://example.org/path/#frag' ),
 			array( '/path#frag&ment=1', 'http://example.org/', 'http://example.org/path#frag&ment=1' ),
 			array( '/path?query=string#frag', 'http://example.org/', 'http://example.org/path?query=string#frag' ),
+			array( '/path?query=string%23frag', 'http://example.org/', 'http://example.org/path?query=string%23frag' ),
 		);
 	}
 

--- a/tests/phpunit/tests/http/http.php
+++ b/tests/phpunit/tests/http/http.php
@@ -10,7 +10,6 @@ class Tests_HTTP_HTTP extends WP_UnitTestCase {
 
 	/**
 	 * @since 3.7.0 Test method introduced.
-	 *
 	 * @ticket 56231
 	 *
 	 * @dataProvider make_absolute_url_testcases


### PR DESCRIPTION
`WP_Http::make_absolute_url()` does not return URLs including the original fragment(s) i.e. `http://example.org/#a_fragment`.

This PR ensures the return URL includes its original fragment(s). Unit tests included.

Trac ticket: https://core.trac.wordpress.org/ticket/56231