### PR TITLE
Tests: Replace some occurrences of `assertEquals()` with `assertSame()`.

### DIFF
--- a/tests/phpunit/tests/comment.php
+++ b/tests/phpunit/tests/comment.php
@@ -161,7 +161,7 @@ class Tests_Comment extends WP_UnitTestCase {
 		);
 
 		$comment = get_comment( $comment_id );
-		$this->assertEquals( '<a href="http://example.localhost/something.html" rel="nofollow ugc">click</a>', $comment->comment_content, 'Comment: ' . $comment->comment_content );
+		$this->assertSame( '<a href="http://example.localhost/something.html" rel="nofollow ugc">click</a>', $comment->comment_content, 'Comment: ' . $comment->comment_content );
 		wp_set_current_user( 0 );
 	}
 

--- a/tests/phpunit/tests/date/query.php
+++ b/tests/phpunit/tests/date/query.php
@@ -1186,7 +1186,7 @@ class Tests_Date_Query extends WP_UnitTestCase {
 
 		$parts = mb_split( '\)\s+AND\s+\(', $sql );
 		$this->assertIsArray( $parts, 'SQL query cannot be split into multiple parts using operator AND.' );
-		$this->assertEquals( 2, count( $parts ), 'SQL query does not contain correct number of AND operators.' );
+		$this->assertSame( 2, count( $parts ), 'SQL query does not contain correct number of AND operators.' );
 
 		$this->assertStringNotContainsString( 'OR', $sql, 'SQL query contains conditions joined by operator OR.' );
 	}
@@ -1233,7 +1233,7 @@ class Tests_Date_Query extends WP_UnitTestCase {
 
 		$parts = mb_split( '\)\s+OR\s+\(', $sql );
 		$this->assertIsArray( $parts, 'SQL query cannot be split into multiple parts using operator OR.' );
-		$this->assertEquals( 2, count( $parts ), 'SQL query does not contain correct number of OR operators.' );
+		$this->assertSame( 2, count( $parts ), 'SQL query does not contain correct number of OR operators.' );
 
 		// Checking number of occurrences of AND while skipping the one at the beginning.
 		$this->assertSame( 2, substr_count( substr( $sql, 5 ), 'AND' ), 'SQL query does not contain expected number conditions joined by operator AND.' );
@@ -1279,7 +1279,7 @@ class Tests_Date_Query extends WP_UnitTestCase {
 
 		$parts = mb_split( '\)\s+AND\s+\(', $sql );
 		$this->assertIsArray( $parts, 'SQL query cannot be split into multiple parts using operator AND.' );
-		$this->assertEquals( 2, count( $parts ), 'SQL query does not contain correct number of AND operators.' );
+		$this->assertSame( 2, count( $parts ), 'SQL query does not contain correct number of AND operators.' );
 
 		$this->assertStringNotContainsString( 'OR', $sql, 'SQL query contains conditions joined by operator OR.' );
 	}

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -3949,11 +3949,11 @@ EOF;
 		);
 
 		$metadata = wp_generate_attachment_metadata( $attachment_id, $file );
-		$this->assertEquals(
+		$this->assertSame(
 			array(),
 			$metadata['sizes']
 		);
-		$this->assertEquals(
+		$this->assertSame(
 			'test-square-150.jpg',
 			basename( $metadata['file'] )
 		);

--- a/tests/phpunit/tests/multisite/getBlogDetails.php
+++ b/tests/phpunit/tests/multisite/getBlogDetails.php
@@ -61,7 +61,7 @@ if ( is_multisite() ) :
 			}
 
 			$site = get_blog_details( 'foo' );
-			$this->assertEquals( self::$site_ids[ 'foo.' . WP_TESTS_DOMAIN . '/' ], $site->blog_id );
+			$this->assertSame( self::$site_ids[ 'foo.' . WP_TESTS_DOMAIN . '/' ], $site->blog_id );
 		}
 
 		public function test_get_blog_details_with_invalid_site_name_string() {

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -4708,7 +4708,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 		$reflection = new ReflectionMethod( $theme_json, 'process_blocks_custom_css' );
 		$reflection->setAccessible( true );
 
-		$this->assertEquals( $expected, $reflection->invoke( $theme_json, $input['css'], $input['selector'] ) );
+		$this->assertSame( $expected, $reflection->invoke( $theme_json, $input['css'], $input['selector'] ) );
 	}
 
 	/**


### PR DESCRIPTION
This ensures that not only the return values match the expected results, but also that their type is the same.

Trac ticket: https://core.trac.wordpress.org/ticket/56800