### PR TITLE
HTML API: Change coding style so linting tools don't reject accepted work.

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1894,7 +1894,7 @@ class WP_HTML_Tag_Processor {
 			 *
 			 *     Result: <div id="new"/>
 			 */
-			$existing_attribute = $this->attributes[ $comparable_name ];
+			$existing_attribute                        = $this->attributes[ $comparable_name ];
 			$this->lexical_updates[ $comparable_name ] = new WP_HTML_Text_Replacement(
 				$existing_attribute->start,
 				$existing_attribute->end,


### PR DESCRIPTION
Trac: [58530-ticket](https://core.trac.wordpress.org/ticket/58530)

When backporting the Tag Processor updates into Gutenberg for the 6.2 branch,
the CI job in Github rejected the backport because the linting rules differ
between the repositories.

Accepted and merged code shouldn't be rejected, but it was, and this change
is meant to unlock merging the backport.