### PR TITLE
Add default value to the @param tag for the constructor in /wp-admin/includes/class-custom-image-header.php

### DIFF
--- a/src/wp-admin/includes/class-custom-image-header.php
+++ b/src/wp-admin/includes/class-custom-image-header.php
@@ -50,8 +50,8 @@ class Custom_Image_Header {
 	 * Constructor - Register administration header callback.
 	 *
 	 * @since 2.1.0
-	 * @param callable $admin_header_callback. Default false.
-	 * @param callable $admin_image_div_callback Optional custom image div output callback.
+	 * @param callable $admin_header_callback.
+	 * @param callable $admin_image_div_callback Optional custom image div output callback. Default empty string.
 	 */
 	public function __construct( $admin_header_callback, $admin_image_div_callback = '' ) {
 		$this->admin_header_callback    = $admin_header_callback;

--- a/src/wp-admin/includes/class-custom-image-header.php
+++ b/src/wp-admin/includes/class-custom-image-header.php
@@ -50,7 +50,7 @@ class Custom_Image_Header {
 	 * Constructor - Register administration header callback.
 	 *
 	 * @since 2.1.0
-	 * @param callable $admin_header_callback
+	 * @param callable $admin_header_callback. Default false.
 	 * @param callable $admin_image_div_callback Optional custom image div output callback.
 	 */
 	public function __construct( $admin_header_callback, $admin_image_div_callback = '' ) {

--- a/src/wp-admin/network/user-new.php
+++ b/src/wp-admin/network/user-new.php
@@ -100,7 +100,8 @@ if ( isset( $_GET['update'] ) ) {
 $title       = __( 'Add New User' );
 $parent_file = 'users.php';
 
-require_once ABSPATH . 'wp-admin/admin-header.php'; ?>
+require_once ABSPATH . 'wp-admin/admin-header.php';
+?>
 
 <div class="wrap">
 <h1 id="add-new-user"><?php _e( 'Add New User' ); ?></h1>

--- a/src/wp-admin/network/user-new.php
+++ b/src/wp-admin/network/user-new.php
@@ -100,8 +100,7 @@ if ( isset( $_GET['update'] ) ) {
 $title       = __( 'Add New User' );
 $parent_file = 'users.php';
 
-require_once ABSPATH . 'wp-admin/admin-header.php';
-?>
+require_once ABSPATH . 'wp-admin/admin-header.php'; ?>
 
 <div class="wrap">
 <h1 id="add-new-user"><?php _e( 'Add New User' ); ?></h1>


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
I added "Default false" to the @param tag for the $admin_image_div_callback parameter, so that it is clear to developers that this parameter is optional and its default value is false.

Trac ticket: [58049](https://core.trac.wordpress.org/ticket/58049)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
