### PR TITLE
Fix typo in class comment.

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-pattern-categories-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-pattern-categories-controller.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * REST API: WP_REST_Block_Pattern_Catergories_Controller class
+ * REST API: WP_REST_Block_Pattern_Categories_Controller class
  *
  * @package    WordPress
  * @subpackage REST_API


### PR DESCRIPTION
The class comment of the `WP_REST_Block_Pattern_Categories_Controller` has a typo.

Trac ticket: https://core.trac.wordpress.org/ticket/58204

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
