### PR TITLE
params pass correctly in method

### DIFF
--- a/src/wp-includes/class-wp-widget-factory.php
+++ b/src/wp-includes/class-wp-widget-factory.php
@@ -59,7 +59,7 @@ class WP_Widget_Factory {
 		if ( $widget instanceof WP_Widget ) {
 			$this->widgets[ spl_object_hash( $widget ) ] = $widget;
 		} else {
-			$this->widgets[ $widget ] = new $widget();
+			$this->widgets[ $widget ] = new $widget($widget, $widget);
 		}
 	}
 

--- a/src/wp-includes/class-wp-widget-factory.php
+++ b/src/wp-includes/class-wp-widget-factory.php
@@ -59,7 +59,7 @@ class WP_Widget_Factory {
 		if ( $widget instanceof WP_Widget ) {
 			$this->widgets[ spl_object_hash( $widget ) ] = $widget;
 		} else {
-			$this->widgets[ $widget ] = new $widget($widget, $widget);
+			$this->widgets[ $widget ] = new $widget( $widget, $widget );
 		}
 	}
 


### PR DESCRIPTION

PHP 8.1 compatibility

wp-includes/class-wp-widget-factory.php file, line 62. 
The line was formerly:  $this->widgets[ $widget ] = new $widget();

I modified the line to be as follows: $this->widgets[ $widget ] = new $widget( $widget, $widget );

Trac ticket: https://core.trac.wordpress.org/ticket/57739