### PR TITLE
Backport: Gutenberg PR #44363 > Add missing blocks origin to theme.json

### DIFF
--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -295,12 +295,10 @@ class WP_Theme_JSON_Resolver {
 		 *
 		 * @param WP_Theme_JSON_Data Class to access and update the underlying data.
 		 */
-		$theme_json = apply_filters( 'theme_json_blocks', new WP_Theme_JSON_Data( $config, 'core' ) );
+		$theme_json = apply_filters( 'theme_json_blocks', new WP_Theme_JSON_Data( $config, 'blocks' ) );
 		$config     = $theme_json->get_data();
 
-		// Core here means it's the lower level part of the styles chain.
-		// It can be a core or a third-party block.
-		return new WP_Theme_JSON( $config, 'core' );
+		return new WP_Theme_JSON( $config, 'blocks' );
 	}
 
 	/**

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -50,10 +50,12 @@ class WP_Theme_JSON {
 	 * The sources of data this object can represent.
 	 *
 	 * @since 5.8.0
+	 * @since 6.1.0 Added 'blocks'.
 	 * @var string[]
 	 */
 	const VALID_ORIGINS = array(
 		'default',
+		'blocks',
 		'theme',
 		'custom',
 	);

--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -204,6 +204,11 @@ function wp_add_global_styles_for_blocks() {
 	foreach ( $block_nodes as $metadata ) {
 		$block_css = $tree->get_styles_for_block( $metadata );
 
+		if ( ! wp_should_load_separate_core_block_assets() ) {
+			wp_add_inline_style( 'global-styles', $block_css );
+			continue;
+		}
+
 		if ( isset( $metadata['name'] ) ) {
 			$block_name = str_replace( 'core/', '', $metadata['name'] );
 			/*

--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -113,15 +113,21 @@ function wp_get_global_stylesheet( $types = array() ) {
 	}
 
 	/*
-	 * If variables are part of the stylesheet,
-	 * we add them for all origins (default, theme, user).
+	 * If variables are part of the stylesheet, then add them.
 	 * This is so themes without a theme.json still work as before 5.9:
 	 * they can override the default presets.
 	 * See https://core.trac.wordpress.org/ticket/54782
 	 */
 	$styles_variables = '';
 	if ( in_array( 'variables', $types, true ) ) {
-		$styles_variables = $tree->get_stylesheet( array( 'variables' ) );
+		/*
+		 * Only use the default, theme, and custom origins. Why?
+		 * Because styles for `blocks` origin are added at a later phase
+		 * (i.e. in the render cycle). Here, only the ones in use are rendered.
+		 * @see wp_add_global_styles_for_blocks
+		 */
+		$origins          = array( 'default', 'theme', 'custom' );
+		$styles_variables = $tree->get_stylesheet( array( 'variables' ), $origins );
 		$types            = array_diff( $types, array( 'variables' ) );
 	}
 
@@ -133,6 +139,12 @@ function wp_get_global_stylesheet( $types = array() ) {
 	 */
 	$styles_rest = '';
 	if ( ! empty( $types ) ) {
+		/*
+		 * Only use the default, theme, and custom origins. Why?
+		 * Because styles for `blocks` origin are added at a later phase
+		 * (i.e. in the render cycle). Here, only the ones in use are rendered.
+		 * @see wp_add_global_styles_for_blocks
+		 */
 		$origins = array( 'default', 'theme', 'custom' );
 		if ( ! $supports_theme_json ) {
 			$origins = array( 'default' );

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2408,12 +2408,13 @@ function wp_enqueue_global_styles() {
 		return;
 	}
 
-	/**
-	 * If we are loading CSS for each block separately, then we can load the theme.json CSS conditionally.
+	/*
+	 * If loading the CSS for each block separately, then load the theme.json CSS conditionally.
 	 * This removes the CSS from the global-styles stylesheet and adds it to the inline CSS for each block.
-	 * This filter has to be registered before we call wp_get_global_stylesheet();
+	 * This filter must be registered before calling wp_get_global_stylesheet();
 	 */
 	add_filter( 'theme_json_get_style_nodes', 'wp_filter_out_block_nodes' );
+
 	$stylesheet = wp_get_global_stylesheet();
 
 	if ( empty( $stylesheet ) ) {
@@ -2424,7 +2425,7 @@ function wp_enqueue_global_styles() {
 	wp_add_inline_style( 'global-styles', $stylesheet );
 	wp_enqueue_style( 'global-styles' );
 
-	// add each block as an inline css.
+	// Add each block as an inline css.
 	wp_add_global_styles_for_blocks();
 }
 

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2413,7 +2413,7 @@ function wp_enqueue_global_styles() {
 	 * This removes the CSS from the global-styles stylesheet and adds it to the inline CSS for each block.
 	 * This filter has to be registered before we call wp_get_global_stylesheet();
 	 */
-	add_filter( 'gutenberg_get_style_nodes', 'filter_out_block_nodes' );
+	add_filter( 'theme_json_get_style_nodes', 'wp_filter_out_block_nodes' );
 	$stylesheet = wp_get_global_stylesheet();
 
 	if ( empty( $stylesheet ) ) {

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2408,16 +2408,12 @@ function wp_enqueue_global_styles() {
 		return;
 	}
 
-	/*
+	/**
 	 * If we are loading CSS for each block separately, then we can load the theme.json CSS conditionally.
 	 * This removes the CSS from the global-styles stylesheet and adds it to the inline CSS for each block.
+	 * This filter has to be registered before we call wp_get_global_stylesheet();
 	 */
-	if ( $separate_assets ) {
-		add_filter( 'theme_json_get_style_nodes', 'wp_filter_out_block_nodes' );
-		// Add each block as an inline css.
-		wp_add_global_styles_for_blocks();
-	}
-
+	add_filter( 'gutenberg_get_style_nodes', 'filter_out_block_nodes' );
 	$stylesheet = wp_get_global_stylesheet();
 
 	if ( empty( $stylesheet ) ) {
@@ -2427,6 +2423,9 @@ function wp_enqueue_global_styles() {
 	wp_register_style( 'global-styles', false, array(), true, true );
 	wp_add_inline_style( 'global-styles', $stylesheet );
 	wp_enqueue_style( 'global-styles' );
+
+	// add each block as an inline css.
+	wp_add_global_styles_for_blocks();
 }
 
 /**


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/56467
Backports https://github.com/WordPress/gutenberg/pull/44363

To test, you can follow the testing instructions on https://github.com/WordPress/gutenberg/pull/44363.

This PR adds a missing origin to the code that processes `theme.json`. It also consolidates its name to `blocks` to be more reflective of what it affects. If the data coming from the `blocks` origin contained presets, it would be overriden by the data coming from the `theme` origin, which is not expected.

<hr>

### Commit message:

Editor: Fix missing `blocks` origin for processing `theme.json`.

This commit updates the `blocks` origin name from `core` to `blocks` and adds it to the list of valid origins for `theme.json`. (See the original fix in [https://github.com/WordPress/wordpress-develop/pull/3319 Gutenberg's PR 44363].)

Why?

- This new origin was missing from the list.
- The `core` name is not reflective of what it does, as this data origin is related to block styles, whether they come with WordPress or third-party blocks.
- The existing filter for this piece of data is called `theme_json_blocks`, to reflect it filters "block" data.
- Though `core` origin was used in the past for `default`, this commit reverts it. Why? It was confusing. The goal is to use names that communicate what part of the pipeline are processing (`default > blocks > theme > custom`).

How?

- Renames the string, from `core` to `blocks`.
- Adds `blocks` to the list of valid origins.
- Verifies that the `$theme_json->get_stylesheet()` call uses the proper `$origins` at all times.

Follow-up to [54162], [54251].

Props oandregal, czapla, jorgefilipecosta, scruffian, bernhard-reiter hellofromTonya.
See #56467.