### PR TITLE
HTTP: Include the old Requests class for plugins and themes that still use it.

### DIFF
--- a/src/wp-includes/Requests/library/Requests.php
+++ b/src/wp-includes/Requests/library/Requests.php
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * This file includes the old Requests class
+ * for plugins or themes that still use it.
+ *
+ * @package WordPress
+ * @since 6.2.0
+ */
+
+include_once ABSPATH . WPINC . '/class-requests.php';

--- a/src/wp-includes/Requests/library/Requests.php
+++ b/src/wp-includes/Requests/library/Requests.php
@@ -1,10 +1,11 @@
 <?php
-
 /**
- * This file includes the old Requests class
- * for plugins or themes that still use it.
+ * Loads the old Requests class file when the autoloader
+ * references the original PSR-0 Requests class.
  *
+ * @deprecated 6.2.0
  * @package WordPress
+ * @subpackage Requests
  * @since 6.2.0
  */
 

--- a/tests/phpunit/tests/http/includeOldRequestsClass.php
+++ b/tests/phpunit/tests/http/includeOldRequestsClass.php
@@ -9,8 +9,6 @@
 class Tests_HTTP_IncludeOldRequestsClass extends WP_UnitTestCase {
 
 	/**
-	 * Tests that the old Requests class is included for plugins or themes that still use it.
-	 *
 	 * @ticket 57341
 	 *
 	 * @coversNothing
@@ -21,5 +19,4 @@ class Tests_HTTP_IncludeOldRequestsClass extends WP_UnitTestCase {
 
 		new Requests();
 	}
-
 }

--- a/tests/phpunit/tests/http/includeOldRequestsClass.php
+++ b/tests/phpunit/tests/http/includeOldRequestsClass.php
@@ -16,10 +16,8 @@ class Tests_HTTP_IncludeOldRequestsClass extends WP_UnitTestCase {
 	 * @coversNothing
 	 */
 	public function test_should_include_old_requests_class() {
-		$expected = 'The PSR-0 `Requests_...` class names in the Request library are deprecated.';
-
 		$this->expectDeprecation();
-		$this->expectDeprecationMessage( $expected );
+		$this->expectDeprecationMessage( 'The PSR-0 `Requests_...` class names in the Request library are deprecated.' );
 
 		new Requests();
 	}

--- a/tests/phpunit/tests/http/includeOldRequestsClass.php
+++ b/tests/phpunit/tests/http/includeOldRequestsClass.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Tests that the old Requests class is included
+ * for plugins or themes that still use it.
+ *
+ * @group http
+ */
+class Tests_HTTP_IncludeOldRequestsClass extends WP_UnitTestCase {
+
+	/**
+	 * Tests that the old Requests class is included for plugins or themes that still use it.
+	 *
+	 * @ticket 57341
+	 *
+	 * @coversNothing
+	 */
+	public function test_should_include_old_requests_class() {
+		$expected = 'The PSR-0 `Requests_...` class names in the Request library are deprecated.';
+
+		$this->expectDeprecation();
+		$this->expectDeprecationMessage( $expected );
+
+		new Requests();
+	}
+
+}


### PR DESCRIPTION
This PR:

Adds the `wp-includes/Requests/library/Requests.php` file, which includes the old Requests class in `wp-includes/class-requests.php` for plugins and themes that still use it.

This will trigger a deprecation notice, which is expected and intentional, to notify extenders to update their plugin or theme at their earliest convenience.

Trac ticket: https://core.trac.wordpress.org/ticket/57341
