### PR TITLE
Rename `wp_get_remote_patterns` to `wp_get_theme_directory_pattern_slugs`

### DIFF
--- a/src/wp-includes/block-patterns.php
+++ b/src/wp-includes/block-patterns.php
@@ -287,7 +287,7 @@ function _register_remote_theme_patterns() {
 		return;
 	}
 
-	$pattern_settings = wp_get_remote_theme_patterns();
+	$pattern_settings = wp_get_theme_directory_pattern_slugs();
 	if ( empty( $pattern_settings ) ) {
 		return;
 	}

--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -435,6 +435,6 @@ function wp_clean_theme_json_cache() {
  *
  * @return string[]
  */
-function wp_get_remote_theme_patterns() {
+function wp_get_theme_directory_pattern_slugs() {
 	return WP_Theme_JSON_Resolver::get_theme_data( array(), array( 'with_supports' => false ) )->get_patterns();
 }


### PR DESCRIPTION
Trac ticket https://core.trac.wordpress.org/ticket/58460
Part of https://github.com/WordPress/gutenberg/issues/45171
Follow-up to https://github.com/WordPress/wordpress-develop/pull/4543

This PR renames the recently landed `wp_get_remote_patterns` function to `wp_get_theme_directory_pattern_slugs`.

The rationale is to better provide context on what it does by avoiding the use of `remote` affix in the function name. Using `remote` may suggest the function actually does an external request, while it only provides metadata for the editor, which will take care of the request itself.

### Commit

```txt
Rename `wp_get_remote_patterns` to `wp_get_theme_directory_pattern_slugs`.

Props dd32, ntsekouras.

Fixes #58460.
```