### PR TITLE
PHP 8.1 | WP_Scripts::localize(): fix autovivification from false to array bug

### DIFF
--- a/src/wp-includes/class.wp-scripts.php
+++ b/src/wp-includes/class.wp-scripts.php
@@ -501,12 +501,17 @@ class WP_Scripts extends WP_Dependencies {
 				),
 				'5.7.0'
 			);
+
+			if ( false === $l10n ) {
+				// This should really not be needed, but BC...
+				$l10n = array( $l10n );
+			}
 		}
 
 		if ( is_string( $l10n ) ) {
 			$l10n = html_entity_decode( $l10n, ENT_QUOTES, 'UTF-8' );
-		} else {
-			foreach ( (array) $l10n as $key => $value ) {
+		} elseif ( is_array( $l10n ) ) {
+			foreach ( $l10n as $key => $value ) {
 				if ( ! is_scalar( $value ) ) {
 					continue;
 				}

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -1428,17 +1428,8 @@ JS;
 	 *
 	 * @param mixed  $l10n_data Localization data passed to wp_localize_script().
 	 * @param string $expected  Expected transformation of localization data.
-	 * @param string $warning   Optional. Whether a PHP native warning/error is expected. Default false.
 	 */
-	public function test_wp_localize_script_data_formats( $l10n_data, $expected, $warning = false ) {
-		if ( $warning ) {
-			if ( PHP_VERSION_ID < 80000 ) {
-				$this->expectWarning();
-			} else {
-				$this->expectError();
-			}
-		}
-
+	public function test_wp_localize_script_data_formats( $l10n_data, $expected ) {
 		if ( ! is_array( $l10n_data ) ) {
 			$this->setExpectedIncorrectUsage( 'WP_Scripts::localize' );
 		}
@@ -1460,7 +1451,6 @@ JS;
 	 *
 	 *     @type mixed  $l10n_data Localization data passed to wp_localize_script().
 	 *     @type string $expected  Expected transformation of localization data.
-	 *     @type string $warning   Optional. Whether a PHP native warning/error is expected.
 	 * }
 	 */
 	public function data_wp_localize_script_data_formats() {
@@ -1471,14 +1461,16 @@ JS;
 			array( array( 'foo' => array( 'bar' => 'foobar' ) ), '{"foo":{"bar":"foobar"}}' ),
 			array( array( 'foo' => 6.6 ), '{"foo":"6.6"}' ),
 			array( array( 'foo' => 6 ), '{"foo":"6"}' ),
+			array( array(), '[]' ),
 
 			// Unofficially supported format.
 			array( 'string', '"string"' ),
 
 			// Unsupported formats.
-			array( 1.5, '1.5', true ),
-			array( 1, '1', true ),
+			array( 1.5, '1.5' ),
+			array( 1, '1' ),
 			array( false, '[""]' ),
+			array( null, 'null' ),
 		);
 	}
 


### PR DESCRIPTION
👉🏻 **This PR is part of a series of PRs to get the builds passing on PHP 8.1 (to prevent having to _also_ allow failures on PHP 8.2, even when the PHP 8.2 issues are fixed (for a certain definition of "fixed")).**

---


This function was previously already problematic as it does not do proper input validation and the function already received tweaks related to PHP 8.0 in [50408] / Trac#52534, which also introduced the `_doing_it_wrong()` and added tests.

The short of it is:
* The function expects to receive an `array` for the `$l10n` parameter;
* ... but silently supported the parameter being passed as a `string`;
* ... and would expect PHP to gracefully handle everything else or throw appropriate warnings/errors.

In the previous fix, a `_doing_it_wrong()` was added for all non-array inputs.
The function would also cause a PHP native "Cannot use a scalar value as an array" warning (PHP < 8.0)/error (PHP 8.0) for all scalar values, except `false`.

PHP 8.1 deprecated autovivification from `false` to `array`, so now `false` starts throwing a "Automatic conversion of false to array is deprecated" deprecation notice.

By rights, the function should just throw an exception when a non-array/string input is received, but BC...

So, while I really hate doing this, the current change will maintain the previous behaviour, but will prevent both the "Cannot use a scalar value as an array" warning/error as well as the "Automatic conversion of false to array" deprecation notice for invalid inputs.

Invalid inputs _will_ still receive a `_doing_it_wrong()`, which is the only reason I find this fix even remotely acceptable.

Includes adding a test passing an empty array.
Includes adding an additional test to the data provider for a `null` input to safeguard the function will not throw a PHP 8.1 "passing null to non-nullable" notice.

Fixes:
```
3) Tests_Dependencies_Scripts::test_wp_localize_script_data_formats with data set #8 (false, '[""]')
Automatic conversion of false to array is deprecated

/var/www/src/wp-includes/class.wp-scripts.php:514
/var/www/src/wp-includes/functions.wp-scripts.php:221
/var/www/tests/phpunit/tests/dependencies/scripts.php:1447
/var/www/vendor/bin/phpunit:123
```

Refs:
* https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.core.autovivification-false

Trac ticket: https://core.trac.wordpress.org/ticket/55656

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
