### PR TITLE
Tests_Ajax_MediaEdit::testImageEditOverwriteConstant(): prevent test being marked as risky

### DIFF
--- a/tests/phpunit/tests/ajax/MediaEdit.php
+++ b/tests/phpunit/tests/ajax/MediaEdit.php
@@ -97,14 +97,23 @@ class Tests_Ajax_MediaEdit extends WP_Ajax_UnitTestCase {
 
 		$file_path = dirname( get_attached_file( $id ) );
 
+		$files_that_shouldnt_exist = array();
 		foreach ( $sizes1 as $key => $size ) {
 			if ( $sizes2[ $key ]['file'] !== $size['file'] ) {
 				$files_that_shouldnt_exist[] = $file_path . '/' . $size['file'];
 			}
 		}
 
-		foreach ( $files_that_shouldnt_exist as $file ) {
-			$this->assertFileDoesNotExist( $file, 'IMAGE_EDIT_OVERWRITE is leaving garbage image files behind.' );
+		if ( ! empty( $files_that_shouldnt_exist ) ) {
+			foreach ( $files_that_shouldnt_exist as $file ) {
+				$this->assertFileDoesNotExist( $file, 'IMAGE_EDIT_OVERWRITE is leaving garbage image files behind.' );
+			}
+		} else {
+			/*
+			 * This assertion will always pass due to the "if" condition, but prevents this test
+			 * from being marked as "risky" due to the test not performing any assertions.
+			 */
+			$this->assertSame( array(), $files_that_shouldnt_exist );
 		}
 	}
 }


### PR DESCRIPTION
If the `$files_that_shouldnt_exist` file list would be empty, this test would be marked as risky as it wouldn't perform any assertions.

This small tweak prevents this from happening.

Trac ticket: https://core.trac.wordpress.org/ticket/55652

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
