### PR TITLE
Tests/Tests_Theme: fix bug in test set_up/tear_down

### DIFF
--- a/tests/phpunit/tests/theme.php
+++ b/tests/phpunit/tests/theme.php
@@ -23,13 +23,20 @@ class Tests_Theme extends WP_UnitTestCase {
 		'twentytwentytwo',
 	);
 
+	/**
+	 * Original theme directory.
+	 *
+	 * @var string[]
+	 */
+	private $orig_theme_dir;
+
 	public function set_up() {
 		global $wp_theme_directories;
 
 		parent::set_up();
 
-		$backup_wp_theme_directories = $wp_theme_directories;
-		$wp_theme_directories        = array( WP_CONTENT_DIR . '/themes' );
+		$this->orig_theme_dir = $wp_theme_directories;
+		$wp_theme_directories = array( WP_CONTENT_DIR . '/themes' );
 
 		add_filter( 'extra_theme_headers', array( $this, 'theme_data_extra_headers' ) );
 		wp_clean_themes_cache();
@@ -39,7 +46,7 @@ class Tests_Theme extends WP_UnitTestCase {
 	public function tear_down() {
 		global $wp_theme_directories;
 
-		$wp_theme_directories = $this->wp_theme_directories;
+		$wp_theme_directories = $this->orig_theme_dir;
 
 		remove_filter( 'extra_theme_headers', array( $this, 'theme_data_extra_headers' ) );
 		wp_clean_themes_cache();


### PR DESCRIPTION
Introduced in [38907] in response to Trac#38457.

In the `set_up()` method, a copy would be made of the original value of the global `$wp_theme_directories`  variable and the intention was to restore that original value in the `tear_down()` method after running each test.

Unfortunately, this was not implemented correctly.
* The backup is made to a function local variable in `set_up()` and not stored somewhere where it is accessible from the `tear_down()` method.
* The restoring then references a non-existent property to restore, which would effectively set the `$wp_theme_directories` global to `null`.

Fixed by declaring a private property, storing the backup in that private property and restoring from the same.

This bug was discovered while fixing (removing) the magic methods in the `WP_UnitTestCase_Base` in an effort to improve compatibility with PHP 8.2.

Note: fixing the above bug _may_ cause other tests to fail if tests run _after_ this test would expect the global `$wp_theme_directories` variable to be `null`. If that's the case, I will separately submit any additional fixes needed for those tests.

Trac ticket: https://core.trac.wordpress.org/ticket/55652

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
