### PR TITLE
Added deprecated warning to deprecated functions missing it.

### DIFF
--- a/src/wp-admin/includes/deprecated.php
+++ b/src/wp-admin/includes/deprecated.php
@@ -857,6 +857,7 @@ function screen_options( $screen ) {
  * @see WP_Screen::render_screen_meta()
  */
 function screen_meta( $screen ) {
+	_deprecated_function( __FUNCTION__, '3.3.0', 'WP_Screen::render_screen_meta()' );
 	$current_screen = get_current_screen();
 	$current_screen->render_screen_meta();
 }
@@ -1252,14 +1253,18 @@ function get_screen_icon() {
  * @since 2.5.0
  * @deprecated 3.8.0
  */
-function wp_dashboard_incoming_links_output() {}
+function wp_dashboard_incoming_links_output() {
+	_deprecated_function( __FUNCTION__, '3.8.0' );
+}
 
 /**
  * Deprecated dashboard secondary output.
  *
  * @deprecated 3.8.0
  */
-function wp_dashboard_secondary_output() {}
+function wp_dashboard_secondary_output() {
+	_deprecated_function( __FUNCTION__, '3.8.0' );
+}
 
 /**
  * Deprecated dashboard widget controls.
@@ -1267,49 +1272,63 @@ function wp_dashboard_secondary_output() {}
  * @since 2.7.0
  * @deprecated 3.8.0
  */
-function wp_dashboard_incoming_links() {}
+function wp_dashboard_incoming_links() {
+	_deprecated_function( __FUNCTION__, '3.8.0' );
+}
 
 /**
  * Deprecated dashboard incoming links control.
  *
  * @deprecated 3.8.0
  */
-function wp_dashboard_incoming_links_control() {}
+function wp_dashboard_incoming_links_control() {
+	_deprecated_function( __FUNCTION__, '3.8.0' );
+}
 
 /**
  * Deprecated dashboard plugins control.
  *
  * @deprecated 3.8.0
  */
-function wp_dashboard_plugins() {}
+function wp_dashboard_plugins() {
+	_deprecated_function( __FUNCTION__, '3.8.0' );
+}
 
 /**
  * Deprecated dashboard primary control.
  *
  * @deprecated 3.8.0
  */
-function wp_dashboard_primary_control() {}
+function wp_dashboard_primary_control() {
+	_deprecated_function( __FUNCTION__, '3.8.0' );
+}
 
 /**
  * Deprecated dashboard recent comments control.
  *
  * @deprecated 3.8.0
  */
-function wp_dashboard_recent_comments_control() {}
+function wp_dashboard_recent_comments_control() {
+	_deprecated_function( __FUNCTION__, '3.8.0' );
+}
 
 /**
  * Deprecated dashboard secondary section.
  *
  * @deprecated 3.8.0
  */
-function wp_dashboard_secondary() {}
+function wp_dashboard_secondary() {
+	_deprecated_function( __FUNCTION__, '3.8.0' );
+}
 
 /**
  * Deprecated dashboard secondary control.
  *
  * @deprecated 3.8.0
  */
-function wp_dashboard_secondary_control() {}
+function wp_dashboard_secondary_control() {
+	_deprecated_function( __FUNCTION__, '3.8.0' );
+}
 
 /**
  * Display plugins text for the WordPress news widget.
@@ -1505,6 +1524,7 @@ function post_form_autocomplete_off() {
  * @deprecated 4.9.0
  */
 function options_permalink_add_js() {
+	_deprecated_function( __FUNCTION__, '4.9.0' );
 	?>
 	<script type="text/javascript">
 		jQuery(document).ready(function() {

--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -2451,6 +2451,7 @@ function get_usernumposts( $userid ) {
  * @return string An HTML entity
  */
 function funky_javascript_callback($matches) {
+	_deprecated_function( __FUNCTION__, '3.0.0' );
 	return "&#".base_convert($matches[1],16,10).";";
 }
 
@@ -3301,7 +3302,9 @@ function user_pass_ok($user_login, $user_pass) {
  * @since 2.3.0
  * @deprecated 3.5.0
  */
-function _save_post_hook() {}
+function _save_post_hook() {
+	_deprecated_function( __FUNCTION__, '3.5.0' );
+}
 
 /**
  * Check if the installed version of GD supports particular image type
@@ -3417,6 +3420,7 @@ function rich_edit_exists() {
  * @return int Number of topics.
  */
 function default_topic_count_text( $count ) {
+	_deprecated_function( __FUNCTION__, '3.9.0' );
 	return $count;
 }
 
@@ -4106,6 +4110,7 @@ function remove_option_whitelist( $del_options, $options = '' ) {
  * @return mixed Slashes $value
  */
 function wp_slash_strings_only( $value ) {
+	_deprecated_function( __FUNCTION__, '5.6.0', 'wp_slash()' );
 	return map_deep( $value, 'addslashes_strings_only' );
 }
 
@@ -4121,6 +4126,7 @@ function wp_slash_strings_only( $value ) {
  * @return mixed
  */
 function addslashes_strings_only( $value ) {
+	_deprecated_function( __FUNCTION__, '5.6.0', 'wp_slash()' );
 	return is_string( $value ) ? addslashes( $value ) : $value;
 }
 

--- a/tests/phpunit/tests/import/import.php
+++ b/tests/phpunit/tests/import/import.php
@@ -249,6 +249,7 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 	}
 
 	public function test_ordering_of_importers() {
+		$this->expected_deprecated = array();
 		global $wp_importers;
 		$_wp_importers = $wp_importers; // Preserve global state.
 		$wp_importers  = array(

--- a/tests/phpunit/tests/import/import.php
+++ b/tests/phpunit/tests/import/import.php
@@ -6,6 +6,12 @@ require_once __DIR__ . '/base.php';
  * @group import
  */
 class Tests_Import_Import extends WP_Import_UnitTestCase {
+
+	protected $expected_deprecated = [
+		'wp_slash_strings_only',
+		'addslashes_strings_only'
+	];
+
 	public function set_up() {
 		parent::set_up();
 

--- a/tests/phpunit/tests/import/import.php
+++ b/tests/phpunit/tests/import/import.php
@@ -9,7 +9,7 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 
 	protected $expected_deprecated = array(
 		'wp_slash_strings_only',
-		'addslashes_strings_only'
+		'addslashes_strings_only',
 	);
 
 	public function set_up() {

--- a/tests/phpunit/tests/import/import.php
+++ b/tests/phpunit/tests/import/import.php
@@ -7,10 +7,10 @@ require_once __DIR__ . '/base.php';
  */
 class Tests_Import_Import extends WP_Import_UnitTestCase {
 
-	protected $expected_deprecated = [
+	protected $expected_deprecated = array(
 		'wp_slash_strings_only',
 		'addslashes_strings_only'
-	];
+	);
 
 	public function set_up() {
 		parent::set_up();

--- a/tests/phpunit/tests/import/parser.php
+++ b/tests/phpunit/tests/import/parser.php
@@ -6,6 +6,12 @@ require_once __DIR__ . '/base.php';
  * @group import
  */
 class Tests_Import_Parser extends WP_Import_UnitTestCase {
+
+	protected $expected_deprecated = [
+		'wp_slash_strings_only',
+		'addslashes_strings_only'
+	];
+
 	public function set_up() {
 		parent::set_up();
 

--- a/tests/phpunit/tests/import/parser.php
+++ b/tests/phpunit/tests/import/parser.php
@@ -7,11 +7,6 @@ require_once __DIR__ . '/base.php';
  */
 class Tests_Import_Parser extends WP_Import_UnitTestCase {
 
-	protected $expected_deprecated = array(
-		'wp_slash_strings_only',
-		'addslashes_strings_only',
-	);
-
 	public function set_up() {
 		parent::set_up();
 

--- a/tests/phpunit/tests/import/parser.php
+++ b/tests/phpunit/tests/import/parser.php
@@ -7,10 +7,10 @@ require_once __DIR__ . '/base.php';
  */
 class Tests_Import_Parser extends WP_Import_UnitTestCase {
 
-	protected $expected_deprecated = [
+	protected $expected_deprecated = array(
 		'wp_slash_strings_only',
 		'addslashes_strings_only'
-	];
+	);
 
 	public function set_up() {
 		parent::set_up();

--- a/tests/phpunit/tests/import/parser.php
+++ b/tests/phpunit/tests/import/parser.php
@@ -9,7 +9,7 @@ class Tests_Import_Parser extends WP_Import_UnitTestCase {
 
 	protected $expected_deprecated = array(
 		'wp_slash_strings_only',
-		'addslashes_strings_only'
+		'addslashes_strings_only',
 	);
 
 	public function set_up() {

--- a/tests/phpunit/tests/import/postmeta.php
+++ b/tests/phpunit/tests/import/postmeta.php
@@ -6,6 +6,11 @@ require_once __DIR__ . '/base.php';
  * @group import
  */
 class Tests_Import_Postmeta extends WP_Import_UnitTestCase {
+	protected $expected_deprecated = array(
+		'wp_slash_strings_only',
+		'addslashes_strings_only',
+	);
+
 	public function set_up() {
 		parent::set_up();
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->
Added missing `_deprecated_function` call in deprecated functions missing it.

Trac ticket: https://core.trac.wordpress.org/ticket/56589

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
