### PR TITLE
Help/About: Remove `aligncenter` in the WordPress 6.2 About Page.

### DIFF
--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -53,7 +53,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 					);
 					?>
 				</h2>
-				<p class="is-subheading aligncenter">
+				<p class="is-subheading">
 					<?php
 					printf(
 						/* translators: 1: Count of enhancements, 2: Count of bug fixes. */

--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -44,7 +44,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 
 		<div class="about__section">
 			<div class="column">
-				<h2 class="aligncenter">
+				<h2>
 					<?php
 					printf(
 						/* translators: %s: Version number. */


### PR DESCRIPTION
This removes the `aligncenter` class from the `h2` and `is-subheading` in the WordPress 6.2 About Page for consistent alignment.

Trac ticket: https://core.trac.wordpress.org/ticket/57387