### PR TITLE
Added checks for incomplete objects in map_deep function

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -5012,6 +5012,10 @@ function sanitize_option( $option, $value ) {
  * @return mixed The value with the callback applied to all non-arrays and non-objects inside it.
  */
 function map_deep( $value, $callback ) {
+	if ( is_object( $value ) && $value instanceof __PHP_Incomplete_Class ) {
+		return $value;
+	}
+
 	if ( is_array( $value ) ) {
 		foreach ( $value as $index => $item ) {
 			$value[ $index ] = map_deep( $item, $callback );

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -5012,7 +5012,7 @@ function sanitize_option( $option, $value ) {
  * @return mixed The value with the callback applied to all non-arrays and non-objects inside it.
  */
 function map_deep( $value, $callback ) {
-	if ( is_object( $value ) && $value instanceof __PHP_Incomplete_Class ) {
+	if ( $value instanceof __PHP_Incomplete_Class ) {
 		return $value;
 	}
 

--- a/tests/phpunit/tests/formatting/mapDeep.php
+++ b/tests/phpunit/tests/formatting/mapDeep.php
@@ -168,6 +168,53 @@ class Tests_Formatting_MapDeep extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * @ticket 55257
+	 */
+	public function test_map_deep_should_skip_incomplete_objects() {
+		$incomplete_object = unserialize( 'O:14:"SuperCustomXyz":1:{s:17:" SuperCustomXyz x";s:4:"test";}' );
+
+		$this->assertSame(
+			array(
+				0          => $incomplete_object,
+				'testdata' => array(
+					'a' => '1baba',
+					'b' => '2baba',
+				),
+			),
+			map_deep(
+				array(
+					0          => $incomplete_object,
+					'testdata' => array(
+						'a' => 1,
+						'b' => 2,
+					),
+				),
+				array( $this, 'append_baba' )
+			),
+			'map_deep should skip incomplete objects while iterating over array values.'
+		);
+
+		$this->assertEquals(
+			array(
+				'testdata' => (object) array(
+					'a' => $incomplete_object,
+					'b' => 'testbaba',
+				),
+			),
+			map_deep(
+				array(
+					'testdata' => (object) array(
+						'a' => $incomplete_object,
+						'b' => 'test',
+					),
+				),
+				array( $this, 'append_baba' )
+			),
+			'map_deep should skip incomplete objects while iterating over object properties.'
+		);
+	}
+
 	public function append_baba( $value ) {
 		return $value . 'baba';
 	}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/55257

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
