### PR TITLE
Clarify inline docs for $excluded_terms

### DIFF
--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1940,7 +1940,7 @@ function get_adjacent_post( $in_same_term = false, $excluded_terms = '', $previo
 	 * @since 2.5.0
 	 * @since 4.4.0 Added the `$taxonomy` and `$post` parameters.
 	 *
-	 * @param string.      $where          The `WHERE` clause in the SQL.
+	 * @param string       $where          The `WHERE` clause in the SQL.
 	 * @param bool         $in_same_term   Whether post should be in a same taxonomy term.
 	 * @param int[]|string $excluded_terms Array of excluded term IDs. Empty string if none were provided.
 	 * @param string       $taxonomy       Taxonomy. Used to identify the term used when `$in_same_term` is true.

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1841,7 +1841,7 @@ function get_adjacent_post( $in_same_term = false, $excluded_terms = '', $previo
 	 *
 	 * @since 4.4.0
 	 *
-	 * @param array|string $excluded_terms Array of excluded term IDs. Empty string if none were provided.
+	 * @param int[]|string $excluded_terms Array of excluded term IDs. Empty string if none were provided.
 	 */
 	$excluded_terms = apply_filters( "get_{$adjacent}_post_excluded_terms", $excluded_terms );
 
@@ -1918,11 +1918,11 @@ function get_adjacent_post( $in_same_term = false, $excluded_terms = '', $previo
 	 * @since 2.5.0
 	 * @since 4.4.0 Added the `$taxonomy` and `$post` parameters.
 	 *
-	 * @param string  $join           The JOIN clause in the SQL.
-	 * @param bool    $in_same_term   Whether post should be in a same taxonomy term.
-	 * @param array   $excluded_terms Array of excluded term IDs.
-	 * @param string  $taxonomy       Taxonomy. Used to identify the term used when `$in_same_term` is true.
-	 * @param WP_Post $post           WP_Post object.
+	 * @param string       $join           The JOIN clause in the SQL.
+	 * @param bool         $in_same_term   Whether post should be in a same taxonomy term.
+	 * @param int[]|string $excluded_terms Array of excluded term IDs.
+	 * @param string       $taxonomy       Taxonomy. Used to identify the term used when `$in_same_term` is true.
+	 * @param WP_Post      $post           WP_Post object.
 	 */
 	$join = apply_filters( "get_{$adjacent}_post_join", $join, $in_same_term, $excluded_terms, $taxonomy, $post );
 
@@ -1940,11 +1940,11 @@ function get_adjacent_post( $in_same_term = false, $excluded_terms = '', $previo
 	 * @since 2.5.0
 	 * @since 4.4.0 Added the `$taxonomy` and `$post` parameters.
 	 *
-	 * @param string  $where          The `WHERE` clause in the SQL.
-	 * @param bool    $in_same_term   Whether post should be in a same taxonomy term.
-	 * @param array   $excluded_terms Array of excluded term IDs.
-	 * @param string  $taxonomy       Taxonomy. Used to identify the term used when `$in_same_term` is true.
-	 * @param WP_Post $post           WP_Post object.
+	 * @param string.      $where          The `WHERE` clause in the SQL.
+	 * @param bool         $in_same_term   Whether post should be in a same taxonomy term.
+	 * @param int[]|string $excluded_terms Array of excluded term IDs.
+	 * @param string       $taxonomy       Taxonomy. Used to identify the term used when `$in_same_term` is true.
+	 * @param WP_Post.     $post           WP_Post object.
 	 */
 	$where = apply_filters( "get_{$adjacent}_post_where", $wpdb->prepare( "WHERE p.post_date $op %s AND p.post_type = %s $where", $current_post_date, $post->post_type ), $in_same_term, $excluded_terms, $taxonomy, $post );
 

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1944,7 +1944,7 @@ function get_adjacent_post( $in_same_term = false, $excluded_terms = '', $previo
 	 * @param bool         $in_same_term   Whether post should be in a same taxonomy term.
 	 * @param int[]|string $excluded_terms Array of excluded term IDs. Empty string if none were provided.
 	 * @param string       $taxonomy       Taxonomy. Used to identify the term used when `$in_same_term` is true.
-	 * @param WP_Post.     $post           WP_Post object.
+	 * @param WP_Post      $post           WP_Post object.
 	 */
 	$where = apply_filters( "get_{$adjacent}_post_where", $wpdb->prepare( "WHERE p.post_date $op %s AND p.post_type = %s $where", $current_post_date, $post->post_type ), $in_same_term, $excluded_terms, $taxonomy, $post );
 

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1920,7 +1920,7 @@ function get_adjacent_post( $in_same_term = false, $excluded_terms = '', $previo
 	 *
 	 * @param string       $join           The JOIN clause in the SQL.
 	 * @param bool         $in_same_term   Whether post should be in a same taxonomy term.
-	 * @param int[]|string $excluded_terms Array of excluded term IDs.
+	 * @param int[]|string $excluded_terms Array of excluded term IDs. Empty string if none were provided.
 	 * @param string       $taxonomy       Taxonomy. Used to identify the term used when `$in_same_term` is true.
 	 * @param WP_Post      $post           WP_Post object.
 	 */
@@ -1942,7 +1942,7 @@ function get_adjacent_post( $in_same_term = false, $excluded_terms = '', $previo
 	 *
 	 * @param string.      $where          The `WHERE` clause in the SQL.
 	 * @param bool         $in_same_term   Whether post should be in a same taxonomy term.
-	 * @param int[]|string $excluded_terms Array of excluded term IDs.
+	 * @param int[]|string $excluded_terms Array of excluded term IDs. Empty string if none were provided.
 	 * @param string       $taxonomy       Taxonomy. Used to identify the term used when `$in_same_term` is true.
 	 * @param WP_Post.     $post           WP_Post object.
 	 */


### PR DESCRIPTION
Correctly document `$excluded_terms` is an array of excluded term IDs or an empty string is none provided.

Trac ticket: https://core.trac.wordpress.org/ticket/56348

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
