### PR TITLE
WP Core: Deprecated the wp_queue_comments_for_comment_meta_lazyload() function. (Ticket: 58301)

### DIFF
--- a/src/wp-admin/includes/deprecated.php
+++ b/src/wp-admin/includes/deprecated.php
@@ -1588,3 +1588,29 @@ function image_attachment_fields_to_save( $post, $attachment ) {
 
 	return $post;
 }
+
+/**
+ * Queues comments for metadata lazy-loading.
+ *
+ * @since 4.5.0
+ * @since 6.3.0 Use wp_lazyload_comment_meta() for lazy-loading of comment meta.
+ * @deprecated 6.3.0 Use wp_lazyload_comment_meta() instead.
+ *
+ * @see wp_lazyload_comment_meta()
+ *
+ * @param WP_Comment[] $comments Array of comment objects.
+ */
+function wp_queue_comments_for_comment_meta_lazyload( $comments ) {
+	_deprecated_function( __FUNCTION__, '6.3.0', 'wp_lazyload_comment_meta' );
+	// Don't use `wp_list_pluck()` to avoid by-reference manipulation.
+	$comment_ids = array();
+	if ( is_array( $comments ) ) {
+		foreach ( $comments as $comment ) {
+			if ( $comment instanceof WP_Comment ) {
+				$comment_ids[] = $comment->comment_ID;
+			}
+		}
+	}
+
+	wp_lazyload_comment_meta( $comment_ids );
+}

