### PR TITLE
Improve performance of `WP_Theme_JSON::get_merged_data` method

### DIFF
--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -548,8 +548,7 @@ class WP_Theme_JSON_Resolver {
 			_deprecated_argument( __FUNCTION__, '5.9.0' );
 		}
 
-		$result = new WP_Theme_JSON();
-		$result->merge( static::get_core_data() );
+		$result = static::get_core_data();
 		$result->merge( static::get_block_data() );
 		$result->merge( static::get_theme_data() );
 


### PR DESCRIPTION
See:

- Performance issue https://github.com/WordPress/gutenberg/issues/44772
- Trac ticket https://core.trac.wordpress.org/ticket/56467

## What

Follow up to https://github.com/WordPress/wordpress-develop/pull/3418

## Why 

We want to squeeze as many ms as possible.

## How

In the WordPress 6.1 cycle, `WP_Theme_JSON_Resolver::get_merged_data` method has become a hot path that is called many times. By improving small things that are repeated multiple times, we get more performance wins. This PR changes this code:

```php
public static function get_merged_data( $origin = 'custom' ) {
	// ...

	$result = new WP_Theme_JSON();
	$result->merge( static::get_core_data() );
	$result->merge( static::get_block_data() );
	$result->merge( static::get_theme_data() );

	// ...
}
```

to:

```php
public static function get_merged_data( $origin = 'custom' ) {
	// ...

	$result = static::get_core_data();
	$result->merge( static::get_block_data() );
	$result->merge( static::get_theme_data() );

	// ...
}
```

As a result, this reduces the number of calls of the low-level `WP_Theme_JSON->merge` method, with the corresponding performance improvements.

## Performance improvements

| Method                                    | WordPress 6.0    | WordPress 6.1 RC1     | PR 3441 (based off trunk@54506)          |
| ----------------------------------------- | ---------------- | ----------------- | ---------------- |
| total time                                | 746ms            | 877ms             | 794ms            |
| `WP_Theme_JSON_Resolver::get_merged_data` | 9ms (27 calls)   | 146ms (98 calls)  | 55ms (98 calls)  |
| `WP_Theme_JSON->merge`                    | 25ms (130 calls) | 114ms (512 calls) | 74ms (414 calls) |

See https://github.com/WordPress/wordpress-develop/pull/3418 for instruction on how to reproduce these numbers yourself. Alternatively, you can import the following cachegrind files to visualize in the tool of choice (kcachegrind, qcachegrind, webgrind, etc.):

- WordPress 6.0: [cachegrind.out.6-0.gz](https://github.com/WordPress/wordpress-develop/files/9775296/cachegrind.out.6-0.gz)
- WordPress 6.1, RC1: [cachegrind.out.6-1-rc-1.gz](https://github.com/WordPress/wordpress-develop/files/9775306/cachegrind.out.6-1-rc-1.gz)
- This PR, based off trunk@54506: [cachegrind.out.6-1-pr-3441.gz](https://github.com/WordPress/wordpress-develop/files/9775311/cachegrind.out.6-1-pr-3441.gz)

## Test

- Make sure automated test pass.
- Manually test that global styles still works as expected by using the TT2 or TT3 themes and updating some block styles via the global styles sidebar.
- Use a localized WordPress and verify that translations for colors are still applied.
