### PR TITLE
GH Actions: show PHPCS results both in log + PR

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -102,10 +102,18 @@ jobs:
         run: phpcs -i
 
       - name: Run PHPCS on all Core files
-        run: phpcs -q -n --report=checkstyle | cs2pr
+        continue-on-error: true
+        run: phpcs -n --report-full --report-checkstyle=./.cache/phpcs-report.xml
+
+      - name: Show PHPCS results in PR
+        run: cs2pr ./.cache/phpcs-report.xml
 
       - name: Check test suite files for warnings
-        run: phpcs tests -q --report=checkstyle | cs2pr
+        continue-on-error: true
+        run: phpcs tests --report-full --report-checkstyle=./.cache/phpcs-tests-report.xml
+
+      - name: Show test suite scan results in PR
+        run: cs2pr ./.cache/phpcs-tests-report.xml
 
       - name: Ensure version-controlled files are not modified during the tests
         run: git diff --exit-code

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -97,7 +97,11 @@ jobs:
         run: phpcs -i
 
       - name: Run PHP compatibility tests
-        run: phpcs --standard=phpcompat.xml.dist -q --report=checkstyle | cs2pr
+        continue-on-error: true
+        run: phpcs --standard=phpcompat.xml.dist --report-full --report-checkstyle=./.cache/phpcs-compat-report.xml
+
+      - name: Show PHPCompatibility results in PR
+        run: cs2pr ./.cache/phpcs-compat-report.xml
 
       - name: Ensure version-controlled files are not modified or deleted
         run: git diff --exit-code

--- a/src/wp-activate.php
+++ b/src/wp-activate.php
@@ -6,7 +6,7 @@
  * @package WordPress
  */
 
-define( 'WP_INSTALLING', true );
+define('WP_INSTALLING', true);
 
 /** Sets up the WordPress Environment. */
 require __DIR__ . '/wp-load.php';
@@ -20,8 +20,8 @@ if ( ! is_multisite() ) {
 
 $valid_error_codes = array( 'already_active', 'blog_taken' );
 
-list( $activate_path ) = explode( '?', wp_unslash( $_SERVER['REQUEST_URI'] ) );
-$activate_cookie       = 'wp-activate-' . COOKIEHASH;
+[ $activate_path ] = explode( '?', wp_unslash( $_SERVER['REQUEST_URI'] ) );
+$activate_cookie   = 'wp-activate-' . COOKIEHASH;
 
 $key    = '';
 $result = null;

--- a/tests/phpunit/includes/bootstrap.php
+++ b/tests/phpunit/includes/bootstrap.php
@@ -31,7 +31,7 @@ require_once $config_file_path;
 require_once __DIR__ . '/functions.php';
 
 if ( defined( 'WP_RUN_CORE_TESTS' ) && WP_RUN_CORE_TESTS && ! is_dir( ABSPATH ) ) {
-	if ( substr( ABSPATH, -7 ) !== '/build/' ) {
+	if ( substr( ABSPATH, -7 ) != '/build/' ) {
 		printf(
 			'Error: The ABSPATH constant in the `wp-tests-config.php` file is set to a non-existent path "%s". Please verify.' . PHP_EOL,
 			ABSPATH


### PR DESCRIPTION
As it was, results of PHPCS runs would only ever show inline in a commit code view/PR code view.

This is confusing as people will often try to find an output log of the run in the GH Actions build log, not realizing the scan results are not available in the GH Actions log.

This commit changes the steps in the GH Actions workflows for both the PHPCS run against the WordPress Coding Standards as well as for the run against PHPCompatibility to show the full scan results report in the GH Actions logs **_as well as_** show the results in commit/PR code views and still fail the build correctly when new issues are detected.

I've elected to store the (temporary) `phpcs-report.xml` file in the `.cache` subdirectory as that directory is (git/svn)-ignored by default already, to prevent this new, temporary file from interfering with the `git diff` check at the end of the workflows.

Note: I'm also removing the `-q` (quiet) flag from the PHPCS runs as it could give the misleading impression that nothing happened in the step for a successfull run. The progress report being shown will take away that impression.

Refs:
* https://github.com/staabm/annotate-pull-request-from-checkstyle#using-php_codesniffer
* https://github.com/WordPress/gutenberg/issues/44536#issuecomment-1261753524


> ❗ The build failure on this PR can be ignored. This is intentional and caused by the second commit which was only added to demonstrate that the first commit works as intended.

Trac ticket: https://core.trac.wordpress.org/ticket/55652

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
