### PR TITLE
Do not strip trailing semicolon out in safecss_filter_attr()

### DIFF
--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -2577,6 +2577,9 @@ function safecss_filter_attr( $css, $deprecated = '' ) {
 		}
 	}
 
+	// Ensure trailing semicolon isn't tripped out.
+	$css = rtrim( $css, ';' ) . ';';
+
 	return $css;
 }
 

--- a/tests/phpunit/tests/kses/safeCSSFilterAttr.php
+++ b/tests/phpunit/tests/kses/safeCSSFilterAttr.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @group kses
+ *
+ * @covers ::safecss_filter_attr
+ */
+class Test_Kses_safeCSSFilterAttr extends WP_UnitTestCase {
+	public function test_allowed_css() {
+		$css      = 'margin-right: 20px;';
+		$filtered = safecss_filter_attr( $css );
+
+		$this->assertSame( $css, $filtered, 'Allowed CSS should not be filtered by safecss_filter_attr().' );
+	}
+
+	public function test_forbidden_css() {
+		$allowed_css   = 'margin-right: 20px;';
+		$forbidden_css = 'word-spacing: 30px;';
+		$filtered      = safecss_filter_attr( $allowed_css . $forbidden_css );
+
+		$this->assertSame( $allowed_css, $filtered, 'Forbidden CSS should be filtered by safecss_filter_attr().' );
+	}
+}


### PR DESCRIPTION
Ticket https://core.trac.wordpress.org/ticket/57002

## Description
- Add tests for `safecss_filter_attr()`.
- Add a `;` before returning filtered CSS in `safecss_filter_attr()`.
