### PR TITLE
TT2: Add Comments block pattern

### DIFF
--- a/src/wp-content/themes/twentytwentytwo/functions.php
+++ b/src/wp-content/themes/twentytwentytwo/functions.php
@@ -65,3 +65,26 @@ add_action( 'wp_enqueue_scripts', 'twentytwentytwo_styles' );
 
 // Add block patterns
 require get_template_directory() . '/inc/block-patterns.php';
+
+/**
+ * Change post comments block heading.
+ *
+ * @param  string $block_content Block content to be rendered.
+ * @param  array  $block         Block attributes.
+ * @return string
+ */
+function twentytwentytwo_post_comments_block_heading( $block_content = '', $block = array() ) {
+	if ( isset( $block['blockName'] ) && 'core/post-comments' === $block['blockName'] ) {
+
+		$html = str_replace(
+			'h3',
+			'h2',
+			$block_content
+		);
+
+		return $html;
+	}
+	return $block_content;
+}
+
+add_filter( 'render_block', 'twentytwentytwo_post_comments_block_heading', 10, 2 );

--- a/src/wp-content/themes/twentytwentytwo/functions.php
+++ b/src/wp-content/themes/twentytwentytwo/functions.php
@@ -67,7 +67,7 @@ add_action( 'wp_enqueue_scripts', 'twentytwentytwo_styles' );
 require get_template_directory() . '/inc/block-patterns.php';
 
 /**
- * Change post comments block heading.
+ * Changes Post Comments block heading.
  *
  * @param  string $block_content Block content to be rendered.
  * @param  array  $block         Block attributes.

--- a/src/wp-content/themes/twentytwentytwo/inc/block-patterns.php
+++ b/src/wp-content/themes/twentytwentytwo/inc/block-patterns.php
@@ -45,7 +45,6 @@ function twentytwentytwo_register_block_patterns() {
 	}
 
 	$block_patterns = array(
-		'comments',
 		'footer-default',
 		'footer-dark',
 		'footer-logo',
@@ -133,4 +132,21 @@ function twentytwentytwo_register_block_patterns() {
 		);
 	}
 }
-add_action( 'init', 'twentytwentytwo_register_block_patterns', 21 );
+add_action( 'init', 'twentytwentytwo_register_block_patterns', 9 );
+
+/**
+ * Registers comment block pattern.
+ *
+ * @since Twenty Twenty-Two 1.2
+ *
+ * @return void
+ */
+function twentytwentytwo_register_comments_patterns() {
+
+	register_block_pattern(
+		'twentytwentytwo/comments',
+		require get_theme_file_path( '/inc/patterns/comments.php' )
+	);
+
+}
+add_action( 'init', 'twentytwentytwo_register_comments_patterns', 21 );

--- a/src/wp-content/themes/twentytwentytwo/inc/block-patterns.php
+++ b/src/wp-content/themes/twentytwentytwo/inc/block-patterns.php
@@ -133,4 +133,4 @@ function twentytwentytwo_register_block_patterns() {
 		);
 	}
 }
-add_action( 'init', 'twentytwentytwo_register_block_patterns', 9 );
+add_action( 'init', 'twentytwentytwo_register_block_patterns', 21 );

