### PR TITLE
40206: Remove condition that checks for slug not provided

### DIFF
--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -2471,7 +2471,7 @@ function wp_insert_term( $term, $taxonomy, $args = array() ) {
 
 	if ( $name_match ) {
 		$slug_match = get_term_by( 'slug', $slug, $taxonomy );
-		if ( ! $slug_provided || $name_match->slug === $slug || $slug_match ) {
+		if ( $name_match->slug === $slug || $slug_match ) {
 			if ( is_taxonomy_hierarchical( $taxonomy ) ) {
 				$siblings = get_terms(
 					array(


### PR DESCRIPTION
It allows a term to be added even if a term with slug and "2" appended is present already. Otherwise the consecutive term would check for the slug-2 and see that it is present and you need to manually add the slug.

Trac ticket: https://core.trac.wordpress.org/ticket/40206