### PR TITLE
2877: Don't force trailing slashes in `get_pagenum_link`

### DIFF
--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -2434,7 +2434,7 @@ function get_pagenum_link( $pagenum = 1, $escape = true ) {
 		$request = preg_replace( '|^' . preg_quote( $wp_rewrite->index, '|' ) . '|i', '', $request );
 		$request = ltrim( $request, '/' );
 
-		if ( $wp_rewrite->using_index_permalinks() && ( $pagenum > 1 || '' != $request ) ) {
+		if ( $wp_rewrite->using_index_permalinks() && ( $pagenum > 1 || '' !== $request ) ) {
 			$parts[] = $wp_rewrite->index;
 		}
 

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -2445,8 +2445,10 @@ function get_pagenum_link( $pagenum = 1, $escape = true ) {
 			$parts[] = $pagenum;
 		}
 
-		$parts[] = $query_string;
-		$result  = user_trailingslashit( implode( '/', array_filter( $parts ) ), 'paged' );
+		$result = user_trailingslashit( implode( '/', array_filter( $parts ) ), 'paged' );
+		if ( ! empty( $query_string ) ) {
+			$result .= $query_string;
+		}
 	}
 
 	/**

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -2420,6 +2420,9 @@ function get_pagenum_link( $pagenum = 1, $escape = true ) {
 		$qs_regex = '|\?.*?$|';
 		preg_match( $qs_regex, $request, $qs_match );
 
+		$parts   = array();
+		$parts[] = untrailingslashit( get_bloginfo( 'url' ) );
+
 		if ( ! empty( $qs_match[0] ) ) {
 			$query_string = $qs_match[0];
 			$request      = preg_replace( $qs_regex, '', $request );
@@ -2431,17 +2434,19 @@ function get_pagenum_link( $pagenum = 1, $escape = true ) {
 		$request = preg_replace( '|^' . preg_quote( $wp_rewrite->index, '|' ) . '|i', '', $request );
 		$request = ltrim( $request, '/' );
 
-		$base = trailingslashit( get_bloginfo( 'url' ) );
-
-		if ( $wp_rewrite->using_index_permalinks() && ( $pagenum > 1 || '' !== $request ) ) {
-			$base .= $wp_rewrite->index . '/';
+		if ( $wp_rewrite->using_index_permalinks() && ( $pagenum > 1 || '' != $request ) ) {
+			$parts[] = 'index.php';
 		}
+
+		$parts[] = untrailingslashit( $request );
 
 		if ( $pagenum > 1 ) {
-			$request = ( ( ! empty( $request ) ) ? trailingslashit( $request ) : $request ) . user_trailingslashit( $wp_rewrite->pagination_base . '/' . $pagenum, 'paged' );
+			$parts[] = $wp_rewrite->pagination_base;
+			$parts[] = $pagenum;
 		}
 
-		$result = $base . $request . $query_string;
+		$parts[] = $query_string;
+		$result  = user_trailingslashit( implode( '/', array_filter( $parts ) ), 'paged' );
 	}
 
 	/**

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -2435,7 +2435,7 @@ function get_pagenum_link( $pagenum = 1, $escape = true ) {
 		$request = ltrim( $request, '/' );
 
 		if ( $wp_rewrite->using_index_permalinks() && ( $pagenum > 1 || '' != $request ) ) {
-			$parts[] = 'index.php';
+			$parts[] = $wp_rewrite->index;
 		}
 
 		$parts[] = untrailingslashit( $request );

--- a/tests/phpunit/tests/link.php
+++ b/tests/phpunit/tests/link.php
@@ -4,28 +4,6 @@
  */
 class Tests_Link extends WP_UnitTestCase {
 
-	public function get_pagenum_link_cb( $url ) {
-		return $url . '/WooHoo';
-	}
-
-	/**
-	 * @ticket 8847
-	 */
-	public function test_get_pagenum_link_case_insensitivity() {
-		$old_req_uri = $_SERVER['REQUEST_URI'];
-
-		$this->set_permalink_structure( '/%year%/%monthnum%/%day%/%postname%/' );
-
-		add_filter( 'home_url', array( $this, 'get_pagenum_link_cb' ) );
-		$_SERVER['REQUEST_URI'] = '/woohoo';
-		$paged                  = get_pagenum_link( 2 );
-
-		remove_filter( 'home_url', array( $this, 'get_pagenum_link_cb' ) );
-		$this->assertSame( $paged, home_url( '/WooHoo/page/2/' ) );
-
-		$_SERVER['REQUEST_URI'] = $old_req_uri;
-	}
-
 	public function test_wp_get_shortlink() {
 		$post_id  = self::factory()->post->create();
 		$post_id2 = self::factory()->post->create();

--- a/tests/phpunit/tests/link/getPagenumLink.php
+++ b/tests/phpunit/tests/link/getPagenumLink.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @group  link
+ * @covers ::get_pagenum_link
+ */
+class Tests_Link_GetPagenumLink extends WP_UnitTestCase {
+
+	public function get_pagenum_link_cb( $url ) {
+		return $url . '/WooHoo';
+	}
+
+	/**
+	 * @ticket 8847
+	 */
+	public function test_get_pagenum_link_case_insensitivity() {
+		$old_req_uri = $_SERVER['REQUEST_URI'];
+
+		$this->set_permalink_structure( '/%year%/%monthnum%/%day%/%postname%/' );
+
+		add_filter( 'home_url', array( $this, 'get_pagenum_link_cb' ) );
+		$_SERVER['REQUEST_URI'] = '/woohoo';
+		$paged                  = get_pagenum_link( 2 );
+
+		remove_filter( 'home_url', array( $this, 'get_pagenum_link_cb' ) );
+		$this->assertSame( $paged, home_url( '/WooHoo/page/2/' ) );
+
+		$_SERVER['REQUEST_URI'] = $old_req_uri;
+	}
+
+	/**
+	 * @ticket 2877
+	 */
+	function test_get_pagenum_link_firstpage_trailingslash() {
+		$old_req_uri = $_SERVER['REQUEST_URI'];
+
+		$this->set_permalink_structure( '/%year%/%monthnum%/%day%/%postname%' );
+
+		add_filter( 'home_url', array( $this, 'get_pagenum_link_cb' ) );
+		$_SERVER['REQUEST_URI'] = '/woohoo';
+		$paged                  = get_pagenum_link( 1 );
+
+		remove_filter( 'home_url', array( $this, 'get_pagenum_link_cb' ) );
+		$this->assertEquals( home_url( '/WooHoo' ), $paged );
+
+		$_SERVER['REQUEST_URI'] = $old_req_uri;
+	}
+}

--- a/tests/phpunit/tests/link/getPagenumLink.php
+++ b/tests/phpunit/tests/link/getPagenumLink.php
@@ -6,10 +6,6 @@
  */
 class Tests_Link_GetPagenumLink extends WP_UnitTestCase {
 
-	public function get_pagenum_link_cb( $url ) {
-		return $url . '/WooHoo';
-	}
-
 	/**
 	 * @ticket 8847
 	 */
@@ -31,18 +27,64 @@ class Tests_Link_GetPagenumLink extends WP_UnitTestCase {
 	/**
 	 * @ticket 2877
 	 */
-	function test_get_pagenum_link_firstpage_trailingslash() {
+	public function test_get_pagenum_link_firstpage_no_trailingslash() {
 		$old_req_uri = $_SERVER['REQUEST_URI'];
 
 		$this->set_permalink_structure( '/%year%/%monthnum%/%day%/%postname%' );
-
-		add_filter( 'home_url', array( $this, 'get_pagenum_link_cb' ) );
-		$_SERVER['REQUEST_URI'] = '/woohoo';
+		$_SERVER['REQUEST_URI'] = '/woohoo/page/2/';
 		$paged                  = get_pagenum_link( 1 );
 
-		remove_filter( 'home_url', array( $this, 'get_pagenum_link_cb' ) );
-		$this->assertEquals( home_url( '/WooHoo' ), $paged );
+		$this->assertEquals( home_url( '/woohoo' ), $paged );
 
 		$_SERVER['REQUEST_URI'] = $old_req_uri;
+	}
+
+	/**
+	 * @ticket 2877
+	 */
+	public function test_get_pagenum_link_paged_no_trailingslash() {
+		$old_req_uri = $_SERVER['REQUEST_URI'];
+
+		$this->set_permalink_structure( '/%year%/%monthnum%/%day%/%postname%' );
+		$_SERVER['REQUEST_URI'] = '/woohoo';
+		$paged                  = get_pagenum_link( 2 );
+
+		$this->assertEquals( home_url( '/woohoo/page/2' ), $paged );
+
+		$_SERVER['REQUEST_URI'] = $old_req_uri;
+	}
+
+	/**
+	 * @ticket 2877
+	 */
+	public function test_get_pagenum_link_firstpage_no_trailingslash_queryargs() {
+		$old_req_uri = $_SERVER['REQUEST_URI'];
+
+		$this->set_permalink_structure( '/%year%/%monthnum%/%day%/%postname%' );
+		$_SERVER['REQUEST_URI'] = '/woohoo/page/2?test=1234';
+		$paged                  = get_pagenum_link( 1 );
+
+		$this->assertEquals( home_url( '/woohoo?test=1234' ), $paged );
+
+		$_SERVER['REQUEST_URI'] = $old_req_uri;
+	}
+
+	/**
+	 * @ticket 2877
+	 */
+	public function test_get_pagenum_link_paged_no_trailingslash_query_args() {
+		$old_req_uri = $_SERVER['REQUEST_URI'];
+
+		$this->set_permalink_structure( '/%year%/%monthnum%/%day%/%postname%' );
+		$_SERVER['REQUEST_URI'] = '/woohoo?test=1234';
+		$paged                  = get_pagenum_link( 2 );
+
+		$this->assertEquals( home_url( '/woohoo/page/2?test=1234' ), $paged );
+
+		$_SERVER['REQUEST_URI'] = $old_req_uri;
+	}
+
+	public function get_pagenum_link_cb( $url ) {
+		return $url . '/WooHoo';
 	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/2877

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
