### PR TITLE
Update sanitize field comment to clarify use of special characters. F…

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2127,9 +2127,9 @@ function sanitize_user( $username, $strict = false ) {
 	$raw_username = $username;
 	$username     = wp_strip_all_tags( $username );
 	$username     = remove_accents( $username );
-	// Kill octets.
+	// Remove percent-encoded characters.
 	$username = preg_replace( '|%([a-fA-F0-9][a-fA-F0-9])|', '', $username );
-	// Kill entities.
+	// Remove HTML entities.
 	$username = preg_replace( '/&.+?;/', '', $username );
 
 	// If strict, reduce to ASCII for max portability.


### PR DESCRIPTION
Hi there! 

I've made some changes to the `sanitize_user()` function to clarify the use of special characters in the comment. Specifically, I updated the comment to reflect that the function removes HTML entities and percent-encoded characters, rather than "killing" them.

Please review my changes and let me know if there are any issues or further improvements that need to be made. Thanks for your help!

Fixes #57712.


Trac ticket: https://core.trac.wordpress.org/ticket/57712

