### PR TITLE
Bookmark Administration on edit_link function in extra remove ( ['lin…

### DIFF
--- a/src/wp-admin/includes/bookmark.php
+++ b/src/wp-admin/includes/bookmark.php
@@ -34,7 +34,6 @@ function edit_link( $link_id = 0 ) {
 		);
 	}
 
-	$_POST['link_url']   = esc_html( $_POST['link_url'] );
 	$_POST['link_url']   = esc_url( $_POST['link_url'] );
 	$_POST['link_name']  = esc_html( $_POST['link_name'] );
 	$_POST['link_image'] = esc_html( $_POST['link_image'] );


### PR DESCRIPTION
I have checked in edit_link function on wp-admin/includes/bookmark.php

And if I look at the code there are add an extra esc_html function to sanitize the ( $_POSTlink_url? ).

After reviewing the example provided for the add_link action, it appears that there is no need to include an esc_html function when handling the ( $_POSTlink_url? ) parameter.

Can you please check my patch and share your feedback.


EDITED by @audrasjb to add a link to the Trac ticket
Trac Ticket: https://core.trac.wordpress.org/ticket/58239
