### PR TITLE
Upgrade/Install: Skip preloading Requests 1.x class/interface names on earlier than WordPress 4.6.

### DIFF
--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -1595,11 +1595,22 @@ function update_core( $from, $to ) {
  *
  * @global array              $_old_requests_files Requests files to be preloaded.
  * @global WP_Filesystem_Base $wp_filesystem       WordPress filesystem subclass.
+ * @global string             $wp_version          The WordPress version string.
  *
  * @param string $to Path to old WordPress installation.
  */
 function _preload_old_requests_classes_and_interfaces( $to ) {
-	global $_old_requests_files, $wp_filesystem;
+	global $_old_requests_files, $wp_filesystem, $wp_version;
+
+	/*
+	 * Requests was introduced in WordPress 4.6.
+	 *
+	 * Skip preloading if the website was previously using
+	 * an earlier version of WordPress.
+	 */
+	if ( version_compare( $wp_version, '4.6', '<' ) ) {
+		return;
+	}
 
 	if ( ! defined( 'REQUESTS_SILENCE_PSR0_DEPRECATIONS' ) ) {
 		define( 'REQUESTS_SILENCE_PSR0_DEPRECATIONS', true );


### PR DESCRIPTION
The Requests library was introduced in WordPress 4.6.

Attempting to preload the Requests 1.x classes/interfaces in earlier versions of WordPress
causes a fatal error.

This skips preloading if the website previously used a WordPress version earlier than 4.6.

Trac ticket: https://core.trac.wordpress.org/ticket/57662
