### PR TITLE
Add _edit_link to template and global styles custom post types

### DIFF
--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1469,10 +1469,22 @@ function get_edit_post_link( $post = 0, $context = 'display' ) {
 		return;
 	}
 
+	$link = '';
+
 	if ( $post_type_object->_edit_link ) {
-		$link = admin_url( sprintf( $post_type_object->_edit_link . $action, $post->ID ) );
-	} else {
-		$link = '';
+		if ( 'wp_template' === $post->post_type || 'wp_template_part' === $post->post_type ) {
+			$action          = '&canvas=edit';
+			$block_templates = get_block_templates(
+				array(),
+				$post->post_type
+			);
+			if ( count( $block_templates ) ) {
+				$template_post_id = $block_templates[0]->id;
+				$link             = admin_url( sprintf( $post_type_object->_edit_link . $action, $template_post_id ) );
+			}
+		} else {
+			$link = admin_url( sprintf( $post_type_object->_edit_link . $action, $post->ID ) );
+		}
 	}
 
 	/**

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1435,9 +1435,10 @@ function get_preview_post_link( $post = null, $query_args = array(), $preview_li
  * Retrieves the edit post link for post.
  *
  * Can be used within the WordPress loop or outside of it. Can be used with
- * pages, posts, attachments, and revisions.
+ * pages, posts, attachments, revisions, templates and template parts.
  *
  * @since 2.3.0
+ * @since 6.3.0 Updated to handle `_edit_link` properties for templates and template parts.
  *
  * @param int|WP_Post $post    Optional. Post ID or post object. Default is the global `$post`.
  * @param string      $context Optional. How to output the '&' character. Default '&amp;'.

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1473,7 +1473,7 @@ function get_edit_post_link( $post = 0, $context = 'display' ) {
 
 	if ( $post_type_object->_edit_link ) {
 		if ( 'wp_template' === $post->post_type || 'wp_template_part' === $post->post_type ) {
-			$action          = '&canvas=edit';
+			$action          = 'display' === $context ? '&amp;canvas=edit' : '&canvas=edit';
 			$block_templates = get_block_templates(
 				array(),
 				$post->post_type

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -357,6 +357,7 @@ function create_initial_post_types() {
 			'description'           => __( 'Templates to include in your theme.' ),
 			'public'                => false,
 			'_builtin'              => true, /* internal use only. don't use this when registering your own post type. */
+			'_edit_link'            => '/site-editor.php?postType=wp_template&postId=%s', /* internal use only. don't use this when registering your own post type. */
 			'has_archive'           => false,
 			'show_ui'               => false,
 			'show_in_menu'          => false,
