### PR TITLE
send language pack updates to copy_dir()

### DIFF
--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -588,15 +588,19 @@ class WP_Upgrader {
 		}
 
 		/*
-		 * Partial updates may want to retain the destination.
-		 * move_dir() returns a WP_Error when the destination exists,
-		 * so copy_dir() should be used.
+		 * If 'clear_working' is false, the source shouldn't be removed, so use copy_dir() instead.
 		 *
-		 * If 'clear_working' is false, the source shouldn't be removed.
-		 * After move_dir() runs, the source will no longer exist.
-		 * Therefore, copy_dir() should be used.
+		 * Partial updates may want to retain the destination, like language packs.
+		 * If the destination exists or has contents, this may be a partial update,
+		 * and the destination shouldn't be removed, so use copy_dir() instead.
 		 */
-		if ( $clear_destination && $args['clear_working'] && ! isset( $args['hook_extra']['language_update_type'] ) ) {
+		if ( $args['clear_working']
+			&& (
+				// Doesn't exist or has no contents.
+				! $wp_filesystem->exists( $remote_destination )
+				|| empty( $wp_filesystem->dirlist( $remote_destination ) )
+			)
+		) {
 			$result = move_dir( $source, $remote_destination, true );
 		} else {
 			// Create destination if needed.

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -596,7 +596,7 @@ class WP_Upgrader {
 		 * After move_dir() runs, the source will no longer exist.
 		 * Therefore, copy_dir() should be used.
 		 */
-		if ( $clear_destination && $args['clear_working'] ) {
+		if ( $clear_destination && $args['clear_working'] && ! isset( $args['hook_extra']['language_update_type'] ) ) {
 			$result = move_dir( $source, $remote_destination, true );
 		} else {
 			// Create destination if needed.


### PR DESCRIPTION
Accommodates language pack updates.

If 'clear_working' is false, the source shouldn't be removed, so use copy_dir() instead.

Partial updates may want to retain the destination, like language packs.
If the destination exists or has contents, this may be a partial update,
and the destination shouldn't be removed, so use copy_dir() instead.

Thanks @costdev for the brainstorming and testing this.

Trac ticket: https://core.trac.wordpress.org/ticket/57557

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
