### PR TITLE
(Refresh) Fix Windows paths resulting from get_attached_file

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -2070,7 +2070,7 @@ function wp_mkdir_p( $target ) {
  * For example, '/foo/bar', or 'c:\windows'.
  *
  * @since 2.5.0
- * @since 6.0.0 Allows normalized Windows paths (forward slashes).
+ * @since 6.1.0 Allows normalized Windows paths (forward slashes).
  *
  * @param string $path File path.
  * @return bool True if path is absolute, false is not absolute.

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -2070,7 +2070,7 @@ function wp_mkdir_p( $target ) {
  * For example, '/foo/bar', or 'c:\windows'.
  *
  * @since 2.5.0
- * @since 6.0.0 Allows Windows normalized paths (forward slashes).
+ * @since 6.0.0 Allows normalized Windows paths (forward slashes).
  *
  * @param string $path File path.
  * @return bool True if path is absolute, false is not absolute.
@@ -2101,7 +2101,7 @@ function path_is_absolute( $path ) {
 		return true;
 	}
 
-	// Windows normalized paths for local filesystem and network shares (forward slashes).
+	// Normalized Windows paths for local filesystem and network shares (forward slashes).
 	if ( preg_match( '#(^[a-zA-Z]+:/|^//[\w!@\#\$%\^\(\)\-\'{}\.~]{1,15})#', $path ) ) {
 		return true;
 	}

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -2070,6 +2070,7 @@ function wp_mkdir_p( $target ) {
  * For example, '/foo/bar', or 'c:\windows'.
  *
  * @since 2.5.0
+ * @since 6.0.0 Allows Windows normalized paths (forward slashes).
  *
  * @param string $path File path.
  * @return bool True if path is absolute, false is not absolute.
@@ -2097,6 +2098,11 @@ function path_is_absolute( $path ) {
 
 	// Windows allows absolute paths like this.
 	if ( preg_match( '#^[a-zA-Z]:\\\\#', $path ) ) {
+		return true;
+	}
+
+	// Windows normalized paths for local filesystem and network shares (forward slashes).
+	if ( preg_match( '#(^[a-zA-Z]+:/|^//[\w!@\#\$%\^\(\)\-\'{}\.~]{1,15})#', $path ) ) {
 		return true;
 	}
 

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -722,10 +722,11 @@ function get_attached_file( $attachment_id, $unfiltered = false ) {
 	$file = get_post_meta( $attachment_id, '_wp_attached_file', true );
 
 	// If the file is relative, prepend upload dir.
-	if ( $file && 0 !== strpos( $file, '/' ) && ! preg_match( '|^.:\\\|', $file ) ) {
+	if ( $file ) {
 		$uploads = wp_get_upload_dir();
+
 		if ( false === $uploads['error'] ) {
-			$file = $uploads['basedir'] . "/$file";
+			$file = path_join( $uploads['basedir'], $file );
 		}
 	}
 

--- a/tests/phpunit/tests/functions.php
+++ b/tests/phpunit/tests/functions.php
@@ -105,6 +105,13 @@ class Tests_Functions extends WP_UnitTestCase {
 			'C:\\',
 			'C:\\WINDOWS',
 			'\\\\sambashare\\foo',
+			'c:/',
+			'c://',
+			'//',
+			'c:/FOO',
+			'//FOO',
+			'C:/WWW/Sites/demo/htdocs/wordpress/wp-content/uploads/2016/03/example.jpg',
+			'//ComputerName/ShareName/SubfolderName/example.txt',
 		);
 		foreach ( $absolute_paths as $path ) {
 			$this->assertTrue( path_is_absolute( $path ), "path_is_absolute('$path') should return true" );
@@ -119,10 +126,14 @@ class Tests_Functions extends WP_UnitTestCase {
 			'../foo',
 			'../',
 			'../foo.bar',
+			'foo.bar',
 			'foo/bar',
 			'foo',
 			'FOO',
 			'..\\WINDOWS',
+			'..//WINDOWS',
+			'c:',
+			'C:',
 		);
 		foreach ( $relative_paths as $path ) {
 			$this->assertFalse( path_is_absolute( $path ), "path_is_absolute('$path') should return false" );

--- a/tests/phpunit/tests/post.php
+++ b/tests/phpunit/tests/post.php
@@ -1800,7 +1800,7 @@ class Tests_Post extends WP_UnitTestCase {
 
 	/**
 	 * Testing the wp_get_attached_file() function.
-	 *
+	 * @covers ::wp_get_attached_file
 	 * @ticket 36308
 	 */
 	public function test_wp_get_attached_file() {

--- a/tests/phpunit/tests/post.php
+++ b/tests/phpunit/tests/post.php
@@ -1799,11 +1799,10 @@ class Tests_Post extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Testing the wp_get_attached_file() function.
-	 * @covers ::wp_get_attached_file
+	 * @covers ::get_attached_file
 	 * @ticket 36308
 	 */
-	public function test_wp_get_attached_file() {
+	public function test_get_attached_file() {
 		$post = self::factory()->post->create_and_get(
 			array(
 				'post_title' => 'example-page',

--- a/tests/phpunit/tests/post.php
+++ b/tests/phpunit/tests/post.php
@@ -1797,39 +1797,4 @@ class Tests_Post extends WP_UnitTestCase {
 		unstick_post( 3 );
 		$this->assertSameSets( array( 1, 2, 2 ), get_option( 'sticky_posts' ) );
 	}
-
-	/**
-	 * @covers ::get_attached_file
-	 * @ticket 36308
-	 */
-	public function test_get_attached_file() {
-		$post = self::factory()->post->create_and_get(
-			array(
-				'post_title' => 'example-page',
-				'post_type'  => 'post',
-			)
-		);
-
-		// Windows local file system path.
-		$attachment = self::factory()->attachment->create_and_get(
-			array(
-				'post_parent' => $post->ID,
-				'file'        => 'C:/WWW/Sites/demo/htdocs/wordpress/wp-content/uploads/2016/03/example.jpg',
-			)
-		);
-
-		$attachment_path = get_attached_file( $attachment->ID );
-		$this->assertSame( $attachment_path, 'C:/WWW/Sites/demo/htdocs/wordpress/wp-content/uploads/2016/03/example.jpg', 'Windows local filesystem paths should be equal' );
-
-		// Windows network shares path.
-		$attachment = self::factory()->attachment->create_and_get(
-			array(
-				'post_parent' => $post->ID,
-				'file'        => '//ComputerName/ShareName/SubfolderName/example.txt',
-			)
-		);
-
-		$attachment_path = get_attached_file( $attachment->ID );
-		$this->assertSame( $attachment_path, '//ComputerName/ShareName/SubfolderName/example.txt', 'Network share paths should be equal' );
-	}
 }

--- a/tests/phpunit/tests/post.php
+++ b/tests/phpunit/tests/post.php
@@ -1797,4 +1797,40 @@ class Tests_Post extends WP_UnitTestCase {
 		unstick_post( 3 );
 		$this->assertSameSets( array( 1, 2, 2 ), get_option( 'sticky_posts' ) );
 	}
+
+	/**
+	 * Testing the wp_get_attached_file() function.
+	 *
+	 * @ticket 36308
+	 */
+	public function test_wp_get_attached_file() {
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_title' => 'example-page',
+				'post_type'  => 'post',
+			)
+		);
+
+		// Windows local file system path.
+		$attachment = self::factory()->attachment->create_and_get(
+			array(
+				'post_parent' => $post->ID,
+				'file'        => 'C:/WWW/Sites/demo/htdocs/wordpress/wp-content/uploads/2016/03/example.jpg',
+			)
+		);
+
+		$attachment_path = get_attached_file( $attachment->ID );
+		$this->assertSame( $attachment_path, 'C:/WWW/Sites/demo/htdocs/wordpress/wp-content/uploads/2016/03/example.jpg', 'Windows local filesystem paths should be equal' );
+
+		// Windows network shares path.
+		$attachment = self::factory()->attachment->create_and_get(
+			array(
+				'post_parent' => $post->ID,
+				'file'        => '//ComputerName/ShareName/SubfolderName/example.txt',
+			)
+		);
+
+		$attachment_path = get_attached_file( $attachment->ID );
+		$this->assertSame( $attachment_path, '//ComputerName/ShareName/SubfolderName/example.txt', 'Network share paths should be equal' );
+	}
 }

--- a/tests/phpunit/tests/post/getAttachedFile.php
+++ b/tests/phpunit/tests/post/getAttachedFile.php
@@ -5,6 +5,24 @@
  * @covers ::get_attached_file
  */
 class Tests_Post_GetAttachedFile extends WP_UnitTestCase {
+	/**
+	 * Post
+	 *
+	 * @var WP_Post
+	 */
+	protected static $post;
+
+	/**
+	 * Create shared fixtures.
+	 */
+	public static function set_up_before_class() {
+		self::$post = self::factory()->post->create_and_get(
+			array(
+				'post_title' => 'example-page',
+				'post_type'  => 'post',
+			)
+		);
+	}
 
 	/**
 	 * @ticket 36308
@@ -16,16 +34,9 @@ class Tests_Post_GetAttachedFile extends WP_UnitTestCase {
 	 * @param string $message  The message when an assertion fails.
 	 */
 	public function test_get_attached_file_with_windows_paths( $file, $expected, $message ) {
-		$post = self::factory()->post->create_and_get(
-			array(
-				'post_title' => 'example-page',
-				'post_type'  => 'post',
-			)
-		);
-
 		$attachment = self::factory()->attachment->create_and_get(
 			array(
-				'post_parent' => $post->ID,
+				'post_parent' => self::$post->ID,
 				'file'        => $file,
 			)
 		);

--- a/tests/phpunit/tests/post/getAttachedFile.php
+++ b/tests/phpunit/tests/post/getAttachedFile.php
@@ -8,8 +8,14 @@ class Tests_Post_GetAttachedFile extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 36308
+	 *
+	 * @dataProvider data_get_attached_file_with_windows_paths
+	 *
+	 * @param string $file     The file path to attach to the post.
+	 * @param string $expected The expected attached file path.
+	 * @param string $message  The message when an assertion fails.
 	 */
-	public function test_get_attached_file_with_windows_paths() {
+	public function test_get_attached_file_with_windows_paths( $file, $expected, $message ) {
 		$post = self::factory()->post->create_and_get(
 			array(
 				'post_title' => 'example-page',
@@ -17,32 +23,33 @@ class Tests_Post_GetAttachedFile extends WP_UnitTestCase {
 			)
 		);
 
-		// Windows local file system path.
 		$attachment = self::factory()->attachment->create_and_get(
 			array(
 				'post_parent' => $post->ID,
-				'file'        => 'C:/WWW/Sites/demo/htdocs/wordpress/wp-content/uploads/2016/03/example.jpg',
+				'file'        => $file,
 			)
 		);
 
-		$this->assertSame(
-			'C:/WWW/Sites/demo/htdocs/wordpress/wp-content/uploads/2016/03/example.jpg',
-			get_attached_file( $attachment->ID ),
-			'Windows local filesystem paths should be equal'
-		);
+		$this->assertSame( $expected, get_attached_file( $attachment->ID ), $message );
+	}
 
-		// Windows network shares path.
-		$attachment = self::factory()->attachment->create_and_get(
-			array(
-				'post_parent' => $post->ID,
-				'file'        => '//ComputerName/ShareName/SubfolderName/example.txt',
-			)
-		);
-
-		$this->assertSame(
-			'//ComputerName/ShareName/SubfolderName/example.txt',
-			get_attached_file( $attachment->ID ),
-			'Network share paths should be equal'
+	/**
+	 * Data provider with Windows paths.
+	 *
+	 * @return array
+	 */
+	public function data_get_attached_file_with_windows_paths() {
+		return array(
+			'a local path'         => array(
+				'file'     => 'C:/WWW/Sites/demo/htdocs/wordpress/wp-content/uploads/2016/03/example.jpg',
+				'expected' => 'C:/WWW/Sites/demo/htdocs/wordpress/wp-content/uploads/2016/03/example.jpg',
+				'message'  => 'Windows local filesystem paths should be equal',
+			),
+			'a network share path' => array(
+				'file'     => '//ComputerName/ShareName/SubfolderName/example.txt',
+				'expected' => '//ComputerName/ShareName/SubfolderName/example.txt',
+				'message'  => 'Network share paths should be equal',
+			),
 		);
 	}
 

--- a/tests/phpunit/tests/post/getAttachedFile.php
+++ b/tests/phpunit/tests/post/getAttachedFile.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @group post
+ * @covers ::get_attached_file
+ */
+class Tests_Post_GetAttachedFile extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 36308
+	 */
+	public function test_get_attached_file_with_windows_paths() {
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_title' => 'example-page',
+				'post_type'  => 'post',
+			)
+		);
+
+		// Windows local file system path.
+		$attachment = self::factory()->attachment->create_and_get(
+			array(
+				'post_parent' => $post->ID,
+				'file'        => 'C:/WWW/Sites/demo/htdocs/wordpress/wp-content/uploads/2016/03/example.jpg',
+			)
+		);
+
+		$attachment_path = get_attached_file( $attachment->ID );
+		$this->assertSame( $attachment_path, 'C:/WWW/Sites/demo/htdocs/wordpress/wp-content/uploads/2016/03/example.jpg', 'Windows local filesystem paths should be equal' );
+
+		// Windows network shares path.
+		$attachment = self::factory()->attachment->create_and_get(
+			array(
+				'post_parent' => $post->ID,
+				'file'        => '//ComputerName/ShareName/SubfolderName/example.txt',
+			)
+		);
+
+		$attachment_path = get_attached_file( $attachment->ID );
+		$this->assertSame( $attachment_path, '//ComputerName/ShareName/SubfolderName/example.txt', 'Network share paths should be equal' );
+	}
+
+}

--- a/tests/phpunit/tests/post/getAttachedFile.php
+++ b/tests/phpunit/tests/post/getAttachedFile.php
@@ -25,8 +25,11 @@ class Tests_Post_GetAttachedFile extends WP_UnitTestCase {
 			)
 		);
 
-		$attachment_path = get_attached_file( $attachment->ID );
-		$this->assertSame( $attachment_path, 'C:/WWW/Sites/demo/htdocs/wordpress/wp-content/uploads/2016/03/example.jpg', 'Windows local filesystem paths should be equal' );
+		$this->assertSame(
+			'C:/WWW/Sites/demo/htdocs/wordpress/wp-content/uploads/2016/03/example.jpg',
+			get_attached_file( $attachment->ID ),
+			'Windows local filesystem paths should be equal'
+		);
 
 		// Windows network shares path.
 		$attachment = self::factory()->attachment->create_and_get(
@@ -36,8 +39,11 @@ class Tests_Post_GetAttachedFile extends WP_UnitTestCase {
 			)
 		);
 
-		$attachment_path = get_attached_file( $attachment->ID );
-		$this->assertSame( $attachment_path, '//ComputerName/ShareName/SubfolderName/example.txt', 'Network share paths should be equal' );
+		$this->assertSame(
+			'//ComputerName/ShareName/SubfolderName/example.txt',
+			get_attached_file( $attachment->ID ),
+			'Network share paths should be equal'
+		);
 	}
 
 }


### PR DESCRIPTION
This PR refreshes [PR 2442](https://github.com/WordPress/wordpress-develop/pull/2442) to use a data provider to stabilise the new test method and use a shared post object for the tests.

Trac ticket: https://core.trac.wordpress.org/ticket/36308