### PR TITLE
Add: has_archive to post types rest endpoint.

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-post-types-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-post-types-controller.php
@@ -198,6 +198,10 @@ class WP_REST_Post_Types_Controller extends WP_REST_Controller {
 			$data['hierarchical'] = $post_type->hierarchical;
 		}
 
+		if ( rest_is_field_included( 'hierarchical', $fields ) ) {
+			$data['has_archive'] = $post_type->has_archive;
+		}
+
 		if ( rest_is_field_included( 'visibility', $fields ) ) {
 			$data['visibility'] = array(
 				'show_in_nav_menus' => (bool) $post_type->show_in_nav_menus,
@@ -351,6 +355,12 @@ class WP_REST_Post_Types_Controller extends WP_REST_Controller {
 					'description' => __( 'All features, supported by the post type.' ),
 					'type'        => 'object',
 					'context'     => array( 'edit' ),
+					'readonly'    => true,
+				),
+				'has_archive'    => array(
+					'description' => __( 'If the value is a string, the value will be used as the archive slug. If the value is false the post type has no archive.' ),
+					'type'        => array( 'string', 'boolean' ),
+					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'taxonomies'     => array(

--- a/tests/phpunit/tests/rest-api/rest-post-types-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-post-types-controller.php
@@ -167,7 +167,7 @@ class WP_Test_REST_Post_Types_Controller extends WP_Test_REST_Controller_Testcas
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertCount( 13, $properties, 'Schema should have 13 properties' );
+		$this->assertCount( 14, $properties, 'Schema should have 14 properties' );
 		$this->assertArrayHasKey( 'capabilities', $properties, '`capabilities` should be included in the schema' );
 		$this->assertArrayHasKey( 'description', $properties, '`description` should be included in the schema' );
 		$this->assertArrayHasKey( 'hierarchical', $properties, '`hierarchical` should be included in the schema' );
@@ -176,6 +176,7 @@ class WP_Test_REST_Post_Types_Controller extends WP_Test_REST_Controller_Testcas
 		$this->assertArrayHasKey( 'name', $properties, '`name` should be included in the schema' );
 		$this->assertArrayHasKey( 'slug', $properties, '`slug` should be included in the schema' );
 		$this->assertArrayHasKey( 'supports', $properties, '`supports` should be included in the schema' );
+		$this->assertArrayHasKey( 'has_archive', $properties, '`has_archive` should be included in the schema' );
 		$this->assertArrayHasKey( 'taxonomies', $properties, '`taxonomies` should be included in the schema' );
 		$this->assertArrayHasKey( 'rest_base', $properties, '`rest_base` should be included in the schema' );
 		$this->assertArrayHasKey( 'rest_namespace', $properties, '`rest_namespace` should be included in the schema' );
@@ -230,6 +231,7 @@ class WP_Test_REST_Post_Types_Controller extends WP_Test_REST_Controller_Testcas
 		$this->assertSame( $post_type_obj->hierarchical, $data['hierarchical'] );
 		$this->assertSame( $post_type_obj->rest_base, $data['rest_base'] );
 		$this->assertSame( $post_type_obj->rest_namespace, $data['rest_namespace'] );
+		$this->assertSame( $post_type_obj->has_archive, $data['has_archive'] );
 
 		$links = test_rest_expand_compact_links( $links );
 		$this->assertSame( rest_url( 'wp/v2/types' ), $links['collection'][0]['href'] );

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -11663,6 +11663,7 @@ mockedApiResponse.TypesCollection = {
     "post": {
         "description": "",
         "hierarchical": false,
+        "has_archive": false,
         "name": "Posts",
         "slug": "post",
         "icon": "dashicons-admin-post",
@@ -11695,6 +11696,7 @@ mockedApiResponse.TypesCollection = {
     "page": {
         "description": "",
         "hierarchical": true,
+        "has_archive": false,
         "name": "Pages",
         "slug": "page",
         "icon": "dashicons-admin-page",
@@ -11724,6 +11726,7 @@ mockedApiResponse.TypesCollection = {
     "attachment": {
         "description": "",
         "hierarchical": false,
+        "has_archive": false,
         "name": "Media",
         "slug": "attachment",
         "icon": "dashicons-admin-media",
@@ -11753,6 +11756,7 @@ mockedApiResponse.TypesCollection = {
     "nav_menu_item": {
         "description": "",
         "hierarchical": false,
+        "has_archive": false,
         "name": "Navigation Menu Items",
         "slug": "nav_menu_item",
         "icon": null,
@@ -11784,6 +11788,7 @@ mockedApiResponse.TypesCollection = {
     "wp_block": {
         "description": "",
         "hierarchical": false,
+        "has_archive": false,
         "name": "Reusable blocks",
         "slug": "wp_block",
         "icon": null,
@@ -11813,6 +11818,7 @@ mockedApiResponse.TypesCollection = {
     "wp_template": {
         "description": "Templates to include in your theme.",
         "hierarchical": false,
+        "has_archive": false,
         "name": "Templates",
         "slug": "wp_template",
         "icon": null,
@@ -11842,6 +11848,7 @@ mockedApiResponse.TypesCollection = {
     "wp_template_part": {
         "description": "Template parts to include in your templates.",
         "hierarchical": false,
+        "has_archive": false,
         "name": "Template Parts",
         "slug": "wp_template_part",
         "icon": null,
@@ -11871,6 +11878,7 @@ mockedApiResponse.TypesCollection = {
     "wp_navigation": {
         "description": "Navigation menus that can be inserted into your site.",
         "hierarchical": false,
+        "has_archive": false,
         "name": "Navigation Menus",
         "slug": "wp_navigation",
         "icon": null,
@@ -11902,6 +11910,7 @@ mockedApiResponse.TypesCollection = {
 mockedApiResponse.TypeModel = {
     "description": "",
     "hierarchical": false,
+    "has_archive": false,
     "name": "Posts",
     "slug": "post",
     "icon": "dashicons-admin-post",


### PR DESCRIPTION
Backports https://github.com/WordPress/gutenberg/pull/42746 to the core. It adds an has_archive field to the post types endpoint.

### Testing
Added the following snippet:
```
add_action( 'init', function() {
	register_post_type(
		'book',
		array(
			'label'                 => __( 'Book' ),
			'description'           => __( 'Books' ),
			'supports'              => array( 'title', 'editor' ),
			'taxonomies'            => array( 'category', 'post_tag' ),
			'hierarchical'          => false,
			'public'                => true,
			'show_ui'               => true,
			'show_in_menu'          => true,
			'show_in_admin_bar'     => true,
			'show_in_nav_menus'     => true,
			'show_in_rest'          => true,
			'can_export'            => true,
			'has_archive'           => true,
			'exclude_from_search'   => false,
			'publicly_queryable'    => true,
		)
	);
	flush_rewrite_rules();
} );
```

Pasted `wp.apiFetch( { path: '/wp/v2/types' } ).then( console.log );` on the browser console and verified book post type contained has_archive true.