### PR TITLE
Allow short-circuiting `get_post_class` for performance

### DIFF
--- a/src/wp-includes/post-template.php
+++ b/src/wp-includes/post-template.php
@@ -556,11 +556,11 @@ function get_post_class( $class = '', $post = null ) {
 	 * @since 6.1.0
 	 *
 	 * @param array    $taxonomies List of all public taxonomies to generate classes for.
+	 * @param int      $post_id    The post ID.
 	 * @param string[] $classes    An array of post class names.
 	 * @param string[] $class      An array of additional class names added to the post.
-	 * @param int      $post_id    The post ID.
 	*/
-	$taxonomies = apply_filters( 'post_class_taxonomies', $taxonomies, $classes, $class, $post->ID );
+	$taxonomies = apply_filters( 'wp_post_class_taxonomies', $taxonomies, $post->ID, $classes, $class );
 
 	foreach ( (array) $taxonomies as $taxonomy ) {
 		if ( is_object_in_taxonomy( $post->post_type, $taxonomy ) ) {

--- a/src/wp-includes/post-template.php
+++ b/src/wp-includes/post-template.php
@@ -547,6 +547,21 @@ function get_post_class( $class = '', $post = null ) {
 
 	// All public taxonomies.
 	$taxonomies = get_taxonomies( array( 'public' => true ) );
+
+	/**
+	 * Filters the taxonomies to generate classes for each individual term.
+	 *
+	 * Default is all public taxonomies registered to the post type.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param array    $taxonomies List of all public taxonomies to generate classes for.
+	 * @param string[] $classes    An array of post class names.
+	 * @param string[] $class      An array of additional class names added to the post.
+	 * @param int      $post_id    The post ID.
+	*/
+	$taxonomies = apply_filters( 'post_class_taxonomies', $taxonomies, $classes, $class, $post->ID );
+
 	foreach ( (array) $taxonomies as $taxonomy ) {
 		if ( is_object_in_taxonomy( $post->post_type, $taxonomy ) ) {
 			foreach ( (array) get_the_terms( $post->ID, $taxonomy ) as $term ) {


### PR DESCRIPTION
The PR refresh the final patch [37114.3.patch](https://core.trac.wordpress.org/attachment/ticket/37114/37114.3.patch) also update the docblock for `$classes` and `$class` similar to `post_class` filter.

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/37114

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
