### PR TITLE
WIP REST API: Add revision count and links to template parts

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
@@ -752,6 +752,23 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 			),
 		);
 
+		$template = get_block_template( $id, $this->post_type );
+		$revisions = wp_get_latest_revision_id_and_total_count( $template->wp_id );
+		$revisions_count = ! is_wp_error( $revisions ) ? $revisions['count'] : 0;
+		$revisions_base  = sprintf( '/%s/%s/%d/revisions', $this->namespace, $this->rest_base, $id );
+
+		$links['version-history'] = array(
+			'href'  => rest_url( $revisions_base ),
+			'count' => $revisions_count,
+		);
+
+		if ( $revisions_count > 0 ) {
+			$links['predecessor-version'] = array(
+				'href' => rest_url( $revisions_base . '/' . $revisions['latest_id'] ),
+				'id'   => $revisions['latest_id'],
+			);
+		}
+
 		return $links;
 	}
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This adds revision information for template parts, which will be needed for WordPress/Gutenberg#44503

## TODO

- [ ] Add checks for templates without wp_id
- [ ] Add endpoints for revisions
- [ ] Unit tests

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
