### PR TITLE
Theme JSON: Fix notice when unknown elements are specified

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -1476,11 +1476,13 @@ class WP_Theme_JSON {
 		);
 
 		if ( isset( $theme_json['styles']['elements'] ) ) {
-			foreach ( $theme_json['styles']['elements'] as $element => $node ) {
-				$nodes[] = array(
-					'path'     => array( 'styles', 'elements', $element ),
-					'selector' => static::ELEMENTS[ $element ],
-				);
+			if ( array_key_exists( $element, static::ELEMENTS ) ) {
+				foreach ( $theme_json['styles']['elements'] as $element => $node ) {
+					$nodes[] = array(
+						'path'     => array( 'styles', 'elements', $element ),
+						'selector' => static::ELEMENTS[ $element ],
+					);
+				}
 			}
 		}
 

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -1476,8 +1476,8 @@ class WP_Theme_JSON {
 		);
 
 		if ( isset( $theme_json['styles']['elements'] ) ) {
-			if ( array_key_exists( $element, static::ELEMENTS ) ) {
-				foreach ( $theme_json['styles']['elements'] as $element => $node ) {
+			foreach ( $theme_json['styles']['elements'] as $element => $node ) {
+				if ( array_key_exists( $element, static::ELEMENTS ) ) {
 					$nodes[] = array(
 						'path'     => array( 'styles', 'elements', $element ),
 						'selector' => static::ELEMENTS[ $element ],


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

If a theme.json file specifies an unknown element then we'll get a notice from line 1482 in this file. This adds an `array_key_exists` check before we get the value of the array at that key, to avoid the notice.

Gutenberg issue: https://github.com/WordPress/gutenberg/issues/42649
Trac issue: https://core.trac.wordpress.org/ticket/56291

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
