### PR TITLE
REST API: Add the missing 'site_icon_url' to the index

### DIFF
--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -1222,7 +1222,6 @@ class WP_REST_Server {
 			'home'            => home_url(),
 			'gmt_offset'      => get_option( 'gmt_offset' ),
 			'timezone_string' => get_option( 'timezone_string' ),
-			'site_icon_url'   => get_site_icon_url(),
 			'namespaces'      => array_keys( $this->namespaces ),
 			'authentication'  => array(),
 			'routes'          => $this->get_data_for_routes( $this->get_routes(), $request['context'] ),
@@ -1306,6 +1305,8 @@ class WP_REST_Server {
 	 * @param WP_REST_Response $response REST API response.
 	 */
 	protected function add_site_icon_to_index( WP_REST_Response $response ) {
+		$response->data['site_icon_url'] = get_site_icon_url();
+
 		$site_icon_id = get_option( 'site_icon', 0 );
 
 		$this->add_image_to_index( $response, $site_icon_id, 'site_icon' );

--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -1222,6 +1222,7 @@ class WP_REST_Server {
 			'home'            => home_url(),
 			'gmt_offset'      => get_option( 'gmt_offset' ),
 			'timezone_string' => get_option( 'timezone_string' ),
+			'site_icon_url'   => get_site_icon_url(),
 			'namespaces'      => array_keys( $this->namespaces ),
 			'authentication'  => array(),
 			'routes'          => $this->get_data_for_routes( $this->get_routes(), $request['context'] ),

--- a/tests/phpunit/tests/rest-api/rest-server.php
+++ b/tests/phpunit/tests/rest-api/rest-server.php
@@ -1062,6 +1062,7 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 		$this->assertArrayHasKey( 'home', $data );
 		$this->assertArrayHasKey( 'gmt_offset', $data );
 		$this->assertArrayHasKey( 'timezone_string', $data );
+		$this->assertArrayHasKey( 'site_icon_url', $data );
 		$this->assertArrayHasKey( 'namespaces', $data );
 		$this->assertArrayHasKey( 'authentication', $data );
 		$this->assertArrayHasKey( 'routes', $data );

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -12,7 +12,6 @@ mockedApiResponse.Schema = {
     "home": "http://example.org",
     "gmt_offset": "0",
     "timezone_string": "",
-    "site_icon_url": "",
     "namespaces": [
         "oembed/1.0",
         "wp/v2",
@@ -10761,6 +10760,7 @@ mockedApiResponse.Schema = {
         }
     },
     "site_logo": 0,
+    "site_icon_url": "",
     "site_icon": 0
 };
 

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -12,6 +12,7 @@ mockedApiResponse.Schema = {
     "home": "http://example.org",
     "gmt_offset": "0",
     "timezone_string": "",
+    "site_icon_url": "",
     "namespaces": [
         "oembed/1.0",
         "wp/v2",


### PR DESCRIPTION
Backports changes from https://github.com/WordPress/gutenberg/pull/42957.

The site_icon_url index was supposed to ship with WP 5.6 but was never backported into the core - https://github.com/WordPress/gutenberg/pull/22952.

I also created an alternative PR to use the existing `site_icon` index, but later @TimothyBJacobs pointed out that `site_icon_url` is preferable since it can be filtered - https://github.com/WordPress/gutenberg/pull/43514#issuecomment-1231049189.

Gutenberg tracking issue: https://github.com/WordPress/gutenberg/issues/43440
Trac ticket: https://core.trac.wordpress.org/ticket/56467

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
