### PR TITLE
Theme JSON classes: Ensure cache is cleared after Template Part block variations are registered

### DIFF
--- a/src/wp-includes/blocks/template-part.php
+++ b/src/wp-includes/blocks/template-part.php
@@ -225,6 +225,15 @@ function build_template_part_block_instance_variations() {
 			),
 		);
 	}
+
+	/*
+	 * Clear Theme JSON block cache so that subsequent block registrations are
+	 * respected when it is next accessed. This is required because `get_block_templates`
+	 * has a side effect of caching the list of currently registered blocks.
+	 */
+	WP_Theme_JSON_Resolver::clean_cached_data();
+	WP_Theme_JSON::clean_cached_data();
+
 	return $variations;
 }
 

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -450,6 +450,15 @@ class WP_Theme_JSON {
 	);
 
 	/**
+	 * Cleans the cached data so it can be recalculated.
+	 *
+	 * @since 6.1.0
+	 */
+	public static function clean_cached_data() {
+		static::$blocks_metadata = null;
+	}
+
+	/**
 	 * Returns a class name by an element name.
 	 *
 	 * @since 6.1.0


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

This is an attempt to resolve the issue where global styles for static blocks are not being output in the WordPress 6.1 beta. There is discussion behind why this issue occurred over in https://github.com/WordPress/gutenberg/issues/44434#issuecomment-1260270326. The short version is that the Template Part block calls `get_block_templates`, a public function which has a side-effect of caching the current list of registered blocks. The Template Part block calls this at registration time, so unless we clear the cache after calling it, the Theme JSON classes will not recognise subsequently registered blocks.

The explored fix here is to add a mechanism to also clear the static cache in `WP_Theme_JSON` and clear the cache for both this and `WP_Theme_JSON_Resolver` once the Template Part block has concluded getting the information it requires to generate the list of variations.

Trac ticket: https://core.trac.wordpress.org/ticket/56644

See also related Github issue: https://github.com/WordPress/gutenberg/issues/44434

### How to test

A simple way to test whether this fix works, is to add a few Button blocks to a post in TwentyTwentyTwo theme. See the below before and after and note that in the after screenshot, the theme's `theme.json` styles for the Button block are correctly output to the site frontend.

### A note on this fix

A better fix might to come up with a more generalised solution for this, or to update how `get_block_templates` works to ensure data isn't cached? The goal with this PR is to try to find a pragmatic but good enough short-term fix. If this looks viable, I'm happy to have a go at adding tests, too — though, I'm not 100% sure how to reliably test for it, so would be very happy for any feedback.

| Before | After |
| --- | --- |
| <img width="1136" alt="image" src="https://user-images.githubusercontent.com/14988353/192704978-e43957d7-8868-490c-814d-83c6fe24fae1.png"> | <img width="1136" alt="image" src="https://user-images.githubusercontent.com/14988353/192704825-6cc455bc-dde5-45ba-b94d-b4e584e92e9e.png"> |


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
