### PR TITLE
Coding Standards: mark warnings that trigger CI failures as errors.

### DIFF
--- a/src/wp-signup.php
+++ b/src/wp-signup.php
@@ -337,9 +337,9 @@ function signup_another_blog( $blogname = '', $blog_title = '', $errors = '' ) {
 	}
 
 	$signup_defaults = array(
-		'blogname'   => $blogname,
+		'blogname' => $blogname,
 		'blog_title' => $blog_title,
-		'errors'     => $errors,
+		'errors' => $errors,
 	);
 
 	/**

--- a/tests/phpunit/includes/class-wp-rest-test-search-handler.php
+++ b/tests/phpunit/includes/class-wp-rest-test-search-handler.php
@@ -23,10 +23,10 @@ class WP_REST_Test_Search_Handler extends WP_REST_Search_Handler {
 			$subtype = $i > $amount / 2 ? 'test_second_type' : 'test_first_type';
 
 			$this->items[ $i ] = (object) array(
-				'test_id' => $i,
+				'test_id'    => $i,
 				'test_title' => sprintf( 'Title %d', $i ),
-				'test_url' => sprintf( home_url( '/tests/%d' ), $i ),
-				'test_type' => $subtype,
+				'test_url'   => sprintf( home_url( '/tests/%d' ), $i ),
+				'test_type'  => $subtype,
 			);
 		}
 	}

--- a/tests/phpunit/includes/class-wp-rest-test-search-handler.php
+++ b/tests/phpunit/includes/class-wp-rest-test-search-handler.php
@@ -23,10 +23,10 @@ class WP_REST_Test_Search_Handler extends WP_REST_Search_Handler {
 			$subtype = $i > $amount / 2 ? 'test_second_type' : 'test_first_type';
 
 			$this->items[ $i ] = (object) array(
-				'test_id'    => $i,
+				'test_id' => $i,
 				'test_title' => sprintf( 'Title %d', $i ),
-				'test_url'   => sprintf( home_url( '/tests/%d' ), $i ),
-				'test_type'  => $subtype,
+				'test_url' => sprintf( home_url( '/tests/%d' ), $i ),
+				'test_type' => $subtype,
 			);
 		}
 	}


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/57426

* PHPCS run for [warning in test suite only -- fails](https://github.com/WordPress/wordpress-develop/actions/runs/3850711899/jobs/6561169307)
* PHPCS run for [warning in src code only -- passes](https://github.com/WordPress/wordpress-develop/actions/runs/3850751614/jobs/6561253288)

