### PR TITLE
Restrict the permissions granted to jobs on GitHub Actions

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -59,6 +59,8 @@ jobs:
   phpcs:
     name: PHP coding standards
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 20
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
 
@@ -130,6 +132,8 @@ jobs:
   jshint:
     name: JavaScript coding standards
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 20
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
     env:
@@ -177,6 +181,8 @@ jobs:
   failed-workflow:
     name: Failed workflow tasks
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     needs: [ phpcs, jshint, slack-notifications ]
     if: |
       always() &&

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -48,6 +48,8 @@ jobs:
   e2e-tests:
     name: E2E Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 20
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
 
@@ -123,6 +125,8 @@ jobs:
   failed-workflow:
     name: Failed workflow tasks
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     needs: [ e2e-tests, slack-notifications ]
     if: |
       always() &&

--- a/.github/workflows/failed-workflow.yml
+++ b/.github/workflows/failed-workflow.yml
@@ -20,6 +20,8 @@ jobs:
   failed-workflow:
     name: Rerun a workflow
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -51,6 +51,8 @@ jobs:
   test-js:
     name: QUnit Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 20
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
 
@@ -96,6 +98,8 @@ jobs:
   failed-workflow:
     name: Failed workflow tasks
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     needs: [ test-js, slack-notifications ]
     if: |
       always() &&

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -54,6 +54,8 @@ jobs:
   php-compatibility:
     name: Check PHP compatibility
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 20
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
 
@@ -121,6 +123,8 @@ jobs:
   failed-workflow:
     name: Failed workflow tasks
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     needs: [ php-compatibility, slack-notifications ]
     if: |
       always() &&

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -54,6 +54,8 @@ jobs:
   test-php:
     name: ${{ matrix.php }}${{ matrix.multisite && ' multisite' || '' }}${{ matrix.split_slow && ' slow tests' || '' }}${{ matrix.memcached && ' with memcached' || '' }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     timeout-minutes: 20
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
     strategy:
@@ -233,6 +235,8 @@ jobs:
   failed-workflow:
     name: Failed workflow tasks
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     needs: [ test-php, slack-notifications ]
     if: |
       always() &&

--- a/.github/workflows/slack-notifications.yml
+++ b/.github/workflows/slack-notifications.yml
@@ -44,6 +44,9 @@ jobs:
   prepare:
     name: Prepare notifications
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
     timeout-minutes: 5
     if: ${{ github.repository == 'WordPress/wordpress-develop' && github.event.workflow_run.event != 'pull_request' }}
     outputs:
@@ -148,6 +151,7 @@ jobs:
   failure:
     name: Failure notifications
     runs-on: ubuntu-latest
+    permissions: {}
     timeout-minutes: 5
     needs: [ prepare ]
     if: ${{ inputs.calling_status == 'failure' || failure() }}
@@ -164,6 +168,7 @@ jobs:
   fixed:
     name: Fixed notifications
     runs-on: ubuntu-latest
+    permissions: {}
     timeout-minutes: 5
     needs: [ prepare ]
     if: ${{ contains( fromJson( '["failure", "cancelled", "none"]' ), needs.prepare.outputs.previous_conclusion ) && inputs.calling_status == 'success' && success() }}
@@ -180,6 +185,7 @@ jobs:
   success:
     name: Success notifications
     runs-on: ubuntu-latest
+    permissions: {}
     timeout-minutes: 5
     needs: [ prepare ]
     if: ${{ inputs.calling_status == 'success' && success() }}
@@ -196,6 +202,7 @@ jobs:
   cancelled:
     name: Cancelled notifications
     runs-on: ubuntu-latest
+    permissions: {}
     timeout-minutes: 5
     needs: [ prepare ]
     if: ${{ inputs.calling_status == 'cancelled' || cancelled() }}

--- a/.github/workflows/test-and-zip-default-themes.yml
+++ b/.github/workflows/test-and-zip-default-themes.yml
@@ -56,6 +56,8 @@ jobs:
   test-build-scripts:
     name: Test ${{ matrix.theme }} build script
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 10
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
     strategy:
@@ -101,6 +103,8 @@ jobs:
   bundle-theme:
     name: Create ${{ matrix.theme }} ZIP file
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: [ test-build-scripts ]
     timeout-minutes: 10
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
@@ -152,6 +156,8 @@ jobs:
   failed-workflow:
     name: Failed workflow tasks
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     needs: [ test-build-scripts, bundle-theme, slack-notifications ]
     if: |
       always() &&

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -56,6 +56,8 @@ jobs:
   test-coverage-report:
     name: ${{ matrix.multisite && 'Multisite' || 'Single site' }} report
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 120
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
     strategy:
@@ -182,6 +184,8 @@ jobs:
   failed-workflow:
     name: Failed workflow tasks
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     needs: [ test-coverage-report, slack-notifications ]
     if: |
       always() &&

--- a/.github/workflows/test-npm.yml
+++ b/.github/workflows/test-npm.yml
@@ -53,6 +53,8 @@ jobs:
   test-npm:
     name: Test npm on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     timeout-minutes: 20
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
     strategy:
@@ -122,6 +124,8 @@ jobs:
   test-npm-macos:
     name: Test npm on MacOS
     runs-on: macos-latest
+    permissions:
+      contents: read
     timeout-minutes: 30
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
     steps:
@@ -179,6 +183,8 @@ jobs:
   failed-workflow:
     name: Failed workflow tasks
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     needs: [ test-npm, test-npm-macos, slack-notifications ]
     if: |
       always() &&

--- a/.github/workflows/test-old-branches.yml
+++ b/.github/workflows/test-old-branches.yml
@@ -16,6 +16,8 @@ jobs:
   dispatch-workflows-for-old-branches:
     name: ${{ matrix.workflow }} for ${{ matrix.branch }}
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     timeout-minutes: 20
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
     strategy:

--- a/.github/workflows/welcome-new-contributors.yml
+++ b/.github/workflows/welcome-new-contributors.yml
@@ -8,6 +8,8 @@ jobs:
   # Comments on a pull request when the author is a new contributor.
   post-welcome-message:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     timeout-minutes: 5
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/57572

The `permissions` key in a job declares the GitHub permissions that are granted to the token that's used by the job. Restricting the permissions reduces the impact that a vulnerability in the CI system can have.

## Docs

* https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

## Changes

* Jobs that re-run workflows have been restricted to `actions: write` as they post to the actions API
* The main Slack notification job has been restricted to `actions: read` and `contents: read` as it prepares the data for its dependent jobs, all of which have been restricted to no permissions
* The new contributor workflow has been restricted to `issues: write` as it posts a comment to the PR
* All other jobs have been restricted to `contents: read` as they need no access other than to read the repo