### PR TITLE
Build warnings: Try builing once to save time.

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -54,7 +54,6 @@ jobs:
           key: ${{ github.sha }}-src
 
       - name: Set up Node.js
-        if: steps.cache.outputs.cache-hit != 'true'
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
           node-version-file: '.nvmrc'
@@ -69,9 +68,11 @@ jobs:
           svn --version
 
       - name: Install npm Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Build WordPress in /src
+        if: steps.cache.outputs.cache-hit != 'true'
         run: npm run build:dev
 
 

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -46,7 +46,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
 
+      - name: Cache WordPress build artifacts
+        uses: actions/cache@v3
+        id: cache
+        with:
+          path: src
+          key: ${{ github.sha }}-src
+
       - name: Set up Node.js
+        if: steps.cache.outputs.cache-hit != 'true'
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
           node-version-file: '.nvmrc'
@@ -66,11 +74,6 @@ jobs:
       - name: Build WordPress in /src
         run: npm run build:dev
 
-      - name: Cache WordPress build artifacts
-        uses: actions/cache@v3
-        with:
-          path: src
-          key: ${{ github.sha }}-src
 
   # Runs the PHPUnit tests for WordPress.
   #

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -66,12 +66,11 @@ jobs:
       - name: Build WordPress in /src
         run: npm run build:dev
 
-      - name: Archive WordPress build artifact
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      - name: Cache WordPress build artifacts
+        uses: actions/cache@v3
         with:
-          if-no-files-found: error
-          name: wordpress-src-built
           path: src
+          key: ${{ github.sha }}-src
 
   # Runs the PHPUnit tests for WordPress.
   #
@@ -177,10 +176,10 @@ jobs:
           custom-cache-suffix: $(/bin/date -u --date='last Mon' "+%F")
 
       - name: Download Build artifact.
-        uses: actions/download-artifact@v3
+        uses: actions/cache@v3
         with:
-          name: wordpress-src-built
           path: src
+          key: ${{ github.sha }}-src
 
       - name: Install npm dependencies
         run: npm ci

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -36,6 +36,43 @@ env:
   SLOW_TESTS: 'external-http,media,restapi'
 
 jobs:
+  create-artifact:
+    name: Build WordPress artifact
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+
+      - name: Log debug information
+        run: |
+          npm --version
+          node --version
+          curl --version
+          git --version
+          svn --version
+
+      - name: Install npm Dependencies
+        run: npm ci
+
+      - name: Build WordPress in /src
+        run: npm run build:dev
+
+      - name: Archive WordPress build artifact
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          if-no-files-found: error
+          name: wordpress-src-built
+          path: src
+
   # Runs the PHPUnit tests for WordPress.
   #
   # Performs the following steps:
@@ -56,6 +93,7 @@ jobs:
   # - Checks out the WordPress Test reporter repository.
   # - Submit the test results to the WordPress.org host test results.
   test-php:
+    needs: create-artifact
     name: ${{ matrix.php }}${{ matrix.multisite && ' multisite' || '' }}${{ matrix.split_slow && ' slow tests' || '' }}${{ matrix.memcached && ' with memcached' || '' }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     permissions:
@@ -137,6 +175,12 @@ jobs:
         uses: ramsey/composer-install@83af392bf5f031813d25e6fe4cd626cdba9a2df6 # v2.2.0
         with:
           custom-cache-suffix: $(/bin/date -u --date='last Mon' "+%F")
+
+      - name: Download Build artifact.
+        uses: actions/download-artifact@v3
+        with:
+          name: wordpress-src-built
+          path: src
 
       - name: Install npm dependencies
         run: npm ci


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Add a build step to the PHP unit tests to allow build to be created once and used in all the test suites. It saves running the same step for each item in the matrix. 

If this is workable, we might be able to move it to it's own file and use the same artifact for the E2E and performance tests.

Trac ticket: https://core.trac.wordpress.org/ticket/57844
