### PR TITLE
Update PHP Docs for `wp_get_global_stylesheet`

### DIFF
--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -75,8 +75,9 @@ function wp_get_global_styles( $path = array(), $context = array() ) {
  * Returns the stylesheet resulting of merging core, theme, and user data.
  *
  * @since 5.9.0
+ * @since 6.1.0 Added 'base-layout-styles' support.
  *
- * @param array $types Types of styles to load. Optional.
+ * @param array $types Optional. Types of styles to load.
  *                     It accepts as values 'variables', 'presets', 'styles', 'base-layout-styles'.
  *                     If empty, it'll load the following:
  *                     - for themes without theme.json: 'variables', 'presets', 'base-layout-styles'.

--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -107,7 +107,7 @@ function wp_get_global_stylesheet( $types = array() ) {
 	if ( empty( $types ) && ! $supports_theme_json ) {
 		$types = array( 'variables', 'presets', 'base-layout-styles' );
 	} elseif ( empty( $types ) ) {
-		$types = array( 'variables', 'presets', 'styles' );
+		$types = array( 'variables', 'styles', 'presets' );
 	}
 
 	/*

--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -77,9 +77,10 @@ function wp_get_global_styles( $path = array(), $context = array() ) {
  * @since 5.9.0
  *
  * @param array $types Types of styles to load. Optional.
- *                     It accepts 'variables', 'styles', 'presets' as values.
- *                     If empty, it'll load all for themes with theme.json support
- *                     and only [ 'variables', 'presets' ] for themes without theme.json support.
+ *                     It accepts as values 'variables', 'presets', 'styles', 'base-layout-styles'.
+ *                     If empty, it'll load the following:
+ *                     - for themes without theme.json: 'variables', 'presets', 'base-layout-styles'.
+ *                     - for themes with theme.json: 'variables', 'presets', 'styles'.
  * @return string Stylesheet.
  */
 function wp_get_global_stylesheet( $types = array() ) {
@@ -106,7 +107,7 @@ function wp_get_global_stylesheet( $types = array() ) {
 	if ( empty( $types ) && ! $supports_theme_json ) {
 		$types = array( 'variables', 'presets', 'base-layout-styles' );
 	} elseif ( empty( $types ) ) {
-		$types = array( 'variables', 'styles', 'presets' );
+		$types = array( 'variables', 'presets', 'styles' );
 	}
 
 	/*


### PR DESCRIPTION
Trac ticket https://core.trac.wordpress.org/ticket/57563
Backports https://github.com/WordPress/gutenberg/pull/46817

Note that this PHPDoc comment does not include yet the `custom-css` as it was not backported.
