### PR TITLE
PHP 8.2 | GH Actions: start running the unit tests against PHP 8.2

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -34,8 +34,8 @@ env:
 jobs:
   # Runs the PHPUnit tests for WordPress.
   #
-  # Note: Steps running tests for PHP 8.1 jobs are allowed to "continue-on-error".
-  # This prevents workflow runs from being marked as "failed" when only PHP 8.1 fails.
+  # Note: Steps running tests on PHP 8.1 + 8.2 are allowed to "continue-on-error" (for now).
+  # This prevents workflow runs from being marked as "failed" when only PHP 8.1/8.2 fails.
   #
   # Performs the following steps:
   # - Sets environment variables.
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1' ]
+        php: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2' ]
         os: [ ubuntu-latest ]
         memcached: [ false ]
         split_slow: [ false ]
@@ -143,8 +143,8 @@ jobs:
           docker-compose run --rm php composer --version
 
           # Install using `composer update` as there is no `composer.lock` file.
-          if [ ${{ env.LOCAL_PHP }} == '8.1-fpm' ]; then
-            docker-compose run --rm php composer update --ignore-platform-reqs
+          if [ ${{ env.LOCAL_PHP }} == '8.2-fpm' ]; then
+            docker-compose run --rm php composer update --ignore-platform-req=php+
           else
             docker-compose run --rm php composer update
           fi
@@ -194,27 +194,27 @@ jobs:
 
       - name: Run PHPUnit tests
         if: ${{ matrix.php >= '7.0' }}
-        continue-on-error: ${{ matrix.php == '8.1' }}
+        continue-on-error: ${{ matrix.php == '8.1' || matrix.php == '8.2'  }}
         run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c ${{ env.PHPUNIT_CONFIG }}
 
       - name: Run AJAX tests
         if: ${{ ! matrix.split_slow }}
-        continue-on-error: ${{ matrix.php == '8.1' }}
+        continue-on-error: ${{ matrix.php == '8.1' || matrix.php == '8.2' }}
         run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c ${{ env.PHPUNIT_CONFIG }} --group ajax
 
       - name: Run ms-files tests as a multisite install
         if: ${{ matrix.multisite && ! matrix.split_slow }}
-        continue-on-error: ${{ matrix.php == '8.1' }}
+        continue-on-error: ${{ matrix.php == '8.1' || matrix.php == '8.2' }}
         run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c tests/phpunit/multisite.xml --group ms-files
 
       - name: Run external HTTP tests
         if: ${{ ! matrix.multisite && ! matrix.split_slow }}
-        continue-on-error: ${{ matrix.php == '8.1' }}
+        continue-on-error: ${{ matrix.php == '8.1' || matrix.php == '8.2' }}
         run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c phpunit.xml.dist --group external-http
 
       # __fakegroup__ is excluded to force PHPUnit to ignore the <exclude> settings in phpunit.xml.dist.
-      - name: Run (xDebug) tests
-        if: ${{ ! matrix.split_slow }}
+      - name: Run (Xdebug) tests
+        if: ${{ ! matrix.split_slow && matrix.php != '8.2' }}
         continue-on-error: ${{ matrix.php == '8.1' }}
         run: LOCAL_PHP_XDEBUG=true node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit -v --group xdebug --exclude-group __fakegroup__
 


### PR DESCRIPTION
Notes:
* The `composer install` for PHP 8.1 was still using `--ignore-platform-reqs`, while that hasn't been needed anymore for quite a while, so I'm just re-using the condition for PHP 8.2 now.
* I've also made the `--ignore-platform...` option used for the install more specific.
    Composer 2.0 added a `--ignore-platform-req=...` option to selectively ignore platform requirements.
    Composer 2.2 then added the ability to only ignore the upper bound of platform requirements by adding the `+` sign.
* As discussed for PHP 8.1, builds against PHP 8.2 will still be allowed to fail (and will fail, not just due to new PHP 8.2 issues, but also due to unsolved PHP 8.1 issues). Allowing those builds to fail prevents merges in the Gutenberg project becoming blocked.
* As for the Xdebug related tests: those will not be run on PHP 8.2 yet as the Docker image for PHP 8.2 does not contain Xdebug yet. Once a stable release of Xdebug 3.2.0 is available, it can be added to the Docker image and the test step can then be enabled for PHP 8.2.

Refs:
* https://github.com/WordPress/wpdev-docker-images/pull/87
* https://github.com/composer/composer/releases/tag/2.0.0
* https://github.com/composer/composer/releases/tag/2.2.0
* https://xdebug.org/announcements/2022-07-20
* https://xdebug.org/announcements/2022-07-25

Trac ticket: https://core.trac.wordpress.org/ticket/56009

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
