### PR TITLE
#57683: Improve performance of mysql2date function

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -466,6 +466,14 @@ class WP_Query {
 	private $compat_methods = array( 'init_query_flags', 'parse_tax_query' );
 
 	/**
+	 * Private variable to cache the timezone string.
+	 *
+	 * @since 6.2.0
+	 * @var string $timezone The cached timezone string.
+	 */
+	private $timezone = '';
+
+	/**
 	 * Resets query flags to false.
 	 *
 	 * The query flags are what page info WordPress was able to figure out.
@@ -4710,12 +4718,16 @@ class WP_Query {
 			return false;
 		}
 
+		if ( ! isset( $this->timezone ) ) {
+			$this->timezone = wp_timezone_string();
+		}
+
 		$id = (int) $post->ID;
 
 		$authordata = get_userdata( $post->post_author );
 
-		$currentday   = mysql2date( 'd.m.y', $post->post_date, false );
-		$currentmonth = mysql2date( 'm', $post->post_date, false );
+		$currentday   = mysql2date( 'd.m.y', $post->post_date, false, $this->timezone );
+		$currentmonth = mysql2date( 'm', $post->post_date, false, $this->timezone );
 		$numpages     = 1;
 		$multipage    = 0;
 		$page         = $this->get( 'page' );

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -27,12 +27,16 @@ require ABSPATH . WPINC . '/option.php';
  * @return string|int|false Integer if `$format` is 'U' or 'G', string otherwise.
  *                          False on failure.
  */
-function mysql2date( $format, $date, $translate = true ) {
+function mysql2date( $format, $date, $translate = true, $timezone = '' ) {
 	if ( empty( $date ) ) {
 		return false;
 	}
 
-	$datetime = date_create( $date, wp_timezone() );
+	if ( empty( $timezone ) ) {
+		$timezone = wp_timezone();
+	}
+
+	$datetime = date_create( $date, $timezone );
 
 	if ( false === $datetime ) {
 		return false;


### PR DESCRIPTION
This change adds an optional fourth parameter to the `mysql2date` function to allow passing in the timezone.
If the timezone is not passed, the function will default to the value returned by `wp_timezone`.

This modification should improve the performance of the `mysql2date` function by reducing the number of calls to `wp_timezone`.

I have tested the changes and they seem to be working fine. However, I would appreciate it if you could take a look and let me know if there are any issues or further changes needed.

Thanks!

Trac ticket: https://core.trac.wordpress.org/ticket/57683
