### PR TITLE
Fix non-strict checking issue on options-writing.php file

### DIFF
--- a/src/wp-admin/options-writing.php
+++ b/src/wp-admin/options-writing.php
@@ -10,7 +10,7 @@
 require_once __DIR__ . '/admin.php';
 
 if ( ! current_user_can( 'manage_options' ) ) {
-	wp_die( __( 'Sorry, you are not allowed to manage options for this site.' ) );
+    wp_die( __( 'Sorry, you are not allowed to manage options for this site.' ) );
 }
 
 // Used in the HTML title tag.
@@ -18,40 +18,40 @@ $title       = __( 'Writing Settings' );
 $parent_file = 'options-general.php';
 
 get_current_screen()->add_help_tab(
-	array(
-		'id'      => 'overview',
-		'title'   => __( 'Overview' ),
-		'content' => '<p>' . __( 'You can submit content in several different ways; this screen holds the settings for all of them. The top section controls the editor within the dashboard, while the rest control external publishing methods. For more information on any of these methods, use the documentation links.' ) . '</p>' .
-			'<p>' . __( 'You must click the Save Changes button at the bottom of the screen for new settings to take effect.' ) . '</p>',
-	)
+    array(
+        'id'      => 'overview',
+        'title'   => __( 'Overview' ),
+        'content' => '<p>' . __( 'You can submit content in several different ways; this screen holds the settings for all of them. The top section controls the editor within the dashboard, while the rest control external publishing methods. For more information on any of these methods, use the documentation links.' ) . '</p>' .
+            '<p>' . __( 'You must click the Save Changes button at the bottom of the screen for new settings to take effect.' ) . '</p>',
+    )
 );
 
 /** This filter is documented in wp-admin/options.php */
 if ( apply_filters( 'enable_post_by_email_configuration', true ) ) {
-	get_current_screen()->add_help_tab(
-		array(
-			'id'      => 'options-postemail',
-			'title'   => __( 'Post Via Email' ),
-			'content' => '<p>' . __( 'Post via email settings allow you to send your WordPress installation an email with the content of your post. You must set up a secret email account with POP3 access to use this, and any mail received at this address will be posted, so it&#8217;s a good idea to keep this address very secret.' ) . '</p>',
-		)
-	);
+    get_current_screen()->add_help_tab(
+        array(
+            'id'      => 'options-postemail',
+            'title'   => __( 'Post Via Email' ),
+            'content' => '<p>' . __( 'Post via email settings allow you to send your WordPress installation an email with the content of your post. You must set up a secret email account with POP3 access to use this, and any mail received at this address will be posted, so it&#8217;s a good idea to keep this address very secret.' ) . '</p>',
+        )
+    );
 }
 
 /** This filter is documented in wp-admin/options-writing.php */
 if ( apply_filters( 'enable_update_services_configuration', true ) ) {
-	get_current_screen()->add_help_tab(
-		array(
-			'id'      => 'options-services',
-			'title'   => __( 'Update Services' ),
-			'content' => '<p>' . __( 'If desired, WordPress will automatically alert various services of your new posts.' ) . '</p>',
-		)
-	);
+    get_current_screen()->add_help_tab(
+        array(
+            'id'      => 'options-services',
+            'title'   => __( 'Update Services' ),
+            'content' => '<p>' . __( 'If desired, WordPress will automatically alert various services of your new posts.' ) . '</p>',
+        )
+    );
 }
 
 get_current_screen()->set_help_sidebar(
-	'<p><strong>' . __( 'For more information:' ) . '</strong></p>' .
-	'<p>' . __( '<a href="https://wordpress.org/documentation/article/settings-writing-screen/">Documentation on Writing Settings</a>' ) . '</p>' .
-	'<p>' . __( '<a href="https://wordpress.org/support/forums/">Support forums</a>' ) . '</p>'
+    '<p><strong>' . __( 'For more information:' ) . '</strong></p>' .
+    '<p>' . __( '<a href="https://wordpress.org/documentation/article/settings-writing-screen/">Documentation on Writing Settings</a>' ) . '</p>' .
+    '<p>' . __( '<a href="https://wordpress.org/support/forums/">Support forums</a>' ) . '</p>'
 );
 
 require_once ABSPATH . 'wp-admin/admin-header.php';
@@ -68,14 +68,14 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 <tr>
 <th scope="row"><?php _e( 'Formatting' ); ?></th>
 <td><fieldset><legend class="screen-reader-text"><span>
-	<?php
-	/* translators: Hidden accessibility text. */
-	_e( 'Formatting' );
-	?>
+    <?php
+    /* translators: Hidden accessibility text. */
+    _e( 'Formatting' );
+    ?>
 </span></legend>
 <label for="use_smilies">
 <input name="use_smilies" type="checkbox" id="use_smilies" value="1" <?php checked( '1', get_option( 'use_smilies' ) ); ?> />
