### PR TITLE
Prevent PHP warning reading property on null in WP_Query::is_singular()

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -4464,6 +4464,10 @@ class WP_Query {
 
 		$post_obj = $this->get_queried_object();
 
+		if ( null === $post_obj ) {
+			return (bool) $this->is_singular;
+		}
+
 		return in_array( $post_obj->post_type, (array) $post_types, true );
 	}
 

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -4465,7 +4465,7 @@ class WP_Query {
 		$post_obj = $this->get_queried_object();
 
 		if ( null === $post_obj ) {
-			return (bool) $this->is_singular;
+			return false;
 		}
 
 		return in_array( $post_obj->post_type, (array) $post_types, true );

--- a/tests/phpunit/tests/query.php
+++ b/tests/phpunit/tests/query.php
@@ -769,4 +769,20 @@ class Tests_Query extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'join', $posts_clauses_request );
 		$this->assertSame( '/* posts_join_request */', $posts_clauses_request['join'] );
 	}
+
+	/**
+	 * Tests that is_singular() returns false for an undefined post object.
+	 *
+	 * @ticket 56188
+	 *
+	 * @covers ::is_singular
+	 */
+	public function test_is_singular_should_return_false_for_an_undefined_post_object() {
+		$query = new WP_Query;
+
+		$query->init();
+		$query->set( 'is_singular', true );
+
+		$this->assertFalse( $query->is_singular( 'a_post_type' ) );
+	}
 }


### PR DESCRIPTION
`get_queried_object()` can return `null`, but there was no check for its value before trying to read the `post_type` property from the value.

Trac ticket: https://core.trac.wordpress.org/ticket/56188 + https://core.trac.wordpress.org/ticket/29660

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
