### PR TITLE
Build/Test Tools: Various improvements to `Tests_Theme_WpGetGlobalStylesheet`.

### DIFF
--- a/tests/phpunit/tests/theme/wpGetGlobalStylesheet.php
+++ b/tests/phpunit/tests/theme/wpGetGlobalStylesheet.php
@@ -1,62 +1,13 @@
 <?php
 
+require_once __DIR__ . '/base.php';
+
 /**
  * Tests wp_get_global_stylesheet().
  *
  * @group themes
  */
-class Tests_Theme_wpGetGlobalStylesheet extends WP_UnitTestCase {
-
-	/**
-	 * Theme root directory.
-	 *
-	 * @var string
-	 */
-	private $theme_root;
-
-	/**
-	 * Original theme directory.
-	 *
-	 * @var string
-	 */
-	private $orig_theme_dir;
-
-	public function set_up() {
-		parent::set_up();
-
-		$this->orig_theme_dir = $GLOBALS['wp_theme_directories'];
-		$this->theme_root     = realpath( DIR_TESTDATA . '/themedir1' );
-
-		// /themes is necessary as theme.php functions assume /themes is the root if there is only one root.
-		$GLOBALS['wp_theme_directories'] = array( WP_CONTENT_DIR . '/themes', $this->theme_root );
-
-		// Set up the new root.
-		add_filter( 'theme_root', array( $this, 'filter_set_theme_root' ) );
-		add_filter( 'stylesheet_root', array( $this, 'filter_set_theme_root' ) );
-		add_filter( 'template_root', array( $this, 'filter_set_theme_root' ) );
-
-		// Clear caches.
-		wp_clean_themes_cache();
-		unset( $GLOBALS['wp_themes'] );
-	}
-
-	public function tear_down() {
-		$GLOBALS['wp_theme_directories'] = $this->orig_theme_dir;
-
-		// Clear up the filters to modify the theme root.
-		remove_filter( 'theme_root', array( $this, 'filter_set_theme_root' ) );
-		remove_filter( 'stylesheet_root', array( $this, 'filter_set_theme_root' ) );
-		remove_filter( 'template_root', array( $this, 'filter_set_theme_root' ) );
-
-		wp_clean_themes_cache();
-		unset( $GLOBALS['wp_themes'] );
-
-		parent::tear_down();
-	}
-
-	public function filter_set_theme_root() {
-		return $this->theme_root;
-	}
+class Tests_Theme_wpGetGlobalStylesheet extends WP_Theme_UnitTestCase {
 
 	public function test_block_theme_using_variables() {
 		switch_theme( 'block-theme' );

--- a/tests/phpunit/tests/theme/wpGetGlobalStylesheet.php
+++ b/tests/phpunit/tests/theme/wpGetGlobalStylesheet.php
@@ -12,124 +12,197 @@ require_once __DIR__ . '/base.php';
 class Tests_Theme_WpGetGlobalStylesheet extends WP_Theme_UnitTestCase {
 
 	/**
+	 * Flag to indicate whether to remove 'editor-font-sizes' theme support at tear_down().
+	 *
+	 * @var bool
+	 */
+	private $remove_theme_support_at_teardown = false;
+
+	/**
+	 * Flag to indicate whether to switch back to the default theme at tear down.
+	 *
+	 * @var bool
+	 */
+	private $switch_to_default_theme_at_teardown = false;
+
+	public function tear_down() {
+		// Reset the theme support.
+		if ( $this->remove_theme_support_at_teardown ) {
+			$this->remove_theme_support_at_teardown = false;
+			remove_theme_support( 'editor-font-sizes' );
+		}
+
+		if ( $this->switch_to_default_theme_at_teardown ) {
+			$this->switch_to_default_theme_at_teardown = false;
+			switch_theme( WP_DEFAULT_THEME );
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * @ticket 54782
+	 *
+	 * @dataProvider data_should_conditionally_include_font_sizes
+	 *
+	 * @param array  $expected            Expected CSS for each font size.
+	 * @param string $theme               The theme to switch to / use.
+	 * @param array  $types               Optional. Types of styles to load. Default empty array.
+	 * @param bool   $classic_has_presets Optional. Whether to apply presets for classic theme tests. Default false.
+	 */
+	public function test_should_conditionally_include_font_sizes( array $expected, $theme, array $types = array(), $classic_has_presets = false ) {
+		$this->maybe_switch_theme( $theme );
+		$this->add_custom_font_sizes( $classic_has_presets );
+
+		$styles = wp_get_global_stylesheet( $types );
+
+		$this->assertStringContainsString( $expected['small'], $styles, 'The small font size should be included.' );
+		$this->assertStringContainsString( $expected['medium'], $styles, 'The medium font size should be included.' );
+		$this->assertStringContainsString( $expected['large'], $styles, 'The large font size should be included.' );
+		$this->assertStringContainsString( $expected['x-large'], $styles, 'The x-large font size should be included.' );
+
+		if ( 'default' !== $theme ) {
+			$this->assertStringContainsString( $expected['custom'], $styles, 'The custom font size should be included.' );
+		}
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_should_conditionally_include_font_sizes() {
+		return array(
+			'block theme using defaults'                   => array(
+				'expected' => array(
+					'small'   => '--wp--preset--font-size--small: 13px',
+					'medium'  => '--wp--preset--font-size--medium: 20px',
+					'large'   => '--wp--preset--font-size--large: 36px',
+					'x-large' => '--wp--preset--font-size--x-large: 42px',
+					'custom'  => '--wp--preset--font-size--custom: 100px;',
+				),
+				'theme'    => 'block-theme',
+			),
+			'block theme using variables'                  => array(
+				'expected' => array(
+					'small'   => '--wp--preset--font-size--small: 13px',
+					'medium'  => '--wp--preset--font-size--medium: 20px',
+					'large'   => '--wp--preset--font-size--large: 36px',
+					'x-large' => '--wp--preset--font-size--x-large: 42px',
+					'custom'  => '--wp--preset--font-size--custom: 100px;',
+				),
+				'theme'    => 'block-theme',
+				'types'    => array( 'variables' ),
+			),
+			'classic theme without presets using defaults' => array(
+				'expected' => array(
+					'small'   => '--wp--preset--font-size--small: 13px',
+					'medium'  => '--wp--preset--font-size--medium: 20px',
+					'large'   => '--wp--preset--font-size--large: 36px',
+					'x-large' => '--wp--preset--font-size--x-large: 42px',
+				),
+				'theme'    => 'default',
+			),
+			'classic theme without presets using variables' => array(
+				'expected' => array(
+					'small'   => '--wp--preset--font-size--small: 13px',
+					'medium'  => '--wp--preset--font-size--medium: 20px',
+					'large'   => '--wp--preset--font-size--large: 36px',
+					'x-large' => '--wp--preset--font-size--x-large: 42px',
+				),
+				'theme'    => 'default',
+				'types'    => array( 'variables' ),
+			),
+			'classic theme with presets using defaults'    => array(
+				'expected'            => array(
+					'small'   => '--wp--preset--font-size--small: 18px',
+					'medium'  => '--wp--preset--font-size--medium: 20px',
+					'large'   => '--wp--preset--font-size--large: 26.25px',
+					'x-large' => '--wp--preset--font-size--x-large: 42px',
+				),
+				'theme'               => 'default',
+				'types'               => array(),
+				'classic_has_presets' => true,
+			),
+			'classic theme with presets using variables'   => array(
+				'expected'            => array(
+					'small'   => '--wp--preset--font-size--small: 18px',
+					'medium'  => '--wp--preset--font-size--medium: 20px',
+					'large'   => '--wp--preset--font-size--large: 26.25px',
+					'x-large' => '--wp--preset--font-size--x-large: 42px',
+				),
+				'theme'               => 'default',
+				'types'               => array( 'variables' ),
+				'classic_has_presets' => true,
+			),
+		);
+	}
+
+	/**
 	 * Tests that wp_get_global_stylesheet() only includes font sizes
 	 * when themes do not use the "presets" types.
 	 *
 	 * @ticket 54782
 	 *
-	 * @dataProvider data_wp_get_global_stylesheet_should_conditionally_include_font_sizes
+	 * @dataProvider data_should_not_conditionally_include_font_sizes
 	 *
-	 * @param bool   $expected            Whether the font sizes should be included.
 	 * @param string $theme               The theme to switch to. Use 'default' for the default theme.
-	 * @param array  $types               Types of styles to load.
+	 * @param array  $types               Optional. Types of styles to load.
+	 *                                    Default empty array.
 	 * @param bool   $classic_has_presets Optional. Whether to apply presets for classic theme tests.
 	 *                                    Default false.
 	 */
-	public function test_wp_get_global_stylesheet_should_conditionally_include_font_sizes( $expected, $theme, $types, $classic_has_presets = false ) {
-		if ( 'default' !== $theme ) {
-			switch_theme( $theme );
-		}
-
-		$small = 13;
-		$large = 36;
-
-		if ( $classic_has_presets ) {
-			$small = 18;
-			$large = 26.25;
-
-			$this->add_custom_font_sizes( $small, $large );
-		}
+	public function test_should_not_conditionally_include_font_sizes( array $expected, $theme, array $types = array(), $classic_has_presets = false ) {
+		$this->maybe_switch_theme( $theme );
+		$this->add_custom_font_sizes( $classic_has_presets );
 
 		$styles = wp_get_global_stylesheet( $types );
 
-		// Reset theme.
+		$this->assertStringNotContainsString( $expected['small'], $styles, 'The small font size should not be included.' );
+		$this->assertStringNotContainsString( $expected['medium'], $styles, 'The medium font size should not be included.' );
+		$this->assertStringNotContainsString( $expected['large'], $styles, 'The large font size should not be included.' );
+		$this->assertStringNotContainsString( $expected['x-large'], $styles, 'The x-large font size should not be included.' );
+
 		if ( 'default' !== $theme ) {
-			switch_theme( WP_DEFAULT_THEME );
-		}
-
-		// Reset theme support.
-		if ( $classic_has_presets ) {
-			remove_theme_support( 'editor-font-sizes' );
-		}
-
-		$expected_small   = '--wp--preset--font-size--small: ' . $small . 'px';
-		$expected_medium  = '--wp--preset--font-size--medium: 20px';
-		$expected_large   = '--wp--preset--font-size--large: ' . $large . 'px';
-		$expected_x_large = '--wp--preset--font-size--x-large: 42px';
-		$expected_custom  = '--wp--preset--font-size--custom: 100px;';
-
-		if ( $expected ) {
-			$this->assertStringContainsString( $expected_small, $styles, 'The small font size should be included.' );
-			$this->assertStringContainsString( $expected_medium, $styles, 'The medium font size should be included.' );
-			$this->assertStringContainsString( $expected_large, $styles, 'The large font size should be included.' );
-			$this->assertStringContainsString( $expected_x_large, $styles, 'The x-large font size should be included.' );
-
-			if ( 'default' !== $theme ) {
-				$this->assertStringContainsString( $expected_custom, $styles, 'The custom font size should be included.' );
-			}
-		} else {
-			$this->assertStringNotContainsString( $expected_small, $styles, 'The small font size should not be included.' );
-			$this->assertStringNotContainsString( $expected_medium, $styles, 'The medium font size should not be included.' );
-			$this->assertStringNotContainsString( $expected_large, $styles, 'The large font size should not be included.' );
-			$this->assertStringNotContainsString( $expected_x_large, $styles, 'The x-large font size should not be included.' );
-
-			if ( 'default' !== $theme ) {
-				$this->assertStringNotContainsString( $expected_custom, $styles, 'The custom font size should not be included.' );
-			}
+			$this->assertStringNotContainsString( $expected['custom'], $styles, 'The custom font size should not be included.' );
 		}
 	}
 
 	/**
-	 * Data provider for test_wp_get_global_stylesheet_should_conditionally_include_font_sizes().
+	 * Data provider.
 	 *
 	 * @return array[]
 	 */
-	public function data_wp_get_global_stylesheet_should_conditionally_include_font_sizes() {
+	public function data_should_not_conditionally_include_font_sizes() {
 		return array(
-			'true => a block theme and default types'    => array(
-				'expected' => true,
-				'theme'    => 'block-theme',
-				'types'    => array(),
-			),
-			'true => a block theme and "variable" types' => array(
-				'expected' => true,
-				'theme'    => 'block-theme',
-				'types'    => array( 'variables' ),
-			),
-			'false => a block theme and "presets" types' => array(
-				'expected' => false,
+			'block theme using presets'                   => array(
+				'expected' => array(
+					'small'   => '--wp--preset--font-size--small: 13px',
+					'medium'  => '--wp--preset--font-size--medium: 20px',
+					'large'   => '--wp--preset--font-size--large: 36px',
+					'x-large' => '--wp--preset--font-size--x-large: 42px',
+					'custom'  => '--wp--preset--font-size--custom: 100px;',
+				),
 				'theme'    => 'block-theme',
 				'types'    => array( 'presets' ),
 			),
-			'true => a classic theme without presets and default types' => array(
-				'expected' => true,
-				'theme'    => 'default',
-				'types'    => array(),
-			),
-			'true => a classic theme without presets and "variable" types' => array(
-				'expected' => true,
-				'theme'    => 'default',
-				'types'    => array( 'variables' ),
-			),
-			'false => a classic theme without presets and "presets" types' => array(
-				'expected' => false,
+			'classic theme without presets using presets' => array(
+				'expected' => array(
+					'small'   => '--wp--preset--font-size--small: 13px',
+					'medium'  => '--wp--preset--font-size--medium: 20px',
+					'large'   => '--wp--preset--font-size--large: 36px',
+					'x-large' => '--wp--preset--font-size--x-large: 42px',
+				),
 				'theme'    => 'default',
 				'types'    => array( 'presets' ),
 			),
-			'true => a classic theme with presets and default types' => array(
-				'expected'            => true,
-				'theme'               => 'default',
-				'types'               => array(),
-				'classic_has_presets' => true,
-			),
-			'true => a classic theme with presets and "variable" types' => array(
-				'expected'            => true,
-				'theme'               => 'default',
-				'types'               => array( 'variables' ),
-				'classic_has_presets' => true,
-			),
-			'false => a classic theme with presets and "presets" types' => array(
-				'expected'            => false,
+			'classic theme with presets using presets'    => array(
+				'expected'            => array(
+					'small'   => '--wp--preset--font-size--small: 18px',
+					'medium'  => '--wp--preset--font-size--medium: 20px',
+					'large'   => '--wp--preset--font-size--large: 26.25px',
+					'x-large' => '--wp--preset--font-size--x-large: 42px',
+				),
 				'theme'               => 'default',
 				'types'               => array( 'presets' ),
 				'classic_has_presets' => true,
@@ -138,41 +211,58 @@ class Tests_Theme_WpGetGlobalStylesheet extends WP_Theme_UnitTestCase {
 	}
 
 	/**
-	 * Adds theme support and custom font sizes.
-	 *
-	 * @param int $small The small font size in pixels.
-	 * @param int $large The large font size in pixels.
-	 */
-	private function add_custom_font_sizes( $small, $large ) {
-		add_theme_support(
-			'editor-font-sizes',
-			array(
-				array(
-					'name' => 'Small',
-					'size' => $small,
-					'slug' => 'small',
-				),
-				array(
-					'name' => 'Large',
-					'size' => $large,
-					'slug' => 'large',
-				),
-			)
-		);
-	}
-
-	/**
-	 * Tests that switching themes recalculates the stylesheet.
-	 *
 	 * @ticket 56970
 	 */
 	public function test_switching_themes_should_recalculate_stylesheet() {
-		$stylesheet_for_default_theme = wp_get_global_stylesheet();
-		switch_theme( 'block-theme' );
-		$stylesheet_for_block_theme = wp_get_global_stylesheet();
-		switch_theme( WP_DEFAULT_THEME );
+		$expected = '--wp--preset--font-size--custom: 100px;';
 
-		$this->assertStringNotContainsString( '--wp--preset--font-size--custom: 100px;', $stylesheet_for_default_theme, 'custom font size (100px) not present for default theme' );
+		$stylesheet_for_default_theme = wp_get_global_stylesheet();
+		$this->assertStringNotContainsString( $expected, $stylesheet_for_default_theme, 'custom font size (100px) not present for default theme' );
+
+		$this->maybe_switch_theme( 'block-theme' );
+		$stylesheet_for_block_theme = wp_get_global_stylesheet();
 		$this->assertStringContainsString( '--wp--preset--font-size--custom: 100px;', $stylesheet_for_block_theme, 'custom font size (100px) is present for block theme' );
+	}
+
+	/**
+	 * Adds the 'editor-font-sizes' theme support with custom font sizes.
+	 *
+	 * @param bool $add_theme_support Whether to add the theme support.
+	 * @param int  $small             Optional. Small font size in pixels. Default 18.
+	 * @param int  $large             Optional. Large font size in pixels. Default 26.25.
+	 */
+	private function add_custom_font_sizes( $add_theme_support, $small = 18, $large = 26.25 ) {
+		if ( ! $add_theme_support ) {
+			return;
+		}
+
+		$args = array(
+			array(
+				'name' => 'Small',
+				'size' => $small,
+				'slug' => 'small',
+			),
+			array(
+				'name' => 'Large',
+				'size' => $large,
+				'slug' => 'large',
+			),
+		);
+		add_theme_support( 'editor-font-sizes', $args );
+		$this->remove_theme_support_at_teardown = true;
+	}
+
+	/**
+	 * Switches the theme when not the 'default' theme.
+	 *
+	 * @param string $theme Theme name to switch to.
+	 */
+	private function maybe_switch_theme( $theme ) {
+		if ( 'default' === $theme ) {
+			return;
+		}
+
+		switch_theme( $theme );
+		$this->switch_to_default_theme_at_teardown = true;
 	}
 }

--- a/tests/phpunit/tests/theme/wpGetGlobalStylesheet.php
+++ b/tests/phpunit/tests/theme/wpGetGlobalStylesheet.php
@@ -139,18 +139,14 @@ class Tests_Theme_WpGetGlobalStylesheet extends WP_Theme_UnitTestCase {
 	}
 
 	/**
-	 * Tests that wp_get_global_stylesheet() only includes font sizes
-	 * when themes do not use the "presets" types.
-	 *
 	 * @ticket 54782
 	 *
 	 * @dataProvider data_should_not_conditionally_include_font_sizes
 	 *
-	 * @param string $theme               The theme to switch to. Use 'default' for the default theme.
-	 * @param array  $types               Optional. Types of styles to load.
-	 *                                    Default empty array.
-	 * @param bool   $classic_has_presets Optional. Whether to apply presets for classic theme tests.
-	 *                                    Default false.
+	 * @param array  $expected            Expected CSS for each font size.
+	 * @param string $theme               The theme to switch to / use.
+	 * @param array  $types               Optional. Types of styles to load. Default empty array.
+	 * @param bool   $classic_has_presets Optional. Whether to apply presets for classic theme tests. Default false.
 	 */
 	public function test_should_not_conditionally_include_font_sizes( array $expected, $theme, array $types = array(), $classic_has_presets = false ) {
 		$this->maybe_switch_theme( $theme );

--- a/tests/phpunit/tests/theme/wpGetGlobalStylesheet.php
+++ b/tests/phpunit/tests/theme/wpGetGlobalStylesheet.php
@@ -213,11 +213,11 @@ class Tests_Theme_WpGetGlobalStylesheet extends WP_Theme_UnitTestCase {
 		$expected = '--wp--preset--font-size--custom: 100px;';
 
 		$stylesheet_for_default_theme = wp_get_global_stylesheet();
-		$this->assertStringNotContainsString( $expected, $stylesheet_for_default_theme, 'custom font size (100px) not present for default theme' );
+		$this->assertStringNotContainsString( $expected, $stylesheet_for_default_theme, 'Custom font size (100px) should not present for default theme' );
 
 		$this->maybe_switch_theme( 'block-theme' );
 		$stylesheet_for_block_theme = wp_get_global_stylesheet();
-		$this->assertStringContainsString( '--wp--preset--font-size--custom: 100px;', $stylesheet_for_block_theme, 'custom font size (100px) is present for block theme' );
+		$this->assertStringContainsString( $expected, $stylesheet_for_block_theme, 'Custom font size (100px) should be present for block theme' );
 	}
 
 	/**

--- a/tests/phpunit/tests/theme/wpGetGlobalStylesheet.php
+++ b/tests/phpunit/tests/theme/wpGetGlobalStylesheet.php
@@ -11,145 +11,154 @@ require_once __DIR__ . '/base.php';
  */
 class Tests_Theme_WpGetGlobalStylesheet extends WP_Theme_UnitTestCase {
 
-	public function test_block_theme_using_variables() {
-		switch_theme( 'block-theme' );
+	/**
+	 * Tests that wp_get_global_stylesheet() only includes font sizes
+	 * when themes do not use the "presets" types.
+	 *
+	 * @ticket 54782
+	 *
+	 * @dataProvider data_wp_get_global_stylesheet_should_conditionally_include_font_sizes
+	 *
+	 * @param bool   $expected            Whether the font sizes should be included.
+	 * @param string $theme               The theme to switch to. Use 'default' for the default theme.
+	 * @param array  $types               Types of styles to load.
+	 * @param bool   $classic_has_presets Optional. Whether to apply presets for classic theme tests.
+	 *                                    Default false.
+	 */
+	public function test_wp_get_global_stylesheet_should_conditionally_include_font_sizes( $expected, $theme, $types, $classic_has_presets = false ) {
+		if ( 'default' !== $theme ) {
+			switch_theme( $theme );
+		}
 
-		$styles = wp_get_global_stylesheet( array( 'variables' ) );
-		$this->assertStringContainsString( '--wp--preset--font-size--small: 13px', $styles, 'small font size is 13px' );
-		$this->assertStringContainsString( '--wp--preset--font-size--medium: 20px', $styles, 'medium font size is 20px' );
-		$this->assertStringContainsString( '--wp--preset--font-size--large: 36px', $styles, 'large font size is 36px' );
-		$this->assertStringContainsString( '--wp--preset--font-size--x-large: 42px', $styles, 'x-large font size is 42px' );
-		$this->assertStringContainsString( '--wp--preset--font-size--custom: 100px;', $styles, 'custom font size is 100px' );
+		$small = 13;
+		$large = 36;
 
-		switch_theme( WP_DEFAULT_THEME );
+		if ( $classic_has_presets ) {
+			$small = 18;
+			$large = 26.25;
+
+			$this->add_custom_font_sizes( $small, $large );
+		}
+
+		$styles = wp_get_global_stylesheet( $types );
+
+		// Reset theme.
+		if ( 'default' !== $theme ) {
+			switch_theme( WP_DEFAULT_THEME );
+		}
+
+		// Reset theme support.
+		if ( $classic_has_presets ) {
+			remove_theme_support( 'editor-font-sizes' );
+		}
+
+		$expected_small   = '--wp--preset--font-size--small: ' . $small . 'px';
+		$expected_medium  = '--wp--preset--font-size--medium: 20px';
+		$expected_large   = '--wp--preset--font-size--large: ' . $large . 'px';
+		$expected_x_large = '--wp--preset--font-size--x-large: 42px';
+		$expected_custom  = '--wp--preset--font-size--custom: 100px;';
+
+		if ( $expected ) {
+			$this->assertStringContainsString( $expected_small, $styles, 'The small font size should be included.' );
+			$this->assertStringContainsString( $expected_medium, $styles, 'The medium font size should be included.' );
+			$this->assertStringContainsString( $expected_large, $styles, 'The large font size should be included.' );
+			$this->assertStringContainsString( $expected_x_large, $styles, 'The x-large font size should be included.' );
+
+			if ( 'default' !== $theme ) {
+				$this->assertStringContainsString( $expected_custom, $styles, 'The custom font size should be included.' );
+			}
+		} else {
+			$this->assertStringNotContainsString( $expected_small, $styles, 'The small font size should not be included.' );
+			$this->assertStringNotContainsString( $expected_medium, $styles, 'The medium font size should not be included.' );
+			$this->assertStringNotContainsString( $expected_large, $styles, 'The large font size should not be included.' );
+			$this->assertStringNotContainsString( $expected_x_large, $styles, 'The x-large font size should not be included.' );
+
+			if ( 'default' !== $theme ) {
+				$this->assertStringNotContainsString( $expected_custom, $styles, 'The custom font size should not be included.' );
+			}
+		}
 	}
 
-	public function test_block_theme_using_presets() {
-		switch_theme( 'block-theme' );
-
-		$styles = wp_get_global_stylesheet( array( 'presets' ) );
-		$this->assertStringNotContainsString( '--wp--preset--font-size--small: 13px', $styles, 'small font size is not present' );
-		$this->assertStringNotContainsString( '--wp--preset--font-size--medium: 20px', $styles, 'medium font size is not present' );
-		$this->assertStringNotContainsString( '--wp--preset--font-size--large: 36px', $styles, 'large font size is not present' );
-		$this->assertStringNotContainsString( '--wp--preset--font-size--x-large: 42px', $styles, 'x-large font size is not present' );
-		$this->assertStringNotContainsString( '--wp--preset--font-size--custom: 100px;', $styles, 'custom font size is not present' );
-
-		switch_theme( WP_DEFAULT_THEME );
+	/**
+	 * Data provider for test_wp_get_global_stylesheet_should_conditionally_include_font_sizes().
+	 *
+	 * @return array[]
+	 */
+	public function data_wp_get_global_stylesheet_should_conditionally_include_font_sizes() {
+		return array(
+			'true => a block theme and default types'    => array(
+				'expected' => true,
+				'theme'    => 'block-theme',
+				'types'    => array(),
+			),
+			'true => a block theme and "variable" types' => array(
+				'expected' => true,
+				'theme'    => 'block-theme',
+				'types'    => array( 'variables' ),
+			),
+			'false => a block theme and "presets" types' => array(
+				'expected' => false,
+				'theme'    => 'block-theme',
+				'types'    => array( 'presets' ),
+			),
+			'true => a classic theme without presets and default types' => array(
+				'expected' => true,
+				'theme'    => 'default',
+				'types'    => array(),
+			),
+			'true => a classic theme without presets and "variable" types' => array(
+				'expected' => true,
+				'theme'    => 'default',
+				'types'    => array( 'variables' ),
+			),
+			'false => a classic theme without presets and "presets" types' => array(
+				'expected' => false,
+				'theme'    => 'default',
+				'types'    => array( 'presets' ),
+			),
+			'true => a classic theme with presets and default types' => array(
+				'expected'            => true,
+				'theme'               => 'default',
+				'types'               => array(),
+				'classic_has_presets' => true,
+			),
+			'true => a classic theme with presets and "variable" types' => array(
+				'expected'            => true,
+				'theme'               => 'default',
+				'types'               => array( 'variables' ),
+				'classic_has_presets' => true,
+			),
+			'false => a classic theme with presets and "presets" types' => array(
+				'expected'            => false,
+				'theme'               => 'default',
+				'types'               => array( 'presets' ),
+				'classic_has_presets' => true,
+			),
+		);
 	}
 
-	public function test_block_theme_using_defaults() {
-		switch_theme( 'block-theme' );
-
-		$styles = wp_get_global_stylesheet();
-		$this->assertStringContainsString( '--wp--preset--font-size--small: 13px', $styles, 'small font size is 13px' );
-		$this->assertStringContainsString( '--wp--preset--font-size--medium: 20px', $styles, 'medium font size is 20px' );
-		$this->assertStringContainsString( '--wp--preset--font-size--large: 36px', $styles, 'large font size is 36px' );
-		$this->assertStringContainsString( '--wp--preset--font-size--x-large: 42px', $styles, 'x-large font size is 42px' );
-		$this->assertStringContainsString( '--wp--preset--font-size--custom: 100px;', $styles, 'custom font size is 100px' );
-
-		switch_theme( WP_DEFAULT_THEME );
-	}
-
-	public function test_variables_in_classic_theme_with_no_presets_using_variables() {
-		$styles = wp_get_global_stylesheet( array( 'variables' ) );
-		$this->assertStringContainsString( '--wp--preset--font-size--small: 13px', $styles, 'small font size is 13px' );
-		$this->assertStringContainsString( '--wp--preset--font-size--medium: 20px', $styles, 'medium font size is 20px' );
-		$this->assertStringContainsString( '--wp--preset--font-size--large: 36px', $styles, 'large font size is 36px' );
-		$this->assertStringContainsString( '--wp--preset--font-size--x-large: 42px', $styles, 'x-large font size is 42px' );
-	}
-
-	public function test_variables_in_classic_theme_with_no_presets_using_presets() {
-		$styles = wp_get_global_stylesheet( array( 'presets' ) );
-		$this->assertStringNotContainsString( '--wp--preset--font-size--small: 13px', $styles, 'small font size is not present' );
-		$this->assertStringNotContainsString( '--wp--preset--font-size--medium: 20px', $styles, 'medium font size is not present' );
-		$this->assertStringNotContainsString( '--wp--preset--font-size--large: 36px', $styles, 'large font size is not present' );
-		$this->assertStringNotContainsString( '--wp--preset--font-size--x-large: 42px', $styles, 'x-large font size is not present' );
-	}
-
-	public function test_variables_in_classic_theme_with_no_presets_using_defaults() {
-		$styles = wp_get_global_stylesheet();
-		$this->assertStringContainsString( '--wp--preset--font-size--small: 13px', $styles, 'small font size is 13px' );
-		$this->assertStringContainsString( '--wp--preset--font-size--medium: 20px', $styles, 'medium font size is 20px' );
-		$this->assertStringContainsString( '--wp--preset--font-size--large: 36px', $styles, 'large font size is 36px' );
-		$this->assertStringContainsString( '--wp--preset--font-size--x-large: 42px', $styles, 'x-large font size is 42px' );
-	}
-
-	public function test_variables_in_classic_theme_with_presets_using_variables() {
+	/**
+	 * Adds theme support and custom font sizes.
+	 *
+	 * @param int $small The small font size in pixels.
+	 * @param int $large The large font size in pixels.
+	 */
+	private function add_custom_font_sizes( $small, $large ) {
 		add_theme_support(
 			'editor-font-sizes',
 			array(
 				array(
 					'name' => 'Small',
-					'size' => 18,
+					'size' => $small,
 					'slug' => 'small',
 				),
 				array(
 					'name' => 'Large',
-					'size' => 26.25,
+					'size' => $large,
 					'slug' => 'large',
 				),
 			)
 		);
-
-		$styles = wp_get_global_stylesheet( array( 'variables' ) );
-		$this->assertStringContainsString( '--wp--preset--font-size--small: 18px', $styles, 'small font size is 18px' );
-		$this->assertStringContainsString( '--wp--preset--font-size--medium: 20px', $styles, 'medium font size is 20px' );
-		$this->assertStringContainsString( '--wp--preset--font-size--large: 26.25px', $styles, 'large font size is 26.25px' );
-		$this->assertStringContainsString( '--wp--preset--font-size--x-large: 42px', $styles, 'x-large font size is 42px' );
-
-		remove_theme_support( 'editor-font-sizes' );
-	}
-
-	public function test_variables_in_classic_theme_with_presets_using_presets() {
-		add_theme_support(
-			'editor-font-sizes',
-			array(
-				array(
-					'name' => 'Small',
-					'size' => 18,
-					'slug' => 'small',
-				),
-				array(
-					'name' => 'Large',
-					'size' => 26.25,
-					'slug' => 'large',
-				),
-			)
-		);
-
-		$styles = wp_get_global_stylesheet( array( 'presets' ) );
-		$this->assertStringNotContainsString( '--wp--preset--font-size--small: 18px', $styles, 'small font size is not present' );
-		$this->assertStringNotContainsString( '--wp--preset--font-size--medium: 20px', $styles, 'medium font size is not present' );
-		$this->assertStringNotContainsString( '--wp--preset--font-size--large: 26.25px', $styles, 'large font size is not present' );
-		$this->assertStringNotContainsString( '--wp--preset--font-size--x-large: 42px', $styles, 'x-large font size is not present' );
-
-		remove_theme_support( 'editor-font-sizes' );
-	}
-
-	public function test_variables_in_classic_theme_with_presets_using_defaults() {
-		add_theme_support(
-			'editor-font-sizes',
-			array(
-				array(
-					'name' => 'Small',
-					'size' => 18,
-					'slug' => 'small',
-				),
-				array(
-					'name' => 'Large',
-					'size' => 26.25,
-					'slug' => 'large',
-				),
-			)
-		);
-
-		$styles = wp_get_global_stylesheet();
-		$this->assertStringContainsString( '--wp--preset--font-size--small: 18px', $styles, 'small font size is 18px' );
-		$this->assertStringContainsString( '--wp--preset--font-size--medium: 20px', $styles, 'medium font size is 20px' );
-		$this->assertStringContainsString( '--wp--preset--font-size--large: 26.25px', $styles, 'large font size is 26.25px' );
-		$this->assertStringContainsString( '--wp--preset--font-size--x-large: 42px', $styles, 'small font size is 42px' );
-
-		remove_theme_support( 'editor-font-sizes' );
 	}
 
 	/**

--- a/tests/phpunit/tests/theme/wpGetGlobalStylesheet.php
+++ b/tests/phpunit/tests/theme/wpGetGlobalStylesheet.php
@@ -9,7 +9,7 @@ require_once __DIR__ . '/base.php';
  *
  * @covers ::wp_get_global_stylesheet
  */
-class Tests_Theme_wpGetGlobalStylesheet extends WP_Theme_UnitTestCase {
+class Tests_Theme_WpGetGlobalStylesheet extends WP_Theme_UnitTestCase {
 
 	public function test_block_theme_using_variables() {
 		switch_theme( 'block-theme' );

--- a/tests/phpunit/tests/theme/wpGetGlobalStylesheet.php
+++ b/tests/phpunit/tests/theme/wpGetGlobalStylesheet.php
@@ -6,6 +6,8 @@ require_once __DIR__ . '/base.php';
  * Tests wp_get_global_stylesheet().
  *
  * @group themes
+ *
+ * @covers ::wp_get_global_stylesheet
  */
 class Tests_Theme_wpGetGlobalStylesheet extends WP_Theme_UnitTestCase {
 


### PR DESCRIPTION
This PR:

- [x] Converts the class to extend `WP_Theme_UnitTestCase`.
- [x] Adds a `@covers` annotation.
- [x] Renames the test class to be compliant with standards.
- [x] Implements a data provider for the tests to reduce code repetition.

Trac ticket:
https://core.trac.wordpress.org/ticket/57841
https://core.trac.wordpress.org/ticket/56793