### PR TITLE
Emoji: Respect all parent nodes classNames, .wp-exclude-emoji.

### DIFF
--- a/src/js/_enqueues/wp/emoji.js
+++ b/src/js/_enqueues/wp/emoji.js
@@ -254,7 +254,7 @@
 				base: browserSupportsSvgAsImage() ? settings.svgUrl : settings.baseUrl,
 				ext:  browserSupportsSvgAsImage() ? settings.svgExt : settings.ext,
 				className: args.className || 'emoji',
-				callback: function( icon, options ) {
+				callback: function( icon, options, textNode ) {
 					// Ignore some standard characters that TinyMCE recommends in its character map.
 					switch ( icon ) {
 						case 'a9':


### PR DESCRIPTION
This iterates up the tree from the textNode looking for emoji's and skips if the `.wp-exclude-emoji` class is present on any parent Elements.

This also causes `.wp-exclude-emoji` to be respected on elements that were on the page at pageload, unlike the existing `.wp-exclude-emoji` implementation.

Trac ticket: https://core.trac.wordpress.org/ticket/52219

A patch to Twemoji is required for this change to be effective on elements that are present on the pageload, and not run through the MutationObserver, as it's not possible to know which element Twemoji is operating upon otherwise.
```diff
Index: js/twemoji.js
===================================================================
--- js/twemoji.js	(revision 54531)
+++ js/twemoji.js	(working copy)
@@ -372,7 +372,7 @@
         rawText = match[0];
         iconId = grabTheRightIcon(rawText);
         i = index + rawText.length;
-        src = options.callback(iconId, options);
+        src = options.callback(iconId, options, subnode);
         if (iconId && src) {
           img = new Image();
           img.onerror = options.onerror;
```

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
