### PR TITLE
Reinstate old persistence system configuration - fixes block editor usage data

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -383,6 +383,22 @@ function wp_default_packages_inline_scripts( $scripts ) {
 		)
 	);
 
+	// Backwards compatibility - configure the old wp-data persistence system.
+	$scripts->add_inline_script(
+		'wp-data',
+		implode(
+			"\n",
+			array(
+				'( function() {',
+				'	var userId = ' . get_current_user_ID() . ';',
+				'	var storageKey = "WP_DATA_USER_" + userId;',
+				'	wp.data',
+				'		.use( wp.data.plugins.persistence, { storageKey: storageKey } );',
+				'} )();',
+			)
+		)
+	);
+
 	// Calculate the timezone abbr (EDT, PST) if possible.
 	$timezone_string = get_option( 'timezone_string', 'UTC' );
 	$timezone_abbr   = '';


### PR DESCRIPTION
In https://github.com/WordPress/wordpress-develop/pull/3253 I was a little too eager to remove the old preferences persistence configuration. This system is still used in the block editor for block inserter usage, so removing this accidentally caused the 'most used blocks' feature to stop working.

Trac ticket: https://core.trac.wordpress.org/ticket/56778

---

Steps to reproduce:
Prerequisite: Remove the WORDPRESS_DATA_USER_{n} local storage data (where {n} is your used id).

1. Open up a block editor and insert the same block a few times (e.g. Code block).
2. Trigger the `/` inserter an notice Code is now top of the list.
3. Reload the block editor.
4. Trigger the `/` inserter again and noticed Code block is no longer top of the list.

In trunk: The code block is no longer present at the top of the list.
In this branch: The code block should be persisted across sessions as the most used block.