### PR TITLE
Site Health: Introduce admin menu counter.

### DIFF
--- a/src/js/_enqueues/admin/site-health.js
+++ b/src/js/_enqueues/admin/site-health.js
@@ -15,6 +15,8 @@ jQuery( function( $ ) {
 		isStatusTab = $( '.health-check-body.health-check-status-tab' ).length,
 		isDebugTab = $( '.health-check-body.health-check-debug-tab' ).length,
 		pathsSizesSection = $( '#health-check-accordion-block-wp-paths-sizes' ),
+		menuCounterWrapper = $( '#adminmenu .site-health-counter' ),
+		menuCounter = $( '#adminmenu .site-health-counter .count' ),
 		successTimeout;
 
 	// Debug information copy section.
@@ -168,8 +170,14 @@ jQuery( function( $ ) {
 			$( '.site-health-issue-count-title', issueWrapper ).html( heading );
 		}
 
+		menuCounter.text( SiteHealth.site_status.issues.critical );
+
 		if ( 0 < parseInt( SiteHealth.site_status.issues.critical, 0 ) ) {
 			$( '#health-check-issues-critical' ).removeClass( 'hidden' );
+
+			menuCounterWrapper.removeClass( 'count-0' );
+		} else {
+			menuCounterWrapper.addClass( 'count-0' );
 		}
 		if ( 0 < parseInt( SiteHealth.site_status.issues.recommended, 0 ) ) {
 			$( '#health-check-issues-recommended' ).removeClass( 'hidden' );

--- a/src/wp-admin/css/admin-menu.css
+++ b/src/wp-admin/css/admin-menu.css
@@ -427,6 +427,7 @@ ul#adminmenu > li.current > a.current:after {
 }
 
 /* @todo: consider to use a single rule for these counters and the list table comments counters. */
+#adminmenu .site-health-counter,
 #adminmenu .awaiting-mod,
 #adminmenu .update-plugins {
 	display: inline-block;
@@ -445,6 +446,7 @@ ul#adminmenu > li.current > a.current:after {
 	z-index: 26;
 }
 
+#adminmenu li.current a .site-health-counter,
 #adminmenu li.current a .awaiting-mod,
 #adminmenu li a.wp-has-current-submenu .update-plugins {
 	background-color: #d63638;

--- a/src/wp-admin/menu.php
+++ b/src/wp-admin/menu.php
@@ -342,11 +342,37 @@ if ( current_user_can( 'list_users' ) ) {
 	}
 }
 
+$site_health_count = '';
+if ( ! is_multisite() && current_user_can( 'update_themes' ) ) {
+	$get_issues = get_transient( 'health-check-site-status-result' );
+
+	$issue_counts = array();
+
+	if ( false !== $get_issues ) {
+		$issue_counts = json_decode( $get_issues, true );
+	}
+
+	if ( ! is_array( $issue_counts ) || ! $issue_counts ) {
+		$issue_counts = array(
+			'good'        => 0,
+			'recommended' => 0,
+			'critical'    => 0,
+		);
+	}
+
+	$site_health_count = sprintf(
+		'<span class="site-health-counter count-%s"><span class="count">%s</span></span>',
+		$issue_counts['critical'],
+		number_format_i18n( $issue_counts['critical'] )
+	);
+}
+
 $menu[75]                     = array( __( 'Tools' ), 'edit_posts', 'tools.php', '', 'menu-top menu-icon-tools', 'menu-tools', 'dashicons-admin-tools' );
 	$submenu['tools.php'][5]  = array( __( 'Available Tools' ), 'edit_posts', 'tools.php' );
 	$submenu['tools.php'][10] = array( __( 'Import' ), 'import', 'import.php' );
 	$submenu['tools.php'][15] = array( __( 'Export' ), 'export', 'export.php' );
-	$submenu['tools.php'][20] = array( __( 'Site Health' ), 'view_site_health_checks', 'site-health.php' );
+	/* translators: %s: Number of critical Site Health checks. */
+	$submenu['tools.php'][20] = array( sprintf( __( 'Site Health %s' ), $site_health_count ), 'view_site_health_checks', 'site-health.php' );
 	$submenu['tools.php'][25] = array( __( 'Export Personal Data' ), 'export_others_personal_data', 'export-personal-data.php' );
 	$submenu['tools.php'][30] = array( __( 'Erase Personal Data' ), 'erase_others_personal_data', 'erase-personal-data.php' );
 if ( is_multisite() && ! is_main_site() ) {

--- a/src/wp-admin/menu.php
+++ b/src/wp-admin/menu.php
@@ -343,7 +343,7 @@ if ( current_user_can( 'list_users' ) ) {
 }
 
 $site_health_count = '';
-if ( ! is_multisite() && current_user_can( 'update_themes' ) ) {
+if ( ! is_multisite() && current_user_can( 'view_site_health_checks' ) ) {
 	$get_issues = get_transient( 'health-check-site-status-result' );
 
 	$issue_counts = array();


### PR DESCRIPTION
Other actionable areas in the WordPress admin interface such as updates, plugins, and themes all have a corresponding menu item with a bubble-count to indication that there is actionable items within, and how many.

This change introduces a similar bubble count to the Site Health sub-menu item, indicating the amount of `critical` actionable items currently available.

Trac ticket: https://core.trac.wordpress.org/ticket/56199

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
