### PR TITLE
`WP_Text_Diff_Renderer_Table` is not compatible with PHP 8.2

### DIFF
--- a/src/wp-includes/class-wp-text-diff-renderer-table.php
+++ b/src/wp-includes/class-wp-text-diff-renderer-table.php
@@ -35,26 +35,36 @@ class WP_Text_Diff_Renderer_Table extends Text_Diff_Renderer {
 	 *
 	 * @var float
 	 * @since 2.6.0
+	 *
+	 * This property must be declared protected,
+	 * but it's declared as public not to break the backward compatibility.
+	 * @since 6.3.0
 	 */
-	protected $_diff_threshold = 0.6;
+	public $_diff_threshold = 0.6;
 
 	/**
 	 * Inline display helper object name.
 	 *
 	 * @var string
 	 * @since 2.6.0
+	 *
+	 * This property must be declared protected,
+	 * but it's declared as public not to break the backward compatibility.
+	 * @since 6.3.0
 	 */
-	protected $inline_diff_renderer = 'WP_Text_Diff_Renderer_inline';
+	public $inline_diff_renderer = 'WP_Text_Diff_Renderer_inline';
 
 	/**
 	 * Should we show the split view or not
 	 *
 	 * @var string
 	 * @since 3.6.0
+	 *
+	 * This property must be declared protected,
+	 * but it's declared as public not to break the backward compatibility.
+	 * @since 6.3.0
 	 */
-	protected $_show_split_view = true;
-
-	protected $compat_fields = array( '_show_split_view', 'inline_diff_renderer', '_diff_threshold' );
+	public $_show_split_view = true;
 
 	/**
 	 * Caches the output of count_chars() in compute_string_distance()
@@ -492,63 +502,5 @@ class WP_Text_Diff_Renderer_Table extends Text_Diff_Renderer {
 	 */
 	public function difference( $a, $b ) {
 		return abs( $a - $b );
-	}
-
-	/**
-	 * Make private properties readable for backward compatibility.
-	 *
-	 * @since 4.0.0
-	 *
-	 * @param string $name Property to get.
-	 * @return mixed Property.
-	 */
-	public function __get( $name ) {
-		if ( in_array( $name, $this->compat_fields, true ) ) {
-			return $this->$name;
-		}
-	}
-
-	/**
-	 * Make private properties settable for backward compatibility.
-	 *
-	 * @since 4.0.0
-	 *
-	 * @param string $name  Property to check if set.
-	 * @param mixed  $value Property value.
-	 * @return mixed Newly-set property.
-	 */
-	public function __set( $name, $value ) {
-		if ( in_array( $name, $this->compat_fields, true ) ) {
-			$this->$name = $value;
-		}
-	}
-
-	/**
-	 * Make private properties checkable for backward compatibility.
-	 *
-	 * @since 4.0.0
-	 *
-	 * @param string $name Property to check if set.
-	 * @return bool Whether the property is set.
-	 */
-	public function __isset( $name ) {
-		if ( in_array( $name, $this->compat_fields, true ) ) {
-			return isset( $this->$name );
-		}
-
-		return false;
-	}
-
-	/**
-	 * Make private properties un-settable for backward compatibility.
-	 *
-	 * @since 4.0.0
-	 *
-	 * @param string $name Property to unset.
-	 */
-	public function __unset( $name ) {
-		if ( in_array( $name, $this->compat_fields, true ) ) {
-			unset( $this->$name );
-		}
 	}
 }

