### PR TITLE
check if there is a correct id in var otherwise use the id_field as id

### DIFF
--- a/src/wp-includes/class-wp-walker.php
+++ b/src/wp-includes/class-wp-walker.php
@@ -135,8 +135,8 @@ class Walker {
 			return;
 		}
 
-		$id_field = $this->db_fields['id'];
-		$id       = $element->$id_field;
+		$id_field = is_array($this->db_fields) ? $this->db_fields['id'] : $this->db_fields;
+		$id       = !is_array($element->$id_field) ? $element->$id_field : $id_field;
 
 		// Display this element.
 		$this->has_children = ! empty( $children_elements[ $id ] );


### PR DESCRIPTION
I have no idea where to create an issue - but here is the fix for:

```
24-May-2023 16:00:16 UTC] PHP Fatal error:  Uncaught TypeError: Cannot access offset of type string on string in wp-includes/class-wp-walker.php:199

Stack trace:

#0 /wp-includes/nav-menu-template.php(616): Walker->walk(Array, 10, Object(stdClass))

#10 {main}
```