### PR TITLE
Help/About: Update links on About page

### DIFF
--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -169,16 +169,16 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 				<div class="column about__image is-edge-to-edge has-accent-background-color">
 					<img src="data:image/svg+xml,%3Csvg width='436' height='436' viewbox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='50%25' cy='50%25' r='30%25' fill='%23E26F56' /%3E%3C/svg%3E" alt="" />
 				</div>
-				<h3 class="is-smaller-heading"><?php _e( 'Header and footer patterns for every theme' ); ?></h3>
+				<h3 class="is-smaller-heading"><?php _e( 'More responsive text with fluid typography' ); ?></h3>
 				<p>
 					<?php
 					printf(
-						/* translators: 1: Link to tutorial for customizing a header, 2: Link to tutorial for customizing a footer. */
-						__( 'Explore these block patterns, making <a href="%1$s">header</a> and <a href="%2$s">footer</a> creation more efficient.' ),
-						'https://learn.wordpress.org/tutorial/customizing-a-header-with-patterns/',
-						'https://learn.wordpress.org/tutorial/customizing-a-footer-with-patterns/'
+						/* translators: %s: Link to fluid typography demo. */
+						__( '<a href="%s">Fluid typography</a> lets you define font sizes that adapt for easy reading in any screen size.' ),
+						'https://make.wordpress.org/core/2022/10/03/fluid-font-sizes-in-wordpress-6-1/'
 					);
 					?>
+				</p>
 			</div>
 		</div>
 
@@ -469,27 +469,6 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 					?>
 				</p>
 				<p><?php _e( 'Combine it with block locking options for even more advanced control over your blocks.' ); ?></p>
-			</div>
-		</div>
-
-		<div class="about__section has-2-columns">
-			<div class="column">
-				<div class="about__image">
-					<svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
-						<rect width="48" height="48" rx="4" fill="#1E1E1E"/>
-						<circle cx="50%" cy="50%" r="30%" fill="red"/>
-					</svg>
-				</div>
-				<h3 class="is-smaller-heading"><?php _e( 'More responsive text with fluid typography' ); ?></h3>
-				<p>
-					<?php
-					printf(
-						/* translators: %s: Link to fluid typography demo. */
-						__( '<a href="%s">Fluid typography</a> lets you define font sizes that adapt for easy reading in any screen size.' ),
-						'https://make.wordpress.org/core/2022/10/03/fluid-font-sizes-in-wordpress-6-1/'
-					);
-					?>
-				</p>
 			</div>
 		</div>
 

--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -541,7 +541,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 					printf(
 						/* translators: %s: WordPress Field Guide link. */
 						__( 'Check out the latest version of the <a href="%s">WordPress Field Guide</a>. It is overflowing with detailed developer notes to help you build with WordPress.' ),
-						__( '#' )
+						__( 'https://make.wordpress.org/core/2022/10/12/wordpress-6-1-field-guide/' )
 					);
 					?>
 				</p>

--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -54,7 +54,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 					?>
 				</h2>
 				<p class="is-subheading">
-					<?php _e( 'WordPress 6.1 includes more than 2,000 updates. This page highlights some of the most significant changes to the product since the May 2022 release of WordPress 6.0. You will also find resources for developers and anyone seeking a deeper understanding of WordPress.' ); ?>
+					<?php _e( 'This page highlights some of the most significant changes to the product since the May 2022 release of WordPress 6.0. You will also find resources for developers and anyone seeking a deeper understanding of WordPress.' ); ?>
 				</p>
 			</div>
 		</div>

--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -108,7 +108,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 					printf(
 						/* translators: %s: Link to layout support refactor dev note. */
 						__( 'Upgrades to the <a href="%s">controls for design elements and blocks</a> make the layout and site-building process more consistent, complete, and intuitive.' ),
-						'https://make.wordpress.org/core/2022/10/10/updated-editor-layout-support-in-6-1-after-refactor/'
+						'https://make.wordpress.org/core/2022/10/11/roster-of-design-tools-per-block/'
 					);
 					?>
 				</p>
@@ -208,7 +208,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 					printf(
 						/* translators: %s: Link to "full site editing" themes on WordPress.org. */
 						__( 'The Themes Directory has <a href="%s">a filter for block themes</a>, and a pattern preview gives a better sense of what the theme might look like while exploring different themes and patterns.' ),
-						__( 'https://wordpress.org/themes/tags/full-site-editing/' )
+						esc_url( __( 'https://wordpress.org/themes/tags/full-site-editing/' ) )
 					);
 					?>
 				</p>
