### PR TITLE
Add inert polyfill to iframe

### DIFF
--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -316,7 +316,9 @@ function get_legacy_widget_block_editor_settings() {
 function _wp_get_iframed_editor_assets() {
 	global $pagenow;
 
-	$script_handles = array();
+	$script_handles = array(
+		'wp-polyfill',
+	);
 	$style_handles  = array(
 		'wp-block-editor',
 		'wp-block-library',


### PR DESCRIPTION
Trac ticket https://core.trac.wordpress.org/ticket/57552

Related Gutenberg PR: https://github.com/WordPress/gutenberg/pull/47398

This PR injects the inert polyfill script for Firefox into the iframe editor instance as well. When you open the site editor, you will see that three new scripts have been added, as shown below:

![script](https://user-images.githubusercontent.com/54422211/214575460-2dcd9c2f-96c4-45cb-942f-17b22eb277fa.png)

@Mamaduka @ntsekouras @youknowriad 