### PR TITLE
Fixed escaping issue

### DIFF
--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -206,7 +206,7 @@ function login_header( $title = 'Log In', $message = '', $wp_error = null ) {
 
 	?>
 	<div id="login">
-		<h1><a href="<?php echo esc_url( $login_header_url ); ?>"><?php echo $login_header_text; ?></a></h1>
+		<h1><a href="<?php echo esc_url( $login_header_url ); ?>"><?php echo esc_html( $login_header_text ); ?></a></h1>
 	<?php
 	/**
 	 * Filters the message to display above the login form.


### PR DESCRIPTION
The variable $login_header_text escaped by esc_html at https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-login.php#L209

I'm no sure that is it should be escaped by esc_html or any other escaping function. So, I'm open for any suggestion to make changes.

Trac ticket: https://core.trac.wordpress.org/ticket/58305