### PR TITLE
Fix for PHP Deprecated:  trim():  in pluggable.php

### DIFF
--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -595,7 +595,9 @@ if ( ! function_exists( 'wp_authenticate' ) ) :
 	 */
 	function wp_authenticate( $username, $password ) {
 		$username = sanitize_user( $username );
-		$password = trim( $password );
+		if ( is_string( $password ) && '' !== $password ) {
+			$password = trim( $password );
+		}
 
 		/**
 		 * Filters whether a set of user login credentials are valid.


### PR DESCRIPTION
Fix for PHP Deprecated:  trim(): Passing null to parameter #1 ($string) of type string is deprecated in app\wp-includes\pluggable.php on line 598

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: [[<!-- insert a link to the WordPress Trac ticket here -->](https://core.trac.wordpress.org/ticket/56850)](https://core.trac.wordpress.org/ticket/56850)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
