### PR TITLE
Support the `blockTypes` and `viewport_width` props for remote patterns fetched from Pattern Directory

### DIFF
--- a/src/wp-includes/block-patterns.php
+++ b/src/wp-includes/block-patterns.php
@@ -159,10 +159,32 @@ function _register_core_block_patterns_and_categories() {
 }
 
 /**
+ * Normalize the pattern from the API (snake_case) to the format expected by `register_block_pattern` (camelCase).
+ *
+ * @since 6.2.0
+ *
+ * @param array $pattern Pattern as returned from the Pattern Directory API.
+ */
+function _normalize_remote_pattern( $pattern ) {
+	if ( isset( $pattern['block_types'] ) ) {
+		$pattern['blockTypes'] = $pattern['block_types'];
+		unset( $pattern['block_types'] );
+	}
+
+	if ( isset( $pattern['viewport_width'] ) ) {
+		$pattern['viewportWidth'] = $pattern['viewport_width'];
+		unset( $pattern['viewport_width'] );
+	}
+
+	return (array) $pattern;
+}
+
+/**
  * Register Core's official patterns from wordpress.org/patterns.
  *
  * @since 5.8.0
  * @since 5.9.0 The $current_screen argument was removed.
+ * @since 6.2.0 Normalize the pattern from the API (snake_case) to the format expected by `register_block_pattern` (camelCase).
  *
  * @param WP_Screen $deprecated Unused. Formerly the screen that the current request was triggered from.
  */
@@ -196,9 +218,10 @@ function _load_remote_block_patterns( $deprecated = null ) {
 		}
 		$patterns = $response->get_data();
 
-		foreach ( $patterns as $settings ) {
-			$pattern_name = 'core/' . sanitize_title( $settings['title'] );
-			register_block_pattern( $pattern_name, (array) $settings );
+		foreach ( $patterns as $pattern ) {
+			$normalized_pattern = _normalize_remote_pattern( $pattern );
+			$pattern_name       = 'core/' . sanitize_title( $normalized_pattern['title'] );
+			register_block_pattern( $pattern_name, (array) $normalized_pattern );
 		}
 	}
 }
@@ -207,6 +230,7 @@ function _load_remote_block_patterns( $deprecated = null ) {
  * Register `Featured` (category) patterns from wordpress.org/patterns.
  *
  * @since 5.9.0
+ * @since 6.2.0 Normalize the pattern from the API (snake_case) to the format expected by `register_block_pattern` (camelCase).
  */
 function _load_remote_featured_patterns() {
 	$supports_core_patterns = get_theme_support( 'core-block-patterns' );
@@ -226,14 +250,14 @@ function _load_remote_featured_patterns() {
 		return;
 	}
 	$patterns = $response->get_data();
-
+	$registry = WP_Block_Patterns_Registry::get_instance();
 	foreach ( $patterns as $pattern ) {
-		$pattern_name = sanitize_title( $pattern['title'] );
-		$registry     = WP_Block_Patterns_Registry::get_instance();
+		$normalized_pattern = _normalize_remote_pattern( $pattern );
+		$pattern_name       = sanitize_title( $normalized_pattern['title'] );
 		// Some patterns might be already registered as core patterns with the `core` prefix.
 		$is_registered = $registry->is_registered( $pattern_name ) || $registry->is_registered( "core/$pattern_name" );
 		if ( ! $is_registered ) {
-			register_block_pattern( $pattern_name, (array) $pattern );
+			register_block_pattern( $pattern_name, (array) $normalized_pattern );
 		}
 	}
 }
@@ -243,6 +267,7 @@ function _load_remote_featured_patterns() {
  * `theme.json` file.
  *
  * @since 6.0.0
+ * @since 6.2.0 Normalize the pattern from the API (snake_case) to the format expected by `register_block_pattern` (camelCase).
  * @access private
  */
 function _register_remote_theme_patterns() {
@@ -269,11 +294,12 @@ function _register_remote_theme_patterns() {
 	$patterns          = $response->get_data();
 	$patterns_registry = WP_Block_Patterns_Registry::get_instance();
 	foreach ( $patterns as $pattern ) {
-		$pattern_name = sanitize_title( $pattern['title'] );
+		$normalized_pattern = _normalize_remote_pattern( $pattern );
+		$pattern_name       = sanitize_title( $normalized_pattern['title'] );
 		// Some patterns might be already registered as core patterns with the `core` prefix.
 		$is_registered = $patterns_registry->is_registered( $pattern_name ) || $patterns_registry->is_registered( "core/$pattern_name" );
 		if ( ! $is_registered ) {
-			register_block_pattern( $pattern_name, (array) $pattern );
+			register_block_pattern( $pattern_name, (array) $normalized_pattern );
 		}
 	}
 }

--- a/src/wp-includes/block-patterns.php
+++ b/src/wp-includes/block-patterns.php
@@ -226,7 +226,7 @@ function _load_remote_block_patterns( $deprecated = null ) {
 		foreach ( $patterns as $pattern ) {
 			$normalized_pattern = _normalize_remote_pattern( $pattern );
 			$pattern_name       = 'core/' . sanitize_title( $normalized_pattern['title'] );
-			register_block_pattern( $pattern_name, (array) $normalized_pattern );
+			register_block_pattern( $pattern_name, $normalized_pattern );
 		}
 	}
 }
@@ -263,7 +263,7 @@ function _load_remote_featured_patterns() {
 		// Some patterns might be already registered as core patterns with the `core` prefix.
 		$is_registered = $registry->is_registered( $pattern_name ) || $registry->is_registered( "core/$pattern_name" );
 		if ( ! $is_registered ) {
-			register_block_pattern( $pattern_name, (array) $normalized_pattern );
+			register_block_pattern( $pattern_name, $normalized_pattern );
 		}
 	}
 }
@@ -306,7 +306,7 @@ function _register_remote_theme_patterns() {
 		// Some patterns might be already registered as core patterns with the `core` prefix.
 		$is_registered = $patterns_registry->is_registered( $pattern_name ) || $patterns_registry->is_registered( "core/$pattern_name" );
 		if ( ! $is_registered ) {
-			register_block_pattern( $pattern_name, (array) $normalized_pattern );
+			register_block_pattern( $pattern_name, $normalized_pattern );
 		}
 	}
 }

