### PR TITLE
WP_REST_Users_Controller::update_item(): bug fix/remove redundant code

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
@@ -715,17 +715,9 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 			return $user;
 		}
 
-		$id = $user->ID;
-
-		if ( ! $id ) {
-			return new WP_Error(
-				'rest_user_invalid_id',
-				__( 'Invalid user ID.' ),
-				array( 'status' => 404 )
-			);
-		}
-
+		$id       = $user->ID;
 		$owner_id = false;
+
 		if ( is_string( $request['email'] ) ) {
 			$owner_id = email_exists( $request['email'] );
 		}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
@@ -717,7 +717,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 
 		$id = $user->ID;
 
-		if ( ! $user ) {
+		if ( ! $id ) {
 			return new WP_Error(
 				'rest_user_invalid_id',
 				__( 'Invalid user ID.' ),


### PR DESCRIPTION
As per https://github.com/WordPress/wordpress-develop/pull/3188#discussion_r981041394, this PR contains two commits to show the different solution directions.

---


### WP_REST_Users_Controller::update_item(): bug fix

While looking at the code of the `WP_REST_Users_Controller::update_item()` method, I also noticed another bug.

At the start of the function, the user is retrieved and it is verified that this doesn't result in a `WP_Error`.
Next, the `WP_User` `$user` variable is used to retrieve the user id.

Then in the next condition, it is checked if the `$user` is falsey. This condition would never match as `WP_REST_Users_Controller::get_user()` returns either a `WP_User` object or `WP_Error` and we already know it's not a `WP_Error` and an instantiated `WP_User` object will never evaluate to falsey.

As the `WP_Error` being thrown _within_ the condition refers to an "invalid user id", I believe the _intention_ of the code was to check that `$id` is not falsey, which would make more sense, as even though it would be unlikely that a `WP_User` object would not have a valid ID, that condition _could_ potential match and trigger the `WP_Error`.

There are already tests in place which (try to) cover this code, but as the `WP_REST_Users_Controller::get_user()` method throws the same error, it went unnoticed that this condition is incorrect.

In all honesty, IMO, this whole condition can be removed as it is already handled by the call to `WP_REST_Users_Controller::get_user()`....

### WP_REST_Users_Controller::update_item(): remove unnecessary condition

The condition could never be `true`, so is redundant.

See the commit message of the first commit and the discussion in PR #3188 for full details.

Trac ticket: https://core.trac.wordpress.org/ticket/56662

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
