### PR TITLE
I18N: Introduce `word_count_type` property to `WP_Locale`.

### DIFF
--- a/src/wp-includes/class-wp-locale.php
+++ b/src/wp-includes/class-wp-locale.php
@@ -254,7 +254,7 @@ class WP_Locale {
 		 */
 		$word_count_type = _x( 'words', 'Word count type. Do not translate!' );
 
-		if ( 'characters_excluding_spaces' === $word_count_type || 'characters_including_spaces' === $word_count_type) {
+		if ( 'characters_excluding_spaces' === $word_count_type || 'characters_including_spaces' === $word_count_type ) {
 			$this->word_count_type = $word_count_type;
 		}
 	}

--- a/src/wp-includes/class-wp-locale.php
+++ b/src/wp-includes/class-wp-locale.php
@@ -117,7 +117,7 @@ class WP_Locale {
 	 *
 	 * Default is 'words'.
 	 *
-	 * @since 6.1.0
+	 * @since 6.2.0
 	 * @var string
 	 */
 	public $word_count_type = 'words';
@@ -421,7 +421,7 @@ class WP_Locale {
 	/**
 	 * Retrieves the localized word count type.
 	 *
-	 * @since 6.1.0
+	 * @since 6.2.0
 	 *
 	 * @return string Localized word count type.
 	 */

--- a/src/wp-includes/class-wp-locale.php
+++ b/src/wp-includes/class-wp-locale.php
@@ -247,20 +247,8 @@ class WP_Locale {
 			$this->text_direction = 'rtl';
 		}
 
-		/*
-		 * translators: If your word count is based on single characters (e.g. East Asian characters),
-		 * enter 'characters_excluding_spaces' or 'characters_including_spaces'. Otherwise, enter 'words'.
-		 * Do not translate into your own language.
-		 */
-		$word_count_type = is_null( $this->word_count_type ) ? _x( 'words', 'Word count type. Do not translate!' ) : $this->word_count_type;
-
-		// Check for valid types.
-		if ( 'characters_excluding_spaces' === $word_count_type || 'characters_including_spaces' === $word_count_type ) {
-			$this->word_count_type = $word_count_type;
-		} else {
-			// Defaults to 'words'.
-			$this->word_count_type = 'words';
-		}
+		// Set the word count type.
+		$this->word_count_type = $this->get_word_count_type();
 	}
 
 	/**
@@ -425,11 +413,27 @@ class WP_Locale {
 	/**
 	 * Retrieves the localized word count type.
 	 *
+	 * Options are 'characters_excluding_spaces', 'characters_including_spaces or 'words'. Defaults to 'words'.
+	 *
 	 * @since 6.2.0
 	 *
 	 * @return string Localized word count type.
 	 */
 	public function get_word_count_type() {
-		return $this->word_count_type;
+
+		/*
+		 * translators: If your word count is based on single characters (e.g. East Asian characters),
+		 * enter 'characters_excluding_spaces' or 'characters_including_spaces'. Otherwise, enter 'words'.
+		 * Do not translate into your own language.
+		 */
+		$word_count_type = is_null( $this->word_count_type ) ? _x( 'words', 'Word count type. Do not translate!' ) : $this->word_count_type;
+
+		// Check for valid types.
+		if ( 'characters_excluding_spaces' !== $word_count_type && 'characters_including_spaces' !== $word_count_type ) {
+			// Defaults to 'words'.
+			$word_count_type = 'words';
+		}
+
+		return $word_count_type;
 	}
 }

--- a/src/wp-includes/class-wp-locale.php
+++ b/src/wp-includes/class-wp-locale.php
@@ -120,7 +120,7 @@ class WP_Locale {
 	 * @since 6.2.0
 	 * @var string
 	 */
-	public $word_count_type = 'words';
+	public $word_count_type;
 
 	/**
 	 * Constructor which calls helper methods to set up object variables.
@@ -252,10 +252,14 @@ class WP_Locale {
 		 * enter 'characters_excluding_spaces' or 'characters_including_spaces'. Otherwise, enter 'words'.
 		 * Do not translate into your own language.
 		 */
-		$word_count_type = _x( 'words', 'Word count type. Do not translate!' );
+		$word_count_type = is_null( $this->word_count_type ) ? _x( 'words', 'Word count type. Do not translate!' ) : $this->word_count_type;
 
+		// Check for valid types.
 		if ( 'characters_excluding_spaces' === $word_count_type || 'characters_including_spaces' === $word_count_type ) {
 			$this->word_count_type = $word_count_type;
+		} else {
+			// Defaults to 'words'.
+			$this->word_count_type = 'words';
 		}
 	}
 

--- a/src/wp-includes/class-wp-locale.php
+++ b/src/wp-includes/class-wp-locale.php
@@ -113,6 +113,16 @@ class WP_Locale {
 	public $list_item_separator;
 
 	/**
+	 * The word count type of the locale language.
+	 *
+	 * Default is 'words'.
+	 *
+	 * @since 6.1.0
+	 * @var string
+	 */
+	public $word_count_type = 'words';
+
+	/**
 	 * Constructor which calls helper methods to set up object variables.
 	 *
 	 * @since 2.1.0
@@ -235,6 +245,17 @@ class WP_Locale {
 			/* translators: 'rtl' or 'ltr'. This sets the text direction for WordPress. */
 		} elseif ( 'rtl' === _x( 'ltr', 'text direction' ) ) {
 			$this->text_direction = 'rtl';
+		}
+
+		/*
+		 * translators: If your word count is based on single characters (e.g. East Asian characters),
+		 * enter 'characters_excluding_spaces' or 'characters_including_spaces'. Otherwise, enter 'words'.
+		 * Do not translate into your own language.
+		 */
+		$word_count_type = _x( 'words', 'Word count type. Do not translate!' );
+
+		if ( 'characters_excluding_spaces' === $word_count_type || 'characters_including_spaces' === $word_count_type) {
+			$this->word_count_type = $word_count_type;
 		}
 	}
 
