### PR TITLE
Enbale classic editor

### DIFF
--- a/src/wp-admin/options-general.php
+++ b/src/wp-admin/options-general.php
@@ -79,6 +79,9 @@ if ( is_multisite() ) {
 <td><input name="blogdescription" type="text" id="blogdescription" aria-describedby="tagline-description" value="<?php form_option( 'blogdescription' ); ?>" class="regular-text" placeholder="<?php echo $sample_tagline; ?>" />
 <p class="description" id="tagline-description"><?php _e( 'In a few words, explain what this site is about.' ); ?></p></td>
 </tr>
+/*
+* Add option to enable the classic editor without a plugin
+*/
 <tr>
 <th>
 <?php _e( 'Enable Classic Editor' ); ?>

--- a/src/wp-admin/options-general.php
+++ b/src/wp-admin/options-general.php
@@ -79,31 +79,6 @@ if ( is_multisite() ) {
 <td><input name="blogdescription" type="text" id="blogdescription" aria-describedby="tagline-description" value="<?php form_option( 'blogdescription' ); ?>" class="regular-text" placeholder="<?php echo $sample_tagline; ?>" />
 <p class="description" id="tagline-description"><?php _e( 'In a few words, explain what this site is about.' ); ?></p></td>
 </tr>
-/*
-* Add option to enable the classic editor without a plugin
-*/
-<tr>
-<th>
-<?php _e( 'Enable Classic Editor' ); ?>
-</th>
-<td>
-<label for="classic_editor_enabled">
-	<input type="checkbox" name="classic_editor_enabled" id="classic_editor_enabled" value="enabled" <?php checked( $classic_editor_enabled, 'enabled' ); ?>>
-	Enable Classic Editor
-</label>
-<td>
-<tr>
-<?php
-    }
-    // Disable Gutenberg if the checkbox is checked
-    add_filter( 'use_block_editor_for_post', 'disable_gutenberg_on_check', 10, 2 );
-    function disable_gutenberg_on_check( $use_block_editor, $post ) {
-        if ( get_option( 'classic_editor_enabled', 'enabled' ) === 'enabled' ) {
-            return false;
-        }
-        return $use_block_editor;
-    }
-?>
 <?php
 if ( ! is_multisite() ) {
 	$wp_site_url_class = '';
@@ -115,7 +90,6 @@ if ( ! is_multisite() ) {
 		$wp_home_class = ' disabled';
 	}
 	?>
-
 <tr>
 <th scope="row"><label for="siteurl"><?php _e( 'WordPress Address (URL)' ); ?></label></th>
 <td><input name="siteurl" type="url" id="siteurl" value="<?php form_option( 'siteurl' ); ?>"<?php disabled( defined( 'WP_SITEURL' ) ); ?> class="regular-text code<?php echo $wp_site_url_class; ?>" /></td>
@@ -428,6 +402,23 @@ endfor;
 ?>
 </select></td>
 </tr>
+/*
+* Add option to enable the classic editor without a plugin
+*/
+<tr>
+<th><label for="classic_editor_enabled"><?php _e( 'Enable Classic Editor' ); ?></label></th>
+<td><input type="checkbox" name="classic_editor_enabled" id="classic_editor_enabled" value="enabled" <?php checked( $classic_editor_enabled, 'enabled' ); ?>><?php _e( 'Enable Classic Editor' ); ?><td>
+<tr>
+<?php
+// Disable Gutenberg if the checkbox is checked
+add_filter( 'use_block_editor_for_post', 'disable_gutenberg_on_check', 10, 2 );
+function disable_gutenberg_on_check( $use_block_editor, $post ) {
+if ( get_option( 'classic_editor_enabled', 'enabled' ) === 'enabled' ) {
+    return false;
+}
+return $use_block_editor;
+}
+?>
 <?php do_settings_fields( 'general', 'default' ); ?>
 </table>
 

--- a/src/wp-admin/options-general.php
+++ b/src/wp-admin/options-general.php
@@ -79,7 +79,28 @@ if ( is_multisite() ) {
 <td><input name="blogdescription" type="text" id="blogdescription" aria-describedby="tagline-description" value="<?php form_option( 'blogdescription' ); ?>" class="regular-text" placeholder="<?php echo $sample_tagline; ?>" />
 <p class="description" id="tagline-description"><?php _e( 'In a few words, explain what this site is about.' ); ?></p></td>
 </tr>
-
+<tr>
+<th>
+<?php _e( 'Enable Classic Editor' ); ?>
+</th>
+<td>
+<label for="classic_editor_enabled">
+	<input type="checkbox" name="classic_editor_enabled" id="classic_editor_enabled" value="enabled" <?php checked( $classic_editor_enabled, 'enabled' ); ?>>
+	Enable Classic Editor
+</label>
+<td>
+<tr>
+<?php
+    }
+    // Disable Gutenberg if the checkbox is checked
+    add_filter( 'use_block_editor_for_post', 'disable_gutenberg_on_check', 10, 2 );
+    function disable_gutenberg_on_check( $use_block_editor, $post ) {
+        if ( get_option( 'classic_editor_enabled', 'enabled' ) === 'enabled' ) {
+            return false;
+        }
+        return $use_block_editor;
+    }
+?>
 <?php
 if ( ! is_multisite() ) {
 	$wp_site_url_class = '';

--- a/src/wp-content/themes/twentytwentyfour/functions.php
+++ b/src/wp-content/themes/twentytwentyfour/functions.php
@@ -204,3 +204,35 @@ if ( ! function_exists( 'twentytwentyfour_pattern_categories' ) ) :
 endif;
 
 add_action( 'init', 'twentytwentyfour_pattern_categories' );
+
+/**
+* Show the post-reading time
+*/
+function estimated_reading_time($content = '') {
+    // Average reading speed (words per minute)
+    $words_per_minute = 200;
+
+    // Count the number of words in the post content
+    $word_count = str_word_count(strip_tags($content));
+
+    // Calculate the reading time in minutes
+    $reading_time = ceil($word_count / $words_per_minute);
+
+    return $reading_time;
+}
+
+function display_reading_time() {
+    global $post;
+
+    // Get the content of the post
+    $content = $post->post_content;
+
+    // Get the estimated reading time
+    $reading_time = estimated_reading_time($content);
+
+    // Output the estimated reading time
+    echo '<p>Estimated reading time: ' . $reading_time . ' minute(s)</p>';
+}
+
+// Use the function to display reading time in posts (hook into 'the_content')
+add_filter('the_content', 'display_reading_time');

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -8474,3 +8474,41 @@ function wp_create_initial_post_meta() {
  *
  * @param array $post_data An array of sanitized post data.
  */
+
+ function edit_post($post_data) {
+    // Verify post ID exists.
+    if (empty($post_data['ID'])) {
+        return new WP_Error('missing_post_id', __('Post ID is missing.', 'dpb'));
+    }
+
+    // Retrieve the post to ensure it exists and can be updated.
+    $post = get_post($post_data['ID']);
+    if (!$post) {
+        return new WP_Error('invalid_post_id', __('Invalid post ID.', 'dpb'));
+    }
+
+    // Check if the post type supports revisions.
+    if (post_type_supports($post->post_type, 'revisions')) {
+        /**
+         * Check if the request was triggered by Quick Edit.
+         * The '_inline_edit' field in the $_POST data indicates Quick Edit usage.
+         */
+        if (isset($_POST['_inline_edit'])) {
+            // Save a new revision for the post being updated.
+            wp_save_post_revision($post_data['ID']);
+        }
+    }
+
+    // Continue with existing logic to update the post (simplified for illustration).
+    $updated = wp_update_post($post_data, true);
+
+    // Return an error if the update failed.
+    if (is_wp_error($updated)) {
+        return $updated;
+    }
+
+    // Perform any additional actions after the post is updated.
+    do_action('post_updated', $post_data['ID'], $post_data);
+
+    return $updated;
+}

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -8465,3 +8465,12 @@ function wp_create_initial_post_meta() {
 		)
 	);
 }
+
+/**
+ * Add revision support for changes made via Quick Edit in the WordPress admin.
+ *
+ * This functionality ensures that any updates made through the Quick Edit option 
+ * are tracked as revisions, allowing users to revert changes if needed.
+ *
+ * @param array $post_data An array of sanitized post data.
+ */


### PR DESCRIPTION
Many users don't want to use the Gutenberg block editor, so they need to install the classic editor plugin separately. My code will add an option to general settings to enable the classic editor, so users don't need to install a plugin for that.