### PR TITLE
PHP 8.1 | load_script_textdomain(): fix passing null to non-nullable

### DIFF
--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -1065,7 +1065,9 @@ function load_script_textdomain( $handle, $domain = 'default', $path = null ) {
 		return false;
 	}
 
-	$path   = untrailingslashit( $path );
+	if ( is_string( $path ) ) {
+		$path = untrailingslashit( $path );
+	}
 	$locale = determine_locale();
 
 	// If a path was given and the handle file exists simply return it.

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -721,16 +721,6 @@ JS;
 		$wp_scripts->base_url  = '';
 		$wp_scripts->do_concat = true;
 
-		if ( PHP_VERSION_ID >= 80100 ) {
-			/*
-			 * For the time being, ignoring PHP 8.1 "null to non-nullable" deprecations coming in
-			 * via hooked in filter functions until a more structural solution to the
-			 * "missing input validation" conundrum has been architected and implemented.
-			 */
-			$this->expectDeprecation();
-			$this->expectDeprecationMessageMatches( '`Passing null to parameter \#[0-9]+ \(\$[^\)]+\) of type [^ ]+ is deprecated`' );
-		}
-
 		$ver       = get_bloginfo( 'version' );
 		$suffix    = wp_scripts_get_suffix();
 		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=jquery-core,jquery-migrate,regenerator-runtime,wp-polyfill,wp-dom-ready,wp-hooks&amp;ver={$ver}'></script>\n";
@@ -782,16 +772,6 @@ JS;
 
 		$wp_scripts->base_url  = '';
 		$wp_scripts->do_concat = true;
-
-		if ( PHP_VERSION_ID >= 80100 ) {
-			/*
-			 * For the time being, ignoring PHP 8.1 "null to non-nullable" deprecations coming in
-			 * via hooked in filter functions until a more structural solution to the
-			 * "missing input validation" conundrum has been architected and implemented.
-			 */
-			$this->expectDeprecation();
-			$this->expectDeprecationMessageMatches( '`Passing null to parameter \#[0-9]+ \(\$[^\)]+\) of type [^ ]+ is deprecated`' );
-		}
 
 		$expected_tail  = "<script type='text/javascript' src='/customize-dependency.js' id='customize-dependency-js'></script>\n";
 		$expected_tail .= "<script type='text/javascript' id='customize-dependency-js-after'>\n";

--- a/tests/phpunit/tests/l10n/loadScriptTextdomain.php
+++ b/tests/phpunit/tests/l10n/loadScriptTextdomain.php
@@ -131,4 +131,17 @@ class Tests_L10n_LoadScriptTextdomain extends WP_UnitTestCase {
 
 		return $relative;
 	}
+
+	/**
+	 * @ticket 55656
+	 */
+	public function test_no_php81_notices_when_optional_params_not_passed() {
+		$handle = 'test-example-root';
+		$src    = '/wp-includes/js/script.js';
+
+		wp_enqueue_script( $handle, $src );
+
+		$expected = file_get_contents( DIR_TESTDATA . '/languages/en_US-813e104eb47e13dd4cc5af844c618754.json' );
+		$this->assertSame( $expected, load_script_textdomain( $handle ) );
+	}
 }


### PR DESCRIPTION
👉🏻 **This PR is part of a series of PRs to get the builds passing on PHP 8.1 (to prevent having to _also_ allow failures on PHP 8.2, even when the PHP 8.2 issues are fixed (for a certain definition of "fixed")).**

---

The `$path` parameter has a default value of `null`, but would be passed onto the `untrailingslashit()` function without any input validation, even though the `untrailingslashit()` function explicitly only expects/supports a string input.

> :point_right: An alternative - and possibly better - solution would be to change the default value of the `$path` parameter to an empty string.
> However, such a change would have a wider impact as all function calls which currently pass the `null` default value for `$path` would need to be updated as well. Within WP, this is largely an issue in the tests, but it _could_ potentially have an impact on external calls to the function as well.

Note: I'm explicitly not changing the `untrailingslashit()` function, but fixing this at the point where the invalid input is incorrectly (not) validated.

Includes adding a dedicated unit test for this issue.

This fix also allows to remove a couple of calls to `expectDeprecation()` in unrelated tests.

Fixes:
```
4) Tests_Dependencies_Scripts::test_wp_external_wp_i18n_print_order
rtrim(): Passing null to parameter #1 ($string) of type string is deprecated

/var/www/src/wp-includes/formatting.php:2782
/var/www/src/wp-includes/l10n.php:1068
/var/www/src/wp-includes/class.wp-scripts.php:605
/var/www/src/wp-includes/class.wp-scripts.php:320
/var/www/src/wp-includes/class.wp-dependencies.php:136
/var/www/src/wp-includes/functions.wp-scripts.php:109
/var/www/tests/phpunit/tests/dependencies/scripts.php:1505
/var/www/tests/phpunit/includes/utils.php:436
/var/www/tests/phpunit/tests/dependencies/scripts.php:1507
/var/www/vendor/bin/phpunit:123
```

Trac ticket: https://core.trac.wordpress.org/ticket/55656

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
