### PR TITLE
Fix Ticket - 57902 - REST API index does not respect fields

### DIFF
--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -577,7 +577,6 @@ class WP_REST_Server {
 				$is_link_requested = implode( ',', $is_link_requested );
 			}
 
-			$is_link_requested = sanitize_text_field( wp_unslash( $is_link_requested ) );
 			$is_link_requested = false !== strpos( $is_link_requested, '_links' );
 		}
 

--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -500,7 +500,7 @@ class WP_REST_Server {
 
 			// Embed links inside the request.
 			$embed  = isset( $_GET['_embed'] ) ? rest_parse_embed_param( $_GET['_embed'] ) : false;
-			$result = $this->response_to_data( $result, $embed );
+			$result = $this->response_to_data( $result, $embed, $request );
 
 			/**
 			 * Filters the REST API response.
@@ -564,24 +564,25 @@ class WP_REST_Server {
 	 *     @type array $_embedded Embedded objects.
 	 * }
 	 */
-	public function response_to_data( $response, $embed ) {
-		$data              = $response->get_data();
-		$links             = self::get_compact_response_links( $response );
-		$is_link_requested = false;
+	public function response_to_data( $response, $embed, $request = null ) {
+		$data  = $response->get_data();
+		$links = self::get_compact_response_links( $response );
 
-		if ( ! empty( $_GET['_fields'] ) ) {
+		if ( null !== $request && ! empty( $request['_fields'] ) && ! empty( $links ) ) {
 
-			$is_link_requested = $_GET['_fields'];
+			$is_link_requested = $request['_fields'];
 
 			if ( is_array( $is_link_requested ) ) {
 				$is_link_requested = implode( ',', $is_link_requested );
 			}
 
 			$is_link_requested = false !== strpos( $is_link_requested, '_links' );
-		}
 
-		if ( ! empty( $links ) && $is_link_requested ) {
-			// Convert links to part of the data.
+			if ( $is_link_requested ) {
+				$data['_links'] = $links;
+			}
+		} elseif ( ! empty( $links ) ) {
+
 			$data['_links'] = $links;
 		}
 

--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -554,9 +554,11 @@ class WP_REST_Server {
 	 *
 	 * @since 4.4.0
 	 * @since 5.4.0 The `$embed` parameter can now contain a list of link relations to include.
+	 * @since 6.3.0 The `$request` parameter was added.
 	 *
 	 * @param WP_REST_Response $response Response object.
 	 * @param bool|string[]    $embed    Whether to embed all links, a filtered list of link relations, or no links.
+	 * @param WP_REST_Request  $request  Request object.
 	 * @return array {
 	 *     Data with sub-requests embedded.
 	 *

--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -572,7 +572,9 @@ class WP_REST_Server {
 
 			$is_link_requested = $_GET['_fields'];
 
-			if ( is_array( $is_link_requested ) ) $is_link_requested = implode( ',', $is_link_requested );
+			if ( is_array( $is_link_requested ) ) {
+				$is_link_requested = implode( ',', $is_link_requested );
+			}
 
 			$is_link_requested = sanitize_text_field( wp_unslash( $is_link_requested ) );
 			$is_link_requested = false !== strpos( $is_link_requested, '_links' );

--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -565,8 +565,9 @@ class WP_REST_Server {
 	 * }
 	 */
 	public function response_to_data( $response, $embed ) {
-		$data  = $response->get_data();
-		$links = self::get_compact_response_links( $response );
+		$data              = $response->get_data();
+		$links             = self::get_compact_response_links( $response );
+		$is_link_requested = false;
 
 		if ( ! empty( $_GET['_fields'] ) ) {
 

--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -568,7 +568,17 @@ class WP_REST_Server {
 		$data  = $response->get_data();
 		$links = self::get_compact_response_links( $response );
 
-		if ( ! empty( $links ) ) {
+		if ( ! empty( $_GET['_fields'] ) ) {
+
+			$is_link_requested = $_GET['_fields'];
+
+			if ( is_array( $is_link_requested ) ) $is_link_requested = implode( ',', $is_link_requested );
+
+			$is_link_requested = sanitize_text_field( wp_unslash( $is_link_requested ) );
+			$is_link_requested = false !== strpos( $is_link_requested, '_links' );
+		}
+
+		if ( ! empty( $links ) && $is_link_requested ) {
 			// Convert links to part of the data.
 			$data['_links'] = $links;
 		}


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/57902

## Description 
This PR introduces validation for the `_links` field in the` _fields` query parameter. If the `_links` field is present, it will be appended to the response object. Otherwise, it will not be included. 

#### Test Case

###### Case 1
- URL - `/wp-json?_fields[]=name&_fields[]=_links`
- Name & links both available 

###### Case 2
- URL - `/wp-json?_fields[]=name`
- Name available 

###### Case 3
- URL - `/wp-json?_fields=name`
- Name available 

###### Case 4
- URL - `/wp-json?_fields=name,_links`
- Name & links both available 

##### Case 5
- URL - `/wp-json`
-  Entire response json object including `_links`
