### PR TITLE
Migrate patten categories

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-patterns-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-patterns-controller.php
@@ -122,10 +122,10 @@ class WP_REST_Block_Patterns_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Migrates old core pattern categories to new ones.
+	 * Migrates old core pattern categories to the new categories.
 	 *
-	 * Core pattern categories are being revamped and we need to handle the migration
-	 * to the new ones and ensure backwards compatibility.
+	 * Core pattern categories are revamped. Migration is needed to ensure
+	 * backwards compatibility.
 	 *
 	 * @since 6.2.0
 	 *
@@ -133,13 +133,21 @@ class WP_REST_Block_Patterns_Controller extends WP_REST_Controller {
 	 * @return array Migrated pattern.
 	 */
 	protected function migrate_pattern_categories( $pattern ) {
-		if ( isset( $pattern['categories'] ) && is_array( $pattern['categories'] ) ) {
-			foreach ( $pattern['categories'] as $i => $category ) {
-				if ( array_key_exists( $category, static::$categories_migration ) ) {
-					$pattern['categories'][ $i ] = static::$categories_migration[ $category ];
-				}
+		// No categories to migrate.
+		if (
+			! isset( $pattern['categories'] ) ||
+			! is_array( $pattern['categories'] )
+		) {
+			return $pattern;
+		}
+
+		foreach ( $pattern['categories'] as $index => $category ) {
+			// If the category exists as a key, then it needs migration.
+			if ( isset( static::$categories_migration[ $category ] ) ) {
+				$pattern['categories'][ $index ] = static::$categories_migration[ $category ];
 			}
 		}
+
 		return $pattern;
 	}
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-patterns-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-patterns-controller.php
@@ -25,6 +25,18 @@ class WP_REST_Block_Patterns_Controller extends WP_REST_Controller {
 	private $remote_patterns_loaded;
 
 	/**
+	 * An array that maps old categories names to new ones.
+	 *
+	 * @since 6.2.0
+	 * @var array
+	 */
+	protected static $categories_migration = array(
+		'buttons' => 'call-to-action',
+		'columns' => 'text',
+		'query'   => 'posts',
+	);
+
+	/**
 	 * Constructs the controller.
 	 *
 	 * @since 6.0.0
@@ -84,6 +96,7 @@ class WP_REST_Block_Patterns_Controller extends WP_REST_Controller {
 	 * Retrieves all block patterns.
 	 *
 	 * @since 6.0.0
+	 * @since 6.2.0 Added migration for old core pattern categories to the new ones.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
@@ -101,10 +114,33 @@ class WP_REST_Block_Patterns_Controller extends WP_REST_Controller {
 		$response = array();
 		$patterns = WP_Block_Patterns_Registry::get_instance()->get_all_registered();
 		foreach ( $patterns as $pattern ) {
-			$prepared_pattern = $this->prepare_item_for_response( $pattern, $request );
+			$migrated_pattern = $this->migrate_pattern_categories( $pattern );
+			$prepared_pattern = $this->prepare_item_for_response( $migrated_pattern, $request );
 			$response[]       = $this->prepare_response_for_collection( $prepared_pattern );
 		}
 		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Migrates old core pattern categories to new ones.
+	 *
+	 * Core pattern categories are being revamped and we need to handle the migration
+	 * to the new ones and ensure backwards compatibility.
+	 *
+	 * @since 6.2.0
+	 *
+	 * @param array $pattern Raw pattern as registered, before applying any changes.
+	 * @return array Migrated pattern.
+	 */
+	protected function migrate_pattern_categories( $pattern ) {
+		if ( isset( $pattern['categories'] ) && is_array( $pattern['categories'] ) ) {
+			foreach ( $pattern['categories'] as $i => $category ) {
+				if ( array_key_exists( $category, static::$categories_migration ) ) {
+					$pattern['categories'][ $i ] = static::$categories_migration[ $category ];
+				}
+			}
+		}
+		return $pattern;
 	}
 
 	/**


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/57532

This PR adds the pattern categories migration in WP_REST_Block_Patterns_Controller.
Related GB PR: https://github.com/WordPress/gutenberg/pull/46144.
Part of the GB PR was merged in this changeset: https://core.trac.wordpress.org/changeset/55098

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
