### PR TITLE
fix: `wp_theme_json_data_default` filter is not properly to setting `settings.spacing.padding` value

### DIFF
--- a/tests/phpunit/tests/theme/wpThemeJsonResolver.php
+++ b/tests/phpunit/tests/theme/wpThemeJsonResolver.php
@@ -777,7 +777,6 @@ class Tests_Theme_wpThemeJsonResolver extends WP_UnitTestCase {
 						),
 					),
 				);
-		
 				return $theme_json->update_with( $new_data );
 			}
 		);
@@ -785,7 +784,6 @@ class Tests_Theme_wpThemeJsonResolver extends WP_UnitTestCase {
 		// expect that $core_settings['spacing']['padding'] is true
 		$core_settings = WP_Theme_JSON_Resolver::get_core_data()->get_settings();
 		$this->assertTrue( $core_settings['spacing']['padding'] );
-		
 		// expect that $merged_settings['spacing']['padding'] is true
 		$merged_settings = WP_Theme_JSON_Resolver::get_merged_data()->get_settings();
 		$this->assertTrue( $merged_settings['spacing']['padding'] );

--- a/tests/phpunit/tests/theme/wpThemeJsonResolver.php
+++ b/tests/phpunit/tests/theme/wpThemeJsonResolver.php
@@ -752,6 +752,46 @@ class Tests_Theme_wpThemeJsonResolver extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 57599
+	 * @covers WP_Theme_JSON_Resolver::get_core_data
+	 */
+	public function test_get_theme_json_data_default_filter_applies_correctly() {
+
+		// expect that $core_settings['spacing']['padding'] is false
+		$core_settings = WP_Theme_JSON_Resolver::get_core_data()->get_settings();
+		$this->assertFalse( $core_settings['spacing']['padding'], 'initial value of the spacing padding support in the core layer should be false' );
+
+		// expect that $merged_settings['spacing']['padding'] is false
+		$merged_settings = WP_Theme_JSON_Resolver::get_merged_data()->get_settings();
+		$this->assertFalse( $merged_settings['spacing']['padding'], 'initial value of the spacing padding support in the final merged theme.json should be false' );
+
+		// apply filter to change $core_settings['spacing']['padding'] to true
+		add_filter(
+			'wp_theme_json_data_default',
+			function( $theme_json ) {
+				$new_data = array(
+					'version' => 2,
+					'settings' => array(
+						'spacing' => array(
+							'padding' => true,
+						),
+					),
+				);
+		
+				return $theme_json->update_with( $new_data );
+			}
+		);
+
+		// expect that $core_settings['spacing']['padding'] is true
+		$core_settings = WP_Theme_JSON_Resolver::get_core_data()->get_settings();
+		$this->assertTrue( $core_settings['spacing']['padding'] );
+		
+		// expect that $merged_settings['spacing']['padding'] is true
+		$merged_settings = WP_Theme_JSON_Resolver::get_merged_data()->get_settings();
+		$this->assertTrue( $merged_settings['spacing']['padding'] );
+	}
+
+	/**
 	 * @ticket 56945
 	 * @covers WP_Theme_JSON_Resolver::get_theme_data
 	 */


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/57599

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
