### PR TITLE
CI: Don't run NPM Test in Windows

### DIFF
--- a/.github/workflows/test-npm.yml
+++ b/.github/workflows/test-npm.yml
@@ -55,6 +55,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    continue-on-error: ${{ matrix.os == 'windows-latest' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-npm.yml
+++ b/.github/workflows/test-npm.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-latest, windows-latest ]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/test-npm.yml
+++ b/.github/workflows/test-npm.yml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
-    continue-on-error: ${{ matrix.os == 'windows-latest' }}
+    continue-on-error: ${{ matrix.os == 'windows-latest' && true }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-npm.yml
+++ b/.github/workflows/test-npm.yml
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-latest ]
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Disable the NPM Test CI workflow in Windows. This is a workaround for [this issue](https://github.com/WordPress/wordpress-develop/pull/3154#issuecomment-1252461333) so it doesn't get in the way of WP 6.1 Beta 1. 

The issue is being actively investigated [here](https://wordpress.slack.com/archives/C02RQBWTW/p1663687642461539).

Trac ticket:

cc/ @Clorith @t-hamano @desrosj @gziolo @jsnajdr @c4rl0sbr4v0

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
