### PR TITLE
Prevent upscaling an image past its original size.

### DIFF
--- a/src/js/_enqueues/lib/image-edit.js
+++ b/src/js/_enqueues/lib/image-edit.js
@@ -226,7 +226,8 @@
 	 */
 	scaleChanged : function( postid, x, el ) {
 		var w = $('#imgedit-scale-width-' + postid), h = $('#imgedit-scale-height-' + postid),
-		warn = $('#imgedit-scale-warn-' + postid), w1 = '', h1 = '';
+		warn = $('#imgedit-scale-warn-' + postid), w1 = '', h1 = '',
+		scaleBtn = $('#imgedit-scale-button');
 
 		if ( false === this.validateNumeric( el ) ) {
 			return;
@@ -242,8 +243,10 @@
 
 		if ( ( h1 && h1 > this.hold.oh ) || ( w1 && w1 > this.hold.ow ) ) {
 			warn.css('visibility', 'visible');
+			scaleBtn.prop('disabled', true);
 		} else {
 			warn.css('visibility', 'hidden');
+			scaleBtn.prop('disabled', false);
 		}
 	},
 

--- a/src/wp-admin/includes/image-edit.php
+++ b/src/wp-admin/includes/image-edit.php
@@ -845,23 +845,30 @@ function wp_save_image( $post_id ) {
 	$target  = ! empty( $_REQUEST['target'] ) ? preg_replace( '/[^a-z0-9_-]+/i', '', $_REQUEST['target'] ) : '';
 	$scale   = ! empty( $_REQUEST['do'] ) && 'scale' === $_REQUEST['do'];
 
-	if ( $scale && $fwidth > 0 && $fheight > 0 ) {
+	if ( $scale ) {
 		$size = $img->get_size();
 		$sX   = $size['width'];
 		$sY   = $size['height'];
 
-		// Check if it has roughly the same w / h ratio.
-		$diff = round( $sX / $sY, 2 ) - round( $fwidth / $fheight, 2 );
-		if ( -0.1 < $diff && $diff < 0.1 ) {
-			// Scale the full size image.
-			if ( $img->resize( $fwidth, $fheight ) ) {
-				$scaled = true;
-			}
+		if ( $sX < $fwidth || $sY < $fheight ) {
+			$return->error = esc_js( __( 'Images cannot be scaled to a size larger than the original.' ) );
+			return $return;
 		}
 
-		if ( ! $scaled ) {
-			$return->error = esc_js( __( 'Error while saving the scaled image. Please reload the page and try again.' ) );
-			return $return;
+		if ( $fwidth > 0 && $fheight > 0 ) {
+			// Check if it has roughly the same w / h ratio.
+			$diff = round( $sX / $sY, 2 ) - round( $fwidth / $fheight, 2 );
+			if ( -0.1 < $diff && $diff < 0.1 ) {
+				// Scale the full size image.
+				if ( $img->resize( $fwidth, $fheight ) ) {
+					$scaled = true;
+				}
+			}
+
+			if ( ! $scaled ) {
+				$return->error = esc_js( __( 'Error while saving the scaled image. Please reload the page and try again.' ) );
+				return $return;
+			}
 		}
 	} elseif ( ! empty( $_REQUEST['history'] ) ) {
 		$changes = json_decode( wp_unslash( $_REQUEST['history'] ) );


### PR DESCRIPTION
This adjusts the logic for the edit image screen in the admin to prevent an image from being scaled larger than the original.

Trac ticket: https://core.trac.wordpress.org/ticket/26381.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
