### PR TITLE
Admin Titles: avoid PHP warnings in PHP 8.1

### DIFF
--- a/src/wp-admin/admin-header.php
+++ b/src/wp-admin/admin-header.php
@@ -33,7 +33,10 @@ if ( empty( $current_screen ) ) {
 }
 
 get_admin_page_title();
-$title = strip_tags( $title );
+
+if ( ! is_null( $title ) ) {
+	$title = wp_strip_all_tags( $title ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+}
 
 if ( is_network_admin() ) {
 	/* translators: Network admin screen title. %s: Network title. */


### PR DESCRIPTION
This avoids the following warning on pages where a title is not defined:

```
PHP Deprecated:  strip_tags(): Passing null to parameter #1 ($string) of type string is deprecated in /wp-admin/admin-header.php on line 36
```

This should not normally happen, but some folks may pass null to `add_submenu_page()` when creating new pages, to hide that page from the admin menu. This may not be the best approach, but it is one that is documented in the codex and used in the wild: https://developer.wordpress.org/reference/functions/add_submenu_page/#comment-445

- Related Core trac ticket: https://core.trac.wordpress.org/ticket/57579
- Related PR: #4084
