### PR TITLE
Build/Test Tools: Remove PHP 7+ test and relocate datasets.

### DIFF
--- a/tests/phpunit/tests/functions/wpListUtil.php
+++ b/tests/phpunit/tests/functions/wpListUtil.php
@@ -223,6 +223,18 @@ class Tests_Functions_wpListUtil extends WP_UnitTestCase {
 				'order'         => 'DESC',
 				'preserve_keys' => true,
 			),
+			'string[], int keys, $orderby a non-existent field, $order = ASC and $preserve_keys = false' => array(
+				'expected'      => array( 'four', 'two', 'three', 'one' ),
+				'target_array'  => array(
+					4 => 'four',
+					2 => 'two',
+					3 => 'three',
+					1 => 'one',
+				),
+				'orderby'       => 'id',
+				'order'         => 'ASC',
+				'preserve_keys' => false,
+			),
 			'string[], string keys, no ordering' => array(
 				'expected'     => array(
 					'four'  => 'four',
@@ -253,6 +265,18 @@ class Tests_Functions_wpListUtil extends WP_UnitTestCase {
 				'orderby'       => 'id',
 				'order'         => 'DESC',
 				'preserve_keys' => true,
+			),
+			'string[], string keys, $orderby a non-existent field, $order = ASC and $preserve_keys = false' => array(
+				'expected'      => array( 'four', 'two', 'three', 'one' ),
+				'target_array'  => array(
+					'four'  => 'four',
+					'two'   => 'two',
+					'three' => 'three',
+					'one'   => 'one',
+				),
+				'orderby'       => 'id',
+				'order'         => 'ASC',
+				'preserve_keys' => false,
 			),
 		);
 	}
@@ -299,6 +323,18 @@ class Tests_Functions_wpListUtil extends WP_UnitTestCase {
 				'order'         => 'DESC',
 				'preserve_keys' => true,
 			),
+			'int[], int keys, $orderby a non-existent field, $order = ASC and $preserve_keys = false' => array(
+				'expected'      => array( 4, 2, 3, 1 ),
+				'target_array'  => array(
+					4 => 4,
+					2 => 2,
+					3 => 3,
+					1 => 1,
+				),
+				'orderby'       => 'id',
+				'order'         => 'ASC',
+				'preserve_keys' => false,
+			),
 			'int[], string keys, no ordering' => array(
 				'expected'     => array(
 					'four'  => 4,
@@ -329,6 +365,18 @@ class Tests_Functions_wpListUtil extends WP_UnitTestCase {
 				'orderby'       => 'id',
 				'order'         => 'DESC',
 				'preserve_keys' => true,
+			),
+			'int[], string keys, $orderby a non-existent field, $order = ASC and $preserve_keys = false' => array(
+				'expected'      => array( 4, 2, 3, 1 ),
+				'target_array'  => array(
+					'four'  => 4,
+					'two'   => 2,
+					'three' => 3,
+					'one'   => 1,
+				),
+				'orderby'       => 'id',
+				'order'         => 'ASC',
+				'preserve_keys' => false,
 			),
 		);
 	}
@@ -621,6 +669,23 @@ class Tests_Functions_wpListUtil extends WP_UnitTestCase {
 				'order'         => 'asc',
 				'preserve_keys' => false,
 			),
