### PR TITLE
Output empty string for get_comment_text() if comment doesn't exist

### DIFF
--- a/src/wp-includes/class-wp-comment.php
+++ b/src/wp-includes/class-wp-comment.php
@@ -183,7 +183,7 @@ final class WP_Comment {
 	public static function get_instance( $id ) {
 		global $wpdb;
 
-		$comment_id = (int) $id;
+		$comment_id = is_numeric( $id ) ? (int) $id : false;
 		if ( ! $comment_id ) {
 			return false;
 		}

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -965,21 +965,24 @@ function get_comments_number_text( $zero = false, $one = false, $more = false, $
  * @return string The comment content.
  */
 function get_comment_text( $comment_ID = 0, $args = array() ) {
-	$comment = get_comment( $comment_ID );
+	$comment         = get_comment( $comment_ID );
+	$comment_content = '';
 
-	$comment_content = $comment->comment_content;
+	if ( ! is_null( $comment ) ) {
+		$comment_content = $comment->comment_content;
 
-	if ( is_comment_feed() && $comment->comment_parent ) {
-		$parent = get_comment( $comment->comment_parent );
-		if ( $parent ) {
-			$parent_link = esc_url( get_comment_link( $parent ) );
-			$name        = get_comment_author( $parent );
+		if ( is_comment_feed() && $comment->comment_parent ) {
+			$parent = get_comment( $comment->comment_parent );
+			if ( $parent ) {
+				$parent_link = esc_url( get_comment_link( $parent ) );
+				$name        = get_comment_author( $parent );
 
-			$comment_content = sprintf(
-				/* translators: %s: Comment link. */
-				ent2ncr( __( 'In reply to %s.' ) ),
-				'<a href="' . $parent_link . '">' . $name . '</a>'
-			) . "\n\n" . $comment_content;
+				$comment_content = sprintf(
+					/* translators: %s: Comment link. */
+					ent2ncr( __( 'In reply to %s.' ) ),
+					'<a href="' . $parent_link . '">' . $name . '</a>'
+				) . "\n\n" . $comment_content;
+			}
 		}
 	}
 

--- a/tests/phpunit/tests/comment/getCommentText.php
+++ b/tests/phpunit/tests/comment/getCommentText.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * @group comment
+ *
+ * @covers ::get_comment_text
+ */
+class Tests_Comment_GetCommentText extends WP_UnitTestCase {
+	protected static $comment = array();
+
+	protected static $comment_content = 'Lorem ipsum dolor sit.';
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		unset( $GLOBALS['comment'] );
+
+		self::$comment = $factory->comment->create_and_get(
+			array(
+				'comment_content' => self::$comment_content,
+			)
+		);
+	}
+
+	public function test_no_comment() {
+		$text = get_comment_text();
+		$this->assertSame( '', $text );
+	}
+
+	public function test_invalid_comment_id_nonexistent_int() {
+		$invalid_comment_id = self::$comment->comment_id + 1;
+		$text               = get_comment_text( $invalid_comment_id );
+		$this->assertSame( '', $text );
+	}
+
+	/**
+	 * @ticket 40143
+	 */
+	public function test_invalid_comment_id_true() {
+		$text = get_comment_text( true );
+		$this->assertSame( '', $text );
+	}
+
+	public function test_global_comment() {
+		$GLOBALS['comment'] = self::$comment;
+		$text               = get_comment_text();
+		$this->assertSame( self::$comment_content, $text );
+	}
+
+	public function test_comment_arg() {
+		$text = get_comment_text( self::$comment );
+		$this->assertSame( self::$comment_content, $text );
+	}
+
+	public function test_comment_feed_reply_to() {
+
+		$comment_post_ID = self::factory()->post->create();
+		$parent_comment  = self::factory()->comment->create_and_get( compact( 'comment_post_ID' ) );
+		$comment         = self::factory()->comment->create_and_get(
+			array(
+				'comment_post_ID' => $comment_post_ID,
+				'comment_parent'  => $parent_comment->comment_ID,
+				'comment_content' => self::$comment_content,
+			)
+		);
+
+		$this->go_to( get_post_comments_feed_link( $comment_post_ID ) );
+
+		$expected = sprintf(
+			'In reply to <a href="%1$s">%2$s</a>.',
+			esc_url( get_comment_link( $parent_comment ) ),
+			get_comment_author( $parent_comment )
+		) . "\n\n" . self::$comment_content;
+		$text     = get_comment_text( $comment );
+		$this->assertSame( $expected, $text );
+	}
+
+}

--- a/tests/phpunit/tests/comment/getCommentText.php
+++ b/tests/phpunit/tests/comment/getCommentText.php
@@ -53,9 +53,11 @@ class Tests_Comment_GetCommentText extends WP_UnitTestCase {
 	public function test_comment_feed_reply_to() {
 
 		$comment_post_id = self::factory()->post->create();
-		$parent_comment  = self::factory()->comment->create_and_get( array(
-			'comment_post_ID' => $comment_post_id,
-		) );
+		$parent_comment  = self::factory()->comment->create_and_get(
+			array(
+				'comment_post_ID' => $comment_post_id,
+			)
+		);
 		$comment         = self::factory()->comment->create_and_get(
 			array(
 				'comment_post_id' => $comment_post_id,

--- a/tests/phpunit/tests/comment/getCommentText.php
+++ b/tests/phpunit/tests/comment/getCommentText.php
@@ -52,17 +52,19 @@ class Tests_Comment_GetCommentText extends WP_UnitTestCase {
 
 	public function test_comment_feed_reply_to() {
 
-		$comment_post_ID = self::factory()->post->create();
-		$parent_comment  = self::factory()->comment->create_and_get( compact( 'comment_post_ID' ) );
+		$comment_post_id = self::factory()->post->create();
+		$parent_comment  = self::factory()->comment->create_and_get( array(
+			'comment_post_ID' => $comment_post_id,
+		) );
 		$comment         = self::factory()->comment->create_and_get(
 			array(
-				'comment_post_ID' => $comment_post_ID,
+				'comment_post_id' => $comment_post_id,
 				'comment_parent'  => $parent_comment->comment_ID,
 				'comment_content' => self::$comment_content,
 			)
 		);
 
-		$this->go_to( get_post_comments_feed_link( $comment_post_ID ) );
+		$this->go_to( get_post_comments_feed_link( $comment_post_id ) );
 
 		$expected = sprintf(
 			'In reply to <a href="%1$s">%2$s</a>.',

--- a/tests/phpunit/tests/comment/wpComment.php
+++ b/tests/phpunit/tests/comment/wpComment.php
@@ -62,4 +62,13 @@ class Tests_Comment_WpComment extends WP_UnitTestCase {
 
 		$this->assertEquals( 1, $found->comment_ID );
 	}
+
+	/**
+	 * @ticket 40143
+	 */
+	public function test_get_instance_should_fail_for_true() {
+		$found = WP_Comment::get_instance( true );
+		$this->assertFalse( $found );
+	}
+
 }


### PR DESCRIPTION
Updates `get_comment_text()` to ensure the supplied comment exists & add related tests.

Trac ticket: https://core.trac.wordpress.org/ticket/40143

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
