### PR TITLE
Templates API: return post modified datetime in response 

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -542,6 +542,7 @@ function _remove_theme_attribute_in_block_template_content( $template_content ) 
  * Builds a unified template object based on a theme file.
  *
  * @since 5.9.0
+ * @since 6.3.0 Added `modified` property to template objects.
  * @access private
  *
  * @param array  $template_file Theme file.
@@ -564,6 +565,7 @@ function _build_block_template_result_from_file( $template_file, $template_type 
 	$template->status         = 'publish';
 	$template->has_theme_file = true;
 	$template->is_custom      = true;
+	$template->modified       = null;
 
 	if ( 'wp_template' === $template_type && isset( $default_template_types[ $template_file['slug'] ] ) ) {
 		$template->description = $default_template_types[ $template_file['slug'] ]['description'];
@@ -743,7 +745,7 @@ function _wp_build_title_and_description_for_taxonomy_block_template( $taxonomy,
  * Builds a unified template object based a post Object.
  *
  * @since 5.9.0
- * @since 6.3.0 Added `modified` property for saved templates.
+ * @since 6.3.0 Added `modified` property to template objects.
  * @access private
  *
  * @param WP_Post $post Template post.

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -743,6 +743,7 @@ function _wp_build_title_and_description_for_taxonomy_block_template( $taxonomy,
  * Builds a unified template object based a post Object.
  *
  * @since 5.9.0
+ * @since 6.3.0 Added `modified` property for saved templates.
  * @access private
  *
  * @param WP_Post $post Template post.
@@ -782,6 +783,7 @@ function _build_block_template_result_from_post( $post ) {
 	$template->has_theme_file = $has_theme_file;
 	$template->is_custom      = empty( $is_wp_suggestion );
 	$template->author         = $post->post_author;
+	$template->modified       = $post->post_modified;
 
 	if ( 'wp_template' === $post->post_type && $has_theme_file && isset( $template_file['postTypes'] ) ) {
 		$template->post_types = $template_file['postTypes'];

--- a/src/wp-includes/class-wp-block-template.php
+++ b/src/wp-includes/class-wp-block-template.php
@@ -146,4 +146,12 @@ class WP_Block_Template {
 	 * @var string|null
 	 */
 	public $area;
+
+	/**
+	 * Modified.
+	 *
+	 * @since 6.3.0
+	 * @var string|null
+	 */
+	public $modified;
 }

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
@@ -941,7 +941,7 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 					'context'     => array( 'view', 'edit', 'embed' ),
 				),
 				'modified'       => array(
-					'description' => __( "The date the post was last modified, in the site's timezone." ),
+					'description' => __( "The date the template was last modified, in the site's timezone." ),
 					'type'        => 'string',
 					'format'      => 'date-time',
 					'context'     => array( 'view', 'edit' ),

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
@@ -614,6 +614,7 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 	 *
 	 * @since 5.8.0
 	 * @since 5.9.0 Renamed `$template` to `$item` to match parent class for PHP 8 named parameter support.
+	 * @since 6.3.0 Added `modified` property to the response.
 	 *
 	 * @param WP_Block_Template $item    Template instance.
 	 * @param WP_REST_Request   $request Request object.
@@ -706,6 +707,19 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 
 		if ( rest_is_field_included( 'area', $fields ) && 'wp_template_part' === $template->type ) {
 			$data['area'] = $template->area;
+		}
+
+		if ( rest_is_field_included( 'author', $fields ) ) {
+			$data['author'] = (int) $template->author;
+		}
+
+		/*
+		 * Only add the template's modified date if it is available.
+		 * This is because the modified date is not available for template files,
+		 * i.e., templates that have not been saved as posts.
+		 */
+		if ( rest_is_field_included( 'modified', $fields ) && ! empty( $template->modified ) ) {
+			$data['modified'] = mysql_to_rfc3339( $template->modified );
 		}
 
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
@@ -925,6 +939,13 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 					'description' => __( 'The ID for the author of the template.' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit', 'embed' ),
+				),
+				'modified'       => array(
+					'description' => __( "The date the post was last modified, in the site's timezone." ),
+					'type'        => 'string',
+					'format'      => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
 				),
 			),
 		);

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
@@ -709,10 +709,6 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 			$data['area'] = $template->area;
 		}
 
-		if ( rest_is_field_included( 'author', $fields ) ) {
-			$data['author'] = (int) $template->author;
-		}
-
 		if ( rest_is_field_included( 'modified', $fields ) ) {
 			$data['modified'] = mysql_to_rfc3339( $template->modified );
 		}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
@@ -713,12 +713,7 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 			$data['author'] = (int) $template->author;
 		}
 
-		/*
-		 * Only add the template's modified date if it is available.
-		 * This is because the modified date is not available for template files,
-		 * i.e., templates that have not been saved as posts.
-		 */
-		if ( rest_is_field_included( 'modified', $fields ) && ! empty( $template->modified ) ) {
+		if ( rest_is_field_included( 'modified', $fields ) ) {
 			$data['modified'] = mysql_to_rfc3339( $template->modified );
 		}
 

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -101,6 +101,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		$this->assertSame( 'My Template', $template->title );
 		$this->assertSame( 'Description of my template', $template->description );
 		$this->assertSame( 'wp_template', $template->type );
+		$this->assertSame( self::$template_post->post_modified, $template->modified );
 
 		// Test template parts.
 		$template_part = _build_block_template_result_from_post(
@@ -117,6 +118,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		$this->assertSame( 'Description of my template part', $template_part->description );
 		$this->assertSame( 'wp_template_part', $template_part->type );
 		$this->assertSame( WP_TEMPLATE_PART_AREA_HEADER, $template_part->area );
+		$this->assertSame( self::$template_part_post->post_modified, $template->modified );
 	}
 
 	public function test_build_block_template_result_from_file() {
@@ -136,6 +138,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		$this->assertSame( 'Single', $template->title );
 		$this->assertSame( 'Displays single posts on your website unless a custom template has been applied to that post or a dedicated template exists.', $template->description );
 		$this->assertSame( 'wp_template', $template->type );
+		$this->assertEmpty( $template->modified );
 
 		// Test template parts.
 		$template_part = _build_block_template_result_from_file(
@@ -155,6 +158,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		$this->assertSame( '', $template_part->description );
 		$this->assertSame( 'wp_template_part', $template_part->type );
 		$this->assertSame( WP_TEMPLATE_PART_AREA_HEADER, $template_part->area );
+		$this->assertEmpty( $template_part->modified );
 	}
 
 	public function test_inject_theme_attribute_in_block_template_content() {

--- a/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
+++ b/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
@@ -118,6 +118,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 				'has_theme_file' => false,
 				'is_custom'      => true,
 				'author'         => 0,
+				'modified'       => mysql_to_rfc3339( self::$post->post_modified ),
 			),
 			$this->find_and_normalize_template_by_id( $data, 'default//my_template' )
 		);
@@ -162,6 +163,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 				'has_theme_file' => false,
 				'is_custom'      => true,
 				'author'         => 0,
+				'modified'       => mysql_to_rfc3339( self::$post->post_modified ),
 			),
 			$data
 		);
@@ -198,6 +200,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 				'has_theme_file' => false,
 				'is_custom'      => true,
 				'author'         => 0,
+				'modified'       => mysql_to_rfc3339( self::$post->post_modified ),
 			),
 			$data
 		);
