### PR TITLE
`plugin_basename` returns wrong `basename` when in subdir of symlinked plugin - Refresh

### DIFF
--- a/src/wp-includes/plugin.php
+++ b/src/wp-includes/plugin.php
@@ -773,6 +773,7 @@ function plugin_basename( $file ) {
 	foreach ( $wp_plugin_paths as $dir => $realdir ) {
 		if ( str_starts_with( $file, $realdir ) ) {
 			$file = $dir . substr( $file, strlen( $realdir ) );
+			break;
 		}
 	}
 

--- a/tests/phpunit/tests/functions/pluginBasename.php
+++ b/tests/phpunit/tests/functions/pluginBasename.php
@@ -78,7 +78,9 @@ class Tests_Functions_PluginBasename extends WP_UnitTestCase {
 		$plugin_project_root_directory = $this->wp_plugin_path;
 
 		$wp_plugin_paths = array(
+			// Symlinked plugin located at project root.
 			$this->wp_plugin_path . '/plugin-root'        => $plugin_project_root_directory,
+			// Plugin in nested WordPress installation.
 			$this->wp_plugin_path . '/wordpress-importer' => $plugin_project_root_directory . '/wordpress/wp-content/plugins/wordpress-importer',
 		);
 

--- a/tests/phpunit/tests/functions/pluginBasename.php
+++ b/tests/phpunit/tests/functions/pluginBasename.php
@@ -62,4 +62,26 @@ class Tests_Functions_PluginBasename extends WP_UnitTestCase {
 		$basename = plugin_basename( '/Users/me/Dropbox/Development/Repositories/plugin/trunk/plugin.php' );
 		$this->assertSame( 'trunk/plugin.php', $basename );
 	}
+
+	/**
+	 * Mimic a parent project directory that contains a plugin and WordPress installation. E.g.
+	 *
+	 *   Project directory: ../Projects/plugin-root
+	 *   WordPress install: ../Projects/plugin-root/wordpress
+	 *
+	 * @ticket 42670
+	 */
+	public function test_should_return_correct_basename_for_plugin_when_wp_plugins_dir_is_subdir_of_symlinked_plugin() {
+		global $wp_plugin_paths;
+
+		$plugin_project_root_directory = dirname( $this->wp_plugin_path, 3 );
+
+		$wp_plugin_paths = array(
+			$this->wp_plugin_path . '/plugin-root'        => $plugin_project_root_directory,
+			$this->wp_plugin_path . '/wordpress-importer' => $plugin_project_root_directory . '/wordpress/wp-content/plugins/wordpress-importer',
+		);
+
+		$actual = plugin_basename( $plugin_project_root_directory . '/wordpress/wp-content/plugins/wordpress-importer/wordpress-importer.php' );
+		$this->assertSame( 'wordpress-importer/wordpress-importer.php', $actual, 'The basename returned is incorrect.' );
+	}
 }

--- a/tests/phpunit/tests/functions/pluginBasename.php
+++ b/tests/phpunit/tests/functions/pluginBasename.php
@@ -74,7 +74,8 @@ class Tests_Functions_PluginBasename extends WP_UnitTestCase {
 	public function test_should_return_correct_basename_for_plugin_when_wp_plugins_dir_is_subdir_of_symlinked_plugin() {
 		global $wp_plugin_paths;
 
-		$plugin_project_root_directory = dirname( $this->wp_plugin_path, 3 );
+		// Set project root directory to any real absolute path. Using WP_PLUGIN_DIR for convenience.
+		$plugin_project_root_directory = $this->wp_plugin_path;
 
 		$wp_plugin_paths = array(
 			$this->wp_plugin_path . '/plugin-root'        => $plugin_project_root_directory,


### PR DESCRIPTION
In this PR:
- Adjust spacing for WPCS standards in `plugin.php`.
- Use `assertSame()` in unit test.
- Add assertion failure message.
- Update test for readability.
- Change test reference to `wordpress-importer`.

Trac ticket: https://core.trac.wordpress.org/ticket/42670

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
