### PR TITLE
Add ID support to block wrapper attributes

### DIFF
--- a/src/wp-includes/block-supports/anchor.php
+++ b/src/wp-includes/block-supports/anchor.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Anchor block support flag.
+ *
+ * @package WordPress
+ * @since 6.2.0
+ */
+
+/**
+ * Registers the anchor block attribute for block types that support it.
+ *
+ * @since 6.2.0
+ * @access private
+ *
+ * @param WP_Block_Type $block_type Block Type.
+ */
+function wp_register_anchor_support( $block_type ) {
+	$has_anchor_support = _wp_array_get( $block_type->supports, array( 'anchor' ), true );
+	if ( ! $has_anchor_support ) {
+		return;
+	}
+
+	if ( ! $block_type->attributes ) {
+		$block_type->attributes = array();
+	}
+
+	if ( ! array_key_exists( 'anchor', $block_type->attributes ) ) {
+		$block_type->attributes['anchor'] = array(
+			'type' => 'string',
+		);
+	}
+}
+
+/**
+ * Add the anchor to the output.
+ *
+ * @since 6.2.0
+ * @access private
+ *
+ * @param WP_Block_Type $block_type       Block Type.
+ * @param array         $block_attributes Block attributes.
+ * @return array Block anchor.
+ */
+function wp_apply_anchor_support( $block_type, $block_attributes ) {
+	if ( ! $block_attributes ) {
+		return array();
+	}
+
+	if ( wp_should_skip_block_supports_serialization( $block_type, 'anchor' ) ) {
+		return array();
+	}
+
+	$has_anchor_support = _wp_array_get( $block_type->supports, array( 'anchor' ), true );
+	if ( ! $has_anchor_support ) {
+		return array();
+	}
+
+	$has_anchor = array_key_exists( 'anchor', $block_attributes );
+	if ( ! $has_anchor ) {
+		return array();
+	}
+
+	return array( 'id' => $block_attributes['anchor'] );
+}
+
+// Register the block support.
+WP_Block_Supports::get_instance()->register(
+	'anchor',
+	array(
+		'register_attribute' => 'wp_register_anchor_support',
+		'apply'              => 'wp_apply_anchor_support',
+	)
+);

--- a/src/wp-includes/class-wp-block-supports.php
+++ b/src/wp-includes/class-wp-block-supports.php
@@ -178,7 +178,7 @@ function get_block_wrapper_attributes( $extra_attributes = array() ) {
 
 	// This is hardcoded on purpose.
 	// We only support a fixed list of attributes.
-	$attributes_to_merge = array( 'style', 'class' );
+	$attributes_to_merge = array( 'style', 'class', 'id' );
 	$attributes          = array();
 	foreach ( $attributes_to_merge as $attribute_name ) {
 		if ( empty( $new_attributes[ $attribute_name ] ) && empty( $extra_attributes[ $attribute_name ] ) ) {

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -323,6 +323,7 @@ require ABSPATH . WPINC . '/block-patterns.php';
 require ABSPATH . WPINC . '/class-wp-block-supports.php';
 require ABSPATH . WPINC . '/block-supports/utils.php';
 require ABSPATH . WPINC . '/block-supports/align.php';
+require ABSPATH . WPINC . '/block-supports/anchor.php';
 require ABSPATH . WPINC . '/block-supports/border.php';
 require ABSPATH . WPINC . '/block-supports/colors.php';
 require ABSPATH . WPINC . '/block-supports/custom-classname.php';


### PR DESCRIPTION
Adds the support for the ID attribute for dynamic rendered blocks. 

Trac ticket: https://core.trac.wordpress.org/ticket/56852

Enable support in the Editor: https://github.com/WordPress/gutenberg/pull/44771


