### PR TITLE
Remove `--no-interaction` from Composer commands.

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Install Composer dependencies
         uses: ramsey/composer-install@f680dac46551dffb2234a240d65ae806c2999dd6 # v2.1.0
         with:
-          composer-options: "--no-progress --no-ansi --no-interaction"
+          composer-options: "--no-progress --no-ansi"
 
       - name: Make Composer packages available globally
         run: echo "${PWD}/vendor/bin" >> $GITHUB_PATH

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Install Composer dependencies
         uses: ramsey/composer-install@f680dac46551dffb2234a240d65ae806c2999dd6 # v2.1.0
         with:
-          composer-options: "--no-progress --no-ansi --no-interaction"
+          composer-options: "--no-progress --no-ansi"
 
       - name: Make Composer packages available globally
         run: echo "${PWD}/vendor/bin" >> $GITHUB_PATH


### PR DESCRIPTION
This is now configured by default in the `setup-php` action.

See https://github.com/shivammathur/setup-php/releases/tag/2.17.0.

Trac ticket: https://core.trac.wordpress.org/ticket/54695

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
