### PR TITLE
.widefat selector is replaced in js files with substitutions #35833

### DIFF
--- a/src/js/_enqueues/admin/edit-comments.js
+++ b/src/js/_enqueues/admin/edit-comments.js
@@ -1150,7 +1150,7 @@ window.commentReply = {
 
 		id = $(id);
 		t.addEvents(id);
-		bg = id.hasClass( 'unapproved' ) ? '#FFFFE0' : id.closest('table.wp-list-table, .postbox').css('backgroundColor');
+		bg = id.hasClass('unapproved') ? '#FFFFE0' : id.closest('table.wp-list-table, .postbox').css('backgroundColor');
 
 		id.animate( { 'backgroundColor':'#CCEEBB' }, 300 )
 			.animate( { 'backgroundColor': bg }, 300, function() {

--- a/src/js/_enqueues/admin/edit-comments.js
+++ b/src/js/_enqueues/admin/edit-comments.js
@@ -1150,7 +1150,7 @@ window.commentReply = {
 
 		id = $(id);
 		t.addEvents(id);
-		bg = id.hasClass('unapproved') ? '#FFFFE0' : id.closest('table.wp-list-table, .postbox').css('backgroundColor');
+		bg = id.hasClass( 'unapproved' ) ? '#FFFFE0' : id.closest('table.wp-list-table, .postbox').css('backgroundColor');
 
 		id.animate( { 'backgroundColor':'#CCEEBB' }, 300 )
 			.animate( { 'backgroundColor': bg }, 300, function() {

--- a/src/js/_enqueues/admin/edit-comments.js
+++ b/src/js/_enqueues/admin/edit-comments.js
@@ -1150,7 +1150,7 @@ window.commentReply = {
 
 		id = $(id);
 		t.addEvents(id);
-		bg = id.hasClass('unapproved') ? '#FFFFE0' : id.closest('.widefat, .postbox').css('backgroundColor');
+		bg = id.hasClass('unapproved') ? '#FFFFE0' : id.closest('table.wp-list-table, .postbox').css('backgroundColor');
 
 		id.animate( { 'backgroundColor':'#CCEEBB' }, 300 )
 			.animate( { 'backgroundColor': bg }, 300, function() {
@@ -1311,7 +1311,7 @@ $( function(){
 		};
 
 		$.table_hotkeys(
-			$('table.widefat'),
+			$('table.wp-list-table'),
 			[
 				'a', 'u', 's', 'd', 'r', 'q', 'z',
 				['e', edit_comment],

--- a/src/js/_enqueues/admin/inline-edit-post.js
+++ b/src/js/_enqueues/admin/inline-edit-post.js
@@ -42,7 +42,7 @@ window.wp = window.wp || {};
 	init : function(){
 		var t = this, qeRow = $('#inline-edit'), bulkRow = $('#bulk-edit');
 
-		t.type = $('table.widefat').hasClass('pages') ? 'page' : 'post';
+		t.type = $('table.wp-list-table').hasClass('pages') ? 'page' : 'post';
 		// Post ID prefix.
 		t.what = '#post-';
 
@@ -180,10 +180,10 @@ window.wp = window.wp || {};
 		var te = '', type = this.type, c = true;
 		this.revert();
 
-		$( '#bulk-edit td' ).attr( 'colspan', $( 'th:visible, td:visible', '.widefat:first thead' ).length );
+		$( '#bulk-edit td' ).attr( 'colspan', $( 'th:visible, td:visible', 'table.wp-list-table:first thead' ).length );
 
 		// Insert the editor at the top of the table with an empty row above to maintain zebra striping.
-		$('table.widefat tbody').prepend( $('#bulk-edit') ).prepend('<tr class="hidden"></tr>');
+		$('table.wp-list-table tbody').prepend( $('#bulk-edit') ).prepend('<tr class="hidden"></tr>');
 		$('#bulk-edit').addClass('inline-editor').show();
 
 		/**
@@ -228,7 +228,7 @@ window.wp = window.wp || {};
 				$prev = $this.parent().prev().children( '.ntdelbutton' ),
 				$next = $this.parent().next().children( '.ntdelbutton' );
 
-			$( 'table.widefat input[value="' + id + '"]' ).prop( 'checked', false );
+				$('table.wp-list-table input[value="' + id + '"]').prop('checked', false);
 			$( '#_' + id ).parent().remove();
 			wp.a11y.speak( wp.i18n.__( 'Item removed.' ), 'assertive' );
 
@@ -292,7 +292,7 @@ window.wp = window.wp || {};
 
 		// Add the new edit row with an extra blank row underneath to maintain zebra striping.
 		editRow = $('#inline-edit').clone(true);
-		$( 'td', editRow ).attr( 'colspan', $( 'th:visible, td:visible', '.widefat:first thead' ).length );
+		$( 'td', editRow ).attr( 'colspan', $( 'th:visible, td:visible', 'table.wp-list-table:first thead' ).length );
 
 		// Remove the ID from the copied row and let the `for` attribute reference the hidden ID.
 		$( 'td', editRow ).find('#quick-edit-legend').removeAttr('id');
@@ -433,7 +433,7 @@ window.wp = window.wp || {};
 			id = this.getId(id);
 		}
 
-		$( 'table.widefat .spinner' ).addClass( 'is-active' );
+		$( 'table.wp-list-table .spinner' ).addClass( 'is-active' );
 
 		params = {
 			action: 'inline-save',
@@ -452,7 +452,7 @@ window.wp = window.wp || {};
 				var $errorNotice = $( '#edit-' + id + ' .inline-edit-save .notice-error' ),
 					$error = $errorNotice.find( '.error' );
 
-				$( 'table.widefat .spinner' ).removeClass( 'is-active' );
+				$( 'table.wp-list-table .spinner' ).removeClass( 'is-active' );
 
 				if (r) {
 					if ( -1 !== r.indexOf( '<tr' ) ) {
@@ -493,7 +493,7 @@ window.wp = window.wp || {};
 	 * @return {boolean} Always returns false.
 	 */
 	revert : function(){
-		var $tableWideFat = $( '.widefat' ),
+		var $tableWideFat = $( 'table.wp-list-table' ),
 			id = $( '.inline-editor', $tableWideFat ).attr( 'id' );
 
 		if ( id ) {

--- a/src/js/_enqueues/admin/inline-edit-tax.js
+++ b/src/js/_enqueues/admin/inline-edit-tax.js
@@ -128,7 +128,7 @@ window.inlineEditTax = {
 		}
 
 		editRow = $('#inline-edit').clone(true), rowData = $('#inline_'+id);
-		$( 'td', editRow ).attr( 'colspan', $( 'th:visible, td:visible', '.wp-list-table.widefat:first thead' ).length );
+		$( 'td', editRow ).attr( 'colspan', $( 'th:visible, td:visible', '.wp-list-table:first thead' ).length );
 
 		$(t.what+id).hide().after(editRow).after('<tr class="hidden"></tr>');
 
@@ -172,7 +172,7 @@ window.inlineEditTax = {
 			id = this.getId(id);
 		}
 
-		$( 'table.widefat .spinner' ).addClass( 'is-active' );
+		$( 'table.wp-list-table .spinner' ).addClass( 'is-active' );
 
 		params = {
 			action: 'inline-save-tax',
@@ -199,7 +199,7 @@ window.inlineEditTax = {
 					$errorNotice = $( '#edit-' + id + ' .inline-edit-save .notice-error' ),
 					$error = $errorNotice.find( '.error' );
 
-				$( 'table.widefat .spinner' ).removeClass( 'is-active' );
+					$( 'table.wp-list-table .spinner' ).removeClass( 'is-active' );
 
 				if (r) {
 					if ( -1 !== r.indexOf( '<tr' ) ) {
@@ -258,10 +258,10 @@ window.inlineEditTax = {
 	 * @return {void}
 	 */
 	revert : function() {
-		var id = $('table.widefat tr.inline-editor').attr('id');
+		var id = $('table.wp-list-table tr.inline-editor').attr('id');
 
 		if ( id ) {
-			$( 'table.widefat .spinner' ).removeClass( 'is-active' );
+			$( 'table.wp-list-table .spinner' ).removeClass( 'is-active' );
 			$('#'+id).siblings('tr.hidden').addBack().remove();
 			id = id.substr( id.lastIndexOf('-') + 1 );
 

--- a/src/js/_enqueues/admin/post.js
+++ b/src/js/_enqueues/admin/post.js
@@ -61,7 +61,7 @@ window.wp = window.wp || {};
 				data,
 				function(r) {
 					r = wpAjax.parseAjaxResponse(r);
-					$('#commentsdiv .widefat').show();
+					$('#commentsdiv table.comments-box').show();
 					$( '#commentsdiv .spinner' ).removeClass( 'is-active' );
 
 					if ( 'object' == typeof r && r.responses[0] ) {


### PR DESCRIPTION
PR is based on the previous PR, patch is updated with regard to new files location,
.widefat selector is removed from JS files and replaced by classes which reference DOM elements and not how they should look.

Trac ticket: [https://core.trac.wordpress.org/ticket/35833](https://core.trac.wordpress.org/ticket/35833)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