@@ -257,6 +260,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 				'has_theme_file' => false,
 				'is_custom'      => true,
 				'author'         => self::$admin_id,
+				'modified'       => mysql_to_rfc3339( $post->post_modified ),
 			),
 			$data
 		);
@@ -413,6 +417,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 		);
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
+		$modified = get_post( $data['wp_id'] )->post_modified;
 		unset( $data['_links'] );
 		unset( $data['wp_id'] );
 
@@ -436,6 +441,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 				'has_theme_file' => false,
 				'is_custom'      => true,
 				'author'         => self::$admin_id,
+				'modified'       => mysql_to_rfc3339( $modified ),
 			),
 			$data
 		);
@@ -459,6 +465,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 		);
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
+		$modified = get_post( $data['wp_id'] )->post_modified;
 		unset( $data['_links'] );
 		unset( $data['wp_id'] );
 
@@ -482,6 +489,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 				'has_theme_file' => false,
 				'is_custom'      => false,
 				'author'         => self::$admin_id,
+				'modified'       => mysql_to_rfc3339( $modified ),
 			),
 			$data
 		);
@@ -509,6 +517,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 		);
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
+		$modified = get_post( $data['wp_id'] )->post_modified;
 		unset( $data['_links'] );
 		unset( $data['wp_id'] );
 
@@ -532,6 +541,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 				'has_theme_file' => false,
 				'is_custom'      => true,
 				'author'         => self::$admin_id,
+				'modified'       => mysql_to_rfc3339( $modified ),
 			),
 			$data
 		);
@@ -690,7 +700,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 		$response   = rest_get_server()->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertCount( 14, $properties );
+		$this->assertCount( 15, $properties );
 		$this->assertArrayHasKey( 'id', $properties );
 		$this->assertArrayHasKey( 'description', $properties );
 		$this->assertArrayHasKey( 'slug', $properties );
@@ -706,6 +716,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 		$this->assertArrayHasKey( 'has_theme_file', $properties );
 		$this->assertArrayHasKey( 'is_custom', $properties );
 		$this->assertArrayHasKey( 'author', $properties );
+		$this->assertArrayHasKey( 'modified', $properties );
 	}
 
 	protected function find_and_normalize_template_by_id( $templates, $id ) {
@@ -736,8 +747,10 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/templates' );
 		$request->set_body_params( $body_params );
-		$response = rest_get_server()->dispatch( $request );
-		$data     = $response->get_data();
+		$response             = rest_get_server()->dispatch( $request );
+		$data                 = $response->get_data();
+		$modified             = get_post( $data['wp_id'] )->post_modified;
+		$expected['modified'] = mysql_to_rfc3339( $modified );
 		unset( $data['_links'] );
 		unset( $data['wp_id'] );
 


### PR DESCRIPTION
Adding 'modified' field and value (if available) to template rest APIcontroller

Synching Core with:

- https://github.com/WordPress/gutenberg/pull/51362

Trac ticket: https://core.trac.wordpress.org/ticket/58540

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
