### PR TITLE
Improve Gallery Shortcode Documentation

### DIFF
--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -2448,7 +2448,7 @@ add_shortcode( 'gallery', 'gallery_shortcode' );
  * @since 2.5.0
  * @since 2.8.0 Added the `$attr` parameter to set the shortcode output. New attributes included
  *        such as `size`, `itemtag`, `icontag`, `captiontag`, and columns. Changed markup from
- *        `<div>` tags to `<dl>`, `<dt>` and `<dd>` tags. Support more than one gallery on the
+ *        `div` tags to `dl`, `dt` and `dd` tags. Support more than one gallery on the
  *        same page.
  * @since 2.9.0 Adds support for `include` and `exclude` to shortcode.
  * @since 3.5.0 Uses get_post() instead of global `$post`. Handle mapping of `ids` to `include`

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -2446,6 +2446,26 @@ add_shortcode( 'gallery', 'gallery_shortcode' );
  * WordPress images on a post.
  *
  * @since 2.5.0
+ * @since 2.8.0 Added the `$attr` parameter to set the shortcode output. New attributes included
+ *        such as `size`, `itemtag`, `icontag`, `captiontag`, and columns. Changed markup from
+ *        `<div>` tags to `<dl>`, `<dt>` and `<dd>` tags. Support more than one gallery on the
+ *        same page.
+ * @since 2.9.0 Adds support for `include` and `exclude` to shortcode.
+ * @since 3.5.0 Uses get_post() instead of global `$post`. Handle mapping of `ids` to `include`
+ *        and `orderby`.
+ * @since 3.6.0 Validate the tags used in gallery shortcode. Add orientation information to items.
+ * @since 3.7.0 `link` attribute introduced wo.
+ * @since 3.9.0 `html5` gallery support, accepting 'itemtag', 'icontag', and 'captiontag' attributes.
+ *        Inline documentation for shortcode attributes.
+ * @since 4.0.0 Eliminate use of `extract()`.
+ * @since 4.1.0 Adds attribute to `wp_get_attachment_link()` to output `aria-describedby`.
+ * @since 4.2.0 Pass the shortcode instance ID to `post_gallery` and `post_playlist` filters.
+ * @since 4.6.0 Standardize filter docs to match documentation standards for PHP.
+ * @since 5.1.0 Code cleanup for WPCS 1.0.0 coding standards.
+ * @since 5.3.0 Save progress of intermediate image creation after upload.
+ * @since 5.5.0 Ensures that galleries can be output as a list of links in feeds.
+ * @since 5.6.0 Replace order-style PHP type conversion functions with typecasts. Fix logic for
+ *        an array of image dimensions.
  *
  * @param array $attr {
  *     Attributes of the gallery shortcode.

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -2447,25 +2447,25 @@ add_shortcode( 'gallery', 'gallery_shortcode' );
  *
  * @since 2.5.0
  * @since 2.8.0 Added the `$attr` parameter to set the shortcode output. New attributes included
- *        such as `size`, `itemtag`, `icontag`, `captiontag`, and columns. Changed markup from
- *        `div` tags to `dl`, `dt` and `dd` tags. Support more than one gallery on the
- *        same page.
- * @since 2.9.0 Adds support for `include` and `exclude` to shortcode.
- * @since 3.5.0 Uses get_post() instead of global `$post`. Handle mapping of `ids` to `include`
- *        and `orderby`.
- * @since 3.6.0 Validate the tags used in gallery shortcode. Add orientation information to items.
- * @since 3.7.0 `link` attribute introduced wo.
+ *              such as `size`, `itemtag`, `icontag`, `captiontag`, and columns. Changed markup from
+ *              `div` tags to `dl`, `dt` and `dd` tags. Support more than one gallery on the
+ *              same page.
+ * @since 2.9.0 Added support for `include` and `exclude` to shortcode.
+ * @since 3.5.0 Use get_post() instead of global `$post`. Handle mapping of `ids` to `include`
+ *              and `orderby`.
+ * @since 3.6.0 Added validation for tags used in gallery shortcode. Add orientation information to items.
+ * @since 3.7.0 Introduced the `link` attribute.
  * @since 3.9.0 `html5` gallery support, accepting 'itemtag', 'icontag', and 'captiontag' attributes.
- *        Inline documentation for shortcode attributes.
- * @since 4.0.0 Eliminate use of `extract()`.
- * @since 4.1.0 Adds attribute to `wp_get_attachment_link()` to output `aria-describedby`.
- * @since 4.2.0 Pass the shortcode instance ID to `post_gallery` and `post_playlist` filters.
- * @since 4.6.0 Standardize filter docs to match documentation standards for PHP.
+ *              Inline documentation for shortcode attributes.
+ * @since 4.0.0 Removed use of `extract()`.
+ * @since 4.1.0 Added attribute to `wp_get_attachment_link()` to output `aria-describedby`.
+ * @since 4.2.0 Passed the shortcode instance ID to `post_gallery` and `post_playlist` filters.
+ * @since 4.6.0 Standardized filter docs to match documentation standards for PHP.
  * @since 5.1.0 Code cleanup for WPCS 1.0.0 coding standards.
- * @since 5.3.0 Save progress of intermediate image creation after upload.
- * @since 5.5.0 Ensures that galleries can be output as a list of links in feeds.
- * @since 5.6.0 Replace order-style PHP type conversion functions with typecasts. Fix logic for
- *        an array of image dimensions.
+ * @since 5.3.0 Saved progress of intermediate image creation after upload.
+ * @since 5.5.0 Ensured that galleries can be output as a list of links in feeds.
+ * @since 5.6.0 Replaced order-style PHP type conversion functions with typecasts. Fix logic for
+ *              an array of image dimensions.
  *
  * @param array $attr {
  *     Attributes of the gallery shortcode.


### PR DESCRIPTION
Adds `@since` for all major functionality and versions for the `gallery_shortcode()` functionality.

Trac ticket: [https://core.trac.wordpress.org/ticket/56206](https://core.trac.wordpress.org/ticket/56206)
