### PR TITLE
Updated 'caniuse' for 6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8124,9 +8124,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001407",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001407.tgz",
-			"integrity": "sha512-4ydV+t4P7X3zH83fQWNDX/mQEzYomossfpViCOx9zHBSMV+rIe3LFqglHHtVyvNl1FhTNxPxs3jei82iqOW04w==",
+			"version": "1.0.30001450",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001450.tgz",
+			"integrity": "sha512-qMBmvmQmFXaSxexkjjfMvD5rnDL0+m+dUMZKoDYsGG8iZN29RuYh9eRoMvKsT6uMAWlyUUGDEQGJJYjzCIO9ew==",
 			"dev": true
 		},
 		"capital-case": {


### PR DESCRIPTION
Updated caniuse from v1.0.30001407 to v1.0.30001450

Trac ticket: https://core.trac.wordpress.org/ticket/57555
