### PR TITLE
`register_block_type`: Accept `editor_script` array for back-compat

### DIFF
--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -372,7 +372,7 @@ class WP_Block_Type {
 				return;
 		}
 
-		$this->{$new_name}[0] = $value;
+		$this->{$new_name} = array( $value );
 	}
 
 	/**

--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -343,11 +343,31 @@ class WP_Block_Type {
 			return;
 		}
 
-		if ( ! is_string( $value ) ) {
+		$new_name = $name . '_handles';
+
+		if ( is_array( $value ) ) {
+			$filtered = array_filter( $value, 'is_string' );
+
+			if ( count( $filtered ) !== count( $value ) ) {
+					_doing_it_wrong(
+							__METHOD__,
+							sprintf(
+							/* translators: %s: The '$value' argument. */
+							__( 'The %s argument must be a string or a string array.' ),
+							'<code>$value</code>'
+							),
+							'6.1.0',
+					);
+			}
+
+			$this->{$new_name} = $filtered;
 			return;
 		}
 
-		$new_name             = $name . '_handles';
+		if ( ! is_string( $value ) ) {
+				return;
+		}
+
 		$this->{$new_name}[0] = $value;
 	}
 

--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -304,6 +304,10 @@ class WP_Block_Type {
 		}
 
 		$new_name = $name . '_handles';
+
+		if ( count( $this->{$new_name} ) > 1 ) {
+			return $this->{$new_name};
+		}
 		return isset( $this->{$new_name}[0] ) ? $this->{$new_name}[0] : null;
 	}
 

