### PR TITLE
Twenty Twenty-Three: Rename Comments template part

### DIFF
--- a/src/wp-content/themes/twentytwentythree/theme.json
+++ b/src/wp-content/themes/twentytwentythree/theme.json
@@ -723,7 +723,7 @@
 		{
 			"area": "uncategorized",
 			"name": "comments",
-			"title": "Comments"
+			"title": "Comments Template Part"
 		},
 		{
 			"area": "uncategorized",


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
This renames the Comments template part to 'Comments Template Part', to reduce confusion with the 'Comments' block when viewing both in the inserter.

![image](https://user-images.githubusercontent.com/1645628/200033049-03a359ec-8bdd-47ec-8b70-ee4ad784c289.png)

Trac ticket: https://core.trac.wordpress.org/ticket/56999

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
