### PR TITLE
Adding an ":" in a string to seperate the word and the link.

### DIFF
--- a/.env
+++ b/.env
@@ -29,7 +29,7 @@ LOCAL_PHP_XDEBUG=false
 #
 # To generate a code coverage report, `coverage` mode must be active.
 #
-# For a full list of accepted values, see https://xdebug.org/docs/all_settings#mode.
+# For a full list of accepted values, see: https://xdebug.org/docs/all_settings#mode.
 ##
 LOCAL_PHP_XDEBUG_MODE=develop,debug
 
@@ -48,8 +48,8 @@ LOCAL_DB_TYPE=mysql
 #
 # Defaults to 5.7 with the assumption that LOCAL_DB_TYPE is set to `mysql` above.
 #
-# When using `mysql`, see https://hub.docker.com/r/amd64/mysql for valid versions.
-# When using `mariadb`, see https://hub.docker.com/r/amd64/mariadb for valid versions.
+# When using `mysql`, see: https://hub.docker.com/r/amd64/mysql for valid versions.
+# When using `mariadb`, see: https://hub.docker.com/r/amd64/mariadb for valid versions.
 ##
 LOCAL_DB_VERSION=5.7
 

--- a/.env
+++ b/.env
@@ -29,7 +29,7 @@ LOCAL_PHP_XDEBUG=false
 #
 # To generate a code coverage report, `coverage` mode must be active.
 #
-# For a full list of accepted values, see: https://xdebug.org/docs/all_settings#mode.
+# For a full list of accepted values, see https://xdebug.org/docs/all_settings#mode.
 ##
 LOCAL_PHP_XDEBUG_MODE=develop,debug
 
@@ -48,8 +48,8 @@ LOCAL_DB_TYPE=mysql
 #
 # Defaults to 5.7 with the assumption that LOCAL_DB_TYPE is set to `mysql` above.
 #
-# When using `mysql`, see: https://hub.docker.com/r/amd64/mysql for valid versions.
-# When using `mariadb`, see: https://hub.docker.com/r/amd64/mariadb for valid versions.
+# When using `mysql`, see https://hub.docker.com/r/amd64/mysql for valid versions.
+# When using `mariadb`, see https://hub.docker.com/r/amd64/mariadb for valid versions.
 ##
 LOCAL_DB_VERSION=5.7
 

--- a/src/wp-admin/options.php
+++ b/src/wp-admin/options.php
@@ -304,7 +304,7 @@ if ( 'update' === $action ) { // We are saving settings sent from a settings pag
 					'2.7.0',
 					sprintf(
 						/* translators: %s: The option/setting. */
-						__( 'The %s setting is unregistered. Unregistered settings are deprecated. See https://developer.wordpress.org/plugins/settings/settings-api/' ),
+						__( 'The %s setting is unregistered. Unregistered settings are deprecated. See: https://developer.wordpress.org/plugins/settings/settings-api/' ),
 						'<code>' . esc_html( $option ) . '</code>'
 					)
 				);


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/57231
Small fix for the above ticket.