### PR TITLE
GH Actions/Tests: no longer allow test runs on PHP 8.1 + 8.2 to fail

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -194,25 +194,22 @@ jobs:
 
       - name: Run PHPUnit tests
         if: ${{ matrix.php >= '7.0' }}
-        continue-on-error: ${{ matrix.php == '8.1' || matrix.php == '8.2'  }}
         run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c ${{ env.PHPUNIT_CONFIG }}
 
       - name: Run AJAX tests
         if: ${{ ! matrix.split_slow }}
-        continue-on-error: ${{ matrix.php == '8.2' }}
         run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c ${{ env.PHPUNIT_CONFIG }} --group ajax
 
       - name: Run ms-files tests as a multisite install
         if: ${{ matrix.multisite && ! matrix.split_slow }}
-        continue-on-error: ${{ matrix.php == '8.2' }}
         run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c tests/phpunit/multisite.xml --group ms-files
 
       - name: Run external HTTP tests
         if: ${{ ! matrix.multisite && ! matrix.split_slow }}
-        continue-on-error: ${{ matrix.php == '8.2' }}
         run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c phpunit.xml.dist --group external-http
 
       # __fakegroup__ is excluded to force PHPUnit to ignore the <exclude> settings in phpunit.xml.dist.
+      # This test group is not (yet) run against PHP 8.2 as there is no stable Xdebug version available yet for PHP 8.2.
       - name: Run (Xdebug) tests
         if: ${{ ! matrix.split_slow && matrix.php != '8.2' }}
         run: LOCAL_PHP_XDEBUG=true node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit -v --group xdebug --exclude-group __fakegroup__

--- a/tests/phpunit/tests/l10n.php
+++ b/tests/phpunit/tests/l10n.php
@@ -431,6 +431,18 @@ class Tests_L10n extends WP_UnitTestCase {
 	 * @covers ::wp_dashboard_recent_drafts
 	 */
 	public function test_length_of_draft_should_be_counted_by_words() {
+		/*
+		 * The recent drafts list is only displayed on the Dashboard screen for users
+		 * with the 'edit_posts' capability.
+		 *
+		 * This means the current user needs to be set to Editor as a prerequisite
+		 * for the call to the wp_dashboard_recent_drafts() function.
+		 * This allows the subsequent call to get_edit_post_link() call to work
+		 * as expected and return a string instead of null (which would otherwise cause
+		 * a PHP 8.1 "passing null to non-nullable" deprecation notice).
+		 */
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
 		require_once ABSPATH . 'wp-admin/includes/dashboard.php';
 
 		switch_to_locale( 'en_US' );
@@ -457,6 +469,18 @@ class Tests_L10n extends WP_UnitTestCase {
 	 * @covers ::wp_dashboard_recent_drafts
 	 */
 	public function test_length_of_draft_should_be_counted_by_chars() {
+		/*
+		 * The recent drafts list is only displayed on the Dashboard screen for users
+		 * with the 'edit_posts' capability.
+		 *
+		 * This means the current user needs to be set to Editor as a prerequisite
+		 * for the call to the wp_dashboard_recent_drafts() function.
+		 * This allows the subsequent call to get_edit_post_link() call to work
+		 * as expected and return a string instead of null (which would otherwise cause
+		 * a PHP 8.1 "passing null to non-nullable" deprecation notice).
+		 */
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
 		require_once ABSPATH . 'wp-admin/includes/dashboard.php';
 
 		switch_to_locale( 'ja_JP' );
@@ -483,6 +507,18 @@ class Tests_L10n extends WP_UnitTestCase {
 	 * @covers ::wp_dashboard_recent_drafts
 	 */
 	public function test_length_of_draft_should_be_counted_by_chars_in_japanese() {
+		/*
+		 * The recent drafts list is only displayed on the Dashboard screen for users
+		 * with the 'edit_posts' capability.
+		 *
+		 * This means the current user needs to be set to Editor as a prerequisite
+		 * for the call to the wp_dashboard_recent_drafts() function.
+		 * This allows the subsequent call to get_edit_post_link() call to work
+		 * as expected and return a string instead of null (which would otherwise cause
+		 * a PHP 8.1 "passing null to non-nullable" deprecation notice).
+		 */
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
 		require_once ABSPATH . 'wp-admin/includes/dashboard.php';
 
 		switch_to_locale( 'ja_JP' );

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -1955,6 +1955,12 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	public function test_get_post_draft_edit_context() {
+		/*
+		 * For an analysis of why this test is considered broken, see:
+		 * https://core.trac.wordpress.org/ticket/56681#comment:3
+		 */
+		$this->markTestSkipped( 'This test is broken and needs to be fixed before reactivating.' );
+
 		$post_content = 'Hello World!';
 		self::factory()->post->create(
 			array(


### PR DESCRIPTION
~~With one prepared PHP 8.1 patch still to be committed (first two commits in this PR),~~ we're down to 3 errors and 1 test failure on both PHP 8.1 + 8.2.

The test failure is being addressed in [Trac ticket 56681](https://core.trac.wordpress.org/ticket/56681).

The last remaining errors need further investigation, but in the mean time, we should actively prevent new PHP issues from being introduced in WP Core.

To that end, I'm proposing to skip those last four tests, either on all PHP versions (the failure, see the explanation in the ticket mentioned above) or on PHP 8.1+ (the three test errors).

With those test skips in place, we now have a 🟢 build for both PHP 8.1 + 8.2 and can remove the `continue-on-error`. 


Trac ticket: https://core.trac.wordpress.org/ticket/55652

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
