### PR TITLE
Users: Add unit tests for `wp_set_password()`.

### DIFF
--- a/tests/phpunit/tests/auth.php
+++ b/tests/phpunit/tests/auth.php
@@ -640,8 +640,9 @@ class Tests_Auth extends WP_UnitTestCase {
 	 * @ticket 57436
 	 */
 	public function test_wp_set_password_action() {
-		$user = self::factory()->user->create_and_get(
+		$user_id = self::factory()->user->create(
 			array(
+				'role'   => 'administrator',
 				'user_login' => 'janedoe',
 			)
 		);
@@ -649,13 +650,13 @@ class Tests_Auth extends WP_UnitTestCase {
 		$expected_meta_value = 'Meta value';
 		add_action(
 			'wp_set_password',
-			static function ( $password, $user->ID ) {
-				update_user_meta( $user->ID, 'my-password-user-meta', $expected_meta_value );
+			static function ( $password, $user_id ) {
+				update_user_meta( $user_id, 'my-password-user-meta', $expected_meta_value );
 			}
 		);
 
-		wp_set_password( 'A simple password', $user->ID );
-		$user_meta_value = get_user_meta( $user->ID, 'my-password-user-meta', true );
+		wp_set_password( 'A simple password', $user_id );
+		$user_meta_value = get_user_meta( $user_id, 'my-password-user-meta', true );
 
 		$this->assertSame( $expected_meta_value, $user_meta_value );
 	}

--- a/tests/phpunit/tests/auth.php
+++ b/tests/phpunit/tests/auth.php
@@ -643,7 +643,7 @@ class Tests_Auth extends WP_UnitTestCase {
 		$expected_meta_value = 'Meta value';
 		add_action(
 			'wp_set_password',
-			function ( $password, $this->user->ID ) {
+			function( $password, $this->user->ID ) {
 				update_user_meta( $this->user->ID, 'my-password-user-meta', $expected_meta_value );
 			}
 		);

--- a/tests/phpunit/tests/auth.php
+++ b/tests/phpunit/tests/auth.php
@@ -101,9 +101,11 @@ class Tests_Auth extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test hooking into wp_set_password().
+	 * Tests hooking into wp_set_password().
 	 *
 	 * @ticket 57436
+	 *
+	 * @covers ::wp_set_password
 	 */
 	public function test_wp_set_password_action() {
 		$action = new MockAction();

--- a/tests/phpunit/tests/auth.php
+++ b/tests/phpunit/tests/auth.php
@@ -645,6 +645,7 @@ class Tests_Auth extends WP_UnitTestCase {
 			'wp_set_password',
 			function( $password, $this->user->ID ) {
 				update_user_meta( $this->user->ID, 'my-password-user-meta', $expected_meta_value );
+				clean_user_cache( $this->user );
 			}
 		);
 

--- a/tests/phpunit/tests/auth.php
+++ b/tests/phpunit/tests/auth.php
@@ -643,13 +643,13 @@ class Tests_Auth extends WP_UnitTestCase {
 		$expected_meta_value = 'Meta value';
 		add_action(
 			'wp_set_password',
-			function( $password, $this->user->ID ) {
-				update_user_meta( $this->user->ID, 'my-password-user-meta', $expected_meta_value );
+			function( $password, self::$_user->ID ) {
+				update_user_meta( self::$_user->ID, 'my-password-user-meta', $expected_meta_value );
 			}
 		);
 
-		wp_set_password( 'A simple password', $this->user->ID );
-		$user_meta_value = get_user_meta( $this->user->ID, 'my-password-user-meta', true );
+		wp_set_password( 'A simple password', self::$_user->ID );
+		$user_meta_value = get_user_meta( self::$_user->ID, 'my-password-user-meta', true );
 
 		$this->assertSame( $expected_meta_value, $user_meta_value );
 	}

--- a/tests/phpunit/tests/auth.php
+++ b/tests/phpunit/tests/auth.php
@@ -101,11 +101,14 @@ class Tests_Auth extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test hooking into wp_set_password().
+	 *
 	 * @ticket 57436
 	 */
 	public function test_wp_set_password_action() {
 		$user_id             = self::$user_id;
 		$expected_meta_value = 'Meta value';
+
 		add_action(
 			'wp_set_password',
 			function( $password, $user_id ) {

--- a/tests/phpunit/tests/auth.php
+++ b/tests/phpunit/tests/auth.php
@@ -640,23 +640,16 @@ class Tests_Auth extends WP_UnitTestCase {
 	 * @ticket 57436
 	 */
 	public function test_wp_set_password_action() {
-		$user_id = self::factory()->user->create(
-			array(
-				'role'       => 'administrator',
-				'user_login' => 'janedoe',
-			)
-		);
-
 		$expected_meta_value = 'Meta value';
 		add_action(
 			'wp_set_password',
-			function ( $password, $user_id ) {
-				update_user_meta( $user_id, 'my-password-user-meta', $expected_meta_value );
+			function ( $password, $this->user->ID ) {
+				update_user_meta( $this->user->ID, 'my-password-user-meta', $expected_meta_value );
 			}
 		);
 
-		wp_set_password( 'A simple password', $user_id );
-		$user_meta_value = get_user_meta( $user_id, 'my-password-user-meta', true );
+		wp_set_password( 'A simple password', $this->user->ID );
+		$user_meta_value = get_user_meta( $this->user->ID, 'my-password-user-meta', true );
 
 		$this->assertSame( $expected_meta_value, $user_meta_value );
 	}

--- a/tests/phpunit/tests/auth.php
+++ b/tests/phpunit/tests/auth.php
@@ -101,6 +101,26 @@ class Tests_Auth extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 57436
+	 */
+	public function test_wp_set_password_action() {
+		$user_id             = self::$user_id;
+		$expected_meta_value = 'Meta value';
+		add_action(
+			'wp_set_password',
+			function( $password, $user_id ) {
+				update_user_meta( $user_id, 'my-password-user-meta', $expected_meta_value );
+				clean_user_cache( $user_id );
+			}
+		);
+
+		wp_set_password( 'A simple password', $user_id );
+		$user_meta_value = get_user_meta( $user_id, 'my-password-user-meta', true );
+
+		$this->assertSame( $expected_meta_value, $user_meta_value );
+	}
+
+	/**
 	 * Test wp_hash_password trims whitespace
 	 *
 	 * This is similar to test_password_trimming but tests the "lower level"
@@ -634,26 +654,6 @@ class Tests_Auth extends WP_UnitTestCase {
 		unset( $_SERVER['PHP_AUTH_PW'] );
 
 		$this->assertNull( wp_validate_application_password( null ) );
-	}
-
-	/**
-	 * @ticket 57436
-	 */
-	public function test_wp_set_password_action() {
-		$user_id             = self::$user_id;
-		$expected_meta_value = 'Meta value';
-		add_action(
-			'wp_set_password',
-			function( $password, $user_id ) {
-				update_user_meta( $user_id, 'my-password-user-meta', $expected_meta_value );
-				clean_user_cache( $user_id );
-			}
-		);
-
-		wp_set_password( 'A simple password', $user_id );
-		$user_meta_value = get_user_meta( $user_id, 'my-password-user-meta', true );
-
-		$this->assertSame( $expected_meta_value, $user_meta_value );
 	}
 
 	/**

--- a/tests/phpunit/tests/auth.php
+++ b/tests/phpunit/tests/auth.php
@@ -640,17 +640,18 @@ class Tests_Auth extends WP_UnitTestCase {
 	 * @ticket 57436
 	 */
 	public function test_wp_set_password_action() {
+		$user_id = $this->user->ID;
 		$expected_meta_value = 'Meta value';
 		add_action(
 			'wp_set_password',
-			function( $password, $this->user->ID ) {
-				update_user_meta( $this->user->ID, 'my-password-user-meta', $expected_meta_value );
-				clean_user_cache( $this->user );
+			function( $password, $user_id ) {
+				update_user_meta( $user_id, 'my-password-user-meta', $expected_meta_value );
+				clean_user_cache( $user_id );
 			}
 		);
 
-		wp_set_password( 'A simple password', $this->user->ID );
-		$user_meta_value = get_user_meta( $this->user->ID, 'my-password-user-meta', true );
+		wp_set_password( 'A simple password', $user_id );
+		$user_meta_value = get_user_meta( $user_id, 'my-password-user-meta', true );
 
 		$this->assertSame( $expected_meta_value, $user_meta_value );
 	}

--- a/tests/phpunit/tests/auth.php
+++ b/tests/phpunit/tests/auth.php
@@ -642,7 +642,7 @@ class Tests_Auth extends WP_UnitTestCase {
 	public function test_wp_set_password_action() {
 		$user_id = self::factory()->user->create(
 			array(
-				'role'   => 'administrator',
+				'role'       => 'administrator',
 				'user_login' => 'janedoe',
 			)
 		);

--- a/tests/phpunit/tests/auth.php
+++ b/tests/phpunit/tests/auth.php
@@ -106,23 +106,12 @@ class Tests_Auth extends WP_UnitTestCase {
 	 * @ticket 57436
 	 */
 	public function test_wp_set_password_action() {
-		$user_id             = self::$user_id;
-		$expected_meta_value = 'Meta value';
+		$action = new MockAction();
 
-		add_action(
-			'wp_set_password',
-			function( $password, $user_id ) {
-				update_user_meta( $user_id, 'my-password-user-meta', 'Meta value' );
-				clean_user_cache( $user_id );
-			},
-			10,
-			2
-		);
+		add_action( 'wp_set_password', array( $action, 'action' ) );
+		wp_set_password( 'A simple password', self::$user_id );
 
-		wp_set_password( 'A simple password', $user_id );
-		$user_meta_value = get_user_meta( $user_id, 'my-password-user-meta', true );
-
-		$this->assertSame( $expected_meta_value, $user_meta_value );
+		$this->assertSame( 1, $action->get_call_count() );
 	}
 
 	/**

--- a/tests/phpunit/tests/auth.php
+++ b/tests/phpunit/tests/auth.php
@@ -109,7 +109,7 @@ class Tests_Auth extends WP_UnitTestCase {
 		add_action(
 			'wp_set_password',
 			function( $password, $user_id ) {
-				update_user_meta( $user_id, 'my-password-user-meta', $expected_meta_value );
+				update_user_meta( $user_id, 'my-password-user-meta', 'Meta value' );
 				clean_user_cache( $user_id );
 			},
 			10,

--- a/tests/phpunit/tests/auth.php
+++ b/tests/phpunit/tests/auth.php
@@ -650,7 +650,7 @@ class Tests_Auth extends WP_UnitTestCase {
 		$expected_meta_value = 'Meta value';
 		add_action(
 			'wp_set_password',
-			static function ( $password, $user_id ) {
+			function ( $password, $user_id ) {
 				update_user_meta( $user_id, 'my-password-user-meta', $expected_meta_value );
 			}
 		);

--- a/tests/phpunit/tests/auth.php
+++ b/tests/phpunit/tests/auth.php
@@ -640,7 +640,7 @@ class Tests_Auth extends WP_UnitTestCase {
 	 * @ticket 57436
 	 */
 	public function test_wp_set_password_action() {
-		$user = self::factory()->user->create_and_get( array( 'user_login' => 'janedoe' ) );
+		$user = self::factory()->user->create( array( 'user_login' => 'janedoe' ) );
 
 		$expected_meta_value = 'Meta value';
 		add_action(

--- a/tests/phpunit/tests/auth.php
+++ b/tests/phpunit/tests/auth.php
@@ -640,18 +640,16 @@ class Tests_Auth extends WP_UnitTestCase {
 	 * @ticket 57436
 	 */
 	public function test_wp_set_password_action() {
-		$user = self::factory()->user->create( array( 'user_login' => 'janedoe' ) );
-
 		$expected_meta_value = 'Meta value';
 		add_action(
 			'wp_set_password',
-			function( $password, $user->ID ) {
-				update_user_meta( $user->ID, 'my-password-user-meta', $expected_meta_value );
+			function( $password, $this->user->ID ) {
+				update_user_meta( $this->user->ID, 'my-password-user-meta', $expected_meta_value );
 			}
 		);
 
-		wp_set_password( 'A simple password', $user->ID );
-		$user_meta_value = get_user_meta( $user->ID, 'my-password-user-meta', true );
+		wp_set_password( 'A simple password', $this->user->ID );
+		$user_meta_value = get_user_meta( $this->user->ID, 'my-password-user-meta', true );
 
 		$this->assertSame( $expected_meta_value, $user_meta_value );
 	}

--- a/tests/phpunit/tests/auth.php
+++ b/tests/phpunit/tests/auth.php
@@ -640,7 +640,7 @@ class Tests_Auth extends WP_UnitTestCase {
 	 * @ticket 57436
 	 */
 	public function test_wp_set_password_action() {
-		$user_id = $this->user->ID;
+		$user_id             = self::$user_id;
 		$expected_meta_value = 'Meta value';
 		add_action(
 			'wp_set_password',

--- a/tests/phpunit/tests/auth.php
+++ b/tests/phpunit/tests/auth.php
@@ -637,6 +637,23 @@ class Tests_Auth extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 57436
+	 */
+	public function test_wp_set_password_action() {
+		$expected_meta_value = 'Meta value';
+		add_action(
+			'wp_set_password',
+			static function ( $password, $user_id ) {
+				update_user_meta( $user_id, 'my-password-user-meta', $expected_meta_value );
+			}
+		);
+		wp_set_password( 'A simple password', $this->user->ID );
+		$user_meta_value = get_user_meta( $this->user->ID, 'my-password-user-meta', true );
+
+		$this->assertSame( $expected_meta_value, $user_meta_value );
+	}
+
+	/**
 	 * @ticket 53386
 	 * @dataProvider data_application_passwords_can_use_capability_checks_to_determine_feature_availability
 	 */

--- a/tests/phpunit/tests/auth.php
+++ b/tests/phpunit/tests/auth.php
@@ -640,15 +640,22 @@ class Tests_Auth extends WP_UnitTestCase {
 	 * @ticket 57436
 	 */
 	public function test_wp_set_password_action() {
+		$user = self::factory()->user->create_and_get(
+			array(
+				'user_login' => 'janedoe',
+			)
+		);
+
 		$expected_meta_value = 'Meta value';
 		add_action(
 			'wp_set_password',
-			static function ( $password, self::$user_id ) {
-				update_user_meta( self::$user_id, 'my-password-user-meta', $expected_meta_value );
+			static function ( $password, $user->ID ) {
+				update_user_meta( $user->ID, 'my-password-user-meta', $expected_meta_value );
 			}
 		);
-		wp_set_password( 'A simple password', self::$user_id );
-		$user_meta_value = get_user_meta( self::$user_id, 'my-password-user-meta', true );
+
+		wp_set_password( 'A simple password', $user->ID );
+		$user_meta_value = get_user_meta( $user->ID, 'my-password-user-meta', true );
 
 		$this->assertSame( $expected_meta_value, $user_meta_value );
 	}

--- a/tests/phpunit/tests/auth.php
+++ b/tests/phpunit/tests/auth.php
@@ -640,16 +640,18 @@ class Tests_Auth extends WP_UnitTestCase {
 	 * @ticket 57436
 	 */
 	public function test_wp_set_password_action() {
+		$user = self::factory()->user->create_and_get( array( 'user_login' => 'janedoe' ) );
+
 		$expected_meta_value = 'Meta value';
 		add_action(
 			'wp_set_password',
-			function( $password, self::$_user->ID ) {
-				update_user_meta( self::$_user->ID, 'my-password-user-meta', $expected_meta_value );
+			function( $password, $user->ID ) {
+				update_user_meta( $user->ID, 'my-password-user-meta', $expected_meta_value );
 			}
 		);
 
-		wp_set_password( 'A simple password', self::$_user->ID );
-		$user_meta_value = get_user_meta( self::$_user->ID, 'my-password-user-meta', true );
+		wp_set_password( 'A simple password', $user->ID );
+		$user_meta_value = get_user_meta( $user->ID, 'my-password-user-meta', true );
 
 		$this->assertSame( $expected_meta_value, $user_meta_value );
 	}

--- a/tests/phpunit/tests/auth.php
+++ b/tests/phpunit/tests/auth.php
@@ -643,8 +643,8 @@ class Tests_Auth extends WP_UnitTestCase {
 		$expected_meta_value = 'Meta value';
 		add_action(
 			'wp_set_password',
-			static function ( $password, $user_id ) {
-				update_user_meta( $user_id, 'my-password-user-meta', $expected_meta_value );
+			static function ( $password, self::$user_id ) {
+				update_user_meta( self::$user_id, 'my-password-user-meta', $expected_meta_value );
 			}
 		);
 		wp_set_password( 'A simple password', self::$user_id );

--- a/tests/phpunit/tests/auth.php
+++ b/tests/phpunit/tests/auth.php
@@ -647,8 +647,8 @@ class Tests_Auth extends WP_UnitTestCase {
 				update_user_meta( $user_id, 'my-password-user-meta', $expected_meta_value );
 			}
 		);
-		wp_set_password( 'A simple password', $this->user->ID );
-		$user_meta_value = get_user_meta( $this->user->ID, 'my-password-user-meta', true );
+		wp_set_password( 'A simple password', self::$user_id );
+		$user_meta_value = get_user_meta( self::$user_id, 'my-password-user-meta', true );
 
 		$this->assertSame( $expected_meta_value, $user_meta_value );
 	}

--- a/tests/phpunit/tests/auth.php
+++ b/tests/phpunit/tests/auth.php
@@ -111,7 +111,9 @@ class Tests_Auth extends WP_UnitTestCase {
 			function( $password, $user_id ) {
 				update_user_meta( $user_id, 'my-password-user-meta', $expected_meta_value );
 				clean_user_cache( $user_id );
-			}
+			},
+			10,
+			2
 		);
 
 		wp_set_password( 'A simple password', $user_id );


### PR DESCRIPTION
_This is an update of #3844 to change "Test" to "Tests" in the docblock and to add a `@covers` annotation_

Trac ticket: https://core.trac.wordpress.org/ticket/57436
