### PR TITLE
Reverse wrapping of `apply_shortcodes()` and `do_shortcode()`.

### DIFF
--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3788,7 +3788,7 @@ function wp_ajax_parse_embed() {
 			$styles .= sprintf( '<link rel="stylesheet" href="%s" />', $style );
 		}
 
-		$html = do_shortcode( $parsed );
+		$html = apply_shortcodes( $parsed );
 
 		global $wp_scripts;
 
@@ -3861,7 +3861,7 @@ function wp_ajax_parse_media_shortcode() {
 		setup_postdata( $post );
 	}
 
-	$parsed = do_shortcode( $shortcode );
+	$parsed = apply_shortcodes( $shortcode );
 
 	if ( empty( $parsed ) ) {
 		wp_send_json_error(

--- a/src/wp-includes/block-template.php
+++ b/src/wp-includes/block-template.php
@@ -242,7 +242,7 @@ function get_the_block_template_html() {
 	$content = convert_smilies( $content );
 	$content = shortcode_unautop( $content );
 	$content = wp_filter_content_tags( $content );
-	$content = do_shortcode( $content );
+	$content = apply_shortcodes( $content );
 	$content = str_replace( ']]>', ']]&gt;', $content );
 
 	// Wrap block template in .wp-site-blocks to allow for specific descendant styles

--- a/src/wp-includes/class-wp-embed.php
+++ b/src/wp-includes/class-wp-embed.php
@@ -52,7 +52,7 @@ class WP_Embed {
 	 *
 	 * Since the [embed] shortcode needs to be run earlier than other shortcodes,
 	 * this function removes all existing shortcodes, registers the [embed] shortcode,
-	 * calls do_shortcode(), and then re-registers the old shortcodes.
+	 * calls apply_shortcodes(), and then re-registers the old shortcodes.
 	 *
 	 * @global array $shortcode_tags
 	 *
@@ -177,7 +177,7 @@ class WP_Embed {
 	}
 
 	/**
-	 * The do_shortcode() callback function.
+	 * The apply_shortcodes() callback function.
 	 *
 	 * Attempts to convert a URL into embed HTML. Starts by checking the URL against the regex of
 	 * the registered embed handlers. If none of the regex matches and it's enabled, then the URL

--- a/src/wp-includes/class-wp-embed.php
+++ b/src/wp-includes/class-wp-embed.php
@@ -69,7 +69,7 @@ class WP_Embed {
 		add_shortcode( 'embed', array( $this, 'shortcode' ) );
 
 		// Do the shortcode (only the [embed] one is registered).
-		$content = do_shortcode( $content, true );
+		$content = apply_shortcodes( $content, true );
 
 		// Put the original shortcodes back.
 		$shortcode_tags = $orig_shortcode_tags;

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -228,7 +228,7 @@ add_filter( 'widget_text_content', 'do_shortcode', 11 ); // Runs after wpautop()
 
 add_filter( 'widget_block_content', 'do_blocks', 9 );
 add_filter( 'widget_block_content', 'wp_filter_content_tags' );
-add_filter( 'widget_block_content', 'do_shortcode', 11 );
+add_filter( 'widget_block_content', 'apply_shortcodes', 11 );
 
 add_filter( 'block_type_metadata', 'wp_migrate_old_typography_shape' );
 
@@ -605,7 +605,7 @@ add_action( 'template_redirect', 'redirect_canonical' );
 add_action( 'template_redirect', 'wp_redirect_admin_locations', 1000 );
 
 // Shortcodes.
-add_filter( 'the_content', 'do_shortcode', 11 ); // AFTER wpautop().
+add_filter( 'the_content', 'apply_shortcodes', 11 ); // AFTER wpautop().
 
 // Media.
 add_action( 'wp_playlist_scripts', 'wp_playlist_scripts' );

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -2296,7 +2296,7 @@ function img_caption_shortcode( $attr, $content = '' ) {
 			$describedby,
 			$style,
 			esc_attr( $class ),
-			do_shortcode( $content ),
+			apply_shortcodes( $content ),
 			sprintf(
 				'<figcaption %sclass="wp-caption-text">%s</figcaption>',
 				$caption_id,
@@ -2309,7 +2309,7 @@ function img_caption_shortcode( $attr, $content = '' ) {
 			$id,
 			$style,
 			esc_attr( $class ),
-			str_replace( '<img ', '<img ' . $describedby, do_shortcode( $content ) ),
+			str_replace( '<img ', '<img ' . $describedby, apply_shortcodes( $content ) ),
 			sprintf(
 				'<p %sclass="wp-caption-text">%s</p>',
 				$caption_id,

--- a/src/wp-includes/shortcodes.php
+++ b/src/wp-includes/shortcodes.php
@@ -171,29 +171,11 @@ function has_shortcode( $content, $tag ) {
 /**
  * Searches content for shortcodes and filter shortcodes through their hooks.
  *
- * This function is an alias for do_shortcode().
- *
- * @since 5.4.0
- *
- * @see do_shortcode()
- *
- * @param string $content     Content to search for shortcodes.
- * @param bool   $ignore_html When true, shortcodes inside HTML elements will be skipped.
- *                            Default false.
- * @return string Content with shortcodes filtered out.
- */
-function apply_shortcodes( $content, $ignore_html = false ) {
-	return do_shortcode( $content, $ignore_html );
-}
-
-/**
- * Searches content for shortcodes and filter shortcodes through their hooks.
- *
  * If there are no shortcode tags defined, then the content will be returned
  * without any filtering. This might cause issues when plugins are disabled but
  * the shortcode will still show up in the post or content.
  *
- * @since 2.5.0
+ * @since 5.4.0
  *
  * @global array $shortcode_tags List of shortcode tags and their callback hooks.
  *
@@ -202,7 +184,7 @@ function apply_shortcodes( $content, $ignore_html = false ) {
  *                            Default false.
  * @return string Content with shortcodes filtered out.
  */
-function do_shortcode( $content, $ignore_html = false ) {
+function apply_shortcodes( $content, $ignore_html = false ) {
 	global $shortcode_tags;
 
 	if ( false === strpos( $content, '[' ) ) {
@@ -230,6 +212,24 @@ function do_shortcode( $content, $ignore_html = false ) {
 	$content = unescape_invalid_shortcodes( $content );
 
 	return $content;
+}
+
+/**
+ * Searches content for shortcodes and filter shortcodes through their hooks.
+ *
+ * This function is an alias for apply_shortcodes().
+ *
+ * @since 2.5.0
+ *
+ * @see apply_shortcodes()
+ *
+ * @param string $content     Content to search for shortcodes.
+ * @param bool   $ignore_html When true, shortcodes inside HTML elements will be skipped.
+ *                            Default false.
+ * @return string Content with shortcodes filtered out.
+ */
+function do_shortcode( $content, $ignore_html = false ) {
+	return apply_shortcodes( $content, $ignore_html );
 }
 
 /**

--- a/src/wp-includes/shortcodes.php
+++ b/src/wp-includes/shortcodes.php
@@ -21,7 +21,7 @@
  *
  * To apply shortcode tags to content:
  *
- *     $out = do_shortcode( $content );
+ *     $out = apply_shortcodes( $content );
  *
  * @link https://developer.wordpress.org/plugins/shortcodes/
  *
@@ -299,7 +299,7 @@ function get_shortcode_regex( $tagnames = null ) {
 }
 
 /**
- * Regular Expression callable for do_shortcode() for calling shortcode hook.
+ * Regular Expression callable for apply_shortcodes() for calling shortcode hook.
  *
  * @see get_shortcode_regex() for details of the match array contents.
  *

--- a/src/wp-includes/widgets/class-wp-widget-text.php
+++ b/src/wp-includes/widgets/class-wp-widget-text.php
@@ -244,9 +244,9 @@ class WP_Widget_Text extends WP_Widget {
 
 		/*
 		 * Suspend legacy plugin-supplied do_shortcode() for 'widget_text' filter for the visual Text widget to prevent
-		 * shortcodes being processed twice. Now do_shortcode() is added to the 'widget_text_content' filter in core itself
+		 * shortcodes being processed twice. Now apply_shortcodes() is added to the 'widget_text_content' filter in core itself
 		 * and it applies after wpautop() to prevent corrupting HTML output added by the shortcode. When do_shortcode() is
-		 * added to 'widget_text_content' then do_shortcode() will be manually called when in legacy mode as well.
+		 * added to 'widget_text_content' then apply_shortcodes() will be manually called when in legacy mode as well.
 		 */
 		$widget_text_do_shortcode_priority       = has_filter( 'widget_text', 'do_shortcode' );
 		$should_suspend_legacy_shortcode_support = ( $is_visual_text_widget && false !== $widget_text_do_shortcode_priority );
@@ -302,9 +302,9 @@ class WP_Widget_Text extends WP_Widget {
 
 			/*
 			 * Manually do shortcodes on the content when the core-added filter is present. It is added by default
-			 * in core by adding do_shortcode() to the 'widget_text_content' filter to apply after wpautop().
+			 * in core by adding apply_shortcodes() to the 'widget_text_content' filter to apply after wpautop().
 			 * Since the legacy Text widget runs wpautop() after 'widget_text' filters are applied, the widget in
-			 * legacy mode here manually applies do_shortcode() on the content unless the default
+			 * legacy mode here manually applies apply_shortcodes() on the content unless the default
 			 * core filter for 'widget_text_content' has been removed, or if do_shortcode() has already
 			 * been applied via a plugin adding do_shortcode() to 'widget_text' filters.
 			 */

--- a/src/wp-includes/widgets/class-wp-widget-text.php
+++ b/src/wp-includes/widgets/class-wp-widget-text.php
@@ -312,7 +312,7 @@ class WP_Widget_Text extends WP_Widget {
 				if ( ! empty( $instance['filter'] ) ) {
 					$text = shortcode_unautop( $text );
 				}
-				$text = do_shortcode( $text );
+				$text = apply_shortcodes( $text );
 			}
 		}
 


### PR DESCRIPTION
This PR changes the wrapping of `apply_shortcodes()` and `do_shortcode()` such that `apply_shortcodes()` is now the recommended function.

In addition:
- Calls to `do_shortcode()` have been changed to `apply_shortcodes()`.
- Some default filter callbacks have been changed from `'do_shortcode'` to `'apply_shortcodes'`.
- Applicable documentation has been updated to refer to `apply_shortcodes()` instead. (please check these!)

This PR does not touch:
- Any other `do_shortcode_*()` function, as I'm not clear if a decision has been made about introducing new wrappers or deprecating the `do_shortcode_*()` variants.
- Any hooks, as I'm not clear if a decision has been made about keeping the hooks, or using `apply_filters_deprecated()`.
- [The default filter callback for widget_text_content](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/default-filters.php#L227), as this causes test failures and may impact legacy support.
  - See [here](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/widgets/class-wp-widget-text.php#L245-L250) and [here](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/widgets/class-wp-widget-text.php#L304-L310).
- [This line](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/blocks/template-part.php#L138) in `wp-includes/blocks/template-part.php` as this file is sourced from Gutenberg.

Trac ticket: https://core.trac.wordpress.org/ticket/55883