### PR TITLE
WP_Test_REST_Attachments_Controller::test_update_item_parent(): bug fix

### DIFF
--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -1079,7 +1079,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 			array(
 				'post_mime_type' => 'image/jpeg',
 				'post_excerpt'   => 'A sample caption',
-				'post_author'    => $this->editor_id,
+				'post_author'    => self::$editor_id,
 			)
 		);
 


### PR DESCRIPTION
Introduced in [38832] in response to Trac#38373.

The `$editor_id` property is declared as `static`, so can only be approached as static, even when used within the same class in which the property is declared.

Using non-static access will result in `null`. See: https://3v4l.org/93HQL

This PHP notice was hidden so far, due to the existence of magic methods in the `WP_UnitTestCase_Base` class.

All the same, the magic methods as they were, would also return `null` for this property.

All in all, the attachment being created for this test would never get the correct `post_author`.

Fixed by using static access to approach the `static` property.

This bug was discovered while fixing (removing) the magic methods in the `WP_UnitTestCase_Base` in an effort to improve compatibility with PHP 8.2.


Trac ticket: https://core.trac.wordpress.org/ticket/55652

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
