### PR TITLE
58312 : Display password hint on additional screens

### DIFF
--- a/src/wp-admin/install.php
+++ b/src/wp-admin/install.php
@@ -153,6 +153,7 @@ function display_setup_form( $error = null ) {
 				<strong><?php _e( 'Important:' ); ?></strong>
 				<?php /* translators: The non-breaking space prevents 1Password from thinking the text "log in" should trigger a password save prompt. */ ?>
 				<?php _e( 'You will need this password to log&nbsp;in. Please store it in a secure location.' ); ?></span></p>
+				<p class="description indicator-hint"><?php echo wp_get_password_hint(); ?></p>
 			</td>
 		</tr>
 		<tr class="form-field form-required user-pass2-wrap hide-if-js">

--- a/src/wp-admin/user-edit.php
+++ b/src/wp-admin/user-edit.php
@@ -655,6 +655,7 @@ switch ( $action ) {
 											<span class="dashicons dashicons-no" aria-hidden="true"></span>
 											<span class="text"><?php _e( 'Cancel' ); ?></span>
 										</button>
+										<p class="description indicator-hint"><?php echo wp_get_password_hint(); ?></p>
 									</div>
 								</td>
 							</tr>

--- a/src/wp-admin/user-new.php
+++ b/src/wp-admin/user-new.php
@@ -578,6 +578,7 @@ if ( current_user_can( 'create_users' ) ) {
 					<span class="dashicons dashicons-hidden" aria-hidden="true"></span>
 					<span class="text"><?php _e( 'Hide' ); ?></span>
 				</button>
+				<p class="description indicator-hint"><?php echo wp_get_password_hint(); ?></p>
 			</div>
 		</td>
 	</tr>


### PR DESCRIPTION
Show passwords hint on :
- WordPress installation screen
- new user screen
- user profile screen

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/58312

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
