### PR TITLE
This will fix error if caption shortcode doesnt have any attributes.

### DIFF
--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -2195,6 +2195,9 @@ function img_caption_shortcode( $attr, $content = '' ) {
 	if ( ! isset( $attr['caption'] ) ) {
 		if ( preg_match( '#((?:<a [^>]+>\s*)?<img [^>]+>(?:\s*</a>)?)(.*)#is', $content, $matches ) ) {
 			$content         = $matches[1];
+			if ( empty( $attr ) ) {
+				$attr = array();
+			}
 			$attr['caption'] = trim( $matches[2] );
 		}
 	} elseif ( strpos( $attr['caption'], '<' ) !== false ) {


### PR DESCRIPTION
I've reinitialized $attr to an array.
The Fatal error is coming with PHP 8.0 and WordPress 6.1

Trac ticket: [https://core.trac.wordpress.org/ticket/56996]