### PR TITLE
HTML API: Set `$this->html` to protected to support subclassing.

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -274,7 +274,7 @@ class WP_HTML_Tag_Processor {
 	 * @since 6.2.0
 	 * @var string
 	 */
-	private $html;
+	protected $html;
 
 	/**
 	 * The last query passed to next_tag().


### PR DESCRIPTION
When the HTML API was introduced a number of fields were switched from `private` visibility to `protected` so that Gutenberg and other systems could more easily enhance the behaviors through subclassing. The `$this->html` property was overlooked but important for systems using the Tag Processor to stich HTML, specifically performing operations on `innerHTML` and `innerText`.

This patch updates that visibility to what it should have been during the introducing of the API in 39bfc2580d9b0ea7e6ff45b8d904408d925cbc4b.

Trac ticket: https://core.trac.wordpress.org/ticket/57575.

cc: @adamziel @ockham @azaozz 