### PR TITLE
Only attempt to register development assets if the dependency files exists.

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -240,7 +240,11 @@ function wp_register_development_scripts( $scripts ) {
 	);
 
 	foreach ( $development_scripts as $script_name ) {
-		$assets = include ABSPATH . WPINC . '/assets/script-loader-' . $script_name . '.php';
+		$asset_path = ABSPATH . WPINC . '/assets/script-loader-' . $script_name . '.php';
+		if ( ! file_exists( $asset_path ) ) {
+			continue;
+		}
+		$assets = include $asset_path;
 		if ( ! is_array( $assets ) ) {
 			return;
 		}

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -291,7 +291,7 @@ function wp_default_packages_scripts( $scripts ) {
 		 */
 		$assets_path = ABSPATH . WPINC . '/assets/script-loader-packages.min.php';
 	}
-	$assets = include ABSPATH . WPINC . "/assets/script-loader-packages{$suffix}.php";
+	$assets = include $asset_path;
 
 	foreach ( $assets as $file_name => $package_data ) {
 		$basename = str_replace( $suffix . '.js', '', basename( $file_name ) );

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -291,7 +291,7 @@ function wp_default_packages_scripts( $scripts ) {
 		 */
 		$assets_path = ABSPATH . WPINC . '/assets/script-loader-packages.min.php';
 	}
-	$assets = include $asset_path;
+	$assets = include $assets_path;
 
 	foreach ( $assets as $file_name => $package_data ) {
 		$basename = str_replace( $suffix . '.js', '', basename( $file_name ) );

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -279,6 +279,18 @@ function wp_default_packages_scripts( $scripts ) {
 	 *     'annotations.js' => array('dependencies' => array(...), 'version' => '...'),
 	 *     'api-fetch.js' => array(...
 	 */
+	$assets_path = ABSPATH . WPINC . "/assets/script-loader-packages{$suffix}.php";
+	if ( '' === $suffix && ! file_exists( $assets_path ) ) {
+		/*
+		 * Most likely due to the use of the `script-loader-packages.php` file.
+		 *
+		 * The `script-loader-packages.min.php` file is committed to WordPress
+		 * so use that for the assets instead. The suffix can remain unchanged
+		 * as the JavaScript files themselves are only ever present in both
+		 * their compressed and uncompressed forms.
+		 */
+		$assets_path = ABSPATH . WPINC . '/assets/script-loader-packages.min.php';
+	}
 	$assets = include ABSPATH . WPINC . "/assets/script-loader-packages{$suffix}.php";
 
 	foreach ( $assets as $file_name => $package_data ) {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Alternative approach to PR #4161.

Instead of building the assets during the build, only attempt to load the development assets if the dependency files exist.

This idea may be entirely broken if `SCRIPT_DEBUG` absolutely can not get by without the files.

Trac ticket: https://core.trac.wordpress.org/ticket/57844

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
