### PR TITLE
#52696 Update i18n.php for Optional $return_singular Parameter and Introduce has_translation() Function

### DIFF
--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -167,14 +167,12 @@ function determine_locale() {
 /**
  * Return true if translation for $text on $domain is available.
  *
- * @since ?.?.?
- *
  * @param string $text
  * @param string $domain
  *
  * @return boolean Wether $text is translated or not.
  */
-function is_translated( $text, $domain = 'default' ) {
+function has_translation( $text, $domain = 'default' ) {
 	return (bool) translate( $text, $domain, false );
 }
 
@@ -187,7 +185,6 @@ function is_translated( $text, $domain = 'default' ) {
  *
  * @since 2.2.0
  * @since 5.5.0 Introduced `gettext-{$domain}` filter.
- * @since ?.?.? Introduced $return_singular parameter.
  *
  * @param string $text            Text to translate.
  * @param string $domain          Optional. Text domain. Unique identifier for retrieving translated strings.
@@ -303,36 +300,15 @@ function translate_with_gettext_context( $text, $context, $domain = 'default' ) 
  *
  * @since 2.1.0
  *
- * @param string $text   Text to translate.
- * @param string $domain Optional. Text domain. Unique identifier for retrieving translated strings.
- *                       Default 'default'.
+ * @param string $text            Text to translate.
+ * @param string $domain          Optional. Text domain. Unique identifier for retrieving translated strings.
+ *                                Default 'default'.
+ * @param bool   $return_singular Optional. Whether to return the singular form of the translation.
  * @return string Translated text.
  */
-function __( $text, $domain = 'default' ) {
-	return translate( $text, $domain );
+function __( $text, $domain = 'default', $return_singular = true ) {
+	return translate( $text, $domain, $return_singular );
 }
-
-/**
- * Retrieves the translation of $text.
- *
- * If there is no translation, or the text domain isn't loaded, null is returned.
- *
- * @param string $text   Text to translate.
- * @param string $domain Text domain. Unique identifier for retrieving translated strings.
- *
- * @return string|null Translated text or null, if no translation exists.
- */
-function __i18n_exists( $text, $domain = 'default' ) {
-	return translate( $text, $domain, false );
-}
-
-__no_def();
-__no_default();
-__exists();
-__nf();
-__nof();
-__nofallback();
-no_default__();
 
 /**
  * Retrieves the translation of $text and escapes it for safe use in an attribute.

--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -165,6 +165,20 @@ function determine_locale() {
 }
 
 /**
+ * Return true if translation for $text on $domain is available.
+ *
+ * @since ?.?.?
+ *
+ * @param string $text
+ * @param string $domain
+ *
+ * @return boolean Wether $text is translated or not.
+ */
+function is_translated( $text, $domain = 'default' ) {
+	return (bool) translate( $text, $domain, false );
+}
+
+/**
  * Retrieves the translation of $text.
  *
  * If there is no translation, or the text domain isn't loaded, the original text is returned.

--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -179,9 +179,9 @@ function determine_locale() {
  *                       Default 'default'.
  * @return string Translated text.
  */
-function translate( $text, $domain = 'default' ) {
+function translate( $text, $domain = 'default', $return_singular = true ) {
 	$translations = get_translations_for_domain( $domain );
-	$translation  = $translations->translate( $text );
+	$translation  = $translations->translate( $text, null, $return_singular );
 
 	/**
 	 * Filters text with its translation.
@@ -293,6 +293,20 @@ function translate_with_gettext_context( $text, $context, $domain = 'default' ) 
  */
 function __( $text, $domain = 'default' ) {
 	return translate( $text, $domain );
+}
+
+/**
+ * Retrieves the translation of $text.
+ *
+ * If there is no translation, or the text domain isn't loaded, null is returned.
+ *
+ * @param string $text   Text to translate.
+ * @param string $domain Text domain. Unique identifier for retrieving translated strings.
+ *
+ * @return string|null Translated text or null, if no translation exists.
+ */
+function __i18n_exists( $text, $domain = 'default' ) {
+	return translate( $text, $domain, false );
 }
 
 /**
@@ -1304,6 +1318,7 @@ function _load_textdomain_just_in_time( $domain ) {
  */
 function get_translations_for_domain( $domain ) {
 	global $l10n;
+	//var_dump( $l10n );
 	if ( isset( $l10n[ $domain ] ) || ( _load_textdomain_just_in_time( $domain ) && isset( $l10n[ $domain ] ) ) ) {
 		return $l10n[ $domain ];
 	}

--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -173,10 +173,13 @@ function determine_locale() {
  *
  * @since 2.2.0
  * @since 5.5.0 Introduced `gettext-{$domain}` filter.
+ * @since ?.?.? Introduced $return_singular parameter.
  *
- * @param string $text   Text to translate.
- * @param string $domain Optional. Text domain. Unique identifier for retrieving translated strings.
- *                       Default 'default'.
+ * @param string $text            Text to translate.
+ * @param string $domain          Optional. Text domain. Unique identifier for retrieving translated strings.
+ *                                Default 'default'.
+ * @param bool   $return_singular Optional. Whether to return the singular form of the translation.
+ *
  * @return string Translated text.
  */
 function translate( $text, $domain = 'default', $return_singular = true ) {
@@ -308,6 +311,14 @@ function __( $text, $domain = 'default' ) {
 function __i18n_exists( $text, $domain = 'default' ) {
 	return translate( $text, $domain, false );
 }
+
+__no_def();
+__no_default();
+__exists();
+__nf();
+__nof();
+__nofallback();
+no_default__();
 
 /**
  * Retrieves the translation of $text and escapes it for safe use in an attribute.

--- a/src/wp-includes/pomo/translations.php
+++ b/src/wp-includes/pomo/translations.php
@@ -95,6 +95,7 @@ if ( ! class_exists( 'Translations', false ) ) :
 		/**
 		 * @param string $singular
 		 * @param string $context
+		 * @param bool   $return_singular
 		 * @return string
 		 */
 		public function translate( $singular, $context = null, $return_singular = true ) {
@@ -107,12 +108,14 @@ if ( ! class_exists( 'Translations', false ) ) :
 			$translated = $this->translate_entry( $entry );
 
 			if ( $translated && ! empty( $translated->translations ) ) {
+				// We got a translation, return it.
 				return $translated->translations[0];
 			} else if ( $return_singular ) {
+				// We got no translation but want $singular to be returned as a fallback.
 				return $singular;
 			}
-			return 'yadda';
-;			//return ( $translated && ! empty( $translated->translations ) ) ? $translated->translations[0] : 'yaddayadda';
+			// No translation found, no $singular fallback wanted.
+			return null;
 		}
 
 		/**

--- a/src/wp-includes/pomo/translations.php
+++ b/src/wp-includes/pomo/translations.php
@@ -97,7 +97,7 @@ if ( ! class_exists( 'Translations', false ) ) :
 		 * @param string $context
 		 * @return string
 		 */
-		public function translate( $singular, $context = null ) {
+		public function translate( $singular, $context = null, $return_singular = true ) {
 			$entry      = new Translation_Entry(
 				array(
 					'singular' => $singular,
@@ -105,7 +105,14 @@ if ( ! class_exists( 'Translations', false ) ) :
 				)
 			);
 			$translated = $this->translate_entry( $entry );
-			return ( $translated && ! empty( $translated->translations ) ) ? $translated->translations[0] : $singular;
+
+			if ( $translated && ! empty( $translated->translations ) ) {
+				return $translated->translations[0];
+			} else if ( $return_singular ) {
+				return $singular;
+			}
+			return 'yadda';
+;			//return ( $translated && ! empty( $translated->translations ) ) ? $translated->translations[0] : 'yaddayadda';
 		}
 
 		/**


### PR DESCRIPTION
Worked together with @samuelsilvapt (wp.org profile: https://profiles.wordpress.org/samuelsilvapt/) on this.

We updated the `__` and `translate()` function within `/wp-includes/i18n.php` as well as `Translations::translate()` function to support a new optional parameter `$return_singular`.

The new parameter defaults to `true` but if set to false, instead of the inputed `$text` as a fallback if no translation exists for that string `null` will returned instead.

We also introduced a new function `has_translation( $text, $domain )` for explicit checks (like `hasTranslation` is already part of the @wordpress/i18n package).

Trac ticket: https://core.trac.wordpress.org/ticket/52696

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
