### PR TITLE
HTML API: Restore mistakenly-removed content in documentation.

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -229,11 +229,11 @@
  * The Tag Processor's design incorporates a "garbage-in-garbage-out" philosophy.
  * HTML5 specifies that certain invalid content be transformed into different forms
  * for display, such as removing null bytes from an input document and replacing
- * invalid characters with the Unicode replacement character `U+FFFD`. Where errors
- * or transformations exist within the HTML5 specification, the Tag Processor leaves
- * those invalid inputs untouched, passing them through to the final browser to handle.
- * While this implies that certain operations will be non-spec-compliant, such as
- * reading the value of an attribute with invalid content, it also preserves a
+ * invalid characters with the Unicode replacement character `U+FFFD` (visually "�").
+ * Where errors or transformations exist within the HTML5 specification, the Tag Processor
+ * leaves those invalid inputs untouched, passing them through to the final browser
+ * to handle. While this implies that certain operations will be non-spec-compliant,
+ * such as reading the value of an attribute with invalid content, it also preserves a
  * simplicity and efficiency for handling those error cases.
  *
  * Most operations within the Tag Processor are designed to minimize the difference


### PR DESCRIPTION
Trac: [#58256-ticket](https://core.trac.wordpress.org/ticket/58256#ticket)

In a3ed152c54c117d39d32a72a3d22f082dd5ffa7f the Unicode replacement character was mistakenly removed, being believed to be a text rendering mistake, because the character _is_ the replacement character used in situations where those text mistakes occur.

However, the purpose of including the character was to communicate what it looks like and why the Tag Processor won't insert it into the document (which would be wrong from the Unicode point of view for such a streaming processor that doesn't produce the final rendered view of the text).

In this patch we're bringing back the character and adding a small clue to try and remove the confusion that previously led to its unwanted removal.