### PR TITLE
Blocks: Add new `render` property in `block.json` for block types

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -235,6 +235,7 @@ function get_block_metadata_i18n_schema() {
  * @since 5.5.0
  * @since 5.7.0 Added support for `textdomain` field and i18n handling for all translatable fields.
  * @since 5.9.0 Added support for `variations` and `viewScript` fields.
+ * @since 6.1.0 Added support for `render` field.
  *
  * @param string $file_or_folder Path to the JSON file with metadata definition for
  *                               the block or path to the folder where the `block.json` file is located.
@@ -343,6 +344,33 @@ function register_block_type_from_metadata( $file_or_folder, $args = array() ) {
 			$metadata,
 			'style'
 		);
+	}
+
+	if ( ! empty( $metadata['render'] ) ) {
+		$template_path = wp_normalize_path(
+			realpath(
+				dirname( $metadata['file'] ) . '/' .
+				remove_block_asset_path_prefix( $metadata['render'] )
+			)
+		);
+		if ( file_exists( $template_path ) ) {
+			/**
+			 * Renders the block on the server.
+			 *
+			 * @since 6.1.0
+			 *
+			 * @param array    $attributes Block attributes.
+			 * @param string   $content    Block default content.
+			 * @param WP_Block $block      Block instance.
+			 *
+			 * @return string Returns the block content.
+			 */
+			$settings['render_callback'] = function( $attributes, $content, $block ) use ( $template_path ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+				ob_start();
+				require $template_path;
+				return ob_get_clean();
+			};
+		}
 	}
 
 	/**

--- a/tests/phpunit/data/blocks/notice/block.json
+++ b/tests/phpunit/data/blocks/notice/block.json
@@ -24,9 +24,7 @@
 	"textdomain": "notice",
 	"attributes": {
 		"message": {
-			"type": "string",
-			"source": "html",
-			"selector": ".message"
+			"type": "string"
 		}
 	},
 	"supports": {
@@ -61,5 +59,6 @@
 	"script": "tests-notice-script",
 	"viewScript": "tests-notice-view-script",
 	"editorStyle": "tests-notice-editor-style",
-	"style": "tests-notice-style"
+	"style": "tests-notice-style",
+	"render": "file:./render.php"
 }

--- a/tests/phpunit/data/blocks/notice/render.php
+++ b/tests/phpunit/data/blocks/notice/render.php
@@ -1,0 +1,1 @@
+<p <?php echo get_block_wrapper_attributes(); ?>><?php echo esc_html( $attributes['message'] ); ?></p>

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -390,8 +390,6 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 			array(
 				'message' => array(
 					'type'     => 'string',
-					'source'   => 'html',
-					'selector' => '.message',
 				),
 				'lock'    => array( 'type' => 'object' ),
 			),
@@ -455,6 +453,9 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 			wp_normalize_path( realpath( DIR_TESTDATA . '/blocks/notice/block.css' ) ),
 			wp_normalize_path( wp_styles()->get_data( 'unit-tests-test-block-style', 'path' ) )
 		);
+
+		// @ticket 53148
+		$this->assertIsCallable( $result->render_callback );
 	}
 
 	/**

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -389,7 +389,7 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 		$this->assertSame(
 			array(
 				'message' => array(
-					'type'     => 'string',
+					'type' => 'string',
 				),
 				'lock'    => array( 'type' => 'object' ),
 			),

--- a/tests/phpunit/tests/blocks/render.php
+++ b/tests/phpunit/tests/blocks/render.php
@@ -47,6 +47,9 @@ class Tests_Blocks_Render extends WP_UnitTestCase {
 		if ( $registry->is_registered( 'core/dynamic' ) ) {
 			$registry->unregister( 'core/dynamic' );
 		}
+		if ( $registry->is_registered( 'tests/notice' ) ) {
+			$registry->unregister( 'tests/notice' );
+		}
 
 		parent::tear_down();
 	}
@@ -236,6 +239,19 @@ class Tests_Blocks_Render extends WP_UnitTestCase {
 			"File '$html_path' does not match expected value"
 		);
 	}
+
+	/**
+	 * @ticket 53148
+	 */
+	public function test_render_field_in_block_json() {
+		$result = register_block_type(
+			DIR_TESTDATA . '/blocks/notice'
+		);
+
+		$actual_content = do_blocks( '<!-- wp:tests/notice {"message":"Hello from the test"} --><!-- /wp:tests/notice -->' );
+		$this->assertSame( '<p class="wp-block-tests-notice">Hello from the test</p>', trim( $actual_content ) );
+	}
+
 
 	/**
 	 * @ticket 45109


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/53148

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
