### PR TITLE
Remove s.w.org DNS prefetch

### DIFF
--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -3317,13 +3317,6 @@ function wp_resource_hints() {
 		'prerender'    => array(),
 	);
 
-	/*
-	 * Add DNS prefetch for the Emoji CDN.
-	 * The path is removed in the foreach loop below.
-	 */
-	/** This filter is documented in wp-includes/formatting.php */
-	$hints['dns-prefetch'][] = apply_filters( 'emoji_svg_url', 'https://s.w.org/images/core/emoji/13.0.0/svg/' );
-
 	foreach ( $hints as $relation_type => $urls ) {
 		$unique_urls = array();
 

--- a/tests/phpunit/tests/general/wpResourceHints.php
+++ b/tests/phpunit/tests/general/wpResourceHints.php
@@ -30,17 +30,8 @@ class Tests_General_wpResourceHints extends WP_UnitTestCase {
 		parent::tear_down();
 	}
 
-	public function test_should_have_defaults_on_frontend() {
-		$expected = "<link rel='dns-prefetch' href='//s.w.org' />\n";
-
-		$this->expectOutputString( $expected );
-
-		wp_resource_hints();
-	}
-
 	public function test_dns_prefetching() {
-		$expected = "<link rel='dns-prefetch' href='//s.w.org' />\n" .
-					"<link rel='dns-prefetch' href='//wordpress.org' />\n" .
+		$expected = "<link rel='dns-prefetch' href='//wordpress.org' />\n" .
 					"<link rel='dns-prefetch' href='//google.com' />\n" .
 					"<link rel='dns-prefetch' href='//make.wordpress.org' />\n";
 
@@ -70,8 +61,7 @@ class Tests_General_wpResourceHints extends WP_UnitTestCase {
 	 * @ticket 37652
 	 */
 	public function test_preconnect() {
-		$expected = "<link rel='dns-prefetch' href='//s.w.org' />\n" .
-					"<link rel='preconnect' href='//wordpress.org' />\n" .
+		$expected = "<link rel='preconnect' href='//wordpress.org' />\n" .
 					"<link rel='preconnect' href='https://make.wordpress.org' />\n" .
 					"<link rel='preconnect' href='http://google.com' />\n" .
 					"<link rel='preconnect' href='http://w.org' />\n";
@@ -98,8 +88,7 @@ class Tests_General_wpResourceHints extends WP_UnitTestCase {
 	}
 
 	public function test_prerender() {
-		$expected = "<link rel='dns-prefetch' href='//s.w.org' />\n" .
-					"<link rel='prerender' href='https://make.wordpress.org/great-again' />\n" .
+		$expected = "<link rel='prerender' href='https://make.wordpress.org/great-again' />\n" .
 					"<link rel='prerender' href='http://jobs.wordpress.net' />\n" .
 					"<link rel='prerender' href='//core.trac.wordpress.org' />\n";
 
@@ -124,8 +113,7 @@ class Tests_General_wpResourceHints extends WP_UnitTestCase {
 	}
 
 	public function test_parse_url_dns_prefetch() {
-		$expected = "<link rel='dns-prefetch' href='//s.w.org' />\n" .
-					"<link rel='dns-prefetch' href='//make.wordpress.org' />\n";
+		$expected = "<link rel='dns-prefetch' href='//make.wordpress.org' />\n";
 
 		add_filter( 'wp_resource_hints', array( $this, 'add_dns_prefetch_long_urls' ), 10, 2 );
 
@@ -145,8 +133,7 @@ class Tests_General_wpResourceHints extends WP_UnitTestCase {
 	}
 
 	public function test_dns_prefetch_styles() {
-		$expected = "<link rel='dns-prefetch' href='//fonts.googleapis.com' />\n" .
-					"<link rel='dns-prefetch' href='//s.w.org' />\n";
+		$expected = "<link rel='dns-prefetch' href='//fonts.googleapis.com' />\n";
 
 		$args = array(
 			'family' => 'Open+Sans:400',
@@ -164,8 +151,7 @@ class Tests_General_wpResourceHints extends WP_UnitTestCase {
 	}
 
 	public function test_dns_prefetch_scripts() {
-		$expected = "<link rel='dns-prefetch' href='//fonts.googleapis.com' />\n" .
-					"<link rel='dns-prefetch' href='//s.w.org' />\n";
+		$expected = "<link rel='dns-prefetch' href='//fonts.googleapis.com' />\n";
 
 		$args = array(
 			'family' => 'Open+Sans:400',
@@ -185,7 +171,7 @@ class Tests_General_wpResourceHints extends WP_UnitTestCase {
 	 * @ticket 37385
 	 */
 	public function test_dns_prefetch_scripts_does_not_include_registered_only() {
-		$expected   = "<link rel='dns-prefetch' href='//s.w.org' />\n";
+		$expected   = '';
 		$unexpected = "<link rel='dns-prefetch' href='//wordpress.org' />\n";
 
 		wp_register_script( 'jquery-elsewhere', 'https://wordpress.org/wp-includes/js/jquery/jquery.js' );
@@ -202,7 +188,7 @@ class Tests_General_wpResourceHints extends WP_UnitTestCase {
 	 * @ticket 37502
 	 */
 	public function test_deregistered_scripts_are_ignored() {
-		$expected = "<link rel='dns-prefetch' href='//s.w.org' />\n";
+		$expected = '';
 
 		wp_enqueue_script( 'test-script', 'http://example.org/script.js' );
 		wp_deregister_script( 'test-script' );
@@ -215,7 +201,7 @@ class Tests_General_wpResourceHints extends WP_UnitTestCase {
 	 * @ticket 37652
 	 */
 	public function test_malformed_urls() {
-		$expected = "<link rel='dns-prefetch' href='//s.w.org' />\n";
+		$expected = '';
 
 		// Errant colon.
 		add_filter( 'wp_resource_hints', array( $this, 'add_malformed_url_errant_colon' ), 10, 2 );
@@ -250,8 +236,7 @@ class Tests_General_wpResourceHints extends WP_UnitTestCase {
 	 * @ticket 38121
 	 */
 	public function test_custom_attributes() {
-		$expected = "<link rel='dns-prefetch' href='//s.w.org' />\n" .
-					"<link rel='preconnect' href='https://make.wordpress.org' />\n" .
+		$expected = "<link rel='preconnect' href='https://make.wordpress.org' />\n" .
 					"<link crossorigin as='image' pr='0.5' href='https://example.com/foo.jpeg' rel='prefetch' />\n" .
 					"<link crossorigin='use-credentials' as='style' href='https://example.com/foo.css' rel='prefetch' />\n" .
 					"<link href='http://wordpress.org' rel='prerender' />\n";


### PR DESCRIPTION
1. Remove `emoji_svg_url` prefetch from `wp_resource_hints()`.
2. Update unit tests in `Tests_General_wpResourceHints` (tests/phpunit/tests/general/wpResourceHints.php): remove `test_should_have_defaults_on_frontend()` entirely and remove s.w.org prefetch from expected output of ten other test functions.

Trac ticket: https://core.trac.wordpress.org/ticket/40426

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
