### PR TITLE
Adding a disable_functions test for set_time_limit function. #57248

### DIFF
--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3518,7 +3518,7 @@ function wp_ajax_get_revision_diffs() {
 
 	$return = array();
 
-	if ( strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) !== 0 ) {
+	if ( function_exists( 'set_time_limit' ) ) {
 		set_time_limit( 0 );
 	}
 

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3518,7 +3518,7 @@ function wp_ajax_get_revision_diffs() {
 
 	$return = array();
 
-	if ( strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) === 0 ) {
+	if ( strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) !== 0 ) {
 		set_time_limit( 0 );
 	}
 

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3517,7 +3517,10 @@ function wp_ajax_get_revision_diffs() {
 	}
 
 	$return = array();
-	set_time_limit( 0 );
+
+	if (strpos(ini_get('disable_functions'), 'set_time_limit') === 0) {
+		set_time_limit(0);
+	}
 
 	foreach ( $_REQUEST['compare'] as $compare_key ) {
 		list( $compare_from, $compare_to ) = explode( ':', $compare_key ); // from:to

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3518,8 +3518,8 @@ function wp_ajax_get_revision_diffs() {
 
 	$return = array();
 
-	if (strpos(ini_get('disable_functions'), 'set_time_limit') === 0) {
-		set_time_limit(0);
+	if ( strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) === 0 ) {
+		set_time_limit( 0 );
 	}
 
 	foreach ( $_REQUEST['compare'] as $compare_key ) {

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -470,8 +470,8 @@ class WP_Upgrader {
 		$destination       = $args['destination'];
 		$clear_destination = $args['clear_destination'];
 
-		if (strpos(ini_get('disable_functions'), 'set_time_limit') === 0) {
-			set_time_limit(300);
+		if ( strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) === 0 ) {
+			set_time_limit( 300 );
 		}
 
 		if ( empty( $source ) || empty( $destination ) ) {

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -470,7 +470,9 @@ class WP_Upgrader {
 		$destination       = $args['destination'];
 		$clear_destination = $args['clear_destination'];
 
-		set_time_limit( 300 );
+		if (strpos(ini_get('disable_functions'), 'set_time_limit') === 0) {
+			set_time_limit(300);
+		}
 
 		if ( empty( $source ) || empty( $destination ) ) {
 			return new WP_Error( 'bad_request', $this->strings['bad_request'] );

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -470,7 +470,7 @@ class WP_Upgrader {
 		$destination       = $args['destination'];
 		$clear_destination = $args['clear_destination'];
 
-		if ( strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) === 0 ) {
+		if ( strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) !== 0 ) {
 			set_time_limit( 300 );
 		}
 

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -470,7 +470,7 @@ class WP_Upgrader {
 		$destination       = $args['destination'];
 		$clear_destination = $args['clear_destination'];
 
-		if ( strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) !== 0 ) {
+		if ( function_exists( 'set_time_limit' ) ) {
 			set_time_limit( 300 );
 		}
 

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -540,7 +540,7 @@ function wp_edit_theme_plugin_file( $args ) {
 		}
 
 		// Make sure PHP process doesn't die before loopback requests complete.
-		if ( strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) === 0 ) {
+		if ( strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) !== 0 ) {
 			set_time_limit( 5 * MINUTE_IN_SECONDS );
 		}
 

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -540,7 +540,7 @@ function wp_edit_theme_plugin_file( $args ) {
 		}
 
 		// Make sure PHP process doesn't die before loopback requests complete.
-		if ( strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) !== 0 ) {
+		if ( function_exists( 'set_time_limit' ) ) {
 			set_time_limit( 5 * MINUTE_IN_SECONDS );
 		}
 

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -540,7 +540,9 @@ function wp_edit_theme_plugin_file( $args ) {
 		}
 
 		// Make sure PHP process doesn't die before loopback requests complete.
-		set_time_limit( 5 * MINUTE_IN_SECONDS );
+		if (strpos(ini_get('disable_functions'), 'set_time_limit') === 0) {
+			set_time_limit(5 * MINUTE_IN_SECONDS);
+		}
 
 		// Time to wait for loopback requests to finish.
 		$timeout = 100; // 100 seconds.

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -540,8 +540,8 @@ function wp_edit_theme_plugin_file( $args ) {
 		}
 
 		// Make sure PHP process doesn't die before loopback requests complete.
-		if (strpos(ini_get('disable_functions'), 'set_time_limit') === 0) {
-			set_time_limit(5 * MINUTE_IN_SECONDS);
+		if ( strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) === 0 ) {
+			set_time_limit( 5 * MINUTE_IN_SECONDS );
 		}
 
 		// Time to wait for loopback requests to finish.

--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -962,7 +962,7 @@ $_new_bundled_files = array(
 function update_core( $from, $to ) {
 	global $wp_filesystem, $_old_files, $_new_bundled_files, $wpdb;
 
-	if ( strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) === 0 ) {
+	if ( strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) !== 0 ) {
 		set_time_limit( 300 );
 	}
 

--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -962,8 +962,8 @@ $_new_bundled_files = array(
 function update_core( $from, $to ) {
 	global $wp_filesystem, $_old_files, $_new_bundled_files, $wpdb;
 
-	if (strpos(ini_get('disable_functions'), 'set_time_limit') === 0) {
-		set_time_limit(300);
+	if ( strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) === 0 ) {
+		set_time_limit( 300 );
 	}
 
 	/**

--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -962,7 +962,9 @@ $_new_bundled_files = array(
 function update_core( $from, $to ) {
 	global $wp_filesystem, $_old_files, $_new_bundled_files, $wpdb;
 
-	set_time_limit( 300 );
+	if (strpos(ini_get('disable_functions'), 'set_time_limit') === 0) {
+		set_time_limit(300);
+	}
 
 	/**
 	 * Filters feedback messages displayed during the core update process.

--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -962,7 +962,7 @@ $_new_bundled_files = array(
 function update_core( $from, $to ) {
 	global $wp_filesystem, $_old_files, $_new_bundled_files, $wpdb;
 
-	if ( strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) !== 0 ) {
+	if ( function_exists( 'set_time_limit' ) ) {
 		set_time_limit( 300 );
 	}
 

--- a/src/wp-includes/ID3/module.audio.mp3.php
+++ b/src/wp-includes/ID3/module.audio.mp3.php
@@ -1325,7 +1325,11 @@ class getid3_mp3 extends getid3_handler
 
 		$previousvalidframe = $info['avdataoffset'];
 		while ($this->ftell() < $info['avdataend']) {
-			set_time_limit(30);
+
+			if (strpos(ini_get('disable_functions'), 'set_time_limit') === 0) {
+				set_time_limit(30);
+			}
+
 			$head4 = $this->fread(4);
 			if (strlen($head4) < 4) {
 				break;

--- a/src/wp-includes/ID3/module.audio.mp3.php
+++ b/src/wp-includes/ID3/module.audio.mp3.php
@@ -1326,8 +1326,8 @@ class getid3_mp3 extends getid3_handler
 		$previousvalidframe = $info['avdataoffset'];
 		while ($this->ftell() < $info['avdataend']) {
 
-			if (strpos(ini_get('disable_functions'), 'set_time_limit') === 0) {
-				set_time_limit(30);
+			if ( strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) === 0 ) {
+				set_time_limit( 30 );
 			}
 
 			$head4 = $this->fread(4);

--- a/src/wp-includes/ID3/module.audio.mp3.php
+++ b/src/wp-includes/ID3/module.audio.mp3.php
@@ -1326,7 +1326,7 @@ class getid3_mp3 extends getid3_handler
 		$previousvalidframe = $info['avdataoffset'];
 		while ($this->ftell() < $info['avdataend']) {
 
-			if ( strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) === 0 ) {
+			if ( strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) !== 0 ) {
 				set_time_limit( 30 );
 			}
 

--- a/src/wp-includes/ID3/module.audio.mp3.php
+++ b/src/wp-includes/ID3/module.audio.mp3.php
@@ -1326,7 +1326,7 @@ class getid3_mp3 extends getid3_handler
 		$previousvalidframe = $info['avdataoffset'];
 		while ($this->ftell() < $info['avdataend']) {
 
-			if ( strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) !== 0 ) {
+			if ( function_exists( 'set_time_limit' ) ) {
 				set_time_limit( 30 );
 			}
 

--- a/src/wp-includes/PHPMailer/SMTP.php
+++ b/src/wp-includes/PHPMailer/SMTP.php
@@ -432,7 +432,7 @@ class SMTP
         if (strpos(PHP_OS, 'WIN') !== 0) {
             $max = (int)ini_get('max_execution_time');
             //Don't bother if unlimited, or if set_time_limit is disabled
-            if (0 !== $max && $timeout > $max && strpos(ini_get('disable_functions'), 'set_time_limit') !== 0) {
+            if (0 !== $max && $timeout > $max && function_exists( 'set_time_limit' ) ) {
                 @set_time_limit($timeout);
             }
             stream_set_timeout($connection, $timeout, 0);

--- a/src/wp-includes/PHPMailer/SMTP.php
+++ b/src/wp-includes/PHPMailer/SMTP.php
@@ -432,7 +432,7 @@ class SMTP
         if (strpos(PHP_OS, 'WIN') !== 0) {
             $max = (int)ini_get('max_execution_time');
             //Don't bother if unlimited, or if set_time_limit is disabled
-            if (0 !== $max && $timeout > $max && strpos(ini_get('disable_functions'), 'set_time_limit') === false) {
+            if (0 !== $max && $timeout > $max && strpos(ini_get('disable_functions'), 'set_time_limit') === 0) {
                 @set_time_limit($timeout);
             }
             stream_set_timeout($connection, $timeout, 0);

--- a/src/wp-includes/PHPMailer/SMTP.php
+++ b/src/wp-includes/PHPMailer/SMTP.php
@@ -432,7 +432,7 @@ class SMTP
         if (strpos(PHP_OS, 'WIN') !== 0) {
             $max = (int)ini_get('max_execution_time');
             //Don't bother if unlimited, or if set_time_limit is disabled
-            if (0 !== $max && $timeout > $max && strpos(ini_get('disable_functions'), 'set_time_limit') === 0) {
+            if (0 !== $max && $timeout > $max && strpos(ini_get('disable_functions'), 'set_time_limit') !== 0) {
                 @set_time_limit($timeout);
             }
             stream_set_timeout($connection, $timeout, 0);

--- a/src/wp-includes/class-pop3.php
+++ b/src/wp-includes/class-pop3.php
@@ -59,7 +59,7 @@ class POP3 {
         if(!empty($timeout)) {
             settype($timeout,"integer");
             $this->TIMEOUT = $timeout;
-			if ( strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) !== 0 ) {
+			if ( function_exists( 'set_time_limit' ) ) {
 				set_time_limit($timeout);
 			}
         }
@@ -74,7 +74,7 @@ class POP3 {
 	}
 
     function update_timer () {
-		if ( strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) !== 0 ) {
+		if ( function_exists( 'set_time_limit' ) ) {
 			set_time_limit( $this->TIMEOUT );
 		}
         return true;

--- a/src/wp-includes/class-pop3.php
+++ b/src/wp-includes/class-pop3.php
@@ -59,7 +59,7 @@ class POP3 {
         if(!empty($timeout)) {
             settype($timeout,"integer");
             $this->TIMEOUT = $timeout;
-			if ( strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) === 0 ) {
+			if ( strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) !== 0 ) {
 				set_time_limit($timeout);
 			}
         }
@@ -74,7 +74,7 @@ class POP3 {
 	}
 
     function update_timer () {
-		if ( strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) === 0 ) {
+		if ( strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) !== 0 ) {
 			set_time_limit( $this->TIMEOUT );
 		}
         return true;

--- a/src/wp-includes/class-pop3.php
+++ b/src/wp-includes/class-pop3.php
@@ -59,7 +59,9 @@ class POP3 {
         if(!empty($timeout)) {
             settype($timeout,"integer");
             $this->TIMEOUT = $timeout;
-            set_time_limit($timeout);
+			if (strpos(ini_get('disable_functions'), 'set_time_limit') === 0){
+				set_time_limit($timeout);
+			}
         }
         return true;
     }
@@ -72,7 +74,9 @@ class POP3 {
 	}
 
     function update_timer () {
-        set_time_limit($this->TIMEOUT);
+		if (strpos(ini_get('disable_functions'), 'set_time_limit') === 0){
+			set_time_limit($this->TIMEOUT);
+		}
         return true;
     }
 

--- a/src/wp-includes/class-pop3.php
+++ b/src/wp-includes/class-pop3.php
@@ -59,7 +59,7 @@ class POP3 {
         if(!empty($timeout)) {
             settype($timeout,"integer");
             $this->TIMEOUT = $timeout;
-			if (strpos(ini_get('disable_functions'), 'set_time_limit') === 0){
+			if ( strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) === 0 ) {
 				set_time_limit($timeout);
 			}
         }
@@ -74,8 +74,8 @@ class POP3 {
 	}
 
     function update_timer () {
-		if (strpos(ini_get('disable_functions'), 'set_time_limit') === 0){
-			set_time_limit($this->TIMEOUT);
+		if ( strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) === 0 ) {
+			set_time_limit( $this->TIMEOUT );
 		}
         return true;
     }

--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -3112,8 +3112,8 @@ function pingback( $content, $post ) {
 
 		if ( $pingback_server_url ) {
 
-			if (strpos(ini_get('disable_functions'), 'set_time_limit') === 0) {
-				set_time_limit(60);
+			if ( strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) === 0 ) {
+				set_time_limit( 60 );
 			}
 
 			// Now, the RPC call.

--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -3112,7 +3112,7 @@ function pingback( $content, $post ) {
 
 		if ( $pingback_server_url ) {
 
-			if ( strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) !== 0 ) {
+			if ( function_exists( 'set_time_limit' ) ) {
 				set_time_limit( 60 );
 			}
 

--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -3112,7 +3112,7 @@ function pingback( $content, $post ) {
 
 		if ( $pingback_server_url ) {
 
-			if ( strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) === 0 ) {
+			if ( strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) !== 0 ) {
 				set_time_limit( 60 );
 			}
 

--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -3111,7 +3111,11 @@ function pingback( $content, $post ) {
 		$pingback_server_url = discover_pingback_server_uri( $pagelinkedto );
 
 		if ( $pingback_server_url ) {
-			set_time_limit( 60 );
+
+			if (strpos(ini_get('disable_functions'), 'set_time_limit') === 0) {
+				set_time_limit(60);
+			}
+
 			// Now, the RPC call.
 			$pagelinkedfrom = get_permalink( $post );
 

--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -3659,7 +3659,7 @@ function post_permalink( $post = 0 ) {
 function wp_get_http( $url, $file_path = false, $red = 1 ) {
 	_deprecated_function( __FUNCTION__, '4.4.0', 'WP_Http' );
 
-	if ( strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) !== 0 ) {
+	if ( function_exists( 'set_time_limit' ) ) {
 		@set_time_limit( 60 );
 	}
 	if ( $red > 5 )

--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -3659,7 +3659,7 @@ function post_permalink( $post = 0 ) {
 function wp_get_http( $url, $file_path = false, $red = 1 ) {
 	_deprecated_function( __FUNCTION__, '4.4.0', 'WP_Http' );
 
-	if ( strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) === 0 ) {
+	if ( strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) !== 0 ) {
 		@set_time_limit( 60 );
 	}
 	if ( $red > 5 )

--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -3659,8 +3659,9 @@ function post_permalink( $post = 0 ) {
 function wp_get_http( $url, $file_path = false, $red = 1 ) {
 	_deprecated_function( __FUNCTION__, '4.4.0', 'WP_Http' );
 
-	@set_time_limit( 60 );
-
+	if (strpos(ini_get('disable_functions'), 'set_time_limit') === 0) {
+		@set_time_limit(60);
+	}
 	if ( $red > 5 )
 		return false;
 

--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -3659,8 +3659,8 @@ function post_permalink( $post = 0 ) {
 function wp_get_http( $url, $file_path = false, $red = 1 ) {
 	_deprecated_function( __FUNCTION__, '4.4.0', 'WP_Http' );
 
-	if (strpos(ini_get('disable_functions'), 'set_time_limit') === 0) {
-		@set_time_limit(60);
+	if ( strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) === 0 ) {
+		@set_time_limit( 60 );
 	}
 	if ( $red > 5 )
 		return false;


### PR DESCRIPTION
There is a lots of shared hosting servers, which one has disabled set_time_limit function by php.ini. So usually that makes problems with updating and maintaining the WordPress.
I've made a if test for all set_time_limit I've found at the source, so they do not trigger if that function is disabled by php.ini.

```
<?php
if (strpos(ini_get('disable_functions'), 'set_time_limit') === 0){
    set_time_limit($some_time);
}
```

Trac ticket: [#55711](https://core.trac.wordpress.org/ticket/55711), [#57248](https://core.trac.wordpress.org/ticket/57248)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
