### PR TITLE
Media: Replace consecutive periods in `sanitize_file_name()`.

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2047,6 +2047,7 @@ function sanitize_file_name( $filename ) {
 
 	$filename = str_replace( $special_chars, '', $filename );
 	$filename = str_replace( array( '%20', '+' ), '-', $filename );
+	$filename = preg_replace( '/\.{2,}/', '.', $filename );
 	$filename = preg_replace( '/[\r\n\t -]+/', '-', $filename );
 	$filename = trim( $filename, '.-_' );
 

--- a/tests/phpunit/tests/formatting/sanitizeFileName.php
+++ b/tests/phpunit/tests/formatting/sanitizeFileName.php
@@ -95,4 +95,53 @@ class Tests_Formatting_SanitizeFileName extends WP_UnitTestCase {
 			array( 'demo' . json_decode( '"\u00a0"' ) . 'bar.png', 'demo-bar.png' ),
 		);
 	}
+
+	/**
+	 * Tests that sanitize_file_name() replaces consecutive periods
+	 * with a single period.
+	 *
+	 * @ticket 57242
+	 *
+	 * @dataProvider data_sanitize_file_name_should_replace_consecutive_periods_with_a_single_period
+	 *
+	 * @param string $filename A filename with consecutive periods.
+	 * @param string $expected The expected filename after sanitization.
+	 */
+	public function test_sanitize_file_name_should_replace_consecutive_periods_with_a_single_period( $filename, $expected ) {
+		$this->assertSame( $expected, sanitize_file_name( $filename ) );
+	}
+
+	/**
+	 * Data provider for test_sanitize_file_name_should_replace_consecutive_periods_with_a_single_period().
+	 *
+	 * @return array[]
+	 */
+	public function data_sanitize_file_name_should_replace_consecutive_periods_with_a_single_period() {
+		return array(
+			'consecutive periods at the start'         => array(
+				'filename' => '...filename.png',
+				'expected' => 'filename.png',
+			),
+			'consecutive periods in the middle'        => array(
+				'filename' => 'file.......name.png',
+				'expected' => 'file.name_.png',
+			),
+			'consecutive periods before the extension' => array(
+				'filename' => 'filename....png',
+				'expected' => 'filename.png',
+			),
+			'consecutive periods after the extension'  => array(
+				'filename' => 'filename.png...',
+				'expected' => 'filename.png',
+			),
+			'consecutive periods at the start, middle, before, after the extension' => array(
+				'filename' => '.....file....name...png......',
+				'expected' => 'file.name_.png',
+			),
+			'consecutive periods and no extension'     => array(
+				'filename' => 'filename...',
+				'expected' => 'filename',
+			),
+		);
+	}
 }

--- a/tests/phpunit/tests/functions.php
+++ b/tests/phpunit/tests/functions.php
@@ -258,7 +258,7 @@ class Tests_Functions extends WP_UnitTestCase {
 		$this->assertSame( 'abcdefgh.png', wp_unique_filename( $testdir, 'abcdefg"h.png' ), 'File with quote failed' );
 
 		// Test crazy name (useful for regression tests).
-		$this->assertSame( '12af34567890@..^_qwerty-fghjkl-zx.png', wp_unique_filename( $testdir, '12%af34567890#~!@#$..%^&*()|_+qwerty  fgh`jkl zx<>?:"{}[]="\'/?.png' ), 'Failed crazy file name' );
+		$this->assertSame( '12af34567890@.^_qwerty-fghjkl-zx.png', wp_unique_filename( $testdir, '12%af34567890#~!@#$..%^&*()|_+qwerty  fgh`jkl zx<>?:"{}[]="\'/?.png' ), 'Failed crazy file name' );
 
 		// Test slashes in names.
 		$this->assertSame( 'abcdefg.png', wp_unique_filename( $testdir, 'abcde\fg.png' ), 'Slash not removed' );


### PR DESCRIPTION
On some servers, consecutive periods in a filename can cause a 403 Forbidden response.

This change replaces consecutive periods with a single period.

Trac ticket: https://core.trac.wordpress.org/ticket/57242

This PR has an expected test failure in `Tests_Functions::test_wp_unique_filename()`. If this PR's approach is supported, I'll update the failing test to facilitate this change in Core.