### PR TITLE
Allow a valueless attribute a the end in kses

### DIFF
--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -1317,7 +1317,7 @@ function wp_kses_hair( $attr, $allowed_protocols ) {
 					break;
 				}
 
-				if ( preg_match( '/^\s+/', $attr ) ) { // Valueless.
+				if ( preg_match( '/^(\s+|\/$)/', $attr ) ) { // Valueless.
 					$working = 1;
 					$mode    = 0;
 					if ( false === array_key_exists( $attrname, $attrarr ) ) {


### PR DESCRIPTION
`wp_kses_hair` fails to parse a valueless attribute at the end of the list.
For example: `<input name="email" required/>` will strip the `required` attribute.
This change fixes it.

https://core.trac.wordpress.org/ticket/56521