### PR TITLE
Replaced all instances of "NPM" and "NodeJS" with "npm" and "Node.js" respectively.

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -21,7 +21,7 @@ on:
       # Any change to a PHP or JavaScript file should run checks.
       - '**.js'
       - '**.php'
-      # These files configure NPM. Changes could affect the outcome.
+      # These files configure npm. Changes could affect the outcome.
       - 'package*.json'
       # These files configure Composer. Changes could affect the outcome.
       - 'composer.*'
@@ -125,9 +125,9 @@ jobs:
   # Performs the following steps:
   # - Checks out the repository.
   # - Logs debug information about the GitHub Action runner.
-  # - Installs NodeJS.
+  # - Installs Node.js.
   # - Logs updated debug information.
-  # _ Installs NPM dependencies.
+  # _ Installs npm dependencies.
   # - Run the WordPress JSHint checks.
   # - Ensures version-controlled files are not modified or deleted.
   jshint:
@@ -149,7 +149,7 @@ jobs:
           git --version
           svn --version
 
-      - name: Install NodeJS
+      - name: Install Node.js
         uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v3.5.1
         with:
           node-version-file: '.nvmrc'

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -36,8 +36,8 @@ jobs:
   # - Sets environment variables.
   # - Checks out the repository.
   # - Logs debug information about the GitHub Action runner.
-  # - Installs NodeJS.
-  # _ Installs NPM dependencies.
+  # - Installs Node.js.
+  # _ Installs npm dependencies.
   # - Builds WordPress to run from the `build` directory.
   # - Starts the WordPress Docker container.
   # - Logs general debug information.
@@ -72,7 +72,7 @@ jobs:
           php -i
           locale -a
 
-      - name: Install NodeJS
+      - name: Install Node.js
         uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v3.5.1
         with:
           node-version-file: '.nvmrc'

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -19,7 +19,7 @@ on:
     paths:
       # Any change to a JavaScript file should run tests.
       - '**.js'
-      # These files configure NPM. Changes could affect the outcome.
+      # These files configure npm. Changes could affect the outcome.
       - 'package*.json'
       # This file configures ESLint. Changes could affect the outcome.
       - '.eslintignore'
@@ -44,9 +44,9 @@ jobs:
   # Performs the following steps:
   # - Checks out the repository.
   # - Logs debug information about the GitHub Action runner.
-  # - Installs NodeJS.
+  # - Installs Node.js.
   # - Logs updated debug information.
-  # _ Installs NPM dependencies.
+  # _ Installs npm dependencies.
   # - Run the WordPress QUnit tests.
   # - Ensures version-controlled files are not modified or deleted.
   test-js:
@@ -66,7 +66,7 @@ jobs:
           git --version
           svn --version
 
-      - name: Install NodeJS
+      - name: Install Node.js
         uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v3.5.1
         with:
           node-version-file: '.nvmrc'

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -37,8 +37,8 @@ jobs:
   # Performs the following steps:
   # - Sets environment variables.
   # - Sets up the environment variables needed for testing with memcached (if desired).
-  # - Installs NodeJS.
-  # - Installs NPM dependencies
+  # - Installs Node.js.
+  # - Installs npm dependencies
   # - Configures caching for Composer.
   # - Installs Composer dependencies.
   # - Logs Docker debug information (about the Docker installation within the runner).
@@ -108,7 +108,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
-      - name: Install NodeJS
+      - name: Install Node.js
         uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v3.5.1
         with:
           node-version-file: '.nvmrc'

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -39,8 +39,8 @@ jobs:
   # - Checks out the repository.
   # - Checks out the WordPress Importer plugin (needed for the Core PHPUnit tests).
   # - Logs debug information about the GitHub Action runner.
-  # - Installs NodeJS.
-  # _ Installs NPM dependencies.
+  # - Installs Node.js.
+  # _ Installs npm dependencies.
   # - Logs Docker debug information (about the Docker installation within the runner).
   # - Starts the WordPress Docker container.
   # - Logs debug general information.
