### PR TITLE
Add support for passing objects to _prime_post_caches() to eliminate an unnecessary database query

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -3476,7 +3476,7 @@ class WP_Query {
 			$this->posts = array_map( 'get_post', $this->posts );
 
 			if ( $q['cache_results'] ) {
-				update_post_caches( $this->posts, $post_type, $q['update_post_term_cache'], $q['update_post_meta_cache'] );
+				_prime_post_caches( $this->posts, $q['update_post_term_cache'], $q['update_post_meta_cache'] );
 			}
 
 			/** @var WP_Post */

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -7939,7 +7939,7 @@ function _prime_post_caches( $posts, $update_term_cache = true, $update_meta_cac
 	}
 
 	if ( $update_term_cache ) {
-		$post_types = array_map( 'get_post_type', $objects );
+		$post_types = array_map( 'get_post_type', $ids );
 		$post_types = array_unique( $post_types );
 		update_object_term_cache( $ids, $post_types );
 	}

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -7875,6 +7875,7 @@ function _update_term_count_on_transition_post_status( $new_status, $old_status,
  *
  * @since 3.4.0
  * @since 6.1.0 This function is no longer marked as "private".
+ * @since 6.2.0 The first parameter can now alternatively be a list of post objects.
  *
  * @see update_post_cache()
  * @see update_postmeta_cache()
@@ -7882,16 +7883,50 @@ function _update_term_count_on_transition_post_status( $new_status, $old_status,
  *
  * @global wpdb $wpdb WordPress database abstraction object.
  *
- * @param int[] $ids               ID list.
- * @param bool  $update_term_cache Optional. Whether to update the term cache. Default true.
- * @param bool  $update_meta_cache Optional. Whether to update the meta cache. Default true.
+ * @param int[]|WP_Post[] $posts             List of post IDs or post objects.
+ * @param bool            $update_term_cache Optional. Whether to update the term cache. Default true.
+ * @param bool            $update_meta_cache Optional. Whether to update the meta cache. Default true.
  */
-function _prime_post_caches( $ids, $update_term_cache = true, $update_meta_cache = true ) {
+function _prime_post_caches( $posts, $update_term_cache = true, $update_meta_cache = true ) {
 	global $wpdb;
+
+	$ids     = array();
+	$objects = array();
+	foreach ( $posts as $post ) {
+		if ( is_object( $post ) ) {
+			$ids[]                = $post->ID;
+			$objects[ $post->ID ] = $post;
+		} else {
+			$ids[] = $post;
+		}
+	}
 
 	$non_cached_ids = _get_non_cached_ids( $ids, 'posts' );
 	if ( ! empty( $non_cached_ids ) ) {
-		$fresh_posts = $wpdb->get_results( sprintf( "SELECT $wpdb->posts.* FROM $wpdb->posts WHERE ID IN (%s)", implode( ',', $non_cached_ids ) ) );
+		$fresh_posts = array();
+
+		/*
+		 * If post objects were passed, check those first for the non cached IDs.
+		 * If post objects are present for all non cached IDs, no additional database query
+		 * needs to be made.
+		 */
+		if ( ! empty( $objects ) ) {
+			$fresh_posts  = array_intersect_key( $objects, array_flip( $non_cached_ids ) );
+			$ids_to_query = array_diff( $non_cached_ids, array_keys( $fresh_posts ) );
+			$fresh_posts  = array_values( $fresh_posts );
+		} else {
+			$ids_to_query = $non_cached_ids;
+		}
+
+		// Only make the database query if there are IDs that aren't present as objects already.
+		if ( ! empty( $ids_to_query ) ) {
+			$queried_fresh_posts = $wpdb->get_results( sprintf( "SELECT $wpdb->posts.* FROM $wpdb->posts WHERE ID IN (%s)", implode( ',', $ids_to_query ) ) );
+			if ( $queried_fresh_posts ) {
+				foreach ( $queried_fresh_posts as $post ) {
+					$fresh_posts[] = $post;
+				}
+			}
+		}
 
 		if ( $fresh_posts ) {
 			// Despite the name, update_post_cache() expects an array rather than a single post.
@@ -7904,7 +7939,7 @@ function _prime_post_caches( $ids, $update_term_cache = true, $update_meta_cache
 	}
 
 	if ( $update_term_cache ) {
-		$post_types = array_map( 'get_post_type', $ids );
+		$post_types = array_map( 'get_post_type', $objects );
 		$post_types = array_unique( $post_types );
 		update_object_term_cache( $ids, $post_types );
 	}


### PR DESCRIPTION
See https://github.com/WordPress/wordpress-develop/pull/3793#discussion_r1063023404 for the idea that led to this.

After adding caching to `WP_Query` in https://core.trac.wordpress.org/changeset/53941, the follow up change https://core.trac.wordpress.org/changeset/54352 aimed to eliminate excessive cache writes by relying on `_prime_post_caches()`, to only refresh those caches for posts that are not in cache yet. That on the other hand resulted in an additional database query, since `_prime_post_caches()` only supports being passed IDs, which led to a partial revert in https://core.trac.wordpress.org/changeset/55035.

This changeset restores the state in https://core.trac.wordpress.org/changeset/54352 in a way that avoids both the excessive cache writes and the additional database query. It does so by adding support for passing post objects to `_prime_post_caches()`: The first parameter can now be either an array of post IDs or an array of post objects.

The test modified in https://core.trac.wordpress.org/changeset/55035 still passing shows that this is working as expected.

Trac ticket: https://core.trac.wordpress.org/ticket/57498

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
