### PR TITLE
Do not show language spinner if dropdown has been removed

### DIFF
--- a/src/wp-admin/includes/ms.php
+++ b/src/wp-admin/includes/ms.php
@@ -993,7 +993,7 @@ jQuery( function($) {
 	$( 'form' ).on( 'submit', function() {
 		// Don't show a spinner for English and installed languages,
 		// as there is nothing to download.
-		if ( ! languageSelect.find( 'option:selected' ).data( 'installed' ) ) {
+		if ( languageSelect && ! languageSelect.find( 'option:selected' ).data( 'installed' ) ) {
 			$( '#submit', this ).after( '<span class="spinner language-install-spinner is-active" />' );
 		}
 	});

--- a/src/wp-admin/includes/options.php
+++ b/src/wp-admin/includes/options.php
@@ -92,7 +92,7 @@ function options_general_add_js() {
 		$( 'form' ).on( 'submit', function() {
 			// Don't show a spinner for English and installed languages,
 			// as there is nothing to download.
-			if ( ! languageSelect.find( 'option:selected' ).data( 'installed' ) ) {
+			if ( languageSelect.length  && ! languageSelect.find( 'option:selected' ).data( 'installed' ) ) {
 				$( '#submit', this ).after( '<span class="spinner language-install-spinner is-active" />' );
 			}
 		});

--- a/src/wp-admin/user-edit.php
+++ b/src/wp-admin/user-edit.php
@@ -923,7 +923,7 @@ switch ( $action ) {
 		$( 'form' ).on( 'submit', function() {
 			// Don't show a spinner for English and installed languages,
 			// as there is nothing to download.
-			if ( ! languageSelect.find( 'option:selected' ).data( 'installed' ) ) {
+			if ( languageSelect && ! languageSelect.find( 'option:selected' ).data( 'installed' ) ) {
 				$( '#submit', this ).after( '<span class="spinner language-install-spinner is-active" />' );
 			}
 		});


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Core contains some code to display a spinner next to the submit button when selecting a language from the dropdown that has first to be installed. However, it does not check whether the dropdown does actually exist on the page, as some plugins do remove it & replace it with a custom solution.

This prevents showing a spinner in such cases as it's misleading.

The change can easily be tested by installing the Preferred Languages featured plugin and then simply saving the settings.

Trac ticket: https://core.trac.wordpress.org/ticket/57644

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
