### PR TITLE
Fix bad variable name $previouspage ==> $nextpage

### DIFF
--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -2579,11 +2579,11 @@ function get_previous_posts_page_link() {
 	global $paged;
 
 	if ( ! is_single() ) {
-		$nextpage = (int) $paged - 1;
-		if ( $nextpage < 1 ) {
-			$nextpage = 1;
+		$previouspage = (int) $paged - 1;
+		if ( $previouspage < 1 ) {
+			$previouspage = 1;
 		}
-		return get_pagenum_link( $nextpage );
+		return get_pagenum_link( $previouspage );
 	}
 }
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Hello !
While i was reading get_previous_posts_page_link() function code:

```php
<?php
function get_previous_posts_page_link() {
        global $paged;

        if ( ! is_single() ) {
                $nextpage = (int) $paged - 1;
                if ( $nextpage < 1 ) {
                        $nextpage = 1;
                }
                return get_pagenum_link( $nextpage );
        }
}
```
my brain crashed for a while because of this line :
`$nextpage = (int) $paged - 1;`

I'm pretty sure that the right variable name is **$previouspage** (instead of **$nextpage**)

Trac ticket: https://core.trac.wordpress.org/ticket/57746#ticket
