### PR TITLE
Stop slugs being cast to ints when theme is exported

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -2836,7 +2836,7 @@ class WP_Theme_JSON {
 				}
 				$flattened_preset = array();
 				foreach ( $items as $slug => $value ) {
-					$flattened_preset[] = array_merge( array( 'slug' => $slug ), $value );
+					$flattened_preset[] = array_merge( array( 'slug' => (string) $slug ), $value );
 				}
 				_wp_array_set( $output, $path, $flattened_preset );
 			}


### PR DESCRIPTION
The new spacing preset slugs get cast to ints when a theme is exported as reported in https://github.com/WordPress/gutenberg/issues/44546. This PR makes sure they are cast back to strings if PHP converts them to ints when they are used as array keys.

Trac ticket: https://core.trac.wordpress.org/ticket/56684

### Testing

- In a site with the 2023 theme set export the theme from the site editor
- Make sure the exported theme.json has the settings.spacingScale slugs as strings
- Check that the spacing presets still work as expected in post editor, site editor and frontend