### PR TITLE
Correctly render the list block for the excerpt

### DIFF
--- a/src/wp-content/themes/twentytwentytwo/functions.php
+++ b/src/wp-content/themes/twentytwentytwo/functions.php
@@ -9,36 +9,6 @@
  * @since Twenty Twenty-Two 1.0
  */
 
-$content = '
-<!-- wp:list -->
-<ul>
-	<!-- wp:list-item -->
-	<li>list item</li>
-	<!-- /wp:list-item -->
-	<!-- wp:list-item -->
-	<li>
-		list item
-		<!-- wp:list {"ordered":true} -->
-		<ol>
-			<!-- wp:list-item -->
-			<li>list item</li>
-			<!-- /wp:list-item -->
-			<!-- wp:list-item -->
-			<li>list item</li>
-			<!-- /wp:list-item -->
-		</ol>
-		<!-- /wp:list -->
-	</li>
-	<!-- /wp:list-item -->
-</ul>
-<!-- /wp:list -->
-';
-
-echo '<pre style="border:1px red solid;">';
-var_dump( excerpt_remove_blocks( $content ) );
-echo '</pre>';
-
-exit;
 
 if ( ! function_exists( 'twentytwentytwo_support' ) ) :
 

--- a/src/wp-content/themes/twentytwentytwo/functions.php
+++ b/src/wp-content/themes/twentytwentytwo/functions.php
@@ -9,6 +9,36 @@
  * @since Twenty Twenty-Two 1.0
  */
 
+$content = '
+<!-- wp:list -->
+<ul>
+	<!-- wp:list-item -->
+	<li>list item</li>
+	<!-- /wp:list-item -->
+	<!-- wp:list-item -->
+	<li>
+		list item
+		<!-- wp:list {"ordered":true} -->
+		<ol>
+			<!-- wp:list-item -->
+			<li>list item</li>
+			<!-- /wp:list-item -->
+			<!-- wp:list-item -->
+			<li>list item</li>
+			<!-- /wp:list-item -->
+		</ol>
+		<!-- /wp:list -->
+	</li>
+	<!-- /wp:list-item -->
+</ul>
+<!-- /wp:list -->
+';
+
+echo '<pre style="border:1px red solid;">';
+var_dump( excerpt_remove_blocks( $content ) );
+echo '</pre>';
+
+exit;
 
 if ( ! function_exists( 'twentytwentytwo_support' ) ) :
 

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -881,6 +881,7 @@ function excerpt_remove_blocks( $content ) {
 		'core/heading',
 		'core/html',
 		'core/list',
+		'core/list-item',
 		'core/media-text',
 		'core/paragraph',
 		'core/preformatted',

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -880,8 +880,6 @@ function excerpt_remove_blocks( $content ) {
 		'core/freeform',
 		'core/heading',
 		'core/html',
-		'core/list',
-		'core/list-item',
 		'core/media-text',
 		'core/paragraph',
 		'core/preformatted',
@@ -895,6 +893,8 @@ function excerpt_remove_blocks( $content ) {
 		'core/columns',
 		'core/column',
 		'core/group',
+		'core/list',
+		'core/list-item',
 	);
 
 	/**

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -880,6 +880,7 @@ function excerpt_remove_blocks( $content ) {
 		'core/freeform',
 		'core/heading',
 		'core/html',
+		'core/list',
 		'core/media-text',
 		'core/paragraph',
 		'core/preformatted',
@@ -893,8 +894,6 @@ function excerpt_remove_blocks( $content ) {
 		'core/columns',
 		'core/column',
 		'core/group',
-		'core/list',
-		'core/list-item',
 	);
 
 	/**
@@ -928,6 +927,14 @@ function excerpt_remove_blocks( $content ) {
 			if ( ! empty( $block['innerBlocks'] ) ) {
 				if ( in_array( $block['blockName'], $allowed_wrapper_blocks, true ) ) {
 					$output .= _excerpt_render_inner_blocks( $block, $allowed_blocks );
+					continue;
+				}
+
+				if (
+					in_array( $block['blockName'], $allowed_inner_blocks, true ) &&
+					'core/list' === $block['blockName']
+				) {
+					$output .= render_block( $block );
 					continue;
 				}
 

--- a/tests/phpunit/tests/formatting/excerptRemoveBlocks.php
+++ b/tests/phpunit/tests/formatting/excerptRemoveBlocks.php
@@ -14,6 +14,16 @@ class Tests_Formatting_ExcerptRemoveBlocks extends WP_UnitTestCase {
 <!-- wp:paragraph -->
 <p>paragraph</p>
 <!-- /wp:paragraph -->
+<!-- wp:list -->
+<ul>
+	<!-- wp:list-item -->
+	<li>list item</li>
+	<!-- /wp:list-item -->
+	<!-- wp:list-item -->
+	<li>list item</li>
+	<!-- /wp:list-item -->
+</ul>
+<!-- /wp:list -->
 <!-- wp:latest-posts {"postsToShow":3,"displayPostDate":true,"order":"asc","orderBy":"title"} /-->
 <!-- wp:spacer -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
@@ -36,6 +46,16 @@ class Tests_Formatting_ExcerptRemoveBlocks extends WP_UnitTestCase {
 	public $filtered_content = '
 
 <p>paragraph</p>
+
+
+<ul>
+	
+	<li>list item</li>
+	
+	
+	<li>list item</li>
+	
+</ul>
 
 
 

--- a/tests/phpunit/tests/formatting/excerptRemoveBlocks.php
+++ b/tests/phpunit/tests/formatting/excerptRemoveBlocks.php
@@ -20,7 +20,19 @@ class Tests_Formatting_ExcerptRemoveBlocks extends WP_UnitTestCase {
 	<li>list item</li>
 	<!-- /wp:list-item -->
 	<!-- wp:list-item -->
-	<li>list item</li>
+	<li>
+		list item
+		<!-- wp:list {"ordered":true} -->
+		<ol>
+			<!-- wp:list-item -->
+			<li>list item</li>
+			<!-- /wp:list-item -->
+			<!-- wp:list-item -->
+			<li>list item</li>
+			<!-- /wp:list-item -->
+		</ol>
+		<!-- /wp:list -->
+	</li>
 	<!-- /wp:list-item -->
 </ul>
 <!-- /wp:list -->
@@ -53,7 +65,19 @@ class Tests_Formatting_ExcerptRemoveBlocks extends WP_UnitTestCase {
 	<li>list item</li>
 	
 	
-	<li>list item</li>
+	<li>
+		list item
+		
+		<ol>
+			
+			<li>list item</li>
+			
+			
+			<li>list item</li>
+			
+		</ol>
+		
+	</li>
 	
 </ul>
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/57235
Related gutenberg issue: https://github.com/WordPress/gutenberg/issues/46167

This PR fixes a problem with the unintentional removal of the list block in the output of excerpts. This appears to be due to the change of list items to blocks in WordPress 6.1.

At the same time, I added the list block markup in the unit test for `excerpt_remove_blocks`.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
