### PR TITLE
Fix repeat calls to file_get_contents

### DIFF
--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -191,11 +191,13 @@ function get_default_block_editor_settings() {
 
 	// These styles are used if the "no theme styles" options is triggered or on
 	// themes without their own editor styles.
-	$default_editor_styles_file                 = ABSPATH . WPINC . '/css/dist/block-editor/default-editor-styles.css';
+	$default_editor_styles_file = ABSPATH . WPINC . '/css/dist/block-editor/default-editor-styles.css';
+
 	static $default_editor_styles_file_contents = false;
 	if ( ! $default_editor_styles_file_contents && file_exists( $default_editor_styles_file ) ) {
 		$default_editor_styles_file_contents = file_get_contents( $default_editor_styles_file );
 	}
+
 	$default_editor_styles = array();
 	if ( $default_editor_styles_file_contents ) {
 		$default_editor_styles = array(

--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -191,13 +191,16 @@ function get_default_block_editor_settings() {
 
 	// These styles are used if the "no theme styles" options is triggered or on
 	// themes without their own editor styles.
-	$default_editor_styles_file = ABSPATH . WPINC . '/css/dist/block-editor/default-editor-styles.css';
-	if ( file_exists( $default_editor_styles_file ) ) {
+	$default_editor_styles_file                 = ABSPATH . WPINC . '/css/dist/block-editor/default-editor-styles.css';
+	static $default_editor_styles_file_contents = false;
+	if ( ! $default_editor_styles_file_contents && file_exists( $default_editor_styles_file ) ) {
+		$default_editor_styles_file_contents = file_get_contents( $default_editor_styles_file );
+	}
+	$default_editor_styles = array();
+	if ( $default_editor_styles_file_contents ) {
 		$default_editor_styles = array(
-			array( 'css' => file_get_contents( $default_editor_styles_file ) ),
+			array( 'css' => $default_editor_styles_file_contents ),
 		);
-	} else {
-		$default_editor_styles = array();
 	}
 
 	$editor_settings = array(


### PR DESCRIPTION
Fixes repeat calls to `file_get_contents`

Testing on WP 6.1 (trunk), on the front-page of a site using Xdebug & webgrind: (values in milliseconds)

Before the patch:

<img width="1264" alt="Screenshot 2022-09-23 at 12 53 03 PM" src="https://user-images.githubusercontent.com/588688/191936131-9a66ac4a-a3c2-490f-bb5f-347b7c35d92d.png">

After the patch:

<img width="1264" alt="Screenshot 2022-09-23 at 1 09 43 PM" src="https://user-images.githubusercontent.com/588688/191938929-f8446531-c6d5-4356-b5a6-6ab2eced9385.png">


Invocation count goes down from 181 to 93. Total self-cost goes down from 160ms to 93ms

Trac ticket: https://core.trac.wordpress.org/ticket/56637

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
