### PR TITLE
Persisted preferences: Fix incorrect `context` property

### DIFF
--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -4990,11 +4990,11 @@ function wp_register_persisted_preferences_meta() {
 			'type'         => 'object',
 			'single'       => true,
 			'show_in_rest' => array(
-				'name'    => 'persisted_preferences',
-				'type'    => 'object',
-				'context' => array( 'edit' ),
-				'schema'  => array(
+				'name'   => 'persisted_preferences',
+				'type'   => 'object',
+				'schema' => array(
 					'type'                 => 'object',
+					'context'              => array( 'edit' ),
 					'properties'           => array(
 						'_modified' => array(
 							'description' => __( 'The date and time the preferences were updated.' ),

--- a/tests/phpunit/tests/user/wpRegisterPersistedPreferencesMeta.php
+++ b/tests/phpunit/tests/user/wpRegisterPersistedPreferencesMeta.php
@@ -36,11 +36,11 @@ class Tests_User_WpRegisterPersistedPreferencesMeta extends WP_UnitTestCase {
 				'sanitize_callback' => null,
 				'auth_callback'     => '__return_true',
 				'show_in_rest'      => array(
-					'name'    => 'persisted_preferences',
-					'type'    => 'object',
-					'context' => array( 'edit' ),
-					'schema'  => array(
+					'name'   => 'persisted_preferences',
+					'type'   => 'object',
+					'schema' => array(
 						'type'                 => 'object',
+						'context'              => array( 'edit' ),
 						'properties'           => array(
 							'_modified' => array(
 								'description' => __( 'The date and time the preferences were updated.' ),


### PR DESCRIPTION
The user meta 'context' property for persisted preference is incorrectly configured. It should be part of the 'schema' array, but is incorrectly part of the 'show_in_rest' array:
https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/user.php#L4986-L5010

Trac ticket: https://core.trac.wordpress.org/ticket/56665

props dd32

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
