### PR TITLE
Don't try to match beginning and ending new lines for null translations

### DIFF
--- a/src/wp-includes/pomo/po.php
+++ b/src/wp-includes/pomo/po.php
@@ -263,10 +263,9 @@ if ( ! class_exists( 'PO', false ) ) :
 		/**
 		 * Match the beginning and ending new lines between original and translation.
 		 *
-		 * @param string|null $translation   Translation text, null if don't exist.
-		 * @return string     $original      Original text.
-		 *
-		 * @return string   Translation matching new lines in the beginning or ending from the original.
+		 * @param string|null $translation Translation text, null if don't exist.
+		 * @param string      $original    Original text.
+		 * @return string Translation matching new lines in the beginning or ending from the original.
 		 */
 		public static function match_begin_and_end_newlines( $translation, $original ) {
 			if ( null === $translation ) {

--- a/src/wp-includes/pomo/po.php
+++ b/src/wp-includes/pomo/po.php
@@ -246,12 +246,12 @@ if ( ! class_exists( 'PO', false ) ) :
 			}
 			$po[] = 'msgid ' . PO::poify( $entry->singular );
 			if ( ! $entry->is_plural ) {
-				$translation = empty( $entry->translations ) ? '' : $entry->translations[0];
+				$translation = empty( $entry->translations ) ? null : $entry->translations[0];
 				$translation = PO::match_begin_and_end_newlines( $translation, $entry->singular );
 				$po[]        = 'msgstr ' . PO::poify( $translation );
 			} else {
 				$po[]         = 'msgid_plural ' . PO::poify( $entry->plural );
-				$translations = empty( $entry->translations ) ? array( '', '' ) : $entry->translations;
+				$translations = empty( $entry->translations ) ? array( null, null ) : $entry->translations;
 				foreach ( $translations as $i => $translation ) {
 					$translation = PO::match_begin_and_end_newlines( $translation, $entry->plural );
 					$po[]        = "msgstr[$i] " . PO::poify( $translation );
@@ -260,8 +260,16 @@ if ( ! class_exists( 'PO', false ) ) :
 			return implode( "\n", $po );
 		}
 
+		/**
+		 * Match the beginning and ending new lines between original and translation.
+		 *
+		 * @param string|null $translation   Translation text, null if don't exist.
+		 * @return string     $original      Original text.
+		 *
+		 * @return string   Translation matching new lines in the beginning or ending from the original.
+		 */
 		public static function match_begin_and_end_newlines( $translation, $original ) {
-			if ( '' === $translation ) {
+			if ( null === $translation ) {
 				return $translation;
 			}
 

--- a/src/wp-includes/pomo/po.php
+++ b/src/wp-includes/pomo/po.php
@@ -270,7 +270,7 @@ if ( ! class_exists( 'PO', false ) ) :
 		 */
 		public static function match_begin_and_end_newlines( $translation, $original ) {
 			if ( null === $translation ) {
-				return $translation;
+				return '';
 			}
 
 			$original_begin    = "\n" === substr( $original, 0, 1 );


### PR DESCRIPTION
Make `export_entry()` only send `$translation` to `match_begin_and_end_newlines()`, either `null` if don't exist, or non-empty string if exist. And make `match_begin_and_end_newlines()` early return for `null`values instead of  `''` (empty), which is wrong and gives wrong exports as reported in https://github.com/GlotPress/GlotPress/issues/1594

Trac ticket: https://core.trac.wordpress.org/ticket/57981
