### PR TITLE
Unused local variable `$parent_post_type` in `class-wp-rest-revisions-controller.php`

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
@@ -410,8 +410,6 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 			return $parent;
 		}
 
-		$parent_post_type = get_post_type_object( $parent->post_type );
-
 		if ( ! current_user_can( 'delete_post', $parent->ID ) ) {
 			return new WP_Error(
 				'rest_cannot_delete',


### PR DESCRIPTION
Removes unused local variable '$parent_post_type'. The value of the variable is not used anywhere.

Trac ticket: https://core.trac.wordpress.org/ticket/58218

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
