### PR TITLE
Backport missing Gutenberg tests to Core

### DIFF
--- a/tests/phpunit/tests/editor/disableBlockEditorForNavigationPostType.php
+++ b/tests/phpunit/tests/editor/disableBlockEditorForNavigationPostType.php
@@ -12,7 +12,7 @@ class Tests_Editor_DisableBlockEditorForNavigationPostType extends WP_UnitTestCa
 	/**
 	 * @ticket 56266
 	 *
-	 * @dataProvider data_data_test_should_only_disable_block_editor_for_navigation_post_types
+	 * @dataProvider data_test_should_only_disable_block_editor_for_navigation_post_types
 	 *
 	 * @param string $post_type The post type.
 	 * @param bool   $value     Whether to disable the block editor.

--- a/tests/phpunit/tests/editor/disableBlockEditorForNavigationPostType.php
+++ b/tests/phpunit/tests/editor/disableBlockEditorForNavigationPostType.php
@@ -13,6 +13,10 @@ class Tests_Editor_DisableBlockEditorForNavigationPostType extends WP_UnitTestCa
 	 * @ticket 56266
 	 *
 	 * @dataProvider data_test_it_correctly_handles_different_post_types
+	 *
+	 * @param string $post_type The post type.
+	 * @param bool   $value     Whether to disable the block editor.
+	 * @param bool   $expected  The expected result.
 	 */
 	public function test_it_correctly_handles_different_post_types( $post_type, $value, $expected ) {
 		$filtered_result = _disable_block_editor_for_navigation_post_type( $value, $post_type );
@@ -20,7 +24,9 @@ class Tests_Editor_DisableBlockEditorForNavigationPostType extends WP_UnitTestCa
 	}
 
 	/**
-	 * @ticket 56266
+	 * Data provider for test_it_correctly_handles_different_post_types().
+	 *
+	 * @return array
 	 */
 	public function data_test_it_correctly_handles_different_post_types() {
 		return array(

--- a/tests/phpunit/tests/editor/disableBlockEditorForNavigationPostType.php
+++ b/tests/phpunit/tests/editor/disableBlockEditorForNavigationPostType.php
@@ -1,54 +1,104 @@
 <?php
+
 /**
  * @group editor
  *
  * @covers ::_disable_block_editor_for_navigation_post_type
  */
 class Tests_Editor_DisableBlockEditorForNavigationPostType extends WP_UnitTestCase {
-
-	const NAVIGATION_POST_TYPE     = 'wp_navigation';
-	const NON_NAVIGATION_POST_TYPE = 'wp_non_navigation';
+	const NAVIGATION_POST_TYPE = 'wp_navigation';
 
 	/**
-	 * @ticket 56266
+	 * @dataProvider data_should_return_false_when_wp_navigation
+	 * @ticket       56266
 	 *
-	 * @dataProvider data_should_only_disable_block_editor_for_navigation_post_types
-	 *
-	 * @param string $post_type The post type.
-	 * @param bool   $value     Whether to disable the block editor.
-	 * @param bool   $expected  The expected result.
+	 * @param bool $supports Whether the CPT supports block editor or not.
 	 */
-	public function test_should_only_disable_block_editor_for_navigation_post_types( $post_type, $value, $expected ) {
-		$filtered_result = _disable_block_editor_for_navigation_post_type( $value, $post_type );
-		$this->assertSame( $expected, $filtered_result );
+	public function test_should_return_false_when_wp_navigation( $supports ) {
+		$this->assertFalse( _disable_block_editor_for_navigation_post_type( $supports, static::NAVIGATION_POST_TYPE ) );
 	}
 
 	/**
-	 * Data provider for test_should_only_disable_block_editor_for_navigation_post_types().
+	 * Data provider.
 	 *
 	 * @return array
 	 */
-	public function data_should_only_disable_block_editor_for_navigation_post_types() {
+	public function data_should_return_false_when_wp_navigation() {
 		return array(
-			'non-navigation post type and false' => array(
-				'post_type' => static::NON_NAVIGATION_POST_TYPE,
-				'value'     => false,
-				'expected'  => false,
+			'support value: true'  => array( true ),
+			'support value: false' => array( false ),
+		);
+	}
+
+	/**
+	 * @dataProvider data_should_return_given_value_for_non_wp_navigation_post_types
+	 * @ticket       56266
+	 *
+	 * @param bool   $supports  Whether the CPT supports block editor or not.
+	 * @param string $post_type The post type
+	 */
+	public function test_should_return_given_value_for_non_wp_navigation_post_types( $supports, $post_type ) {
+		$this->assertSame( $supports, _disable_block_editor_for_navigation_post_type( $supports, $post_type ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_should_return_given_value_for_non_wp_navigation_post_types() {
+		return array(
+			'post'                => array(
+				'post_type' => 'post',
+				'supports'  => true,
 			),
-			'non-navigation post type and true'  => array(
-				'post_type' => static::NON_NAVIGATION_POST_TYPE,
-				'value'     => true,
-				'expected'  => true,
+			'page'                => array(
+				'post_type' => 'page',
+				'supports'  => true,
 			),
-			'navigation post type and false'     => array(
-				'post_type' => static::NAVIGATION_POST_TYPE,
-				'value'     => false,
-				'expected'  => false,
+			'attachments'         => array(
+				'post_type' => 'attachments',
+				'supports'  => false,
 			),
-			'navigation post type and true'      => array(
-				'post_type' => static::NAVIGATION_POST_TYPE,
-				'value'     => true,
-				'expected'  => false,
+			'revision'            => array(
+				'post_type' => 'revision',
+				'supports'  => false,
+			),
+			'custom_css'          => array(
+				'post_type' => 'custom_css',
+				'supports'  => false,
+			),
+			'customize_changeset' => array(
+				'post_type' => 'customize_changeset',
+				'supports'  => false,
+			),
+			'nav_menu_item'       => array(
+				'post_type' => 'nav_menu_item',
+				'supports'  => true,
+			),
+			'oembed_cache'        => array(
+				'post_type' => 'oembed_cache',
+				'supports'  => true,
+			),
+			'user_request'        => array(
+				'post_type' => 'user_request',
+				'supports'  => true,
+			),
+			'wp_block'            => array(
+				'post_type' => 'wp_block',
+				'supports'  => true,
+			),
+			'wp_template'         => array(
+				'post_type' => 'wp_template',
+				'supports'  => true,
+			),
+			'wp_template_part'    => array(
+				'post_type' => 'wp_template_part',
+				'supports'  => true,
+			),
+			'wp_global_styles'    => array(
+				'post_type' => 'wp_global_styles',
+				'supports'  => true,
 			),
 		);
 	}

--- a/tests/phpunit/tests/editor/disableBlockEditorForNavigationPostType.php
+++ b/tests/phpunit/tests/editor/disableBlockEditorForNavigationPostType.php
@@ -4,8 +4,8 @@
  *
  * @covers ::_disable_block_editor_for_navigation_post_type
  */
-class Tests_Editor_DisableBlockEditorForNavigationPostType extends WP_UnitTestCase
-{
+class Tests_Editor_DisableBlockEditorForNavigationPostType extends WP_UnitTestCase {
+
 	const NAVIGATION_POST_TYPE     = 'wp_navigation';
 	const NON_NAVIGATION_POST_TYPE = 'wp_non_navigation';
 

--- a/tests/phpunit/tests/editor/disableBlockEditorForNavigationPostType.php
+++ b/tests/phpunit/tests/editor/disableBlockEditorForNavigationPostType.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @group editor
+ *
+ * @covers ::_disable_block_editor_for_navigation_post_type
+ */
+class Tests_Editor_DisableBlockEditorForNavigationPostType extends WP_UnitTestCase
+{
+	const NAVIGATION_POST_TYPE     = 'wp_navigation';
+	const NON_NAVIGATION_POST_TYPE = 'wp_non_navigation';
+
+	/**
+	 * @ticket 56266
+	 */
+	public function test_it_doesnt_disable_block_editor_for_non_navigation_post_types() {
+		$filtered_result = _disable_block_editor_for_navigation_post_type( true, static::NON_NAVIGATION_POST_TYPE );
+		$this->assertTrue( $filtered_result );
+	}
+
+	/**
+	 * @ticket 56266
+	 */
+	public function test_it_disables_block_editor_for_navigation_post_types() {
+		$filtered_result = _disable_block_editor_for_navigation_post_type( true, static::NAVIGATION_POST_TYPE );
+		$this->assertFalse( $filtered_result );
+	}
+}

--- a/tests/phpunit/tests/editor/disableBlockEditorForNavigationPostType.php
+++ b/tests/phpunit/tests/editor/disableBlockEditorForNavigationPostType.php
@@ -12,7 +12,7 @@ class Tests_Editor_DisableBlockEditorForNavigationPostType extends WP_UnitTestCa
 	/**
 	 * @ticket 56266
 	 *
-	 * @dataProvider data_test_should_only_disable_block_editor_for_navigation_post_types
+	 * @dataProvider data_should_only_disable_block_editor_for_navigation_post_types
 	 *
 	 * @param string $post_type The post type.
 	 * @param bool   $value     Whether to disable the block editor.
@@ -28,7 +28,7 @@ class Tests_Editor_DisableBlockEditorForNavigationPostType extends WP_UnitTestCa
 	 *
 	 * @return array
 	 */
-	public function data_test_should_only_disable_block_editor_for_navigation_post_types() {
+	public function data_should_only_disable_block_editor_for_navigation_post_types() {
 		return array(
 			'non-navigation post type and false' => array(
 				'post_type' => static::NON_NAVIGATION_POST_TYPE,

--- a/tests/phpunit/tests/editor/disableBlockEditorForNavigationPostType.php
+++ b/tests/phpunit/tests/editor/disableBlockEditorForNavigationPostType.php
@@ -11,17 +11,39 @@ class Tests_Editor_DisableBlockEditorForNavigationPostType extends WP_UnitTestCa
 
 	/**
 	 * @ticket 56266
+	 *
+	 * @dataProvider data_test_it_correctly_handles_different_post_types
 	 */
-	public function test_it_doesnt_disable_block_editor_for_non_navigation_post_types() {
-		$filtered_result = _disable_block_editor_for_navigation_post_type( true, static::NON_NAVIGATION_POST_TYPE );
-		$this->assertTrue( $filtered_result );
+	public function test_it_correctly_handles_different_post_types( $post_type, $value, $expected ) {
+		$filtered_result = _disable_block_editor_for_navigation_post_type( $value, $post_type );
+		$this->assertSame( $expected, $filtered_result );
 	}
 
 	/**
 	 * @ticket 56266
 	 */
-	public function test_it_disables_block_editor_for_navigation_post_types() {
-		$filtered_result = _disable_block_editor_for_navigation_post_type( true, static::NAVIGATION_POST_TYPE );
-		$this->assertFalse( $filtered_result );
+	public function data_test_it_correctly_handles_different_post_types() {
+		return array(
+			'non-navigation post type and false' => array(
+				'post_type' => static::NON_NAVIGATION_POST_TYPE,
+				'value'     => false,
+				'expected'  => false,
+			),
+			'non-navigation post type and true'  => array(
+				'post_type' => static::NON_NAVIGATION_POST_TYPE,
+				'value'     => true,
+				'expected'  => true,
+			),
+			'navigation post type and false'     => array(
+				'post_type' => static::NAVIGATION_POST_TYPE,
+				'value'     => false,
+				'expected'  => false,
+			),
+			'navigation post type and true'      => array(
+				'post_type' => static::NAVIGATION_POST_TYPE,
+				'value'     => true,
+				'expected'  => false,
+			),
+		);
 	}
 }

--- a/tests/phpunit/tests/editor/disableBlockEditorForNavigationPostType.php
+++ b/tests/phpunit/tests/editor/disableBlockEditorForNavigationPostType.php
@@ -12,23 +12,23 @@ class Tests_Editor_DisableBlockEditorForNavigationPostType extends WP_UnitTestCa
 	/**
 	 * @ticket 56266
 	 *
-	 * @dataProvider data_test_it_correctly_handles_different_post_types
+	 * @dataProvider data_data_test_should_only_disable_block_editor_for_navigation_post_types
 	 *
 	 * @param string $post_type The post type.
 	 * @param bool   $value     Whether to disable the block editor.
 	 * @param bool   $expected  The expected result.
 	 */
-	public function test_it_correctly_handles_different_post_types( $post_type, $value, $expected ) {
+	public function test_should_only_disable_block_editor_for_navigation_post_types( $post_type, $value, $expected ) {
 		$filtered_result = _disable_block_editor_for_navigation_post_type( $value, $post_type );
 		$this->assertSame( $expected, $filtered_result );
 	}
 
 	/**
-	 * Data provider for test_it_correctly_handles_different_post_types().
+	 * Data provider for test_should_only_disable_block_editor_for_navigation_post_types().
 	 *
 	 * @return array
 	 */
-	public function data_test_it_correctly_handles_different_post_types() {
+	public function data_test_should_only_disable_block_editor_for_navigation_post_types() {
 		return array(
 			'non-navigation post type and false' => array(
 				'post_type' => static::NON_NAVIGATION_POST_TYPE,

--- a/tests/phpunit/tests/editor/disableContentEditorForNavigationPostType.php
+++ b/tests/phpunit/tests/editor/disableContentEditorForNavigationPostType.php
@@ -4,8 +4,8 @@
  *
  * @covers ::_disable_content_editor_for_navigation_post_type
  */
-class Tests_Editor_DisableContentEditorForNavigationPostType extends WP_UnitTestCase
-{
+class Tests_Editor_DisableContentEditorForNavigationPostType extends WP_UnitTestCase {
+
 	const NAVIGATION_POST_TYPE     = 'wp_navigation';
 	const NON_NAVIGATION_POST_TYPE = 'wp_non_navigation';
 

--- a/tests/phpunit/tests/editor/disableContentEditorForNavigationPostType.php
+++ b/tests/phpunit/tests/editor/disableContentEditorForNavigationPostType.php
@@ -17,7 +17,7 @@ class Tests_Editor_DisableContentEditorForNavigationPostType extends WP_UnitTest
 	/**
 	 * @ticket 56266
 	 *
-	 * @dataProvider data_test_should_only_disable_content_editor_for_navigation_post_types
+	 * @dataProvider data_should_only_disable_content_editor_for_navigation_post_types
 	 *
 	 * @param string $post_type             The post type.
 	 * @param bool   $enable_editor_support Whether to enable editor support.
@@ -44,7 +44,7 @@ class Tests_Editor_DisableContentEditorForNavigationPostType extends WP_UnitTest
 	 *
 	 * @return array
 	 */
-	public function data_test_should_only_disable_content_editor_for_navigation_post_types() {
+	public function data_should_only_disable_content_editor_for_navigation_post_types() {
 		return array(
 			'non-navigation post type and false' => array(
 				'post_type'             => static::NON_NAVIGATION_POST_TYPE,

--- a/tests/phpunit/tests/editor/disableContentEditorForNavigationPostType.php
+++ b/tests/phpunit/tests/editor/disableContentEditorForNavigationPostType.php
@@ -18,6 +18,11 @@ class Tests_Editor_DisableContentEditorForNavigationPostType extends WP_UnitTest
 	 * @ticket 56266
 	 *
 	 * @dataProvider data_test_it_correctly_handles_different_post_types
+	 *
+	 * @param string $post_type             The post type.
+	 * @param bool   $enable_editor_support Whether to enable editor support.
+	 * @param bool   $expected              The expected result.
+	 * @param string $message               The message to display if the test fails.
 	 */
 	public function test_it_correctly_handles_different_post_types( $post_type, $enable_editor_support, $expected, $message ) {
 		$post = $this->create_post( $post_type );
@@ -35,7 +40,9 @@ class Tests_Editor_DisableContentEditorForNavigationPostType extends WP_UnitTest
 	}
 
 	/**
-	 * @ticket 56266
+	 * Data provider for test_it_correctly_handles_different_post_types().
+	 *
+	 * @return array
 	 */
 	public function data_test_it_correctly_handles_different_post_types() {
 		return array(

--- a/tests/phpunit/tests/editor/disableContentEditorForNavigationPostType.php
+++ b/tests/phpunit/tests/editor/disableContentEditorForNavigationPostType.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * @group editor
+ *
+ * @covers ::_disable_content_editor_for_navigation_post_type
+ */
+class Tests_Editor_DisableContentEditorForNavigationPostType extends WP_UnitTestCase
+{
+	const NAVIGATION_POST_TYPE     = 'wp_navigation';
+	const NON_NAVIGATION_POST_TYPE = 'wp_non_navigation';
+
+	/**
+	 * @ticket 56266
+	 */
+	public function test_it_doesnt_disable_content_editor_for_non_navigation_type_posts() {
+		$post = $this->create_non_navigation_post();
+		$this->assertTrue( $this->supports_block_editor() );
+
+		_disable_content_editor_for_navigation_post_type( $post );
+
+		$this->assertTrue( $this->supports_block_editor() );
+	}
+
+	/**
+	 * @ticket 56266
+	 */
+	public function test_it_disables_content_editor_for_navigation_type_posts() {
+		$post = $this->create_navigation_post();
+		$this->assertTrue( $this->supports_block_editor() );
+
+		_disable_content_editor_for_navigation_post_type( $post );
+
+		$this->assertFalse( $this->supports_block_editor() );
+	}
+
+	private function supports_block_editor() {
+		return post_type_supports( static::NAVIGATION_POST_TYPE, 'editor' );
+	}
+
+	private function create_post( $type ) {
+		$post            = new WP_Post( new StdClass() );
+		$post->post_type = $type;
+		$post->filter    = 'raw';
+		return $post;
+	}
+
+	private function create_non_navigation_post() {
+		return $this->create_post( static::NON_NAVIGATION_POST_TYPE );
+	}
+
+	private function create_navigation_post() {
+		return $this->create_post( static::NAVIGATION_POST_TYPE );
+	}
+}

--- a/tests/phpunit/tests/editor/disableContentEditorForNavigationPostType.php
+++ b/tests/phpunit/tests/editor/disableContentEditorForNavigationPostType.php
@@ -19,11 +19,11 @@ class Tests_Editor_DisableContentEditorForNavigationPostType extends WP_UnitTest
 	 */
 	public function test_it_doesnt_disable_content_editor_for_non_navigation_type_posts() {
 		$post = $this->create_non_navigation_post();
-		$this->assertTrue( $this->supports_block_editor() );
+		$this->assertTrue( $this->supports_block_editor(), 'Editor support must be enabled before running the test.' );
 
 		_disable_content_editor_for_navigation_post_type( $post );
 
-		$this->assertTrue( $this->supports_block_editor() );
+		$this->assertTrue( $this->supports_block_editor(), '_disable_content_editor_for_navigation_post_type() must not disable editor support for non-navigation type posts.' );
 	}
 
 	/**
@@ -31,11 +31,11 @@ class Tests_Editor_DisableContentEditorForNavigationPostType extends WP_UnitTest
 	 */
 	public function test_it_disables_content_editor_for_navigation_type_posts() {
 		$post = $this->create_navigation_post();
-		$this->assertTrue( $this->supports_block_editor() );
+		$this->assertTrue( $this->supports_block_editor(), 'Editor support must be enabled before running the test.' );
 
 		_disable_content_editor_for_navigation_post_type( $post );
 
-		$this->assertFalse( $this->supports_block_editor() );
+		$this->assertFalse( $this->supports_block_editor(), '_disable_content_editor_for_navigation_post_type() must disable editor support for navigation type posts.' );
 	}
 
 	private function supports_block_editor() {

--- a/tests/phpunit/tests/editor/disableContentEditorForNavigationPostType.php
+++ b/tests/phpunit/tests/editor/disableContentEditorForNavigationPostType.php
@@ -43,7 +43,7 @@ class Tests_Editor_DisableContentEditorForNavigationPostType extends WP_UnitTest
 	}
 
 	private function create_post( $post_type ) {
-		$post            = new WP_Post( new StdClass() );
+		$post            = new WP_Post( new stdClass() );
 		$post->post_type = $post_type;
 		$post->filter    = 'raw';
 		return $post;

--- a/tests/phpunit/tests/editor/disableContentEditorForNavigationPostType.php
+++ b/tests/phpunit/tests/editor/disableContentEditorForNavigationPostType.php
@@ -37,9 +37,9 @@ class Tests_Editor_DisableContentEditorForNavigationPostType extends WP_UnitTest
 		return post_type_supports( static::NAVIGATION_POST_TYPE, 'editor' );
 	}
 
-	private function create_post( $type ) {
+	private function create_post( $post_type ) {
 		$post            = new WP_Post( new StdClass() );
-		$post->post_type = $type;
+		$post->post_type = $post_type;
 		$post->filter    = 'raw';
 		return $post;
 	}

--- a/tests/phpunit/tests/editor/disableContentEditorForNavigationPostType.php
+++ b/tests/phpunit/tests/editor/disableContentEditorForNavigationPostType.php
@@ -43,10 +43,9 @@ class Tests_Editor_DisableContentEditorForNavigationPostType extends WP_UnitTest
 	}
 
 	private function create_post( $post_type ) {
-		$post            = new WP_Post( new stdClass() );
-		$post->post_type = $post_type;
-		$post->filter    = 'raw';
-		return $post;
+		return $this->factory()->post->create(
+			array( 'post_type' => $post_type )
+		);
 	}
 
 	private function create_non_navigation_post() {

--- a/tests/phpunit/tests/editor/disableContentEditorForNavigationPostType.php
+++ b/tests/phpunit/tests/editor/disableContentEditorForNavigationPostType.php
@@ -17,14 +17,14 @@ class Tests_Editor_DisableContentEditorForNavigationPostType extends WP_UnitTest
 	/**
 	 * @ticket 56266
 	 *
-	 * @dataProvider data_test_it_correctly_handles_different_post_types
+	 * @dataProvider data_test_should_only_disable_content_editor_for_navigation_post_types
 	 *
 	 * @param string $post_type             The post type.
 	 * @param bool   $enable_editor_support Whether to enable editor support.
 	 * @param bool   $expected              The expected result.
 	 * @param string $message               The message to display if the test fails.
 	 */
-	public function test_it_correctly_handles_different_post_types( $post_type, $enable_editor_support, $expected, $message ) {
+	public function test_should_only_disable_content_editor_for_navigation_post_types( $post_type, $enable_editor_support, $expected, $message ) {
 		$post = $this->create_post( $post_type );
 		if ( $enable_editor_support ) {
 			$this->enable_editor_support();
@@ -40,11 +40,11 @@ class Tests_Editor_DisableContentEditorForNavigationPostType extends WP_UnitTest
 	}
 
 	/**
-	 * Data provider for test_it_correctly_handles_different_post_types().
+	 * Data provider for test_should_only_disable_content_editor_for_navigation_post_types().
 	 *
 	 * @return array
 	 */
-	public function data_test_it_correctly_handles_different_post_types() {
+	public function data_test_should_only_disable_content_editor_for_navigation_post_types() {
 		return array(
 			'non-navigation post type and false' => array(
 				'post_type'             => static::NON_NAVIGATION_POST_TYPE,

--- a/tests/phpunit/tests/editor/disableContentEditorForNavigationPostType.php
+++ b/tests/phpunit/tests/editor/disableContentEditorForNavigationPostType.php
@@ -9,6 +9,11 @@ class Tests_Editor_DisableContentEditorForNavigationPostType extends WP_UnitTest
 	const NAVIGATION_POST_TYPE     = 'wp_navigation';
 	const NON_NAVIGATION_POST_TYPE = 'wp_non_navigation';
 
+	public function tear_down() {
+		$this->enable_editor_support();
+		parent::tear_down();
+	}
+
 	/**
 	 * @ticket 56266
 	 */
@@ -50,5 +55,9 @@ class Tests_Editor_DisableContentEditorForNavigationPostType extends WP_UnitTest
 
 	private function create_navigation_post() {
 		return $this->create_post( static::NAVIGATION_POST_TYPE );
+	}
+
+	private function enable_editor_support() {
+		add_post_type_support( static::NAVIGATION_POST_TYPE, 'editor' );
 	}
 }

--- a/tests/phpunit/tests/editor/enableContentEditorForNavigationPostType.php
+++ b/tests/phpunit/tests/editor/enableContentEditorForNavigationPostType.php
@@ -4,16 +4,25 @@
  *
  * @covers ::_enable_content_editor_for_navigation_post_type
  */
-class Tests_Editor_EnableContentEditorForNavigationPostType extends WP_UnitTestCase
-{
+class Tests_Editor_EnableContentEditorForNavigationPostType extends WP_UnitTestCase {
+
 	const NAVIGATION_POST_TYPE     = 'wp_navigation';
 	const NON_NAVIGATION_POST_TYPE = 'wp_non_navigation';
+
+	public function set_up() {
+		parent::set_up();
+		$this->disable_editor_support();
+	}
+
+	public function tear_down() {
+		$this->enable_editor_support();
+		parent::tear_down();
+	}
 
 	/**
 	 * @ticket 56266
 	 */
 	public function test_it_enables_content_editor_for_non_navigation_type_posts_after_the_content_editor_form() {
-		$this->disable_editor_support();
 		$post = $this->create_navigation_post();
 		$this->assertFalse( $this->supports_block_editor() );
 
@@ -26,7 +35,6 @@ class Tests_Editor_EnableContentEditorForNavigationPostType extends WP_UnitTestC
 	 * @ticket 56266
 	 */
 	public function test_it_doesnt_enable_content_editor_for_non_navigation_type_posts_after_the_content_editor_form() {
-		$this->disable_editor_support();
 		$post = $this->create_non_navigation_post();
 		$this->assertFalse( $this->supports_block_editor() );
 
@@ -52,6 +60,10 @@ class Tests_Editor_EnableContentEditorForNavigationPostType extends WP_UnitTestC
 
 	private function create_navigation_post() {
 		return $this->create_post( static::NAVIGATION_POST_TYPE );
+	}
+
+	private function enable_editor_support() {
+		add_post_type_support( static::NAVIGATION_POST_TYPE, 'editor' );
 	}
 
 	private function disable_editor_support() {

--- a/tests/phpunit/tests/editor/enableContentEditorForNavigationPostType.php
+++ b/tests/phpunit/tests/editor/enableContentEditorForNavigationPostType.php
@@ -45,10 +45,9 @@ class Tests_Editor_EnableContentEditorForNavigationPostType extends WP_UnitTestC
 	}
 
 	private function create_post( $post_type ) {
-		$post            = new WP_Post( new stdClass() );
-		$post->post_type = $post_type;
-		$post->filter    = 'raw';
-		return $post;
+		return $this->factory()->post->create(
+			array( 'post_type' => $post_type )
+		);
 	}
 
 	private function create_non_navigation_post() {

--- a/tests/phpunit/tests/editor/enableContentEditorForNavigationPostType.php
+++ b/tests/phpunit/tests/editor/enableContentEditorForNavigationPostType.php
@@ -44,9 +44,9 @@ class Tests_Editor_EnableContentEditorForNavigationPostType extends WP_UnitTestC
 		return post_type_supports( static::NAVIGATION_POST_TYPE, 'editor' );
 	}
 
-	private function create_post( $type ) {
+	private function create_post( $post_type ) {
 		$post            = new WP_Post( new StdClass() );
-		$post->post_type = $type;
+		$post->post_type = $post_type;
 		$post->filter    = 'raw';
 		return $post;
 	}

--- a/tests/phpunit/tests/editor/enableContentEditorForNavigationPostType.php
+++ b/tests/phpunit/tests/editor/enableContentEditorForNavigationPostType.php
@@ -17,7 +17,7 @@ class Tests_Editor_EnableContentEditorForNavigationPostType extends WP_UnitTestC
 	/**
 	 * @ticket 56266
 	 *
-	 * @dataProvider data_test_should_only_enable_content_editor_for_navigation_post_types
+	 * @dataProvider data_should_only_enable_content_editor_for_navigation_post_types
 	 *
 	 * @param string $post_type             The post type.
 	 * @param bool   $enable_editor_support Whether to enable editor support.
@@ -44,7 +44,7 @@ class Tests_Editor_EnableContentEditorForNavigationPostType extends WP_UnitTestC
 	 *
 	 * @return array
 	 */
-	public function data_test_should_only_enable_content_editor_for_navigation_post_types() {
+	public function data_should_only_enable_content_editor_for_navigation_post_types() {
 		return array(
 			'non-navigation post type and false' => array(
 				'post_type'             => static::NON_NAVIGATION_POST_TYPE,

--- a/tests/phpunit/tests/editor/enableContentEditorForNavigationPostType.php
+++ b/tests/phpunit/tests/editor/enableContentEditorForNavigationPostType.php
@@ -18,6 +18,11 @@ class Tests_Editor_EnableContentEditorForNavigationPostType extends WP_UnitTestC
 	 * @ticket 56266
 	 *
 	 * @dataProvider data_test_it_correctly_handles_different_post_types
+	 *
+	 * @param string $post_type             The post type.
+	 * @param bool   $enable_editor_support Whether to enable editor support.
+	 * @param bool   $expected              The expected result.
+	 * @param string $message               The message to display if the test fails.
 	 */
 	public function test_it_correctly_handles_different_post_types( $post_type, $enable_editor_support, $expected, $message ) {
 		$post = $this->create_post( $post_type );
@@ -35,7 +40,9 @@ class Tests_Editor_EnableContentEditorForNavigationPostType extends WP_UnitTestC
 	}
 
 	/**
-	 * @ticket 56266
+	 * Data provider for test_it_correctly_handles_different_post_types().
+	 *
+	 * @return array
 	 */
 	public function data_test_it_correctly_handles_different_post_types() {
 		return array(

--- a/tests/phpunit/tests/editor/enableContentEditorForNavigationPostType.php
+++ b/tests/phpunit/tests/editor/enableContentEditorForNavigationPostType.php
@@ -17,14 +17,14 @@ class Tests_Editor_EnableContentEditorForNavigationPostType extends WP_UnitTestC
 	/**
 	 * @ticket 56266
 	 */
-	public function test_it_enables_content_editor_for_non_navigation_type_posts_after_the_content_editor_form() {
+	public function test_it_enables_content_editor_for_navigation_type_posts_after_the_content_editor_form() {
 		$this->disable_editor_support();
 		$post = $this->create_navigation_post();
-		$this->assertFalse( $this->supports_block_editor() );
+		$this->assertFalse( $this->supports_block_editor(), 'Editor support must be disabled before running the test.' );
 
 		_enable_content_editor_for_navigation_post_type( $post );
 
-		$this->assertTrue( $this->supports_block_editor() );
+		$this->assertTrue( $this->supports_block_editor(), '_enable_content_editor_for_navigation_post_type() must enable editor support for navigation type posts.' );
 	}
 
 	/**
@@ -33,11 +33,11 @@ class Tests_Editor_EnableContentEditorForNavigationPostType extends WP_UnitTestC
 	public function test_it_doesnt_enable_content_editor_for_non_navigation_type_posts_after_the_content_editor_form() {
 		$this->disable_editor_support();
 		$post = $this->create_non_navigation_post();
-		$this->assertFalse( $this->supports_block_editor() );
+		$this->assertFalse( $this->supports_block_editor(), 'Editor support must be disabled before running the test.' );
 
 		_enable_content_editor_for_navigation_post_type( $post );
 
-		$this->assertFalse( $this->supports_block_editor() );
+		$this->assertFalse( $this->supports_block_editor(), '_enable_content_editor_for_navigation_post_type() must enable editor support for non-navigation type posts.' );
 	}
 
 	private function supports_block_editor() {

--- a/tests/phpunit/tests/editor/enableContentEditorForNavigationPostType.php
+++ b/tests/phpunit/tests/editor/enableContentEditorForNavigationPostType.php
@@ -17,14 +17,14 @@ class Tests_Editor_EnableContentEditorForNavigationPostType extends WP_UnitTestC
 	/**
 	 * @ticket 56266
 	 *
-	 * @dataProvider data_test_it_correctly_handles_different_post_types
+	 * @dataProvider data_test_should_only_enable_content_editor_for_navigation_post_types
 	 *
 	 * @param string $post_type             The post type.
 	 * @param bool   $enable_editor_support Whether to enable editor support.
 	 * @param bool   $expected              The expected result.
 	 * @param string $message               The message to display if the test fails.
 	 */
-	public function test_it_correctly_handles_different_post_types( $post_type, $enable_editor_support, $expected, $message ) {
+	public function test_should_only_enable_content_editor_for_navigation_post_types( $post_type, $enable_editor_support, $expected, $message ) {
 		$post = $this->create_post( $post_type );
 		if ( $enable_editor_support ) {
 			$this->enable_editor_support();
@@ -40,11 +40,11 @@ class Tests_Editor_EnableContentEditorForNavigationPostType extends WP_UnitTestC
 	}
 
 	/**
-	 * Data provider for test_it_correctly_handles_different_post_types().
+	 * Data provider for test_should_only_enable_content_editor_for_navigation_post_types().
 	 *
 	 * @return array
 	 */
-	public function data_test_it_correctly_handles_different_post_types() {
+	public function data_test_should_only_enable_content_editor_for_navigation_post_types() {
 		return array(
 			'non-navigation post type and false' => array(
 				'post_type'             => static::NON_NAVIGATION_POST_TYPE,

--- a/tests/phpunit/tests/editor/enableContentEditorForNavigationPostType.php
+++ b/tests/phpunit/tests/editor/enableContentEditorForNavigationPostType.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @group editor
+ *
+ * @covers ::_enable_content_editor_for_navigation_post_type
+ */
+class Tests_Editor_EnableContentEditorForNavigationPostType extends WP_UnitTestCase
+{
+	const NAVIGATION_POST_TYPE     = 'wp_navigation';
+	const NON_NAVIGATION_POST_TYPE = 'wp_non_navigation';
+
+	/**
+	 * @ticket 56266
+	 */
+	public function test_it_enables_content_editor_for_non_navigation_type_posts_after_the_content_editor_form() {
+		$this->disable_editor_support();
+		$post = $this->create_navigation_post();
+		$this->assertFalse( $this->supports_block_editor() );
+
+		_enable_content_editor_for_navigation_post_type( $post );
+
+		$this->assertTrue( $this->supports_block_editor() );
+	}
+
+	/**
+	 * @ticket 56266
+	 */
+	public function test_it_doesnt_enable_content_editor_for_non_navigation_type_posts_after_the_content_editor_form() {
+		$this->disable_editor_support();
+		$post = $this->create_non_navigation_post();
+		$this->assertFalse( $this->supports_block_editor() );
+
+		_enable_content_editor_for_navigation_post_type( $post );
+
+		$this->assertFalse( $this->supports_block_editor() );
+	}
+
+	private function supports_block_editor() {
+		return post_type_supports( static::NAVIGATION_POST_TYPE, 'editor' );
+	}
+
+	private function create_post( $type ) {
+		$post            = new WP_Post( new StdClass() );
+		$post->post_type = $type;
+		$post->filter    = 'raw';
+		return $post;
+	}
+
+	private function create_non_navigation_post() {
+		return $this->create_post( static::NON_NAVIGATION_POST_TYPE );
+	}
+
+	private function create_navigation_post() {
+		return $this->create_post( static::NAVIGATION_POST_TYPE );
+	}
+
+	private function disable_editor_support() {
+		remove_post_type_support( static::NAVIGATION_POST_TYPE, 'editor' );
+	}
+}

--- a/tests/phpunit/tests/editor/enableContentEditorForNavigationPostType.php
+++ b/tests/phpunit/tests/editor/enableContentEditorForNavigationPostType.php
@@ -16,28 +16,54 @@ class Tests_Editor_EnableContentEditorForNavigationPostType extends WP_UnitTestC
 
 	/**
 	 * @ticket 56266
+	 *
+	 * @dataProvider data_test_it_correctly_handles_different_post_types
 	 */
-	public function test_it_enables_content_editor_for_navigation_type_posts_after_the_content_editor_form() {
-		$this->disable_editor_support();
-		$post = $this->create_navigation_post();
-		$this->assertFalse( $this->supports_block_editor(), 'Editor support must be disabled before running the test.' );
+	public function test_it_correctly_handles_different_post_types( $post_type, $enable_editor_support, $expected, $message ) {
+		$post = $this->create_post( $post_type );
+		if ( $enable_editor_support ) {
+			$this->enable_editor_support();
+			$this->assertTrue( $this->supports_block_editor(), 'Editor support must be enabled before running the test.' );
+		} else {
+			$this->disable_editor_support();
+			$this->assertFalse( $this->supports_block_editor(), 'Editor support must be disabled before running the test.' );
+		}
 
 		_enable_content_editor_for_navigation_post_type( $post );
 
-		$this->assertTrue( $this->supports_block_editor(), '_enable_content_editor_for_navigation_post_type() must enable editor support for navigation type posts.' );
+		$this->assertSame( $expected, $this->supports_block_editor(), $message );
 	}
 
 	/**
 	 * @ticket 56266
 	 */
-	public function test_it_doesnt_enable_content_editor_for_non_navigation_type_posts_after_the_content_editor_form() {
-		$this->disable_editor_support();
-		$post = $this->create_non_navigation_post();
-		$this->assertFalse( $this->supports_block_editor(), 'Editor support must be disabled before running the test.' );
-
-		_enable_content_editor_for_navigation_post_type( $post );
-
-		$this->assertFalse( $this->supports_block_editor(), '_enable_content_editor_for_navigation_post_type() must enable editor support for non-navigation type posts.' );
+	public function data_test_it_correctly_handles_different_post_types() {
+		return array(
+			'non-navigation post type and false' => array(
+				'post_type'             => static::NON_NAVIGATION_POST_TYPE,
+				'enable_editor_support' => false,
+				'expected'              => false,
+				'message'               => '_enable_content_editor_for_navigation_post_type() must not enable editor support for non-navigation type posts.',
+			),
+			'non-navigation post type and true'  => array(
+				'post_type'             => static::NON_NAVIGATION_POST_TYPE,
+				'enable_editor_support' => true,
+				'expected'              => true,
+				'message'               => '_enable_content_editor_for_navigation_post_type() must not disable editor support for non-navigation type posts.',
+			),
+			'navigation post type and false'     => array(
+				'post_type'             => static::NAVIGATION_POST_TYPE,
+				'enable_editor_support' => false,
+				'expected'              => true,
+				'message'               => '_enable_content_editor_for_navigation_post_type() must enable editor support for navigation type posts.',
+			),
+			'navigation post type and true'      => array(
+				'post_type'             => static::NAVIGATION_POST_TYPE,
+				'enable_editor_support' => true,
+				'expected'              => true,
+				'message'               => '_enable_content_editor_for_navigation_post_type() must not disable editor support for navigation type posts.',
+			),
+		);
 	}
 
 	private function supports_block_editor() {
@@ -48,14 +74,6 @@ class Tests_Editor_EnableContentEditorForNavigationPostType extends WP_UnitTestC
 		return $this->factory()->post->create(
 			array( 'post_type' => $post_type )
 		);
-	}
-
-	private function create_non_navigation_post() {
-		return $this->create_post( static::NON_NAVIGATION_POST_TYPE );
-	}
-
-	private function create_navigation_post() {
-		return $this->create_post( static::NAVIGATION_POST_TYPE );
 	}
 
 	private function enable_editor_support() {

--- a/tests/phpunit/tests/editor/enableContentEditorForNavigationPostType.php
+++ b/tests/phpunit/tests/editor/enableContentEditorForNavigationPostType.php
@@ -45,7 +45,7 @@ class Tests_Editor_EnableContentEditorForNavigationPostType extends WP_UnitTestC
 	}
 
 	private function create_post( $post_type ) {
-		$post            = new WP_Post( new StdClass() );
+		$post            = new WP_Post( new stdClass() );
 		$post->post_type = $post_type;
 		$post->filter    = 'raw';
 		return $post;

--- a/tests/phpunit/tests/editor/enableContentEditorForNavigationPostType.php
+++ b/tests/phpunit/tests/editor/enableContentEditorForNavigationPostType.php
@@ -1,93 +1,130 @@
 <?php
+
 /**
  * @group editor
  *
  * @covers ::_enable_content_editor_for_navigation_post_type
  */
 class Tests_Editor_EnableContentEditorForNavigationPostType extends WP_UnitTestCase {
-
-	const NAVIGATION_POST_TYPE     = 'wp_navigation';
-	const NON_NAVIGATION_POST_TYPE = 'wp_non_navigation';
+	const NAVIGATION_POST_TYPE = 'wp_navigation';
 
 	public function tear_down() {
-		$this->enable_editor_support();
+		add_post_type_support( static::NAVIGATION_POST_TYPE, 'editor' );
 		parent::tear_down();
 	}
 
 	/**
 	 * @ticket 56266
-	 *
-	 * @dataProvider data_should_only_enable_content_editor_for_navigation_post_types
-	 *
-	 * @param string $post_type             The post type.
-	 * @param bool   $enable_editor_support Whether to enable editor support.
-	 * @param bool   $expected              The expected result.
-	 * @param string $message               The message to display if the test fails.
 	 */
-	public function test_should_only_enable_content_editor_for_navigation_post_types( $post_type, $enable_editor_support, $expected, $message ) {
-		$post = $this->create_post( $post_type );
-		if ( $enable_editor_support ) {
-			$this->enable_editor_support();
-			$this->assertTrue( $this->supports_block_editor(), 'Editor support must be enabled before running the test.' );
-		} else {
-			$this->disable_editor_support();
-			$this->assertFalse( $this->supports_block_editor(), 'Editor support must be disabled before running the test.' );
-		}
-
-		_enable_content_editor_for_navigation_post_type( $post );
-
-		$this->assertSame( $expected, $this->supports_block_editor(), $message );
+	public function test_should_be_enabled_by_default() {
+		$this->assertTrue( post_type_supports( static::NAVIGATION_POST_TYPE, 'editor' ) );
 	}
 
 	/**
-	 * Data provider for test_should_only_enable_content_editor_for_navigation_post_types().
+	 * @ticket 56266
+	 */
+	public function test_should_enable() {
+		$post = $this->create_post( static::NAVIGATION_POST_TYPE );
+
+		_enable_content_editor_for_navigation_post_type( $post );
+
+		$this->assertTrue( post_type_supports( static::NAVIGATION_POST_TYPE, 'editor' ) );
+	}
+
+	/**
+	 * @ticket 56266
+	 */
+	public function test_should_reenable_when_disabled() {
+		$post = $this->create_post( static::NAVIGATION_POST_TYPE );
+
+		// Set up the test by removing the 'editor' post type support.
+		remove_post_type_support( static::NAVIGATION_POST_TYPE, 'editor' );
+		$this->assertFalse( post_type_supports( static::NAVIGATION_POST_TYPE, 'editor' ) );
+
+		_enable_content_editor_for_navigation_post_type( $post );
+
+		$this->assertTrue( post_type_supports( static::NAVIGATION_POST_TYPE, 'editor' ) );
+	}
+
+	/**
+	 * @dataProvider data_should_not_enable
+	 * @ticket       56266
+	 *
+	 * @param string $post_type Post type to test.
+	 */
+	public function test_should_not_enable( $post_type ) {
+		$post = $this->create_post( $post_type );
+
+		_enable_content_editor_for_navigation_post_type( $post );
+
+		$this->assertFalse( post_type_supports( $post_type, 'editor' ) );
+	}
+
+	/**
+	 * Data provider.
 	 *
 	 * @return array
 	 */
-	public function data_should_only_enable_content_editor_for_navigation_post_types() {
+	public function data_should_not_enable() {
 		return array(
-			'non-navigation post type and false' => array(
-				'post_type'             => static::NON_NAVIGATION_POST_TYPE,
-				'enable_editor_support' => false,
-				'expected'              => false,
-				'message'               => '_enable_content_editor_for_navigation_post_type() must not enable editor support for non-navigation type posts.',
-			),
-			'non-navigation post type and true'  => array(
-				'post_type'             => static::NON_NAVIGATION_POST_TYPE,
-				'enable_editor_support' => true,
-				'expected'              => true,
-				'message'               => '_enable_content_editor_for_navigation_post_type() must not disable editor support for non-navigation type posts.',
-			),
-			'navigation post type and false'     => array(
-				'post_type'             => static::NAVIGATION_POST_TYPE,
-				'enable_editor_support' => false,
-				'expected'              => true,
-				'message'               => '_enable_content_editor_for_navigation_post_type() must enable editor support for navigation type posts.',
-			),
-			'navigation post type and true'      => array(
-				'post_type'             => static::NAVIGATION_POST_TYPE,
-				'enable_editor_support' => true,
-				'expected'              => true,
-				'message'               => '_enable_content_editor_for_navigation_post_type() must not disable editor support for navigation type posts.',
-			),
+			'invalid post type'   => array( 'book' ),
+			'attachments'         => array( 'attachments' ),
+			'revision'            => array( 'revision' ),
+			'custom_css'          => array( 'custom_css' ),
+			'customize_changeset' => array( 'customize_changeset' ),
 		);
 	}
 
-	private function supports_block_editor() {
-		return post_type_supports( static::NAVIGATION_POST_TYPE, 'editor' );
+	/**
+	 * @dataProvider data_should_not_change_post_type_support
+	 * @ticket       56266
+	 *
+	 * @param string $post_type Post type to test.
+	 */
+	public function test_should_not_change_post_type_support( $post_type ) {
+		$post = $this->create_post( $post_type );
+
+		// Capture the original support.
+		$before = post_type_supports( $post_type, 'editor' );
+
+		_enable_content_editor_for_navigation_post_type( $post );
+
+		// Ensure it did not change.
+		$this->assertSame( $before, post_type_supports( $post_type, 'editor' ) );
 	}
 
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_should_not_change_post_type_support() {
+		return array(
+			'post'                => array( 'post' ),
+			'page'                => array( 'page' ),
+			'attachments'         => array( 'attachments' ),
+			'revision'            => array( 'revision' ),
+			'custom_css'          => array( 'custom_css' ),
+			'customize_changeset' => array( 'customize_changeset' ),
+			'nav_menu_item'       => array( 'nav_menu_item' ),
+			'oembed_cache'        => array( 'oembed_cache' ),
+			'user_request'        => array( 'user_request' ),
+			'wp_block'            => array( 'wp_block' ),
+			'wp_template'         => array( 'wp_template' ),
+			'wp_template_part'    => array( 'wp_template_part' ),
+			'wp_global_styles'    => array( 'wp_global_styles' ),
+		);
+	}
+
+	/**
+	 * Creates a post.
+	 *
+	 * @param string $post_type Post type to create.
+	 * @return int
+	 */
 	private function create_post( $post_type ) {
 		return $this->factory()->post->create(
 			array( 'post_type' => $post_type )
 		);
-	}
-
-	private function enable_editor_support() {
-		add_post_type_support( static::NAVIGATION_POST_TYPE, 'editor' );
-	}
-
-	private function disable_editor_support() {
-		remove_post_type_support( static::NAVIGATION_POST_TYPE, 'editor' );
 	}
 }

--- a/tests/phpunit/tests/editor/enableContentEditorForNavigationPostType.php
+++ b/tests/phpunit/tests/editor/enableContentEditorForNavigationPostType.php
@@ -9,11 +9,6 @@ class Tests_Editor_EnableContentEditorForNavigationPostType extends WP_UnitTestC
 	const NAVIGATION_POST_TYPE     = 'wp_navigation';
 	const NON_NAVIGATION_POST_TYPE = 'wp_non_navigation';
 
-	public function set_up() {
-		parent::set_up();
-		$this->disable_editor_support();
-	}
-
 	public function tear_down() {
 		$this->enable_editor_support();
 		parent::tear_down();
@@ -23,6 +18,7 @@ class Tests_Editor_EnableContentEditorForNavigationPostType extends WP_UnitTestC
 	 * @ticket 56266
 	 */
 	public function test_it_enables_content_editor_for_non_navigation_type_posts_after_the_content_editor_form() {
+		$this->disable_editor_support();
 		$post = $this->create_navigation_post();
 		$this->assertFalse( $this->supports_block_editor() );
 
@@ -35,6 +31,7 @@ class Tests_Editor_EnableContentEditorForNavigationPostType extends WP_UnitTestC
 	 * @ticket 56266
 	 */
 	public function test_it_doesnt_enable_content_editor_for_non_navigation_type_posts_after_the_content_editor_form() {
+		$this->disable_editor_support();
 		$post = $this->create_non_navigation_post();
 		$this->assertFalse( $this->supports_block_editor() );
 

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -2105,7 +2105,7 @@ HTML;
 	 *
 	 * @covers ::wp_filter_global_styles_post
 	 */
-	function test_wp_filter_global_styles_post_returns_correct_value() {
+	public function test_wp_filter_global_styles_post_returns_correct_value() {
 		$user_theme_json = '{
  			"isGlobalStylesUserThemeJSON": 1,
  			"version": 1,

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -2101,9 +2101,11 @@ HTML;
 	}
 
 	/**
+	 * @ticket 56266
+	 *
 	 * @covers ::wp_filter_global_styles_post
 	 */
-	function test_wp_filter_global_styles_post() {
+	function test_wp_filter_global_styles_post_returns_correct_value() {
 		$user_theme_json = '{
  			"isGlobalStylesUserThemeJSON": 1,
  			"version": 1,
@@ -2119,6 +2121,6 @@ HTML;
  		}';
 
 		$filtered_user_theme_json = wp_filter_global_styles_post( $user_theme_json );
-		$this->assertEquals( $user_theme_json, $filtered_user_theme_json );
+		$this->assertEquals( $user_theme_json, $filtered_user_theme_json, 'Filtered and expected json data must match.' );
 	}
 }

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -2099,4 +2099,26 @@ HTML;
 
 		return $this->text_array_to_dataprovider( $globals );
 	}
+
+	/**
+	 * @covers ::wp_filter_global_styles_post
+	 */
+	function test_wp_filter_global_styles_post() {
+		$user_theme_json = '{
+ 			"isGlobalStylesUserThemeJSON": 1,
+ 			"version": 1,
+ 			"settings": {
+ 				"typography": {
+ 					"fontFamilies": {
+ 						"fontFamily": "\"DM Sans\", sans-serif",
+ 						"slug": "dm-sans",
+ 						"name": "DM Sans",
+ 					}
+ 				}
+ 			}
+ 		}';
+
+		$filtered_user_theme_json = wp_filter_global_styles_post( $user_theme_json );
+		$this->assertEquals( $user_theme_json, $filtered_user_theme_json );
+	}
 }

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -2099,28 +2099,4 @@ HTML;
 
 		return $this->text_array_to_dataprovider( $globals );
 	}
-
-	/**
-	 * @ticket 56266
-	 *
-	 * @covers ::wp_filter_global_styles_post
-	 */
-	public function test_wp_filter_global_styles_post_returns_correct_value() {
-		$user_theme_json = '{
- 			"isGlobalStylesUserThemeJSON": 1,
- 			"version": 1,
- 			"settings": {
- 				"typography": {
- 					"fontFamilies": {
- 						"fontFamily": "\"DM Sans\", sans-serif",
- 						"slug": "dm-sans",
- 						"name": "DM Sans",
- 					}
- 				}
- 			}
- 		}';
-
-		$filtered_user_theme_json = wp_filter_global_styles_post( $user_theme_json );
-		$this->assertEquals( $user_theme_json, $filtered_user_theme_json, 'Filtered and expected json data must match.' );
-	}
 }

--- a/tests/phpunit/tests/kses/wpFilterGlobalStylesPost.php
+++ b/tests/phpunit/tests/kses/wpFilterGlobalStylesPost.php
@@ -32,11 +32,11 @@ class Tests_Kses_WpFilterGlobalStylesPost extends WP_UnitTestCase {
 	 *
 	 * @param string $rule A rule to test.
 	 */
-	public function test_should_not_remove_safe_global_style_rules($rule) {
-		$theme_data = wp_parse_args( $this->user_theme_data, array( $rule => 'someValue' ) );
+	public function test_should_not_remove_safe_global_style_rules( $rule ) {
+		$theme_data               = wp_parse_args( $this->user_theme_data, array( $rule => 'someValue' ) );
 		$filtered_user_theme_json = $this->filter_global_styles( $theme_data );
-		$safe_rules = array_keys($theme_data);
-		foreach ($safe_rules as $safe_rule) {
+		$safe_rules               = array_keys( $theme_data );
+		foreach ( $safe_rules as $safe_rule ) {
 			$this->assertArrayHasKey( $safe_rule, $filtered_user_theme_json, sprintf( 'wp_filter_global_styles_post() must not remove the "%s" rule as it\'s considered safe.', $safe_rule ) );
 		}
 	}
@@ -47,10 +47,8 @@ class Tests_Kses_WpFilterGlobalStylesPost extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function data_should_not_remove_safe_global_style_rules() {
-		$safe_rules = array_diff( WP_Theme_JSON::VALID_TOP_LEVEL_KEYS, array_keys( $this->user_theme_data ) );
-
 		$result = array();
-		foreach ( $safe_rules as $safe_rule ) {
+		foreach ( WP_Theme_JSON::VALID_TOP_LEVEL_KEYS as $safe_rule ) {
 			$result[ $safe_rule ] = array( $safe_rule );
 		}
 
@@ -59,8 +57,6 @@ class Tests_Kses_WpFilterGlobalStylesPost extends WP_UnitTestCase {
 
 		return $result;
 	}
-
-
 
 	/**
 	 * @ticket 56266
@@ -81,7 +77,6 @@ class Tests_Kses_WpFilterGlobalStylesPost extends WP_UnitTestCase {
 	private function filter_global_styles( $theme_data ) {
 		$user_theme_json          = wp_slash( wp_json_encode( $theme_data ) );
 		$filtered_user_theme_json = wp_filter_global_styles_post( $user_theme_json );
-
 
 		return json_decode( wp_unslash( $filtered_user_theme_json ), true );
 	}

--- a/tests/phpunit/tests/kses/wpFilterGlobalStylesPost.php
+++ b/tests/phpunit/tests/kses/wpFilterGlobalStylesPost.php
@@ -32,7 +32,7 @@ class Tests_Kses_WpFilterGlobalStylesPost extends WP_UnitTestCase {
 	 */
 	public function test_should_not_remove_safe_global_style_rules() {
 		$filtered_user_theme_json = $this->filter_global_styles( $this->user_theme_data );
-		$this->assertArrayNotHasKey( 'nonSchemaRule', $filtered_user_theme_json, 'Filtered json data must not contain unsafe global style rules.' );
+		$this->assertArrayHasKey( 'styles', $filtered_user_theme_json, 'Filtered json data must contain safe global style rules.' );
 	}
 
 	/**
@@ -40,7 +40,7 @@ class Tests_Kses_WpFilterGlobalStylesPost extends WP_UnitTestCase {
 	 */
 	public function test_should_remove_unsafe_global_style_rules() {
 		$filtered_user_theme_json = $this->filter_global_styles( $this->user_theme_data );
-		$this->assertArrayHasKey( 'styles', $filtered_user_theme_json, 'Filtered json data must contain safe global style rules.' );
+		$this->assertArrayNotHasKey( 'nonSchemaRule', $filtered_user_theme_json, 'Filtered json data must not contain unsafe global style rules.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/kses/wpFilterGlobalStylesPost.php
+++ b/tests/phpunit/tests/kses/wpFilterGlobalStylesPost.php
@@ -15,81 +15,52 @@ class Tests_Kses_WpFilterGlobalStylesPost extends WP_UnitTestCase {
 	private $user_theme_data = array(
 		'isGlobalStylesUserThemeJSON' => 1,
 		'version'                     => 1,
-		'nonSchemaRule'               => 'someValue',
 		'styles'                      => array(
-			'blocks' => array(),
+			'blocks' => array(
+				'core/button' => array(
+					'border' => array(
+						'radius' => '0',
+					),
+				),
+			),
 		),
 	);
 
 	/**
-	 * @param $block_name
+	 * @dataProvider data_should_not_remove_safe_global_style_rules
+	 * @ticket       56266
 	 *
-	 * @dataProvider data_should_not_remove_valid_blocks
+	 * @param string $rule A rule to test.
 	 */
-	public function test_should_not_remove_valid_blocks( $block_name, $user_theme_data ) {
-		$filtered_user_theme_json = $this->filter_global_styles( $user_theme_data );
-		$this->assertFalse( empty( $filtered_user_theme_json['styles']['blocks'][ $block_name ] ), sprintf( 'wp_filter_global_styles_post() must not remove "%s" from the theme data as it\'s a valid block.', $block_name ) );
-		$this->assertIsArray( $filtered_user_theme_json['styles']['blocks'][ $block_name ], sprintf( 'The "%s" block data must be of type array.', $block_name ) );
-	}
-
-	public function data_should_not_remove_valid_blocks() {
-		$registry          = WP_Block_Type_Registry::get_instance();
-		$registered_blocks = $registry->get_all_registered();
-		$user_themes       = array();
-		foreach ( $registered_blocks as $registered_block ) {
-			$user_theme_data                                                = $this->user_theme_data;
-			$user_theme_data['styles']['blocks'][ $registered_block->name ] = array(
-				'border' => array(
-					'radius' => '0',
-				)
-			);
-
-			$user_themes[ 'block: ' . $registered_block->name ] = array(
-				'block_name'      => $registered_block->name,
-				'user_theme_data' => $user_theme_data,
-			);
+	public function test_should_not_remove_safe_global_style_rules($rule) {
+		$theme_data = wp_parse_args( $this->user_theme_data, array( $rule => 'someValue' ) );
+		$filtered_user_theme_json = $this->filter_global_styles( $theme_data );
+		$safe_rules = array_keys($theme_data);
+		foreach ($safe_rules as $safe_rule) {
+			$this->assertArrayHasKey( $safe_rule, $filtered_user_theme_json, sprintf( 'wp_filter_global_styles_post() must not remove the "%s" rule as it\'s considered safe.', $safe_rule ) );
 		}
-
-		return $user_themes;
 	}
 
 	/**
-	 * @param $block_name
+	 * Data provider.
 	 *
-	 * @dataProvider data_should_remove_invalid_blocks
+	 * @return array
 	 */
-	public function test_should_remove_invalid_blocks( $block_name, $user_theme_data ) {
-		$filtered_user_theme_json = $this->filter_global_styles( $user_theme_data );
-		$this->assertTrue( empty( $filtered_user_theme_json['styles']['blocks'][ $block_name ] ), sprintf( 'wp_filter_global_styles_post() must remove "%s" from the theme data as it\'s invalid.', $block_name ) );
-	}
+	public function data_should_not_remove_safe_global_style_rules() {
+		$safe_rules = array_diff( WP_Theme_JSON::VALID_TOP_LEVEL_KEYS, array_keys( $this->user_theme_data ) );
 
-	public function data_should_remove_invalid_blocks() {
-		$user_themes = array();
-		for ( $i = 0; $i < 50; $i ++ ) {
-			$user_theme_data                                    = $this->user_theme_data;
-			$block_name                                         = uniqid( 'core/' );
-			$user_theme_data['styles']['blocks'][ $block_name ] = array(
-				'border' => array(
-					'radius' => '0',
-				)
-			);
-
-			$user_themes[ 'block: ' . $block_name ] = array(
-				'block_name'      => $block_name,
-				'user_theme_data' => $user_theme_data,
-			);
+		$result = array();
+		foreach ( $safe_rules as $safe_rule ) {
+			$result[ $safe_rule ] = array( $safe_rule );
 		}
 
-		return $user_themes;
+		// Settings always get removed.
+		unset( $result['settings'] );
+
+		return $result;
 	}
 
-	/**
-	 * @ticket 56266
-	 */
-	public function test_should_not_remove_safe_global_style_rules() {
-		$filtered_user_theme_json = $this->filter_global_styles( $this->user_theme_data );
-		$this->assertArrayHasKey( 'styles', $filtered_user_theme_json, 'Filtered json data must contain safe global style rules.' );
-	}
+
 
 	/**
 	 * @ticket 56266
@@ -105,11 +76,12 @@ class Tests_Kses_WpFilterGlobalStylesPost extends WP_UnitTestCase {
 	 *
 	 * @param array $theme_data Theme data to filter.
 	 *
-	 * @return array             Filtered theme data.
+	 * @return array Filtered theme data.
 	 */
 	private function filter_global_styles( $theme_data ) {
 		$user_theme_json          = wp_slash( wp_json_encode( $theme_data ) );
 		$filtered_user_theme_json = wp_filter_global_styles_post( $user_theme_json );
+
 
 		return json_decode( wp_unslash( $filtered_user_theme_json ), true );
 	}

--- a/tests/phpunit/tests/kses/wpFilterGlobalStylesPost.php
+++ b/tests/phpunit/tests/kses/wpFilterGlobalStylesPost.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @group kses
+ *
+ * @covers ::wp_filter_global_styles_post
+ */
+class Tests_Kses_WpFilterGlobalStylesPost extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 56266
+	 */
+	public function test_wp_filter_global_styles_post_returns_correct_value() {
+		$user_theme_json = '{
+ 			"isGlobalStylesUserThemeJSON": 1,
+ 			"version": 1,
+ 			"settings": {
+ 				"typography": {
+ 					"fontFamilies": {
+ 						"fontFamily": "\"DM Sans\", sans-serif",
+ 						"slug": "dm-sans",
+ 						"name": "DM Sans",
+ 					}
+ 				}
+ 			}
+ 		}';
+
+		$filtered_user_theme_json = wp_filter_global_styles_post( $user_theme_json );
+		$this->assertSame( $user_theme_json, $filtered_user_theme_json, 'Filtered and expected json data must match.' );
+	}
+}

--- a/tests/phpunit/tests/kses/wpFilterGlobalStylesPost.php
+++ b/tests/phpunit/tests/kses/wpFilterGlobalStylesPost.php
@@ -47,9 +47,9 @@ class Tests_Kses_WpFilterGlobalStylesPost extends WP_UnitTestCase {
 	 * This is a helper method.
 	 * It filters JSON theme data and returns it as an array.
 	 *
-	 * @param $theme_data Theme data to filter.
+	 * @param  array $theme_data Theme data to filter.
 	 *
-	 * @return array Filtered theme data.
+	 * @return array             Filtered theme data.
 	 */
 	private function filter_global_styles( $theme_data ) {
 		$user_theme_json          = wp_slash( wp_json_encode( $theme_data ) );

--- a/tests/phpunit/tests/kses/wpFilterGlobalStylesPost.php
+++ b/tests/phpunit/tests/kses/wpFilterGlobalStylesPost.php
@@ -17,15 +17,71 @@ class Tests_Kses_WpFilterGlobalStylesPost extends WP_UnitTestCase {
 		'version'                     => 1,
 		'nonSchemaRule'               => 'someValue',
 		'styles'                      => array(
-			'blocks' => array(
-				'core/button' => array(
-					'border' => array(
-						'radius' => '0',
-					),
-				),
-			),
+			'blocks' => array(),
 		),
 	);
+
+	/**
+	 * @param $block_name
+	 *
+	 * @dataProvider data_should_not_remove_valid_blocks
+	 */
+	public function test_should_not_remove_valid_blocks( $block_name, $user_theme_data ) {
+		$filtered_user_theme_json = $this->filter_global_styles( $user_theme_data );
+		$this->assertFalse( empty( $filtered_user_theme_json['styles']['blocks'][ $block_name ] ), sprintf( 'wp_filter_global_styles_post() must not remove "%s" from the theme data as it\'s a valid block.', $block_name ) );
+		$this->assertIsArray( $filtered_user_theme_json['styles']['blocks'][ $block_name ], sprintf( 'The "%s" block data must be of type array.', $block_name ) );
+	}
+
+	public function data_should_not_remove_valid_blocks() {
+		$registry          = WP_Block_Type_Registry::get_instance();
+		$registered_blocks = $registry->get_all_registered();
+		$user_themes       = array();
+		foreach ( $registered_blocks as $registered_block ) {
+			$user_theme_data                                                = $this->user_theme_data;
+			$user_theme_data['styles']['blocks'][ $registered_block->name ] = array(
+				'border' => array(
+					'radius' => '0',
+				)
+			);
+
+			$user_themes[ 'block: ' . $registered_block->name ] = array(
+				'block_name'      => $registered_block->name,
+				'user_theme_data' => $user_theme_data,
+			);
+		}
+
+		return $user_themes;
+	}
+
+	/**
+	 * @param $block_name
+	 *
+	 * @dataProvider data_should_remove_invalid_blocks
+	 */
+	public function test_should_remove_invalid_blocks( $block_name, $user_theme_data ) {
+		$filtered_user_theme_json = $this->filter_global_styles( $user_theme_data );
+		$this->assertTrue( empty( $filtered_user_theme_json['styles']['blocks'][ $block_name ] ), sprintf( 'wp_filter_global_styles_post() must remove "%s" from the theme data as it\'s invalid.', $block_name ) );
+	}
+
+	public function data_should_remove_invalid_blocks() {
+		$user_themes = array();
+		for ( $i = 0; $i < 50; $i ++ ) {
+			$user_theme_data                                    = $this->user_theme_data;
+			$block_name                                         = uniqid( 'core/' );
+			$user_theme_data['styles']['blocks'][ $block_name ] = array(
+				'border' => array(
+					'radius' => '0',
+				)
+			);
+
+			$user_themes[ 'block: ' . $block_name ] = array(
+				'block_name'      => $block_name,
+				'user_theme_data' => $user_theme_data,
+			);
+		}
+
+		return $user_themes;
+	}
 
 	/**
 	 * @ticket 56266
@@ -47,13 +103,14 @@ class Tests_Kses_WpFilterGlobalStylesPost extends WP_UnitTestCase {
 	 * This is a helper method.
 	 * It filters JSON theme data and returns it as an array.
 	 *
-	 * @param  array $theme_data Theme data to filter.
+	 * @param array $theme_data Theme data to filter.
 	 *
 	 * @return array             Filtered theme data.
 	 */
 	private function filter_global_styles( $theme_data ) {
 		$user_theme_json          = wp_slash( wp_json_encode( $theme_data ) );
 		$filtered_user_theme_json = wp_filter_global_styles_post( $user_theme_json );
+
 		return json_decode( wp_unslash( $filtered_user_theme_json ), true );
 	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This PR aims to backport `WP_Navigation_Test` and `WP_Global_Styles_Test` test classes to Core.
These tests haven't been backported to Core.
Original tests classes:

1. https://github.com/WordPress/gutenberg/blob/release/13.6/phpunit/global-styles-test.php
2. https://github.com/WordPress/gutenberg/blob/release/13.6/phpunit/navigation-test.php 

Trac ticket: https://core.trac.wordpress.org/ticket/56266

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
