### PR TITLE
Tests: Changing assertion type for test_skip_block_math_elements() me…

### DIFF
--- a/tests/phpunit/tests/formatting/wpAutop.php
+++ b/tests/phpunit/tests/formatting/wpAutop.php
@@ -158,7 +158,7 @@ PS.  Not yet subscribed for update notifications?  <a href="%1$s" title="Subscri
 	</mtable>
 </math>';
 
-		$this->assertSame( "<p>$str</p>", trim( wpautop( $str ) ) );
+		$this->assertSameIgnoreEOL( "<p>$str</p>", trim( wpautop( $str ) ) );
 	}
 
 	/**


### PR DESCRIPTION
Tests: Changing assertion type for test_skip_block_math_elements() method from Tests_Formatting_wpAutop class.

The assertion type has been changed due to an issue with Windows installations and differences in EOL characters.

Trac ticket: https://core.trac.wordpress.org/ticket/57718

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
