### PR TITLE
Users: handling the retrieve_password() answer correctly (as potential WP_Error)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,6 @@ wp-tests-config.php
 /packagehash.txt
 /artifacts
 /setup.log
-/.idea
 
 # Files and folders that get created in wp-content
 /src/wp-content/blogs.dir

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ wp-tests-config.php
 /packagehash.txt
 /artifacts
 /setup.log
+/.idea
 
 # Files and folders that get created in wp-content
 /src/wp-content/blogs.dir

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -5568,12 +5568,12 @@ function wp_ajax_send_password_reset() {
 
 	if ( true === $results ) {
 		wp_send_json_success(
-		/* translators: %s: User's display name. */
+			/* translators: %s: User's display name. */
 			sprintf( __( 'A password reset link was emailed to %s.' ), $user->display_name )
 		);
 	} elseif ( is_wp_error( $results ) ) {
 		wp_send_json_success(
-		/* translators: %s: User's display name. */
+			/* translators: %s: User's display name. */
 			sprintf( __( 'A password reset link was emailed to %s.' ), $user->display_name )
 		);
 	} else {

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -5577,6 +5577,6 @@ function wp_ajax_send_password_reset() {
 			sprintf( __( 'A password reset link was emailed to %s.' ), $user->display_name )
 		);
 	} else {
-		wp_send_json_error( 'Cannot retrieve user\'s password', 500);
+		wp_send_json_error( 'Cannot retrieve user\'s password', 500 );
 	}
 }

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -5566,12 +5566,17 @@ function wp_ajax_send_password_reset() {
 	$user    = get_userdata( $user_id );
 	$results = retrieve_password( $user->user_login );
 
-	if ( ! is_wp_error( $results ) ) {
+	if ( true === $results ) {
 		wp_send_json_success(
-			/* translators: %s: User's display name. */
+		/* translators: %s: User's display name. */
+			sprintf( __( 'A password reset link was emailed to %s.' ), $user->display_name )
+		);
+	} elseif ( is_wp_error( $results ) ) {
+		wp_send_json_success(
+		/* translators: %s: User's display name. */
 			sprintf( __( 'A password reset link was emailed to %s.' ), $user->display_name )
 		);
 	} else {
-		wp_send_json_error( $results->get_error_message() );
+		wp_send_json_error( 'Cannot retrieve user\'s password', 500);
 	}
 }

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -5566,7 +5566,7 @@ function wp_ajax_send_password_reset() {
 	$user    = get_userdata( $user_id );
 	$results = retrieve_password( $user->user_login );
 
-	if ( true === $results ) {
+	if ( ! is_wp_error( $results ) ) {
 		wp_send_json_success(
 			/* translators: %s: User's display name. */
 			sprintf( __( 'A password reset link was emailed to %s.' ), $user->display_name )

--- a/src/wp-admin/users.php
+++ b/src/wp-admin/users.php
@@ -250,7 +250,7 @@ switch ( $wp_list_table->current_action() ) {
 
 			// Send the password reset link.
 			$user = get_userdata( $id );
-			if ( ! is_wp_error( retrieve_password( $user->user_login ) ) ) {
+			if ( true === retrieve_password( $user->user_login ) ) {
 				++$reset_count;
 			}
 		}

--- a/src/wp-admin/users.php
+++ b/src/wp-admin/users.php
@@ -250,7 +250,7 @@ switch ( $wp_list_table->current_action() ) {
 
 			// Send the password reset link.
 			$user = get_userdata( $id );
-			if ( retrieve_password( $user->user_login ) ) {
+			if ( ! is_wp_error( retrieve_password( $user->user_login ) ) ) {
 				++$reset_count;
 			}
 		}

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -793,7 +793,7 @@ switch ( $action ) {
 		if ( $http_post ) {
 			$errors = retrieve_password();
 
-			if ( ! is_wp_error( $errors ) ) {
+			if ( true === $errors ) {
 				$redirect_to = ! empty( $_REQUEST['redirect_to'] ) ? $_REQUEST['redirect_to'] : 'wp-login.php?checkemail=confirm';
 				wp_safe_redirect( $redirect_to );
 				exit;


### PR DESCRIPTION
Handling the `retrieve_password()` in `wp-admin/users.php` answer correctly (as potential WP_Error) to prevent incorrect `Password reset link sent` for users that are not allowed to reset their passwords

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/58407

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