@@ -86,7 +86,7 @@ jobs:
           php -i
           locale -a
 
-      - name: Install NodeJS
+      - name: Install Node.js
         uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v3.5.1
         with:
           node-version-file: '.nvmrc'

--- a/.github/workflows/test-npm.yml
+++ b/.github/workflows/test-npm.yml
@@ -1,4 +1,4 @@
-name: Test NPM
+name: Test npm
 
 on:
   push:
@@ -15,11 +15,11 @@ on:
       - '3.[7-9]'
       - '[4-9].[0-9]'
     paths:
-      # These files configure NPM. Changes could affect the outcome.
+      # These files configure npm. Changes could affect the outcome.
       - 'package*.json'
-      # JavaScript files are built using NPM.
+      # JavaScript files are built using npm.
       - '**.js'
-      # CSS and SCSS files are built using NPM.
+      # CSS and SCSS files are built using npm.
       - '**.scss'
       - '**.css'
       # Changes to workflow files should always verify all workflows are successful.
@@ -37,13 +37,13 @@ env:
   PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: ${{ true }}
 
 jobs:
-  # Verifies that installing NPM dependencies and building WordPress works as expected.
+  # Verifies that installing npm dependencies and building WordPress works as expected.
   #
   # Performs the following steps:
   # - Checks out the repository.
   # - Logs debug information about the GitHub Action runner.
-  # - Installs NodeJS.
-  # _ Installs NPM dependencies.
+  # - Installs Node.js.
+  # _ Installs npm dependencies.
   # - Builds WordPress to run from the `build` directory.
   # - Cleans up after building WordPress to the `build` directory.
   # - Ensures version-controlled files are not modified or deleted.
@@ -51,7 +51,7 @@ jobs:
   # - Cleans up after building WordPress to the `src` directory.
   # - Ensures version-controlled files are not modified or deleted.
   test-npm:
-    name: Test NPM on ${{ matrix.os }}
+    name: Test npm on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
@@ -72,7 +72,7 @@ jobs:
           git --version
           svn --version
 
-      - name: Install NodeJS
+      - name: Install Node.js
         uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v3.5.1
         with:
           node-version-file: '.nvmrc'
@@ -99,7 +99,7 @@ jobs:
       - name: Ensure version-controlled files are not modified or deleted during building and cleaning
         run: git diff --exit-code
 
-  # Verifies that installing NPM dependencies and building WordPress works as expected on MacOS.
+  # Verifies that installing npm dependencies and building WordPress works as expected on MacOS.
   #
   # This is separate from the job above in order to use stricter conditions about when to run.
   # This avoids unintentionally consuming excessive minutes, as MacOS jobs consume minutes at a 10x rate.
@@ -107,8 +107,8 @@ jobs:
   # Performs the following steps:
   # - Checks out the repository.
   # - Logs debug information about the GitHub Action runner.
-  # - Installs NodeJS.
-  # _ Installs NPM dependencies.
+  # - Installs Node.js.
+  # _ Installs npm dependencies.
   # - Builds WordPress to run from the `build` directory.
   # - Cleans up after building WordPress to the `build` directory.
   # - Ensures version-controlled files are not modified or deleted.
@@ -116,7 +116,7 @@ jobs:
   # - Cleans up after building WordPress to the `src` directory.
   # - Ensures version-controlled files are not modified or deleted.
   test-npm-macos:
-    name: Test NPM on MacOS
+    name: Test npm on MacOS
     runs-on: macos-latest
     timeout-minutes: 30
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -132,7 +132,7 @@ jobs:
           git --version
           svn --version
 
