### PR TITLE
Merge two docblocks to keep code according DRY rule

### DIFF
--- a/tests/phpunit/tests/admin/wpCommunityEvents.php
+++ b/tests/phpunit/tests/admin/wpCommunityEvents.php
@@ -5,15 +5,9 @@
  * @package WordPress
  * @subpackage UnitTests
  * @since 4.8.0
- */
-
-/**
- * Class Tests_Admin_wpCommunityEvents.
  *
  * @group admin
  * @group community-events
- *
- * @since 4.8.0
  */
 class Tests_Admin_wpCommunityEvents extends WP_UnitTestCase {
 

--- a/tests/phpunit/tests/admin/wpPrivacyRequestsTable.php
+++ b/tests/phpunit/tests/admin/wpPrivacyRequestsTable.php
@@ -5,15 +5,9 @@
  * @package WordPress\UnitTests
  *
  * @since 5.1.0
- */
-
-/**
- * Tests_Admin_wpPrivacyRequestsTable class.
  *
  * @group admin
  * @group privacy
- *
- * @since 5.1.0
  */
 class Tests_Admin_wpPrivacyRequestsTable extends WP_UnitTestCase {
 

--- a/tests/phpunit/tests/ajax/wpAjaxWpPrivacyErasePersonalData.php
+++ b/tests/phpunit/tests/ajax/wpAjaxWpPrivacyErasePersonalData.php
@@ -4,12 +4,6 @@
  *
  * @package WordPress\UnitTests
  * @since 5.2.0
- */
-
-/**
- * Tests_Ajax_PrivacyExportPersonalData class.
- *
- * @since 5.2.0
  *
  * @group ajax
  * @group privacy

--- a/tests/phpunit/tests/ajax/wpAjaxWpPrivacyExportPersonalData.php
+++ b/tests/phpunit/tests/ajax/wpAjaxWpPrivacyExportPersonalData.php
@@ -4,12 +4,6 @@
  *
  * @package WordPress\UnitTests
  * @since 5.2.0
- */
-
-/**
- * Tests_Ajax_PrivacyExportPersonalData class.
- *
- * @since 5.2.0
  *
  * @group ajax
  * @group privacy

--- a/tests/phpunit/tests/comment/isAvatarCommentType.php
+++ b/tests/phpunit/tests/comment/isAvatarCommentType.php
@@ -5,14 +5,8 @@
  * @package WordPress\UnitTests
  *
  * @since 5.1.0
- */
-
-/**
- * Tests_Comment_IsAvatarCommentType class.
  *
  * @group comment
- *
- * @since 5.1.0
  *
  * @covers ::is_avatar_comment_type
  */

--- a/tests/phpunit/tests/functions/doEnclose.php
+++ b/tests/phpunit/tests/functions/doEnclose.php
@@ -1,14 +1,9 @@
 <?php
+
 /**
  * Test cases for the `do_enclose()` function.
  *
  * @package WordPress\UnitTests
- *
- * @since 5.3.0
- */
-
-/**
- * Tests_Functions_DoEnclose class.
  *
  * @since 5.3.0
  *

--- a/tests/phpunit/tests/privacy/wpCreateUserRequest.php
+++ b/tests/phpunit/tests/privacy/wpCreateUserRequest.php
@@ -1,19 +1,13 @@
 <?php
 /**
- * Test the `wp_create_user_request()` function.
+ * Test cases for the `wp_create_user_request()` function.
  *
  * @package WordPress
  * @subpackage UnitTests
  * @since 5.2.0
- */
-
-/**
- * Tests_Privacy_wpCreateUserRequest class.
  *
  * @group privacy
  * @covers ::wp_create_user_request
- *
- * @since 5.2.0
  */
 class Tests_Privacy_wpCreateUserRequest extends WP_UnitTestCase {
 	/**

--- a/tests/phpunit/tests/privacy/wpPrivacyCompletedRequest.php
+++ b/tests/phpunit/tests/privacy/wpPrivacyCompletedRequest.php
@@ -1,19 +1,13 @@
 <?php
 /**
- * Test the `_wp_privacy_completed_request()` function.
+ * Test cases for the `_wp_privacy_completed_request()` function.
  *
  * @package WordPress
  * @subpackage UnitTests
  * @since 4.9.6
- */
-
-/**
- * Tests_Privacy_wpPrivacyCompletedRequest class.
  *
  * @group privacy
  * @covers ::_wp_privacy_completed_request
- *
- * @since 4.9.6
  */
 class Tests_Privacy_wpPrivacyCompletedRequest extends WP_UnitTestCase {
 	/**

--- a/tests/phpunit/tests/privacy/wpPrivacyDeleteOldExportFiles.php
+++ b/tests/phpunit/tests/privacy/wpPrivacyDeleteOldExportFiles.php
@@ -1,19 +1,13 @@
 <?php
 /**
- * Define a class to test `wp_privacy_delete_old_export_files()`.
+ * Test cases for the `wp_privacy_delete_old_export_files()` function.
  *
  * @package WordPress
  * @subpackage UnitTests
  * @since 4.9.6
- */
-
-/**
- * Test cases for `wp_privacy_delete_old_export_files()`.
  *
  * @group privacy
  * @covers ::wp_privacy_delete_old_export_files
- *
- * @since 4.9.6
  */
 class Tests_Privacy_wpPrivacyDeleteOldExportFiles extends WP_UnitTestCase {
 	/**

--- a/tests/phpunit/tests/privacy/wpPrivacyGeneratePersonalDataExportFile.php
+++ b/tests/phpunit/tests/privacy/wpPrivacyGeneratePersonalDataExportFile.php
@@ -1,20 +1,14 @@
 <?php
 /**
- * Define a class to test `wp_privacy_generate_personal_data_export_file()`.
+ * Test cases for the `wp_privacy_generate_personal_data_export_file()` function.
  *
  * @package WordPress
  * @subpackage UnitTests
  * @since 5.2.0
- */
-
-/**
- * Test cases for `wp_privacy_generate_personal_data_export_file()`.
  *
  * @group privacy
  * @covers ::wp_privacy_generate_personal_data_export_file
  * @requires extension zip
- *
- * @since 5.2.0
  */
 class Tests_Privacy_wpPrivacyGeneratePersonalDataExportFile extends WP_UnitTestCase {
 	/**

--- a/tests/phpunit/tests/privacy/wpPrivacyGeneratePersonalDataExportGroupHtml.php
+++ b/tests/phpunit/tests/privacy/wpPrivacyGeneratePersonalDataExportGroupHtml.php
@@ -5,15 +5,9 @@
  * @package WordPress
  * @subpackage UnitTests
  * @since 5.2.0
- */
-
-/**
- * Tests_Privacy_wpPrivacyGeneratePersonalDataExportGroupHtml class.
  *
  * @group privacy
  * @covers ::wp_privacy_generate_personal_data_export_group_html
- *
- * @since 5.2.0
  */
 class Tests_Privacy_wpPrivacyGeneratePersonalDataExportGroupHtml extends WP_UnitTestCase {
 

--- a/tests/phpunit/tests/privacy/wpPrivacyProcessPersonalDataExportPage.php
+++ b/tests/phpunit/tests/privacy/wpPrivacyProcessPersonalDataExportPage.php
@@ -5,15 +5,9 @@
  * @package WordPress
  * @subpackage UnitTests
  * @since 5.2.0
- */
-
-/**
- * Tests_Privacy_wpPrivacyProcessPersonalDataExportPage class.
  *
  * @group privacy
  * @covers ::wp_privacy_process_personal_data_export_page
- *
- * @since 5.2.0
  */
 class Tests_Privacy_wpPrivacyProcessPersonalDataExportPage extends WP_UnitTestCase {
 	/**

--- a/tests/phpunit/tests/privacy/wpPrivacySendErasureFulfillmentNotification.php
+++ b/tests/phpunit/tests/privacy/wpPrivacySendErasureFulfillmentNotification.php
@@ -5,15 +5,9 @@
  * @package WordPress
  * @subpackage UnitTests
  * @since 5.1.0
- */
-
-/**
- * Tests_Privacy_wpPrivacySendErasureFulfillmentNotification class.
  *
  * @group privacy
  * @covers ::_wp_privacy_send_erasure_fulfillment_notification
- *
- * @since 5.1.0
  */
 class Tests_Privacy_wpPrivacySendErasureFulfillmentNotification extends WP_UnitTestCase {
 	/**

--- a/tests/phpunit/tests/privacy/wpPrivacySendPersonalDataExportEmail.php
+++ b/tests/phpunit/tests/privacy/wpPrivacySendPersonalDataExportEmail.php
@@ -5,15 +5,9 @@
  * @package WordPress
  * @subpackage UnitTests
  * @since 4.9.6
- */
-
-/**
- * Tests_Privacy_wpPrivacySendPersonalDataExportEmail class.
  *
  * @group privacy
  * @covers ::wp_privacy_send_personal_data_export_email
- *
- * @since 4.9.6
  */
 class Tests_Privacy_wpPrivacySendPersonalDataExportEmail extends WP_UnitTestCase {
 	/**

--- a/tests/phpunit/tests/privacy/wpPrivacySendRequestConfirmationNotification.php
+++ b/tests/phpunit/tests/privacy/wpPrivacySendRequestConfirmationNotification.php
@@ -5,16 +5,10 @@
  * @package WordPress
  * @subpackage UnitTests
  * @since 4.9.8
- */
-
-/**
- * Tests_Privacy_wpPrivacySendRequestConfirmationNotification class.
  *
  * @group privacy
  * @group user
  * @covers ::_wp_privacy_send_request_confirmation_notification
- *
- * @since 4.9.8
  */
 class Tests_Privacy_wpPrivacySendRequestConfirmationNotification extends WP_UnitTestCase {
 	/**

--- a/tests/phpunit/tests/user/wpSendUserRequest.php
+++ b/tests/phpunit/tests/user/wpSendUserRequest.php
@@ -4,12 +4,6 @@
  *
  * @package WordPress
  * @since 4.9.9
- */
-
-/**
- * Tests_User_WpSendUserRequest class.
- *
- * @since 4.9.9
  *
  * @group privacy
  * @group user


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

In this PR, I propose merging file-level docblock with class-level docblock to avoid repeating information.

Trac ticket: <!-- insert a link to the WordPress Trac ticket here --> https://core.trac.wordpress.org/ticket/57099

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
