### PR TITLE
Add size parameter to get_attached_file function

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -705,6 +705,8 @@ function create_initial_post_types() {
 /**
  * Retrieves attached file path based on attachment ID.
  *
+ * Will return intermediate size path if $size param is provided.
+ *
  * By default the path will go through the 'get_attached_file' filter, but
  * passing a true to the $unfiltered argument of get_attached_file() will
  * return the file path unfiltered.
@@ -715,13 +717,27 @@ function create_initial_post_types() {
  * attached filename through a filter.
  *
  * @since 2.0.0
+ * @since 6.2 The `$size` parameter was added
  *
- * @param int  $attachment_id Attachment ID.
- * @param bool $unfiltered    Optional. Whether to apply filters. Default false.
+ * @param int          $attachment_id Attachment ID.
+ * @param bool         $unfiltered    Optional. Whether to apply filters. Default false.
+ * @param string|int[] $size          Optional. Image size. Accepts any registered image size name, or an array
+ *                                    of width and height values in pixels (in that order). Default 'thumbnail'.
+ *
  * @return string|false The file path to where the attached file should be, false otherwise.
  */
-function get_attached_file( $attachment_id, $unfiltered = false ) {
-	$file = get_post_meta( $attachment_id, '_wp_attached_file', true );
+function get_attached_file( $attachment_id, $unfiltered = false, $size = '' ) {
+
+	// Check for intermediate sizes first, otherwise fallback to original attachment size
+	if ( ! empty( $size ) ) {
+		$intermediate_image = image_get_intermediate_size( $attachment_id, $size );
+		if ( ! $intermediate_image || ! isset( $intermediate_image['path'] ) ) {
+			return false;
+		}
+		$file = $intermediate_image['path'];
+	} else {
+		$file = get_post_meta( $attachment_id, '_wp_attached_file', true );
+	}
 
 	// If the file is relative, prepend upload dir.
 	if ( $file && 0 !== strpos( $file, '/' ) && ! preg_match( '|^.:\\\|', $file ) ) {

--- a/tests/phpunit/tests/media/wpGenerateAttachmentMetadata.php
+++ b/tests/phpunit/tests/media/wpGenerateAttachmentMetadata.php
@@ -18,6 +18,7 @@ class Tests_Media_wpGenerateAttachmentMetadata extends WP_UnitTestCase {
 	 * Tests that filesize meta is generated for JPEGs.
 	 *
 	 * @ticket 49412
+	 * @ticket 51780
 	 *
 	 * @covers ::wp_create_image_subsizes
 	 */
@@ -28,10 +29,11 @@ class Tests_Media_wpGenerateAttachmentMetadata extends WP_UnitTestCase {
 
 		$this->assertSame( wp_filesize( get_attached_file( $attachment ) ), $metadata['filesize'] );
 
-		foreach ( $metadata['sizes'] as $intermediate_size ) {
+		foreach ( $metadata['sizes'] as $size => $intermediate_size ) {
 			$this->assertArrayHasKey( 'filesize', $intermediate_size );
 			$this->assertNotEmpty( $intermediate_size['filesize'] );
 			$this->assertIsNumeric( $intermediate_size['filesize'] );
+			$this->assertStringContainsString( $intermediate_size['file'], get_attached_file( $attachment, false, $size ) );
 		}
 	}
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/51780

Currently, you can call get_attached_file() and get the path to the full-sized version of the image.
However, if you can't directly get the path to a smaller variant of the image, making further code implementation prone to error and not efficient.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
