### PR TITLE
Pass $locale to override_load_textdomain filter

### DIFF
--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -725,12 +725,14 @@ function load_textdomain( $domain, $mofile, $locale = null ) {
 	 * Filters whether to override the .mo file loading.
 	 *
 	 * @since 2.9.0
+	 * @since 6.2.0 Added the `$locale` parameter.
 	 *
 	 * @param bool   $override Whether to override the .mo file loading. Default false.
 	 * @param string $domain   Text domain. Unique identifier for retrieving translated strings.
 	 * @param string $mofile   Path to the MO file.
+	 * @param string $locale   Locale.
 	 */
-	$plugin_override = apply_filters( 'override_load_textdomain', false, $domain, $mofile );
+	$plugin_override = apply_filters( 'override_load_textdomain', false, $domain, $mofile, $locale );
 
 	if ( true === (bool) $plugin_override ) {
 		unset( $l10n_unloaded[ $domain ] );

--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -730,7 +730,7 @@ function load_textdomain( $domain, $mofile, $locale = null ) {
 	 * @param bool   $override Whether to override the .mo file loading. Default false.
 	 * @param string $domain   Text domain. Unique identifier for retrieving translated strings.
 	 * @param string $mofile   Path to the MO file.
-	 * @param string $locale   Locale.
+	 * @param string|null $locale   Locale.
 	 */
 	$plugin_override = apply_filters( 'override_load_textdomain', false, $domain, $mofile, $locale );
 

--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -727,9 +727,9 @@ function load_textdomain( $domain, $mofile, $locale = null ) {
 	 * @since 2.9.0
 	 * @since 6.2.0 Added the `$locale` parameter.
 	 *
-	 * @param bool   $override Whether to override the .mo file loading. Default false.
-	 * @param string $domain   Text domain. Unique identifier for retrieving translated strings.
-	 * @param string $mofile   Path to the MO file.
+	 * @param bool        $override Whether to override the .mo file loading. Default false.
+	 * @param string      $domain   Text domain. Unique identifier for retrieving translated strings.
+	 * @param string      $mofile   Path to the MO file.
 	 * @param string|null $locale   Locale.
 	 */
 	$plugin_override = apply_filters( 'override_load_textdomain', false, $domain, $mofile, $locale );


### PR DESCRIPTION
In [[53874]](https://core.trac.wordpress.org/changeset/53874) the `$locale` parameter was added to `load_textdomain()` so it can be used to properly fill `WP_Textdomain_Registry`.

Since the `$locale` may not be the same value as `determine_locale()` returns (e.g. when filtered by `plugin_locale` in `load_plugin_textdomain()`) we should also pass the new parameter to the filter so custom file loading implementations are using the same locale as `load_textdomain()` got.

Trac ticket: https://core.trac.wordpress.org/ticket/57056
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
