### PR TITLE
Reduce code duplication in tests that upload file as attachment.

### DIFF
--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -1571,23 +1571,6 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 	}
 
 	/**
-	 * Uploads given file and creates an attachment post from it.
-	 *
-	 * @since 6.1.0
-	 *
-	 * @param array $filename       Absolute path to the file to upload.
-	 * @param int   $parent_post_id Optional. Parent post ID.
-	 *
-	 * @return int|WP_Error The attachment ID on success. The value 0 or WP_Error on failure.
-	 */
-	public function _upload_file_and_make_attachment( $filename, $parent_post_id = 0 ) {
-		$contents = file_get_contents( $filename );
-		$upload   = wp_upload_bits( wp_basename( $filename ), null, $contents );
-
-		return $this->_make_attachment( $upload, $parent_post_id );
-	}
-
-	/**
 	 * Updates the modified and modified GMT date of a post in the database.
 	 *
 	 * @since 4.8.0

--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -1571,6 +1571,23 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 	}
 
 	/**
+	 * Uploads given file and creates an attachment post from it.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param array $filename       Absolute path to the file to upload.
+	 * @param int   $parent_post_id Optional. Parent post ID.
+	 *
+	 * @return int|WP_Error The attachment ID on success. The value 0 or WP_Error on failure.
+	 */
+	public function _upload_file_and_make_attachment( $filename, $parent_post_id = 0 ) {
+		$contents = file_get_contents( $filename );
+		$upload   = wp_upload_bits( wp_basename( $filename ), null, $contents );
+
+		return $this->_make_attachment( $upload, $parent_post_id );
+	}
+
+	/**
 	 * Updates the modified and modified GMT date of a post in the database.
 	 *
 	 * @since 4.8.0

--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -1527,50 +1527,6 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 	}
 
 	/**
-	 * Creates an attachment post from an uploaded file.
-	 *
-	 * @since 4.4.0
-	 * @since 6.2.0 Returns a WP_Error object on failure.
-	 *
-	 * @param array $upload         Array of information about the uploaded file, provided by wp_upload_bits().
-	 * @param int   $parent_post_id Optional. Parent post ID.
-	 * @return int|WP_Error The attachment ID on success, WP_Error object on failure.
-	 */
-	public function _make_attachment( $upload, $parent_post_id = 0 ) {
-		$type = '';
-		if ( ! empty( $upload['type'] ) ) {
-			$type = $upload['type'];
-		} else {
-			$mime = wp_check_filetype( $upload['file'] );
-			if ( $mime ) {
-				$type = $mime['type'];
-			}
-		}
-
-		$attachment = array(
-			'post_title'     => wp_basename( $upload['file'] ),
-			'post_content'   => '',
-			'post_type'      => 'attachment',
-			'post_parent'    => $parent_post_id,
-			'post_mime_type' => $type,
-			'guid'           => $upload['url'],
-		);
-
-		$attachment_id = wp_insert_attachment( $attachment, $upload['file'], $parent_post_id, true );
-
-		if ( is_wp_error( $attachment_id ) ) {
-			return $attachment_id;
-		}
-
-		wp_update_attachment_metadata(
-			$attachment_id,
-			wp_generate_attachment_metadata( $attachment_id, $upload['file'] )
-		);
-
-		return $attachment_id;
-	}
-
-	/**
 	 * Updates the modified and modified GMT date of a post in the database.
 	 *
 	 * @since 4.8.0

--- a/tests/phpunit/includes/bootstrap.php
+++ b/tests/phpunit/includes/bootstrap.php
@@ -331,6 +331,7 @@ require __DIR__ . '/class-wp-fake-block-type.php';
 require __DIR__ . '/class-wp-sitemaps-test-provider.php';
 require __DIR__ . '/class-wp-sitemaps-empty-test-provider.php';
 require __DIR__ . '/class-wp-sitemaps-large-test-provider.php';
+require __DIR__ . '/trait-runs-file-upload-tests.php';
 
 /**
  * A class to handle additional command line arguments passed to the script.

--- a/tests/phpunit/includes/trait-runs-file-upload-tests.php
+++ b/tests/phpunit/includes/trait-runs-file-upload-tests.php
@@ -19,7 +19,7 @@ trait WP_Test_RunsFileUploadTests {
 	 * @param array $filename       Absolute path to the file to upload.
 	 * @param int   $parent_post_id Optional. Parent post ID.
 	 *
-	 * @return int|WP_Error The attachment ID on success. The value 0 or WP_Error on failure.
+	 * @return int|WP_Error The attachment ID on success, WP_Error object on failure.
 	 */
 	public function _upload_file_and_make_attachment( $filename, $parent_post_id = 0 ) {
 		$contents = file_get_contents( $filename );

--- a/tests/phpunit/includes/trait-runs-file-upload-tests.php
+++ b/tests/phpunit/includes/trait-runs-file-upload-tests.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Defines a basic fixture to run multiple tests.
+ *
+ * Resets the state of the WordPress installation before and after every test.
+ *
+ * Includes utility functions and assertions useful for testing WordPress.
+ *
+ * All WordPress unit tests should inherit from this class.
+ */
+trait WP_Test_RunsFileUploadTests {
+
+	/**
+	 * Uploads given file and creates an attachment post from it.
+	 *
+	 * @since 6.2.0
+	 *
+	 * @param array $filename       Absolute path to the file to upload.
+	 * @param int   $parent_post_id Optional. Parent post ID.
+	 *
+	 * @return int|WP_Error The attachment ID on success. The value 0 or WP_Error on failure.
+	 */
+	public function _upload_file_and_make_attachment( $filename, $parent_post_id = 0 ) {
+		$contents = file_get_contents( $filename );
+		$upload   = wp_upload_bits( wp_basename( $filename ), null, $contents );
+
+		return $this->_make_attachment( $upload, $parent_post_id );
+	}
+}

--- a/tests/phpunit/includes/trait-runs-file-upload-tests.php
+++ b/tests/phpunit/includes/trait-runs-file-upload-tests.php
@@ -6,6 +6,50 @@
 trait WP_Test_RunsFileUploadTests {
 
 	/**
+	 * Creates an attachment post from an uploaded file.
+	 *
+	 * @since 4.4.0
+	 * @since 6.2.0 Returns a WP_Error object on failure.
+	 *
+	 * @param array $upload         Array of information about the uploaded file, provided by wp_upload_bits().
+	 * @param int   $parent_post_id Optional. Parent post ID.
+	 * @return int|WP_Error The attachment ID on success, WP_Error object on failure.
+	 */
+	public function _make_attachment( $upload, $parent_post_id = 0 ) {
+		$type = '';
+		if ( ! empty( $upload['type'] ) ) {
+			$type = $upload['type'];
+		} else {
+			$mime = wp_check_filetype( $upload['file'] );
+			if ( $mime ) {
+				$type = $mime['type'];
+			}
+		}
+
+		$attachment = array(
+			'post_title'     => wp_basename( $upload['file'] ),
+			'post_content'   => '',
+			'post_type'      => 'attachment',
+			'post_parent'    => $parent_post_id,
+			'post_mime_type' => $type,
+			'guid'           => $upload['url'],
+		);
+
+		$attachment_id = wp_insert_attachment( $attachment, $upload['file'], $parent_post_id, true );
+
+		if ( is_wp_error( $attachment_id ) ) {
+			return $attachment_id;
+		}
+
+		wp_update_attachment_metadata(
+			$attachment_id,
+			wp_generate_attachment_metadata( $attachment_id, $upload['file'] )
+		);
+
+		return $attachment_id;
+	}
+
+	/**
 	 * Uploads given file and creates an attachment post from it.
 	 *
 	 * @since 6.2.0

--- a/tests/phpunit/includes/trait-runs-file-upload-tests.php
+++ b/tests/phpunit/includes/trait-runs-file-upload-tests.php
@@ -1,13 +1,7 @@
 <?php
 
 /**
- * Defines a basic fixture to run multiple tests.
- *
- * Resets the state of the WordPress installation before and after every test.
- *
- * Includes utility functions and assertions useful for testing WordPress.
- *
- * All WordPress unit tests should inherit from this class.
+ * Defines helper functions for dealing with file uploads and attachment creation.
  */
 trait WP_Test_RunsFileUploadTests {
 

--- a/tests/phpunit/tests/ajax/wpAjaxCropImage.php
+++ b/tests/phpunit/tests/ajax/wpAjaxCropImage.php
@@ -16,6 +16,8 @@ require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-direct.php';
  */
 class Tests_Ajax_WpAjaxCropImage extends WP_Ajax_UnitTestCase {
 
+	use WP_Test_RunsFileUploadTests;
+
 	/**
 	 * @var WP_Post|null
 	 */

--- a/tests/phpunit/tests/ajax/wpAjaxImageEditor.php
+++ b/tests/phpunit/tests/ajax/wpAjaxImageEditor.php
@@ -38,7 +38,7 @@ class Tests_Ajax_wpAjaxImageEditor extends WP_Ajax_UnitTestCase {
 	public function testCropImageThumbnail() {
 		require_once ABSPATH . 'wp-admin/includes/image-edit.php';
 
-		$id     = $this->_upload_file_and_make_attachment( DIR_TESTDATA . '/images/canola.jpg' );
+		$id = $this->_upload_file_and_make_attachment( DIR_TESTDATA . '/images/canola.jpg' );
 
 		$_REQUEST['action']  = 'image-editor';
 		$_REQUEST['context'] = 'edit-attachment';
@@ -69,7 +69,7 @@ class Tests_Ajax_wpAjaxImageEditor extends WP_Ajax_UnitTestCase {
 
 		require_once ABSPATH . 'wp-admin/includes/image-edit.php';
 
-		$id     = $this->_make_attachment( DIR_TESTDATA . '/images/canola.jpg' );
+		$id = $this->_make_attachment( DIR_TESTDATA . '/images/canola.jpg' );
 
 		$_REQUEST['action']  = 'image-editor';
 		$_REQUEST['context'] = 'edit-attachment';

--- a/tests/phpunit/tests/ajax/wpAjaxImageEditor.php
+++ b/tests/phpunit/tests/ajax/wpAjaxImageEditor.php
@@ -38,11 +38,7 @@ class Tests_Ajax_wpAjaxImageEditor extends WP_Ajax_UnitTestCase {
 	public function testCropImageThumbnail() {
 		require_once ABSPATH . 'wp-admin/includes/image-edit.php';
 
-		$filename = DIR_TESTDATA . '/images/canola.jpg';
-		$contents = file_get_contents( $filename );
-
-		$upload = wp_upload_bits( wp_basename( $filename ), null, $contents );
-		$id     = $this->_make_attachment( $upload );
+		$id     = $this->_upload_file_and_make_attachment( DIR_TESTDATA . '/images/canola.jpg' );
 
 		$_REQUEST['action']  = 'image-editor';
 		$_REQUEST['context'] = 'edit-attachment';
@@ -73,11 +69,7 @@ class Tests_Ajax_wpAjaxImageEditor extends WP_Ajax_UnitTestCase {
 
 		require_once ABSPATH . 'wp-admin/includes/image-edit.php';
 
-		$filename = DIR_TESTDATA . '/images/canola.jpg';
-		$contents = file_get_contents( $filename );
-
-		$upload = wp_upload_bits( wp_basename( $filename ), null, $contents );
-		$id     = $this->_make_attachment( $upload );
+		$id     = $this->_make_attachment( DIR_TESTDATA . '/images/canola.jpg' );
 
 		$_REQUEST['action']  = 'image-editor';
 		$_REQUEST['context'] = 'edit-attachment';

--- a/tests/phpunit/tests/ajax/wpAjaxImageEditor.php
+++ b/tests/phpunit/tests/ajax/wpAjaxImageEditor.php
@@ -69,7 +69,7 @@ class Tests_Ajax_wpAjaxImageEditor extends WP_Ajax_UnitTestCase {
 
 		require_once ABSPATH . 'wp-admin/includes/image-edit.php';
 
-		$id = $this->_make_attachment( DIR_TESTDATA . '/images/canola.jpg' );
+		$id = $this->_upload_file_and_make_attachment( DIR_TESTDATA . '/images/canola.jpg' );
 
 		$_REQUEST['action']  = 'image-editor';
 		$_REQUEST['context'] = 'edit-attachment';

--- a/tests/phpunit/tests/ajax/wpAjaxImageEditor.php
+++ b/tests/phpunit/tests/ajax/wpAjaxImageEditor.php
@@ -19,6 +19,8 @@ require_once ABSPATH . 'wp-admin/includes/ajax-actions.php';
  */
 class Tests_Ajax_wpAjaxImageEditor extends WP_Ajax_UnitTestCase {
 
+	use WP_Test_RunsFileUploadTests;
+
 	/**
 	 * Tear down the test fixture.
 	 */

--- a/tests/phpunit/tests/ajax/wpAjaxSendAttachmentToEditor.php
+++ b/tests/phpunit/tests/ajax/wpAjaxSendAttachmentToEditor.php
@@ -22,11 +22,7 @@ class Tests_Ajax_wpAjaxSendAttachmentToEditor extends WP_Ajax_UnitTestCase {
 		// Become an administrator.
 		$this->_setRole( 'administrator' );
 
-		$filename = DIR_TESTDATA . '/images/canola.jpg';
-		$contents = file_get_contents( $filename );
-
-		$upload     = wp_upload_bits( wp_basename( $filename ), null, $contents );
-		$attachment = $this->_make_attachment( $upload );
+		$attachment = $this->_upload_file_and_make_attachment( DIR_TESTDATA . '/images/canola.jpg' );
 
 		// Set up a default request.
 		$_POST['nonce']      = wp_create_nonce( 'media-send-to-editor' );
@@ -65,11 +61,7 @@ class Tests_Ajax_wpAjaxSendAttachmentToEditor extends WP_Ajax_UnitTestCase {
 		// Become an administrator.
 		$this->_setRole( 'administrator' );
 
-		$filename = DIR_TESTDATA . '/formatting/entities.txt';
-		$contents = file_get_contents( $filename );
-
-		$upload     = wp_upload_bits( wp_basename( $filename ), null, $contents );
-		$attachment = $this->_make_attachment( $upload );
+		$attachment = $this->_upload_file_and_make_attachment( DIR_TESTDATA . '/formatting/entities.txt' );
 
 		// Set up a default request.
 		$_POST['nonce']      = wp_create_nonce( 'media-send-to-editor' );

--- a/tests/phpunit/tests/ajax/wpAjaxSendAttachmentToEditor.php
+++ b/tests/phpunit/tests/ajax/wpAjaxSendAttachmentToEditor.php
@@ -13,6 +13,8 @@ require_once ABSPATH . 'wp-admin/includes/ajax-actions.php';
  */
 class Tests_Ajax_wpAjaxSendAttachmentToEditor extends WP_Ajax_UnitTestCase {
 
+	use WP_Test_RunsFileUploadTests;
+
 	/**
 	 * @ticket 36578
 	 *

--- a/tests/phpunit/tests/general/template.php
+++ b/tests/phpunit/tests/general/template.php
@@ -10,6 +10,9 @@
 require_once ABSPATH . 'wp-admin/includes/class-wp-site-icon.php';
 
 class Tests_General_Template extends WP_UnitTestCase {
+
+	use WP_Test_RunsFileUploadTests;
+
 	protected $wp_site_icon;
 	public $site_icon_id;
 	public $site_icon_url;

--- a/tests/phpunit/tests/image/intermediateSize.php
+++ b/tests/phpunit/tests/image/intermediateSize.php
@@ -15,13 +15,6 @@ class Tests_Image_Intermediate_Size extends WP_UnitTestCase {
 		parent::tear_down();
 	}
 
-	public function _make_attachment( $file, $parent_post_id = 0 ) {
-		$contents = file_get_contents( $file );
-		$upload   = wp_upload_bits( wp_basename( $file ), null, $contents );
-
-		return parent::_make_attachment( $upload, $parent_post_id );
-	}
-
 	public function test_make_intermediate_size_no_size() {
 		$image = image_make_intermediate_size( DIR_TESTDATA . '/images/a2-small.jpg', 0, 0, false );
 
@@ -96,7 +89,7 @@ class Tests_Image_Intermediate_Size extends WP_UnitTestCase {
 		add_image_size( 'test-size', 330, 220, true );
 
 		$file = DIR_TESTDATA . '/images/waffles.jpg';
-		$id   = $this->_make_attachment( $file, 0 );
+		$id   = $this->_upload_file_and_make_attachment( $file );
 
 		// Look for a size by name.
 		$image = image_get_intermediate_size( $id, 'test-size' );
@@ -120,7 +113,7 @@ class Tests_Image_Intermediate_Size extends WP_UnitTestCase {
 		add_image_size( 'false-width', 600, 220, true );
 
 		$file = DIR_TESTDATA . '/images/waffles.jpg';
-		$id   = $this->_make_attachment( $file, 0 );
+		$id   = $this->_upload_file_and_make_attachment( $file );
 
 		// Look for a size by array that exists.
 		// Note: Staying larger than 300px to miss default medium crop.
@@ -143,7 +136,7 @@ class Tests_Image_Intermediate_Size extends WP_UnitTestCase {
 		add_image_size( 'false-width', 150, 220, true );
 
 		$file = DIR_TESTDATA . '/images/waffles.jpg';
-		$id   = $this->_make_attachment( $file, 0 );
+		$id   = $this->_upload_file_and_make_attachment( $file );
 
 		// Look for a size by array that doesn't exist.
 		// Note: Staying larger than 300px to miss default medium crop.
@@ -165,7 +158,7 @@ class Tests_Image_Intermediate_Size extends WP_UnitTestCase {
 		add_image_size( 'false-width', 150, 220, true );
 
 		$file = DIR_TESTDATA . '/images/waffles.jpg';
-		$id   = $this->_make_attachment( $file, 0 );
+		$id   = $this->_upload_file_and_make_attachment( $file );
 
 		// Look for a size by array that doesn't exist.
 		// Note: Staying larger than 300px to miss default medium crop.
@@ -189,7 +182,7 @@ class Tests_Image_Intermediate_Size extends WP_UnitTestCase {
 		add_image_size( 'false-height', $width, 100, true );
 
 		$file = DIR_TESTDATA . '/images/waffles.jpg';
-		$id   = $this->_make_attachment( $file, 0 );
+		$id   = $this->_upload_file_and_make_attachment( $file );
 
 		$original = wp_get_attachment_metadata( $id );
 		$image_w  = $width;
@@ -218,7 +211,7 @@ class Tests_Image_Intermediate_Size extends WP_UnitTestCase {
 		add_image_size( 'false-height', 300, $height, true );
 
 		$file = DIR_TESTDATA . '/images/waffles.jpg';
-		$id   = $this->_make_attachment( $file, 0 );
+		$id   = $this->_upload_file_and_make_attachment( $file );
 
 		$original = wp_get_attachment_metadata( $id );
 		$image_h  = $height;
@@ -245,7 +238,7 @@ class Tests_Image_Intermediate_Size extends WP_UnitTestCase {
 		add_image_size( 'off-by-one', $width, $height, true );
 
 		$file = DIR_TESTDATA . '/images/waffles.jpg';
-		$id   = $this->_make_attachment( $file, 0 );
+		$id   = $this->_upload_file_and_make_attachment( $file );
 
 		$original = wp_get_attachment_metadata( $id );
 		$image_h  = $height;
@@ -267,7 +260,7 @@ class Tests_Image_Intermediate_Size extends WP_UnitTestCase {
 		add_image_size( 'test-size', 200, 100, true );
 
 		$file = DIR_TESTDATA . '/images/waffles.jpg';
-		$id   = $this->_make_attachment( $file, 0 );
+		$id   = $this->_upload_file_and_make_attachment( $file );
 
 		// Request a size by array that doesn't exist and is smaller than the 'thumbnail'.
 		$image = image_get_intermediate_size( $id, array( 50, 25 ) );
@@ -282,7 +275,7 @@ class Tests_Image_Intermediate_Size extends WP_UnitTestCase {
 	 */
 	public function test_get_intermediate_size_with_small_size_array_fallback() {
 		$file = DIR_TESTDATA . '/images/waffles.jpg';
-		$id   = $this->_make_attachment( $file, 0 );
+		$id   = $this->_upload_file_and_make_attachment( $file );
 
 		$original       = wp_get_attachment_metadata( $id );
 		$thumbnail_file = $original['sizes']['thumbnail']['file'];

--- a/tests/phpunit/tests/image/intermediateSize.php
+++ b/tests/phpunit/tests/image/intermediateSize.php
@@ -5,6 +5,9 @@
  * @group upload
  */
 class Tests_Image_Intermediate_Size extends WP_UnitTestCase {
+
+	use WP_Test_RunsFileUploadTests;
+
 	public function tear_down() {
 		$this->remove_added_uploads();
 

--- a/tests/phpunit/tests/image/siteIcon.php
+++ b/tests/phpunit/tests/image/siteIcon.php
@@ -8,6 +8,9 @@
 require_once ABSPATH . 'wp-admin/includes/class-wp-site-icon.php';
 
 class Tests_WP_Site_Icon extends WP_UnitTestCase {
+
+	use WP_Test_RunsFileUploadTests;
+
 	protected $wp_site_icon;
 
 	public $attachment_id = 0;

--- a/tests/phpunit/tests/image/siteIcon.php
+++ b/tests/phpunit/tests/image/siteIcon.php
@@ -160,12 +160,7 @@ class Tests_WP_Site_Icon extends WP_UnitTestCase {
 			return $this->attachment_id;
 		}
 
-		$filename = DIR_TESTDATA . '/images/test-image.jpg';
-		$contents = file_get_contents( $filename );
-
-		$upload = wp_upload_bits( wp_basename( $filename ), null, $contents );
-
-		$this->attachment_id = $this->_make_attachment( $upload );
+		$this->attachment_id = $this->_upload_file_and_make_attachment( DIR_TESTDATA . '/images/test-image.jpg' );
 		return $this->attachment_id;
 	}
 }

--- a/tests/phpunit/tests/post/attachments.php
+++ b/tests/phpunit/tests/post/attachments.php
@@ -441,11 +441,7 @@ class Tests_Post_Attachments extends WP_UnitTestCase {
 	}
 
 	public function test_wp_attachment_is() {
-		$filename = DIR_TESTDATA . '/images/test-image.jpg';
-		$contents = file_get_contents( $filename );
-
-		$upload        = wp_upload_bits( wp_basename( $filename ), null, $contents );
-		$attachment_id = $this->_make_attachment( $upload );
+		$attachment_id = $this->_upload_file_and_make_attachment( DIR_TESTDATA . '/images/test-image.jpg' );
 
 		$this->assertTrue( wp_attachment_is_image( $attachment_id ) );
 		$this->assertTrue( wp_attachment_is( 'image', $attachment_id ) );
@@ -459,11 +455,7 @@ class Tests_Post_Attachments extends WP_UnitTestCase {
 			add_filter( 'upload_mimes', array( $this, 'allow_psd_mime_type' ), 10, 2 );
 		}
 
-		$filename = DIR_TESTDATA . '/images/test-image.psd';
-		$contents = file_get_contents( $filename );
-
-		$upload        = wp_upload_bits( wp_basename( $filename ), null, $contents );
-		$attachment_id = $this->_make_attachment( $upload );
+		$attachment_id = $this->_upload_file_and_make_attachment( DIR_TESTDATA . '/images/test-image.psd' );
 
 		$this->assertFalse( wp_attachment_is_image( $attachment_id ) );
 		$this->assertTrue( wp_attachment_is( 'psd', $attachment_id ) );

--- a/tests/phpunit/tests/post/attachments.php
+++ b/tests/phpunit/tests/post/attachments.php
@@ -7,6 +7,8 @@
  */
 class Tests_Post_Attachments extends WP_UnitTestCase {
 
+	use WP_Test_RunsFileUploadTests;
+
 	public function tear_down() {
 		// Remove all uploads.
 		$this->remove_added_uploads();

--- a/tests/phpunit/tests/xmlrpc/wp/getMediaItem.php
+++ b/tests/phpunit/tests/xmlrpc/wp/getMediaItem.php
@@ -19,11 +19,7 @@ class Tests_XMLRPC_wp_getMediaItem extends WP_XMLRPC_UnitTestCase {
 
 		add_theme_support( 'post-thumbnails' );
 
-		$filename = ( DIR_TESTDATA . '/images/waffles.jpg' );
-		$contents = file_get_contents( $filename );
-		$upload   = wp_upload_bits( wp_basename( $filename ), null, $contents );
-
-		$this->attachment_id   = $this->_make_attachment( $upload, self::$post_id );
+		$this->attachment_id   = $this->_upload_file_and_make_attachment( DIR_TESTDATA . '/images/waffles.jpg', self::$post_id );
 		$this->attachment_data = get_post( $this->attachment_id, ARRAY_A );
 
 		set_post_thumbnail( self::$post_id, $this->attachment_id );

--- a/tests/phpunit/tests/xmlrpc/wp/getMediaItem.php
+++ b/tests/phpunit/tests/xmlrpc/wp/getMediaItem.php
@@ -5,6 +5,9 @@
  * @requires function imagejpeg
  */
 class Tests_XMLRPC_wp_getMediaItem extends WP_XMLRPC_UnitTestCase {
+
+	use WP_Test_RunsFileUploadTests;
+
 	protected static $post_id;
 
 	public $attachment_data;


### PR DESCRIPTION
The PR introduces a new method `WP_UnitTestCase_Base::_upload_file_and_make_attachment()` that uploads given file and creates an attachment post from it.

It also replaces all occurrences of the repetitive code - with the exception of few places where extra tests are ran to check the result of `wp_upload_bits()` call.

Trac ticket: https://core.trac.wordpress.org/ticket/56248

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
