### PR TITLE
dont load directly

### DIFF
--- a/src/wp-includes/blocks/index.php
+++ b/src/wp-includes/blocks/index.php
@@ -5,6 +5,11 @@
  * @package WordPress
  */
 
+// Don't load directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	die( '-1' );
+}
+
 define( 'BLOCKS_PATH', ABSPATH . WPINC . '/blocks/' );
 
 // Include files required for core blocks registration.


### PR DESCRIPTION
We've been noticing a large # of requests going directly to /wp-content/wp-includes/blocks/index.php with a user-agent containing "python".

The error being thrown is:

Uncaught exception 'Error' with message 'Undefined constant "ABSPATH"' in /var/www/wp-includes/blocks/index.php:8

This PR should prevent this.

Trac ticket: https://core.trac.wordpress.org/ticket/58496

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
