### PR TITLE
File block: Re-add frontend styles for classic themes

### DIFF
--- a/src/wp-includes/css/classic-themes.css
+++ b/src/wp-includes/css/classic-themes.css
@@ -16,3 +16,9 @@
 
 	font-size: 1.125em;
 }
+
+.wp-block-file__button {
+	background: #32373c;
+	color: #ffffff;
+	text-decoration: none;
+}


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/57688

This PR adds text color and background color to the file block on the frontend, which is lost in the Classic theme.

## Testing Instruction

Classic themes such as Twenty Twenty One and Twenty Twenty cannot be reproduced because they have styles for file blocks. Therefore, create a plain theme with the following files:

empty-classic/style.css

```css
/*
Theme Name: Empty Classic
*/
```

empty-classic/index.php

```php
<?php
wp_head();
the_post();
the_content();
wp_footer();
```

- Insert the file block.
- Confirm that the text color and background color are applied correctly on frontend.

### Before

![before](https://user-images.githubusercontent.com/54422211/217994141-aef26390-81f4-4c34-9901-f1dd5e66bca8.png)

### After

![after](https://user-images.githubusercontent.com/54422211/217994156-6ac95885-549d-4c3a-a701-b28e8a495e2f.png)
