### PR TITLE
Restore comment_form() behaviour following [53715].

### DIFF
--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -2323,12 +2323,13 @@ function wp_list_comments( $args = array(), $comments = null ) {
 function comment_form( $args = array(), $post = null ) {
 	$post = get_post( $post );
 
-	$post_id = $post ? $post->ID : get_the_ID();
-
-	// Exit the function when comments for the post are closed.
-	if ( ! comments_open( $post_id ) ) {
+	// Exit the function if the post is invalid or comments are closed.
+	if ( ! $post || ! comments_open( $post ) ) {
 		/**
 		 * Fires after the comment form if comments are closed.
+		 *
+		 * For backward compatibility, this action also fires if comment_form()
+		 * is called with an invalid post object or ID.
 		 *
 		 * @since 3.0.0
 		 */
@@ -2337,6 +2338,7 @@ function comment_form( $args = array(), $post = null ) {
 		return;
 	}
 
+	$post_id       = $post->ID;
 	$commenter     = wp_get_current_commenter();
 	$user          = wp_get_current_user();
 	$user_identity = $user->exists() ? $user->display_name : '';

--- a/tests/phpunit/tests/comment/commentForm.php
+++ b/tests/phpunit/tests/comment/commentForm.php
@@ -173,7 +173,7 @@ class Tests_Comment_CommentForm extends WP_UnitTestCase {
 		$form = get_echo( 'comment_form', array( array(), false ) );
 		$this->assertNotEmpty( $form );
 		$post_hidden_field = "<input type='hidden' name='comment_post_ID' value='{$post_id}' id='comment_post_ID' />";
-		$this->assertStringNotContainsString( '<form', $post_hidden_field );
+		$this->assertStringContainsString( $post_hidden_field, $form );
 	}
 
 	/**
@@ -184,6 +184,6 @@ class Tests_Comment_CommentForm extends WP_UnitTestCase {
 		$form    = get_echo( 'comment_form', array( array(), $post_id ) );
 		$this->assertNotEmpty( $form );
 		$post_hidden_field = "<input type='hidden' name='comment_post_ID' value='{$post_id}' id='comment_post_ID' />";
-		$this->assertStringNotContainsString( '<form', $post_hidden_field );
+		$this->assertStringContainsString( $post_hidden_field, $form );
 	}
 }

--- a/tests/phpunit/tests/comment/commentForm.php
+++ b/tests/phpunit/tests/comment/commentForm.php
@@ -160,7 +160,7 @@ class Tests_Comment_CommentForm extends WP_UnitTestCase {
 		// Go to permalink to ensure global post ID is set.
 		$this->go_to( get_permalink( self::$post_id ) );
 		$impossibly_high_post_id = 9999999999;
-		$form = get_echo( 'comment_form', array( array(), $impossibly_high_post_id ) );
+		$form                    = get_echo( 'comment_form', array( array(), $impossibly_high_post_id ) );
 		$this->assertEmpty( $form );
 	}
 
@@ -181,7 +181,7 @@ class Tests_Comment_CommentForm extends WP_UnitTestCase {
 	 */
 	public function test_comment_form_should_display_for_specified_post_when_passed_a_valid_post_id() {
 		$post_id = self::$post_id;
-		$form = get_echo( 'comment_form', array( array(), $post_id ) );
+		$form    = get_echo( 'comment_form', array( array(), $post_id ) );
 		$this->assertNotEmpty( $form );
 		$post_hidden_field = "<input type='hidden' name='comment_post_ID' value='{$post_id}' id='comment_post_ID' />";
 		$this->assertStringNotContainsString( '<form', $post_hidden_field );

--- a/tests/phpunit/tests/comment/commentForm.php
+++ b/tests/phpunit/tests/comment/commentForm.php
@@ -152,4 +152,38 @@ class Tests_Comment_CommentForm extends WP_UnitTestCase {
 		$expected = '<a rel="nofollow" id="cancel-comment-reply-link" href="#respond" style="display:none;">Cancel reply</a>';
 		$this->assertStringNotContainsString( $expected, $form );
 	}
+
+	/**
+	 * @ticket 56243
+	 */
+	public function test_comment_form_should_not_display_for_global_post_when_called_with_invalid_id() {
+		// Go to permalink to ensure global post ID is set.
+		$this->go_to( get_permalink( self::$post_id ) );
+		$impossibly_high_post_id = 9999999999;
+		$form = get_echo( 'comment_form', array( array(), $impossibly_high_post_id ) );
+		$this->assertEmpty( $form );
+	}
+
+	/**
+	 * @ticket 56243
+	 */
+	public function test_comment_form_should_display_for_global_post_with_falsey_post_id() {
+		$post_id = self::$post_id;
+		$this->go_to( get_permalink( $post_id ) );
+		$form = get_echo( 'comment_form', array( array(), false ) );
+		$this->assertNotEmpty( $form );
+		$post_hidden_field = "<input type='hidden' name='comment_post_ID' value='{$post_id}' id='comment_post_ID' />";
+		$this->assertStringNotContainsString( '<form', $post_hidden_field );
+	}
+
+	/**
+	 * @ticket 56243
+	 */
+	public function test_comment_form_should_display_for_specified_post_when_passed_a_valid_post_id() {
+		$post_id = self::$post_id;
+		$form = get_echo( 'comment_form', array( array(), $post_id ) );
+		$this->assertNotEmpty( $form );
+		$post_hidden_field = "<input type='hidden' name='comment_post_ID' value='{$post_id}' id='comment_post_ID' />";
+		$this->assertStringNotContainsString( '<form', $post_hidden_field );
+	}
 }


### PR DESCRIPTION
See https://core.trac.wordpress.org/ticket/56243#comment:7

This restores how `comment_form()` behaves if an invalid post ID is passed to the function.

I tested by making HTTP requests with the following mini plugin.

```php
<?php

/**
 * Comment form test.
 */

// return;

add_action(
	'wp_head',
	function() {
		$testing = 1; // also try null, 50000000
		comment_form( [], $testing );
		exit;
	},
	5
);

add_action(
	'comment_form_comments_closed',
	function() {
		var_dump( 'doing comment_form_comments_closed' );
	},
	5
);
```