### PR TITLE
Fix failing unit tests on PHP 8.1

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -1717,7 +1717,12 @@ class WP_Theme_JSON {
 	 * @return string|array Style property value.
 	 */
 	protected static function get_property_value( $styles, $path, $theme_json = null ) {
-		$value = _wp_array_get( $styles, $path );
+		$value = _wp_array_get( $styles, $path, '' );
+
+		// It doesn't make sense to process the value further.
+		if ( in_array( $value, array( '', null ), true ) ) {
+			return '';
+		}
 
 		/*
 		 * This converts references to a path to the value at that path

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -1720,7 +1720,7 @@ class WP_Theme_JSON {
 		$value = _wp_array_get( $styles, $path, '' );
 
 		// It doesn't make sense to process the value further.
-		if ( in_array( $value, array( '', null ), true ) ) {
+		if ( ( '' === $value ) || ( null === $value ) ) {
 			return '';
 		}
 

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -3874,4 +3874,19 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 			),
 		);
 	}
+
+	/**
+	 * Tests that get_property_value static method returns an empty string
+	 * if the path is invalid.
+	 *
+	 * @ticket 56620
+	 */
+	public function test_get_property_value_should_return_string_with_invalid_path() {
+		$reflection_class = new ReflectionClass( WP_Theme_JSON::class );
+
+		$get_property_value_method = $reflection_class->getMethod( 'get_property_value' );
+		$get_property_value_method->setAccessible( true );
+		$result = $get_property_value_method->invoke( null, array(), array( 'non_existent_path' ) );
+		$this->assertSame( '', $result );
+	}
 }

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -3876,29 +3876,13 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Data provider for test_get_property_value_should_return_string_for_invalid_paths_or_null_values().
-	 *
-	 * @return array
-	 */
-	public function data_get_property_value_should_return_string_for_invalid_paths_or_null_values() {
-		return array(
-			'null'         => array(
-				'styles' => array(),
-				'path'   => array('non_existent_path'),
-			),
-			'empty string' => array(
-				'styles' => array( 'some_null_value' => null ),
-				'path'   => array( 'some_null_value' ),
-			),
-		);
-	}
-
-	/**
 	 * Tests that get_property_value static method returns an empty string
 	 * if the path is invalid or the value is null.
 	 *
 	 * @dataProvider data_get_property_value_should_return_string_for_invalid_paths_or_null_values
 	 * @ticket       56620
+	 *
+	 * @covers WP_Theme_JSON::get_property_value
 	 *
 	 * @param array $styles An array with style definitions.
 	 * @param array $path   Path to the desired properties.
@@ -3911,5 +3895,23 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 		$get_property_value_method->setAccessible( true );
 		$result = $get_property_value_method->invoke( null, $styles, $path );
 		$this->assertSame( '', $result );
+	}
+
+	/**
+	 * Data provider for test_get_property_value_should_return_string_for_invalid_paths_or_null_values().
+	 *
+	 * @return array
+	 */
+	public function data_get_property_value_should_return_string_for_invalid_paths_or_null_values() {
+		return array(
+			'null'         => array(
+				'styles' => array(),
+				'path'   => array( 'non_existent_path' ),
+			),
+			'empty string' => array(
+				'styles' => array( 'some_null_value' => null ),
+				'path'   => array( 'some_null_value' ),
+			),
+		);
 	}
 }

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -3878,6 +3878,8 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 	/**
 	 * Tests that get_property_value static method returns an empty string
 	 * if the path is invalid or the value is null.
+	 * Also, this test checks that no "strncmp(): Passing null to parameter #1 ($string1) of type string is deprecated"
+	 * error is thrown on PHP 8.1 and above.
 	 *
 	 * @dataProvider data_get_property_value_should_return_string_for_invalid_paths_or_null_values
 	 * @ticket       56620

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -3876,17 +3876,40 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that get_property_value static method returns an empty string
-	 * if the path is invalid.
+	 * Data provider for test_get_property_value_should_return_string_for_invalid_paths_or_null_values().
 	 *
-	 * @ticket 56620
+	 * @return array
 	 */
