### PR TITLE
Backport script loader: enqueue stored block supports styles

### DIFF
--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -575,6 +575,10 @@ add_action( 'admin_head', 'wp_check_widget_editor_deps' );
 add_action( 'wp_enqueue_scripts', 'wp_enqueue_global_styles' );
 add_action( 'wp_footer', 'wp_enqueue_global_styles', 1 );
 
+// Block supports, and other styles parsed and stored in the Style Engine.
+add_action( 'wp_enqueue_scripts', 'wp_enqueue_stored_styles' );
+add_action( 'wp_footer', 'wp_enqueue_stored_styles', 1 );
+
 // SVG filters like duotone have to be loaded at the beginning of the body in both admin and the front-end.
 add_action( 'wp_body_open', 'wp_global_styles_render_svg_filters' );
 add_action( 'in_admin_header', 'wp_global_styles_render_svg_filters' );

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2924,6 +2924,64 @@ function wp_enqueue_block_support_styles( $style, $priority = 10 ) {
 }
 
 /**
+ * Fetches, processes and compiles stored core styles, then combines and renders them to the page.
+ * Styles are stored via the Style Engine API.
+ * See: https://developer.wordpress.org/block-editor/reference-guides/packages/packages-style-engine/
+ *
+ * @since 6.1.0
+ */
+function wp_enqueue_stored_styles() {
+	$is_block_theme   = wp_is_block_theme();
+	$is_classic_theme = ! $is_block_theme;
+
+	/*
+	 * For block themes, this function prints stored styles in the header.
+	 * For classic themes, in the footer.
+	 */
+	if (
+		( $is_block_theme && doing_action( 'wp_footer' ) ) ||
+		( $is_classic_theme && doing_action( 'wp_enqueue_scripts' ) )
+	) {
+		return;
+	}
+
+	$core_styles_keys         = array( 'block-supports' );
+	$compiled_core_stylesheet = '';
+	$style_tag_id             = 'core';
+	foreach ( $core_styles_keys as $style_key ) {
+		// Adds comment to identify core styles sections in debugging.
+		if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
+			$compiled_core_stylesheet .= "/**\n * Core styles: $style_key\n */\n";
+		}
+		// Chains core store ids to signify what the styles contain.
+		$style_tag_id             .= '-' . $style_key;
+		$compiled_core_stylesheet .= wp_style_engine_get_stylesheet_from_context( $style_key );
+	}
+
+	// Combines Core styles.
+	if ( ! empty( $compiled_core_stylesheet ) ) {
+		wp_register_style( $style_tag_id, false, array(), true, true );
+		wp_add_inline_style( $style_tag_id, $compiled_core_stylesheet );
+		wp_enqueue_style( $style_tag_id );
+	}
+
+	// If there are any other stores registered by themes etc, print them out.
+	$additional_stores = WP_Style_Engine_CSS_Rules_Store::get_stores();
+	foreach ( array_keys( $additional_stores ) as $store_name ) {
+		if ( in_array( $store_name, $core_styles_keys, true ) ) {
+			continue;
+		}
+		$styles = wp_style_engine_get_stylesheet_from_context( $store_name );
+		if ( ! empty( $styles ) ) {
+			$key = "wp-style-engine-$store_name";
+			wp_register_style( $key, false, array(), true, true );
+			wp_add_inline_style( $key, $styles );
+			wp_enqueue_style( $key );
+		}
+	}
+}
+
+/**
  * Enqueues a stylesheet for a specific block.
  *
  * If the theme has opted-in to separate-styles loading,

--- a/tests/phpunit/tests/script-loader.php
+++ b/tests/phpunit/tests/script-loader.php
@@ -24,8 +24,6 @@ class Tests_Script_Loader extends WP_UnitTestCase {
 	 * @covers ::wp_enqueue_stored_styles
 	 */
 	public function test_should_enqueue_stored_styles() {
-		global $wp_styles;
-
 		$core_styles_to_enqueue = array(
 			array(
 				'selector'     => '.saruman',

--- a/tests/phpunit/tests/script-loader.php
+++ b/tests/phpunit/tests/script-loader.php
@@ -1,0 +1,8 @@
+<?php
+
+/**
+ * Test functions and classes for widgets and sidebars.
+ *
+ * @group script-loader
+ */
+class Tests_Script_Loader extends WP_UnitTestCase {}

--- a/tests/phpunit/tests/script-loader.php
+++ b/tests/phpunit/tests/script-loader.php
@@ -1,13 +1,13 @@
 <?php
 
 /**
- * Test functions and classes for widgets and sidebars.
+ * Tests functions and classes for widgets and sidebars.
  *
  * @group script-loader
  */
 class Tests_Script_Loader extends WP_UnitTestCase {
 	/**
-	 * Clean up global scope.
+	 * Cleans up global scope.
 	 *
 	 * @global WP_Scripts $wp_scripts
 	 * @global WP_Styles $wp_styles
@@ -21,6 +21,7 @@ class Tests_Script_Loader extends WP_UnitTestCase {
 	 * Tests that stored CSS is enqueued.
 	 *
 	 * @ticket 56467
+	 *
 	 * @covers ::wp_enqueue_stored_styles
 	 */
 	public function test_should_enqueue_stored_styles() {
@@ -35,7 +36,7 @@ class Tests_Script_Loader extends WP_UnitTestCase {
 			),
 		);
 
-		// Enqueue a block supports (core styles).
+		// Enqueues a block supports (core styles).
 		wp_style_engine_get_stylesheet_from_css_rules(
 			$core_styles_to_enqueue,
 			array(

--- a/tests/phpunit/tests/script-loader.php
+++ b/tests/phpunit/tests/script-loader.php
@@ -5,4 +5,77 @@
  *
  * @group script-loader
  */
-class Tests_Script_Loader extends WP_UnitTestCase {}
+class Tests_Script_Loader extends WP_UnitTestCase {
+	/**
+	 * Clean up global scope.
+	 *
+	 * @global WP_Scripts $wp_scripts
+	 * @global WP_Styles $wp_styles
+	 */
+	public function clean_up_global_scope() {
+		global $wp_styles;
+		parent::clean_up_global_scope();
+		$wp_styles = null;
+	}
+	/**
+	 * Tests that stored CSS is enqueued.
+	 *
+	 * @ticket 56467
+	 * @covers ::wp_enqueue_stored_styles
+	 */
+	public function test_should_enqueue_stored_styles() {
+		global $wp_styles;
+
+		$core_styles_to_enqueue = array(
+			array(
+				'selector'     => '.saruman',
+				'declarations' => array(
+					'color'        => 'white',
+					'height'       => '100px',
+					'border-style' => 'solid',
+				),
+			),
+		);
+
+		// Enqueue a block supports (core styles).
+		wp_style_engine_get_stylesheet_from_css_rules(
+			$core_styles_to_enqueue,
+			array(
+				'context' => 'block-supports',
+			)
+		);
+
+		$my_styles_to_enqueue = array(
+			array(
+				'selector'     => '.gandalf',
+				'declarations' => array(
+					'color'        => 'grey',
+					'height'       => '90px',
+					'border-style' => 'dotted',
+				),
+			),
+		);
+
+		// Enqueue some other styles.
+		wp_style_engine_get_stylesheet_from_css_rules(
+			$my_styles_to_enqueue,
+			array(
+				'context' => 'my-styles',
+			)
+		);
+
+		wp_enqueue_stored_styles();
+
+		$this->assertEquals(
+			array( '.saruman{color:white;height:100px;border-style:solid;}' ),
+			wp_styles()->registered['core-block-supports']->extra['after'],
+			'Registered styles with handle of "core-block-supports" do not match expected value from Style Engine store.'
+		);
+
+		$this->assertEquals(
+			array( '.gandalf{color:grey;height:90px;border-style:dotted;}' ),
+			wp_styles()->registered['wp-style-engine-my-styles']->extra['after'],
+			'Registered styles with handle of "wp-style-engine-my-styles" do not match expected value from the Style Engine store.'
+		);
+	}
+}


### PR DESCRIPTION
❗ BLOCKED by https://github.com/WordPress/wordpress-develop/pull/3199

Backporting changes to script-loader that enqueue block support styles stored by the style engine/

See tracking issue: https://github.com/WordPress/gutenberg/issues/43440

### Backporting the following changes

- https://github.com/WordPress/gutenberg/pull/42880

Trac ticket: https://core.trac.wordpress.org/ticket/56467

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
