### PR TITLE
Remove get_default_block_editor_settings from theme JSON resolver

### DIFF
--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -216,13 +216,6 @@ function get_default_block_editor_settings() {
 		'allowedMimeTypes'                 => get_allowed_mime_types(),
 		'defaultEditorStyles'              => $default_editor_styles,
 		'blockCategories'                  => get_default_block_categories(),
-		'disableCustomColors'              => get_theme_support( 'disable-custom-colors' ),
-		'disableCustomFontSizes'           => get_theme_support( 'disable-custom-font-sizes' ),
-		'disableCustomGradients'           => get_theme_support( 'disable-custom-gradients' ),
-		'disableLayoutStyles'              => get_theme_support( 'disable-layout-styles' ),
-		'enableCustomLineHeight'           => get_theme_support( 'custom-line-height' ),
-		'enableCustomSpacing'              => get_theme_support( 'custom-spacing' ),
-		'enableCustomUnits'                => get_theme_support( 'custom-units' ),
 		'isRTL'                            => is_rtl(),
 		'imageDefaultSize'                 => $image_default_size,
 		'imageDimensions'                  => $image_dimensions,
@@ -233,23 +226,9 @@ function get_default_block_editor_settings() {
 		'__unstableGalleryWithImageBlocks' => true,
 	);
 
-	// Theme settings.
-	$color_palette = current( (array) get_theme_support( 'editor-color-palette' ) );
-	if ( false !== $color_palette ) {
-		$editor_settings['colors'] = $color_palette;
-	}
+	$theme_settings = get_legacy_theme_supports_block_editor_settings();
 
-	$font_sizes = current( (array) get_theme_support( 'editor-font-sizes' ) );
-	if ( false !== $font_sizes ) {
-		$editor_settings['fontSizes'] = $font_sizes;
-	}
-
-	$gradient_presets = current( (array) get_theme_support( 'editor-gradient-presets' ) );
-	if ( false !== $gradient_presets ) {
-		$editor_settings['gradients'] = $gradient_presets;
-	}
-
-	return $editor_settings;
+	return array_merge( $editor_settings, $theme_settings );
 }
 
 /**
@@ -693,4 +672,41 @@ function get_block_editor_theme_styles() {
 	}
 
 	return $styles;
+}
+
+/**
+ * Returns the legacy theme supports settings for block editor.
+ *
+ * @since 6.2.0
+ *
+ * @return array The legacy theme supports settings.
+ */
+function get_legacy_theme_supports_block_editor_settings() {
+	$theme_settings = array(
+		'disableCustomColors'    => get_theme_support( 'disable-custom-colors' ),
+		'disableCustomFontSizes' => get_theme_support( 'disable-custom-font-sizes' ),
+		'disableCustomGradients' => get_theme_support( 'disable-custom-gradients' ),
+		'disableLayoutStyles'    => get_theme_support( 'disable-layout-styles' ),
+		'enableCustomLineHeight' => get_theme_support( 'custom-line-height' ),
+		'enableCustomSpacing'    => get_theme_support( 'custom-spacing' ),
+		'enableCustomUnits'      => get_theme_support( 'custom-units' ),
+	);
+
+	// Theme settings.
+	$color_palette = current( (array) get_theme_support( 'editor-color-palette' ) );
+	if ( false !== $color_palette ) {
+		$theme_settings['colors'] = $color_palette;
+	}
+
+	$font_sizes = current( (array) get_theme_support( 'editor-font-sizes' ) );
+	if ( false !== $font_sizes ) {
+		$theme_settings['fontSizes'] = $font_sizes;
+	}
+
+	$gradient_presets = current( (array) get_theme_support( 'editor-gradient-presets' ) );
+	if ( false !== $gradient_presets ) {
+		$theme_settings['gradients'] = $gradient_presets;
+	}
+
+	return $theme_settings;
 }

--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -226,9 +226,12 @@ function get_default_block_editor_settings() {
 		'__unstableGalleryWithImageBlocks' => true,
 	);
 
-	$theme_settings = get_legacy_theme_supports_block_editor_settings();
+	$theme_settings = get_classic_theme_supports_block_editor_settings();
+	foreach ( $theme_settings as $key => $value ) {
+		$editor_settings[ $key ] = $value;
+	}
 
-	return array_merge( $editor_settings, $theme_settings );
+	return $editor_settings;
 }
 
 /**
@@ -675,13 +678,13 @@ function get_block_editor_theme_styles() {
 }
 
 /**
- * Returns the legacy theme supports settings for block editor.
+ * Returns the classic theme supports settings for block editor.
  *
  * @since 6.2.0
  *
- * @return array The legacy theme supports settings.
+ * @return array The classic theme supports settings.
  */
