### PR TITLE
Twenty Twenty: Fix social icons margin

### DIFF
--- a/src/wp-content/themes/twentytwenty/style.css
+++ b/src/wp-content/themes/twentytwenty/style.css
@@ -4107,7 +4107,7 @@ div.comment:first-of-type {
 	margin: 0 0 2rem;
 }
 
-.widget li {
+.widget li:not(.wp-social-link) {
 	margin: 2rem 0 0 0;
 }
 

--- a/src/wp-content/themes/twentytwenty/style.css
+++ b/src/wp-content/themes/twentytwenty/style.css
@@ -4107,8 +4107,8 @@ div.comment:first-of-type {
 	margin: 0 0 2rem;
 }
 
-.widget li:not(.wp-social-link) {
-	margin: 2rem 0 0 0;
+.widget .wp-block-social-links li {
+	margin-top: 0;
 }
 
 .widget li:first-child,


### PR DESCRIPTION
This is supposed to fix the margin on the social icons in the footer widget for Twenty Twenty

![image](https://user-images.githubusercontent.com/45571053/187665894-15229f80-0676-4179-9715-4132daa8850a.png)

Trac ticket: https://core.trac.wordpress.org/ticket/56474
