### PR TITLE
Trac #45950 -- Update social media icons' size to 26

### DIFF
--- a/src/wp-content/themes/twentynineteen/inc/icon-functions.php
+++ b/src/wp-content/themes/twentynineteen/inc/icon-functions.php
@@ -10,21 +10,21 @@
 /**
  * Gets the SVG code for a given icon.
  */
-function twentynineteen_get_icon_svg( $icon, $size = 24 ) {
+function twentynineteen_get_icon_svg( $icon, $size = 26 ) {
 	return TwentyNineteen_SVG_Icons::get_svg( 'ui', $icon, $size );
 }
 
 /**
  * Gets the SVG code for a given social icon.
  */
-function twentynineteen_get_social_icon_svg( $icon, $size = 24 ) {
+function twentynineteen_get_social_icon_svg( $icon, $size = 26 ) {
 	return TwentyNineteen_SVG_Icons::get_svg( 'social', $icon, $size );
 }
 
 /**
  * Detects the social network from a URL and returns the SVG code for its icon.
  */
-function twentynineteen_get_social_link_svg( $uri, $size = 24 ) {
+function twentynineteen_get_social_link_svg( $uri, $size = 26 ) {
 	return TwentyNineteen_SVG_Icons::get_social_link_svg( $uri, $size );
 }
 


### PR DESCRIPTION
I updated the instances of svg icons in icon-functions.php to 26px from 24px.

Trac ticket: [https://core.trac.wordpress.org/ticket/45950](https://core.trac.wordpress.org/ticket/45950)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
