### PR TITLE
 i18n: Define 'word count type' as a WP_Locale property.

### DIFF
--- a/src/wp-includes/class-wp-locale.php
+++ b/src/wp-includes/class-wp-locale.php
@@ -247,7 +247,7 @@ class WP_Locale {
 		 */
 		$word_count_type = _x( 'words', 'Word count type. Do not translate!' );
 
-		if ( 'characters_excluding_spaces' === $word_count_type || 'characters_including_spaces' === $word_count_type) {
+		if ( 'characters_excluding_spaces' === $word_count_type || 'characters_including_spaces' === $word_count_type ) {
 			$this->word_count_type = $word_count_type;
 		}
 	}

--- a/src/wp-includes/class-wp-locale.php
+++ b/src/wp-includes/class-wp-locale.php
@@ -105,6 +105,16 @@ class WP_Locale {
 	public $list_item_separator;
 
 	/**
+	 * The word count type of the locale language.
+	 *
+	 * Default is 'words'.
+	 *
+	 * @since 6.1.0
+	 * @var string
+	 */
+	public $word_count_type = 'words';
+
+	/**
 	 * Constructor which calls helper methods to set up object variables.
 	 *
 	 * @since 2.1.0
@@ -228,6 +238,17 @@ class WP_Locale {
 			/* translators: 'rtl' or 'ltr'. This sets the text direction for WordPress. */
 		} elseif ( 'rtl' === _x( 'ltr', 'text direction' ) ) {
 			$this->text_direction = 'rtl';
+		}
+
+		/*
+		 * translators: If your word count is based on single characters (e.g. East Asian characters),
+		 * enter 'characters_excluding_spaces' or 'characters_including_spaces'. Otherwise, enter 'words'.
+		 * Do not translate into your own language.
+		 */
+		$word_count_type = _x( 'words', 'Word count type. Do not translate!' );
+
+		if ( 'characters_excluding_spaces' === $word_count_type || 'characters_including_spaces' === $word_count_type) {
+			$this->word_count_type = $word_count_type;
 		}
 	}
 
@@ -388,5 +409,16 @@ class WP_Locale {
 	 */
 	public function get_list_item_separator() {
 		return $this->list_item_separator;
+	}
+
+	/**
+	 * Retrieves the localized word count type.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @return string Localized word count type.
+	 */
+	public function get_word_count_type() {
+		return $this->word_count_type;
 	}
 }

--- a/src/wp-includes/class-wp-locale.php
+++ b/src/wp-includes/class-wp-locale.php
@@ -109,7 +109,7 @@ class WP_Locale {
 	 *
 	 * Default is 'words'.
 	 *
-	 * @since 6.1.0
+	 * @since 6.2.0
 	 * @var string
 	 */
 	public $word_count_type = 'words';
@@ -414,7 +414,7 @@ class WP_Locale {
 	/**
 	 * Retrieves the localized word count type.
 	 *
-	 * @since 6.1.0
+	 * @since 6.2.0
 	 *
 	 * @return string Localized word count type.
 	 */

--- a/src/wp-includes/class-wp-locale.php
+++ b/src/wp-includes/class-wp-locale.php
@@ -240,20 +240,8 @@ class WP_Locale {
 			$this->text_direction = 'rtl';
 		}
 
-		/*
-		 * translators: If your word count is based on single characters (e.g. East Asian characters),
-		 * enter 'characters_excluding_spaces' or 'characters_including_spaces'. Otherwise, enter 'words'.
-		 * Do not translate into your own language.
-		 */
-		$word_count_type = is_null( $this->word_count_type ) ? _x( 'words', 'Word count type. Do not translate!' ) : $this->word_count_type;
-
-		// Check for valid types.
-		if ( 'characters_excluding_spaces' === $word_count_type || 'characters_including_spaces' === $word_count_type ) {
-			$this->word_count_type = $word_count_type;
-		} else {
-			// Defaults to 'words'.
-			$this->word_count_type = 'words';
-		}
+		// Set the word count type.
+		$this->word_count_type = $this->get_word_count_type();
 	}
 
 	/**
@@ -418,11 +406,27 @@ class WP_Locale {
 	/**
 	 * Retrieves the localized word count type.
 	 *
+	 * Options are 'characters_excluding_spaces', 'characters_including_spaces or 'words'. Defaults to 'words'.
+	 *
 	 * @since 6.2.0
 	 *
 	 * @return string Localized word count type.
 	 */
 	public function get_word_count_type() {
-		return $this->word_count_type;
+
+		/*
+		 * translators: If your word count is based on single characters (e.g. East Asian characters),
+		 * enter 'characters_excluding_spaces' or 'characters_including_spaces'. Otherwise, enter 'words'.
+		 * Do not translate into your own language.
+		 */
+		$word_count_type = is_null( $this->word_count_type ) ? _x( 'words', 'Word count type. Do not translate!' ) : $this->word_count_type;
+
+		// Check for valid types.
+		if ( 'characters_excluding_spaces' !== $word_count_type && 'characters_including_spaces' !== $word_count_type ) {
+			// Defaults to 'words'.
+			$word_count_type = 'words';
+		}
+
+		return $word_count_type;
 	}
 }

