### PR TITLE
Backport appearance tools theme_support

### DIFF
--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -322,6 +322,11 @@ class WP_Theme_JSON_Resolver {
 
 			// Classic themes without a theme.json don't support global duotone.
 			$theme_support_data['settings']['color']['defaultDuotone'] = false;
+
+			// Allow themes to enable appearance tools via theme_support.
+			if ( current_theme_supports( 'appearance-tools' ) ) {
+				$theme_support_data['settings']['appearanceTools'] = true;
+			}
 		}
 		$with_theme_supports = new WP_Theme_JSON( $theme_support_data );
 		$with_theme_supports->merge( static::$theme );


### PR DESCRIPTION
Backport of https://github.com/WordPress/gutenberg/pull/43337.

Quoting that PR's description:

> ## What?
> Allow a theme to enable `appearanceTools` to any theme including classic themes.
> 
> ## Why?
> Appearance tools are options in the block editor and don't require the use of the FSE to take advantage of. However there's no way to enable those tools for themes that don't use theme.json.
> 
> ## How?
> This checks for the 'appearance-tools' support and if present flags `settings.appearanceTools` as true in the `theme` portion of Global Styles.
> 
> ## Testing Instructions
> Using a theme that does NOT use a theme.json file enable the 'appearanceTools` theme support.
> 
> ```
> add_theme_support( 'appearance-tools' );
> ```
> 
> Add a group block to a new post. Note the block settings panel includes `Border` settings.

Trac ticket: https://core.trac.wordpress.org/ticket/56467
Trac ticket: https://core.trac.wordpress.org/ticket/56487

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