-	<?php _e( 'Convert emoticons like <code>:-)</code> and <code>:-P</code> to graphics on display' ); ?></label><br />
+    <?php _e( 'Convert emoticons like <code>:-)</code> and <code>:-P</code> to graphics on display' ); ?></label><br />
 <label for="use_balanceTags"><input name="use_balanceTags" type="checkbox" id="use_balanceTags" value="1" <?php checked( '1', get_option( 'use_balanceTags' ) ); ?> /> <?php _e( 'WordPress should correct invalidly nested XHTML automatically' ); ?></label>
 </fieldset></td>
 </tr>
@@ -85,13 +85,13 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 <td>
 <?php
 wp_dropdown_categories(
-	array(
-		'hide_empty'   => 0,
-		'name'         => 'default_category',
-		'orderby'      => 'name',
-		'selected'     => get_option( 'default_category' ),
-		'hierarchical' => true,
-	)
+    array(
+        'hide_empty'   => 0,
+        'name'         => 'default_category',
+        'orderby'      => 'name',
+        'selected'     => get_option( 'default_category' ),
+        'hierarchical' => true,
+    )
 );
 ?>
 </td>
@@ -103,32 +103,32 @@ unset( $post_formats['standard'] );
 <tr>
 <th scope="row"><label for="default_post_format"><?php _e( 'Default Post Format' ); ?></label></th>
 <td>
-	<select name="default_post_format" id="default_post_format">
-		<option value="0"><?php echo get_post_format_string( 'standard' ); ?></option>
+    <select name="default_post_format" id="default_post_format">
+        <option value="0"><?php echo get_post_format_string( 'standard' ); ?></option>
 <?php foreach ( $post_formats as $format_slug => $format_name ) : ?>
-		<option<?php selected( get_option( 'default_post_format' ), $format_slug ); ?> value="<?php echo esc_attr( $format_slug ); ?>"><?php echo esc_html( $format_name ); ?></option>
+        <option<?php selected( get_option( 'default_post_format' ), $format_slug ); ?> value="<?php echo esc_attr( $format_slug ); ?>"><?php echo esc_html( $format_name ); ?></option>
 <?php endforeach; ?>
-	</select>
+    </select>
 </td>
 </tr>
 <?php
 if ( get_option( 'link_manager_enabled' ) ) :
-	?>
+    ?>
 <tr>
 <th scope="row"><label for="default_link_category"><?php _e( 'Default Link Category' ); ?></label></th>
 <td>
-	<?php
-	wp_dropdown_categories(
-		array(
-			'hide_empty'   => 0,
-			'name'         => 'default_link_category',
-			'orderby'      => 'name',
-			'selected'     => get_option( 'default_link_category' ),
-			'hierarchical' => true,
-			'taxonomy'     => 'link_category',
-		)
-	);
-	?>
+    <?php
+    wp_dropdown_categories(
+        array(
+            'hide_empty'   => 0,
+            'name'         => 'default_link_category',
+            'orderby'      => 'name',
+            'selected'     => get_option( 'default_link_category' ),
+            'hierarchical' => true,
+            'taxonomy'     => 'link_category',
+        )
+    );
+    ?>
 </td>
 </tr>
 <?php endif; ?>