-      - name: Install NodeJS
+      - name: Install Node.js
         uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v3.5.1
         with:
           node-version-file: '.nvmrc'

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You will need Node and npm installed on your computer. Node is a JavaScript runt
 
 If you are not using a package manager, see the [Node.js download page](https://nodejs.org/en/download/) for installers and binaries.
 
-**Note:** WordPress currently only supports NodeJS `14.x` and npm `6.x`.
+**Note:** WordPress currently only supports Node.js `14.x` and npm `6.x`.
 
 You will also need [Docker](https://www.docker.com/products/docker-desktop) installed and running on your computer. Docker is the virtualization software that powers the local development environment. Docker can be installed just like any other regular application.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -75,7 +75,7 @@ We generally **aren’t** interested in the following problems:
 *   Output from automated scans - please manually verify issues and include a valid proof of concept.
 *   Any non-severe vulnerability on `irclogs.wordpress.org`, `lists.wordpress.org`, or any other low impact site.
 *   Clickjacking with minimal security implications
-*   Vulnerabilities in Composer/NPM `devDependencies`, unless there's a practical way to exploit it remotely.
+*   Vulnerabilities in Composer/npm `devDependencies`, unless there's a practical way to exploit it remotely.
 *   Theoretical vulnerabilities where you can't demonstrate a significant security impact with a PoC.
 
 ## Guidelines

--- a/src/index.php
+++ b/src/index.php
@@ -55,8 +55,8 @@ $die .= '<code style="color: green;">npm run build</code></li>';
 $die .= '</ul>';
 
 $die .= '<p>' . sprintf(
-	/* translators: 1: NPM URL, 2: Handbook URL. */
-	__( 'This requires <a href="%1$s">NPM</a>. <a href="%2$s">Learn more about setting up your local development environment</a>.' ),
+	/* translators: 1: npm URL, 2: Handbook URL. */
+	__( 'This requires <a href="%1$s">npm</a>. <a href="%2$s">Learn more about setting up your local development environment</a>.' ),
 	'https://www.npmjs.com/get-npm',
 	__( 'https://make.wordpress.org/core/handbook/tutorials/installing-wordpress-locally/' )
 ) . '</p>';

--- a/src/js/_enqueues/vendor/README.md
+++ b/src/js/_enqueues/vendor/README.md
@@ -1,6 +1,6 @@
 # src/js/enqueues/vendor
 
-In this directory you'll find vendor JavaScript packages that cannot be installed through NPM, but are included in WordPress. Below we've documented the sources for those packages.
+In this directory you'll find vendor JavaScript packages that cannot be installed through npm, but are included in WordPress. Below we've documented the sources for those packages.
 
 ## Folder dependencies
 
@@ -62,9 +62,9 @@ In this directory you'll find vendor JavaScript packages that cannot be installe
 - farbtastic: https://github.com/mattfarina/farbtastic
 - iris: https://github.com/Automattic/Iris
 - json2: https://github.com/douglascrockford/JSON-js
-- jquery/jquery.color: https://github.com/jquery/jquery-color. Package is on NPM but not published by maintainer.
+- jquery/jquery.color: https://github.com/jquery/jquery-color. Package is on npm but not published by maintainer.
 - jquery/jquery.hotkeys: https://github.com/tzuryby/jquery.hotkeys
-- jquery/jquery.masonry: Old version for BC purposes, can't include two versions with NPM. The newer version is included through NPM and built to `wp-includes/js/masonry.min.js`
+- jquery/jquery.masonry: Old version for BC purposes, can't include two versions with npm. The newer version is included through npm and built to `wp-includes/js/masonry.min.js`
 - jquery/jquery.query: https://github.com/blairmitchelmore/jquery.plugins/blob/master/jquery.query.js
 - jquery/jquery.schedule: https://github.com/rse/jquery-schedule
 - jquery/jquery.serializeobject: https://github.com/cowboy/jquery-misc/blob/master/jquery.ba-serializeobject.js


### PR DESCRIPTION
Replaced all instances of "NPM" and "NodeJS" with "npm" and "Node.js" respectively, which are the correct names

Trac ticket: [https://core.trac.wordpress.org/ticket/56816](https://core.trac.wordpress.org/ticket/56816)
