### PR TITLE
Tests_Rewrite_OldDateRedirect::test_old_date_redirect_cache_invalidation(): bug fix x 2

### DIFF
--- a/tests/phpunit/tests/rewrite/oldDateRedirect.php
+++ b/tests/phpunit/tests/rewrite/oldDateRedirect.php
@@ -147,10 +147,12 @@ class Tests_Rewrite_OldDateRedirect extends WP_UnitTestCase {
 			)
 		);
 
+		$new_permalink = user_trailingslashit( get_permalink( self::$post_id ) );
+
 		$num_queries = get_num_queries();
 		$this->go_to( $permalink );
 		wp_old_slug_redirect();
-		$this->assertSame( $permalink, $this->old_date_redirect_url );
+		$this->assertSame( $new_permalink, $this->old_date_redirect_url );
 		$this->assertGreaterThan( $num_queries, get_num_queries() );
 	}
 

--- a/tests/phpunit/tests/rewrite/oldDateRedirect.php
+++ b/tests/phpunit/tests/rewrite/oldDateRedirect.php
@@ -140,7 +140,7 @@ class Tests_Rewrite_OldDateRedirect extends WP_UnitTestCase {
 		$time = '2014-02-01 00:00:00';
 		wp_update_post(
 			array(
-				'ID'            => $this->post_id,
+				'ID'            => self::$post_id,
 				'post_date'     => $time,
 				'post_date_gmt' => get_gmt_from_date( $time ),
 				'post_name'     => 'bar-baz',


### PR DESCRIPTION
### Tests_Rewrite_OldDateRedirect::test_old_date_redirect_cache_invalidation(): bug fix [1]

Introduced in [53549] in response to Trac#36723.

The `$post_id` property is declared as `static`, so can only be approached as static, even when used within the same class in which the property is declared.

Using non-static access will result in `null`. See: https://3v4l.org/93HQL

This PHP notice was hidden so far, due to the existence of magic methods in the `WP_UnitTestCase_Base` class.

All the same, the magic methods as they were, would also return `null` for this property.

All in all, the post being updated for this test would never get the correct `post_id`.

Fixed by using static access to approach the `static` property.

This bug was discovered while fixing (removing) the magic methods in the `WP_UnitTestCase_Base` in an effort to improve compatibility with PHP 8.2.

### Tests_Rewrite_OldDateRedirect::test_old_date_redirect_cache_invalidation(): bug fix [2]

Introduced in [53549] in response to Trac#36723.

The previous bug fix (using the actual `$post_id` instead of `null`) exposed that this test was in actual fact failing. This was just hidden by the first bug.

Based on the original commit introducing the test, I gather the fix I'm applying now was what the test actually _intended_ to test, but it would be good to get confirmation of this from one of the original authors. /cc @spacedmonkey 

Trac ticket: https://core.trac.wordpress.org/ticket/55652

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
