### PR TITLE
PHP 8.2: Fix property typo in IXR_Message class

### DIFF
--- a/src/wp-includes/IXR/class-IXR-message.php
+++ b/src/wp-includes/IXR/class-IXR-message.php
@@ -144,7 +144,7 @@ class IXR_Message
     function tag_open($parser, $tag, $attr)
     {
         $this->_currentTagContents = '';
-        $this->currentTag = $tag;
+        $this->_currentTag = $tag;
         switch($tag) {
             case 'methodCall':
             case 'methodResponse':

--- a/tests/phpunit/tests/IXR/IXR-message.php
+++ b/tests/phpunit/tests/IXR/IXR-message.php
@@ -13,7 +13,12 @@
  */
 class Tests_IXR_IXR_Message extends WP_UnitTestCase {
 
-	public function test_parse() {
+	/**
+	 * @ticket 56033
+	 *
+	 * @covers IXR_Message::tag_open
+	 */    
+	public function test_tag_open_does_not_create_dynamic_property() {
 		$message = new IXR_Message( '<methodResponse><params><param><value>1</value></param></params></methodResponse>' );
 		$this->assertTrue( $message->parse() );
 		$this->assertSame( 'methodResponse', $message->messageType ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase

--- a/tests/phpunit/tests/IXR/IXR-message.php
+++ b/tests/phpunit/tests/IXR/IXR-message.php
@@ -17,7 +17,7 @@ class Tests_IXR_IXR_Message extends WP_UnitTestCase {
 	 * @ticket 56033
 	 *
 	 * @covers IXR_Message::tag_open
-	 */    
+	 */
 	public function test_tag_open_does_not_create_dynamic_property() {
 		$message = new IXR_Message( '<methodResponse><params><param><value>1</value></param></params></methodResponse>' );
 		$this->assertTrue( $message->parse() );

--- a/tests/phpunit/tests/IXR/IXR-message.php
+++ b/tests/phpunit/tests/IXR/IXR-message.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Unit tests covering IXR_Message functionality.
+ *
+ * @package    WordPress
+ * @subpackage IXR
+ */
+
+/**
+ * Test wp-includes/IXR/class-IXR-message.php
+ *
+ * @group IXR
+ */
+class Tests_IXR_IXR_Message extends WP_UnitTestCase {
+
+	public function test_parse() {
+		$message = new IXR_Message( '<methodResponse><params><param><value>1</value></param></params></methodResponse>' );
+		$this->assertTrue( $message->parse() );
+		$this->assertSame( 'methodResponse', $message->messageType ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		$this->assertSame( array( '1' ), $message->params );
+	}
+
+}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

The IXR_Message class declares a property `_currentTag`, which is never assigned or used. It does assign to `currentTag`, which outside of that one assignment is never used either. A search on wpdirectory didn't turn up anything using either property (but lots of results for other classes having a property of the same name).

Since there are various other underscore-prefixed properties declared on the class, including one named `_currentTagContents` which is used in several places, it seems likely the declared property is correct and the assignment is a typo.

Trac ticket: https://core.trac.wordpress.org/ticket/56790

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
