### PR TITLE
Add _doing_it_wrong() checks if incorrect callback value for apply_filters()

### DIFF
--- a/src/wp-includes/class-wp-hook.php
+++ b/src/wp-includes/class-wp-hook.php
@@ -301,6 +301,18 @@ final class WP_Hook implements Iterator, ArrayAccess {
 					$args[0] = $value;
 				}
 
+				if ( ! isset( $the_['function'] ) ) {
+					_doing_it_wrong( 'apply_filters()', 'callback value can not be empty', '6.x' );
+
+					continue;
+				}
+
+				if ( ! is_callable( $the_['function'] ) ) {
+					_doing_it_wrong( 'apply_filters()', 'filter callback value should be a valid callable function', '6.x' );
+
+					continue;
+				}
+
 				// Avoid the array_slice() if possible.
 				if ( 0 == $the_['accepted_args'] ) {
 					$value = call_user_func( $the_['function'] );


### PR DESCRIPTION
Add check for the callback function value passed to apply_filters, to determine if the value is empty or not callable. Trigger a _doing_it_wrong() call if an invalid value is passed to make sure the error is not silenced.

Trac ticket: https://core.trac.wordpress.org/ticket/38116

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
