### PR TITLE
WP 6.1 deactivate Gutenberg plugin older than version 14.1

### DIFF
--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -1438,7 +1438,7 @@ function update_core( $from, $to ) {
 	_upgrade_440_force_deactivate_incompatible_plugins();
 
 	// Deactivate incompatible plugins.
-	_wp_upgrade_force_deactivate_incompatible_plugins();
+	_upgrade_core_deactivate_incompatible_plugins();
 
 	// Upgrade DB with separate request.
 	/** This filter is documented in wp-admin/includes/update-core.php */
@@ -1641,7 +1641,7 @@ function _upgrade_440_force_deactivate_incompatible_plugins() {
  * @since 5.9.0 The minimum compatible version of Gutenberg is 11.9.
  * @since 6.1.1 The minimum compatible version of Gutenberg is 14.1.
  */
-function _wp_upgrade_force_deactivate_incompatible_plugins() {
+function _upgrade_core_deactivate_incompatible_plugins() {
 	if ( defined( 'GUTENBERG_VERSION' ) && version_compare( GUTENBERG_VERSION, '14.1', '<' ) ) {
 		$deactivated_gutenberg['gutenberg'] = array(
 			'plugin_name'         => 'Gutenberg',

--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -1437,7 +1437,7 @@ function update_core( $from, $to ) {
 	// Deactivate the REST API plugin if its version is 2.0 Beta 4 or lower.
 	_upgrade_440_force_deactivate_incompatible_plugins();
 
-	// Deactivate the Gutenberg plugin if its version is 14.1.0 or lower.
+	// Deactivate the Gutenberg plugin if its version is older than 14.1.0.
 	_upgrade_611_force_deactivate_incompatible_plugins();
 
 	// Upgrade DB with separate request.

--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -1437,8 +1437,8 @@ function update_core( $from, $to ) {
 	// Deactivate the REST API plugin if its version is 2.0 Beta 4 or lower.
 	_upgrade_440_force_deactivate_incompatible_plugins();
 
-	// Deactivate the Gutenberg plugin if its version is 11.8 or lower.
-	_upgrade_590_force_deactivate_incompatible_plugins();
+	// Deactivate the Gutenberg plugin if its version is 14.1.0 or lower.
+	_upgrade_611_force_deactivate_incompatible_plugins();
 
 	// Upgrade DB with separate request.
 	/** This filter is documented in wp-admin/includes/update-core.php */
@@ -1637,14 +1637,14 @@ function _upgrade_440_force_deactivate_incompatible_plugins() {
 /**
  * @access private
  * @ignore
- * @since 5.9.0
+ * @since 6.1.1
  */
-function _upgrade_590_force_deactivate_incompatible_plugins() {
+function _upgrade_611_force_deactivate_incompatible_plugins() {
 	if ( defined( 'GUTENBERG_VERSION' ) && version_compare( GUTENBERG_VERSION, '11.9', '<' ) ) {
 		$deactivated_gutenberg['gutenberg'] = array(
 			'plugin_name'         => 'Gutenberg',
 			'version_deactivated' => GUTENBERG_VERSION,
-			'version_compatible'  => '11.9',
+			'version_compatible'  => '14.1',
 		);
 		if ( is_plugin_active_for_network( 'gutenberg/gutenberg.php' ) ) {
 			$deactivated_plugins = get_site_option( 'wp_force_deactivated_plugins', array() );

--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -1640,7 +1640,7 @@ function _upgrade_440_force_deactivate_incompatible_plugins() {
  * @since 6.1.1
  */
 function _upgrade_611_force_deactivate_incompatible_plugins() {
-	if ( defined( 'GUTENBERG_VERSION' ) && version_compare( GUTENBERG_VERSION, '11.9', '<' ) ) {
+	if ( defined( 'GUTENBERG_VERSION' ) && version_compare( GUTENBERG_VERSION, '14.1', '<' ) ) {
 		$deactivated_gutenberg['gutenberg'] = array(
 			'plugin_name'         => 'Gutenberg',
 			'version_deactivated' => GUTENBERG_VERSION,

--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -1637,7 +1637,7 @@ function _upgrade_440_force_deactivate_incompatible_plugins() {
 /**
  * @access private
  * @ignore
- * @since 5.8.0 The minimum compatible version of Gutenberg is 10.7.
+ * @since 5.8.0
  * @since 5.9.0 The minimum compatible version of Gutenberg is 11.9.
  * @since 6.1.1 The minimum compatible version of Gutenberg is 14.1.
  */

--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -1437,8 +1437,8 @@ function update_core( $from, $to ) {
 	// Deactivate the REST API plugin if its version is 2.0 Beta 4 or lower.
 	_upgrade_440_force_deactivate_incompatible_plugins();
 
-	// Deactivate the Gutenberg plugin if its version is older than 14.1.0.
-	_upgrade_611_force_deactivate_incompatible_plugins();
+	// Deactivate incompatible plugins.
+	_wp_upgrade_force_deactivate_incompatible_plugins();
 
 	// Upgrade DB with separate request.
 	/** This filter is documented in wp-admin/includes/update-core.php */
@@ -1639,7 +1639,7 @@ function _upgrade_440_force_deactivate_incompatible_plugins() {
  * @ignore
  * @since 6.1.1
  */
-function _upgrade_611_force_deactivate_incompatible_plugins() {
+function _wp_upgrade_force_deactivate_incompatible_plugins() {
 	if ( defined( 'GUTENBERG_VERSION' ) && version_compare( GUTENBERG_VERSION, '14.1', '<' ) ) {
 		$deactivated_gutenberg['gutenberg'] = array(
 			'plugin_name'         => 'Gutenberg',

--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -1637,7 +1637,9 @@ function _upgrade_440_force_deactivate_incompatible_plugins() {
 /**
  * @access private
  * @ignore
- * @since 6.1.1
+ * @since 5.8.0 The minimum compatible version of Gutenberg is 10.7.
+ * @since 5.9.0 The minimum compatible version of Gutenberg is 11.9.
+ * @since 6.1.1 The minimum compatible version of Gutenberg is 14.1.
  */
 function _wp_upgrade_force_deactivate_incompatible_plugins() {
 	if ( defined( 'GUTENBERG_VERSION' ) && version_compare( GUTENBERG_VERSION, '14.1', '<' ) ) {


### PR DESCRIPTION
## Details

Using the same strategy during WP 5.9 (see changeset https://core.trac.wordpress.org/changeset/52199):

* Renames the update function for WP 6.1
* Changes the Gutenberg version number from `11.9` to `14.1`

Why? Gutenberg plugin versions less than 14.1.0 are not compatible with WP 6.1, especially GB 13.9.0 to 14.0.x versions which will cause a fatal error.

## How to Test
Testing instructions are found here in the Trac ticket https://core.trac.wordpress.org/ticket/56985#comment:10

Trac ticket: https://core.trac.wordpress.org/ticket/56985

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
