### PR TITLE
58183 warning unregistered widget panel

### DIFF
--- a/src/wp-includes/class-wp-customize-widgets.php
+++ b/src/wp-includes/class-wp-customize-widgets.php
@@ -421,7 +421,6 @@ final class WP_Customize_Widgets {
 				'priority'                 => 110,
 				'active_callback'          => array( $this, 'is_panel_active' ),
 				'auto_expand_sole_section' => true,
-				'theme_supports'           => 'widgets',
 			)
 		);
 

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -4265,7 +4265,7 @@ function _add_default_theme_supports() {
 	add_filter( 'should_load_separate_core_block_assets', '__return_true' );
 
 	/*
-	 * Remove the Customizer's Menus panel when block theme is active.
+	 * Remove the Customizer's Menus and Widgets panels when block theme is active.
 	 */
 	add_filter(
 		'customize_panel_active',
@@ -4273,6 +4273,12 @@ function _add_default_theme_supports() {
 			if (
 				'nav_menus' === $panel->id &&
 				! current_theme_supports( 'menus' ) &&
+				! current_theme_supports( 'widgets' )
+			) {
+				$active = false;
+			}
+			if (
+				'widgets' === $panel->id &&
 				! current_theme_supports( 'widgets' )
 			) {
 				$active = false;


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Hide instead of remove the widget panel to prevent PHP warning in classic themes.

Trac ticket: https://core.trac.wordpress.org/ticket/58183#comment:5

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
