### PR TITLE
Parameter #1 ($post) of type is nullable.

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -56,7 +56,6 @@ jobs:
   # - Runs PHPCS on the `tests` directory without warnings suppressed.
   # - Generate a report for displaying `test` directory issues as pull request annotations.
   # - Ensures version-controlled files are not modified or deleted.
-
   phpcs:
     name: PHP coding standards
     runs-on: ubuntu-latest
@@ -72,7 +71,7 @@ jobs:
         with:
           php-version: '7.4'
           coverage: none
-          tools: composer, cs2pr
+          tools: cs2pr
 
       # This date is used to ensure that the PHPCS cache is cleared at least once every week.
       # http://man7.org/linux/man-pages/man1/date.1.html
@@ -86,10 +85,12 @@ jobs:
           path: .cache/phpcs.json
           key: ${{ runner.os }}-date-${{ steps.get-date.outputs.date }}-phpcs-cache-${{ hashFiles('**/composer.json', 'phpcs.xml.dist') }}
 
+      # Since Composer dependencies are installed using `composer update` and no lock file is in version control,
+      # passing a custom cache suffix ensures that the cache is flushed at least once per week.
       - name: Install Composer dependencies
         uses: ramsey/composer-install@83af392bf5f031813d25e6fe4cd626cdba9a2df6 # v2.2.0
         with:
-          composer-options: "--no-progress --no-ansi"
+          custom-cache-suffix: ${{ steps.get-date.outputs.date }}
 
       - name: Make Composer packages available globally
         run: echo "${PWD}/vendor/bin" >> $GITHUB_PATH

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           php-version: '7.4'
           coverage: none
-          tools: composer, cs2pr
+          tools: cs2pr
 
       - name: Log debug information
         run: |
@@ -84,10 +84,12 @@ jobs:
           path: .cache/phpcompat.json
           key: ${{ runner.os }}-date-${{ steps.get-date.outputs.date }}-phpcompat-cache-${{ hashFiles('**/composer.json', 'phpcompat.xml.dist') }}
 
+      # Since Composer dependencies are installed using `composer update` and no lock file is in version control,
+      # passing a custom cache suffix ensures that the cache is flushed at least once per week.
       - name: Install Composer dependencies
         uses: ramsey/composer-install@83af392bf5f031813d25e6fe4cd626cdba9a2df6 # v2.2.0
         with:
-          composer-options: "--no-progress --no-ansi"
+          custom-cache-suffix: ${{ steps.get-date.outputs.date }}
 
       - name: Make Composer packages available globally
         run: echo "${PWD}/vendor/bin" >> $GITHUB_PATH

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -38,10 +38,10 @@ jobs:
   # - Sets environment variables.
   # - Checks out the repository.
   # - Sets up Node.js.
-  # - Logs general debug information about the runner.
-  # - Installs npm dependencies
-  # - Configures caching for Composer.
+  # - Sets up PHP.
   # - Installs Composer dependencies.
+  # - Installs npm dependencies
+  # - Logs general debug information about the runner.
   # - Logs Docker debug information (about the Docker installation within the runner).
   # - Starts the WordPress Docker container.
   # - Logs the running Docker containers.
@@ -112,6 +112,29 @@ jobs:
           node-version-file: '.nvmrc'
           cache: npm
 
+      ##
+      # This allows Composer dependencies to be installed using a single step.
+      #
+      # Since the tests are currently run within the Docker containers where the PHP version varies,
+      # the same PHP version needs to be configured for the action runner machine so that the correct
+      # dependency versions are installed and cached.
+      ##
+      - name: Set up PHP
+        uses: shivammathur/setup-php@1a18b2267f80291a81ca1d33e7c851fe09e7dfc4 # v2.22.0
+        with:
+          php-version: '${{ matrix.php }}'
+          coverage: none
+
+      # Since Composer dependencies are installed using `composer update` and no lock file is in version control,
+      # passing a custom cache suffix ensures that the cache is flushed at least once per week.
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@83af392bf5f031813d25e6fe4cd626cdba9a2df6 # v2.2.0
+        with:
+          custom-cache-suffix: $(/bin/date -u --date='last Mon' "+%F")
+
+      - name: Install npm dependencies
+        run: npm ci
+
       - name: General debug information
         run: |
           npm --version
@@ -119,38 +142,8 @@ jobs:
           curl --version
           git --version
           svn --version
-
-      - name: Install npm dependencies
-        run: npm ci
-
-      # This date is used to ensure that the Composer cache is refreshed at least once every week.
-      # http://man7.org/linux/man-pages/man1/date.1.html
-      - name: "Get last Monday's date"
-        id: get-date
-        run: echo "date=$(/bin/date -u --date='last Mon' "+%F")" >> $GITHUB_OUTPUT
-
-      - name: Get Composer cache directory
-        id: composer-cache
-        run: echo "composer_dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache Composer dependencies
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # v3.0.11
-        env:
-          cache-name: cache-composer-dependencies
-        with:
-          path: ${{ steps.composer-cache.outputs.composer_dir }}
-          key: ${{ runner.os }}-php-${{ matrix.php }}-date-${{ steps.get-date.outputs.date }}-composer-${{ hashFiles('**/composer.json') }}
-
-      - name: Install Composer dependencies
-        run: |
-          docker-compose run --rm php composer --version
-
-          # Install using `composer update` as there is no `composer.lock` file.
-          if [ ${{ env.LOCAL_PHP }} == '8.2-fpm' ]; then
-            docker-compose run --rm php composer update --ignore-platform-req=php+
-          else
-            docker-compose run --rm php composer update
-          fi
+          composer --version
+          locale -a
 
       - name: Docker debug information
         run: |

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -38,10 +38,10 @@ jobs:
   # - Sets environment variables.
   # - Checks out the repository.
   # - Sets up Node.js.
-  # - Logs general debug information about the runner.
-  # - Installs npm dependencies
-  # - Configures caching for Composer.
+  # - Sets up PHP.
   # - Installs Composer dependencies.
+  # - Installs npm dependencies
+  # - Logs general debug information about the runner.
   # - Logs Docker debug information (about the Docker installation within the runner).
   # - Starts the WordPress Docker container.
   # - Logs the running Docker containers.
@@ -78,6 +78,29 @@ jobs:
           node-version-file: '.nvmrc'
           cache: npm
 
+      ##
+      # This allows Composer dependencies to be installed using a single step.
+      #
+      # Since the tests are currently run within the Docker containers where the PHP version varies,
+      # the same PHP version needs to be configured for the action runner machine so that the correct
+      # dependency versions are installed and cached.
+      ##
+      - name: Set up PHP
+        uses: shivammathur/setup-php@1a18b2267f80291a81ca1d33e7c851fe09e7dfc4 # v2.22.0
+        with:
+          php-version: '7.4'
+          coverage: none
+
+      # Since Composer dependencies are installed using `composer update` and no lock file is in version control,
+      # passing a custom cache suffix ensures that the cache is flushed at least once per week.
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@83af392bf5f031813d25e6fe4cd626cdba9a2df6 # v2.2.0
+        with:
+          custom-cache-suffix: $(/bin/date -u --date='last Mon' "+%F")
+
+      - name: Install npm Dependencies
+        run: npm ci
+
       - name: Log debug information
         run: |
           echo "$GITHUB_REF"
@@ -87,35 +110,8 @@ jobs:
           curl --version
           git --version
           svn --version
+          composer --version
           locale -a
