### PR TITLE
Move sanitization in `update_option()` to prevent double-sanitizing uncreated options.

### DIFF
--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -445,7 +445,6 @@ function update_option( $option, $value, $autoload = null ) {
 		$value = clone $value;
 	}
 
-	$value     = sanitize_option( $option, $value );
 	$old_value = get_option( $option );
 
 	/**
@@ -496,6 +495,7 @@ function update_option( $option, $value, $autoload = null ) {
 		return add_option( $option, $value, '', $autoload );
 	}
 
+	$value            = sanitize_option( $option, $value );
 	$serialized_value = maybe_serialize( $value );
 
 	/**


### PR DESCRIPTION
I'm running into this 10+ year old issue here:

Trac ticket: https://core.trac.wordpress.org/ticket/21989

...and wondering if something like this would be an acceptable fix. It works from what I can tell, but forgive me (and please correct me) if I'm out of protocol here, I've never opened a pull request before.

The TL;DR issue is that the value gets sanitized in `update_option()`, but then gets re-sanitized in `add_option()` if the option does not exist. In most situations it's not really an issue but in situations like the one that led me to this, sanitization functions that hash a password or encrypt something end up hashing the hash or double-encrypting prior to saving. This obviously renders hashed/encrypted data unusable, because any subsequent saves only sanitize/hash/encrypt the data once.

Can we not simply move the sanitization down in `update_option()` to prevent this? There's no output prior to that and since the filtered value may end up getting passed to `add_action()` and re-sanitized anyway, it seems safe to sanitize after the filters in `update_option()` as well... Besides, it seems safer regardless to sanitize after the filters, no?

Anyway this fixes the problem in my own use case, but perhaps I'm missing something.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
