### PR TITLE
Trac 56975 Stub functions in noop and restore caching

### DIFF
--- a/src/wp-admin/includes/noop.php
+++ b/src/wp-admin/includes/noop.php
@@ -104,3 +104,19 @@ function get_file( $path ) {
 
 	return @file_get_contents( $path );
 }
+
+/**
+ * @ignore
+ * @since 6.2.0
+ */
+function wp_cache_get() {
+	return false;
+}
+
+/**
+ * @ignore
+ * @since 6.2.0
+ */
+function wp_cache_set() {
+	return false;
+}

--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -264,6 +264,42 @@ function wp_add_global_styles_for_blocks() {
  * @return bool Returns true if theme or its parent has a theme.json file, false otherwise.
  */
 function wp_theme_has_theme_json() {
+	/*
+	 * By using the 'theme_json' group, this data is marked to be non-persistent across requests.
+	 * @see `wp_cache_add_non_persistent_groups()`.
+	 *
+	 * The rationale for this is to make sure derived data from theme.json
+	 * is always fresh from the potential modifications done via hooks
+	 * that can use dynamic data (modify the stylesheet depending on some option,
+	 * settings depending on user permissions, etc.).
+	 * For some of the existing hooks to modify theme.json behavior:
+	 * @see https://make.wordpress.org/core/2022/10/10/filters-for-theme-json-data/
+	 *
+	 * A different alternative considered was to invalidate the cache upon certain
+	 * events such as options add/update/delete, user meta, etc.
+	 * It was judged not enough, hence this approach.
+	 * @see https://github.com/WordPress/gutenberg/pull/45372
+	 */
+	$cache_group       = 'theme_json';
+	$cache_key         = 'wp_theme_has_theme_json';
+	$theme_has_support = wp_cache_get( $cache_key, $cache_group );
+
+	/*
+	 * $theme_has_support is stored as an int in the cache.
+	 *
+	 * The reason not to store it as a boolean is to avoid working
+	 * with the $found parameter which apparently had some issues in some implementations
+	 * @see https://developer.wordpress.org/reference/functions/wp_cache_get/
+	 *
+	 * Ignore cache when `WP_DEBUG` is enabled, so it doesn't interfere with the theme
+	 * developer's workflow.
+	 *
+	 * @todo Replace `WP_DEBUG` once an "in development mode" check is available in Core.
+	 */
+	if ( ! WP_DEBUG && is_int( $theme_has_support ) ) {
+		return (bool) $theme_has_support;
+	}
+
 	// Does the theme have its own theme.json?
 	$theme_has_support = is_readable( get_stylesheet_directory() . '/theme.json' );
 
@@ -272,7 +308,11 @@ function wp_theme_has_theme_json() {
 		$theme_has_support = is_readable( get_template_directory() . '/theme.json' );
 	}
 
-	return $theme_has_support;
+	$theme_has_support = $theme_has_support ? 1 : 0;
+
+	wp_cache_set( $cache_key, $theme_has_support, $cache_group );
+
+	return (bool) $theme_has_support;
 }
 
 /**
@@ -281,5 +321,7 @@ function wp_theme_has_theme_json() {
  * @since 6.2.0
  */
 function wp_clean_theme_json_cache() {
+	wp_cache_delete( 'wp_theme_has_theme_json', 'theme_json' );
+
 	WP_Theme_JSON_Resolver::clean_cached_data();
 }

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -753,7 +753,7 @@ function wp_start_object_cache() {
 			)
 		);
 
-		wp_cache_add_non_persistent_groups( array( 'counts', 'plugins' ) );
+		wp_cache_add_non_persistent_groups( array( 'counts', 'plugins', 'theme_json' ) );
 	}
 
 	$first_init = false;

--- a/src/wp-includes/ms-blogs.php
+++ b/src/wp-includes/ms-blogs.php
@@ -575,7 +575,7 @@ function switch_to_blog( $new_blog_id, $deprecated = null ) {
 				);
 			}
 
-			wp_cache_add_non_persistent_groups( array( 'counts', 'plugins' ) );
+			wp_cache_add_non_persistent_groups( array( 'counts', 'plugins', 'theme_json' ) );
 		}
 	}
 
@@ -666,7 +666,7 @@ function restore_current_blog() {
 				);
 			}
 
-			wp_cache_add_non_persistent_groups( array( 'counts', 'plugins' ) );
+			wp_cache_add_non_persistent_groups( array( 'counts', 'plugins', 'theme_json' ) );
 		}
 	}
 

--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -401,7 +401,7 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 			)
 		);
 
-		wp_cache_add_non_persistent_groups( array( 'counts', 'plugins' ) );
+		wp_cache_add_non_persistent_groups( array( 'counts', 'plugins', 'theme_json' ) );
 	}
 
 	/**


### PR DESCRIPTION
Option 2:  Stubbing the functions in `wp-admin/includes/noop.php`:

As detailed in the trac ticket, this PR implements option 2 to prevent the fatal error due to `load-styles.php` only loading a very small subset of WordPress, thus not having the `wp_cache_*()` functions available.

This PR:
* Stubs `wp_cache_get()` and `wp_cache_set()` returning their failure state.
* Restores the reverted caching code from PR #3556 ([reverted in r55092](https://core.trac.wordpress.org/changeset/55092).

How to test:
* Add the following to `wp-config.php`:
```php
define( 'CONCATENATE_SCRIPTS', true );
define( 'WP_DEBUG', false );
define( 'SCRIPT_DEBUG', false );
```
* Load WP Admin, which will then load `load-styles.php` as a CSS file. 

Trac ticket: https://core.trac.wordpress.org/ticket/56975

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
