### PR TITLE
Revise comments using "we" in WordPress root directory files

### DIFF
--- a/src/wp-cron.php
+++ b/src/wp-cron.php
@@ -23,7 +23,7 @@ if ( ! headers_sent() ) {
 	header( 'Cache-Control: no-cache, must-revalidate, max-age=0' );
 }
 
-// Don't run cron until request finishes, if possible.
+// Don't run cron until the request finishes, if possible.
 if ( PHP_VERSION_ID >= 70016 && function_exists( 'fastcgi_finish_request' ) ) {
 	fastcgi_finish_request();
 } elseif ( function_exists( 'litespeed_finish_request' ) ) {

--- a/src/wp-cron.php
+++ b/src/wp-cron.php
@@ -35,7 +35,7 @@ if ( ! empty( $_POST ) || defined( 'DOING_AJAX' ) || defined( 'DOING_CRON' ) ) {
 }
 
 /**
- * Tell WordPress we are doing the cron task.
+ * Tell WordPress the cron task is running.
  *
  * @var bool
  */

--- a/src/wp-cron.php
+++ b/src/wp-cron.php
@@ -23,7 +23,7 @@ if ( ! headers_sent() ) {
 	header( 'Cache-Control: no-cache, must-revalidate, max-age=0' );
 }
 
-/* Don't run cron until request finishes, if possible. */
+// Don't run cron until request finishes, if possible.
 if ( PHP_VERSION_ID >= 70016 && function_exists( 'fastcgi_finish_request' ) ) {
 	fastcgi_finish_request();
 } elseif ( function_exists( 'litespeed_finish_request' ) ) {

--- a/src/wp-cron.php
+++ b/src/wp-cron.php
@@ -23,7 +23,7 @@ if ( ! headers_sent() ) {
 	header( 'Cache-Control: no-cache, must-revalidate, max-age=0' );
 }
 
-/* Don't make the request block till we finish, if possible. */
+/* Don't run cron until request finishes, if possible. */
 if ( PHP_VERSION_ID >= 70016 && function_exists( 'fastcgi_finish_request' ) ) {
 	fastcgi_finish_request();
 } elseif ( function_exists( 'litespeed_finish_request' ) ) {

--- a/src/wp-load.php
+++ b/src/wp-load.php
@@ -68,11 +68,7 @@ if ( file_exists( ABSPATH . 'wp-config.php' ) ) {
 
 	$path = wp_guess_url() . '/wp-admin/setup-config.php';
 
-	/*
-	 * We're going to redirect to setup-config.php. While this shouldn't result
-	 * in an infinite loop, that's a silly thing to assume, don't you think? If
-	 * we're traveling in circles, our last-ditch effort is "Need more help?"
-	 */
+	// Redirect to setup-config.php.
 	if ( false === strpos( $_SERVER['REQUEST_URI'], 'setup-config' ) ) {
 		header( 'Location: ' . $path );
 		exit;

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -1242,7 +1242,7 @@ switch ( $action ) {
 					)
 				);
 			} elseif ( isset( $_POST['testcookie'] ) && empty( $_COOKIE[ TEST_COOKIE ] ) ) {
-				// If cookies are disabled, user can't log in even with a valid username and password.
+				// If cookies are disabled, the user can't log in even with a valid username and password.
 				$user = new WP_Error(
 					'test_cookie',
 					sprintf(

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -1242,7 +1242,7 @@ switch ( $action ) {
 					)
 				);
 			} elseif ( isset( $_POST['testcookie'] ) && empty( $_COOKIE[ TEST_COOKIE ] ) ) {
-				// If cookies are disabled, we can't log in even with a valid user and password.
+				// If cookies are disabled, user can't log in even with a valid username and password.
 				$user = new WP_Error(
 					'test_cookie',
 					sprintf(

--- a/src/wp-mail.php
+++ b/src/wp-mail.php
@@ -231,7 +231,7 @@ for ( $i = 1; $i <= $count; $i++ ) {
 		echo "\n" . $post_ID->get_error_message();
 	}
 
-	// We couldn't post, for whatever reason. Better move forward to the next email.
+	// The post wasn't inserted or updated, for whatever reason. Better move forward to the next email.
 	if ( empty( $post_ID ) ) {
 		continue;
 	}

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -60,7 +60,7 @@ global $blog_id;
 // Set initial default constants including WP_MEMORY_LIMIT, WP_MAX_MEMORY_LIMIT, WP_DEBUG, SCRIPT_DEBUG, WP_CONTENT_DIR and WP_CACHE.
 wp_initial_constants();
 
-// Make sure we register the shutdown handler for fatal errors as soon as possible.
+// Register the shutdown handler for fatal errors as soon as possible.
 wp_register_fatal_error_handler();
 
 // WordPress calculates offsets from UTC.

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -76,7 +76,7 @@ wp_maintenance();
 // Start loading timer.
 timer_start();
 
-// Check if we're in WP_DEBUG mode.
+// Check if WP_DEBUG mode is enabled.
 wp_debug_mode();
 
 /**

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -19,8 +19,8 @@ define( 'WPINC', 'wp-includes' );
  * Version information for the current WordPress release.
  *
  * These can't be directly globalized in version.php. When updating,
- * we're including version.php from another installation and don't want
- * these values to be overridden if already set.
+ * include version.php from another installation and don't override
+ * these values if already set.
  *
  * @global string $wp_version             The WordPress version string.
  * @global int    $wp_db_version          WordPress database version.

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -145,7 +145,7 @@ if ( is_multisite() ) {
 
 register_shutdown_function( 'shutdown_action_hook' );
 
-// Stop most of WordPress from being loaded if we just want the basics.
+// Stop most of WordPress from being loaded if SHORTINIT is enabled.
 if ( SHORTINIT ) {
 	return false;
 }

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -70,7 +70,7 @@ date_default_timezone_set( 'UTC' );
 // Standardize $_SERVER variables across setups.
 wp_fix_server_vars();
 
-// Check if site is in maintenance mode.
+// Check if the site is in maintenance mode.
 wp_maintenance();
 
 // Start loading timer.

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -70,7 +70,7 @@ date_default_timezone_set( 'UTC' );
 // Standardize $_SERVER variables across setups.
 wp_fix_server_vars();
 
-// Check if we're in maintenance mode.
+// Check if site is in maintenance mode.
 wp_maintenance();
 
 // Start loading timer.

--- a/src/wp-trackback.php
+++ b/src/wp-trackback.php
@@ -76,7 +76,7 @@ if ( function_exists( 'mb_convert_encoding' ) ) {
 	$blog_name = mb_convert_encoding( $blog_name, get_option( 'blog_charset' ), $charset );
 }
 
-// Now that mb_convert_encoding() has been given a swing, we need to escape these three.
+// Escape values to use in the trackback.
 $title     = wp_slash( $title );
 $excerpt   = wp_slash( $excerpt );
 $blog_name = wp_slash( $blog_name );

--- a/src/xmlrpc.php
+++ b/src/xmlrpc.php
@@ -12,7 +12,7 @@
  */
 define( 'XMLRPC_REQUEST', true );
 
-// Some browser-embedded clients send cookies. We don't want them.
+// Some browser-embedded clients send cookies, but are not needed, so discard them.
 $_COOKIE = array();
 
 // $HTTP_RAW_POST_DATA was deprecated in PHP 5.6 and removed in PHP 7.0.

--- a/src/xmlrpc.php
+++ b/src/xmlrpc.php
@@ -12,7 +12,7 @@
  */
 define( 'XMLRPC_REQUEST', true );
 
-// Some browser-embedded clients send cookies, but are not needed, so discard them.
+// Discard unneeded cookies sent by some browser-embedded clients.
 $_COOKIE = array();
 
 // $HTTP_RAW_POST_DATA was deprecated in PHP 5.6 and removed in PHP 7.0.


### PR DESCRIPTION
- Replaces first-person usage of "we" with second person point of view.
- Also makes small clarification adjustments where voice is much too casual or lacks clear context, especially for non-native English speakers.

This PR focuses on files in the WordPress root directory.

Trac ticket: https://core.trac.wordpress.org/ticket/57052

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
