### PR TITLE
Account for primed posts without primed meta/terms.

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -7891,28 +7891,20 @@ function _prime_post_caches( $ids, $update_term_cache = true, $update_meta_cache
 	if ( ! empty( $non_cached_ids ) ) {
 		$fresh_posts = $wpdb->get_results( sprintf( "SELECT $wpdb->posts.* FROM $wpdb->posts WHERE ID IN (%s)", implode( ',', $non_cached_ids ) ) );
 
-		update_post_caches( $fresh_posts, 'any', $update_term_cache, $update_meta_cache );
-	}
-
-	if ( ! $update_meta_cache && ! $update_term_cache ) {
-		return;
-	}
-
-	$ids_may_have_uncached_data = array_diff( $ids, $non_cached_ids );
-
-	if ( empty( $ids_may_have_uncached_data ) ) {
-		// No work to do.
-		return;
+		if ( $fresh_posts ) {
+			// Despite the name, update_post_cache() expects an array rather than a single post.
+			update_post_cache( $fresh_posts );
+		}
 	}
 
 	if ( $update_meta_cache ) {
-		$ids_with_uncached_meta = _get_non_cached_ids( $ids_may_have_uncached_data, 'post_meta' );
-		update_postmeta_cache( $ids_with_uncached_meta );
+		update_postmeta_cache( $ids );
 	}
 
 	if ( $update_term_cache ) {
-		// update_object_term_cache() checks for uncached IDs internally.
-		update_object_term_cache( $ids_may_have_uncached_data, 'post' );
+		$post_types = array_map( 'get_post_type', $ids );
+		$post_types = array_unique( $post_types );
+		update_object_term_cache( $ids, $post_types );
 	}
 }
 

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -7876,7 +7876,9 @@ function _update_term_count_on_transition_post_status( $new_status, $old_status,
  * @since 3.4.0
  * @since 6.1.0 This function is no longer marked as "private".
  *
- * @see update_post_caches()
+ * @see update_post_cache()
+ * @see update_postmeta_cache()
+ * @see update_object_term_cache()
  *
  * @global wpdb $wpdb WordPress database abstraction object.
  *

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -7901,7 +7901,7 @@ function _prime_post_caches( $ids, $update_term_cache = true, $update_meta_cache
 	$ids_may_have_uncached_data = array_diff( $ids, $non_cached_ids );
 
 	if ( empty( $ids_may_have_uncached_data ) ) {
-		// No work to do.
+		// No work to do, caches primed within update_post_caches().
 		return;
 	}
 

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -7893,6 +7893,27 @@ function _prime_post_caches( $ids, $update_term_cache = true, $update_meta_cache
 
 		update_post_caches( $fresh_posts, 'any', $update_term_cache, $update_meta_cache );
 	}
+
+	if ( ! $update_meta_cache && ! $update_term_cache ) {
+		return;
+	}
+
+	$ids_may_have_uncached_data = array_diff( $ids, $non_cached_ids );
+
+	if ( empty( $ids_may_have_uncached_data ) ) {
+		// No work to do.
+		return;
+	}
+
+	if ( $update_meta_cache ) {
+		$ids_with_uncached_meta = _get_non_cached_ids( $ids_may_have_uncached_data, 'post_meta' );
+		update_postmeta_cache( $ids_with_uncached_meta );
+	}
+
+	if ( $update_term_cache ) {
+		// update_object_term_cache() checks for uncached IDs internally.
+		update_object_term_cache( $ids_may_have_uncached_data, 'post' );
+	}
 }
 
 /**

--- a/tests/phpunit/tests/post/primePostCaches.php
+++ b/tests/phpunit/tests/post/primePostCaches.php
@@ -76,7 +76,7 @@ class Tests_Post_PrimePostCaches extends WP_UnitTestCase {
 
 		// Test post meta cache.
 		$before_num_queries = get_num_queries();
-		$meta = get_post_meta( $post_id, 'meta', true );
+		$meta               = get_post_meta( $post_id, 'meta', true );
 		$num_queries        = get_num_queries() - $before_num_queries;
 
 		$this->assertSame( 'foo', $meta, 'Meta has unexpected value.' );
@@ -84,7 +84,7 @@ class Tests_Post_PrimePostCaches extends WP_UnitTestCase {
 
 		// Test term cache.
 		$before_num_queries = get_num_queries();
-		$categories = get_the_category( $post_id );
+		$categories         = get_the_category( $post_id );
 		$num_queries        = get_num_queries() - $before_num_queries;
 
 		$this->assertNotEmpty( $categories, 'Categories does return an empty result set.' );
@@ -154,7 +154,7 @@ class Tests_Post_PrimePostCaches extends WP_UnitTestCase {
 
 		// Test term cache.
 		$before_num_queries = get_num_queries();
-		$categories = get_the_category( self::$posts[0] );
+		$categories         = get_the_category( self::$posts[0] );
 		$num_queries        = get_num_queries() - $before_num_queries;
 
 		$this->assertNotEmpty( $categories, 'Categories does return an empty result set.' );
@@ -182,8 +182,8 @@ class Tests_Post_PrimePostCaches extends WP_UnitTestCase {
 
 		// Test post meta cache.
 		$before_num_queries = get_num_queries();
-		$meta_1 = get_post_meta( self::$posts[0], 'meta', true );
-		$meta_2 = get_post_meta( self::$posts[1], 'meta', true );
+		$meta_1             = get_post_meta( self::$posts[0], 'meta', true );
+		$meta_2             = get_post_meta( self::$posts[1], 'meta', true );
 		$num_queries        = get_num_queries() - $before_num_queries;
 
 		$this->assertSame( 'foo', $meta_1, 'Meta 1 has unexpected value.' );

--- a/tests/phpunit/tests/post/primePostCaches.php
+++ b/tests/phpunit/tests/post/primePostCaches.php
@@ -1,0 +1,236 @@
+<?php
+/**
+ * Test `_prime_post_caches()`.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Test class for `_prime_post_caches()`.
+ *
+ * @group post
+ *
+ * @covers ::_prime_post_caches
+ */
+class Tests_Post_PrimePostCaches extends WP_UnitTestCase {
+
+	/**
+	 * Post IDs.
+	 *
+	 * @var int[]
+	 */
+	public static $posts;
+
+	/**
+	 * Set up test resources before the class.
+	 *
+	 * @param WP_UnitTest_Factory $factory The unit test factory.
+	 */
+	public static function wpSetupBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$posts = $factory->post->create_many( 3 );
+
+		$category = $factory->term->create(
+			array(
+				'taxonomy' => 'category',
+				'slug'     => 'foo',
+				'name'     => 'Foo',
+			)
+		);
+
+		wp_set_post_terms( self::$posts[0], $category, 'category' );
+		add_post_meta( self::$posts[0], 'meta', 'foo' );
+		add_post_meta( self::$posts[1], 'meta', 'bar' );
+	}
+
+	public function set_up() {
+		parent::set_up();
+
+		foreach ( self::$posts as $post_id ) {
+			clean_post_cache( $post_id );
+		}
+	}
+
+	/**
+	 * @ticket 57163
+	 */
+	public function test_prime_post_caches() {
+		$post_id = self::$posts[0];
+
+		$this->assertSame( array( $post_id ), _get_non_cached_ids( array( $post_id ), 'posts' ), 'Post is already cached.' );
+
+		// Test posts cache.
+		$before_num_queries = get_num_queries();
+		_prime_post_caches( array( $post_id ) );
+		$num_queries = get_num_queries() - $before_num_queries;
+
+		/*
+		 * Four expected queries:
+		 * 1: Posts data,
+		 * 2: Post meta data,
+		 * 3: Taxonomy data,
+		 * 4: Term data.
+		 */
+		$this->assertSame( 4, $num_queries, 'Unexpected number of queries.' );
+
+		$this->assertSame( array(), _get_non_cached_ids( array( $post_id ), 'posts' ), 'Post is not cached.' );
+
+		// Test post meta cache.
+		$before_num_queries = get_num_queries();
+		$meta = get_post_meta( $post_id, 'meta', true );
+		$num_queries        = get_num_queries() - $before_num_queries;
+
+		$this->assertSame( 'foo', $meta, 'Meta has unexpected value.' );
+		$this->assertSame( 0, $num_queries, 'Unexpected number of queries.' );
+
+		// Test term cache.
+		$before_num_queries = get_num_queries();
+		$categories = get_the_category( $post_id );
+		$num_queries        = get_num_queries() - $before_num_queries;
+
+		$this->assertNotEmpty( $categories, 'Categories does return an empty result set.' );
+		$this->assertSame( 0, $num_queries, 'Unexpected number of queries.' );
+	}
+
+	/**
+	 * @ticket 57163
+	 */
+	public function test_prime_post_caches_with_multiple_posts() {
+		$this->assertSame( self::$posts, _get_non_cached_ids( self::$posts, 'posts' ), 'Posts are already cached.' );
+
+		$before_num_queries = get_num_queries();
+		_prime_post_caches( self::$posts );
+		$num_queries = get_num_queries() - $before_num_queries;
+
+		/*
+		 * Four expected queries:
+		 * 1: Posts data,
+		 * 2: Post meta data,
+		 * 3: Taxonomy data,
+		 * 4: Term data.
+		 */
+		$this->assertSame( 4, $num_queries, 'Unexpected number of queries.' );
+
+		$this->assertSame( array(), _get_non_cached_ids( self::$posts, 'posts' ), 'Posts are not cached.' );
+	}
+
+	/**
+	 * @ticket 57163
+	 */
+	public function test_prime_post_caches_only_posts_cache() {
+		$this->assertSame( self::$posts, _get_non_cached_ids( self::$posts, 'posts' ), 'Posts are already cached.' );
+
+		$before_num_queries = get_num_queries();
+		_prime_post_caches( self::$posts, false, false );
+		$num_queries = get_num_queries() - $before_num_queries;
+
+		/*
+		 * One expected query:
+		 * 1: Posts data.
+		 */
+		$this->assertSame( 1, $num_queries, 'Unexpected number of queries.' );
+
+		$this->assertSame( array(), _get_non_cached_ids( self::$posts, 'posts' ), 'Posts are not cached.' );
+	}
+
+	/**
+	 * @ticket 57163
+	 */
+	public function test_prime_post_caches_only_posts_and_term_cache() {
+		$this->assertSame( self::$posts, _get_non_cached_ids( self::$posts, 'posts' ), 'Posts are already cached.' );
+
+		$before_num_queries = get_num_queries();
+		_prime_post_caches( self::$posts, true, false );
+		$num_queries = get_num_queries() - $before_num_queries;
+
+		/*
+		 * Three expected queries:
+		 * 1: Posts data.
+		 * 2: Taxonomy data,
+		 * 3: Term data.
+		 */
+		$this->assertSame( 3, $num_queries, 'Unexpected number of queries.' );
+
+		$this->assertSame( array(), _get_non_cached_ids( self::$posts, 'posts' ), 'Posts are not cached.' );
+
+		// Test term cache.
+		$before_num_queries = get_num_queries();
+		$categories = get_the_category( self::$posts[0] );
+		$num_queries        = get_num_queries() - $before_num_queries;
+
+		$this->assertNotEmpty( $categories, 'Categories does return an empty result set.' );
+		$this->assertSame( 0, $num_queries, 'Unexpected number of queries.' );
+	}
+
+	/**
+	 * @ticket 57163
+	 */
+	public function test_prime_post_caches_only_posts_and_meta_cache() {
+		$this->assertSame( self::$posts, _get_non_cached_ids( self::$posts, 'posts' ), 'Posts are already cached.' );
+
+		$before_num_queries = get_num_queries();
+		_prime_post_caches( self::$posts, false, true );
+		$num_queries = get_num_queries() - $before_num_queries;
+
+		/*
+		 * Two expected queries:
+		 * 1: Posts data.
+		 * 2: Post meta data.
+		 */
+		$this->assertSame( 2, $num_queries, 'Unexpected number of queries.' );
+
+		$this->assertSame( array(), _get_non_cached_ids( self::$posts, 'posts' ), 'Posts are not cached.' );
+
+		// Test post meta cache.
+		$before_num_queries = get_num_queries();
+		$meta_1 = get_post_meta( self::$posts[0], 'meta', true );
+		$meta_2 = get_post_meta( self::$posts[1], 'meta', true );
+		$num_queries        = get_num_queries() - $before_num_queries;
+
+		$this->assertSame( 'foo', $meta_1, 'Meta 1 has unexpected value.' );
+		$this->assertSame( 'bar', $meta_2, 'Meta 2 has unexpected value.' );
+		$this->assertSame( 0, $num_queries, 'Unexpected number of queries.' );
+	}
+
+	/**
+	 * @ticket 57163
+	 */
+	public function test_prime_post_caches_accounts_for_posts_without_primed_meta_terms() {
+		$post_id = self::$posts[0];
+
+		$this->assertSame( array( $post_id ), _get_non_cached_ids( array( $post_id ), 'posts' ), 'Post is already cached.' );
+
+		// Warm only the posts cache.
+		$post = get_post( $post_id );
+		$this->assertNotEmpty( $post, 'Post does not exist.' );
+		$this->assertEmpty( _get_non_cached_ids( array( $post_id ), 'posts' ), 'Post is not cached.' );
+
+		$before_num_queries = get_num_queries();
+		_prime_post_caches( array( $post_id ) );
+		$num_queries = get_num_queries() - $before_num_queries;
+
+		/*
+		 * Two expected queries:
+		 * 1: Post meta data,
+		 * 2: Taxonomy data,
+		 * 3: Term data.
+		 */
+		$this->assertSame( 3, $num_queries, 'Unexpected number of queries.' );
+	}
+
+	/**
+	 * @ticket 57163
+	 */
+	public function test_prime_post_caches_does_not_prime_caches_twice() {
+		$this->assertSame( self::$posts, _get_non_cached_ids( self::$posts, 'posts' ), 'Posts are already cached.' );
+
+		_prime_post_caches( self::$posts );
+
+		$this->assertSame( array(), _get_non_cached_ids( self::$posts, 'posts' ), 'Posts are not cached.' );
+
+		$before_num_queries = get_num_queries();
+		_prime_post_caches( self::$posts );
+		$num_queries = get_num_queries() - $before_num_queries;
+
+		$this->assertSame( 0, $num_queries, 'Unexpected number of queries.' );
+	}
+}

