### PR TITLE
#57754 Deprecated Error Passing null to parameter in preg_replace fixed

### DIFF
--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -2085,6 +2085,10 @@ function get_plugin_page_hookname( $plugin_page, $parent_page ) {
 		$page_type = $admin_page_hooks[ $parent ];
 	}
 
+	if(empty($plugin_page)){
+		$plugin_page = $parent_page;
+	}
+
 	$plugin_name = preg_replace( '!\.php!', '', $plugin_page );
 
 	return $page_type . '_page_' . $plugin_name;

--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -2085,7 +2085,7 @@ function get_plugin_page_hookname( $plugin_page, $parent_page ) {
 		$page_type = $admin_page_hooks[ $parent ];
 	}
 
-	if(empty($plugin_page)){
+	if( empty( $plugin_page ) ){
 		$plugin_page = $parent_page;
 	}
 


### PR DESCRIPTION
**FIXED** Deprecated Error Passing null to parameter in preg_replace() in Privacy Page on WP 6.1.1 and PHP 8.2.1


Trac ticket: https://core.trac.wordpress.org/ticket/57754

