### PR TITLE
Add new grid layout type

### DIFF
--- a/src/wp-includes/block-supports/layout.php
+++ b/src/wp-includes/block-supports/layout.php
@@ -287,6 +287,44 @@ function wp_get_layout_style( $selector, $layout, $has_block_gap_support = false
 				);
 			}
 		}
+	} elseif ( 'grid' === $layout_type ) {
+		if ( ! empty( $layout['columnCount'] ) ) {
+			$layout_styles[] = array(
+				'selector'     => $selector,
+				'declarations' => array( 'grid-template-columns' => 'repeat(' . $layout['columnCount'] . ', minmax(0, 1fr))' ),
+			);
+		} else {
+			$minimum_column_width = ! empty( $layout['minimumColumnWidth'] ) ? $layout['minimumColumnWidth'] : '12rem';
+
+			$layout_styles[] = array(
+				'selector'     => $selector,
+				'declarations' => array( 'grid-template-columns' => 'repeat(auto-fill, minmax(min(' . $minimum_column_width . ', 100%), 1fr))' ),
+			);
+		}
+
+		if ( $has_block_gap_support && isset( $gap_value ) ) {
+			$combined_gap_value = '';
+			$gap_sides          = is_array( $gap_value ) ? array( 'top', 'left' ) : array( 'top' );
+
+			foreach ( $gap_sides as $gap_side ) {
+				$process_value = is_string( $gap_value ) ? $gap_value : _wp_array_get( $gap_value, array( $gap_side ), $fallback_gap_value );
+				// Get spacing CSS variable from preset value if provided.
+				if ( is_string( $process_value ) && str_contains( $process_value, 'var:preset|spacing|' ) ) {
+					$index_to_splice = strrpos( $process_value, '|' ) + 1;
+					$slug            = _wp_to_kebab_case( substr( $process_value, $index_to_splice ) );
+					$process_value   = "var(--wp--preset--spacing--$slug)";
+				}
+				$combined_gap_value .= "$process_value ";
+			}
+			$gap_value = trim( $combined_gap_value );
+
+			if ( null !== $gap_value && ! $should_skip_gap_serialization ) {
+				$layout_styles[] = array(
+					'selector'     => $selector,
+					'declarations' => array( 'gap' => $gap_value ),
+				);
+			}
+		}
 	}
 
 	if ( ! empty( $layout_styles ) ) {

--- a/src/wp-includes/block-supports/layout.php
+++ b/src/wp-includes/block-supports/layout.php
@@ -34,6 +34,7 @@ function wp_register_layout_support( $block_type ) {
  *
  * @since 5.9.0
  * @since 6.1.0 Added `$block_spacing` param, use style engine to enqueue styles.
+ * @since 6.3.0 Added grid layout type.
  * @access private
  *
  * @param string               $selector                      CSS selector.

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -1370,7 +1370,7 @@ class WP_Theme_JSON {
 
 				if (
 					! empty( $class_name ) &&
-					! empty( $base_style_rules )
+					is_array( $base_style_rules )
 				) {
 					// Output display mode. This requires special handling as `display` is not exposed in `safe_style_css_filter`.
 					if (

--- a/src/wp-includes/theme.json
+++ b/src/wp-includes/theme.json
@@ -332,6 +332,28 @@
 							}
 						}
 					]
+				},
+				"grid": {
+					"name": "grid",
+					"slug": "grid",
+					"className": "is-layout-grid",
+					"displayMode": "grid",
+					"baseStyles": [
+						{
+							"selector": " > *",
+							"rules": {
+								"margin": "0"
+							}
+						}
+					],
+					"spacingStyles": [
+						{
+							"selector": "",
+							"rules": {
+								"gap": null
+							}
+						}
+					]
 				}
 			}
 		},


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/58554

Introduces the PHP changes from https://github.com/WordPress/gutenberg/pull/49018 (except for the kses filter which will be dealt with separately) and the changes to `layout.php` from https://github.com/WordPress/gutenberg/pull/49050, because they build upon the changes from the first PR.

To test this change, check out this branch locally and update the following npm packages:

`@wordpress/block-editor": "11.8.0"`
`"@wordpress/block-library": "8.8.0"`
`"@wordpress/blocks": "12.8.0"`

Then run `npm run postsync-gutenberg-packages` followed by `npm run build:dev` (assuming you're building from src, otherwise run `npm run build`)

Then, in the post editor, paste the following block markup:

```
<!-- wp:group {"layout":{"type":"grid","minimumColumnWidth":"8rem"}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>grid</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>row</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>stack</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>group</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```

The grid should look fine in the editor; on the front end it won't show the correct column number without the kses patch to support `repeat`.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
