### PR TITLE
Media: Add tests for `wp_check_filetype()`.

### DIFF
--- a/tests/phpunit/tests/functions/wpCheckFiletype.php
+++ b/tests/phpunit/tests/functions/wpCheckFiletype.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * Test the wp_upload_bits function
+ *
+ * @group Functions
+ * @group Upload
+ * @covers ::wp_check_filetype
+ */
+class Test_wp_check_filetype extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 57151
+	 * @dataProvider wp_check_filetype_dataset
+	 */
+	function test_wp_check_filetypes( $filename, $mines, $expected ) {
+		$this->assertSame( $expected, wp_check_filetype( $filename, $mines ) );
+	}
+
+	function wp_check_filetype_dataset() {
+		return array(
+			'default'     => array(
+				'filename' => 'canola.jpg',
+				'mines'    => null,
+				'expected' => array(
+					'ext'  => 'jpg',
+					'type' => 'image/jpeg',
+				),
+			),
+			'short_mines' => array(
+				'filename' => 'canola.jpg',
+				'mines'    => array(
+					'jpg|jpeg|jpe' => 'image/jpeg',
+					'gif'          => 'image/gif',
+				),
+				'expected' => array(
+					'ext'  => 'jpg',
+					'type' => 'image/jpeg',
+				),
+			),
+			'badfile'     => array(
+				'filename' => 'canola.XXX',
+				'mines'    => array(
+					'jpg|jpeg|jpe' => 'image/jpeg',
+					'gif'          => 'image/gif',
+				),
+				'expected' => array(
+					'ext'  => false,
+					'type' => false,
+				),
+			),
+			'bad_mines'   => array(
+				'filename' => 'canola.jpg',
+				'mines'    => array(
+					'gif' => 'image/gif',
+				),
+				'expected' => array(
+					'ext'  => false,
+					'type' => false,
+				),
+			),
+
+		);
+	}
+}

