### PR TITLE
External Libraries: Prevent a PHP 8.1 deprecation notice in `PasswordHash::gensalt_blowfish()`.

### DIFF
--- a/src/wp-includes/class-phpass.php
+++ b/src/wp-includes/class-phpass.php
@@ -174,7 +174,7 @@ class PasswordHash {
 
 		$output = '$2a$';
 		$output .= chr((int)(ord('0') + $this->iteration_count_log2 / 10));
-		$output .= chr((int)(ord('0') + $this->iteration_count_log2 % 10));
+		$output .= chr((ord('0') + $this->iteration_count_log2 % 10));
 		$output .= '$';
 
 		$i = 0;

--- a/src/wp-includes/class-phpass.php
+++ b/src/wp-includes/class-phpass.php
@@ -173,8 +173,8 @@ class PasswordHash {
 		$itoa64 = './ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
 
 		$output = '$2a$';
-		$output .= chr(ord('0') + $this->iteration_count_log2 / 10);
-		$output .= chr(ord('0') + $this->iteration_count_log2 % 10);
+		$output .= chr((int)(ord('0') + $this->iteration_count_log2 / 10));
+		$output .= chr((int)(ord('0') + $this->iteration_count_log2 % 10));
 		$output .= '$';
 
 		$i = 0;

--- a/tests/phpunit/tests/passwordHash.php
+++ b/tests/phpunit/tests/passwordHash.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Tests for the PasswordHash external library.
+ *
+ * @covers PasswordHash
+ */
+class Tests_PasswordHash extends WP_UnitTestCase {
+
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		require_once ABSPATH . WPINC . '/class-phpass.php';
+	}
+
+	/**
+	 * Tests that PasswordHash::gensalt_blowfish() does not throw a deprecation
+	 * notice on PHP 8.1 for "Implicit conversion from float to int loses precision".
+	 *
+	 * @ticket 56340
+	 *
+	 * @covers PasswordHash::gensalt_blowfish
+	 */
+	public function test_gensalt_blowfish_should_not_throw_deprecation_notice_in_php81() {
+		if ( version_compare( PHP_VERSION, '8.1.0', '<' ) ) {
+			$this->markTestSkipped( 'This test should only run on PHP 8.1 or greater.' );
+		}
+
+		try {
+			$this->expectNotToPerformAssertions();
+
+			$hasher = new PasswordHash( 8, true );
+			$hasher->gensalt_blowfish( 'a password string' );
+		} catch ( \Exception $exception ) {
+			$message = $exception->getMessage();
+
+			if ( str_contains( $message, 'Implicit conversion from float' ) ) {
+				$this->fail( 'The deprecation notice was thrown: ' . $message );
+			} else {
+				$this->fail( 'The deprecation notice was not thrown, but another exception was: ' . $message );
+			}
+		}
+	}
+
+}

--- a/tests/phpunit/tests/passwordHash.php
+++ b/tests/phpunit/tests/passwordHash.php
@@ -22,13 +22,10 @@ class Tests_PasswordHash extends WP_UnitTestCase {
 	 * @ticket 56340
 	 *
 	 * @covers PasswordHash::gensalt_blowfish
+	 *
+	 * @requires PHP 8.1
 	 */
 	public function test_gensalt_blowfish_should_not_throw_deprecation_notice_in_php81() {
-		if ( version_compare( PHP_VERSION, '8.1.0', '<' ) ) {
-			$this->markTestSkipped( 'This test should only run on PHP 8.1 or greater.' );
-		}
-
-		try {
 			$this->expectNotToPerformAssertions();
 
 			$hasher = new PasswordHash( 8, true );

--- a/tests/phpunit/tests/passwordHash.php
+++ b/tests/phpunit/tests/passwordHash.php
@@ -17,6 +17,8 @@ class Tests_PasswordHash extends WP_UnitTestCase {
 	 * Tests that PasswordHash::gensalt_blowfish() does not throw a deprecation
 	 * notice on PHP 8.1 for "Implicit conversion from float to int loses precision".
 	 *
+	 * Should this test fail, it will produce an error "E" in the results.
+	 *
 	 * @ticket 56340
 	 *
 	 * @covers PasswordHash::gensalt_blowfish
@@ -31,15 +33,6 @@ class Tests_PasswordHash extends WP_UnitTestCase {
 
 			$hasher = new PasswordHash( 8, true );
 			$hasher->gensalt_blowfish( 'a password string' );
-		} catch ( \Exception $exception ) {
-			$message = $exception->getMessage();
-
-			if ( str_contains( $message, 'Implicit conversion from float' ) ) {
-				$this->fail( 'The deprecation notice was thrown: ' . $message );
-			} else {
-				$this->fail( 'The deprecation notice was not thrown, but another exception was: ' . $message );
-			}
-		}
 	}
 
 }


### PR DESCRIPTION
In PHP 8.1, `PasswordHash::gensalt_blowfish()` threw a deprecation notice for "Implicit conversation from float to int loses precision".

This change uses an `(int)` cast to prevent the deprecation notice.

Trac ticket: https://core.trac.wordpress.org/ticket/56340