### PR TITLE
WP_HTML_Tag_Processor: Support tag closer bookmarks

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -722,7 +722,7 @@ class WP_HTML_Tag_Processor {
 		}
 
 		$this->bookmarks[ $name ] = new WP_HTML_Span(
-			$this->tag_name_starts_at - 1,
+			$this->tag_name_starts_at - ( $this->is_closing_tag ? 2 : 1 ),
 			$this->tag_ends_at
 		);
 
@@ -1504,7 +1504,7 @@ class WP_HTML_Tag_Processor {
 		$this->bytes_already_parsed = $this->bookmarks[ $bookmark_name ]->start;
 		$this->bytes_already_copied = $this->bytes_already_parsed;
 		$this->output_buffer        = substr( $this->html, 0, $this->bytes_already_copied );
-		return $this->next_tag();
+		return $this->next_tag( array( 'tag_closers' => 'visit' ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor-bookmark.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor-bookmark.php
@@ -64,7 +64,7 @@ class Tests_HtmlApi_wpHtmlTagProcessor_Bookmark extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket 56299
+	 * @ticket 57787
 	 *
 	 * @covers WP_HTML_Tag_Processor::seek
 	 */

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor-bookmark.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor-bookmark.php
@@ -64,6 +64,28 @@ class Tests_HtmlApi_wpHtmlTagProcessor_Bookmark extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 56299
+	 *
+	 * @covers WP_HTML_Tag_Processor::seek
+	 */
+	public function test_seeks_to_tag_closer_bookmark() {
+		$p = new WP_HTML_Tag_Processor( '<div>First</div><span>Second</span>' );
+		$p->next_tag( array( 'tag_closers' => 'visit' ) );
+		$p->set_bookmark( 'first' );
+		$p->next_tag( array( 'tag_closers' => 'visit' ) );
+		$p->set_bookmark( 'second' );
+
+		$p->seek( 'first' );
+		$p->seek( 'second' );
+
+		$this->assertSame(
+			'DIV',
+			$p->get_tag(),
+			'Did not seek to the intended bookmark location'
+		);
+	}
+
+	/**
 	 * WP_HTML_Tag_Processor used to test for the diffs affecting
 	 * the adjusted bookmark position while simultaneously adjusting
 	 * the bookmark in question. As a result, updating the bookmarks


### PR DESCRIPTION
## Description

With this PR `seek()` correctly finds bookmarks set on tag closers. It:

* Uses the correct starting index for tag closer bookmarks
* Adds `array( 'tag_closers' => 'visit' )` in `seek()`

### About bookmark start indices:

Setting a bookmark on a tag should set its "start" position before the opening "<", e.g.:

```
<div> Testing a <b>Bookmark</b>
----------------^
```

The current calculation assumes this is always one byte to the left from $tag_name_starts_at.

However, in tag closers that index points to a solidus symbol "/":

```
<div> Testing a <b>Bookmark</b>
----------------------------^
```

The bookmark should therefore start two bytes before the tag name:

```
<div> Testing a <b>Bookmark</b>
---------------------------^
```

Trac ticket: https://core.trac.wordpress.org/ticket/57787

cc @ockham @dmsnell @gziolo 