### PR TITLE
Only call wp_max_upload_filesize() when user can actually upload files.

### DIFF
--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -153,9 +153,14 @@ function get_allowed_block_types( $block_editor_context ) {
  */
 function get_default_block_editor_settings() {
 	// Media settings.
-	$max_upload_size = wp_max_upload_size();
-	if ( ! $max_upload_size ) {
-		$max_upload_size = 0;
+
+	// wp_max_upload_size() can be expensive, so only call it when relevant for the current user.
+	$max_upload_size = 0;
+	if ( current_user_can( 'upload_files' ) ) {
+		$max_upload_size = wp_max_upload_size();
+		if ( ! $max_upload_size ) {
+			$max_upload_size = 0;
+		}
 	}
 
 	/** This filter is documented in wp-admin/includes/media.php */

--- a/tests/phpunit/tests/blocks/editor.php
+++ b/tests/phpunit/tests/blocks/editor.php
@@ -302,6 +302,31 @@ class Tests_Blocks_Editor extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 56815
+	 */
+	public function test_get_default_block_editor_settings_max_upload_file_size() {
+		// Force the return value of wp_max_upload_size() to be 500.
+		add_filter(
+			'upload_size_limit',
+			function() {
+				return 500;
+			}
+		);
+
+		// Expect 0 when user is not allowed to upload (as wp_max_upload_size() should not be called).
+		$settings = get_default_block_editor_settings();
+		$this->assertSame( 0, $settings['maxUploadFileSize'] );
+
+		// Set up an administrator, as they can upload files.
+		$administrator = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $administrator );
+
+		// Expect the above 500 as the user is now allowed to upload.
+		$settings = get_default_block_editor_settings();
+		$this->assertSame( 500, $settings['maxUploadFileSize'] );
+	}
+
+	/**
 	 * @ticket 53397
 	 */
 	public function test_get_legacy_widget_block_editor_settings() {


### PR DESCRIPTION
This is basically the same as #3569, only with a unit test added.

Trac ticket: https://core.trac.wordpress.org/ticket/56815

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
