### PR TITLE
Notices fix for http1.0

### DIFF
--- a/src/wp-includes/canonical.php
+++ b/src/wp-includes/canonical.php
@@ -63,10 +63,22 @@ function redirect_canonical( $requested_url = null, $do_redirect = true ) {
 		return;
 	}
 
-	if ( ! $requested_url && isset( $_SERVER['HTTP_HOST'] ) ) {
+	// www.example.com vs. example.com
+	$user_home = parse_url( home_url('/') );
+
+	if ( ! $requested_url ) {
 		// Build the URL in the address bar.
-		$requested_url  = is_ssl() ? 'https://' : 'http://';
-		$requested_url .= $_SERVER['HTTP_HOST'];
+		$requested_url = is_ssl() ? 'https://' : 'http://';
+		if ( isset( $_SERVER['HTTP_HOST'] ) ) {
+			$requested_url .= $_SERVER['HTTP_HOST'];
+		} else {
+			// Falback for http1.0 where requested host and port are unknown
+			// In this case correct redirect no-www <=> yes-www is not possible
+			$requested_url .= $user_home['host'];
+			if ( ! empty( $user_home['port'] ) ) {
+				$requested_url .= ':' . $user_home['port'];
+			}
+		}
 		$requested_url .= $_SERVER['REQUEST_URI'];
 	}
 
@@ -569,9 +581,6 @@ function redirect_canonical( $requested_url = null, $do_redirect = true ) {
 	if ( $redirect_url ) {
 		$redirect = parse_url( $redirect_url );
 	}
-
-	// www.example.com vs. example.com
-	$user_home = parse_url( home_url() );
 
 	if ( ! empty( $user_home['host'] ) ) {
 		$redirect['host'] = $user_home['host'];

--- a/src/wp-includes/canonical.php
+++ b/src/wp-includes/canonical.php
@@ -72,7 +72,7 @@ function redirect_canonical( $requested_url = null, $do_redirect = true ) {
 		if ( isset( $_SERVER['HTTP_HOST'] ) ) {
 			$requested_url .= $_SERVER['HTTP_HOST'];
 		} else {
-			// Falback for http1.0 where requested host and port are unknown
+			// Fallback for http1.0 where requested host and port are unknown
 			// In this case correct redirect no-www <=> yes-www is not possible
 			$requested_url .= $user_home['host'];
 			if ( ! empty( $user_home['port'] ) ) {

--- a/src/wp-includes/canonical.php
+++ b/src/wp-includes/canonical.php
@@ -72,8 +72,10 @@ function redirect_canonical( $requested_url = null, $do_redirect = true ) {
 		if ( isset( $_SERVER['HTTP_HOST'] ) ) {
 			$requested_url .= $_SERVER['HTTP_HOST'];
 		} else {
-			// Fallback for http1.0 where requested host and port are unknown
-			// In this case correct redirect no-www <=> yes-www is not possible
+			/*
+			 * Fallback for HTTP/1.0 where the requested host and port are unknown.
+			 * In this case, correctly redirecting no-www <=> yes-www is not possible.
+			 */
 			$requested_url .= $user_home['host'];
 			if ( ! empty( $user_home['port'] ) ) {
 				$requested_url .= ':' . $user_home['port'];

--- a/src/wp-includes/canonical.php
+++ b/src/wp-includes/canonical.php
@@ -64,7 +64,7 @@ function redirect_canonical( $requested_url = null, $do_redirect = true ) {
 	}
 
 	// www.example.com vs. example.com
-	$user_home = parse_url( home_url('/') );
+	$user_home = parse_url( home_url( '/' ) );
 
 	if ( ! $requested_url ) {
 		// Build the URL in the address bar.


### PR DESCRIPTION
In the absence of `$_SERVER['HTTP_HOST']` while http1.0 protocol is used, the only available way to go through all other checks is to assume that the host and port are already correct and take them from the site settings. 

Trac ticket: [#34353](https://core.trac.wordpress.org/ticket/34353)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
