### PR TITLE
update move_dir to help ::move

### DIFF
--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1955,6 +1955,8 @@ function copy_dir( $from, $to, $skip_list = array() ) {
  *
  * Assumes that WP_Filesystem() has already been called and setup.
  *
+ * move_dir() is not designed to merge directories, copy_dir() should be used instead.
+ *
  * @since 6.2.0
  *
  * @global WP_Filesystem_Base $wp_filesystem WordPress filesystem subclass.
@@ -1979,7 +1981,12 @@ function move_dir( $from, $to, $overwrite = false ) {
 		return new WP_Error( 'destination_already_exists_move_dir', __( 'The destination folder already exists.' ), $to );
 	}
 
-	if ( $wp_filesystem->move( $from, $to, $overwrite ) ) {
+	if ( $overwrite && $wp_filesystem->exists( $to ) && ! $wp_filesystem->delete( $to, true ) ) {
+		// Can't overwrite if the destination couldn't be deleted.
+		return WP_Error( 'destination_not_deleted_move_dir', __( 'The destination directory already exists and could not be removed.' ) );
+	}
+
+	if ( $wp_filesystem->move( $from, $to ) ) {
 		/*
 		 * When using an environment with shared folders,
 		 * there is a delay in updating the filesystem's cache.


### PR DESCRIPTION
Update `move_dir()` to better accommodate non-direct `::move()`.

This will attempt to delete the destination, required for `rename()`, before calling `::move()`. If unable it will fail.

Trac ticket: https://core.trac.wordpress.org/ticket/57375

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
