### PR TITLE
Fix possible mismatch of template slug

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -307,13 +307,14 @@ function _get_block_templates_files( $template_type ) {
 	$template_files = array();
 	foreach ( $themes as $theme_slug => $theme_dir ) {
 		$template_base_paths  = get_block_theme_folders( $theme_slug );
-		$theme_template_files = _get_block_templates_paths( $theme_dir . '/' . $template_base_paths[ $template_type ] );
+		$template_base_path = $template_base_paths[ $template_type ];
+		$theme_template_files = _get_block_templates_paths( $theme_dir . '/' . $template_base_path );
 		foreach ( $theme_template_files as $template_file ) {
-			$template_base_path = $template_base_paths[ $template_type ];
-			$template_slug      = substr(
-				$template_file,
-				// Starting position of slug.
-				strpos( $template_file, $template_base_path . DIRECTORY_SEPARATOR ) + 1 + strlen( $template_base_path ),
+			$split = explode( DIRECTORY_SEPARATOR . $template_base_path . DIRECTORY_SEPARATOR, $template_file );
+			$template_file_name = end( $split );
+			$template_slug = substr(
+				$template_file_name,
+				0,
 				// Subtract ending '.html'.
 				-5
 			);


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
The current way of loading in FSE theme template files may conflict when the WordPress installation is stored in a `templates` or `block-templates` folder. This PR fixes that constraint.

Trac ticket: https://core.trac.wordpress.org/ticket/57757
WPSE Question: https://wordpress.stackexchange.com/questions/413959/full-site-editing-templates-folder-vs-block-templates (Made by me before finding the problem)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
