### PR TITLE
Improvements and bug fixes for the theme ZIP workflow

### DIFF
--- a/.github/workflows/test-and-zip-default-themes.yml
+++ b/.github/workflows/test-and-zip-default-themes.yml
@@ -131,13 +131,14 @@ jobs:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.branch || github.ref }}
 
       - name: Create theme ZIP file
-        run: zip -r ${{ matrix.theme }}.zip src/wp-content/themes/${{ matrix.theme }} -x "*/node_modules/*"
+        run: zip -r ${{ matrix.theme }}.zip ${{ matrix.theme }} -x "*/node_modules/*"
+        working-directory: src/wp-content/themes
 
       - name: Upload theme ZIP as an artifact
         uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
         with:
           name: ${{ matrix.theme }}
-          path: ${{ matrix.theme }}.zip
+          path: src/wp-content/themes/${{ matrix.theme }}.zip
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/test-and-zip-default-themes.yml
+++ b/.github/workflows/test-and-zip-default-themes.yml
@@ -97,8 +97,7 @@ jobs:
   #
   # Performs the following steps:
   # - Checks out the repository.
-  # - Creates a ZIP file of the theme for wordpress.org.
-  # - Uploads the ZIP file as a workflow artifact.
+  # - Uploads the theme files as a workflow artifact (all artifacts are ZIP files).
   bundle-theme:
     name: Create ${{ matrix.theme }} ZIP file
     runs-on: ubuntu-latest
@@ -130,15 +129,13 @@ jobs:
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.branch || github.ref }}
 
-      - name: Create theme ZIP file
-        run: zip -r ${{ matrix.theme }}.zip ${{ matrix.theme }} -x "*/node_modules/*"
-        working-directory: src/wp-content/themes
-
       - name: Upload theme ZIP as an artifact
         uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
         with:
-          name: ${{ matrix.theme }}
-          path: src/wp-content/themes/${{ matrix.theme }}.zip
+          name: ${{ matrix.theme }}.zip
+          path: |
+            src/wp-content/themes/${{ matrix.theme }}
+            !*/node_modules/*
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/test-and-zip-default-themes.yml
+++ b/.github/workflows/test-and-zip-default-themes.yml
@@ -97,7 +97,7 @@ jobs:
   #
   # Performs the following steps:
   # - Checks out the repository.
-  # - Uploads the theme files as a workflow artifact (all artifacts are ZIP files).
+  # - Uploads the theme files as a workflow artifact (files uploaded as an artifact are automatically zipped).
   bundle-theme:
     name: Create ${{ matrix.theme }} ZIP file
     runs-on: ubuntu-latest
@@ -134,9 +134,7 @@ jobs:
         with:
           if-no-files-found: error
           name: ${{ matrix.theme }}
-          path: |
-            src/wp-content/themes/${{ matrix.theme }}
-            !*/node_modules/*
+          path: src/wp-content/themes/${{ matrix.theme }}
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/test-and-zip-default-themes.yml
+++ b/.github/workflows/test-and-zip-default-themes.yml
@@ -132,7 +132,7 @@ jobs:
       - name: Upload theme ZIP as an artifact
         uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
         with:
-          name: ${{ matrix.theme }}.zip
+          name: ${{ matrix.theme }}
           path: |
             src/wp-content/themes/${{ matrix.theme }}
             !*/node_modules/*

--- a/.github/workflows/test-and-zip-default-themes.yml
+++ b/.github/workflows/test-and-zip-default-themes.yml
@@ -132,6 +132,7 @@ jobs:
       - name: Upload theme ZIP as an artifact
         uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
         with:
+          if-no-files-found: error
           name: ${{ matrix.theme }}
           path: |
             src/wp-content/themes/${{ matrix.theme }}


### PR DESCRIPTION
- GitHub Action artifacts are always zipped. This update prevents zipping a ZIP file (double zipping).
- Only the theme's directory should be included in the workflow. Not `src/wp-content/theme/THEMENAME`.

Trac ticket: https://core.trac.wordpress.org/ticket/56898

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
