### PR TITLE
Add preload paths for media categories

### DIFF
--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -72,6 +72,9 @@ $preload_paths = array(
 	sprintf( '%s/autosaves?context=edit', $rest_path ),
 	'/wp/v2/settings',
 	array( '/wp/v2/settings', 'OPTIONS' ),
+	'/wp/v2/media?context=edit&per_page=1&orderBy=date&media_type=image',
+	'/wp/v2/media?context=edit&per_page=1&orderBy=date&media_type=video',
+	'/wp/v2/media?context=edit&per_page=1&orderBy=date&media_type=audio',
 );
 
 block_editor_rest_api_preload( $preload_paths, $block_editor_context );

--- a/src/wp-admin/site-editor.php
+++ b/src/wp-admin/site-editor.php
@@ -113,6 +113,9 @@ $preload_paths           = array(
 	'/wp/v2/global-styles/' . $active_global_styles_id . '?context=edit',
 	'/wp/v2/global-styles/' . $active_global_styles_id,
 	'/wp/v2/global-styles/themes/' . $active_theme,
+	'/wp/v2/media?context=edit&per_page=1&orderBy=date&media_type=image',
+	'/wp/v2/media?context=edit&per_page=1&orderBy=date&media_type=video',
+	'/wp/v2/media?context=edit&per_page=1&orderBy=date&media_type=audio',
 );
 
 block_editor_rest_api_preload( $preload_paths, $block_editor_context );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/57533

This PR adds the new preload paths for the inserter media categories for post and site editors.
Related GB PR: https://github.com/WordPress/gutenberg/pull/46251

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
