### PR TITLE
Help: design update for help tab.

### DIFF
--- a/src/js/_enqueues/admin/common.js
+++ b/src/js/_enqueues/admin/common.js
@@ -660,9 +660,11 @@ window.screenMeta = {
  *
  * @return {void}
  */
-$('.contextual-help-tabs').on( 'click', 'a', function(e) {
+$('.contextual-help-tabs').on( 'click', 'button', function(e) {
 	var link = $(this),
 		panel;
+
+	console.log(e);
 
 	e.preventDefault();
 

--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -1866,7 +1866,8 @@ p.auto-update-status {
 }
 
 #contextual-help-columns {
-	position: relative;
+	display: flex;
+	flex-direction: row;
 }
 
 #contextual-help-back {
@@ -1879,6 +1880,8 @@ p.auto-update-status {
 	border-top: none;
 	border-bottom: none;
 	background: #fff;
+
+	display: none;
 }
 
 #contextual-help-wrap.no-sidebar #contextual-help-back {
@@ -1888,10 +1891,10 @@ p.auto-update-status {
 }
 
 .contextual-help-tabs {
-	float: left;
+	order: 1;
 	width: 150px;
-	margin: 0;
 	background-color: #f0f6fc;
+	z-index: 1;
 }
 
 .contextual-help-tabs ul {
@@ -1926,6 +1929,7 @@ p.auto-update-status {
 	border-left: 3px solid #2271b1;
 	background: #fff;
 	box-shadow: 0 2px 0 rgba(0, 0, 0, 0.02), 0 1px 0 rgba(0, 0, 0, 0.02);
+	font-weight: 600;
 }
 
 .contextual-help-tabs .active a {
@@ -1934,14 +1938,21 @@ p.auto-update-status {
 }
 
 .contextual-help-tabs-wrap {
-	padding: 0 20px;
+	order: 2;
 	overflow: auto;
+	max-width: calc(100% - 300px);
+	border: 1px solid #c3c4c7;
+	border-top: none;
+	border-bottom: none;
+}
+
+.contextual-help-tabs-wrap > * {
+	padding: 0 20px;
 }
 
 .help-tab-content {
 	display: none;
-	margin: 0 22px 12px 0;
-	line-height: 1.6;
+	margin: 0 0 12px 0;
 }
 
 .help-tab-content.active {
@@ -1955,10 +1966,13 @@ p.auto-update-status {
 
 .contextual-help-sidebar {
 	width: 150px;
-	float: right;
-	padding: 0 8px 0 12px;
+	order: 3;
 	overflow: auto;
 	background-color: #f0f6fc;
+}
+
+.contextual-help-sidebar > * {
+	padding: 0 8px 0 12px;
 }
 
 /*------------------------------------------------------------------------------
@@ -4035,10 +4049,12 @@ img {
 		display: none;
 	}
 
+	#contextual-help-columns {
+		flex-direction: column;
+	}	
+
 	#screen-meta .contextual-help-tabs {
-		clear: both;
 		width: 100%;
-		float: none;
 	}
 
 	#screen-meta .contextual-help-tabs ul {

--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -1891,7 +1891,7 @@ p.auto-update-status {
 	border-color: transparent;
 }
 
-.contextual-help-tabs a {
+.contextual-help-tabs button {
 	display: block;
 	padding: 8px 5px 8px 12px;
 	line-height: 1.4;
@@ -1901,11 +1901,11 @@ p.auto-update-status {
 	border-left: none;
 }
 
-.contextual-help-tabs a:hover {
+.contextual-help-tabs button:hover {
 	color: #2c3338;
 }
 
-.contextual-help-tabs .active {
+.contextual-help-tabs [aria-selected=true] {
 	padding: 0;
 	margin: 0 -1px 0 0;
 	border-left: 3px solid #2271b1;

--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -1729,7 +1729,6 @@ p.auto-update-status {
 
 #screen-meta-links .show-settings {
 	border: 1px solid #c3c4c7;
-	border-top: none;
 	height: auto;
 	margin-bottom: 0;
 	padding: 3px 6px 3px 16px;
@@ -1737,8 +1736,8 @@ p.auto-update-status {
 	border-radius: 0 0 4px 4px;
 	color: #646970;
 	line-height: 1.7;
-	box-shadow: 0 0 0 transparent;
-	transition: box-shadow 0.1s linear;
+	/* box-shadow: 0 0 0 transparent;
+	transition: box-shadow 0.1s linear; */
 }
 
 #screen-meta-links .show-settings:hover,
@@ -1748,8 +1747,11 @@ p.auto-update-status {
 }
 
 #screen-meta-links .show-settings:focus {
-	border-color: #4f94d4;
-	box-shadow: 0 0 3px rgba(34, 113, 177, 0.8);
+	/* border-color: #4f94d4;
+	box-shadow: 0 0 3px rgba(34, 113, 177, 0.8); */
+	box-shadow: 0 0 0 1px #3582c4;
+	outline: 2px solid transparent;
+	outline-offset: 0;
 }
 
 #screen-meta-links .show-settings:active {
@@ -1876,7 +1878,7 @@ p.auto-update-status {
 	border: 1px solid #c3c4c7;
 	border-top: none;
 	border-bottom: none;
-	background: #f0f6fc;
+	background: #fff;
 }
 
 #contextual-help-wrap.no-sidebar #contextual-help-back {
@@ -1889,6 +1891,7 @@ p.auto-update-status {
 	float: left;
 	width: 150px;
 	margin: 0;
+	background-color: #f0f6fc;
 }
 
 .contextual-help-tabs ul {
@@ -1905,7 +1908,7 @@ p.auto-update-status {
 
 .contextual-help-tabs a {
 	display: block;
-	padding: 5px 5px 5px 12px;
+	padding: 8px 5px 8px 12px;
 	line-height: 1.4;
 	text-decoration: none;
 	border: 1px solid transparent;
@@ -1920,8 +1923,8 @@ p.auto-update-status {
 .contextual-help-tabs .active {
 	padding: 0;
 	margin: 0 -1px 0 0;
-	border-left: 2px solid #72aee6;
-	background: #f0f6fc;
+	border-left: 3px solid #2271b1;
+	background: #fff;
 	box-shadow: 0 2px 0 rgba(0, 0, 0, 0.02), 0 1px 0 rgba(0, 0, 0, 0.02);
 }
 
@@ -1955,6 +1958,7 @@ p.auto-update-status {
 	float: right;
 	padding: 0 8px 0 12px;
 	overflow: auto;
+	background-color: #f0f6fc;
 }
 
 /*------------------------------------------------------------------------------

--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -1759,13 +1759,14 @@ p.auto-update-status {
 }
 
 #screen-meta-links .show-settings:after {
-	right: 0;
-	content: "\f140";
+	left: 2px;
+	content: "\f347";
 	font: normal 20px/1 dashicons;
+	font-size: 18px;
 	speak: never;
 	display: inline-block;
 	padding: 0 5px 0 0;
-	bottom: 2px;
+	bottom: 1px;
 	position: relative;
 	vertical-align: bottom;
 	-webkit-font-smoothing: antialiased;
@@ -1774,7 +1775,7 @@ p.auto-update-status {
 }
 
 #screen-meta-links .screen-meta-active:after {
-	content: "\f142";
+	content: "\f343";
 }
 
 /* end screen options and help tabs */
@@ -1944,6 +1945,12 @@ p.auto-update-status {
 	border: 1px solid #c3c4c7;
 	border-top: none;
 	border-bottom: none;
+	flex-grow: 1;
+}
+
+.no-sidebar .contextual-help-tabs-wrap {
+	max-width: calc(100% - 150px);
+	border-right: none;
 }
 
 .contextual-help-tabs-wrap > * {

--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -1940,7 +1940,7 @@ p.auto-update-status {
 .contextual-help-tabs-wrap {
 	order: 2;
 	overflow: auto;
-	max-width: calc(100% - 300px);
+	max-width: calc(100% - 320px);
 	border: 1px solid #c3c4c7;
 	border-top: none;
 	border-bottom: none;
@@ -1965,7 +1965,7 @@ p.auto-update-status {
 }
 
 .contextual-help-sidebar {
-	width: 150px;
+	width: 170px;
 	order: 3;
 	overflow: auto;
 	background-color: #f0f6fc;

--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -1960,6 +1960,7 @@ p.auto-update-status {
 .help-tab-content {
 	display: none;
 	margin: 0 0 12px 0;
+	padding: 5px 20px 0 20px;
 }
 
 .help-tab-content.active {

--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -1736,8 +1736,6 @@ p.auto-update-status {
 	border-radius: 0 0 4px 4px;
 	color: #646970;
 	line-height: 1.7;
-	/* box-shadow: 0 0 0 transparent;
-	transition: box-shadow 0.1s linear; */
 }
 
 #screen-meta-links .show-settings:hover,
@@ -1747,8 +1745,6 @@ p.auto-update-status {
 }
 
 #screen-meta-links .show-settings:focus {
-	/* border-color: #4f94d4;
-	box-shadow: 0 0 3px rgba(34, 113, 177, 0.8); */
 	box-shadow: 0 0 0 1px #3582c4;
 	outline: 2px solid transparent;
 	outline-offset: 0;
@@ -1871,20 +1867,6 @@ p.auto-update-status {
 	flex-direction: row;
 }
 
-#contextual-help-back {
-	position: absolute;
-	top: 0;
-	bottom: 0;
-	left: 150px;
-	right: 170px;
-	border: 1px solid #c3c4c7;
-	border-top: none;
-	border-bottom: none;
-	background: #fff;
-
-	display: none;
-}
-
 #contextual-help-wrap.no-sidebar #contextual-help-back {
 	right: 0;
 	border-right-width: 0;
@@ -1892,7 +1874,6 @@ p.auto-update-status {
 }
 
 .contextual-help-tabs {
-	order: 1;
 	width: 150px;
 	background-color: #f0f6fc;
 	z-index: 1;
@@ -1939,7 +1920,6 @@ p.auto-update-status {
 }
 
 .contextual-help-tabs-wrap {
-	order: 2;
 	overflow: auto;
 	max-width: calc(100% - 320px);
 	border: 1px solid #c3c4c7;
@@ -1974,7 +1954,6 @@ p.auto-update-status {
 
 .contextual-help-sidebar {
 	width: 170px;
-	order: 3;
 	overflow: auto;
 	background-color: #f0f6fc;
 }

--- a/src/wp-admin/includes/class-wp-screen.php
+++ b/src/wp-admin/includes/class-wp-screen.php
@@ -874,21 +874,21 @@ final class WP_Screen {
 				<div id="contextual-help-back"></div>
 				<div id="contextual-help-columns">
 					<div class="contextual-help-tabs">
-						<ul>
+						<ul role="tablist">
 						<?php
-						$class = ' class="active"';
+						$selected = 'true';
 						foreach ( $this->get_help_tabs() as $tab ) :
 							$link_id  = "tab-link-{$tab['id']}";
 							$panel_id = "tab-panel-{$tab['id']}";
 							?>
 
-							<li id="<?php echo esc_attr( $link_id ); ?>"<?php echo $class; ?>>
-								<a href="<?php echo esc_url( "#$panel_id" ); ?>" aria-controls="<?php echo esc_attr( $panel_id ); ?>">
+							<li id="<?php echo esc_attr( $link_id ); ?>">
+								<button aria-controls="<?php echo esc_attr( $panel_id ); ?>" role="tab" aria-selected="<?php echo $selected; ?>">
 									<?php echo esc_html( $tab['title'] ); ?>
-								</a>
+								</button>
 							</li>
 							<?php
-							$class = '';
+							$selected = 'false';
 						endforeach;
 						?>
 						</ul>

--- a/src/wp-admin/includes/class-wp-screen.php
+++ b/src/wp-admin/includes/class-wp-screen.php
@@ -894,12 +894,6 @@ final class WP_Screen {
 						</ul>
 					</div>
 
-					<?php if ( $help_sidebar ) : ?>
-					<div class="contextual-help-sidebar">
-						<?php echo $help_sidebar; ?>
-					</div>
-					<?php endif; ?>
-
 					<div class="contextual-help-tabs-wrap">
 						<?php
 						$classes = 'help-tab-content active';
@@ -923,6 +917,12 @@ final class WP_Screen {
 						endforeach;
 						?>
 					</div>
+
+					<?php if ( $help_sidebar ) : ?>
+					<div class="contextual-help-sidebar">
+						<?php echo $help_sidebar; ?>
+					</div>
+					<?php endif; ?>
 				</div>
 			</div>
 		<?php


### PR DESCRIPTION
Draft PR
- makes background on main text area white
- makes background for sidebar and menu blue
- help tab + screen options icon changed
- Active tab label is bold
- Active tab border is darker and wider
- layout of help tab uses flex.

## Goal
- Update layout and style
- Make help tab more accessible. Maybe add aria-* ?
- Easier to read

## Todo
- reduce line length?
- update html markup in help tab to correct order
  -  menu
  - content
  - sidebar
- Current order is:
  - menu
  - sidebar
  - content

## Tested
- one tab
- multiple tabs
- sidebar and no sidebar
- desktop
- handheld