### PR TITLE
Allow error_reporting to be configurable for WP_DEBUG

### DIFF
--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -457,7 +457,12 @@ function wp_debug_mode() {
 	}
 
 	if ( WP_DEBUG ) {
-		error_reporting( E_ALL );
+		if ( defined( 'WP_DEBUG_ERROR_LEVEL' ) ) {
+			error_reporting( WP_DEBUG_ERROR_LEVEL );
+
+		} else {
+			error_reporting( E_ALL );
+		}
 
 		if ( WP_DEBUG_DISPLAY ) {
 			ini_set( 'display_errors', 1 );


### PR DESCRIPTION
The new constant `WP_DEBUG_ERROR_LEVEL` can be set from `wp-config.php` to override the `E_ALL` level forced in `wp_debug_mode()` .

Trac ticket: https://core.trac.wordpress.org/ticket/56252
