### PR TITLE
`get_block_templates`: remove the `theme` parameter from the query

### DIFF
--- a/src/wp-includes/block-template.php
+++ b/src/wp-includes/block-template.php
@@ -145,7 +145,6 @@ function resolve_block_template( $template_type, $template_hierarchy, $fallback_
 
 	// Find all potential templates 'wp_template' post matching the hierarchy.
 	$query     = array(
-		'theme'    => get_stylesheet(),
 		'slug__in' => $slugs,
 	);
 	$templates = get_block_templates( $query );


### PR DESCRIPTION
Trac ticket https://core.trac.wordpress.org/ticket/57736

This PR removes the `theme` parameter from the query passed to [get_block_templates](https://github.com/WordPress/wordpress-develop/blob/dcec7f5554963149f29b462ee5c049024c38d62f/src/wp-includes/block-template-utils.php#L876). It is not used or documented. This removal doesn't have any effect in the code, as the data is ignored anyway.
