### PR TITLE
Ensure that timezone offset passed to wp-date is a float

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -416,7 +416,7 @@ function wp_default_packages_inline_scripts( $scripts ) {
 						'datetimeAbbreviated' => __( 'M j, Y g:i a' ),
 					),
 					'timezone' => array(
-						'offset' => get_option( 'gmt_offset', 0 ),
+						'offset' => (float) get_option( 'gmt_offset', 0 ),
 						'string' => $timezone_string,
 						'abbr'   => $timezone_abbr,
 					),


### PR DESCRIPTION
Fixes bug described in https://core.trac.wordpress.org/ticket/56459 and https://github.com/WordPress/gutenberg/issues/21977 by casting `timezone.offset` to a float before giving it to `wp.date.setSettings()`.

Trac ticket: https://core.trac.wordpress.org/ticket/56459

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
