### PR TITLE
Use the new /documentation/ URLs for links about WordPress version

### DIFF
--- a/src/wp-admin/_index.php
+++ b/src/wp-admin/_index.php
@@ -116,7 +116,7 @@ $is_dev_version  = preg_match( '/alpha|beta|RC/', $wp_version );
 if ( ! $is_dev_version ) {
 	$version_url = sprintf(
 		/* translators: %s: WordPress version. */
-		esc_url( __( 'https://wordpress.org/support/wordpress-version/version-%s/' ) ),
+		esc_url( __( 'https://wordpress.org/documentation/wordpress-version/version-%s/' ) ),
 		sanitize_title( $wp_version )
 	);
 

--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -266,7 +266,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 						__( '<a href="%1$s">Read the WordPress %2$s Release Notes</a> for more information on the included enhancements and issues fixed, installation information, developer notes and resources, release contributors, and the list of file changes in this release.' ),
 						sprintf(
 							/* translators: %s: WordPress version number. */
-							esc_url( __( 'https://wordpress.org/support/wordpress-version/version-%s/' ) ),
+							esc_url( __( 'https://wordpress.org/documentation/wordpress-version/version-%s/' ) ),
 							'6-2'
 						),
 						'6.2'

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -303,7 +303,7 @@ function update_nag() {
 
 	$version_url = sprintf(
 		/* translators: %s: WordPress version. */
-		esc_url( __( 'https://wordpress.org/support/wordpress-version/version-%s/' ) ),
+		esc_url( __( 'https://wordpress.org/documentation/wordpress-version/version-%s/' ) ),
 		sanitize_title( $cur->current )
 	);
 

--- a/src/wp-admin/install.php
+++ b/src/wp-admin/install.php
@@ -244,7 +244,7 @@ $mysql_compat  = version_compare( $mysql_version, $required_mysql_version, '>=' 
 
 $version_url = sprintf(
 	/* translators: %s: WordPress version. */
-	esc_url( __( 'https://wordpress.org/support/wordpress-version/version-%s/' ) ),
+	esc_url( __( 'https://wordpress.org/documentation/wordpress-version/version-%s/' ) ),
 	sanitize_title( $wp_version )
 );
 

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -91,7 +91,7 @@ function list_core_update( $update ) {
 
 			$version_url = sprintf(
 				/* translators: %s: WordPress version. */
-				esc_url( __( 'https://wordpress.org/support/wordpress-version/version-%s/' ) ),
+				esc_url( __( 'https://wordpress.org/documentation/wordpress-version/version-%s/' ) ),
 				sanitize_title( $update->current )
 			);
 

--- a/src/wp-admin/upgrade.php
+++ b/src/wp-admin/upgrade.php
@@ -78,7 +78,7 @@ header( 'Content-Type: ' . get_option( 'html_type' ) . '; charset=' . get_option
 elseif ( ! $php_compat || ! $mysql_compat ) :
 	$version_url = sprintf(
 		/* translators: %s: WordPress version. */
-		esc_url( __( 'https://wordpress.org/support/wordpress-version/version-%s/' ) ),
+		esc_url( __( 'https://wordpress.org/documentation/wordpress-version/version-%s/' ) ),
 		sanitize_title( $wp_version )
 	);
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/58052
