### PR TITLE
WIP: HTML API: Introduce `make_tag` helper for creating HTML tags

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-spec.php
+++ b/src/wp-includes/html-api/class-wp-html-spec.php
@@ -1,0 +1,28 @@
+<?php
+
+class WP_HTML_Spec {
+	/**
+ 	 * @see https://html.spec.whatwg.org/#elements-2
+ 	 */
+ 	public static function is_void_element( $tag_name ) {
+ 		switch ( strtoupper( $tag_name ) ) {
+ 			case 'AREA':
+ 			case 'BASE':
+ 			case 'BR':
+ 			case 'COL':
+ 			case 'EMBED':
+ 			case 'HR':
+ 			case 'IMG':
+ 			case 'INPUT':
+ 			case 'LINK':
+ 			case 'META':
+ 			case 'SOURCE':
+ 			case 'TRACK':
+ 			case 'WBR':
+ 				return true;
+
+ 			default:
+ 				return false;
+ 		}
+ 	}
+}

--- a/src/wp-includes/html-api/class-wp-html-spec.php
+++ b/src/wp-includes/html-api/class-wp-html-spec.php
@@ -2,27 +2,27 @@
 
 class WP_HTML_Spec {
 	/**
- 	 * @see https://html.spec.whatwg.org/#elements-2
- 	 */
- 	public static function is_void_element( $tag_name ) {
- 		switch ( strtoupper( $tag_name ) ) {
- 			case 'AREA':
- 			case 'BASE':
- 			case 'BR':
- 			case 'COL':
- 			case 'EMBED':
- 			case 'HR':
- 			case 'IMG':
- 			case 'INPUT':
- 			case 'LINK':
- 			case 'META':
- 			case 'SOURCE':
- 			case 'TRACK':
- 			case 'WBR':
- 				return true;
+	 * @see https://html.spec.whatwg.org/#elements-2
+	 */
+	public static function is_void_element( $tag_name ) {
+		switch ( strtoupper( $tag_name ) ) {
+			case 'AREA':
+			case 'BASE':
+			case 'BR':
+			case 'COL':
+			case 'EMBED':
+			case 'HR':
+			case 'IMG':
+			case 'INPUT':
+			case 'LINK':
+			case 'META':
+			case 'SOURCE':
+			case 'TRACK':
+			case 'WBR':
+				return true;
 
- 			default:
- 				return false;
- 		}
- 	}
+			default:
+				return false;
+		}
+	}
 }

--- a/src/wp-includes/html-api/class-wp-html.php
+++ b/src/wp-includes/html-api/class-wp-html.php
@@ -1,0 +1,19 @@
+<?php
+
+class WP_HTML {
+	public static function make_tag( $tag_name, $attributes = null, $data = '' ) {
+		$is_void = WP_HTML_Spec::is_void_element( $tag_name );
+		$html = $is_void ? "<{$tag_name}>" : "<{$tag_name}>{$data}</{$tag_name}>";
+
+		$p = new WP_HTML_Tag_Processor( $html );
+
+		if ( is_array( $attributes ) ) {
+			$p->next_tag();
+			foreach ( $attributes as $name => $value ) {
+				$p->set_attribute( $name, $value );
+			}
+		}
+
+		return $p->get_updated_html();
+	}
+}

