### PR TITLE
Update `wp_render_elements_support` to use html API

### DIFF
--- a/src/wp-includes/block-supports/elements.php
+++ b/src/wp-includes/block-supports/elements.php
@@ -56,29 +56,14 @@ function wp_render_elements_support( $block_content, $block ) {
 		return $block_content;
 	}
 
-	$class_name = wp_get_elements_class_name( $block );
-
 	// Like the layout hook this assumes the hook only applies to blocks with a single wrapper.
-	// Retrieve the opening tag of the first HTML element.
-	$html_element_matches = array();
-	preg_match( '/<[^>]+>/', $block_content, $html_element_matches, PREG_OFFSET_CAPTURE );
-	$first_element = $html_element_matches[0][0];
-	// If the first HTML element has a class attribute just add the new class
-	// as we do on layout and duotone.
-	if ( strpos( $first_element, 'class="' ) !== false ) {
-		$content = preg_replace(
-			'/' . preg_quote( 'class="', '/' ) . '/',
-			'class="' . $class_name . ' ',
-			$block_content,
-			1
-		);
-	} else {
-		// If the first HTML element has no class attribute we should inject the attribute before the attribute at the end.
-		$first_element_offset = $html_element_matches[0][1];
-		$content              = substr_replace( $block_content, ' class="' . $class_name . '"', $first_element_offset + strlen( $first_element ) - 1, 0 );
+	// Add the class name to the first element, presuming it's the wrapper, if it exists.
+	$tags = new WP_HTML_Tag_Processor( $block_content );
+	if ( $tags->next_tag() ) {
+		$tags->add_class( wp_get_elements_class_name( $block ) );
 	}
 
-	return $content;
+	return $tags->get_updated_html();
 }
 
 /**

--- a/tests/phpunit/tests/block-supports/elements.php
+++ b/tests/phpunit/tests/block-supports/elements.php
@@ -73,7 +73,7 @@ class Tests_Block_Supports_Elements extends WP_UnitTestCase {
 		);
 		$this->assertSame(
 			$result,
-			'<p class="wp-elements-1 has-dark-gray-background-color has-background">Hello <a href="http://www.wordpress.org/">WordPress</a>!</p>'
+			'<p class="has-dark-gray-background-color has-background wp-elements-1">Hello <a href="http://www.wordpress.org/">WordPress</a>!</p>'
 		);
 	}
 
@@ -103,7 +103,7 @@ class Tests_Block_Supports_Elements extends WP_UnitTestCase {
 		);
 		$this->assertSame(
 			$result,
-			'<p id="anchor" class="wp-elements-1">Hello <a href="http://www.wordpress.org/">WordPress</a>!</p>'
+			'<p class="wp-elements-1" id="anchor">Hello <a href="http://www.wordpress.org/">WordPress</a>!</p>'
 		);
 	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/57642


Updates  `wp_render_elements_support` to use the new html API.

Related GB PR: https://github.com/WordPress/gutenberg/pull/46625

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
