### PR TITLE
Add is_block_theme property to Themes REST API response

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -326,6 +326,10 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 			}
 		}
 
+		if ( rest_is_field_included( 'is_block_theme', $fields ) ) {
+			$data['is_block_theme'] = $theme->is_block_theme();
+		}
+
 		$data = $this->add_additional_fields_to_object( $data, $request );
 
 		// Wrap the data in a response object.
@@ -493,6 +497,11 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 							'type'        => 'string',
 						),
 					),
+				),
+				'is_block_theme' => array(
+					'description' => __( 'Whether the theme is a block-based theme.' ),
+					'type'        => 'boolean',
+					'readonly'    => true,
 				),
 				'name'           => array(
 					'description' => __( 'The name of the theme.' ),

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -480,21 +480,20 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	public function test_theme_is_block_theme() {
-		switch_theme( 'block-theme' );
-
-		$response = self::perform_active_theme_request();
-		$result   = $response->get_data();
-
-		$this->assertArrayHasKey( 'is_block_theme', $result[0] );
-		$this->assertTrue( $result[0]['is_block_theme'] );
-	}
-
-	public function test_theme_is_not_block_theme() {
+		// Test classic theme, activated in test setup.
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
 
 		$this->assertArrayHasKey( 'is_block_theme', $result[0] );
 		$this->assertFalse( $result[0]['is_block_theme'] );
+
+		// Test block theme.
+		switch_theme( 'block-theme' );
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+
+		$this->assertArrayHasKey( 'is_block_theme', $result[0] );
+		$this->assertTrue( $result[0]['is_block_theme'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -186,6 +186,8 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 			'theme_uri',
 			'version',
 		);
+		$this->assertIsArray( $data );
+		$this->assertNotEmpty( $data );
 		$this->assertSameSets( $fields, array_keys( $data[0] ) );
 	}
 
@@ -222,6 +224,8 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 			'theme_uri',
 			'version',
 		);
+		$this->assertIsArray( $data );
+		$this->assertNotEmpty( $data );
 		$this->assertSameSets( $fields, array_keys( $data[0] ) );
 
 		$this->assertContains( 'twentytwenty', wp_list_pluck( $data, 'stylesheet' ) );

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -479,6 +479,10 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertSame( '5.3', $result[0]['requires_wp'] );
 	}
 
+	/**
+	 * @ticket 58123
+	 * @covers WP_REST_Themes_Controller::prepare_item_for_response
+	 */
 	public function test_theme_is_block_theme() {
 		// Test classic theme, activated in test setup.
 		$response = self::perform_active_theme_request();

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -481,7 +481,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
 
-		$this->assertTrue( isset( $result[0]['is_block_theme'] ) );
+		$this->assertArrayHasKey( 'is_block_theme', $result[0] );
 		$this->assertTrue( $result[0]['is_block_theme'] );
 	}
 
@@ -489,7 +489,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
 
-		$this->assertTrue( isset( $result[0]['is_block_theme'] ) );
+		$this->assertArrayHasKey( 'is_block_theme', $result[0] );
 		$this->assertFalse( $result[0]['is_block_theme'] );
 	}
 

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -481,6 +481,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
 
+		$this->assertTrue( isset( $result[0]['is_block_theme'] ) );
 		$this->assertTrue( $result[0]['is_block_theme'] );
 	}
 
@@ -488,6 +489,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
 
+		$this->assertTrue( isset( $result[0]['is_block_theme'] ) );
 		$this->assertFalse( $result[0]['is_block_theme'] );
 	}
 

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -172,6 +172,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 			'author',
 			'author_uri',
 			'description',
+			'is_block_theme',
 			'name',
 			'requires_php',
 			'requires_wp',
@@ -208,6 +209,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 			'author',
 			'author_uri',
 			'description',
+			'is_block_theme',
 			'name',
 			'requires_php',
 			'requires_wp',
@@ -343,7 +345,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$response   = self::perform_active_theme_request( 'OPTIONS' );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertCount( 15, $properties );
+		$this->assertCount( 16, $properties );
 
 		$this->assertArrayHasKey( 'author', $properties );
 		$this->assertArrayHasKey( 'raw', $properties['author']['properties'] );
@@ -356,6 +358,8 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( 'description', $properties );
 		$this->assertArrayHasKey( 'raw', $properties['description']['properties'] );
 		$this->assertArrayHasKey( 'rendered', $properties['description']['properties'] );
+
+		$this->assertArrayHasKey( 'is_block_theme', $properties );
 
 		$this->assertArrayHasKey( 'name', $properties );
 		$this->assertArrayHasKey( 'raw', $properties['name']['properties'] );
@@ -469,6 +473,22 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$result   = $response->get_data();
 		$this->assertArrayHasKey( 'requires_wp', $result[0] );
 		$this->assertSame( '5.3', $result[0]['requires_wp'] );
+	}
+
+	public function test_theme_is_block_theme() {
+		switch_theme( 'block-theme' );
+
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+
+		$this->assertTrue( $result[0]['is_block_theme'] );
+	}
+
+	public function test_theme_is_not_block_theme() {
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+
+		$this->assertFalse( $result[0]['is_block_theme'] );
 	}
 
 	/**
@@ -1234,6 +1254,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 			'author',
 			'author_uri',
 			'description',
+			'is_block_theme',
 			'name',
 			'requires_php',
 			'requires_wp',


### PR DESCRIPTION
Adds a `is_block_theme` property to each theme in the wp/v2/themes API response, which uses `WP_Theme::is_block_theme`.

This helps to indicate if a theme supports the Site editor, or not.

Trac ticket: https://core.trac.wordpress.org/ticket/58123

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
