### PR TITLE
Use a `foreach` loop instead of `array_map` in `WP_Theme_JSON::get_default_slugs`

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -2422,12 +2422,11 @@ class WP_Theme_JSON {
 			}
 
 			$slugs_for_preset = array();
-			$slugs_for_preset = array_map(
-				static function( $value ) {
-					return isset( $value['slug'] ) ? $value['slug'] : null;
-				},
-				$preset
-			);
+			foreach ( $preset as $item ) {
+				if ( isset( $item['slug'] ) ) {
+					$slugs_for_preset[] = $item['slug'];
+				}
+			}
 			_wp_array_set( $slugs, $metadata['path'], $slugs_for_preset );
 		}
 


### PR DESCRIPTION
When loading a page on the frontend, the biggest performance bottleneck right now (on the PHP side) is `WP_Theme_JSON->merge`. Analysing the data a bit more, it becomes evident that `WP_Theme_JSON::get_default_slugs` is the part of that function that takes most of the resources and time (see screenshot below)

<img width="888" alt="Screenshot 2022-10-06 at 12 02 43 PM" src="https://user-images.githubusercontent.com/588688/194285929-847418a1-3134-48de-a090-51f18df461fe.png">

Further analysis of the `WP_Theme_JSON::get_default_slugs` method reveals that `array_map()` is the call that slows it down:

<img width="903" alt="Screenshot 2022-10-06 at 11 59 59 AM" src="https://user-images.githubusercontent.com/588688/194286171-25bb9589-9599-4e6c-b855-4831dbb7e48e.png">

This PR replaces `array_map` with a simple `foreach` loop. The end result is the same, and processing happens a lot faster:

<img width="903" alt="Screenshot 2022-10-06 at 12 00 16 PM" src="https://user-images.githubusercontent.com/588688/194286421-80d3f867-beb8-42ed-806e-1f2e1733ae44.png">

Notes: 
Screenshots above shown with `%` values. So overall this changes makes each page-load ~1% faster. 
In all tests, the actual page-load was reduced from ~6300ms to ~5900
Tests were performed on a new WP installation with no plugins activated, using the twentytwentythree theme.
Reports generated using Xdebug & webgrind.

Trac ticket: https://core.trac.wordpress.org/ticket/56745

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
