### PR TITLE
trac-54812: fix Overflow issue with image name while uploading on mob…

### DIFF
--- a/src/wp-admin/css/media.css
+++ b/src/wp-admin/css/media.css
@@ -191,7 +191,7 @@
 
 .media-item .original {
 	position: relative;
-	height: 34px;
+	min-height: 34px;
 }
 
 .media-item .progress {
@@ -1240,7 +1240,7 @@ audio, video {
 	.edit-attachment-frame textarea {
 		line-height: 1.5;
 	}
-	
+
 	.wp_attachment_details label[for="content"] {
 		font-size: 14px;
 		line-height: 1.5;


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/54812

**Before**
![image](https://user-images.githubusercontent.com/9963909/211641405-ba044e75-c580-43aa-9927-c8dda0db0db0.png)

**After**
![image](https://user-images.githubusercontent.com/9963909/211641340-c9284e6b-c8f4-463c-80bb-39e59dcc499c.png)
