### PR TITLE
Test workflows against ubuntu-22.04.

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -58,7 +58,7 @@ jobs:
   # - Ensures version-controlled files are not modified or deleted.
   phpcs:
     name: PHP coding standards
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 20
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
 
@@ -129,7 +129,7 @@ jobs:
   # - Ensures version-controlled files are not modified or deleted.
   jshint:
     name: JavaScript coding standards
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 20
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
     env:
@@ -176,7 +176,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [ phpcs, jshint, slack-notifications ]
     if: |
       always() &&

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -47,7 +47,7 @@ jobs:
   # - Ensures version-controlled files are not modified or deleted.
   e2e-tests:
     name: E2E Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 20
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
 
@@ -122,7 +122,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [ e2e-tests, slack-notifications ]
     if: |
       always() &&

--- a/.github/workflows/failed-workflow.yml
+++ b/.github/workflows/failed-workflow.yml
@@ -19,7 +19,7 @@ jobs:
   # - Restarts all failed jobs when the workflow fails or is cancelled for the first time.
   failed-workflow:
     name: Rerun a workflow
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -50,7 +50,7 @@ jobs:
   # - Ensures version-controlled files are not modified or deleted.
   test-js:
     name: QUnit Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 20
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
 
@@ -95,7 +95,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [ test-js, slack-notifications ]
     if: |
       always() &&

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -53,7 +53,7 @@ jobs:
   # - Ensures version-controlled files are not modified or deleted.
   php-compatibility:
     name: Check PHP compatibility
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 20
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
 
@@ -120,7 +120,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [ php-compatibility, slack-notifications ]
     if: |
       always() &&

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -60,34 +60,34 @@ jobs:
       fail-fast: false
       matrix:
         php: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2' ]
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-22.04 ]
         memcached: [ false ]
         split_slow: [ false ]
         multisite: [ false, true ]
         include:
           # Additional "slow" jobs for PHP 5.6.
           - php: '5.6'
-            os: ubuntu-latest
+            os: ubuntu-22.04
             memcached: false
             multisite: false
             split_slow: true
           - php: '5.6'
-            os: ubuntu-latest
+            os: ubuntu-22.04
             memcached: false
             multisite: true
             split_slow: true
           # Include jobs for PHP 7.4 with memcached.
           - php: '7.4'
-            os: ubuntu-latest
+            os: ubuntu-22.04
             memcached: true
             multisite: false
           - php: '7.4'
-            os: ubuntu-latest
+            os: ubuntu-22.04
             memcached: true
             multisite: true
           # Report the results of the PHP 7.4 without memcached job.
           - php: '7.4'
-            os: ubuntu-latest
+            os: ubuntu-22.04
             memcached: false
             multisite: false
             report: true
@@ -233,7 +233,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [ test-php, slack-notifications ]
     if: |
       always() &&

--- a/.github/workflows/slack-notifications.yml
+++ b/.github/workflows/slack-notifications.yml
@@ -43,7 +43,7 @@ jobs:
   # - Constructs and stores a message payload as an output.
   prepare:
     name: Prepare notifications
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 5
     if: ${{ github.repository == 'WordPress/wordpress-develop' && github.event.workflow_run.event != 'pull_request' }}
     outputs:
@@ -147,7 +147,7 @@ jobs:
   # Posts notifications when a workflow fails.
   failure:
     name: Failure notifications
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 5
     needs: [ prepare ]
     if: ${{ inputs.calling_status == 'failure' || failure() }}
@@ -163,7 +163,7 @@ jobs:
   # Posts notifications the first time a workflow run succeeds after previously failing.
   fixed:
     name: Fixed notifications
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 5
     needs: [ prepare ]
     if: ${{ contains( fromJson( '["failure", "cancelled", "none"]' ), needs.prepare.outputs.previous_conclusion ) && inputs.calling_status == 'success' && success() }}
@@ -179,7 +179,7 @@ jobs:
   # Posts notifications when a workflow is successful.
   success:
     name: Success notifications
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 5
     needs: [ prepare ]
     if: ${{ inputs.calling_status == 'success' && success() }}
@@ -195,7 +195,7 @@ jobs:
   # Posts notifications when a workflow is cancelled.
   cancelled:
     name: Cancelled notifications
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 5
     needs: [ prepare ]
     if: ${{ inputs.calling_status == 'cancelled' || cancelled() }}

--- a/.github/workflows/test-and-zip-default-themes.yml
+++ b/.github/workflows/test-and-zip-default-themes.yml
@@ -55,7 +55,7 @@ jobs:
   # - Ensures version-controlled files are not modified or deleted.
   test-build-scripts:
     name: Test ${{ matrix.theme }} build script
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
     strategy:
@@ -100,7 +100,7 @@ jobs:
   # - Uploads the theme files as a workflow artifact (files uploaded as an artifact are automatically zipped).
   bundle-theme:
     name: Create ${{ matrix.theme }} ZIP file
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [ test-build-scripts ]
     timeout-minutes: 10
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
@@ -151,7 +151,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [ test-build-scripts, bundle-theme, slack-notifications ]
     if: |
       always() &&

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -55,7 +55,7 @@ jobs:
   # - Upload the multisite code coverage report to Codecov.io.
   test-coverage-report:
     name: ${{ matrix.multisite && 'Multisite' || 'Single site' }} report
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 120
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
     strategy:
@@ -181,7 +181,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [ test-coverage-report, slack-notifications ]
     if: |
       always() &&

--- a/.github/workflows/test-npm.yml
+++ b/.github/workflows/test-npm.yml
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-22.04, windows-latest ]
 
     steps:
       - name: Checkout repository
@@ -178,7 +178,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [ test-npm, test-npm-macos, slack-notifications ]
     if: |
       always() &&

--- a/.github/workflows/test-old-branches.yml
+++ b/.github/workflows/test-old-branches.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   dispatch-workflows-for-old-branches:
     name: ${{ matrix.workflow }} for ${{ matrix.branch }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 20
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
     strategy:

--- a/.github/workflows/welcome-new-contributors.yml
+++ b/.github/workflows/welcome-new-contributors.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   # Comments on a pull request when the author is a new contributor.
   post-welcome-message:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 5
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
 


### PR DESCRIPTION
`ubuntu-latest` will begin running `ubuntu-22.04` in the near future (see https://github.com/actions/runner-images/issues/6399).

This PR is to confirm that this will not introduce any issues in the Core workflows.

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
