### PR TITLE
Use %i for table names (part 1)

### DIFF
--- a/src/wp-admin/edit.php
+++ b/src/wp-admin/edit.php
@@ -97,7 +97,7 @@ if ( $doaction ) {
 			 */
 			global $wpdb;
 
-			$post_ids = $wpdb->get_col( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_type=%s AND post_status = %s", $post_type, $post_status ) );
+			$post_ids = $wpdb->get_col( $wpdb->prepare( 'SELECT ID FROM %i WHERE post_type = %s AND post_status = %s', $wpdb->posts, $post_type, $post_status ) );
 		}
 		$doaction = 'delete';
 	} elseif ( isset( $_REQUEST['media'] ) ) {

--- a/src/wp-admin/export.php
+++ b/src/wp-admin/export.php
@@ -192,7 +192,7 @@ function export_date_options( $post_type = 'post' ) {
 	<li>
 		<label><span class="label-responsive"><?php _e( 'Authors:' ); ?></span>
 		<?php
-		$authors = $wpdb->get_col( "SELECT DISTINCT post_author FROM {$wpdb->posts} WHERE post_type = 'post'" );
+		$authors = $wpdb->get_col( $wpdb->prepare( 'SELECT DISTINCT post_author FROM %i WHERE post_type = "post"', $wpdb->posts ) );
 		wp_dropdown_users(
 			array(
 				'include'         => $authors,
@@ -239,7 +239,7 @@ function export_date_options( $post_type = 'post' ) {
 	<li>
 		<label><span class="label-responsive"><?php _e( 'Authors:' ); ?></span>
 		<?php
-		$authors = $wpdb->get_col( "SELECT DISTINCT post_author FROM {$wpdb->posts} WHERE post_type = 'page'" );
+		$authors = $wpdb->get_col( $wpdb->prepare( 'SELECT DISTINCT post_author FROM %i WHERE post_type = "page"', $wpdb->posts ) );
 		wp_dropdown_users(
 			array(
 				'include'         => $authors,

--- a/src/wp-admin/includes/export.php
+++ b/src/wp-admin/includes/export.php
@@ -323,7 +323,7 @@ function export_wp( $args = array() ) {
 	function wxr_term_meta( $term ) {
 		global $wpdb;
 
-		$termmeta = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM $wpdb->termmeta WHERE term_id = %d", $term->term_id ) );
+		$termmeta = $wpdb->get_results( $wpdb->prepare( 'SELECT * FROM %i WHERE term_id = %d', $wpdb->termmeta, $term->term_id ) );
 
 		foreach ( $termmeta as $meta ) {
 			/**
@@ -599,7 +599,7 @@ function export_wp( $args = array() ) {
 	<?php endif; ?>
 				<?php wxr_post_taxonomy(); ?>
 				<?php
-				$postmeta = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM $wpdb->postmeta WHERE post_id = %d", $post->ID ) );
+				$postmeta = $wpdb->get_results( $wpdb->prepare( 'SELECT * FROM %i WHERE post_id = %d', $wpdb->postmeta, $post->ID ) );
 				foreach ( $postmeta as $meta ) :
 					/**
 					 * Filters whether to selectively skip post meta used for WXR exports.
@@ -624,7 +624,7 @@ function export_wp( $args = array() ) {
 					<?php
 	endforeach;
 
-				$_comments = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM $wpdb->comments WHERE comment_post_ID = %d AND comment_approved <> 'spam'", $post->ID ) );
+				$_comments = $wpdb->get_results( $wpdb->prepare( 'SELECT * FROM %i WHERE comment_post_ID = %d AND comment_approved <> "spam"', $wpdb->comments, $post->ID ) );
 				$comments  = array_map( 'get_comment', $_comments );
 				foreach ( $comments as $c ) :
 					?>
@@ -642,7 +642,7 @@ function export_wp( $args = array() ) {
 			<wp:comment_parent><?php echo (int) $c->comment_parent; ?></wp:comment_parent>
 			<wp:comment_user_id><?php echo (int) $c->user_id; ?></wp:comment_user_id>
 					<?php
-					$c_meta = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM $wpdb->commentmeta WHERE comment_id = %d", $c->comment_ID ) );
+					$c_meta = $wpdb->get_results( $wpdb->prepare( 'SELECT * FROM %i WHERE comment_id = %d', $wpdb->commentmeta, $c->comment_ID ) );
 					foreach ( $c_meta as $meta ) :
 						/**
 						 * Filters whether to selectively skip comment meta used for WXR exports.

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -52,7 +52,7 @@ function update_gallery_tab( $tabs ) {
 	$post_id = (int) $_REQUEST['post_id'];
 
 	if ( $post_id ) {
-		$attachments = (int) $wpdb->get_var( $wpdb->prepare( "SELECT count(*) FROM $wpdb->posts WHERE post_type = 'attachment' AND post_status != 'trash' AND post_parent = %d", $post_id ) );
+		$attachments = (int) $wpdb->get_var( $wpdb->prepare( 'SELECT count(*) FROM %i WHERE post_type = "attachment" AND post_status != "trash" AND post_parent = %d', $wpdb->posts, $post_id ) );
 	}
 
 	if ( empty( $attachments ) ) {

--- a/src/wp-admin/includes/ms.php
+++ b/src/wp-admin/includes/ms.php
@@ -179,13 +179,13 @@ function wpmu_delete_user( $id ) {
 			switch_to_blog( $blog->userblog_id );
 			remove_user_from_blog( $id, $blog->userblog_id );
 
-			$post_ids = $wpdb->get_col( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_author = %d", $id ) );
+			$post_ids = $wpdb->get_col( $wpdb->prepare( 'SELECT ID FROM %i WHERE post_author = %d', $wpdb->posts, $id ) );
 			foreach ( (array) $post_ids as $post_id ) {
 				wp_delete_post( $post_id );
 			}
 
 			// Clean links.
-			$link_ids = $wpdb->get_col( $wpdb->prepare( "SELECT link_id FROM $wpdb->links WHERE link_owner = %d", $id ) );
+			$link_ids = $wpdb->get_col( $wpdb->prepare( 'SELECT link_id FROM %i WHERE link_owner = %d', $wpdb->links, $id ) );
 
 			if ( $link_ids ) {
 				foreach ( $link_ids as $link_id ) {
@@ -197,7 +197,7 @@ function wpmu_delete_user( $id ) {
 		}
 	}
 
-	$meta = $wpdb->get_col( $wpdb->prepare( "SELECT umeta_id FROM $wpdb->usermeta WHERE user_id = %d", $id ) );
+	$meta = $wpdb->get_col( $wpdb->prepare( 'SELECT umeta_id FROM %i WHERE user_id = %d', $wpdb->usermeta, $id ) );
 	foreach ( $meta as $mid ) {
 		delete_metadata_by_mid( 'user', $mid );
 	}

--- a/src/wp-admin/includes/schema.php
+++ b/src/wp-admin/includes/schema.php
@@ -599,7 +599,7 @@ function populate_options( array $options = array() ) {
 	}
 
 	if ( ! empty( $insert ) ) {
-		$wpdb->query( "INSERT INTO $wpdb->options (option_name, option_value, autoload) VALUES " . $insert ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query( $wpdb->prepare( 'INSERT INTO %i (option_name, option_value, autoload) VALUES ', $wpdb->options ) . $insert );
 	}
 
 	// In case it is set, but blank, update "home".

--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -160,7 +160,7 @@ if ( ! function_exists( 'wp_install_defaults' ) ) :
 		$cat_slug = sanitize_title( _x( 'Uncategorized', 'Default category slug' ) );
 
 		if ( global_terms_enabled() ) {
-			$cat_id = $wpdb->get_var( $wpdb->prepare( "SELECT cat_ID FROM {$wpdb->sitecategories} WHERE category_nicename = %s", $cat_slug ) );
+			$cat_id = $wpdb->get_var( $wpdb->prepare( 'SELECT cat_ID FROM %i WHERE category_nicename = %s', $wpdb->sitecategories, $cat_slug ) );
 			if ( null == $cat_id ) {
 				$wpdb->insert(
 					$wpdb->sitecategories,
@@ -2252,7 +2252,8 @@ function upgrade_560() {
 	if ( $wp_current_db_version < 49752 ) {
 		$results = $wpdb->get_results(
 			$wpdb->prepare(
-				"SELECT 1 FROM {$wpdb->usermeta} WHERE meta_key = %s LIMIT 1",
+				'SELECT 1 FROM %i WHERE meta_key = %s LIMIT 1',
+				$wpdb->usermeta,
 				WP_Application_Passwords::USERMETA_KEY_APPLICATION_PASSWORDS
 			)
 		);
@@ -2665,7 +2666,7 @@ function __get_option( $setting ) { // phpcs:ignore WordPress.NamingConventions.
 		return untrailingslashit( WP_SITEURL );
 	}
 
-	$option = $wpdb->get_var( $wpdb->prepare( "SELECT option_value FROM $wpdb->options WHERE option_name = %s", $setting ) );
+	$option = $wpdb->get_var( $wpdb->prepare( 'SELECT option_value FROM %i WHERE option_name = %s', $wpdb->options, $setting ) );
 
 	if ( 'home' === $setting && ! $option ) {
 		return __get_option( 'siteurl' );
@@ -2800,7 +2801,7 @@ function dbDelta( $queries = '', $execute = true ) { // phpcs:ignore WordPress.N
 
 		// Fetch the table column structure from the database.
 		$suppress    = $wpdb->suppress_errors();
-		$tablefields = $wpdb->get_results( "DESCRIBE {$table};" );
+		$tablefields = $wpdb->get_results( $wpdb->prepare( 'DESCRIBE %i', $table ) );
 		$wpdb->suppress_errors( $suppress );
 
 		if ( ! $tablefields ) {
@@ -3004,7 +3005,7 @@ function dbDelta( $queries = '', $execute = true ) { // phpcs:ignore WordPress.N
 		}
 
 		// Index stuff goes here. Fetch the table index structure from the database.
-		$tableindices = $wpdb->get_results( "SHOW INDEX FROM {$table};" );
+		$tableindices = $wpdb->get_results( $wpdb->prepare( 'SHOW INDEX FROM %i', $table ) );
 
 		if ( $tableindices ) {
 			// Clear the index array.

--- a/src/wp-admin/includes/user.php
+++ b/src/wp-admin/includes/user.php
@@ -395,7 +395,7 @@ function wp_delete_user( $id, $reassign = null ) {
 		}
 
 		// Clean links.
-		$link_ids = $wpdb->get_col( $wpdb->prepare( "SELECT link_id FROM $wpdb->links WHERE link_owner = %d", $id ) );
+		$link_ids = $wpdb->get_col( $wpdb->prepare( 'SELECT link_id FROM %i WHERE link_owner = %d', $wpdb->links, $id ) );
 
 		if ( $link_ids ) {
 			foreach ( $link_ids as $link_id ) {
@@ -403,14 +403,14 @@ function wp_delete_user( $id, $reassign = null ) {
 			}
 		}
 	} else {
-		$post_ids = $wpdb->get_col( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_author = %d", $id ) );
+		$post_ids = $wpdb->get_col( $wpdb->prepare( 'SELECT ID FROM %i WHERE post_author = %d', $wpdb->posts, $id ) );
 		$wpdb->update( $wpdb->posts, array( 'post_author' => $reassign ), array( 'post_author' => $id ) );
 		if ( ! empty( $post_ids ) ) {
 			foreach ( $post_ids as $post_id ) {
 				clean_post_cache( $post_id );
 			}
 		}
-		$link_ids = $wpdb->get_col( $wpdb->prepare( "SELECT link_id FROM $wpdb->links WHERE link_owner = %d", $id ) );
+		$link_ids = $wpdb->get_col( $wpdb->prepare( 'SELECT link_id FROM %i WHERE link_owner = %d', $wpdb->links, $id ) );
 		$wpdb->update( $wpdb->links, array( 'link_owner' => $reassign ), array( 'link_owner' => $id ) );
 		if ( ! empty( $link_ids ) ) {
 			foreach ( $link_ids as $link_id ) {
@@ -423,7 +423,7 @@ function wp_delete_user( $id, $reassign = null ) {
 	if ( is_multisite() ) {
 		remove_user_from_blog( $id, get_current_blog_id() );
 	} else {
-		$meta = $wpdb->get_col( $wpdb->prepare( "SELECT umeta_id FROM $wpdb->usermeta WHERE user_id = %d", $id ) );
+		$meta = $wpdb->get_col( $wpdb->prepare( 'SELECT umeta_id FROM %i WHERE user_id = %d', $wpdb->usermeta, $id ) );
 		foreach ( $meta as $mid ) {
 			delete_metadata_by_mid( 'user', $mid );
 		}

--- a/src/wp-admin/user-new.php
+++ b/src/wp-admin/user-new.php
@@ -227,7 +227,7 @@ Please click the following link to confirm the invite:
 				)
 			);
 			if ( isset( $_POST['noconfirmation'] ) && current_user_can( 'manage_network_users' ) ) {
-				$key      = $wpdb->get_var( $wpdb->prepare( "SELECT activation_key FROM {$wpdb->signups} WHERE user_login = %s AND user_email = %s", $new_user_login, $new_user_email ) );
+				$key      = $wpdb->get_var( $wpdb->prepare( 'SELECT activation_key FROM %i WHERE user_login = %s AND user_email = %s', $wpdb->signups, $new_user_login, $new_user_email ) );
 				$new_user = wpmu_activate_signup( $key );
 				if ( is_wp_error( $new_user ) ) {
 					$redirect = add_query_arg( array( 'update' => 'addnoconfirmation' ), 'user-new.php' );

--- a/src/wp-cron.php
+++ b/src/wp-cron.php
@@ -69,7 +69,7 @@ function _get_cron_lock() {
 		 */
 		$value = wp_cache_get( 'doing_cron', 'transient', true );
 	} else {
-		$row = $wpdb->get_row( $wpdb->prepare( "SELECT option_value FROM $wpdb->options WHERE option_name = %s LIMIT 1", '_transient_doing_cron' ) );
+		$row = $wpdb->get_row( $wpdb->prepare( 'SELECT option_value FROM %i WHERE option_name = %s LIMIT 1', $wpdb->options, '_transient_doing_cron' ) );
 		if ( is_object( $row ) ) {
 			$value = $row->option_value;
 		}

--- a/src/wp-includes/class-wp-comment.php
+++ b/src/wp-includes/class-wp-comment.php
@@ -190,7 +190,7 @@ final class WP_Comment {
 		$_comment = wp_cache_get( $comment_id, 'comment' );
 
 		if ( ! $_comment ) {
-			$_comment = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->comments WHERE comment_ID = %d LIMIT 1", $comment_id ) );
+			$_comment = $wpdb->get_row( $wpdb->prepare( 'SELECT * FROM %i WHERE comment_ID = %d LIMIT 1', $wpdb->comments, $comment_id ) );
 
 			if ( ! $_comment ) {
 				return false;

--- a/src/wp-includes/class-wp-network.php
+++ b/src/wp-includes/class-wp-network.php
@@ -102,7 +102,7 @@ class WP_Network {
 		$_network = wp_cache_get( $network_id, 'networks' );
 
 		if ( false === $_network ) {
-			$_network = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->site} WHERE id = %d LIMIT 1", $network_id ) );
+			$_network = $wpdb->get_row( $wpdb->prepare( 'SELECT * FROM %i WHERE id = %d LIMIT 1', $wpdb->site, $network_id ) );
 
 			if ( empty( $_network ) || is_wp_error( $_network ) ) {
 				$_network = -1;

--- a/src/wp-includes/class-wp-post.php
+++ b/src/wp-includes/class-wp-post.php
@@ -239,7 +239,7 @@ final class WP_Post {
 		$_post = wp_cache_get( $post_id, 'posts' );
 
 		if ( ! $_post ) {
-			$_post = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->posts WHERE ID = %d LIMIT 1", $post_id ) );
+			$_post = $wpdb->get_row( $wpdb->prepare( 'SELECT * FROM %i WHERE ID = %d LIMIT 1', $wpdb->posts, $post_id ) );
 
 			if ( ! $_post ) {
 				return false;

--- a/src/wp-includes/class-wp-site.php
+++ b/src/wp-includes/class-wp-site.php
@@ -165,7 +165,7 @@ final class WP_Site {
 		$_site = wp_cache_get( $site_id, 'sites' );
 
 		if ( false === $_site ) {
-			$_site = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->blogs} WHERE blog_id = %d LIMIT 1", $site_id ) );
+			$_site = $wpdb->get_row( $wpdb->prepare( 'SELECT * FROM %i WHERE blog_id = %d LIMIT 1', $wpdb->blogs, $site_id ) );
 
 			if ( empty( $_site ) || is_wp_error( $_site ) ) {
 				$_site = -1;

--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -775,7 +775,8 @@ function wp_allow_comment( $commentdata, $wp_error = false ) {
 		$user        = get_userdata( $commentdata['user_id'] );
 		$post_author = $wpdb->get_var(
 			$wpdb->prepare(
-				"SELECT post_author FROM $wpdb->posts WHERE ID = %d LIMIT 1",
+				'SELECT post_author FROM %i WHERE ID = %d LIMIT 1',
+				$wpdb->posts,
 				$commentdata['comment_post_ID']
 			)
 		);
@@ -1468,14 +1469,14 @@ function wp_delete_comment( $comment_id, $force_delete = false ) {
 	do_action( 'delete_comment', $comment->comment_ID, $comment );
 
 	// Move children up a level.
-	$children = $wpdb->get_col( $wpdb->prepare( "SELECT comment_ID FROM $wpdb->comments WHERE comment_parent = %d", $comment->comment_ID ) );
+	$children = $wpdb->get_col( $wpdb->prepare( 'SELECT comment_ID FROM %i WHERE comment_parent = %d', $wpdb->comments, $comment->comment_ID ) );
 	if ( ! empty( $children ) ) {
 		$wpdb->update( $wpdb->comments, array( 'comment_parent' => $comment->comment_parent ), array( 'comment_parent' => $comment->comment_ID ) );
 		clean_comment_cache( $children );
 	}
 
 	// Delete metadata.
-	$meta_ids = $wpdb->get_col( $wpdb->prepare( "SELECT meta_id FROM $wpdb->commentmeta WHERE comment_id = %d", $comment->comment_ID ) );
+	$meta_ids = $wpdb->get_col( $wpdb->prepare( 'SELECT meta_id FROM %i WHERE comment_id = %d', $wpdb->commentmeta, $comment->comment_ID ) );
 	foreach ( $meta_ids as $mid ) {
 		delete_metadata_by_mid( 'comment', $mid );
 	}
@@ -2723,7 +2724,7 @@ function wp_update_comment_count_now( $post_id ) {
 	$new = apply_filters( 'pre_wp_update_comment_count_now', null, $old, $post_id );
 
 	if ( is_null( $new ) ) {
-		$new = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM $wpdb->comments WHERE comment_post_ID = %d AND comment_approved = '1'", $post_id ) );
+		$new = (int) $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM %i WHERE comment_post_ID = %d AND comment_approved = "1"', $wpdb->comments, $post_id ) );
 	} else {
 		$new = (int) $new;
 	}

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -1770,7 +1770,7 @@ function is_blog_installed() {
 	}
 	// If siteurl is not set to autoload, check it specifically.
 	if ( ! isset( $alloptions['siteurl'] ) ) {
-		$installed = $wpdb->get_var( "SELECT option_value FROM $wpdb->options WHERE option_name = 'siteurl'" );
+		$installed = $wpdb->get_var( $wpdb->prepare( 'SELECT option_value FROM %i WHERE option_name = "siteurl"', $wpdb->options ) );
 	} else {
 		$installed = $alloptions['siteurl'];
 	}
@@ -1805,7 +1805,7 @@ function is_blog_installed() {
 			continue;
 		}
 
-		$described_table = $wpdb->get_results( "DESCRIBE $table;" );
+		$described_table = $wpdb->get_results( $wpdb->prepare( 'DESCRIBE %i', $table ) );
 		if (
 			( ! $described_table && empty( $wpdb->last_error ) ) ||
 			( is_array( $described_table ) && 0 === count( $described_table ) )

--- a/src/wp-includes/meta.php
+++ b/src/wp-includes/meta.php
@@ -82,7 +82,8 @@ function add_metadata( $meta_type, $object_id, $meta_key, $meta_value, $unique =
 
 	if ( $unique && $wpdb->get_var(
 		$wpdb->prepare(
-			"SELECT COUNT(*) FROM $table WHERE meta_key = %s AND $column = %d",
+			"SELECT COUNT(*) FROM %i WHERE meta_key = %s AND $column = %d",
+			$table,
 			$meta_key,
 			$object_id
 		)
@@ -827,7 +828,7 @@ function get_metadata_by_mid( $meta_type, $meta_id ) {
 
 	$id_column = ( 'user' === $meta_type ) ? 'umeta_id' : 'meta_id';
 
-	$meta = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $table WHERE $id_column = %d", $meta_id ) );
+	$meta = $wpdb->get_row( $wpdb->prepare( 'SELECT * FROM %i WHERE %i = %d', $table, $id_column, $meta_id ) );
 
 	if ( empty( $meta ) ) {
 		return false;

--- a/src/wp-includes/ms-blogs.php
+++ b/src/wp-includes/ms-blogs.php
@@ -759,7 +759,7 @@ function get_blog_status( $id, $pref ) {
 		return $details->$pref;
 	}
 
-	return $wpdb->get_var( $wpdb->prepare( "SELECT %s FROM {$wpdb->blogs} WHERE blog_id = %d", $pref, $id ) );
+	return $wpdb->get_var( $wpdb->prepare( 'SELECT %s FROM %i WHERE blog_id = %d', $pref, $wpdb->blogs, $id ) );
 }
 
 /**

--- a/src/wp-includes/ms-deprecated.php
+++ b/src/wp-includes/ms-deprecated.php
@@ -613,7 +613,7 @@ function install_blog( $blog_id, $blog_title = '' ) {
 	require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 
 	$suppress = $wpdb->suppress_errors();
-	if ( $wpdb->get_results( "DESCRIBE {$wpdb->posts}" ) ) {
+	if ( $wpdb->get_results( $wpdb->prepare( 'DESCRIBE %i', $wpdb->posts ) ) ) {
 		die( '<h1>' . __( 'Already Installed' ) . '</h1><p>' . __( 'You appear to have already installed WordPress. To reinstall please clear your old database tables first.' ) . '</p></body></html>' );
 	}
 	$wpdb->suppress_errors( $suppress );

--- a/src/wp-includes/ms-functions.php
+++ b/src/wp-includes/ms-functions.php
@@ -2010,7 +2010,7 @@ function check_upload_mimes( $mimes ) {
  */
 function update_posts_count( $deprecated = '' ) {
 	global $wpdb;
-	update_option( 'post_count', (int) $wpdb->get_var( "SELECT COUNT(ID) FROM {$wpdb->posts} WHERE post_status = 'publish' and post_type = 'post'" ) );
+	update_option( 'post_count', (int) $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(ID) FROM %i WHERE post_status = "publish" and post_type = "post"', $wpdb->posts ) ) );
 }
 
 /**

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -172,7 +172,7 @@ function get_option( $option, $default = false ) {
 			$value = wp_cache_get( $option, 'options' );
 
 			if ( false === $value ) {
-				$row = $wpdb->get_row( $wpdb->prepare( "SELECT option_value FROM $wpdb->options WHERE option_name = %s LIMIT 1", $option ) );
+				$row = $wpdb->get_row( $wpdb->prepare( 'SELECT option_value FROM %i WHERE option_name = %s LIMIT 1', $wpdb->options, $option ) );
 
 				// Has to be get_row() instead of get_var() because of funkiness with 0, false, null values.
 				if ( is_object( $row ) ) {
@@ -193,7 +193,7 @@ function get_option( $option, $default = false ) {
 		}
 	} else {
 		$suppress = $wpdb->suppress_errors();
-		$row      = $wpdb->get_row( $wpdb->prepare( "SELECT option_value FROM $wpdb->options WHERE option_name = %s LIMIT 1", $option ) );
+		$row      = $wpdb->get_row( $wpdb->prepare( 'SELECT option_value FROM %i WHERE option_name = %s LIMIT 1', $wpdb->options, $option ) );
 		$wpdb->suppress_errors( $suppress );
 
 		if ( is_object( $row ) ) {
@@ -710,7 +710,7 @@ function delete_option( $option ) {
 	wp_protect_special_option( $option );
 
 	// Get the ID, if no ID then return.
-	$row = $wpdb->get_row( $wpdb->prepare( "SELECT autoload FROM $wpdb->options WHERE option_name = %s", $option ) );
+	$row = $wpdb->get_row( $wpdb->prepare( 'SELECT autoload FROM %i WHERE option_name = %s', $wpdb->options, $option ) );
 	if ( is_null( $row ) ) {
 		return false;
 	}
@@ -1659,7 +1659,7 @@ function delete_network_option( $network_id, $option ) {
 	if ( ! is_multisite() ) {
 		$result = delete_option( $option );
 	} else {
-		$row = $wpdb->get_row( $wpdb->prepare( "SELECT meta_id FROM {$wpdb->sitemeta} WHERE meta_key = %s AND site_id = %d", $option, $network_id ) );
+		$row = $wpdb->get_row( $wpdb->prepare( 'SELECT meta_id FROM %i WHERE meta_key = %s AND site_id = %d', $wpdb->sitemeta, $option, $network_id ) );
 		if ( is_null( $row ) || ! $row->meta_id ) {
 			return false;
 		}

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -3353,7 +3353,7 @@ function wp_post_mime_type_where( $post_mime_types, $table_alias = '' ) {
 function wp_delete_post( $postid = 0, $force_delete = false ) {
 	global $wpdb;
 
-	$post = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->posts WHERE ID = %d", $postid ) );
+	$post = $wpdb->get_row( $wpdb->prepare( 'SELECT * FROM %i WHERE ID = %d', $wpdb->posts, $postid ) );
 
 	if ( ! $post ) {
 		return $post;
@@ -3414,7 +3414,7 @@ function wp_delete_post( $postid = 0, $force_delete = false ) {
 	}
 
 	// Do raw query. wp_get_post_revisions() is filtered.
-	$revision_ids = $wpdb->get_col( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_parent = %d AND post_type = 'revision'", $postid ) );
+	$revision_ids = $wpdb->get_col( $wpdb->prepare( 'SELECT ID FROM %i WHERE post_parent = %d AND post_type = "revision"', $wpdb->posts, $postid ) );
 	// Use wp_delete_post (via wp_delete_post_revision) again. Ensures any meta/misplaced data gets cleaned up.
 	foreach ( $revision_ids as $revision_id ) {
 		wp_delete_post_revision( $revision_id );
@@ -3425,14 +3425,14 @@ function wp_delete_post( $postid = 0, $force_delete = false ) {
 
 	wp_defer_comment_counting( true );
 
-	$comment_ids = $wpdb->get_col( $wpdb->prepare( "SELECT comment_ID FROM $wpdb->comments WHERE comment_post_ID = %d ORDER BY comment_ID DESC", $postid ) );
+	$comment_ids = $wpdb->get_col( $wpdb->prepare( 'SELECT comment_ID FROM %i WHERE comment_post_ID = %d ORDER BY comment_ID DESC', $wpdb->comments, $postid ) );
 	foreach ( $comment_ids as $comment_id ) {
 		wp_delete_comment( $comment_id, true );
 	}
 
 	wp_defer_comment_counting( false );
 
-	$post_meta_ids = $wpdb->get_col( $wpdb->prepare( "SELECT meta_id FROM $wpdb->postmeta WHERE post_id = %d ", $postid ) );
+	$post_meta_ids = $wpdb->get_col( $wpdb->prepare( 'SELECT meta_id FROM %i WHERE post_id = %d', $wpdb->postmeta, $postid ) );
 	foreach ( $post_meta_ids as $mid ) {
 		delete_metadata_by_mid( 'post', $mid );
 	}
@@ -3730,7 +3730,7 @@ function wp_trash_post_comments( $post = null ) {
 	 */
 	do_action( 'trash_post_comments', $post_id );
 
-	$comments = $wpdb->get_results( $wpdb->prepare( "SELECT comment_ID, comment_approved FROM $wpdb->comments WHERE comment_post_ID = %d", $post_id ) );
+	$comments = $wpdb->get_results( $wpdb->prepare( 'SELECT comment_ID, comment_approved FROM %i WHERE comment_post_ID = %d', $wpdb->comments, $post_id ) );
 
 	if ( ! $comments ) {
 		return;
@@ -6413,14 +6413,14 @@ function wp_delete_attachment( $post_id, $force_delete = false ) {
 
 	wp_defer_comment_counting( true );
 
-	$comment_ids = $wpdb->get_col( $wpdb->prepare( "SELECT comment_ID FROM $wpdb->comments WHERE comment_post_ID = %d ORDER BY comment_ID DESC", $post_id ) );
+	$comment_ids = $wpdb->get_col( $wpdb->prepare( 'SELECT comment_ID FROM %i WHERE comment_post_ID = %d ORDER BY comment_ID DESC', $wpdb->comments, $post_id ) );
 	foreach ( $comment_ids as $comment_id ) {
 		wp_delete_comment( $comment_id, true );
 	}
 
 	wp_defer_comment_counting( false );
 
-	$post_meta_ids = $wpdb->get_col( $wpdb->prepare( "SELECT meta_id FROM $wpdb->postmeta WHERE post_id = %d ", $post_id ) );
+	$post_meta_ids = $wpdb->get_col( $wpdb->prepare( 'SELECT meta_id FROM %i WHERE post_id = %d', $wpdb->postmeta, $post_id ) );
 	foreach ( $post_meta_ids as $mid ) {
 		delete_metadata_by_mid( 'post', $mid );
 	}

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -2043,7 +2043,7 @@ function wp_delete_term( $term, $taxonomy, $args = array() ) {
 	// Get the term before deleting it or its term relationships so we can pass to actions below.
 	$deleted_term = get_term( $term, $taxonomy );
 
-	$object_ids = (array) $wpdb->get_col( $wpdb->prepare( "SELECT object_id FROM $wpdb->term_relationships WHERE term_taxonomy_id = %d", $tt_id ) );
+	$object_ids = (array) $wpdb->get_col( $wpdb->prepare( 'SELECT object_id FROM %i WHERE term_taxonomy_id = %d', $wpdb->term_relationships, $tt_id ) );
 
 	foreach ( $object_ids as $object_id ) {
 		if ( ! isset( $default ) ) {
@@ -2079,7 +2079,7 @@ function wp_delete_term( $term, $taxonomy, $args = array() ) {
 		clean_object_term_cache( $object_ids, $object_type );
 	}
 
-	$term_meta_ids = $wpdb->get_col( $wpdb->prepare( "SELECT meta_id FROM $wpdb->termmeta WHERE term_id = %d ", $term ) );
+	$term_meta_ids = $wpdb->get_col( $wpdb->prepare( 'SELECT meta_id FROM %i WHERE term_id = %d', $wpdb->termmeta, $term ) );
 	foreach ( $term_meta_ids as $mid ) {
 		delete_metadata_by_mid( 'term', $mid );
 	}
@@ -2105,7 +2105,7 @@ function wp_delete_term( $term, $taxonomy, $args = array() ) {
 	do_action( 'deleted_term_taxonomy', $tt_id );
 
 	// Delete the term if no taxonomies use it.
-	if ( ! $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM $wpdb->term_taxonomy WHERE term_id = %d", $term ) ) ) {
+	if ( ! $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM %i WHERE term_id = %d', $wpdb->term_taxonomy, $term ) ) ) {
 		$wpdb->delete( $wpdb->terms, array( 'term_id' => $term ) );
 	}
 
@@ -2772,7 +2772,7 @@ function wp_set_object_terms( $object_id, $terms, $taxonomy, $append = false ) {
 		$tt_id      = $term_info['term_taxonomy_id'];
 		$tt_ids[]   = $tt_id;
 
-		if ( $wpdb->get_var( $wpdb->prepare( "SELECT term_taxonomy_id FROM $wpdb->term_relationships WHERE object_id = %d AND term_taxonomy_id = %d", $object_id, $tt_id ) ) ) {
+		if ( $wpdb->get_var( $wpdb->prepare( 'SELECT term_taxonomy_id FROM %i WHERE object_id = %d AND term_taxonomy_id = %d', $wpdb->term_relationships, $object_id, $tt_id ) ) ) {
 			continue;
 		}
 
@@ -4163,7 +4163,7 @@ function _split_shared_term( $term_id, $term_taxonomy_id, $record = true ) {
 	}
 
 	// If there are no shared term_taxonomy rows, there's nothing to do here.
-	$shared_tt_count = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM $wpdb->term_taxonomy tt WHERE tt.term_id = %d AND tt.term_taxonomy_id != %d", $term_id, $term_taxonomy_id ) );
+	$shared_tt_count = (int) $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM %i tt WHERE tt.term_id = %d AND tt.term_taxonomy_id != %d', $wpdb->term_taxonomy, $term_id, $term_taxonomy_id ) );
 
 	if ( ! $shared_tt_count ) {
 		return $term_id;
@@ -4173,14 +4173,14 @@ function _split_shared_term( $term_id, $term_taxonomy_id, $record = true ) {
 	 * Verify that the term_taxonomy_id passed to the function is actually associated with the term_id.
 	 * If there's a mismatch, it may mean that the term is already split. Return the actual term_id from the db.
 	 */
-	$check_term_id = (int) $wpdb->get_var( $wpdb->prepare( "SELECT term_id FROM $wpdb->term_taxonomy WHERE term_taxonomy_id = %d", $term_taxonomy_id ) );
+	$check_term_id = (int) $wpdb->get_var( $wpdb->prepare( 'SELECT term_id FROM %i WHERE term_taxonomy_id = %d', $wpdb->term_taxonomy, $term_taxonomy_id ) );
 	if ( $check_term_id !== $term_id ) {
 		return $check_term_id;
 	}
 
 	// Pull up data about the currently shared slug, which we'll use to populate the new one.
 	if ( empty( $shared_term ) ) {
-		$shared_term = $wpdb->get_row( $wpdb->prepare( "SELECT t.* FROM $wpdb->terms t WHERE t.term_id = %d", $term_id ) );
+		$shared_term = $wpdb->get_row( $wpdb->prepare( 'SELECT t.* FROM %i t WHERE t.term_id = %d', $wpdb->terms, $term_id ) );
 	}
 
 	$new_term_data = array(
@@ -4204,10 +4204,9 @@ function _split_shared_term( $term_id, $term_taxonomy_id, $record = true ) {
 
 	// Reassign child terms to the new parent.
 	if ( empty( $term_taxonomy ) ) {
-		$term_taxonomy = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->term_taxonomy WHERE term_taxonomy_id = %d", $term_taxonomy_id ) );
+		$term_taxonomy = $wpdb->get_row( $wpdb->prepare( 'SELECT * FROM %i WHERE term_taxonomy_id = %d', $wpdb->term_taxonomy, $term_taxonomy_id ) );
 	}
-
-	$children_tt_ids = $wpdb->get_col( $wpdb->prepare( "SELECT term_taxonomy_id FROM $wpdb->term_taxonomy WHERE parent = %d AND taxonomy = %s", $term_id, $term_taxonomy->taxonomy ) );
+	$children_tt_ids = $wpdb->get_col( $wpdb->prepare( 'SELECT term_taxonomy_id FROM %i WHERE parent = %d AND taxonomy = %s', $wpdb->term_taxonomy, $term_id, $term_taxonomy->taxonomy ) );
 	if ( ! empty( $children_tt_ids ) ) {
 		foreach ( $children_tt_ids as $child_tt_id ) {
 			$wpdb->update(
@@ -4231,7 +4230,7 @@ function _split_shared_term( $term_id, $term_taxonomy_id, $record = true ) {
 	$taxonomies_to_clean = array( $term_taxonomy->taxonomy );
 
 	// Clean the cache for term taxonomies formerly shared with the current term.
-	$shared_term_taxonomies = $wpdb->get_col( $wpdb->prepare( "SELECT taxonomy FROM $wpdb->term_taxonomy WHERE term_id = %d", $term_id ) );
+	$shared_term_taxonomies = $wpdb->get_col( $wpdb->prepare( 'SELECT taxonomy FROM %i WHERE term_id = %d', $wpdb->term_taxonomy, $term_id ) );
 	$taxonomies_to_clean    = array_merge( $taxonomies_to_clean, $shared_term_taxonomies );
 
 	foreach ( $taxonomies_to_clean as $taxonomy_to_clean ) {

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -2145,7 +2145,7 @@ function wp_insert_user( $userdata ) {
 		return new WP_Error( 'user_nicename_too_long', __( 'Nicename may not be longer than 50 characters.' ) );
 	}
 
-	$user_nicename_check = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM $wpdb->users WHERE user_nicename = %s AND user_login != %s LIMIT 1", $user_nicename, $user_login ) );
+	$user_nicename_check = $wpdb->get_var( $wpdb->prepare( 'SELECT ID FROM %i WHERE user_nicename = %s AND user_login != %s LIMIT 1', $wpdb->users, $user_nicename, $user_login ) );
 
 	if ( $user_nicename_check ) {
 		$suffix = 2;
@@ -2153,7 +2153,7 @@ function wp_insert_user( $userdata ) {
 			// user_nicename allows 50 chars. Subtract one for a hyphen, plus the length of the suffix.
 			$base_length         = 49 - mb_strlen( $suffix );
 			$alt_user_nicename   = mb_substr( $user_nicename, 0, $base_length ) . "-$suffix";
-			$user_nicename_check = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM $wpdb->users WHERE user_nicename = %s AND user_login != %s LIMIT 1", $alt_user_nicename, $user_login ) );
+			$user_nicename_check = $wpdb->get_var( $wpdb->prepare( 'SELECT ID FROM %i WHERE user_nicename = %s AND user_login != %s LIMIT 1', $wpdb->users, $alt_user_nicename, $user_login ) );
 			$suffix++;
 		}
 		$user_nicename = $alt_user_nicename;


### PR DESCRIPTION
First patch, only affecting SQL that is used directly by `$wpdb->get_col()`, `$wpdb->get_var()`, etc.

Trac ticket: https://core.trac.wordpress.org/ticket/56091