### PR TITLE
Fixes registering block scripts & styles for parent themes

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -135,30 +135,30 @@ function register_block_script_handle( $metadata, $field_name, $index = 0 ) {
 	}
 	
 	// Cache the $template_path_norm and $stylesheet_path_norm to avoid unnecessary additional calls.
-	static $template_path_norm = '';
-        static $stylesheet_path_norm = '';
+	static $template_path_norm   = '';
+    static $stylesheet_path_norm = '';
 	if ( ! $template_path_norm || ! $stylesheet_path_norm ) {
-	        $template_path_norm =  wp_normalize_path(get_template_directory());
-                $stylesheet_path_norm = wp_normalize_path(get_stylesheet_directory());
+	    $template_path_norm   = wp_normalize_path(get_template_directory());
+        $stylesheet_path_norm = wp_normalize_path(get_stylesheet_directory());
 	}
 	$script_path_norm = wp_normalize_path( realpath( dirname( $metadata['file'] ) . '/' . $script_path ) );
 
-	$is_core_block  = isset( $metadata['file'] ) && 0 === strpos( $metadata['file'], $wpinc_path_norm );
+	$is_core_block = isset( $metadata['file'] ) && 0 === strpos( $metadata['file'], $wpinc_path_norm );
 	
 	// Determine if the block script was registered in a theme, by checking if the script path starts with either 
 	// the parent (template) or child (stylesheet) directory path. 
 	$is_parent_theme_block = str_starts_with( $script_path_norm, $template_path_norm );
-        $is_child_theme_block = str_starts_with( $script_path_norm, $stylesheet_path_norm );
-	$is_theme_block = ( $is_parent_theme_block || $is_child_theme_block );
+    $is_child_theme_block  = str_starts_with( $script_path_norm, $stylesheet_path_norm );
+	$is_theme_block        = ( $is_parent_theme_block || $is_child_theme_block );
 
 	$script_uri = plugins_url( $script_path, $metadata['file'] );
 	if ( $is_core_block ) {
 		$script_uri = includes_url( str_replace( $wpinc_path_norm, '', $script_path_norm ) );
 	} elseif ( $is_theme_block ) {
 		// Get the script path deterministically based on whether or not it was registered in a parent or child theme. 
-		$script_uri = $is_parent_theme_block 
-			      ? get_theme_file_uri( str_replace( $template_path_norm, '', $script_path_norm ) )
-			      : get_theme_file_uri( str_replace( $stylesheet_path_norm, '', $script_path_norm ) );
+		$script_uri = $is_parent_theme_block
+			? get_theme_file_uri( str_replace( $template_path_norm, '', $script_path_norm ) )
+			: get_theme_file_uri( str_replace( $stylesheet_path_norm, '', $script_path_norm ) );
 	}
 
 	$script_asset        = require $script_asset_path;
