### PR TITLE
TASK: set input type for password field to password in installation

### DIFF
--- a/src/wp-admin/setup-config.php
+++ b/src/wp-admin/setup-config.php
@@ -233,7 +233,7 @@ switch ( $step ) {
 		</tr>
 		<tr>
 			<th scope="row"><label for="pwd"><?php _e( 'Password' ); ?></label></th>
-			<td><input name="pwd" id="pwd" type="text" aria-describedby="pwd-desc" size="25" placeholder="<?php echo htmlspecialchars( _x( 'password', 'example password' ), ENT_QUOTES ); ?>" autocomplete="off" spellcheck="false" /></td>
+			<td><input name="pwd" id="pwd" type="password" aria-describedby="pwd-desc" size="25" placeholder="<?php echo htmlspecialchars( _x( 'password', 'example password' ), ENT_QUOTES ); ?>" autocomplete="off" spellcheck="false" /></td>
 			<td id="pwd-desc"><?php _e( 'Your database password.' ); ?></td>
 		</tr>
 		<tr>


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/58029#ticket

It is better for the MySQL password to be displayed as "password" rather than in plain text during the WordPress installation process for security reasons. When a password is displayed in plain text, it becomes easier for malicious individuals to intercept and access sensitive information, potentially leading to security breaches and data theft.

Displaying the password as "password" instead of in plain text provides an extra layer of security by obscuring the actual password, making it harder for attackers to access the system. This technique is called "hashing," which involves converting the password into a unique string of characters that cannot be reversed or decrypted.

In addition, displaying the password as "password" during the installation process can also prevent mistakes caused by typos or human error. This is because users are less likely to accidentally copy and paste the wrong information if the password is already displayed for them.

Overall, obscuring the MySQL password during the WordPress installation process is a good security practice that can help protect sensitive information and prevent security breaches.

## Screenshot
![SCR-20230330-shpm](https://user-images.githubusercontent.com/39345336/228938777-45b7ec81-49ea-41a2-b85d-a18f8cf143f4.png)


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
