### PR TITLE
Build WP prior to starting docker in PHP Unit actions.

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -135,6 +135,9 @@ jobs:
       - name: Install npm dependencies
         run: npm ci
 
+      - name: Build WordPress in /src
+        run: npm run build:dev
+
       - name: General debug information
         run: |
           npm --version


### PR DESCRIPTION
Build WP in the source directory prior to running the PHP Unit tests.

This is to account for the generated files in `src/wp-includes/assets`.

An alternative approach exists in PR #4162

Trac ticket: https://core.trac.wordpress.org/ticket/57844

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
