### PR TITLE
Media: Don't let PHP timeout in the middle of an ImageMagick operation.

### DIFF
--- a/src/wp-admin/includes/class-wp-debug-data.php
+++ b/src/wp-admin/includes/class-wp-debug-data.php
@@ -581,6 +581,7 @@ class WP_Debug_Data {
 				'map'    => ( defined( 'imagick::RESOURCETYPE_MAP' ) ? size_format( $imagick->getResourceLimit( imagick::RESOURCETYPE_MAP ) ) : $not_available ),
 				'memory' => ( defined( 'imagick::RESOURCETYPE_MEMORY' ) ? size_format( $imagick->getResourceLimit( imagick::RESOURCETYPE_MEMORY ) ) : $not_available ),
 				'thread' => ( defined( 'imagick::RESOURCETYPE_THREAD' ) ? $imagick->getResourceLimit( imagick::RESOURCETYPE_THREAD ) : $not_available ),
+				'time'   => ( defined( 'imagick::RESOURCETYPE_TIME' ) ? $imagick->getResourceLimit( imagick::RESOURCETYPE_TIME ) : $not_available ),
 			);
 
 			$limits_debug = array(
@@ -590,6 +591,7 @@ class WP_Debug_Data {
 				'imagick::RESOURCETYPE_MAP'    => ( defined( 'imagick::RESOURCETYPE_MAP' ) ? size_format( $imagick->getResourceLimit( imagick::RESOURCETYPE_MAP ) ) : 'not available' ),
 				'imagick::RESOURCETYPE_MEMORY' => ( defined( 'imagick::RESOURCETYPE_MEMORY' ) ? size_format( $imagick->getResourceLimit( imagick::RESOURCETYPE_MEMORY ) ) : 'not available' ),
 				'imagick::RESOURCETYPE_THREAD' => ( defined( 'imagick::RESOURCETYPE_THREAD' ) ? $imagick->getResourceLimit( imagick::RESOURCETYPE_THREAD ) : 'not available' ),
+				'imagick::RESOURCETYPE_TIME'   => ( defined( 'imagick::RESOURCETYPE_TIME' ) ? $imagick->getResourceLimit( imagick::RESOURCETYPE_TIME ) : 'not available' ),
 			);
 
 			$info['wp-media']['fields']['imagick_limits'] = array(

--- a/src/wp-includes/class-wp-image-editor-imagick.php
+++ b/src/wp-includes/class-wp-image-editor-imagick.php
@@ -257,19 +257,19 @@ class WP_Image_Editor_Imagick extends WP_Image_Editor {
 	 * Depending on configuration, Imagick processing may take time.
 	 *
 	 * Multiple problems exist if PHP timeouts before ImageMagick completed:
-	 * 1. Temporary files aren't cleaned by ImageMagick garbage collection
-	 * 2. No clear error is provided
+	 * 1. Temporary files aren't cleaned by ImageMagick garbage collection.
+	 * 2. No clear error is provided.
 	 * 3. The cause of such timeout can be hard to pinpoint.
 	 *
-	 * This function (expected to be run before heavy image routines) resolves
-	 *  above point 1 by aligning Imagick's timeout on PHP one (assuming it's set).
+	 * This function, which is expected to be run before heavy image routines, resolves
+	 * point 1 above by aligning Imagick's timeout with PHP's timeout, assuming it's set.
 	 *
 	 * Note: Imagick resource exhaustion does not issue catchable exceptions (yet)
 	 *       See https://github.com/Imagick/imagick/issues/333
 	 * Note: The resource limit isn't saved/restored. It applies to
 	 *       subsequent image operations within the time of the HTTP request.
 	 *
-	 * @since 6.1.0
+	 * @since 6.2.0
 	 *
 	 * @return int|null Whether the new limit or null if none was set
 	 */
@@ -278,10 +278,12 @@ class WP_Image_Editor_Imagick extends WP_Image_Editor {
 			return null;
 		}
 
-		// returns PHP_FLOAT_MAX if unset
+		// Returns PHP_FLOAT_MAX if unset.
 		$imagick_timeout = Imagick::getResourceLimit( Imagick::RESOURCETYPE_TIME );
-		// convert to a int keeping in mind that (int)PHP_FLOAT_MAX) == 0
+
+		// Convert to an integer, keeping in mind that: 0 === (int) PHP_FLOAT_MAX.
 		$imagick_timeout = $imagick_timeout > PHP_INT_MAX ? PHP_INT_MAX : (int) $imagick_timeout;
+
 		$php_timeout = intval( ini_get( 'max_execution_time' ) );
 
 		if ( $php_timeout > 1 && $php_timeout < $imagick_timeout ) {

--- a/src/wp-includes/class-wp-image-editor-imagick.php
+++ b/src/wp-includes/class-wp-image-editor-imagick.php
@@ -280,7 +280,7 @@ class WP_Image_Editor_Imagick extends WP_Image_Editor {
 		// returns PHP_FLOAT_MAX if unset
 		$imagick_timeout = Imagick::getResourceLimit( Imagick::RESOURCETYPE_TIME );
 		// convert to a int keeping in mind that (int)PHP_FLOAT_MAX) == 0
-		$imagick_timeout = $imagick_timeout > PHP_INT_MAX ? PHP_INT_MAX : (int)$imagick_timeout;
+		$imagick_timeout = $imagick_timeout > PHP_INT_MAX ? PHP_INT_MAX : (int) $imagick_timeout;
 		$php_timeout = intval( ini_get( 'max_execution_time' ) );
 
 		if ( $php_timeout > 1 && $php_timeout < $imagick_timeout ) {

--- a/src/wp-includes/class-wp-image-editor-imagick.php
+++ b/src/wp-includes/class-wp-image-editor-imagick.php
@@ -254,9 +254,9 @@ class WP_Image_Editor_Imagick extends WP_Image_Editor {
 	}
 
 	/**
-	 * Depending on configuration Imagick processing may take time.
+	 * Depending on configuration, Imagick processing may take time.
 	 *
-	 * Multiple problems exist if PHP timeout before ImageMagick completed:
+	 * Multiple problems exist if PHP timeouts before ImageMagick completed:
 	 * 1. Temporary files aren't cleaned by ImageMagick garbage collection
 	 * 2. No clear error is provided
 	 * 3. The cause of such timeout can be hard to pinpoint.
@@ -264,11 +264,12 @@ class WP_Image_Editor_Imagick extends WP_Image_Editor {
 	 * This function (expected to be run before heavy image routines) resolves
 	 *  above point 1 by aligning Imagick's timeout on PHP one (assuming it's set).
 	 *
-	 * Note: Imagick resource exhaustion do not catchable issue exceptions (yet).
-	 * Note: The resource limit isn't backuped nor restored and will remain
-	 *  for subsequent image operations within the time of the HTTP request.
+	 * Note: Imagick resource exhaustion does not issue catchable exceptions (yet)
+	 *       See https://github.com/Imagick/imagick/issues/333
+	 * Note: The resource limit isn't saved/restored. It applies to
+	 *       subsequent image operations within the time of the HTTP request.
 	 *
-	 * @since 5.7.0
+	 * @since 6.1.0
 	 *
 	 * @return int|null Whether the new limit or null if none was set
 	 */

--- a/src/wp-includes/class-wp-image-editor-imagick.php
+++ b/src/wp-includes/class-wp-image-editor-imagick.php
@@ -254,6 +254,45 @@ class WP_Image_Editor_Imagick extends WP_Image_Editor {
 	}
 
 	/**
+	 * Depending on configuration Imagick processing may take time.
+	 *
+	 * Multiple problems exist if PHP timeout before ImageMagick completed:
+	 * 1. Temporary files aren't cleaned by ImageMagick garbage collection
+	 * 2. No clear error is provided
+	 * 3. The cause of such timeout can be hard to pinpoint.
+	 *
+	 * This function (expected to be run before heavy image routines) resolves
+	 *  above point 1 by aligning Imagick's timeout on PHP one (assuming it's set).
+	 *
+	 * Note: Imagick resource exhaustion do not catchable issue exceptions (yet).
+	 * Note: The resource limit isn't backuped nor restored and will remain
+	 *  for subsequent image operations within the time of the HTTP request.
+	 *
+	 * @since 5.7.0
+	 *
+	 * @return int|null Whether the new limit or null if none was set
+	 */
+	public static function setImagickTimeLimit() {
+		if ( !defined( 'Imagick::RESOURCETYPE_TIME' ) ) {
+			return null;
+		}
+
+		// returns PHP_FLOAT_MAX if unset
+		$imagick_timeout = Imagick::getResourceLimit( Imagick::RESOURCETYPE_TIME );
+		// convert to a int keeping in mind that (int)PHP_FLOAT_MAX) == 0
+		$imagick_timeout = $imagick_timeout > PHP_INT_MAX ? PHP_INT_MAX : (int)$imagick_timeout;
+		$php_timeout = intval( ini_get( 'max_execution_time' ) );
+
+		if ( $php_timeout > 1 && $php_timeout < $imagick_timeout ) {
+			// $limit = $php_timeout - 1;
+			$limit = floatval( 0.8 * $php_timeout );
+			Imagick::setResourceLimit( Imagick::RESOURCETYPE_TIME, $limit );
+
+			return $limit;
+		}
+	}
+
+	/**
 	 * Resizes current image.
 	 *
 	 * At minimum, either a height or width must be provided.
@@ -278,6 +317,8 @@ class WP_Image_Editor_Imagick extends WP_Image_Editor {
 		}
 
 		list( $dst_x, $dst_y, $src_x, $src_y, $dst_w, $dst_h, $src_w, $src_h ) = $dims;
+
+		self::setImagickTimeLimit();
 
 		if ( $crop ) {
 			return $this->crop( $src_x, $src_y, $src_w, $src_h, $dst_w, $dst_h );
@@ -548,6 +589,8 @@ class WP_Image_Editor_Imagick extends WP_Image_Editor {
 			$src_w -= $src_x;
 			$src_h -= $src_y;
 		}
+
+		self::setImagickTimeLimit();
 
 		try {
 			$this->image->cropImage( $src_w, $src_h, $src_x, $src_y );

--- a/src/wp-includes/class-wp-image-editor-imagick.php
+++ b/src/wp-includes/class-wp-image-editor-imagick.php
@@ -273,7 +273,7 @@ class WP_Image_Editor_Imagick extends WP_Image_Editor {
 	 * @return int|null Whether the new limit or null if none was set
 	 */
 	public static function setImagickTimeLimit() {
-		if ( !defined( 'Imagick::RESOURCETYPE_TIME' ) ) {
+		if ( ! defined( 'Imagick::RESOURCETYPE_TIME' ) ) {
 			return null;
 		}
 


### PR DESCRIPTION
This PR is a refresh of #1019, with some docs improvements.

Trac ticket: https://core.trac.wordpress.org/ticket/52569
