### PR TITLE
Sync: Update core shadow presets

### DIFF
--- a/src/wp-includes/theme.json
+++ b/src/wp-includes/theme.json
@@ -326,16 +326,32 @@
 			}
 		},
 		"shadow": {
+			"defaultPresets": true,
 			"presets": [
 				{
 					"name": "Natural",
 					"slug": "natural",
-					"shadow": "0 .2rem .3rem 0 rgba(0,0,0, 0.3), 0 .5rem .6rem 0 rgba(0,0,0, 0.4)"
+					"shadow": "6px 6px 9px rgba(0, 0, 0, 0.2)"
+				},
+				{
+					"name": "Deep",
+					"slug": "deep",
+					"shadow": "12px 12px 50px rgba(0, 0, 0, 0.4)"
 				},
 				{
 					"name": "Sharp",
 					"slug": "sharp",
-					"shadow": ".5rem .5rem 0 0 rgba(0,0,0, 0.4)"
+					"shadow": "6px 6px 0px rgba(0, 0, 0, 0.2)"
+				},
+				{
+					"name": "Outlined",
+					"slug": "outlined",
+					"shadow": "6px 6px 0px -3px rgba(255, 255, 255, 1), 6px 6px rgba(0, 0, 0, 1)"
+				},
+				{
+					"name": "Crisp",
+					"slug": "crisp",
+					"shadow": "6px 6px 0px rgba(0, 0, 0, 1)"
 				}
 			]
 		},


### PR DESCRIPTION
PR sync core shadow presets from the Gutenberg plugin. This should also fix shadow presets being empty in 6.2 beta3.

Trac ticket: https://core.trac.wordpress.org/ticket/57708
