### PR TITLE
Fix PHP 8.0 deprecation error in uasort callback

### DIFF
--- a/src/wp-includes/category-template.php
+++ b/src/wp-includes/category-template.php
@@ -1087,7 +1087,10 @@ function _wp_object_name_sort_cb( $a, $b ) {
  * @return bool Whether the count value for `$a` is greater than the count value for `$b`.
  */
 function _wp_object_count_sort_cb( $a, $b ) {
-	return ( $a->count > $b->count );
+	if ( $a->count === $b->count ) {
+		return 0;
+	}
+	return ( $a->count < $b->count ) ? -1 : 1;
 }
 
 //


### PR DESCRIPTION
Fix `uasort(): Returning bool from comparison function is deprecated, return an integer less than, equal to, or greater than zero` deprecation error.

Trac ticket: https://core.trac.wordpress.org/ticket/56838