### PR TITLE
Backport: Gutenberg 43660 - Separator color bugfix (update)

### DIFF
--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -3998,4 +3998,96 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 			),
 		);
 	}
+
+	/**
+	 * Tests the core separator block outbut based on various provided settings.
+	 *
+	 * @ticket 56903
+	 *
+	 * @dataProvider data_update_separator_declarations
+	 *
+	 * @param array $separator_block_settings Example separator block settings from the data provider.
+	 * @param array $expected_output          Expected output from data provider.
+	 */
+	public function test_update_separator_declarations( $separator_block_settings, $expected_output ) {
+		// If only background is defined, test that includes border-color to the style so it is applied on the front end.
+		$theme_json = new WP_Theme_JSON(
+			array(
+				'version' => WP_Theme_JSON::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'core/separator' => $separator_block_settings,
+					),
+				),
+			),
+			'default'
+		);
+
+		$stylesheet = $theme_json->get_stylesheet( array( 'styles' ) );
+
+		$this->assertSame( $expected_output, $stylesheet );
+	}
+
+	/**
+	 * Data provider for separator declaration tests.
+	 *
+	 * @return array
+	 */
+	function data_update_separator_declarations() {
+		return array(
+			// If only background is defined, test that includes border-color to the style so it is applied on the front end.
+			'only background'                      => array(
+				array(
+					'color' => array(
+						'background' => 'blue',
+					),
+				),
+				'expected_output' => 'body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-block-separator{background-color: blue;color: blue;}',
+			),
+			// If background and text are defined, do not include border-color, as text color is enough.
+			'background and text, no border-color' => array(
+				array(
+					'color' => array(
+						'background' => 'blue',
+						'text'       => 'red',
+					),
+				),
+				'expected_output' => 'body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-block-separator{background-color: blue;color: red;}',
+			),
+			// If only text is defined, do not include border-color, as by itself is enough.
+			'only text'                            => array(
+				array(
+					'color' => array(
+						'text' => 'red',
+					),
+				),
+				'expected_output' => 'body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-block-separator{color: red;}',
+			),
+			// If background, text, and border-color are defined, include everything, CSS specifity will decide which to apply.
+			'background, text, and border-color'   => array(
+				array(
+					'color'  => array(
+						'background' => 'blue',
+						'text'       => 'red',
+					),
+					'border' => array(
+						'color' => 'pink',
+					),
+				),
+				'expected_output' => 'body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-block-separator{background-color: blue;border-color: pink;color: red;}',
+			),
+			// If background and border color are defined, include everything, CSS specifity will decide which to apply.
+			'background, text, and border-color'   => array(
+				array(
+					'color'  => array(
+						'background' => 'blue',
+					),
+					'border' => array(
+						'color' => 'pink',
+					),
+				),
+				'expected_output' => 'body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-block-separator{background-color: blue;border-color: pink;}',
+			),
+		);
+	}
 }


### PR DESCRIPTION
* This is basically #3522, with the additional suggestion from https://github.com/WordPress/wordpress-develop/pull/3522#pullrequestreview-1176606228 applied.
* Make sure props for original contributors @c4rl0sbr4v0, @dream-encode, and @hellofromtonya are included.

Trac ticket: https://core.trac.wordpress.org/ticket/56903

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
