### PR TITLE
Editor: Add RTL test for `register_block_style_handle()`.

### DIFF
--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -372,6 +372,36 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 			wp_normalize_path( realpath( DIR_TESTDATA . '/blocks/notice/block.css' ) ),
 			wp_normalize_path( wp_styles()->get_data( 'unit-tests-test-block-style', 'path' ) )
 		);
+
+	}
+
+	/**
+	 * @ticket 56797
+	 */
+	public function test_success_register_block_style_handle_rtl() {
+
+		global $wp_locale;
+		$orig_text_dir = $wp_locale->text_direction;
+
+		$wp_locale->text_direction = 'rtl';
+
+		$metadata = array(
+			'file'  => DIR_TESTDATA . '/blocks/notice/block.json',
+			'name'  => 'unit-tests/test-block-rtl',
+			'style' => 'file:./block.css',
+		);
+		$result   = register_block_style_handle( $metadata, 'style' );
+
+		$this->assertSame( 'unit-tests-test-block-rtl-style', $result );
+		$this->assertSame( 'replace', wp_styles()->get_data( 'unit-tests-test-block-rtl-style', 'rtl' ) );
+		$this->assertSame( '', wp_styles()->get_data( 'unit-tests-test-block-rtl-style', 'suffix' ) );
+		$this->assertSame(
+			wp_normalize_path( realpath( DIR_TESTDATA . '/blocks/notice/block-rtl.css' ) ),
+			wp_normalize_path( wp_styles()->get_data( 'unit-tests-test-block-rtl-style', 'path' ) )
+		);
+
+		$wp_locale->text_direction = $orig_text_dir;
+
 	}
 
 	/**

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -376,32 +376,52 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that register_block_style_handle() loads RTL stylesheets when an RTL locale is set.
+	 *
 	 * @ticket 56797
+	 *
+	 * @covers ::register_block_style_handle
 	 */
-	public function test_success_register_block_style_handle_rtl() {
-
+	public function test_register_block_style_handle_should_load_rtl_stylesheets_for_rtl_text_direction() {
 		global $wp_locale;
-		$orig_text_dir = $wp_locale->text_direction;
-
-		$wp_locale->text_direction = 'rtl';
 
 		$metadata = array(
 			'file'  => DIR_TESTDATA . '/blocks/notice/block.json',
 			'name'  => 'unit-tests/test-block-rtl',
 			'style' => 'file:./block.css',
 		);
-		$result   = register_block_style_handle( $metadata, 'style' );
 
-		$this->assertSame( 'unit-tests-test-block-rtl-style', $result );
-		$this->assertSame( 'replace', wp_styles()->get_data( 'unit-tests-test-block-rtl-style', 'rtl' ) );
-		$this->assertSame( '', wp_styles()->get_data( 'unit-tests-test-block-rtl-style', 'suffix' ) );
-		$this->assertSame(
-			wp_normalize_path( realpath( DIR_TESTDATA . '/blocks/notice/block-rtl.css' ) ),
-			wp_normalize_path( wp_styles()->get_data( 'unit-tests-test-block-rtl-style', 'path' ) )
-		);
-
+		$orig_text_dir             = $wp_locale->text_direction;
+		$wp_locale->text_direction = 'rtl';
+		$handle                    = register_block_style_handle( $metadata, 'style' );
+		$extra_rtl                 = wp_styles()->get_data( 'unit-tests-test-block-rtl-style', 'rtl' );
+		$extra_suffix              = wp_styles()->get_data( 'unit-tests-test-block-rtl-style', 'suffix' );
+		$extra_path                = wp_normalize_path( wp_styles()->get_data( 'unit-tests-test-block-rtl-style', 'path' ) );
 		$wp_locale->text_direction = $orig_text_dir;
 
+		$this->assertSame(
+			'unit-tests-test-block-rtl-style',
+			$handle,
+			'The handle does not match the expected handle.'
+		);
+
+		$this->assertSame(
+			'replace',
+			$extra_rtl,
+			'The extra "rtl" data was not "replace".'
+		);
+
+		$this->assertSame(
+			'',
+			$extra_suffix,
+			'The extra "suffix" data was not an empty string.'
+		);
+
+		$this->assertSame(
+			wp_normalize_path( realpath( DIR_TESTDATA . '/blocks/notice/block-rtl.css' ) ),
+			$extra_path,
+			'The "path" did not match the expected path.'
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -402,7 +402,7 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 		$this->assertSame(
 			'unit-tests-test-block-rtl-style',
 			$handle,
-			'The handle does not match the expected handle.'
+			'The handle did not match the expected handle.'
 		);
 
 		$this->assertSame(


### PR DESCRIPTION
This adds a PHPUnit test for `register_block_style_handle()` to confirm that RTL stylesheets for blocks are correctly loaded when an RTL locale is set.

Refreshes the previous patch.

Coverage report:
![image](https://user-images.githubusercontent.com/79332690/222069922-0da6416c-36bf-4a03-a898-06bf4c09d3b0.png)


Trac ticket: https://core.trac.wordpress.org/ticket/56797