### PR TITLE
TT2: Make Post Comments block headlines H2s

### DIFF
--- a/src/wp-content/themes/twentytwentytwo/comments.php
+++ b/src/wp-content/themes/twentytwentytwo/comments.php
@@ -61,6 +61,6 @@ if ( post_password_required() ) { ?>
 <?php comment_form(
 	array(
 		'title_reply_before' => '<h2 id="reply-title" class="comment-reply-title">',
-		'title_reply_after'  => '</h2>'
+		'title_reply_after'  => '</h2>',
 	)
 ); ?>

--- a/src/wp-content/themes/twentytwentytwo/comments.php
+++ b/src/wp-content/themes/twentytwentytwo/comments.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * @package WordPress
+ * @subpackage Theme_Compat
+ * @deprecated 3.0.0
+ *
+ * This file is here for backward compatibility with old themes and will be removed in a future version
+ */
+_deprecated_file(
+	/* translators: %s: Template name. */
+	sprintf( __( 'Theme without %s' ), basename( __FILE__ ) ),
+	'3.0.0',
+	null,
+	/* translators: %s: Template name. */
+	sprintf( __( 'Please include a %s template in your theme.' ), basename( __FILE__ ) )
+);
+
+// Do not delete these lines.
+if ( ! empty( $_SERVER['SCRIPT_FILENAME'] ) && 'comments.php' === basename( $_SERVER['SCRIPT_FILENAME'] ) ) {
+	die( 'Please do not load this page directly. Thanks!' );
+}
+
+if ( post_password_required() ) { ?>
+		<p class="nocomments"><?php _e( 'This post is password protected. Enter the password to view comments.' ); ?></p>
+	<?php
+	return;
+}
+?>
+
+<!-- You can start editing here. -->
+
+<?php if ( have_comments() ) : ?>
+	<h2 id="comments">
+		<?php
+		if ( 1 == get_comments_number() ) {
+			printf(
+				/* translators: %s: Post title. */
+				__( 'One response to %s' ),
+				'&#8220;' . get_the_title() . '&#8221;'
+			);
+		} else {
+			printf(
+				/* translators: 1: Number of comments, 2: Post title. */
+				_n( '%1$s response to %2$s', '%1$s responses to %2$s', get_comments_number() ),
+				number_format_i18n( get_comments_number() ),
+				'&#8220;' . get_the_title() . '&#8221;'
+			);
+		}
+		?>
+	</h2>
+
+	<div class="navigation">
+		<div class="alignleft"><?php previous_comments_link(); ?></div>
+		<div class="alignright"><?php next_comments_link(); ?></div>
+	</div>
+
+	<ol class="commentlist">
+	<?php wp_list_comments(); ?>
+	</ol>
+
+	<div class="navigation">
+		<div class="alignleft"><?php previous_comments_link(); ?></div>
+		<div class="alignright"><?php next_comments_link(); ?></div>
+	</div>
+<?php else : // This is displayed if there are no comments so far. ?>
+
+	<?php if ( comments_open() ) : ?>
+		<!-- If comments are open, but there are no comments. -->
+
+	<?php else : // Comments are closed. ?>
+		<!-- If comments are closed. -->
+		<p class="nocomments"><?php _e( 'Comments are closed.' ); ?></p>
+
+	<?php endif; ?>
+<?php endif; ?>
+
+<?php comment_form(); ?>

--- a/src/wp-content/themes/twentytwentytwo/comments.php
+++ b/src/wp-content/themes/twentytwentytwo/comments.php
@@ -1,20 +1,4 @@
 <?php
-/**
- * @package WordPress
- * @subpackage Theme_Compat
- * @deprecated 3.0.0
- *
- * This file is here for backward compatibility with old themes and will be removed in a future version
- */
-_deprecated_file(
-	/* translators: %s: Template name. */
-	sprintf( __( 'Theme without %s' ), basename( __FILE__ ) ),
-	'3.0.0',
-	null,
-	/* translators: %s: Template name. */
-	sprintf( __( 'Please include a %s template in your theme.' ), basename( __FILE__ ) )
-);
-
 // Do not delete these lines.
 if ( ! empty( $_SERVER['SCRIPT_FILENAME'] ) && 'comments.php' === basename( $_SERVER['SCRIPT_FILENAME'] ) ) {
 	die( 'Please do not load this page directly. Thanks!' );

--- a/src/wp-content/themes/twentytwentytwo/comments.php
+++ b/src/wp-content/themes/twentytwentytwo/comments.php
@@ -74,4 +74,9 @@ if ( post_password_required() ) { ?>
 	<?php endif; ?>
 <?php endif; ?>
 
-<?php comment_form(); ?>
+<?php comment_form(
+	array(
+		'title_reply_before' => '<h2 id="reply-title" class="comment-reply-title">',
+		'title_reply_after'  => '</h2>'
+	)
+); ?>


### PR DESCRIPTION
Add a `src/wp-content/themes/twentytwentytwo/comments.php` file that will be picked up by the Post Comments block to render, well, a post's comments. The file is copied from Core's [`theme-compat/comments.php`](https://github.com/WordPress/wordpress-develop/blob/e9acf1fc0aaec0cff20106c0314f9edf2ceda7be/src/wp-includes/theme-compat/comments.php), with some modifications to change the H3 headings ("One reply to..." and "Leave a reply") to H2, in order to address [this a11y issue](https://core.trac.wordpress.org/ticket/55172). 

Note that this issue has been discussed in both https://github.com/WordPress/gutenberg/issues/43203 and https://github.com/WordPress/wordpress-develop/pull/3136. I currently believe that this PR is both necessary and sufficient, so it could be deemed a complete solution. (As @carolina [pointed out](https://github.com/WordPress/gutenberg/issues/43203#issuecomment-1226750740), it's unfortunate that we have to add a PHP file to customize a block theme, but I currently don't see any alternative.)

Trac ticket: https://core.trac.wordpress.org/ticket/55172

### Testing instructions

Using the TT2 theme, view a single post with comments on the frontend (e.g. the "Hello World" post that comes with a new WP install. Verify that both the "One reply to..." and "Leave a reply" headings are H2.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
