### PR TITLE
Do not slow query by sotring, when counting

### DIFF
--- a/src/wp-includes/class-wp-comment-query.php
+++ b/src/wp-includes/class-wp-comment-query.php
@@ -961,8 +961,9 @@ class WP_Comment_Query {
 		$this->sql_clauses['select']  = "SELECT $found_rows $fields";
 		$this->sql_clauses['from']    = "FROM $wpdb->comments $join";
 		$this->sql_clauses['groupby'] = $groupby;
-		if ( !$this->query_vars['count'] )
+		if ( ! $this->query_vars['count'] ) {
 			$this->sql_clauses['orderby'] = $orderby;
+		}
 		$this->sql_clauses['limits']  = $limits;
 
 		$this->request = "

--- a/src/wp-includes/class-wp-comment-query.php
+++ b/src/wp-includes/class-wp-comment-query.php
@@ -961,7 +961,8 @@ class WP_Comment_Query {
 		$this->sql_clauses['select']  = "SELECT $found_rows $fields";
 		$this->sql_clauses['from']    = "FROM $wpdb->comments $join";
 		$this->sql_clauses['groupby'] = $groupby;
-		$this->sql_clauses['orderby'] = $orderby;
+		if ( !$this->query_vars['count'] )
+			$this->sql_clauses['orderby'] = $orderby;
 		$this->sql_clauses['limits']  = $limits;
 
 		$this->request = "


### PR DESCRIPTION
If the caller wants a count, sorting just slows down the database (sometimes massively) without providing any more information.

Trac ticket: https://github.com/guss77/wordpress-develop/pull/1

EDIT by @audrasjb: Trac ticket: https://core.trac.wordpress.org/ticket/58368
