### PR TITLE
prevent publish date from being set on draft post.

### DIFF
--- a/src/js/_enqueues/admin/inline-edit-post.js
+++ b/src/js/_enqueues/admin/inline-edit-post.js
@@ -449,6 +449,13 @@ window.wp = window.wp || {};
 		};
 
 		fields = $('#edit-'+id).find(':input').serialize();
+
+		var status = $(':input[name="_status"]').val();
+
+		if ( [ 'draft', 'pending', 'auto-draft' ].includes( status ) ) {
+			params.edit_date = 'false';
+		}
+
 		params = fields + '&' + $.param(params);
 
 		// Make Ajax request.

--- a/src/wp-admin/includes/post.php
+++ b/src/wp-admin/includes/post.php
@@ -169,6 +169,10 @@ function _wp_translate_postdata( $update = false, $post_data = null ) {
 		}
 	}
 
+	if ( isset( $post_data['edit_date'] ) && 'false' === $post_data['edit_date'] ) {
+		$post_data['edit_date'] = false;
+	}
+
 	if ( ! empty( $post_data['edit_date'] ) ) {
 		$aa = $post_data['aa'];
 		$mm = $post_data['mm'];


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/19907

In this PR, we are disabling saving of date when a `draft` post is being saved in the quik-editor for posts.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
