### PR TITLE
Type cast to string as null may be passed and gives PHP8.1 Deprecation notice

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -5394,7 +5394,7 @@ function normalize_whitespace( $str ) {
  * @return string The processed string.
  */
 function wp_strip_all_tags( $text, $remove_breaks = false ) {
-	$text = preg_replace( '@<(script|style)[^>]*?>.*?</\\1>@si', '', $text );
+	$text = preg_replace( '@<(script|style)[^>]*?>.*?</\\1>@si', '', (string) $text );
 	$text = strip_tags( $text );
 
 	if ( $remove_breaks ) {

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -597,7 +597,7 @@ if ( ! function_exists( 'wp_authenticate' ) ) :
 	 */
 	function wp_authenticate( $username, $password ) {
 		$username = sanitize_user( $username );
-		$password = trim( $password );
+		$password = trim( (string) $password );
 
 		/**
 		 * Filters whether a set of user login credentials are valid.


### PR DESCRIPTION
In testing Rollback during an auto-update I discovered some PHP Deprecation notices that only occur in PHP8.1 as `null` is the passed value. Both of these values should be strings. These are easily fixed by type casting.

Trac ticket: https://core.trac.wordpress.org/ticket/57605#ticket
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
