### PR TITLE
REST attachments controller: Fix issue where terms cannot be assigned…

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -188,6 +188,13 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 
 		$request->set_param( 'context', 'edit' );
 
+		// Assign terms to the freshly uploaded attachment.
+
+		$terms_update = $this->handle_terms( $attachment_id, $request );
+		if ( is_wp_error( $terms_update ) ) {
+			return $terms_update;
+		}
+
 		/**
 		 * Fires after a single attachment is completely created or updated via the REST API.
 		 *


### PR DESCRIPTION
This PR fixes an issue where terms could not be assigned to newly uploaded attachments through the REST API, due to the `\WP_REST_Attachments_Controller::create_item()` function not calling `parent::create_item()` and thus not calling `\WP_REST_Posts_Controller::handle_terms()`. This PR adds the necessary lines of code to call `handle_terms()` in `create_item()`, allowing terms to be assigned to attachments through the REST API. The changes have been tested and work as expected.

Trac ticket: https://core.trac.wordpress.org/ticket/57897