### PR TITLE
Add `theme_json_` prefix to hook name

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -1873,7 +1873,7 @@ class WP_Theme_JSON {
 		 *
 		 * @param array $nodes Style nodes with metadata.
 		 */
-		return apply_filters( 'get_style_nodes', $nodes );
+		return apply_filters( 'theme_json_get_style_nodes', $nodes );
 	}
 
 	/**

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2406,7 +2406,7 @@ function wp_enqueue_global_styles() {
 	 * This removes the CSS from the global-styles stylesheet and adds it to the inline CSS for each block.
 	 */
 	if ( $separate_assets ) {
-		add_filter( 'get_style_nodes', 'wp_filter_out_block_nodes' );
+		add_filter( 'theme_json_get_style_nodes', 'wp_filter_out_block_nodes' );
 		// Add each block as an inline css.
 		wp_add_global_styles_for_blocks();
 	}


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/56467
Backports https://github.com/WordPress/gutenberg/pull/44189

This PR consolidates the name of a filter introduced in this cycle, renaming it from `get_style_nodes` to `theme_json_get_style_nodes` as to be more coherent with the other hooks that we introduce in 6.1 as well, see https://github.com/WordPress/wordpress-develop/pull/3247