### PR TITLE
Return empty array when not using themes

### DIFF
--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -948,6 +948,10 @@ function wp_get_active_and_valid_themes() {
 		return $themes;
 	}
 
+	if ( ! wp_using_themes() ) {
+		return $themes;
+	}
+
 	if ( TEMPLATEPATH !== STYLESHEETPATH ) {
 		$themes[] = STYLESHEETPATH;
 	}

--- a/tests/phpunit/includes/bootstrap.php
+++ b/tests/phpunit/includes/bootstrap.php
@@ -252,6 +252,7 @@ $phpmailer = new MockPHPMailer( true );
 if ( ! defined( 'WP_DEFAULT_THEME' ) ) {
 	define( 'WP_DEFAULT_THEME', 'default' );
 }
+define( 'WP_USE_THEMES', true );
 $wp_theme_directories = array();
 
 if ( file_exists( DIR_TESTDATA . '/themedir1' ) ) {

--- a/tests/phpunit/tests/load/wpGetActiveAndValidThemes.php
+++ b/tests/phpunit/tests/load/wpGetActiveAndValidThemes.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Tests for wp_get_active_and_valid_themes().
+ *
+ * @group load.php
+ * @covers ::wp_get_active_and_valid_themes
+ */
+class Tests_Load_WpGetActiveAndValidThemes extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 19898
+	 */
+	public function test_wp_get_active_and_valid_themes() {
+		// Defaults to TEMPLATEPATH (and potentially STYLESHEETPATH).
+		$this->assertEquals(
+			array(
+				TEMPLATEPATH,
+			),
+			wp_get_active_and_valid_themes()
+		);
+
+		// Disabling 'wp_using_themes' should return an empty array.
+		add_filter( 'wp_using_themes', '__return_false' );
+		$this->assertEquals(
+			array(),
+			wp_get_active_and_valid_themes()
+		);
+	}
+}

--- a/tests/phpunit/tests/load/wpGetActiveAndValidThemes.php
+++ b/tests/phpunit/tests/load/wpGetActiveAndValidThemes.php
@@ -9,7 +9,7 @@
 class Tests_Load_WpGetActiveAndValidThemes extends WP_UnitTestCase {
 
 	/**
-	 * @ticket 19898
+	 * @ticket 57928
 	 */
 	public function test_wp_get_active_and_valid_themes() {
 		// Defaults to TEMPLATEPATH (and potentially STYLESHEETPATH).


### PR DESCRIPTION
Returns an empty array from `wp_get_active_and_valid_themes()` when `! wp_using_themes()`. The empty array prevents `wp-content/themes/functions.php` from being loaded erroneously.

See https://core.trac.wordpress.org/ticket/57928