### PR TITLE
get_block_templates() must return unique templates/template parts

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -696,7 +696,7 @@ function get_block_templates( $query = array(), $template_type = 'wp_template' )
 
 			$is_not_custom   = false === array_search(
 				wp_get_theme()->get_stylesheet() . '//' . $template_file['slug'],
-				array_column( $query_result, 'id' ),
+				wp_list_pluck( $query_result, 'id' ),
 				true
 			);
 			$fits_slug_query =

--- a/tests/phpunit/tests/blocks/getBlockTemplates.php
+++ b/tests/phpunit/tests/blocks/getBlockTemplates.php
@@ -19,7 +19,6 @@ class Tests_Blocks_GetBlockTemplates extends WP_UnitTestCase {
 	private static $template_part;
 
 	public static function wpSetUpBeforeClass() {
-
 		/**
 		 * This template has to have the same ID ("block-theme/index") as the template that is shipped with the
 		 * "block-theme" theme. This is needed for testing purposes.
@@ -35,8 +34,8 @@ class Tests_Blocks_GetBlockTemplates extends WP_UnitTestCase {
 				),
 			)
 		);
-		wp_set_post_terms( static::$template->ID, static::TEST_THEME, 'wp_theme' );
 
+		wp_set_post_terms( static::$template->ID, static::TEST_THEME, 'wp_theme' );
 
 		/**
 		 * This template part has to have the same ID ("block-theme/small-header") as the template part that is shipped with the
@@ -56,6 +55,7 @@ class Tests_Blocks_GetBlockTemplates extends WP_UnitTestCase {
 				),
 			)
 		);
+
 		wp_set_post_terms( self::$template_part->ID, WP_TEMPLATE_PART_AREA_HEADER, 'wp_template_part_area' );
 		wp_set_post_terms( self::$template_part->ID, static::TEST_THEME, 'wp_theme' );
 	}

--- a/tests/phpunit/tests/blocks/getBlockTemplates.php
+++ b/tests/phpunit/tests/blocks/getBlockTemplates.php
@@ -88,7 +88,7 @@ class Tests_Blocks_GetBlockTemplates extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_test_it_returns_unique_entities
 	 *
-	 * @param string $post_type The tempalte type.
+	 * @param string $template_type The tempalte type.
 	 * @param string $error_message An error message to display if the test fails.
 	 */
 	public function test_it_returns_unique_entities( $template_type, $error_message ) {

--- a/tests/phpunit/tests/blocks/getBlockTemplates.php
+++ b/tests/phpunit/tests/blocks/getBlockTemplates.php
@@ -1,40 +1,56 @@
 <?php
-
+/**
+ * @group blocks
+ *
+ * @covers ::get_block_templates
+ */
 class Tests_Blocks_GetBlockTemplates extends WP_UnitTestCase {
 
 	const TEST_THEME = 'block-theme';
+
+	/**
+	 * @var WP_Post
+	 */
+	private static $template;
+
+	/**
+	 * @var WP_Post
+	 */
+	private static $template_part;
 
 	public static function wpSetUpBeforeClass() {
 
 		// This template has to have the same ID ("block-theme/index") as the template that is shipped with the
 		// "block-theme" theme. This is needed for testing purposes.
-		$args             = array(
-			'post_type' => 'wp_template',
-			'post_name' => 'index',
-			'tax_input' => array(
-				'wp_theme' => array(
-					static::TEST_THEME,
+		static::$template = self::factory()->post->create_and_get(
+			array(
+				'post_type' => 'wp_template',
+				'post_name' => 'index',
+				'tax_input' => array(
+					'wp_theme' => array(
+						static::TEST_THEME,
+					),
 				),
-			),
+			)
 		);
-		static::$template = self::factory()->post->create_and_get( $args );
 		wp_set_post_terms( static::$template->ID, static::TEST_THEME, 'wp_theme' );
 
 		// This template part has to have the same ID ("block-theme/small-header") as the template that is shipped with the
 		// "block-theme" theme. This is needed for testing purposes.
-		$template_part_args  = array(
-			'post_type' => 'wp_template_part',
-			'post_name' => 'small-header',
-			'tax_input' => array(
-				'wp_theme'              => array(
-					static::TEST_THEME,
+		self::$template_part = self::factory()->post->create_and_get(
+			array(
+				'post_type' => 'wp_template_part',
+				'post_name' => 'small-header',
+				'tax_input' => array(
+					'wp_theme'              => array(
+						static::TEST_THEME,
+					),
+					'wp_template_part_area' => array(
+						WP_TEMPLATE_PART_AREA_HEADER,
+					),
 				),
-				'wp_template_part_area' => array(
-					WP_TEMPLATE_PART_AREA_HEADER,
-				),
-			),
+			)
 		);
-		self::$template_part = self::factory()->post->create_and_get( $template_part_args );
 		wp_set_post_terms( self::$template_part->ID, WP_TEMPLATE_PART_AREA_HEADER, 'wp_template_part_area' );
 		wp_set_post_terms( self::$template_part->ID, static::TEST_THEME, 'wp_theme' );
 	}
@@ -49,7 +65,33 @@ class Tests_Blocks_GetBlockTemplates extends WP_UnitTestCase {
 		switch_theme( static::TEST_THEME );
 	}
 
-	public function test_it_returns_unique_templates_and_template_parts() {
+	/**
+	 * Data provider for test_it_returns_unique_entities().
+	 *
+	 * @return array
+	 */
+	public function data_test_it_returns_unique_entities() {
+		return array(
+			'wp_template template type'      => array(
+				'template_type' => 'wp_template',
+				'error_message' => 'get_block_templates() must return unique templates.',
+			),
+			'wp_template_part template type' => array(
+				'template_type' => 'wp_template',
+				'error_message' => 'get_block_templates() must return unique template parts.',
+			),
+		);
+	}
+
+	/**
+	 * @ticket 56271
+	 *
+	 * @dataProvider data_test_it_returns_unique_entities
+	 *
+	 * @param string $post_type The tempalte type.
+	 * @param string $error_message An error message to display if the test fails.
+	 */
+	public function test_it_returns_unique_entities( $template_type, $error_message ) {
 		$templates    = get_block_templates( array(), 'wp_template' );
 		$template_ids = array_map(
 			static function( WP_Block_Template $template ) {
@@ -59,19 +101,6 @@ class Tests_Blocks_GetBlockTemplates extends WP_UnitTestCase {
 		);
 
 		$this->assertNotEmpty( $template_ids, 'get_block_templates() must return a non-empty value.' );
-		$this->assertSame( count( array_unique( $template_ids ) ), count( $template_ids ), 'get_block_templates() must return unique templates.' );
-	}
-
-	public function test_it_returns_unique_template_parts() {
-		$templates    = get_block_templates( array(), 'wp_template_part' );
-		$template_ids = array_map(
-			static function( WP_Block_Template $template ) {
-				return $template->id;
-			},
-			$templates
-		);
-
-		$this->assertNotEmpty( $template_ids, 'get_block_templates() must return a non-empty value.' );
-		$this->assertSame( count( array_unique( $template_ids ) ), count( $template_ids ), 'get_block_templates() must return unique template parts.' );
+		$this->assertSame( count( array_unique( $template_ids ) ), count( $template_ids ), $error_message );
 	}
 }

--- a/tests/phpunit/tests/blocks/getBlockTemplates.php
+++ b/tests/phpunit/tests/blocks/getBlockTemplates.php
@@ -35,7 +35,7 @@ class Tests_Blocks_GetBlockTemplates extends WP_UnitTestCase {
 		);
 		wp_set_post_terms( static::$template->ID, static::TEST_THEME, 'wp_theme' );
 
-		// This template part has to have the same ID ("block-theme/small-header") as the template that is shipped with the
+		// This template part has to have the same ID ("block-theme/small-header") as the template part that is shipped with the
 		// "block-theme" theme. This is needed for testing purposes.
 		self::$template_part = self::factory()->post->create_and_get(
 			array(

--- a/tests/phpunit/tests/blocks/getBlockTemplates.php
+++ b/tests/phpunit/tests/blocks/getBlockTemplates.php
@@ -93,12 +93,7 @@ class Tests_Blocks_GetBlockTemplates extends WP_UnitTestCase {
 	 */
 	public function test_it_returns_unique_entities( $template_type, $error_message ) {
 		$block_templates    = get_block_templates( array(), $template_type );
-		$block_template_ids = array_map(
-			static function( WP_Block_Template $block_template ) {
-				return $block_template->id;
-			},
-			$block_templates
-		);
+		$block_template_ids = wp_list_pluck( $block_templates, 'id' );
 
 		$this->assertNotEmpty( $block_template_ids, 'get_block_templates() must return a non-empty value.' );
 		$this->assertSame( count( array_unique( $block_template_ids ) ), count( $block_template_ids ), $error_message );

--- a/tests/phpunit/tests/blocks/getBlockTemplates.php
+++ b/tests/phpunit/tests/blocks/getBlockTemplates.php
@@ -20,8 +20,10 @@ class Tests_Blocks_GetBlockTemplates extends WP_UnitTestCase {
 
 	public static function wpSetUpBeforeClass() {
 
-		// This template has to have the same ID ("block-theme/index") as the template that is shipped with the
-		// "block-theme" theme. This is needed for testing purposes.
+		/**
+		 * This template has to have the same ID ("block-theme/index") as the template that is shipped with the
+		 * "block-theme" theme. This is needed for testing purposes.
+		 */
 		static::$template = self::factory()->post->create_and_get(
 			array(
 				'post_type' => 'wp_template',
@@ -35,8 +37,11 @@ class Tests_Blocks_GetBlockTemplates extends WP_UnitTestCase {
 		);
 		wp_set_post_terms( static::$template->ID, static::TEST_THEME, 'wp_theme' );
 
-		// This template part has to have the same ID ("block-theme/small-header") as the template part that is shipped with the
-		// "block-theme" theme. This is needed for testing purposes.
+
+		/**
+		 * This template part has to have the same ID ("block-theme/small-header") as the template part that is shipped with the
+		 * "block-theme" theme. This is needed for testing purposes.
+		 */
 		self::$template_part = self::factory()->post->create_and_get(
 			array(
 				'post_type' => 'wp_template_part',
@@ -90,9 +95,9 @@ class Tests_Blocks_GetBlockTemplates extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_test_it_returns_unique_entities
 	 *
-	 * @param string $template_type The template type.
+	 * @param string $template_type        The template type.
 	 * @param string $original_template_id ID (slug) of the default entity.
-	 * @param string $error_message An error message to display if the test fails.
+	 * @param string $error_message        An error message to display if the test fails.
 	 */
 	public function test_it_returns_unique_entities( $template_type, $original_template_id, $error_message ) {
 		$original_template = _get_block_template_file( $template_type, $original_template_id );

--- a/tests/phpunit/tests/blocks/getBlockTemplates.php
+++ b/tests/phpunit/tests/blocks/getBlockTemplates.php
@@ -73,12 +73,14 @@ class Tests_Blocks_GetBlockTemplates extends WP_UnitTestCase {
 	public function data_test_it_returns_unique_entities() {
 		return array(
 			'wp_template template type'      => array(
-				'template_type' => 'wp_template',
-				'error_message' => 'get_block_templates() must return unique templates.',
+				'template_type'        => 'wp_template',
+				'original_template_id' => 'index',
+				'error_message'        => 'get_block_templates() must return unique templates.',
 			),
 			'wp_template_part template type' => array(
-				'template_type' => 'wp_template_part',
-				'error_message' => 'get_block_templates() must return unique template parts.',
+				'template_type'        => 'wp_template_part',
+				'original_template_id' => 'small-header',
+				'error_message'        => 'get_block_templates() must return unique template parts.',
 			),
 		);
 	}
@@ -89,9 +91,13 @@ class Tests_Blocks_GetBlockTemplates extends WP_UnitTestCase {
 	 * @dataProvider data_test_it_returns_unique_entities
 	 *
 	 * @param string $template_type The template type.
+	 * @param string $original_template_id ID (slug) of the default entity.
 	 * @param string $error_message An error message to display if the test fails.
 	 */
-	public function test_it_returns_unique_entities( $template_type, $error_message ) {
+	public function test_it_returns_unique_entities( $template_type, $original_template_id, $error_message ) {
+		$original_template = _get_block_template_file( $template_type, $original_template_id );
+		$this->assertNotEmpty( $original_template, 'An original (non-duplicate) template must exist for this test to work correctly.' );
+
 		$block_templates = get_block_templates( array(), $template_type );
 		$this->assertNotEmpty( $block_templates, 'get_block_templates() must return a non-empty value.' );
 

--- a/tests/phpunit/tests/blocks/getBlockTemplates.php
+++ b/tests/phpunit/tests/blocks/getBlockTemplates.php
@@ -92,15 +92,15 @@ class Tests_Blocks_GetBlockTemplates extends WP_UnitTestCase {
 	 * @param string $error_message An error message to display if the test fails.
 	 */
 	public function test_it_returns_unique_entities( $template_type, $error_message ) {
-		$templates    = get_block_templates( array(), $template_type );
-		$template_ids = array_map(
-			static function( WP_Block_Template $template ) {
-				return $template->id;
+		$block_templates    = get_block_templates( array(), $template_type );
+		$block_template_ids = array_map(
+			static function( WP_Block_Template $block_template ) {
+				return $block_template->id;
 			},
-			$templates
+			$block_templates
 		);
 
-		$this->assertNotEmpty( $template_ids, 'get_block_templates() must return a non-empty value.' );
-		$this->assertSame( count( array_unique( $template_ids ) ), count( $template_ids ), $error_message );
+		$this->assertNotEmpty( $block_template_ids, 'get_block_templates() must return a non-empty value.' );
+		$this->assertSame( count( array_unique( $block_template_ids ) ), count( $block_template_ids ), $error_message );
 	}
 }

--- a/tests/phpunit/tests/blocks/getBlockTemplates.php
+++ b/tests/phpunit/tests/blocks/getBlockTemplates.php
@@ -6,10 +6,9 @@ class Tests_Blocks_GetBlockTemplates extends WP_UnitTestCase {
 
 	public static function wpSetUpBeforeClass() {
 
-		// This custom template has to be created for testing purposes.
-		// It has the same ID ("wp_block/index") as the template that is shipped with the
-		// wp_block theme.
-		$args = array(
+		// This template has to have the same ID ("block-theme/index") as the template that is shipped with the
+		// "block-theme" theme. This is needed for testing purposes.
+		$args             = array(
 			'post_type' => 'wp_template',
 			'post_name' => 'index',
 			'tax_input' => array(
@@ -18,8 +17,31 @@ class Tests_Blocks_GetBlockTemplates extends WP_UnitTestCase {
 				),
 			),
 		);
-		$post = self::factory()->post->create_and_get( $args );
-		wp_set_post_terms( $post->ID, static::TEST_THEME, 'wp_theme' );
+		static::$template = self::factory()->post->create_and_get( $args );
+		wp_set_post_terms( static::$template->ID, static::TEST_THEME, 'wp_theme' );
+
+		// This template part has to have the same ID ("block-theme/small-header") as the template that is shipped with the
+		// "block-theme" theme. This is needed for testing purposes.
+		$template_part_args  = array(
+			'post_type' => 'wp_template_part',
+			'post_name' => 'small-header',
+			'tax_input' => array(
+				'wp_theme'              => array(
+					static::TEST_THEME,
+				),
+				'wp_template_part_area' => array(
+					WP_TEMPLATE_PART_AREA_HEADER,
+				),
+			),
+		);
+		self::$template_part = self::factory()->post->create_and_get( $template_part_args );
+		wp_set_post_terms( self::$template_part->ID, WP_TEMPLATE_PART_AREA_HEADER, 'wp_template_part_area' );
+		wp_set_post_terms( self::$template_part->ID, static::TEST_THEME, 'wp_theme' );
+	}
+
+	public static function wpTearDownAfterClass() {
+		wp_delete_post( static::$template->ID );
+		wp_delete_post( static::$template_part->ID );
 	}
 
 	public function set_up() {
@@ -27,7 +49,7 @@ class Tests_Blocks_GetBlockTemplates extends WP_UnitTestCase {
 		switch_theme( static::TEST_THEME );
 	}
 
-	public function test_get_block_templates_returns_unique_templates() {
+	public function test_it_returns_unique_templates_and_template_parts() {
 		$templates    = get_block_templates( array(), 'wp_template' );
 		$template_ids = array_map(
 			static function( WP_Block_Template $template ) {
@@ -36,7 +58,20 @@ class Tests_Blocks_GetBlockTemplates extends WP_UnitTestCase {
 			$templates
 		);
 
-		$this->assertNotEmpty( $template_ids, 'get_block_templates must' );
+		$this->assertNotEmpty( $template_ids, 'get_block_templates() must return a non-empty value.' );
 		$this->assertSame( count( array_unique( $template_ids ) ), count( $template_ids ), 'get_block_templates() must return unique templates.' );
+	}
+
+	public function test_it_returns_unique_template_parts() {
+		$templates    = get_block_templates( array(), 'wp_template_part' );
+		$template_ids = array_map(
+			static function( WP_Block_Template $template ) {
+				return $template->id;
+			},
+			$templates
+		);
+
+		$this->assertNotEmpty( $template_ids, 'get_block_templates() must return a non-empty value.' );
+		$this->assertSame( count( array_unique( $template_ids ) ), count( $template_ids ), 'get_block_templates() must return unique template parts.' );
 	}
 }

--- a/tests/phpunit/tests/blocks/getBlockTemplates.php
+++ b/tests/phpunit/tests/blocks/getBlockTemplates.php
@@ -71,26 +71,6 @@ class Tests_Blocks_GetBlockTemplates extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Data provider for test_it_returns_unique_entities().
-	 *
-	 * @return array
-	 */
-	public function data_test_it_returns_unique_entities() {
-		return array(
-			'wp_template template type'      => array(
-				'template_type'        => 'wp_template',
-				'original_template_id' => 'index',
-				'error_message'        => 'get_block_templates() must return unique templates.',
-			),
-			'wp_template_part template type' => array(
-				'template_type'        => 'wp_template_part',
-				'original_template_id' => 'small-header',
-				'error_message'        => 'get_block_templates() must return unique template parts.',
-			),
-		);
-	}
-
-	/**
 	 * @ticket 56271
 	 *
 	 * @dataProvider data_test_it_returns_unique_entities
@@ -108,5 +88,25 @@ class Tests_Blocks_GetBlockTemplates extends WP_UnitTestCase {
 
 		$block_template_ids = wp_list_pluck( $block_templates, 'id' );
 		$this->assertSame( count( array_unique( $block_template_ids ) ), count( $block_template_ids ), $error_message );
+	}
+
+	/**
+	 * Data provider for test_it_returns_unique_entities().
+	 *
+	 * @return array
+	 */
+	public function data_test_it_returns_unique_entities() {
+		return array(
+			'wp_template template type'      => array(
+				'template_type'        => 'wp_template',
+				'original_template_id' => 'index',
+				'error_message'        => 'get_block_templates() must return unique templates.',
+			),
+			'wp_template_part template type' => array(
+				'template_type'        => 'wp_template_part',
+				'original_template_id' => 'small-header',
+				'error_message'        => 'get_block_templates() must return unique template parts.',
+			),
+		);
 	}
 }

--- a/tests/phpunit/tests/blocks/getBlockTemplates.php
+++ b/tests/phpunit/tests/blocks/getBlockTemplates.php
@@ -88,7 +88,7 @@ class Tests_Blocks_GetBlockTemplates extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_test_it_returns_unique_entities
 	 *
-	 * @param string $template_type The tempalte type.
+	 * @param string $template_type The template type.
 	 * @param string $error_message An error message to display if the test fails.
 	 */
 	public function test_it_returns_unique_entities( $template_type, $error_message ) {

--- a/tests/phpunit/tests/blocks/getBlockTemplates.php
+++ b/tests/phpunit/tests/blocks/getBlockTemplates.php
@@ -77,7 +77,7 @@ class Tests_Blocks_GetBlockTemplates extends WP_UnitTestCase {
 				'error_message' => 'get_block_templates() must return unique templates.',
 			),
 			'wp_template_part template type' => array(
-				'template_type' => 'wp_template',
+				'template_type' => 'wp_template_part',
 				'error_message' => 'get_block_templates() must return unique template parts.',
 			),
 		);

--- a/tests/phpunit/tests/blocks/getBlockTemplates.php
+++ b/tests/phpunit/tests/blocks/getBlockTemplates.php
@@ -92,7 +92,7 @@ class Tests_Blocks_GetBlockTemplates extends WP_UnitTestCase {
 	 * @param string $error_message An error message to display if the test fails.
 	 */
 	public function test_it_returns_unique_entities( $template_type, $error_message ) {
-		$templates    = get_block_templates( array(), 'wp_template' );
+		$templates    = get_block_templates( array(), $template_type );
 		$template_ids = array_map(
 			static function( WP_Block_Template $template ) {
 				return $template->id;

--- a/tests/phpunit/tests/blocks/getBlockTemplates.php
+++ b/tests/phpunit/tests/blocks/getBlockTemplates.php
@@ -92,10 +92,10 @@ class Tests_Blocks_GetBlockTemplates extends WP_UnitTestCase {
 	 * @param string $error_message An error message to display if the test fails.
 	 */
 	public function test_it_returns_unique_entities( $template_type, $error_message ) {
-		$block_templates    = get_block_templates( array(), $template_type );
-		$block_template_ids = wp_list_pluck( $block_templates, 'id' );
+		$block_templates = get_block_templates( array(), $template_type );
+		$this->assertNotEmpty( $block_templates, 'get_block_templates() must return a non-empty value.' );
 
-		$this->assertNotEmpty( $block_template_ids, 'get_block_templates() must return a non-empty value.' );
+		$block_template_ids = wp_list_pluck( $block_templates, 'id' );
 		$this->assertSame( count( array_unique( $block_template_ids ) ), count( $block_template_ids ), $error_message );
 	}
 }

--- a/tests/phpunit/tests/blocks/getBlockTemplates.php
+++ b/tests/phpunit/tests/blocks/getBlockTemplates.php
@@ -1,0 +1,42 @@
+<?php
+
+class Tests_Blocks_GetBlockTemplates extends WP_UnitTestCase {
+
+	const TEST_THEME = 'block-theme';
+
+	public static function wpSetUpBeforeClass() {
+
+		// This custom template has to be created for testing purposes.
+		// It has the same ID ("wp_block/index") as the template that is shipped with the
+		// wp_block theme.
+		$args = array(
+			'post_type' => 'wp_template',
+			'post_name' => 'index',
+			'tax_input' => array(
+				'wp_theme' => array(
+					static::TEST_THEME,
+				),
+			),
+		);
+		$post = self::factory()->post->create_and_get( $args );
+		wp_set_post_terms( $post->ID, static::TEST_THEME, 'wp_theme' );
+	}
+
+	public function set_up() {
+		parent::set_up();
+		switch_theme( static::TEST_THEME );
+	}
+
+	public function test_get_block_templates_returns_unique_templates() {
+		$templates    = get_block_templates( array(), 'wp_template' );
+		$template_ids = array_map(
+			static function( WP_Block_Template $template ) {
+				return $template->id;
+			},
+			$templates
+		);
+
+		$this->assertNotEmpty( $template_ids, 'get_block_templates must' );
+		$this->assertSame( count( array_unique( $template_ids ) ), count( $template_ids ), 'get_block_templates() must return unique templates.' );
+	}
+}

--- a/tests/phpunit/tests/blocks/getBlockTemplates.php
+++ b/tests/phpunit/tests/blocks/getBlockTemplates.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @group blocks
+ * @group block-templates
  *
  * @covers ::get_block_templates
  */
@@ -18,7 +18,9 @@ class Tests_Blocks_GetBlockTemplates extends WP_UnitTestCase {
 	 */
 	private static $template_part;
 
-	public static function wpSetUpBeforeClass() {
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
 		/**
 		 * This template has to have the same ID ("block-theme/index") as the template that is shipped with the
 		 * "block-theme" theme. This is needed for testing purposes.
@@ -60,9 +62,11 @@ class Tests_Blocks_GetBlockTemplates extends WP_UnitTestCase {
 		wp_set_post_terms( self::$template_part->ID, static::TEST_THEME, 'wp_theme' );
 	}
 
-	public static function wpTearDownAfterClass() {
+	public static function tear_down_after_class() {
 		wp_delete_post( static::$template->ID );
 		wp_delete_post( static::$template_part->ID );
+
+		parent::tear_down_after_class();
 	}
 
 	public function set_up() {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This PR aims to fix a bug in the `get_block_templates()` method.
`array_column` doesn't work correctly with an array of objects on PHP <= 5.6. So, under certain circumstances, `get_block_templates()` could return entities with the same ID (slug).
A regression unit test (included in this PR) should prevent this from happening in the future.

Trac ticket: https://core.trac.wordpress.org/ticket/56271
Steps to test this PR: https://core.trac.wordpress.org/ticket/56271#comment:18

Props to @darrencoutts118 for the original fix (see https://github.com/WordPress/wordpress-develop/pull/3010).
Props to @costdev for code reviews/valuable feedback.
My contribution was to write unit tests to make sure that the bug would not happen again.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
