### PR TITLE
Editor: Make template names and descriptions dynamic.

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -531,6 +531,136 @@ function _build_block_template_result_from_file( $template_file, $template_type 
 }
 
 /**
+ * Builds the title and description of a post specific template based on the underlying referenced post.
+ * Mutates the underlying template object.
+ *
+ * @access private
+ * @internal
+ *
+ * @param string            $post_type Post type e.g.: page, post, product.
+ * @param string            $slug      Slug of the post e.g.: a-story-about-shoes.
+ * @param WP_Block_Template $template  Template to mutate adding the description and title computed.
+ *
+ * @return boolean Returns true if the referenced post was found and false otherwise.
+ */
+function _wp_build_title_and_description_for_single_post_type_block_template( $post_type, $slug, WP_Block_Template $template ) {
+	$post_type_object = get_post_type_object( $post_type );
+
+	$posts = get_posts(
+		array(
+			'name'      => $slug,
+			'post_type' => $post_type,
+		)
+	);
+	if ( empty( $posts ) ) {
+		$template->title = sprintf(
+			// translators: Represents the title of a user's custom template in the Site Editor referencing a post that was not found, where %1$s is the singular name of a post type and %2$s is the slug of the deleted post, e.g. "Not found: Page(hello)".
+			__( 'Not found: %1$s(%2$s)' ),
+			$post_type_object->labels->singular_name,
+			$slug
+		);
+		return false;
+	}
+
+	$post_title = $posts[0]->post_title;
+
+	$template->title = sprintf(
+		// translators: Represents the title of a user's custom template in the Site Editor, where %1$s is the singular name of a post type and %2$s is the name of the post, e.g. "Page: Hello".
+		__( '%1$s: %2$s' ),
+		$post_type_object->labels->singular_name,
+		$post_title
+	);
+	$template->description = sprintf(
+		// translators: Represents the description of a user's custom template in the Site Editor, e.g. "Template for Page: Hello".
+		__( 'Template for %1$s' ),
+		$post_title
+	);
+
+	$posts_with_same_title = get_posts(
+		array(
+			'title'       => $post_title,
+			'post_type'   => $post_type,
+			'post_status' => 'publish',
+		)
+	);
+	if ( count( $posts_with_same_title ) > 1 ) {
+		$template->title = sprintf(
+			// translators: Represents the title of a user's custom template in the Site Editor, where %1$s is the template title and %2$s is the slug of the post type, e.g. "Project: Hello (project_type)".
+			__( '%1$s (%2$s)' ),
+			$template->title,
+			$slug
+		);
+	}
+	return true;
+}
+
+/**
+ * Builds the title and description of a taxonomy specific template based on the underlying entity referenced.
+ * Mutates the underlying template object.
+ *
+ * @access private
+ * @internal
+ *
+ * @param string            $taxonomy Identifier of the taxonomy, e.g.: category.
+ * @param string            $slug     Slug of the term, e.g.: shoes.
+ * @param WP_Block_Template $template Template to mutate adding the description and title computed.
+ *
+ * @return boolean True if an term referenced was found and false otherwise.
+ */
+function _wp_build_title_and_description_for_taxonomy_block_template( $taxonomy, $slug, WP_Block_Template $template ) {
+	$taxonomy_object = get_taxonomy( $taxonomy );
+
+	$terms = get_terms(
+		array(
+			'taxonomy'   => $taxonomy,
+			'hide_empty' => false,
+			'slug'       => $slug,
+		)
+	);
+
+	if ( empty( $terms ) ) {
+		$template->title = sprintf(
+			// translators: Represents the title of a user's custom template in the Site Editor referencing a taxonomy term that was not found, where %1$s is the singular name of a taxonomy and %2$s is the slug of the deleted term, e.g. "Not found: Category(shoes)".
+			__( 'Not found: %1$s(%2$s)' ),
+			$taxonomy_object->labels->singular_name,
+			$slug
+		);
+		return false;
+	}
+
+	$term_title = $terms[0]->name;
+
+	$template->title = sprintf(
+		// translators: Represents the title of a user's custom template in the Site Editor, where %1$s is the singular name of a taxonomy and %2$s is the name of the term, e.g. "Category: shoes".
+		__( '%1$s: %2$s' ),
+		$taxonomy_object->labels->singular_name,
+		$term_title
+	);
+	$template->description = sprintf(
+		// translators: Represents the description of a user's custom template in the Site Editor, e.g. "Template for Category: shoes".
+		__( 'Template for %1$s' ),
+		$term_title
+	);
+
+	$terms_with_same_title = get_terms(
+		array(
+			'taxonomy'   => $taxonomy,
+			'hide_empty' => false,
+			'name'       => $term_title,
+		)
+	);
+	if ( count( $terms_with_same_title ) > 1 ) {
+		$template->title = sprintf(
+			// translators: Represents the title of a user's custom template in the Site Editor, where %1$s is the template title and %2$s is the slug of the taxonomy, e.g. "Category: shoes (product_tag)".
+			__( '%1$s (%2$s)' ),
+			$template->title,
+			$slug
+		);
+	}
+	return true;
+}
+
+/**
  * Builds a unified template object based a post Object.
  *
  * @since 5.9.0
@@ -589,6 +719,103 @@ function _build_block_template_result_from_post( $post ) {
 		}
 	}
 
+	// If it is a block template without description and without title or with title equal to the slug.
+	if ( 'wp_template' === $post->post_type && empty( $template->description ) && ( empty( $template->title ) || $template->title === $template->slug ) ) {
+		$matches = array();
+		// If it is a block template for a single author, page, post, tag, category, custom post type or custom taxonomy.
+		if ( preg_match( '/(author|page|single|tag|category|taxonomy)-(.+)/', $template->slug, $matches ) ) {
+			$type           = $matches[1];
+			$slug_remaining = $matches[2];
+			switch ( $type ) {
+				case 'author':
+					$nice_name = $slug_remaining;
+					$users     = get_users(
+						array(
+							'capability'     => 'edit_posts',
+							'search'         => $nice_name,
+							'search_columns' => array( 'user_nicename' ),
+							'fields'         => 'display_name',
+						)
+					);
+
+					if ( empty( $users ) ) {
+						$template->title = sprintf(
+							// translators: Represents the title of a user's custom template in the Site Editor referencing a deleted author, where %s is the author's nicename, e.g. "Deleted author: jane-doe".
+							__( 'Deleted author: %s' ),
+							$nice_name
+						);
+					} else {
+						$author_name = $users[0];
+
+						$template->title = sprintf(
+							// translators: Represents the title of a user's custom template in the Site Editor, where %s is the author's name, e.g. "Author: Jane Doe".
+							__( 'Author: %s' ),
+							$author_name
+						);
+						$template->description = sprintf(
+							// translators: Represents the description of a user's custom template in the Site Editor, e.g. "Template for Author: Jane Doe".
+							__( 'Template for %1$s' ),
+							$author_name
+						);
+
+						$users_with_same_name = get_users(
+							array(
+								'capability'     => 'edit_posts',
+								'search'         => $author_name,
+								'search_columns' => array( 'display_name' ),
+								'fields'         => 'display_name',
+							)
+						);
+						if ( count( $users_with_same_name ) > 1 ) {
+							$template->title = sprintf(
+								// translators: Represents the title of a user's custom template in the Site Editor, where %1$s is the template title of an author template and %2$s is the nicename of the author, e.g. "Author: Jorge (jorge-costa)".
+								__( '%1$s (%2$s)' ),
+								$template->title,
+								$nice_name
+							);
+						}
+					}
+					break;
+				case 'page':
+					_wp_build_title_and_description_for_single_post_type_block_template( 'page', $slug_remaining, $template );
+					break;
+				case 'single':
+					$post_types = get_post_types();
+					foreach ( $post_types as $post_type ) {
+						$post_type_length = strlen( $post_type ) + 1;
+						// If $slug_remaining starts with $post_type followed by a hyphen.
+						if ( 0 === strncmp( $slug_remaining, $post_type . '-', $post_type_length ) ) {
+							$slug  = substr( $slug_remaining, $post_type_length, strlen( $slug_remaining ) );
+							$found = _wp_build_title_and_description_for_single_post_type_block_template( $post_type, $slug, $template );
+							if ( $found ) {
+								break;
+							}
+						}
+					}
+					break;
+				case 'tag':
+					_wp_build_title_and_description_for_taxonomy_block_template( 'post_tag', $slug_remaining, $template );
+					break;
+				case 'category':
+					_wp_build_title_and_description_for_taxonomy_block_template( 'category', $slug_remaining, $template );
+					break;
+				case 'taxonomy':
+					$taxonomies = get_taxonomies();
+					foreach ( $taxonomies as $taxonomy ) {
+						$taxonomy_length = strlen( $taxonomy ) + 1;
+						// If $slug_remaining starts with $taxonomy followed by a hyphen.
+						if ( 0 === strncmp( $slug_remaining, $taxonomy . '-', $taxonomy_length ) ) {
+							$slug  = substr( $slug_remaining, $taxonomy_length, strlen( $slug_remaining ) );
+							$found = _wp_build_title_and_description_for_taxonomy_block_template( $taxonomy, $slug, $template );
+							if ( $found ) {
+								break;
+							}
+						}
+					}
+					break;
+			}
+		}
+	}
 	return $template;
 }
 


### PR DESCRIPTION
Backports PHP changes in WordPress/gutenberg#43862 to the core. Adds a mechanism to dynamically compute names and descriptions of the author, page, single, tag, category, and taxonomy templates.

Props mcsf, ntsekouras, antonvlasenko, jameskoster.
See #56467.
