### PR TITLE
WP_Locale: Initialize array properties before using them

### DIFF
--- a/src/wp-includes/class-wp-locale.php
+++ b/src/wp-includes/class-wp-locale.php
@@ -58,7 +58,7 @@ class WP_Locale {
 	 * @since 4.4.0
 	 * @var string[]
 	 */
-	public $month_genitive;
+	public $month_genitive = array();
 
 	/**
 	 * Stores the translated strings for the abbreviated month names.

--- a/src/wp-includes/class-wp-locale.php
+++ b/src/wp-includes/class-wp-locale.php
@@ -21,7 +21,7 @@ class WP_Locale {
 	 * @since 2.1.0
 	 * @var string[]
 	 */
-	public $weekday;
+	public $weekday = array();
 
 	/**
 	 * Stores the translated strings for the one character weekday names.
@@ -34,7 +34,7 @@ class WP_Locale {
 	 * @since 2.1.0
 	 * @var string[]
 	 */
-	public $weekday_initial;
+	public $weekday_initial = array();
 
 	/**
 	 * Stores the translated strings for the abbreviated weekday names.
@@ -42,7 +42,7 @@ class WP_Locale {
 	 * @since 2.1.0
 	 * @var string[]
 	 */
-	public $weekday_abbrev;
+	public $weekday_abbrev = array();
 
 	/**
 	 * Stores the translated strings for the full month names.
@@ -50,7 +50,7 @@ class WP_Locale {
 	 * @since 2.1.0
 	 * @var string[]
 	 */
-	public $month;
+	public $month = array();
 
 	/**
 	 * Stores the translated strings for the month names in genitive case, if the locale specifies.
@@ -66,7 +66,7 @@ class WP_Locale {
 	 * @since 2.1.0
 	 * @var string[]
 	 */
-	public $month_abbrev;
+	public $month_abbrev = array();
 
 	/**
 	 * Stores the translated strings for 'am' and 'pm'.
@@ -76,7 +76,7 @@ class WP_Locale {
 	 * @since 2.1.0
 	 * @var string[]
 	 */
-	public $meridiem;
+	public $meridiem = array();
 
 	/**
 	 * The text direction of the locale language.
@@ -94,7 +94,7 @@ class WP_Locale {
 	 * @since 2.3.0
 	 * @var array
 	 */
-	public $number_format;
+	public $number_format = array();
 
 	/**
 	 * The separator string used for localizing list item separator.

--- a/src/wp-includes/class-wp-locale.php
+++ b/src/wp-includes/class-wp-locale.php
@@ -19,6 +19,7 @@ class WP_Locale {
 	 * Stores the translated strings for the full weekday names.
 	 *
 	 * @since 2.1.0
+	 * @since 6.2.0 Initialized to an empty array.
 	 * @var string[]
 	 */
 	public $weekday = array();
@@ -32,6 +33,7 @@ class WP_Locale {
 	 * @see WP_Locale::init() for how to handle the hack.
 	 *
 	 * @since 2.1.0
+	 * @since 6.2.0 Initialized to an empty array.
 	 * @var string[]
 	 */
 	public $weekday_initial = array();
@@ -40,6 +42,7 @@ class WP_Locale {
 	 * Stores the translated strings for the abbreviated weekday names.
 	 *
 	 * @since 2.1.0
+	 * @since 6.2.0 Initialized to an empty array.
 	 * @var string[]
 	 */
 	public $weekday_abbrev = array();
@@ -48,6 +51,7 @@ class WP_Locale {
 	 * Stores the translated strings for the full month names.
 	 *
 	 * @since 2.1.0
+	 * @since 6.2.0 Initialized to an empty array.
 	 * @var string[]
 	 */
 	public $month = array();
@@ -56,6 +60,7 @@ class WP_Locale {
 	 * Stores the translated strings for the month names in genitive case, if the locale specifies.
 	 *
 	 * @since 4.4.0
+	 * @since 6.2.0 Initialized to an empty array.
 	 * @var string[]
 	 */
 	public $month_genitive = array();
@@ -64,6 +69,7 @@ class WP_Locale {
 	 * Stores the translated strings for the abbreviated month names.
 	 *
 	 * @since 2.1.0
+	 * @since 6.2.0 Initialized to an empty array.
 	 * @var string[]
 	 */
 	public $month_abbrev = array();
@@ -74,6 +80,7 @@ class WP_Locale {
 	 * Also the capitalized versions.
 	 *
 	 * @since 2.1.0
+	 * @since 6.2.0 Initialized to an empty array.
 	 * @var string[]
 	 */
 	public $meridiem = array();
@@ -92,6 +99,7 @@ class WP_Locale {
 	 * The thousands separator and decimal point values used for localizing numbers.
 	 *
 	 * @since 2.3.0
+	 * @since 6.2.0 Initialized to an empty array.
 	 * @var array
 	 */
 	public $number_format = array();

--- a/tests/phpunit/tests/locale.php
+++ b/tests/phpunit/tests/locale.php
@@ -16,6 +16,38 @@ class Tests_Locale extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @dataProvider data_property_initializes_to_array
+	 * @ticket 57427
+	 *
+	 * @param string $name Property name to test.
+	 */
+	public function test_property_initializes_to_array( $name ) {
+		$this->assertIsArray( $this->locale->$name, "WP_Locale::{$name} property should be an array" );
+
+		// Test a custom implementation when `init()` is not invoked in the constructor.
+		$wp_locale = new Custom_WP_Locale();
+		$this->assertIsArray( $wp_locale->$name, "Custom_WP_Locale::{$name} property should be an array" );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_property_initializes_to_array() {
+		return array(
+			'weekday'         => array( 'weekday' ),
+			'weekday_initial' => array( 'weekday_initial' ),
+			'weekday_abbrev'  => array( 'weekday_abbrev' ),
+			'month'           => array( 'month' ),
+			'month_genitive'  => array( 'month_genitive' ),
+			'month_abbrev'    => array( 'month_abbrev' ),
+			'meridiem'        => array( 'meridiem' ),
+			'number_format'   => array( 'number_format' ),
+		);
+	}
+
+	/**
 	 * @covers WP_Locale::get_weekday
 	 */
 	public function test_get_weekday() {
@@ -139,5 +171,13 @@ class Tests_Locale extends WP_UnitTestCase {
 		$this->assertTrue( $this->locale->is_rtl() );
 		$this->locale->text_direction = 'ltr';
 		$this->assertFalse( $this->locale->is_rtl() );
+	}
+}
+
+class Custom_WP_Locale extends WP_Locale {
+	public function __construct() {
+		// Do not initialize to test property initialization.
+		// $this->init();
+		$this->register_globals();
 	}
 }

--- a/tests/phpunit/tests/locale.php
+++ b/tests/phpunit/tests/locale.php
@@ -16,8 +16,9 @@ class Tests_Locale extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @dataProvider data_property_initializes_to_array
 	 * @ticket 57427
+	 *
+	 * @dataProvider data_property_initializes_to_array
 	 *
 	 * @param string $name Property name to test.
 	 */


### PR DESCRIPTION
Currently, `WP_Locale` does not initialize its internal property arrays:

https://github.com/wordpress/wordpress-develop/blob/trunk/src/wp-includes/class-wp-locale.php#L24

However, it starts using them immediately:

https://github.com/wordpress/wordpress-develop/blob/trunk/src/wp-includes/class-wp-locale.php#L130

In some setups this has caused warnings from PHP 7.4 on:

```
Warning: array_values() expects parameter 1 to be array, null given in /wordpress/plugins/gutenberg/14.8.4/lib/compat/wordpress-6.1/date-settings.php on line 48
```

This is because from PHP 7.4 on, using `null` values as arrays will trigger a warning:

https://www.php.net/manual/en/migration74.incompatible.php#migration74.incompatible.core.non-array-access

To fix this, the most straightforward way forward is to provide default values for all array properties in the `WP_Locale` class. That way they'll always be declared as arrays when we use them as such.

That's what this PR suggests.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/57427

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
