### PR TITLE
General: Remove the `IMAGETYPE_WEBP` constant defined in PHP 7.1+.

### DIFF
--- a/src/wp-includes/compat.php
+++ b/src/wp-includes/compat.php
@@ -488,11 +488,6 @@ if ( ! function_exists( 'str_ends_with' ) ) {
 	}
 }
 
-// IMAGETYPE_WEBP constant is only defined in PHP 7.1 or later.
-if ( ! defined( 'IMAGETYPE_WEBP' ) ) {
-	define( 'IMAGETYPE_WEBP', 18 );
-}
-
 // IMG_WEBP constant is only defined in PHP 7.0.10 or later.
 if ( ! defined( 'IMG_WEBP' ) ) {
 	define( 'IMG_WEBP', IMAGETYPE_WEBP );


### PR DESCRIPTION
The `IMAGETYPE_WEBP` constant is defined in PHP 7.1 and later.

Now that the minimum PHP version has been raised, the `IMAGETYPE_WEBP` constant definition can be removed.

Ref:
PHP manual - Migrating from PHP 7.0.x to PHP 7.1.x
https://www.php.net/manual/en/migration71.constants.php

N.B. This PR has expected test failures in PHP 5.6 and 7.0 tests until #3779  is merged.

Trac ticket: https://core.trac.wordpress.org/ticket/57345