--- a/src/wp-includes/html-api/class-wp-html.php
+++ b/src/wp-includes/html-api/class-wp-html.php
@@ -1,9 +1,13 @@
 <?php
 
 class WP_HTML {
-	public static function make_tag( $tag_name, $attributes = null, $data = '' ) {
+	public static function tag( $tag_name, $attributes = null, $inner_text = '' ) {
+		return WP_HTML::tag_with_inner_html( $tag_name, $attributes, esc_html( $inner_text ) );
+	}
+
+	public static function tag_with_inner_html( $tag_name, $attributes = null, $inner_html = '' ) {
 		$is_void = WP_HTML_Spec::is_void_element( $tag_name );
-		$html = $is_void ? "<{$tag_name}>" : "<{$tag_name}>{$data}</{$tag_name}>";
+		$html = $is_void ? "<{$tag_name}>" : "<{$tag_name}>{$inner_html}</{$tag_name}>";
 
 		$p = new WP_HTML_Tag_Processor( $html );
 

--- a/src/wp-includes/html-api/class-wp-html.php
+++ b/src/wp-includes/html-api/class-wp-html.php
@@ -8,10 +8,10 @@ class WP_HTML {
 	 * Serializes an HTML tag, escaping inner text if provided.
 	 *
 	 * Example:
-	 *     echo WP_HTML::tag( 'p', array( 'class' => 'summary' ), '<p> makes a paragraph.' );
+	 *     WP_HTML::tag( 'p', array( 'class' => 'summary' ), '<p> makes a paragraph.' );
 	 *     // <p class="summary">&lt;p> makes a paragraph.</p>
 	 *
-	 *     echo WP_HTML::tag( 'input', array( 'enabled' => true, 'inert' => false, 'type' => 'text', 'value' => '<3 HTML' ) );
+	 *     WP_HTML::tag( 'input', array( 'enabled' => true, 'inert' => false, 'type' => 'text', 'value' => '<3 HTML' ) );
 	 *     // <input enabled type="text" value="&lt;3 HTML">
 	 *
 	 * @since 6.3.0
@@ -29,10 +29,10 @@ class WP_HTML {
 	 * Serializes an HTML tag, inserting verbatim inner HTML if provided.
 	 *
 	 * Example:
-	 *     echo WP_HTML::tag_with_inner_html( 'p', array( 'class' => 'summary' ), 'this <em>is</em> important' );
+	 *     WP_HTML::tag_with_inner_html( 'p', array( 'class' => 'summary' ), 'this <em>is</em> important' );
 	 *     // <p class="summary">this <em>is</em> important</p>
 	 *
-	 *     echo WP_HTML::tag_with_inner_html( 'div', null, WP_HTML::tag( 'p', null, 'Fire & Ice' ) . ' & Bubblegum');
+	 *     WP_HTML::tag_with_inner_html( 'div', null, WP_HTML::tag( 'p', null, 'Fire & Ice' ) . ' & Bubblegum');
 	 *     // <div><p>Fire &amp; Ice</p> & Bubblegum</div>
 	 *                     └─┬─┘    └────┴── Not Escaped because it was passed into `WP_HTML::tag_with_inner_html`.
 	 *                       └────────────── Escaped because it was created with `WP_HTML::tag`.

--- a/src/wp-includes/html-api/class-wp-html.php
+++ b/src/wp-includes/html-api/class-wp-html.php
@@ -1,13 +1,63 @@
 <?php
 
+/**
+ * @since 6.3.0
+ */
 class WP_HTML {
+	/**
+	 * Serializes an HTML tag, escaping inner text if provided.
+	 *
+	 * Example:
+	 *     echo WP_HTML::tag( 'p', array( 'class' => 'summary' ), '<p> makes a paragraph.' );
+	 *     // <p class="summary">&lt;p> makes a paragraph.</p>
+	 *
+	 *     echo WP_HTML::tag( 'input', array( 'enabled' => true, 'inert' => false, 'type' => 'text', 'value' => '<3 HTML' ) );
+	 *     // <input enabled type="text" value="&lt;3 HTML">
+	 *
+	 * @since 6.3.0
+	 *
+	 * @param string $tag_name   Name of HTML tag to create, e.g. "div".
+	 * @param array  $attributes Name-value pairs of HTML attributes to create; `false` values are excluded from generated HTML.
+	 * @param string $inner_text Raw inner text which browsers should render to display verbatim, not as HTML.
+	 * @return string Generated HTML corresponding to tag described by inputs.
+	 */
 	public static function tag( $tag_name, $attributes = null, $inner_text = '' ) {
 		return WP_HTML::tag_with_inner_html( $tag_name, $attributes, esc_html( $inner_text ) );
 	}
 
+	/**
+	 * Serializes an HTML tag, inserting verbatim inner HTML if provided.
+	 *
+	 * Example:
+	 *     echo WP_HTML::tag_with_inner_html( 'p', array( 'class' => 'summary' ), 'this <em>is</em> important' );
+	 *     // <p class="summary">this <em>is</em> important</p>
+	 *
+	 *     echo WP_HTML::tag_with_inner_html( 'div', null, WP_HTML::tag( 'p', null, 'Fire & Ice' ) . ' & Bubblegum');
+	 *     // <div><p>Fire &amp; Ice</p> & Bubblegum</div>
+	 *                     └─┬─┘    └────┴── Not Escaped because it was passed into `WP_HTML::tag_with_inner_html`.
+	 *                       └────────────── Escaped because it was created with `WP_HTML::tag`.
+	 *
+	 * @since 6.3.0
+	 *
+	 * @param string $tag_name   Name of HTML tag to create, e.g. "div".
+	 * @param array  $attributes Name-value pairs of HTML attributes to create; `false` values are excluded from generated HTML.
+	 * @param string $inner_html Already-escaped inner HTML which contains HTML syntax that browsers should interpret at HTML.
+	 * @return string Generated HTML corresponding to tag described by inputs.
+	 */
 	public static function tag_with_inner_html( $tag_name, $attributes = null, $inner_html = '' ) {
 		$is_void = WP_HTML_Spec::is_void_element( $tag_name );
 		$html = $is_void ? "<{$tag_name}>" : "<{$tag_name}>{$inner_html}</{$tag_name}>";
+		if ( $is_void && ! empty( $inner_html ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				sprintf(
+					// translator: 1: The name of a given HTML tag.
+					__( 'HTML void element %1$s cannot contain child nodes.' ),
+					"<{$tag_name}>"
+				),
+				'6.3.0'
+			);
+		}
 
 		$p = new WP_HTML_Tag_Processor( $html );
 

--- a/src/wp-includes/html-api/class-wp-html.php
+++ b/src/wp-includes/html-api/class-wp-html.php
@@ -32,7 +32,7 @@ class WP_HTML {
 	 *     WP_HTML::tag_with_inner_html( 'p', array( 'class' => 'summary' ), 'this <em>is</em> important' );
 	 *     // <p class="summary">this <em>is</em> important</p>
 	 *
-	 *     WP_HTML::tag_with_inner_html( 'div', null, WP_HTML::tag( 'p', null, 'Fire & Ice' ) . ' & Bubblegum');
+	 *     WP_HTML::tag_with_inner_html( 'div', null, WP_HTML::tag( 'p', null, 'Fire & Ice' ) . ' & Bubblegum' );
 	 *     // <div><p>Fire &amp; Ice</p> & Bubblegum</div>
 	 *                     └─┬─┘    └────┴── Not Escaped because it was passed into `WP_HTML::tag_with_inner_html`.
 	 *                       └────────────── Escaped because it was created with `WP_HTML::tag`.

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -238,6 +238,8 @@ require ABSPATH . WPINC . '/html-api/class-wp-html-attribute-token.php';
 require ABSPATH . WPINC . '/html-api/class-wp-html-span.php';
 require ABSPATH . WPINC . '/html-api/class-wp-html-text-replacement.php';
 require ABSPATH . WPINC . '/html-api/class-wp-html-tag-processor.php';
+require ABSPATH . WPINC . '/html-api/class-wp-html-spec.php';
+require ABSPATH . WPINC . '/html-api/class-wp-html.php';
 require ABSPATH . WPINC . '/class-wp-http.php';
 require ABSPATH . WPINC . '/class-wp-http-streams.php';
 require ABSPATH . WPINC . '/class-wp-http-curl.php';

--- a/tests/phpunit/tests/html-api/wpHtml.php
+++ b/tests/phpunit/tests/html-api/wpHtml.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Unit tests covering WP_HTML functionality.
+ *
+ * @package WordPress
+ * @subpackage HTML-API
+ */
+
+/**
+ * @group html-api
+ *
+ * @coversDefaultClass WP_HTML
+ */
+class Tests_HtmlApi_wpHtml extends WP_UnitTestCase {
+	public function test_make_tag() {
+		$script = WP_HTML::make_tag(
+			'script',
+			array( 'defer' => true, 'nonce' => 'HXhIuUk5lfXb' ),
+			'console.log("loaded");'
+		);
+
+		$this->assertSame( '<script defer nonce="HXhIuUk5lfXb">console.log("loaded");</script>', $script );
+	}
+}

--- a/tests/phpunit/tests/html-api/wpHtml.php
+++ b/tests/phpunit/tests/html-api/wpHtml.php
@@ -15,7 +15,10 @@ class Tests_HtmlApi_wpHtml extends WP_UnitTestCase {
 	public function test_tag() {
 		$script = WP_HTML::tag(
 			'script',
-			array( 'defer' => true, 'nonce' => 'HXhIuUk5lfXb' ),
+			array(
+				'defer' => true,
+				'nonce' => 'HXhIuUk5lfXb'
+			),
 			'console.log("loaded");'
 		);
 

--- a/tests/phpunit/tests/html-api/wpHtml.php
+++ b/tests/phpunit/tests/html-api/wpHtml.php
@@ -17,7 +17,7 @@ class Tests_HtmlApi_wpHtml extends WP_UnitTestCase {
 			'script',
 			array(
 				'defer' => true,
-				'nonce' => 'HXhIuUk5lfXb'
+				'nonce' => 'HXhIuUk5lfXb',
 			),
 			'console.log("loaded");'
 		);

--- a/tests/phpunit/tests/html-api/wpHtml.php
+++ b/tests/phpunit/tests/html-api/wpHtml.php
@@ -12,13 +12,23 @@
  * @coversDefaultClass WP_HTML
  */
 class Tests_HtmlApi_wpHtml extends WP_UnitTestCase {
-	public function test_make_tag() {
-		$script = WP_HTML::make_tag(
+	public function test_tag() {
+		$script = WP_HTML::tag(
 			'script',
 			array( 'defer' => true, 'nonce' => 'HXhIuUk5lfXb' ),
 			'console.log("loaded");'
 		);
 
 		$this->assertSame( '<script defer nonce="HXhIuUk5lfXb">console.log("loaded");</script>', $script );
+	}
+
+	public function test_tag_with_escapable_text() {
+		$div = WP_HTML::tag( 'div', null, '4 < <em>9</em>. <3' );
+		$this->assertSame( '<div>4 &lt; &lt;em>9&lt;/em>. &lt;3</div>', $div );
+	}
+
+	public function test_tag_with_inner_html_does_not_escape() {
+		$div = WP_HTML::tag_with_inner_html( 'div', null, '4 < <em>9</em>. <3' );
+		$this->assertSame( '<div>4 < <em>9</em>. <3</div>', $div );
 	}
 }


### PR DESCRIPTION
## Status

I don't like this anymore and have replaced any desire to introduce it with some form of an HTML template built from the Tag Processor. I've included a quick demo [in a comment below](https://github.com/WordPress/wordpress-develop/pull/4065#issuecomment-1502395980)

```php
WP_HTML::template(
	'<a href="</%url>"></%title></a>',
	array( 'url' => $url, 'title' => 'Wonders beyond your dreams' )
);
```

---

Been wanting to look at adding a helper like this for the common need of creating new markup.

E.g.

**Before**
```php
if ( current_user_can( 'create_users' ) ) :
	?>
	<a href="<?php echo esc_url( network_admin_url( 'user-new.php' ) ); ?>" class="page-title-action"><?php echo esc_html_x( 'Add New', 'user' ); ?></a>
	<?php
endif;
```

**After**
```php
if ( current_user_can( 'create_users' ) ) {
	echo WP_HTML::make_tag(
		'a',
		array(
			'href'  => network_admin_url( 'user-new.php' ),
			'class' => 'page-title-action'
		),
		esc_html_x( 'Add New', 'user' )
	);
}
```

This is a good place to examine the needs in the `data` markup. If this takes _HTML strings_ as the inner markup, then we should leave escaping to the caller, because we don't want to escape `<strong>` into `&lt;strong>`, but if we leave it up to the caller then people will forget to escape it.

**Before**
```php
<form method="post" action="<?php echo $referer ? esc_url( $referer ) : ''; ?>" style="display:inline;">
	<?php submit_button( __( 'No, return me to the theme list' ), '', 'submit', false ); ?>
</form>
```

**After**
```php
echo WP_HTML::make_tag(
	'form',
	array(
		'method' => 'post',
		'action' => $referer ?: false,
		'style'  => 'display: inline;'
	),
	submit_button( __( 'No, return me to the theme list' ), '', 'submit', false )
);
```

**Before**
```php
<<?php echo $safe_type; ?> controls="controls" preload="none" width="<?php echo (int) $theme_width; ?>"
	<?php
	if ( 'video' === $safe_type ) {
		echo ' height="', (int) $theme_height, '"';
	}
	?>
></<?php echo $safe_type; ?>>
```

**After**
```php
echo WP_HTML::make_tag(
	$safe_type,
	array(
		'controls' => true,
		'preload'  => 'none',
		'width'    => (int) $theme_width,
		'height'   => 'video' === $safe_type ? (int) $theme_height : false
	)
);
```

cc: @adamziel @ockham @gziolo @azaozz 