### PR TITLE
Use original image size data for full size secondary mime generation

### DIFF
--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -341,11 +341,26 @@ function wp_create_image_subsizes( $file, $attachment_id ) {
 	wp_update_attachment_metadata( $attachment_id, $image_meta );
 
 	if ( ! empty( $additional_mime_types ) ) {
-		// Use the original file's exif_meta orientation information for secondary mime generation.
-		$saved_orientation                       = $image_meta['image_meta']['orientation'];
+		// Use the original file's exif_meta orientation and size information for secondary mime generation to ensure
+		// sub-sized images are correctly scaled and rotated.
+
+		// Save data.
+		$saved_meta                = array();
+		$saved_meta['orientation'] = $image_meta['image_meta']['orientation'];
+		$saved_meta['width']       = $image_meta['width'];
+		$saved_meta['height']      = $image_meta['height'];
+
+		// Temporarily set the image meta to the original file's meta.
 		$image_meta['image_meta']['orientation'] = $exif_meta['orientation'];
-		$image_meta                              = _wp_make_additional_mime_types( $additional_mime_types, $file, $image_meta, $attachment_id );
-		$image_meta['image_meta']['orientation'] = $saved_orientation;
+		$image_meta['width']                     = $imagesize[0];
+		$image_meta['height']                    = $imagesize[1];
+
+		$image_meta = _wp_make_additional_mime_types( $additional_mime_types, $file, $image_meta, $attachment_id );
+
+		// Restore the saved meta data.
+		$image_meta['image_meta']['orientation'] = $saved_meta['orientation'];
+		$image_meta['width']                     = $saved_meta['width'];
+		$image_meta['height']                    = $saved_meta['height'];
 
 	}
 


### PR DESCRIPTION
Correct an issue where the secondary mime image would not be properly `-scaled`.  This was happening because the sizes passed into the image generation function were already resized to the threshold. Passing in the original file image sizes elicits the correct behavior.

Test by uploading a large image and checking the full size generated WebP. It should be scaled to the threshold dimensions and have a `-scaled` suffix as part of its name.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/55443
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
