### PR TITLE
Add spaces before and after function arguments in wp-includes/Text/Di…

### DIFF
--- a/src/wp-includes/Text/Diff/Renderer/inline.php
+++ b/src/wp-includes/Text/Diff/Renderer/inline.php
@@ -90,17 +90,17 @@ class Text_Diff_Renderer_inline extends Text_Diff_Renderer {
      */
     var $_split_level = 'lines';
 
-    function _blockHeader($xbeg, $xlen, $ybeg, $ylen)
+    function _blockHeader( $xbeg, $xlen, $ybeg, $ylen )
     {
         return $this->_block_header;
     }
 
-    function _startBlock($header)
+    function _startBlock( $header )
     {
         return $header;
     }
 
-    function _lines($lines, $prefix = ' ', $encode = true)
+    function _lines( $lines, $prefix = ' ', $encode = true )
     {
         if ($encode) {
             array_walk($lines, array(&$this, '_encode'));
@@ -113,7 +113,7 @@ class Text_Diff_Renderer_inline extends Text_Diff_Renderer {
         }
     }
 
-    function _added($lines)
+    function _added( $lines )
     {
         array_walk($lines, array(&$this, '_encode'));
         $lines[0] = $this->_ins_prefix . $lines[0];
@@ -121,7 +121,7 @@ class Text_Diff_Renderer_inline extends Text_Diff_Renderer {
         return $this->_lines($lines, ' ', false);
     }
 
-    function _deleted($lines, $words = false)
+    function _deleted( $lines, $words = false )
     {
         array_walk($lines, array(&$this, '_encode'));
         $lines[0] = $this->_del_prefix . $lines[0];
@@ -129,7 +129,7 @@ class Text_Diff_Renderer_inline extends Text_Diff_Renderer {
         return $this->_lines($lines, ' ', false);
     }
 
-    function _changed($orig, $final)
+    function _changed( $orig, $final )
     {
         /* If we've already split on characters, just display. */
         if ($this->_split_level == 'characters') {
@@ -178,7 +178,7 @@ class Text_Diff_Renderer_inline extends Text_Diff_Renderer {
         return str_replace($nl, "\n", $renderer->render($diff)) . "\n";
     }
 
-    function _splitOnWords($string, $newlineEscape = "\n")
+    function _splitOnWords( $string, $newlineEscape = "\n" )
     {
         // Ignore \0; otherwise the while loop will never finish.
         $string = str_replace("\0", '', $string);
@@ -198,7 +198,7 @@ class Text_Diff_Renderer_inline extends Text_Diff_Renderer {
         return $words;
     }
 
-    function _encode(&$string)
+    function _encode( &$string )
     {
         $string = htmlspecialchars($string);
     }

--- a/src/wp-includes/widgets/class-wp-widget-media-audio.php
+++ b/src/wp-includes/widgets/class-wp-widget-media-audio.php
@@ -192,11 +192,11 @@ class WP_Widget_Media_Audio extends WP_Widget_Media {
 				<div class="notice notice-error notice-alt notice-missing-attachment">
 					<p><?php echo $this->l10n['missing_attachment']; ?></p>
 				</div>
-			<# } else if ( data.error ) { #>
+			<# } elseif ( data.error ) { #>
 				<div class="notice notice-error notice-alt">
 					<p><?php _e( 'Unable to preview media due to an unknown error.' ); ?></p>
 				</div>
-			<# } else if ( data.model && data.model.src ) { #>
+			<# } elseif ( data.model && data.model.src ) { #>
 				<?php wp_underscore_audio_template(); ?>
 			<# } #>
 		</script>

--- a/src/wp-includes/widgets/class-wp-widget-media-image.php
+++ b/src/wp-includes/widgets/class-wp-widget-media-image.php
@@ -349,11 +349,11 @@ class WP_Widget_Media_Image extends WP_Widget_Media {
 				<div class="notice notice-error notice-alt notice-missing-attachment">
 					<p><?php echo $this->l10n['missing_attachment']; ?></p>
 				</div>
-			<# } else if ( data.error ) { #>
+			<# } elseif ( data.error ) { #>
 				<div class="notice notice-error notice-alt">
 					<p><?php _e( 'Unable to preview media due to an unknown error.' ); ?></p>
 				</div>
-			<# } else if ( data.url ) { #>
+			<# } elseif ( data.url ) { #>
 				<img class="attachment-thumb" src="{{ data.url }}" draggable="false" alt="{{ data.alt }}"
 					<# if ( ! data.alt && data.currentFilename ) { #>
 						aria-label="

--- a/src/wp-includes/widgets/class-wp-widget-media-video.php
+++ b/src/wp-includes/widgets/class-wp-widget-media-video.php
@@ -231,23 +231,23 @@ class WP_Widget_Media_Video extends WP_Widget_Media {
 				<div class="notice notice-error notice-alt notice-missing-attachment">
 					<p><?php echo $this->l10n['missing_attachment']; ?></p>
 				</div>
-			<# } else if ( data.error && 'unsupported_file_type' === data.error ) { #>
+			<# } elseif ( data.error && 'unsupported_file_type' === data.error ) { #>
 				<div class="notice notice-error notice-alt notice-missing-attachment">
 					<p><?php echo $this->l10n['unsupported_file_type']; ?></p>
 				</div>
-			<# } else if ( data.error ) { #>
+			<# } elseif ( data.error ) { #>
 				<div class="notice notice-error notice-alt">
 					<p><?php _e( 'Unable to preview media due to an unknown error.' ); ?></p>
 				</div>
-			<# } else if ( data.is_oembed && data.model.poster ) { #>
+			<# } elseif ( data.is_oembed && data.model.poster ) { #>
 				<a href="{{ data.model.src }}" target="_blank" class="media-widget-video-link">
 					<img src="{{ data.model.poster }}" />
 				</a>
-			<# } else if ( data.is_oembed ) { #>
+			<# } elseif ( data.is_oembed ) { #>
 				<a href="{{ data.model.src }}" target="_blank" class="media-widget-video-link no-poster">
 					<span class="dashicons dashicons-format-video"></span>
 				</a>
-			<# } else if ( data.model.src ) { #>
+			<# } elseif ( data.model.src ) { #>
 				<?php wp_underscore_video_template(); ?>
 			<# } #>
 		</script>


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
The WordPress coding standards recommend adding spaces before and after function arguments to improve code readability and consistency. However, in the `wp-includes/Text/Diff/Renderer/inline.php` file, some functions do not follow this standard.

To improve the code quality and consistency, I have updated the affected functions by adding spaces before and after their arguments.

Trac ticket: https://core.trac.wordpress.org/ticket/57839

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
