### PR TITLE
Prevents an infinite loop when the parent menu item of a menu item is itself.

### DIFF
--- a/src/wp-includes/nav-menu-template.php
+++ b/src/wp-includes/nav-menu-template.php
@@ -208,7 +208,8 @@ function wp_nav_menu( $args = array() ) {
 		// Calculate the depth of each menu item with children
 		foreach ( $menu_items_with_children as $menu_item_key => &$menu_item_depth ) {
 			$menu_item_parent = $menu_items_tree[ $menu_item_key ];
-			while ( $menu_item_parent ) {
+			// Do not calculate the depth when the current item has itself as parent.
+			while ( $menu_item_parent && (int) $menu_item_parent !== $menu_item_key ) {
 				$menu_item_depth  = $menu_item_depth + 1;
 				$menu_item_parent = $menu_items_tree[ $menu_item_parent ];
 			}


### PR DESCRIPTION
Co-authored-by: Hugo de Vos <hdvos93@gmail.com>

Created during **Yoast Contributor Day** on Friday 4 November.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Prevents an infinite loop when the parent menu item of a menu item is itself. We do not know the root cause of this issue, but with this PR, we add a safeguard to make sure the menu is still being output. This PR also adds a unit test to confirm the output is as expected. 

Trac ticket: https://core.trac.wordpress.org/ticket/56926

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
