### PR TITLE
Feature: Block-based template parts for Classic themes

### DIFF
--- a/src/wp-admin/menu.php
+++ b/src/wp-admin/menu.php
@@ -214,12 +214,20 @@ if ( wp_is_block_theme() ) {
 	);
 }
 
+if ( ! wp_is_block_theme() && current_theme_supports( 'block-template-parts' ) ) {
+	$submenu['themes.php'][6] = array(
+		__( 'Template Parts' ),
+		'edit_theme_options',
+		'site-editor.php?postType=wp_template_part',
+	);
+}
+
 $customize_url = add_query_arg( 'return', urlencode( remove_query_arg( wp_removable_query_args(), wp_unslash( $_SERVER['REQUEST_URI'] ) ) ), 'customize.php' );
 
 // Hide Customize link on block themes unless a plugin or theme
 // is using 'customize_register' to add a setting.
 if ( ! wp_is_block_theme() || has_action( 'customize_register' ) ) {
-	$position = wp_is_block_theme() ? 7 : 6;
+	$position = ( wp_is_block_theme() || current_theme_supports( 'block-template-parts' ) ) ? 7 : 6;
 
 	$submenu['themes.php'][ $position ] = array( __( 'Customize' ), 'customize', esc_url( $customize_url ), '', 'hide-if-no-customize' );
 }

--- a/src/wp-admin/site-editor.php
+++ b/src/wp-admin/site-editor.php
@@ -19,7 +19,7 @@ if ( ! current_user_can( 'edit_theme_options' ) ) {
 	);
 }
 
