### PR TITLE
Add `wp_get_remote_theme_patterns` function

### DIFF
--- a/src/wp-includes/block-patterns.php
+++ b/src/wp-includes/block-patterns.php
@@ -287,7 +287,7 @@ function _register_remote_theme_patterns() {
 		return;
 	}
 
-	$pattern_settings = WP_Theme_JSON_Resolver::get_theme_data()->get_patterns();
+	$pattern_settings = wp_get_remote_theme_patterns();
 	if ( empty( $pattern_settings ) ) {
 		return;
 	}

--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -426,3 +426,15 @@ function wp_clean_theme_json_cache() {
 	wp_cache_delete( 'wp_get_global_styles_custom_css', 'theme_json' );
 	WP_Theme_JSON_Resolver::clean_cached_data();
 }
+
+/**
+ * Returns the current theme's wanted patterns (slugs) to be
+ * registered from Pattern Directory.
+ *
+ * @since 6.3.0
+ *
+ * @return string[]
+ */
+function wp_get_remote_theme_patterns() {
+	return WP_Theme_JSON_Resolver::get_theme_data( array(), array( 'with_supports' => false ) )->get_patterns();
+}


### PR DESCRIPTION
Trac ticket https://core.trac.wordpress.org/ticket/58460
Part of https://github.com/WordPress/gutenberg/issues/45171
Backports https://github.com/WordPress/gutenberg/pull/49307

## What?

Adds a new public function, `wp_get_remote_theme_patterns` to query the `patterns` datum from `theme.json` and substitutes current usage of private APIs.

## Why?

We need to offer public APIs for consumers to add the data they need, so they don't resort to using private APIs.

## How?

- Creates a new function called `wp_get_remote_theme_patterns`.
- Uses the new function in place of the call to the private class `WP_Theme_JSON_Resolver`.

## Testing Instructions

- Use TwentyTwentyThree theme and add the following to its `theme.json`:

```json
{
  "patterns": [ "partner-logos" ]
}
```

- Go to the post editor and open the inserter.
- Search for "logos".
- The expected result is that the pattern shows up in the list.

Also test that by removing the `patterns` from `theme.json` the pattern is not present.

## Commit message

```msg
Themes: add wp_get_remote_theme_patterns function.

Adds a new public function, `wp_get_remote_theme_patterns` to query the `patterns` datum from `theme.json` and substitutes current usage of private APIs.

Props ntsekouras, poena, audrasjb.
Fixes #58460
```
