### PR TITLE
Drop the usage of the local CSS rule

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -3497,8 +3497,6 @@ function _wp_theme_json_webfonts_handler() {
 	 * @return string The CSS.
 	 */
 	$fn_compile_src = static function( $font_family, array $value ) {
-		$src = '';
-
 		$items = array();
 		foreach ( $value as $item ) {
 
@@ -3514,9 +3512,7 @@ function _wp_theme_json_webfonts_handler() {
 				: "url('{$item['url']}') format('{$item['format']}')";
 		}
 
-		$src = implode( ', ', $items );
-
-		return $src;
+		return implode( ', ', $items );;
 	};
 
 	/**

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -3512,7 +3512,7 @@ function _wp_theme_json_webfonts_handler() {
 				: "url('{$item['url']}') format('{$item['format']}')";
 		}
 
-		return implode( ', ', $items );;
+		return implode( ', ', $items );
 	};
 
 	/**

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -3499,6 +3499,7 @@ function _wp_theme_json_webfonts_handler() {
 	$fn_compile_src = static function( $font_family, array $value ) {
 		$src = '';
 
+		$items = array();
 		foreach ( $value as $item ) {
 
 			if (
@@ -3508,10 +3509,12 @@ function _wp_theme_json_webfonts_handler() {
 				$item['url'] = wp_make_link_relative( $item['url'] );
 			}
 
-			$src .= ( 'data' === $item['format'] )
+			$items[] = ( 'data' === $item['format'] )
 				? ", url({$item['url']})"
 				: ", url('{$item['url']}') format('{$item['format']}')";
 		}
+
+		$src = implode( ', ', $items );
 
 		return $src;
 	};

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -3510,8 +3510,8 @@ function _wp_theme_json_webfonts_handler() {
 			}
 
 			$items[] = ( 'data' === $item['format'] )
-				? ", url({$item['url']})"
-				: ", url('{$item['url']}') format('{$item['format']}')";
+				? "url({$item['url']})"
+				: "url('{$item['url']}') format('{$item['format']}')";
 		}
 
 		$src = implode( ', ', $items );

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -3497,7 +3497,7 @@ function _wp_theme_json_webfonts_handler() {
 	 * @return string The CSS.
 	 */
 	$fn_compile_src = static function( $font_family, array $value ) {
-		$src = "local($font_family)";
+		$src = '';
 
 		foreach ( $value as $item ) {
 

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -3491,6 +3491,7 @@ function _wp_theme_json_webfonts_handler() {
 	 * Compiles the 'src' into valid CSS.
 	 *
 	 * @since 6.0.0
+	 * @since 6.2.0 Removed local() CSS.
 	 *
 	 * @param string $font_family Font family.
 	 * @param array  $value       Value to process.

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -3514,6 +3514,8 @@ function _wp_theme_json_webfonts_handler() {
 				: ", url('{$item['url']}') format('{$item['format']}')";
 		}
 
+		$src = ltrim( $src, ', ' );
+
 		return $src;
 	};
 

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -3497,7 +3497,8 @@ function _wp_theme_json_webfonts_handler() {
 	 * @return string The CSS.
 	 */
 	$fn_compile_src = static function( $font_family, array $value ) {
-		$items = array();
+		$src = '';
+
 		foreach ( $value as $item ) {
 
 			if (
@@ -3507,12 +3508,12 @@ function _wp_theme_json_webfonts_handler() {
 				$item['url'] = wp_make_link_relative( $item['url'] );
 			}
 
-			$items[] = ( 'data' === $item['format'] )
-				? "url({$item['url']})"
-				: "url('{$item['url']}') format('{$item['format']}')";
+			$src .= ( 'data' === $item['format'] )
+				? ", url({$item['url']})"
+				: ", url('{$item['url']}') format('{$item['format']}')";
 		}
 
-		return implode( ', ', $items );
+		return $src;
 	};
 
 	/**

--- a/tests/phpunit/tests/webfonts/wpThemeJsonWebfontsHandler.php
+++ b/tests/phpunit/tests/webfonts/wpThemeJsonWebfontsHandler.php
@@ -82,7 +82,7 @@ class Tests_Webfonts_wpThemeJsonWebfontsHandler extends WP_UnitTestCase {
 
 		$expected = <<<EOF
 <style id='wp-webfonts-inline-css' type='text/css'>
-@font-face{font-family:"Source Serif Pro";font-style:normal;font-weight:200 900;font-display:fallback;src:url('THEME_ROOT_URL/assets/fonts/SourceSerif4Variable-Roman.ttf.woff2') format('woff2');font-stretch:normal;}@font-face{font-family:"Source Serif Pro";font-style:italic;font-weight:200 900;font-display:fallback;src:local("Source Serif Pro"), url('THEME_ROOT_URL/assets/fonts/SourceSerif4Variable-Italic.ttf.woff2') format('woff2');font-stretch:normal;}
+@font-face{font-family:"Source Serif Pro";font-style:normal;font-weight:200 900;font-display:fallback;src:url('THEME_ROOT_URL/assets/fonts/SourceSerif4Variable-Roman.ttf.woff2') format('woff2');font-stretch:normal;}@font-face{font-family:"Source Serif Pro";font-style:italic;font-weight:200 900;font-display:fallback;src:url('THEME_ROOT_URL/assets/fonts/SourceSerif4Variable-Italic.ttf.woff2') format('woff2');font-stretch:normal;}
 </style>
 EOF;
 		$expected = str_replace( 'THEME_ROOT_URL', get_stylesheet_directory_uri(), $expected );

--- a/tests/phpunit/tests/webfonts/wpThemeJsonWebfontsHandler.php
+++ b/tests/phpunit/tests/webfonts/wpThemeJsonWebfontsHandler.php
@@ -76,6 +76,7 @@ class Tests_Webfonts_wpThemeJsonWebfontsHandler extends WP_UnitTestCase {
 	/**
 	 * @ticket 55567
 	 * @ticket 46370
+	 * @ticket 57430
 	 */
 	public function test_font_face_generated_from_themejson() {
 		$this->setup_theme_and_test( 'webfonts-theme' );

--- a/tests/phpunit/tests/webfonts/wpThemeJsonWebfontsHandler.php
+++ b/tests/phpunit/tests/webfonts/wpThemeJsonWebfontsHandler.php
@@ -82,7 +82,7 @@ class Tests_Webfonts_wpThemeJsonWebfontsHandler extends WP_UnitTestCase {
 
 		$expected = <<<EOF
 <style id='wp-webfonts-inline-css' type='text/css'>
-@font-face{font-family:"Source Serif Pro";font-style:normal;font-weight:200 900;font-display:fallback;src:local("Source Serif Pro"), url('THEME_ROOT_URL/assets/fonts/SourceSerif4Variable-Roman.ttf.woff2') format('woff2');font-stretch:normal;}@font-face{font-family:"Source Serif Pro";font-style:italic;font-weight:200 900;font-display:fallback;src:local("Source Serif Pro"), url('THEME_ROOT_URL/assets/fonts/SourceSerif4Variable-Italic.ttf.woff2') format('woff2');font-stretch:normal;}
+@font-face{font-family:"Source Serif Pro";font-style:normal;font-weight:200 900;font-display:fallback;src:url('THEME_ROOT_URL/assets/fonts/SourceSerif4Variable-Roman.ttf.woff2') format('woff2');font-stretch:normal;}@font-face{font-family:"Source Serif Pro";font-style:italic;font-weight:200 900;font-display:fallback;src:local("Source Serif Pro"), url('THEME_ROOT_URL/assets/fonts/SourceSerif4Variable-Italic.ttf.woff2') format('woff2');font-stretch:normal;}
 </style>
 EOF;
 		$expected = str_replace( 'THEME_ROOT_URL', get_stylesheet_directory_uri(), $expected );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

As discussed, loading the local font file can lean to unexpected compatibility issues due to version or locale mismatches of the font.

Vendors like Google have dropped using local in their font delivery.

That is why I would propose dropping the local rule altogether.

Trac ticket: https://core.trac.wordpress.org/ticket/57430

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
