### PR TITLE
Backport: Outline support for blocks in theme.json with unit test

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -192,6 +192,8 @@ class WP_Theme_JSON {
 	 * @since 6.1.0 Added the `border-*-color`, `border-*-width`, `border-*-style`,
 	 *              `--wp--style--root--padding-*`, and `box-shadow` properties,
 	 *              removed the `--wp--style--block-gap` property.
+	 * @since 6.2.0 Added `outline-*` properties.
+	 *
 	 * @var array
 	 */
 	const PROPERTIES_METADATA = array(
@@ -356,6 +358,8 @@ class WP_Theme_JSON {
 	 * @since 6.1.0 Added new side properties for `border`,
 	 *              added new property `shadow`,
 	 *              updated `blockGap` to be allowed at any level.
+	 * @since 6.2.0 Added `outline` properties.
+	 *
 	 * @var array
 	 */
 	const VALID_STYLES = array(

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -229,6 +229,10 @@ class WP_Theme_JSON {
 		'margin-right'                      => array( 'spacing', 'margin', 'right' ),
 		'margin-bottom'                     => array( 'spacing', 'margin', 'bottom' ),
 		'margin-left'                       => array( 'spacing', 'margin', 'left' ),
+		'outline-color'                     => array( 'outline', 'color' ),
+		'outline-offset'                    => array( 'outline', 'offset' ),
+		'outline-style'                     => array( 'outline', 'style' ),
+		'outline-width'                     => array( 'outline', 'width' ),
 		'padding'                           => array( 'spacing', 'padding' ),
 		'padding-top'                       => array( 'spacing', 'padding', 'top' ),
 		'padding-right'                     => array( 'spacing', 'padding', 'right' ),
@@ -374,6 +378,12 @@ class WP_Theme_JSON {
 			'duotone' => null,
 		),
 		'shadow'     => null,
+		'outline'    => array(
+			'color'  => null,
+			'offset' => null,
+			'style'  => null,
+			'width'  => null,
+		),
 		'spacing'    => array(
 			'margin'   => null,
 			'padding'  => null,

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -4090,4 +4090,42 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 			),
 		);
 	}
+
+	/**
+	 * @ticket 57354
+	 */
+	public function test_get_stylesheet_returns_outline_styles() {
+		$theme_json = new WP_Theme_JSON(
+			array(
+				'version' => WP_Theme_JSON::LATEST_SCHEMA,
+				'styles'  => array(
+					'elements' => array(
+						'button' => array(
+							'outline' => array(
+								'offset' => '3px',
+								'width'  => '3px',
+								'style'  => 'dashed',
+								'color'  => 'red',
+							),
+							':hover'  => array(
+								'outline' => array(
+									'offset' => '3px',
+									'width'  => '3px',
+									'style'  => 'solid',
+									'color'  => 'blue',
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$base_styles = 'body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
+
+		$element_styles = '.wp-element-button, .wp-block-button__link{outline-color: red;outline-offset: 3px;outline-style: dashed;outline-width: 3px;}.wp-element-button:hover, .wp-block-button__link:hover{outline-color: blue;outline-offset: 3px;outline-style: solid;outline-width: 3px;}';
+
+		$expected = $base_styles . $element_styles;
+		$this->assertSame( $expected, $theme_json->get_stylesheet() );
+	}
 }


### PR DESCRIPTION
Refresh of  PR #3788: adds test commit (that fails before the backport) and then adds the backport commit, while ensuring it's based on `trunk`.

This PR backports the changes in [#43526](https://github.com/WordPress/gutenberg/pull/43526) that add support for the outline property on theme.json

Trac ticket:  https://core.trac.wordpress.org/ticket/57354

Props: @MaggieCabrera and @audrasjb (from the previous PR)

## [How to Test](#-how-to-test)

Open  TT3's `theme.json` and go to `"elements"` on about line 596 and then `"button"` on the next line. Then make the following changes:

* Add this code as the first entry (before `"border"`): 
```json
"outline": {
	"offset": "3px",
	"width": "3px",
	"style": "dashed",
	"color": "red"
},
```

and in `":hover"`, add this code as the last entry (after `"color"`):
```json
"outline": {
	"offset": "3px",
	"width": "3px",
	"style": "solid",
	"color": "blue"
}
```

Then add a new post and a button block. In the front-end it should render similar to this:

![Screen Capture on 2022-08-23 at 16-45-03](https://user-images.githubusercontent.com/3593343/186188731-7f8076a1-9733-45c3-8985-34e3b99aff39.gif)
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