-function get_legacy_theme_supports_block_editor_settings() {
+function get_classic_theme_supports_block_editor_settings() {
 	$theme_settings = array(
 		'disableCustomColors'    => get_theme_support( 'disable-custom-colors' ),
 		'disableCustomFontSizes' => get_theme_support( 'disable-custom-font-sizes' ),

--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -286,7 +286,7 @@ class WP_Theme_JSON_Resolver {
 		 * So we take theme supports, transform it to theme.json shape
 		 * and merge the static::$theme upon that.
 		 */
-		$theme_support_data = WP_Theme_JSON::get_from_editor_settings( get_default_block_editor_settings() );
+		$theme_support_data = WP_Theme_JSON::get_from_editor_settings( get_legacy_theme_supports_block_editor_settings() );
 		if ( ! wp_theme_has_theme_json() ) {
 			if ( ! isset( $theme_support_data['settings']['color'] ) ) {
 				$theme_support_data['settings']['color'] = array();

--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -286,7 +286,7 @@ class WP_Theme_JSON_Resolver {
 		 * So we take theme supports, transform it to theme.json shape
 		 * and merge the static::$theme upon that.
 		 */
-		$theme_support_data = WP_Theme_JSON::get_from_editor_settings( get_legacy_theme_supports_block_editor_settings() );
+		$theme_support_data = WP_Theme_JSON::get_from_editor_settings( get_classic_theme_supports_block_editor_settings() );
 		if ( ! wp_theme_has_theme_json() ) {
 			if ( ! isset( $theme_support_data['settings']['color'] ) ) {
 				$theme_support_data['settings']['color'] = array();

--- a/tests/phpunit/tests/blocks/editor.php
+++ b/tests/phpunit/tests/blocks/editor.php
@@ -569,6 +569,42 @@ class Tests_Blocks_Editor extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 57547
+	 */
+	public function test_get_classic_theme_supports_block_editor_settings() {
+		$font_sizes = array(
+			array(
+				'name' => 'Small',
+				'size' => 12,
+				'slug' => 'small',
+			),
+			array(
+				'name' => 'Regular',
+				'size' => 16,
+				'slug' => 'regular',
+			),
+		);
+
+		add_theme_support( 'editor-font-sizes', $font_sizes );
+		$settings = get_classic_theme_supports_block_editor_settings();
+
+		$this->assertFalse( $settings['disableCustomColors'] );
+		$this->assertFalse( $settings['disableCustomFontSizes'] );
+		$this->assertFalse( $settings['disableCustomGradients'] );
+		$this->assertFalse( $settings['disableLayoutStyles'] );
+		$this->assertFalse( $settings['enableCustomLineHeight'] );
+		$this->assertFalse( $settings['enableCustomSpacing'] );
+		$this->assertFalse( $settings['enableCustomUnits'] );
+
+		$this->assertSame(
+			$font_sizes,
+			$settings['fontSizes']
+		);
+
+		remove_theme_support( 'editor-font-sizes' );
+	}
+
+	/**
 	 * Data provider.
 	 *
 	 * @return array

--- a/tests/phpunit/tests/blocks/editor.php
+++ b/tests/phpunit/tests/blocks/editor.php
@@ -570,6 +570,8 @@ class Tests_Blocks_Editor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 57547
+	 *
+	 * @covers ::get_classic_theme_supports_block_editor_settings
 	 */
 	public function test_get_classic_theme_supports_block_editor_settings() {
 		$font_sizes = array(
@@ -589,17 +591,18 @@ class Tests_Blocks_Editor extends WP_UnitTestCase {
 		$settings = get_classic_theme_supports_block_editor_settings();
 		remove_theme_support( 'editor-font-sizes' );
 
-		$this->assertFalse( $settings['disableCustomColors'] );
-		$this->assertFalse( $settings['disableCustomFontSizes'] );
-		$this->assertFalse( $settings['disableCustomGradients'] );
-		$this->assertFalse( $settings['disableLayoutStyles'] );
-		$this->assertFalse( $settings['enableCustomLineHeight'] );
-		$this->assertFalse( $settings['enableCustomSpacing'] );
-		$this->assertFalse( $settings['enableCustomUnits'] );
+		$this->assertFalse( $settings['disableCustomColors'], 'Value for array key "disableCustomColors" does not match expectations' );
+		$this->assertFalse( $settings['disableCustomFontSizes'], 'Value for array key "disableCustomFontSizes" does not match expectations' );
+		$this->assertFalse( $settings['disableCustomGradients'], 'Value for array key "disableCustomGradients" does not match expectations' );
+		$this->assertFalse( $settings['disableLayoutStyles'], 'Value for array key "disableLayoutStyles" does not match expectations' );
+		$this->assertFalse( $settings['enableCustomLineHeight'], 'Value for array key "enableCustomLineHeight" does not match expectations' );
+		$this->assertFalse( $settings['enableCustomSpacing'], 'Value for array key "enableCustomSpacing" does not match expectations' );
+		$this->assertFalse( $settings['enableCustomUnits'], 'Value for array key "enableCustomUnits" does not match expectations' );
 
 		$this->assertSame(
 			$font_sizes,
-			$settings['fontSizes']
+			$settings['fontSizes'],
+			'Value for array key "fontSizes" does not match expectations'
 		);
 	}
 

--- a/tests/phpunit/tests/blocks/editor.php
+++ b/tests/phpunit/tests/blocks/editor.php
@@ -587,6 +587,7 @@ class Tests_Blocks_Editor extends WP_UnitTestCase {
 
 		add_theme_support( 'editor-font-sizes', $font_sizes );
 		$settings = get_classic_theme_supports_block_editor_settings();
+		remove_theme_support( 'editor-font-sizes' );
 
 		$this->assertFalse( $settings['disableCustomColors'] );
 		$this->assertFalse( $settings['disableCustomFontSizes'] );
@@ -600,8 +601,6 @@ class Tests_Blocks_Editor extends WP_UnitTestCase {
 			$font_sizes,
 			$settings['fontSizes']
 		);
-
-		remove_theme_support( 'editor-font-sizes' );
 	}
 
 	/**

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -2645,7 +2645,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 	 */
 	public function test_get_editor_settings_custom_units_can_be_disabled() {
 		add_theme_support( 'custom-units', array() );
-		$actual = WP_Theme_JSON::get_from_editor_settings( get_default_block_editor_settings() );
+		$actual = WP_Theme_JSON::get_from_editor_settings( get_legacy_theme_supports_block_editor_settings() );
 		remove_theme_support( 'custom-units' );
 
 		$expected = array(
@@ -2662,7 +2662,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 	 */
 	public function test_get_editor_settings_custom_units_can_be_enabled() {
 		add_theme_support( 'custom-units' );
-		$actual = WP_Theme_JSON::get_from_editor_settings( get_default_block_editor_settings() );
+		$actual = WP_Theme_JSON::get_from_editor_settings( get_legacy_theme_supports_block_editor_settings() );
 		remove_theme_support( 'custom-units' );
 
 		$expected = array(
@@ -2679,7 +2679,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 	 */
 	public function test_get_editor_settings_custom_units_can_be_filtered() {
 		add_theme_support( 'custom-units', 'rem', 'em' );
-		$actual = WP_Theme_JSON::get_from_editor_settings( get_default_block_editor_settings() );
+		$actual = WP_Theme_JSON::get_from_editor_settings( get_legacy_theme_supports_block_editor_settings() );
 		remove_theme_support( 'custom-units' );
 
 		$expected = array(

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -2645,7 +2645,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 	 */
 	public function test_get_editor_settings_custom_units_can_be_disabled() {
 		add_theme_support( 'custom-units', array() );
-		$actual = WP_Theme_JSON::get_from_editor_settings( get_legacy_theme_supports_block_editor_settings() );
+		$actual = WP_Theme_JSON::get_from_editor_settings( get_classic_theme_supports_block_editor_settings() );
 		remove_theme_support( 'custom-units' );
 
 		$expected = array(
@@ -2662,7 +2662,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 	 */
 	public function test_get_editor_settings_custom_units_can_be_enabled() {
 		add_theme_support( 'custom-units' );
-		$actual = WP_Theme_JSON::get_from_editor_settings( get_legacy_theme_supports_block_editor_settings() );
+		$actual = WP_Theme_JSON::get_from_editor_settings( get_classic_theme_supports_block_editor_settings() );
 		remove_theme_support( 'custom-units' );
 
 		$expected = array(
@@ -2679,7 +2679,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 	 */
 	public function test_get_editor_settings_custom_units_can_be_filtered() {
 		add_theme_support( 'custom-units', 'rem', 'em' );
-		$actual = WP_Theme_JSON::get_from_editor_settings( get_legacy_theme_supports_block_editor_settings() );
+		$actual = WP_Theme_JSON::get_from_editor_settings( get_classic_theme_supports_block_editor_settings() );
 		remove_theme_support( 'custom-units' );
 
 		$expected = array(


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/57547
Gutenberg PR: https://github.com/WordPress/gutenberg/pull/46112

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
