### PR TITLE
Canonical: Validate NOT EXISTS tax_query does not error

### DIFF
--- a/src/wp-includes/canonical.php
+++ b/src/wp-includes/canonical.php
@@ -331,7 +331,9 @@ function redirect_canonical( $requested_url = null, $do_redirect = true ) {
 			$term_count = 0;
 
 			foreach ( $wp_query->tax_query->queried_terms as $tax_query ) {
-				$term_count += count( $tax_query['terms'] );
+				if ( isset( $tax_query['terms'] ) && is_countable( $tax_query['terms'] ) ) {
+					$term_count += count( $tax_query['terms'] );
+				}
 			}
 
 			$obj = $wp_query->get_queried_object();

--- a/tests/phpunit/tests/canonical.php
+++ b/tests/phpunit/tests/canonical.php
@@ -397,9 +397,9 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 		);
 
 		$url = redirect_canonical( get_term_feed_link( self::$terms['/category/parent/'] ), false );
-		$this->assertNull( $url );
-
 		// Restore original global.
 		$GLOBALS['wp_query'] = $global_query;
+
+		$this->assertNull( $url );
 	}
 }

--- a/tests/phpunit/tests/canonical.php
+++ b/tests/phpunit/tests/canonical.php
@@ -383,16 +383,18 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 	 */
 	public function test_feed_canonical_with_not_exists_query() {
 		// Set a NOT EXISTS tax_query on the global query.
-		$global_query = $GLOBALS['wp_query'];
-		$GLOBALS['wp_query'] = new WP_Query( array(
-			'post_type' => 'post',
-			'tax_query' => array(
-				array(
-					'taxonomy' => 'post_format',
-					'operator' => 'NOT EXISTS',
+		$global_query        = $GLOBALS['wp_query'];
+		$GLOBALS['wp_query'] = new WP_Query(
+			array(
+				'post_type' => 'post',
+				'tax_query' => array(
+					array(
+						'taxonomy' => 'post_format',
+						'operator' => 'NOT EXISTS',
+					),
 				),
-			),
-		) );
+			)
+		);
 
 		$url = redirect_canonical( get_term_feed_link( self::$terms['/category/parent/'] ), false );
 		$this->assertNull( $url );

--- a/tests/phpunit/tests/canonical.php
+++ b/tests/phpunit/tests/canonical.php
@@ -375,4 +375,29 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 
 		delete_option( 'page_on_front' );
 	}
+
+	/**
+	 * Ensure NOT EXISTS queries do not trigger not-countable or undefined array key errors.
+	 *
+	 * @ticket 55955
+	 */
+	public function test_feed_canonical_with_not_exists_query() {
+		// Set a NOT EXISTS tax_query on the global query.
+		$global_query = $GLOBALS['wp_query'];
+		$GLOBALS['wp_query'] = new WP_Query( array(
+			'post_type' => 'post',
+			'tax_query' => array(
+				array(
+					'taxonomy' => 'post_format',
+					'operator' => 'NOT EXISTS',
+				),
+			),
+		) );
+
+		$url = redirect_canonical( get_term_feed_link( self::$terms['/category/parent/'] ), false );
+		$this->assertNull( $url );
+
+		// Restore original global.
+		$GLOBALS['wp_query'] = $global_query;
+	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

As discussed in [55955](https://core.trac.wordpress.org/ticket/55955), a NOT EXISTS tax_query causes a warning (PHP <= 7.4) or an error (PHP >= 8.0) in the `redirect_canonical` function because there is a `count( $tax_query['terms'] )` check in that function that does not verify whether the `terms` property is present. It will not be present in NOT EXISTS queries because there is no purpose in specifying individual terms when we are querying for posts which have no terms at all.

Trac ticket: https://core.trac.wordpress.org/ticket/55955

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
