### PR TITLE
Do not use get_term  in wp_queue_posts_for_term_meta_lazyload

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -7802,17 +7802,19 @@ function wp_queue_posts_for_term_meta_lazyload( $posts ) {
 			$prime_term_ids = array_unique( $prime_term_ids );
 			// Do not prime term meta at this point, let the lazy loader take care of that.
 			_prime_term_caches( $prime_term_ids, false );
-
+			$cache_values = wp_cache_get_multiple( $prime_term_ids, 'terms' );
 			foreach ( $prime_taxonomy_ids as $taxonomy => $_term_ids ) {
 				foreach ( $_term_ids as $term_id ) {
 					if ( in_array( $term_id, $term_ids, true ) ) {
 						continue;
 					}
-					$term = get_term( $term_id, $taxonomy );
-					if ( is_wp_error( $term ) ) {
+					$term = isset( $cache_values[ $term_id ] ) ? $cache_values[ $term_id ] : false;
+					if ( ! is_object( $term ) ) {
 						continue;
 					}
-
+					if ( $term->taxonomy !== $taxonomy ) {
+						continue;
+					}
 					$term_ids[] = $term_id;
 				}
 			}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket:  https://core.trac.wordpress.org/ticket/57966

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
