### PR TITLE
Comments navigation links for Twenty Nineteen

### DIFF
--- a/src/wp-content/themes/twentynineteen/comments.php
+++ b/src/wp-content/themes/twentynineteen/comments.php
@@ -87,13 +87,22 @@ $discussion = twentynineteen_get_discussion_data();
 
 		// Show comment navigation.
 		if ( have_comments() ) :
-			$prev_icon     = twentynineteen_get_icon_svg( 'chevron_left', 22 );
-			$next_icon     = twentynineteen_get_icon_svg( 'chevron_right', 22 );
-			$comments_text = __( 'Comments', 'twentynineteen' );
+			$prev_icon = twentynineteen_get_icon_svg( 'chevron_left', 22 );
+			$next_icon = twentynineteen_get_icon_svg( 'chevron_right', 22 );
 			the_comments_navigation(
 				array(
-					'prev_text' => sprintf( '%s <span class="nav-prev-text"><span class="primary-text">%s</span> <span class="secondary-text">%s</span></span>', $prev_icon, __( 'Previous', 'twentynineteen' ), __( 'Comments', 'twentynineteen' ) ),
-					'next_text' => sprintf( '<span class="nav-next-text"><span class="primary-text">%s</span> <span class="secondary-text">%s</span></span> %s', __( 'Next', 'twentynineteen' ), __( 'Comments', 'twentynineteen' ), $next_icon ),
+					'prev_text' => sprintf(
+						'%1$s <span class="nav-prev-text">%2$s</span>',
+						$prev_icon,
+						/* translators: Comments navigation link text. The secondary-text element may be hidden. */
+						__( '<span class="primary-text">Previous</span> <span class="secondary-text">Comments</span>', 'twentynineteen' )
+					),
+					'next_text' => sprintf(
+						'<span class="nav-next-text">%1$s</span> %2$s',
+						/* translators: Comments navigation link text. The secondary-text element may be hidden. */
+						__( '<span class="primary-text">Next</span> <span class="secondary-text">Comments</span>', 'twentynineteen' ),
+						$next_icon
+					),
 				)
 			);
 		endif;

--- a/src/wp-content/themes/twentynineteen/comments.php
+++ b/src/wp-content/themes/twentynineteen/comments.php
@@ -94,12 +94,12 @@ $discussion = twentynineteen_get_discussion_data();
 					'prev_text' => sprintf(
 						'%1$s <span class="nav-prev-text">%2$s</span>',
 						$prev_icon,
-						/* translators: Comments navigation link text. The secondary-text element may be hidden. */
+						/* translators: Comments navigation link text. The secondary-text element is hidden on small screens. */
 						__( '<span class="primary-text">Previous</span> <span class="secondary-text">Comments</span>', 'twentynineteen' )
 					),
 					'next_text' => sprintf(
 						'<span class="nav-next-text">%1$s</span> %2$s',
-						/* translators: Comments navigation link text. The secondary-text element may be hidden. */
+						/* translators: Comments navigation link text. The secondary-text element is hidden on small screens. */
 						__( '<span class="primary-text">Next</span> <span class="secondary-text">Comments</span>', 'twentynineteen' ),
 						$next_icon
 					),


### PR DESCRIPTION
Combine text strings for "Previous Comments" and "Next Comments" links. The `span` tags are included in the translation to give more control over what is hidden on small screens.

Trac ticket: https://core.trac.wordpress.org/ticket/58149

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
