### PR TITLE
Follow-up to `switch_to_user_locale()`

### DIFF
--- a/src/wp-includes/class-wp-locale-switcher.php
+++ b/src/wp-includes/class-wp-locale-switcher.php
@@ -92,8 +92,8 @@ class WP_Locale_Switcher {
 		 * @since 4.7.0
 		 * @since 6.2.0 The `$user_id` parameter was added.
 		 *
-		 * @param string   $locale  The new locale.
-		 * @param null|int $user_id User ID for context if available.
+		 * @param string    $locale  The new locale.
+		 * @param false|int $user_id User ID for context if available.
 		 */
 		do_action( 'switch_locale', $locale, $user_id );
 

--- a/src/wp-includes/class-wp-locale-switcher.php
+++ b/src/wp-includes/class-wp-locale-switcher.php
@@ -222,7 +222,7 @@ class WP_Locale_Switcher {
 	 * @return string The locale currently being switched to.
 	 */
 	public function filter_locale( $locale ) {
-		$switched_locale = $this->get_locale();
+		$switched_locale = $this->get_switched_locale();
 
 		if ( $switched_locale ) {
 			return $switched_locale;

--- a/src/wp-includes/class-wp-locale-switcher.php
+++ b/src/wp-includes/class-wp-locale-switcher.php
@@ -186,7 +186,7 @@ class WP_Locale_Switcher {
 	 *
 	 * @return string|false Locale if the locale has been switched, false otherwise.
 	 */
-	public function get_locale() {
+	public function get_switched_locale() {
 		$entry = end( $this->stack );
 
 		if ( $entry ) {
@@ -203,7 +203,7 @@ class WP_Locale_Switcher {
 	 *
 	 * @return int|false User ID if set and if the locale has been switched, false otherwise.
 	 */
-	public function get_user_id() {
+	public function get_switched_user_id() {
 		$entry = end( $this->stack );
 
 		if ( $entry ) {

--- a/src/wp-includes/class-wp-locale-switcher.php
+++ b/src/wp-includes/class-wp-locale-switcher.php
@@ -186,7 +186,7 @@ class WP_Locale_Switcher {
 	 *
 	 * @return string|false Locale if the locale has been switched, false otherwise.
 	 */
-	public function get_current_locale() {
+	public function get_locale() {
 		$entry = end( $this->stack );
 
 		if ( $entry ) {
@@ -203,7 +203,7 @@ class WP_Locale_Switcher {
 	 *
 	 * @return int|false User ID if set and if the locale has been switched, false otherwise.
 	 */
-	public function get_current_user_id() {
+	public function get_user_id() {
 		$entry = end( $this->stack );
 
 		if ( $entry ) {
@@ -222,7 +222,7 @@ class WP_Locale_Switcher {
 	 * @return string The locale currently being switched to.
 	 */
 	public function filter_locale( $locale ) {
-		$switched_locale = $this->get_current_locale();
+		$switched_locale = $this->get_locale();
 
 		if ( $switched_locale ) {
 			return $switched_locale;

--- a/tests/phpunit/tests/l10n/wpLocaleSwitcher.php
+++ b/tests/phpunit/tests/l10n/wpLocaleSwitcher.php
@@ -54,6 +54,10 @@ class Tests_L10n_wpLocaleSwitcher extends WP_UnitTestCase {
 
 		$wp_textdomain_registry = new WP_Textdomain_Registry();
 
+		// Clean up after any tests that don't restore the locale afterwards,
+		// before resetting $wp_locale_switcher.
+		restore_current_locale();
+
 		remove_filter( 'locale', array( $wp_locale_switcher, 'filter_locale' ) );
 		$wp_locale_switcher = new WP_Locale_Switcher();
 		$wp_locale_switcher->init();

--- a/tests/phpunit/tests/l10n/wpLocaleSwitcher.php
+++ b/tests/phpunit/tests/l10n/wpLocaleSwitcher.php
@@ -602,8 +602,8 @@ class Tests_L10n_wpLocaleSwitcher extends WP_UnitTestCase {
 	 *
 	 * @covers ::switch_to_locale
 	 * @covers ::switch_to_user_locale
-	 * @covers WP_Locale_Switcher::get_locale
-	 * @covers WP_Locale_Switcher::get_user_id
+	 * @covers WP_Locale_Switcher::get_switched_locale
+	 * @covers WP_Locale_Switcher::get_switched_user_id
 	 */
 	public function test_returns_current_locale_and_user_after_switching() {
 		global $wp_locale_switcher;
@@ -615,28 +615,28 @@ class Tests_L10n_wpLocaleSwitcher extends WP_UnitTestCase {
 			)
 		);
 
-		$locale_1  = $wp_locale_switcher->get_locale();
-		$user_id_1 = $wp_locale_switcher->get_user_id();
+		$locale_1  = $wp_locale_switcher->get_switched_locale();
+		$user_id_1 = $wp_locale_switcher->get_switched_user_id();
 
 		switch_to_user_locale( self::$user_id );
 
-		$locale_2  = $wp_locale_switcher->get_locale();
-		$user_id_2 = $wp_locale_switcher->get_user_id();
+		$locale_2  = $wp_locale_switcher->get_switched_locale();
+		$user_id_2 = $wp_locale_switcher->get_switched_user_id();
 
 		switch_to_locale( 'en_GB' );
 
-		$locale_3  = $wp_locale_switcher->get_locale();
-		$user_id_3 = $wp_locale_switcher->get_user_id();
+		$locale_3  = $wp_locale_switcher->get_switched_locale();
+		$user_id_3 = $wp_locale_switcher->get_switched_user_id();
 
 		switch_to_user_locale( $user_2 );
 
-		$locale_4  = $wp_locale_switcher->get_locale();
-		$user_id_4 = $wp_locale_switcher->get_user_id();
+		$locale_4  = $wp_locale_switcher->get_switched_locale();
+		$user_id_4 = $wp_locale_switcher->get_switched_user_id();
 
 		restore_current_locale();
 
-		$locale_5  = $wp_locale_switcher->get_locale();
-		$user_id_5 = $wp_locale_switcher->get_user_id();
+		$locale_5  = $wp_locale_switcher->get_switched_locale();
+		$user_id_5 = $wp_locale_switcher->get_switched_user_id();
 
 		$this->assertFalse( $locale_1, 'Locale should be false before switching' );
 		$this->assertFalse( $user_id_1, 'User ID should be false before switching' );
@@ -659,29 +659,29 @@ class Tests_L10n_wpLocaleSwitcher extends WP_UnitTestCase {
 	 *
 	 * @covers ::switch_to_locale
 	 * @covers ::switch_to_user_locale
-	 * @covers WP_Locale_Switcher::get_locale
-	 * @covers WP_Locale_Switcher::get_user_id
+	 * @covers WP_Locale_Switcher::get_switched_locale
+	 * @covers WP_Locale_Switcher::get_switched_user_id
 	 */
 	public function test_returns_previous_locale_and_user_after_switching() {
 		global $wp_locale_switcher;
 
-		$locale_1  = $wp_locale_switcher->get_locale();
-		$user_id_1 = $wp_locale_switcher->get_user_id();
+		$locale_1  = $wp_locale_switcher->get_switched_locale();
+		$user_id_1 = $wp_locale_switcher->get_switched_user_id();
 
 		switch_to_user_locale( self::$user_id );
 
-		$locale_2  = $wp_locale_switcher->get_locale();
-		$user_id_2 = $wp_locale_switcher->get_user_id();
+		$locale_2  = $wp_locale_switcher->get_switched_locale();
+		$user_id_2 = $wp_locale_switcher->get_switched_user_id();
 
 		switch_to_locale( 'en_GB' );
 
-		$locale_3  = $wp_locale_switcher->get_locale();
-		$user_id_3 = $wp_locale_switcher->get_user_id();
+		$locale_3  = $wp_locale_switcher->get_switched_locale();
+		$user_id_3 = $wp_locale_switcher->get_switched_user_id();
 
 		restore_previous_locale();
 
-		$locale_4  = $wp_locale_switcher->get_locale();
-		$user_id_4 = $wp_locale_switcher->get_user_id();
+		$locale_4  = $wp_locale_switcher->get_switched_locale();
+		$user_id_4 = $wp_locale_switcher->get_switched_user_id();
 
 		$this->assertFalse( $locale_1, 'Locale should be false before switching' );
 		$this->assertFalse( $user_id_1, 'User ID should be false before switching' );

--- a/tests/phpunit/tests/l10n/wpLocaleSwitcher.php
+++ b/tests/phpunit/tests/l10n/wpLocaleSwitcher.php
@@ -648,7 +648,48 @@ class Tests_L10n_wpLocaleSwitcher extends WP_UnitTestCase {
 
 		$this->assertFalse( $locale_5, 'Locale should be false after restoring' );
 		$this->assertFalse( $user_id_5, 'User ID should be false after restoring' );
+	}
 
+	/**
+	 * @ticket 57123
+	 *
+	 * @covers ::switch_to_locale
+	 * @covers ::switch_to_user_locale
+	 * @covers WP_Locale_Switcher::get_current_locale
+	 * @covers WP_Locale_Switcher::get_current_user_id
+	 */
+	public function test_returns_previous_locale_and_user_after_switching() {
+		global $wp_locale_switcher;
+
+		$locale_1  = $wp_locale_switcher->get_current_locale();
+		$user_id_1 = $wp_locale_switcher->get_current_user_id();
+
+		switch_to_user_locale( self::$user_id );
+
+		$locale_2  = $wp_locale_switcher->get_current_locale();
+		$user_id_2 = $wp_locale_switcher->get_current_user_id();
+
+		switch_to_locale( 'en_GB' );
+
+		$locale_3  = $wp_locale_switcher->get_current_locale();
+		$user_id_3 = $wp_locale_switcher->get_current_user_id();
+
+		restore_previous_locale();
+
+		$locale_4  = $wp_locale_switcher->get_current_locale();
+		$user_id_4 = $wp_locale_switcher->get_current_user_id();
+
+		$this->assertFalse( $locale_1, 'Locale should be false before switching' );
+		$this->assertFalse( $user_id_1, 'User ID should be false before switching' );
+
+		$this->assertSame( 'de_DE', $locale_2, 'The locale was not changed to de_DE' );
+		$this->assertSame( self::$user_id, $user_id_2, 'User ID should match the main admin ID' );
+
+		$this->assertSame( 'en_GB', $locale_3, 'The locale was not changed to en_GB' );
+		$this->assertFalse( $user_id_3, 'User ID should be false after normal locale switching' );
+
+		$this->assertSame( 'de_DE', $locale_4, 'The locale was not changed back to de_DE' );
+		$this->assertSame( self::$user_id, $user_id_4, 'User ID should match the main admin ID again' );
 	}
 
 	public function filter_locale() {

--- a/tests/phpunit/tests/l10n/wpLocaleSwitcher.php
+++ b/tests/phpunit/tests/l10n/wpLocaleSwitcher.php
@@ -598,8 +598,8 @@ class Tests_L10n_wpLocaleSwitcher extends WP_UnitTestCase {
 	 *
 	 * @covers ::switch_to_locale
 	 * @covers ::switch_to_user_locale
-	 * @covers WP_Locale_Switcher::get_current_locale
-	 * @covers WP_Locale_Switcher::get_current_user_id
+	 * @covers WP_Locale_Switcher::get_locale
+	 * @covers WP_Locale_Switcher::get_user_id
 	 */
 	public function test_returns_current_locale_and_user_after_switching() {
 		global $wp_locale_switcher;
@@ -611,28 +611,28 @@ class Tests_L10n_wpLocaleSwitcher extends WP_UnitTestCase {
 			)
 		);
 
-		$locale_1  = $wp_locale_switcher->get_current_locale();
-		$user_id_1 = $wp_locale_switcher->get_current_user_id();
+		$locale_1  = $wp_locale_switcher->get_locale();
+		$user_id_1 = $wp_locale_switcher->get_user_id();
 
 		switch_to_user_locale( self::$user_id );
 
-		$locale_2  = $wp_locale_switcher->get_current_locale();
-		$user_id_2 = $wp_locale_switcher->get_current_user_id();
+		$locale_2  = $wp_locale_switcher->get_locale();
+		$user_id_2 = $wp_locale_switcher->get_user_id();
 
 		switch_to_locale( 'en_GB' );
 
-		$locale_3  = $wp_locale_switcher->get_current_locale();
-		$user_id_3 = $wp_locale_switcher->get_current_user_id();
+		$locale_3  = $wp_locale_switcher->get_locale();
+		$user_id_3 = $wp_locale_switcher->get_user_id();
 
 		switch_to_user_locale( $user_2 );
 
-		$locale_4  = $wp_locale_switcher->get_current_locale();
-		$user_id_4 = $wp_locale_switcher->get_current_user_id();
+		$locale_4  = $wp_locale_switcher->get_locale();
+		$user_id_4 = $wp_locale_switcher->get_user_id();
 
 		restore_current_locale();
 
-		$locale_5  = $wp_locale_switcher->get_current_locale();
-		$user_id_5 = $wp_locale_switcher->get_current_user_id();
+		$locale_5  = $wp_locale_switcher->get_locale();
+		$user_id_5 = $wp_locale_switcher->get_user_id();
 
 		$this->assertFalse( $locale_1, 'Locale should be false before switching' );
 		$this->assertFalse( $user_id_1, 'User ID should be false before switching' );
@@ -655,29 +655,29 @@ class Tests_L10n_wpLocaleSwitcher extends WP_UnitTestCase {
 	 *
 	 * @covers ::switch_to_locale
 	 * @covers ::switch_to_user_locale
-	 * @covers WP_Locale_Switcher::get_current_locale
-	 * @covers WP_Locale_Switcher::get_current_user_id
+	 * @covers WP_Locale_Switcher::get_locale
+	 * @covers WP_Locale_Switcher::get_user_id
 	 */
 	public function test_returns_previous_locale_and_user_after_switching() {
 		global $wp_locale_switcher;
 
-		$locale_1  = $wp_locale_switcher->get_current_locale();
-		$user_id_1 = $wp_locale_switcher->get_current_user_id();
+		$locale_1  = $wp_locale_switcher->get_locale();
+		$user_id_1 = $wp_locale_switcher->get_user_id();
 
 		switch_to_user_locale( self::$user_id );
 
-		$locale_2  = $wp_locale_switcher->get_current_locale();
-		$user_id_2 = $wp_locale_switcher->get_current_user_id();
+		$locale_2  = $wp_locale_switcher->get_locale();
+		$user_id_2 = $wp_locale_switcher->get_user_id();
 
 		switch_to_locale( 'en_GB' );
 
-		$locale_3  = $wp_locale_switcher->get_current_locale();
-		$user_id_3 = $wp_locale_switcher->get_current_user_id();
+		$locale_3  = $wp_locale_switcher->get_locale();
+		$user_id_3 = $wp_locale_switcher->get_user_id();
 
 		restore_previous_locale();
 
-		$locale_4  = $wp_locale_switcher->get_current_locale();
-		$user_id_4 = $wp_locale_switcher->get_current_user_id();
+		$locale_4  = $wp_locale_switcher->get_locale();
+		$user_id_4 = $wp_locale_switcher->get_user_id();
 
 		$this->assertFalse( $locale_1, 'Locale should be false before switching' );
 		$this->assertFalse( $user_id_1, 'User ID should be false before switching' );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

This is a follow-up to #3637 / https://core.trac.wordpress.org/changeset/55161 with the following changes:

* Fix docblock for `switch_locale` filter. The User ID is `false` if missing, not `null`. Props @ocean90.
* Rename `::get_current_locale()` to `::get_switched_locale()` and `::get_current_user_id()` to `::get_switched_user_id()`. Props @JJJ and @ocean90 .
* Add additional test involving `restore_previous_locale()` as suggested by @ocean90.

Trac ticket: https://core.trac.wordpress.org/ticket/57123

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
