### PR TITLE
remove unnecessary condition from assets-loading

### DIFF
--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -266,7 +266,7 @@ class WP_Block {
 			}
 		}
 
-		if ( ! empty( $this->block_type->view_script_handles ) && empty( $this->block_type->render_callback ) ) {
+		if ( ! empty( $this->block_type->view_script_handles ) ) {
 			foreach ( $this->block_type->view_script_handles as $view_script_handle ) {
 				wp_enqueue_script( $view_script_handle );
 			}


### PR DESCRIPTION
It appears that an extra condition was preventing multiple scripts from loading in blocks like the navigation block - where we need a separate script for the modal.

This patch removes an additional condition that is not necessary.
Whether a style or script gets enqueued should not be related to the block's render callback.

Trac ticket: https://core.trac.wordpress.org/ticket/56408

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
