### PR TITLE
Posts/Post Types: Introduced the 'item_trashed' default label

### DIFF
--- a/src/wp-includes/class-wp-post-type.php
+++ b/src/wp-includes/class-wp-post-type.php
@@ -839,6 +839,7 @@ final class WP_Post_Type {
 			'search_items'             => array( __( 'Search Posts' ), __( 'Search Pages' ) ),
 			'not_found'                => array( __( 'No posts found.' ), __( 'No pages found.' ) ),
 			'not_found_in_trash'       => array( __( 'No posts found in Trash.' ), __( 'No pages found in Trash.' ) ),
+			'item_trashed'             => array( __( 'Post trashed.' ), __( 'Page trashed.' ) ),
 			'parent_item_colon'        => array( null, __( 'Parent Page:' ) ),
 			'all_items'                => array( __( 'All Posts' ), __( 'All Pages' ) ),
 			'archives'                 => array( __( 'Post Archives' ), __( 'Page Archives' ) ),


### PR DESCRIPTION
Added the `item_trashed` default label to the `get_default_labels()` method.

This update adds the `item_trashed` default label to the `get_default_labels()` method. As per [#25604 ](https://github.com/WordPress/gutenberg/pull/25604), this should allow [#25563 ](https://github.com/WordPress/gutenberg/pull/25563) to move forward now that the strings are translatable. Note: [#25563 ](https://github.com/WordPress/gutenberg/pull/25563) was reverted, pending this update to core.

Testing Instructions:

1. Manually apply the changes in [#25563 ](https://github.com/WordPress/gutenberg/pull/25563) to a local copy of the Gutenberg plugin.
2. Remove the if statement [here]( https://github.com/WordPress/gutenberg/blob/trunk/packages/editor/src/store/utils/notice-builder.js#L26).
3. Instead of `noticeMessage = ${ postType.labels.singular_name } trashed.;`, use `noticeMessage = postType.labels.item_trashed;`
4. Re-build Gutenberg - `npm run build`.
5. Open a post in the editor - On the Document settings pane, click on "Move to trash". 
6. Voice Over should read "Post trashed" before redirecting.

Trac ticket: https://core.trac.wordpress.org/ticket/51387