### PR TITLE
Updated patch on 56170 for tests

### DIFF
--- a/src/wp-admin/upload.php
+++ b/src/wp-admin/upload.php
@@ -219,6 +219,7 @@ if ( $doaction ) {
 	} elseif ( isset( $_REQUEST['ids'] ) ) {
 		$post_ids = explode( ',', $_REQUEST['ids'] );
 	}
+	$post_ids = array_map( 'intval', (array) $post_ids );
 
 	$location = 'upload.php';
 	$referer  = wp_get_referer();
@@ -241,7 +242,7 @@ if ( $doaction ) {
 			if ( empty( $post_ids ) ) {
 				break;
 			}
-			foreach ( (array) $post_ids as $post_id ) {
+			foreach ( $post_ids as $post_id ) {
 				if ( ! current_user_can( 'delete_post', $post_id ) ) {
 					wp_die( __( 'Sorry, you are not allowed to move this item to the Trash.' ) );
 				}
@@ -262,7 +263,7 @@ if ( $doaction ) {
 			if ( empty( $post_ids ) ) {
 				break;
 			}
-			foreach ( (array) $post_ids as $post_id ) {
+			foreach ( $post_ids as $post_id ) {
 				if ( ! current_user_can( 'delete_post', $post_id ) ) {
 					wp_die( __( 'Sorry, you are not allowed to restore this item from the Trash.' ) );
 				}
@@ -277,7 +278,7 @@ if ( $doaction ) {
 			if ( empty( $post_ids ) ) {
 				break;
 			}
-			foreach ( (array) $post_ids as $post_id_del ) {
+			foreach ( $post_ids as $post_id_del ) {
 				if ( ! current_user_can( 'delete_post', $post_id_del ) ) {
 					wp_die( __( 'Sorry, you are not allowed to delete this item.' ) );
 				}


### PR DESCRIPTION
Ensure that post IDs passed to `wp_trash_post`, `wp_untrash_post`, and `wp_delete_attachment` are always of type `int`.

Trac ticket: https://core.trac.wordpress.org/ticket/56170

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
