### PR TITLE
Delete `link-manager` during test tear down

### DIFF
--- a/tests/phpunit/tests/rest-api/rest-plugins-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-plugins-controller.php
@@ -89,6 +89,9 @@ class WP_REST_Plugins_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		if ( file_exists( DIR_TESTDATA . '/link-manager.zip' ) ) {
 			unlink( DIR_TESTDATA . '/link-manager.zip' );
 		}
+		if ( isset( get_plugins()['link-manager/link-manager.php'] ) ) {
+			delete_plugins( array( 'link-manager/link-manager.php' ) );
+		}
 
 		parent::tear_down();
 	}


### PR DESCRIPTION
In [tests/phpunit/tests/rest-api/rest-plugins-controller.php](https://github.com/WordPress/wordpress-develop/compare/trunk...ironprogrammer:wordpress-develop:delete-link-manager-plugin?expand=1#diff-44625fa58026efa5f33ea4e055673b601bd59fc703c0ab846d0889d1a758f24c):

- Delete `link-manager` plugin during test tear down.

Trac ticket: https://core.trac.wordpress.org/ticket/56629

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
