### PR TITLE
Bookmark Administration on edit_link function in extra remove ( $_POST['link_url'] = esc_html( $_POST['link_url'] ); )

### DIFF
--- a/src/wp-admin/includes/bookmark.php
+++ b/src/wp-admin/includes/bookmark.php
@@ -33,8 +33,7 @@ function edit_link( $link_id = 0 ) {
 			403
 		);
 	}
-
-	$_POST['link_url']   = esc_html( $_POST['link_url'] );
+	
 	$_POST['link_url']   = esc_url( $_POST['link_url'] );
 	$_POST['link_name']  = esc_html( $_POST['link_name'] );
 	$_POST['link_image'] = esc_html( $_POST['link_image'] );

--- a/src/wp-admin/includes/user.php
+++ b/src/wp-admin/includes/user.php
@@ -531,7 +531,7 @@ function default_password_nag() {
 	echo '<strong>' . __( 'Notice:' ) . '</strong> ';
 	_e( 'You&rsquo;re using the auto-generated password for your account. Would you like to change it?' );
 	echo '</p><p>';
-	printf( '<a href="%s">' . __( 'Yes, take me to my profile page' ) . '</a> | ', get_edit_profile_url() . '#password' );
+	printf( '<a href="%s">' . __( 'Yes, take me to my profile page' ) . '</a> | ', esc_url( get_edit_profile_url() . '#password' ) );
 	printf( '<a href="%s" id="default-password-nag-no">' . __( 'No thanks, do not remind me again' ) . '</a>', '?default_password_nag=0' );
 	echo '</p></div>';
 }


### PR DESCRIPTION
I have checked in edit_link function on wp-admin/includes/bookmark.php

And if I look at the code there are add an extra esc_html function to sanitize the ( $_POSTlink_url? ).

After reviewing the example provided for the add_link action, it appears that there is no need to include an esc_html function when handling the ( $_POSTlink_url? ) parameter.

Can you please check my patch and share your feedback.

Trac Ticket: https://core.trac.wordpress.org/ticket/58239

**EDITED by @audrasjb to add a link to the Trac ticket**