### PR TITLE
Update sodium_compat to 1.20.0.

### DIFF
--- a/src/wp-includes/sodium_compat/LICENSE
+++ b/src/wp-includes/sodium_compat/LICENSE
@@ -1,6 +1,6 @@
 ISC License
 
-Copyright (c) 2016-2022, Paragon Initiative Enterprises <security at paragonie dot com>
+Copyright (c) 2016-2023, Paragon Initiative Enterprises <security at paragonie dot com>
 Copyright (c) 2013-2019, Frank Denis <j at pureftpd dot org>
 
 Permission to use, copy, modify, and/or distribute this software for any

--- a/src/wp-includes/sodium_compat/lib/php72compat.php
+++ b/src/wp-includes/sodium_compat/lib/php72compat.php
@@ -1360,6 +1360,8 @@ if (!is_callable('sodium_memzero')) {
      * @return void
      * @throws SodiumException
      * @throws TypeError
+     *
+     * @psalm-suppress ReferenceConstraintViolation
      */
     function sodium_memzero(&$string)
     {

--- a/src/wp-includes/sodium_compat/src/Core/Poly1305/State.php
+++ b/src/wp-includes/sodium_compat/src/Core/Poly1305/State.php
@@ -210,43 +210,43 @@ class ParagonIE_Sodium_Core_Poly1305_State extends ParagonIE_Sodium_Core_Util
 
             /* h *= r */
             $d0 = (
-                self::mul($h0, $r0, 25) +
-                self::mul($s4, $h1, 26) +
-                self::mul($s3, $h2, 26) +
-                self::mul($s2, $h3, 26) +
-                self::mul($s1, $h4, 26)
+                self::mul($h0, $r0, 27) +
+                self::mul($s4, $h1, 27) +
+                self::mul($s3, $h2, 27) +
+                self::mul($s2, $h3, 27) +
+                self::mul($s1, $h4, 27)
             );
 
             $d1 = (
-                self::mul($h0, $r1, 25) +
-                self::mul($h1, $r0, 25) +
-                self::mul($s4, $h2, 26) +
-                self::mul($s3, $h3, 26) +
-                self::mul($s2, $h4, 26)
+                self::mul($h0, $r1, 27) +
+                self::mul($h1, $r0, 27) +
+                self::mul($s4, $h2, 27) +
+                self::mul($s3, $h3, 27) +
+                self::mul($s2, $h4, 27)
             );
 
             $d2 = (
-                self::mul($h0, $r2, 25) +
-                self::mul($h1, $r1, 25) +
-                self::mul($h2, $r0, 25) +
-                self::mul($s4, $h3, 26) +
-                self::mul($s3, $h4, 26)
+                self::mul($h0, $r2, 27) +
+                self::mul($h1, $r1, 27) +
+                self::mul($h2, $r0, 27) +
+                self::mul($s4, $h3, 27) +
+                self::mul($s3, $h4, 27)
             );
 
             $d3 = (
-                self::mul($h0, $r3, 25) +
-                self::mul($h1, $r2, 25) +
-                self::mul($h2, $r1, 25) +
-                self::mul($h3, $r0, 25) +
-                self::mul($s4, $h4, 26)
+                self::mul($h0, $r3, 27) +
+                self::mul($h1, $r2, 27) +
+                self::mul($h2, $r1, 27) +
+                self::mul($h3, $r0, 27) +
+                self::mul($s4, $h4, 27)
             );
 
             $d4 = (
-                self::mul($h0, $r4, 25) +
-                self::mul($h1, $r3, 25) +
-                self::mul($h2, $r2, 25) +
-                self::mul($h3, $r1, 25) +
-                self::mul($h4, $r0, 25)
+                self::mul($h0, $r4, 27) +
+                self::mul($h1, $r3, 27) +
+                self::mul($h2, $r2, 27) +
+                self::mul($h3, $r1, 27) +
+                self::mul($h4, $r0, 27)
             );
 
             /* (partial) h %= p */

--- a/src/wp-includes/sodium_compat/src/Core32/Poly1305/State.php
+++ b/src/wp-includes/sodium_compat/src/Core32/Poly1305/State.php
@@ -255,39 +255,39 @@ class ParagonIE_Sodium_Core32_Poly1305_State extends ParagonIE_Sodium_Core32_Uti
 
             /* h *= r */
             $d0 = $zero
-                ->addInt64($h0->mulInt64($r0, 25))
-                ->addInt64($s4->mulInt64($h1, 26))
-                ->addInt64($s3->mulInt64($h2, 26))
-                ->addInt64($s2->mulInt64($h3, 26))
-                ->addInt64($s1->mulInt64($h4, 26));
+                ->addInt64($h0->mulInt64($r0, 27))
+                ->addInt64($s4->mulInt64($h1, 27))
+                ->addInt64($s3->mulInt64($h2, 27))
+                ->addInt64($s2->mulInt64($h3, 27))
+                ->addInt64($s1->mulInt64($h4, 27));
 
             $d1 = $zero
-                ->addInt64($h0->mulInt64($r1, 25))
-                ->addInt64($h1->mulInt64($r0, 25))
-                ->addInt64($s4->mulInt64($h2, 26))
-                ->addInt64($s3->mulInt64($h3, 26))
-                ->addInt64($s2->mulInt64($h4, 26));
+                ->addInt64($h0->mulInt64($r1, 27))
+                ->addInt64($h1->mulInt64($r0, 27))
+                ->addInt64($s4->mulInt64($h2, 27))
+                ->addInt64($s3->mulInt64($h3, 27))
+                ->addInt64($s2->mulInt64($h4, 27));
 
             $d2 = $zero
-                ->addInt64($h0->mulInt64($r2, 25))
-                ->addInt64($h1->mulInt64($r1, 25))
-                ->addInt64($h2->mulInt64($r0, 25))
-                ->addInt64($s4->mulInt64($h3, 26))
-                ->addInt64($s3->mulInt64($h4, 26));
+                ->addInt64($h0->mulInt64($r2, 27))
+                ->addInt64($h1->mulInt64($r1, 27))
+                ->addInt64($h2->mulInt64($r0, 27))
+                ->addInt64($s4->mulInt64($h3, 27))
+                ->addInt64($s3->mulInt64($h4, 27));
 
             $d3 = $zero
-                ->addInt64($h0->mulInt64($r3, 25))
-                ->addInt64($h1->mulInt64($r2, 25))
-                ->addInt64($h2->mulInt64($r1, 25))
-                ->addInt64($h3->mulInt64($r0, 25))
-                ->addInt64($s4->mulInt64($h4, 26));
+                ->addInt64($h0->mulInt64($r3, 27))
+                ->addInt64($h1->mulInt64($r2, 27))
+                ->addInt64($h2->mulInt64($r1, 27))
+                ->addInt64($h3->mulInt64($r0, 27))
+                ->addInt64($s4->mulInt64($h4, 27));
 
             $d4 = $zero
-                ->addInt64($h0->mulInt64($r4, 25))
-                ->addInt64($h1->mulInt64($r3, 25))
-                ->addInt64($h2->mulInt64($r2, 25))
-                ->addInt64($h3->mulInt64($r1, 25))
-                ->addInt64($h4->mulInt64($r0, 25));
+                ->addInt64($h0->mulInt64($r4, 27))
+                ->addInt64($h1->mulInt64($r3, 27))
+                ->addInt64($h2->mulInt64($r2, 27))
+                ->addInt64($h3->mulInt64($r1, 27))
+                ->addInt64($h4->mulInt64($r0, 27));
 
             /* (partial) h %= p */
             $c = $d0->shiftRight(26);


### PR DESCRIPTION
The latest version of sodium_compat includes a fix for the Poly1305 implementation.

Release Notes:
https://github.com/paragonie/sodium_compat/releases/tag/v1.20.0

A full list of changes in this update can be found on GitHub:
https://github.com/paragonie/sodium_compat/compare/v1.19.0...v1.20.0

Trac ticket: https://core.trac.wordpress.org/ticket/58224