### PR TITLE
Fix for issue #58194

### DIFF
--- a/src/wp-admin/includes/class-wp-users-list-table.php
+++ b/src/wp-admin/includes/class-wp-users-list-table.php
@@ -499,9 +499,11 @@ class WP_Users_List_Table extends WP_List_Table {
 				);
 			}
 
-			// Add a link to send the user a reset password link by email if the user is allowed to get his password reset.
-			$allow = apply_filters( 'allow_password_reset', true, $user_object->ID );
-			if ( true === $allow
+			/** This filter is documented in src/wp-includes/user.php */
+			$allow_password_reset = apply_filters( 'allow_password_reset', true, $user_object->ID );
+
+			// If passwords are allowed to be reset, add a link to send the user a reset password link by email.
+			if ( true === $allow_password_reset
 				&& get_current_user_id() !== $user_object->ID
 				&& current_user_can( 'edit_user', $user_object->ID )
 			) {

--- a/src/wp-admin/includes/class-wp-users-list-table.php
+++ b/src/wp-admin/includes/class-wp-users-list-table.php
@@ -501,7 +501,7 @@ class WP_Users_List_Table extends WP_List_Table {
 
 			// Add a link to send the user a reset password link by email if the user is allowed to get his password reset.
 			$allow = apply_filters( 'allow_password_reset', true, $user_object->ID );
-			if ( $allow === true 
+			if ( $allow === true
 				&& get_current_user_id() !== $user_object->ID
 				&& current_user_can( 'edit_user', $user_object->ID )
 			) {

--- a/src/wp-admin/includes/class-wp-users-list-table.php
+++ b/src/wp-admin/includes/class-wp-users-list-table.php
@@ -501,7 +501,7 @@ class WP_Users_List_Table extends WP_List_Table {
 
 			// Add a link to send the user a reset password link by email if the user is allowed to get his password reset.
 			$allow = apply_filters( 'allow_password_reset', true, $user_object->ID );
-			if ( $allow === true
+			if ( true === $allow
 				&& get_current_user_id() !== $user_object->ID
 				&& current_user_can( 'edit_user', $user_object->ID )
 			) {

--- a/src/wp-admin/includes/class-wp-users-list-table.php
+++ b/src/wp-admin/includes/class-wp-users-list-table.php
@@ -499,8 +499,10 @@ class WP_Users_List_Table extends WP_List_Table {
 				);
 			}
 
-			// Add a link to send the user a reset password link by email.
-			if ( get_current_user_id() !== $user_object->ID
+			// Add a link to send the user a reset password link by email if the user is allowed to get his password reset.
+			$allow = apply_filters( 'allow_password_reset', true, $user_object->ID );
+			if ( $allow === true 
+				&& get_current_user_id() !== $user_object->ID
 				&& current_user_can( 'edit_user', $user_object->ID )
 			) {
 				$actions['resetpassword'] = "<a class='resetpassword' href='" . wp_nonce_url( "users.php?action=resetpassword&amp;users=$user_object->ID", 'bulk-users' ) . "'>" . __( 'Send password reset' ) . '</a>';


### PR DESCRIPTION
If the [allow_password_reset](https://developer.wordpress.org/reference/hooks/allow_password_reset/) filter is set to false, the admin panel still shows the `Send Password reset`, even though this does nothing. This PR adds a check to see if the filter is set to false and if it is set to false it does not show the button.

See: https://core.trac.wordpress.org/ticket/58194