### PR TITLE
Remove unused wp-nux css dependencies.

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1663,12 +1663,10 @@ function wp_default_styles( $styles ) {
 			'wp-editor',
 			'wp-edit-blocks',
 			'wp-block-library',
-			'wp-nux',
 		),
 		'editor'               => array(
 			'wp-components',
 			'wp-block-editor',
-			'wp-nux',
 			'wp-reusable-blocks',
 		),
 		'format-library'       => array(),


### PR DESCRIPTION
Alternative approach to PR https://github.com/WordPress/wordpress-develop/pull/3775 for deprecating nux https://github.com/WordPress/gutenberg/pull/46110

In the discussion for the original pull request, it seems the `wp-edit-post` and `wp-editor` styles no longer require the `wp-nux` css file as a dependency.

This removes the CSS dependencies while retaining the JavaScript to ensure JavaScript continues to function for extenders still using the nux package. As the styles are not needed, this will see a small performance gain for most WordPress installs.

Trac tickets:
* https://core.trac.wordpress.org/ticket/57643
* https://core.trac.wordpress.org/ticket/57827