### PR TITLE
HTML API: Explore deferring attribute name allocations until needed

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-attribute-token.php
+++ b/src/wp-includes/html-api/class-wp-html-attribute-token.php
@@ -22,9 +22,9 @@ class WP_HTML_Attribute_Token {
 	 * Attribute name.
 	 *
 	 * @since 6.2.0
-	 * @var string
+	 * @var int
 	 */
-	public $name;
+	public $name_length;
 
 	/**
 	 * Attribute value.
@@ -71,15 +71,14 @@ class WP_HTML_Attribute_Token {
 	 *
 	 * @since 6.2.0
 	 *
-	 * @param string $name         Attribute name.
 	 * @param int    $value_start  Attribute value.
 	 * @param int    $value_length Number of bytes attribute value spans.
 	 * @param int    $start        The string offset where the attribute name starts.
 	 * @param int    $end          The string offset after the attribute value or its name.
 	 * @param bool   $is_true      Whether the attribute is a boolean attribute with true value.
 	 */
-	public function __construct( $name, $value_start, $value_length, $start, $end, $is_true ) {
-		$this->name            = $name;
+	public function __construct( $name_length, $value_start, $value_length, $start, $end, $is_true ) {
+		$this->name_length     = $name_length;
 		$this->value_starts_at = $value_start;
 		$this->value_length    = $value_length;
 		$this->start           = $start;


### PR DESCRIPTION
**Creating and closing this for perpetuity sake**

Inspired by a C port of the Tag Processor I wanted to experiment with the idea of deferring the allocation of strings for the parsed attribute names until and unless they are needed.

Effectively this means storing only the starting and ending string index at which the names are found instead of storing the names themselves as strings.

While not all tests are passing in this patch, the idea was built soundly and those tests are solvable with a little more code.

Unfortunately the Tag Processor appears to run around 4% slower in this branch withs its indices than in the `trunk` branch with its allocations. While not obvbious why it's slower that's a non-starter for the optimization.

To try and investigate further, I added a static allocation for the "class" attribute under the idea that associative arrays might be the reason for the slowness. So I created `$this->attr_class` which should make for near instant lookup of the "class" attribute, but it didn't impact speed at all.

I have thought that if we can trap the most common set of attributes as static properties then we might be able to avoid arrays in most tags. That _may_ have a measurable speedup, but right now with only `class` it's non-conclusive.