### PR TITLE
Tweaks for WPDB and %i

### DIFF
--- a/src/wp-includes/class-wpdb.php
+++ b/src/wp-includes/class-wpdb.php
@@ -792,6 +792,7 @@ class wpdb {
 			'col_meta',
 			'table_charset',
 			'check_current_query',
+			'allow_unsafe_unquoted_parameters',
 		);
 		if ( in_array( $name, $protected_members, true ) ) {
 			return;

--- a/src/wp-includes/class-wpdb.php
+++ b/src/wp-includes/class-wpdb.php
@@ -1395,7 +1395,7 @@ class wpdb {
 	 * @param string $identifier Identifier to escape.
 	 * @return string Escaped identifier.
 	 */
-	public function escape_identifier( $identifier ) {
+	public function quote_identifier( $identifier ) {
 		return '`' . $this->_escape_identifier_value( $identifier ) . '`';
 	}
 

--- a/src/wp-includes/class-wpdb.php
+++ b/src/wp-includes/class-wpdb.php
@@ -1595,7 +1595,7 @@ class wpdb {
 				'wpdb::prepare',
 				sprintf(
 					/* translators: %s: A comma-separated list of arguments found to be a problem. */
-					__( 'Arguments (%s) cannot be used for both String and Identifier escaping.' ),
+					__( 'The arguments (%s) cannot be prepared as both an Identifier, and as a value.' ),
 					implode( ', ', $dual_use )
 				),
 				'6.1.0'

--- a/src/wp-includes/class-wpdb.php
+++ b/src/wp-includes/class-wpdb.php
@@ -1570,6 +1570,8 @@ class wpdb {
 
 				if ( false !== $argnum_pos ) {
 					$arg_strings[] = ( intval( substr( $format, 0, $argnum_pos ) ) - 1 );
+				} else {
+					$arg_strings[] = $arg_id;
 				}
 
 				// Unquoted strings for backward compatibility (dangerous).

--- a/src/wp-includes/class-wpdb.php
+++ b/src/wp-includes/class-wpdb.php
@@ -1406,7 +1406,6 @@ class wpdb {
 	 * - To quote the identifier itself, you need to double the character, e.g. `a``b`.
 	 *
 	 * @since 6.1.0
-	 * @access private
 	 *
 	 * @link https://dev.mysql.com/doc/refman/8.0/en/identifiers.html
 	 *

--- a/tests/phpunit/tests/db.php
+++ b/tests/phpunit/tests/db.php
@@ -1822,6 +1822,12 @@ class Tests_DB extends WP_UnitTestCase {
 				null, // Should be rejected, otherwise the `%1$s` could use Identifier escaping, e.g. 'WHERE `field -- ` LIKE field --  LIMIT 1' (thanks @vortfu).
 			),
 			array(
+				'WHERE %2$i IN ( %s , %s ) LIMIT 1',
+				array( 'a', 'b' ),
+				'Arguments cannot be prepared as both an Identifier and Value. Found the following conflicts: %2$i and %s',
+				null,
+			),
+			array(
 				'WHERE %1$i = %1$s',
 				array( 'a', 'b' ),
 				'Arguments cannot be prepared as both an Identifier and Value. Found the following conflicts: %1$i and %1$s',

--- a/tests/phpunit/tests/db.php
+++ b/tests/phpunit/tests/db.php
@@ -1856,19 +1856,23 @@ class Tests_DB extends WP_UnitTestCase {
 
 		$default = $wpdb->allow_unsafe_unquoted_parameters;
 
-		$wpdb->allow_unsafe_unquoted_parameters = true;
+		$property = new ReflectionProperty( $wpdb, 'allow_unsafe_unquoted_parameters' );
+		$property->setAccessible( true );
+
+		$property->setValue( $wpdb, true );
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		$part = $wpdb->prepare( $sql, $values );
 		$this->assertSame( 'WHERE (`field_a` = \'string_a\') OR (`   field_b` =   string_b) OR (`field_c` = string_c)', $part ); // Unsafe, unquoted parameters.
 
-		$wpdb->allow_unsafe_unquoted_parameters = false;
+		$property->setValue( $wpdb, false );
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		$part = $wpdb->prepare( $sql, $values );
 		$this->assertSame( 'WHERE (`field_a` = \'string_a\') OR (`   field_b` = \'  string_b\') OR (`field_c` = \'string_c\')', $part );
 
-		$wpdb->allow_unsafe_unquoted_parameters = $default;
+		$property->setValue( $wpdb, $default );
+		$property->setAccessible( false );
 
 	}
 


### PR DESCRIPTION
Some feedback from Juliette (@jrfnl):

Trac ticket: https://core.trac.wordpress.org/ticket/52506

---

1. Using `%1s`, you're right, it's not common, so I've replaced those examples (except the "risky" and "safer approaches" examples, to show both styles).
2. Dockblock for `_escape_identifier_value()`, I copied the "To quote the identifier itself" line directly from the [MySQL manual](https://dev.mysql.com/doc/refman/8.0/en/identifiers.html), I'm happy to change the word "quote" with "escape", I'm just not sure if a direct quote is better?
3. `@access private`, you're right, it shouldn't be used on a method.
4. With the doing it wrong line, I'd like to keep the `(%s)` in there (to show what's wrong), but I also made a mistake in saying "String and Identifier" escaping, because Integers and Floats also exist - does the suggested change help?
5. I've added 'wpdb->allow_unsafe_unquoted_parameters private' to the list of `protected_members` (so it cannot be easily/accidentally set to false; at least for now).