### PR TITLE
Backport: Gutenberg 43660 - Separator color bugfix

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -1929,7 +1929,7 @@ class WP_Theme_JSON {
 	 * Returns a filtered declarations array if there is a separator block with only a background
 	 * style defined in theme.json by adding a color attribute to reflect the changes in the front.
 	 *
-	 * @since 6.1.0
+	 * @since 6.1.1
 	 *
 	 * @param array $declarations List of declarations.
 	 *

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -1932,36 +1932,31 @@ class WP_Theme_JSON {
 	 * @since 6.1.1
 	 *
 	 * @param array $declarations List of declarations.
-	 *
 	 * @return array $declarations List of declarations filtered.
 	 */
 	private static function update_separator_declarations( $declarations ) {
 		$background_matches = array_values(
 			array_filter(
 				$declarations,
-				function( $declaration ) {
+				static function( $declaration ) {
 					return 'background-color' === $declaration['name'];
 				}
 			)
 		);
-		if ( ! empty( $background_matches && isset( $background_matches[0]['value'] ) ) ) {
-			$border_color_matches = array_values(
-				array_filter(
-					$declarations,
-					function( $declaration ) {
-						return 'border-color' === $declaration['name'];
-					}
-				)
-			);
-			$text_color_matches   = array_values(
-				array_filter(
-					$declarations,
-					function( $declaration ) {
-						return 'color' === $declaration['name'];
-					}
-				)
-			);
-			if ( empty( $border_color_matches ) && empty( $text_color_matches ) ) {
+
+		if ( isset( $background_matches[0]['value'] ) ) {
+			$border_color_matches = false;
+			$text_color_matches   = false;
+
+			foreach ( $declarations as $declaration ) {
+				if ( 'border-color' === $declaration['name'] ) {
+					$border_color_matches = true;
+				} elseif ( 'color' === $declaration['name'] ) {
+					$text_color_matches = true;
+				}
+			}
+
+			if ( ! $border_color_matches && ! $text_color_matches ) {
 				$declarations[] = array(
 					'name'  => 'color',
 					'value' => $background_matches[0]['value'],

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -3999,116 +3999,94 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests the core separator block outbut based on various provided settings.
+	 *
 	 * @ticket 56903
+	 *
+	 * @dataProvider data_update_separator_declarations
+	 *
+	 * @param array $separator_block_settings Example separator block settings from the data provider.
+	 * @param array $expected_output          Expected output from data provider.
 	 */
-	function test_update_separator_declarations() {
+	public function test_update_separator_declarations( $separator_block_settings, $expected_output ) {
 		// If only background is defined, test that includes border-color to the style so it is applied on the front end.
 		$theme_json = new WP_Theme_JSON(
 			array(
 				'version' => WP_Theme_JSON::LATEST_SCHEMA,
 				'styles'  => array(
 					'blocks' => array(
-						'core/separator' => array(
-							'color' => array(
-								'background' => 'blue',
-							),
-						),
+						'core/separator' => $separator_block_settings,
 					),
 				),
 			),
 			'default'
 		);
-		$expected   = 'body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-block-separator{background-color: blue;color: blue;}';
-		$stylesheet = $theme_json->get_stylesheet( array( 'styles' ) );
-		$this->assertEquals( $expected, $stylesheet );
 
-		// If background and text are defined, do not include border-color, as text color is enough.
-		$theme_json = new WP_Theme_JSON(
-			array(
-				'version' => WP_Theme_JSON::LATEST_SCHEMA,
-				'styles'  => array(
-					'blocks' => array(
-						'core/separator' => array(
-							'color' => array(
-								'background' => 'blue',
-								'text'       => 'red',
-							),
-						),
+		$stylesheet = $theme_json->get_stylesheet( array( 'styles' ) );
+
+		$this->assertSame( $expected_output, $stylesheet );
+	}
+
+	/**
+	 * Data provider for separator declaration tests.
+	 *
+	 * @return array
+	 */
+	function data_update_separator_declarations() {
+		return array(
+			// If only background is defined, test that includes border-color to the style so it is applied on the front end.
+			'only background'  => array(
+				array(
+					'color' => array(
+						'background' => 'blue',
 					),
 				),
+				'expected_output' => 'body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-block-separator{background-color: blue;color: blue;}',
 			),
-			'default'
-		);
-		$expected   = 'body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-block-separator{background-color: blue;color: red;}';
-		$stylesheet = $theme_json->get_stylesheet( array( 'styles' ) );
-		$this->assertEquals( $expected, $stylesheet );
-
-		// If only text is defined, do not include border-color, as by itself is enough.
-		$theme_json = new WP_Theme_JSON(
-			array(
-				'version' => WP_Theme_JSON::LATEST_SCHEMA,
-				'styles'  => array(
-					'blocks' => array(
-						'core/separator' => array(
-							'color' => array(
-								'text' => 'red',
-							),
-						),
+			// If background and text are defined, do not include border-color, as text color is enough.
+			'background and text, no border-color'  => array(
+				array(
+					'color' => array(
+						'background' => 'blue',
+						'text'       => 'red',
 					),
 				),
+				'expected_output' => 'body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-block-separator{background-color: blue;color: red;}',
 			),
-			'default'
-		);
-		$expected   = 'body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-block-separator{color: red;}';
-		$stylesheet = $theme_json->get_stylesheet( array( 'styles' ) );
-		$this->assertEquals( $expected, $stylesheet );
-
-		// If background, text, and border-color are defined, include everything, CSS specifity will decide which to apply.
-		$theme_json = new WP_Theme_JSON(
-			array(
-				'version' => WP_Theme_JSON::LATEST_SCHEMA,
-				'styles'  => array(
-					'blocks' => array(
-						'core/separator' => array(
-							'color'  => array(
-								'background' => 'blue',
-								'text'       => 'red',
-							),
-							'border' => array(
-								'color' => 'pink',
-							),
-						),
+			// If only text is defined, do not include border-color, as by itself is enough.
+			'only text'  => array(
+				array(
+					'color' => array(
+						'text' => 'red',
 					),
 				),
+				'expected_output' => 'body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-block-separator{color: red;}',
 			),
-			'default'
-		);
-		$expected   = 'body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-block-separator{background-color: blue;border-color: pink;color: red;}';
-		$stylesheet = $theme_json->get_stylesheet( array( 'styles' ) );
-		$this->assertEquals( $expected, $stylesheet );
-
-		// If background and border color are defined, include everything, CSS specifity will decide which to apply.
-		$theme_json = new WP_Theme_JSON(
-			array(
-				'version' => WP_Theme_JSON::LATEST_SCHEMA,
-				'styles'  => array(
-					'blocks' => array(
-						'core/separator' => array(
-							'color'  => array(
-								'background' => 'blue',
-							),
-							'border' => array(
-								'color' => 'pink',
-							),
-						),
+			// If background, text, and border-color are defined, include everything, CSS specifity will decide which to apply.
+			'background, text, and border-color'  => array(
+				array(
+					'color'  => array(
+						'background' => 'blue',
+						'text'       => 'red',
+					),
+					'border' => array(
+						'color' => 'pink',
 					),
 				),
+				'expected_output' => 'body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-block-separator{background-color: blue;border-color: pink;color: red;}',
 			),
-			'default'
+			// If background and border color are defined, include everything, CSS specifity will decide which to apply.
+			'background, text, and border-color'  => array(
+				array(
+					'color'  => array(
+						'background' => 'blue',
+					),
+					'border' => array(
+						'color' => 'pink',
+					),
+				),
+				'expected_output' => 'body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-block-separator{background-color: blue;border-color: pink;}',
+			),
 		);
-		$expected   = 'body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-block-separator{background-color: blue;border-color: pink;}';
-		$stylesheet = $theme_json->get_stylesheet( array( 'styles' ) );
-		$this->assertEquals( $expected, $stylesheet );
-
 	}
 }

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -4018,7 +4018,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 			),
 			'default'
 		);
-		$expected   = 'body { margin: 0;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-block-separator{background-color: blue;color: blue;}';
+		$expected   = 'body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-block-separator{background-color: blue;color: blue;}';
 		$stylesheet = $theme_json->get_stylesheet( array( 'styles' ) );
 		$this->assertEquals( $expected, $stylesheet );
 
@@ -4039,7 +4039,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 			),
 			'default'
 		);
-		$expected   = 'body { margin: 0;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-block-separator{background-color: blue;color: red;}';
+		$expected   = 'body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-block-separator{background-color: blue;color: red;}';
 		$stylesheet = $theme_json->get_stylesheet( array( 'styles' ) );
 		$this->assertEquals( $expected, $stylesheet );
 
@@ -4059,7 +4059,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 			),
 			'default'
 		);
-		$expected   = 'body { margin: 0;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-block-separator{color: red;}';
+		$expected   = 'body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-block-separator{color: red;}';
 		$stylesheet = $theme_json->get_stylesheet( array( 'styles' ) );
 		$this->assertEquals( $expected, $stylesheet );
 
@@ -4083,7 +4083,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 			),
 			'default'
 		);
-		$expected   = 'body { margin: 0;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-block-separator{background-color: blue;border-color: pink;color: red;}';
+		$expected   = 'body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-block-separator{background-color: blue;border-color: pink;color: red;}';
 		$stylesheet = $theme_json->get_stylesheet( array( 'styles' ) );
 		$this->assertEquals( $expected, $stylesheet );
 
@@ -4106,7 +4106,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 			),
 			'default'
 		);
-		$expected   = 'body { margin: 0;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-block-separator{background-color: blue;border-color: pink;}';
+		$expected   = 'body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-block-separator{background-color: blue;border-color: pink;}';
 		$stylesheet = $theme_json->get_stylesheet( array( 'styles' ) );
 		$this->assertEquals( $expected, $stylesheet );
 

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -4035,7 +4035,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 	function data_update_separator_declarations() {
 		return array(
 			// If only background is defined, test that includes border-color to the style so it is applied on the front end.
-			'only background'  => array(
+			'only background'                      => array(
 				array(
 					'color' => array(
 						'background' => 'blue',
@@ -4044,7 +4044,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 				'expected_output' => 'body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-block-separator{background-color: blue;color: blue;}',
 			),
 			// If background and text are defined, do not include border-color, as text color is enough.
-			'background and text, no border-color'  => array(
+			'background and text, no border-color' => array(
 				array(
 					'color' => array(
 						'background' => 'blue',
@@ -4054,7 +4054,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 				'expected_output' => 'body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-block-separator{background-color: blue;color: red;}',
 			),
 			// If only text is defined, do not include border-color, as by itself is enough.
-			'only text'  => array(
+			'only text'                            => array(
 				array(
 					'color' => array(
 						'text' => 'red',
@@ -4063,7 +4063,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 				'expected_output' => 'body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-block-separator{color: red;}',
 			),
 			// If background, text, and border-color are defined, include everything, CSS specifity will decide which to apply.
-			'background, text, and border-color'  => array(
+			'background, text, and border-color'   => array(
 				array(
 					'color'  => array(
 						'background' => 'blue',
@@ -4076,7 +4076,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 				'expected_output' => 'body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-block-separator{background-color: blue;border-color: pink;color: red;}',
 			),
 			// If background and border color are defined, include everything, CSS specifity will decide which to apply.
-			'background, text, and border-color'  => array(
+			'background, text, and border-color'   => array(
 				array(
 					'color'  => array(
 						'background' => 'blue',

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -4003,9 +4003,9 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 	 */
 	function test_update_separator_declarations() {
 		// If only background is defined, test that includes border-color to the style so it is applied on the front end.
-		$theme_json = new WP_Theme_JSON_Gutenberg(
+		$theme_json = new WP_Theme_JSON(
 			array(
-				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'version' => WP_Theme_JSON::LATEST_SCHEMA,
 				'styles'  => array(
 					'blocks' => array(
 						'core/separator' => array(
@@ -4023,9 +4023,9 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $stylesheet );
 
 		// If background and text are defined, do not include border-color, as text color is enough.
-		$theme_json = new WP_Theme_JSON_Gutenberg(
+		$theme_json = new WP_Theme_JSON(
 			array(
-				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'version' => WP_Theme_JSON::LATEST_SCHEMA,
 				'styles'  => array(
 					'blocks' => array(
 						'core/separator' => array(
@@ -4044,9 +4044,9 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $stylesheet );
 
 		// If only text is defined, do not include border-color, as by itself is enough.
-		$theme_json = new WP_Theme_JSON_Gutenberg(
+		$theme_json = new WP_Theme_JSON(
 			array(
-				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'version' => WP_Theme_JSON::LATEST_SCHEMA,
 				'styles'  => array(
 					'blocks' => array(
 						'core/separator' => array(
@@ -4064,9 +4064,9 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $stylesheet );
 
 		// If background, text, and border-color are defined, include everything, CSS specifity will decide which to apply.
-		$theme_json = new WP_Theme_JSON_Gutenberg(
+		$theme_json = new WP_Theme_JSON(
 			array(
-				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'version' => WP_Theme_JSON::LATEST_SCHEMA,
 				'styles'  => array(
 					'blocks' => array(
 						'core/separator' => array(
@@ -4088,9 +4088,9 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $stylesheet );
 
 		// If background and border color are defined, include everything, CSS specifity will decide which to apply.
-		$theme_json = new WP_Theme_JSON_Gutenberg(
+		$theme_json = new WP_Theme_JSON(
 			array(
-				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'version' => WP_Theme_JSON::LATEST_SCHEMA,
 				'styles'  => array(
 					'blocks' => array(
 						'core/separator' => array(

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -3997,4 +3997,118 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 			),
 		);
 	}
+
+	/**
+	 * @ticket 56903
+	 */
+	function test_update_separator_declarations() {
+		// If only background is defined, test that includes border-color to the style so it is applied on the front end.
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'core/separator' => array(
+							'color' => array(
+								'background' => 'blue',
+							),
+						),
+					),
+				),
+			),
+			'default'
+		);
+		$expected   = 'body { margin: 0;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-block-separator{background-color: blue;color: blue;}';
+		$stylesheet = $theme_json->get_stylesheet( array( 'styles' ) );
+		$this->assertEquals( $expected, $stylesheet );
+
+		// If background and text are defined, do not include border-color, as text color is enough.
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'core/separator' => array(
+							'color' => array(
+								'background' => 'blue',
+								'text'       => 'red',
+							),
+						),
+					),
+				),
+			),
+			'default'
+		);
+		$expected   = 'body { margin: 0;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-block-separator{background-color: blue;color: red;}';
+		$stylesheet = $theme_json->get_stylesheet( array( 'styles' ) );
+		$this->assertEquals( $expected, $stylesheet );
+
+		// If only text is defined, do not include border-color, as by itself is enough.
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'core/separator' => array(
+							'color' => array(
+								'text' => 'red',
+							),
+						),
+					),
+				),
+			),
+			'default'
+		);
+		$expected   = 'body { margin: 0;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-block-separator{color: red;}';
+		$stylesheet = $theme_json->get_stylesheet( array( 'styles' ) );
+		$this->assertEquals( $expected, $stylesheet );
+
+		// If background, text, and border-color are defined, include everything, CSS specifity will decide which to apply.
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'core/separator' => array(
+							'color'  => array(
+								'background' => 'blue',
+								'text'       => 'red',
+							),
+							'border' => array(
+								'color' => 'pink',
+							),
+						),
+					),
+				),
+			),
+			'default'
+		);
+		$expected   = 'body { margin: 0;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-block-separator{background-color: blue;border-color: pink;color: red;}';
+		$stylesheet = $theme_json->get_stylesheet( array( 'styles' ) );
+		$this->assertEquals( $expected, $stylesheet );
+
+		// If background and border color are defined, include everything, CSS specifity will decide which to apply.
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'core/separator' => array(
+							'color'  => array(
+								'background' => 'blue',
+							),
+							'border' => array(
+								'color' => 'pink',
+							),
+						),
+					),
+				),
+			),
+			'default'
+		);
+		$expected   = 'body { margin: 0;}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-block-separator{background-color: blue;border-color: pink;}';
+		$stylesheet = $theme_json->get_stylesheet( array( 'styles' ) );
+		$this->assertEquals( $expected, $stylesheet );
+
+	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Backport for https://github.com/WordPress/gutenberg/pull/44943

Trac ticket: <!-- insert a link to the WordPress Trac ticket here --> https://core.trac.wordpress.org/ticket/56903#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
