### PR TITLE
Fix the attributes for the email input field on the new network user screen

### DIFF
--- a/src/wp-admin/network/user-new.php
+++ b/src/wp-admin/network/user-new.php
@@ -132,7 +132,7 @@ if ( isset( $add_user_errors ) && is_wp_error( $add_user_errors ) ) {
 			</tr>
 			<tr class="form-field form-required">
 				<th scope="row"><label for="email"><?php _e( 'Email' ); ?> <?php echo wp_required_field_indicator(); ?></label></th>
-				<td><input type="text" class="regular-text" name="user[email]" id="email" autocapitalize="none" autocorrect="off" required="required" /></td>
+				<td><input type="email" class="regular-text" name="user[email]" id="email" autocapitalize="none" autocorrect="off" required="required" /></td>
 			</tr>
 			<tr class="form-field">
 				<td colspan="2" class="td-full"><?php _e( 'A password reset link will be sent to the user via email.' ); ?></td>

--- a/src/wp-admin/network/user-new.php
+++ b/src/wp-admin/network/user-new.php
@@ -132,7 +132,7 @@ if ( isset( $add_user_errors ) && is_wp_error( $add_user_errors ) ) {
 			</tr>
 			<tr class="form-field form-required">
 				<th scope="row"><label for="email"><?php _e( 'Email' ); ?> <?php echo wp_required_field_indicator(); ?></label></th>
-				<td><input type="text" class="regular-text" name="user[username]" id="username" autocapitalize="none" autocorrect="off" maxlength="60" required="required" /></td>
+				<td><input type="text" class="regular-text" name="user[email]" id="email" autocapitalize="none" autocorrect="off" required="required" /></td>
 			</tr>
 			<tr class="form-field">
 				<td colspan="2" class="td-full"><?php _e( 'A password reset link will be sent to the user via email.' ); ?></td>

--- a/src/wp-admin/network/user-new.php
+++ b/src/wp-admin/network/user-new.php
@@ -132,7 +132,7 @@ if ( isset( $add_user_errors ) && is_wp_error( $add_user_errors ) ) {
 			</tr>
 			<tr class="form-field form-required">
 				<th scope="row"><label for="email"><?php _e( 'Email' ); ?> <?php echo wp_required_field_indicator(); ?></label></th>
-				<td><input type="email" class="regular-text" name="user[email]" id="email" autocapitalize="none" autocorrect="off" required="required" /></td>
+				<td><input type="email" class="regular-text" name="user[email]" id="email" required="required" /></td>
 			</tr>
 			<tr class="form-field">
 				<td colspan="2" class="td-full"><?php _e( 'A password reset link will be sent to the user via email.' ); ?></td>


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/38460

This reverts the email input field back to its previous state, except for the expected addition of the `required` attribute.