### PR TITLE
Refactor `determine_locale()` for performance and readability

### DIFF
--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -132,30 +132,25 @@ function determine_locale() {
 	 */
 	$determined_locale = apply_filters( 'pre_determine_locale', null );
 
-	if ( ! empty( $determined_locale ) && is_string( $determined_locale ) ) {
+	if ( $determined_locale && is_string( $determined_locale ) ) {
 		return $determined_locale;
 	}
 
-	$determined_locale = get_locale();
-
-	if ( is_admin() ) {
+	if (
+		( isset( $_GET['_locale'] ) && 'user' === $_GET['_locale'] && wp_is_json_request() ) ||
+		is_admin()
+	) {
 		$determined_locale = get_user_locale();
+	} else {
+		$determined_locale = get_locale();
 	}
 
-	if ( isset( $_GET['_locale'] ) && 'user' === $_GET['_locale'] && wp_is_json_request() ) {
-		$determined_locale = get_user_locale();
-	}
-
-	$wp_lang = '';
-
-	if ( ! empty( $_GET['wp_lang'] ) ) {
-		$wp_lang = sanitize_locale_name( wp_unslash( $_GET['wp_lang'] ) );
-	} elseif ( ! empty( $_COOKIE['wp_lang'] ) ) {
-		$wp_lang = sanitize_locale_name( wp_unslash( $_COOKIE['wp_lang'] ) );
-	}
-
-	if ( ! empty( $wp_lang ) && ! empty( $GLOBALS['pagenow'] ) && 'wp-login.php' === $GLOBALS['pagenow'] ) {
-		$determined_locale = $wp_lang;
+	if ( isset( $GLOBALS['pagenow'] ) && 'wp-login.php' === $GLOBALS['pagenow'] ) {
+		if ( ! empty( $_GET['wp_lang'] ) ) {
+			$determined_locale = sanitize_locale_name( $_GET['wp_lang'] ) ?: $determined_locale;
+		} elseif ( ! empty( $_COOKIE['wp_lang'] ) ) {
+			$determined_locale = sanitize_locale_name( $_COOKIE['wp_lang'] ) ?: $determined_locale;
+		}
 	}
 
 	/**

--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -147,9 +147,9 @@ function determine_locale() {
 
 	if ( isset( $GLOBALS['pagenow'] ) && 'wp-login.php' === $GLOBALS['pagenow'] ) {
 		if ( ! empty( $_GET['wp_lang'] ) ) {
-			$determined_locale = sanitize_locale_name( $_GET['wp_lang'] ) ?: $determined_locale;
+			$determined_locale = sanitize_locale_name( $_GET['wp_lang'] );
 		} elseif ( ! empty( $_COOKIE['wp_lang'] ) ) {
-			$determined_locale = sanitize_locale_name( $_COOKIE['wp_lang'] ) ?: $determined_locale;
+			$determined_locale = sanitize_locale_name( $_COOKIE['wp_lang'] );
 		}
 	}
 

--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -137,20 +137,21 @@ function determine_locale() {
 	}
 
 	if (
+		isset( $GLOBALS['pagenow'] ) && 'wp-login.php' === $GLOBALS['pagenow'] &&
+		( ! empty( $_GET['wp_lang'] ) || ! empty( $_COOKIE['wp_lang'] ) )
+	) {
+		if ( ! empty( $_GET['wp_lang'] ) ) {
+			$determined_locale = sanitize_locale_name( $_GET['wp_lang'] );
+		} else {
+			$determined_locale = sanitize_locale_name( $_COOKIE['wp_lang'] );
+		}
+	} else if (
 		( isset( $_GET['_locale'] ) && 'user' === $_GET['_locale'] && wp_is_json_request() ) ||
 		is_admin()
 	) {
 		$determined_locale = get_user_locale();
 	} else {
 		$determined_locale = get_locale();
-	}
-
-	if ( isset( $GLOBALS['pagenow'] ) && 'wp-login.php' === $GLOBALS['pagenow'] ) {
-		if ( ! empty( $_GET['wp_lang'] ) ) {
-			$determined_locale = sanitize_locale_name( $_GET['wp_lang'] );
-		} elseif ( ! empty( $_COOKIE['wp_lang'] ) ) {
-			$determined_locale = sanitize_locale_name( $_COOKIE['wp_lang'] );
-		}
 	}
 
 	/**

--- a/tests/phpunit/tests/l10n/determineLocale.php
+++ b/tests/phpunit/tests/l10n/determineLocale.php
@@ -1,0 +1,226 @@
+<?php
+
+/**
+ * @group l10n
+ * @group i18n
+ *
+ * @covers ::determine_locale
+ */
+class Tests_L10n_DetermineLocale extends WP_UnitTestCase {
+	protected $locale;
+	protected static $user_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$user_id = $factory->user->create(
+			array(
+				'role'   => 'administrator',
+				'locale' => 'userLocale',
+			)
+		);
+	}
+
+	public function tear_down()	{
+		unset( $_SERVER['CONTENT_TYPE'], $_GET['_locale'], $_COOKIE['wp_lang'], $GLOBALS['pagenow'] );
+
+		parent::tear_down();
+	}
+
+	public function test_short_circuit_empty() {
+		add_filter( 'pre_determine_locale',	'__return_false' );
+		$this->assertNotFalse( determine_locale() );
+	}
+
+	public function test_short_circuit_no_string() {
+		add_filter(
+			'pre_determine_locale',
+			static function() {
+				return 1234;
+			}
+		);
+		$this->assertNotFalse( determine_locale() );
+	}
+
+	public function test_short_circuit_string() {
+		add_filter(
+			'pre_determine_locale',
+			static function() {
+					return 'myNewLocale';
+			}
+		);
+		$this->assertSame( 'myNewLocale', determine_locale() );
+	}
+
+	public function test_defaults_to_site_locale() {
+		add_filter(
+			'locale',
+			static function() {
+				return 'siteLocale';
+			}
+		);
+
+		$this->assertSame( get_locale(), determine_locale() );
+	}
+
+	public function test_is_admin_no_user() {
+		add_filter(
+			'locale',
+			static function() {
+				return 'siteLocale';
+			}
+		);
+
+		set_current_screen( 'dashboard' );
+
+		$this->assertSame( 'siteLocale', determine_locale() );
+	}
+
+	public function test_is_admin_user_locale() {
+		add_filter(
+			'locale',
+			static function() {
+				return 'siteLocale';
+			}
+		);
+
+		set_current_screen( 'dashboard' );
+		wp_set_current_user( self::$user_id );
+
+		$this->assertSame( 'userLocale', determine_locale() );
+	}
+
+	public function test_json_request_user_locale() {
+		add_filter(
+			'locale',
+			static function() {
+				return 'siteLocale';
+			}
+		);
+
+		wp_set_current_user( self::$user_id );
+
+		$_SERVER['CONTENT_TYPE'] = 'application/json';
+		$_GET['_locale']         = 'user';
+
+		$this->assertSame( 'userLocale', determine_locale() );
+	}
+
+	public function test_json_request_user_locale_no_user() {
+		add_filter(
+			'locale',
+			static function() {
+				return 'siteLocale';
+			}
+		);
+
+		$_SERVER['CONTENT_TYPE'] = 'application/json';
+		$_GET['_locale']         = 'user';
+
+		$this->assertSame( 'siteLocale', determine_locale() );
+	}
+
+	public function test_json_request_missing_get_param() {
+		add_filter(
+			'locale',
+			static function() {
+				return 'siteLocale';
+			}
+		);
+
+		wp_set_current_user( self::$user_id );
+
+		$_SERVER['CONTENT_TYPE'] = 'application/json';
+
+		$this->assertSame( 'siteLocale', determine_locale() );
+	}
+
+	public function test_json_request_incorrect_get_param() {
+		add_filter(
+			'locale',
+			static function() {
+				return 'siteLocale';
+			}
+		);
+
+		wp_set_current_user( self::$user_id );
+
+		$_SERVER['CONTENT_TYPE'] = 'application/json';
+		$_GET['_locale']         = 'foo';
+
+		$this->assertSame( 'siteLocale', determine_locale() );
+	}
+
+	public function test_get_param_but_no_json_request() {
+		add_filter(
+			'locale',
+			static function() {
+				return 'siteLocale';
+			}
+		);
+
+		wp_set_current_user( self::$user_id );
+
+		$_GET['_locale'] = 'user';
+
+		$this->assertSame( 'siteLocale', determine_locale() );
+	}
+
+	public function test_wp_login_get_param_not_on_login_page() {
+		add_filter(
+			'locale',
+			static function() {
+				return 'siteLocale';
+			}
+		);
+
+		wp_set_current_user( self::$user_id );
+
+		$_GET['wp_lang'] = 'de_DE';
+
+		$this->assertSame( 'siteLocale', determine_locale() );
+	}
+	public function test_wp_login_get_param_on_login_page() {
+		add_filter(
+			'locale',
+			static function() {
+				return 'siteLocale';
+			}
+		);
+
+		wp_set_current_user( self::$user_id );
+
+		$GLOBALS['pagenow'] = 'wp-login.php';
+		$_GET['wp_lang']    = 'de_DE';
+
+		$this->assertSame( 'de_DE', determine_locale() );
+	}
+
+	public function test_wp_login_cookie_not_on_login_page() {
+		add_filter(
+			'locale',
+			static function() {
+				return 'siteLocale';
+			}
+		);
+
+		wp_set_current_user( self::$user_id );
+
+		$_COOKIE['wp_lang'] = 'de_DE';
+
+		$this->assertSame( 'siteLocale', determine_locale() );
+	}
+	public function test_wp_login_cookie_on_login_page() {
+		add_filter(
+			'locale',
+			static function() {
+				return 'siteLocale';
+			}
+		);
+
+		wp_set_current_user( self::$user_id );
+
+		$GLOBALS['pagenow'] = 'wp-login.php';
+		$_COOKIE['wp_lang'] = 'de_DE';
+
+		$this->assertSame( 'de_DE', determine_locale() );
+	}
+}

--- a/tests/phpunit/tests/l10n/determineLocale.php
+++ b/tests/phpunit/tests/l10n/determineLocale.php
@@ -19,14 +19,14 @@ class Tests_L10n_DetermineLocale extends WP_UnitTestCase {
 		);
 	}
 
-	public function tear_down()	{
+	public function tear_down() {
 		unset( $_SERVER['CONTENT_TYPE'], $_GET['_locale'], $_COOKIE['wp_lang'], $GLOBALS['pagenow'] );
 
 		parent::tear_down();
 	}
 
 	public function test_short_circuit_empty() {
-		add_filter( 'pre_determine_locale',	'__return_false' );
+		add_filter( 'pre_determine_locale', '__return_false' );
 		$this->assertNotFalse( determine_locale() );
 	}
 

--- a/tests/phpunit/tests/l10n/determineLocale.php
+++ b/tests/phpunit/tests/l10n/determineLocale.php
@@ -178,7 +178,7 @@ class Tests_L10n_DetermineLocale extends WP_UnitTestCase {
 
 		$this->assertSame( 'siteLocale', determine_locale() );
 	}
-	
+
 	public function test_wp_login_get_param_on_login_page() {
 		add_filter(
 			'locale',

--- a/tests/phpunit/tests/l10n/determineLocale.php
+++ b/tests/phpunit/tests/l10n/determineLocale.php
@@ -178,6 +178,7 @@ class Tests_L10n_DetermineLocale extends WP_UnitTestCase {
 
 		$this->assertSame( 'siteLocale', determine_locale() );
 	}
+	
 	public function test_wp_login_get_param_on_login_page() {
 		add_filter(
 			'locale',
@@ -224,6 +225,7 @@ class Tests_L10n_DetermineLocale extends WP_UnitTestCase {
 
 		$this->assertSame( 'siteLocale', determine_locale() );
 	}
+
 	public function test_wp_login_cookie_on_login_page() {
 		add_filter(
 			'locale',

--- a/tests/phpunit/tests/l10n/determineLocale.php
+++ b/tests/phpunit/tests/l10n/determineLocale.php
@@ -194,6 +194,22 @@ class Tests_L10n_DetermineLocale extends WP_UnitTestCase {
 		$this->assertSame( 'de_DE', determine_locale() );
 	}
 
+	public function test_wp_login_get_param_on_login_page_empty_string() {
+		add_filter(
+			'locale',
+			static function() {
+				return 'siteLocale';
+			}
+		);
+
+		wp_set_current_user( self::$user_id );
+
+		$GLOBALS['pagenow'] = 'wp-login.php';
+		$_GET['wp_lang']    = '';
+
+		$this->assertSame( 'siteLocale', determine_locale() );
+	}
+
 	public function test_wp_login_cookie_not_on_login_page() {
 		add_filter(
 			'locale',
@@ -222,5 +238,21 @@ class Tests_L10n_DetermineLocale extends WP_UnitTestCase {
 		$_COOKIE['wp_lang'] = 'de_DE';
 
 		$this->assertSame( 'de_DE', determine_locale() );
+	}
+
+	public function test_wp_login_cookie_on_login_page_empty_string() {
+		add_filter(
+			'locale',
+			static function() {
+				return 'siteLocale';
+			}
+		);
+
+		wp_set_current_user( self::$user_id );
+
+		$GLOBALS['pagenow'] = 'wp-login.php';
+		$_COOKIE['wp_lang'] = '';
+
+		$this->assertSame( 'siteLocale', determine_locale() );
 	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Refreshed `l10n.php.patch` patch + additional tests for `determine_locale()` that pass before and after the patch.

Refactors `determine_locale()` for performance and readability.

I prefer the original patch over #4455 as it has a good balance between readability and performance.

Trac ticket: https://core.trac.wordpress.org/ticket/58317

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
