### PR TITLE
E2E Tests: Add basic coverage for the Gutenberg plugin

### DIFF
--- a/tests/e2e/specs/gutenberg-plugin.test.js
+++ b/tests/e2e/specs/gutenberg-plugin.test.js
@@ -16,9 +16,11 @@ describe( 'Gutenberg plugin', () => {
 
 	it( 'Activate the Gutenberg plugin', async () => {
 		await activatePlugin( 'gutenberg' );
-		// If plugin activation fails, it will time out and throw an error,
-		// since the activatePlugin helper is looking for a `.deactivate` link
-		// which is only there if activation succeeds.
+		/*
+		 * If plugin activation fails, it will time out and throw an error,
+		 * since the activatePlugin helper is looking for a `.deactivate` link
+		 * which is only there if activation succeeds.
+		 */
 		await deactivatePlugin( 'gutenberg' );
 	} );
 } );

--- a/tests/e2e/specs/gutenberg-plugin.test.js
+++ b/tests/e2e/specs/gutenberg-plugin.test.js
@@ -1,0 +1,24 @@
+import {
+	activatePlugin,
+	deactivatePlugin,
+	installPlugin,
+	uninstallPlugin,
+} from '@wordpress/e2e-test-utils';
+
+describe( 'Gutenberg plugin', () => {
+	beforeAll( async () => {
+		await installPlugin( 'gutenberg' );
+	} );
+
+	afterAll( async () => {
+		await uninstallPlugin( 'gutenberg' );
+	} );
+
+	it( 'Activate the Gutenberg plugin', async () => {
+		await activatePlugin( 'gutenberg' );
+		// If plugin activation fails, it will time out and throw an error,
+		// since the activatePlugin helper is looking for a `.deactivate` link
+		// which is only there if activation succeeds.
+		await deactivatePlugin( 'gutenberg' );
+	} );
+} );

--- a/tests/e2e/specs/gutenberg-plugin.test.js
+++ b/tests/e2e/specs/gutenberg-plugin.test.js
@@ -14,7 +14,7 @@ describe( 'Gutenberg plugin', () => {
 		await uninstallPlugin( 'gutenberg' );
 	} );
 
-	it( 'Activate the Gutenberg plugin', async () => {
+	it( 'should activate', async () => {
 		await activatePlugin( 'gutenberg' );
 		/*
 		 * If plugin activation fails, it will time out and throw an error,


### PR DESCRIPTION
Try to activate and install the Gutenberg plugin. This will catch naming collisions between Core and GB (see [Core ticket 57197](https://core.trac.wordpress.org/ticket/57197) for an example).

To test:
1. Check out this branch and run `npm run env:start`.
2. Run `npm run test:e2e -- tests/e2e/specs/gutenberg-plugin.test.js` locally and verify that it passes.
3. Add a function definition to Core that's also present in Gutenberg (without `function_exists` guards or the like). I use the following:

```diff
diff --git a/src/wp-settings.php b/src/wp-settings.php
index 3ed93b2f36..d2fdafc74b 100644
--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -8,6 +8,10 @@
  * @package WordPress
  */
 
+function gutenberg_style_engine_get_styles() {
+       die();
+}
+
 /**
  * Stores the location of the WordPress directory of functions, classes, and core content.
  *
```
4. Run `npm run test:e2e -- tests/e2e/specs/gutenberg-plugin.test.js` again and watch it fail.

Trac ticket: https://core.trac.wordpress.org/ticket/57197

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
