### PR TITLE
HTML API: Fix invalid comment syntax cases

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1056,7 +1056,8 @@ class WP_HTML_Tag_Processor {
 					 *
 					 * See https://html.spec.whatwg.org/#parse-error-incorrectly-closed-comment
 					 */
-					while ( $closer_at < strlen( $html ) ) {
+					$closer_at--; // Pre-increment inside condition avoids risk of infinite looping.
+					while ( ++$closer_at < strlen( $html ) ) {
 						$closer_at = strpos( $html, '--', $closer_at );
 						if ( false === $closer_at ) {
 							return false;
@@ -1071,8 +1072,6 @@ class WP_HTML_Tag_Processor {
 							$at = $closer_at + 4;
 							continue 2;
 						}
-
-						$closer_at = $closer_at + 1;
 					}
 				}
 

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1036,7 +1036,7 @@ class WP_HTML_Tag_Processor {
 				 * https://html.spec.whatwg.org/multipage/parsing.html#tag-open-state
 				 */
 				if (
-					strlen( $html ) > $at + 3 &&
+					strlen( $html ) > $at + 4 &&
 					'-' === $html[ $at + 2 ] &&
 					'-' === $html[ $at + 3 ]
 				) {

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -971,6 +971,7 @@ class WP_HTML_Tag_Processor {
 	 * closing `>`; these are left for other methods.
 	 *
 	 * @since 6.2.0
+	 * @since 6.3.0 Passes over invalid-tag-closer-comments like "</3 this is a comment>".
 	 *
 	 * @return bool Whether a tag was found before the end of the document.
 	 */

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -971,7 +971,7 @@ class WP_HTML_Tag_Processor {
 	 * closing `>`; these are left for other methods.
 	 *
 	 * @since 6.2.0
-	 * @since 6.3.0 Passes over invalid-tag-closer-comments like "</3 this is a comment>".
+	 * @since 6.2.1 Passes over invalid-tag-closer-comments like "</3 this is a comment>".
 	 *
 	 * @return bool Whether a tag was found before the end of the document.
 	 */
@@ -1042,9 +1042,7 @@ class WP_HTML_Tag_Processor {
 				) {
 					$closer_at = $at + 4;
 
-					/*
-					 * Abruptly-closed empty comments are a sequence of dashes followed by `>`.
-					 */
+					// Abruptly-closed empty comments are a sequence of dashes followed by `>`.
 					$span_of_dashes = strspn( $html, '-', $closer_at );
 					if ( '>' === $html[ $closer_at + $span_of_dashes ] ) {
 						$at = $closer_at + $span_of_dashes + 1;

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1072,7 +1072,7 @@ class WP_HTML_Tag_Processor {
 							continue 2;
 						}
 
-						$closer_at = $closer_at + 2;
+						$closer_at = $closer_at + 1;
 					}
 				}
 

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1055,19 +1055,19 @@ class WP_HTML_Tag_Processor {
 					 *
 					 * See https://html.spec.whatwg.org/#parse-error-incorrectly-closed-comment
 					 */
-					$closer_at--; // Pre-increment inside condition avoids risk of infinite looping.
+					$closer_at--; // Pre-increment inside condition below reduces risk of accidental infinite looping.
 					while ( ++$closer_at < strlen( $html ) ) {
 						$closer_at = strpos( $html, '--', $closer_at );
 						if ( false === $closer_at ) {
 							return false;
 						}
 
-						if ( '>' === $html[ $closer_at + 2 ] ) {
+						if ( $closer_at + 2 < strlen( $html ) && '>' === $html[ $closer_at + 2 ] ) {
 							$at = $closer_at + 3;
 							continue 2;
 						}
 
-						if ( '!' === $html[ $closer_at + 2 ] && '>' === $html[ $closer_at + 3 ] ) {
+						if ( $closer_at + 3 < strlen( $html ) && '!' === $html[ $closer_at + 2 ] && '>' === $html[ $closer_at + 3 ] ) {
 							$at = $closer_at + 4;
 							continue 2;
 						}

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -971,7 +971,7 @@ class WP_HTML_Tag_Processor {
 	 * closing `>`; these are left for other methods.
 	 *
 	 * @since 6.2.0
-	 * @since 6.2.1 Passes over invalid-tag-closer-comments like "</3 this is a comment>".
+	 * @since 6.2.1 Support abruptly-closed comments and invalid-tag-closer-comments.
 	 *
 	 * @return bool Whether a tag was found before the end of the document.
 	 */

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1036,11 +1036,15 @@ class WP_HTML_Tag_Processor {
 				 * https://html.spec.whatwg.org/multipage/parsing.html#tag-open-state
 				 */
 				if (
-					strlen( $html ) > $at + 4 &&
+					strlen( $html ) > $at + 3 &&
 					'-' === $html[ $at + 2 ] &&
 					'-' === $html[ $at + 3 ]
 				) {
 					$closer_at = $at + 4;
+					// If it's not possible to close the comment then there is nothing more to scan.
+					if ( strlen( $html ) <= $closer_at ) {
+						return false;
+					}
 
 					// Abruptly-closed empty comments are a sequence of dashes followed by `>`.
 					$span_of_dashes = strspn( $html, '-', $closer_at );

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -971,7 +971,7 @@ class WP_HTML_Tag_Processor {
 	 * closing `>`; these are left for other methods.
 	 *
 	 * @since 6.2.0
-	 * @since 6.2.1 Support abruptly-closed comments and invalid-tag-closer-comments.
+	 * @since 6.2.1 Support abruptly-closed comments, invalid-tag-closer-comments, and empty elements.
 	 *
 	 * @return bool Whether a tag was found before the end of the document.
 	 */

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1158,7 +1158,7 @@ class WP_HTML_Tag_Processor {
 			 * If a non-alpha starts the tag name in a tag closer it's a comment.
 			 * Find the first `>`, which closes the comment.
 			 *
-			 * See https://github.com/WordPress/wordpress-develop/pull/4256
+			 * See https://html.spec.whatwg.org/#parse-error-invalid-first-character-of-tag-name
 			 */
 			if ( $this->is_closing_tag ) {
 				$closer_at = strpos( $html, '>', $at + 3 );

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -1796,6 +1796,7 @@ HTML;
 			'Empty comment with four dashes'     => array( '<hr><!----><hr id=after>' ),
 			'Empty comment with four dashes, improperly closed' => array( '<hr><!----!><hr id=after>--><hr id=final>' ),
 			'Comment with four dashes, improperly closed twice' => array( '<hr><!----!><hr id=after>--!><hr id=final>' ),
+			'Comment with almost-closer inside'  => array( '<hr><!-- ---!><hr id=after>--!><hr id=final>' ),
 		);
 	}
 

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -1807,7 +1807,7 @@ HTML;
 			'Comment with closer look-alike'   => array( '<!-- this ends --x' ),
 			'Comment with closer look-alike 2' => array( '<!-- this ends --!x' ),
 			'Invalid tag-closer comment'       => array( '</(when will this madness end?)' ),
-			'Invalid tag-closer comment 2'     => array( '</(when will this madness end?)--' )
+			'Invalid tag-closer comment 2'     => array( '</(when will this madness end?)--' ),
 		);
 	}
 

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -1800,6 +1800,7 @@ HTML;
 	 */
 	public function data_html_with_unclosed_comments() {
 		return array(
+			'Shortest open valid comment'      => array( '<!--' ),
 			'Basic truncated comment'          => array( '<!-- this ends --' ),
 			'Comment with closer look-alike'   => array( '<!-- this ends --x' ),
 			'Comment with closer look-alike 2' => array( '<!-- this ends --!x' ),

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -1778,9 +1778,41 @@ HTML;
 	}
 
 	/**
+	 * Ensures that unclosed and invalid comments don't trigger warnings or errors.
+	 *
+	 * @ticket 58007
+	 *
+	 * @covers WP_HTML_Tag_Processor::next_tag
+	 * @dataProvider data_html_with_unclosed_comments
+	 *
+	 * @param string $html_ending_before_comment_close HTML with opened comments that aren't closed
+	 */
+	public function test_documents_may_end_with_unclosed_comment( $html_ending_before_comment_close ) {
+		$p = new WP_HTML_Tag_Processor( $html_ending_before_comment_close );
+
+		$this->assertFalse( $p->next_tag() );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_html_with_unclosed_comments() {
+		return array(
+			'Basic truncated comment'          => array( '<!-- this ends --' ),
+			'Comment with closer look-alike'   => array( '<!-- this ends --x' ),
+			'Comment with closer look-alike 2' => array( '<!-- this ends --!x' ),
+			'Invalid tag-closer comment'       => array( '</(when will this madness end?)' ),
+			'Invalid tag-closer comment 2'     => array( '</(when will this madness end?)--' )
+		);
+	}
+
+	/**
 	 * Ensures that abruptly-closed empty comments are properly closed.
 	 *
 	 * @ticket 58007
+	 *
 	 * @covers WP_HTML_Tag_Processor::next_tag
 	 * @dataProvider data_abruptly_closed_empty_comments
 	 *
@@ -1796,8 +1828,6 @@ HTML;
 
 	/**
 	 * Data provider.
-	 *
-	 * @ticket 58007
 	 *
 	 * @return array[]
 	 */

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -1670,9 +1670,11 @@ HTML;
 	 * See https://html.spec.whatwg.org/#parse-error-invalid-first-character-of-tag-name
 	 *
 	 * @ticket 58007
+	 *
 	 * @dataProvider data_next_tag_ignores_invalid_first_character_of_tag_name_comments
 	 *
-	 * @param string $html_with_markers HTML containing an invalid tag closer whose element before and element after contain the "start" and "end" CSS classes.
+	 * @param string $html_with_markers HTML containing an invalid tag closer whose element before and
+	 *                                  element after contain the "start" and "end" CSS classes.
 	 */
 	public function test_next_tag_ignores_invalid_first_character_of_tag_name_comments( $html_with_markers ) {
 		$p = new WP_HTML_Tag_Processor( $html_with_markers );
@@ -1684,8 +1686,6 @@ HTML;
 
 	/**
 	 * Data provider.
-	 *
-	 * @ticket 58007
 	 *
 	 * @return array[]
 	 */

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -1667,9 +1667,9 @@ HTML;
 	/**
 	 * Invalid tag names are comments on tag closers.
 	 *
-	 * See https://html.spec.whatwg.org/#parse-error-invalid-first-character-of-tag-name
-	 *
 	 * @ticket 58007
+	 *
+	 * @link https://html.spec.whatwg.org/#parse-error-invalid-first-character-of-tag-name
 	 *
 	 * @dataProvider data_next_tag_ignores_invalid_first_character_of_tag_name_comments
 	 *
@@ -1761,6 +1761,7 @@ HTML;
 	 * Ensures that the invalid comment closing syntax "--!>" properly closes a comment.
 	 *
 	 * @ticket 58007
+	 *
 	 * @covers WP_HTML_Tag_Processor::next_tag
 	 *
 	 */
@@ -1783,6 +1784,7 @@ HTML;
 	 * @ticket 58007
 	 *
 	 * @covers WP_HTML_Tag_Processor::next_tag
+	 *
 	 * @dataProvider data_html_with_unclosed_comments
 	 *
 	 * @param string $html_ending_before_comment_close HTML with opened comments that aren't closed
@@ -1815,6 +1817,7 @@ HTML;
 	 * @ticket 58007
 	 *
 	 * @covers WP_HTML_Tag_Processor::next_tag
+	 *
 	 * @dataProvider data_abruptly_closed_empty_comments
 	 *
 	 * @param string $html_with_after_marker HTML to test with "id=after" on element immediately following an abruptly closed comment.


### PR DESCRIPTION
## Status

 - [x] Satisfy linter requirements
 - [x] Create Trac ticket [#58007-trac](https://core.trac.wordpress.org/ticket/58007#ticket)
 - [x] Expand comments, docblocks, add version and Trac ticket refereces
 - [ ] Create backport in Gutenberg

## What

Adds support for a few invalid HTML comment forms.

 - comments created by means of a tag closer with an invalid tag name, e.g. `</3>`
 - comments closed with the invalid `--!>` closer (comments should be closed by `-->` but if the `!` appears it will also close it, in error).
 - empty tag name elements, which are technically skipped over and aren't comments, e.g. `</>`

## Why

We want to continue to find and handle edge cases in HTML so that the Tag Processor remains reliable in the face of unexpected inputs.

## How

Captures the patterns described in the HTML specification for parse errors relating to invalid comment construction. Since these are comments it's appropriate to proceed consuming input until the end, and there's no need to look for other tags or attributes in the process.

cc: @adamziel @gziolo