### PR TITLE
Trac 57886: WP_Theme->get_post_templates fixed MS caching issue for block templates

### DIFF
--- a/src/wp-includes/class-wp-theme.php
+++ b/src/wp-includes/class-wp-theme.php
@@ -1287,24 +1287,24 @@ final class WP_Theme implements ArrayAccess {
 				}
 			}
 
-			if ( current_theme_supports( 'block-templates' ) ) {
-				$block_templates = get_block_templates( array(), 'wp_template' );
-				foreach ( get_post_types( array( 'public' => true ) ) as $type ) {
-					foreach ( $block_templates as $block_template ) {
-						if ( ! $block_template->is_custom ) {
-							continue;
-						}
+			$this->cache_add( 'post_templates', $post_templates );
+		}
 
-						if ( isset( $block_template->post_types ) && ! in_array( $type, $block_template->post_types, true ) ) {
-							continue;
-						}
-
-						$post_templates[ $type ][ $block_template->slug ] = $block_template->title;
+		if ( current_theme_supports( 'block-templates' ) ) {
+			$block_templates = get_block_templates( array(), 'wp_template' );
+			foreach ( get_post_types( array( 'public' => true ) ) as $type ) {
+				foreach ( $block_templates as $block_template ) {
+					if ( ! $block_template->is_custom ) {
+						continue;
 					}
+
+					if ( isset( $block_template->post_types ) && ! in_array( $type, $block_template->post_types, true ) ) {
+						continue;
+					}
+
+					$post_templates[ $type ][ $block_template->slug ] = $block_template->title;
 				}
 			}
-
-			$this->cache_add( 'post_templates', $post_templates );
 		}
 
 		if ( $this->load_textdomain() ) {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Moves block templates outside global caching in WP_Theme->get_post_templates so those templates are not cached globally in the WP network. 

Trac ticket: https://core.trac.wordpress.org/ticket/57886

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
