### PR TITLE
`plugins_api` PHPDoc: remove unsupported value `hot_categories` for the `action` parameter

### DIFF
--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -28,26 +28,26 @@
  *
  * Supported arguments per action:
  *
- * | Argument Name        | query_plugins | plugin_information | hot_tags | hot_categories |
- * | -------------------- | :-----------: | :----------------: | :------: | :------------: |
- * | `$slug`              | No            |  Yes               | No       | No             |
- * | `$per_page`          | Yes           |  No                | No       | No             |
- * | `$page`              | Yes           |  No                | No       | No             |
- * | `$number`            | No            |  No                | Yes      | Yes            |
- * | `$search`            | Yes           |  No                | No       | No             |
- * | `$tag`               | Yes           |  No                | No       | No             |
- * | `$author`            | Yes           |  No                | No       | No             |
- * | `$user`              | Yes           |  No                | No       | No             |
- * | `$browse`            | Yes           |  No                | No       | No             |
- * | `$locale`            | Yes           |  Yes               | No       | No             |
- * | `$installed_plugins` | Yes           |  No                | No       | No             |
- * | `$is_ssl`            | Yes           |  Yes               | No       | No             |
- * | `$fields`            | Yes           |  Yes               | No       | No             |
+ * | Argument Name        | query_plugins | plugin_information | hot_tags |
+ * | -------------------- | :-----------: | :----------------: | :------: |
+ * | `$slug`              | No            |  Yes               | No       |
+ * | `$per_page`          | Yes           |  No                | No       |
+ * | `$page`              | Yes           |  No                | No       |
+ * | `$number`            | No            |  No                | Yes      |
+ * | `$search`            | Yes           |  No                | No       |
+ * | `$tag`               | Yes           |  No                | No       |
+ * | `$author`            | Yes           |  No                | No       |
+ * | `$user`              | Yes           |  No                | No       |
+ * | `$browse`            | Yes           |  No                | No       |
+ * | `$locale`            | Yes           |  Yes               | No       |
+ * | `$installed_plugins` | Yes           |  No                | No       |
+ * | `$is_ssl`            | Yes           |  Yes               | No       |
+ * | `$fields`            | Yes           |  Yes               | No       |
  *
  * @since 2.7.0
  *
- * @param string       $action API action to perform: 'query_plugins', 'plugin_information',
- *                             'hot_tags' or 'hot_categories'.
+ * @param string       $action API action to perform: 'query_plugins', 'plugin_information'
+ *                             or 'hot_tags'.
  * @param array|object $args   {
  *     Optional. Array or object of arguments to serialize for the Plugin Info API.
  *
@@ -95,7 +95,7 @@
  *         @type bool $contributors      Whether to return the list of contributors. Default false.
  *     }
  * }
- * @return object|array|WP_Error Response object or array on success, WP_Error on failure. See the
+ * @return object|array|WP_Error array containingResponse object or array on success, WP_Error on failure. See the
  *         {@link https://developer.wordpress.org/reference/functions/plugins_api/ function reference article}
  *         for more information on the make-up of possible return values depending on the value of `$action`.
  */

--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -95,7 +95,7 @@
  *         @type bool $contributors      Whether to return the list of contributors. Default false.
  *     }
  * }
- * @return object|array|WP_Error array containingResponse object or array on success, WP_Error on failure. See the
+ * @return object|array|WP_Error Response object or array on success, WP_Error on failure. See the
  *         {@link https://developer.wordpress.org/reference/functions/plugins_api/ function reference article}
  *         for more information on the make-up of possible return values depending on the value of `$action`.
  */


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Removes the unsupported value `hot_categories` for the `action` parameter from the docblock of `plugins_api()`.

Trac ticket: https://core.trac.wordpress.org/ticket/55645

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
