### PR TITLE
PHP 8.2 | WP_UnitTestCase_Base: remove magic methods (without BC break)

### DIFF
--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -23,15 +23,14 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 	protected static $hooks_saved = array();
 	protected static $ignore_files;
 
-	public function __isset( $name ) {
-		return 'factory' === $name;
-	}
-
-	public function __get( $name ) {
-		if ( 'factory' === $name ) {
-			return self::factory();
-		}
-	}
+	/**
+	 * Fixture factory.
+	 *
+	 * @deprecated 6.1.0 Use the WP_UnitTestCase_Base::factory() method instead.
+	 *
+	 * @var WP_UnitTest_Factory
+	 */
+	protected $factory;
 
 	/**
 	 * Fetches the factory object for generating WordPress fixtures.
@@ -102,6 +101,8 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 	 */
 	public function set_up() {
 		set_time_limit( 0 );
+
+		$this->factory = self::factory();
 
 		if ( ! self::$ignore_files ) {
 			self::$ignore_files = $this->scan_user_uploads();

--- a/tests/phpunit/tests/admin/includesScreen.php
+++ b/tests/phpunit/tests/admin/includesScreen.php
@@ -495,7 +495,7 @@ class Tests_Admin_IncludesScreen extends WP_UnitTestCase {
 		$GLOBALS['hook_suffix'] = $hook;
 
 		if ( 'post.php' === $hook ) {
-			$post_id      = $this->factory->post->create(
+			$post_id      = self::factory()->post->create(
 				array(
 					'post_type' => 'type_shows_in_rest',
 				)

--- a/tests/phpunit/tests/admin/includesTheme.php
+++ b/tests/phpunit/tests/admin/includesTheme.php
@@ -230,7 +230,7 @@ class Tests_Admin_IncludesTheme extends WP_UnitTestCase {
 	 * @ticket 28121
 	 */
 	public function test_get_theme_featured_list_api() {
-		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
 		$featured_list_api = get_theme_feature_list( true );
 		$this->assertNonEmptyMultidimensionalArray( $featured_list_api );
 	}

--- a/tests/phpunit/tests/adminbar.php
+++ b/tests/phpunit/tests/adminbar.php
@@ -656,7 +656,7 @@ class Tests_AdminBar extends WP_UnitTestCase {
 		$this->go_to( home_url( "/?customize_changeset_uuid=$uuid" ) );
 		wp_set_current_user( self::$admin_id );
 
-		$this->factory()->post->create(
+		self::factory()->post->create(
 			array(
 				'post_type'   => 'customize_changeset',
 				'post_status' => 'auto-draft',

--- a/tests/phpunit/tests/ajax/CustomizeManager.php
+++ b/tests/phpunit/tests/ajax/CustomizeManager.php
@@ -307,7 +307,7 @@ class Tests_Ajax_CustomizeManager extends WP_Ajax_UnitTestCase {
 	public function test_save_success_publish_edit() {
 		$uuid = wp_generate_uuid4();
 
-		$post_id      = $this->factory()->post->create(
+		$post_id      = self::factory()->post->create(
 			array(
 				'post_name'    => $uuid,
 				'post_title'   => 'Original',
@@ -346,7 +346,7 @@ class Tests_Ajax_CustomizeManager extends WP_Ajax_UnitTestCase {
 	 */
 	public function test_success_save_post_date() {
 		$uuid         = wp_generate_uuid4();
-		$post_id      = $this->factory()->post->create(
+		$post_id      = self::factory()->post->create(
 			array(
 				'post_name'    => $uuid,
 				'post_title'   => 'Original',
@@ -446,7 +446,7 @@ class Tests_Ajax_CustomizeManager extends WP_Ajax_UnitTestCase {
 	public function test_save_autosave() {
 		$uuid = wp_generate_uuid4();
 
-		$post_id = $this->factory()->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_name'    => $uuid,
 				'post_type'    => 'customize_changeset',
@@ -614,12 +614,12 @@ class Tests_Ajax_CustomizeManager extends WP_Ajax_UnitTestCase {
 		$this->assertFalse( $this->_last_response_parsed['success'] );
 		$this->assertSame( 'no_auto_draft_to_delete', $this->_last_response_parsed['data'] );
 
-		$other_user_id = $this->factory()->user->create();
+		$other_user_id = self::factory()->user->create();
 
 		// Create auto-drafts.
 		$user_auto_draft_ids = array();
 		for ( $i = 0; $i < 3; $i++ ) {
-			$user_auto_draft_ids[] = $this->factory()->post->create(
+			$user_auto_draft_ids[] = self::factory()->post->create(
 				array(
 					'post_name'    => wp_generate_uuid4(),
 					'post_type'    => 'customize_changeset',
@@ -631,7 +631,7 @@ class Tests_Ajax_CustomizeManager extends WP_Ajax_UnitTestCase {
 		}
 		$other_user_auto_draft_ids = array();
 		for ( $i = 0; $i < 3; $i++ ) {
-			$other_user_auto_draft_ids[] = $this->factory()->post->create(
+			$other_user_auto_draft_ids[] = self::factory()->post->create(
 				array(
 					'post_name'    => wp_generate_uuid4(),
 					'post_type'    => 'customize_changeset',

--- a/tests/phpunit/tests/ajax/CustomizeMenus.php
+++ b/tests/phpunit/tests/ajax/CustomizeMenus.php
@@ -706,7 +706,7 @@ class Tests_Ajax_CustomizeMenus extends WP_Ajax_UnitTestCase {
 		$this->assertSame( 'bad_nonce', $response['data'] );
 
 		// Bad nonce.
-		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'subscriber' ) ) );
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
 		$_POST                = wp_slash(
 			array(
 				'customize-menus-nonce' => wp_create_nonce( 'customize-menus' ),
@@ -719,7 +719,7 @@ class Tests_Ajax_CustomizeMenus extends WP_Ajax_UnitTestCase {
 		$this->assertSame( 'customize_not_allowed', $response['data'] );
 
 		// Missing params.
-		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
 		$_POST                = wp_slash(
 			array(
 				'customize-menus-nonce' => wp_create_nonce( 'customize-menus' ),

--- a/tests/phpunit/tests/auth.php
+++ b/tests/phpunit/tests/auth.php
@@ -421,7 +421,7 @@ class Tests_Auth extends WP_UnitTestCase {
 			'user_email' => "mail\'@example.com",
 			'user_pass'  => 'password',
 		);
-		$this->factory()->user->create( $user_args );
+		self::factory()->user->create( $user_args );
 
 		$_POST['log'] = $user_args['user_email'];
 		$_POST['pwd'] = $user_args['user_pass'];
@@ -436,7 +436,7 @@ class Tests_Auth extends WP_UnitTestCase {
 	 * @covers ::wp_validate_application_password
 	 */
 	public function test_application_password_authentication() {
-		$user_id = $this->factory()->user->create(
+		$user_id = self::factory()->user->create(
 			array(
 				'user_login' => 'http_auth_login',
 				'user_pass'  => 'http_auth_pass', // Shouldn't be allowed for API login.

--- a/tests/phpunit/tests/auth.php
+++ b/tests/phpunit/tests/auth.php
@@ -407,7 +407,7 @@ class Tests_Auth extends WP_UnitTestCase {
 			'user_email' => 'mail@example.com',
 			'user_pass'  => 'password',
 		);
-		$this->factory->user->create( $user_args );
+		self::factory()->user->create( $user_args );
 
 		$this->assertInstanceOf( 'WP_User', wp_authenticate( $user_args['user_email'], $user_args['user_pass'] ) );
 		$this->assertInstanceOf( 'WP_User', wp_authenticate( $user_args['user_login'], $user_args['user_pass'] ) );

--- a/tests/phpunit/tests/blocks/context.php
+++ b/tests/phpunit/tests/blocks/context.php
@@ -36,7 +36,7 @@ class Tests_Blocks_Context extends WP_UnitTestCase {
 			'post_excerpt' => '',
 		);
 
-		$post = $this->factory()->post->create_and_get( $args );
+		$post = self::factory()->post->create_and_get( $args );
 		setup_postdata( $post );
 	}
 

--- a/tests/phpunit/tests/blocks/editor.php
+++ b/tests/phpunit/tests/blocks/editor.php
@@ -28,7 +28,7 @@ class Tests_Blocks_Editor extends WP_UnitTestCase {
 			'post_title' => 'Example',
 		);
 
-		$post = $this->factory()->post->create_and_get( $args );
+		$post = self::factory()->post->create_and_get( $args );
 
 		global $wp_rest_server;
 		$wp_rest_server = new Spy_REST_Server;

--- a/tests/phpunit/tests/category/walkerCategory.php
+++ b/tests/phpunit/tests/category/walkerCategory.php
@@ -30,7 +30,7 @@ class Tests_Category_Walker_Category extends WP_UnitTestCase {
 	 */
 	public function test_start_el_with_empty_attributes( $value, $expected ) {
 		$output   = '';
-		$category = $this->factory->category->create_and_get();
+		$category = self::factory()->category->create_and_get();
 		$link     = get_term_link( $category );
 
 		$args = array(

--- a/tests/phpunit/tests/comment.php
+++ b/tests/phpunit/tests/comment.php
@@ -720,13 +720,13 @@ class Tests_Comment extends WP_UnitTestCase {
 		/**
 		 * Set up a comment for testing.
 		 */
-		$post = $this->factory->post->create(
+		$post = self::factory()->post->create(
 			array(
 				'post_author' => self::$user_id,
 			)
 		);
 
-		$comment = $this->factory->comment->create(
+		$comment = self::factory()->comment->create(
 			array(
 				'comment_post_ID' => $post,
 			)

--- a/tests/phpunit/tests/comment/checkComment.php
+++ b/tests/phpunit/tests/comment/checkComment.php
@@ -138,7 +138,7 @@ class Tests_Comment_CheckComment extends WP_UnitTestCase {
 	 * @ticket 28603
 	 */
 	public function test_should_return_true_when_comment_previously_approved_is_enabled_and_user_has_previously_approved_comments_with_different_email() {
-		$subscriber_id = $this->factory()->user->create(
+		$subscriber_id = self::factory()->user->create(
 			array(
 				'role'  => 'subscriber',
 				'email' => 'sub@example.com',
@@ -170,7 +170,7 @@ class Tests_Comment_CheckComment extends WP_UnitTestCase {
 	 * @ticket 28603
 	 */
 	public function test_should_return_false_when_comment_previously_approved_is_enabled_and_user_does_not_have_a_previously_approved_comment_with_any_email() {
-		$subscriber_id = $this->factory()->user->create(
+		$subscriber_id = self::factory()->user->create(
 			array(
 				'role'  => 'subscriber',
 				'email' => 'zig@example.com',

--- a/tests/phpunit/tests/comment/checkComment.php
+++ b/tests/phpunit/tests/comment/checkComment.php
@@ -146,7 +146,7 @@ class Tests_Comment_CheckComment extends WP_UnitTestCase {
 		);
 
 		// Make sure comment author has an approved comment.
-		$this->factory->comment->create(
+		self::factory()->comment->create(
 			array(
 				'user_id'              => $subscriber_id,
 				'comment_approved'     => '1',

--- a/tests/phpunit/tests/comment/commentsOpen.php
+++ b/tests/phpunit/tests/comment/commentsOpen.php
@@ -17,7 +17,7 @@ class Tests_Comment_CommentsOpen extends WP_UnitTestCase {
 	 * @ticket 54159
 	 */
 	public function test_post_exist_status_open() {
-		$post = $this->factory->post->create_and_get();
+		$post = self::factory()->post->create_and_get();
 		$this->assertTrue( comments_open( $post ) );
 	}
 
@@ -25,7 +25,7 @@ class Tests_Comment_CommentsOpen extends WP_UnitTestCase {
 	 * @ticket 54159
 	 */
 	public function test_post_exist_status_closed() {
-		$post                 = $this->factory->post->create_and_get();
+		$post                 = self::factory()->post->create_and_get();
 		$post->comment_status = 'closed';
 
 		$this->assertFalse( comments_open( $post ) );

--- a/tests/phpunit/tests/comment/pingsOpen.php
+++ b/tests/phpunit/tests/comment/pingsOpen.php
@@ -17,7 +17,7 @@ class Tests_Comment_PingsOpen extends WP_UnitTestCase {
 	 * @ticket 54159
 	 */
 	public function test_post_exist_status_open() {
-		$post = $this->factory->post->create_and_get();
+		$post = self::factory()->post->create_and_get();
 		$this->assertTrue( pings_open( $post ) );
 	}
 
@@ -25,7 +25,7 @@ class Tests_Comment_PingsOpen extends WP_UnitTestCase {
 	 * @ticket 54159
 	 */
 	public function test_post_exist_status_closed() {
-		$post              = $this->factory->post->create_and_get();
+		$post              = self::factory()->post->create_and_get();
 		$post->ping_status = 'closed';
 
 		$this->assertFalse( pings_open( $post ) );

--- a/tests/phpunit/tests/comment/template.php
+++ b/tests/phpunit/tests/comment/template.php
@@ -58,7 +58,7 @@ class Tests_Comment_Template extends WP_UnitTestCase {
 	 */
 	public function test_get_comments_number_text_with_post_id() {
 		$post_id = self::$post_id;
-		$this->factory->comment->create_post_comments( $post_id, 6 );
+		self::factory()->comment->create_post_comments( $post_id, 6 );
 
 		$comments_number_text = get_comments_number_text( false, false, false, $post_id );
 
@@ -84,12 +84,12 @@ class Tests_Comment_Template extends WP_UnitTestCase {
 
 		$this->assertSame( __( 'No Comments' ), get_comments_number_text() );
 
-		$this->factory->comment->create_post_comments( $post_id, 1 );
+		self::factory()->comment->create_post_comments( $post_id, 1 );
 		$this->go_to( $permalink );
 
 		$this->assertSame( __( '1 Comment' ), get_comments_number_text() );
 
-		$this->factory->comment->create_post_comments( $post_id, 1 );
+		self::factory()->comment->create_post_comments( $post_id, 1 );
 		$this->go_to( $permalink );
 
 		$this->assertSame( sprintf( _n( '%s Comment', '%s Comments', 2 ), '2' ), get_comments_number_text() );
@@ -106,7 +106,7 @@ class Tests_Comment_Template extends WP_UnitTestCase {
 		$post_id   = self::$post_id;
 		$permalink = get_permalink( $post_id );
 
-		$this->factory->comment->create_post_comments( $post_id, $number );
+		self::factory()->comment->create_post_comments( $post_id, $number );
 		$this->go_to( $permalink );
 
 		add_filter( 'gettext_with_context', array( $this, 'enable_comment_number_declension' ), 10, 4 );

--- a/tests/phpunit/tests/customize/control.php
+++ b/tests/phpunit/tests/customize/control.php
@@ -26,7 +26,7 @@ class Test_WP_Customize_Control extends WP_UnitTestCase {
 	 */
 	public function set_up() {
 		parent::set_up();
-		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
 		require_once ABSPATH . WPINC . '/class-wp-customize-manager.php';
 		$GLOBALS['wp_customize'] = new WP_Customize_Manager();
 		$this->wp_customize      = $GLOBALS['wp_customize'];
@@ -138,21 +138,21 @@ class Test_WP_Customize_Control extends WP_UnitTestCase {
 		$this->assertStringContainsString( '<option value="0">', $content, 'Dropdown-pages renders select even without any pages published.' );
 
 		// Ensure that auto-draft pages are included if they are among the nav_menus_created_posts.
-		$auto_draft_page_id = $this->factory()->post->create(
+		$auto_draft_page_id = self::factory()->post->create(
 			array(
 				'post_type'   => 'page',
 				'post_status' => 'auto-draft',
 				'post_title'  => 'Auto Draft Page',
 			)
 		);
-		$this->factory()->post->create(
+		self::factory()->post->create(
 			array(
 				'post_type'   => 'page',
 				'post_status' => 'auto-draft',
 				'post_title'  => 'Orphan Auto Draft Page',
 			)
 		);
-		$auto_draft_post_id = $this->factory()->post->create(
+		$auto_draft_post_id = self::factory()->post->create(
 			array(
 				'post_type'   => 'post',
 				'post_status' => 'auto-draft',

--- a/tests/phpunit/tests/customize/custom-css-setting.php
+++ b/tests/phpunit/tests/customize/custom-css-setting.php
@@ -120,7 +120,7 @@ class Test_WP_Customize_Custom_CSS_Setting extends WP_UnitTestCase {
 		$this->assertNull( wp_get_custom_css_post( 'twentyten' ) );
 
 		$original_css      = 'body { color: black; }';
-		$post_id           = $this->factory()->post->create(
+		$post_id           = self::factory()->post->create(
 			array(
 				'post_title'   => $this->setting->stylesheet,
 				'post_name'    => $this->setting->stylesheet,
@@ -130,7 +130,7 @@ class Test_WP_Customize_Custom_CSS_Setting extends WP_UnitTestCase {
 			)
 		);
 		$twentyten_css     = 'body { color: red; }';
-		$twentyten_post_id = $this->factory()->post->create(
+		$twentyten_post_id = self::factory()->post->create(
 			array(
 				'post_title'   => 'twentyten',
 				'post_name'    => 'twentyten',
@@ -273,7 +273,7 @@ class Test_WP_Customize_Custom_CSS_Setting extends WP_UnitTestCase {
 		$this->setting->default = '/*default*/';
 		$this->assertSame( '/*default*//*filtered*/', $this->setting->value() );
 
-		$this->factory()->post->create(
+		self::factory()->post->create(
 			array(
 				'post_title'   => $this->setting->stylesheet,
 				'post_name'    => $this->setting->stylesheet,
@@ -310,7 +310,7 @@ class Test_WP_Customize_Custom_CSS_Setting extends WP_UnitTestCase {
 	 */
 	public function test_update_filter() {
 		$original_css = 'body { color:red; }';
-		$post_id      = $this->factory()->post->create(
+		$post_id      = self::factory()->post->create(
 			array(
 				'post_title'   => $this->setting->stylesheet,
 				'post_name'    => $this->setting->stylesheet,

--- a/tests/phpunit/tests/customize/manager.php
+++ b/tests/phpunit/tests/customize/manager.php
@@ -162,7 +162,7 @@ class Tests_WP_Customize_Manager extends WP_UnitTestCase {
 	 */
 	public function test_constructor_deferred_changeset_uuid() {
 		wp_set_current_user( self::$admin_user_id );
-		$other_admin_user_id = $this->factory()->user->create( array( 'role' => 'admin' ) );
+		$other_admin_user_id = self::factory()->user->create( array( 'role' => 'admin' ) );
 
 		$data = array(
 			'blogname' => array(
@@ -171,7 +171,7 @@ class Tests_WP_Customize_Manager extends WP_UnitTestCase {
 		);
 
 		$uuid1 = wp_generate_uuid4();
-		$this->factory()->post->create(
+		self::factory()->post->create(
 			array(
 				'post_type'     => 'customize_changeset',
 				'post_name'     => $uuid1,
@@ -187,7 +187,7 @@ class Tests_WP_Customize_Manager extends WP_UnitTestCase {
 		 * as in non-branching mode there should only be one pending changeset at a time.
 		 */
 		$uuid2   = wp_generate_uuid4();
-		$post_id = $this->factory()->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_type'     => 'customize_changeset',
 				'post_name'     => $uuid2,
@@ -424,7 +424,7 @@ class Tests_WP_Customize_Manager extends WP_UnitTestCase {
 	 */
 	public function test_find_changeset_post_id() {
 		$uuid    = wp_generate_uuid4();
-		$post_id = $this->factory()->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_name'    => $uuid,
 				'post_type'    => 'customize_changeset',
@@ -454,7 +454,7 @@ class Tests_WP_Customize_Manager extends WP_UnitTestCase {
 
 		$uuid         = wp_generate_uuid4();
 		$wp_customize = new WP_Customize_Manager( array( 'changeset_uuid' => $uuid ) );
-		$post_id      = $this->factory()->post->create(
+		$post_id      = self::factory()->post->create(
 			array(
 				'post_name'    => $uuid,
 				'post_type'    => 'customize_changeset',
@@ -482,7 +482,7 @@ class Tests_WP_Customize_Manager extends WP_UnitTestCase {
 			'blogname'        => array( 'value' => 'Hello World' ),
 			'blogdescription' => array( 'value' => 'Greet the world' ),
 		);
-		$this->factory()->post->create(
+		self::factory()->post->create(
 			array(
 				'post_name'    => $uuid,
 				'post_type'    => 'customize_changeset',
@@ -565,14 +565,14 @@ class Tests_WP_Customize_Manager extends WP_UnitTestCase {
 				'post_name'      => 'canola',
 			)
 		);
-		$existing_published_home_page_id   = $this->factory()->post->create(
+		$existing_published_home_page_id   = self::factory()->post->create(
 			array(
 				'post_name'   => 'home',
 				'post_type'   => 'page',
 				'post_status' => 'publish',
 			)
 		);
-		$existing_auto_draft_about_page_id = $this->factory()->post->create(
+		$existing_auto_draft_about_page_id = self::factory()->post->create(
 			array(
 				'post_name'   => 'about',
 				'post_type'   => 'page',
@@ -820,7 +820,7 @@ class Tests_WP_Customize_Manager extends WP_UnitTestCase {
 	public function test_import_theme_starter_content_with_nested_arrays() {
 		wp_set_current_user( self::$admin_user_id );
 
-		$existing_published_home_page_id = $this->factory()->post->create(
+		$existing_published_home_page_id = self::factory()->post->create(
 			array(
 				'post_name'   => 'home',
 				'post_type'   => 'page',
@@ -1878,7 +1878,7 @@ class Tests_WP_Customize_Manager extends WP_UnitTestCase {
 		$r = $wp_customize->save_changeset_post(
 			array(
 				'autosave' => true,
-				'user_id'  => $this->factory()->user->create( array( 'role' => 'administrator' ) ),
+				'user_id'  => self::factory()->user->create( array( 'role' => 'administrator' ) ),
 			)
 		);
 		$this->assertSame( 'illegal_autosave_with_non_current_user', $r->get_error_code() );
@@ -2031,7 +2031,7 @@ class Tests_WP_Customize_Manager extends WP_UnitTestCase {
 		$this->assertGreaterThan( 2, count( $new_sidebars_widgets['sidebar-1'] ) );
 		$new_sidebar_1 = array_reverse( $new_sidebars_widgets['sidebar-1'] );
 
-		$post_id = $this->factory()->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_type'    => 'customize_changeset',
 				'post_status'  => 'draft',
@@ -2335,7 +2335,7 @@ class Tests_WP_Customize_Manager extends WP_UnitTestCase {
 				'value' => 'Changeset Tagline',
 			),
 		);
-		$this->factory()->post->create(
+		self::factory()->post->create(
 			array(
 				'post_type'    => 'customize_changeset',
 				'post_status'  => 'auto-draft',
@@ -2830,7 +2830,7 @@ class Tests_WP_Customize_Manager extends WP_UnitTestCase {
 		}
 		$this->assertFalse( $this->manager->has_published_pages() );
 
-		$this->factory()->post->create(
+		self::factory()->post->create(
 			array(
 				'post_type'   => 'page',
 				'post_status' => 'private',
@@ -2838,7 +2838,7 @@ class Tests_WP_Customize_Manager extends WP_UnitTestCase {
 		);
 		$this->assertFalse( $this->manager->has_published_pages() );
 
-		$this->factory()->post->create(
+		self::factory()->post->create(
 			array(
 				'post_type'   => 'page',
 				'post_status' => 'publish',
@@ -2864,7 +2864,7 @@ class Tests_WP_Customize_Manager extends WP_UnitTestCase {
 		$setting_id = 'nav_menus_created_posts';
 		$setting    = $this->manager->get_setting( $setting_id );
 		$this->assertInstanceOf( 'WP_Customize_Filter_Setting', $setting );
-		$auto_draft_page = $this->factory()->post->create(
+		$auto_draft_page = self::factory()->post->create(
 			array(
 				'post_type'   => 'page',
 				'post_status' => 'auto-draft',

--- a/tests/phpunit/tests/customize/nav-menus.php
+++ b/tests/phpunit/tests/customize/nav-menus.php
@@ -417,7 +417,7 @@ class Test_WP_Customize_Nav_Menus extends WP_UnitTestCase {
 			)
 		);
 
-		$term_id = $this->factory->term->create(
+		$term_id = self::factory()->term->create(
 			array(
 				'taxonomy' => 'wptests_tax',
 				'name'     => 'foobar',

--- a/tests/phpunit/tests/customize/nav-menus.php
+++ b/tests/phpunit/tests/customize/nav-menus.php
@@ -851,11 +851,11 @@ class Test_WP_Customize_Nav_Menus extends WP_UnitTestCase {
 	 */
 	public function test_sanitize_nav_menus_created_posts() {
 		$menus                 = new WP_Customize_Nav_Menus( $this->wp_customize );
-		$contributor_user_id   = $this->factory()->user->create( array( 'role' => 'contributor' ) );
-		$author_user_id        = $this->factory()->user->create( array( 'role' => 'author' ) );
-		$administrator_user_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
+		$contributor_user_id   = self::factory()->user->create( array( 'role' => 'contributor' ) );
+		$author_user_id        = self::factory()->user->create( array( 'role' => 'author' ) );
+		$administrator_user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
 
-		$contributor_post_id   = $this->factory()->post->create(
+		$contributor_post_id   = self::factory()->post->create(
 			array(
 				'post_status' => 'auto-draft',
 				'post_title'  => 'Contributor Post',
@@ -863,7 +863,7 @@ class Test_WP_Customize_Nav_Menus extends WP_UnitTestCase {
 				'post_author' => $contributor_user_id,
 			)
 		);
-		$author_post_id        = $this->factory()->post->create(
+		$author_post_id        = self::factory()->post->create(
 			array(
 				'post_status' => 'auto-draft',
 				'post_title'  => 'Author Post',
@@ -871,7 +871,7 @@ class Test_WP_Customize_Nav_Menus extends WP_UnitTestCase {
 				'post_author' => $author_user_id,
 			)
 		);
-		$administrator_post_id = $this->factory()->post->create(
+		$administrator_post_id = self::factory()->post->create(
 			array(
 				'post_status' => 'auto-draft',
 				'post_title'  => 'Admin Post',
@@ -880,7 +880,7 @@ class Test_WP_Customize_Nav_Menus extends WP_UnitTestCase {
 			)
 		);
 
-		$draft_post_id = $this->factory()->post->create(
+		$draft_post_id = self::factory()->post->create(
 			array(
 				'post_status' => 'draft',
 				'post_title'  => 'Draft',
@@ -888,7 +888,7 @@ class Test_WP_Customize_Nav_Menus extends WP_UnitTestCase {
 			)
 		);
 
-		$private_post_id = $this->factory()->post->create(
+		$private_post_id = self::factory()->post->create(
 			array(
 				'post_status' => 'private',
 				'post_title'  => 'Private',
@@ -990,7 +990,7 @@ class Test_WP_Customize_Nav_Menus extends WP_UnitTestCase {
 		$post_ids[]      = $r->ID;
 		$trashed_post_id = $r->ID;
 
-		$pre_published_post_id = $this->factory()->post->create( array( 'post_status' => 'publish' ) );
+		$pre_published_post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
 
 		$setting_id = 'nav_menus_created_posts';
 		$this->wp_customize->set_post_value( $setting_id, array_merge( $post_ids, array( $pre_published_post_id ) ) );

--- a/tests/phpunit/tests/customize/setting.php
+++ b/tests/phpunit/tests/customize/setting.php
@@ -137,7 +137,7 @@ class Tests_WP_Customize_Setting extends WP_UnitTestCase {
 	 * @see WP_Customize_Setting::value()
 	 */
 	public function test_preview_standard_types_non_multidimensional() {
-		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
 		$_POST['customized'] = wp_slash( wp_json_encode( $this->post_data_overrides ) );
 
 		// Try non-multidimensional settings.
@@ -216,7 +216,7 @@ class Tests_WP_Customize_Setting extends WP_UnitTestCase {
 	 * @see WP_Customize_Setting::value()
 	 */
 	public function test_preview_standard_types_multidimensional() {
-		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
 		$_POST['customized'] = wp_slash( wp_json_encode( $this->post_data_overrides ) );
 
 		foreach ( $this->standard_type_configs as $type => $type_options ) {
@@ -362,7 +362,7 @@ class Tests_WP_Customize_Setting extends WP_UnitTestCase {
 	 * @see WP_Customize_Setting::preview()
 	 */
 	public function test_preview_custom_type() {
-		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
 		$type                = 'custom_type';
 		$post_data_overrides = array(
 			"unset_{$type}_with_post_value" => "unset_{$type}_without_post_value\\o/",
@@ -551,7 +551,7 @@ class Tests_WP_Customize_Setting extends WP_UnitTestCase {
 	 * @ticket 31428
 	 */
 	public function test_is_current_blog_previewed() {
-		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
 		$type       = 'option';
 		$name       = 'blogname';
 		$post_value = __FUNCTION__;
@@ -743,7 +743,7 @@ class Tests_WP_Customize_Setting extends WP_UnitTestCase {
 	 * @ticket 37294
 	 */
 	public function test_multidimensional_value_when_previewed() {
-		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
 		WP_Customize_Setting::reset_aggregated_multidimensionals();
 
 		$initial_value = 456;

--- a/tests/phpunit/tests/date/getFeedBuildDate.php
+++ b/tests/phpunit/tests/date/getFeedBuildDate.php
@@ -55,7 +55,7 @@ class Tests_Date_GetFeedBuildDate extends WP_UnitTestCase {
 
 		$this->assertFalse( get_feed_build_date( DATE_RFC3339 ), 'False when unable to determine valid time' );
 
-		$this->factory->post->create(
+		self::factory()->post->create(
 			array(
 				'post_date' => $datetime->format( 'Y-m-d H:i:s' ),
 			)
@@ -68,7 +68,7 @@ class Tests_Date_GetFeedBuildDate extends WP_UnitTestCase {
 			'Fall back to time of last post modified with no posts'
 		);
 
-		$post_id_broken = $this->factory->post->create();
+		$post_id_broken = self::factory()->post->create();
 		$post_broken    = get_post( $post_id_broken );
 
 		$post_broken->post_modified_gmt = 0;

--- a/tests/phpunit/tests/date/getTheModifiedDate.php
+++ b/tests/phpunit/tests/date/getTheModifiedDate.php
@@ -20,7 +20,7 @@ class Tests_Date_GetTheModifiedDate extends WP_UnitTestCase {
 			'post_date'     => '2016-01-21 15:34:36',
 			'post_date_gmt' => '2016-01-21 15:34:36',
 		);
-		$post_id  = $this->factory->post->create( $details );
+		$post_id  = self::factory()->post->create( $details );
 		$format   = 'Y-m-d';
 		$expected = '2016-01-21';
 		$actual   = get_the_modified_date( $format, $post_id );
@@ -39,7 +39,7 @@ class Tests_Date_GetTheModifiedDate extends WP_UnitTestCase {
 			'post_date'     => '2016-01-21 15:34:36',
 			'post_date_gmt' => '2016-01-21 15:34:36',
 		);
-		$post_id = $this->factory->post->create( $details );
+		$post_id = self::factory()->post->create( $details );
 		$post    = get_post( $post_id );
 
 		$GLOBALS['post'] = $post;
@@ -111,7 +111,7 @@ class Tests_Date_GetTheModifiedDate extends WP_UnitTestCase {
 			'post_date'     => '2016-01-21 15:34:36',
 			'post_date_gmt' => '2016-01-21 15:34:36',
 		);
-		$post_id  = $this->factory->post->create( $details );
+		$post_id  = self::factory()->post->create( $details );
 		$format   = 'G';
 		$expected = 1453390476;
 		$actual   = get_the_modified_time( $format, $post_id );
@@ -130,7 +130,7 @@ class Tests_Date_GetTheModifiedDate extends WP_UnitTestCase {
 			'post_date'     => '2016-01-21 15:34:36',
 			'post_date_gmt' => '2016-01-21 15:34:36',
 		);
-		$post_id = $this->factory->post->create( $details );
+		$post_id = self::factory()->post->create( $details );
 		$post    = get_post( $post_id );
 
 		$GLOBALS['post'] = $post;

--- a/tests/phpunit/tests/date/xmlrpc.php
+++ b/tests/phpunit/tests/date/xmlrpc.php
@@ -221,7 +221,7 @@ class Tests_Date_XMLRPC extends WP_XMLRPC_UnitTestCase {
 		$datetimeutc = $datetime->setTimezone( new DateTimeZone( 'UTC' ) );
 
 		$this->make_user_by_role( 'administrator' );
-		$post_id = $this->factory->post->create();
+		$post_id = self::factory()->post->create();
 
 		$comment_data = array(
 			'comment_post_ID'      => $post_id,

--- a/tests/phpunit/tests/feed/rss2.php
+++ b/tests/phpunit/tests/feed/rss2.php
@@ -522,10 +522,10 @@ class Tests_Feed_RSS2 extends WP_UnitTestCase {
 		$yesterday = gmdate( 'Y-m-d H:i:s', strtotime( '-1 day' ) );
 
 		// Create a post dated last week.
-		$post_id = $this->factory()->post->create( array( 'post_date' => $last_week ) );
+		$post_id = self::factory()->post->create( array( 'post_date' => $last_week ) );
 
 		// Create a comment dated yesterday.
-		$this->factory()->comment->create(
+		self::factory()->comment->create(
 			array(
 				'comment_post_ID' => $post_id,
 				'comment_date'    => $yesterday,
@@ -561,10 +561,10 @@ class Tests_Feed_RSS2 extends WP_UnitTestCase {
 		$yesterday = gmdate( 'Y-m-d H:i:s', strtotime( '-1 day' ) );
 
 		// Create a post dated last week.
-		$post_id = $this->factory()->post->create( array( 'post_date' => $last_week ) );
+		$post_id = self::factory()->post->create( array( 'post_date' => $last_week ) );
 
 		// Create a comment dated yesterday.
-		$this->factory()->comment->create(
+		self::factory()->comment->create(
 			array(
 				'comment_post_ID' => $post_id,
 				'comment_date'    => $yesterday,
@@ -601,10 +601,10 @@ class Tests_Feed_RSS2 extends WP_UnitTestCase {
 		$today     = gmdate( 'Y-m-d H:i:s' );
 
 		// Create a post dated last week.
-		$post_id = $this->factory()->post->create( array( 'post_date' => $last_week ) );
+		$post_id = self::factory()->post->create( array( 'post_date' => $last_week ) );
 
 		// Create a comment dated yesterday.
-		$this->factory()->comment->create(
+		self::factory()->comment->create(
 			array(
 				'comment_post_ID' => $post_id,
 				'comment_date'    => $yesterday,
@@ -612,7 +612,7 @@ class Tests_Feed_RSS2 extends WP_UnitTestCase {
 		);
 
 		// Create a post dated today.
-		$this->factory()->post->create( array( 'post_date' => $today ) );
+		self::factory()->post->create( array( 'post_date' => $today ) );
 
 		// The Last-Modified header should have the date from today's post when it is the latest update.
 		add_filter(

--- a/tests/phpunit/tests/formatting/excerptRemoveBlocks.php
+++ b/tests/phpunit/tests/formatting/excerptRemoveBlocks.php
@@ -60,7 +60,7 @@ class Tests_Formatting_ExcerptRemoveBlocks extends WP_UnitTestCase {
 	 */
 	public function set_up() {
 		parent::set_up();
-		self::$post_id = $this->factory()->post->create(
+		self::$post_id = self::factory()->post->create(
 			array(
 				'post_excerpt' => '', // Empty excerpt, so it has to be generated.
 				'post_content' => '<!-- wp:core/fake /-->',

--- a/tests/phpunit/tests/formatting/wpTargetedLinkRel.php
+++ b/tests/phpunit/tests/formatting/wpTargetedLinkRel.php
@@ -89,7 +89,7 @@ class Tests_Formatting_wpTargetedLinkRel extends WP_UnitTestCase {
 		$content  = '<p>Links: <a href="/" target="_blank">No rel</a></p>';
 		$expected = '<p>Links: <a href="/" target="_blank" rel="noopener">No rel</a></p>';
 
-		$post = $this->factory()->post->create_and_get(
+		$post = self::factory()->post->create_and_get(
 			array(
 				'post_content' => $content,
 			)

--- a/tests/phpunit/tests/general/template.php
+++ b/tests/phpunit/tests/general/template.php
@@ -104,7 +104,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 * @covers ::has_site_icon
 	 */
 	public function test_has_site_icon_returns_true_when_called_for_other_site_with_site_icon_set() {
-		$blog_id = $this->factory->blog->create();
+		$blog_id = self::factory()->blog->create();
 		switch_to_blog( $blog_id );
 		$this->set_site_icon();
 		restore_current_blog();
@@ -119,7 +119,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 * @covers ::has_site_icon
 	 */
 	public function test_has_site_icon_returns_false_when_called_for_other_site_without_site_icon_set() {
-		$blog_id = $this->factory->blog->create();
+		$blog_id = self::factory()->blog->create();
 
 		$this->assertFalse( has_site_icon( $blog_id ) );
 	}
@@ -298,7 +298,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 * @covers ::has_custom_logo
 	 */
 	public function test_has_custom_logo_returns_true_when_called_for_other_site_with_custom_logo_set() {
-		$blog_id = $this->factory->blog->create();
+		$blog_id = self::factory()->blog->create();
 		switch_to_blog( $blog_id );
 		$this->set_custom_logo();
 		restore_current_blog();
@@ -313,7 +313,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 * @covers ::has_custom_logo
 	 */
 	public function test_has_custom_logo_returns_false_when_called_for_other_site_without_custom_logo_set() {
-		$blog_id = $this->factory->blog->create();
+		$blog_id = self::factory()->blog->create();
 
 		$this->assertFalse( has_custom_logo( $blog_id ) );
 	}
@@ -343,7 +343,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 * @covers ::get_custom_logo
 	 */
 	public function test_get_custom_logo_returns_logo_when_called_for_other_site_with_custom_logo_set() {
-		$blog_id = $this->factory->blog->create();
+		$blog_id = self::factory()->blog->create();
 		switch_to_blog( $blog_id );
 
 		$this->set_custom_logo();
@@ -466,7 +466,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 * @covers ::get_site_icon_url
 	 */
 	public function test_get_site_icon_url_preserves_switched_state() {
-		$blog_id = $this->factory->blog->create();
+		$blog_id = self::factory()->blog->create();
 		switch_to_blog( $blog_id );
 
 		$expected = $GLOBALS['_wp_switched_stack'];
@@ -486,7 +486,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 * @covers ::has_custom_logo
 	 */
 	public function test_has_custom_logo_preserves_switched_state() {
-		$blog_id = $this->factory->blog->create();
+		$blog_id = self::factory()->blog->create();
 		switch_to_blog( $blog_id );
 
 		$expected = $GLOBALS['_wp_switched_stack'];
@@ -506,7 +506,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 * @covers ::get_custom_logo
 	 */
 	public function test_get_custom_logo_preserves_switched_state() {
-		$blog_id = $this->factory->blog->create();
+		$blog_id = self::factory()->blog->create();
 		switch_to_blog( $blog_id );
 
 		$expected = $GLOBALS['_wp_switched_stack'];

--- a/tests/phpunit/tests/general/template.php
+++ b/tests/phpunit/tests/general/template.php
@@ -180,7 +180,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 */
 	public function test_customize_preview_wp_site_icon_empty() {
 		global $wp_customize;
-		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
 
 		require_once ABSPATH . WPINC . '/class-wp-customize-manager.php';
 		$wp_customize = new WP_Customize_Manager();
@@ -198,7 +198,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 */
 	public function test_customize_preview_wp_site_icon_dirty() {
 		global $wp_customize;
-		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
 
 		require_once ABSPATH . WPINC . '/class-wp-customize-manager.php';
 		$wp_customize = new WP_Customize_Manager();
@@ -598,18 +598,18 @@ class Tests_General_Template extends WP_UnitTestCase {
 	 * @covers ::get_the_archive_title
 	 */
 	public function test_get_the_archive_title_is_correct_for_author_queries() {
-		$user_with_posts    = $this->factory()->user->create_and_get(
+		$user_with_posts    = self::factory()->user->create_and_get(
 			array(
 				'role' => 'author',
 			)
 		);
-		$user_with_no_posts = $this->factory()->user->create_and_get(
+		$user_with_no_posts = self::factory()->user->create_and_get(
 			array(
 				'role' => 'author',
 			)
 		);
 
-		$this->factory()->post->create(
+		self::factory()->post->create(
 			array(
 				'post_author' => $user_with_posts->ID,
 			)

--- a/tests/phpunit/tests/general/wpGetDocumentTitle.php
+++ b/tests/phpunit/tests/general/wpGetDocumentTitle.php
@@ -101,7 +101,7 @@ class Tests_General_wpGetDocumentTitle extends WP_UnitTestCase {
 		update_option( 'show_on_front', 'page' );
 		update_option(
 			'page_on_front',
-			$this->factory->post->create(
+			self::factory()->post->create(
 				array(
 					'post_title' => 'front-page',
 					'post_type'  => 'page',
@@ -128,7 +128,7 @@ class Tests_General_wpGetDocumentTitle extends WP_UnitTestCase {
 	}
 
 	public function test_home_title() {
-		$blog_page_id = $this->factory->post->create(
+		$blog_page_id = self::factory()->post->create(
 			array(
 				'post_title' => 'blog-page',
 				'post_type'  => 'page',
@@ -205,7 +205,7 @@ class Tests_General_wpGetDocumentTitle extends WP_UnitTestCase {
 			)
 		);
 
-		$this->factory->post->create(
+		self::factory()->post->create(
 			array(
 				'post_type' => 'cpt',
 			)

--- a/tests/phpunit/tests/image/editor.php
+++ b/tests/phpunit/tests/image/editor.php
@@ -372,7 +372,7 @@ class Tests_Image_Editor extends WP_Image_UnitTestCase {
 	 * @dataProvider provider_image_with_default_behaviors_during_upload
 	 */
 	public function it_should_create_the_original_image_mime_type_when_the_image_is_uploaded( $file_location, $expected_mime, $targeted_mime ) {
-		$attachment_id = $this->factory->attachment->create_upload_object( $file_location );
+		$attachment_id = self::factory()->attachment->create_upload_object( $file_location );
 
 		$metadata = wp_get_attachment_metadata( $attachment_id );
 
@@ -414,7 +414,7 @@ class Tests_Image_Editor extends WP_Image_UnitTestCase {
 	public function it_should_not_create_the_sources_property_if_no_transform_is_provided() {
 		add_filter( 'wp_upload_image_mime_transforms', '__return_empty_array' );
 
-		$attachment_id = $this->factory->attachment->create_upload_object(
+		$attachment_id = self::factory()->attachment->create_upload_object(
 			DIR_TESTDATA . '/images/test-image.jpg'
 		);
 
@@ -439,7 +439,7 @@ class Tests_Image_Editor extends WP_Image_UnitTestCase {
 			}
 		);
 
-		$attachment_id = $this->factory->attachment->create_upload_object(
+		$attachment_id = self::factory()->attachment->create_upload_object(
 			DIR_TESTDATA . '/images/test-image.jpg'
 		);
 
@@ -469,7 +469,7 @@ class Tests_Image_Editor extends WP_Image_UnitTestCase {
 			}
 		);
 
-		$attachment_id = $this->factory->attachment->create_upload_object(
+		$attachment_id = self::factory()->attachment->create_upload_object(
 			DIR_TESTDATA . '/images/webp-lossy.webp'
 		);
 
@@ -488,7 +488,7 @@ class Tests_Image_Editor extends WP_Image_UnitTestCase {
 	 * @ticket 55443
 	 */
 	public function it_should_create_a_webp_version_with_all_the_required_properties() {
-		$attachment_id = $this->factory->attachment->create_upload_object(
+		$attachment_id = self::factory()->attachment->create_upload_object(
 			DIR_TESTDATA . '/images/test-image.jpg'
 		);
 
@@ -518,7 +518,7 @@ class Tests_Image_Editor extends WP_Image_UnitTestCase {
 			}
 		);
 
-		$attachment_id = $this->factory->attachment->create_upload_object(
+		$attachment_id = self::factory()->attachment->create_upload_object(
 			DIR_TESTDATA . '/images/test-image.jpg'
 		);
 		$metadata      = wp_get_attachment_metadata( $attachment_id );
@@ -535,7 +535,7 @@ class Tests_Image_Editor extends WP_Image_UnitTestCase {
 	 */
 	public function it_should_remove_the_generated_webp_images_when_the_attachment_is_deleted() {
 		// Make sure no editor is available.
-		$attachment_id = $this->factory->attachment->create_upload_object(
+		$attachment_id = self::factory()->attachment->create_upload_object(
 			DIR_TESTDATA . '/images/test-image.jpg'
 		);
 
@@ -572,7 +572,7 @@ class Tests_Image_Editor extends WP_Image_UnitTestCase {
 	 */
 	public function it_should_remove_the_attached_webp_version_if_the_attachment_is_force_deleted_but_empty_trash_day_is_not_defined() {
 		// Make sure no editor is available.
-		$attachment_id = $this->factory->attachment->create_upload_object(
+		$attachment_id = self::factory()->attachment->create_upload_object(
 			DIR_TESTDATA . '/images/test-image.jpg'
 		);
 
@@ -602,7 +602,7 @@ class Tests_Image_Editor extends WP_Image_UnitTestCase {
 	 */
 	public function it_should_remove_the_webp_version_of_the_image_if_the_image_is_force_deleted_and_empty_trash_days_is_set_to_zero() {
 		// Make sure no editor is available.
-		$attachment_id = $this->factory->attachment->create_upload_object(
+		$attachment_id = self::factory()->attachment->create_upload_object(
 			DIR_TESTDATA . '/images/test-image.jpg'
 		);
 
@@ -655,7 +655,7 @@ class Tests_Image_Editor extends WP_Image_UnitTestCase {
 	 * @ticket 55443
 	 */
 	public function it_should_test_preventing_replacing_a_webp_image() {
-		$attachment_id = $this->factory->attachment->create_upload_object(
+		$attachment_id = self::factory()->attachment->create_upload_object(
 			DIR_TESTDATA . '/images/webp-lossy.webp'
 		);
 
@@ -670,7 +670,7 @@ class Tests_Image_Editor extends WP_Image_UnitTestCase {
 	 * @ticket 55443
 	 */
 	public function it_should_test_preventing_replacing_a_jpg_image_if_the_image_does_not_have_the_target_class_name() {
-		$attachment_id = $this->factory->attachment->create_upload_object(
+		$attachment_id = self::factory()->attachment->create_upload_object(
 			DIR_TESTDATA . '/images/test-image.jpg'
 		);
 
@@ -687,7 +687,7 @@ class Tests_Image_Editor extends WP_Image_UnitTestCase {
 	 * @ticket 55443
 	 */
 	public function it_should_replace_the_references_to_a_jpg_image_to_a_webp_version( $image_path ) {
-		$attachment_id = $this->factory->attachment->create_upload_object( $image_path );
+		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
 
 		$tag          = wp_get_attachment_image( $attachment_id, 'medium', false, array( 'class' => "wp-image-{$attachment_id}" ) );
 		$expected_tag = $tag;
@@ -712,7 +712,7 @@ class Tests_Image_Editor extends WP_Image_UnitTestCase {
 	 * @ticket 55443
 	 */
 	public function it_should_contain_the_full_image_size_from_the_original_mime() {
-		$attachment_id = $this->factory->attachment->create_upload_object(
+		$attachment_id = self::factory()->attachment->create_upload_object(
 			DIR_TESTDATA . '/images/test-image.jpg'
 		);
 
@@ -734,7 +734,7 @@ class Tests_Image_Editor extends WP_Image_UnitTestCase {
 	public function it_should_prevent_replacing_an_image_with_no_available_sources() {
 		add_filter( 'wp_upload_image_mime_transforms', '__return_empty_array' );
 
-		$attachment_id = $this->factory->attachment->create_upload_object( DIR_TESTDATA . '/images/test-image.jpg' );
+		$attachment_id = self::factory()->attachment->create_upload_object( DIR_TESTDATA . '/images/test-image.jpg' );
 
 		$tag = wp_get_attachment_image( $attachment_id, 'full', false, array( 'class' => "wp-image-{$attachment_id}" ) );
 		$this->assertSame( $tag, webp_uploads_img_tag_update_mime_type( $tag, 'the_content', $attachment_id ) );
@@ -748,7 +748,7 @@ class Tests_Image_Editor extends WP_Image_UnitTestCase {
 	 * @ticket 55443
 	 */
 	public function it_should_prevent_update_not_supported_images_with_no_available_sources( $image_path ) {
-		$attachment_id = $this->factory->attachment->create_upload_object( $image_path );
+		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
 
 		$this->assertIsNumeric( $attachment_id );
 		$tag = wp_get_attachment_image( $attachment_id, 'full', false, array( 'class' => "wp-image-{$attachment_id}" ) );

--- a/tests/phpunit/tests/image/functions.php
+++ b/tests/phpunit/tests/image/functions.php
@@ -651,7 +651,7 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 			$this->markTestSkipped( $editor->get_error_message() );
 		}
 
-		$attachment_id = $this->factory->attachment->create_object(
+		$attachment_id = self::factory()->attachment->create_object(
 			$test_file,
 			0,
 			array(
@@ -750,7 +750,7 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 			$this->markTestSkipped( $editor->get_error_message() );
 		}
 
-		$attachment_id = $this->factory->attachment->create_object(
+		$attachment_id = self::factory()->attachment->create_object(
 			$test_file,
 			0,
 			array(
@@ -847,7 +847,7 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 			$this->markTestSkipped( $editor->get_error_message() );
 		}
 
-		$attachment_id = $this->factory->attachment->create_object(
+		$attachment_id = self::factory()->attachment->create_object(
 			$test_file,
 			0,
 			array(
@@ -928,7 +928,7 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 			$this->markTestSkipped( $editor->get_error_message() );
 		}
 
-		$attachment_id = $this->factory->attachment->create_object(
+		$attachment_id = self::factory()->attachment->create_object(
 			$pdf_path,
 			0,
 			array(
@@ -1392,7 +1392,7 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 		}
 
 		$attributes    = array( 'post_mime_type' => $mime_type );
-		$attachment_id = $this->factory->attachment->create_object( $file, 0, $attributes );
+		$attachment_id = self::factory()->attachment->create_object( $file, 0, $attributes );
 		$exif_meta     = wp_read_image_metadata( $file );
 
 		list( $editor, $resized, $rotated ) = _wp_maybe_scale_and_rotate_image( $file, $attachment_id, $imagesize, $exif_meta, $mime_type );

--- a/tests/phpunit/tests/l10n.php
+++ b/tests/phpunit/tests/l10n.php
@@ -309,7 +309,7 @@ class Tests_L10n extends WP_UnitTestCase {
 			'post_excerpt' => '',
 		);
 
-		$post = $this->factory()->post->create_and_get( $args );
+		$post = self::factory()->post->create_and_get( $args );
 		setup_postdata( $post );
 
 		$expect = "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat [&hellip;]</p>\n";
@@ -335,7 +335,7 @@ class Tests_L10n extends WP_UnitTestCase {
 			'post_excerpt' => '',
 		);
 
-		$post = $this->factory()->post->create_and_get( $args );
+		$post = self::factory()->post->create_and_get( $args );
 		setup_postdata( $post );
 
 		$expect = "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore  [&hellip;]</p>\n";
@@ -361,7 +361,7 @@ class Tests_L10n extends WP_UnitTestCase {
 			'post_excerpt' => '',
 		);
 
-		$post = $this->factory()->post->create_and_get( $args );
+		$post = self::factory()->post->create_and_get( $args );
 		setup_postdata( $post );
 
 		$expect = '<p>' . str_repeat( 'あ', 110 ) . " [&hellip;]</p>\n";
@@ -387,7 +387,7 @@ class Tests_L10n extends WP_UnitTestCase {
 			'post_excerpt' => '',
 		);
 
-		$post = $this->factory()->post->create_and_get( $args );
+		$post = self::factory()->post->create_and_get( $args );
 		setup_postdata( $post );
 
 		$expect = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat [&#8230;]';
@@ -413,7 +413,7 @@ class Tests_L10n extends WP_UnitTestCase {
 			'post_excerpt' => '',
 		);
 
-		$post = $this->factory()->post->create_and_get( $args );
+		$post = self::factory()->post->create_and_get( $args );
 		setup_postdata( $post );
 
 		$expect = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore  [&#8230;]';
@@ -441,7 +441,7 @@ class Tests_L10n extends WP_UnitTestCase {
 			'post_status'  => 'draft',
 		);
 
-		$this->factory()->post->create( $args );
+		self::factory()->post->create( $args );
 
 		$expect = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do&hellip;';
 		$this->expectOutputRegex( '/' . $expect . '/' );
@@ -467,7 +467,7 @@ class Tests_L10n extends WP_UnitTestCase {
 			'post_status'  => 'draft',
 		);
 
-		$post = $this->factory()->post->create( $args );
+		$post = self::factory()->post->create( $args );
 
 		$expect = 'Lorem ipsum dolor sit amet, consectetur &hellip;';
 		$this->expectOutputRegex( '/' . $expect . '/' );
@@ -493,7 +493,7 @@ class Tests_L10n extends WP_UnitTestCase {
 			'post_status'  => 'draft',
 		);
 
-		$this->factory()->post->create( $args );
+		self::factory()->post->create( $args );
 
 		$expect = str_repeat( 'あ', 40 ) . '&hellip;';
 		$this->expectOutputRegex( '/' . $expect . '/' );
@@ -514,7 +514,7 @@ class Tests_L10n extends WP_UnitTestCase {
 		$args            = array(
 			'comment_content' => $this->long_text,
 		);
-		$comment_id      = $this->factory()->comment->create( $args );
+		$comment_id      = self::factory()->comment->create( $args );
 		$expect          = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut&hellip;';
 		$comment_excerpt = get_comment_excerpt( $comment_id );
 
@@ -534,7 +534,7 @@ class Tests_L10n extends WP_UnitTestCase {
 		$args            = array(
 			'comment_content' => $this->long_text,
 		);
-		$comment_id      = $this->factory()->comment->create( $args );
+		$comment_id      = self::factory()->comment->create( $args );
 		$expect          = 'Lorem ipsum dolor sit amet, consectetur &hellip;';
 		$comment_excerpt = get_comment_excerpt( $comment_id );
 
@@ -554,7 +554,7 @@ class Tests_L10n extends WP_UnitTestCase {
 		$args            = array(
 			'comment_content' => str_repeat( 'あ', 200 ),
 		);
-		$comment_id      = $this->factory()->comment->create( $args );
+		$comment_id      = self::factory()->comment->create( $args );
 		$expect          = str_repeat( 'あ', 40 ) . '&hellip;';
 		$comment_excerpt = get_comment_excerpt( $comment_id );
 

--- a/tests/phpunit/tests/l10n/getUserLocale.php
+++ b/tests/phpunit/tests/l10n/getUserLocale.php
@@ -12,7 +12,7 @@ class Tests_L10n_GetUserLocale extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		$this->user_id = $this->factory()->user->create(
+		$this->user_id = self::factory()->user->create(
 			array(
 				'role'   => 'administrator',
 				'locale' => 'de_DE',
@@ -82,7 +82,7 @@ class Tests_L10n_GetUserLocale extends WP_UnitTestCase {
 	}
 
 	public function test_user_id_argument_with_id() {
-		$user_id = $this->factory()->user->create(
+		$user_id = self::factory()->user->create(
 			array(
 				'locale' => 'es_ES',
 			)
@@ -99,7 +99,7 @@ class Tests_L10n_GetUserLocale extends WP_UnitTestCase {
 	}
 
 	public function test_user_id_argument_with_wp_user_object() {
-		$user_id = $this->factory()->user->create(
+		$user_id = self::factory()->user->create(
 			array(
 				'locale' => 'es_ES',
 			)

--- a/tests/phpunit/tests/l10n/wpLocaleSwitcher.php
+++ b/tests/phpunit/tests/l10n/wpLocaleSwitcher.php
@@ -326,7 +326,7 @@ class Tests_L10n_wpLocaleSwitcher extends WP_UnitTestCase {
 
 		$site_locale = get_locale();
 
-		$user_id = $this->factory()->user->create(
+		$user_id = self::factory()->user->create(
 			array(
 				'role'   => 'administrator',
 				'locale' => 'de_DE',
@@ -378,7 +378,7 @@ class Tests_L10n_wpLocaleSwitcher extends WP_UnitTestCase {
 
 		$site_locale = get_locale();
 
-		$user_id = $this->factory()->user->create(
+		$user_id = self::factory()->user->create(
 			array(
 				'role'   => 'administrator',
 				'locale' => 'de_DE',
@@ -430,7 +430,7 @@ class Tests_L10n_wpLocaleSwitcher extends WP_UnitTestCase {
 
 		$site_locale = get_locale();
 
-		$user_id = $this->factory()->user->create(
+		$user_id = self::factory()->user->create(
 			array(
 				'role'   => 'administrator',
 				'locale' => 'en_GB',

--- a/tests/phpunit/tests/link/getPostTypeArchiveLink.php
+++ b/tests/phpunit/tests/link/getPostTypeArchiveLink.php
@@ -19,7 +19,7 @@ class Tests_Link_GetPostTypeArchiveLink extends WP_UnitTestCase {
 	 * @ticket 19902
 	 */
 	public function test_get_post_archive_link_with_post_archive_on_a_blog_page() {
-		$page_for_posts = $this->factory->post->create(
+		$page_for_posts = self::factory()->post->create(
 			array(
 				'post_title' => 'blog-page',
 				'post_type'  => 'page',

--- a/tests/phpunit/tests/link/getThePrivacyPolicyLink.php
+++ b/tests/phpunit/tests/link/getThePrivacyPolicyLink.php
@@ -115,7 +115,7 @@ class Tests_Link_GetThePrivacyPolicyLink extends WP_UnitTestCase {
 	 * @ticket 44192
 	 */
 	public function test_function_should_return_empty_string_when_privacy_page_title_empty() {
-		$nameless_page_id = $this->factory->post->create(
+		$nameless_page_id = self::factory()->post->create(
 			array(
 				'post_type'  => 'page',
 				'post_title' => '',

--- a/tests/phpunit/tests/media/getPostGalleries.php
+++ b/tests/phpunit/tests/media/getPostGalleries.php
@@ -28,7 +28,7 @@ class Tests_Media_GetPostGalleries extends WP_UnitTestCase {
 	 * @ticket 43826
 	 */
 	public function test_returns_empty_array_with_post_with_no_gallery() {
-		$post_id = $this->factory->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_content' => '<p>A post with no gallery</p>',
 			)
@@ -49,7 +49,7 @@ class Tests_Media_GetPostGalleries extends WP_UnitTestCase {
 	 * @param string $needle  The content of a non-gallery block.
 	 */
 	public function test_returns_only_galleries( $content, $needle ) {
-		$image_id = $this->factory->attachment->create_object(
+		$image_id = self::factory()->attachment->create_object(
 			array(
 				'file'           => 'test.jpg',
 				'post_parent'    => 0,
@@ -66,7 +66,7 @@ class Tests_Media_GetPostGalleries extends WP_UnitTestCase {
 			$content
 		);
 
-		$post_id = $this->factory->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_content' => $content,
 			)
@@ -124,7 +124,7 @@ class Tests_Media_GetPostGalleries extends WP_UnitTestCase {
 	 */
 	public function test_returns_no_srcs_with_shortcode_in_post_with_no_attached_images() {
 		// Set up an unattached image.
-		$this->factory->attachment->create_object(
+		self::factory()->attachment->create_object(
 			array(
 				'file'           => 'test.jpg',
 				'post_parent'    => 0,
@@ -133,7 +133,7 @@ class Tests_Media_GetPostGalleries extends WP_UnitTestCase {
 			)
 		);
 
-		$post_id = $this->factory->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_content' => '[gallery]',
 			)
@@ -173,7 +173,7 @@ class Tests_Media_GetPostGalleries extends WP_UnitTestCase {
 	 */
 	public function test_returns_no_srcs_with_block_in_post_with_no_attached_images() {
 		// Set up an unattached image.
-		$this->factory->attachment->create_object(
+		self::factory()->attachment->create_object(
 			array(
 				'file'           => 'test.jpg',
 				'post_parent'    => 0,
@@ -182,7 +182,7 @@ class Tests_Media_GetPostGalleries extends WP_UnitTestCase {
 			)
 		);
 
-		$post_id = $this->factory->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_content' => '<!-- wp:gallery -->',
 			)
@@ -231,7 +231,7 @@ class Tests_Media_GetPostGalleries extends WP_UnitTestCase {
 	 */
 	public function test_returns_no_srcs_with_block_v2_in_post_with_no_attached_images() {
 		// Set up an unattached image.
-		$image_id = $this->factory->attachment->create_object(
+		$image_id = self::factory()->attachment->create_object(
 			array(
 				'file'           => 'test.jpg',
 				'post_parent'    => 0,
@@ -260,7 +260,7 @@ class Tests_Media_GetPostGalleries extends WP_UnitTestCase {
 <!-- /wp:gallery -->
 BLOB;
 
-		$post_id = $this->factory->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_content' => $blob,
 			)
@@ -309,19 +309,19 @@ BLOB;
 	 * @group shortcode
 	 */
 	public function test_returns_html_with_shortcode_gallery() {
-		$post_id = $this->factory->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_content' => 'I have no gallery',
 			)
 		);
 
-		$post_id_two = $this->factory->post->create(
+		$post_id_two = self::factory()->post->create(
 			array(
 				'post_content' => "[gallery id='$post_id']",
 			)
 		);
 
-		$this->factory->attachment->create_object(
+		self::factory()->attachment->create_object(
 			array(
 				'file'           => 'test.jpg',
 				'post_parent'    => $post_id,
@@ -363,14 +363,14 @@ BLOB;
 	 * @group blocks
 	 */
 	public function test_returns_html_with_block_gallery() {
-		$post_id = $this->factory->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_content' => 'I have no gallery.',
 			)
 		);
 
 		// Set up an unattached image.
-		$image_id = $this->factory->attachment->create(
+		$image_id = self::factory()->attachment->create(
 			array(
 				'file'           => 'test.jpg',
 				'post_parent'    => $post_id,
@@ -387,7 +387,7 @@ BLOB;
 <!-- /wp:gallery -->
 BLOB;
 
-		$post_id_two = $this->factory->post->create(
+		$post_id_two = self::factory()->post->create(
 			array(
 				'post_content' => $blob,
 			)
@@ -426,7 +426,7 @@ BLOB;
 	 * @group blocks
 	 */
 	public function test_returns_html_with_block_gallery_v2() {
-		$image_id = $this->factory->attachment->create_object(
+		$image_id = self::factory()->attachment->create_object(
 			array(
 				'file'           => 'test.jpg',
 				'post_parent'    => 0,
@@ -455,7 +455,7 @@ BLOB;
 <!-- /wp:gallery -->
 BLOB;
 
-		$post_id = $this->factory->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_content' => $blob,
 			)
@@ -495,17 +495,17 @@ BLOB;
 	 * @group shortcode
 	 */
 	public function test_respects_post_id_with_shortcode_gallery() {
-		$global_post_id = $this->factory->post->create(
+		$global_post_id = self::factory()->post->create(
 			array(
 				'post_content' => 'Global Post',
 			)
 		);
-		$post_id        = $this->factory->post->create(
+		$post_id        = self::factory()->post->create(
 			array(
 				'post_content' => '[gallery]',
 			)
 		);
-		$this->factory->attachment->create_object(
+		self::factory()->attachment->create_object(
 			array(
 				'file'           => 'test.jpg',
 				'post_parent'    => $post_id,
@@ -577,7 +577,7 @@ BLOB;
 
 		$ids_joined = join( ',', $ids );
 
-		$global_post_id = $this->factory->post->create(
+		$global_post_id = self::factory()->post->create(
 			array(
 				'post_content' => 'Global Post',
 			)
@@ -588,12 +588,12 @@ BLOB;
 <!-- /wp:gallery -->
 BLOB;
 
-		$post_id = $this->factory->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_content' => $blob,
 			)
 		);
-		$this->factory->attachment->create_object(
+		self::factory()->attachment->create_object(
 			array(
 				'file'           => 'test.jpg',
 				'post_parent'    => $post_id,
@@ -657,7 +657,7 @@ BLOB;
 		);
 		$metadata       = array_merge( array( 'file' => 'image1.jpg' ), self::IMG_META );
 		$url            = 'http://' . WP_TESTS_DOMAIN . '/wp-content/uploads/' . 'image1.jpg';
-		$global_post_id = $this->factory->post->create(
+		$global_post_id = self::factory()->post->create(
 			array(
 				'post_content' => 'Global Post',
 			)
@@ -683,12 +683,12 @@ BLOB;
 <!-- /wp:gallery -->
 BLOB;
 
-		$post_id = $this->factory->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_content' => $blob,
 			)
 		);
-		$this->factory->attachment->create_object(
+		self::factory()->attachment->create_object(
 			array(
 				'file'           => 'test.jpg',
 				'post_parent'    => $post_id,
@@ -742,17 +742,17 @@ BLOB;
 	 * @group shortcode
 	 */
 	public function test_respects_shortcode_id_attribute() {
-		$post_id     = $this->factory->post->create(
+		$post_id     = self::factory()->post->create(
 			array(
 				'post_content' => 'No gallery defined',
 			)
 		);
-		$post_id_two = $this->factory->post->create(
+		$post_id_two = self::factory()->post->create(
 			array(
 				'post_content' => "[gallery id='$post_id']",
 			)
 		);
-		$this->factory->attachment->create_object(
+		self::factory()->attachment->create_object(
 			array(
 				'file'           => 'test.jpg',
 				'post_parent'    => $post_id,
@@ -950,7 +950,7 @@ BLOB;
 	 */
 	public function test_returns_srcs_from_html_with_block_with_no_json_blob() {
 		// Set up an unattached image.
-		$image_id = $this->factory->attachment->create_object(
+		$image_id = self::factory()->attachment->create_object(
 			array(
 				'file'           => 'test.jpg',
 				'post_parent'    => 0,
@@ -972,7 +972,7 @@ BLOB;
 <!-- /wp:gallery -->
 BLOB;
 
-		$post_id = $this->factory->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_content' => $blob,
 			)
@@ -1022,12 +1022,12 @@ BLOB;
 	 * @group blocks
 	 */
 	public function test_returns_srcs_with_nested_block_gallery() {
-		$post_id  = $this->factory->post->create(
+		$post_id  = self::factory()->post->create(
 			array(
 				'post_content' => 'I have no gallery.',
 			)
 		);
-		$image_id = $this->factory->attachment->create_object(
+		$image_id = self::factory()->attachment->create_object(
 			array(
 				'file'           => 'test.jpg',
 				'post_parent'    => $post_id,
@@ -1045,7 +1045,7 @@ BLOB;
 <!-- /wp:columns -->
 BLOB;
 
-		$post_id_two = $this->factory->post->create( array( 'post_content' => $blob ) );
+		$post_id_two = self::factory()->post->create( array( 'post_content' => $blob ) );
 
 		$galleries = get_post_galleries( $post_id_two, false );
 

--- a/tests/phpunit/tests/menu/walker-nav-menu-edit.php
+++ b/tests/phpunit/tests/menu/walker-nav-menu-edit.php
@@ -40,7 +40,7 @@ class Tests_Menu_Walker_Nav_Menu_Edit extends WP_UnitTestCase {
 	public function test_original_title_prefix_should_not_be_shown_if_empty() {
 		$expected = '';
 
-		$post_id = $this->factory->post->create();
+		$post_id = self::factory()->post->create();
 
 		$item = array(
 			'classes'          => array(),

--- a/tests/phpunit/tests/menu/walker-nav-menu.php
+++ b/tests/phpunit/tests/menu/walker-nav-menu.php
@@ -49,7 +49,7 @@ class Tests_Menu_Walker_Nav_Menu extends WP_UnitTestCase {
 	 */
 	public function test_noopener_no_referrer_for_target_blank() {
 		$actual     = '';
-		$post_id    = $this->factory->post->create();
+		$post_id    = self::factory()->post->create();
 		$post_title = get_the_title( $post_id );
 
 		$item = array(
@@ -80,7 +80,7 @@ class Tests_Menu_Walker_Nav_Menu extends WP_UnitTestCase {
 	 */
 	public function test_start_el_with_empty_attributes( $value, $expected ) {
 		$output     = '';
-		$post_id    = $this->factory->post->create();
+		$post_id    = self::factory()->post->create();
 		$post_title = get_the_title( $post_id );
 
 		$item = array(

--- a/tests/phpunit/tests/menu/wpAjaxMenuQuickSearch.php
+++ b/tests/phpunit/tests/menu/wpAjaxMenuQuickSearch.php
@@ -104,7 +104,7 @@ class Tests_Menu_WpAjaxMenuQuickSeach extends WP_UnitTestCase {
 	public function test_search_should_return_unassigned_term_items() {
 		register_taxonomy( 'wptests_tax', 'post' );
 
-		$this->factory->term->create(
+		self::factory()->term->create(
 			array(
 				'taxonomy' => 'wptests_tax',
 				'name'     => 'foobar',

--- a/tests/phpunit/tests/multisite/network.php
+++ b/tests/phpunit/tests/multisite/network.php
@@ -561,7 +561,7 @@ if ( is_multisite() ) :
 			$new_network_id = $this->_get_next_network_id();
 			$this->assertNull( get_network( $new_network_id ) );
 
-			$new_network = $this->factory()->network->create_and_get();
+			$new_network = self::factory()->network->create_and_get();
 
 			// Double-check we got the ID of the new network correct.
 			$this->assertSame( $new_network_id, $new_network->id );

--- a/tests/phpunit/tests/multisite/site.php
+++ b/tests/phpunit/tests/multisite/site.php
@@ -2459,7 +2459,7 @@ if ( is_multisite() ) :
 			$new_site_id = $this->_get_next_site_id();
 			$this->assertNull( get_site( $new_site_id ) );
 
-			$new_site = $this->factory()->blog->create_and_get();
+			$new_site = self::factory()->blog->create_and_get();
 
 			// Double-check we got the ID of the new site correct.
 			$this->assertEquals( $new_site_id, $new_site->blog_id );

--- a/tests/phpunit/tests/multisite/wpInstallDefaults.php
+++ b/tests/phpunit/tests/multisite/wpInstallDefaults.php
@@ -13,7 +13,7 @@ if ( is_multisite() ) :
 		 * @ticket 40036
 		 */
 		public function test_option_should_not_be_empty_by_default() {
-			$blog_id = $this->factory->blog->create();
+			$blog_id = self::factory()->blog->create();
 
 			switch_to_blog( $blog_id );
 
@@ -39,7 +39,7 @@ if ( is_multisite() ) :
 			update_site_option( 'first_page', '' );
 			update_site_option( 'first_comment', '' );
 
-			$blog_id = $this->factory->blog->create();
+			$blog_id = self::factory()->blog->create();
 
 			switch_to_blog( $blog_id );
 
@@ -65,7 +65,7 @@ if ( is_multisite() ) :
 			update_site_option( 'first_page', 'Some page content' );
 			update_site_option( 'first_comment', 'Some comment content' );
 
-			$blog_id = $this->factory->blog->create();
+			$blog_id = self::factory()->blog->create();
 
 			switch_to_blog( $blog_id );
 

--- a/tests/phpunit/tests/oembed/WpEmbed.php
+++ b/tests/phpunit/tests/oembed/WpEmbed.php
@@ -28,7 +28,7 @@ class Tests_WP_Embed extends WP_UnitTestCase {
 	}
 
 	public function test_maybe_run_ajax_cache_should_return_nothing_if_there_is_no_message() {
-		$GLOBALS['post'] = $this->factory()->post->create_and_get(
+		$GLOBALS['post'] = self::factory()->post->create_and_get(
 			array(
 				'post_title' => 'Hello World',
 			)
@@ -41,7 +41,7 @@ class Tests_WP_Embed extends WP_UnitTestCase {
 	}
 
 	public function test_maybe_run_ajax_cache_should_return_javascript() {
-		$GLOBALS['post'] = $this->factory()->post->create_and_get(
+		$GLOBALS['post'] = self::factory()->post->create_and_get(
 			array(
 				'post_title' => 'Hello World',
 			)
@@ -134,7 +134,7 @@ class Tests_WP_Embed extends WP_UnitTestCase {
 	}
 
 	public function test_delete_oembed_caches() {
-		$post_id = $this->factory()->post->create();
+		$post_id = self::factory()->post->create();
 
 		add_post_meta( $post_id, '_oembed_foo', 'bar' );
 		add_post_meta( $post_id, '_oembed_foo', 'baz' );
@@ -147,14 +147,14 @@ class Tests_WP_Embed extends WP_UnitTestCase {
 	}
 
 	public function test_cache_oembed_invalid_post_type() {
-		$post_id = $this->factory()->post->create( array( 'post_type' => 'nav_menu_item' ) );
+		$post_id = self::factory()->post->create( array( 'post_type' => 'nav_menu_item' ) );
 
 		$this->wp_embed->cache_oembed( $post_id );
 		$this->assertNotSame( $post_id, $this->wp_embed->post_ID );
 	}
 
 	public function test_cache_oembed_empty_content() {
-		$post_id = $this->factory()->post->create( array( 'post_content' => '' ) );
+		$post_id = self::factory()->post->create( array( 'post_content' => '' ) );
 
 		$this->wp_embed->cache_oembed( $post_id );
 		$this->assertNotSame( $post_id, $this->wp_embed->post_ID );
@@ -167,7 +167,7 @@ class Tests_WP_Embed extends WP_UnitTestCase {
 		$cachekey      = '_oembed_' . $key_suffix;
 		$cachekey_time = '_oembed_time_' . $key_suffix;
 
-		$post_id = $this->factory()->post->create( array( 'post_content' => 'https://example.com/' ) );
+		$post_id = self::factory()->post->create( array( 'post_content' => 'https://example.com/' ) );
 
 		add_filter( 'pre_oembed_result', array( $this, '_pre_oembed_result_callback' ) );
 		$this->wp_embed->cache_oembed( $post_id );
@@ -181,7 +181,7 @@ class Tests_WP_Embed extends WP_UnitTestCase {
 	public function test_shortcode_should_get_cached_data_from_post_meta_for_known_post() {
 		global $post;
 
-		$post       = $this->factory()->post->create_and_get();
+		$post       = self::factory()->post->create_and_get();
 		$url        = 'https://example.com/';
 		$expected   = '<b>Embedded content</b>';
 		$key_suffix = md5( $url . serialize( wp_embed_defaults( $url ) ) );
@@ -208,7 +208,7 @@ class Tests_WP_Embed extends WP_UnitTestCase {
 	public function test_shortcode_should_get_cached_failure_from_post_meta_for_known_post() {
 		global $post;
 
-		$post          = $this->factory()->post->create_and_get();
+		$post          = self::factory()->post->create_and_get();
 		$url           = 'https://example.com/';
 		$expected      = '<a href="' . esc_url( $url ) . '">' . esc_html( $url ) . '</a>';
 		$key_suffix    = md5( $url . serialize( wp_embed_defaults( $url ) ) );

--- a/tests/phpunit/tests/oembed/controller.php
+++ b/tests/phpunit/tests/oembed/controller.php
@@ -290,7 +290,7 @@ class Test_oEmbed_Controller extends WP_UnitTestCase {
 	}
 
 	public function test_request_invalid_format() {
-		$post_id = $this->factory()->post->create();
+		$post_id = self::factory()->post->create();
 
 		$request = new WP_REST_Request( 'GET', '/oembed/1.0/embed' );
 		$request->set_param( 'url', get_permalink( $post_id ) );
@@ -461,12 +461,12 @@ class Test_oEmbed_Controller extends WP_UnitTestCase {
 	}
 
 	public function test_rest_pre_serve_request() {
-		$user = $this->factory()->user->create_and_get(
+		$user = self::factory()->user->create_and_get(
 			array(
 				'display_name' => 'John Doe',
 			)
 		);
-		$post = $this->factory()->post->create_and_get(
+		$post = self::factory()->post->create_and_get(
 			array(
 				'post_author' => $user->ID,
 				'post_title'  => 'Hello World',
@@ -485,7 +485,7 @@ class Test_oEmbed_Controller extends WP_UnitTestCase {
 	}
 
 	public function test_rest_pre_serve_request_wrong_format() {
-		$post = $this->factory()->post->create_and_get();
+		$post = self::factory()->post->create_and_get();
 
 		$request = new WP_REST_Request( 'GET', '/oembed/1.0/embed' );
 		$request->set_param( 'url', get_permalink( $post->ID ) );
@@ -497,7 +497,7 @@ class Test_oEmbed_Controller extends WP_UnitTestCase {
 	}
 
 	public function test_rest_pre_serve_request_wrong_method() {
-		$post = $this->factory()->post->create_and_get();
+		$post = self::factory()->post->create_and_get();
 
 		$request = new WP_REST_Request( 'HEAD', '/oembed/1.0/embed' );
 		$request->set_param( 'url', get_permalink( $post->ID ) );
@@ -513,7 +513,7 @@ class Test_oEmbed_Controller extends WP_UnitTestCase {
 		$this->assertSame( home_url() . '/index.php?rest_route=/oembed/1.0/embed', get_oembed_endpoint_url( '', 'json' ) );
 		$this->assertSame( home_url() . '/index.php?rest_route=/oembed/1.0/embed', get_oembed_endpoint_url( '', 'xml' ) );
 
-		$post_id     = $this->factory()->post->create();
+		$post_id     = self::factory()->post->create();
 		$url         = get_permalink( $post_id );
 		$url_encoded = urlencode( $url );
 
@@ -527,7 +527,7 @@ class Test_oEmbed_Controller extends WP_UnitTestCase {
 		$this->assertSame( home_url() . '/wp-json/oembed/1.0/embed', get_oembed_endpoint_url() );
 		$this->assertSame( home_url() . '/wp-json/oembed/1.0/embed', get_oembed_endpoint_url( '', 'xml' ) );
 
-		$post_id     = $this->factory()->post->create();
+		$post_id     = self::factory()->post->create();
 		$url         = get_permalink( $post_id );
 		$url_encoded = urlencode( $url );
 

--- a/tests/phpunit/tests/oembed/headers.php
+++ b/tests/phpunit/tests/oembed/headers.php
@@ -13,7 +13,7 @@ class Tests_oEmbed_HTTP_Headers extends WP_UnitTestCase {
 	 * @requires function xdebug_get_headers
 	 */
 	public function test_rest_pre_serve_request_headers() {
-		$post = $this->factory()->post->create_and_get(
+		$post = self::factory()->post->create_and_get(
 			array(
 				'post_title' => 'Hello World',
 			)

--- a/tests/phpunit/tests/post.php
+++ b/tests/phpunit/tests/post.php
@@ -726,7 +726,7 @@ class Tests_Post extends WP_UnitTestCase {
 	 */
 	public function test_use_block_editor_for_post() {
 		$this->assertFalse( use_block_editor_for_post( -1 ) );
-		$bogus_post_id = $this->factory()->post->create(
+		$bogus_post_id = self::factory()->post->create(
 			array(
 				'post_type' => 'bogus',
 			)
@@ -739,14 +739,14 @@ class Tests_Post extends WP_UnitTestCase {
 				'show_in_rest' => false,
 			)
 		);
-		$restless_post_id = $this->factory()->post->create(
+		$restless_post_id = self::factory()->post->create(
 			array(
 				'post_type' => 'restless',
 			)
 		);
 		$this->assertFalse( use_block_editor_for_post( $restless_post_id ) );
 
-		$generic_post_id = $this->factory()->post->create();
+		$generic_post_id = self::factory()->post->create();
 
 		add_filter( 'use_block_editor_for_post', '__return_false' );
 		$this->assertFalse( use_block_editor_for_post( $generic_post_id ) );

--- a/tests/phpunit/tests/post.php
+++ b/tests/phpunit/tests/post.php
@@ -454,7 +454,7 @@ class Tests_Post extends WP_UnitTestCase {
 	public function test_pre_wp_unique_post_slug_filter() {
 		add_filter( 'pre_wp_unique_post_slug', array( $this, 'filter_pre_wp_unique_post_slug' ), 10, 6 );
 
-		$post_id = $this->factory->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'title'       => 'An example',
 				'post_status' => 'publish',

--- a/tests/phpunit/tests/post/isPostPubliclyViewable.php
+++ b/tests/phpunit/tests/post/isPostPubliclyViewable.php
@@ -54,7 +54,7 @@ class Tests_Post_IsPostPubliclyViewable extends WP_UnitTestCase {
 			$date = date_format( date_create( '+1 year' ), 'Y-m-d H:i:s' );
 		}
 
-		$post_id = $this->factory()->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_type'   => $post_type,
 				'post_status' => $post_status,

--- a/tests/phpunit/tests/post/nav-menu.php
+++ b/tests/phpunit/tests/post/nav-menu.php
@@ -745,17 +745,17 @@ class Tests_Post_Nav_Menu extends WP_UnitTestCase {
 	 * @covers ::_wp_delete_customize_changeset_dependent_auto_drafts
 	 */
 	public function test_wp_delete_customize_changeset_dependent_auto_drafts() {
-		$auto_draft_post_id = $this->factory()->post->create(
+		$auto_draft_post_id = self::factory()->post->create(
 			array(
 				'post_status' => 'auto-draft',
 			)
 		);
-		$draft_post_id      = $this->factory()->post->create(
+		$draft_post_id      = self::factory()->post->create(
 			array(
 				'post_status' => 'draft',
 			)
 		);
-		$private_post_id    = $this->factory()->post->create(
+		$private_post_id    = self::factory()->post->create(
 			array(
 				'post_status' => 'private',
 			)

--- a/tests/phpunit/tests/post/walkerPage.php
+++ b/tests/phpunit/tests/post/walkerPage.php
@@ -28,7 +28,7 @@ class Tests_Post_Walker_Page extends WP_UnitTestCase {
 	 */
 	public function test_start_el_with_empty_attributes( $value, $expected ) {
 		$output = '';
-		$page   = $this->factory->post->create_and_get( array( 'post_type' => 'page' ) );
+		$page   = self::factory()->post->create_and_get( array( 'post_type' => 'page' ) );
 		$link   = get_permalink( $page );
 
 		add_filter(

--- a/tests/phpunit/tests/post/wpInsertPost.php
+++ b/tests/phpunit/tests/post/wpInsertPost.php
@@ -1425,7 +1425,7 @@ class Tests_Post_wpInsertPost extends WP_UnitTestCase {
 	public function test_contributor_cannot_set_post_slug( $post_type ) {
 		wp_set_current_user( self::$user_ids['contributor'] );
 
-		$post_id = $this->factory()->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_title'   => 'Jefferson claim: nice to have Washington on your side.',
 				'post_content' => "I’m in the cabinet. I am complicit in watching him grabbin’ at power and kiss it.\n\nIf Washington isn’t gon’ listen to disciplined dissidents, this is the difference: this kid is out!",
@@ -1464,7 +1464,7 @@ class Tests_Post_wpInsertPost extends WP_UnitTestCase {
 	public function test_administrator_can_set_post_slug( $post_type ) {
 		wp_set_current_user( self::$user_ids['administrator'] );
 
-		$post_id = $this->factory()->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_title'   => 'What is the Conner Project?',
 				'post_content' => 'Evan Hansen’s last link to his friend Conner is a signature on his broken arm.',
@@ -1505,7 +1505,7 @@ class Tests_Post_wpInsertPost extends WP_UnitTestCase {
 	public function test_administrator_cannot_set_post_slug_on_post_type_they_cannot_publish() {
 		wp_set_current_user( self::$user_ids['administrator'] );
 
-		$post_id = $this->factory()->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_title'   => 'Everything is legal in New Jersey',
 				'post_content' => 'Shortly before his death, Philip Hamilton was heard to claim everything was legal in the garden state.',
@@ -1542,7 +1542,7 @@ class Tests_Post_wpInsertPost extends WP_UnitTestCase {
 
 		$now = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 
-		$post_id = $this->factory()->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_date_gmt' => $now->modify( '-1 year' )->format( 'Y-m-d H:i:s' ),
 				'post_status'   => 'future',
@@ -1551,7 +1551,7 @@ class Tests_Post_wpInsertPost extends WP_UnitTestCase {
 
 		$this->assertSame( 'publish', get_post_status( $post_id ) );
 
-		$post_id = $this->factory()->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_date_gmt' => $now->modify( '+50 years' )->format( 'Y-m-d H:i:s' ),
 				'post_status'   => 'future',

--- a/tests/phpunit/tests/post/wpPublishPost.php
+++ b/tests/phpunit/tests/post/wpPublishPost.php
@@ -142,7 +142,7 @@ class Tests_Post_wpPublishPost extends WP_UnitTestCase {
 	 */
 	public function test_wp_publish_post_respects_current_categories() {
 		$post_id     = self::$auto_draft_id;
-		$category_id = $this->factory->term->create( array( 'taxonomy' => 'category' ) );
+		$category_id = self::factory()->term->create( array( 'taxonomy' => 'category' ) );
 		wp_set_post_categories( $post_id, $category_id );
 		wp_publish_post( $post_id );
 
@@ -183,7 +183,7 @@ class Tests_Post_wpPublishPost extends WP_UnitTestCase {
 	 */
 	public function test_wp_publish_post_adds_default_category_when_tagged() {
 		$post_id = self::$auto_draft_id;
-		$tag_id  = $this->factory->term->create( array( 'taxonomy' => 'post_tag' ) );
+		$tag_id  = self::factory()->term->create( array( 'taxonomy' => 'post_tag' ) );
 		wp_set_post_tags( $post_id, array( $tag_id ) );
 		wp_publish_post( $post_id );
 
@@ -218,7 +218,7 @@ class Tests_Post_wpPublishPost extends WP_UnitTestCase {
 		);
 
 		$post_id = self::$auto_draft_id;
-		$term_id = $this->factory->term->create( array( 'taxonomy' => 'tax_51292' ) );
+		$term_id = self::factory()->term->create( array( 'taxonomy' => 'tax_51292' ) );
 		wp_set_object_terms( $post_id, array( $term_id ), 'tax_51292' );
 		wp_publish_post( $post_id );
 

--- a/tests/phpunit/tests/privacy/wpPrivacySendErasureFulfillmentNotification.php
+++ b/tests/phpunit/tests/privacy/wpPrivacySendErasureFulfillmentNotification.php
@@ -131,7 +131,7 @@ class Tests_Privacy_wpPrivacySendErasureFulfillmentNotification extends WP_UnitT
 	 * @ticket 44234
 	 */
 	public function test_should_send_email_with_privacy_policy() {
-		$privacy_policy = $this->factory->post->create(
+		$privacy_policy = self::factory()->post->create(
 			array(
 				'post_type'   => 'page',
 				'title'       => 'Site Privacy Policy',
@@ -307,7 +307,7 @@ class Tests_Privacy_wpPrivacySendErasureFulfillmentNotification extends WP_UnitT
 	 * @ticket 44234
 	 */
 	public function test_should_not_send_email_when_not_user_request() {
-		$post_id = $this->factory->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_type' => 'post', // Should be 'user_request'.
 			)

--- a/tests/phpunit/tests/privacy/wpPrivacySendRequestConfirmationNotification.php
+++ b/tests/phpunit/tests/privacy/wpPrivacySendRequestConfirmationNotification.php
@@ -55,7 +55,7 @@ class Tests_Privacy_wpPrivacySendRequestConfirmationNotification extends WP_Unit
 	 * @ticket 43967
 	 */
 	public function test_function_should_not_send_email_when_not_a_wp_user_request() {
-		$post_id = $this->factory->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_type' => 'post',
 			)

--- a/tests/phpunit/tests/query.php
+++ b/tests/phpunit/tests/query.php
@@ -644,19 +644,19 @@ class Tests_Query extends WP_UnitTestCase {
 		register_taxonomy( 'tax1', 'post' );
 		register_taxonomy( 'tax2', 'post' );
 
-		$term1   = $this->factory->term->create(
+		$term1   = self::factory()->term->create(
 			array(
 				'taxonomy' => 'tax1',
 				'name'     => 'term1',
 			)
 		);
-		$term2   = $this->factory->term->create(
+		$term2   = self::factory()->term->create(
 			array(
 				'taxonomy' => 'tax2',
 				'name'     => 'term2',
 			)
 		);
-		$post_id = $this->factory->post->create();
+		$post_id = self::factory()->post->create();
 		wp_set_object_terms( $post_id, 'term1', 'tax1' );
 		wp_set_object_terms( $post_id, 'term2', 'tax2' );
 
@@ -674,19 +674,19 @@ class Tests_Query extends WP_UnitTestCase {
 		register_taxonomy( 'tax1', 'post' );
 		register_taxonomy( 'tax2', 'post' );
 
-		$term1   = $this->factory->term->create(
+		$term1   = self::factory()->term->create(
 			array(
 				'taxonomy' => 'tax1',
 				'name'     => 'term1',
 			)
 		);
-		$term2   = $this->factory->term->create(
+		$term2   = self::factory()->term->create(
 			array(
 				'taxonomy' => 'tax2',
 				'name'     => 'term2',
 			)
 		);
-		$post_id = $this->factory->post->create();
+		$post_id = self::factory()->post->create();
 		wp_set_object_terms( $post_id, 'term1', 'tax1' );
 		wp_set_object_terms( $post_id, 'term2', 'tax2' );
 

--- a/tests/phpunit/tests/query/conditionals.php
+++ b/tests/phpunit/tests/query/conditionals.php
@@ -978,13 +978,13 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	public function test_is_single_with_slug_that_clashes_with_attachment() {
 		$this->set_permalink_structure( '/%postname%/' );
 
-		$attachment_id = $this->factory->post->create(
+		$attachment_id = self::factory()->post->create(
 			array(
 				'post_type' => 'attachment',
 			)
 		);
 
-		$post_id = $this->factory->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_title' => get_post( $attachment_id )->post_title,
 			)

--- a/tests/phpunit/tests/query/noFoundRows.php
+++ b/tests/phpunit/tests/query/noFoundRows.php
@@ -73,7 +73,7 @@ class Tests_Query_NoFoundRows extends WP_UnitTestCase {
 	 * @ticket 29552
 	 */
 	public function test_no_found_rows_default_with_nopaging_true() {
-		$p = $this->factory->post->create();
+		$p = self::factory()->post->create();
 
 		$q = new WP_Query(
 			array(
@@ -90,7 +90,7 @@ class Tests_Query_NoFoundRows extends WP_UnitTestCase {
 	 * @ticket 29552
 	 */
 	public function test_no_found_rows_default_with_postsperpage_minus1() {
-		$p = $this->factory->post->create();
+		$p = self::factory()->post->create();
 
 		$q = new WP_Query(
 			array(

--- a/tests/phpunit/tests/query/search.php
+++ b/tests/phpunit/tests/query/search.php
@@ -266,7 +266,7 @@ class Tests_Query_Search extends WP_UnitTestCase {
 	 * @ticket 31025
 	 */
 	public function test_s_zero() {
-		$p1 = $this->factory->post->create(
+		$p1 = self::factory()->post->create(
 			array(
 				'post_status'  => 'publish',
 				'post_title'   => '1',
@@ -275,7 +275,7 @@ class Tests_Query_Search extends WP_UnitTestCase {
 			)
 		);
 
-		$p2 = $this->factory->post->create(
+		$p2 = self::factory()->post->create(
 			array(
 				'post_status'  => 'publish',
 				'post_title'   => '0',

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -182,7 +182,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$this->assertSame( 'view', $data['endpoints'][0]['args']['context']['default'] );
 		$this->assertSame( array( 'view', 'embed', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
 		// Single.
-		$attachment_id = $this->factory->attachment->create_object(
+		$attachment_id = self::factory()->attachment->create_object(
 			$this->test_file,
 			0,
 			array(
@@ -243,7 +243,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	}
 
 	public function test_registered_get_item_params() {
-		$id1      = $this->factory->attachment->create_object(
+		$id1      = self::factory()->attachment->create_object(
 			$this->test_file,
 			0,
 			array(
@@ -263,7 +263,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	 * @ticket 43701
 	 */
 	public function test_allow_header_sent_on_options_request() {
-		$id1      = $this->factory->attachment->create_object(
+		$id1      = self::factory()->attachment->create_object(
 			$this->test_file,
 			0,
 			array(
@@ -291,7 +291,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 
 	public function test_get_items() {
 		wp_set_current_user( 0 );
-		$id1            = $this->factory->attachment->create_object(
+		$id1            = self::factory()->attachment->create_object(
 			$this->test_file,
 			0,
 			array(
@@ -299,8 +299,8 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 				'post_excerpt'   => 'A sample caption',
 			)
 		);
-		$draft_post     = $this->factory->post->create( array( 'post_status' => 'draft' ) );
-		$id2            = $this->factory->attachment->create_object(
+		$draft_post     = self::factory()->post->create( array( 'post_status' => 'draft' ) );
+		$id2            = self::factory()->attachment->create_object(
 			$this->test_file,
 			$draft_post,
 			array(
@@ -308,8 +308,8 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 				'post_excerpt'   => 'A sample caption',
 			)
 		);
-		$published_post = $this->factory->post->create( array( 'post_status' => 'publish' ) );
-		$id3            = $this->factory->attachment->create_object(
+		$published_post = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$id3            = self::factory()->attachment->create_object(
 			$this->test_file,
 			$published_post,
 			array(
@@ -331,7 +331,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 
 	public function test_get_items_logged_in_editor() {
 		wp_set_current_user( self::$editor_id );
-		$id1            = $this->factory->attachment->create_object(
+		$id1            = self::factory()->attachment->create_object(
 			$this->test_file,
 			0,
 			array(
@@ -339,8 +339,8 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 				'post_excerpt'   => 'A sample caption',
 			)
 		);
-		$draft_post     = $this->factory->post->create( array( 'post_status' => 'draft' ) );
-		$id2            = $this->factory->attachment->create_object(
+		$draft_post     = self::factory()->post->create( array( 'post_status' => 'draft' ) );
+		$id2            = self::factory()->attachment->create_object(
 			$this->test_file,
 			$draft_post,
 			array(
@@ -348,8 +348,8 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 				'post_excerpt'   => 'A sample caption',
 			)
 		);
-		$published_post = $this->factory->post->create( array( 'post_status' => 'publish' ) );
-		$id3            = $this->factory->attachment->create_object(
+		$published_post = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$id3            = self::factory()->attachment->create_object(
 			$this->test_file,
 			$published_post,
 			array(
@@ -369,7 +369,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	}
 
 	public function test_get_items_media_type() {
-		$id1      = $this->factory->attachment->create_object(
+		$id1      = self::factory()->attachment->create_object(
 			$this->test_file,
 			0,
 			array(
@@ -392,7 +392,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	}
 
 	public function test_get_items_mime_type() {
-		$id1      = $this->factory->attachment->create_object(
+		$id1      = self::factory()->attachment->create_object(
 			$this->test_file,
 			0,
 			array(
@@ -415,8 +415,8 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	}
 
 	public function test_get_items_parent() {
-		$post_id        = $this->factory->post->create( array( 'post_title' => 'Test Post' ) );
-		$attachment_id  = $this->factory->attachment->create_object(
+		$post_id        = self::factory()->post->create( array( 'post_title' => 'Test Post' ) );
+		$attachment_id  = self::factory()->attachment->create_object(
 			$this->test_file,
 			$post_id,
 			array(
@@ -424,7 +424,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 				'post_excerpt'   => 'A sample caption',
 			)
 		);
-		$attachment_id2 = $this->factory->attachment->create_object(
+		$attachment_id2 = self::factory()->attachment->create_object(
 			$this->test_file,
 			0,
 			array(
@@ -460,7 +460,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 
 	public function test_get_items_invalid_status_param_is_error_response() {
 		wp_set_current_user( self::$editor_id );
-		$this->factory->attachment->create_object(
+		self::factory()->attachment->create_object(
 			$this->test_file,
 			0,
 			array(
@@ -478,7 +478,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	public function test_get_items_private_status() {
 		// Logged out users can't make the request.
 		wp_set_current_user( 0 );
-		$attachment_id1 = $this->factory->attachment->create_object(
+		$attachment_id1 = self::factory()->attachment->create_object(
 			$this->test_file,
 			0,
 			array(
@@ -502,7 +502,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	public function test_get_items_multiple_statuses() {
 		// Logged out users can't make the request.
 		wp_set_current_user( 0 );
-		$attachment_id1 = $this->factory->attachment->create_object(
+		$attachment_id1 = self::factory()->attachment->create_object(
 			$this->test_file,
 			0,
 			array(
@@ -511,7 +511,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 				'post_status'    => 'private',
 			)
 		);
-		$attachment_id2 = $this->factory->attachment->create_object(
+		$attachment_id2 = self::factory()->attachment->create_object(
 			$this->test_file,
 			0,
 			array(
@@ -547,7 +547,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	}
 
 	public function test_get_items_valid_date() {
-		$id1     = $this->factory->attachment->create_object(
+		$id1     = self::factory()->attachment->create_object(
 			$this->test_file,
 			0,
 			array(
@@ -556,7 +556,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 				'post_excerpt'   => 'A sample caption',
 			)
 		);
-		$id2     = $this->factory->attachment->create_object(
+		$id2     = self::factory()->attachment->create_object(
 			$this->test_file,
 			0,
 			array(
@@ -565,7 +565,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 				'post_excerpt'   => 'A sample caption',
 			)
 		);
-		$id3     = $this->factory->attachment->create_object(
+		$id3     = self::factory()->attachment->create_object(
 			$this->test_file,
 			0,
 			array(
@@ -598,7 +598,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	 * @ticket 50617
 	 */
 	public function test_get_items_valid_modified_date() {
-		$id1 = $this->factory->attachment->create_object(
+		$id1 = self::factory()->attachment->create_object(
 			$this->test_file,
 			0,
 			array(
@@ -607,7 +607,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 				'post_excerpt'   => 'A sample caption',
 			)
 		);
-		$id2 = $this->factory->attachment->create_object(
+		$id2 = self::factory()->attachment->create_object(
 			$this->test_file,
 			0,
 			array(
@@ -616,7 +616,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 				'post_excerpt'   => 'A sample caption',
 			)
 		);
-		$id3 = $this->factory->attachment->create_object(
+		$id3 = self::factory()->attachment->create_object(
 			$this->test_file,
 			0,
 			array(
@@ -658,7 +658,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	 * @ticket 55677
 	 */
 	public function test_get_items_with_empty_page_runs_count_query_after() {
-		$this->factory->attachment->create_object(
+		self::factory()->attachment->create_object(
 			$this->test_file,
 			0,
 			array(
@@ -680,7 +680,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	}
 
 	public function test_get_item() {
-		$attachment_id = $this->factory->attachment->create_object(
+		$attachment_id = self::factory()->attachment->create_object(
 			$this->test_file,
 			0,
 			array(
@@ -700,7 +700,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	 * @requires function imagejpeg
 	 */
 	public function test_get_item_sizes() {
-		$attachment_id = $this->factory->attachment->create_object(
+		$attachment_id = self::factory()->attachment->create_object(
 			$this->test_file,
 			0,
 			array(
@@ -731,7 +731,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	 * @requires function imagejpeg
 	 */
 	public function test_get_item_sizes_with_no_url() {
-		$attachment_id = $this->factory->attachment->create_object(
+		$attachment_id = self::factory()->attachment->create_object(
 			$this->test_file,
 			0,
 			array(
@@ -758,8 +758,8 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 
 	public function test_get_item_private_post_not_authenticated() {
 		wp_set_current_user( 0 );
-		$draft_post = $this->factory->post->create( array( 'post_status' => 'draft' ) );
-		$id1        = $this->factory->attachment->create_object(
+		$draft_post = self::factory()->post->create( array( 'post_status' => 'draft' ) );
+		$id1        = self::factory()->attachment->create_object(
 			$this->test_file,
 			$draft_post,
 			array(
@@ -773,7 +773,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	}
 
 	public function test_get_item_inherit_status_with_invalid_parent() {
-		$attachment_id = $this->factory->attachment->create_object(
+		$attachment_id = self::factory()->attachment->create_object(
 			$this->test_file,
 			REST_TESTS_IMPOSSIBLY_HIGH_NUMBER,
 			array(
@@ -790,7 +790,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	}
 
 	public function test_get_item_auto_status_with_invalid_parent_not_authenticated_returns_error() {
-		$attachment_id = $this->factory->attachment->create_object(
+		$attachment_id = self::factory()->attachment->create_object(
 			$this->test_file,
 			REST_TESTS_IMPOSSIBLY_HIGH_NUMBER,
 			array(
@@ -960,7 +960,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	}
 
 	public function test_create_item_invalid_edit_permissions() {
-		$post_id = $this->factory->post->create( array( 'post_author' => self::$editor_id ) );
+		$post_id = self::factory()->post->create( array( 'post_author' => self::$editor_id ) );
 		wp_set_current_user( self::$author_id );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
 		$request->set_param( 'post', $post_id );
@@ -969,7 +969,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	}
 
 	public function test_create_item_invalid_upload_permissions() {
-		$post_id = $this->factory->post->create( array( 'post_author' => self::$editor_id ) );
+		$post_id = self::factory()->post->create( array( 'post_author' => self::$editor_id ) );
 		wp_set_current_user( self::$uploader_id );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
 		$request->set_param( 'post', $post_id );
@@ -978,7 +978,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	}
 
 	public function test_create_item_invalid_post_type() {
-		$attachment_id = $this->factory->post->create(
+		$attachment_id = self::factory()->post->create(
 			array(
 				'post_type'   => 'attachment',
 				'post_status' => 'inherit',
@@ -1043,7 +1043,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 
 	public function test_update_item() {
 		wp_set_current_user( self::$editor_id );
-		$attachment_id = $this->factory->attachment->create_object(
+		$attachment_id = self::factory()->attachment->create_object(
 			$this->test_file,
 			0,
 			array(
@@ -1072,8 +1072,8 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 
 	public function test_update_item_parent() {
 		wp_set_current_user( self::$editor_id );
-		$original_parent = $this->factory->post->create( array() );
-		$attachment_id   = $this->factory->attachment->create_object(
+		$original_parent = self::factory()->post->create( array() );
+		$attachment_id   = self::factory()->attachment->create_object(
 			$this->test_file,
 			$original_parent,
 			array(
@@ -1086,7 +1086,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$attachment = get_post( $attachment_id );
 		$this->assertSame( $original_parent, $attachment->post_parent );
 
-		$new_parent = $this->factory->post->create( array() );
+		$new_parent = self::factory()->post->create( array() );
 		$request    = new WP_REST_Request( 'POST', '/wp/v2/media/' . $attachment_id );
 		$request->set_param( 'post', $new_parent );
 		rest_get_server()->dispatch( $request );
@@ -1097,7 +1097,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 
 	public function test_update_item_invalid_permissions() {
 		wp_set_current_user( self::$author_id );
-		$attachment_id = $this->factory->attachment->create_object(
+		$attachment_id = self::factory()->attachment->create_object(
 			$this->test_file,
 			0,
 			array(
@@ -1113,7 +1113,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	}
 
 	public function test_update_item_invalid_post_type() {
-		$attachment_id = $this->factory->post->create(
+		$attachment_id = self::factory()->post->create(
 			array(
 				'post_type'   => 'attachment',
 				'post_status' => 'inherit',
@@ -1121,7 +1121,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 			)
 		);
 		wp_set_current_user( self::$editor_id );
-		$attachment_id = $this->factory->attachment->create_object(
+		$attachment_id = self::factory()->attachment->create_object(
 			$this->test_file,
 			0,
 			array(
@@ -1445,7 +1445,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 
 	public function test_delete_item() {
 		wp_set_current_user( self::$editor_id );
-		$attachment_id    = $this->factory->attachment->create_object(
+		$attachment_id    = self::factory()->attachment->create_object(
 			$this->test_file,
 			0,
 			array(
@@ -1461,7 +1461,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 
 	public function test_delete_item_no_trash() {
 		wp_set_current_user( self::$editor_id );
-		$attachment_id = $this->factory->attachment->create_object(
+		$attachment_id = self::factory()->attachment->create_object(
 			$this->test_file,
 			0,
 			array(
@@ -1486,7 +1486,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 
 	public function test_delete_item_invalid_delete_permissions() {
 		wp_set_current_user( self::$author_id );
-		$attachment_id = $this->factory->attachment->create_object(
+		$attachment_id = self::factory()->attachment->create_object(
 			$this->test_file,
 			0,
 			array(
@@ -1501,7 +1501,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	}
 
 	public function test_prepare_item() {
-		$attachment_id = $this->factory->attachment->create_object(
+		$attachment_id = self::factory()->attachment->create_object(
 			$this->test_file,
 			0,
 			array(
@@ -1520,7 +1520,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	}
 
 	public function test_prepare_item_limit_fields() {
-		$attachment_id = $this->factory->attachment->create_object(
+		$attachment_id = self::factory()->attachment->create_object(
 			$this->test_file,
 			0,
 			array(
@@ -1611,7 +1611,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$this->assertArrayHasKey( 'my_custom_int', $data['schema']['properties'] );
 		$this->assertSame( $schema, $data['schema']['properties']['my_custom_int'] );
 
-		$attachment_id = $this->factory->attachment->create_object(
+		$attachment_id = self::factory()->attachment->create_object(
 			$this->test_file,
 			0,
 			array(
@@ -1648,7 +1648,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		);
 
 		wp_set_current_user( self::$editor_id );
-		$attachment_id = $this->factory->attachment->create_object(
+		$attachment_id = self::factory()->attachment->create_object(
 			$this->test_file,
 			0,
 			array(
@@ -1674,14 +1674,14 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	}
 
 	public function test_search_item_by_filename() {
-		$id1 = $this->factory->attachment->create_object(
+		$id1 = self::factory()->attachment->create_object(
 			$this->test_file,
 			0,
 			array(
 				'post_mime_type' => 'image/jpeg',
 			)
 		);
-		$id2 = $this->factory->attachment->create_object(
+		$id2 = self::factory()->attachment->create_object(
 			$this->test_file2,
 			0,
 			array(
@@ -1932,7 +1932,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		add_action( 'rest_after_insert_attachment', array( $this, 'filter_rest_after_insert_attachment' ) );
 
 		wp_set_current_user( self::$editor_id );
-		$attachment_id = $this->factory->attachment->create_object(
+		$attachment_id = self::factory()->attachment->create_object(
 			$this->test_file,
 			0,
 			array(

--- a/tests/phpunit/tests/rest-api/rest-categories-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-categories-controller.php
@@ -121,7 +121,7 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 		$this->assertSame( 'view', $data['endpoints'][0]['args']['context']['default'] );
 		$this->assertSameSets( array( 'view', 'embed', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
 		// Single.
-		$category1 = $this->factory->category->create( array( 'name' => 'Season 5' ) );
+		$category1 = self::factory()->category->create( array( 'name' => 'Season 5' ) );
 		$request   = new WP_REST_Request( 'OPTIONS', '/wp/v2/categories/' . $category1 );
 		$response  = rest_get_server()->dispatch( $request );
 		$data      = $response->get_data();
@@ -172,9 +172,9 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 	}
 
 	public function test_get_items_hide_empty_arg() {
-		$post_id   = $this->factory->post->create();
-		$category1 = $this->factory->category->create( array( 'name' => 'Season 5' ) );
-		$category2 = $this->factory->category->create( array( 'name' => 'The Be Sharps' ) );
+		$post_id   = self::factory()->post->create();
+		$category1 = self::factory()->category->create( array( 'name' => 'Season 5' ) );
+		$category2 = self::factory()->category->create( array( 'name' => 'The Be Sharps' ) );
 
 		$total_categories = self::$total_categories + 2;
 
@@ -197,15 +197,15 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 	}
 
 	public function test_get_items_parent_zero_arg() {
-		$parent1 = $this->factory->category->create( array( 'name' => 'Homer' ) );
-		$parent2 = $this->factory->category->create( array( 'name' => 'Marge' ) );
-		$this->factory->category->create(
+		$parent1 = self::factory()->category->create( array( 'name' => 'Homer' ) );
+		$parent2 = self::factory()->category->create( array( 'name' => 'Marge' ) );
+		self::factory()->category->create(
 			array(
 				'name'   => 'Bart',
 				'parent' => $parent1,
 			)
 		);
-		$this->factory->category->create(
+		self::factory()->category->create(
 			array(
 				'name'   => 'Lisa',
 				'parent' => $parent2,
@@ -229,15 +229,15 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 	}
 
 	public function test_get_items_parent_zero_arg_string() {
-		$parent1 = $this->factory->category->create( array( 'name' => 'Homer' ) );
-		$parent2 = $this->factory->category->create( array( 'name' => 'Marge' ) );
-		$this->factory->category->create(
+		$parent1 = self::factory()->category->create( array( 'name' => 'Homer' ) );
+		$parent2 = self::factory()->category->create( array( 'name' => 'Marge' ) );
+		self::factory()->category->create(
 			array(
 				'name'   => 'Bart',
 				'parent' => $parent1,
 			)
 		);
-		$this->factory->category->create(
+		self::factory()->category->create(
 			array(
 				'name'   => 'Lisa',
 				'parent' => $parent2,
@@ -261,7 +261,7 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 	}
 
 	public function test_get_items_by_parent_non_found() {
-		$parent1 = $this->factory->category->create( array( 'name' => 'Homer' ) );
+		$parent1 = self::factory()->category->create( array( 'name' => 'Homer' ) );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/categories' );
 		$request->set_param( 'parent', $parent1 );
@@ -284,8 +284,8 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 	}
 
 	public function test_get_items_include_query() {
-		$id1 = $this->factory->category->create();
-		$id2 = $this->factory->category->create();
+		$id1 = self::factory()->category->create();
+		$id2 = self::factory()->category->create();
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/categories' );
 
@@ -305,8 +305,8 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 	}
 
 	public function test_get_items_exclude_query() {
-		$id1 = $this->factory->category->create();
-		$id2 = $this->factory->category->create();
+		$id1 = self::factory()->category->create();
+		$id2 = self::factory()->category->create();
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/categories' );
 		$request->set_param( 'per_page', self::$per_page );
@@ -325,8 +325,8 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 	}
 
 	public function test_get_items_orderby_args() {
-		$this->factory->category->create( array( 'name' => 'Apple' ) );
-		$this->factory->category->create( array( 'name' => 'Banana' ) );
+		self::factory()->category->create( array( 'name' => 'Apple' ) );
+		self::factory()->category->create( array( 'name' => 'Banana' ) );
 
 		/*
 		 * Tests:
@@ -356,9 +356,9 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 	}
 
 	public function test_get_items_orderby_id() {
-		$this->factory->category->create( array( 'name' => 'Cantaloupe' ) );
-		$this->factory->category->create( array( 'name' => 'Apple' ) );
-		$this->factory->category->create( array( 'name' => 'Banana' ) );
+		self::factory()->category->create( array( 'name' => 'Cantaloupe' ) );
+		self::factory()->category->create( array( 'name' => 'Apple' ) );
+		self::factory()->category->create( array( 'name' => 'Banana' ) );
 
 		// Defaults to 'orderby' => 'name', 'order' => 'asc'.
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/categories' );
@@ -392,9 +392,9 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 	}
 
 	public function test_get_items_orderby_slugs() {
-		$this->factory->category->create( array( 'name' => 'Burrito' ) );
-		$this->factory->category->create( array( 'name' => 'Taco' ) );
-		$this->factory->category->create( array( 'name' => 'Chalupa' ) );
+		self::factory()->category->create( array( 'name' => 'Burrito' ) );
+		self::factory()->category->create( array( 'name' => 'Taco' ) );
+		self::factory()->category->create( array( 'name' => 'Chalupa' ) );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/categories' );
 		$request->set_param( 'orderby', 'include_slugs' );
@@ -408,20 +408,20 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 	}
 
 	protected function post_with_categories() {
-		$post_id   = $this->factory->post->create();
-		$category1 = $this->factory->category->create(
+		$post_id   = self::factory()->post->create();
+		$category1 = self::factory()->category->create(
 			array(
 				'name'        => 'DC',
 				'description' => 'Purveyor of fine detective comics',
 			)
 		);
-		$category2 = $this->factory->category->create(
+		$category2 = self::factory()->category->create(
 			array(
 				'name'        => 'Marvel',
 				'description' => 'Home of the Marvel Universe',
 			)
 		);
-		$category3 = $this->factory->category->create(
+		$category3 = self::factory()->category->create(
 			array(
 				'name'        => 'Image',
 				'description' => 'American independent comic publisher',
@@ -493,25 +493,25 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 		register_taxonomy( 'batman', 'post', array( 'show_in_rest' => true ) );
 		$controller = new WP_REST_Terms_Controller( 'batman' );
 		$controller->register_routes();
-		$term1 = $this->factory->term->create(
+		$term1 = self::factory()->term->create(
 			array(
 				'name'     => 'Cape',
 				'taxonomy' => 'batman',
 			)
 		);
-		$term2 = $this->factory->term->create(
+		$term2 = self::factory()->term->create(
 			array(
 				'name'     => 'Mask',
 				'taxonomy' => 'batman',
 			)
 		);
-		$this->factory->term->create(
+		self::factory()->term->create(
 			array(
 				'name'     => 'Car',
 				'taxonomy' => 'batman',
 			)
 		);
-		$post_id = $this->factory->post->create();
+		$post_id = self::factory()->post->create();
 		wp_set_object_terms( $post_id, array( $term1, $term2 ), 'batman' );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/batman' );
@@ -525,8 +525,8 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 	}
 
 	public function test_get_items_search_args() {
-		$this->factory->category->create( array( 'name' => 'Apple' ) );
-		$this->factory->category->create( array( 'name' => 'Banana' ) );
+		self::factory()->category->create( array( 'name' => 'Apple' ) );
+		self::factory()->category->create( array( 'name' => 'Banana' ) );
 
 		/*
 		 * Tests:
@@ -549,8 +549,8 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 	}
 
 	public function test_get_items_slug_arg() {
-		$this->factory->category->create( array( 'name' => 'Apple' ) );
-		$this->factory->category->create( array( 'name' => 'Banana' ) );
+		self::factory()->category->create( array( 'name' => 'Apple' ) );
+		self::factory()->category->create( array( 'name' => 'Banana' ) );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/categories' );
 		$request->set_param( 'slug', 'apple' );
@@ -562,8 +562,8 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 	}
 
 	public function test_get_terms_parent_arg() {
-		$category1 = $this->factory->category->create( array( 'name' => 'Parent' ) );
-		$this->factory->category->create(
+		$category1 = self::factory()->category->create( array( 'name' => 'Parent' ) );
+		self::factory()->category->create(
 			array(
 				'name'   => 'Child',
 				'parent' => $category1,
@@ -587,13 +587,13 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 
 	public function test_get_terms_private_taxonomy() {
 		register_taxonomy( 'robin', 'post', array( 'public' => false ) );
-		$this->factory->term->create(
+		self::factory()->term->create(
 			array(
 				'name'     => 'Cape',
 				'taxonomy' => 'robin',
 			)
 		);
-		$this->factory->term->create(
+		self::factory()->term->create(
 			array(
 				'name'     => 'Mask',
 				'taxonomy' => 'robin',
@@ -632,7 +632,7 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 		$this->assertStringContainsString( '<' . $next_link . '>; rel="next"', $headers['Link'] );
 
 		// 3rd page.
-		$this->factory->category->create();
+		self::factory()->category->create();
 		$total_categories++;
 		$total_pages++;
 		$request = new WP_REST_Request( 'GET', '/wp/v2/categories' );
@@ -775,7 +775,7 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 
 	public function test_get_term_private_taxonomy() {
 		register_taxonomy( 'robin', 'post', array( 'public' => false ) );
-		$term1 = $this->factory->term->create(
+		$term1 = self::factory()->term->create(
 			array(
 				'name'     => 'Cape',
 				'taxonomy' => 'robin',
@@ -789,7 +789,7 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 
 	public function test_get_item_incorrect_taxonomy() {
 		register_taxonomy( 'robin', 'post' );
-		$term1 = $this->factory->term->create(
+		$term1 = self::factory()->term->create(
 			array(
 				'name'     => 'Cape',
 				'taxonomy' => 'robin',
@@ -824,7 +824,7 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 	public function test_create_item_term_already_exists() {
 		wp_set_current_user( self::$administrator );
 
-		$existing_id = $this->factory->category->create( array( 'name' => 'Existing' ) );
+		$existing_id = self::factory()->category->create( array( 'name' => 'Existing' ) );
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/categories' );
 		$request->set_param( 'name', 'Existing' );
@@ -890,7 +890,7 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 	public function test_create_item_invalid_parent() {
 		wp_set_current_user( self::$administrator );
 
-		$term = get_term_by( 'id', $this->factory->category->create(), 'category' );
+		$term = get_term_by( 'id', self::factory()->category->create(), 'category' );
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/categories/' . $term->term_id );
 		$request->set_param( 'name', 'My Awesome Term' );
@@ -922,7 +922,7 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 			'slug'        => 'original-slug',
 		);
 
-		$term = get_term_by( 'id', $this->factory->category->create( $orig_args ), 'category' );
+		$term = get_term_by( 'id', self::factory()->category->create( $orig_args ), 'category' );
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/categories/' . $term->term_id );
 		$request->set_param( 'name', 'New Name' );
@@ -968,7 +968,7 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 	public function test_update_item_incorrect_permissions() {
 		wp_set_current_user( self::$subscriber );
 
-		$term = get_term_by( 'id', $this->factory->category->create(), 'category' );
+		$term = get_term_by( 'id', self::factory()->category->create(), 'category' );
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/categories/' . $term->term_id );
 		$request->set_param( 'name', 'Incorrect permissions' );
@@ -979,8 +979,8 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 	public function test_update_item_parent() {
 		wp_set_current_user( self::$administrator );
 
-		$parent = get_term_by( 'id', $this->factory->category->create(), 'category' );
-		$term   = get_term_by( 'id', $this->factory->category->create(), 'category' );
+		$parent = get_term_by( 'id', self::factory()->category->create(), 'category' );
+		$term   = get_term_by( 'id', self::factory()->category->create(), 'category' );
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/categories/' . $term->term_id );
 		$request->set_param( 'parent', $parent->term_id );
@@ -994,12 +994,12 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 	public function test_update_item_remove_parent() {
 		wp_set_current_user( self::$administrator );
 
-		$old_parent_term = get_term_by( 'id', $this->factory->category->create(), 'category' );
+		$old_parent_term = get_term_by( 'id', self::factory()->category->create(), 'category' );
 		$new_parent_id   = 0;
 
 		$term = get_term_by(
 			'id',
-			$this->factory->category->create(
+			self::factory()->category->create(
 				array(
 					'parent' => $old_parent_term->term_id,
 				)
@@ -1021,7 +1021,7 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 	public function test_update_item_invalid_parent() {
 		wp_set_current_user( self::$administrator );
 
-		$term = get_term_by( 'id', $this->factory->category->create(), 'category' );
+		$term = get_term_by( 'id', self::factory()->category->create(), 'category' );
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/categories/' . $term->term_id );
 		$request->set_param( 'parent', REST_TESTS_IMPOSSIBLY_HIGH_NUMBER );
@@ -1032,7 +1032,7 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 	public function test_delete_item() {
 		wp_set_current_user( self::$administrator );
 
-		$term = get_term_by( 'id', $this->factory->category->create( array( 'name' => 'Deleted Category' ) ), 'category' );
+		$term = get_term_by( 'id', self::factory()->category->create( array( 'name' => 'Deleted Category' ) ), 'category' );
 
 		$request = new WP_REST_Request( 'DELETE', '/wp/v2/categories/' . $term->term_id );
 		$request->set_param( 'force', true );
@@ -1046,7 +1046,7 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 	public function test_delete_item_no_trash() {
 		wp_set_current_user( self::$administrator );
 
-		$term = get_term_by( 'id', $this->factory->category->create( array( 'name' => 'Deleted Category' ) ), 'category' );
+		$term = get_term_by( 'id', self::factory()->category->create( array( 'name' => 'Deleted Category' ) ), 'category' );
 
 		$request  = new WP_REST_Request( 'DELETE', '/wp/v2/categories/' . $term->term_id );
 		$response = rest_get_server()->dispatch( $request );
@@ -1076,7 +1076,7 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 	public function test_delete_item_incorrect_permissions() {
 		wp_set_current_user( self::$subscriber );
 
-		$term     = get_term_by( 'id', $this->factory->category->create(), 'category' );
+		$term     = get_term_by( 'id', self::factory()->category->create(), 'category' );
 		$request  = new WP_REST_Request( 'DELETE', '/wp/v2/categories/' . $term->term_id );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertErrorResponse( 'rest_cannot_delete', $response, 403 );
@@ -1108,7 +1108,7 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 	}
 
 	public function test_prepare_taxonomy_term_child() {
-		$child = $this->factory->category->create(
+		$child = self::factory()->category->create(
 			array(
 				'parent' => 1,
 			)
@@ -1170,7 +1170,7 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 		$this->assertArrayHasKey( 'my_custom_int', $data['schema']['properties'] );
 		$this->assertSame( $schema, $data['schema']['properties']['my_custom_int'] );
 
-		$category_id = $this->factory->category->create();
+		$category_id = self::factory()->category->create();
 		$request     = new WP_REST_Request( 'GET', '/wp/v2/categories/' . $category_id );
 
 		$response = rest_get_server()->dispatch( $request );

--- a/tests/phpunit/tests/rest-api/rest-comments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-comments-controller.php
@@ -237,7 +237,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			'comment_post_ID'  => self::$password_id,
 		);
 
-		$password_comment = $this->factory->comment->create( $args );
+		$password_comment = self::factory()->comment->create( $args );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
 		$request->set_param( 'password', 'toomanysecrets' );
@@ -261,7 +261,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			'comment_post_ID'  => self::$password_id,
 		);
 
-		$password_comment = $this->factory->comment->create( $args );
+		$password_comment = self::factory()->comment->create( $args );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
 		$request->set_param( 'password', 'toomanysecrets' );
@@ -284,7 +284,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			'comment_post_ID'  => self::$password_id,
 		);
 
-		$password_comment = $this->factory->comment->create( $args );
+		$password_comment = self::factory()->comment->create( $args );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
 		$request->set_param( 'password', 'toomanysecrets' );
@@ -302,7 +302,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			'comment_post_ID'  => self::$password_id,
 		);
 
-		$password_comment = $this->factory->comment->create( $args );
+		$password_comment = self::factory()->comment->create( $args );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
 
@@ -321,7 +321,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			'comment_post_ID'  => self::$password_id,
 		);
 
-		$password_comment = $this->factory->comment->create( $args );
+		$password_comment = self::factory()->comment->create( $args );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
 
@@ -340,7 +340,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			'comment_post_ID'  => self::$private_id,
 		);
 
-		$private_comment = $this->factory->comment->create( $args );
+		$private_comment = self::factory()->comment->create( $args );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
 
@@ -359,7 +359,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			'comment_post_ID'  => self::$private_id,
 		);
 
-		$private_comment = $this->factory->comment->create( $args );
+		$private_comment = self::factory()->comment->create( $args );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
 
@@ -373,7 +373,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	public function test_get_items_with_invalid_post() {
 		wp_set_current_user( 0 );
 
-		$comment_id = $this->factory->comment->create(
+		$comment_id = self::factory()->comment->create(
 			array(
 				'comment_approved' => 1,
 				'comment_post_ID'  => REST_TESTS_IMPOSSIBLY_HIGH_NUMBER,
@@ -394,7 +394,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	public function test_get_items_with_invalid_post_permission() {
 		wp_set_current_user( self::$admin_id );
 
-		$comment_id = $this->factory->comment->create(
+		$comment_id = self::factory()->comment->create(
 			array(
 				'comment_approved' => 1,
 				'comment_post_ID'  => REST_TESTS_IMPOSSIBLY_HIGH_NUMBER,
@@ -424,7 +424,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	public function test_get_items_no_post() {
 		wp_set_current_user( self::$admin_id );
 
-		$this->factory->comment->create_post_comments( 0, 2 );
+		self::factory()->comment->create_post_comments( 0, 2 );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
 		$request->set_param( 'post', 0 );
@@ -453,8 +453,8 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	}
 
 	public function test_get_items_for_post() {
-		$second_post_id = $this->factory->post->create();
-		$this->factory->comment->create_post_comments( $second_post_id, 2 );
+		$second_post_id = self::factory()->post->create();
+		self::factory()->comment->create_post_comments( $second_post_id, 2 );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
 		$request->set_query_params(
@@ -478,8 +478,8 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			'comment_post_ID'  => self::$post_id,
 		);
 
-		$id1 = $this->factory->comment->create( $args );
-		$id2 = $this->factory->comment->create( $args );
+		$id1 = self::factory()->comment->create( $args );
+		$id2 = self::factory()->comment->create( $args );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
 
@@ -518,8 +518,8 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			'comment_post_ID'  => self::$post_id,
 		);
 
-		$id1 = $this->factory->comment->create( $args );
-		$id2 = $this->factory->comment->create( $args );
+		$id1 = self::factory()->comment->create( $args );
+		$id2 = self::factory()->comment->create( $args );
 
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/comments' );
 		$response = rest_get_server()->dispatch( $request );
@@ -574,7 +574,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			'comment_post_ID'  => self::$post_id,
 		);
 
-		$id = $this->factory->comment->create( $args );
+		$id = self::factory()->comment->create( $args );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
 
@@ -598,7 +598,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	public function test_get_items_private_post_no_permissions() {
 		wp_set_current_user( 0 );
 
-		$post_id = $this->factory->post->create( array( 'post_status' => 'private' ) );
+		$post_id = self::factory()->post->create( array( 'post_status' => 'private' ) );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
 		$request->set_param( 'post', $post_id );
@@ -616,11 +616,11 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			'user_id'          => self::$author_id,
 		);
 
-		$this->factory->comment->create( $args );
+		self::factory()->comment->create( $args );
 		$args['user_id'] = self::$subscriber_id;
-		$this->factory->comment->create( $args );
+		self::factory()->comment->create( $args );
 		unset( $args['user_id'] );
-		$this->factory->comment->create( $args );
+		self::factory()->comment->create( $args );
 
 		// Limit to comment author.
 		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
@@ -659,11 +659,11 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			'user_id'          => self::$author_id,
 		);
 
-		$this->factory->comment->create( $args );
+		self::factory()->comment->create( $args );
 		$args['user_id'] = self::$subscriber_id;
-		$this->factory->comment->create( $args );
+		self::factory()->comment->create( $args );
 		unset( $args['user_id'] );
-		$this->factory->comment->create( $args );
+		self::factory()->comment->create( $args );
 
 		$total_comments = self::$total_comments + 3;
 
@@ -709,12 +709,12 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			'comment_approved' => 1,
 			'comment_post_ID'  => self::$post_id,
 		);
-		$parent_id              = $this->factory->comment->create( $args );
-		$parent_id2             = $this->factory->comment->create( $args );
+		$parent_id              = self::factory()->comment->create( $args );
+		$parent_id2             = self::factory()->comment->create( $args );
 		$args['comment_parent'] = $parent_id;
-		$this->factory->comment->create( $args );
+		self::factory()->comment->create( $args );
 		$args['comment_parent'] = $parent_id2;
-		$this->factory->comment->create( $args );
+		self::factory()->comment->create( $args );
 
 		$total_comments = self::$total_comments + 4;
 
@@ -745,12 +745,12 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			'comment_approved' => 1,
 			'comment_post_ID'  => self::$post_id,
 		);
-		$parent_id              = $this->factory->comment->create( $args );
-		$parent_id2             = $this->factory->comment->create( $args );
+		$parent_id              = self::factory()->comment->create( $args );
+		$parent_id2             = self::factory()->comment->create( $args );
 		$args['comment_parent'] = $parent_id;
-		$this->factory->comment->create( $args );
+		self::factory()->comment->create( $args );
 		$args['comment_parent'] = $parent_id2;
-		$this->factory->comment->create( $args );
+		self::factory()->comment->create( $args );
 
 		$total_comments = self::$total_comments + 4;
 
@@ -786,7 +786,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			'comment_author'   => 'Homer J Simpson',
 		);
 
-		$id = $this->factory->comment->create( $args );
+		$id = self::factory()->comment->create( $args );
 
 		$total_comments = self::$total_comments + 1;
 
@@ -825,7 +825,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$this->assertStringContainsString( '<' . $next_link . '>; rel="next"', $headers['Link'] );
 
 		// 3rd page.
-		$this->factory->comment->create(
+		self::factory()->comment->create(
 			array(
 				'comment_post_ID' => self::$post_id,
 			)
@@ -895,19 +895,19 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	}
 
 	public function test_get_comments_valid_date() {
-		$comment1 = $this->factory->comment->create(
+		$comment1 = self::factory()->comment->create(
 			array(
 				'comment_date'    => '2016-01-15T00:00:00Z',
 				'comment_post_ID' => self::$post_id,
 			)
 		);
-		$comment2 = $this->factory->comment->create(
+		$comment2 = self::factory()->comment->create(
 			array(
 				'comment_date'    => '2016-01-16T00:00:00Z',
 				'comment_post_ID' => self::$post_id,
 			)
 		);
-		$comment3 = $this->factory->comment->create(
+		$comment3 = self::factory()->comment->create(
 			array(
 				'comment_date'    => '2016-01-17T00:00:00Z',
 				'comment_post_ID' => self::$post_id,
@@ -1003,7 +1003,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	public function test_get_comment_invalid_post_id() {
 		wp_set_current_user( 0 );
 
-		$comment_id = $this->factory->comment->create(
+		$comment_id = self::factory()->comment->create(
 			array(
 				'comment_approved' => 1,
 				'comment_post_ID'  => REST_TESTS_IMPOSSIBLY_HIGH_NUMBER,
@@ -1018,7 +1018,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	public function test_get_comment_invalid_post_id_as_admin() {
 		wp_set_current_user( self::$admin_id );
 
-		$comment_id = $this->factory->comment->create(
+		$comment_id = self::factory()->comment->create(
 			array(
 				'comment_approved' => 1,
 				'comment_post_ID'  => REST_TESTS_IMPOSSIBLY_HIGH_NUMBER,
@@ -1047,7 +1047,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	}
 
 	public function test_get_comment_with_children_link() {
-		$comment_id_1 = $this->factory->comment->create(
+		$comment_id_1 = self::factory()->comment->create(
 			array(
 				'comment_approved' => 1,
 				'comment_post_ID'  => self::$post_id,
@@ -1055,7 +1055,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			)
 		);
 
-		$child_comment = $this->factory->comment->create(
+		$child_comment = self::factory()->comment->create(
 			array(
 				'comment_approved' => 1,
 				'comment_parent'   => $comment_id_1,
@@ -1071,7 +1071,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	}
 
 	public function test_get_comment_without_children_link() {
-		$comment_id_1 = $this->factory->comment->create(
+		$comment_id_1 = self::factory()->comment->create(
 			array(
 				'comment_approved' => 1,
 				'comment_post_ID'  => self::$post_id,
@@ -1093,7 +1093,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			'comment_post_ID'  => self::$password_id,
 		);
 
-		$password_comment = $this->factory->comment->create( $args );
+		$password_comment = self::factory()->comment->create( $args );
 
 		$request  = new WP_REST_Request( 'GET', sprintf( '/wp/v2/comments/%s', $password_comment ) );
 		$response = rest_get_server()->dispatch( $request );
@@ -1111,7 +1111,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			'comment_post_ID'  => self::$password_id,
 		);
 
-		$password_comment = $this->factory->comment->create( $args );
+		$password_comment = self::factory()->comment->create( $args );
 
 		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/comments/%s', $password_comment ) );
 		$request->set_param( 'password', 'toomanysecrets' );
@@ -1490,7 +1490,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 
 
 	public function test_create_item_assign_different_user() {
-		$subscriber_id = $this->factory->user->create(
+		$subscriber_id = self::factory()->user->create(
 			array(
 				'role'       => 'subscriber',
 				'user_email' => 'cbg@androidsdungeon.com',
@@ -1521,7 +1521,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	}
 
 	public function test_create_comment_without_type() {
-		$post_id = $this->factory->post->create();
+		$post_id = self::factory()->post->create();
 
 		wp_set_current_user( self::$admin_id );
 
@@ -1559,7 +1559,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	 * @ticket 38820
 	 */
 	public function test_create_comment_with_invalid_type() {
-		$post_id = $this->factory->post->create();
+		$post_id = self::factory()->post->create();
 
 		wp_set_current_user( self::$admin_id );
 
@@ -1583,7 +1583,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	}
 
 	public function test_create_comment_invalid_email() {
-		$post_id = $this->factory->post->create();
+		$post_id = self::factory()->post->create();
 
 		wp_set_current_user( self::$admin_id );
 
@@ -1606,7 +1606,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	}
 
 	public function test_create_item_current_user() {
-		$user_id = $this->factory->user->create(
+		$user_id = self::factory()->user->create(
 			array(
 				'role'         => 'subscriber',
 				'user_email'   => 'lylelanley@example.com',
@@ -1728,7 +1728,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	}
 
 	public function test_create_comment_with_status_IP_and_user_agent() {
-		$post_id = $this->factory->post->create();
+		$post_id = self::factory()->post->create();
 
 		wp_set_current_user( self::$admin_id );
 
@@ -2006,7 +2006,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	public function test_create_item_duplicate() {
 		wp_set_current_user( self::$subscriber_id );
 
-		$this->factory->comment->create(
+		self::factory()->comment->create(
 			array(
 				'comment_post_ID'      => self::$post_id,
 				'comment_author'       => 'Guy N. Cognito',
@@ -2031,7 +2031,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	}
 
 	public function test_create_comment_closed() {
-		$post_id = $this->factory->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'comment_status' => 'closed',
 			)
@@ -2303,7 +2303,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	}
 
 	public function test_update_item() {
-		$post_id = $this->factory->post->create();
+		$post_id = self::factory()->post->create();
 
 		wp_set_current_user( self::$admin_id );
 
@@ -2347,7 +2347,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 
 		update_option( 'timezone_string', $params['timezone_string'] );
 
-		$comment_id = $this->factory->comment->create();
+		$comment_id = self::factory()->comment->create();
 
 		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/comments/%d', $comment_id ) );
 		if ( isset( $params['date'] ) ) {
@@ -2374,7 +2374,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	}
 
 	public function test_update_item_no_content() {
-		$post_id = $this->factory->post->create();
+		$post_id = self::factory()->post->create();
 
 		wp_set_current_user( self::$admin_id );
 
@@ -2412,7 +2412,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	public function test_update_comment_status() {
 		wp_set_current_user( self::$admin_id );
 
-		$comment_id = $this->factory->comment->create(
+		$comment_id = self::factory()->comment->create(
 			array(
 				'comment_approved' => 0,
 				'comment_post_ID'  => self::$post_id,
@@ -2439,7 +2439,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	public function test_update_comment_field_does_not_use_default_values() {
 		wp_set_current_user( self::$admin_id );
 
-		$comment_id = $this->factory->comment->create(
+		$comment_id = self::factory()->comment->create(
 			array(
 				'comment_approved' => 0,
 				'comment_post_ID'  => self::$post_id,
@@ -2720,7 +2720,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	}
 
 	public function test_update_comment_private_post_invalid_permission() {
-		$private_comment_id = $this->factory->comment->create(
+		$private_comment_id = self::factory()->comment->create(
 			array(
 				'comment_approved' => 1,
 				'comment_post_ID'  => self::$private_id,
@@ -2745,7 +2745,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	public function test_update_comment_with_children_link() {
 		wp_set_current_user( self::$admin_id );
 
-		$comment_id_1 = $this->factory->comment->create(
+		$comment_id_1 = self::factory()->comment->create(
 			array(
 				'comment_approved' => 1,
 				'comment_post_ID'  => self::$post_id,
@@ -2753,7 +2753,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			)
 		);
 
-		$child_comment = $this->factory->comment->create(
+		$child_comment = self::factory()->comment->create(
 			array(
 				'comment_approved' => 1,
 				'comment_post_ID'  => self::$post_id,
@@ -3047,7 +3047,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	public function test_delete_item() {
 		wp_set_current_user( self::$admin_id );
 
-		$comment_id = $this->factory->comment->create(
+		$comment_id = self::factory()->comment->create(
 			array(
 				'comment_approved' => 1,
 				'comment_post_ID'  => self::$post_id,
@@ -3067,7 +3067,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	public function test_delete_item_skip_trash() {
 		wp_set_current_user( self::$admin_id );
 
-		$comment_id = $this->factory->comment->create(
+		$comment_id = self::factory()->comment->create(
 			array(
 				'comment_approved' => 1,
 				'comment_post_ID'  => self::$post_id,
@@ -3088,7 +3088,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	public function test_delete_item_already_trashed() {
 		wp_set_current_user( self::$admin_id );
 
-		$comment_id = $this->factory->comment->create(
+		$comment_id = self::factory()->comment->create(
 			array(
 				'comment_approved' => 1,
 				'comment_post_ID'  => self::$post_id,
@@ -3123,7 +3123,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	public function test_delete_child_comment_link() {
 		wp_set_current_user( self::$admin_id );
 
-		$comment_id_1 = $this->factory->comment->create(
+		$comment_id_1 = self::factory()->comment->create(
 			array(
 				'comment_approved' => 1,
 				'comment_post_ID'  => self::$post_id,
@@ -3131,7 +3131,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			)
 		);
 
-		$child_comment = $this->factory->comment->create(
+		$child_comment = self::factory()->comment->create(
 			array(
 				'comment_approved' => 1,
 				'comment_parent'   => $comment_id_1,

--- a/tests/phpunit/tests/rest-api/rest-pages-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-pages-controller.php
@@ -51,7 +51,7 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertSame( 'view', $data['endpoints'][0]['args']['context']['default'] );
 		$this->assertSame( array( 'view', 'embed', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
 		// Single.
-		$page_id  = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$page_id  = self::factory()->post->create( array( 'post_type' => 'page' ) );
 		$request  = new WP_REST_Request( 'OPTIONS', '/wp/v2/pages/' . $page_id );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
@@ -94,13 +94,13 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_get_items() {
-		$id1      = $this->factory->post->create(
+		$id1      = self::factory()->post->create(
 			array(
 				'post_status' => 'publish',
 				'post_type'   => 'page',
 			)
 		);
-		$id2      = $this->factory->post->create(
+		$id2      = self::factory()->post->create(
 			array(
 				'post_status' => 'draft',
 				'post_type'   => 'page',
@@ -114,13 +114,13 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_get_items_parent_query() {
-		$id1 = $this->factory->post->create(
+		$id1 = self::factory()->post->create(
 			array(
 				'post_status' => 'publish',
 				'post_type'   => 'page',
 			)
 		);
-		$id2 = $this->factory->post->create(
+		$id2 = self::factory()->post->create(
 			array(
 				'post_status' => 'publish',
 				'post_type'   => 'page',
@@ -148,26 +148,26 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_get_items_parents_query() {
-		$id1 = $this->factory->post->create(
+		$id1 = self::factory()->post->create(
 			array(
 				'post_status' => 'publish',
 				'post_type'   => 'page',
 			)
 		);
-		$id2 = $this->factory->post->create(
+		$id2 = self::factory()->post->create(
 			array(
 				'post_status' => 'publish',
 				'post_type'   => 'page',
 				'post_parent' => $id1,
 			)
 		);
-		$id3 = $this->factory->post->create(
+		$id3 = self::factory()->post->create(
 			array(
 				'post_status' => 'publish',
 				'post_type'   => 'page',
 			)
 		);
-		$id4 = $this->factory->post->create(
+		$id4 = self::factory()->post->create(
 			array(
 				'post_status' => 'publish',
 				'post_type'   => 'page',
@@ -190,13 +190,13 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_get_items_parent_exclude_query() {
-		$id1 = $this->factory->post->create(
+		$id1 = self::factory()->post->create(
 			array(
 				'post_status' => 'publish',
 				'post_type'   => 'page',
 			)
 		);
-		$this->factory->post->create(
+		self::factory()->post->create(
 			array(
 				'post_status' => 'publish',
 				'post_type'   => 'page',
@@ -224,27 +224,27 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_get_items_menu_order_query() {
-		$id1 = $this->factory->post->create(
+		$id1 = self::factory()->post->create(
 			array(
 				'post_status' => 'publish',
 				'post_type'   => 'page',
 			)
 		);
-		$id2 = $this->factory->post->create(
+		$id2 = self::factory()->post->create(
 			array(
 				'post_status' => 'publish',
 				'post_type'   => 'page',
 				'menu_order'  => 2,
 			)
 		);
-		$id3 = $this->factory->post->create(
+		$id3 = self::factory()->post->create(
 			array(
 				'post_status' => 'publish',
 				'post_type'   => 'page',
 				'menu_order'  => 3,
 			)
 		);
-		$id4 = $this->factory->post->create(
+		$id4 = self::factory()->post->create(
 			array(
 				'post_status' => 'publish',
 				'post_type'   => 'page',
@@ -302,13 +302,13 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_get_items_private_filter_query_var() {
 		// Private query vars inaccessible to unauthorized users.
 		wp_set_current_user( 0 );
-		$page_id  = $this->factory->post->create(
+		$page_id  = self::factory()->post->create(
 			array(
 				'post_status' => 'publish',
 				'post_type'   => 'page',
 			)
 		);
-		$draft_id = $this->factory->post->create(
+		$draft_id = self::factory()->post->create(
 			array(
 				'post_status' => 'draft',
 				'post_type'   => 'page',
@@ -336,19 +336,19 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_get_items_valid_date() {
-		$post1   = $this->factory->post->create(
+		$post1   = self::factory()->post->create(
 			array(
 				'post_date' => '2016-01-15T00:00:00Z',
 				'post_type' => 'page',
 			)
 		);
-		$post2   = $this->factory->post->create(
+		$post2   = self::factory()->post->create(
 			array(
 				'post_date' => '2016-01-16T00:00:00Z',
 				'post_type' => 'page',
 			)
 		);
-		$post3   = $this->factory->post->create(
+		$post3   = self::factory()->post->create(
 			array(
 				'post_date' => '2016-01-17T00:00:00Z',
 				'post_type' => 'page',
@@ -378,19 +378,19 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	 * @ticket 50617
 	 */
 	public function test_get_items_valid_modified_date() {
-		$post1 = $this->factory->post->create(
+		$post1 = self::factory()->post->create(
 			array(
 				'post_date' => '2016-01-01 00:00:00',
 				'post_type' => 'page',
 			)
 		);
-		$post2 = $this->factory->post->create(
+		$post2 = self::factory()->post->create(
 			array(
 				'post_date' => '2016-01-02 00:00:00',
 				'post_type' => 'page',
 			)
 		);
-		$post3 = $this->factory->post->create(
+		$post3 = self::factory()->post->create(
 			array(
 				'post_date' => '2016-01-03 00:00:00',
 				'post_type' => 'page',
@@ -416,7 +416,7 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_get_item_invalid_post_type() {
-		$post_id  = $this->factory->post->create();
+		$post_id  = self::factory()->post->create();
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/pages/' . $post_id );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertSame( 404, $response->get_status() );
@@ -448,7 +448,7 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_create_page_with_parent() {
-		$page_id = $this->factory->post->create(
+		$page_id = self::factory()->post->create(
 			array(
 				'type' => 'page',
 			)
@@ -498,7 +498,7 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_delete_item() {
-		$page_id = $this->factory->post->create(
+		$page_id = self::factory()->post->create(
 			array(
 				'post_type'  => 'page',
 				'post_title' => 'Deleted page',
@@ -525,7 +525,7 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 
 	public function test_prepare_item_limit_fields() {
 		wp_set_current_user( self::$editor_id );
-		$page_id  = $this->factory->post->create(
+		$page_id  = self::factory()->post->create(
 			array(
 				'post_status' => 'publish',
 				'post_type'   => 'page',
@@ -547,7 +547,7 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_get_pages_params() {
-		$this->factory->post->create_many(
+		self::factory()->post->create_many(
 			8,
 			array(
 				'post_type' => 'page',
@@ -578,7 +578,7 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 
 	public function test_update_page_menu_order() {
 
-		$page_id = $this->factory->post->create(
+		$page_id = self::factory()->post->create(
 			array(
 				'post_type' => 'page',
 			)
@@ -601,7 +601,7 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 
 	public function test_update_page_menu_order_to_zero() {
 
-		$page_id = $this->factory->post->create(
+		$page_id = self::factory()->post->create(
 			array(
 				'post_type'  => 'page',
 				'menu_order' => 1,
@@ -624,12 +624,12 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_update_page_parent_non_zero() {
-		$page_id1 = $this->factory->post->create(
+		$page_id1 = self::factory()->post->create(
 			array(
 				'post_type' => 'page',
 			)
 		);
-		$page_id2 = $this->factory->post->create(
+		$page_id2 = self::factory()->post->create(
 			array(
 				'post_type' => 'page',
 			)
@@ -647,12 +647,12 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_update_page_parent_zero() {
-		$page_id1 = $this->factory->post->create(
+		$page_id1 = self::factory()->post->create(
 			array(
 				'post_type' => 'page',
 			)
 		);
-		$page_id2 = $this->factory->post->create(
+		$page_id2 = self::factory()->post->create(
 			array(
 				'post_type'   => 'page',
 				'post_parent' => $page_id1,
@@ -671,7 +671,7 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_get_page_with_password() {
-		$page_id = $this->factory->post->create(
+		$page_id = self::factory()->post->create(
 			array(
 				'post_type'     => 'page',
 				'post_password' => '$inthebananastand',
@@ -689,7 +689,7 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_get_page_with_password_using_password() {
-		$page_id = $this->factory->post->create(
+		$page_id = self::factory()->post->create(
 			array(
 				'post_type'     => 'page',
 				'post_password' => '$inthebananastand',
@@ -711,7 +711,7 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_get_page_with_password_using_incorrect_password() {
-		$page_id = $this->factory->post->create(
+		$page_id = self::factory()->post->create(
 			array(
 				'post_type'     => 'page',
 				'post_password' => '$inthebananastand',
@@ -727,7 +727,7 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_get_page_with_password_without_permission() {
-		$page_id  = $this->factory->post->create(
+		$page_id  = self::factory()->post->create(
 			array(
 				'post_type'     => 'page',
 				'post_password' => '$inthebananastand',

--- a/tests/phpunit/tests/rest-api/rest-post-meta-fields.php
+++ b/tests/phpunit/tests/rest-api/rest-post-meta-fields.php
@@ -253,7 +253,7 @@ class WP_Test_REST_Post_Meta_Fields extends WP_Test_REST_TestCase {
 
 	protected function grant_write_permission() {
 		// Ensure we have write permission.
-		$user = $this->factory->user->create(
+		$user = self::factory()->user->create(
 			array(
 				'role' => 'editor',
 			)

--- a/tests/phpunit/tests/rest-api/rest-post-statuses-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-post-statuses-controller.php
@@ -43,7 +43,7 @@ class WP_Test_REST_Post_Statuses_Controller extends WP_Test_REST_Controller_Test
 	}
 
 	public function test_get_items_logged_in() {
-		$user_id = $this->factory->user->create( array( 'role' => 'author' ) );
+		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
 		wp_set_current_user( $user_id );
 
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/statuses' );
@@ -72,7 +72,7 @@ class WP_Test_REST_Post_Statuses_Controller extends WP_Test_REST_Controller_Test
 	}
 
 	public function test_get_item() {
-		$user_id = $this->factory->user->create( array( 'role' => 'author' ) );
+		$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
 		wp_set_current_user( $user_id );
 		$request = new WP_REST_Request( 'GET', '/wp/v2/statuses/publish' );
 		$request->set_param( 'context', 'edit' );
@@ -94,7 +94,7 @@ class WP_Test_REST_Post_Statuses_Controller extends WP_Test_REST_Controller_Test
 	}
 
 	public function test_get_item_invalid_internal() {
-		$user_id = $this->factory->user->create();
+		$user_id = self::factory()->user->create();
 		wp_set_current_user( $user_id );
 
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/statuses/inherit' );

--- a/tests/phpunit/tests/rest-api/rest-post-types-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-post-types-controller.php
@@ -94,7 +94,7 @@ class WP_Test_REST_Post_Types_Controller extends WP_Test_REST_Controller_Testcas
 	}
 
 	public function test_get_item_edit_context() {
-		$editor_id = $this->factory->user->create( array( 'role' => 'editor' ) );
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
 		wp_set_current_user( $editor_id );
 		$request = new WP_REST_Request( 'GET', '/wp/v2/types/post' );
 		$request->set_param( 'context', 'edit' );

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -273,8 +273,8 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_get_items_author_query() {
-		$this->factory->post->create( array( 'post_author' => self::$editor_id ) );
-		$this->factory->post->create( array( 'post_author' => self::$author_id ) );
+		self::factory()->post->create( array( 'post_author' => self::$editor_id ) );
+		self::factory()->post->create( array( 'post_author' => self::$author_id ) );
 
 		$total_posts = self::$total_posts + 2;
 
@@ -305,8 +305,8 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_get_items_author_exclude_query() {
-		$this->factory->post->create( array( 'post_author' => self::$editor_id ) );
-		$this->factory->post->create( array( 'post_author' => self::$author_id ) );
+		self::factory()->post->create( array( 'post_author' => self::$editor_id ) );
+		self::factory()->post->create( array( 'post_author' => self::$author_id ) );
 
 		$total_posts = self::$total_posts + 2;
 
@@ -347,13 +347,13 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_get_items_include_query() {
-		$id1 = $this->factory->post->create(
+		$id1 = self::factory()->post->create(
 			array(
 				'post_status' => 'publish',
 				'post_date'   => '2001-02-03 04:05:06',
 			)
 		);
-		$id2 = $this->factory->post->create(
+		$id2 = self::factory()->post->create(
 			array(
 				'post_status' => 'publish',
 				'post_date'   => '2001-02-03 04:05:07',
@@ -386,19 +386,19 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_get_items_orderby_author_query() {
-		$id2 = $this->factory->post->create(
+		$id2 = self::factory()->post->create(
 			array(
 				'post_status' => 'publish',
 				'post_author' => self::$editor_id,
 			)
 		);
-		$id3 = $this->factory->post->create(
+		$id3 = self::factory()->post->create(
 			array(
 				'post_status' => 'publish',
 				'post_author' => self::$editor_id,
 			)
 		);
-		$id1 = $this->factory->post->create(
+		$id1 = self::factory()->post->create(
 			array(
 				'post_status' => 'publish',
 				'post_author' => self::$author_id,
@@ -421,9 +421,9 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_get_items_orderby_modified_query() {
-		$id1 = $this->factory->post->create( array( 'post_status' => 'publish' ) );
-		$id2 = $this->factory->post->create( array( 'post_status' => 'publish' ) );
-		$id3 = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$id1 = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$id2 = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$id3 = self::factory()->post->create( array( 'post_status' => 'publish' ) );
 
 		$this->update_post_modified( $id1, '2016-04-20 4:26:20' );
 		$this->update_post_modified( $id2, '2016-02-01 20:24:02' );
@@ -445,19 +445,19 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_get_items_orderby_parent_query() {
-		$id1 = $this->factory->post->create(
+		$id1 = self::factory()->post->create(
 			array(
 				'post_status' => 'publish',
 				'post_type'   => 'page',
 			)
 		);
-		$id2 = $this->factory->post->create(
+		$id2 = self::factory()->post->create(
 			array(
 				'post_status' => 'publish',
 				'post_type'   => 'page',
 			)
 		);
-		$id3 = $this->factory->post->create(
+		$id3 = self::factory()->post->create(
 			array(
 				'post_status' => 'publish',
 				'post_type'   => 'page',
@@ -483,8 +483,8 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_get_items_exclude_query() {
-		$id1 = $this->factory->post->create( array( 'post_status' => 'publish' ) );
-		$id2 = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$id1 = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$id2 = self::factory()->post->create( array( 'post_status' => 'publish' ) );
 
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/posts' );
 		$response = rest_get_server()->dispatch( $request );
@@ -513,7 +513,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_get_items_search_query() {
-		$this->factory->post->create(
+		self::factory()->post->create(
 			array(
 				'post_title'  => 'Search Result',
 				'post_status' => 'publish',
@@ -535,13 +535,13 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_get_items_slug_query() {
-		$this->factory->post->create(
+		self::factory()->post->create(
 			array(
 				'post_title'  => 'Apple',
 				'post_status' => 'publish',
 			)
 		);
-		$this->factory->post->create(
+		self::factory()->post->create(
 			array(
 				'post_title'  => 'Banana',
 				'post_status' => 'publish',
@@ -558,19 +558,19 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_get_items_multiple_slugs_array_query() {
-		$this->factory->post->create(
+		self::factory()->post->create(
 			array(
 				'post_title'  => 'Apple',
 				'post_status' => 'publish',
 			)
 		);
-		$this->factory->post->create(
+		self::factory()->post->create(
 			array(
 				'post_title'  => 'Banana',
 				'post_status' => 'publish',
 			)
 		);
-		$this->factory->post->create(
+		self::factory()->post->create(
 			array(
 				'post_title'  => 'Peach',
 				'post_status' => 'publish',
@@ -592,19 +592,19 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_get_items_multiple_slugs_string_query() {
-		$this->factory->post->create(
+		self::factory()->post->create(
 			array(
 				'post_title'  => 'Apple',
 				'post_status' => 'publish',
 			)
 		);
-		$this->factory->post->create(
+		self::factory()->post->create(
 			array(
 				'post_title'  => 'Banana',
 				'post_status' => 'publish',
 			)
 		);
-		$this->factory->post->create(
+		self::factory()->post->create(
 			array(
 				'post_title'  => 'Peach',
 				'post_status' => 'publish',
@@ -628,7 +628,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_get_items_status_query() {
 		wp_set_current_user( 0 );
 
-		$this->factory->post->create( array( 'post_status' => 'draft' ) );
+		self::factory()->post->create( array( 'post_status' => 'draft' ) );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
 		$request->set_param( 'per_page', self::$per_page );
@@ -654,9 +654,9 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_get_items_multiple_statuses_string_query() {
 		wp_set_current_user( self::$editor_id );
 
-		$this->factory->post->create( array( 'post_status' => 'draft' ) );
-		$this->factory->post->create( array( 'post_status' => 'private' ) );
-		$this->factory->post->create( array( 'post_status' => 'publish' ) );
+		self::factory()->post->create( array( 'post_status' => 'draft' ) );
+		self::factory()->post->create( array( 'post_status' => 'private' ) );
+		self::factory()->post->create( array( 'post_status' => 'publish' ) );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
 		$request->set_param( 'context', 'edit' );
@@ -677,9 +677,9 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_get_items_multiple_statuses_array_query() {
 		wp_set_current_user( self::$editor_id );
 
-		$this->factory->post->create( array( 'post_status' => 'draft' ) );
-		$this->factory->post->create( array( 'post_status' => 'pending' ) );
-		$this->factory->post->create( array( 'post_status' => 'publish' ) );
+		self::factory()->post->create( array( 'post_status' => 'draft' ) );
+		self::factory()->post->create( array( 'post_status' => 'pending' ) );
+		self::factory()->post->create( array( 'post_status' => 'publish' ) );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
 		$request->set_param( 'context', 'edit' );
@@ -709,7 +709,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	 * @ticket 43701
 	 */
 	public function test_get_items_multiple_statuses_custom_role_one_invalid_query() {
-		$private_post_id = $this->factory->post->create( array( 'post_status' => 'private' ) );
+		$private_post_id = self::factory()->post->create( array( 'post_status' => 'private' ) );
 
 		wp_set_current_user( self::$private_reader_id );
 
@@ -730,7 +730,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_get_items_status_without_permissions() {
-		$draft_id = $this->factory->post->create(
+		$draft_id = self::factory()->post->create(
 			array(
 				'post_status' => 'draft',
 			)
@@ -750,25 +750,25 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_get_items_order_and_orderby() {
-		$this->factory->post->create(
+		self::factory()->post->create(
 			array(
 				'post_title'  => 'Apple Pie',
 				'post_status' => 'publish',
 			)
 		);
-		$this->factory->post->create(
+		self::factory()->post->create(
 			array(
 				'post_title'  => 'Apple Sauce',
 				'post_status' => 'publish',
 			)
 		);
-		$this->factory->post->create(
+		self::factory()->post->create(
 			array(
 				'post_title'  => 'Apple Cobbler',
 				'post_status' => 'publish',
 			)
 		);
-		$this->factory->post->create(
+		self::factory()->post->create(
 			array(
 				'post_title'  => 'Apple Coffee Cake',
 				'post_status' => 'publish',
@@ -805,7 +805,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_get_items_with_orderby_include_without_include_param() {
-		$this->factory->post->create( array( 'post_status' => 'publish' ) );
+		self::factory()->post->create( array( 'post_status' => 'publish' ) );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
 		$request->set_param( 'orderby', 'include' );
@@ -816,19 +816,19 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_get_items_with_orderby_id() {
-		$id1 = $this->factory->post->create(
+		$id1 = self::factory()->post->create(
 			array(
 				'post_status' => 'publish',
 				'post_date'   => '2016-01-13 02:26:48',
 			)
 		);
-		$id2 = $this->factory->post->create(
+		$id2 = self::factory()->post->create(
 			array(
 				'post_status' => 'publish',
 				'post_date'   => '2016-01-12 02:26:48',
 			)
 		);
-		$id3 = $this->factory->post->create(
+		$id3 = self::factory()->post->create(
 			array(
 				'post_status' => 'publish',
 				'post_date'   => '2016-01-11 02:26:48',
@@ -850,14 +850,14 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_get_items_with_orderby_slug() {
-		$id1 = $this->factory->post->create(
+		$id1 = self::factory()->post->create(
 			array(
 				'post_title'  => 'ABC',
 				'post_name'   => 'xyz',
 				'post_status' => 'publish',
 			)
 		);
-		$id2 = $this->factory->post->create(
+		$id2 = self::factory()->post->create(
 			array(
 				'post_title'  => 'XYZ',
 				'post_name'   => 'abc',
@@ -881,7 +881,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_get_items_with_orderby_slugs() {
 		$slugs = array( 'burrito', 'taco', 'chalupa' );
 		foreach ( $slugs as $slug ) {
-			$this->factory->post->create(
+			self::factory()->post->create(
 				array(
 					'post_title'  => $slug,
 					'post_name'   => $slug,
@@ -903,14 +903,14 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_get_items_with_orderby_relevance() {
-		$id1 = $this->factory->post->create(
+		$id1 = self::factory()->post->create(
 			array(
 				'post_title'   => 'Title is more relevant',
 				'post_content' => 'Content is',
 				'post_status'  => 'publish',
 			)
 		);
-		$id2 = $this->factory->post->create(
+		$id2 = self::factory()->post->create(
 			array(
 				'post_title'   => 'Title is',
 				'post_content' => 'Content is less relevant',
@@ -931,14 +931,14 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_get_items_with_orderby_relevance_two_terms() {
-		$id1 = $this->factory->post->create(
+		$id1 = self::factory()->post->create(
 			array(
 				'post_title'   => 'Title is more relevant',
 				'post_content' => 'Content is',
 				'post_status'  => 'publish',
 			)
 		);
-		$id2 = $this->factory->post->create(
+		$id2 = self::factory()->post->create(
 			array(
 				'post_title'   => 'Title is',
 				'post_content' => 'Content is less relevant',
@@ -1005,9 +1005,9 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 
 	public function test_get_items_tags_exclude_query() {
 		$id1 = self::$post_id;
-		$id2 = $this->factory->post->create( array( 'post_status' => 'publish' ) );
-		$id3 = $this->factory->post->create( array( 'post_status' => 'publish' ) );
-		$id4 = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$id2 = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$id3 = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$id4 = self::factory()->post->create( array( 'post_status' => 'publish' ) );
 		$tag = wp_insert_term( 'My Tag', 'post_tag' );
 
 		$total_posts = self::$total_posts + 3;
@@ -1028,7 +1028,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 
 	public function test_get_items_tags_and_categories_query() {
 		$id1      = self::$post_id;
-		$id2      = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$id2      = self::factory()->post->create( array( 'post_status' => 'publish' ) );
 		$tag      = wp_insert_term( 'My Tag', 'post_tag' );
 		$category = wp_insert_term( 'My Category', 'category' );
 
@@ -1053,7 +1053,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	 */
 	public function test_get_items_tags_or_categories_query() {
 		$id1      = self::$post_id;
-		$id2      = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$id2      = self::factory()->post->create( array( 'post_status' => 'publish' ) );
 		$tag      = wp_insert_term( 'My Tag', 'post_tag' );
 		$category = wp_insert_term( 'My Category', 'category' );
 
@@ -1075,7 +1075,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 
 	public function test_get_items_tags_and_categories_exclude_query() {
 		$id1      = self::$post_id;
-		$id2      = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$id2      = self::factory()->post->create( array( 'post_status' => 'publish' ) );
 		$tag      = wp_insert_term( 'My Tag', 'post_tag' );
 		$category = wp_insert_term( 'My Category', 'category' );
 
@@ -1102,9 +1102,9 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	 */
 	public function test_get_items_tags_or_categories_exclude_query() {
 		$id1      = end( self::$post_ids );
-		$id2      = $this->factory->post->create( array( 'post_status' => 'publish' ) );
-		$id3      = $this->factory->post->create( array( 'post_status' => 'publish' ) );
-		$id4      = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$id2      = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$id3      = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$id4      = self::factory()->post->create( array( 'post_status' => 'publish' ) );
 		$tag      = wp_insert_term( 'My Tag', 'post_tag' );
 		$category = wp_insert_term( 'My Category', 'category' );
 
@@ -1366,7 +1366,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 
 	public function test_get_items_sticky() {
 		$id1 = self::$post_id;
-		$id2 = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$id2 = self::factory()->post->create( array( 'post_status' => 'publish' ) );
 
 		update_option( 'sticky_posts', array( $id2 ) );
 
@@ -1387,7 +1387,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 
 	public function test_get_items_sticky_with_include() {
 		$id1 = self::$post_id;
-		$id2 = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$id2 = self::factory()->post->create( array( 'post_status' => 'publish' ) );
 
 		update_option( 'sticky_posts', array( $id2 ) );
 
@@ -1455,7 +1455,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 
 	public function test_get_items_not_sticky() {
 		$id1 = end( self::$post_ids );
-		$id2 = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$id2 = self::factory()->post->create( array( 'post_status' => 'publish' ) );
 
 		$total_posts = self::$total_posts + 1;
 
@@ -1477,8 +1477,8 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 
 	public function test_get_items_not_sticky_with_exclude() {
 		$id1 = end( self::$post_ids );
-		$id2 = $this->factory->post->create( array( 'post_status' => 'publish' ) );
-		$id3 = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$id2 = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$id3 = self::factory()->post->create( array( 'post_status' => 'publish' ) );
 
 		$total_posts = self::$total_posts + 2;
 
@@ -1503,8 +1503,8 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 
 	public function test_get_items_not_sticky_with_exclude_no_sticky_posts() {
 		$id1 = self::$post_id;
-		$id2 = $this->factory->post->create( array( 'post_status' => 'publish' ) );
-		$id3 = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$id2 = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$id3 = self::factory()->post->create( array( 'post_status' => 'publish' ) );
 
 		$total_posts = self::$total_posts + 2;
 
@@ -1574,7 +1574,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$parent_id2       = self::$post_ids[1];
 		$parent_ids       = array( $parent_id1, $parent_id2 );
 		$attachment_ids   = array();
-		$attachment_ids[] = $this->factory->attachment->create_object(
+		$attachment_ids[] = self::factory()->attachment->create_object(
 			DIR_TESTDATA . '/images/canola.jpg',
 			$parent_id1,
 			array(
@@ -1583,7 +1583,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 			)
 		);
 
-		$attachment_ids[] = $this->factory->attachment->create_object(
+		$attachment_ids[] = self::factory()->attachment->create_object(
 			DIR_TESTDATA . '/images/canola.jpg',
 			$parent_id2,
 			array(
@@ -1628,7 +1628,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertStringContainsString( '<' . $next_link . '>; rel="next"', $headers['Link'] );
 
 		// 3rd page.
-		$this->factory->post->create();
+		self::factory()->post->create();
 		$total_posts++;
 		$total_pages++;
 		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
@@ -1707,7 +1707,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_get_items_status_draft_permissions() {
-		$draft_id = $this->factory->post->create( array( 'post_status' => 'draft' ) );
+		$draft_id = self::factory()->post->create( array( 'post_status' => 'draft' ) );
 
 		// Drafts status query var inaccessible to unauthorized users.
 		wp_set_current_user( 0 );
@@ -1737,7 +1737,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	 * @ticket 43701
 	 */
 	public function test_get_items_status_private_permissions() {
-		$private_post_id = $this->factory->post->create( array( 'post_status' => 'private' ) );
+		$private_post_id = self::factory()->post->create( array( 'post_status' => 'private' ) );
 
 		wp_set_current_user( 0 );
 
@@ -1792,9 +1792,9 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_get_items_valid_date() {
-		$post1 = $this->factory->post->create( array( 'post_date' => '2016-01-15T00:00:00Z' ) );
-		$post2 = $this->factory->post->create( array( 'post_date' => '2016-01-16T00:00:00Z' ) );
-		$post3 = $this->factory->post->create( array( 'post_date' => '2016-01-17T00:00:00Z' ) );
+		$post1 = self::factory()->post->create( array( 'post_date' => '2016-01-15T00:00:00Z' ) );
+		$post2 = self::factory()->post->create( array( 'post_date' => '2016-01-16T00:00:00Z' ) );
+		$post3 = self::factory()->post->create( array( 'post_date' => '2016-01-17T00:00:00Z' ) );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
 		$request->set_param( 'after', '2016-01-15T00:00:00Z' );
@@ -1820,9 +1820,9 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	 * @ticket 50617
 	 */
 	public function test_get_items_valid_modified_date() {
-		$post1 = $this->factory->post->create( array( 'post_date' => '2016-01-01 00:00:00' ) );
-		$post2 = $this->factory->post->create( array( 'post_date' => '2016-01-02 00:00:00' ) );
-		$post3 = $this->factory->post->create( array( 'post_date' => '2016-01-03 00:00:00' ) );
+		$post1 = self::factory()->post->create( array( 'post_date' => '2016-01-01 00:00:00' ) );
+		$post2 = self::factory()->post->create( array( 'post_date' => '2016-01-02 00:00:00' ) );
+		$post3 = self::factory()->post->create( array( 'post_date' => '2016-01-03 00:00:00' ) );
 		$this->update_post_modified( $post1, '2016-01-15 00:00:00' );
 		$this->update_post_modified( $post2, '2016-01-16 00:00:00' );
 		$this->update_post_modified( $post3, '2016-01-17 00:00:00' );
@@ -1940,7 +1940,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_get_post_draft_status_not_authenticated() {
-		$draft_id = $this->factory->post->create(
+		$draft_id = self::factory()->post->create(
 			array(
 				'post_status' => 'draft',
 			)
@@ -1956,7 +1956,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 
 	public function test_get_post_draft_edit_context() {
 		$post_content = 'Hello World!';
-		$this->factory->post->create(
+		self::factory()->post->create(
 			array(
 				'post_title'    => 'Hola',
 				'post_password' => 'password',
@@ -1965,7 +1965,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 				'post_author'   => self::$editor_id,
 			)
 		);
-		$draft_id = $this->factory->post->create(
+		$draft_id = self::factory()->post->create(
 			array(
 				'post_status'  => 'draft',
 				'post_author'  => self::$contributor_id,
@@ -2031,7 +2031,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_get_post_with_password() {
-		$post_id = $this->factory->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_password' => '$inthebananastand',
 			)
@@ -2050,7 +2050,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_get_post_with_password_using_password() {
-		$post_id = $this->factory->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_password' => '$inthebananastand',
 				'post_content'  => 'Some secret content.',
@@ -2074,7 +2074,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_get_post_with_password_using_incorrect_password() {
-		$post_id = $this->factory->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_password' => '$inthebananastand',
 			)
@@ -2090,7 +2090,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_get_post_with_password_without_permission() {
-		$post_id = $this->factory->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_password' => '$inthebananastand',
 				'post_content'  => 'Some secret content.',
@@ -2114,7 +2114,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	 * @ticket 43887
 	 */
 	public function test_get_post_should_not_have_block_version_when_context_view() {
-		$post_id = $this->factory->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_content' => '<!-- wp:core/separator -->',
 			)
@@ -2134,7 +2134,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_get_post_should_have_block_version_indicate_block_content_when_context_edit() {
 		wp_set_current_user( self::$editor_id );
 
-		$post_id = $this->factory->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_content' => '<!-- wp:core/separator -->',
 			)
@@ -2155,7 +2155,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_get_post_should_have_block_version_indicate_no_block_content_when_context_edit() {
 		wp_set_current_user( self::$editor_id );
 
-		$post_id = $this->factory->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_content' => '<hr />',
 			)
@@ -2783,7 +2783,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_create_update_post_with_featured_media() {
 
 		$file          = DIR_TESTDATA . '/images/canola.jpg';
-		$attachment_id = $this->factory->attachment->create_object(
+		$attachment_id = self::factory()->attachment->create_object(
 			$file,
 			0,
 			array(
@@ -3187,7 +3187,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	 */
 	public function test_rest_update_post_with_empty_date() {
 		// Create a new test post.
-		$post_id = $this->factory->post->create();
+		$post_id = self::factory()->post->create();
 
 		wp_set_current_user( self::$editor_id );
 
@@ -3436,7 +3436,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 
 		update_option( 'timezone_string', $params['timezone_string'] );
 
-		$post_id = $this->factory->post->create( array( 'post_status' => $status ) );
+		$post_id = self::factory()->post->create( array( 'post_status' => $status ) );
 
 		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d', $post_id ) );
 		if ( isset( $params['date'] ) ) {
@@ -3501,7 +3501,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 
 		// Need to set dates using wpdb directly because `wp_update_post` and
 		// `wp_insert_post` have additional validation on dates.
-		$post_id = $this->factory->post->create();
+		$post_id = self::factory()->post->create();
 		$wpdb->update(
 			$wpdb->posts,
 			array(
@@ -4171,7 +4171,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_delete_item() {
-		$post_id = $this->factory->post->create( array( 'post_title' => 'Deleted post' ) );
+		$post_id = self::factory()->post->create( array( 'post_title' => 'Deleted post' ) );
 
 		wp_set_current_user( self::$editor_id );
 
@@ -4186,7 +4186,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_delete_item_skip_trash() {
-		$post_id = $this->factory->post->create( array( 'post_title' => 'Deleted post' ) );
+		$post_id = self::factory()->post->create( array( 'post_title' => 'Deleted post' ) );
 
 		wp_set_current_user( self::$editor_id );
 
@@ -4201,7 +4201,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_delete_item_already_trashed() {
-		$post_id = $this->factory->post->create( array( 'post_title' => 'Deleted post' ) );
+		$post_id = self::factory()->post->create( array( 'post_title' => 'Deleted post' ) );
 
 		wp_set_current_user( self::$editor_id );
 
@@ -4222,7 +4222,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_delete_post_invalid_post_type() {
-		$page_id = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$page_id = self::factory()->post->create( array( 'post_type' => 'page' ) );
 
 		wp_set_current_user( self::$editor_id );
 
@@ -4465,7 +4465,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 
 		wp_set_current_user( 1 );
 
-		$post_id = $this->factory->post->create();
+		$post_id = self::factory()->post->create();
 
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/posts/' . $post_id );
 		$response = rest_get_server()->dispatch( $request );
@@ -4510,7 +4510,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 				'update_callback' => null,
 			)
 		);
-		$post_id = $this->factory->post->create();
+		$post_id = self::factory()->post->create();
 
 		// 'my_custom_int' should appear because ?_fields= isn't set.
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/posts/' . $post_id );
@@ -4931,7 +4931,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 
 		wp_set_current_user( self::$editor_id );
 
-		$post_id = $this->factory->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_title'  => 'Permalink Template',
 				'post_type'   => 'private-post',
@@ -4955,7 +4955,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 
 		wp_set_current_user( self::$editor_id );
 
-		$post_id = $this->factory->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_title'  => 'Permalink Template',
 				'post_type'   => 'post',

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -5256,7 +5256,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	 */
 	public function test_draft_post_does_not_have_the_same_slug_as_existing_post() {
 		wp_set_current_user( self::$editor_id );
-		$this->factory()->post->create( array( 'post_name' => 'sample-slug' ) );
+		self::factory()->post->create( array( 'post_name' => 'sample-slug' ) );
 
 		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d', self::$post_id ) );
 		$params  = $this->set_post_data(

--- a/tests/phpunit/tests/rest-api/rest-schema-setup.php
+++ b/tests/phpunit/tests/rest-api/rest-schema-setup.php
@@ -205,7 +205,7 @@ class WP_Test_REST_Schema_Initialization extends WP_Test_REST_TestCase {
 		// fixture file will be different between runs of PHPUnit tests, which
 		// is not desirable.
 
-		$administrator_id = $this->factory->user->create(
+		$administrator_id = self::factory()->user->create(
 			array(
 				'role'          => 'administrator',
 				'display_name'  => 'REST API Client Fixture: User',
@@ -215,7 +215,7 @@ class WP_Test_REST_Schema_Initialization extends WP_Test_REST_TestCase {
 		);
 		wp_set_current_user( $administrator_id );
 
-		$post_id = $this->factory->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_name'    => 'restapi-client-fixture-post',
 				'post_title'   => 'REST API Client Fixture: Post',
@@ -243,7 +243,7 @@ class WP_Test_REST_Schema_Initialization extends WP_Test_REST_TestCase {
 			)
 		);
 
-		$page_id = $this->factory->post->create(
+		$page_id = self::factory()->post->create(
 			array(
 				'post_type'     => 'page',
 				'post_name'     => 'restapi-client-fixture-page',
@@ -273,7 +273,7 @@ class WP_Test_REST_Schema_Initialization extends WP_Test_REST_TestCase {
 			)
 		);
 
-		$tag_id = $this->factory->tag->create(
+		$tag_id = self::factory()->tag->create(
 			array(
 				'name'        => 'REST API Client Fixture: Tag',
 				'slug'        => 'restapi-client-fixture-tag',
@@ -281,7 +281,7 @@ class WP_Test_REST_Schema_Initialization extends WP_Test_REST_TestCase {
 			)
 		);
 
-		$media_id = $this->factory->attachment->create_object(
+		$media_id = self::factory()->attachment->create_object(
 			get_temp_dir() . 'canola.jpg',
 			0,
 			array(
@@ -295,7 +295,7 @@ class WP_Test_REST_Schema_Initialization extends WP_Test_REST_TestCase {
 			)
 		);
 
-		$comment_id = $this->factory->comment->create(
+		$comment_id = self::factory()->comment->create(
 			array(
 				'comment_approved'     => 1,
 				'comment_post_ID'      => $post_id,

--- a/tests/phpunit/tests/rest-api/rest-tags-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-tags-controller.php
@@ -139,7 +139,7 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertSame( 'view', $data['endpoints'][0]['args']['context']['default'] );
 		$this->assertSameSets( array( 'view', 'embed', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
 		// Single.
-		$tag1     = $this->factory->tag->create( array( 'name' => 'Season 5' ) );
+		$tag1     = self::factory()->tag->create( array( 'name' => 'Season 5' ) );
 		$request  = new WP_REST_Request( 'OPTIONS', '/wp/v2/tags/' . $tag1 );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
@@ -174,7 +174,7 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_get_items() {
-		$this->factory->tag->create();
+		self::factory()->tag->create();
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/tags' );
 		$request->set_param( 'per_page', self::$per_page );
@@ -192,9 +192,9 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_get_items_hide_empty_arg() {
-		$post_id = $this->factory->post->create();
-		$tag1    = $this->factory->tag->create( array( 'name' => 'Season 5' ) );
-		$tag2    = $this->factory->tag->create( array( 'name' => 'The Be Sharps' ) );
+		$post_id = self::factory()->post->create();
+		$tag1    = self::factory()->tag->create( array( 'name' => 'Season 5' ) );
+		$tag2    = self::factory()->tag->create( array( 'name' => 'The Be Sharps' ) );
 
 		wp_set_object_terms( $post_id, array( $tag1, $tag2 ), 'post_tag' );
 
@@ -213,8 +213,8 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_get_items_include_query() {
-		$id1 = $this->factory->tag->create();
-		$id2 = $this->factory->tag->create();
+		$id1 = self::factory()->tag->create();
+		$id2 = self::factory()->tag->create();
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/tags' );
 
@@ -239,8 +239,8 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_get_items_exclude_query() {
-		$id1 = $this->factory->tag->create();
-		$id2 = $this->factory->tag->create();
+		$id1 = self::factory()->tag->create();
+		$id2 = self::factory()->tag->create();
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/tags' );
 		$request->set_param( 'per_page', self::$per_page );
@@ -288,8 +288,8 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 
 
 	public function test_get_items_orderby_args() {
-		$tag1 = $this->factory->tag->create( array( 'name' => 'Apple' ) );
-		$tag2 = $this->factory->tag->create( array( 'name' => 'Zucchini' ) );
+		$tag1 = self::factory()->tag->create( array( 'name' => 'Apple' ) );
+		$tag2 = self::factory()->tag->create( array( 'name' => 'Zucchini' ) );
 
 		/*
 		 * Tests:
@@ -324,9 +324,9 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_get_items_orderby_id() {
-		$tag0 = $this->factory->tag->create( array( 'name' => 'Cantaloupe' ) );
-		$tag1 = $this->factory->tag->create( array( 'name' => 'Apple' ) );
-		$tag2 = $this->factory->tag->create( array( 'name' => 'Banana' ) );
+		$tag0 = self::factory()->tag->create( array( 'name' => 'Cantaloupe' ) );
+		$tag1 = self::factory()->tag->create( array( 'name' => 'Apple' ) );
+		$tag2 = self::factory()->tag->create( array( 'name' => 'Banana' ) );
 
 		// Defaults to 'orderby' => 'name', 'order' => 'asc'.
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/tags' );
@@ -360,9 +360,9 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_get_items_orderby_slugs() {
-		$this->factory->tag->create( array( 'name' => 'Burrito' ) );
-		$this->factory->tag->create( array( 'name' => 'Taco' ) );
-		$this->factory->tag->create( array( 'name' => 'Chalupa' ) );
+		self::factory()->tag->create( array( 'name' => 'Burrito' ) );
+		self::factory()->tag->create( array( 'name' => 'Taco' ) );
+		self::factory()->tag->create( array( 'name' => 'Chalupa' ) );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/tags' );
 		$request->set_param( 'orderby', 'include_slugs' );
@@ -376,10 +376,10 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_get_items_post_args() {
-		$post_id = $this->factory->post->create();
-		$tag1    = $this->factory->tag->create( array( 'name' => 'DC' ) );
-		$tag2    = $this->factory->tag->create( array( 'name' => 'Marvel' ) );
-		$this->factory->tag->create( array( 'name' => 'Dark Horse' ) );
+		$post_id = self::factory()->post->create();
+		$tag1    = self::factory()->tag->create( array( 'name' => 'DC' ) );
+		$tag2    = self::factory()->tag->create( array( 'name' => 'Marvel' ) );
+		self::factory()->tag->create( array( 'name' => 'Dark Horse' ) );
 
 		wp_set_object_terms( $post_id, array( $tag1, $tag2 ), 'post_tag' );
 
@@ -400,7 +400,7 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_get_terms_post_args_paging() {
-		$post_id = $this->factory->post->create();
+		$post_id = self::factory()->post->create();
 
 		wp_set_object_terms( $post_id, self::$tag_ids, 'post_tag' );
 
@@ -437,7 +437,7 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_get_items_post_empty() {
-		$post_id = $this->factory->post->create();
+		$post_id = self::factory()->post->create();
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/tags' );
 		$request->set_param( 'post', $post_id );
@@ -452,25 +452,25 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 		register_taxonomy( 'batman', 'post', array( 'show_in_rest' => true ) );
 		$controller = new WP_REST_Terms_Controller( 'batman' );
 		$controller->register_routes();
-		$term1 = $this->factory->term->create(
+		$term1 = self::factory()->term->create(
 			array(
 				'name'     => 'Cape',
 				'taxonomy' => 'batman',
 			)
 		);
-		$term2 = $this->factory->term->create(
+		$term2 = self::factory()->term->create(
 			array(
 				'name'     => 'Mask',
 				'taxonomy' => 'batman',
 			)
 		);
-		$this->factory->term->create(
+		self::factory()->term->create(
 			array(
 				'name'     => 'Car',
 				'taxonomy' => 'batman',
 			)
 		);
-		$post_id = $this->factory->post->create();
+		$post_id = self::factory()->post->create();
 
 		wp_set_object_terms( $post_id, array( $term1, $term2 ), 'batman' );
 
@@ -485,8 +485,8 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_get_items_search_args() {
-		$tag1 = $this->factory->tag->create( array( 'name' => 'Apple' ) );
-		$tag2 = $this->factory->tag->create( array( 'name' => 'Banana' ) );
+		$tag1 = self::factory()->tag->create( array( 'name' => 'Apple' ) );
+		$tag2 = self::factory()->tag->create( array( 'name' => 'Banana' ) );
 
 		/*
 		 * Tests:
@@ -509,8 +509,8 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_get_items_slug_arg() {
-		$tag1 = $this->factory->tag->create( array( 'name' => 'Apple' ) );
-		$tag2 = $this->factory->tag->create( array( 'name' => 'Banana' ) );
+		$tag1 = self::factory()->tag->create( array( 'name' => 'Apple' ) );
+		$tag2 = self::factory()->tag->create( array( 'name' => 'Banana' ) );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/tags' );
 		$request->set_param( 'slug', 'apple' );
@@ -522,10 +522,10 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_get_items_slug_array_arg() {
-		$id1 = $this->factory->tag->create( array( 'name' => 'Taco' ) );
-		$id2 = $this->factory->tag->create( array( 'name' => 'Enchilada' ) );
-		$id3 = $this->factory->tag->create( array( 'name' => 'Burrito' ) );
-		$this->factory->tag->create( array( 'name' => 'Pizza' ) );
+		$id1 = self::factory()->tag->create( array( 'name' => 'Taco' ) );
+		$id2 = self::factory()->tag->create( array( 'name' => 'Enchilada' ) );
+		$id3 = self::factory()->tag->create( array( 'name' => 'Burrito' ) );
+		self::factory()->tag->create( array( 'name' => 'Pizza' ) );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/tags' );
 		$request->set_param(
@@ -545,10 +545,10 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_get_items_slug_csv_arg() {
-		$id1 = $this->factory->tag->create( array( 'name' => 'Taco' ) );
-		$id2 = $this->factory->tag->create( array( 'name' => 'Enchilada' ) );
-		$id3 = $this->factory->tag->create( array( 'name' => 'Burrito' ) );
-		$this->factory->tag->create( array( 'name' => 'Pizza' ) );
+		$id1 = self::factory()->tag->create( array( 'name' => 'Taco' ) );
+		$id2 = self::factory()->tag->create( array( 'name' => 'Enchilada' ) );
+		$id3 = self::factory()->tag->create( array( 'name' => 'Burrito' ) );
+		self::factory()->tag->create( array( 'name' => 'Pizza' ) );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/tags' );
 		$request->set_param( 'slug', 'taco,burrito, enchilada' );
@@ -562,13 +562,13 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 
 	public function test_get_terms_private_taxonomy() {
 		register_taxonomy( 'robin', 'post', array( 'public' => false ) );
-		$term1 = $this->factory->term->create(
+		$term1 = self::factory()->term->create(
 			array(
 				'name'     => 'Cape',
 				'taxonomy' => 'robin',
 			)
 		);
-		$term2 = $this->factory->term->create(
+		$term2 = self::factory()->term->create(
 			array(
 				'name'     => 'Mask',
 				'taxonomy' => 'robin',
@@ -600,7 +600,7 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertStringContainsString( '<' . $next_link . '>; rel="next"', $headers['Link'] );
 
 		// 3rd page.
-		$this->factory->tag->create();
+		self::factory()->tag->create();
 		$total_tags++;
 		$total_pages++;
 		$request = new WP_REST_Request( 'GET', '/wp/v2/tags' );
@@ -665,7 +665,7 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_get_item() {
-		$id = $this->factory->tag->create();
+		$id = self::factory()->tag->create();
 
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/tags/' . $id );
 		$response = rest_get_server()->dispatch( $request );
@@ -676,7 +676,7 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 	 * @ticket 39122
 	 */
 	public function test_get_item_meta() {
-		$id = $this->factory->tag->create();
+		$id = self::factory()->tag->create();
 
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/tags/' . $id );
 		$response = rest_get_server()->dispatch( $request );
@@ -698,7 +698,7 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 	 * @ticket 39122
 	 */
 	public function test_get_item_meta_registered_for_different_taxonomy() {
-		$id = $this->factory->tag->create();
+		$id = self::factory()->tag->create();
 
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/tags/' . $id );
 		$response = rest_get_server()->dispatch( $request );
@@ -716,7 +716,7 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_get_item_invalid_permission_for_context() {
-		$id = $this->factory->tag->create();
+		$id = self::factory()->tag->create();
 
 		wp_set_current_user( 0 );
 
@@ -728,7 +728,7 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 
 	public function test_get_term_private_taxonomy() {
 		register_taxonomy( 'robin', 'post', array( 'public' => false ) );
-		$term1 = $this->factory->term->create(
+		$term1 = self::factory()->term->create(
 			array(
 				'name'     => 'Cape',
 				'taxonomy' => 'robin',
@@ -742,7 +742,7 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 
 	public function test_get_item_incorrect_taxonomy() {
 		register_taxonomy( 'robin', 'post' );
-		$term1 = $this->factory->term->create(
+		$term1 = self::factory()->term->create(
 			array(
 				'name'     => 'Cape',
 				'taxonomy' => 'robin',
@@ -833,7 +833,7 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_create_item_with_meta_wrong_id() {
 		wp_set_current_user( self::$administrator );
 
-		$existing_tag_id = $this->factory->tag->create( array( 'name' => 'My Not So Awesome Term' ) );
+		$existing_tag_id = self::factory()->tag->create( array( 'name' => 'My Not So Awesome Term' ) );
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/tags' );
 		$request->set_param( 'name', 'My Awesome Term' );
@@ -858,7 +858,7 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 			'slug'        => 'original-slug',
 		);
 
-		$term = get_term_by( 'id', $this->factory->tag->create( $orig_args ), 'post_tag' );
+		$term = get_term_by( 'id', self::factory()->tag->create( $orig_args ), 'post_tag' );
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/tags/' . $term->term_id );
 		$request->set_param( 'name', 'New Name' );
@@ -886,7 +886,7 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_update_item_no_change() {
 		wp_set_current_user( self::$administrator );
 
-		$term = get_term_by( 'id', $this->factory->tag->create(), 'post_tag' );
+		$term = get_term_by( 'id', self::factory()->tag->create(), 'post_tag' );
 
 		$request  = new WP_REST_Request( 'PUT', '/wp/v2/tags/' . $term->term_id );
 		$response = rest_get_server()->dispatch( $request );
@@ -914,7 +914,7 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_update_item_incorrect_permissions() {
 		wp_set_current_user( self::$subscriber );
 
-		$term = get_term_by( 'id', $this->factory->tag->create(), 'post_tag' );
+		$term = get_term_by( 'id', self::factory()->tag->create(), 'post_tag' );
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/tags/' . $term->term_id );
 		$request->set_param( 'name', 'Incorrect permissions' );
@@ -928,7 +928,7 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_update_item_with_edit_term_cap_granted() {
 		wp_set_current_user( self::$subscriber );
 
-		$term = $this->factory->tag->create_and_get();
+		$term = self::factory()->tag->create_and_get();
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/tags/' . $term->term_id );
 		$request->set_param( 'name', 'New Name' );
@@ -955,7 +955,7 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_update_item_with_edit_term_cap_revoked() {
 		wp_set_current_user( self::$administrator );
 
-		$term = $this->factory->tag->create_and_get();
+		$term = self::factory()->tag->create_and_get();
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/tags/' . $term->term_id );
 		$request->set_param( 'name', 'New Name' );
@@ -977,7 +977,7 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_update_item_parent_non_hierarchical_taxonomy() {
 		wp_set_current_user( self::$administrator );
 
-		$term = get_term_by( 'id', $this->factory->tag->create(), 'post_tag' );
+		$term = get_term_by( 'id', self::factory()->tag->create(), 'post_tag' );
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/tags/' . $term->term_id );
 		$request->set_param( 'parent', REST_TESTS_IMPOSSIBLY_HIGH_NUMBER );
@@ -1104,7 +1104,7 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_delete_item() {
 		wp_set_current_user( self::$administrator );
 
-		$term = get_term_by( 'id', $this->factory->tag->create( array( 'name' => 'Deleted Tag' ) ), 'post_tag' );
+		$term = get_term_by( 'id', self::factory()->tag->create( array( 'name' => 'Deleted Tag' ) ), 'post_tag' );
 
 		$request = new WP_REST_Request( 'DELETE', '/wp/v2/tags/' . $term->term_id );
 		$request->set_param( 'force', true );
@@ -1118,7 +1118,7 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_delete_item_no_trash() {
 		wp_set_current_user( self::$administrator );
 
-		$term = get_term_by( 'id', $this->factory->tag->create( array( 'name' => 'Deleted Tag' ) ), 'post_tag' );
+		$term = get_term_by( 'id', self::factory()->tag->create( array( 'name' => 'Deleted Tag' ) ), 'post_tag' );
 
 		$request  = new WP_REST_Request( 'DELETE', '/wp/v2/tags/' . $term->term_id );
 		$response = rest_get_server()->dispatch( $request );
@@ -1140,7 +1140,7 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_delete_item_incorrect_permissions() {
 		wp_set_current_user( self::$subscriber );
 
-		$term = get_term_by( 'id', $this->factory->tag->create(), 'post_tag' );
+		$term = get_term_by( 'id', self::factory()->tag->create(), 'post_tag' );
 
 		$request  = new WP_REST_Request( 'DELETE', '/wp/v2/tags/' . $term->term_id );
 		$response = rest_get_server()->dispatch( $request );
@@ -1153,7 +1153,7 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_delete_item_with_delete_term_cap_granted() {
 		wp_set_current_user( self::$subscriber );
 
-		$term = get_term_by( 'id', $this->factory->tag->create( array( 'name' => 'Deleted Tag' ) ), 'post_tag' );
+		$term = get_term_by( 'id', self::factory()->tag->create( array( 'name' => 'Deleted Tag' ) ), 'post_tag' );
 
 		$request = new WP_REST_Request( 'DELETE', '/wp/v2/tags/' . $term->term_id );
 		$request->set_param( 'force', true );
@@ -1181,7 +1181,7 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_delete_item_with_delete_term_cap_revoked() {
 		wp_set_current_user( self::$administrator );
 
-		$term = get_term_by( 'id', $this->factory->tag->create( array( 'name' => 'Deleted Tag' ) ), 'post_tag' );
+		$term = get_term_by( 'id', self::factory()->tag->create( array( 'name' => 'Deleted Tag' ) ), 'post_tag' );
 
 		$request = new WP_REST_Request( 'DELETE', '/wp/v2/tags/' . $term->term_id );
 		$request->set_param( 'force', true );
@@ -1201,7 +1201,7 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_prepare_item() {
-		$term = get_term_by( 'id', $this->factory->tag->create(), 'post_tag' );
+		$term = get_term_by( 'id', self::factory()->tag->create(), 'post_tag' );
 
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/tags/' . $term->term_id );
 		$response = rest_get_server()->dispatch( $request );
@@ -1214,7 +1214,7 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 		$request  = new WP_REST_Request;
 		$endpoint = new WP_REST_Terms_Controller( 'post_tag' );
 		$request->set_param( '_fields', 'id,name' );
-		$term     = get_term_by( 'id', $this->factory->tag->create(), 'post_tag' );
+		$term     = get_term_by( 'id', self::factory()->tag->create(), 'post_tag' );
 		$response = $endpoint->prepare_item_for_response( $term, $request );
 		$this->assertSame(
 			array(
@@ -1276,7 +1276,7 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( 'my_custom_int', $data['schema']['properties'] );
 		$this->assertSame( $schema, $data['schema']['properties']['my_custom_int'] );
 
-		$tag_id = $this->factory->tag->create();
+		$tag_id = self::factory()->tag->create();
 
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/tags/' . $tag_id );
 		$response = rest_get_server()->dispatch( $request );
@@ -1306,7 +1306,7 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 
 		wp_set_current_user( self::$administrator );
 
-		$tag_id = $this->factory->tag->create();
+		$tag_id = self::factory()->tag->create();
 
 		// Check for error on update.
 		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/tags/%d', $tag_id ) );
@@ -1330,8 +1330,8 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_object_term_queries_are_cached() {
 		global $wpdb;
 
-		$tags = $this->factory->tag->create_many( 2 );
-		$p    = $this->factory->post->create();
+		$tags = self::factory()->tag->create_many( 2 );
+		$p    = self::factory()->post->create();
 		wp_set_object_terms( $p, $tags[0], 'post_tag' );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/tags' );

--- a/tests/phpunit/tests/rest-api/rest-taxonomies-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-taxonomies-controller.php
@@ -112,7 +112,7 @@ class WP_Test_REST_Taxonomies_Controller extends WP_Test_REST_Controller_Testcas
 	}
 
 	public function test_get_item_edit_context() {
-		$editor_id = $this->factory->user->create( array( 'role' => 'editor' ) );
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
 		wp_set_current_user( $editor_id );
 		$request = new WP_REST_Request( 'GET', '/wp/v2/taxonomies/category' );
 		$request->set_param( 'context', 'edit' );

--- a/tests/phpunit/tests/rest-api/rest-term-meta-fields.php
+++ b/tests/phpunit/tests/rest-api/rest-term-meta-fields.php
@@ -200,7 +200,7 @@ class WP_Test_REST_Term_Meta_Fields extends WP_Test_REST_TestCase {
 
 	protected function grant_write_permission() {
 		// Ensure we have write permission.
-		$user = $this->factory->user->create(
+		$user = self::factory()->user->create(
 			array(
 				'role' => 'editor',
 			)

--- a/tests/phpunit/tests/rest-api/rest-users-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-users-controller.php
@@ -340,7 +340,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertStringContainsString( '<' . $next_link . '>; rel="next"', $headers['Link'] );
 
 		// 3rd page.
-		$this->factory->user->create();
+		self::factory()->user->create();
 		$total_users++;
 		$total_pages++;
 		$request = new WP_REST_Request( 'GET', '/wp/v2/users' );
@@ -432,9 +432,9 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_get_items_orderby_name() {
 		wp_set_current_user( self::$user );
 
-		$low_id  = $this->factory->user->create( array( 'display_name' => 'AAAAA' ) );
-		$mid_id  = $this->factory->user->create( array( 'display_name' => 'NNNNN' ) );
-		$high_id = $this->factory->user->create( array( 'display_name' => 'ZZZZ' ) );
+		$low_id  = self::factory()->user->create( array( 'display_name' => 'AAAAA' ) );
+		$mid_id  = self::factory()->user->create( array( 'display_name' => 'NNNNN' ) );
+		$high_id = self::factory()->user->create( array( 'display_name' => 'ZZZZ' ) );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/users' );
 		$request->set_param( 'orderby', 'name' );
@@ -456,8 +456,8 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_get_items_orderby_url() {
 		wp_set_current_user( self::$user );
 
-		$low_id  = $this->factory->user->create( array( 'user_url' => 'http://a.com' ) );
-		$high_id = $this->factory->user->create( array( 'user_url' => 'http://b.com' ) );
+		$low_id  = self::factory()->user->create( array( 'user_url' => 'http://a.com' ) );
+		$high_id = self::factory()->user->create( array( 'user_url' => 'http://b.com' ) );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/users' );
 		$request->set_param( 'orderby', 'url' );
@@ -481,8 +481,8 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_get_items_orderby_slug() {
 		wp_set_current_user( self::$user );
 
-		$high_id = $this->factory->user->create( array( 'user_nicename' => 'blogin' ) );
-		$low_id  = $this->factory->user->create( array( 'user_nicename' => 'alogin' ) );
+		$high_id = self::factory()->user->create( array( 'user_nicename' => 'blogin' ) );
+		$low_id  = self::factory()->user->create( array( 'user_nicename' => 'alogin' ) );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/users' );
 		$request->set_param( 'orderby', 'slug' );
@@ -506,9 +506,9 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_get_items_orderby_slugs() {
 		wp_set_current_user( self::$user );
 
-		$this->factory->user->create( array( 'user_nicename' => 'burrito' ) );
-		$this->factory->user->create( array( 'user_nicename' => 'taco' ) );
-		$this->factory->user->create( array( 'user_nicename' => 'chalupa' ) );
+		self::factory()->user->create( array( 'user_nicename' => 'burrito' ) );
+		self::factory()->user->create( array( 'user_nicename' => 'taco' ) );
+		self::factory()->user->create( array( 'user_nicename' => 'chalupa' ) );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/users' );
 		$request->set_param( 'orderby', 'include_slugs' );
@@ -524,8 +524,8 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_get_items_orderby_email() {
 		wp_set_current_user( self::$user );
 
-		$high_id = $this->factory->user->create( array( 'user_email' => 'bemail@gmail.com' ) );
-		$low_id  = $this->factory->user->create( array( 'user_email' => 'aemail@gmail.com' ) );
+		$high_id = self::factory()->user->create( array( 'user_email' => 'bemail@gmail.com' ) );
+		$low_id  = self::factory()->user->create( array( 'user_email' => 'aemail@gmail.com' ) );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/users' );
 		$request->set_param( 'orderby', 'email' );
@@ -604,8 +604,8 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_get_items_include_query() {
 		wp_set_current_user( self::$user );
 
-		$id1 = $this->factory->user->create();
-		$id2 = $this->factory->user->create();
+		$id1 = self::factory()->user->create();
+		$id2 = self::factory()->user->create();
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/users' );
 
@@ -640,8 +640,8 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_get_items_exclude_query() {
 		wp_set_current_user( self::$user );
 
-		$id1 = $this->factory->user->create();
-		$id2 = $this->factory->user->create();
+		$id1 = self::factory()->user->create();
+		$id2 = self::factory()->user->create();
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/users' );
 		$request->set_param( 'per_page', self::$per_page ); // There are >10 users at this point.
@@ -672,14 +672,14 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertCount( 0, $response->get_data() );
 
-		$yolo_id = $this->factory->user->create( array( 'display_name' => 'yololololo' ) );
+		$yolo_id = self::factory()->user->create( array( 'display_name' => 'yololololo' ) );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/users' );
 		$request->set_param( 'search', 'yololololo' );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertCount( 1, $response->get_data() );
 		// Default to wildcard search.
-		$adam_id = $this->factory->user->create(
+		$adam_id = self::factory()->user->create(
 			array(
 				'role'          => 'author',
 				'user_nicename' => 'adam',
@@ -697,13 +697,13 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_get_items_slug_query() {
 		wp_set_current_user( self::$user );
 
-		$this->factory->user->create(
+		self::factory()->user->create(
 			array(
 				'display_name' => 'foo',
 				'user_login'   => 'bar',
 			)
 		);
-		$id2 = $this->factory->user->create(
+		$id2 = self::factory()->user->create(
 			array(
 				'display_name' => 'Moo',
 				'user_login'   => 'foo',
@@ -721,25 +721,25 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_get_items_slug_array_query() {
 		wp_set_current_user( self::$user );
 
-		$id1 = $this->factory->user->create(
+		$id1 = self::factory()->user->create(
 			array(
 				'display_name' => 'Taco',
 				'user_login'   => 'taco',
 			)
 		);
-		$id2 = $this->factory->user->create(
+		$id2 = self::factory()->user->create(
 			array(
 				'display_name' => 'Enchilada',
 				'user_login'   => 'enchilada',
 			)
 		);
-		$id3 = $this->factory->user->create(
+		$id3 = self::factory()->user->create(
 			array(
 				'display_name' => 'Burrito',
 				'user_login'   => 'burrito',
 			)
 		);
-		$this->factory->user->create(
+		self::factory()->user->create(
 			array(
 				'display_name' => 'Hon Pizza',
 				'user_login'   => 'pizza',
@@ -767,25 +767,25 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	public function test_get_items_slug_csv_query() {
 		wp_set_current_user( self::$user );
 
-		$id1 = $this->factory->user->create(
+		$id1 = self::factory()->user->create(
 			array(
 				'display_name' => 'Taco',
 				'user_login'   => 'taco',
 			)
 		);
-		$id2 = $this->factory->user->create(
+		$id2 = self::factory()->user->create(
 			array(
 				'display_name' => 'Enchilada',
 				'user_login'   => 'enchilada',
 			)
 		);
-		$id3 = $this->factory->user->create(
+		$id3 = self::factory()->user->create(
 			array(
 				'display_name' => 'Burrito',
 				'user_login'   => 'burrito',
 			)
 		);
-		$this->factory->user->create(
+		self::factory()->user->create(
 			array(
 				'display_name' => 'Hon Pizza',
 				'user_login'   => 'pizza',
@@ -962,7 +962,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_get_item() {
-		$user_id = $this->factory->user->create();
+		$user_id = self::factory()->user->create();
 
 		wp_set_current_user( self::$user );
 
@@ -1029,7 +1029,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 
 		$this->allow_user_to_manage_multisite();
 
-		$lolz = $this->factory->user->create(
+		$lolz = self::factory()->user->create(
 			array(
 				'display_name' => 'lolz',
 				'roles'        => '',
@@ -1114,13 +1114,13 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_get_item_published_author_post() {
-		$author_id = $this->factory->user->create(
+		$author_id = self::factory()->user->create(
 			array(
 				'role' => 'author',
 			)
 		);
 
-		$post_id = $this->factory->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_author' => $author_id,
 			)
@@ -1134,7 +1134,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_get_item_published_author_pages() {
-		$author_id = $this->factory->user->create(
+		$author_id = self::factory()->user->create(
 			array(
 				'role' => 'author',
 			)
@@ -1146,7 +1146,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertSame( 401, $response->get_status() );
 
-		$post_id = $this->factory->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_author' => $author_id,
 				'post_type'   => 'page',
@@ -1158,7 +1158,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_get_user_with_edit_context() {
-		$user_id = $this->factory->user->create();
+		$user_id = self::factory()->user->create();
 
 		$this->allow_user_to_manage_multisite();
 
@@ -1169,13 +1169,13 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_get_item_published_author_wrong_context() {
-		$author_id = $this->factory->user->create(
+		$author_id = self::factory()->user->create(
 			array(
 				'role' => 'author',
 			)
 		);
 
-		$post_id = $this->factory->post->create(
+		$post_id = self::factory()->post->create(
 			array(
 				'post_author' => $author_id,
 			)
@@ -1554,7 +1554,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_update_item() {
-		$user_id = $this->factory->user->create(
+		$user_id = self::factory()->user->create(
 			array(
 				'user_email' => 'test@example.com',
 				'user_pass'  => 'sjflsfls',
@@ -1620,13 +1620,13 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_update_item_existing_email() {
-		$user1 = $this->factory->user->create(
+		$user1 = self::factory()->user->create(
 			array(
 				'user_login' => 'test_json_user',
 				'user_email' => 'testjson@example.com',
 			)
 		);
-		$user2 = $this->factory->user->create(
+		$user2 = self::factory()->user->create(
 			array(
 				'user_login' => 'test_json_user2',
 				'user_email' => 'testjson2@example.com',
@@ -1684,7 +1684,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_update_item_invalid_locale() {
-		$user1 = $this->factory->user->create(
+		$user1 = self::factory()->user->create(
 			array(
 				'user_login' => 'test_json_user',
 				'user_email' => 'testjson@example.com',
@@ -1703,7 +1703,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_update_item_en_US_locale() {
-		$user_id = $this->factory->user->create(
+		$user_id = self::factory()->user->create(
 			array(
 				'user_login' => 'test_json_user',
 				'user_email' => 'testjson@example.com',
@@ -1727,7 +1727,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	 * @ticket 38632
 	 */
 	public function test_update_item_empty_locale() {
-		$user_id = $this->factory->user->create(
+		$user_id = self::factory()->user->create(
 			array(
 				'user_login' => 'test_json_user',
 				'user_email' => 'testjson@example.com',
@@ -1751,13 +1751,13 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_update_item_username_attempt() {
-		$user1 = $this->factory->user->create(
+		$user1 = self::factory()->user->create(
 			array(
 				'user_login' => 'test_json_user',
 				'user_email' => 'testjson@example.com',
 			)
 		);
-		$user2 = $this->factory->user->create(
+		$user2 = self::factory()->user->create(
 			array(
 				'user_login' => 'test_json_user2',
 				'user_email' => 'testjson2@example.com',
@@ -1776,13 +1776,13 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_update_item_existing_nicename() {
-		$user1 = $this->factory->user->create(
+		$user1 = self::factory()->user->create(
 			array(
 				'user_login' => 'test_json_user',
 				'user_email' => 'testjson@example.com',
 			)
 		);
-		$user2 = $this->factory->user->create(
+		$user2 = self::factory()->user->create(
 			array(
 				'user_login' => 'test_json_user2',
 				'user_email' => 'testjson2@example.com',
@@ -1801,7 +1801,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_json_update_user() {
-		$user_id = $this->factory->user->create(
+		$user_id = self::factory()->user->create(
 			array(
 				'user_email' => 'testjson2@example.com',
 				'user_pass'  => 'sjflsfl3sdjls',
@@ -1846,7 +1846,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_update_user_role() {
-		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
 
 		wp_set_current_user( self::$user );
 
@@ -1867,7 +1867,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_update_user_multiple_roles() {
-		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
 
 		wp_set_current_user( self::$user );
 
@@ -1913,7 +1913,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	 * @group ms-excluded
 	 */
 	public function test_update_user_role_invalid_privilege_deescalation() {
-		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
 
 		wp_set_current_user( $user_id );
 
@@ -1942,7 +1942,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	 * @group ms-required
 	 */
 	public function test_update_user_role_privilege_deescalation_multisite() {
-		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
 
 		wp_set_current_user( $user_id );
 		$user = wp_get_current_user();
@@ -1956,7 +1956,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertSame( 'editor', $new_data['roles'][0] );
 		$this->assertNotEquals( 'administrator', $new_data['roles'][0] );
 
-		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
 
 		wp_set_current_user( $user_id );
 		$user = wp_get_current_user();
@@ -2046,7 +2046,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	 * @ticket 40263
 	 */
 	public function test_update_item_only_roles_as_editor() {
-		$user_id = $this->factory->user->create(
+		$user_id = self::factory()->user->create(
 			array(
 				'role' => 'author',
 			)
@@ -2064,7 +2064,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	 * @ticket 40263
 	 */
 	public function test_update_item_only_roles_as_site_administrator() {
-		$user_id = $this->factory->user->create(
+		$user_id = self::factory()->user->create(
 			array(
 				'role' => 'author',
 			)
@@ -2085,7 +2085,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	 * @ticket 40263
 	 */
 	public function test_update_item_including_roles_and_other_params() {
-		$user_id = $this->factory->user->create(
+		$user_id = self::factory()->user->create(
 			array(
 				'role' => 'author',
 			)
@@ -2341,7 +2341,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_delete_item() {
-		$user_id = $this->factory->user->create( array( 'display_name' => 'Deleted User' ) );
+		$user_id = self::factory()->user->create( array( 'display_name' => 'Deleted User' ) );
 
 		$this->allow_user_to_manage_multisite();
 
@@ -2366,7 +2366,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_delete_item_no_trash() {
-		$user_id = $this->factory->user->create( array( 'display_name' => 'Deleted User' ) );
+		$user_id = self::factory()->user->create( array( 'display_name' => 'Deleted User' ) );
 
 		$this->allow_user_to_manage_multisite();
 
@@ -2396,7 +2396,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_delete_current_item() {
-		$user_id = $this->factory->user->create(
+		$user_id = self::factory()->user->create(
 			array(
 				'role'         => 'administrator',
 				'display_name' => 'Deleted User',
@@ -2425,7 +2425,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_delete_current_item_no_trash() {
-		$user_id = $this->factory->user->create(
+		$user_id = self::factory()->user->create(
 			array(
 				'role'         => 'administrator',
 				'display_name' => 'Deleted User',
@@ -2458,7 +2458,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_delete_user_without_permission() {
-		$user_id = $this->factory->user->create();
+		$user_id = self::factory()->user->create();
 
 		$this->allow_user_to_manage_multisite();
 
@@ -2496,9 +2496,9 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->allow_user_to_manage_multisite();
 
 		// Test with a new user, to avoid any complications.
-		$user_id     = $this->factory->user->create();
-		$reassign_id = $this->factory->user->create();
-		$test_post   = $this->factory->post->create(
+		$user_id     = self::factory()->user->create();
+		$reassign_id = self::factory()->user->create();
+		$test_post   = self::factory()->post->create(
 			array(
 				'post_author' => $user_id,
 			)
@@ -2530,7 +2530,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_delete_user_invalid_reassign_id() {
-		$user_id = $this->factory->user->create();
+		$user_id = self::factory()->user->create();
 
 		$this->allow_user_to_manage_multisite();
 
@@ -2551,7 +2551,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_delete_user_invalid_reassign_passed_as_string() {
-		$user_id = $this->factory->user->create();
+		$user_id = self::factory()->user->create();
 
 		$this->allow_user_to_manage_multisite();
 
@@ -2566,13 +2566,13 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_delete_user_reassign_passed_as_boolean_false_trashes_post() {
-		$user_id = $this->factory->user->create();
+		$user_id = self::factory()->user->create();
 
 		$this->allow_user_to_manage_multisite();
 
 		wp_set_current_user( self::$user );
 
-		$test_post = $this->factory->post->create(
+		$test_post = self::factory()->post->create(
 			array(
 				'post_author' => $user_id,
 			)
@@ -2594,13 +2594,13 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_delete_user_reassign_passed_as_string_false_trashes_post() {
-		$user_id = $this->factory->user->create();
+		$user_id = self::factory()->user->create();
 
 		$this->allow_user_to_manage_multisite();
 
 		wp_set_current_user( self::$user );
 
-		$test_post = $this->factory->post->create(
+		$test_post = self::factory()->post->create(
 			array(
 				'post_author' => $user_id,
 			)
@@ -2622,13 +2622,13 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_delete_user_reassign_passed_as_empty_string_trashes_post() {
-		$user_id = $this->factory->user->create();
+		$user_id = self::factory()->user->create();
 
 		$this->allow_user_to_manage_multisite();
 
 		wp_set_current_user( self::$user );
 
-		$test_post = $this->factory->post->create(
+		$test_post = self::factory()->post->create(
 			array(
 				'post_author' => $user_id,
 			)
@@ -2650,13 +2650,13 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_delete_user_reassign_passed_as_0_reassigns_author() {
-		$user_id = $this->factory->user->create();
+		$user_id = self::factory()->user->create();
 
 		$this->allow_user_to_manage_multisite();
 
 		wp_set_current_user( self::$user );
 
-		$test_post = $this->factory->post->create(
+		$test_post = self::factory()->post->create(
 			array(
 				'post_author' => $user_id,
 			)
@@ -2831,7 +2831,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	 */
 	public function test_get_item_from_different_site_as_site_administrator() {
 		switch_to_blog( self::$site );
-		$user_id = $this->factory->user->create(
+		$user_id = self::factory()->user->create(
 			array(
 				'role' => 'author',
 			)
@@ -2851,7 +2851,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	 */
 	public function test_get_item_from_different_site_as_network_administrator() {
 		switch_to_blog( self::$site );
-		$user_id = $this->factory->user->create(
+		$user_id = self::factory()->user->create(
 			array(
 				'role' => 'author',
 			)
@@ -2871,7 +2871,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	 */
 	public function test_update_item_from_different_site_as_site_administrator() {
 		switch_to_blog( self::$site );
-		$user_id = $this->factory->user->create(
+		$user_id = self::factory()->user->create(
 			array(
 				'role' => 'author',
 			)
@@ -2893,7 +2893,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	 */
 	public function test_update_item_from_different_site_as_network_administrator() {
 		switch_to_blog( self::$site );
-		$user_id = $this->factory->user->create(
+		$user_id = self::factory()->user->create(
 			array(
 				'role' => 'author',
 			)
@@ -2915,7 +2915,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	 */
 	public function test_delete_item_from_different_site_as_site_administrator() {
 		switch_to_blog( self::$site );
-		$user_id = $this->factory->user->create(
+		$user_id = self::factory()->user->create(
 			array(
 				'role' => 'author',
 			)
@@ -2937,7 +2937,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	 */
 	public function test_delete_item_from_different_site_as_network_administrator() {
 		switch_to_blog( self::$site );
-		$user_id = $this->factory->user->create(
+		$user_id = self::factory()->user->create(
 			array(
 				'role' => 'author',
 			)

--- a/tests/phpunit/tests/rest-api/wpRestBlockPatternCategoriesController.php
+++ b/tests/phpunit/tests/rest-api/wpRestBlockPatternCategoriesController.php
@@ -136,7 +136,7 @@ class Tests_REST_WpRestBlockPatternCategoriesController extends WP_Test_REST_Con
 	 */
 	public function test_get_items_forbidden() {
 		// Set current user without `edit_posts` capability.
-		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'subscriber' ) ) );
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
 
 		$request  = new WP_REST_Request( 'GET', static::REQUEST_ROUTE );
 		$response = rest_do_request( $request );

--- a/tests/phpunit/tests/rest-api/wpRestBlockPatternsController.php
+++ b/tests/phpunit/tests/rest-api/wpRestBlockPatternsController.php
@@ -162,7 +162,7 @@ class Tests_REST_WpRestBlockPatternsController extends WP_Test_REST_Controller_T
 	 */
 	public function test_get_items_forbidden() {
 		// Set current user without `edit_posts` capability.
-		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'subscriber' ) ) );
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
 
 		$request  = new WP_REST_Request( 'GET', static::REQUEST_ROUTE );
 		$response = rest_do_request( $request );

--- a/tests/phpunit/tests/rest-api/wpRestMenusController.php
+++ b/tests/phpunit/tests/rest-api/wpRestMenusController.php
@@ -85,7 +85,7 @@ class Tests_REST_WpRestMenusController extends WP_Test_REST_Controller_Testcase 
 			'taxonomy'    => 'nav_menu',
 		);
 
-		$this->menu_id = $this->factory->term->create( $orig_args );
+		$this->menu_id = self::factory()->term->create( $orig_args );
 
 		register_meta(
 			'term',
@@ -133,7 +133,7 @@ class Tests_REST_WpRestMenusController extends WP_Test_REST_Controller_Testcase 
 		$this->assertSameSets( array( 'view', 'embed', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
 		$this->assertSame( array( 'v1' => true ), $data['endpoints'][0]['allow_batch'] );
 		// Single.
-		$tag1     = $this->factory->tag->create( array( 'name' => 'Season 5' ) );
+		$tag1     = self::factory()->tag->create( array( 'name' => 'Season 5' ) );
 		$request  = new WP_REST_Request( 'OPTIONS', '/wp/v2/menus/' . $tag1 );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();

--- a/tests/phpunit/tests/taxonomy.php
+++ b/tests/phpunit/tests/taxonomy.php
@@ -681,13 +681,13 @@ class Tests_Taxonomy extends WP_UnitTestCase {
 				'publicly_queryable' => false,
 			)
 		);
-		$t = $this->factory->term->create_and_get(
+		$t = self::factory()->term->create_and_get(
 			array(
 				'taxonomy' => 'wptests_tax',
 			)
 		);
 
-		$p = $this->factory->post->create();
+		$p = self::factory()->post->create();
 		wp_set_object_terms( $p, $t->slug, 'wptests_tax' );
 
 		add_filter( 'do_parse_request', array( $this, 'register_query_var' ) );

--- a/tests/phpunit/tests/term/cache.php
+++ b/tests/phpunit/tests/term/cache.php
@@ -244,7 +244,7 @@ class Tests_Term_Cache extends WP_UnitTestCase {
 	public function test_get_term_by_slug_cache() {
 		global $wpdb;
 
-		$term_id = $this->factory->term->create(
+		$term_id = self::factory()->term->create(
 			array(
 				'slug'     => 'burrito',
 				'name'     => 'Taco',
@@ -275,7 +275,7 @@ class Tests_Term_Cache extends WP_UnitTestCase {
 	public function test_get_term_by_slug_cache_update() {
 		global $wpdb;
 
-		$term_id = $this->factory->term->create(
+		$term_id = self::factory()->term->create(
 			array(
 				'slug'     => 'burrito',
 				'name'     => 'Taco',
@@ -313,7 +313,7 @@ class Tests_Term_Cache extends WP_UnitTestCase {
 	public function test_get_term_by_name_cache() {
 		global $wpdb;
 
-		$term_id = $this->factory->term->create(
+		$term_id = self::factory()->term->create(
 			array(
 				'name'     => 'Burrito',
 				'slug'     => 'noburrito',
@@ -342,7 +342,7 @@ class Tests_Term_Cache extends WP_UnitTestCase {
 	public function test_get_term_by_name_cache_update() {
 		global $wpdb;
 
-		$term_id = $this->factory->term->create(
+		$term_id = self::factory()->term->create(
 			array(
 				'name'     => 'Burrito',
 				'slug'     => 'noburrito',
@@ -377,7 +377,7 @@ class Tests_Term_Cache extends WP_UnitTestCase {
 	public function test_invalidating_term_caches_should_fail_when_invalidation_is_suspended() {
 		global $wpdb;
 
-		$term_id = $this->factory->term->create(
+		$term_id = self::factory()->term->create(
 			array(
 				'name'     => 'Burrito',
 				'taxonomy' => 'post_tag',
@@ -420,7 +420,7 @@ class Tests_Term_Cache extends WP_UnitTestCase {
 	public function test_get_term_by_does_not_prime_term_meta_cache() {
 		global $wpdb;
 
-		$term_id = $this->factory->term->create(
+		$term_id = self::factory()->term->create(
 			array(
 				'name'     => 'Burrito',
 				'taxonomy' => 'post_tag',

--- a/tests/phpunit/tests/term/getTermBy.php
+++ b/tests/phpunit/tests/term/getTermBy.php
@@ -196,7 +196,7 @@ class Tests_Term_GetTermBy extends WP_UnitTestCase {
 	public function test_query_should_not_contain_order_by_clause() {
 		global $wpdb;
 
-		$term_id = $this->factory->term->create(
+		$term_id = self::factory()->term->create(
 			array(
 				'name'     => 'burrito',
 				'taxonomy' => 'post_tag',
@@ -211,7 +211,7 @@ class Tests_Term_GetTermBy extends WP_UnitTestCase {
 	 * @ticket 21760
 	 */
 	public function test_query_should_contain_limit_clause() {
-		$term_id = $this->factory->term->create(
+		$term_id = self::factory()->term->create(
 			array(
 				'name'     => 'burrito',
 				'taxonomy' => 'post_tag',
@@ -242,7 +242,7 @@ class Tests_Term_GetTermBy extends WP_UnitTestCase {
 	public function test_get_term_by_name_with_string_0() {
 		register_taxonomy( 'wptests_tax', 'post', array( 'hierarchical' => true ) );
 
-		$term_id = $this->factory->term->create(
+		$term_id = self::factory()->term->create(
 			array(
 				'name'     => '0',
 				'taxonomy' => 'wptests_tax',
@@ -259,7 +259,7 @@ class Tests_Term_GetTermBy extends WP_UnitTestCase {
 	public function test_get_term_by_slug_with_string_0() {
 		register_taxonomy( 'wptests_tax', 'post', array( 'hierarchical' => true ) );
 
-		$term_id = $this->factory->term->create(
+		$term_id = self::factory()->term->create(
 			array(
 				'taxonomy' => 'wptests_tax',
 				'name'     => '0',

--- a/tests/phpunit/tests/term/isTermPubliclyViewable.php
+++ b/tests/phpunit/tests/term/isTermPubliclyViewable.php
@@ -25,7 +25,7 @@ class Tests_Term_IsTermPubliclyViewable extends WP_UnitTestCase {
 	 * @param bool   $expected The expected result of the function call.
 	 */
 	public function test_is_term_publicly_viewable( $taxonomy, $expected ) {
-		$term_id = $this->factory()->term->create(
+		$term_id = self::factory()->term->create(
 			array(
 				'taxonomy' => $taxonomy,
 			)

--- a/tests/phpunit/tests/term/termCounts.php
+++ b/tests/phpunit/tests/term/termCounts.php
@@ -90,7 +90,7 @@ class Tests_Term_termCount extends WP_UnitTestCase {
 	public function test_term_count_changes_for_post_statuses( $post_status, $change ) {
 		$term_count = get_term( get_option( 'default_category' ) )->count;
 		// Do not use shared fixture for this test as it relies on a new post.
-		$post_id = $this->factory()->post->create( array( 'post_status' => $post_status ) );
+		$post_id = self::factory()->post->create( array( 'post_status' => $post_status ) );
 
 		$expected = $term_count + $change;
 		$this->assertSame( $expected, get_term( get_option( 'default_category' ) )->count );
@@ -244,7 +244,7 @@ class Tests_Term_termCount extends WP_UnitTestCase {
 
 		add_filter( 'update_post_term_count_statuses', array( $this, 'add_custom_status_to_counted_statuses' ) );
 
-		$post_id = $this->factory()->post->create( array( 'post_status' => $post_status ) );
+		$post_id = self::factory()->post->create( array( 'post_status' => $post_status ) );
 		wp_add_object_terms( $post_id, self::$attachment_term, 'wp_test_tax_counts' );
 		$attachment_id = self::factory()->attachment->create_object(
 			array(
@@ -296,7 +296,7 @@ class Tests_Term_termCount extends WP_UnitTestCase {
 	public function test_term_count_changes_for_post_statuses_with_attachments( $post_status, $change ) {
 		$term_count = get_term( self::$attachment_term )->count;
 		// Do not use shared fixture for this test as it relies on a new post.
-		$post_id = $this->factory()->post->create( array( 'post_status' => $post_status ) );
+		$post_id = self::factory()->post->create( array( 'post_status' => $post_status ) );
 		wp_add_object_terms( $post_id, self::$attachment_term, 'wp_test_tax_counts' );
 		$attachment_id = self::factory()->attachment->create_object(
 			array(

--- a/tests/phpunit/tests/theme.php
+++ b/tests/phpunit/tests/theme.php
@@ -366,7 +366,7 @@ class Tests_Theme extends WP_UnitTestCase {
 	 * @covers ::_wp_keep_alive_customize_changeset_dependent_auto_drafts
 	 */
 	public function test_wp_keep_alive_customize_changeset_dependent_auto_drafts() {
-		$nav_created_post_ids = $this->factory()->post->create_many(
+		$nav_created_post_ids = self::factory()->post->create_many(
 			2,
 			array(
 				'post_status' => 'auto-draft',

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -1696,7 +1696,7 @@ class Tests_User extends WP_UnitTestCase {
 		reset_phpmailer_instance();
 		$was_confirmation_email_sent = false;
 
-		$user = $this->factory()->user->create_and_get(
+		$user = self::factory()->user->create_and_get(
 			array(
 				'user_email' => 'before@example.com',
 			)
@@ -1733,7 +1733,7 @@ class Tests_User extends WP_UnitTestCase {
 		reset_phpmailer_instance();
 		$was_confirmation_email_sent = false;
 
-		$user = $this->factory()->user->create_and_get(
+		$user = self::factory()->user->create_and_get(
 			array(
 				'user_email' => 'before@example.com',
 			)

--- a/tests/phpunit/tests/user/capabilities.php
+++ b/tests/phpunit/tests/user/capabilities.php
@@ -1828,7 +1828,7 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 		$contributor = self::$users['contributor'];
 
 		// Give them a scheduled post.
-		$post = $this->factory->post->create_and_get(
+		$post = self::factory()->post->create_and_get(
 			array(
 				'post_author' => $contributor->ID,
 				'post_status' => 'future',

--- a/tests/phpunit/tests/user/query.php
+++ b/tests/phpunit/tests/user/query.php
@@ -1665,7 +1665,7 @@ class Tests_User_Query extends WP_UnitTestCase {
 	 */
 	public function test_search_by_display_name_only() {
 
-		$new_user1          = $this->factory->user->create(
+		$new_user1          = self::factory()->user->create(
 			array(
 				'user_login'   => 'name1',
 				'display_name' => 'Sophia Andresen',
@@ -1693,7 +1693,7 @@ class Tests_User_Query extends WP_UnitTestCase {
 	 */
 	public function test_search_by_display_name_only_ignore_others() {
 
-		$new_user1          = $this->factory->user->create(
+		$new_user1          = self::factory()->user->create(
 			array(
 				'user_login'   => 'Sophia Andresen',
 				'display_name' => 'name1',

--- a/tests/phpunit/tests/user/wpDropdownUsers.php
+++ b/tests/phpunit/tests/user/wpDropdownUsers.php
@@ -13,7 +13,7 @@ class Tests_User_wpDropdownUsers extends WP_UnitTestCase {
 	public function test_default_value_of_show_should_be_display_name() {
 
 		// Create a user with a different display_name.
-		$u = $this->factory->user->create(
+		$u = self::factory()->user->create(
 			array(
 				'user_login'   => 'foo',
 				'display_name' => 'Foo Person',
@@ -37,7 +37,7 @@ class Tests_User_wpDropdownUsers extends WP_UnitTestCase {
 	public function test_show_should_display_display_name_show_is_specified_as_empty() {
 
 		// Create a user with a different display_name.
-		$u = $this->factory->user->create(
+		$u = self::factory()->user->create(
 			array(
 				'user_login'   => 'foo',
 				'display_name' => 'Foo Person',
@@ -63,7 +63,7 @@ class Tests_User_wpDropdownUsers extends WP_UnitTestCase {
 	public function test_show_should_display_user_property_when_the_value_of_show_is_a_valid_user_property() {
 
 		// Create a user with a different display_name.
-		$u = $this->factory->user->create(
+		$u = self::factory()->user->create(
 			array(
 				'user_login'   => 'foo',
 				'display_name' => 'Foo Person',
@@ -89,7 +89,7 @@ class Tests_User_wpDropdownUsers extends WP_UnitTestCase {
 	public function test_show_display_name_with_login() {
 
 		// Create a user with a different display_name.
-		$u = $this->factory->user->create(
+		$u = self::factory()->user->create(
 			array(
 				'user_login'   => 'foo',
 				'display_name' => 'Foo Person',

--- a/tests/phpunit/tests/widgets/wpWidgetCustomHtml.php
+++ b/tests/phpunit/tests/widgets/wpWidgetCustomHtml.php
@@ -172,7 +172,7 @@ class Tests_Widgets_wpWidgetCustomHtml extends WP_UnitTestCase {
 		);
 
 		wp_set_current_user(
-			$this->factory()->user->create(
+			self::factory()->user->create(
 				array(
 					'role' => 'administrator',
 				)
@@ -241,7 +241,7 @@ class Tests_Widgets_wpWidgetCustomHtml extends WP_UnitTestCase {
 	 * @covers WP_Widget_Custom_HTML::enqueue_admin_scripts
 	 */
 	public function test_enqueue_admin_scripts_when_logged_in_and_syntax_highlighting_on() {
-		$user = $this->factory()->user->create();
+		$user = self::factory()->user->create();
 		wp_set_current_user( $user );
 		wp_get_current_user()->syntax_highlighting = 'true';
 		set_current_screen( 'widgets.php' );
@@ -262,7 +262,7 @@ class Tests_Widgets_wpWidgetCustomHtml extends WP_UnitTestCase {
 	 * @covers WP_Widget_Custom_HTML::enqueue_admin_scripts
 	 */
 	public function test_enqueue_admin_scripts_when_logged_in_and_syntax_highlighting_off() {
-		$user = $this->factory()->user->create();
+		$user = self::factory()->user->create();
 		wp_set_current_user( $user );
 		update_user_meta( $user, 'syntax_highlighting', 'false' );
 		set_current_screen( 'widgets.php' );

--- a/tests/phpunit/tests/widgets/wpWidgetMedia.php
+++ b/tests/phpunit/tests/widgets/wpWidgetMedia.php
@@ -116,7 +116,7 @@ class Tests_Widgets_wpWidgetMedia extends WP_UnitTestCase {
 	public function test_constructor_in_customize_preview() {
 		global $wp_customize;
 		wp_set_current_user(
-			$this->factory()->user->create(
+			self::factory()->user->create(
 				array(
 					'role' => 'administrator',
 				)
@@ -159,7 +159,7 @@ class Tests_Widgets_wpWidgetMedia extends WP_UnitTestCase {
 		$this->assertFalse( $widget->is_attachment_with_mime_type( 0, 'image' ) );
 		$this->assertFalse( $widget->is_attachment_with_mime_type( -123, 'image' ) );
 
-		$post_id = $this->factory()->post->create();
+		$post_id = self::factory()->post->create();
 		$this->assertFalse( $widget->is_attachment_with_mime_type( $post_id, 'image' ) );
 		$this->assertFalse( $widget->is_attachment_with_mime_type( $attachment_id, 'video' ) );
 		$this->assertTrue( $widget->is_attachment_with_mime_type( $attachment_id, 'image' ) );

--- a/tests/phpunit/tests/widgets/wpWidgetText.php
+++ b/tests/phpunit/tests/widgets/wpWidgetText.php
@@ -81,7 +81,7 @@ class Tests_Widgets_wpWidgetText extends WP_UnitTestCase {
 	public function test__register_in_customize_preview() {
 		global $wp_customize;
 		wp_set_current_user(
-			$this->factory()->user->create(
+			self::factory()->user->create(
 				array(
 					'role' => 'administrator',
 				)
@@ -315,7 +315,7 @@ class Tests_Widgets_wpWidgetText extends WP_UnitTestCase {
 	 */
 	public function test_widget_shortcodes() {
 		global $post;
-		$post_id = $this->factory()->post->create();
+		$post_id = self::factory()->post->create();
 		$post    = get_post( $post_id );
 
 		$args   = array(
@@ -716,7 +716,7 @@ class Tests_Widgets_wpWidgetText extends WP_UnitTestCase {
 		);
 
 		wp_set_current_user(
-			$this->factory()->user->create(
+			self::factory()->user->create(
 				array(
 					'role' => 'administrator',
 				)


### PR DESCRIPTION
### PHP 8.2 | WP_UnitTestCase_Base: remove magic methods (without BC break)

⚠️ **This PR depends on PR ~~#3127~~, ~~#3128~~ and #3129, which should be merged first (as otherwise the tests will start failing).** ⚠️

Introduced in [35242] in response to Trac#30017 and Trac#33968.

These magic methods were introduced to prevent a BC-break, but in actual fact:
1. _Caused_ a BC break.
    The original `$factory` property was a `static` property and this declared property was replaced by the magic methods.
    Unfortunately, it wasn't realized at the time, that these magic methods **_are not called for static property access_**.
    > Property overloading only works in object context. These magic methods will not be triggered in static context.

    And as approaching a static property in a non-static manner is [not supported in PHP](https://3v4l.org/93HQL), this effectively created a BC-break instead of preventing it.
2. Were hiding errors in tests...
    ... as the magic methods would be invoked for non-existent properties and would return `null` (get)/`false` (isset).
    See PRs #3127, #3128 and #3129 for bug fixes related to this.
3. Are problematic in relation to PHP 8.2...
    ... as the implementation is incomplete, doesn't protect against dynamic properties and hides PHP notices about undefined properties.

Now, there were several options to mitigate this:
1. Revert the original commit.
    This would be problematic, as the _non-static_ version of these properties has now been supported for 7 years, so this would create a new BC-break.
2. Improve the magic methods.
    With all the issues we've seen with magic methods (see the discussion in the [livestream from August 16](https://www.youtube.com/watch?v=vDZWepDQQVE)), this would probably cause more problems than its worth and would make for a much more complex implementation, which is over the top for this relative simple functionality, especially in the context of a test suite.
3. Remove the magic methods without adding the property.
    This would again cause a BC-break, though one for which the mitigation solution would be relatively straight-forward. I.e. to replace property access using `$this->factory` with a function call `$this->factory()` (or `self::factory()` as the method is declared as static).
    While we can (and have in a subsequent commit) mitigate this for the WP Core test suite, mitigating this for integration tests for plugins/themes is outside of our purview and they would still need to deal with this BC-break.
4. The current solution: removing the magic methods and explicitly declaring the (non-static) property and setting it in the `set_up()` method.
    This does not constitute a BC-break with the functionality as it was over the past 7 years.
    Setting the property in `set_up()` may be "late", but that is the earliest place in which the property can be set as non-static.
    If the factory would be needed prior to `set_up()`, the (static) `WP_UnitTestCase_Base::factory()` method should be called directly. This is no different from how this functionality behaved over the past 7 years.

Note: I've straight-away marked the property as "deprecated" as the method should be favoured over the use of the property.

Refs:
* https://www.php.net/manual/en/language.oop5.overloading.php#object.get

---

While working on the above commit, I have investigated how the factory method and property were used in the WP Core test suite.

These were my findings:
* Direct use of the property in tests `$this->factory->...`: 614 instances in 53 test files
* Direct use of the method in tests (non-static) `$this->factory()->...`: 131 instances in 38 test files
* Direct use of the method in tests (static) `[self|static|parent]::factory()->...`: 3441 instances in 268 test files

The use of static function calls to the `factory()` method clearly wins out and this is in line with the original intention of the changes which were made in [35242].

With that in mind, I've created the two below commits which fix the non-static usages of the method and usages of the property within the WP Core test suite.

---

### Tests: correctly use the factory method

This replaces all non-static calls to the `WP_UnitTestCase_Base::factory()` method with static function calls as the method is declared as static.

This is a consistency improvement for the test suite.

Follow up to [35242].

### Tests: use the factory method instead of the property

This replaces all references to the `WP_UnitTestCase_Base::$factory` property with static function calls to the `WP_UnitTestCase_Base::factory()` method.

This is a consistency improvement for the test suite.

Follow up to [35242].



Trac ticket: https://core.trac.wordpress.org/ticket/56514 (first commit)
Trac ticket: https://core.trac.wordpress.org/ticket/55652 (second + third commit)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
