### PR TITLE
improve performance for placeholder_escape()

### DIFF
--- a/src/wp-includes/class-wpdb.php
+++ b/src/wp-includes/class-wpdb.php
@@ -2493,12 +2493,10 @@ class wpdb {
 		static $placeholder;
 
 		if ( ! $placeholder ) {
-			// If ext/hash is not present, compat.php's hash_hmac() does not support sha256.
-			$algo = function_exists( 'hash' ) ? 'sha256' : 'sha1';
 			// Old WP installs may not have AUTH_SALT defined.
 			$salt = defined( 'AUTH_SALT' ) && AUTH_SALT ? AUTH_SALT : (string) rand();
 
-			$placeholder = '{' . hash_hmac( $algo, uniqid( $salt, true ), $salt ) . '}';
+			$placeholder = '{' . hash( 'md4', uniqid( $salt, true ) ) . '}';
 		}
 
 		/*


### PR DESCRIPTION
remove unnecessary encryption. 

just to test against unittests.