### PR TITLE
#58171 Twenty Nineteen: The pullquote block appears to have a problem…

### DIFF
--- a/src/wp-content/themes/twentynineteen/style-editor.css
+++ b/src/wp-content/themes/twentynineteen/style-editor.css
@@ -1078,8 +1078,8 @@ figcaption,
   word-break: break-word;
 }
 
-.wp-block-pullquote:not(.is-style-solid-color) .wp-block-pullquote__citation {
-  color: #767676;
+.wp-block-pullquote blockquote p {
+	color: inherit;
 }
 
 .wp-block-pullquote.is-style-solid-color blockquote {


### PR DESCRIPTION
## Twenty Nineteen: The pullquote block appears to have a problem when selecting the text color. Fixed

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Pullqoute block has an issue with selecting a color. Fixed this issue with a change of some CSS code.

Image1: https://prnt.sc/-SUk4prZKz9F
Image2: https://prnt.sc/-QS5Ty-nLmPP
Image3: https://prnt.sc/C2F-qsPDM0Bp

Trac ticket: https://core.trac.wordpress.org/ticket/58171
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
