### PR TITLE
Remove end-of-options from docker-compose launch command

### DIFF
--- a/tools/local-env/scripts/start.js
+++ b/tools/local-env/scripts/start.js
@@ -8,7 +8,7 @@ dotenvExpand.expand( dotenv.config() );
 const containers = ( process.env.LOCAL_PHP_MEMCACHED === 'true' )
 	? 'wordpress-develop memcached'
 	: 'wordpress-develop';
-execSync( `docker-compose up -d -- ${containers}`, { stdio: 'inherit' } );
+execSync( `docker-compose up -d ${containers}`, { stdio: 'inherit' } );
 
 // If Docker Toolbox is being used, we need to manually forward LOCAL_PORT to the Docker VM.
 if ( process.env.DOCKER_TOOLBOX_INSTALL_PATH ) {


### PR DESCRIPTION
Docker-compose interprets end of options (--) as a service name when running local tools start script.

The hyphens are unnecessary here.

Docs: https://docs.docker.com/engine/reference/commandline/compose_up/


Trac ticket: https://core.trac.wordpress.org/ticket/56550

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
