### PR TITLE
Fix php 'deprecated' warning on null parameters.

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2783,7 +2783,7 @@ function trailingslashit( $value ) {
  * @return string String without the trailing slashes.
  */
 function untrailingslashit( $value ) {
-	return rtrim( $value, '/\\' );
+	return rtrim( $value ?? '', '/\\' );
 }
 
 /**


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This little fix removes the following PHP warning from the debug log:

"[04-Mar-2023 10:45:00 UTC] PHP Deprecated:  rtrim(): Passing null to parameter #1 ($string) of type string is deprecated in /homepages/36/d24807059/htdocs/clickandbuilds/BergsportFamilieRaddatz/wp-includes/formatting.php on line 2786"

Trac ticket: https://core.trac.wordpress.org/ticket/57867

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
