### PR TITLE
`wp_get_global_stylesheet`: substitute 1-minute transient by non-persistent object cache

### DIFF
--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -352,7 +352,6 @@ add_action( 'after_switch_theme', '_wp_menus_changed' );
 add_action( 'after_switch_theme', '_wp_sidebars_changed' );
 add_action( 'wp_print_styles', 'print_emoji_styles' );
 add_action( 'plugins_loaded', '_wp_theme_json_webfonts_handler' );
-add_action( 'plugins_loaded', '_wp_add_non_persistent_theme_json_cache_group' );
 
 if ( isset( $_GET['replytocom'] ) ) {
 	add_filter( 'wp_robots', 'wp_robots_no_robots' );

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -352,6 +352,7 @@ add_action( 'after_switch_theme', '_wp_menus_changed' );
 add_action( 'after_switch_theme', '_wp_sidebars_changed' );
 add_action( 'wp_print_styles', 'print_emoji_styles' );
 add_action( 'plugins_loaded', '_wp_theme_json_webfonts_handler' );
+add_action( 'plugins_loaded', '_wp_add_non_persistent_theme_json_cache_group' );
 
 if ( isset( $_GET['replytocom'] ) ) {
 	add_filter( 'wp_robots', 'wp_robots_no_robots' );

--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -87,7 +87,7 @@ function wp_get_global_stylesheet( $types = array() ) {
 	$can_use_cached = empty( $types ) && ! WP_DEBUG;
 	/**
 	 * By using the 'theme_json' group, this data is marked to be non-persistent across requests.
-	 * See `wp_cache_add_non_persistent_groups` in src/wp-includes/load.php
+	 * See `wp_cache_add_non_persistent_groups` in src/wp-includes/load.php and other places.
 	 *
 	 * The rationale for this is to make sure derived data from theme.json
 	 * is always fresh from the potential modifications done via hooks

--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -85,7 +85,7 @@ function wp_get_global_styles( $path = array(), $context = array() ) {
 function wp_get_global_stylesheet( $types = array() ) {
 	// Ignore cache when `WP_DEBUG` is enabled, so it doesn't interfere with the theme developers workflow.
 	$can_use_cached = empty( $types ) && ! WP_DEBUG;
-	/**
+	/*
 	 * By using the 'theme_json' group, this data is marked to be non-persistent across requests.
 	 * See `wp_cache_add_non_persistent_groups` in src/wp-includes/load.php and other places.
 	 *

--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -83,7 +83,13 @@ function wp_get_global_styles( $path = array(), $context = array() ) {
  * @return string Stylesheet.
  */
 function wp_get_global_stylesheet( $types = array() ) {
-	// Ignore cache when `WP_DEBUG` is enabled, so it doesn't interfere with the theme developers workflow.
+	/*
+	 *
+	 * Ignore cache when `WP_DEBUG` is enabled, so it doesn't interfere with the theme
+	 * developer's workflow.
+	 *
+	 * @todo Replace `WP_DEBUG` once an "in development mode" check is available in Core.
+	 */
 	$can_use_cached = empty( $types ) && ! WP_DEBUG;
 	/*
 	 * By using the 'theme_json' group, this data is marked to be non-persistent across requests.

--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -83,18 +83,12 @@ function wp_get_global_styles( $path = array(), $context = array() ) {
  * @return string Stylesheet.
  */
 function wp_get_global_stylesheet( $types = array() ) {
-	// Return cached value if it can be used and exists.
-	// It's cached by theme to make sure that theme switching clears the cache.
-	$can_use_cached = (
-		( empty( $types ) ) &&
-		( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) &&
-		( ! defined( 'SCRIPT_DEBUG' ) || ! SCRIPT_DEBUG ) &&
-		( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) &&
-		! is_admin()
-	);
-	$transient_name = 'global_styles_' . get_stylesheet();
+	// Ignore cache when `WP_DEBUG` is enabled, so it doesn't interfere with the theme developers workflow.
+	$can_use_cached = empty( $types ) && ! WP_DEBUG;
+	$cache_key      = 'wp_get_global_stylesheet';
+	$cache_group    = 'theme_json';
 	if ( $can_use_cached ) {
-		$cached = get_transient( $transient_name );
+		$cached = wp_cache_get( $cache_key, $cache_group );
 		if ( $cached ) {
 			return $cached;
 		}
@@ -148,15 +142,10 @@ function wp_get_global_stylesheet( $types = array() ) {
 		}
 		$styles_rest = $tree->get_stylesheet( $types, $origins );
 	}
-
 	$stylesheet = $styles_variables . $styles_rest;
-
 	if ( $can_use_cached ) {
-		// Cache for a minute.
-		// This cache doesn't need to be any longer, we only want to avoid spikes on high-traffic sites.
-		set_transient( $transient_name, $stylesheet, MINUTE_IN_SECONDS );
+		wp_cache_set( $cache_key, $stylesheet, $cache_group );
 	}
-
 	return $stylesheet;
 }
 
@@ -283,3 +272,31 @@ function wp_theme_has_theme_json() {
 function wp_clean_theme_json_cache() {
 	WP_Theme_JSON_Resolver::clean_cached_data();
 }
+
+/**
+ * Tell the cache mechanisms not to persist theme.json data across requests.
+ * The data stored under this cache group:
+ *
+ * - wp_get_global_stylesheet
+ *
+ * There is some hooks consumers can use to modify parts
+ * of the theme.json logic.
+ * See https://make.wordpress.org/core/2022/10/10/filters-for-theme-json-data/
+ *
+ * The rationale to make this cache group non persistent is to make sure derived data
+ * from theme.json is always fresh from the potential modifications done via hooks
+ * that can use dynamic data (modify the stylesheet depending on some option,
+ * or settings depending on user permissions, etc.).
+ *
+ * A different alternative considered was to invalidate the cache upon certain
+ * events such as options add/update/delete, user meta, etc.
+ * It was judged not enough, hence this approach.
+ * See https://github.com/WordPress/gutenberg/pull/45372
+ *
+ * @since 6.1.2
+ * @access private
+ */
+function _wp_add_non_persistent_theme_json_cache_group() {
+	wp_cache_add_non_persistent_groups( 'theme_json' );
+}
+add_action( 'plugins_loaded', '_wp_add_non_persistent_theme_json_cache_group' );

--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -294,5 +294,6 @@ function wp_theme_has_theme_json() {
  * @since 6.2.0
  */
 function wp_clean_theme_json_cache() {
+	wp_cache_delete( 'wp_get_global_stylesheet', 'theme_json' );
 	WP_Theme_JSON_Resolver::clean_cached_data();
 }

--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -299,4 +299,3 @@ function wp_clean_theme_json_cache() {
 function _wp_add_non_persistent_theme_json_cache_group() {
 	wp_cache_add_non_persistent_groups( 'theme_json' );
 }
-add_action( 'plugins_loaded', '_wp_add_non_persistent_theme_json_cache_group' );

--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -84,31 +84,31 @@ function wp_get_global_styles( $path = array(), $context = array() ) {
  */
 function wp_get_global_stylesheet( $types = array() ) {
 	/*
-	 *
 	 * Ignore cache when `WP_DEBUG` is enabled, so it doesn't interfere with the theme
 	 * developer's workflow.
 	 *
 	 * @todo Replace `WP_DEBUG` once an "in development mode" check is available in Core.
 	 */
 	$can_use_cached = empty( $types ) && ! WP_DEBUG;
+
 	/*
 	 * By using the 'theme_json' group, this data is marked to be non-persistent across requests.
-	 * See `wp_cache_add_non_persistent_groups` in src/wp-includes/load.php and other places.
+	 * @see `wp_cache_add_non_persistent_groups()`.
 	 *
 	 * The rationale for this is to make sure derived data from theme.json
 	 * is always fresh from the potential modifications done via hooks
 	 * that can use dynamic data (modify the stylesheet depending on some option,
 	 * settings depending on user permissions, etc.).
-	 * See some of the existing hooks to modify theme.json behaviour:
-	 * https://make.wordpress.org/core/2022/10/10/filters-for-theme-json-data/
+	 * See some of the existing hooks to modify theme.json behavior:
+	 * @see https://make.wordpress.org/core/2022/10/10/filters-for-theme-json-data/
 	 *
 	 * A different alternative considered was to invalidate the cache upon certain
 	 * events such as options add/update/delete, user meta, etc.
 	 * It was judged not enough, hence this approach.
-	 * See https://github.com/WordPress/gutenberg/pull/45372
+	 * @see https://github.com/WordPress/gutenberg/pull/45372
 	 */
-	$cache_group    = 'theme_json';
-	$cache_key      = 'wp_get_global_stylesheet';
+	$cache_group = 'theme_json';
+	$cache_key   = 'wp_get_global_stylesheet';
 	if ( $can_use_cached ) {
 		$cached = wp_cache_get( $cache_key, $cache_group );
 		if ( $cached ) {
@@ -164,10 +164,12 @@ function wp_get_global_stylesheet( $types = array() ) {
 		}
 		$styles_rest = $tree->get_stylesheet( $types, $origins );
 	}
+
 	$stylesheet = $styles_variables . $styles_rest;
 	if ( $can_use_cached ) {
 		wp_cache_set( $cache_key, $stylesheet, $cache_group );
 	}
+
 	return $stylesheet;
 }
 

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -753,7 +753,7 @@ function wp_start_object_cache() {
 			)
 		);
 
-		wp_cache_add_non_persistent_groups( array( 'counts', 'plugins' ) );
+		wp_cache_add_non_persistent_groups( array( 'counts', 'plugins', 'theme_json' ) );
 	}
 
 	$first_init = false;

--- a/src/wp-includes/ms-blogs.php
+++ b/src/wp-includes/ms-blogs.php
@@ -575,7 +575,7 @@ function switch_to_blog( $new_blog_id, $deprecated = null ) {
 				);
 			}
 
-			wp_cache_add_non_persistent_groups( array( 'counts', 'plugins' ) );
+			wp_cache_add_non_persistent_groups( array( 'counts', 'plugins', 'theme_json' ) );
 		}
 	}
 
@@ -666,7 +666,7 @@ function restore_current_blog() {
 				);
 			}
 
-			wp_cache_add_non_persistent_groups( array( 'counts', 'plugins' ) );
+			wp_cache_add_non_persistent_groups( array( 'counts', 'plugins', 'theme_json' ) );
 		}
 	}
 

--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -401,7 +401,7 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 			)
 		);
 
