### PR TITLE
Update the wp_uninitialize_site function to delete the uploads folder and custom db tables created by plugins

### DIFF
--- a/src/wp-includes/ms-site.php
+++ b/src/wp-includes/ms-site.php
@@ -799,22 +799,23 @@ function wp_uninitialize_site( $site_id ) {
 		switch_to_blog( $site->id );
 	}
 
-	$uploads = wp_get_upload_dir();
-
-	$tables = $wpdb->tables( 'blog' );
+	$prep_query = $wpdb->prepare( 'SELECT table_name FROM information_schema.TABLES WHERE table_name LIKE %s;', $wpdb->esc_like( "{$wpdb->base_prefix}{$site->id}_" ) . '%' );
+	$tables     = $wpdb->get_results( $prep_query, ARRAY_A );
 
 	/**
 	 * Filters the tables to drop when the site is deleted.
 	 *
 	 * @since MU (3.0.0)
 	 *
-	 * @param string[] $tables  Array of names of the site tables to be dropped.
-	 * @param int      $site_id The ID of the site to drop tables for.
+	 * @param string[] $drop_tables Array of names of the site tables to be dropped.
+	 * @param onject   $site        Contains the objects related to the subsite like the multisite site id that will be used to reference the drop tables for.
 	 */
 	$drop_tables = apply_filters( 'wpmu_drop_tables', $tables, $site->id );
 
 	foreach ( (array) $drop_tables as $table ) {
-		$wpdb->query( "DROP TABLE IF EXISTS `$table`" ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$table_name = $table['table_name'];
+
+		$wpdb->query( "DROP TABLE IF EXISTS `$table_name`" ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 	}
 
 	/**
@@ -822,48 +823,18 @@ function wp_uninitialize_site( $site_id ) {
 	 *
 	 * @since MU (3.0.0)
 	 *
-	 * @param string $basedir Uploads path without subdirectory. @see wp_upload_dir()
-	 * @param int    $site_id The site ID.
+	 * @param object $uploads Uploads path object. @see wp_upload_dir()
+	 * @param string $dir Filtered actual subsite directory path to be deleted.
 	 */
+	$uploads = wp_get_upload_dir();
 	$dir     = apply_filters( 'wpmu_delete_blog_upload_dir', $uploads['basedir'], $site->id );
-	$dir     = rtrim( $dir, DIRECTORY_SEPARATOR );
-	$top_dir = $dir;
-	$stack   = array( $dir );
-	$index   = 0;
 
-	while ( $index < count( $stack ) ) {
-		// Get indexed directory from stack.
-		$dir = $stack[ $index ];
+	require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-base.php';
+	require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-direct.php';
 
-		// phpcs:disable WordPress.PHP.NoSilencedErrors.Discouraged
-		$dh = @opendir( $dir );
-		if ( $dh ) {
-			$file = @readdir( $dh );
-			while ( false !== $file ) {
-				if ( '.' === $file || '..' === $file ) {
-					$file = @readdir( $dh );
-					continue;
-				}
+	$fileSystemDirect = new WP_Filesystem_Direct( false );
 
-				if ( @is_dir( $dir . DIRECTORY_SEPARATOR . $file ) ) {
-					$stack[] = $dir . DIRECTORY_SEPARATOR . $file;
-				} elseif ( @is_file( $dir . DIRECTORY_SEPARATOR . $file ) ) {
-					@unlink( $dir . DIRECTORY_SEPARATOR . $file );
-				}
-
-				$file = @readdir( $dh );
-			}
-			@closedir( $dh );
-		}
-		$index++;
-	}
-
-	$stack = array_reverse( $stack ); // Last added directories are deepest.
-	foreach ( (array) $stack as $dir ) {
-		if ( $dir != $top_dir ) {
-			@rmdir( $dir );
-		}
-	}
+	$fileSystemDirect->rmdir( $dir, true );
 
 	// phpcs:enable WordPress.PHP.NoSilencedErrors.Discouraged
 	if ( $switch ) {

--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -1386,7 +1386,9 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 	 */
 	public function remove_added_uploads() {
 		$uploads = wp_upload_dir();
-		$this->rmdir( $uploads['basedir'] );
+		if ( is_dir( $uploads['basedir'] ) ) {
+			$this->rmdir( $uploads['basedir'] );
+		}
 	}
 
 	/**


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Update the wp_uninitialize_site function to delete the uploads folder and custom db tables created by plugins

Trac ticket: https://core.trac.wordpress.org/ticket/43162

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
