### PR TITLE
Revert 55045

### DIFF
--- a/src/wp-admin/css/colors/_admin.scss
+++ b/src/wp-admin/css/colors/_admin.scss
@@ -2,6 +2,10 @@
 @import 'variables';
 @import 'mixins';
 
+/**
+ * Use British English to maintain backward compatibility, 
+ * developers may use the function in their own admin CSS files.
+ */
 @function url-friendly-colour( $color ) {
 	@return '%23' + str-slice( '#{ $color }', 2, -1 );
 }

--- a/src/wp-admin/css/colors/_admin.scss
+++ b/src/wp-admin/css/colors/_admin.scss
@@ -2,7 +2,7 @@
 @import 'variables';
 @import 'mixins';
 
-@function url-friendly-color( $color ) {
+@function url-friendly-colour( $color ) {
 	@return '%23' + str-slice( '#{ $color }', 2, -1 );
 }
 
@@ -62,7 +62,7 @@ span.wp-media-buttons-icon:before {
 /* Forms */
 
 input[type=checkbox]:checked::before {
-	content: url("data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2020%2020%27%3E%3Cpath%20d%3D%27M14.83%204.89l1.34.94-5.81%208.38H9.02L5.78%209.67l1.34-1.25%202.57%202.4z%27%20fill%3D%27#{url-friendly-color($form-checked)}%27%2F%3E%3C%2Fsvg%3E");
+	content: url("data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2020%2020%27%3E%3Cpath%20d%3D%27M14.83%204.89l1.34.94-5.81%208.38H9.02L5.78%209.67l1.34-1.25%202.57%202.4z%27%20fill%3D%27#{url-friendly-colour($form-checked)}%27%2F%3E%3C%2Fsvg%3E");
 }
 
 input[type=radio]:checked::before {


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/56811

Revert the name change of the admin scss-function. Keep `function url-friendly-colour` to maintain backward compatibility.