### PR TITLE
Move media mobile select styles to max-width: 782px breakpoint

### DIFF
--- a/src/wp-includes/css/media-views.css
+++ b/src/wp-includes/css/media-views.css
@@ -2703,13 +2703,6 @@
 		padding: 3px 6px;
 	}
 
-	.wp-admin .media-frame select {
-		min-height: 40px;
-		font-size: 16px;
-		line-height: 1.625;
-		padding: 5px 24px 5px 8px;
-	}
-
 	.image-details .column-image {
 		width: 30%;
 		left: 70%;
@@ -2840,6 +2833,13 @@
 	.attachment-details .copy-to-clipboard-container .success {
 		font-size: 14px;
 		line-height: 2.71428571;
+	}
+
+	.wp-admin .media-frame select {
+		min-height: 40px;
+		font-size: 16px;
+		line-height: 1.625;
+		padding: 5px 24px 5px 8px;
 	}
 }
 


### PR DESCRIPTION
This PR fix [this issue](https://core.trac.wordpress.org/ticket/57948). I moved the mobile select styles from the max-width: 900px breakpoint to the max-width: 782px to standardize the height of the inputs.

Trac ticket: https://core.trac.wordpress.org/ticket/57948