### PR TITLE
fix php8.1 gensalt_blowfish E_DEPRECATED

### DIFF
--- a/src/wp-includes/class-phpass.php
+++ b/src/wp-includes/class-phpass.php
@@ -173,7 +173,7 @@ class PasswordHash {
 		$itoa64 = './ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
 
 		$output = '$2a$';
-		$output .= chr(ord('0') + $this->iteration_count_log2 / 10);
+		$output .= chr((int)(ord('0') + $this->iteration_count_log2 / 10));
 		$output .= chr((int)(ord('0') + $this->iteration_count_log2 % 10));
 		$output .= '$';
 

--- a/src/wp-includes/class-phpass.php
+++ b/src/wp-includes/class-phpass.php
@@ -174,7 +174,7 @@ class PasswordHash {
 
 		$output = '$2a$';
 		$output .= chr(ord('0') + $this->iteration_count_log2 / 10);
-		$output .= chr(ord('0') + $this->iteration_count_log2 % 10);
+		$output .= chr((int)(ord('0') + $this->iteration_count_log2 % 10));
 		$output .= '$';
 
 		$i = 0;


### PR DESCRIPTION
fix PHP>=8.1 E_DEPRECATED: Deprecated: Implicit conversion from float 48.8 to int loses precision

Trac ticket: https://core.trac.wordpress.org/ticket/56340

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
