### PR TITLE
A similar typo has been fixed in wp-includes/ms-blogs.php

### DIFF
--- a/src/wp-includes/ms-blogs.php
+++ b/src/wp-includes/ms-blogs.php
@@ -419,7 +419,7 @@ function add_blog_option( $id, $option, $value ) {
 }
 
 /**
- * Removes option by name for a given blog ID. Prevents removal of protected WordPress options.
+ * Removes an option by name for a given blog ID. Prevents removal of protected WordPress options.
  *
  * @since MU (3.0.0)
  *


### PR DESCRIPTION
A similar typo has been fixed in [line 422 of wp-includes/ms-blogs.php](https://github.com/krupal-panchal/wordpress-develop/blob/trunk/src/wp-includes/ms-blogs.php#L422).

Trac ticket: https://core.trac.wordpress.org/ticket/58338