### PR TITLE
Return empty array when `template` and `stylesheet` are empty

### DIFF
--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -948,6 +948,10 @@ function wp_get_active_and_valid_themes() {
 		return $themes;
 	}
 
+	if ( ! get_template() && ! get_stylesheet() ) {
+		return $themes;
+	}
+
 	if ( TEMPLATEPATH !== STYLESHEETPATH ) {
 		$themes[] = STYLESHEETPATH;
 	}


### PR DESCRIPTION
See https://core.trac.wordpress.org/ticket/57928

Returns an empty array from `wp_get_active_and_valid_themes()` when `get_template()` and `get_stylesheet()` return falsy values. The empty array prevents `wp-content/themes/functions.php` from being loaded erroneously.