### PR TITLE
Implement new timeout/duration/expiration format.

### DIFF
--- a/src/wp-admin/includes/class-wp-debug-data.php
+++ b/src/wp-admin/includes/class-wp-debug-data.php
@@ -1597,7 +1597,7 @@ class WP_Debug_Data {
 		// The max_execution_time defaults to 0 when PHP runs from cli.
 		// We still want to limit it below.
 		if ( empty( $max_execution_time ) ) {
-			$max_execution_time = 30;
+			$max_execution_time = 30; // 30 seconds.
 		}
 
 		if ( $max_execution_time > 20 ) {

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -2026,7 +2026,7 @@ class WP_Site_Health {
 		);
 
 		$cookies = wp_unslash( $_COOKIE );
-		$timeout = 10;
+		$timeout = 10; // 10 seconds.
 		$headers = array(
 			'Cache-Control' => 'no-cache',
 			'X-WP-Nonce'    => wp_create_nonce( 'wp_rest' ),
@@ -2656,7 +2656,7 @@ class WP_Site_Health {
 	public function can_perform_loopback() {
 		$body    = array( 'site-health' => 'loopback-test' );
 		$cookies = wp_unslash( $_COOKIE );
-		$timeout = 10;
+		$timeout = 10; // 10 seconds.
 		$headers = array(
 			'Cache-Control' => 'no-cache',
 		);

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -539,10 +539,10 @@ function wp_edit_theme_plugin_file( $args ) {
 		}
 
 		// Make sure PHP process doesn't die before loopback requests complete.
-		set_time_limit( 300 );
+		set_time_limit( 5 * MINUTE_IN_SECONDS );
 
 		// Time to wait for loopback requests to finish.
-		$timeout = 100;
+		$timeout = 100; // 100 seconds.
 
 		$needle_start = "###### wp_scraping_result_start:$scrape_key ######";
 		$needle_end   = "###### wp_scraping_result_end:$scrape_key ######";
@@ -2007,10 +2007,10 @@ function WP_Filesystem( $args = false, $context = false, $allow_relaxed_file_own
 	 * to allow for per-transport overriding of the default.
 	 */
 	if ( ! defined( 'FS_CONNECT_TIMEOUT' ) ) {
-		define( 'FS_CONNECT_TIMEOUT', MINUTE_IN_SECONDS / 2 );
+		define( 'FS_CONNECT_TIMEOUT', 30 ); // 30 seconds.
 	}
 	if ( ! defined( 'FS_TIMEOUT' ) ) {
-		define( 'FS_TIMEOUT', MINUTE_IN_SECONDS / 2 );
+		define( 'FS_TIMEOUT', 30 ); // 30 seconds.
 	}
 
 	if ( is_wp_error( $wp_filesystem->errors ) && $wp_filesystem->errors->has_errors() ) {

--- a/src/wp-admin/options-permalink.php
+++ b/src/wp-admin/options-permalink.php
@@ -203,7 +203,7 @@ if ( $structure_updated ) {
 		add_settings_error( 'general', 'settings_updated', $message, 'success' );
 	}
 
-	set_transient( 'settings_errors', get_settings_errors(), MINUTE_IN_SECONDS / 2 );
+	set_transient( 'settings_errors', get_settings_errors(), 30 ); // 30 seconds.
 
 	wp_redirect( admin_url( 'options-permalink.php?settings-updated=true' ) );
 	exit;

--- a/src/wp-admin/options.php
+++ b/src/wp-admin/options.php
@@ -345,7 +345,7 @@ if ( 'update' === $action ) { // We are saving settings sent from a settings pag
 		add_settings_error( 'general', 'settings_updated', __( 'Settings saved.' ), 'success' );
 	}
 
-	set_transient( 'settings_errors', get_settings_errors(), MINUTE_IN_SECONDS / 2 );
+	set_transient( 'settings_errors', get_settings_errors(), 30 ); // 30 seconds.
 
 	// Redirect back to the settings page that was submitted.
 	$goback = add_query_arg( 'settings-updated', 'true', wp_get_referer() );

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -405,7 +405,7 @@ function wp_update_plugins( $extra_stats = array() ) {
 	$locales = array_unique( $locales );
 
 	if ( $doing_cron ) {
-		$timeout = 30;
+		$timeout = 30; // 30 seconds.
 	} else {
 		// Three seconds, plus one extra second for every 10 plugins.
 		$timeout = 3 + (int) ( count( $plugins ) / 10 );
@@ -686,7 +686,7 @@ function wp_update_themes( $extra_stats = array() ) {
 	$locales = array_unique( $locales );
 
 	if ( $doing_cron ) {
-		$timeout = 30;
+		$timeout = 30; // 30 seconds.
 	} else {
 		// Three seconds, plus one extra second for every 10 themes.
 		$timeout = 3 + (int) ( count( $themes ) / 10 );


### PR DESCRIPTION
- If the value can be represented as an integer (not a fractional) number of minutes (hours, etc.), use the appropriate constant multiplied by that number.
- Otherwise, keep the value as is and add a comment with the units for clarity.

Trac ticket: https://core.trac.wordpress.org/ticket/56293