### PR TITLE
Use an inline style tag instead of an external file request for `classic-themes.css` styles

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -3693,13 +3693,19 @@ function _wp_theme_json_webfonts_handler() {
  * This is needed for backwards compatibility for button blocks specifically.
  *
  * @since 6.1.0
+ * @since 6.2.0 Uses an inline <style> tag instead of an external file request.
  */
 function wp_enqueue_classic_theme_styles() {
-	if ( ! wp_theme_has_theme_json() ) {
-		$suffix = wp_scripts_get_suffix();
-		wp_register_style( 'classic-theme-styles', '/' . WPINC . "/css/classic-themes$suffix.css", array(), true );
-		wp_enqueue_style( 'classic-theme-styles' );
+	if ( wp_theme_has_theme_json() ) {
+		return;
 	}
+
+	$suffix               = wp_scripts_get_suffix();
+	$classic_theme_styles = ABSPATH . WPINC . "/css/classic-themes$suffix.css";
+
+	wp_register_style( 'classic-theme-styles', false, array(), true );
+	wp_add_inline_style( 'classic-theme-styles', file_get_contents( $classic_theme_styles ) );
+	wp_enqueue_style( 'classic-theme-styles' );
 }
 
 /**

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -3703,7 +3703,7 @@ function wp_enqueue_classic_theme_styles() {
 	$suffix               = wp_scripts_get_suffix();
 	$classic_theme_styles = ABSPATH . WPINC . "/css/classic-themes$suffix.css";
 
-	wp_register_style( 'classic-theme-styles', false, array(), true );
+	wp_register_style( 'classic-theme-styles', false, array(), null );
 	wp_add_inline_style( 'classic-theme-styles', file_get_contents( $classic_theme_styles ) );
 	wp_enqueue_style( 'classic-theme-styles' );
 }


### PR DESCRIPTION
This is a simpler solution to the overhead of enqueuing the `classic-themes.css` file on every page load (in classic themes).

* It keeps using the enqueue logic, which makes this backward compatible (e.g. allows other stylesheets to depend on it and keeps the styles in the exact same place in the dependency chain), therefore making this a safer change than https://core.trac.wordpress.org/attachment/ticket/56990/56990-inline-style.diff.
* It limits the changes to simply avoiding the external request which is the main caveat from the Trac ticket. The CSS itself is so little that it adds little overhead, it's just the external file request itself that is problematic for performance. #3561 doesn't address this adequately as it simply removes the styles and adds them to the Twenty Ten theme, which isn't a proper fix.
* Note that this PR also indirectly fixes the `$version` parameter used before, which was incorrectly set to `true` (not a valid value for the parameter). This caused the `?ver=` query arg to be always set to `1`. With the inline style, this is no longer relevant anyway, but just pointing out that it was incorrect before.

Trac ticket: https://core.trac.wordpress.org/ticket/56990

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
