### PR TITLE
Try/56199 colorize badge php version check

### DIFF
--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -886,6 +886,7 @@ form#tags-filter {
 	pointer-events: none;
 	font-weight: 600;
 	flex-grow: 1;
+	padding-right: 1.5em;
 }
 
 .privacy-settings-accordion-trigger .icon,

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -784,6 +784,7 @@ class WP_Site_Health {
 			);
 
 			$result['status']         = 'critical';
+			$result['badge']['color'] = 'red';
 			$result['badge']['label'] = __( 'Requirements' );
 
 			return $result;
@@ -817,9 +818,9 @@ class WP_Site_Health {
 			);
 		}
 
-		$result['label']  = $message;
-		$result['status'] = 'critical';
-
+		$result['label']          = $message;
+		$result['status']         = 'critical';
+		$result['badge']['color'] = 'red';
 		$result['badge']['label'] = __( 'Security' );
 
 		return $result;

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -767,7 +767,8 @@ class WP_Site_Health {
 				__( 'Your site is running on an older version of PHP (%s)' ),
 				PHP_VERSION
 			);
-			$result['status'] = 'recommended';
+			$result['status']         = 'recommended';
+			$result['badge']['color'] = 'orange';
 
 			return $result;
 		}
@@ -797,7 +798,8 @@ class WP_Site_Health {
 				__( 'Your site is running on an older version of PHP (%s), which should be updated' ),
 				PHP_VERSION
 			);
-			$result['status'] = 'recommended';
+			$result['status']         = 'recommended';
+			$result['badge']['color'] = 'orange';
 
 			return $result;
 		}


### PR DESCRIPTION
In Site Health PHP version check results:
- Colorizes "critical" status results in red.
- Colorizes "recommended" status results in orange.
- Adds padding to give space between result description and status badge.

Test instructions: https://core.trac.wordpress.org/ticket/56199#comment:39

Trac ticket: https://core.trac.wordpress.org/ticket/56199

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
