### PR TITLE
Coding Standards: Ignore some database and naming sniffs in `install-helper.php`.

### DIFF
--- a/src/wp-admin/install-helper.php
+++ b/src/wp-admin/install-helper.php
@@ -89,6 +89,7 @@ if ( ! function_exists( 'maybe_add_column' ) ) :
 	function maybe_add_column( $table_name, $column_name, $create_ddl ) {
 		global $wpdb;
 
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Cannot be prepared. Fetches columns for table names.
 		foreach ( $wpdb->get_col( "DESC $table_name", 0 ) as $column ) {
 			if ( $column === $column_name ) {
 				return true;
@@ -100,6 +101,7 @@ if ( ! function_exists( 'maybe_add_column' ) ) :
 		$wpdb->query( $create_ddl );
 
 		// We cannot directly tell that whether this succeeded!
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Cannot be prepared. Fetches columns for table names.
 		foreach ( $wpdb->get_col( "DESC $table_name", 0 ) as $column ) {
 			if ( $column === $column_name ) {
 				return true;
@@ -125,6 +127,7 @@ endif;
 function maybe_drop_column( $table_name, $column_name, $drop_ddl ) {
 	global $wpdb;
 
+	// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Cannot be prepared. Fetches columns for table names.
 	foreach ( $wpdb->get_col( "DESC $table_name", 0 ) as $column ) {
 		if ( $column === $column_name ) {
 
@@ -133,6 +136,7 @@ function maybe_drop_column( $table_name, $column_name, $drop_ddl ) {
 			$wpdb->query( $drop_ddl );
 
 			// We cannot directly tell that whether this succeeded!
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Cannot be prepared. Fetches columns for table names.
 			foreach ( $wpdb->get_col( "DESC $table_name", 0 ) as $column ) {
 				if ( $column === $column_name ) {
 					return false;
@@ -177,7 +181,9 @@ function maybe_drop_column( $table_name, $column_name, $drop_ddl ) {
 function check_column( $table_name, $col_name, $col_type, $is_null = null, $key = null, $default_value = null, $extra = null ) {
 	global $wpdb;
 
-	$diffs   = 0;
+	$diffs = 0;
+
+	// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Cannot be prepared. Fetches columns for table names.
 	$results = $wpdb->get_results( "DESC $table_name" );
 
 	foreach ( $results as $row ) {

--- a/src/wp-admin/install-helper.php
+++ b/src/wp-admin/install-helper.php
@@ -59,6 +59,7 @@ if ( ! function_exists( 'maybe_create_table' ) ) :
 		}
 
 		// Didn't find it, so try to create it.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- No applicable variables for this query.
 		$wpdb->query( $create_ddl );
 
 		// We cannot directly tell that whether this succeeded!
@@ -95,6 +96,7 @@ if ( ! function_exists( 'maybe_add_column' ) ) :
 		}
 
 		// Didn't find it, so try to create it.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- No applicable variables for this query.
 		$wpdb->query( $create_ddl );
 
 		// We cannot directly tell that whether this succeeded!
@@ -127,6 +129,7 @@ function maybe_drop_column( $table_name, $column_name, $drop_ddl ) {
 		if ( $column === $column_name ) {
 
 			// Found it, so try to drop it.
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- No applicable variables for this query.
 			$wpdb->query( $drop_ddl );
 
 			// We cannot directly tell that whether this succeeded!


### PR DESCRIPTION
Refreshes [43761-fix-coding-standards.patch](https://core.trac.wordpress.org/attachment/ticket/43761/43761-fix-coding-standards.patch) against `trunk` with some minor updates.

---

This adds inline comments instructing PHPCS to ignore some lines for database queries and property naming in `wp-admin/install-helper.php`.

An explanation is provided with each instruction.

The sniffs in question are:
- WordPress.DB.PreparedSQL.NotPrepared - Ignored as needed.
- WordPress.DB.PreparedSQL.InterpolatedNotPrepared - Ignored as needed.
- WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase - Temporarily disabled, then re-enabled.

Trac ticket: https://core.trac.wordpress.org/ticket/43761