### PR TITLE
Include attachments and featured images for posts being exported

### DIFF
--- a/src/wp-admin/includes/export.php
+++ b/src/wp-admin/includes/export.php
@@ -147,14 +147,16 @@ function export_wp( $args = array() ) {
 	// Get IDs for the attachments of each post, unless all content is already being exported.
 	if ( 'all' !== $args['content'] ) {
 		foreach ( array_chunk( $post_ids, 20 ) as $chunk ) {
-			$posts_in = esc_sql( implode( ',', array_map( 'absint', $chunk ) ) );
+			$posts_in     = array_map( 'absint', $chunk );
+			$placeholders = array_fill( 0, count( $posts_in ), '%d' );
 
+			// Prepare the SQL statement for attachment ids
 			$attachment_ids = $wpdb->get_col(
 				$wpdb->prepare(
 					"
 				SELECT ID
 				FROM $wpdb->posts
-				WHERE post_parent IN (%s) AND post_type = 'attachment'
+				WHERE post_parent IN (" . implode( ',', $placeholders ) . ") AND post_type = 'attachment'
 					",
 					$posts_in
 				)
@@ -165,7 +167,7 @@ function export_wp( $args = array() ) {
 					"
 				SELECT meta_value
 				FROM {$wpdb->postmeta}
-				WHERE {$wpdb->postmeta}.post_id IN (%s)
+				WHERE {$wpdb->postmeta}.post_id IN (" . implode( ',', $placeholders ) . ")
 				AND {$wpdb->postmeta}.meta_key = '_thumbnail_id'
 					",
 					$posts_in

--- a/src/wp-admin/includes/export.php
+++ b/src/wp-admin/includes/export.php
@@ -144,6 +144,38 @@ function export_wp( $args = array() ) {
 	// Grab a snapshot of post IDs, just in case it changes during the export.
 	$post_ids = $wpdb->get_col( "SELECT ID FROM {$wpdb->posts} $join WHERE $where" );
 
+	// Get IDs for the attachments of each post, unless all content is already being exported.
+	if ( 'all' !== $args['content'] ) {
+		foreach ( array_chunk( $post_ids, 20 ) as $chunk ) {
+			$posts_in = esc_sql( implode( ',', array_map( 'absint', $chunk ) ) );
+
+			$attachment_ids = $wpdb->get_col(
+				$wpdb->prepare(
+					"
+				SELECT ID
+				FROM $wpdb->posts
+				WHERE post_parent IN (%s) AND post_type = 'attachment'
+					",
+					$posts_in
+				)
+			);
+
+			$thumbnails_ids = $wpdb->get_col(
+				$wpdb->prepare(
+					"
+				SELECT meta_value
+				FROM {$wpdb->postmeta}
+				WHERE {$wpdb->postmeta}.post_id IN (%s)
+				AND {$wpdb->postmeta}.meta_key = '_thumbnail_id'
+					",
+					$posts_in
+				)
+			);
+
+			$post_ids = array_unique( array_merge( $post_ids, $attachment_ids, $thumbnails_ids ) );
+		}
+	}
+
 	/*
 	 * Get the requested terms ready, empty unless posts filtered by category
 	 * or all content.

--- a/tests/phpunit/tests/export/attachments.php
+++ b/tests/phpunit/tests/export/attachments.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * @group export
+ * @group attachments
+ * @ticket 17379
+ */
+class Test_Export_Includes_Attachments extends WP_UnitTestCase {
+
+	public static $post;
+
+	public static $author;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$author = $factory->user->create( array( 'role' => 'editor' ) );
+
+		$args       = array(
+			'post_title'   => 'Test Post',
+			'post_content' => 'Test Content',
+			'post_status'  => 'publish',
+			'post_author'  => self::$author,
+		);
+		self::$post = self::factory()->post->create_and_get( $args );
+
+		$file          = DIR_TESTDATA . '/images/test-image.jpg';
+		$attachment_id = $factory->attachment->create_upload_object( $file );
+
+		set_post_thumbnail( self::$post->ID, $attachment_id );
+	}
+
+	/**
+	 * Tests the export function to ensure that attachments are included.
+	 *
+	 * Runs in a separate process to prevent "headers already sent" error.
+	 *
+	 * This test does not preserve global state to prevent the exception
+	 * "Serialization of 'Closure' is not allowed" when running in
+	 * a separate process.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_export_includes_attachments_for_specific_author() {
+		require_once ABSPATH . 'wp-admin/includes/export.php';
+
+		ob_start();
+		export_wp(
+			array(
+				'content' => 'post',
+				'author'  => self::$post->post_author,
+			)
+		);
+		$xml = simplexml_load_string( ob_get_clean() );
+
+		$this->assertNotEmpty( $xml->channel->item->title );
+		$this->assertEquals( self::$post->post_title, (string) $xml->channel->item[0]->title );
+		$this->assertEquals( basename( get_attached_file( get_post_thumbnail_id( self::$post->ID ) ) ), (string) $xml->channel->item[1]->title );
+	}
+}


### PR DESCRIPTION
This pull request fixes an issue where attachments are not included when exporting posts, unless you choose the "all" option.

A unit test is also included.

Trac ticket: [17379](https://core.trac.wordpress.org/ticket/17379)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
