### PR TITLE
Use assertSame() in Tests_Media::test_wp_generate_attachment_metadata_doesnt_generate_sizes_for_150_square_image()

### DIFF
--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -3935,6 +3935,8 @@ EOF;
 
 	/**
 	 * Test that an image size isn't generated if it matches the original image size.
+	 *
+	 * @ticket 57370
 	 */
 	public function test_wp_generate_attachment_metadata_doesnt_generate_sizes_for_150_square_image() {
 		$temp_dir = get_temp_dir();
@@ -3951,19 +3953,23 @@ EOF;
 		$metadata = wp_generate_attachment_metadata( $attachment_id, $file );
 		$this->assertSame(
 			array(),
-			$metadata['sizes']
+			$metadata['sizes'],
+			'The sizes should be an empty array'
 		);
 		$this->assertSame(
 			'test-square-150.jpg',
-			basename( $metadata['file'] )
+			basename( $metadata['file'] ),
+			'The file basename should match the given filename'
 		);
 		$this->assertSame(
 			150,
-			$metadata['width']
+			$metadata['width'],
+			'The width should be 150 (integer)'
 		);
 		$this->assertSame(
 			150,
-			$metadata['height']
+			$metadata['height'],
+			'The height should be 150 (integer)'
 		);
 	}
 

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -3958,11 +3958,11 @@ EOF;
 			basename( $metadata['file'] )
 		);
 		$this->assertSame(
-			'150',
+			150,
 			$metadata['width']
 		);
 		$this->assertSame(
-			'150',
+			150,
 			$metadata['height']
 		);
 	}

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -3949,7 +3949,7 @@ EOF;
 		);
 
 		$metadata = wp_generate_attachment_metadata( $attachment_id, $file );
-		$this->assertSame
+		$this->assertSame(
 			array(),
 			$metadata['sizes']
 		);

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -3949,19 +3949,19 @@ EOF;
 		);
 
 		$metadata = wp_generate_attachment_metadata( $attachment_id, $file );
-		$this->assertEquals(
+		$this->assertSame
 			array(),
 			$metadata['sizes']
 		);
-		$this->assertEquals(
+		$this->assertSame(
 			'test-square-150.jpg',
 			basename( $metadata['file'] )
 		);
-		$this->assertEquals(
+		$this->assertSame(
 			'150',
 			$metadata['width']
 		);
-		$this->assertEquals(
+		$this->assertSame(
 			'150',
 			$metadata['height']
 		);


### PR DESCRIPTION
Follow-up to PR #4166.

Changes:

* from `assertEquals()` to `assertSame()`. Why? To ensure both the return value and data type match the expected results.

* the expected height and width from `string` to `integer` data types. Why integer? `getimagesize()` (within `wp_getimagesize()`) will return an integer for both height and weight.

* adds the ticket annotation.

* adds assertion failure messages. Why? To denote which assertion failed, which aids in debugging efforts.

PR is a confidence check before committing.

Trac ticket: https://core.trac.wordpress.org/ticket/56800

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
