### PR TITLE
Safeguard `has_blocks()` against fatal errors.

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -425,9 +425,12 @@ function unregister_block_type( $name ) {
 function has_blocks( $post = null ) {
 	if ( ! is_string( $post ) ) {
 		$wp_post = get_post( $post );
-		if ( $wp_post instanceof WP_Post ) {
-			$post = $wp_post->post_content;
+
+		if ( ! $wp_post instanceof WP_Post ) {
+			return false;
 		}
+
+		$post = $wp_post->post_content;
 	}
 
 	return false !== strpos( (string) $post, '<!-- wp:' );

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -553,6 +553,21 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that `has_blocks()` returns `false` with an invalid post.
+	 *
+	 * @ticket 55705
+	 *
+	 * @covers ::has_blocks
+	 */
+	public function test_has_blocks_with_invalid_post() {
+		$a_post = (object) array(
+			'ID'     => 55705,
+			'filter' => 'display',
+		);
+		$this->assertFalse( has_blocks( $a_post ) );
+	}
+
+	/**
 	 * @ticket 49615
 	 */
 	public function test_filter_block_registration() {


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/55705