### PR TITLE
PHP 8.2 | Add `AllowDynamicProperties` attribute to all (parent) classes

### DIFF
--- a/src/wp-admin/includes/class-custom-background.php
+++ b/src/wp-admin/includes/class-custom-background.php
@@ -11,6 +11,7 @@
  *
  * @since 3.0.0
  */
+#[AllowDynamicProperties]
 class Custom_Background {
 
 	/**

--- a/src/wp-admin/includes/class-custom-image-header.php
+++ b/src/wp-admin/includes/class-custom-image-header.php
@@ -11,6 +11,7 @@
  *
  * @since 2.1.0
  */
+#[AllowDynamicProperties]
 class Custom_Image_Header {
 
 	/**

--- a/src/wp-admin/includes/class-file-upload-upgrader.php
+++ b/src/wp-admin/includes/class-file-upload-upgrader.php
@@ -16,6 +16,7 @@
  * @since 2.8.0
  * @since 4.6.0 Moved to its own file from wp-admin/includes/class-wp-upgrader.php.
  */
+#[AllowDynamicProperties]
 class File_Upload_Upgrader {
 
 	/**

--- a/src/wp-admin/includes/class-wp-automatic-updater.php
+++ b/src/wp-admin/includes/class-wp-automatic-updater.php
@@ -13,6 +13,7 @@
  * @since 3.7.0
  * @since 4.6.0 Moved to its own file from wp-admin/includes/class-wp-upgrader.php.
  */
+#[AllowDynamicProperties]
 class WP_Automatic_Updater {
 
 	/**

--- a/src/wp-admin/includes/class-wp-community-events.php
+++ b/src/wp-admin/includes/class-wp-community-events.php
@@ -14,6 +14,7 @@
  *
  * @since 4.8.0
  */
+#[AllowDynamicProperties]
 class WP_Community_Events {
 	/**
 	 * ID for a WordPress user account.

--- a/src/wp-admin/includes/class-wp-debug-data.php
+++ b/src/wp-admin/includes/class-wp-debug-data.php
@@ -7,6 +7,7 @@
  * @since 5.2.0
  */
 
+#[AllowDynamicProperties]
 class WP_Debug_Data {
 	/**
 	 * Calls all core functions to check for updates.

--- a/src/wp-admin/includes/class-wp-filesystem-base.php
+++ b/src/wp-admin/includes/class-wp-filesystem-base.php
@@ -11,6 +11,7 @@
  *
  * @since 2.5.0
  */
+#[AllowDynamicProperties]
 class WP_Filesystem_Base {
 
 	/**

--- a/src/wp-admin/includes/class-wp-importer.php
+++ b/src/wp-admin/includes/class-wp-importer.php
@@ -2,6 +2,7 @@
 /**
  * WP_Importer base class
  */
+#[AllowDynamicProperties]
 class WP_Importer {
 	/**
 	 * Class Constructor

--- a/src/wp-admin/includes/class-wp-internal-pointers.php
+++ b/src/wp-admin/includes/class-wp-internal-pointers.php
@@ -12,6 +12,7 @@
  *
  * @since 3.3.0
  */
+#[AllowDynamicProperties]
 final class WP_Internal_Pointers {
 	/**
 	 * Initializes the new feature pointers.

--- a/src/wp-admin/includes/class-wp-list-table.php
+++ b/src/wp-admin/includes/class-wp-list-table.php
@@ -13,6 +13,7 @@
  * @since 3.1.0
  * @access private
  */
+#[AllowDynamicProperties]
 class WP_List_Table {
 
 	/**

--- a/src/wp-admin/includes/class-wp-privacy-policy-content.php
+++ b/src/wp-admin/includes/class-wp-privacy-policy-content.php
@@ -7,6 +7,7 @@
  * @since 4.9.6
  */
 
+#[AllowDynamicProperties]
 final class WP_Privacy_Policy_Content {
 
 	private static $policy_content = array();

--- a/src/wp-admin/includes/class-wp-screen.php
+++ b/src/wp-admin/includes/class-wp-screen.php
@@ -12,6 +12,7 @@
  *
  * @since 3.3.0
  */
+#[AllowDynamicProperties]
 final class WP_Screen {
 	/**
 	 * Any action associated with the screen.

--- a/src/wp-admin/includes/class-wp-site-health-auto-updates.php
+++ b/src/wp-admin/includes/class-wp-site-health-auto-updates.php
@@ -7,6 +7,7 @@
  * @since 5.2.0
  */
 
+#[AllowDynamicProperties]
 class WP_Site_Health_Auto_Updates {
 	/**
 	 * WP_Site_Health_Auto_Updates constructor.

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -7,6 +7,7 @@
  * @since 5.2.0
  */
 
+#[AllowDynamicProperties]
 class WP_Site_Health {
 	private static $instance = null;
 

--- a/src/wp-admin/includes/class-wp-site-icon.php
+++ b/src/wp-admin/includes/class-wp-site-icon.php
@@ -12,6 +12,7 @@
  *
  * @since 4.3.0
  */
+#[AllowDynamicProperties]
 class WP_Site_Icon {
 
 	/**

--- a/src/wp-admin/includes/class-wp-upgrader-skin.php
+++ b/src/wp-admin/includes/class-wp-upgrader-skin.php
@@ -13,6 +13,7 @@
  * @since 2.8.0
  * @since 4.6.0 Moved to its own file from wp-admin/includes/class-wp-upgrader-skins.php.
  */
+#[AllowDynamicProperties]
 class WP_Upgrader_Skin {
 
 	/**

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -48,6 +48,7 @@ require_once ABSPATH . 'wp-admin/includes/class-wp-ajax-upgrader-skin.php';
  *
  * @since 2.8.0
  */
+#[AllowDynamicProperties]
 class WP_Upgrader {
 
 	/**

--- a/src/wp-includes/class-wp-admin-bar.php
+++ b/src/wp-includes/class-wp-admin-bar.php
@@ -12,6 +12,7 @@
  *
  * @since 3.1.0
  */
+#[AllowDynamicProperties]
 class WP_Admin_Bar {
 	private $nodes = array();
 	private $bound = false;

--- a/src/wp-includes/class-wp-ajax-response.php
+++ b/src/wp-includes/class-wp-ajax-response.php
@@ -5,6 +5,7 @@
  * @package WordPress
  * @since 2.1.0
  */
+#[AllowDynamicProperties]
 class WP_Ajax_Response {
 	/**
 	 * Store XML responses to send.

--- a/src/wp-includes/class-wp-application-passwords.php
+++ b/src/wp-includes/class-wp-application-passwords.php
@@ -11,6 +11,7 @@
  *
  * @package WordPress
  */
+#[AllowDynamicProperties]
 class WP_Application_Passwords {
 
 	/**

--- a/src/wp-includes/class-wp-block-editor-context.php
+++ b/src/wp-includes/class-wp-block-editor-context.php
@@ -11,6 +11,7 @@
  *
  * @since 5.8.0
  */
+#[AllowDynamicProperties]
 final class WP_Block_Editor_Context {
 	/**
 	 * String that identifies the block editor being rendered. Can be one of:

--- a/src/wp-includes/class-wp-block-list.php
+++ b/src/wp-includes/class-wp-block-list.php
@@ -11,6 +11,7 @@
  *
  * @since 5.5.0
  */
+#[AllowDynamicProperties]
 class WP_Block_List implements Iterator, ArrayAccess, Countable {
 
 	/**

--- a/src/wp-includes/class-wp-block-pattern-categories-registry.php
+++ b/src/wp-includes/class-wp-block-pattern-categories-registry.php
@@ -10,6 +10,7 @@
 /**
  * Class used for interacting with block pattern categories.
  */
+#[AllowDynamicProperties]
 final class WP_Block_Pattern_Categories_Registry {
 	/**
 	 * Registered block pattern categories array.

--- a/src/wp-includes/class-wp-block-patterns-registry.php
+++ b/src/wp-includes/class-wp-block-patterns-registry.php
@@ -12,6 +12,7 @@
  *
  * @since 5.5.0
  */
+#[AllowDynamicProperties]
 final class WP_Block_Patterns_Registry {
 	/**
 	 * Registered block patterns array.

--- a/src/wp-includes/class-wp-block-styles-registry.php
+++ b/src/wp-includes/class-wp-block-styles-registry.php
@@ -12,6 +12,7 @@
  *
  * @since 5.3.0
  */
+#[AllowDynamicProperties]
 final class WP_Block_Styles_Registry {
 	/**
 	 * Registered block styles, as `$block_name => $block_style_name => $block_style_properties` multidimensional arrays.

--- a/src/wp-includes/class-wp-block-supports.php
+++ b/src/wp-includes/class-wp-block-supports.php
@@ -14,6 +14,7 @@
  *
  * @access private
  */
+#[AllowDynamicProperties]
 class WP_Block_Supports {
 
 	/**

--- a/src/wp-includes/class-wp-block-template.php
+++ b/src/wp-includes/class-wp-block-template.php
@@ -11,6 +11,7 @@
  *
  * @since 5.8.0
  */
+#[AllowDynamicProperties]
 class WP_Block_Template {
 
 	/**

--- a/src/wp-includes/class-wp-block-type-registry.php
+++ b/src/wp-includes/class-wp-block-type-registry.php
@@ -12,6 +12,7 @@
  *
  * @since 5.0.0
  */
+#[AllowDynamicProperties]
 final class WP_Block_Type_Registry {
 	/**
 	 * Registered block types, as `$name => $instance` pairs.

--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -14,6 +14,7 @@
  *
  * @see register_block_type()
  */
+#[AllowDynamicProperties]
 class WP_Block_Type {
 
 	/**

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -12,6 +12,7 @@
  * @since 5.5.0
  * @property array $attributes
  */
+#[AllowDynamicProperties]
 class WP_Block {
 
 	/**

--- a/src/wp-includes/class-wp-comment-query.php
+++ b/src/wp-includes/class-wp-comment-query.php
@@ -14,6 +14,7 @@
  *
  * @see WP_Comment_Query::__construct() for accepted arguments.
  */
+#[AllowDynamicProperties]
 class WP_Comment_Query {
 
 	/**

--- a/src/wp-includes/class-wp-comment.php
+++ b/src/wp-includes/class-wp-comment.php
@@ -12,6 +12,7 @@
  *
  * @since 4.4.0
  */
+#[AllowDynamicProperties]
 final class WP_Comment {
 
 	/**

--- a/src/wp-includes/class-wp-customize-control.php
+++ b/src/wp-includes/class-wp-customize-control.php
@@ -12,6 +12,7 @@
  *
  * @since 3.4.0
  */
+#[AllowDynamicProperties]
 class WP_Customize_Control {
 
 	/**

--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -20,6 +20,7 @@
  *
  * @since 3.4.0
  */
+#[AllowDynamicProperties]
 final class WP_Customize_Manager {
 	/**
 	 * An instance of the theme being previewed.

--- a/src/wp-includes/class-wp-customize-nav-menus.php
+++ b/src/wp-includes/class-wp-customize-nav-menus.php
@@ -16,6 +16,7 @@
  *
  * @see WP_Customize_Manager
  */
+#[AllowDynamicProperties]
 final class WP_Customize_Nav_Menus {
 
 	/**

--- a/src/wp-includes/class-wp-customize-panel.php
+++ b/src/wp-includes/class-wp-customize-panel.php
@@ -16,6 +16,7 @@
  *
  * @see WP_Customize_Manager
  */
+#[AllowDynamicProperties]
 class WP_Customize_Panel {
 
 	/**

--- a/src/wp-includes/class-wp-customize-section.php
+++ b/src/wp-includes/class-wp-customize-section.php
@@ -16,6 +16,7 @@
  *
  * @see WP_Customize_Manager
  */
+#[AllowDynamicProperties]
 class WP_Customize_Section {
 
 	/**

--- a/src/wp-includes/class-wp-customize-setting.php
+++ b/src/wp-includes/class-wp-customize-setting.php
@@ -17,6 +17,7 @@
  * @see WP_Customize_Manager
  * @link https://developer.wordpress.org/themes/customize-api
  */
+#[AllowDynamicProperties]
 class WP_Customize_Setting {
 	/**
 	 * Customizer bootstrap instance.

--- a/src/wp-includes/class-wp-customize-widgets.php
+++ b/src/wp-includes/class-wp-customize-widgets.php
@@ -16,6 +16,7 @@
  *
  * @see WP_Customize_Manager
  */
+#[AllowDynamicProperties]
 final class WP_Customize_Widgets {
 
 	/**

--- a/src/wp-includes/class-wp-date-query.php
+++ b/src/wp-includes/class-wp-date-query.php
@@ -14,6 +14,7 @@
  *
  * @since 3.7.0
  */
+#[AllowDynamicProperties]
 class WP_Date_Query {
 	/**
 	 * Array of date queries.

--- a/src/wp-includes/class-wp-dependency.php
+++ b/src/wp-includes/class-wp-dependency.php
@@ -16,6 +16,7 @@
  * @access private
  * @since 2.6.0
  */
+#[AllowDynamicProperties]
 class _WP_Dependency {
 	/**
 	 * The handle name.

--- a/src/wp-includes/class-wp-editor.php
+++ b/src/wp-includes/class-wp-editor.php
@@ -8,6 +8,7 @@
  * Private, not included by default. See wp_editor() in wp-includes/general-template.php.
  */
 
+#[AllowDynamicProperties]
 final class _WP_Editors {
 	public static $mce_locale;
 

--- a/src/wp-includes/class-wp-embed.php
+++ b/src/wp-includes/class-wp-embed.php
@@ -6,6 +6,7 @@
  * @subpackage Embed
  * @since 2.9.0
  */
+#[AllowDynamicProperties]
 class WP_Embed {
 	public $handlers = array();
 	public $post_ID;

--- a/src/wp-includes/class-wp-error.php
+++ b/src/wp-includes/class-wp-error.php
@@ -15,6 +15,7 @@
  *
  * @since 2.1.0
  */
+#[AllowDynamicProperties]
 class WP_Error {
 	/**
 	 * Stores the list of errors.

--- a/src/wp-includes/class-wp-fatal-error-handler.php
+++ b/src/wp-includes/class-wp-fatal-error-handler.php
@@ -16,6 +16,7 @@
  *
  * @since 5.2.0
  */
+#[AllowDynamicProperties]
 class WP_Fatal_Error_Handler {
 
 	/**

--- a/src/wp-includes/class-wp-feed-cache-transient.php
+++ b/src/wp-includes/class-wp-feed-cache-transient.php
@@ -12,6 +12,7 @@
  *
  * @since 2.8.0
  */
+#[AllowDynamicProperties]
 class WP_Feed_Cache_Transient {
 
 	/**

--- a/src/wp-includes/class-wp-feed-cache.php
+++ b/src/wp-includes/class-wp-feed-cache.php
@@ -22,6 +22,7 @@ _deprecated_file(
  *
  * @see SimplePie_Cache
  */
+#[AllowDynamicProperties]
 class WP_Feed_Cache extends SimplePie_Cache {
 
 	/**

--- a/src/wp-includes/class-wp-hook.php
+++ b/src/wp-includes/class-wp-hook.php
@@ -15,6 +15,7 @@
  * @see Iterator
  * @see ArrayAccess
  */
+#[AllowDynamicProperties]
 final class WP_Hook implements Iterator, ArrayAccess {
 
 	/**

--- a/src/wp-includes/class-wp-http-cookie.php
+++ b/src/wp-includes/class-wp-http-cookie.php
@@ -18,6 +18,7 @@
  *
  * @since 2.8.0
  */
+#[AllowDynamicProperties]
 class WP_Http_Cookie {
 
 	/**

--- a/src/wp-includes/class-wp-http-curl.php
+++ b/src/wp-includes/class-wp-http-curl.php
@@ -16,6 +16,7 @@
  *
  * @since 2.7.0
  */
+#[AllowDynamicProperties]
 class WP_Http_Curl {
 
 	/**

--- a/src/wp-includes/class-wp-http-encoding.php
+++ b/src/wp-includes/class-wp-http-encoding.php
@@ -14,6 +14,7 @@
  *
  * @since 2.8.0
  */
+#[AllowDynamicProperties]
 class WP_Http_Encoding {
 
 	/**

--- a/src/wp-includes/class-wp-http-ixr-client.php
+++ b/src/wp-includes/class-wp-http-ixr-client.php
@@ -5,6 +5,7 @@
  * @package WordPress
  * @since 3.1.0
  */
+#[AllowDynamicProperties]
 class WP_HTTP_IXR_Client extends IXR_Client {
 	public $scheme;
 	/**

--- a/src/wp-includes/class-wp-http-proxy.php
+++ b/src/wp-includes/class-wp-http-proxy.php
@@ -39,6 +39,7 @@
  *
  * @since 2.8.0
  */
+#[AllowDynamicProperties]
 class WP_HTTP_Proxy {
 
 	/**

--- a/src/wp-includes/class-wp-http-requests-hooks.php
+++ b/src/wp-includes/class-wp-http-requests-hooks.php
@@ -14,6 +14,7 @@
  *
  * @see Requests_Hooks
  */
+#[AllowDynamicProperties]
 class WP_HTTP_Requests_Hooks extends Requests_Hooks {
 	/**
 	 * Requested URL.

--- a/src/wp-includes/class-wp-http-response.php
+++ b/src/wp-includes/class-wp-http-response.php
@@ -12,6 +12,7 @@
  *
  * @since 4.4.0
  */
+#[AllowDynamicProperties]
 class WP_HTTP_Response {
 
 	/**

--- a/src/wp-includes/class-wp-http-streams.php
+++ b/src/wp-includes/class-wp-http-streams.php
@@ -13,6 +13,7 @@
  * @since 2.7.0
  * @since 3.7.0 Combined with the fsockopen transport and switched to `stream_socket_client()`.
  */
+#[AllowDynamicProperties]
 class WP_Http_Streams {
 	/**
 	 * Send a HTTP request to a URI using PHP Streams.

--- a/src/wp-includes/class-wp-http.php
+++ b/src/wp-includes/class-wp-http.php
@@ -25,6 +25,7 @@ if ( ! class_exists( 'Requests' ) ) {
  *
  * @since 2.7.0
  */
+#[AllowDynamicProperties]
 class WP_Http {
 
 	// Aliases for HTTP response codes.

--- a/src/wp-includes/class-wp-image-editor.php
+++ b/src/wp-includes/class-wp-image-editor.php
@@ -11,6 +11,7 @@
  *
  * @since 3.5.0
  */
+#[AllowDynamicProperties]
 abstract class WP_Image_Editor {
 	protected $file              = null;
 	protected $size              = null;

--- a/src/wp-includes/class-wp-list-util.php
+++ b/src/wp-includes/class-wp-list-util.php
@@ -13,6 +13,7 @@
  *
  * @since 4.7.0
  */
+#[AllowDynamicProperties]
 class WP_List_Util {
 	/**
 	 * The input array.

--- a/src/wp-includes/class-wp-locale-switcher.php
+++ b/src/wp-includes/class-wp-locale-switcher.php
@@ -12,6 +12,7 @@
  *
  * @since 4.7.0
  */
+#[AllowDynamicProperties]
 class WP_Locale_Switcher {
 	/**
 	 * Locale stack.

--- a/src/wp-includes/class-wp-locale.php
+++ b/src/wp-includes/class-wp-locale.php
@@ -13,6 +13,7 @@
  * @since 2.1.0
  * @since 4.6.0 Moved to its own file from wp-includes/locale.php.
  */
+#[AllowDynamicProperties]
 class WP_Locale {
 	/**
 	 * Stores the translated strings for the full weekday names.

--- a/src/wp-includes/class-wp-matchesmapregex.php
+++ b/src/wp-includes/class-wp-matchesmapregex.php
@@ -11,6 +11,7 @@
  *
  * @since 2.9.0
  */
+#[AllowDynamicProperties]
 class WP_MatchesMapRegex {
 	/**
 	 * store for matches

--- a/src/wp-includes/class-wp-meta-query.php
+++ b/src/wp-includes/class-wp-meta-query.php
@@ -19,6 +19,7 @@
  *
  * @since 3.2.0
  */
+#[AllowDynamicProperties]
 class WP_Meta_Query {
 	/**
 	 * Array of metadata queries.

--- a/src/wp-includes/class-wp-metadata-lazyloader.php
+++ b/src/wp-includes/class-wp-metadata-lazyloader.php
@@ -28,6 +28,7 @@
  *
  * @since 4.5.0
  */
+#[AllowDynamicProperties]
 class WP_Metadata_Lazyloader {
 	/**
 	 * Pending objects queue.

--- a/src/wp-includes/class-wp-network-query.php
+++ b/src/wp-includes/class-wp-network-query.php
@@ -14,6 +14,7 @@
  *
  * @see WP_Network_Query::__construct() for accepted arguments.
  */
+#[AllowDynamicProperties]
 class WP_Network_Query {
 
 	/**

--- a/src/wp-includes/class-wp-network.php
+++ b/src/wp-includes/class-wp-network.php
@@ -21,6 +21,7 @@
  * @property int $id
  * @property int $site_id
  */
+#[AllowDynamicProperties]
 class WP_Network {
 
 	/**

--- a/src/wp-includes/class-wp-object-cache.php
+++ b/src/wp-includes/class-wp-object-cache.php
@@ -21,6 +21,7 @@
  *
  * @since 2.0.0
  */
+#[AllowDynamicProperties]
 class WP_Object_Cache {
 
 	/**

--- a/src/wp-includes/class-wp-oembed-controller.php
+++ b/src/wp-includes/class-wp-oembed-controller.php
@@ -15,6 +15,7 @@
  *
  * @since 4.4.0
  */
+#[AllowDynamicProperties]
 final class WP_oEmbed_Controller {
 	/**
 	 * Register the oEmbed REST API route.

--- a/src/wp-includes/class-wp-oembed.php
+++ b/src/wp-includes/class-wp-oembed.php
@@ -16,6 +16,7 @@
  *
  * @since 2.9.0
  */
+#[AllowDynamicProperties]
 class WP_oEmbed {
 
 	/**

--- a/src/wp-includes/class-wp-paused-extensions-storage.php
+++ b/src/wp-includes/class-wp-paused-extensions-storage.php
@@ -11,6 +11,7 @@
  *
  * @since 5.2.0
  */
+#[AllowDynamicProperties]
 class WP_Paused_Extensions_Storage {
 
 	/**

--- a/src/wp-includes/class-wp-post-type.php
+++ b/src/wp-includes/class-wp-post-type.php
@@ -14,6 +14,7 @@
  *
  * @see register_post_type()
  */
+#[AllowDynamicProperties]
 final class WP_Post_Type {
 	/**
 	 * Post type key.

--- a/src/wp-includes/class-wp-post.php
+++ b/src/wp-includes/class-wp-post.php
@@ -18,6 +18,7 @@
  * @property-read int[]    $post_category
  * @property-read string[] $tags_input
  */
+#[AllowDynamicProperties]
 final class WP_Post {
 
 	/**

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -15,6 +15,7 @@
  * @since 1.5.0
  * @since 4.5.0 Removed the `$comments_popup` property.
  */
+#[AllowDynamicProperties]
 class WP_Query {
 
 	/**

--- a/src/wp-includes/class-wp-recovery-mode-cookie-service.php
+++ b/src/wp-includes/class-wp-recovery-mode-cookie-service.php
@@ -11,6 +11,7 @@
  *
  * @since 5.2.0
  */
+#[AllowDynamicProperties]
 final class WP_Recovery_Mode_Cookie_Service {
 
 	/**

--- a/src/wp-includes/class-wp-recovery-mode-email-service.php
+++ b/src/wp-includes/class-wp-recovery-mode-email-service.php
@@ -11,6 +11,7 @@
  *
  * @since 5.2.0
  */
+#[AllowDynamicProperties]
 final class WP_Recovery_Mode_Email_Service {
 
 	const RATE_LIMIT_OPTION = 'recovery_mode_email_last_sent';

--- a/src/wp-includes/class-wp-recovery-mode-key-service.php
+++ b/src/wp-includes/class-wp-recovery-mode-key-service.php
@@ -11,6 +11,7 @@
  *
  * @since 5.2.0
  */
+#[AllowDynamicProperties]
 final class WP_Recovery_Mode_Key_Service {
 
 	/**

--- a/src/wp-includes/class-wp-recovery-mode-link-service.php
+++ b/src/wp-includes/class-wp-recovery-mode-link-service.php
@@ -11,6 +11,7 @@
  *
  * @since 5.2.0
  */
+#[AllowDynamicProperties]
 class WP_Recovery_Mode_Link_Service {
 	const LOGIN_ACTION_ENTER   = 'enter_recovery_mode';
 	const LOGIN_ACTION_ENTERED = 'entered_recovery_mode';

--- a/src/wp-includes/class-wp-recovery-mode.php
+++ b/src/wp-includes/class-wp-recovery-mode.php
@@ -11,6 +11,7 @@
  *
  * @since 5.2.0
  */
+#[AllowDynamicProperties]
 class WP_Recovery_Mode {
 
 	const EXIT_ACTION = 'exit_recovery_mode';

--- a/src/wp-includes/class-wp-rewrite.php
+++ b/src/wp-includes/class-wp-rewrite.php
@@ -22,6 +22,7 @@
  *
  * @since 1.5.0
  */
+#[AllowDynamicProperties]
 class WP_Rewrite {
 	/**
 	 * Permalink structure for posts.

--- a/src/wp-includes/class-wp-role.php
+++ b/src/wp-includes/class-wp-role.php
@@ -12,6 +12,7 @@
  *
  * @since 2.0.0
  */
+#[AllowDynamicProperties]
 class WP_Role {
 	/**
 	 * Role name.

--- a/src/wp-includes/class-wp-roles.php
+++ b/src/wp-includes/class-wp-roles.php
@@ -23,6 +23,7 @@
  *
  * @since 2.0.0
  */
+#[AllowDynamicProperties]
 class WP_Roles {
 	/**
 	 * List of roles and capabilities.

--- a/src/wp-includes/class-wp-session-tokens.php
+++ b/src/wp-includes/class-wp-session-tokens.php
@@ -12,6 +12,7 @@
  *
  * @since 4.0.0
  */
+#[AllowDynamicProperties]
 abstract class WP_Session_Tokens {
 
 	/**

--- a/src/wp-includes/class-wp-simplepie-file.php
+++ b/src/wp-includes/class-wp-simplepie-file.php
@@ -17,6 +17,7 @@
  *
  * @see SimplePie_File
  */
+#[AllowDynamicProperties]
 class WP_SimplePie_File extends SimplePie_File {
 
 	/**

--- a/src/wp-includes/class-wp-simplepie-sanitize-kses.php
+++ b/src/wp-includes/class-wp-simplepie-sanitize-kses.php
@@ -17,6 +17,7 @@
  *
  * @see SimplePie_Sanitize
  */
+#[AllowDynamicProperties]
 class WP_SimplePie_Sanitize_KSES extends SimplePie_Sanitize {
 
 	/**

--- a/src/wp-includes/class-wp-site-query.php
+++ b/src/wp-includes/class-wp-site-query.php
@@ -14,6 +14,7 @@
  *
  * @see WP_Site_Query::__construct() for accepted arguments.
  */
+#[AllowDynamicProperties]
 class WP_Site_Query {
 
 	/**

--- a/src/wp-includes/class-wp-site.php
+++ b/src/wp-includes/class-wp-site.php
@@ -22,6 +22,7 @@
  * @property int    $post_count
  * @property string $home
  */
+#[AllowDynamicProperties]
 final class WP_Site {
 
 	/**

--- a/src/wp-includes/class-wp-tax-query.php
+++ b/src/wp-includes/class-wp-tax-query.php
@@ -19,6 +19,7 @@
  *
  * @since 3.1.0
  */
+#[AllowDynamicProperties]
 class WP_Tax_Query {
 
 	/**

--- a/src/wp-includes/class-wp-taxonomy.php
+++ b/src/wp-includes/class-wp-taxonomy.php
@@ -12,6 +12,7 @@
  *
  * @since 4.7.0
  */
+#[AllowDynamicProperties]
 final class WP_Taxonomy {
 	/**
 	 * Taxonomy key.

--- a/src/wp-includes/class-wp-term-query.php
+++ b/src/wp-includes/class-wp-term-query.php
@@ -15,6 +15,7 @@
  *
  * @see WP_Term_Query::__construct() for accepted arguments.
  */
+#[AllowDynamicProperties]
 class WP_Term_Query {
 
 	/**

--- a/src/wp-includes/class-wp-term.php
+++ b/src/wp-includes/class-wp-term.php
@@ -14,6 +14,7 @@
  *
  * @property-read object $data Sanitized term data.
  */
+#[AllowDynamicProperties]
 final class WP_Term {
 
 	/**

--- a/src/wp-includes/class-wp-text-diff-renderer-inline.php
+++ b/src/wp-includes/class-wp-text-diff-renderer-inline.php
@@ -13,6 +13,7 @@
  * @since 2.6.0
  * @uses Text_Diff_Renderer_inline Extends
  */
+#[AllowDynamicProperties]
 class WP_Text_Diff_Renderer_inline extends Text_Diff_Renderer_inline {
 
 	/**

--- a/src/wp-includes/class-wp-text-diff-renderer-table.php
+++ b/src/wp-includes/class-wp-text-diff-renderer-table.php
@@ -13,6 +13,7 @@
  * @since 2.6.0
  * @uses Text_Diff_Renderer Extends
  */
+#[AllowDynamicProperties]
 class WP_Text_Diff_Renderer_Table extends Text_Diff_Renderer {
 
 	/**

--- a/src/wp-includes/class-wp-textdomain-registry.php
+++ b/src/wp-includes/class-wp-textdomain-registry.php
@@ -12,6 +12,7 @@
  *
  * @since 6.1.0
  */
+#[AllowDynamicProperties]
 class WP_Textdomain_Registry {
 	/**
 	 * List of domains and all their language directory paths for each locale.

--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -17,6 +17,7 @@
  *
  * @access private
  */
+#[AllowDynamicProperties]
 class WP_Theme_JSON_Resolver {
 
 	/**

--- a/src/wp-includes/class-wp-theme-json-schema.php
+++ b/src/wp-includes/class-wp-theme-json-schema.php
@@ -17,6 +17,7 @@
  * @since 5.9.0
  * @access private
  */
+#[AllowDynamicProperties]
 class WP_Theme_JSON_Schema {
 
 	/**

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -16,6 +16,7 @@
  *
  * @access private
  */
+#[AllowDynamicProperties]
 class WP_Theme_JSON {
 
 	/**

--- a/src/wp-includes/class-wp-theme.php
+++ b/src/wp-includes/class-wp-theme.php
@@ -6,6 +6,7 @@
  * @subpackage Theme
  * @since 3.4.0
  */
+#[AllowDynamicProperties]
 final class WP_Theme implements ArrayAccess {
 
 	/**

--- a/src/wp-includes/class-wp-user-query.php
+++ b/src/wp-includes/class-wp-user-query.php
@@ -14,6 +14,7 @@
  *
  * @see WP_User_Query::prepare_query() for information on accepted arguments.
  */
+#[AllowDynamicProperties]
 class WP_User_Query {
 
 	/**

--- a/src/wp-includes/class-wp-user-request.php
+++ b/src/wp-includes/class-wp-user-request.php
@@ -6,6 +6,7 @@
  *
  * @since 4.9.6
  */
+#[AllowDynamicProperties]
 final class WP_User_Request {
 	/**
 	 * Request ID.

--- a/src/wp-includes/class-wp-user.php
+++ b/src/wp-includes/class-wp-user.php
@@ -36,6 +36,7 @@
  * @property string $syntax_highlighting
  * @property string $use_ssl
  */
+#[AllowDynamicProperties]
 class WP_User {
 	/**
 	 * User data container.

--- a/src/wp-includes/class-wp-walker.php
+++ b/src/wp-includes/class-wp-walker.php
@@ -11,6 +11,7 @@
  * @package WordPress
  * @abstract
  */
+#[AllowDynamicProperties]
 class Walker {
 	/**
 	 * What the class handles.

--- a/src/wp-includes/class-wp-widget-factory.php
+++ b/src/wp-includes/class-wp-widget-factory.php
@@ -13,6 +13,7 @@
  * @since 2.8.0
  * @since 4.4.0 Moved to its own file from wp-includes/widgets.php
  */
+#[AllowDynamicProperties]
 class WP_Widget_Factory {
 
 	/**

--- a/src/wp-includes/class-wp-widget.php
+++ b/src/wp-includes/class-wp-widget.php
@@ -17,6 +17,7 @@
  * @since 2.8.0
  * @since 4.4.0 Moved to its own file from wp-includes/widgets.php
  */
+#[AllowDynamicProperties]
 class WP_Widget {
 
 	/**

--- a/src/wp-includes/class-wp-xmlrpc-server.php
+++ b/src/wp-includes/class-wp-xmlrpc-server.php
@@ -20,6 +20,7 @@
  *
  * @see IXR_Server
  */
+#[AllowDynamicProperties]
 class wp_xmlrpc_server extends IXR_Server {
 	/**
 	 * Methods.

--- a/src/wp-includes/class-wp.php
+++ b/src/wp-includes/class-wp.php
@@ -5,6 +5,7 @@
  * @package WordPress
  * @since 2.0.0
  */
+#[AllowDynamicProperties]
 class WP {
 	/**
 	 * Public query variables.

--- a/src/wp-includes/class-wpdb.php
+++ b/src/wp-includes/class-wpdb.php
@@ -51,6 +51,7 @@ define( 'ARRAY_N', 'ARRAY_N' );
  *
  * @since 0.71
  */
+#[AllowDynamicProperties]
 class wpdb {
 
 	/**

--- a/src/wp-includes/class.wp-dependencies.php
+++ b/src/wp-includes/class.wp-dependencies.php
@@ -15,6 +15,7 @@
  *
  * @see _WP_Dependency
  */
+#[AllowDynamicProperties]
 class WP_Dependencies {
 	/**
 	 * An array of all registered dependencies keyed by handle.

--- a/src/wp-includes/customize/class-wp-customize-partial.php
+++ b/src/wp-includes/customize/class-wp-customize-partial.php
@@ -16,6 +16,7 @@
  *
  * @since 4.5.0
  */
+#[AllowDynamicProperties]
 class WP_Customize_Partial {
 
 	/**

--- a/src/wp-includes/customize/class-wp-customize-selective-refresh.php
+++ b/src/wp-includes/customize/class-wp-customize-selective-refresh.php
@@ -12,6 +12,7 @@
  *
  * @since 4.5.0
  */
+#[AllowDynamicProperties]
 final class WP_Customize_Selective_Refresh {
 
 	/**

--- a/src/wp-includes/pomo/entry.php
+++ b/src/wp-includes/pomo/entry.php
@@ -11,6 +11,7 @@ if ( ! class_exists( 'Translation_Entry', false ) ) :
 	/**
 	 * Translation_Entry class encapsulates a translatable string.
 	 */
+	#[AllowDynamicProperties]
 	class Translation_Entry {
 
 		/**

--- a/src/wp-includes/pomo/plural-forms.php
+++ b/src/wp-includes/pomo/plural-forms.php
@@ -6,6 +6,7 @@
  * @since 4.9.0
  */
 if ( ! class_exists( 'Plural_Forms', false ) ) :
+	#[AllowDynamicProperties]
 	class Plural_Forms {
 		/**
 		 * Operator characters.

--- a/src/wp-includes/pomo/streams.php
+++ b/src/wp-includes/pomo/streams.php
@@ -9,6 +9,7 @@
  */
 
 if ( ! class_exists( 'POMO_Reader', false ) ) :
+	#[AllowDynamicProperties]
 	class POMO_Reader {
 
 		public $endian = 'little';

--- a/src/wp-includes/pomo/translations.php
+++ b/src/wp-includes/pomo/translations.php
@@ -11,6 +11,7 @@ require_once __DIR__ . '/plural-forms.php';
 require_once __DIR__ . '/entry.php';
 
 if ( ! class_exists( 'Translations', false ) ) :
+	#[AllowDynamicProperties]
 	class Translations {
 		public $entries = array();
 		public $headers = array();
@@ -299,6 +300,7 @@ if ( ! class_exists( 'NOOP_Translations', false ) ) :
 	/**
 	 * Provides the same interface as Translations, but doesn't do anything
 	 */
+	#[AllowDynamicProperties]
 	class NOOP_Translations {
 		public $entries = array();
 		public $headers = array();

--- a/src/wp-includes/rest-api/class-wp-rest-request.php
+++ b/src/wp-includes/rest-api/class-wp-rest-request.php
@@ -26,6 +26,7 @@
  *
  * @link https://www.php.net/manual/en/class.arrayaccess.php
  */
+#[AllowDynamicProperties]
 class WP_REST_Request implements ArrayAccess {
 
 	/**

--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -12,6 +12,7 @@
  *
  * @since 4.4.0
  */
+#[AllowDynamicProperties]
 class WP_REST_Server {
 
 	/**

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-controller.php
@@ -12,6 +12,7 @@
  *
  * @since 4.7.0
  */
+#[AllowDynamicProperties]
 abstract class WP_REST_Controller {
 
 	/**

--- a/src/wp-includes/rest-api/fields/class-wp-rest-meta-fields.php
+++ b/src/wp-includes/rest-api/fields/class-wp-rest-meta-fields.php
@@ -12,6 +12,7 @@
  *
  * @since 4.7.0
  */
+#[AllowDynamicProperties]
 abstract class WP_REST_Meta_Fields {
 
 	/**

--- a/src/wp-includes/rest-api/search/class-wp-rest-search-handler.php
+++ b/src/wp-includes/rest-api/search/class-wp-rest-search-handler.php
@@ -12,6 +12,7 @@
  *
  * @since 5.0.0
  */
+#[AllowDynamicProperties]
 abstract class WP_REST_Search_Handler {
 
 	/**

--- a/src/wp-includes/sitemaps/class-wp-sitemaps-index.php
+++ b/src/wp-includes/sitemaps/class-wp-sitemaps-index.php
@@ -15,6 +15,7 @@
  *
  * @since 5.5.0
  */
+#[AllowDynamicProperties]
 class WP_Sitemaps_Index {
 	/**
 	 * The main registry of supported sitemaps.

--- a/src/wp-includes/sitemaps/class-wp-sitemaps-provider.php
+++ b/src/wp-includes/sitemaps/class-wp-sitemaps-provider.php
@@ -14,6 +14,7 @@
  *
  * @since 5.5.0
  */
+#[AllowDynamicProperties]
 abstract class WP_Sitemaps_Provider {
 	/**
 	 * Provider name.

--- a/src/wp-includes/sitemaps/class-wp-sitemaps-registry.php
+++ b/src/wp-includes/sitemaps/class-wp-sitemaps-registry.php
@@ -14,6 +14,7 @@
  *
  * @since 5.5.0
  */
+#[AllowDynamicProperties]
 class WP_Sitemaps_Registry {
 	/**
 	 * Registered sitemap providers.

--- a/src/wp-includes/sitemaps/class-wp-sitemaps-renderer.php
+++ b/src/wp-includes/sitemaps/class-wp-sitemaps-renderer.php
@@ -14,6 +14,7 @@
  *
  * @since 5.5.0
  */
+#[AllowDynamicProperties]
 class WP_Sitemaps_Renderer {
 	/**
 	 * XSL stylesheet for styling a sitemap for web browsers.

--- a/src/wp-includes/sitemaps/class-wp-sitemaps-stylesheet.php
+++ b/src/wp-includes/sitemaps/class-wp-sitemaps-stylesheet.php
@@ -14,6 +14,7 @@
  *
  * @since 5.5.0
  */
+#[AllowDynamicProperties]
 class WP_Sitemaps_Stylesheet {
 	/**
 	 * Renders the XSL stylesheet depending on whether it's the sitemap index or not.

--- a/src/wp-includes/sitemaps/class-wp-sitemaps.php
+++ b/src/wp-includes/sitemaps/class-wp-sitemaps.php
@@ -14,6 +14,7 @@
  *
  * @since 5.5.0
  */
+#[AllowDynamicProperties]
 class WP_Sitemaps {
 	/**
 	 * The main index of supported sitemaps.


### PR DESCRIPTION
Dynamic (non-explicitly declared) properties are deprecated as of PHP 8.2 and are expected to become a fatal error in PHP 9.0.

There are a number of ways to mitigate this:
* If it's an accidental typo for a declared property: fix the typo.
* For known properties: declare them on the class.
* For unknown properties: add the magic `__get()`, `__set()` et al methods to the class or let the class extend `stdClass` which has highly optimized versions of these magic methods build in.
* For unknown _use of_ dynamic properties, the `#[AllowDynamicProperties]` attribute can be added to the class. The attribute will automatically be inherited by child classes.

[Trac ticket 56034](https://core.trac.wordpress.org/ticket/56034) is open to investigate and handle the third and fourth type of situations, however it has become clear this will need more time and will not be ready in time for WP 6.1.

To reduce "noise" in the mean time, both in the error logs of WP users moving onto PHP 8.2, in the test run logs of WP itself, in test runs of plugins/themes, as well as to prevent duplicate issues from being opened for the same, this patch adds the `#[AllowDynamicProperties]` attribute to all "parent" classes in WP.

The logic used to create the patch is as follows:
* If a class already has the attribute: no action needed.
* If a class does not `extend`: add the attribute.
* If a class does `extend`:
    - If it extends `stdClass`: no action needed (as `stdClass` supports dynamic properties).
    - If it extends a PHP native class: add the attribute.
    - If it extends a class from one of WP's external dependencies: add the attribute.
* In all other cases: no action - the attribute should not be needed as child classes inherit from the parent.

Whether or not a class contains magic methods has not been taken into account, as a review of the currently existing magic methods has shown that those are generally not sturdy enough and often even set dynamic properties (which they shouldn't).
See the live stream from August 16 for more details.

The patch has been automatically generated (and can be automatically updated (by me) if needs be, with or without updated logic).

The patch has only been created for classes in the WP `src` directory.
* Tests should not get this attribute, but should be fixed to not use dynamic properties instead. Patches for this are already open under ticket 56033.
* While a number of WP native themes (2014, 2019, 2020, 2021) contain classes, I have not added the attribute to those as those themes are generally maintained elsewhere.

Refs:
* https://wiki.php.net/rfc/deprecate_dynamic_properties

Trac ticket: https://core.trac.wordpress.org/ticket/56513

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
