### PR TITLE
Editor: Ensure `has_blocks()` returns `false` and a `_doing_it_wrong()` notice when `get_post()` returns `null`.

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -431,7 +431,7 @@ function has_blocks( $post = null ) {
 				__FUNCTION__,
 				sprintf(
 					/* translators: %s: The $post variable. */
-					__( '%s is not a valid post.'),
+					__( '%s is not a valid post.' ),
 					'<code>$post</code>'
 				),
 				'6.1.0'

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -425,6 +425,21 @@ function unregister_block_type( $name ) {
 function has_blocks( $post = null ) {
 	if ( ! is_string( $post ) ) {
 		$wp_post = get_post( $post );
+
+		if ( null === $wp_post ) {
+			_doing_it_wrong(
+				__FUNCTION__,
+				sprintf(
+					/* translators: %s: The $post variable. */
+					__( '%s is not a valid post.'),
+					'<code>$post</code>'
+				),
+				'6.1.0'
+			);
+
+			return false;
+		}
+
 		if ( $wp_post instanceof WP_Post ) {
 			$post = $wp_post->post_content;
 		}

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -561,7 +561,7 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 	 */
 	public function test_has_blocks_with_invalid_post() {
 		$a_post = (object) array(
-			'ID' => 13585,
+			'ID'     => 13585,
 			'filter' => 'display',
 		);
 		$this->assertFalse( has_blocks( $a_post ) );

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -553,6 +553,18 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 55705
+	 *
+	 * @expectedIncorrectUsage has_blocks
+	 *
+	 * @covers ::has_blocks
+	 */
+	public function test_has_blocks_with_invalid_post() {
+		$a_post = (object) array( 'ID' => 13585, 'filter' => 'display' );
+		$this->assertFalse( has_blocks( $a_post ) );
+	}
+
+	/**
 	 * @ticket 49615
 	 */
 	public function test_filter_block_registration() {

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -560,7 +560,10 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 	 * @covers ::has_blocks
 	 */
 	public function test_has_blocks_with_invalid_post() {
-		$a_post = (object) array( 'ID' => 13585, 'filter' => 'display' );
+		$a_post = (object) array(
+			'ID' => 13585,
+			'filter' => 'display',
+		);
 		$this->assertFalse( has_blocks( $a_post ) );
 	}
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/55705

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
