### PR TITLE
Fix PHP warning from invalid `wp_add_inline_style()` call in Twenty Twenty

### DIFF
--- a/src/wp-content/themes/twentytwenty/classes/class-twentytwenty-non-latin-languages.php
+++ b/src/wp-content/themes/twentytwenty/classes/class-twentytwenty-non-latin-languages.php
@@ -25,7 +25,7 @@ if ( ! class_exists( 'TwentyTwenty_Non_Latin_Languages' ) ) {
 		 * @since Twenty Twenty 1.0
 		 *
 		 * @param string $type Whether to return CSS for the "front-end", "block-editor", or "classic-editor".
-		 * @return void
+		 * @return string|null Custom CSS, or null if not applicable.
 		 */
 		public static function get_non_latin_css( $type = 'front-end' ) {
 
@@ -105,7 +105,7 @@ if ( ! class_exists( 'TwentyTwenty_Non_Latin_Languages' ) ) {
 
 			// Return if the selected language has no fallback fonts.
 			if ( empty( $font_family[ $locale ] ) ) {
-				return;
+				return null;
 			}
 
 			/**
@@ -126,7 +126,7 @@ if ( ! class_exists( 'TwentyTwenty_Non_Latin_Languages' ) ) {
 
 			// Return if the specified type doesn't exist.
 			if ( empty( $elements[ $type ] ) ) {
-				return;
+				return null;
 			}
 
 			// Return the specified styles.

--- a/src/wp-content/themes/twentytwenty/functions.php
+++ b/src/wp-content/themes/twentytwenty/functions.php
@@ -427,7 +427,10 @@ function twentytwenty_block_editor_styles() {
 	wp_add_inline_style( 'twentytwenty-block-editor-styles', twentytwenty_get_customizer_css( 'block-editor' ) );
 
 	// Add inline style for non-latin fonts.
-	wp_add_inline_style( 'twentytwenty-block-editor-styles', TwentyTwenty_Non_Latin_Languages::get_non_latin_css( 'block-editor' ) );
+	$custom_css = TwentyTwenty_Non_Latin_Languages::get_non_latin_css( 'block-editor' );
+	if ( $custom_css ) {
+		wp_add_inline_style( 'twentytwenty-block-editor-styles', $custom_css );
+	}
 
 	// Enqueue the editor script.
 	wp_enqueue_script( 'twentytwenty-block-editor-script', get_theme_file_uri( '/assets/js/editor-script-block.js' ), array( 'wp-blocks', 'wp-dom' ), wp_get_theme()->get( 'Version' ), true );

--- a/src/wp-content/themes/twentytwenty/functions.php
+++ b/src/wp-content/themes/twentytwenty/functions.php
@@ -196,7 +196,10 @@ function twentytwenty_register_styles() {
 	wp_style_add_data( 'twentytwenty-style', 'rtl', 'replace' );
 
 	// Add output of Customizer settings as inline style.
-	wp_add_inline_style( 'twentytwenty-style', twentytwenty_get_customizer_css( 'front-end' ) );
+	$customizer_css = twentytwenty_get_customizer_css( 'front-end' );
+	if ( $customizer_css ) {
+		wp_add_inline_style( 'twentytwenty-style', $customizer_css );
+	}
 
 	// Add print CSS.
 	wp_enqueue_style( 'twentytwenty-print-style', get_template_directory_uri() . '/print.css', null, $theme_version, 'print' );
@@ -424,7 +427,10 @@ function twentytwenty_block_editor_styles() {
 	wp_style_add_data( 'twentytwenty-block-editor-styles', 'rtl', 'replace' );
 
 	// Add inline style from the Customizer.
-	wp_add_inline_style( 'twentytwenty-block-editor-styles', twentytwenty_get_customizer_css( 'block-editor' ) );
+	$customizer_css = twentytwenty_get_customizer_css( 'block-editor' );
+	if ( $customizer_css ) {
+		wp_add_inline_style( 'twentytwenty-block-editor-styles', $customizer_css );
+	}
 
 	// Add inline style for non-latin fonts.
 	$custom_css = TwentyTwenty_Non_Latin_Languages::get_non_latin_css( 'block-editor' );
@@ -467,6 +473,10 @@ add_action( 'init', 'twentytwenty_classic_editor_styles' );
 function twentytwenty_add_classic_editor_customizer_styles( $mce_init ) {
 
 	$styles = twentytwenty_get_customizer_css( 'classic-editor' );
+
+	if ( ! $styles ) {
+		return $mce_init;
+	}
 
 	if ( ! isset( $mce_init['content_style'] ) ) {
 		$mce_init['content_style'] = $styles . ' ';


### PR DESCRIPTION
* Fixes the bug outlined in the ticket.
* Also fixes inaccurate `@return` docs and makes the `null` return explicit.

Trac ticket: https://core.trac.wordpress.org/ticket/57777

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