--- a/src/wp-includes/class-wp-locale.php
+++ b/src/wp-includes/class-wp-locale.php
@@ -112,7 +112,7 @@ class WP_Locale {
 	 * @since 6.2.0
 	 * @var string
 	 */
-	public $word_count_type = 'words';
+	public $word_count_type;
 
 	/**
 	 * Constructor which calls helper methods to set up object variables.
@@ -245,10 +245,14 @@ class WP_Locale {
 		 * enter 'characters_excluding_spaces' or 'characters_including_spaces'. Otherwise, enter 'words'.
 		 * Do not translate into your own language.
 		 */
-		$word_count_type = _x( 'words', 'Word count type. Do not translate!' );
+		$word_count_type = is_null( $this->word_count_type ) ? _x( 'words', 'Word count type. Do not translate!' ) : $this->word_count_type;
 
+		// Check for valid types.
 		if ( 'characters_excluding_spaces' === $word_count_type || 'characters_including_spaces' === $word_count_type ) {
 			$this->word_count_type = $word_count_type;
+		} else {
+			// Defaults to 'words'.
+			$this->word_count_type = 'words';
 		}
 	}
 

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -3941,12 +3941,7 @@ function wp_trim_words( $text, $num_words = 55, $more = null ) {
 	$text          = wp_strip_all_tags( $text );
 	$num_words     = (int) $num_words;
 
-	/*
-	 * translators: If your word count is based on single characters (e.g. East Asian characters),
-	 * enter 'characters_excluding_spaces' or 'characters_including_spaces'. Otherwise, enter 'words'.
-	 * Do not translate into your own language.
-	 */
-	if ( strpos( _x( 'words', 'Word count type. Do not translate!' ), 'characters' ) === 0 && preg_match( '/^utf\-?8$/i', get_option( 'blog_charset' ) ) ) {
+	if ( strpos( wp_get_word_count_type(), 'characters' ) === 0 && preg_match( '/^utf\-?8$/i', get_option( 'blog_charset' ) ) ) {
 		$text = trim( preg_replace( "/[\n\r\t ]+/", ' ', $text ), ' ' );
 		preg_match_all( '/./u', $text, $words_array );
 		$words_array = array_slice( $words_array[0], 0, $num_words + 1 );

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -3941,7 +3941,7 @@ function wp_trim_words( $text, $num_words = 55, $more = null ) {
 	$text          = wp_strip_all_tags( $text );
 	$num_words     = (int) $num_words;
 
-	if ( strpos( wp_get_word_count_type(), 'characters' ) === 0 && preg_match( '/^utf\-?8$/i', get_option( 'blog_charset' ) ) ) {
+	if ( str_starts_with( wp_get_word_count_type(), 'characters' ) && preg_match( '/^utf\-?8$/i', get_option( 'blog_charset' ) ) ) {
 		$text = trim( preg_replace( "/[\n\r\t ]+/", ' ', $text ), ' ' );
 		preg_match_all( '/./u', $text, $words_array );
 		$words_array = array_slice( $words_array[0], 0, $num_words + 1 );

--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -1773,3 +1773,18 @@ function wp_get_list_item_separator() {
 
 	return $wp_locale->get_list_item_separator();
 }
+
+/**
+ * Retrieves the word count type based on the locale.
+ *
+ * @since 6.1.0
+ *
+ * @global WP_Locale $wp_locale WordPress date and time locale object.
+ *
+ * @return string Locale-specific word count type.
+ */
+function wp_get_word_count_type() {
+	global $wp_locale;
+
+	return $wp_locale->get_word_count_type();
+}

--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -1777,7 +1777,7 @@ function wp_get_list_item_separator() {
 /**
  * Retrieves the word count type based on the locale.
  *
- * @since 6.1.0
+ * @since 6.2.0
  *
  * @global WP_Locale $wp_locale WordPress date and time locale object.
  *

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1802,12 +1802,7 @@ function wp_just_in_time_script_localization() {
 		'word-count',
 		'wordCountL10n',
 		array(
-			/*
-			 * translators: If your word count is based on single characters (e.g. East Asian characters),
-			 * enter 'characters_excluding_spaces' or 'characters_including_spaces'. Otherwise, enter 'words'.
-			 * Do not translate into your own language.
-			 */
-			'type'       => _x( 'words', 'Word count type. Do not translate!' ),
+			'type'       => wp_get_word_count_type(),
 			'shortcodes' => ! empty( $GLOBALS['shortcode_tags'] ) ? array_keys( $GLOBALS['shortcode_tags'] ) : array(),
 		)
 	);

--- a/tests/phpunit/tests/locale.php
+++ b/tests/phpunit/tests/locale.php
@@ -140,4 +140,27 @@ class Tests_Locale extends WP_UnitTestCase {
 		$this->locale->text_direction = 'ltr';
 		$this->assertFalse( $this->locale->is_rtl() );
 	}
+
+	/**
+	 * @covers WP_Locale::get_word_count_type
+	 */
+	public function test_get_word_count_type() {
+		// Default value is 'words'.
+		$this->assertSame( 'words' ), $this->locale->get_word_count_type() );
+		// Type set to empty, fallsback to 'words'.
+		$this->locale->word_count_type = '';
+		$this->assertSame( 'words' ), $this->locale->get_word_count_type() );
+		// Type set to 'foo' (wrong), fallsback to 'words'.
+		$this->locale->word_count_type = 'foo';
+		$this->assertSame( 'words' ), $this->locale->get_word_count_type() );
+		// Type set to 'words' (correct).
+		$this->locale->word_count_type = 'words';
+		$this->assertSame( 'words' ), $this->locale->get_word_count_type() );
+		// Type set to 'characters_excluding_spaces' (correct).
+		$this->locale->word_count_type = 'characters_excluding_spaces';
+		$this->assertSame( 'characters_excluding_spaces' ), $this->locale->get_word_count_type() );
+		// Type set to 'characters_including_spaces' (correct).
+		$this->locale->word_count_type = 'characters_including_spaces';
+		$this->assertSame( 'characters_including_spaces' ), $this->locale->get_word_count_type() );
+	}
 }

