### PR TITLE
Fix for `WP_Theme_JSON_Resolver::get_merged_data`

### DIFF
--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -559,7 +559,8 @@ class WP_Theme_JSON_Resolver {
 			_deprecated_argument( __FUNCTION__, '5.9.0' );
 		}
 
-		$result = static::get_core_data();
+		$result = new WP_Theme_JSON();
+		$result->merge( static::get_core_data() );
 		if ( 'default' === $origin ) {
 			$result->set_spacing_sizes();
 			return $result;

--- a/tests/phpunit/tests/theme/wpThemeJsonResolver.php
+++ b/tests/phpunit/tests/theme/wpThemeJsonResolver.php
@@ -848,6 +848,40 @@ class Tests_Theme_wpThemeJsonResolver extends WP_UnitTestCase {
 
 	}
 
+	public function test_get_merged_data_returns_origin_proper(){
+		// Make sure the theme has a theme.json
+		// though it doesn't have any data for styles.spacing.padding.
+		switch_theme( 'block-theme' );
+
+		// Make sure the user defined some data for styles.spacing.padding.
+		wp_set_current_user( self::$administrator_id );
+		$user_cpt = WP_Theme_JSON_Resolver::get_user_data_from_wp_global_styles( wp_get_theme(), true );
+		$config   = json_decode( $user_cpt['post_content'], true );
+		$config['styles']['spacing']['padding'] = array(
+				'top'    => '23px',
+				'left'   => '23px',
+				'bottom' => '23px',
+				'right'  => '23px',
+		);
+		$user_cpt['post_content']                         = wp_json_encode( $config );
+		wp_update_post( $user_cpt, true, false );
+
+		// Query data from the user origin and then for the theme origin.
+		$theme_json_user  = WP_Theme_JSON_Resolver::get_merged_data( 'custom' );
+		$padding_user     = $theme_json_user->get_raw_data()['styles']['spacing']['padding'];
+		$theme_json_theme = WP_Theme_JSON_Resolver::get_merged_data( 'theme' );
+		$padding_theme    = $theme_json_theme->get_raw_data()['styles']['spacing']['padding'];
+
+		$this->assertSame( '23px', $padding_user['top'] );
+		$this->assertSame( '23px', $padding_user['right'] );
+		$this->assertSame( '23px', $padding_user['bottom'] );
+		$this->assertSame( '23px', $padding_user['left'] );
+		$this->assertSame( '0px', $padding_theme['top'] );
+		$this->assertSame( '0px', $padding_theme['right'] );
+		$this->assertSame( '0px', $padding_theme['bottom'] );
+		$this->assertSame( '0px', $padding_theme['left'] );
+	}
+
 	/**
 	 * Data provider.
 	 *

--- a/tests/phpunit/tests/theme/wpThemeJsonResolver.php
+++ b/tests/phpunit/tests/theme/wpThemeJsonResolver.php
@@ -848,7 +848,16 @@ class Tests_Theme_wpThemeJsonResolver extends WP_UnitTestCase {
 
 	}
 
-	public function test_get_merged_data_returns_origin_proper(){
+	/**
+	 * Tests that get_merged_data returns the data merged up to the proper origin
+	 * and that the core values have the proper data.
+	 *
+	 * @ticket 57824
+	 *
+	 * @covers WP_Theme_JSON_Resolver::get_merged_data
+	 *
+	 */
+	public function test_get_merged_data_returns_origin_proper() {
 		// Make sure the theme has a theme.json
 		// though it doesn't have any data for styles.spacing.padding.
 		switch_theme( 'block-theme' );
@@ -858,10 +867,10 @@ class Tests_Theme_wpThemeJsonResolver extends WP_UnitTestCase {
 		$user_cpt = WP_Theme_JSON_Resolver::get_user_data_from_wp_global_styles( wp_get_theme(), true );
 		$config   = json_decode( $user_cpt['post_content'], true );
 		$config['styles']['spacing']['padding'] = array(
-				'top'    => '23px',
-				'left'   => '23px',
-				'bottom' => '23px',
-				'right'  => '23px',
+			'top'    => '23px',
+			'left'   => '23px',
+			'bottom' => '23px',
+			'right'  => '23px',
 		);
 		$user_cpt['post_content']                         = wp_json_encode( $config );
 		wp_update_post( $user_cpt, true, false );

--- a/tests/phpunit/tests/theme/wpThemeJsonResolver.php
+++ b/tests/phpunit/tests/theme/wpThemeJsonResolver.php
@@ -864,15 +864,15 @@ class Tests_Theme_wpThemeJsonResolver extends WP_UnitTestCase {
 
 		// Make sure the user defined some data for styles.spacing.padding.
 		wp_set_current_user( self::$administrator_id );
-		$user_cpt = WP_Theme_JSON_Resolver::get_user_data_from_wp_global_styles( wp_get_theme(), true );
-		$config   = json_decode( $user_cpt['post_content'], true );
+		$user_cpt                               = WP_Theme_JSON_Resolver::get_user_data_from_wp_global_styles( wp_get_theme(), true );
+		$config                                 = json_decode( $user_cpt['post_content'], true );
 		$config['styles']['spacing']['padding'] = array(
 			'top'    => '23px',
 			'left'   => '23px',
 			'bottom' => '23px',
 			'right'  => '23px',
 		);
-		$user_cpt['post_content']                         = wp_json_encode( $config );
+		$user_cpt['post_content']               = wp_json_encode( $config );
 		wp_update_post( $user_cpt, true, false );
 
 		// Query data from the user origin and then for the theme origin.


### PR DESCRIPTION
Trac ticket https://core.trac.wordpress.org/ticket/57824
Reverts https://github.com/WordPress/wordpress-develop/pull/3441

## What

This PR fixes a bug by which the reset function of the global styles sidebar wouldn't work as expected in the site editor.

## How to reproduce

Take the following steps:

- Using TwentyTwentyTwo and any WordPress version after [rev54517](https://github.com/WordPress/wordpress-develop/pull/3441), for example, WordPress 6.2 beta 3.
- Go to the site editor.
- Open the global styles sidebar and set the padding values to something else (222px, for example).
- Save the changes and reload the editor.
- Open the global styles sidebar and try resetting the padding values (for example, by using the "Reset to defaults" option displayed under the three dot menu of the global styles sidebar).
- The expected result is that the values would be reset. However, they are not.

Note that if this is saved and then site editor reloaded, the proper data is shown.

## How this PR fixes the issue

By reverting https://github.com/WordPress/wordpress-develop/pull/3441 which was the one that introduced the issue.

That PR changed the `get_merged_data` code to (pseudo-code):

```php
function get_merged_data( $origin ) {
    $result = static::get_core_data();

    if ( 'block' === $origin ) { $result->merge( static::get_block_data() ); }
    if ( 'theme' === $origin ) { $result->merge( static::get_theme_data() ); }
    if ( 'custom' === $origin ) { $result->merge( static::get_custom_data() ); }

    return $result;
}
```

However, by doing so, the base object (`$result`) is modifying the `$core` object directly, and `$core` ends up storing the consolidated values instead of only the ones coming from the `theme.json` provided by core.

This is problematic because `$core` data is cached. Take, for example, the following scenario:

```php
$data = get_merged_data( 'custom' );
$data = get_merged_data( 'theme' );
```

The expected output for `$data` is that it should not have data coming from the 'custom' origin, however, it does.

The fix is reverting the change and use an empty object as base (pseudo-code):

```php
function get_merged_data( $origin ) {
    $result = new WP_Theme_JSON();

    $result->merge( static::get_core_data() );
    if ( 'block' === $origin ) { $result->merge( static::get_block_data() ); }
    if ( 'theme' === $origin ) { $result->merge( static::get_theme_data() ); }
    if ( 'custom' === $origin ) { $result->merge( static::get_custom_data() ); }

    return $result;
}
```

## Performance

This is a bug that needs to be fixed. I thought about running some performance analysis anyway, given the intent of the PR this reverts was improving performance. Given the improvements introduced in 6.2, reverting the PR doesn't affect performance.

Using XDebug (only for completeness, we should not use data extracted from a xdebug profiler to make perf decisions, as there's a cost to observability):

| Method                                    | WordPress 6.2 rev55436     | This PR (based off trunk@55436)          |
| ----------------------------------------- | ---------------- | ----------------- |
| `WP_Theme_JSON_Resolver::get_merged_data` | 23ms (6 calls)   | 24ms (6 calls)  |
| `WP_Theme_JSON->merge`                    | 3.5ms (24ms) | 5.8ms (30 calls) |

Using production code (see [raw data](https://docs.google.com/spreadsheets/d/14kxomBT3PurwJk_-4vKr1CLZJZm9BL8tMIhn0Ks4Baw/edit#gid=0)): the variance is sub-millisecond, so it may be attributed to the measuring conditions.

![image](https://user-images.githubusercontent.com/583546/221940283-0cbbfeb0-d12a-4b4c-ad1b-85b3c752ec69.png)

