### PR TITLE
HTML API: Preserve internal cursor across updates.

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -2128,7 +2128,7 @@ class WP_HTML_Tag_Processor {
 		 * 1. Apply the edits by flushing them to the output buffer and updating the copied byte count.
 		 */
 		$this->class_name_updates_to_attributes_updates();
-		$shift = $this->apply_attributes_updates( $before_tag_name );
+		$before_tag_name += $this->apply_attributes_updates( $before_tag_name );
 
 		/*
 		 * 2. Replace the original HTML with the now-updated HTML so that it's possible to
@@ -2149,12 +2149,10 @@ class WP_HTML_Tag_Processor {
 		 *                 ^  | back up by the length of the tag name plus the opening <
 		 *                 \<-/ back up by strlen("em") + 1 ==> 3
 		 */
-//		$this->bytes_already_parsed = $start_of_current_tag + $current_tag_shift;
 		$pointer = $this->bytes_already_parsed;
-		$this->bytes_already_parsed = $before_tag_name + $shift;
-		$this->next_tag();
+		$this->bytes_already_parsed = $before_tag_name;
+		$this->next_tag( $this->last_query );
 		$this->bytes_already_parsed = $pointer;
-//		$this->bytes_already_parsed = $before;
 
 		return $this->html;
 	}

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -318,23 +318,6 @@ class WP_HTML_Tag_Processor {
 	private $stop_on_tag_closers;
 
 	/**
-	 * Holds updated HTML as updates are applied.
-	 *
-	 * Updates and unmodified portions of the input document are
-	 * appended to this value as they are applied. It will hold
-	 * a copy of the updated document up until the point of the
-	 * latest applied update. The fully-updated HTML document
-	 * will comprise this value plus the part of the input document
-	 * which follows that latest update.
-	 *
-	 * @see $bytes_already_copied
-	 *
-	 * @since 6.2.0
-	 * @var string
-	 */
-	private $output_buffer = '';
-
-	/**
 	 * How many bytes from the original HTML document have been read and parsed.
 	 *
 	 * This value points to the latest byte offset in the input document which
@@ -345,32 +328,6 @@ class WP_HTML_Tag_Processor {
 	 * @var int
 	 */
 	private $bytes_already_parsed = 0;
-
-	/**
-	 * Shift `$this->bytes_already_parsed` by this amount to find
-	 * the corresponding location in `$this->output_buffer`.
-	 *
-	 * @since 6.2.1
-	 * @var int
-	 */
-	private $acccumulated_shift = 0;
-
-	/**
-	 * How many bytes from the input HTML document have already been
-	 * copied into the output buffer.
-	 *
-	 * Lexical updates are enqueued and processed in batches. Prior
-	 * to any given update in the input document, there might exist
-	 * a span of HTML unaffected by any changes. This span ought to
-	 * be copied verbatim into the output buffer before applying the
-	 * following update. This value will point to the starting byte
-	 * offset in the input document where that unaffected span of
-	 * HTML starts.
-	 *
-	 * @since 6.2.0
-	 * @var int
-	 */
-	private $bytes_already_copied = 0;
 
 	/**
 	 * Byte offset in input document where current tag name starts.
@@ -1312,8 +1269,7 @@ class WP_HTML_Tag_Processor {
 	 * @return void
 	 */
 	private function after_tag() {
-		$this->class_name_updates_to_attributes_updates();
-		$this->apply_attributes_updates();
+		$this->get_updated_html();
 		$this->tag_name_starts_at = null;
 		$this->tag_name_length    = null;
 		$this->tag_ends_at        = null;
@@ -1472,7 +1428,6 @@ class WP_HTML_Tag_Processor {
 	 * @since 6.2.1 Accumulates shift for internal cursor and passed pointer.
 	 * @since 6.3.0 Invalidate any bookmarks whose targets are overwritten.
 	 *
-	 * @param int $shift_this_point Pointer in document which might be shifted by updates.
 	 * @return int How many bytes the given pointer moved in response to the updates.
 	 */
 	private function apply_attributes_updates( $shift_this_point = 0) {
@@ -1494,12 +1449,14 @@ class WP_HTML_Tag_Processor {
 		 */
 		usort( $this->lexical_updates, array( self::class, 'sort_start_ascending' ) );
 
+		$bytes_already_copied = 0;
+		$output_buffer        = '';
 		foreach ( $this->lexical_updates as $diff ) {
 			$shift = strlen( $diff->text ) - ( $diff->end - $diff->start );
 
-			// Accumulate shift of the internal pointer across calls to this function.
+			// Adjust the cursor position by however much an update affects it.
 			if ( $diff->start <= $this->bytes_already_parsed ) {
-				$this->acccumulated_shift += $shift;
+				$this->bytes_already_parsed += $shift;
 			}
 
 			// Accumulate shift of the given pointer within this function call.
@@ -1507,10 +1464,12 @@ class WP_HTML_Tag_Processor {
 				$accumulated_shift_for_given_point += $shift;
 			}
 
-			$this->output_buffer       .= substr( $this->html, $this->bytes_already_copied, $diff->start - $this->bytes_already_copied );
-			$this->output_buffer       .= $diff->text;
-			$this->bytes_already_copied = $diff->end;
+			$output_buffer        .= substr( $this->html, $bytes_already_copied, $diff->start - $bytes_already_copied );
+			$output_buffer        .= $diff->text;
+			$bytes_already_copied  = $diff->end;
 		}
+
+		$this->html = $output_buffer . substr( $this->html, $bytes_already_copied );
 
 		/*
 		 * Adjust bookmark locations to account for how the text
@@ -1603,8 +1562,6 @@ class WP_HTML_Tag_Processor {
 
 		// Point this tag processor before the sought tag opener and consume it.
 		$this->bytes_already_parsed = $this->bookmarks[ $bookmark_name ]->start;
-		$this->bytes_already_copied = $this->bytes_already_parsed;
-		$this->output_buffer        = substr( $this->html, 0, $this->bytes_already_copied );
 		return $this->next_tag( array( 'tag_closers' => 'visit' ) );
 	}
 
@@ -2160,28 +2117,24 @@ class WP_HTML_Tag_Processor {
 		 * When there is nothing more to update and nothing has already been
 		 * updated, return the original document and avoid a string copy.
 		 */
-		if ( $requires_no_updating && 0 === $this->bytes_already_copied ) {
+		if ( $requires_no_updating ) {
 			return $this->html;
 		}
 
 		// Apply the updates, rewind to before the current tag, and reparse the attributes.
-		$start_of_current_tag = strlen( $this->output_buffer ) + ( $this->tag_name_starts_at - $this->bytes_already_copied ) - 1;
+		$before_tag_name = $this->tag_name_starts_at - 1;
 
 		/*
 		 * 1. Apply the edits by flushing them to the output buffer and updating the copied byte count.
-		 *
-		 * Note: `apply_attributes_updates()` modifies `$this->output_buffer`.
 		 */
 		$this->class_name_updates_to_attributes_updates();
-		$start_of_current_tag += $this->apply_attributes_updates( $start_of_current_tag );
+		$shift = $this->apply_attributes_updates( $before_tag_name );
 
 		/*
 		 * 2. Replace the original HTML with the now-updated HTML so that it's possible to
 		 *    seek to a previous location and have a consistent view of the updated document.
 		 */
-		$this->html                 = $this->output_buffer . substr( $this->html, $this->bytes_already_copied );
-		$this->output_buffer        = '';
-		$this->bytes_already_copied = 0;
+//		$this->html = $updated_html;
 
 		/*
 		 * 3. Point this tag processor at the original tag opener and consume it
@@ -2196,9 +2149,12 @@ class WP_HTML_Tag_Processor {
 		 *                 ^  | back up by the length of the tag name plus the opening <
 		 *                 \<-/ back up by strlen("em") + 1 ==> 3
 		 */
-		$this->bytes_already_parsed = $start_of_current_tag;
-		$this->acccumulated_shift   = 0;
+//		$this->bytes_already_parsed = $start_of_current_tag + $current_tag_shift;
+		$pointer = $this->bytes_already_parsed;
+		$this->bytes_already_parsed = $before_tag_name + $shift;
 		$this->next_tag();
+		$this->bytes_already_parsed = $pointer;
+//		$this->bytes_already_parsed = $before;
 
 		return $this->html;
 	}

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -2165,11 +2165,7 @@ class WP_HTML_Tag_Processor {
 		}
 
 		// Apply the updates, rewind to before the current tag, and reparse the attributes.
-		$content_up_to_opened_tag_name = $this->output_buffer . substr(
-			$this->html,
-			$this->bytes_already_copied,
-			$this->tag_name_starts_at + $this->tag_name_length - $this->bytes_already_copied
-		);
+		$start_of_current_tag = strlen( $this->output_buffer ) + ( $this->tag_name_starts_at - $this->bytes_already_copied ) - 1;
 
 		/*
 		 * 1. Apply the edits by flushing them to the output buffer and updating the copied byte count.
@@ -2177,7 +2173,7 @@ class WP_HTML_Tag_Processor {
 		 * Note: `apply_attributes_updates()` modifies `$this->output_buffer`.
 		 */
 		$this->class_name_updates_to_attributes_updates();
-		$tag_adjust = $this->apply_attributes_updates( strlen( $content_up_to_opened_tag_name ) - $this->tag_name_length - 1 );
+		$start_of_current_tag += $this->apply_attributes_updates( $start_of_current_tag );
 
 		/*
 		 * 2. Replace the original HTML with the now-updated HTML so that it's possible to
@@ -2200,8 +2196,8 @@ class WP_HTML_Tag_Processor {
 		 *                 ^  | back up by the length of the tag name plus the opening <
 		 *                 \<-/ back up by strlen("em") + 1 ==> 3
 		 */
-		$this->bytes_already_parsed = strlen( $content_up_to_opened_tag_name ) + $tag_adjust - $this->tag_name_length - 1;
-		$this->acccumulated_shift = 0;
+		$this->bytes_already_parsed = $start_of_current_tag;
+		$this->acccumulated_shift   = 0;
 		$this->next_tag();
 
 		return $this->html;

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1431,7 +1431,7 @@ class WP_HTML_Tag_Processor {
 	 * @param int $shift_this_point Accumulate and return shift for this position.
 	 * @return int How many bytes the given pointer moved in response to the updates.
 	 */
-	private function apply_attributes_updates( $shift_this_point = 0) {
+	private function apply_attributes_updates( $shift_this_point = 0 ) {
 		if ( ! count( $this->lexical_updates ) ) {
 			return 0;
 		}

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -2107,7 +2107,7 @@ class WP_HTML_Tag_Processor {
 	 * Returns the string representation of the HTML Tag Processor.
 	 *
 	 * @since 6.2.0
-	 * @since 6.2.1 Shifts the internal cursor based on updates made before this function call.
+	 * @since 6.2.1 Shifts the internal cursor corresponding to the applied updates.
 	 *
 	 * @return string The processed HTML.
 	 */
@@ -2147,9 +2147,17 @@ class WP_HTML_Tag_Processor {
 		 *                 ^  | back up by the length of the tag name plus the opening <
 		 *                 \<-/ back up by strlen("em") + 1 ==> 3
 		 */
-		$bytes_already_parsed = $this->bytes_already_parsed;
+
+		// Store existing state so it can be restored after reparsing.
+		$bytes_already_parsed       = $this->bytes_already_parsed;
 		$this->bytes_already_parsed = $before_current_tag;
-		$this->next_tag( $this->last_query );
+		$query                      = $this->last_query;
+
+		// Reparse attributes.
+		$this->next_tag();
+
+		// Restore previous state.
+		$this->parse_query( $query );
 		$this->bytes_already_parsed = $bytes_already_parsed;
 
 		return $this->html;

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -2149,16 +2149,16 @@ class WP_HTML_Tag_Processor {
 		 */
 
 		// Store existing state so it can be restored after reparsing.
-		$bytes_already_parsed       = $this->bytes_already_parsed;
-		$this->bytes_already_parsed = $before_current_tag;
-		$query                      = $this->last_query;
+		$previous_parsed_byte_count = $this->bytes_already_parsed;
+		$previous_query             = $this->last_query;
 
 		// Reparse attributes.
+		$this->bytes_already_parsed = $before_current_tag;
 		$this->next_tag();
 
 		// Restore previous state.
-		$this->parse_query( $query );
-		$this->bytes_already_parsed = $bytes_already_parsed;
+		$this->bytes_already_parsed = $previous_parsed_byte_count;
+		$this->parse_query( $previous_query );
 
 		return $this->html;
 	}

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -571,6 +571,25 @@ class Tests_HtmlApi_wpHtmlTagProcessor extends WP_UnitTestCase {
 		$this->assertTrue( $p->next_tag( array( 'tag_closers' => 'visit' ) ), 'Did not find the </title> tag closer when there was no tag opener' );
 	}
 
+	public function test_internal_pointer_returns_to_original_spot_after_inserting_content_before_cursor() {
+		$tags = new WP_HTML_Tag_Processor( '<div>outside</div><section><div><img>inside</div></section>' );
+
+		$tags->next_tag();
+		// Also try 'fooooooo'. This causes the assertion to fail differently.
+		$tags->add_class( 'foooooooo' );
+		$tags->next_tag( 'section' );
+
+		// Return to this spot after moving ahead.
+		$tags->set_bookmark( 'here' );
+
+		// Move ahead.
+		$tags->next_tag( 'img' );
+		$tags->seek( 'here' );
+		$this->assertSame( '<div class="foooooooo">outside</div><section><div><img>inside</div></section>', $tags->get_updated_html() );
+		$this->assertSame( 'SECTION', $tags->get_tag() );
+		$this->assertFalse( $tags->is_tag_closer() );
+	}
+
 	/**
 	 * @ticket 56299
 	 *

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -571,12 +571,19 @@ class Tests_HtmlApi_wpHtmlTagProcessor extends WP_UnitTestCase {
 		$this->assertTrue( $p->next_tag( array( 'tag_closers' => 'visit' ) ), 'Did not find the </title> tag closer when there was no tag opener' );
 	}
 
+	/**
+	 * Verifies that updates to a document before calls to `get_updated_html()` don't
+	 * lead to the Tag Processor jumping to the wrong tag after the updates.
+	 *
+	 * @ticket 58179
+	 *
+	 * @covers WP_HTML_Tag_Processor::get_updated_html
+	 */
 	public function test_internal_pointer_returns_to_original_spot_after_inserting_content_before_cursor() {
 		$tags = new WP_HTML_Tag_Processor( '<div>outside</div><section><div><img>inside</div></section>' );
 
 		$tags->next_tag();
-		// Also try 'fooooooo'. This causes the assertion to fail differently.
-		$tags->add_class( 'foooooooo' );
+		$tags->add_class( 'foo' );
 		$tags->next_tag( 'section' );
 
 		// Return to this spot after moving ahead.
@@ -585,7 +592,7 @@ class Tests_HtmlApi_wpHtmlTagProcessor extends WP_UnitTestCase {
 		// Move ahead.
 		$tags->next_tag( 'img' );
 		$tags->seek( 'here' );
-		$this->assertSame( '<div class="foooooooo">outside</div><section><div><img>inside</div></section>', $tags->get_updated_html() );
+		$this->assertSame( '<div class="foo">outside</div><section><div><img>inside</div></section>', $tags->get_updated_html() );
 		$this->assertSame( 'SECTION', $tags->get_tag() );
 		$this->assertFalse( $tags->is_tag_closer() );
 	}

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -1548,7 +1548,7 @@ HTML;
 HTML;
 
 		$p = new WP_HTML_Tag_Processor( $input );
-		$this->assertTrue( $p->next_tag( 'div' ), 'Querying an existing tag did not return true' );
+		$this->assertTrue( $p->next_tag( 'div' ), 'Did not find first DIV tag in input.' );
 		$p->set_attribute( 'data-details', '{ "key": "value" }' );
 		$p->add_class( 'is-processed' );
 		$this->assertTrue(
@@ -1558,7 +1558,7 @@ HTML;
 					'class_name' => 'BtnGroup',
 				)
 			),
-			'Querying an existing tag did not return true'
+			'Did not find the first BtnGroup DIV tag'
 		);
 		$p->remove_class( 'BtnGroup' );
 		$p->add_class( 'button-group' );
@@ -1570,7 +1570,7 @@ HTML;
 					'class_name' => 'BtnGroup',
 				)
 			),
-			'Querying an existing tag did not return true'
+			'Did not find the second BtnGroup DIV tag'
 		);
 		$p->remove_class( 'BtnGroup' );
 		$p->add_class( 'button-group' );
@@ -1583,10 +1583,10 @@ HTML;
 					'match_offset' => 3,
 				)
 			),
-			'Querying an existing tag did not return true'
+			'Did not find third BUTTON tag with "btn" CSS class'
 		);
 		$p->remove_attribute( 'class' );
-		$this->assertFalse( $p->next_tag( 'non-existent' ), 'Querying a non-existing tag did not return false' );
+		$this->assertFalse( $p->next_tag( 'non-existent' ), "Found a {$p->get_tag()} tag when none should have been found." );
 		$p->set_attribute( 'class', 'test' );
 		$this->assertSame( $expected_output, $p->get_updated_html(), 'Calling get_updated_html after updating the attributes did not return the expected HTML' );
 	}


### PR DESCRIPTION
Trac [#58179-ticket](https://core.trac.wordpress.org/ticket/58179#ticket)

While working on WordPress/block-interactivity-experiments#141 @ockham discovered that the Tag Processor was making a small mistake. After making some updates the parser wasn't returning to the start of the affected tag. A test case was created in #4355.

In few words, the Tag Processor has not been treating its own internal pointer `bytes_already_parsed` the same way it treats its bookmarks. That is, when updates are applied to the input document and then `get_updated_html()` is called, the internal pointer transfers to the newly-updated content as if no updates had been applied since the previous call to `get_updated_html()`.

In this patch we're refactoring how the Tag Processor applies enqueued changes. Previously there was a two-step process of appending updates into its `$this->output_buffer` and maintaining a tracker `$this->bytes_already_copied` for how much of the input HTML had already been copied into the output buffer, and then of flushing everything into the buffer and then swapping it into the new "input HTML" so the processor can restart with all the updates applied. Now the two-step process has been collapsed into one step and the buffering process has been removed from the class. After every `next_tag()` invocation the entire set of enqueued changes is flushed into the updated HTML and then the internal cursor is adjusted and reset to point into the updated HTML into the same spot it was pointing in the original input.