### PR TITLE
Add check and warning before bumping the minimum PHP version

### DIFF
--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -1186,7 +1186,8 @@ a.rsswidget {
 	padding-right: 6px;
 }
 
-#dashboard_php_nag.php-insecure .dashicons-warning {
+#dashboard_php_nag.php-no-security-updates .dashicons-warning,
+#dashboard_php_nag.php-version-lower-than-future-minimum .dashicons-warning {
 	color: #d63638;
 }
 
@@ -1198,12 +1199,13 @@ a.rsswidget {
 	margin: 12px 0;
 }
 
-#dashboard_php_nag h3 {
-	font-weight: 600;
-}
-
 #dashboard_php_nag .button .dashicons-external {
 	line-height: 25px;
+}
+
+.bigger-bolder-text {
+	font-weight: 600;
+	font-size: 14px;
 }
 
 /* =Media Queries

--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -1585,7 +1585,8 @@ function wp_check_php_version() {
 		 *  'recommended_version' - string - The PHP version recommended by WordPress.
 		 *  'is_supported' - boolean - Whether the PHP version is actively supported.
 		 *  'is_secure' - boolean - Whether the PHP version receives security updates.
-		 *  'is_acceptable' - boolean - Whether the PHP version is still acceptable for WordPress.
+		 *  'is_acceptable' - boolean - Whether the PHP version is still acceptable or warnings
+		 *                              should be shown and an update recommended.
 		 */
 		$response = json_decode( wp_remote_retrieve_body( $response ), true );
 
@@ -1611,6 +1612,16 @@ function wp_check_php_version() {
 		 * @param string $version       PHP version checked.
 		 */
 		$response['is_acceptable'] = (bool) apply_filters( 'wp_is_php_version_acceptable', true, $version );
+	}
+
+	$response['is_lower_than_future_minimum'] = false;
+
+	// The minimum supported PHP version will be updated to 7.2. Check if the current version is lower.
+	if ( version_compare( $version, '7.2', '<' ) ) {
+		$response['is_lower_than_future_minimum'] = true;
+
+		// Force showing of warnings.
+		$response['is_acceptable'] = false;
 	}
 
 	return $response;


### PR DESCRIPTION
Show Site Health and Dasboard's ServerHappy warnings when the current PHP version will be lower than the minimum supported PHP version when bumped up in the near future.

Trac ticket: https://core.trac.wordpress.org/ticket/56199

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
