### PR TITLE
Upgrade/Install: Document the `$update_results` parameter in auto-update email filters.

### DIFF
--- a/src/wp-admin/includes/class-wp-automatic-updater.php
+++ b/src/wp-admin/includes/class-wp-automatic-updater.php
@@ -930,8 +930,36 @@ class WP_Automatic_Updater {
 			 * @since 5.5.0
 			 * @since 5.5.1 Added the `$update_results` parameter.
 			 *
-			 * @param bool  $enabled        True if plugin update notifications are enabled, false otherwise.
-			 * @param array $update_results The results of plugins update tasks.
+			 * @param bool  $enabled True if plugin update notifications are enabled, false otherwise.
+			 * @param array $update_results {
+			 *     An array of results of plugin update tasks.
+			 *
+			 *     @type array ...$0 {
+			 *         Each element is an object containing plugin update result data.
+			 *
+			 *         @type object $item {
+			 *             Data for the plugin update.
+			 *
+			 *             @type string   $id              Plugin ID. Example: `w.org/plugins/[plugin-name]`.
+			 *             @type string   $slug            Plugin slug.
+			 *             @type string   $plugin          Plugin basename.
+			 *             @type string   $new_version     New plugin version.
+			 *             @type string   $url             Plugin URL.
+			 *             @type string   $package         Plugin update package URL.
+			 *             @type string[] $icons           An array of plugin icon URLs.
+			 *             @type string[] $banners         An array of plugin banner URLs.
+			 *             @type string[] $banners_rtl     An array of plugin RTL banner URLs.
+			 *             @type string   $requires        The version of WordPress which the plugin requires.
+			 *             @type string   $tested          The version of WordPress the plugin is tested against.
+			 *             @type string   $requires_php    The version of PHP which the plugin requires.
+			 *             @type string   $current_version The currently installed version of the plugin.
+			 *         }
+			 *         @type bool|WP_Error $result   The result of the update.
+			 *                                       True on success, otherwise false or WP_Error on failure.
+			 *         @type string        $name     The name of the plugin.
+			 *         @type string[]      $messages The upgrade messages.
+			 *     }
+			 * }
 			 */
 			$notifications_enabled = apply_filters( 'auto_plugin_update_send_email', true, $update_results['plugin'] );
 

--- a/src/wp-admin/includes/class-wp-automatic-updater.php
+++ b/src/wp-admin/includes/class-wp-automatic-updater.php
@@ -981,8 +981,30 @@ class WP_Automatic_Updater {
 			 * @since 5.5.0
 			 * @since 5.5.1 Added the `$update_results` parameter.
 			 *
-			 * @param bool  $enabled        True if theme update notifications are enabled, false otherwise.
-			 * @param array $update_results The results of theme update tasks.
+			 * @param bool  $enabled True if theme update notifications are enabled, false otherwise.
+			 * @param array $update_results {
+			 *     An array of results of theme update tasks.
+			 *
+			 *     @type array ...$0 {
+			 *         Each element is an object containing theme update result data.
+			 *
+			 *         @type object $item {
+			 *             Data for the theme update.
+			 *
+			 *             @type string $theme            Theme slug.
+			 *             @type string $new_version      New theme version.
+			 *             @type string $url              Theme URL.
+			 *             @type string $package          Theme update package URL.
+			 *             @type string $requires         The version of WordPress which the theme requires.
+			 *             @type string $requires_php     The version of PHP which the theme requires.
+			 *             @type string $current_version  The currently installed version of the theme.
+			 *         }
+			 *         @type bool|WP_Error $result   The result of the update.
+			 *                                       True on success, otherwise false or WP_Error on failure.
+			 *         @type string        $name     The name of the theme.
+			 *         @type string[]      $messages The upgrade messages.
+			 *     }
+			 * }
 			 */
 			$notifications_enabled = apply_filters( 'auto_theme_update_send_email', true, $update_results['theme'] );
 


### PR DESCRIPTION
This PR documents the `$update_results` parameter for the following auto-update email filters:

- `auto_plugin_update_send_email`
- `auto_theme_update_send_email`

Trac ticket: https://core.trac.wordpress.org/ticket/51167
