### PR TITLE
Resolve duplicate template parts in PHP 5.6

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -696,9 +696,12 @@ function get_block_templates( $query = array(), $template_type = 'wp_template' )
 
 			$is_not_custom   = false === array_search(
 				wp_get_theme()->get_stylesheet() . '//' . $template_file['slug'],
-				array_map( function ($template) {
-					return $template->id;
-				},  $query_result ),
+				array_map(
+					function ( $template ) {
+						return $template->id;
+					},
+					$query_result
+				),
 				true
 			);
 			$fits_slug_query =

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -696,12 +696,7 @@ function get_block_templates( $query = array(), $template_type = 'wp_template' )
 
 			$is_not_custom   = false === array_search(
 				wp_get_theme()->get_stylesheet() . '//' . $template_file['slug'],
-				array_map(
-					function ( $template ) {
-						return $template->id;
-					},
-					$query_result
-				),
+				wp_list_pluck( $query_result, 'id' ),
 				true
 			);
 			$fits_slug_query =

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -696,7 +696,9 @@ function get_block_templates( $query = array(), $template_type = 'wp_template' )
 
 			$is_not_custom   = false === array_search(
 				wp_get_theme()->get_stylesheet() . '//' . $template_file['slug'],
-				array_column( $query_result, 'id' ),
+				array_map( function ($template) {
+					return $template->id;
+				},  $query_result ),
 				true
 			);
 			$fits_slug_query =


### PR DESCRIPTION
An issue has been reported whereby template parts can be duplicated when running on PHP 5.6. 

This has been tracked down to the use of `array_column` on an array of `WP_Block_Template`. Whilst this works correctly in PHP 7, it will always return an empty array in PHP 5.6. See: https://stackoverflow.com/a/23335938

I have converted the `array_column` call to `array_map` to ensure that this will continue to work with backwards compatibility. 

Full details of the issue and the analysis can be found in the trac ticket.

Trac ticket: https://core.trac.wordpress.org/ticket/56271

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
