### PR TITLE
Introduce "include" and "exclude" params on /wp/v2/search endpoint

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-search-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-search-controller.php
@@ -331,6 +331,24 @@ class WP_REST_Search_Controller extends WP_REST_Controller {
 			'sanitize_callback' => array( $this, 'sanitize_subtypes' ),
 		);
 
+		$query_params['exclude'] = array(
+			'description' => __( 'Ensure result set excludes specific IDs.' ),
+			'type'        => 'array',
+			'items'       => array(
+				'type' => 'integer',
+			),
+			'default'     => array(),
+		);
+
+		$query_params['include'] = array(
+			'description' => __( 'Limit result set to specific IDs.' ),
+			'type'        => 'array',
+			'items'       => array(
+				'type' => 'integer',
+			),
+			'default'     => array(),
+		);
+
 		return $query_params;
 	}
 

--- a/src/wp-includes/rest-api/search/class-wp-rest-post-search-handler.php
+++ b/src/wp-includes/rest-api/search/class-wp-rest-post-search-handler.php
@@ -69,6 +69,14 @@ class WP_REST_Post_Search_Handler extends WP_REST_Search_Handler {
 			$query_args['s'] = $request['search'];
 		}
 
+		if ( ! empty( $request['exclude'] ) ) {
+			$query_args['post__not_in'] = $request['exclude'];
+		}
+
+		if ( ! empty( $request['include'] ) ) {
+			$query_args['post__in'] = $request['include'];
+		}
+
 		/**
 		 * Filters the query arguments for a REST API search request.
 		 *

--- a/src/wp-includes/rest-api/search/class-wp-rest-term-search-handler.php
+++ b/src/wp-includes/rest-api/search/class-wp-rest-term-search-handler.php
@@ -70,6 +70,14 @@ class WP_REST_Term_Search_Handler extends WP_REST_Search_Handler {
 			$query_args['search'] = $request['search'];
 		}
 
+		if ( ! empty( $request['exclude'] ) ) {
+			$query_args['exclude'] = $request['exclude'];
+		}
+
+		if ( ! empty( $request['include'] ) ) {
+			$query_args['include'] = $request['include'];
+		}
+
 		/**
 		 * Filters the query arguments for a REST API search request.
 		 *

--- a/tests/phpunit/tests/rest-api/rest-search-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-search-controller.php
@@ -819,4 +819,78 @@ class WP_Test_REST_Search_Controller extends WP_Test_REST_Controller_Testcase {
 		return $request;
 	}
 
+	/**
+	 * @ticket 56546
+	 */
+	public function test_get_items_search_posts_include_ids() {
+		$response = $this->do_request_with_params(
+			array(
+				'include' => array_slice( self::$my_title_post_ids, 1, 2 ),
+			)
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSameSets(
+			[ self::$my_title_post_ids[1], self::$my_title_post_ids[2] ],
+			wp_list_pluck( $response->get_data(), 'id' )
+		);
+	}
+
+	/**
+	 * @ticket 56546
+	 */
+	public function test_get_items_search_posts_exclude_ids() {
+		$response = $this->do_request_with_params(
+			array(
+				'exclude' => self::$my_title_page_ids,
+			)
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSameSets(
+			array_merge(
+				self::$my_title_post_ids,
+				self::$my_content_post_ids
+			),
+			wp_list_pluck( $response->get_data(), 'id' )
+		);
+	}
+
+	/**
+	 * @ticket 56546
+	 */
+	public function test_get_items_search_terms_include_ids() {
+		$response = $this->do_request_with_params(
+			array(
+				'include' => self::$my_tag_id,
+				'type'    => 'term',
+			)
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSameSets(
+			[ self::$my_tag_id ],
+			wp_list_pluck( $response->get_data(), 'id' )
+		);
+	}
+
+	/**
+	 * @ticket 56546
+	 */
+	public function test_get_items_search_terms_exclude_ids() {
+		$response = $this->do_request_with_params(
+			array(
+				// "1" is the default category.
+				'exclude' => [ 1, self::$my_tag_id ],
+				'type'    => 'term',
+			)
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSameSets(
+			[ self::$my_category_id ],
+			wp_list_pluck( $response->get_data(), 'id' )
+		);
+	}
+
 }

--- a/tests/phpunit/tests/rest-api/rest-search-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-search-controller.php
@@ -831,7 +831,7 @@ class WP_Test_REST_Search_Controller extends WP_Test_REST_Controller_Testcase {
 
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertSameSets(
-			[ self::$my_title_post_ids[1], self::$my_title_post_ids[2] ],
+			array( self::$my_title_post_ids[1], self::$my_title_post_ids[2] ),
 			wp_list_pluck( $response->get_data(), 'id' )
 		);
 	}
@@ -869,7 +869,7 @@ class WP_Test_REST_Search_Controller extends WP_Test_REST_Controller_Testcase {
 
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertSameSets(
-			[ self::$my_tag_id ],
+			array( self::$my_tag_id ),
 			wp_list_pluck( $response->get_data(), 'id' )
 		);
 	}
@@ -881,14 +881,14 @@ class WP_Test_REST_Search_Controller extends WP_Test_REST_Controller_Testcase {
 		$response = $this->do_request_with_params(
 			array(
 				// "1" is the default category.
-				'exclude' => [ 1, self::$my_tag_id ],
+				'exclude' => array( 1, self::$my_tag_id ),
 				'type'    => 'term',
 			)
 		);
 
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertSameSets(
-			[ self::$my_category_id ],
+			array( self::$my_category_id ),
 			wp_list_pluck( $response->get_data(), 'id' )
 		);
 	}

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -9269,6 +9269,24 @@ mockedApiResponse.Schema = {
                                 "type": "string"
                             },
                             "required": false
+                        },
+                        "exclude": {
+                            "description": "Ensure result set excludes specific IDs.",
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            },
+                            "default": [],
+                            "required": false
+                        },
+                        "include": {
+                            "description": "Limit result set to specific IDs.",
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            },
+                            "default": [],
+                            "required": false
                         }
                     }
                 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Permits retrieving a resource of unknown subtype, for example retrieving a custom post type object when you only know its ID with the "include" parameter. Alternatively, allows you to search without including results from a known list of target IDs with the "exclude" parameter.

Currently introduces include/exclude for post and term search controllers only.

Trac ticket: https://core.trac.wordpress.org/ticket/56546

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
