### PR TITLE
Html api/tag processor self closing flag

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1760,6 +1760,31 @@ class WP_HTML_Tag_Processor {
 	}
 
 	/**
+	 * Indicates if the currently matched tag contains the self-closing flag.
+	 *
+	 * No HTML elements ought to have the self-closing flag and for those, the self-closing
+	 * flag will be ignored. For void elements this is benign because they "self close"
+	 * automatically. For non-void HTML elements though problems will appear if someone
+	 * intends to use a self-closing element in place of that element with an empty body.
+	 * For HTML foreign elements and custom elements the self-closing flag determines if
+	 * they self-close or not.
+	 *
+	 * This function does not determine if a tag is self-closing,
+	 * but only if the self-closing flag is present in the syntax.
+	 *
+	 * @since 6.3.0
+	 *
+	 * @return bool Whether the currently matched tag contains the self-closing flag.
+	 */
+	public function has_self_closing_flag() {
+		if ( ! $this->tag_name_starts_at ) {
+			return false;
+		}
+
+		return '/' === $this->html[ $this->tag_ends_at - 1 ];
+	}
+
+	/**
 	 * Indicates if the current tag token is a tag closer.
 	 *
 	 * Example:


### PR DESCRIPTION
Introduce has_self_closing_flag() to the HTML Tag Processor, exposing whether a currently-matched tag contains the self-closing flag /, used when determining if one needs to look for a closing tag of the same name.

This enables structural parsing of an HTML document and is needed to identify self-closing HTML foreign elements.

Trac ticket [#58009](https://core.trac.wordpress.org/ticket/58009#ticket)

cc: @adamziel @gziolo @ockham 