### PR TITLE
Check if `$authordata` is not false before trying to read property

### DIFF
--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -263,7 +263,7 @@ function get_permalink( $post = 0, $leavename = false ) {
 		if ( strpos( $permalink, '%author%' ) !== false ) {
 			$authordata = get_userdata( $post->post_author );
 
-			if ( false !== $authordata ) {
+			if ( $authordata instanceof WP_User ) {
 				$author = $authordata->user_nicename;
 			}
 		}

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -262,7 +262,10 @@ function get_permalink( $post = 0, $leavename = false ) {
 		$author = '';
 		if ( strpos( $permalink, '%author%' ) !== false ) {
 			$authordata = get_userdata( $post->post_author );
-			$author     = $authordata->user_nicename;
+
+			if ( false !== $authordata ) {
+				$author = $authordata->user_nicename;
+			}
 		}
 
 		// This is not an API call because the permalink is based on the stored post_date value,


### PR DESCRIPTION
Prevent PHP warning when reading user_nicename property from `$authordata` variable

Trac ticket: https://core.trac.wordpress.org/ticket/56229

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
