### PR TITLE
Widgets: Make sure mapped sidebar widgets is an array

### DIFF
--- a/src/wp-includes/widgets.php
+++ b/src/wp-includes/widgets.php
@@ -1400,7 +1400,7 @@ function wp_map_sidebars_widgets( $existing_sidebars_widgets ) {
 
 	foreach ( $wp_registered_sidebars as $sidebar => $name ) {
 		if ( in_array( $sidebar, $existing_sidebars, true ) ) {
-			$new_sidebars_widgets[ $sidebar ] = $existing_sidebars_widgets[ $sidebar ];
+			$new_sidebars_widgets[ $sidebar ] = (array) $existing_sidebars_widgets[ $sidebar ];
 			unset( $existing_sidebars_widgets[ $sidebar ] );
 		} elseif ( ! array_key_exists( $sidebar, $new_sidebars_widgets ) ) {
 			$new_sidebars_widgets[ $sidebar ] = array();

--- a/tests/phpunit/tests/widgets.php
+++ b/tests/phpunit/tests/widgets.php
@@ -1288,8 +1288,8 @@ class Tests_Widgets extends WP_UnitTestCase {
 	public function test_sidebars_with_same_slug() {
 		$this->register_sidebars( array( 'primary', 'secondary' ) );
 		$prev_theme_sidebars = array(
-			'primary'             => 1,
-			'secondary'           => 2,
+			'primary'             => array( 1 ),
+			'secondary'           => array( 2 ),
 			'wp_inactive_widgets' => array(),
 		);
 
@@ -1364,4 +1364,29 @@ class Tests_Widgets extends WP_UnitTestCase {
 		);
 		$this->assertSameSetsWithIndex( $expected_sidebars, $new_next_theme_sidebars );
 	}
+
+	/**
+	 * Make sure wp_map_sidebars_widgets always return an array of mapped sidebar widgets
+	 *
+	 * @ticket 57469
+	 *
+	 * @covers ::wp_map_sidebars_widgets
+	 */
+	public function test_wp_map_sidebar_widgets_enforce_array() {
+		$this->register_sidebars( array( 'primary', 'main' ) );
+
+		$prev_theme_sidebars = array(
+			'main' => null,
+		);
+
+		$new_next_theme_sidebars = wp_map_sidebars_widgets( $prev_theme_sidebars );
+
+		$expected_sidebars = array(
+			'main'                => array(),
+			'primary'             => array(),
+			'wp_inactive_widgets' => array(),
+		);
+		$this->assertSameSetsWithIndex( $expected_sidebars, $new_next_theme_sidebars );
+	}
+
 }


### PR DESCRIPTION
wp_map_sidebar_widgets is called in retrieve_widgets and is expected to return array<string, array>.

Before this change it was possible to return something like `['sidebar-1' => [], 'sidebar-2' => null]`.
 array_merge in PHP 8.0 is stricter and throws an TypeError when null given.

PHP 7.4: `array_merge(...[['hello', 'world'], null])` => null 
PHP 8.0: `array_merge(...[['hello', 'world'], null])` => Fatal error

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/57469

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