--- a/tests/phpunit/tests/post/primePostCaches.php
+++ b/tests/phpunit/tests/post/primePostCaches.php
@@ -42,14 +42,6 @@ class Tests_Post_PrimePostCaches extends WP_UnitTestCase {
 		add_post_meta( self::$posts[1], 'meta', 'bar' );
 	}
 
-	public function set_up() {
-		parent::set_up();
-
-		foreach ( self::$posts as $post_id ) {
-			clean_post_cache( $post_id );
-		}
-	}
-
 	/**
 	 * @ticket 57163
 	 */
@@ -176,7 +168,7 @@ class Tests_Post_PrimePostCaches extends WP_UnitTestCase {
 		 * 1: Posts data.
 		 * 2: Post meta data.
 		 */
-		$this->assertSame( 2, $num_queries, 'Unexpected number of queries.' );
+		$this->assertSame( 2, $num_queries, 'Unexpected number of queries warming cache.' );
 
 		$this->assertSame( array(), _get_non_cached_ids( self::$posts, 'posts' ), 'Posts are not cached.' );
 
@@ -188,7 +180,7 @@ class Tests_Post_PrimePostCaches extends WP_UnitTestCase {
 
 		$this->assertSame( 'foo', $meta_1, 'Meta 1 has unexpected value.' );
 		$this->assertSame( 'bar', $meta_2, 'Meta 2 has unexpected value.' );
-		$this->assertSame( 0, $num_queries, 'Unexpected number of queries.' );
+		$this->assertSame( 0, $num_queries, 'Unexpected number of queries getting post meta.' );
 	}
 
 	/**
@@ -209,7 +201,7 @@ class Tests_Post_PrimePostCaches extends WP_UnitTestCase {
 		$num_queries = get_num_queries() - $before_num_queries;
 
 		/*
-		 * Two expected queries:
+		 * Three expected queries:
 		 * 1: Post meta data,
 		 * 2: Taxonomy data,
 		 * 3: Term data.

--- a/tests/phpunit/tests/post/primePostCaches.php
+++ b/tests/phpunit/tests/post/primePostCaches.php
@@ -9,6 +9,7 @@
  * Test class for `_prime_post_caches()`.
  *
  * @group post
+ * @group cache
  *
  * @covers ::_prime_post_caches
  */

--- a/tests/phpunit/tests/query/cacheResults.php
+++ b/tests/phpunit/tests/query/cacheResults.php
@@ -1223,7 +1223,7 @@ class Test_Query_CacheResults extends WP_UnitTestCase {
 
 		// Clear the post cache.
 		clean_post_cache( $post_id );
-		$this->assertSame( array( $post_id ), _get_non_cached_ids( array( $post_id ), 'posts', ), 'Post is already cached.' );
+		$this->assertSame( array( $post_id ), _get_non_cached_ids( array( $post_id ), 'posts' ), 'Post is already cached.' );
 
 		// Warm only the post cache.
 		$post = get_post( $post_id );

--- a/tests/phpunit/tests/query/cacheResults.php
+++ b/tests/phpunit/tests/query/cacheResults.php
@@ -1306,7 +1306,7 @@ class Test_Query_CacheResults extends WP_UnitTestCase {
 		$query_posts       = $query->query(
 			array(
 				'lazy_load_term_meta' => true,
-				'no_found_rows' => true,
+				'no_found_rows'       => true,
 			)
 		);
 		$num_queries       = get_num_queries() - $num_queries_start;

--- a/tests/phpunit/tests/query/cacheResults.php
+++ b/tests/phpunit/tests/query/cacheResults.php
@@ -1228,7 +1228,7 @@ class Test_Query_CacheResults extends WP_UnitTestCase {
 		// Warm only the post cache.
 		$post = get_post( $post_id );
 		$this->assertNotEmpty( $post, 'Post does not exist.' );
-		$this->assertEmpty( _get_non_cached_ids( array( $post_id ), 'posts', ), 'Post is not already cached.' );
+		$this->assertEmpty( _get_non_cached_ids( array( $post_id ), 'posts' ), 'Post is not already cached.' );
 
 		$args  = array(
 			'post_type'     => 'post',
@@ -1238,8 +1238,8 @@ class Test_Query_CacheResults extends WP_UnitTestCase {
 		$query = new WP_Query();
 
 		$before_num_queries = get_num_queries();
-		$posts = $query->query( $args );
-		$num_queries = get_num_queries() - $before_num_queries;
+		$posts              = $query->query( $args );
+		$num_queries        = get_num_queries() - $before_num_queries;
 
 		$this->assertNotEmpty( $posts, 'Query does return an empty result set.' );
 		// 1 query for the SELECT posts, 1 query for the post meta, 2 queries for the terms.

--- a/tests/phpunit/tests/query/cacheResults.php
+++ b/tests/phpunit/tests/query/cacheResults.php
@@ -1221,9 +1221,10 @@ class Test_Query_CacheResults extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_author_cache_warmed_by_the_loop
 	 *
-	 * @param string $fields Query fields.
+	 * @param string $fields   Query fields.
+	 * @param int    $expected Expected number of queries.
 	 */
-	public function test_author_cache_warmed_by_the_loop( $fields ) {
+	public function test_author_cache_warmed_by_the_loop( $fields, $expected ) {
 		// Update post author for the parent post.
 		self::factory()->post->update_object( self::$pages[0], array( 'post_author' => self::$author_id ) );
 
@@ -1247,7 +1248,7 @@ class Test_Query_CacheResults extends WP_UnitTestCase {
 		$start_loop_queries = get_num_queries();
 		$query_1->the_post();
 		$num_loop_queries = get_num_queries() - $start_loop_queries;
-		$this->assertSame( 2, $num_loop_queries, 'Unexpected number of queries while initializing the loop.' );
+		$this->assertSame( $expected, $num_loop_queries, 'Unexpected number of queries while initializing the loop.' );
 
 		$start_author_queries = get_num_queries();
 		get_user_by( 'ID', self::$author_id );
@@ -1262,9 +1263,34 @@ class Test_Query_CacheResults extends WP_UnitTestCase {
 	 */
 	public function data_author_cache_warmed_by_the_loop() {
 		return array(
-			'fields: empty' => array( '' ),
-			'fields: all'   => array( 'all' ),
-			'fields: ids'   => array( 'ids' ),
+			/*
+			 * Two expected queries:
+			 * 1: User meta data,
+			 * 2: User data.
+			 */
+			'fields: empty' => array(
+				'fields'   => '',
+				'expected' => 2,
+			),
+			/*
+			 * Two expected queries:
+			 * 1: User meta data,
+			 * 2: User data.
+			 */
+			'fields: all'   => array(
+				'fields'   => 'all',
+				'expected' => 2,
+			),
+			/*
+			 * Three expected queries:
+			 * 1: Warm the post meta cache (no terms as the test queries pages),
+			 * 2: User meta data,
+			 * 3: User data.
+			 */
+			'fields: ids'   => array(
+				'fields'   => 'ids',
+				'expected' => 3,
+			),
 			/*
 			 * `id=>parent` is untested pending the resolution of an existing bug.
 			 * See https://core.trac.wordpress.org/ticket/56992

--- a/tests/phpunit/tests/query/cacheResults.php
+++ b/tests/phpunit/tests/query/cacheResults.php
@@ -1256,10 +1256,9 @@ class Test_Query_CacheResults extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_author_cache_warmed_by_the_loop
 	 *
-	 * @param string $fields   Query fields.
-	 * @param int    $expected Expected number of queries.
+	 * @param string $fields Query fields.
 	 */
-	public function test_author_cache_warmed_by_the_loop( $fields, $expected ) {
+	public function test_author_cache_warmed_by_the_loop( $fields ) {
 		// Update post author for the parent post.
 		self::factory()->post->update_object( self::$pages[0], array( 'post_author' => self::$author_id ) );
 
@@ -1285,7 +1284,12 @@ class Test_Query_CacheResults extends WP_UnitTestCase {
 		$start_loop_queries = get_num_queries();
 		$query_1->the_post();
 		$num_loop_queries = get_num_queries() - $start_loop_queries;
-		$this->assertSame( $expected, $num_loop_queries, 'Unexpected number of queries while initializing the loop.' );
+		/*
+		 * Two expected queries:
+		 * 1: User meta data,
+		 * 2: User data.
+		 */
+		$this->assertSame( 2, $num_loop_queries, 'Unexpected number of queries while initializing the loop.' );
 
 		$start_author_queries = get_num_queries();
 		get_user_by( 'ID', self::$author_id );
@@ -1300,34 +1304,9 @@ class Test_Query_CacheResults extends WP_UnitTestCase {
 	 */
 	public function data_author_cache_warmed_by_the_loop() {
 		return array(
-			/*
-			 * Two expected queries:
-			 * 1: User meta data,
-			 * 2: User data.
-			 */
-			'fields: empty' => array(
-				'fields'   => '',
-				'expected' => 2,
-			),
-			/*
-			 * Two expected queries:
-			 * 1: User meta data,
-			 * 2: User data.
-			 */
-			'fields: all'   => array(
-				'fields'   => 'all',
-				'expected' => 2,
-			),
-			/*
-			 * Three expected queries:
-			 * 1: Warm the post meta cache (no terms as the test queries pages),
-			 * 2: User meta data,
-			 * 3: User data.
-			 */
-			'fields: ids'   => array(
-				'fields'   => 'ids',
-				'expected' => 3,
-			),
+			'fields: empty' => array( '' ),
+			'fields: all'   => array( 'all' ),
+			'fields: ids'   => array( 'ids' ),
 			/*
 			 * `id=>parent` is untested pending the resolution of an existing bug.
 			 * See https://core.trac.wordpress.org/ticket/56992

--- a/tests/phpunit/tests/query/cacheResults.php
+++ b/tests/phpunit/tests/query/cacheResults.php
@@ -1212,6 +1212,41 @@ class Test_Query_CacheResults extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensure post meta/term caches are warmed even if a post is already cached.
+	 *
+	 * @covers ::_prime_post_caches
+	 *
+	 * @ticket 57163
+	 */
+	public function test_post_meta_and_term_caches_are_warmed_even_if_post_is_already_cached() {
+		$post_id = self::$posts[0];
+
+		// Clear the post cache.
+		clean_post_cache( $post_id );
+		$this->assertSame( array( $post_id ), _get_non_cached_ids( array( $post_id ), 'posts', ), 'Post is already cached.' );
+
+		// Warm only the post cache.
+		$post = get_post( $post_id );
+		$this->assertNotEmpty( $post, 'Post does not exist.' );
+		$this->assertEmpty( _get_non_cached_ids( array( $post_id ), 'posts', ), 'Post is not already cached.' );
+
+		$args  = array(
+			'post_type'     => 'post',
+			'post__in'      => array( $post_id ),
+			'no_found_rows' => true,
+		);
+		$query = new WP_Query();
+
+		$before_num_queries = get_num_queries();
+		$posts = $query->query( $args );
+		$num_queries = get_num_queries() - $before_num_queries;
+
+		$this->assertNotEmpty( $posts, 'Query does return an empty result set.' );
+		// 1 query for the SELECT posts, 1 query for the post meta, 2 queries for the terms.
+		$this->assertSame( 4, $num_queries, 'Unexpected number of queries.' );
+	}
+
+	/**
 	 * Ensure starting the loop warms the author cache.
 	 *
 	 * @since 6.1.1

--- a/tests/phpunit/tests/query/cacheResults.php
+++ b/tests/phpunit/tests/query/cacheResults.php
@@ -1237,9 +1237,11 @@ class Test_Query_CacheResults extends WP_UnitTestCase {
 
 		$query_1 = new WP_Query(
 			array(
-				'post_type' => 'page',
-				'fields'    => $fields,
-				'author'    => self::$author_id,
+				'post_type'              => 'page',
+				'fields'                 => $fields,
+				'author'                 => self::$author_id,
+				'update_post_meta_cache' => false,
+				'update_post_term_cache' => false,
 			)
 		);
 

--- a/tests/phpunit/tests/query/cacheResults.php
+++ b/tests/phpunit/tests/query/cacheResults.php
@@ -1212,41 +1212,6 @@ class Test_Query_CacheResults extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Ensure post meta/term caches are warmed even if a post is already cached.
-	 *
-	 * @covers ::_prime_post_caches
-	 *
-	 * @ticket 57163
-	 */
-	public function test_post_meta_and_term_caches_are_warmed_even_if_post_is_already_cached() {
-		$post_id = self::$posts[0];
-
-		// Clear the post cache.
-		clean_post_cache( $post_id );
-		$this->assertSame( array( $post_id ), _get_non_cached_ids( array( $post_id ), 'posts' ), 'Post is already cached.' );
-
-		// Warm only the post cache.
-		$post = get_post( $post_id );
-		$this->assertNotEmpty( $post, 'Post does not exist.' );
-		$this->assertEmpty( _get_non_cached_ids( array( $post_id ), 'posts' ), 'Post is not already cached.' );
-
-		$args  = array(
-			'post_type'     => 'post',
-			'post__in'      => array( $post_id ),
-			'no_found_rows' => true,
-		);
-		$query = new WP_Query();
-
-		$before_num_queries = get_num_queries();
-		$posts              = $query->query( $args );
-		$num_queries        = get_num_queries() - $before_num_queries;
-
-		$this->assertNotEmpty( $posts, 'Query does return an empty result set.' );
-		// 1 query for the SELECT posts, 1 query for the post meta, 2 queries for the terms.
-		$this->assertSame( 4, $num_queries, 'Unexpected number of queries.' );
-	}
-
-	/**
 	 * Ensure starting the loop warms the author cache.
 	 *
 	 * @since 6.1.1


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/57163

Todo:
* [x] Manual testing
* [x] Unit tests
* [x] Figure out why `Test_Query_CacheResults::test_author_cache_warmed_by_the_loop` is failing.

_Edit: I suspect `Test_Query_CacheResults::test_author_cache_warmed_by_the_loop` fails due to this very issue. The post cache is warmed by `wp_insert_post()` when created but its term and meta data cache is not._