### PR TITLE
Build/Test Tools: Remove < PHP 7.2 test workflows.

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -59,23 +59,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2' ]
+        php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2' ]
         os: [ ubuntu-latest ]
         memcached: [ false ]
         split_slow: [ false ]
         multisite: [ false, true ]
         include:
-          # Additional "slow" jobs for PHP 5.6.
-          - php: '5.6'
-            os: ubuntu-latest
-            memcached: false
-            multisite: false
-            split_slow: true
-          - php: '5.6'
-            os: ubuntu-latest
-            memcached: false
-            multisite: true
-            split_slow: true
           # Include jobs for PHP 7.4 with memcached.
           - php: '7.4'
             os: ubuntu-latest
@@ -172,16 +161,7 @@ jobs:
         if: ${{ matrix.split_slow }}
         run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c ${{ env.PHPUNIT_CONFIG }} --group ${{ env.SLOW_TESTS }}
 
-      - name: Run PHPUnit tests for single site excluding slow tests
-        if: ${{ matrix.php < '7.0' && ! matrix.split_slow && ! matrix.multisite }}
-        run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c ${{ env.PHPUNIT_CONFIG }} --exclude-group ${{ env.SLOW_TESTS }},ajax,ms-files,ms-required
-
-      - name: Run PHPUnit tests for Multisite excluding slow tests
-        if: ${{ matrix.php < '7.0' && ! matrix.split_slow && matrix.multisite }}
-        run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c ${{ env.PHPUNIT_CONFIG }} --exclude-group ${{ env.SLOW_TESTS }},ajax,ms-files,ms-excluded,oembed-headers
-
       - name: Run PHPUnit tests
-        if: ${{ matrix.php >= '7.0' }}
         run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c ${{ env.PHPUNIT_CONFIG }}
 
       - name: Run AJAX tests


### PR DESCRIPTION
Now that the minimum PHP version has been raised, the test workflows should not run against earlier PHP versions.

This change removes references to PHP versions lower than 7.2 from the GitHub workflows.

Trac ticket: https://core.trac.wordpress.org/ticket/57345