### PR TITLE
Backport: Add the Behaviors UI

### DIFF
--- a/src/wp-includes/behaviors.php
+++ b/src/wp-includes/behaviors.php
@@ -14,10 +14,9 @@
  * @param array $editor_settings The array of editor settings.
  * @return array A filtered array of editor settings.
  */
-function wp_add_behaviors( $settings )
-{
+function wp_add_behaviors( $settings ) {
 	$theme_data = WP_Theme_JSON_Resolver::get_merged_data()->get_data();
-	if (array_key_exists('behaviors', $theme_data)) {
+	if ( array_key_exists( 'behaviors', $theme_data ) ) {
 		$settings['behaviors'] = $theme_data['behaviors'];
 	}
 	return $settings;

--- a/src/wp-includes/behaviors.php
+++ b/src/wp-includes/behaviors.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Block Behaviors.
+ *
+ * @package WordPress
+ * @since 6.3.0
+ *
+ */
+
+/**
+ * Updates the block editor settings with the theme's behaviors.
+ *
+ * @since 6.3.0
+ * @param array $editor_settings The array of editor settings.
+ * @return array A filtered array of editor settings.
+ */
+function wp_add_behaviors($settings)
+{
+	$theme_data = WP_Theme_JSON_Resolver::get_merged_data()->get_data();
+	if (array_key_exists('behaviors', $theme_data)) {
+		$settings['behaviors'] = $theme_data['behaviors'];
+	}
+	return $settings;
+}

--- a/src/wp-includes/behaviors.php
+++ b/src/wp-includes/behaviors.php
@@ -14,7 +14,7 @@
  * @param array $editor_settings The array of editor settings.
  * @return array A filtered array of editor settings.
  */
-function wp_add_behaviors($settings)
+function wp_add_behaviors( $settings )
 {
 	$theme_data = WP_Theme_JSON_Resolver::get_merged_data()->get_data();
 	if (array_key_exists('behaviors', $theme_data)) {

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -321,6 +321,7 @@ class WP_Theme_JSON {
 		'templateParts',
 		'title',
 		'version',
+		'behaviors',
 	);
 
 	/**
@@ -398,6 +399,7 @@ class WP_Theme_JSON {
 			'textDecoration' => null,
 			'textTransform'  => null,
 		),
+		'behaviors'                     => null,
 	);
 
 	/**

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -720,4 +720,7 @@ add_filter( 'render_block', 'wp_render_typography_support', 10, 2 );
 // User preferences.
 add_action( 'init', 'wp_register_persisted_preferences_meta' );
 
+// Behaviors
+add_filter( 'block_editor_settings_all', 'wp_add_behaviors' );
+
 unset( $filter, $action );

--- a/src/wp-includes/theme.json
+++ b/src/wp-includes/theme.json
@@ -1,5 +1,12 @@
 {
 	"version": 2,
+	"behaviors": {
+		"blocks": {
+			"core/image": {
+				"lightbox": false
+			}
+		}
+	},
 	"settings": {
 		"appearanceTools": false,
 		"useRootPaddingAwareAlignments": false,
@@ -413,6 +420,11 @@
 					"radius": true,
 					"style": true,
 					"width": true
+				}
+			},
+			"core/image": {
+				"behaviors": {
+					"lightbox": true
 				}
 			}
 		}

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -344,6 +344,7 @@ require ABSPATH . WPINC . '/style-engine/class-wp-style-engine-css-declarations.
 require ABSPATH . WPINC . '/style-engine/class-wp-style-engine-css-rule.php';
 require ABSPATH . WPINC . '/style-engine/class-wp-style-engine-css-rules-store.php';
 require ABSPATH . WPINC . '/style-engine/class-wp-style-engine-processor.php';
+require ABSPATH . WPINC . '/behaviors.php';
 
 $GLOBALS['wp_embed'] = new WP_Embed();
 


### PR DESCRIPTION
Backport the PR that introduced the Behaviors UI in the block editor:

- https://github.com/WordPress/gutenberg/pull/49972/

Trac ticket: https://core.trac.wordpress.org/ticket/58431

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
