### PR TITLE
Site Health: Check that the fatal error handler is enabled before initializing recovery mode.

### DIFF
--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -434,7 +434,7 @@ wp_start_scraping_edited_file_errors();
 // Register the default theme directory root.
 register_theme_directory( get_theme_root() );
 
-if ( ! is_multisite() ) {
+if ( ! is_multisite() && wp_is_fatal_error_handler_enabled() ) {
 	// Handle users requesting a recovery mode link and initiating recovery mode.
 	wp_recovery_mode()->initialize();
 }


### PR DESCRIPTION
This PR adds a `wp_is_fatal_error_handler_enabled()` condition before initializing recovery mode.

Trac ticket: https://core.trac.wordpress.org/ticket/56848
