### PR TITLE
Add new test class for wp_enqueue_stored_styles()

### DIFF
--- a/tests/phpunit/tests/theme/wpEnqueueStoredStyles.php
+++ b/tests/phpunit/tests/theme/wpEnqueueStoredStyles.php
@@ -1,0 +1,83 @@
+<?php
+
+require_once __DIR__ . '/base.php';
+
+/**
+ * Tests wp_enqueue_stored_styles().
+ *
+ * @group themes
+ *
+ * @covers ::wp_enqueue_stored_styles
+ */
+class Tests_Themes_WpEnqueueStoredStyles extends WP_Theme_UnitTestCase {
+
+	/**
+	 * Cleans up global scope.
+	 *
+	 * @global WP_Styles $wp_styles
+	 */
+	public function clean_up_global_scope() {
+		global $wp_styles;
+		parent::clean_up_global_scope();
+		$wp_styles = null;
+	}
+
+	/**
+	 * Tests that stored CSS is enqueued.
+	 *
+	 * @ticket 56467
+	 */
+	public function test_should_enqueue_stored_styles() {
+		$core_styles_to_enqueue = array(
+			array(
+				'selector'     => '.saruman',
+				'declarations' => array(
+					'color'        => 'white',
+					'height'       => '100px',
+					'border-style' => 'solid',
+				),
+			),
+		);
+
+		// Enqueues a block supports (core styles).
+		wp_style_engine_get_stylesheet_from_css_rules(
+			$core_styles_to_enqueue,
+			array(
+				'context' => 'block-supports',
+			)
+		);
+
+		$my_styles_to_enqueue = array(
+			array(
+				'selector'     => '.gandalf',
+				'declarations' => array(
+					'color'        => 'grey',
+					'height'       => '90px',
+					'border-style' => 'dotted',
+				),
+			),
+		);
+
+		// Enqueues some other styles.
+		wp_style_engine_get_stylesheet_from_css_rules(
+			$my_styles_to_enqueue,
+			array(
+				'context' => 'my-styles',
+			)
+		);
+
+		wp_enqueue_stored_styles( array( 'prettify' => false ) );
+
+		$this->assertSame(
+			array( '.saruman{color:white;height:100px;border-style:solid;}' ),
+			wp_styles()->registered['core-block-supports']->extra['after'],
+			'Registered styles with handle of "core-block-supports" do not match expected value from Style Engine store.'
+		);
+
+		$this->assertSame(
+			array( '.gandalf{color:grey;height:90px;border-style:dotted;}' ),
+			wp_styles()->registered['wp-style-engine-my-styles']->extra['after'],
+			'Registered styles with handle of "wp-style-engine-my-styles" do not match expected value from the Style Engine store.'
+		);
+	}
+}

--- a/tests/phpunit/tests/theme/wpEnqueueStoredStyles.php
+++ b/tests/phpunit/tests/theme/wpEnqueueStoredStyles.php
@@ -12,17 +12,6 @@ require_once __DIR__ . '/base.php';
 class Tests_Themes_WpEnqueueStoredStyles extends WP_Theme_UnitTestCase {
 
 	/**
-	 * Cleans up global scope.
-	 *
-	 * @global WP_Styles $wp_styles
-	 */
-	public function clean_up_global_scope() {
-		global $wp_styles;
-		parent::clean_up_global_scope();
-		$wp_styles = null;
-	}
-
-	/**
 	 * Tests that stored CSS is enqueued.
 	 *
 	 * @ticket 56467

--- a/tests/phpunit/tests/theme/wpGetGlobalStylesheet.php
+++ b/tests/phpunit/tests/theme/wpGetGlobalStylesheet.php
@@ -54,17 +54,6 @@ class Tests_Theme_wpGetGlobalStylesheet extends WP_UnitTestCase {
 		parent::tear_down();
 	}
 
-	/**
-	 * Cleans up global scope.
-	 *
-	 * @global WP_Styles $wp_styles
-	 */
-	public function clean_up_global_scope() {
-		global $wp_styles;
-		parent::clean_up_global_scope();
-		$wp_styles = null;
-	}
-
 	public function filter_set_theme_root() {
 		return $this->theme_root;
 	}
@@ -210,66 +199,6 @@ class Tests_Theme_wpGetGlobalStylesheet extends WP_UnitTestCase {
 		remove_theme_support( 'editor-font-sizes' );
 	}
 
-	/**
-	 * Tests that stored CSS is enqueued.
-	 *
-	 * @ticket 56467
-	 *
-	 * @covers ::wp_enqueue_stored_styles
-	 */
-	public function test_should_enqueue_stored_styles() {
-		$core_styles_to_enqueue = array(
-			array(
-				'selector'     => '.saruman',
-				'declarations' => array(
-					'color'        => 'white',
-					'height'       => '100px',
-					'border-style' => 'solid',
-				),
-			),
-		);
-
-		// Enqueues a block supports (core styles).
-		wp_style_engine_get_stylesheet_from_css_rules(
-			$core_styles_to_enqueue,
-			array(
-				'context' => 'block-supports',
-			)
-		);
-
-		$my_styles_to_enqueue = array(
-			array(
-				'selector'     => '.gandalf',
-				'declarations' => array(
-					'color'        => 'grey',
-					'height'       => '90px',
-					'border-style' => 'dotted',
-				),
-			),
-		);
-
-		// Enqueues some other styles.
-		wp_style_engine_get_stylesheet_from_css_rules(
-			$my_styles_to_enqueue,
-			array(
-				'context' => 'my-styles',
-			)
-		);
-
-		wp_enqueue_stored_styles( array( 'prettify' => false ) );
-
-		$this->assertSame(
-			array( '.saruman{color:white;height:100px;border-style:solid;}' ),
-			wp_styles()->registered['core-block-supports']->extra['after'],
-			'Registered styles with handle of "core-block-supports" do not match expected value from Style Engine store.'
-		);
-
-		$this->assertSame(
-			array( '.gandalf{color:grey;height:90px;border-style:dotted;}' ),
-			wp_styles()->registered['wp-style-engine-my-styles']->extra['after'],
-			'Registered styles with handle of "wp-style-engine-my-styles" do not match expected value from the Style Engine store.'
-		);
-	}
 	/**
 	 * Tests that switching themes recalculates the stylesheet.
 	 *


### PR DESCRIPTION
Tests: Add test class for `wp_enqueue_stored_styles()`.

[54214] added the `wp_enqueue_stored_styles()` tests and `clean_up_global_scope()` reset global method to `Tests_Theme_wpGetGlobalStylesheet`.

This changeset relocates those tests a new test class specifically for `wp_enqueue_stored_styles()` and removes `Tests_Theme_wpGetGlobalStylesheet::clean_up_global_scope()` method.

Why not relocate the `clean_up_global_scope()` method to the new test class?
The test class extends from `WP_Theme_UnitTestCase` which includes this method.

Follow-up to [54214], [54703].

Props costdev.
See #57841.

Trac ticket: https://core.trac.wordpress.org/ticket/57841

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
