### PR TITLE
Allow safecss_filter_attr in custom CSS props

### DIFF
--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -2414,11 +2414,12 @@ function safecss_filter_attr( $css, $deprecated = '' ) {
 			continue;
 		}
 
-		$css_item        = trim( $css_item );
-		$css_test_string = $css_item;
-		$found           = false;
-		$url_attr        = false;
-		$gradient_attr   = false;
+		$css_item            = trim( $css_item );
+		$css_test_string     = $css_item;
+		$found               = false;
+		$url_attr            = false;
+		$gradient_attr       = false;
+		$custom_css_property = false;
 
 		if ( strpos( $css_item, ':' ) === false ) {
 			$found = true;
@@ -2426,7 +2427,13 @@ function safecss_filter_attr( $css, $deprecated = '' ) {
 			$parts        = explode( ':', $css_item, 2 );
 			$css_selector = trim( $parts[0] );
 
-			if ( in_array( $css_selector, $allowed_attr, true ) ) {
+			// Custom CSS properties, e.g., `--font-size-xl`.
+			if ( strpos( $css_selector, '--' ) === 0 && preg_match( '/^([a-z0-9\-]+)$/', $css_selector ) ) {
+				$custom_css_property = true;
+			}
+
+			// Allow properties defined in $allowed_attr or custom CSS properties.
+			if ( in_array( $css_selector, $allowed_attr, true ) || $custom_css_property ) {
 				$found         = true;
 				$url_attr      = in_array( $css_selector, $css_url_data_types, true );
 				$gradient_attr = in_array( $css_selector, $css_gradient_data_types, true );

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -1120,6 +1120,11 @@ EOF;
 				'css'      => 'color: rgb( 100, 100, 100, .4 )',
 				'expected' => '',
 			),
+			// Custom CSS properties.
+			array(
+				'css'      => '--wp--medium-width: 100px;--background-color-2: #cccccc;--CAPS-not-allowed:red;--underscore_not-allowed:red;--_:?><.%-not-allowed:red;',
+				'expected' => '--wp--medium-width: 100px;--background-color-2: #cccccc',
+			),
 		);
 	}
 


### PR DESCRIPTION
A bit late. https://github.com/WordPress/wordpress-develop/pull/3078 illustrates the solution. 

I'm just putting this up there to see the tests pass 😄 

## Proposal

[CSS custom properties](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties) don't pass the tests in safecss_filter_attr() at [if ( in_array( $css_selector, $allowed_attr, true ) ) ](https://github.com/WordPress/wordpress-develop/blob/cab053271e272a21b4d140e50ac0d6a78094ecd5/src/wp-includes/kses.php#L2429) because there's no allowing entry in the `allowed_attrs` array.

This is a PR to stimulate discussion around whether, and how, we WordPress could be permissive of such properties.


Trac ticket: https://core.trac.wordpress.org/ticket/56353

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
