### PR TITLE
Add new functions for enabling site theme in multisite

### DIFF
--- a/src/wp-includes/class-wp-theme.php
+++ b/src/wp-includes/class-wp-theme.php
@@ -1707,6 +1707,87 @@ final class WP_Theme implements ArrayAccess {
 	}
 
 	/**
+	 * Enables a theme for a site.
+	 *
+	 * @param string|string[] $stylesheets Stylesheet name or array of stylesheet names.
+	 * @param int             $site_id     Site ID.
+	 *
+	 * @since 6.3
+	 *
+	 */
+	public static function site_enable_theme( $stylesheets, $site_id = null ) {
+		$site_id = (int) $site_id;
+
+		if ( ! is_multisite() ) {
+			return;
+		}
+
+		if ( ! is_array( $stylesheets ) ) {
+			$stylesheets = array( $stylesheets );
+		}
+
+		$current_site_id = get_current_blog_id();
+		if ( ! $site_id ) {
+			$site_id = $current_site_id;
+		}
+
+		if ( $site_id !== $current_site_id ) {
+			switch_to_blog( $site_id );
+		}
+
+		$allowed_themes = get_option( 'allowedthemes' );
+		foreach ( $stylesheets as $stylesheet ) {
+			$allowed_themes[ $stylesheet ] = true;
+		}
+		update_option( 'allowedthemes', $allowed_themes );
+
+		if ( $site_id !== $current_site_id ) {
+			restore_current_blog();
+		}
+	}
+
+	/**
+	 * Disables a theme for a site.
+	 *
+	 * @since 6.3
+	 *
+	 * @param string|string[] $stylesheets Stylesheet name or array of stylesheet names.
+	 * @param int             $site_id     Site ID.
+	 */
+	public static function site_disable_theme( $stylesheets, $site_id = null ) {
+		$site_id = (int) $site_id;
+
+		if ( ! is_multisite() ) {
+			return;
+		}
+
+		if ( ! is_array( $stylesheets ) ) {
+			$stylesheets = array( $stylesheets );
+		}
+
+		$current_site_id = get_current_blog_id();
+		if ( ! $site_id ) {
+			$site_id = $current_site_id;
+		}
+
+		if ( $site_id !== $current_site_id ) {
+			switch_to_blog( $site_id );
+		}
+
+		$allowed_themes = get_option( 'allowedthemes' );
+		foreach ( $stylesheets as $stylesheet ) {
+			if ( isset( $allowed_themes[ $stylesheet ] ) ) {
+				unset( $allowed_themes[ $stylesheet ] );
+			}
+		}
+		update_option( 'allowedthemes', $allowed_themes );
+
+		if ( $site_id !== $current_site_id ) {
+			restore_current_blog();
+		}
+	}
+
+	/**
 	 * Enables a theme for all sites on the current network.
 	 *
 	 * @since 4.6.0

--- a/src/wp-includes/class-wp-theme.php
+++ b/src/wp-includes/class-wp-theme.php
@@ -1731,19 +1731,12 @@ final class WP_Theme implements ArrayAccess {
 			$site_id = $current_site_id;
 		}
 
-		if ( $site_id !== $current_site_id ) {
-			switch_to_blog( $site_id );
-		}
-
-		$allowed_themes = get_option( 'allowedthemes' );
+		$allowed_themes = get_blog_option( $site_id, 'allowedthemes' );
 		foreach ( $stylesheets as $stylesheet ) {
 			$allowed_themes[ $stylesheet ] = true;
 		}
-		update_option( 'allowedthemes', $allowed_themes );
 
-		if ( $site_id !== $current_site_id ) {
-			restore_current_blog();
-		}
+		update_blog_option( $site_id, 'allowedthemes', $allowed_themes );
 	}
 
 	/**
@@ -1770,21 +1763,14 @@ final class WP_Theme implements ArrayAccess {
 			$site_id = $current_site_id;
 		}
 
-		if ( $site_id !== $current_site_id ) {
-			switch_to_blog( $site_id );
-		}
-
-		$allowed_themes = get_option( 'allowedthemes' );
+		$allowed_themes = get_blog_option( $site_id, 'allowedthemes' );
 		foreach ( $stylesheets as $stylesheet ) {
 			if ( isset( $allowed_themes[ $stylesheet ] ) ) {
 				unset( $allowed_themes[ $stylesheet ] );
 			}
 		}
-		update_option( 'allowedthemes', $allowed_themes );
 
-		if ( $site_id !== $current_site_id ) {
-			restore_current_blog();
-		}
+		update_blog_option( $site_id, 'allowedthemes', $allowed_themes );
 	}
 
 	/**

--- a/tests/phpunit/tests/theme/wpTheme.php
+++ b/tests/phpunit/tests/theme/wpTheme.php
@@ -265,7 +265,7 @@ class Tests_Theme_wpTheme extends WP_UnitTestCase {
 	 * Enable a single theme on a network site.
 	 *
 	 * @ticket 43728
-	 * @group ms-required, failure
+	 * @group ms-required
 	 */
 	public function test_wp_theme_site_enable_single_theme() {
 		$theme                  = 'testtheme-1';
@@ -279,10 +279,33 @@ class Tests_Theme_wpTheme extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Enable multiple themes on a network site.
+	 *
+	 * @ticket 43728
+	 * @group ms-required
+	 */
+	public function test_wp_theme_site_enable_multiple_themes() {
+		$themes                 = array( 'testtheme-2', 'testtheme-3' );
+		$current_allowed_themes = get_blog_option( 2, 'allowedthemes' );
+		WP_Theme::site_enable_theme( $themes );
+		$new_allowed_themes = get_blog_option( 2, 'allowedthemes' );
+		update_blog_option( 2, 'allowedthemes', $current_allowed_themes ); // Reset previous value.
+		$current_allowed_themes = array_merge(
+			$current_allowed_themes,
+			array(
+				'testtheme-2' => true,
+				'testtheme-3' => true,
+			)
+		);
+
+		$this->assertSameSetsWithIndex( $current_allowed_themes, $new_allowed_themes );
+	}
+
+	/**
 	 * Disable a single theme on a network site.
 	 *
 	 * @ticket 43728
-	 * @group ms-required, failure
+	 * @group ms-required
 	 */
 	public function test_site_disable_single_theme() {
 		$current_allowed_themes = get_blog_option( 2, 'allowedthemes' );
@@ -299,6 +322,32 @@ class Tests_Theme_wpTheme extends WP_UnitTestCase {
 		$new_allowed_themes = get_blog_option( 2, 'allowedthemes' );
 		update_blog_option( 2, 'allowedthemes', $current_allowed_themes ); // Reset previous value.
 		unset( $allowed_themes[ $disable_theme ] ); // Remove deleted theme from initial set.
+
+		$this->assertSameSetsWithIndex( $allowed_themes, $new_allowed_themes );
+	}
+
+	/**
+	 * Disable multiple themes on a network site.
+	 *
+	 * @ticket 43728
+	 * @group ms-required
+	 */
+	public function test_site_disable_multiple_themes() {
+		$current_allowed_themes = get_blog_option( 2, 'allowedthemes' );
+
+		$allowed_themes = array(
+			'existing-4' => true,
+			'existing-5' => true,
+			'existing-6' => true,
+		);
+		update_blog_option( 2, 'allowedthemes', $allowed_themes );
+
+		$disable_themes = array( 'existing-4', 'existing-5' );
+		WP_Theme::site_disable_theme( $disable_themes );
+		$new_allowed_themes = get_blog_option( 2, 'allowedthemes' );
+		update_blog_option( 2, 'allowedthemes', $current_allowed_themes ); // Reset previous value.
+		unset( $allowed_themes['existing-4'] );
+		unset( $allowed_themes['existing-5'] );
 
 		$this->assertSameSetsWithIndex( $allowed_themes, $new_allowed_themes );
 	}

--- a/tests/phpunit/tests/theme/wpTheme.php
+++ b/tests/phpunit/tests/theme/wpTheme.php
@@ -214,7 +214,7 @@ class Tests_Theme_wpTheme extends WP_UnitTestCase {
 	 * Disable a single theme on a network.
 	 *
 	 * @ticket 30594
-	 * @group ms-required, fail
+	 * @group ms-required
 	 */
 	public function test_network_disable_single_theme() {
 		$current_allowed_themes = get_site_option( 'allowedthemes' );

--- a/tests/phpunit/tests/theme/wpTheme.php
+++ b/tests/phpunit/tests/theme/wpTheme.php
@@ -262,6 +262,48 @@ class Tests_Theme_wpTheme extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Enable a single theme on a network site.
+	 *
+	 * @ticket 43728
+	 * @group ms-required, failure
+	 */
+	public function test_wp_theme_site_enable_single_theme() {
+		$theme                  = 'testtheme-1';
+		$current_allowed_themes = get_blog_option( 2, 'allowedthemes' );
+		WP_Theme::site_enable_theme( $theme, 2 );
+		$new_allowed_themes = get_blog_option( 2, 'allowedthemes' );
+		update_blog_option( 2, 'allowedthemes', $current_allowed_themes ); // Reset previous value.
+		$current_allowed_themes['testtheme-1'] = true; // Add the new theme to the previous set.
+
+		$this->assertSameSetsWithIndex( $current_allowed_themes, $new_allowed_themes );
+	}
+
+	/**
+	 * Disable a single theme on a network site.
+	 *
+	 * @ticket 43728
+	 * @group ms-required, failure
+	 */
+	public function test_site_disable_single_theme() {
+		$current_allowed_themes = get_blog_option( 2, 'allowedthemes' );
+
+		$allowed_themes = array(
+			'existing-1' => true,
+			'existing-2' => true,
+			'existing-3' => true,
+		);
+		update_blog_option( 2, 'allowedthemes', $allowed_themes );
+
+		$disable_theme = 'existing-2';
+		WP_Theme::site_disable_theme( $disable_theme );
+		$new_allowed_themes = get_blog_option( 2, 'allowedthemes' );
+		update_blog_option( 2, 'allowedthemes', $current_allowed_themes ); // Reset previous value.
+		unset( $allowed_themes[ $disable_theme ] ); // Remove deleted theme from initial set.
+
+		$this->assertSameSetsWithIndex( $allowed_themes, $new_allowed_themes );
+	}
+
+	/**
 	 * @dataProvider data_is_block_theme
 	 * @ticket 54460
 	 *

--- a/tests/phpunit/tests/theme/wpTheme.php
+++ b/tests/phpunit/tests/theme/wpTheme.php
@@ -214,7 +214,7 @@ class Tests_Theme_wpTheme extends WP_UnitTestCase {
 	 * Disable a single theme on a network.
 	 *
 	 * @ticket 30594
-	 * @group ms-required
+	 * @group ms-required, fail
 	 */
 	public function test_network_disable_single_theme() {
 		$current_allowed_themes = get_site_option( 'allowedthemes' );
@@ -269,7 +269,7 @@ class Tests_Theme_wpTheme extends WP_UnitTestCase {
 	 */
 	public function test_wp_theme_site_enable_single_theme() {
 		$blog_id = self::factory()->blog->create();
-		update_blog_option( $blog_id, 'allowedthemes', [] ); // default value.
+		update_blog_option( $blog_id, 'allowedthemes', array() ); // default value.
 
 		$theme                  = 'testtheme-1';
 		$current_allowed_themes = get_blog_option( $blog_id, 'allowedthemes' );
@@ -289,7 +289,7 @@ class Tests_Theme_wpTheme extends WP_UnitTestCase {
 	 */
 	public function test_wp_theme_site_enable_multiple_themes() {
 		$blog_id = self::factory()->blog->create();
-		update_blog_option( $blog_id, 'allowedthemes', [] ); // default value.
+		update_blog_option( $blog_id, 'allowedthemes', array() ); // default value.
 
 		$themes                 = array( 'testtheme-2', 'testtheme-3' );
 		$current_allowed_themes = get_blog_option( $blog_id, 'allowedthemes' );
@@ -324,8 +324,9 @@ class Tests_Theme_wpTheme extends WP_UnitTestCase {
 		update_blog_option( $blog_id, 'allowedthemes', $allowed_themes );
 
 		$disable_theme = 'existing-2';
-		WP_Theme::site_disable_theme( $disable_theme );
+		WP_Theme::site_disable_theme( $disable_theme, $blog_id );
 		$new_allowed_themes = get_blog_option( $blog_id, 'allowedthemes' );
+
 		update_blog_option( $blog_id, 'allowedthemes', $allowed_themes ); // Reset previous value.
 		unset( $allowed_themes[ $disable_theme ] ); // Remove deleted theme from initial set.
 
@@ -349,7 +350,7 @@ class Tests_Theme_wpTheme extends WP_UnitTestCase {
 		update_blog_option( $blog_id, 'allowedthemes', $allowed_themes );
 
 		$disable_themes = array( 'existing-4', 'existing-5' );
-		WP_Theme::site_disable_theme( $disable_themes );
+		WP_Theme::site_disable_theme( $disable_themes, $blog_id );
 		$new_allowed_themes = get_blog_option( $blog_id, 'allowedthemes' );
 		update_blog_option( $blog_id, 'allowedthemes', $allowed_themes ); // Reset previous value.
 		unset( $allowed_themes['existing-4'] );

--- a/tests/phpunit/tests/theme/wpTheme.php
+++ b/tests/phpunit/tests/theme/wpTheme.php
@@ -268,9 +268,8 @@ class Tests_Theme_wpTheme extends WP_UnitTestCase {
 	 * @group ms-required
 	 */
 	public function test_wp_theme_site_enable_single_theme() {
-		$blog_id                = self::factory()->blog->create();
-		$default_allowed_themes = [ 'sandbox' ];
-		update_blog_option( $blog_id, 'allowedthemes', $default_allowed_themes ); // Random default allowed theme.
+		$blog_id = self::factory()->blog->create();
+		update_blog_option( $blog_id, 'allowedthemes', [] ); // default value.
 
 		$theme                  = 'testtheme-1';
 		$current_allowed_themes = get_blog_option( $blog_id, 'allowedthemes' );
@@ -290,8 +289,7 @@ class Tests_Theme_wpTheme extends WP_UnitTestCase {
 	 */
 	public function test_wp_theme_site_enable_multiple_themes() {
 		$blog_id = self::factory()->blog->create();
-		$default_allowed_themes = [ 'sandbox' ];
-		update_blog_option( $blog_id, 'allowedthemes', $default_allowed_themes ); // Random default allowed theme.
+		update_blog_option( $blog_id, 'allowedthemes', [] ); // default value.
 
 		$themes                 = array( 'testtheme-2', 'testtheme-3' );
 		$current_allowed_themes = get_blog_option( $blog_id, 'allowedthemes' );
@@ -317,10 +315,6 @@ class Tests_Theme_wpTheme extends WP_UnitTestCase {
 	 */
 	public function test_site_disable_single_theme() {
 		$blog_id = self::factory()->blog->create();
-		$default_allowed_themes = [ 'sandbox' ];
-		update_blog_option( $blog_id, 'allowedthemes', $default_allowed_themes ); // Random default allowed theme.
-
-		$current_allowed_themes = get_blog_option( $blog_id, 'allowedthemes' );
 
 		$allowed_themes = array(
 			'existing-1' => true,
@@ -332,7 +326,7 @@ class Tests_Theme_wpTheme extends WP_UnitTestCase {
 		$disable_theme = 'existing-2';
 		WP_Theme::site_disable_theme( $disable_theme );
 		$new_allowed_themes = get_blog_option( $blog_id, 'allowedthemes' );
-		update_blog_option( $blog_id, 'allowedthemes', $current_allowed_themes ); // Reset previous value.
+		update_blog_option( $blog_id, 'allowedthemes', $allowed_themes ); // Reset previous value.
 		unset( $allowed_themes[ $disable_theme ] ); // Remove deleted theme from initial set.
 
 		$this->assertSameSetsWithIndex( $allowed_themes, $new_allowed_themes );
@@ -346,10 +340,6 @@ class Tests_Theme_wpTheme extends WP_UnitTestCase {
 	 */
 	public function test_site_disable_multiple_themes() {
 		$blog_id = self::factory()->blog->create();
-		$default_allowed_themes = [ 'sandbox' ];
-		update_blog_option( $blog_id, 'allowedthemes', $default_allowed_themes ); // Random default allowed theme.
-
-		$current_allowed_themes = get_blog_option( $blog_id, 'allowedthemes' );
 
 		$allowed_themes = array(
 			'existing-4' => true,
@@ -361,7 +351,7 @@ class Tests_Theme_wpTheme extends WP_UnitTestCase {
 		$disable_themes = array( 'existing-4', 'existing-5' );
 		WP_Theme::site_disable_theme( $disable_themes );
 		$new_allowed_themes = get_blog_option( $blog_id, 'allowedthemes' );
-		update_blog_option( $blog_id, 'allowedthemes', $current_allowed_themes ); // Reset previous value.
+		update_blog_option( $blog_id, 'allowedthemes', $allowed_themes ); // Reset previous value.
 		unset( $allowed_themes['existing-4'] );
 		unset( $allowed_themes['existing-5'] );
 

--- a/tests/phpunit/tests/theme/wpTheme.php
+++ b/tests/phpunit/tests/theme/wpTheme.php
@@ -268,11 +268,12 @@ class Tests_Theme_wpTheme extends WP_UnitTestCase {
 	 * @group ms-required
 	 */
 	public function test_wp_theme_site_enable_single_theme() {
+		$blog_id                = self::factory()->blog->create();
 		$theme                  = 'testtheme-1';
-		$current_allowed_themes = get_blog_option( 2, 'allowedthemes' );
-		WP_Theme::site_enable_theme( $theme, 2 );
-		$new_allowed_themes = get_blog_option( 2, 'allowedthemes' );
-		update_blog_option( 2, 'allowedthemes', $current_allowed_themes ); // Reset previous value.
+		$current_allowed_themes = get_blog_option( $blog_id, 'allowedthemes' );
+		WP_Theme::site_enable_theme( $theme, $blog_id );
+		$new_allowed_themes = get_blog_option( $blog_id, 'allowedthemes' );
+		update_blog_option( $blog_id, 'allowedthemes', $current_allowed_themes ); // Reset previous value.
 		$current_allowed_themes['testtheme-1'] = true; // Add the new theme to the previous set.
 
 		$this->assertSameSetsWithIndex( $current_allowed_themes, $new_allowed_themes );
@@ -285,11 +286,12 @@ class Tests_Theme_wpTheme extends WP_UnitTestCase {
 	 * @group ms-required
 	 */
 	public function test_wp_theme_site_enable_multiple_themes() {
+		$blog_id = self::factory()->blog->create();
 		$themes                 = array( 'testtheme-2', 'testtheme-3' );
-		$current_allowed_themes = get_blog_option( 2, 'allowedthemes' );
-		WP_Theme::site_enable_theme( $themes );
-		$new_allowed_themes = get_blog_option( 2, 'allowedthemes' );
-		update_blog_option( 2, 'allowedthemes', $current_allowed_themes ); // Reset previous value.
+		$current_allowed_themes = get_blog_option( $blog_id, 'allowedthemes' );
+		WP_Theme::site_enable_theme( $themes, $blog_id );
+		$new_allowed_themes = get_blog_option( $blog_id, 'allowedthemes' );
+		update_blog_option( $blog_id, 'allowedthemes', $current_allowed_themes ); // Reset previous value.
 		$current_allowed_themes = array_merge(
 			$current_allowed_themes,
 			array(
@@ -308,19 +310,20 @@ class Tests_Theme_wpTheme extends WP_UnitTestCase {
 	 * @group ms-required
 	 */
 	public function test_site_disable_single_theme() {
-		$current_allowed_themes = get_blog_option( 2, 'allowedthemes' );
+		$blog_id = self::factory()->blog->create();
+		$current_allowed_themes = get_blog_option( $blog_id, 'allowedthemes' );
 
 		$allowed_themes = array(
 			'existing-1' => true,
 			'existing-2' => true,
 			'existing-3' => true,
 		);
-		update_blog_option( 2, 'allowedthemes', $allowed_themes );
+		update_blog_option( $blog_id, 'allowedthemes', $allowed_themes );
 
 		$disable_theme = 'existing-2';
 		WP_Theme::site_disable_theme( $disable_theme );
-		$new_allowed_themes = get_blog_option( 2, 'allowedthemes' );
-		update_blog_option( 2, 'allowedthemes', $current_allowed_themes ); // Reset previous value.
+		$new_allowed_themes = get_blog_option( $blog_id, 'allowedthemes' );
+		update_blog_option( $blog_id, 'allowedthemes', $current_allowed_themes ); // Reset previous value.
 		unset( $allowed_themes[ $disable_theme ] ); // Remove deleted theme from initial set.
 
 		$this->assertSameSetsWithIndex( $allowed_themes, $new_allowed_themes );
@@ -333,19 +336,20 @@ class Tests_Theme_wpTheme extends WP_UnitTestCase {
 	 * @group ms-required
 	 */
 	public function test_site_disable_multiple_themes() {
-		$current_allowed_themes = get_blog_option( 2, 'allowedthemes' );
+		$blog_id = self::factory()->blog->create();
+		$current_allowed_themes = get_blog_option( $blog_id, 'allowedthemes' );
 
 		$allowed_themes = array(
 			'existing-4' => true,
 			'existing-5' => true,
 			'existing-6' => true,
 		);
-		update_blog_option( 2, 'allowedthemes', $allowed_themes );
+		update_blog_option( $blog_id, 'allowedthemes', $allowed_themes );
 
 		$disable_themes = array( 'existing-4', 'existing-5' );
 		WP_Theme::site_disable_theme( $disable_themes );
-		$new_allowed_themes = get_blog_option( 2, 'allowedthemes' );
-		update_blog_option( 2, 'allowedthemes', $current_allowed_themes ); // Reset previous value.
+		$new_allowed_themes = get_blog_option( $blog_id, 'allowedthemes' );
+		update_blog_option( $blog_id, 'allowedthemes', $current_allowed_themes ); // Reset previous value.
 		unset( $allowed_themes['existing-4'] );
 		unset( $allowed_themes['existing-5'] );
 

--- a/tests/phpunit/tests/theme/wpTheme.php
+++ b/tests/phpunit/tests/theme/wpTheme.php
@@ -269,6 +269,9 @@ class Tests_Theme_wpTheme extends WP_UnitTestCase {
 	 */
 	public function test_wp_theme_site_enable_single_theme() {
 		$blog_id                = self::factory()->blog->create();
+		$default_allowed_themes = [ 'sandbox' ];
+		update_blog_option( $blog_id, 'allowedthemes', $default_allowed_themes ); // Random default allowed theme.
+
 		$theme                  = 'testtheme-1';
 		$current_allowed_themes = get_blog_option( $blog_id, 'allowedthemes' );
 		WP_Theme::site_enable_theme( $theme, $blog_id );
@@ -287,6 +290,9 @@ class Tests_Theme_wpTheme extends WP_UnitTestCase {
 	 */
 	public function test_wp_theme_site_enable_multiple_themes() {
 		$blog_id = self::factory()->blog->create();
+		$default_allowed_themes = [ 'sandbox' ];
+		update_blog_option( $blog_id, 'allowedthemes', $default_allowed_themes ); // Random default allowed theme.
+
 		$themes                 = array( 'testtheme-2', 'testtheme-3' );
 		$current_allowed_themes = get_blog_option( $blog_id, 'allowedthemes' );
 		WP_Theme::site_enable_theme( $themes, $blog_id );
@@ -311,6 +317,9 @@ class Tests_Theme_wpTheme extends WP_UnitTestCase {
 	 */
 	public function test_site_disable_single_theme() {
 		$blog_id = self::factory()->blog->create();
+		$default_allowed_themes = [ 'sandbox' ];
+		update_blog_option( $blog_id, 'allowedthemes', $default_allowed_themes ); // Random default allowed theme.
+
 		$current_allowed_themes = get_blog_option( $blog_id, 'allowedthemes' );
 
 		$allowed_themes = array(
@@ -337,6 +346,9 @@ class Tests_Theme_wpTheme extends WP_UnitTestCase {
 	 */
 	public function test_site_disable_multiple_themes() {
 		$blog_id = self::factory()->blog->create();
+		$default_allowed_themes = [ 'sandbox' ];
+		update_blog_option( $blog_id, 'allowedthemes', $default_allowed_themes ); // Random default allowed theme.
+
 		$current_allowed_themes = get_blog_option( $blog_id, 'allowedthemes' );
 
 		$allowed_themes = array(


### PR DESCRIPTION
Implementing methods WP_Theme::site_enable_theme( $stylesheets, $site_id ) and WP_Theme::site_disable_theme( $stylesheets, $site_id ).

Trac ticket: [<!-- insert a link to the WordPress Trac ticket here -->](https://core.trac.wordpress.org/ticket/43728)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
