### PR TITLE
move location of $upgrade_notice for improved consistency

### DIFF
--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -591,11 +591,13 @@ function list_plugin_updates() {
 				$plugin_data->update->new_version
 			);
 
-			echo ' ' . $details . $compat . $upgrade_notice;
+			echo ' ' . $details . $compat;
 
 			if ( in_array( $plugin_file, $auto_updates, true ) ) {
 				echo $auto_update_notice;
 			}
+
+			echo $upgrade_notice;
 			?>
 		</p></td>
 	</tr>


### PR DESCRIPTION
Since the `$auto_upgrade_notice` has been added to the `update-core.php` table listing if an `$upgrade_notice` is present by virtue of the readme.txt containing data in the `== Upgrade Notice ==` section this text will appear in between the compatibility information and the auto update information. This provides a less consistent appearance

Trac ticket: https://core.trac.wordpress.org/ticket/57939

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
