### PR TITLE
Media: Rename the `wp_ajax_save_attachment` action to `wp_ajax_save_attachment_updated`.

### DIFF
--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3149,12 +3149,15 @@ function wp_ajax_save_attachment() {
 		 * Fires after an attachment has been updated via the Ajax handler
 		 * and before the JSON response is sent.
 		 *
+		 * When checking if an action is being done, `doing_action( 'wp_ajax_save-attachment' )`
+		 * may be used if that is more convenient.
+		 *
 		 * @since 6.2.0
 		 *
 		 * @param array $post    The attachment data.
 		 * @param array $changes An array containing the updated attachment attributes.
 		 */
-		do_action( 'wp_ajax_save_attachment', $post, $changes );
+		do_action( 'wp_ajax_save_attachment_updated', $post, $changes );
 	}
 
 	wp_send_json_success();


### PR DESCRIPTION
This renames the `wp_ajax_save_attachment` action to `wp_ajax_save_attachment_updated` to avoid confusion with the similarly named `wp_ajax_save-attachment` action.

When checking if an action is being done, `doing_action( 'wp_ajax_save-attachment' )` may be used if that is more convenient.

Trac ticket: https://core.trac.wordpress.org/ticket/23148