### PR TITLE
Fixed duplicate hook reference for 'notify_moderator' in wp_new_comment_notify_moderator()

### DIFF
--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -2342,7 +2342,7 @@ function wp_new_comment_notify_moderator( $comment_id ) {
 	// Only send notifications for pending comments.
 	$maybe_notify = ( '0' == $comment->comment_approved );
 
-	/** This filter is documented in wp-includes/comment.php */
+	/** This filter is documented in wp-includes/pluggable.php */
 	$maybe_notify = apply_filters( 'notify_moderator', $maybe_notify, $comment_id );
 
 	if ( ! $maybe_notify ) {


### PR DESCRIPTION
See https://core.trac.wordpress.org/ticket/57808