### PR TITLE
Twenty Twenty-Three: Try replacing base and contrast with ref values

### DIFF
--- a/src/wp-content/themes/twentytwentythree/styles/aubergine.json
+++ b/src/wp-content/themes/twentytwentythree/styles/aubergine.json
@@ -6,14 +6,14 @@
 		"color": {
 			"gradients": [
 				{
-					"gradient": "linear-gradient(180deg, var(--wp--preset--color--secondary) 0%,var(--wp--preset--color--base) 100%)",
-					"name": "Secondary to Base",
-					"slug": "secondary-base"
+					"gradient": "linear-gradient(180deg, var(--wp--preset--color--secondary) 0%,var(--wp--preset--color--dark-purple) 100%)",
+					"name": "Secondary to Dark Purple",
+					"slug": "secondary-dark-purple"
 				},
 				{
-					"gradient": "linear-gradient(180deg, var(--wp--preset--color--base) 0 min(24rem, 10%), var(--wp--preset--color--secondary) 0% 30%, var(--wp--preset--color--base) 100%)",
-					"name": "Base to Secondary to Base",
-					"slug": "base-secondary-base"
+					"gradient": "linear-gradient(180deg, var(--wp--preset--color--dark-purple) 0 min(24rem, 10%), var(--wp--preset--color--secondary) 0% 30%, var(--wp--preset--color--dark-purple) 100%)",
+					"name": "Dark Purple to Secondary to Dark Purple",
+					"slug": "dark-purple-secondary-dark-purple"
 				},
 				{
 					"gradient": "linear-gradient(90deg, var(--wp--preset--color--tertiary) 5.74%, var(--wp--preset--color--primary) 100%);",
@@ -28,16 +28,6 @@
 			],
 			"palette": [
 				{
-					"color": "#1B1031",
-					"name": "Base",
-					"slug": "base"
-				},
-				{
-					"color": "#FFFFFF",
-					"name": "Contrast",
-					"slug": "contrast"
-				},
-				{
 					"color": "#FF746D",
 					"name": "Primary",
 					"slug": "primary"
@@ -51,6 +41,11 @@
 					"color": "#FB326B",
 					"name": "Tertiary",
 					"slug": "tertiary"
+				},
+				{
+					"color": "#1B1031",
+					"name": "Dark Purple",
+					"slug": "dark-purple"
 				}
 			]
 		},
@@ -138,7 +133,9 @@
 				"elements": {
 					"link": {
 						"color": {
-							"text": "var(--wp--preset--color--contrast)"
+							"text": {
+								"ref": "styles.color.text"
+							}
 						},
 						"typography": {
 							"letterSpacing": "0.09rem",
@@ -164,7 +161,12 @@
 					"link": {
 						":active": {
 							"color": {
-								"text": "var(--wp--preset--color--contrast)"
+								"background": {
+									"ref": "styles.color.background"
+								},
+								"text": {
+									"ref": "styles.color.text"
+								}
 							}
 						}
 					}
@@ -234,7 +236,9 @@
 			}
 		},
 		"color": {
-			"gradient": "var(--wp--preset--gradient--base-secondary-base) no-repeat"
+			"background": "#1B1031",
+			"gradient": "var(--wp--preset--gradient--dark-purple-secondary-dark-purple) no-repeat",
+			"text": "#FFFFFF"
 		},
 		"elements": {
 			"button": {
@@ -243,7 +247,9 @@
 				},
 				"color": {
 					"gradient": "var(--wp--preset--gradient--tertiary-primary)",
-					"text": "var(--wp--preset--color--base)"
+					"text": {
+						"ref": "styles.color.background"
+					}
 				},
 				":hover": {
 					"color": {
@@ -268,7 +274,9 @@
 				},
 				":visited": {
 					"color": {
-						"text": "var(--wp--preset--color--base)"
+						"text": {
+							"ref": "styles.color.background"
+						}
 					}
 				}
 			},

--- a/src/wp-content/themes/twentytwentythree/styles/aubergine.json
+++ b/src/wp-content/themes/twentytwentythree/styles/aubergine.json
@@ -236,9 +236,9 @@
 			}
 		},
 		"color": {
-			"background": "#1B1031",
+			"background": "var(--wp--preset--color--dark-purple)",
 			"gradient": "var(--wp--preset--gradient--dark-purple-secondary-dark-purple) no-repeat",
-			"text": "#FFFFFF"
+			"text": "var(--wp--preset--color--white)"
 		},
 		"elements": {
 			"button": {

--- a/src/wp-content/themes/twentytwentythree/styles/block-out.json
+++ b/src/wp-content/themes/twentytwentythree/styles/block-out.json
@@ -192,8 +192,8 @@
 			}
 		},
 		"color": {
-			"background": "#ff5252",
-			"text": "#252525"
+			"background": "var(--wp--preset--color--block-out-red)",
+			"text": "var(--wp--preset--color--dark-grey)"
 		},
 		"elements": {
 			"button": {

--- a/src/wp-content/themes/twentytwentythree/styles/block-out.json
+++ b/src/wp-content/themes/twentytwentythree/styles/block-out.json
@@ -16,16 +16,6 @@
 			],
 			"palette": [
 				{
-					"color": "#ff5252",
-					"name": "Base",
-					"slug": "base"
-				},
-				{
-					"color": "#252525",
-					"name": "Contrast",
-					"slug": "contrast"
-				},
-				{
 					"color": "#ffffff",
 					"name": "Primary",
 					"slug": "primary"
@@ -39,6 +29,16 @@
 					"color": "#ff7e7e",
 					"name": "Tertiary",
 					"slug": "tertiary"
+				},
+				{
+					"color": "#ff5252",
+					"name": "Block out Red",
+					"slug": "block-out-red"
+				},
+				{
+					"color": "#252525",
+					"name": "Dark Grey",
+					"slug": "dark-grey"
 				}
 			]
 		},
@@ -108,12 +108,16 @@
 				"elements": {
 					"link": {
 						"color": {
-							"text": "var(--wp--preset--color--contrast)"
+							"text": {
+								"ref": "styles.color.text"
+							}
 						}
 					},
 					"h1": {
 						"color": {
-							"text": "var(--wp--preset--color--contrast)"
+							"text": {
+								"ref": "styles.color.text"
+							}
 						}
 					}
 				}
@@ -187,6 +191,10 @@
 				}
 			}
 		},