@@ -395,5 +416,16 @@ class WP_Locale {
 	 */
 	public function get_list_item_separator() {
 		return $this->list_item_separator;
+	}
+
+	/**
+	 * Retrieves the localized word count type.
+	 *
+	 * @since 6.1.0
+	 *
+	 * @return string Localized word count type.
+	 */
+	public function get_word_count_type() {
+		return $this->word_count_type;
 	}
 }

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -3945,12 +3945,7 @@ function wp_trim_words( $text, $num_words = 55, $more = null ) {
 	$text          = wp_strip_all_tags( $text );
 	$num_words     = (int) $num_words;
 
-	/*
-	 * translators: If your word count is based on single characters (e.g. East Asian characters),
-	 * enter 'characters_excluding_spaces' or 'characters_including_spaces'. Otherwise, enter 'words'.
-	 * Do not translate into your own language.
-	 */
-	if ( strpos( _x( 'words', 'Word count type. Do not translate!' ), 'characters' ) === 0 && preg_match( '/^utf\-?8$/i', get_option( 'blog_charset' ) ) ) {
+	if ( strpos( wp_get_word_count_type(), 'characters' ) === 0 && preg_match( '/^utf\-?8$/i', get_option( 'blog_charset' ) ) ) {
 		$text = trim( preg_replace( "/[\n\r\t ]+/", ' ', $text ), ' ' );
 		preg_match_all( '/./u', $text, $words_array );
 		$words_array = array_slice( $words_array[0], 0, $num_words + 1 );

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -3945,7 +3945,7 @@ function wp_trim_words( $text, $num_words = 55, $more = null ) {
 	$text          = wp_strip_all_tags( $text );
 	$num_words     = (int) $num_words;
 
-	if ( strpos( wp_get_word_count_type(), 'characters' ) === 0 && preg_match( '/^utf\-?8$/i', get_option( 'blog_charset' ) ) ) {
+	if ( str_starts_with( wp_get_word_count_type(), 'characters' ) && preg_match( '/^utf\-?8$/i', get_option( 'blog_charset' ) ) ) {
 		$text = trim( preg_replace( "/[\n\r\t ]+/", ' ', $text ), ' ' );
 		preg_match_all( '/./u', $text, $words_array );
 		$words_array = array_slice( $words_array[0], 0, $num_words + 1 );

--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -1809,3 +1809,18 @@ function wp_get_list_item_separator() {
 
 	return $wp_locale->get_list_item_separator();
 }
+
+/**
+ * Retrieves the word count type based on the locale.
+ *
+ * @since 6.1.0
+ *
+ * @global WP_Locale $wp_locale WordPress date and time locale object.
+ *
+ * @return string Locale-specific word count type.
+ */
+function wp_get_word_count_type() {
+	global $wp_locale;
+
+	return $wp_locale->get_word_count_type();
+}

--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -1813,7 +1813,7 @@ function wp_get_list_item_separator() {
 /**
  * Retrieves the word count type based on the locale.
  *
- * @since 6.1.0
+ * @since 6.2.0
  *
  * @global WP_Locale $wp_locale WordPress date and time locale object.
  *

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1827,12 +1827,7 @@ function wp_just_in_time_script_localization() {
 		'word-count',
 		'wordCountL10n',
 		array(
-			/*
-			 * translators: If your word count is based on single characters (e.g. East Asian characters),
-			 * enter 'characters_excluding_spaces' or 'characters_including_spaces'. Otherwise, enter 'words'.
-			 * Do not translate into your own language.
-			 */
-			'type'       => _x( 'words', 'Word count type. Do not translate!' ),
+			'type'       => wp_get_word_count_type(),
 			'shortcodes' => ! empty( $GLOBALS['shortcode_tags'] ) ? array_keys( $GLOBALS['shortcode_tags'] ) : array(),
 		)
 	);

--- a/tests/phpunit/tests/locale.php
+++ b/tests/phpunit/tests/locale.php
@@ -179,22 +179,22 @@ class Tests_Locale extends WP_UnitTestCase {
 	 */
 	public function test_get_word_count_type() {
 		// Default value is 'words'.
-		$this->assertSame( 'words' ), $this->locale->get_word_count_type() );
+		$this->assertSame( 'words', $this->locale->get_word_count_type() );
 		// Type set to empty, fallsback to 'words'.
 		$this->locale->word_count_type = '';
-		$this->assertSame( 'words' ), $this->locale->get_word_count_type() );
+		$this->assertSame( 'words', $this->locale->get_word_count_type() );
 		// Type set to 'foo' (wrong), fallsback to 'words'.
 		$this->locale->word_count_type = 'foo';
-		$this->assertSame( 'words' ), $this->locale->get_word_count_type() );
+		$this->assertSame( 'words', $this->locale->get_word_count_type() );
 		// Type set to 'words' (correct).
 		$this->locale->word_count_type = 'words';
-		$this->assertSame( 'words' ), $this->locale->get_word_count_type() );
+		$this->assertSame( 'words', $this->locale->get_word_count_type() );
 		// Type set to 'characters_excluding_spaces' (correct).
 		$this->locale->word_count_type = 'characters_excluding_spaces';
-		$this->assertSame( 'characters_excluding_spaces' ), $this->locale->get_word_count_type() );
+		$this->assertSame( 'characters_excluding_spaces', $this->locale->get_word_count_type() );
 		// Type set to 'characters_including_spaces' (correct).
 		$this->locale->word_count_type = 'characters_including_spaces';
-		$this->assertSame( 'characters_including_spaces' ), $this->locale->get_word_count_type() );
+		$this->assertSame( 'characters_including_spaces', $this->locale->get_word_count_type() );
 	}
 }
 

