### PR TITLE
WordPress 3.7 final release patches -- about, version bump.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "WordPress",
-	"version": "3.7.40",
+	"version": "3.7.41",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "WordPress",
-	"version": "3.7.40",
+	"version": "3.7.41",
 	"description": "WordPress is web software you can use to create a beautiful website or blog.",
 	"repository": {
 		"type": "svn",

--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -36,7 +36,31 @@ include( ABSPATH . 'wp-admin/admin-header.php' );
 </h2>
 
 <div class="changelog point-releases">
-	<h3><?php echo _n( 'Maintenance and Security Release', 'Maintenance and Security Releases', 40 ); ?></h3>
+	<h3><?php echo _n( 'Maintenance and Security Release', 'Maintenance and Security Releases', 41 ); ?></h3>
+	<p>
+		<?php
+		printf(
+			/* translators: %s: WordPress version number */
+			_n(
+				'<strong>Version %1$s</strong> addressed a security issue.',
+				'<strong>Version %1$s</strong> addressed some security issues.',
+				1
+			),
+			'3.7.41'
+		);
+		?>
+		<?php
+		printf(
+			/* translators: %s: HelpHub URL */
+			__( 'For more information, see <a href="%s">the release notes</a>.' ),
+			sprintf(
+				/* translators: %s: WordPress version */
+				esc_url( __( 'https://wordpress.org/support/wordpress-version/version-%s/' ) ),
+				sanitize_title( '3.7.41' )
+			)
+		);
+		?>
+	</p>
 	<p>
 		<?php
 		printf(

--- a/src/wp-includes/version.php
+++ b/src/wp-includes/version.php
@@ -4,7 +4,7 @@
  *
  * @global string $wp_version
  */
-$wp_version = '3.7.40-src';
+$wp_version = '3.7.41-src';
 
 /**
  * Holds the WordPress DB revision, increments when changes are made to the WordPress DB schema.


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/56786 version and about page bump targeting 3.7 branch