### PR TITLE
FIX: Remove param from wp_get_session_token call

### DIFF
--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -2359,7 +2359,7 @@ if ( ! function_exists( 'wp_create_nonce' ) ) :
 			$uid = apply_filters( 'nonce_user_logged_out', $uid, $action );
 		}
 
-		$token = wp_get_session_token( $action );
+		$token = wp_get_session_token();
 		$i     = wp_nonce_tick( $action );
 
 		return substr( wp_hash( $i . '|' . $action . '|' . $uid . '|' . $token, 'nonce' ), -12, 10 );


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/58181

**Description:**
In [[54218]](https://core.trac.wordpress.org/changeset/54218) / [#35188](https://core.trac.wordpress.org/ticket/35188) $action was accidentally passed to wp_get_session_token(). This function doesn't accept any parameters.
In this PR, I have removed it to avoid consequences.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
