### PR TITLE
Added test post navigation link attribute filters

### DIFF
--- a/tests/phpunit/tests/link/postNavigationLinkAttributeFilters.php
+++ b/tests/phpunit/tests/link/postNavigationLinkAttributeFilters.php
@@ -49,7 +49,9 @@ class Tests_Link_PostNavigationLinkAttributeFilters extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the 'previous_posts_link_attributes' filter is applied correctly.
+	 * Tests that the 'previous_posts_link_attributes' filter is applied correctly.
+	 *
+	 * @ticket 55751
 	 */
 	public function test_previous_posts_link_attributes() {
 		$expected = "data-attribute='previous'";

--- a/tests/phpunit/tests/link/postNavigationLinkAttributeFilters.php
+++ b/tests/phpunit/tests/link/postNavigationLinkAttributeFilters.php
@@ -18,8 +18,9 @@ class Tests_Link_PostNavigationLinkAttributeFilters extends WP_UnitTestCase {
 	 * @param WP_UnitTest_Factory $factory
 	 */
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
-		$factory->post->create_many( 3 );
 		global $wp_query, $paged;
+
+		$factory->post->create_many( 3 );
 		$paged    = 2;
 		$wp_query = new WP_Query(
 			array(

--- a/tests/phpunit/tests/link/postNavigationLinkAttributeFilters.php
+++ b/tests/phpunit/tests/link/postNavigationLinkAttributeFilters.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Test post navigation link attribute filters.
+ * @ticket 55751
+ * @since 6.2.0
+ *
+ * @covers ::next_posts_link_attributes
+ * @covers ::previous_posts_link_attributes
+ */
+class Tests_Link_PostNavigationLinkAttributeFilters extends WP_UnitTestCase {
+
+	/**
+	 * Create posts for the tests.
+	 *
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		$factory->post->create_many( 3 );
+		global $wp_query, $paged;
+		$paged    = 2;
+		$wp_query = new WP_Query(
+			array(
+				'post_type'      => 'post',
+				'posts_per_page' => 1,
+				'paged'          => $paged,
+			)
+		);
+	}
+
+	/**
+	 * Test that the 'next_posts_link_attributes' filter is applied correctly.
+	 */
+	public function test_next_posts_link_attribute() {
+		$expected = "data-attribute='next'";
+		add_filter(
+			'next_posts_link_attributes',
+			function() use ( $expected ) {
+				return $expected;
+			}
+		);
+
+		$next_posts_link = get_next_posts_link();
+		$this->assertStringContainsString( $expected, $next_posts_link );
+	}
+
+	/**
+	 * Test that the 'previous_posts_link_attributes' filter is applied correctly.
+	 */
+	public function test_previous_posts_link_attributes() {
+		$expected = "data-attribute='previous'";
+		add_filter(
+			'previous_posts_link_attributes',
+			function() use ( $expected ) {
+				return $expected;
+			}
+		);
+
+		$previous_posts_link = get_previous_posts_link();
+		$this->assertStringContainsString( $expected, $previous_posts_link );
+	}
+
+}

--- a/tests/phpunit/tests/link/postNavigationLinkAttributeFilters.php
+++ b/tests/phpunit/tests/link/postNavigationLinkAttributeFilters.php
@@ -13,7 +13,7 @@
 class Tests_Link_PostNavigationLinkAttributeFilters extends WP_UnitTestCase {
 
 	/**
-	 * Create posts for the tests.
+	 * Creates posts before any tests run.
 	 *
 	 * @param WP_UnitTest_Factory $factory
 	 */

--- a/tests/phpunit/tests/link/postNavigationLinkAttributeFilters.php
+++ b/tests/phpunit/tests/link/postNavigationLinkAttributeFilters.php
@@ -1,10 +1,9 @@
 <?php
 
 /**
- * Test post navigation link attribute filters.
+ * Tests post navigation link attribute filters.
  *
  * @since 6.2.0
- * @ticket 55751
  *
  * @group link
  *

--- a/tests/phpunit/tests/link/postNavigationLinkAttributeFilters.php
+++ b/tests/phpunit/tests/link/postNavigationLinkAttributeFilters.php
@@ -32,7 +32,9 @@ class Tests_Link_PostNavigationLinkAttributeFilters extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the 'next_posts_link_attributes' filter is applied correctly.
+	 * Tests that the 'next_posts_link_attributes' filter is applied correctly.
+	 *
+	 * @ticket 55751
 	 */
 	public function test_next_posts_link_attribute() {
 		$expected = "data-attribute='next'";

--- a/tests/phpunit/tests/link/postNavigationLinkAttributeFilters.php
+++ b/tests/phpunit/tests/link/postNavigationLinkAttributeFilters.php
@@ -2,8 +2,11 @@
 
 /**
  * Test post navigation link attribute filters.
- * @ticket 55751
+ *
  * @since 6.2.0
+ * @ticket 55751
+ *
+ * @group link
  *
  * @covers ::next_posts_link_attributes
  * @covers ::previous_posts_link_attributes
@@ -40,8 +43,7 @@ class Tests_Link_PostNavigationLinkAttributeFilters extends WP_UnitTestCase {
 			}
 		);
 
-		$next_posts_link = get_next_posts_link();
-		$this->assertStringContainsString( $expected, $next_posts_link );
+		$this->assertStringContainsString( $expected, get_next_posts_link() );
 	}
 
 	/**
@@ -56,8 +58,7 @@ class Tests_Link_PostNavigationLinkAttributeFilters extends WP_UnitTestCase {
 			}
 		);
 
-		$previous_posts_link = get_previous_posts_link();
-		$this->assertStringContainsString( $expected, $previous_posts_link );
+		$this->assertStringContainsString( $expected, get_previous_posts_link() );
 	}
 
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/55751

This PR adds tests for `next_posts_link_attributes` & `previous_posts_link_attributes` filters and invalidates the patch https://github.com/WordPress/wordpress-develop/pull/2725 submitted in the above-mentioned ticket as the current functionality is correct.