### PR TITLE
Remove `_wp_image_belongs_to_attachment` function

### DIFF
--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -726,39 +726,6 @@ function _wp_make_additional_mime_types( $new_mime_types, $file, $image_meta, $a
 	return $image_meta;
 }
 
-
-/**
- * Check if an image belongs to an attachment.
- *
- * @since 6.1.0
- * @access private
- *
- * @param string $filename     Full path to the image file.
- * @param int   $attachment_id Attachment ID to check.
- * @return bool True if the image belongs to the attachment, false otherwise.
- */
-function _wp_image_belongs_to_attachment( $filename, $attachment_id ) {
-	$meta_data = wp_get_attachment_metadata( $attachment_id );
-
-	if ( ! isset( $image_meta['sizes'] ) ) {
-		return false;
-	}
-	$sizes = $image_meta['sizes'];
-	foreach ( $sizes as $size ) {
-		if ( $size['file'] === $filename ) {
-			return true;
-		}
-		if ( isset( $size['sources'] ) && is_array( $size['sources'] ) ) {
-			foreach ( $size['sources'] as $source ) {
-				if ( $source['file'] === $filename ) {
-					return true;
-				}
-			}
-		}
-	}
-	return false;
-}
-
 /**
  * Generate attachment meta data and create image sub-sizes for images.
  *


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/56333

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
