### PR TITLE
57145

### DIFF
--- a/src/js/_enqueues/admin/site-health.js
+++ b/src/js/_enqueues/admin/site-health.js
@@ -429,6 +429,7 @@ jQuery( function( $ ) {
 		} );
 
 		copyButton.attr( 'data-clipboard-text', clipboardText );
+		copyButton.removeAttr( 'disabled ');
 
 		pathsSizesSection.find( 'td[class]' ).each( function( i, element ) {
 			var td = $( element );

--- a/src/wp-admin/site-health-info.php
+++ b/src/wp-admin/site-health-info.php
@@ -49,7 +49,7 @@ $health_check_site_status = WP_Site_Health::get_instance();
 
 	<div class="site-health-copy-buttons">
 		<div class="copy-button-wrapper">
-			<button type="button" class="button copy-button" data-clipboard-text="<?php echo esc_attr( WP_Debug_Data::format( $info, 'debug' ) ); ?>">
+			<button type="button" class="button copy-button" data-clipboard-text="<?php echo esc_attr( WP_Debug_Data::format( $info, 'debug' ) ); ?>" disabled>
 				<?php _e( 'Copy site info to clipboard' ); ?>
 			</button>
 			<span class="success hidden" aria-hidden="true"><?php _e( 'Copied!' ); ?></span>

--- a/src/wp-includes/class-wp-list-util.php
+++ b/src/wp-includes/class-wp-list-util.php
@@ -158,7 +158,7 @@ class WP_List_Util {
 	public function pluck( $field, $index_key = null ) {
 		$newlist = array();
 
-		if ( ! $index_key ) {
+		if ( is_null( $index_key ) ) {
 			/*
 			 * This is simple. Could at some point wrap array_column()
 			 * if we knew we had an array of arrays.

--- a/src/wp-includes/class-wp-list-util.php
+++ b/src/wp-includes/class-wp-list-util.php
@@ -158,7 +158,7 @@ class WP_List_Util {
 	public function pluck( $field, $index_key = null ) {
 		$newlist = array();
 
-		if ( is_null( $index_key ) ) {
+		if ( ! $index_key ) {
 			/*
 			 * This is simple. Could at some point wrap array_column()
 			 * if we knew we had an array of arrays.


### PR DESCRIPTION
In the (German) support forums we frequently ask people to provide more information about their website and refer to the button "Copy site info to clipboard" in Tools > Site Health > Info. Often users try to react immediately and spontanously click the button before the health check is completed and the status is shown above. This results in an incomplete report, showing the text "loading …" for the size of the entire website and some subdirectories. We are then missing an important piece of information to fully evaluate the website.

As an enhancement I kindly suggest that the button gets grayed out until the Health Check is completed.

Trac ticket: https://core.trac.wordpress.org/ticket/57145

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
