### PR TITLE
Run template-part registration after all other blocks

### DIFF
--- a/src/wp-includes/blocks/template-part.php
+++ b/src/wp-includes/blocks/template-part.php
@@ -249,4 +249,8 @@ function register_block_core_template_part() {
 		)
 	);
 }
-add_action( 'init', 'register_block_core_template_part', 22 );
+/*
+ * This block relies on generated styles from previously registered blocks, so
+ * it should be registered last.
+ */
+add_action( 'init', 'register_block_core_template_part', 29 );

--- a/src/wp-includes/blocks/template-part.php
+++ b/src/wp-includes/blocks/template-part.php
@@ -249,4 +249,4 @@ function register_block_core_template_part() {
 		)
 	);
 }
-add_action( 'init', 'register_block_core_template_part' );
+add_action( 'init', 'register_block_core_template_part', 22 );

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -345,7 +345,7 @@ add_action( 'template_redirect', 'wp_shortlink_header', 11, 0 );
 add_action( 'wp_print_footer_scripts', '_wp_footer_scripts' );
 add_action( 'init', '_register_core_block_patterns_and_categories' );
 add_action( 'init', 'check_theme_switched', 99 );
-add_action( 'init', array( 'WP_Block_Supports', 'init' ), 22 );
+add_action( 'init', array( 'WP_Block_Supports', 'init' ), 30 );
 add_action( 'switch_theme', array( 'WP_Theme_JSON_Resolver', 'clean_cached_data' ) );
 add_action( 'start_previewing_theme', array( 'WP_Theme_JSON_Resolver', 'clean_cached_data' ) );
 add_action( 'after_switch_theme', '_wp_menus_changed' );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This is another (partial) alternative to #3352, #3359, and #3373.

This adjusts the priorities of block registration so that the `core/template-part` block is registered last. This means that all blocks (except `core/template-part`) will be registered before the metadata form `get_blocks_metadata` is called for the first time.

It currently has the problem that the block metadata for the `core/template-part` block itself won't be included, but that may be fixed with the combination of cache invalidation from #3373 if we can guarantee that `register_block_core_template_part` never unregisters any blocks.

I upped the `WP_Block_Supports::init` priority value to make room for blocks like [`core/post-comments`](https://github.com/WordPress/wordpress-develop/blob/4a3d6ff8213d5264ba36c4021f8b9f0be227da51/src/wp-includes/blocks/comments.php#L152) to be registered after the rest of the core blocks, but before the `core/template-part` registration.

Trac ticket: https://core.trac.wordpress.org/ticket/56736

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
