### PR TITLE
Use require_once instead of require for dynamic blocks

### DIFF
--- a/tools/release/sync-stable-blocks.js
+++ b/tools/release/sync-stable-blocks.js
@@ -49,8 +49,8 @@ ${ staticBlockFolderNames }
 		.filter( isDynamic )
 		.map( toDirectoryName )
 		.sort()
-		// To PHP require statement:
-		.map( dirname => `require ABSPATH . WPINC . '/blocks/${ dirname }.php';` )
+		// To PHP require_once statement:
+		.map( dirname => `require_once ABSPATH . WPINC . '/blocks/${ dirname }.php';` )
 		.join( "\n" );
 
 	fs.writeFileSync(


### PR DESCRIPTION
In `sync-stable-blocks.js` we're compiling the contents of the `require-dynamic-blocks.php` file.
When doing that, we currently use `require` instead of `require_once` to load the block files.

Trac ticket: https://core.trac.wordpress.org/ticket/56738

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
