### PR TITLE
Require fix with PHP Warning: Use of undefined constant ABSPATH

### DIFF
--- a/src/wp-includes/blocks/index.php
+++ b/src/wp-includes/blocks/index.php
@@ -5,7 +5,7 @@
  * @package WordPress
  */
 
-define( 'BLOCKS_PATH', ABSPATH . WPINC . '/blocks/' );
+define( 'BLOCKS_PATH', 'ABSPATH' . 'WPINC' . '/blocks/' );
 
 // Include files required for core blocks registration.
 require BLOCKS_PATH . 'legacy-widget.php';


### PR DESCRIPTION
Need to fix PHP Warning which throws Use of undefined constant ABSPATH - assumed 'ABSPATH' https://core.trac.wordpress.org/ticket/56606


