### PR TITLE
Wp admin comments screen performance

### DIFF
--- a/src/wp-admin/includes/class-wp-comments-list-table.php
+++ b/src/wp-admin/includes/class-wp-comments-list-table.php
@@ -518,8 +518,9 @@ class WP_Comments_List_Table extends WP_List_Table {
 			foreach ( $comment_types as $type => $label ) {
 				if ( get_comments(
 					array(
-						'number' => 1,
-						'type'   => $type,
+						'number'  => 1,
+						'orderby' => 'none',
+						'type'    => $type,
 					)
 				) ) {
 					printf(

--- a/src/wp-admin/includes/schema.php
+++ b/src/wp-admin/includes/schema.php
@@ -119,7 +119,8 @@ CREATE TABLE $wpdb->comments (
 	KEY comment_approved_date_gmt (comment_approved,comment_date_gmt),
 	KEY comment_date_gmt (comment_date_gmt),
 	KEY comment_parent (comment_parent),
-	KEY comment_author_email (comment_author_email(10))
+	KEY comment_author_email (comment_author_email(10)),
+	KEY comment_type (comment_type),
 ) $charset_collate;
 CREATE TABLE $wpdb->links (
 	link_id bigint(20) unsigned NOT NULL auto_increment,

--- a/src/wp-admin/includes/schema.php
+++ b/src/wp-admin/includes/schema.php
@@ -120,7 +120,7 @@ CREATE TABLE $wpdb->comments (
 	KEY comment_date_gmt (comment_date_gmt),
 	KEY comment_parent (comment_parent),
 	KEY comment_author_email (comment_author_email(10)),
-	KEY comment_type (comment_type),
+	KEY comment_type (comment_type)
 ) $charset_collate;
 CREATE TABLE $wpdb->links (
 	link_id bigint(20) unsigned NOT NULL auto_increment,

--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -2316,6 +2316,11 @@ function upgrade_630() {
 				delete_option( 'can_compress_scripts' );
 				add_option( 'can_compress_scripts', $can_compress_scripts, 'yes' );
 			}
+
+			global $wpdb;
+			$wpdb->hide_errors();
+			$wpdb->query( "ALTER TABLE $wpdb->comments ADD INDEX `comment_type` (`comment_type`)" );
+			$wpdb->show_errors();
 		}
 	}
 }
@@ -2469,6 +2474,13 @@ function upgrade_network() {
 		$network_id = get_main_network_id();
 		delete_network_option( $network_id, 'site_meta_supported' );
 		is_site_meta_supported();
+	}
+
+	// 6.3.0
+	if ( $wp_current_db_version < 55853 ) {
+		$wpdb->hide_errors();
+		$wpdb->query( "ALTER TABLE $wpdb->comments ADD INDEX `comment_type` (`comment_type`)" );
+		$wpdb->show_errors();
 	}
 }
 


### PR DESCRIPTION
wp-admin -> Comments screen is slowed down by the inefficient way of getting the comment types for the comment type drop down filter.

To fix that we:

* improve the PHP code to create a simpler MySQL query.
* add `comment_type` index for `wp_comments`

This has reduced our wp-admin -> Comments load times by 85%.

Please see this ticket for full details and performance testing https://core.trac.wordpress.org/ticket/58488