### PR TITLE
Fix `cite` styles declared via `theme.json`

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -421,6 +421,7 @@ class WP_Theme_JSON {
 		'button'  => '.wp-element-button, .wp-block-button__link',
 		// The block classes are necessary to target older content that won't use the new class names.
 		'caption' => '.wp-element-caption, .wp-block-audio figcaption, .wp-block-embed figcaption, .wp-block-gallery figcaption, .wp-block-image figcaption, .wp-block-table figcaption, .wp-block-video figcaption',
+		'cite'    => 'cite',
 	);
 
 	const __EXPERIMENTAL_ELEMENT_CLASS_NAMES = array(


### PR DESCRIPTION
Trac ticket https://core.trac.wordpress.org/ticket/56467
Backports https://github.com/WordPress/gutenberg/pull/43543

## What

This PR fixes an issue by which the styles of `cite` element declared via `theme.json` are not enqueued.

## Why

All element's styles should work. `cite` is one of the new elements added in this cycle and to be announced in [this devnote](https://make.wordpress.org/core/?p=98557&preview=1&_ppp=4f920f8d6b).

## How

By registering the element into the proper allowed list array.

## Test

- Add the following snippet to your theme's `theme.json` (I've tested with TwentyTwentyTwo):

```json
{
  "elements": {
    "cite": {
      "color": {
        "background": "hotpink"
      }
    }
  }
}
```

- Go to the post editor and add a quote block. Fill it with text and a cite.

The expected result is that in the editors and the frontend the cite of the quote should have hotpink as background color.

## Notes

Note this works as expected with the Gutenberg plugin active but not in core without the plugin because [it's part of the registry](https://github.com/WordPress/gutenberg/blob/trunk/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php#L117).