--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -350,13 +350,13 @@ class WP_Block_Type {
 
 			if ( count( $filtered ) !== count( $value ) ) {
 					_doing_it_wrong(
-							__METHOD__,
-							sprintf(
-							/* translators: %s: The '$value' argument. */
-							__( 'The %s argument must be a string or a string array.' ),
-							'<code>$value</code>'
-							),
-							'6.1.0',
+						__METHOD__,
+						sprintf(
+						/* translators: %s: The '$value' argument. */
+						__( 'The %s argument must be a string or a string array.' ),
+						'<code>$value</code>'
+						),
+						'6.1.0',
 					);
 			}
 

--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -295,8 +295,8 @@ class WP_Block_Type {
 	 *
 	 * @param string $name Deprecated property name.
 	 *
-	 * @return string|null|void The value read from the new property if the first item in the array provided,
-	 *                          null when value not found, or void when unknown property name provided.
+	 * @return string|string[]|null|void The value read from the new property if the first item in the array provided,
+	 *                                   null when value not found, or void when unknown property name provided.
 	 */
 	public function __get( $name ) {
 		if ( ! in_array( $name, $this->deprecated_properties ) ) {

--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -352,9 +352,9 @@ class WP_Block_Type {
 					_doing_it_wrong(
 						__METHOD__,
 						sprintf(
-						/* translators: %s: The '$value' argument. */
-						__( 'The %s argument must be a string or a string array.' ),
-						'<code>$value</code>'
+							/* translators: %s: The '$value' argument. */
+							__( 'The %s argument must be a string or a string array.' ),
+							'<code>$value</code>'
 						),
 						'6.1.0',
 					);

--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -305,6 +305,10 @@ class WP_Block_Type {
 
 		$new_name = $name . '_handles';
 
+		if ( ! property_exists( $this, $new_name ) || ! is_array( $this->{$new_name} ) ) {
+			return null;
+		}
+
 		if ( count( $this->{$new_name} ) > 1 ) {
 			return $this->{$new_name};
 		}

--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -364,7 +364,7 @@ class WP_Block_Type {
 					);
 			}
 
-			$this->{$new_name} = $filtered;
+			$this->{$new_name} = array_values( $filtered );
 			return;
 		}
 

--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -369,7 +369,7 @@ class WP_Block_Type {
 		}
 
 		if ( ! is_string( $value ) ) {
-				return;
+			return;
 		}
 
 		$this->{$new_name} = array( $value );

--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -356,7 +356,7 @@ class WP_Block_Type {
 							__( 'The %s argument must be a string or a string array.' ),
 							'<code>$value</code>'
 						),
-						'6.1.0',
+						'6.1.0'
 					);
 			}
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
@@ -297,7 +297,7 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 					$field = $block_type->$extra_field;
 					if ( in_array( $extra_field, $deprecated_fields, true ) && is_array( $field ) ) {
 						// Since the schema only allows strings or null (but no arrays), we return the first array item.
-						$field = !empty( $field ) ? array_shift( $field ) : '';
+						$field = ! empty( $field ) ? array_shift( $field ) : '';
 					}
 				} elseif ( array_key_exists( 'default', $schema['properties'][ $extra_field ] ) ) {
 					$field = $schema['properties'][ $extra_field ]['default'];

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
@@ -297,7 +297,7 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 					$field = $block_type->$extra_field;
 					if ( in_array( $extra_field, $deprecated_fields, true ) && is_array( $field ) ) {
 						// Since the schema only allows strings or null (but no arrays), we return the first array item.
-						$field = isset( $field[0] ) ? $field[0] : null;
+						$field = !empty( $field ) ? array_shift( $field ) : '';
 					}
 				} elseif ( array_key_exists( 'default', $schema['properties'][ $extra_field ] ) ) {
 					$field = $schema['properties'][ $extra_field ]['default'];

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
@@ -295,6 +295,10 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 			if ( rest_is_field_included( $extra_field, $fields ) ) {
 				if ( isset( $block_type->$extra_field ) ) {
 					$field = $block_type->$extra_field;
+					if ( in_array( $extra_field, $deprecated_fields, true ) && is_array( $field ) ) {
+						// Since the schema only allows strings or null (but no arrays), we return the first array item.
+						$field = $field[0];
+					}
 				} elseif ( array_key_exists( 'default', $schema['properties'][ $extra_field ] ) ) {
 					$field = $schema['properties'][ $extra_field ]['default'];
 				} else {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
@@ -297,7 +297,7 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 					$field = $block_type->$extra_field;
 					if ( in_array( $extra_field, $deprecated_fields, true ) && is_array( $field ) ) {
 						// Since the schema only allows strings or null (but no arrays), we return the first array item.
-						$field = $field[0];
+						$field = isset( $field[0] ) ? $field[0] : null;
 					}
 				} elseif ( array_key_exists( 'default', $schema['properties'][ $extra_field ] ) ) {
 					$field = $schema['properties'][ $extra_field ]['default'];

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -573,8 +573,8 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 		$settings = array( 'editor_script' => $editor_script );
 		register_block_type( 'core/test-static', $settings );
 
-		$registry              = WP_Block_Type_Registry::get_instance();
-		$block_type            = $registry->get_registered( 'core/test-static' );
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$block_type = $registry->get_registered( 'core/test-static' );
 		$this->assertObjectHasAttribute( 'editor_script', $block_type );
 		$this->assertObjectHasAttribute( 'editor_script_handles', $block_type );
 		$actual_script         = $block_type->editor_script;
@@ -640,8 +640,8 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 		$settings = array( 'editor_script' => $editor_script );
 		register_block_type( 'core/test-static', $settings );
 
-		$registry              = WP_Block_Type_Registry::get_instance();
-		$block_type            = $registry->get_registered( 'core/test-static' );
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$block_type = $registry->get_registered( 'core/test-static' );
 		$this->assertObjectHasAttribute( 'editor_script', $block_type );
 		$this->assertObjectHasAttribute( 'editor_script_handles', $block_type );
 		$actual_script         = $block_type->editor_script;

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -561,7 +561,7 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 
 		$registry   = WP_Block_Type_Registry::get_instance();
 		$registered = $registry->get_all_registered();
-		$actual     = json_encode( $registered['core/test-static']->editor_script );
+		$actual     = $registered['core/test-static']->editor_script;
 
 		$this->assertSame( $settings['editor_script'], $actual );
 	}

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -575,7 +575,6 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 
 		$registry   = WP_Block_Type_Registry::get_instance();
 		$block_type = $registry->get_registered( 'core/test-static' );
-		$this->assertObjectHasAttribute( 'editor_script', $block_type );
 		$this->assertObjectHasAttribute( 'editor_script_handles', $block_type );
 		$actual_script         = $block_type->editor_script;
 		$actual_script_handles = $block_type->editor_script_handles;
@@ -642,7 +641,6 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 
 		$registry   = WP_Block_Type_Registry::get_instance();
 		$block_type = $registry->get_registered( 'core/test-static' );
-		$this->assertObjectHasAttribute( 'editor_script', $block_type );
 		$this->assertObjectHasAttribute( 'editor_script_handles', $block_type );
 		$actual_script         = $block_type->editor_script;
 		$actual_script_handles = $block_type->editor_script_handles;

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -553,6 +553,20 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 56707
+	 */
+	public function test_register_block_type_accepts_editor_script_array() {
+		$settings = array( 'editor_script' => array( 'hello', 'world' ) );
+		register_block_type( 'core/test-static', $settings );
+
+		$registry   = WP_Block_Type_Registry::get_instance();
+		$registered = $registry->get_all_registered();
+		$actual     = json_encode( $registered['core/test-static']->editor_script );
+
+		$this->assertSame( $settings['editor_script'], $actual );
+	}
+
+	/**
 	 * @ticket 52301
 	 */
 	public function test_block_registers_with_metadata_i18n_support() {

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -574,7 +574,7 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 		register_block_type( 'core/test-static', $settings );
 
 		$registry              = WP_Block_Type_Registry::get_instance();
-		$block_type            = $registry->get_registered('core/test-static');
+		$block_type            = $registry->get_registered( 'core/test-static' );
 		$actual_script         = $block_type->editor_script;
 		$actual_script_handles = $block_type->editor_script_handles;
 
@@ -639,7 +639,7 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 		register_block_type( 'core/test-static', $settings );
 
 		$registry              = WP_Block_Type_Registry::get_instance();
-		$block_type            = $registry->get_registered('core/test-static');
+		$block_type            = $registry->get_registered( 'core/test-static' );
 		$actual_script         = $block_type->editor_script;
 		$actual_script_handles = $block_type->editor_script_handles;
 

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -574,9 +574,9 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 		register_block_type( 'core/test-static', $settings );
 
 		$registry              = WP_Block_Type_Registry::get_instance();
-		$registered            = $registry->get_all_registered();
-		$actual_script         = $registered['core/test-static']->editor_script;
-		$actual_script_handles = $registered['core/test-static']->editor_script_handles;
+		$block_type         = $registry->get_registered('core/test-static');
+		$actual_script         = $block_type->editor_script;
+		$actual_script_handles = $block_type->editor_script_handles;
 
 		$this->assertSame(
 			$expected,

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -575,6 +575,8 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 
 		$registry              = WP_Block_Type_Registry::get_instance();
 		$block_type            = $registry->get_registered( 'core/test-static' );
+		$this->assertObjectHasAttribute( 'editor_script', $block_type );
+		$this->assertObjectHasAttribute( 'editor_script_handles', $block_type );
 		$actual_script         = $block_type->editor_script;
 		$actual_script_handles = $block_type->editor_script_handles;
 

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -574,7 +574,7 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 		register_block_type( 'core/test-static', $settings );
 
 		$registry              = WP_Block_Type_Registry::get_instance();
-		$block_type         = $registry->get_registered('core/test-static');
+		$block_type            = $registry->get_registered('core/test-static');
 		$actual_script         = $block_type->editor_script;
 		$actual_script_handles = $block_type->editor_script_handles;
 

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -639,9 +639,9 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 		register_block_type( 'core/test-static', $settings );
 
 		$registry              = WP_Block_Type_Registry::get_instance();
-		$registered            = $registry->get_all_registered();
-		$actual_script         = $registered['core/test-static']->editor_script;
-		$actual_script_handles = $registered['core/test-static']->editor_script_handles;
+		$block_type            = $registry->get_registered('core/test-static');
+		$actual_script         = $block_type->editor_script;
+		$actual_script_handles = $block_type->editor_script_handles;
 
 		$this->assertSame(
 			$expected,

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -640,6 +640,8 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 
 		$registry              = WP_Block_Type_Registry::get_instance();
 		$block_type            = $registry->get_registered( 'core/test-static' );
+		$this->assertObjectHasAttribute( 'editor_script', $block_type );
+		$this->assertObjectHasAttribute( 'editor_script_handles', $block_type );
 		$actual_script         = $block_type->editor_script;
 		$actual_script_handles = $block_type->editor_script_handles;
 

--- a/tests/phpunit/tests/rest-api/rest-block-type-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-block-type-controller.php
@@ -338,6 +338,36 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$this->assertNull( $data['style'] );
 	}
 
+	/**
+	 * @ticket 56733
+	 */
+	public function test_get_item_deprecated() {
+		$block_type = 'fake/deprecated';
+		$settings   = array(
+			'editor_script' => array( 'editor', 'script' ),
+			'script'        => array( 'guten', 'berg' ),
+			'view_script'   => array( 'view', 'script' ),
+			'editor_style'  => array( 'editor', 'style' ),
+			'style'         => array( 'out', 'of', 'style' ),
+		);
+		register_block_type( $block_type, $settings );
+		wp_set_current_user( self::$admin_id );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/block-types/' . $block_type );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		$this->assertSameSets( $settings['editor_script'], $data['editor_script_handles'] );
+		$this->assertSameSets( $settings['script'], $data['script_handles'] );
+		$this->assertSameSets( $settings['view_script'], $data['view_script_handles'] );
+		$this->assertSameSets( $settings['editor_style'], $data['editor_style_handles'] );
+		$this->assertSameSets( $settings['style'], $data['style_handles'] );
+		// Deprecated properties.
+		$this->assertSameSets( $settings['editor_script'], $data['editor_script'] );
+		$this->assertSameSets( $settings['script'], $data['script'] );
+		$this->assertSameSets( $settings['view_script'], $data['view_script'] );
+		$this->assertSameSets( $settings['editor_style'], $data['editor_style'] );
+		$this->assertSameSets( $settings['style'], $data['style'] );
+	}
+
 	public function test_get_variation() {
 		$block_type = 'fake/variations';
 		$settings   = array(

--- a/tests/phpunit/tests/rest-api/rest-block-type-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-block-type-controller.php
@@ -355,17 +355,57 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/block-types/' . $block_type );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
-		$this->assertSameSets( array( 'hello_world' ), $data['editor_script_handles'] );
-		$this->assertSameSets( array( 'gutenberg' ), $data['script_handles'] );
-		$this->assertSameSets( array( 'foo_bar' ), $data['view_script_handles'] );
-		$this->assertSameSets( array( 'guten_tag' ), $data['editor_style_handles'] );
-		$this->assertSameSets( array( 'out_of_style' ), $data['style_handles'] );
+		$this->assertSameSets(
+			array( 'hello_world' ),
+			$data['editor_script_handles'],
+			"Endpoint doesn't return correct array for editor_script_handles."
+		);
+		$this->assertSameSets(
+			array( 'gutenberg' ),
+			$data['script_handles'],
+			"Endpoint doesn't return correct array for script_handles."
+		);
+		$this->assertSameSets(
+			array( 'foo_bar' ),
+			$data['view_script_handles'],
+			"Endpoint doesn't return correct array for view_script_handles."
+		);
+		$this->assertSameSets(
+			array( 'guten_tag' ),
+			$data['editor_style_handles'],
+			"Endpoint doesn't return correct array for editor_style_handles."
+		);
+		$this->assertSameSets(
+			array( 'out_of_style' ),
+			$data['style_handles'],
+			"Endpoint doesn't return correct array for style_handles."
+		);
 		// Deprecated properties.
-		$this->assertSame( 'hello_world', $data['editor_script'] );
-		$this->assertSame( 'gutenberg', $data['script'] );
-		$this->assertSame( 'foo_bar', $data['view_script'] );
-		$this->assertSame( 'guten_tag', $data['editor_style'] );
-		$this->assertSame( 'out_of_style', $data['style'] );
+		$this->assertSame(
+			'hello_world',
+			$data['editor_script'],
+			"Endpoint doesn't return correct string for editor_script."
+		);
+		$this->assertSame(
+			'gutenberg',
+			$data['script'],
+			"Endpoint doesn't return correct string for script."
+		);
+		$this->assertSame(
+			'foo_bar',
+			$data['view_script'],
+			"Endpoint doesn't return correct string for view_script."
+		);
+		$this->assertSame(
+			'guten_tag',
+			$data['editor_style'],
+			"Endpoint doesn't return correct string for editor_style."
+		);
+		$this->assertSame(
+			'out_of_style',
+			$data['style'],
+			"Endpoint doesn't return correct string for style."
+		);
 	}
 
 	/**
@@ -385,18 +425,59 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/block-types/' . $block_type );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
-		$this->assertSameSets( $settings['editor_script'], $data['editor_script_handles'] );
-		$this->assertSameSets( $settings['script'], $data['script_handles'] );
-		$this->assertSameSets( $settings['view_script'], $data['view_script_handles'] );
-		$this->assertSameSets( $settings['editor_style'], $data['editor_style_handles'] );
-		$this->assertSameSets( $settings['style'], $data['style_handles'] );
+		$this->assertSameSets(
+			$settings['editor_script'],
+			$data['editor_script_handles'],
+			"Endpoint doesn't return correct array for editor_script_handles."
+		);
+		$this->assertSameSets(
+			$settings['script'],
+			$data['script_handles'],
+			"Endpoint doesn't return correct array for script_handles."
+		);
+		$this->assertSameSets(
+			$settings['view_script'],
+			$data['view_script_handles'],
+			"Endpoint doesn't return correct array for view_script_handles."
+		);
+		$this->assertSameSets(
+			$settings['editor_style'],
+			$data['editor_style_handles'],
+			"Endpoint doesn't return correct array for editor_style_handles."
+		);
+		$this->assertSameSets(
+			$settings['style'],
+			$data['style_handles'],
+			"Endpoint doesn't return correct array for style_handles."
+		);
 		// Deprecated properties.
 		// Since the schema only allows strings or null (but no arrays), we return the first array item.
-		$this->assertSame( 'hello', $data['editor_script'] );
-		$this->assertSame( 'gutenberg', $data['script'] );
-		$this->assertSame( 'foo', $data['view_script'] );
-		$this->assertSame( 'guten', $data['editor_style'] );
-		$this->assertSame( 'out', $data['style'] );
+		// Deprecated properties.
+		$this->assertSame(
+			'hello',
+			$data['editor_script'],
+			"Endpoint doesn't return first array element for editor_script."
+		);
+		$this->assertSame(
+			'gutenberg',
+			$data['script'],
+			"Endpoint doesn't return first array element for script."
+		);
+		$this->assertSame(
+			'foo',
+			$data['view_script'],
+			"Endpoint doesn't return first array element for view_script."
+		);
+		$this->assertSame(
+			'guten',
+			$data['editor_style'],
+			"Endpoint doesn't return first array element for editor_style."
+		);
+		$this->assertSame(
+			'out',
+			$data['style'],
+			"Endpoint doesn't return first array element for style."
+		);
 	}
 
 	public function test_get_variation() {

--- a/tests/phpunit/tests/rest-api/rest-block-type-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-block-type-controller.php
@@ -344,10 +344,40 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	public function test_get_item_deprecated() {
 		$block_type = 'fake/deprecated';
 		$settings   = array(
-			'editor_script' => array( 'editor', 'script' ),
-			'script'        => array( 'guten', 'berg' ),
-			'view_script'   => array( 'view', 'script' ),
-			'editor_style'  => array( 'editor', 'style' ),
+			'editor_script' => 'hello_world',
+			'script'        => 'gutenberg',
+			'view_script'   => 'foo_bar',
+			'editor_style'  => 'guten_tag',
+			'style'         => 'out_of_style',
+		);
+		register_block_type( $block_type, $settings );
+		wp_set_current_user( self::$admin_id );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/block-types/' . $block_type );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		$this->assertSameSets( array( 'hello_world' ), $data['editor_script_handles'] );
+		$this->assertSameSets( array( 'gutenberg' ), $data['script_handles'] );
+		$this->assertSameSets( array( 'foo_bar' ), $data['view_script_handles'] );
+		$this->assertSameSets( array( 'guten_tag' ), $data['editor_style_handles'] );
+		$this->assertSameSets( array( 'out_of_style' ), $data['style_handles'] );
+		// Deprecated properties.
+		$this->assertSame( 'hello_world', $data['editor_script'] );
+		$this->assertSame( 'gutenberg', $data['script'] );
+		$this->assertSame( 'foo_bar', $data['view_script'] );
+		$this->assertSame( 'guten_tag', $data['editor_style'] );
+		$this->assertSame( 'out_of_style', $data['style'] );
+	}
+
+	/**
+	 * @ticket 56733
+	 */
+	public function test_get_item_deprecated_with_arrays() {
+		$block_type = 'fake/deprecated-with-arrays';
+		$settings   = array(
+			'editor_script' => array( 'hello', 'world' ),
+			'script'        => array( 'gutenberg' ),
+			'view_script'   => array( 'foo', 'bar' ),
+			'editor_style'  => array( 'guten', 'tag' ),
 			'style'         => array( 'out', 'of', 'style' ),
 		);
 		register_block_type( $block_type, $settings );
@@ -361,11 +391,12 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$this->assertSameSets( $settings['editor_style'], $data['editor_style_handles'] );
 		$this->assertSameSets( $settings['style'], $data['style_handles'] );
 		// Deprecated properties.
-		$this->assertSameSets( $settings['editor_script'], $data['editor_script'] );
-		$this->assertSameSets( $settings['script'], $data['script'] );
-		$this->assertSameSets( $settings['view_script'], $data['view_script'] );
-		$this->assertSameSets( $settings['editor_style'], $data['editor_style'] );
-		$this->assertSameSets( $settings['style'], $data['style'] );
+		// Since the schema only allows strings or null (but no arrays), we return the first array item.
+		$this->assertSame( 'hello', $data['editor_script'] );
+		$this->assertSame( 'gutenberg', $data['script'] );
+		$this->assertSame( 'foo', $data['view_script'] );
+		$this->assertSame( 'guten', $data['editor_style'] );
+		$this->assertSame( 'out', $data['style'] );
 	}
 
 	public function test_get_variation() {


### PR DESCRIPTION
Based on prior work by @nendeb and @costdev in [56707](https://core.trac.wordpress.org/ticket/56707). Quoting that ticket:

> I had multiple handles for `editor_script` and passed the handles to `editor_script` as an array.
It works fine in WP6.0 but fails in WP61 and the block becomes unusable.
I know that `editor_script` was deprecated in WP6.1 and changed to `editor_script_handles`, but please fix it because it is not backward compatible that `editor_script` cannot be passed as an array.

Props @nendeb @costdev @gziolo

### TODO

- [x] Fix getter (see currently failing unit test and @gziolo's [comment](https://core.trac.wordpress.org/ticket/56707#comment:7))
- [x] ~Ideally test setter separately from getter~ _Probably okay as-is; they're two faces of the same medal._
- [x] Make sure REST API endpoint works -- add tests?
- [x] Update PHPDoc

Trac ticket: https://core.trac.wordpress.org/ticket/56707

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
