### PR TITLE
Tests_External_HTTP_Basic::test_readme_php_version(): temporarily skip the test

### DIFF
--- a/tests/phpunit/tests/external-http/basic.php
+++ b/tests/phpunit/tests/external-http/basic.php
@@ -10,6 +10,10 @@ class Tests_External_HTTP_Basic extends WP_UnitTestCase {
 	 * @covers ::wp_remote_retrieve_body
 	 */
 	public function test_readme_php_version() {
+		$this->markTestSkipped(
+			'Temporarily disabled. Test should be re-enabled once WordPress is fully compatible with PHP 8.0+.'
+		);
+
 		// This test is designed to only run on trunk.
 		$this->skipOnAutomatedBranches();
 
@@ -21,8 +25,7 @@ class Tests_External_HTTP_Basic extends WP_UnitTestCase {
 
 		preg_match_all( '#<tr class="stable">\s*<td>\s*<a [^>]*>\s*([0-9.]*)#s', $response_body, $php_matches );
 
-		// TODO: Enable this check once PHP 8.0 compatibility is achieved.
-		// $this->assertContains( $matches[1], $php_matches[1], "readme.html's Recommended PHP version is too old. Remember to update the WordPress.org Requirements page, too." );
+		$this->assertContains( $matches[1], $php_matches[1], "readme.html's Recommended PHP version is too old. Remember to update the WordPress.org Requirements page, too." );
 	}
 
 	/**


### PR DESCRIPTION
This test verifies that the WordPress `readme.html` file recommends a supported PHP version, however, WordPress currently still recommends PHP 7.4 due to PHP 8.0/8.1 compatibility not being fully achieved, even though PHP 7.4 is end-of-life.

As things were, the assertion in the test was commented out, leading to this test being marked as "risky" for not performing any assertions.

Instead, let's skip the test with a clear skip notification.

Trac ticket: https://core.trac.wordpress.org/ticket/55652

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
