### PR TITLE
WP_Query caching discards `posts_fields` and `posts_clauses['fields']` filters.

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -3103,8 +3103,23 @@ class WP_Query {
 		 * cannot be cached. Note the space before `RAND` in the string
 		 * search, that to ensure against a collision with another
 		 * function.
+		 *
+		 * If `$fields` has been modified by the `posts_fields`,
+		 * `posts_fields_request`, `post_clauses` or `posts_clauses_request`
+		 * filters, then caching is disabled to prevent caching collisions.
 		 */
 		$id_query_is_cacheable = ! str_contains( strtoupper( $orderby ), ' RAND(' );
+
+		$cachable_field_values = array(
+			"{$wpdb->posts}.*",
+			"{$wpdb->posts}.ID, {$wpdb->posts}.post_parent",
+			"{$wpdb->posts}.ID",
+		);
+
+		if ( ! in_array( $fields, $cachable_field_values, true ) ) {
+			$id_query_is_cacheable = false;
+		}
+
 		if ( $q['cache_results'] && $id_query_is_cacheable ) {
 			$new_request = str_replace( $fields, "{$wpdb->posts}.*", $this->request );
 			$cache_key   = $this->generate_cache_key( $q, $new_request );

--- a/tests/phpunit/tests/query/fieldsClause.php
+++ b/tests/phpunit/tests/query/fieldsClause.php
@@ -19,6 +19,7 @@ class Tests_Query_FieldsClause extends WP_UnitTestCase {
 	static $page_ids = array();
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		// Register CPT for use with shared fixtures.
 		register_post_type( 'wptests_pt' );
 
 		self::$post_ids = $factory->post->create_many( 5, array( 'post_type' => 'wptests_pt' ) );
@@ -26,7 +27,13 @@ class Tests_Query_FieldsClause extends WP_UnitTestCase {
 
 	public function set_up() {
 		parent::set_up();
-
+		/*
+		 * Re-register the CPT for use within each test.
+		 *
+		 * Custom post types are deregistered by the default tear_down method
+		 * so need to be re-registered for each test as WP_Query calls
+		 * get_post_types().
+		 */
 		register_post_type( 'wptests_pt' );
 	}
 

--- a/tests/phpunit/tests/query/fieldsClause.php
+++ b/tests/phpunit/tests/query/fieldsClause.php
@@ -1,6 +1,8 @@
 <?php
 /**
  * @group query
+ *  
+ * @covers WP_Query::get_posts
  */
 class Tests_Query_FieldsClause extends WP_UnitTestCase {
 

--- a/tests/phpunit/tests/query/fieldsClause.php
+++ b/tests/phpunit/tests/query/fieldsClause.php
@@ -31,9 +31,7 @@ class Tests_Query_FieldsClause extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Ensure the WP_Query fields parameter is respected.
-	 *
-	 * This tests limiting the fields to the ID and parent sub-set.
+	 * Tests limiting the WP_Query fields to the ID and parent sub-set.
 	 *
 	 * @ticket 57012
 	 */
@@ -63,9 +61,7 @@ class Tests_Query_FieldsClause extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Ensure the WP_Query fields parameter is respected.
-	 *
-	 * This tests limiting the fields to the IDs only.
+	 * Tests limiting the WP_Query fields to the IDs only.
 	 *
 	 * @ticket 57012
 	 */
@@ -89,7 +85,7 @@ class Tests_Query_FieldsClause extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Ensure the WP_Query fields parameter is respected.
+	 * Tests querying all fields via WP_Query.
 	 *
 	 * @ticket 57012
 	 */
@@ -113,10 +109,7 @@ class Tests_Query_FieldsClause extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Ensure the WP_Query fields parameter is respected.
-	 *
-	 * This tests limiting the fields to the ID and parent sub-set but
-	 * requesting additional items using the clause related filters.
+	 * Tests adding fields to WP_Query via filters when requesting the ID and parent sub-set.
 	 *
 	 * @ticket 57012
 	 */
@@ -155,10 +148,7 @@ class Tests_Query_FieldsClause extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Ensure the WP_Query fields parameter is respected.
-	 *
-	 * This tests limiting the fields to the IDs only but modifying the
-	 * database query via the clause related filters.
+	 * Tests adding fields to WP_Query via filters when requesting the ID field.
 	 *
 	 * @ticket 57012
 	 */
@@ -186,9 +176,7 @@ class Tests_Query_FieldsClause extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Ensure the WP_Query fields parameter is respected.
-	 *
-	 * This tests requesting additional items using the clause related filters.
+	 * Tests adding fields to WP_Query via filters when requesting all fields.
 	 *
 	 * @ticket 57012
 	 */
@@ -221,7 +209,7 @@ class Tests_Query_FieldsClause extends WP_UnitTestCase {
 	/**
 	 * Filter the posts fields.
 	 *
-	 * @param string $fields The fields to select.
+	 * @param string $fields The fields to SELECT.
 	 * @return string The filtered fields.
 	 */
 	function filter_posts_fields( $fields ) {
@@ -231,8 +219,8 @@ class Tests_Query_FieldsClause extends WP_UnitTestCase {
 	/**
 	 * Filter the posts clauses.
 	 *
-	 * @param array $clauses The query clauses.
-	 * @return array The filtered clauses.
+	 * @param array $clauses The WP_Query database clauses.
+	 * @return array The filtered database clauses.
 	 */
 	function filter_posts_clauses( $clauses ) {
 		$clauses['fields'] .= ', 2 as test_post_clauses';

--- a/tests/phpunit/tests/query/fieldsClause.php
+++ b/tests/phpunit/tests/query/fieldsClause.php
@@ -1,0 +1,241 @@
+<?php
+/**
+ * @group query
+ */
+class Tests_Query_FieldsClause extends WP_UnitTestCase {
+
+	/**
+	 * Post IDs.
+	 *
+	 * @var int[]
+	 */
+	static $post_ids = array();
+
+	/**
+	 * Page IDs.
+	 *
+	 * @var int[]
+	 */
+	static $page_ids = array();
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		register_post_type( 'wptests_pt' );
+
+		self::$post_ids = $factory->post->create_many( 5, array( 'post_type' => 'wptests_pt' ) );
+	}
+
+	public function set_up() {
+		parent::set_up();
+
+		register_post_type( 'wptests_pt' );
+	}
+
+	/**
+	 * Ensure the WP_Query fields parameter is respected.
+	 *
+	 * This tests limiting the fields to the ID and parent sub-set.
+	 *
+	 * @ticket 57012
+	 */
+	public function test_set_found_posts_fields_idparent() {
+		$q = new WP_Query(
+			array(
+				'post_type' => 'wptests_pt',
+				'fields'    => 'id=>parent',
+			)
+		);
+
+		$expected = array();
+		foreach ( self::$post_ids as $post_id ) {
+			// Use array_shift to populate in the reverse order.
+			array_unshift(
+				$expected,
+				(object) array(
+					'ID'          => $post_id,
+					'post_parent' => 0,
+				)
+			);
+		}
+
+		$this->assertEquals( $expected, $q->posts, 'Posts property is not of expected form.' );
+		$this->assertSame( 5, $q->found_posts, 'Number of found posts is not five.' );
+		$this->assertEquals( 1, $q->max_num_pages, 'Number of found pages is not one.' );
+	}
+
+	/**
+	 * Ensure the WP_Query fields parameter is respected.
+	 *
+	 * This tests limiting the fields to the IDs only.
+	 *
+	 * @ticket 57012
+	 */
+	public function test_set_found_posts_fields_ids() {
+		$query_args = array(
+			'post_type' => 'wptests_pt',
+			'fields'    => 'ids',
+		);
+
+		$q = new WP_Query( $query_args );
+
+		$expected = array_reverse( self::$post_ids );
+
+		$this->assertEquals( $expected, $q->posts, 'Posts property is not of expected form.' );
+		$this->assertSame( 5, $q->found_posts, 'Number of found posts is not five.' );
+		$this->assertEquals( 1, $q->max_num_pages, 'Number of found pages is not one.' );
+
+		// Test the cached results match.
+		$q2 = new WP_Query( $query_args );
+		$this->assertEquals( $expected, $q2->posts, 'Posts property is not cached in the expected form.' );
+	}
+
+	/**
+	 * Ensure the WP_Query fields parameter is respected.
+	 *
+	 * @ticket 57012
+	 */
+	public function test_set_found_posts_fields_all() {
+		$query_args = array(
+			'post_type' => 'wptests_pt',
+			'fields'    => 'all',
+		);
+
+		$q = new WP_Query( $query_args );
+
+		$expected = array_map( 'get_post', array_reverse( self::$post_ids ) );
+
+		$this->assertEquals( $expected, $q->posts, 'Posts property is not of expected form.' );
+		$this->assertSame( 5, $q->found_posts, 'Number of found posts is not five.' );
+		$this->assertEquals( 1, $q->max_num_pages, 'Number of found pages is not one.' );
+
+		// Test the cached results match.
+		$q2 = new WP_Query( $query_args );
+		$this->assertEquals( $expected, $q2->posts, 'Posts property is not cached in the expected form.' );
+	}
+
+	/**
+	 * Ensure the WP_Query fields parameter is respected.
+	 *
+	 * This tests limiting the fields to the ID and parent sub-set but
+	 * requesting additional items using the clause related filters.
+	 *
+	 * @ticket 57012
+	 */
+	public function test_set_found_posts_fields_idparent_filtered() {
+		add_filter( 'posts_fields', array( $this, 'filter_posts_fields' ) );
+		add_filter( 'posts_clauses', array( $this, 'filter_posts_clauses' ) );
+
+		$query_args = array(
+			'post_type' => 'wptests_pt',
+			'fields'    => 'id=>parent',
+		);
+
+		$q = new WP_Query( $query_args );
+
+		$expected = array();
+		foreach ( self::$post_ids as $post_id ) {
+			// Use array_shift to populate in the reverse order.
+			array_unshift(
+				$expected,
+				(object) array(
+					'ID'                => $post_id,
+					'post_parent'       => 0,
+					'test_post_fields'  => 1,
+					'test_post_clauses' => 2,
+				)
+			);
+		}
+
+		$this->assertEquals( $expected, $q->posts, 'Posts property is not of expected form.' );
+		$this->assertSame( 5, $q->found_posts, 'Number of found posts is not five.' );
+		$this->assertEquals( 1, $q->max_num_pages, 'Number of found pages is not one.' );
+
+		// Test the cached results match.
+		$q2 = new WP_Query( $query_args );
+		$this->assertEquals( $expected, $q2->posts, 'Posts property is not cached in the expected form.' );
+	}
+
+	/**
+	 * Ensure the WP_Query fields parameter is respected.
+	 *
+	 * This tests limiting the fields to the IDs only but modifying the
+	 * database query via the clause related filters.
+	 *
+	 * @ticket 57012
+	 */
+	public function test_set_found_posts_fields_id_filtered() {
+		add_filter( 'posts_fields', array( $this, 'filter_posts_fields' ) );
+		add_filter( 'posts_clauses', array( $this, 'filter_posts_clauses' ) );
+
+		$query_args = array(
+			'post_type' => 'wptests_pt',
+			'fields'    => 'ids',
+		);
+
+		$q = new WP_Query( $query_args );
+
+		// Fields => ID does not include the additional fields.
+		$expected = array_reverse( self::$post_ids );
+
+		$this->assertEquals( $expected, $q->posts, 'Posts property is not of expected form.' );
+		$this->assertSame( 5, $q->found_posts, 'Number of found posts is not five.' );
+		$this->assertEquals( 1, $q->max_num_pages, 'Number of found pages is not one.' );
+
+		// Test the cached results match.
+		$q2 = new WP_Query( $query_args );
+		$this->assertEquals( $expected, $q2->posts, 'Posts property is not cached in the expected form.' );
+	}
+
+	/**
+	 * Ensure the WP_Query fields parameter is respected.
+	 *
+	 * This tests requesting additional items using the clause related filters.
+	 *
+	 * @ticket 57012
+	 */
+	public function test_set_found_posts_fields_all_filtered() {
+		add_filter( 'posts_fields', array( $this, 'filter_posts_fields' ) );
+		add_filter( 'posts_clauses', array( $this, 'filter_posts_clauses' ) );
+
+		$query_args = array(
+			'post_type' => 'wptests_pt',
+			'fields'    => 'all',
+		);
+
+		$q = new WP_Query( $query_args );
+
+		$expected = array_map( 'get_post', array_reverse( self::$post_ids ) );
+		foreach ( $expected as $post ) {
+			$post->test_post_fields  = 1;
+			$post->test_post_clauses = 2;
+		}
+
+		$this->assertEquals( $expected, $q->posts, 'Posts property is not of expected form.' );
+		$this->assertSame( 5, $q->found_posts, 'Number of found posts is not five.' );
+		$this->assertEquals( 1, $q->max_num_pages, 'Number of found pages is not one.' );
+
+		// Test the cached results match.
+		$q2 = new WP_Query( $query_args );
+		$this->assertEquals( $expected, $q2->posts, 'Posts property is not cached in the expected form.' );
+	}
+
+	/**
+	 * Filter the posts fields.
+	 *
+	 * @param string $fields The fields to select.
+	 * @return string The filtered fields.
+	 */
+	function filter_posts_fields( $fields ) {
+		return "$fields, 1 as test_post_fields";
+	}
+
+	/**
+	 * Filter the posts clauses.
+	 *
+	 * @param array $clauses The query clauses.
+	 * @return array The filtered clauses.
+	 */
+	function filter_posts_clauses( $clauses ) {
+		$clauses['fields'] .= ', 2 as test_post_clauses';
+		return $clauses;
+	}
+}

--- a/tests/phpunit/tests/query/fieldsClause.php
+++ b/tests/phpunit/tests/query/fieldsClause.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @group query
- *  
+ *
  * @covers WP_Query::get_posts
  */
 class Tests_Query_FieldsClause extends WP_UnitTestCase {

--- a/tests/phpunit/tests/query/fieldsClause.php
+++ b/tests/phpunit/tests/query/fieldsClause.php
@@ -37,7 +37,7 @@ class Tests_Query_FieldsClause extends WP_UnitTestCase {
 	 *
 	 * @ticket 57012
 	 */
-	public function test_set_found_posts_fields_idparent() {
+	public function test_should_limit_fields_to_id_and_parent_subset() {
 		$q = new WP_Query(
 			array(
 				'post_type' => 'wptests_pt',
@@ -69,7 +69,7 @@ class Tests_Query_FieldsClause extends WP_UnitTestCase {
 	 *
 	 * @ticket 57012
 	 */
-	public function test_set_found_posts_fields_ids() {
+	public function test_should_limit_fields_to_ids() {
 		$query_args = array(
 			'post_type' => 'wptests_pt',
 			'fields'    => 'ids',
@@ -93,7 +93,7 @@ class Tests_Query_FieldsClause extends WP_UnitTestCase {
 	 *
 	 * @ticket 57012
 	 */
-	public function test_set_found_posts_fields_all() {
+	public function test_should_not_limit_fields() {
 		$query_args = array(
 			'post_type' => 'wptests_pt',
 			'fields'    => 'all',
@@ -120,7 +120,7 @@ class Tests_Query_FieldsClause extends WP_UnitTestCase {
 	 *
 	 * @ticket 57012
 	 */
-	public function test_set_found_posts_fields_idparent_filtered() {
+	public function test_should_include_filtered_values_in_addition_to_id_and_parent_subset() {
 		add_filter( 'posts_fields', array( $this, 'filter_posts_fields' ) );
 		add_filter( 'posts_clauses', array( $this, 'filter_posts_clauses' ) );
 
@@ -162,7 +162,7 @@ class Tests_Query_FieldsClause extends WP_UnitTestCase {
 	 *
 	 * @ticket 57012
 	 */
-	public function test_set_found_posts_fields_id_filtered() {
+	public function test_should_include_filtered_values_in_addition_to_id() {
 		add_filter( 'posts_fields', array( $this, 'filter_posts_fields' ) );
 		add_filter( 'posts_clauses', array( $this, 'filter_posts_clauses' ) );
 
@@ -192,7 +192,7 @@ class Tests_Query_FieldsClause extends WP_UnitTestCase {
 	 *
 	 * @ticket 57012
 	 */
-	public function test_set_found_posts_fields_all_filtered() {
+	public function test_should_include_filtered_values() {
 		add_filter( 'posts_fields', array( $this, 'filter_posts_fields' ) );
 		add_filter( 'posts_clauses', array( $this, 'filter_posts_clauses' ) );
 

--- a/tests/phpunit/tests/query/fieldsClause.php
+++ b/tests/phpunit/tests/query/fieldsClause.php
@@ -43,8 +43,6 @@ class Tests_Query_FieldsClause extends WP_UnitTestCase {
 	 * Tests limiting the WP_Query fields to the ID and parent sub-set.
 	 *
 	 * @ticket 57012
-	 *
-	 * @covers WP_Query::get_posts()
 	 */
 	public function test_should_limit_fields_to_id_and_parent_subset() {
 		$q = new WP_Query(
@@ -75,8 +73,6 @@ class Tests_Query_FieldsClause extends WP_UnitTestCase {
 	 * Tests limiting the WP_Query fields to the IDs only.
 	 *
 	 * @ticket 57012
-	 *
-	 * @covers WP_Query::get_posts()
 	 */
 	public function test_should_limit_fields_to_ids() {
 		$query_args = array(
@@ -101,8 +97,6 @@ class Tests_Query_FieldsClause extends WP_UnitTestCase {
 	 * Tests querying all fields via WP_Query.
 	 *
 	 * @ticket 57012
-	 *
-	 * @covers WP_Query::get_posts()
 	 */
 	public function test_should_query_all_fields() {
 		$query_args = array(
@@ -127,8 +121,6 @@ class Tests_Query_FieldsClause extends WP_UnitTestCase {
 	 * Tests adding fields to WP_Query via filters when requesting the ID and parent sub-set.
 	 *
 	 * @ticket 57012
-	 *
-	 * @covers WP_Query::get_posts()
 	 */
 	public function test_should_include_filtered_values_in_addition_to_id_and_parent_subset() {
 		add_filter( 'posts_fields', array( $this, 'filter_posts_fields' ) );
@@ -168,8 +160,6 @@ class Tests_Query_FieldsClause extends WP_UnitTestCase {
 	 * Tests adding fields to WP_Query via filters when requesting the ID field.
 	 *
 	 * @ticket 57012
-	 *
-	 * @covers WP_Query::get_posts()
 	 */
 	public function test_should_include_filtered_values_in_addition_to_id() {
 		add_filter( 'posts_fields', array( $this, 'filter_posts_fields' ) );
@@ -198,8 +188,6 @@ class Tests_Query_FieldsClause extends WP_UnitTestCase {
 	 * Tests adding fields to WP_Query via filters when requesting all fields.
 	 *
 	 * @ticket 57012
-	 *
-	 * @covers WP_Query::get_posts()
 	 */
 	public function test_should_include_filtered_values() {
 		add_filter( 'posts_fields', array( $this, 'filter_posts_fields' ) );

--- a/tests/phpunit/tests/query/fieldsClause.php
+++ b/tests/phpunit/tests/query/fieldsClause.php
@@ -45,12 +45,12 @@ class Tests_Query_FieldsClause extends WP_UnitTestCase {
 	 * @ticket 57012
 	 */
 	public function test_should_limit_fields_to_id_and_parent_subset() {
-		$q = new WP_Query(
-			array(
-				'post_type' => 'wptests_pt',
-				'fields'    => 'id=>parent',
-			)
+		$query_args = array(
+			'post_type' => 'wptests_pt',
+			'fields'    => 'id=>parent',
 		);
+
+		$q = new WP_Query( $query_args );
 
 		$expected = array();
 		foreach ( self::$post_ids as $post_id ) {
@@ -64,9 +64,13 @@ class Tests_Query_FieldsClause extends WP_UnitTestCase {
 			);
 		}
 
-		$this->assertEquals( $expected, $q->posts, 'Posts property is not of expected form.' );
+		$this->assertEquals( $expected, $q->posts, 'Posts property for first query is not of expected form.' );
 		$this->assertSame( 5, $q->found_posts, 'Number of found posts is not five.' );
 		$this->assertEquals( 1, $q->max_num_pages, 'Number of found pages is not one.' );
+
+		// Test the second query's results match.
+		$q2 = new WP_Query( $query_args );
+		$this->assertEquals( $expected, $q2->posts, 'Posts property for second query is not in the expected form.' );
 	}
 
 	/**
@@ -84,13 +88,13 @@ class Tests_Query_FieldsClause extends WP_UnitTestCase {
 
 		$expected = array_reverse( self::$post_ids );
 
-		$this->assertEquals( $expected, $q->posts, 'Posts property is not of expected form.' );
+		$this->assertEquals( $expected, $q->posts, 'Posts property for first query is not of expected form.' );
 		$this->assertSame( 5, $q->found_posts, 'Number of found posts is not five.' );
 		$this->assertEquals( 1, $q->max_num_pages, 'Number of found pages is not one.' );
 
-		// Test the cached results match.
+		// Test the second query's results match.
 		$q2 = new WP_Query( $query_args );
-		$this->assertEquals( $expected, $q2->posts, 'Posts property is not cached in the expected form.' );
+		$this->assertEquals( $expected, $q2->posts, 'Posts property for second query is not in the expected form.' );
 	}
 
 	/**
@@ -108,13 +112,13 @@ class Tests_Query_FieldsClause extends WP_UnitTestCase {
 
 		$expected = array_map( 'get_post', array_reverse( self::$post_ids ) );
 
-		$this->assertEquals( $expected, $q->posts, 'Posts property is not of expected form.' );
+		$this->assertEquals( $expected, $q->posts, 'Posts property for first query is not of expected form.' );
 		$this->assertSame( 5, $q->found_posts, 'Number of found posts is not five.' );
 		$this->assertEquals( 1, $q->max_num_pages, 'Number of found pages is not one.' );
 
-		// Test the cached results match.
+		// Test the second query's results match.
 		$q2 = new WP_Query( $query_args );
-		$this->assertEquals( $expected, $q2->posts, 'Posts property is not cached in the expected form.' );
+		$this->assertEquals( $expected, $q2->posts, 'Posts property for second query is not in the expected form.' );
 	}
 
 	/**
@@ -147,13 +151,13 @@ class Tests_Query_FieldsClause extends WP_UnitTestCase {
 			);
 		}
 
-		$this->assertEquals( $expected, $q->posts, 'Posts property is not of expected form.' );
+		$this->assertEquals( $expected, $q->posts, 'Posts property for first query is not of expected form.' );
 		$this->assertSame( 5, $q->found_posts, 'Number of found posts is not five.' );
 		$this->assertEquals( 1, $q->max_num_pages, 'Number of found pages is not one.' );
 
-		// Test the cached results match.
+		// Test the second query's results match.
 		$q2 = new WP_Query( $query_args );
-		$this->assertEquals( $expected, $q2->posts, 'Posts property is not cached in the expected form.' );
+		$this->assertEquals( $expected, $q2->posts, 'Posts property for second query is not in the expected form.' );
 	}
 
 	/**
@@ -175,13 +179,13 @@ class Tests_Query_FieldsClause extends WP_UnitTestCase {
 		// Fields => ID does not include the additional fields.
 		$expected = array_reverse( self::$post_ids );
 
-		$this->assertEquals( $expected, $q->posts, 'Posts property is not of expected form.' );
+		$this->assertEquals( $expected, $q->posts, 'Posts property for first query is not of expected form.' );
 		$this->assertSame( 5, $q->found_posts, 'Number of found posts is not five.' );
 		$this->assertEquals( 1, $q->max_num_pages, 'Number of found pages is not one.' );
 
-		// Test the cached results match.
+		// Test the second query's results match.
 		$q2 = new WP_Query( $query_args );
-		$this->assertEquals( $expected, $q2->posts, 'Posts property is not cached in the expected form.' );
+		$this->assertEquals( $expected, $q2->posts, 'Posts property for second query is not in the expected form.' );
 	}
 
 	/**
@@ -206,13 +210,13 @@ class Tests_Query_FieldsClause extends WP_UnitTestCase {
 			$post->test_post_clauses = 2;
 		}
 
-		$this->assertEquals( $expected, $q->posts, 'Posts property is not of expected form.' );
+		$this->assertEquals( $expected, $q->posts, 'Posts property for first query is not of expected form.' );
 		$this->assertSame( 5, $q->found_posts, 'Number of found posts is not five.' );
 		$this->assertEquals( 1, $q->max_num_pages, 'Number of found pages is not one.' );
 
-		// Test the cached results match.
+		// Test the second query's results match.
 		$q2 = new WP_Query( $query_args );
-		$this->assertEquals( $expected, $q2->posts, 'Posts property is not cached in the expected form.' );
+		$this->assertEquals( $expected, $q2->posts, 'Posts property for second query is not in the expected form.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/query/fieldsClause.php
+++ b/tests/phpunit/tests/query/fieldsClause.php
@@ -89,7 +89,7 @@ class Tests_Query_FieldsClause extends WP_UnitTestCase {
 	 *
 	 * @ticket 57012
 	 */
-	public function test_should_not_limit_fields() {
+	public function test_should_query_all_fields() {
 		$query_args = array(
 			'post_type' => 'wptests_pt',
 			'fields'    => 'all',
@@ -207,7 +207,7 @@ class Tests_Query_FieldsClause extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Filter the posts fields.
+	 * Filters the posts fields.
 	 *
 	 * @param string $fields The fields to SELECT.
 	 * @return string The filtered fields.
@@ -217,7 +217,7 @@ class Tests_Query_FieldsClause extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Filter the posts clauses.
+	 * Filters the posts clauses.
 	 *
 	 * @param array $clauses The WP_Query database clauses.
 	 * @return array The filtered database clauses.

--- a/tests/phpunit/tests/query/fieldsClause.php
+++ b/tests/phpunit/tests/query/fieldsClause.php
@@ -34,6 +34,8 @@ class Tests_Query_FieldsClause extends WP_UnitTestCase {
 	 * Tests limiting the WP_Query fields to the ID and parent sub-set.
 	 *
 	 * @ticket 57012
+	 *
+	 * @covers WP_Query::get_posts()
 	 */
 	public function test_should_limit_fields_to_id_and_parent_subset() {
 		$q = new WP_Query(
@@ -64,6 +66,8 @@ class Tests_Query_FieldsClause extends WP_UnitTestCase {
 	 * Tests limiting the WP_Query fields to the IDs only.
 	 *
 	 * @ticket 57012
+	 *
+	 * @covers WP_Query::get_posts()
 	 */
 	public function test_should_limit_fields_to_ids() {
 		$query_args = array(
@@ -88,6 +92,8 @@ class Tests_Query_FieldsClause extends WP_UnitTestCase {
 	 * Tests querying all fields via WP_Query.
 	 *
 	 * @ticket 57012
+	 *
+	 * @covers WP_Query::get_posts()
 	 */
 	public function test_should_query_all_fields() {
 		$query_args = array(
@@ -112,6 +118,8 @@ class Tests_Query_FieldsClause extends WP_UnitTestCase {
 	 * Tests adding fields to WP_Query via filters when requesting the ID and parent sub-set.
 	 *
 	 * @ticket 57012
+	 *
+	 * @covers WP_Query::get_posts()
 	 */
 	public function test_should_include_filtered_values_in_addition_to_id_and_parent_subset() {
 		add_filter( 'posts_fields', array( $this, 'filter_posts_fields' ) );
@@ -151,6 +159,8 @@ class Tests_Query_FieldsClause extends WP_UnitTestCase {
 	 * Tests adding fields to WP_Query via filters when requesting the ID field.
 	 *
 	 * @ticket 57012
+	 *
+	 * @covers WP_Query::get_posts()
 	 */
 	public function test_should_include_filtered_values_in_addition_to_id() {
 		add_filter( 'posts_fields', array( $this, 'filter_posts_fields' ) );
@@ -179,6 +189,8 @@ class Tests_Query_FieldsClause extends WP_UnitTestCase {
 	 * Tests adding fields to WP_Query via filters when requesting all fields.
 	 *
 	 * @ticket 57012
+	 *
+	 * @covers WP_Query::get_posts()
 	 */
 	public function test_should_include_filtered_values() {
 		add_filter( 'posts_fields', array( $this, 'filter_posts_fields' ) );


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/57012

First commit is some tests that pass on 6.0 but not on 6.1

The second commit modifies `WP_Query` to disable caching if the fields parameter has been modified to a non-standard form. This is the quick, point release suitable fix rather than messing around with the cache itself. 

In the future it may be possible to cache custom values but care will need to be taken to avoid huge values if a plugin modifies the select to include many items.