### PR TITLE
Alternate approach: Guard `wp_strip_all_tags()` against non-string values.

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -5390,6 +5390,16 @@ function normalize_whitespace( $str ) {
  * @return string The processed string.
  */
 function wp_strip_all_tags( $string, $remove_breaks = false ) {
+	// Skip processing for non-string values.
+	if ( ! is_string( $string ) ) {
+		return is_scalar( $string ) ? (string) $string : '';
+	}
+
+	// Skip processing for empty strings.
+	if ( '' === trim( $string ) ) {
+		return '';
+	}
+
 	$string = preg_replace( '@<(script|style)[^>]*?>.*?</\\1>@si', '', $string );
 	$string = strip_tags( $string );
 

--- a/tests/phpunit/tests/formatting/wpStripAllTags.php
+++ b/tests/phpunit/tests/formatting/wpStripAllTags.php
@@ -83,6 +83,7 @@ class Tests_Formatting_wpStripAllTags extends WP_UnitTestCase {
 	 */
 	public function data_non_scalar_values() {
 		return array(
+			'null'               => array( 'non_scalar' => null ),
 			'an empty array'     => array( 'non_scalar' => array() ),
 			'a non-empty array'  => array( 'non_scalar' => array( 'howdy', 'admin' ) ),
 			'an empty object'    => array( 'non_scalar' => new stdClass() ),

--- a/tests/phpunit/tests/formatting/wpStripAllTags.php
+++ b/tests/phpunit/tests/formatting/wpStripAllTags.php
@@ -54,8 +54,10 @@ class Tests_Formatting_wpStripAllTags extends WP_UnitTestCase {
 		return array(
 			'(int) 0'      => array( 'scalar' => 0 ),
 			'(int) 1'      => array( 'scalar' => 1 ),
+			'(int) -1'     => array( 'scalar' => -1 ),
 			'(float) 0.0'  => array( 'scalar' => 0.0 ),
 			'(float) 1.0'  => array( 'scalar' => 1.0 ),
+			'(float) -1.0' => array( 'scalar' => -1.0 ),
 			'(bool) false' => array( 'scalar' => false ),
 			'(bool) true'  => array( 'scalar' => true ),
 		);

--- a/tests/phpunit/tests/formatting/wpStripAllTags.php
+++ b/tests/phpunit/tests/formatting/wpStripAllTags.php
@@ -31,5 +31,61 @@ class Tests_Formatting_wpStripAllTags extends WP_UnitTestCase {
 		$text = "lorem<style>* { display: 'none' }<script>alert( document.cookie )</script></style>ipsum";
 		$this->assertSame( 'loremipsum', wp_strip_all_tags( $text ) );
 	}
+
+	/**
+	 * Tests that `wp_strip_all_tags()` casts non-string scalar values to string.
+	 *
+	 * @ticket 56434
+	 *
+	 * @dataProvider data_non_string_scalar_values
+	 *
+	 * @param mixed $scalar A non-string scalar value.
+	 */
+	public function test_wp_strip_all_tags_should_cast_non_string_scalar_values_to_string( $scalar ) {
+		$this->assertSame( (string) $scalar, wp_strip_all_tags( $scalar ) );
+	}
+
+	/**
+	 * Data provider: Provides non-string scalar values.
+	 *
+	 * @return array
+	 */
+	public function data_non_string_scalar_values() {
+		return array(
+			'(int) 0'      => array( 'scalar' => 0 ),
+			'(int) 1'      => array( 'scalar' => 1 ),
+			'(float) 0.0'  => array( 'scalar' => 0.0 ),
+			'(float) 1.0'  => array( 'scalar' => 1.0 ),
+			'(bool) false' => array( 'scalar' => false ),
+			'(bool) true'  => array( 'scalar' => true ),
+		);
+	}
+
+	/**
+	 * Tests that `wp_strip_all_tags()` returns an empty string for non-scalar values.
+	 *
+	 * @ticket 56434
+	 *
+	 * @dataProvider data_non_scalar_values
+	 *
+	 * @param mixed $non_scalar A non-scalar value.
+	 */
+	public function test_wp_strip_all_tags_should_return_an_empty_string_for_non_scalar_values( $non_scalar ) {
+		$this->assertSame( '', wp_strip_all_tags( $non_scalar ) );
+	}
+
+	/**
+	 * Data provider: Provides non-scalar values.
+	 *
+	 * @return array
+	 */
+	public function data_non_scalar_values() {
+		return array(
+			'an empty array'     => array( 'non_scalar' => array() ),
+			'a non-empty array'  => array( 'non_scalar' => array( 'howdy', 'admin' ) ),
+			'an empty object'    => array( 'non_scalar' => new stdClass() ),
+			'a non-empty object' => array( 'non_scalar' => (object) array( 'howdy', 'admin' ) ),
+		);
+	}
 }
 

--- a/tests/phpunit/tests/formatting/wpStripAllTags.php
+++ b/tests/phpunit/tests/formatting/wpStripAllTags.php
@@ -54,6 +54,7 @@ class Tests_Formatting_wpStripAllTags extends WP_UnitTestCase {
 		return array(
 			'(int) 0'      => array( 'scalar' => 0 ),
 			'(int) 1'      => array( 'scalar' => 1 ),
+			'(int) 2'      => array( 'scalar' => 2 ),
 			'(int) -1'     => array( 'scalar' => -1 ),
 			'(float) 0.0'  => array( 'scalar' => 0.0 ),
 			'(float) 1.0'  => array( 'scalar' => 1.0 ),


### PR DESCRIPTION
This PR provides an alternate approach to [PR 3132](https://github.com/WordPress/wordpress-develop/pull/3132).

I put this into a separate PR to make it easier to review changes against Core and to compare the approaches.

Trac ticket: https://core.trac.wordpress.org/ticket/56434
