### PR TITLE
GH Actions: do not allow tests to fail for select PHP 8.1 test runs

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -199,23 +199,22 @@ jobs:
 
       - name: Run AJAX tests
         if: ${{ ! matrix.split_slow }}
-        continue-on-error: ${{ matrix.php == '8.1' || matrix.php == '8.2' }}
+        continue-on-error: ${{ matrix.php == '8.2' }}
         run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c ${{ env.PHPUNIT_CONFIG }} --group ajax
 
       - name: Run ms-files tests as a multisite install
         if: ${{ matrix.multisite && ! matrix.split_slow }}
-        continue-on-error: ${{ matrix.php == '8.1' || matrix.php == '8.2' }}
+        continue-on-error: ${{ matrix.php == '8.2' }}
         run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c tests/phpunit/multisite.xml --group ms-files
 
       - name: Run external HTTP tests
         if: ${{ ! matrix.multisite && ! matrix.split_slow }}
-        continue-on-error: ${{ matrix.php == '8.1' || matrix.php == '8.2' }}
+        continue-on-error: ${{ matrix.php == '8.2' }}
         run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c phpunit.xml.dist --group external-http
 
       # __fakegroup__ is excluded to force PHPUnit to ignore the <exclude> settings in phpunit.xml.dist.
       - name: Run (Xdebug) tests
         if: ${{ ! matrix.split_slow && matrix.php != '8.2' }}
-        continue-on-error: ${{ matrix.php == '8.1' }}
         run: LOCAL_PHP_XDEBUG=true node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit -v --group xdebug --exclude-group __fakegroup__
 
       - name: Ensure version-controlled files are not modified or deleted


### PR DESCRIPTION
👉🏻 **This PR is part of a series of PRs to get the builds passing on PHP 8.1 (to prevent having to _also_ allow failures on PHP 8.2, even when the PHP 8.2 issues are fixed (for a certain definition of "fixed")).**

---

The tests being run in these particular test groups are passing on PHP 8.1, however, the test runs are still allowed to "continue on error".

This creates the risk that new PHP 8.1 incompatibilities will be introduced without anyone noticing.

By no longer allowing these test runs to "continue on error", that risk is removed.

Trac ticket: https://core.trac.wordpress.org/ticket/55656
Trac ticket: https://core.trac.wordpress.org/ticket/55652

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
