### PR TITLE
55840: Display custom images size's name when editing a media

### DIFF
--- a/src/wp-admin/includes/image-edit.php
+++ b/src/wp-admin/includes/image-edit.php
@@ -271,9 +271,7 @@ function wp_image_editor( $post_id, $msg = false ) {
 					?>
 					<span class="imgedit-label">
 						<input type="radio" id="imgedit-target-custom<?php echo esc_attr( $key ); ?>" name="imgedit-target-<?php echo $post_id; ?>" value="<?php echo esc_attr( $size ); ?>" />
-						<label for="imgedit-target-custom<?php echo esc_attr( $key ); ?>">
-							<?php echo isset( $image_size_names[ $size ] ) ? esc_html( $image_size_names[ $size ] ) : esc_html( $size ); ?>
-						</label>
+						<label for="imgedit-target-custom<?php echo esc_attr( $key ); ?>"><?php echo esc_html( isset( $image_size_names[ $size ] ) ? $image_size_names[ $size ] : $size ); ?></label>
 					</span>
 					<?php
 				}

--- a/src/wp-admin/includes/image-edit.php
+++ b/src/wp-admin/includes/image-edit.php
@@ -255,12 +255,12 @@ function wp_image_editor( $post_id, $msg = false ) {
 
 			/** This filter is documented in wp-admin/includes/media.php */
 			$image_size_names = apply_filters(
-					'image_size_names_choose',
-					array(
-							'medium'       => __( 'Medium' ),
-							'medium_large' => __( 'Medium Large' ),
-							'large'        => __( 'Large' ),
-					)
+				'image_size_names_choose',
+				array(
+					'medium'       => __( 'Medium' ),
+					'medium_large' => __( 'Medium Large' ),
+					'large'        => __( 'Large' ),
+				)
 			);
 
 			foreach ( array_unique( $edit_custom_sizes ) as $key => $size ) {

--- a/src/wp-admin/includes/image-edit.php
+++ b/src/wp-admin/includes/image-edit.php
@@ -252,6 +252,17 @@ function wp_image_editor( $post_id, $msg = false ) {
 			if ( ! is_array( $edit_custom_sizes ) ) {
 				$edit_custom_sizes = get_intermediate_image_sizes();
 			}
+
+			/** This filter is documented in wp-admin/includes/media.php */
+			$image_size_names = apply_filters(
+					'image_size_names_choose',
+					array(
+							'medium'       => __( 'Medium' ),
+							'medium_large' => __( 'Medium Large' ),
+							'large'        => __( 'Large' ),
+					)
+			);
+
 			foreach ( array_unique( $edit_custom_sizes ) as $key => $size ) {
 				if ( array_key_exists( $size, $meta['sizes'] ) ) {
 					if ( 'thumbnail' === $size ) {
@@ -260,7 +271,9 @@ function wp_image_editor( $post_id, $msg = false ) {
 					?>
 					<span class="imgedit-label">
 						<input type="radio" id="imgedit-target-custom<?php echo esc_attr( $key ); ?>" name="imgedit-target-<?php echo $post_id; ?>" value="<?php echo esc_attr( $size ); ?>" />
-						<label for="imgedit-target-custom<?php echo esc_attr( $key ); ?>"><?php echo esc_html( $size ); ?></label>
+						<label for="imgedit-target-custom<?php echo esc_attr( $key ); ?>">
+							<?php echo isset( $image_size_names[ $size ] ) ? esc_html( $image_size_names[ $size ] ) : esc_html( $size ); ?>
+						</label>
 					</span>
 					<?php
 				}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Trac ticket: https://core.trac.wordpress.org/ticket/55840

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
