### PR TITLE
Use PasswordHash API directly in Recovery Mode.

### DIFF
--- a/src/wp-includes/class-wp-recovery-mode-key-service.php
+++ b/src/wp-includes/class-wp-recovery-mode-key-service.php
@@ -85,12 +85,15 @@ final class WP_Recovery_Mode_Key_Service {
 	 *
 	 * @since 5.2.0
 	 *
+	 * @global PasswordHash $wp_hasher
+	 *
 	 * @param string $token The token used when generating the given key.
 	 * @param string $key   The unhashed key.
 	 * @param int    $ttl   Time in seconds for the key to be valid for.
 	 * @return true|WP_Error True on success, error object on failure.
 	 */
 	public function validate_recovery_mode_key( $token, $key, $ttl ) {
+		global $wp_hasher;
 
 		$records = $this->get_keys();
 
@@ -106,7 +109,12 @@ final class WP_Recovery_Mode_Key_Service {
 			return new WP_Error( 'invalid_recovery_key_format', __( 'Invalid recovery key format.' ) );
 		}
 
-		if ( ! wp_check_password( $key, $record['hashed_key'] ) ) {
+		if ( empty( $wp_hasher ) ) {
+			require_once ABSPATH . WPINC . '/class-phpass.php';
+			$wp_hasher = new PasswordHash( 8, true );
+		}
+
+		if ( ! $wp_hasher->CheckPassword( $key, $record['hashed_key'] ) ) {
 			return new WP_Error( 'hash_mismatch', __( 'Invalid recovery key.' ) );
 		}
 


### PR DESCRIPTION
Previously, the wp_check_password function was used for validating keys, while the PasswordHash class was used for creating keys. This would prevent Recovery Mode from working on sites that provide a custom implementation for the wp_check_password pluggable function.

Trac ticket: https://core.trac.wordpress.org/ticket/56787

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
