### PR TITLE
Coding Standards: Use more meaningful variable names in Plugin Upgrader.

### DIFF
--- a/src/wp-admin/includes/class-plugin-upgrader.php
+++ b/src/wp-admin/includes/class-plugin-upgrader.php
@@ -428,9 +428,9 @@ class Plugin_Upgrader extends WP_Upgrader {
 		$files = glob( $working_directory . '*.php' );
 		if ( $files ) {
 			foreach ( $files as $file ) {
-				$info = get_plugin_data( $file, false, false );
-				if ( ! empty( $info['Name'] ) ) {
-					$this->new_plugin_data = $info;
+				$new_plugin_data = get_plugin_data( $file, false, false );
+				if ( ! empty( $new_plugin_data['Name'] ) ) {
+					$this->new_plugin_data = $new_plugin_data;
 					break;
 				}
 			}
@@ -440,8 +440,8 @@ class Plugin_Upgrader extends WP_Upgrader {
 			return new WP_Error( 'incompatible_archive_no_plugins', $this->strings['incompatible_archive'], __( 'No valid plugins were found.' ) );
 		}
 
-		$requires_php = isset( $info['RequiresPHP'] ) ? $info['RequiresPHP'] : null;
-		$requires_wp  = isset( $info['RequiresWP'] ) ? $info['RequiresWP'] : null;
+		$requires_php = isset( $new_plugin_data['RequiresPHP'] ) ? $new_plugin_data['RequiresPHP'] : null;
+		$requires_wp  = isset( $new_plugin_data['RequiresWP'] ) ? $new_plugin_data['RequiresWP'] : null;
 
 		if ( ! is_php_version_compatible( $requires_php ) ) {
 			$error = sprintf(

--- a/src/wp-admin/includes/class-plugin-upgrader.php
+++ b/src/wp-admin/includes/class-plugin-upgrader.php
@@ -492,9 +492,9 @@ class Plugin_Upgrader extends WP_Upgrader {
 		}
 
 		// Assume the requested plugin is the first in the list.
-		$pluginfiles = array_keys( $plugin );
+		$plugin_files = array_keys( $plugin );
 
-		return $this->result['destination_name'] . '/' . $pluginfiles[0];
+		return $this->result['destination_name'] . '/' . $plugin_files[0];
 	}
 
 	/**

--- a/src/wp-admin/includes/class-plugin-upgrader.php
+++ b/src/wp-admin/includes/class-plugin-upgrader.php
@@ -290,8 +290,8 @@ class Plugin_Upgrader extends WP_Upgrader {
 		$this->skin->header();
 
 		// Connect to the filesystem first.
-		$res = $this->fs_connect( array( WP_CONTENT_DIR, WP_PLUGIN_DIR ) );
-		if ( ! $res ) {
+		$connected = $this->fs_connect( array( WP_CONTENT_DIR, WP_PLUGIN_DIR ) );
+		if ( ! $connected ) {
 			$this->skin->footer();
 			return false;
 		}

--- a/src/wp-admin/includes/class-plugin-upgrader.php
+++ b/src/wp-admin/includes/class-plugin-upgrader.php
@@ -206,7 +206,7 @@ class Plugin_Upgrader extends WP_Upgrader {
 		}
 
 		// Get the URL to the zip file.
-		$r = $current->response[ $plugin ];
+		$upgrade_data = $current->response[ $plugin ];
 
 		add_filter( 'upgrader_pre_install', array( $this, 'deactivate_plugin_before_upgrade' ), 10, 2 );
 		add_filter( 'upgrader_pre_install', array( $this, 'active_before' ), 10, 2 );
@@ -221,7 +221,7 @@ class Plugin_Upgrader extends WP_Upgrader {
 
 		$this->run(
 			array(
-				'package'           => $r->package,
+				'package'           => $upgrade_data->package,
 				'destination'       => WP_PLUGIN_DIR,
 				'clear_destination' => true,
 				'clear_working'     => true,
@@ -330,13 +330,13 @@ class Plugin_Upgrader extends WP_Upgrader {
 			}
 
 			// Get the URL to the zip file.
-			$r = $current->response[ $plugin ];
+			$upgrade_data = $current->response[ $plugin ];
 
 			$this->skin->plugin_active = is_plugin_active( $plugin );
 
 			$result = $this->run(
 				array(
-					'package'           => $r->package,
+					'package'           => $upgrade_data->package,
 					'destination'       => WP_PLUGIN_DIR,
 					'clear_destination' => true,
 					'clear_working'     => true,


### PR DESCRIPTION
Per naming conventions, don’t abbreviate variable names unnecessarily; let the code be unambiguous and self-documenting.

[See PHP Coding Standards - Naming Conventions](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#naming-conventions).

This PR includes renaming of the following variables:
- `$r` to `$upgrade_data`.
- `$res` to `$connected`.
- `$pluginfiles` to `$plugin_files` - Per naming conventions, separate words via underscores.
- `$info` to `$new_plugin_data`.

Trac ticket:
https://core.trac.wordpress.org/ticket/63168
https://core.trac.wordpress.org/ticket/55647