### PR TITLE
Add aspect-ratio as a valid CSS property to kses

### DIFF
--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -2370,6 +2370,8 @@ function safecss_filter_attr( $css, $deprecated = '' ) {
 			'text-indent',
 			'text-transform',
 
+			'aspect-ratio',
+
 			'height',
 			'min-height',
 			'max-height',

--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -2277,7 +2277,7 @@ function kses_init() {
  *              nested `var()` values, and assigning values to CSS variables.
  *              Added support for `object-fit`, `gap`, `column-gap`, `row-gap`, and `flex-wrap`.
  *              Extended `margin-*` and `padding-*` support for logical properties.
- * @since 6.2.0 Added support for `position`, `top`, `right`, `bottom`, `left` and `z-index` position CSS properties.
+ * @since 6.2.0 Added support for `aspect-ratio`, `position`, `top`, `right`, `bottom`, `left` and `z-index`.
  *
  * @param string $css        A string of CSS rules.
  * @param string $deprecated Not used.


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Adds `aspect-ratio` to `safe_style_css` list of properties. Required for WordPress/gutenberg#47854

Trac ticket: https://core.trac.wordpress.org/ticket/57664

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
