### PR TITLE
57483 differentiate between failed and zero-results call to get_row()

### DIFF
--- a/src/wp-includes/class-wp-network.php
+++ b/src/wp-includes/class-wp-network.php
@@ -105,8 +105,10 @@ class WP_Network {
 		if ( false === $_network ) {
 			$_network = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->site} WHERE id = %d LIMIT 1", $network_id ) );
 
-			if ( empty( $_network ) || is_wp_error( $_network ) ) {
+			if ( null === $_network ) {
 				$_network = -1;
+			} elseif ( empty( $_network ) || is_wp_error( $_network ) ) {
+				return false;
 			}
 
 			wp_cache_add( $network_id, $_network, 'networks' );

--- a/src/wp-includes/class-wp-site.php
+++ b/src/wp-includes/class-wp-site.php
@@ -168,8 +168,10 @@ final class WP_Site {
 		if ( false === $_site ) {
 			$_site = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->blogs} WHERE blog_id = %d LIMIT 1", $site_id ) );
 
-			if ( empty( $_site ) || is_wp_error( $_site ) ) {
+			if ( null === $_site ) {
 				$_site = -1;
+			} elseif ( empty( $_site ) || is_wp_error( $_site ) ) {
+				return false;
 			}
 
 			wp_cache_add( $site_id, $_site, 'sites' );


### PR DESCRIPTION
This PR utilises the fact that `$wpdb->get_row()` will return a `null` when no entries were found vs `false` when it experienced an error. A `null` result is still cached (site/network does not exist), while a `false` one (query failed) is not.
 
Trac ticket: https://core.trac.wordpress.org/ticket/57483

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