@@ -142,18 +142,18 @@ do_settings_fields( 'writing', 'remote_publishing' ); // A deprecated section.
 <?php
 /** This filter is documented in wp-admin/options.php */
 if ( apply_filters( 'enable_post_by_email_configuration', true ) ) {
-	?>
+    ?>
 <h2 class="title"><?php _e( 'Post via email' ); ?></h2>
 <p>
-	<?php
-	printf(
-		/* translators: 1, 2, 3: Examples of random email addresses. */
-		__( 'To post to WordPress by email, you must set up a secret email account with POP3 access. Any mail received at this address will be posted, so it&#8217;s a good idea to keep this address very secret. Here are three random strings you could use: %1$s, %2$s, %3$s.' ),
-		sprintf( '<kbd>%s</kbd>', wp_generate_password( 8, false ) ),
-		sprintf( '<kbd>%s</kbd>', wp_generate_password( 8, false ) ),
-		sprintf( '<kbd>%s</kbd>', wp_generate_password( 8, false ) )
-	);
-	?>
+    <?php
+    printf(
+        /* translators: 1, 2, 3: Examples of random email addresses. */
+        __( 'To post to WordPress by email, you must set up a secret email account with POP3 access. Any mail received at this address will be posted, so it&#8217;s a good idea to keep this address very secret. Here are three random strings you could use: %1$s, %2$s, %3$s.' ),
+        sprintf( '<kbd>%s</kbd>', wp_generate_password( 8, false ) ),
+        sprintf( '<kbd>%s</kbd>', wp_generate_password( 8, false ) ),
+        sprintf( '<kbd>%s</kbd>', wp_generate_password( 8, false ) )
+    );
+    ?>
 </p>
 
 <table class="form-table" role="presentation">
@@ -177,20 +177,20 @@ if ( apply_filters( 'enable_post_by_email_configuration', true ) ) {
 <tr>
 <th scope="row"><label for="default_email_category"><?php _e( 'Default Mail Category' ); ?></label></th>
 <td>
-	<?php
-	wp_dropdown_categories(
-		array(
-			'hide_empty'   => 0,
-			'name'         => 'default_email_category',
-			'orderby'      => 'name',
-			'selected'     => get_option( 'default_email_category' ),
-			'hierarchical' => true,
-		)
-	);
-	?>
+    <?php
+    wp_dropdown_categories(
+        array(
+            'hide_empty'   => 0,
+            'name'         => 'default_email_category',
+            'orderby'      => 'name',
+            'selected'     => get_option( 'default_email_category' ),
+            'hierarchical' => true,
+        )
+    );
+    ?>
 </td>
 </tr>
-	<?php do_settings_fields( 'writing', 'post_via_email' ); ?>
+    <?php do_settings_fields( 'writing', 'post_via_email' ); ?>
 </table>
 <?php } ?>
 
@@ -203,37 +203,37 @@ if ( apply_filters( 'enable_post_by_email_configuration', true ) ) {
  * @param bool $enable Whether to enable the Update Services settings area. Default true.
  */
 if ( apply_filters( 'enable_update_services_configuration', true ) ) {
-	?>
+    ?>
 <h2 class="title"><?php _e( 'Update Services' ); ?></h2>
 
-	<?php if ( 1 == get_option( 'blog_public' ) ) : ?>
+    <?php if ( 1 == get_option( 'blog_public' ) ) : ?>
 
-	<p><label for="ping_sites">
-		<?php
-		printf(
-			/* translators: %s: Documentation URL. */
-			__( 'When you publish a new post, WordPress automatically notifies the following site update services. For more about this, see the <a href="%s">Update Services</a> documentation article. Separate multiple service URLs with line breaks.' ),
-			__( 'https://wordpress.org/documentation/article/update-services/' )
-		);
-		?>
-	</label></p>
+    <p><label for="ping_sites">
+        <?php
+        printf(
+            /* translators: %s: Documentation URL. */
+            __( 'When you publish a new post, WordPress automatically notifies the following site update services. For more about this, see the <a href="%s">Update Services</a> documentation article. Separate multiple service URLs with line breaks.' ),
+            __( 'https://wordpress.org/documentation/article/update-services/' )
+        );
+        ?>
+    </label></p>
 
-	<textarea name="ping_sites" id="ping_sites" class="large-text code" rows="3"><?php echo esc_textarea( get_option( 'ping_sites' ) ); ?></textarea>
+    <textarea name="ping_sites" id="ping_sites" class="large-text code" rows="3"><?php echo esc_textarea( get_option( 'ping_sites' ) ); ?></textarea>
 
-	<?php else : ?>
+    <?php else : ?>
 
-	<p>
-		<?php
-		printf(
-			/* translators: 1: Documentation URL, 2: URL to Reading Settings screen. */
-			__( 'WordPress is not notifying any <a href="%1$s">Update Services</a> because of your site&#8217;s <a href="%2$s">visibility settings</a>.' ),
-			__( 'https://wordpress.org/documentation/article/update-services/' ),
-			'options-reading.php'
-		);
-		?>
-	</p>
+    <p>
+        <?php
+        printf(
+            /* translators: 1: Documentation URL, 2: URL to Reading Settings screen. */
+            __( 'WordPress is not notifying any <a href="%1$s">Update Services</a> because of your site&#8217;s <a href="%2$s">visibility settings</a>.' ),
+            __( 'https://wordpress.org/documentation/article/update-services/' ),
+            'options-reading.php'
+        );
+        ?>
+    </p>
 
-	<?php endif; ?>
+    <?php endif; ?>
 <?php } // enable_update_services_configuration ?>
 
 <?php do_settings_sections( 'writing' ); ?>


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
This PR fixes a non-strict checking issue on the WordPress file options-writing.php. Specifically, on line 209, the code uses the "==" operator instead of the "===" operator. This can cause unexpected behavior since the "==" operator can coerce values and compare them in unexpected ways.

The fix involves replacing the "==" operator with the "===" operator to perform a strict comparison between the value returned by the get_option() function and the integer 1. This ensures that the comparison is done in a type-safe way and that unexpected behavior is avoided.

The fixed code is as follows:
`<?php if ( 1 === get_option( 'blog_public' ) ) : ?>`

With this fix, the code in the options-writing.php file will be more reliable and less prone to unexpected behavior.

Trac ticket: [58039](https://core.trac.wordpress.org/ticket/58039)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
