### PR TITLE
Cast (int) $cron->time - time() to prevent String - int error

### DIFF
--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -2799,7 +2799,7 @@ class WP_Site_Health {
 		}
 
 		foreach ( $this->crons as $id => $cron ) {
-			if ( ( $cron->time - time() ) < $this->timeout_missed_cron ) {
+			if ( ( (int) $cron->time - time() ) < $this->timeout_missed_cron ) {
 				$this->last_missed_cron = $cron->hook;
 				return true;
 			}
@@ -2825,7 +2825,7 @@ class WP_Site_Health {
 		}
 
 		foreach ( $this->crons as $id => $cron ) {
-			$cron_offset = $cron->time - time();
+			$cron_offset = (int) $cron->time - time();
 			if (
 				$cron_offset >= $this->timeout_missed_cron &&
 				$cron_offset < $this->timeout_late_cron


### PR DESCRIPTION
On line 2802 and 2828 of wp-admin/includes/class-wp-site-health.php, $cron->time - time() is not automatically cast by PHP version 8.1.2 from the String $cron->time to an integer to perform the arithmetic. Forcing the cast with (int) $cron->time - time() corrects the critical error, detailed below, that prevented the site health dashboard from loading.

2023-04-28T16:27:37+00:00 CRITICAL Uncaught TypeError: Unsupported operand types: string - int in /var/www/toddlahman.com/wp-admin/includes/class-wp-site-health.php:2802
Stack trace:
#0 /var/www/toddlahman.com/wp-admin/includes/class-wp-site-health.php(1768): WP_Site_Health->has_missed_cron()
#1 /var/www/toddlahman.com/wp-admin/includes/class-wp-site-health.php(194): WP_Site_Health->get_test_scheduled_events()
#2 /var/www/toddlahman.com/wp-admin/includes/class-wp-site-health.php(139): WP_Site_Health->perform_test()
#3 /var/www/toddlahman.com/wp-includes/class-wp-hook.php(308): WP_Site_Health->enqueue_scripts()
#4 /var/www/toddlahman.com/wp-includes/class-wp-hook.php(332): WP_Hook->apply_filters()
#5 /var/www/toddlahman.com/wp-includes/plugin.php(517): WP_Hook->do_action()
#6 /var/www/toddlahman.com/wp-admin/admin-header.php(118): do_action()
#7 /var/www/toddlahman.com/wp-admin/site-health.php(96): require_once('...')
#8 {main}
  thrown in /var/www/toddlahman.com/wp-admin/includes/class-wp-site-health.php on line 2802

Trac ticket: [#58221](https://core.trac.wordpress.org/ticket/58221)
