### PR TITLE
Adding fix for REST_Block_Type_Controller_Test::test_get_item_invalid()

### DIFF
--- a/tests/phpunit/tests/rest-api/rest-block-type-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-block-type-controller.php
@@ -223,7 +223,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			'parent'           => 'invalid_parent',
 			'ancestor'         => 'invalid_ancestor',
 			'supports'         => 'invalid_supports',
-			'styles'           => 'invalid_styles',
+			'styles'           => array(),
 			'render_callback'  => 'invalid_callback',
 			'textdomain'       => true,
 			'variations'       => 'invalid_variations',


### PR DESCRIPTION
Added fix for `REST_Block_Type_Controller_Test::test_get_item_invalid()` which was throwing a PHP warning due to an incorrect data type in the 'styles' property of the `WP_Block_Type`.

This PR Fixes a PHP Warning in the test caused by the 'styles' property not being an array. The proposed fix sets the 'styles' property to an empty array().

Could you please review the changes and let me know if anything needs to be updated or changed? I would really appreciate your feedback.
Thank you for taking the time to review this.

Trac ticket: https://core.trac.wordpress.org/ticket/57706

