### PR TITLE
remove duplicate $style_file calculation

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -215,8 +215,7 @@ function register_block_style_handle( $metadata, $field_name, $index = 0 ) {
 		$style_uri  = includes_url( 'blocks/' . str_replace( 'core/', '', $metadata['name'] ) . "/style$suffix.css" );
 	}
 
-	$block_dir       = dirname( $metadata['file'] );
-	$style_path_norm = wp_normalize_path( realpath( $block_dir . '/' . $style_path ) );
+	$style_path_norm = wp_normalize_path( realpath( dirname( $metadata['file'] ) . '/' . $style_path ) );
 	$is_theme_block  = 0 === strpos( $style_path_norm, $theme_path_norm );
 
 	if ( $is_theme_block ) {

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -224,8 +224,7 @@ function register_block_style_handle( $metadata, $field_name, $index = 0 ) {
 
 	$style_handle   = generate_block_asset_handle( $metadata['name'], $field_name, $index );
 	$block_dir      = dirname( $metadata['file'] );
-	$style_file     = wp_normalize_path( realpath( "$block_dir/$style_path" ) );
-	$has_style_file = false !== $style_file;
+	$has_style_file = false !== $style_path_norm;
 	$version        = ! $is_core_block && isset( $metadata['version'] ) ? $metadata['version'] : false;
 	$style_uri      = $has_style_file ? $style_uri : false;
 	$result         = wp_register_style(
@@ -234,14 +233,14 @@ function register_block_style_handle( $metadata, $field_name, $index = 0 ) {
 		array(),
 		$version
 	);
-	if ( file_exists( str_replace( '.css', '-rtl.css', $style_file ) ) ) {
+	if ( file_exists( str_replace( '.css', '-rtl.css', $style_path_norm ) ) ) {
 		wp_style_add_data( $style_handle, 'rtl', 'replace' );
 	}
 	if ( $has_style_file ) {
-		wp_style_add_data( $style_handle, 'path', $style_file );
+		wp_style_add_data( $style_handle, 'path', $style_path_norm );
 	}
 
-	$rtl_file = str_replace( "$suffix.css", "-rtl$suffix.css", $style_file );
+	$rtl_file = str_replace( "$suffix.css", "-rtl$suffix.css", $style_path_norm );
 	if ( is_rtl() && file_exists( $rtl_file ) ) {
 		wp_style_add_data( $style_handle, 'path', $rtl_file );
 	}

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -215,7 +215,8 @@ function register_block_style_handle( $metadata, $field_name, $index = 0 ) {
 		$style_uri  = includes_url( 'blocks/' . str_replace( 'core/', '', $metadata['name'] ) . "/style$suffix.css" );
 	}
 
-	$style_path_norm = wp_normalize_path( realpath( dirname( $metadata['file'] ) . '/' . $style_path ) );
+	$block_dir       = dirname( $metadata['file'] );
+	$style_path_norm = wp_normalize_path( realpath( $block_dir . '/' . $style_path ) );
 	$is_theme_block  = 0 === strpos( $style_path_norm, $theme_path_norm );
 
 	if ( $is_theme_block ) {
@@ -223,7 +224,6 @@ function register_block_style_handle( $metadata, $field_name, $index = 0 ) {
 	}
 
 	$style_handle   = generate_block_asset_handle( $metadata['name'], $field_name, $index );
-	$block_dir      = dirname( $metadata['file'] );
 	$has_style_file = false !== $style_path_norm;
 	$version        = ! $is_core_block && isset( $metadata['version'] ) ? $metadata['version'] : false;
 	$style_uri      = $has_style_file ? $style_uri : false;


### PR DESCRIPTION
This patch removes duplicate calculations for a variable, reducing by half the number of times we call `realpath()`.

Tests ran using Xdebug & webgind, attaching screenshots of the reports:

Before the patch:

<img width="1406" alt="Screenshot 2022-09-23 at 11 28 43 AM" src="https://user-images.githubusercontent.com/588688/191922115-5a1d3611-c683-4e26-887b-80dc2809fa05.png">

After the patch:

<img width="1406" alt="Screenshot 2022-09-23 at 11 35 16 AM" src="https://user-images.githubusercontent.com/588688/191922218-ce423a27-86d8-461e-b41c-277d22f712e7.png">

Invocation count goes down from 639 to 461. Total self-cost goes down from 146ms to 89ms (values shown are in milliseconds).

Trac ticket: https://core.trac.wordpress.org/ticket/56636

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
