### PR TITLE
Fluid typography: use layout.wideSize as max viewport width 

### DIFF
--- a/src/wp-includes/block-supports/typography.php
+++ b/src/wp-includes/block-supports/typography.php
@@ -454,6 +454,7 @@ function wp_get_computed_fluid_typography_value( $args = array() ) {
  * @since 6.1.0
  * @since 6.1.1 Adjusted rules for min and max font sizes.
  * @since 6.2.0 Added 'settings.typography.fluid.minFontSize' support.
+ * @since 6.3.0 Using layout.wideSize as max viewport width.
  *
  * @param array $preset                     {
  *     Required. fontSizes preset value as seen in theme.json.

--- a/src/wp-includes/block-supports/typography.php
+++ b/src/wp-includes/block-supports/typography.php
@@ -368,6 +368,7 @@ function wp_get_typography_value_and_unit( $raw_value, $options = array() ) {
  * width and min/max font sizes.
  *
  * @since 6.1.0
+ * @since 6.3.0 Checks for unsupported min/max viewport values that cause invalid clamp values.
  * @access private
  *
  * @param array $args {
@@ -432,6 +433,11 @@ function wp_get_computed_fluid_typography_value( $args = array() ) {
 			'coerce_to' => $font_size_unit,
 		)
 	);
+
+	// Protects against unsupported units in min and max viewport widths.
+	if ( ! $minimum_viewport_width || ! $maximum_viewport_width ) {
+		return null;
+	}
 
 	/*
 	 * Build CSS rule.

--- a/src/wp-includes/block-supports/typography.php
+++ b/src/wp-includes/block-supports/typography.php
@@ -480,7 +480,10 @@ function wp_get_typography_font_size_value( $preset, $should_use_fluid_typograph
 	}
 
 	// Checks if fluid font sizes are activated.
-	$typography_settings = wp_get_global_settings( array( 'typography' ) );
+	$global_settings     = wp_get_global_settings();
+	$typography_settings = isset( $global_settings['typography'] ) ? $global_settings['typography'] : array();
+	$layout_settings     = isset( $global_settings['layout'] ) ? $global_settings['layout'] : array();
+
 	if (
 		isset( $typography_settings['fluid'] ) &&
 		( true === $typography_settings['fluid'] || is_array( $typography_settings['fluid'] ) )
@@ -497,7 +500,7 @@ function wp_get_typography_font_size_value( $preset, $should_use_fluid_typograph
 		: array();
 
 	// Defaults.
-	$default_maximum_viewport_width   = '1600px';
+	$default_maximum_viewport_width   = isset( $layout_settings['wideSize'] ) ? $layout_settings['wideSize'] : '1600px';
 	$default_minimum_viewport_width   = '768px';
 	$default_minimum_font_size_factor = 0.75;
 	$default_scale_factor             = 1;

--- a/tests/phpunit/data/themedir1/block-theme-child-with-fluid-typography-config/theme.json
+++ b/tests/phpunit/data/themedir1/block-theme-child-with-fluid-typography-config/theme.json
@@ -2,6 +2,9 @@
 	"version": 2,
 	"settings": {
 		"appearanceTools": true,
+		"layout": {
+			"wideSize": "1000px"
+		},
 		"typography": {
 			"fluid": {
 				"minFontSize": "16px"

--- a/tests/phpunit/tests/block-supports/typography.php
+++ b/tests/phpunit/tests/block-supports/typography.php
@@ -848,4 +848,90 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 			'size: array' => array( array( '10' ) ),
 		);
 	}
+
+	/**
+	 * Tests computed font size values.
+	 *
+	 * @ticket 58522
+	 *
+	 * @covers ::wp_get_computed_fluid_typography_value
+	 *
+	 * @dataProvider data_wp_get_computed_fluid_typography_value
+	 *
+	 * @param array  $args {
+	 *      Optional. An associative array of values to calculate a fluid formula for font size. Default is empty array.
+	 *
+	 *     @type string $maximum_viewport_width Maximum size up to which type will have fluidity.
+	 *     @type string $minimum_viewport_width Minimum viewport size from which type will have fluidity.
+	 *     @type string $maximum_font_size      Maximum font size for any clamp() calculation.
+	 *     @type string $minimum_font_size      Minimum font size for any clamp() calculation.
+	 *     @type int    $scale_factor           A scale factor to determine how fast a font scales within boundaries.
+	 * }
+	 * @param string $expected_output             Expected value of style property from gutenberg_apply_typography_support().
+	 */
+	public function test_wp_get_computed_fluid_typography_value( $args, $expected_output ) {
+		$actual = wp_get_computed_fluid_typography_value( $args );
+		$this->assertSame( $expected_output, $actual );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_wp_get_computed_fluid_typography_value() {
+		return array(
+			'returns clamped value with valid args' => array(
+				'args'            => array(
+					'minimum_viewport_width' => '320px',
+					'maximum_viewport_width' => '1000px',
+					'minimum_font_size'      => '50px',
+					'maximum_font_size'      => '100px',
+					'scale_factor'           => 1,
+				),
+				'expected_output' => 'clamp(50px, 3.125rem + ((1vw - 3.2px) * 7.353), 100px)',
+			),
+			'returns `null` when `maximum_viewport_width` is an unsupported unit' => array(
+				'args'            => array(
+					'minimum_viewport_width' => '320px',
+					'maximum_viewport_width' => 'calc(100% - 60px)',
+					'minimum_font_size'      => '50px',
+					'maximum_font_size'      => '100px',
+					'scale_factor'           => 1,
+				),
+				'expected_output' => null,
+			),
+			'returns `null` when `minimum_viewport_width` is an unsupported unit' => array(
+				'args'            => array(
+					'minimum_viewport_width' => 'calc(100% - 60px)',
+					'maximum_viewport_width' => '1000px',
+					'minimum_font_size'      => '50px',
+					'maximum_font_size'      => '100px',
+					'scale_factor'           => 1,
+				),
+				'expected_output' => null,
+			),
+			'returns `null` when `minimum_font_size` is an unsupported unit' => array(
+				'args'            => array(
+					'minimum_viewport_width' => '320em',
+					'maximum_viewport_width' => '1000em',
+					'minimum_font_size'      => '10vw',
+					'maximum_font_size'      => '100em',
+					'scale_factor'           => 1,
+				),
+				'expected_output' => null,
+			),
+			'returns `null` when `maximum_font_size` is an unsupported unit' => array(
+				'args'            => array(
+					'minimum_viewport_width' => '320em',
+					'maximum_viewport_width' => '1000em',
+					'minimum_font_size'      => '50px',
+					'maximum_font_size'      => '100%',
+					'scale_factor'           => 1,
+				),
+				'expected_output' => null,
+			),
+		);
+	}
 }
+

--- a/tests/phpunit/tests/block-supports/typography.php
+++ b/tests/phpunit/tests/block-supports/typography.php
@@ -638,7 +638,7 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 			'returns clamp value using custom fluid config' => array(
 				'font_size_value' => '17px',
 				'theme_slug'      => 'block-theme-child-with-fluid-typography-config',
-				'expected_output' => 'font-size:clamp(16px, 1rem + ((1vw - 7.68px) * 0.12), 17px);',
+				'expected_output' => 'font-size:clamp(16px, 1rem + ((1vw - 7.68px) * 0.431), 17px);',
 			),
 			'returns value when font size <= custom min font size bound' => array(
 				'font_size_value' => '15px',

--- a/tests/phpunit/tests/block-supports/typography.php
+++ b/tests/phpunit/tests/block-supports/typography.php
@@ -568,6 +568,7 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 	 * @ticket 56467
 	 * @ticket 57065
 	 * @ticket 57529
+	 * @ticket 58522
 	 *
 	 * @covers ::wp_register_typography_support
 	 *


### PR DESCRIPTION
Let's use the value of `settings.layout.wideSize`, if set, as the maximum viewport width for fluid font size calculations.

The default value is `1600px`.

Checks against invalid `settings.layout.wideSize` values to ensure resulting clamp values are calculated correctly. This is s defensive measure to prevent bugs.

Added to the Gutenberg plugin in: 
- https://github.com/WordPress/gutenberg/pull/49815
- https://github.com/WordPress/gutenberg/pull/51516

❗ If https://github.com/WordPress/wordpress-develop/pull/4605 is merged first, this PR will need a rebase and possibly the tests updated

### Testing

1. Fire up this branch and use 2023 (a theme that has fluid font sizes enabled)
2. In the site editor play around with setting the wide size for layouts, as well as adding some custom font sizes.
3. In the frontend, check that your font sizes should be at their maximum values when viewport is at least as wide as the value of layout.wideSize

**Note**: this will only work on the frontend. The editor JS changes will be ready once https://github.com/WordPress/gutenberg/pull/51516 is bundled with the npm packages destined for Core

`npm run test:php -- --filter Tests_Block_Supports_Typography`

Trac ticket: https://core.trac.wordpress.org/ticket/58522

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
