### PR TITLE
add Rollback help tab

### DIFF
--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -1021,7 +1021,7 @@ if ( current_user_can( 'update_themes' ) || current_user_can( 'update_plugins' )
 	get_current_screen()->add_help_tab(
 		array(
 			'id'      => 'rollback-plugins-themes',
-			'title'   => __( 'Rollback' ),
+			'title'   => __( 'Restore Plugin or Theme' ),
 			'content' => $rollback_help,
 		)
 	);

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -1014,7 +1014,7 @@ if ( ( current_user_can( 'update_themes' ) && wp_is_auto_update_enabled_for_type
 $help_sidebar_rollback = '';
 
 if ( current_user_can( 'update_themes' ) || current_user_can( 'update_plugins' ) ) {
-	$rollback_help = '<p>' . __( 'Rollback is a feature that will create a temporary backup of a plugin or theme before it is upgraded. This backup is used to restore the plugin or theme back to its previous state if there is an error during the update process.' ) . '</p>';
+	$rollback_help = '<p>' . __( 'This feature will create a temporary backup of a plugin or theme before it is upgraded. This backup is used to restore the plugin or theme back to its previous state if there is an error during the update process.' ) . '</p>';
 
 	$rollback_help .= '<p>' . __( 'On systems with fewer resources, this may lead to server timeouts or resource limits being reached. If you encounter an issue during the update process, please create a support forum ticket and reference <strong>Rollback</strong> in the issue title.' ) . '</p>';
 

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -1047,6 +1047,7 @@ if ( 'upgrade-core' === $action ) {
 	<div class="wrap">
 	<h1><?php _e( 'WordPress Updates' ); ?></h1>
 	<p><?php _e( 'Here you can find information about updates, set auto-updates and see what plugins or themes need updating.' ); ?></p>
+	<p><?php _e( 'If there seems to be very slow plugin or theme update times, or errors, please refer to the <strong>Rollback</strong> Help section above.' ); ?></p>
 
 	<?php
 	if ( $upgrade_error ) {

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -1011,8 +1011,10 @@ if ( ( current_user_can( 'update_themes' ) && wp_is_auto_update_enabled_for_type
 	$help_sidebar_autoupdates = '<p>' . __( '<a href="https://wordpress.org/documentation/article/plugins-themes-auto-updates/">Documentation on Auto-updates</a>' ) . '</p>';
 }
 
+$help_sidebar_rollback = '';
+
 if ( current_user_can( 'update_themes' ) || current_user_can( 'update_plugins' ) ) {
-	$rollback_help = '<p>' . __( 'Rollback is a feature that will create temporary backups of your plugin and theme. These backups are used to restore your plugin or theme back to its previous state if there is an error during the update process.' ) . '</p>';
+	$rollback_help = '<p>' . __( 'Rollback is a feature that will create a temporary backup of a plugin or theme before it is upgraded. This backup is used to restore the plugin or theme back to its previous state if there is an error during the update process.' ) . '</p>';
 
 	$rollback_help .= '<p>' . __( 'On systems with fewer resources, this may lead to server timeouts or resource limits being reached. If you encounter an issue during the update process, please create a support forum ticket and reference <strong>Rollback</strong> in the issue title.' ) . '</p>';
 
@@ -1023,13 +1025,16 @@ if ( current_user_can( 'update_themes' ) || current_user_can( 'update_plugins' )
 			'content' => $rollback_help,
 		)
 	);
+
+	$help_sidebar_rollback = '<p>' . __( '<a href="https://wordpress.org/documentation/article/common-wordpress-errors/">Common Errors</a>' ) . '</p>';
 }
 
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __( 'For more information:' ) . '</strong></p>' .
 	'<p>' . __( '<a href="https://wordpress.org/documentation/article/dashboard-updates-screen/">Documentation on Updating WordPress</a>' ) . '</p>' .
 	$help_sidebar_autoupdates .
-	'<p>' . __( '<a href="https://wordpress.org/support/forums/">Support forums</a>' ) . '</p>'
+	'<p>' . __( '<a href="https://wordpress.org/support/forums/">Support forums</a>' ) . '</p>' .
+	$help_sidebar_rollback
 );
 
 if ( 'upgrade-core' === $action ) {

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -1011,6 +1011,20 @@ if ( ( current_user_can( 'update_themes' ) && wp_is_auto_update_enabled_for_type
 	$help_sidebar_autoupdates = '<p>' . __( '<a href="https://wordpress.org/documentation/article/plugins-themes-auto-updates/">Documentation on Auto-updates</a>' ) . '</p>';
 }
 
+if ( current_user_can( 'update_themes' ) || current_user_can( 'update_plugins' ) ) {
+	$rollback_help = '<p>' . __( 'Rollback is a feature that will create temporary backups of your plugin and theme. These backups are used to restore your plugin or theme back to its previous state if there is an error during the update process.' ) . '</p>';
+
+	$rollback_help .= '<p>' . __( 'On systems with fewer resources, this may lead to server timeouts or resource limits being reached. If you encounter an issue during the update process, please create a support forum ticket and reference <strong>Rollback</strong> in the issue title.' ) . '</p>';
+
+	get_current_screen()->add_help_tab(
+		array(
+			'id'      => 'rollback-plugins-themes',
+			'title'   => __( 'Rollback' ),
+			'content' => $rollback_help,
+		)
+	);
+}
+
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __( 'For more information:' ) . '</strong></p>' .
 	'<p>' . __( '<a href="https://wordpress.org/documentation/article/dashboard-updates-screen/">Documentation on Updating WordPress</a>' ) . '</p>' .

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -1047,7 +1047,7 @@ if ( 'upgrade-core' === $action ) {
 	<div class="wrap">
 	<h1><?php _e( 'WordPress Updates' ); ?></h1>
 	<p><?php _e( 'Here you can find information about updates, set auto-updates and see what plugins or themes need updating.' ); ?></p>
-	<p><?php _e( 'If there seems to be very slow plugin or theme update times, or errors, please refer to the <strong>Rollback</strong> Help section above.' ); ?></p>
+	<p><?php _e( 'Updates may take several minutes to complete. If there is no feedback after 5 minutes, or if there are errors please refer to the Help section above.' ); ?></p>
 
 	<?php
 	if ( $upgrade_error ) {


### PR DESCRIPTION
<!-- Insert a description of your changes here -->
In preparation for Rollback [PR 2225](https://github.com/WordPress/wordpress-develop/pull/2225) being committed, @azaozz suggested the creation of a help/description of Rollback for users that might encounter a problem. This is an attempt to satisfy that documentation.

Trac ticket: https://core.trac.wordpress.org/ticket/58199

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
