### PR TITLE
Check for non-empty array key 1 before using it with `current_user_can()`

### DIFF
--- a/src/wp-admin/menu-header.php
+++ b/src/wp-admin/menu-header.php
@@ -199,7 +199,7 @@ function _wp_menu_output( $menu, $submenu, $submenu_as_parent = true ) {
 
 			// 0 = menu_title, 1 = capability, 2 = menu_slug, 3 = page_title, 4 = classes.
 			foreach ( $submenu_items as $sub_key => $sub_item ) {
-				if ( ! empty( $sub_item[1] ) && ! current_user_can( $sub_item[1] ) ) {
+				if ( empty( $sub_item[1] ) || ! current_user_can( $sub_item[1] ) ) {
 					continue;
 				}
 

--- a/src/wp-admin/menu-header.php
+++ b/src/wp-admin/menu-header.php
@@ -199,7 +199,7 @@ function _wp_menu_output( $menu, $submenu, $submenu_as_parent = true ) {
 
 			// 0 = menu_title, 1 = capability, 2 = menu_slug, 3 = page_title, 4 = classes.
 			foreach ( $submenu_items as $sub_key => $sub_item ) {
-				if ( ! current_user_can( $sub_item[1] ) ) {
+				if ( ! empty( $sub_item[1] ) && ! current_user_can( $sub_item[1] ) ) {
 					continue;
 				}
 


### PR DESCRIPTION
Check for non-empty array key 1 before using it with current_user_can() to avoid PHP warning

Trac ticket: [https://core.trac.wordpress.org/ticket/56254](https://core.trac.wordpress.org/ticket/56254)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
