### PR TITLE
Add defensive coding for wp_get_word_count_type

### DIFF
--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -1821,6 +1821,10 @@ function wp_get_list_item_separator() {
  */
 function wp_get_word_count_type() {
 	global $wp_locale;
+	if ( ! ( $wp_locale instanceof WP_Locale ) ) {
+		// Default value of get_word_count_type.
+		return 'words';
+	}
 
 	return $wp_locale->get_word_count_type();
 }

--- a/tests/phpunit/tests/l10n/wpGetWordCountType.php
+++ b/tests/phpunit/tests/l10n/wpGetWordCountType.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @group formatting
+ *
+ * @covers ::wp_get_word_count_type
+ */
+class Tests_L10n_WpGetWordCountType extends WP_UnitTestCase {
+	/**
+	 * Confirms the function returns a value when the $wp_locale global is not set.
+	 * @ticket 56698
+	 */
+	public function test_should_return_default_if_locale_unset() {
+		global $wp_locale;
+		$locale = $wp_locale;
+		$wp_locale = null;
+		$this->assertEquals( 'words', wp_get_word_count_type() );
+		$wp_locale = $locale;
+	}
+}

--- a/tests/phpunit/tests/l10n/wpGetWordCountType.php
+++ b/tests/phpunit/tests/l10n/wpGetWordCountType.php
@@ -12,7 +12,7 @@ class Tests_L10n_WpGetWordCountType extends WP_UnitTestCase {
 	 */
 	public function test_should_return_default_if_locale_unset() {
 		global $wp_locale;
-		$locale = $wp_locale;
+		$locale    = $wp_locale;
 		$wp_locale = null;
 		$this->assertEquals( 'words', wp_get_word_count_type() );
 		$wp_locale = $locale;


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
`wp_trim_words` can be called earlier in the stack than when the `WP_Locale` is currently set (during theme setup).

This adds some defensive coding to ensure a value is returned without a fatal error. The default value of `words` is used.

Trac ticket: https://core.trac.wordpress.org/ticket/56698

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
