### PR TITLE
Ticket/17904

### DIFF
--- a/src/wp-admin/includes/user.php
+++ b/src/wp-admin/includes/user.php
@@ -143,7 +143,7 @@ function edit_user( $user_id = 0 ) {
 
 	$errors = new WP_Error();
 
-	/* Validate the user_login when not updating the user */
+	// Validate the user_login when not updating the user.
 	if ( ! $update ) {
 		$user->user_login = '';
 		if ( isset( $_POST['user_login'] ) ) {

--- a/src/wp-admin/includes/user.php
+++ b/src/wp-admin/includes/user.php
@@ -20,7 +20,7 @@ function add_user() {
 /**
  * Edit user settings based on contents of $_POST
  *
- * Used on user-edit.php and profile.php to manage and process user options, passwords etc.
+ * Used on user-edit.php, user-new.php, and profile.php to manage and process user options, passwords etc.
  *
  * @since 2.0.0
  *
@@ -38,10 +38,6 @@ function edit_user( $user_id = 0 ) {
 		$user->user_login = wp_slash( $userdata->user_login );
 	} else {
 		$update = false;
-	}
-
-	if ( ! $update && isset( $_POST['user_login'] ) ) {
-		$user->user_login = sanitize_user( wp_unslash( $_POST['user_login'] ), true );
 	}
 
 	$pass1 = '';
@@ -147,9 +143,14 @@ function edit_user( $user_id = 0 ) {
 
 	$errors = new WP_Error();
 
-	/* checking that username has been typed */
-	if ( '' === $user->user_login ) {
-		$errors->add( 'user_login', __( '<strong>Error:</strong> Please enter a username.' ) );
+	/* Validate the user_login when not updating the user */
+	if ( ! $update ) {
+		$user->user_login = '';
+		if ( isset( $_POST['user_login'] ) ) {
+			$user->user_login = $_POST['user_login'];
+		}
+
+		wp_validate_user_login( $user->user_login, $errors );
 	}
 
 	/* checking that nickname has been typed */
@@ -187,22 +188,7 @@ function edit_user( $user_id = 0 ) {
 		$user->user_pass = $pass1;
 	}
 
-	if ( ! $update && isset( $_POST['user_login'] ) && ! validate_username( $_POST['user_login'] ) ) {
-		$errors->add( 'user_login', __( '<strong>Error:</strong> This username is invalid because it uses illegal characters. Please enter a valid username.' ) );
-	}
-
-	if ( ! $update && username_exists( $user->user_login ) ) {
-		$errors->add( 'user_login', __( '<strong>Error:</strong> This username is already registered. Please choose another one.' ) );
-	}
-
-	/** This filter is documented in wp-includes/user.php */
-	$illegal_logins = (array) apply_filters( 'illegal_user_logins', array() );
-
-	if ( in_array( strtolower( $user->user_login ), array_map( 'strtolower', $illegal_logins ), true ) ) {
-		$errors->add( 'invalid_username', __( '<strong>Error:</strong> Sorry, that username is not allowed.' ) );
-	}
-
-	// Checking email address.
+	/* checking email address */
 	if ( empty( $user->user_email ) ) {
 		$errors->add( 'empty_email', __( '<strong>Error:</strong> Please enter an email address.' ), array( 'form-field' => 'email' ) );
 	} elseif ( ! is_email( $user->user_email ) ) {

--- a/src/wp-includes/ms-functions.php
+++ b/src/wp-includes/ms-functions.php
@@ -592,7 +592,7 @@ function wpmu_validate_blog_signup( $blogname, $blog_title, $user = '' ) {
 
 	if ( preg_match( '/[^a-z0-9-]+/', $blogname ) ) {
 		$errors->add( 'blogname', __( 'Site names can only contain lowercase letters (a-z), numbers, and hyphens.' ) );
-	} elseif ( trim( $blogname, '-' ) !== $blogname  ) {
+	} elseif ( trim( $blogname, '-' ) !== $blogname ) {
 		$errors->add( 'blogname', __( 'Site names can not begin or end with a hyphen.' ) );
 	}
 

--- a/src/wp-includes/ms-functions.php
+++ b/src/wp-includes/ms-functions.php
@@ -591,7 +591,9 @@ function wpmu_validate_blog_signup( $blogname, $blog_title, $user = '' ) {
 	}
 
 	if ( preg_match( '/[^a-z0-9-]+/', $blogname ) ) {
-		$errors->add( 'blogname', __( 'Site names can only contain lowercase letters (a-z), numbers, and dashes.' ) );
+		$errors->add( 'blogname', __( 'Site names can only contain lowercase letters (a-z), numbers, and hyphens.' ) );
+	} elseif ( trim( $blogname, '-' ) !== $blogname  ) {
+		$errors->add( 'blogname', __( 'Site names can not begin or end with a hyphen.' ) );
 	}
 
 	if ( in_array( $blogname, $illegal_names, true ) ) {

--- a/src/wp-includes/ms-functions.php
+++ b/src/wp-includes/ms-functions.php
@@ -590,8 +590,8 @@ function wpmu_validate_blog_signup( $blogname, $blog_title, $user = '' ) {
 		$errors->add( 'blogname', __( 'Please enter a site name.' ) );
 	}
 
-	if ( preg_match( '/[^a-z0-9]+/', $blogname ) ) {
-		$errors->add( 'blogname', __( 'Site names can only contain lowercase letters (a-z) and numbers.' ) );
+	if ( preg_match( '/[^a-z0-9-]+/', $blogname ) ) {
+		$errors->add( 'blogname', __( 'Site names can only contain lowercase letters (a-z), numbers and dashes.' ) );
 	}
 
 	if ( in_array( $blogname, $illegal_names, true ) ) {

--- a/src/wp-includes/ms-functions.php
+++ b/src/wp-includes/ms-functions.php
@@ -591,7 +591,7 @@ function wpmu_validate_blog_signup( $blogname, $blog_title, $user = '' ) {
 	}
 
 	if ( preg_match( '/[^a-z0-9-]+/', $blogname ) ) {
-		$errors->add( 'blogname', __( 'Site names can only contain lowercase letters (a-z), numbers and dashes.' ) );
+		$errors->add( 'blogname', __( 'Site names can only contain lowercase letters (a-z), numbers, and dashes.' ) );
 	}
 
 	if ( in_array( $blogname, $illegal_names, true ) ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
@@ -1280,17 +1280,17 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		if ( is_wp_error( $valid_username ) ) {
 			$error_message = '';
 
-			// Check for `illegal_user_logins` error message for the username on single install.
+			// Check for a `illegal_user_logins` error message for the username on a single install.
 			if ( ! is_multisite() ) {
 				$error_message = $valid_username->get_error_message( 'invalid_username' );
 			}
 
-			// Check for other error message for the username on single/multisite install.
+			// Check for other error messages concerning the username on single/multisite installs.
 			if ( empty( $error_message ) ) {
 				$error_message = $valid_username->get_error_message( 'user_name' );
 			}
 
-			// Use the correct error message for username with illegal characters in REST response.
+			// Use the correct error message for username with illegal characters in the REST response.
 			if ( __( '<strong>Error:</strong> This username is invalid because it uses illegal characters. Please enter a valid username.' ) === $error_message ) {
 				$error_message = __( 'This username is invalid because it uses illegal characters. Please enter a valid username.' );
 			}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
@@ -1276,21 +1276,28 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 	public function check_username( $value, $request, $param ) {
 		$username = (string) $value;
 
-		if ( ! validate_username( $username ) ) {
+		$valid_username = validate_username( $username, true );
+		if ( is_wp_error( $valid_username ) ) {
+			$error_message = '';
+
+			// Check for `illegal_user_logins` error message for the username on single install.
+			if ( ! is_multisite() ) {
+				$error_message = $valid_username->get_error_message( 'invalid_username' );
+			}
+
+			// Check for other error message for the username on single/multisite install.
+			if ( empty( $error_message ) ) {
+				$error_message = $valid_username->get_error_message( 'user_name' );
+			}
+
+			// Use the correct error message for username with illegal characters in REST response.
+			if ( __( '<strong>Error:</strong> This username is invalid because it uses illegal characters. Please enter a valid username.' ) === $error_message ) {
+				$error_message = __( 'This username is invalid because it uses illegal characters. Please enter a valid username.' );
+			}
+
 			return new WP_Error(
 				'rest_user_invalid_username',
-				__( 'This username is invalid because it uses illegal characters. Please enter a valid username.' ),
-				array( 'status' => 400 )
-			);
-		}
-
-		/** This filter is documented in wp-includes/user.php */
-		$illegal_logins = (array) apply_filters( 'illegal_user_logins', array() );
-
-		if ( in_array( strtolower( $username ), array_map( 'strtolower', $illegal_logins ), true ) ) {
-			return new WP_Error(
-				'rest_user_invalid_username',
-				__( 'Sorry, that username is not allowed.' ),
+				$error_message,
 				array( 'status' => 400 )
 			);
 		}

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -2025,7 +2025,7 @@ function email_exists( $email ) {
  *
  * @since 2.0.1
  * @since 4.4.0 Empty sanitized usernames are now considered invalid.
- * @since n.e.x.t New argument $wp_error has been added.
+ * @since 6.5.0 New argument $wp_error has been added.
  *
  * @param string $username Username to validate.
  * @param bool   $wp_error Whether to return a WP_Error if the username is invalid.
@@ -2099,7 +2099,7 @@ function validate_username( $username, $wp_error = false ) {
 	 */
 	$valid = apply_filters( 'validate_username', true, $username );
 	if ( ! $valid ) {
-		$errors->add( 'user_name', __( 'Sorry, that username is invalid.' ) );
+		$errors->add( 'user_name', __( 'Sorry, that username is not allowed.' ) );
 	}
 
 	if ( $errors->has_errors() && $wp_error ) {
@@ -2115,7 +2115,7 @@ function validate_username( $username, $wp_error = false ) {
  * In multisite, this checks if a signup with the provided username already exists. If the signup has been registered
  * more than two days ago, it'll be deleted and the username considered available again.
  *
- * @since n.e.x.t
+ * @since 6.5.0
  *
  * @global wpdb $wpdb WordPress database abstraction object.
  *
@@ -2143,7 +2143,7 @@ function is_username_reserved( $username ) {
 		/**
 		 * Filters whether the username is reserved or not.
 		 *
-		 * @since n.e.x.t
+		 * @since 6.5.0
 		 *
 		 * @param bool $reserved Whether given username is reserved.
 		 * @param string $username Username to check.
@@ -2162,7 +2162,7 @@ function is_username_reserved( $username ) {
  * - {@see username_exists}
  * - {@see is_username_reserved}
  *
- * @since n.e.x.t
+ * @since 6.5.0
  *
  * @param string   $user_login User login to validate.
  * @param WP_Error $errors    Existing WP_Error object to use. If null, a new WP_Error object will be created and returned.

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -2157,6 +2157,48 @@ function is_username_reserved( $username ) {
 }
 
 /**
+ * Check if a user login is valid.
+ *
+ * This function combine various check that are run on the provided user login :
+ * - {@see validate_username}
+ * - {@see username_exists}
+ * - {@see is_username_reserved}
+ *
+ * @since n.e.x.t
+ *
+ * @param string $user_login User login to validate.
+ * @param WP_Error $errors Existing WP_Error object to use. If null a new WP_Error object will be created and returned.
+ *
+ * @return bool|WP_Error True is the login is valid, WP_Error otherwise.
+ */
+function wp_validate_user_login( $user_login = '', $errors = null ) {
+	if ( null === $errors ) {
+		$errors = new WP_Error();
+	}
+
+	$validate_username = validate_username( $user_login, true );
+	if ( is_wp_error( $validate_username ) ) {
+		$errors->merge_from( $validate_username );
+	}
+
+	// Check if the username has been used already.
+	if ( username_exists( $user_login ) ) {
+		$errors->add( 'user_name', __( 'Sorry, that username already exists!' ) );
+	}
+
+	// Check if the username is reserved.
+	if ( is_username_reserved( $user_login ) ) {
+		$errors->add( 'user_name', __( 'That username is currently reserved but may be available in a couple of days.' ) );
+	}
+
+	if ( $errors->has_errors() ) {
+		return $errors;
+	}
+
+	return true;
+}
+
+/**
  * Inserts a user into the database.
  *
  * Most of the `$userdata` array fields have filters associated with the values. Exceptions are

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -2028,40 +2028,39 @@ function email_exists( $email ) {
  * @since n.e.x.t New argument $wp_error has been added.
  *
  * @param string $username Username to validate.
- * @param bool $wp_error Whether to return a WP_Error if the username is invalid.
- *
- * @return bool|WP_Error Whether username given is valid. True is the username is valid, false or WP_Error otherwise.
+ * @param bool   $wp_error Whether to return a WP_Error if the username is invalid.
+ * @return bool|WP_Error Whether provided username is valid. True if the username is valid, false or WP_Error otherwise.
  */
 function validate_username( $username, $wp_error = false ) {
 	$original_username = $username;
 
 	$errors = new WP_Error();
 
-	// User login cannot be empty
+	// User login cannot be empty.
 	if ( empty( $username ) ) {
 		$errors->add( 'user_name', __( 'Please enter a username.' ) );
 	}
 
-	// User login must be more than 4 characters
+	// User login must be more than 4 characters.
 	if ( strlen( $username ) < 4 ) {
 		$errors->add( 'user_name', __( 'Username must be at least 4 characters.' ) );
 	}
 
-	// User login must be less than 60 characters
+	// User login must be less than 60 characters.
 	if ( strlen( $username ) > 60 ) {
 		$errors->add( 'user_name', __( 'Username may not be longer than 60 characters.' ) );
 	}
 
-	// Strip any whitespace and then match against case insensitive characters a-z 0-9 _ . - @
+	// Strip any whitespace and then match against case insensitive characters a-z, 0-9, _, ., -, @.
 	$username = preg_replace( '/\s+/', '', sanitize_user( $username, true ) );
 
-	// If the previous operation generated a different value, the username is invalid
+	// If the previous operation generated a different value, the username is invalid.
 	if ( $username !== $original_username ) {
 		$errors->add( 'user_name', __( '<strong>Error:</strong> This username is invalid because it uses illegal characters. Please enter a valid username.' ) );
 	}
 
 	if ( is_multisite() ) {
-		// Check the user_login against an array of illegal names
+		// Check the user_login against an array of illegal names.
 		$illegal_names = get_site_option( 'illegal_names' );
 		if ( false === is_array( $illegal_names ) ) {
 			$illegal_names = array( 'www', 'web', 'root', 'admin', 'main', 'invite', 'administrator' );
@@ -2084,7 +2083,7 @@ function validate_username( $username, $wp_error = false ) {
 	}
 
 	if ( is_multisite() ) {
-		// User login must have at least one letter
+		// User login must have at least one letter.
 		if ( ! preg_match( '/[a-zA-Z]+/', $username ) ) {
 			$errors->add( 'user_name', __( 'Sorry, usernames must have letters too!' ) );
 		}
@@ -2113,16 +2112,15 @@ function validate_username( $username, $wp_error = false ) {
 /**
  * Check whether the given username is reserved or not.
  *
- * In multisite this check if a signup with the username already exist. If the signup has been registered more than two
- * days ago it'll be deleted and the username considered available again.
+ * In multisite, this checks if a signup with the provided username already exists. If the signup has been registered 
+ * more than two days ago, it'll be deleted and the username considered available again.
  *
  * @since n.e.x.t
  *
  * @global wpdb $wpdb WordPress database abstraction object.
  *
  * @param string $username Username to check.
- *
- * @return bool True is the username is available, false otherwise.
+ * @return bool True if the username is available, false otherwise.
  */
 function is_username_reserved( $username ) {
 	global $wpdb;
@@ -2159,17 +2157,17 @@ function is_username_reserved( $username ) {
 /**
  * Check if a user login is valid.
  *
- * This function combine various check that are run on the provided user login :
+ * This function combines various checks that are run on the provided user login:
  * - {@see validate_username}
  * - {@see username_exists}
  * - {@see is_username_reserved}
  *
  * @since n.e.x.t
  *
- * @param string $user_login User login to validate.
- * @param WP_Error $errors Existing WP_Error object to use. If null a new WP_Error object will be created and returned.
+ * @param string   $user_login User login to validate.
+ * @param WP_Error $errors    Existing WP_Error object to use. If null, a new WP_Error object will be created and returned.
  *
- * @return bool|WP_Error True is the login is valid, WP_Error otherwise.
+ * @return bool|WP_Error True if the login is valid, WP_Error otherwise.
  */
 function wp_validate_user_login( $user_login = '', $errors = null ) {
 	if ( null === $errors ) {
@@ -2181,14 +2179,14 @@ function wp_validate_user_login( $user_login = '', $errors = null ) {
 		$errors->merge_from( $validate_username );
 	}
 
-	// Check if the username has been used already.
+	// Check if the username is already in use.
 	if ( username_exists( $user_login ) ) {
 		$errors->add( 'user_name', __( 'Sorry, that username already exists!' ) );
 	}
 
 	// Check if the username is reserved.
 	if ( is_username_reserved( $user_login ) ) {
-		$errors->add( 'user_name', __( 'That username is currently reserved but may be available in a couple of days.' ) );
+		$errors->add( 'user_name', __( 'That username is currently reserved, but it may be available in a couple of days.' ) );
 	}
 
 	if ( $errors->has_errors() ) {
@@ -3543,7 +3541,7 @@ function register_new_user( $user_login, $user_email ) {
 	 */
 	$user_email = apply_filters( 'user_registration_email', $user_email );
 
-	// Validate the username
+	// Validate the username.
 	wp_validate_user_login( $user_login, $errors );
 
 	// Check the email address.

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -3534,7 +3534,6 @@ function reset_password( $user, $new_pass ) {
 function register_new_user( $user_login, $user_email ) {
 	$errors = new WP_Error();
 
-	$sanitized_user_login = sanitize_user( $user_login );
 	/**
 	 * Filters the email address of a user being registered.
 	 *
@@ -3544,21 +3543,8 @@ function register_new_user( $user_login, $user_email ) {
 	 */
 	$user_email = apply_filters( 'user_registration_email', $user_email );
 
-	// Check the username.
-	if ( '' === $sanitized_user_login ) {
-		$errors->add( 'empty_username', __( '<strong>Error:</strong> Please enter a username.' ) );
-	} elseif ( ! validate_username( $user_login ) ) {
-		$errors->add( 'invalid_username', __( '<strong>Error:</strong> This username is invalid because it uses illegal characters. Please enter a valid username.' ) );
-		$sanitized_user_login = '';
-	} elseif ( username_exists( $sanitized_user_login ) ) {
-		$errors->add( 'username_exists', __( '<strong>Error:</strong> This username is already registered. Please choose another one.' ) );
-	} else {
-		/** This filter is documented in wp-includes/user.php */
-		$illegal_user_logins = (array) apply_filters( 'illegal_user_logins', array() );
-		if ( in_array( strtolower( $sanitized_user_login ), array_map( 'strtolower', $illegal_user_logins ), true ) ) {
-			$errors->add( 'invalid_username', __( '<strong>Error:</strong> Sorry, that username is not allowed.' ) );
-		}
-	}
+	// Validate the username
+	wp_validate_user_login( $user_login, $errors );
 
 	// Check the email address.
 	if ( '' === $user_email ) {
@@ -3582,13 +3568,13 @@ function register_new_user( $user_login, $user_email ) {
 	 *
 	 * @since 2.1.0
 	 *
-	 * @param string   $sanitized_user_login The submitted username after being sanitized.
-	 * @param string   $user_email           The submitted email.
-	 * @param WP_Error $errors               Contains any errors with submitted username and email,
-	 *                                       e.g., an empty field, an invalid username or email,
-	 *                                       or an existing username or email.
+	 * @param string   $user_login The submitted username.
+	 * @param string   $user_email The submitted email.
+	 * @param WP_Error $errors     Contains any errors with submitted username and email,
+	 *                             e.g., an empty field, an invalid username or email,
+	 *                             or an existing username or email.
 	 */
-	do_action( 'register_post', $sanitized_user_login, $user_email, $errors );
+	do_action( 'register_post', $user_login, $user_email, $errors );
 
 	/**
 	 * Filters the errors encountered when a new user is being registered.
@@ -3601,19 +3587,19 @@ function register_new_user( $user_login, $user_email ) {
 	 *
 	 * @since 2.1.0
 	 *
-	 * @param WP_Error $errors               A WP_Error object containing any errors encountered
-	 *                                       during registration.
-	 * @param string   $sanitized_user_login User's username after it has been sanitized.
-	 * @param string   $user_email           User's email.
+	 * @param WP_Error $errors     A WP_Error object containing any errors encountered
+	 *                             during registration.
+	 * @param string   $user_login User's username after it has been sanitized.
+	 * @param string   $user_email User's email.
 	 */
-	$errors = apply_filters( 'registration_errors', $errors, $sanitized_user_login, $user_email );
+	$errors = apply_filters( 'registration_errors', $errors, $user_login, $user_email );
 
 	if ( $errors->has_errors() ) {
 		return $errors;
 	}
 
 	$user_pass = wp_generate_password( 12, false );
-	$user_id   = wp_create_user( $sanitized_user_login, $user_pass, $user_email );
+	$user_id   = wp_create_user( $user_login, $user_pass, $user_email );
 	if ( ! $user_id || is_wp_error( $user_id ) ) {
 		$errors->add(
 			'registerfail',

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -2112,7 +2112,7 @@ function validate_username( $username, $wp_error = false ) {
 /**
  * Check whether the given username is reserved or not.
  *
- * In multisite, this checks if a signup with the provided username already exists. If the signup has been registered 
+ * In multisite, this checks if a signup with the provided username already exists. If the signup has been registered
  * more than two days ago, it'll be deleted and the username considered available again.
  *
  * @since n.e.x.t

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -2025,7 +2025,7 @@ function email_exists( $email ) {
  *
  * @since 2.0.1
  * @since 4.4.0 Empty sanitized usernames are now considered invalid.
- * @since 6.5.0 New argument $wp_error has been added.
+ * @since 6.7.0 New argument $wp_error has been added.
  *
  * @param string $username Username to validate.
  * @param bool   $wp_error Whether to return a WP_Error if the username is invalid.
@@ -2115,7 +2115,7 @@ function validate_username( $username, $wp_error = false ) {
  * In multisite, this checks if a signup with the provided username already exists. If the signup has been registered
  * more than two days ago, it'll be deleted and the username considered available again.
  *
- * @since 6.5.0
+ * @since 6.7.0
  *
  * @global wpdb $wpdb WordPress database abstraction object.
  *
@@ -2143,7 +2143,7 @@ function is_username_reserved( $username ) {
 		/**
 		 * Filters whether the username is reserved or not.
 		 *
-		 * @since 6.5.0
+		 * @since 6.7.0
 		 *
 		 * @param bool $reserved Whether given username is reserved.
 		 * @param string $username Username to check.
@@ -2162,7 +2162,7 @@ function is_username_reserved( $username ) {
  * - {@see username_exists}
  * - {@see is_username_reserved}
  *
- * @since 6.5.0
+ * @since 6.7.0
  *
  * @param string   $user_login User login to validate.
  * @param WP_Error $errors    Existing WP_Error object to use. If null, a new WP_Error object will be created and returned.

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -2132,7 +2132,7 @@ function is_username_reserved( $username ) {
 		$signup = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->signups WHERE user_login = %s", $username ) );
 		if ( null !== $signup ) {
 			$registered_at = mysql2date( 'U', $signup->registered );
-			$now           = current_time( 'timestamp', true );
+			$now           = time();
 			$diff          = $now - $registered_at;
 			// If registered more than two days ago, cancel registration and let this signup go through.
 			if ( $diff > 2 * DAY_IN_SECONDS ) {

--- a/tests/phpunit/tests/multisite/wpmuValidateBlogSignup.php
+++ b/tests/phpunit/tests/multisite/wpmuValidateBlogSignup.php
@@ -61,7 +61,6 @@ if ( is_multisite() ) :
 		public function data_validate_blogname() {
 			$data = array(
 				array( '', 'Site names must not be empty.' ),
-				array( 'foo-hello', 'Site names must not contain hyphens.' ),
 				array( 'foo_hello', 'Site names must not contain underscores.' ),
 				array( 'foo hello', 'Site names must not contain spaces.' ),
 				array( 'FooHello', 'Site names must not contain uppercase letters.' ),

--- a/tests/phpunit/tests/multisite/wpmuValidateBlogSignup.php
+++ b/tests/phpunit/tests/multisite/wpmuValidateBlogSignup.php
@@ -62,6 +62,8 @@ if ( is_multisite() ) :
 			$data = array(
 				array( '', 'Site names must not be empty.' ),
 				array( 'foo_hello', 'Site names must not contain underscores.' ),
+				array( '-foo-hello', 'Site names must not begin with a hyphen.' ),
+				array( 'foo-hello-', 'Site names must not end with a hyphen.' ),
 				array( 'foo hello', 'Site names must not contain spaces.' ),
 				array( 'FooHello', 'Site names must not contain uppercase letters.' ),
 				array( '12345678', 'Site names must not consist of numbers only.' ),

--- a/tests/phpunit/tests/multisite/wpmuValidateUserSignup.php
+++ b/tests/phpunit/tests/multisite/wpmuValidateUserSignup.php
@@ -18,12 +18,10 @@ if ( is_multisite() ) :
 			return array(
 				array( 'contains spaces', 'User names with spaces are not allowed.' ),
 				array( 'ContainsCaps', 'User names with capital letters are not allowed.' ),
-				array( 'contains_underscores', 'User names with underscores are not allowed.' ),
 				array( 'contains%^*()junk', 'User names with non-alphanumeric characters are not allowed.' ),
 				array( '', 'Empty user names are not allowed.' ),
 				array( 'foo', 'User names of 3 characters are not allowed.' ),
 				array( 'fo', 'User names of 2 characters are not allowed.' ),
-				array( 'f', 'User names of 1 characters are not allowed.' ),
 				array( 'f', 'User names of 1 characters are not allowed.' ),
 				array( '12345', 'User names consisting only of numbers are not allowed.' ),
 				array( 'thisusernamecontainsenoughcharacterstobelongerthan60characters', 'User names longer than 60 characters are not allowed.' ),

--- a/tests/phpunit/tests/rest-api/rest-users-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-users-controller.php
@@ -1287,7 +1287,6 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$errors = $data['data']['params'];
 		$this->assertIsString( $errors['username'] );
 		$this->assertSame( 'This username is invalid because it uses illegal characters. Please enter a valid username.', $errors['username'] );
-
 	}
 
 	public function get_illegal_user_logins() {

--- a/tests/phpunit/tests/rest-api/rest-users-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-users-controller.php
@@ -1275,11 +1275,6 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 			'url'         => 'http://example.com',
 		);
 
-		// Username rules are different (more strict) for multisite; see `wpmu_validate_user_signup`.
-		if ( is_multisite() ) {
-			$params['username'] = 'no-dashes-allowed';
-		}
-
 		$request = new WP_REST_Request( 'POST', '/wp/v2/users' );
 		$request->add_header( 'Content-Type', 'application/x-www-form-urlencoded' );
 		$request->set_body_params( $params );
@@ -1288,18 +1283,11 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 
 		$data = $response->get_data();
 
-		if ( is_multisite() ) {
-			$this->assertIsArray( $data['additional_errors'] );
-			$this->assertCount( 1, $data['additional_errors'] );
-			$error = $data['additional_errors'][0];
-			$this->assertSame( 'user_name', $error['code'] );
-			$this->assertSame( 'Usernames can only contain lowercase letters (a-z) and numbers.', $error['message'] );
-		} else {
-			$this->assertIsArray( $data['data']['params'] );
-			$errors = $data['data']['params'];
-			$this->assertIsString( $errors['username'] );
-			$this->assertSame( 'This username is invalid because it uses illegal characters. Please enter a valid username.', $errors['username'] );
-		}
+		$this->assertIsArray( $data['data']['params'] );
+		$errors = $data['data']['params'];
+		$this->assertIsString( $errors['username'] );
+		$this->assertSame( 'This username is invalid because it uses illegal characters. Please enter a valid username.', $errors['username'] );
+
 	}
 
 	public function get_illegal_user_logins() {

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -2204,17 +2204,18 @@ class Tests_User extends WP_UnitTestCase {
 		// Existing signup username
 		$wpdb->insert(
 			$wpdb->signups,
-			[
+			array(
 				'user_login' => 'testsuser1',
-				'registered' => date( 'Y-m-d H:i:s', strtotime( 'now' ) )
-			],
-			[
+				'registered' => gmdate( 'Y-m-d H:i:s', strtotime( 'now' ) ),
+			),
+			array(
 				'%s',
 				'%s',
-			]
+			)
 		);
 		$this->assertEquals(
-			true, is_username_reserved( 'testsuser1' ),
+			true,
+			is_username_reserved( 'testsuser1' ),
 			'assert username in signups for less than two days to not be available.'
 		);
 		$this->assertEquals(
@@ -2226,14 +2227,14 @@ class Tests_User extends WP_UnitTestCase {
 		// Expired signup username
 		$wpdb->insert(
 			$wpdb->signups,
-			[
+			array(
 				'user_login' => 'testsuser2',
-				'registered' => date( 'Y-m-d H:i:s', strtotime( '3 days ago' ) )
-			],
-			[
+				'registered' => gmdate( 'Y-m-d H:i:s', strtotime( '3 days ago' ) ),
+			),
+			array(
 				'%s',
 				'%s',
-			]
+			)
 		);
 		$this->assertEquals( false, is_username_reserved( 'testsuser2' ), 'assert username in signups for more than two days to be available.' );
 		$this->assertEquals(

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -2186,4 +2186,60 @@ class Tests_User extends WP_UnitTestCase {
 
 		return $additional_profile_data;
 	}
+
+	/**
+	 * @ticket 17904
+	 * @group ms-required
+	 */
+	public function test_is_username_reserved() {
+		global $wpdb;
+
+		// New username
+		$this->assertEquals(
+			false,
+			is_username_reserved( 'testsuser' ),
+			'assert username not in signups to be available.'
+		);
+
+		// Existing signup username
+		$wpdb->insert(
+			$wpdb->signups,
+			[
+				'user_login' => 'testsuser1',
+				'registered' => date( 'Y-m-d H:i:s', strtotime( 'now' ) )
+			],
+			[
+				'%s',
+				'%s',
+			]
+		);
+		$this->assertEquals(
+			true, is_username_reserved( 'testsuser1' ),
+			'assert username in signups for less than two days to not be available.'
+		);
+		$this->assertEquals(
+			1,
+			$wpdb->get_var( $wpdb->prepare( "SELECT count(signup_id) FROM $wpdb->signups WHERE user_login = %s", 'testsuser1' ) ),
+			"assert username in signups for less than two days to haven't be deleted."
+		);
+
+		// Expired signup username
+		$wpdb->insert(
+			$wpdb->signups,
+			[
+				'user_login' => 'testsuser2',
+				'registered' => date( 'Y-m-d H:i:s', strtotime( '3 days ago' ) )
+			],
+			[
+				'%s',
+				'%s',
+			]
+		);
+		$this->assertEquals( false, is_username_reserved( 'testsuser2' ), 'assert username in signups for more than two days to be available.' );
+		$this->assertEquals(
+			0,
+			$wpdb->get_var( $wpdb->prepare( "SELECT count(signup_id) FROM $wpdb->signups WHERE user_login = %s", 'testsuser2' ) ),
+			'assert username in signups for more than two days to have been deleted.'
+		);
+	}
 }

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -739,7 +739,8 @@ class Tests_User extends WP_UnitTestCase {
 
 		$response = register_new_user( $user_login, $user_email );
 		$this->assertInstanceOf( 'WP_Error', $response );
-		$this->assertSame( 'invalid_username', $response->get_error_code() );
+		$expected = is_multisite() ? 'user_name' : 'invalid_username';
+		$this->assertSame( $expected, $response->get_error_code() );
 
 		remove_filter( 'illegal_user_logins', array( $this, 'illegal_user_logins' ) );
 

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -2191,17 +2191,17 @@ class Tests_User extends WP_UnitTestCase {
 	 * @ticket 17904
 	 * @group ms-required
 	 */
-	public function test_is_username_reserved() {
+	public function test_is_username_reserved_no_signup() {
+		$this->assertEquals( false, is_username_reserved( 'testsuser' ) );
+	}
+
+	/**
+	 * @ticket 17904
+	 * @group ms-required
+	 */
+	public function test_is_username_reserved_existing_signup() {
 		global $wpdb;
 
-		// New username
-		$this->assertEquals(
-			false,
-			is_username_reserved( 'testsuser' ),
-			'assert username not in signups to be available.'
-		);
-
-		// Existing signup username
 		$wpdb->insert(
 			$wpdb->signups,
 			array(
@@ -2223,8 +2223,15 @@ class Tests_User extends WP_UnitTestCase {
 			$wpdb->get_var( $wpdb->prepare( "SELECT count(signup_id) FROM $wpdb->signups WHERE user_login = %s", 'testsuser1' ) ),
 			"assert username in signups for less than two days to haven't be deleted."
 		);
+	}
 
-		// Expired signup username
+	/**
+	 * @ticket 17904
+	 * @group ms-required
+	 */
+	public function test_is_username_reserved_expired_signup() {
+		global $wpdb;
+
 		$wpdb->insert(
 			$wpdb->signups,
 			array(
@@ -2236,7 +2243,11 @@ class Tests_User extends WP_UnitTestCase {
 				'%s',
 			)
 		);
-		$this->assertEquals( false, is_username_reserved( 'testsuser2' ), 'assert username in signups for more than two days to be available.' );
+		$this->assertEquals(
+			false,
+			is_username_reserved( 'testsuser2' ),
+			'assert username in signups for more than two days to be available.'
+		);
 		$this->assertEquals(
 			0,
 			$wpdb->get_var( $wpdb->prepare( "SELECT count(signup_id) FROM $wpdb->signups WHERE user_login = %s", 'testsuser2' ) ),

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -2243,4 +2243,31 @@ class Tests_User extends WP_UnitTestCase {
 			'assert username in signups for more than two days to have been deleted.'
 		);
 	}
+
+	/**
+	 * @ticket 17904
+	 * @group ms-excluded
+	 */
+	public function test_is_username_reserved_single_site() {
+		add_filter(
+			'is_username_reserved',
+			function ( $is_reserved, $username ) {
+				return 'testsuser1' === $username;
+			},
+			10,
+			2
+		);
+
+		$this->assertEquals(
+			false,
+			is_username_reserved( 'testsuser' ),
+			'assert usernames are not reserved on single site installation.'
+		);
+
+		$this->assertEquals(
+			true,
+			is_username_reserved( 'testsuser1' ),
+			'assert is_username_reserved filter allow to mark usernames as reserved.'
+		);
+	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This PR implement changes proposed in[ ticket 17904#comment:64](https://core.trac.wordpress.org/ticket/17904#comment:64)

The goal is to align how single and multisite check the validity of a username.

**Changes in PR :**
* Update `validate_username()` to include all restrictions from multisite,
* Introduce new function `is_username_reserved()`, this function performs the `wp_signups` query for existing username that was previously done in wpmu_validate_user_signup(),
* Introduce new function `wp_validate_user_login()`, that acts as a wrapper calling `validate_username()`, `username_exists()` and `is_username_reserved()`,
* Update codebase to use the new `wp_validate_user_login()` where applicable and remove code that was merge in `validate_username()`,
* Update User REST endpoint following the refactoring of `validate_username()`,
* Update `wpmu_validate_blog_signup()` to allow dashes in blogname.

**Changes not in PR :**
* Change `username_exists()` to accept a second parameter `$check_reserved = true`, this seem like a tricky change to me. Currently the function will return either a user id matching the username or false. Returning a `true` when the username is reserved could break other code casting the return of `username_exists()` to int.

Trac ticket: https://core.trac.wordpress.org/ticket/17904

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
