### PR TITLE
Revert "Enqueue registered assets once."

### DIFF
--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -571,6 +571,19 @@ add_action( 'admin_enqueue_scripts', 'wp_localize_jquery_ui_datepicker', 1000 );
 add_action( 'admin_enqueue_scripts', 'wp_common_block_scripts_and_styles' );
 add_action( 'enqueue_block_assets', 'wp_enqueue_registered_block_scripts_and_styles' );
 add_action( 'enqueue_block_assets', 'enqueue_block_styles_assets', 30 );
+/*
+ * `wp_enqueue_registered_block_scripts_and_styles` is bound to both
+ * `enqueue_block_editor_assets` and `enqueue_block_assets` hooks
+ * since the introduction of the block editor in WordPress 5.0.
+ *
+ * The way this works is that the block assets are loaded before any other assets.
+ * For example, this is the order of styles for the editor:
+ *
+ * - front styles registered for blocks, via `styles` handle (block.json)
+ * - editor styles registered for blocks, via `editorStyles` handle (block.json)
+ * - editor styles enqueued via `enqueue_block_editor_assets` hook
+ * - front styles enqueued via `enqueue_block_assets` hook
+ */
 add_action( 'enqueue_block_editor_assets', 'wp_enqueue_registered_block_scripts_and_styles' );
 add_action( 'enqueue_block_editor_assets', 'enqueue_editor_block_styles_assets' );
 add_action( 'enqueue_block_editor_assets', 'wp_enqueue_editor_block_directory_assets' );

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -571,6 +571,7 @@ add_action( 'admin_enqueue_scripts', 'wp_localize_jquery_ui_datepicker', 1000 );
 add_action( 'admin_enqueue_scripts', 'wp_common_block_scripts_and_styles' );
 add_action( 'enqueue_block_assets', 'wp_enqueue_registered_block_scripts_and_styles' );
 add_action( 'enqueue_block_assets', 'enqueue_block_styles_assets', 30 );
+add_action( 'enqueue_block_editor_assets', 'wp_enqueue_registered_block_scripts_and_styles' );
 add_action( 'enqueue_block_editor_assets', 'enqueue_editor_block_styles_assets' );
 add_action( 'enqueue_block_editor_assets', 'wp_enqueue_editor_block_directory_assets' );
 add_action( 'enqueue_block_editor_assets', 'wp_enqueue_editor_format_library_assets' );


### PR DESCRIPTION
Trac ticket https://core.trac.wordpress.org/ticket/58208
Reverts changeset https://core.trac.wordpress.org/changeset/55695

## What 

This PR reverts PR https://github.com/WordPress/wordpress-develop/pull/4356

## Why

It caused issues in the ordering of styles in the editor, which went unnoticed in the testing. The reason is that block styles (editor-only and front styles) would now be enqueued using the `enqueue_block_assets` which runs later than the `enqueue_block_editor_assets` hook.

The order of styles enqueued **before** the change was:

1. front styles registered for blocks, via `styles` handle (block.json)
2. editor styles registered for blocks, via `editorStyles` handle (block.json)
3. editor styles enqueued via `enqueue_block_editor_assets` hook
4. front styles enqueued via `enqueue_block_assets` hook

The order of styles enqueued **after** the change was:

1. editor styles enqueued via `enqueue_block_editor_assets` hook
2. front styles registered for blocks, via `styles` handle (block.json)
3. editor styles registered for blocks, via `editorStyles` handle (block.json)
4. front styles enqueued via `enqueue_block_assets` hook

## How to test

- Use this PR.
- Install and activate the test plugin [iframed-inline-styles.zip](https://github.com/WordPress/wordpress-develop/files/11551805/iframed-inline-styles.zip).
- Go to the editor and add the block "iframed-inline-styles".
- The expected result is that padding is 20px and border width is 2px:

![image](https://github.com/WordPress/wordpress-develop/assets/583546/1ffd2a83-9810-4485-8918-fd455c3c5655)

## SVN Commit Message

```txt
Loading assets for the editor: Revert [55695].

The changeset [55695] introduced a regression in the order of styles for the editor, causing the styles registered for the block (both editor and front) to be loaded after any other styles enqueued using the `enqueue_block_editor_assets` hook.

Since the original behavior was introduced in WordPress 5.0 changing it breaks the expectations of the ecosystem.

Props ellatrix.
Fixes #58208.
```
