### PR TITLE
Make sure fileupload_maxk is an int + tests for upload_size_limit_filter

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -4770,6 +4770,7 @@ function sanitize_option( $option, $value ) {
 		case 'users_can_register':
 		case 'start_of_week':
 		case 'site_icon':
+		case 'fileupload_maxk':
 			$value = absint( $value );
 			break;
 

--- a/src/wp-includes/ms-functions.php
+++ b/src/wp-includes/ms-functions.php
@@ -2706,12 +2706,14 @@ function is_upload_space_available() {
  * @return int Upload size limit in bytes.
  */
 function upload_size_limit_filter( $size ) {
-	$fileupload_maxk = KB_IN_BYTES * get_site_option( 'fileupload_maxk', 1500 );
+	$fileupload_maxk         = (int) get_site_option( 'fileupload_maxk', 1500 );
+	$max_fileupload_in_bytes = KB_IN_BYTES * $fileupload_maxk;
+
 	if ( get_site_option( 'upload_space_check_disabled' ) ) {
-		return min( $size, $fileupload_maxk );
+		return min( $size, $max_fileupload_in_bytes );
 	}
 
-	return min( $size, $fileupload_maxk, get_upload_space_available() );
+	return min( $size, $max_fileupload_in_bytes, get_upload_space_available() );
 }
 
 /**

--- a/tests/phpunit/tests/multisite/network.php
+++ b/tests/phpunit/tests/multisite/network.php
@@ -398,6 +398,54 @@ if ( is_multisite() ) :
 		}
 
 		/**
+		 * Test the default behavior of upload_size_limit_filter.
+		 * If any default option is changed, the function returns the min value between the
+		 * parameter passed and the `fileupload_maxk` site option (1500Kb by default)
+		 *
+		 * @ticket 55926
+		 */
+		public function test_upload_size_limit_filter() {
+			$return = upload_size_limit_filter( 1499 * KB_IN_BYTES );
+			$this->assertSame( 1499 * KB_IN_BYTES, $return );
+			$return = upload_size_limit_filter( 1501 * KB_IN_BYTES );
+			$this->assertSame( 1500 * KB_IN_BYTES, $return );
+		}
+
+		/**
+		 * Test if upload_size_limit_filter behaves as expected when the `fileupload_maxk` is 0 or an empty string.
+		 *
+		 * @ticket 55926
+		 * @dataProvider data_upload_size_limit_filter_empty_fileupload_maxk
+		 */
+		public function test_upload_size_limit_filter_empty_fileupload_maxk( $callable_set_fileupload_maxk ) {
+			add_filter( 'site_option_fileupload_maxk', $callable_set_fileupload_maxk );
+			$return = upload_size_limit_filter( 1500 );
+			$this->assertSame( 0, $return );
+		}
+
+		/**
+		 * @ticket 55926
+		 */
+		public function data_upload_size_limit_filter_empty_fileupload_maxk() {
+			return array(
+				array( '__return_zero' ),
+				array( '__return_empty_string' ),
+			);
+		}
+
+		/**
+		 * When upload_space_check is enabled, the space allowed is also considered by `upload_size_limit_filter`.
+		 *
+		 * @ticket 55926
+		 */
+		public function test_upload_size_limit_filter_when_upload_space_check_enabled() {
+			add_filter( 'get_space_allowed', '__return_zero' );
+			add_filter( 'site_option_upload_space_check_disabled', '__return_false' );
+			$return = upload_size_limit_filter( 100 );
+			$this->assertSame( 0, $return );
+		}
+
+		/**
 		 * @ticket 40489
 		 * @dataProvider data_wp_is_large_network
 		 */


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This PR uses the solution from https://core.trac.wordpress.org/attachment/ticket/55926/55926.diff and also casts the `fileupload_maxk` site option to an int in `upload_size_limit_filter()`. It also adds some unit tests for that function.

Trac ticket: https://core.trac.wordpress.org/ticket/55926

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
