### PR TITLE
Filesystem API: Return `false` when an empty path is provided to FTP `::exists()` methods.

### DIFF
--- a/src/wp-admin/includes/class-wp-filesystem-ftpext.php
+++ b/src/wp-admin/includes/class-wp-filesystem-ftpext.php
@@ -419,11 +419,22 @@ class WP_Filesystem_FTPext extends WP_Filesystem_Base {
 	 * Checks if a file or directory exists.
 	 *
 	 * @since 2.5.0
+	 * @since 6.3.0 Returns false for an empty path.
 	 *
 	 * @param string $path Path to file or directory.
 	 * @return bool Whether $path exists or not.
 	 */
 	public function exists( $path ) {
+		/*
+		 * Check for empty path. If ftp_nlist() receives an empty path,
+		 * it checks the current working directory and may return true.
+		 *
+		 * See https://core.trac.wordpress.org/ticket/33058
+		 */
+		if ( '' === $path ) {
+			return false;
+		}
+
 		$list = ftp_nlist( $this->link, $path );
 
 		if ( empty( $list ) && $this->is_dir( $path ) ) {

--- a/src/wp-admin/includes/class-wp-filesystem-ftpsockets.php
+++ b/src/wp-admin/includes/class-wp-filesystem-ftpsockets.php
@@ -421,11 +421,22 @@ class WP_Filesystem_ftpsockets extends WP_Filesystem_Base {
 	 * Checks if a file or directory exists.
 	 *
 	 * @since 2.5.0
+	 * @since 6.3.0 Returns false for an empty path.
 	 *
 	 * @param string $path Path to file or directory.
 	 * @return bool Whether $path exists or not.
 	 */
 	public function exists( $path ) {
+		/*
+		 * Check for empty path. If nlist() receives an empty path,
+		 * it checks the current working directory and may return true.
+		 *
+		 * See https://core.trac.wordpress.org/ticket/33058
+		 */
+		if ( '' === $path ) {
+			return false;
+		}
+
 		$list = $this->ftp->nlist( $path );
 
 		if ( empty( $list ) && $this->is_dir( $path ) ) {


### PR DESCRIPTION
When `ftp_nlist()` or `nlist()` receive an empty path, they check the current working directory and may return `true`.

For consistency with the `WP_Filesystem_Direct` filesystem abstraction class, this returns `false` when an empty path is provided to `WP_Filesystem_FTPext::exists()` or `WP_Filesystem_ftpsockets::exists()`.

Trac ticket: https://core.trac.wordpress.org/ticket/33058