--- a/tests/phpunit/tests/functions/wpCheckFiletype.php
+++ b/tests/phpunit/tests/functions/wpCheckFiletype.php
@@ -31,7 +31,7 @@ class Test_wp_check_filetype extends WP_UnitTestCase {
 	 */
 	public function data_wp_check_filetype() {
 		return array(
-			'default'     => array(
+			'.jpg filename and default allowed'       => array(
 				'filename' => 'canola.jpg',
 				'mimes'    => null,
 				'expected' => array(
@@ -39,7 +39,7 @@ class Test_wp_check_filetype extends WP_UnitTestCase {
 					'type' => 'image/jpeg',
 				),
 			),
-			'short_mines' => array(
+			'.jpg filename and jpg|jpeg|jpe'          => array(
 				'filename' => 'canola.jpg',
 				'mimes'    => array(
 					'jpg|jpeg|jpe' => 'image/jpeg',
@@ -83,6 +83,7 @@ class Test_wp_check_filetype extends WP_UnitTestCase {
 					'type' => 'image/jpeg',
 				),
 			),
+			'.XXX filename and no matching MIME type' => array(
 				'filename' => 'canola.XXX',
 				'mimes'    => array(
 					'jpg|jpeg|jpe' => 'image/jpeg',
@@ -93,7 +94,7 @@ class Test_wp_check_filetype extends WP_UnitTestCase {
 					'type' => false,
 				),
 			),
-			'bad_mines'   => array(
+			'.jpg filename but only gif allowed'      => array(
 				'filename' => 'canola.jpg',
 				'mimes'    => array(
 					'gif' => 'image/gif',

--- a/tests/phpunit/tests/functions/wpCheckFiletype.php
+++ b/tests/phpunit/tests/functions/wpCheckFiletype.php
@@ -1,13 +1,14 @@
 <?php
 
 /**
- * Test the wp_upload_bits function
+ * Tests for wp_check_filetype().
  *
- * @group Functions
- * @group Upload
+ * @group functions.php
+ * @group upload
+ *
  * @covers ::wp_check_filetype
  */
-class Test_wp_check_filetype extends WP_UnitTestCase {
+class Tests_Functions_WpCheckFiletype extends WP_UnitTestCase {
 
 	/**
 	 * Tests that wp_check_filetype() returns the correct extension and MIME type.

--- a/tests/phpunit/tests/functions/wpCheckFiletype.php
+++ b/tests/phpunit/tests/functions/wpCheckFiletype.php
@@ -10,18 +10,30 @@
 class Test_wp_check_filetype extends WP_UnitTestCase {
 
 	/**
+	 * Tests that wp_check_filetype() returns the correct extension and MIME type.
+	 *
 	 * @ticket 57151
-	 * @dataProvider wp_check_filetype_dataset
+	 *
+	 * @dataProvider data_wp_check_filetype
+	 *
+	 * @param string     $filename   The filename to check.
+	 * @param array|null $mimes      An array of MIME types, or null.
+	 * @param array      $expected   An array containing the expected extension and MIME type.
 	 */
-	function test_wp_check_filetypes( $filename, $mines, $expected ) {
-		$this->assertSame( $expected, wp_check_filetype( $filename, $mines ) );
+	public function test_wp_check_filetype( $filename, $mimes, $expected ) {
+		$this->assertSame( $expected, wp_check_filetype( $filename, $mimes ) );
 	}
 
-	function wp_check_filetype_dataset() {
+	/**
+	 * Data provider.
+	 *
+	 * @return[]
+	 */
+	public function data_wp_check_filetype() {
 		return array(
 			'default'     => array(
 				'filename' => 'canola.jpg',
-				'mines'    => null,
+				'mimes'    => null,
 				'expected' => array(
 					'ext'  => 'jpg',
 					'type' => 'image/jpeg',
@@ -29,7 +41,7 @@ class Test_wp_check_filetype extends WP_UnitTestCase {
 			),
 			'short_mines' => array(
 				'filename' => 'canola.jpg',
-				'mines'    => array(
+				'mimes'    => array(
 					'jpg|jpeg|jpe' => 'image/jpeg',
 					'gif'          => 'image/gif',
 				),
@@ -72,7 +84,7 @@ class Test_wp_check_filetype extends WP_UnitTestCase {
 				),
 			),
 				'filename' => 'canola.XXX',
-				'mines'    => array(
+				'mimes'    => array(
 					'jpg|jpeg|jpe' => 'image/jpeg',
 					'gif'          => 'image/gif',
 				),
@@ -83,7 +95,7 @@ class Test_wp_check_filetype extends WP_UnitTestCase {
 			),
 			'bad_mines'   => array(
 				'filename' => 'canola.jpg',
-				'mines'    => array(
+				'mimes'    => array(
 					'gif' => 'image/gif',
 				),
 				'expected' => array(

--- a/tests/phpunit/tests/functions/wpCheckFiletype.php
+++ b/tests/phpunit/tests/functions/wpCheckFiletype.php
@@ -38,7 +38,39 @@ class Test_wp_check_filetype extends WP_UnitTestCase {
 					'type' => 'image/jpeg',
 				),
 			),
-			'badfile'     => array(
+			'.jpeg filename and jpg|jpeg|jpe'         => array(
+				'filename' => 'canola.jpeg',
+				'mimes'    => array(
+					'jpg|jpeg|jpe' => 'image/jpeg',
+					'gif'          => 'image/gif',
+				),
+				'expected' => array(
+					'ext'  => 'jpeg',
+					'type' => 'image/jpeg',
+				),
+			),
+			'.jpe filename and jpg|jpeg|jpe'          => array(
+				'filename' => 'canola.jpe',
+				'mimes'    => array(
+					'jpg|jpeg|jpe' => 'image/jpeg',
+					'gif'          => 'image/gif',
+				),
+				'expected' => array(
+					'ext'  => 'jpe',
+					'type' => 'image/jpeg',
+				),
+			),
+			'uppercase filename and jpg|jpeg|jpe'     => array(
+				'filename' => 'canola.JPG',
+				'mimes'    => array(
+					'jpg|jpeg|jpe' => 'image/jpeg',
+					'gif'          => 'image/gif',
+				),
+				'expected' => array(
+					'ext'  => 'JPG',
+					'type' => 'image/jpeg',
+				),
+			),
 				'filename' => 'canola.XXX',
 				'mines'    => array(
 					'jpg|jpeg|jpe' => 'image/jpeg',


### PR DESCRIPTION
Refreshes #3648.

This adds tests for `wp_check_filetype()`, and achieves 100% line and branch coverage.

![image](https://user-images.githubusercontent.com/79332690/222239711-f85dd8c1-482f-4274-8740-9a12906af35f.png)

Trac ticket: https://core.trac.wordpress.org/ticket/57151
