### PR TITLE
Update documentation and forum link strings

### DIFF
--- a/src/wp-admin/customize.php
+++ b/src/wp-admin/customize.php
@@ -250,7 +250,7 @@ do_action( 'customize_controls_head' );
 						</p>
 						<p>
 							<?php
-							_e( '<a href="https://wordpress.org/documentation/article/appearance-customize-screen/">Documentation on Customizer</a>' );
+							_e( '<a href="https://wordpress.org/documentation/article/customizer/">Documentation on Customizer</a>' );
 							?>
 						</p>
 					</div>

--- a/src/wp-admin/theme-editor.php
+++ b/src/wp-admin/theme-editor.php
@@ -50,7 +50,7 @@ get_current_screen()->add_help_tab(
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __( 'For more information:' ) . '</strong></p>' .
 	'<p>' . __( '<a href="https://developer.wordpress.org/themes/">Documentation on Theme Development</a>' ) . '</p>' .
-	'<p>' . __( '<a href="https://wordpress.org/documentation/article/appearance-editor-screen/">Documentation on Editing Themes</a>' ) . '</p>' .
+	'<p>' . __( '<a href="https://wordpress.org/documentation/article/appearance-theme-file-editor-screen/">Documentation on Editing Themes</a>' ) . '</p>' .
 	'<p>' . __( '<a href="https://wordpress.org/documentation/article/editing-files/">Documentation on Editing Files</a>' ) . '</p>' .
 	'<p>' . __( '<a href="https://developer.wordpress.org/themes/basics/template-tags/">Documentation on Template Tags</a>' ) . '</p>' .
 	'<p>' . __( '<a href="https://wordpress.org/support/forums/">Support forums</a>' ) . '</p>'

--- a/src/wp-content/themes/twentytwentyone/inc/starter-content.php
+++ b/src/wp-content/themes/twentytwentyone/inc/starter-content.php
@@ -125,7 +125,7 @@ function twenty_twenty_one_get_starter_content() {
 
 					<!-- wp:column -->
 					<div class="wp-block-column"><!-- wp:paragraph -->
-					<p><a href="https://wordpress.org/support/theme/twentytwentyone/">' . esc_html_x( 'Check out the Support forums', 'Theme starter content', 'twentytwentyone' ) . '</a></p>
+					<p><a href="https://wordpress.org/support/theme/twentytwentyone/">' . esc_html_x( 'Check out the support forums', 'Theme starter content', 'twentytwentyone' ) . '</a></p>
 					<!-- /wp:paragraph --></div>
 					<!-- /wp:column --></div>
 					<!-- /wp:columns -->

--- a/src/wp-includes/class-wpdb.php
+++ b/src/wp-includes/class-wpdb.php
@@ -1267,7 +1267,7 @@ class wpdb {
 
 				$message .= '<p>' . sprintf(
 					/* translators: %s: Support forums URL. */
-					__( 'If you do not know how to set up a database you should <strong>contact your host</strong>. If all else fails you may find help at the <a href="%s">WordPress Support forums</a>.' ),
+					__( 'If you do not know how to set up a database, you should <strong>contact your host</strong>. If all else fails, you may find help at the <a href="%s">WordPress support forums</a>.' ),
 					__( 'https://wordpress.org/support/forums/' )
 				) . "</p>\n";
 
@@ -2081,7 +2081,7 @@ class wpdb {
 
 			$message .= '<p>' . sprintf(
 				/* translators: %s: Support forums URL. */
-				__( 'If you are unsure what these terms mean you should probably contact your host. If you still need help you can always visit the <a href="%s">WordPress Support forums</a>.' ),
+				__( 'If you are unsure what these terms mean, you should probably contact your host. If you still need help, you can always visit the <a href="%s">WordPress support forums</a>.' ),
 				__( 'https://wordpress.org/support/forums/' )
 			) . "</p>\n";
 
@@ -2241,7 +2241,7 @@ class wpdb {
 
 		$message .= '<p>' . sprintf(
 			/* translators: %s: Support forums URL. */
-			__( 'If you are unsure what these terms mean you should probably contact your host. If you still need help you can always visit the <a href="%s">WordPress Support forums</a>.' ),
+			__( 'If you are unsure what these terms mean, you should probably contact your host. If you still need help, you can always visit the <a href="%s">WordPress support forums</a>.' ),
 			__( 'https://wordpress.org/support/forums/' )
 		) . "</p>\n";
 

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -176,7 +176,7 @@ function wp_check_php_mysql_versions() {
 
 		$message .= '<p>' . sprintf(
 			/* translators: %s: Support forums URL. */
-			__( 'If you are unsure what these terms mean you should probably contact your host. If you still need help you can always visit the <a href="%s">WordPress Support forums</a>.' ),
+			__( 'If you are unsure what these terms mean, you should probably contact your host. If you still need help, you can always visit the <a href="%s">WordPress support forums</a>.' ),
 			__( 'https://wordpress.org/support/forums/' )
 		) . "</p>\n";
 


### PR DESCRIPTION
- Updates Customizer and Theme documentation links to eliminate a redirect.
- Uses lowercase "support" in forum links (Twenty Twenty-One starter content, `wp-includes/class-wpdb.php` and `wp-includes/load.php`).
- Adds commas in the sentences for `wp-includes/class-wpdb.php` and `wp-includes/load.php`.

[Trac 57726](https://core.trac.wordpress.org/ticket/57726)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
