### PR TITLE
WP_Core: Fix load_theme_textdomain() call in themes (58318)

### DIFF
--- a/src/wp-content/themes/twentyeleven/functions.php
+++ b/src/wp-content/themes/twentyeleven/functions.php
@@ -79,8 +79,8 @@ if ( ! function_exists( 'twentyeleven_setup' ) ) :
 		 * If you're building a theme based on Twenty Eleven, use
 		 * a find and replace to change 'twentyeleven' to the name
 		 * of your theme in all the template files.
-		 * 
-		 * Manual loading of text domain is not required after the introduction of 
+		 *
+		 * Manual loading of text domain is not required after the introduction of
 		 * just in time translation loading in WordPress version 4.6.
 		 * @ticket 58318
 		 */

--- a/src/wp-content/themes/twentyeleven/functions.php
+++ b/src/wp-content/themes/twentyeleven/functions.php
@@ -82,6 +82,7 @@ if ( ! function_exists( 'twentyeleven_setup' ) ) :
 		 *
 		 * Manual loading of text domain is not required after the introduction of
 		 * just in time translation loading in WordPress version 4.6.
+		 *
 		 * @ticket 58318
 		 */
 		if ( version_compare( $GLOBALS['wp_version'], '4.6', '<' ) ) {

--- a/src/wp-content/themes/twentyeleven/functions.php
+++ b/src/wp-content/themes/twentyeleven/functions.php
@@ -79,8 +79,10 @@ if ( ! function_exists( 'twentyeleven_setup' ) ) :
 		 * If you're building a theme based on Twenty Eleven, use
 		 * a find and replace to change 'twentyeleven' to the name
 		 * of your theme in all the template files.
+		 * 
 		 * Manual loading of text domain is not required after the introduction of 
-		 * just in time loading for translations in WordPress version 4.6.
+		 * just in time translation loading in WordPress version 4.6.
+		 * @ticket 58318
 		 */
 		if ( version_compare( $GLOBALS['wp_version'], '4.6', '<' ) ) {
 			load_theme_textdomain( 'twentyeleven', get_template_directory() . '/languages' );

--- a/src/wp-content/themes/twentyeleven/functions.php
+++ b/src/wp-content/themes/twentyeleven/functions.php
@@ -79,8 +79,12 @@ if ( ! function_exists( 'twentyeleven_setup' ) ) :
 		 * If you're building a theme based on Twenty Eleven, use
 		 * a find and replace to change 'twentyeleven' to the name
 		 * of your theme in all the template files.
+		 * Manual loading of text domain is not required after the introduction of 
+		 * just in time loading for translations in WordPress version 4.6.
 		 */
-		load_theme_textdomain( 'twentyeleven', get_template_directory() . '/languages' );
+		if ( version_compare( $GLOBALS['wp_version'], '4.6', '<' ) ) {
+			load_theme_textdomain( 'twentyeleven', get_template_directory() . '/languages' );
+		}
 
 		// This theme styles the visual editor with editor-style.css to match the theme style.
 		add_editor_style();

--- a/src/wp-content/themes/twentyfifteen/functions.php
+++ b/src/wp-content/themes/twentyfifteen/functions.php
@@ -58,8 +58,8 @@ if ( ! function_exists( 'twentyfifteen_setup' ) ) :
 		 * Translations can be filed at WordPress.org. See: https://translate.wordpress.org/projects/wp-themes/twentyfifteen
 		 * If you're building a theme based on twentyfifteen, use a find and replace
 		 * to change 'twentyfifteen' to the name of your theme in all the template files.
-		 * 
-		 * Manual loading of text domain is not required after the introduction of 
+		 *
+		 * Manual loading of text domain is not required after the introduction of
 		 * just in time translation loading in WordPress version 4.6.
 		 * @ticket 58318
 		 */

--- a/src/wp-content/themes/twentyfifteen/functions.php
+++ b/src/wp-content/themes/twentyfifteen/functions.php
@@ -61,6 +61,7 @@ if ( ! function_exists( 'twentyfifteen_setup' ) ) :
 		 *
 		 * Manual loading of text domain is not required after the introduction of
 		 * just in time translation loading in WordPress version 4.6.
+		 *
 		 * @ticket 58318
 		 */
 

--- a/src/wp-content/themes/twentyfifteen/functions.php
+++ b/src/wp-content/themes/twentyfifteen/functions.php
@@ -57,9 +57,14 @@ if ( ! function_exists( 'twentyfifteen_setup' ) ) :
 		 * Make theme available for translation.
 		 * Translations can be filed at WordPress.org. See: https://translate.wordpress.org/projects/wp-themes/twentyfifteen
 		 * If you're building a theme based on twentyfifteen, use a find and replace
-		 * to change 'twentyfifteen' to the name of your theme in all the template files
+		 * to change 'twentyfifteen' to the name of your theme in all the template files.
+		 * Manual loading of text domain is not required after the introduction of 
+		 * just in time loading for translations in WordPress version 4.6.
 		 */
-		load_theme_textdomain( 'twentyfifteen' );
+
+		if ( version_compare( $GLOBALS['wp_version'], '4.6', '<' ) ) {
+			load_theme_textdomain( 'twentyfifteen' );
+		}
 
 		// Add default posts and comments RSS feed links to head.
 		add_theme_support( 'automatic-feed-links' );

--- a/src/wp-content/themes/twentyfifteen/functions.php
+++ b/src/wp-content/themes/twentyfifteen/functions.php
@@ -58,8 +58,10 @@ if ( ! function_exists( 'twentyfifteen_setup' ) ) :
 		 * Translations can be filed at WordPress.org. See: https://translate.wordpress.org/projects/wp-themes/twentyfifteen
 		 * If you're building a theme based on twentyfifteen, use a find and replace
 		 * to change 'twentyfifteen' to the name of your theme in all the template files.
+		 * 
 		 * Manual loading of text domain is not required after the introduction of 
-		 * just in time loading for translations in WordPress version 4.6.
+		 * just in time translation loading in WordPress version 4.6.
+		 * @ticket 58318
 		 */
 
 		if ( version_compare( $GLOBALS['wp_version'], '4.6', '<' ) ) {

--- a/src/wp-content/themes/twentyfourteen/functions.php
+++ b/src/wp-content/themes/twentyfourteen/functions.php
@@ -64,8 +64,10 @@ if ( ! function_exists( 'twentyfourteen_setup' ) ) :
 		 * If you're building a theme based on Twenty Fourteen, use a find and
 		 * replace to change 'twentyfourteen' to the name of your theme in all
 		 * template files.
+		 * 
 		 * Manual loading of text domain is not required after the introduction of 
-		 * just in time loading for translations in WordPress version 4.6.
+		 * just in time translation loading in WordPress version 4.6.
+		 * @ticket 58318
 		 */
 		if ( version_compare( $GLOBALS['wp_version'], '4.6', '<' ) ) {
 			load_theme_textdomain( 'twentyfourteen' );

--- a/src/wp-content/themes/twentyfourteen/functions.php
+++ b/src/wp-content/themes/twentyfourteen/functions.php
@@ -64,8 +64,12 @@ if ( ! function_exists( 'twentyfourteen_setup' ) ) :
 		 * If you're building a theme based on Twenty Fourteen, use a find and
 		 * replace to change 'twentyfourteen' to the name of your theme in all
 		 * template files.
+		 * Manual loading of text domain is not required after the introduction of 
+		 * just in time loading for translations in WordPress version 4.6.
 		 */
-		load_theme_textdomain( 'twentyfourteen' );
+		if ( version_compare( $GLOBALS['wp_version'], '4.6', '<' ) ) {
+			load_theme_textdomain( 'twentyfourteen' );
+		}
 
 		/*
 		 * This theme styles the visual editor to resemble the theme style.

--- a/src/wp-content/themes/twentyfourteen/functions.php
+++ b/src/wp-content/themes/twentyfourteen/functions.php
@@ -67,6 +67,7 @@ if ( ! function_exists( 'twentyfourteen_setup' ) ) :
 		 *
 		 * Manual loading of text domain is not required after the introduction of
 		 * just in time translation loading in WordPress version 4.6.
+		 *
 		 * @ticket 58318
 		 */
 		if ( version_compare( $GLOBALS['wp_version'], '4.6', '<' ) ) {

--- a/src/wp-content/themes/twentyfourteen/functions.php
+++ b/src/wp-content/themes/twentyfourteen/functions.php
@@ -64,8 +64,8 @@ if ( ! function_exists( 'twentyfourteen_setup' ) ) :
 		 * If you're building a theme based on Twenty Fourteen, use a find and
 		 * replace to change 'twentyfourteen' to the name of your theme in all
 		 * template files.
-		 * 
-		 * Manual loading of text domain is not required after the introduction of 
+		 *
+		 * Manual loading of text domain is not required after the introduction of
 		 * just in time translation loading in WordPress version 4.6.
 		 * @ticket 58318
 		 */

--- a/src/wp-content/themes/twentynineteen/functions.php
+++ b/src/wp-content/themes/twentynineteen/functions.php
@@ -26,13 +26,6 @@ if ( ! function_exists( 'twentynineteen_setup' ) ) :
 	 * as indicating support for post thumbnails.
 	 */
 	function twentynineteen_setup() {
-		/*
-		 * Make theme available for translation.
-		 * Translations can be filed in the /languages/ directory.
-		 * If you're building a theme based on Twenty Nineteen, use a find and replace
-		 * to change 'twentynineteen' to the name of your theme in all the template files.
-		 */
-		load_theme_textdomain( 'twentynineteen', get_template_directory() . '/languages' );
 
 		// Add default posts and comments RSS feed links to head.
 		add_theme_support( 'automatic-feed-links' );

--- a/src/wp-content/themes/twentyseventeen/functions.php
+++ b/src/wp-content/themes/twentyseventeen/functions.php
@@ -25,13 +25,6 @@ if ( version_compare( $GLOBALS['wp_version'], '4.7-alpha', '<' ) ) {
  * as indicating support for post thumbnails.
  */
 function twentyseventeen_setup() {
-	/*
-	 * Make theme available for translation.
-	 * Translations can be filed at WordPress.org. See: https://translate.wordpress.org/projects/wp-themes/twentyseventeen
-	 * If you're building a theme based on Twenty Seventeen, use a find and replace
-	 * to change 'twentyseventeen' to the name of your theme in all the template files.
-	 */
-	load_theme_textdomain( 'twentyseventeen' );
 
 	// Add default posts and comments RSS feed links to head.
 	add_theme_support( 'automatic-feed-links' );

--- a/src/wp-content/themes/twentysixteen/functions.php
+++ b/src/wp-content/themes/twentysixteen/functions.php
@@ -53,6 +53,7 @@ if ( ! function_exists( 'twentysixteen_setup' ) ) :
 		 *
 		 * Manual loading of text domain is not required after the introduction of
 		 * just in time translation loading in WordPress version 4.6.
+		 *
 		 * @ticket 58318
 		 */
 		if ( version_compare( $GLOBALS['wp_version'], '4.6', '<' ) ) {

--- a/src/wp-content/themes/twentysixteen/functions.php
+++ b/src/wp-content/themes/twentysixteen/functions.php
@@ -49,9 +49,13 @@ if ( ! function_exists( 'twentysixteen_setup' ) ) :
 		 * Make theme available for translation.
 		 * Translations can be filed at WordPress.org. See: https://translate.wordpress.org/projects/wp-themes/twentysixteen
 		 * If you're building a theme based on Twenty Sixteen, use a find and replace
-		 * to change 'twentysixteen' to the name of your theme in all the template files
+		 * to change 'twentysixteen' to the name of your theme in all the template files.
+		 * Manual loading of text domain is not required after the introduction of 
+		 * just in time loading for translations in WordPress version 4.6.
 		 */
-		load_theme_textdomain( 'twentysixteen' );
+		if ( version_compare( $GLOBALS['wp_version'], '4.6', '<' ) ) {
+			load_theme_textdomain( 'twentysixteen' );
+		}
 
 		// Add default posts and comments RSS feed links to head.
 		add_theme_support( 'automatic-feed-links' );

--- a/src/wp-content/themes/twentysixteen/functions.php
+++ b/src/wp-content/themes/twentysixteen/functions.php
@@ -50,8 +50,8 @@ if ( ! function_exists( 'twentysixteen_setup' ) ) :
 		 * Translations can be filed at WordPress.org. See: https://translate.wordpress.org/projects/wp-themes/twentysixteen
 		 * If you're building a theme based on Twenty Sixteen, use a find and replace
 		 * to change 'twentysixteen' to the name of your theme in all the template files.
-		 * 
-		 * Manual loading of text domain is not required after the introduction of 
+		 *
+		 * Manual loading of text domain is not required after the introduction of
 		 * just in time translation loading in WordPress version 4.6.
 		 * @ticket 58318
 		 */

--- a/src/wp-content/themes/twentysixteen/functions.php
+++ b/src/wp-content/themes/twentysixteen/functions.php
@@ -50,8 +50,10 @@ if ( ! function_exists( 'twentysixteen_setup' ) ) :
 		 * Translations can be filed at WordPress.org. See: https://translate.wordpress.org/projects/wp-themes/twentysixteen
 		 * If you're building a theme based on Twenty Sixteen, use a find and replace
 		 * to change 'twentysixteen' to the name of your theme in all the template files.
+		 * 
 		 * Manual loading of text domain is not required after the introduction of 
-		 * just in time loading for translations in WordPress version 4.6.
+		 * just in time translation loading in WordPress version 4.6.
+		 * @ticket 58318
 		 */
 		if ( version_compare( $GLOBALS['wp_version'], '4.6', '<' ) ) {
 			load_theme_textdomain( 'twentysixteen' );

--- a/src/wp-content/themes/twentyten/functions.php
+++ b/src/wp-content/themes/twentyten/functions.php
@@ -128,8 +128,10 @@ if ( ! function_exists( 'twentyten_setup' ) ) :
 		/*
 		 * Make theme available for translation.
 		 * Translations can be filed in the /languages/ directory.
+		 * 
 		 * Manual loading of text domain is not required after the introduction of 
-		 * just in time loading for translations in WordPress version 4.6.
+		 * just in time translation loading in WordPress version 4.6.
+		 * @ticket 58318
 		 */
 		if ( version_compare( $GLOBALS['wp_version'], '4.6', '<' ) ) {
 			load_theme_textdomain( 'twentyten', get_template_directory() . '/languages' );

--- a/src/wp-content/themes/twentyten/functions.php
+++ b/src/wp-content/themes/twentyten/functions.php
@@ -128,8 +128,12 @@ if ( ! function_exists( 'twentyten_setup' ) ) :
 		/*
 		 * Make theme available for translation.
 		 * Translations can be filed in the /languages/ directory.
+		 * Manual loading of text domain is not required after the introduction of 
+		 * just in time loading for translations in WordPress version 4.6.
 		 */
-		load_theme_textdomain( 'twentyten', get_template_directory() . '/languages' );
+		if ( version_compare( $GLOBALS['wp_version'], '4.6', '<' ) ) {
+			load_theme_textdomain( 'twentyten', get_template_directory() . '/languages' );
+		}
 
 		// This theme uses wp_nav_menu() in one location.
 		register_nav_menus(

--- a/src/wp-content/themes/twentyten/functions.php
+++ b/src/wp-content/themes/twentyten/functions.php
@@ -128,8 +128,8 @@ if ( ! function_exists( 'twentyten_setup' ) ) :
 		/*
 		 * Make theme available for translation.
 		 * Translations can be filed in the /languages/ directory.
-		 * 
-		 * Manual loading of text domain is not required after the introduction of 
+		 *
+		 * Manual loading of text domain is not required after the introduction of
 		 * just in time translation loading in WordPress version 4.6.
 		 * @ticket 58318
 		 */

--- a/src/wp-content/themes/twentyten/functions.php
+++ b/src/wp-content/themes/twentyten/functions.php
@@ -131,6 +131,7 @@ if ( ! function_exists( 'twentyten_setup' ) ) :
 		 *
 		 * Manual loading of text domain is not required after the introduction of
 		 * just in time translation loading in WordPress version 4.6.
+		 *
 		 * @ticket 58318
 		 */
 		if ( version_compare( $GLOBALS['wp_version'], '4.6', '<' ) ) {

--- a/src/wp-content/themes/twentythirteen/functions.php
+++ b/src/wp-content/themes/twentythirteen/functions.php
@@ -78,6 +78,7 @@ function twentythirteen_setup() {
 	 *
 	 * Manual loading of text domain is not required after the introduction of
 	 * just in time translation loading in WordPress version 4.6.
+	 *
 	 * @ticket 58318
 	 */
 	if ( version_compare( $GLOBALS['wp_version'], '4.6', '<' ) ) {

--- a/src/wp-content/themes/twentythirteen/functions.php
+++ b/src/wp-content/themes/twentythirteen/functions.php
@@ -75,8 +75,13 @@ function twentythirteen_setup() {
 	 * If you're building a theme based on Twenty Thirteen, use a find and
 	 * replace to change 'twentythirteen' to the name of your theme in all
 	 * template files.
+	 * Manual loading of text domain is not required after the introduction of 
+	 * just in time loading for translations in WordPress version 4.6.
 	 */
-	load_theme_textdomain( 'twentythirteen' );
+	if ( version_compare( $GLOBALS['wp_version'], '4.6', '<' ) ) {
+		load_theme_textdomain( 'twentythirteen' );
+	}
+	
 
 	/*
 	 * This theme styles the visual editor to resemble the theme style,

--- a/src/wp-content/themes/twentythirteen/functions.php
+++ b/src/wp-content/themes/twentythirteen/functions.php
@@ -75,15 +75,14 @@ function twentythirteen_setup() {
 	 * If you're building a theme based on Twenty Thirteen, use a find and
 	 * replace to change 'twentythirteen' to the name of your theme in all
 	 * template files.
-	 * 
-	 * Manual loading of text domain is not required after the introduction of 
+	 *
+	 * Manual loading of text domain is not required after the introduction of
 	 * just in time translation loading in WordPress version 4.6.
 	 * @ticket 58318
 	 */
 	if ( version_compare( $GLOBALS['wp_version'], '4.6', '<' ) ) {
 		load_theme_textdomain( 'twentythirteen' );
 	}
-	
 
 	/*
 	 * This theme styles the visual editor to resemble the theme style,

--- a/src/wp-content/themes/twentythirteen/functions.php
+++ b/src/wp-content/themes/twentythirteen/functions.php
@@ -75,8 +75,10 @@ function twentythirteen_setup() {
 	 * If you're building a theme based on Twenty Thirteen, use a find and
 	 * replace to change 'twentythirteen' to the name of your theme in all
 	 * template files.
+	 * 
 	 * Manual loading of text domain is not required after the introduction of 
-	 * just in time loading for translations in WordPress version 4.6.
+	 * just in time translation loading in WordPress version 4.6.
+	 * @ticket 58318
 	 */
 	if ( version_compare( $GLOBALS['wp_version'], '4.6', '<' ) ) {
 		load_theme_textdomain( 'twentythirteen' );

--- a/src/wp-content/themes/twentytwelve/functions.php
+++ b/src/wp-content/themes/twentytwelve/functions.php
@@ -54,6 +54,7 @@ function twentytwelve_setup() {
 	 *
 	 * Manual loading of text domain is not required after the introduction of
 	 * just in time translation loading in WordPress version 4.6.
+	 *
 	 * @ticket 58318
 	 */
 	if ( version_compare( $GLOBALS['wp_version'], '4.6', '<' ) ) {

--- a/src/wp-content/themes/twentytwelve/functions.php
+++ b/src/wp-content/themes/twentytwelve/functions.php
@@ -51,15 +51,14 @@ function twentytwelve_setup() {
 	 * Translations can be filed at WordPress.org. See: https://translate.wordpress.org/projects/wp-themes/twentytwelve
 	 * If you're building a theme based on Twenty Twelve, use a find and replace
 	 * to change 'twentytwelve' to the name of your theme in all the template files.
-	 * 
-	 * Manual loading of text domain is not required after the introduction of 
+	 *
+	 * Manual loading of text domain is not required after the introduction of
 	 * just in time translation loading in WordPress version 4.6.
 	 * @ticket 58318
 	 */
 	if ( version_compare( $GLOBALS['wp_version'], '4.6', '<' ) ) {
 		load_theme_textdomain( 'twentytwelve' );
 	}
-	
 
 	// This theme styles the visual editor with editor-style.css to match the theme style.
 	add_editor_style();

--- a/src/wp-content/themes/twentytwelve/functions.php
+++ b/src/wp-content/themes/twentytwelve/functions.php
@@ -51,8 +51,13 @@ function twentytwelve_setup() {
 	 * Translations can be filed at WordPress.org. See: https://translate.wordpress.org/projects/wp-themes/twentytwelve
 	 * If you're building a theme based on Twenty Twelve, use a find and replace
 	 * to change 'twentytwelve' to the name of your theme in all the template files.
+	 * Manual loading of text domain is not required after the introduction of 
+	 * just in time loading for translations in WordPress version 4.6.
 	 */
-	load_theme_textdomain( 'twentytwelve' );
+	if ( version_compare( $GLOBALS['wp_version'], '4.6', '<' ) ) {
+		load_theme_textdomain( 'twentytwelve' );
+	}
+	
 
 	// This theme styles the visual editor with editor-style.css to match the theme style.
 	add_editor_style();

--- a/src/wp-content/themes/twentytwelve/functions.php
+++ b/src/wp-content/themes/twentytwelve/functions.php
@@ -51,8 +51,10 @@ function twentytwelve_setup() {
 	 * Translations can be filed at WordPress.org. See: https://translate.wordpress.org/projects/wp-themes/twentytwelve
 	 * If you're building a theme based on Twenty Twelve, use a find and replace
 	 * to change 'twentytwelve' to the name of your theme in all the template files.
+	 * 
 	 * Manual loading of text domain is not required after the introduction of 
-	 * just in time loading for translations in WordPress version 4.6.
+	 * just in time translation loading in WordPress version 4.6.
+	 * @ticket 58318
 	 */
 	if ( version_compare( $GLOBALS['wp_version'], '4.6', '<' ) ) {
 		load_theme_textdomain( 'twentytwelve' );

--- a/src/wp-content/themes/twentytwenty/functions.php
+++ b/src/wp-content/themes/twentytwenty/functions.php
@@ -111,14 +111,6 @@ function twentytwenty_theme_support() {
 		)
 	);
 
-	/*
-	 * Make theme available for translation.
-	 * Translations can be filed in the /languages/ directory.
-	 * If you're building a theme based on Twenty Twenty, use a find and replace
-	 * to change 'twentytwenty' to the name of your theme in all the template files.
-	 */
-	load_theme_textdomain( 'twentytwenty' );
-
 	// Add support for full and wide align images.
 	add_theme_support( 'align-wide' );
 

--- a/src/wp-content/themes/twentytwentyone/functions.php
+++ b/src/wp-content/themes/twentytwentyone/functions.php
@@ -27,13 +27,6 @@ if ( ! function_exists( 'twenty_twenty_one_setup' ) ) {
 	 * @return void
 	 */
 	function twenty_twenty_one_setup() {
-		/*
-		 * Make theme available for translation.
-		 * Translations can be filed in the /languages/ directory.
-		 * If you're building a theme based on Twenty Twenty-One, use a find and replace
-		 * to change 'twentytwentyone' to the name of your theme in all the template files.
-		 */
-		load_theme_textdomain( 'twentytwentyone', get_template_directory() . '/languages' );
 
 		// Add default posts and comments RSS feed links to head.
 		add_theme_support( 'automatic-feed-links' );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Remove explicit call to `load_theme_textdomain()` after `twentyseventeen` theme since they all require WordPress version 4.6 (just in time translation loading introduced) and above. Add a `wp_version` conditional check for themes before `twentyseventeen` for a call to `load_theme_textdomain()` to be included.

Trac ticket: https://core.trac.wordpress.org/ticket/58318

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