-	public function test_get_property_value_should_return_string_with_invalid_path() {
+	public function data_get_property_value_should_return_string_for_invalid_paths_or_null_values() {
+		return array(
+			'null'         => array(
+				'styles' => array(),
+				'path'   => array('non_existent_path'),
+			),
+			'empty string' => array(
+				'styles' => array( 'some_null_value' => null ),
+				'path'   => array( 'some_null_value' ),
+			),
+		);
+	}
+
+	/**
+	 * Tests that get_property_value static method returns an empty string
+	 * if the path is invalid or the value is null.
+	 *
+	 * @dataProvider data_get_property_value_should_return_string_for_invalid_paths_or_null_values
+	 * @ticket       56620
+	 *
+	 * @param array $styles An array with style definitions.
+	 * @param array $path   Path to the desired properties.
+	 *
+	 */
+	public function test_get_property_value_should_return_string_for_invalid_paths_or_null_values( $styles, $path ) {
 		$reflection_class = new ReflectionClass( WP_Theme_JSON::class );
 
 		$get_property_value_method = $reflection_class->getMethod( 'get_property_value' );
 		$get_property_value_method->setAccessible( true );
-		$result = $get_property_value_method->invoke( null, array(), array( 'non_existent_path' ) );
+		$result = $get_property_value_method->invoke( null, $styles, $path );
 		$this->assertSame( '', $result );
 	}
 }

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -3896,6 +3896,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 		$get_property_value_method = $reflection_class->getMethod( 'get_property_value' );
 		$get_property_value_method->setAccessible( true );
 		$result = $get_property_value_method->invoke( null, $styles, $path );
+		$get_property_value_method->setAccessible( false );
 		$this->assertSame( '', $result );
 	}
 


### PR DESCRIPTION
This PR aims to fix errors caused by incorrect usage of the `strncmp` function inside the `WP_Theme_JSON::get_property_value` methodon PHP 8.1 and above.
Please see the list of the errors below:

