### PR TITLE
Update: Backport block settings to core.

### DIFF
--- a/src/wp-includes/block-supports/settings.php
+++ b/src/wp-includes/block-supports/settings.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Block level presets support.
+ *
+ * @package WordPress
+ * @since 6.2.0
+ */
+
+/**
+ * Get the class name used on block level presets.
+ *
+ * @internal
+ *
+ * @since 6.2.0
+ * @access private
+ *
+ * @param array $block Block object.
+ * @return string      The unique class name.
+ */
+function _wp_get_presets_class_name( $block ) {
+	return 'wp-settings-' . md5( serialize( $block ) );
+}
+
+/**
+ * Update the block content with block level presets class name.
+ *
+ * @internal
+ *
+ * @since 6.2.0
+ * @access private
+ *
+ * @param  string $block_content Rendered block content.
+ * @param  array  $block         Block object.
+ * @return string                Filtered block content.
+ */
+function _wp_add_block_level_presets_class( $block_content, $block ) {
+	if ( ! $block_content ) {
+		return $block_content;
+	}
+
+	// return early if the block doesn't have support for settings.
+	$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
+	if ( ! block_has_support( $block_type, array( '__experimentalSettings' ), false ) ) {
+		return $block_content;
+	}
+
+	// return early if no settings are found on the block attributes.
+	$block_settings = _wp_array_get( $block, array( 'attrs', 'settings' ), null );
+	if ( empty( $block_settings ) ) {
+		return $block_content;
+	}
+
+	// Like the layout hook this assumes the hook only applies to blocks with a single wrapper.
+	// Add the class name to the first element, presuming it's the wrapper, if it exists.
+	$tags = new WP_HTML_Tag_Processor( $block_content );
+	if ( $tags->next_tag() ) {
+		$tags->add_class( _wp_get_presets_class_name( $block ) );
+	}
+
+	return $tags->get_updated_html();
+}
+
+/**
+ * Render the block level presets stylesheet.
+ *
+ * @internal
+ *
+ * @since 6.2.0
+ * @access private
+ *
+ * @param string|null $pre_render   The pre-rendered content. Default null.
+ * @param array       $block The block being rendered.
+ *
+ * @return null
+ */
+function _wp_add_block_level_preset_styles( $pre_render, $block ) {
+	// Return early if the block has not support for descendent block styles.
+	$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
+	if ( ! block_has_support( $block_type, array( '__experimentalSettings' ), false ) ) {
+		return null;
+	}
+
+	// return early if no settings are found on the block attributes.
+	$block_settings = _wp_array_get( $block, array( 'attrs', 'settings' ), null );
+	if ( empty( $block_settings ) ) {
+		return null;
+	}
+
+	$class_name = '.' . _wp_get_presets_class_name( $block );
+
+	// the root selector for preset variables needs to target every possible block selector
+	// in order for the general setting to override any bock specific setting of a parent block or
+	// the site root.
+	$variables_root_selector = '*,[class*="wp-block"]';
+	$registry                = WP_Block_Type_Registry::get_instance();
+	$blocks                  = $registry->get_all_registered();
+	foreach ( $blocks as $block_type ) {
+		if (
+			isset( $block_type->supports['__experimentalSelector'] ) &&
+			is_string( $block_type->supports['__experimentalSelector'] )
+		) {
+			$variables_root_selector .= ',' . $block_type->supports['__experimentalSelector'];
+		}
+	}
+	$variables_root_selector = WP_Theme_JSON::scope_selector( $class_name, $variables_root_selector );
+
+	// Remove any potentially unsafe styles.
+	$theme_json_shape  = WP_Theme_JSON::remove_insecure_properties(
+		array(
+			'version'  => WP_Theme_JSON::LATEST_SCHEMA,
+			'settings' => $block_settings,
+		)
+	);
+	$theme_json_object = new WP_Theme_JSON( $theme_json_shape );
+
+	$styles = '';
+
+	// include preset css variables declaration on the stylesheet.
+	$styles .= $theme_json_object->get_stylesheet(
+		array( 'variables' ),
+		null,
+		array(
+			'root_selector' => $variables_root_selector,
+			'scope'         => $class_name,
+		)
+	);
+
+	// include preset css classes on the the stylesheet.
+	$styles .= $theme_json_object->get_stylesheet(
+		array( 'presets' ),
+		null,
+		array(
+			'root_selector' => $class_name . ',' . $class_name . ' *',
+			'scope'         => $class_name,
+		)
+	);
+
+	if ( ! empty( $styles ) ) {
+		wp_enqueue_block_support_styles( $styles );
+	}
+
+	return null;
+}
+
+add_filter( 'render_block', '_wp_add_block_level_presets_class', 10, 2 );
+add_filter( 'pre_render_block', '_wp_add_block_level_preset_styles', 10, 2 );

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -338,6 +338,7 @@ require ABSPATH . WPINC . '/block-supports/generated-classname.php';
 require ABSPATH . WPINC . '/block-supports/layout.php';
 require ABSPATH . WPINC . '/block-supports/spacing.php';
 require ABSPATH . WPINC . '/block-supports/typography.php';
+require ABSPATH . WPINC . '/block-supports/settings.php';
 require ABSPATH . WPINC . '/style-engine.php';
 require ABSPATH . WPINC . '/style-engine/class-wp-style-engine.php';
 require ABSPATH . WPINC . '/style-engine/class-wp-style-engine-css-declarations.php';


### PR DESCRIPTION
This PR allows a block to define the preset settings of its nested blocks using the same shape as theme.json.
Backports https://github.com/WordPress/gutenberg/pull/42124/ and https://github.com/WordPress/gutenberg/pull/46625/ into the core.

## Testing
- With Gutenberg, disable paste the following markup on the block editor code editor and save the post.

```
<!-- wp:group {"settings":{"blocks":{"core/button":{"color":{"palette":{"custom":[{"slug":"button-red","color":"red","name":"button red"},{"slug":"button-blue","color":"blue","name":"button blue"}]}}}},"color":{"palette":{"custom":[{"slug":"global-aquamarine","color":"aquamarine","name":"Global aquamarine"},{"slug":"global-pink","color":"pink","name":"Global Pink"}]}}}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>Leaf paragraph of inner group block.</p>
<!-- /wp:paragraph -->

<!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button {"backgroundColor":"button-blue"} -->
<div class="wp-block-button"><a class="wp-block-button__link has-button-blue-background-color has-background wp-element-button">blue</a></div>
<!-- /wp:button -->

<!-- wp:button {"backgroundColor":"button-red"} -->
<div class="wp-block-button"><a class="wp-block-button__link has-button-red-background-color has-background wp-element-button">red</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->

<!-- wp:paragraph {"backgroundColor":"global-aquamarine"} -->
<p class="has-global-aquamarine-background-color has-background">global-aquamarine</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"backgroundColor":"global-pink"} -->
<p class="has-global-pink-background-color has-background">global-pink</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```

- Verify the result is the following on the post frontend (excluding the background color, which comes from my test theme):
<img width="826" alt="Screenshot 2023-02-06 at 23 41 43" src="https://user-images.githubusercontent.com/11271197/217111985-ba5d5e6d-89cf-46dd-8abb-2fc99cab1440.png">