--- a/src/wp-includes/class-wp-text-diff-renderer-table.php
+++ b/src/wp-includes/class-wp-text-diff-renderer-table.php
@@ -114,9 +114,8 @@ class WP_Text_Diff_Renderer_Table extends Text_Diff_Renderer {
 	 * @return string
 	 */
 	public function addedLine( $line ) {
-		$a = 5;
-		while ( $a < 5 ) {
-			// Nothing to do here.
+		while ( $this->parse_next_attribute() ) {
+			// No code is needed here.
 		}
 
 		return "<td class='diff-addedline'><span aria-hidden='true' class='dashicons dashicons-plus'></span><span class='screen-reader-text'>" . __( 'Added:' ) . " </span>{$line}</td>";

--- a/src/wp-includes/class-wp-text-diff-renderer-table.php
+++ b/src/wp-includes/class-wp-text-diff-renderer-table.php
@@ -507,6 +507,15 @@ class WP_Text_Diff_Renderer_Table extends Text_Diff_Renderer {
 			return $this->$name;
 		}
 
+		_doing_it_wrong(
+			__METHOD__,
+			sprintf(
+			// translators: 1: The name of the non-existent class property.
+				__( 'The "%1$s" property isn\'t defined. Dynamic properties are deprecated in PHP 8.2 and above.' ),
+				$name
+			),
+			'6.3.0'
+		);
 	}
 
 	/**
@@ -522,6 +531,16 @@ class WP_Text_Diff_Renderer_Table extends Text_Diff_Renderer {
 			$this->$name = $value;
 			return;
 		}
+
+		_doing_it_wrong(
+			__METHOD__,
+			sprintf(
+			// translators: 1: The name of the non-existent class property.
+				__( 'The "%1$s" property isn\'t defined. Dynamic properties are deprecated in PHP 8.2 and above.' ),
+				$name
+			),
+			'6.3.0'
+		);
 	}
 
 	/**

--- a/src/wp-includes/class-wp-text-diff-renderer-table.php
+++ b/src/wp-includes/class-wp-text-diff-renderer-table.php
@@ -519,7 +519,7 @@ class WP_Text_Diff_Renderer_Table extends Text_Diff_Renderer {
 	 */
 	public function __set( $name, $value ) {
 		if ( in_array( $name, $this->compat_fields, true ) ) {
-			return $this->$name = $value;
+			$this->$name = $value;
 		}
 	}
 
@@ -535,6 +535,8 @@ class WP_Text_Diff_Renderer_Table extends Text_Diff_Renderer {
 		if ( in_array( $name, $this->compat_fields, true ) ) {
 			return isset( $this->$name );
 		}
+
+		return false;
 	}
 
 	/**

--- a/src/wp-includes/class-wp-text-diff-renderer-table.php
+++ b/src/wp-includes/class-wp-text-diff-renderer-table.php
@@ -114,10 +114,6 @@ class WP_Text_Diff_Renderer_Table extends Text_Diff_Renderer {
 	 * @return string
 	 */
 	public function addedLine( $line ) {
-		while ( $this->parse_next_attribute() ) {
-			// No code is needed here.
-		}
-
 		return "<td class='diff-addedline'><span aria-hidden='true' class='dashicons dashicons-plus'></span><span class='screen-reader-text'>" . __( 'Added:' ) . " </span>{$line}</td>";
 
 	}

--- a/src/wp-includes/class-wp-text-diff-renderer-table.php
+++ b/src/wp-includes/class-wp-text-diff-renderer-table.php
@@ -35,36 +35,26 @@ class WP_Text_Diff_Renderer_Table extends Text_Diff_Renderer {
 	 *
 	 * @var float
 	 * @since 2.6.0
-	 *
-	 * This property must be declared protected,
-	 * but it's declared as public not to break the backward compatibility.
-	 * @since 6.3.0
 	 */
-	public $_diff_threshold = 0.6;
+	protected $_diff_threshold = 0.6;
 
 	/**
 	 * Inline display helper object name.
 	 *
 	 * @var string
 	 * @since 2.6.0
-	 *
-	 * This property must be declared protected,
-	 * but it's declared as public not to break the backward compatibility.
-	 * @since 6.3.0
 	 */
-	public $inline_diff_renderer = 'WP_Text_Diff_Renderer_inline';
+	protected $inline_diff_renderer = 'WP_Text_Diff_Renderer_inline';
 
 	/**
 	 * Should we show the split view or not
 	 *
 	 * @var string
 	 * @since 3.6.0
-	 *
-	 * This property must be declared protected,
-	 * but it's declared as public not to break the backward compatibility.
-	 * @since 6.3.0
 	 */
-	public $_show_split_view = true;
+	protected $_show_split_view = true;
+
+	protected $compat_fields = array( '_show_split_view', 'inline_diff_renderer', '_diff_threshold' );
 
 	/**
 	 * Caches the output of count_chars() in compute_string_distance()
@@ -502,5 +492,64 @@ class WP_Text_Diff_Renderer_Table extends Text_Diff_Renderer {
 	 */
 	public function difference( $a, $b ) {
 		return abs( $a - $b );
+	}
+
+	/**
+	 * Make private properties readable for backward compatibility.
+	 *
+	 * @since 4.0.0
+	 *
+	 * @param string $name Property to get.
+	 * @return mixed Property.
+	 */
+	public function __get( $name ) {
+		if ( in_array( $name, $this->compat_fields, true ) ) {
+			return $this->$name;
+		}
+
+	}
+
+	/**
+	 * Make private properties settable for backward compatibility.
+	 *
+	 * @since 4.0.0
+	 *
+	 * @param string $name  Property to check if set.
+	 * @param mixed  $value Property value.
+	 */
+	public function __set( $name, $value ) {
+		if ( in_array( $name, $this->compat_fields, true ) ) {
+			$this->$name = $value;
+			return;
+		}
+	}
+
+	/**
+	 * Make private properties checkable for backward compatibility.
+	 *
+	 * @since 4.0.0
+	 *
+	 * @param string $name Property to check if set.
+	 * @return bool Whether the property is set.
+	 */
+	public function __isset( $name ) {
+		if ( in_array( $name, $this->compat_fields, true ) ) {
+			return isset( $this->$name );
+		}
+
+		return false;
+	}
+
+	/**
+	 * Make private properties un-settable for backward compatibility.
+	 *
+	 * @since 4.0.0
+	 *
+	 * @param string $name Property to unset.
+	 */
+	public function __unset( $name ) {
+		if ( in_array( $name, $this->compat_fields, true ) ) {
+			unset( $this->$name );
+		}
 	}
 }

--- a/src/wp-includes/class-wp-text-diff-renderer-table.php
+++ b/src/wp-includes/class-wp-text-diff-renderer-table.php
@@ -114,6 +114,11 @@ class WP_Text_Diff_Renderer_Table extends Text_Diff_Renderer {
 	 * @return string
 	 */
 	public function addedLine( $line ) {
+		$a = 5;
+		while ( $a < 5 ) {
+			// Nothing to do here.
+		}
+
 		return "<td class='diff-addedline'><span aria-hidden='true' class='dashicons dashicons-plus'></span><span class='screen-reader-text'>" . __( 'Added:' ) . " </span>{$line}</td>";
 
 	}

--- a/tests/phpunit/tests/diff/wpTextDiffRendererTable.php
+++ b/tests/phpunit/tests/diff/wpTextDiffRendererTable.php
@@ -5,4 +5,96 @@
  */
 class Tests_Diff_WpTextDiffRendererTable extends WP_UnitTestCase {
 
+	/**
+	 * @var WP_Text_Diff_Renderer_Table
+	 */
+	private $diff_renderer_table;
+
+	public function set_up() {
+		parent::set_up();
+		require_once ABSPATH . 'wp-includes/class-wp-text-diff-renderer-table.php';
+		$this->diff_renderer_table = new WP_Text_Diff_Renderer_Table();
+	}
+
+	/**
+	 * @dataProvider data_should_allow_predefined_dynamic_properties
+	 * @ticket       56876
+	 *
+	 * @covers       WP_Text_Diff_Renderer_Table::__set
+	 * @covers       WP_Text_Diff_Renderer_Table::__get
+	 *
+	 * @param string $property_name Name of the class property.
+	 */
+	public function test_should_allow_predefined_dynamic_properties( $property_name ) {
+		$value = uniqid();
+
+		// Calling the getter first to make sure it doesn't cause errors.
+		$this->diff_renderer_table->$property_name;
+
+		$this->diff_renderer_table->$property_name = $value;
+		$this->assertSame( $value, $this->diff_renderer_table->$property_name );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_should_allow_predefined_dynamic_properties() {
+		// This code doesn't have access to self::$list_table, so the WP_Text_Diff_Renderer_Table object has to be called this way.
+		$compat_fields_property = new ReflectionProperty( $this->diff_renderer_table, 'compat_fields' );
+		$compat_fields_property->setAccessible( true );
+
+		$predefined_properties = $compat_fields_property->getValue( $this->diff_renderer_table );
+
+		$compat_fields_property->setAccessible( false );
+		$predefined_properties = array_map(
+			function ( $property_name ) {
+				return array( $property_name );
+			},
+			$predefined_properties
+		);
+
+		return $predefined_properties;
+	}
+
+	/**
+	 * @ticket 56876
+	 *
+	 * @covers WP_Text_Diff_Renderer_Table::__get
+	 */
+	public function test_should_not_allow_to_get_dynamic_properties() {
+		$this->enable_doing_it_wrong_error();
+		$property_name = uniqid();
+		$this->setExpectedIncorrectUsage( 'WP_Text_Diff_Renderer_Table::__get' );
+		$this->expectNotice();
+		$this->expectNoticeMessageMatches( '/^.+' . $property_name . '.+$/' );
+
+		// Invoking WP_Text_Diff_Renderer_Table::__get.
+		$this->diff_renderer_table->$property_name;
+	}
+
+	/**
+	 * @ticket 56876
+	 *
+	 * @covers WP_Text_Diff_Renderer_Table::__set
+	 */
+	public function test_should_not_allow_to_set_dynamic_properties() {
+		$this->enable_doing_it_wrong_error();
+		$property_name = uniqid();
+		$this->setExpectedIncorrectUsage( 'WP_Text_Diff_Renderer_Table::__set' );
+		$this->expectNotice();
+		$this->expectNoticeMessageMatches( '/^.+' . $property_name . '.+$/' );
+
+		// Invoking WP_Text_Diff_Renderer_Table::__set.
+		$this->diff_renderer_table->$property_name = 'value';
+	}
+
+	/**
+	 * This function is needed to remove the filter and disable triggering
+	 * the "doing it wrong" error.
+	 */
+	private function enable_doing_it_wrong_error() {
+		add_filter( 'doing_it_wrong_trigger_error', '__return_true', 9999 );
+	}
 }

--- a/tests/phpunit/tests/diff/wpTextDiffRendererTable.php
+++ b/tests/phpunit/tests/diff/wpTextDiffRendererTable.php
@@ -1,0 +1,8 @@
+<?php
+
+/**
+ * @group diff
+ */
+class Tests_Diff_WpTextDiffRendererTable extends WP_UnitTestCase {
+
+}

--- a/tests/phpunit/tests/diff/wpTextDiffRendererTable.php
+++ b/tests/phpunit/tests/diff/wpTextDiffRendererTable.php
@@ -4,15 +4,19 @@
  * @group diff
  */
 class Tests_Diff_WpTextDiffRendererTable extends WP_UnitTestCase {
-
 	/**
 	 * @var WP_Text_Diff_Renderer_Table
 	 */
 	private $diff_renderer_table;
 
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+		require_once ABSPATH . 'wp-includes/Text/Diff/Renderer.php';
+		require_once ABSPATH . 'wp-includes/class-wp-text-diff-renderer-table.php';
+	}
+
 	public function set_up() {
 		parent::set_up();
-		require_once ABSPATH . 'wp-includes/class-wp-text-diff-renderer-table.php';
 		$this->diff_renderer_table = new WP_Text_Diff_Renderer_Table();
 	}
 
@@ -41,11 +45,12 @@ class Tests_Diff_WpTextDiffRendererTable extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function data_should_allow_predefined_dynamic_properties() {
-		// This code doesn't have access to self::$list_table, so the WP_Text_Diff_Renderer_Table object has to be called this way.
-		$compat_fields_property = new ReflectionProperty( $this->diff_renderer_table, 'compat_fields' );
+		// This code doesn't have access to self::$renderer_table, so the WP_Text_Diff_Renderer_Table object has to be instantiated this way.
+		$renderer_table         = new WP_Text_Diff_Renderer_Table();
+		$compat_fields_property = new ReflectionProperty( $renderer_table, 'compat_fields' );
 		$compat_fields_property->setAccessible( true );
 
-		$predefined_properties = $compat_fields_property->getValue( $this->diff_renderer_table );
+		$predefined_properties = $compat_fields_property->getValue( $renderer_table );
 
 		$compat_fields_property->setAccessible( false );
 		$predefined_properties = array_map(


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This is a draft PR. Please don't review.

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
