### PR TITLE
Filesystem API: Introduce `pre_unzip_file` and `post_unzip_file` hooks.

### DIFF
--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1594,7 +1594,7 @@ function unzip_file( $file, $to ) {
 	 * @param bool $ziparchive Whether to use ZipArchive. Default true.
 	 */
 	if ( class_exists( 'ZipArchive', false ) && apply_filters( 'unzip_file_use_ziparchive', true ) ) {
-		$result = _unzip_file_ziparchive( $file, $to, $needed_dirs );
+		$result = _unzip_file( $file, $to, $needed_dirs, 'ziparchive' );
 		if ( true === $result ) {
 			return $result;
 		} elseif ( is_wp_error( $result ) ) {
@@ -1604,7 +1604,7 @@ function unzip_file( $file, $to ) {
 		}
 	}
 	// Fall through to PclZip if ZipArchive is not available, or encountered an error opening the file.
-	return _unzip_file_pclzip( $file, $to, $needed_dirs );
+	return _unzip_file( $file, $to, $needed_dirs, 'pclzip' );
 }
 
 /**

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1722,7 +1722,7 @@ function _unzip_file( $file, $to, $needed_dirs = array(), $mode = 'ziparchive' )
 				continue;
 			}
 
-			// Don't extract invalid files:
+			// Don't extract invalid files.
 			if ( 0 !== validate_file( $info['name'] ) ) {
 				continue;
 			}
@@ -1836,7 +1836,7 @@ function _unzip_file( $file, $to, $needed_dirs = array(), $mode = 'ziparchive' )
 				continue;
 			}
 
-			// Don't extract invalid files:
+			// Don't extract invalid files.
 			if ( 0 !== validate_file( $info['name'] ) ) {
 				continue;
 			}

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1627,132 +1627,7 @@ function unzip_file( $file, $to ) {
  * @return true|WP_Error True on success, WP_Error on failure.
  */
 function _unzip_file_ziparchive( $file, $to, $needed_dirs = array() ) {
-	global $wp_filesystem;
-
-	$z = new ZipArchive();
-
-	$zopen = $z->open( $file, ZIPARCHIVE::CHECKCONS );
-
-	if ( true !== $zopen ) {
-		return new WP_Error( 'incompatible_archive', __( 'Incompatible Archive.' ), array( 'ziparchive_error' => $zopen ) );
-	}
-
-	$uncompressed_size = 0;
-
-	for ( $i = 0; $i < $z->numFiles; $i++ ) {
-		$info = $z->statIndex( $i );
-
-		if ( ! $info ) {
-			return new WP_Error( 'stat_failed_ziparchive', __( 'Could not retrieve file from archive.' ) );
-		}
-
-		if ( '__MACOSX/' === substr( $info['name'], 0, 9 ) ) { // Skip the OS X-created __MACOSX directory.
-			continue;
-		}
-
-		// Don't extract invalid files:
-		if ( 0 !== validate_file( $info['name'] ) ) {
-			continue;
-		}
-
-		$uncompressed_size += $info['size'];
-
-		$dirname = dirname( $info['name'] );
-
-		if ( '/' === substr( $info['name'], -1 ) ) {
-			// Directory.
-			$needed_dirs[] = $to . untrailingslashit( $info['name'] );
-		} elseif ( '.' !== $dirname ) {
-			// Path to a file.
-			$needed_dirs[] = $to . untrailingslashit( $dirname );
-		}
-	}
-
-	/*
-	 * disk_free_space() could return false. Assume that any falsey value is an error.
-	 * A disk that has zero free bytes has bigger problems.
-	 * Require we have enough space to unzip the file and copy its contents, with a 10% buffer.
-	 */
-	if ( wp_doing_cron() ) {
-		$available_space = function_exists( 'disk_free_space' ) ? @disk_free_space( WP_CONTENT_DIR ) : false;
-
-		if ( $available_space && ( $uncompressed_size * 2.1 ) > $available_space ) {
-			return new WP_Error(
-				'disk_full_unzip_file',
-				__( 'Could not copy files. You may have run out of disk space.' ),
-				compact( 'uncompressed_size', 'available_space' )
-			);
-		}
-	}
-
-	$needed_dirs = array_unique( $needed_dirs );
-
-	foreach ( $needed_dirs as $dir ) {
-		// Check the parent folders of the folders all exist within the creation array.
-		if ( untrailingslashit( $to ) === $dir ) { // Skip over the working directory, we know this exists (or will exist).
-			continue;
-		}
-
-		if ( strpos( $dir, $to ) === false ) { // If the directory is not within the working directory, skip it.
-			continue;
-		}
-
-		$parent_folder = dirname( $dir );
-
-		while ( ! empty( $parent_folder )
-			&& untrailingslashit( $to ) !== $parent_folder
-			&& ! in_array( $parent_folder, $needed_dirs, true )
-		) {
-			$needed_dirs[] = $parent_folder;
-			$parent_folder = dirname( $parent_folder );
-		}
-	}
-
-	asort( $needed_dirs );
-
-	// Create those directories if need be:
-	foreach ( $needed_dirs as $_dir ) {
-		// Only check to see if the Dir exists upon creation failure. Less I/O this way.
-		if ( ! $wp_filesystem->mkdir( $_dir, FS_CHMOD_DIR ) && ! $wp_filesystem->is_dir( $_dir ) ) {
-			return new WP_Error( 'mkdir_failed_ziparchive', __( 'Could not create directory.' ), $_dir );
-		}
-	}
-	unset( $needed_dirs );
-
-	for ( $i = 0; $i < $z->numFiles; $i++ ) {
-		$info = $z->statIndex( $i );
-
-		if ( ! $info ) {
-			return new WP_Error( 'stat_failed_ziparchive', __( 'Could not retrieve file from archive.' ) );
-		}
-
-		if ( '/' === substr( $info['name'], -1 ) ) { // Directory.
-			continue;
-		}
-
-		if ( '__MACOSX/' === substr( $info['name'], 0, 9 ) ) { // Don't extract the OS X-created __MACOSX directory files.
-			continue;
-		}
-
-		// Don't extract invalid files:
-		if ( 0 !== validate_file( $info['name'] ) ) {
-			continue;
-		}
-
-		$contents = $z->getFromIndex( $i );
-
-		if ( false === $contents ) {
-			return new WP_Error( 'extract_failed_ziparchive', __( 'Could not extract file from archive.' ), $info['name'] );
-		}
-
-		if ( ! $wp_filesystem->put_contents( $to . $info['name'], $contents, FS_CHMOD_FILE ) ) {
-			return new WP_Error( 'copy_failed_ziparchive', __( 'Could not copy file.' ), $info['name'] );
-		}
-	}
-
-	$z->close();
-
-	return true;
+	return _unzip_file( $file, $to, $needed_dirs, 'ziparchive' );
 }
 
 /**
@@ -1775,38 +1650,106 @@ function _unzip_file_ziparchive( $file, $to, $needed_dirs = array() ) {
  * @return true|WP_Error True on success, WP_Error on failure.
  */
 function _unzip_file_pclzip( $file, $to, $needed_dirs = array() ) {
+	return _unzip_file( $file, $to, $needed_dirs, 'pclzip' );
+}
+
+/**
+ * Attempts to unzip an archive using either the ZipArchive class or the PclZip library.
+ *
+ * This function should not be called directly, use `unzip_file()` instead.
+ *
+ * Assumes that WP_Filesystem() has already been called and set up.
+ *
+ * @since 6.3.0
+ * @access private
+ *
+ * @see unzip_file()
+ *
+ * @global WP_Filesystem_Base $wp_filesystem WordPress filesystem subclass.
+ *
+ * @param string   $file        Full path and filename of ZIP archive.
+ * @param string   $to          Full path on the filesystem to extract archive to.
+ * @param string[] $needed_dirs Optional. A partial list of required folders needed to be created.
+ *                              Default empty array.
+ * @param string   $mode        Optional. The mode used to unzip. Accepts "ziparchive" or "pclzip".
+ *                              Default "ziparchive".
+ * @return true|WP_Error True on success, WP_Error on failure.
+ */
+function _unzip_file( $file, $to, $needed_dirs = array(), $mode = 'ziparchive' ) {
 	global $wp_filesystem;
 
-	mbstring_binary_safe_encoding();
+	$mode = strtolower( $mode );
 
-	require_once ABSPATH . 'wp-admin/includes/class-pclzip.php';
-
-	$archive = new PclZip( $file );
-
-	$archive_files = $archive->extract( PCLZIP_OPT_EXTRACT_AS_STRING );
-
-	reset_mbstring_encoding();
-
-	// Is the archive valid?
-	if ( ! is_array( $archive_files ) ) {
-		return new WP_Error( 'incompatible_archive', __( 'Incompatible Archive.' ), $archive->errorInfo( true ) );
+	if ( ! in_array( $mode, array( 'ziparchive', 'pclzip' ), true ) ) {
+		/** This filter is documented in src/wp-admin/includes/file.php */
+		$mode = apply_filters( 'unzip_file_use_ziparchive', true ) ? 'ziparchive' : 'pclzip';
 	}
 
-	if ( 0 === count( $archive_files ) ) {
-		return new WP_Error( 'empty_archive_pclzip', __( 'Empty archive.' ) );
+	if ( 'ziparchive' === $mode ) {
+		$z     = new ZipArchive();
+		$zopen = $z->open( $file, ZIPARCHIVE::CHECKCONS );
+
+		// Is the archive valid?
+		if ( true !== $zopen ) {
+			return new WP_Error( 'incompatible_archive', __( 'Incompatible Archive.' ), array( 'ziparchive_error' => $zopen ) );
+		}
+	} elseif ( 'pclzip' === $mode ) {
+		mbstring_binary_safe_encoding();
+		require_once ABSPATH . 'wp-admin/includes/class-pclzip.php';
+		$archive       = new PclZip( $file );
+		$archive_files = $archive->extract( PCLZIP_OPT_EXTRACT_AS_STRING );
+		reset_mbstring_encoding();
+
+		// Is the archive valid?
+		if ( ! is_array( $archive_files ) ) {
+			return new WP_Error( 'incompatible_archive', __( 'Incompatible Archive.' ), $archive->errorInfo( true ) );
+		} elseif ( empty( $archive_files ) ) {
+			return new WP_Error( 'empty_archive_pclzip', __( 'Empty archive.' ) );
+		}
 	}
 
 	$uncompressed_size = 0;
 
-	// Determine any children directories needed (From within the archive).
-	foreach ( $archive_files as $file ) {
-		if ( '__MACOSX/' === substr( $file['filename'], 0, 9 ) ) { // Skip the OS X-created __MACOSX directory.
-			continue;
+	if ( 'ziparchive' === $mode ) {
+		for ( $i = 0; $i < $z->numFiles; $i++ ) {
+			$info = $z->statIndex( $i );
+
+			if ( ! $info ) {
+				return new WP_Error( 'stat_failed_ziparchive', __( 'Could not retrieve file from archive.' ) );
+			}
+
+			if ( '__MACOSX/' === substr( $info['name'], 0, 9 ) ) { // Skip the OS X-created __MACOSX directory.
+				continue;
+			}
+
+			// Don't extract invalid files:
+			if ( 0 !== validate_file( $info['name'] ) ) {
+				continue;
+			}
+
+			$uncompressed_size += $info['size'];
+
+			$dirname = dirname( $info['name'] );
+
+			if ( '/' === substr( $info['name'], -1 ) ) {
+				// Directory.
+				$needed_dirs[] = $to . untrailingslashit( $info['name'] );
+			} elseif ( '.' !== $dirname ) {
+				// Path to a file.
+				$needed_dirs[] = $to . untrailingslashit( $dirname );
+			}
 		}
+	} elseif ( 'pclzip' === $mode ) {
+		// Determine any children directories needed (From within the archive).
+		foreach ( $archive_files as $file ) {
+			if ( '__MACOSX/' === substr( $file['filename'], 0, 9 ) ) { // Skip the OS X-created __MACOSX directory.
+				continue;
+			}
 
-		$uncompressed_size += $file['size'];
+			$uncompressed_size += $file['size'];
 
-		$needed_dirs[] = $to . untrailingslashit( $file['folder'] ? $file['filename'] : dirname( $file['filename'] ) );
+			$needed_dirs[] = $to . untrailingslashit( $file['folder'] ? $file['filename'] : dirname( $file['filename'] ) );
+		}
 	}
 
 	/*
@@ -1853,30 +1796,65 @@ function _unzip_file_pclzip( $file, $to, $needed_dirs = array() ) {
 
 	// Create those directories if need be:
 	foreach ( $needed_dirs as $_dir ) {
-		// Only check to see if the dir exists upon creation failure. Less I/O this way.
+		// Only check to see if the directory exists upon creation failure. Less I/O this way.
 		if ( ! $wp_filesystem->mkdir( $_dir, FS_CHMOD_DIR ) && ! $wp_filesystem->is_dir( $_dir ) ) {
-			return new WP_Error( 'mkdir_failed_pclzip', __( 'Could not create directory.' ), $_dir );
+			return new WP_Error( "mkdir_failed_$mode", __( 'Could not create directory.' ), $_dir );
 		}
 	}
 	unset( $needed_dirs );
 
 	// Extract the files from the zip.
-	foreach ( $archive_files as $file ) {
-		if ( $file['folder'] ) {
-			continue;
+	if ( 'ziparchive' === $mode ) {
+		for ( $i = 0; $i < $z->numFiles; $i++ ) {
+			$info = $z->statIndex( $i );
+
+			if ( ! $info ) {
+				return new WP_Error( 'stat_failed_ziparchive', __( 'Could not retrieve file from archive.' ) );
+			}
+
+			if ( '/' === substr( $info['name'], -1 ) ) { // Directory.
+				continue;
+			}
+
+			if ( '__MACOSX/' === substr( $info['name'], 0, 9 ) ) { // Don't extract the OS X-created __MACOSX directory files.
+				continue;
+			}
+
+			// Don't extract invalid files:
+			if ( 0 !== validate_file( $info['name'] ) ) {
+				continue;
+			}
+
+			$contents = $z->getFromIndex( $i );
+
+			if ( false === $contents ) {
+				return new WP_Error( 'extract_failed_ziparchive', __( 'Could not extract file from archive.' ), $info['name'] );
+			}
+
+			if ( ! $wp_filesystem->put_contents( $to . $info['name'], $contents, FS_CHMOD_FILE ) ) {
+				return new WP_Error( 'copy_failed_ziparchive', __( 'Could not copy file.' ), $info['name'] );
+			}
 		}
 
-		if ( '__MACOSX/' === substr( $file['filename'], 0, 9 ) ) { // Don't extract the OS X-created __MACOSX directory files.
-			continue;
-		}
+		$z->close();
+	} elseif ( 'pclzip' === $mode ) {
+		foreach ( $archive_files as $file ) {
+			if ( $file['folder'] ) {
+				continue;
+			}
 
-		// Don't extract invalid files:
-		if ( 0 !== validate_file( $file['filename'] ) ) {
-			continue;
-		}
+			if ( '__MACOSX/' === substr( $file['filename'], 0, 9 ) ) { // Don't extract the OS X-created __MACOSX directory files.
+				continue;
+			}
 
-		if ( ! $wp_filesystem->put_contents( $to . $file['filename'], $file['content'], FS_CHMOD_FILE ) ) {
-			return new WP_Error( 'copy_failed_pclzip', __( 'Could not copy file.' ), $file['filename'] );
+			// Don't extract invalid files:
+			if ( 0 !== validate_file( $file['filename'] ) ) {
+				continue;
+			}
+
+			if ( ! $wp_filesystem->put_contents( $to . $file['filename'], $file['content'], FS_CHMOD_FILE ) ) {
+				return new WP_Error( 'copy_failed_pclzip', __( 'Could not copy file.' ), $file['filename'] );
+			}
 		}
 	}
 


### PR DESCRIPTION
This introduces two new actions: `pre_unzip_file` and `post_unzip_file`.

Both actions pass the following:
- `string $file` - Full path and filename of ZIP archive.
- `string $to` - Full path on the filesystem to extract archive to.
- `string[] $needed_dirs` - A full list of required folders needed to be created.
- `float|false $required_space` - The space required to unzip the file and copy its contents, with a 10% buffer. False if `disk_free_space()` returned `false`.
- `string $mode` - The mode used to unzip. Accepts "ziparchive" or "pclzip". Default "ziparchive".

Additionally:
- Combines the `_unzip_file_ziparchive()` and `_unzip_file_pclzip()` functions into a new function: `_unzip_file()`.
  - Conditionally runs distinct functionality, and merges common functionality.
  - For BC, both functions act as wrappers for `_unzip_file( $file, $to, $needed_dirs, ziparchive||pclzip )`.
  - Note: Despite the docblock clearly stating that these functions should not be used directly, [plugins](https://wpdirectory.net/search/01GV72HHEBKYFF7TMFBTEM76TV) still use it directly.
- Implements `_unzip_file()` in `unzip_file()` to avoid calling the wrapper functions unnecessarily.
  - No other locations in Core use `_unzip_file_ziparchive()` or `_unzip_file_pclzip()` directly.

Trac ticket: https://core.trac.wordpress.org/ticket/37719