### PR TITLE
Add description support for block pattern categories

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-pattern-categories-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-pattern-categories-controller.php
@@ -102,10 +102,10 @@ class WP_REST_Block_Pattern_Categories_Controller extends WP_REST_Controller {
 	 */
 	public function prepare_item_for_response( $item, $request ) {
 		$fields = $this->get_fields_for_response( $request );
-		$keys   = array( 'name', 'label' );
+		$keys   = array( 'name', 'label', 'description' );
 		$data   = array();
 		foreach ( $keys as $key ) {
-			if ( rest_is_field_included( $key, $fields ) ) {
+			if ( isset( $item[ $key ] ) && rest_is_field_included( $key, $fields ) ) {
 				$data[ $key ] = $item[ $key ];
 			}
 		}
@@ -130,14 +130,20 @@ class WP_REST_Block_Pattern_Categories_Controller extends WP_REST_Controller {
 			'title'      => 'block-pattern-category',
 			'type'       => 'object',
 			'properties' => array(
-				'name'  => array(
+				'name'        => array(
 					'description' => __( 'The category name.' ),
 					'type'        => 'string',
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit', 'embed' ),
 				),
-				'label' => array(
+				'label'       => array(
 					'description' => __( 'The category label, in human readable format.' ),
+					'type'        => 'string',
+					'readonly'    => true,
+					'context'     => array( 'view', 'edit', 'embed' ),
+				),
+				'description' => array(
+					'description' => __( 'The category description, in human readable format.' ),
 					'type'        => 'string',
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit', 'embed' ),

--- a/tests/phpunit/tests/rest-api/wpRestBlockPatternCategoriesController.php
+++ b/tests/phpunit/tests/rest-api/wpRestBlockPatternCategoriesController.php
@@ -74,8 +74,8 @@ class Tests_REST_WpRestBlockPatternCategoriesController extends WP_Test_REST_Con
 		self::$registry_instance_property->setValue( $test_registry );
 
 		// Register some categories in the test registry.
-		$test_registry->register( 'test', array( 'label' => 'Test' ) );
-		$test_registry->register( 'query', array( 'label' => 'Query' ) );
+		$test_registry->register( 'test', array( 'label' => 'Test', 'description' => 'Test description' ) );
+		$test_registry->register( 'query', array( 'label' => 'Query', 'description' => 'Query' ) );
 	}
 
 	public static function wpTearDownAfterClass() {
@@ -103,10 +103,10 @@ class Tests_REST_WpRestBlockPatternCategoriesController extends WP_Test_REST_Con
 		wp_set_current_user( self::$admin_id );
 
 		$expected_names  = array( 'test', 'query' );
-		$expected_fields = array( 'name', 'label' );
+		$expected_fields = array( 'name', 'label', 'description' );
 
 		$request            = new WP_REST_Request( 'GET', static::REQUEST_ROUTE );
-		$request['_fields'] = 'name,label';
+		$request['_fields'] = 'name,label,description';
 		$response           = rest_get_server()->dispatch( $request );
 		$data               = $response->get_data();
 

--- a/tests/phpunit/tests/rest-api/wpRestBlockPatternCategoriesController.php
+++ b/tests/phpunit/tests/rest-api/wpRestBlockPatternCategoriesController.php
@@ -74,8 +74,20 @@ class Tests_REST_WpRestBlockPatternCategoriesController extends WP_Test_REST_Con
 		self::$registry_instance_property->setValue( $test_registry );
 
 		// Register some categories in the test registry.
-		$test_registry->register( 'test', array( 'label' => 'Test', 'description' => 'Test description' ) );
-		$test_registry->register( 'query', array( 'label' => 'Query', 'description' => 'Query' ) );
+		$test_registry->register(
+			'test',
+			array(
+				'label'       => 'Test',
+				'description' => 'Test description',
+			)
+		);
+		$test_registry->register(
+			'query',
+			array(
+				'label'       => 'Query',
+				'description' => 'Query',
+			)
+		);
 	}
 
 	public static function wpTearDownAfterClass() {


### PR DESCRIPTION
Trac ticket https://core.trac.wordpress.org/ticket/57478

Related Gutenberg PRs:

- https://github.com/WordPress/gutenberg/pull/45244/
- https://github.com/WordPress/gutenberg/pull/45410/

## What

This adds "description" to the block pattern categories endpoint.

@Mamaduka