### PR TITLE
Explore HTML parser based on the Tag Processor

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -995,10 +995,10 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 
 	private function insert_node( WP_HTML_Node $node, $override_target = null ) {
 		$target = $override_target ?: $this->current_node();
-
-		// Appropriate place for inserting a node:
-		// For now skip foster parenting and always use the
-		// location after the last child of the target
+		/**
+		 * Appropriate place for inserting a node is always the end of the
+		 * target's children thanks to the assumptions this parser makes.
+		 */
 		$target->append_child($node);
 		dbg("Inserted element: {$node->token->tag} to parent {$target->token->tag}", 2);
 	}

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -1503,8 +1503,6 @@ DOM after main loop:
          └─ #text: Amet
 */
 
-die();
-
 $p = new WP_HTML_Processor( '<div>1<span>2</div>3</span>4' );
 $p->parse();
 /*
@@ -1519,8 +1517,6 @@ Outputs:
 	│  └─ #text: 4
 	└─ #text: 5
 */
-
-die();
 
 $p = new WP_HTML_Processor( '<p>1<b>2<i>3</b>4</i>5</p>' );
 $p->parse();

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -1,0 +1,1376 @@
+<?php
+
+// PHPUnit is slow to load, so I'll just run this file directly.
+if ( ! class_exists( 'WP_HTML_Tag_Processor' ) ) {
+	require __DIR__ . '/class-wp-html-attribute-token.php';
+	require __DIR__ . '/class-wp-html-span.php';
+	require __DIR__ . '/class-wp-html-text-replacement.php';
+	require __DIR__ . '/class-wp-html-tag-processor.php';
+	function esc_attr( $text ) {
+		return htmlspecialchars( $text, ENT_QUOTES, 'UTF-8' );
+	}
+}
+
+// Could be just WP_HTML_Node actually
+class WP_HTML_Element {
+	const MARKER = -1;
+	public $tag;
+	public $attributes;
+	public $is_closer;
+	public $is_opener;
+	public $tag_processor_bookmark;
+	public function __construct( $tag, $attributes = null, $is_opener = true ) {
+		$this->tag        = $tag;
+		$this->attributes = $attributes;
+		$this->is_opener  = $is_opener;
+		$this->is_closer  = ! $is_opener;
+	}
+
+	public function equivalent( WP_HTML_Element $other ) {
+		if ( $this->is_closer !== $other->is_closer ) {
+			return false;
+		}
+
+		if ( $this->tag !== $other->tag ) {
+			return false;
+		}
+
+		if ( count( $this->attributes ) !== count( $other->attributes ) ) {
+			return false;
+		}
+
+		$attributes_match = true;
+		foreach ( $other->attributes as $name => $value ) {
+			if ( ! isset( $this->attributes[ $name ] ) || $this->attributes[ $name ] !== $value ) {
+				$attributes_match = false;
+				break;
+			}
+		}
+		return $attributes_match;
+	}
+
+	public function is_marker() {
+		return self::MARKER === $this->tag;
+	}
+}
+
+class WP_HTML_Insertion_Mode {
+
+	const INITIAL            = 'INITIAL';
+	const IN_SELECT          = 'IN_SELECT';
+	const IN_SELECT_IN_TABLE = 'IN_SELECT_IN_TABLE';
+	const IN_CELL            = 'IN_CELL';
+	const IN_ROW             = 'IN_ROW';
+	const IN_TABLE_BODY      = 'IN_TABLE_BODY';
+	const IN_CAPTION         = 'IN_CAPTION';
+	const IN_COLUMN_GROUP    = 'IN_COLUMN_GROUP';
+	const IN_TABLE           = 'IN_TABLE';
+	const IN_HEAD            = 'IN_HEAD';
+	const IN_BODY            = 'IN_BODY';
+	const IN_FRAMESET        = 'IN_FRAMESET';
+	const BEFORE_HEAD        = 'BEFORE_HEAD';
+	const TEXT               = 'TEXT';
+
+}
+
+/**
+ *
+ */
+class WP_HTML_Processor extends WP_HTML_Tag_Processor {
+
+	private $tag_processor;
+	/**
+	 * @var WP_HTML_Element[]
+	 */
+	private $open_elements = array();
+	/**
+	 * @var WP_HTML_Element[]
+	 */
+	private $active_formatting_elements = array();
+	private $root_node                  = null;
+	private $context_node               = null;
+	private $original_insertion_mode    = null;
+	private $insertion_mode             = null;
+
+	private $inserted_tokens = array();
+
+	private $head_pointer;
+	private $form_pointer;
+
+	public function __construct( $html ) {
+		parent::__construct( $html );
+		$this->root_node     = new WP_HTML_Element( 'HTML' );
+		$this->context_node  = new WP_HTML_Element( 'DOCUMENT' );
+		$this->open_elements = array( $this->root_node );
+		$this->reset_insertion_mode();
+	}
+
+	public function parse_next() {
+		return $this->next_tag_in_body_insertion_mode();
+		// @TODO:
+		// switch($this->insertion_mode) {
+		// case WP_HTML_Insertion_Mode::INITIAL:
+		// $this->next_tag_in_initial_mode();
+		// break;
+		// case WP_HTML_Insertion_Mode::BEFORE_HEAD:
+		// $this->next_tag_in_before_head_mode();
+		// break;
+		// case WP_HTML_Insertion_Mode::IN_HEAD:
+		// $this->next_tag_in_head_mode();
+		// break;
+		// case WP_HTML_Insertion_Mode::IN_BODY:
+		// $this->next_tag_in_body_insertion_mode();
+		// break;
+		// case WP_HTML_Insertion_Mode::IN_TABLE:
+		// $this->next_tag_in_table_insertion_mode();
+		// break;
+		// case WP_HTML_Insertion_Mode::IN_TABLE_BODY:
+		// $this->next_tag_in_table_body_insertion_mode();
+		// break;
+		// case WP_HTML_Insertion_Mode::IN_ROW:
+		// $this->next_tag_in_row_insertion_mode();
+		// break;
+		// case WP_HTML_Insertion_Mode::IN_CELL:
+		// $this->next_tag_in_cell_insertion_mode();
+		// break;
+		// case WP_HTML_Insertion_Mode::IN_SELECT:
+		// $this->next_tag_in_select_insertion_mode();
+		// break;
+		// case WP_HTML_Insertion_Mode::IN_SELECT_IN_TABLE:
+		// $this->next_tag_in_select_in_table_insertion_mode();
+		// break;
+		// case WP_HTML_Insertion_Mode::IN_CAPTION:
+		// $this->next_tag_in_caption_insertion_mode();
+		// break;
+		// case WP_HTML_Insertion_Mode::IN_COLUMN_GROUP:
+		// $this->next_tag_in_column_group_insertion_mode();
+		// break;
+		// case WP_HTML_Insertion_Mode::IN_FRAMESET:
+		// $this->next_tag_in_frameset_insertion_mode();
+		// break;
+		// case WP_HTML_Insertion_Mode::TEXT:
+		// $this->next_tag_in_text_insertion_mode();
+		// break;
+		// }
+	}
+
+	public function next_tag_in_body_insertion_mode() {
+		$token = $this->next_token();
+		if ( $token->is_opener ) {
+			// Should we care?
+			// if(self::is_rcdata_element($token->tag)) {
+			// $this->original_insertion_mode = $this->insertion_mode;
+			// $this->insertion_mode = WP_HTML_Insertion_Mode::TEXT;
+			// }
+			switch ( $token->tag ) {
+				case 'ADDRESS':
+				case 'ARTICLE':
+				case 'ASIDE':
+				case 'BLOCKQUOTE':
+				case 'CENTER':
+				case 'DETAILS':
+				case 'DIALOG':
+				case 'DIR':
+				case 'DIV':
+				case 'DL':
+				case 'FIELDSET':
+				case 'FIGCAPTION':
+				case 'FIGURE':
+				case 'FOOTER':
+				case 'HEADER':
+				case 'HGROUP':
+				case 'MAIN':
+				case 'MENU':
+				case 'NAV':
+				case 'OL':
+				case 'P':
+				case 'SECTION':
+				case 'SUMMARY':
+				case 'UL':
+					// Ignore special rules for 'PRE' and 'LISTING'
+				case 'PRE':
+				case 'LISTING':
+					if ( $this->is_element_in_button_scope( 'P' ) ) {
+						$this->close_p_element();
+					}
+					$this->insert_element( $token );
+					break;
+				// A start tag whose tag name is "h1", "h2", "h3", "h4", "h5", or "h6"
+				case 'H1':
+				case 'H2':
+				case 'H3':
+				case 'H4':
+				case 'H5':
+				case 'H6':
+					if ( $this->is_element_in_button_scope( 'P' ) ) {
+						$this->close_p_element();
+					}
+					if ( in_array( $this->current_node()->tag, array( 'H1', 'H2', 'H3', 'H4', 'H5', 'H6' ) ) ) {
+						$this->pop_open_element();
+					}
+					$this->insert_element( $token );
+					break;
+				case 'FORM':
+					if ( $this->form_pointer ) {
+						$this->ignore_token( $token );
+						return $this->next_tag();
+					}
+					if ( $this->is_element_in_button_scope( 'P' ) ) {
+						$this->close_p_element();
+					}
+					$this->form_pointer = $token;
+					$this->insert_element( $token );
+					break;
+				case 'LI':
+					$i = count( $this->open_elements ) - 1;
+					while ( true ) {
+						$node = $this->open_elements[ $i ];
+						if ( $node->tag === 'LI' ) {
+							$this->generate_implied_end_tags(
+								array(
+									'except_for' => array( 'LI' ),
+								)
+							);
+							$this->pop_until_tag_name( 'LI' );
+							break;
+						} elseif ( self::is_special_element( $node->tag, array( 'ADDRESS', 'DIV', 'P' ) ) ) {
+							break;
+						} else {
+							--$i;
+							$node = $this->open_elements[ $i ];
+						}
+					}
+
+					if ( $this->is_element_in_button_scope( 'P' ) ) {
+						$this->close_p_element();
+					}
+					$this->insert_element( $token );
+					break;
+				case 'DD':
+				case 'DT':
+					$i = count( $this->open_elements ) - 1;
+					while ( true ) {
+						$node = $this->open_elements[ $i ];
+						if ( $node->tag === 'DD' ) {
+							$this->generate_implied_end_tags(
+								array(
+									'except_for' => array( 'DD' ),
+								)
+							);
+							$this->pop_until_tag_name( 'DD' );
+							break;
+						} elseif ( $node->tag === 'DT' ) {
+							$this->generate_implied_end_tags(
+								array(
+									'except_for' => array( 'DT' ),
+								)
+							);
+							$this->pop_until_tag_name( 'DT' );
+							break;
+						} elseif ( self::is_special_element( $node->tag, array( 'ADDRESS', 'DIV', 'P' ) ) ) {
+							break;
+						} else {
+							--$i;
+							$node = $this->open_elements[ $i ];
+						}
+					}
+
+					if ( $this->is_element_in_button_scope( 'P' ) ) {
+						$this->close_p_element();
+					}
+					$this->insert_element( $token );
+					break;
+				case 'PLAINTEXT':
+					throw new Exception( 'PLAINTEXT not implemented yet' );
+				case 'BUTTON':
+					if ( $this->is_element_in_button_scope( 'BUTTON' ) ) {
+						$this->generate_implied_end_tags();
+						$this->pop_until_tag_name( 'BUTTON' );
+					}
+					$this->reconstruct_active_formatting_elements();
+					$this->insert_element( $token );
+					break;
+				case 'A':
+					$active_a = null;
+					for ( $i = count( $this->active_formatting_elements ) - 1; $i >= 0; --$i ) {
+						$elem = $this->active_formatting_elements[ $i ];
+						if ( $elem->tag === 'A' ) {
+							$active_a = $elem;
+							break;
+						} elseif ( $elem->is_marker() ) {
+							break;
+						}
+					}
+
+					if ( $active_a ) {
+						$this->parse_error();
+						// @TODO:
+						// Run the adoption agency algorithm with the tag name "a".
+					}
+
+					$this->reconstruct_active_formatting_elements();
+					$this->insert_element( $token );
+					break;
+				case 'B':
+				case 'BIG':
+				case 'CODE':
+				case 'EM':
+				case 'FONT':
+				case 'I':
+				case 'S':
+				case 'SMALL':
+				case 'STRIKE':
+				case 'STRONG':
+				case 'TT':
+				case 'U':
+					$this->reconstruct_active_formatting_elements();
+					$this->push_active_formatting_element( $token );
+					$this->insert_element( $token );
+					break;
+				case 'NOBR':
+					$this->reconstruct_active_formatting_elements();
+					if ( $this->is_element_in_scope( 'NOBR' ) ) {
+						$this->parse_error();
+						$this->adoption_agency_algorithm( $token );
+						$this->reconstruct_active_formatting_elements();
+					}
+					$this->insert_element( $token );
+					$this->push_active_formatting_element( $token );
+					break;
+				case 'APPLET':
+				case 'MARQUEE':
+				case 'OBJECT':
+					$this->reconstruct_active_formatting_elements();
+					$this->insert_element( $token );
+					$this->active_formatting_elements[] = new WP_HTML_Element( WP_HTML_Element::MARKER );
+					break;
+				case 'TABLE':
+					$this->insert_element( $token );
+					$this->insertion_mode = WP_HTML_Insertion_Mode::IN_TABLE;
+					break;
+				case 'AREA':
+				case 'BR':
+				case 'EMBED':
+				case 'IMG':
+				case 'KEYGEN':
+				case 'WBR':
+					$this->reconstruct_active_formatting_elements();
+					$this->insert_element( $token );
+					$this->pop_open_element();
+					// @TODO: Acknowledge the token's self-closing flag, if it is set.
+					break;
+				case 'PARAM':
+				case 'SOURCE':
+				case 'TRACK':
+					$this->insert_element( $token );
+					$this->pop_open_element();
+					break;
+				case 'HR':
+					if ( $this->is_element_in_button_scope( 'P' ) ) {
+						$this->close_p_element();
+					}
+					$this->insert_element( $token );
+					$this->pop_open_element();
+					break;
+				case 'IMAGE':
+					$this->parse_error();
+					// Change the tag name to "img" and reprocess the token.
+					throw new Exception( 'IMAGE not implemented yet' );
+				case 'TEXTAREA':
+					$this->insert_element( $token );
+					$this->original_insertion_mode = $this->insertion_mode;
+					$this->insertion_mode          = WP_HTML_Insertion_Mode::TEXT;
+					break;
+
+				case 'XMP':
+					if ( $this->is_element_in_button_scope( 'P' ) ) {
+						$this->close_p_element();
+					}
+					$this->reconstruct_active_formatting_elements();
+					// @TODO: Follow the generic raw text element parsing algorithm.
+					throw new Exception( 'XMP not implemented yet' );
+					break;
+				case 'IFRAME':
+				case 'NOEMBED':
+				case 'NOSCRIPT':
+					// @TODO: Follow the generic raw text element parsing algorithm.
+					throw new Exception( $token->tag . ' not implemented yet' );
+				case 'SELECT':
+					$this->reconstruct_active_formatting_elements();
+					$this->insert_element( $token );
+					if ( in_array(
+						$this->insertion_mode,
+						array(
+							WP_HTML_Insertion_Mode::IN_TABLE,
+							WP_HTML_Insertion_Mode::IN_CAPTION,
+							WP_HTML_Insertion_Mode::IN_TABLE_BODY,
+							WP_HTML_Insertion_Mode::IN_ROW,
+							WP_HTML_Insertion_Mode::IN_CELL,
+						)
+					) ) {
+						$this->insertion_mode = WP_HTML_Insertion_Mode::IN_SELECT_IN_TABLE;
+					} else {
+						$this->insertion_mode = WP_HTML_Insertion_Mode::IN_SELECT;
+					}
+					break;
+				case 'OPTGROUP':
+				case 'OPTION':
+					if ( 'OPTION' === $token->tag ) {
+						$this->pop_open_element();
+					}
+					$this->reconstruct_active_formatting_elements();
+					$this->insert_element( $token );
+					break;
+				case 'RB':
+				case 'RTC':
+					if ( $this->is_element_in_scope( 'RB' ) || $this->is_element_in_scope( 'RTC' ) ) {
+						$this->parse_error();
+						$this->adoption_agency_algorithm( $token );
+						$this->reconstruct_active_formatting_elements();
+					}
+					$this->insert_element( $token );
+					break;
+				case 'RP':
+				case 'RT':
+					if ( $this->is_element_in_scope( 'RP' ) || $this->is_element_in_scope( 'RT' ) ) {
+						$this->parse_error();
+						$this->adoption_agency_algorithm( $token );
+						$this->reconstruct_active_formatting_elements();
+					}
+					$this->insert_element( $token );
+					break;
+				case 'MATH':
+					throw new Exception( 'MATH not implemented yet' );
+				case 'SVG':
+					throw new Exception( 'SVG not implemented yet' );
+				case 'CAPTION':
+				case 'COL':
+				case 'COLGROUP':
+				case 'FRAME':
+				case 'HEAD':
+				case 'TBODY':
+				case 'TD':
+				case 'TFOOT':
+				case 'TH':
+				case 'THEAD':
+				case 'TR':
+					$this->parse_error();
+					// Ignore the token.
+					return;
+				default:
+					$this->reconstruct_active_formatting_elements();
+					$this->insert_element( $token );
+					break;
+			}
+		} else {
+			switch ( $token->tag ) {
+				case 'ADDRESS':
+				case 'ARTICLE':
+				case 'ASIDE':
+				case 'BLOCKQUOTE':
+				case 'CENTER':
+				case 'DETAILS':
+				case 'DIALOG':
+				case 'DIR':
+				case 'DIV':
+				case 'DL':
+				case 'FIELDSET':
+				case 'FIGCAPTION':
+				case 'FIGURE':
+				case 'FOOTER':
+				case 'HEADER':
+				case 'HGROUP':
+				case 'MAIN':
+				case 'MENU':
+				case 'NAV':
+				case 'OL':
+				case 'P':
+				case 'SECTION':
+				case 'SUMMARY':
+				case 'UL':
+					if ( $this->is_element_in_scope( $token->tag ) ) {
+						$this->ignore_token( $token );
+						$this->parse_error();
+						return $this->next_tag();
+					}
+					$this->generate_implied_end_tags();
+					$this->pop_until_tag_name( $token->tag );
+					break;
+				case 'FORM':
+					if ( $this->form_pointer ) {
+						$this->ignore_token( $token );
+						$this->parse_error();
+						return $this->next_tag();
+					}
+					if ( $this->is_element_in_scope( $this->form_pointer ) ) {
+						$this->ignore_token( $token );
+						$this->parse_error();
+						return $this->next_tag();
+					}
+					$this->generate_implied_end_tags();
+					array_splice( $this->open_elements, array_search( $this->form_pointer, $this->open_elements ), 1 );
+					$this->form_pointer = null;
+					break;
+				case 'P':
+					if ( ! $this->is_element_in_button_scope( 'P' ) ) {
+						// Parse error, insert an HTML element for a "p" start tag token with no attributes.
+						$this->parse_error();
+						$this->insert_element( new WP_HTML_Element( 'P', array() ) );
+					}
+					$this->close_p_element();
+					break;
+				case 'LI':
+					if ( $this->is_element_in_list_item_scope( 'LI' ) ) {
+						$this->ignore_token( $token );
+						$this->parse_error();
+						return $this->next_tag();
+					}
+					$this->generate_implied_end_tags();
+					$this->pop_until_tag_name( 'LI' );
+					break;
+				case 'DD':
+				case 'DT':
+					if ( $this->is_element_in_scope( $token->tag ) ) {
+						$this->ignore_token( $token );
+						$this->parse_error();
+						return $this->next_tag();
+					}
+					$this->generate_implied_end_tags();
+					$this->pop_until_tag_name( $token->tag );
+					break;
+				case 'H1':
+				case 'H2':
+				case 'H3':
+				case 'H4':
+				case 'H5':
+				case 'H6':
+					if ( $this->is_element_in_scope( array( 'H1', 'H2', 'H3', 'H4', 'H5', 'H6' ) ) ) {
+						$this->ignore_token( $token );
+						$this->parse_error();
+						return $this->next_tag();
+					}
+					$this->generate_implied_end_tags();
+					$this->pop_until_tag_name( array( 'H1', 'H2', 'H3', 'H4', 'H5', 'H6' ) );
+					break;
+				case 'A':
+				case 'B':
+				case 'BIG':
+				case 'CODE':
+				case 'EM':
+				case 'FONT':
+				case 'I':
+				case 'S':
+				case 'SMALL':
+				case 'STRIKE':
+				case 'STRONG':
+				case 'TT':
+				case 'U':
+					$this->parse_error();
+					$this->adoption_agency_algorithm( $token );
+					break;
+
+				case 'APPLET':
+				case 'MARQUEE':
+				case 'OBJECT':
+					if ( $this->is_element_in_scope( $token->tag ) ) {
+						$this->ignore_token( $token );
+						$this->parse_error();
+						return $this->next_tag();
+					}
+					$this->generate_implied_end_tags();
+					if ( $this->current_node()->tag !== $token->tag ) {
+						$this->parse_error();
+					}
+					$this->pop_until_tag_name( $token->tag );
+					$this->clear_active_formatting_elements_up_to_last_marker();
+					break;
+				case 'BR':
+					// This should never happen since Tag_Processor corrects that
+				default:
+					$i = count( $this->open_elements ) - 1;
+					while ( true ) {
+						$node = $this->open_elements[ $i ];
+						if ( $node->tag === $token->tag ) {
+							$this->generate_implied_end_tags(
+								array(
+									'except_for' => array( $token->tag ),
+								)
+							);
+							$this->pop_until_node( $node );
+							break;
+						} elseif ( $this->is_special_element( $node->tag ) ) {
+							$this->ignore_token( $token );
+							$this->parse_error();
+							return $this->next_tag();
+						} else {
+							--$i;
+						}
+					}
+					break;
+			}
+		}
+	}
+
+	private $element_bookmark_idx = 0;
+	private function next_token() {
+		if ( ! $this->next_tag( array( 'tag_closers' => 'visit' ) ) ) {
+			return false;
+		}
+
+		$consumed_node = new WP_HTML_Element(
+			$this->get_tag(),
+			array(),
+			! $this->is_tag_closer()
+		);
+
+		$consumed_node->tag_processor_bookmark = $this->set_bookmark(
+			'__internal_' . ( $this->element_bookmark_idx++ )
+		);
+
+		return $consumed_node;
+	}
+
+	const ANY_OTHER_END_TAG = 1;
+	private function adoption_agency_algorithm( WP_HTML_Element $token ) {
+		$subject = $token->tag;
+		if (
+			$this->current_node()->tag === $subject
+			&& ! in_array( $subject, $this->active_formatting_elements, true )
+		) {
+			$this->pop_open_element();
+			return;
+		}
+
+		$outer_loop_counter = 0;
+		while ( ++$outer_loop_counter < 8 ) {
+			/*
+			 * Let __formatting element__ be the last element in the list of active
+			 * formatting elements that:
+			 *    - is between the end of the list and the last marker in the list,
+			 *      if any, or the start of the list otherwise, and
+			 *    - has the same tag name as the token.
+			 */
+			$formatting_element     = null;
+			$formatting_element_idx = -1;
+			for ( $i = count( $this->active_formatting_elements ) - 1; $i >= 0; $i-- ) {
+				$candidate = $this->active_formatting_elements[ $i ];
+				if ( $candidate->is_marker() ) {
+					break;
+				}
+				if ( $candidate->tag === $subject ) {
+					$formatting_element     = $candidate;
+					$formatting_element_idx = $i;
+					break;
+				}
+			}
+			// If there is no such element, then abort these steps and instead act as
+			// described in the "any other end tag" entry below.
+			if ( null === $formatting_element ) {
+				return self::ANY_OTHER_END_TAG;
+			}
+
+			// If formatting element is not in the stack of open elements, then this is
+			// a parse error; remove the element from the list, and return.
+			if ( ! in_array( $formatting_element, $this->open_elements, true ) ) {
+				array_splice( $this->active_formatting_elements, $formatting_element_idx, 1 );
+				$this->parse_error();
+				return;
+			}
+
+			// If formatting element is not in scope, then this is a parse error; return
+			if ( ! $this->is_element_in_scope( $formatting_element->tag ) ) {
+				$this->parse_error();
+				return;
+			}
+
+			// If formatting element is not the current node, then this is a parse error.
+			// (But do not return.)
+			if ( $formatting_element !== $this->current_node() ) {
+				$this->parse_error();
+			}
+
+			/*
+			 * Let furthest block be the topmost node in the stack of open elements that
+			 * is lower in the stack than formatting element, and is an element in the
+			 * special category. There might not be one.
+			 */
+			$furthest_block = null;
+			for ( $i = count( $this->open_elements ) - 1; $i >= 0; $i-- ) {
+				$node = $this->open_elements[ $i ];
+				if ( $node === $formatting_element ) {
+					break;
+				}
+				if ( $this->is_special_element( $node->tag ) ) {
+					$furthest_block = $node;
+					break;
+				}
+			}
+
+			// If there is no such node, then the UA must first pop all the nodes from
+			// the bottom of the stack of open elements, from the current node up to
+			// and including formatting element, then remove formatting element from
+			// the list of active formatting elements, and finally abort these steps.
+			if ( null === $furthest_block ) {
+				$this->pop_until_node( $formatting_element );
+				array_splice( $this->active_formatting_elements, $formatting_element_idx, 1 );
+				return;
+			}
+
+			// Let common ancestor be the element immediately above formatting element
+			// in the stack of open elements.
+			$formatting_elem_stack_index = array_search( $formatting_element, $this->open_elements, true );
+			$common_ancestor             = $this->open_elements[ $formatting_elem_stack_index - 1 ];
+
+			// Let a bookmark note the position of formatting element in the list of
+			// active formatting elements relative to the elements on either side of it
+			// in the list.
+			$bookmark = $formatting_element_idx;
+
+			// Let node and last node be furthest block.
+			$node                     = $last_node = $furthest_block;
+			$node_open_elements_index = array_search( $node, $this->open_elements, true );
+
+			$prev_node_open_elements_index = -1;
+			$inner_loop_counter            = 0;
+			while ( true ) {
+				$inner_loop_counter++;
+
+				/**
+				 * Let node be the element immediately above node in the stack of open elements,
+				 * or if node is no longer in the stack of open elements (e.g. because it got
+				 * removed by this algorithm), the element that was immediately above node in
+				 * the stack of open elements before node was removed.
+				 */
+				$node_open_elements_index = array_search( $node, $this->open_elements, true );
+				if ( false === $node_open_elements_index ) {
+					$node_open_elements_index = $prev_node_open_elements_index;
+					return;
+				}
+				--$node_open_elements_index;
+				$node                          = $this->open_elements[ $node_open_elements_index ];
+				$prev_node_open_elements_index = $node_open_elements_index;
+
+				// If node is formatting element, then break.
+				if ( $node === $formatting_element ) {
+					break;
+				}
+
+				/*
+				 * If inner loop counter is greater than 3 and node is in the list
+				 * of active formatting elements, then remove node from the list of
+				 * active formatting elements.
+				 */
+				if ( $inner_loop_counter > 3 && in_array( $node, $this->active_formatting_elements, true ) ) {
+					$node_formatting_idx = array_search( $node, $this->active_formatting_elements, true );
+					array_splice( $this->active_formatting_elements, $node_formatting_idx, 1 );
+				}
+
+				/*
+				 * If node is not in the list of active formatting elements, then remove
+				 * node from the stack of open elements and continue.
+				 */
+				if ( ! in_array( $node, $this->active_formatting_elements, true ) ) {
+					array_splice( $this->open_elements, $node_open_elements_index, 1 );
+					continue;
+				}
+
+				/*
+				 * Create an element for the token for which the element node was created,
+				 * in the HTML namespace, with common ancestor as the intended parent.
+				 *
+				 * Replace the entry for node in the list of active formatting elements with an entry
+				 * for the new element.
+				 *
+				 * Replace the entry for node in the stack of open elements with an entry for
+				 * the new element.
+				 *
+				 * Let node be the new element.
+				 */
+				$new_node            = new WP_HTML_Element( $node->tag, array() );
+				$node_formatting_idx = array_search( $node, $this->active_formatting_elements, true );
+				$this->active_formatting_elements[ $node_formatting_idx ] = $new_node;
+
+				$node_open_elements_index                         = array_search( $node, $this->open_elements, true );
+				$this->open_elements[ $node_open_elements_index ] = $new_node;
+				$node = $new_node;
+
+				/*
+				 * If last node is furthest block, then move the aforementioned bookmark to be
+				 * immediately after the new node in the list of active formatting elements.
+				 */
+				if ( $last_node === $furthest_block ) {
+					$bookmark = $node_formatting_idx + 1;
+				}
+
+				// Append last node to node.
+				// @TODO
+
+				// Set last node to node.
+				$last_node = $node;
+			}
+
+			// Insert whatever last node ended up being in the previous step at the appropriate place
+			// for inserting a node, but using common ancestor as the override target.
+			// @TODO
+
+			// Create an element for the token for which formatting element was created, in the HTML
+			// namespace, with furthest block as the intended parent.
+			$new_element = new WP_HTML_Element( $formatting_element->tag, array() );
+
+			// Take all of the child nodes of furthest block and append them to the element created in
+			// the last step.
+			// @TODO
+
+			// Append that new element to furthest block.
+			// @TODO
+
+			// Remove formatting element from the list of active formatting elements, and insert the new
+			// element into the list of active formatting elements at the position of the aforementioned
+			// bookmark.
+			$formatting_element_idx = array_search( $formatting_element, $this->active_formatting_elements, true );
+			array_splice( $this->active_formatting_elements, $formatting_element_idx, 1, array( $new_element ) );
+			array_splice( $this->active_formatting_elements, $bookmark, 0, array( $new_element ) );
+
+			// Remove formatting element from the stack of open elements, and insert the new element into
+			// the stack of open elements immediately below the position of furthest block in that stack.
+			$formatting_element_idx = array_search( $formatting_element, $this->active_formatting_elements, true );
+			array_splice( $this->active_formatting_elements, $formatting_element_idx, 1, array( $new_element ) );
+
+			$furthest_block_idx = array_search( $furthest_block, $this->open_elements, true );
+			array_splice( $this->open_elements, $furthest_block_idx + 1, 0, array( $new_element ) );
+		}
+	}
+
+	/*
+		@TODO Implement https://html.spec.whatwg.org/multipage/parsing.html#insert-a-foreign-element
+
+		Let the adjusted insertion location be the appropriate place for inserting a node.
+
+		Let element be the result of creating an element for the token in the given namespace, with the intended parent being the element in which the adjusted insertion location finds itself.
+
+		If it is possible to insert element at the adjusted insertion location, then:
+
+		If the parser was not created as part of the HTML fragment parsing algorithm, then push a new element queue onto element's relevant agent's custom element reactions stack.
+
+		Insert element at the adjusted insertion location.
+
+		If the parser was not created as part of the HTML fragment parsing algorithm, then pop the element queue from element's relevant agent's custom element reactions stack, and invoke custom element reactions in that queue.
+
+		If the adjusted insertion location cannot accept more elements, e.g. because it's a Document that already has an element child, then element is dropped on the floor.
+
+		Push element onto the stack of open elements so that it is the new current node.
+
+		Return element.
+
+	*/
+	private function insert_html_element( $node ) {
+		if ( ! $node->is_closer ) {
+			$this->insert_element( $node );
+		}
+		$this->inserted_tokens[] = $node;
+	}
+
+	private function ignore_token( $token ) {
+		if ( $token->tag_processor_bookmark ) {
+			$this->release_bookmark( $token->tag_processor_bookmark );
+			$token->tag_processor_bookmark = null;
+		}
+		return;
+	}
+
+	private function insert_element( $node ) {
+		$this->open_elements[] = $node;
+	}
+
+	private function parse_error() {
+		// Noop for now
+	}
+
+	private function pop_until_tag_name( $tags ) {
+		if ( ! is_array( $tags ) ) {
+			$tags = array( $tags );
+		}
+		while ( ! in_array( $this->current_node()->tag, $tags ) ) {
+			$this->pop_open_element();
+		}
+	}
+
+	private function pop_until_node( $node ) {
+		do {
+			$popped = $this->pop_open_element();
+		} while ( $popped !== $node );
+	}
+
+	private function pop_open_element() {
+		$popped = array_pop( $this->open_elements );
+		if ( $popped->tag_processor_bookmark ) {
+			$this->release_bookmark( $popped->tag_processor_bookmark );
+			$popped->tag_processor_bookmark = null;
+		}
+		return $popped;
+	}
+
+	private function generate_implied_end_tags( $options = null ) {
+		while ( $this->should_generate_implied_end_tags( $options ) ) {
+			yield $this->pop_open_element();
+		}
+	}
+
+	private function current_node() {
+		return end( $this->open_elements );
+	}
+
+	private function close_p_element() {
+		$this->generate_implied_end_tags(
+			array(
+				'except_for' => array( 'P' ),
+			)
+		);
+		// If the current node is not a p element, then this is a parse error.
+		if ( $this->current_node()->tag !== 'P' ) {
+			$this->parse_error();
+		}
+		$this->pop_until_tag_name( 'P' );
+	}
+
+	private function should_generate_implied_end_tags( $options = null ) {
+		$current_tag_name = $this->current_node()->tag;
+		if ( null !== $options && isset( $options['except_for'] ) && in_array( $current_tag_name, $options['except_for'] ) ) {
+			return false;
+		}
+		switch ( $current_tag_name ) {
+			case 'DD':
+			case 'DT':
+			case 'LI':
+			case 'OPTION':
+			case 'OPTGROUP':
+			case 'P':
+			case 'RB':
+			case 'RP':
+			case 'RT':
+			case 'RTC':
+				return true;
+		}
+
+		$thoroughly = null !== $options && isset( $options['thoroughly'] ) && $options['thoroughly'];
+		if ( $thoroughly ) {
+			switch ( $current_tag_name ) {
+				case 'TBODY':
+				case 'TFOOT':
+				case 'THEAD':
+				case 'TD':
+				case 'TH':
+				case 'TR':
+					return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * https://html.spec.whatwg.org/multipage/parsing.html#the-list-of-active-formatting-elements
+	 */
+	private function push_active_formatting_element( $node ) {
+		$count = 0;
+		for ( $i = count( $this->active_formatting_elements ) - 1; $i >= 0; $i-- ) {
+			$formatting_element = $this->active_formatting_elements[ $i ];
+			if ( $formatting_element->is_marker() ) {
+				break;
+			}
+			if ( ! $node->equivalent( $node ) ) {
+				continue;
+			}
+			$count++;
+			if ( $count === 3 ) {
+				array_splice( $this->active_formatting_elements, $i, 1 );
+				break;
+			}
+		}
+		$this->active_formatting_elements[] = $node;
+	}
+
+	private function reconstruct_active_formatting_elements() {
+		if ( empty( $this->active_formatting_elements ) ) {
+			return;
+		}
+		$i          = count( $this->active_formatting_elements ) - 1;
+		$last_entry = $this->active_formatting_elements[ $i ];
+		if ( $last_entry->is_marker() || in_array( $last_entry, $this->open_elements, true ) ) {
+			return;
+		}
+		$entry = $last_entry;
+		while ( true ) {
+			if ( $i <= 0 ) {
+				break;
+			}
+			--$i;
+			$entry = $this->active_formatting_elements[ $i ];
+			if ( $entry->is_marker() || in_array( $entry, $this->open_elements, true ) ) {
+				break;
+			}
+		}
+		while ( true ) {
+			++$i;
+			$entry = $this->active_formatting_elements[ $i ];
+			if ( $entry === $last_entry ) {
+				break;
+			}
+
+			// @TODO:
+			// Create: Insert an HTML element for the token for which the element entry
+			// was created, to obtain new element.
+			$new_element = new WP_HTML_Element( $entry->tag, $entry->attributes );
+
+			// Replace the entry for entry in the list with an entry for new element.
+			$index = array_search( $entry, $this->active_formatting_elements, true );
+
+			$this->active_formatting_elements[ $index ] = $new_element;
+			if ( $index === count( $this->active_formatting_elements ) - 1 ) {
+				break;
+			}
+		}
+	}
+
+	private function clear_active_formatting_elements_up_to_last_marker() {
+		while ( ! empty( $this->active_formatting_elements ) ) {
+			$entry = array_pop( $this->active_formatting_elements );
+			if ( $entry->is_marker() ) {
+				break;
+			}
+		}
+	}
+
+	private function is_element_in_select_scope( $target_node ) {
+		return $this->is_element_in_specific_scope(
+			$target_node,
+			array(
+				'optgroup',
+				'option',
+			),
+			array(
+				'negative_match' => 'true',
+			)
+		);
+	}
+
+	private function is_element_in_table_scope( $target_node ) {
+		return $this->is_element_in_specific_scope(
+			$target_node,
+			array(
+				'html',
+				'table',
+				'template',
+			)
+		);
+	}
+
+	private function is_element_in_button_scope( $target_node ) {
+		return $this->is_element_in_scope(
+			$target_node,
+			array(
+				'button',
+			)
+		);
+	}
+
+	private function is_element_in_list_item_scope( $target_node ) {
+		return $this->is_element_in_scope(
+			$target_node,
+			array(
+				'li',
+				'dd',
+				'dt',
+			)
+		);
+	}
+
+	private function is_element_in_scope( $target_node, $additional_elements = array() ) {
+		return $this->is_element_in_specific_scope(
+			$target_node,
+			array_merge(
+				array(
+					'applet',
+					'caption',
+					'html',
+					'table',
+					'td',
+					'th',
+					'marquee',
+					'object',
+					'template',
+				),
+				$additional_elements
+			)
+		);
+	}
+
+	/**
+	 * https://html.spec.whatwg.org/multipage/parsing.html#the-stack-of-open-elements
+	 */
+	private function is_element_in_specific_scope( $target_node, $element_types_list, $options = array() ) {
+		$negative_match = isset( $options['negative_match'] ) ? $options['negative_match'] : false;
+		$i              = count( $this->open_elements ) - 1;
+		while ( true ) {
+			$node = $this->open_elements[ $i ];
+
+			if ( $node === $target_node ) {
+				return true;
+			}
+
+			$is_in_the_list = in_array( $node->tag, $element_types_list, true );
+			$failure        = $negative_match ? $is_in_the_list : ! $is_in_the_list;
+			if ( $failure ) {
+				return false;
+			}
+		}
+	}
+
+	/**
+	 * https://html.spec.whatwg.org/multipage/parsing.html#reset-the-insertion-mode-appropriately
+	 */
+	private function reset_insertion_mode() {
+		$last = false;
+		$node = end( $this->open_elements );
+
+		while ( true ) {
+			if ( count( $this->open_elements ) === 1 && $node === reset( $this->open_elements ) ) {
+				$last = true;
+				$node = $this->context_node;
+			}
+
+			if ( $node->tag === 'select' ) {
+				if ( $last ) {
+					break;
+				}
+
+				$ancestor = $node;
+				while ( true ) {
+					if ( $ancestor === $this->open_elements[0] ) {
+						break;
+					}
+
+					$index    = array_search( $ancestor, $this->open_elements );
+					$ancestor = $this->open_elements[ $index - 1 ];
+					if ( $ancestor->tag === 'template' ) {
+						break;
+					}
+
+					if ( $ancestor->tag === 'table' ) {
+						$this->insertion_mode = wP_HTML_Insertion_Mode::IN_SELECT_IN_TABLE;
+						return;
+					}
+				}
+
+				$this->insertion_mode = wP_HTML_Insertion_Mode::IN_SELECT;
+				return;
+			}
+
+			switch ( $node->tag ) {
+				case 'TD':
+				case 'TH':
+					if ( ! $last ) {
+						$this->insertion_mode = wP_HTML_Insertion_Mode::IN_CELL;
+						return;
+					}
+					break;
+				case 'TR':
+					$this->insertion_mode = wP_HTML_Insertion_Mode::IN_ROW;
+					return;
+				case 'TBODY':
+				case 'THEAD':
+				case 'TFOOT':
+					$this->insertion_mode = wP_HTML_Insertion_Mode::IN_TABLE_BODY;
+					return;
+				case 'CAPTION':
+					$this->insertion_mode = wP_HTML_Insertion_Mode::IN_CAPTION;
+					return;
+				case 'COLGROUP':
+					$this->insertion_mode = wP_HTML_Insertion_Mode::IN_COLUMN_GROUP;
+					return;
+				case 'TABLE':
+					$this->insertion_mode = wP_HTML_Insertion_Mode::IN_TABLE;
+					return;
+				case 'TEMPLATE':
+					// TODO: implement the current template insertion mode
+					$this->insertion_mode = 0;
+					return;
+				case 'HEAD':
+					if ( ! $last ) {
+						$this->insertion_mode = wP_HTML_Insertion_Mode::IN_HEAD;
+						return;
+					}
+					break;
+				case 'BODY':
+					$this->insertion_mode = wP_HTML_Insertion_Mode::IN_BODY;
+					return;
+				case 'FRAMESET':
+					$this->insertion_mode = wP_HTML_Insertion_Mode::IN_FRAMESET;
+					return;
+				case 'HTML':
+					// TODO: implement the head element pointer
+					$this->insertion_mode = WP_HTML_Insertion_Mode::BEFORE_HEAD;
+					return;
+				default:
+					if ( $last ) {
+						$this->insertion_mode = wP_HTML_Insertion_Mode::IN_BODY;
+						return;
+					}
+			}
+
+			$index = array_search( $node, $this->open_elements );
+			$node  = $this->open_elements[ $index - 1 ];
+		}
+
+		$this->insertion_mode = wP_HTML_Insertion_Mode::IN_BODY;
+	}
+
+
+	private static function is_special_element( $tag_name, $except = null ) {
+		if ( null !== $except && in_array( $tag_name, $except, true ) ) {
+			return false;
+		}
+
+		switch ( $tag_name ) {
+			case 'ADDRESS':
+			case 'APPLET':
+			case 'AREA':
+			case 'ARTICLE':
+			case 'ASIDE':
+			case 'BASE':
+			case 'BASEFONT':
+			case 'BGSOUND':
+			case 'BLOCKQUOTE':
+			case 'BODY':
+			case 'BR':
+			case 'BUTTON':
+			case 'CAPTION':
+			case 'CENTER':
+			case 'COL':
+			case 'COLGROUP':
+			case 'DD':
+			case 'DETAILS':
+			case 'DIR':
+			case 'DIV':
+			case 'DL':
+			case 'DT':
+			case 'EMBED':
+			case 'FIELDSET':
+			case 'FIGCAPTION':
+			case 'FIGURE':
+			case 'FOOTER':
+			case 'FORM':
+			case 'FRAME':
+			case 'FRAMESET':
+			case 'H1':
+			case 'H2':
+			case 'H3':
+			case 'H4':
+			case 'H5':
+			case 'H6':
+			case 'HEAD':
+			case 'HEADER':
+			case 'HGROUP':
+			case 'HR':
+			case 'HTML':
+			case 'IFRAME':
+			case 'IMG':
+			case 'INPUT':
+			case 'ISINDEX':
+			case 'LI':
+			case 'LINK':
+			case 'LISTING':
+			case 'MAIN':
+			case 'MARQUEE':
+			case 'MENU':
+			case 'MENUITEM':
+			case 'META':
+			case 'NAV':
+			case 'NOEMBED':
+			case 'NOFRAMES':
+			case 'NOSCRIPT':
+			case 'OBJECT':
+			case 'OL':
+			case 'P':
+			case 'PARAM':
+			case 'PLAINTEXT':
+			case 'PRE':
+			case 'SCRIPT':
+			case 'SECTION':
+			case 'SELECT':
+			case 'SOURCE':
+			case 'STYLE':
+			case 'SUMMARY':
+			case 'TABLE':
+			case 'TBODY':
+			case 'TD':
+			case 'TEMPLATE':
+			case 'TEXTAREA':
+			case 'TFOOT':
+			case 'TH':
+			case 'THEAD':
+			case 'TITLE':
+			case 'TR':
+			case 'TRACK':
+			case 'UL':
+			case 'WBR':
+			case 'XMP':
+				return true;
+			default:
+				return false;
+		}
+	}
+
+	private static function is_rcdata_element( $tag_name ) {
+		switch ( $tag_name ) {
+			case 'TITLE':
+			case 'TEXTAREA':
+			case 'STYLE':
+			case 'XMP':
+			case 'IFRAME':
+			case 'NOEMBED':
+			case 'NOFRAMES':
+			case 'NOSCRIPT':
+				return true;
+			default:
+				return false;
+		}
+	}
+
+	private static function is_formatting_element( $tag_name ) {
+		switch ( strtoupper( $tag_name ) ) {
+			case 'A':
+			case 'B':
+			case 'BIG':
+			case 'CODE':
+			case 'EM':
+			case 'FONT':
+			case 'I':
+			case 'NOBR':
+			case 'S':
+			case 'SMALL':
+			case 'STRIKE':
+			case 'STRONG':
+			case 'TT':
+			case 'U':
+				return true;
+			default:
+				return false;
+		}
+	}
+
+}
+
+
+$p = new WP_HTML_Processor( '<p>Lorem<b>Ipsum</p>Dolor</b>Sit' );
+// The controller's schema is hardcoded, so tests would not be meaningful.
+$p->parse_next();
+
+// $this->tag_processor->next_tag(
+//     array(
+//         'tag_closers' => 'visit',
+//     )
+// );
+// var_dump( $this->tag_processor->get_tag() );
+// var_dump( $this->tag_processor->is_tag_closer() );
+// $last_parent = end( $this->open_elements );

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -11,6 +11,15 @@ if ( ! class_exists( 'WP_HTML_Tag_Processor' ) ) {
 	}
 }
 
+function dbg( $message, $indent = 0 ) {
+	$show_debug = true;
+	// $show_debug = false;
+	if( $show_debug ) {
+		$indent = str_repeat( ' ', $indent * 2 );
+		echo $indent . $message . "\n";
+	}
+}
+
 class WP_HTML_Token {
 	const MARKER = 1;
 	const TAG = 2;
@@ -33,7 +42,7 @@ class WP_HTML_Token {
 	}
 
 	static public function tag( $tag, $attributes = null, $is_opener = true, $bookmark = null ) {
-		$token = new WP_HTML_Token( self::TAG, $tag );
+		$token = new WP_HTML_Token( self::TAG );
 		$token->tag        = $tag;
 		$token->attributes = $attributes;
 		$token->is_opener  = $is_opener;
@@ -108,6 +117,46 @@ class WP_HTML_Token {
 	}
 }
 
+class WP_HTML_Node {
+	public $parent;
+	public $children = array();
+	public $token;
+	public $depth = 1;
+
+	// For the adoption agency algorithm:
+	public $intended_parent = null;
+
+	public function __construct( WP_HTML_Token $token ) {
+		$this->token = $token;
+	}
+
+	public function append_child( WP_HTML_Node $node ) {
+		if($node->parent) {
+			$node->parent->remove($node);
+		}
+		$node->parent = $this;
+		$this->children[] = $node;
+		$node->depth = $this->depth + 1;
+	}
+
+	public function remove( WP_HTML_Node $node ) {
+		$index = array_search( $node, $this->children, true );
+		if ( false !== $index ) {
+			unset( $this->children[ $index ] );
+		}
+	}
+
+	public function __toString() {
+		$out = '';
+		$indent = str_repeat( ' ', $this->depth );
+		$out .= $indent . $this->token . "\n";
+		foreach ( $this->children as $child ) {
+			$out .= $child;
+		}
+		return $out;
+	}
+}
+
 class WP_HTML_Insertion_Mode {
 
 	const INITIAL            = 'INITIAL';
@@ -133,11 +182,11 @@ class WP_HTML_Insertion_Mode {
 class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 
 	/**
-	 * @var WP_HTML_Token[]
+	 * @var WP_HTML_Node[]
 	 */
 	private $open_elements = array();
 	/**
-	 * @var WP_HTML_Token[]
+	 * @var WP_HTML_Node[]
 	 */
 	private $active_formatting_elements = array();
 	private $root_node                  = null;
@@ -166,23 +215,24 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 
 	public function __construct( $html ) {
 		parent::__construct( $html );
-		$this->root_node     = WP_HTML_Token::tag( 'HTML' );
-		$this->context_node  = WP_HTML_Token::tag( 'DOCUMENT' );
+		$this->root_node     = new WP_HTML_Node(WP_HTML_Token::tag( 'HTML' ));
+		$this->context_node  = new WP_HTML_Node(WP_HTML_Token::tag( 'DOCUMENT' ));
 		$this->open_elements = array( $this->root_node );
 		$this->reset_insertion_mode();
 	}
 
-	public function main() {
-		for ($i = 0; $i < 10; $i++) {
-			$token = $this->next_token();
-			if(!$token) {
-				break;
-			}
-			echo "TOKEN: $token\n";
+	public function parse() {
+		echo("HTML before main loop:\n");
+		echo($this->html);
+		echo("\n\n");
+		while ($token = $this->next_token()) {
 			$this->last_token = $token;
-			// $processed_token = $this->process_in_body_insertion_mode($token);
-			// $this->last_token = $processed_token;
+			$processed_token = $this->process_in_body_insertion_mode($token);
+			$this->last_token = $processed_token;
 		}
+		echo("\n");
+		echo("DOM after main loop:\n");
+		echo($this->root_node.'');
 		// @TODO:
 		// switch($this->insertion_mode) {
 		// case WP_HTML_Insertion_Mode::INITIAL:
@@ -232,7 +282,10 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 
 	public function process_in_body_insertion_mode(WP_HTML_Token $token) {
 		if ( $token->is_text() ) {
-			// ?
+			dbg( "Found text node '$token'" );
+			dbg( "Inserting text to current node " . $this->current_node()->token->tag, 1 );
+			$this->reconstruct_active_formatting_elements();
+			$this->insert_text( $token );
 		}
 		else if ( $token->is_opener ) {
 			// Should we care?
@@ -268,6 +321,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					// Ignore special rules for 'PRE' and 'LISTING'
 				case 'PRE':
 				case 'LISTING':
+					dbg( "Found {$token->tag} tag opener" );
 					if ( $this->is_element_in_button_scope( 'P' ) ) {
 						$this->close_p_element();
 					}
@@ -283,7 +337,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					if ( $this->is_element_in_button_scope( 'P' ) ) {
 						$this->close_p_element();
 					}
-					if ( in_array( $this->current_node()->tag, array( 'H1', 'H2', 'H3', 'H4', 'H5', 'H6' ) ) ) {
+					if ( in_array( $this->current_node()->token->tag, array( 'H1', 'H2', 'H3', 'H4', 'H5', 'H6' ) ) ) {
 						$this->pop_open_element();
 					}
 					$this->insert_element( $token );
@@ -303,7 +357,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					$i = count( $this->open_elements ) - 1;
 					while ( true ) {
 						$node = $this->open_elements[ $i ];
-						if ( $node->tag === 'LI' ) {
+						if ( $node->token->tag === 'LI' ) {
 							$this->generate_implied_end_tags(
 								array(
 									'except_for' => array( 'LI' ),
@@ -311,7 +365,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 							);
 							$this->pop_until_tag_name( 'LI' );
 							break;
-						} elseif ( self::is_special_element( $node->tag, array( 'ADDRESS', 'DIV', 'P' ) ) ) {
+						} elseif ( self::is_special_element( $node->token->tag, array( 'ADDRESS', 'DIV', 'P' ) ) ) {
 							break;
 						} else {
 							--$i;
@@ -329,7 +383,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					$i = count( $this->open_elements ) - 1;
 					while ( true ) {
 						$node = $this->open_elements[ $i ];
-						if ( $node->tag === 'DD' ) {
+						if ( $node->token->tag === 'DD' ) {
 							$this->generate_implied_end_tags(
 								array(
 									'except_for' => array( 'DD' ),
@@ -337,7 +391,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 							);
 							$this->pop_until_tag_name( 'DD' );
 							break;
-						} elseif ( $node->tag === 'DT' ) {
+						} elseif ( $node->token->tag === 'DT' ) {
 							$this->generate_implied_end_tags(
 								array(
 									'except_for' => array( 'DT' ),
@@ -345,7 +399,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 							);
 							$this->pop_until_tag_name( 'DT' );
 							break;
-						} elseif ( self::is_special_element( $node->tag, array( 'ADDRESS', 'DIV', 'P' ) ) ) {
+						} elseif ( self::is_special_element( $node->token->tag, array( 'ADDRESS', 'DIV', 'P' ) ) ) {
 							break;
 						} else {
 							--$i;
@@ -371,11 +425,11 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				case 'A':
 					$active_a = null;
 					for ( $i = count( $this->active_formatting_elements ) - 1; $i >= 0; --$i ) {
-						$elem = $this->active_formatting_elements[ $i ];
-						if ( $elem->tag === 'A' ) {
-							$active_a = $elem;
+						$node = $this->active_formatting_elements[ $i ];
+						if ( $node->token->tag === 'A' ) {
+							$active_a = $node;
 							break;
-						} elseif ( $elem->is_marker() ) {
+						} elseif ( $node->token->is_marker() ) {
 							break;
 						}
 					}
@@ -400,9 +454,10 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				case 'STRONG':
 				case 'TT':
 				case 'U':
+					dbg( "Found {$token->tag} tag opener" );
 					$this->reconstruct_active_formatting_elements();
-					$this->push_active_formatting_element( $token );
-					$this->insert_element( $token );
+					$node = $this->insert_element( $token );
+					$this->push_active_formatting_element( $node );
 					break;
 				case 'NOBR':
 					$this->reconstruct_active_formatting_elements();
@@ -411,8 +466,8 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 						$this->adoption_agency_algorithm( $token );
 						$this->reconstruct_active_formatting_elements();
 					}
-					$this->insert_element( $token );
-					$this->push_active_formatting_element( $token );
+					$node = $this->insert_element( $token );
+					$this->push_active_formatting_element( $node );
 					break;
 				case 'APPLET':
 				case 'MARQUEE':
@@ -466,7 +521,6 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					$this->reconstruct_active_formatting_elements();
 					// @TODO: Follow the generic raw text element parsing algorithm.
 					throw new Exception( 'XMP not implemented yet' );
-					break;
 				case 'IFRAME':
 				case 'NOEMBED':
 				case 'NOSCRIPT':
@@ -561,7 +615,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				case 'MENU':
 				case 'NAV':
 				case 'OL':
-				case 'P':
+				case 'PRE':
 				case 'SECTION':
 				case 'SUMMARY':
 				case 'UL':
@@ -589,6 +643,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					$this->form_pointer = null;
 					break;
 				case 'P':
+					dbg( "Found {$token->tag} tag closer" );
 					if ( ! $this->is_element_in_button_scope( 'P' ) ) {
 						// Parse error, insert an HTML element for a "p" start tag token with no attributes.
 						$this->parse_error();
@@ -642,7 +697,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				case 'STRONG':
 				case 'TT':
 				case 'U':
-					$this->parse_error();
+					dbg( "Found {$token->tag} tag closer" );
 					$this->adoption_agency_algorithm( $token );
 					break;
 
@@ -655,7 +710,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 						return $this->next_tag();
 					}
 					$this->generate_implied_end_tags();
-					if ( $this->current_node()->tag !== $token->tag ) {
+					if ( $this->current_node()->token->tag !== $token->tag ) {
 						$this->parse_error();
 					}
 					$this->pop_until_tag_name( $token->tag );
@@ -667,7 +722,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					$i = count( $this->open_elements ) - 1;
 					while ( true ) {
 						$node = $this->open_elements[ $i ];
-						if ( $node->tag === $token->tag ) {
+						if ( $node->token->tag === $token->tag ) {
 							$this->generate_implied_end_tags(
 								array(
 									'except_for' => array( $token->tag ),
@@ -675,7 +730,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 							);
 							$this->pop_until_node( $node );
 							break;
-						} elseif ( $this->is_special_element( $node->tag ) ) {
+						} elseif ( $this->is_special_element( $node->token->tag ) ) {
 							$this->ignore_token( $token );
 							$this->parse_error();
 							return $this->next_tag();
@@ -697,18 +752,20 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			return $next_tag;
 		}
 
-		if ( ! $this->next_tag( array( 'tag_closers' => 'visit' ) ) ) {
-			return false;
+		$next_tag = false;
+		if ( $this->next_tag( array( 'tag_closers' => 'visit' ) ) ) {
+			$bookmark = '__internal_' . ( $this->element_bookmark_idx++ );
+			$this->set_bookmark($bookmark);
+			$next_tag = WP_HTML_Token::tag(
+				$this->get_tag(),
+				array(),
+				! $this->is_tag_closer(),
+				$bookmark
+			);
+			$text_end = $this->bookmarks[$bookmark]->start;
+		} else {
+			$text_end = strlen($this->html);
 		}
-
-		$bookmark = '__internal_' . ( $this->element_bookmark_idx++ );
-		$this->set_bookmark($bookmark);
-		$next_tag = WP_HTML_Token::tag(
-			$this->get_tag(),
-			array(),
-			! $this->is_tag_closer(),
-			$bookmark
-		);
 
 		/*
 		 * If any text was found between the last tag and this one, 
@@ -722,7 +779,6 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			&& $this->has_bookmark($last->bookmark)
 		) {
 			$text_start = $this->bookmarks[$last->bookmark]->end + 1;
-			$text_end = $this->bookmarks[$bookmark]->start;
 			if ($text_start < $text_end) {
 				$this->buffered_tag = $next_tag;
 				$text = substr($this->html, $text_start, $text_end - $text_start);
@@ -735,12 +791,15 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 
 	const ANY_OTHER_END_TAG = 1;
 	private function adoption_agency_algorithm( WP_HTML_Token $token ) {
+		dbg("Adoption Agency Algorithm", 1);
 		$subject = $token->tag;
+		$current_node = $this->current_node();
 		if (
-			$this->current_node()->tag === $subject
-			&& ! in_array( $subject, $this->active_formatting_elements, true )
+			$current_node->token->tag === $subject
+			&& ! in_array( $current_node, $this->active_formatting_elements, true )
 		) {
 			$this->pop_open_element();
+			dbg("Skipping AAA: current node is \$subject ($subject) and is not AFE", 2);
 			return;
 		}
 
@@ -757,18 +816,21 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			$formatting_element_idx = -1;
 			for ( $i = count( $this->active_formatting_elements ) - 1; $i >= 0; $i-- ) {
 				$candidate = $this->active_formatting_elements[ $i ];
-				if ( $candidate->is_marker() ) {
+				if ( $candidate->token->is_marker() ) {
 					break;
 				}
-				if ( $candidate->tag === $subject ) {
+				if ( $candidate->token->tag === $subject ) {
 					$formatting_element     = $candidate;
 					$formatting_element_idx = $i;
 					break;
 				}
 			}
+			dbg("AAA: Formatting element = {$formatting_element->token->tag}", 2);
+
 			// If there is no such element, then abort these steps and instead act as
 			// described in the "any other end tag" entry below.
 			if ( null === $formatting_element ) {
+				dbg("Skipping AAA: no formatting element found", 2);
 				return self::ANY_OTHER_END_TAG;
 			}
 
@@ -777,12 +839,15 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			if ( ! in_array( $formatting_element, $this->open_elements, true ) ) {
 				array_splice( $this->active_formatting_elements, $formatting_element_idx, 1 );
 				$this->parse_error();
+				dbg("Skipping AAA: formatting element is not in the stack of open elements", 2);
 				return;
 			}
 
 			// If formatting element is not in scope, then this is a parse error; return
-			if ( ! $this->is_element_in_scope( $formatting_element->tag ) ) {
+			if ( ! $this->is_element_in_scope( $formatting_element ) ) {
 				$this->parse_error();
+				dbg("Skipping AAA: formatting element {$formatting_element->token->tag} is not in scope", 2);
+				$this->print_open_elements('Open elements: ', 2);
 				return;
 			}
 
@@ -803,9 +868,8 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				if ( $node === $formatting_element ) {
 					break;
 				}
-				if ( $this->is_special_element( $node->tag ) ) {
+				if ( $this->is_special_element( $node->token->tag ) ) {
 					$furthest_block = $node;
-					break;
 				}
 			}
 
@@ -816,13 +880,21 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			if ( null === $furthest_block ) {
 				$this->pop_until_node( $formatting_element );
 				array_splice( $this->active_formatting_elements, $formatting_element_idx, 1 );
+				dbg("Skipping AAA: no furthest block found", 2);
 				return;
 			}
+
+			dbg("AAA: Furthest block = {$furthest_block->token->tag}", 2);
 
 			// Let common ancestor be the element immediately above formatting element
 			// in the stack of open elements.
 			$formatting_elem_stack_index = array_search( $formatting_element, $this->open_elements, true );
 			$common_ancestor             = $this->open_elements[ $formatting_elem_stack_index - 1 ];
+
+			dbg("AAA: Common ancestor = {$common_ancestor->token->tag}", 2);
+
+			$this->print_open_elements('AAA: Open elements: ', 2);
+			$this->print_rafe_formats('AAA: Formatting elements: ', 2);
 
 			// Let a bookmark note the position of formatting element in the list of
 			// active formatting elements relative to the elements on either side of it
@@ -833,8 +905,8 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			$node                     = $last_node = $furthest_block;
 			$node_open_elements_index = array_search( $node, $this->open_elements, true );
 
-			$prev_node_open_elements_index = -1;
-			$inner_loop_counter            = 0;
+			$prev_open_element_index = false;
+			$inner_loop_counter      = 0;
 			while ( true ) {
 				$inner_loop_counter++;
 
@@ -846,15 +918,21 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				 */
 				$node_open_elements_index = array_search( $node, $this->open_elements, true );
 				if ( false === $node_open_elements_index ) {
-					$node_open_elements_index = $prev_node_open_elements_index;
-					return;
+					if ( false === $prev_open_element_index ) {
+						throw new Exception( 'Unexpected error in AAA algorithm – cannot find node.' );
+					}
+					$node_open_elements_index = $prev_open_element_index;
 				}
 				--$node_open_elements_index;
-				$node                          = $this->open_elements[ $node_open_elements_index ];
-				$prev_node_open_elements_index = $node_open_elements_index;
+				if( $node_open_elements_index < 0 ) {
+					throw new Exception( 'Unexpected error in AAA algorithm – node is not in the stack of open elements.' );
+				}
+				$node                     = $this->open_elements[ $node_open_elements_index ];
+				$prev_open_element_index = $node_open_elements_index;
 
 				// If node is formatting element, then break.
 				if ( $node === $formatting_element ) {
+					dbg("AAA: Inner loop break – node is formatting element", 3);
 					break;
 				}
 
@@ -873,28 +951,34 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				 * node from the stack of open elements and continue.
 				 */
 				if ( ! in_array( $node, $this->active_formatting_elements, true ) ) {
+					dbg("AAA: Inner loop – removing node from the stack of open elements", 3);
 					array_splice( $this->open_elements, $node_open_elements_index, 1 );
-					continue;
 				}
 
 				/*
 				 * Create an element for the token for which the element node was created,
 				 * in the HTML namespace, with common ancestor as the intended parent.
-				 *
+				 */
+				$new_node            = $this->create_element_for_token( $node->token );
+				$new_node->intended_parent = $common_ancestor;
+
+				/*
 				 * Replace the entry for node in the list of active formatting elements with an entry
 				 * for the new element.
-				 *
-				 * Replace the entry for node in the stack of open elements with an entry for
-				 * the new element.
-				 *
-				 * Let node be the new element.
 				 */
-				$new_node            = WP_HTML_Token::tag( $node->tag );
 				$node_formatting_idx = array_search( $node, $this->active_formatting_elements, true );
 				$this->active_formatting_elements[ $node_formatting_idx ] = $new_node;
 
-				$node_open_elements_index                         = array_search( $node, $this->open_elements, true );
-				$this->open_elements[ $node_open_elements_index ] = $new_node;
+				/*
+				 * Replace the entry for node in the stack of open elements with an entry for
+				 * the new element.
+				 */
+				$idx                         = array_search( $node, $this->open_elements, true );
+				$this->open_elements[ $idx ] = $new_node;
+
+				/*
+				 * Let node be the new element.
+				 */
 				$node = $new_node;
 
 				/*
@@ -906,7 +990,8 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				}
 
 				// Append last node to node.
-				// @TODO
+				dbg("AAA: Appending {$last_node->token->tag} to {$node->token->tag}", 3);
+				$node->append_child( $last_node );
 
 				// Set last node to node.
 				$last_node = $node;
@@ -914,63 +999,77 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 
 			// Insert whatever last node ended up being in the previous step at the appropriate place
 			// for inserting a node, but using common ancestor as the override target.
-			// @TODO
+			$this->insert_element( $last_node, $common_ancestor );
 
 			// Create an element for the token for which formatting element was created, in the HTML
 			// namespace, with furthest block as the intended parent.
-			$new_element = WP_HTML_Token::tag( $formatting_element->tag );
+			$new_element = $this->create_element_for_token( $formatting_element->token );
+			$new_element->intended_parent = $furthest_block;
 
 			// Take all of the child nodes of furthest block and append them to the element created in
 			// the last step.
-			// @TODO
+			foreach ($furthest_block->children as $child) {
+				$new_element->append_child( $child );
+			}
 
 			// Append that new element to furthest block.
-			// @TODO
+			$furthest_block->append_child( $new_element );
 
-			// Remove formatting element from the list of active formatting elements, and insert the new
-			// element into the list of active formatting elements at the position of the aforementioned
-			// bookmark.
-			$formatting_element_idx = array_search( $formatting_element, $this->active_formatting_elements, true );
-			array_splice( $this->active_formatting_elements, $formatting_element_idx, 1, array( $new_element ) );
+			// Remove formatting element from the list of active formatting elements
+			$idx = array_search( $formatting_element, $this->active_formatting_elements, true );
+			array_splice( $this->active_formatting_elements, $idx, 1 );
+	
+			// Insert the new element into the list of active formatting elements at the 
+			// position of the aforementioned bookmark.
 			array_splice( $this->active_formatting_elements, $bookmark, 0, array( $new_element ) );
 
-			// Remove formatting element from the stack of open elements, and insert the new element into
-			// the stack of open elements immediately below the position of furthest block in that stack.
-			$formatting_element_idx = array_search( $formatting_element, $this->active_formatting_elements, true );
-			array_splice( $this->active_formatting_elements, $formatting_element_idx, 1, array( $new_element ) );
-
-			$furthest_block_idx = array_search( $furthest_block, $this->open_elements, true );
-			array_splice( $this->open_elements, $furthest_block_idx + 1, 0, array( $new_element ) );
+			// Remove formatting element from the stack of open elements
+			$idx = array_search( $formatting_element, $this->open_elements, true );
+			array_splice( $this->open_elements, $idx, 1 );
+			
+			// Insert the new element into the stack of open elements immediately below the 
+			// position of furthest block in that stack.
+			$idx = array_search( $furthest_block, $this->open_elements, true );
+			array_splice( $this->open_elements, $idx + 1, 0, array( $new_element ) );
 		}
 	}
 
-	/*
-		@TODO Implement https://html.spec.whatwg.org/multipage/parsing.html#insert-a-foreign-element
-
-		Let the adjusted insertion location be the appropriate place for inserting a node.
-
-		Let element be the result of creating an element for the token in the given namespace, with the intended parent being the element in which the adjusted insertion location finds itself.
-
-		If it is possible to insert element at the adjusted insertion location, then:
-
-		If the parser was not created as part of the HTML fragment parsing algorithm, then push a new element queue onto element's relevant agent's custom element reactions stack.
-
-		Insert element at the adjusted insertion location.
-
-		If the parser was not created as part of the HTML fragment parsing algorithm, then pop the element queue from element's relevant agent's custom element reactions stack, and invoke custom element reactions in that queue.
-
-		If the adjusted insertion location cannot accept more elements, e.g. because it's a Document that already has an element child, then element is dropped on the floor.
-
-		Push element onto the stack of open elements so that it is the new current node.
-
-		Return element.
-
-	*/
-	private function insert_html_element( $node ) {
-		if ( ! $node->is_closer ) {
-			$this->insert_element( $node );
+	private function insert_element( $token_or_node, $override_target = null ) {
+		// Create element for a token
+		// Skip reset algorithm for now
+		// Skip form-association for now
+		if($token_or_node instanceof WP_HTML_Token) {
+			$node = $this->create_element_for_token($token_or_node);
+		} else {
+			$node = $token_or_node;
 		}
-		$this->inserted_tokens[] = $node;
+
+		$target = $override_target ?: $this->current_node();
+
+		// Appropriate place for inserting a node:
+		// For now skip foster parenting and always use the
+		// location after the last child of the target
+		$target->append_child($node);
+		array_push($this->open_elements, $node);
+		dbg("inserted element: {$node->token->tag} to parent {$target->token->tag}", 2);
+		return $node;
+	}
+
+	private function create_element_for_token( WP_HTML_Token $token ) {
+		$node = new WP_HTML_Node($token);
+		return $node;
+	}
+
+	private function insert_text( WP_HTML_Token $token ) {
+		$target = $this->current_node();
+		if(count($target->children)){
+			$last_child = end($target->children);
+			if ( $last_child && $last_child->token->is_text() ) {
+				$last_child->token->value .= $token->value;
+				return;
+			}
+		}
+		$target->append_child(new WP_HTML_Node($token));
 	}
 
 	private function ignore_token( $token ) {
@@ -981,10 +1080,6 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		return;
 	}
 
-	private function insert_element( $node ) {
-		$this->open_elements[] = $node;
-	}
-
 	private function parse_error() {
 		// Noop for now
 	}
@@ -993,9 +1088,12 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		if ( ! is_array( $tags ) ) {
 			$tags = array( $tags );
 		}
-		while ( ! in_array( $this->current_node()->tag, $tags ) ) {
+		dbg( "Popping until tag names: " . implode(', ', $tags), 1 );
+		$this->print_open_elements( "Open elements before: " );
+		while ( ! in_array( $this->current_node()->token->tag, $tags ) ) {
 			$this->pop_open_element();
 		}
+		$this->print_open_elements( "Open elements after: " );
 	}
 
 	private function pop_until_node( $node ) {
@@ -1006,9 +1104,9 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 
 	private function pop_open_element() {
 		$popped = array_pop( $this->open_elements );
-		if ( $popped->bookmark ) {
-			$this->release_bookmark( $popped->bookmark );
-			$popped->bookmark = null;
+		if ( $popped->token->bookmark ) {
+			$this->release_bookmark( $popped->token->bookmark );
+			$popped->token->bookmark = null;
 		}
 		return $popped;
 	}
@@ -1024,20 +1122,21 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	}
 
 	private function close_p_element() {
+		dbg( "close_p_element" );
 		$this->generate_implied_end_tags(
 			array(
 				'except_for' => array( 'P' ),
 			)
 		);
 		// If the current node is not a p element, then this is a parse error.
-		if ( $this->current_node()->tag !== 'P' ) {
+		if ( $this->current_node()->token->tag !== 'P' ) {
 			$this->parse_error();
 		}
 		$this->pop_until_tag_name( 'P' );
 	}
 
 	private function should_generate_implied_end_tags( $options = null ) {
-		$current_tag_name = $this->current_node()->tag;
+		$current_tag_name = $this->current_node()->token->tag;
 		if ( null !== $options && isset( $options['except_for'] ) && in_array( $current_tag_name, $options['except_for'] ) ) {
 			return false;
 		}
@@ -1074,14 +1173,14 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	/**
 	 * https://html.spec.whatwg.org/multipage/parsing.html#the-list-of-active-formatting-elements
 	 */
-	private function push_active_formatting_element( $node ) {
+	private function push_active_formatting_element( WP_HTML_Node $node ) {
 		$count = 0;
 		for ( $i = count( $this->active_formatting_elements ) - 1; $i >= 0; $i-- ) {
 			$formatting_element = $this->active_formatting_elements[ $i ];
-			if ( $formatting_element->is_marker() ) {
+			if ( $formatting_element->token->is_marker() ) {
 				break;
 			}
-			if ( ! $node->equivalent( $node ) ) {
+			if ( ! $formatting_element->token->equivalent( $node->token ) ) {
 				continue;
 			}
 			$count++;
@@ -1093,63 +1192,100 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		$this->active_formatting_elements[] = $node;
 	}
 
+	private function print_rafe_formats($msg, $indent=1) {
+		$formats = array_map( function( $node ) { 
+			return $node->token->tag ?: ($node->token->is_marker() ? 'M' : 'ERROR'); 
+		}, $this->active_formatting_elements);
+		dbg( "$msg " . implode(', ', $formats), $indent );
+	}
+
+	private function print_open_elements($msg, $indent=1) {
+		$elems = array_map(function ($node) {
+			return $node->token->tag; 
+		}, $this->open_elements);
+		dbg( "$msg " . implode(', ', $elems), $indent );
+	}
+
 	private function reconstruct_active_formatting_elements() {
+		$this->print_rafe_formats('RAFE: before');
 		if ( empty( $this->active_formatting_elements ) ) {
+			dbg( "Skipping RAFE: empty list", 1 );
 			return;
 		}
-		$i          = count( $this->active_formatting_elements ) - 1;
-		$last_entry = $this->active_formatting_elements[ $i ];
-		if ( $last_entry->is_marker() || in_array( $last_entry, $this->open_elements, true ) ) {
+		$entry_idx          = count( $this->active_formatting_elements ) - 1;
+		$last_entry = $this->active_formatting_elements[ $entry_idx ];
+		if ( $last_entry->token->is_marker() || in_array( $last_entry, $this->open_elements, true ) ) {
+			dbg( "Skipping RAFE: marker or open element", 1 );
 			return;
 		}
+
+		// Let entry be the last (most recently added) element in the list of active formatting elements.
 		$entry = $last_entry;
+
+		$is_rewinding = true;
 		while ( true ) {
-			if ( $i <= 0 ) {
-				break;
-			}
-			--$i;
-			$entry = $this->active_formatting_elements[ $i ];
-			if ( $entry->is_marker() || in_array( $entry, $this->open_elements, true ) ) {
-				break;
-			}
-		}
-		while ( true ) {
-			++$i;
-			$entry = $this->active_formatting_elements[ $i ];
-			if ( $entry === $last_entry ) {
-				break;
+			if ( $is_rewinding ) {
+				// Rewind:
+				/*
+				 * If there are no entries before entry in the list of active formatting elements,
+				 * then jump to the step labeled create.
+				 */
+				if ( $entry_idx === 0 ) {
+					$is_rewinding = false;
+				} else {
+					// Let entry be the entry one earlier than entry in the list of active formatting elements.
+					$entry = $this->active_formatting_elements[ --$entry_idx ];
+
+					// If entry is neither a marker nor an element that is also in the stack of open elements,
+					// go to the step labeled rewind.
+					if ( ! $entry->token->is_marker() && ! in_array( $entry, $this->open_elements, true ) ) {
+						continue;
+					}
+				}
+			} else {
+				// Advance:
+				// Let entry be the element one later than entry in the list of active formatting elements.
+				$entry = $this->active_formatting_elements[ ++$entry_idx ];
 			}
 
-			// @TODO:
-			// Create: Insert an HTML element for the token for which the element entry
-			// was created, to obtain new element.
-			$new_element = WP_HTML_Token::tag( $entry->tag, $entry->attributes );
+			// Create: Insert an HTML element for the token for which the element entry was created,
+			// to obtain new element.
+			$new_element = $this->insert_element( $entry->token );
 
 			// Replace the entry for entry in the list with an entry for new element.
-			$index = array_search( $entry, $this->active_formatting_elements, true );
+			$this->active_formatting_elements[ $entry_idx ] = $new_element;
 
-			$this->active_formatting_elements[ $index ] = $new_element;
-			if ( $index === count( $this->active_formatting_elements ) - 1 ) {
+			// If the entry for new element in the list of active formatting elements is not the last entry 
+			// in the list, return to the step labeled advance.
+			if ( $entry_idx === count( $this->active_formatting_elements ) - 1 ) {
 				break;
 			}
 		}
+		$this->print_rafe_formats('RAFE: after');
 	}
 
 	private function clear_active_formatting_elements_up_to_last_marker() {
 		while ( ! empty( $this->active_formatting_elements ) ) {
 			$entry = array_pop( $this->active_formatting_elements );
-			if ( $entry->is_marker() ) {
+			if ( $entry->token->is_marker() ) {
 				break;
 			}
 		}
 	}
 
+	/**
+	 * The stack of open elements is said to have a particular element in 
+	 * select scope when it has that element in the specific scope consisting
+	 * of all element types except the following:
+	 * * optgroup
+	 * * option
+	 */
 	private function is_element_in_select_scope( $target_node ) {
 		return $this->is_element_in_specific_scope(
 			$target_node,
 			array(
-				'optgroup',
-				'option',
+				'OPTGROUP',
+				'OPTION',
 			),
 			array(
 				'negative_match' => 'true',
@@ -1161,9 +1297,9 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		return $this->is_element_in_specific_scope(
 			$target_node,
 			array(
-				'html',
-				'table',
-				'template',
+				'HTML',
+				'TABLE',
+				'TEMPLATE',
 			)
 		);
 	}
@@ -1172,7 +1308,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		return $this->is_element_in_scope(
 			$target_node,
 			array(
-				'button',
+				'BUTTON',
 			)
 		);
 	}
@@ -1181,9 +1317,9 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		return $this->is_element_in_scope(
 			$target_node,
 			array(
-				'li',
-				'dd',
-				'dt',
+				'LI',
+				'DD',
+				'DT',
 			)
 		);
 	}
@@ -1193,39 +1329,60 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			$target_node,
 			array_merge(
 				array(
-					'applet',
-					'caption',
-					'html',
-					'table',
-					'td',
-					'th',
-					'marquee',
-					'object',
-					'template',
+					'APPLET',
+					'CAPTION',
+					'HTML',
+					'TABLE',
+					'TD',
+					'TH',
+					'MARQUEE',
+					'OBJECT',
+					'TEMPLATE',
 				),
 				$additional_elements
 			)
 		);
 	}
 
-	/**
+	/*
 	 * https://html.spec.whatwg.org/multipage/parsing.html#the-stack-of-open-elements
 	 */
 	private function is_element_in_specific_scope( $target_node, $element_types_list, $options = array() ) {
 		$negative_match = isset( $options['negative_match'] ) ? $options['negative_match'] : false;
-		$i              = count( $this->open_elements ) - 1;
-		while ( true ) {
-			$node = $this->open_elements[ $i ];
 
-			if ( $node === $target_node ) {
+		/**
+		 * The stack of open elements is said to have an element target node in a
+		 * specific scope consisting of a list of element types list when the following
+		 * algorithm terminates in a match state:
+		 */
+		$i = count( $this->open_elements ) - 1;
+		// 1. Initialize node to be the current node (the bottommost node of the stack).
+		$node = $this->open_elements[ $i ];
+
+		while ( true ) {
+			// 2. If node is the target node, terminate in a match state.
+			if ( $node === $target_node || $node->token->tag === $target_node ) {
 				return true;
 			}
 
-			$is_in_the_list = in_array( $node->tag, $element_types_list, true );
-			$failure        = $negative_match ? $is_in_the_list : ! $is_in_the_list;
+			// 3. Otherwise, if node is one of the element types in list, terminate in a failure state.
+			$failure = in_array( $node->token->tag, $element_types_list, true );
+
+			// Some elements say:
+			// > If has that element in the specific scope consisting of all element types 
+			// > except the following
+			// So we need to invert the result.
+			if($negative_match) {
+				$failure = ! $failure;
+			}
 			if ( $failure ) {
 				return false;
 			}
+
+			// Otherwise, set node to the previous entry in the stack of open elements and
+			// return to step 2. (This will never fail, since the loop will always terminate 
+			// in the previous step if the top of the stack — an html element — is reached.)
+			$node = $this->open_elements[ --$i ];
 		}
 	}
 
@@ -1242,7 +1399,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				$node = $this->context_node;
 			}
 
-			if ( $node->tag === 'select' ) {
+			if ( $node->token->tag === 'select' ) {
 				if ( $last ) {
 					break;
 				}
@@ -1269,7 +1426,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				return;
 			}
 
-			switch ( $node->tag ) {
+			switch ( $node->token->tag ) {
 				case 'TD':
 				case 'TH':
 					if ( ! $last ) {
@@ -1465,15 +1622,29 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 }
 
 
-$p = new WP_HTML_Processor( '<p>Lorem<b>Ipsum<i></i></p>Dolor</b>Sit' );
-// The controller's schema is hardcoded, so tests would not be meaningful.
-$p->main();
+// $p = new WP_HTML_Processor( '<p>1<b>2<i>3</b>4</i>5</p>' );
+// $p->parse();
+/*
+Should output:
+	p
+	├─ #text: 1
+	├─ b
+	│  ├─ #text: 2
+	│  └─ i
+	│     └─ #text: 3
+	├─ i
+	│  └─ #text: 4
+	└─ #text: 5
+*/
 
-// $this->tag_processor->next_tag(
-//     array(
-//         'tag_closers' => 'visit',
-//     )
-// );
-// var_dump( $this->tag_processor->get_tag() );
-// var_dump( $this->tag_processor->is_tag_closer() );
-// $last_parent = end( $this->open_elements );
+$p = new WP_HTML_Processor( '<b>1<p>2</b>3</p>' );
+$p->parse();
+/*
+Should output:
+b
+└─ #text: 1
+p
+├─ b
+│  └─ #text: 2
+└─ #text: 3
+*/

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -149,7 +149,7 @@ class WP_HTML_Node {
 		$this->tag = $token->tag;
 	}
 
-	public function append_child( WP_HTML_Node $node ) {
+	public function append_child( WP_HTML_Node $node ) { 
 		if($node->parent) {
 			$node->parent->remove($node);
 		}
@@ -278,13 +278,8 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		// 	// $ignored_token->bookmark = null;
 		// }
 
-		$token = $this->next_token();
-		if(!$token){
-			return false;
-		}
-		$processed_token = $this->process_token($token);
-		$this->last_token = $processed_token;
-		return $processed_token;
+		$this->last_token = $ignored_token;
+		return $this->process_next_token();
 	}
 
 	public function process_token(WP_HTML_Token $token) {
@@ -1476,7 +1471,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 
 // die();
 
-$p = new WP_HTML_Processor( '<ul><li>1<li>2<li>3<li>Lorem<b>Ipsum<li>Dolor</ul>Sit<div>Amet' );
+$p = new WP_HTML_Processor( '<ul><li>1<li>2<li>3<li>Lorem<b>Ipsum<li>Dolor</ul></ul></ul><span></ul>Sit<span>Sit<span><div>Amet' );
 $p->parse();
 /*
 Outputs:
@@ -1498,9 +1493,13 @@ DOM after main loop:
          └─ B
             └─ #text: Dolor
    └─ B
-      ├─ #text: Sit
-      └─ DIV
-         └─ #text: Amet
+      └─ SPAN
+         ├─ #text: Sit
+         └─ SPAN
+            ├─ #text: Sit
+            └─ SPAN
+               └─ DIV
+                  └─ #text: Amet
 */
 
 $p = new WP_HTML_Processor( '<div>1<span>2</div>3</span>4' );

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -11,7 +11,7 @@ if ( ! class_exists( 'WP_HTML_Tag_Processor' ) ) {
 	}
 }
 
-define('HTML_DEBUG_MODE', true);
+define('HTML_DEBUG_MODE', false);
 function dbg( $message, $indent = 0 ) {
 	if( HTML_DEBUG_MODE ) {
 		$indent = str_repeat( ' ', $indent * 2 );
@@ -441,7 +441,8 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					}
 
 					$this->reconstruct_active_formatting_elements();
-					$this->insert_element( $token );
+					$node = $this->insert_element( $token );
+					$this->push_active_formatting_element( $node );
 					break;
 				case 'B':
 				case 'BIG':
@@ -948,6 +949,10 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				// Set last node to node.
 				$last_node = $node;
 			}
+
+			// $this->reconstructed_html .= '<AA>';
+			// $this->reconstructed_html .= '<'.$common_ancestor->token->tag.'>';
+			// $this->reconstructed_html .= '<'.$last_node->token->tag.'>';
 
 			// Insert whatever last node ended up being in the previous step at the appropriate place
 			// for inserting a node, but using common ancestor as the override target.
@@ -1551,24 +1556,29 @@ DOM after main loop:
                   └─ #text: Amet
 */
 
-
-$p = new WP_HTML_Processor( '<b>1<p>2</b>3</p>' );
+$p = new WP_HTML_Processor( '<b>
+<div>
+   <div></div>
+   </b>
+ </div>
+</b>' );
 $p->parse();
-/*
-Outputs the correct result:
-  HTML
-   ├─ B
-      └─ #text: 1
-   └─ P
-      ├─ B
-         └─ #text: 2
-      └─ #text: 3
-*/
+// $p = new WP_HTML_Processor( '<b>1<p><div>2</b>3</p></div>' );
+// $p->parse();
+// /*
+// Outputs the correct result:
+// B
+// └─ #text: 1
+// P
+// ├─ B
+//    └─ #text: 2
+// └─ #text: 3
+// */
 echo "\n\n";
 echo $p->reconstructed_html;
 die();
 
-$p = new WP_HTML_Processor( '<p><b class=x><b class=x><b><b class=x><b class=x><b>X
+$p = new WP_HTML_Processor( '<p><b class=x><b class=x><b><b class=x><b class=x><b><b class=x><b class=x><b><b class=x><b class=x><b>X
 <p>X
 <p><b><b class=x><b>X
 <p></b></b></b></b></b></b>X' );

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -179,8 +179,9 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				break;
 			}
 			echo "TOKEN: $token\n";
-			$processed_token = $this->process_in_body_insertion_mode($token);
-			$this->last_token = $processed_token;
+			$this->last_token = $token;
+			// $processed_token = $this->process_in_body_insertion_mode($token);
+			// $this->last_token = $processed_token;
 		}
 		// @TODO:
 		// switch($this->insertion_mode) {
@@ -720,11 +721,10 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			&& $last->bookmark
 			&& $this->has_bookmark($last->bookmark)
 		) {
-			$this->buffered_tag = $next_tag;
-
 			$text_start = $this->bookmarks[$last->bookmark]->end + 1;
 			$text_end = $this->bookmarks[$bookmark]->start;
 			if ($text_start < $text_end) {
+				$this->buffered_tag = $next_tag;
 				$text = substr($this->html, $text_start, $text_end - $text_start);
 				return WP_HTML_Token::text($text);
 			}

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -601,7 +601,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					$this->close_p_element();
 					break;
 				case 'LI':
-					if ( $this->is_element_in_list_item_scope( 'LI' ) ) {
+					if ( ! $this->is_element_in_list_item_scope( 'LI' ) ) {
 						$this->parse_error();
 						return $this->ignore_token( $token );
 					}
@@ -610,7 +610,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					break;
 				case 'DD':
 				case 'DT':
-					if ( $this->is_element_in_scope( $token->tag ) ) {
+					if ( ! $this->is_element_in_scope( $token->tag ) ) {
 						$this->parse_error();
 						return $this->ignore_token( $token );
 					}
@@ -623,7 +623,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				case 'H4':
 				case 'H5':
 				case 'H6':
-					if ( $this->is_element_in_scope( array( 'H1', 'H2', 'H3', 'H4', 'H5', 'H6' ) ) ) {
+					if ( ! $this->is_element_in_scope( array( 'H1', 'H2', 'H3', 'H4', 'H5', 'H6' ) ) ) {
 						$this->parse_error();
 						return $this->ignore_token( $token );
 					}
@@ -650,7 +650,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				case 'APPLET':
 				case 'MARQUEE':
 				case 'OBJECT':
-					if ( $this->is_element_in_scope( $token->tag ) ) {
+					if ( ! $this->is_element_in_scope( $token->tag ) ) {
 						$this->parse_error();
 						return $this->ignore_token( $token );
 					}

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -722,7 +722,7 @@ class WP_HTML_Tag_Processor {
 		}
 
 		$this->bookmarks[ $name ] = new WP_HTML_Span(
-			$this->tag_name_starts_at - 1,
+			$this->tag_name_starts_at - ( $this->is_closing_tag ? 2 : 1 ),
 			$this->tag_ends_at
 		);
 
@@ -1504,7 +1504,7 @@ class WP_HTML_Tag_Processor {
 		$this->bytes_already_parsed = $this->bookmarks[ $bookmark_name ]->start;
 		$this->bytes_already_copied = $this->bytes_already_parsed;
 		$this->output_buffer        = substr( $this->html, 0, $this->bytes_already_copied );
-		return $this->next_tag();
+		return $this->next_tag( array( 'tag_closers' => 'visit' ) );
 	}
 
 	/**

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -274,7 +274,7 @@ class WP_HTML_Tag_Processor {
 	 * @since 6.2.0
 	 * @var string
 	 */
-	private $html;
+	public $html;
 
 	/**
 	 * The last query passed to next_tag().
@@ -343,7 +343,7 @@ class WP_HTML_Tag_Processor {
 	 * @since 6.2.0
 	 * @var int
 	 */
-	private $bytes_already_parsed = 0;
+	protected $bytes_already_parsed = 0;
 
 	/**
 	 * How many bytes from the input HTML document have already been
@@ -406,7 +406,7 @@ class WP_HTML_Tag_Processor {
 	 * @since 6.2.0
 	 * @var int|null
 	 */
-	private $tag_ends_at;
+	protected $tag_ends_at;
 
 	/**
 	 * Whether the current tag is an opening tag, e.g. <div>, or a closing tag, e.g. </div>.
@@ -734,7 +734,7 @@ class WP_HTML_Tag_Processor {
 		}
 
 		$this->bookmarks[ $name ] = new WP_HTML_Span(
-			$this->tag_name_starts_at - 1,
+			$this->tag_name_starts_at - ($this->is_closing_tag ? 2 : 1),
 			$this->tag_ends_at
 		);
 

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -724,7 +724,7 @@ class WP_HTML_Tag_Processor {
 			return false;
 		}
 
-		if ( ! array_key_exists( $name, $this->bookmarks ) && count( $this->bookmarks ) >= self::MAX_BOOKMARKS ) {
+		if ( ! array_key_exists( $name, $this->bookmarks ) && count( $this->bookmarks ) >= static::MAX_BOOKMARKS ) {
 			_doing_it_wrong(
 				__METHOD__,
 				__( 'Too many bookmarks: cannot create any more.' ),

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -238,6 +238,7 @@ require ABSPATH . WPINC . '/html-api/class-wp-html-attribute-token.php';
 require ABSPATH . WPINC . '/html-api/class-wp-html-span.php';
 require ABSPATH . WPINC . '/html-api/class-wp-html-text-replacement.php';
 require ABSPATH . WPINC . '/html-api/class-wp-html-tag-processor.php';
+require ABSPATH . WPINC . '/html-api/class-wp-html-processor.php';
 require ABSPATH . WPINC . '/class-wp-http.php';
 require ABSPATH . WPINC . '/class-wp-http-streams.php';
 require ABSPATH . WPINC . '/class-wp-http-curl.php';

--- a/tests/phpunit/tests/html-api/wpHtmlProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessor.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Unit tests covering WP_HTML_Processor functionality.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Unit tests for the mobile block editor settings.
+ *
+ * @covers WP_HTML_Processor
+ */
+
+ class Tests_HtmlApi_wpHtmlProcessor extends WP_UnitTestCase {
+
+	public function test_starts() {
+		$p = new WP_HTML_Processor( '<p>Lorem<b>Ipsum</p>Dolor</b>Sit' );
+		// The controller's schema is hardcoded, so tests would not be meaningful.
+		$p->next_tag_in_body_insertion_mode();
+	}
+
+}

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor-bookmark.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor-bookmark.php
@@ -64,6 +64,28 @@ class Tests_HtmlApi_wpHtmlTagProcessor_Bookmark extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 56299
+	 *
+	 * @covers WP_HTML_Tag_Processor::seek
+	 */
+	public function test_seeks_to_tag_closer_bookmark() {
+		$p = new WP_HTML_Tag_Processor( '<div>First</div><span>Second</span>' );
+		$p->next_tag( array( 'tag_closers' => 'visit' ) );
+		$p->set_bookmark( 'first' );
+		$p->next_tag( array( 'tag_closers' => 'visit' ) );
+		$p->set_bookmark( 'second' );
+
+		$p->seek( 'first' );
+		$p->seek( 'second' );
+
+		$this->assertSame(
+			'DIV',
+			$p->get_tag(),
+			'Did not seek to the intended bookmark location'
+		);
+	}
+
+	/**
 	 * WP_HTML_Tag_Processor used to test for the diffs affecting
 	 * the adjusted bookmark position while simultaneously adjusting
 	 * the bookmark in question. As a result, updating the bookmarks


### PR DESCRIPTION
(This is a continuation of https://github.com/adamziel/wordpress-develop/pull/1 but opened against wordpress-develop for more visibility. It's exploratory work and not something I'd like to merge in its current shape)

## Description

Explores processing HTML as a tree to go beyond `WP_HTML_Tag_Processor` and enable these highly requested features:

* [`set_content_inside_balanced_tags`](https://github.com/WordPress/gutenberg/pull/47036) 
* Finding HTML nodes via a CSS selector
* Inserting new HTML nodes at a correct location

## Understanding a document tree is hard

CSS selector, `innerHTML`, and others all operate on a DOM tree. However, figuring out a DOM tree from HTML markup isn't a straightforward task! Consider:

```
new DOMParser().parseFromString("<p>Tree <b>structure</p> isn't </b> easy", "text/html").body.innerHTML

"<p>Tree <b>structure</b></p><b> isn't </b> easy"
```

## Let's implement the HTML parsing spec

The [WHATWG HTML spec describes in detail](https://html.spec.whatwg.org/multipage/parsing.html#an-introduction-to-error-handling-and-strange-cases-in-the-parser) how to handle misnested tags, unexpected markup, and other non-normative artifacts commonly seen in HTML markup. One of the fundamental ideas it describes is the [adoption agency algorithm](https://html.spec.whatwg.org/multipage/parsing.html#adoptionAgency) used to rewrite the DOM tree.

## But let's ditch most of it

HTML spec is huge and contains many features indispensable for web browsers. However, we're not building a browser. We only want to handle non-normative HTML markup fragments.

For example, the parsing spec demands ignoring `<tr>` tags found outside of a `<table>`. Here's what happens if we implement that part:

```php
$p = new WP_HTML_Processor('<tr><td><b>Test!</b></td></tr>');
echo $p->get_updated_html();
// <b>Test!</b>
```

That's not helpful at all!

The spec describes an algorithm for [Parsing HTML fragments](https://html.spec.whatwg.org/multipage/parsing.html#parsing-html-fragments) that takes an HTML string and a `context` elements. Eventually, we could perhaps use it to treat the markup as if it was nested in a specific tag:

```php
$p = new WP_HTML_Processor('<tr><td><b>Test!</b></td></tr>', '<table>');
echo $p->get_updated_html();
// <tr><td><b>Test!</b></td></tr>
```

Still, it adds a lot of complexity AND requires developers to be mindful of the `$context`. I suggest not implementing it at this time.

### Specific things I'd like to ditch from [Tree Construction](https://html.spec.whatwg.org/multipage/parsing.html#tree-construction)

#### All insertion modes targeting markup outside of document body

Let's skip the following sections and assume we're already in a document body. The parser will be permissive of weird stuff like multiple doctype declarations:

1. [13.2.6.4.1 The "initial" insertion mode](https://html.spec.whatwg.org/multipage/parsing.html#the-initial-insertion-mode)
2. [13.2.6.4.2 The "before html" insertion mode](https://html.spec.whatwg.org/multipage/parsing.html#the-before-html-insertion-mode)
3. [13.2.6.4.3 The "before head" insertion mode](https://html.spec.whatwg.org/multipage/parsing.html#the-before-head-insertion-mode)
4. [13.2.6.4.4 The "in head" insertion mode](https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inhead)
5. [13.2.6.4.5 The "in head noscript" insertion mode](https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inheadnoscript)
6. [13.2.6.4.6 The "after head" insertion mode](https://html.spec.whatwg.org/multipage/parsing.html#the-after-head-insertion-mode)
7. [13.2.6.4.19 The "after body" insertion mode](https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-afterbody)
8. [13.2.6.4.22 The "after after body" insertion mode](https://html.spec.whatwg.org/multipage/parsing.html#the-after-after-body-insertion-mode)

#### All insertion modes targeting framesets

Come on, who uses framesets?

1. [13.2.6.4.20 The "in frameset" insertion mode](https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inframeset)
2. [13.2.6.4.21 The "after frameset" insertion mode](https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-afterframeset)
3. [13.2.6.4.23 The "after after frameset" insertion mode](https://html.spec.whatwg.org/multipage/parsing.html#the-after-after-frameset-insertion-mode)

#### [The text insertion mode](https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-incdata)

`WP_HTML_Tag_Processor` already implements the script nesting rules, so we can safely assume anything not classified as a tag is a text. This insertion mode doesn't offer any extra value.

#### Tag-specific insertion modes

We're working with HTML fragments and can't assume the context in which it will be displayed. Brownie points – by ditching these insertion modes we don't have to implement [foster parenting](https://html.spec.whatwg.org/multipage/parsing.html#foster-parent).

1. [13.2.6.4.9 The "in table" insertion mode](https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-intable)
2. [13.2.6.4.10 The "in table text" insertion mode](https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-intabletext)
3. [13.2.6.4.11 The "in caption" insertion mode](https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-incaption)
4. [13.2.6.4.12 The "in column group" insertion mode](https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-incolgroup)
5. [13.2.6.4.13 The "in table body" insertion mode](https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-intbody)
6. [13.2.6.4.14 The "in row" insertion mode](https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-intr)
7. [13.2.6.4.15 The "in cell" insertion mode](https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-intd)
8. [13.2.6.4.16 The "in select" insertion mode](https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inselect)
9. [13.2.6.4.17 The "in select in table" insertion mode](https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inselectintable)
10. [13.2.6.4.18 The "in template" insertion mode](https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-intemplate)

## Let's only implement parts of the _in body_ insertion mode

That's all we need in order to handle:

* Misnested formatting elements (`<p>1<b>2<i>3</b>4</i>5</p>`)
* Misnested blocks (`<b>1<p>2</b>3</p>`)
* Misnested list items (`<ul><li>1<li>2</ul>`)

Conveniently, this means new nodes are always inserted after the last child of the target node = simpler text-based implementation.

## Important findings so far

### Object-oriented DOM representation works but is inefficient

I benchmarked it on the HTML parsing spec itself, which is a 12MB HTML document:

I tried parsing the HTML spec page (12MB):

```
Mem peak usage: 499MB
Time: 30.60s
```

That's awful but not surprising. This PR builds an actual document tree and uses inefficient operations such as `array_splice`.

A text-based version similar to WP_HTML_Tag_Processor should be much faster and more memory-efficient. Let's explore one!

### Parsing HTML requires a full pass through the HTML document

[HTML spec deals with misnested nodes using Adoption Agency Algorithm.](https://html.spec.whatwg.org/multipage/parsing.html#adoption-agency-algorithm) In the worst-case scenario, the **entire document** must be parsed to know even the **second** node.

Consider this markup:

```html
<b>
 <div>
    <div><!-- 100k tags amounting to 2 MB of normative HTML --></div>
    </b> <!-- suddenly, a rogue </b> -->
  </div>
</b>
```

The correct DOM would be:

```
B
DIV
└─ B
      └─ DIV (with 100k tags)
```

The adoption agency algorithm makes the `<div>` a direct child of `<html>` only **once we process the misnested `</b>`**.

## What if we built an HTML normalizer instead?

Since the entire markup must be processed upfront, this could work just as well:

```php
class WP_HTML_Processor {

     public function __construct( $html, $options ) {
         // Apply HTML parsing rules first, unless explicitly asked not to
         if ( true !== $options['is_normative'] ) {
              $html = WP_HTML_Normalizer::normalize( $html );
         }

         // From now on, we assume normative markup
         $this->html = $html;
     }

     public function next_by_css( $selector );
     public function set_inner_html( $html );

     // ...

```



cc @dmsnell @ockham



## Open questions

- What can we assume about the context? Even in the _in body_ insertion mode `</ul>` closers are ignored if there's no matching `<ul>` opener. I think that's fine, but I'd like to bring it up for discussion.
- What to do with SVG and MathML foreign elements? If they have no conflicting tag names, then we could perhaps let them be handled by the default _in body_ insertion rules.

cc @ockham @dmsnell

Trac ticket: TODO 
