### PR TITLE
58094 8.1 CSV files

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -3181,7 +3181,7 @@ function wp_check_filetype_and_ext( $file, $filename, $mimes = null ) {
 				$type = false;
 				$ext  = false;
 			}
-		} elseif ( 'application/csv' === $real_mime ) {
+		} elseif ( ( 'application/csv' === $real_mime ) || ( 'text/csv' === $real_mime ) ) {
 			// Special casing for CSV files.
 			if ( ! in_array(
 				$type,


### PR DESCRIPTION
Include text/csv to the list of supported types in wp_check_filetype_and_ext().

Track ticket: https://core.trac.wordpress.org/ticket/58094