### PR TITLE
Add hooks to filter `theme.json` data

### DIFF
--- a/src/wp-includes/class-wp-theme-json-data.php
+++ b/src/wp-includes/class-wp-theme-json-data.php
@@ -33,6 +33,8 @@ class WP_Theme_JSON_Data {
 	 *
 	 * @since 6.1.0
 	 *
+	 * @link https://developer.wordpress.org/block-editor/reference-guides/theme-json-reference/
+	 *
 	 * @param array  $data   Array following the theme.json specification.
 	 * @param string $origin The origin of the data: default, theme, user.
 	 */

--- a/src/wp-includes/class-wp-theme-json-data.php
+++ b/src/wp-includes/class-wp-theme-json-data.php
@@ -56,7 +56,8 @@ class WP_Theme_JSON_Data {
 	}
 
 	/**
-	 * Returns the underlying data.
+	 * Returns an array containing the underlying data
+	 * following the theme.json specification.
 	 *
 	 * @since 6.1.0
 	 *

--- a/src/wp-includes/class-wp-theme-json-data.php
+++ b/src/wp-includes/class-wp-theme-json-data.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * WP_Theme_JSON_Data class
+ *
+ * @package WordPress
+ * @subpackage Theme
+ * @since 6.1.0
+ */
+
+/**
+ * Class to provide access to update a theme.json structure.
+ */
+class WP_Theme_JSON_Data {
+
+	/**
+	 * Container of the data to update.
+	 *
+     * @since 6.1.0
+	 * @var WP_Theme_JSON
+	 */
+	private $theme_json = null;
+
+	/**
+	 * The origin of the data: default, theme, user, etc.
+	 *
+     * @since 6.1.0
+	 * @var string
+	 */
+	private $origin = '';
+
+	/**
+	 * Constructor.
+	 *
+     * @since 6.1.0
+     *
+	 * @param array  $data   Array following the theme.json specification.
+	 * @param string $origin The origin of the data: default, theme, user.
+	 */
+	public function __construct( $data = array(), $origin = 'theme' ) {
+		$this->origin     = $origin;
+		$this->theme_json = new WP_Theme_JSON( $data, $this->origin );
+	}
+
+	/**
+	 * Updates the theme.json with the the given data.
+	 *
+     * @since 6.1.0
+     *
+	 * @param array $new_data Array following the theme.json specification.
+	 *
+	 * @return WP_Theme_JSON_Data The own instance with access to the modified data.
+	 */
+	public function update_with( $new_data ) {
+		$this->theme_json->merge( new WP_Theme_JSON( $new_data, $this->origin ) );
+		return $this;
+	}
+
+	/**
+	 * Returns the underlying data.
+     *
+     * @since 6.1.0
+	 *
+	 * @return array
+	 */
+	public function get_data() {
+		return $this->theme_json->get_raw_data();
+	}
+
+}

--- a/src/wp-includes/class-wp-theme-json-data.php
+++ b/src/wp-includes/class-wp-theme-json-data.php
@@ -15,7 +15,7 @@ class WP_Theme_JSON_Data {
 	/**
 	 * Container of the data to update.
 	 *
-     * @since 6.1.0
+	 * @since 6.1.0
 	 * @var WP_Theme_JSON
 	 */
 	private $theme_json = null;
@@ -23,7 +23,7 @@ class WP_Theme_JSON_Data {
 	/**
 	 * The origin of the data: default, theme, user, etc.
 	 *
-     * @since 6.1.0
+	 * @since 6.1.0
 	 * @var string
 	 */
 	private $origin = '';
@@ -31,8 +31,8 @@ class WP_Theme_JSON_Data {
 	/**
 	 * Constructor.
 	 *
-     * @since 6.1.0
-     *
+	 * @since 6.1.0
+	 *
 	 * @param array  $data   Array following the theme.json specification.
 	 * @param string $origin The origin of the data: default, theme, user.
 	 */
@@ -44,8 +44,8 @@ class WP_Theme_JSON_Data {
 	/**
 	 * Updates the theme.json with the the given data.
 	 *
-     * @since 6.1.0
-     *
+	 * @since 6.1.0
+	 *
 	 * @param array $new_data Array following the theme.json specification.
 	 *
 	 * @return WP_Theme_JSON_Data The own instance with access to the modified data.
@@ -57,8 +57,8 @@ class WP_Theme_JSON_Data {
 
 	/**
 	 * Returns the underlying data.
-     *
-     * @since 6.1.0
+	 *
+	 * @since 6.1.0
 	 *
 	 * @return array
 	 */

--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -140,6 +140,8 @@ class WP_Theme_JSON_Resolver {
 		/**
 		 * Filters the default data provided by WordPress for global styles & settings.
 		 *
+		 * @since 6.1.0
+		 *
 		 * @param WP_Theme_JSON_Data Class to access and update the underlying data.
 		 */
 		$theme_json   = apply_filters( 'theme_json_default', new WP_Theme_JSON_Data( $config, 'default' ) );
@@ -181,6 +183,8 @@ class WP_Theme_JSON_Resolver {
 			$theme_json_data = static::translate( $theme_json_data, wp_get_theme()->get( 'TextDomain' ) );
 			/**
 			 * Filters the data provided by the theme for global styles & settings.
+			 *
+			 * @since 6.1.0
 			 *
 			 * @param WP_Theme_JSON_Data Class to access and update the underlying data.
 			 */
@@ -274,6 +278,8 @@ class WP_Theme_JSON_Resolver {
 
 		/**
 		 * Filters the data provided by the blocks for global styles & settings.
+		 *
+		 * @since 6.1.0
 		 *
 		 * @param WP_Theme_JSON_Data Class to access and update the underlying data.
 		 */
@@ -402,6 +408,8 @@ class WP_Theme_JSON_Resolver {
 				/**
 				 * Filters the data provided by the user for global styles & settings.
 				 *
+				 * @since 6.1.0
+				 *
 				 * @param WP_Theme_JSON_Data Class to access and update the underlying data.
 				 */
 				$theme_json = apply_filters( 'theme_json_user', new WP_Theme_JSON_Data( $config, 'custom' ) );
@@ -423,6 +431,8 @@ class WP_Theme_JSON_Resolver {
 
 		/**
 		 * Filters the data provided by the user for global styles & settings.
+		 *
+		 * @since 6.1.0
 		 *
 		 * @param WP_Theme_JSON_Data Class to access and update the underlying data.
 		 */

--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -137,6 +137,13 @@ class WP_Theme_JSON_Resolver {
 
 		$config       = static::read_json_file( __DIR__ . '/theme.json' );
 		$config       = static::translate( $config );
+		/**
+		 * Filters the default data provided by WordPress for global styles & settings.
+		 *
+		 * @param WP_Theme_JSON_Data Class to access and update the underlying data.
+		 */
+		$theme_json   = apply_filters( 'global_styles_default', new WP_Theme_JSON_Data( $config, 'default' ) );
+		$config       = $theme_json->get_data();
 		static::$core = new WP_Theme_JSON( $config, 'default' );
 
 		return static::$core;
@@ -172,6 +179,13 @@ class WP_Theme_JSON_Resolver {
 		if ( null === static::$theme ) {
 			$theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json' ) );
 			$theme_json_data = static::translate( $theme_json_data, wp_get_theme()->get( 'TextDomain' ) );
+			/**
+			 * Filters the data provided by the theme for global styles & settings.
+			 *
+			 * @param WP_Theme_JSON_Data Class to access and update the underlying data.
+			 */
+			$theme_json      = apply_filters( 'global_styles_theme', new WP_Theme_JSON_Data( $theme_json_data, 'theme' ) );
+			$theme_json_data = $theme_json->get_data();
 			static::$theme   = new WP_Theme_JSON( $theme_json_data );
 
 			if ( wp_get_theme()->parent() ) {
@@ -257,6 +271,14 @@ class WP_Theme_JSON_Resolver {
 				$config['styles']['blocks'][ $block_name ]['spacing']['blockGap'] = null;
 			}
 		}
+
+		/**
+		 * Filters the data provided by the blocks for global styles & settings.
+		 *
+		 * @param WP_Theme_JSON_Data Class to access and update the underlying data.
+		 */
+		$theme_json = apply_filters( 'global_styles_blocks', new WP_Theme_JSON_Data( $config, 'core' ) );
+		$config     = $theme_json->get_data();
 
 		// Core here means it's the lower level part of the styles chain.
 		// It can be a core or a third-party block.
@@ -377,6 +399,13 @@ class WP_Theme_JSON_Resolver {
 			$json_decoding_error = json_last_error();
 			if ( JSON_ERROR_NONE !== $json_decoding_error ) {
 				trigger_error( 'Error when decoding a theme.json schema for user data. ' . json_last_error_msg() );
+				/**
+				 * Filters the data provided by the user for global styles & settings.
+				 *
+				 * @param WP_Theme_JSON_Data Class to access and update the underlying data.
+				 */
+				$theme_json = apply_filters( 'global_styles_user', new WP_Theme_JSON_Data( $config, 'custom' ) );
+				$config     = $theme_json->get_data();
 				return new WP_Theme_JSON( $config, 'custom' );
 			}
 
@@ -391,6 +420,14 @@ class WP_Theme_JSON_Resolver {
 				$config = $decoded_data;
 			}
 		}
+
+		/**
+		 * Filters the data provided by the user for global styles & settings.
+		 *
+		 * @param WP_Theme_JSON_Data Class to access and update the underlying data.
+		 */
+		$theme_json   = apply_filters( 'global_styles_user', new WP_Theme_JSON_Data( $config, 'custom' ) );
+		$config       = $theme_json->get_data();
 		static::$user = new WP_Theme_JSON( $config, 'custom' );
 
 		return static::$user;

--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -142,7 +142,7 @@ class WP_Theme_JSON_Resolver {
 		 *
 		 * @param WP_Theme_JSON_Data Class to access and update the underlying data.
 		 */
-		$theme_json   = apply_filters( 'global_styles_default', new WP_Theme_JSON_Data( $config, 'default' ) );
+		$theme_json   = apply_filters( 'theme_json_default', new WP_Theme_JSON_Data( $config, 'default' ) );
 		$config       = $theme_json->get_data();
 		static::$core = new WP_Theme_JSON( $config, 'default' );
 
@@ -184,7 +184,7 @@ class WP_Theme_JSON_Resolver {
 			 *
 			 * @param WP_Theme_JSON_Data Class to access and update the underlying data.
 			 */
-			$theme_json      = apply_filters( 'global_styles_theme', new WP_Theme_JSON_Data( $theme_json_data, 'theme' ) );
+			$theme_json      = apply_filters( 'theme_json_theme', new WP_Theme_JSON_Data( $theme_json_data, 'theme' ) );
 			$theme_json_data = $theme_json->get_data();
 			static::$theme   = new WP_Theme_JSON( $theme_json_data );
 
@@ -277,7 +277,7 @@ class WP_Theme_JSON_Resolver {
 		 *
 		 * @param WP_Theme_JSON_Data Class to access and update the underlying data.
 		 */
-		$theme_json = apply_filters( 'global_styles_blocks', new WP_Theme_JSON_Data( $config, 'core' ) );
+		$theme_json = apply_filters( 'theme_json_blocks', new WP_Theme_JSON_Data( $config, 'core' ) );
 		$config     = $theme_json->get_data();
 
 		// Core here means it's the lower level part of the styles chain.
@@ -404,7 +404,7 @@ class WP_Theme_JSON_Resolver {
 				 *
 				 * @param WP_Theme_JSON_Data Class to access and update the underlying data.
 				 */
-				$theme_json = apply_filters( 'global_styles_user', new WP_Theme_JSON_Data( $config, 'custom' ) );
+				$theme_json = apply_filters( 'theme_json_user', new WP_Theme_JSON_Data( $config, 'custom' ) );
 				$config     = $theme_json->get_data();
 				return new WP_Theme_JSON( $config, 'custom' );
 			}
@@ -426,7 +426,7 @@ class WP_Theme_JSON_Resolver {
 		 *
 		 * @param WP_Theme_JSON_Data Class to access and update the underlying data.
 		 */
-		$theme_json   = apply_filters( 'global_styles_user', new WP_Theme_JSON_Data( $config, 'custom' ) );
+		$theme_json   = apply_filters( 'theme_json_user', new WP_Theme_JSON_Data( $config, 'custom' ) );
 		$config       = $theme_json->get_data();
 		static::$user = new WP_Theme_JSON( $config, 'custom' );
 

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -172,6 +172,7 @@ require ABSPATH . WPINC . '/class-wp-date-query.php';
 require ABSPATH . WPINC . '/theme.php';
 require ABSPATH . WPINC . '/class-wp-theme.php';
 require ABSPATH . WPINC . '/class-wp-theme-json-schema.php';
+require ABSPATH . WPINC . '/class-wp-theme-json-data.php';
 require ABSPATH . WPINC . '/class-wp-theme-json.php';
 require ABSPATH . WPINC . '/class-wp-theme-json-resolver.php';
 require ABSPATH . WPINC . '/global-styles-and-settings.php';


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/56467

Backports https://github.com/WordPress/gutenberg/pull/44015 https://github.com/WordPress/gutenberg/pull/44109 https://github.com/WordPress/gutenberg/pull/44159

This PR ports the work done in Gutenberg (to be released in 14.1) to add hooks to filter the `theme.json` data. Specifically, it adds the following filters: `theme_json_default`, `theme_json_blocks`, `theme_json_theme``theme_json_user`.
