### PR TITLE
Add: Post types to wp-rest-block-patterns-controller.php.

### DIFF
--- a/src/wp-includes/block-patterns.php
+++ b/src/wp-includes/block-patterns.php
@@ -189,6 +189,7 @@ function _register_remote_theme_patterns() {
  *   - Categories       (comma-separated values)
  *   - Keywords         (comma-separated values)
  *   - Block Types      (comma-separated values)
+ *   - Post Types       (comma-separated values)
  *   - Inserter         (yes/no)
  *
  * @since 6.0.0
@@ -203,6 +204,7 @@ function _register_theme_block_patterns() {
 		'categories'    => 'Categories',
 		'keywords'      => 'Keywords',
 		'blockTypes'    => 'Block Types',
+		'postTypes'     => 'Post Types',
 		'inserter'      => 'Inserter',
 	);
 
@@ -274,7 +276,7 @@ function _register_theme_block_patterns() {
 					}
 
 					// For properties of type array, parse data as comma-separated.
-					foreach ( array( 'categories', 'keywords', 'blockTypes' ) as $property ) {
+					foreach ( array( 'categories', 'keywords', 'blockTypes', 'postTypes' ) as $property ) {
 						if ( ! empty( $pattern_data[ $property ] ) ) {
 							$pattern_data[ $property ] = array_filter(
 								preg_split(

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-patterns-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-patterns-controller.php
@@ -124,6 +124,7 @@ class WP_REST_Block_Patterns_Controller extends WP_REST_Controller {
 			'description'   => 'description',
 			'viewportWidth' => 'viewport_width',
 			'blockTypes'    => 'block_types',
+			'postTypes'     => 'post_types',
 			'categories'    => 'categories',
 			'keywords'      => 'keywords',
 			'content'       => 'content',
@@ -181,6 +182,12 @@ class WP_REST_Block_Patterns_Controller extends WP_REST_Controller {
 				),
 				'block_types'    => array(
 					'description' => __( 'Block types that the pattern is intended to be used with.' ),
+					'type'        => 'array',
+					'readonly'    => true,
+					'context'     => array( 'view', 'edit', 'embed' ),
+				),
+				'post_types'     => array(
+					'description' => __( ' An array of post types that the pattern is restricted to be used with.' ),
 					'type'        => 'array',
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit', 'embed' ),


### PR DESCRIPTION
Backports PHP changes in https://github.com/WordPress/gutenberg/pull/41791 to the core. Adding the post types property to the rest API.

### Testing
Added the following code snippet:
```
register_block_pattern( 'custom-pattern', array(
			'title'      => _x( 'Start post pattern', 'Block pattern title', 'gutenberg' ),
			'blockTypes' => array( 'core/paragraph', 'core/post-content' ),
			'postTypes' => array( 'post' ),
			'content'    => '<!-- wp:paragraph -->
<p>A start post pattern</p>
<!-- /wp:paragraph -->',
		) );
```
Opened the editor pasted on the browser console:
```
wp.apiFetch( { path: '/wp/v2/block-patterns/patterns' } ).then( console.log );
```

Verified post types was included in the rest response as part of custom-pattern.