### PR TITLE
Add test to the `aspect-ratio` CSS property in KSES

### DIFF
--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -1313,7 +1313,7 @@ EOF;
 				'expected' => 'aspect-ratio: calc( 16 / 9 )',
 			),
 			array(
-				'css'      => 'aspect-ratio: url( https://wordpress.com/wp-content/uploads/aspect-ratio.jpg );',
+				'css'      => 'aspect-ratio: url( https://wordpress.org/wp-content/uploads/aspect-ratio.jpg );',
 				'expected' => '',
 			),
 		);

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -1300,6 +1300,22 @@ EOF;
 				'css'      => 'aspect-ratio: 16 / 9;',
 				'expected' => 'aspect-ratio: 16 / 9',
 			),
+			array(
+				'css'      => 'aspect-ratio: expression( 16 / 9 );',
+				'expected' => '',
+			),
+			array(
+				'css'      => 'aspect-ratio: calc( 16 / 9;',
+				'expected' => '',
+			),
+			array(
+				'css'      => 'aspect-ratio: calc( 16 / 9 );',
+				'expected' => 'aspect-ratio: calc( 16 / 9 )',
+			),
+			array(
+				'css'      => 'aspect-ratio: url( https://wordpress.com/wp-content/uploads/aspect-ratio.jpg );',
+				'expected' => '',
+			),
 		);
 	}
 

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -1283,6 +1283,23 @@ EOF;
 				'css'      => 'position: sticky;top: 0;left: 0;right: 0;bottom: 0;z-index: 10;',
 				'expected' => 'position: sticky;top: 0;left: 0;right: 0;bottom: 0;z-index: 10',
 			),
+			// `aspect-ratio` introduced in 6.2.
+			array(
+				'css'      => 'aspect-ratio: auto;',
+				'expected' => 'aspect-ratio: auto',
+			),
+			array(
+				'css'      => 'aspect-ratio: 0.5;',
+				'expected' => 'aspect-ratio: 0.5',
+			),
+			array(
+				'css'      => 'aspect-ratio: 1;',
+				'expected' => 'aspect-ratio: 1',
+			),
+			array(
+				'css'      => 'aspect-ratio: 16 / 9;',
+				'expected' => 'aspect-ratio: 16 / 9',
+			),
 		);
 	}
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This PR adds tests to the `aspect-ratio` CSS property in KSES since this property was added as safe for inline CSS.

Trac ticket: https://core.trac.wordpress.org/ticket/57664

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
