### PR TITLE
Deprecate _resolve_home_block_template()

### DIFF
--- a/src/wp-includes/block-template.php
+++ b/src/wp-includes/block-template.php
@@ -335,35 +335,3 @@ function _resolve_template_for_new_post( $wp_query ) {
 		$wp_query->set( 'post_status', 'auto-draft' );
 	}
 }
-
-/**
- * Returns the correct template for the site's home page.
- *
- * @access private
- * @since 6.0.0
- *
- * @return array|null A template object, or null if none could be found.
- */
-function _resolve_home_block_template() {
-	$show_on_front = get_option( 'show_on_front' );
-	$front_page_id = get_option( 'page_on_front' );
-
-	if ( 'page' === $show_on_front && $front_page_id ) {
-		return array(
-			'postType' => 'page',
-			'postId'   => $front_page_id,
-		);
-	}
-
-	$hierarchy = array( 'front-page', 'home', 'index' );
-	$template  = resolve_block_template( 'home', $hierarchy, '' );
-
-	if ( ! $template ) {
-		return null;
-	}
-
-	return array(
-		'postType' => 'wp_template',
-		'postId'   => $template->id,
-	);
-}

--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -4591,3 +4591,38 @@ function get_page_by_title( $page_title, $output = OBJECT, $post_type = 'page' )
 
 	return null;
 }
+
+/**
+ * Returns the correct template for the site's home page.
+ *
+ * @access private
+ * @since 6.0.0
+ * @deprecated 6.2.0
+ *
+ * @return array|null A template object, or null if none could be found.
+ */
+function _resolve_home_block_template() {
+	_deprecated_function( __FUNCTION__, '6.2.0' );
+
+	$show_on_front = get_option( 'show_on_front' );
+	$front_page_id = get_option( 'page_on_front' );
+
+	if ( 'page' === $show_on_front && $front_page_id ) {
+		return array(
+				'postType' => 'page',
+				'postId'   => $front_page_id,
+		);
+	}
+
+	$hierarchy = array( 'front-page', 'home', 'index' );
+	$template  = resolve_block_template( 'home', $hierarchy, '' );
+
+	if ( ! $template ) {
+		return null;
+	}
+
+	return array(
+			'postType' => 'wp_template',
+			'postId'   => $template->id,
+	);
+}

--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -4597,7 +4597,8 @@ function get_page_by_title( $page_title, $output = OBJECT, $post_type = 'page' )
  *
  * @access private
  * @since 6.0.0
- * @deprecated 6.2.0
+ * @deprecated 6.2.0 Site Editor's server-side redirect for missing postType and postId
+ *             		 query args is removed. Thus, this function is no longer used.
  *
  * @return array|null A template object, or null if none could be found.
  */

--- a/tests/phpunit/tests/block-template.php
+++ b/tests/phpunit/tests/block-template.php
@@ -188,42 +188,4 @@ class Tests_Block_Template extends WP_UnitTestCase {
 		$resolved_template_path = locate_block_template( '', 'search', array() );
 		$this->assertSame( '', $resolved_template_path );
 	}
-
-	/**
-	 * Covers: https://github.com/WordPress/gutenberg/pull/38817.
-	 *
-	 * @ticket 55505
-	 */
-	public function test_resolve_home_block_template_default_hierarchy() {
-		$template = _resolve_home_block_template();
-
-		$this->assertSame( 'wp_template', $template['postType'] );
-		$this->assertSame( get_stylesheet() . '//index', $template['postId'] );
-	}
-
-	/**
-	 * @ticket 55505
-	 */
-	public function test_resolve_home_block_template_static_homepage() {
-		$post_id = self::factory()->post->create( array( 'post_type' => 'page' ) );
-		update_option( 'show_on_front', 'page' );
-		update_option( 'page_on_front', $post_id );
-
-		$template = _resolve_home_block_template();
-
-		$this->assertSame( 'page', $template['postType'] );
-		$this->assertSame( $post_id, $template['postId'] );
-
-		delete_option( 'show_on_front', 'page' );
-	}
-
-	/**
-	 * @ticket 55505
-	 */
-	public function test_resolve_home_block_template_no_resolution() {
-		switch_theme( 'stylesheetonly' );
-		$template = _resolve_home_block_template();
-
-		$this->assertNull( $template );
-	}
 }


### PR DESCRIPTION
Deprecate `_resolve_home_block_template()` which is no longer used in Core since [55338](https://core.trac.wordpress.org/changeset/55338).

As there is no replacement function, none is suggested in the deprecation notice.

Trac ticket: https://core.trac.wordpress.org/ticket/57716

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
