### PR TITLE
Fix PHP 8 deprecation warning in category-template.php

### DIFF
--- a/src/wp-includes/category-template.php
+++ b/src/wp-includes/category-template.php
@@ -1084,10 +1084,10 @@ function _wp_object_name_sort_cb( $a, $b ) {
  *
  * @param object $a The first object to compare.
  * @param object $b The second object to compare.
- * @return bool Whether the count value for `$a` is greater than the count value for `$b`.
+ * @return int the count value for `$a` minus the count value for `$b` (less than, equal to, or greater than zero).
  */
 function _wp_object_count_sort_cb( $a, $b ) {
-	return ( $a->count > $b->count );
+	return ( $a->count - $b->count );
 }
 
 //

--- a/src/wp-includes/category-template.php
+++ b/src/wp-includes/category-template.php
@@ -1084,7 +1084,7 @@ function _wp_object_name_sort_cb( $a, $b ) {
  *
  * @param object $a The first object to compare.
  * @param object $b The second object to compare.
- * @return int the count value for `$a` minus the count value for `$b` (less than, equal to, or greater than zero).
+ * @return int The count value for `$a` minus the count value for `$b` (less than, equal to, or greater than zero).
  */
 function _wp_object_count_sort_cb( $a, $b ) {
 	return ( $a->count - $b->count );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Change return value from boolean to int less, equal or greater than zero as requited by php 8. Using substraction instead of the spaceship operator (<=>) for php 5.6 compat

Trac ticket: https://core.trac.wordpress.org/ticket/57358

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
