### PR TITLE
Try improving get_option() performance

### DIFF
--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -86,6 +86,11 @@ function get_option( $option, $default = false ) {
 		return false;
 	}
 
+	static $queried_options = array();
+	if ( isset( $queried_options[ $option ] ) ) {
+		return $queried_options[ $option ];
+	}
+
 	/*
 	 * Until a proper _deprecated_option() function can be introduced,
 	 * redirect requests to deprecated keys to the new, correct ones.
@@ -179,7 +184,8 @@ function get_option( $option, $default = false ) {
 			 * @param string $option  Option name.
 			 * @param bool   $passed_default Was `get_option()` passed a default value?
 			 */
-			return apply_filters( "default_option_{$option}", $default, $option, $passed_default );
+			$queried_options[ $option ] = apply_filters( "default_option_{$option}", $default, $option, $passed_default );
+			return $queried_options[ $option ];
 		}
 
 		$alloptions = wp_load_alloptions();
@@ -205,7 +211,8 @@ function get_option( $option, $default = false ) {
 					wp_cache_set( 'notoptions', $notoptions, 'options' );
 
 					/** This filter is documented in wp-includes/option.php */
-					return apply_filters( "default_option_{$option}", $default, $option, $passed_default );
+					$queried_options[ $option ] = apply_filters( "default_option_{$option}", $default, $option, $passed_default );
+					return $queried_options[ $option ];
 				}
 			}
 		}
@@ -218,7 +225,8 @@ function get_option( $option, $default = false ) {
 			$value = $row->option_value;
 		} else {
 			/** This filter is documented in wp-includes/option.php */
-			return apply_filters( "default_option_{$option}", $default, $option, $passed_default );
+			$queried_options[ $option ] = apply_filters( "default_option_{$option}", $default, $option, $passed_default );
+			return $queried_options[ $option ];
 		}
 	}
 
@@ -244,7 +252,8 @@ function get_option( $option, $default = false ) {
 	 *                       unserialized prior to being returned.
 	 * @param string $option Option name.
 	 */
-	return apply_filters( "option_{$option}", maybe_unserialize( $value ), $option );
+	$queried_options[ $option ] = apply_filters( "option_{$option}", maybe_unserialize( $value ), $option );
+	return $queried_options[ $option ];
 }
 
 /**


### PR DESCRIPTION
While running performance tests with Xdebug profiling & webgrind, it looks like `get_option` is the function that costs the most:

<img width="1264" alt="Screenshot 2022-09-26 at 1 59 39 PM" src="https://user-images.githubusercontent.com/588688/192260869-4bf9aa72-1bb1-4220-8d42-deaa871cbe4f.png">

While trying to see how to improve the performance of that function, I think we can achieve a lot by adding a `$queried_options` **static** variable.

With this patch applied, the results change completely. `get_option` moves down the list of costly functions and is now in the 21st position - no longer a bottleneck. Before the patch, it consumed 3.75% of resources (self-cost), after the patch it drops to 0.95%

<img width="1264" alt="Screenshot 2022-09-26 at 2 00 17 PM" src="https://user-images.githubusercontent.com/588688/192261326-3d31a3f9-2d0c-4b61-9f32-47b2fb71878a.png">

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
