### PR TITLE
Replace loose comparison operator in plugins.php

### DIFF
--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -495,7 +495,7 @@ if ( $action ) {
 
 				// Return early if all selected plugins already have auto-updates enabled or disabled.
 				// Must use non-strict comparison, so that array order is not treated as significant.
-				if ( $new_auto_updates == $auto_updates ) { // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
+				if ( $new_auto_updates === $auto_updates ) { // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
 					wp_redirect( $redirect );
 					exit;
 				}


### PR DESCRIPTION
This pull request replaces a loose comparison operator in the WordPress file /wp-admin/plugins.php on line 498 with a strict comparison operator. The current code is using == to compare two values, which can lead to unexpected behavior and security vulnerabilities. The updated code uses === to perform a strict comparison, ensuring that the values being compared are of the same data type. This improves the security and reliability of the code.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
This pull request replaces a loose comparison operator in the WordPress file /wp-admin/plugins.php on line 498 with a strict comparison operator. The current code is using == to compare two values, which can lead to unexpected behavior and security vulnerabilities. The updated code uses === to perform a strict comparison, ensuring that the values being compared are of the same data type. This improves the security and reliability of the code.

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->
https://core.trac.wordpress.org/ticket/58057

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
