### PR TITLE
Trac 56706: Fix wp_list_pluck() coverage report

### DIFF
--- a/tests/phpunit/tests/functions/wpListPluck.php
+++ b/tests/phpunit/tests/functions/wpListPluck.php
@@ -11,7 +11,18 @@ class Tests_Functions_wpListPluck extends WP_UnitTestCase {
 	public $array_list  = array();
 
 	public function set_up() {
-		parent::set_up();
+		/*
+		 * This method deliberately does not call parent::set_up(). Why?
+		 *
+		 * The call stack for WP_UnitTestCase_Base::set_up() includes a call to
+		 * WP_List_Util::pluck(), which creates an inaccurate coverage report
+		 * for this method.
+		 *
+		 * To ensure that deprecation and incorrect usage notices continue to be
+		 * detectable, this method uses WP_UnitTestCase_Base::expectDeprecated().
+		 */
+		$this->expectDeprecated();
+
 		$this->array_list['foo'] = array(
 			'name'   => 'foo',
 			'id'     => 'f',


### PR DESCRIPTION
[56706.diff](https://core.trac.wordpress.org/attachment/ticket/56706/56706.diff) props costdev

This PR is intended to run 56706.diff against all of the CI jobs before commit.

Trac ticket: https://core.trac.wordpress.org/ticket/56706

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
