### PR TITLE
Introduce new `queries` cache group

### DIFF
--- a/src/wp-includes/class-wp-comment-query.php
+++ b/src/wp-includes/class-wp-comment-query.php
@@ -463,7 +463,7 @@ class WP_Comment_Query {
 				'comment_ids'    => $comment_ids,
 				'found_comments' => $this->found_comments,
 			);
-			wp_cache_add( $cache_key, $cache_value, 'comment' );
+			wp_cache_add( $cache_key, $cache_value, 'queries' );
 		} else {
 			$comment_ids          = $cache_value['comment_ids'];
 			$this->found_comments = $cache_value['found_comments'];

--- a/src/wp-includes/class-wp-comment-query.php
+++ b/src/wp-includes/class-wp-comment-query.php
@@ -452,7 +452,7 @@ class WP_Comment_Query {
 		$last_changed = wp_cache_get_last_changed( 'comment' );
 
 		$cache_key   = "get_comments:$key:$last_changed";
-		$cache_value = wp_cache_get( $cache_key, 'queries' );
+		$cache_value = wp_cache_get( $cache_key, 'comment-queries' );
 		if ( false === $cache_value ) {
 			$comment_ids = $this->get_comment_ids();
 			if ( $comment_ids ) {
@@ -463,7 +463,7 @@ class WP_Comment_Query {
 				'comment_ids'    => $comment_ids,
 				'found_comments' => $this->found_comments,
 			);
-			wp_cache_add( $cache_key, $cache_value, 'queries' );
+			wp_cache_add( $cache_key, $cache_value, 'comment-queries' );
 		} else {
 			$comment_ids          = $cache_value['comment_ids'];
 			$this->found_comments = $cache_value['found_comments'];
@@ -1038,7 +1038,7 @@ class WP_Comment_Query {
 			$_parent_ids         = $levels[ $level ];
 			foreach ( $_parent_ids as $parent_id ) {
 				$cache_key        = "get_comment_child_ids:$parent_id:$key:$last_changed";
-				$parent_child_ids = wp_cache_get( $cache_key, 'queries' );
+				$parent_child_ids = wp_cache_get( $cache_key, 'comment-queries' );
 				if ( false !== $parent_child_ids ) {
 					$child_ids = array_merge( $child_ids, $parent_child_ids );
 				} else {
@@ -1072,7 +1072,7 @@ class WP_Comment_Query {
 					$cache_key          = "get_comment_child_ids:$parent_id:$key:$last_changed";
 					$data[ $cache_key ] = $children;
 				}
-				wp_cache_set_multiple( $data, 'queries' );
+				wp_cache_set_multiple( $data, 'comment-queries' );
 			}
 
 			$level++;

--- a/src/wp-includes/class-wp-comment-query.php
+++ b/src/wp-includes/class-wp-comment-query.php
@@ -452,7 +452,7 @@ class WP_Comment_Query {
 		$last_changed = wp_cache_get_last_changed( 'comment' );
 
 		$cache_key   = "get_comments:$key:$last_changed";
-		$cache_value = wp_cache_get( $cache_key, 'comment' );
+		$cache_value = wp_cache_get( $cache_key, 'queries' );
 		if ( false === $cache_value ) {
 			$comment_ids = $this->get_comment_ids();
 			if ( $comment_ids ) {
@@ -1038,7 +1038,7 @@ class WP_Comment_Query {
 			$_parent_ids         = $levels[ $level ];
 			foreach ( $_parent_ids as $parent_id ) {
 				$cache_key        = "get_comment_child_ids:$parent_id:$key:$last_changed";
-				$parent_child_ids = wp_cache_get( $cache_key, 'comment' );
+				$parent_child_ids = wp_cache_get( $cache_key, 'queries' );
 				if ( false !== $parent_child_ids ) {
 					$child_ids = array_merge( $child_ids, $parent_child_ids );
 				} else {
@@ -1072,7 +1072,7 @@ class WP_Comment_Query {
 					$cache_key          = "get_comment_child_ids:$parent_id:$key:$last_changed";
 					$data[ $cache_key ] = $children;
 				}
-				wp_cache_set_multiple( $data, 'comment' );
+				wp_cache_set_multiple( $data, 'queries' );
 			}
 
 			$level++;

--- a/src/wp-includes/class-wp-network-query.php
+++ b/src/wp-includes/class-wp-network-query.php
@@ -250,7 +250,7 @@ class WP_Network_Query {
 		$last_changed = wp_cache_get_last_changed( 'networks' );
 
 		$cache_key   = "get_network_ids:$key:$last_changed";
-		$cache_value = wp_cache_get( $cache_key, 'queries' );
+		$cache_value = wp_cache_get( $cache_key, 'network-queries' );
 
 		if ( false === $cache_value ) {
 			$network_ids = $this->get_network_ids();
@@ -262,7 +262,7 @@ class WP_Network_Query {
 				'network_ids'    => $network_ids,
 				'found_networks' => $this->found_networks,
 			);
-			wp_cache_add( $cache_key, $cache_value, 'queries' );
+			wp_cache_add( $cache_key, $cache_value, 'network-queries' );
 		} else {
 			$network_ids          = $cache_value['network_ids'];
 			$this->found_networks = $cache_value['found_networks'];

--- a/src/wp-includes/class-wp-network-query.php
+++ b/src/wp-includes/class-wp-network-query.php
@@ -250,7 +250,7 @@ class WP_Network_Query {
 		$last_changed = wp_cache_get_last_changed( 'networks' );
 
 		$cache_key   = "get_network_ids:$key:$last_changed";
-		$cache_value = wp_cache_get( $cache_key, 'networks' );
+		$cache_value = wp_cache_get( $cache_key, 'queries' );
 
 		if ( false === $cache_value ) {
 			$network_ids = $this->get_network_ids();
@@ -262,7 +262,7 @@ class WP_Network_Query {
 				'network_ids'    => $network_ids,
 				'found_networks' => $this->found_networks,
 			);
-			wp_cache_add( $cache_key, $cache_value, 'networks' );
+			wp_cache_add( $cache_key, $cache_value, 'queries' );
 		} else {
 			$network_ids          = $cache_value['network_ids'];
 			$this->found_networks = $cache_value['found_networks'];

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -2808,10 +2808,10 @@ class WP_Query {
 			$last_changed = wp_cache_get_last_changed( 'comment' ) . ':' . wp_cache_get_last_changed( 'posts' );
 
 			$cache_key   = "comment_feed:$key:$last_changed";
-			$comment_ids = wp_cache_get( $cache_key, 'queries' );
+			$comment_ids = wp_cache_get( $cache_key, 'comment-queries' );
 			if ( false === $comment_ids ) {
 				$comment_ids = $wpdb->get_col( $comments_request );
-				wp_cache_add( $cache_key, $comment_ids, 'queries' );
+				wp_cache_add( $cache_key, $comment_ids, 'comment-queries' );
 			}
 			_prime_comment_caches( $comment_ids, false );
 
@@ -3165,7 +3165,7 @@ class WP_Query {
 
 			$cache_found = false;
 			if ( null === $this->posts ) {
-				$cached_results = wp_cache_get( $cache_key, 'queries', false, $cache_found );
+				$cached_results = wp_cache_get( $cache_key, 'post-queries', false, $cache_found );
 
 				if ( $cached_results ) {
 					if ( 'ids' === $q['fields'] ) {
@@ -3220,7 +3220,7 @@ class WP_Query {
 					'max_num_pages' => $this->max_num_pages,
 				);
 
-				wp_cache_set( $cache_key, $cache_value, 'queries' );
+				wp_cache_set( $cache_key, $cache_value, 'post-queries' );
 			}
 
 			return $this->posts;
@@ -3253,7 +3253,7 @@ class WP_Query {
 					'max_num_pages' => $this->max_num_pages,
 				);
 
-				wp_cache_set( $cache_key, $cache_value, 'queries' );
+				wp_cache_set( $cache_key, $cache_value, 'post-queries' );
 			}
 
 			return $post_parents;
@@ -3328,7 +3328,7 @@ class WP_Query {
 				'max_num_pages' => $this->max_num_pages,
 			);
 
-			wp_cache_set( $cache_key, $cache_value, 'queries' );
+			wp_cache_set( $cache_key, $cache_value, 'post-queries' );
 		}
 
 		if ( ! $q['suppress_filters'] ) {
@@ -3367,10 +3367,10 @@ class WP_Query {
 			$comment_last_changed = wp_cache_get_last_changed( 'comment' );
 
 			$comment_cache_key = "comment_feed:$comment_key:$comment_last_changed";
-			$comment_ids       = wp_cache_get( $comment_cache_key, 'queries' );
+			$comment_ids       = wp_cache_get( $comment_cache_key, 'comment-queries' );
 			if ( false === $comment_ids ) {
 				$comment_ids = $wpdb->get_col( $comments_request );
-				wp_cache_add( $comment_cache_key, $comment_ids, 'queries' );
+				wp_cache_add( $comment_cache_key, $comment_ids, 'comment-queries' );
 			}
 			_prime_comment_caches( $comment_ids, false );
 

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -2808,10 +2808,10 @@ class WP_Query {
 			$last_changed = wp_cache_get_last_changed( 'comment' ) . ':' . wp_cache_get_last_changed( 'posts' );
 
 			$cache_key   = "comment_feed:$key:$last_changed";
-			$comment_ids = wp_cache_get( $cache_key, 'comment' );
+			$comment_ids = wp_cache_get( $cache_key, 'queries' );
 			if ( false === $comment_ids ) {
 				$comment_ids = $wpdb->get_col( $comments_request );
-				wp_cache_add( $cache_key, $comment_ids, 'comment' );
+				wp_cache_add( $cache_key, $comment_ids, 'queries' );
 			}
 			_prime_comment_caches( $comment_ids, false );
 
@@ -3165,7 +3165,7 @@ class WP_Query {
 
 			$cache_found = false;
 			if ( null === $this->posts ) {
-				$cached_results = wp_cache_get( $cache_key, 'posts', false, $cache_found );
+				$cached_results = wp_cache_get( $cache_key, 'queries', false, $cache_found );
 
 				if ( $cached_results ) {
 					if ( 'ids' === $q['fields'] ) {
@@ -3220,7 +3220,7 @@ class WP_Query {
 					'max_num_pages' => $this->max_num_pages,
 				);
 
-				wp_cache_set( $cache_key, $cache_value, 'posts' );
+				wp_cache_set( $cache_key, $cache_value, 'queries' );
 			}
 
 			return $this->posts;
@@ -3253,7 +3253,7 @@ class WP_Query {
 					'max_num_pages' => $this->max_num_pages,
 				);
 
-				wp_cache_set( $cache_key, $cache_value, 'posts' );
+				wp_cache_set( $cache_key, $cache_value, 'queries' );
 			}
 
 			return $post_parents;
@@ -3328,7 +3328,7 @@ class WP_Query {
 				'max_num_pages' => $this->max_num_pages,
 			);
 
-			wp_cache_set( $cache_key, $cache_value, 'posts' );
+			wp_cache_set( $cache_key, $cache_value, 'queries' );
 		}
 
 		if ( ! $q['suppress_filters'] ) {
@@ -3367,10 +3367,10 @@ class WP_Query {
 			$comment_last_changed = wp_cache_get_last_changed( 'comment' );
 
 			$comment_cache_key = "comment_feed:$comment_key:$comment_last_changed";
-			$comment_ids       = wp_cache_get( $comment_cache_key, 'comment' );
+			$comment_ids       = wp_cache_get( $comment_cache_key, 'queries' );
 			if ( false === $comment_ids ) {
 				$comment_ids = $wpdb->get_col( $comments_request );
-				wp_cache_add( $comment_cache_key, $comment_ids, 'comment' );
+				wp_cache_add( $comment_cache_key, $comment_ids, 'queries' );
 			}
 			_prime_comment_caches( $comment_ids, false );
 

--- a/src/wp-includes/class-wp-site-query.php
+++ b/src/wp-includes/class-wp-site-query.php
@@ -358,7 +358,7 @@ class WP_Site_Query {
 		$last_changed = wp_cache_get_last_changed( 'sites' );
 
 		$cache_key   = "get_sites:$key:$last_changed";
-		$cache_value = wp_cache_get( $cache_key, 'sites' );
+		$cache_value = wp_cache_get( $cache_key, 'queries' );
 
 		if ( false === $cache_value ) {
 			$site_ids = $this->get_site_ids();
@@ -370,7 +370,7 @@ class WP_Site_Query {
 				'site_ids'    => $site_ids,
 				'found_sites' => $this->found_sites,
 			);
-			wp_cache_add( $cache_key, $cache_value, 'sites' );
+			wp_cache_add( $cache_key, $cache_value, 'queries' );
 		} else {
 			$site_ids          = $cache_value['site_ids'];
 			$this->found_sites = $cache_value['found_sites'];

--- a/src/wp-includes/class-wp-site-query.php
+++ b/src/wp-includes/class-wp-site-query.php
@@ -358,7 +358,7 @@ class WP_Site_Query {
 		$last_changed = wp_cache_get_last_changed( 'sites' );
 
 		$cache_key   = "get_sites:$key:$last_changed";
-		$cache_value = wp_cache_get( $cache_key, 'queries' );
+		$cache_value = wp_cache_get( $cache_key, 'site-queries' );
 
 		if ( false === $cache_value ) {
 			$site_ids = $this->get_site_ids();
@@ -370,7 +370,7 @@ class WP_Site_Query {
 				'site_ids'    => $site_ids,
 				'found_sites' => $this->found_sites,
 			);
-			wp_cache_add( $cache_key, $cache_value, 'queries' );
+			wp_cache_add( $cache_key, $cache_value, 'site-queries' );
 		} else {
 			$site_ids          = $cache_value['site_ids'];
 			$this->found_sites = $cache_value['found_sites'];

--- a/src/wp-includes/class-wp-term-query.php
+++ b/src/wp-includes/class-wp-term-query.php
@@ -775,7 +775,7 @@ class WP_Term_Query {
 		}
 
 		$cache_key = $this->generate_cache_key( $args, $this->request );
-		$cache     = wp_cache_get( $cache_key, 'terms' );
+		$cache     = wp_cache_get( $cache_key, 'queries' );
 
 		if ( false !== $cache ) {
 			if ( 'ids' === $_fields ) {
@@ -801,14 +801,14 @@ class WP_Term_Query {
 
 		if ( 'count' === $_fields ) {
 			$count = $wpdb->get_var( $this->request ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-			wp_cache_set( $cache_key, $count, 'terms' );
+			wp_cache_set( $cache_key, $count, 'queries' );
 			return $count;
 		}
 
 		$terms = $wpdb->get_results( $this->request ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 
 		if ( empty( $terms ) ) {
-			wp_cache_add( $cache_key, array(), 'terms' );
+			wp_cache_add( $cache_key, array(), 'queries' );
 			return array();
 		}
 
@@ -888,7 +888,7 @@ class WP_Term_Query {
 			$term_cache = wp_list_pluck( $term_objects, 'term_id' );
 		}
 
-		wp_cache_add( $cache_key, $term_cache, 'terms' );
+		wp_cache_add( $cache_key, $term_cache, 'queries' );
 		$this->terms = $this->format_terms( $term_objects, $_fields );
 
 		return $this->terms;

--- a/src/wp-includes/class-wp-term-query.php
+++ b/src/wp-includes/class-wp-term-query.php
@@ -775,7 +775,7 @@ class WP_Term_Query {
 		}
 
 		$cache_key = $this->generate_cache_key( $args, $this->request );
-		$cache     = wp_cache_get( $cache_key, 'queries' );
+		$cache     = wp_cache_get( $cache_key, 'term-queries' );
 
 		if ( false !== $cache ) {
 			if ( 'ids' === $_fields ) {
@@ -801,14 +801,14 @@ class WP_Term_Query {
 
 		if ( 'count' === $_fields ) {
 			$count = $wpdb->get_var( $this->request ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-			wp_cache_set( $cache_key, $count, 'queries' );
+			wp_cache_set( $cache_key, $count, 'term-queries' );
 			return $count;
 		}
 
 		$terms = $wpdb->get_results( $this->request ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 
 		if ( empty( $terms ) ) {
-			wp_cache_add( $cache_key, array(), 'queries' );
+			wp_cache_add( $cache_key, array(), 'term-queries' );
 			return array();
 		}
 
@@ -888,7 +888,7 @@ class WP_Term_Query {
 			$term_cache = wp_list_pluck( $term_objects, 'term_id' );
 		}
 
-		wp_cache_add( $cache_key, $term_cache, 'queries' );
+		wp_cache_add( $cache_key, $term_cache, 'term-queries' );
 		$this->terms = $this->format_terms( $term_objects, $_fields );
 
 		return $this->terms;

--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -3285,7 +3285,7 @@ function clean_comment_cache( $ids ) {
 		do_action( 'clean_comment_cache', $id );
 	}
 
-	wp_cache_set( 'last_changed', microtime(), 'comment' );
+	wp_cache_set_comments_last_changed();
 }
 
 /**

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -2054,10 +2054,10 @@ function wp_get_archives( $args = '' ) {
 		$query   = "SELECT YEAR(post_date) AS `year`, MONTH(post_date) AS `month`, count(ID) as posts FROM $wpdb->posts $join $where GROUP BY YEAR(post_date), MONTH(post_date) ORDER BY post_date $order $limit";
 		$key     = md5( $query );
 		$key     = "wp_get_archives:$key:$last_changed";
-		$results = wp_cache_get( $key, 'queries' );
+		$results = wp_cache_get( $key, 'post-queries' );
 		if ( ! $results ) {
 			$results = $wpdb->get_results( $query );
-			wp_cache_set( $key, $results, 'queries' );
+			wp_cache_set( $key, $results, 'post-queries' );
 		}
 		if ( $results ) {
 			$after = $parsed_args['after'];
@@ -2079,10 +2079,10 @@ function wp_get_archives( $args = '' ) {
 		$query   = "SELECT YEAR(post_date) AS `year`, count(ID) as posts FROM $wpdb->posts $join $where GROUP BY YEAR(post_date) ORDER BY post_date $order $limit";
 		$key     = md5( $query );
 		$key     = "wp_get_archives:$key:$last_changed";
-		$results = wp_cache_get( $key, 'queries' );
+		$results = wp_cache_get( $key, 'post-queries' );
 		if ( ! $results ) {
 			$results = $wpdb->get_results( $query );
-			wp_cache_set( $key, $results, 'queries' );
+			wp_cache_set( $key, $results, 'post-queries' );
 		}
 		if ( $results ) {
 			$after = $parsed_args['after'];
@@ -2103,10 +2103,10 @@ function wp_get_archives( $args = '' ) {
 		$query   = "SELECT YEAR(post_date) AS `year`, MONTH(post_date) AS `month`, DAYOFMONTH(post_date) AS `dayofmonth`, count(ID) as posts FROM $wpdb->posts $join $where GROUP BY YEAR(post_date), MONTH(post_date), DAYOFMONTH(post_date) ORDER BY post_date $order $limit";
 		$key     = md5( $query );
 		$key     = "wp_get_archives:$key:$last_changed";
-		$results = wp_cache_get( $key, 'queries' );
+		$results = wp_cache_get( $key, 'post-queries' );
 		if ( ! $results ) {
 			$results = $wpdb->get_results( $query );
-			wp_cache_set( $key, $results, 'queries' );
+			wp_cache_set( $key, $results, 'post-queries' );
 		}
 		if ( $results ) {
 			$after = $parsed_args['after'];
@@ -2129,10 +2129,10 @@ function wp_get_archives( $args = '' ) {
 		$query   = "SELECT DISTINCT $week AS `week`, YEAR( `post_date` ) AS `yr`, DATE_FORMAT( `post_date`, '%Y-%m-%d' ) AS `yyyymmdd`, count( `ID` ) AS `posts` FROM `$wpdb->posts` $join $where GROUP BY $week, YEAR( `post_date` ) ORDER BY `post_date` $order $limit";
 		$key     = md5( $query );
 		$key     = "wp_get_archives:$key:$last_changed";
-		$results = wp_cache_get( $key, 'queries' );
+		$results = wp_cache_get( $key, 'post-queries' );
 		if ( ! $results ) {
 			$results = $wpdb->get_results( $query );
-			wp_cache_set( $key, $results, 'queries' );
+			wp_cache_set( $key, $results, 'post-queries' );
 		}
 		$arc_w_last = '';
 		if ( $results ) {
@@ -2168,10 +2168,10 @@ function wp_get_archives( $args = '' ) {
 		$query   = "SELECT * FROM $wpdb->posts $join $where ORDER BY $orderby $limit";
 		$key     = md5( $query );
 		$key     = "wp_get_archives:$key:$last_changed";
-		$results = wp_cache_get( $key, 'queries' );
+		$results = wp_cache_get( $key, 'post-queries' );
 		if ( ! $results ) {
 			$results = $wpdb->get_results( $query );
-			wp_cache_set( $key, $results, 'queries' );
+			wp_cache_set( $key, $results, 'post-queries' );
 		}
 		if ( $results ) {
 			foreach ( (array) $results as $result ) {

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -2054,10 +2054,10 @@ function wp_get_archives( $args = '' ) {
 		$query   = "SELECT YEAR(post_date) AS `year`, MONTH(post_date) AS `month`, count(ID) as posts FROM $wpdb->posts $join $where GROUP BY YEAR(post_date), MONTH(post_date) ORDER BY post_date $order $limit";
 		$key     = md5( $query );
 		$key     = "wp_get_archives:$key:$last_changed";
-		$results = wp_cache_get( $key, 'posts' );
+		$results = wp_cache_get( $key, 'queries' );
 		if ( ! $results ) {
 			$results = $wpdb->get_results( $query );
-			wp_cache_set( $key, $results, 'posts' );
+			wp_cache_set( $key, $results, 'queries' );
 		}
 		if ( $results ) {
 			$after = $parsed_args['after'];
@@ -2079,10 +2079,10 @@ function wp_get_archives( $args = '' ) {
 		$query   = "SELECT YEAR(post_date) AS `year`, count(ID) as posts FROM $wpdb->posts $join $where GROUP BY YEAR(post_date) ORDER BY post_date $order $limit";
 		$key     = md5( $query );
 		$key     = "wp_get_archives:$key:$last_changed";
-		$results = wp_cache_get( $key, 'posts' );
+		$results = wp_cache_get( $key, 'queries' );
 		if ( ! $results ) {
 			$results = $wpdb->get_results( $query );
-			wp_cache_set( $key, $results, 'posts' );
+			wp_cache_set( $key, $results, 'queries' );
 		}
 		if ( $results ) {
 			$after = $parsed_args['after'];
@@ -2103,10 +2103,10 @@ function wp_get_archives( $args = '' ) {
 		$query   = "SELECT YEAR(post_date) AS `year`, MONTH(post_date) AS `month`, DAYOFMONTH(post_date) AS `dayofmonth`, count(ID) as posts FROM $wpdb->posts $join $where GROUP BY YEAR(post_date), MONTH(post_date), DAYOFMONTH(post_date) ORDER BY post_date $order $limit";
 		$key     = md5( $query );
 		$key     = "wp_get_archives:$key:$last_changed";
-		$results = wp_cache_get( $key, 'posts' );
+		$results = wp_cache_get( $key, 'queries' );
 		if ( ! $results ) {
 			$results = $wpdb->get_results( $query );
-			wp_cache_set( $key, $results, 'posts' );
+			wp_cache_set( $key, $results, 'queries' );
 		}
 		if ( $results ) {
 			$after = $parsed_args['after'];
@@ -2129,10 +2129,10 @@ function wp_get_archives( $args = '' ) {
 		$query   = "SELECT DISTINCT $week AS `week`, YEAR( `post_date` ) AS `yr`, DATE_FORMAT( `post_date`, '%Y-%m-%d' ) AS `yyyymmdd`, count( `ID` ) AS `posts` FROM `$wpdb->posts` $join $where GROUP BY $week, YEAR( `post_date` ) ORDER BY `post_date` $order $limit";
 		$key     = md5( $query );
 		$key     = "wp_get_archives:$key:$last_changed";
-		$results = wp_cache_get( $key, 'posts' );
+		$results = wp_cache_get( $key, 'queries' );
 		if ( ! $results ) {
 			$results = $wpdb->get_results( $query );
-			wp_cache_set( $key, $results, 'posts' );
+			wp_cache_set( $key, $results, 'queries' );
 		}
 		$arc_w_last = '';
 		if ( $results ) {
@@ -2168,10 +2168,10 @@ function wp_get_archives( $args = '' ) {
 		$query   = "SELECT * FROM $wpdb->posts $join $where ORDER BY $orderby $limit";
 		$key     = md5( $query );
 		$key     = "wp_get_archives:$key:$last_changed";
-		$results = wp_cache_get( $key, 'posts' );
+		$results = wp_cache_get( $key, 'queries' );
 		if ( ! $results ) {
 			$results = $wpdb->get_results( $query );
-			wp_cache_set( $key, $results, 'posts' );
+			wp_cache_set( $key, $results, 'queries' );
 		}
 		if ( $results ) {
 			foreach ( (array) $results as $result ) {

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1984,7 +1984,7 @@ function get_adjacent_post( $in_same_term = false, $excluded_terms = '', $previo
 	}
 	$cache_key = "adjacent_post:$key:$last_changed";
 
-	$result = wp_cache_get( $cache_key, 'posts' );
+	$result = wp_cache_get( $cache_key, 'queries' );
 	if ( false !== $result ) {
 		if ( $result ) {
 			$result = get_post( $result );
@@ -1997,7 +1997,7 @@ function get_adjacent_post( $in_same_term = false, $excluded_terms = '', $previo
 		$result = '';
 	}
 
-	wp_cache_set( $cache_key, $result, 'posts' );
+	wp_cache_set( $cache_key, $result, 'queries' );
 
 	if ( $result ) {
 		$result = get_post( $result );

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1984,7 +1984,7 @@ function get_adjacent_post( $in_same_term = false, $excluded_terms = '', $previo
 	}
 	$cache_key = "adjacent_post:$key:$last_changed";
 
-	$result = wp_cache_get( $cache_key, 'queries' );
+	$result = wp_cache_get( $cache_key, 'post-queries' );
 	if ( false !== $result ) {
 		if ( $result ) {
 			$result = get_post( $result );
@@ -1997,7 +1997,7 @@ function get_adjacent_post( $in_same_term = false, $excluded_terms = '', $previo
 		$result = '';
 	}
 
-	wp_cache_set( $cache_key, $result, 'queries' );
+	wp_cache_set( $cache_key, $result, 'post-queries' );
 
 	if ( $result ) {
 		$result = get_post( $result );

--- a/src/wp-includes/ms-functions.php
+++ b/src/wp-includes/ms-functions.php
@@ -1398,7 +1398,7 @@ function wpmu_create_blog( $domain, $path, $title, $user_id, $options = array(),
 		return $blog_id;
 	}
 
-	wp_cache_set( 'last_changed', microtime(), 'sites' );
+	wp_cache_set_sites_last_changed();
 
 	return $blog_id;
 }

--- a/src/wp-includes/ms-site.php
+++ b/src/wp-includes/ms-site.php
@@ -988,7 +988,7 @@ function clean_blog_cache( $blog ) {
 	 */
 	do_action( 'clean_site_cache', $blog_id, $blog, $domain_path_key );
 
-	wp_cache_set( 'last_changed', microtime(), 'sites' );
+	wp_cache_set_sites_last_changed();
 
 	/**
 	 * Fires after the blog details cache is cleared.

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -5694,7 +5694,7 @@ function get_page_by_path( $page_path, $output = OBJECT, $post_type = 'page' ) {
 
 	$hash      = md5( $page_path . serialize( $post_type ) );
 	$cache_key = "get_page_by_path:$hash:$last_changed";
-	$cached    = wp_cache_get( $cache_key, 'posts' );
+	$cached    = wp_cache_get( $cache_key, 'queries' );
 	if ( false !== $cached ) {
 		// Special case: '0' is a bad `$page_path`.
 		if ( '0' === $cached || 0 === $cached ) {
@@ -5761,7 +5761,7 @@ function get_page_by_path( $page_path, $output = OBJECT, $post_type = 'page' ) {
 	}
 
 	// We cache misses as well as hits.
-	wp_cache_set( $cache_key, $foundid, 'posts' );
+	wp_cache_set( $cache_key, $foundid, 'queries' );
 
 	if ( $foundid ) {
 		return get_post( $foundid, $output );
@@ -6002,7 +6002,7 @@ function get_pages( $args = array() ) {
 	$last_changed = wp_cache_get_last_changed( 'posts' );
 
 	$cache_key = "get_pages:$key:$last_changed";
-	$cache     = wp_cache_get( $cache_key, 'posts' );
+	$cache     = wp_cache_get( $cache_key, 'queries' );
 	if ( false !== $cache ) {
 		_prime_post_caches( $cache, false, false );
 
@@ -6167,7 +6167,7 @@ function get_pages( $args = array() ) {
 	$pages = $wpdb->get_results( $query );
 
 	if ( empty( $pages ) ) {
-		wp_cache_set( $cache_key, array(), 'posts' );
+		wp_cache_set( $cache_key, array(), 'queries' );
 
 		/** This filter is documented in wp-includes/post.php */
 		$pages = apply_filters( 'get_pages', array(), $parsed_args );
@@ -6210,7 +6210,7 @@ function get_pages( $args = array() ) {
 		$page_structure[] = $page->ID;
 	}
 
-	wp_cache_set( $cache_key, $page_structure, 'posts' );
+	wp_cache_set( $cache_key, $page_structure, 'queries' );
 
 	// Convert to WP_Post instances.
 	$pages = array_map( 'get_post', $pages );

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -5694,7 +5694,7 @@ function get_page_by_path( $page_path, $output = OBJECT, $post_type = 'page' ) {
 
 	$hash      = md5( $page_path . serialize( $post_type ) );
 	$cache_key = "get_page_by_path:$hash:$last_changed";
-	$cached    = wp_cache_get( $cache_key, 'queries' );
+	$cached    = wp_cache_get( $cache_key, 'post-queries' );
 	if ( false !== $cached ) {
 		// Special case: '0' is a bad `$page_path`.
 		if ( '0' === $cached || 0 === $cached ) {
@@ -5761,7 +5761,7 @@ function get_page_by_path( $page_path, $output = OBJECT, $post_type = 'page' ) {
 	}
 
 	// We cache misses as well as hits.
-	wp_cache_set( $cache_key, $foundid, 'queries' );
+	wp_cache_set( $cache_key, $foundid, 'post-queries' );
 
 	if ( $foundid ) {
 		return get_post( $foundid, $output );
@@ -6002,7 +6002,7 @@ function get_pages( $args = array() ) {
 	$last_changed = wp_cache_get_last_changed( 'posts' );
 
 	$cache_key = "get_pages:$key:$last_changed";
-	$cache     = wp_cache_get( $cache_key, 'queries' );
+	$cache     = wp_cache_get( $cache_key, 'post-queries' );
 	if ( false !== $cache ) {
 		_prime_post_caches( $cache, false, false );
 
@@ -6167,7 +6167,7 @@ function get_pages( $args = array() ) {
 	$pages = $wpdb->get_results( $query );
 
 	if ( empty( $pages ) ) {
-		wp_cache_set( $cache_key, array(), 'queries' );
+		wp_cache_set( $cache_key, array(), 'post-queries' );
 
 		/** This filter is documented in wp-includes/post.php */
 		$pages = apply_filters( 'get_pages', array(), $parsed_args );
@@ -6210,7 +6210,7 @@ function get_pages( $args = array() ) {
 		$page_structure[] = $page->ID;
 	}
 
-	wp_cache_set( $cache_key, $page_structure, 'queries' );
+	wp_cache_set( $cache_key, $page_structure, 'post-queries' );
 
 	// Convert to WP_Post instances.
 	$pages = array_map( 'get_post', $pages );

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -7374,7 +7374,7 @@ function clean_post_cache( $post ) {
 		do_action( 'clean_page_cache', $post->ID );
 	}
 
-	wp_cache_set( 'last_changed', microtime(), 'posts' );
+	wp_cache_set_posts_last_changed();
 }
 
 /**

--- a/src/wp-includes/query.php
+++ b/src/wp-includes/query.php
@@ -1154,12 +1154,12 @@ function _find_post_by_old_slug( $post_type ) {
 	$key          = md5( $query );
 	$last_changed = wp_cache_get_last_changed( 'posts' );
 	$cache_key    = "find_post_by_old_slug:$key:$last_changed";
-	$cache        = wp_cache_get( $cache_key, 'queries' );
+	$cache        = wp_cache_get( $cache_key, 'post-queries' );
 	if ( false !== $cache ) {
 		$id = $cache;
 	} else {
 		$id = (int) $wpdb->get_var( $query );
-		wp_cache_set( $cache_key, $id, 'queries' );
+		wp_cache_set( $cache_key, $id, 'post-queries' );
 	}
 
 	return $id;
@@ -1197,7 +1197,7 @@ function _find_post_by_old_date( $post_type ) {
 		$key          = md5( $query );
 		$last_changed = wp_cache_get_last_changed( 'posts' );
 		$cache_key    = "find_post_by_old_date:$key:$last_changed";
-		$cache        = wp_cache_get( $cache_key, 'queries' );
+		$cache        = wp_cache_get( $cache_key, 'post-queries' );
 		if ( false !== $cache ) {
 			$id = $cache;
 		} else {
@@ -1206,7 +1206,7 @@ function _find_post_by_old_date( $post_type ) {
 				// Check to see if an old slug matches the old date.
 				$id = (int) $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM $wpdb->posts, $wpdb->postmeta AS pm_slug, $wpdb->postmeta AS pm_date WHERE ID = pm_slug.post_id AND ID = pm_date.post_id AND post_type = %s AND pm_slug.meta_key = '_wp_old_slug' AND pm_slug.meta_value = %s AND pm_date.meta_key = '_wp_old_date'" . $date_query, $post_type, get_query_var( 'name' ) ) );
 			}
-			wp_cache_set( $cache_key, $id, 'queries' );
+			wp_cache_set( $cache_key, $id, 'post-queries' );
 		}
 	}
 

--- a/src/wp-includes/query.php
+++ b/src/wp-includes/query.php
@@ -1154,12 +1154,12 @@ function _find_post_by_old_slug( $post_type ) {
 	$key          = md5( $query );
 	$last_changed = wp_cache_get_last_changed( 'posts' );
 	$cache_key    = "find_post_by_old_slug:$key:$last_changed";
-	$cache        = wp_cache_get( $cache_key, 'posts' );
+	$cache        = wp_cache_get( $cache_key, 'queries' );
 	if ( false !== $cache ) {
 		$id = $cache;
 	} else {
 		$id = (int) $wpdb->get_var( $query );
-		wp_cache_set( $cache_key, $id, 'posts' );
+		wp_cache_set( $cache_key, $id, 'queries' );
 	}
 
 	return $id;
@@ -1197,7 +1197,7 @@ function _find_post_by_old_date( $post_type ) {
 		$key          = md5( $query );
 		$last_changed = wp_cache_get_last_changed( 'posts' );
 		$cache_key    = "find_post_by_old_date:$key:$last_changed";
-		$cache        = wp_cache_get( $cache_key, 'posts' );
+		$cache        = wp_cache_get( $cache_key, 'queries' );
 		if ( false !== $cache ) {
 			$id = $cache;
 		} else {
@@ -1206,7 +1206,7 @@ function _find_post_by_old_date( $post_type ) {
 				// Check to see if an old slug matches the old date.
 				$id = (int) $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM $wpdb->posts, $wpdb->postmeta AS pm_slug, $wpdb->postmeta AS pm_date WHERE ID = pm_slug.post_id AND ID = pm_date.post_id AND post_type = %s AND pm_slug.meta_key = '_wp_old_slug' AND pm_slug.meta_value = %s AND pm_date.meta_key = '_wp_old_date'" . $date_query, $post_type, get_query_var( 'name' ) ) );
 			}
-			wp_cache_set( $cache_key, $id, 'posts' );
+			wp_cache_set( $cache_key, $id, 'queries' );
 		}
 	}
 

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -847,10 +847,10 @@ function get_objects_in_term( $term_ids, $taxonomies, $args = array() ) {
 
 	$last_changed = wp_cache_get_last_changed( 'terms' );
 	$cache_key    = 'get_objects_in_term:' . md5( $sql ) . ":$last_changed";
-	$cache        = wp_cache_get( $cache_key, 'queries' );
+	$cache        = wp_cache_get( $cache_key, 'term-queries' );
 	if ( false === $cache ) {
 		$object_ids = $wpdb->get_col( $sql );
-		wp_cache_set( $cache_key, $object_ids, 'queries' );
+		wp_cache_set( $cache_key, $object_ids, 'term-queries' );
 	} else {
 		$object_ids = (array) $cache;
 	}

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -3617,7 +3617,7 @@ function clean_term_cache( $ids, $taxonomy = '', $clean_taxonomy = true ) {
 		do_action( 'clean_term_cache', $ids, $taxonomy, $clean_taxonomy );
 	}
 
-	wp_cache_set( 'last_changed', microtime(), 'terms' );
+	wp_cache_set_terms_last_changed();
 }
 
 /**

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -2858,7 +2858,7 @@ function wp_set_object_terms( $object_id, $terms, $taxonomy, $append = false ) {
 	}
 
 	wp_cache_delete( $object_id, $taxonomy . '_relationships' );
-	wp_cache_delete( 'last_changed', 'terms' );
+	wp_cache_set_terms_last_changed();
 
 	/**
 	 * Fires after an object's terms have been set.
@@ -2956,7 +2956,7 @@ function wp_remove_object_terms( $object_id, $terms, $taxonomy ) {
 		$deleted = $wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->term_relationships WHERE object_id = %d AND term_taxonomy_id IN ($in_tt_ids)", $object_id ) );
 
 		wp_cache_delete( $object_id, $taxonomy . '_relationships' );
-		wp_cache_delete( 'last_changed', 'terms' );
+		wp_cache_set_terms_last_changed();
 
 		/**
 		 * Fires immediately after an object-term relationship is deleted.
@@ -3542,7 +3542,7 @@ function clean_object_term_cache( $object_ids, $object_type ) {
 		wp_cache_delete_multiple( $object_ids, "{$taxonomy}_relationships" );
 	}
 
-	wp_cache_delete( 'last_changed', 'terms' );
+	wp_cache_set_terms_last_changed();
 
 	/**
 	 * Fires after the object term cache has been cleaned.
@@ -3630,7 +3630,7 @@ function clean_term_cache( $ids, $taxonomy = '', $clean_taxonomy = true ) {
 function clean_taxonomy_cache( $taxonomy ) {
 	wp_cache_delete( 'all_ids', $taxonomy );
 	wp_cache_delete( 'get', $taxonomy );
-	wp_cache_delete( 'last_changed', 'terms' );
+	wp_cache_set_terms_last_changed();
 
 	// Regenerate cached hierarchy.
 	delete_option( "{$taxonomy}_children" );

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -847,10 +847,10 @@ function get_objects_in_term( $term_ids, $taxonomies, $args = array() ) {
 
 	$last_changed = wp_cache_get_last_changed( 'terms' );
 	$cache_key    = 'get_objects_in_term:' . md5( $sql ) . ":$last_changed";
-	$cache        = wp_cache_get( $cache_key, 'terms' );
+	$cache        = wp_cache_get( $cache_key, 'queries' );
 	if ( false === $cache ) {
 		$object_ids = $wpdb->get_col( $sql );
-		wp_cache_set( $cache_key, $object_ids, 'terms' );
+		wp_cache_set( $cache_key, $object_ids, 'queries' );
 	} else {
 		$object_ids = (array) $cache;
 	}


### PR DESCRIPTION
As per discussion with @spacedmonkey on Slack, this PR changes to storing all WordPress 6.1 query-caching in the `queries` group for more flexibility.

- This allows for `wp_cache_add_non_persistent_groups( 'post-queries' )`
- This allows object cache implementation to set a custom TTL for the `*-queries` groups

Trac ticket: https://core.trac.wordpress.org/ticket/57625

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