@@ -417,6 +418,7 @@ function create_initial_post_types() {
 			'description'           => __( 'Template parts to include in your templates.' ),
 			'public'                => false,
 			'_builtin'              => true, /* internal use only. don't use this when registering your own post type. */
+			'_edit_link'            => '/site-editor.php?postType=wp_template_part&postId=%s', /* internal use only. don't use this when registering your own post type. */
 			'has_archive'           => false,
 			'show_ui'               => false,
 			'show_in_menu'          => false,
@@ -457,6 +459,7 @@ function create_initial_post_types() {
 			'description'  => __( 'Global styles to include in themes.' ),
 			'public'       => false,
 			'_builtin'     => true, /* internal use only. don't use this when registering your own post type. */
+			'_edit_link'   => '/site-editor.php?canvas=edit', /* internal use only. don't use this when registering your own post type. */
 			'show_ui'      => false,
 			'show_in_rest' => false,
 			'rewrite'      => false,

--- a/tests/phpunit/tests/link/getEditPostLink.php
+++ b/tests/phpunit/tests/link/getEditPostLink.php
@@ -1,24 +1,54 @@
 <?php
 /**
+ * Tests the `get_edit_post_link()` function.
+ *
+ * @since 6.3.0
+ *
  * @group link
+ *
  * @covers ::get_edit_post_link
  */
 class Tests_Link_GetEditPostLink extends WP_UnitTestCase {
+	/**
+	 * The name of the theme to use for the test.
+	 *
+	 * @since 6.3.0
+	 * @var string
+	 */
 	const TEST_THEME = 'block-theme';
 
+	/**
+	 * The id of the user to use for the test.
+	 *
+	 * @since 6.3.0
+	 * @var int
+	 */
 	private static $admin_id;
 
+	/**
+	 * Creates admin user before tests run.
+	 *
+	 * @param WP_UnitTest_Factory $factory
+	 */
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		// Create an admin user because get_edit_post_link() requires 'edit_post' capability.
 		self::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
 	}
 
+	/**
+	 * Performs setup tasks for every test.
+	 *
+	 * @since 6.3.0
+	 */
 	public function set_up() {
 		parent::set_up();
 		wp_set_current_user( self::$admin_id );
 		switch_theme( self::TEST_THEME );
 	}
 
+	/**
+	 * Tests getting the edit post link for a post.
+	 */
 	public function test_get_edit_post_link() {
 		$post                 = self::factory()->post->create_and_get(
 			array(
@@ -36,6 +66,11 @@ class Tests_Link_GetEditPostLink extends WP_UnitTestCase {
 		$this->assertSame( $link_custom_context, get_edit_post_link( $post, 'something-else' ), 'Pass non-default value in second argument.' );
 	}
 
+	/**
+	 * Tests getting the edit post link for a template post type
+	 *
+	 * @ticket 57709
+	 */
 	public function test_get_edit_post_link_for_wp_template_post_type() {
 		$template_post = self::factory()->post->create_and_get(
 			array(
@@ -62,6 +97,11 @@ class Tests_Link_GetEditPostLink extends WP_UnitTestCase {
 		$this->assertSame( $link_custom_context, get_edit_post_link( $template_post, 'something-else' ), 'Pass non-default value in second argument.' );
 	}
 
+	/**
+	 * Tests getting the edit post link for a template part post type
+	 *
+	 * @ticket 57709
+	 */
 	public function test_get_edit_post_link_for_wp_template_part_post_type() {
 		$template_part_post = self::factory()->post->create_and_get(
 			array(

--- a/tests/phpunit/tests/link/getEditPostLink.php
+++ b/tests/phpunit/tests/link/getEditPostLink.php
@@ -4,18 +4,22 @@
  * @covers ::get_edit_post_link
  */
 class Tests_Link_GetEditPostLink extends WP_UnitTestCase {
-
 	const TEST_THEME = 'block-theme';
-	private static $admin_user;
+
+	private static $admin_id;
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
-		switch_theme( self::TEST_THEME );
 		// Create an admin user because get_edit_post_link() requires 'edit_post' capability.
-		self::$admin_user = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	public function set_up() {
+		parent::set_up();
+		wp_set_current_user( self::$admin_id );
+		switch_theme( self::TEST_THEME );
 	}
 
 	public function test_get_edit_post_link() {
-		wp_set_current_user( self::$admin_user );
 		$post                 = self::factory()->post->create_and_get(
 			array(
 				'post_type'   => 'post',
@@ -33,7 +37,6 @@ class Tests_Link_GetEditPostLink extends WP_UnitTestCase {
 	}
 
 	public function test_get_edit_post_link_for_wp_template_post_type() {
-		wp_set_current_user( self::$admin_user );
 		$template_post = self::factory()->post->create_and_get(
 			array(
 				'post_type'    => 'wp_template',
@@ -60,7 +63,6 @@ class Tests_Link_GetEditPostLink extends WP_UnitTestCase {
 	}
 
 	public function test_get_edit_post_link_for_wp_template_part_post_type() {
-		wp_set_current_user( self::$admin_user );
 		$template_part_post = self::factory()->post->create_and_get(
 			array(
 				'post_type'    => 'wp_template_part',

--- a/tests/phpunit/tests/link/getEditPostLink.php
+++ b/tests/phpunit/tests/link/getEditPostLink.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * @group link
+ * @covers ::get_edit_post_link
+ */
+class Tests_Link_GetEditPostLink extends WP_UnitTestCase {
+
+	const TEST_THEME = 'block-theme';
+	private static $admin_user;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		switch_theme( self::TEST_THEME );
+		// Create an admin user because get_edit_post_link() requires 'edit_post' capability.
+		self::$admin_user = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	public function test_get_edit_post_link() {
+		wp_set_current_user( self::$admin_user );
+		$post                 = self::factory()->post->create_and_get(
+			array(
+				'post_type'   => 'post',
+				'post_title'  => 'Test Post',
+				'post_name'   => 'test-post',
+				'post_status' => 'publish',
+			)
+		);
+		$post_type_object     = get_post_type_object( $post->post_type );
+		$link_default_context = admin_url( sprintf( $post_type_object->_edit_link . '&amp;action=edit', $post->ID ) );
+		$link_custom_context  = admin_url( sprintf( $post_type_object->_edit_link . '&action=edit', $post->ID ) );
+
+		$this->assertSame( $link_default_context, get_edit_post_link( $post ), 'Second argument `$context` has a default context of `"display"`.' );
+		$this->assertSame( $link_custom_context, get_edit_post_link( $post, 'something-else' ), 'Pass non-default value in second argument.' );
+	}
+
+	public function test_get_edit_post_link_for_wp_template_post_type() {
+		wp_set_current_user( self::$admin_user );
+		$template_post = self::factory()->post->create_and_get(
+			array(
+				'post_type'    => 'wp_template',
+				'post_name'    => 'my_template',
+				'post_title'   => 'My Template',
+				'post_content' => 'Content',
+				'post_excerpt' => 'Description of my template',
+				'tax_input'    => array(
+					'wp_theme' => array(
+						self::TEST_THEME,
+					),
+				),
+			)
+		);
+
+		wp_set_post_terms( $template_post->ID, self::TEST_THEME, 'wp_theme' );
+
+		$post_type_object     = get_post_type_object( $template_post->post_type );
+		$link_default_context = admin_url( sprintf( $post_type_object->_edit_link . '&amp;canvas=edit', get_stylesheet() . '//my_template' ) );
+		$link_custom_context  = admin_url( sprintf( $post_type_object->_edit_link . '&canvas=edit', get_stylesheet() . '//my_template' ) );
+
+		$this->assertSame( $link_default_context, get_edit_post_link( $template_post ), 'Second argument `$context` has a default context of `"display"`.' );
+		$this->assertSame( $link_custom_context, get_edit_post_link( $template_post, 'something-else' ), 'Pass non-default value in second argument.' );
+	}
+
+	public function test_get_edit_post_link_for_wp_template_part_post_type() {
+		wp_set_current_user( self::$admin_user );
+		$template_part_post = self::factory()->post->create_and_get(
+			array(
+				'post_type'    => 'wp_template_part',
+				'post_name'    => 'my_template_part',
+				'post_title'   => 'My Template Part',
+				'post_content' => 'Content',
+				'post_excerpt' => 'Description of my template part',
+				'tax_input'    => array(
+					'wp_theme'              => array(
+						self::TEST_THEME,
+					),
+					'wp_template_part_area' => array(
+						WP_TEMPLATE_PART_AREA_HEADER,
+					),
+				),
+			)
+		);
+
+		wp_set_post_terms( $template_part_post->ID, WP_TEMPLATE_PART_AREA_HEADER, 'wp_template_part_area' );
+		wp_set_post_terms( $template_part_post->ID, self::TEST_THEME, 'wp_theme' );
+
+		$post_type_object     = get_post_type_object( $template_part_post->post_type );
+		$link_default_context = admin_url( sprintf( $post_type_object->_edit_link . '&amp;canvas=edit', get_stylesheet() . '//my_template_part' ) );
+		$link_custom_context  = admin_url( sprintf( $post_type_object->_edit_link . '&canvas=edit', get_stylesheet() . '//my_template_part' ) );
+
+		$this->assertSame( $link_default_context, get_edit_post_link( $template_part_post ), 'Second argument `$context` has a default context of `"display"`.' );
+		$this->assertSame( $link_custom_context, get_edit_post_link( $template_part_post, 'something-else' ), 'Pass non-default value in second argument.' );
+	}
+}


### PR DESCRIPTION
Testing out adding `_edit_link` properties to custom post types: templates, template_parts and global styles.

The motivation is to allow `get_edit_post_link()` to return the correct link for these custom post types, for example, for the revisions UI.

See: https://github.com/WordPress/gutenberg/issues/48065

https://user-images.githubusercontent.com/6458278/231906775-3037cb5f-dab4-4a4d-82ec-724eb5cbcece.mp4



<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
