### PR TITLE
54803 — Fix docblocks for `https_ssl_verify` and `https_local_ssl_verify`

### DIFF
--- a/src/wp-includes/class-wp-http-streams.php
+++ b/src/wp-includes/class-wp-http-streams.php
@@ -101,8 +101,9 @@ class WP_Http_Streams {
 			 * @since 2.8.0
 			 * @since 5.1.0 The `$url` parameter was added.
 			 *
-			 * @param bool   $ssl_verify Whether to verify the SSL connection. Default true.
-			 * @param string $url        The request URL.
+			 * @param bool|string $ssl_verify Boolean to control whether to verify the SSL connection
+			 *                                or path to an SSL certificate.
+			 * @param ?string     $url        Optional. The request URL.
 			 */
 			$ssl_verify = apply_filters( 'https_local_ssl_verify', $ssl_verify, $url );
 		} elseif ( ! $is_local ) {

--- a/src/wp-includes/class-wp-http.php
+++ b/src/wp-includes/class-wp-http.php
@@ -371,8 +371,9 @@ class WP_Http {
 		 * @since 2.8.0
 		 * @since 5.1.0 The `$url` parameter was added.
 		 *
-		 * @param bool   $ssl_verify Whether to verify the SSL connection. Default true.
-		 * @param string $url        The request URL.
+		 * @param bool|string $ssl_verify Boolean to control whether to verify the SSL connection
+		 *                                or path to an SSL certificate.
+		 * @param ?string     $url        Optional. The request URL.
 		 */
 		$options['verify'] = apply_filters( 'https_ssl_verify', $options['verify'], $url );
 


### PR DESCRIPTION
The [`https_ssl_verify`](https://developer.wordpress.org/reference/hooks/https_ssl_verify/) and [`https_local_ssl_verify`](https://developer.wordpress.org/reference/hooks/https_local_ssl_verify/) filters are currently documented to expect and return a boolean value (whether to verify the SSL connection) and to expect a request URL.

However a string value (path to SSL certificate bundle) is often provided and when a boolean is provided, it is often `false` instead of `true`.

Furthermore, the request URL is often omitted.

See [`WP_Site_Health::get_test_rest_availability()`](https://github.com/WordPress/wordpress-develop/blob/6.1/src/wp-admin/includes/class-wp-site-health.php#L2068) for an example.

Trac ticket: https://core.trac.wordpress.org/ticket/54803