### PR TITLE
fix rewind_posts index

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -3698,7 +3698,7 @@ class WP_Query {
 	public function rewind_posts() {
 		$this->current_post = -1;
 		if ( $this->post_count > 0 ) {
-			$this->post = $this->posts[0];
+			$this->post = $this->posts[array_key_first($this->posts)];
 		}
 	}
 

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -3698,7 +3698,7 @@ class WP_Query {
 	public function rewind_posts() {
 		$this->current_post = -1;
 		if ( $this->post_count > 0 ) {
-			$this->post = $this->posts[array_key_first($this->posts)];
+			$this->post = $this->posts[ array_key_first( $this->posts ) ];
 		}
 	}
 

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -3698,7 +3698,8 @@ class WP_Query {
 	public function rewind_posts() {
 		$this->current_post = -1;
 		if ( $this->post_count > 0 ) {
-			$this->post = $this->posts[ array_key_first( $this->posts ) ];
+			reset( $this->posts );
+			$this->post = $this->posts[ key( $this->posts ) ];
 		}
 	}
 


### PR DESCRIPTION
Hi team, 
The rewind_posts crashes when we have an object with posts that don't start at position 0. I use an api with more than 5 thousand objects and sometimes the posts start with an index greater than 0.

Trac ticket: [58147](https://core.trac.wordpress.org/ticket/58147)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
