### PR TITLE
create filter to enable use of custom directory copy code

### DIFF
--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -593,21 +593,18 @@ class WP_Upgrader {
 			}
 		}
 
-		// Copy new version of item into place.
-		if ( class_exists( 'Rollback_Update_Failure\WP_Upgrader' )
-			&& function_exists( '\Rollback_Update_Failure\move_dir' )
-		) {
-			/*
-			 * If the {@link https://wordpress.org/plugins/rollback-update-failure/ Rollback Update Failure}
-			 * feature plugin is installed, use the move_dir() function from there for better performance.
-			 * Instead of copying a directory from one location to another, it uses the rename() PHP function
-			 * to speed up the process. If the renaming failed, it falls back to copy_dir().
-			 *
-			 * This condition aims to facilitate broader testing of the Rollbacks (temp backups) feature project.
-			 * It is temporary, until the plugin is merged into core.
-			 */
-			$result = \Rollback_Update_Failure\move_dir( $source, $remote_destination );
-		} else {
+		/**
+		 * Filters whether to skip use of standard directory copy function so that
+		 * custom function may be more easily substituted.
+		 *
+		 * @since 6.2.0
+		 *
+		 * @param bool|WP_Error $result             Filter response.
+		 * @param string        $source             File source location.
+		 * @param string        $remote_destination The remote package destination.
+		 */
+		$result = apply_filters( 'upgrader_copy_directory', false, $source, $remote_destination );
+		if ( false === $result ) {
 			$result = copy_dir( $source, $remote_destination );
 		}
 

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -594,19 +594,14 @@ class WP_Upgrader {
 		}
 
 		/**
-		 * Filters whether to skip use of standard directory copy function so that
-		 * custom function may be more easily substituted.
+		 * Filters callback function to use for copying directory.
 		 *
 		 * @since 6.2.0
 		 *
-		 * @param bool|WP_Error $result             Filter response.
-		 * @param string        $source             File source location.
-		 * @param string        $remote_destination The remote package destination.
+		 * @param string $callback Name of callback.
 		 */
-		$result = apply_filters( 'upgrader_copy_directory', false, $source, $remote_destination );
-		if ( false === $result ) {
-			$result = copy_dir( $source, $remote_destination );
-		}
+		$callback = apply_filters( 'upgrader_copy_directory', 'copy_dir' );
+		$result   = call_user_func( $callback, $source, $remote_destination );
 
 		if ( is_wp_error( $result ) ) {
 			if ( $args['clear_working'] ) {


### PR DESCRIPTION
Instead of the custom conditional for testing Rollback, add a filter hook that enables the ability to use custom code in place of `copy_dir()` in `WP_Upgrader::install_package()`.

Filter sets callback function to use for directory copy.

Trac ticket: https://core.trac.wordpress.org/ticket/56057

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
