### PR TITLE
Add: Template types to the patterns API.

### DIFF
--- a/src/wp-includes/block-patterns.php
+++ b/src/wp-includes/block-patterns.php
@@ -302,6 +302,7 @@ function _register_remote_theme_patterns() {
  *   - Keywords         (comma-separated values)
  *   - Block Types      (comma-separated values)
  *   - Post Types       (comma-separated values)
+ *   - Template Types   (comma-separated values)
  *   - Inserter         (yes/no)
  *
  * @since 6.0.0

--- a/src/wp-includes/block-patterns.php
+++ b/src/wp-includes/block-patterns.php
@@ -318,6 +318,7 @@ function _register_theme_block_patterns() {
 		'blockTypes'    => 'Block Types',
 		'postTypes'     => 'Post Types',
 		'inserter'      => 'Inserter',
+		'templateTypes' => 'Template Types',
 	);
 
 	/*
@@ -388,7 +389,7 @@ function _register_theme_block_patterns() {
 					}
 
 					// For properties of type array, parse data as comma-separated.
-					foreach ( array( 'categories', 'keywords', 'blockTypes', 'postTypes' ) as $property ) {
+					foreach ( array( 'categories', 'keywords', 'blockTypes', 'postTypes', 'templateTypes' ) as $property ) {
 						if ( ! empty( $pattern_data[ $property ] ) ) {
 							$pattern_data[ $property ] = array_filter(
 								preg_split(

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-patterns-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-patterns-controller.php
@@ -250,7 +250,7 @@ class WP_REST_Block_Patterns_Controller extends WP_REST_Controller {
 					'context'     => array( 'view', 'edit', 'embed' ),
 				),
 				'template_types' => array(
-					'description' => __( 'An array of template types where the pattern fits.', 'gutenberg' ),
+					'description' => __( 'An array of template types where the pattern fits.' ),
 					'type'        => 'array',
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit', 'embed' ),

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-patterns-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-patterns-controller.php
@@ -173,6 +173,7 @@ class WP_REST_Block_Patterns_Controller extends WP_REST_Controller {
 			'keywords'      => 'keywords',
 			'content'       => 'content',
 			'inserter'      => 'inserter',
+			'templateTypes' => 'template_types',
 		);
 		$data   = array();
 		foreach ( $keys as $item_key => $rest_key ) {
@@ -244,6 +245,12 @@ class WP_REST_Block_Patterns_Controller extends WP_REST_Controller {
 				),
 				'keywords'       => array(
 					'description' => __( 'The pattern keywords.' ),
+					'type'        => 'array',
+					'readonly'    => true,
+					'context'     => array( 'view', 'edit', 'embed' ),
+				),
+				'template_types' => array(
+					'description' => __( 'An array of template types where the pattern fits.', 'gutenberg' ),
 					'type'        => 'array',
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit', 'embed' ),

--- a/tests/phpunit/tests/rest-api/wpRestBlockPatternsController.php
+++ b/tests/phpunit/tests/rest-api/wpRestBlockPatternsController.php
@@ -81,15 +81,17 @@ class Tests_REST_WpRestBlockPatternsController extends WP_Test_REST_Controller_T
 				'categories'    => array( 'test' ),
 				'viewportWidth' => 1440,
 				'content'       => '<!-- wp:heading {"level":1} --><h1>One</h1><!-- /wp:heading -->',
+				'templateTypes' => array( 'page' ),
 			)
 		);
 
 		$test_registry->register(
 			'test/two',
 			array(
-				'title'      => 'Pattern Two',
-				'categories' => array( 'test' ),
-				'content'    => '<!-- wp:paragraph --><p>Two</p><!-- /wp:paragraph -->',
+				'title'         => 'Pattern Two',
+				'categories'    => array( 'test' ),
+				'content'       => '<!-- wp:paragraph --><p>Two</p><!-- /wp:paragraph -->',
+				'templateTypes' => array( 'single' ),
 			)
 		);
 
@@ -128,7 +130,7 @@ class Tests_REST_WpRestBlockPatternsController extends WP_Test_REST_Controller_T
 		wp_set_current_user( self::$admin_id );
 
 		$request            = new WP_REST_Request( 'GET', static::REQUEST_ROUTE );
-		$request['_fields'] = 'name,content';
+		$request['_fields'] = 'name,content,template_types';
 		$response           = rest_get_server()->dispatch( $request );
 		$data               = $response->get_data();
 
@@ -136,16 +138,18 @@ class Tests_REST_WpRestBlockPatternsController extends WP_Test_REST_Controller_T
 		$this->assertGreaterThanOrEqual( 2, count( $data ), 'WP_REST_Block_Patterns_Controller::get_items() should return at least 2 items' );
 		$this->assertSame(
 			array(
-				'name'    => 'test/one',
-				'content' => '<!-- wp:heading {"level":1} --><h1>One</h1><!-- /wp:heading -->',
+				'name'           => 'test/one',
+				'content'        => '<!-- wp:heading {"level":1} --><h1>One</h1><!-- /wp:heading -->',
+				'template_types' => array( 'page' ),
 			),
 			$data[0],
 			'WP_REST_Block_Patterns_Controller::get_items() should return test/one'
 		);
 		$this->assertSame(
 			array(
-				'name'    => 'test/two',
-				'content' => '<!-- wp:paragraph --><p>Two</p><!-- /wp:paragraph -->',
+				'name'           => 'test/two',
+				'content'        => '<!-- wp:paragraph --><p>Two</p><!-- /wp:paragraph -->',
+				'template_types' => array( 'single' ),
 			),
 			$data[1],
 			'WP_REST_Block_Patterns_Controller::get_items() should return test/two'


### PR DESCRIPTION
Backports https://github.com/WordPress/gutenberg/pull/45814 into the core.

## Testing
I pasted the following sample pattern on lib/compat/wordpress-6.2/block-patterns.php.
```
register_block_pattern(
	'query/template-type-test',
	array(
		'title'      => __( 'Template type test', 'gutenberg' ),
		'templateTypes' => array( '404' ),
		'content'    => '<!-- wp:paragraph {"align":"center","fontSize":"x-large"} -->
						<p class="has-text-align-center has-x-large-font-size">404</p>
						<!-- /wp:paragraph -->',
	)
);
```
I opened the post editor and the developer tools and pasted `wp.apiFetch( { path: '/wp/v2/block-patterns/patterns' } ).then( console.log );` on the browser console.
I verified that the API response for included query/template-type-test include 404 in the templateTypes.