### PR TITLE
Remove file_exists() checks after calling realpath()

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -442,7 +442,7 @@ function register_block_type_from_metadata( $file_or_folder, $args = array() ) {
 				remove_block_asset_path_prefix( $metadata['render'] )
 			)
 		);
-		if ( file_exists( $template_path ) ) {
+		if ( $template_path ) {
 			/**
 			 * Renders the block on the server.
 			 *

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -4528,7 +4528,7 @@ function wp_check_jsonp_callback( $callback ) {
 function wp_json_file_decode( $filename, $options = array() ) {
 	$result   = null;
 	$filename = wp_normalize_path( realpath( $filename ) );
-	if ( ! file_exists( $filename ) ) {
+	if ( ! $filename ) {
 		trigger_error(
 			sprintf(
 				/* translators: %s: Path to the JSON file. */


### PR DESCRIPTION
`realpath()` returns false if the file does not exist. Running an additional `file_exists()` check on a variable that has already passed through `realpath()` is wasteful.

This PR simplifies the checks in 2 instances, removing the function call.
Note: In both these cases, the variables passes through `wp_normalize_path` after `realpath`, so if the file does not exist, the `false` value gets converted to an empty string. The updated checks work both for `false` and `''` values.

Trac ticket: https://core.trac.wordpress.org/ticket/56654

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