--- a/src/wp-includes/block-patterns.php
+++ b/src/wp-includes/block-patterns.php
@@ -169,7 +169,7 @@ function _register_core_block_patterns_and_categories() {
  * @param array $pattern Pattern as returned from the Pattern Directory API.
  * @return array Normalized pattern.
  */
-function _normalize_remote_block_pattern( $pattern ) {
+function wp_normalize_remote_block_pattern( $pattern ) {
 	if ( isset( $pattern['block_types'] ) ) {
 		$pattern['blockTypes'] = $pattern['block_types'];
 		unset( $pattern['block_types'] );
@@ -224,7 +224,7 @@ function _load_remote_block_patterns( $deprecated = null ) {
 		$patterns = $response->get_data();
 
 		foreach ( $patterns as $pattern ) {
-			$normalized_pattern = _normalize_remote_block_pattern( $pattern );
+			$normalized_pattern = wp_normalize_remote_block_pattern( $pattern );
 			$pattern_name       = 'core/' . sanitize_title( $normalized_pattern['title'] );
 			register_block_pattern( $pattern_name, $normalized_pattern );
 		}
@@ -258,7 +258,7 @@ function _load_remote_featured_patterns() {
 	$patterns = $response->get_data();
 	$registry = WP_Block_Patterns_Registry::get_instance();
 	foreach ( $patterns as $pattern ) {
-		$normalized_pattern = _normalize_remote_block_pattern( $pattern );
+		$normalized_pattern = wp_normalize_remote_block_pattern( $pattern );
 		$pattern_name       = sanitize_title( $normalized_pattern['title'] );
 		// Some patterns might be already registered as core patterns with the `core` prefix.
 		$is_registered = $registry->is_registered( $pattern_name ) || $registry->is_registered( "core/$pattern_name" );
@@ -301,7 +301,7 @@ function _register_remote_theme_patterns() {
 	$patterns          = $response->get_data();
 	$patterns_registry = WP_Block_Patterns_Registry::get_instance();
 	foreach ( $patterns as $pattern ) {
-		$normalized_pattern = _normalize_remote_block_pattern( $pattern );
+		$normalized_pattern = wp_normalize_remote_block_pattern( $pattern );
 		$pattern_name       = sanitize_title( $normalized_pattern['title'] );
 		// Some patterns might be already registered as core patterns with the `core` prefix.
 		$is_registered = $patterns_registry->is_registered( $pattern_name ) || $patterns_registry->is_registered( "core/$pattern_name" );

--- a/src/wp-includes/block-patterns.php
+++ b/src/wp-includes/block-patterns.php
@@ -169,7 +169,7 @@ function _register_core_block_patterns_and_categories() {
  * @param array $pattern Pattern as returned from the Pattern Directory API.
  * @return array Normalized pattern.
  */
-function _normalize_remote_pattern( $pattern ) {
+function _normalize_remote_block_pattern( $pattern ) {
 	if ( isset( $pattern['block_types'] ) ) {
 		$pattern['blockTypes'] = $pattern['block_types'];
 		unset( $pattern['block_types'] );
@@ -224,7 +224,7 @@ function _load_remote_block_patterns( $deprecated = null ) {
 		$patterns = $response->get_data();
 
 		foreach ( $patterns as $pattern ) {
-			$normalized_pattern = _normalize_remote_pattern( $pattern );
+			$normalized_pattern = _normalize_remote_block_pattern( $pattern );
 			$pattern_name       = 'core/' . sanitize_title( $normalized_pattern['title'] );
 			register_block_pattern( $pattern_name, $normalized_pattern );
 		}
@@ -258,7 +258,7 @@ function _load_remote_featured_patterns() {
 	$patterns = $response->get_data();
 	$registry = WP_Block_Patterns_Registry::get_instance();
 	foreach ( $patterns as $pattern ) {
-		$normalized_pattern = _normalize_remote_pattern( $pattern );
+		$normalized_pattern = _normalize_remote_block_pattern( $pattern );
 		$pattern_name       = sanitize_title( $normalized_pattern['title'] );
 		// Some patterns might be already registered as core patterns with the `core` prefix.
 		$is_registered = $registry->is_registered( $pattern_name ) || $registry->is_registered( "core/$pattern_name" );
@@ -301,7 +301,7 @@ function _register_remote_theme_patterns() {
 	$patterns          = $response->get_data();
 	$patterns_registry = WP_Block_Patterns_Registry::get_instance();
 	foreach ( $patterns as $pattern ) {
-		$normalized_pattern = _normalize_remote_pattern( $pattern );
+		$normalized_pattern = _normalize_remote_block_pattern( $pattern );
 		$pattern_name       = sanitize_title( $normalized_pattern['title'] );
 		// Some patterns might be already registered as core patterns with the `core` prefix.
 		$is_registered = $patterns_registry->is_registered( $pattern_name ) || $patterns_registry->is_registered( "core/$pattern_name" );

--- a/src/wp-includes/block-patterns.php
+++ b/src/wp-includes/block-patterns.php
@@ -159,11 +159,15 @@ function _register_core_block_patterns_and_categories() {
 }
 
 /**
- * Normalize the pattern from the API (snake_case) to the format expected by `register_block_pattern` (camelCase).
+ * Normalize the pattern properties to camelCase.
+ *
+ * The API's format is snake_case, `register_block_pattern()` expects camelCase.
  *
  * @since 6.2.0
+ * @access private
  *
  * @param array $pattern Pattern as returned from the Pattern Directory API.
+ * @return array Normalized pattern.
  */
 function _normalize_remote_pattern( $pattern ) {
 	if ( isset( $pattern['block_types'] ) ) {
@@ -184,7 +188,8 @@ function _normalize_remote_pattern( $pattern ) {
  *
  * @since 5.8.0
  * @since 5.9.0 The $current_screen argument was removed.
- * @since 6.2.0 Normalize the pattern from the API (snake_case) to the format expected by `register_block_pattern` (camelCase).
+ * @since 6.2.0 Normalize the pattern from the API (snake_case) to the
+ *              format expected by `register_block_pattern` (camelCase).
  *
  * @param WP_Screen $deprecated Unused. Formerly the screen that the current request was triggered from.
  */
@@ -230,7 +235,8 @@ function _load_remote_block_patterns( $deprecated = null ) {
  * Register `Featured` (category) patterns from wordpress.org/patterns.
  *
  * @since 5.9.0
- * @since 6.2.0 Normalize the pattern from the API (snake_case) to the format expected by `register_block_pattern` (camelCase).
+ * @since 6.2.0 Normalized the pattern from the API (snake_case) to the
+ *              format expected by `register_block_pattern()` (camelCase).
  */
 function _load_remote_featured_patterns() {
 	$supports_core_patterns = get_theme_support( 'core-block-patterns' );
@@ -267,7 +273,8 @@ function _load_remote_featured_patterns() {
  * `theme.json` file.
  *
  * @since 6.0.0
- * @since 6.2.0 Normalize the pattern from the API (snake_case) to the format expected by `register_block_pattern` (camelCase).
+ * @since 6.2.0 Normalized the pattern from the API (snake_case) to the
+ *              format expected by `register_block_pattern()` (camelCase).
  * @access private
  */
 function _register_remote_theme_patterns() {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-pattern-directory-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-pattern-directory-controller.php
@@ -225,6 +225,7 @@ class WP_REST_Pattern_Directory_Controller extends WP_REST_Controller {
 	 * Retrieves the block pattern's schema, conforming to JSON Schema.
 	 *
 	 * @since 5.8.0
+	 * @since 6.2.0 Added `'block_types'` to schema.
 	 *
 	 * @return array Item schema data.
 	 */

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-pattern-directory-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-pattern-directory-controller.php
@@ -103,7 +103,7 @@ class WP_REST_Pattern_Directory_Controller extends WP_REST_Controller {
 			'search'   => true,
 			'slug'     => true,
 		);
-		$query_args = array_intersect_key( $request->get_params(), $valid_query_args );
+		$query_args       = array_intersect_key( $request->get_params(), $valid_query_args );
 
 		$query_args['locale']             = get_user_locale();
 		$query_args['wp-version']         = $wp_version; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable -- it's defined in `version.php` above.
@@ -202,6 +202,7 @@ class WP_REST_Pattern_Directory_Controller extends WP_REST_Controller {
 			'keywords'       => array_map( 'sanitize_text_field', explode( ',', $raw_pattern->meta->wpop_keywords ) ),
 			'description'    => sanitize_text_field( $raw_pattern->meta->wpop_description ),
 			'viewport_width' => absint( $raw_pattern->meta->wpop_viewport_width ),
+			'block_types'    => array_map( 'sanitize_text_field', $raw_pattern->meta->wpop_block_types ),
 		);
 
 		$prepared_pattern = $this->add_additional_fields_to_object( $prepared_pattern, $request );
@@ -285,6 +286,14 @@ class WP_REST_Pattern_Directory_Controller extends WP_REST_Controller {
 					'description' => __( 'The preferred width of the viewport when previewing a pattern, in pixels.' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit', 'embed' ),
+				),
+
+				'block_types'    => array(
+					'description' => __( 'The block types which can use this pattern.' ),
+					'type'        => 'array',
+					'uniqueItems' => true,
+					'items'       => array( 'type' => 'string' ),
+					'context'     => array( 'view', 'embed' ),
 				),
 			),
 		);

--- a/tests/phpunit/data/blocks/pattern-directory/browse-all.json
+++ b/tests/phpunit/data/blocks/pattern-directory/browse-all.json
@@ -10,7 +10,8 @@
 			"spay_email": "",
 			"wpop_description": "A heading preceded by a chapter number, and followed by a paragraph.",
 			"wpop_keywords": "blog post",
-			"wpop_viewport_width": 1000
+			"wpop_viewport_width": 1000,
+			"wpop_block_types": [ "core/heading" ]
 		},
 		"category_slugs": [ "text" ],
 		"keyword_slugs": [ "core" ],
@@ -27,7 +28,8 @@
 			"spay_email": "",
 			"wpop_description": "A large hero section with an example background image and a heading in the center.",
 			"wpop_keywords": "header, hero",
-			"wpop_viewport_width": 1000
+			"wpop_viewport_width": 1000,
+			"wpop_block_types": []
 		},
 		"category_slugs": [ "header" ],
 		"keyword_slugs": [ "core" ],
@@ -44,7 +46,8 @@
 			"spay_email": "",
 			"wpop_description": "A large hero section with a bright gradient background, a big heading and a filled button.",
 			"wpop_keywords": "call to action, hero section",
-			"wpop_viewport_width": 1000
+			"wpop_viewport_width": 1000,
+			"wpop_block_types": []
 		},
 		"category_slugs": [ "header" ],
 		"keyword_slugs": [ "core" ],

--- a/tests/phpunit/data/blocks/pattern-directory/browse-category-2.json
+++ b/tests/phpunit/data/blocks/pattern-directory/browse-category-2.json
@@ -10,7 +10,8 @@
 			"spay_email": "",
 			"wpop_description": "Three filled buttons with rounded corners, side by side.",
 			"wpop_keywords": "",
-			"wpop_viewport_width": 600
+			"wpop_viewport_width": 600,
+			"wpop_block_types": []
 		},
 		"category_slugs": [ "buttons" ],
 		"keyword_slugs": [ "core" ],
@@ -27,7 +28,8 @@
 			"spay_email": "",
 			"wpop_description": "Two buttons, one filled and one outlined, side by side.",
 			"wpop_keywords": "",
-			"wpop_viewport_width": 500
+			"wpop_viewport_width": 500,
+			"wpop_block_types": []
 		},
 		"category_slugs": [ "buttons" ],
 		"keyword_slugs": [ "core" ],

--- a/tests/phpunit/data/blocks/pattern-directory/browse-keyword-11.json
+++ b/tests/phpunit/data/blocks/pattern-directory/browse-keyword-11.json
@@ -10,7 +10,8 @@
 			"spay_email": "",
 			"wpop_description": "A heading preceded by a chapter number, and followed by a paragraph.",
 			"wpop_keywords": "",
-			"wpop_viewport_width": 1000
+			"wpop_viewport_width": 1000,
+			"wpop_block_types": []
 		},
 		"category_slugs": [ "text" ],
 		"keyword_slugs": [ "core" ],
@@ -27,7 +28,8 @@
 			"spay_email": "",
 			"wpop_description": "A large hero section with an example background image and a heading in the center.",
 			"wpop_keywords": "",
-			"wpop_viewport_width": 1000
+			"wpop_viewport_width": 1000,
+			"wpop_block_types": []
 		},
 		"category_slugs": [ "header" ],
 		"keyword_slugs": [ "core" ],
@@ -44,7 +46,8 @@
 			"spay_email": "",
 			"wpop_description": "A large hero section with a bright gradient background, a big heading and a filled button.",
 			"wpop_keywords": "",
-			"wpop_viewport_width": 1000
+			"wpop_viewport_width": 1000,
+			"wpop_block_types": []
 		},
 		"category_slugs": [ "header" ],
 		"keyword_slugs": [ "core" ],

--- a/tests/phpunit/data/blocks/pattern-directory/search-button.json
+++ b/tests/phpunit/data/blocks/pattern-directory/search-button.json
@@ -10,7 +10,8 @@
 			"spay_email": "",
 			"wpop_description": "A large hero section with a bright gradient background, a big heading and a filled button.",
 			"wpop_keywords": "",
-			"wpop_viewport_width": 1000
+			"wpop_viewport_width": 1000,
+			"wpop_block_types": []
 		},
 		"category_slugs": [ "header" ],
 		"keyword_slugs": [ "core" ],
@@ -27,7 +28,8 @@
 			"spay_email": "",
 			"wpop_description": "Three small columns of text, each with an outlined button with rounded corners at the bottom.",
 			"wpop_keywords": "",
-			"wpop_viewport_width": 1000
+			"wpop_viewport_width": 1000,
+			"wpop_block_types": []
 		},
 		"category_slugs": [ "columns" ],
 		"keyword_slugs": [ "core" ],
@@ -44,7 +46,8 @@
 			"spay_email": "",
 			"wpop_description": "Three filled buttons with rounded corners, side by side.",
 			"wpop_keywords": "",
-			"wpop_viewport_width": 600
+			"wpop_viewport_width": 600,
+			"wpop_block_types": []
 		},
 		"category_slugs": [ "buttons" ],
 		"keyword_slugs": [ "core" ],
@@ -61,7 +64,8 @@
 			"spay_email": "",
 			"wpop_description": "Two buttons, one filled and one outlined, side by side.",
 			"wpop_keywords": "",
-			"wpop_viewport_width": 500
+			"wpop_viewport_width": 500,
+			"wpop_block_types": []
 		},
 		"category_slugs": [ "buttons" ],
 		"keyword_slugs": [ "core" ],


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/57611

We need to add the support for `block_types` and `viewport_width` props for remote patterns fetched from Pattern Directory.

With this support, we can fetch remote patterns and use them properly as suggestions where needed.

The addition of block_types field in Pattern Directory API was made here: https://github.com/WordPress/pattern-directory/pull/111


GB PR: https://github.com/WordPress/gutenberg/pull/47677

props @ryelle 

#### Before

https://user-images.githubusercontent.com/16275880/216287451-cbadec15-3a7e-4461-bb8e-d3e8ea7f9aab.mov



#### After


https://user-images.githubusercontent.com/16275880/216287480-253f724b-4605-4387-9796-8767cd0fa080.mov



## Testing Instructions
1. Insert a Heading block
2. Open the block switcher menu
3. Observe that there is a pattern suggested, coming from Pattern Directory



---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
