### PR TITLE
#54997  Fix null to parameter #1 ($string) of type string is deprecated in wp…

### DIFF
--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -1064,7 +1064,9 @@ function load_script_textdomain( $handle, $domain = 'default', $path = null ) {
 	if ( ! isset( $wp_scripts->registered[ $handle ] ) ) {
 		return false;
 	}
-
+	if(!is_null($path)) {
+		//removing slashes from null doesn't make sense
+	}
 	$path   = untrailingslashit( $path );
 	$locale = determine_locale();
 

--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -1064,10 +1064,10 @@ function load_script_textdomain( $handle, $domain = 'default', $path = null ) {
 	if ( ! isset( $wp_scripts->registered[ $handle ] ) ) {
 		return false;
 	}
-	if(!is_null($path)) {
+	if ( ! is_null( $path ) ) {
 		//removing slashes from null doesn't make sense
+		$path   = untrailingslashit( $path );
 	}
-	$path   = untrailingslashit( $path );
 	$locale = determine_locale();
 
 	// If a path was given and the handle file exists simply return it.


### PR DESCRIPTION
…-includes\formatting.php on line 2789

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
