### PR TITLE
Fix/username check

### DIFF
--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -2129,7 +2129,8 @@ function wp_insert_user( $userdata ) {
 	}
 
 	// Username must not match an existing user email.
-	if ( email_exists( $user_login ) ) {
+	$existing_user_id = email_exists( $user_login );
+	if ( $existing_user_id && ( ! $update || ( isset( $user_id ) && $existing_user_id !== $user_id ) ) ) {
 		return new WP_Error( 'existing_user_email_as_login', __( 'Sorry, that username is not available.' ) );
 	}
 

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -916,10 +916,13 @@ class Tests_User extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that `wp_update_user()` allows updating a user when
+	 * the `user_login` and `user_email` are the same.
+	 *
 	 * @ticket 57967
 	 */
 	public function test_wp_update_user_should_allow_user_login_with_same_user_email() {
-		$user_email = str_repeat( 'a', 5 ) . '@example.com';
+		$user_email = 'ababa@example.com';
 
 		$user_id = wp_insert_user(
 			array(
@@ -937,15 +940,19 @@ class Tests_User extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertNotWPError( $existing_id );
-		$this->assertSame( $existing_id, $user_id );
+		$this->assertNotWPError( $existing_id, 'A WP_Error object was not returned.' );
+		$this->assertSame( $existing_id, $user_id, 'The user ID to be updated and the existing user ID do not match.' );
 	}
 
 	/**
+	 * Tests that `wp_update_user()` rejects a `user_login` that matches an existing `user_email`.
+	 *
 	 * @ticket 57967
+	 *
+	 * @covers ::wp_update_user
 	 */
 	public function test_wp_update_user_should_reject_user_login_that_matches_existing_user_email() {
-		$user_email_a = str_repeat( 'a', 5 ) . '@example.com';
+		$user_email_a = 'aaaaa@example.com';
 
 		$user_id_a = wp_insert_user(
 			array(
@@ -956,7 +963,7 @@ class Tests_User extends WP_UnitTestCase {
 			)
 		);
 
-		$user_email_b = str_repeat( 'b', 5 ) . '@example.com';
+		$user_email_b = 'bbbbb@example.com';
 
 		$user_id_b = wp_insert_user(
 			array(
@@ -974,8 +981,8 @@ class Tests_User extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertWPError( $existing_id_b );
-		$this->assertSame( 'existing_user_email_as_login', $existing_id_b->get_error_code() );
+		$this->assertWPError( $existing_id_b, 'A WP_Error object was not returned.' );
+		$this->assertSame( 'existing_user_email_as_login', $existing_id_b->get_error_code(), 'An unexpected error code was returned.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -920,6 +920,8 @@ class Tests_User extends WP_UnitTestCase {
 	 * the `user_login` and `user_email` are the same.
 	 *
 	 * @ticket 57967
+	 *
+	 * @covers ::wp_update_user
 	 */
 	public function test_wp_update_user_should_allow_user_login_with_same_user_email() {
 		$user_email = 'ababa@example.com';

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -916,6 +916,69 @@ class Tests_User extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 57967
+	 */
+	public function test_wp_update_user_should_allow_user_login_with_same_user_email() {
+		$user_email = str_repeat( 'a', 5 ) . '@example.com';
+
+		$user_id = wp_insert_user(
+			array(
+				'user_login'    => $user_email,
+				'user_email'    => $user_email,
+				'user_pass'     => 'whatever',
+				'user_nicename' => 'whatever',
+			)
+		);
+
+		$existing_id = wp_update_user(
+			array(
+				'ID'         => $user_id,
+				'first_name' => 'Bob',
+			)
+		);
+
+		$this->assertNotWPError( $existing_id );
+		$this->assertSame( $existing_id, $user_id );
+	}
+
+	/**
+	 * @ticket 57967
+	 */
+	public function test_wp_update_user_should_reject_user_login_that_matches_existing_user_email() {
+		$user_email_a = str_repeat( 'a', 5 ) . '@example.com';
+
+		$user_id_a = wp_insert_user(
+			array(
+				'user_login'    => $user_email_a,
+				'user_email'    => $user_email_a,
+				'user_pass'     => 'whatever',
+				'user_nicename' => 'whatever',
+			)
+		);
+
+		$user_email_b = str_repeat( 'b', 5 ) . '@example.com';
+
+		$user_id_b = wp_insert_user(
+			array(
+				'user_login'    => $user_email_b,
+				'user_email'    => $user_email_b,
+				'user_pass'     => 'whatever',
+				'user_nicename' => 'whatever',
+			)
+		);
+
+		$existing_id_b = wp_update_user(
+			array(
+				'ID'         => $user_id_b,
+				'user_login' => $user_email_a,
+			)
+		);
+
+		$this->assertWPError( $existing_id_b );
+		$this->assertSame( 'existing_user_email_as_login', $existing_id_b->get_error_code() );
+	}
+
+	/**
 	 * @ticket 33793
 	 */
 	public function test_wp_insert_user_should_reject_user_nicename_over_50_characters() {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
This patch improves the logic around the username checks added in [WP 6.2](https://core.trac.wordpress.org/ticket/57394), to make sure the check doesn't cause issues when updating a user.

Trac ticket: https://core.trac.wordpress.org/ticket/57967

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
