### PR TITLE
Global Styles: Update the order of pseudo selectors

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -394,13 +394,17 @@ class WP_Theme_JSON {
 	/**
 	 * Defines which pseudo selectors are enabled for which elements.
 	 *
+	 * The order of the selectors should be: visited, hover, focus, active.
+	 * This is to ensure that 'visited' has the lowest specificity
+	 * and the other selectors can always overwrite it.
+	 *
 	 * Note: this will affect both top-level and block-level elements.
 	 *
 	 * @since 6.1.0
 	 */
 	const VALID_ELEMENT_PSEUDO_SELECTORS = array(
-		'link'   => array( ':hover', ':focus', ':active', ':visited' ),
-		'button' => array( ':hover', ':focus', ':active', ':visited' ),
+		'link'   => array( ':visited', ':hover', ':focus', ':active' ),
+		'button' => array( ':visited', ':hover', ':focus', ':active' ),
 	);
 
 	/**

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -398,6 +398,7 @@ class WP_Theme_JSON {
 	 * This is to ensure that 'visited' has the lowest specificity
 	 * and the other selectors can always overwrite it.
 	 *
+	 * See https://core.trac.wordpress.org/ticket/56928.
 	 * Note: this will affect both top-level and block-level elements.
 	 *
 	 * @since 6.1.0


### PR DESCRIPTION
Backports changes from https://github.com/WordPress/gutenberg/pull/45559

> The order of the selectors should be: visited, hover, focus, active. This is to ensure that 'visited' has the lowest specificity and the other selectors can always overwrite it.

Props: @mikachan, @sabernhardt, @getdave (get_dave).

Trac ticket: https://core.trac.wordpress.org/ticket/56928

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
