### PR TITLE
Test what happens when there's a blank `node-version`.

### DIFF
--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
-          node-version:
+          node-version: ''
           node-version-file: '.nvmrc'
           cache: npm
 

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -61,6 +61,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
+          node-version:
           node-version-file: '.nvmrc'
           cache: npm
 


### PR DESCRIPTION
Testing how `actions/setup-node` handles different empty values WordPress/gutenberg#45932.