### PR TITLE
add upgrade notice for themes to update-core.php

### DIFF
--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -682,7 +682,7 @@ function list_theme_updates() {
 
 		// Get the upgrade notice for the new theme version.
 		if ( isset( $theme->update['upgrade_notice'] ) ) {
-				$upgrade_notice = '<br/>' . strip_tags( $theme->update['upgrade_notice'] );
+			$upgrade_notice = '<br/>' . strip_tags( $theme->update['upgrade_notice'] );
 		} else {
 			$upgrade_notice = '';
 		}

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -680,6 +680,13 @@ function list_theme_updates() {
 
 		$compat = '';
 
+		// Get the upgrade notice for the new theme version.
+		if ( isset( $theme->update['upgrade_notice'] ) ) {
+				$upgrade_notice = '<br/>' . strip_tags( $theme->update['upgrade_notice'] );
+		} else {
+			$upgrade_notice = '';
+		}
+
 		if ( ! $compatible_wp && ! $compatible_php ) {
 			$compat .= '<br />' . __( 'This update does not work with your versions of WordPress and PHP.' ) . '&nbsp;';
 			if ( current_user_can( 'update_core' ) && current_user_can( 'update_php' ) ) {
@@ -765,7 +772,7 @@ function list_theme_updates() {
 				$theme->update['new_version']
 			);
 
-			echo ' ' . $compat;
+			echo ' ' . $compat . $upgrade_notice;
 
 			if ( in_array( $stylesheet, $auto_updates, true ) ) {
 				echo $auto_update_notice;

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -772,11 +772,13 @@ function list_theme_updates() {
 				$theme->update['new_version']
 			);
 
-			echo ' ' . $compat . $upgrade_notice;
+			echo ' ' . $compat;
 
 			if ( in_array( $stylesheet, $auto_updates, true ) ) {
 				echo $auto_update_notice;
 			}
+
+			echo $upgrade_notice;
 			?>
 		</p></td>
 	</tr>

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -778,7 +778,7 @@ function list_theme_updates() {
 				echo $auto_update_notice;
 			}
 
-			echo $upgrade_notice;
+			echo '<br />' . wp_strip_all_tags( $upgrade_notice );
 			?>
 		</p></td>
 	</tr>

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -682,7 +682,7 @@ function list_theme_updates() {
 
 		// Get the upgrade notice for the new theme version.
 		if ( isset( $theme->update['upgrade_notice'] ) ) {
-			$upgrade_notice = '<br/>' . strip_tags( $theme->update['upgrade_notice'] );
+			$upgrade_notice = $theme->update['upgrade_notice'];
 		} else {
 			$upgrade_notice = '';
 		}


### PR DESCRIPTION
Updated PR for adding an upgrade notice to theme updates in update-core.php as there is for plugin updates.

Trac ticket: https://core.trac.wordpress.org/ticket/34986

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
