### PR TITLE
Fix: notice for undefined width and height full svg image

### DIFF
--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -1181,7 +1181,7 @@ function _wp_get_attachment_relative_path( $file ) {
  */
 function _wp_get_image_size_from_meta( $size_name, $image_meta ) {
 	if ( 'full' === $size_name ) {
-		if (empty( $image_meta['width'] ) || empty( $image_meta['height'] )) {
+		if ( empty( $image_meta['width'] ) || empty( $image_meta['height'] ) ) {
 			return false;
 		}
 		return array(

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -1181,6 +1181,9 @@ function _wp_get_attachment_relative_path( $file ) {
  */
 function _wp_get_image_size_from_meta( $size_name, $image_meta ) {
 	if ( 'full' === $size_name ) {
+		if (empty( $image_meta['width'] ) || empty( $image_meta['height'] )) {
+		    return false;
+		}
 		return array(
 			absint( $image_meta['width'] ),
 			absint( $image_meta['height'] ),

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -1182,7 +1182,7 @@ function _wp_get_attachment_relative_path( $file ) {
 function _wp_get_image_size_from_meta( $size_name, $image_meta ) {
 	if ( 'full' === $size_name ) {
 		if (empty( $image_meta['width'] ) || empty( $image_meta['height'] )) {
-		    return false;
+			return false;
 		}
 		return array(
 			absint( $image_meta['width'] ),


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

If you add media like an svg and use it with the "full size" option the width and height are not fetched. Currently the function expects those array keys. This PR checks both of the keys and if one of the keys are empty return false.

Trac ticket: [57239](https://core.trac.wordpress.org/ticket/57239)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