--- a/tests/phpunit/tests/locale.php
+++ b/tests/phpunit/tests/locale.php
@@ -146,21 +146,21 @@ class Tests_Locale extends WP_UnitTestCase {
 	 */
 	public function test_get_word_count_type() {
 		// Default value is 'words'.
-		$this->assertSame( 'words' ), $this->locale->get_word_count_type() );
+		$this->assertSame( 'words', $this->locale->get_word_count_type() );
 		// Type set to empty, fallsback to 'words'.
 		$this->locale->word_count_type = '';
-		$this->assertSame( 'words' ), $this->locale->get_word_count_type() );
+		$this->assertSame( 'words', $this->locale->get_word_count_type() );
 		// Type set to 'foo' (wrong), fallsback to 'words'.
 		$this->locale->word_count_type = 'foo';
-		$this->assertSame( 'words' ), $this->locale->get_word_count_type() );
+		$this->assertSame( 'words', $this->locale->get_word_count_type() );
 		// Type set to 'words' (correct).
 		$this->locale->word_count_type = 'words';
-		$this->assertSame( 'words' ), $this->locale->get_word_count_type() );
+		$this->assertSame( 'words', $this->locale->get_word_count_type() );
 		// Type set to 'characters_excluding_spaces' (correct).
 		$this->locale->word_count_type = 'characters_excluding_spaces';
-		$this->assertSame( 'characters_excluding_spaces' ), $this->locale->get_word_count_type() );
+		$this->assertSame( 'characters_excluding_spaces', $this->locale->get_word_count_type() );
 		// Type set to 'characters_including_spaces' (correct).
 		$this->locale->word_count_type = 'characters_including_spaces';
-		$this->assertSame( 'characters_including_spaces' ), $this->locale->get_word_count_type() );
+		$this->assertSame( 'characters_including_spaces', $this->locale->get_word_count_type() );
 	}
 }


### PR DESCRIPTION
Add word count type as a locale property, so it doesn't need to be translated separately across multiple projects. This PR implements the following modifications:

- Define word count type as a new WP_Locale property
- Add `wp_get_word_count_type()` as a wrapper for `WP_Locale::get_word_count_type`
- Replace all `_x( 'words', 'Word count type. Do not translate!' )` strings with `wp_get_word_count_type()`


Trac ticket: #56698

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
