### PR TITLE
Coding Standards: Use more meaningful variable names in Theme Upgrader.

### DIFF
--- a/src/wp-admin/includes/class-theme-upgrader.php
+++ b/src/wp-admin/includes/class-theme-upgrader.php
@@ -311,7 +311,7 @@ class Theme_Upgrader extends WP_Upgrader {
 			return false;
 		}
 
-		$r = $current->response[ $theme ];
+		$upgrade_data = $current->response[ $theme ];
 
 		add_filter( 'upgrader_pre_install', array( $this, 'current_before' ), 10, 2 );
 		add_filter( 'upgrader_post_install', array( $this, 'current_after' ), 10, 2 );
@@ -323,7 +323,7 @@ class Theme_Upgrader extends WP_Upgrader {
 
 		$this->run(
 			array(
-				'package'           => $r['package'],
+				'package'           => $upgrade_data['package'],
 				'destination'       => get_theme_root( $theme ),
 				'clear_destination' => true,
 				'clear_working'     => true,
@@ -433,11 +433,11 @@ class Theme_Upgrader extends WP_Upgrader {
 			}
 
 			// Get the URL to the zip file.
-			$r = $current->response[ $theme ];
+			$upgrade_data = $current->response[ $theme ];
 
 			$result = $this->run(
 				array(
-					'package'           => $r['package'],
+					'package'           => $upgrade_data['package'],
 					'destination'       => get_theme_root( $theme ),
 					'clear_destination' => true,
 					'clear_working'     => true,

--- a/src/wp-admin/includes/class-theme-upgrader.php
+++ b/src/wp-admin/includes/class-theme-upgrader.php
@@ -542,7 +542,7 @@ class Theme_Upgrader extends WP_Upgrader {
 		}
 
 		// All these headers are needed on Theme_Installer_Skin::do_overwrite().
-		$info = get_file_data(
+		$new_theme_data = get_file_data(
 			$working_directory . 'style.css',
 			array(
 				'Name'        => 'Theme Name',
@@ -554,7 +554,7 @@ class Theme_Upgrader extends WP_Upgrader {
 			)
 		);
 
-		if ( empty( $info['Name'] ) ) {
+		if ( empty( $new_theme_data['Name'] ) ) {
 			return new WP_Error(
 				'incompatible_archive_theme_no_name',
 				$this->strings['incompatible_archive'],
@@ -572,7 +572,7 @@ class Theme_Upgrader extends WP_Upgrader {
 		 * - block themes require /templates/index.html or block-templates/index.html (deprecated 5.9.0).
 		 */
 		if (
-			empty( $info['Template'] ) &&
+			empty( $new_theme_data['Template'] ) &&
 			! file_exists( $working_directory . 'index.php' ) &&
 			! file_exists( $working_directory . 'templates/index.html' ) &&
 			! file_exists( $working_directory . 'block-templates/index.html' )
@@ -592,8 +592,8 @@ class Theme_Upgrader extends WP_Upgrader {
 			);
 		}
 
-		$requires_php = isset( $info['RequiresPHP'] ) ? $info['RequiresPHP'] : null;
-		$requires_wp  = isset( $info['RequiresWP'] ) ? $info['RequiresWP'] : null;
+		$requires_php = isset( $new_theme_data['RequiresPHP'] ) ? $new_theme_data['RequiresPHP'] : null;
+		$requires_wp  = isset( $new_theme_data['RequiresWP'] ) ? $new_theme_data['RequiresWP'] : null;
 
 		if ( ! is_php_version_compatible( $requires_php ) ) {
 			$error = sprintf(
@@ -616,7 +616,7 @@ class Theme_Upgrader extends WP_Upgrader {
 			return new WP_Error( 'incompatible_wp_required_version', $this->strings['incompatible_archive'], $error );
 		}
 
-		$this->new_theme_data = $info;
+		$this->new_theme_data = $new_theme_data;
 
 		return $source;
 	}

--- a/src/wp-admin/includes/class-theme-upgrader.php
+++ b/src/wp-admin/includes/class-theme-upgrader.php
@@ -392,8 +392,8 @@ class Theme_Upgrader extends WP_Upgrader {
 		$this->skin->header();
 
 		// Connect to the filesystem first.
-		$res = $this->fs_connect( array( WP_CONTENT_DIR ) );
-		if ( ! $res ) {
+		$connected = $this->fs_connect( array( WP_CONTENT_DIR ) );
+		if ( ! $connected ) {
 			$this->skin->footer();
 			return false;
 		}


### PR DESCRIPTION
Per naming conventions, don’t abbreviate variable names unnecessarily; let the code be unambiguous and self-documenting.

[See PHP Coding Standards - Naming Conventions](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#naming-conventions).

This PR includes renaming of the following variables:
- `$r` to `$upgrade_data`.
- `$res` to `$connected`.
- `$info` to `$new_theme_data`.

Trac ticket:
https://core.trac.wordpress.org/ticket/63168
https://core.trac.wordpress.org/ticket/55647