### PR TITLE
HTML API: Fix case where updates are overlooked when seeking to earlier locations.

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -2086,6 +2086,8 @@ class WP_HTML_Tag_Processor {
 		 * to the end of the updated document and return.
 		 */
 		if ( $requires_no_updating && $this->bytes_already_copied > 0 ) {
+			$this->html                 = $this->output_buffer . substr( $this->html, $this->bytes_already_copied );
+			$this->bytes_already_copied = strlen( $this->output_buffer );
 			return $this->output_buffer . substr( $this->html, $this->bytes_already_copied );
 		}
 

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -460,8 +460,7 @@ class Tests_HtmlApi_wpHtmlTagProcessor extends WP_UnitTestCase {
 	 * Ensures that when seeking to an earlier spot in the document that
 	 * all previously-enqueued updates are applied as they ought to be.
 	 *
-	 * @TODO: Add ticket number.
-	 * @ticket XXXXXX
+	 * @ticket 58160
 	 */
 	public function test_get_updated_html_applies_updates_to_content_after_seeking_to_before_parsed_bytes() {
 		$p = new WP_HTML_Tag_Processor( '<div><img hidden></div>' );

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -457,6 +457,27 @@ class Tests_HtmlApi_wpHtmlTagProcessor extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensures that when seeking to an earlier spot in the document that
+	 * all previously-enqueued updates are applied as they ought to be.
+	 *
+	 * @TODO: Add ticket number.
+	 * @ticket XXXXXX
+	 */
+	public function test_get_updated_html_applies_updates_to_content_after_seeking_to_before_parsed_bytes() {
+		$p = new WP_HTML_Tag_Processor( '<div><img src="https://s.wp.com/i/atat.png"></div>' );
+
+		$p->next_tag();
+		$p->add_class('wonky');
+		$p->next_tag();
+		$p->set_bookmark('here');
+
+		$p->next_tag( [ 'tag_closers' => 'visit' ] );
+		$p->seek('here');
+
+		$this->assertSame( '<div class="wonky"><img src="https://s.wp.com/i/atat.png"></div>', $p->get_updated_html() );
+	}
+
+	/**
 	 * @ticket 56299
 	 *
 	 * @covers WP_HTML_Tag_Processor::next_tag

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -464,17 +464,17 @@ class Tests_HtmlApi_wpHtmlTagProcessor extends WP_UnitTestCase {
 	 * @ticket XXXXXX
 	 */
 	public function test_get_updated_html_applies_updates_to_content_after_seeking_to_before_parsed_bytes() {
-		$p = new WP_HTML_Tag_Processor( '<div><img src="https://s.wp.com/i/atat.png"></div>' );
+		$p = new WP_HTML_Tag_Processor( '<div><img hidden></div>' );
 
 		$p->next_tag();
-		$p->add_class('wonky');
+		$p->set_attribute( 'wonky', true );
 		$p->next_tag();
-		$p->set_bookmark('here');
+		$p->set_bookmark( 'here' );
 
 		$p->next_tag( [ 'tag_closers' => 'visit' ] );
-		$p->seek('here');
+		$p->seek( 'here' );
 
-		$this->assertSame( '<div class="wonky"><img src="https://s.wp.com/i/atat.png"></div>', $p->get_updated_html() );
+		$this->assertSame( '<div wonky><img hidden></div>', $p->get_updated_html() );
 	}
 
 	/**

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -471,7 +471,7 @@ class Tests_HtmlApi_wpHtmlTagProcessor extends WP_UnitTestCase {
 		$p->next_tag();
 		$p->set_bookmark( 'here' );
 
-		$p->next_tag( [ 'tag_closers' => 'visit' ] );
+		$p->next_tag( array( 'tag_closers' => 'visit' ) );
 		$p->seek( 'here' );
 
 		$this->assertSame( '<div wonky><img hidden></div>', $p->get_updated_html() );


### PR DESCRIPTION
Trac ticket [#58160-trac](https://core.trac.wordpress.org/ticket/58160#ticket)

In certain cases when seeking to an earlier location in a document after changes have been enqueued, the tag processor will lose the earlier changes.

In this patch we're fixing the bug so that it properly retains the changes that were applied before the call to `seek()`.

The problem was that when changes had already been applied and no more were enqueued, the tag processor was returning the updated HTML without updating its internal state to reflect that. This was probably an optimization for that case but I can't remember exactly why it doesn't update the internal pointers (@adamziel maybe you remember?). The fix is simple: mirror the second case and update the internal pointers.