### PR TITLE
[Dynamic Properties] Remove WP_Admin_Bar::__get()

### DIFF
--- a/.env
+++ b/.env
@@ -15,7 +15,7 @@ LOCAL_PORT=8889
 LOCAL_DIR=src
 
 # The PHP version to use. Valid options are 'latest', and '{version}-fpm'.
-LOCAL_PHP=latest
+LOCAL_PHP=8.2-fpm
 
 # Whether or not to enable Xdebug.
 LOCAL_PHP_XDEBUG=false

--- a/.env
+++ b/.env
@@ -15,7 +15,7 @@ LOCAL_PORT=8889
 LOCAL_DIR=src
 
 # The PHP version to use. Valid options are 'latest', and '{version}-fpm'.
-LOCAL_PHP=8.2-fpm
+LOCAL_PHP=latest
 
 # Whether or not to enable Xdebug.
 LOCAL_PHP_XDEBUG=false

--- a/src/wp-includes/class-wp-admin-bar.php
+++ b/src/wp-includes/class-wp-admin-bar.php
@@ -12,6 +12,7 @@
  *
  * @since 3.1.0
  */
+#[AllowDynamicProperties]
 class WP_Admin_Bar {
 	private $nodes = array();
 	private $bound = false;

--- a/src/wp-includes/class-wp-admin-bar.php
+++ b/src/wp-includes/class-wp-admin-bar.php
@@ -12,7 +12,6 @@
  *
  * @since 3.1.0
  */
-#[AllowDynamicProperties]
 class WP_Admin_Bar {
 	private $nodes = array();
 	private $bound = false;

--- a/src/wp-includes/class-wp-admin-bar.php
+++ b/src/wp-includes/class-wp-admin-bar.php
@@ -19,21 +19,13 @@ class WP_Admin_Bar {
 	public $user;
 
 	/**
-	 * @since 3.3.0
+	 * Deprecated menu property.
 	 *
-	 * @param string $name
-	 * @return string|array|void
+	 * @since 3.1.0
+	 * @deprecated 3.3.0 Modify admin bar nodes with WP_Admin_Bar::get_node(), WP_Admin_Bar::add_node(), and WP_Admin_Bar::remove_node().
+	 * @var array
 	 */
-	public function __get( $name ) {
-		switch ( $name ) {
-			case 'proto':
-				return is_ssl() ? 'https://' : 'http://';
-
-			case 'menu':
-				_deprecated_argument( 'WP_Admin_Bar', '3.3.0', 'Modify admin bar nodes with WP_Admin_Bar::get_node(), WP_Admin_Bar::add_node(), and WP_Admin_Bar::remove_node(), not the <code>menu</code> property.' );
-				return array(); // Sorry, folks.
-		}
-	}
+	public $menu = array();
 
 	/**
 	 * Initializes the admin bar.

--- a/src/wp-includes/class-wp-admin-bar.php
+++ b/src/wp-includes/class-wp-admin-bar.php
@@ -22,7 +22,8 @@ class WP_Admin_Bar {
 	 * Deprecated menu property.
 	 *
 	 * @since 3.1.0
-	 * @deprecated 3.3.0 Modify admin bar nodes with WP_Admin_Bar::get_node(), WP_Admin_Bar::add_node(), and WP_Admin_Bar::remove_node().
+	 * @deprecated 3.3.0 Modify admin bar nodes with WP_Admin_Bar::get_node(),
+	 *                   WP_Admin_Bar::add_node(), and WP_Admin_Bar::remove_node().
 	 * @var array
 	 */
 	public $menu = array();

--- a/tests/phpunit/tests/adminbar.php
+++ b/tests/phpunit/tests/adminbar.php
@@ -756,8 +756,7 @@ class Tests_AdminBar extends WP_UnitTestCase {
 	}
 
 	/**
-	 * This test ensures that WP_Admin_Bar::$proto is not defined
-	 * (including magic methods).
+	 * This test ensures that WP_Admin_Bar::$proto is not defined (including magic methods).
 	 *
 	 * @ticket 56876
 	 * @coversNothing
@@ -769,8 +768,7 @@ class Tests_AdminBar extends WP_UnitTestCase {
 	}
 
 	/**
-	 * This test ensures that WP_Admin_Bar::$menu
-	 * is declared as a "regular" class property.
+	 * This test ensures that WP_Admin_Bar::$menu is declared as a "regular" class property.
 	 *
 	 * @ticket 56876
 	 * @coversNothing

--- a/tests/phpunit/tests/adminbar.php
+++ b/tests/phpunit/tests/adminbar.php
@@ -762,20 +762,10 @@ class Tests_AdminBar extends WP_UnitTestCase {
 	 * @ticket 56876
 	 * @coversNothing
 	 */
-	public function test_proto_property_is_not_be_defined() {
-		set_error_handler(
-			static function ( $errno, $errstr ) {
-				restore_error_handler();
-				throw new Exception( $errstr, $errno );
-			},
-			E_ALL
-		);
+	public function test_proto_property_is_not_defined() {
 		$admin_bar = new WP_Admin_Bar();
-		$this->assertFalse( property_exists( $admin_bar, 'proto' ), 'WP_Admin_Bar::$proto must not be defined.' );
-		$this->assertFalse( isset( $admin_bar->proto ), 'WP_Admin_Bar::$proto must not be defined.' );
-		$this->expectException( Exception::class );
-		$this->expectExceptionMessageMatches( '/Undefined property.+WP_Admin_Bar::\$proto/' );
-		$admin_bar->proto;
+		$this->assertFalse( property_exists( $admin_bar, 'proto' ), 'WP_Admin_Bar::$proto should not be defined.' );
+		$this->assertFalse( isset( $admin_bar->proto ), 'WP_Admin_Bar::$proto should not be defined.' );
 	}
 
 	/**
@@ -788,7 +778,7 @@ class Tests_AdminBar extends WP_UnitTestCase {
 	public function test_menu_property_is_defined() {
 		$bar           = new WP_Admin_Bar();
 		$menu_property = new ReflectionProperty( $bar, 'menu' );
-		$this->assertTrue( $menu_property->isPublic(), 'WP_Admin_Bar::$menu must be public.' );
-		$this->assertSame( array(), $bar->menu, 'WP_Admin_Bar::$menu must be equal to an empty array.' );
+		$this->assertTrue( $menu_property->isPublic(), 'WP_Admin_Bar::$menu should be public.' );
+		$this->assertSame( array(), $bar->menu, 'WP_Admin_Bar::$menu should be equal to an empty array.' );
 	}
 }

--- a/tests/phpunit/tests/adminbar.php
+++ b/tests/phpunit/tests/adminbar.php
@@ -756,13 +756,16 @@ class Tests_AdminBar extends WP_UnitTestCase {
 	}
 
 	public function test_proto_property_should_not_be_defined() {
-		set_error_handler(static function ($errno, $errstr) {
-			throw new Exception($errstr, $errno);
-		}, E_WARNING);
+		set_error_handler(
+			static function ( $errno, $errstr ) {
+				throw new Exception( $errstr, $errno );
+			},
+			E_WARNING
+		);
 		$admin_bar = new WP_Admin_Bar();
 		$this->assertFalse( property_exists( $admin_bar, 'proto' ), 'Proto' );
 		$this->assertFalse( isset( $admin_bar->proto ) );
-		$this->expectException(Exception::class);
+		$this->expectException( Exception::class );
 		$this->expectExceptionMessage( 'Undefined property.+WP_Admin_Bar::\$proto' );
 		$admin_bar->proto;
 		restore_error_handler();

--- a/tests/phpunit/tests/adminbar.php
+++ b/tests/phpunit/tests/adminbar.php
@@ -766,7 +766,7 @@ class Tests_AdminBar extends WP_UnitTestCase {
 		$this->assertFalse( property_exists( $admin_bar, 'proto' ), 'Proto' );
 		$this->assertFalse( isset( $admin_bar->proto ) );
 		$this->expectException( Exception::class );
-		$this->expectExceptionMessage( 'Undefined property.+WP_Admin_Bar::\$proto' );
+		$this->expectExceptionMessageMatches( '/Undefined property.+WP_Admin_Bar::\$proto/' );
 		$admin_bar->proto;
 		restore_error_handler();
 	}

--- a/tests/phpunit/tests/adminbar.php
+++ b/tests/phpunit/tests/adminbar.php
@@ -776,9 +776,13 @@ class Tests_AdminBar extends WP_UnitTestCase {
 	 * @coversNothing
 	 */
 	public function test_menu_property_is_defined() {
-		$bar           = new WP_Admin_Bar();
-		$menu_property = new ReflectionProperty( $bar, 'menu' );
+		$admin_bar = new WP_Admin_Bar();
+		$this->assertTrue( property_exists( $admin_bar, 'menu' ), 'WP_Admin_Bar::$proto property should be defined.' );
+
+		$menu_property = new ReflectionProperty( WP_Admin_Bar::class, 'menu' );
 		$this->assertTrue( $menu_property->isPublic(), 'WP_Admin_Bar::$menu should be public.' );
-		$this->assertSame( array(), $bar->menu, 'WP_Admin_Bar::$menu should be equal to an empty array.' );
+
+		$this->assertTrue( isset( $admin_bar->menu ), 'WP_Admin_Bar::$menu should be set.' );
+		$this->assertSame( array(), $admin_bar->menu, 'WP_Admin_Bar::$menu should be equal to an empty array.' );
 	}
 }

--- a/tests/phpunit/tests/adminbar.php
+++ b/tests/phpunit/tests/adminbar.php
@@ -765,16 +765,30 @@ class Tests_AdminBar extends WP_UnitTestCase {
 	public function test_proto_property_is_not_be_defined() {
 		set_error_handler(
 			static function ( $errno, $errstr ) {
+				restore_error_handler();
 				throw new Exception( $errstr, $errno );
 			},
 			E_ALL
 		);
 		$admin_bar = new WP_Admin_Bar();
-		$this->assertFalse( property_exists( $admin_bar, 'proto' ), 'Proto' );
-		$this->assertFalse( isset( $admin_bar->proto ) );
+		$this->assertFalse( property_exists( $admin_bar, 'proto' ), 'WP_Admin_Bar::$proto must not be defined.' );
+		$this->assertFalse( isset( $admin_bar->proto ), 'WP_Admin_Bar::$proto must not be defined.' );
 		$this->expectException( Exception::class );
 		$this->expectExceptionMessageMatches( '/Undefined property.+WP_Admin_Bar::\$proto/' );
 		$admin_bar->proto;
-		restore_error_handler();
+	}
+
+	/**
+	 * This test ensures that WP_Admin_Bar::$menu is defined as a
+	 * "regular" class property.
+	 *
+	 * @ticket 56876
+	 * @coversNothing
+	 */
+	public function test_menu_property_is_defined() {
+		$bar           = new WP_Admin_Bar();
+		$menu_property = new ReflectionProperty( $bar, 'menu' );
+		$this->assertTrue( $menu_property->isPublic(), 'WP_Admin_Bar::$menu must be public.' );
+		$this->assertSame( array(), $bar->menu, 'WP_Admin_Bar::$menu must be equal to an empty array.' );
 	}
 }

--- a/tests/phpunit/tests/adminbar.php
+++ b/tests/phpunit/tests/adminbar.php
@@ -754,4 +754,13 @@ class Tests_AdminBar extends WP_UnitTestCase {
 			'network-admin-o'      => 'manage_network_options',
 		);
 	}
+
+	public function test_proto_property_should_not_be_defined() {
+		$admin_bar = new WP_Admin_Bar();
+		$this->assertFalse( property_exists( $admin_bar, 'proto' ), 'Proto' );
+		$this->assertFalse( isset( $admin_bar->proto ) );
+		$this->expectWarning();
+		$this->expectWarningMessageMatches( '/Undefined property:.+WP_Admin_Bar::$proto/' );
+		$admin_bar->proto;
+	}
 }

--- a/tests/phpunit/tests/adminbar.php
+++ b/tests/phpunit/tests/adminbar.php
@@ -755,7 +755,14 @@ class Tests_AdminBar extends WP_UnitTestCase {
 		);
 	}
 
