### PR TITLE
Coding Standards: Use more meaningful variable names in Plugin Editor.

### DIFF
--- a/src/wp-admin/plugin-editor.php
+++ b/src/wp-admin/plugin-editor.php
@@ -111,9 +111,9 @@ if ( ! is_file( $real_file ) ) {
 } else {
 	// Get the extension of the file.
 	if ( preg_match( '/\.([^.]+)$/', $real_file, $matches ) ) {
-		$ext = strtolower( $matches[1] );
+		$extension = strtolower( $matches[1] );
 		// If extension is not in the acceptable list, skip it.
-		if ( ! in_array( $ext, $editable_extensions, true ) ) {
+		if ( ! in_array( $extension, $editable_extensions, true ) ) {
 			wp_die( sprintf( '<p>%s</p>', __( 'Files of this type are not editable.' ) ) );
 		}
 	}

--- a/src/wp-admin/plugin-editor.php
+++ b/src/wp-admin/plugin-editor.php
@@ -82,9 +82,9 @@ $edit_error     = null;
 $posted_content = null;
 
 if ( 'POST' === $_SERVER['REQUEST_METHOD'] ) {
-	$r = wp_edit_theme_plugin_file( wp_unslash( $_POST ) );
-	if ( is_wp_error( $r ) ) {
-		$edit_error = $r;
+	$edit_result = wp_edit_theme_plugin_file( wp_unslash( $_POST ) );
+	if ( is_wp_error( $edit_result ) ) {
+		$edit_error = $edit_result;
 		if ( check_ajax_referer( 'edit-plugin_' . $file, 'nonce', false ) && isset( $_POST['newcontent'] ) ) {
 			$posted_content = wp_unslash( $_POST['newcontent'] );
 		}


### PR DESCRIPTION
Per naming conventions, don’t abbreviate variable names unnecessarily; let the code be unambiguous and self-documenting.

[See PHP Coding Standards - Naming Conventions](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#naming-conventions).

This PR includes renaming of the following variables:
- `$r` to `$edit_result`.
- `$ext` to `$extension`.

Trac ticket:
https://core.trac.wordpress.org/ticket/63168
https://core.trac.wordpress.org/ticket/55647