-
-      - name: Install npm Dependencies
-        run: npm ci
-
-      # This date is used to ensure that the Composer cache is refreshed at least once every week.
-      # http://man7.org/linux/man-pages/man1/date.1.html
-      - name: "Get last Monday's date"
-        id: get-date
-        run: echo "date=$(/bin/date -u --date='last Mon' "+%F")" >> $GITHUB_OUTPUT
-
-      - name: Get Composer cache directory
-        id: composer-cache
-        run: echo "composer_dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache Composer dependencies
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # v3.0.11
-        env:
-          cache-name: cache-composer-dependencies
-        with:
-          path: ${{ steps.composer-cache.outputs.composer_dir }}
-          key: ${{ runner.os }}-php-${{ matrix.php }}-date-${{ steps.get-date.outputs.date }}-composer-${{ hashFiles('**/composer.json') }}
-
-      - name: Install Composer dependencies
-        run: |
-          docker-compose run --rm php composer --version
-
-          # Install using `composer update` as there is no `composer.lock` file.
-          docker-compose run --rm php composer update
 
       - name: Docker debug information
         run: |

--- a/src/js/_enqueues/lib/nav-menu.js
+++ b/src/js/_enqueues/lib/nav-menu.js
@@ -1557,14 +1557,14 @@
 		});
 	});
 
-	// Show bulk action
+	// Show bulk action.
 	$( document ).on( 'menu-item-added', function() {
 		if ( ! $( '.bulk-actions' ).is( ':visible' ) ) {
 			$( '.bulk-actions' ).show();
 		}
 	} );
 
