### PR TITLE
Coding Standards: Use more meaningful variable names in Media Library.

### DIFF
--- a/src/wp-admin/upload.php
+++ b/src/wp-admin/upload.php
@@ -31,11 +31,11 @@ if ( 'grid' === $mode ) {
 	$query_string = $_GET;
 	// Let JS handle this.
 	unset( $query_string['s'] );
-	$vars   = wp_edit_attachments_query_vars( $query_string );
-	$ignore = array( 'mode', 'post_type', 'post_status', 'posts_per_page' );
-	foreach ( $vars as $key => $value ) {
+	$query_vars = wp_edit_attachments_query_vars( $query_string );
+	$ignore     = array( 'mode', 'post_type', 'post_status', 'posts_per_page' );
+	foreach ( $query_vars as $key => $value ) {
 		if ( ! $value || in_array( $key, $ignore, true ) ) {
-			unset( $vars[ $key ] );
+			unset( $query_vars[ $key ] );
 		}
 	}
 
@@ -44,7 +44,7 @@ if ( 'grid' === $mode ) {
 		'_wpMediaGridSettings',
 		array(
 			'adminUrl'  => parse_url( self_admin_url(), PHP_URL_PATH ),
-			'queryVars' => (object) $vars,
+			'queryVars' => (object) $query_vars,
 		)
 	);
 

--- a/src/wp-admin/upload.php
+++ b/src/wp-admin/upload.php
@@ -28,10 +28,10 @@ if ( 'grid' === $mode ) {
 
 	remove_action( 'admin_head', 'wp_admin_canonical_url' );
 
-	$q = $_GET;
+	$query_string = $_GET;
 	// Let JS handle this.
-	unset( $q['s'] );
-	$vars   = wp_edit_attachments_query_vars( $q );
+	unset( $query_string['s'] );
+	$vars   = wp_edit_attachments_query_vars( $query_string );
 	$ignore = array( 'mode', 'post_type', 'post_status', 'posts_per_page' );
 	foreach ( $vars as $key => $value ) {
 		if ( ! $value || in_array( $key, $ignore, true ) ) {


### PR DESCRIPTION
Per naming conventions, don’t abbreviate variable names unnecessarily; let the code be unambiguous and self-documenting.

[See PHP Coding Standards - Naming Conventions](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#naming-conventions).

This PR includes renaming of the following variables:
- `$q` to `$query_string`.
- `$vars` to `$query_vars`.

Trac ticket:
https://core.trac.wordpress.org/ticket/63168
https://core.trac.wordpress.org/ticket/55647