### PR TITLE
Add pre_update_term filter hook

### DIFF
--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -3154,6 +3154,17 @@ function wp_update_term( $term_id, $taxonomy, $args = array() ) {
 	// First, get all of the original args.
 	$term = get_term( $term_id, $taxonomy );
 
+	/**
+	 * Filters a term before it is sanitized and updated into the database.
+	 *
+	 * @since 6.3.0
+	 *
+	 * @param string|WP_Error $term     The term name to add, or a WP_Error object if there's an error.
+	 * @param string          $taxonomy Taxonomy slug.
+	 * @param array|string    $args     Array or query string of arguments passed to wp_update_term().
+	 */
+	$term = apply_filters( 'pre_update_term', $term, $taxonomy, $args );
+
 	if ( is_wp_error( $term ) ) {
 		return $term;
 	}


### PR DESCRIPTION
Hi
In file:
`wp-includes/taxonomy.php`
In function:
`wp_update_term`
How can to validate a custom term before updated?
A filter needs here like `pre_insert_term` in `wp_insert_term()` functin.
I think this filter has been forgotten in here.
`$term = apply_filters( 'pre_update_term', $term, $taxonomy, $args );`

https://core.trac.wordpress.org/ticket/58404

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
