### PR TITLE
Fix PHP warning on unregister_setting()

### DIFF
--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -2500,7 +2500,10 @@ function unregister_setting( $option_group, $option_name, $deprecated = '' ) {
 		$option_group = 'reading';
 	}
 
-	$pos = array_search( $option_name, (array) $new_allowed_options[ $option_group ], true );
+	$pos = false;
+	if ( isset( $new_allowed_options[ $option_group ] ) ) {
+		$pos = array_search( $option_name, (array) $new_allowed_options[ $option_group ], true );
+	}
 
 	if ( false !== $pos ) {
 		unset( $new_allowed_options[ $option_group ][ $pos ] );

--- a/tests/phpunit/tests/option/registration.php
+++ b/tests/phpunit/tests/option/registration.php
@@ -151,26 +151,16 @@ class Tests_Option_Registration extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The test passes if a Notice | Warning | Error is not raised. Thus. the absence of a Notice | Warning | Error
+	 * is an indicator the fix in the ticket resolves the issue.
+	 *
 	 * @ticket 57674
 	 *
 	 * @covers ::unregister_setting
 	 */
-	public function test_unregister_invalid_setting_does_not_raise_a_php_warning() {
+	public function test_unregister_invalid_setting_does_not_raise_php_notice_warning_or_error() {
 		$setting = uniqid();
-		set_error_handler(
-			function ( $errno = 0, $errstr = '' ) {
-				$error_types = array(
-					E_ERROR   => 'Fatal',
-					E_WARNING => 'Warning',
-					E_NOTICE  => 'Notice',
-				);
-				$error_type  = isset( $error_types[ $errno ] ) ? $error_types[ $errno ] : 'Unknown';
-				$this->fail( 'PHP ' . $error_type . ': ' . $errstr );
-				return false;
-			}
-		);
 		unregister_setting( $setting, $setting );
-		restore_error_handler();
 		$this->assertFalse( has_filter( 'default_option_' . $setting, 'filter_default_option' ) );
 	}
 }

--- a/tests/phpunit/tests/option/registration.php
+++ b/tests/phpunit/tests/option/registration.php
@@ -160,9 +160,9 @@ class Tests_Option_Registration extends WP_UnitTestCase {
 		set_error_handler(
 			function ( $errno = 0, $errstr = '' ) {
 				$error_types = array(
-					E_ERROR => 'Fatal',
+					E_ERROR   => 'Fatal',
 					E_WARNING => 'Warning',
-					E_NOTICE => 'Notice',
+					E_NOTICE  => 'Notice',
 				);
 				$error_type = isset( $error_types[ $errno ] ) ? $error_types[ $errno ] : 'Unknown';
 				$this->fail( 'PHP ' . $error_type . ': ' . $errstr );

--- a/tests/phpunit/tests/option/registration.php
+++ b/tests/phpunit/tests/option/registration.php
@@ -164,7 +164,7 @@ class Tests_Option_Registration extends WP_UnitTestCase {
 					E_WARNING => 'Warning',
 					E_NOTICE  => 'Notice',
 				);
-				$error_type = isset( $error_types[ $errno ] ) ? $error_types[ $errno ] : 'Unknown';
+				$error_type  = isset( $error_types[ $errno ] ) ? $error_types[ $errno ] : 'Unknown';
 				$this->fail( 'PHP ' . $error_type . ': ' . $errstr );
 				return false;
 			}

--- a/tests/phpunit/tests/option/registration.php
+++ b/tests/phpunit/tests/option/registration.php
@@ -149,4 +149,28 @@ class Tests_Option_Registration extends WP_UnitTestCase {
 
 		$this->assertFalse( has_filter( 'default_option_test_default', 'filter_default_option' ) );
 	}
+
+	/**
+	 * @ticket 57674
+	 *
+	 * @covers ::unregister_setting
+	 */
+	public function test_unregister_invalid_setting_does_not_raise_a_php_warning() {
+		$setting = uniqid();
+		set_error_handler(
+			function ( $errno = 0, $errstr = '' ) {
+				$error_types = array(
+					E_ERROR => 'Fatal',
+					E_WARNING => 'Warning',
+					E_NOTICE => 'Notice',
+				);
+				$error_type = isset( $error_types[ $errno ] ) ? $error_types[ $errno ] : 'Unknown';
+				$this->fail( 'PHP ' . $error_type . ': ' . $errstr );
+				return false;
+			}
+		);
+		unregister_setting( $setting, $setting );
+		restore_error_handler();
+		$this->assertFalse( has_filter( 'default_option_' . $setting, 'filter_default_option' ) );
+	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/57674

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
