### PR TITLE
Make Editor and Frontend reflect Block Styles in theme.json

### DIFF
--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -212,8 +212,10 @@ class WP_Theme_JSON_Resolver {
 			$parent_theme_json_data = static::translate( $parent_theme_json_data, wp_get_theme()->parent()->get( 'TextDomain' ) );
 			$parent_theme           = new WP_Theme_JSON( $parent_theme_json_data );
 
-			// Merge the child theme.json into the parent theme.json.
-			// The child theme takes precedence over the parent.
+			/*
+			 * Merge the child theme.json into the parent theme.json.
+			 * The child theme takes precedence over the parent.
+			 */
 			$parent_theme->merge( static::$theme );
 			static::$theme = $parent_theme;
 		}

--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -146,12 +146,9 @@ class WP_Theme_JSON_Resolver {
 	 * @return WP_Theme_JSON Entity that holds core data.
 	 */
 	public static function get_core_data() {
-		if ( null !== static::$core ) {
-			return static::$core;
-		}
-
 		$config = static::read_json_file( __DIR__ . '/theme.json' );
 		$config = static::translate( $config );
+
 		/**
 		 * Filters the default data provided by WordPress for global styles & settings.
 		 *

--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -193,31 +193,29 @@ class WP_Theme_JSON_Resolver {
 
 		$options = wp_parse_args( $options, array( 'with_supports' => true ) );
 
-		if ( null === static::$theme ) {
-			$theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json' ) );
-			$theme_json_data = static::translate( $theme_json_data, wp_get_theme()->get( 'TextDomain' ) );
-			/**
-			 * Filters the data provided by the theme for global styles & settings.
-			 *
-			 * @since 6.1.0
-			 *
-			 * @param WP_Theme_JSON_Data Class to access and update the underlying data.
-			 */
-			$theme_json      = apply_filters( 'theme_json_theme', new WP_Theme_JSON_Data( $theme_json_data, 'theme' ) );
-			$theme_json_data = $theme_json->get_data();
-			static::$theme   = new WP_Theme_JSON( $theme_json_data );
+		$theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json' ) );
+		$theme_json_data = static::translate( $theme_json_data, wp_get_theme()->get( 'TextDomain' ) );
+		/**
+		 * Filters the data provided by the theme for global styles & settings.
+		 *
+		 * @since 6.1.0
+		 *
+		 * @param WP_Theme_JSON_Data Class to access and update the underlying data.
+		 */
+		$theme_json      = apply_filters( 'theme_json_theme', new WP_Theme_JSON_Data( $theme_json_data, 'theme' ) );
+		$theme_json_data = $theme_json->get_data();
+		static::$theme   = new WP_Theme_JSON( $theme_json_data );
 
-			if ( wp_get_theme()->parent() ) {
-				// Get parent theme.json.
-				$parent_theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json', true ) );
-				$parent_theme_json_data = static::translate( $parent_theme_json_data, wp_get_theme()->parent()->get( 'TextDomain' ) );
-				$parent_theme           = new WP_Theme_JSON( $parent_theme_json_data );
+		if ( wp_get_theme()->parent() ) {
+			// Get parent theme.json.
+			$parent_theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json', true ) );
+			$parent_theme_json_data = static::translate( $parent_theme_json_data, wp_get_theme()->parent()->get( 'TextDomain' ) );
+			$parent_theme           = new WP_Theme_JSON( $parent_theme_json_data );
 
-				// Merge the child theme.json into the parent theme.json.
-				// The child theme takes precedence over the parent.
-				$parent_theme->merge( static::$theme );
-				static::$theme = $parent_theme;
-			}
+			// Merge the child theme.json into the parent theme.json.
+			// The child theme takes precedence over the parent.
+			$parent_theme->merge( static::$theme );
+			static::$theme = $parent_theme;
 		}
 
 		if ( ! $options['with_supports'] ) {

--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -195,6 +195,7 @@ class WP_Theme_JSON_Resolver {
 
 		$theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json' ) );
 		$theme_json_data = static::translate( $theme_json_data, wp_get_theme()->get( 'TextDomain' ) );
+		
 		/**
 		 * Filters the data provided by the theme for global styles & settings.
 		 *

--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -195,7 +195,7 @@ class WP_Theme_JSON_Resolver {
 
 		$theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json' ) );
 		$theme_json_data = static::translate( $theme_json_data, wp_get_theme()->get( 'TextDomain' ) );
-		
+
 		/**
 		 * Filters the data provided by the theme for global styles & settings.
 		 *

--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -410,10 +410,6 @@ class WP_Theme_JSON_Resolver {
 	 * @return WP_Theme_JSON Entity that holds styles for user data.
 	 */
 	public static function get_user_data() {
-		if ( null !== static::$user ) {
-			return static::$user;
-		}
-
 		$config   = array();
 		$user_cpt = static::get_user_data_from_wp_global_styles( wp_get_theme() );
 

--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -71,23 +71,38 @@ class WP_Theme_JSON_Resolver {
 	protected static $i18n_schema = null;
 
 	/**
+	 * `theme.json` file cache.
+	 *
+	 * @since 6.1.0
+	 * @var array
+	 * @access private
+	 */
+	protected static $theme_json_file_cache = array();
+
+	/**
 	 * Processes a file that adheres to the theme.json schema
 	 * and returns an array with its contents, or a void array if none found.
 	 *
 	 * @since 5.8.0
+	 * @since 6.1.0 Added caching.
 	 *
 	 * @param string $file_path Path to file. Empty if no file.
 	 * @return array Contents that adhere to the theme.json schema.
 	 */
 	protected static function read_json_file( $file_path ) {
-		$config = array();
 		if ( $file_path ) {
+			if ( array_key_exists( $file_path, static::$theme_json_file_cache ) ) {
+				return static::$theme_json_file_cache[ $file_path ];
+			}
+
 			$decoded_file = wp_json_file_decode( $file_path, array( 'associative' => true ) );
 			if ( is_array( $decoded_file ) ) {
-				$config = $decoded_file;
+				static::$theme_json_file_cache[ $file_path ] = $decoded_file;
+				return static::$theme_json_file_cache[ $file_path ];
 			}
+		} else {
+			return array();
 		}
-		return $config;
 	}
 
 	/**

--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -100,9 +100,9 @@ class WP_Theme_JSON_Resolver {
 				static::$theme_json_file_cache[ $file_path ] = $decoded_file;
 				return static::$theme_json_file_cache[ $file_path ];
 			}
-		} else {
-			return array();
 		}
+
+		return array();
 	}
 
 	/**


### PR DESCRIPTION
Based on @c4rl0sbr4v0's https://github.com/WordPress/wordpress-develop/pull/3401, and @oandregal's [suggestion](https://github.com/WordPress/wordpress-develop/pull/3359#discussion_r985689298).

### Description

Currently, individual block styling defined in a theme's `theme.json` isn't being applied on the frontend (see https://core.trac.wordpress.org/ticket/56736 or the testing instructions below).

While working on https://github.com/WordPress/gutenberg/issues/44434 (which is somewhat related), we've identified `WP_Theme_JSON_Resolver`'s caching of theme data as the problem. That caching happens early and sanitizes block-specific styling found in `theme.json` against the list of registered blocks. However, this can happen before all blocks are registered. As a consequence, some styling is scrapped.

This can be fixed by removing the caching from `WP_Theme_JSON_Resolver::get_theme_data()`, and instead freshly computing theme data each time that method is called, which will take into account all blocks registered at that point.

In order to prevent performance from being impacted all too much, we add caching to the JSON file reading and processing in `WP_Theme_JSON_Resolver::read_json_file()` instead (per [this suggestion](https://github.com/WordPress/wordpress-develop/pull/3359#discussion_r985689298)).

### Testing instructions

To test, activate the TT2 theme. In a new post, insert some button blocks and view on the frontend. [They should be rectangular, with a dark green background](https://github.com/WordPress/wordpress-develop/blob/c819764c81c8b14de9104f5488a88c949e715b25/src/wp-content/themes/twentytwentytwo/theme.json#L224-L237) (rather than round and black).

| Before (broken) | After (fixed) |
| --- | --- |
| <img width="1136" alt="image" src="https://user-images.githubusercontent.com/14988353/192704978-e43957d7-8868-490c-814d-83c6fe24fae1.png"> | <img width="1136" alt="image" src="https://user-images.githubusercontent.com/14988353/192704825-6cc455bc-dde5-45ba-b94d-b4e584e92e9e.png"> |

Trac ticket: https://core.trac.wordpress.org/ticket/56736

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
