### PR TITLE
PHP 8.1 | wp_xmlrpc_server::(mw_newPost|_insert_post)(): fix passing null to non-nullable and more

### DIFF
--- a/src/wp-includes/class-wp-xmlrpc-server.php
+++ b/src/wp-includes/class-wp-xmlrpc-server.php
@@ -1411,19 +1411,19 @@ class wp_xmlrpc_server extends IXR_Server {
 		$defaults = array(
 			'post_status'    => 'draft',
 			'post_type'      => 'post',
-			'post_author'    => null,
-			'post_password'  => null,
-			'post_excerpt'   => null,
-			'post_content'   => null,
-			'post_title'     => null,
-			'post_date'      => null,
-			'post_date_gmt'  => null,
+			'post_author'    => 0,
+			'post_password'  => '',
+			'post_excerpt'   => '',
+			'post_content'   => '',
+			'post_title'     => '',
+			'post_date'      => '',
+			'post_date_gmt'  => '',
 			'post_format'    => null,
 			'post_name'      => null,
 			'post_thumbnail' => null,
-			'post_parent'    => null,
-			'ping_status'    => null,
-			'comment_status' => null,
+			'post_parent'    => 0,
+			'ping_status'    => '',
+			'comment_status' => '',
 			'custom_fields'  => null,
 			'terms_names'    => null,
 			'terms'          => null,
@@ -1498,11 +1498,11 @@ class wp_xmlrpc_server extends IXR_Server {
 			$post_data['post_author'] = $user->ID;
 		}
 
-		if ( isset( $post_data['comment_status'] ) && 'open' !== $post_data['comment_status'] && 'closed' !== $post_data['comment_status'] ) {
+		if ( 'open' !== $post_data['comment_status'] && 'closed' !== $post_data['comment_status'] ) {
 			unset( $post_data['comment_status'] );
 		}
 
-		if ( isset( $post_data['ping_status'] ) && 'open' !== $post_data['ping_status'] && 'closed' !== $post_data['ping_status'] ) {
+		if ( 'open' !== $post_data['ping_status'] && 'closed' !== $post_data['ping_status'] ) {
 			unset( $post_data['ping_status'] );
 		}
 
@@ -1679,6 +1679,14 @@ class wp_xmlrpc_server extends IXR_Server {
 		 * @param array $content_struct Post data array.
 		 */
 		$post_data = apply_filters( 'xmlrpc_wp_insert_post_data', $post_data, $content_struct );
+
+		// Remove all null values to allow for using the insert/update post default values for those keys instead.
+		$post_data = array_filter(
+			$post_data,
+			static function ( $value ) {
+				return null !== $value;
+			}
+		);
 
 		$post_ID = $update ? wp_update_post( $post_data, true ) : wp_insert_post( $post_data, true );
 		if ( is_wp_error( $post_ID ) ) {

--- a/src/wp-includes/class-wp-xmlrpc-server.php
+++ b/src/wp-includes/class-wp-xmlrpc-server.php
@@ -5398,30 +5398,27 @@ class wp_xmlrpc_server extends IXR_Server {
 
 		// Let WordPress generate the 'post_name' (slug) unless
 		// one has been provided.
-		$post_name = '';
+		$post_name = null;
 		if ( isset( $content_struct['wp_slug'] ) ) {
 			$post_name = $content_struct['wp_slug'];
 		}
 
 		// Only use a password if one was given.
+		$post_password = '';
 		if ( isset( $content_struct['wp_password'] ) ) {
 			$post_password = $content_struct['wp_password'];
-		} else {
-			$post_password = '';
 		}
 
 		// Only set a post parent if one was given.
+		$post_parent = 0;
 		if ( isset( $content_struct['wp_page_parent_id'] ) ) {
 			$post_parent = $content_struct['wp_page_parent_id'];
-		} else {
-			$post_parent = 0;
 		}
 
 		// Only set the 'menu_order' if it was given.
+		$menu_order = 0;
 		if ( isset( $content_struct['wp_page_order'] ) ) {
 			$menu_order = $content_struct['wp_page_order'];
-		} else {
-			$menu_order = 0;
 		}
 
 		$post_author = $user->ID;
@@ -5449,8 +5446,8 @@ class wp_xmlrpc_server extends IXR_Server {
 			$post_author = $content_struct['wp_author_id'];
 		}
 
-		$post_title   = isset( $content_struct['title'] ) ? $content_struct['title'] : null;
-		$post_content = isset( $content_struct['description'] ) ? $content_struct['description'] : null;
+		$post_title   = isset( $content_struct['title'] ) ? $content_struct['title'] : '';
+		$post_content = isset( $content_struct['description'] ) ? $content_struct['description'] : '';
 
 		$post_status = $publish ? 'publish' : 'draft';
 
@@ -5463,15 +5460,15 @@ class wp_xmlrpc_server extends IXR_Server {
 					$post_status = $content_struct[ "{$post_type}_status" ];
 					break;
 				default:
-					$post_status = $publish ? 'publish' : 'draft';
+					// Deliberably left empty.
 					break;
 			}
 		}
 
-		$post_excerpt = isset( $content_struct['mt_excerpt'] ) ? $content_struct['mt_excerpt'] : null;
-		$post_more    = isset( $content_struct['mt_text_more'] ) ? $content_struct['mt_text_more'] : null;
+		$post_excerpt = isset( $content_struct['mt_excerpt'] ) ? $content_struct['mt_excerpt'] : '';
+		$post_more    = isset( $content_struct['mt_text_more'] ) ? $content_struct['mt_text_more'] : '';
 
-		$tags_input = isset( $content_struct['mt_keywords'] ) ? $content_struct['mt_keywords'] : null;
+		$tags_input = isset( $content_struct['mt_keywords'] ) ? $content_struct['mt_keywords'] : array();
 
 		if ( isset( $content_struct['mt_allow_comments'] ) ) {
 			if ( ! is_numeric( $content_struct['mt_allow_comments'] ) ) {
@@ -5535,10 +5532,10 @@ class wp_xmlrpc_server extends IXR_Server {
 		}
 
 		if ( $post_more ) {
-			$post_content = $post_content . '<!--more-->' . $post_more;
+			$post_content .= '<!--more-->' . $post_more;
 		}
 
-		$to_ping = null;
+		$to_ping = '';
 		if ( isset( $content_struct['mt_tb_ping_urls'] ) ) {
 			$to_ping = $content_struct['mt_tb_ping_urls'];
 			if ( is_array( $to_ping ) ) {
@@ -5554,12 +5551,11 @@ class wp_xmlrpc_server extends IXR_Server {
 			$dateCreated = $content_struct['dateCreated']->getIso();
 		}
 
+		$post_date     = '';
+		$post_date_gmt = '';
 		if ( ! empty( $dateCreated ) ) {
 			$post_date     = iso8601_to_datetime( $dateCreated );
 			$post_date_gmt = iso8601_to_datetime( $dateCreated, 'gmt' );
-		} else {
-			$post_date     = '';
-			$post_date_gmt = '';
 		}
 
 		$post_category = array();

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -4024,6 +4024,7 @@ function wp_get_recent_posts( $args = array(), $output = ARRAY_A ) {
  *                                         child terms can have the same names with different parent terms,
  *                                         so the only way to connect them is using ID. Default empty.
  *     @type array  $meta_input            Array of post meta values keyed by their post meta key. Default empty.
+ *     @type string $page_template         Page template to use.
  * }
  * @param bool  $wp_error         Optional. Whether to return a WP_Error on failure. Default false.
  * @param bool  $fire_after_hooks Optional. Whether to fire the after insert hooks. Default true.

--- a/tests/phpunit/tests/date/xmlrpc.php
+++ b/tests/phpunit/tests/date/xmlrpc.php
@@ -14,16 +14,6 @@ class Tests_Date_XMLRPC extends WP_XMLRPC_UnitTestCase {
 	 * @covers wp_xmlrpc_server::mw_newPost
 	 */
 	public function test_date_new_post() {
-		if ( PHP_VERSION_ID >= 80100 ) {
-			/*
-			 * For the time being, ignoring PHP 8.1 "null to non-nullable" deprecations coming in
-			 * via hooked in filter functions until a more structural solution to the
-			 * "missing input validation" conundrum has been architected and implemented.
-			 */
-			$this->expectDeprecation();
-			$this->expectDeprecationMessageMatches( '`Passing null to parameter \#[0-9]+ \(\$[^\)]+\) of type [^ ]+ is deprecated`' );
-		}
-
 		$timezone = 'Europe/Kiev';
 		update_option( 'timezone_string', $timezone );
 


### PR DESCRIPTION
👉🏻 **This PR is part of a series of PRs to get the builds passing on PHP 8.1 (to prevent having to _also_ allow failures on PHP 8.2, even when the PHP 8.2 issues are fixed (for a certain definition of "fixed")).**

---

### PHP 8.1 | wp_xmlrpc_server::mw_newPost(): fix passing null to non-nullable and more

The `wp_xmlrpc_server::mw_newPost()` method creates a new post via `wp_insert_post()`, but the default/fall-back values used in the function were not in line with the default/fall-back values used in the `wp_insert_post()` function.

The `wp_insert_post()` function does a `wp_parse_args()` (array merge) of the received arguments with the defaults.
If any of the received arguments would be `null`, this would overwrite the default value (see: https://3v4l.org/bfVlv ) and will lead to "passing null to non-nullable" deprecation notices on PHP 8.1 for certain arguments.

For this commit, I've:
* Ensured that all arguments are defined before they are `compact()`-ed together to the arguments array.
* Verified that the default/fall-back value of the arguments as set within the `wp_xmlrpc_server::mw_newPost()` method are the same as the default/fall-back values used in the `wp_insert_post()` function.
* Verified that arguments which do not have a default/fall-back value defined in the `wp_insert_post()` function are handled correctly.
    - This was not the case for `$post_name`, which would previously already get an empty string default value in the `wp_xmlrpc_server::mw_newPost()` function, but then in the `wp_insert_post()` function, this would prevent the slug generation from being activated.
        Fixed now by setting the default in the `wp_xmlrpc_server::mw_newPost()` function to `null`..
    - The `page_template` argument was handled, but not documented in the `wp_insert_post()` function. I've now documented the argument in the `wp_insert_post()` function docblock.
        Note: there are more than likely several other potential arguments missing from that list, but verifying the whole list is outside the scope of this particular commit.

Includes minor simplifications, such as:
* Setting a default ahead of an `if`, instead of in an `else` clause (as long as no function call is needed to set the default).
* Remove the unnecessary logic duplication in the `$post_status` switch.
* Using a combined concatenation + assignment operator for adding `$post_more`.

Fixes various errors along the lines of:
```
1) Tests_XMLRPC_mw_editPost::test_draft_not_prematurely_published
strpos(): Passing null to parameter https://github.com/WordPress/wordpress-develop/pull/1 ($haystack) of type string is deprecated

/var/www/src/wp-includes/formatting.php:2497
/var/www/src/wp-includes/class-wp-hook.php:308
/var/www/src/wp-includes/plugin.php:205
/var/www/src/wp-includes/post.php:2835
/var/www/src/wp-includes/post.php:2720
/var/www/src/wp-includes/post.php:4066
/var/www/src/wp-includes/class-wp-xmlrpc-server.php:5616
/var/www/tests/phpunit/tests/xmlrpc/mw/editPost.php:315
```
```
23) Tests_XMLRPC_mw_editPost::test_draft_not_prematurely_published
json_decode(): Passing null to parameter https://github.com/WordPress/wordpress-develop/pull/1 ($json) of type string is deprecated

/var/www/src/wp-includes/kses.php:2074
/var/www/src/wp-includes/class-wp-hook.php:307
/var/www/src/wp-includes/plugin.php:205
/var/www/src/wp-includes/post.php:2835
/var/www/src/wp-includes/post.php:2720
/var/www/src/wp-includes/post.php:4066
/var/www/src/wp-includes/class-wp-xmlrpc-server.php:5615
/var/www/tests/phpunit/tests/xmlrpc/mw/editPost.php:315
/var/www/vendor/bin/phpunit:123
```

### PHP 8.1 | wp_xmlrpc_server::_insert_post(): fix passing null to non-nullable and more

The `wp_xmlrpc_server::_insert_post()` method creates a new post via `wp_insert_post()` or updates an existing one via `wp_update_post()` (which subsequently calls `wp_insert_post()`), but the default/fall-back values used in the function were not in line with the default/fall-back values used in the `wp_insert_post()` function.

The `wp_insert_post()` function does a `wp_parse_args()` (array merge) of the received arguments with the defaults.
If any of the received arguments would be `null`, this would overwrite the default value (see: https://3v4l.org/bfVlv ) and will lead to "passing null to non-nullable" deprecation notices on PHP 8.1 for certain arguments.

Unfortunately, the conditional logic within the `wp_xmlrpc_server::_insert_post()` function itself often uses an `isset()` to trigger certain code blocks., so syncing the defaults with those used in the `wp_insert_post()` function was not an option.

So for this commit, I've:
* I've updated the default/fall-back values in the `$defaults` array only for those values where this would not lead to a change in the behaviour of the function.
* I've also added a safeguard function, filtering out all remaining `null` values from the `$post_data` array before it is passed on to the `wp_insert_post()` or `wp_update_post()` functions.
    Removing those values is safe as this means that these array keys will now:
    - either be set to the default/fall-back value as defined in `wp_insert_post()`.
    - or not be set and for those values which don't have a default/fall-back value in `wp_insert_post()`, `wp_insert_post()` does an `! empty()` or `isset()` check anyway and those array keys not being defined means that the result of those checks will remain the same.

Includes removing a couple of conditions which are now redundant.

Includes removing an `expectDeprecation()` in the `Tests_Date_XMLRPC` test class, which is now no longer needed.

Fixes various errors along the lines of:
```
36) Tests_XMLRPC_wp_newPost::test_no_content
json_decode(): Passing null to parameter https://github.com/WordPress/wordpress-develop/pull/1 ($json) of type string is deprecated

/var/www/src/wp-includes/kses.php:2074
/var/www/src/wp-includes/class-wp-hook.php:307
/var/www/src/wp-includes/plugin.php:205
/var/www/src/wp-includes/post.php:2835
/var/www/src/wp-includes/post.php:2720
/var/www/src/wp-includes/post.php:4066
/var/www/src/wp-includes/class-wp-xmlrpc-server.php:1683
/var/www/src/wp-includes/class-wp-xmlrpc-server.php:1347
/var/www/tests/phpunit/tests/xmlrpc/wp/newPost.php:25
/var/www/vendor/bin/phpunit:123
```


Trac ticket: https://core.trac.wordpress.org/ticket/55656

Closes #1658

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