--- a/src/wp-content/themes/twentytwentytwo/inc/block-patterns.php
+++ b/src/wp-content/themes/twentytwentytwo/inc/block-patterns.php
@@ -45,6 +45,7 @@ function twentytwentytwo_register_block_patterns() {
 	}
 
 	$block_patterns = array(
+		'comments',
 		'footer-default',
 		'footer-dark',
 		'footer-logo',

--- a/src/wp-content/themes/twentytwentytwo/inc/block-patterns.php
+++ b/src/wp-content/themes/twentytwentytwo/inc/block-patterns.php
@@ -145,7 +145,7 @@ function twentytwentytwo_register_comments_patterns() {
 
 	register_block_pattern(
 		'twentytwentytwo/comments',
-		require get_theme_file_path( '/inc/patterns/comments.php' )
+		require get_theme_file_path( '/inc/patterns/hidden-comments.php' )
 	);
 
 }

--- a/src/wp-content/themes/twentytwentytwo/inc/patterns/comments.php
+++ b/src/wp-content/themes/twentytwentytwo/inc/patterns/comments.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Comments block (for WP >= 6.1), or legacy Post Comments block.
+ */
+
+if ( WP_Block_Type_Registry::get_instance()->is_registered( 'core/comments' ) ) {
+	return array(
+		'title'      => __( 'Comments block', 'twentytwentytwo' ),
+		'content'    => '<!-- wp:comments -->
+						<div class="wp-block-comments"><!-- wp:comments-title /-->
+
+						<!-- wp:comment-template -->
+						<!-- wp:columns -->
+						<div class="wp-block-columns"><!-- wp:column {"width":"40px"} -->
+						<div class="wp-block-column" style="flex-basis:40px"><!-- wp:avatar {"size":40,"style":{"border":{"radius":"20px"}}} /--></div>
+						<!-- /wp:column -->
+
+						<!-- wp:column -->
+						<div class="wp-block-column"><!-- wp:comment-author-name {"fontSize":"small"} /-->
+
+						<!-- wp:group {"layout":{"type":"flex"},"style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}}}} -->
+						<div class="wp-block-group" style="margin-top:0px;margin-bottom:0px"><!-- wp:comment-date {"fontSize":"small"} /-->
+
+						<!-- wp:comment-edit-link {"fontSize":"small"} /--></div>
+						<!-- /wp:group -->
+
+						<!-- wp:comment-content /-->
+
+						<!-- wp:comment-reply-link {"fontSize":"small"} /--></div>
+						<!-- /wp:column --></div>
+						<!-- /wp:columns -->
+						<!-- /wp:comment-template -->
+
+						<!-- wp:comments-pagination -->
+						<!-- wp:comments-pagination-previous /-->
+
+						<!-- wp:comments-pagination-numbers /-->
+
+						<!-- wp:comments-pagination-next /-->
+						<!-- /wp:comments-pagination -->
+
+						<!-- wp:post-comments-form /--></div>
+						<!-- /wp:comments -->',
+	);
+}
+return array(
+	'title'      => __( 'Post Comments block', 'twentytwentytwo' ),
+	'content'    => '<!-- wp:post-comments /-->',
+);

--- a/src/wp-content/themes/twentytwentytwo/inc/patterns/comments.php
+++ b/src/wp-content/themes/twentytwentytwo/inc/patterns/comments.php
@@ -45,5 +45,5 @@ if ( WP_Block_Type_Registry::get_instance()->is_registered( 'core/comments' ) ) 
 }
 return array(
 	'title'      => __( 'Post Comments block', 'twentytwentytwo' ),
-	'content'    => '<!-- wp:post-comments /-->',
+	'content'    => '<!-- wp:heading --><h2>' . __( 'Comments', 'twentytwentytwo' ) . '</h2><!-- /wp:heading --><!-- wp:post-comments /-->',
 );

--- a/src/wp-content/themes/twentytwentytwo/inc/patterns/comments.php
+++ b/src/wp-content/themes/twentytwentytwo/inc/patterns/comments.php
@@ -3,7 +3,7 @@
  * Comments block (for WP >= 6.1), or legacy Post Comments block.
  */
 
-if ( WP_Block_Type_Registry::get_instance()->is_registered( 'core/comments' ) ) {
+if ( WP_Block_Type_Registry::get_instance()->is_registered( 'core/comments' ) && version_compare( $GLOBALS['wp_version'], '6.1', '>=' ) ) {
 	return array(
 		'title'      => __( 'Comments block', 'twentytwentytwo' ),
 		'content'    => '<!-- wp:comments -->

--- a/src/wp-content/themes/twentytwentytwo/inc/patterns/hidden-comments.php
+++ b/src/wp-content/themes/twentytwentytwo/inc/patterns/hidden-comments.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Comments block (for WP >= 6.1), or legacy Post Comments block.
+ * Comments block (for WP >= 6.2), or legacy Post Comments block.
  */
 
-if ( WP_Block_Type_Registry::get_instance()->is_registered( 'core/comments' ) && version_compare( $GLOBALS['wp_version'], '6.1', '>=' ) ) {
+if ( WP_Block_Type_Registry::get_instance()->is_registered( 'core/comments' ) && version_compare( $GLOBALS['wp_version'], '6.2', '>=' ) ) {
 	return array(
 		'title'    => __( 'Comments block', 'twentytwentytwo' ),
 		'inserter' => false,

--- a/src/wp-content/themes/twentytwentytwo/inc/patterns/hidden-comments.php
+++ b/src/wp-content/themes/twentytwentytwo/inc/patterns/hidden-comments.php
@@ -5,8 +5,9 @@
 
 if ( WP_Block_Type_Registry::get_instance()->is_registered( 'core/comments' ) && version_compare( $GLOBALS['wp_version'], '6.1', '>=' ) ) {
 	return array(
-		'title'      => __( 'Comments block', 'twentytwentytwo' ),
-		'content'    => '<!-- wp:comments -->
+		'title'    => __( 'Comments block', 'twentytwentytwo' ),
+		'inserter' => false,
+		'content'  => '<!-- wp:comments -->
 						<div class="wp-block-comments"><!-- wp:comments-title /-->
 
 						<!-- wp:comment-template -->
@@ -44,6 +45,7 @@ if ( WP_Block_Type_Registry::get_instance()->is_registered( 'core/comments' ) &&
 	);
 }
 return array(
-	'title'      => __( 'Post Comments block', 'twentytwentytwo' ),
-	'content'    => '<!-- wp:heading --><h2>' . __( 'Comments', 'twentytwentytwo' ) . '</h2><!-- /wp:heading --><!-- wp:post-comments /-->',
+	'title'    => __( 'Post Comments block', 'twentytwentytwo' ),
+	'inserter' => false,
+	'content'  => '<!-- wp:post-comments /-->',
 );

--- a/src/wp-content/themes/twentytwentytwo/templates/page-no-separators.html
+++ b/src/wp-content/themes/twentytwentytwo/templates/page-no-separators.html
@@ -9,9 +9,9 @@
 
 <!-- wp:post-content {"layout":{"inherit":true}} /-->
 
-<!-- wp:group {"layout":{"inherit":true}} -->
+<!-- wp:group {"layout":{"inherit":true},"style":{"spacing":{"padding":{"top":"var(--wp--custom--spacing--medium, 6rem)"}}}} -->
 <div class="wp-block-group">
-<!-- wp:post-comments {"style":{"spacing":{"padding":{"top":"var(--wp--custom--spacing--medium, 6rem)"}}}} /--></div>
+<!-- wp:pattern {"slug":"twentytwentytwo/comments"} /--></div>
 <!-- /wp:group --></main>
 <!-- /wp:group -->
 

--- a/src/wp-content/themes/twentytwentytwo/templates/page-no-separators.html
+++ b/src/wp-content/themes/twentytwentytwo/templates/page-no-separators.html
@@ -10,7 +10,7 @@
 <!-- wp:post-content {"layout":{"inherit":true}} /-->
 
 <!-- wp:group {"layout":{"inherit":true},"style":{"spacing":{"padding":{"top":"var(--wp--custom--spacing--medium, 6rem)"}}}} -->
-<div class="wp-block-group">
+<div class="wp-block-group" style="padding-top:var(--wp--custom--spacing--medium, 6rem)">
 <!-- wp:pattern {"slug":"twentytwentytwo/comments"} /--></div>
 <!-- /wp:group --></main>
 <!-- /wp:group -->

--- a/src/wp-content/themes/twentytwentytwo/templates/page.html
+++ b/src/wp-content/themes/twentytwentytwo/templates/page.html
@@ -17,9 +17,9 @@
 
 <!-- wp:post-content {"layout":{"inherit":true}} /-->
 
-<!-- wp:group {"layout":{"inherit":true}} -->
+<!-- wp:group {"layout":{"inherit":true},"style":{"spacing":{"padding":{"top":"var(--wp--custom--spacing--medium, 6rem)"}}}} -->
 <div class="wp-block-group">
-<!-- wp:post-comments {"style":{"spacing":{"padding":{"top":"var(--wp--custom--spacing--medium, 6rem)"}}}} /--></div>
+<!-- wp:pattern {"slug":"twentytwentytwo/comments"} /--></div>
 <!-- /wp:group --></main>
 <!-- /wp:group -->
 

--- a/src/wp-content/themes/twentytwentytwo/templates/page.html
+++ b/src/wp-content/themes/twentytwentytwo/templates/page.html
@@ -18,7 +18,7 @@
 <!-- wp:post-content {"layout":{"inherit":true}} /-->
 
 <!-- wp:group {"layout":{"inherit":true},"style":{"spacing":{"padding":{"top":"var(--wp--custom--spacing--medium, 6rem)"}}}} -->
-<div class="wp-block-group">
+<div class="wp-block-group" style="padding-top:var(--wp--custom--spacing--medium, 6rem)">
 <!-- wp:pattern {"slug":"twentytwentytwo/comments"} /--></div>
 <!-- /wp:group --></main>
 <!-- /wp:group -->

--- a/src/wp-content/themes/twentytwentytwo/templates/single-no-separators.html
+++ b/src/wp-content/themes/twentytwentytwo/templates/single-no-separators.html
@@ -28,7 +28,7 @@
 <div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:post-comments /--></div>
+<!-- wp:pattern {"slug":"twentytwentytwo/comments"} /--></div>
 <!-- /wp:group --></main>
 <!-- /wp:group -->
 

--- a/src/wp-content/themes/twentytwentytwo/templates/single.html
+++ b/src/wp-content/themes/twentytwentytwo/templates/single.html
@@ -40,7 +40,7 @@
 <hr class="wp-block-separator is-style-wide"/>
 <!-- /wp:separator -->
 
-<!-- wp:post-comments /--></div>
+<!-- wp:pattern {"slug":"twentytwentytwo/comments"} /--></div>
 <!-- /wp:group --></main>
 <!-- /wp:group -->
 


### PR DESCRIPTION
_While I'm nominally the PR author, all credit really goes to @MaggieCabrera for doing most of the work, and to @carolinan for the [original suggestion](https://github.com/WordPress/gutenberg/issues/43203#issuecomment-1226756338)._

The Post Comments block uses an h3 heading on it, this causes a11y issues _[as discussed in [#43203](https://github.com/WordPress/gutenberg/issues/43203) (and previously https://core.trac.wordpress.org/ticket/55172 )]_ on the templates where it's inserted, since there are no existing h2 in them. The new Comments block doesn't have the same problem because it allows you to change the heading as you need, but it's only available with Gutenberg or WP >= 6.1. To solve this issue, we are doing the following:

- We are creating a hidden block pattern that inserts either of the blocks depending on if the new block is registered and the WP version is >= 6.1
- For users that will get the deprecated version of the block, we are using the `render_block` hook to swap the h3 with an h2, and solve the a11y for them
- Users that will get the newer version of the block, will have the h2 instead.

To test this:

- Run this branch, check a page with comments on it, you should be seeing the headings using h2. On the editor, you should be seeing the new Comments block (there is no deprecation message present). You may need to tweak this line in `hidden-comments.php`, since this branch is still not a 6.1 version of WP:

`if ( WP_Block_Type_Registry::get_instance()->is_registered( 'core/comments' ) && version_compare( $GLOBALS['wp_version'], '6.1', '>=' ) ) {`

- Run the code from this branch on a 6.0 environment, you should be seeing the old block, with the deprecation notice in the editor. In the frontend, you should still see the headings on the comments block using h2, instead of h3.

Aside from a11y, note that this PR also improves User Experience of the TT2 theme: Users with WP >= 6.1 will get the Comments block in editable mode automatically, rather than seeing the legacy mode and the upgrade notice:

![image](https://user-images.githubusercontent.com/96308/186190954-4712101b-7c11-44e2-81bf-850edfba9858.png)

### Related PRs

- Make Post Comments Form block heading customizable (see https://github.com/WordPress/wordpress-develop/pull/3136#issuecomment-1230257962 and https://github.com/WordPress/gutenberg/issues/43681).
- Make Post Comments block use H2 instead of H3 for both "One reply to..." and "Leave a reply" (see https://github.com/WordPress/wordpress-develop/pull/3136#issuecomment-1230467503 and #3150).

Trac ticket: https://core.trac.wordpress.org/ticket/55172

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
