### PR TITLE
Tag Processor: Support RCData and Script tag closers

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -775,7 +775,8 @@ class WP_HTML_Tag_Processor {
 				return false;
 			}
 
-			$at += 2;
+			$closer_potentially_starts_at = $at;
+			$at                          += 2;
 
 			/*
 			 * Find a case-insensitive match to the tag name.
@@ -818,7 +819,7 @@ class WP_HTML_Tag_Processor {
 			}
 
 			if ( '>' === $html[ $at ] || '/' === $html[ $at ] ) {
-				++$this->bytes_already_parsed;
+				$this->bytes_already_parsed = $closer_potentially_starts_at;
 				return true;
 			}
 		}
@@ -887,7 +888,8 @@ class WP_HTML_Tag_Processor {
 			}
 
 			if ( '/' === $html[ $at ] ) {
-				$is_closing = true;
+				$closer_potentially_starts_at = $at - 1;
+				$is_closing                   = true;
 				++$at;
 			} else {
 				$is_closing = false;
@@ -938,7 +940,7 @@ class WP_HTML_Tag_Processor {
 			}
 
 			if ( $is_closing ) {
-				$this->bytes_already_parsed = $at;
+				$this->bytes_already_parsed = $closer_potentially_starts_at;
 				if ( $this->bytes_already_parsed >= $doc_length ) {
 					return false;
 				}
@@ -948,7 +950,7 @@ class WP_HTML_Tag_Processor {
 				}
 
 				if ( '>' === $html[ $this->bytes_already_parsed ] ) {
-					++$this->bytes_already_parsed;
+					$this->bytes_already_parsed = $closer_potentially_starts_at;
 					return true;
 				}
 			}

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -464,6 +464,36 @@ class Tests_HtmlApi_wpHtmlTagProcessor extends WP_UnitTestCase {
 	/**
 	 * @ticket 56299
 	 *
+	 * @dataProvider data_rcdata_and_script_tags
+	 * @covers WP_HTML_Tag_Processor::next_tag
+	 * @covers WP_HTML_Tag_Processor::is_tag_closer
+	 *
+	 * @param string $tag_name The name of the tag to test.
+	 */
+	public function test_next_tag_should_stop_on_rcdata_and_script_tag_closers_when_requested( $tag_name ) {
+		$p = new WP_HTML_Tag_Processor( "<$tag_name>abc</$tag_name>" );
+
+		$p->next_tag();
+		$this->assertTrue( $p->next_tag( array( 'tag_closers' => 'visit' ), 'Did not find the tag closer.' ) );
+		$this->assertTrue( $p->is_tag_closer(), 'Indicated a tag opener is a tag closer' );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return string[][].
+	 */
+	public function data_rcdata_and_script_tags() {
+		return array(
+			array( 'script' ),
+			array( 'textarea' ),
+			array( 'title' ),
+		);
+	}
+
+	/**
+	 * @ticket 56299
+	 *
 	 * @covers WP_HTML_Tag_Processor::set_attribute
 	 */
 	public function test_set_attribute_on_a_non_existing_tag_does_not_change_the_markup() {

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -474,7 +474,7 @@ class Tests_HtmlApi_wpHtmlTagProcessor extends WP_UnitTestCase {
 		$p = new WP_HTML_Tag_Processor( "<$tag_name>abc</$tag_name>" );
 
 		$p->next_tag();
-		$this->assertTrue( $p->next_tag( array( 'tag_closers' => 'visit' ), 'Did not find the tag closer.' ) );
+		$this->assertTrue( $p->next_tag( array( 'tag_closers' => 'visit' ) ), 'Did not find the tag closer' );
 		$this->assertTrue( $p->is_tag_closer(), 'Indicated a tag opener is a tag closer' );
 	}
 

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -464,31 +464,38 @@ class Tests_HtmlApi_wpHtmlTagProcessor extends WP_UnitTestCase {
 	/**
 	 * @ticket 57852
 	 *
-	 * @dataProvider data_rcdata_and_script_tags
 	 * @covers WP_HTML_Tag_Processor::next_tag
 	 * @covers WP_HTML_Tag_Processor::is_tag_closer
 	 *
 	 * @param string $tag_name The name of the tag to test.
 	 */
-	public function test_next_tag_should_stop_on_rcdata_and_script_tag_closers_when_requested( $tag_name ) {
-		$p = new WP_HTML_Tag_Processor( "<$tag_name>abc</$tag_name>" );
+	public function test_next_tag_should_stop_on_rcdata_and_script_tag_closers_when_requested() {
+		$p = new WP_HTML_Tag_Processor( '<script>abc</script>' );
 
 		$p->next_tag();
-		$this->assertTrue( $p->next_tag( array( 'tag_closers' => 'visit' ) ), 'Did not find the tag closer' );
-		$this->assertTrue( $p->is_tag_closer(), 'Indicated a tag opener is a tag closer' );
-	}
+		$this->assertTrue( $p->next_tag( array( 'tag_closers' => 'visit' ) ), 'Did not find the </script> tag closer' );
+		$this->assertTrue( $p->is_tag_closer(), 'Indicated a <script> tag opener is a tag closer' );
 
-	/**
-	 * Data provider.
-	 *
-	 * @return string[][].
-	 */
-	public function data_rcdata_and_script_tags() {
-		return array(
-			array( 'script' ),
-			array( 'textarea' ),
-			array( 'title' ),
-		);
+		$p = new WP_HTML_Tag_Processor( 'abc</script>' );
+		$this->assertTrue( $p->next_tag( array( 'tag_closers' => 'visit' ) ), 'Did not find the </script> tag closer when there was no tag opener' );
+
+		$p = new WP_HTML_Tag_Processor( '<textarea>abc</textarea>' );
+
+		$p->next_tag();
+		$this->assertTrue( $p->next_tag( array( 'tag_closers' => 'visit' ) ), 'Did not find the </textarea> tag closer' );
+		$this->assertTrue( $p->is_tag_closer(), 'Indicated a <textarea> tag opener is a tag closer' );
+
+		$p = new WP_HTML_Tag_Processor( 'abc</textarea>' );
+		$this->assertTrue( $p->next_tag( array( 'tag_closers' => 'visit' ) ), 'Did not find the </textarea> tag closer when there was no tag opener' );
+
+		$p = new WP_HTML_Tag_Processor( '<title>abc</title>' );
+
+		$p->next_tag();
+		$this->assertTrue( $p->next_tag( array( 'tag_closers' => 'visit' ) ), 'Did not find the </title> tag closer' );
+		$this->assertTrue( $p->is_tag_closer(), 'Indicated a <title> tag opener is a tag closer' );
+
+		$p = new WP_HTML_Tag_Processor( 'abc</title>' );
+		$this->assertTrue( $p->next_tag( array( 'tag_closers' => 'visit' ) ), 'Did not find the </title> tag closer when there was no tag opener' );
 	}
 
 	/**

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -462,7 +462,7 @@ class Tests_HtmlApi_wpHtmlTagProcessor extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket 56299
+	 * @ticket 57852
 	 *
 	 * @dataProvider data_rcdata_and_script_tags
 	 * @covers WP_HTML_Tag_Processor::next_tag

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -471,8 +471,6 @@ class Tests_HtmlApi_wpHtmlTagProcessor extends WP_UnitTestCase {
 	 *
 	 * @covers WP_HTML_Tag_Processor::next_tag
 	 * @covers WP_HTML_Tag_Processor::is_tag_closer
-	 *
-	 * @param string $tag_name The name of the tag to test.
 	 */
 	public function test_next_tag_should_stop_on_rcdata_and_script_tag_closers_when_requested() {
 		$p = new WP_HTML_Tag_Processor( '<script>abc</script>' );

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -430,6 +430,7 @@ class Tests_HtmlApi_wpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
+	 * @ticket 57852
 	 *
 	 * @covers WP_HTML_Tag_Processor::next_tag
 	 * @covers WP_HTML_Tag_Processor::is_tag_closer

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -459,6 +459,10 @@ class Tests_HtmlApi_wpHtmlTagProcessor extends WP_UnitTestCase {
 			'Did not stop at desired tag closer'
 		);
 		$this->assertTrue( $p->is_tag_closer(), 'Indicated a tag closer is a tag opener' );
+
+		$p = new WP_HTML_Tag_Processor( '<div>' );
+		$this->assertTrue( $p->next_tag( array( 'tag_closers' => 'visit' ) ), "Did not find a tag opener when tag_closers was set to 'visit'" );
+		$this->assertFalse( $p->next_tag( array( 'tag_closers' => 'visit' ) ), "Found a closer where there wasn't one" );
 	}
 
 	/**


### PR DESCRIPTION
## Description

With this PR, Tag Processor can navigate to `</script>`, `</textarea>`, and `</title>` tag closers:

```php
$p = new WP_HTML_Tag_Processor('<script>ABC</script><p>');
$p->next_tag();
$p->next_tag( array( 'tag_closers' => 'visit' ) );
$p->get_tag(); // 'script'
```

Without this commit, Tag Processor skips over them:

```php
$p = new WP_HTML_Tag_Processor('<script>ABC</script><p>');
$p->next_tag();
$p->next_tag( array( 'tag_closers' => 'visit' ) );
$p->get_tag(); // 'p'
```

Tag closers are supported by Tag Processor so it only makes sense to consistently support all of them.

cc @ockham @dmsnell @hellofromtonya @gziolo

Trac ticket: https://core.trac.wordpress.org/ticket/57852
