### PR TITLE
REST API (settings) - Switch to rest_default_additional_properties_to_false

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-settings-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-settings-controller.php
@@ -322,8 +322,8 @@ class WP_REST_Settings_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Recursively add additionalProperties = false to all objects in a schema if no additionalProperties setting
-	 * is specified.
+	 * Recursively add additionalProperties = false to all objects in a schema
+	 * if no additionalProperties setting is specified.
 	 *
 	 * This is needed to restrict properties of objects in settings values to only
 	 * registered items, as the REST API will allow additional properties by

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-settings-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-settings-controller.php
@@ -330,13 +330,13 @@ class WP_REST_Settings_Controller extends WP_REST_Controller {
 	 * default.
 	 *
 	 * @since 4.9.0
-	 * @deprecated x.y.z Use rest_default_additional_properties_to_false() instead.
+	 * @deprecated 6.1.0 Use {@see rest_default_additional_properties_to_false()} instead.
 	 *
 	 * @param array $schema The schema array.
 	 * @return array
 	 */
 	protected function set_additional_properties_to_false( $schema ) {
-		_deprecated_function( __METHOD__, 'x.y.z', 'rest_default_additional_properties_to_false()' );
+		_deprecated_function( __METHOD__, '6.1.0', 'rest_default_additional_properties_to_false()' );
 
 		return rest_default_additional_properties_to_false( $schema );
 	}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-settings-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-settings-controller.php
@@ -258,7 +258,7 @@ class WP_REST_Settings_Controller extends WP_REST_Controller {
 				continue;
 			}
 
-			$rest_args['schema'] = $this->set_additional_properties_to_false( $rest_args['schema'] );
+			$rest_args['schema'] = rest_default_additional_properties_to_false( $rest_args['schema'] );
 
 			$rest_options[ $rest_args['name'] ] = $rest_args;
 		}
@@ -322,31 +322,22 @@ class WP_REST_Settings_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Recursively add additionalProperties = false to all objects in a schema.
+	 * Recursively add additionalProperties = false to all objects in a schema if no additionalProperties setting
+	 * is specified.
 	 *
-	 * This is need to restrict properties of objects in settings values to only
+	 * This is needed to restrict properties of objects in settings values to only
 	 * registered items, as the REST API will allow additional properties by
 	 * default.
 	 *
 	 * @since 4.9.0
+	 * @deprecated x.y.z Use rest_default_additional_properties_to_false() instead.
 	 *
 	 * @param array $schema The schema array.
 	 * @return array
 	 */
 	protected function set_additional_properties_to_false( $schema ) {
-		switch ( $schema['type'] ) {
-			case 'object':
-				foreach ( $schema['properties'] as $key => $child_schema ) {
-					$schema['properties'][ $key ] = $this->set_additional_properties_to_false( $child_schema );
-				}
+		_deprecated_function( __METHOD__, 'x.y.z', 'rest_default_additional_properties_to_false()' );
 
-				$schema['additionalProperties'] = false;
-				break;
-			case 'array':
-				$schema['items'] = $this->set_additional_properties_to_false( $schema['items'] );
-				break;
-		}
-
-		return $schema;
+		return rest_default_additional_properties_to_false( $schema );
 	}
 }


### PR DESCRIPTION
This PR:

- switches to `rest_default_additional_properties_to_false` function
- deprecates the `WP_REST_Settings_Controller::set_additional_properties_to_false` method.

The requested changes has similarities with [`WP_REST_Meta_Fields::default_additional_properties_to_false`](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/rest-api/fields/class-wp-rest-meta-fields.php#L579-L598)

Trac ticket: https://core.trac.wordpress.org/ticket/56493

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
