### PR TITLE
Block Support Styles: Add priority param

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2899,6 +2899,7 @@ function wp_enqueue_global_styles_css_custom_properties() {
  * in the proper place, depending on the theme in use.
  *
  * @since 5.9.1
+ * @since 6.1.0 Added the `$priority` parameter.
  *
  * For block themes, it's loaded in the head.
  * For classic ones, it's loaded in the body
@@ -2908,8 +2909,9 @@ function wp_enqueue_global_styles_css_custom_properties() {
  * @link https://core.trac.wordpress.org/ticket/53494.
  *
  * @param string $style String containing the CSS styles to be added.
+ * @param int    $priority To set the priority for the add_action.
  */
-function wp_enqueue_block_support_styles( $style ) {
+function wp_enqueue_block_support_styles( $style, $priority = 10 ) {
 	$action_hook_name = 'wp_footer';
 	if ( wp_is_block_theme() ) {
 		$action_hook_name = 'wp_head';
@@ -2918,7 +2920,8 @@ function wp_enqueue_block_support_styles( $style ) {
 		$action_hook_name,
 		static function () use ( $style ) {
 			echo "<style>$style</style>\n";
-		}
+		},
+		$priority
 	);
 }
 


### PR DESCRIPTION
Backport of https://github.com/WordPress/gutenberg/pull/41015.

Needed for the package-sync "dry run" PR: https://github.com/WordPress/wordpress-develop/pull/3154#discussion_r958841837

### Questions:

- [ ] Should this include other related changes, e.g. https://github.com/WordPress/gutenberg/pull/43073?
- [ ] ~Does this need a (basic) unit test?~ _Edit: I'm leaning towards No, see https://github.com/WordPress/wordpress-develop/pull/3158#issuecomment-1234327286._

cc/ @glendaviesnz @ramonjd for review 😊 

Gutenberg tracking issue: https://github.com/WordPress/gutenberg/issues/43440
Trac ticket: https://core.trac.wordpress.org/ticket/56467

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
