### PR TITLE
Fix docblock param type

### DIFF
--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -3162,7 +3162,7 @@ class WP_Site_Health {
 		 *
 		 * @since 6.1.0
 		 *
-		 * @param int $cache_headers Array of supported cache headers.
+		 * @param array $cache_headers Array of supported cache headers.
 		 */
 		return apply_filters( 'site_status_page_cache_supported_cache_headers', $cache_headers );
 	}


### PR DESCRIPTION
Fix param type from `int` to `array` in `site_status_page_cache_supported_cache_headers` filter.

Trac ticket: https://core.trac.wordpress.org/ticket/56805

