### PR TITLE
Twenty Seventeen: Image Block captions are Italic on frontend but not…

### DIFF
--- a/src/wp-content/themes/twentyseventeen/assets/css/blocks.css
+++ b/src/wp-content/themes/twentyseventeen/assets/css/blocks.css
@@ -21,7 +21,7 @@ Description: Used to style blocks.
 /* Captions */
 
 [class^="wp-block-"]:not(.wp-block-gallery) figcaption {
-	font-style: italic;
+	font-style: normal;
 	margin-bottom: 1.5em;
 	text-align: left;
 }
@@ -30,6 +30,11 @@ Description: Used to style blocks.
 	text-align: right;
 }
 
+[class^="wp-block-"]:not(.wp-block-gallery) figcaption cite,
+[class^="wp-block-"]:not(.wp-block-gallery) figcaption em,
+[class^="wp-block-"]:not(.wp-block-gallery) figcaption i {
+	font-style: italic;
+}
 /*--------------------------------------------------------------
 2.0 Blocks - Common Blocks
 --------------------------------------------------------------*/

--- a/src/wp-content/themes/twentyseventeen/assets/css/editor-blocks.css
+++ b/src/wp-content/themes/twentyseventeen/assets/css/editor-blocks.css
@@ -460,16 +460,26 @@ html[lang="th"] .edit-post-visual-editor * {
 
 /* Caption styles*/
 
-[class^="wp-block-"]:not(.wp-block-gallery) figcaption {
-	font-style: italic;
+[class^="wp-block-"]:not(.wp-block-gallery) figcaption,
+[class*=" wp-block-"]:not(.wp-block-gallery) figcaption {
+	font-style: normal;
 	margin-bottom: 1.5em;
 	text-align: left;
+
 }
 
 .rtl [class^="wp-block-"]:not(.wp-block-gallery) figcaption {
 	text-align: right;
 }
 
+[class^="wp-block-"]:not(.wp-block-gallery) figcaption cite,
+[class*=" wp-block-"]:not(.wp-block-gallery) figcaption cite,
+[class^="wp-block-"]:not(.wp-block-gallery) figcaption em,
+[class*=" wp-block-"]:not(.wp-block-gallery) figcaption em,
+[class^="wp-block-"]:not(.wp-block-gallery) figcaption i,
+[class*=" wp-block-"]:not(.wp-block-gallery) figcaption i {
+	font-style: italic;
+}
 /* Code styles */
 
 .wp-block-freeform.block-library-rich-text__tinymce code {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
In the editor, if the 'I' option is selected, the caption text should appear in italics. If the 'I' option is not selected, the caption text should appear in its normal font. However, it appears that in the previous patch, this behavior is reversed. in this patch the reversed issue has been fixed. 

Trac ticket: [56747](https://core.trac.wordpress.org/ticket/56747)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
