### PR TITLE
Align with American English Suffix "-ize"

### DIFF
--- a/tests/phpunit/tests/multisite/site.php
+++ b/tests/phpunit/tests/multisite/site.php
@@ -2123,7 +2123,7 @@ if ( is_multisite() ) :
 
 			$blog_id = wpmu_create_blog( 'testsite1.example.org', '/test', 'test', 1, array( 'public' => 1 ), 2 );
 
-			// Should not hit blog_details cache initialised in $this->populate_options_callback tirggered during
+			// Should not hit blog_details cache initialized in $this->populate_options_callback tirggered during
 			// populate_options callback's call of get_blog_details.
 			$this->assertSame( 'http://testsite1.example.org/test', get_blog_details( $blog_id )->siteurl );
 			$this->assertSame( 'http://testsite1.example.org/test', get_site( $blog_id )->siteurl );

--- a/tests/phpunit/tests/multisite/site.php
+++ b/tests/phpunit/tests/multisite/site.php
@@ -2123,8 +2123,10 @@ if ( is_multisite() ) :
 
 			$blog_id = wpmu_create_blog( 'testsite1.example.org', '/test', 'test', 1, array( 'public' => 1 ), 2 );
 
-			// Should not hit blog_details cache initialized in $this->populate_options_callback triggered during
-			// populate_options callback's call of get_blog_details.
+			/*
+			 * Should not hit blog_details cache initialized in $this->populate_options_callback triggered during
+			 * populate_options callback's call of get_blog_details.
+			 */
 			$this->assertSame( 'http://testsite1.example.org/test', get_blog_details( $blog_id )->siteurl );
 			$this->assertSame( 'http://testsite1.example.org/test', get_site( $blog_id )->siteurl );
 

--- a/tests/phpunit/tests/multisite/site.php
+++ b/tests/phpunit/tests/multisite/site.php
@@ -2123,7 +2123,7 @@ if ( is_multisite() ) :
 
 			$blog_id = wpmu_create_blog( 'testsite1.example.org', '/test', 'test', 1, array( 'public' => 1 ), 2 );
 
-			// Should not hit blog_details cache initialized in $this->populate_options_callback tirggered during
+			// Should not hit blog_details cache initialized in $this->populate_options_callback triggered during
 			// populate_options callback's call of get_blog_details.
 			$this->assertSame( 'http://testsite1.example.org/test', get_blog_details( $blog_id )->siteurl );
 			$this->assertSame( 'http://testsite1.example.org/test', get_site( $blog_id )->siteurl );

--- a/tests/phpunit/tests/query/vars.php
+++ b/tests/phpunit/tests/query/vars.php
@@ -14,7 +14,7 @@ class Tests_Query_Vars extends WP_UnitTestCase {
 	public function testPublicQueryVarsAreAsExpected() {
 		global $wp;
 
-		// Re-initialise any dynamically-added public query vars:
+		// Re-initialize any dynamically-added public query vars:
 		do_action( 'init' );
 
 		$this->assertSame(


### PR DESCRIPTION
Update use of "-ise" suffix to American English "-ize" in comments. Checked for `(normal|standard|initial|color|colour)ise`.

Trac ticket: https://core.trac.wordpress.org/ticket/56811

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