-		wp_cache_add_non_persistent_groups( array( 'counts', 'plugins' ) );
+		wp_cache_add_non_persistent_groups( array( 'counts', 'plugins', 'theme_json' ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/theme/wpGetGlobalStylesheet.php
+++ b/tests/phpunit/tests/theme/wpGetGlobalStylesheet.php
@@ -270,4 +270,12 @@ class Tests_Theme_wpGetGlobalStylesheet extends WP_UnitTestCase {
 			'Registered styles with handle of "wp-style-engine-my-styles" do not match expected value from the Style Engine store.'
 		);
 	}
+
+	public function test_switching_themes_recalculates_stylesheet() {
+		$stylesheet_for_default_theme = wp_get_global_stylesheet();
+		switch_theme( 'block-theme' );
+		$stylesheet_for_block_theme = wp_get_global_stylesheet();
+		$this->assertStringNotContainsString( '--wp--preset--font-size--custom: 100px;', $stylesheet_for_default_theme, 'custom font size (100px) not present for default theme' );
+		$this->assertStringContainsString( '--wp--preset--font-size--custom: 100px;', $stylesheet_for_block_theme, 'custom font size (100px) is present for block theme' );
+	}
 }

--- a/tests/phpunit/tests/theme/wpGetGlobalStylesheet.php
+++ b/tests/phpunit/tests/theme/wpGetGlobalStylesheet.php
@@ -279,10 +279,9 @@ class Tests_Theme_wpGetGlobalStylesheet extends WP_UnitTestCase {
 		$stylesheet_for_default_theme = wp_get_global_stylesheet();
 		switch_theme( 'block-theme' );
 		$stylesheet_for_block_theme = wp_get_global_stylesheet();
+		switch_theme( WP_DEFAULT_THEME );
 
 		$this->assertStringNotContainsString( '--wp--preset--font-size--custom: 100px;', $stylesheet_for_default_theme, 'custom font size (100px) not present for default theme' );
 		$this->assertStringContainsString( '--wp--preset--font-size--custom: 100px;', $stylesheet_for_block_theme, 'custom font size (100px) is present for block theme' );
-
-		switch_theme( WP_DEFAULT_THEME );
 	}
 }

