### PR TITLE
Improve realpath usage for block registration. 

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -222,7 +222,8 @@ function register_block_style_handle( $metadata, $field_name, $index = 0 ) {
 		$style_path = "style$suffix.css";
 	}
 
-	$style_path_norm = wp_normalize_path( realpath( dirname( $metadata['file'] ) . '/' . $style_path ) );
+	$style_path      = dirname( $metadata['file'] ) . '/' . $style_path;
+	$style_path_norm = file_exists( $style_path ) ? wp_normalize_path( realpath( $style_path ) ) : '';
 	$has_style_file  = '' !== $style_path_norm;
 
 	if ( $has_style_file ) {
@@ -331,7 +332,7 @@ function register_block_type_from_metadata( $file_or_folder, $args = array() ) {
 	}
 
 	// Try to get metadata from the static cache for core blocks.
-	$metadata = false;
+	$metadata      = false;
 	$is_core_block = str_starts_with( $file_or_folder, ABSPATH . WPINC );
 	if ( $is_core_block ) {
 		$core_block_name = str_replace( ABSPATH . WPINC . '/blocks/', '', $file_or_folder );
@@ -367,11 +368,11 @@ function register_block_type_from_metadata( $file_or_folder, $args = array() ) {
 
 		if ( ! isset( $metadata['style'] ) ) {
 			$metadata['style'] = "wp-block-$block_name";
-			$default_styles[] = 'style';
+			$default_styles[]  = 'style';
 		}
 		if ( ! isset( $metadata['editorStyle'] ) ) {
 			$metadata['editorStyle'] = "wp-block-{$block_name}-editor";
-			$default_styles[] = 'editorStyle';
+			$default_styles[]        = 'editorStyle';
 		}
 	}
 
@@ -444,16 +445,13 @@ function register_block_type_from_metadata( $file_or_folder, $args = array() ) {
 		'style'       => 'style_handles',
 	);
 	$version      = ! $is_core_block && isset( $metadata['version'] ) ? $metadata['version'] : false;
-
 	foreach ( $style_fields as $metadata_field_name => $settings_field_name ) {
 		if ( ! empty( $metadata[ $metadata_field_name ] ) ) {
 			$styles           = $metadata[ $metadata_field_name ];
 			$processed_styles = array();
 			if ( is_array( $styles ) ) {
 				for ( $index = 0; $index < count( $styles ); $index++ ) {
-
-var_dump($is_core_block && in_array( $metadata_field_name, $default_styles, true));
-					if( $is_core_block && in_array( $metadata_field_name, $default_styles, true)){
+					if ( $is_core_block && in_array( $metadata_field_name, $default_styles, true ) ) {
 						$style_handle = generate_block_asset_handle( $metadata['name'], $metadata_field_name, $index );
 						$result       = wp_register_style(
 							$style_handle,
@@ -473,8 +471,7 @@ var_dump($is_core_block && in_array( $metadata_field_name, $default_styles, true
 					}
 				}
 			} else {
-				var_dump($is_core_block && in_array( $metadata_field_name, $default_styles, true), $metadata_field_name, $default_styles);
-				if( $is_core_block && in_array( $metadata_field_name, $default_styles, true)){
+				if ( $is_core_block && in_array( $metadata_field_name, $default_styles, true ) ) {
 					$style_handle = generate_block_asset_handle( $metadata['name'], $metadata_field_name );
 					$result       = wp_register_style(
 						$style_handle,

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -222,10 +222,21 @@ function register_block_style_handle( $metadata, $field_name, $index = 0, $looku
 	if ( $is_core_block ) {
 		$style_path = "style$suffix.css";
 	}
+	$style_path_raw = dirname( $metadata['file'] ) . '/' . $style_path;
 
-	$style_path      = dirname( $metadata['file'] ) . '/' . $style_path;
-	$style_path_norm = $lookup && file_exists( $style_path ) ? wp_normalize_path( realpath( $style_path ) ) : '';
-	$has_style_file  = '' !== $style_path_norm;
+	static $styles_path_norm = array();
+	if ( ! $styles_path_norm ) {
+		$styles_path_norm = array();
+	}
+
+	if ( isset( $styles_path_norm[ $style_path_raw ] ) ) {
+		$style_path_norm = $styles_path_norm[ $style_path_raw ];
+	} else {
+		$style_path_norm                     = $lookup && file_exists( $style_path ) ? wp_normalize_path( realpath( $style_path ) ) : '';
+		$styles_path_norm[ $style_path_raw ] = $style_path_norm;
+	}
+
+	$has_style_file = '' !== $style_path_norm;
 
 	if ( $has_style_file ) {
 		$style_uri = plugins_url( $style_path, $metadata['file'] );
@@ -335,7 +346,7 @@ function register_block_type_from_metadata( $file_or_folder, $args = array() ) {
 	}
 
 	// Try to get metadata from the static cache for core blocks.
-	$metadata      = false;
+	$metadata = false;
 	if ( $is_core_block ) {
 		$core_block_name = str_replace( ABSPATH . WPINC . '/blocks/', '', $file_or_folder );
 		if ( ! empty( $core_blocks_meta[ $core_block_name ] ) ) {


### PR DESCRIPTION
This ticket fixes two issues with block registration. 

1. Fix an issue, introduced in https://github.com/WordPress/wordpress-develop/commit/716a99587c04e5b37b4ceacc3ccce6c72c842464. Basically, Register styles that the we know the file do not exist, results in calling realpath on a file that is not there. This means realpath caches and is expensive. 
2. Also had a simple check, for file_exists before realpath is called, for third party blocks that are also registering styles that are not there. 

This can result in some really big server response time gains. 

Trac ticket:  https://core.trac.wordpress.org/ticket/58528

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