+		"color": {
+			"background": "#ff5252",
+			"text": "#252525"
+		},
 		"elements": {
 			"button": {
 				"border": {
@@ -199,7 +207,9 @@
 				},
 				":active": {
 					"color": {
-						"text": "var(--wp--preset--color--contrast)"
+						"text": {
+							"ref": "styles.color.text"
+						}
 					}
 				}
 			},

--- a/src/wp-content/themes/twentytwentythree/styles/canary.json
+++ b/src/wp-content/themes/twentytwentythree/styles/canary.json
@@ -16,16 +16,6 @@
 			],
 			"palette": [
 				{
-					"color": "#fdff85",
-					"name": "Base",
-					"slug": "base"
-				},
-				{
-					"color": "#000000",
-					"name": "Contrast",
-					"slug": "contrast"
-				},
-				{
 					"color": "#000000",
 					"name": "Primary",
 					"slug": "primary"
@@ -39,6 +29,11 @@
 					"color": "#ffffff",
 					"name": "Tertiary",
 					"slug": "tertiary"
+				},
+				{
+					"color": "#fdff85",
+					"name": "Canary Yellow",
+					"slug": "canary-yellow"
 				}
 			]
 		},
@@ -165,43 +160,65 @@
 				}
 			}
 		},
+		"color": {
+			"background": "#fdff85",
+			"text": "#000000"
+		},
 		"elements": {
 			"button": {
 				":hover": {
 					"color": {
-						"background": "var(--wp--preset--color--base)",
-						"text": "var(--wp--preset--color--contrast)"
+						"background": {
+							"ref": "styles.color.background"
+						},
+						"text": {
+							"ref": "styles.color.text"
+						}
 					},
 					"border": {
-						"color": "var(--wp--preset--color--contrast)",
+						"color": {
+							"ref": "styles.color.text"
+						},
 						"style": "solid",
 						"width": "2px"
 					}
 				},
 				":focus": {
 					"color": {
-						"background": "var(--wp--preset--color--base)",
-						"text": "var(--wp--preset--color--contrast)"
+						"background": {
+							"ref": "styles.color.background"
+						},
+						"text": {
+							"ref": "styles.color.text"
+						}
 					},
 					"border": {
-						"color": "var(--wp--preset--color--contrast)",
+						"color": {
+							"ref": "styles.color.text"
+						},
 						"style": "solid",
 						"width": "2px"
 					}
 				},
 				":visited": {
 					"color": {
-						"text": "var(--wp--preset--color--base)"
+						"text": {
+							"ref": "styles.color.background"
+						}
 					}
 				},
 				"border": {
 					"radius": "5px",
-					"color": "var(--wp--preset--color--contrast)",
+					"color": {
+						"ref": "styles.color.text"
+					},
 					"style": "solid",
 					"width": "2px"
 				},
 				"color": {
-					"text": "var(--wp--preset--color--base)"
+					"text": {
+						"ref": "styles.color.background"
+					}
 				},
 				"spacing": {
 					"padding": {

--- a/src/wp-content/themes/twentytwentythree/styles/canary.json
+++ b/src/wp-content/themes/twentytwentythree/styles/canary.json
@@ -161,8 +161,8 @@
 			}
 		},
 		"color": {
-			"background": "#fdff85",
-			"text": "#000000"
+			"background": "var(--wp--preset--color--canary-yellow)",
+			"text": "var(--wp--preset--color--black)"
 		},
 		"elements": {
 			"button": {

--- a/src/wp-content/themes/twentytwentythree/styles/electric.json
+++ b/src/wp-content/themes/twentytwentythree/styles/electric.json
@@ -7,16 +7,6 @@
 			"palette": [
 				{
 					"color": "#f3f3f1",
-					"name": "Base",
-					"slug": "base"
-				},
-				{
-					"color": "#2500ff",
-					"name": "Contrast",
-					"slug": "contrast"
-				},
-				{
-					"color": "#f3f3f1",
 					"name": "Primary",
 					"slug": "primary"
 				},
@@ -34,16 +24,26 @@
 		}
 	},
 	"styles": {
+		"color": {
+			"background": "#f3f3f1",
+			"text": "#2500ff"
+		},
 		"elements": {
 			"button": {
 				"border": {
 					"style": "solid",
 					"width": "2px",
-					"color": "var(--wp--preset--color--contrast)"
+					"color": {
+						"ref": "styles.color.text"
+					}
 				},
 				"color": {
-					"background": "var(--wp--preset--color--contrast)",
-					"text": "var(--wp--preset--color--base)"
+					"background": {
+						"ref": "styles.color.text"
+					},
+					"text": {
+						"ref": "styles.color.background"
+					}
 				},
 				"spacing": {
 					"padding": {
@@ -65,18 +65,26 @@
 				},
 				":hover": {
 					"border": {
-						"color": "var(--wp--preset--color--contrast)",
+						"color": {
+							"ref": "styles.color.text"
+						},
 						"style": "solid",
 						"width": "2px"
 					},
 					"color": {
-						"background": "var(--wp--preset--color--base)",
-						"text": "var(--wp--preset--color--contrast)"
+						"background": {
+							"ref": "styles.color.background"
+						},
+						"text": {
+							"ref": "styles.color.text"
+						}
 					}
 				},
 				":visited": {
 					"color": {
-						"text": "var(--wp--preset--color--base)"
+						"text": {
+							"ref": "styles.color.background"
+						}
 					}
 				}
 			},

--- a/src/wp-content/themes/twentytwentythree/styles/electric.json
+++ b/src/wp-content/themes/twentytwentythree/styles/electric.json
@@ -25,8 +25,8 @@
 	},
 	"styles": {
 		"color": {
-			"background": "#f3f3f1",
-			"text": "#2500ff"
+			"background": "var(--wp--preset--color--primary)",
+			"text": "var(--wp--preset--color--secondary)"
 		},
 		"elements": {
 			"button": {

--- a/src/wp-content/themes/twentytwentythree/styles/grapes.json
+++ b/src/wp-content/themes/twentytwentythree/styles/grapes.json
@@ -6,16 +6,6 @@
 		"color": {
 			"palette": [
 				{
-					"color": "#E1E1C7",
-					"name": "Base",
-					"slug": "base"
-				},
-				{
-					"color": "#000000",
-					"name": "Contrast",
-					"slug": "contrast"
-				},
-				{
 					"color": "#214F31",
 					"name": "Primary",
 					"slug": "primary"
@@ -29,6 +19,11 @@
 					"color": "#F0EBD2",
 					"name": "Tertiary",
 					"slug": "tertiary"
+				},
+				{
+					"color": "#E1E1C7",
+					"name": "Olive",
+					"slug": "olive"
 				}
 			]
 		}
@@ -64,6 +59,10 @@
 				}
 			}
 		},
+		"color": {
+			"background": "#E1E1C7",
+			"text": "#000000"
+		},
 		"elements": {
 			"button": {
 				"border": {
@@ -71,11 +70,15 @@
 				},
 				"color": {
 					"background": "var(--wp--preset--color--primary)",
-					"text": "var(--wp--preset--color--base)"
+					"text": {
+						"ref": "styles.color.background"
+					}
 				},
 				":visited": {
 					"color": {
-						"text": "var(--wp--preset--color--base)"
+						"text": {
+							"ref": "styles.color.background"
+						}
 					}
 				}
 			},

--- a/src/wp-content/themes/twentytwentythree/styles/grapes.json
+++ b/src/wp-content/themes/twentytwentythree/styles/grapes.json
@@ -60,8 +60,8 @@
 			}
 		},
 		"color": {
-			"background": "#E1E1C7",
-			"text": "#000000"
+			"background": "var(--wp--preset--color--olive)",
+			"text": "var(--wp--preset--color--black)"
 		},
 		"elements": {
 			"button": {

--- a/src/wp-content/themes/twentytwentythree/styles/marigold.json
+++ b/src/wp-content/themes/twentytwentythree/styles/marigold.json
@@ -216,8 +216,8 @@
 			}
 		},
 		"color": {
-			"background": "#F6F2EC",
-			"text": "#21251F"
+			"background": "var(--wp--preset--color--stone)",
+			"text": "var(--wp--preset--color--dark-grey)"
 		},
 		"elements": {
 			"h1": {

--- a/src/wp-content/themes/twentytwentythree/styles/marigold.json
+++ b/src/wp-content/themes/twentytwentythree/styles/marigold.json
@@ -6,16 +6,6 @@
 		"color": {
 			"palette": [
 				{
-					"color": "#F6F2EC",
-					"name": "Base",
-					"slug": "base"
-				},
-				{
-					"color": "#21251F",
-					"name": "Contrast",
-					"slug": "contrast"
-				},
-				{
 					"color": "#5B4460",
 					"name": "Primary",
 					"slug": "primary"
@@ -29,6 +19,16 @@
 					"color": "#E7A1A9",
 					"name": "Tertiary",
 					"slug": "tertiary"
+				},
+				{
+					"color": "#F6F2EC",
+					"name": "Stone",
+					"slug": "stone"
+				},
+				{
+					"color": "#21251F",
+					"name": "Dark Grey",
+					"slug": "dark-grey"
 				}
 			]
 		},
@@ -215,6 +215,10 @@
 				}
 			}
 		},
+		"color": {
+			"background": "#F6F2EC",
+			"text": "#21251F"
+		},
 		"elements": {
 			"h1": {
 				"typography": {
@@ -284,7 +288,9 @@
 				":hover": {
 					"color": {
 						"background": "var(--wp--preset--color--tertiary)",
-						"text": "var(--wp--preset--color--contrast)"
+						"text": {
+							"ref": "styles.color.text"
+						}
 					}
 				},
 				":focus": {

--- a/src/wp-content/themes/twentytwentythree/styles/pilgrimage.json
+++ b/src/wp-content/themes/twentytwentythree/styles/pilgrimage.json
@@ -36,27 +36,17 @@
 					"slug": "tertiary-primary"
 				},
 				{
-					"gradient": "linear-gradient(180deg, var(--wp--preset--color--base) 0%,var(--wp--preset--color--primary) 350%)",
-					"name": "Base to Primary",
-					"slug": "base-primary"
+					"gradient": "linear-gradient(180deg, var(--wp--preset--color--dark-grey) 0%,var(--wp--preset--color--primary) 350%)",
+					"name": "Dark Grey to Primary",
+					"slug": "dark-grey-primary"
 				},
 				{
-					"gradient": "radial-gradient(circle at 5px 5px,#0c0d0d70 2px,#ffffff00 0px,#ffffff00 0px) 0 0 / 8px 8px, linear-gradient(180deg, var(--wp--preset--color--base) 0%,#000000 200%)",
+					"gradient": "radial-gradient(circle at 5px 5px,#0c0d0d70 2px,#ffffff00 0px,#ffffff00 0px) 0 0 / 8px 8px, linear-gradient(180deg, var(--wp--preset--color--dark-grey) 0%,#000000 200%)",
 					"name": "Dots",
 					"slug": "dots"
 				}
 			],
 			"palette": [
-				{
-					"color": "#222828",
-					"name": "Base",
-					"slug": "base"
-				},
-				{
-					"color": "#ffffff",
-					"name": "Contrast",
-					"slug": "contrast"
-				},
 				{
 					"color": "#53ED85",
 					"name": "Primary",
@@ -71,6 +61,11 @@
 					"color": "#D8E202",
 					"name": "Tertiary",
 					"slug": "tertiary"
+				},
+				{
+					"color": "#222828",
+					"name": "Dark Grey",
+					"slug": "dark-grey"
 				}
 			]
 		}
@@ -230,7 +225,9 @@
 			}
 		},
 		"color": {
-			"gradient": "var(--wp--preset--gradient--dots)"
+			"background": "#222828",
+			"gradient": "var(--wp--preset--gradient--dots)",
+			"text": "#ffffff"
 		},
 		"elements": {
 			"button": {
@@ -252,7 +249,9 @@
 				},
 				":visited": {
 					"color": {
-						"text": "var(--wp--preset--color--base)"
+						"text": {
+							"ref": "styles.color.background"
+						}
 					}
 				},
 				"border": {
@@ -260,7 +259,9 @@
 				},
 				"color": {
 					"gradient": "var(--wp--preset--gradient--primary-secondary)",
-					"text": "var(--wp--preset--color--base)"
+					"text": {
+						"ref": "styles.color.background"
+					}
 				}
 			},
 			"h1": {

--- a/src/wp-content/themes/twentytwentythree/styles/pilgrimage.json
+++ b/src/wp-content/themes/twentytwentythree/styles/pilgrimage.json
@@ -225,9 +225,9 @@
 			}
 		},
 		"color": {
-			"background": "#222828",
+			"background": "var(--wp--preset--color--dark-grey)",
 			"gradient": "var(--wp--preset--gradient--dots)",
-			"text": "#ffffff"
+			"text": "var(--wp--preset--color--white)"
 		},
 		"elements": {
 			"button": {

--- a/src/wp-content/themes/twentytwentythree/styles/pitch.json
+++ b/src/wp-content/themes/twentytwentythree/styles/pitch.json
@@ -6,16 +6,6 @@
 		"color": {
 			"palette": [
 				{
-					"color": "#202124",
-					"name": "Base",
-					"slug": "base"
-				},
-				{
-					"color": "#e8eaed",
-					"name": "Contrast",
-					"slug": "contrast"
-				},
-				{
 					"color": "#e3cbc0",
 					"name": "Primary",
 					"slug": "primary"
@@ -29,6 +19,16 @@
 					"color": "#303134",
 					"name": "Tertiary",
 					"slug": "tertiary"
+				},
+				{
+					"color": "#202124",
+					"name": "Dark Grey",
+					"slug": "dark-grey"
+				},
+				{
+					"color": "#e8eaed",
+					"name": "Light Grey",
+					"slug": "light-grey"
 				}
 			]
 		},
@@ -144,6 +144,10 @@
 				}
 			}
 		},
