### PR TITLE
get_page_of_comment support for desc comment order

### DIFF
--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -1108,8 +1108,8 @@ function get_page_of_comment( $comment_ID, $args = array() ) {
 		}
 
 		// If comment order is ascending count older comments, otherwise count newer ones.
-		$comment_order = get_option('comment_order');
-		if ($comment_order === 'asc') {
+		$comment_order = get_option( 'comment_order' );
+		if ( 'asc' === $comment_order ) {
 			$time_key = 'before';
 		} else {
 			$time_key = 'after';

--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -1107,6 +1107,14 @@ function get_page_of_comment( $comment_ID, $args = array() ) {
 			return get_page_of_comment( $comment->comment_parent, $args );
 		}
 
+		// If comment order is ascending count older comments, otherwise count newer ones.
+		$comment_order = get_option('comment_order');
+		if ($comment_order === 'asc') {
+			$time_key = 'before';
+		} else {
+			$time_key = 'after';
+		}
+
 		$comment_args = array(
 			'type'       => $args['type'],
 			'post_id'    => $comment->comment_post_ID,
@@ -1117,7 +1125,7 @@ function get_page_of_comment( $comment_ID, $args = array() ) {
 			'date_query' => array(
 				array(
 					'column' => "$wpdb->comments.comment_date_gmt",
-					'before' => $comment->comment_date_gmt,
+					$time_key => $comment->comment_date_gmt,
 				),
 			),
 		);


### PR DESCRIPTION
As the creator of Trac ticket, I found this bug and the solution is to change the hardcoded time_key **before** to dynamic value based on the option **comment_order**

Trac ticket: https://core.trac.wordpress.org/ticket/56186

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
