### PR TITLE
Deprecate wp_enqueue_block_support_styles

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2988,6 +2988,7 @@ function wp_enqueue_global_styles_css_custom_properties() {
  *
  * @since 5.9.1
  * @since 6.1.0 Added the `$priority` parameter.
+ * @deprecated 6.2.0 Use wp_style_engine_get_stylesheet_from_css_rules() instead.
  *
  * For block themes, styles are loaded in the head.
  * For classic ones, styles are loaded in the body because the wp_head action happens before render_block.
@@ -2998,6 +2999,7 @@ function wp_enqueue_global_styles_css_custom_properties() {
  * @param int    $priority To set the priority for the add_action.
  */
 function wp_enqueue_block_support_styles( $style, $priority = 10 ) {
+	_deprecated_function( __FUNCTION__, '6.2.0', 'wp_style_engine_get_stylesheet_from_css_rules()' );
 	$action_hook_name = 'wp_footer';
 	if ( wp_is_block_theme() ) {
 		$action_hook_name = 'wp_head';


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

In 6.2, once the JS packages have been updated, which includes changes to core blocks' `index.php` files, all usage in core of `wp_enqueue_block_support_styles` will have been removed. It should then be possible to deprecate `wp_enqueue_block_support_styles` as a function.

Since the style engine classes were added in 6.1, the style engine is now a better way to enqueue block support styles, as styles can be registered in multiple places, with those styles grouped together to be output only a single time, whereas `wp_enqueue_block_support_styles` resulted in multiple `<style>` tags being output on the site frontend (one for each instance of a block support being rendered), along with redundant style output.

Note: this PR should only land after the JS packages update that includes the changes to the gallery block, which roll in this PR: https://github.com/WordPress/gutenberg/pull/43070. Without that, then you if a request a post or page containing a Gallery block, the following will be logged, as the gallery block in `trunk` currently still contains a call to `wp_enqueue_block_support_styles`:

![image](https://user-images.githubusercontent.com/14988353/217120189-616a63a3-11e3-4fcf-831b-ee92eae282e6.png)

Trac ticket: https://core.trac.wordpress.org/ticket/57647

CC: @Mamaduka 

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