--- a/tests/phpunit/tests/theme/wpGetGlobalStylesheet.php
+++ b/tests/phpunit/tests/theme/wpGetGlobalStylesheet.php
@@ -270,8 +270,12 @@ class Tests_Theme_wpGetGlobalStylesheet extends WP_UnitTestCase {
 			'Registered styles with handle of "wp-style-engine-my-styles" do not match expected value from the Style Engine store.'
 		);
 	}
-
-	public function test_switching_themes_recalculates_stylesheet() {
+	/**
+	 * Tests that switching themes recalculates the stylesheet.
+	 *
+	 * @ticket 56970
+	 */
+	public function test_switching_themes_should_recalculate_stylesheet() {
 		$stylesheet_for_default_theme = wp_get_global_stylesheet();
 		switch_theme( 'block-theme' );
 		$stylesheet_for_block_theme = wp_get_global_stylesheet();

--- a/tests/phpunit/tests/theme/wpGetGlobalStylesheet.php
+++ b/tests/phpunit/tests/theme/wpGetGlobalStylesheet.php
@@ -279,7 +279,10 @@ class Tests_Theme_wpGetGlobalStylesheet extends WP_UnitTestCase {
 		$stylesheet_for_default_theme = wp_get_global_stylesheet();
 		switch_theme( 'block-theme' );
 		$stylesheet_for_block_theme = wp_get_global_stylesheet();
+
 		$this->assertStringNotContainsString( '--wp--preset--font-size--custom: 100px;', $stylesheet_for_default_theme, 'custom font size (100px) not present for default theme' );
 		$this->assertStringContainsString( '--wp--preset--font-size--custom: 100px;', $stylesheet_for_block_theme, 'custom font size (100px) is present for block theme' );
+
+		switch_theme( WP_DEFAULT_THEME );
 	}
 }


### PR DESCRIPTION
Trac tickets: https://core.trac.wordpress.org/ticket/56910
Related to https://github.com/WordPress/gutenberg/issues/45171

Backports the relevant parts of these PRs:

- https://github.com/WordPress/gutenberg/pull/45679
- https://github.com/WordPress/gutenberg/pull/46150

This PR:

- provides a fix to an issue reported for 6.1.1 (see trac ticket and [gutenberg issue](https://github.com/WordPress/gutenberg/issues/45713))
- backports part of the work of introducing object cache to theme.json APIs ([see](https://github.com/WordPress/gutenberg/issues/45171))

Props @mmtr @felixarntz @spacedmonkey @aristath 
