### PR TITLE
General: Remove the `IMG_WEBP` defined in PHP 7.0.10+.

### DIFF
--- a/src/wp-includes/compat.php
+++ b/src/wp-includes/compat.php
@@ -492,8 +492,3 @@ if ( ! function_exists( 'str_ends_with' ) ) {
 if ( ! defined( 'IMAGETYPE_WEBP' ) ) {
 	define( 'IMAGETYPE_WEBP', 18 );
 }
-
-// IMG_WEBP constant is only defined in PHP 7.0.10 or later.
-if ( ! defined( 'IMG_WEBP' ) ) {
-	define( 'IMG_WEBP', IMAGETYPE_WEBP );
-}


### PR DESCRIPTION
The `IMG_WEBP` constant is defined in PHP 7.0.10 and later.

Now that the minimum PHP version has been raised, the `IMG_WEBP` constant definition can be removed.

Ref:
PHP manual - Migrating from PHP 5.6.x to PHP 7.0.x
https://www.php.net/manual/en/migration70.constants.php

Trac ticket: https://core.trac.wordpress.org/ticket/57345