### PR TITLE
Fixed non-strict comparison operator in /wp-includes/theme-compat/comments.php line 35

### DIFF
--- a/src/wp-includes/theme-compat/comments.php
+++ b/src/wp-includes/theme-compat/comments.php
@@ -32,7 +32,7 @@ if ( post_password_required() ) { ?>
 <?php if ( have_comments() ) : ?>
 	<h3 id="comments">
 		<?php
-		if ( 1 == get_comments_number() ) {
+		if ( 1 === get_comments_number() ) {
 			printf(
 				/* translators: %s: Post title. */
 				__( 'One response to %s' ),


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
The issue with the code in /wp-includes/theme-compat/comments.php line 35 is that the comparison operator "==" is being used to compare the response code returned by get_comments_number() with the integer value 1. This is a non-strict comparison operator, which means that it will also return true if the response code is a string "1". This can lead to unexpected behavior or security vulnerabilities.

Trac ticket: https://core.trac.wordpress.org/ticket/57839

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
