### PR TITLE
Test for variable type when checking page count in get_the_content

### DIFF
--- a/src/wp-includes/post-template.php
+++ b/src/wp-includes/post-template.php
@@ -318,9 +318,11 @@ function get_the_content( $more_link_text = null, $strip_teaser = false, $post =
 	}
 
 	// If the requested page doesn't exist.
-	if ( $elements['page'] > count( $elements['pages'] ) ) {
-		// Give them the highest numbered page that DOES exist.
-		$elements['page'] = count( $elements['pages'] );
+	if ( 'integer' === gettype( $elements['page'] ) && 'array' === gettype( $elements['pages'] ) ) { {
+		if ( $elements['page'] > count( $elements['pages'] ) ) {
+			// Give them the highest numbered page that DOES exist.
+			$elements['page'] = count( $elements['pages'] );
+		}
 	}
 
 	$page_no = $elements['page'];


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
Adds an if statement for the variable types of `$elements['page']` and `$elements['pages']` in function `get_the_content`, to address cases where they would be a different type than expected, including null, such as for a search request with no results where a plugin like Timber is used to assign $post a non-WordPress-core value.

Trac ticket: https://core.trac.wordpress.org/ticket/56590

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
