### PR TITLE
Fixing fatal error when dispatch returns WP_Error

### DIFF
--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -727,16 +727,8 @@ class WP_REST_Server {
 
 					$response = $this->dispatch( $request );
 
-					// Normalize to either WP_Error or WP_REST_Response...
-					$response = rest_ensure_response( $response );
-
-					// ...then convert WP_Error across.
-					if ( is_wp_error( $response ) ) {
-						$response = $this->error_to_response( $response );
-					}
-
 					/** This filter is documented in wp-includes/rest-api/class-wp-rest-server.php */
-					$response = apply_filters( 'rest_post_dispatch', $response, $this, $request );
+					$response = apply_filters( 'rest_post_dispatch', rest_ensure_response( $response ), $this, $request );
 
 					$this->embed_cache[ $item['href'] ] = $this->response_to_data( $response, false );
 				}
@@ -991,6 +983,15 @@ class WP_REST_Server {
 		$result = apply_filters( 'rest_pre_dispatch', null, $this, $request );
 
 		if ( ! empty( $result ) ) {
+		
+			// Normalize to either WP_Error or WP_REST_Response...
+			$result = rest_ensure_response( $result );
+
+			// ...then convert WP_Error across.
+			if ( is_wp_error( $result ) ) {
+				$result = $this->error_to_response( $result );
+			}
+
 			return $result;
 		}
 

--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -983,7 +983,7 @@ class WP_REST_Server {
 		$result = apply_filters( 'rest_pre_dispatch', null, $this, $request );
 
 		if ( ! empty( $result ) ) {
-		
+
 			// Normalize to either WP_Error or WP_REST_Response...
 			$result = rest_ensure_response( $result );
 

--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -727,8 +727,16 @@ class WP_REST_Server {
 
 					$response = $this->dispatch( $request );
 
+					// Normalize to either WP_Error or WP_REST_Response...
+					$response = rest_ensure_response( $response );
+
+					// ...then convert WP_Error across.
+					if ( is_wp_error( $response ) ) {
+						$response = $this->error_to_response( $response );
+					}
+
 					/** This filter is documented in wp-includes/rest-api/class-wp-rest-server.php */
-					$response = apply_filters( 'rest_post_dispatch', rest_ensure_response( $response ), $this, $request );
+					$response = apply_filters( 'rest_post_dispatch', $response, $this, $request );
 
 					$this->embed_cache[ $item['href'] ] = $this->response_to_data( $response, false );
 				}

--- a/tests/phpunit/tests/rest-api/rest-server.php
+++ b/tests/phpunit/tests/rest-api/rest-server.php
@@ -913,12 +913,10 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 	 * Ensure embedding is a no-op without links in the data.
 	 */
 	public function test_link_embedding_without_links() {
-		$data   = new WP_REST_Response(
-			array(
-				'untouched' => 'data',
-			)
+		$data   = array(
+			'untouched' => 'data',
 		);
-		$result = rest_get_server()->response_to_data( $data, true );
+		$result = rest_get_server()->embed_links( $data, true );
 
 		$this->assertArrayNotHasKey( '_links', $result );
 		$this->assertArrayNotHasKey( '_embedded', $result );

--- a/tests/phpunit/tests/rest-api/rest-server.php
+++ b/tests/phpunit/tests/rest-api/rest-server.php
@@ -934,13 +934,16 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 		};
 		add_filter( 'rest_pre_dispatch', $return_wp_error );
 
+		$mock = new MockAction();
+		add_filter( 'rest_post_dispatch', array( $mock, 'filter' ) );
+
 		$response = new WP_REST_Response();
 		$response->add_link( 'author', rest_url( 'test' ), array( 'embeddable' => true ) );
 
 		$data = rest_get_server()->response_to_data( $response, true );
 
 		$this->assertArrayHasKey( '_links', $data );
-		$this->assertSame( 1, did_filter( 'rest_post_dispatch' ) );
+		$this->assertCount( 1, $mock->get_events() );
 		$this->assertSame( 'some-error', $data['_embedded']['author'][0]['code'] );
 	}
 

--- a/tests/phpunit/tests/rest-api/rest-server.php
+++ b/tests/phpunit/tests/rest-api/rest-server.php
@@ -944,8 +944,6 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 		$this->assertArrayHasKey( '_links', $data );
 		$this->assertSame( 1, did_filter( 'rest_post_dispatch' ) );
 		$this->assertSame( 'some-error', $data['_embedded']['author'][0]['code'] );
-
-		remove_filter( 'rest_pre_dispatch', $return_wp_error );
 	}
 
 	public function embedded_response_callback( $request ) {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This PR is a version of [#3242](https://github.com/WordPress/wordpress-develop/pull/3242) with PHPUnit tests. Original PR description:

> Replicating treatment of potential WP_Error that is done in the serve_request() method to avoid fatal errors while processing WP_Error as if it were a WP_REST_Response.

Props to @davefx for the fix.

Trac ticket: https://core.trac.wordpress.org/ticket/56566

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
