### PR TITLE
Switch copy_dir() with move_dir() in WP_Upgrader::install_package()

### DIFF
--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -604,7 +604,7 @@ class WP_Upgrader {
 		 * Therefore, copy_dir() should be used.
 		 */
 		if ( $clear_destination && $args['clear_working'] ) {
-			$result = move_dir( $source, $remote_destination, true );
+			$result = move_dir( $source, $remote_destination );
 		} else {
 			$result = copy_dir( $source, $remote_destination );
 		}

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -593,8 +593,8 @@ class WP_Upgrader {
 			}
 		}
 
-		// Copy new version of item into place.
-		$result = copy_dir( $source, $remote_destination );
+		// Move new version of directory into place.
+		$result = move_dir( $source, $remote_destination, true );
 
 		// Clear the working folder?
 		if ( $args['clear_working'] ) {

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -604,7 +604,7 @@ class WP_Upgrader {
 		 * Therefore, copy_dir() should be used.
 		 */
 		if ( $clear_destination && $args['clear_working'] ) {
-			$result = move_dir( $source, $remote_destination );
+			$result = move_dir( $source, $remote_destination, true );
 		} else {
 			$result = copy_dir( $source, $remote_destination );
 		}

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -429,6 +429,7 @@ class WP_Upgrader {
 	 * clear out the destination folder if it already exists.
 	 *
 	 * @since 2.8.0
+	 * @since 6.2.0 Switch from using copy_dir() to move_dir().
 	 *
 	 * @global WP_Filesystem_Base $wp_filesystem        WordPress filesystem subclass.
 	 * @global array              $wp_theme_directories

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -594,8 +594,20 @@ class WP_Upgrader {
 			}
 		}
 
-		// Move new version of directory into place.
-		$result = move_dir( $source, $remote_destination, true );
+		/*
+		 * Partial updates may want to retain the destination.
+		 * move_dir() returns a WP_Error when the destination exists,
+		 * so copy_dir() should be used.
+		 *
+		 * If 'clear_working' is false, the source shouldn't be removed.
+		 * After move_dir() runs, the source will no longer exist.
+		 * Therefore, copy_dir() should be used.
+		 */
+		if ( $clear_destination && $args['clear_working'] ) {
+			$result = move_dir( $source, $remote_destination, true );
+		} else {
+			$result = copy_dir( $source, $remote_destination );
+		}
 
 		// Clear the working folder?
 		if ( $args['clear_working'] ) {

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -587,13 +587,6 @@ class WP_Upgrader {
 			}
 		}
 
-		// Create destination if needed.
-		if ( ! $wp_filesystem->exists( $remote_destination ) ) {
-			if ( ! $wp_filesystem->mkdir( $remote_destination, FS_CHMOD_DIR ) ) {
-				return new WP_Error( 'mkdir_failed_destination', $this->strings['mkdir_failed'], $remote_destination );
-			}
-		}
-
 		/*
 		 * Partial updates may want to retain the destination.
 		 * move_dir() returns a WP_Error when the destination exists,
@@ -606,6 +599,12 @@ class WP_Upgrader {
 		if ( $clear_destination && $args['clear_working'] ) {
 			$result = move_dir( $source, $remote_destination, true );
 		} else {
+			// Create destination if needed.
+			if ( ! $wp_filesystem->exists( $remote_destination ) ) {
+				if ( ! $wp_filesystem->mkdir( $remote_destination, FS_CHMOD_DIR ) ) {
+					return new WP_Error( 'mkdir_failed_destination', $this->strings['mkdir_failed'], $remote_destination );
+				}
+			}
 			$result = copy_dir( $source, $remote_destination );
 		}
 


### PR DESCRIPTION
While working extensively on #57375 in various discussions on that ticket and on [Slack](https://wordpress.slack.com/archives/CULBN711P/p1674693806689949) it was decided to move forward with [PR3909](https://github.com/WordPress/wordpress-develop/pull/3909).

PR3909 does not include the needed change to WP_Upgrader::install_package() to take advantage of its new code. This ticket and PR will accomplish that. The plan is to replace copy_dir() in WP_Upgrader::install_package() with move_dir().

This change was tested extensively during the development of #57375

Related: #57375, #57386

Trac ticket: https://core.trac.wordpress.org/ticket/57557
