### PR TITLE
Backport Fluid Typography settings for minimum font size

### DIFF
--- a/src/wp-includes/block-supports/typography.php
+++ b/src/wp-includes/block-supports/typography.php
@@ -520,7 +520,10 @@ function wp_get_typography_font_size_value( $preset, $should_use_fluid_typograph
 		return $preset['size'];
 	}
 
-	// Parses the minimum font size limit, so we can perform checks using it.
+	/*
+	 * Normalizes the minimum font size limit according to the incoming unit,
+	 * in order to perform comparative checks.
+	 */
 	$minimum_font_size_limit = wp_get_typography_value_and_unit(
 		$default_minimum_font_size_limit,
 		array(

--- a/src/wp-includes/block-supports/typography.php
+++ b/src/wp-includes/block-supports/typography.php
@@ -453,6 +453,7 @@ function wp_get_computed_fluid_typography_value( $args = array() ) {
  *
  * @since 6.1.0
  * @since 6.1.1 Adjusted rules for min and max font sizes.
+ * @since 6.2.0 Added 'settings.typography.fluid.minFontSize' support.
  *
  * @param array $preset                     {
  *     Required. fontSizes preset value as seen in theme.json.

--- a/src/wp-includes/block-supports/typography.php
+++ b/src/wp-includes/block-supports/typography.php
@@ -553,7 +553,10 @@ function wp_get_typography_font_size_value( $preset, $should_use_fluid_typograph
 	 * the given font size multiplied by the min font size scale factor.
 	 */
 	if ( ! $minimum_font_size_raw ) {
-		$calculated_minimum_font_size = round( $preferred_size['value'] * $default_minimum_font_size_factor, 3 );
+		$calculated_minimum_font_size = round(
+			$preferred_size['value'] * $default_minimum_font_size_factor,
+			3
+		);
 
 		// Only use calculated min font size if it's > $minimum_font_size_limit value.
 		if ( ! empty( $minimum_font_size_limit ) && $calculated_minimum_font_size <= $minimum_font_size_limit['value'] ) {

--- a/src/wp-includes/block-supports/typography.php
+++ b/src/wp-includes/block-supports/typography.php
@@ -482,7 +482,7 @@ function wp_get_typography_font_size_value( $preset, $should_use_fluid_typograph
 	$typography_settings = wp_get_global_settings( array( 'typography' ) );
 	if (
 		isset( $typography_settings['fluid'] ) &&
-		( true === $typography_settings['fluid'] || is_array( $typography_settings['fluid'] )
+		( true === $typography_settings['fluid'] || is_array( $typography_settings['fluid'] ) )
 	) {
 		$should_use_fluid_typography = true;
 	}

--- a/src/wp-includes/block-supports/typography.php
+++ b/src/wp-includes/block-supports/typography.php
@@ -479,18 +479,21 @@ function wp_get_typography_font_size_value( $preset, $should_use_fluid_typograph
 	}
 
 	// Checks if fluid font sizes are activated.
-	$typography_settings         = wp_get_global_settings( array( 'typography' ) );
-	$should_use_fluid_typography =
+	$typography_settings = wp_get_global_settings( array( 'typography' ) );
+	if (
 		isset( $typography_settings['fluid'] ) &&
-		( true === $typography_settings['fluid'] || is_array( $typography_settings['fluid'] ) ) ?
-			true :
-			$should_use_fluid_typography;
+		( true === $typography_settings['fluid'] || is_array( $typography_settings['fluid'] )
+	) {
+		$should_use_fluid_typography = true;
+	}
 
 	if ( ! $should_use_fluid_typography ) {
 		return $preset['size'];
 	}
 
-	$fluid_settings = isset( $typography_settings['fluid'] ) && is_array( $typography_settings['fluid'] ) ? $typography_settings['fluid'] : array();
+	$fluid_settings = isset( $typography_settings['fluid'] ) && is_array( $typography_settings['fluid'] )
+		? $typography_settings['fluid']
+		: array();
 
 	// Defaults.
 	$default_maximum_viewport_width   = '1600px';

--- a/tests/phpunit/data/themedir1/block-theme-child-with-fluid-typography-config/style.css
+++ b/tests/phpunit/data/themedir1/block-theme-child-with-fluid-typography-config/style.css
@@ -1,0 +1,8 @@
+/*
+Theme Name: Block Theme Child Theme With Fluid Typography Config
+Theme URI: https://wordpress.org/
+Description: For testing purposes only.
+Template: block-theme
+Version: 1.0.0
+Text Domain: block-theme-child-with-fluid-typography
+*/

--- a/tests/phpunit/data/themedir1/block-theme-child-with-fluid-typography-config/theme.json
+++ b/tests/phpunit/data/themedir1/block-theme-child-with-fluid-typography-config/theme.json
@@ -1,0 +1,11 @@
+{
+	"version": 2,
+	"settings": {
+		"appearanceTools": true,
+		"typography": {
+			"fluid": {
+				"minFontSize": "16px"
+			}
+		}
+	}
+}

--- a/tests/phpunit/tests/block-supports/typography.php
+++ b/tests/phpunit/tests/block-supports/typography.php
@@ -572,16 +572,12 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_generate_block_supports_font_size_fixtures
 	 *
-	 * @param string $font_size_value             The block supports custom font size value.
-	 * @param bool   $should_use_fluid_typography An override to switch fluid typography "on". Can be used for unit testing.
-	 * @param string $expected_output             Expected value of style property from wp_apply_typography_support().
+	 * @param string $font_size_value The block supports custom font size value.
+	 * @param string $theme_slug      A theme slug corresponding to an available test theme.
+	 * @param string $expected_output Expected value of style property from wp_apply_typography_support().
 	 */
-	public function test_should_covert_font_sizes_to_fluid_values( $font_size_value, $should_use_fluid_typography, $expected_output ) {
-		if ( $should_use_fluid_typography ) {
-			switch_theme( 'block-theme-child-with-fluid-typography' );
-		} else {
-			switch_theme( 'default' );
-		}
+	public function test_should_covert_font_sizes_to_fluid_values( $font_size_value, $theme_slug, $expected_output ) {
+		switch_theme( $theme_slug );
 
 		$this->test_block_name = 'test/font-size-fluid-value';
 		register_block_type(
@@ -623,15 +619,30 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 	 */
 	public function data_generate_block_supports_font_size_fixtures() {
 		return array(
-			'default_return_value'               => array(
-				'font_size_value'             => '50px',
-				'should_use_fluid_typography' => false,
-				'expected_output'             => 'font-size:50px;',
+			'returns value when fluid typography is not active' => array(
+				'font_size_value' => '15px',
+				'theme_slug'      => 'default',
+				'expected_output' => 'font-size:15px;',
 			),
-			'return_value_with_fluid_typography' => array(
-				'font_size_value'             => '50px',
-				'should_use_fluid_typography' => true,
-				'expected_output'             => 'font-size:clamp(37.5px, 2.344rem + ((1vw - 7.68px) * 1.502), 50px);',
+			'returns clamp value using default config' => array(
+				'font_size_value' => '15px',
+				'theme_slug'      => 'block-theme-child-with-fluid-typography',
+				'expected_output' => 'font-size:clamp(14px, 0.875rem + ((1vw - 7.68px) * 0.12), 15px);',
+			),
+			'returns value when font size <= default min font size bound' => array(
+				'font_size_value' => '13px',
+				'theme_slug'      => 'block-theme-child-with-fluid-typography',
+				'expected_output' => 'font-size:13px;',
+			),
+			'returns clamp value using custom fluid config' => array(
+				'font_size_value' => '17px',
+				'theme_slug'      => 'block-theme-child-with-fluid-typography-config',
+				'expected_output' => 'font-size:clamp(16px, 1rem + ((1vw - 7.68px) * 0.12), 17px);',
+			),
+			'returns value when font size <= custom min font size bound' => array(
+				'font_size_value' => '15px',
+				'theme_slug'      => 'block-theme-child-with-fluid-typography-config',
+				'expected_output' => 'font-size:15px;',
 			),
 		);
 	}

--- a/tests/phpunit/tests/block-supports/typography.php
+++ b/tests/phpunit/tests/block-supports/typography.php
@@ -567,6 +567,7 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 	 *
 	 * @ticket 56467
 	 * @ticket 57065
+	 * @ticket 57529
 	 *
 	 * @covers ::wp_register_typography_support
 	 *

--- a/tests/phpunit/tests/theme/themeDir.php
+++ b/tests/phpunit/tests/theme/themeDir.php
@@ -180,6 +180,7 @@ class Tests_Theme_ThemeDir extends WP_UnitTestCase {
 			'Block Theme Child Theme',
 			'Block Theme Child with no theme.json',
 			'Block Theme Child Theme With Fluid Typography',
+			'Block Theme Child Theme With Fluid Typography Config',
 			'Block Theme [0.4.0]',
 			'Block Theme [1.0.0] in subdirectory',
 			'Block Theme Deprecated Path',


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

This PR backports the PHP changes in this Gutenberg PR: https://github.com/WordPress/gutenberg/pull/42489

The feature adds a `settings.typography.fluid.minFontSize` property to `theme.json` which allows themes to set a minimum font size for fluid typography calculations.

### Testing instructions

To test: edit the TT3 theme's `theme.json` file to swap out `settings.typography.fluid` from its current boolean value tor an object that specifies a minimum font size. For example, the following sets the minimum font size to 15px:

```
			"fluid": {
				"minFontSize": "15px"
			},
```

Then, in a post, create a few paragraphs and set a variety of custom font sizes. In the below screenshot of the markup, there are three paragraph blocks, set to `15px`, `16px`, and `20px` respectively. Notice how the first block does not have fluid rules applied, and for the second and third blocks, the minimum size is `15px`:

<img width="606" alt="image" src="https://user-images.githubusercontent.com/14988353/213966207-17a887a4-2159-40e9-a561-9113e1eb0ee3.png">

Note: this PR backports the PHP changes only. The update to support this feature within the block editor will be backported as part of the usual JS packages update. It should be pretty safe to land this PHP change first.

Trac ticket: https://core.trac.wordpress.org/ticket/57529

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
