### PR TITLE
Coding Standards: Use more meaningful variable names in Admin AJAX actions.

### DIFF
--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -2034,19 +2034,19 @@ function wp_ajax_inline_save() {
 		wp_die();
 	}
 
-	$post_ID = (int) $_POST['post_ID'];
+	$post_id = (int) $_POST['post_ID'];
 
 	if ( 'page' === $_POST['post_type'] ) {
-		if ( ! current_user_can( 'edit_page', $post_ID ) ) {
+		if ( ! current_user_can( 'edit_page', $post_id ) ) {
 			wp_die( __( 'Sorry, you are not allowed to edit this page.' ) );
 		}
 	} else {
-		if ( ! current_user_can( 'edit_post', $post_ID ) ) {
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
 			wp_die( __( 'Sorry, you are not allowed to edit this post.' ) );
 		}
 	}
 
-	$last = wp_check_post_lock( $post_ID );
+	$last = wp_check_post_lock( $post_id );
 	if ( $last ) {
 		$last_user      = get_userdata( $last );
 		$last_user_name = $last_user ? $last_user->display_name : __( 'Someone' );
@@ -2065,7 +2065,7 @@ function wp_ajax_inline_save() {
 
 	$data = &$_POST;
 
-	$post = get_post( $post_ID, ARRAY_A );
+	$post = get_post( $post_id, ARRAY_A );
 
 	// Since it's coming from the database.
 	$post = wp_slash( $post );
@@ -2699,30 +2699,30 @@ function wp_ajax_image_editor() {
 function wp_ajax_set_post_thumbnail() {
 	$json = ! empty( $_REQUEST['json'] ); // New-style request.
 
-	$post_ID = (int) $_POST['post_id'];
-	if ( ! current_user_can( 'edit_post', $post_ID ) ) {
+	$post_id = (int) $_POST['post_id'];
+	if ( ! current_user_can( 'edit_post', $post_id ) ) {
 		wp_die( -1 );
 	}
 
 	$thumbnail_id = (int) $_POST['thumbnail_id'];
 
 	if ( $json ) {
-		check_ajax_referer( "update-post_$post_ID" );
+		check_ajax_referer( "update-post_$post_id" );
 	} else {
-		check_ajax_referer( "set_post_thumbnail-$post_ID" );
+		check_ajax_referer( "set_post_thumbnail-$post_id" );
 	}
 
 	if ( '-1' == $thumbnail_id ) {
-		if ( delete_post_thumbnail( $post_ID ) ) {
-			$return = _wp_post_thumbnail_html( null, $post_ID );
+		if ( delete_post_thumbnail( $post_id ) ) {
+			$return = _wp_post_thumbnail_html( null, $post_id );
 			$json ? wp_send_json_success( $return ) : wp_die( $return );
 		} else {
 			wp_die( 0 );
 		}
 	}
 
-	if ( set_post_thumbnail( $post_ID, $thumbnail_id ) ) {
-		$return = _wp_post_thumbnail_html( $thumbnail_id, $post_ID );
+	if ( set_post_thumbnail( $post_id, $thumbnail_id ) ) {
+		$return = _wp_post_thumbnail_html( $thumbnail_id, $post_id );
 		$json ? wp_send_json_success( $return ) : wp_die( $return );
 	}
 
@@ -2735,11 +2735,11 @@ function wp_ajax_set_post_thumbnail() {
  * @since 4.6.0
  */
 function wp_ajax_get_post_thumbnail_html() {
-	$post_ID = (int) $_POST['post_id'];
+	$post_id = (int) $_POST['post_id'];
 
-	check_ajax_referer( "update-post_$post_ID" );
+	check_ajax_referer( "update-post_$post_id" );
 
-	if ( ! current_user_can( 'edit_post', $post_ID ) ) {
+	if ( ! current_user_can( 'edit_post', $post_id ) ) {
 		wp_die( -1 );
 	}
 
@@ -2750,7 +2750,7 @@ function wp_ajax_get_post_thumbnail_html() {
 		$thumbnail_id = null;
 	}
 
-	$return = _wp_post_thumbnail_html( $thumbnail_id, $post_ID );
+	$return = _wp_post_thumbnail_html( $thumbnail_id, $post_id );
 	wp_send_json_success( $return );
 }
 

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -1586,7 +1586,7 @@ function wp_ajax_add_menu_item() {
  */
 function wp_ajax_add_meta() {
 	check_ajax_referer( 'add-meta', '_ajax_nonce-add-meta' );
-	$c       = 0;
+	$count   = 0;
 	$post_id = (int) $_POST['post_id'];
 	$post    = get_post( $post_id );
 
@@ -1645,7 +1645,7 @@ function wp_ajax_add_meta() {
 			array(
 				'what'         => 'meta',
 				'id'           => $mid,
-				'data'         => _list_meta_row( $meta, $c ),
+				'data'         => _list_meta_row( $meta, $count ),
 				'position'     => 1,
 				'supplemental' => array( 'postid' => $post_id ),
 			)

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -1107,14 +1107,14 @@ function wp_ajax_add_tag() {
 
 	$wp_list_table = _get_list_table( 'WP_Terms_List_Table', array( 'screen' => $_POST['screen'] ) );
 
-	$level     = 0;
-	$noparents = '';
+	$level      = 0;
+	$no_parents = '';
 
 	if ( is_taxonomy_hierarchical( $taxonomy ) ) {
 		$level = count( get_ancestors( $tag->term_id, $taxonomy, 'taxonomy' ) );
 		ob_start();
 		$wp_list_table->single_row( $tag, $level );
-		$noparents = ob_get_clean();
+		$no_parents = ob_get_clean();
 	}
 
 	ob_start();
@@ -1136,7 +1136,7 @@ function wp_ajax_add_tag() {
 			'data'         => $message,
 			'supplemental' => array(
 				'parents'   => $parents,
-				'noparents' => $noparents,
+				'noparents' => $no_parents,
 				'notice'    => $message,
 			),
 		)

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -2228,11 +2228,11 @@ function wp_ajax_find_posts() {
 		wp_send_json_error( __( 'No items found.' ) );
 	}
 
-	$html = '<table class="widefat"><thead><tr><th class="found-radio"><br /></th><th>' . __( 'Title' ) . '</th><th class="no-break">' . __( 'Type' ) . '</th><th class="no-break">' . __( 'Date' ) . '</th><th class="no-break">' . __( 'Status' ) . '</th></tr></thead><tbody>';
-	$alt  = '';
+	$html      = '<table class="widefat"><thead><tr><th class="found-radio"><br /></th><th>' . __( 'Title' ) . '</th><th class="no-break">' . __( 'Type' ) . '</th><th class="no-break">' . __( 'Date' ) . '</th><th class="no-break">' . __( 'Status' ) . '</th></tr></thead><tbody>';
+	$alternate = '';
 	foreach ( $posts as $post ) {
-		$title = trim( $post->post_title ) ? $post->post_title : __( '(no title)' );
-		$alt   = ( 'alternate' === $alt ) ? '' : 'alternate';
+		$title     = trim( $post->post_title ) ? $post->post_title : __( '(no title)' );
+		$alternate = ( 'alternate' === $alternate ) ? '' : 'alternate';
 
 		switch ( $post->post_status ) {
 			case 'publish':
@@ -2257,7 +2257,7 @@ function wp_ajax_find_posts() {
 			$time = mysql2date( __( 'Y/m/d' ), $post->post_date );
 		}
 
-		$html .= '<tr class="' . trim( 'found-posts ' . $alt ) . '"><td class="found-radio"><input type="radio" id="found-' . $post->ID . '" name="found_post_id" value="' . esc_attr( $post->ID ) . '"></td>';
+		$html .= '<tr class="' . trim( 'found-posts ' . $alternate ) . '"><td class="found-radio"><input type="radio" id="found-' . $post->ID . '" name="found_post_id" value="' . esc_attr( $post->ID ) . '"></td>';
 		$html .= '<td><label for="found-' . $post->ID . '">' . esc_html( $title ) . '</label></td><td class="no-break">' . esc_html( $post_types[ $post->post_type ]->labels->singular_name ) . '</td><td class="no-break">' . esc_html( $time ) . '</td><td class="no-break">' . esc_html( $stat ) . ' </td></tr>' . "\n\n";
 	}
 

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3394,9 +3394,9 @@ function wp_ajax_send_link_to_editor() {
 	$type      = 'file';
 	$extension = preg_replace( '/^.+?\.([^.]+)$/', '$1', $src );
 	if ( $extension ) {
-		$ext_type = wp_ext2type( $extension );
-		if ( 'audio' === $ext_type || 'video' === $ext_type ) {
-			$type = $ext_type;
+		$extension_type = wp_ext2type( $extension );
+		if ( 'audio' === $extension_type || 'video' === $extension_type ) {
+			$type = $extension_type;
 		}
 	}
 

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -1547,13 +1547,13 @@ function wp_ajax_add_menu_item() {
 	$menu_items = array();
 
 	foreach ( (array) $item_ids as $menu_item_id ) {
-		$menu_obj = get_post( $menu_item_id );
+		$menu_object = get_post( $menu_item_id );
 
-		if ( ! empty( $menu_obj->ID ) ) {
-			$menu_obj        = wp_setup_nav_menu_item( $menu_obj );
-			$menu_obj->title = empty( $menu_obj->title ) ? __( 'Menu Item' ) : $menu_obj->title;
-			$menu_obj->label = $menu_obj->title; // Don't show "(pending)" in ajax-added items.
-			$menu_items[]    = $menu_obj;
+		if ( ! empty( $menu_object->ID ) ) {
+			$menu_object        = wp_setup_nav_menu_item( $menu_object );
+			$menu_object->title = empty( $menu_object->title ) ? __( 'Menu Item' ) : $menu_object->title;
+			$menu_object->label = $menu_object->title; // Don't show "(pending)" in ajax-added items.
+			$menu_items[]       = $menu_object;
 		}
 	}
 

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -593,15 +593,15 @@ function _wp_ajax_add_hierarchical_term() {
 	$checked_categories = array_map( 'absint', (array) $post_category );
 	$popular_ids        = wp_popular_terms_checklist( $taxonomy->name, 0, 10, false );
 
-	foreach ( $names as $cat_name ) {
-		$cat_name          = trim( $cat_name );
-		$category_nicename = sanitize_title( $cat_name );
+	foreach ( $names as $category_name ) {
+		$category_name     = trim( $category_name );
+		$category_nicename = sanitize_title( $category_name );
 
 		if ( '' === $category_nicename ) {
 			continue;
 		}
 
-		$cat_id = wp_insert_term( $cat_name, $taxonomy->name, array( 'parent' => $parent ) );
+		$cat_id = wp_insert_term( $category_name, $taxonomy->name, array( 'parent' => $parent ) );
 
 		if ( ! $cat_id || is_wp_error( $cat_id ) ) {
 			continue;
@@ -1031,15 +1031,15 @@ function wp_ajax_add_link_category( $action ) {
 	$names    = explode( ',', wp_unslash( $_POST['newcat'] ) );
 	$response = new WP_Ajax_Response();
 
-	foreach ( $names as $cat_name ) {
-		$cat_name = trim( $cat_name );
-		$slug     = sanitize_title( $cat_name );
+	foreach ( $names as $category_name ) {
+		$category_name = trim( $category_name );
+		$slug     = sanitize_title( $category_name );
 
 		if ( '' === $slug ) {
 			continue;
 		}
 
-		$cat_id = wp_insert_term( $cat_name, 'link_category' );
+		$cat_id = wp_insert_term( $category_name, 'link_category' );
 
 		if ( ! $cat_id || is_wp_error( $cat_id ) ) {
 			continue;
@@ -1047,13 +1047,13 @@ function wp_ajax_add_link_category( $action ) {
 			$cat_id = $cat_id['term_id'];
 		}
 
-		$cat_name = esc_html( $cat_name );
+		$category_name = esc_html( $category_name );
 
 		$response->add(
 			array(
 				'what'     => 'link-category',
 				'id'       => $cat_id,
-				'data'     => "<li id='link-category-$cat_id'><label for='in-link-category-$cat_id' class='selectit'><input value='" . esc_attr( $cat_id ) . "' type='checkbox' checked='checked' name='link_category[]' id='in-link-category-$cat_id'/> $cat_name</label></li>",
+				'data'     => "<li id='link-category-$cat_id'><label for='in-link-category-$cat_id' class='selectit'><input value='" . esc_attr( $cat_id ) . "' type='checkbox' checked='checked' name='link_category[]' id='in-link-category-$cat_id'/> $category_name</label></li>",
 				'position' => -1,
 			)
 		);

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -461,7 +461,7 @@ function _wp_ajax_delete_comment_response( $comment_id, $delta = -1 ) {
 
 		$counts = wp_count_comments();
 
-		$x = new WP_Ajax_Response(
+		$response = new WP_Ajax_Response(
 			array(
 				'what'         => 'comment',
 				// Here for completeness - not used.
@@ -485,7 +485,7 @@ function _wp_ajax_delete_comment_response( $comment_id, $delta = -1 ) {
 				),
 			)
 		);
-		$x->send();
+		$response->send();
 	}
 
 	$total += $delta;
@@ -533,7 +533,7 @@ function _wp_ajax_delete_comment_response( $comment_id, $delta = -1 ) {
 	$comment = get_comment( $comment_id );
 	$counts  = wp_count_comments();
 
-	$x = new WP_Ajax_Response(
+	$response = new WP_Ajax_Response(
 		array(
 			'what'         => 'comment',
 			'id'           => $comment_id,
@@ -555,7 +555,7 @@ function _wp_ajax_delete_comment_response( $comment_id, $delta = -1 ) {
 			),
 		)
 	);
-	$x->send();
+	$response->send();
 }
 
 //
@@ -688,8 +688,8 @@ function _wp_ajax_add_hierarchical_term() {
 
 	$add['supplemental'] = array( 'newcat_parent' => $sup );
 
-	$x = new WP_Ajax_Response( $add );
-	$x->send();
+	$response = new WP_Ajax_Response( $add );
+	$response->send();
 }
 
 /**
@@ -962,7 +962,7 @@ function wp_ajax_dim_comment() {
 	$comment = get_comment( $id );
 
 	if ( ! $comment ) {
-		$x = new WP_Ajax_Response(
+		$response = new WP_Ajax_Response(
 			array(
 				'what' => 'comment',
 				'id'   => new WP_Error(
@@ -972,7 +972,7 @@ function wp_ajax_dim_comment() {
 				),
 			)
 		);
-		$x->send();
+		$response->send();
 	}
 
 	if ( ! current_user_can( 'edit_comment', $comment->comment_ID ) && ! current_user_can( 'moderate_comments' ) ) {
@@ -994,13 +994,13 @@ function wp_ajax_dim_comment() {
 	}
 
 	if ( is_wp_error( $result ) ) {
-		$x = new WP_Ajax_Response(
+		$response = new WP_Ajax_Response(
 			array(
 				'what' => 'comment',
 				'id'   => $result,
 			)
 		);
-		$x->send();
+		$response->send();
 	}
 
 	// Decide if we need to send back '1' or a more complicated response including page links and comment counts.
@@ -1028,8 +1028,8 @@ function wp_ajax_add_link_category( $action ) {
 		wp_die( -1 );
 	}
 
-	$names = explode( ',', wp_unslash( $_POST['newcat'] ) );
-	$x     = new WP_Ajax_Response();
+	$names    = explode( ',', wp_unslash( $_POST['newcat'] ) );
+	$response = new WP_Ajax_Response();
 
 	foreach ( $names as $cat_name ) {
 		$cat_name = trim( $cat_name );
@@ -1049,7 +1049,7 @@ function wp_ajax_add_link_category( $action ) {
 
 		$cat_name = esc_html( $cat_name );
 
-		$x->add(
+		$response->add(
 			array(
 				'what'     => 'link-category',
 				'id'       => $cat_id,
@@ -1058,7 +1058,7 @@ function wp_ajax_add_link_category( $action ) {
 			)
 		);
 	}
-	$x->send();
+	$response->send();
 }
 
 /**
@@ -1076,7 +1076,7 @@ function wp_ajax_add_tag() {
 		wp_die( -1 );
 	}
 
-	$x = new WP_Ajax_Response();
+	$response = new WP_Ajax_Response();
 
 	$tag = wp_insert_term( $_POST['tag-name'], $taxonomy, $_POST );
 
@@ -1096,13 +1096,13 @@ function wp_ajax_add_tag() {
 			$error_code = $tag->get_error_code();
 		}
 
-		$x->add(
+		$response->add(
 			array(
 				'what' => 'taxonomy',
 				'data' => new WP_Error( $error_code, $message ),
 			)
 		);
-		$x->send();
+		$response->send();
 	}
 
 	$wp_list_table = _get_list_table( 'WP_Terms_List_Table', array( 'screen' => $_POST['screen'] ) );
@@ -1130,7 +1130,7 @@ function wp_ajax_add_tag() {
 		$message = $messages['_item'][1];
 	}
 
-	$x->add(
+	$response->add(
 		array(
 			'what'         => 'taxonomy',
 			'data'         => $message,
@@ -1142,7 +1142,7 @@ function wp_ajax_add_tag() {
 		)
 	);
 
-	$x->add(
+	$response->add(
 		array(
 			'what'         => 'term',
 			'position'     => $level,
@@ -1150,7 +1150,7 @@ function wp_ajax_add_tag() {
 		)
 	);
 
-	$x->send();
+	$response->send();
 }
 
 /**
@@ -1254,7 +1254,7 @@ function wp_ajax_get_comments( $action ) {
 		wp_die( 1 );
 	}
 
-	$x = new WP_Ajax_Response();
+	$response = new WP_Ajax_Response();
 
 	ob_start();
 	foreach ( $wp_list_table->items as $comment ) {
@@ -1266,14 +1266,14 @@ function wp_ajax_get_comments( $action ) {
 	}
 	$comment_list_item = ob_get_clean();
 
-	$x->add(
+	$response->add(
 		array(
 			'what' => 'comments',
 			'data' => $comment_list_item,
 		)
 	);
 
-	$x->send();
+	$response->send();
 }
 
 /**
@@ -1404,7 +1404,7 @@ function wp_ajax_replyto_comment( $action ) {
 	}
 	$comment_list_item = ob_get_clean();
 
-	$response = array(
+	$response_data = array(
 		'what'     => 'comment',
 		'id'       => $comment->comment_ID,
 		'data'     => $comment_list_item,
@@ -1412,7 +1412,7 @@ function wp_ajax_replyto_comment( $action ) {
 	);
 
 	$counts                   = wp_count_comments();
-	$response['supplemental'] = array(
+	$response_data['supplemental'] = array(
 		'in_moderation'        => $counts->moderated,
 		'i18n_comments_text'   => sprintf(
 			/* translators: %s: Number of comments. */
@@ -1427,13 +1427,13 @@ function wp_ajax_replyto_comment( $action ) {
 	);
 
 	if ( $comment_auto_approved ) {
-		$response['supplemental']['parent_approved'] = $parent->comment_ID;
-		$response['supplemental']['parent_post_id']  = $parent->comment_post_ID;
+		$response_data['supplemental']['parent_approved'] = $parent->comment_ID;
+		$response_data['supplemental']['parent_post_id']  = $parent->comment_post_ID;
 	}
 
-	$x = new WP_Ajax_Response();
-	$x->add( $response );
-	$x->send();
+	$response = new WP_Ajax_Response();
+	$response->add( $response_data );
+	$response->send();
 }
 
 /**
@@ -1477,9 +1477,9 @@ function wp_ajax_edit_comment() {
 	$wp_list_table->single_row( $comment );
 	$comment_list_item = ob_get_clean();
 
-	$x = new WP_Ajax_Response();
+	$response = new WP_Ajax_Response();
 
-	$x->add(
+	$response->add(
 		array(
 			'what'     => 'edit_comment',
 			'id'       => $comment->comment_ID,
@@ -1488,7 +1488,7 @@ function wp_ajax_edit_comment() {
 		)
 	);
 
-	$x->send();
+	$response->send();
 }
 
 /**
@@ -1614,13 +1614,13 @@ function wp_ajax_add_meta() {
 
 			if ( $pid ) {
 				if ( is_wp_error( $pid ) ) {
-					$x = new WP_Ajax_Response(
+					$response = new WP_Ajax_Response(
 						array(
 							'what' => 'meta',
 							'data' => $pid,
 						)
 					);
-					$x->send();
+					$response->send();
 				}
 
 				$mid = add_meta( $pid );
@@ -1641,7 +1641,7 @@ function wp_ajax_add_meta() {
 		$pid  = (int) $meta->post_id;
 		$meta = get_object_vars( $meta );
 
-		$x = new WP_Ajax_Response(
+		$response = new WP_Ajax_Response(
 			array(
 				'what'         => 'meta',
 				'id'           => $mid,
@@ -1680,7 +1680,7 @@ function wp_ajax_add_meta() {
 			}
 		}
 
-		$x = new WP_Ajax_Response(
+		$response = new WP_Ajax_Response(
 			array(
 				'what'         => 'meta',
 				'id'           => $mid,
@@ -1698,7 +1698,7 @@ function wp_ajax_add_meta() {
 			)
 		);
 	}
-	$x->send();
+	$response->send();
 }
 
 /**
@@ -1724,13 +1724,13 @@ function wp_ajax_add_user( $action ) {
 	if ( ! $user_id ) {
 		wp_die( 0 );
 	} elseif ( is_wp_error( $user_id ) ) {
-		$x = new WP_Ajax_Response(
+		$response = new WP_Ajax_Response(
 			array(
 				'what' => 'user',
 				'id'   => $user_id,
 			)
 		);
-		$x->send();
+		$response->send();
 	}
 
 	$user_object   = get_userdata( $user_id );
@@ -1738,7 +1738,7 @@ function wp_ajax_add_user( $action ) {
 
 	$role = current( $user_object->roles );
 
-	$x = new WP_Ajax_Response(
+	$response = new WP_Ajax_Response(
 		array(
 			'what'         => 'user',
 			'id'           => $user_id,
@@ -1753,7 +1753,7 @@ function wp_ajax_add_user( $action ) {
 			),
 		)
 	);
-	$x->send();
+	$response->send();
 }
 
 /**

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -1674,8 +1674,8 @@ function wp_ajax_add_meta() {
 		}
 
 		if ( $meta->meta_value != $value || $meta->meta_key != $key ) {
-			$u = update_metadata_by_mid( 'post', $mid, $value, $key );
-			if ( ! $u ) {
+			$update_result = update_metadata_by_mid( 'post', $mid, $value, $key );
+			if ( ! $update_result ) {
 				wp_die( 0 ); // We know meta exists; we also know it's unchanged (or DB error, in which case there are bigger problems).
 			}
 		}

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -2651,33 +2651,33 @@ function wp_ajax_image_editor() {
 	check_ajax_referer( "image_editor-$attachment_id" );
 	include_once ABSPATH . 'wp-admin/includes/image-edit.php';
 
-	$msg = false;
+	$message = false;
 
 	switch ( $_POST['do'] ) {
 		case 'save':
-			$msg = wp_save_image( $attachment_id );
-			if ( ! empty( $msg->error ) ) {
-				wp_send_json_error( $msg );
+			$message = wp_save_image( $attachment_id );
+			if ( ! empty( $message->error ) ) {
+				wp_send_json_error( $message );
 			}
 
-			wp_send_json_success( $msg );
+			wp_send_json_success( $message );
 			break;
 		case 'scale':
-			$msg = wp_save_image( $attachment_id );
+			$message = wp_save_image( $attachment_id );
 			break;
 		case 'restore':
-			$msg = wp_restore_image( $attachment_id );
+			$message = wp_restore_image( $attachment_id );
 			break;
 	}
 
 	ob_start();
-	wp_image_editor( $attachment_id, $msg );
+	wp_image_editor( $attachment_id, $message );
 	$html = ob_get_clean();
 
-	if ( ! empty( $msg->error ) ) {
+	if ( ! empty( $message->error ) ) {
 		wp_send_json_error(
 			array(
-				'message' => $msg,
+				'message' => $message,
 				'html'    => $html,
 			)
 		);
@@ -2685,7 +2685,7 @@ function wp_ajax_image_editor() {
 
 	wp_send_json_success(
 		array(
-			'message' => $msg,
+			'message' => $message,
 			'html'    => $html,
 		)
 	);

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3391,10 +3391,10 @@ function wp_ajax_send_link_to_editor() {
 	}
 
 	// Figure out what filter to run:
-	$type = 'file';
-	$ext  = preg_replace( '/^.+?\.([^.]+)$/', '$1', $src );
-	if ( $ext ) {
-		$ext_type = wp_ext2type( $ext );
+	$type      = 'file';
+	$extension = preg_replace( '/^.+?\.([^.]+)$/', '$1', $src );
+	if ( $extension ) {
+		$ext_type = wp_ext2type( $extension );
 		if ( 'audio' === $ext_type || 'video' === $ext_type ) {
 			$type = $ext_type;
 		}

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -719,13 +719,13 @@ function wp_ajax_delete_comment() {
 			wp_die( time() );
 		}
 
-		$r = wp_trash_comment( $comment );
+		$result = wp_trash_comment( $comment );
 	} elseif ( isset( $_POST['untrash'] ) && 1 == $_POST['untrash'] ) {
 		if ( 'trash' !== $status ) {
 			wp_die( time() );
 		}
 
-		$r = wp_untrash_comment( $comment );
+		$result = wp_untrash_comment( $comment );
 
 		// Undo trash, not in Trash.
 		if ( ! isset( $_POST['comment_status'] ) || 'trash' !== $_POST['comment_status'] ) {
@@ -736,25 +736,25 @@ function wp_ajax_delete_comment() {
 			wp_die( time() );
 		}
 
-		$r = wp_spam_comment( $comment );
+		$result = wp_spam_comment( $comment );
 	} elseif ( isset( $_POST['unspam'] ) && 1 == $_POST['unspam'] ) {
 		if ( 'spam' !== $status ) {
 			wp_die( time() );
 		}
 
-		$r = wp_unspam_comment( $comment );
+		$result = wp_unspam_comment( $comment );
 
 		// Undo spam, not in spam.
 		if ( ! isset( $_POST['comment_status'] ) || 'spam' !== $_POST['comment_status'] ) {
 			$delta = 1;
 		}
 	} elseif ( isset( $_POST['delete'] ) && 1 == $_POST['delete'] ) {
-		$r = wp_delete_comment( $comment );
+		$result = wp_delete_comment( $comment );
 	} else {
 		wp_die( -1 );
 	}
 
-	if ( $r ) {
+	if ( $result ) {
 		// Decide if we need to send back '1' or a more complicated response including page links and comment counts.
 		_wp_ajax_delete_comment_response( $comment->comment_ID, $delta );
 	}

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -4823,16 +4823,16 @@ function wp_ajax_search_install_plugins() {
  * @see wp_edit_theme_plugin_file()
  */
 function wp_ajax_edit_theme_plugin_file() {
-	$r = wp_edit_theme_plugin_file( wp_unslash( $_POST ) ); // Validation of args is done in wp_edit_theme_plugin_file().
+	$edit_result = wp_edit_theme_plugin_file( wp_unslash( $_POST ) ); // Validation of args is done in wp_edit_theme_plugin_file().
 
-	if ( is_wp_error( $r ) ) {
+	if ( is_wp_error( $edit_result ) ) {
 		wp_send_json_error(
 			array_merge(
 				array(
-					'code'    => $r->get_error_code(),
-					'message' => $r->get_error_message(),
+					'code'    => $edit_result->get_error_code(),
+					'message' => $edit_result->get_error_message(),
 				),
-				(array) $r->get_error_data()
+				(array) $edit_result->get_error_data()
 			)
 		);
 	} else {

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -210,15 +210,15 @@ function wp_ajax_wp_compression_test() {
 
 			if ( false !== stripos( $_SERVER['HTTP_ACCEPT_ENCODING'], 'deflate' ) && function_exists( 'gzdeflate' ) && ! $force_gzip ) {
 				header( 'Content-Encoding: deflate' );
-				$out = gzdeflate( $test_str, 1 );
+				$output = gzdeflate( $test_str, 1 );
 			} elseif ( false !== stripos( $_SERVER['HTTP_ACCEPT_ENCODING'], 'gzip' ) && function_exists( 'gzencode' ) ) {
 				header( 'Content-Encoding: gzip' );
-				$out = gzencode( $test_str, 1 );
+				$output = gzencode( $test_str, 1 );
 			} else {
 				wp_die( -1 );
 			}
 
-			echo $out;
+			echo $output;
 			wp_die();
 		} elseif ( 'no' === $_GET['test'] ) {
 			check_ajax_referer( 'update_can_compress_scripts' );

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3120,23 +3120,23 @@ function wp_ajax_save_attachment() {
 	}
 
 	if ( wp_attachment_is( 'audio', $post['ID'] ) ) {
-		$changed = false;
-		$id3data = wp_get_attachment_metadata( $post['ID'] );
+		$changed  = false;
+		$id3_data = wp_get_attachment_metadata( $post['ID'] );
 
-		if ( ! is_array( $id3data ) ) {
-			$changed = true;
-			$id3data = array();
+		if ( ! is_array( $id3_data ) ) {
+			$changed  = true;
+			$id3_data = array();
 		}
 
 		foreach ( wp_get_attachment_id3_keys( (object) $post, 'edit' ) as $key => $label ) {
 			if ( isset( $changes[ $key ] ) ) {
-				$changed         = true;
-				$id3data[ $key ] = sanitize_text_field( wp_unslash( $changes[ $key ] ) );
+				$changed          = true;
+				$id3_data[ $key ] = sanitize_text_field( wp_unslash( $changes[ $key ] ) );
 			}
 		}
 
 		if ( $changed ) {
-			wp_update_attachment_metadata( $id, $id3data );
+			wp_update_attachment_metadata( $id, $id3_data );
 		}
 	}
 

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -684,9 +684,9 @@ function _wp_ajax_add_hierarchical_term() {
 		)
 	);
 
-	$sup = ob_get_clean();
+	$supplemental = ob_get_clean();
 
-	$add['supplemental'] = array( 'newcat_parent' => $sup );
+	$add['supplemental'] = array( 'newcat_parent' => $supplemental );
 
 	$response = new WP_Ajax_Response( $add );
 	$response->send();

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -601,15 +601,15 @@ function _wp_ajax_add_hierarchical_term() {
 			continue;
 		}
 
-		$cat_id = wp_insert_term( $category_name, $taxonomy->name, array( 'parent' => $parent ) );
+		$category_id = wp_insert_term( $category_name, $taxonomy->name, array( 'parent' => $parent ) );
 
-		if ( ! $cat_id || is_wp_error( $cat_id ) ) {
+		if ( ! $category_id || is_wp_error( $category_id ) ) {
 			continue;
 		} else {
-			$cat_id = $cat_id['term_id'];
+			$category_id = $category_id['term_id'];
 		}
 
-		$checked_categories[] = $cat_id;
+		$checked_categories[] = $category_id;
 
 		if ( $parent ) { // Do these all at once in a second.
 			continue;
@@ -621,7 +621,7 @@ function _wp_ajax_add_hierarchical_term() {
 			0,
 			array(
 				'taxonomy'             => $taxonomy->name,
-				'descendants_and_self' => $cat_id,
+				'descendants_and_self' => $category_id,
 				'selected_cats'        => $checked_categories,
 				'popular_cats'         => $popular_ids,
 			)
@@ -631,7 +631,7 @@ function _wp_ajax_add_hierarchical_term() {
 
 		$add = array(
 			'what'     => $taxonomy->name,
-			'id'       => $cat_id,
+			'id'       => $category_id,
 			'data'     => str_replace( array( "\n", "\t" ), '', $data ),
 			'position' => -1,
 		);
@@ -1033,18 +1033,18 @@ function wp_ajax_add_link_category( $action ) {
 
 	foreach ( $names as $category_name ) {
 		$category_name = trim( $category_name );
-		$slug     = sanitize_title( $category_name );
+		$slug          = sanitize_title( $category_name );
 
 		if ( '' === $slug ) {
 			continue;
 		}
 
-		$cat_id = wp_insert_term( $category_name, 'link_category' );
+		$category_id = wp_insert_term( $category_name, 'link_category' );
 
-		if ( ! $cat_id || is_wp_error( $cat_id ) ) {
+		if ( ! $category_id || is_wp_error( $category_id ) ) {
 			continue;
 		} else {
-			$cat_id = $cat_id['term_id'];
+			$category_id = $category_id['term_id'];
 		}
 
 		$category_name = esc_html( $category_name );
@@ -1052,8 +1052,8 @@ function wp_ajax_add_link_category( $action ) {
 		$response->add(
 			array(
 				'what'     => 'link-category',
-				'id'       => $cat_id,
-				'data'     => "<li id='link-category-$cat_id'><label for='in-link-category-$cat_id' class='selectit'><input value='" . esc_attr( $cat_id ) . "' type='checkbox' checked='checked' name='link_category[]' id='in-link-category-$cat_id'/> $category_name</label></li>",
+				'id'       => $category_id,
+				'data'     => "<li id='link-category-$category_id'><label for='in-link-category-$category_id' class='selectit'><input value='" . esc_attr( $category_id ) . "' type='checkbox' checked='checked' name='link_category[]' id='in-link-category-$category_id'/> $category_name</label></li>",
 				'position' => -1,
 			)
 		);

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -2998,9 +2998,9 @@ function wp_ajax_query_attachments() {
 		'monthnum',
 	);
 
-	foreach ( get_taxonomies_for_attachments( 'objects' ) as $t ) {
-		if ( $t->query_var && isset( $query[ $t->query_var ] ) ) {
-			$keys[] = $t->query_var;
+	foreach ( get_taxonomies_for_attachments( 'objects' ) as $taxonomy ) {
+		if ( $taxonomy->query_var && isset( $query[ $taxonomy->query_var ] ) ) {
+			$keys[] = $taxonomy->query_var;
 		}
 	}
 

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -1586,12 +1586,12 @@ function wp_ajax_add_menu_item() {
  */
 function wp_ajax_add_meta() {
 	check_ajax_referer( 'add-meta', '_ajax_nonce-add-meta' );
-	$c    = 0;
-	$pid  = (int) $_POST['post_id'];
-	$post = get_post( $pid );
+	$c       = 0;
+	$post_id = (int) $_POST['post_id'];
+	$post    = get_post( $post_id );
 
 	if ( isset( $_POST['metakeyselect'] ) || isset( $_POST['metakeyinput'] ) ) {
-		if ( ! current_user_can( 'edit_post', $pid ) ) {
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
 			wp_die( -1 );
 		}
 
@@ -1603,27 +1603,27 @@ function wp_ajax_add_meta() {
 		if ( 'auto-draft' === $post->post_status ) {
 			$post_data                = array();
 			$post_data['action']      = 'draft'; // Warning fix.
-			$post_data['post_ID']     = $pid;
+			$post_data['post_ID']     = $post_id;
 			$post_data['post_type']   = $post->post_type;
 			$post_data['post_status'] = 'draft';
 			$now                      = time();
 			/* translators: 1: Post creation date, 2: Post creation time. */
 			$post_data['post_title'] = sprintf( __( 'Draft created on %1$s at %2$s' ), gmdate( __( 'F j, Y' ), $now ), gmdate( __( 'g:i a' ), $now ) );
 
-			$pid = edit_post( $post_data );
+			$post_id = edit_post( $post_data );
 
-			if ( $pid ) {
-				if ( is_wp_error( $pid ) ) {
+			if ( $post_id ) {
+				if ( is_wp_error( $post_id ) ) {
 					$response = new WP_Ajax_Response(
 						array(
 							'what' => 'meta',
-							'data' => $pid,
+							'data' => $post_id,
 						)
 					);
 					$response->send();
 				}
 
-				$mid = add_meta( $pid );
+				$mid = add_meta( $post_id );
 				if ( ! $mid ) {
 					wp_die( __( 'Please provide a custom field value.' ) );
 				}
@@ -1631,15 +1631,15 @@ function wp_ajax_add_meta() {
 				wp_die( 0 );
 			}
 		} else {
-			$mid = add_meta( $pid );
+			$mid = add_meta( $post_id );
 			if ( ! $mid ) {
 				wp_die( __( 'Please provide a custom field value.' ) );
 			}
 		}
 
-		$meta = get_metadata_by_mid( 'post', $mid );
-		$pid  = (int) $meta->post_id;
-		$meta = get_object_vars( $meta );
+		$meta    = get_metadata_by_mid( 'post', $mid );
+		$post_id = (int) $meta->post_id;
+		$meta    = get_object_vars( $meta );
 
 		$response = new WP_Ajax_Response(
 			array(
@@ -1647,7 +1647,7 @@ function wp_ajax_add_meta() {
 				'id'           => $mid,
 				'data'         => _list_meta_row( $meta, $c ),
 				'position'     => 1,
-				'supplemental' => array( 'postid' => $pid ),
+				'supplemental' => array( 'postid' => $post_id ),
 			)
 		);
 	} else { // Update?

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -2285,7 +2285,7 @@ function wp_ajax_widgets_order() {
 		$sidebars = array();
 
 		foreach ( wp_unslash( $_POST['sidebars'] ) as $key => $val ) {
-			$sb = array();
+			$sidebar = array();
 
 			if ( ! empty( $val ) ) {
 				$val = explode( ',', $val );
@@ -2295,10 +2295,10 @@ function wp_ajax_widgets_order() {
 						continue;
 					}
 
-					$sb[ $k ] = substr( $v, strpos( $v, '_' ) + 1 );
+					$sidebar[ $k ] = substr( $v, strpos( $v, '_' ) + 1 );
 				}
 			}
-			$sidebars[ $key ] = $sb;
+			$sidebars[ $key ] = $sidebar;
 		}
 
 		wp_set_sidebars_widgets( $sidebars );


### PR DESCRIPTION
Per naming conventions, don’t abbreviate variable names unnecessarily; let the code be unambiguous and self-documenting.

[See PHP Coding Standards - Naming Conventions](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#naming-conventions).

This PR includes renaming of the following variables:
- `$post_ID` to `$post_id`. - "Use lowercase letters in variable, action/filter, and function names"
- `$ext_type` to `$extension_type`.
- `$ext` to `$extension`.
- `$id3data` to `$id3_data`. - "Separate words via underscores."
- `$msg` to `$message`.
- `$sb` to `$sidebar`.
- `$alt` to `$alternate`.
- `$pid` to `$post_id`.
- `$menu_obj` to `$menu_object`.
- `$noparents` to `$no_parents`. - "Separate words via underscores."
- `$sup` to `$supplemental`.
- `$cat_id` to `$category_id`.
- `$cat_name` to `$category_name`.
- `$out` to `$output`.
- `$r` to `$edit_result`.
- `$t` to `$taxonomy`.
- `$u` to `$update_result`.
- `$r` to `$result`.
- `$response` to `$response_data`.
- `$x` to `$response`.

Trac ticket:
https://core.trac.wordpress.org/ticket/64226
https://core.trac.wordpress.org/ticket/63168
https://core.trac.wordpress.org/ticket/55647