### PR TITLE
Backport: Bug fixes in theme json with fluid typography and spacing presets

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -334,6 +334,7 @@ class WP_Theme_JSON {
 			'units'             => null,
 		),
 		'typography'                    => array(
+			'fluid'          => null,
 			'customFontSize' => null,
 			'dropCap'        => null,
 			'fontFamilies'   => null,

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -173,15 +173,6 @@ class WP_Theme_JSON {
 			'classes'           => array(),
 			'properties'        => array( 'padding', 'margin' ),
 		),
-		array(
-			'path'              => array( 'spacing', 'spacingScale' ),
-			'prevent_override'  => false,
-			'use_default_names' => true,
-			'value_key'         => 'size',
-			'css_vars'          => '--wp--preset--spacing--$slug',
-			'classes'           => array(),
-			'properties'        => array( 'padding', 'margin' ),
-		),
 	);
 
 	/**


### PR DESCRIPTION
The new fluid typography setting is missing from the theme.json valid values in 6.1, which causes the value to be dropped from theme exports from the editor as [reported here](https://github.com/WordPress/gutenberg/issues/44546).

Trac ticket: https://core.trac.wordpress.org/ticket/56684