### PR TITLE
Add the 6.2 branch to the workflow for testing branches.

### DIFF
--- a/.github/workflows/test-old-branches.yml
+++ b/.github/workflows/test-old-branches.yml
@@ -28,12 +28,14 @@ jobs:
             'test-npm.yml'
         ]
         branch: [
-            '6.1','6.0',
+            '6.2', '6.1','6.0',
             '5.9', '5.8', '5.7', '5.6', '5.5', '5.4', '5.3', '5.2', '5.1', '5.0',
             '4.9', '4.8', '4.7', '4.6', '4.5', '4.4', '4.3', '4.2', '4.1'
         ]
         include:
           # PHP Compatibility testing was introduced in 5.5.
+          - branch: '6.2'
+            workflow: 'php-compatibility.yml'
           - branch: '6.1'
             workflow: 'php-compatibility.yml'
           - branch: '6.0'
@@ -52,6 +54,8 @@ jobs:
           # End-to-end testing was introduced in 5.3 but was later removed as there were no meaningful assertions.
           # Starting in 5.8 with #52905, some additional tests with real assertions were introduced.
           # Branches 5.8 and newer should be tested to confirm no regressions are introduced.
+          - branch: '6.2'
+            workflow: 'end-to-end-tests.yml'
           - branch: '6.1'
             workflow: 'end-to-end-tests.yml'
           - branch: '6.0'
@@ -65,7 +69,7 @@ jobs:
     steps:
       - name: Dispatch workflow run
         uses: actions/github-script@98814c53be79b1d30f795b907e553d8679345975 # v6.4.0
-        if: ${{ github.event_name == 'push' || github.event.schedule == '0 0 15 * *' || matrix.branch == '6.1' }}
+        if: ${{ github.event_name == 'push' || github.event.schedule == '0 0 15 * *' || matrix.branch == '6.2' }}
         with:
           retries: 2
           retry-exempt-status-codes: 418


### PR DESCRIPTION
Updates the Test Old Branches GitHub Actions workflow for the 6.2 branch.

This PR does not include changing the performance workflow (see PR #4160). [See discussion in Slack](https://wordpress.slack.com/archives/C02RQBWTW/p1678396750049369). @desrosj will handle the performance workflow separately.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
