### PR TITLE
Prevent excessive `notoptions` key lookups

### DIFF
--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -165,8 +165,9 @@ function get_option( $option, $default = false ) {
 		$notoptions = wp_cache_get( 'notoptions', 'options' );
 
 		// Prevent non-existent `notoptions` key from triggering multiple key lookups.
-		if ( $notoptions === false ) {
-			wp_cache_set( 'notoptions', [], 'options' );
+		if ( ! is_array( $notoptions ) ) {
+			$notoptions = array();
+			wp_cache_set( 'notoptions', $notoptions, 'options' );
 		}
 
 		if ( isset( $notoptions[ $option ] ) ) {

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -164,6 +164,11 @@ function get_option( $option, $default = false ) {
 		// Prevent non-existent options from triggering multiple queries.
 		$notoptions = wp_cache_get( 'notoptions', 'options' );
 
+		// Prevent non-existent `notoptions` key from triggering multiple key lookups.
+		if ( $notoptions === false ) {
+			wp_cache_set( 'notoptions', [], 'options' );
+		}
+
 		if ( isset( $notoptions[ $option ] ) ) {
 			/**
 			 * Filters the default value for an option.


### PR DESCRIPTION
When the `notoptions` key does not exist in a persistent object cache, it's requested hundreds of times until the first not-option is written.

Trac ticket: https://core.trac.wordpress.org/ticket/56639