### PR TITLE
Backport the changes to the site editor intialization

### DIFF
--- a/src/wp-admin/site-editor.php
+++ b/src/wp-admin/site-editor.php
@@ -76,16 +76,7 @@ $custom_settings      = array(
 	'defaultTemplatePartAreas'  => get_allowed_block_template_part_areas(),
 	'supportsLayout'            => wp_theme_has_theme_json(),
 	'supportsTemplatePartsMode' => ! wp_is_block_theme() && current_theme_supports( 'block-template-parts' ),
-	'__unstableHomeTemplate'    => $home_template,
 );
-
-/**
- * Home template resolution is not needed when block template parts are supported.
- * Set the value to `true` to satisfy the editor initialization guard clause.
- */
-if ( $custom_settings['supportsTemplatePartsMode'] ) {
-	$custom_settings['__unstableHomeTemplate'] = true;
-}
 
 // Add additional back-compat patterns registered by `current_screen` et al.
 $custom_settings['__experimentalAdditionalBlockPatterns']          = WP_Block_Patterns_Registry::get_instance()->get_all_registered( true );


### PR DESCRIPTION
Trac ticket https://core.trac.wordpress.org/ticket/57480

Related Gutenberg PRs:

https://github.com/WordPress/gutenberg/pull/44770

This updates the site initialization to match Gutenberg by removing a key that is not used anymore. That said, we can't land this PR until the package updates happens.

@Mamaduka @ntsekouras