### PR TITLE
Tests for changes in 43502

### DIFF
--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -5372,4 +5372,30 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		);
 		return $schema;
 	}
+
+	/**
+	 * @ticket 43502
+	 */
+	public function test_postdata_reset_by_prepare_item_for_response() {
+		wp_set_current_user( self::$editor_id );
+
+		$endpoint = new WP_REST_Posts_Controller( 'post' );
+
+		global $post;
+		$post = get_post(self::$post_id);
+
+		$original_content = $post->post_content;
+
+		if ( have_posts() ) {
+			while ( have_posts() ) {
+				the_post();
+
+				$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . $post_id );
+				$response = $endpoint->prepare_item_for_response( $post, $request );
+			}
+		}
+
+		$this->assertSame(get_post(self::$post_id), $post);
+		$this->assertSame($original_content, $post->post_content);
+	}
 }

--- a/tests/phpunit/tests/rest-api/rest-revisions-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-revisions-controller.php
@@ -815,4 +815,31 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertCount( $expected_count, $response->get_data() );
 	}
+
+	/**
+	 * @ticket 43502
+	 */
+	public function test_postdata_reset_by_prepare_item_for_response_revisions() {
+		wp_set_current_user( self::$editor_id );
+
+		$endpoint = new WP_REST_Revisions_Controller( 'post' );
+
+		$revision_id = wp_save_post_revision( self::$post_id );
+		global $revision;
+		$revision = get_post( $revision_id );
+
+		$original_content = $revision->post_content;
+
+		if ( have_posts() ) {
+			while ( have_posts() ) {
+				the_post();
+
+				$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id . '/revisions/' . $revision_id );
+				$response = $endpoint->prepare_item_for_response( $revision, $request );
+			}
+		}
+
+		$this->assertSame( get_post( $revision_id ), $revision );
+		$this->assertSame( $original_content, $revision->post_content );
+	}
 }


### PR DESCRIPTION
Hi, I am including some tests for the changes from this PR:

https://github.com/WordPress/wordpress-develop/pull/1165/

However I want to mention that the post data is still not being reverted even with the wp_reset_postdata() action added to the methods.

Trac ticket: https://core.trac.wordpress.org/ticket/43502
