### PR TITLE
Fix wrong condition on WP_Customize_Manager::has_published_pages().

### DIFF
--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -5764,7 +5764,14 @@ final class WP_Customize_Manager {
 				}
 			}
 		}
-		return 0 !== count( get_pages( array( 'number' => 1 ) ) );
+		return 0 !== count(
+			get_pages(
+				array(
+					'number'       => 1,
+					'hierarchical' => 0,
+				)
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
Add `hierarchical = 0` to the `get_pages()` call on `WP_Customize_Manager::has_published_pages()` so the check doesn't fail when the queried page is not top-level.

Trac ticket: https://core.trac.wordpress.org/ticket/57198

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
