### PR TITLE
Improve `get_block_templates` performance

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -340,7 +340,7 @@ function _get_block_templates_files( $template_type, $query = array() ) {
 			);
 
 			// Skip this item if its slug doesn't match any of the slugs to include.
-			if ( ! empty( $slugs_to_include ) && ( false === array_search( $template_slug, $slugs_to_include, true ) ) ) {
+			if ( ! empty( $slugs_to_include ) && ! in_array( $template_slug, $slugs_to_include, true ) ) {
 				continue;
 			}
 

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -297,10 +297,10 @@ function _get_block_template_file( $template_type, $slug ) {
  * @param array  $query {
  *     Arguments to retrieve templates. Optional, empty by default.
  *
- *     @type array  $slug__in      List of slugs to include.
- *     @type array  $slug__not_in  List of slugs to skip.
- *     @type string $area          A 'wp_template_part_area' taxonomy value to filter by (for wp_template_part template type only).
- *     @type string $post_type     Post type to get the templates for.
+ *     @type array  $slug__in     List of slugs to include.
+ *     @type array  $slug__not_in List of slugs to skip.
+ *     @type string $area         A 'wp_template_part_area' taxonomy value to filter by (for wp_template_part template type only).
+ *     @type string $post_type    Post type to get the templates for.
  * }
  *
  * @return array Template

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -340,7 +340,7 @@ function _get_block_templates_files( $template_type, $query = array() ) {
 			);
 
 			// Skip this item if its slug doesn't match any of the slugs to include.
-			if ( ! empty( $slugs_to_include ) && ! isset( $slugs_to_include[ $template_slug ] ) ) {
+			if ( ! empty( $slugs_to_include ) && ( false === array_search( $template_slug, $slugs_to_include, true ) ) ) {
 				continue;
 			}
 

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -290,10 +290,21 @@ function _get_block_template_file( $template_type, $slug ) {
  * Retrieves the template files from the theme.
  *
  * @since 5.9.0
+ * @since 6.3.0 Added the `$query` and `$user_templates` parameters.
  * @access private
  *
  * @param string $template_type 'wp_template' or 'wp_template_part'.
- * @return array Template.
+ * @param array  $query {
+ *     Arguments to retrieve templates. Optional, empty by default.
+ *
+ *     @type array  $slug__in  List of slugs to include.
+ *     @type int    $wp_id     Post ID of customized template.
+ *     @type string $area      A 'wp_template_part_area' taxonomy value to filter by (for wp_template_part template type only).
+ *     @type string $post_type Post type to get the templates for.
+ * }
+ * @param array $user_templates Array of user templates that match the search. Optional, empty by default.
+ *
+ * @return array Template
  */
 function _get_block_templates_files( $template_type, $query = array(), $user_templates = array() ) {
 	if ( 'wp_template' !== $template_type && 'wp_template_part' !== $template_type ) {

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -298,7 +298,6 @@ function _get_block_template_file( $template_type, $slug ) {
  *     Arguments to retrieve templates. Optional, empty by default.
  *
  *     @type array  $slug__in  List of slugs to include.
- *     @type int    $wp_id     Post ID of customized template.
  *     @type string $area      A 'wp_template_part_area' taxonomy value to filter by (for wp_template_part template type only).
  *     @type string $post_type Post type to get the templates for.
  * }

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -984,7 +984,7 @@ function get_block_templates( $query = array(), $template_type = 'wp_template' )
 
 	if ( ! empty( $query['slug__in'] ) ) {
 		$wp_query_args['post_name__in']  = $query['slug__in'];
-		$wp_query_args['posts_per_page'] = count( $query['slug__in'] );
+		$wp_query_args['posts_per_page'] = count( array_unique( $query['slug__in'] ) );
 	}
 
 	// This is only needed for the regular templates/template parts post type listing and editor.

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -345,7 +345,7 @@ function _get_block_templates_files( $template_type, $query = array() ) {
 			}
 
 			// Skip this item if its slug matches any of the slugs to skip.
-			if ( ! empty( $slugs_to_skip ) && ( false !== array_search( $template_slug, $slugs_to_skip, true ) ) ) {
+			if ( ! empty( $slugs_to_skip ) && in_array( $template_slug, $slugs_to_skip, true ) ) {
 				continue;
 			}
 

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -340,7 +340,7 @@ function _get_block_templates_files( $template_type, $query = array() ) {
 			);
 
 			// Skip this item if its slug doesn't match any of the slugs to include.
-			if ( ! empty( $slugs_to_include ) && ( false === array_search( $template_slug, $slugs_to_include, true ) ) ) {
+			if ( ! empty( $slugs_to_include ) && ! isset( $slugs_to_include[ $template_slug ] ) ) {
 				continue;
 			}
 

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -982,8 +982,9 @@ function get_block_templates( $query = array(), $template_type = 'wp_template' )
 		$wp_query_args['tax_query']['relation'] = 'AND';
 	}
 
-	if ( isset( $query['slug__in'] ) ) {
-		$wp_query_args['post_name__in'] = $query['slug__in'];
+	if ( ! empty( $query['slug__in'] ) ) {
+		$wp_query_args['post_name__in']  = $query['slug__in'];
+		$wp_query_args['posts_per_page'] = count( $query['slug__in'] );
 	}
 
 	// This is only needed for the regular templates/template parts post type listing and editor.

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -316,11 +316,15 @@ function _get_block_templates_files( $template_type, $query = array(), $user_tem
 	$area      = isset( $query['area'] ) ? $query['area'] : null;
 	$post_type = isset( $query['post_type'] ) ? $query['post_type'] : '';
 
-	$stylesheet     = get_stylesheet();
-	$themes         = array(
-		$stylesheet    => get_stylesheet_directory(),
-		get_template() => get_template_directory(),
+	$stylesheet = get_stylesheet();
+	$template   = get_template();
+	$themes     = array(
+		$stylesheet => get_stylesheet_directory(),
 	);
+	// Add the parent theme if it's not the same as the current theme.
+	if ( $stylesheet !== $template ) {
+		$themes[ $template ] = get_template_directory();
+	}
 	$template_files = array();
 	foreach ( $themes as $theme_slug => $theme_dir ) {
 		$template_base_paths  = get_block_theme_folders( $theme_slug );


### PR DESCRIPTION
Trac ticket https://core.trac.wordpress.org/ticket/57756

## What

This PR improves the performance of block template resolution.

## Why

It provides a performance improvement for block themes. This change should not affect themes that don't have block templates, given they [bail early](https://github.com/WordPress/wordpress-develop/blob/4049c5d3543e59f92d48fd9cef735420996dce2e/src/wp-includes/block-template.php#L51).

The effect of this PR according to the [performance CI job](https://github.com/WordPress/wordpress-develop/actions/runs/4733710372/jobs/8401618173?pr=4097):

- Home classic theme

| Metric (ms) | This PR | Base | Improvement |
| --- | --- | --- | --- |
| wpBeforeTemplate | 17.02 | 19.47 | +12.58% |
|    wpTemplate    | 41.06 |  44.40 | +7.52% |
|     wpTotal      | 57.92 | 64.23 | +9.82% |

- Home block theme

| Metric (ms) | This PR | Base | Improvement % |
| --- | --- | --- | --- |
| wpBeforeTemplate | 23.34 | 24.42 | +4.42% |
|    wpTemplate    | 44.27 | 55.24 | +19.85% |
|     wpTotal      | 67.63 | 79.56 | +14.99% |


## How

The `get_block_templates` function is responsible to find block templates that match a given search. The function is provided a query parameter that is used to find the relevant user templates (database) and theme templates (file directory). The query parameter includes data such the slugs of the templates, the areas of the template parts, etc.

I've found that the `get_block_templates` retrieves and processes [all block templates provided by the theme](https://github.com/WordPress/wordpress-develop/blob/4049c5d3543e59f92d48fd9cef735420996dce2e/src/wp-includes/block-template-utils.php#L977), to [filter out the ones that don't match](https://github.com/WordPress/wordpress-develop/blob/4049c5d3543e59f92d48fd9cef735420996dce2e/src/wp-includes/block-template-utils.php#L997) after. This function can be more performant if it filters out the ones that don't match _before_ processing them, so it only computes the data to be used.

The following profile shows the impact of this modification:

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/583546/219652222-2aca88ad-c4b4-4d6f-9b3f-707df626711e.png) | ![image](https://user-images.githubusercontent.com/583546/219652291-3c1f3246-4ac4-49f8-a087-50949f21b48b.png) |

- The time it takes as measured by XDebug profiler: 55ms (before) vs 27ms (after).
- The number of times the `_build_block_template_result_from_file` is called: 22 (before) vs 5 (after).

## How to test

- Start the bundled environment.
- Set `.env` to production by applying the following patch:

```diff
diff --git a/.env b/.env
index 63a8169f64..9b1d52ac50 100644
--- a/.env
+++ b/.env
@@ -54,10 +54,10 @@ LOCAL_DB_TYPE=mysql
 LOCAL_DB_VERSION=5.7
 
 # The debug settings to add to `wp-config.php`.
-LOCAL_WP_DEBUG=true
-LOCAL_WP_DEBUG_LOG=true
-LOCAL_WP_DEBUG_DISPLAY=true
-LOCAL_SCRIPT_DEBUG=true
+LOCAL_WP_DEBUG=false
+LOCAL_WP_DEBUG_LOG=false
+LOCAL_WP_DEBUG_DISPLAY=false
+LOCAL_SCRIPT_DEBUG=false
 LOCAL_WP_ENVIRONMENT_TYPE=local
 
 # The URL to use when running e2e tests.
```
- Run 100 test of the homepage: `seq 100 | xargs -Iz curl -o /dev/null -H 'Cache-Control: no-cache' -s -w "%{time_starttransfer}\n" http://localhost:8889 | xclip -selection clipboard`.
- Copy the results to a spreadsheet like [this one](https://docs.google.com/spreadsheets/d/1K2u5oOh7rd23HBOz3pPAcAi9P8290E0IV2NZhk_E9i4/edit#gid=0) to measure the changes.

## Notes

I submitted this PR to core instead of Gutenberg because it modifies functions that are no longer there:

- `_get_block_templates_files`: no longer present.
- `get_block_templates`: the corresponding `gutenberg_get_block_templates` is [still present](https://github.com/WordPress/gutenberg/blob/trunk/lib/compat/wordpress-6.1/block-template-utils.php#L53), but it'll be removed once WordPress 6.2 is published. It won't be present in Gutenberg when this PR lands (WordPress 6.3 cycle).
