### PR TITLE
Improve the compatibility of WP_Admin_Bar with PHP 8.2

### DIFF
--- a/src/wp-includes/class-wp-admin-bar.php
+++ b/src/wp-includes/class-wp-admin-bar.php
@@ -17,8 +17,6 @@ class WP_Admin_Bar {
 	private $bound = false;
 	public $user;
 
-	public $menu = array();
-
 	/**
 	 * Initializes the admin bar.
 	 *

--- a/src/wp-includes/class-wp-admin-bar.php
+++ b/src/wp-includes/class-wp-admin-bar.php
@@ -24,13 +24,9 @@ class WP_Admin_Bar {
 	 * @return string|array|void
 	 */
 	public function __get( $name ) {
-		switch ( $name ) {
-			case 'proto':
-				return is_ssl() ? 'https://' : 'http://';
-
-			case 'menu':
-				_deprecated_argument( 'WP_Admin_Bar', '3.3.0', 'Modify admin bar nodes with WP_Admin_Bar::get_node(), WP_Admin_Bar::add_node(), and WP_Admin_Bar::remove_node(), not the <code>menu</code> property.' );
-				return array(); // Sorry, folks.
+		if ( 'menu' === $name ) {
+			_deprecated_argument( 'WP_Admin_Bar', '3.3.0', 'Modify admin bar nodes with WP_Admin_Bar::get_node(), WP_Admin_Bar::add_node(), and WP_Admin_Bar::remove_node(), not the <code>menu</code> property.' );
+			return array(); // Sorry, folks.
 		}
 	}
 

--- a/src/wp-includes/class-wp-admin-bar.php
+++ b/src/wp-includes/class-wp-admin-bar.php
@@ -17,18 +17,7 @@ class WP_Admin_Bar {
 	private $bound = false;
 	public $user;
 
-	/**
-	 * @since 3.3.0
-	 *
-	 * @param string $name
-	 * @return string|array|void
-	 */
-	public function __get( $name ) {
-		if ( 'menu' === $name ) {
-			_deprecated_argument( 'WP_Admin_Bar', '3.3.0', 'Modify admin bar nodes with WP_Admin_Bar::get_node(), WP_Admin_Bar::add_node(), and WP_Admin_Bar::remove_node(), not the <code>menu</code> property.' );
-			return array(); // Sorry, folks.
-		}
-	}
+	public $menu = array();
 
 	/**
 	 * Initializes the admin bar.

--- a/tests/phpunit/tests/adminbar.php
+++ b/tests/phpunit/tests/adminbar.php
@@ -742,22 +742,27 @@ class Tests_AdminBar extends WP_UnitTestCase {
 		}
 	}
 
+	/**
+	 * Data provider for test_should_not_use_dynamic_properties().
+	 *
+	 * @return array
+	 */
 	private function data_should_not_use_dynamic_properties()
 	{
 		return array(
 			'property_name' => array(
-				'proto' => 'proto',
-				'menu' => 'menu',
+				'$wp_admin_bar->proto' => 'proto',
+				'$wp_admin_bar->menu' => 'menu',
 			)
 		);
 	}
 
 	/**
-	 * @param $property_name
+	 * @ticket 56535
 	 *
 	 * @dataProvider data_should_not_use_dynamic_properties
 	 *
-	 * @return void
+	 * @param string $property_name Name of the property.
 	 */
 	public function test_should_not_use_dynamic_properties($property_name)
 	{
@@ -773,8 +778,8 @@ class Tests_AdminBar extends WP_UnitTestCase {
 			// Assert that the property is not being used in the __get method.
 			$property_defined = null !== $wp_admin_bar->$property_name;
 		} catch (Exception $e) {
-			// Catching the exception as dynamic properties
-			// generate PHP warnings on PHP >= 8.2.
+			// Catch the exception as dynamic properties
+			// generate warnings on PHP >= 8.2.
 			$property_defined = false;
 		}
 

--- a/tests/phpunit/tests/adminbar.php
+++ b/tests/phpunit/tests/adminbar.php
@@ -745,22 +745,33 @@ class Tests_AdminBar extends WP_UnitTestCase {
 	private function data_should_not_use_dynamic_properties()
 	{
 		return array(
-			'proto',
-			'menu',
+			'property_name' => array(
+				'proto' => 'proto',
+				'menu' => 'menu',
+			)
 		);
 	}
 
+	/**
+	 * @param $property_name
+	 *
+	 * @dataProvider data_should_not_use_dynamic_properties
+	 *
+	 * @return void
+	 */
 	public function test_should_not_use_dynamic_properties($property_name)
 	{
 		$wp_admin_bar = $this->get_standard_admin_bar();
 		$this->assertFalse(property_exists($wp_admin_bar, $property_name), sprintf('The "%s" property is deprecated and must not be used.', $property_name));
-		$this->assertFalse(isset($wp_admin_bar->$property_name), sprintf('The "%s" property is deprecated and must not be used.', $property_name));
+
+		// Assert that the property is not being used in the __isset method.
+		$this->assertFalse(isset($wp_admin_bar->$property_name), sprintf('The "%s" property is deprecated and must not be used in the __isset method.', $property_name));
 
 		$property_defined = true;
 
 		try {
-			// This code should run without exceptions on PHP 8.1 and below.
-			$property_defined = null !== $wp_admin_bar->proto;
+			// Assert that the property is not being used in the __get method.
+			$property_defined = null !== $wp_admin_bar->$property_name;
 		} catch (Exception $e) {
 			// Catching the exception as dynamic properties
 			// generate PHP warnings on PHP >= 8.2.

--- a/tests/phpunit/tests/adminbar.php
+++ b/tests/phpunit/tests/adminbar.php
@@ -748,12 +748,12 @@ class Tests_AdminBar extends WP_UnitTestCase {
 	 * @return array
 	 */
 	private function data_should_not_use_dynamic_properties() {
-		 return array(
-			 'property_name' => array(
-				 '$wp_admin_bar->proto' => 'proto',
-				 '$wp_admin_bar->menu'  => 'menu',
-			 ),
-		 );
+		return array(
+			'property_name' => array(
+				'$wp_admin_bar->proto' => 'proto',
+				'$wp_admin_bar->menu'  => 'menu',
+			),
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/adminbar.php
+++ b/tests/phpunit/tests/adminbar.php
@@ -747,7 +747,7 @@ class Tests_AdminBar extends WP_UnitTestCase {
 	 *
 	 * @return array
 	 */
-	private function data_should_not_use_dynamic_properties() {
+	public function data_should_not_use_dynamic_properties() {
 		return array(
 			'property_name' => array(
 				'$wp_admin_bar->proto' => 'proto',

--- a/tests/phpunit/tests/adminbar.php
+++ b/tests/phpunit/tests/adminbar.php
@@ -747,14 +747,13 @@ class Tests_AdminBar extends WP_UnitTestCase {
 	 *
 	 * @return array
 	 */
-	private function data_should_not_use_dynamic_properties()
-	{
-		return array(
-			'property_name' => array(
-				'$wp_admin_bar->proto' => 'proto',
-				'$wp_admin_bar->menu' => 'menu',
-			)
-		);
+	private function data_should_not_use_dynamic_properties() {
+		 return array(
+			 'property_name' => array(
+				 '$wp_admin_bar->proto' => 'proto',
+				 '$wp_admin_bar->menu'  => 'menu',
+			 ),
+		 );
 	}
 
 	/**
@@ -764,27 +763,26 @@ class Tests_AdminBar extends WP_UnitTestCase {
 	 *
 	 * @param string $property_name Name of the property.
 	 */
-	public function test_should_not_use_dynamic_properties($property_name)
-	{
+	public function test_should_not_use_dynamic_properties( $property_name ) {
 		$wp_admin_bar = $this->get_standard_admin_bar();
-		$this->assertFalse(property_exists($wp_admin_bar, $property_name), sprintf('The "%s" property is deprecated and must not be used.', $property_name));
+		$this->assertFalse( property_exists( $wp_admin_bar, $property_name ), sprintf( 'The "%s" property is deprecated and must not be used.', $property_name ) );
 
 		// Assert that the property is not being used in the __isset method.
-		$this->assertFalse(isset($wp_admin_bar->$property_name), sprintf('The "%s" property is deprecated and must not be used in the __isset method.', $property_name));
+		$this->assertFalse( isset( $wp_admin_bar->$property_name ), sprintf( 'The "%s" property is deprecated and must not be used in the __isset method.', $property_name ) );
 
 		$property_defined = true;
 
 		try {
 			// Assert that the property is not being used in the __get method.
 			$property_defined = null !== $wp_admin_bar->$property_name;
-		} catch (Exception $e) {
+		} catch ( Exception $e ) {
 			// Catch the exception as dynamic properties
 			// generate warnings on PHP >= 8.2.
 			$property_defined = false;
 		}
 
-		if ($property_defined) {
-			$this->fail('The magic methods of the WP_Admin_Bar class should not be used to define dynamic properties.');
+		if ( $property_defined ) {
+			$this->fail( 'The magic methods of the WP_Admin_Bar class should not be used to define dynamic properties.' );
 		}
 	}
 

--- a/tests/phpunit/tests/adminbar.php
+++ b/tests/phpunit/tests/adminbar.php
@@ -742,6 +742,36 @@ class Tests_AdminBar extends WP_UnitTestCase {
 		}
 	}
 
+	private function data_should_not_use_dynamic_properties()
+	{
+		return array(
+			'proto',
+			'menu',
+		);
+	}
+
+	public function test_should_not_use_dynamic_properties($property_name)
+	{
+		$wp_admin_bar = $this->get_standard_admin_bar();
+		$this->assertFalse(property_exists($wp_admin_bar, $property_name), sprintf('The "%s" property is deprecated and must not be used.', $property_name));
+		$this->assertFalse(isset($wp_admin_bar->$property_name), sprintf('The "%s" property is deprecated and must not be used.', $property_name));
+
+		$property_defined = true;
+
+		try {
+			// This code should run without exceptions on PHP 8.1 and below.
+			$property_defined = null !== $wp_admin_bar->proto;
+		} catch (Exception $e) {
+			// Catching the exception as dynamic properties
+			// generate PHP warnings on PHP >= 8.2.
+			$property_defined = false;
+		}
+
+		if ($property_defined) {
+			$this->fail('The magic methods of the WP_Admin_Bar class should not be used to define dynamic properties.');
+		}
+	}
+
 	private function get_my_sites_network_menu_items() {
 		return array(
 			'my-sites-super-admin' => 'manage_network',


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This PR aims to improve compatibility of the WP_Admin_Bar class with PHP 8.2 and above by removing dynamic properties while making sure that this won't break backward compatibility.

Trac ticket: https://core.trac.wordpress.org/ticket/56535

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
