### PR TITLE
Fix wordpress posted plugin check overriding author UpdateURI

### DIFF
--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -463,7 +463,7 @@ function wp_update_plugins( $extra_stats = array() ) {
 
 	// Support updates for any plugins using the `Update URI` header field.
 	foreach ( $plugins as $plugin_file => $plugin_data ) {
-		if ( ! $plugin_data['UpdateURI'] || isset( $updates->response[ $plugin_file ] ) ) {
+		if ( ! $plugin_data['UpdateURI'] ) {
 			continue;
 		}
 


### PR DESCRIPTION
The isset( $updates->response[ $plugin_file ] ) check should not be present, as it defeats the purpose of UpdateURI and the original addition/commit ("This allows third-party plugins to avoid accidentally being overwritten with an update of a plugin of a similar name from the WordPress.org Plugin Directory.")

If there is already a response from the plugin check at http://api.wordpress.org/plugins/update-check/1.1/, the plugin with UpdateURI is skipped and therefore, the apply_filters( "update_plugins_{$hostname}"... is also skipped.

If a plugin author specifies an UpdateURI, this should always take precedence over a similar named plugin in the WordPress plugin repository

Trac ticket: https://core.trac.wordpress.org/ticket/57719#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
