### PR TITLE
Prevent empty locales being returned in `determine_locale()`

### DIFF
--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -145,9 +145,9 @@ function determine_locale() {
 		} else {
 			$determined_locale = sanitize_locale_name( $_COOKIE['wp_lang'] );
 		}
-	} else if (
 		( isset( $_GET['_locale'] ) && 'user' === $_GET['_locale'] && wp_is_json_request() ) ||
 		is_admin()
+	} elseif (
 	) {
 		$determined_locale = get_user_locale();
 	} else {

--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -145,9 +145,9 @@ function determine_locale() {
 		} else {
 			$determined_locale = sanitize_locale_name( $_COOKIE['wp_lang'] );
 		}
-		( isset( $_GET['_locale'] ) && 'user' === $_GET['_locale'] && wp_is_json_request() ) ||
-		is_admin()
 	} elseif (
+		is_admin() ||
+		( isset( $_GET['_locale'] ) && 'user' === $_GET['_locale'] && wp_is_json_request() )
 	) {
 		$determined_locale = get_user_locale();
 	} else {

--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -150,7 +150,9 @@ function determine_locale() {
 		( isset( $_GET['_locale'] ) && 'user' === $_GET['_locale'] && wp_is_json_request() )
 	) {
 		$determined_locale = get_user_locale();
-	} else {
+	}
+
+	if ( ! $determined_locale ) {
 		$determined_locale = get_locale();
 	}
 

--- a/tests/phpunit/tests/l10n/determineLocale.php
+++ b/tests/phpunit/tests/l10n/determineLocale.php
@@ -211,6 +211,22 @@ class Tests_L10n_DetermineLocale extends WP_UnitTestCase {
 		$this->assertSame( 'siteLocale', determine_locale() );
 	}
 
+	public function test_wp_login_get_param_on_login_page_incorrect_string() {
+		add_filter(
+			'locale',
+			static function() {
+				return 'siteLocale';
+			}
+		);
+
+		wp_set_current_user( self::$user_id );
+
+		$GLOBALS['pagenow'] = 'wp-login.php';
+		$_GET['wp_lang']    = '###'; // Something sanitize_locale_name() strips away.
+
+		$this->assertSame( 'siteLocale', determine_locale() );
+	}
+
 	public function test_wp_login_cookie_not_on_login_page() {
 		add_filter(
 			'locale',


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Also uses proper `elseif` and checks for `is_admin()` first

Trac ticket: https://core.trac.wordpress.org/ticket/58317

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