-if ( ! wp_is_block_theme() ) {
+if ( ! ( current_theme_supports( 'block-template-parts' ) || wp_is_block_theme() ) ) {
 	wp_die( __( 'The theme you are currently using is not compatible with Full Site Editing.' ) );
 }
 
@@ -64,13 +64,23 @@ foreach ( get_default_block_template_types() as $slug => $template_type ) {
 
 $block_editor_context = new WP_Block_Editor_Context( array( 'name' => 'core/edit-site' ) );
 $custom_settings      = array(
-	'siteUrl'                  => site_url(),
-	'postsPerPage'             => get_option( 'posts_per_page' ),
-	'styles'                   => get_block_editor_theme_styles(),
-	'defaultTemplateTypes'     => $indexed_template_types,
-	'defaultTemplatePartAreas' => get_allowed_block_template_part_areas(),
-	'__unstableHomeTemplate'   => $home_template,
+	'siteUrl'                   => site_url(),
+	'postsPerPage'              => get_option( 'posts_per_page' ),
+	'styles'                    => get_block_editor_theme_styles(),
+	'defaultTemplateTypes'      => $indexed_template_types,
+	'defaultTemplatePartAreas'  => get_allowed_block_template_part_areas(),
+	'supportsLayout'            => WP_Theme_JSON_Resolver::theme_has_support(),
+	'supportsTemplatePartsMode' => ! wp_is_block_theme() && current_theme_supports( 'block-template-parts' ),
+	'__unstableHomeTemplate'    => $home_template,
 );
+
+/**
+ * We don't need home template resolution when block template parts are supported.
+ * Set the value to true to satisfy the editor initialization guard clause.
+ */
+if ( $custom_settings['supportsTemplatePartsMode'] ) {
+	$custom_settings['__unstableHomeTemplate'] = true;
+}
 
 // Add additional back-compat patterns registered by `current_screen` et al.
 $custom_settings['__experimentalAdditionalBlockPatterns']          = WP_Block_Patterns_Registry::get_instance()->get_all_registered( true );

--- a/src/wp-admin/site-editor.php
+++ b/src/wp-admin/site-editor.php
@@ -23,6 +23,11 @@ if ( ! ( current_theme_supports( 'block-template-parts' ) || wp_is_block_theme()
 	wp_die( __( 'The theme you are currently using is not compatible with Full Site Editing.' ) );
 }
 
+$is_template_part_editor = isset( $_GET['postType'] ) && 'wp_template_part' === sanitize_key( $_GET['postType'] );
+if ( ! wp_is_block_theme() && ! $is_template_part_editor ) {
+	wp_die( __( 'The theme you are currently using is not compatible with the Site Editor.' ) );
+}
+
 /**
  * Do a server-side redirection if missing `postType` and `postId`
  * query args when visiting Site Editor.

--- a/src/wp-admin/site-editor.php
+++ b/src/wp-admin/site-editor.php
@@ -80,8 +80,8 @@ $custom_settings      = array(
 );
 
 /**
- * We don't need home template resolution when block template parts are supported.
- * Set the value to true to satisfy the editor initialization guard clause.
+ * Home template resolution is not needed when block template parts are supported.
+ * Set the value to `true` to satisfy the editor initialization guard clause.
  */
 if ( $custom_settings['supportsTemplatePartsMode'] ) {
 	$custom_settings['__unstableHomeTemplate'] = true;

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -5261,7 +5261,7 @@ function wp_widgets_add_menu() {
 	}
 
 	$menu_name = __( 'Widgets' );
-	if ( wp_is_block_theme() ) {
+	if ( wp_is_block_theme() || current_theme_supports( 'block-template-parts' ) ) {
 		$submenu['themes.php'][] = array( $menu_name, 'edit_theme_options', 'widgets.php' );
 	} else {
 		$submenu['themes.php'][7] = array( $menu_name, 'edit_theme_options', 'widgets.php' );

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -3844,6 +3844,13 @@ function create_initial_theme_features() {
 		)
 	);
 	register_theme_feature(
+		'block-template-parts',
+		array(
+			'description'  => __( 'Whether a theme uses block-based template parts.' ),
+			'show_in_rest' => true,
+		)
+	);
+	register_theme_feature(
 		'custom-background',
 		array(
 			'description'  => __( 'Custom background if defined by the theme.' ),

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -388,7 +388,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( 'align-wide', $theme_supports );
 		$this->assertArrayHasKey( 'automatic-feed-links', $theme_supports );
 		$this->assertArrayHasKey( 'block-templates', $theme_supports );
-		$this->assertArrayHasKey( 'block-template-parts', $theme_supports );
+		$this->assertArrayHasKey( 'block-template-parts', $theme_supports, "Theme supports should have 'block-template-parts' key"  );
 		$this->assertArrayHasKey( 'custom-header', $theme_supports );
 		$this->assertArrayHasKey( 'custom-background', $theme_supports );
 		$this->assertArrayHasKey( 'custom-logo', $theme_supports );
@@ -408,7 +408,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( 'responsive-embeds', $theme_supports );
 		$this->assertArrayHasKey( 'title-tag', $theme_supports );
 		$this->assertArrayHasKey( 'wp-block-styles', $theme_supports );
-		$this->assertCount( 23, $theme_supports );
+		$this->assertCount( 23, $theme_supports, 'There should be 23 theme supports' );
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -408,7 +408,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( 'responsive-embeds', $theme_supports );
 		$this->assertArrayHasKey( 'title-tag', $theme_supports );
 		$this->assertArrayHasKey( 'wp-block-styles', $theme_supports );
-		$this->assertCount( 22, $theme_supports );
+		$this->assertCount( 23, $theme_supports );
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -388,6 +388,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( 'align-wide', $theme_supports );
 		$this->assertArrayHasKey( 'automatic-feed-links', $theme_supports );
 		$this->assertArrayHasKey( 'block-templates', $theme_supports );
+		$this->assertArrayHasKey( 'block-template-parts', $theme_supports );
 		$this->assertArrayHasKey( 'custom-header', $theme_supports );
 		$this->assertArrayHasKey( 'custom-background', $theme_supports );
 		$this->assertArrayHasKey( 'custom-logo', $theme_supports );

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -388,7 +388,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( 'align-wide', $theme_supports );
 		$this->assertArrayHasKey( 'automatic-feed-links', $theme_supports );
 		$this->assertArrayHasKey( 'block-templates', $theme_supports );
-		$this->assertArrayHasKey( 'block-template-parts', $theme_supports, "Theme supports should have 'block-template-parts' key"  );
+		$this->assertArrayHasKey( 'block-template-parts', $theme_supports, "Theme supports should have 'block-template-parts' key" );
 		$this->assertArrayHasKey( 'custom-header', $theme_supports );
 		$this->assertArrayHasKey( 'custom-background', $theme_supports );
 		$this->assertArrayHasKey( 'custom-logo', $theme_supports );


### PR DESCRIPTION
Fork of @Mamaduka's https://github.com/WordPress/wordpress-develop/pull/3234, to apply [this small fix](https://github.com/WordPress/wordpress-develop/pull/3234#pullrequestreview-1108881653).

Quoting that PR's description:

> ## Testing Instructions
> **Classic theme - TT1**
> 
> * The new "Template Parts" menu shouldn't appear in Appearance.
> * Users can't access the `/wp-admin/site-editor.php` path directly.
> 
> **Block theme - TT2**
> 
> * The new "Template Parts" menu shouldn't appear in Appearance.
> * The "Editor" menu is accessible.
> * The Site Editor works as before.
> 
> **Themes with block-based templates part enabled** You can grab the testing theme from this repo - https://github.com/Mamaduka/block-fragments
> 
> * The new "Template Parts" menu is visible under Appearance.
> * The menu redirects to the "Template Parts" list view.
> * The "Site" and "Templates" navigation items aren't visible.
> 
> > Warning
> > The last item will require the latest package update PR to be merged, and it might not be possible to test immediately.

For any other details, please see the [original PR.](https://github.com/WordPress/wordpress-develop/pull/3234)

(@Mamaduka is AFK and gave me permission to fork his PR via DM.)

Gutenberg tracking issue: https://github.com/WordPress/gutenberg/issues/43440
Trac ticket: https://core.trac.wordpress.org/ticket/56467

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
