### PR TITLE
PHP 8.2 | Tests/Basic_Object: fix magic methods

### DIFF
--- a/tests/phpunit/includes/class-basic-object.php
+++ b/tests/phpunit/includes/class-basic-object.php
@@ -13,22 +13,29 @@
  * @since 4.0.0
  */
 class Basic_Object {
-	private $foo = 'bar';
+
+	private $arbitrary_props = array(
+		'foo' => 'bar',
+	);
 
 	public function __get( $name ) {
-		return $this->$name;
+		if ( array_key_exists( $name, $this->arbitrary_props ) ) {
+			return $this->arbitrary_props[ $name ];
+		}
+
+		return null;
 	}
 
 	public function __set( $name, $value ) {
-		return $this->$name = $value;
+		$this->arbitrary_props[ $name ] = $value;
 	}
 
 	public function __isset( $name ) {
-		return isset( $this->$name );
+		return isset( $this->arbitrary_props[ $name ] );
 	}
 
 	public function __unset( $name ) {
-		unset( $this->$name );
+		unset( $this->arbitrary_props[ $name ] );
 	}
 
 	public function __call( $name, $arguments ) {


### PR DESCRIPTION
\<rant\>
Magic methods are not supposed to _use_ dynamic properties... they are supposed to _handle_ access _to_ inaccessible (`protected` or `private`) or non-existing properties *sigh*.

What's the point of having the magic methods in place otherwise ?
\</rant\>

This is a test fixture (dummy class only used in a test context), which incorrectly implements the magic methods.

What with the deprecation of dynamic properties in PHP 8.2, this needs to be fixed.

The new implementation represents a "proper" implementation of the magic methods for a class without non-`public` or typed properties.

Notes:
* Instead of relying on dynamic properties, the magic methods now store properties in a `private` `$arbitrary_props` array and retrieve them from there as well.
* The original `$foo` property, even though declared as `private`, was never `private` in practice due to the way the magic methods were originally implemented. In effect, it was fully publicly retrievable and modifiable without any (type) restrictions.
    With that in mind, the `foo` property has been moved into the `$arbitrary_props` array to keep the implementation of the magic methods as clean and straight-forward as possible.
    With the adjusted magic methods, access to and modification of `$foo` will (on the surface) continue to work in the same way as before, while under the hood, it is no longer affected by the dynamic properties deprecation.
* Take note of the use of `array_key_exists()` instead of `isset()` in the `__get()` method. This is intentional and allows for `null` values to be stored and retrieved.
*  Also take note of `__set()` method no longer returning. `__set()` is supposed to be a `void` method.
    In practice, the return value would always be ignored due to how PHP handles magic methods, so in effect, this change will not make any difference and does not constitute a BC-break.
    > The return value of __set() is ignored because of the way PHP processes the assignment operator.

Alternatives considered:
* Instead of fixing the magic methods, they could have been removed instead and the class be made to `extend` `stdClass`.
    I've chosen not to do so for two reasons:
    1. It's kind of nice to have at least _one_ correct implementation of magic methods in WP, which can be used as an example to point to as well.
    2. Extending `stdClass` would change the class hierarchy, which _may_ or _may not_ affect the tests using this fixture (depending on what's being done with the class).
        Extending `stdClass` would also obfuscate what's going on in the class and would require extensive documentation to prevent the extension being inadvertently removed at a future point in time.
* Instead of fixing the magic methods, the test fixture could have been deprecate and/or removed, with the few tests which use the fixture being updated to use `stdClass` for their test fixture instead.
    I've chosen not to do so as there may well be external (plugin/theme) tests relying on this test fixtures and evaluating if this is so, would be hard as WP Directory cannot be used, as test code is normally not included in the code published on wp.org.
    Also note, there is still a (deprecated) `Basic_Subclass` fixture in the test suite, which extends this class.

Refs:
* https://www.php.net/manual/en/language.oop5.overloading.php#object.set
* https://wiki.php.net/rfc/deprecate_dynamic_properties
* php/php-src#7786

These magic methods and the `Basic_Object` test fixture were originally introduced in [28480] and [28523].
The fixture was deprecated in [42381] and undeprecated again in [45807].

At this time, the test fixture is used in the `WP_Test_REST_Post_Meta_Fields` and the `Tests_REST_API` test classes.

Trac ticket: https://core.trac.wordpress.org/ticket/56514

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
