### PR TITLE
Docs: Use correct C in docblock `get_test_theme_version`

### DIFF
--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -478,7 +478,7 @@ class WP_Site_Health {
 	/**
 	 * Tests if themes are outdated, or unnecessary.
 	 *
-	 * Сhecks if your site has a default theme (to fall back on if there is a need),
+	 * Checks if your site has a default theme (to fall back on if there is a need),
 	 * if your themes are up to date and, finally, encourages you to remove any themes
 	 * that are not needed.
 	 *


### PR DESCRIPTION
Use `C` instead of `С` in docblock for `get_test_theme_version`.
https://en.wikipedia.org/wiki/Es_(Cyrillic)

https://core.trac.wordpress.org/ticket/55646