### PR TITLE
Remove title attributes from bundled themes

### DIFF
--- a/src/wp-content/themes/twentyeleven/author.php
+++ b/src/wp-content/themes/twentyeleven/author.php
@@ -29,7 +29,7 @@ get_header(); ?>
 					<h1 class="page-title author">
 					<?php
 					/* translators: %s: Author display name. */
-					printf( __( 'Author Archives: %s', 'twentyeleven' ), '<span class="vcard"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '" title="' . esc_attr( get_the_author() ) . '" rel="me">' . get_the_author() . '</a></span>' );
+					printf( __( 'Author Archives: %s', 'twentyeleven' ), '<span class="vcard"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '" rel="me">' . get_the_author() . '</a></span>' );
 					?>
 					</h1>
 				</header>

--- a/src/wp-content/themes/twentyeleven/showcase.php
+++ b/src/wp-content/themes/twentyeleven/showcase.php
@@ -163,7 +163,7 @@ get_header(); ?>
 								/* translators: %s: Post title. */
 								$title = sprintf( __( 'Featuring: %s', 'twentyeleven' ), the_title_attribute( 'echo=0' ) );
 								?>
-					<li><a href="#featured-post-<?php echo esc_attr( $counter_slider ); ?>" title="<?php echo esc_attr( $title ); ?>"<?php echo $class; ?>></a></li>
+					<li><a href="#featured-post-<?php echo esc_attr( $counter_slider ); ?>"<?php echo $class; ?>><span class="feature-slider-tooltip" aria-hidden="true" title="<?php echo esc_attr( $title ); ?>"></span><span class="screen-reader-text"><?php echo esc_html( $title ); ?></span></a></li>
 						<?php endwhile; ?>
 					</ul>
 					</nav>

--- a/src/wp-content/themes/twentyeleven/style.css
+++ b/src/wp-content/themes/twentyeleven/style.css
@@ -1628,6 +1628,11 @@ section.feature-image.large img {
 	width: 14px;
 	height: 14px;
 }
+.feature-slider a .feature-slider-tooltip {
+	display: block;
+	width: 14px;
+	height: 14px;
+}
 .feature-slider a.active {
 	background: #1982d1;
 	-webkit-box-shadow: inset 1px 1px 5px rgba(0,0,0,0.4), inset 0 0 2px rgba(255,255,255,0.8);

--- a/src/wp-content/themes/twentynineteen/classes/class-twentynineteen-walker-comment.php
+++ b/src/wp-content/themes/twentynineteen/classes/class-twentynineteen-walker-comment.php
@@ -78,10 +78,9 @@ class TwentyNineteen_Walker_Comment extends Walker_Comment {
 						$comment_timestamp = sprintf( __( '%1$s at %2$s', 'twentynineteen' ), get_comment_date( '', $comment ), get_comment_time() );
 
 						printf(
-							'<a href="%s"><time datetime="%s" title="%s">%s</time></a>',
+							'<a href="%s"><time datetime="%s">%s</time></a>',
 							esc_url( get_comment_link( $comment, $args ) ),
 							get_comment_time( 'c' ),
-							esc_attr( $comment_timestamp ),
 							$comment_timestamp
 						);
 

--- a/src/wp-content/themes/twentyten/author.php
+++ b/src/wp-content/themes/twentyten/author.php
@@ -29,7 +29,7 @@ if ( have_posts() ) {
 				<h1 class="page-title author">
 				<?php
 				/* translators: %s: Author display name. */
-				printf( __( 'Author Archives: %s', 'twentyten' ), '<span class="vcard"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '" title="' . esc_attr( get_the_author() ) . '" rel="me">' . get_the_author() . '</a></span>' );
+				printf( __( 'Author Archives: %s', 'twentyten' ), '<span class="vcard"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '" rel="me">' . get_the_author() . '</a></span>' );
 				?>
 				</h1>
 

--- a/src/wp-content/themes/twentyten/footer.php
+++ b/src/wp-content/themes/twentyten/footer.php
@@ -24,7 +24,7 @@
 ?>
 
 			<div id="site-info">
-				<a href="<?php echo esc_url( home_url( '/' ) ); ?>" title="<?php echo esc_attr( get_bloginfo( 'name', 'display' ) ); ?>" rel="home">
+				<a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home">
 					<?php bloginfo( 'name' ); ?>
 				</a>
 				<?php

--- a/src/wp-content/themes/twentyten/header.php
+++ b/src/wp-content/themes/twentyten/header.php
@@ -69,7 +69,7 @@ if ( is_singular() && get_option( 'thread_comments' ) ) {
 				<?php $heading_tag = ( is_home() || is_front_page() ) ? 'h1' : 'div'; ?>
 				<<?php echo $heading_tag; ?> id="site-title">
 					<span>
-						<a href="<?php echo esc_url( home_url( '/' ) ); ?>" title="<?php echo esc_attr( get_bloginfo( 'name', 'display' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a>
+						<a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a>
 					</span>
 				</<?php echo $heading_tag; ?>>
 				<div id="site-description"><?php bloginfo( 'description' ); ?></div>
@@ -112,7 +112,7 @@ if ( is_singular() && get_option( 'thread_comments' ) ) {
 
 			<div id="access" role="navigation">
 				<?php // Allow screen readers / text browsers to skip the navigation menu and get right to the good stuff. ?>
-				<div class="skip-link screen-reader-text"><a href="#content" title="<?php esc_attr_e( 'Skip to content', 'twentyten' ); ?>"><?php _e( 'Skip to content', 'twentyten' ); ?></a></div>
+				<div class="skip-link screen-reader-text"><a href="#content"><?php _e( 'Skip to content', 'twentyten' ); ?></a></div>
 				<?php
 				/*
 				 * Our navigation menu. If one isn't filled out, wp_nav_menu() falls back to wp_page_menu().

--- a/src/wp-content/themes/twentythirteen/author.php
+++ b/src/wp-content/themes/twentythirteen/author.php
@@ -31,7 +31,7 @@ get_header(); ?>
 				<h1 class="archive-title">
 				<?php
 				/* translators: %s: Author display name. */
-				printf( __( 'All posts by %s', 'twentythirteen' ), '<span class="vcard"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '" title="' . esc_attr( get_the_author() ) . '" rel="me">' . get_the_author() . '</a></span>' );
+				printf( __( 'All posts by %s', 'twentythirteen' ), '<span class="vcard"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '" rel="me">' . get_the_author() . '</a></span>' );
 				?>
 				</h1>
 			</header><!-- .archive-header -->

--- a/src/wp-content/themes/twentythirteen/header.php
+++ b/src/wp-content/themes/twentythirteen/header.php
@@ -34,7 +34,7 @@
 	<?php wp_body_open(); ?>
 	<div id="page" class="hfeed site">
 		<header id="masthead" class="site-header">
-			<a class="home-link" href="<?php echo esc_url( home_url( '/' ) ); ?>" title="<?php echo esc_attr( get_bloginfo( 'name', 'display' ) ); ?>" rel="home">
+			<a class="home-link" href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home">
 				<h1 class="site-title"><?php bloginfo( 'name' ); ?></h1>
 				<h2 class="site-description"><?php bloginfo( 'description' ); ?></h2>
 			</a>
@@ -42,7 +42,7 @@
 			<div id="navbar" class="navbar">
 				<nav id="site-navigation" class="navigation main-navigation">
 					<button class="menu-toggle"><?php _e( 'Menu', 'twentythirteen' ); ?></button>
-					<a class="screen-reader-text skip-link" href="#content" title="<?php esc_attr_e( 'Skip to content', 'twentythirteen' ); ?>"><?php _e( 'Skip to content', 'twentythirteen' ); ?></a>
+					<a class="screen-reader-text skip-link" href="#content"><?php _e( 'Skip to content', 'twentythirteen' ); ?></a>
 					<?php
 					wp_nav_menu(
 						array(

--- a/src/wp-content/themes/twentytwelve/author.php
+++ b/src/wp-content/themes/twentytwelve/author.php
@@ -33,7 +33,7 @@ get_header(); ?>
 				<h1 class="archive-title">
 				<?php
 				/* translators: Author display name. */
-				printf( __( 'Author Archives: %s', 'twentytwelve' ), '<span class="vcard"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '" title="' . esc_attr( get_the_author() ) . '" rel="me">' . get_the_author() . '</a></span>' );
+				printf( __( 'Author Archives: %s', 'twentytwelve' ), '<span class="vcard"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '" rel="me">' . get_the_author() . '</a></span>' );
 				?>
 				</h1>
 			</header><!-- .archive-header -->

--- a/src/wp-content/themes/twentytwelve/header.php
+++ b/src/wp-content/themes/twentytwelve/header.php
@@ -36,13 +36,13 @@
 <div id="page" class="hfeed site">
 	<header id="masthead" class="site-header">
 		<hgroup>
-			<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" title="<?php echo esc_attr( get_bloginfo( 'name', 'display' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
+			<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
 			<h2 class="site-description"><?php bloginfo( 'description' ); ?></h2>
 		</hgroup>
 
 		<nav id="site-navigation" class="main-navigation">
 			<button class="menu-toggle"><?php _e( 'Menu', 'twentytwelve' ); ?></button>
-			<a class="assistive-text" href="#content" title="<?php esc_attr_e( 'Skip to content', 'twentytwelve' ); ?>"><?php _e( 'Skip to content', 'twentytwelve' ); ?></a>
+			<a class="assistive-text" href="#content"><?php _e( 'Skip to content', 'twentytwelve' ); ?></a>
 			<?php
 			wp_nav_menu(
 				array(

--- a/src/wp-content/themes/twentytwenty/classes/class-twentytwenty-walker-comment.php
+++ b/src/wp-content/themes/twentytwenty/classes/class-twentytwenty-walker-comment.php
@@ -72,10 +72,9 @@ if ( ! class_exists( 'TwentyTwenty_Walker_Comment' ) ) {
 							$comment_timestamp = sprintf( __( '%1$s at %2$s', 'twentytwenty' ), get_comment_date( '', $comment ), get_comment_time() );
 
 							printf(
-								'<a href="%s"><time datetime="%s" title="%s">%s</time></a>',
+								'<a href="%s"><time datetime="%s">%s</time></a>',
 								esc_url( get_comment_link( $comment, $args ) ),
 								get_comment_time( 'c' ),
-								esc_attr( $comment_timestamp ),
 								esc_html( $comment_timestamp )
 							);
 


### PR DESCRIPTION
This starts with the most straightforward problems:
1. Removes 13 redundant `title` attributes.
2. Adds accessible text to the Showcase template links. The `title` attribute remains, silenced with `aria-hidden`, with a style change so it still covers the full link area.

Trac ticket: https://core.trac.wordpress.org/ticket/57199

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
