### PR TITLE
Docs: Fix parameter type of $feature in `block_has_support()`

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1017,7 +1017,7 @@ function unregister_block_style( $block_name, $block_style_name ) {
  * @since 5.8.0
  *
  * @param WP_Block_Type $block_type Block type to check for support.
- * @param array         $feature    Path to the specific feature to check support for.
+ * @param array         $feature    Path to a specific feature to check support for.
  * @param mixed         $default    Optional. Fallback value for feature support. Default false.
  * @return bool Whether the feature is supported.
  */

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1017,7 +1017,7 @@ function unregister_block_style( $block_name, $block_style_name ) {
  * @since 5.8.0
  *
  * @param WP_Block_Type $block_type Block type to check for support.
- * @param string        $feature    Name of the feature to check support for.
+ * @param array         $feature    Path to the specific feature to check support for.
  * @param mixed         $default    Optional. Fallback value for feature support. Default false.
  * @return bool Whether the feature is supported.
  */


### PR DESCRIPTION
In the docs of `block_has_support()` the type of `$feature` is `string`, should be `array`.

Trac ticket: https://core.trac.wordpress.org/ticket/56307

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