--- a/tests/phpunit/tests/locale.php
+++ b/tests/phpunit/tests/locale.php
@@ -203,27 +203,27 @@ class Tests_Locale extends WP_UnitTestCase {
 	 */
 	public function data_get_word_count_type() {
 		return array(
-			'default'                     => array(
+			'default'                   => array(
 				'word_count_type' => null,
 				'expected'        => 'words',
 			),
-			'empty string'                => array(
+			'empty string'              => array(
 				'word_count_type' => '',
 				'expected'        => 'words',
 			),
-			'an invalid option'           => array(
+			'an invalid option - "foo"' => array(
 				'word_count_type' => 'foo',
 				'expected'        => 'words',
 			),
-			'a valid option'              => array(
+			'a valid option - "words"'  => array(
 				'word_count_type' => 'words',
 				'expected'        => 'words',
 			),
-			'characters_excluding_spaces' => array(
+			'a valid option - "characters_excluding_spaces"' => array(
 				'word_count_type' => 'characters_excluding_spaces',
 				'expected'        => 'characters_excluding_spaces',
 			),
-			'characters_including_spaces' => array(
+			'a valid option - "characters_including_spaces"' => array(
 				'word_count_type' => 'characters_including_spaces',
 				'expected'        => 'characters_including_spaces',
 			),

--- a/tests/phpunit/tests/locale.php
+++ b/tests/phpunit/tests/locale.php
@@ -175,26 +175,59 @@ class Tests_Locale extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that `WP_Locale::get_word_count_type()` returns
+	 * the appropriate value.
+	 *
+	 * @ticket 56698
+	 *
 	 * @covers WP_Locale::get_word_count_type
+	 *
+	 * @dataProvider data_get_word_count_type
+	 *
+	 * @param string $word_count_type The word count type.
+	 * @param string $expected        The expected return value.
 	 */
-	public function test_get_word_count_type() {
-		// Default value is 'words'.
-		$this->assertSame( 'words', $this->locale->get_word_count_type() );
-		// Type set to empty, fallsback to 'words'.
-		$this->locale->word_count_type = '';
-		$this->assertSame( 'words', $this->locale->get_word_count_type() );
-		// Type set to 'foo' (wrong), fallsback to 'words'.
-		$this->locale->word_count_type = 'foo';
-		$this->assertSame( 'words', $this->locale->get_word_count_type() );
-		// Type set to 'words' (correct).
-		$this->locale->word_count_type = 'words';
-		$this->assertSame( 'words', $this->locale->get_word_count_type() );
-		// Type set to 'characters_excluding_spaces' (correct).
-		$this->locale->word_count_type = 'characters_excluding_spaces';
-		$this->assertSame( 'characters_excluding_spaces', $this->locale->get_word_count_type() );
-		// Type set to 'characters_including_spaces' (correct).
-		$this->locale->word_count_type = 'characters_including_spaces';
-		$this->assertSame( 'characters_including_spaces', $this->locale->get_word_count_type() );
+	public function test_get_word_count_type( $word_count_type, $expected ) {
+		if ( is_string( $word_count_type ) ) {
+			$this->locale->word_count_type = $word_count_type;
+
+		}
+
+		$this->assertSame( $expected, $this->locale->get_word_count_type() );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_get_word_count_type() {
+		return array(
+			'default'                     => array(
+				'word_count_type' => null,
+				'expected'        => 'words',
+			),
+			'empty string'                => array(
+				'word_count_type' => '',
+				'expected'        => 'words',
+			),
+			'an invalid option'           => array(
+				'word_count_type' => 'foo',
+				'expected'        => 'words',
+			),
+			'a valid option'              => array(
+				'word_count_type' => 'words',
+				'expected'        => 'words',
+			),
+			'characters_excluding_spaces' => array(
+				'word_count_type' => 'characters_excluding_spaces',
+				'expected'        => 'characters_excluding_spaces',
+			),
+			'characters_including_spaces' => array(
+				'word_count_type' => 'characters_including_spaces',
+				'expected'        => 'characters_including_spaces',
+			),
+		);
 	}
 }
 

--- a/tests/phpunit/tests/locale.php
+++ b/tests/phpunit/tests/locale.php
@@ -173,6 +173,29 @@ class Tests_Locale extends WP_UnitTestCase {
 		$this->locale->text_direction = 'ltr';
 		$this->assertFalse( $this->locale->is_rtl() );
 	}
+
+	/**
+	 * @covers WP_Locale::get_word_count_type
+	 */
+	public function test_get_word_count_type() {
+		// Default value is 'words'.
+		$this->assertSame( 'words' ), $this->locale->get_word_count_type() );
+		// Type set to empty, fallsback to 'words'.
+		$this->locale->word_count_type = '';
+		$this->assertSame( 'words' ), $this->locale->get_word_count_type() );
+		// Type set to 'foo' (wrong), fallsback to 'words'.
+		$this->locale->word_count_type = 'foo';
+		$this->assertSame( 'words' ), $this->locale->get_word_count_type() );
+		// Type set to 'words' (correct).
+		$this->locale->word_count_type = 'words';
+		$this->assertSame( 'words' ), $this->locale->get_word_count_type() );
+		// Type set to 'characters_excluding_spaces' (correct).
+		$this->locale->word_count_type = 'characters_excluding_spaces';
+		$this->assertSame( 'characters_excluding_spaces' ), $this->locale->get_word_count_type() );
+		// Type set to 'characters_including_spaces' (correct).
+		$this->locale->word_count_type = 'characters_including_spaces';
+		$this->assertSame( 'characters_including_spaces' ), $this->locale->get_word_count_type() );
+	}
 }
 
 class Custom_WP_Locale extends WP_Locale {


### PR DESCRIPTION
_This PR is a refresh of #3377 to improve the tests prior to 6.2 Beta 1_

Adds a `word_count_type` property, so that it does not need to be translated separately across multiple projects.

- New property: `WP_Locale::word_count_type`.
- New method: `WP_Locale::get_word_count_type()`.
- New function: `wp_get_word_count_type()` as a wrapper for `WP_Locale::get_word_count_type()`.
- All `_x( 'words', 'Word count type. Do not translate!' )` strings have been replaced with a call to `wp_get_word_count_type()`.

Trac ticket: https://core.trac.wordpress.org/ticket/56698