### PR TITLE
Coding Standards: Use more meaningful variable names in Admin Menu.

### DIFF
--- a/src/wp-admin/menu.php
+++ b/src/wp-admin/menu.php
@@ -110,76 +110,76 @@ $submenu['edit-comments.php'][0] = array( __( 'All Comments' ), 'edit_posts', 'e
 
 $_wp_last_object_menu = 25; // The index of the last top-level menu in the object menu group.
 
-$types   = (array) get_post_types(
+$post_types = (array) get_post_types(
 	array(
 		'show_ui'      => true,
 		'_builtin'     => false,
 		'show_in_menu' => true,
 	)
 );
-$builtin = array( 'post', 'page' );
-foreach ( array_merge( $builtin, $types ) as $ptype ) {
-	$ptype_obj = get_post_type_object( $ptype );
+$builtin    = array( 'post', 'page' );
+foreach ( array_merge( $builtin, $post_types ) as $post_type ) {
+	$post_type_obj = get_post_type_object( $post_type );
 	// Check if it should be a submenu.
-	if ( true !== $ptype_obj->show_in_menu ) {
+	if ( true !== $post_type_obj->show_in_menu ) {
 		continue;
 	}
-	$ptype_menu_position = is_int( $ptype_obj->menu_position ) ? $ptype_obj->menu_position : ++$_wp_last_object_menu; // If we're to use $_wp_last_object_menu, increment it first.
-	$ptype_for_id        = sanitize_html_class( $ptype );
+	$post_type_menu_position = is_int( $post_type_obj->menu_position ) ? $post_type_obj->menu_position : ++$_wp_last_object_menu; // If we're to use $_wp_last_object_menu, increment it first.
+	$post_type_for_id        = sanitize_html_class( $post_type );
 
 	$menu_icon = 'dashicons-admin-post';
-	if ( is_string( $ptype_obj->menu_icon ) ) {
+	if ( is_string( $post_type_obj->menu_icon ) ) {
 		// Special handling for data:image/svg+xml and Dashicons.
-		if ( 0 === strpos( $ptype_obj->menu_icon, 'data:image/svg+xml;base64,' ) || 0 === strpos( $ptype_obj->menu_icon, 'dashicons-' ) ) {
-			$menu_icon = $ptype_obj->menu_icon;
+		if ( 0 === strpos( $post_type_obj->menu_icon, 'data:image/svg+xml;base64,' ) || 0 === strpos( $post_type_obj->menu_icon, 'dashicons-' ) ) {
+			$menu_icon = $post_type_obj->menu_icon;
 		} else {
-			$menu_icon = esc_url( $ptype_obj->menu_icon );
+			$menu_icon = esc_url( $post_type_obj->menu_icon );
 		}
-	} elseif ( in_array( $ptype, $builtin, true ) ) {
-		$menu_icon = 'dashicons-admin-' . $ptype;
+	} elseif ( in_array( $post_type, $builtin, true ) ) {
+		$menu_icon = 'dashicons-admin-' . $post_type;
 	}
 
-	$menu_class = 'menu-top menu-icon-' . $ptype_for_id;
+	$menu_class = 'menu-top menu-icon-' . $post_type_for_id;
 	// 'post' special case.
-	if ( 'post' === $ptype ) {
+	if ( 'post' === $post_type ) {
 		$menu_class    .= ' open-if-no-js';
-		$ptype_file     = 'edit.php';
+		$post_type_file = 'edit.php';
 		$post_new_file  = 'post-new.php';
 		$edit_tags_file = 'edit-tags.php?taxonomy=%s';
 	} else {
-		$ptype_file     = "edit.php?post_type=$ptype";
-		$post_new_file  = "post-new.php?post_type=$ptype";
-		$edit_tags_file = "edit-tags.php?taxonomy=%s&amp;post_type=$ptype";
+		$post_type_file = "edit.php?post_type=$post_type";
+		$post_new_file  = "post-new.php?post_type=$post_type";
+		$edit_tags_file = "edit-tags.php?taxonomy=%s&amp;post_type=$post_type";
 	}
 
-	if ( in_array( $ptype, $builtin, true ) ) {
-		$ptype_menu_id = 'menu-' . $ptype_for_id . 's';
+	if ( in_array( $post_type, $builtin, true ) ) {
+		$post_type_menu_id = 'menu-' . $post_type_for_id . 's';
 	} else {
-		$ptype_menu_id = 'menu-posts-' . $ptype_for_id;
+		$post_type_menu_id = 'menu-posts-' . $post_type_for_id;
 	}
 	/*
-	 * If $ptype_menu_position is already populated or will be populated
+	 * If $post_type_menu_position is already populated or will be populated
 	 * by a hard-coded value below, increment the position.
 	 */
 	$core_menu_positions = array( 59, 60, 65, 70, 75, 80, 85, 99 );
-	while ( isset( $menu[ $ptype_menu_position ] ) || in_array( $ptype_menu_position, $core_menu_positions, true ) ) {
-		$ptype_menu_position++;
+	while ( isset( $menu[ $post_type_menu_position ] ) || in_array( $post_type_menu_position, $core_menu_positions, true ) ) {
+		$post_type_menu_position++;
 	}
 
-	$menu[ $ptype_menu_position ] = array( esc_attr( $ptype_obj->labels->menu_name ), $ptype_obj->cap->edit_posts, $ptype_file, '', $menu_class, $ptype_menu_id, $menu_icon );
-	$submenu[ $ptype_file ][5]    = array( $ptype_obj->labels->all_items, $ptype_obj->cap->edit_posts, $ptype_file );
-	$submenu[ $ptype_file ][10]   = array( $ptype_obj->labels->add_new, $ptype_obj->cap->create_posts, $post_new_file );
+	$menu[ $post_type_menu_position ] = array( esc_attr( $post_type_obj->labels->menu_name ), $post_type_obj->cap->edit_posts, $post_type_file, '', $menu_class, $post_type_menu_id, $menu_icon );
+	$submenu[ $post_type_file ][5]    = array( $post_type_obj->labels->all_items, $post_type_obj->cap->edit_posts, $post_type_file );
+	$submenu[ $post_type_file ][10]   = array( $post_type_obj->labels->add_new, $post_type_obj->cap->create_posts, $post_new_file );
 
 	$submenu_index = 15;
 	foreach ( get_taxonomies( array(), 'objects' ) as $tax ) {
-		if ( ! $tax->show_ui || ! $tax->show_in_menu || ! in_array( $ptype, (array) $tax->object_type, true ) ) {
+		if ( ! $tax->show_ui || ! $tax->show_in_menu || ! in_array( $post_type, (array) $tax->object_type, true ) ) {
 			continue;
 		}
 
-		$submenu[ $ptype_file ][ $submenu_index++ ] = array( esc_attr( $tax->labels->menu_name ), $tax->cap->manage_terms, sprintf( $edit_tags_file, $tax->name ) );
+		$submenu[ $post_type_file ][ $submenu_index++ ] = array( esc_attr( $tax->labels->menu_name ), $tax->cap->manage_terms, sprintf( $edit_tags_file, $tax->name ) );
 	}
 }
-unset( $ptype, $ptype_obj, $ptype_for_id, $ptype_menu_position, $menu_icon, $submenu_index, $tax, $post_new_file );
+unset( $post_type, $post_type_obj, $post_type_for_id, $post_type_menu_position, $menu_icon, $submenu_index, $tax, $post_new_file );
 
 $menu[59] = array( '', 'read', 'separator2', '', 'wp-menu-separator' );
 

--- a/src/wp-admin/menu.php
+++ b/src/wp-admin/menu.php
@@ -171,15 +171,15 @@ foreach ( array_merge( $builtin, $post_types ) as $post_type ) {
 	$submenu[ $post_type_file ][10]   = array( $post_type_obj->labels->add_new, $post_type_obj->cap->create_posts, $post_new_file );
 
 	$submenu_index = 15;
-	foreach ( get_taxonomies( array(), 'objects' ) as $tax ) {
-		if ( ! $tax->show_ui || ! $tax->show_in_menu || ! in_array( $post_type, (array) $tax->object_type, true ) ) {
+	foreach ( get_taxonomies( array(), 'objects' ) as $taxonomy ) {
+		if ( ! $taxonomy->show_ui || ! $taxonomy->show_in_menu || ! in_array( $post_type, (array) $taxonomy->object_type, true ) ) {
 			continue;
 		}
 
-		$submenu[ $post_type_file ][ $submenu_index++ ] = array( esc_attr( $tax->labels->menu_name ), $tax->cap->manage_terms, sprintf( $edit_tags_file, $tax->name ) );
+		$submenu[ $post_type_file ][ $submenu_index++ ] = array( esc_attr( $taxonomy->labels->menu_name ), $taxonomy->cap->manage_terms, sprintf( $edit_tags_file, $taxonomy->name ) );
 	}
 }
-unset( $post_type, $post_type_obj, $post_type_for_id, $post_type_menu_position, $menu_icon, $submenu_index, $tax, $post_new_file );
+unset( $post_type, $post_type_obj, $post_type_for_id, $post_type_menu_position, $menu_icon, $submenu_index, $taxonomy, $post_new_file );
 
 $menu[59] = array( '', 'read', 'separator2', '', 'wp-menu-separator' );
 

--- a/src/wp-admin/menu.php
+++ b/src/wp-admin/menu.php
@@ -35,13 +35,13 @@ if ( ! is_multisite() || current_user_can( 'update_core' ) ) {
 
 if ( ! is_multisite() ) {
 	if ( current_user_can( 'update_core' ) ) {
-		$cap = 'update_core';
+		$capability = 'update_core';
 	} elseif ( current_user_can( 'update_plugins' ) ) {
-		$cap = 'update_plugins';
+		$capability = 'update_plugins';
 	} elseif ( current_user_can( 'update_themes' ) ) {
-		$cap = 'update_themes';
+		$capability = 'update_themes';
 	} else {
-		$cap = 'update_languages';
+		$capability = 'update_languages';
 	}
 	$submenu['index.php'][10] = array(
 		sprintf(
@@ -53,10 +53,10 @@ if ( ! is_multisite() ) {
 				number_format_i18n( $update_data['counts']['total'] )
 			)
 		),
-		$cap,
+		$capability,
 		'update-core.php',
 	);
-	unset( $cap );
+	unset( $capability );
 }
 
 $menu[4] = array( '', 'read', 'separator1', '', 'wp-menu-separator' );

--- a/src/wp-admin/menu.php
+++ b/src/wp-admin/menu.php
@@ -68,14 +68,14 @@ $menu[10]                     = array( __( 'Media' ), 'upload_files', 'upload.ph
 	/* translators: Add new file. */
 	$submenu['upload.php'][10] = array( _x( 'Add New', 'file' ), 'upload_files', 'media-new.php' );
 	$submenu_index             = 15;
-foreach ( get_taxonomies_for_attachments( 'objects' ) as $tax ) {
-	if ( ! $tax->show_ui || ! $tax->show_in_menu ) {
+foreach ( get_taxonomies_for_attachments( 'objects' ) as $taxonomy ) {
+	if ( ! $taxonomy->show_ui || ! $taxonomy->show_in_menu ) {
 		continue;
 	}
 
-	$submenu['upload.php'][ $submenu_index++ ] = array( esc_attr( $tax->labels->menu_name ), $tax->cap->manage_terms, 'edit-tags.php?taxonomy=' . $tax->name . '&amp;post_type=attachment' );
+	$submenu['upload.php'][ $submenu_index++ ] = array( esc_attr( $taxonomy->labels->menu_name ), $taxonomy->cap->manage_terms, 'edit-tags.php?taxonomy=' . $taxonomy->name . '&amp;post_type=attachment' );
 }
-	unset( $tax, $submenu_index );
+	unset( $taxonomy, $submenu_index );
 
 $menu[15]                           = array( __( 'Links' ), 'manage_links', 'link-manager.php', '', 'menu-top menu-icon-links', 'menu-links', 'dashicons-admin-links' );
 	$submenu['link-manager.php'][5] = array( _x( 'All Links', 'admin menu' ), 'manage_links', 'link-manager.php' );

--- a/src/wp-admin/menu.php
+++ b/src/wp-admin/menu.php
@@ -87,15 +87,15 @@ $menu[15]                           = array( __( 'Links' ), 'manage_links', 'lin
 
 // Avoid the comment count query for users who cannot edit_posts.
 if ( current_user_can( 'edit_posts' ) ) {
-	$awaiting_mod      = wp_count_comments();
-	$awaiting_mod      = $awaiting_mod->moderated;
-	$awaiting_mod_i18n = number_format_i18n( $awaiting_mod );
+	$awaiting_moderation      = wp_count_comments();
+	$awaiting_moderation      = $awaiting_moderation->moderated;
+	$awaiting_moderation_i18n = number_format_i18n( $awaiting_moderation );
 	/* translators: %s: Number of comments. */
-	$awaiting_mod_text = sprintf( _n( '%s Comment in moderation', '%s Comments in moderation', $awaiting_mod ), $awaiting_mod_i18n );
+	$awaiting_moderation_text = sprintf( _n( '%s Comment in moderation', '%s Comments in moderation', $awaiting_moderation ), $awaiting_moderation_i18n );
 
 	$menu[25] = array(
 		/* translators: %s: Number of comments. */
-		sprintf( __( 'Comments %s' ), '<span class="awaiting-mod count-' . absint( $awaiting_mod ) . '"><span class="pending-count" aria-hidden="true">' . $awaiting_mod_i18n . '</span><span class="comments-in-moderation-text screen-reader-text">' . $awaiting_mod_text . '</span></span>' ),
+		sprintf( __( 'Comments %s' ), '<span class="awaiting-mod count-' . absint( $awaiting_moderation ) . '"><span class="pending-count" aria-hidden="true">' . $awaiting_moderation_i18n . '</span><span class="comments-in-moderation-text screen-reader-text">' . $awaiting_moderation_text . '</span></span>' ),
 		'edit_posts',
 		'edit-comments.php',
 		'',
@@ -103,7 +103,7 @@ if ( current_user_can( 'edit_posts' ) ) {
 		'menu-comments',
 		'dashicons-admin-comments',
 	);
-	unset( $awaiting_mod );
+	unset( $awaiting_moderation );
 }
 
 $submenu['edit-comments.php'][0] = array( __( 'All Comments' ), 'edit_posts', 'edit-comments.php' );

--- a/src/wp-admin/menu.php
+++ b/src/wp-admin/menu.php
@@ -183,9 +183,9 @@ unset( $post_type, $post_type_obj, $post_type_for_id, $post_type_menu_position, 
 
 $menu[59] = array( '', 'read', 'separator2', '', 'wp-menu-separator' );
 
-$appearance_cap = current_user_can( 'switch_themes' ) ? 'switch_themes' : 'edit_theme_options';
+$appearance_capability = current_user_can( 'switch_themes' ) ? 'switch_themes' : 'edit_theme_options';
 
-$menu[60] = array( __( 'Appearance' ), $appearance_cap, 'themes.php', '', 'menu-top menu-icon-appearance', 'menu-appearance', 'dashicons-admin-appearance' );
+$menu[60] = array( __( 'Appearance' ), $appearance_capability, 'themes.php', '', 'menu-top menu-icon-appearance', 'menu-appearance', 'dashicons-admin-appearance' );
 
 $count = '';
 if ( ! is_multisite() && current_user_can( 'update_themes' ) ) {
@@ -200,7 +200,7 @@ if ( ! is_multisite() && current_user_can( 'update_themes' ) ) {
 }
 
 	/* translators: %s: Number of available theme updates. */
-	$submenu['themes.php'][5] = array( sprintf( __( 'Themes %s' ), $count ), $appearance_cap, 'themes.php' );
+	$submenu['themes.php'][5] = array( sprintf( __( 'Themes %s' ), $count ), $appearance_capability, 'themes.php' );
 
 if ( wp_is_block_theme() ) {
 	$submenu['themes.php'][6] = array(
@@ -230,17 +230,17 @@ if ( current_theme_supports( 'menus' ) || current_theme_supports( 'widgets' ) ) 
 
 if ( current_theme_supports( 'custom-header' ) && current_user_can( 'customize' ) ) {
 	$customize_header_url      = add_query_arg( array( 'autofocus' => array( 'control' => 'header_image' ) ), $customize_url );
-	$submenu['themes.php'][15] = array( __( 'Header' ), $appearance_cap, esc_url( $customize_header_url ), '', 'hide-if-no-customize' );
+	$submenu['themes.php'][15] = array( __( 'Header' ), $appearance_capability, esc_url( $customize_header_url ), '', 'hide-if-no-customize' );
 }
 
 if ( current_theme_supports( 'custom-background' ) && current_user_can( 'customize' ) ) {
 	$customize_background_url  = add_query_arg( array( 'autofocus' => array( 'control' => 'background_image' ) ), $customize_url );
-	$submenu['themes.php'][20] = array( __( 'Background' ), $appearance_cap, esc_url( $customize_background_url ), '', 'hide-if-no-customize' );
+	$submenu['themes.php'][20] = array( __( 'Background' ), $appearance_capability, esc_url( $customize_background_url ), '', 'hide-if-no-customize' );
 }
 
 unset( $customize_url );
 
-unset( $appearance_cap );
+unset( $appearance_capability );
 
 // Add 'Theme File Editor' to the bottom of the Appearance (non-block themes) or Tools (block themes) menu.
 if ( ! is_multisite() ) {

--- a/src/wp-admin/menu.php
+++ b/src/wp-admin/menu.php
@@ -67,15 +67,15 @@ $menu[10]                     = array( __( 'Media' ), 'upload_files', 'upload.ph
 	$submenu['upload.php'][5] = array( __( 'Library' ), 'upload_files', 'upload.php' );
 	/* translators: Add new file. */
 	$submenu['upload.php'][10] = array( _x( 'Add New', 'file' ), 'upload_files', 'media-new.php' );
-	$i                         = 15;
+	$submenu_index             = 15;
 foreach ( get_taxonomies_for_attachments( 'objects' ) as $tax ) {
 	if ( ! $tax->show_ui || ! $tax->show_in_menu ) {
 		continue;
 	}
 
-	$submenu['upload.php'][ $i++ ] = array( esc_attr( $tax->labels->menu_name ), $tax->cap->manage_terms, 'edit-tags.php?taxonomy=' . $tax->name . '&amp;post_type=attachment' );
+	$submenu['upload.php'][ $submenu_index++ ] = array( esc_attr( $tax->labels->menu_name ), $tax->cap->manage_terms, 'edit-tags.php?taxonomy=' . $tax->name . '&amp;post_type=attachment' );
 }
-	unset( $tax, $i );
+	unset( $tax, $submenu_index );
 
 $menu[15]                           = array( __( 'Links' ), 'manage_links', 'link-manager.php', '', 'menu-top menu-icon-links', 'menu-links', 'dashicons-admin-links' );
 	$submenu['link-manager.php'][5] = array( _x( 'All Links', 'admin menu' ), 'manage_links', 'link-manager.php' );
@@ -170,16 +170,16 @@ foreach ( array_merge( $builtin, $types ) as $ptype ) {
 	$submenu[ $ptype_file ][5]    = array( $ptype_obj->labels->all_items, $ptype_obj->cap->edit_posts, $ptype_file );
 	$submenu[ $ptype_file ][10]   = array( $ptype_obj->labels->add_new, $ptype_obj->cap->create_posts, $post_new_file );
 
-	$i = 15;
+	$submenu_index = 15;
 	foreach ( get_taxonomies( array(), 'objects' ) as $tax ) {
 		if ( ! $tax->show_ui || ! $tax->show_in_menu || ! in_array( $ptype, (array) $tax->object_type, true ) ) {
 			continue;
 		}
 
-		$submenu[ $ptype_file ][ $i++ ] = array( esc_attr( $tax->labels->menu_name ), $tax->cap->manage_terms, sprintf( $edit_tags_file, $tax->name ) );
+		$submenu[ $ptype_file ][ $submenu_index++ ] = array( esc_attr( $tax->labels->menu_name ), $tax->cap->manage_terms, sprintf( $edit_tags_file, $tax->name ) );
 	}
 }
-unset( $ptype, $ptype_obj, $ptype_for_id, $ptype_menu_position, $menu_icon, $i, $tax, $post_new_file );
+unset( $ptype, $ptype_obj, $ptype_for_id, $ptype_menu_position, $menu_icon, $submenu_index, $tax, $post_new_file );
 
 $menu[59] = array( '', 'read', 'separator2', '', 'wp-menu-separator' );
 


### PR DESCRIPTION
Per naming conventions, don’t abbreviate variable names unnecessarily; let the code be unambiguous and self-documenting.

[See PHP Coding Standards - Naming Conventions](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#naming-conventions).

This PR includes renaming of the following variables:
- `$i` to `$submenu_index`.
- `$cap` to `$capability`.
- `$tax` to `$taxonomy`.
- Several `$awaiting_mod_*` to `$awaiting_moderation_*`.
- Several `$ptype_*` to `$post_type_*`.
- `$types` to `$post_types`.
- `$appearance_cap` to `$appearance_capability`.

Trac ticket:
https://core.trac.wordpress.org/ticket/63168
https://core.trac.wordpress.org/ticket/55647