### PR TITLE
Add new query args to Pattern Directory Controller

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-pattern-directory-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-pattern-directory-controller.php
@@ -94,15 +94,19 @@ class WP_REST_Pattern_Directory_Controller extends WP_REST_Controller {
 		 */
 		require ABSPATH . WPINC . '/version.php';
 
-		$valid_query_args = array( 'offset', 'order', 'orderby', 'page', 'per_page', 'search', 'slug' );
-		$query_args       = array_merge(
-			array_intersect_key( $request->get_params(), array_flip( $valid_query_args ) ),
-			array(
-				'locale'     => get_user_locale(),
-				'wp-version' => $wp_version, // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable -- it's defined in `version.php` above.
-			)
+		$valid_query_args = array(
+			'offset'   => true,
+			'order'    => true,
+			'orderby'  => true,
+			'page'     => true,
+			'per_page' => true,
+			'search'   => true,
+			'slug'     => true,
 		);
+		$query_args = array_intersect_key( $request->get_params(), $valid_query_args );
 
+		$query_args['locale']             = get_user_locale();
+		$query_args['wp-version']         = $wp_version; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable -- it's defined in `version.php` above.
 		$query_args['pattern-categories'] = isset( $request['category'] ) ? $request['category'] : false;
 		$query_args['pattern-keywords']   = isset( $request['keyword'] ) ? $request['keyword'] : false;
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-pattern-directory-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-pattern-directory-controller.php
@@ -81,6 +81,7 @@ class WP_REST_Pattern_Directory_Controller extends WP_REST_Controller {
 	 *
 	 * @since 5.8.0
 	 * @since 6.0.0 Added 'slug' to request.
+	 * @since 6.2.0 Added 'per_page', 'page', 'offset', 'order', and 'orderby' to request.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
@@ -93,31 +94,19 @@ class WP_REST_Pattern_Directory_Controller extends WP_REST_Controller {
 		 */
 		require ABSPATH . WPINC . '/version.php';
 
-		$query_args = array(
-			'locale'     => get_user_locale(),
-			'wp-version' => $wp_version,
+		$valid_query_args = array( 'offset', 'order', 'orderby', 'page', 'per_page', 'search', 'slug' );
+		$query_args       = array_merge(
+			array_intersect_key( $request->get_params(), array_flip( $valid_query_args ) ),
+			array(
+				'locale'     => get_user_locale(),
+				'wp-version' => $wp_version, // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable -- it's defined in `version.php` above.
+			)
 		);
 
-		$category_id = $request['category'];
-		$keyword_id  = $request['keyword'];
-		$search_term = $request['search'];
-		$slug        = $request['slug'];
+		$query_args['pattern-categories'] = isset( $request['category'] ) ? $request['category'] : false;
+		$query_args['pattern-keywords']   = isset( $request['keyword'] ) ? $request['keyword'] : false;
 
-		if ( $category_id ) {
-			$query_args['pattern-categories'] = $category_id;
-		}
-
-		if ( $keyword_id ) {
-			$query_args['pattern-keywords'] = $keyword_id;
-		}
-
-		if ( $search_term ) {
-			$query_args['search'] = $search_term;
-		}
-
-		if ( $slug ) {
-			$query_args['slug'] = $slug;
-		}
+		$query_args = array_filter( $query_args );
 
 		$transient_key = $this->get_transient_key( $query_args );
 
@@ -303,16 +292,14 @@ class WP_REST_Pattern_Directory_Controller extends WP_REST_Controller {
 	 * Retrieves the search parameters for the block pattern's collection.
 	 *
 	 * @since 5.8.0
+	 * @since 6.2.0 Added 'per_page', 'page', 'offset', 'order', and 'orderby' to request.
 	 *
 	 * @return array Collection parameters.
 	 */
 	public function get_collection_params() {
 		$query_params = parent::get_collection_params();
 
-		// Pagination is not supported.
-		unset( $query_params['page'] );
-		unset( $query_params['per_page'] );
-
+		$query_params['per_page']['default'] = 100;
 		$query_params['search']['minLength'] = 1;
 		$query_params['context']['default']  = 'view';
 
@@ -331,6 +318,37 @@ class WP_REST_Pattern_Directory_Controller extends WP_REST_Controller {
 		$query_params['slug'] = array(
 			'description' => __( 'Limit results to those matching a pattern (slug).' ),
 			'type'        => 'array',
+		);
+
+		$query_params['offset'] = array(
+			'description' => __( 'Offset the result set by a specific number of items.', 'gutenberg' ),
+			'type'        => 'integer',
+		);
+
+		$query_params['order'] = array(
+			'description' => __( 'Order sort attribute ascending or descending.', 'gutenberg' ),
+			'type'        => 'string',
+			'default'     => 'desc',
+			'enum'        => array( 'asc', 'desc' ),
+		);
+
+		$query_params['orderby'] = array(
+			'description' => __( 'Sort collection by post attribute.', 'gutenberg' ),
+			'type'        => 'string',
+			'default'     => 'date',
+			'enum'        => array(
+				'author',
+				'date',
+				'id',
+				'include',
+				'modified',
+				'parent',
+				'relevance',
+				'slug',
+				'include_slugs',
+				'title',
+				'favorite_count',
+			),
 		);
 
 		/**

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-pattern-directory-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-pattern-directory-controller.php
@@ -325,19 +325,19 @@ class WP_REST_Pattern_Directory_Controller extends WP_REST_Controller {
 		);
 
 		$query_params['offset'] = array(
-			'description' => __( 'Offset the result set by a specific number of items.', 'gutenberg' ),
+			'description' => __( 'Offset the result set by a specific number of items.' ),
 			'type'        => 'integer',
 		);
 
 		$query_params['order'] = array(
-			'description' => __( 'Order sort attribute ascending or descending.', 'gutenberg' ),
+			'description' => __( 'Order sort attribute ascending or descending.' ),
 			'type'        => 'string',
 			'default'     => 'desc',
 			'enum'        => array( 'asc', 'desc' ),
 		);
 
 		$query_params['orderby'] = array(
-			'description' => __( 'Sort collection by post attribute.', 'gutenberg' ),
+			'description' => __( 'Sort collection by post attribute.' ),
 			'type'        => 'string',
 			'default'     => 'date',
 			'enum'        => array(

--- a/tests/phpunit/tests/rest-api/rest-pattern-directory-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-pattern-directory-controller.php
@@ -375,36 +375,136 @@ class WP_REST_Pattern_Directory_Controller_Test extends WP_Test_REST_Controller_
 	}
 
 	/**
-	 * Data provider for test_get_items_query_args.
+	 * Data provider.
 	 *
-	 * @since 6.2.0
+	 * return array[]
 	 */
 	public function data_get_items_query_args() {
 		return array(
-			'per_page default'   => array( 'per_page', false, false, 100 ),
-			'per_page custom-1'  => array( 'per_page', 5, false, 5 ),
-			'per_page custom-2'  => array( 'per_page', 50, false, 50 ),
-			'per_page invalid-1' => array( 'per_page', 200, true, 'rest_invalid_param' ),
-			'per_page invalid-2' => array( 'per_page', 'abc', true, 'rest_invalid_param' ),
+			'per_page default'   => array(
+				'param'    => 'per_page',
+				'value'    => false,
+				'is_error' => false,
+				'expected' => 100,
+			),
+			'per_page custom-1'  => array(
+				'param'    => 'per_page',
+				'value'    => 5,
+				'is_error' => false,
+				'expected' => 5,
+			),
+			'per_page custom-2'  => array(
+				'param'    => 'per_page',
+				'value'    => 50,
+				'is_error' => false,
+				'expected' => 50,
+			),
+			'per_page invalid-1' => array(
+				'param'    => 'per_page',
+				'value'    => 200,
+				'is_error' => true,
+				'expected' => 'rest_invalid_param',
+			),
+			'per_page invalid-2' => array(
+				'param'    => 'per_page',
+				'value'    => 'abc',
+				'is_error' => true,
+				'expected' => 'rest_invalid_param',
+			),
 
-			'page default'       => array( 'page', false, false, 1 ),
-			'page custom'        => array( 'page', 5, false, 5 ),
-			'page invalid'       => array( 'page', 'abc', true, 'rest_invalid_param' ),
+			'page default'       => array(
+				'param'    => 'page',
+				'value'    => false,
+				'is_error' => false,
+				'expected' => 1,
+			),
+			'page custom'        => array(
+				'param'    => 'page',
+				'value'    => 5,
+				'is_error' => false,
+				'expected' => 5,
+			),
+			'page invalid'       => array(
+				'param'    => 'page',
+				'value'    => 'abc',
+				'is_error' => true,
+				'expected' => 'rest_invalid_param',
+			),
 
-			'offset custom'      => array( 'offset', 5, false, 5 ),
-			'offset invalid-1'   => array( 'offset', 'abc', true, 'rest_invalid_param' ),
+			'offset custom'      => array(
+				'param'    => 'offset',
+				'value'    => 5,
+				'is_error' => false,
+				'expected' => 5,
+			),
+			'offset invalid-1'   => array(
+				'param'    => 'offset',
+				'value'    => 'abc',
+				'is_error' => true,
+				'expected' => 'rest_invalid_param',
+			),
 
-			'order default'      => array( 'order', false, false, 'desc' ),
-			'order custom'       => array( 'order', 'asc', false, 'asc' ),
-			'order invalid-1'    => array( 'order', 10, true, 'rest_invalid_param' ),
-			'order invalid-2'    => array( 'order', 'fake', true, 'rest_invalid_param' ),
+			'order default'      => array(
+				'param'    => 'order',
+				'value'    => false,
+				'is_error' => false,
+				'expected' => 'desc',
+			),
+			'order custom'       => array(
+				'param'    => 'order',
+				'value'    => 'asc',
+				'is_error' => false,
+				'expected' => 'asc',
+			),
+			'order invalid-1'    => array(
+				'param'    => 'order',
+				'value'    => 10,
+				'is_error' => true,
+				'expected' => 'rest_invalid_param',
+			),
+			'order invalid-2'    => array(
+				'param'    => 'order',
+				'value'    => 'fake',
+				'is_error' => true,
+				'expected' => 'rest_invalid_param',
+			),
 
-			'orderby default'    => array( 'orderby', false, false, 'date' ),
-			'orderby custom-1'   => array( 'orderby', 'title', false, 'title' ),
-			'orderby custom-2'   => array( 'orderby', 'date', false, 'date' ),
-			'orderby custom-3'   => array( 'orderby', 'favorite_count', false, 'favorite_count' ),
-			'orderby invalid-1'  => array( 'orderby', 10, true, 'rest_invalid_param' ),
-			'orderby invalid-2'  => array( 'orderby', 'fake', true, 'rest_invalid_param' ),
+			'orderby default'    => array(
+				'param'    => 'orderby',
+				'value'    => false,
+				'is_error' => false,
+				'expected' => 'date',
+			),
+			'orderby custom-1'   => array(
+				'param'    => 'orderby',
+				'value'    => 'title',
+				'is_error' => false,
+				'expected' => 'title',
+			),
+			'orderby custom-2'   => array(
+				'param'    => 'orderby',
+				'value'    => 'date',
+				'is_error' => false,
+				'expected' => 'date',
+			),
+			'orderby custom-3'   => array(
+				'param'    => 'orderby',
+				'value'    => 'favorite_count',
+				'is_error' => false,
+				'expected' => 'favorite_count',
+			),
+			'orderby invalid-1'  => array(
+				'param'    => 'orderby',
+				'value'    => 10,
+				'is_error' => true,
+				'expected' => 'rest_invalid_param',
+			),
+			'orderby invalid-2'  => array(
+				'param'    => 'orderby',
+				'value'    => 'fake',
+				'is_error' => true,
+				'expected' => 'rest_invalid_param',
+			),
 		);
 	}
 

--- a/tests/phpunit/tests/rest-api/rest-pattern-directory-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-pattern-directory-controller.php
@@ -31,6 +31,15 @@ class WP_REST_Pattern_Directory_Controller_Test extends WP_Test_REST_Controller_
 	private static $controller;
 
 	/**
+	 * List of URLs captured.
+	 *
+	 * @since 6.2.0
+	 *
+	 * @var string[]
+	 */
+	protected static $http_request_urls;
+
+	/**
 	 * Set up class test fixtures.
 	 *
 	 * @since 5.8.0
@@ -44,7 +53,28 @@ class WP_REST_Pattern_Directory_Controller_Test extends WP_Test_REST_Controller_
 			)
 		);
 
+		self::$http_request_urls = array();
+
 		static::$controller = new WP_REST_Pattern_Directory_Controller();
+	}
+
+	/**
+	 * Tear down after class.
+	 *
+	 * @since 6.2.0
+	 */
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$contributor_id );
+	}
+
+	/**
+	 * Clear the captured request URLs after each test.
+	 *
+	 * @since 6.2.0
+	 */
+	public function tear_down() {
+		self::$http_request_urls = array();
+		parent::tear_down();
 	}
 
 	/**
@@ -308,6 +338,108 @@ class WP_REST_Pattern_Directory_Controller_Test extends WP_Test_REST_Controller_
 		$patterns = $response->get_data();
 
 		$this->assertSame( 'modified the cache', $patterns[0] );
+	}
+
+	/**
+	 * Tests if the provided query args are passed through to the wp.org API.
+	 *
+	 * @dataProvider data_get_items_query_args
+	 *
+	 * @covers WP_REST_Pattern_Directory_Controller::get_items
+	 *
+	 * @since 6.2.0
+	 *
+	 * @param string $param    Query parameter name (ex, page).
+	 * @param mixed  $value    Query value to test.
+	 * @param bool   $is_error Whether this value should error or not.
+	 * @param mixed  $expected Expected value (or expected error code).
+	 */
+	public function test_get_items_query_args( $param, $value, $is_error, $expected ) {
+		wp_set_current_user( self::$contributor_id );
+		self::capture_http_urls();
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/pattern-directory/patterns' );
+		if ( $value ) {
+			$request->set_query_params( array( $param => $value ) );
+		}
+
+		$response = rest_do_request( $request );
+		$data     = $response->get_data();
+		if ( $is_error ) {
+			$this->assertSame( $expected, $data['code'] );
+			$this->assertStringContainsString( $param, $data['message'] );
+		} else {
+			$this->assertCount( 1, self::$http_request_urls );
+			$this->assertStringContainsString( $param . '=' . $expected, self::$http_request_urls[0] );
+		}
+	}
+
+	/**
+	 * Data provider for test_get_items_query_args.
+	 *
+	 * @since 6.2.0
+	 */
+	public function data_get_items_query_args() {
+		return array(
+			'per_page default'   => array( 'per_page', false, false, 100 ),
+			'per_page custom-1'  => array( 'per_page', 5, false, 5 ),
+			'per_page custom-2'  => array( 'per_page', 50, false, 50 ),
+			'per_page invalid-1' => array( 'per_page', 200, true, 'rest_invalid_param' ),
+			'per_page invalid-2' => array( 'per_page', 'abc', true, 'rest_invalid_param' ),
+
+			'page default'       => array( 'page', false, false, 1 ),
+			'page custom'        => array( 'page', 5, false, 5 ),
+			'page invalid'       => array( 'page', 'abc', true, 'rest_invalid_param' ),
+
+			'offset custom'      => array( 'offset', 5, false, 5 ),
+			'offset invalid-1'   => array( 'offset', 'abc', true, 'rest_invalid_param' ),
+
+			'order default'      => array( 'order', false, false, 'desc' ),
+			'order custom'       => array( 'order', 'asc', false, 'asc' ),
+			'order invalid-1'    => array( 'order', 10, true, 'rest_invalid_param' ),
+			'order invalid-2'    => array( 'order', 'fake', true, 'rest_invalid_param' ),
+
+			'orderby default'    => array( 'orderby', false, false, 'date' ),
+			'orderby custom-1'   => array( 'orderby', 'title', false, 'title' ),
+			'orderby custom-2'   => array( 'orderby', 'date', false, 'date' ),
+			'orderby custom-3'   => array( 'orderby', 'favorite_count', false, 'favorite_count' ),
+			'orderby invalid-1'  => array( 'orderby', 10, true, 'rest_invalid_param' ),
+			'orderby invalid-2'  => array( 'orderby', 'fake', true, 'rest_invalid_param' ),
+		);
+	}
+
+	/**
+	 * Attach a filter to capture requested wp.org URL.
+	 *
+	 * @since 6.2.0
+	 */
+	private static function capture_http_urls() {
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) {
+				if ( 'api.wordpress.org' !== wp_parse_url( $url, PHP_URL_HOST ) ) {
+					return $preempt;
+				}
+
+				self::$http_request_urls[] = $url;
+
+				// Return a response to prevent external API request.
+				$response = array(
+					'headers'  => array(),
+					'response' => array(
+						'code'    => 200,
+						'message' => 'OK',
+					),
+					'body'     => '[]',
+					'cookies'  => array(),
+					'filename' => null,
+				);
+
+				return $response;
+			},
+			10,
+			3
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/rest-pattern-directory-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-pattern-directory-controller.php
@@ -343,11 +343,13 @@ class WP_REST_Pattern_Directory_Controller_Test extends WP_Test_REST_Controller_
 	/**
 	 * Tests if the provided query args are passed through to the wp.org API.
 	 *
-	 * @dataProvider data_get_items_query_args
+	 * @since 6.2.0
+	 *
+	 * @ticket 57501
 	 *
 	 * @covers WP_REST_Pattern_Directory_Controller::get_items
 	 *
-	 * @since 6.2.0
+	 * @dataProvider data_get_items_query_args
 	 *
 	 * @param string $param    Query parameter name (ex, page).
 	 * @param mixed  $value    Query value to test.

--- a/tests/phpunit/tests/rest-api/rest-pattern-directory-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-pattern-directory-controller.php
@@ -366,11 +366,11 @@ class WP_REST_Pattern_Directory_Controller_Test extends WP_Test_REST_Controller_
 		$response = rest_do_request( $request );
 		$data     = $response->get_data();
 		if ( $is_error ) {
-			$this->assertSame( $expected, $data['code'] );
-			$this->assertStringContainsString( $param, $data['message'] );
+			$this->assertSame( $expected, $data['code'], 'Response error code does not match' );
+			$this->assertStringContainsString( $param, $data['message'], 'Response error message does not match' );
 		} else {
-			$this->assertCount( 1, self::$http_request_urls );
-			$this->assertStringContainsString( $param . '=' . $expected, self::$http_request_urls[0] );
+			$this->assertCount( 1, self::$http_request_urls, 'The number of HTTP Request URLs is not 1' );
+			$this->assertStringContainsString( $param . '=' . $expected, self::$http_request_urls[0], 'The param and/or value do not match' );
 		}
 	}
 

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -10475,6 +10475,21 @@ mockedApiResponse.Schema = {
                             "default": "view",
                             "required": false
                         },
+                        "page": {
+                            "description": "Current page of the collection.",
+                            "type": "integer",
+                            "default": 1,
+                            "minimum": 1,
+                            "required": false
+                        },
+                        "per_page": {
+                            "description": "Maximum number of items to be returned in result set.",
+                            "type": "integer",
+                            "default": 100,
+                            "minimum": 1,
+                            "maximum": 100,
+                            "required": false
+                        },
                         "search": {
                             "description": "Limit results to those matching a string.",
                             "type": "string",
@@ -10496,6 +10511,40 @@ mockedApiResponse.Schema = {
                         "slug": {
                             "description": "Limit results to those matching a pattern (slug).",
                             "type": "array",
+                            "required": false
+                        },
+                        "offset": {
+                            "description": "Offset the result set by a specific number of items.",
+                            "type": "integer",
+                            "required": false
+                        },
+                        "order": {
+                            "description": "Order sort attribute ascending or descending.",
+                            "type": "string",
+                            "default": "desc",
+                            "enum": [
+                                "asc",
+                                "desc"
+                            ],
+                            "required": false
+                        },
+                        "orderby": {
+                            "description": "Sort collection by post attribute.",
+                            "type": "string",
+                            "default": "date",
+                            "enum": [
+                                "author",
+                                "date",
+                                "id",
+                                "include",
+                                "modified",
+                                "parent",
+                                "relevance",
+                                "slug",
+                                "include_slugs",
+                                "title",
+                                "favorite_count"
+                            ],
                             "required": false
                         }
                     }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/57501


Adds the 'per_page', 'page', 'offset', 'order', and 'orderby' args to WP_REST_Pattern_Directory_Controller.

GB PR: https://github.com/WordPress/gutenberg/pull/45293

--cc @hellofromtonya @ryelle 

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
