### PR TITLE
HTML API: Update code style so it passes when backported into Gutenberg

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1964,7 +1964,7 @@ class WP_HTML_Tag_Processor {
 			 *
 			 *    Result: <div id="new"/>
 			 */
-			$existing_attribute = $this->attributes[ $comparable_name ];
+			$existing_attribute                        = $this->attributes[ $comparable_name ];
 			$this->lexical_updates[ $comparable_name ] = new WP_HTML_Text_Replacement(
 				$existing_attribute->start,
 				$existing_attribute->end,


### PR DESCRIPTION
Trac ticket [#58170-trac](https://core.trac.wordpress.org/ticket/58170#ticket)

During the attempted merge of WordPress/gutenberg#49966 the PHP linting rule rejected the PR, even though it's a direct copy from Core.

In this PR we're adding spacing so that we can merge the "blessed" PR without creating conflicts between the two repositories.