### PR TITLE
WP_Theme_JSON Elements: check value and whitelist before building style nodes

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -1477,7 +1477,7 @@ class WP_Theme_JSON {
 
 		if ( isset( $theme_json['styles']['elements'] ) ) {
 			foreach ( $theme_json['styles']['elements'] as $element => $node ) {
-				if ( ! isset( $theme_json['styles']['elements'][ $element ] ) || empty( static::ELEMENTS[ $element ] ) ) {
+				if ( ! isset( $theme_json['styles']['elements'][ $element ] ) || ! array_key_exists( $element, static::ELEMENTS ) ) {
 					continue;
 				}
 				$nodes[] = array(

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -1477,6 +1477,9 @@ class WP_Theme_JSON {
 
 		if ( isset( $theme_json['styles']['elements'] ) ) {
 			foreach ( $theme_json['styles']['elements'] as $element => $node ) {
+				if ( ! isset( $theme_json['styles']['elements'][ $element ] ) || empty( static::ELEMENTS[ $element ] ) ) {
+					continue;
+				}
 				$nodes[] = array(
 					'path'     => array( 'styles', 'elements', $element ),
 					'selector' => static::ELEMENTS[ $element ],


### PR DESCRIPTION
## What?
In `WP_Theme_JSON::get_style_nodes()`

- Check for elements values in theme.json before creating a node
- Check for element name in the whitelist before creating a node

## Why?
If an element does not exist in the `static::ELEMENTS` whitelist, PHP will complain about `Notice: Undefined index`.


Gutenberg PR: https://github.com/WordPress/gutenberg/pull/43622


Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->