+		"color": {
+			"background": "#202124",
+			"text": "#e8eaed"
+		},
 		"elements": {
 			"button": {
 				"border": {
@@ -154,7 +158,9 @@
 				},
 				"color": {
 					"background": "var(--wp--preset--color--primary)",
-					"text": "var(--wp--preset--color--base)"
+					"text": {
+						"ref": "styles.color.background"
+					}
 				},
 				"spacing": {
 					"padding": {
@@ -172,34 +178,48 @@
 				},
 				":hover": {
 					"border": {
-						"color": "var(--wp--preset--color--contrast)"
+						"color": {
+							"ref": "styles.color.text"
+						}
 					},
 					"color": {
-						"background": "var(--wp--preset--color--contrast)",
+						"background": {
+							"ref": "styles.color.text"
+						},
 						"text": "var(--wp--preset--color--tertiary)"
 					}
 				},
 				":focus": {
 					"border": {
-						"color": "var(--wp--preset--color--contrast)"
+						"color": {
+							"ref": "styles.color.text"
+						}
 					},
 					"color": {
-						"background": "var(--wp--preset--color--contrast)",
+						"background": {
+							"ref": "styles.color.text"
+						},
 						"text": "var(--wp--preset--color--tertiary)"
 					}
 				},
 				":active": {
 					"border": {
-						"color": "var(--wp--preset--color--contrast)"
+						"color": {
+							"ref": "styles.color.text"
+						}
 					},
 					"color": {
-						"background": "var(--wp--preset--color--contrast)",
+						"background": {
+							"ref": "styles.color.text"
+						},
 						"text": "var(--wp--preset--color--tertiary)"
 					}
 				},
 				":visited": {
 					"color": {
-						"text": "var(--wp--preset--color--base)"
+						"text": {
+							"ref": "styles.color.background"
+						}
 					}
 				}
 			},

--- a/src/wp-content/themes/twentytwentythree/styles/pitch.json
+++ b/src/wp-content/themes/twentytwentythree/styles/pitch.json
@@ -145,8 +145,8 @@
 			}
 		},
 		"color": {
-			"background": "#202124",
-			"text": "#e8eaed"
+			"background": "var(--wp--preset--color--dark-grey)",
+			"text": "var(--wp--preset--color--light-grey)"
 		},
 		"elements": {
 			"button": {

--- a/src/wp-content/themes/twentytwentythree/styles/sherbet.json
+++ b/src/wp-content/themes/twentytwentythree/styles/sherbet.json
@@ -34,16 +34,6 @@
 			],
 			"palette": [
 				{
-					"color": "#FFFFFF",
-					"name": "Base",
-					"slug": "base"
-				},
-				{
-					"color": "#000000",
-					"name": "Contrast",
-					"slug": "contrast"
-				},
-				{
 					"color": "#FFCCFF",
 					"name": "Primary",
 					"slug": "primary"
@@ -117,7 +107,9 @@
 					"link": {
 						":active": {
 							"color": {
-								"text": "var(--wp--preset--color--contrast)"
+								"text": {
+									"ref": "styles.color.text"
+								}
 							}
 						}
 					}
@@ -146,11 +138,15 @@
 				"elements": {
 					"link": {
 						"color": {
-							"text": "var(--wp--preset--color--contrast)"
+							"text": {
+								"ref": "styles.color.text"
+							}
 						},
 						":active": {
 							"color": {
-								"text": "var(--wp--preset--color--contrast)"
+								"text": {
+									"ref": "styles.color.text"
+								}
 							}
 						}
 					}
@@ -190,20 +186,28 @@
 			}
 		},
 		"color": {
-			"gradient": "var(--wp--preset--gradient--primary-secondary-tertiary)"
+			"background": "#FFFFFF",
+			"gradient": "var(--wp--preset--gradient--primary-secondary-tertiary)",
+			"text": "#000000"
 		},
 		"elements": {
 			"button": {
 				"border": {
-					"color": "var(--wp--preset--color--contrast)",
+					"color": {
+						"ref": "styles.color.text"
+					},
 					"radius": "99999px",
 					"style": "solid",
 					"width": "2px"
 				},
 				"color": {
-					"background": "var(--wp--preset--color--base)",
+					"background": {
+						"ref": "styles.color.background"
+					},
 					"gradient": "var(--wp--preset--gradient--primary-secondary-tertiary-fixed)",
-					"text": "var(--wp--preset--color--contrast)"
+					"text": {
+						"ref": "styles.color.text"
+					}
 				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--x-small)",
@@ -213,18 +217,24 @@
 				":hover": {
 					"color": {
 						"gradient": "var(--wp--preset--gradient--tertiary-secondary-primary-fixed)",
-						"text": "var(--wp--preset--color--contrast)"
+						"text": {
+							"ref": "styles.color.text"
+						}
 					}
 				},
 				":focus": {
 					"color": {
-						"background": "var(--wp--preset--color--contrast)",
+						"background": {
+							"ref": "styles.color.text"
+						},
 						"gradient": "none"
 					}
 				},
 				":active": {
 					"color": {
-						"background": "var(--wp--preset--color--contrast)",
+						"background": {
+							"ref": "styles.color.text"
+						},
 						"gradient": "none"
 					}
 				}

--- a/src/wp-content/themes/twentytwentythree/styles/sherbet.json
+++ b/src/wp-content/themes/twentytwentythree/styles/sherbet.json
@@ -186,9 +186,9 @@
 			}
 		},
 		"color": {
-			"background": "#FFFFFF",
+			"background": "var(--wp--preset--color--white)",
 			"gradient": "var(--wp--preset--gradient--primary-secondary-tertiary)",
-			"text": "#000000"
+			"text": "var(--wp--preset--color--black)"
 		},
 		"elements": {
 			"button": {

--- a/src/wp-content/themes/twentytwentythree/styles/whisper.json
+++ b/src/wp-content/themes/twentytwentythree/styles/whisper.json
@@ -6,16 +6,6 @@
 		"color": {
 			"palette": [
 				{
-					"color": "#E5E7F2",
-					"name": "Base",
-					"slug": "base"
-				},
-				{
-					"color": "#47484B",
-					"name": "Contrast",
-					"slug": "contrast"
-				},
-				{
 					"color": "#B50B3E",
 					"name": "Primary",
 					"slug": "primary"
@@ -29,6 +19,16 @@
 					"color": "#F9F9FB",
 					"name": "Tertiary",
 					"slug": "tertiary"
+				},
+				{
+					"color": "#E5E7F2",
+					"name": "Light Purple",
+					"slug": "light-purple"
+				},
+				{
+					"color": "#47484B",
+					"name": "Grey",
+					"slug": "grey"
 				}
 			]
 		},
@@ -85,7 +85,9 @@
 		"blocks": {
 			"core/navigation": {
 				"color": {
-					"text": "var(--wp--preset--color--contrast)"
+					"text": {
+						"ref": "styles.color.text"
+					}
 				},
 				"elements": {
 					"link": {
@@ -97,7 +99,9 @@
 							}
 						},
 						"color": {
-							"text": "var(--wp--preset--color--contrast)"
+							"text": {
+								"ref": "styles.color.text"
+							}
 						},
 						":hover": {
 							"border": {
@@ -140,7 +144,9 @@
 					"link": {
 						":hover": {
 							"border": {
-								"color": "var(--wp--preset--color--contrast)"
+								"color": {
+									"ref": "styles.color.text"
+								}
 							},
 							"color": {
 								"background": "var(--wp--preset--color--tertiary)"
@@ -157,7 +163,9 @@
 					"link": {
 						":hover": {
 							"border": {
-								"color": "var(--wp--preset--color--contrast)"
+								"color": {
+									"ref": "styles.color.text"
+								}
 							},
 							"color": {
 								"background": "var(--wp--preset--color--tertiary)"
@@ -195,7 +203,9 @@
 			},
 			"core/pullquote": {
 				"border": {
-					"color": "var(--wp--preset--color--contrast)",
+					"color": {
+						"ref": "styles.color.text"
+					},
 					"style": "double",
 					"width": "6px"
 				},
@@ -205,7 +215,9 @@
 			},
 			"core/quote": {
 				"border": {
-					"color": "var(--wp--preset--color--contrast)",
+					"color": {
+						"ref": "styles.color.text"
+					},
 					"style": "double",
 					"width": "0 0 0 6px"
 				},
@@ -226,7 +238,9 @@
 					"link": {
 						":hover": {
 							"border": {
-								"color": "var(--wp--preset--color--contrast)"
+								"color": {
+									"ref": "styles.color.text"
+								}
 							},
 							"color": {
 								"background": "var(--wp--preset--color--tertiary)"
@@ -237,7 +251,9 @@
 						},
 						":active": {
 							"border": {
-								"color": "var(--wp--preset--color--base)",
+								"color": {
+									"ref": "styles.color.background"
+								},
 								"width": "0 0 2px 0"
 							}
 						}
@@ -246,7 +262,9 @@
 			},
 			"core/separator": {
 				"border": {
-					"color": "var(--wp--preset--color--contrast)",
+					"color": {
+						"ref": "styles.color.text"
+					},
 					"style": "double",
 					"width": "6px 0 0 0"
 				}
@@ -350,6 +368,10 @@
 					}
 				}
 			}
+		},
+		"color": {
+			"background": "#E5E7F2",
+			"text": "#47484B"
 		},
 		"elements": {
 			"button": {
@@ -498,7 +520,9 @@
 				},
 				":hover": {
 					"border": {
-						"color": "var(--wp--preset--color--contrast)"
+						"color": {
+							"ref": "styles.color.text"
+						}
 					},
 					"color": {
 						"text": "var(--wp--preset--color--secondary)"

--- a/src/wp-content/themes/twentytwentythree/styles/whisper.json
+++ b/src/wp-content/themes/twentytwentythree/styles/whisper.json
@@ -370,8 +370,8 @@
 			}
 		},
 		"color": {
-			"background": "#E5E7F2",
-			"text": "#47484B"
+			"background": "var(--wp--preset--color--light-purple)",
+			"text": "var(--wp--preset--color--grey)"
 		},
 		"elements": {
 			"button": {

--- a/src/wp-content/themes/twentytwentythree/theme.json
+++ b/src/wp-content/themes/twentytwentythree/theme.json
@@ -580,8 +580,8 @@
 			}
 		},
 		"color": {
-			"background": "#ffffff",
-			"text": "#000000"
+			"background": "var(--wp--preset--color--white)",
+			"text": "var(--wp--preset--color--black)"
 		},
 		"elements": {
 			"button": {

--- a/src/wp-content/themes/twentytwentythree/theme.json
+++ b/src/wp-content/themes/twentytwentythree/theme.json
@@ -30,16 +30,6 @@
 		"color": {
 			"palette": [
 				{
-					"color": "#ffffff",
-					"name": "Base",
-					"slug": "base"
-				},
-				{
-					"color": "#000000",
-					"name": "Contrast",
-					"slug": "contrast"
-				},
-				{
 					"color": "#9DFF20",
 					"name": "Primary",
 					"slug": "primary"
@@ -590,8 +580,8 @@
 			}
 		},
 		"color": {
-			"background": "var(--wp--preset--color--base)",
-			"text": "var(--wp--preset--color--contrast)"
+			"background": "#ffffff",
+			"text": "#000000"
 		},
 		"elements": {
 			"button": {
@@ -600,29 +590,43 @@
 				},
 				"color": {
 					"background": "var(--wp--preset--color--primary)",
-					"text": "var(--wp--preset--color--contrast)"
+					"text": {
+						"ref": "styles.color.text"
+					}
 				},
 				":hover": {
 					"color": {
-						"background": "var(--wp--preset--color--contrast)",
-						"text": "var(--wp--preset--color--base)"
+						"background": {
+							"ref": "styles.color.text"
+						},
+						"text": {
+							"ref": "styles.color.background"
+						}
 					}
 				},
 				":focus": {
 					"color": {
-						"background": "var(--wp--preset--color--contrast)",
-						"text": "var(--wp--preset--color--base)"
+						"background": {
+							"ref": "styles.color.text"
+						},
+						"text": {
+							"ref": "styles.color.background"
+						}
 					}
 				},
 				":active": {
 					"color": {
 						"background": "var(--wp--preset--color--secondary)",
-						"text": "var(--wp--preset--color--base)"
+						"text": {
+							"ref": "styles.color.background"
+						}
 					}
 				},
 				":visited": {
 					"color": {
-						"text": "var(--wp--preset--color--contrast)"
+						"text": {
+							"ref": "styles.color.text"
+						}
 					}
 				}
 			},
@@ -669,7 +673,9 @@
 			},
 			"link": {
 				"color": {
-					"text": "var(--wp--preset--color--contrast)"
+					"text": {
+						"ref": "styles.color.text"
+					}
 				},
 				":hover": {
 					"typography": {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
This PR replaces the `base` and `contrast` color palette names in Twenty Twenty-Three with descriptive names (e.g. "dark purple"), and uses `ref` values for where we were previously using `var(--wp--preset--color--contrast)` or `var(--wp--preset--color--base)`.

I haven't included colors in the color palettes that are already included as part of Core, such as `#000000` and `#FFFFFF`.

Trac ticket: https://core.trac.wordpress.org/ticket/57167

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
