### PR TITLE
Coding Standards: Use more meaningful variable names in Custom Image Header.

### DIFF
--- a/src/wp-admin/includes/class-custom-image-header.php
+++ b/src/wp-admin/includes/class-custom-image-header.php
@@ -1526,8 +1526,8 @@ endif;
 
 		$already_has_default = false;
 
-		foreach ( $this->default_headers as $k => $h ) {
-			if ( $h['url'] === $default ) {
+		foreach ( $this->default_headers as $k => $header ) {
+			if ( $header['url'] === $default ) {
 				$already_has_default = true;
 				break;
 			}


### PR DESCRIPTION
Per naming conventions, don’t abbreviate variable names unnecessarily; let the code be unambiguous and self-documenting.

[See PHP Coding Standards - Naming Conventions](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#naming-conventions).

This PR includes renaming of the following variables:
- `$h` to `$header`.

Not touched:
- `$oitar` - This is `$ratio` backwards. Props @SergeyBiryukov.
  - This is also used as a hidden form field's name.
  - Not touched by this PR. **If** there's a desire to change it, let's change it on its own after auditing for BC.

There are a couple of variables I'd like some input on:
- `$dst_height` - This could be `$dest_height`, but that doesn't seem like a worthwhile change. Suggestions?
- `$dst_width` - See above.
- **Edit** Feedback received. No change to these.

Trac ticket:
https://core.trac.wordpress.org/ticket/63168
https://core.trac.wordpress.org/ticket/55647