### PR TITLE
Fix wp_get_raw_referer() to make sure it always returns strings/booleans

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -1970,7 +1970,7 @@ function wp_get_referer() {
  * @return string|false Referer URL on success, false on failure.
  */
 function wp_get_raw_referer() {
-	if ( ! empty( $_REQUEST['_wp_http_referer'] ) ) {
+	if ( ! empty( $_REQUEST['_wp_http_referer'] ) && is_string( $_REQUEST['_wp_http_referer'] ) ) {
 		return wp_unslash( $_REQUEST['_wp_http_referer'] );
 	} elseif ( ! empty( $_SERVER['HTTP_REFERER'] ) ) {
 		return wp_unslash( $_SERVER['HTTP_REFERER'] );

--- a/tests/phpunit/tests/functions/referer.php
+++ b/tests/phpunit/tests/functions/referer.php
@@ -160,7 +160,7 @@ class Tests_Functions_Referer extends WP_UnitTestCase {
 	/**
 	 * @ticket 57670
 	 */
-	public function test_raw_referer_is_empty_on_invalid_request_parameter() {
+	public function test_raw_referer_is_false_on_invalid_request_parameter() {
 		$_REQUEST['_wp_http_referer'] = array( 'demo' );
 		$this->assertFalse( wp_get_raw_referer() );
 	}

--- a/tests/phpunit/tests/functions/referer.php
+++ b/tests/phpunit/tests/functions/referer.php
@@ -157,8 +157,11 @@ class Tests_Functions_Referer extends WP_UnitTestCase {
 		$this->assertSame( 'http://foo.bar/baz', wp_get_raw_referer() );
 	}
 
+	/**
+	 * @ticket 57670
+	 */
 	public function test_raw_referer_is_empty_on_invalid_request_parameter() {
-		$_REQUEST['_wp_http_referer'] = ['demo'];
+		$_REQUEST['_wp_http_referer'] = array( 'demo' );
 		$this->assertFalse( wp_get_raw_referer() );
 	}
 }

--- a/tests/phpunit/tests/functions/referer.php
+++ b/tests/phpunit/tests/functions/referer.php
@@ -156,4 +156,9 @@ class Tests_Functions_Referer extends WP_UnitTestCase {
 		$_REQUEST['_wp_http_referer'] = addslashes( 'http://foo.bar/baz' );
 		$this->assertSame( 'http://foo.bar/baz', wp_get_raw_referer() );
 	}
+
+	public function test_raw_referer_is_empty_on_invalid_request_parameter() {
+		$_REQUEST['_wp_http_referer'] = ['demo'];
+		$this->assertFalse( wp_get_raw_referer() );
+	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/57670#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
