### PR TITLE
Add support for "RoboHash" avatars for Gravatar

### DIFF
--- a/src/wp-admin/options-discussion.php
+++ b/src/wp-admin/options-discussion.php
@@ -281,7 +281,7 @@ $avatar_defaults = array(
 	'wavatar'          => __( 'Wavatar (Generated)' ),
 	'monsterid'        => __( 'MonsterID (Generated)' ),
 	'retro'            => __( 'Retro (Generated)' ),
-	'robohash'         => __( 'RoboHash (Generated)' ), 
+	'robohash'         => __( 'RoboHash (Generated)' ),
 );
 /**
  * Filters the default avatars.

--- a/src/wp-admin/options-discussion.php
+++ b/src/wp-admin/options-discussion.php
@@ -281,6 +281,7 @@ $avatar_defaults = array(
 	'wavatar'          => __( 'Wavatar (Generated)' ),
 	'monsterid'        => __( 'MonsterID (Generated)' ),
 	'retro'            => __( 'Retro (Generated)' ),
+	'robohash'         => __( 'RoboHash (Generated)' ), 
 );
 /**
  * Filters the default avatars.


### PR DESCRIPTION
Add support for "RoboHash" avatars for Gravatar
This is a native option, source: https://en.gravatar.com/site/implement/images/

Trac ticket: https://core.trac.wordpress.org/ticket/57493#ticket