--- a/src/wp-admin/includes/deprecated.php
+++ b/src/wp-admin/includes/deprecated.php
@@ -1593,10 +1593,7 @@ function image_attachment_fields_to_save( $post, $attachment ) {
  * Queues comments for metadata lazy-loading.
  *
  * @since 4.5.0
- * @since 6.3.0 Use wp_lazyload_comment_meta() for lazy-loading of comment meta.
  * @deprecated 6.3.0 Use wp_lazyload_comment_meta() instead.
- *
- * @see wp_lazyload_comment_meta()
  *
  * @param WP_Comment[] $comments Array of comment objects.
  */

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -4879,7 +4879,7 @@ class WP_Query {
 	 * Lazyload comment meta for comments in the loop.
 	 *
 	 * @since 4.4.0
-	 * @deprecated 4.5.0 See wp_queue_comments_for_comment_meta_lazyload().
+	 * @deprecated 4.5.0 See wp_lazyload_comment_meta().
 	 *
 	 * @param mixed $check
 	 * @param int   $comment_id

--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -526,32 +526,6 @@ function update_comment_meta( $comment_id, $meta_key, $meta_value, $prev_value =
 }
 
 /**
- * Queues comments for metadata lazy-loading.
- *
- * @since 4.5.0
- * @since 6.3.0 Use wp_lazyload_comment_meta() for lazy-loading of comment meta.
- * @deprecated 6.3.0 Use wp_lazyload_comment_meta() instead.
- *
- * @see wp_lazyload_comment_meta()
- *
- * @param WP_Comment[] $comments Array of comment objects.
- */
-function wp_queue_comments_for_comment_meta_lazyload( $comments ) {
-	_deprecated_function( __FUNCTION__, '6.3.0', 'wp_lazyload_comment_meta' );
-	// Don't use `wp_list_pluck()` to avoid by-reference manipulation.
-	$comment_ids = array();
-	if ( is_array( $comments ) ) {
-		foreach ( $comments as $comment ) {
-			if ( $comment instanceof WP_Comment ) {
-				$comment_ids[] = $comment->comment_ID;
-			}
-		}
-	}
-
-	wp_lazyload_comment_meta( $comment_ids );
-}
-
-/**
  * Sets the cookies used to store an unauthenticated commentator's identity. Typically used
  * to recall previous comments by this commentator that are still held in moderation.
  *

--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -530,12 +530,14 @@ function update_comment_meta( $comment_id, $meta_key, $meta_value, $prev_value =
  *
  * @since 4.5.0
  * @since 6.3.0 Use wp_lazyload_comment_meta() for lazy-loading of comment meta.
+ * @deprecated 6.3.0 Use wp_lazyload_comment_meta() instead.
  *
  * @see wp_lazyload_comment_meta()
  *
  * @param WP_Comment[] $comments Array of comment objects.
  */
 function wp_queue_comments_for_comment_meta_lazyload( $comments ) {
+	_deprecated_function( __FUNCTION__, '6.3.0', 'wp_lazyload_comment_meta' );
 	// Don't use `wp_list_pluck()` to avoid by-reference manipulation.
 	$comment_ids = array();
 	if ( is_array( $comments ) ) {

--- a/tests/phpunit/tests/query/lazyLoadCommentMeta.php
+++ b/tests/phpunit/tests/query/lazyLoadCommentMeta.php
@@ -23,9 +23,9 @@ class Tests_Lazy_Load_Comment_Meta extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket 57901
+	 * @ticket 58301
 	 *
-	 * @covers ::wp_queue_comments_for_comment_meta_lazyload
+	 * @covers ::wp_lazyload_comment_meta
 	 */
 	public function test_wp_queue_comments_for_comment_meta_lazyload() {
 		$filter = new MockAction();
@@ -41,9 +41,9 @@ class Tests_Lazy_Load_Comment_Meta extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket 57901
+	 * @ticket 58301
 	 *
-	 * @covers ::wp_queue_comments_for_comment_meta_lazyload
+	 * @covers ::wp_lazyload_comment_meta
 	 */
 	public function test_wp_queue_comments_for_comment_meta_lazyload_new_comment() {
 		$filter = new MockAction();

--- a/tests/phpunit/tests/query/lazyLoadCommentMeta.php
+++ b/tests/phpunit/tests/query/lazyLoadCommentMeta.php
@@ -26,6 +26,7 @@ class Tests_Lazy_Load_Comment_Meta extends WP_UnitTestCase {
 	 * @ticket 57901
 	 *
 	 * @covers ::wp_queue_comments_for_comment_meta_lazyload
+	 * @expectedDeprecated wp_queue_comments_for_comment_meta_lazyload
 	 */
 	public function test_wp_queue_comments_for_comment_meta_lazyload() {
 		$filter = new MockAction();
@@ -45,6 +46,7 @@ class Tests_Lazy_Load_Comment_Meta extends WP_UnitTestCase {
 	 * @ticket 57901
 	 *
 	 * @covers ::wp_queue_comments_for_comment_meta_lazyload
+	 * @expectedDeprecated wp_queue_comments_for_comment_meta_lazyload
 	 */
 	public function test_wp_queue_comments_for_comment_meta_lazyload_new_comment() {
 		$filter = new MockAction();

--- a/tests/phpunit/tests/query/lazyLoadCommentMeta.php
+++ b/tests/phpunit/tests/query/lazyLoadCommentMeta.php
@@ -26,6 +26,7 @@ class Tests_Lazy_Load_Comment_Meta extends WP_UnitTestCase {
 	 * @ticket 57901
 	 *
 	 * @covers ::wp_queue_comments_for_comment_meta_lazyload
+	 *
 	 * @expectedDeprecated wp_queue_comments_for_comment_meta_lazyload
 	 */
 	public function test_wp_queue_comments_for_comment_meta_lazyload() {
@@ -46,6 +47,7 @@ class Tests_Lazy_Load_Comment_Meta extends WP_UnitTestCase {
 	 * @ticket 57901
 	 *
 	 * @covers ::wp_queue_comments_for_comment_meta_lazyload
+	 *
 	 * @expectedDeprecated wp_queue_comments_for_comment_meta_lazyload
 	 */
 	public function test_wp_queue_comments_for_comment_meta_lazyload_new_comment() {

--- a/tests/phpunit/tests/query/lazyLoadCommentMeta.php
+++ b/tests/phpunit/tests/query/lazyLoadCommentMeta.php
@@ -30,9 +30,8 @@ class Tests_Lazy_Load_Comment_Meta extends WP_UnitTestCase {
 	public function test_wp_queue_comments_for_comment_meta_lazyload() {
 		$filter = new MockAction();
 		add_filter( 'update_comment_metadata_cache', array( $filter, 'filter' ), 10, 2 );
-		$comments   = array_map( 'get_comment', self::$comment_ids );
+		wp_lazyload_comment_meta( self::$comment_ids );
 		$comment_id = reset( self::$comment_ids );
-		wp_queue_comments_for_comment_meta_lazyload( $comments );
 		get_comment_meta( $comment_id );
 
 		$args             = $filter->get_args();
@@ -49,13 +48,12 @@ class Tests_Lazy_Load_Comment_Meta extends WP_UnitTestCase {
 	public function test_wp_queue_comments_for_comment_meta_lazyload_new_comment() {
 		$filter = new MockAction();
 		add_filter( 'update_comment_metadata_cache', array( $filter, 'filter' ), 10, 2 );
-		$comments   = array_map( 'get_comment', self::$comment_ids );
+		wp_lazyload_comment_meta( self::$comment_ids );
 		$comment_id = self::factory()->comment->create(
 			array(
 				'comment_post_ID' => self::$post_id,
 			)
 		);
-		wp_queue_comments_for_comment_meta_lazyload( $comments );
 		get_comment_meta( $comment_id );
 
 		$args             = $filter->get_args();

--- a/tests/phpunit/tests/query/lazyLoadCommentMeta.php
+++ b/tests/phpunit/tests/query/lazyLoadCommentMeta.php
@@ -23,15 +23,16 @@ class Tests_Lazy_Load_Comment_Meta extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket 58301
+	 * @ticket 57901
 	 *
-	 * @covers ::wp_lazyload_comment_meta
+	 * @covers ::wp_queue_comments_for_comment_meta_lazyload
 	 */
 	public function test_wp_queue_comments_for_comment_meta_lazyload() {
 		$filter = new MockAction();
 		add_filter( 'update_comment_metadata_cache', array( $filter, 'filter' ), 10, 2 );
-		wp_lazyload_comment_meta( self::$comment_ids );
+		$comments   = array_map( 'get_comment', self::$comment_ids );
 		$comment_id = reset( self::$comment_ids );
+		wp_queue_comments_for_comment_meta_lazyload( $comments );
 		get_comment_meta( $comment_id );
 
 		$args             = $filter->get_args();
@@ -41,19 +42,20 @@ class Tests_Lazy_Load_Comment_Meta extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket 58301
+	 * @ticket 57901
 	 *
-	 * @covers ::wp_lazyload_comment_meta
+	 * @covers ::wp_queue_comments_for_comment_meta_lazyload
 	 */
 	public function test_wp_queue_comments_for_comment_meta_lazyload_new_comment() {
 		$filter = new MockAction();
 		add_filter( 'update_comment_metadata_cache', array( $filter, 'filter' ), 10, 2 );
-		wp_lazyload_comment_meta( self::$comment_ids );
+		$comments   = array_map( 'get_comment', self::$comment_ids );
 		$comment_id = self::factory()->comment->create(
 			array(
 				'comment_post_ID' => self::$post_id,
 			)
 		);
+		wp_queue_comments_for_comment_meta_lazyload( $comments );
 		get_comment_meta( $comment_id );
 
 		$args             = $filter->get_args();


### PR DESCRIPTION
- Added the _deprecate_function() inside the wp_queue_comments_for_comment_meta_lazyload() function. Updated the DocBlock for the same function.
- Updated the DocBlock of WP_Query::lazyload_term_meta( $check, $term_id ) method.

Trac ticket: https://core.trac.wordpress.org/ticket/58301

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**