### PR TITLE
#58311

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2144,7 +2144,7 @@ function sanitize_user( $username, $strict = false ) {
 		/**
 		 * Filters the regexp of characters which are allowed in a username in strict mode.
 		 *
-		 * @param string[] $allowed_chars Regexp pattern for matching allowed characters.
+		 * @param string   $allowed_chars Regexp pattern for matching allowed characters.
 		 * @param string   $raw_username  The original username to be sanitized.
 		 */
 		$allowed_chars = apply_filters( 'sanitize_user_allowed_chars_regexp', $allowed_chars, $raw_username );

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2116,7 +2116,7 @@ function sanitize_file_name( $filename ) {
  * Sanitizes a username, stripping out unsafe characters.
  *
  * Removes tags, percent-encoded characters, HTML entities, and if strict is enabled,
- * will only keep alphanumeric, _, space, ., -, @. After sanitizing, it passes the username,
+ * will only keep alphanumeric, _, space, ., -. After sanitizing, it passes the username,
  * raw username (the username in the parameter), and the value of $strict as parameters
  * for the {@see 'sanitize_user'} filter.
  *
@@ -2138,7 +2138,17 @@ function sanitize_user( $username, $strict = false ) {
 
 	// If strict, reduce to ASCII for max portability.
 	if ( $strict ) {
-		$username = preg_replace( '|[^a-z0-9 _.\-@]|i', '', $username );
+		// Removed @ to disallow email adresses as username for new users.
+		$allowed_chars = 'a-z0-9 _.\-';
+
+		/**
+		 * Filters the regexp of characters which are allowed in a username in strict mode.
+		 *
+		 * @param string[] $allowed_chars Regexp pattern for matching allowed characters.
+		 * @param string   $raw_username  The original username to be sanitized.
+		 */
+		$allowed_chars = apply_filters( 'sanitize_user_allowed_chars_regexp', $allowed_chars, $raw_username );
+		$username = preg_replace( "|[^{$allowed_chars}]|i", '', $username );
 	}
 
 	$username = trim( $username );

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -793,7 +793,6 @@ class Tests_User extends WP_UnitTestCase {
 	 */
 	public function test_validate_username_string() {
 		$this->assertTrue( validate_username( 'johndoe' ) );
-		$this->assertTrue( validate_username( 'test@test.com' ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/user/retrievePassword.php
+++ b/tests/phpunit/tests/user/retrievePassword.php
@@ -66,12 +66,12 @@ class Tests_User_RetrievePassword extends WP_UnitTestCase {
 	public function test_retrieve_password_should_fetch_user_by_login_if_not_found_by_email() {
 		self::factory()->user->create(
 			array(
-				'user_login' => 'foo@example.com',
+				'user_login' => 'foo',
 				'user_email' => 'bar@example.com',
 			)
 		);
 
-		$this->assertTrue( retrieve_password( 'foo@example.com' ), 'Fetching user by login failed.' );
+		$this->assertTrue( retrieve_password( 'foo' ), 'Fetching user by login failed.' );
 		$this->assertTrue( retrieve_password( 'bar@example.com' ), 'Fetching user by email failed.' );
 	}
 }


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/58311

Removing the @ symbol in the sanitize_user function in strict mode and adding a filter for the allowed characters in case someone wants to change this behavior.

This disallows the symbol at user registration so that future usernames cannot be email adresses.