### PR TITLE
HTML API: Verify that things are fine when mbstring.func_overload is set

### DIFF
--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -2309,9 +2309,9 @@ HTML
 		$p->next_tag();
 
 		$this->assertSame( "🅰 is not א", $p->get_attribute( 'title' ) );
-	
+
 		$p->remove_attribute( 'title' );
 		$p->remove_class( 'me' );
-		$this->assertSame( '<a class="take  away">Test</a>', $p->get_updated_html() );
+		$this->assertSame( '<a  class="take  away">Test</a>', $p->get_updated_html() );
 	}
 }

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -2304,6 +2304,12 @@ HTML
 
 	public function test_handles_binary_data_when_mbstring_func_overloading_active() {
 		ini_set( 'mbstring.func_overload', 7 );
+
+		$func_overload = ini_get( 'mbstring.func_overload' );
+		if ( false === $func_overload ) {
+			return;
+		}
+
 		$this->assertSame( 7, ini_get( 'mbstring.func_overload' ) );
 
 		$p = new WP_HTML_Tag_Processor( '<a title="🅰 is not א" class="take me away">Test</a>"' );

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -2304,6 +2304,7 @@ HTML
 
 	public function test_handles_binary_data_when_mbstring_func_overloading_active() {
 		ini_set( 'mbstring.func_overload', 7 );
+		$this->assertSame( 7, ini_get( 'mbstring.func_overload' ) );
 
 		$p = new WP_HTML_Tag_Processor( '<a title="🅰 is not א" class="take me away">Test</a>"' );
 		$p->next_tag();

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -2301,4 +2301,17 @@ HTML
 			),
 		);
 	}
+
+	public function test_handles_binary_data_when_mbstring_func_overloading_active() {
+		ini_set( 'mbstring.func_overload', 7 );
+
+		$p = new WP_HTML_Tag_Processor( '<a title="🅰 is not א" class="take me away">Test</a>"' );
+		$p->next_tag();
+
+		$this->assertSame( "🅰 is not א", $p->get_attribute( 'title' ) );
+	
+		$p->remove_attribute( 'title' );
+		$p->remove_class( 'me' );
+		$this->assertSame( '<a class="take  away">Test</a>', $p->get_updated_html() );
+	}
 }


### PR DESCRIPTION
Ignore for now: trying to run tests

## Status

 - [ ] Try calling `mbstring_binary_safe_encoding`