### PR TITLE
Fix the typo

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -114,7 +114,7 @@ class WP_Theme_JSON {
 	 * @since 5.9.0 Added the `color.duotone` and `typography.fontFamilies` presets,
 	 *              `use_default_names` preset key, and simplified the metadata structure.
 	 * @since 6.0.0 Replaced `override` with `prevent_override` and updated the
-	 *              `prevent_overried` value for `color.duotone` to use `color.defaultDuotone`.
+	 *              `prevent_override` value for `color.duotone` to use `color.defaultDuotone`.
 	 * @var array
 	 */
 	const PRESETS_METADATA = array(


### PR DESCRIPTION
Fix a typo in the PRESETS_METADATA constant description, in WP_Theme_JSON

https://core.trac.wordpress.org/ticket/56792 