### PR TITLE
Suggestion for new action at the end of /wp-admin/import.php

### DIFF
--- a/src/wp-admin/import.php
+++ b/src/wp-admin/import.php
@@ -230,6 +230,13 @@ if ( current_user_can( 'install_plugins' ) ) {
 		esc_url( network_admin_url( 'plugin-install.php?tab=search&type=tag&s=importer' ) )
 	) . '</p>';
 }
+	
+/**
+* Fires at the end of the importers Administration screen.
+*
+*/
+do_action( 'after_importers' );
+
 ?>
 
 </div>

--- a/src/wp-admin/import.php
+++ b/src/wp-admin/import.php
@@ -236,7 +236,6 @@ if ( current_user_can( 'install_plugins' ) ) {
 *
 */
 do_action( 'after_importers' );
-
 ?>
 
 </div>


### PR DESCRIPTION
The patch adds an action at the end of /wp-admin/import.php page much like the one we have on other administration pages ex. tools page in https://core.trac.wordpress.org/browser/trunk/src/wp-admin/tools.php#L93

Trac ticket: [<!-- insert a link to the WordPress Trac ticket here -->](https://core.trac.wordpress.org/ticket/54419)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
