### PR TITLE
check if a valid post object is returned before trying to access its …

### DIFF
--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -387,7 +387,7 @@ function get_post_permalink( $post = 0, $leavename = false, $sample = false ) {
 function get_page_link( $post = false, $leavename = false, $sample = false ) {
 	$post = get_post( $post );
 
-	if ( !$post ) {
+	if ( ! $post ) {
 		_doing_it_wrong( 'get_page_link', __( 'Invalid Post ID or object' ), '6.3.0' );
 		return '';
 	}

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -382,10 +382,15 @@ function get_post_permalink( $post = 0, $leavename = false, $sample = false ) {
  * @param bool        $leavename Optional. Whether to keep the page name. Default false.
  * @param bool        $sample    Optional. Whether it should be treated as a sample permalink.
  *                               Default false.
- * @return string The page permalink.
+ * @return string The page permalink on success, empty string on failure.
  */
 function get_page_link( $post = false, $leavename = false, $sample = false ) {
 	$post = get_post( $post );
+
+	if ( !$post ) {
+		_doing_it_wrong( 'get_page_link', __( 'Invalid Post ID or object' ), '6.3.0' );
+		return '';
+	}
 
 	if ( 'page' === get_option( 'show_on_front' ) && get_option( 'page_on_front' ) == $post->ID ) {
 		$link = home_url( '/' );


### PR DESCRIPTION
…properties

Modified get_page_link() function to check if post object is found before proceeding to access its properties.

Trac ticket: [44497](https://core.trac.wordpress.org/ticket/44497)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
