### PR TITLE
Always include `core/query` block correctly in Twenty Twenty-Three theme

### DIFF
--- a/src/wp-content/themes/twentytwentythree/templates/blog-alternative.html
+++ b/src/wp-content/themes/twentytwentythree/templates/blog-alternative.html
@@ -2,7 +2,7 @@
 
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
 <main class="wp-block-group">
-	<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"align":"wide","layout":{"type":"default"}} -->
+	<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"align":"wide","layout":{"type":"default"}} -->
 	<div class="wp-block-query alignwide">
 		<!-- wp:post-template -->
 			<!-- wp:columns {"style":{"border":{"bottom":{"width":"1px"}},"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"},"margin":{"top":"-1.5rem","bottom":"0px"}}}} -->

--- a/src/wp-content/themes/twentytwentythree/templates/page.html
+++ b/src/wp-content/themes/twentytwentythree/templates/page.html
@@ -2,15 +2,21 @@
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|50"}}}} -->
 <main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--50)">
-	<!-- wp:group {"layout":{"type":"constrained"}} -->
-	<div class="wp-block-group">
-		<!-- wp:post-featured-image {"overlayColor":"contrast","dimRatio":50,"align":"wide","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50","top":"calc(-1 * var(--wp--preset--spacing--50))"}}}} /-->
-		<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} /-->
-	</div>
-	<!-- /wp:group -->
+	<!-- wp:query {"query":{"perPage":1,"pages":0,"offset":0,"postType":"page","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"align":"full","layout":{"type":"default"}} -->
+	<div class="wp-block-query alignfull">
+		<!-- wp:post-template {"align":"full"} -->
+			<!-- wp:group {"layout":{"type":"constrained"}} -->
+			<div class="wp-block-group">
+				<!-- wp:post-featured-image {"overlayColor":"contrast","dimRatio":50,"align":"wide","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50","top":"calc(-1 * var(--wp--preset--spacing--50))"}}}} /-->
+				<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} /-->
+			</div>
+			<!-- /wp:group -->
 
-	<!-- wp:post-content {"layout":{"type":"constrained"}} /-->
-	<!-- wp:template-part {"slug":"comments","tagName":"section"} /-->
+			<!-- wp:post-content {"layout":{"type":"constrained"}} /-->
+			<!-- wp:template-part {"slug":"comments","tagName":"section"} /-->
+		<!-- /wp:post-template -->
+	</div>
+	<!-- /wp:query -->
 </main>
 <!-- /wp:group -->
 

--- a/src/wp-content/themes/twentytwentythree/templates/single.html
+++ b/src/wp-content/themes/twentytwentythree/templates/single.html
@@ -2,16 +2,22 @@
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|50"}}}} -->
 <main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--50)">
-	<!-- wp:group {"layout":{"type":"constrained"}} -->
-	<div class="wp-block-group">
-		<!-- wp:post-featured-image {"overlayColor":"contrast","dimRatio":50,"align":"wide","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50","top":"calc(-1 * var(--wp--preset--spacing--50))"}}}} /-->
-		<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} /-->
-	</div>
-	<!-- /wp:group -->
+	<!-- wp:query {"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"align":"full","layout":{"type":"default"}} -->
+	<div class="wp-block-query alignfull">
+		<!-- wp:post-template {"align":"full"} -->
+			<!-- wp:group {"layout":{"type":"constrained"}} -->
+			<div class="wp-block-group">
+				<!-- wp:post-featured-image {"overlayColor":"contrast","dimRatio":50,"align":"wide","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50","top":"calc(-1 * var(--wp--preset--spacing--50))"}}}} /-->
+				<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} /-->
+			</div>
+			<!-- /wp:group -->
 
-	<!-- wp:post-content {"layout":{"type":"constrained"}} /-->
-	<!-- wp:template-part {"slug":"post-meta"} /-->
-	<!-- wp:template-part {"slug":"comments","tagName":"section"} /-->
+			<!-- wp:post-content {"layout":{"type":"constrained"}} /-->
+			<!-- wp:template-part {"slug":"post-meta"} /-->
+			<!-- wp:template-part {"slug":"comments","tagName":"section"} /-->
+		<!-- /wp:post-template -->
+	</div>
+	<!-- /wp:query -->
 </main>
 <!-- /wp:group -->
 


### PR DESCRIPTION
This PR fixes the 3 templates in TT3 which had problems due to incorrect / missing usage of the `core/query` block.

Trac ticket: https://core.trac.wordpress.org/ticket/58154

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
