### PR TITLE
Fix #wpbody alignment and avoid sticky menu when there is a PHP notice

### DIFF
--- a/src/js/_enqueues/admin/common.js
+++ b/src/js/_enqueues/admin/common.js
@@ -816,7 +816,7 @@ $( function() {
 		currentPage = pageInput.val(),
 		isIOS = /iPhone|iPad|iPod/.test( navigator.userAgent ),
 		isAndroid = navigator.userAgent.indexOf( 'Android' ) !== -1,
-		$adminMenuWrap = $( '#adminmenuwrap' ),
+		$adminMenuWrap = $( 'body:not(.php-error) #adminmenuwrap' ),
 		$wpwrap = $( '#wpwrap' ),
 		$adminmenu = $( '#adminmenu' ),
 		$overlay = $( '#wp-responsive-overlay' ),

--- a/src/wp-admin/css/admin-menu.css
+++ b/src/wp-admin/css/admin-menu.css
@@ -326,7 +326,7 @@ div.wp-menu-image:before {
 }
 
 /* Sticky admin menu */
-.sticky-menu #adminmenuwrap {
+.sticky-menu:not(.php-error) #adminmenuwrap {
 	position: fixed;
 }
 

--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -736,6 +736,12 @@ form#tags-filter {
 	margin-top: 5px;
 }
 
+/* Additional margin when there is a PHP notice */
+.privacy-settings.php-error #wpbody-content,
+.site-health.php-error #wpbody-content {
+	margin-top: 2em;
+}
+
 /* Emulates .wrap h1 styling */
 .privacy-settings-header h1,
 .health-check-header h1 {


### PR DESCRIPTION
Fixes https://core.trac.wordpress.org/ticket/58455
And also https://core.trac.wordpress.org/ticket/58449
