### PR TITLE
WP_Theme_JSON: Invalidate blocks metadata cache when needed

### DIFF
--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -178,29 +178,31 @@ class WP_Theme_JSON_Resolver {
 
 		$options = wp_parse_args( $options, array( 'with_supports' => true ) );
 
-		$theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json' ) );
-		$theme_json_data = static::translate( $theme_json_data, wp_get_theme()->get( 'TextDomain' ) );
-		/**
-		 * Filters the data provided by the theme for global styles & settings.
-		 *
-		 * @since 6.1.0
-		 *
-		 * @param WP_Theme_JSON_Data Class to access and update the underlying data.
-		 */
-		$theme_json      = apply_filters( 'theme_json_theme', new WP_Theme_JSON_Data( $theme_json_data, 'theme' ) );
-		$theme_json_data = $theme_json->get_data();
-		static::$theme   = new WP_Theme_JSON( $theme_json_data );
+		if ( null === static::$theme ) {
+			$theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json' ) );
+			$theme_json_data = static::translate( $theme_json_data, wp_get_theme()->get( 'TextDomain' ) );
+			/**
+			 * Filters the data provided by the theme for global styles & settings.
+			 *
+			 * @since 6.1.0
+			 *
+			 * @param WP_Theme_JSON_Data Class to access and update the underlying data.
+			 */
+			$theme_json      = apply_filters( 'theme_json_theme', new WP_Theme_JSON_Data( $theme_json_data, 'theme' ) );
+			$theme_json_data = $theme_json->get_data();
+			static::$theme   = new WP_Theme_JSON( $theme_json_data );
 
-		if ( wp_get_theme()->parent() ) {
-			// Get parent theme.json.
-			$parent_theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json', true ) );
-			$parent_theme_json_data = static::translate( $parent_theme_json_data, wp_get_theme()->parent()->get( 'TextDomain' ) );
-			$parent_theme           = new WP_Theme_JSON( $parent_theme_json_data );
+			if ( wp_get_theme()->parent() ) {
+				// Get parent theme.json.
+				$parent_theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json', true ) );
+				$parent_theme_json_data = static::translate( $parent_theme_json_data, wp_get_theme()->parent()->get( 'TextDomain' ) );
+				$parent_theme           = new WP_Theme_JSON( $parent_theme_json_data );
 
-			// Merge the child theme.json into the parent theme.json.
-			// The child theme takes precedence over the parent.
-			$parent_theme->merge( static::$theme );
-			static::$theme = $parent_theme;
+				// Merge the child theme.json into the parent theme.json.
+				// The child theme takes precedence over the parent.
+				$parent_theme->merge( static::$theme );
+				static::$theme = $parent_theme;
+			}
 		}
 
 		if ( ! $options['with_supports'] ) {

--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -178,31 +178,29 @@ class WP_Theme_JSON_Resolver {
 
 		$options = wp_parse_args( $options, array( 'with_supports' => true ) );
 
-		if ( null === static::$theme ) {
-			$theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json' ) );
-			$theme_json_data = static::translate( $theme_json_data, wp_get_theme()->get( 'TextDomain' ) );
-			/**
-			 * Filters the data provided by the theme for global styles & settings.
-			 *
-			 * @since 6.1.0
-			 *
-			 * @param WP_Theme_JSON_Data Class to access and update the underlying data.
-			 */
-			$theme_json      = apply_filters( 'theme_json_theme', new WP_Theme_JSON_Data( $theme_json_data, 'theme' ) );
-			$theme_json_data = $theme_json->get_data();
-			static::$theme   = new WP_Theme_JSON( $theme_json_data );
+		$theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json' ) );
+		$theme_json_data = static::translate( $theme_json_data, wp_get_theme()->get( 'TextDomain' ) );
+		/**
+		 * Filters the data provided by the theme for global styles & settings.
+		 *
+		 * @since 6.1.0
+		 *
+		 * @param WP_Theme_JSON_Data Class to access and update the underlying data.
+		 */
+		$theme_json      = apply_filters( 'theme_json_theme', new WP_Theme_JSON_Data( $theme_json_data, 'theme' ) );
+		$theme_json_data = $theme_json->get_data();
+		static::$theme   = new WP_Theme_JSON( $theme_json_data );
 
-			if ( wp_get_theme()->parent() ) {
-				// Get parent theme.json.
-				$parent_theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json', true ) );
-				$parent_theme_json_data = static::translate( $parent_theme_json_data, wp_get_theme()->parent()->get( 'TextDomain' ) );
-				$parent_theme           = new WP_Theme_JSON( $parent_theme_json_data );
+		if ( wp_get_theme()->parent() ) {
+			// Get parent theme.json.
+			$parent_theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json', true ) );
+			$parent_theme_json_data = static::translate( $parent_theme_json_data, wp_get_theme()->parent()->get( 'TextDomain' ) );
+			$parent_theme           = new WP_Theme_JSON( $parent_theme_json_data );
 
-				// Merge the child theme.json into the parent theme.json.
-				// The child theme takes precedence over the parent.
-				$parent_theme->merge( static::$theme );
-				static::$theme = $parent_theme;
-			}
+			// Merge the child theme.json into the parent theme.json.
+			// The child theme takes precedence over the parent.
+			$parent_theme->merge( static::$theme );
+			static::$theme = $parent_theme;
 		}
 
 		if ( ! $options['with_supports'] ) {

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -735,7 +735,7 @@ class WP_Theme_JSON {
 
 		// Do we have metadata for all currently registered blocks?
 		$blocks = array_diff_key( $blocks, static::$blocks_metadata );
-		if ( count( $blocks ) === 0 ) {
+		if ( empty( $blocks ) ) {
 			return static::$blocks_metadata;
 		}
 

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -740,7 +740,6 @@ class WP_Theme_JSON {
 			}
 		}
 
-		static::$blocks_metadata = array();
 		foreach ( $blocks as $block_name => $block_type ) {
 			if (
 				isset( $block_type->supports['__experimentalSelector'] ) &&

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -33,7 +33,7 @@ class WP_Theme_JSON {
 	 * process it twice.
 	 *
 	 * @since 5.8.0
-	 * @since 6.1.0 Initialize as empty array.
+	 * @since 6.1.0 Initialize as an empty array.
 	 * @var array
 	 */
 	protected static $blocks_metadata = array();

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -729,14 +729,16 @@ class WP_Theme_JSON {
 	 * @return array Block metadata.
 	 */
 	protected static function get_blocks_metadata() {
-		if ( null !== static::$blocks_metadata ) {
-			return static::$blocks_metadata;
-		}
-
-		static::$blocks_metadata = array();
-
 		$registry = WP_Block_Type_Registry::get_instance();
 		$blocks   = $registry->get_all_registered();
+
+		if ( null !== static::$blocks_metadata ) {
+			$missing_blocks = array_diff_key( $blocks, static::$blocks_metadata );
+			if ( count( $missing_blocks ) === 0 ) {
+				return static::$blocks_metadata;
+			}
+		}
+
 		foreach ( $blocks as $block_name => $block_type ) {
 			if (
 				isset( $block_type->supports['__experimentalSelector'] ) &&

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -733,7 +733,7 @@ class WP_Theme_JSON {
 		$registry = WP_Block_Type_Registry::get_instance();
 		$blocks   = $registry->get_all_registered();
 
-		// Do we have metadata for all currently registered blocks?
+		// Is there metadata for all currently registered blocks?
 		$blocks = array_diff_key( $blocks, static::$blocks_metadata );
 		if ( empty( $blocks ) ) {
 			return static::$blocks_metadata;

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -33,9 +33,10 @@ class WP_Theme_JSON {
 	 * process it twice.
 	 *
 	 * @since 5.8.0
+	 * @since 6.1.0 Initialize as empty array.
 	 * @var array
 	 */
-	protected static $blocks_metadata = null;
+	protected static $blocks_metadata = array();
 
 	/**
 	 * The CSS selector for the top-level styles.
@@ -732,14 +733,10 @@ class WP_Theme_JSON {
 		$registry = WP_Block_Type_Registry::get_instance();
 		$blocks   = $registry->get_all_registered();
 
-		if ( null === static::$blocks_metadata ) {
-			static::$blocks_metadata = array();
-		} else {
-			// Do we have metadata for all currently registered blocks?
-			$blocks = array_diff_key( $blocks, static::$blocks_metadata );
-			if ( count( $blocks ) === 0 ) {
-				return static::$blocks_metadata;
-			}
+		// Do we have metadata for all currently registered blocks?
+		$blocks = array_diff_key( $blocks, static::$blocks_metadata );
+		if ( count( $blocks ) === 0 ) {
+			return static::$blocks_metadata;
 		}
 
 		foreach ( $blocks as $block_name => $block_type ) {

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -739,6 +739,7 @@ class WP_Theme_JSON {
 			}
 		}
 
+		static::$blocks_metadata = array();
 		foreach ( $blocks as $block_name => $block_type ) {
 			if (
 				isset( $block_type->supports['__experimentalSelector'] ) &&

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -732,7 +732,9 @@ class WP_Theme_JSON {
 		$registry = WP_Block_Type_Registry::get_instance();
 		$blocks   = $registry->get_all_registered();
 
-		if ( null !== static::$blocks_metadata ) {
+		if ( null === static::$blocks_metadata ) {
+			static::$blocks_metadata = array();
+		} else {
 			// Do we have metadata for all currently registered blocks?
 			$blocks = array_diff_key( $blocks, static::$blocks_metadata );
 			if ( count( $blocks ) === 0 ) {

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -733,8 +733,9 @@ class WP_Theme_JSON {
 		$blocks   = $registry->get_all_registered();
 
 		if ( null !== static::$blocks_metadata ) {
-			$missing_blocks = array_diff_key( $blocks, static::$blocks_metadata );
-			if ( count( $missing_blocks ) === 0 ) {
+			// Do we have metadata for all currently registered blocks?
+			$blocks = array_diff_key( $blocks, static::$blocks_metadata );
+			if ( count( $blocks ) === 0 ) {
 				return static::$blocks_metadata;
 			}
 		}


### PR DESCRIPTION
Tentative fix for [56644](https://core.trac.wordpress.org/ticket/56644). Alternative to https://github.com/WordPress/wordpress-develop/pull/3352.

Props @oandregal @andrewserong @talldan for tracking this down in https://github.com/WordPress/gutenberg/issues/44434.

The essential conclusion from https://github.com/WordPress/gutenberg/issues/44434 is that blocks metadata is cached upon reading. However, since it's read during registration of the Template Part block, metadata is never updated _after_ that block is registered, and thus absent for [a whole slew of blocks](https://github.com/WordPress/gutenberg/issues/44434#issuecomment-1260077765). OTOH, Global Styles uses a sanitization mechanism that, among other things, verifies that the block that a style is applied to is actually registered. This means that styles are stripped from all blocks that happen to be registered after Template Part.

The solution I'm proposing is to make `WP_Theme_JSON::get_blocks_metadata()`'s caching a bit smarter, i.e. by checking if there are any blocks that have been registered for which no blocks metadata exists in cache, and to add that missing metadata.

## Testing Instructions

### Step-by-step reproduction instructions

(based on https://github.com/WordPress/gutenberg/issues/44434, originally from https://core.trac.wordpress.org/ticket/56644).

1. Go to the site editor.
1. Insert a button.
1. Open the global styles sidebar.
1. Open the blocks section.
1. Navigate to the button block.
1. Apply a background color.
1. Save the global styles.
1. Verify that the background color persist. _On trunk, it would be discarded on Save._

_Note that this PR doesn't fix https://github.com/WordPress/gutenberg/issues/44619, which, while closely related, isn't the same issue. (Some of the comments on this PR refer to that issue; I've opted to tackle it separately, see https://github.com/WordPress/gutenberg/issues/44434#issuecomment-1266889744.)_

Trac ticket: https://core.trac.wordpress.org/ticket/56644

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
