### PR TITLE
Always pass $locale to load_textdomain() if we know the locale

### DIFF
--- a/src/wp-admin/includes/admin.php
+++ b/src/wp-admin/includes/admin.php
@@ -13,7 +13,9 @@ if ( ! defined( 'WP_ADMIN' ) ) {
 	 * some setup was skipped. Make sure the admin message catalog is loaded since
 	 * load_default_textdomain() will not have done so in this context.
 	 */
-	load_textdomain( 'default', WP_LANG_DIR . '/admin-' . get_locale() . '.mo' );
+	$admin_locale = get_locale();
+	load_textdomain( 'default', WP_LANG_DIR . '/admin-' . $admin_locale . '.mo', $admin_locale );
+	unset( $admin_locale );
 }
 
 /** WordPress Administration Hooks */

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -6351,7 +6351,7 @@ function wp_timezone_choice( $selected_zone, $locale = null ) {
 		$locale_loaded = $locale ? $locale : get_locale();
 		$mofile        = WP_LANG_DIR . '/continents-cities-' . $locale_loaded . '.mo';
 		unload_textdomain( 'continents-cities' );
-		load_textdomain( 'continents-cities', $mofile );
+		load_textdomain( 'continents-cities', $mofile, $locale_loaded );
 		$mo_loaded = true;
 	}
 

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -1392,9 +1392,9 @@ function wp_load_translations_early() {
 		foreach ( $locales as $locale ) {
 			foreach ( $locations as $location ) {
 				if ( file_exists( $location . '/' . $locale . '.mo' ) ) {
-					load_textdomain( 'default', $location . '/' . $locale . '.mo' );
+					load_textdomain( 'default', $location . '/' . $locale . '.mo', $locale );
 					if ( defined( 'WP_SETUP_CONFIG' ) && file_exists( $location . '/admin-' . $locale . '.mo' ) ) {
-						load_textdomain( 'default', $location . '/admin-' . $locale . '.mo' );
+						load_textdomain( 'default', $location . '/admin-' . $locale . '.mo', $locale );
 					}
 					break 2;
 				}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-site-health-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-site-health-controller.php
@@ -336,7 +336,7 @@ class WP_REST_Site_Health_Controller extends WP_REST_Controller {
 		// Accounts for inner REST API requests in the admin.
 		if ( ! is_admin() ) {
 			$locale = determine_locale();
-			load_textdomain( 'default', WP_LANG_DIR . "/admin-$locale.mo" );
+			load_textdomain( 'default', WP_LANG_DIR . "/admin-$locale.mo", $locale );
 		}
 	}
 


### PR DESCRIPTION


Trac ticket: https://core.trac.wordpress.org/ticket/57060

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
