### PR TITLE
Test 40144.3.diff

### DIFF
--- a/src/js/_enqueues/vendor/mediaelement/wp-mediaelement.js
+++ b/src/js/_enqueues/vendor/mediaelement/wp-mediaelement.js
@@ -19,6 +19,8 @@
 		 * @return {void}
 		 */
 		function initialize() {
+			var selectors = [];
+
 			if ( typeof _wpmejsSettings !== 'undefined' ) {
 				settings = $.extend( true, {}, _wpmejsSettings );
 			}
@@ -63,8 +65,18 @@
 				}
 			};
 
+			if ( 'undefined' === typeof settings.videoShortcodeLibrary || 'mediaelement' === settings.videoShortcodeLibrary ) {
+				selectors.push( '.wp-video-shortcode' );
+			}
+			if ( 'undefined' === typeof settings.audioShortcodeLibrary || 'mediaelement' === settings.audioShortcodeLibrary ) {
+				selectors.push( '.wp-audio-shortcode' );
+			}
+			if ( ! selectors.length ) {
+				return;
+			}
+
 			// Only initialize new media elements.
-			$( '.wp-audio-shortcode, .wp-video-shortcode' )
+			$( selectors.join( ', ' ) )
 				.not( '.mejs-container' )
 				.filter(function () {
 					return ! $( this ).parent().hasClass( 'mejs-mediaelement' );

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1111,6 +1111,10 @@ function wp_default_scripts( $scripts ) {
 		'pluginPath'  => includes_url( 'js/mediaelement/', 'relative' ),
 		'classPrefix' => 'mejs-',
 		'stretching'  => 'responsive',
+		/** This filter is documented in wp-includes/media.php */
+		'audioShortcodeLibrary' => apply_filters( 'wp_audio_shortcode_library', 'mediaelement' ),
+		/** This filter is documented in wp-includes/media.php */
+		'videoShortcodeLibrary' => apply_filters( 'wp_video_shortcode_library', 'mediaelement' ),
 	);
 	did_action( 'init' ) && $scripts->localize(
 		'mediaelement',


### PR DESCRIPTION
Allow filters to disable mediaelement shortcodes selectively

Trac ticket: https://core.trac.wordpress.org/ticket/40144

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