-	// Hide bulk action
+	// Hide bulk action.
 	$( document ).on( 'menu-removing-item', function( e, el ) {
 		var menuElement = $( el ).parents( '#menu-to-edit' );
 		if ( menuElement.find( 'li' ).length === 1 && $( '.bulk-actions' ).is( ':visible' ) ) {

--- a/src/wp-admin/install-helper.php
+++ b/src/wp-admin/install-helper.php
@@ -1,27 +1,29 @@
 <?php
 /**
- * Plugins may load this file to gain access to special helper functions for
- * plugin installation. This file is not included by WordPress and it is
+ * Plugins may load this file to gain access to special helper functions
+ * for plugin installation. This file is not included by WordPress and it is
  * recommended, to prevent fatal errors, that this file is included using
  * require_once.
  *
  * These functions are not optimized for speed, but they should only be used
  * once in a while, so speed shouldn't be a concern. If it is and you are
- * needing to use these functions a lot, you might experience time outs. If you
- * do, then it is advised to just write the SQL code yourself.
+ * needing to use these functions a lot, you might experience timeouts.
+ * If you do, then it is advised to just write the SQL code yourself.
  *
  *     check_column( 'wp_links', 'link_description', 'mediumtext' );
+ *
  *     if ( check_column( $wpdb->comments, 'comment_author', 'tinytext' ) ) {
  *         echo "ok\n";
  *     }
  *
- *     $error_count = 0;
- *     $tablename = $wpdb->links;
  *     // Check the column.
  *     if ( ! check_column( $wpdb->links, 'link_description', 'varchar( 255 )' ) ) {
  *         $ddl = "ALTER TABLE $wpdb->links MODIFY COLUMN link_description varchar(255) NOT NULL DEFAULT '' ";
  *         $q = $wpdb->query( $ddl );
  *     }
+ *
+ *     $error_count = 0;
+ *     $tablename   = $wpdb->links;
  *
  *     if ( check_column( $wpdb->links, 'link_description', 'varchar( 255 )' ) ) {
  *         $res .= $tablename . ' - ok <br />';
@@ -59,9 +61,10 @@ if ( ! function_exists( 'maybe_create_table' ) ) :
 		}
 
 		// Didn't find it, so try to create it.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- No applicable variables for this query.
 		$wpdb->query( $create_ddl );
 
-		// We cannot directly tell that whether this succeeded!
+		// We cannot directly tell whether this succeeded!
 		foreach ( $wpdb->get_col( 'SHOW TABLES', 0 ) as $table ) {
 			if ( $table === $table_name ) {
 				return true;
@@ -88,6 +91,7 @@ if ( ! function_exists( 'maybe_add_column' ) ) :
 	function maybe_add_column( $table_name, $column_name, $create_ddl ) {
 		global $wpdb;
 
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Cannot be prepared. Fetches columns for table names.
 		foreach ( $wpdb->get_col( "DESC $table_name", 0 ) as $column ) {
 			if ( $column === $column_name ) {
 				return true;
@@ -95,9 +99,11 @@ if ( ! function_exists( 'maybe_add_column' ) ) :
 		}
 
 		// Didn't find it, so try to create it.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- No applicable variables for this query.
 		$wpdb->query( $create_ddl );
 
-		// We cannot directly tell that whether this succeeded!
+		// We cannot directly tell whether this succeeded!
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Cannot be prepared. Fetches columns for table names.
 		foreach ( $wpdb->get_col( "DESC $table_name", 0 ) as $column ) {
 			if ( $column === $column_name ) {
 				return true;
@@ -123,13 +129,16 @@ endif;
 function maybe_drop_column( $table_name, $column_name, $drop_ddl ) {
 	global $wpdb;
 
+	// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Cannot be prepared. Fetches columns for table names.
 	foreach ( $wpdb->get_col( "DESC $table_name", 0 ) as $column ) {
 		if ( $column === $column_name ) {
 
 			// Found it, so try to drop it.
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- No applicable variables for this query.
 			$wpdb->query( $drop_ddl );
 
-			// We cannot directly tell that whether this succeeded!
+			// We cannot directly tell whether this succeeded!
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Cannot be prepared. Fetches columns for table names.
 			foreach ( $wpdb->get_col( "DESC $table_name", 0 ) as $column ) {
 				if ( $column === $column_name ) {
 					return false;
@@ -147,16 +156,16 @@ function maybe_drop_column( $table_name, $column_name, $drop_ddl ) {
  *
  * Uses the SQL DESC for retrieving the table info for the column. It will help
  * understand the parameters, if you do more research on what column information
- * is returned by the SQL statement. Pass in null to skip checking that
- * criteria.
+ * is returned by the SQL statement. Pass in null to skip checking that criteria.
  *
- * Column names returned from DESC table are case sensitive and are listed:
- *      Field
- *      Type
- *      Null
- *      Key
- *      Default
- *      Extra
+ * Column names returned from DESC table are case sensitive and are as listed:
+ *
+ *  - Field
+ *  - Type
+ *  - Null
+ *  - Key
+ *  - Default
+ *  - Extra
  *
  * @since 1.0.0
  *
@@ -174,7 +183,9 @@ function maybe_drop_column( $table_name, $column_name, $drop_ddl ) {
 function check_column( $table_name, $col_name, $col_type, $is_null = null, $key = null, $default_value = null, $extra = null ) {
 	global $wpdb;
 
-	$diffs   = 0;
+	$diffs = 0;
+
+	// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Cannot be prepared. Fetches columns for table names.
 	$results = $wpdb->get_results( "DESC $table_name" );
 
 	foreach ( $results as $row ) {

--- a/src/wp-admin/user-new.php
+++ b/src/wp-admin/user-new.php
@@ -442,8 +442,8 @@ if ( is_multisite() && current_user_can( 'promote_users' ) ) {
 
 <table class="form-table" role="presentation">
 	<tr class="form-field form-required">
-		<th scope="row"><label for="adduser-email"><?php echo $label; ?></label></th>
-		<td><input name="email" type="<?php echo $type; ?>" id="adduser-email" class="wp-suggest-user" value="" /></td>
+		<th scope="row"><label for="adduser-email"><?php echo esc_html( $label ); ?></label></th>
+		<td><input name="email" type="<?php echo esc_attr( $type ); ?>" id="adduser-email" class="wp-suggest-user" value="" /></td>
 	</tr>
 	<tr class="form-field">
 		<th scope="row"><label for="adduser-role"><?php _e( 'Role' ); ?></label></th>

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -503,7 +503,7 @@ function _build_block_template_result_from_file( $template_file, $template_type 
 
 	$template                 = new WP_Block_Template();
 	$template->id             = $theme . '//' . $template_file['slug'];
-	$template->theme          = $theme;
+	$template->theme          = ! empty( $template_file['theme'] ) ? $template_file['theme'] : $theme;
 	$template->content        = _inject_theme_attribute_in_block_template_content( $template_content );
 	$template->slug           = $template_file['slug'];
 	$template->source         = 'theme';

--- a/src/wp-includes/category-template.php
+++ b/src/wp-includes/category-template.php
@@ -1017,7 +1017,7 @@ function wp_generate_tag_cloud( $tags, $args = '' ) {
 
 	switch ( $args['format'] ) {
 		case 'array':
-			$return =& $a;
+			$return = & $a;
 			break;
 		case 'list':
 			/*
@@ -1279,8 +1279,10 @@ function term_description( $term = 0, $deprecated = null ) {
  *
  * @since 2.5.0
  *
- * @param int|WP_Post $post     Post ID or object.
- * @param string      $taxonomy Taxonomy name.
+ * @param int|WP_Post|null $post     Post ID or object. null or 0 values return taxonomy attached
+ *                                   the current global post inside the loop. A numerically valid
+ *                                   post ID that points to a non-existent post returns false.
+ * @param string           $taxonomy Taxonomy name.
  * @return WP_Term[]|false|WP_Error Array of WP_Term objects on success, false if there are no terms
  *                                  or the post does not exist, WP_Error on failure.
  */

--- a/src/wp-includes/class-wp-list-util.php
+++ b/src/wp-includes/class-wp-list-util.php
@@ -207,9 +207,10 @@ class WP_List_Util {
 	 * @since 4.7.0
 	 *
 	 * @param string|array $orderby       Optional. Either the field name to order by or an array
-	 *                                    of multiple orderby fields as $orderby => $order.
-	 * @param string       $order         Optional. Either 'ASC' or 'DESC'. Only used if $orderby
-	 *                                    is a string.
+	 *                                    of multiple orderby fields as `$orderby => $order`.
+	 *                                    Default empty array.
+	 * @param string       $order         Optional. Either 'ASC' or 'DESC'. Only used if `$orderby`
+	 *                                    is a string. Default 'ASC'.
 	 * @param bool         $preserve_keys Optional. Whether to preserve keys. Default false.
 	 * @return array The sorted array.
 	 */

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -114,7 +114,7 @@ class WP_Theme_JSON {
 	 * @since 5.9.0 Added the `color.duotone` and `typography.fontFamilies` presets,
 	 *              `use_default_names` preset key, and simplified the metadata structure.
 	 * @since 6.0.0 Replaced `override` with `prevent_override` and updated the
-	 *              `prevent_overried` value for `color.duotone` to use `color.defaultDuotone`.
+	 *              `prevent_override` value for `color.duotone` to use `color.defaultDuotone`.
 	 * @var array
 	 */
 	const PRESETS_METADATA = array(
@@ -412,7 +412,7 @@ class WP_Theme_JSON {
 	 * The valid elements that can be found under styles.
 	 *
 	 * @since 5.8.0
-	 * @since 6.1.0 Added `heading`, `button`. and `caption` elements.
+	 * @since 6.1.0 Added `heading`, `button`, and `caption` elements.
 	 * @var string[]
 	 */
 	const ELEMENTS = array(

--- a/src/wp-includes/compat.php
+++ b/src/wp-includes/compat.php
@@ -156,7 +156,7 @@ endif;
 /**
  * Internal compat function to mimic mb_strlen().
  *
- * Only understands UTF-8 and 8bit.  All other character sets will be treated as 8bit.
+ * Only understands UTF-8 and 8bit. All other character sets will be treated as 8bit.
  * For `$encoding === UTF-8`, the `$str` input is expected to be a valid UTF-8 byte
  * sequence. The behavior of this function for invalid inputs is undefined.
  *

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -934,7 +934,7 @@ function do_enclose( $content, $post ) {
 	 * @since 4.4.0
 	 *
 	 * @param string[] $post_links An array of enclosure links.
-	 * @param int      $post_ID    Post ID.
+	 * @param int      $post_id    Post ID.
 	 */
 	$post_links = apply_filters( 'enclosure_links', $post_links, $post->ID );
 
@@ -3330,7 +3330,7 @@ function wp_get_mime_types() {
 	 * @since 3.5.0
 	 *
 	 * @param string[] $wp_get_mime_types Mime types keyed by the file extension regex
-	 *                                 corresponding to those types.
+	 *                                    corresponding to those types.
 	 */
 	return apply_filters(
 		'mime_types',
@@ -5200,9 +5200,10 @@ function wp_list_pluck( $list, $field, $index_key = null ) {
  *
  * @param array        $list          An array of objects or arrays to sort.
  * @param string|array $orderby       Optional. Either the field name to order by or an array
- *                                    of multiple orderby fields as $orderby => $order.
- * @param string       $order         Optional. Either 'ASC' or 'DESC'. Only used if $orderby
- *                                    is a string.
+ *                                    of multiple orderby fields as `$orderby => $order`.
+ *                                    Default empty array.
+ * @param string       $order         Optional. Either 'ASC' or 'DESC'. Only used if `$orderby`
+ *                                    is a string. Default 'ASC'.
  * @param bool         $preserve_keys Optional. Whether to preserve keys. Default false.
  * @return array The sorted array.
  */

--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -176,7 +176,7 @@ function determine_locale() {
  * *Note:* Don't use translate() directly, use __() or related functions.
  *
  * @since 2.2.0
- * @since 5.5.0 Introduced gettext-{$domain} filter.
+ * @since 5.5.0 Introduced `gettext-{$domain}` filter.
  *
  * @param string $text   Text to translate.
  * @param string $domain Optional. Text domain. Unique identifier for retrieving translated strings.
@@ -242,7 +242,7 @@ function before_last_bar( $string ) {
  * *Note:* Don't use translate_with_gettext_context() directly, use _x() or related functions.
  *
  * @since 2.8.0
- * @since 5.5.0 Introduced gettext_with_context-{$domain} filter.
+ * @since 5.5.0 Introduced `gettext_with_context-{$domain}` filter.
  *
  * @param string $text    Text to translate.
  * @param string $context Context information for the translators.
@@ -463,7 +463,7 @@ function esc_html_x( $text, $context, $domain = 'default' ) {
  *     printf( _n( '%s person', '%s people', $count, 'text-domain' ), number_format_i18n( $count ) );
  *
  * @since 2.8.0
- * @since 5.5.0 Introduced ngettext-{$domain} filter.
+ * @since 5.5.0 Introduced `ngettext-{$domain}` filter.
  *
  * @param string $single The text to be used if the number is singular.
  * @param string $plural The text to be used if the number is plural.
@@ -521,7 +521,7 @@ function _n( $single, $plural, $number, $domain = 'default' ) {
  *     printf( _nx( '%s group', '%s groups', $animals, 'group of animals', 'text-domain' ), number_format_i18n( $animals ) );
  *
  * @since 2.8.0
- * @since 5.5.0 Introduced ngettext_with_context-{$domain} filter.
+ * @since 5.5.0 Introduced `ngettext_with_context-{$domain}` filter.
  *
  * @param string $single  The text to be used if the number is singular.
  * @param string $plural  The text to be used if the number is plural.
@@ -1022,9 +1022,9 @@ function load_theme_textdomain( $domain, $path = false ) {
 }
 
 /**
- * Loads the child themes translated strings.
+ * Loads the child theme's translated strings.
  *
- * If the current locale exists as a .mo file in the child themes
+ * If the current locale exists as a .mo file in the child theme's
  * root directory, it will be included in the translated strings by the $domain.
  *
  * The .mo files must be named based on the locale exactly.
@@ -1361,7 +1361,8 @@ function translate_user_role( $name, $domain = 'default' ) {
  *
  * @param string $dir A directory to search for language files.
  *                    Default WP_LANG_DIR.
- * @return string[] An array of language codes or an empty array if no languages are present. Language codes are formed by stripping the .mo extension from the language file names.
+ * @return string[] An array of language codes or an empty array if no languages are present.
+ *                  Language codes are formed by stripping the .mo extension from the language file names.
  */
 function get_available_languages( $dir = null ) {
 	$languages = array();

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -1322,10 +1322,10 @@ function get_current_network_id() {
  * @access private
  *
  * @global WP_Textdomain_Registry $wp_textdomain_registry WordPress Textdomain Registry.
- * @global WP_Locale $wp_locale WordPress date and time locale object.
+ * @global WP_Locale              $wp_locale              WordPress date and time locale object.
  */
 function wp_load_translations_early() {
-	global $wp_locale, $wp_textdomain_registry;
+	global $wp_textdomain_registry, $wp_locale;
 
 	static $loaded = false;
 	if ( $loaded ) {

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -1547,9 +1547,8 @@ function get_post_types( $args = array(), $output = 'names', $operator = 'and' )
  *
  * @global array $wp_post_types List of post types.
  *
- * @param string       $post_type Post type key. Must not exceed 20 characters and may
- *                                only contain lowercase alphanumeric characters, dashes,
- *                                and underscores. See sanitize_key().
+ * @param string       $post_type Post type key. Must not exceed 20 characters and may only contain
+ *                                lowercase alphanumeric characters, dashes, and underscores. See sanitize_key().
  * @param array|string $args {
  *     Array or string of arguments for registering a post type.
  *
@@ -3057,7 +3056,7 @@ function wp_count_posts( $type = 'post', $perm = '' ) {
 	wp_cache_set( $cache_key, $counts, 'counts' );
 
 	/**
-	 * Modifies returned post counts by status for the current post type.
+	 * Filters the post counts by status for the current post type.
 	 *
 	 * @since 3.7.0
 	 *
@@ -3109,7 +3108,7 @@ function wp_count_attachments( $mime_type = '' ) {
 	}
 
 	/**
-	 * Modifies returned attachment counts by mime type.
+	 * Filters the attachment counts by mime type.
 	 *
 	 * @since 3.7.0
 	 *
@@ -4198,7 +4197,7 @@ function wp_insert_post( $postarr, $wp_error = false, $fire_after_hooks = true )
 
 		if ( $update && strtolower( urlencode( $post_name ) ) == $check_name && get_post_field( 'post_name', $post_ID ) == $check_name ) {
 			$post_name = $check_name;
-		} else { // new post, or slug has changed.
+		} else { // New post, or slug has changed.
 			$post_name = sanitize_title( $post_name );
 		}
 	}

--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -553,7 +553,7 @@ class WP_REST_Server {
 	 * Converts a response to data to send.
 	 *
 	 * @since 4.4.0
-	 * @since 5.4.0 The $embed parameter can now contain a list of link relations to include.
+	 * @since 5.4.0 The `$embed` parameter can now contain a list of link relations to include.
 	 *
 	 * @param WP_REST_Response $response Response object.
 	 * @param bool|string[]    $embed    Whether to embed all links, a filtered list of link relations, or no links.
@@ -677,7 +677,7 @@ class WP_REST_Server {
 	 * Embeds the links from the data into the request.
 	 *
 	 * @since 4.4.0
-	 * @since 5.4.0 The $embed parameter can now contain a list of link relations to include.
+	 * @since 5.4.0 The `$embed` parameter can now contain a list of link relations to include.
 	 *
 	 * @param array         $data  Data from the request.
 	 * @param bool|string[] $embed Whether to embed all links or a filtered list of link relations.
@@ -759,7 +759,7 @@ class WP_REST_Server {
 	 * data instead.
 	 *
 	 * @since 4.4.0
-	 * @since 6.0.0 The $embed parameter can now contain a list of link relations to include
+	 * @since 6.0.0 The `$embed` parameter can now contain a list of link relations to include.
 	 *
 	 * @param WP_REST_Response $response Response object.
 	 * @param bool|string[]    $embed    Whether to embed all links, a filtered list of link relations, or no links.

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -659,11 +659,9 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			&& in_array( $prepared_post->post_status, array( 'draft', 'pending' ), true )
 		) {
 			/*
-			 * `wp_unique_post_slug()` returns the same
-			 * slug for 'draft' or 'pending' posts.
+			 * `wp_unique_post_slug()` returns the same slug for 'draft' or 'pending' posts.
 			 *
-			 * To ensure that a unique slug is generated,
-			 * pass the post data with the 'publish' status.
+			 * To ensure that a unique slug is generated, pass the post data with the 'publish' status.
 			 */
 			$prepared_post->post_name = wp_unique_post_slug(
 				$prepared_post->post_name,
@@ -862,15 +860,19 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		}
 
 		/*
-		 * `wp_unique_post_slug()` returns the same
-		 * slug for 'draft' or 'pending' posts.
+		 * `wp_unique_post_slug()` returns the same slug for 'draft' or 'pending' posts.
 		 *
-		 * To ensure that a unique slug is generated,
-		 * pass the post data with the 'publish' status.
+		 * To ensure that a unique slug is generated, pass the post data with the 'publish' status.
 		 */
 		if ( ! empty( $post->post_name ) && in_array( $post_status, array( 'draft', 'pending' ), true ) ) {
 			$post_parent     = ! empty( $post->post_parent ) ? $post->post_parent : 0;
-			$post->post_name = wp_unique_post_slug( $post->post_name, $post->ID, 'publish', $post->post_type, $post_parent );
+			$post->post_name = wp_unique_post_slug(
+				$post->post_name,
+				$post->ID,
+				'publish',
+				$post->post_type,
+				$post_parent
+			);
 		}
 
 		// Convert the post object to an array, otherwise wp_update_post() will expect non-escaped input.

--- a/src/wp-includes/sitemaps/providers/class-wp-sitemaps-posts.php
+++ b/src/wp-includes/sitemaps/providers/class-wp-sitemaps-posts.php
@@ -221,7 +221,7 @@ class WP_Sitemaps_Posts extends WP_Sitemaps_Provider {
 				'no_found_rows'          => true,
 				'update_post_term_cache' => false,
 				'update_post_meta_cache' => false,
-				'ignore_sticky_posts'    => true, // sticky posts will still appear, but they won't be moved to the front.
+				'ignore_sticky_posts'    => true, // Sticky posts will still appear, but they won't be moved to the front.
 			),
 			$post_type
 		);

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -390,8 +390,8 @@ function is_taxonomy_hierarchical( $taxonomy ) {
  *
  * @global WP_Taxonomy[] $wp_taxonomies Registered taxonomies.
  *
- * @param string       $taxonomy    Taxonomy key, must not exceed 32 characters and may only contain lowercase alphanumeric
- *                                  characters, dashes, and underscores. See sanitize_key().
+ * @param string       $taxonomy    Taxonomy key. Must not exceed 32 characters and may only contain
+ *                                  lowercase alphanumeric characters, dashes, and underscores. See sanitize_key().
  * @param array|string $object_type Object type or array of object types with which the taxonomy should be associated.
  * @param array|string $args        {
  *     Optional. Array or query string of arguments for registering a taxonomy.

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -3567,7 +3567,7 @@ function _wp_customize_publish_changeset( $new_status, $old_status, $changeset_p
 		remove_action( 'customize_register', array( $wp_customize, 'register_controls' ) );
 		$wp_customize->register_controls();
 
-		/** This filter is documented in /wp-includes/class-wp-customize-manager.php */
+		/** This filter is documented in wp-includes/class-wp-customize-manager.php */
 		do_action( 'customize_register', $wp_customize );
 	}
 	$wp_customize->_publish_changeset_values( $changeset_post->ID );

--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -322,7 +322,7 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 	 * Saves the action and filter-related globals so they can be restored later.
 	 *
 	 * Stores $wp_actions, $wp_current_filter, and $wp_filter on a class variable
-	 * so they can be restored on tearDown() using _restore_hooks().
+	 * so they can be restored on tear_down() using _restore_hooks().
 	 *
 	 * @global array $wp_actions
 	 * @global array $wp_current_filter
@@ -340,7 +340,7 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 	}
 
 	/**
-	 * Restores the hook-related globals to their state at setUp()
+	 * Restores the hook-related globals to their state at set_up()
 	 * so that future tests aren't affected by hooks set during this last test.
 	 *
 	 * @global array $wp_actions
@@ -1365,11 +1365,12 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 	/**
 	 * Deletes files added to the `uploads` directory during tests.
 	 *
-	 * This method works in tandem with the `setUp()` and `rmdir()` methods:
-	 * - `setUp()` scans the `uploads` directory before every test, and stores its contents inside of the
-	 *   `$ignore_files` property.
-	 * - `rmdir()` and its helper methods only delete files that are not listed in the `$ignore_files` property. If
-	 *   called during `tearDown()` in tests, this will only delete files added during the previously run test.
+	 * This method works in tandem with the `set_up()` and `rmdir()` methods:
+	 * - `set_up()` scans the `uploads` directory before every test, and stores
+	 *   its contents inside of the `$ignore_files` property.
+	 * - `rmdir()` and its helper methods only delete files that are not listed
+	 *   in the `$ignore_files` property. If called during `tear_down()` in tests,
+	 *   this will only delete files added during the previously run test.
 	 */
 	public function remove_added_uploads() {
 		$uploads = wp_upload_dir();

--- a/tests/phpunit/includes/testcase-canonical.php
+++ b/tests/phpunit/includes/testcase-canonical.php
@@ -37,7 +37,7 @@ abstract class WP_Canonical_UnitTestCase extends WP_UnitTestCase {
 	/**
 	 * Generate fixtures to be shared between canonical tests.
 	 *
-	 * Abstracted here because it's invoked by setUpBeforeClass() in more than one class.
+	 * Abstracted here because it's invoked by wpSetUpBeforeClass() in more than one class.
 	 *
 	 * @since 4.1.0
 	 */
@@ -46,7 +46,7 @@ abstract class WP_Canonical_UnitTestCase extends WP_UnitTestCase {
 		self::$author_id        = $factory->user->create( array( 'user_login' => 'canonical-author' ) );
 
 		/*
-		 * Also set in self::setUp(), but we must configure here to make sure that
+		 * Also set in self::set_up(), but we must configure here to make sure that
 		 * post authorship is properly attributed for fixtures.
 		 */
 		wp_set_current_user( self::$author_id );

--- a/tests/phpunit/includes/utils.php
+++ b/tests/phpunit/includes/utils.php
@@ -459,12 +459,12 @@ function gen_tests_array( $name, $array ) {
 }
 
 /**
- * Use to create objects by yourself
+ * Use to create objects by yourself.
  */
 class MockClass extends stdClass {}
 
 /**
- * Drops all tables from the WordPress database
+ * Drops all tables from the WordPress database.
  */
 function drop_tables() {
 	global $wpdb;

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -123,6 +123,25 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		$this->assertSame( WP_TEMPLATE_PART_AREA_HEADER, $template_part->area );
 	}
 
+	/**
+	 * Tests that _build_block_template_result_from_post() returns the correct theme
+	 * for the template when a child theme is active.
+	 *
+	 * @ticket 55437
+	 *
+	 * @covers ::_build_block_template_result_from_post
+	 */
+	function test_build_block_template_result_from_post_with_child_theme() {
+		switch_theme( 'block-theme-child' );
+
+		$template = _build_block_template_result_from_post(
+			self::$template_post,
+			'wp_template'
+		);
+
+		$this->assertSame( self::TEST_THEME, $template->theme );
+	}
+
 	function test_build_block_template_result_from_file() {
 		$template = _build_block_template_result_from_file(
 			array(
@@ -159,6 +178,29 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		$this->assertSame( '', $template_part->description );
 		$this->assertSame( 'wp_template_part', $template_part->type );
 		$this->assertSame( WP_TEMPLATE_PART_AREA_HEADER, $template_part->area );
+	}
+
+	/**
+	 * Tests that _build_block_template_result_from_file() returns the correct theme
+	 * for the template when a child theme is active.
+	 *
+	 * @ticket 55437
+	 *
+	 * @covers ::_build_block_template_result_from_file
+	 */
+	function test_build_block_template_result_from_file_with_child_theme() {
+		switch_theme( 'block-theme-child' );
+
+		$template = _build_block_template_result_from_file(
+			array(
+				'slug'  => 'single',
+				'path'  => __DIR__ . '/../data/templates/template.html',
+				'theme' => self::TEST_THEME,
+			),
+			'wp_template'
+		);
+
+		$this->assertSame( self::TEST_THEME, $template->theme );
 	}
 
 	function test_inject_theme_attribute_in_block_template_content() {

--- a/tests/phpunit/tests/customize/custom-css-setting.php
+++ b/tests/phpunit/tests/customize/custom-css-setting.php
@@ -25,7 +25,7 @@ class Test_WP_Customize_Custom_CSS_Setting extends WP_UnitTestCase {
 	/**
 	 * Set up the test case.
 	 *
-	 * @see WP_UnitTestCase::setup()
+	 * @see WP_UnitTestCase_Base::set_up()
 	 */
 	public function set_up() {
 		parent::set_up();

--- a/tests/phpunit/tests/customize/nav-menu-item-setting.php
+++ b/tests/phpunit/tests/customize/nav-menu-item-setting.php
@@ -16,7 +16,7 @@ class Test_WP_Customize_Nav_Menu_Item_Setting extends WP_UnitTestCase {
 	/**
 	 * Set up a test case.
 	 *
-	 * @see WP_UnitTestCase::setup()
+	 * @see WP_UnitTestCase_Base::set_up()
 	 */
 	public function set_up() {
 		parent::set_up();

--- a/tests/phpunit/tests/customize/nav-menu-setting.php
+++ b/tests/phpunit/tests/customize/nav-menu-setting.php
@@ -17,7 +17,7 @@ class Test_WP_Customize_Nav_Menu_Setting extends WP_UnitTestCase {
 	/**
 	 * Set up a test case.
 	 *
-	 * @see WP_UnitTestCase::setup()
+	 * @see WP_UnitTestCase_Base::set_up()
 	 */
 	public function set_up() {
 		parent::set_up();

--- a/tests/phpunit/tests/customize/nav-menus.php
+++ b/tests/phpunit/tests/customize/nav-menus.php
@@ -17,7 +17,7 @@ class Test_WP_Customize_Nav_Menus extends WP_UnitTestCase {
 	/**
 	 * Set up a test case.
 	 *
-	 * @see WP_UnitTestCase::setup()
+	 * @see WP_UnitTestCase_Base::set_up()
 	 */
 	public function set_up() {
 		parent::set_up();

--- a/tests/phpunit/tests/db/dbDelta.php
+++ b/tests/phpunit/tests/db/dbDelta.php
@@ -99,7 +99,7 @@ class Tests_DB_dbDelta extends WP_UnitTestCase {
 
 		parent::tear_down();
 
-		// This has to be called after the parent `tearDown()` method.
+		// This has to be called after the parent `tear_down()` method.
 		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}dbdelta_test" );
 	}
 

--- a/tests/phpunit/tests/functions.php
+++ b/tests/phpunit/tests/functions.php
@@ -2066,41 +2066,6 @@ class Tests_Functions extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket 49412
-	 * @covers ::wp_filesize
-	 */
-	function test_wp_filesize_with_nonexistent_file() {
-		$file = 'nonexistent/file.jpg';
-		$this->assertSame( 0, wp_filesize( $file ) );
-	}
-
-	/**
-	 * @ticket 49412
-	 * @covers ::wp_filesize
-	 */
-	function test_wp_filesize() {
-		$file = DIR_TESTDATA . '/images/test-image-upside-down.jpg';
-
-		$this->assertSame( filesize( $file ), wp_filesize( $file ) );
-
-		$filter = function() {
-			return 999;
-		};
-
-		add_filter( 'wp_filesize', $filter );
-
-		$this->assertSame( 999, wp_filesize( $file ) );
-
-		$pre_filter = function() {
-			return 111;
-		};
-
-		add_filter( 'pre_wp_filesize', $pre_filter );
-
-		$this->assertSame( 111, wp_filesize( $file ) );
-	}
-
-	/**
 	 * @ticket 55505
 	 * @covers ::wp_recursive_ksort
 	 */

--- a/tests/phpunit/tests/functions/sizeFormat.php
+++ b/tests/phpunit/tests/functions/sizeFormat.php
@@ -14,58 +14,58 @@ class Tests_Functions_SizeFormat extends WP_UnitTestCase {
 
 	public function _data_size_format() {
 		return array(
-			// Invalid values
+			// Invalid values.
 			array( array(), 0, false ),
 			array( 'baba', 0, false ),
 			array( '', 0, false ),
 			array( '-1', 0, false ),
 			array( -1, 0, false ),
-			// Bytes
+			// Bytes.
 			array( 0, 0, '0 B' ),
 			array( 1, 0, '1 B' ),
 			array( 1023, 0, '1,023 B' ),
-			// Kilobytes
+			// Kilobytes.
 			array( KB_IN_BYTES, 0, '1 KB' ),
 			array( KB_IN_BYTES, 2, '1.00 KB' ),
 			array( 2.5 * KB_IN_BYTES, 0, '3 KB' ),
 			array( 2.5 * KB_IN_BYTES, 2, '2.50 KB' ),
 			array( 10 * KB_IN_BYTES, 0, '10 KB' ),
-			// Megabytes
+			// Megabytes.
 			array( (string) 1024 * KB_IN_BYTES, 2, '1.00 MB' ),
 			array( MB_IN_BYTES, 0, '1 MB' ),
 			array( 2.5 * MB_IN_BYTES, 0, '3 MB' ),
 			array( 2.5 * MB_IN_BYTES, 2, '2.50 MB' ),
-			// Gigabytes
+			// Gigabytes.
 			array( (string) 1024 * MB_IN_BYTES, 2, '1.00 GB' ),
 			array( GB_IN_BYTES, 0, '1 GB' ),
 			array( 2.5 * GB_IN_BYTES, 0, '3 GB' ),
 			array( 2.5 * GB_IN_BYTES, 2, '2.50 GB' ),
-			// Terabytes
+			// Terabytes.
 			array( (string) 1024 * GB_IN_BYTES, 2, '1.00 TB' ),
 			array( TB_IN_BYTES, 0, '1 TB' ),
 			array( 2.5 * TB_IN_BYTES, 0, '3 TB' ),
 			array( 2.5 * TB_IN_BYTES, 2, '2.50 TB' ),
-			// Petabytes
+			// Petabytes.
 			array( (string) 1024 * TB_IN_BYTES, 2, '1.00 PB' ),
 			array( PB_IN_BYTES, 0, '1 PB' ),
 			array( 2.5 * PB_IN_BYTES, 0, '3 PB' ),
 			array( 2.5 * PB_IN_BYTES, 2, '2.50 PB' ),
-			// Exabytes
+			// Exabytes.
 			array( (string) 1024 * PB_IN_BYTES, 2, '1.00 EB' ),
 			array( EB_IN_BYTES, 0, '1 EB' ),
 			array( 2.5 * EB_IN_BYTES, 0, '3 EB' ),
 			array( 2.5 * EB_IN_BYTES, 2, '2.50 EB' ),
-			// Zettabytes
+			// Zettabytes.
 			array( (string) 1024 * EB_IN_BYTES, 2, '1.00 ZB' ),
 			array( ZB_IN_BYTES, 0, '1 ZB' ),
 			array( 2.5 * ZB_IN_BYTES, 0, '3 ZB' ),
 			array( 2.5 * ZB_IN_BYTES, 2, '2.50 ZB' ),
-			// Yottabytes
+			// Yottabytes.
 			array( (string) 1024 * ZB_IN_BYTES, 2, '1.00 YB' ),
 			array( YB_IN_BYTES, 0, '1 YB' ),
 			array( 2.5 * YB_IN_BYTES, 0, '3 YB' ),
 			array( 2.5 * YB_IN_BYTES, 2, '2.50 YB' ),
-			// Edge values
+			// Edge values.
 			array( TB_IN_BYTES + ( TB_IN_BYTES / 2 ) + MB_IN_BYTES, 1, '1.5 TB' ),
 			array( TB_IN_BYTES - MB_IN_BYTES - KB_IN_BYTES, 3, '1,023.999 GB' ),
 		);

--- a/tests/phpunit/tests/functions/wpFilesize.php
+++ b/tests/phpunit/tests/functions/wpFilesize.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Tests for the wp_filesize() function.
+ *
+ * @group functions.php
+ * @covers ::wp_filesize
+ */
+class Tests_Functions_wpFilesize extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 49412
+	 */
+	public function test_wp_filesize() {
+		$file = DIR_TESTDATA . '/images/test-image-upside-down.jpg';
+
+		$this->assertSame( filesize( $file ), wp_filesize( $file ) );
+	}
+
+	/**
+	 * @ticket 49412
+	 */
+	public function test_wp_filesize_filters() {
+		$file = DIR_TESTDATA . '/images/test-image-upside-down.jpg';
+
+		add_filter(
+			'wp_filesize',
+			static function() {
+				return 999;
+			}
+		);
+
+		$this->assertSame( 999, wp_filesize( $file ) );
+
+		add_filter(
+			'pre_wp_filesize',
+			static function() {
+				return 111;
+			}
+		);
+
+		$this->assertSame( 111, wp_filesize( $file ) );
+	}
+
+	/**
+	 * @ticket 49412
+	 */
+	public function test_wp_filesize_with_nonexistent_file() {
+		$file = 'nonexistent/file.jpg';
+
+		$this->assertSame( 0, wp_filesize( $file ) );
+	}
+}

--- a/tests/phpunit/tests/functions/wpListSort.php
+++ b/tests/phpunit/tests/functions/wpListSort.php
@@ -12,7 +12,7 @@ class Tests_Functions_wpListSort extends WP_UnitTestCase {
 	 * @dataProvider data_test_wp_list_sort
 	 *
 	 * @param string|array $orderby Either the field name to order by or an array
-	 *                              of multiple orderby fields as $orderby => $order.
+	 *                              of multiple orderby fields as `$orderby => $order`.
 	 * @param string       $order   Either 'ASC' or 'DESC'.
 	 */
 	public function test_wp_list_sort( $list, $orderby, $order, $expected ) {
@@ -337,7 +337,7 @@ class Tests_Functions_wpListSort extends WP_UnitTestCase {
 	 * @dataProvider data_test_wp_list_sort_preserve_keys
 	 *
 	 * @param string|array $orderby Either the field name to order by or an array
-	 *                              of multiple orderby fields as $orderby => $order.
+	 *                              of multiple orderby fields as `$orderby => $order`.
 	 * @param string       $order   Either 'ASC' or 'DESC'.
 	 */
 	public function test_wp_list_sort_preserve_keys( $list, $orderby, $order, $expected ) {

--- a/tests/phpunit/tests/functions/wpListUtil.php
+++ b/tests/phpunit/tests/functions/wpListUtil.php
@@ -64,7 +64,8 @@ class Tests_Functions_wpListUtil extends WP_UnitTestCase {
 	 * @param array  $target_array The array to create the list from.
 	 * @param string $target_key   The key to pluck.
 	 * @param array  $expected     The expected array.
-	 * @param string $index_key    Optional. Field from the element to use as keys for the new array. Default null.
+	 * @param string $index_key    Optional. Field from the element to use as keys for the new array.
+	 *                             Default null.
 	 */
 	public function test_wp_list_util_pluck( $target_array, $target_key, $expected, $index_key = null ) {
 		$util   = new WP_List_Util( $target_array );
@@ -156,9 +157,11 @@ class Tests_Functions_wpListUtil extends WP_UnitTestCase {
 	 *
 	 * @param array  $expected      The expected array.
 	 * @param array  $target_array  The array to create a list from.
-	 * @param array  $orderby       Optional. Either the field name to order by or an array of multiple orderby fields as $orderby => $order.
+	 * @param array  $orderby       Optional. Either the field name to order by or an array
+	 *                              of multiple orderby fields as `$orderby => $order`.
 	 *                              Default empty array.
-	 * @param string $order         Optional. Either 'ASC' or 'DESC'. Only used if $orderby is a string. Default 'ASC'.
+	 * @param string $order         Optional. Either 'ASC' or 'DESC'. Only used if `$orderby`
+	 *                              is a string. Default 'ASC'.
 	 * @param bool   $preserve_keys Optional. Whether to preserve keys. Default false.
 	 */
 	public function test_wp_list_util_sort( $expected, $target_array, $orderby = array(), $order = 'ASC', $preserve_keys = false ) {
@@ -955,9 +958,11 @@ class Tests_Functions_wpListUtil extends WP_UnitTestCase {
 	 *
 	 * @param array  $expected      The expected array.
 	 * @param array  $target_array  The array to create a list from.
-	 * @param array  $orderby       Optional. Either the field name to order by or an array of multiple orderby fields as $orderby => $order.
+	 * @param array  $orderby       Optional. Either the field name to order by or an array
+	 *                              of multiple orderby fields as `$orderby => $order`.
 	 *                              Default empty array.
-	 * @param string $order         Optional. Either 'ASC' or 'DESC'. Only used if $orderby is a string. Default 'ASC'.
+	 * @param string $order         Optional. Either 'ASC' or 'DESC'. Only used if `$orderby`
+	 *                              is a string. Default 'ASC'.
 	 * @param bool   $preserve_keys Optional. Whether to preserve keys. Default false.
 	 */
 	public function test_wp_list_util_sort_php_7_or_greater( $expected, $target_array, $orderby = array(), $order = 'ASC', $preserve_keys = false ) {

--- a/tests/phpunit/tests/functions/wpNonceField.php
+++ b/tests/phpunit/tests/functions/wpNonceField.php
@@ -14,7 +14,6 @@ class Tests_Functions_wpNonceField extends WP_UnitTestCase {
 	 * @ticket 55578
 	 */
 	public function test_wp_nonce_field() {
-
 		wp_nonce_field();
 		$this->expectOutputRegex( '#^<input type="hidden" id="_wpnonce" name="_wpnonce" value=".{10}" /><input type="hidden" name="_wp_http_referer" value="" />$#' );
 	}
@@ -24,14 +23,13 @@ class Tests_Functions_wpNonceField extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_wp_nonce_field
 	 *
-	 * @param int|string $action Action name.
-	 * @param string     $name Nonce name.
-	 * @param bool       $referer Whether to set the referer field fior validation.
-	 * @param string     $expected_reg_exp The expected regular expression.
+	 * @param int|string $action          Action name.
+	 * @param string     $name            Nonce name.
+	 * @param bool       $referer         Whether to set the referer field for validation.
+	 * @param string     $expected_regexp The expected regular expression.
 	 */
-	public function test_wp_nonce_field_return( $action, $name, $referer, $expected_reg_exp ) {
-
-		$this->assertMatchesRegularExpression( $expected_reg_exp, wp_nonce_field( $action, $name, $referer, false ) );
+	public function test_wp_nonce_field_return( $action, $name, $referer, $expected_regexp ) {
+		$this->assertMatchesRegularExpression( $expected_regexp, wp_nonce_field( $action, $name, $referer, false ) );
 	}
 
 	/**
@@ -40,37 +38,36 @@ class Tests_Functions_wpNonceField extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function data_wp_nonce_field() {
-
 		return array(
 			'default'     => array(
-				'action'           => - 1,
-				'name'             => '_wpnonce',
-				'referer'          => true,
-				'expected_reg_exp' => '#^<input type="hidden" id="_wpnonce" name="_wpnonce" value=".{10}" /><input type="hidden" name="_wp_http_referer" value="" />$#',
+				'action'          => -1,
+				'name'            => '_wpnonce',
+				'referer'         => true,
+				'expected_regexp' => '#^<input type="hidden" id="_wpnonce" name="_wpnonce" value=".{10}" /><input type="hidden" name="_wp_http_referer" value="" />$#',
 			),
 			'nonce_name'  => array(
-				'action'           => - 1,
-				'name'             => 'nonce_name',
-				'referer'          => true,
-				'expected_reg_exp' => '#^<input type="hidden" id="nonce_name" name="nonce_name" value=".{10}" /><input type="hidden" name="_wp_http_referer" value="" />$#',
+				'action'          => -1,
+				'name'            => 'nonce_name',
+				'referer'         => true,
+				'expected_regexp' => '#^<input type="hidden" id="nonce_name" name="nonce_name" value=".{10}" /><input type="hidden" name="_wp_http_referer" value="" />$#',
 			),
 			'action_name' => array(
-				'action'           => 'action_name',
-				'name'             => '_wpnonce',
-				'referer'          => true,
-				'expected_reg_exp' => '#^<input type="hidden" id="_wpnonce" name="_wpnonce" value="' . wp_create_nonce( 'action_name' ) . '" /><input type="hidden" name="_wp_http_referer" value="" />$#',
+				'action'          => 'action_name',
+				'name'            => '_wpnonce',
+				'referer'         => true,
+				'expected_regexp' => '#^<input type="hidden" id="_wpnonce" name="_wpnonce" value="' . wp_create_nonce( 'action_name' ) . '" /><input type="hidden" name="_wp_http_referer" value="" />$#',
 			),
 			'no_referer'  => array(
-				'action'           => - 1,
-				'name'             => '_wpnonce',
-				'referer'          => false,
-				'expected_reg_exp' => '#^<input type="hidden" id="_wpnonce" name="_wpnonce" value=".{10}" />$#',
+				'action'          => -1,
+				'name'            => '_wpnonce',
+				'referer'         => false,
+				'expected_regexp' => '#^<input type="hidden" id="_wpnonce" name="_wpnonce" value=".{10}" />$#',
 			),
 			'& in name'   => array(
-				'action'           => - 1,
-				'name'             => 'a&b',
-				'referer'          => false,
-				'expected_reg_exp' => '#^<input type="hidden" id="a\&amp;b" name="a\&amp;b" value=".{10}" />$#',
+				'action'          => -1,
+				'name'            => 'a&b',
+				'referer'         => false,
+				'expected_regexp' => '#^<input type="hidden" id="a\&amp;b" name="a\&amp;b" value=".{10}" />$#',
 			),
 		);
 	}

--- a/tests/phpunit/tests/functions/wpRefererField.php
+++ b/tests/phpunit/tests/functions/wpRefererField.php
@@ -14,8 +14,8 @@ class Tests_Functions_wpRefererField extends WP_UnitTestCase {
 	 * @ticket 55578
 	 */
 	public function test_wp_referer_field() {
-
 		$_SERVER['REQUEST_URI'] = '/test/';
+
 		wp_referer_field();
 		$this->expectOutputString( '<input type="hidden" name="_wp_http_referer" value="/test/" />' );
 	}
@@ -24,7 +24,6 @@ class Tests_Functions_wpRefererField extends WP_UnitTestCase {
 	 * @ticket 55578
 	 */
 	public function test_wp_referer_field_return() {
-
 		$_SERVER['REQUEST_URI'] = '/test/';
 
 		$this->assertSame( '<input type="hidden" name="_wp_http_referer" value="/test/" />', wp_referer_field( false ) );

--- a/tests/phpunit/tests/media/wpGenerateAttachmentMetadata.php
+++ b/tests/phpunit/tests/media/wpGenerateAttachmentMetadata.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * Tests for the `wp_generate_attachment_metadata()` function.
+ *
+ * @group media
+ * @covers ::wp_generate_attachment_metadata
+ */
+class Tests_Media_wpGenerateAttachmentMetadata extends WP_UnitTestCase {
+
+	public function tear_down() {
+		$this->remove_added_uploads();
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Tests that filesize meta is generated for JPEGs.
+	 *
+	 * @ticket 49412
+	 *
+	 * @covers ::wp_create_image_subsizes
+	 */
+	public function test_wp_generate_attachment_metadata_includes_filesize_in_jpg_meta() {
+		$attachment = $this->factory->attachment->create_upload_object( DIR_TESTDATA . '/images/canola.jpg' );
+
+		$metadata = wp_get_attachment_metadata( $attachment );
+
+		$this->assertSame( wp_filesize( get_attached_file( $attachment ) ), $metadata['filesize'] );
+
+		foreach ( $metadata['sizes'] as $intermediate_size ) {
+			$this->assertArrayHasKey( 'filesize', $intermediate_size );
+			$this->assertNotEmpty( $intermediate_size['filesize'] );
+			$this->assertIsNumeric( $intermediate_size['filesize'] );
+		}
+	}
+
+	/**
+	 * Checks that filesize meta is generated for PNGs.
+	 *
+	 * @ticket 49412
+	 *
+	 * @covers ::wp_create_image_subsizes
+	 */
+	public function test_wp_generate_attachment_metadata_includes_filesize_in_png_meta() {
+		$attachment = $this->factory->attachment->create_upload_object( DIR_TESTDATA . '/images/test-image.png' );
+
+		$metadata = wp_get_attachment_metadata( $attachment );
+
+		$this->assertSame( wp_filesize( get_attached_file( $attachment ) ), $metadata['filesize'] );
+	}
+
+	/**
+	 * Checks that filesize meta is generated for PDFs.
+	 *
+	 * @ticket 49412
+	 */
+	public function test_wp_generate_attachment_metadata_includes_filesize_in_pdf_meta() {
+		$attachment = $this->factory->attachment->create_upload_object( DIR_TESTDATA . '/images/wordpress-gsoc-flyer.pdf' );
+
+		$metadata = wp_get_attachment_metadata( $attachment );
+
+		$this->assertSame( wp_filesize( get_attached_file( $attachment ) ), $metadata['filesize'] );
+	}
+
+	/**
+	 * Checks that filesize meta is generated for PSDs.
+	 *
+	 * @ticket 49412
+	 */
+	public function test_wp_generate_attachment_metadata_includes_filesize_in_psd_meta() {
+		if ( is_multisite() ) {
+			// PSD mime type is not allowed by default on multisite.
+			add_filter(
+				'upload_mimes',
+				static function( $mimes ) {
+					$mimes['psd'] = 'application/octet-stream';
+					return $mimes;
+				}
+			);
+		}
+
+		$attachment = $this->factory->attachment->create_upload_object( DIR_TESTDATA . '/images/test-image.psd' );
+
+		$metadata = wp_get_attachment_metadata( $attachment );
+
+		$this->assertSame( wp_filesize( get_attached_file( $attachment ) ), $metadata['filesize'] );
+	}
+}

--- a/tests/phpunit/tests/media/wpImageTagAddDecodingAttr.php
+++ b/tests/phpunit/tests/media/wpImageTagAddDecodingAttr.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Tests the `wp_img_tag_add_decoding_attr()` function.
+ * Tests for the `wp_img_tag_add_decoding_attr()` function.
  *
  * @group media
  * @covers ::wp_img_tag_add_decoding_attr

--- a/tests/phpunit/tests/multisite/msFilesRewriting.php
+++ b/tests/phpunit/tests/multisite/msFilesRewriting.php
@@ -72,6 +72,8 @@ if ( is_multisite() ) :
 			// The file on the main site should still exist. The file on the deleted site should not.
 			$this->assertFileExists( $file1['file'] );
 			$this->assertFileDoesNotExist( $file2['file'] );
+
+			unlink( $file1['file'] );
 		}
 	}
 

--- a/tests/phpunit/tests/multisite/site.php
+++ b/tests/phpunit/tests/multisite/site.php
@@ -398,6 +398,8 @@ if ( is_multisite() ) :
 			// The file on the main site should still exist. The file on the deleted site should not.
 			$this->assertFileExists( $file1['file'] );
 			$this->assertFileDoesNotExist( $file2['file'] );
+
+			unlink( $file1['file'] );
 		}
 
 		public function test_wpmu_update_blogs_date() {

--- a/tests/phpunit/tests/query/postStatus.php
+++ b/tests/phpunit/tests/query/postStatus.php
@@ -87,7 +87,7 @@ class Tests_Query_PostStatus extends WP_UnitTestCase {
 	 * Register custom post types and statuses used in multiple tests.
 	 *
 	 * CPTs and CPSs are reset between each test run so need to be registered
-	 * in both the wpSetUpBeforeClass() and setUp() methods.
+	 * in both the wpSetUpBeforeClass() and set_up() methods.
 	 */
 	public static function register_custom_post_objects() {
 		register_post_type(

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -1529,6 +1529,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 
 	/**
 	 * @ticket 55592
+	 *
 	 * @covers WP_REST_Posts_Controller::get_items
 	 * @covers ::update_post_thumbnail_cache
 	 */
@@ -1566,6 +1567,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 
 	/**
 	 * @ticket 55593
+	 *
 	 * @covers WP_REST_Posts_Controller::get_items
 	 * @covers ::update_post_parent_caches
 	 */

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -3026,7 +3026,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Testing that dynamic properties in theme.json return the value they refrence,
+	 * Testing that dynamic properties in theme.json return the value they reference,
 	 * e.g. array( 'ref' => 'styles.color.background' ) => "#ffffff".
 	 *
 	 * @ticket 56467

--- a/tests/phpunit/tests/user/capabilities.php
+++ b/tests/phpunit/tests/user/capabilities.php
@@ -1707,7 +1707,7 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 	}
 
 	public function nullify_current_user() {
-		// Prevents fatal errors in ::tearDown()'s and other uses of restore_current_blog().
+		// Prevents fatal errors in ::tear_down()'s and other uses of restore_current_blog().
 		$function_stack = wp_debug_backtrace_summary( null, 0, false );
 		if ( in_array( 'restore_current_blog', $function_stack, true ) ) {
 			return;


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

From documentation on the return value of `get_the_terms()`, and the usage of `get_the_category()`, it may be assumed that this function may be used in `$term = get_the_terms( null, 'category' );`.

Trac ticket: https://core.trac.wordpress.org/ticket/57131

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
