### PR TITLE
Tag Processor: Add Bookmark Invalidation Logic

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1401,6 +1401,7 @@ class WP_HTML_Tag_Processor {
 	 * Applies attribute updates to HTML document.
 	 *
 	 * @since 6.2.0
+	 * @since 6.3.0 Invalidate any bookmarks whose targets are overwritten.
 	 *
 	 * @return void
 	 */
@@ -1431,7 +1432,7 @@ class WP_HTML_Tag_Processor {
 		 * Adjust bookmark locations to account for how the text
 		 * replacements adjust offsets in the input document.
 		 */
-		foreach ( $this->bookmarks as $bookmark ) {
+		foreach ( $this->bookmarks as $bookmark_name => $bookmark ) {
 			/*
 			 * Each lexical update which appears before the bookmark's endpoints
 			 * might shift the offsets for those endpoints. Loop through each change
@@ -1442,20 +1443,22 @@ class WP_HTML_Tag_Processor {
 			$tail_delta = 0;
 
 			foreach ( $this->lexical_updates as $diff ) {
-				$update_head = $bookmark->start >= $diff->start;
-				$update_tail = $bookmark->end >= $diff->start;
-
-				if ( ! $update_head && ! $update_tail ) {
+				if ( $bookmark->start < $diff->start && $bookmark->end < $diff->start ) {
 					break;
+				}
+
+				if ( $bookmark->start >= $diff->start && $bookmark->end < $diff->end ) {
+					$this->release_bookmark( $bookmark_name );
+					continue 2;
 				}
 
 				$delta = strlen( $diff->text ) - ( $diff->end - $diff->start );
 
-				if ( $update_head ) {
+				if ( $bookmark->start >= $diff->start ) {
 					$head_delta += $delta;
 				}
 
-				if ( $update_tail ) {
+				if ( $bookmark->end >= $diff->end ) {
 					$tail_delta += $delta;
 				}
 			}
@@ -1465,6 +1468,18 @@ class WP_HTML_Tag_Processor {
 		}
 
 		$this->lexical_updates = array();
+	}
+
+	/**
+	 * Checks whether a bookmark with the given name exists.
+	 *
+	 * @since 6.3.0
+	 *
+	 * @param string $bookmark_name Name to identify a bookmark that potentially exists.
+	 * @return bool Whether that bookmark exists.
+	 */
+	public function has_bookmark( $bookmark_name ) {
+		return array_key_exists( $bookmark_name, $this->bookmarks );
 	}
 
 	/**

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor-bookmark.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor-bookmark.php
@@ -41,6 +41,41 @@ class Tests_HtmlApi_wpHtmlTagProcessor_Bookmark extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 57788
+	 *
+	 * @covers WP_HTML_Tag_Processor::has_bookmark
+	 */
+	public function test_has_bookmark_returns_false_if_bookmark_does_not_exist() {
+		$p = new WP_HTML_Tag_Processor( '<div>Test</div>' );
+		$this->assertFalse( $p->has_bookmark( 'my-bookmark' ) );
+	}
+
+	/**
+	 * @ticket 57788
+	 *
+	 * @covers WP_HTML_Tag_Processor::has_bookmark
+	 */
+	public function test_has_bookmark_returns_true_if_bookmark_exists() {
+		$p = new WP_HTML_Tag_Processor( '<div>Test</div>' );
+		$p->next_tag();
+		$p->set_bookmark( 'my-bookmark' );
+		$this->assertTrue( $p->has_bookmark( 'my-bookmark' ) );
+	}
+
+	/**
+	 * @ticket 57788
+	 *
+	 * @covers WP_HTML_Tag_Processor::has_bookmark
+	 */
+	public function test_has_bookmark_returns_false_if_bookmark_has_been_released() {
+		$p = new WP_HTML_Tag_Processor( '<div>Test</div>' );
+		$p->next_tag();
+		$p->set_bookmark( 'my-bookmark' );
+		$p->release_bookmark( 'my-bookmark' );
+		$this->assertFalse( $p->has_bookmark( 'my-bookmark' ) );
+	}
+
+	/**
 	 * @ticket 56299
 	 *
 	 * @covers WP_HTML_Tag_Processor::seek


### PR DESCRIPTION
_Targeting WP 6.3._

While `WP_HTML_Tag_Processor` currently only supports changing a given tag's attributes, we plan to also provide methods to make broader changes (possibly through a subclass of `WP_HTML_Tag_Processor`).
An API like that will have the potential of replacing a tag that a bookmark points to. As a preparation, we thus need to make sure that all bookmarks affected by a HTML replacement are invalidated (i.e. released).

This is done by extending the existing loop in `apply_attributes_updates` that adjusts bookmarks' start and end positions upon HTML changes to check if the entire bookmark is within a portion of the HTML that has been replaced.

Note that this PR is a backport of https://github.com/WordPress/gutenberg/pull/47559.

Trac ticket: https://core.trac.wordpress.org/ticket/57788

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
