### PR TITLE
Fluid Typography: Backport PHP changes for custom font sizes

### DIFF
--- a/src/wp-includes/block-supports/typography.php
+++ b/src/wp-includes/block-supports/typography.php
@@ -297,7 +297,7 @@ function wp_get_typography_value_and_unit( $raw_value, $options = array() ) {
 	if ( ! is_string( $raw_value ) && ! is_int( $raw_value ) && ! is_float( $raw_value ) ) {
 		_doing_it_wrong(
 			__FUNCTION__,
-			__( 'Raw size value must be a string, integer or a float.' ),
+			__( 'Raw size value must be a string, integer, or float.' ),
 			'6.1.0'
 		);
 		return null;

--- a/src/wp-includes/block-supports/typography.php
+++ b/src/wp-includes/block-supports/typography.php
@@ -253,7 +253,7 @@ function wp_typography_get_preset_inline_style_value( $style_value, $css_propert
  *
  * @param string $block_content Rendered block content.
  * @param array  $block         Block object.
- * @return string                Filtered block content.
+ * @return string Filtered block content.
  */
 function wp_render_typography_support( $block_content, $block ) {
 	if ( ! isset( $block['attrs']['style']['typography']['fontSize'] ) ) {

--- a/src/wp-includes/block-supports/typography.php
+++ b/src/wp-includes/block-supports/typography.php
@@ -251,8 +251,8 @@ function wp_typography_get_preset_inline_style_value( $style_value, $css_propert
 /**
  * Renders typography styles/content to the block wrapper.
  *
- * @param  string $block_content Rendered block content.
- * @param  array  $block         Block object.
+ * @param string $block_content Rendered block content.
+ * @param array  $block         Block object.
  * @return string                Filtered block content.
  */
 function wp_render_typography_support( $block_content, $block ) {

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -1675,6 +1675,18 @@ class WP_Theme_JSON {
 				continue;
 			}
 
+			// Calculates fluid typography rules where available.
+			if ( 'font-size' === $css_property ) {
+				/*
+				 * wp_get_typography_font_size_value() will check
+				 * if fluid typography has been activated and also
+				 * whether the incoming value can be converted to a fluid value.
+				 * Values that already have a "clamp()" function will not pass the test,
+				 * and therefore the original $value will be returned.
+				 */
+				$value = wp_get_typography_font_size_value( array( 'size' => $value ) );
+			}
+
 			$declarations[] = array(
 				'name'  => $css_property,
 				'value' => $value,

--- a/tests/phpunit/data/themedir1/block-theme-child-with-fluid-typography/style.css
+++ b/tests/phpunit/data/themedir1/block-theme-child-with-fluid-typography/style.css
@@ -1,0 +1,8 @@
+/*
+Theme Name: Block Theme Child Theme With Fluid Typography
+Theme URI: https://wordpress.org/
+Description: For testing purposes only.
+Template: block-theme
+Version: 1.0.0
+Text Domain: block-theme-child-with-fluid-typography
+*/

--- a/tests/phpunit/data/themedir1/block-theme-child-with-fluid-typography/theme.json
+++ b/tests/phpunit/data/themedir1/block-theme-child-with-fluid-typography/theme.json
@@ -1,0 +1,9 @@
+{
+	"version": 2,
+	"settings": {
+		"appearanceTools": true,
+		"typography": {
+			"fluid": true
+		}
+	}
+}

--- a/tests/phpunit/tests/block-supports/typography.php
+++ b/tests/phpunit/tests/block-supports/typography.php
@@ -645,7 +645,7 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 	 * @param mixed $expected  An expected return value.
 	 */
 	public function test_valid_size_wp_get_typography_value_and_unit( $raw_value, $expected ) {
-		$this->assertEquals( $expected, wp_get_typography_value_and_unit( $raw_value ) );
+		$this->assertSame( $expected, wp_get_typography_value_and_unit( $raw_value ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/block-supports/typography.php
+++ b/tests/phpunit/tests/block-supports/typography.php
@@ -29,7 +29,7 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 		$this->test_block_name = null;
 
 		// Sets up the `wp-content/themes/` directory to ensure consistency when running tests.
-		$this->theme_root                = realpath( __DIR__ . '/../data/themedir1' );
+		$this->theme_root                = realpath( DIR_TESTDATA . '/themedir1' );
 		$this->orig_theme_dir            = $GLOBALS['wp_theme_directories'];
 		$GLOBALS['wp_theme_directories'] = array( WP_CONTENT_DIR . '/themes', $this->theme_root );
 

--- a/tests/phpunit/tests/block-supports/typography.php
+++ b/tests/phpunit/tests/block-supports/typography.php
@@ -346,7 +346,7 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 				'expected_output'             => 'clamp(21px, 1.3125rem + ((1vw - 7.68px) * 2.524), 42px)',
 			),
 
-			'default_return_value_with_unsupported_unit'   => array(
+			'default_return_value_with_unsupported_unit'  => array(
 				'font_size_preset'            => array(
 					'size'  => '1000%',
 					'fluid' => false,
@@ -354,7 +354,6 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 				'should_use_fluid_typography' => true,
 				'expected_output'             => '1000%',
 			),
-
 
 			'return_fluid_value'                          => array(
 				'font_size_preset'            => array(

--- a/tests/phpunit/tests/block-supports/typography.php
+++ b/tests/phpunit/tests/block-supports/typography.php
@@ -8,17 +8,56 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 	 */
 	private $test_block_name;
 
+	/**
+	 * Stores the current test theme root.
+	 *
+	 * @var string|null
+	 */
+	private $theme_root;
+
+	/**
+	 * Caches the original theme directory global value in order
+	 * to restore it in tear down.
+	 *
+	 * @var string|null
+	 */
+	private $orig_theme_dir;
+
 	function set_up() {
 		parent::set_up();
+
 		$this->test_block_name = null;
+
+		// Sets up the `wp-content/themes/` directory to ensure consistency when running tests.
+		$this->theme_root                = realpath( __DIR__ . '/../data/themedir1' );
+		$this->orig_theme_dir            = $GLOBALS['wp_theme_directories'];
+		$GLOBALS['wp_theme_directories'] = array( WP_CONTENT_DIR . '/themes', $this->theme_root );
+
+		$theme_root_callback = function () {
+			return $this->theme_root;
+		};
+		add_filter( 'theme_root', $theme_root_callback );
+		add_filter( 'stylesheet_root', $theme_root_callback );
+		add_filter( 'template_root', $theme_root_callback );
+
+		// Clear caches.
+		wp_clean_themes_cache();
+		unset( $GLOBALS['wp_themes'] );
 	}
 
 	/**
 	 * Unregisters block type after each test.
 	 */
 	function tear_down() {
+		// Restores the original theme directory setup.
+		$GLOBALS['wp_theme_directories'] = $this->orig_theme_dir;
+		wp_clean_themes_cache();
+		unset( $GLOBALS['wp_themes'] );
+
+		// Resets test block name.
 		unregister_block_type( $this->test_block_name );
 		$this->test_block_name = null;
+
 		parent::tear_down();
 	}
 
@@ -298,6 +337,25 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 				'expected_output'             => '28px',
 			),
 
+			'default_return_value_when_value_is_already_clamped' => array(
+				'font_size_preset'            => array(
+					'size'  => 'clamp(21px, 1.3125rem + ((1vw - 7.68px) * 2.524), 42px)',
+					'fluid' => false,
+				),
+				'should_use_fluid_typography' => true,
+				'expected_output'             => 'clamp(21px, 1.3125rem + ((1vw - 7.68px) * 2.524), 42px)',
+			),
+
+			'default_return_value_with_unsupported_unit'   => array(
+				'font_size_preset'            => array(
+					'size'  => '1000%',
+					'fluid' => false,
+				),
+				'should_use_fluid_typography' => true,
+				'expected_output'             => '1000%',
+			),
+
+
 			'return_fluid_value'                          => array(
 				'font_size_preset'            => array(
 					'size' => '1.75rem',
@@ -368,6 +426,161 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 				),
 				'should_use_fluid_typography' => true,
 				'expected_output'             => 'clamp(21px, 1.3125rem + ((1vw - 7.68px) * 7.091), 80px)',
+			),
+		);
+	}
+
+	/**
+	 * Tests that custom font sizes are converted to fluid values
+	 * in inline block supports styles,
+	 * when "settings.typography.fluid" is set to `true`.
+	 *
+	 * @ticket 56467
+	 *
+	 * @covers ::wp_register_typography_support
+	 *
+	 * @dataProvider data_generate_block_supports_font_size_fixtures
+	 *
+	 * @param string $font_size_value             The block supports custom font size value.
+	 * @param bool   $should_use_fluid_typography An override to switch fluid typography "on". Can be used for unit testing.
+	 * @param string $expected_output             Expected value of style property from wp_apply_typography_support().
+	 */
+	public function test_should_covert_font_sizes_to_fluid_values( $font_size_value, $should_use_fluid_typography, $expected_output ) {
+		if ( $should_use_fluid_typography ) {
+			switch_theme( 'block-theme-child-with-fluid-typography' );
+		} else {
+			switch_theme( 'default' );
+		}
+
+		$this->test_block_name = 'test/font-size-fluid-value';
+		register_block_type(
+			$this->test_block_name,
+			array(
+				'api_version' => 2,
+				'attributes'  => array(
+					'style' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array(
+					'typography' => array(
+						'fontSize' => true,
+					),
+				),
+			)
+		);
+		$registry         = WP_Block_Type_Registry::get_instance();
+		$block_type       = $registry->get_registered( $this->test_block_name );
+		$block_attributes = array(
+			'style' => array(
+				'typography' => array(
+					'fontSize' => $font_size_value,
+				),
+			),
+		);
+
+		$actual   = wp_apply_typography_support( $block_type, $block_attributes );
+		$expected = array( 'style' => $expected_output );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Data provider for test_should_covert_font_sizes_to_fluid_values.
+	 *
+	 * @return array
+	 */
+	public function data_generate_block_supports_font_size_fixtures() {
+		return array(
+			'default_return_value'               => array(
+				'font_size_value'             => '50px',
+				'should_use_fluid_typography' => false,
+				'expected_output'             => 'font-size:50px;',
+			),
+			'return_value_with_fluid_typography' => array(
+				'font_size_value'             => '50px',
+				'should_use_fluid_typography' => true,
+				'expected_output'             => 'font-size:clamp(37.5px, 2.34375rem + ((1vw - 7.68px) * 4.507), 75px);',
+			),
+		);
+	}
+
+	/**
+	 * Tests that a block element's custom font size in the inline style attribute
+	 * is replaced with a fluid value when "settings.typography.fluid" is set to `true`,
+	 * and the correct block content is generated.
+	 *
+	 * @dataProvider data_generate_replace_inline_font_styles_with_fluid_values_fixtures
+	 *
+	 * @param string $block_content               HTML block content.
+	 * @param string $font_size_value             The block supports custom font size value.
+	 * @param bool   $should_use_fluid_typography An override to switch fluid typography "on". Can be used for unit testing.
+	 * @param string $expected_output             Expected value of style property from wp_apply_typography_support().
+	 */
+	public function test_should_replace_inline_font_styles_with_fluid_values( $block_content, $font_size_value, $should_use_fluid_typography, $expected_output ) {
+		if ( $should_use_fluid_typography ) {
+			switch_theme( 'block-theme-child-with-fluid-typography' );
+		} else {
+			switch_theme( 'default' );
+		}
+
+		$block  = array(
+			'blockName' => 'core/image',
+			'attrs'     => array(
+				'style' => array(
+					'typography' => array(
+						'fontSize' => $font_size_value,
+					),
+				),
+			),
+		);
+		$actual = wp_render_typography_support( $block_content, $block );
+
+		$this->assertSame( $expected_output, $actual );
+	}
+
+	/**
+	 * Data provider for test_should_replace_inline_font_styles_with_fluid_values.
+	 *
+	 * @return array
+	 */
+	public function data_generate_replace_inline_font_styles_with_fluid_values_fixtures() {
+		return array(
+			'default_return_content'                       => array(
+				'block_content'               => '<h2 class="has-vivid-red-background-color has-background has-link-color" style="margin-top:var(--wp--preset--spacing--60);font-size:4rem;font-style:normal;font-weight:600;letter-spacing:29px;text-decoration:underline;text-transform:capitalize">This is a heading</h2>',
+				'font_size_value'             => '4rem',
+				'should_use_fluid_typography' => false,
+				'expected_output'             => '<h2 class="has-vivid-red-background-color has-background has-link-color" style="margin-top:var(--wp--preset--spacing--60);font-size:4rem;font-style:normal;font-weight:600;letter-spacing:29px;text-decoration:underline;text-transform:capitalize">This is a heading</h2>',
+			),
+			'return_content_with_replaced_fluid_font_size_inline_style' => array(
+				'block_content'               => '<h2 class="has-vivid-red-background-color has-background has-link-color" style="margin-top:var(--wp--preset--spacing--60);font-size:4rem;font-style:normal;font-weight:600;letter-spacing:29px;text-decoration:underline;text-transform:capitalize">This is a heading</h2>',
+				'font_size_value'             => '4rem',
+				'should_use_fluid_typography' => true,
+				'expected_output'             => '<h2 class="has-vivid-red-background-color has-background has-link-color" style="margin-top:var(--wp--preset--spacing--60);font-size:clamp(3rem, 3rem + ((1vw - 0.48rem) * 5.769), 6rem);font-style:normal;font-weight:600;letter-spacing:29px;text-decoration:underline;text-transform:capitalize">This is a heading</h2>',
+			),
+			'return_content_if_no_inline_font_size_found'  => array(
+				'block_content'               => '<p class="has-medium-font-size" style="font-style:normal;font-weight:600;letter-spacing:29px;">A paragraph inside a group</p>',
+				'font_size_value'             => '20px',
+				'should_use_fluid_typography' => true,
+				'expected_output'             => '<p class="has-medium-font-size" style="font-style:normal;font-weight:600;letter-spacing:29px;">A paragraph inside a group</p>',
+			),
+			'return_content_css_var'                       => array(
+				'block_content'               => '<p class="has-medium-font-size" style="font-size:var(--wp--preset--font-size--x-large);">A paragraph inside a group</p>',
+				'font_size_value'             => 'var:preset|font-size|x-large',
+				'should_use_fluid_typography' => true,
+				'expected_output'             => '<p class="has-medium-font-size" style="font-size:var(--wp--preset--font-size--x-large);">A paragraph inside a group</p>',
+			),
+			'return_content_with_spaces'                   => array(
+				'block_content'               => '<p class="has-medium-font-size" style="    font-size:   20px   ;    ">A paragraph inside a group</p>',
+				'font_size_value'             => '20px',
+				'should_use_fluid_typography' => true,
+				'expected_output'             => '<p class="has-medium-font-size" style="    font-size:clamp(15px, 0.9375rem + ((1vw - 7.68px) * 1.803), 30px);    ">A paragraph inside a group</p>',
+			),
+			'return_content_with_first_match_replace_only' => array(
+				'block_content'               => "<div class=\"wp-block-group\" style=\"font-size:1em\"> \n \n<p style=\"font-size:1em\">A paragraph inside a group</p></div>",
+				'font_size_value'             => '1em',
+				'should_use_fluid_typography' => true,
+				'expected_output'             => "<div class=\"wp-block-group\" style=\"font-size:clamp(0.75em, 0.75em + ((1vw - 0.48em) * 1.442), 1.5em);\"> \n \n<p style=\"font-size:1em\">A paragraph inside a group</p></div>",
 			),
 		);
 	}

--- a/tests/phpunit/tests/block-supports/typography.php
+++ b/tests/phpunit/tests/block-supports/typography.php
@@ -645,7 +645,7 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 	 * @param mixed $expected  An expected return value.
 	 */
 	public function test_valid_size_wp_get_typography_value_and_unit( $raw_value, $expected ) {
-		$this->assertSame( $expected, wp_get_typography_value_and_unit( $raw_value ) );
+		$this->assertEquals( $expected, wp_get_typography_value_and_unit( $raw_value ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/theme/themeDir.php
+++ b/tests/phpunit/tests/theme/themeDir.php
@@ -177,6 +177,7 @@ class Tests_Theme_ThemeDir extends WP_UnitTestCase {
 			'REST Theme',
 			'Block Theme',
 			'Block Theme Child Theme',
+			'Block Theme Child Theme With Fluid Typography',
 			'Block Theme [0.4.0]',
 			'Block Theme [1.0.0] in subdirectory',
 			'Block Theme Deprecated Path',


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Backports the PHP elements of the following Fluid Typography bug fixes from Gutenberg:

* https://github.com/WordPress/gutenberg/pull/44762
* https://github.com/WordPress/gutenberg/pull/44764
* https://github.com/WordPress/gutenberg/pull/44761
* https://github.com/WordPress/gutenberg/pull/44807
* The adjustments to the above change proposed in https://github.com/WordPress/wordpress-develop/pull/3428
* https://github.com/WordPress/gutenberg/pull/44847

Note: from the above PRs, any changes to files in `block-library` have _not_ been included, as they will form part of a backport PR for the JS/npm packages changes.

Trac ticket: https://core.trac.wordpress.org/ticket/56467

Gutenberg tracking issue: https://github.com/WordPress/gutenberg/issues/44758

To test:

* With a theme with `settings.typography.fluid` set to `true` (e.g. tests with TT3 theme), create a post and set a custom font size on a heading or paragraph block. Save the post and view on the site frontend, if you inspect the markup, the font-size inline style for those blocks should be a `clamp()` value with the fluid rules applied.
* In global styles, set the Typography H1 setting to a custom font-size (e.g. 4rem). Save the global styles, then on the site frontend, inspect the markup for the post or page title. The `h1` element should have a styling rule associated with it with the `clamp()` based rules applied.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
