### PR TITLE
Coding Standards: Rename `$c` to `$blog_count` in `wp-admin/admin.php`.

### DIFF
--- a/src/wp-admin/admin.php
+++ b/src/wp-admin/admin.php
@@ -71,13 +71,13 @@ if ( get_option( 'db_upgraded' ) ) {
 	 * @param bool $do_mu_upgrade Whether to perform the Multisite upgrade routine. Default true.
 	 */
 	if ( apply_filters( 'do_mu_upgrade', true ) ) {
-		$c = get_blog_count();
+		$blog_count = get_blog_count();
 
 		/*
 		 * If there are 50 or fewer sites, run every time. Otherwise, throttle to reduce load:
 		 * attempt to do no more than threshold value, with some +/- allowed.
 		 */
-		if ( $c <= 50 || ( $c > 50 && mt_rand( 0, (int) ( $c / 50 ) ) === 1 ) ) {
+		if ( $blog_count <= 50 || ( $blog_count > 50 && mt_rand( 0, (int) ( $blog_count / 50 ) ) === 1 ) ) {
 			require_once ABSPATH . WPINC . '/http.php';
 			$response = wp_remote_get(
 				admin_url( 'upgrade.php?step=1' ),
@@ -90,7 +90,7 @@ if ( get_option( 'db_upgraded' ) ) {
 			do_action( 'after_mu_upgrade', $response );
 			unset( $response );
 		}
-		unset( $c );
+		unset( $blog_count );
 	}
 }
 


### PR DESCRIPTION
Per naming conventions, don’t abbreviate variable names unnecessarily; let the code be unambiguous and self-documenting.

[See PHP Coding Standards - Naming Conventions](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#naming-conventions).

Trac ticket:
https://core.trac.wordpress.org/ticket/63168
https://core.trac.wordpress.org/ticket/55647
