### PR TITLE
Remove unnecessary test

### DIFF
--- a/tests/phpunit/tests/theme/wpThemeJsonResolver.php
+++ b/tests/phpunit/tests/theme/wpThemeJsonResolver.php
@@ -849,49 +849,6 @@ class Tests_Theme_wpThemeJsonResolver extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that get_merged_data returns the data merged up to the proper origin
-	 * and that the core values have the proper data.
-	 *
-	 * @ticket 57824
-	 *
-	 * @covers WP_Theme_JSON_Resolver::get_merged_data
-	 *
-	 */
-	public function test_get_merged_data_returns_origin_proper() {
-		// Make sure the theme has a theme.json
-		// though it doesn't have any data for styles.spacing.padding.
-		switch_theme( 'block-theme' );
-
-		// Make sure the user defined some data for styles.spacing.padding.
-		wp_set_current_user( self::$administrator_id );
-		$user_cpt                               = WP_Theme_JSON_Resolver::get_user_data_from_wp_global_styles( wp_get_theme(), true );
-		$config                                 = json_decode( $user_cpt['post_content'], true );
-		$config['styles']['spacing']['padding'] = array(
-			'top'    => '23px',
-			'left'   => '23px',
-			'bottom' => '23px',
-			'right'  => '23px',
-		);
-		$user_cpt['post_content']               = wp_json_encode( $config );
-		wp_update_post( $user_cpt, true, false );
-
-		// Query data from the user origin and then for the theme origin.
-		$theme_json_user  = WP_Theme_JSON_Resolver::get_merged_data( 'custom' );
-		$padding_user     = $theme_json_user->get_raw_data()['styles']['spacing']['padding'];
-		$theme_json_theme = WP_Theme_JSON_Resolver::get_merged_data( 'theme' );
-		$padding_theme    = $theme_json_theme->get_raw_data()['styles']['spacing']['padding'];
-
-		$this->assertSame( '23px', $padding_user['top'] );
-		$this->assertSame( '23px', $padding_user['right'] );
-		$this->assertSame( '23px', $padding_user['bottom'] );
-		$this->assertSame( '23px', $padding_user['left'] );
-		$this->assertSame( '0px', $padding_theme['top'] );
-		$this->assertSame( '0px', $padding_theme['right'] );
-		$this->assertSame( '0px', $padding_theme['bottom'] );
-		$this->assertSame( '0px', $padding_theme['left'] );
-	}
-
-	/**
 	 * Data provider.
 	 *
 	 * @return array[]


### PR DESCRIPTION
Trac ticket https://core.trac.wordpress.org/ticket/57824

The test introduced in https://github.com/WordPress/wordpress-develop/pull/4145 wasn't actually reporting the bug. Unless we find a way in that it works to signal a regression, it should be removed to avoid an illusion of security.

