### PR TITLE
Remove bundled theme files from `$_old_files`.

### DIFF
--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -845,11 +845,7 @@ $_old_files = array(
 	'wp-includes/blocks/tag-cloud/editor.min.css',
 	'wp-includes/blocks/tag-cloud/editor-rtl.css',
 	'wp-includes/blocks/tag-cloud/editor-rtl.min.css',
-	// 6.0
-	'wp-content/themes/twentytwentytwo/assets/fonts/LICENSE.md',
 	// 6.1
-	'wp-content/themes/twentytwentyone/assets/sass/05-blocks/spacer/_style.scss',
-	'wp-content/themes/twentytwentyone/assets/sass/05-blocks/spacer',
 	'wp-includes/blocks/post-comments.php',
 	'wp-includes/blocks/post-comments/block.json',
 	'wp-includes/blocks/post-comments/editor.css',

--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -10,6 +10,8 @@
 /**
  * Stores files to be deleted.
  *
+ * This should not include bundled theme files.
+ *
  * @since 2.7.0
  *
  * @global array $_old_files


### PR DESCRIPTION
This PR:
- [x] Adds a note not to include bundled theme files in `$_old_files`.
- [x] Removes bundled theme files entries.

Trac ticket: https://core.trac.wordpress.org/ticket/56936
