### PR TITLE
allow string '0' for post_title / post_content / post_excerpt #58141

### DIFF
--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -2083,7 +2083,7 @@ function the_post_password() {
  */
 function _draft_or_post_title( $post = 0 ) {
 	$title = get_the_title( $post );
-	if ( empty( $title ) ) {
+	if ( is_null( $title ) || '' === $title ) {
 		$title = __( '(no title)' );
 	}
 	return esc_html( $title );

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -4113,10 +4113,12 @@ function wp_insert_post( $postarr, $wp_error = false, $fire_after_hooks = true )
 	}
 
 	$maybe_empty = 'attachment' !== $post_type
-		&& ! $post_content && ! $post_title && ! $post_excerpt
-		&& post_type_supports( $post_type, 'editor' )
-		&& post_type_supports( $post_type, 'title' )
-		&& post_type_supports( $post_type, 'excerpt' );
+	               && ( is_null( $post_content ) || '' === $post_content )
+	               && ( is_null( $post_title ) || '' === $post_title )
+	               && ( is_null( $post_excerpt ) || '' === $post_excerpt )
+	               && post_type_supports( $post_type, 'editor' )
+	               && post_type_supports( $post_type, 'title' )
+	               && post_type_supports( $post_type, 'excerpt' );
 
 	/**
 	 * Filters whether the post should be considered "empty".
@@ -5123,10 +5125,10 @@ function wp_unique_post_slug( $slug, $post_id, $post_status, $post_type, $post_p
 		 */
 		$is_bad_flat_slug = apply_filters( 'wp_unique_post_slug_is_bad_flat_slug', false, $slug, $post_type );
 
-		if ( $post_name_check
-			|| in_array( $slug, $feeds, true ) || 'embed' === $slug
-			|| $conflicts_with_date_archive
-			|| $is_bad_flat_slug
+		if ( ( ! is_null( $post_name_check ) && '' !== $post_name_check )
+		     || in_array( $slug, $feeds, true ) || 'embed' === $slug
+		     || $conflicts_with_date_archive
+		     || $is_bad_flat_slug
 		) {
 			$suffix = 2;
 			do {

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -4113,12 +4113,12 @@ function wp_insert_post( $postarr, $wp_error = false, $fire_after_hooks = true )
 	}
 
 	$maybe_empty = 'attachment' !== $post_type
-	               && ( is_null( $post_content ) || '' === $post_content )
-	               && ( is_null( $post_title ) || '' === $post_title )
-	               && ( is_null( $post_excerpt ) || '' === $post_excerpt )
-	               && post_type_supports( $post_type, 'editor' )
-	               && post_type_supports( $post_type, 'title' )
-	               && post_type_supports( $post_type, 'excerpt' );
+		&& ( is_null( $post_content ) || '' === $post_content )
+		&& ( is_null( $post_title ) || '' === $post_title )
+		&& ( is_null( $post_excerpt ) || '' === $post_excerpt )
+		&& post_type_supports( $post_type, 'editor' )
+		&& post_type_supports( $post_type, 'title' )
+		&& post_type_supports( $post_type, 'excerpt' );
 
 	/**
 	 * Filters whether the post should be considered "empty".
@@ -5126,9 +5126,9 @@ function wp_unique_post_slug( $slug, $post_id, $post_status, $post_type, $post_p
 		$is_bad_flat_slug = apply_filters( 'wp_unique_post_slug_is_bad_flat_slug', false, $slug, $post_type );
 
 		if ( ( ! is_null( $post_name_check ) && '' !== $post_name_check )
-		     || in_array( $slug, $feeds, true ) || 'embed' === $slug
-		     || $conflicts_with_date_archive
-		     || $is_bad_flat_slug
+			|| in_array( $slug, $feeds, true ) || 'embed' === $slug
+			|| $conflicts_with_date_archive
+			|| $is_bad_flat_slug
 		) {
 			$suffix = 2;
 			do {

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -5033,7 +5033,7 @@ function wp_unique_post_slug( $slug, $post_id, $post_status, $post_type, $post_p
 		 */
 		$is_bad_attachment_slug = apply_filters( 'wp_unique_post_slug_is_bad_attachment_slug', false, $slug );
 
-		if ( $post_name_check
+		if ( ( ! is_null( $post_name_check ) && '' !== $post_name_check )
 			|| in_array( $slug, $feeds, true ) || 'embed' === $slug
 			|| $is_bad_attachment_slug
 		) {
@@ -5069,7 +5069,7 @@ function wp_unique_post_slug( $slug, $post_id, $post_status, $post_type, $post_p
 		 */
 		$is_bad_hierarchical_slug = apply_filters( 'wp_unique_post_slug_is_bad_hierarchical_slug', false, $slug, $post_type, $post_parent );
 
-		if ( $post_name_check
+		if ( ( ! is_null( $post_name_check ) && '' !== $post_name_check )
 			|| in_array( $slug, $feeds, true ) || 'embed' === $slug
 			|| preg_match( "@^($wp_rewrite->pagination_base)?\d+$@", $slug )
 			|| $is_bad_hierarchical_slug

--- a/tests/phpunit/tests/post/wpInsertPost.php
+++ b/tests/phpunit/tests/post/wpInsertPost.php
@@ -1570,7 +1570,7 @@ class Tests_Post_wpInsertPost extends WP_UnitTestCase {
 
 		$post_id = self::factory()->post->create(
 			array(
-				'post_title' => '0',
+				'post_title'   => '0',
 				'post_content' => '0',
 				'post_excerpt' => '0',
 			)
@@ -1590,7 +1590,7 @@ class Tests_Post_wpInsertPost extends WP_UnitTestCase {
 
 		$post_id = self::factory()->post->create(
 			array(
-				'post_title' => '0',
+				'post_title'   => '0',
 				'post_content' => 'post_content',
 				'post_excerpt' => 'post_excerpt',
 			)
@@ -1610,7 +1610,7 @@ class Tests_Post_wpInsertPost extends WP_UnitTestCase {
 
 		$post_id = self::factory()->post->create(
 			array(
-				'post_title' => 'post_title',
+				'post_title'   => 'post_title',
 				'post_content' => '0',
 				'post_excerpt' => 'post_excerpt',
 			)
@@ -1630,7 +1630,7 @@ class Tests_Post_wpInsertPost extends WP_UnitTestCase {
 
 		$post_id = self::factory()->post->create(
 			array(
-				'post_title' => 'post_title',
+				'post_title'   => 'post_title',
 				'post_content' => 'post_content',
 				'post_excerpt' => '0',
 			)

--- a/tests/phpunit/tests/post/wpInsertPost.php
+++ b/tests/phpunit/tests/post/wpInsertPost.php
@@ -1576,9 +1576,9 @@ class Tests_Post_wpInsertPost extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertSame( '0', get_the_title( $post_id ) );
-		$this->assertSame( '0', get_the_content( null, false, $post_id ) );
-		$this->assertSame( '0', get_the_excerpt( $post_id ) );
+		$this->assertSame( '0', get_the_title( $post_id ), 'Check post_title = "0"' );
+		$this->assertSame( '0', get_the_content( null, false, $post_id ), 'Check post_content = "0"' );
+		$this->assertSame( '0', get_the_excerpt( $post_id ), 'Check post_excerpt = "0"' );
 	}
 
 	/**
@@ -1596,9 +1596,9 @@ class Tests_Post_wpInsertPost extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertSame( '0', get_the_title( $post_id ) );
-		$this->assertSame( 'post_content', get_the_content( null, false, $post_id ) );
-		$this->assertSame( 'post_excerpt', get_the_excerpt( $post_id ) );
+		$this->assertSame( '0', get_the_title( $post_id ), 'Check post_title = "0"' );
+		$this->assertSame( 'post_content', get_the_content( null, false, $post_id ), 'Check post_content = "post_content"' );
+		$this->assertSame( 'post_excerpt', get_the_excerpt( $post_id ), 'Check post_excerpt = "post_excerpt"' );
 	}
 
 	/**
@@ -1616,9 +1616,9 @@ class Tests_Post_wpInsertPost extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertSame( 'post_title', get_the_title( $post_id ) );
-		$this->assertSame( '0', get_the_content( null, false, $post_id ) );
-		$this->assertSame( 'post_excerpt', get_the_excerpt( $post_id ) );
+		$this->assertSame( 'post_title', get_the_title( $post_id ), 'Check post_title = "post_title"' );
+		$this->assertSame( '0', get_the_content( null, false, $post_id ), 'Check post_content = "0"' );
+		$this->assertSame( 'post_excerpt', get_the_excerpt( $post_id ), 'Check post_excerpt = "post_excerpt"' );
 	}
 
 	/**
@@ -1636,9 +1636,9 @@ class Tests_Post_wpInsertPost extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertSame( 'post_title', get_the_title( $post_id ) );
-		$this->assertSame( 'post_content', get_the_content( null, false, $post_id ) );
-		$this->assertSame( '0', get_the_excerpt( $post_id ) );
+		$this->assertSame( 'post_title', get_the_title( $post_id ), 'Check post_title = "post_title"' );
+		$this->assertSame( 'post_content', get_the_content( null, false, $post_id ), 'Check post_content = "post_content"' );
+		$this->assertSame( '0', get_the_excerpt( $post_id ), 'Check post_excerpt = "0"' );
 	}
 
 	/**
@@ -1660,6 +1660,6 @@ class Tests_Post_wpInsertPost extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertNotEquals( $post->post_name, $post_2->post_name );
+		$this->assertNotEquals( $post->post_name, $post_2->post_name, 'Check post_name are different for 2 created posts with post_title "0"' );
 	}
 }

--- a/tests/phpunit/tests/post/wpInsertPost.php
+++ b/tests/phpunit/tests/post/wpInsertPost.php
@@ -1560,4 +1560,106 @@ class Tests_Post_wpInsertPost extends WP_UnitTestCase {
 
 		$this->assertSame( 'future', get_post_status( $post_id ) );
 	}
+
+	/**
+	 * @ticket 58141
+	 *
+	 * @covers ::wp_insert_post
+	 */
+	public function test_zero_is_not_considered_as_empty_value_for_post_title_and_post_content_and_post_excerpt() {
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title' => '0',
+				'post_content' => '0',
+				'post_excerpt' => '0',
+			)
+		);
+
+		$this->assertSame( '0', get_the_title( $post_id ) );
+		$this->assertSame( '0', get_the_content( null, false, $post_id ) );
+		$this->assertSame( '0', get_the_excerpt( $post_id ) );
+	}
+
+	/**
+	 * @ticket 58141
+	 *
+	 * @covers ::wp_insert_post
+	 */
+	public function test_zero_is_not_considered_as_empty_value_for_post_title() {
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title' => '0',
+				'post_content' => 'post_content',
+				'post_excerpt' => 'post_excerpt',
+			)
+		);
+
+		$this->assertSame( '0', get_the_title( $post_id ) );
+		$this->assertSame( 'post_content', get_the_content( null, false, $post_id ) );
+		$this->assertSame( 'post_excerpt', get_the_excerpt( $post_id ) );
+	}
+
+	/**
+	 * @ticket 58141
+	 *
+	 * @covers ::wp_insert_post
+	 */
+	public function test_zero_is_not_considered_as_empty_value_for_post_content() {
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title' => 'post_title',
+				'post_content' => '0',
+				'post_excerpt' => 'post_excerpt',
+			)
+		);
+
+		$this->assertSame( 'post_title', get_the_title( $post_id ) );
+		$this->assertSame( '0', get_the_content( null, false, $post_id ) );
+		$this->assertSame( 'post_excerpt', get_the_excerpt( $post_id ) );
+	}
+
+	/**
+	 * @ticket 58141
+	 *
+	 * @covers ::wp_insert_post
+	 */
+	public function test_zero_is_not_considered_as_empty_value_for_post_excerpt() {
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title' => 'post_title',
+				'post_content' => 'post_content',
+				'post_excerpt' => '0',
+			)
+		);
+
+		$this->assertSame( 'post_title', get_the_title( $post_id ) );
+		$this->assertSame( 'post_content', get_the_content( null, false, $post_id ) );
+		$this->assertSame( '0', get_the_excerpt( $post_id ) );
+	}
+
+	/**
+	 * @ticket 58141
+	 *
+	 * @covers ::wp_insert_post
+	 */
+	public function test_slug_different_for_post_title_zero() {
+
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_title' => '0',
+			)
+		);
+
+		$post_2 = self::factory()->post->create_and_get(
+			array(
+				'post_title' => '0',
+			)
+		);
+
+		$this->assertNotEquals( $post->post_name, $post_2->post_name );
+	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
Considers "0" is not an empty value for post_title / post_content and post_excerpt 

Trac ticket: https://core.trac.wordpress.org/ticket/58141

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
