### PR TITLE
Twenty Twenty-Three: In "Blog (Alternative)" template, make post titles links

### DIFF
--- a/src/wp-content/themes/twentytwentythree/templates/blog-alternative.html
+++ b/src/wp-content/themes/twentytwentythree/templates/blog-alternative.html
@@ -15,7 +15,7 @@
 
 				<!-- wp:column {"verticalAlignment":"center","width":"80%"} -->
 				<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:80%">
-					<!-- wp:post-title /-->
+					<!-- wp:post-title {"isLink":true} /-->
 				</div>
 				<!-- /wp:column -->
 			</div>


### PR DESCRIPTION
The Twenty Twenty-Three theme has a custom page template called "Blog (alternative)", which displays blog posts "in a list format with the date on the left and the post title on the right" (as per [docs](https://wordpress.org/support/article/twenty-twenty-three/#templates)).

Currently, those post title blocks are not set to be links -- as a consequence, a visitor to a page using that template cannot click on any on them -- which is likely contrary to expectations.

Originally reported [here](https://wordpress.org/support/topic/blog-alternate-template-doesnt-link-to-posts/).

### Screencast to illustrate the issue

https://user-images.githubusercontent.com/96308/204306041-3f792879-6947-4865-b8e7-ae11ffe756a6.mp4

### Proposed solution

This PR changes the template to turn the post title blocks into links.

Trac ticket: https://core.trac.wordpress.org/ticket/57175

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
