### PR TITLE
Silence Requests deprecations before preloading.

### DIFF
--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -1599,6 +1599,10 @@ function update_core( $from, $to ) {
 function _preload_old_requests_classes_and_interfaces( $to ) {
 	global $_old_requests_files, $wp_filesystem;
 
+	if ( ! defined( 'REQUESTS_SILENCE_PSR0_DEPRECATIONS' ) ) {
+		define( 'REQUESTS_SILENCE_PSR0_DEPRECATIONS', true );
+	}
+
 	foreach ( $_old_requests_files as $name => $file ) {
 		// Skip files that aren't interfaces or classes.
 		if ( is_int( $name ) ) {


### PR DESCRIPTION
Intentional preloading of Requests 2.x classes and interfaces using their old/Requests 1.x names, should not produce deprecation notices.

This PR defines `REQUESTS_SILENCE_PSR0_DEPRECATIONS` as `true` in `_preload_old_requests_classes_and_interfaces()`.

Trac ticket: https://core.trac.wordpress.org/ticket/54504
