### PR TITLE
Enqueue registered assets once

### DIFF
--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -569,7 +569,6 @@ add_action( 'admin_enqueue_scripts', 'wp_localize_jquery_ui_datepicker', 1000 );
 add_action( 'admin_enqueue_scripts', 'wp_common_block_scripts_and_styles' );
 add_action( 'enqueue_block_assets', 'wp_enqueue_registered_block_scripts_and_styles' );
 add_action( 'enqueue_block_assets', 'enqueue_block_styles_assets', 30 );
-add_action( 'enqueue_block_editor_assets', 'wp_enqueue_registered_block_scripts_and_styles' );
 add_action( 'enqueue_block_editor_assets', 'enqueue_editor_block_styles_assets' );
 add_action( 'enqueue_block_editor_assets', 'wp_enqueue_editor_block_directory_assets' );
 add_action( 'enqueue_block_editor_assets', 'wp_enqueue_editor_format_library_assets' );


### PR DESCRIPTION
Trac ticket https://core.trac.wordpress.org/ticket/58208
Follow-up to https://core.trac.wordpress.org/ticket/45065

## What 

This PR removes the `wp_enqueue_registered_block_scripts_and_styles` callback from the `enqueue_block_editor_assets` action.

## Why

There are two actions to enqueue block assets: `enqueue_block_editor_assets` and `enqueue_block_assets`. The former enqueues the assets to the editor and the later enqueues them to the front-and AND the editor.

Given `wp_enqueue_registered_block_scripts_and_styles` is already bound to the `enqueue_block_assets` (front-end & editor), it is unnecessary to bind it to `enqueue_block_editor_assets` (editor) as well.

This was originally introduced at https://github.com/WordPress/wordpress-develop/commit/76525a75b7e84a8a34aede1b8aef4aecb6623bf8 and hasn't been modified since.

## How

Removes the action callback from being hooked to `enqueue_block_editor_assets`.

## How to test

- Install a 3rd party block that contains JS and CSS assets. You can download and use the [blockjson-assets](https://github.com/oandregal/understanding-gutenberg/tree/trunk/blockjson-assets) test plugin I created.
- If you use that plugin, verify that a "DOM" message is logged to the console (JS assets are loaded).
- Insert the "blockjson-assets" block and verify the styles look proper:

![image](https://user-images.githubusercontent.com/583546/233603833-e9be02c8-aa8c-4c2d-a897-ed6f1212cbe9.png)

## SVN commit message

```txt
Enqueue registered assets once.

This PR removes the `wp_enqueue_registered_block_scripts_and_styles` callback from the `enqueue_block_editor_assets` action.

There are two actions to enqueue block assets: `enqueue_block_editor_assets` and `enqueue_block_assets`. The former enqueues the assets to the editor and the later enqueues them to the front-and and the editor. Given `wp_enqueue_registered_block_scripts_and_styles` is already bound to the `enqueue_block_assets` (front-end & editor), it is unnecessary to bind it to `enqueue_block_editor_assets` (editor) as well.

This was originally introduced at [44157] and hasn't been modified since.

Props ellatrix, costdev.
Fixes #58208.
```