### PR TITLE
Avoid PHP Warnings in posts rest endpoints with invalid slug/status data

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -4824,7 +4824,7 @@ function wp_parse_list( $list ) {
 		return preg_split( '/[\s,]+/', $list, -1, PREG_SPLIT_NO_EMPTY );
 	}
 
-	// Validate all entries of the list are scalar.
+	// Validate all entries of the list are scalar
 	$list = array_filter( $list, 'is_scalar' );
 
 	return $list;

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -4824,6 +4824,9 @@ function wp_parse_list( $list ) {
 		return preg_split( '/[\s,]+/', $list, -1, PREG_SPLIT_NO_EMPTY );
 	}
 
+	// Validate all entries of the list are scalar.
+	$list = array_filter( $list, 'is_scalar' );
+
 	return $list;
 }
 

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -4824,7 +4824,7 @@ function wp_parse_list( $list ) {
 		return preg_split( '/[\s,]+/', $list, -1, PREG_SPLIT_NO_EMPTY );
 	}
 
-	// Validate all entries of the list are scalar
+	// Validate all entries of the list are scalar.
 	$list = array_filter( $list, 'is_scalar' );
 
 	return $list;

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -2895,7 +2895,6 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			'items'             => array(
 				'type' => 'string',
 			),
-			'sanitize_callback' => 'wp_parse_slug_list',
 		);
 
 		$query_params['status'] = array(


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This contains two changes:
 1. Removal of sanitize_callback to allow the REST API to handle the validation natively, this also causes the proper error to be output for `?slug[0][1]=2` that it's an invalid value.
 2. Ensure that `wp_parse_list()` only returns a single-dimensioned array, even if passed a multi-dimension array, which fits the functions expected use-case and resolves warnings in code that expects the function to return a single-dimensioned array.

Part 2 is potential for back-compat issues, as although it's not documented as such, any broken code that expects to pass `wp_parse_list( [ [ 'key' => 'val' ] ] )` and have the same output as input will break.. IMHO this is not the intention of the function, and breakage should be expected.
If however, that potential back-compat is a potential issue, that line could instead be moved into `wp_parse_id_list()` and `wp_parse_slug_list()` instead.

Trac ticket: https://core.trac.wordpress.org/ticket/55838

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
