### PR TITLE
PHP 8.2: remove deprecated callable in Style Engine value functions

### DIFF
--- a/src/wp-includes/style-engine/class-wp-style-engine.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine.php
@@ -107,28 +107,28 @@ class WP_Style_Engine {
 				'path'          => array( 'border', 'width' ),
 			),
 			'top'    => array(
-				'value_func' => 'static::get_individual_property_css_declarations',
+				'value_func' => array( self::class, 'get_individual_property_css_declarations' ),
 				'path'       => array( 'border', 'top' ),
 				'css_vars'   => array(
 					'color' => '--wp--preset--color--$slug',
 				),
 			),
 			'right'  => array(
-				'value_func' => 'static::get_individual_property_css_declarations',
+				'value_func' => array( self::class, 'get_individual_property_css_declarations' ),
 				'path'       => array( 'border', 'right' ),
 				'css_vars'   => array(
 					'color' => '--wp--preset--color--$slug',
 				),
 			),
 			'bottom' => array(
-				'value_func' => 'static::get_individual_property_css_declarations',
+				'value_func' => array( self::class, 'get_individual_property_css_declarations' ),
 				'path'       => array( 'border', 'bottom' ),
 				'css_vars'   => array(
 					'color' => '--wp--preset--color--$slug',
 				),
 			),
 			'left'   => array(
-				'value_func' => 'static::get_individual_property_css_declarations',
+				'value_func' => array( self::class, 'get_individual_property_css_declarations' ),
 				'path'       => array( 'border', 'left' ),
 				'css_vars'   => array(
 					'color' => '--wp--preset--color--$slug',

--- a/src/wp-includes/style-engine/class-wp-style-engine.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine.php
@@ -14,13 +14,14 @@
  *
  * The Style Engine aims to provide a consistent API for rendering styling for blocks across both client-side and server-side applications.
  *
+ * This class is final and should not be extended.
  * This class is for internal Core usage and is not supposed to be used by extenders (plugins and/or themes).
  * This is a low-level API that may need to do breaking changes. Please, use wp_style_engine_get_styles instead.
  *
  * @access private
  * @since 6.1.0
  */
-class WP_Style_Engine {
+final class WP_Style_Engine {
 	/**
 	 * Style definitions that contain the instructions to
 	 * parse/output valid Gutenberg styles from a block's attributes.


### PR DESCRIPTION
The string syntax for callables will be deprecated in version 9. 

8.2 shows a deprecation notice.

See: https://wiki.php.net/rfc/deprecate_partially_supported_callables

This PR switches to use to `array( self::class, '*' )` and makes the WP_Style_Engine class final with the understanding that we won't need to, nor should we, extend it.

See comment: https://core.trac.wordpress.org/ticket/56467#comment:242 for a description of the deprecation notice and explanation.

Check the unit test run logs created by the `8.2 on ubuntu-latest` job and ensure that the deprecation notice does not appear:

For example:

```
1) Test_Block_Supports_Border::test_border_color_slug_with_numbers_is_kebab_cased_properly
Use of "static" in callables is deprecated
```

Props to @jrfnl 

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/56467

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
