### PR TITLE
Use the correct variable name for the new feature declaration

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -2111,7 +2111,7 @@ class WP_Theme_JSON {
 					// support features use the same custom selector.
 					if ( isset( $feature_declarations[ $feature_selector ] ) ) {
 						foreach ( $new_feature_declarations as $new_feature_declaration ) {
-							$feature_declarations[ $feature_selector ][] = $feature_declaration;
+							$feature_declarations[ $feature_selector ][] = $new_feature_declaration;
 						}
 					} else {
 						$feature_declarations[ $feature_selector ] = $new_feature_declarations;


### PR DESCRIPTION
PR fixes a small regression after [54805](https://core.trac.wordpress.org/changeset/54805), where an incorrect variable was used inside the loop.

Trac ticket: https://core.trac.wordpress.org/ticket/57067

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
