### PR TITLE
Revise comments using "we" in WordPress wp-admin directory

### DIFF
--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -292,7 +292,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 
 <?php
 
-// These are strings we may use to describe maintenance/security releases, where we aim for no new strings.
+// These are strings used to describe maintenance/security releases. Adding new strings is discouraged.
 return;
 
 __( 'Maintenance Release' );

--- a/src/wp-admin/admin-post.php
+++ b/src/wp-admin/admin-post.php
@@ -8,7 +8,7 @@
  * @subpackage Administration
  */
 
-/** We are located in WordPress Administration Screens */
+/** Request is to WordPress Administration Screens */
 if ( ! defined( 'WP_ADMIN' ) ) {
 	define( 'WP_ADMIN', true );
 }

--- a/src/wp-admin/admin.php
+++ b/src/wp-admin/admin.php
@@ -187,7 +187,7 @@ if ( isset( $plugin_page ) ) {
 
 		// Back-compat for plugins using add_management_page().
 		if ( empty( $page_hook ) && 'edit.php' === $pagenow && get_plugin_page_hook( $plugin_page, 'tools.php' ) ) {
-			// There could be plugin specific params on the URL, so we need the whole query string.
+			// There could be plugin specific params on the URL, so read whole query string.
 			if ( ! empty( $_SERVER['QUERY_STRING'] ) ) {
 				$query_string = $_SERVER['QUERY_STRING'];
 			} else {

--- a/src/wp-admin/credits.php
+++ b/src/wp-admin/credits.php
@@ -128,7 +128,7 @@ require_once ABSPATH . 'wp-admin/admin-footer.php';
 
 return;
 
-// These are strings returned by the API that we want to be translatable.
+// These are strings returned by the API that need to be translatable.
 __( 'Project Leaders' );
 /* translators: %s: The current WordPress version number. */
 __( 'Core Contributors to WordPress %s' );

--- a/src/wp-admin/customize.php
+++ b/src/wp-admin/customize.php
@@ -222,7 +222,7 @@ do_action( 'customize_controls_head' );
 			</div>
 		</div>
 
-		<div id="widgets-right" class="wp-clearfix"><!-- For Widget Customizer, many widgets try to look for instances under div#widgets-right, so we have to add that ID to a container div in the Customizer for compat -->
+		<div id="widgets-right" class="wp-clearfix"><!-- For Widget Customizer, many widgets try to look for instances under div#widgets-right, so add that ID to a container div in the Customizer for compat -->
 			<div id="customize-notifications-area" class="customize-control-notifications-container">
 				<ul></ul>
 			</div>

--- a/src/wp-admin/customize.php
+++ b/src/wp-admin/customize.php
@@ -218,7 +218,7 @@ do_action( 'customize_controls_head' );
 
 		<div id="customize-sidebar-outer-content">
 			<div id="customize-outer-theme-controls">
-				<ul class="customize-outer-pane-parent"><?php // Outer panel and sections are not implemented, but its here as a placeholder to avoid any side-effect in api.Section. ?></ul>
+				<ul class="customize-outer-pane-parent"><?php // Outer panel and sections are not implemented, but it's here as a placeholder to avoid any side-effect in api.Section. ?></ul>
 			</div>
 		</div>
 

--- a/src/wp-admin/edit-form-advanced.php
+++ b/src/wp-admin/edit-form-advanced.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 global $post_type, $post_type_object, $post;
 
-// Flag that we're not loading the block editor.
+// Flag that the block editor is not loaded.
 $current_screen = get_current_screen();
 $current_screen->is_block_editor( false );
 

--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -24,7 +24,7 @@ global $post_type, $post_type_object, $post, $title, $wp_meta_boxes;
 
 $block_editor_context = new WP_Block_Editor_Context( array( 'post' => $post ) );
 
-// Flag that we're loading the block editor.
+// Flag that the block editor is loaded.
 $current_screen = get_current_screen();
 $current_screen->is_block_editor( true );
 

--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -206,8 +206,7 @@ $editor_settings = array(
 	'supportsLayout'       => wp_theme_has_theme_json(),
 	'supportsTemplateMode' => current_theme_supports( 'block-templates' ),
 
-	// Whether or not to load the 'postcustom' meta box is stored as a user meta
-	// field so that we're not always loading its assets.
+	// Check whether the 'postcustom' meta box should be loaded.
 	'enableCustomFields'   => (bool) get_user_meta( get_current_user_id(), 'enable_custom_fields', true ),
 );
 

--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -130,7 +130,7 @@ wp_add_inline_script(
 /*
  * Get all available templates for the post/page attributes meta-box.
  * The "Default template" array element should only be added if the array is
- * not empty so we do not trigger the template select element without any options
+ * not empty, to not trigger the template select element without any options
  * besides the default value.
  */
 $available_templates = wp_get_theme()->get_page_templates( get_post( $post->ID ) );

--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -270,7 +270,7 @@ wp_enqueue_style( 'wp-edit-post' );
  */
 do_action( 'enqueue_block_editor_assets' );
 
-// In order to duplicate classic meta box behavior, we need to run the classic meta box actions.
+// In order to duplicate classic meta box behavior, run the classic meta box actions.
 require_once ABSPATH . 'wp-admin/includes/meta-boxes.php';
 register_and_do_post_meta_boxes( $post );
 

--- a/src/wp-admin/edit.php
+++ b/src/wp-admin/edit.php
@@ -432,7 +432,7 @@ if ( isset( $_REQUEST['s'] ) && strlen( $_REQUEST['s'] ) ) {
 <hr class="wp-header-end">
 
 <?php
-// If we have a bulk message to issue:
+// If there is a bulk message to issue:
 $messages = array();
 foreach ( $bulk_counts as $message => $count ) {
 	if ( isset( $bulk_messages[ $post_type ][ $message ] ) ) {

--- a/src/wp-admin/install-helper.php
+++ b/src/wp-admin/install-helper.php
@@ -137,7 +137,7 @@ function maybe_drop_column( $table_name, $column_name, $drop_ddl ) {
 			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- No applicable variables for this query.
 			$wpdb->query( $drop_ddl );
 
-			// Check if column was dropped.
+			// Check if the column was dropped.
 			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Cannot be prepared. Fetches columns for table names.
 			foreach ( $wpdb->get_col( "DESC $table_name", 0 ) as $column ) {
 				if ( $column === $column_name ) {

--- a/src/wp-admin/install-helper.php
+++ b/src/wp-admin/install-helper.php
@@ -64,7 +64,7 @@ if ( ! function_exists( 'maybe_create_table' ) ) :
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- No applicable variables for this query.
 		$wpdb->query( $create_ddl );
 
-		// We cannot directly tell whether this succeeded!
+		// Check if table was created.
 		foreach ( $wpdb->get_col( 'SHOW TABLES', 0 ) as $table ) {
 			if ( $table === $table_name ) {
 				return true;

--- a/src/wp-admin/install-helper.php
+++ b/src/wp-admin/install-helper.php
@@ -137,7 +137,7 @@ function maybe_drop_column( $table_name, $column_name, $drop_ddl ) {
 			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- No applicable variables for this query.
 			$wpdb->query( $drop_ddl );
 
-			// We cannot directly tell whether this succeeded!
+			// Check if column was dropped.
 			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Cannot be prepared. Fetches columns for table names.
 			foreach ( $wpdb->get_col( "DESC $table_name", 0 ) as $column ) {
 				if ( $column === $column_name ) {

--- a/src/wp-admin/install-helper.php
+++ b/src/wp-admin/install-helper.php
@@ -102,7 +102,7 @@ if ( ! function_exists( 'maybe_add_column' ) ) :
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- No applicable variables for this query.
 		$wpdb->query( $create_ddl );
 
-		// We cannot directly tell whether this succeeded!
+		// Check if column was created.
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Cannot be prepared. Fetches columns for table names.
 		foreach ( $wpdb->get_col( "DESC $table_name", 0 ) as $column ) {
 			if ( $column === $column_name ) {

--- a/src/wp-admin/install-helper.php
+++ b/src/wp-admin/install-helper.php
@@ -102,7 +102,7 @@ if ( ! function_exists( 'maybe_add_column' ) ) :
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- No applicable variables for this query.
 		$wpdb->query( $create_ddl );
 
-		// Check if column was created.
+		// Check if the column was created.
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Cannot be prepared. Fetches columns for table names.
 		foreach ( $wpdb->get_col( "DESC $table_name", 0 ) as $column ) {
 			if ( $column === $column_name ) {

--- a/src/wp-admin/install-helper.php
+++ b/src/wp-admin/install-helper.php
@@ -64,7 +64,7 @@ if ( ! function_exists( 'maybe_create_table' ) ) :
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- No applicable variables for this query.
 		$wpdb->query( $create_ddl );
 
-		// Check if table was created.
+		// Check if the table was created.
 		foreach ( $wpdb->get_col( 'SHOW TABLES', 0 ) as $table ) {
 			if ( $table === $table_name ) {
 				return true;

--- a/src/wp-admin/install.php
+++ b/src/wp-admin/install.php
@@ -348,7 +348,7 @@ switch ( $step ) {
 			}
 		}
 
-		// Deliberately fall through if we can't reach the translations API.
+		// Deliberately fall through if the translations API is unreachable.
 
 	case 1: // Step 1, direct link or from language chooser.
 		if ( ! empty( $language ) ) {

--- a/src/wp-admin/install.php
+++ b/src/wp-admin/install.php
@@ -25,7 +25,7 @@ if ( false ) {
 }
 
 /**
- * We are installing WordPress.
+ * Installing WordPress.
  *
  * @since 1.5.1
  * @var bool

--- a/src/wp-admin/install.php
+++ b/src/wp-admin/install.php
@@ -387,7 +387,7 @@ switch ( $step ) {
 		$scripts_to_print[] = 'user-profile';
 
 		display_header();
-		// Fill in the data we gathered.
+		// Fill in the gathered data.
 		$weblog_title         = isset( $_POST['weblog_title'] ) ? trim( wp_unslash( $_POST['weblog_title'] ) ) : '';
 		$user_name            = isset( $_POST['user_name'] ) ? trim( wp_unslash( $_POST['user_name'] ) ) : '';
 		$admin_password       = isset( $_POST['admin_password'] ) ? wp_unslash( $_POST['admin_password'] ) : '';


### PR DESCRIPTION
**DRAFT -- work in progress**

- Replaces first-person usage of "we" with second person point of view.
- Also makes small clarification adjustments where voice is much too casual or lacks clear context, especially for non-native English speakers.

This PR focuses on files in the WordPress `wp-admin` directory.

Trac ticket: https://core.trac.wordpress.org/ticket/57052

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
