### PR TITLE
Upgrader copy directory filter

### DIFF
--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -593,21 +593,18 @@ class WP_Upgrader {
 			}
 		}
 
-		// Copy new version of item into place.
-		if ( class_exists( 'Rollback_Update_Failure\WP_Upgrader' )
-			&& function_exists( '\Rollback_Update_Failure\move_dir' )
-		) {
-			/*
-			 * If the {@link https://wordpress.org/plugins/rollback-update-failure/ Rollback Update Failure}
-			 * feature plugin is installed, use the move_dir() function from there for better performance.
-			 * Instead of copying a directory from one location to another, it uses the rename() PHP function
-			 * to speed up the process. If the renaming failed, it falls back to copy_dir().
-			 *
-			 * This condition aims to facilitate broader testing of the Rollbacks (temp backups) feature project.
-			 * It is temporary, until the plugin is merged into core.
-			 */
-			$result = \Rollback_Update_Failure\move_dir( $source, $remote_destination );
-		} else {
+		/**
+		 * Filters whether to skip use of standard directory copy function so that
+		 * custom function may be more easily substituted.
+		 *
+		 * @since 6.2.0
+		 *
+		 * @param bool|WP_Error $result             Filter response.
+		 * @param string        $source             File source location.
+		 * @param string        $remote_destination The remote package destination.
+		 */
+		$result = apply_filters( 'upgrader_copy_directory', false, $source, $remote_destination );
+		if ( false === $result ) {
 			$result = copy_dir( $source, $remote_destination );
 		}
 

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -603,16 +603,13 @@ class WP_Upgrader {
 		$callback = apply_filters( 'upgrader_copy_directory', 'copy_dir' );
 		$result   = call_user_func( $callback, $source, $remote_destination );
 
-		if ( is_wp_error( $result ) ) {
-			if ( $args['clear_working'] ) {
-				$wp_filesystem->delete( $remote_source, true );
-			}
-			return $result;
-		}
-
 		// Clear the working folder?
 		if ( $args['clear_working'] ) {
 			$wp_filesystem->delete( $remote_source, true );
+		}
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
 		}
 
 		$destination_name = basename( str_replace( $local_destination, '', $destination ) );

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -594,19 +594,14 @@ class WP_Upgrader {
 		}
 
 		/**
-		 * Filters whether to skip use of standard directory copy function so that
-		 * custom function may be more easily substituted.
+		 * Filters callback function to use for copying directory.
 		 *
 		 * @since 6.2.0
 		 *
-		 * @param bool|WP_Error $result             Filter response.
-		 * @param string        $source             File source location.
-		 * @param string        $remote_destination The remote package destination.
+		 * @param string $callback Name of callback.
 		 */
-		$result = apply_filters( 'upgrader_copy_directory', false, $source, $remote_destination );
-		if ( false === $result ) {
-			$result = copy_dir( $source, $remote_destination );
-		}
+		$callback = apply_filters( 'upgrader_copy_directory', 'copy_dir' );
+		$result   = call_user_func( $callback, $source, $remote_destination );
 
 		if ( is_wp_error( $result ) ) {
 			if ( $args['clear_working'] ) {

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -598,7 +598,7 @@ class WP_Upgrader {
 		 *
 		 * @since 6.2.0
 		 *
-		 * @param bool                       false to use copy_dir().
+		 * @param bool                       Default, false to use copy_dir().
 		 * @param string $source             File source location.
 		 * @param string $remote_destination The remote package destination.
 		 */

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -598,9 +598,11 @@ class WP_Upgrader {
 		 *
 		 * @since 6.2.0
 		 *
-		 * @param bool false to use copy_dir().
+		 * @param bool                       false to use copy_dir().
+		 * @param string $source             File source location.
+		 * @param string $remote_destination The remote package destination.
 		 */
-		if ( ! apply_filters( 'upgrader_use_move_dir', false ) ) {
+		if ( ! apply_filters( 'upgrader_use_move_dir', false, $source, $remote_destination ) ) {
 			$result = copy_dir( $source, $remote_destination );
 		} else {
 			$result = move_dir( $source, $remote_destination );

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -594,14 +594,17 @@ class WP_Upgrader {
 		}
 
 		/**
-		 * Filters callback function to use for copying directory.
+		 * Filters whether to use move_dir() or copy_dir().
 		 *
 		 * @since 6.2.0
 		 *
-		 * @param string $callback Name of callback.
+		 * @param bool false to use copy_dir().
 		 */
-		$callback = apply_filters( 'upgrader_copy_directory', 'copy_dir' );
-		$result   = call_user_func( $callback, $source, $remote_destination );
+		if ( ! apply_filters( 'upgrader_use_move_dir', false ) ) {
+			$result = copy_dir( $source, $remote_destination );
+		} else {
+			$result = move_dir( $source, $remote_destination );
+		}
 
 		// Clear the working folder?
 		if ( $args['clear_working'] ) {


### PR DESCRIPTION
`copy_dir()` is a recursive file copy for directories and is used when updating plugins, themes, and core. 

There are several tickets related to timeouts and optimization of the update process. As part of Rollback #51857, a new function `move_dir()` and a new filter #56057 were introduced. This ticket is an improvement upon #56057.

Optimizing the plugin/theme update process can be solved using the `move_dir()` function and a filter similar to #56057.

#57357 was opened to add `move_dir()` to core. This ticket is to add the new filter.

The new filter would easily allow the substitution of `move_dir` for `copy_dir` adding more efficiency to the plugin/theme update process by having the user add a simple filter. This could improve the efficiency and performance for 99+% of users who opt-in and will likely fix #53832, #54166, and #34676.


```php
add_filter( 'upgrader_copy_directory', function($callback) {
    return 'move_dir';
}, 10, 1 );
```

I believe the use cases are sufficient to merit inclusion to core, additionally both of these have been tested rigorously in the Rollback PR/feature plugin.

Trac ticket: https://core.trac.wordpress.org/ticket/57386
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
