### PR TITLE
Robots.txt: Add inline comments to the User-agent

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -1698,7 +1698,9 @@ function do_robots() {
 	 */
 	do_action( 'do_robotstxt' );
 
-	$output = "User-agent: *\n";
+	$output = "# Prevent crawling of WP internals\n";
+	$output .= "# --------------------------------\n";
+	$output .= "User-agent: *\n";
 	$public = get_option( 'blog_public' );
 
 	$site_url = parse_url( site_url() );


### PR DESCRIPTION
Trac ticket: https://meta.trac.wordpress.org/ticket/6763

This PR adds an inline comment to robots.txt.
Related: https://github.com/WordPress/wordpress.org/pull/129:

## Before
```
User-agent: *
Disallow: /wp-admin/
Disallow: /*/wp-admin/
Allow: /wp-admin/admin-ajax.php
Allow: /wp-admin/load-scripts.php
Allow: /wp-admin/load-styles.php
Disallow: /?rest_route=
Disallow: /xmlrpc.php
Disallow: /plugins/search/

# Prevent crawling of search URLs
# --------------------------------
Disallow: /search/
Disallow: /*/search/
Disallow: /?s=
Disallow: /*/?s=

# Prevent crawling of leaky theme endpoints
# --------------------------------
Disallow: /plugins/wp-json/plugins/v1/locale-banner
```

## After
```
# Prevent crawling of WP internals
# --------------------------------
User-agent: *
Disallow: /wp-admin/
Disallow: /*/wp-admin/
Allow: /wp-admin/admin-ajax.php
Allow: /wp-admin/load-scripts.php
Allow: /wp-admin/load-styles.php
Disallow: /?rest_route=
Disallow: /xmlrpc.php
Disallow: /plugins/search/

# Prevent crawling of search URLs
# --------------------------------
Disallow: /search/
Disallow: /*/search/
Disallow: /?s=
Disallow: /*/?s=

# Prevent crawling of leaky theme endpoints
# --------------------------------
Disallow: /plugins/wp-json/plugins/v1/locale-banner
```