### PR TITLE
#50197 filename should be a string so seems_utf8 doesn't output a warning

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2012,7 +2012,7 @@ function remove_accents( $string, $locale = '' ) {
  */
 function sanitize_file_name( $filename ) {
 	$filename_raw = $filename;
-	$filename     = remove_accents( $filename );
+	$filename     = remove_accents( (string)$filename );
 
 	$special_chars = array( '?', '[', ']', '/', '\\', '=', '<', '>', ':', ';', ',', "'", '"', '&', '$', '#', '*', '(', ')', '|', '~', '`', '!', '{', '}', '%', '+', '’', '«', '»', '”', '“', chr( 0 ) );
 


### PR DESCRIPTION
I've come across the issue of integers passed to '_seems_utf8_' for validation and as a result PHP outputs a warning. 

To preface the solution, I agree that seems_utf8 shouldn't be responsible for string conversions. 

The function '_sanitize_file_name_' that is calling it though (in my case) is already making string conversions to normalize the param. This param is supposed to be a filename so making sure it is a string to begin with is only reasonable. 


Trac ticket: https://core.trac.wordpress.org/ticket/50197
