### PR TITLE
Honor postTypes property in theme's theme.json when getting templates from post

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -552,10 +552,8 @@ function _build_block_template_result_from_post( $post ) {
 	}
 
 	$theme          = $terms[0]->name;
-	$template_file = null;
-	if ( wp_get_theme()->get_stylesheet() === $theme ) {
-		$template_file = _get_block_template_file( $post->post_type, $post->post_name );
-	}
+	$template_file = _get_block_template_file( $post->post_type, $post->post_name );
+	$has_theme_file = wp_get_theme()->get_stylesheet() === $theme && null !== $template_file;
 
 	$origin = get_post_meta( $post->ID, 'origin', true );
 
@@ -571,11 +569,11 @@ function _build_block_template_result_from_post( $post ) {
 	$template->description    = $post->post_excerpt;
 	$template->title          = $post->post_title;
 	$template->status         = $post->post_status;
-	$template->has_theme_file = null !== $template_file;
+	$template->has_theme_file = $has_theme_file;
 	$template->is_custom      = true;
 	$template->author         = $post->post_author;
 
-	if ( null !== $template_file && isset( $template_file['postTypes'] ) ) {
+	if ( 'wp_template' === $post->post_type && $has_theme_file && isset( $template_file['postTypes'] ) ) {
 		$template->post_types = $template_file['postTypes'];
 	}
 

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -552,8 +552,10 @@ function _build_block_template_result_from_post( $post ) {
 	}
 
 	$theme          = $terms[0]->name;
-	$has_theme_file = wp_get_theme()->get_stylesheet() === $theme &&
-		null !== _get_block_template_file( $post->post_type, $post->post_name );
+	$template_file = null;
+	if ( wp_get_theme()->get_stylesheet() === $theme ) {
+		$template_file = _get_block_template_file( $post->post_type, $post->post_name );
+	}
 
 	$origin = get_post_meta( $post->ID, 'origin', true );
 
@@ -569,9 +571,13 @@ function _build_block_template_result_from_post( $post ) {
 	$template->description    = $post->post_excerpt;
 	$template->title          = $post->post_title;
 	$template->status         = $post->post_status;
-	$template->has_theme_file = $has_theme_file;
+	$template->has_theme_file = null !== $template_file;
 	$template->is_custom      = true;
 	$template->author         = $post->post_author;
+
+	if ( null !== $template_file && isset( $template_file['postTypes'] ) ) {
+		$template->post_types = $template_file['postTypes'];
+	}
 
 	if ( 'wp_template' === $post->post_type && isset( $default_template_types[ $template->slug ] ) ) {
 		$template->is_custom = false;
@@ -672,6 +678,13 @@ function get_block_templates( $query = array(), $template_type = 'wp_template' )
 		}
 
 		if ( $post_type && ! $template->is_custom ) {
+			continue;
+		}
+
+		if ( $post_type &&
+			isset( $template->post_types ) &&
+			! in_array( $post_type, $template->post_types, true )
+		) {
 			continue;
 		}
 

--- a/tests/phpunit/data/themedir1/block-theme/templates/custom-single-post-template.html
+++ b/tests/phpunit/data/themedir1/block-theme/templates/custom-single-post-template.html
@@ -1,0 +1,3 @@
+<!-- wp:paragraph -->
+<p>Custom Single Post template</p>
+<!-- /wp:paragraph -->

--- a/tests/phpunit/data/themedir1/block-theme/theme.json
+++ b/tests/phpunit/data/themedir1/block-theme/theme.json
@@ -58,6 +58,11 @@
 		{
 			"name": "page-home",
 			"title": "Homepage template"
+		},
+		{
+			"name": "custom-single-post-template",
+			"title": "Custom Single Post template",
+			"postTypes": ["post"]
 		}
 	],
 	"templateParts": [

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -337,26 +337,61 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 			$template_ids
 		);
 		*/
+	}
 
-		// Filter by post type.
-		$templates    = get_block_templates( array( 'post_type' => 'post' ), 'wp_template' );
-		$template_ids = get_template_ids( $templates );
+	/**
+	 * @dataProvider data_get_block_template_should_respect_posttypes_property
+	 * @ticket 55881
+	 * @covers ::get_block_templates
+	 *
+	 * @param string $post_type Post type for query.
+	 * @param array  $expected  Expected template IDs.
+	 */
+	public function test_get_block_template_should_respect_posttypes_property( $post_type, $expected ) {
+		$templates = get_block_templates( array( 'post_type' => $post_type ) );
+
 		$this->assertSame(
-			array(
-				get_stylesheet() . '//' . 'my_template',
-				get_stylesheet() . '//' . 'custom-single-post-template',
-			),
-			$template_ids
+			$expected,
+			$this->get_template_ids( $templates )
 		);
+	}
 
-		$templates    = get_block_templates( array( 'post_type' => 'page' ), 'wp_template' );
-		$template_ids = get_template_ids( $templates );
-		$this->assertSame(
-			array(
-				get_stylesheet() . '//' . 'my_template',
-				get_stylesheet() . '//' . 'page-home',
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_get_block_template_should_respect_posttypes_property() {
+		return array(
+			'post' => array(
+				'post_type' => 'post',
+				'expected'  => array(
+					'block-theme//my_template',
+					'block-theme//custom-single-post-template',
+				),
 			),
-			$template_ids
+			'page' => array(
+				'post_type' => 'page',
+				'expected'  => array(
+					'block-theme//my_template',
+					'block-theme//page-home',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Gets the template IDs from the given array.
+	 *
+	 * @param object[] $templates Array of template objects to parse.
+	 * @return string[] The template IDs.
+	 */
+	private function get_template_ids( $templates ) {
+		return array_map(
+			static function( $template ) {
+				return $template->id;
+			},
+			$templates
 		);
 	}
 

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -12,6 +12,7 @@
  */
 class Tests_Block_Template_Utils extends WP_UnitTestCase {
 	private static $post;
+	private static $custom_single_post_template_post;
 	private static $template_part_post;
 	private static $test_theme = 'block-theme';
 
@@ -50,6 +51,22 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		self::$post = self::factory()->post->create_and_get( $args );
 		wp_set_post_terms( self::$post->ID, self::$test_theme, 'wp_theme' );
 
+		// Set up template post.
+		$args                                   = array(
+			'post_type'    => 'wp_template',
+			'post_name'    => 'custom-single-post-template',
+			'post_title'   => 'Custom Single Post template (modified)',
+			'post_content' => 'Content',
+			'post_excerpt' => 'Description of custom single post template',
+			'tax_input'    => array(
+				'wp_theme' => array(
+					self::$test_theme,
+				),
+			),
+		);
+		self::$custom_single_post_template_post = self::factory()->post->create_and_get( $args );
+		wp_set_post_terms( self::$custom_single_post_template_post->ID, self::$test_theme, 'wp_theme' );
+
 		// Set up template part post.
 		$template_part_args       = array(
 			'post_type'    => 'wp_template_part',
@@ -78,6 +95,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 
 	public static function wpTearDownAfterClass() {
 		wp_delete_post( self::$post->ID );
+		wp_delete_post( self::$custom_single_post_template_post->ID );
 	}
 
 	public function test_build_block_template_result_from_post() {
@@ -319,6 +337,27 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 			$template_ids
 		);
 		*/
+
+		// Filter by post type.
+		$templates    = get_block_templates( array( 'post_type' => 'post' ), 'wp_template' );
+		$template_ids = get_template_ids( $templates );
+		$this->assertSame(
+			array(
+				get_stylesheet() . '//' . 'my_template',
+				get_stylesheet() . '//' . 'custom-single-post-template',
+			),
+			$template_ids
+		);
+
+		$templates    = get_block_templates( array( 'post_type' => 'page' ), 'wp_template' );
+		$template_ids = get_template_ids( $templates );
+		$this->assertSame(
+			array(
+				get_stylesheet() . '//' . 'my_template',
+				get_stylesheet() . '//' . 'page-home',
+			),
+			$template_ids
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/theme/wpThemeJsonResolver.php
+++ b/tests/phpunit/tests/theme/wpThemeJsonResolver.php
@@ -154,14 +154,15 @@ class Tests_Theme_wpThemeJsonResolver extends WP_UnitTestCase {
 			),
 			$theme_data->get_settings()
 		);
-		$this->assertSameSets(
+
+		$custom_templates = $theme_data->get_custom_templates();
+		$this->assertArrayHasKey( 'page-home', $custom_templates );
+		$this->assertSame(
+			$custom_templates['page-home'],
 			array(
-				'page-home' => array(
-					'title'     => 'Szablon strony głównej',
-					'postTypes' => array( 'page' ),
-				),
-			),
-			$theme_data->get_custom_templates()
+				'title'     => 'Szablon strony głównej',
+				'postTypes' => array( 'page' ),
+			)
 		);
 		$this->assertSameSets(
 			array(
@@ -340,9 +341,13 @@ class Tests_Theme_wpThemeJsonResolver extends WP_UnitTestCase {
 		$this->assertSame(
 			WP_Theme_JSON_Resolver::get_theme_data()->get_custom_templates(),
 			array(
-				'page-home' => array(
+				'page-home'                   => array(
 					'title'     => 'Homepage',
 					'postTypes' => array( 'page' ),
+				),
+				'custom-single-post-template' => array(
+					'title'     => 'Custom Single Post template',
+					'postTypes' => array( 'post' ),
 				),
 			)
 		);


### PR DESCRIPTION
When loading a block template from post (ie: the user had made some modifications to it), WP was not setting the `post_types` attribute for that template. That caused templates specific to some post types to show available for all.

Trac ticket: https://core.trac.wordpress.org/ticket/55881#ticket

## Steps to test
1. With a block theme, create two templates and add them to theme.json:
```JSON
{
	"version": 2,
	"customTemplates": [
		....
		{
			"name": "custom-single-post-template",
			"title": "Custom Single Post template",
			"postTypes": [
				"post"
			]
		},
		{
			"name": "custom-single-post-template-not-modified",
			"title": "Custom Single Post template (not modified)",
			"postTypes": [
				"post"
			]
		}
	],
	...
}
```
2. Go to Appearance > Editor > Templates and make a modification to _Custom Single Post template_.
3. Now, create a new page.
4. Verify in the Template panel in the sidebar neither _Custom Single Post template_ nor _Custom Single Post template (not modified)_ are available.

Before | After
--- | ---
![Screenshot showing the Template selector witho a Custom Single Post Template option](https://user-images.githubusercontent.com/3616980/186490258-915e7e9e-2465-40a7-8f64-91b0b3cec3b4.png) | ![Screenshot showing the Template selector without a Custom Single Post Template option](https://user-images.githubusercontent.com/3616980/186490105-a144a1ea-27d6-4e6f-9bc2-470298431a83.png)
