### PR TITLE
Empty nicename check fix after sanitize_user to avoid creating user with empty value

### DIFF
--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -1855,7 +1855,7 @@ function wp_insert_user( $userdata ) {
 	 * If a nicename is provided, remove unsafe user characters before using it.
 	 * Otherwise build a nicename from the user_login.
 	 */
-	if ( ! empty( $userdata['user_nicename'] ) ) {
+	if ( ! empty( sanitize_user( $userdata['user_nicename'], true ) ) ) {
 		$user_nicename = sanitize_user( $userdata['user_nicename'], true );
 		if ( mb_strlen( $user_nicename ) > 50 ) {
 			return new WP_Error( 'user_nicename_too_long', __( 'Nicename may not be longer than 50 characters.' ) );


### PR DESCRIPTION
Improvement in nicename empty check and adding sanitized value in empty check to avoid creating user with empty value.

Trac ticket: https://core.trac.wordpress.org/ticket/57635