### PR TITLE
Prevent type error in img_caption_shortcode

### DIFF
--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -2191,6 +2191,7 @@ add_shortcode( 'caption', 'img_caption_shortcode' );
  * @return string HTML content to display the caption.
  */
 function img_caption_shortcode( $attr, $content = '' ) {
+	$attr = (array) $attr;
 	// New-style shortcode with the caption inside the shortcode with the link and image tags.
 	if ( ! isset( $attr['caption'] ) ) {
 		if ( preg_match( '#((?:<a [^>]+>\s*)?<img [^>]+>(?:\s*</a>)?)(.*)#is', $content, $matches ) ) {

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -266,7 +266,7 @@ CAP;
 
 	public function test_img_caption_without_attributes() {
 		$out = do_shortcode( '[caption]<img class="alignnone" src="test.jpeg" width="2048" height="1091" />Test[/caption]' );
-		$this->assertSame( 'Test', $out );
+		$this->assertSame( '<img class="alignnone" src="test.jpeg" width="2048" height="1091" />', $out );
 	}
 
 	/**

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -264,6 +264,11 @@ CAP;
 		$this->assertFalse( wp_oembed_remove_provider( 'http://foo.bar/*' ) );
 	}
 
+	public function test_img_caption_without_attributes() {
+		$out = do_shortcode( '[caption]<img class="alignnone" src="test.jpeg" width="2048" height="1091" />Test[/caption]' );
+		$this->assertSame( 'Test', $out );
+	}
+
 	/**
 	 * @ticket 23776
 	 */


### PR DESCRIPTION
On PHP 8, there is a fatal error for the `[caption]` shortcode when there are no attributes.

To replicate the issue, add the following code to the shortcode block: 
`[caption]<img class="alignnone" src="test.jpeg" width="2048" height="1091" />Test[/caption]`

I suggest solving this issue by casting `$attr` to an array, as this is the same way that the function `shortcode_atts` prevents this issue, which is what other shortcode callback functions call, like `wp_video_shortcode`.

Trac ticket: https://core.trac.wordpress.org/ticket/56996
