### PR TITLE
Add helpers for default/empty datetime value

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -6767,6 +6767,34 @@ function __return_empty_string() { // phpcs:ignore WordPress.NamingConventions.V
 }
 
 /**
+ * Returns an empty datetime value.
+ *
+ * @since x.x
+ *
+ * @return string
+ */
+function __return_empty_datetime() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionDoubleUnderscore,PHPCompatibility.FunctionNameRestrictions.ReservedFunctionNames.FunctionDoubleUnderscore
+	return '0000-00-00 00:00:00';
+}
+
+/**
+ * Checks if the provided string is an empty datetime
+ *
+ * @since x.x
+ *
+ * @param string $datetime String in datetime format
+ *
+ * @return bool
+ */
+function is_empty_datetime( $datetime = '' ) {
+	if ( empty( $datetime ) ) {
+		return true;
+	}
+
+	return $datetime === '0000-00-00 00:00:00';
+}
+
+/**
  * Sends a HTTP header to disable content type sniffing in browsers which support it.
  *
  * @since 3.0.0

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -6791,7 +6791,7 @@ function is_empty_datetime( $datetime = '' ) {
 		return true;
 	}
 
-	return $datetime === '0000-00-00 00:00:00';
+	return '0000-00-00 00:00:00' === $datetime;
 }
 
 /**


### PR DESCRIPTION
Add helper functions for default datetime value and check for empty datetime value.

Trac ticket: https://core.trac.wordpress.org/ticket/46210

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
