### PR TITLE
Introduce `wp_get_attachment_link_attributes` filter.

### DIFF
--- a/src/wp-includes/post-template.php
+++ b/src/wp-includes/post-template.php
@@ -1666,7 +1666,24 @@ function wp_get_attachment_link( $post = 0, $size = 'thumbnail', $permalink = fa
 		$link_text = esc_html( pathinfo( get_attached_file( $_post->ID ), PATHINFO_FILENAME ) );
 	}
 
-	$link_html = "<a href='" . esc_url( $url ) . "'>$link_text</a>";
+	/**
+	 * Filters the list of attachment link attributes.
+	 *
+	 * @since 6.2.0
+	 *
+	 * @param array $attributes An array of attributes for the link markup,
+	 *                          keyed on the attribute name.
+	 * @param int   $id         Post ID.
+	 */
+	$attributes = apply_filters( 'wp_get_attachment_link_attributes', array( 'href' => $url ), $_post->ID );
+
+	$link_attributes = '';
+	foreach ( $attributes as $name => $value ) {
+		$value            = 'href' === $name ? esc_url( $value ) : esc_attr( $value );
+		$link_attributes .= ' ' . esc_attr( $name ) . "='" . $value . "'";
+	}
+
+	$link_html = "<a$link_attributes>$link_text</a>";
 
 	/**
 	 * Filters a retrieved attachment page link.

--- a/tests/phpunit/tests/post/wpGetAttachmentLink.php
+++ b/tests/phpunit/tests/post/wpGetAttachmentLink.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * @group post
+ * @group media
+ * @group upload
+ *
+ * @covers ::wp_get_attachment_link
+ */
+class Tests_Post_WpGetAttachmentLink extends WP_UnitTestCase {
+
+	/**
+	 * The ID of an attachment for testing.
+	 *
+	 * @var int $attachment
+	 */
+	private static $attachment;
+
+	/**
+	 * Creates an attachment for testing before any tests run.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		self::$attachment = self::factory()->attachment->create();
+	}
+
+	/**
+	 * Tests that wp_get_attachment_link() applies the
+	 * wp_get_attachment_link_attributes filter.
+	 *
+	 * @ticket 41574
+	 *
+	 * @dataProvider data_should_apply_attributes_filter
+	 *
+	 * @param array  $attributes Attributes to return from the callback.
+	 * @param string $expected   The substring expected to be in the attachment link.
+	 */
+	public function test_should_apply_attributes_filter( $attributes, $expected ) {
+		$expected = str_replace( 'ATTACHMENT_ID', self::$attachment, $expected );
+
+		add_filter(
+			'wp_get_attachment_link_attributes',
+			static function( $attr ) use ( $attributes ) {
+				return array_merge( $attr, $attributes );
+			}
+		);
+
+		$this->assertStringContainsString(
+			$expected,
+			wp_get_attachment_link( self::$attachment )
+		);
+	}
+
+	/**
+	 * Data provider for test_should_apply_attributes_filter().
+	 *
+	 * @return array[]
+	 */
+	public function data_should_apply_attributes_filter() {
+		return array(
+			'no new attributes'                         => array(
+				'attributes' => array(),
+				'expected'   => "<a href='http://example.org/?attachment_id=ATTACHMENT_ID'>",
+			),
+			'one new attribute'                         => array(
+				'attributes' => array(
+					'class' => 'test-attribute-filter',
+				),
+				'expected'   => " class='test-attribute-filter'",
+			),
+			'two new attributes'                        => array(
+				'attributes' => array(
+					'class' => 'test-attribute-filter',
+					'id'    => 'test-attribute-filter-1',
+				),
+				'expected'   => " class='test-attribute-filter' id='test-attribute-filter-1'",
+			),
+			'an existing attribute'                     => array(
+				'attributes' => array(
+					'href' => 'http://test-attribute-filter.org',
+				),
+				'expected'   => " href='http://test-attribute-filter.org'",
+			),
+			'an existing attribute and a new attribute' => array(
+				'attributes' => array(
+					'href'  => 'http://test-attribute-filter.org',
+					'class' => 'test-attribute-filter',
+				),
+				'expected'   => " href='http://test-attribute-filter.org' class='test-attribute-filter'",
+			),
+			'an attribute name with unsafe characters'  => array(
+				'attributes' => array(
+					"> <script>alert('Howdy, admin!')</script> <a href=''></a" => '',
+				),
+				'expected'   => " &gt; &lt;script&gt;alert(&#039;Howdy, admin!&#039;)&lt;/script&gt; &lt;a href=&#039;&#039;&gt;&lt;/a=''",
+			),
+			'an attribute value with unsafe characters' => array(
+				'attributes' => array(
+					'class' => "'> <script>alert('Howdy, admin!')</script> <a href=''></a",
+				),
+				'expected'   => '&#039;&gt; &lt;script&gt;alert(&#039;Howdy, admin!&#039;)&lt;/script&gt; &lt;a href=&#039;&#039;&gt;&lt;/a',
+			),
+		);
+	}
+
+}


### PR DESCRIPTION
This PR refreshes patch: 41574.2.diff to:

- Fix CS issues.
- Update `@since` annotation and remove an empty line from the docblock.
- Backward compatibility: Use single quotes for attribute values.
- Remove an unnecessary `array_map()` for performance.
- Addresses concerns about the image attributes and link attributes clashing.
  - Image attributes: Stays as `$attr` for backward compatibility (i.e. named parameters).
  - Link attributes: Is called `$attributes` and, once collapsed to a string, `$link_attributes`, for consistency with `$link_text`.
- Add tests.

Trac ticket: https://core.trac.wordpress.org/ticket/41574