### PR TITLE
Docs: describe return type of `_get_block_template_file()`.

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -259,7 +259,7 @@ function _get_block_templates_paths( $base_directory ) {
  *    @type string $type      Template type.
  *    @type string $title     Optional. Template title.
  *    @type string $area      Template area. Only for 'wp_template_part'.
- *    @type array  $postTypes List of post types that the template supports. Optional. Only for 'wp_template'.
+ *    @type array  $postTypes Optional. List of post types that the template supports. Only for 'wp_template'.
  * }
  */
 function _get_block_template_file( $template_type, $slug ) {

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -253,12 +253,12 @@ function _get_block_templates_paths( $base_directory ) {
  *    Array with template metadata if $template_type is one of 'wp_template' or 'wp_template_part'.
  *    null otherwise.
  *
- *    @type string $slug      Template slug.
- *    @type string $path      Template file path.
- *    @type string $theme     Theme slug.
- *    @type string $type      Template type.
- *    @type string $title     Optional. Template title.
- *    @type string $area      Template area. Only for 'wp_template_part'.
+ *    @type string   $slug      Template slug.
+ *    @type string   $path      Template file path.
+ *    @type string   $theme     Theme slug.
+ *    @type string   $type      Template type.
+ *    @type string   $area      Template area. Only for 'wp_template_part'.
+ *    @type string   $title     Optional. Template title.
  *    @type string[] $postTypes Optional. List of post types that the template supports. Only for 'wp_template'.
  * }
  */

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -259,7 +259,7 @@ function _get_block_templates_paths( $base_directory ) {
  *    @type string $type      Template type.
  *    @type string $title     Optional. Template title.
  *    @type string $area      Template area. Only for 'wp_template_part'.
- *    @type array  $postTypes Optional. List of post types that the template supports. Only for 'wp_template'.
+ *    @type string[] $postTypes Optional. List of post types that the template supports. Only for 'wp_template'.
  * }
  */
 function _get_block_template_file( $template_type, $slug ) {

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -257,7 +257,7 @@ function _get_block_templates_paths( $base_directory ) {
  *    @type string $path      Template file path.
  *    @type string $theme     Theme slug.
  *    @type string $type      Template type.
- *    @type string $title     Template title. Optional.
+ *    @type string $title     Optional. Template title.
  *    @type string $area      Template area. Only for 'wp_template_part'.
  *    @type array  $postTypes List of post types that the template supports. Optional. Only for 'wp_template'.
  * }

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -250,8 +250,8 @@ function _get_block_templates_paths( $base_directory ) {
  * @param string $template_type 'wp_template' or 'wp_template_part'.
  * @param string $slug          Template slug.
  * @return array|null {
- *     Array with template metadata if $template_type is one of 'wp_template' or 'wp_template_part'.
- *     Otherwise, it's null.
+ *    Array with template metadata if $template_type is one of 'wp_template' or 'wp_template_part'.
+ *    null otherwise.
  *
  *    @type string $slug      Template slug.
  *    @type string $path      Template file path.

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -249,7 +249,18 @@ function _get_block_templates_paths( $base_directory ) {
  *
  * @param string $template_type 'wp_template' or 'wp_template_part'.
  * @param string $slug          Template slug.
- * @return array|null Template.
+ * @return array|null {
+ *     Array with template metadata if $template_type is one of 'wp_template' or 'wp_template_part'.
+ *     Otherwise, it's null.
+ *
+ *    @type string $slug      Template slug.
+ *    @type string $path      Template file path.
+ *    @type string $theme     Theme slug.
+ *    @type string $type      Template type.
+ *    @type string $title     Template title. Optional.
+ *    @type string $area      Template area. Only for 'wp_template_part'.
+ *    @type array  $postTypes List of post types that the template supports. Optional. Only for 'wp_template'.
+ * }
  */
 function _get_block_template_file( $template_type, $slug ) {
 	if ( 'wp_template' !== $template_type && 'wp_template_part' !== $template_type ) {
@@ -357,16 +368,6 @@ function _get_block_templates_files( $template_type, $query = array() ) {
 			);
 
 			if ( 'wp_template_part' === $template_type ) {
-				/*
-				 * Structure of a wp_template_part item:
-				 *
-				 * - slug
-				 * - path
-				 * - theme
-				 * - type
-				 * - area
-				 * - title (optional)
-				 */
 				$candidate = _add_block_template_part_area_info( $new_template_item );
 				if ( ! isset( $area ) || ( isset( $area ) && $area === $candidate['area'] ) ) {
 					$template_files[] = $candidate;
@@ -374,16 +375,6 @@ function _get_block_templates_files( $template_type, $query = array() ) {
 			}
 
 			if ( 'wp_template' === $template_type ) {
-				/*
-				 * Structure of a wp_template item:
-				 *
-				 * - slug
-				 * - path
-				 * - theme
-				 * - type
-				 * - title (optional)
-				 * - postTypes (optional)
-				 */
 				$candidate = _add_block_template_info( $new_template_item );
 				if (
 					! $post_type ||


### PR DESCRIPTION
It was brought up at https://core.trac.wordpress.org/ticket/57756#comment:16 that some inline comments introduced at https://github.com/WordPress/wordpress-develop/pull/4097 could be graduated to a PHP DocBlock for better maintenance: use single place for documenting them as well as enable the existing automated docs to pick them up.

This PR removes the inline comments and makes them part of the `_get_block_template_file()`.

---

SVN commit message:

```txt
Docs: describe return type of `_get_block_template_file()`.

Props: desrosj, mukesh27, costdev, johnbillion.
Fixes #57756.
```
