### PR TITLE
Fix revision screen links for templates and template parts

### DIFF
--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1435,7 +1435,7 @@ function get_preview_post_link( $post = null, $query_args = array(), $preview_li
  * Retrieves the edit post link for post.
  *
  * Can be used within the WordPress loop or outside of it. Can be used with
- * pages, posts, attachments, and revisions.
+ * pages, posts, attachments, revisions, global styles, templates and template parts.
  *
  * @since 2.3.0
  *

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1477,7 +1477,7 @@ function get_edit_post_link( $post = 0, $context = 'display' ) {
 
 	if (  'wp_template' === $post->post_type || 'wp_template_part' === $post->post_type ) {
 		$slug = urlencode( get_stylesheet() . '//' . $post->post_name );
-		$link = admin_url( sprintf( $post_type_object->_edit_link, $slug ) );
+		$link = admin_url( sprintf( $post_type_object->_edit_link, $post->post_type, $slug ) );
 	}
 
 	/**

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1475,6 +1475,11 @@ function get_edit_post_link( $post = 0, $context = 'display' ) {
 		$link = '';
 	}
 
+	if (  'wp_template' === $post->post_type || 'wp_template_part' === $post->post_type ) {
+		$slug = urlencode( wp_get_theme()->get_stylesheet() . '//' . $post->post_name );
+		$link = admin_url( sprintf( $post_type_object->_edit_link, $slug ) );
+	}
+
 	/**
 	 * Filters the post edit link.
 	 *

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1476,7 +1476,7 @@ function get_edit_post_link( $post = 0, $context = 'display' ) {
 	}
 
 	if (  'wp_template' === $post->post_type || 'wp_template_part' === $post->post_type ) {
-		$slug = urlencode( wp_get_theme()->get_stylesheet() . '//' . $post->post_name );
+		$slug = urlencode( get_stylesheet() . '//' . $post->post_name );
 		$link = admin_url( sprintf( $post_type_object->_edit_link, $slug ) );
 	}
 

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1469,15 +1469,15 @@ function get_edit_post_link( $post = 0, $context = 'display' ) {
 		return;
 	}
 
-	if ( $post_type_object->_edit_link ) {
-		$link = admin_url( sprintf( $post_type_object->_edit_link . $action, $post->ID ) );
-	} else {
-		$link = '';
-	}
-
 	if (  'wp_template' === $post->post_type || 'wp_template_part' === $post->post_type ) {
 		$slug = urlencode( get_stylesheet() . '//' . $post->post_name );
 		$link = admin_url( sprintf( $post_type_object->_edit_link, $post->post_type, $slug ) );
+	} else {
+		if ( $post_type_object->_edit_link ) {
+			$link = sprintf( $post_type_object->_edit_link . $action, $post->ID );
+		} else {
+			$link = '';
+		}
 	}
 
 	/**

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1474,7 +1474,7 @@ function get_edit_post_link( $post = 0, $context = 'display' ) {
 		$link = admin_url( sprintf( $post_type_object->_edit_link, $post->post_type, $slug ) );
 	} else {
 		if ( $post_type_object->_edit_link ) {
-			$link = sprintf( $post_type_object->_edit_link . $action, $post->ID );
+			$link = admin_url( sprintf( $post_type_object->_edit_link . $action, $post->ID ) );
 		} else {
 			$link = '';
 		}

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1469,7 +1469,7 @@ function get_edit_post_link( $post = 0, $context = 'display' ) {
 		return;
 	}
 
-	if (  'wp_template' === $post->post_type || 'wp_template_part' === $post->post_type ) {
+	if ( 'wp_template' === $post->post_type || 'wp_template_part' === $post->post_type ) {
 		$slug = urlencode( get_stylesheet() . '//' . $post->post_name );
 		$link = admin_url( sprintf( $post_type_object->_edit_link, $post->post_type, $slug ) );
 	} else {

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1473,10 +1473,9 @@ function get_edit_post_link( $post = 0, $context = 'display' ) {
 		$slug = urlencode( get_stylesheet() . '//' . $post->post_name );
 		$link = admin_url( sprintf( $post_type_object->_edit_link, $post->post_type, $slug ) );
 	} else {
+		$link = '';
 		if ( $post_type_object->_edit_link ) {
 			$link = admin_url( sprintf( $post_type_object->_edit_link . $action, $post->ID ) );
-		} else {
-			$link = '';
 		}
 	}
 

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -331,11 +331,13 @@ function create_initial_post_types() {
 		)
 	);
 
-	$template_edit_link = 'site-editor.php?' . build_query( array(
-		'postType' => '%s',
-		'postId'   => '%s',
-		'canvas'   => 'edit',
-	) );
+	$template_edit_link = 'site-editor.php?' . build_query(
+		array(
+			'postType' => '%s',
+			'postId'   => '%s',
+			'canvas'   => 'edit',
+		)
+	);
 
 	register_post_type(
 		'wp_template',

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -357,6 +357,7 @@ function create_initial_post_types() {
 			'description'           => __( 'Templates to include in your theme.' ),
 			'public'                => false,
 			'_builtin'              => true, /* internal use only. don't use this when registering your own post type. */
+			'_edit_link'            => 'site-editor.php?postType=wp_template&postId=%s&canvas=edit', /* internal use only. don't use this when registering your own post type. */
 			'has_archive'           => false,
 			'show_ui'               => false,
 			'show_in_menu'          => false,
@@ -417,6 +418,7 @@ function create_initial_post_types() {
 			'description'           => __( 'Template parts to include in your templates.' ),
 			'public'                => false,
 			'_builtin'              => true, /* internal use only. don't use this when registering your own post type. */
+			'_edit_link'            => 'site-editor.php?postType=wp_template_part&postId=%s&canvas=edit', /* internal use only. don't use this when registering your own post type. */
 			'has_archive'           => false,
 			'show_ui'               => false,
 			'show_in_menu'          => false,

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -331,6 +331,12 @@ function create_initial_post_types() {
 		)
 	);
 
+	$template_edit_link = 'site-editor.php?' . build_query( array(
+		'postType' => '%s',
+		'postId'   => '%s',
+		'canvas'   => 'edit',
+	) );
+
 	register_post_type(
 		'wp_template',
 		array(
@@ -357,7 +363,7 @@ function create_initial_post_types() {
 			'description'           => __( 'Templates to include in your theme.' ),
 			'public'                => false,
 			'_builtin'              => true, /* internal use only. don't use this when registering your own post type. */
-			'_edit_link'            => 'site-editor.php?postType=%s&postId=%s&canvas=edit', /* internal use only. don't use this when registering your own post type. */
+			'_edit_link'            => $template_edit_link, /* internal use only. don't use this when registering your own post type. */
 			'has_archive'           => false,
 			'show_ui'               => false,
 			'show_in_menu'          => false,
@@ -418,7 +424,7 @@ function create_initial_post_types() {
 			'description'           => __( 'Template parts to include in your templates.' ),
 			'public'                => false,
 			'_builtin'              => true, /* internal use only. don't use this when registering your own post type. */
-			'_edit_link'            => 'site-editor.php?postType=%s&postId=%s&canvas=edit', /* internal use only. don't use this when registering your own post type. */
+			'_edit_link'            => $template_edit_link, /* internal use only. don't use this when registering your own post type. */
 			'has_archive'           => false,
 			'show_ui'               => false,
 			'show_in_menu'          => false,

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -357,7 +357,7 @@ function create_initial_post_types() {
 			'description'           => __( 'Templates to include in your theme.' ),
 			'public'                => false,
 			'_builtin'              => true, /* internal use only. don't use this when registering your own post type. */
-			'_edit_link'            => 'site-editor.php?postType=wp_template&postId=%s&canvas=edit', /* internal use only. don't use this when registering your own post type. */
+			'_edit_link'            => 'site-editor.php?postType=%s&postId=%s&canvas=edit', /* internal use only. don't use this when registering your own post type. */
 			'has_archive'           => false,
 			'show_ui'               => false,
 			'show_in_menu'          => false,

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -418,7 +418,7 @@ function create_initial_post_types() {
 			'description'           => __( 'Template parts to include in your templates.' ),
 			'public'                => false,
 			'_builtin'              => true, /* internal use only. don't use this when registering your own post type. */
-			'_edit_link'            => 'site-editor.php?postType=wp_template_part&postId=%s&canvas=edit', /* internal use only. don't use this when registering your own post type. */
+			'_edit_link'            => 'site-editor.php?postType=%s&postId=%s&canvas=edit', /* internal use only. don't use this when registering your own post type. */
 			'has_archive'           => false,
 			'show_ui'               => false,
 			'show_in_menu'          => false,

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -467,6 +467,7 @@ function create_initial_post_types() {
 			'description'  => __( 'Global styles to include in themes.' ),
 			'public'       => false,
 			'_builtin'     => true, /* internal use only. don't use this when registering your own post type. */
+			'_edit_link'   => '/site-editor.php?canvas=edit', /* internal use only. don't use this when registering your own post type. */
 			'show_ui'      => false,
 			'show_in_rest' => false,
 			'rewrite'      => false,

--- a/tests/phpunit/tests/link/getEditPostLink.php
+++ b/tests/phpunit/tests/link/getEditPostLink.php
@@ -90,7 +90,7 @@ class Tests_Link_GetEditPostLink extends WP_UnitTestCase {
 		wp_set_post_terms( $template_post->ID, self::TEST_THEME, 'wp_theme' );
 
 		$post_type_object     = get_post_type_object( $template_post->post_type );
-		$link_default_context = admin_url( sprintf( $post_type_object->_edit_link . '&amp;canvas=edit', $template_post->post_type, get_stylesheet() . '//my_template',  ) );
+		$link_default_context = admin_url( sprintf( $post_type_object->_edit_link . '&amp;canvas=edit', $template_post->post_type, get_stylesheet() . '//my_template' ) );
 		$link_custom_context  = admin_url( sprintf( $post_type_object->_edit_link . '&canvas=edit', $template_post->post_type, get_stylesheet() . '//my_template' ) );
 
 		$this->assertSame( $link_default_context, get_edit_post_link( $template_post ), 'Second argument `$context` has a default context of `"display"`.' );

--- a/tests/phpunit/tests/link/getEditPostLink.php
+++ b/tests/phpunit/tests/link/getEditPostLink.php
@@ -125,8 +125,8 @@ class Tests_Link_GetEditPostLink extends WP_UnitTestCase {
 		wp_set_post_terms( $template_part_post->ID, self::TEST_THEME, 'wp_theme' );
 
 		$post_type_object     = get_post_type_object( $template_part_post->post_type );
-		$link_default_context = admin_url( sprintf( $post_type_object->_edit_link . '&amp;canvas=edit', $template_part_post->post_type, get_stylesheet() . '//my_template_part' ) );
-		$link_custom_context  = admin_url( sprintf( $post_type_object->_edit_link . '&canvas=edit', $template_part_post->post_type, get_stylesheet() . '//my_template_part' ) );
+		$link_default_context = admin_url( sprintf( $post_type_object->_edit_link, $template_part_post->post_type, get_stylesheet() . '%2F%2Fmy_template_part' ) );
+		$link_custom_context  = admin_url( sprintf( $post_type_object->_edit_link, $template_part_post->post_type, get_stylesheet() . '%2F%2Fmy_template_part' ) );
 
 		$this->assertSame( $link_default_context, get_edit_post_link( $template_part_post ), 'Second argument `$context` has a default context of `"display"`.' );
 		$this->assertSame( $link_custom_context, get_edit_post_link( $template_part_post, 'something-else' ), 'Pass non-default value in second argument.' );

--- a/tests/phpunit/tests/link/getEditPostLink.php
+++ b/tests/phpunit/tests/link/getEditPostLink.php
@@ -90,8 +90,8 @@ class Tests_Link_GetEditPostLink extends WP_UnitTestCase {
 		wp_set_post_terms( $template_post->ID, self::TEST_THEME, 'wp_theme' );
 
 		$post_type_object     = get_post_type_object( $template_post->post_type );
-		$link_default_context = admin_url( sprintf( $post_type_object->_edit_link . '&amp;canvas=edit', get_stylesheet() . '//my_template' ) );
-		$link_custom_context  = admin_url( sprintf( $post_type_object->_edit_link . '&canvas=edit', get_stylesheet() . '//my_template' ) );
+		$link_default_context = admin_url( sprintf( $post_type_object->_edit_link . '&amp;canvas=edit', $template_post->post_type, get_stylesheet() . '//my_template',  ) );
+		$link_custom_context  = admin_url( sprintf( $post_type_object->_edit_link . '&canvas=edit', $template_post->post_type, get_stylesheet() . '//my_template' ) );
 
 		$this->assertSame( $link_default_context, get_edit_post_link( $template_post ), 'Second argument `$context` has a default context of `"display"`.' );
 		$this->assertSame( $link_custom_context, get_edit_post_link( $template_post, 'something-else' ), 'Pass non-default value in second argument.' );
@@ -125,8 +125,8 @@ class Tests_Link_GetEditPostLink extends WP_UnitTestCase {
 		wp_set_post_terms( $template_part_post->ID, self::TEST_THEME, 'wp_theme' );
 
 		$post_type_object     = get_post_type_object( $template_part_post->post_type );
-		$link_default_context = admin_url( sprintf( $post_type_object->_edit_link . '&amp;canvas=edit', get_stylesheet() . '//my_template_part' ) );
-		$link_custom_context  = admin_url( sprintf( $post_type_object->_edit_link . '&canvas=edit', get_stylesheet() . '//my_template_part' ) );
+		$link_default_context = admin_url( sprintf( $post_type_object->_edit_link . '&amp;canvas=edit', $template_part_post->post_type, get_stylesheet() . '//my_template_part' ) );
+		$link_custom_context  = admin_url( sprintf( $post_type_object->_edit_link . '&canvas=edit', $template_part_post->post_type, get_stylesheet() . '//my_template_part' ) );
 
 		$this->assertSame( $link_default_context, get_edit_post_link( $template_part_post ), 'Second argument `$context` has a default context of `"display"`.' );
 		$this->assertSame( $link_custom_context, get_edit_post_link( $template_part_post, 'something-else' ), 'Pass non-default value in second argument.' );

--- a/tests/phpunit/tests/link/getEditPostLink.php
+++ b/tests/phpunit/tests/link/getEditPostLink.php
@@ -90,8 +90,8 @@ class Tests_Link_GetEditPostLink extends WP_UnitTestCase {
 		wp_set_post_terms( $template_post->ID, self::TEST_THEME, 'wp_theme' );
 
 		$post_type_object     = get_post_type_object( $template_post->post_type );
-		$link_default_context = admin_url( sprintf( $post_type_object->_edit_link . '&amp;canvas=edit', $template_post->post_type, get_stylesheet() . '//my_template' ) );
-		$link_custom_context  = admin_url( sprintf( $post_type_object->_edit_link . '&canvas=edit', $template_post->post_type, get_stylesheet() . '//my_template' ) );
+		$link_default_context = admin_url( sprintf( $post_type_object->_edit_link, $template_post->post_type, get_stylesheet() . '%2F%2Fmy_template' ) );
+		$link_custom_context  = admin_url( sprintf( $post_type_object->_edit_link, $template_post->post_type, get_stylesheet() . '%2F%2Fmy_template' ) );
 
 		$this->assertSame( $link_default_context, get_edit_post_link( $template_post ), 'Second argument `$context` has a default context of `"display"`.' );
 		$this->assertSame( $link_custom_context, get_edit_post_link( $template_post, 'something-else' ), 'Pass non-default value in second argument.' );

--- a/tests/phpunit/tests/link/getEditPostLink.php
+++ b/tests/phpunit/tests/link/getEditPostLink.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Tests the `get_edit_post_link()` function.
+ *
+ * @since 6.3.0
+ *
+ * @group link
+ *
+ * @covers ::get_edit_post_link
+ */
+class Tests_Link_GetEditPostLink extends WP_UnitTestCase {
+	/**
+	 * The name of the theme to use for the test.
+	 *
+	 * @since 6.3.0
+	 * @var string
+	 */
+	const TEST_THEME = 'block-theme';
+
+	/**
+	 * The id of the user to use for the test.
+	 *
+	 * @since 6.3.0
+	 * @var int
+	 */
+	private static $admin_id;
+
+	/**
+	 * Creates admin user before tests run.
+	 *
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		// Create an admin user because get_edit_post_link() requires 'edit_post' capability.
+		self::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	/**
+	 * Performs setup tasks for every test.
+	 *
+	 * @since 6.3.0
+	 */
+	public function set_up() {
+		parent::set_up();
+		wp_set_current_user( self::$admin_id );
+		switch_theme( self::TEST_THEME );
+	}
+
+	/**
+	 * Tests getting the edit post link for a post.
+	 */
+	public function test_get_edit_post_link() {
+		$post                 = self::factory()->post->create_and_get(
+			array(
+				'post_type'   => 'post',
+				'post_title'  => 'Test Post',
+				'post_name'   => 'test-post',
+				'post_status' => 'publish',
+			)
+		);
+		$post_type_object     = get_post_type_object( $post->post_type );
+		$link_default_context = admin_url( sprintf( $post_type_object->_edit_link . '&amp;action=edit', $post->ID ) );
+		$link_custom_context  = admin_url( sprintf( $post_type_object->_edit_link . '&action=edit', $post->ID ) );
+
+		$this->assertSame( $link_default_context, get_edit_post_link( $post ), 'Second argument `$context` has a default context of `"display"`.' );
+		$this->assertSame( $link_custom_context, get_edit_post_link( $post, 'something-else' ), 'Pass non-default value in second argument.' );
+	}
+
+	/**
+	 * Tests getting the edit post link for a template post type
+	 *
+	 * @ticket 57709
+	 */
+	public function test_get_edit_post_link_for_wp_template_post_type() {
+		$template_post = self::factory()->post->create_and_get(
+			array(
+				'post_type'    => 'wp_template',
+				'post_name'    => 'my_template',
+				'post_title'   => 'My Template',
+				'post_content' => 'Content',
+				'post_excerpt' => 'Description of my template',
+				'tax_input'    => array(
+					'wp_theme' => array(
+						self::TEST_THEME,
+					),
+				),
+			)
+		);
+
+		wp_set_post_terms( $template_post->ID, self::TEST_THEME, 'wp_theme' );
+
+		$post_type_object     = get_post_type_object( $template_post->post_type );
+		$link_default_context = admin_url( sprintf( $post_type_object->_edit_link . '&amp;canvas=edit', get_stylesheet() . '//my_template' ) );
+		$link_custom_context  = admin_url( sprintf( $post_type_object->_edit_link . '&canvas=edit', get_stylesheet() . '//my_template' ) );
+
+		$this->assertSame( $link_default_context, get_edit_post_link( $template_post ), 'Second argument `$context` has a default context of `"display"`.' );
+		$this->assertSame( $link_custom_context, get_edit_post_link( $template_post, 'something-else' ), 'Pass non-default value in second argument.' );
+	}
+
+	/**
+	 * Tests getting the edit post link for a template part post type
+	 *
+	 * @ticket 57709
+	 */
+	public function test_get_edit_post_link_for_wp_template_part_post_type() {
+		$template_part_post = self::factory()->post->create_and_get(
+			array(
+				'post_type'    => 'wp_template_part',
+				'post_name'    => 'my_template_part',
+				'post_title'   => 'My Template Part',
+				'post_content' => 'Content',
+				'post_excerpt' => 'Description of my template part',
+				'tax_input'    => array(
+					'wp_theme'              => array(
+						self::TEST_THEME,
+					),
+					'wp_template_part_area' => array(
+						WP_TEMPLATE_PART_AREA_HEADER,
+					),
+				),
+			)
+		);
+
+		wp_set_post_terms( $template_part_post->ID, WP_TEMPLATE_PART_AREA_HEADER, 'wp_template_part_area' );
+		wp_set_post_terms( $template_part_post->ID, self::TEST_THEME, 'wp_theme' );
+
+		$post_type_object     = get_post_type_object( $template_part_post->post_type );
+		$link_default_context = admin_url( sprintf( $post_type_object->_edit_link . '&amp;canvas=edit', get_stylesheet() . '//my_template_part' ) );
+		$link_custom_context  = admin_url( sprintf( $post_type_object->_edit_link . '&canvas=edit', get_stylesheet() . '//my_template_part' ) );
+
+		$this->assertSame( $link_default_context, get_edit_post_link( $template_part_post ), 'Second argument `$context` has a default context of `"display"`.' );
+		$this->assertSame( $link_custom_context, get_edit_post_link( $template_part_post, 'something-else' ), 'Pass non-default value in second argument.' );
+	}
+}


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/57709


<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
