### PR TITLE
Remove superfluous HTML span tags from SECURITY.md.

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,19 +34,19 @@ currently being supported with security updates.
 
 ## Reporting a Vulnerability
 
-[<span>WordPress</span>](https://wordpress.org/) is an open-source publishing platform. Our HackerOne program covers the Core software, as well as a variety of related projects and infrastructure.
+[WordPress](https://wordpress.org/) is an open-source publishing platform. Our HackerOne program covers the Core software, as well as a variety of related projects and infrastructure.
 
 Our most critical targets are:
 
-*   WordPress Core [<span>software</span>](https://wordpress.org/download/source/), [<span>API</span>](https://codex.wordpress.org/WordPress.org_API), and [<span>website</span>](https://wordpress.org/).
-*   Gutenberg [<span>software</span>](https://github.com/WordPress/gutenberg/) and Classic Editor [<span>software</span>](https://wordpress.org/plugins/classic-editor/).
-*   WP-CLI [<span>software</span>](https://github.com/wp-cli/) and [<span>website</span>](https://wp-cli.org/).
-*   BuddyPress [<span>software</span>](https://buddypress.org/download/) and [<span>website</span>](https://buddypress.org/).
-*   bbPress [<span>software</span>](https://bbpress.org/download/) and [<span>website</span>](https://bbpress.org/).
-*   GlotPress [<span>software</span>](https://github.com/glotpress/glotpress-wp) (but not the website).
-*   WordCamp.org [<span>website</span>](https://central.wordcamp.org).
+*   WordPress Core [software](https://wordpress.org/download/source/), [API](https://codex.wordpress.org/WordPress.org_API), and [website](https://wordpress.org/).
+*   Gutenberg [software](https://github.com/WordPress/gutenberg/) and Classic Editor [software](https://wordpress.org/plugins/classic-editor/).
+*   WP-CLI [software](https://github.com/wp-cli/) and [website](https://wp-cli.org/).
+*   BuddyPress [software](https://buddypress.org/download/) and [website](https://buddypress.org/).
+*   bbPress [software](https://bbpress.org/download/) and [website](https://bbpress.org/).
+*   GlotPress [software](https://github.com/glotpress/glotpress-wp) (but not the website).
+*   WordCamp.org [website](https://central.wordcamp.org).
 
-Source code for most websites can be found in the Meta repository (`git clone git://meta.git.wordpress.org/`). [<span>The Meta Environment</span>](https://github.com/WordPress/meta-environment) will automatically provision a local copy of some sites for you.
+Source code for most websites can be found in the Meta repository (`git clone git://meta.git.wordpress.org/`). [The Meta Environment](https://github.com/WordPress/meta-environment) will automatically provision a local copy of some sites for you.
 
 For more targets, see the `In Scope` section below.
 
@@ -58,14 +58,14 @@ Any reproducible vulnerability that has a severe effect on the security or priva
 
 We generally **aren’t** interested in the following problems:
 
-*   Any vulnerability with a [<span>CVSS 3</span>](https://www.first.org/cvss/calculator/3.0) score lower than `4.0`, unless it can be combined with other vulnerabilities to achieve a higher score.
+*   Any vulnerability with a [CVSS 3](https://www.first.org/cvss/calculator/3.0) score lower than `4.0`, unless it can be combined with other vulnerabilities to achieve a higher score.
 *   Brute force, DoS, phishing, text injection, or social engineering attacks. Wikis, Tracs, forums, etc are intended to allow users to edit them.
-*   Security vulnerabilities in WordPress plugins not _specifically_ listed as an in-scope asset. Out of scope plugins can be [<span>reported to the Plugin Review team</span>](https://developer.wordpress.org/plugins/wordpress-org/plugin-developer-faq/#how-can-i-send-a-security-report).
-*   Reports for hacked websites. The site owner can [<span>learn more about restoring their site</span>](https://make.wordpress.org/core/handbook/testing/reporting-security-vulnerabilities/#ive-been-hacked-what-do-i-do-now).
-*   [<span>Users with administrator or editor privileges can post arbitrary JavaScript</span>](https://make.wordpress.org/core/handbook/testing/reporting-security-vulnerabilities/#why-are-some-users-allowed-to-post-unfiltered-html)
-*   [<span>Disclosure of user IDs</span>](https://make.wordpress.org/core/handbook/testing/reporting-security-vulnerabilities/#why-are-disclosures-of-usernames-or-user-ids-not-a-security-issue)
-*   Open API endpoints serving public data (Including [<span>usernames and user IDs</span>](https://make.wordpress.org/core/handbook/testing/reporting-security-vulnerabilities/#why-are-disclosures-of-usernames-or-user-ids-not-a-security-issue))
-*   [<span>Path disclosures for errors, warnings, or notices</span>](https://make.wordpress.org/core/handbook/testing/reporting-security-vulnerabilities/#why-are-there-path-disclosures-when-directly-loading-certain-files)
+*   Security vulnerabilities in WordPress plugins not _specifically_ listed as an in-scope asset. Out of scope plugins can be [reported to the Plugin Review team](https://developer.wordpress.org/plugins/wordpress-org/plugin-developer-faq/#how-can-i-send-a-security-report).
+*   Reports for hacked websites. The site owner can [learn more about restoring their site](https://make.wordpress.org/core/handbook/testing/reporting-security-vulnerabilities/#ive-been-hacked-what-do-i-do-now).
+*   [Users with administrator or editor privileges can post arbitrary JavaScript](https://make.wordpress.org/core/handbook/testing/reporting-security-vulnerabilities/#why-are-some-users-allowed-to-post-unfiltered-html)
+*   [Disclosure of user IDs](https://make.wordpress.org/core/handbook/testing/reporting-security-vulnerabilities/#why-are-disclosures-of-usernames-or-user-ids-not-a-security-issue)
+*   Open API endpoints serving public data (Including [usernames and user IDs](https://make.wordpress.org/core/handbook/testing/reporting-security-vulnerabilities/#why-are-disclosures-of-usernames-or-user-ids-not-a-security-issue))
+*   [Path disclosures for errors, warnings, or notices](https://make.wordpress.org/core/handbook/testing/reporting-security-vulnerabilities/#why-are-there-path-disclosures-when-directly-loading-certain-files)
 *   WordPress version number disclosure
 *   Mixed content warnings for passive assets like images and videos
 *   Lack of HTTP security headers (CSP, X-XSS, etc.)
@@ -79,7 +79,7 @@ We generally **aren’t** interested in the following problems:
 
 We're committed to working with security researchers to resolve the vulnerabilities they discover. You can help us by following these guidelines:
 
-*   Follow [<span>HackerOne's disclosure guidelines</span>](https://www.hackerone.com/disclosure-guidelines).
+*   Follow [HackerOne's disclosure guidelines](https://www.hackerone.com/disclosure-guidelines).
 *   Pen-testing Production:
     *   Please **setup a local environment** instead whenever possible. Most of our code is open source (see above).
     *   If that's not possible, **limit any data access/modification** to the bare minimum necessary to reproduce a PoC.


### PR DESCRIPTION
Core's SECURITY.md file is written in Markdown, and while that allows for using inline HTML code, there is no reason (at least I couldn't find one documented) to wrap all link texts in extra HTML `<span>` tags.

This PR removes these extra tags to make the file more readable and maintainable.

Trac ticket: https://core.trac.wordpress.org/ticket/57243