@@ -266,9 +266,9 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 				<p>
 					<?php
 					printf(
-						/* translators: %s: Link to WordPress.org accessibility statement. */
+						/* translators: %s: Link to accessibility improvements dev note. */
 						__( 'More than 40 improvements in accessibility include resolving focus loss problems in the editor, improving form labels and audible messages, making alternative text easier to edit, and fixing the sub-menu overlap in the expanded admin side navigation at smaller screen sizes and higher zoom levels. Learn more about <a href="%s">accessibility in WordPress</a>.' ),
-						'https://wordpress.org/about/accessibility/'
+						'https://make.wordpress.org/core/2022/10/11/wordpress-6-1-accessibility-improvements/'
 					);
 					?>
 				</p>
@@ -446,7 +446,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 					printf(
 						/* translators: %s: Link to install Performance Lab plugin if permitted, otherwise link to plugin on WordPress.org. */
 						__( 'Be among the first to get the latest improvements by adding the <a href="%s">Performance Lab plugin</a> to your WordPress test site or sandbox.' ),
-						current_user_can( 'install_plugins' ) ? admin_url( 'plugin-install.php?s=slug%253Aperformance-lab&tab=search&type=term' ) : 'https://wordpress.org/plugins/performance-lab/'
+						current_user_can( 'install_plugins' ) ? admin_url( 'plugin-install.php?s=slug%253Aperformance-lab&tab=search&type=term' ) : esc_url( __( 'https://wordpress.org/plugins/performance-lab/' ) )
 					);
 					?>
 				</p>
@@ -459,7 +459,15 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 					</svg>
 				</div>
 				<h3 class="is-smaller-heading"><?php _e( 'Content-only editing support for container blocks' ); ?></h3>
-				<p><?php _e( 'Thanks to content-only editing settings, layouts can be locked within container blocks. In a content-only block, its children are invisible to the List View and entirely uneditable. So you control the layout while your writers can focus on the content.' ); ?></p>
+				<p>
+					<?php
+					printf(
+						/* translators: %s: Link to content locking dev note. */
+						__( 'Thanks to <a href="%s">content-only editing settings</a>, layouts can be locked within container blocks. In a content-only block, its children are invisible to the List View and entirely uneditable. So you control the layout while your writers can focus on the content.' ),
+						'https://make.wordpress.org/core/2022/10/11/content-locking-features-and-updates/'
+					);
+					?>
+				</p>
 				<p><?php _e( 'Combine it with block locking options for even more advanced control over your blocks.' ); ?></p>
 			</div>
 		</div>
@@ -478,7 +486,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 					printf(
 						/* translators: %s: Link to fluid typography demo. */
 						__( '<a href="%s">Fluid typography</a> lets you define font sizes that adapt for easy reading in any screen size.' ),
-						'https://make.wordpress.org/core/2022/08/04/whats-new-in-gutenberg-13-8-3-august/#fluid-typography-support'
+						'https://make.wordpress.org/core/2022/10/03/fluid-font-sizes-in-wordpress-6-1/'
 					);
 					?>
 				</p>
@@ -520,10 +528,9 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 				<p>
 					<?php
 					printf(
-						/* translators: 1: Learn WordPress workshops link, 2: Learn WordPress social learning link. */
-						__( 'Explore <a href="%1$s">learn.wordpress.org/&#8203;workshops</a> for quick how-to videos and lots more on new features in WordPress. Or join a live <a href="%2$s">interactive online learning session</a> on a specific WordPress topic.' ),
-						'https://learn.wordpress.org/workshops/',
-						'https://learn.wordpress.org/social-learning/'
+						/* translators: 1: Learn WordPress link. */
+						__( 'Explore <a href="%s">learn.wordpress.org</a> for tutorial videos, online workshops, courses, and lesson plans for Meetup organizers, including new features in WordPress.' ),
+						'https://learn.wordpress.org/'
 					);
 					?>
 				</p>


### PR DESCRIPTION
In this PR, I've updated the learn copy (comment 37) & added the links mentioned in comments 38, 40, 41, and added a translation wrapper around the performance plugin link (comment 44). Also updated the field guide link.

The "header & footer" section has been removed in and replaced with the "fluid typography" section from the icon grid.

The intro sentence with "2,000" in it has been removed.

[View page screenshot](https://user-images.githubusercontent.com/541093/195657525-06a432c6-5c35-4f76-b429-3058cd9bf28e.png)


Trac ticket: https://core.trac.wordpress.org/ticket/56357

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
