### PR TITLE
HTML API: Fix ordering issue in docblock that's breaking Developer Resources

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1740,8 +1740,6 @@ class WP_HTML_Tag_Processor {
 	 * > case-insensitive match for each other.
 	 *     - HTML 5 spec
 	 *
-	 * @see https://html.spec.whatwg.org/multipage/syntax.html#attributes-2:ascii-case-insensitive
-	 *
 	 * Example:
 	 * ```php
 	 * $p = new WP_HTML_Tag_Processor( '<div data-ENABLED class="test" DATA-test-id="14">Test</div>' );
@@ -1753,6 +1751,8 @@ class WP_HTML_Tag_Processor {
 	 * ```
 	 *
 	 * @since 6.2.0
+	 *
+	 * @see https://html.spec.whatwg.org/multipage/syntax.html#attributes-2:ascii-case-insensitive
 	 *
 	 * @param string $prefix Prefix of requested attribute names.
 	 * @return array|null List of attribute names, or `null` when no tag opener is matched.
@@ -1778,7 +1778,7 @@ class WP_HTML_Tag_Processor {
 	 *
 	 * Example:
 	 * ```php
-	 * $p = new WP_HTML_Tag_Processor( '<DIV CLASS="test">Test</DIV>' );
+	 * $p = new WP_HTML_Tag_Processor( '<div class="test">Test</div>' );
 	 * $p->next_tag() === true;
 	 * $p->get_tag() === 'DIV';
 	 *


### PR DESCRIPTION
Trac: [#58254-ticket](https://core.trac.wordpress.org/ticket/58254#ticket)

In this patch we're re-ordering the `@see` tag in the docblock comment for `WP_HTML_Tag_Processor::get_attribute_names_with_prefix`. Previously the rendering in Developer Resources was broken, whereby it merged the link in the `@see` tag with the example code.

https://developer.wordpress.org/reference/classes/wp_html_tag_processor/get_attribute_names_with_prefix/

Now, in this patch, the `@see` tag has been moved below the code example so that the example is properly extracted.

Additionally the example code for `WP_HTML_Tag_Processor::get_tag` has been updated to show lowercase tag names in the input HTML so that it doesn't convey the wrong impression that the uppercase output from `get_tag()` depends on the case of the input HTML.

## Screenshot

<img width="1000" alt="Screenshot 2023-05-04 at 12 56 38 PM" src="https://user-images.githubusercontent.com/5431237/236184790-13ed04d9-39f3-4641-9b25-97f4d23c0707.png">

After this patch the example code should appear in its own block as with all the other methods in the class.