### PR TITLE
Fixed PHP 8.1.10 bug Core WP Deprecated errors

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2769,7 +2769,8 @@ function trailingslashit( $string ) {
  * @return string String without the trailing slashes.
  */
 function untrailingslashit( $string ) {
-	return rtrim( $string, '/\\' );
+	$string = ! empty( $string ) ? rtrim( $string, '/\\' ) : $string;
+	return $string;
 }
 
 /**


### PR DESCRIPTION
Check non-empty variable before return may be it will work.

Trac ticket: https://core.trac.wordpress.org/ticket/56612