### PR TITLE
`is_email()`: add check for double period in the local part of the address

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -3557,6 +3557,12 @@ function is_email( $email, $deprecated = false ) {
 	list( $local, $domain ) = explode( '@', $email, 2 );
 
 	// LOCAL PART
+	// Test for sequences of periods.
+	if ( preg_match( '/\.{2,}/', $local ) ) {
+		/** This filter is documented in wp-includes/formatting.php */
+		return apply_filters( 'is_email', false, $email, 'local_period_sequence' );
+	}
+
 	// Test for invalid characters.
 	if ( ! preg_match( '/^[a-zA-Z0-9!#$%&\'*+\/=?^_`{|}~\.-]+$/', $local ) ) {
 		/** This filter is documented in wp-includes/formatting.php */

--- a/tests/phpunit/tests/formatting/isEmail.php
+++ b/tests/phpunit/tests/formatting/isEmail.php
@@ -28,6 +28,8 @@ class Tests_Formatting_IsEmail extends WP_UnitTestCase {
 			'com.exampleNOSPAMbob',
 			'bob@your mom',
 			'a@b.c',
+			'a@b..c',
+			'a..b@c.d',
 		);
 		foreach ( $data as $datum ) {
 			$this->assertFalse( is_email( $datum ), $datum );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Added a check for double periods on the local part of the email address (taking inspiration from the same check on the domain part) + added unit test cases for both the local and the domain part (which was missing).

Trac ticket: https://core.trac.wordpress.org/ticket/55821

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
