### PR TITLE
Backport `build_query_vars_from_query_block` changes

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1094,6 +1094,7 @@ function wp_migrate_old_typography_shape( $metadata ) {
  * It's used in Query Loop, Query Pagination Numbers and Query Pagination Next blocks.
  *
  * @since 5.8.0
+ * @since 6.1.0 Added `query_loop_block_query_vars` filter and `parents` support in query.
  *
  * @param WP_Block $block Block instance.
  * @param int      $page  Current query's page.
@@ -1194,8 +1195,32 @@ function build_query_vars_from_query_block( $block, $page ) {
 		if ( ! empty( $block->context['query']['search'] ) ) {
 			$query['s'] = $block->context['query']['search'];
 		}
+		if ( ! empty( $block->context['query']['parents'] ) && is_post_type_hierarchical( $query['post_type'] ) ) {
+			$query['post_parent__in'] = array_filter( array_map( 'intval', $block->context['query']['parents'] ) );
+		}
 	}
-	return $query;
+
+	/**
+	 * Filters the arguments which will be passed to `WP_Query` for the Query Loop Block.
+	 *
+	 * Anything to this filter should be compatible with the `WP_Query` API to form
+	 * the query context which will be passed down to the Query Loop Block's children.
+	 * This can help, for example, to include additional settings or meta queries not
+	 * directly supported by the core Query Loop Block, and extend its capabilities.
+	 *
+	 * Please note that this will only influence the query that will be rendered on the
+	 * front-end. The editor preview is not affected by this filter. Also, worth noting
+	 * that the editor preview uses the REST API, so, ideally, one should aim to provide
+	 * attributes which are also compatible with the REST API, in order to be able to
+	 * implement identical queries on both sides.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @param array    $query Array containing parameters for `WP_Query` as parsed by the block context.
+	 * @param WP_Block $block Block instance.
+	 * @param int      $page  Current query's page.
+	 */
+	return apply_filters( 'query_loop_block_query_vars', $query, $block, $page );
 }
 
 /**

--- a/tests/phpunit/tests/blocks/wpBlock.php
+++ b/tests/phpunit/tests/blocks/wpBlock.php
@@ -437,6 +437,7 @@ class Tests_Blocks_wpBlock extends WP_UnitTestCase {
 				'categoryIds' => array( 56 ),
 				'orderBy'     => 'title',
 				'tagIds'      => array( 3, 11, 10 ),
+				'parents'     => array( 1, 2 ),
 			),
 		);
 		$block         = new WP_Block( $parsed_block, $context, $this->registry );
@@ -445,11 +446,11 @@ class Tests_Blocks_wpBlock extends WP_UnitTestCase {
 		$this->assertSame(
 			$query,
 			array(
-				'post_type'    => 'page',
-				'order'        => 'DESC',
-				'orderby'      => 'title',
-				'post__not_in' => array( 1, 2 ),
-				'tax_query'    => array(
+				'post_type'       => 'page',
+				'order'           => 'DESC',
+				'orderby'         => 'title',
+				'post__not_in'    => array( 1, 2 ),
+				'tax_query'       => array(
 					array(
 						'taxonomy'         => 'category',
 						'terms'            => array( 56 ),
@@ -461,6 +462,7 @@ class Tests_Blocks_wpBlock extends WP_UnitTestCase {
 						'include_children' => false,
 					),
 				),
+				'post_parent__in' => array( 1, 2 ),
 			)
 		);
 	}
@@ -580,6 +582,42 @@ class Tests_Blocks_wpBlock extends WP_UnitTestCase {
 				'post__not_in'   => array(),
 				'offset'         => 12,
 				'posts_per_page' => 5,
+			)
+		);
+	}
+
+	/**
+	 * @ticket 56467
+	 */
+	public function test_query_loop_block_query_vars_filter() {
+		$this->registry->register(
+			'core/example',
+			array( 'uses_context' => array( 'query' ) )
+		);
+
+		$parsed_blocks = parse_blocks( '<!-- wp:example {"ok":true} -->a<!-- wp:example /-->b<!-- /wp:example -->' );
+		$parsed_block  = $parsed_blocks[0];
+		$context       = array(
+			'query' => array(
+				'postType' => 'page',
+				'orderBy'  => 'title',
+			),
+		);
+		$block         = new WP_Block( $parsed_block, $context, $this->registry );
+		function filterQuery( $query, $block, $page ) {
+			$query['post_type'] = 'book';
+			return $query;
+		}
+		add_filter( 'query_loop_block_query_vars', 'filterQuery', 10, 3 );
+		$query = build_query_vars_from_query_block( $block, 1 );
+		remove_filter( 'query_loop_block_query_vars', 'filterQuery' );
+		$this->assertSame(
+			$query,
+			array(
+				'post_type'    => 'book',
+				'order'        => 'DESC',
+				'orderby'      => 'title',
+				'post__not_in' => array(),
 			)
 		);
 	}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/56467


Backports changes from:
- https://github.com/WordPress/gutenberg/pull/43590
- https://github.com/WordPress/gutenberg/pull/40933


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
