### PR TITLE
Style engine: migrate functions, classes and tests

### DIFF
--- a/src/wp-includes/style-engine.php
+++ b/src/wp-includes/style-engine.php
@@ -101,8 +101,8 @@ function wp_style_engine_get_styles( $block_styles, $options = array() ) {
  *
  *     @type string|null $context  An identifier describing the origin of the style object, e.g., 'block-supports' or 'global-styles'. Default is 'block-supports'.
  *                                 When set, the style engine will attempt to store the CSS rules.
- *     @type boolean     $optimize Whether to optimize the CSS output, e.g., combine rules. Default is `false`.
- *     @type boolean     $prettify Whether to add new lines and indents to output. Default is the test of whether the global constant `SCRIPT_DEBUG` is defined.
+ *     @type bool        $optimize Whether to optimize the CSS output, e.g., combine rules. Default is `false`.
+ *     @type bool        $prettify Whether to add new lines and indents to output. Default is the test of whether the global constant `SCRIPT_DEBUG` is defined.
  * }
  *
  * @return string A compiled CSS string.
@@ -149,8 +149,8 @@ function wp_style_engine_get_stylesheet_from_css_rules( $css_rules, $options = a
  * @param array  $options {
  *     Optional. An array of options. Default empty array.
  *
- *     @type boolean $optimize Whether to optimize the CSS output, e.g., combine rules. Default is `false`.
- *     @type boolean $prettify Whether to add new lines and indents to output. Default is the test of whether the global constant `SCRIPT_DEBUG` is defined.
+ *     @type bool $optimize Whether to optimize the CSS output, e.g., combine rules. Default is `false`.
+ *     @type bool $prettify Whether to add new lines and indents to output. Default is the test of whether the global constant `SCRIPT_DEBUG` is defined.
  * }
  *
  * @return string A compiled CSS string.

--- a/src/wp-includes/style-engine.php
+++ b/src/wp-includes/style-engine.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Style engine: Public functions
+ *
+ * This file contains a variety of public functions developers can use to interact with
+ * the Style Engine API.
+ *
+ * @package WordPress
+ * @subpackage StyleEngine
+ * @since 6.1.0
+ */
+
+
+/**
+ * Global public interface method to generate styles from a single style object, e.g.,
+ * the value of a block's attributes.style object or the top level styles in theme.json.
+ * See: https://developer.wordpress.org/block-editor/reference-guides/theme-json-reference/theme-json-living/#styles and
+ * https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/
+ *
+ * Example usage:
+ *
+ * $styles = wp_style_engine_get_styles( array( 'color' => array( 'text' => '#cccccc' ) ) );
+ * // Returns `array( 'css' => 'color: #cccccc', 'declarations' => array( 'color' => '#cccccc' ), 'classnames' => 'has-color' )`.
+ *
+ * @access public
+ * @since 6.1.0
+ *
+ * @param array                 $block_styles The style object.
+ * @param array<string|boolean> $options      array(
+ *     'context' => (string|null) An identifier describing the origin of the style object, e.g., 'block-supports' or 'global-styles'. Default is 'block-supports'.
+ *                  When set, the style engine will attempt to store the CSS rules, where a selector is also passed.
+ *     'convert_vars_to_classnames' => (boolean) Whether to skip converting CSS var:? values to var( --wp--preset--* ) values. Default is `false`.
+ *     'selector'                   => (string) When a selector is passed, `generate()` will return a full CSS rule `$selector { ...rules }`, otherwise a concatenated string of properties and values.
+ * );.
+ *
+ * @return array<string|array> array(
+ *     'css'          => (string) A CSS ruleset or declarations block formatted to be placed in an HTML `style` attribute or tag.
+ *     'declarations' => (array) An array of property/value pairs representing parsed CSS declarations.
+ *     'classnames'   => (string) Classnames separated by a space.
+ * );
+ */
+function wp_style_engine_get_styles( $block_styles, $options = array() ) {
+	if ( ! class_exists( 'WP_Style_Engine' ) ) {
+		return array();
+	}
+
+	$options = wp_parse_args(
+		$options,
+		array(
+			'selector'                   => null,
+			'context'                    => null,
+			'convert_vars_to_classnames' => false,
+		)
+	);
+
+	$parsed_styles = WP_Style_Engine::parse_block_styles( $block_styles, $options );
+
+	// Output.
+	$styles_output = array();
+
+	if ( ! empty( $parsed_styles['declarations'] ) ) {
+		$styles_output['css']          = WP_Style_Engine::compile_css( $parsed_styles['declarations'], $options['selector'] );
+		$styles_output['declarations'] = $parsed_styles['declarations'];
+		if ( ! empty( $options['context'] ) ) {
+			WP_Style_Engine::store_css_rule( $options['context'], $options['selector'], $parsed_styles['declarations'] );
+		}
+	}
+
+	if ( ! empty( $parsed_styles['classnames'] ) ) {
+		$styles_output['classnames'] = implode( ' ', array_unique( $parsed_styles['classnames'] ) );
+	}
+
+	return array_filter( $styles_output );
+}
+
+/**
+ * Returns compiled CSS from a collection of selectors and declarations.
+ * This won't add to any store, but is useful for returning a compiled style sheet from any CSS selector + declarations combos.
+ *
+ * @access public
+ * @since 6.1.0
+ *
+ * @param array<array>  $css_rules array(
+ *      array(
+ *          'selector'    => (string) A CSS selector.
+ *          declarations' => (boolean) An array of CSS definitions, e.g., array( "$property" => "$value" ).
+ *      )
+ *  );.
+ * @param array<string> $options array(
+ *     'context' => (string|null) An identifier describing the origin of the style object, e.g., 'block-supports' or 'global-styles'. Default is 'block-supports'.
+ *                  When set, the style engine will attempt to store the CSS rules.
+ * );.
+ *
+ * @return string A compiled CSS string.
+ */
+function wp_style_engine_get_stylesheet_from_css_rules( $css_rules, $options = array() ) {
+	if ( ! class_exists( 'WP_Style_Engine' ) || empty( $css_rules ) ) {
+		return '';
+	}
+
+	$options = wp_parse_args(
+		$options,
+		array(
+			'context' => null,
+		)
+	);
+
+	$css_rule_objects = array();
+	foreach ( $css_rules as $css_rule ) {
+		if ( empty( $css_rule['selector'] ) || empty( $css_rule['declarations'] ) || ! is_array( $css_rule['declarations'] ) ) {
+			continue;
+		}
+
+		if ( ! empty( $options['context'] ) ) {
+			WP_Style_Engine::store_css_rule( $options['context'], $css_rule['selector'], $css_rule['declarations'] );
+		}
+
+		$css_rule_objects[] = new WP_Style_Engine_CSS_Rule( $css_rule['selector'], $css_rule['declarations'] );
+	}
+
+	if ( empty( $css_rule_objects ) ) {
+		return '';
+	}
+
+	return WP_Style_Engine::compile_stylesheet_from_css_rules( $css_rule_objects );
+}
+
+/**
+ * Returns compiled CSS from a store, if found.
+ *
+ * @access public
+ * @since 6.1.0
+ *
+ * @param string $store_name A valid store name.
+ *
+ * @return string A compiled CSS string.
+ */
+function wp_style_engine_get_stylesheet_from_context( $store_name ) {
+	if ( ! class_exists( 'WP_Style_Engine' ) || empty( $store_name ) ) {
+		return '';
+	}
+
+	return WP_Style_Engine::compile_stylesheet_from_css_rules( WP_Style_Engine::get_store( $store_name )->get_all_rules() );
+}

--- a/src/wp-includes/style-engine.php
+++ b/src/wp-includes/style-engine.php
@@ -25,19 +25,22 @@
  * @access public
  * @since 6.1.0
  *
- * @param array                 $block_styles The style object.
- * @param array<string|boolean> $options      array(
- *     'context' => (string|null) An identifier describing the origin of the style object, e.g., 'block-supports' or 'global-styles'. Default is 'block-supports'.
- *                  When set, the style engine will attempt to store the CSS rules, where a selector is also passed.
- *     'convert_vars_to_classnames' => (boolean) Whether to skip converting CSS var:? values to var( --wp--preset--* ) values. Default is `false`.
- *     'selector'                   => (string) When a selector is passed, `generate()` will return a full CSS rule `$selector { ...rules }`, otherwise a concatenated string of properties and values.
- * );.
+ * @param array $block_styles The style object.
+ * @param array $options {
+ *     Optional. An array of options. Default empty array.
  *
- * @return array<string|array> array(
- *     'css'          => (string) A CSS ruleset or declarations block formatted to be placed in an HTML `style` attribute or tag.
- *     'declarations' => (array) An array of property/value pairs representing parsed CSS declarations.
- *     'classnames'   => (string) Classnames separated by a space.
- * );
+ *     @type string|null $context                    An identifier describing the origin of the style object, e.g., 'block-supports' or 'global-styles'. Default is `null`.
+ *                                                   When set, the style engine will attempt to store the CSS rules, where a selector is also passed.
+ *     @type bool        $convert_vars_to_classnames Whether to skip converting incoming CSS var patterns, e.g., `var:preset|<PRESET_TYPE>|<PRESET_SLUG>`, to var( --wp--preset--* ) values. Default `false`.
+ *     @type string      $selector                   Optional. When a selector is passed, the value of `$css` in the return value will comprise a full CSS rule `$selector { ...$css_declarations }`,
+ *                                                   otherwise, the value will be a concatenated string of CSS declarations.
+ * }
+ *
+ * @return array {
+ *     @type string                $css          A CSS ruleset or declarations block formatted to be placed in an HTML `style` attribute or tag.
+ *     @type array<string, string> $declarations An array of property/value pairs representing parsed CSS declarations.
+ *     @type string                $classnames   Classnames separated by a space.
+ * }
  */
 function wp_style_engine_get_styles( $block_styles, $options = array() ) {
 	if ( ! class_exists( 'WP_Style_Engine' ) ) {
@@ -75,23 +78,32 @@ function wp_style_engine_get_styles( $block_styles, $options = array() ) {
 
 /**
  * Returns compiled CSS from a collection of selectors and declarations.
- * This won't add to any store, but is useful for returning a compiled style sheet from any CSS selector + declarations combos.
+ * Useful for returning a compiled stylesheet from any collection of  CSS selector + declarations.
+ *
+ * Example usage:
+ * $css_rules = array( array( 'selector' => '.elephant-are-cool', 'declarations' => array( 'color' => 'gray', 'width' => '3em' ) ) );
+ * $css       = wp_style_engine_get_stylesheet_from_css_rules( $css_rules );
+ * // Returns `.elephant-are-cool{color:gray;width:3em}`.
  *
  * @access public
  * @since 6.1.0
  *
- * @param array<array>  $css_rules array(
- *      array(
- *          'selector'    => (string) A CSS selector.
- *          declarations' => (boolean) An array of CSS definitions, e.g., array( "$property" => "$value" ).
- *      )
- *  );.
- * @param array<string> $options array(
- *     'context' => (string|null) An identifier describing the origin of the style object, e.g., 'block-supports' or 'global-styles'. Default is 'block-supports'.
- *                  When set, the style engine will attempt to store the CSS rules.
- *    'optimize' => (boolean) Whether to optimize the CSS output, e.g., combine rules.
- *    'prettify' => (boolean) Whether to add new lines to output.
- * );.
+ * @param array $css_rules {
+ *     Required. A collection of CSS rules.
+ *
+ *     @type array ...$0 {
+ *         @type string                $selector     A CSS selector.
+ *         @type array<string, string> $declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
+ *     }
+ * }
+ * @param array $options {
+ *     Optional. An array of options. Default empty array.
+ *
+ *     @type string|null $context  An identifier describing the origin of the style object, e.g., 'block-supports' or 'global-styles'. Default is 'block-supports'.
+ *                                 When set, the style engine will attempt to store the CSS rules.
+ *     @type boolean     $optimize Whether to optimize the CSS output, e.g., combine rules. Default is `false`.
+ *     @type boolean     $prettify Whether to add new lines and indents to output. Default is the test of whether the global constant `SCRIPT_DEBUG` is defined.
+ * }
  *
  * @return string A compiled CSS string.
  */
@@ -133,18 +145,20 @@ function wp_style_engine_get_stylesheet_from_css_rules( $css_rules, $options = a
  * @access public
  * @since 6.1.0
  *
- * @param string $store_name A valid store name.
- * @param array  $options    array(
- *    'optimize' => (boolean) Whether to optimize the CSS output, e.g., combine rules.
- *    'prettify' => (boolean) Whether to add new lines to output.
- * );.
+ * @param string $context A valid context name, corresponding to an existing store key.
+ * @param array  $options {
+ *     Optional. An array of options. Default empty array.
+ *
+ *     @type boolean $optimize Whether to optimize the CSS output, e.g., combine rules. Default is `false`.
+ *     @type boolean $prettify Whether to add new lines and indents to output. Default is the test of whether the global constant `SCRIPT_DEBUG` is defined.
+ * }
  *
  * @return string A compiled CSS string.
  */
-function wp_style_engine_get_stylesheet_from_context( $store_name, $options = array() ) {
-	if ( ! class_exists( 'WP_Style_Engine' ) || empty( $store_name ) ) {
+function wp_style_engine_get_stylesheet_from_context( $context, $options = array() ) {
+	if ( ! class_exists( 'WP_Style_Engine' ) || empty( $context ) ) {
 		return '';
 	}
 
-	return WP_Style_Engine::compile_stylesheet_from_css_rules( WP_Style_Engine::get_store( $store_name )->get_all_rules(), $options );
+	return WP_Style_Engine::compile_stylesheet_from_css_rules( WP_Style_Engine::get_store( $context )->get_all_rules(), $options );
 }

--- a/src/wp-includes/style-engine.php
+++ b/src/wp-includes/style-engine.php
@@ -37,16 +37,12 @@
  * }
  *
  * @return array {
- *     @type string                $css          A CSS ruleset or declarations block formatted to be placed in an HTML `style` attribute or tag.
- *     @type array<string, string> $declarations An array of property/value pairs representing parsed CSS declarations.
- *     @type string                $classnames   Classnames separated by a space.
+ *     @type string   $css          A CSS ruleset or declarations block formatted to be placed in an HTML `style` attribute or tag.
+ *     @type string[] $declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
+ *     @type string   $classnames   Classnames separated by a space.
  * }
  */
 function wp_style_engine_get_styles( $block_styles, $options = array() ) {
-	if ( ! class_exists( 'WP_Style_Engine' ) ) {
-		return array();
-	}
-
 	$options = wp_parse_args(
 		$options,
 		array(
@@ -85,15 +81,14 @@ function wp_style_engine_get_styles( $block_styles, $options = array() ) {
  * $css       = wp_style_engine_get_stylesheet_from_css_rules( $css_rules );
  * // Returns `.elephant-are-cool{color:gray;width:3em}`.
  *
- * @access public
  * @since 6.1.0
  *
  * @param array $css_rules {
  *     Required. A collection of CSS rules.
  *
  *     @type array ...$0 {
- *         @type string                $selector     A CSS selector.
- *         @type array<string, string> $declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
+ *         @type string   $selector     A CSS selector.
+ *         @type string[] $declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
  *     }
  * }
  * @param array $options {
@@ -105,10 +100,10 @@ function wp_style_engine_get_styles( $block_styles, $options = array() ) {
  *     @type bool        $prettify Whether to add new lines and indents to output. Default is the test of whether the global constant `SCRIPT_DEBUG` is defined.
  * }
  *
- * @return string A compiled CSS string.
+ * @return string A string of compiled CSS declarations, or empty string.
  */
 function wp_style_engine_get_stylesheet_from_css_rules( $css_rules, $options = array() ) {
-	if ( ! class_exists( 'WP_Style_Engine' ) || empty( $css_rules ) ) {
+	if ( empty( $css_rules ) ) {
 		return '';
 	}
 
@@ -142,7 +137,6 @@ function wp_style_engine_get_stylesheet_from_css_rules( $css_rules, $options = a
 /**
  * Returns compiled CSS from a store, if found.
  *
- * @access public
  * @since 6.1.0
  *
  * @param string $context A valid context name, corresponding to an existing store key.
@@ -156,9 +150,5 @@ function wp_style_engine_get_stylesheet_from_css_rules( $css_rules, $options = a
  * @return string A compiled CSS string.
  */
 function wp_style_engine_get_stylesheet_from_context( $context, $options = array() ) {
-	if ( ! class_exists( 'WP_Style_Engine' ) || empty( $context ) ) {
-		return '';
-	}
-
 	return WP_Style_Engine::compile_stylesheet_from_css_rules( WP_Style_Engine::get_store( $context )->get_all_rules(), $options );
 }

--- a/src/wp-includes/style-engine.php
+++ b/src/wp-includes/style-engine.php
@@ -89,6 +89,8 @@ function wp_style_engine_get_styles( $block_styles, $options = array() ) {
  * @param array<string> $options array(
  *     'context' => (string|null) An identifier describing the origin of the style object, e.g., 'block-supports' or 'global-styles'. Default is 'block-supports'.
  *                  When set, the style engine will attempt to store the CSS rules.
+ *    'optimize' => (boolean) Whether to optimize the CSS output, e.g., combine rules.
+ *    'prettify' => (boolean) Whether to add new lines to output.
  * );.
  *
  * @return string A compiled CSS string.
@@ -122,7 +124,7 @@ function wp_style_engine_get_stylesheet_from_css_rules( $css_rules, $options = a
 		return '';
 	}
 
-	return WP_Style_Engine::compile_stylesheet_from_css_rules( $css_rule_objects );
+	return WP_Style_Engine::compile_stylesheet_from_css_rules( $css_rule_objects, $options );
 }
 
 /**
@@ -132,13 +134,17 @@ function wp_style_engine_get_stylesheet_from_css_rules( $css_rules, $options = a
  * @since 6.1.0
  *
  * @param string $store_name A valid store name.
+ * @param array  $options    array(
+ *    'optimize' => (boolean) Whether to optimize the CSS output, e.g., combine rules.
+ *    'prettify' => (boolean) Whether to add new lines to output.
+ * );.
  *
  * @return string A compiled CSS string.
  */
-function wp_style_engine_get_stylesheet_from_context( $store_name ) {
+function wp_style_engine_get_stylesheet_from_context( $store_name, $options = array() ) {
 	if ( ! class_exists( 'WP_Style_Engine' ) || empty( $store_name ) ) {
 		return '';
 	}
 
-	return WP_Style_Engine::compile_stylesheet_from_css_rules( WP_Style_Engine::get_store( $store_name )->get_all_rules() );
+	return WP_Style_Engine::compile_stylesheet_from_css_rules( WP_Style_Engine::get_store( $store_name )->get_all_rules(), $options );
 }

--- a/src/wp-includes/style-engine/class-wp-style-engine-css-declarations.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine-css-declarations.php
@@ -14,7 +14,6 @@
  *
  * Holds, sanitizes, processes and prints CSS declarations for the style engine.
  *
- * @access private
  * @since 6.1.0
  */
 class WP_Style_Engine_CSS_Declarations {

--- a/src/wp-includes/style-engine/class-wp-style-engine-css-declarations.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine-css-declarations.php
@@ -36,14 +36,14 @@ class WP_Style_Engine_CSS_Declarations {
 	 *
 	 * @since 6.1.0
 	 *
-	 * @param array $declarations An array of declarations (property => value pairs).
+	 * @param string[] $declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
 	 */
 	public function __construct( $declarations = array() ) {
 		$this->add_declarations( $declarations );
 	}
 
 	/**
-	 * Add a single declaration.
+	 * Adds a single declaration.
 	 *
 	 * @since 6.1.0
 	 *
@@ -53,28 +53,27 @@ class WP_Style_Engine_CSS_Declarations {
 	 * @return WP_Style_Engine_CSS_Declarations Returns the object to allow chaining methods.
 	 */
 	public function add_declaration( $property, $value ) {
-
-		// Sanitize the property.
+		// Sanitizes the property.
 		$property = $this->sanitize_property( $property );
-		// Bail early if the property is empty.
+		// Bails early if the property is empty.
 		if ( empty( $property ) ) {
 			return $this;
 		}
 
-		// Trim the value. If empty, bail early.
+		// Trims the value. If empty, bail early.
 		$value = trim( $value );
 		if ( '' === $value ) {
 			return $this;
 		}
 
-		// Add the declaration property/value pair.
+		// Adds the declaration property/value pair.
 		$this->declarations[ $property ] = $value;
 
 		return $this;
 	}
 
 	/**
-	 * Remove a single declaration.
+	 * Removes a single declaration.
 	 *
 	 * @since 6.1.0
 	 *
@@ -88,7 +87,7 @@ class WP_Style_Engine_CSS_Declarations {
 	}
 
 	/**
-	 * Add multiple declarations.
+	 * Adds multiple declarations.
 	 *
 	 * @since 6.1.0
 	 *
@@ -104,7 +103,7 @@ class WP_Style_Engine_CSS_Declarations {
 	}
 
 	/**
-	 * Remove multiple declarations.
+	 * Removes multiple declarations.
 	 *
 	 * @since 6.1.0
 	 *
@@ -120,7 +119,7 @@ class WP_Style_Engine_CSS_Declarations {
 	}
 
 	/**
-	 * Get the declarations array.
+	 * Gets the declarations array.
 	 *
 	 * @since 6.1.0
 	 *
@@ -139,7 +138,7 @@ class WP_Style_Engine_CSS_Declarations {
 	 * @param string $value    The value to be filtered.
 	 * @param string $spacer   The spacer between the colon and the value. Defaults to an empty string.
 	 *
-	 * @return string The filtered declaration as a single string.
+	 * @return string The filtered declaration or an empty string.
 	 */
 	protected static function filter_declaration( $property, $value, $spacer = '' ) {
 		$filtered_value = wp_strip_all_tags( $value, true );
@@ -177,7 +176,7 @@ class WP_Style_Engine_CSS_Declarations {
 	}
 
 	/**
-	 * Sanitize property names.
+	 * Sanitizes property names.
 	 *
 	 * @since 6.1.0
 	 *

--- a/src/wp-includes/style-engine/class-wp-style-engine-css-declarations.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine-css-declarations.php
@@ -1,0 +1,191 @@
+<?php
+/**
+ * WP_Style_Engine_CSS_Declarations
+ *
+ * Holds, sanitizes and prints CSS rules declarations
+ *
+ * @package WordPress
+ * @subpackage StyleEngine
+ * @since 6.1.0
+ */
+
+/**
+ * Class WP_Style_Engine_CSS_Declarations.
+ *
+ * Holds, sanitizes, processes and prints CSS declarations for the style engine.
+ *
+ * @access private
+ * @since 6.1.0
+ */
+class WP_Style_Engine_CSS_Declarations {
+
+	/**
+	 * An array of CSS declarations (property => value pairs).
+	 *
+	 * @since 6.1.0
+	 *
+	 * @var array
+	 */
+	protected $declarations = array();
+
+	/**
+	 * Constructor for this object.
+	 *
+	 * If a `$declarations` array is passed, it will be used to populate
+	 * the initial $declarations prop of the object by calling add_declarations().
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param array $declarations An array of declarations (property => value pairs).
+	 */
+	public function __construct( $declarations = array() ) {
+		$this->add_declarations( $declarations );
+	}
+
+	/**
+	 * Add a single declaration.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param string $property The CSS property.
+	 * @param string $value    The CSS value.
+	 *
+	 * @return WP_Style_Engine_CSS_Declarations Returns the object to allow chaining methods.
+	 */
+	public function add_declaration( $property, $value ) {
+
+		// Sanitize the property.
+		$property = $this->sanitize_property( $property );
+		// Bail early if the property is empty.
+		if ( empty( $property ) ) {
+			return $this;
+		}
+
+		// Trim the value. If empty, bail early.
+		$value = trim( $value );
+		if ( '' === $value ) {
+			return $this;
+		}
+
+		// Add the declaration property/value pair.
+		$this->declarations[ $property ] = $value;
+
+		return $this;
+	}
+
+	/**
+	 * Remove a single declaration.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param string $property The CSS property.
+	 *
+	 * @return WP_Style_Engine_CSS_Declarations Returns the object to allow chaining methods.
+	 */
+	public function remove_declaration( $property ) {
+		unset( $this->declarations[ $property ] );
+		return $this;
+	}
+
+	/**
+	 * Add multiple declarations.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param array $declarations An array of declarations.
+	 *
+	 * @return WP_Style_Engine_CSS_Declarations Returns the object to allow chaining methods.
+	 */
+	public function add_declarations( $declarations ) {
+		foreach ( $declarations as $property => $value ) {
+			$this->add_declaration( $property, $value );
+		}
+		return $this;
+	}
+
+	/**
+	 * Remove multiple declarations.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param array $properties An array of properties.
+	 *
+	 * @return WP_Style_Engine_CSS_Declarations Returns the object to allow chaining methods.
+	 */
+	public function remove_declarations( $properties = array() ) {
+		foreach ( $properties as $property ) {
+			$this->remove_declaration( $property );
+		}
+		return $this;
+	}
+
+	/**
+	 * Get the declarations array.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @return array
+	 */
+	public function get_declarations() {
+		return $this->declarations;
+	}
+
+	/**
+	 * Filters a CSS property + value pair.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param string $property The CSS property.
+	 * @param string $value    The value to be filtered.
+	 * @param string $spacer   The spacer between the colon and the value. Defaults to an empty string.
+	 *
+	 * @return string The filtered declaration as a single string.
+	 */
+	protected static function filter_declaration( $property, $value, $spacer = '' ) {
+		$filtered_value = wp_strip_all_tags( $value, true );
+		if ( '' !== $filtered_value ) {
+			return safecss_filter_attr( "{$property}:{$spacer}{$filtered_value}" );
+		}
+		return '';
+	}
+
+	/**
+	 * Filters and compiles the CSS declarations.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param boolean $should_prettify Whether to add spacing, new lines and indents.
+	 * @param number  $indent_count    The number of tab indents to apply to the rule. Applies if `prettify` is `true`.
+	 *
+	 * @return string The CSS declarations.
+	 */
+	public function get_declarations_string( $should_prettify = false, $indent_count = 0 ) {
+		$declarations_array  = $this->get_declarations();
+		$declarations_output = '';
+		$indent              = $should_prettify ? str_repeat( "\t", $indent_count ) : '';
+		$suffix              = $should_prettify ? ' ' : '';
+		$suffix              = $should_prettify && $indent_count > 0 ? "\n" : $suffix;
+		$spacer              = $should_prettify ? ' ' : '';
+
+		foreach ( $declarations_array as $property => $value ) {
+			$filtered_declaration = static::filter_declaration( $property, $value, $spacer );
+			if ( $filtered_declaration ) {
+				$declarations_output .= "{$indent}{$filtered_declaration};$suffix";
+			}
+		}
+		return rtrim( $declarations_output );
+	}
+
+	/**
+	 * Sanitize property names.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param string $property The CSS property.
+	 *
+	 * @return string The sanitized property name.
+	 */
+	protected function sanitize_property( $property ) {
+		return sanitize_key( $property );
+	}
+}

--- a/src/wp-includes/style-engine/class-wp-style-engine-css-declarations.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine-css-declarations.php
@@ -154,8 +154,8 @@ class WP_Style_Engine_CSS_Declarations {
 	 *
 	 * @since 6.1.0
 	 *
-	 * @param boolean $should_prettify Whether to add spacing, new lines and indents.
-	 * @param number  $indent_count    The number of tab indents to apply to the rule. Applies if `prettify` is `true`.
+	 * @param bool   $should_prettify Whether to add spacing, new lines and indents.
+	 * @param number $indent_count    The number of tab indents to apply to the rule. Applies if `prettify` is `true`.
 	 *
 	 * @return string The CSS declarations.
 	 */

--- a/src/wp-includes/style-engine/class-wp-style-engine-css-rule.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine-css-rule.php
@@ -14,7 +14,6 @@
  *
  * Holds, sanitizes, processes and prints CSS declarations for the style engine.
  *
- * @access private
  * @since 6.1.0
  */
 class WP_Style_Engine_CSS_Rule {

--- a/src/wp-includes/style-engine/class-wp-style-engine-css-rule.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine-css-rule.php
@@ -118,8 +118,8 @@ class WP_Style_Engine_CSS_Rule {
 	 *
 	 * @since 6.1.0
 	 *
-	 * @param boolean $should_prettify Whether to add spacing, new lines and indents.
-	 * @param number  $indent_count    The number of tab indents to apply to the rule. Applies if `prettify` is `true`.
+	 * @param bool   $should_prettify Whether to add spacing, new lines and indents.
+	 * @param number $indent_count    The number of tab indents to apply to the rule. Applies if `prettify` is `true`.
 	 *
 	 * @return string
 	 */

--- a/src/wp-includes/style-engine/class-wp-style-engine-css-rule.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine-css-rule.php
@@ -42,9 +42,9 @@ class WP_Style_Engine_CSS_Rule {
 	 *
 	 * @since 6.1.0
 	 *
-	 * @param string                                 $selector     The CSS selector.
-	 * @param array|WP_Style_Engine_CSS_Declarations $declarations An array of declarations (property => value pairs),
-	 *                                                             or a WP_Style_Engine_CSS_Declarations object.
+	 * @param string                                    $selector     The CSS selector.
+	 * @param string[]|WP_Style_Engine_CSS_Declarations $declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ),
+	 *                                                                or a WP_Style_Engine_CSS_Declarations object.
 	 */
 	public function __construct( $selector = '', $declarations = array() ) {
 		$this->set_selector( $selector );
@@ -52,7 +52,7 @@ class WP_Style_Engine_CSS_Rule {
 	}
 
 	/**
-	 * Set the selector.
+	 * Sets the selector.
 	 *
 	 * @since 6.1.0
 	 *
@@ -66,7 +66,7 @@ class WP_Style_Engine_CSS_Rule {
 	}
 
 	/**
-	 * Set the declarations.
+	 * Sets the declarations.
 	 *
 	 * @since 6.1.0
 	 *
@@ -92,18 +92,18 @@ class WP_Style_Engine_CSS_Rule {
 	}
 
 	/**
-	 * Get the declarations object.
+	 * Gets the declarations object.
 	 *
 	 * @since 6.1.0
 	 *
-	 * @return WP_Style_Engine_CSS_Declarations
+	 * @return WP_Style_Engine_CSS_Declarations The declarations object.
 	 */
 	public function get_declarations() {
 		return $this->declarations;
 	}
 
 	/**
-	 * Get the full selector.
+	 * Gets the full selector.
 	 *
 	 * @since 6.1.0
 	 *
@@ -114,7 +114,7 @@ class WP_Style_Engine_CSS_Rule {
 	}
 
 	/**
-	 * Get the CSS.
+	 * Gets the CSS.
 	 *
 	 * @since 6.1.0
 	 *
@@ -126,8 +126,8 @@ class WP_Style_Engine_CSS_Rule {
 	public function get_css( $should_prettify = false, $indent_count = 0 ) {
 		$rule_indent         = $should_prettify ? str_repeat( "\t", $indent_count ) : '';
 		$declarations_indent = $should_prettify ? $indent_count + 1 : 0;
-		$new_line            = $should_prettify ? "\n" : '';
-		$space               = $should_prettify ? ' ' : '';
+		$suffix              = $should_prettify ? "\n" : '';
+		$spacer              = $should_prettify ? ' ' : '';
 		$selector            = $should_prettify ? str_replace( ',', ",\n", $this->get_selector() ) : $this->get_selector();
 		$css_declarations    = $this->declarations->get_declarations_string( $should_prettify, $declarations_indent );
 
@@ -135,6 +135,6 @@ class WP_Style_Engine_CSS_Rule {
 			return '';
 		}
 
-		return "{$rule_indent}{$selector}{$space}{{$new_line}{$css_declarations}{$new_line}{$rule_indent}}";
+		return "{$rule_indent}{$selector}{$spacer}{{$suffix}{$css_declarations}{$suffix}{$rule_indent}}";
 	}
 }

--- a/src/wp-includes/style-engine/class-wp-style-engine-css-rule.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine-css-rule.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * WP_Style_Engine_CSS_Rule
+ *
+ * An object for CSS rules.
+ *
+ * @package WordPress
+ * @subpackage StyleEngine
+ * @since 6.1.0
+ */
+
+/**
+ * Class WP_Style_Engine_CSS_Rule.
+ *
+ * Holds, sanitizes, processes and prints CSS declarations for the style engine.
+ *
+ * @access private
+ * @since 6.1.0
+ */
+class WP_Style_Engine_CSS_Rule {
+
+	/**
+	 * The selector.
+	 *
+	 * @since 6.1.0
+	 * @var string
+	 */
+	protected $selector;
+
+	/**
+	 * The selector declarations.
+	 *
+	 * Contains a WP_Style_Engine_CSS_Declarations object.
+	 *
+	 * @since 6.1.0
+	 * @var WP_Style_Engine_CSS_Declarations
+	 */
+	protected $declarations;
+
+	/**
+	 * Constructor
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param string                                 $selector     The CSS selector.
+	 * @param array|WP_Style_Engine_CSS_Declarations $declarations An array of declarations (property => value pairs),
+	 *                                                             or a WP_Style_Engine_CSS_Declarations object.
+	 */
+	public function __construct( $selector = '', $declarations = array() ) {
+		$this->set_selector( $selector );
+		$this->add_declarations( $declarations );
+	}
+
+	/**
+	 * Set the selector.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param string $selector The CSS selector.
+	 *
+	 * @return WP_Style_Engine_CSS_Rule Returns the object to allow chaining of methods.
+	 */
+	public function set_selector( $selector ) {
+		$this->selector = $selector;
+		return $this;
+	}
+
+	/**
+	 * Set the declarations.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param array|WP_Style_Engine_CSS_Declarations $declarations An array of declarations (property => value pairs),
+	 *                                                             or a WP_Style_Engine_CSS_Declarations object.
+	 *
+	 * @return WP_Style_Engine_CSS_Rule Returns the object to allow chaining of methods.
+	 */
+	public function add_declarations( $declarations ) {
+		$is_declarations_object = ! is_array( $declarations );
+		$declarations_array     = $is_declarations_object ? $declarations->get_declarations() : $declarations;
+
+		if ( null === $this->declarations ) {
+			if ( $is_declarations_object ) {
+				$this->declarations = $declarations;
+				return $this;
+			}
+			$this->declarations = new WP_Style_Engine_CSS_Declarations( $declarations_array );
+		}
+		$this->declarations->add_declarations( $declarations_array );
+
+		return $this;
+	}
+
+	/**
+	 * Get the declarations object.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @return WP_Style_Engine_CSS_Declarations
+	 */
+	public function get_declarations() {
+		return $this->declarations;
+	}
+
+	/**
+	 * Get the full selector.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @return string
+	 */
+	public function get_selector() {
+		return $this->selector;
+	}
+
+	/**
+	 * Get the CSS.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param boolean $should_prettify Whether to add spacing, new lines and indents.
+	 * @param number  $indent_count    The number of tab indents to apply to the rule. Applies if `prettify` is `true`.
+	 *
+	 * @return string
+	 */
+	public function get_css( $should_prettify = false, $indent_count = 0 ) {
+		$rule_indent         = $should_prettify ? str_repeat( "\t", $indent_count ) : '';
+		$declarations_indent = $should_prettify ? $indent_count + 1 : 0;
+		$new_line            = $should_prettify ? "\n" : '';
+		$space               = $should_prettify ? ' ' : '';
+		$selector            = $should_prettify ? str_replace( ',', ",\n", $this->get_selector() ) : $this->get_selector();
+		$css_declarations    = $this->declarations->get_declarations_string( $should_prettify, $declarations_indent );
+
+		if ( empty( $css_declarations ) ) {
+			return '';
+		}
+
+		return "{$rule_indent}{$selector}{$space}{{$new_line}{$css_declarations}{$new_line}{$rule_indent}}";
+	}
+}

--- a/src/wp-includes/style-engine/class-wp-style-engine-css-rules-store.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine-css-rules-store.php
@@ -14,7 +14,6 @@
  *
  * Holds, sanitizes, processes and prints CSS declarations for the style engine.
  *
- * @access private
  * @since 6.1.0
  */
 class WP_Style_Engine_CSS_Rules_Store {

--- a/src/wp-includes/style-engine/class-wp-style-engine-css-rules-store.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine-css-rules-store.php
@@ -46,7 +46,7 @@ class WP_Style_Engine_CSS_Rules_Store {
 	protected $rules = array();
 
 	/**
-	 * Get an instance of the store.
+	 * Gets an instance of the store.
 	 *
 	 * @since 6.1.0
 	 *
@@ -67,7 +67,7 @@ class WP_Style_Engine_CSS_Rules_Store {
 	}
 
 	/**
-	 * Get an array of all available stores.
+	 * Gets an array of all available stores.
 	 *
 	 * @since 6.1.0
 	 *
@@ -89,7 +89,7 @@ class WP_Style_Engine_CSS_Rules_Store {
 	}
 
 	/**
-	 * Set the store name.
+	 * Sets the store name.
 	 *
 	 * @since 6.1.0
 	 *
@@ -102,7 +102,7 @@ class WP_Style_Engine_CSS_Rules_Store {
 	}
 
 	/**
-	 * Get the store name.
+	 * Gets the store name.
 	 *
 	 * @since 6.1.0
 	 *
@@ -113,7 +113,7 @@ class WP_Style_Engine_CSS_Rules_Store {
 	}
 
 	/**
-	 * Get an array of all rules.
+	 * Gets an array of all rules.
 	 *
 	 * @since 6.1.0
 	 *
@@ -124,7 +124,7 @@ class WP_Style_Engine_CSS_Rules_Store {
 	}
 
 	/**
-	 * Get a WP_Style_Engine_CSS_Rule object by its selector.
+	 * Gets a WP_Style_Engine_CSS_Rule object by its selector.
 	 * If the rule does not exist, it will be created.
 	 *
 	 * @since 6.1.0
@@ -150,7 +150,7 @@ class WP_Style_Engine_CSS_Rules_Store {
 	}
 
 	/**
-	 * Remove a selector from the store.
+	 * Removes a selector from the store.
 	 *
 	 * @since 6.1.0
 	 *

--- a/src/wp-includes/style-engine/class-wp-style-engine-css-rules-store.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine-css-rules-store.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * WP_Style_Engine_CSS_Rules_Store
+ *
+ * A store for WP_Style_Engine_CSS_Rule objects.
+ *
+ * @package WordPress
+ * @subpackage StyleEngine
+ * @since 6.1.0
+ */
+
+/**
+ * Class WP_Style_Engine_CSS_Rules_Store.
+ *
+ * Holds, sanitizes, processes and prints CSS declarations for the style engine.
+ *
+ * @access private
+ * @since 6.1.0
+ */
+class WP_Style_Engine_CSS_Rules_Store {
+
+	/**
+	 * An array of named WP_Style_Engine_CSS_Rules_Store objects.
+	 *
+	 * @static
+	 *
+	 * @since 6.1.0
+	 * @var WP_Style_Engine_CSS_Rules_Store[]
+	 */
+	protected static $stores = array();
+
+	/**
+	 * The store name.
+	 *
+	 * @since 6.1.0
+	 * @var string
+	 */
+	protected $name = '';
+
+	/**
+	 * An array of CSS Rules objects assigned to the store.
+	 *
+	 * @since 6.1.0
+	 * @var WP_Style_Engine_CSS_Rule[]
+	 */
+	protected $rules = array();
+
+	/**
+	 * Get an instance of the store.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param string $store_name The name of the store.
+	 *
+	 * @return WP_Style_Engine_CSS_Rules_Store|void
+	 */
+	public static function get_store( $store_name = 'default' ) {
+		if ( ! is_string( $store_name ) || empty( $store_name ) ) {
+			return;
+		}
+		if ( ! isset( static::$stores[ $store_name ] ) ) {
+			static::$stores[ $store_name ] = new static();
+			// Set the store name.
+			static::$stores[ $store_name ]->set_name( $store_name );
+		}
+		return static::$stores[ $store_name ];
+	}
+
+	/**
+	 * Get an array of all available stores.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @return WP_Style_Engine_CSS_Rules_Store[]
+	 */
+	public static function get_stores() {
+		return static::$stores;
+	}
+
+	/**
+	 * Clears all stores from static::$stores.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @return void
+	 */
+	public static function remove_all_stores() {
+		static::$stores = array();
+	}
+
+	/**
+	 * Set the store name.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param string $name The store name.
+	 *
+	 * @return void
+	 */
+	public function set_name( $name ) {
+		$this->name = $name;
+	}
+
+	/**
+	 * Get the store name.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @return string
+	 */
+	public function get_name() {
+		return $this->name;
+	}
+
+	/**
+	 * Get an array of all rules.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @return WP_Style_Engine_CSS_Rule[]
+	 */
+	public function get_all_rules() {
+		return $this->rules;
+	}
+
+	/**
+	 * Get a WP_Style_Engine_CSS_Rule object by its selector.
+	 * If the rule does not exist, it will be created.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param string $selector The CSS selector.
+	 *
+	 * @return WP_Style_Engine_CSS_Rule|void Returns a WP_Style_Engine_CSS_Rule object, or null if the selector is empty.
+	 */
+	public function add_rule( $selector ) {
+		$selector = trim( $selector );
+
+		// Bail early if there is no selector.
+		if ( empty( $selector ) ) {
+			return;
+		}
+
+		// Create the rule if it doesn't exist.
+		if ( empty( $this->rules[ $selector ] ) ) {
+			$this->rules[ $selector ] = new WP_Style_Engine_CSS_Rule( $selector );
+		}
+
+		return $this->rules[ $selector ];
+	}
+
+	/**
+	 * Remove a selector from the store.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param string $selector The CSS selector.
+	 *
+	 * @return void
+	 */
+	public function remove_rule( $selector ) {
+		unset( $this->rules[ $selector ] );
+	}
+}

--- a/src/wp-includes/style-engine/class-wp-style-engine-processor.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine-processor.php
@@ -62,7 +62,7 @@ class WP_Style_Engine_Processor {
 	/**
 	 * Adds rules to be processed.
 	 *
-	 * @since 6.1.0 a store to t
+	 * @since 6.1.0
 	 *
 	 * @param WP_Style_Engine_CSS_Rule|WP_Style_Engine_CSS_Rule[] $css_rules A single, or an array of, WP_Style_Engine_CSS_Rule objects from a store or otherwise.
 	 *

--- a/src/wp-includes/style-engine/class-wp-style-engine-processor.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine-processor.php
@@ -14,7 +14,6 @@
  *
  * Compiles styles from stores or collection of CSS rules.
  *
- * @access private
  * @since 6.1.0
  */
 class WP_Style_Engine_Processor {

--- a/src/wp-includes/style-engine/class-wp-style-engine-processor.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine-processor.php
@@ -36,7 +36,7 @@ class WP_Style_Engine_Processor {
 	protected $css_rules = array();
 
 	/**
-	 * Add a store to the processor.
+	 * Adds a store to the processor.
 	 *
 	 * @since 6.1.0
 	 *
@@ -44,7 +44,16 @@ class WP_Style_Engine_Processor {
 	 *
 	 * @return WP_Style_Engine_Processor Returns the object to allow chaining methods.
 	 */
-	public function add_store( WP_Style_Engine_CSS_Rules_Store $store ) {
+	public function add_store( $store ) {
+		if ( ! $store instanceof WP_Style_Engine_CSS_Rules_Store ) {
+			_doing_it_wrong(
+				__METHOD__,
+				__( '$store must be an instance of WP_Style_Engine_CSS_Rules_Store' ),
+				'6.1.0'
+			);
+			return $this;
+		}
+
 		$this->stores[ $store->get_name() ] = $store;
 
 		return $this;
@@ -53,7 +62,7 @@ class WP_Style_Engine_Processor {
 	/**
 	 * Adds rules to be processed.
 	 *
-	 * @since 6.1.0
+	 * @since 6.1.0 a store to t
 	 *
 	 * @param WP_Style_Engine_CSS_Rule|WP_Style_Engine_CSS_Rule[] $css_rules A single, or an array of, WP_Style_Engine_CSS_Rule objects from a store or otherwise.
 	 *
@@ -77,15 +86,15 @@ class WP_Style_Engine_Processor {
 	}
 
 	/**
-	 * Get the CSS rules as a string.
+	 * Gets the CSS rules as a string.
 	 *
 	 * @since 6.1.0
 	 *
 	 * @param array $options   {
 	 *     Optional. An array of options. Default empty array.
 	 *
-	 *     @type boolean $optimize Whether to optimize the CSS output, e.g., combine rules. Default is `false`.
-	 *     @type boolean $prettify Whether to add new lines and indents to output. Default is the test of whether the global constant `SCRIPT_DEBUG` is defined.
+	 *     @type bool $optimize Whether to optimize the CSS output, e.g., combine rules. Default is `false`.
+	 *     @type bool $prettify Whether to add new lines and indents to output. Default is the test of whether the global constant `SCRIPT_DEBUG` is defined.
 	 * }
 	 *
 	 * @return string The computed CSS.

--- a/src/wp-includes/style-engine/class-wp-style-engine-processor.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine-processor.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * WP_Style_Engine_Processor
+ *
+ * Compiles styles from stores or collection of CSS rules.
+ *
+ * @package WordPress
+ * @subpackage StyleEngine
+ * @since 6.1.0
+ */
+
+/**
+ * Class WP_Style_Engine_Processor.
+ *
+ * Compiles styles from stores or collection of CSS rules.
+ *
+ * @access private
+ * @since 6.1.0
+ */
+class WP_Style_Engine_Processor {
+
+	/**
+	 * The Style-Engine Store objects
+	 *
+	 * @since 6.1.0
+	 * @var WP_Style_Engine_CSS_Rules_Store[]
+	 */
+	protected $stores = array();
+
+	/**
+	 * The set of CSS rules that this processor will work on.
+	 *
+	 * @since 6.1.0
+	 * @var WP_Style_Engine_CSS_Rule[]
+	 */
+	protected $css_rules = array();
+
+	/**
+	 * Add a store to the processor.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param WP_Style_Engine_CSS_Rules_Store $store The store to add.
+	 *
+	 * @return WP_Style_Engine_Processor Returns the object to allow chaining methods.
+	 */
+	public function add_store( WP_Style_Engine_CSS_Rules_Store $store ) {
+		$this->stores[ $store->get_name() ] = $store;
+
+		return $this;
+	}
+
+	/**
+	 * Adds rules to be processed.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param WP_Style_Engine_CSS_Rule|WP_Style_Engine_CSS_Rule[] $css_rules A single, or an array of, WP_Style_Engine_CSS_Rule objects from a store or otherwise.
+	 *
+	 * @return WP_Style_Engine_Processor Returns the object to allow chaining methods.
+	 */
+	public function add_rules( $css_rules ) {
+		if ( ! is_array( $css_rules ) ) {
+			$css_rules = array( $css_rules );
+		}
+		foreach ( $css_rules as $rule ) {
+			$selector = $rule->get_selector();
+			if ( isset( $this->css_rules[ $selector ] ) ) {
+				$this->css_rules[ $selector ]->add_declarations( $rule->get_declarations() );
+				continue;
+			}
+			$this->css_rules[ $rule->get_selector() ] = $rule;
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Get the CSS rules as a string.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param array $options array(
+	 *    'optimize' => (boolean) Whether to optimize the CSS output, e.g., combine rules.
+	 *    'prettify' => (boolean) Whether to add new lines to output.
+	 * );.
+	 *
+	 * @return string The computed CSS.
+	 */
+	public function get_css( $options = array() ) {
+		$defaults = array(
+			'optimize' => true,
+			'prettify' => defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG,
+		);
+		$options  = wp_parse_args( $options, $defaults );
+
+		// If we have stores, get the rules from them.
+		foreach ( $this->stores as $store ) {
+			$this->add_rules( $store->get_all_rules() );
+		}
+
+		// Combine CSS selectors that have identical declarations.
+		if ( true === $options['optimize'] ) {
+			$this->combine_rules_selectors();
+		}
+
+		// Build the CSS.
+		$css = '';
+		foreach ( $this->css_rules as $rule ) {
+			$css .= $rule->get_css( $options['prettify'] );
+			$css .= $options['prettify'] ? "\n" : '';
+		}
+		return $css;
+	}
+
+	/**
+	 * Combines selectors from the rules store when they have the same styles.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @return void
+	 */
+	private function combine_rules_selectors() {
+		// Build an array of selectors along with the JSON-ified styles to make comparisons easier.
+		$selectors_json = array();
+		foreach ( $this->css_rules as $rule ) {
+			$declarations = $rule->get_declarations()->get_declarations();
+			ksort( $declarations );
+			$selectors_json[ $rule->get_selector() ] = wp_json_encode( $declarations );
+		}
+
+		// Combine selectors that have the same styles.
+		foreach ( $selectors_json as $selector => $json ) {
+			// Get selectors that use the same styles.
+			$duplicates = array_keys( $selectors_json, $json, true );
+			// Skip if there are no duplicates.
+			if ( 1 >= count( $duplicates ) ) {
+				continue;
+			}
+
+			$declarations = $this->css_rules[ $selector ]->get_declarations();
+
+			foreach ( $duplicates as $key ) {
+				// Unset the duplicates from the $selectors_json array to avoid looping through them as well.
+				unset( $selectors_json[ $key ] );
+				// Remove the rules from the rules collection.
+				unset( $this->css_rules[ $key ] );
+			}
+			// Create a new rule with the combined selectors.
+			$duplicate_selectors                     = implode( ',', $duplicates );
+			$this->css_rules[ $duplicate_selectors ] = new WP_Style_Engine_CSS_Rule( $duplicate_selectors, $declarations );
+		}
+	}
+}

--- a/src/wp-includes/style-engine/class-wp-style-engine-processor.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine-processor.php
@@ -63,6 +63,7 @@ class WP_Style_Engine_Processor {
 		if ( ! is_array( $css_rules ) ) {
 			$css_rules = array( $css_rules );
 		}
+
 		foreach ( $css_rules as $rule ) {
 			$selector = $rule->get_selector();
 			if ( isset( $this->css_rules[ $selector ] ) ) {
@@ -80,10 +81,12 @@ class WP_Style_Engine_Processor {
 	 *
 	 * @since 6.1.0
 	 *
-	 * @param array $options array(
-	 *    'optimize' => (boolean) Whether to optimize the CSS output, e.g., combine rules.
-	 *    'prettify' => (boolean) Whether to add new lines to output.
-	 * );.
+	 * @param array $options   {
+	 *     Optional. An array of options. Default empty array.
+	 *
+	 *     @type boolean $optimize Whether to optimize the CSS output, e.g., combine rules. Default is `false`.
+	 *     @type boolean $prettify Whether to add new lines and indents to output. Default is the test of whether the global constant `SCRIPT_DEBUG` is defined.
+	 * }
 	 *
 	 * @return string The computed CSS.
 	 */

--- a/src/wp-includes/style-engine/class-wp-style-engine-processor.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine-processor.php
@@ -20,7 +20,7 @@
 class WP_Style_Engine_Processor {
 
 	/**
-	 * The Style-Engine Store objects
+	 * A collection of Style Engine Store objects.
 	 *
 	 * @since 6.1.0
 	 * @var WP_Style_Engine_CSS_Rules_Store[]

--- a/src/wp-includes/style-engine/class-wp-style-engine.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine.php
@@ -275,9 +275,9 @@ class WP_Style_Engine {
 	 *
 	 * @since 6.1.0
 	 *
-	 * @param string $store_name       A valid store key.
-	 * @param string $css_selector     When a selector is passed, the function will return a full CSS rule `$selector { ...rules }`, otherwise a concatenated string of properties and values.
-	 * @param array  $css_declarations An array of parsed CSS property => CSS value pairs.
+	 * @param string                $store_name       A valid store key.
+	 * @param string                $css_selector     When a selector is passed, the function will return a full CSS rule `$selector { ...rules }`, otherwise a concatenated string of properties and values.
+	 * @param array<string, string> $css_declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
 	 *
 	 * @return void.
 	 */
@@ -308,15 +308,18 @@ class WP_Style_Engine {
 	 * @since 6.1.0
 	 *
 	 * @param array $block_styles The style object.
-	 * @param array $options      array(
-	 *     'selector'                   => (string) When a selector is passed, `generate()` will return a full CSS rule `$selector { ...rules }`, otherwise a concatenated string of properties and values.
-	 *     'convert_vars_to_classnames' => (boolean) Whether to skip converting CSS var:? values to var( --wp--preset--* ) values. Default is `false`.
-	 * );.
+	 * @param array $options      {
+	 *     Optional. An array of options. Default empty array.
 	 *
-	 * @return array array(
-	 *     'declarations' => (array) An array of parsed CSS property => CSS value pairs.
-	 *     'classnames'   => (array) A flat array of classnames.
-	 * );
+	 *     @type bool        $convert_vars_to_classnames Whether to skip converting incoming CSS var patterns, e.g., `var:preset|<PRESET_TYPE>|<PRESET_SLUG>`, to var( --wp--preset--* ) values. Default `false`.
+	 *     @type string      $selector                   Optional. When a selector is passed, the value of `$css` in the return value will comprise a full CSS rule `$selector { ...$css_declarations }`,
+	 *                                                   otherwise, the value will be a concatenated string of CSS declarations.
+	 * }
+	 *
+	 * @return array {
+	 *     @type string                $classnames   Classnames separated by a space.
+	 *     @type array<string, string> $declarations An array of property/value pairs representing parsed CSS declarations.
+	 * }
 	 */
 	public static function parse_block_styles( $block_styles, $options ) {
 		$parsed_styles = array(
@@ -348,14 +351,14 @@ class WP_Style_Engine {
 	}
 
 	/**
-	 * Returns classnames, and generates classname(s) from a CSS preset property pattern, e.g., 'var:preset|color|heavenly-blue'.
+	 * Returns classnames, and generates classname(s) from a CSS preset property pattern, e.g., '`var:preset|<PRESET_TYPE>|<PRESET_SLUG>`'.
 	 *
 	 * @since 6.1.0
 	 *
-	 * @param array         $style_value      A single raw style value or css preset property from the generate() $block_styles array.
-	 * @param array<string> $style_definition A single style definition from BLOCK_STYLE_DEFINITIONS_METADATA.
+	 * @param array $style_value      A single raw style value or css preset property from the $block_styles array.
+	 * @param array $style_definition A single style definition from BLOCK_STYLE_DEFINITIONS_METADATA.
 	 *
-	 * @return array        An array of CSS classnames.
+	 * @return array<string> An array of CSS classnames.
 	 */
 	protected static function get_classnames( $style_value, $style_definition ) {
 		if ( empty( $style_value ) ) {
@@ -389,15 +392,17 @@ class WP_Style_Engine {
 	 *
 	 * @since 6.1.0
 	 *
-	 * @param array         $style_value          A single raw style value from the generate() $block_styles array.
-	 * @param array<string> $style_definition     A single style definition from BLOCK_STYLE_DEFINITIONS_METADATA.
-	 * @param array         $options              array(
-	 *     'convert_vars_to_classnames' => (boolean) Whether to skip converting CSS var:? values to var( --wp--preset--* ) values. Default is `false`.
-	 * );.
+	 * @param array $style_value          A single raw style value from $block_styles array.
+	 * @param array $style_definition     A single style definition from BLOCK_STYLE_DEFINITIONS_METADATA.
+	 * @param array $options              {
+	 *     Optional. An array of options. Default empty array.
 	 *
-	 * @return array        An array of CSS definitions, e.g., array( "$property" => "$value" ).
+	 *     @type bool $convert_vars_to_classnames Whether to skip converting incoming CSS var patterns, e.g., `var:preset|<PRESET_TYPE>|<PRESET_SLUG>`, to var( --wp--preset--* ) values. Default `false`.
+	 * }
+	 *
+	 * @return array<string, string> An array of CSS definitions, e.g., array( "$property" => "$value" ).
 	 */
-	protected static function get_css_declarations( $style_value, $style_definition, $options ) {
+	protected static function get_css_declarations( $style_value, $style_definition, $options = array() ) {
 		if ( isset( $style_definition['value_func'] ) && is_callable( $style_definition['value_func'] ) ) {
 			return call_user_func( $style_definition['value_func'], $style_value, $style_definition, $options );
 		}
@@ -406,7 +411,7 @@ class WP_Style_Engine {
 		$style_property_keys  = $style_definition['property_keys'];
 		$should_skip_css_vars = isset( $options['convert_vars_to_classnames'] ) && true === $options['convert_vars_to_classnames'];
 
-		// Build CSS var values from var:? values, e.g, `var(--wp--css--rule-slug )`
+		// Build CSS var values from `var:preset|<PRESET_TYPE>|<PRESET_SLUG>` values, e.g, `var(--wp--css--rule-slug )`.
 		// Check if the value is a CSS preset and there's a corresponding css_var pattern in the style definition.
 		if ( is_string( $style_value ) && str_contains( $style_value, 'var:' ) ) {
 			if ( ! $should_skip_css_vars && ! empty( $style_definition['css_vars'] ) ) {
@@ -455,15 +460,17 @@ class WP_Style_Engine {
 	 *
 	 * @since 6.1.0
 	 *
-	 * @param array $style_value                    A single raw Gutenberg style attributes value for a CSS property.
-	 * @param array $individual_property_definition A single style definition from BLOCK_STYLE_DEFINITIONS_METADATA.
-	 * @param array $options                        array(
-	 *     'convert_vars_to_classnames' => (boolean) Whether to skip converting CSS var:? values to var( --wp--preset--* ) values. Default is `false`.
-	 * );.
+	 * @param array $style_value                    A single raw style value from $block_styles array.
+	 * @param array $individual_property_definition A single style definition from BLOCK_STYLE_DEFINITIONS_METADATA representing an individual property of a CSS property, e.g., 'top' in 'border-top'.
+	 * @param array $options                        {
+	 *     Optional. An array of options. Default empty array.
 	 *
-	 * @return array An array of CSS definitions, e.g., array( "$property" => "$value" ).
+	 *     @type bool $convert_vars_to_classnames Whether to skip converting incoming CSS var patterns, e.g., `var:preset|<PRESET_TYPE>|<PRESET_SLUG>`, to var( --wp--preset--* ) values. Default `false`.
+	 * }
+	 *
+	 * @return array<string, string> An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
 	 */
-	protected static function get_individual_property_css_declarations( $style_value, $individual_property_definition, $options ) {
+	protected static function get_individual_property_css_declarations( $style_value, $individual_property_definition, $options = array() ) {
 		if ( ! is_array( $style_value ) || empty( $style_value ) || empty( $individual_property_definition['path'] ) ) {
 			return array();
 		}
@@ -502,8 +509,8 @@ class WP_Style_Engine {
 	 *
 	 * @since 6.1.0
 	 *
-	 * @param array  $css_declarations An array of parsed CSS property => CSS value pairs.
-	 * @param string $css_selector     When a selector is passed, the function will return a full CSS rule `$selector { ...rules }`, otherwise a concatenated string of properties and values.
+	 * @param array<string, string> $css_declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
+	 * @param string                $css_selector     When a selector is passed, the function will return a full CSS rule `$selector { ...rules }`, otherwise a concatenated string of properties and values.
 	 *
 	 * @return string A compiled CSS string.
 	 */
@@ -528,10 +535,12 @@ class WP_Style_Engine {
 	 * @since 6.1.0
 	 *
 	 * @param WP_Style_Engine_CSS_Rule[] $css_rules An array of WP_Style_Engine_CSS_Rule objects from a store or otherwise.
-	 * @param array                      $options array(
-	 *    'optimize' => (boolean) Whether to optimize the CSS output, e.g., combine rules.
-	 *    'prettify' => (boolean) Whether to add new lines to output.
-	 * );.
+	 * @param array                      $options   {
+	 *     Optional. An array of options. Default empty array.
+	 *
+	 *     @type boolean     $optimize Whether to optimize the CSS output, e.g., combine rules. Default is `false`.
+	 *     @type boolean     $prettify Whether to add new lines and indents to output. Default is the test of whether the global constant `SCRIPT_DEBUG` is defined.
+	 * }
 	 *
 	 * @return string A compiled stylesheet from stored CSS rules.
 	 */

--- a/src/wp-includes/style-engine/class-wp-style-engine.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine.php
@@ -1,0 +1,539 @@
+<?php
+/**
+ * StyleEngine: WP_Style_Engine class
+ *
+ * This is the main class integrating all other WP_Style_Engine_* classes.
+ *
+ * @package WordPress
+ * @subpackage StyleEngine
+ * @since 6.1.0
+ */
+
+/**
+ * Class WP_Style_Engine.
+ *
+ * The Style Engine aims to provide a consistent API for rendering styling for blocks across both client-side and server-side applications.
+ *
+ * This class is for internal Core usage and is not supposed to be used by extenders (plugins and/or themes).
+ * This is a low-level API that may need to do breaking changes. Please, use wp_style_engine_get_styles instead.
+ *
+ * @access private
+ * @since 6.1.0
+ */
+class WP_Style_Engine {
+	/**
+	 * Style definitions that contain the instructions to
+	 * parse/output valid Gutenberg styles from a block's attributes.
+	 * For every style definition, the follow properties are valid:
+	 *  - classnames    => (array) an array of classnames to be returned for block styles. The key is a classname or pattern.
+	 *                    A value of `true` means the classname should be applied always. Otherwise, a valid CSS property (string)
+	 *                    to match the incoming value, e.g., "color" to match var:preset|color|somePresetSlug.
+	 *  - css_vars      => (array) an array of key value pairs used to generate CSS var values. The key is a CSS var pattern, whose `$slug` fragment will be replaced with a preset slug.
+	 *                    The value should be a valid CSS property (string) to match the incoming value, e.g., "color" to match var:preset|color|somePresetSlug.
+	 *  - property_keys => (array) array of keys whose values represent a valid CSS property, e.g., "margin" or "border".
+	 *  - path          => (array) a path that accesses the corresponding style value in the block style object.
+	 *  - value_func    => (string) the name of a function to generate a CSS definition array for a particular style object. The output of this function should be `array( "$property" => "$value", ... )`.
+	 *
+	 * @since 6.1.0
+	 * @var array
+	 */
+	const BLOCK_STYLE_DEFINITIONS_METADATA = array(
+		'color'      => array(
+			'text'       => array(
+				'property_keys' => array(
+					'default' => 'color',
+				),
+				'path'          => array( 'color', 'text' ),
+				'css_vars'      => array(
+					'color' => '--wp--preset--color--$slug',
+				),
+				'classnames'    => array(
+					'has-text-color'  => true,
+					'has-$slug-color' => 'color',
+				),
+			),
+			'background' => array(
+				'property_keys' => array(
+					'default' => 'background-color',
+				),
+				'path'          => array( 'color', 'background' ),
+				'classnames'    => array(
+					'has-background'             => true,
+					'has-$slug-background-color' => 'color',
+				),
+			),
+			'gradient'   => array(
+				'property_keys' => array(
+					'default' => 'background',
+				),
+				'path'          => array( 'color', 'gradient' ),
+				'classnames'    => array(
+					'has-background'                => true,
+					'has-$slug-gradient-background' => 'gradient',
+				),
+			),
+		),
+		'border'     => array(
+			'color'  => array(
+				'property_keys' => array(
+					'default'    => 'border-color',
+					'individual' => 'border-%s-color',
+				),
+				'path'          => array( 'border', 'color' ),
+				'classnames'    => array(
+					'has-border-color'       => true,
+					'has-$slug-border-color' => 'color',
+				),
+			),
+			'radius' => array(
+				'property_keys' => array(
+					'default'    => 'border-radius',
+					'individual' => 'border-%s-radius',
+				),
+				'path'          => array( 'border', 'radius' ),
+			),
+			'style'  => array(
+				'property_keys' => array(
+					'default'    => 'border-style',
+					'individual' => 'border-%s-style',
+				),
+				'path'          => array( 'border', 'style' ),
+			),
+			'width'  => array(
+				'property_keys' => array(
+					'default'    => 'border-width',
+					'individual' => 'border-%s-width',
+				),
+				'path'          => array( 'border', 'width' ),
+			),
+			'top'    => array(
+				'value_func' => 'static::get_individual_property_css_declarations',
+				'path'       => array( 'border', 'top' ),
+				'css_vars'   => array(
+					'color' => '--wp--preset--color--$slug',
+				),
+			),
+			'right'  => array(
+				'value_func' => 'static::get_individual_property_css_declarations',
+				'path'       => array( 'border', 'right' ),
+				'css_vars'   => array(
+					'color' => '--wp--preset--color--$slug',
+				),
+			),
+			'bottom' => array(
+				'value_func' => 'static::get_individual_property_css_declarations',
+				'path'       => array( 'border', 'bottom' ),
+				'css_vars'   => array(
+					'color' => '--wp--preset--color--$slug',
+				),
+			),
+			'left'   => array(
+				'value_func' => 'static::get_individual_property_css_declarations',
+				'path'       => array( 'border', 'left' ),
+				'css_vars'   => array(
+					'color' => '--wp--preset--color--$slug',
+				),
+			),
+		),
+		'spacing'    => array(
+			'padding' => array(
+				'property_keys' => array(
+					'default'    => 'padding',
+					'individual' => 'padding-%s',
+				),
+				'path'          => array( 'spacing', 'padding' ),
+				'css_vars'      => array(
+					'spacing' => '--wp--preset--spacing--$slug',
+				),
+			),
+			'margin'  => array(
+				'property_keys' => array(
+					'default'    => 'margin',
+					'individual' => 'margin-%s',
+				),
+				'path'          => array( 'spacing', 'margin' ),
+				'css_vars'      => array(
+					'spacing' => '--wp--preset--spacing--$slug',
+				),
+			),
+		),
+		'typography' => array(
+			'fontSize'       => array(
+				'property_keys' => array(
+					'default' => 'font-size',
+				),
+				'path'          => array( 'typography', 'fontSize' ),
+				'classnames'    => array(
+					'has-$slug-font-size' => 'font-size',
+				),
+			),
+			'fontFamily'     => array(
+				'property_keys' => array(
+					'default' => 'font-family',
+				),
+				'path'          => array( 'typography', 'fontFamily' ),
+				'classnames'    => array(
+					'has-$slug-font-family' => 'font-family',
+				),
+			),
+			'fontStyle'      => array(
+				'property_keys' => array(
+					'default' => 'font-style',
+				),
+				'path'          => array( 'typography', 'fontStyle' ),
+			),
+			'fontWeight'     => array(
+				'property_keys' => array(
+					'default' => 'font-weight',
+				),
+				'path'          => array( 'typography', 'fontWeight' ),
+			),
+			'lineHeight'     => array(
+				'property_keys' => array(
+					'default' => 'line-height',
+				),
+				'path'          => array( 'typography', 'lineHeight' ),
+			),
+			'textDecoration' => array(
+				'property_keys' => array(
+					'default' => 'text-decoration',
+				),
+				'path'          => array( 'typography', 'textDecoration' ),
+			),
+			'textTransform'  => array(
+				'property_keys' => array(
+					'default' => 'text-transform',
+				),
+				'path'          => array( 'typography', 'textTransform' ),
+			),
+			'letterSpacing'  => array(
+				'property_keys' => array(
+					'default' => 'letter-spacing',
+				),
+				'path'          => array( 'typography', 'letterSpacing' ),
+			),
+		),
+	);
+
+	/**
+	 * Util: Extracts the slug in kebab case from a preset string, e.g., "heavenly-blue" from 'var:preset|color|heavenlyBlue'.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param string? $style_value  A single css preset value.
+	 * @param string  $property_key The CSS property that is the second element of the preset string. Used for matching.
+	 *
+	 * @return string The slug, or empty string if not found.
+	 */
+	protected static function get_slug_from_preset_value( $style_value, $property_key ) {
+		if ( is_string( $style_value ) && str_contains( $style_value, "var:preset|{$property_key}|" ) ) {
+			$index_to_splice = strrpos( $style_value, '|' ) + 1;
+			return _wp_to_kebab_case( substr( $style_value, $index_to_splice ) );
+		}
+		return '';
+	}
+
+	/**
+	 * Util: Generates a css var string, eg var(--wp--preset--color--background) from a preset string, eg. `var:preset|space|50`.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param string $style_value  A single css preset value.
+	 * @param array  $css_vars The css var patterns used to generate the var string.
+	 *
+	 * @return string The css var, or an empty string if no match for slug found.
+	 */
+	protected static function get_css_var_value( $style_value, $css_vars ) {
+		foreach ( $css_vars as  $property_key => $css_var_pattern ) {
+			$slug = static::get_slug_from_preset_value( $style_value, $property_key );
+			if ( static::is_valid_style_value( $slug ) ) {
+				$var = strtr(
+					$css_var_pattern,
+					array( '$slug' => $slug )
+				);
+				return "var($var)";
+			}
+		}
+		return '';
+	}
+
+	/**
+	 * Util: Checks whether an incoming block style value is valid.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param string? $style_value  A single css preset value.
+	 *
+	 * @return boolean
+	 */
+	protected static function is_valid_style_value( $style_value ) {
+		return '0' === $style_value || ! empty( $style_value );
+	}
+
+	/**
+	 * Stores a CSS rule using the provided CSS selector and CSS declarations.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param string $store_name       A valid store key.
+	 * @param string $css_selector     When a selector is passed, the function will return a full CSS rule `$selector { ...rules }`, otherwise a concatenated string of properties and values.
+	 * @param array  $css_declarations An array of parsed CSS property => CSS value pairs.
+	 *
+	 * @return void.
+	 */
+	public static function store_css_rule( $store_name, $css_selector, $css_declarations ) {
+		if ( empty( $store_name ) || empty( $css_selector ) || empty( $css_declarations ) ) {
+			return;
+		}
+		static::get_store( $store_name )->add_rule( $css_selector )->add_declarations( $css_declarations );
+	}
+
+	/**
+	 * Returns a store by store key.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param string $store_name A store key.
+	 *
+	 * @return WP_Style_Engine_CSS_Rules_Store
+	 */
+	public static function get_store( $store_name ) {
+		return WP_Style_Engine_CSS_Rules_Store::get_store( $store_name );
+	}
+
+	/**
+	 * Returns classnames and CSS based on the values in a styles object.
+	 * Return values are parsed based on the instructions in BLOCK_STYLE_DEFINITIONS_METADATA.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param array $block_styles The style object.
+	 * @param array $options      array(
+	 *     'selector'                   => (string) When a selector is passed, `generate()` will return a full CSS rule `$selector { ...rules }`, otherwise a concatenated string of properties and values.
+	 *     'convert_vars_to_classnames' => (boolean) Whether to skip converting CSS var:? values to var( --wp--preset--* ) values. Default is `false`.
+	 * );.
+	 *
+	 * @return array array(
+	 *     'declarations' => (array) An array of parsed CSS property => CSS value pairs.
+	 *     'classnames'   => (array) A flat array of classnames.
+	 * );
+	 */
+	public static function parse_block_styles( $block_styles, $options ) {
+		$parsed_styles = array(
+			'classnames'   => array(),
+			'declarations' => array(),
+		);
+		if ( empty( $block_styles ) || ! is_array( $block_styles ) ) {
+			return $parsed_styles;
+		}
+
+		// Collect CSS and classnames.
+		foreach ( static::BLOCK_STYLE_DEFINITIONS_METADATA as $definition_group_key => $definition_group_style ) {
+			if ( empty( $block_styles[ $definition_group_key ] ) ) {
+				continue;
+			}
+			foreach ( $definition_group_style as $style_definition ) {
+				$style_value = _wp_array_get( $block_styles, $style_definition['path'], null );
+
+				if ( ! static::is_valid_style_value( $style_value ) ) {
+					continue;
+				}
+
+				$parsed_styles['classnames']   = array_merge( $parsed_styles['classnames'], static::get_classnames( $style_value, $style_definition ) );
+				$parsed_styles['declarations'] = array_merge( $parsed_styles['declarations'], static::get_css_declarations( $style_value, $style_definition, $options ) );
+			}
+		}
+
+		return $parsed_styles;
+	}
+
+	/**
+	 * Returns classnames, and generates classname(s) from a CSS preset property pattern, e.g., 'var:preset|color|heavenly-blue'.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param array         $style_value      A single raw style value or css preset property from the generate() $block_styles array.
+	 * @param array<string> $style_definition A single style definition from BLOCK_STYLE_DEFINITIONS_METADATA.
+	 *
+	 * @return array        An array of CSS classnames.
+	 */
+	protected static function get_classnames( $style_value, $style_definition ) {
+		if ( empty( $style_value ) ) {
+			return array();
+		}
+
+		$classnames = array();
+		if ( ! empty( $style_definition['classnames'] ) ) {
+			foreach ( $style_definition['classnames'] as $classname => $property_key ) {
+				if ( true === $property_key ) {
+					$classnames[] = $classname;
+				}
+
+				$slug = static::get_slug_from_preset_value( $style_value, $property_key );
+
+				if ( $slug ) {
+					// Right now we expect a classname pattern to be stored in BLOCK_STYLE_DEFINITIONS_METADATA.
+					// One day, if there are no stored schemata, we could allow custom patterns or
+					// generate classnames based on other properties
+					// such as a path or a value or a prefix passed in options.
+					$classnames[] = strtr( $classname, array( '$slug' => $slug ) );
+				}
+			}
+		}
+
+		return $classnames;
+	}
+
+	/**
+	 * Returns an array of CSS declarations based on valid block style values.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param array         $style_value          A single raw style value from the generate() $block_styles array.
+	 * @param array<string> $style_definition     A single style definition from BLOCK_STYLE_DEFINITIONS_METADATA.
+	 * @param array         $options              array(
+	 *     'convert_vars_to_classnames' => (boolean) Whether to skip converting CSS var:? values to var( --wp--preset--* ) values. Default is `false`.
+	 * );.
+	 *
+	 * @return array        An array of CSS definitions, e.g., array( "$property" => "$value" ).
+	 */
+	protected static function get_css_declarations( $style_value, $style_definition, $options ) {
+		if ( isset( $style_definition['value_func'] ) && is_callable( $style_definition['value_func'] ) ) {
+			return call_user_func( $style_definition['value_func'], $style_value, $style_definition, $options );
+		}
+
+		$css_declarations     = array();
+		$style_property_keys  = $style_definition['property_keys'];
+		$should_skip_css_vars = isset( $options['convert_vars_to_classnames'] ) && true === $options['convert_vars_to_classnames'];
+
+		// Build CSS var values from var:? values, e.g, `var(--wp--css--rule-slug )`
+		// Check if the value is a CSS preset and there's a corresponding css_var pattern in the style definition.
+		if ( is_string( $style_value ) && str_contains( $style_value, 'var:' ) ) {
+			if ( ! $should_skip_css_vars && ! empty( $style_definition['css_vars'] ) ) {
+				$css_var = static::get_css_var_value( $style_value, $style_definition['css_vars'] );
+				if ( static::is_valid_style_value( $css_var ) ) {
+					$css_declarations[ $style_property_keys['default'] ] = $css_var;
+				}
+			}
+			return $css_declarations;
+		}
+
+		// Default rule builder.
+		// If the input contains an array, assume box model-like properties
+		// for styles such as margins and padding.
+		if ( is_array( $style_value ) ) {
+			// Bail out early if the `'individual'` property is not defined.
+			if ( ! isset( $style_property_keys['individual'] ) ) {
+				return $css_declarations;
+			}
+
+			foreach ( $style_value as $key => $value ) {
+				if ( is_string( $value ) && str_contains( $value, 'var:' ) && ! $should_skip_css_vars && ! empty( $style_definition['css_vars'] ) ) {
+					$value = static::get_css_var_value( $value, $style_definition['css_vars'] );
+				}
+
+				$individual_property = sprintf( $style_property_keys['individual'], _wp_to_kebab_case( $key ) );
+
+				if ( $individual_property && static::is_valid_style_value( $value ) ) {
+					$css_declarations[ $individual_property ] = $value;
+				}
+			}
+
+			return $css_declarations;
+		}
+
+		$css_declarations[ $style_property_keys['default'] ] = $style_value;
+		return $css_declarations;
+	}
+
+	/**
+	 * Style value parser that returns a CSS definition array comprising style properties
+	 * that have keys representing individual style properties, otherwise known as longhand CSS properties.
+	 * e.g., "$style_property-$individual_feature: $value;", which could represent the following:
+	 * "border-{top|right|bottom|left}-{color|width|style}: {value};" or,
+	 * "border-image-{outset|source|width|repeat|slice}: {value};"
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param array $style_value                    A single raw Gutenberg style attributes value for a CSS property.
+	 * @param array $individual_property_definition A single style definition from BLOCK_STYLE_DEFINITIONS_METADATA.
+	 * @param array $options                        array(
+	 *     'convert_vars_to_classnames' => (boolean) Whether to skip converting CSS var:? values to var( --wp--preset--* ) values. Default is `false`.
+	 * );.
+	 *
+	 * @return array An array of CSS definitions, e.g., array( "$property" => "$value" ).
+	 */
+	protected static function get_individual_property_css_declarations( $style_value, $individual_property_definition, $options ) {
+		if ( ! is_array( $style_value ) || empty( $style_value ) || empty( $individual_property_definition['path'] ) ) {
+			return array();
+		}
+
+		// The first item in $individual_property_definition['path'] array tells us the style property, e.g., "border".
+		// We use this to get a corresponding CSS style definition such as "color" or "width" from the same group.
+		// The second item in $individual_property_definition['path'] array refers to the individual property marker, e.g., "top".
+		$definition_group_key    = $individual_property_definition['path'][0];
+		$individual_property_key = $individual_property_definition['path'][1];
+		$should_skip_css_vars    = isset( $options['convert_vars_to_classnames'] ) && true === $options['convert_vars_to_classnames'];
+		$css_declarations        = array();
+
+		foreach ( $style_value as $css_property => $value ) {
+			if ( empty( $value ) ) {
+				continue;
+			}
+
+			// Build a path to the individual rules in definitions.
+			$style_definition_path = array( $definition_group_key, $css_property );
+			$style_definition      = _wp_array_get( static::BLOCK_STYLE_DEFINITIONS_METADATA, $style_definition_path, null );
+
+			if ( $style_definition && isset( $style_definition['property_keys']['individual'] ) ) {
+				// Set a CSS var if there is a valid preset value.
+				if ( is_string( $value ) && str_contains( $value, 'var:' ) && ! $should_skip_css_vars && ! empty( $individual_property_definition['css_vars'] ) ) {
+					$value = static::get_css_var_value( $value, $individual_property_definition['css_vars'] );
+				}
+				$individual_css_property                      = sprintf( $style_definition['property_keys']['individual'], $individual_property_key );
+				$css_declarations[ $individual_css_property ] = $value;
+			}
+		}
+		return $css_declarations;
+	}
+
+	/**
+	 * Returns compiled CSS from css_declarations.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param array  $css_declarations An array of parsed CSS property => CSS value pairs.
+	 * @param string $css_selector     When a selector is passed, the function will return a full CSS rule `$selector { ...rules }`, otherwise a concatenated string of properties and values.
+	 *
+	 * @return string A compiled CSS string.
+	 */
+	public static function compile_css( $css_declarations, $css_selector ) {
+		if ( empty( $css_declarations ) || ! is_array( $css_declarations ) ) {
+			return '';
+		}
+
+		// Return an entire rule if there is a selector.
+		if ( $css_selector ) {
+			$css_rule = new WP_Style_Engine_CSS_Rule( $css_selector, $css_declarations );
+			return $css_rule->get_css();
+		}
+
+		$css_declarations = new WP_Style_Engine_CSS_Declarations( $css_declarations );
+		return $css_declarations->get_declarations_string();
+	}
+
+	/**
+	 * Returns a compiled stylesheet from stored CSS rules.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param WP_Style_Engine_CSS_Rule[] $css_rules An array of WP_Style_Engine_CSS_Rule objects from a store or otherwise.
+	 *
+	 * @return string A compiled stylesheet from stored CSS rules.
+	 */
+	public static function compile_stylesheet_from_css_rules( $css_rules ) {
+		$processor = new WP_Style_Engine_Processor();
+		$processor->add_rules( $css_rules );
+		return $processor->get_css();
+	}
+}

--- a/src/wp-includes/style-engine/class-wp-style-engine.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine.php
@@ -220,13 +220,13 @@ class WP_Style_Engine {
 	 *
 	 * @since 6.1.0
 	 *
-	 * @param string? $style_value  A single css preset value.
-	 * @param string  $property_key The CSS property that is the second element of the preset string. Used for matching.
+	 * @param string $style_value  A single CSS preset value.
+	 * @param string $property_key The CSS property that is the second element of the preset string. Used for matching.
 	 *
 	 * @return string The slug, or empty string if not found.
 	 */
 	protected static function get_slug_from_preset_value( $style_value, $property_key ) {
-		if ( is_string( $style_value ) && str_contains( $style_value, "var:preset|{$property_key}|" ) ) {
+		if ( is_string( $style_value ) && is_string( $property_key ) && str_contains( $style_value, "var:preset|{$property_key}|" ) ) {
 			$index_to_splice = strrpos( $style_value, '|' ) + 1;
 			return _wp_to_kebab_case( substr( $style_value, $index_to_splice ) );
 		}
@@ -234,12 +234,12 @@ class WP_Style_Engine {
 	}
 
 	/**
-	 * Util: Generates a css var string, eg var(--wp--preset--color--background) from a preset string, eg. `var:preset|space|50`.
+	 * Util: Generates a CSS var string, e.g., var(--wp--preset--color--background) from a preset string such as `var:preset|space|50`.
 	 *
 	 * @since 6.1.0
 	 *
-	 * @param string $style_value  A single css preset value.
-	 * @param array  $css_vars The css var patterns used to generate the var string.
+	 * @param string   $style_value  A single css preset value.
+	 * @param string[] $css_vars     An associate array of css var patterns used to generate the var string.
 	 *
 	 * @return string The css var, or an empty string if no match for slug found.
 	 */
@@ -262,7 +262,7 @@ class WP_Style_Engine {
 	 *
 	 * @since 6.1.0
 	 *
-	 * @param string? $style_value  A single css preset value.
+	 * @param string $style_value A single CSS preset value.
 	 *
 	 * @return bool
 	 */
@@ -275,9 +275,9 @@ class WP_Style_Engine {
 	 *
 	 * @since 6.1.0
 	 *
-	 * @param string                $store_name       A valid store key.
-	 * @param string                $css_selector     When a selector is passed, the function will return a full CSS rule `$selector { ...rules }`, otherwise a concatenated string of properties and values.
-	 * @param array<string, string> $css_declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
+	 * @param string   $store_name       A valid store key.
+	 * @param string   $css_selector     When a selector is passed, the function will return a full CSS rule `$selector { ...rules }`, otherwise a concatenated string of properties and values.
+	 * @param string[] $css_declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
 	 *
 	 * @return void.
 	 */
@@ -317,8 +317,8 @@ class WP_Style_Engine {
 	 * }
 	 *
 	 * @return array {
-	 *     @type string                $classnames   Classnames separated by a space.
-	 *     @type array<string, string> $declarations An array of property/value pairs representing parsed CSS declarations.
+	 *     @type string   $classnames   Classnames separated by a space.
+	 *     @type string[] $declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
 	 * }
 	 */
 	public static function parse_block_styles( $block_styles, $options ) {
@@ -358,7 +358,7 @@ class WP_Style_Engine {
 	 * @param array $style_value      A single raw style value or css preset property from the $block_styles array.
 	 * @param array $style_definition A single style definition from BLOCK_STYLE_DEFINITIONS_METADATA.
 	 *
-	 * @return array<string> An array of CSS classnames.
+	 * @return array|string[] An array of CSS classnames, or empty array.
 	 */
 	protected static function get_classnames( $style_value, $style_definition ) {
 		if ( empty( $style_value ) ) {
@@ -375,10 +375,12 @@ class WP_Style_Engine {
 				$slug = static::get_slug_from_preset_value( $style_value, $property_key );
 
 				if ( $slug ) {
-					// Right now we expect a classname pattern to be stored in BLOCK_STYLE_DEFINITIONS_METADATA.
-					// One day, if there are no stored schemata, we could allow custom patterns or
-					// generate classnames based on other properties
-					// such as a path or a value or a prefix passed in options.
+					/*
+					 * Right now we expect a classname pattern to be stored in BLOCK_STYLE_DEFINITIONS_METADATA.
+					 * One day, if there are no stored schemata, we could allow custom patterns or
+					 * generate classnames based on other properties
+					 * such as a path or a value or a prefix passed in options.
+					 */
 					$classnames[] = strtr( $classname, array( '$slug' => $slug ) );
 				}
 			}
@@ -392,15 +394,15 @@ class WP_Style_Engine {
 	 *
 	 * @since 6.1.0
 	 *
-	 * @param array $style_value          A single raw style value from $block_styles array.
-	 * @param array $style_definition     A single style definition from BLOCK_STYLE_DEFINITIONS_METADATA.
-	 * @param array $options              {
+	 * @param array $style_value      A single raw style value from $block_styles array.
+	 * @param array $style_definition A single style definition from BLOCK_STYLE_DEFINITIONS_METADATA.
+	 * @param array $options          {
 	 *     Optional. An array of options. Default empty array.
 	 *
 	 *     @type bool $convert_vars_to_classnames Whether to skip converting incoming CSS var patterns, e.g., `var:preset|<PRESET_TYPE>|<PRESET_SLUG>`, to var( --wp--preset--* ) values. Default `false`.
 	 * }
 	 *
-	 * @return array<string, string> An array of CSS definitions, e.g., array( "$property" => "$value" ).
+	 * @return string[] An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
 	 */
 	protected static function get_css_declarations( $style_value, $style_definition, $options = array() ) {
 		if ( isset( $style_definition['value_func'] ) && is_callable( $style_definition['value_func'] ) ) {
@@ -411,8 +413,10 @@ class WP_Style_Engine {
 		$style_property_keys  = $style_definition['property_keys'];
 		$should_skip_css_vars = isset( $options['convert_vars_to_classnames'] ) && true === $options['convert_vars_to_classnames'];
 
-		// Build CSS var values from `var:preset|<PRESET_TYPE>|<PRESET_SLUG>` values, e.g, `var(--wp--css--rule-slug )`.
-		// Check if the value is a CSS preset and there's a corresponding css_var pattern in the style definition.
+		/*
+		 * Build CSS var values from `var:preset|<PRESET_TYPE>|<PRESET_SLUG>` values, e.g, `var(--wp--css--rule-slug )`.
+		 * Check if the value is a CSS preset and there's a corresponding css_var pattern in the style definition.
+		 */
 		if ( is_string( $style_value ) && str_contains( $style_value, 'var:' ) ) {
 			if ( ! $should_skip_css_vars && ! empty( $style_definition['css_vars'] ) ) {
 				$css_var = static::get_css_var_value( $style_value, $style_definition['css_vars'] );
@@ -423,9 +427,11 @@ class WP_Style_Engine {
 			return $css_declarations;
 		}
 
-		// Default rule builder.
-		// If the input contains an array, assume box model-like properties
-		// for styles such as margins and padding.
+		/*
+		 * Default rule builder.
+		 * If the input contains an array, assume box model-like properties
+		 * for styles such as margins and padding.
+		 */
 		if ( is_array( $style_value ) ) {
 			// Bail out early if the `'individual'` property is not defined.
 			if ( ! isset( $style_property_keys['individual'] ) ) {
@@ -468,16 +474,18 @@ class WP_Style_Engine {
 	 *     @type bool $convert_vars_to_classnames Whether to skip converting incoming CSS var patterns, e.g., `var:preset|<PRESET_TYPE>|<PRESET_SLUG>`, to var( --wp--preset--* ) values. Default `false`.
 	 * }
 	 *
-	 * @return array<string, string> An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
+	 * @return string[] An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
 	 */
 	protected static function get_individual_property_css_declarations( $style_value, $individual_property_definition, $options = array() ) {
 		if ( ! is_array( $style_value ) || empty( $style_value ) || empty( $individual_property_definition['path'] ) ) {
 			return array();
 		}
 
-		// The first item in $individual_property_definition['path'] array tells us the style property, e.g., "border".
-		// We use this to get a corresponding CSS style definition such as "color" or "width" from the same group.
-		// The second item in $individual_property_definition['path'] array refers to the individual property marker, e.g., "top".
+		/*
+		 * The first item in $individual_property_definition['path'] array tells us the style property, e.g., "border".
+		 * We use this to get a corresponding CSS style definition such as "color" or "width" from the same group.
+		 * The second item in $individual_property_definition['path'] array refers to the individual property marker, e.g., "top".
+		 */
 		$definition_group_key    = $individual_property_definition['path'][0];
 		$individual_property_key = $individual_property_definition['path'][1];
 		$should_skip_css_vars    = isset( $options['convert_vars_to_classnames'] ) && true === $options['convert_vars_to_classnames'];
@@ -509,8 +517,8 @@ class WP_Style_Engine {
 	 *
 	 * @since 6.1.0
 	 *
-	 * @param array<string, string> $css_declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
-	 * @param string                $css_selector     When a selector is passed, the function will return a full CSS rule `$selector { ...rules }`, otherwise a concatenated string of properties and values.
+	 * @param string[] $css_declarations An associative array of CSS definitions, e.g., array( "$property" => "$value", "$property" => "$value" ).
+	 * @param string   $css_selector     When a selector is passed, the function will return a full CSS rule `$selector { ...rules }`, otherwise a concatenated string of properties and values.
 	 *
 	 * @return string A compiled CSS string.
 	 */

--- a/src/wp-includes/style-engine/class-wp-style-engine.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine.php
@@ -528,12 +528,16 @@ class WP_Style_Engine {
 	 * @since 6.1.0
 	 *
 	 * @param WP_Style_Engine_CSS_Rule[] $css_rules An array of WP_Style_Engine_CSS_Rule objects from a store or otherwise.
+	 * @param array                      $options array(
+	 *    'optimize' => (boolean) Whether to optimize the CSS output, e.g., combine rules.
+	 *    'prettify' => (boolean) Whether to add new lines to output.
+	 * );.
 	 *
 	 * @return string A compiled stylesheet from stored CSS rules.
 	 */
-	public static function compile_stylesheet_from_css_rules( $css_rules ) {
+	public static function compile_stylesheet_from_css_rules( $css_rules, $options = array() ) {
 		$processor = new WP_Style_Engine_Processor();
 		$processor->add_rules( $css_rules );
-		return $processor->get_css();
+		return $processor->get_css( $options );
 	}
 }

--- a/src/wp-includes/style-engine/class-wp-style-engine.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine.php
@@ -264,7 +264,7 @@ class WP_Style_Engine {
 	 *
 	 * @param string? $style_value  A single css preset value.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	protected static function is_valid_style_value( $style_value ) {
 		return '0' === $style_value || ! empty( $style_value );
@@ -538,8 +538,8 @@ class WP_Style_Engine {
 	 * @param array                      $options   {
 	 *     Optional. An array of options. Default empty array.
 	 *
-	 *     @type boolean     $optimize Whether to optimize the CSS output, e.g., combine rules. Default is `false`.
-	 *     @type boolean     $prettify Whether to add new lines and indents to output. Default is the test of whether the global constant `SCRIPT_DEBUG` is defined.
+	 *     @type bool $optimize Whether to optimize the CSS output, e.g., combine rules. Default is `false`.
+	 *     @type bool $prettify Whether to add new lines and indents to output. Default is the test of whether the global constant `SCRIPT_DEBUG` is defined.
 	 * }
 	 *
 	 * @return string A compiled stylesheet from stored CSS rules.

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -332,6 +332,12 @@ require ABSPATH . WPINC . '/block-supports/generated-classname.php';
 require ABSPATH . WPINC . '/block-supports/layout.php';
 require ABSPATH . WPINC . '/block-supports/spacing.php';
 require ABSPATH . WPINC . '/block-supports/typography.php';
+require ABSPATH . WPINC . '/style-engine.php';
+require ABSPATH . WPINC . '/style-engine/class-wp-style-engine.php';
+require ABSPATH . WPINC . '/style-engine/class-wp-style-engine-css-declarations.php';
+require ABSPATH . WPINC . '/style-engine/class-wp-style-engine-css-rule.php';
+require ABSPATH . WPINC . '/style-engine/class-wp-style-engine-css-rules-store.php';
+require ABSPATH . WPINC . '/style-engine/class-wp-style-engine-processor.php';
 
 $GLOBALS['wp_embed'] = new WP_Embed();
 

--- a/tests/phpunit/tests/style-engine/styleEngine.php
+++ b/tests/phpunit/tests/style-engine/styleEngine.php
@@ -24,13 +24,15 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 	/**
 	 * Tests generating block styles and classnames based on various manifestations of the $block_styles argument.
 	 *
+	 * @covers ::wp_style_engine_get_styles
+	 *
 	 * @dataProvider data_get_styles_fixtures
 	 *
 	 * @param array  $block_styles The incoming block styles object.
 	 * @param array  $options Style engine options.
 	 * @param string $expected_output The expected output.
 	 */
-	public function test_generate_get_styles( $block_styles, $options, $expected_output ) {
+	public function test_wp_style_engine_get_styles( $block_styles, $options, $expected_output ) {
 		$generated_styles = wp_style_engine_get_styles( $block_styles, $options );
 		$this->assertSame( $expected_output, $generated_styles );
 	}
@@ -491,8 +493,10 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 
 	/**
 	 * Tests adding rules to a store and retrieving a generated stylesheet.
+	 *
+	 * @covers ::wp_style_engine_get_styles
 	 */
-	public function test_store_block_styles_using_context() {
+	public function test_wp_style_engine_get_styles_and_store_using_context() {
 		$block_styles = array(
 			'spacing' => array(
 				'padding' => array(
@@ -518,8 +522,10 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 
 	/**
 	 * Tests adding rules to a store and retrieving a generated stylesheet.
+	 *
+	 * @covers ::wp_style_engine_get_styles
 	 */
-	public function test_does_not_store_block_styles_without_context() {
+	public function test_wp_style_engine_get_styles_without_context() {
 		$block_styles = array(
 			'typography' => array(
 				'fontSize' => '999px',
@@ -540,8 +546,10 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 
 	/**
 	 * Tests adding rules to a store and retrieving a generated stylesheet.
+	 *
+	 * @covers ::wp_style_engine_get_stylesheet_from_context
 	 */
-	public function test_add_to_store() {
+	public function test_wp_style_engine_get_stylesheet_from_context() {
 		$css_rules           = array(
 			array(
 				'selector'     => '.frodo',
@@ -569,16 +577,15 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 			)
 		);
 
-		// Check that the style engine knows about the store.
-		$stored_store = WP_Style_Engine::get_store( 'test-store' );
-		$this->assertInstanceOf( 'WP_Style_Engine_CSS_Rules_Store', $stored_store );
-		$this->assertSame( $compiled_stylesheet, WP_Style_Engine::compile_stylesheet_from_css_rules( $stored_store->get_all_rules() ) );
+		$this->assertSame( $compiled_stylesheet, wp_style_engine_get_stylesheet_from_context( 'test-store' ) );
 	}
 
 	/**
 	 * Tests retrieving a generated stylesheet from any rules.
+	 *
+	 * @covers ::wp_style_engine_get_stylesheet_from_css_rules
 	 */
-	public function test_get_stylesheet_from_css_rules() {
+	public function test_wp_style_engine_get_stylesheet_from_css_rules() {
 		$css_rules = array(
 			array(
 				'selector'     => '.saruman',
@@ -615,8 +622,10 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 
 	/**
 	 * Tests that incoming styles are deduped and merged.
+	 *
+	 * @covers ::wp_style_engine_get_stylesheet_from_css_rules
 	 */
-	public function test_get_deduped_and_merged_stylesheet() {
+	public function test_wp_style_engine_get_stylesheet_from_css_rules_dedupes_and_merges() {
 		$css_rules = array(
 			array(
 				'selector'     => '.gandalf',

--- a/tests/phpunit/tests/style-engine/styleEngine.php
+++ b/tests/phpunit/tests/style-engine/styleEngine.php
@@ -531,7 +531,7 @@ class Tests_wpStyleEngine extends WP_UnitTestCase {
 			)
 		);
 
-		$all_stores = WP_Style_Engine_CSS_Rules_Store_Gutenberg::get_stores();
+		$all_stores = WP_Style_Engine_CSS_Rules_Store::get_stores();
 
 		$this->assertEmpty( $all_stores );
 	}

--- a/tests/phpunit/tests/style-engine/styleEngine.php
+++ b/tests/phpunit/tests/style-engine/styleEngine.php
@@ -6,7 +6,7 @@
  * @subpackage StyleEngine
  * @since 6.1.0
  *
- * @group styleEngine
+ * @group style-engine
  */
 
 /**

--- a/tests/phpunit/tests/style-engine/styleEngine.php
+++ b/tests/phpunit/tests/style-engine/styleEngine.php
@@ -1,0 +1,659 @@
+<?php
+/**
+ * Tests the Style Engine class and associated functionality.
+ *
+ * @package WordPress
+ * @subpackage StyleEngine
+ * @since 6.1.0
+ *
+ * @group styleEngine
+ */
+
+/**
+ * Tests for registering, storing and generating styles.
+ */
+class WP_Style_Engine_Test extends WP_UnitTestCase {
+	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down() {
+		parent::tear_down();
+		WP_Style_Engine_CSS_Rules_Store::remove_all_stores();
+	}
+
+	/**
+	 * Tests generating block styles and classnames based on various manifestations of the $block_styles argument.
+	 *
+	 * @dataProvider data_get_styles_fixtures
+	 *
+	 * @param array  $block_styles The incoming block styles object.
+	 * @param array  $options Style engine options.
+	 * @param string $expected_output The expected output.
+	 */
+	public function test_generate_get_styles( $block_styles, $options, $expected_output ) {
+		$generated_styles = wp_style_engine_get_styles( $block_styles, $options );
+		$this->assertSame( $expected_output, $generated_styles );
+	}
+
+	/**
+	 * Data provider for test_generate_get_styles().
+	 *
+	 * @return array
+	 */
+	public function data_get_styles_fixtures() {
+		return array(
+			'default_return_value'                         => array(
+				'block_styles'    => array(),
+				'options'         => null,
+				'expected_output' => array(),
+			),
+
+			'inline_invalid_block_styles_empty'            => array(
+				'block_styles'    => 'hello world!',
+				'options'         => null,
+				'expected_output' => array(),
+			),
+
+			'inline_invalid_block_styles_unknown_style'    => array(
+				'block_styles'    => array(
+					'pageBreakAfter' => 'verso',
+				),
+				'options'         => null,
+				'expected_output' => array(),
+			),
+
+			'inline_invalid_block_styles_unknown_definition' => array(
+				'block_styles'    => array(
+					'pageBreakAfter' => 'verso',
+				),
+				'options'         => null,
+				'expected_output' => array(),
+			),
+
+			'inline_invalid_block_styles_unknown_property' => array(
+				'block_styles'    => array(
+					'spacing' => array(
+						'gap' => '1000vw',
+					),
+				),
+				'options'         => null,
+				'expected_output' => array(),
+			),
+
+			'valid_inline_css_and_classnames_as_default_context' => array(
+				'block_styles'    => array(
+					'color'   => array(
+						'text' => 'var:preset|color|texas-flood',
+					),
+					'spacing' => array(
+						'margin'  => '111px',
+						'padding' => '0',
+					),
+					'border'  => array(
+						'color' => 'var:preset|color|cool-caramel',
+						'width' => '2rem',
+						'style' => 'dotted',
+					),
+				),
+				'options'         => array( 'convert_vars_to_classnames' => true ),
+				'expected_output' => array(
+					'css'          => 'border-style:dotted;border-width:2rem;padding:0;margin:111px;',
+					'declarations' => array(
+						'border-style' => 'dotted',
+						'border-width' => '2rem',
+						'padding'      => '0',
+						'margin'       => '111px',
+					),
+					'classnames'   => 'has-text-color has-texas-flood-color has-border-color has-cool-caramel-border-color',
+				),
+			),
+
+			'valid_inline_css_and_classnames_with_context' => array(
+				'block_styles'    => array(
+					'color'   => array(
+						'text' => 'var:preset|color|little-lamb',
+					),
+					'spacing' => array(
+						'margin' => '20px',
+					),
+				),
+				'options'         => array(
+					'convert_vars_to_classnames' => true,
+					'context'                    => 'block-supports',
+				),
+				'expected_output' => array(
+					'css'          => 'margin:20px;',
+					'declarations' => array(
+						'margin' => '20px',
+					),
+					'classnames'   => 'has-text-color has-little-lamb-color',
+				),
+			),
+
+			'inline_valid_box_model_style'                 => array(
+				'block_styles'    => array(
+					'spacing' => array(
+						'padding' => array(
+							'top'    => '42px',
+							'left'   => '2%',
+							'bottom' => '44px',
+							'right'  => '5rem',
+						),
+						'margin'  => array(
+							'top'    => '12rem',
+							'left'   => '2vh',
+							'bottom' => '2px',
+							'right'  => '10em',
+						),
+					),
+					'border'  => array(
+						'radius' => array(
+							'topLeft'     => '99px',
+							'topRight'    => '98px',
+							'bottomLeft'  => '97px',
+							'bottomRight' => '96px',
+						),
+					),
+				),
+				'options'         => null,
+				'expected_output' => array(
+					'css'          => 'border-top-left-radius:99px;border-top-right-radius:98px;border-bottom-left-radius:97px;border-bottom-right-radius:96px;padding-top:42px;padding-left:2%;padding-bottom:44px;padding-right:5rem;margin-top:12rem;margin-left:2vh;margin-bottom:2px;margin-right:10em;',
+					'declarations' => array(
+						'border-top-left-radius'     => '99px',
+						'border-top-right-radius'    => '98px',
+						'border-bottom-left-radius'  => '97px',
+						'border-bottom-right-radius' => '96px',
+						'padding-top'                => '42px',
+						'padding-left'               => '2%',
+						'padding-bottom'             => '44px',
+						'padding-right'              => '5rem',
+						'margin-top'                 => '12rem',
+						'margin-left'                => '2vh',
+						'margin-bottom'              => '2px',
+						'margin-right'               => '10em',
+					),
+				),
+			),
+
+			'inline_valid_typography_style'                => array(
+				'block_styles'    => array(
+					'typography' => array(
+						'fontSize'       => 'clamp(2em, 2vw, 4em)',
+						'fontFamily'     => 'Roboto,Oxygen-Sans,Ubuntu,sans-serif',
+						'fontStyle'      => 'italic',
+						'fontWeight'     => '800',
+						'lineHeight'     => '1.3',
+						'textDecoration' => 'underline',
+						'textTransform'  => 'uppercase',
+						'letterSpacing'  => '2',
+					),
+				),
+				'options'         => null,
+				'expected_output' => array(
+					'css'          => 'font-size:clamp(2em, 2vw, 4em);font-family:Roboto,Oxygen-Sans,Ubuntu,sans-serif;font-style:italic;font-weight:800;line-height:1.3;text-decoration:underline;text-transform:uppercase;letter-spacing:2;',
+					'declarations' => array(
+						'font-size'       => 'clamp(2em, 2vw, 4em)',
+						'font-family'     => 'Roboto,Oxygen-Sans,Ubuntu,sans-serif',
+						'font-style'      => 'italic',
+						'font-weight'     => '800',
+						'line-height'     => '1.3',
+						'text-decoration' => 'underline',
+						'text-transform'  => 'uppercase',
+						'letter-spacing'  => '2',
+					),
+				),
+			),
+
+			'style_block_with_selector'                    => array(
+				'block_styles'    => array(
+					'spacing' => array(
+						'padding' => array(
+							'top'    => '42px',
+							'left'   => '2%',
+							'bottom' => '44px',
+							'right'  => '5rem',
+						),
+					),
+				),
+				'options'         => array( 'selector' => '.wp-selector > p' ),
+				'expected_output' => array(
+					'css'          => '.wp-selector > p{padding-top:42px;padding-left:2%;padding-bottom:44px;padding-right:5rem;}',
+					'declarations' => array(
+						'padding-top'    => '42px',
+						'padding-left'   => '2%',
+						'padding-bottom' => '44px',
+						'padding-right'  => '5rem',
+					),
+				),
+			),
+
+			'elements_with_css_var_value'                  => array(
+				'block_styles'    => array(
+					'color' => array(
+						'text' => 'var:preset|color|my-little-pony',
+					),
+				),
+				'options'         => array(
+					'selector' => '.wp-selector',
+				),
+				'expected_output' => array(
+					'css'          => '.wp-selector{color:var(--wp--preset--color--my-little-pony);}',
+					'declarations' => array(
+						'color' => 'var(--wp--preset--color--my-little-pony)',
+					),
+					'classnames'   => 'has-text-color has-my-little-pony-color',
+				),
+			),
+
+			'elements_with_invalid_preset_style_property'  => array(
+				'block_styles'    => array(
+					'color' => array(
+						'text' => 'var:preset|invalid_property|my-little-pony',
+					),
+				),
+				'options'         => array( 'selector' => '.wp-selector' ),
+				'expected_output' => array(
+					'classnames' => 'has-text-color',
+				),
+			),
+
+			'valid_classnames_deduped'                     => array(
+				'block_styles'    => array(
+					'color'      => array(
+						'text'       => 'var:preset|color|copper-socks',
+						'background' => 'var:preset|color|splendid-carrot',
+						'gradient'   => 'var:preset|gradient|like-wow-dude',
+					),
+					'typography' => array(
+						'fontSize'   => 'var:preset|font-size|fantastic',
+						'fontFamily' => 'var:preset|font-family|totally-awesome',
+					),
+				),
+				'options'         => array( 'convert_vars_to_classnames' => true ),
+				'expected_output' => array(
+					'classnames' => 'has-text-color has-copper-socks-color has-background has-splendid-carrot-background-color has-like-wow-dude-gradient-background has-fantastic-font-size has-totally-awesome-font-family',
+				),
+			),
+
+			'valid_classnames_and_css_vars'                => array(
+				'block_styles'    => array(
+					'color' => array(
+						'text' => 'var:preset|color|teal-independents',
+					),
+				),
+				'options'         => array(),
+				'expected_output' => array(
+					'css'          => 'color:var(--wp--preset--color--teal-independents);',
+					'declarations' => array(
+						'color' => 'var(--wp--preset--color--teal-independents)',
+					),
+					'classnames'   => 'has-text-color has-teal-independents-color',
+				),
+			),
+
+			'valid_classnames_with_null_style_values'      => array(
+				'block_styles'    => array(
+					'color' => array(
+						'text'       => '#fff',
+						'background' => null,
+					),
+				),
+				'options'         => array(),
+				'expected_output' => array(
+					'css'          => 'color:#fff;',
+					'declarations' => array(
+						'color' => '#fff',
+					),
+					'classnames'   => 'has-text-color',
+				),
+			),
+
+			'invalid_classnames_preset_value'              => array(
+				'block_styles'    => array(
+					'color'   => array(
+						'text'       => 'var:cheese|color|fantastic',
+						'background' => 'var:preset|fromage|fantastic',
+					),
+					'spacing' => array(
+						'margin'  => 'var:cheese|spacing|margin',
+						'padding' => 'var:preset|spacing|padding',
+					),
+				),
+				'options'         => array( 'convert_vars_to_classnames' => true ),
+				'expected_output' => array(
+					'classnames' => 'has-text-color has-background',
+				),
+			),
+
+			'valid_spacing_single_preset_values'           => array(
+				'block_styles'    => array(
+					'spacing' => array(
+						'margin'  => 'var:preset|spacing|10',
+						'padding' => 'var:preset|spacing|20',
+					),
+				),
+				'options'         => array(),
+				'expected_output' => array(
+					'css'          => 'padding:var(--wp--preset--spacing--20);margin:var(--wp--preset--spacing--10);',
+					'declarations' => array(
+						'padding' => 'var(--wp--preset--spacing--20)',
+						'margin'  => 'var(--wp--preset--spacing--10)',
+					),
+				),
+			),
+
+			'valid_spacing_multi_preset_values'            => array(
+				'block_styles'    => array(
+					'spacing' => array(
+						'margin'  => array(
+							'left'   => 'var:preset|spacing|10',
+							'right'  => 'var:preset|spacing|20',
+							'top'    => '1rem',
+							'bottom' => '1rem',
+						),
+						'padding' => array(
+							'left'   => 'var:preset|spacing|30',
+							'right'  => 'var:preset|spacing|40',
+							'top'    => '14px',
+							'bottom' => '14px',
+						),
+					),
+				),
+				'options'         => array(),
+				'expected_output' => array(
+					'css'          => 'padding-left:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--40);padding-top:14px;padding-bottom:14px;margin-left:var(--wp--preset--spacing--10);margin-right:var(--wp--preset--spacing--20);margin-top:1rem;margin-bottom:1rem;',
+					'declarations' => array(
+						'padding-left'   => 'var(--wp--preset--spacing--30)',
+						'padding-right'  => 'var(--wp--preset--spacing--40)',
+						'padding-top'    => '14px',
+						'padding-bottom' => '14px',
+						'margin-left'    => 'var(--wp--preset--spacing--10)',
+						'margin-right'   => 'var(--wp--preset--spacing--20)',
+						'margin-top'     => '1rem',
+						'margin-bottom'  => '1rem',
+					),
+				),
+			),
+
+			'invalid_spacing_multi_preset_values'          => array(
+				'block_styles'    => array(
+					'spacing' => array(
+						'margin' => array(
+							'left'   => 'var:preset|spaceman|10',
+							'right'  => 'var:preset|spaceman|20',
+							'top'    => '1rem',
+							'bottom' => '0',
+						),
+					),
+				),
+				'options'         => array(),
+				'expected_output' => array(
+					'css'          => 'margin-top:1rem;margin-bottom:0;',
+					'declarations' => array(
+						'margin-top'    => '1rem',
+						'margin-bottom' => '0',
+					),
+				),
+			),
+
+			'invalid_classnames_options'                   => array(
+				'block_styles'    => array(
+					'typography' => array(
+						'fontSize'   => array(
+							'tomodachi' => 'friends',
+						),
+						'fontFamily' => array(
+							'oishii' => 'tasty',
+						),
+					),
+				),
+				'options'         => array(),
+				'expected_output' => array(),
+			),
+
+			'inline_valid_box_model_style_with_sides'      => array(
+				'block_styles'    => array(
+					'border' => array(
+						'top'    => array(
+							'color' => '#fe1',
+							'width' => '1.5rem',
+							'style' => 'dashed',
+						),
+						'right'  => array(
+							'color' => '#fe2',
+							'width' => '1.4rem',
+							'style' => 'solid',
+						),
+						'bottom' => array(
+							'color' => '#fe3',
+							'width' => '1.3rem',
+						),
+						'left'   => array(
+							'color' => 'var:preset|color|swampy-yellow',
+							'width' => '0.5rem',
+							'style' => 'dotted',
+						),
+					),
+				),
+				'options'         => array(),
+				'expected_output' => array(
+					'css'          => 'border-top-color:#fe1;border-top-width:1.5rem;border-top-style:dashed;border-right-color:#fe2;border-right-width:1.4rem;border-right-style:solid;border-bottom-color:#fe3;border-bottom-width:1.3rem;border-left-color:var(--wp--preset--color--swampy-yellow);border-left-width:0.5rem;border-left-style:dotted;',
+					'declarations' => array(
+						'border-top-color'    => '#fe1',
+						'border-top-width'    => '1.5rem',
+						'border-top-style'    => 'dashed',
+						'border-right-color'  => '#fe2',
+						'border-right-width'  => '1.4rem',
+						'border-right-style'  => 'solid',
+						'border-bottom-color' => '#fe3',
+						'border-bottom-width' => '1.3rem',
+						'border-left-color'   => 'var(--wp--preset--color--swampy-yellow)',
+						'border-left-width'   => '0.5rem',
+						'border-left-style'   => 'dotted',
+					),
+				),
+			),
+
+			'inline_invalid_box_model_style_with_sides'    => array(
+				'block_styles'    => array(
+					'border' => array(
+						'top'    => array(
+							'top'    => '#fe1',
+							'right'  => '1.5rem',
+							'cheese' => 'dashed',
+						),
+						'right'  => array(
+							'right' => '#fe2',
+							'top'   => '1.4rem',
+							'bacon' => 'solid',
+						),
+						'bottom' => array(
+							'color'  => 'var:preset|color|terrible-lizard',
+							'bottom' => '1.3rem',
+						),
+						'left'   => array(
+							'left'  => null,
+							'width' => null,
+							'top'   => 'dotted',
+						),
+					),
+				),
+				'options'         => array(),
+				'expected_output' => array(
+					'css'          => 'border-bottom-color:var(--wp--preset--color--terrible-lizard);',
+					'declarations' => array(
+						'border-bottom-color' => 'var(--wp--preset--color--terrible-lizard)',
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Tests adding rules to a store and retrieving a generated stylesheet.
+	 */
+	public function test_store_block_styles_using_context() {
+		$block_styles = array(
+			'spacing' => array(
+				'padding' => array(
+					'top'    => '42px',
+					'left'   => '2%',
+					'bottom' => '44px',
+					'right'  => '5rem',
+				),
+			),
+		);
+
+		$generated_styles = wp_style_engine_get_styles(
+			$block_styles,
+			array(
+				'context'  => 'block-supports',
+				'selector' => 'article',
+			)
+		);
+		$store            = WP_Style_Engine::get_store( 'block-supports' );
+		$rule             = $store->get_all_rules()['article'];
+		$this->assertSame( $generated_styles['css'], $rule->get_css() );
+	}
+
+	/**
+	 * Tests adding rules to a store and retrieving a generated stylesheet.
+	 */
+	public function test_does_not_store_block_styles_without_context() {
+		$block_styles = array(
+			'typography' => array(
+				'fontSize' => '999px',
+			),
+		);
+
+		wp_style_engine_get_styles(
+			$block_styles,
+			array(
+				'selector' => '#font-size-rulez',
+			)
+		);
+
+		$all_stores = WP_Style_Engine_CSS_Rules_Store_Gutenberg::get_stores();
+
+		$this->assertEmpty( $all_stores );
+	}
+
+	/**
+	 * Tests adding rules to a store and retrieving a generated stylesheet.
+	 */
+	public function test_add_to_store() {
+		$css_rules           = array(
+			array(
+				'selector'     => '.frodo',
+				'declarations' => array(
+					'color'        => 'brown',
+					'height'       => '10px',
+					'width'        => '30px',
+					'border-style' => 'dotted',
+				),
+			),
+			array(
+				'selector'     => '.samwise',
+				'declarations' => array(
+					'color'        => 'brown',
+					'height'       => '20px',
+					'width'        => '50px',
+					'border-style' => 'solid',
+				),
+			),
+		);
+		$compiled_stylesheet = wp_style_engine_get_stylesheet_from_css_rules(
+			$css_rules,
+			array(
+				'context' => 'test-store',
+			)
+		);
+
+		// Check that the style engine knows about the store.
+		$stored_store = WP_Style_Engine::get_store( 'test-store' );
+		$this->assertInstanceOf( 'WP_Style_Engine_CSS_Rules_Store', $stored_store );
+		$this->assertSame( $compiled_stylesheet, WP_Style_Engine::compile_stylesheet_from_css_rules( $stored_store->get_all_rules() ) );
+	}
+
+	/**
+	 * Tests retrieving a generated stylesheet from any rules.
+	 */
+	public function test_get_stylesheet_from_css_rules() {
+		$css_rules = array(
+			array(
+				'selector'     => '.saruman',
+				'declarations' => array(
+					'color'        => 'white',
+					'height'       => '100px',
+					'border-style' => 'solid',
+					'align-self'   => 'unset',
+				),
+			),
+			array(
+				'selector'     => '.gandalf',
+				'declarations' => array(
+					'color'        => 'grey',
+					'height'       => '90px',
+					'border-style' => 'dotted',
+					'align-self'   => 'safe center',
+				),
+			),
+			array(
+				'selector'     => '.radagast',
+				'declarations' => array(
+					'color'        => 'brown',
+					'height'       => '60px',
+					'border-style' => 'dashed',
+					'align-self'   => 'stretch',
+				),
+			),
+		);
+
+		$compiled_stylesheet = wp_style_engine_get_stylesheet_from_css_rules( $css_rules );
+		$this->assertSame( '.saruman{color:white;height:100px;border-style:solid;align-self:unset;}.gandalf{color:grey;height:90px;border-style:dotted;align-self:safe center;}.radagast{color:brown;height:60px;border-style:dashed;align-self:stretch;}', $compiled_stylesheet );
+	}
+
+	/**
+	 * Tests that incoming styles are deduped and merged.
+	 */
+	public function test_get_deduped_and_merged_stylesheet() {
+		$css_rules = array(
+			array(
+				'selector'     => '.gandalf',
+				'declarations' => array(
+					'color'        => 'grey',
+					'height'       => '90px',
+					'border-style' => 'dotted',
+				),
+			),
+			array(
+				'selector'     => '.gandalf',
+				'declarations' => array(
+					'color'         => 'white',
+					'height'        => '190px',
+					'padding'       => '10px',
+					'margin-bottom' => '100px',
+				),
+			),
+			array(
+				'selector'     => '.dumbledore',
+				'declarations' => array(
+					'color'        => 'grey',
+					'height'       => '90px',
+					'border-style' => 'dotted',
+				),
+			),
+			array(
+				'selector'     => '.rincewind',
+				'declarations' => array(
+					'color'        => 'grey',
+					'height'       => '90px',
+					'border-style' => 'dotted',
+				),
+			),
+		);
+
+		$compiled_stylesheet = wp_style_engine_get_stylesheet_from_css_rules( $css_rules );
+		$this->assertSame( '.gandalf{color:white;height:190px;border-style:dotted;padding:10px;margin-bottom:100px;}.dumbledore,.rincewind{color:grey;height:90px;border-style:dotted;}', $compiled_stylesheet );
+	}
+}

--- a/tests/phpunit/tests/style-engine/styleEngine.php
+++ b/tests/phpunit/tests/style-engine/styleEngine.php
@@ -14,7 +14,7 @@
  */
 class Tests_wpStyleEngine extends WP_UnitTestCase {
 	/**
-	 * Tear down after each test.
+	 * Cleans up stores after each test.
 	 */
 	public function tear_down() {
 		WP_Style_Engine_CSS_Rules_Store::remove_all_stores();
@@ -25,9 +25,8 @@ class Tests_wpStyleEngine extends WP_UnitTestCase {
 	 * Tests generating block styles and classnames based on various manifestations of the $block_styles argument.
 	 *
 	 * @ticket 56467
+	 *
 	 * @covers ::wp_style_engine_get_styles
-	 * @covers WP_Style_Engine::parse_block_styles
-	 * @covers WP_Style_Engine::compile_css
 	 *
 	 * @dataProvider data_wp_style_engine_get_styles
 	 *
@@ -45,6 +44,7 @@ class Tests_wpStyleEngine extends WP_UnitTestCase {
 	 */
 	public function test_wp_style_engine_get_styles( $block_styles, $options, $expected_output ) {
 		$generated_styles = wp_style_engine_get_styles( $block_styles, $options );
+
 		$this->assertSame( $expected_output, $generated_styles );
 	}
 
@@ -484,8 +484,8 @@ class Tests_wpStyleEngine extends WP_UnitTestCase {
 	 * Tests adding rules to a store and retrieving a generated stylesheet.
 	 *
 	 * @ticket 56467
+	 *
 	 * @covers ::wp_style_engine_get_styles
-	 * @covers WP_Style_Engine::store_css_rule
 	 */
 	public function test_should_store_block_styles_using_context() {
 		$block_styles = array(
@@ -508,6 +508,7 @@ class Tests_wpStyleEngine extends WP_UnitTestCase {
 		);
 		$store            = WP_Style_Engine::get_store( 'block-supports' );
 		$rule             = $store->get_all_rules()['article'];
+
 		$this->assertSame( $generated_styles['css'], $rule->get_css() );
 	}
 
@@ -515,6 +516,7 @@ class Tests_wpStyleEngine extends WP_UnitTestCase {
 	 * Tests that passing no context does not store styles.
 	 *
 	 * @ticket 56467
+	 *
 	 * @covers ::wp_style_engine_get_styles
 	 */
 	public function test_should_not_store_block_styles_without_context() {
@@ -540,9 +542,8 @@ class Tests_wpStyleEngine extends WP_UnitTestCase {
 	 * Tests adding rules to a store and retrieving a generated stylesheet.
 	 *
 	 * @ticket 56467
+	 *
 	 * @covers ::wp_style_engine_get_stylesheet_from_context
-	 * @covers WP_Style_Engine::store_css_rule
-	 * @covers WP_Style_Engine::compile_stylesheet_from_css_rules
 	 */
 	public function test_should_get_stored_stylesheet_from_context() {
 		$css_rules           = array(
@@ -579,8 +580,8 @@ class Tests_wpStyleEngine extends WP_UnitTestCase {
 	 * Tests returning a generated stylesheet from a set of rules.
 	 *
 	 * @ticket 56467
+	 *
 	 * @covers ::wp_style_engine_get_stylesheet_from_css_rules
-	 * @covers WP_Style_Engine::compile_stylesheet_from_css_rules
 	 */
 	public function test_should_return_stylesheet_from_css_rules() {
 		$css_rules = array(
@@ -614,6 +615,7 @@ class Tests_wpStyleEngine extends WP_UnitTestCase {
 		);
 
 		$compiled_stylesheet = wp_style_engine_get_stylesheet_from_css_rules( $css_rules, array( 'prettify' => false ) );
+
 		$this->assertSame( '.saruman{color:white;height:100px;border-style:solid;align-self:unset;}.gandalf{color:grey;height:90px;border-style:dotted;align-self:safe center;}.radagast{color:brown;height:60px;border-style:dashed;align-self:stretch;}', $compiled_stylesheet );
 	}
 
@@ -621,6 +623,7 @@ class Tests_wpStyleEngine extends WP_UnitTestCase {
 	 * Tests that incoming styles are deduped and merged.
 	 *
 	 * @ticket 56467
+	 *
 	 * @covers ::wp_style_engine_get_stylesheet_from_css_rules
 	 */
 	public function test_should_dedupe_and_merge_css_rules() {
@@ -661,6 +664,7 @@ class Tests_wpStyleEngine extends WP_UnitTestCase {
 		);
 
 		$compiled_stylesheet = wp_style_engine_get_stylesheet_from_css_rules( $css_rules, array( 'prettify' => false ) );
+
 		$this->assertSame( '.gandalf{color:white;height:190px;border-style:dotted;padding:10px;margin-bottom:100px;}.dumbledore,.rincewind{color:grey;height:90px;border-style:dotted;}', $compiled_stylesheet );
 	}
 }

--- a/tests/phpunit/tests/style-engine/styleEngine.php
+++ b/tests/phpunit/tests/style-engine/styleEngine.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests the Style Engine class and associated functionality.
+ * Tests the Style Engine global functions that interact with the WP_Style_Engine class.
  *
  * @package WordPress
  * @subpackage StyleEngine
@@ -12,7 +12,7 @@
 /**
  * Tests for registering, storing and generating styles.
  */
-class WP_Style_Engine_Test extends WP_UnitTestCase {
+class Tests_wpStyleEngine extends WP_UnitTestCase {
 	/**
 	 * Tear down after each test.
 	 */
@@ -26,6 +26,8 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 	 *
 	 * @ticket 56467
 	 * @covers ::wp_style_engine_get_styles
+	 * @covers WP_Style_Engine::parse_block_styles
+	 * @covers WP_Style_Engine::compile_css
 	 *
 	 * @dataProvider data_wp_style_engine_get_styles
 	 *
@@ -116,28 +118,6 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 						'margin'       => '111px',
 					),
 					'classnames'   => 'has-text-color has-texas-flood-color has-border-color has-cool-caramel-border-color',
-				),
-			),
-
-			'valid_inline_css_and_classnames_with_context' => array(
-				'block_styles'    => array(
-					'color'   => array(
-						'text' => 'var:preset|color|little-lamb',
-					),
-					'spacing' => array(
-						'margin' => '20px',
-					),
-				),
-				'options'         => array(
-					'convert_vars_to_classnames' => true,
-					'context'                    => 'block-supports',
-				),
-				'expected_output' => array(
-					'css'          => 'margin:20px;',
-					'declarations' => array(
-						'margin' => '20px',
-					),
-					'classnames'   => 'has-text-color has-little-lamb-color',
 				),
 			),
 
@@ -505,6 +485,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 	 *
 	 * @ticket 56467
 	 * @covers ::wp_style_engine_get_styles
+	 * @covers WP_Style_Engine::store_css_rule
 	 */
 	public function test_should_store_block_styles_using_context() {
 		$block_styles = array(
@@ -560,6 +541,8 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 	 *
 	 * @ticket 56467
 	 * @covers ::wp_style_engine_get_stylesheet_from_context
+	 * @covers WP_Style_Engine::store_css_rule
+	 * @covers WP_Style_Engine::compile_stylesheet_from_css_rules
 	 */
 	public function test_should_get_stored_stylesheet_from_context() {
 		$css_rules           = array(
@@ -597,6 +580,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 	 *
 	 * @ticket 56467
 	 * @covers ::wp_style_engine_get_stylesheet_from_css_rules
+	 * @covers WP_Style_Engine::compile_stylesheet_from_css_rules
 	 */
 	public function test_should_return_stylesheet_from_css_rules() {
 		$css_rules = array(

--- a/tests/phpunit/tests/style-engine/styleEngine.php
+++ b/tests/phpunit/tests/style-engine/styleEngine.php
@@ -616,7 +616,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 			),
 		);
 
-		$compiled_stylesheet = wp_style_engine_get_stylesheet_from_css_rules( $css_rules );
+		$compiled_stylesheet = wp_style_engine_get_stylesheet_from_css_rules( $css_rules, array( 'prettify' => false ) );
 		$this->assertSame( '.saruman{color:white;height:100px;border-style:solid;align-self:unset;}.gandalf{color:grey;height:90px;border-style:dotted;align-self:safe center;}.radagast{color:brown;height:60px;border-style:dashed;align-self:stretch;}', $compiled_stylesheet );
 	}
 
@@ -662,7 +662,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 			),
 		);
 
-		$compiled_stylesheet = wp_style_engine_get_stylesheet_from_css_rules( $css_rules );
+		$compiled_stylesheet = wp_style_engine_get_stylesheet_from_css_rules( $css_rules, array( 'prettify' => false ) );
 		$this->assertSame( '.gandalf{color:white;height:190px;border-style:dotted;padding:10px;margin-bottom:100px;}.dumbledore,.rincewind{color:grey;height:90px;border-style:dotted;}', $compiled_stylesheet );
 	}
 }

--- a/tests/phpunit/tests/style-engine/styleEngine.php
+++ b/tests/phpunit/tests/style-engine/styleEngine.php
@@ -17,19 +17,20 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 	 * Tear down after each test.
 	 */
 	public function tear_down() {
-		parent::tear_down();
 		WP_Style_Engine_CSS_Rules_Store::remove_all_stores();
+		parent::tear_down();
 	}
 
 	/**
 	 * Tests generating block styles and classnames based on various manifestations of the $block_styles argument.
 	 *
+	 * @ticket 56467
 	 * @covers ::wp_style_engine_get_styles
 	 *
 	 * @dataProvider data_get_styles_fixtures
 	 *
-	 * @param array  $block_styles The incoming block styles object.
-	 * @param array  $options Style engine options.
+	 * @param array  $block_styles    The incoming block styles object.
+	 * @param array  $options         Style engine options.
 	 * @param string $expected_output The expected output.
 	 */
 	public function test_wp_style_engine_get_styles( $block_styles, $options, $expected_output ) {
@@ -494,9 +495,10 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 	/**
 	 * Tests adding rules to a store and retrieving a generated stylesheet.
 	 *
+	 * @ticket 56467
 	 * @covers ::wp_style_engine_get_styles
 	 */
-	public function test_wp_style_engine_get_styles_and_store_using_context() {
+	public function test_should_store_block_styles_using_context() {
 		$block_styles = array(
 			'spacing' => array(
 				'padding' => array(
@@ -521,11 +523,12 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests adding rules to a store and retrieving a generated stylesheet.
+	 * Tests that passing no context does not store styles.
 	 *
+	 * @ticket 56467
 	 * @covers ::wp_style_engine_get_styles
 	 */
-	public function test_wp_style_engine_get_styles_without_context() {
+	public function test_should_not_store_block_styles_without_context() {
 		$block_styles = array(
 			'typography' => array(
 				'fontSize' => '999px',
@@ -547,9 +550,10 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 	/**
 	 * Tests adding rules to a store and retrieving a generated stylesheet.
 	 *
+	 * @ticket 56467
 	 * @covers ::wp_style_engine_get_stylesheet_from_context
 	 */
-	public function test_wp_style_engine_get_stylesheet_from_context() {
+	public function test_should_get_stored_stylesheet_from_context() {
 		$css_rules           = array(
 			array(
 				'selector'     => '.frodo',
@@ -581,11 +585,12 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests retrieving a generated stylesheet from any rules.
+	 * Tests returning a generated stylesheet from a set of rules.
 	 *
+	 * @ticket 56467
 	 * @covers ::wp_style_engine_get_stylesheet_from_css_rules
 	 */
-	public function test_wp_style_engine_get_stylesheet_from_css_rules() {
+	public function test_should_return_stylesheet_from_css_rules() {
 		$css_rules = array(
 			array(
 				'selector'     => '.saruman',
@@ -623,9 +628,10 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 	/**
 	 * Tests that incoming styles are deduped and merged.
 	 *
+	 * @ticket 56467
 	 * @covers ::wp_style_engine_get_stylesheet_from_css_rules
 	 */
-	public function test_wp_style_engine_get_stylesheet_from_css_rules_dedupes_and_merges() {
+	public function test_should_dedupe_and_merge_css_rules() {
 		$css_rules = array(
 			array(
 				'selector'     => '.gandalf',

--- a/tests/phpunit/tests/style-engine/styleEngine.php
+++ b/tests/phpunit/tests/style-engine/styleEngine.php
@@ -27,10 +27,18 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 	 * @ticket 56467
 	 * @covers ::wp_style_engine_get_styles
 	 *
-	 * @dataProvider data_get_styles_fixtures
+	 * @dataProvider data_wp_style_engine_get_styles
 	 *
 	 * @param array  $block_styles    The incoming block styles object.
-	 * @param array  $options         Style engine options.
+	 * @param array  $options         {
+	 *     An array of options to pass to `wp_style_engine_get_styles()`.
+	 *
+	 *     @type string|null $context                    An identifier describing the origin of the style object, e.g., 'block-supports' or 'global-styles'. Default is `null`.
+	 *                                                   When set, the style engine will attempt to store the CSS rules, where a selector is also passed.
+	 *     @type bool        $convert_vars_to_classnames Whether to skip converting incoming CSS var patterns, e.g., `var:preset|<PRESET_TYPE>|<PRESET_SLUG>`, to var( --wp--preset--* ) values. Default `false`.
+	 *     @type string      $selector                   Optional. When a selector is passed, the value of `$css` in the return value will comprise a full CSS rule `$selector { ...$css_declarations }`,
+	 *                                                   otherwise, the value will be a concatenated string of CSS declarations.
+	 * }
 	 * @param string $expected_output The expected output.
 	 */
 	public function test_wp_style_engine_get_styles( $block_styles, $options, $expected_output ) {
@@ -39,11 +47,11 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Data provider for test_generate_get_styles().
+	 * Data provider for test_wp_style_engine_get_styles().
 	 *
 	 * @return array
 	 */
-	public function data_get_styles_fixtures() {
+	public function data_wp_style_engine_get_styles() {
 		return array(
 			'default_return_value'                         => array(
 				'block_styles'    => array(),

--- a/tests/phpunit/tests/style-engine/wpStyleEngineCssDeclarations.php
+++ b/tests/phpunit/tests/style-engine/wpStyleEngineCssDeclarations.php
@@ -71,7 +71,6 @@ class Tests_Style_Engine_wpStyleEngineCSSDeclarations extends WP_UnitTestCase {
 	 * Tests that properties are sanitized before storing.
 	 *
 	 * @ticket 56467
-	 * @covers ::filter_declaration
 	 * @covers ::sanitize_property
 	 */
 	public function test_should_sanitize_properties() {
@@ -91,24 +90,76 @@ class Tests_Style_Engine_wpStyleEngineCSSDeclarations extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that values are escaped and run the CSS through safecss_filter_attr().
+	 * Test that values with HTML tags are escaped, and CSS properties are run through safecss_filter_attr().
 	 *
 	 * @ticket 56467
+	 * @covers ::get_declarations_string
 	 * @covers ::filter_declaration
 	 */
-	public function test_should_remove_unsafe_properties_and_values() {
-		$input_declarations = array(
-			'color'        => 'url("https://wordpress.org")',
+	public function test_should_strip_html_tags_andremove_unsafe_css_properties() {
+		$input_declarations         = array(
 			'font-size'    => '<red/>',
-			'margin-right' => '10em',
 			'padding'      => '</style>',
 			'potato'       => 'uppercase',
+			'cheese'       => '10px',
+			'margin-right' => '10em',
 		);
-		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
+		$css_declarations           = new WP_Style_Engine_CSS_Declarations( $input_declarations );
+		$safe_style_css_mock_action = new MockAction();
+
+		// filter_declaration() is called in get_declarations_string().
+		add_filter( 'safe_style_css', array( $safe_style_css_mock_action, 'filter' ) );
+		$css_declarations_string = $css_declarations->get_declarations_string();
+
+		$this->assertSame(
+			3, // Values with HTML tags are removed first by wp_strip_all_tags().
+			$safe_style_css_mock_action->get_call_count(),
+			'"safe_style_css" filters were not applied to CSS declaration properties.'
+		);
 
 		$this->assertSame(
 			'margin-right:10em;',
-			$css_declarations->get_declarations_string()
+			$css_declarations_string,
+			'Unallowed CSS properties or values with HTML tags were not removed.'
+		);
+	}
+
+	/**
+	 * Tests that calc, clamp, min, max, and minmax CSS functions are allowed.
+	 *
+	 * @ticket 56467
+	 * @covers ::get_declarations_string
+	 * @covers ::filter_declaration
+	 */
+	public function test_should_allow_css_functions_and_strip_unsafe_css_values() {
+		$input_declarations                        = array(
+			'background'       => 'var(--wp--preset--color--primary, 10px)', // Simple var().
+			'font-size'        => 'clamp(36.00rem, calc(32.00rem + 10.00vw), 40.00rem)', // Nested clamp().
+			'width'            => 'min(150vw, 100px)',
+			'min-width'        => 'max(150vw, 100px)',
+			'max-width'        => 'minmax(400px, 50%)',
+			'padding'          => 'calc(80px * -1)',
+			'background-image' => 'url("https://wordpress.org")',
+			'line-height'      => 'url("https://wordpress.org")',
+			'margin'           => 'illegalfunction(30px)',
+		);
+		$css_declarations                          = new WP_Style_Engine_CSS_Declarations( $input_declarations );
+		$safecss_filter_attr_allow_css_mock_action = new MockAction();
+
+		// filter_declaration() is called in get_declarations_string().
+		add_filter( 'safecss_filter_attr_allow_css', array( $safecss_filter_attr_allow_css_mock_action, 'filter' ) );
+		$css_declarations_string = $css_declarations->get_declarations_string();
+
+		$this->assertSame(
+			9,
+			$safecss_filter_attr_allow_css_mock_action->get_call_count(),
+			'"safecss_filter_attr_allow_css" filters were not applied to CSS declaration values.'
+		);
+
+		$this->assertSame(
+			'background:var(--wp--preset--color--primary, 10px);font-size:clamp(36.00rem, calc(32.00rem + 10.00vw), 40.00rem);width:min(150vw, 100px);min-width:max(150vw, 100px);max-width:minmax(400px, 50%);padding:calc(80px * -1);background-image:url("https://wordpress.org");',
+			$css_declarations_string,
+			'Unsafe values were not removed'
 		);
 	}
 
@@ -167,33 +218,6 @@ class Tests_Style_Engine_wpStyleEngineCSSDeclarations extends WP_UnitTestCase {
 				'should_prettify' => true,
 				'indent_count'    => 2,
 			),
-		);
-	}
-
-	/**
-	 * Tests that calc, clamp, min, max, and minmax CSS functions are allowed.
-	 *
-	 * @ticket 56467
-	 * @covers ::filter_declaration
-	 * @covers ::get_declarations_string
-	 */
-	public function test_should_allow_css_functions() {
-		$input_declarations = array(
-			'background'       => 'var(--wp--preset--color--primary, 10px)', // Simple var().
-			'font-size'        => 'clamp(36.00rem, calc(32.00rem + 10.00vw), 40.00rem)', // Nested clamp().
-			'width'            => 'min(150vw, 100px)',
-			'min-width'        => 'max(150vw, 100px)',
-			'max-width'        => 'minmax(400px, 50%)',
-			'padding'          => 'calc(80px * -1)',
-			'background-image' => 'url("https://wordpress.org")',
-			'line-height'      => 'url("https://wordpress.org")',
-			'margin'           => 'illegalfunction(30px)',
-		);
-		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
-
-		$this->assertSame(
-			'background:var(--wp--preset--color--primary, 10px);font-size:clamp(36.00rem, calc(32.00rem + 10.00vw), 40.00rem);width:min(150vw, 100px);min-width:max(150vw, 100px);max-width:minmax(400px, 50%);padding:calc(80px * -1);background-image:url("https://wordpress.org");',
-			$css_declarations->get_declarations_string()
 		);
 	}
 

--- a/tests/phpunit/tests/style-engine/wpStyleEngineCssDeclarations.php
+++ b/tests/phpunit/tests/style-engine/wpStyleEngineCssDeclarations.php
@@ -6,7 +6,7 @@
  * @subpackage StyleEngine
  * @since 6.1.0
  *
- * @group styleEngine
+ * @group style-engine
  */
 
 /**

--- a/tests/phpunit/tests/style-engine/wpStyleEngineCssDeclarations.php
+++ b/tests/phpunit/tests/style-engine/wpStyleEngineCssDeclarations.php
@@ -1,0 +1,235 @@
+<?php
+/**
+ * Tests the Style Engine CSS declarations class.
+ *
+ * @package WordPress
+ * @subpackage StyleEngine
+ * @since 6.1.0
+ *
+ * @group styleEngine
+ */
+
+/**
+ * Tests for registering, storing and generating CSS declarations.
+ */
+class WP_Style_Engine_CSS_Declarations_Test extends WP_UnitTestCase {
+	/**
+	 * Should set declarations on instantiation.
+	 */
+	public function test_instantiate_with_declarations() {
+		$input_declarations = array(
+			'margin-top' => '10px',
+			'font-size'  => '2rem',
+		);
+		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
+		$this->assertSame( $input_declarations, $css_declarations->get_declarations() );
+	}
+
+	/**
+	 * Should add declarations.
+	 */
+	public function test_add_declarations() {
+		$input_declarations = array(
+			'padding' => '20px',
+			'color'   => 'var(--wp--preset--elbow-patches)',
+		);
+		$css_declarations   = new WP_Style_Engine_CSS_Declarations();
+		$css_declarations->add_declarations( $input_declarations );
+		$this->assertSame( $input_declarations, $css_declarations->get_declarations() );
+	}
+
+	/**
+	 * Should add declarations.
+	 */
+	public function test_add_a_single_declaration() {
+		$input_declarations = array(
+			'border-width'     => '1%',
+			'background-color' => 'var(--wp--preset--english-mustard)',
+		);
+		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
+		$extra_declaration  = array(
+			'letter-spacing' => '1.5px',
+		);
+		$css_declarations->add_declarations( $extra_declaration );
+		$this->assertSame( array_merge( $input_declarations, $extra_declaration ), $css_declarations->get_declarations() );
+	}
+
+	/**
+	 * Should sanitize properties before storing.
+	 */
+	public function test_sanitize_properties() {
+		$input_declarations = array(
+			'^--wp--style--sleepy-potato$' => '40px',
+			'<background-//color>'         => 'var(--wp--preset--english-mustard)',
+		);
+		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
+
+		$this->assertSame(
+			array(
+				'--wp--style--sleepy-potato' => '40px',
+				'background-color'           => 'var(--wp--preset--english-mustard)',
+			),
+			$css_declarations->get_declarations()
+		);
+	}
+
+	/**
+	 * Should compile css declarations into a css declarations block string.
+	 */
+	public function test_generate_css_declarations_string() {
+		$input_declarations = array(
+			'color'                  => 'red',
+			'border-top-left-radius' => '99px',
+			'text-decoration'        => 'underline',
+		);
+		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
+
+		$this->assertSame(
+			'color:red;border-top-left-radius:99px;text-decoration:underline;',
+			$css_declarations->get_declarations_string()
+		);
+	}
+
+	/**
+	 * Should compile css declarations into a prettified css declarations block string.
+	 */
+	public function test_generate_prettified_css_declarations_string() {
+		$input_declarations = array(
+			'color'                  => 'red',
+			'border-top-left-radius' => '99px',
+			'text-decoration'        => 'underline',
+		);
+		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
+
+		$this->assertSame(
+			'color: red; border-top-left-radius: 99px; text-decoration: underline;',
+			$css_declarations->get_declarations_string( true )
+		);
+	}
+
+	/**
+	 * Should compile css declarations into a prettified and indented css declarations block string.
+	 */
+	public function test_generate_prettified_with_indent_css_declarations_string() {
+		$input_declarations = array(
+			'color'                  => 'red',
+			'border-top-left-radius' => '99px',
+			'text-decoration'        => 'underline',
+		);
+		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
+
+		$this->assertSame(
+			'	color: red;
+	border-top-left-radius: 99px;
+	text-decoration: underline;',
+			$css_declarations->get_declarations_string( true, 1 )
+		);
+	}
+
+	/**
+	 * Should compile css declarations into a css declarations block string.
+	 */
+	public function test_generate_prettified_with_more_indents_css_declarations_string() {
+		$input_declarations = array(
+			'color'                  => 'red',
+			'border-top-left-radius' => '99px',
+			'text-decoration'        => 'underline',
+		);
+		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
+
+		$this->assertSame(
+			'		color: red;
+		border-top-left-radius: 99px;
+		text-decoration: underline;',
+			$css_declarations->get_declarations_string( true, 2 )
+		);
+	}
+
+	/**
+	 * Should escape values and run the CSS through safecss_filter_attr.
+	 */
+	public function test_remove_unsafe_properties_and_values() {
+		$input_declarations = array(
+			'color'        => 'url("https://wordpress.org")',
+			'font-size'    => '<red/>',
+			'margin-right' => '10em',
+			'padding'      => '</style>',
+			'potato'       => 'uppercase',
+		);
+		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
+
+		$this->assertSame(
+			'margin-right:10em;',
+			$css_declarations->get_declarations_string()
+		);
+	}
+
+	/**
+	 * Should allow calc, clamp, min, max, and minmax CSS functions.
+	 */
+	public function test_allow_particular_css_functions() {
+		$input_declarations = array(
+			'background'       => 'var(--wp--preset--color--primary, 10px)', // Simple var().
+			'font-size'        => 'clamp(36.00rem, calc(32.00rem + 10.00vw), 40.00rem)', // Nested clamp().
+			'width'            => 'min(150vw, 100px)',
+			'min-width'        => 'max(150vw, 100px)',
+			'max-width'        => 'minmax(400px, 50%)',
+			'padding'          => 'calc(80px * -1)',
+			'background-image' => 'url("https://wordpress.org")',
+			'line-height'      => 'url("https://wordpress.org")',
+			'margin'           => 'illegalfunction(30px)',
+		);
+		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
+
+		$this->assertSame(
+			'background:var(--wp--preset--color--primary, 10px);font-size:clamp(36.00rem, calc(32.00rem + 10.00vw), 40.00rem);width:min(150vw, 100px);min-width:max(150vw, 100px);max-width:minmax(400px, 50%);padding:calc(80px * -1);background-image:url("https://wordpress.org");',
+			$css_declarations->get_declarations_string()
+		);
+	}
+
+	/**
+	 * Should remove a declaration
+	 */
+	public function test_remove_declaration() {
+		$input_declarations = array(
+			'color'       => 'tomato',
+			'margin'      => '10em 10em 20em 1px',
+			'font-family' => 'Happy Font serif',
+		);
+		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
+
+		$this->assertSame(
+			'color:tomato;margin:10em 10em 20em 1px;font-family:Happy Font serif;',
+			$css_declarations->get_declarations_string()
+		);
+
+		$css_declarations->remove_declaration( 'color' );
+		$this->assertSame(
+			'margin:10em 10em 20em 1px;font-family:Happy Font serif;',
+			$css_declarations->get_declarations_string()
+		);
+	}
+
+	/**
+	 * Should remove declarations
+	 */
+	public function test_remove_declarations() {
+		$input_declarations = array(
+			'color'       => 'cucumber',
+			'margin'      => '10em 10em 20em 1px',
+			'font-family' => 'Happy Font serif',
+		);
+		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
+
+		$this->assertSame(
+			'color:cucumber;margin:10em 10em 20em 1px;font-family:Happy Font serif;',
+			$css_declarations->get_declarations_string()
+		);
+
+		$css_declarations->remove_declarations( array( 'color', 'margin' ) );
+		$this->assertSame(
+			'font-family:Happy Font serif;',
+			$css_declarations->get_declarations_string()
+		);
+	}
+}

--- a/tests/phpunit/tests/style-engine/wpStyleEngineCssDeclarations.php
+++ b/tests/phpunit/tests/style-engine/wpStyleEngineCssDeclarations.php
@@ -213,13 +213,15 @@ class Tests_Style_Engine_wpStyleEngineCSSDeclarations extends WP_UnitTestCase {
 
 		$this->assertSame(
 			'color:tomato;margin:10em 10em 20em 1px;font-family:Happy Font serif;',
-			$css_declarations->get_declarations_string()
+			$css_declarations->get_declarations_string(),
+			'CSS declarations string does not match the values of `$declarations` passed to the constructor.'
 		);
 
 		$css_declarations->remove_declaration( 'color' );
 		$this->assertSame(
 			'margin:10em 10em 20em 1px;font-family:Happy Font serif;',
-			$css_declarations->get_declarations_string()
+			$css_declarations->get_declarations_string(),
+			'Output after removing CSS declaration via `remove_declaration()` does not match expectations'
 		);
 	}
 
@@ -239,13 +241,15 @@ class Tests_Style_Engine_wpStyleEngineCSSDeclarations extends WP_UnitTestCase {
 
 		$this->assertSame(
 			'color:cucumber;margin:10em 10em 20em 1px;font-family:Happy Font serif;',
-			$css_declarations->get_declarations_string()
+			$css_declarations->get_declarations_string(),
+			'CSS declarations string does not match the values of `$declarations` passed to the constructor.'
 		);
 
 		$css_declarations->remove_declarations( array( 'color', 'margin' ) );
 		$this->assertSame(
 			'font-family:Happy Font serif;',
-			$css_declarations->get_declarations_string()
+			$css_declarations->get_declarations_string(),
+			'Output after removing multiple CSS declaration via `remove_declarations()` does not match expectations'
 		);
 	}
 }

--- a/tests/phpunit/tests/style-engine/wpStyleEngineCssDeclarations.php
+++ b/tests/phpunit/tests/style-engine/wpStyleEngineCssDeclarations.php
@@ -10,13 +10,18 @@
  */
 
 /**
- * Tests for registering, storing and generating CSS declarations.
+ * Tests registering, storing and generating CSS declarations.
+ *
+ * @coversDefaultClass WP_Style_Engine_CSS_Declarations
  */
-class WP_Style_Engine_CSS_Declarations_Test extends WP_UnitTestCase {
+class Tests_Style_Engine_wpStyleEngineCSSDeclarations extends WP_UnitTestCase {
 	/**
-	 * Should set declarations on instantiation.
+	 * Tests setting declarations on instantiation.
+	 *
+	 * @ticket 56467
+	 * @covers ::__construct
 	 */
-	public function test_instantiate_with_declarations() {
+	public function test_should_set_declarations_on_instantiation() {
 		$input_declarations = array(
 			'margin-top' => '10px',
 			'font-size'  => '2rem',
@@ -26,9 +31,13 @@ class WP_Style_Engine_CSS_Declarations_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Should add declarations.
+	 * Tests that declarations are added.
+	 *
+	 * @ticket 56467
+	 * @covers ::add_declarations
+	 * @covers ::add_declaration
 	 */
-	public function test_add_declarations() {
+	public function test_should_add_declarations() {
 		$input_declarations = array(
 			'padding' => '20px',
 			'color'   => 'var(--wp--preset--elbow-patches)',
@@ -39,9 +48,13 @@ class WP_Style_Engine_CSS_Declarations_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Should add declarations.
+	 * Tests that new declarations are added to existing declarations.
+	 *
+	 * @ticket 56467
+	 * @covers ::add_declarations
+	 * @covers ::add_declaration
 	 */
-	public function test_add_a_single_declaration() {
+	public function test_should_add_new_declarations_to_existing() {
 		$input_declarations = array(
 			'border-width'     => '1%',
 			'background-color' => 'var(--wp--preset--english-mustard)',
@@ -55,9 +68,13 @@ class WP_Style_Engine_CSS_Declarations_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Should sanitize properties before storing.
+	 * Tests that properties are sanitized before storing.
+	 *
+	 * @ticket 56467
+	 * @covers ::filter_declaration
+	 * @covers ::sanitize_property
 	 */
-	public function test_sanitize_properties() {
+	public function test_should_sanitize_properties() {
 		$input_declarations = array(
 			'^--wp--style--sleepy-potato$' => '40px',
 			'<background-//color>'         => 'var(--wp--preset--english-mustard)',
@@ -74,81 +91,12 @@ class WP_Style_Engine_CSS_Declarations_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Should compile css declarations into a css declarations block string.
+	 * Test that values are escaped and run the CSS through safecss_filter_attr().
+	 *
+	 * @ticket 56467
+	 * @covers ::filter_declaration
 	 */
-	public function test_generate_css_declarations_string() {
-		$input_declarations = array(
-			'color'                  => 'red',
-			'border-top-left-radius' => '99px',
-			'text-decoration'        => 'underline',
-		);
-		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
-
-		$this->assertSame(
-			'color:red;border-top-left-radius:99px;text-decoration:underline;',
-			$css_declarations->get_declarations_string()
-		);
-	}
-
-	/**
-	 * Should compile css declarations into a prettified css declarations block string.
-	 */
-	public function test_generate_prettified_css_declarations_string() {
-		$input_declarations = array(
-			'color'                  => 'red',
-			'border-top-left-radius' => '99px',
-			'text-decoration'        => 'underline',
-		);
-		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
-
-		$this->assertSame(
-			'color: red; border-top-left-radius: 99px; text-decoration: underline;',
-			$css_declarations->get_declarations_string( true )
-		);
-	}
-
-	/**
-	 * Should compile css declarations into a prettified and indented css declarations block string.
-	 */
-	public function test_generate_prettified_with_indent_css_declarations_string() {
-		$input_declarations = array(
-			'color'                  => 'red',
-			'border-top-left-radius' => '99px',
-			'text-decoration'        => 'underline',
-		);
-		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
-
-		$this->assertSame(
-			'	color: red;
-	border-top-left-radius: 99px;
-	text-decoration: underline;',
-			$css_declarations->get_declarations_string( true, 1 )
-		);
-	}
-
-	/**
-	 * Should compile css declarations into a css declarations block string.
-	 */
-	public function test_generate_prettified_with_more_indents_css_declarations_string() {
-		$input_declarations = array(
-			'color'                  => 'red',
-			'border-top-left-radius' => '99px',
-			'text-decoration'        => 'underline',
-		);
-		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
-
-		$this->assertSame(
-			'		color: red;
-		border-top-left-radius: 99px;
-		text-decoration: underline;',
-			$css_declarations->get_declarations_string( true, 2 )
-		);
-	}
-
-	/**
-	 * Should escape values and run the CSS through safecss_filter_attr.
-	 */
-	public function test_remove_unsafe_properties_and_values() {
+	public function test_should_remove_unsafe_properties_and_values() {
 		$input_declarations = array(
 			'color'        => 'url("https://wordpress.org")',
 			'font-size'    => '<red/>',
@@ -165,9 +113,97 @@ class WP_Style_Engine_CSS_Declarations_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Should allow calc, clamp, min, max, and minmax CSS functions.
+	 * Tests that css declarations are compiled into a css declarations block string.
+	 *
+	 * @ticket 56467
+	 * @covers ::get_declarations_string
 	 */
-	public function test_allow_particular_css_functions() {
+	public function test_should_generate_css_declarations_string() {
+		$input_declarations = array(
+			'color'                  => 'red',
+			'border-top-left-radius' => '99px',
+			'text-decoration'        => 'underline',
+		);
+		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
+
+		$this->assertSame(
+			'color:red;border-top-left-radius:99px;text-decoration:underline;',
+			$css_declarations->get_declarations_string()
+		);
+	}
+
+	/**
+	 * Tests that inline css declarations are compiled into a prettified css declarations block string.
+	 *
+	 * @ticket 56467
+	 * @covers ::get_declarations_string
+	 */
+	public function test_should_generate_prettified_css_declarations_string() {
+		$input_declarations = array(
+			'color'                  => 'red',
+			'border-top-left-radius' => '99px',
+			'text-decoration'        => 'underline',
+		);
+		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
+
+		$this->assertSame(
+			'color: red; border-top-left-radius: 99px; text-decoration: underline;',
+			$css_declarations->get_declarations_string( true )
+		);
+	}
+
+	/**
+	 * Tests that inline css declarations are compiled into a prettified css declarations block string with new lines and indents.
+	 *
+	 * @ticket 56467
+	 * @covers ::get_declarations_string
+	 */
+	public function test_should_generate_prettified_css_declarations_string_with_new_lines_and_indents() {
+		$input_declarations = array(
+			'color'                  => 'red',
+			'border-top-left-radius' => '99px',
+			'text-decoration'        => 'underline',
+		);
+		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
+
+		$this->assertSame(
+			'	color: red;
+	border-top-left-radius: 99px;
+	text-decoration: underline;',
+			$css_declarations->get_declarations_string( true, 1 )
+		);
+	}
+
+	/**
+	 * Tests that inline css declarations are compiled into a prettified css declarations block string with extra indents.
+	 *
+	 * @ticket 56467
+	 * @covers ::get_declarations_string
+	 */
+	public function test_should_generate_prettified_with_extra_indents_css_declarations_string() {
+		$input_declarations = array(
+			'color'                  => 'red',
+			'border-top-left-radius' => '99px',
+			'text-decoration'        => 'underline',
+		);
+		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
+
+		$this->assertSame(
+			'		color: red;
+		border-top-left-radius: 99px;
+		text-decoration: underline;',
+			$css_declarations->get_declarations_string( true, 2 )
+		);
+	}
+
+	/**
+	 * Tests that calc, clamp, min, max, and minmax CSS functions are allowed.
+	 *
+	 * @ticket 56467
+	 * @covers ::filter_declaration
+	 * @covers ::get_declarations_string
+	 */
+	public function test_should_allow_css_functions() {
 		$input_declarations = array(
 			'background'       => 'var(--wp--preset--color--primary, 10px)', // Simple var().
 			'font-size'        => 'clamp(36.00rem, calc(32.00rem + 10.00vw), 40.00rem)', // Nested clamp().
@@ -188,9 +224,12 @@ class WP_Style_Engine_CSS_Declarations_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Should remove a declaration
+	 * Tests removing a single declaration.
+	 *
+	 * @ticket 56467
+	 * @covers ::remove_declaration
 	 */
-	public function test_remove_declaration() {
+	public function test_should_remove_single_declaration() {
 		$input_declarations = array(
 			'color'       => 'tomato',
 			'margin'      => '10em 10em 20em 1px',
@@ -211,9 +250,12 @@ class WP_Style_Engine_CSS_Declarations_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Should remove declarations
+	 * Tests removing multiple declarations.
+	 *
+	 * @ticket 56467
+	 * @covers ::remove_declarations
 	 */
-	public function test_remove_declarations() {
+	public function test_should_remove_multiple_declarations() {
 		$input_declarations = array(
 			'color'       => 'cucumber',
 			'margin'      => '10em 10em 20em 1px',

--- a/tests/phpunit/tests/style-engine/wpStyleEngineCssDeclarations.php
+++ b/tests/phpunit/tests/style-engine/wpStyleEngineCssDeclarations.php
@@ -221,12 +221,12 @@ class Tests_Style_Engine_wpStyleEngineCSSDeclarations extends WP_UnitTestCase {
 		$this->assertSame(
 			'margin:10em 10em 20em 1px;font-family:Happy Font serif;',
 			$css_declarations->get_declarations_string(),
-			'Output after removing CSS declaration via `remove_declaration()` does not match expectations'
+			'Output after removing "color" declaration via `remove_declaration()` does not match expectations'
 		);
 	}
 
 	/**
-	 * Tests removing multiple declarations.
+	 * Tests that multiple declarations are removed.
 	 *
 	 * @ticket 56467
 	 * @covers ::remove_declarations
@@ -249,7 +249,7 @@ class Tests_Style_Engine_wpStyleEngineCSSDeclarations extends WP_UnitTestCase {
 		$this->assertSame(
 			'font-family:Happy Font serif;',
 			$css_declarations->get_declarations_string(),
-			'Output after removing multiple CSS declaration via `remove_declarations()` does not match expectations'
+			'Output after removing "color" and "margin" declarations via `remove_declarations()` does not match expectations'
 		);
 	}
 }

--- a/tests/phpunit/tests/style-engine/wpStyleEngineCssDeclarations.php
+++ b/tests/phpunit/tests/style-engine/wpStyleEngineCssDeclarations.php
@@ -96,7 +96,7 @@ class Tests_Style_Engine_wpStyleEngineCSSDeclarations extends WP_UnitTestCase {
 	 * @covers ::get_declarations_string
 	 * @covers ::filter_declaration
 	 */
-	public function test_should_strip_html_tags_andremove_unsafe_css_properties() {
+	public function test_should_strip_html_tags_and_remove_unsafe_css_properties() {
 		$input_declarations         = array(
 			'font-size'    => '<red/>',
 			'padding'      => '</style>',

--- a/tests/phpunit/tests/style-engine/wpStyleEngineCssDeclarations.php
+++ b/tests/phpunit/tests/style-engine/wpStyleEngineCssDeclarations.php
@@ -19,6 +19,7 @@ class Tests_Style_Engine_wpStyleEngineCSSDeclarations extends WP_UnitTestCase {
 	 * Tests setting declarations on instantiation.
 	 *
 	 * @ticket 56467
+	 *
 	 * @covers ::__construct
 	 */
 	public function test_should_set_declarations_on_instantiation() {
@@ -27,6 +28,7 @@ class Tests_Style_Engine_wpStyleEngineCSSDeclarations extends WP_UnitTestCase {
 			'font-size'  => '2rem',
 		);
 		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
+
 		$this->assertSame( $input_declarations, $css_declarations->get_declarations() );
 	}
 
@@ -34,6 +36,7 @@ class Tests_Style_Engine_wpStyleEngineCSSDeclarations extends WP_UnitTestCase {
 	 * Tests that declarations are added.
 	 *
 	 * @ticket 56467
+	 *
 	 * @covers ::add_declarations
 	 * @covers ::add_declaration
 	 */
@@ -44,6 +47,7 @@ class Tests_Style_Engine_wpStyleEngineCSSDeclarations extends WP_UnitTestCase {
 		);
 		$css_declarations   = new WP_Style_Engine_CSS_Declarations();
 		$css_declarations->add_declarations( $input_declarations );
+
 		$this->assertSame( $input_declarations, $css_declarations->get_declarations() );
 	}
 
@@ -51,6 +55,7 @@ class Tests_Style_Engine_wpStyleEngineCSSDeclarations extends WP_UnitTestCase {
 	 * Tests that new declarations are added to existing declarations.
 	 *
 	 * @ticket 56467
+	 *
 	 * @covers ::add_declarations
 	 * @covers ::add_declaration
 	 */
@@ -64,6 +69,7 @@ class Tests_Style_Engine_wpStyleEngineCSSDeclarations extends WP_UnitTestCase {
 			'letter-spacing' => '1.5px',
 		);
 		$css_declarations->add_declarations( $extra_declaration );
+
 		$this->assertSame( array_merge( $input_declarations, $extra_declaration ), $css_declarations->get_declarations() );
 	}
 
@@ -71,6 +77,7 @@ class Tests_Style_Engine_wpStyleEngineCSSDeclarations extends WP_UnitTestCase {
 	 * Tests that properties are sanitized before storing.
 	 *
 	 * @ticket 56467
+	 *
 	 * @covers ::sanitize_property
 	 */
 	public function test_should_sanitize_properties() {
@@ -93,6 +100,7 @@ class Tests_Style_Engine_wpStyleEngineCSSDeclarations extends WP_UnitTestCase {
 	 * Test that values with HTML tags are escaped, and CSS properties are run through safecss_filter_attr().
 	 *
 	 * @ticket 56467
+	 *
 	 * @covers ::get_declarations_string
 	 * @covers ::filter_declaration
 	 */
@@ -128,6 +136,7 @@ class Tests_Style_Engine_wpStyleEngineCSSDeclarations extends WP_UnitTestCase {
 	 * Tests that calc, clamp, min, max, and minmax CSS functions are allowed.
 	 *
 	 * @ticket 56467
+	 *
 	 * @covers ::get_declarations_string
 	 * @covers ::filter_declaration
 	 */
@@ -183,6 +192,7 @@ class Tests_Style_Engine_wpStyleEngineCSSDeclarations extends WP_UnitTestCase {
 			'text-decoration'        => 'underline',
 		);
 		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
+
 		$this->assertSame(
 			$expected,
 			$css_declarations->get_declarations_string( $should_prettify, $indent_count )
@@ -225,6 +235,7 @@ class Tests_Style_Engine_wpStyleEngineCSSDeclarations extends WP_UnitTestCase {
 	 * Tests removing a single declaration.
 	 *
 	 * @ticket 56467
+	 *
 	 * @covers ::remove_declaration
 	 */
 	public function test_should_remove_single_declaration() {
@@ -242,6 +253,7 @@ class Tests_Style_Engine_wpStyleEngineCSSDeclarations extends WP_UnitTestCase {
 		);
 
 		$css_declarations->remove_declaration( 'color' );
+
 		$this->assertSame(
 			'margin:10em 10em 20em 1px;font-family:Happy Font serif;',
 			$css_declarations->get_declarations_string(),
@@ -253,6 +265,7 @@ class Tests_Style_Engine_wpStyleEngineCSSDeclarations extends WP_UnitTestCase {
 	 * Tests that multiple declarations are removed.
 	 *
 	 * @ticket 56467
+	 *
 	 * @covers ::remove_declarations
 	 */
 	public function test_should_remove_multiple_declarations() {
@@ -270,6 +283,7 @@ class Tests_Style_Engine_wpStyleEngineCSSDeclarations extends WP_UnitTestCase {
 		);
 
 		$css_declarations->remove_declarations( array( 'color', 'margin' ) );
+
 		$this->assertSame(
 			'font-family:Happy Font serif;',
 			$css_declarations->get_declarations_string(),

--- a/tests/phpunit/tests/style-engine/wpStyleEngineCssDeclarations.php
+++ b/tests/phpunit/tests/style-engine/wpStyleEngineCssDeclarations.php
@@ -113,86 +113,60 @@ class Tests_Style_Engine_wpStyleEngineCSSDeclarations extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that css declarations are compiled into a css declarations block string.
+	 * Tests that CSS declarations are compiled into a CSS declarations block string.
 	 *
 	 * @ticket 56467
+	 *
 	 * @covers ::get_declarations_string
+	 *
+	 * @dataProvider data_should_compile_css_declarations_to_css_declarations_string
+	 *
+	 * @param string $expected        The expected declarations block string.
+	 * @param bool   $should_prettify Optional. Whether to pretty the string. Default false.
+	 * @param int    $indent_count    Optional. The number of tab indents. Default false.
 	 */
-	public function test_should_generate_css_declarations_string() {
+	public function test_should_compile_css_declarations_to_css_declarations_string( $expected, $should_prettify = false, $indent_count = 0 ) {
 		$input_declarations = array(
 			'color'                  => 'red',
 			'border-top-left-radius' => '99px',
 			'text-decoration'        => 'underline',
 		);
 		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
-
 		$this->assertSame(
-			'color:red;border-top-left-radius:99px;text-decoration:underline;',
-			$css_declarations->get_declarations_string()
+			$expected,
+			$css_declarations->get_declarations_string( $should_prettify, $indent_count )
 		);
 	}
 
 	/**
-	 * Tests that inline css declarations are compiled into a prettified css declarations block string.
+	 * Data provider for test_should_compile_css_declarations_to_css_declarations_string().
 	 *
-	 * @ticket 56467
-	 * @covers ::get_declarations_string
+	 * @return array
 	 */
-	public function test_should_generate_prettified_css_declarations_string() {
-		$input_declarations = array(
-			'color'                  => 'red',
-			'border-top-left-radius' => '99px',
-			'text-decoration'        => 'underline',
-		);
-		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
-
-		$this->assertSame(
-			'color: red; border-top-left-radius: 99px; text-decoration: underline;',
-			$css_declarations->get_declarations_string( true )
-		);
-	}
-
-	/**
-	 * Tests that inline css declarations are compiled into a prettified css declarations block string with new lines and indents.
-	 *
-	 * @ticket 56467
-	 * @covers ::get_declarations_string
-	 */
-	public function test_should_generate_prettified_css_declarations_string_with_new_lines_and_indents() {
-		$input_declarations = array(
-			'color'                  => 'red',
-			'border-top-left-radius' => '99px',
-			'text-decoration'        => 'underline',
-		);
-		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
-
-		$this->assertSame(
-			'	color: red;
-	border-top-left-radius: 99px;
-	text-decoration: underline;',
-			$css_declarations->get_declarations_string( true, 1 )
-		);
-	}
-
-	/**
-	 * Tests that inline css declarations are compiled into a prettified css declarations block string with extra indents.
-	 *
-	 * @ticket 56467
-	 * @covers ::get_declarations_string
-	 */
-	public function test_should_generate_prettified_with_extra_indents_css_declarations_string() {
-		$input_declarations = array(
-			'color'                  => 'red',
-			'border-top-left-radius' => '99px',
-			'text-decoration'        => 'underline',
-		);
-		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
-
-		$this->assertSame(
-			'		color: red;
-		border-top-left-radius: 99px;
-		text-decoration: underline;',
-			$css_declarations->get_declarations_string( true, 2 )
+	public function data_should_compile_css_declarations_to_css_declarations_string() {
+		return array(
+			'unprettified, no indent'  => array(
+				'expected' => 'color:red;border-top-left-radius:99px;text-decoration:underline;',
+			),
+			'unprettified, one indent' => array(
+				'expected'        => 'color:red;border-top-left-radius:99px;text-decoration:underline;',
+				'should_prettify' => false,
+				'indent_count'    => 1,
+			),
+			'prettified, no indent'    => array(
+				'expected'        => 'color: red; border-top-left-radius: 99px; text-decoration: underline;',
+				'should_prettify' => true,
+			),
+			'prettified, one indent'   => array(
+				'expected'        => "\tcolor: red;\n\tborder-top-left-radius: 99px;\n\ttext-decoration: underline;",
+				'should_prettify' => true,
+				'indent_count'    => 1,
+			),
+			'prettified, two indents'  => array(
+				'expected'        => "\t\tcolor: red;\n\t\tborder-top-left-radius: 99px;\n\t\ttext-decoration: underline;",
+				'should_prettify' => true,
+				'indent_count'    => 2,
+			),
 		);
 	}
 

--- a/tests/phpunit/tests/style-engine/wpStyleEngineCssRule.php
+++ b/tests/phpunit/tests/style-engine/wpStyleEngineCssRule.php
@@ -6,7 +6,7 @@
  * @subpackage StyleEngine
  * @since 6.1.0
  *
- * @group styleEngine
+ * @group style-engine
  */
 
 /**

--- a/tests/phpunit/tests/style-engine/wpStyleEngineCssRule.php
+++ b/tests/phpunit/tests/style-engine/wpStyleEngineCssRule.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Tests the Style Engine CSS Rule class.
+ *
+ * @package WordPress
+ * @subpackage StyleEngine
+ * @since 6.1.0
+ *
+ * @group styleEngine
+ */
+
+/**
+ * Tests for registering, storing and generating CSS declarations.
+ */
+class WP_Style_Engine_CSS_Rule_Test extends WP_UnitTestCase {
+	/**
+	 * Should set declarations on instantiation.
+	 */
+	public function test_instantiate_with_selector_and_rules() {
+		$selector           = '.law-and-order';
+		$input_declarations = array(
+			'margin-top' => '10px',
+			'font-size'  => '2rem',
+		);
+		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
+		$css_rule           = new WP_Style_Engine_CSS_Rule( $selector, $css_declarations );
+
+		$this->assertSame( $selector, $css_rule->get_selector() );
+
+		$expected = "$selector{{$css_declarations->get_declarations_string()}}";
+		$this->assertSame( $expected, $css_rule->get_css() );
+	}
+
+	/**
+	 * Test dedupe declaration properties.
+	 */
+	public function test_dedupe_properties_in_rules() {
+		$selector                    = '.taggart';
+		$first_declaration           = array(
+			'font-size' => '2rem',
+		);
+		$overwrite_first_declaration = array(
+			'font-size' => '4px',
+		);
+		$css_rule                    = new WP_Style_Engine_CSS_Rule( $selector, $first_declaration );
+		$css_rule->add_declarations( new WP_Style_Engine_CSS_Declarations( $overwrite_first_declaration ) );
+
+		$expected = '.taggart{font-size:4px;}';
+		$this->assertSame( $expected, $css_rule->get_css() );
+	}
+
+	/**
+	 * Should add declarations.
+	 */
+	public function test_add_declarations() {
+		// Declarations using a WP_Style_Engine_CSS_Declarations object.
+		$some_css_declarations = new WP_Style_Engine_CSS_Declarations( array( 'margin-top' => '10px' ) );
+		// Declarations using a property => value array.
+		$some_more_css_declarations = array( 'font-size' => '1rem' );
+		$css_rule                   = new WP_Style_Engine_CSS_Rule( '.hill-street-blues', $some_css_declarations );
+		$css_rule->add_declarations( $some_more_css_declarations );
+
+		$expected = '.hill-street-blues{margin-top:10px;font-size:1rem;}';
+		$this->assertSame( $expected, $css_rule->get_css() );
+	}
+
+	/**
+	 * Should set selector.
+	 */
+	public function test_set_selector() {
+		$selector = '.taggart';
+		$css_rule = new WP_Style_Engine_CSS_Rule( $selector );
+
+		$this->assertSame( $selector, $css_rule->get_selector() );
+
+		$css_rule->set_selector( '.law-and-order' );
+
+		$this->assertSame( '.law-and-order', $css_rule->get_selector() );
+	}
+
+	/**
+	 * Should generate CSS rules.
+	 */
+	public function test_get_css() {
+		$selector           = '.chips';
+		$input_declarations = array(
+			'margin-top' => '10px',
+			'font-size'  => '2rem',
+		);
+		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
+		$css_rule           = new WP_Style_Engine_CSS_Rule( $selector, $css_declarations );
+		$expected           = "$selector{{$css_declarations->get_declarations_string()}}";
+
+		$this->assertSame( $expected, $css_rule->get_css() );
+	}
+
+	/**
+	 * Should return empty string with no declarations.
+	 */
+	public function test_get_css_no_declarations() {
+		$selector           = '.holmes';
+		$input_declarations = array();
+		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
+		$css_rule           = new WP_Style_Engine_CSS_Rule( $selector, $css_declarations );
+
+		$this->assertSame( '', $css_rule->get_css() );
+	}
+
+	/**
+	 * Should generate prettified CSS rules.
+	 */
+	public function test_get_prettified_css() {
+		$selector           = '.baptiste';
+		$input_declarations = array(
+			'margin-left' => '0',
+			'font-family' => 'Detective Sans',
+		);
+		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
+		$css_rule           = new WP_Style_Engine_CSS_Rule( $selector, $css_declarations );
+		$expected           = '.baptiste {
+	margin-left: 0;
+	font-family: Detective Sans;
+}';
+
+		$this->assertSame( $expected, $css_rule->get_css( true ) );
+	}
+}

--- a/tests/phpunit/tests/style-engine/wpStyleEngineCssRule.php
+++ b/tests/phpunit/tests/style-engine/wpStyleEngineCssRule.php
@@ -30,10 +30,10 @@ class Tests_Style_Engine_wpStyleEngineCSSRule extends WP_UnitTestCase {
 		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
 		$css_rule           = new WP_Style_Engine_CSS_Rule( $selector, $css_declarations );
 
-		$this->assertSame( $selector, $css_rule->get_selector() );
+		$this->assertSame( $selector, $css_rule->get_selector(), 'Return value of get_selector() does not match value passed to constructor.' );
 
 		$expected = "$selector{{$css_declarations->get_declarations_string()}}";
-		$this->assertSame( $expected, $css_rule->get_css() );
+		$this->assertSame( $expected, $css_rule->get_css(), 'Value returned by get_css() does not match expected declarations string.' );
 	}
 
 	/**
@@ -87,11 +87,11 @@ class Tests_Style_Engine_wpStyleEngineCSSRule extends WP_UnitTestCase {
 		$selector = '.taggart';
 		$css_rule = new WP_Style_Engine_CSS_Rule( $selector );
 
-		$this->assertSame( $selector, $css_rule->get_selector() );
+		$this->assertSame( $selector, $css_rule->get_selector(), 'Return value of get_selector() does not match value passed to constructor.' );
 
 		$css_rule->set_selector( '.law-and-order' );
 
-		$this->assertSame( '.law-and-order', $css_rule->get_selector() );
+		$this->assertSame( '.law-and-order', $css_rule->get_selector(), 'Return value of get_selector() does not match value passed to set_selector().' );
 	}
 
 	/**

--- a/tests/phpunit/tests/style-engine/wpStyleEngineCssRule.php
+++ b/tests/phpunit/tests/style-engine/wpStyleEngineCssRule.php
@@ -10,13 +10,18 @@
  */
 
 /**
- * Tests for registering, storing and generating CSS declarations.
+ * Tests for registering, storing and generating CSS rules.
+ *
+ * @coversDefaultClass WP_Style_Engine_CSS_Rule
  */
-class WP_Style_Engine_CSS_Rule_Test extends WP_UnitTestCase {
+class Tests_Style_Engine_wpStyleEngineCSSRule extends WP_UnitTestCase {
 	/**
-	 * Should set declarations on instantiation.
+	 * Tests that declarations are set on instantiation.
+	 *
+	 * @ticket 56467
+	 * @covers ::__construct
 	 */
-	public function test_instantiate_with_selector_and_rules() {
+	public function test_should_instantiate_with_selector_and_rules() {
 		$selector           = '.law-and-order';
 		$input_declarations = array(
 			'margin-top' => '10px',
@@ -32,9 +37,13 @@ class WP_Style_Engine_CSS_Rule_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test dedupe declaration properties.
+	 * Test that declaration properties are deduplicated.
+	 *
+	 * @ticket 56467
+	 * @covers ::add_declarations
+	 * @covers ::get_css
 	 */
-	public function test_dedupe_properties_in_rules() {
+	public function test_should_dedupe_properties_in_rules() {
 		$selector                    = '.taggart';
 		$first_declaration           = array(
 			'font-size' => '2rem',
@@ -50,9 +59,13 @@ class WP_Style_Engine_CSS_Rule_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Should add declarations.
+	 * Test that declarations can be added to existing rules.
+	 *
+	 * @ticket 56467
+	 * @covers ::add_declarations
+	 * @covers ::get_css
 	 */
-	public function test_add_declarations() {
+	public function test_should_add_declarations_to_existing_rules() {
 		// Declarations using a WP_Style_Engine_CSS_Declarations object.
 		$some_css_declarations = new WP_Style_Engine_CSS_Declarations( array( 'margin-top' => '10px' ) );
 		// Declarations using a property => value array.
@@ -65,9 +78,12 @@ class WP_Style_Engine_CSS_Rule_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Should set selector.
+	 * Test setting a selector to a rule.
+	 *
+	 * @ticket 56467
+	 * @covers ::set_selector
 	 */
-	public function test_set_selector() {
+	public function test_should_set_selector() {
 		$selector = '.taggart';
 		$css_rule = new WP_Style_Engine_CSS_Rule( $selector );
 
@@ -79,9 +95,12 @@ class WP_Style_Engine_CSS_Rule_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Should generate CSS rules.
+	 * Tests generating a CSS rule string.
+	 *
+	 * @ticket 56467
+	 * @covers ::get_css
 	 */
-	public function test_get_css() {
+	public function test_should_generate_css_rule_string() {
 		$selector           = '.chips';
 		$input_declarations = array(
 			'margin-top' => '10px',
@@ -95,9 +114,12 @@ class WP_Style_Engine_CSS_Rule_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Should return empty string with no declarations.
+	 * Tests that an empty string will be returned where there are no declarations in a CSS rule.
+	 *
+	 * @ticket 56467
+	 * @covers ::get_css
 	 */
-	public function test_get_css_no_declarations() {
+	public function test_should_return_empty_string_with_no_declarations() {
 		$selector           = '.holmes';
 		$input_declarations = array();
 		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $input_declarations );
@@ -107,9 +129,12 @@ class WP_Style_Engine_CSS_Rule_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Should generate prettified CSS rules.
+	 * Tests that CSS rules are prettified.
+	 *
+	 * @ticket 56467
+	 * @covers ::get_css
 	 */
-	public function test_get_prettified_css() {
+	public function test_should_prettify_css_rule_output() {
 		$selector           = '.baptiste';
 		$input_declarations = array(
 			'margin-left' => '0',

--- a/tests/phpunit/tests/style-engine/wpStyleEngineCssRule.php
+++ b/tests/phpunit/tests/style-engine/wpStyleEngineCssRule.php
@@ -33,6 +33,7 @@ class Tests_Style_Engine_wpStyleEngineCSSRule extends WP_UnitTestCase {
 		$this->assertSame( $selector, $css_rule->get_selector(), 'Return value of get_selector() does not match value passed to constructor.' );
 
 		$expected = "$selector{{$css_declarations->get_declarations_string()}}";
+
 		$this->assertSame( $expected, $css_rule->get_css(), 'Value returned by get_css() does not match expected declarations string.' );
 	}
 
@@ -40,6 +41,7 @@ class Tests_Style_Engine_wpStyleEngineCSSRule extends WP_UnitTestCase {
 	 * Tests that declaration properties are deduplicated.
 	 *
 	 * @ticket 56467
+	 *
 	 * @covers ::add_declarations
 	 * @covers ::get_css
 	 */
@@ -55,6 +57,7 @@ class Tests_Style_Engine_wpStyleEngineCSSRule extends WP_UnitTestCase {
 		$css_rule->add_declarations( new WP_Style_Engine_CSS_Declarations( $overwrite_first_declaration ) );
 
 		$expected = '.taggart{font-size:4px;}';
+
 		$this->assertSame( $expected, $css_rule->get_css() );
 	}
 
@@ -62,6 +65,7 @@ class Tests_Style_Engine_wpStyleEngineCSSRule extends WP_UnitTestCase {
 	 * Tests that declarations can be added to existing rules.
 	 *
 	 * @ticket 56467
+	 *
 	 * @covers ::add_declarations
 	 * @covers ::get_css
 	 */
@@ -74,6 +78,7 @@ class Tests_Style_Engine_wpStyleEngineCSSRule extends WP_UnitTestCase {
 		$css_rule->add_declarations( $some_more_css_declarations );
 
 		$expected = '.hill-street-blues{margin-top:10px;font-size:1rem;}';
+
 		$this->assertSame( $expected, $css_rule->get_css() );
 	}
 
@@ -81,6 +86,7 @@ class Tests_Style_Engine_wpStyleEngineCSSRule extends WP_UnitTestCase {
 	 * Tests setting a selector to a rule.
 	 *
 	 * @ticket 56467
+	 *
 	 * @covers ::set_selector
 	 */
 	public function test_should_set_selector() {
@@ -98,6 +104,7 @@ class Tests_Style_Engine_wpStyleEngineCSSRule extends WP_UnitTestCase {
 	 * Tests generating a CSS rule string.
 	 *
 	 * @ticket 56467
+	 *
 	 * @covers ::get_css
 	 */
 	public function test_should_generate_css_rule_string() {
@@ -117,6 +124,7 @@ class Tests_Style_Engine_wpStyleEngineCSSRule extends WP_UnitTestCase {
 	 * Tests that an empty string will be returned where there are no declarations in a CSS rule.
 	 *
 	 * @ticket 56467
+	 *
 	 * @covers ::get_css
 	 */
 	public function test_should_return_empty_string_with_no_declarations() {
@@ -132,6 +140,7 @@ class Tests_Style_Engine_wpStyleEngineCSSRule extends WP_UnitTestCase {
 	 * Tests that CSS rules are prettified.
 	 *
 	 * @ticket 56467
+	 *
 	 * @covers ::get_css
 	 */
 	public function test_should_prettify_css_rule_output() {

--- a/tests/phpunit/tests/style-engine/wpStyleEngineCssRule.php
+++ b/tests/phpunit/tests/style-engine/wpStyleEngineCssRule.php
@@ -37,7 +37,7 @@ class Tests_Style_Engine_wpStyleEngineCSSRule extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that declaration properties are deduplicated.
+	 * Tests that declaration properties are deduplicated.
 	 *
 	 * @ticket 56467
 	 * @covers ::add_declarations
@@ -59,7 +59,7 @@ class Tests_Style_Engine_wpStyleEngineCSSRule extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that declarations can be added to existing rules.
+	 * Tests that declarations can be added to existing rules.
 	 *
 	 * @ticket 56467
 	 * @covers ::add_declarations
@@ -78,7 +78,7 @@ class Tests_Style_Engine_wpStyleEngineCSSRule extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test setting a selector to a rule.
+	 * Tests setting a selector to a rule.
 	 *
 	 * @ticket 56467
 	 * @covers ::set_selector

--- a/tests/phpunit/tests/style-engine/wpStyleEngineCssRulesStore.php
+++ b/tests/phpunit/tests/style-engine/wpStyleEngineCssRulesStore.php
@@ -6,7 +6,7 @@
  * @subpackage StyleEngine
  * @since 6.1.0
  *
- * @group styleEngine
+ * @group style-engine
  */
 
 /**

--- a/tests/phpunit/tests/style-engine/wpStyleEngineCssRulesStore.php
+++ b/tests/phpunit/tests/style-engine/wpStyleEngineCssRulesStore.php
@@ -24,7 +24,7 @@ class Tests_Style_Engine_wpStyleEngineCSSRulesStore extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test creating a new store on instantiation.
+	 * Tests creating a new store on instantiation.
 	 *
 	 * @ticket 56467
 	 * @covers ::__construct

--- a/tests/phpunit/tests/style-engine/wpStyleEngineCssRulesStore.php
+++ b/tests/phpunit/tests/style-engine/wpStyleEngineCssRulesStore.php
@@ -42,13 +42,13 @@ class Tests_Style_Engine_wpStyleEngineCSSRulesStore extends WP_UnitTestCase {
 	 */
 	public function test_should_not_create_store_without_a_store_name() {
 		$not_a_store = WP_Style_Engine_CSS_Rules_Store::get_store( '' );
-		$this->assertEmpty( $not_a_store );
+		$this->assertEmpty( $not_a_store, 'get_store() did not return an empty value with empty string as argument.' );
 
 		$also_not_a_store = WP_Style_Engine_CSS_Rules_Store::get_store( 123 );
-		$this->assertEmpty( $also_not_a_store );
+		$this->assertEmpty( $also_not_a_store, 'get_store() did not return an empty value with number as argument.' );
 
 		$definitely_not_a_store = WP_Style_Engine_CSS_Rules_Store::get_store( null );
-		$this->assertEmpty( $definitely_not_a_store );
+		$this->assertEmpty( $definitely_not_a_store, 'get_store() did not return an empty value with `null` as argument.' );
 	}
 
 	/**
@@ -61,11 +61,11 @@ class Tests_Style_Engine_wpStyleEngineCSSRulesStore extends WP_UnitTestCase {
 		$new_fish_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'fish-n-chips' );
 		$selector       = '.haddock';
 
-		$new_fish_store->add_rule( $selector )->get_selector();
-		$this->assertEquals( $selector, $new_fish_store->add_rule( $selector )->get_selector() );
+		$new_fish_store->add_rule( $selector );
+		$this->assertEquals( $selector, $new_fish_store->add_rule( $selector )->get_selector(), 'Selector string of store rule does not match expected value' );
 
 		$the_same_fish_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'fish-n-chips' );
-		$this->assertEquals( $selector, $the_same_fish_store->add_rule( $selector )->get_selector() );
+		$this->assertEquals( $selector, $the_same_fish_store->add_rule( $selector )->get_selector(), 'Selector string of existing store rule does not match expected value' );
 	}
 
 	/**
@@ -100,12 +100,14 @@ class Tests_Style_Engine_wpStyleEngineCSSRulesStore extends WP_UnitTestCase {
 				'dolmades' => $dolmades_store,
 				'tzatziki' => $tzatziki_store,
 			),
-			WP_Style_Engine_CSS_Rules_Store::get_stores()
+			WP_Style_Engine_CSS_Rules_Store::get_stores(),
+			'Return value of get_stores() does not match expectation'
 		);
 		WP_Style_Engine_CSS_Rules_Store::remove_all_stores();
 		$this->assertEquals(
 			array(),
-			WP_Style_Engine_CSS_Rules_Store::get_stores()
+			WP_Style_Engine_CSS_Rules_Store::get_stores(),
+			'Return value of get_stores() is not an empty array after remove_all_stores() called.'
 		);
 	}
 
@@ -120,7 +122,7 @@ class Tests_Style_Engine_wpStyleEngineCSSRulesStore extends WP_UnitTestCase {
 		$selector      = '.wp-block-sauce a:hover';
 		$store_rule    = $new_pie_store->add_rule( $selector );
 		$expected      = '';
-		$this->assertEquals( $expected, $store_rule->get_css() );
+		$this->assertEquals( $expected, $store_rule->get_css(), 'Return value of get_css() is not a empty string where a rule has no CSS declarations.' );
 
 		$pie_declarations = array(
 			'color'         => 'brown',
@@ -132,7 +134,7 @@ class Tests_Style_Engine_wpStyleEngineCSSRulesStore extends WP_UnitTestCase {
 
 		$store_rule = $new_pie_store->add_rule( $selector );
 		$expected   = "$selector{{$css_declarations->get_declarations_string()}}";
-		$this->assertEquals( $expected, $store_rule->get_css() );
+		$this->assertEquals( $expected, $store_rule->get_css(), 'Return value of get_css() does not match expected CSS from existing store rules.' );
 	}
 
 	/**
@@ -149,33 +151,7 @@ class Tests_Style_Engine_wpStyleEngineCSSRulesStore extends WP_UnitTestCase {
 			$selector => $store_rule,
 		);
 
-		$this->assertEquals( $expected, $new_pizza_store->get_all_rules() );
-
-		$pizza_declarations = array(
-			'color'         => 'red',
-			'border-color'  => 'yellow',
-			'border-radius' => '10rem',
-		);
-		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $pizza_declarations );
-		$store_rule->add_declarations( array( $css_declarations ) );
-
-		$expected = array(
-			$selector => $store_rule,
-		);
-		$this->assertEquals( $expected, $new_pizza_store->get_all_rules() );
-
-		$new_pizza_declarations = array(
-			'color'        => 'red',
-			'border-color' => 'red',
-			'font-size'    => '10rem',
-		);
-		$css_declarations       = new WP_Style_Engine_CSS_Declarations( $new_pizza_declarations );
-		$store_rule->add_declarations( array( $css_declarations ) );
-
-		$expected = array(
-			$selector => $store_rule,
-		);
-		$this->assertEquals( $expected, $new_pizza_store->get_all_rules() );
+		$this->assertEquals( $expected, $new_pizza_store->get_all_rules(), 'Return value for get_all_rules() does not match expectations.' );
 
 		$new_selector             = '.wp-block-mushroom a:hover';
 		$newer_pizza_declarations = array(
@@ -189,6 +165,6 @@ class Tests_Style_Engine_wpStyleEngineCSSRulesStore extends WP_UnitTestCase {
 			$selector     => $store_rule,
 			$new_selector => $new_store_rule,
 		);
-		$this->assertEquals( $expected, $new_pizza_store->get_all_rules() );
+		$this->assertEquals( $expected, $new_pizza_store->get_all_rules(), 'Return value for get_all_rules() does not match expectations after adding new rules to store.' );
 	}
 }

--- a/tests/phpunit/tests/style-engine/wpStyleEngineCssRulesStore.php
+++ b/tests/phpunit/tests/style-engine/wpStyleEngineCssRulesStore.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * Tests the Style Engine CSS Rules Store class.
+ *
+ * @package WordPress
+ * @subpackage StyleEngine
+ * @since 6.1.0
+ *
+ * @group styleEngine
+ */
+
+/**
+ * Tests for registering, storing and retrieving CSS Rules.
+ */
+class WP_Style_Engine_CSS_Rules_Store_Test extends WP_UnitTestCase {
+	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down() {
+		parent::tear_down();
+		WP_Style_Engine_CSS_Rules_Store::remove_all_stores();
+	}
+	/**
+	 * Should create a new store.
+	 */
+	public function test_create_new_store() {
+		$new_pancakes_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'pancakes-with-strawberries' );
+		$this->assertInstanceOf( 'WP_Style_Engine_CSS_Rules_Store', $new_pancakes_store );
+	}
+
+	/**
+	 * Should not create a new store with invalid $store_name.
+	 */
+	public function test_store_name_required() {
+		$not_a_store = WP_Style_Engine_CSS_Rules_Store::get_store( '' );
+		$this->assertEmpty( $not_a_store );
+
+		$also_not_a_store = WP_Style_Engine_CSS_Rules_Store::get_store( 123 );
+		$this->assertEmpty( $also_not_a_store );
+
+		$definitely_not_a_store = WP_Style_Engine_CSS_Rules_Store::get_store( null );
+		$this->assertEmpty( $definitely_not_a_store );
+	}
+
+	/**
+	 * Should return previously created store when the same selector key is passed.
+	 */
+	public function test_get_store() {
+		$new_fish_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'fish-n-chips' );
+		$selector       = '.haddock';
+
+		$new_fish_store->add_rule( $selector )->get_selector();
+		$this->assertEquals( $selector, $new_fish_store->add_rule( $selector )->get_selector() );
+
+		$the_same_fish_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'fish-n-chips' );
+		$this->assertEquals( $selector, $the_same_fish_store->add_rule( $selector )->get_selector() );
+	}
+
+	/**
+	 * Should return all previously created stores.
+	 */
+	public function test_get_stores() {
+		$burrito_store    = WP_Style_Engine_CSS_Rules_Store::get_store( 'burrito' );
+		$quesadilla_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'quesadilla' );
+		$this->assertEquals(
+			array(
+				'burrito'    => $burrito_store,
+				'quesadilla' => $quesadilla_store,
+			),
+			WP_Style_Engine_CSS_Rules_Store::get_stores()
+		);
+	}
+
+	/**
+	 * Should delete all previously created stores.
+	 */
+	public function test_remove_all_stores() {
+		$dolmades_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'dolmades' );
+		$tzatziki_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'tzatziki' );
+		$this->assertEquals(
+			array(
+				'dolmades' => $dolmades_store,
+				'tzatziki' => $tzatziki_store,
+			),
+			WP_Style_Engine_CSS_Rules_Store::get_stores()
+		);
+		WP_Style_Engine_CSS_Rules_Store::remove_all_stores();
+		$this->assertEquals(
+			array(),
+			WP_Style_Engine_CSS_Rules_Store::get_stores()
+		);
+	}
+
+	/**
+	 * Should return a stored rule.
+	 */
+	public function test_add_rule() {
+		$new_pie_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'meat-pie' );
+		$selector      = '.wp-block-sauce a:hover';
+		$store_rule    = $new_pie_store->add_rule( $selector );
+		$expected      = '';
+		$this->assertEquals( $expected, $store_rule->get_css() );
+
+		$pie_declarations = array(
+			'color'         => 'brown',
+			'border-color'  => 'yellow',
+			'border-radius' => '10rem',
+		);
+		$css_declarations = new WP_Style_Engine_CSS_Declarations( $pie_declarations );
+		$store_rule->add_declarations( $css_declarations );
+
+		$store_rule = $new_pie_store->add_rule( $selector );
+		$expected   = "$selector{{$css_declarations->get_declarations_string()}}";
+		$this->assertEquals( $expected, $store_rule->get_css() );
+	}
+
+	/**
+	 * Should return all stored rules.
+	 */
+	public function test_get_all_rules() {
+		$new_pizza_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'pizza-with-mozzarella' );
+		$selector        = '.wp-block-anchovies a:hover';
+		$store_rule      = $new_pizza_store->add_rule( $selector );
+		$expected        = array(
+			$selector => $store_rule,
+		);
+
+		$this->assertEquals( $expected, $new_pizza_store->get_all_rules() );
+
+		$pizza_declarations = array(
+			'color'         => 'red',
+			'border-color'  => 'yellow',
+			'border-radius' => '10rem',
+		);
+		$css_declarations   = new WP_Style_Engine_CSS_Declarations( $pizza_declarations );
+		$store_rule->add_declarations( array( $css_declarations ) );
+
+		$expected = array(
+			$selector => $store_rule,
+		);
+		$this->assertEquals( $expected, $new_pizza_store->get_all_rules() );
+
+		$new_pizza_declarations = array(
+			'color'        => 'red',
+			'border-color' => 'red',
+			'font-size'    => '10rem',
+		);
+		$css_declarations       = new WP_Style_Engine_CSS_Declarations( $new_pizza_declarations );
+		$store_rule->add_declarations( array( $css_declarations ) );
+
+		$expected = array(
+			$selector => $store_rule,
+		);
+		$this->assertEquals( $expected, $new_pizza_store->get_all_rules() );
+
+		$new_selector             = '.wp-block-mushroom a:hover';
+		$newer_pizza_declarations = array(
+			'padding' => '100px',
+		);
+		$new_store_rule           = $new_pizza_store->add_rule( $new_selector );
+		$css_declarations         = new WP_Style_Engine_CSS_Declarations( $newer_pizza_declarations );
+		$new_store_rule->add_declarations( array( $css_declarations ) );
+
+		$expected = array(
+			$selector     => $store_rule,
+			$new_selector => $new_store_rule,
+		);
+		$this->assertEquals( $expected, $new_pizza_store->get_all_rules() );
+	}
+}

--- a/tests/phpunit/tests/style-engine/wpStyleEngineCssRulesStore.php
+++ b/tests/phpunit/tests/style-engine/wpStyleEngineCssRulesStore.php
@@ -16,7 +16,7 @@
  */
 class Tests_Style_Engine_wpStyleEngineCSSRulesStore extends WP_UnitTestCase {
 	/**
-	 * Tear down after each test.
+	 * Cleans up stores after each test.
 	 */
 	public function tear_down() {
 		WP_Style_Engine_CSS_Rules_Store::remove_all_stores();
@@ -27,10 +27,12 @@ class Tests_Style_Engine_wpStyleEngineCSSRulesStore extends WP_UnitTestCase {
 	 * Tests creating a new store on instantiation.
 	 *
 	 * @ticket 56467
+	 *
 	 * @covers ::__construct
 	 */
 	public function test_should_create_new_store_on_instantiation() {
 		$new_pancakes_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'pancakes-with-strawberries' );
+
 		$this->assertInstanceOf( 'WP_Style_Engine_CSS_Rules_Store', $new_pancakes_store );
 	}
 
@@ -38,16 +40,20 @@ class Tests_Style_Engine_wpStyleEngineCSSRulesStore extends WP_UnitTestCase {
 	 * Tests that a `$store_name` argument is required and no store will be created without one.
 	 *
 	 * @ticket 56467
+	 *
 	 * @covers ::get_store
 	 */
 	public function test_should_not_create_store_without_a_store_name() {
 		$not_a_store = WP_Style_Engine_CSS_Rules_Store::get_store( '' );
+
 		$this->assertEmpty( $not_a_store, 'get_store() did not return an empty value with empty string as argument.' );
 
 		$also_not_a_store = WP_Style_Engine_CSS_Rules_Store::get_store( 123 );
+
 		$this->assertEmpty( $also_not_a_store, 'get_store() did not return an empty value with number as argument.' );
 
 		$definitely_not_a_store = WP_Style_Engine_CSS_Rules_Store::get_store( null );
+
 		$this->assertEmpty( $definitely_not_a_store, 'get_store() did not return an empty value with `null` as argument.' );
 	}
 
@@ -55,6 +61,7 @@ class Tests_Style_Engine_wpStyleEngineCSSRulesStore extends WP_UnitTestCase {
 	 * Tests returning a previously created store when the same selector key is passed.
 	 *
 	 * @ticket 56467
+	 *
 	 * @covers ::get_store
 	 */
 	public function test_should_return_existing_store() {
@@ -62,21 +69,25 @@ class Tests_Style_Engine_wpStyleEngineCSSRulesStore extends WP_UnitTestCase {
 		$selector       = '.haddock';
 
 		$new_fish_store->add_rule( $selector );
-		$this->assertEquals( $selector, $new_fish_store->add_rule( $selector )->get_selector(), 'Selector string of store rule does not match expected value' );
+
+		$this->assertSame( $selector, $new_fish_store->add_rule( $selector )->get_selector(), 'Selector string of store rule does not match expected value' );
 
 		$the_same_fish_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'fish-n-chips' );
-		$this->assertEquals( $selector, $the_same_fish_store->add_rule( $selector )->get_selector(), 'Selector string of existing store rule does not match expected value' );
+
+		$this->assertSame( $selector, $the_same_fish_store->add_rule( $selector )->get_selector(), 'Selector string of existing store rule does not match expected value' );
 	}
 
 	/**
 	 * Tests returning all previously created stores.
 	 *
 	 * @ticket 56467
+	 *
 	 * @covers ::get_stores
 	 */
 	public function test_should_get_all_existing_stores() {
 		$burrito_store    = WP_Style_Engine_CSS_Rules_Store::get_store( 'burrito' );
 		$quesadilla_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'quesadilla' );
+
 		$this->assertEquals(
 			array(
 				'burrito'    => $burrito_store,
@@ -90,11 +101,13 @@ class Tests_Style_Engine_wpStyleEngineCSSRulesStore extends WP_UnitTestCase {
 	 * Tests that all previously created stores are deleted.
 	 *
 	 * @ticket 56467
+	 *
 	 * @covers ::remove_all_stores
 	 */
 	public function test_should_remove_all_stores() {
 		$dolmades_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'dolmades' );
 		$tzatziki_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'tzatziki' );
+
 		$this->assertEquals(
 			array(
 				'dolmades' => $dolmades_store,
@@ -103,7 +116,9 @@ class Tests_Style_Engine_wpStyleEngineCSSRulesStore extends WP_UnitTestCase {
 			WP_Style_Engine_CSS_Rules_Store::get_stores(),
 			'Return value of get_stores() does not match expectation'
 		);
+
 		WP_Style_Engine_CSS_Rules_Store::remove_all_stores();
+
 		$this->assertEquals(
 			array(),
 			WP_Style_Engine_CSS_Rules_Store::get_stores(),
@@ -115,6 +130,7 @@ class Tests_Style_Engine_wpStyleEngineCSSRulesStore extends WP_UnitTestCase {
 	 * Tests adding rules to an existing store.
 	 *
 	 * @ticket 56467
+	 *
 	 * @covers ::add_rule
 	 */
 	public function test_should_add_rule_to_existing_store() {
@@ -122,7 +138,8 @@ class Tests_Style_Engine_wpStyleEngineCSSRulesStore extends WP_UnitTestCase {
 		$selector      = '.wp-block-sauce a:hover';
 		$store_rule    = $new_pie_store->add_rule( $selector );
 		$expected      = '';
-		$this->assertEquals( $expected, $store_rule->get_css(), 'Return value of get_css() is not a empty string where a rule has no CSS declarations.' );
+
+		$this->assertSame( $expected, $store_rule->get_css(), 'Return value of get_css() is not a empty string where a rule has no CSS declarations.' );
 
 		$pie_declarations = array(
 			'color'         => 'brown',
@@ -131,16 +148,18 @@ class Tests_Style_Engine_wpStyleEngineCSSRulesStore extends WP_UnitTestCase {
 		);
 		$css_declarations = new WP_Style_Engine_CSS_Declarations( $pie_declarations );
 		$store_rule->add_declarations( $css_declarations );
-
 		$store_rule = $new_pie_store->add_rule( $selector );
-		$expected   = "$selector{{$css_declarations->get_declarations_string()}}";
-		$this->assertEquals( $expected, $store_rule->get_css(), 'Return value of get_css() does not match expected CSS from existing store rules.' );
+
+		$expected = "$selector{{$css_declarations->get_declarations_string()}}";
+
+		$this->assertSame( $expected, $store_rule->get_css(), 'Return value of get_css() does not match expected CSS from existing store rules.' );
 	}
 
 	/**
 	 * Tests that all stored rule objects are returned.
 	 *
 	 * @ticket 56467
+	 *
 	 * @covers ::get_all_rules
 	 */
 	public function test_should_get_all_rule_objects_for_a_store() {
@@ -151,7 +170,7 @@ class Tests_Style_Engine_wpStyleEngineCSSRulesStore extends WP_UnitTestCase {
 			$selector => $store_rule,
 		);
 
-		$this->assertEquals( $expected, $new_pizza_store->get_all_rules(), 'Return value for get_all_rules() does not match expectations.' );
+		$this->assertSame( $expected, $new_pizza_store->get_all_rules(), 'Return value for get_all_rules() does not match expectations.' );
 
 		$new_selector             = '.wp-block-mushroom a:hover';
 		$newer_pizza_declarations = array(
@@ -165,6 +184,7 @@ class Tests_Style_Engine_wpStyleEngineCSSRulesStore extends WP_UnitTestCase {
 			$selector     => $store_rule,
 			$new_selector => $new_store_rule,
 		);
-		$this->assertEquals( $expected, $new_pizza_store->get_all_rules(), 'Return value for get_all_rules() does not match expectations after adding new rules to store.' );
+
+		$this->assertSame( $expected, $new_pizza_store->get_all_rules(), 'Return value for get_all_rules() does not match expectations after adding new rules to store.' );
 	}
 }

--- a/tests/phpunit/tests/style-engine/wpStyleEngineCssRulesStore.php
+++ b/tests/phpunit/tests/style-engine/wpStyleEngineCssRulesStore.php
@@ -10,28 +10,37 @@
  */
 
 /**
- * Tests for registering, storing and retrieving CSS Rules.
+ * Tests for registering, storing and retrieving a collection of CSS Rules (a store).
+ *
+ * @coversDefaultClass WP_Style_Engine_CSS_Rules_Store
  */
-class WP_Style_Engine_CSS_Rules_Store_Test extends WP_UnitTestCase {
+class Tests_Style_Engine_wpStyleEngineCSSRulesStore extends WP_UnitTestCase {
 	/**
 	 * Tear down after each test.
 	 */
 	public function tear_down() {
-		parent::tear_down();
 		WP_Style_Engine_CSS_Rules_Store::remove_all_stores();
+		parent::tear_down();
 	}
+
 	/**
-	 * Should create a new store.
+	 * Test creating a new store on instantiation.
+	 *
+	 * @ticket 56467
+	 * @covers ::__construct
 	 */
-	public function test_create_new_store() {
+	public function test_should_create_new_store_on_instantiation() {
 		$new_pancakes_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'pancakes-with-strawberries' );
 		$this->assertInstanceOf( 'WP_Style_Engine_CSS_Rules_Store', $new_pancakes_store );
 	}
 
 	/**
-	 * Should not create a new store with invalid $store_name.
+	 * Tests that a `$store_name` argument is required and no store will be created without one.
+	 *
+	 * @ticket 56467
+	 * @covers ::get_store
 	 */
-	public function test_store_name_required() {
+	public function test_should_not_create_store_without_a_store_name() {
 		$not_a_store = WP_Style_Engine_CSS_Rules_Store::get_store( '' );
 		$this->assertEmpty( $not_a_store );
 
@@ -43,9 +52,12 @@ class WP_Style_Engine_CSS_Rules_Store_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Should return previously created store when the same selector key is passed.
+	 * Tests returning a previously created store when the same selector key is passed.
+	 *
+	 * @ticket 56467
+	 * @covers ::get_store
 	 */
-	public function test_get_store() {
+	public function test_should_return_existing_store() {
 		$new_fish_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'fish-n-chips' );
 		$selector       = '.haddock';
 
@@ -57,9 +69,12 @@ class WP_Style_Engine_CSS_Rules_Store_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Should return all previously created stores.
+	 * Tests returning all previously created stores.
+	 *
+	 * @ticket 56467
+	 * @covers ::get_stores
 	 */
-	public function test_get_stores() {
+	public function test_should_get_all_existing_stores() {
 		$burrito_store    = WP_Style_Engine_CSS_Rules_Store::get_store( 'burrito' );
 		$quesadilla_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'quesadilla' );
 		$this->assertEquals(
@@ -72,9 +87,12 @@ class WP_Style_Engine_CSS_Rules_Store_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Should delete all previously created stores.
+	 * Tests that all previously created stores are deleted.
+	 *
+	 * @ticket 56467
+	 * @covers ::remove_all_stores
 	 */
-	public function test_remove_all_stores() {
+	public function test_should_remove_all_stores() {
 		$dolmades_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'dolmades' );
 		$tzatziki_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'tzatziki' );
 		$this->assertEquals(
@@ -92,9 +110,12 @@ class WP_Style_Engine_CSS_Rules_Store_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Should return a stored rule.
+	 * Tests adding rules to an existing store.
+	 *
+	 * @ticket 56467
+	 * @covers ::add_rule
 	 */
-	public function test_add_rule() {
+	public function test_should_add_rule_to_existing_store() {
 		$new_pie_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'meat-pie' );
 		$selector      = '.wp-block-sauce a:hover';
 		$store_rule    = $new_pie_store->add_rule( $selector );
@@ -115,9 +136,12 @@ class WP_Style_Engine_CSS_Rules_Store_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Should return all stored rules.
+	 * Tests that all stored rule objects are returned.
+	 *
+	 * @ticket 56467
+	 * @covers ::get_all_rules
 	 */
-	public function test_get_all_rules() {
+	public function test_should_get_all_rule_objects_for_a_store() {
 		$new_pizza_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'pizza-with-mozzarella' );
 		$selector        = '.wp-block-anchovies a:hover';
 		$store_rule      = $new_pizza_store->add_rule( $selector );

--- a/tests/phpunit/tests/style-engine/wpStyleEngineProcessor.php
+++ b/tests/phpunit/tests/style-engine/wpStyleEngineProcessor.php
@@ -6,7 +6,7 @@
  * @subpackage StyleEngine
  * @since 6.1.0
  *
- * @group styleEngine
+ * @group style-engine
  */
 
 /**

--- a/tests/phpunit/tests/style-engine/wpStyleEngineProcessor.php
+++ b/tests/phpunit/tests/style-engine/wpStyleEngineProcessor.php
@@ -36,7 +36,7 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 		$a_nice_processor->add_rules( array( $a_nice_css_rule, $a_nicer_css_rule ) );
 		$this->assertEquals(
 			'.a-nice-rule{color:var(--nice-color);background-color:purple;}.a-nicer-rule{font-family:Nice sans;font-size:1em;background-color:purple;}',
-			$a_nice_processor->get_css()
+			$a_nice_processor->get_css( array( 'prettify' => false ) )
 		);
 	}
 
@@ -108,7 +108,7 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 		$a_nice_renderer->add_store( $a_nice_store );
 		$this->assertEquals(
 			'.a-nice-rule{color:var(--nice-color);background-color:purple;}.a-nicer-rule{font-family:Nice sans;font-size:1em;background-color:purple;}',
-			$a_nice_renderer->get_css()
+			$a_nice_renderer->get_css( array( 'prettify' => false ) )
 		);
 	}
 
@@ -137,7 +137,7 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 		$an_excellent_processor->add_rules( $another_excellent_rule );
 		$this->assertEquals(
 			'.an-excellent-rule{color:var(--excellent-color);border-style:dotted;border-color:brown;}',
-			$an_excellent_processor->get_css()
+			$an_excellent_processor->get_css( array( 'prettify' => false ) )
 		);
 
 		$yet_another_excellent_rule = new WP_Style_Engine_CSS_Rule( '.an-excellent-rule' );
@@ -151,7 +151,7 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 		$an_excellent_processor->add_rules( $yet_another_excellent_rule );
 		$this->assertEquals(
 			'.an-excellent-rule{color:var(--excellent-color);border-style:dashed;border-color:brown;border-width:2px;}',
-			$an_excellent_processor->get_css()
+			$an_excellent_processor->get_css( array( 'prettify' => false ) )
 		);
 	}
 
@@ -188,7 +188,12 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 
 		$this->assertEquals(
 			'.a-sweet-rule{color:var(--sweet-color);background-color:purple;}#an-even-sweeter-rule > marquee{color:var(--sweet-color);background-color:purple;}.the-sweetest-rule-of-all a{color:var(--sweet-color);background-color:purple;}',
-			$a_sweet_processor->get_css( array( 'optimize' => false ) )
+			$a_sweet_processor->get_css(
+				array(
+					'optimize' => false,
+					'prettify' => false,
+				)
+			)
 		);
 	}
 
@@ -217,7 +222,7 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 
 		$this->assertEquals(
 			'.a-sweet-rule,#an-even-sweeter-rule > marquee{color:var(--sweet-color);background-color:purple;}',
-			$a_sweet_processor->get_css()
+			$a_sweet_processor->get_css( array( 'prettify' => false ) )
 		);
 	}
 		/**
@@ -239,7 +244,7 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 			)
 		);
 		$a_lovely_processor->add_rules( $a_lovelier_rule );
-		$this->assertEquals( '.a-lovely-rule,.a-lovelier-rule{border-color:purple;}', $a_lovely_processor->get_css() );
+		$this->assertEquals( '.a-lovely-rule,.a-lovelier-rule{border-color:purple;}', $a_lovely_processor->get_css( array( 'prettify' => false ) ) );
 
 		$a_most_lovely_rule = new WP_Style_Engine_CSS_Rule(
 			'.a-most-lovely-rule',
@@ -259,7 +264,7 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 
 		$this->assertEquals(
 			'.a-lovely-rule,.a-lovelier-rule,.a-most-lovely-rule,.a-perfectly-lovely-rule{border-color:purple;}',
-			$a_lovely_processor->get_css()
+			$a_lovely_processor->get_css( array( 'prettify' => false ) )
 		);
 	}
 }

--- a/tests/phpunit/tests/style-engine/wpStyleEngineProcessor.php
+++ b/tests/phpunit/tests/style-engine/wpStyleEngineProcessor.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests the Style Engine Renderer class.
+ * Tests the Style Engine Processor class.
  *
  * @package WordPress
  * @subpackage StyleEngine
@@ -11,12 +11,18 @@
 
 /**
  * Tests for compiling and rendering styles from a store of CSS rules.
+ *
+ * @coversDefaultClass WP_Style_Engine_Processor
  */
-class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
+class Tests_Style_Engine_wpStyleEngineProcessor extends WP_UnitTestCase {
 	/**
-	 * Should compile CSS rules.
+	 * Tests adding rules and returning compiled CSS rules.
+	 *
+	 * @ticket 56467
+	 * @covers ::add_rules
+	 * @covers ::get_css
 	 */
-	public function test_return_rules_as_css() {
+	public function test_should_return_rules_as_compiled_css() {
 		$a_nice_css_rule = new WP_Style_Engine_CSS_Rule( '.a-nice-rule' );
 		$a_nice_css_rule->add_declarations(
 			array(
@@ -41,9 +47,12 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Should compile CSS rules.
+	 * Tests compiling CSS rules and formatting them with new lines and indents.
+	 *
+	 * @ticket 56467
+	 * @covers ::get_css
 	 */
-	public function test_return_prettified_rules_as_css() {
+	public function test_should_return_prettified_css_rules() {
 		$a_wonderful_css_rule = new WP_Style_Engine_CSS_Rule( '.a-wonderful-rule' );
 		$a_wonderful_css_rule->add_declarations(
 			array(
@@ -87,9 +96,12 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Should compile CSS rules from the store.
+	 * Tests adding a store and compiling CSS rules from that store.
+	 *
+	 * @ticket 56467
+	 * @covers ::add_store
 	 */
-	public function test_return_store_rules_as_css() {
+	public function test_should_return_store_rules_as_css() {
 		$a_nice_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'nice' );
 		$a_nice_store->add_rule( '.a-nice-rule' )->add_declarations(
 			array(
@@ -113,9 +125,13 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Should merge CSS declarations.
+	 * Tests that CSS declarations are merged and deduped in the final CSS rules output.
+	 *
+	 * @ticket 56467
+	 * @covers ::add_rules
+	 * @covers ::get_css
 	 */
-	public function test_dedupe_and_merge_css_declarations() {
+	public function test_should_dedupe_and_merge_css_declarations() {
 		$an_excellent_rule      = new WP_Style_Engine_CSS_Rule( '.an-excellent-rule' );
 		$an_excellent_processor = new WP_Style_Engine_Processor();
 		$an_excellent_rule->add_declarations(
@@ -156,9 +172,12 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Should print out uncombined selectors duplicate CSS rules.
+	 * Tests printing out 'unoptimized' CSS, that is, uncombined selectors and duplicate CSS rules.
+	 *
+	 * @ticket 56467
+	 * @covers ::get_css
 	 */
-	public function test_output_verbose_css_rules() {
+	public function test_should_not_optimize_css_output() {
 		$a_sweet_rule = new WP_Style_Engine_CSS_Rule(
 			'.a-sweet-rule',
 			array(
@@ -198,9 +217,12 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Should combine duplicate CSS rules.
+	 * Tests that 'optimized' CSS is output, that is, that duplicate CSS rules are combined under their corresponding selectors.
+	 *
+	 * @ticket 56467
+	 * @covers ::get_css
 	 */
-	public function test_combine_css_rules() {
+	public function test_should_optimize_css_output_by_default() {
 		$a_sweet_rule = new WP_Style_Engine_CSS_Rule(
 			'.a-sweet-rule',
 			array(
@@ -225,10 +247,14 @@ class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
 			$a_sweet_processor->get_css( array( 'prettify' => false ) )
 		);
 	}
-		/**
-		 * Should combine and store CSS rules.
-		 */
-	public function test_combine_previously_added_css_rules() {
+
+	/**
+	 * Tests that incoming CSS rules are merged with existing CSS rules.
+	 *
+	 * @ticket 56467
+	 * @covers ::add_rules
+	 */
+	public function test_should_combine_previously_added_css_rules() {
 		$a_lovely_processor = new WP_Style_Engine_Processor();
 		$a_lovely_rule      = new WP_Style_Engine_CSS_Rule(
 			'.a-lovely-rule',

--- a/tests/phpunit/tests/style-engine/wpStyleEngineProcessor.php
+++ b/tests/phpunit/tests/style-engine/wpStyleEngineProcessor.php
@@ -19,6 +19,7 @@ class Tests_Style_Engine_wpStyleEngineProcessor extends WP_UnitTestCase {
 	 * Tests adding rules and returning compiled CSS rules.
 	 *
 	 * @ticket 56467
+	 *
 	 * @covers ::add_rules
 	 * @covers ::get_css
 	 */
@@ -40,7 +41,8 @@ class Tests_Style_Engine_wpStyleEngineProcessor extends WP_UnitTestCase {
 		);
 		$a_nice_processor = new WP_Style_Engine_Processor();
 		$a_nice_processor->add_rules( array( $a_nice_css_rule, $a_nicer_css_rule ) );
-		$this->assertEquals(
+
+		$this->assertSame(
 			'.a-nice-rule{color:var(--nice-color);background-color:purple;}.a-nicer-rule{font-family:Nice sans;font-size:1em;background-color:purple;}',
 			$a_nice_processor->get_css( array( 'prettify' => false ) )
 		);
@@ -50,6 +52,7 @@ class Tests_Style_Engine_wpStyleEngineProcessor extends WP_UnitTestCase {
 	 * Tests compiling CSS rules and formatting them with new lines and indents.
 	 *
 	 * @ticket 56467
+	 *
 	 * @covers ::get_css
 	 */
 	public function test_should_return_prettified_css_rules() {
@@ -89,7 +92,7 @@ class Tests_Style_Engine_wpStyleEngineProcessor extends WP_UnitTestCase {
 	background-color: orange;
 }
 ';
-		$this->assertEquals(
+		$this->assertSame(
 			$expected,
 			$a_wonderful_processor->get_css( array( 'prettify' => true ) )
 		);
@@ -99,6 +102,7 @@ class Tests_Style_Engine_wpStyleEngineProcessor extends WP_UnitTestCase {
 	 * Tests adding a store and compiling CSS rules from that store.
 	 *
 	 * @ticket 56467
+	 *
 	 * @covers ::add_store
 	 */
 	public function test_should_return_store_rules_as_css() {
@@ -118,7 +122,8 @@ class Tests_Style_Engine_wpStyleEngineProcessor extends WP_UnitTestCase {
 		);
 		$a_nice_renderer = new WP_Style_Engine_Processor();
 		$a_nice_renderer->add_store( $a_nice_store );
-		$this->assertEquals(
+
+		$this->assertSame(
 			'.a-nice-rule{color:var(--nice-color);background-color:purple;}.a-nicer-rule{font-family:Nice sans;font-size:1em;background-color:purple;}',
 			$a_nice_renderer->get_css( array( 'prettify' => false ) )
 		);
@@ -128,6 +133,7 @@ class Tests_Style_Engine_wpStyleEngineProcessor extends WP_UnitTestCase {
 	 * Tests that CSS declarations are merged and deduped in the final CSS rules output.
 	 *
 	 * @ticket 56467
+	 *
 	 * @covers ::add_rules
 	 * @covers ::get_css
 	 */
@@ -151,7 +157,8 @@ class Tests_Style_Engine_wpStyleEngineProcessor extends WP_UnitTestCase {
 			)
 		);
 		$an_excellent_processor->add_rules( $another_excellent_rule );
-		$this->assertEquals(
+
+		$this->assertSame(
 			'.an-excellent-rule{color:var(--excellent-color);border-style:dotted;border-color:brown;}',
 			$an_excellent_processor->get_css( array( 'prettify' => false ) ),
 			'Return value of get_css() does not match expectations with new, deduped and merged declarations.'
@@ -166,7 +173,8 @@ class Tests_Style_Engine_wpStyleEngineProcessor extends WP_UnitTestCase {
 			)
 		);
 		$an_excellent_processor->add_rules( $yet_another_excellent_rule );
-		$this->assertEquals(
+
+		$this->assertSame(
 			'.an-excellent-rule{color:var(--excellent-color);border-style:dashed;border-color:brown;border-width:2px;}',
 			$an_excellent_processor->get_css( array( 'prettify' => false ) ),
 			'Return value of get_css() does not match expectations with deduped and merged declarations.'
@@ -177,6 +185,7 @@ class Tests_Style_Engine_wpStyleEngineProcessor extends WP_UnitTestCase {
 	 * Tests printing out 'unoptimized' CSS, that is, uncombined selectors and duplicate CSS rules.
 	 *
 	 * @ticket 56467
+	 *
 	 * @covers ::get_css
 	 */
 	public function test_should_not_optimize_css_output() {
@@ -207,7 +216,7 @@ class Tests_Style_Engine_wpStyleEngineProcessor extends WP_UnitTestCase {
 		$a_sweet_processor = new WP_Style_Engine_Processor();
 		$a_sweet_processor->add_rules( array( $a_sweet_rule, $a_sweeter_rule, $the_sweetest_rule ) );
 
-		$this->assertEquals(
+		$this->assertSame(
 			'.a-sweet-rule{color:var(--sweet-color);background-color:purple;}#an-even-sweeter-rule > marquee{color:var(--sweet-color);background-color:purple;}.the-sweetest-rule-of-all a{color:var(--sweet-color);background-color:purple;}',
 			$a_sweet_processor->get_css(
 				array(
@@ -222,6 +231,7 @@ class Tests_Style_Engine_wpStyleEngineProcessor extends WP_UnitTestCase {
 	 * Tests that 'optimized' CSS is output, that is, that duplicate CSS rules are combined under their corresponding selectors.
 	 *
 	 * @ticket 56467
+	 *
 	 * @covers ::get_css
 	 */
 	public function test_should_optimize_css_output_by_default() {
@@ -244,7 +254,7 @@ class Tests_Style_Engine_wpStyleEngineProcessor extends WP_UnitTestCase {
 		$a_sweet_processor = new WP_Style_Engine_Processor();
 		$a_sweet_processor->add_rules( array( $a_sweet_rule, $a_sweeter_rule ) );
 
-		$this->assertEquals(
+		$this->assertSame(
 			'.a-sweet-rule,#an-even-sweeter-rule > marquee{color:var(--sweet-color);background-color:purple;}',
 			$a_sweet_processor->get_css( array( 'prettify' => false ) )
 		);
@@ -254,6 +264,7 @@ class Tests_Style_Engine_wpStyleEngineProcessor extends WP_UnitTestCase {
 	 * Tests that incoming CSS rules are merged with existing CSS rules.
 	 *
 	 * @ticket 56467
+	 *
 	 * @covers ::add_rules
 	 */
 	public function test_should_combine_previously_added_css_rules() {
@@ -272,7 +283,8 @@ class Tests_Style_Engine_wpStyleEngineProcessor extends WP_UnitTestCase {
 			)
 		);
 		$a_lovely_processor->add_rules( $a_lovelier_rule );
-		$this->assertEquals(
+
+		$this->assertSame(
 			'.a-lovely-rule,.a-lovelier-rule{border-color:purple;}',
 			$a_lovely_processor->get_css( array( 'prettify' => false ) ),
 			'Return value of get_css() does not match expectations when combining 2 CSS rules'
@@ -294,7 +306,7 @@ class Tests_Style_Engine_wpStyleEngineProcessor extends WP_UnitTestCase {
 		);
 		$a_lovely_processor->add_rules( $a_perfectly_lovely_rule );
 
-		$this->assertEquals(
+		$this->assertSame(
 			'.a-lovely-rule,.a-lovelier-rule,.a-most-lovely-rule,.a-perfectly-lovely-rule{border-color:purple;}',
 			$a_lovely_processor->get_css( array( 'prettify' => false ) ),
 			'Return value of get_css() does not match expectations when combining 4 CSS rules'

--- a/tests/phpunit/tests/style-engine/wpStyleEngineProcessor.php
+++ b/tests/phpunit/tests/style-engine/wpStyleEngineProcessor.php
@@ -1,0 +1,265 @@
+<?php
+/**
+ * Tests the Style Engine Renderer class.
+ *
+ * @package WordPress
+ * @subpackage StyleEngine
+ * @since 6.1.0
+ *
+ * @group styleEngine
+ */
+
+/**
+ * Tests for compiling and rendering styles from a store of CSS rules.
+ */
+class WP_Style_Engine_Processor_Test extends WP_UnitTestCase {
+	/**
+	 * Should compile CSS rules.
+	 */
+	public function test_return_rules_as_css() {
+		$a_nice_css_rule = new WP_Style_Engine_CSS_Rule( '.a-nice-rule' );
+		$a_nice_css_rule->add_declarations(
+			array(
+				'color'            => 'var(--nice-color)',
+				'background-color' => 'purple',
+			)
+		);
+		$a_nicer_css_rule = new WP_Style_Engine_CSS_Rule( '.a-nicer-rule' );
+		$a_nicer_css_rule->add_declarations(
+			array(
+				'font-family'      => 'Nice sans',
+				'font-size'        => '1em',
+				'background-color' => 'purple',
+			)
+		);
+		$a_nice_processor = new WP_Style_Engine_Processor();
+		$a_nice_processor->add_rules( array( $a_nice_css_rule, $a_nicer_css_rule ) );
+		$this->assertEquals(
+			'.a-nice-rule{color:var(--nice-color);background-color:purple;}.a-nicer-rule{font-family:Nice sans;font-size:1em;background-color:purple;}',
+			$a_nice_processor->get_css()
+		);
+	}
+
+	/**
+	 * Should compile CSS rules.
+	 */
+	public function test_return_prettified_rules_as_css() {
+		$a_wonderful_css_rule = new WP_Style_Engine_CSS_Rule( '.a-wonderful-rule' );
+		$a_wonderful_css_rule->add_declarations(
+			array(
+				'color'            => 'var(--wonderful-color)',
+				'background-color' => 'orange',
+			)
+		);
+		$a_very_wonderful_css_rule = new WP_Style_Engine_CSS_Rule( '.a-very_wonderful-rule' );
+		$a_very_wonderful_css_rule->add_declarations(
+			array(
+				'color'            => 'var(--wonderful-color)',
+				'background-color' => 'orange',
+			)
+		);
+		$a_more_wonderful_css_rule = new WP_Style_Engine_CSS_Rule( '.a-more-wonderful-rule' );
+		$a_more_wonderful_css_rule->add_declarations(
+			array(
+				'font-family'      => 'Wonderful sans',
+				'font-size'        => '1em',
+				'background-color' => 'orange',
+			)
+		);
+		$a_wonderful_processor = new WP_Style_Engine_Processor();
+		$a_wonderful_processor->add_rules( array( $a_wonderful_css_rule, $a_very_wonderful_css_rule, $a_more_wonderful_css_rule ) );
+
+		$expected = '.a-more-wonderful-rule {
+	font-family: Wonderful sans;
+	font-size: 1em;
+	background-color: orange;
+}
+.a-wonderful-rule,
+.a-very_wonderful-rule {
+	color: var(--wonderful-color);
+	background-color: orange;
+}
+';
+		$this->assertEquals(
+			$expected,
+			$a_wonderful_processor->get_css( array( 'prettify' => true ) )
+		);
+	}
+
+	/**
+	 * Should compile CSS rules from the store.
+	 */
+	public function test_return_store_rules_as_css() {
+		$a_nice_store = WP_Style_Engine_CSS_Rules_Store::get_store( 'nice' );
+		$a_nice_store->add_rule( '.a-nice-rule' )->add_declarations(
+			array(
+				'color'            => 'var(--nice-color)',
+				'background-color' => 'purple',
+			)
+		);
+		$a_nice_store->add_rule( '.a-nicer-rule' )->add_declarations(
+			array(
+				'font-family'      => 'Nice sans',
+				'font-size'        => '1em',
+				'background-color' => 'purple',
+			)
+		);
+		$a_nice_renderer = new WP_Style_Engine_Processor();
+		$a_nice_renderer->add_store( $a_nice_store );
+		$this->assertEquals(
+			'.a-nice-rule{color:var(--nice-color);background-color:purple;}.a-nicer-rule{font-family:Nice sans;font-size:1em;background-color:purple;}',
+			$a_nice_renderer->get_css()
+		);
+	}
+
+	/**
+	 * Should merge CSS declarations.
+	 */
+	public function test_dedupe_and_merge_css_declarations() {
+		$an_excellent_rule      = new WP_Style_Engine_CSS_Rule( '.an-excellent-rule' );
+		$an_excellent_processor = new WP_Style_Engine_Processor();
+		$an_excellent_rule->add_declarations(
+			array(
+				'color'        => 'var(--excellent-color)',
+				'border-style' => 'dotted',
+			)
+		);
+		$an_excellent_processor->add_rules( $an_excellent_rule );
+
+		$another_excellent_rule = new WP_Style_Engine_CSS_Rule( '.an-excellent-rule' );
+		$another_excellent_rule->add_declarations(
+			array(
+				'color'        => 'var(--excellent-color)',
+				'border-style' => 'dotted',
+				'border-color' => 'brown',
+			)
+		);
+		$an_excellent_processor->add_rules( $another_excellent_rule );
+		$this->assertEquals(
+			'.an-excellent-rule{color:var(--excellent-color);border-style:dotted;border-color:brown;}',
+			$an_excellent_processor->get_css()
+		);
+
+		$yet_another_excellent_rule = new WP_Style_Engine_CSS_Rule( '.an-excellent-rule' );
+		$yet_another_excellent_rule->add_declarations(
+			array(
+				'color'        => 'var(--excellent-color)',
+				'border-style' => 'dashed',
+				'border-width' => '2px',
+			)
+		);
+		$an_excellent_processor->add_rules( $yet_another_excellent_rule );
+		$this->assertEquals(
+			'.an-excellent-rule{color:var(--excellent-color);border-style:dashed;border-color:brown;border-width:2px;}',
+			$an_excellent_processor->get_css()
+		);
+	}
+
+	/**
+	 * Should print out uncombined selectors duplicate CSS rules.
+	 */
+	public function test_output_verbose_css_rules() {
+		$a_sweet_rule = new WP_Style_Engine_CSS_Rule(
+			'.a-sweet-rule',
+			array(
+				'color'            => 'var(--sweet-color)',
+				'background-color' => 'purple',
+			)
+		);
+
+		$a_sweeter_rule = new WP_Style_Engine_CSS_Rule(
+			'#an-even-sweeter-rule > marquee',
+			array(
+				'color'            => 'var(--sweet-color)',
+				'background-color' => 'purple',
+			)
+		);
+
+		$the_sweetest_rule = new WP_Style_Engine_CSS_Rule(
+			'.the-sweetest-rule-of-all a',
+			array(
+				'color'            => 'var(--sweet-color)',
+				'background-color' => 'purple',
+			)
+		);
+
+		$a_sweet_processor = new WP_Style_Engine_Processor();
+		$a_sweet_processor->add_rules( array( $a_sweet_rule, $a_sweeter_rule, $the_sweetest_rule ) );
+
+		$this->assertEquals(
+			'.a-sweet-rule{color:var(--sweet-color);background-color:purple;}#an-even-sweeter-rule > marquee{color:var(--sweet-color);background-color:purple;}.the-sweetest-rule-of-all a{color:var(--sweet-color);background-color:purple;}',
+			$a_sweet_processor->get_css( array( 'optimize' => false ) )
+		);
+	}
+
+	/**
+	 * Should combine duplicate CSS rules.
+	 */
+	public function test_combine_css_rules() {
+		$a_sweet_rule = new WP_Style_Engine_CSS_Rule(
+			'.a-sweet-rule',
+			array(
+				'color'            => 'var(--sweet-color)',
+				'background-color' => 'purple',
+			)
+		);
+
+		$a_sweeter_rule = new WP_Style_Engine_CSS_Rule(
+			'#an-even-sweeter-rule > marquee',
+			array(
+				'color'            => 'var(--sweet-color)',
+				'background-color' => 'purple',
+			)
+		);
+
+		$a_sweet_processor = new WP_Style_Engine_Processor();
+		$a_sweet_processor->add_rules( array( $a_sweet_rule, $a_sweeter_rule ) );
+
+		$this->assertEquals(
+			'.a-sweet-rule,#an-even-sweeter-rule > marquee{color:var(--sweet-color);background-color:purple;}',
+			$a_sweet_processor->get_css()
+		);
+	}
+		/**
+		 * Should combine and store CSS rules.
+		 */
+	public function test_combine_previously_added_css_rules() {
+		$a_lovely_processor = new WP_Style_Engine_Processor();
+		$a_lovely_rule      = new WP_Style_Engine_CSS_Rule(
+			'.a-lovely-rule',
+			array(
+				'border-color' => 'purple',
+			)
+		);
+		$a_lovely_processor->add_rules( $a_lovely_rule );
+		$a_lovelier_rule = new WP_Style_Engine_CSS_Rule(
+			'.a-lovelier-rule',
+			array(
+				'border-color' => 'purple',
+			)
+		);
+		$a_lovely_processor->add_rules( $a_lovelier_rule );
+		$this->assertEquals( '.a-lovely-rule,.a-lovelier-rule{border-color:purple;}', $a_lovely_processor->get_css() );
+
+		$a_most_lovely_rule = new WP_Style_Engine_CSS_Rule(
+			'.a-most-lovely-rule',
+			array(
+				'border-color' => 'purple',
+			)
+		);
+		$a_lovely_processor->add_rules( $a_most_lovely_rule );
+
+		$a_perfectly_lovely_rule = new WP_Style_Engine_CSS_Rule(
+			'.a-perfectly-lovely-rule',
+			array(
+				'border-color' => 'purple',
+			)
+		);
+		$a_lovely_processor->add_rules( $a_perfectly_lovely_rule );
+
+		$this->assertEquals(
+			'.a-lovely-rule,.a-lovelier-rule,.a-most-lovely-rule,.a-perfectly-lovely-rule{border-color:purple;}',
+			$a_lovely_processor->get_css()
+		);
+	}
+}

--- a/tests/phpunit/tests/style-engine/wpStyleEngineProcessor.php
+++ b/tests/phpunit/tests/style-engine/wpStyleEngineProcessor.php
@@ -153,7 +153,8 @@ class Tests_Style_Engine_wpStyleEngineProcessor extends WP_UnitTestCase {
 		$an_excellent_processor->add_rules( $another_excellent_rule );
 		$this->assertEquals(
 			'.an-excellent-rule{color:var(--excellent-color);border-style:dotted;border-color:brown;}',
-			$an_excellent_processor->get_css( array( 'prettify' => false ) )
+			$an_excellent_processor->get_css( array( 'prettify' => false ) ),
+			'Return value of get_css() does not match expectations with new, deduped and merged declarations.'
 		);
 
 		$yet_another_excellent_rule = new WP_Style_Engine_CSS_Rule( '.an-excellent-rule' );
@@ -167,7 +168,8 @@ class Tests_Style_Engine_wpStyleEngineProcessor extends WP_UnitTestCase {
 		$an_excellent_processor->add_rules( $yet_another_excellent_rule );
 		$this->assertEquals(
 			'.an-excellent-rule{color:var(--excellent-color);border-style:dashed;border-color:brown;border-width:2px;}',
-			$an_excellent_processor->get_css( array( 'prettify' => false ) )
+			$an_excellent_processor->get_css( array( 'prettify' => false ) ),
+			'Return value of get_css() does not match expectations with deduped and merged declarations.'
 		);
 	}
 
@@ -270,7 +272,11 @@ class Tests_Style_Engine_wpStyleEngineProcessor extends WP_UnitTestCase {
 			)
 		);
 		$a_lovely_processor->add_rules( $a_lovelier_rule );
-		$this->assertEquals( '.a-lovely-rule,.a-lovelier-rule{border-color:purple;}', $a_lovely_processor->get_css( array( 'prettify' => false ) ) );
+		$this->assertEquals(
+			'.a-lovely-rule,.a-lovelier-rule{border-color:purple;}',
+			$a_lovely_processor->get_css( array( 'prettify' => false ) ),
+			'Return value of get_css() does not match expectations when combining 2 CSS rules'
+		);
 
 		$a_most_lovely_rule = new WP_Style_Engine_CSS_Rule(
 			'.a-most-lovely-rule',
@@ -290,7 +296,8 @@ class Tests_Style_Engine_wpStyleEngineProcessor extends WP_UnitTestCase {
 
 		$this->assertEquals(
 			'.a-lovely-rule,.a-lovelier-rule,.a-most-lovely-rule,.a-perfectly-lovely-rule{border-color:purple;}',
-			$a_lovely_processor->get_css( array( 'prettify' => false ) )
+			$a_lovely_processor->get_css( array( 'prettify' => false ) ),
+			'Return value of get_css() does not match expectations when combining 4 CSS rules'
 		);
 	}
 }


### PR DESCRIPTION
This PR migrates the Style Engine PHP functions, classes and tests into Core for 6.1.

It reflects the latest changes from https://github.com/WordPress/gutenberg/pull/43840

See tracking issue: https://github.com/WordPress/gutenberg/issues/43440

## Backport PRs blocked by this changeset (that I know of)

- https://github.com/WordPress/wordpress-develop/pull/3218
- https://github.com/WordPress/wordpress-develop/pull/3203
- https://github.com/WordPress/wordpress-develop/pull/3204

Trac ticket: https://core.trac.wordpress.org/ticket/56467
