### PR TITLE
Guard `wp_strip_all_tags()` against non-string `$string` argument.

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -5400,6 +5400,11 @@ function wp_strip_all_tags( $text, $remove_breaks = false ) {
 
 	if ( ! is_scalar( $text ) ) {
 		if ( WP_DEBUG ) {
+			/*
+			 * To maintain consistency with pre-PHP 8 error levels,
+			 * trigger_error() is used to trigger an E_USER_WARNING,
+			 * rather than _doing_it_wrong(), which triggers an E_USER_NOTICE.
+			 */
 			trigger_error(
 				sprintf(
 					/* translators: 1: The function name, 2: The argument number, 3: The argument name, 4: The expected type, 5: The provided type. */

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -5402,10 +5402,11 @@ function wp_strip_all_tags( $text, $remove_breaks = false ) {
 		if ( WP_DEBUG ) {
 			trigger_error(
 				sprintf(
-					/* translators: 1: The function name, 2: The argument number, 3: The expected type, 4: The provided type. */
-					__( 'Warning: %1$s expects parameter %2$d to be a %3$s, %4$s given.' ),
+					/* translators: 1: The function name, 2: The argument number, 3: The argument name, 4: The expected type, 5: The provided type. */
+					__( 'Warning: %1$s expects parameter %2$s (%3$s) to be a %4$s, %5$s given.' ),
 					__FUNCTION__,
-					'1',
+					'#1',
+					'$text',
 					'string',
 					gettype( $text )
 				),

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -5394,6 +5394,20 @@ function normalize_whitespace( $str ) {
  * @return string The processed string.
  */
 function wp_strip_all_tags( $text, $remove_breaks = false ) {
+	if ( ! is_string( $text ) ) {
+		_doing_it_wrong(
+			__FUNCTION__,
+			sprintf(
+				/* translators: %s: The `$string` argument. */
+				__( 'The %s argument must be a string' ),
+				'$string'
+			),
+			'6.1.0'
+		);
+
+		return '';
+	}
+
 	$text = preg_replace( '@<(script|style)[^>]*?>.*?</\\1>@si', '', $text );
 	$text = strip_tags( $text );
 

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -5399,25 +5399,23 @@ function wp_strip_all_tags( $text, $remove_breaks = false ) {
 	}
 
 	if ( ! is_scalar( $text ) ) {
-		if ( WP_DEBUG ) {
-			/*
-			 * To maintain consistency with pre-PHP 8 error levels,
-			 * trigger_error() is used to trigger an E_USER_WARNING,
-			 * rather than _doing_it_wrong(), which triggers an E_USER_NOTICE.
-			 */
-			trigger_error(
-				sprintf(
-					/* translators: 1: The function name, 2: The argument number, 3: The argument name, 4: The expected type, 5: The provided type. */
-					__( 'Warning: %1$s expects parameter %2$s (%3$s) to be a %4$s, %5$s given.' ),
-					__FUNCTION__,
-					'#1',
-					'$text',
-					'string',
-					gettype( $text )
-				),
-				E_USER_WARNING
-			);
-		}
+		/*
+		 * To maintain consistency with pre-PHP 8 error levels,
+		 * trigger_error() is used to trigger an E_USER_WARNING,
+		 * rather than _doing_it_wrong(), which triggers an E_USER_NOTICE.
+		 */
+		trigger_error(
+			sprintf(
+				/* translators: 1: The function name, 2: The argument number, 3: The argument name, 4: The expected type, 5: The provided type. */
+				__( 'Warning: %1$s expects parameter %2$s (%3$s) to be a %4$s, %5$s given.' ),
+				__FUNCTION__,
+				'#1',
+				'$text',
+				'string',
+				gettype( $text )
+			),
+			E_USER_WARNING
+		);
 
 		return '';
 	}

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -5394,13 +5394,17 @@ function normalize_whitespace( $str ) {
  * @return string The processed string.
  */
 function wp_strip_all_tags( $text, $remove_breaks = false ) {
+	if ( is_null( $text ) ) {
+		return '';
+	}
+
 	if ( ! is_string( $text ) ) {
 		_doing_it_wrong(
 			__FUNCTION__,
 			sprintf(
 				/* translators: %s: The `$string` argument. */
 				__( 'The %s argument must be a string' ),
-				'$string'
+				'$text'
 			),
 			'6.1.0'
 		);

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -5398,7 +5398,7 @@ function wp_strip_all_tags( $text, $remove_breaks = false ) {
 		return '';
 	}
 
-	if ( ! is_string( $text ) ) {
+	if ( ! is_scalar( $text ) ) {
 		if ( WP_DEBUG ) {
 			trigger_error(
 				sprintf(
@@ -5416,6 +5416,7 @@ function wp_strip_all_tags( $text, $remove_breaks = false ) {
 		return '';
 	}
 
+	$text = (string) $text;
 	$text = preg_replace( '@<(script|style)[^>]*?>.*?</\\1>@si', '', $text );
 	$text = strip_tags( $text );
 

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -5399,15 +5399,19 @@ function wp_strip_all_tags( $text, $remove_breaks = false ) {
 	}
 
 	if ( ! is_string( $text ) ) {
-		_doing_it_wrong(
-			__FUNCTION__,
-			sprintf(
-				/* translators: %s: The `$string` argument. */
-				__( 'The %s argument must be a string' ),
-				'$text'
-			),
-			'6.1.0'
-		);
+		if ( WP_DEBUG ) {
+			trigger_error(
+				sprintf(
+					/* translators: 1: The function name, 2: The argument number, 3: The expected type, 4: The provided type. */
+					__( 'Warning: %1$s expects parameter %2$d to be a %3$s, %4$s given.' ),
+					__FUNCTION__,
+					'1',
+					'string',
+					gettype( $text )
+				),
+				E_USER_WARNING
+			);
+		}
 
 		return '';
 	}

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -5416,7 +5416,6 @@ function wp_strip_all_tags( $text, $remove_breaks = false ) {
 		return '';
 	}
 
-	$text = (string) $text;
 	$text = preg_replace( '@<(script|style)[^>]*?>.*?</\\1>@si', '', $text );
 	$text = strip_tags( $text );
 

--- a/tests/phpunit/tests/formatting/wpStripAllTags.php
+++ b/tests/phpunit/tests/formatting/wpStripAllTags.php
@@ -42,7 +42,7 @@ class Tests_Formatting_wpStripAllTags extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that `wp_strip_all_tags()` trigger a warning and returns
+	 * Tests that `wp_strip_all_tags()` triggers a warning and returns
 	 * an empty string when passed a non-string argument.
 	 *
 	 * @ticket 56434

--- a/tests/phpunit/tests/formatting/wpStripAllTags.php
+++ b/tests/phpunit/tests/formatting/wpStripAllTags.php
@@ -31,5 +31,38 @@ class Tests_Formatting_wpStripAllTags extends WP_UnitTestCase {
 		$text = "lorem<style>* { display: 'none' }<script>alert( document.cookie )</script></style>ipsum";
 		$this->assertSame( 'loremipsum', wp_strip_all_tags( $text ) );
 	}
+
+	/**
+	 * Tests that `wp_strip_all_tags()` throws a `_doing_it_wrong()` and returns
+	 * an empty string when passed a non-string `$string` argument.
+	 *
+	 * @ticket 56434
+	 *
+	 * @expectedIncorrectUsage wp_strip_all_tags
+	 *
+	 * @dataProvider data_wp_strip_all_tags_should_throw_doing_it_wrong_for_non_string
+	 *
+	 * @param mixed $non_string A non-string value.
+	 */
+	public function test_wp_strip_all_tags_should_return_empty_string_and_throw_doing_it_wrong_for_non_string_arg( $non_string ) {
+		$this->assertSame( '', wp_strip_all_tags( $non_string ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_wp_strip_all_tags_should_throw_doing_it_wrong_for_non_string() {
+		return array(
+			'(int) 0'           => array( 'non_string' => 0 ),
+			'(int) 1'           => array( 'non_string' => 1 ),
+			'(bool) false'      => array( 'non_string' => false ),
+			'(bool) true'       => array( 'non_string' => true ),
+			'an empty array'    => array( 'non_string' => array() ),
+			'a non-empty array' => array( 'non_string' => array( 'a string' ) ),
+			'an object'         => array( 'non_string' => new stdClass() ),
+		);
+	}
 }
 

--- a/tests/phpunit/tests/formatting/wpStripAllTags.php
+++ b/tests/phpunit/tests/formatting/wpStripAllTags.php
@@ -42,7 +42,7 @@ class Tests_Formatting_wpStripAllTags extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that `wp_strip_all_tags()` throws a `_doing_it_wrong()` and returns
+	 * Tests that `wp_strip_all_tags()` trigger a warning and returns
 	 * an empty string when passed a non-string argument.
 	 *
 	 * @ticket 56434

--- a/tests/phpunit/tests/formatting/wpStripAllTags.php
+++ b/tests/phpunit/tests/formatting/wpStripAllTags.php
@@ -38,22 +38,23 @@ class Tests_Formatting_wpStripAllTags extends WP_UnitTestCase {
 	 *
 	 * @ticket 56434
 	 *
-	 * @expectedIncorrectUsage wp_strip_all_tags
-	 *
-	 * @dataProvider data_wp_strip_all_tags_should_throw_doing_it_wrong_for_non_string
+	 * @dataProvider data_wp_strip_all_tags_should_return_empty_string_and_trigger_an_error_for_non_string_arg
 	 *
 	 * @param mixed $non_string A non-string value.
 	 */
-	public function test_wp_strip_all_tags_should_return_empty_string_and_throw_doing_it_wrong_for_non_string_arg( $non_string ) {
+	public function test_wp_strip_all_tags_should_return_empty_string_and_trigger_an_error_for_non_string_arg( $non_string ) {
+		$type = gettype( $non_string );
+		$this->expectError();
+		$this->expectErrorMessage( "Warning: wp_strip_all_tags expects parameter 1 to be a string, $type given." );
 		$this->assertSame( '', wp_strip_all_tags( $non_string ) );
 	}
 
 	/**
-	 * Data provider.
+	 * Data provider for test_wp_strip_all_tags_should_return_empty_string_and_trigger_an_error_for_non_string_arg().
 	 *
-	 * @return array
+	 * @return array[]
 	 */
-	public function data_wp_strip_all_tags_should_throw_doing_it_wrong_for_non_string() {
+	public function data_wp_strip_all_tags_should_return_empty_string_and_trigger_an_error_for_non_string_arg() {
 		return array(
 			'(int) 0'           => array( 'non_string' => 0 ),
 			'(int) 1'           => array( 'non_string' => 1 ),

--- a/tests/phpunit/tests/formatting/wpStripAllTags.php
+++ b/tests/phpunit/tests/formatting/wpStripAllTags.php
@@ -34,7 +34,7 @@ class Tests_Formatting_wpStripAllTags extends WP_UnitTestCase {
 
 	/**
 	 * Tests that `wp_strip_all_tags()` throws a `_doing_it_wrong()` and returns
-	 * an empty string when passed a non-string `$string` argument.
+	 * an empty string when passed a non-string argument.
 	 *
 	 * @ticket 56434
 	 *
@@ -56,13 +56,38 @@ class Tests_Formatting_wpStripAllTags extends WP_UnitTestCase {
 	 */
 	public function data_wp_strip_all_tags_should_return_empty_string_and_trigger_an_error_for_non_string_arg() {
 		return array(
-			'(int) 0'           => array( 'non_string' => 0 ),
-			'(int) 1'           => array( 'non_string' => 1 ),
-			'(bool) false'      => array( 'non_string' => false ),
-			'(bool) true'       => array( 'non_string' => true ),
 			'an empty array'    => array( 'non_string' => array() ),
 			'a non-empty array' => array( 'non_string' => array( 'a string' ) ),
 			'an object'         => array( 'non_string' => new stdClass() ),
+		);
+	}
+
+	/**
+	 * Tests that `wp_strip_all_tags()` casts scalar values to string.
+	 *
+	 * @ticket 56434
+	 *
+	 * @dataProvider data_wp_strip_all_tags_should_cast_scalar_values_to_string
+	 *
+	 * @param mixed $text A scalar value.
+	 */
+	public function test_wp_strip_all_tags_should_cast_scalar_values_to_string( $text ) {
+		$this->assertSame( (string) $text, wp_strip_all_tags( $text ) );
+	}
+
+	/**
+	 * Data provider for test_wp_strip_all_tags_should_cast_scalar_values_to_string()/
+	 *
+	 * @return array[]
+	 */
+	public function data_wp_strip_all_tags_should_cast_scalar_values_to_string() {
+		return array(
+			'(int) 0'      => array( 'text' => 0 ),
+			'(int) 1'      => array( 'text' => 1 ),
+			'(float) 0.0'  => array( 'text' => 0.0 ),
+			'(float) 1.0'  => array( 'text' => 1.0 ),
+			'(bool) false' => array( 'text' => false ),
+			'(bool) true'  => array( 'text' => true ),
 		);
 	}
 }

--- a/tests/phpunit/tests/formatting/wpStripAllTags.php
+++ b/tests/phpunit/tests/formatting/wpStripAllTags.php
@@ -33,6 +33,15 @@ class Tests_Formatting_wpStripAllTags extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that `wp_strip_all_tags()` returns an empty string when null is passed.
+	 *
+	 * @ticket 56434
+	 */
+	public function test_wp_strip_all_tags_should_return_empty_string_for_a_null_arg() {
+		$this->assertSame( '', wp_strip_all_tags( null ) );
+	}
+
+	/**
 	 * Tests that `wp_strip_all_tags()` throws a `_doing_it_wrong()` and returns
 	 * an empty string when passed a non-string argument.
 	 *
@@ -56,9 +65,10 @@ class Tests_Formatting_wpStripAllTags extends WP_UnitTestCase {
 	 */
 	public function data_wp_strip_all_tags_should_return_empty_string_and_trigger_an_error_for_non_string_arg() {
 		return array(
-			'an empty array'    => array( 'non_string' => array() ),
-			'a non-empty array' => array( 'non_string' => array( 'a string' ) ),
-			'an object'         => array( 'non_string' => new stdClass() ),
+			'an empty array'     => array( 'non_string' => array() ),
+			'a non-empty array'  => array( 'non_string' => array( 'a string' ) ),
+			'an empty object'    => array( 'non_string' => new stdClass() ),
+			'a non-empty object' => array( 'non_string' => (object) array( 'howdy' => 'admin' ) ),
 		);
 	}
 
@@ -84,8 +94,10 @@ class Tests_Formatting_wpStripAllTags extends WP_UnitTestCase {
 		return array(
 			'(int) 0'      => array( 'text' => 0 ),
 			'(int) 1'      => array( 'text' => 1 ),
+			'(int) -1'     => array( 'text' => -1 ),
 			'(float) 0.0'  => array( 'text' => 0.0 ),
 			'(float) 1.0'  => array( 'text' => 1.0 ),
+			'(float) -1.0' => array( 'text' => -1.0 ),
 			'(bool) false' => array( 'text' => false ),
 			'(bool) true'  => array( 'text' => true ),
 		);

--- a/tests/phpunit/tests/formatting/wpStripAllTags.php
+++ b/tests/phpunit/tests/formatting/wpStripAllTags.php
@@ -54,7 +54,7 @@ class Tests_Formatting_wpStripAllTags extends WP_UnitTestCase {
 	public function test_wp_strip_all_tags_should_return_empty_string_and_trigger_an_error_for_non_string_arg( $non_string ) {
 		$type = gettype( $non_string );
 		$this->expectError();
-		$this->expectErrorMessage( "Warning: wp_strip_all_tags expects parameter 1 to be a string, $type given." );
+		$this->expectErrorMessage( "Warning: wp_strip_all_tags expects parameter #1 (\$text) to be a string, $type given." );
 		$this->assertSame( '', wp_strip_all_tags( $non_string ) );
 	}
 


### PR DESCRIPTION
This PR builds on patch `56434.diff`.

Trac ticket: https://core.trac.wordpress.org/ticket/56434