### PR TITLE
Consistently check for unsaved state before closing image edit dialog

### DIFF
--- a/src/js/_enqueues/lib/image-edit.js
+++ b/src/js/_enqueues/lib/image-edit.js
@@ -841,14 +841,13 @@
 	 * @memberof imageEdit
 	 *
 	 * @param {number}  postid The post ID.
-	 * @param {boolean} warn   Warning message.
+	 * @param {boolean} warn   Deprecated: Check whether to warn on unsaved before closing. New behavior is to always check for unsaved before closing.
 	 *
 	 * @return {void|boolean} Returns false if there is a warning.
 	 */
 	close : function(postid, warn) {
-		warn = warn || false;
 
-		if ( warn && this.notsaved(postid) ) {
+		if ( this.notsaved(postid) ) {
 			return false;
 		}
 


### PR DESCRIPTION
For https://core.trac.wordpress.org/ticket/57637

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
