### PR TITLE
Fix fatal error triggered by `?taxonomy[]=term` URLs for hierarchical taxonomies

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -1167,7 +1167,11 @@ class WP_Query {
 				);
 
 				if ( ! empty( $t->rewrite['hierarchical'] ) ) {
-					$q[ $t->query_var ] = wp_basename( $q[ $t->query_var ] );
+					if ( is_array( $q[ $t->query_var ] ) ) {
+						$q[ $t->query_var ] = array_map( 'wp_basename', $q[ $t->query_var ] );
+					} else {
+						$q[ $t->query_var ] = wp_basename( $q[ $t->query_var ] );
+					}
 				}
 
 				$term = $q[ $t->query_var ];


### PR DESCRIPTION
When accessing a URL with a taxonomy slug URL parameter using array format (such as `?product_cat[]=accessories`), a fatal error is triggered if the related taxonomy rewrite is hierarchical.
For example, visiting the default WooCommerce `/shop` page with multiple `product_cat[]=…` query args will trigger this error.

Trac ticket: [https://core.trac.wordpress.org/ticket/57300](https://core.trac.wordpress.org/ticket/57300)

---

**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
