### PR TITLE
Fixes Trac #55342 by adding scrollIntoViewIfNeeded()

### DIFF
--- a/src/js/_enqueues/admin/common.js
+++ b/src/js/_enqueues/admin/common.js
@@ -1407,8 +1407,8 @@ $( function() {
 	 * @return {void}
  	 */
 	$('#contextual-help-link, #show-settings-link').on( 'focus.scroll-into-view', function(e){
-		if ( e.target.scrollIntoView )
-			e.target.scrollIntoView(false);
+		if ( e.target.scrollIntoViewIfNeeded )
+			e.target.scrollIntoViewIfNeeded(false);
 	});
 
 	/**


### PR DESCRIPTION
This request fixes a bug in the WordPress Admin screen. Currently, opening the contextual help menu, scrolling, and trying to close the Help menu causes the user to have to click twice to scroll thanks to the behavior of `scrollIntoView()`. This request changes that function to use `scrollIntoViewIfNeeded()` which allows the user to successfully close the contextual menu with one click.

Fixes: [https://core.trac.wordpress.org/ticket/55342](https://core.trac.wordpress.org/ticket/55342)
