### PR TITLE
Fix: Category specific templates always appear as not found.

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -637,7 +637,7 @@ function _wp_build_title_and_description_for_taxonomy_block_template( $taxonomy,
 	$args        = wp_parse_args( $args, $default_args );
 	$terms_query = $term_query->query( $args );
 
-	if ( empty( $terms_query->terms ) ) {
+	if ( empty( $terms_query ) ) {
 		$template->title = sprintf(
 			/* translators: Custom template title in the Site Editor, referencing a taxonomy term that was not found. 1: Taxonomy singular name, 2: Term slug. */
 			__( 'Not found: %1$s (%2$s)' ),
@@ -647,7 +647,7 @@ function _wp_build_title_and_description_for_taxonomy_block_template( $taxonomy,
 		return false;
 	}
 
-	$term_title = $terms_query->terms[0]->name;
+	$term_title = $terms_query[0]->name;
 
 	$template->title = sprintf(
 		/* translators: Custom template title in the Site Editor. 1: Taxonomy singular name, 2: Term title. */
@@ -671,7 +671,7 @@ function _wp_build_title_and_description_for_taxonomy_block_template( $taxonomy,
 	$args                        = wp_parse_args( $args, $default_args );
 	$terms_with_same_title_query = $term_query->query( $args );
 
-	if ( count( $terms_with_same_title_query->terms ) > 1 ) {
+	if ( count( $terms_with_same_title_query ) > 1 ) {
 		$template->title = sprintf(
 			/* translators: Custom template title in the Site Editor. 1: Template title, 2: Term slug. */
 			__( '%1$s (%2$s)' ),


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/45374, https://core.trac.wordpress.org/ticket/56902.

This issue does not affect the Gutenberg plugin and is a core-specific regression introduced in 
https://github.com/WordPress/wordpress-develop/commit/628e83d157dd7e987c3c58c69b9a7c2bc173e2a9.
According to the docs (https://developer.wordpress.org/reference/classes/wp_term_query/query/) WP_Term_Query:->query( string|array $query ) returns [WP_Term][]|int[]|string[]|string, and we were using an inexistent object property `terms` making it always empty and look like the taxonomy did not exist.
This PR fixes the issue.