### PR TITLE
GH Actions: harden the workflow against PHPCS ruleset errors

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -102,17 +102,19 @@ jobs:
         run: phpcs -i
 
       - name: Run PHPCS on all Core files
-        continue-on-error: true
+        id: phpcs-core
         run: phpcs -n --report-full --report-checkstyle=./.cache/phpcs-report.xml
 
       - name: Show PHPCS results in PR
+        if: ${{ always() && steps.phpcs-core.outcome == 'failure' }}
         run: cs2pr ./.cache/phpcs-report.xml
 
       - name: Check test suite files for warnings
-        continue-on-error: true
+        id: phpcs-tests
         run: phpcs tests --report-full --report-checkstyle=./.cache/phpcs-tests-report.xml
 
       - name: Show test suite scan results in PR
+        if: ${{ always() && steps.phpcs-tests.outcome == 'failure' }}
         run: cs2pr ./.cache/phpcs-tests-report.xml
 
       - name: Ensure version-controlled files are not modified during the tests

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -97,10 +97,11 @@ jobs:
         run: phpcs -i
 
       - name: Run PHP compatibility tests
-        continue-on-error: true
+        id: phpcs
         run: phpcs --standard=phpcompat.xml.dist --report-full --report-checkstyle=./.cache/phpcs-compat-report.xml
 
       - name: Show PHPCompatibility results in PR
+        if: ${{ always() && steps.phpcs.outcome == 'failure' }}
         run: cs2pr ./.cache/phpcs-compat-report.xml
 
       - name: Ensure version-controlled files are not modified or deleted


### PR DESCRIPTION
Follow up on PR #3368 and in particular @TobiasBg's remark in https://core.trac.wordpress.org/ticket/55652#comment:203

Ha! Found a situation which would allow the build to pass, even though the CS step would fail (but it would do so silently due to the `continue-on-error`)

If there is a ruleset error, the `cs2pr` action doesn't receive an `xml` report and exits with a `0` error code, even though the PHPCS run failed (though not on CS errors, but on a ruleset error).

This changes the GH Actions workflow to allow for that situation and still fail the build in that case.


Trac ticket: https://core.trac.wordpress.org/ticket/55652
Trac ticket: https://core.trac.wordpress.org/ticket/56793

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