+			'array[], int keys, $orderby a non-existent field, $order = ASC and $preserve_keys = false' => array(
+				'expected'      => array(
+					array( 'value' => 'four' ),
+					array( 'value' => 'two' ),
+					array( 'value' => 'three' ),
+					array( 'value' => 'one' ),
+				),
+				'target_array'  => array(
+					4 => array( 'value' => 'four' ),
+					2 => array( 'value' => 'two' ),
+					3 => array( 'value' => 'three' ),
+					1 => array( 'value' => 'one' ),
+				),
+				'orderby'       => 'id',
+				'order'         => 'ASC',
+				'preserve_keys' => false,
+			),
 			'array[], string keys, $orderby an existing field, no order and $preserve_keys = false' => array(
 				'expected'      => array(
 					'four'  => array(
@@ -704,6 +769,23 @@ class Tests_Functions_wpListUtil extends WP_UnitTestCase {
 					'value' => 'DESC',
 				),
 				'order'         => null,
+				'preserve_keys' => false,
+			),
+			'array[], string keys, $orderby a non-existent field, $order = ASC and $preserve_keys = false' => array(
+				'expected'      => array(
+					array( 'value' => 'four' ),
+					array( 'value' => 'two' ),
+					array( 'value' => 'three' ),
+					array( 'value' => 'one' ),
+				),
+				'target_array'  => array(
+					'four'  => array( 'value' => 'four' ),
+					'two'   => array( 'value' => 'two' ),
+					'three' => array( 'value' => 'three' ),
+					'one'   => array( 'value' => 'one' ),
+				),
+				'orderby'       => 'id',
+				'order'         => 'ASC',
 				'preserve_keys' => false,
 			),
 		);
@@ -826,6 +908,40 @@ class Tests_Functions_wpListUtil extends WP_UnitTestCase {
 				'order'         => 'DESC',
 				'preserve_keys' => true,
 			),
+			'object[], int keys, $orderby a non-existent field, $order = ASC and $preserve_keys = false' => array(
+				'expected'      => array(
+					(object) array( 'value' => 'four' ),
+					(object) array( 'value' => 'two' ),
+					(object) array( 'value' => 'three' ),
+					(object) array( 'value' => 'one' ),
+				),
+				'target_array'  => array(
+					4 => (object) array( 'value' => 'four' ),
+					2 => (object) array( 'value' => 'two' ),
+					3 => (object) array( 'value' => 'three' ),
+					1 => (object) array( 'value' => 'one' ),
+				),
+				'orderby'       => 'id',
+				'order'         => 'ASC',
+				'preserve_keys' => false,
+			),
+			'object[], int keys, $orderby a non-existent field, $order = DESC and $preserve_keys = true' => array(
+				'expected'      => array(
+					4 => (object) array( 'value' => 'four' ),
+					2 => (object) array( 'value' => 'two' ),
+					3 => (object) array( 'value' => 'three' ),
+					1 => (object) array( 'value' => 'one' ),
+				),
+				'target_array'  => array(
+					4 => (object) array( 'value' => 'four' ),
+					2 => (object) array( 'value' => 'two' ),
+					3 => (object) array( 'value' => 'three' ),
+					1 => (object) array( 'value' => 'one' ),
+				),
+				'orderby'       => 'id',
+				'order'         => 'DESC',
+				'preserve_keys' => true,
+			),
 			'object[], string keys, no ordering' => array(
 				'expected'     => array(
 					'four'  => (object) array( 'value' => 'four' ),
@@ -934,175 +1050,6 @@ class Tests_Functions_wpListUtil extends WP_UnitTestCase {
 						'id'    => 4,
 						'value' => 'four',
 					),
-				),
-				'orderby'       => 'id',
-				'order'         => 'DESC',
-				'preserve_keys' => true,
-			),
-		);
-	}
-
-	/**
-	 * Tests non-existent '$orderby' fields.
-	 *
-	 * In PHP < 7.0.0, the sorting behavior is different, which Core does not
-	 * currently handle. Until this is fixed, or the minimum PHP version is
-	 * raised to PHP 7.0.0+, these tests will be skipped on PHP < 7.0.0.
-	 *
-	 * @ticket 55300
-	 *
-	 * @dataProvider data_wp_list_util_sort_php_7_or_greater
-	 *
-	 * @covers WP_List_Util::sort
-	 * @covers ::wp_list_sort
-	 *
-	 * @param array  $expected      The expected array.
-	 * @param array  $target_array  The array to create a list from.
-	 * @param array  $orderby       Optional. Either the field name to order by or an array
-	 *                              of multiple orderby fields as `$orderby => $order`.
-	 *                              Default empty array.
-	 * @param string $order         Optional. Either 'ASC' or 'DESC'. Only used if `$orderby`
-	 *                              is a string. Default 'ASC'.
-	 * @param bool   $preserve_keys Optional. Whether to preserve keys. Default false.
-	 */
-	public function test_wp_list_util_sort_php_7_or_greater( $expected, $target_array, $orderby = array(), $order = 'ASC', $preserve_keys = false ) {
-		if ( version_compare( PHP_VERSION, '7.0.0', '<' ) ) {
-			$this->markTestSkipped( 'This test can only run on PHP 7.0 or greater due to an unstable sort order.' );
-		}
-
-		$util   = new WP_List_Util( $target_array );
-		$actual = $util->sort( $orderby, $order, $preserve_keys );
-
-		$this->assertEqualSetsWithIndex(
-			$expected,
-			$actual,
-			'The sorted value did not match the expected value.'
-		);
-		$this->assertEqualSetsWithIndex(
-			$expected,
-			$util->get_output(),
-			'::get_output() did not return the expected value.'
-		);
-	}
-
-	/**
-	 * Data provider for test_wp_list_util_sort_php_7_or_greater().
-	 *
-	 * @return array[]
-	 */
-	public function data_wp_list_util_sort_php_7_or_greater() {
-		return array(
-			'int[], int keys, $orderby a non-existent field, $order = ASC and $preserve_keys = false' => array(
-				'expected'      => array( 4, 2, 3, 1 ),
-				'target_array'  => array(
-					4 => 4,
-					2 => 2,
-					3 => 3,
-					1 => 1,
-				),
-				'orderby'       => 'id',
-				'order'         => 'ASC',
-				'preserve_keys' => false,
-			),
-			'int[], string keys, $orderby a non-existent field, $order = ASC and $preserve_keys = false' => array(
-				'expected'      => array( 4, 2, 3, 1 ),
-				'target_array'  => array(
-					'four'  => 4,
-					'two'   => 2,
-					'three' => 3,
-					'one'   => 1,
-				),
-				'orderby'       => 'id',
-				'order'         => 'ASC',
-				'preserve_keys' => false,
-			),
-			'string[], int keys, $orderby a non-existent field, $order = ASC and $preserve_keys = false' => array(
-				'expected'      => array( 'four', 'two', 'three', 'one' ),
-				'target_array'  => array(
-					4 => 'four',
-					2 => 'two',
-					3 => 'three',
-					1 => 'one',
-				),
-				'orderby'       => 'id',
-				'order'         => 'ASC',
-				'preserve_keys' => false,
-			),
-			'string[], string keys, $orderby a non-existent field, $order = ASC and $preserve_keys = false' => array(
-				'expected'      => array( 'four', 'two', 'three', 'one' ),
-				'target_array'  => array(
-					'four'  => 'four',
-					'two'   => 'two',
-					'three' => 'three',
-					'one'   => 'one',
-				),
-				'orderby'       => 'id',
-				'order'         => 'ASC',
-				'preserve_keys' => false,
-			),
-			'array[], int keys, $orderby a non-existent field, $order = ASC and $preserve_keys = false' => array(
-				'expected'      => array(
-					array( 'value' => 'four' ),
-					array( 'value' => 'two' ),
-					array( 'value' => 'three' ),
-					array( 'value' => 'one' ),
-				),
-				'target_array'  => array(
-					4 => array( 'value' => 'four' ),
-					2 => array( 'value' => 'two' ),
-					3 => array( 'value' => 'three' ),
-					1 => array( 'value' => 'one' ),
-				),
-				'orderby'       => 'id',
-				'order'         => 'ASC',
-				'preserve_keys' => false,
-			),
-			'array[], string keys, $orderby a non-existent field, $order = ASC and $preserve_keys = false' => array(
-				'expected'      => array(
-					array( 'value' => 'four' ),
-					array( 'value' => 'two' ),
-					array( 'value' => 'three' ),
-					array( 'value' => 'one' ),
-				),
-				'target_array'  => array(
-					'four'  => array( 'value' => 'four' ),
-					'two'   => array( 'value' => 'two' ),
-					'three' => array( 'value' => 'three' ),
-					'one'   => array( 'value' => 'one' ),
-				),
-				'orderby'       => 'id',
-				'order'         => 'ASC',
-				'preserve_keys' => false,
-			),
-			'object[], int keys, $orderby a non-existent field, $order = ASC and $preserve_keys = false' => array(
-				'expected'      => array(
-					(object) array( 'value' => 'four' ),
-					(object) array( 'value' => 'two' ),
-					(object) array( 'value' => 'three' ),
-					(object) array( 'value' => 'one' ),
-				),
-				'target_array'  => array(
-					4 => (object) array( 'value' => 'four' ),
-					2 => (object) array( 'value' => 'two' ),
-					3 => (object) array( 'value' => 'three' ),
-					1 => (object) array( 'value' => 'one' ),
-				),
-				'orderby'       => 'id',
-				'order'         => 'ASC',
-				'preserve_keys' => false,
-			),
-			'object[], int keys, $orderby a non-existent field, $order = DESC and $preserve_keys = true' => array(
-				'expected'      => array(
-					4 => (object) array( 'value' => 'four' ),
-					2 => (object) array( 'value' => 'two' ),
-					3 => (object) array( 'value' => 'three' ),
-					1 => (object) array( 'value' => 'one' ),
-				),
-				'target_array'  => array(
-					4 => (object) array( 'value' => 'four' ),
-					2 => (object) array( 'value' => 'two' ),
-					3 => (object) array( 'value' => 'three' ),
-					1 => (object) array( 'value' => 'one' ),
 				),
 				'orderby'       => 'id',
 				'order'         => 'DESC',


### PR DESCRIPTION
Now that the minimum PHP version has been raised, this test and its data provider can be removed.

The datasets from the data provider have been relocated to other data providers in the test class.

N.B. This PR has expected test failures in PHP 5.6 tests until #3779 is merged.

Trac ticket: https://core.trac.wordpress.org/ticket/57345