### PR TITLE
Move wp_default_image_output_mapping() filter callback to frontend

### DIFF
--- a/src/wp-admin/includes/admin-filters.php
+++ b/src/wp-admin/includes/admin-filters.php
@@ -37,8 +37,6 @@ add_filter( 'media_upload_library', 'media_upload_library' );
 
 add_filter( 'media_upload_tabs', 'update_gallery_tab' );
 
-add_filter( 'image_editor_output_format', 'wp_default_image_output_mapping' );
-
 // Admin color schemes.
 add_action( 'admin_init', 'register_admin_color_schemes', 1 );
 add_action( 'admin_head', 'wp_color_scheme_settings' );

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -3843,18 +3843,3 @@ function wp_media_attach_action( $parent_id, $action = 'attach' ) {
 		exit;
 	}
 }
-
-/**
- * Filters the default image output mapping.
- *
- * With this filter callback, WebP image files will be generated for certain JPEG source files.
- *
- * @since 6.1.0
- *
- * @param array $output_mapping Map of mime type to output format.
- * @retun array The adjusted default output mapping.
- */
-function wp_default_image_output_mapping( $output_mapping ) {
-	$output_mapping['image/jpeg'] = 'image/webp';
-	return $output_mapping;
-}

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -632,6 +632,8 @@ add_action( 'media_buttons', 'media_buttons' );
 add_filter( 'image_send_to_editor', 'image_add_caption', 20, 8 );
 add_filter( 'media_send_to_editor', 'image_media_send_to_editor', 10, 3 );
 
+add_filter( 'image_editor_output_format', 'wp_default_image_output_mapping' );
+
 // Embeds.
 add_action( 'rest_api_init', 'wp_oembed_register_route' );
 add_filter( 'rest_pre_serve_request', '_oembed_rest_pre_serve_request', 10, 4 );

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -3905,6 +3905,21 @@ function _wp_image_editor_choose( $args = array() ) {
 }
 
 /**
+ * Filters the default image output mapping.
+ *
+ * With this filter callback, WebP image files will be generated for certain JPEG source files.
+ *
+ * @since 6.1.0
+ *
+ * @param array $output_mapping Map of mime type to output format.
+ * @retun array The adjusted default output mapping.
+ */
+function wp_default_image_output_mapping( $output_mapping ) {
+	$output_mapping['image/jpeg'] = 'image/webp';
+	return $output_mapping;
+}
+
+/**
  * Prints default Plupload arguments.
  *
  * @since 3.4.0


### PR DESCRIPTION
This is a follow up to https://core.trac.wordpress.org/ticket/55443: The `WP_Image_Editor` classes are loaded also in the frontend and could theoretically be used there, so while I suggested otherwise on the original pull request, on second thought I think it's more appropriate to hook in the filter also in the frontend.

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