```
1) Tests_Blocks_Editor::test_get_block_editor_settings_theme_json_settings
strncmp(): Passing null to parameter #1 ($string1) of type string is deprecated
2) Tests_Blocks_Editor::test_get_block_editor_settings_deprecated_filter_post_editor
strncmp(): Passing null to parameter #1 ($string1) of type string is deprecated
12) Tests_Theme_wpGetGlobalStylesheet::test_block_theme_using_defaults
strncmp(): Passing null to parameter #1 ($string1) of type string is deprecated
13) Tests_Theme_wpGetGlobalStylesheet::test_variables_in_classic_theme_with_no_presets_using_defaults
strncmp(): Passing null to parameter #1 ($string1) of type string is deprecated
14) Tests_Theme_wpGetGlobalStylesheet::test_variables_in_classic_theme_with_presets_using_defaults
strncmp(): Passing null to parameter #1 ($string1) of type string is deprecated
15) Tests_Theme_wpThemeJson::test_get_stylesheet_support_for_shorthand_and_longhand_values
strncmp(): Passing null to parameter #1 ($string1) of type string is deprecated
16) Tests_Theme_wpThemeJson::test_get_stylesheet_skips_disabled_protected_properties
strncmp(): Passing null to parameter #1 ($string1) of type string is deprecated
17) Tests_Theme_wpThemeJson::test_get_stylesheet_renders_enabled_protected_properties
strncmp(): Passing null to parameter #1 ($string1) of type string is deprecated
18) Tests_Theme_wpThemeJson::test_get_stylesheet
strncmp(): Passing null to parameter #1 ($string1) of type string is deprecated
19) Tests_Theme_wpThemeJson::test_get_stylesheet_preset_rules_come_after_block_rules
strncmp(): Passing null to parameter #1 ($string1) of type string is deprecated
20) Tests_Theme_wpThemeJson::test_get_stylesheet_preset_values_are_marked_as_important
strncmp(): Passing null to parameter #1 ($string1) of type string is deprecated
21) Tests_Theme_wpThemeJson::test_get_stylesheet_handles_whitelisted_element_pseudo_selectors
strncmp(): Passing null to parameter #1 ($string1) of type string is deprecated
22) Tests_Theme_wpThemeJson::test_get_stylesheet_handles_only_pseudo_selector_rules_for_given_property
strncmp(): Passing null to parameter #1 ($string1) of type string is deprecated
23) Tests_Theme_wpThemeJson::test_get_stylesheet_ignores_pseudo_selectors_on_non_whitelisted_elements
strncmp(): Passing null to parameter #1 ($string1) of type string is deprecated
24) Tests_Theme_wpThemeJson::test_get_stylesheet_ignores_non_whitelisted_pseudo_selectors
strncmp(): Passing null to parameter #1 ($string1) of type string is deprecated
25) Tests_Theme_wpThemeJson::test_get_stylesheet_handles_priority_of_elements_vs_block_elements_pseudo_selectors
strncmp(): Passing null to parameter #1 ($string1) of type string is deprecated
26) Tests_Theme_wpThemeJson::test_get_stylesheet_handles_whitelisted_block_level_element_pseudo_selectors
strncmp(): Passing null to parameter #1 ($string1) of type string is deprecated
27) Tests_Theme_wpThemeJson::test_remove_insecure_properties_removes_unsafe_styles
strncmp(): Passing null to parameter #1 ($string1) of type string is deprecated
28) Tests_Theme_wpThemeJson::test_remove_insecure_properties_removes_unsafe_styles_sub_properties
strncmp(): Passing null to parameter #1 ($string1) of type string is deprecated
29) Tests_Theme_wpThemeJson::test_remove_insecure_properties_applies_safe_styles
strncmp(): Passing null to parameter #1 ($string1) of type string is deprecated
30) Tests_Theme_wpThemeJson::test_remove_invalid_element_pseudo_selectors
strncmp(): Passing null to parameter #1 ($string1) of type string is deprecated
31) Tests_Theme_wpThemeJson::test_get_property_value_valid
strncmp(): Passing null to parameter #1 ($string1) of type string is deprecated
32) Tests_Theme_wpThemeJson::test_get_property_value_loop
strncmp(): Passing null to parameter #1 ($string1) of type string is deprecated
33) Tests_Theme_wpThemeJson::test_get_property_value_recursion
strncmp(): Passing null to parameter #1 ($string1) of type string is deprecated
34) Tests_Theme_wpThemeJson::test_get_property_value_self
strncmp(): Passing null to parameter #1 ($string1) of type string is deprecated
35) Tests_Theme_wpThemeJson::test_get_stylesheet_generates_layout_styles with data set "layout definitions" (array(array('default', 'flow', 'is-layout-flow', array(array(' > .alignleft', array('left', '0', '2em')), array(' > .alignright', array('right', '2em', '0')), array(' > .aligncenter', array('auto !important', 'auto !important'))), array(array(' > *', array('0', '0')), array(' > * + *', array(null, '0')))), array('flex', 'flex', 'is-layout-flex', 'flex', array(array('', array('wrap', 'center'))), array(array('', array(null))))))
strncmp(): Passing null to parameter #1 ($string1) of type string is deprecated
36) Tests_Theme_wpThemeJson::test_get_stylesheet_generates_layout_styles_with_spacing_presets with data set "layout definitions" (array(array('default', 'flow', 'is-layout-flow', array(array(' > .alignleft', array('left', '0', '2em')), array(' > .alignright', array('right', '2em', '0')), array(' > .aligncenter', array('auto !important', 'auto !important'))), array(array(' > *', array('0', '0')), array(' > * + *', array(null, '0')))), array('flex', 'flex', 'is-layout-flex', 'flex', array(array('', array('wrap', 'center'))), array(array('', array(null))))))
strncmp(): Passing null to parameter #1 ($string1) of type string is deprecated
37) Tests_Theme_wpThemeJson::test_get_stylesheet_generates_fallback_gap_layout_styles with data set "layout definitions" (array(array('default', 'flow', 'is-layout-flow', array(array(' > .alignleft', array('left', '0', '2em')), array(' > .alignright', array('right', '2em', '0')), array(' > .aligncenter', array('auto !important', 'auto !important'))), array(array(' > *', array('0', '0')), array(' > * + *', array(null, '0')))), array('flex', 'flex', 'is-layout-flex', 'flex', array(array('', array('wrap', 'center'))), array(array('', array(null))))))
strncmp(): Passing null to parameter #1 ($string1) of type string is deprecated
38) Tests_Theme_wpThemeJson::test_get_stylesheet_generates_valid_block_gap_values_and_skips_null_or_false_values with data set "layout definitions" (array(array('default', 'flow', 'is-layout-flow', array(array(' > .alignleft', array('left', '0', '2em')), array(' > .alignright', array('right', '2em', '0')), array(' > .aligncenter', array('auto !important', 'auto !important'))), array(array(' > *', array('0', '0')), array(' > * + *', array(null, '0')))), array('flex', 'flex', 'is-layout-flex', 'flex', array(array('', array('wrap', 'center'))), array(array('', array(null))))))
strncmp(): Passing null to parameter #1 ($string1) of type string is deprecated
39) Tests_Theme_wpThemeJson::test_get_styles_for_block_with_padding_aware_alignments
strncmp(): Passing null to parameter #1 ($string1) of type string is deprecated
40) Tests_Theme_wpThemeJson::test_get_styles_for_block_without_padding_aware_alignments
strncmp(): Passing null to parameter #1 ($string1) of type string is deprecated
41) Tests_Theme_wpThemeJson::test_get_styles_for_block_with_content_width
strncmp(): Passing null to parameter #1 ($string1) of type string is deprecated
42) Tests_Webfonts_wpThemeJsonWebfontsHandler::test_font_face_generated_from_themejson
strncmp(): Passing null to parameter #1 ($string1) of type string is deprecated
43) Tests_Webfonts_wpThemeJsonWebfontsHandler::test_font_face_not_generated with data set "no "fontFace" in theme.json" ('block-theme')
strncmp(): Passing null to parameter #1 ($string1) of type string is deprecated
44) Tests_Webfonts_wpThemeJsonWebfontsHandler::test_font_face_not_generated with data set "empty "fontFace" in theme.json" ('empty-fontface-theme')
strncmp(): Passing null to parameter #1 ($string1) of type string is deprecated
```

Trac ticket: https://core.trac.wordpress.org/ticket/56620



---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
