### PR TITLE
Twenty Twelve and Twenty Fifteen: maintain font subset translations

### DIFF
--- a/src/wp-content/themes/twentyfifteen/functions.php
+++ b/src/wp-content/themes/twentyfifteen/functions.php
@@ -397,6 +397,21 @@ if ( ! function_exists( 'twentyfifteen_fonts_url' ) ) :
 endif;
 
 /**
+ * Define a special character set for fonts in the current language.
+ *
+ * @since Twenty Fifteen 3.4
+ *
+ * @return string Special font subset or 'no-subset'.
+ */
+function twentyfifteen_font_subset() {
+	/*
+	 * translators: To add an additional character subset specific to your language,
+	 * translate this to 'greek', 'cyrillic', 'devanagari' or 'vietnamese'. Do not translate into your own language.
+	 */
+	return _x( 'no-subset', 'Add new subset (greek, cyrillic, devanagari, vietnamese)', 'twentyfifteen' );
+}
+
+/**
  * JavaScript Detection.
  *
  * Adds a `js` class to the root `<html>` element when JavaScript is detected.

--- a/src/wp-content/themes/twentytwelve/functions.php
+++ b/src/wp-content/themes/twentytwelve/functions.php
@@ -165,6 +165,21 @@ if ( ! function_exists( 'twentytwelve_get_font_url' ) ) :
 endif;
 
 /**
+ * Define a special character set for fonts in the current language.
+ *
+ * @since Twenty Twelve 3.9
+ *
+ * @return string Special font subset or 'no-subset'.
+ */
+function twentytwelve_font_subset() {
+	/*
+	 * translators: To add an additional Open Sans character subset specific to your language,
+	 * translate this to 'greek', 'cyrillic' or 'vietnamese'. Do not translate into your own language.
+	 */
+	return _x( 'no-subset', 'Open Sans font: add new subset (greek, cyrillic, vietnamese)', 'twentytwelve' );
+}
+
+/**
  * Enqueue scripts and styles for front end.
  *
  * @since Twenty Twelve 1.0


### PR DESCRIPTION
Creates new functions to output the string from `no-subset` translations that previously were included in Twenty Twelve and Twenty Fifteen.

[Trac 57807](https://core.trac.wordpress.org/ticket/57807)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
