### PR TITLE
Support additional link related pseudo classes in theme.json

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -404,8 +404,8 @@ class WP_Theme_JSON {
 	 * @since 6.1.0
 	 */
 	const VALID_ELEMENT_PSEUDO_SELECTORS = array(
-		'link'   => array( ':visited', ':hover', ':focus', ':active' ),
-		'button' => array( ':visited', ':hover', ':focus', ':active' ),
+		'link'   => array( ':link', ':any-link', ':visited', ':hover', ':focus', ':active' ),
+		'button' => array( ':link', ':any-link', ':visited', ':hover', ':focus', ':active' ),
 	);
 
 	/**

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -394,14 +394,15 @@ class WP_Theme_JSON {
 	/**
 	 * Defines which pseudo selectors are enabled for which elements.
 	 *
-	 * The order of the selectors should be: visited, hover, focus, active.
-	 * This is to ensure that 'visited' has the lowest specificity
-	 * and the other selectors can always overwrite it.
+	 * The order of the selectors should be: link, any-link, visited, hover, focus, active.
+	 * This is to ensure that 'visited' has the lowest specificity and the other selectors
+	 * can always overwrite it.
 	 *
 	 * See https://core.trac.wordpress.org/ticket/56928.
 	 * Note: this will affect both top-level and block-level elements.
 	 *
 	 * @since 6.1.0
+	 * @since 6.2.0 Added support for ':link' and ':any-link'.
 	 */
 	const VALID_ELEMENT_PSEUDO_SELECTORS = array(
 		'link'   => array( ':link', ':any-link', ':visited', ':hover', ':focus', ':active' ),

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -396,7 +396,7 @@ class WP_Theme_JSON {
 	 *
 	 * The order of the selectors should be: link, any-link, visited, hover, focus, active.
 	 * This is to ensure the user action (hover, focus and active) styles have a
-	 * higher specificity than the visited styles, which in turn have a higher 
+	 * higher specificity than the visited styles, which in turn have a higher
 	 * specificity than the unvisited styles.
 	 *
 	 * See https://core.trac.wordpress.org/ticket/56928.

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -395,8 +395,9 @@ class WP_Theme_JSON {
 	 * Defines which pseudo selectors are enabled for which elements.
 	 *
 	 * The order of the selectors should be: link, any-link, visited, hover, focus, active.
-	 * This is to ensure that 'visited' has the lowest specificity and the other selectors
-	 * can always overwrite it.
+	 * This is to ensure the user action (hover, focus and active) styles have a
+	 * higher specificity than the visited styles, which in turn have a higher 
+	 * specificity than the unvisited styles.
 	 *
 	 * See https://core.trac.wordpress.org/ticket/56928.
 	 * Note: this will affect both top-level and block-level elements.


### PR DESCRIPTION
Added `:link` and `:any-link` to VALID_ELEMENT_PSEUDO_SELECTORS array

Maybe we should change the corresponding docblock 


Trac ticket: https://core.trac.wordpress.org/ticket/57053

