### PR TITLE
PHP 8.1 | WP_Customize_Manager::get_return_url(): bug fix

### DIFF
--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -4685,27 +4685,27 @@ final class WP_Customize_Manager {
 
 		if ( $this->return_url ) {
 			$return_url = $this->return_url;
+
+			$return_url_basename = wp_basename( parse_url( $this->return_url, PHP_URL_PATH ) );
+			$return_url_query    = parse_url( $this->return_url, PHP_URL_QUERY );
+
+			if ( 'themes.php' === $return_url_basename && $return_url_query ) {
+				parse_str( $return_url_query, $query_vars );
+
+				/*
+				 * If the return URL is a page added by a theme to the Appearance menu via add_submenu_page(),
+				 * verify that it belongs to the active theme, otherwise fall back to the Themes screen.
+				 */
+				if ( isset( $query_vars['page'] ) && ! isset( $_registered_pages[ "appearance_page_{$query_vars['page']}" ] ) ) {
+					$return_url = admin_url( 'themes.php' );
+				}
+			}
 		} elseif ( $referer && ! in_array( wp_basename( parse_url( $referer, PHP_URL_PATH ) ), $excluded_referer_basenames, true ) ) {
 			$return_url = $referer;
 		} elseif ( $this->preview_url ) {
 			$return_url = $this->preview_url;
 		} else {
 			$return_url = home_url( '/' );
-		}
-
-		$return_url_basename = wp_basename( parse_url( $this->return_url, PHP_URL_PATH ) );
-		$return_url_query    = parse_url( $this->return_url, PHP_URL_QUERY );
-
-		if ( 'themes.php' === $return_url_basename && $return_url_query ) {
-			parse_str( $return_url_query, $query_vars );
-
-			/*
-			 * If the return URL is a page added by a theme to the Appearance menu via add_submenu_page(),
-			 * verify that it belongs to the active theme, otherwise fall back to the Themes screen.
-			 */
-			if ( isset( $query_vars['page'] ) && ! isset( $_registered_pages[ "appearance_page_{$query_vars['page']}" ] ) ) {
-				$return_url = admin_url( 'themes.php' );
-			}
 		}
 
 		return $return_url;


### PR DESCRIPTION
👉🏻 **This PR is part of a series of PRs to get the builds passing on PHP 8.1 (to prevent having to _also_ allow failures on PHP 8.2, even when the PHP 8.2 issues are fixed (for a certain definition of "fixed")).**

---


Introduced in [46754] in response to Trac#46686.

This particular code block only makes sense to run when `$this->return_url` is not `null` and causes a "passing null to non-nullable" deprecation notice on PHP 8.1 as it was.

By moving the code into the `if ( $this->return_url )` condition block, the code will only be run when `$this->return_url` contains a non-falsy/non-null value.

No additional tests added as this issue was found via the existing tests for the function containing the bug.

This solves the following two PHP 8.1 test errors:
```
1) Tests_WP_Customize_Manager::test_return_url
parse_url(): Passing null to parameter #1 ($url) of type string is deprecated

/var/www/src/wp-includes/class-wp-customize-manager.php:4696
/var/www/tests/phpunit/tests/customize/manager.php:2975
/var/www/vendor/bin/phpunit:123

2) Tests_WP_Customize_Manager::test_customize_pane_settings
parse_url(): Passing null to parameter #1 ($url) of type string is deprecated

/var/www/src/wp-includes/class-wp-customize-manager.php:4696
/var/www/src/wp-includes/class-wp-customize-manager.php:4898
/var/www/tests/phpunit/tests/customize/manager.php:3085
/var/www/vendor/bin/phpunit:123
```

Trac ticket: https://core.trac.wordpress.org/ticket/55656

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
