### PR TITLE
Safe style css: Add position CSS properties to support position controls in blocks

### DIFF
--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -2438,6 +2438,13 @@ function safecss_filter_attr( $css, $deprecated = '' ) {
 			'overflow',
 			'vertical-align',
 
+			'position',
+			'top',
+			'right',
+			'bottom',
+			'left',
+			'z-index',
+
 			// Custom CSS properties.
 			'--*',
 		)

--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -2277,6 +2277,7 @@ function kses_init() {
  *              nested `var()` values, and assigning values to CSS variables.
  *              Added support for `object-fit`, `gap`, `column-gap`, `row-gap`, and `flex-wrap`.
  *              Extended `margin-*` and `padding-*` support for logical properties.
+ * @since 6.2.0 Added support for `position`, `top`, `right`, `bottom`, `left` and `z-index` position CSS properties.
  *
  * @param string $css        A string of CSS rules.
  * @param string $deprecated Not used.

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -1278,6 +1278,11 @@ EOF;
 				'css'      => '--?><.%-not-allowed: red;',
 				'expected' => '',
 			),
+			// Position properties introduced in 6.2.
+			array(
+				'css'      => 'position: sticky;top: 0;left: 0;right: 0;bottom: 0;z-index: 10;',
+				'expected' => 'position: sticky;top: 0;left: 0;right: 0;bottom: 0;z-index: 10',
+			)
 		);
 	}
 

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -1282,7 +1282,7 @@ EOF;
 			array(
 				'css'      => 'position: sticky;top: 0;left: 0;right: 0;bottom: 0;z-index: 10;',
 				'expected' => 'position: sticky;top: 0;left: 0;right: 0;bottom: 0;z-index: 10',
-			)
+			),
 		);
 	}
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

This PR adds the following CSS properties to `safe_style_css` to support positioning:

* `position`
* `top`
* `right`
* `bottom`
* `left`
* `z-index`

This is a prerequisite for rolling out a feature from Gutenberg that allows container blocks (e.g. Group) to be set to a particular position (e.g. sticky or fixed). For more context, see the Gutenberg PR: https://github.com/WordPress/gutenberg/pull/46142

The goal with adding these CSS properties is to be able to support (especially in the longer term) sticky/fixed/relative/absolute positioning of blocks, a position offset (top/right/bottom/left) and which block sits ontop of another block (so that sticky/fixed blocks can sit above site or post content).

To test, ensure the tests pass, or if you're using the Docker environment for `wordpress-develop`, run the following locally: `npm run test:php /var/www/tests/phpunit/tests/kses.php`

Trac ticket: https://core.trac.wordpress.org/ticket/57504

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