-	public function test_proto_property_should_not_be_defined() {
+	/**
+	 * This test ensures that WP_Admin_Bar::$proto is not defined
+	 * (including magic methods).
+	 *
+	 * @ticket 56876
+	 * @coversNothing
+	 */
+	public function test_proto_property_is_not_be_defined() {
 		set_error_handler(
 			static function ( $errno, $errstr ) {
 				throw new Exception( $errstr, $errno );

--- a/tests/phpunit/tests/adminbar.php
+++ b/tests/phpunit/tests/adminbar.php
@@ -779,8 +779,8 @@ class Tests_AdminBar extends WP_UnitTestCase {
 	}
 
 	/**
-	 * This test ensures that WP_Admin_Bar::$menu is defined as a
-	 * "regular" class property.
+	 * This test ensures that WP_Admin_Bar::$menu
+	 * is declared as a "regular" class property.
 	 *
 	 * @ticket 56876
 	 * @coversNothing

--- a/tests/phpunit/tests/adminbar.php
+++ b/tests/phpunit/tests/adminbar.php
@@ -760,7 +760,7 @@ class Tests_AdminBar extends WP_UnitTestCase {
 			static function ( $errno, $errstr ) {
 				throw new Exception( $errstr, $errno );
 			},
-			E_WARNING
+			E_ALL
 		);
 		$admin_bar = new WP_Admin_Bar();
 		$this->assertFalse( property_exists( $admin_bar, 'proto' ), 'Proto' );

--- a/tests/phpunit/tests/adminbar.php
+++ b/tests/phpunit/tests/adminbar.php
@@ -756,11 +756,15 @@ class Tests_AdminBar extends WP_UnitTestCase {
 	}
 
 	public function test_proto_property_should_not_be_defined() {
+		set_error_handler(static function ($errno, $errstr) {
+			throw new Exception($errstr, $errno);
+		}, E_WARNING);
 		$admin_bar = new WP_Admin_Bar();
 		$this->assertFalse( property_exists( $admin_bar, 'proto' ), 'Proto' );
 		$this->assertFalse( isset( $admin_bar->proto ) );
-		$this->expectWarning();
-		$this->expectWarningMessageMatches( '/Undefined property:.+WP_Admin_Bar::$proto/' );
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage( 'Undefined property.+WP_Admin_Bar::\$proto' );
 		$admin_bar->proto;
+		restore_error_handler();
 	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This PR aims to refactor WP_Admin_Bar and remove the `__get` magic method. Dynamic class properties are deprecated in PHP 8.2.

Trac ticket: https://core.trac.wordpress.org/ticket/56876

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
