### PR TITLE
Add move_dir() and wp_opcache_invalidate_directory() functions

### DIFF
--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -593,8 +593,8 @@ class WP_Upgrader {
 			}
 		}
 
-		// Copy new version of item into place.
-		$result = copy_dir( $source, $remote_destination );
+		// Move new version of directory into place.
+		$result = move_dir( $source, $remote_destination );
 
 		// Clear the working folder?
 		if ( $args['clear_working'] ) {

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -594,7 +594,7 @@ class WP_Upgrader {
 		}
 
 		// Move new version of directory into place.
-		$result = move_dir( $source, $remote_destination );
+		$result = move_dir( $source, $remote_destination, true );
 
 		// Clear the working folder?
 		if ( $args['clear_working'] ) {

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -2638,8 +2638,8 @@ function wp_opcache_invalidate_directory( $dir ) {
 	if ( ! is_string( $dir ) || '' === trim( $dir ) ) {
 		if ( WP_DEBUG ) {
 			$error_message = sprintf(
-			/* translators: %s: The function. */
-				__( 'The %s argument must be a non-empty string.' ),
+				/* translators: %s: The function name. */
+				__( '%s expects a non-empty string.' ),
 				'<code>wp_opcache_invalidate_directory()</code>'
 			);
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1989,8 +1989,7 @@ function move_dir( $from, $to ) {
 		 * When using an environment with shared folders,
 		 * there is a delay in updating the filesystem's cache.
 		 *
-		 * This is an issue known primarily in environments
-		 * with a VirtualBox provider.
+		 * This is a known issue in environments with a VirtualBox provider.
 		 *
 		 * A 200ms delay gives time for the filesystem to update
 		 * its cache, and prevents "Operation not permitted" and

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1947,6 +1947,68 @@ function copy_dir( $from, $to, $skip_list = array() ) {
 }
 
 /**
+ * Moves a directory from one location to another via the rename() PHP function.
+ * If the renaming failed, falls back to copy_dir().
+ *
+ * Assumes that WP_Filesystem() has already been called and setup.
+ *
+ * @since 6.2.0
+ *
+ * @global WP_Filesystem_Base $wp_filesystem WordPress filesystem subclass.
+ *
+ * @param string $from        Source directory.
+ * @param string $to          Destination directory.
+ * @return true|WP_Error True on success, WP_Error on failure.
+ */
+function move_dir( $from, $to ) {
+	global $wp_filesystem;
+
+	$result = false;
+
+	/**
+	 * Fires before move_dir().
+	 *
+	 * @since 6.2.0
+	 */
+	do_action( 'pre_move_dir' );
+
+	if ( 'direct' === $wp_filesystem->method ) {
+		$wp_filesystem->rmdir( $to );
+
+		$result = @rename( $from, $to );
+	}
+
+	// Non-direct filesystems use some version of rename without a fallback.
+	if ( 'direct' !== $wp_filesystem->method ) {
+		$result = $wp_filesystem->move( $from, $to );
+	}
+
+	if ( ! $result ) {
+		if ( ! $wp_filesystem->is_dir( $to ) ) {
+			if ( ! $wp_filesystem->mkdir( $to, FS_CHMOD_DIR ) ) {
+				return new \WP_Error( 'mkdir_failed_move_dir', __( 'Could not create directory.' ), $to );
+			}
+		}
+
+		$result = copy_dir( $from, $to, array( basename( $to ) ) );
+
+		// Clear the source directory.
+		if ( ! is_wp_error( $result ) ) {
+			$wp_filesystem->delete( $from, true );
+		}
+	}
+
+	/**
+	 * Fires after move_dir().
+	 *
+	 * @since 6.2.0
+	 */
+	do_action( 'post_move_dir' );
+
+	return $result;
+}
+
+/**
  * Initializes and connects the WordPress Filesystem Abstraction classes.
  *
  * This function will include the chosen transport and attempt connecting.

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -2647,6 +2647,7 @@ function wp_opcache_invalidate_directory( $dir ) {
 			__( 'The %s argument must be a non-empty string.' ),
 			'<code>$dir</code>'
 		);
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 		trigger_error( $error_message );
 		return;
 	}

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -2633,12 +2633,11 @@ function wp_opcache_invalidate( $filepath, $force = false ) {
  *
  * @global WP_Filesystem_Base $wp_filesystem WordPress filesystem subclass.
  *
- * @param string|array $dir  The path to invalidate, or the results of ::dirlist().
- * @param string       $path The path to invalidate for nested directories.
+ * @param string $dir The path to invalidate.
  *
  * @return void
  */
-function wp_opcache_invalidate_directory( $dir, $path = '' ) {
+function wp_opcache_invalidate_directory( $dir ) {
 	global $wp_filesystem;
 
 	if ( ! is_string( $dir ) || '' === trim( $dir ) ) {

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1956,7 +1956,7 @@ function copy_dir( $from, $to, $skip_list = array() ) {
  *
  * @global WP_Filesystem_Base $wp_filesystem WordPress filesystem subclass.
  *
-* @param string $from      Source directory.
+ * @param string $from      Source directory.
  * @param string $to        Destination directory.
  * @param bool   $overwrite Overwrite destination.
  *                          Default is false.

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1956,12 +1956,25 @@ function copy_dir( $from, $to, $skip_list = array() ) {
  *
  * @global WP_Filesystem_Base $wp_filesystem WordPress filesystem subclass.
  *
- * @param string $from Source directory.
- * @param string $to   Destination directory.
+* @param string $from      Source directory.
+ * @param string $to        Destination directory.
+ * @param bool   $overwrite Overwrite destination.
+ *                          Default is false.
  * @return true|WP_Error True on success, WP_Error on failure.
  */
-function move_dir( $from, $to ) {
+function move_dir( $from, $to, $overwrite = false ) {
 	global $wp_filesystem;
+
+	if ( ! $overwrite && $wp_filesystem->exists( $to ) ) {
+		return new WP_Error(
+			'to_directory_already_exists_move_dir',
+			sprintf(
+				/* translators: %s: The '$to' argument name. */
+				__( '%s already exists.' ),
+				'<code>$to</code>'
+			)
+		);
+	}
 
 	$result = false;
 

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -2020,10 +2020,11 @@ function move_dir( $from, $to ) {
 	 *
 	 * @since 6.2.0
 	 *
-	 * @param string $from Source directory.
-	 * @param string $to   Destination directory.
+	 * @param string $from  Source directory.
+	 * @param string $to    Destination directory.
+	 * @param true|WP_Error Result from move_dir().
 	 */
-	do_action( 'post_move_dir', $from, $to );
+	do_action( 'post_move_dir', $from, $to, $result );
 
 	return $result;
 }

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1979,10 +1979,8 @@ function move_dir( $from, $to ) {
 		$wp_filesystem->rmdir( $to );
 
 		$result = @rename( $from, $to );
-	}
-
-	// Non-direct filesystems use some version of rename without a fallback.
-	if ( 'direct' !== $wp_filesystem->method ) {
+	} else {
+		// Non-direct filesystems use some version of rename without a fallback.
 		$result = $wp_filesystem->move( $from, $to );
 	}
 

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1969,8 +1969,11 @@ function move_dir( $from, $to ) {
 	 * Fires before move_dir().
 	 *
 	 * @since 6.2.0
+	 *
+	 * @param string $from Source directory.
+	 * @param string $to   Destination directory.
 	 */
-	do_action( 'pre_move_dir' );
+	do_action( 'pre_move_dir', $from, $to );
 
 	if ( 'direct' === $wp_filesystem->method ) {
 		$wp_filesystem->rmdir( $to );
@@ -2002,8 +2005,11 @@ function move_dir( $from, $to ) {
 	 * Fires after move_dir().
 	 *
 	 * @since 6.2.0
+	 *
+	 * @param string $from Source directory.
+	 * @param string $to   Destination directory.
 	 */
-	do_action( 'post_move_dir' );
+	do_action( 'post_move_dir', $from, $to );
 
 	return $result;
 }

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1965,16 +1965,6 @@ function move_dir( $from, $to ) {
 
 	$result = false;
 
-	/**
-	 * Fires before move_dir().
-	 *
-	 * @since 6.2.0
-	 *
-	 * @param string $from Source directory.
-	 * @param string $to   Destination directory.
-	 */
-	do_action( 'pre_move_dir', $from, $to );
-
 	if ( 'direct' === $wp_filesystem->method ) {
 		if ( $wp_filesystem->rmdir( $to ) ) {
 			$result = @rename( $from, $to );
@@ -2015,17 +2005,6 @@ function move_dir( $from, $to ) {
 			$wp_filesystem->delete( $from, true );
 		}
 	}
-
-	/**
-	 * Fires after move_dir().
-	 *
-	 * @since 6.2.0
-	 *
-	 * @param string        $from   Source directory.
-	 * @param string        $to     Destination directory.
-	 * @param true|WP_Error $result Result from move_dir().
-	 */
-	do_action( 'post_move_dir', $from, $to, $result );
 
 	return $result;
 }

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -2636,13 +2636,15 @@ function wp_opcache_invalidate_directory( $dir ) {
 	global $wp_filesystem;
 
 	if ( ! is_string( $dir ) || '' === trim( $dir ) ) {
-		$error_message = sprintf(
-			/* translators: %s: The '$dir' argument. */
-			__( 'The %s argument must be a non-empty string.' ),
-			'<code>$dir</code>'
-		);
-		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
-		trigger_error( wp_kses_post( $error_message ) );
+		if ( WP_DEBUG ) {
+			$error_message = sprintf(
+			/* translators: %s: The function. */
+				__( 'The %s argument must be a non-empty string.' ),
+				'<code>wp_opcache_invalidate_directory()</code>'
+			);
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+			trigger_error( $error_message );
+		}
 		return;
 	}
 

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -2627,14 +2627,15 @@ function wp_opcache_invalidate( $filepath, $force = false ) {
 }
 
 /**
- * Invalidate OPcache of directory of files.
+ * Attempts to clear the opcode cache for a directory of files.
  *
  * @since 6.2.0
  *
+ * @see wp_opcache_invalidate()
+ * @link https://www.php.net/manual/en/function.opcache-invalidate.php
  * @global WP_Filesystem_Base $wp_filesystem WordPress filesystem subclass.
  *
- * @param string $dir The path to invalidate.
- * @return void
+ * @param string $dir The path to the directory for which the opcode cache is to be cleared.
  */
 function wp_opcache_invalidate_directory( $dir ) {
 	global $wp_filesystem;

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1979,7 +1979,7 @@ function move_dir( $from, $to, $overwrite = false ) {
 	$result = false;
 
 	if ( 'direct' === $wp_filesystem->method ) {
-		if ( $wp_filesystem->rmdir( $to ) ) {
+		if ( $wp_filesystem->delete( $to, true ) ) {
 			$result = @rename( $from, $to );
 		}
 	} else {

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -2644,8 +2644,6 @@ function wp_opcache_invalidate_directory( $dir, $path = '' ) {
 	if ( is_string( $dir ) ) {
 		$path = $dir;
 		$dir  = $wp_filesystem->dirlist( $dir, false, true );
-		wp_opcache_invalidate_directory( $dir, trailingslashit( $path ) );
-		return;
 	}
 
 	foreach ( $dir as $name => $details ) {
@@ -2653,6 +2651,6 @@ function wp_opcache_invalidate_directory( $dir, $path = '' ) {
 			wp_opcache_invalidate_directory( $details['files'], trailingslashit( $path ) . trailingslashit( $name ) );
 			continue;
 		}
-		wp_opcache_invalidate( $path . $name );
+		wp_opcache_invalidate( trailingslashit( $path ) . $name );
 	}
 }

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1984,7 +1984,7 @@ function move_dir( $from, $to, $overwrite = false ) {
 		}
 	} else {
 		// Non-direct filesystems use some version of rename without a fallback.
-		$result = $wp_filesystem->move( $from, $to );
+		$result = $wp_filesystem->move( $from, $to, $overwrite );
 	}
 
 	if ( $result ) {

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -2002,7 +2002,7 @@ function move_dir( $from, $to ) {
 	if ( ! $result ) {
 		if ( ! $wp_filesystem->is_dir( $to ) ) {
 			if ( ! $wp_filesystem->mkdir( $to, FS_CHMOD_DIR ) ) {
-				return new \WP_Error( 'mkdir_failed_move_dir', __( 'Could not create directory.' ), $to );
+				return new WP_Error( 'mkdir_failed_move_dir', __( 'Could not create directory.' ), $to );
 			}
 		}
 

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1991,9 +1991,11 @@ function move_dir( $from, $to ) {
 		 *
 		 * This is a known issue in environments with a VirtualBox provider.
 		 *
-		 * A 200ms delay gives time for the filesystem to update
-		 * its cache, and prevents "Operation not permitted" and
-		 * "No such file or directory" warnings.
+		 * A 200ms delay gives time for the filesystem to update its cache,
+		 * prevents "Operation not permitted", and "No such file or directory" warnings.
+		 *
+		 * This delay is used in other projects, including Composer.
+		 * @link https://github.com/composer/composer/blob/main/src/Composer/Util/Platform.php#L228-L233
 		 */
 		usleep( 200000 );
 		wp_opcache_invalidate_directory( $to );

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1956,9 +1956,8 @@ function copy_dir( $from, $to, $skip_list = array() ) {
  *
  * @global WP_Filesystem_Base $wp_filesystem WordPress filesystem subclass.
  *
- * @param string $from        Source directory.
- * @param string $to          Destination directory.
- *
+ * @param string $from Source directory.
+ * @param string $to   Destination directory.
  * @return true|WP_Error True on success, WP_Error on failure.
  */
 function move_dir( $from, $to ) {

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -2647,7 +2647,7 @@ function wp_opcache_invalidate_directory( $dir ) {
 			'<code>$dir</code>'
 		);
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
-		trigger_error( $error_message );
+		trigger_error( wp_kses_post( $error_message ) );
 		return;
 	}
 

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1976,9 +1976,9 @@ function move_dir( $from, $to ) {
 	do_action( 'pre_move_dir', $from, $to );
 
 	if ( 'direct' === $wp_filesystem->method ) {
-		$wp_filesystem->rmdir( $to );
-
-		$result = @rename( $from, $to );
+		if ( $wp_filesystem->rmdir( $to ) ) {
+			$result = @rename( $from, $to );
+		}
 	} else {
 		// Non-direct filesystems use some version of rename without a fallback.
 		$result = $wp_filesystem->move( $from, $to );

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -2659,10 +2659,17 @@ function wp_opcache_invalidate_directory( $dir ) {
 	}
 
 	/*
-	 * Recursively invalidate opcache of nested files.
+	 * Recursively invalidate opcache of files in a directory.
 	 *
-	 * @param array  $dirlist Array of file/directory information from WP_Filesystem_Base::dirlist().
-	 * @param string $path    Path to directory.
+	 * WP_Filesystem_*::dirlist() returns an array of file and directory information.
+	 *
+	 * This does not include a path to the file or directory.
+	 * To invalidate files within sub-directories, recursion is needed
+	 * to prepend an absolute path containing the sub-directory's name.
+	 *
+	 * @param array  $dirlist Array of file/directory information from WP_Filesystem_Base::dirlist(),
+	 *                        with sub-directories represented as nested arrays.
+	 * @param string $path    Absolute path to the directory.
 	 */
 	$invalidate_directory = function( $dirlist, $path ) use ( &$invalidate_directory ) {
 		$path = trailingslashit( $path );

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -2634,7 +2634,6 @@ function wp_opcache_invalidate( $filepath, $force = false ) {
  * @global WP_Filesystem_Base $wp_filesystem WordPress filesystem subclass.
  *
  * @param string $dir The path to invalidate.
- *
  * @return void
  */
 function wp_opcache_invalidate_directory( $dir ) {

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -2650,7 +2650,7 @@ function wp_opcache_invalidate_directory( $dir, $path = '' ) {
 
 	foreach ( $dir as $name => $details ) {
 		if ( ! empty( $details['files'] ) ) {
-			wp_opcache_invalidate_directory( $details['files'], $path . $name . '/' );
+			wp_opcache_invalidate_directory( $details['files'], trailingslashit( $path ) . trailingslashit( $name ) );
 			continue;
 		}
 		wp_opcache_invalidate( $path . $name );

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -2020,9 +2020,9 @@ function move_dir( $from, $to ) {
 	 *
 	 * @since 6.2.0
 	 *
-	 * @param string $from  Source directory.
-	 * @param string $to    Destination directory.
-	 * @param true|WP_Error Result from move_dir().
+	 * @param string        $from   Source directory.
+	 * @param string        $to     Destination directory.
+	 * @param true|WP_Error $result Result from move_dir().
 	 */
 	do_action( 'post_move_dir', $from, $to, $result );
 

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1958,6 +1958,7 @@ function copy_dir( $from, $to, $skip_list = array() ) {
  *
  * @param string $from        Source directory.
  * @param string $to          Destination directory.
+ *
  * @return true|WP_Error True on success, WP_Error on failure.
  */
 function move_dir( $from, $to ) {

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1978,10 +1978,12 @@ function move_dir( $from, $to ) {
 	if ( 'direct' === $wp_filesystem->method ) {
 		if ( $wp_filesystem->rmdir( $to ) ) {
 			$result = @rename( $from, $to );
+			wp_opcache_invalidate_directory( $to );
 		}
 	} else {
 		// Non-direct filesystems use some version of rename without a fallback.
 		$result = $wp_filesystem->move( $from, $to );
+		wp_opcache_invalidate_directory( $to );
 	}
 
 	if ( ! $result ) {
@@ -2622,4 +2624,42 @@ function wp_opcache_invalidate( $filepath, $force = false ) {
 	}
 
 	return false;
+}
+
+/**
+ * Invalidate OPcache of directory of files.
+ *
+ * @since 6.2.0
+ *
+ * @param string $dir Path to directory.
+ *
+ * @return void
+ */
+function wp_opcache_invalidate_directory( $dir ) {
+	global $wp_filesystem;
+
+	$dirlist = $wp_filesystem->dirlist( $dir, false, true );
+
+	// Local version of WP_Upgrader::flatten_dirlist().
+	$flatten_dirlist = function( $nested_files, $path = '' ) use ( &$flatten_dirlist ) {
+		$files = array();
+
+		foreach ( $nested_files as $name => $details ) {
+			$files[ $path . $name ] = $details;
+
+			// Append children recursively.
+			if ( ! empty( $details['files'] ) ) {
+				$children = $flatten_dirlist( $details['files'], $path . $name . '/' );
+
+				// Merge keeping possible numeric keys, which array_merge() will reindex from 0..n.
+				$files = $files + $children;
+			}
+		}
+		return $files;
+	};
+	$files           = $flatten_dirlist( $dirlist );
+
+	foreach ( array_keys( $files ) as $file ) {
+		wp_opcache_invalidate( trailingslashit( $dir ) . $file );
+	}
 }

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1978,11 +1978,13 @@ function move_dir( $from, $to ) {
 	if ( 'direct' === $wp_filesystem->method ) {
 		if ( $wp_filesystem->rmdir( $to ) ) {
 			$result = @rename( $from, $to );
+			usleep( 200000 ); // VirtualBox needs to nap.
 			wp_opcache_invalidate_directory( $to );
 		}
 	} else {
 		// Non-direct filesystems use some version of rename without a fallback.
 		$result = $wp_filesystem->move( $from, $to );
+		usleep( 200000 ); // VirtualBox needs to nap.
 		wp_opcache_invalidate_directory( $to );
 	}
 

--- a/tests/phpunit/tests/functions/moveDir.php
+++ b/tests/phpunit/tests/functions/moveDir.php
@@ -127,6 +127,9 @@ class Tests_Functions_MoveDir extends WP_UnitTestCase {
 		parent::tear_down();
 	}
 
+	/**
+	 * Restores the filesystem after all tests have run.
+	 */
 	public static function tear_down_after_class() {
 		global $wp_filesystem;
 

--- a/tests/phpunit/tests/functions/moveDir.php
+++ b/tests/phpunit/tests/functions/moveDir.php
@@ -9,6 +9,13 @@
 class Tests_Functions_MoveDir extends WP_UnitTestCase {
 
 	/**
+	 * Filesystem backup.
+	 *
+	 * @var null|WP_Filesystem_Base $wp_filesystem_backup
+	 */
+	private static $wp_filesystem_backup;
+
+	/**
 	 * The test directory.
 	 *
 	 * @var string $test_dir
@@ -64,12 +71,12 @@ class Tests_Functions_MoveDir extends WP_UnitTestCase {
 	public static function set_up_before_class() {
 		global $wp_filesystem;
 
+		self::$wp_filesystem_backup = $wp_filesystem;
+
 		parent::set_up_before_class();
 
-		if ( ! $wp_filesystem ) {
-			require_once ABSPATH . 'wp-admin/includes/file.php';
-			WP_Filesystem();
-		}
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+		WP_Filesystem( array( 'method' => 'direct' ) );
 
 		self::$test_dir                  = trailingslashit( DIR_TESTDATA ) . 'functions/move_dir/';
 		self::$existing_from             = self::$test_dir . 'existing_from/';
@@ -112,6 +119,14 @@ class Tests_Functions_MoveDir extends WP_UnitTestCase {
 		$wp_filesystem->delete( self::$test_dir, true );
 
 		parent::tear_down();
+	}
+
+	public static function tear_down_after_class() {
+		global $wp_filesystem;
+
+		$wp_filesystem = self::$wp_filesystem_backup;
+
+		parent::tear_down_after_class();
 	}
 
 	/**

--- a/tests/phpunit/tests/functions/moveDir.php
+++ b/tests/phpunit/tests/functions/moveDir.php
@@ -130,6 +130,7 @@ class Tests_Functions_MoveDir extends WP_UnitTestCase {
 	public static function tear_down_after_class() {
 		global $wp_filesystem;
 
+		// Restore the filesystem.
 		$wp_filesystem = self::$wp_filesystem_backup;
 
 		parent::tear_down_after_class();

--- a/tests/phpunit/tests/functions/moveDir.php
+++ b/tests/phpunit/tests/functions/moveDir.php
@@ -75,6 +75,12 @@ class Tests_Functions_MoveDir extends WP_UnitTestCase {
 
 		parent::set_up_before_class();
 
+		/*
+		 * WP_Filesystem_MockFS has a bug that appears in CI.
+		 *
+		 * Until this is resolved, use WP_Filesystem_Direct and restore
+		 * $wp_filesystem to its original state after the tests.
+		 */
 		require_once ABSPATH . 'wp-admin/includes/file.php';
 		WP_Filesystem( array( 'method' => 'direct' ) );
 

--- a/tests/phpunit/tests/functions/moveDir.php
+++ b/tests/phpunit/tests/functions/moveDir.php
@@ -1,0 +1,256 @@
+<?php
+
+/**
+ * Tests move_dir().
+ *
+ * @group functions.php
+ * @covers ::move_dir
+ */
+class Tests_Functions_MoveDir extends WP_UnitTestCase {
+
+	/**
+	 * The test directory.
+	 *
+	 * @var string $test_dir
+	 */
+	private static $test_dir;
+
+	/**
+	 * The existing 'from' directory path.
+	 *
+	 * @var string $existing_from
+	 */
+	private static $existing_from;
+
+	/**
+	 * The existing 'from' sub-directory path.
+	 *
+	 * @var string $existing_from_subdir
+	 */
+	private static $existing_from_subdir;
+
+	/**
+	 * The existing 'from' file path.
+	 *
+	 * @var string $existing_from_file
+	 */
+	private static $existing_from_file;
+
+	/**
+	 * The existing 'from' sub-directory file path.
+	 *
+	 * @var string $existing_from_subdir_file
+	 */
+	private static $existing_from_subdir_file;
+
+	/**
+	 * The existing 'to' directory file path.
+	 *
+	 * @var string $existing_to
+	 */
+	private static $existing_to;
+
+	/**
+	 * The existing 'to' file path.
+	 *
+	 * @var string $existing_to_file
+	 */
+	private static $existing_to_file;
+
+	/**
+	 * Sets up the filesystem and directory structure properties
+	 * before any tests run.
+	 */
+	public static function set_up_before_class() {
+		global $wp_filesystem;
+
+		parent::set_up_before_class();
+
+		if ( ! $wp_filesystem ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+			WP_Filesystem();
+		}
+
+		self::$test_dir                  = trailingslashit( DIR_TESTDATA ) . 'functions/move_dir/';
+		self::$existing_from             = self::$test_dir . 'existing_from/';
+		self::$existing_from_subdir      = self::$existing_from . 'existing_from_subdir/';
+		self::$existing_from_file        = self::$existing_from . 'existing_from_file.txt';
+		self::$existing_from_subdir_file = self::$existing_from_subdir . 'existing_from_subdir_file.txt';
+		self::$existing_to               = self::$test_dir . 'existing_to/';
+		self::$existing_to_file          = self::$existing_to . 'existing_to_file.txt';
+	}
+
+	/**
+	 * Sets up the directory structure before each test.
+	 */
+	public function set_up() {
+		global $wp_filesystem;
+
+		parent::set_up();
+
+		// Create the root directory.
+		$wp_filesystem->mkdir( self::$test_dir );
+
+		// Create the "from" directory structure.
+		$wp_filesystem->mkdir( self::$existing_from );
+		$wp_filesystem->touch( self::$existing_from_file );
+		$wp_filesystem->mkdir( self::$existing_from_subdir );
+		$wp_filesystem->touch( self::$existing_from_subdir_file );
+
+		// Create the "to" directory structure.
+		$wp_filesystem->mkdir( self::$existing_to );
+		$wp_filesystem->touch( self::$existing_to_file );
+	}
+
+	/**
+	 * Removes the test directory structure after each test.
+	 */
+	public function tear_down() {
+		global $wp_filesystem;
+
+		// Delete the root directory and its contents.
+		$wp_filesystem->delete( self::$test_dir, true );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Tests that move_dir() returns a WP_Error object.
+	 *
+	 * @ticket 57375
+	 *
+	 * @dataProvider data_should_return_wp_error
+	 *
+	 * @param string $from      The source directory path.
+	 * @param string $to        The destination directory path.
+	 * @param bool   $overwrite Whether to overwrite the destination directory.
+	 * @param string $expected  The expected WP_Error code.
+	 */
+	public function test_should_return_wp_error( $from, $to, $overwrite, $expected ) {
+		global $wp_filesystem;
+
+		$from   = self::$test_dir . $from;
+		$to     = self::$test_dir . $to;
+		$result = move_dir( $from, $to, $overwrite );
+
+		$this->assertWPError(
+			$result,
+			'move_dir() did not return a WP_Error object.'
+		);
+
+		$this->assertSame(
+			$expected,
+			$result->get_error_code(),
+			'The expected error code was not returned.'
+		);
+
+		$this->assertTrue(
+			$wp_filesystem->exists( $from ),
+			'The $from directory does not exist anymore.'
+		);
+
+		if ( false === $overwrite && 'existing_to' === untrailingslashit( $to ) ) {
+			$this->assertTrue(
+				$wp_filesystem->exists( $to ),
+				'The $to directory does not exist anymore.'
+			);
+		}
+	}
+
+	/**
+	 * Data provider for test_should_return_wp_error().
+	 *
+	 * @return array[]
+	 */
+	public function data_should_return_wp_error() {
+		return array(
+			'$overwrite is false and $to exists' => array(
+				'from'      => 'existing_from',
+				'to'        => 'existing_to',
+				'overwrite' => false,
+				'expected'  => 'to_directory_already_exists_move_dir',
+			),
+		);
+	}
+
+	/**
+	 * Tests that move_dir() successfully moves a directory.
+	 *
+	 * @ticket 57375
+	 *
+	 * @dataProvider data_should_move_directory
+	 *
+	 * @param string $from      The source directory path.
+	 * @param string $to        The destination directory path.
+	 * @param bool   $overwrite Whether to overwrite the destination directory.
+	 */
+	public function test_should_move_directory( $from, $to, $overwrite ) {
+		global $wp_filesystem;
+
+		$from   = self::$test_dir . $from;
+		$to     = self::$test_dir . $to;
+		$result = move_dir( $from, $to, $overwrite );
+
+		$this->assertTrue(
+			$result,
+			'The directory was not moved.'
+		);
+
+		$this->assertFalse(
+			$wp_filesystem->exists( $from ),
+			'The source directory still exists.'
+		);
+
+		$this->assertTrue(
+			$wp_filesystem->exists( $to ),
+			'The destination directory does not exist.'
+		);
+
+		$dirlist = $wp_filesystem->dirlist( $to, true, true );
+
+		$this->assertIsArray(
+			$dirlist,
+			'The directory listing of the destination directory could not be retrieved.'
+		);
+
+		// Prevent PHP array sorting bugs from breaking tests.
+		$to_contents = array_keys( $dirlist );
+		sort( $to_contents );
+
+		$this->assertSame(
+			array(
+				'existing_from_file.txt',
+				'existing_from_subdir',
+			),
+			$to_contents,
+			'The expected files were not moved.'
+		);
+
+		$this->assertSame(
+			array( 'existing_from_subdir_file.txt' ),
+			array_keys( $dirlist['existing_from_subdir']['files'] ),
+			'Sub-directory files failed to move.'
+		);
+	}
+
+	/**
+	 * Data provider for test_should_move_directory().
+	 *
+	 * @return array[]
+	 */
+	public function data_should_move_directory() {
+		return array(
+			'$overwrite is false and $to does not exist' => array(
+				'from'      => 'existing_from',
+				'to'        => 'non_existing_to',
+				'overwrite' => false,
+			),
+			'$overwrite is true and $to exists'          => array(
+				'from'      => 'existing_from',
+				'to'        => 'existing_to',
+				'overwrite' => true,
+			),
+		);
+	}
+
+}

--- a/tests/phpunit/tests/functions/wpOpcacheInvalidateDirectory.php
+++ b/tests/phpunit/tests/functions/wpOpcacheInvalidateDirectory.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * Tests wp_opcache_invalidate_directory().
+ *
+ * @group functions.php
+ * @covers ::wp_opcache_invalidate_directory
+ */
+class Tests_Functions_WpOpcacheInvalidateDirectory extends WP_UnitTestCase {
+
+	public static function set_up_before_class() {
+		global $wp_filesystem;
+
+		parent::set_up_before_class();
+
+		if ( ! $wp_filesystem ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+			WP_Filesystem();
+		}
+	}
+
+	/**
+	 * Tests that wp_opcache_invalidate_directory() returns a WP_Error object
+	 * when the $dir argument invalid.
+	 *
+	 * @ticket 57375
+	 *
+	 * @dataProvider data_should_trigger_error_with_invalid_dir
+	 *
+	 * @param mixed $dir An invalid directory path.
+	 */
+	public function test_should_trigger_error_with_invalid_dir( $dir ) {
+		$this->expectError();
+		$this->expectErrorMessage(
+			'<code>wp_opcache_invalidate_directory()</code>',
+			'The expected error was not triggered.'
+		);
+
+		wp_opcache_invalidate_directory( $dir );
+	}
+
+	/**
+	 * Data provider for test_trigger_should_error_with_invalid_dir().
+	 *
+	 * @return array[]
+	 */
+	public function data_should_trigger_error_with_invalid_dir() {
+		return array(
+			'an empty string'                => array( '' ),
+			'a string with spaces'           => array( '   ' ),
+			'a string with tabs'             => array( "\t" ),
+			'a string with new lines'        => array( "\n" ),
+			'a string with carriage returns' => array( "\r" ),
+			'int -1'                         => array( -1 ),
+			'int 0'                          => array( 0 ),
+			'int 1'                          => array( 1 ),
+			'float -1.0'                     => array( -1.0 ),
+			'float 0.0'                      => array( 0.0 ),
+			'float 1.0'                      => array( 1.0 ),
+			'false'                          => array( false ),
+			'true'                           => array( true ),
+			'null'                           => array( null ),
+			'an empty array'                 => array( array() ),
+			'a non-empty array'              => array( array( 'directory_path' ) ),
+			'an empty object'                => array( new stdClass() ),
+			'a non-empty object'             => array( (object) array( 'directory_path' ) ),
+			'INF'                            => array( INF ),
+			'NAN'                            => array( NAN ),
+		);
+	}
+
+	/**
+	 * Tests that wp_opcache_invalidate_directory() does not trigger an error
+	 * with a valid directory.
+	 *
+	 * @ticket 57375
+	 *
+	 * @dataProvider data_should_not_trigger_error_wp_opcache_valid_directory
+	 *
+	 * @param string $dir A directory path.
+	 */
+	public function test_should_not_trigger_error_wp_opcache_valid_directory( $dir ) {
+		if ( 'test_dir' === $dir ) {
+			$dir = DIR_TESTDATA;
+		}
+
+		$this->assertNull( wp_opcache_invalidate_directory( $dir ) );
+	}
+
+	/**
+	 * Data provider for test_should_not_trigger_error_wp_opcache_valid_directory().
+	 *
+	 * @return array[]
+	 */
+	public function data_should_not_trigger_error_wp_opcache_valid_directory() {
+		return array(
+			'an existing directory'    => array( 'test_dir' ),
+			'a non-existent directory' => array( 'non_existent_directory' ),
+		);
+	}
+}

--- a/tests/phpunit/tests/functions/wpOpcacheInvalidateDirectory.php
+++ b/tests/phpunit/tests/functions/wpOpcacheInvalidateDirectory.php
@@ -8,6 +8,9 @@
  */
 class Tests_Functions_WpOpcacheInvalidateDirectory extends WP_UnitTestCase {
 
+	/**
+	 * Sets up the filesystem before any tests run.
+	 */
 	public static function set_up_before_class() {
 		global $wp_filesystem;
 


### PR DESCRIPTION
WordPress lacks an internal function to move a directory from one location to another.

WordPress has a `$wp_filesystem->move()` but for `WP_Filesystem_Direct` it is designed with only a single file copy fallback. `copy_dir()` is a recursive file copy from one  location to another. `copy_dir()` is effective but it is more resource intensive and does require the user to delete the source after copying.

`move_dir()` is a battle tested function that has been part of testing for a feature plugin having over 8000+ active installs.

The idea is to use `rename()` with `copy_dir()` as a fallback. Non-direct WP_Filessytem `move()` commands are a variation of `rename()` all of which report a boolean result with no fallback. This means that a failure will be caught and the fallback will be used.

Trac ticket: https://core.trac.wordpress.org/ticket/57375

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
