### PR TITLE
PHP 8.1 | WP_REST_Users_Controller::update_item(): fix passing null to non-nullable

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
@@ -725,7 +725,10 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 			);
 		}
 
-		$owner_id = email_exists( $request['email'] );
+		$owner_id = false;
+		if ( is_string( $request['email'] ) ) {
+			$owner_id = email_exists( $request['email'] );
+		}
 
 		if ( $owner_id && $owner_id !== $id ) {
 			return new WP_Error(

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
@@ -717,7 +717,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 
 		$id = $user->ID;
 
-		if ( ! $user ) {
+		if ( ! $id ) {
 			return new WP_Error(
 				'rest_user_invalid_id',
 				__( 'Invalid user ID.' ),


### PR DESCRIPTION
👉🏻 **This PR is part of a series of PRs to get the builds passing on PHP 8.1 (to prevent having to _also_ allow failures on PHP 8.2, even when the PHP 8.2 issues are fixed (for a certain definition of "fixed")).**

---

### PHP 8.1 | WP_REST_Users_Controller::update_item(): fix passing null to non-nullable

Not all requests are accompanied by a `$request['email']`. This leads to a PHP 8.1 "passing null to non-nullable" deprecation notice when the `WP_REST_Users_Controller::update_item()` method passes a `null` email address onto `email_exists()`, which eventually reached the `WP_User::get_data_by()` method where things go wrong.

In the next condition in the code of the `WP_REST_Users_Controller::update_item()` method - `if ( $owner_id && $owner_id !== $id )` - you can see that the code already takes this into account as it will not throw a `WP_Error` if `$owner_id` is falsey.

`WP_User::get_data_by()` returns `false` for a failed field request. The other functions through which the return value is passed through, do the same.

So, by setting a default value for `$owner_id` of `false` and only checking `email_exists()` when there is an email to check, the "passing null to non-nullable" deprecation notice is bypassed without breaking BC.

Fixes a whole slew of test errors along the lines of:
```
6) WP_Test_REST_Users_Controller::test_update_item_en_US_locale
trim(): Passing null to parameter https://github.com/WordPress/wordpress-develop/pull/1 ($string) of type string is deprecated

/var/www/src/wp-includes/class-wp-user.php:211
/var/www/src/wp-includes/pluggable.php:105
/var/www/src/wp-includes/user.php:1953
/var/www/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php:728
/var/www/src/wp-includes/rest-api/class-wp-rest-server.php:1143
/var/www/src/wp-includes/rest-api/class-wp-rest-server.php:990
/var/www/tests/phpunit/includes/spy-rest-server.php:67
/var/www/tests/phpunit/tests/rest-api/rest-users-controller.php:1719
/var/www/vendor/bin/phpunit:123
```

Trac ticket: https://core.trac.wordpress.org/ticket/55656

This commit was merged via https://core.trac.wordpress.org/changeset/54317 ✅ 

### WP_REST_Users_Controller::update_item(): bug fix

While looking at the code of the `WP_REST_Users_Controller::update_item()` method, I also noticed another bug.

At the start of the function, the user is retrieved and it is verified that this doesn't result in a `WP_Error`.
Next, the `WP_User` `$user` variable is used to retrieve the user id.

Then in the next condition, it is checked if the `$user` is falsey. This condition would never match as `WP_REST_Users_Controller::get_user()` returns either a `WP_User` object or `WP_Error` and we already know it's not a `WP_Error` and an instantiated `WP_User` object will never evaluate to falsey.

As the `WP_Error` being thrown _within_ the condition refers to an "invalid user id", I believe the _intention_ of the code was to check that `$id` is not falsey, which would make more sense, as even though it would be unlikely that a `WP_User` object would not have a valid ID, that condition _could_ potential match and trigger the `WP_Error`.

There are already tests in place which (try to) cover this code, but as the `WP_REST_Users_Controller::get_user()` method throws the same error, it went unnoticed that this condition is incorrect.

In all honesty, IMO, this whole condition can be removed as it is already handled by the call to `WP_REST_Users_Controller::get_user()`....

Trac ticket: https://core.trac.wordpress.org/ticket/56662

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**