@@ -243,26 +243,26 @@ function register_block_style_handle( $metadata, $field_name, $index = 0 ) {
 		$style_uri = plugins_url( $style_path, $metadata['file'] );
 
 		// Cache the $template_path_norm and $stylesheet_path_norm to avoid unnecessary additional calls.
-                static $template_path_norm = '';
-                static $stylesheet_path_norm = '';
+        static $template_path_norm   = '';
+        static $stylesheet_path_norm = '';
 		if ( ! $template_path_norm || ! $stylesheet_path_norm ) {
-	                $template_path_norm =  wp_normalize_path(get_template_directory());
-                        $stylesheet_path_norm = wp_normalize_path(get_stylesheet_directory());
+	        $template_path_norm   = wp_normalize_path( get_template_directory() );
+            $stylesheet_path_norm = wp_normalize_path( get_stylesheet_directory() );
 		}
                 
 		// Determine if the block style was registered in a theme, by checking if the script path starts with either 
 		// the parent (template) or child (stylesheet) directory path.
-                $is_parent_theme_block = str_starts_with( $style_path_norm, $template_path_norm );
-                $is_child_theme_block = str_starts_with( $style_path_norm, $stylesheet_path_norm );
-		$is_theme_block = ( $is_parent_theme_block || $is_child_theme_block );
+        $is_parent_theme_block = str_starts_with( $style_path_norm, $template_path_norm );
+		$is_child_theme_block  = str_starts_with( $style_path_norm, $stylesheet_path_norm );
+		$is_theme_block        = ( $is_parent_theme_block || $is_child_theme_block );
 
 		if ( $is_core_block ) {
 			$style_uri = includes_url( 'blocks/' . str_replace( 'core/', '', $metadata['name'] ) . "/style$suffix.css" );
 		} elseif ( $is_theme_block ) {
 			// Get the script path deterministically based on whether or not it was registered in a parent or child theme. 
-                        $style_uri = $is_parent_theme_block 
-                                     ? get_theme_file_uri( str_replace( $template_path_norm, '', $style_path_norm ) )
-                                     : get_theme_file_uri( str_replace( $stylesheet_path_norm, '', $style_path_norm ) );
+            $style_uri = $is_parent_theme_block
+                ? get_theme_file_uri( str_replace( $template_path_norm, '', $style_path_norm ) )
+                : get_theme_file_uri( str_replace( $stylesheet_path_norm, '', $style_path_norm ) );
 		} 
 	} else {
 		$style_uri = false;

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -249,7 +249,7 @@ function register_block_style_handle( $metadata, $field_name, $index = 0 ) {
 			$template_path_norm   = wp_normalize_path( get_template_directory() );
 			$stylesheet_path_norm = wp_normalize_path( get_stylesheet_directory() );
 		}
-          
+  
 		// Determine if the block style was registered in a theme, by checking if the script path starts with either
 		// the parent (template) or child (stylesheet) directory path.
 		$is_parent_theme_block = str_starts_with( $style_path_norm, $template_path_norm );

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -133,29 +133,29 @@ function register_block_script_handle( $metadata, $field_name, $index = 0 ) {
 	if ( ! $wpinc_path_norm ) {
 		$wpinc_path_norm = wp_normalize_path( realpath( ABSPATH . WPINC ) );
 	}
-	
+
 	// Cache the $template_path_norm and $stylesheet_path_norm to avoid unnecessary additional calls.
 	static $template_path_norm   = '';
-    static $stylesheet_path_norm = '';
+	static $stylesheet_path_norm = '';
 	if ( ! $template_path_norm || ! $stylesheet_path_norm ) {
-	    $template_path_norm   = wp_normalize_path(get_template_directory());
-        $stylesheet_path_norm = wp_normalize_path(get_stylesheet_directory());
+		$template_path_norm   = wp_normalize_path( get_template_directory() );
+		$stylesheet_path_norm = wp_normalize_path( get_stylesheet_directory() );
 	}
 	$script_path_norm = wp_normalize_path( realpath( dirname( $metadata['file'] ) . '/' . $script_path ) );
 
 	$is_core_block = isset( $metadata['file'] ) && 0 === strpos( $metadata['file'], $wpinc_path_norm );
-	
-	// Determine if the block script was registered in a theme, by checking if the script path starts with either 
-	// the parent (template) or child (stylesheet) directory path. 
+
+	// Determine if the block script was registered in a theme, by checking if the script path starts with either
+	// the parent (template) or child (stylesheet) directory path.
 	$is_parent_theme_block = str_starts_with( $script_path_norm, $template_path_norm );
-    $is_child_theme_block  = str_starts_with( $script_path_norm, $stylesheet_path_norm );
+	$is_child_theme_block  = str_starts_with( $script_path_norm, $stylesheet_path_norm );
 	$is_theme_block        = ( $is_parent_theme_block || $is_child_theme_block );
 
 	$script_uri = plugins_url( $script_path, $metadata['file'] );
 	if ( $is_core_block ) {
 		$script_uri = includes_url( str_replace( $wpinc_path_norm, '', $script_path_norm ) );
 	} elseif ( $is_theme_block ) {
-		// Get the script path deterministically based on whether or not it was registered in a parent or child theme. 
+		// Get the script path deterministically based on whether or not it was registered in a parent or child theme.
 		$script_uri = $is_parent_theme_block
 			? get_theme_file_uri( str_replace( $template_path_norm, '', $script_path_norm ) )
 			: get_theme_file_uri( str_replace( $stylesheet_path_norm, '', $script_path_norm ) );
@@ -243,27 +243,27 @@ function register_block_style_handle( $metadata, $field_name, $index = 0 ) {
 		$style_uri = plugins_url( $style_path, $metadata['file'] );
 
 		// Cache the $template_path_norm and $stylesheet_path_norm to avoid unnecessary additional calls.
-        static $template_path_norm   = '';
-        static $stylesheet_path_norm = '';
+		static $template_path_norm   = '';
+		static $stylesheet_path_norm = '';
 		if ( ! $template_path_norm || ! $stylesheet_path_norm ) {
-	        $template_path_norm   = wp_normalize_path( get_template_directory() );
-            $stylesheet_path_norm = wp_normalize_path( get_stylesheet_directory() );
+			$template_path_norm   = wp_normalize_path( get_template_directory() );
+			$stylesheet_path_norm = wp_normalize_path( get_stylesheet_directory() );
 		}
-                
-		// Determine if the block style was registered in a theme, by checking if the script path starts with either 
+          
+		// Determine if the block style was registered in a theme, by checking if the script path starts with either
 		// the parent (template) or child (stylesheet) directory path.
-        $is_parent_theme_block = str_starts_with( $style_path_norm, $template_path_norm );
+		$is_parent_theme_block = str_starts_with( $style_path_norm, $template_path_norm );
 		$is_child_theme_block  = str_starts_with( $style_path_norm, $stylesheet_path_norm );
 		$is_theme_block        = ( $is_parent_theme_block || $is_child_theme_block );
 
 		if ( $is_core_block ) {
 			$style_uri = includes_url( 'blocks/' . str_replace( 'core/', '', $metadata['name'] ) . "/style$suffix.css" );
 		} elseif ( $is_theme_block ) {
-			// Get the script path deterministically based on whether or not it was registered in a parent or child theme. 
-            $style_uri = $is_parent_theme_block
-                ? get_theme_file_uri( str_replace( $template_path_norm, '', $style_path_norm ) )
-                : get_theme_file_uri( str_replace( $stylesheet_path_norm, '', $style_path_norm ) );
-		} 
+			// Get the script path deterministically based on whether or not it was registered in a parent or child theme.
+			$style_uri = $is_parent_theme_block
+				? get_theme_file_uri( str_replace( $template_path_norm, '', $style_path_norm ) )
+				: get_theme_file_uri( str_replace( $stylesheet_path_norm, '', $style_path_norm ) );
+		}
 	} else {
 		$style_uri = false;
 	}

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -249,7 +249,7 @@ function register_block_style_handle( $metadata, $field_name, $index = 0 ) {
 			$template_path_norm   = wp_normalize_path( get_template_directory() );
 			$stylesheet_path_norm = wp_normalize_path( get_stylesheet_directory() );
 		}
-  
+
 		// Determine if the block style was registered in a theme, by checking if the script path starts with either
 		// the parent (template) or child (stylesheet) directory path.
 		$is_parent_theme_block = str_starts_with( $style_path_norm, $template_path_norm );

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -133,18 +133,32 @@ function register_block_script_handle( $metadata, $field_name, $index = 0 ) {
 	if ( ! $wpinc_path_norm ) {
 		$wpinc_path_norm = wp_normalize_path( realpath( ABSPATH . WPINC ) );
 	}
-
-	$theme_path_norm  = wp_normalize_path( get_theme_file_path() );
+	
+	// Cache the $template_path_norm and $stylesheet_path_norm to avoid unnecessary additional calls.
+	static $template_path_norm = '';
+        static $stylesheet_path_norm = '';
+	if ( ! $template_path_norm || ! $stylesheet_path_norm ) {
+	        $template_path_norm =  wp_normalize_path(get_template_directory());
+                $stylesheet_path_norm = wp_normalize_path(get_stylesheet_directory());
+	}
 	$script_path_norm = wp_normalize_path( realpath( dirname( $metadata['file'] ) . '/' . $script_path ) );
 
 	$is_core_block  = isset( $metadata['file'] ) && 0 === strpos( $metadata['file'], $wpinc_path_norm );
-	$is_theme_block = 0 === strpos( $script_path_norm, $theme_path_norm );
+	
+	// Determine if the block script was registered in a theme, by checking if the script path starts with either 
+	// the parent (template) or child (stylesheet) directory path. 
+	$is_parent_theme_block = str_starts_with( $script_path_norm, $template_path_norm );
+        $is_child_theme_block = str_starts_with( $script_path_norm, $stylesheet_path_norm );
+	$is_theme_block = ( $is_parent_theme_block || $is_child_theme_block );
 
 	$script_uri = plugins_url( $script_path, $metadata['file'] );
 	if ( $is_core_block ) {
 		$script_uri = includes_url( str_replace( $wpinc_path_norm, '', $script_path_norm ) );
 	} elseif ( $is_theme_block ) {
-		$script_uri = get_theme_file_uri( str_replace( $theme_path_norm, '', $script_path_norm ) );
+		// Get the script path deterministically based on whether or not it was registered in a parent or child theme. 
+		$script_uri = $is_parent_theme_block 
+			      ? get_theme_file_uri( str_replace( $template_path_norm, '', $script_path_norm ) )
+			      : get_theme_file_uri( str_replace( $stylesheet_path_norm, '', $script_path_norm ) );
 	}
 
 	$script_asset        = require $script_asset_path;
@@ -228,19 +242,28 @@ function register_block_style_handle( $metadata, $field_name, $index = 0 ) {
 	if ( $has_style_file ) {
 		$style_uri = plugins_url( $style_path, $metadata['file'] );
 
-		// Cache $theme_path_norm to avoid calling get_theme_file_path() multiple times.
-		static $theme_path_norm = '';
-		if ( ! $theme_path_norm ) {
-			$theme_path_norm = wp_normalize_path( get_theme_file_path() );
+		// Cache the $template_path_norm and $stylesheet_path_norm to avoid unnecessary additional calls.
+                static $template_path_norm = '';
+                static $stylesheet_path_norm = '';
+		if ( ! $template_path_norm || ! $stylesheet_path_norm ) {
+	                $template_path_norm =  wp_normalize_path(get_template_directory());
+                        $stylesheet_path_norm = wp_normalize_path(get_stylesheet_directory());
 		}
+                
+		// Determine if the block style was registered in a theme, by checking if the script path starts with either 
+		// the parent (template) or child (stylesheet) directory path.
+                $is_parent_theme_block = str_starts_with( $style_path_norm, $template_path_norm );
+                $is_child_theme_block = str_starts_with( $style_path_norm, $stylesheet_path_norm );
+		$is_theme_block = ( $is_parent_theme_block || $is_child_theme_block );
 
-		$is_theme_block = str_starts_with( $style_path_norm, $theme_path_norm );
-
-		if ( $is_theme_block ) {
-			$style_uri = get_theme_file_uri( str_replace( $theme_path_norm, '', $style_path_norm ) );
-		} elseif ( $is_core_block ) {
+		if ( $is_core_block ) {
 			$style_uri = includes_url( 'blocks/' . str_replace( 'core/', '', $metadata['name'] ) . "/style$suffix.css" );
-		}
+		} elseif ( $is_theme_block ) {
+			// Get the script path deterministically based on whether or not it was registered in a parent or child theme. 
+                        $style_uri = $is_parent_theme_block 
+                                     ? get_theme_file_uri( str_replace( $template_path_norm, '', $style_path_norm ) )
+                                     : get_theme_file_uri( str_replace( $stylesheet_path_norm, '', $style_path_norm ) );
+		} 
 	} else {
 		$style_uri = false;
 	}


### PR DESCRIPTION
<!-- Insert a description of your changes here -->

Fixes for both the `register_block_script_handle()` and  `register_block_style_handle()` functions within `wp-includes/blocks.js` , allowing for child themes to access and utilise blocks defined in parent themes. 

Previously these functions could not handle blocks registered in Parent themes, however the above changes fix this by determining whether the given asset path belongs to either of the template or stylesheet directories (Parent and Child themes respectively) as opposed to just checking using `get_theme_file_path('')` as is currently the case, thus mitigating this  issue.

An issue was raised under the [WordPress / gutenberg](https://github.com/WordPress/gutenberg) Repo, however as `wp-includes/blocks.js` is included in the [WordPress / wordpress-develop](https://github.com/WordPress/wordpress-develop) repo I have created the PR here instead. That original ticket can be found [here](https://github.com/WordPress/gutenberg/issues/47470).

Trac ticket: [Ticket](https://core.trac.wordpress.org/ticket/57566#ticket)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
