### PR TITLE
Add `wp_cache_set_last_changed()` helper

### DIFF
--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -3918,7 +3918,7 @@ function wp_comments_personal_data_eraser( $email_address, $page = 1 ) {
  * @since 5.0.0
  */
 function wp_cache_set_comments_last_changed() {
-	wp_cache_set( 'last_changed', microtime(), 'comment' );
+	wp_cache_set_last_changed( 'comment' );
 }
 
 /**

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -7690,7 +7690,7 @@ function wp_cache_get_last_changed( $group ) {
 /**
  * Sets last changed date for the specified cache group to now.
  *
- * @since n.e.x.t.
+ * @since n.e.x.t
  *
  * @param string $group Where the cache contents are grouped.
  * @return string UNIX timestamp when the group was last changed.

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -7680,12 +7680,40 @@ function wp_unique_id( $prefix = '' ) {
 function wp_cache_get_last_changed( $group ) {
 	$last_changed = wp_cache_get( 'last_changed', $group );
 
-	if ( ! $last_changed ) {
-		$last_changed = microtime();
-		wp_cache_set( 'last_changed', $last_changed, $group );
+	if ( $last_changed ) {
+		return $last_changed;
 	}
 
-	return $last_changed;
+	return wp_cache_set_last_changed( $group );
+}
+
+/**
+ * Sets last changed date for the specified cache group to now.
+ *
+ * @since n.e.x.t.
+ *
+ * @param string $group Where the cache contents are grouped.
+ * @return string UNIX timestamp when the group was last changed.
+ */
+function wp_cache_set_last_changed( $group ) {
+	$previous_time = wp_cache_get( 'last_changed', $group );
+
+	$time = microtime();
+
+	wp_cache_set( 'last_changed', $time, $group );
+
+	/**
+	 * Fires after a cache group `last_changed` time is updated.
+	 *
+	 * @since n.e.x.t.
+	 *
+	 * @param string    $group          The cache group name.
+	 * @param int       $time           The new last changed time.
+	 * @param int|false $previous_value The previous last changed time.
+	 */
+	do_action( 'wp_cache_set_last_changed', $group, $time, $previous_time );
+
+	return $time;
 }
 
 /**

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -7705,7 +7705,7 @@ function wp_cache_set_last_changed( $group ) {
 	/**
 	 * Fires after a cache group `last_changed` time is updated.
 	 *
-	 * @since n.e.x.t.
+	 * @since n.e.x.t
 	 *
 	 * @param string    $group         The cache group name.
 	 * @param int       $time          The new last changed time.

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -7709,7 +7709,7 @@ function wp_cache_set_last_changed( $group ) {
 	 *
 	 * @param string    $group          The cache group name.
 	 * @param int       $time           The new last changed time.
-	 * @param int|false $previous_value The previous last changed time.
+	 * @param int|false $previous_time  The previous last changed time.
 	 */
 	do_action( 'wp_cache_set_last_changed', $group, $time, $previous_time );
 

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -7707,9 +7707,9 @@ function wp_cache_set_last_changed( $group ) {
 	 *
 	 * @since n.e.x.t.
 	 *
-	 * @param string    $group          The cache group name.
-	 * @param int       $time           The new last changed time.
-	 * @param int|false $previous_time  The previous last changed time.
+	 * @param string    $group         The cache group name.
+	 * @param int       $time          The new last changed time.
+	 * @param int|false $previous_time The previous last changed time.
 	 */
 	do_action( 'wp_cache_set_last_changed', $group, $time, $previous_time );
 

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -7709,7 +7709,7 @@ function wp_cache_set_last_changed( $group ) {
 	 *
 	 * @param string    $group         The cache group name.
 	 * @param int       $time          The new last changed time.
-	 * @param int|false $previous_time The previous last changed time.
+	 * @param int|false $previous_time The previous last changed time. False if not previously set.
 	 */
 	do_action( 'wp_cache_set_last_changed', $group, $time, $previous_time );
 

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -7704,6 +7704,8 @@ function wp_cache_set_last_changed( $group ) {
 
 	/**
 	 * Fires after a cache group `last_changed` time is updated.
+	 * This may occur multiple times per page load and registered
+	 * actions must be performant.
 	 *
 	 * @since 6.3.0
 	 *

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -7690,7 +7690,7 @@ function wp_cache_get_last_changed( $group ) {
 /**
  * Sets last changed date for the specified cache group to now.
  *
- * @since n.e.x.t
+ * @since 6.3.0
  *
  * @param string $group Where the cache contents are grouped.
  * @return string UNIX timestamp when the group was last changed.
@@ -7705,7 +7705,7 @@ function wp_cache_set_last_changed( $group ) {
 	/**
 	 * Fires after a cache group `last_changed` time is updated.
 	 *
-	 * @since n.e.x.t
+	 * @since 6.3.0
 	 *
 	 * @param string    $group         The cache group name.
 	 * @param int       $time          The new last changed time.

--- a/src/wp-includes/ms-network.php
+++ b/src/wp-includes/ms-network.php
@@ -96,7 +96,7 @@ function clean_network_cache( $ids ) {
 		do_action( 'clean_network_cache', $id );
 	}
 
-	wp_cache_set( 'last_changed', microtime(), 'networks' );
+	wp_cache_set_last_changed( 'networks' );
 }
 
 /**

--- a/src/wp-includes/ms-site.php
+++ b/src/wp-includes/ms-site.php
@@ -1281,7 +1281,7 @@ function wp_update_blog_public_option_on_site_update( $site_id, $is_public ) {
  * @since 5.1.0
  */
 function wp_cache_set_sites_last_changed() {
-	wp_cache_set( 'last_changed', microtime(), 'sites' );
+	wp_cache_set_last_changed( 'sites' );
 }
 
 /**

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -7828,7 +7828,7 @@ function wp_add_trashed_suffix_to_post_name_for_post( $post ) {
  * @since 5.0.0
  */
 function wp_cache_set_posts_last_changed() {
-	wp_cache_set( 'last_changed', microtime(), 'posts' );
+	wp_cache_set_last_changed( 'posts' );
 }
 
 /**

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -5034,7 +5034,7 @@ function is_term_publicly_viewable( $term ) {
  * @since 5.0.0
  */
 function wp_cache_set_terms_last_changed() {
-	wp_cache_set( 'last_changed', microtime(), 'terms' );
+	wp_cache_set_last_changed( 'terms' );
 }
 
 /**

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -5024,5 +5024,5 @@ function wp_register_persisted_preferences_meta() {
  * @since 6.3.0
  */
 function wp_cache_set_users_last_changed() {
-	wp_cache_set( 'last_changed', microtime(), 'users' );
+	wp_cache_set_last_changed( 'users' );
 }


### PR DESCRIPTION
This is a follow up to #4077 as suggest by @peterwilsoncc and @JJJ.

This PR adds the `wp_cache_set_last_changed()` function to fire the `wp_cache_set_last_changed` action when a cache group's `last_changed` timestamp was updated.

Trac ticket: https://core.trac.wordpress.org/ticket/57905