### PR TITLE
Html api: Fix setting attribute multiple times

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1908,7 +1908,7 @@ class WP_HTML_Tag_Processor {
 			 *    Result: <div id="new"/>
 			 */
 			$existing_attribute             = $this->attributes[ $comparable_name ];
-			$this->lexical_updates[ $name ] = new WP_HTML_Text_Replacement(
+			$this->lexical_updates[ $comparable_name ] = new WP_HTML_Text_Replacement(
 				$existing_attribute->start,
 				$existing_attribute->end,
 				$updated_attribute

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1908,7 +1908,7 @@ class WP_HTML_Tag_Processor {
 			 *
 			 *    Result: <div id="new"/>
 			 */
-			$existing_attribute             = $this->attributes[ $comparable_name ];
+			$existing_attribute = $this->attributes[ $comparable_name ];
 			$this->lexical_updates[ $comparable_name ] = new WP_HTML_Text_Replacement(
 				$existing_attribute->start,
 				$existing_attribute->end,

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1815,6 +1815,7 @@ class WP_HTML_Tag_Processor {
 	 * For string attributes, the value is escaped using the `esc_attr` function.
 	 *
 	 * @since 6.2.0
+	 * @since 6.2.1 Fix: Only create a single update for multiple calls with case-variant attribute names.
 	 *
 	 * @param string      $name  The attribute name to target.
 	 * @param string|bool $value The new attribute value.

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -963,6 +963,20 @@ class Tests_HtmlApi_wpHtmlTagProcessor extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensures that when setting an attribute multiple times that only
+	 * one update flushes out into the updated HTML.
+	 */
+	public function test_set_attribute_with_case_variants_updates_only_the_original_first_copy() {
+		$p = new WP_HTML_Tag_Processor( '<div data-enabled="5">' );
+		$p->next_tag();
+		$p->set_attribute( 'DATA-ENABLED', 'canary' );
+		$p->set_attribute( 'Data-Enabled', 'canary' );
+		$p->set_attribute( 'dATa-EnABled', 'canary' );
+
+		$this->assertSame(  '<div data-enabled="canary">', strtolower( $p->get_updated_html() ) );
+	}
+
+	/**
 	 * @ticket 56299
 	 *
 	 * @covers WP_HTML_Tag_Processor::next_tag

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -965,6 +965,10 @@ class Tests_HtmlApi_wpHtmlTagProcessor extends WP_UnitTestCase {
 	/**
 	 * Ensures that when setting an attribute multiple times that only
 	 * one update flushes out into the updated HTML.
+	 *
+	 * @ticket 58146
+	 *
+	 * @covers WP_HTML_Tag_Processor::set_attribute
 	 */
 	public function test_set_attribute_with_case_variants_updates_only_the_original_first_copy() {
 		$p = new WP_HTML_Tag_Processor( '<div data-enabled="5">' );

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -977,7 +977,7 @@ class Tests_HtmlApi_wpHtmlTagProcessor extends WP_UnitTestCase {
 		$p->set_attribute( 'Data-Enabled', 'canary' );
 		$p->set_attribute( 'dATa-EnABled', 'canary' );
 
-		$this->assertSame(  '<div data-enabled="canary">', strtolower( $p->get_updated_html() ) );
+		$this->assertSame( '<div data-enabled="canary">', strtolower( $p->get_updated_html() ) );
 	}
 
 	/**


### PR DESCRIPTION
HTML API: Ensure attribute updates happen only once for case variants

Trac ticket: [#58146-trac](https://core.trac.wordpress.org/ticket/58146#ticket)

When setting a new value for an attribute multiple times and providing
multiple case variations of the attribute name the Tag Processor has
been appending multiple copies of the attribute into the updated HTML.

This means that only the first attribute set determines the value in
the final output.

In this patch we're adding a test to catch the situation, and then fixing
the bug by using the comparable name to key the attribute updates instead
of the case-sensitive name.