### PR TITLE
Only retrieve upload related information when user can upload

### DIFF
--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -152,10 +152,15 @@ function get_allowed_block_types( $block_editor_context ) {
  * @return array The default block editor settings.
  */
 function get_default_block_editor_settings() {
+
 	// Media settings.
-	$max_upload_size = wp_max_upload_size();
-	if ( ! $max_upload_size ) {
-		$max_upload_size = 0;
+	$max_upload_size = 0;
+	// wp_max_upload_size is potentially expensive. Only call this if absolutely necessary.
+	if ( current_user_can( 'upload_files' ) ) {
+		$max_upload_size = wp_max_upload_size();
+		if ( ! $max_upload_size ) {
+			$max_upload_size = 0;
+		}
 	}
 
 	/** This filter is documented in wp-admin/includes/media.php */


### PR DESCRIPTION
Only retrieve upload related information for the theme.json resolver when user can actually upload

Trac ticket: https://core.trac.wordpress.org/ticket/56815

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
