### PR TITLE
[Backport] Add `wp_theme_element_class_name()` alias

### DIFF
--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -4207,11 +4207,12 @@ function wp_is_block_theme() {
  * Given an element name, returns a class name.
  * Alias of WP_Theme_JSON::get_element_class_name.
  *
+ * @since 6.1.0
+ *
  * @param string $element The name of the element.
  *
  * @return string The name of the class.
  *
- * @since 6.1.0
  */
 function wp_theme_element_class_name( $element ) {
 	return WP_Theme_JSON::get_element_class_name( $element );

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -4205,7 +4205,7 @@ function wp_is_block_theme() {
 
 /**
  * Given an element name, returns a class name.
- * Alias from WP_Theme_JSON::get_element_class_name.
+ * Alias of WP_Theme_JSON::get_element_class_name.
  *
  * @param string $element The name of the element.
  *

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -4212,7 +4212,6 @@ function wp_is_block_theme() {
  * @param string $element The name of the element.
  *
  * @return string The name of the class.
- *
  */
 function wp_theme_element_class_name( $element ) {
 	return WP_Theme_JSON::get_element_class_name( $element );

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -4213,7 +4213,7 @@ function wp_is_block_theme() {
  *
  * @return string The name of the class.
  */
-function wp_theme_element_class_name( $element ) {
+function wp_theme_get_element_class_name( $element ) {
 	return WP_Theme_JSON::get_element_class_name( $element );
 }
 

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -4204,6 +4204,20 @@ function wp_is_block_theme() {
 }
 
 /**
+ * Given an element name, returns a class name.
+ * Alias from WP_Theme_JSON::get_element_class_name.
+ *
+ * @param string $element The name of the element.
+ *
+ * @return string The name of the class.
+ *
+ * @since 6.1.0
+ */
+function wp_theme_element_class_name( $element ) {
+	return WP_Theme_JSON::get_element_class_name( $element );
+}
+
+/**
  * Adds default theme supports for block themes when the 'setup_theme' action fires.
  *
  * See {@see 'setup_theme'}.


### PR DESCRIPTION
Add `wp_theme_element_class_name()` alias for the "internal" `WP_Theme_JSON::get_element_class_name()`.

Backport of @c4rl0sbr4v0s' https://github.com/WordPress/gutenberg/pull/44099.

See [this discussion](https://github.com/WordPress/wordpress-develop/pull/3154#discussion_r962832417) for the rationale.

Note that I've opted not to replace calls to `WP_Theme_JSON::get_element_class_name` in the [tests](https://github.com/WordPress/wordpress-develop/blob/3381f05fa241daf172d6c1c893fd25959c3b0656/tests/phpunit/tests/theme/wpThemeJson.php#L2945-L2963) -- since those are specifically for the `WP_Theme_JSON` class.

Trac ticket: https://core.trac.wordpress.org/ticket/56467

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
