### PR TITLE
HTML API: Adjust coding style to pass Gutenberg linter

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1465,9 +1465,9 @@ class WP_HTML_Tag_Processor {
 				$accumulated_shift_for_given_point += $shift;
 			}
 
-			$output_buffer        .= substr( $this->html, $bytes_already_copied, $diff->start - $bytes_already_copied );
-			$output_buffer        .= $diff->text;
-			$bytes_already_copied  = $diff->end;
+			$output_buffer       .= substr( $this->html, $bytes_already_copied, $diff->start - $bytes_already_copied );
+			$output_buffer       .= $diff->text;
+			$bytes_already_copied = $diff->end;
 		}
 
 		$this->html = $output_buffer . substr( $this->html, $bytes_already_copied );


### PR DESCRIPTION
Trac: [#58250-ticket](https://core.trac.wordpress.org/ticket/58250#ticket)

Nothing special here: just removing some spaces so that this code can be back-ported into Gutenberg.

There are no changes in this PR other than removing three neutral whitespaces.