### PR TITLE
Implementing the new `Requires Network` plugin header

### DIFF
--- a/src/wp-admin/includes/class-plugin-installer-skin.php
+++ b/src/wp-admin/includes/class-plugin-installer-skin.php
@@ -261,7 +261,7 @@ class Plugin_Installer_Skin extends WP_Upgrader_Skin {
 
 		$requires_php     = isset( $new_plugin_data['RequiresPHP'] ) ? $new_plugin_data['RequiresPHP'] : null;
 		$requires_wp      = isset( $new_plugin_data['RequiresWP'] ) ? $new_plugin_data['RequiresWP'] : null;
-		$requires_network = isset( $new_plugin_data['Requires Network'] ) ? $new_plugin_data['Requires Network'] : null;
+		$requires_network = isset( $new_plugin_data['RequiresNetwork'] ) ? $new_plugin_data['RequiresNetwork'] : null;
 
 		if ( ! is_php_version_compatible( $requires_php ) ) {
 			$error = sprintf(

--- a/src/wp-admin/includes/class-plugin-installer-skin.php
+++ b/src/wp-admin/includes/class-plugin-installer-skin.php
@@ -259,8 +259,9 @@ class Plugin_Installer_Skin extends WP_Upgrader_Skin {
 		$blocked_message  = '<p>' . esc_html__( 'The plugin cannot be updated due to the following:' ) . '</p>';
 		$blocked_message .= '<ul class="ul-disc">';
 
-		$requires_php = isset( $new_plugin_data['RequiresPHP'] ) ? $new_plugin_data['RequiresPHP'] : null;
-		$requires_wp  = isset( $new_plugin_data['RequiresWP'] ) ? $new_plugin_data['RequiresWP'] : null;
+		$requires_php     = isset( $new_plugin_data['RequiresPHP'] ) ? $new_plugin_data['RequiresPHP'] : null;
+		$requires_wp      = isset( $new_plugin_data['RequiresWP'] ) ? $new_plugin_data['RequiresWP'] : null;
+		$requires_network = isset( $new_plugin_data['Requires Network'] ) ? $new_plugin_data['Requires Network'] : null;
 
 		if ( ! is_php_version_compatible( $requires_php ) ) {
 			$error = sprintf(
@@ -281,6 +282,13 @@ class Plugin_Installer_Skin extends WP_Upgrader_Skin {
 				get_bloginfo( 'version' ),
 				$requires_wp
 			);
+
+			$blocked_message .= '<li>' . esc_html( $error ) . '</li>';
+			$can_update       = false;
+		}
+
+		if ( ! is_wp_installation_compatible( $requires_network ) ) {
+			$error = __( 'The uploaded plugin requires a network installation to work.' );
 
 			$blocked_message .= '<li>' . esc_html( $error ) . '</li>';
 			$can_update       = false;

--- a/src/wp-admin/includes/class-plugin-upgrader.php
+++ b/src/wp-admin/includes/class-plugin-upgrader.php
@@ -442,7 +442,7 @@ class Plugin_Upgrader extends WP_Upgrader {
 
 		$requires_php     = isset( $info['RequiresPHP'] ) ? $info['RequiresPHP'] : null;
 		$requires_wp      = isset( $info['RequiresWP'] ) ? $info['RequiresWP'] : null;
-		$requires_network = isset( $new_plugin_data['Requires Network'] ) ? $new_plugin_data['Requires Network'] : null;
+		$requires_network = isset( $new_plugin_data['RequiresNetwork'] ) ? $new_plugin_data['RequiresNetwork'] : null;
 
 		if ( ! is_php_version_compatible( $requires_php ) ) {
 			$error = sprintf(

--- a/src/wp-admin/includes/class-plugin-upgrader.php
+++ b/src/wp-admin/includes/class-plugin-upgrader.php
@@ -440,8 +440,9 @@ class Plugin_Upgrader extends WP_Upgrader {
 			return new WP_Error( 'incompatible_archive_no_plugins', $this->strings['incompatible_archive'], __( 'No valid plugins were found.' ) );
 		}
 
-		$requires_php = isset( $info['RequiresPHP'] ) ? $info['RequiresPHP'] : null;
-		$requires_wp  = isset( $info['RequiresWP'] ) ? $info['RequiresWP'] : null;
+		$requires_php     = isset( $info['RequiresPHP'] ) ? $info['RequiresPHP'] : null;
+		$requires_wp      = isset( $info['RequiresWP'] ) ? $info['RequiresWP'] : null;
+		$requires_network = isset( $new_plugin_data['Requires Network'] ) ? $new_plugin_data['Requires Network'] : null;
 
 		if ( ! is_php_version_compatible( $requires_php ) ) {
 			$error = sprintf(
@@ -463,6 +464,12 @@ class Plugin_Upgrader extends WP_Upgrader {
 			);
 
 			return new WP_Error( 'incompatible_wp_required_version', $this->strings['incompatible_archive'], $error );
+		}
+
+		if ( ! is_wp_installation_compatible( $requires_network ) ) {
+			$error = __( 'The uploaded plugin requires a network installation to work.' );
+
+			return new WP_Error( 'incompatible_wp_installation', $this->strings['incompatible_archive'], $error );
 		}
 
 		return $source;

--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -737,11 +737,13 @@ class WP_Plugins_List_Table extends WP_List_Table {
 		$restrict_network_active = false;
 		$restrict_network_only   = false;
 
-		$requires_php = isset( $plugin_data['RequiresPHP'] ) ? $plugin_data['RequiresPHP'] : null;
-		$requires_wp  = isset( $plugin_data['RequiresWP'] ) ? $plugin_data['RequiresWP'] : null;
+		$requires_php     = isset( $plugin_data['RequiresPHP'] ) ? $plugin_data['RequiresPHP'] : null;
+		$requires_wp      = isset( $plugin_data['RequiresWP'] ) ? $plugin_data['RequiresWP'] : null;
+		$requires_network = isset( $plugin_data['Requires Network'] ) ? $plugin_data['Requires Network'] : null;
 
-		$compatible_php = is_php_version_compatible( $requires_php );
-		$compatible_wp  = is_wp_version_compatible( $requires_wp );
+		$compatible_php             = is_php_version_compatible( $requires_php );
+		$compatible_wp              = is_wp_version_compatible( $requires_wp );
+		$compatible_wp_installation = is_wp_installation_compatible( $requires_network );
 
 		if ( 'mustuse' === $context ) {
 			$is_active = true;
@@ -857,7 +859,7 @@ class WP_Plugins_List_Table extends WP_List_Table {
 					}
 				} else {
 					if ( current_user_can( 'activate_plugin', $plugin_file ) ) {
-						if ( $compatible_php && $compatible_wp ) {
+						if ( $compatible_php && $compatible_wp && $compatible_wp_installation ) {
 							$actions['activate'] = sprintf(
 								'<a href="%s" id="activate-%s" class="edit" aria-label="%s">%s</a>',
 								wp_nonce_url( 'plugins.php?action=activate&amp;plugin=' . urlencode( $plugin_file ) . '&amp;plugin_status=' . $context . '&amp;paged=' . $page . '&amp;s=' . $s, 'activate-plugin_' . $plugin_file ),
@@ -997,7 +999,7 @@ class WP_Plugins_List_Table extends WP_List_Table {
 		}
 
 		if ( ! empty( $totals['upgrade'] ) && ! empty( $plugin_data['update'] )
-			|| ! $compatible_php || ! $compatible_wp
+			|| ! $compatible_php || ! $compatible_wp || ! $compatible_wp_installation
 		) {
 			$class .= ' update';
 		}
@@ -1261,7 +1263,7 @@ class WP_Plugins_List_Table extends WP_List_Table {
 
 		echo '</tr>';
 
-		if ( ! $compatible_php || ! $compatible_wp ) {
+		if ( ! $compatible_php || ! $compatible_wp || ! $compatible_wp_installation ) {
 			printf(
 				'<tr class="plugin-update-tr">' .
 				'<td colspan="%s" class="plugin-update colspanchange">' .
@@ -1311,6 +1313,15 @@ class WP_Plugins_List_Table extends WP_List_Table {
 						esc_url( wp_get_update_php_url() )
 					);
 					wp_update_php_annotation( '</p><p><em>', '</em>' );
+				}
+			} elseif ( ! $compatible_wp_installation ) {
+				_e( 'The uploaded plugin requires a network installation to work.' );
+				if ( current_user_can( 'setup_network' ) ) {
+					printf(
+						/* translators: %s: URL to Update PHP page. */
+						' ' . __( '<a href="%s">Learn more about network installation.</a>.' ),
+						esc_url( wp_get_default_network_installation_url() )
+					);
 				}
 			}
 

--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -739,7 +739,7 @@ class WP_Plugins_List_Table extends WP_List_Table {
 
 		$requires_php     = isset( $plugin_data['RequiresPHP'] ) ? $plugin_data['RequiresPHP'] : null;
 		$requires_wp      = isset( $plugin_data['RequiresWP'] ) ? $plugin_data['RequiresWP'] : null;
-		$requires_network = isset( $plugin_data['Requires Network'] ) ? $plugin_data['Requires Network'] : null;
+		$requires_network = isset( $plugin_data['RequiresNetwork'] ) ? $plugin_data['RequiresNetwork'] : null;
 
 		$compatible_php             = is_php_version_compatible( $requires_php );
 		$compatible_wp              = is_wp_version_compatible( $requires_wp );

--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -1319,7 +1319,7 @@ class WP_Plugins_List_Table extends WP_List_Table {
 				if ( current_user_can( 'setup_network' ) ) {
 					printf(
 						/* translators: %s: URL to Update PHP page. */
-						' ' . __( '<a href="%s">Learn more about network installation.</a>.' ),
+						' ' . __( '<a href="%s">Learn more about network installation</a>.' ),
 						esc_url( wp_get_default_network_installation_url() )
 					);
 				}

--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -72,18 +72,19 @@
 function get_plugin_data( $plugin_file, $markup = true, $translate = true ) {
 
 	$default_headers = array(
-		'Name'        => 'Plugin Name',
-		'PluginURI'   => 'Plugin URI',
-		'Version'     => 'Version',
-		'Description' => 'Description',
-		'Author'      => 'Author',
-		'AuthorURI'   => 'Author URI',
-		'TextDomain'  => 'Text Domain',
-		'DomainPath'  => 'Domain Path',
-		'Network'     => 'Network',
-		'RequiresWP'  => 'Requires at least',
-		'RequiresPHP' => 'Requires PHP',
-		'UpdateURI'   => 'Update URI',
+		'Name'            => 'Plugin Name',
+		'PluginURI'       => 'Plugin URI',
+		'Version'         => 'Version',
+		'Description'     => 'Description',
+		'Author'          => 'Author',
+		'AuthorURI'       => 'Author URI',
+		'TextDomain'      => 'Text Domain',
+		'DomainPath'      => 'Domain Path',
+		'Network'         => 'Network',
+		'RequiresWP'      => 'Requires at least',
+		'RequiresPHP'     => 'Requires PHP',
+		'UpdateURI'       => 'Update URI',
+		'RequiresNetwork' => 'Requires Network',
 		// Site Wide Only is deprecated in favor of Network.
 		'_sitewide'   => 'Site Wide Only',
 	);
@@ -1124,12 +1125,14 @@ function validate_plugin_requirements( $plugin ) {
 	$plugin_headers = get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin );
 
 	$requirements = array(
-		'requires'     => ! empty( $plugin_headers['RequiresWP'] ) ? $plugin_headers['RequiresWP'] : '',
-		'requires_php' => ! empty( $plugin_headers['RequiresPHP'] ) ? $plugin_headers['RequiresPHP'] : '',
+		'requires'         => ! empty( $plugin_headers['RequiresWP'] ) ? $plugin_headers['RequiresWP'] : '',
+		'requires_php'     => ! empty( $plugin_headers['RequiresPHP'] ) ? $plugin_headers['RequiresPHP'] : '',
+		'requires_network' => ! empty( $plugin_headers['RequiresNetwork'] ) ? $plugin_headers['RequiresNetwork'] : '',
 	);
 
-	$compatible_wp  = is_wp_version_compatible( $requirements['requires'] );
-	$compatible_php = is_php_version_compatible( $requirements['requires_php'] );
+	$compatible_wp              = is_wp_version_compatible( $requirements['requires'] );
+	$compatible_php             = is_php_version_compatible( $requirements['requires_php'] );
+	$compatible_wp_installation = is_wp_installation_compatible( $requirements['requires_network'] );
 
 	$php_update_message = '</p><p>' . sprintf(
 		/* translators: %s: URL to Update PHP page. */
@@ -1176,6 +1179,15 @@ function validate_plugin_requirements( $plugin ) {
 				get_bloginfo( 'version' ),
 				$plugin_headers['Name'],
 				$requirements['requires']
+			) . '</p>'
+		);
+	} elseif ( ! $compatible_wp_installation ) {
+		return new WP_Error(
+			'plugin_wp_incompatible',
+			'<p>' . sprintf(
+				/* translators: 1: Plugin name. */
+				_x( '<strong>Error:</strong> Current WordPress installation does not meet the requirements for %1$s. The plugin requires a network installation.', 'plugin' ),
+				$plugin_headers['Name']
 			) . '</p>'
 		);
 	}

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -7993,6 +7993,65 @@ function wp_get_default_update_php_url() {
 }
 
 /**
+ * Gets the URL to learn more about installing a network.
+ *
+ * This URL can be overridden by specifying an environment variable `WP_NETWORK_INSTALLATION_URL` or by using the
+ * {@see 'wp_network_installation_url'} filter. Providing an empty string is not allowed and will result in the
+ * default URL being used. Furthermore the page the URL links to should preferably be localized in the
+ * site language.
+ *
+ * @since 6.2.0
+ *
+ * @return string URL to learn more about installing a network.
+ */
+function wp_get_network_installation_url() {
+	$default_url = wp_get_default_network_installation_url();
+
+	$update_url = $default_url;
+	if ( false !== getenv( 'WP_NETWORK_INSTALLATION_URL' ) ) {
+		$update_url = getenv( 'WP_NETWORK_INSTALLATION_URL' );
+	}
+
+	/**
+	 * Filters the URL to learn more about installing a network.
+	 *
+	 * Providing an empty string is not allowed and will result in the default URL being used. Furthermore
+	 * the page the URL links to should preferably be localized in the site language.
+	 *
+	 * @since 6.2.0
+	 *
+	 * @param string $update_url URL to learn more about installing a network.
+	 */
+	$update_url = apply_filters( 'wp_network_installation_url', $update_url );
+
+	if ( empty( $update_url ) ) {
+		$update_url = $default_url;
+	}
+
+	return $update_url;
+}
+
+/**
+ * Gets the default URL to learn more about installing a network.
+ *
+ * Do not use this function to retrieve this URL. Instead, use {@see wp_get_network_installation_url()} when relying
+ * on the URL.
+ * This function does not allow modifying the returned URL, and is only used to compare the actually used URL with the
+ * default one.
+ *
+ * @since 6.2.0
+ * @access private
+ *
+ * @return string Default URL to learn more about updating PHP.
+ */
+function wp_get_default_network_installation_url() {
+	return _x(
+		'https://wordpress.org/support/article/create-a-network/',
+		'localized network installation information page'
+	);
+}
+
+/**
  * Prints the default annotation for the web host altering the "Update PHP" page URL.
  *
  * This function is to be used after {@see wp_get_update_php_url()} to display a consistent
@@ -8412,6 +8471,29 @@ function is_wp_version_compatible( $required ) {
  */
 function is_php_version_compatible( $required ) {
 	return empty( $required ) || version_compare( PHP_VERSION, $required, '>=' );
+}
+
+/**
+ * Checks compatibility with the current WordPress installation.
+ *
+ * @since 6.2.0
+ *
+ * @param string|int|bool $required
+ *
+ * @return bool
+ */
+function is_wp_installation_compatible( $required ) {
+	if ( is_string( $required ) ) {
+		$requires_network = true;
+		$required         = strtolower( $required );
+		if ( empty( $required ) || in_array( $required, array( 'false', '0' ), true ) ) {
+			$requires_network = false;
+		}
+	} else {
+		$requires_network = (bool) $required;
+	}
+
+	return false === $requires_network || is_multisite();
 }
 
 /**

--- a/tests/phpunit/tests/functions/isWpInstallationCompatible.php
+++ b/tests/phpunit/tests/functions/isWpInstallationCompatible.php
@@ -15,12 +15,12 @@ class Tests_Functions_IsWpInstallationCompatible extends WP_UnitTestCase {
 	 * @param mixed $required The required WordPress installation, truthy for multisite and falsy for .
 	 * @param bool  $expected The expected result.
 	 */
-	public function test_is_php_version_compatible( $required, $expected ) {
+	public function test_is_wp_installation_compatible( $required, $expected ) {
 		$this->assertSame( $expected, is_wp_installation_compatible( $required ) );
 	}
 
 	/**
-	 * Data provider.
+	 * Data provider for test_is_wp_installation_compatible()
 	 *
 	 * @return array
 	 */

--- a/tests/phpunit/tests/functions/isWpInstallationCompatible.php
+++ b/tests/phpunit/tests/functions/isWpInstallationCompatible.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * Tests the is_wp_installation_compatible() function.
+ *
+ * @group functions.php
+ * @covers ::is_wp_installation_compatible
+ */
+class Tests_Functions_IsWpInstallationCompatible extends WP_UnitTestCase {
+	/**
+	 * Tests is_wp_installation_compatible().
+	 *
+	 * @dataProvider data_is_wp_installation_compatible
+	 *
+	 * @param mixed $required The required WordPress installation, truthy for multisite and falsy for .
+	 * @param bool  $expected The expected result.
+	 */
+	public function test_is_php_version_compatible( $required, $expected ) {
+		$this->assertSame( $expected, is_wp_installation_compatible( $required ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_is_wp_installation_compatible() {
+
+		return array(
+			'true'         => array(
+				'required' => true,
+				'expected' => is_multisite(),
+			),
+			'false'        => array(
+				'required' => false,
+				'expected' => true,
+			),
+			'1 int'        => array(
+				'required' => 1,
+				'expected' => is_multisite(),
+			),
+			'0 int'        => array(
+				'required' => 0,
+				'expected' => true,
+			),
+			'empty string' => array(
+				'required' => '',
+				'expected' => true,
+			),
+			'null'         => array(
+				'required' => null,
+				'expected' => true,
+			),
+			'true string'  => array(
+				'required' => 'true',
+				'expected' => is_multisite(),
+			),
+			'false string' => array(
+				'required' => 'false',
+				'expected' => true,
+			),
+			'1 string'     => array(
+				'required' => '1',
+				'expected' => is_multisite(),
+			),
+			'0 string'     => array(
+				'required' => '0',
+				'expected' => true,
+			),
+		);
+	}
+}

--- a/tests/phpunit/tests/functions/isWpInstallationCompatible.php
+++ b/tests/phpunit/tests/functions/isWpInstallationCompatible.php
@@ -12,7 +12,7 @@ class Tests_Functions_IsWpInstallationCompatible extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_is_wp_installation_compatible
 	 *
-	 * @param mixed $required The required WordPress installation, truthy for multisite and falsy for .
+	 * @param mixed $required The required WordPress installation, true for multisite false otherwise.
 	 * @param bool  $expected The expected result.
 	 */
 	public function test_is_wp_installation_compatible( $required, $expected ) {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Implementation of the new `Requires Network` plugin header.

Changes from this PR only touch parts of the admin UI that relies on data from `get_plugin_data`.
Other parts of the admin that use the response from the WP.org plugin API were not updated.

Trac ticket: https://core.trac.wordpress.org/ticket/57220

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
