### PR TITLE
Introduce 'ignored_theme_directory' filter during theme export

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -901,7 +901,17 @@ function block_footer_area() {
  * @return Bool Whether this file is in an ignored directory.
  */
 function wp_is_theme_directory_ignored( $path ) {
-	$directories_to_ignore = array( '.svn', '.git', '.hg', '.bzr', 'node_modules', 'vendor' );
+	$default_directories_to_ignore = array( '.svn', '.git', '.hg', '.bzr', 'node_modules', 'vendor' );
+
+	/**
+	 * Filters the list of theme directories to ignore during export.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param array $default_directories_to_ignore An array of directory names.
+	 */
+	$directories_to_ignore = apply_filters( 'ignored_theme_directory', $default_directories_to_ignore );
+
 	foreach ( $directories_to_ignore as $directory ) {
 		if ( strpos( $path, $directory ) === 0 ) {
 			return true;


### PR DESCRIPTION
The wp_is_theme_directory_ignored function excludes the majority of common vendor or VCS files by default during theme export via the Site Editor.

There are themes which may need to exclude additional directories on a case by case basis. A few examples include:

1. Source files for JS tools like Webpack.
2. Unit test files.
3. .yarn files for Yarn projects with PNP support.

By offering a filter to theme developers we allow developers to filter as needed without needing to maintain a list of exclusions which covers all cases.

### Testing
Assuming running the TwentyTwentyTwo theme.
```php
add_filter( 'ignored_theme_directory', function( $dirs ) {
	$dirs[] = 'inc';
	return $dirs;
} );
```
1. Open the Site Editor (FSE)
2. Click the 3 dot menu.
3. Click Export.
4. Notice the "inc" directory is not included in the .zip archive.


https://core.trac.wordpress.org/ticket/56382