### PR TITLE
Add admin-post.php wp_die() handler

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -3701,6 +3701,19 @@ function wp_die( $message = '', $title = '', $args = array() ) {
 		 * @param callable $callback Callback function name.
 		 */
 		$callback = apply_filters( 'wp_die_xml_handler', '_xml_wp_die_handler' );
+	} elseif ( is_admin() &&
+			   substr( get_admin_url(), strlen( get_bloginfo( 'url' ) ) ) . 'admin-post.php' === wp_parse_url( '//' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'],  PHP_URL_PATH )
+	) {
+
+		/**
+		 * Filters the callback for killing WordPress execution for admin-post.php requests.
+		 *
+		 * @since 6.2.0
+		 *
+		 * @param callable $callback Callback function name.
+		 */
+		$callback = apply_filters( 'wp_die_admin_post_handler', '_default_wp_die_handler' );
+
 	} else {
 		/**
 		 * Filters the callback for killing WordPress execution for all non-Ajax, non-JSON, non-XML requests.


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Adds a condition to `wp_die()` to identify when it is being called in response to an `admin-post.php` request and a filter for hooking a custom handler.

Trac ticket: https://core.trac.wordpress.org/ticket/27671

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
