### PR TITLE
Remove IE specific checks from default themes in Twenty Fourteen

### DIFF
--- a/src/wp-content/themes/twentyfourteen/functions.php
+++ b/src/wp-content/themes/twentyfourteen/functions.php
@@ -351,8 +351,7 @@ function twentyfourteen_scripts() {
 	wp_enqueue_style( 'twentyfourteen-block-style', get_template_directory_uri() . '/css/blocks.css', array( 'twentyfourteen-style' ), '20230206' );
 
 	// Load the Internet Explorer specific stylesheet.
-	wp_enqueue_style( 'twentyfourteen-ie', get_template_directory_uri() . '/css/ie.css', array( 'twentyfourteen-style' ), '20140711' );
-	wp_style_add_data( 'twentyfourteen-ie', 'conditional', 'lt IE 9' );
+	wp_register_style( 'twentyfourteen-ie', get_template_directory_uri() . '/css/ie.css', array( 'twentyfourteen-style' ), '20140711' );
 
 	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
 		wp_enqueue_script( 'comment-reply' );

--- a/src/wp-content/themes/twentyfourteen/functions.php
+++ b/src/wp-content/themes/twentyfourteen/functions.php
@@ -350,8 +350,9 @@ function twentyfourteen_scripts() {
 	// Theme block stylesheet.
 	wp_enqueue_style( 'twentyfourteen-block-style', get_template_directory_uri() . '/css/blocks.css', array( 'twentyfourteen-style' ), '20230206' );
 
-	// Load the Internet Explorer specific stylesheet.
+	// Register the Internet Explorer specific stylesheet.
 	wp_register_style( 'twentyfourteen-ie', get_template_directory_uri() . '/css/ie.css', array( 'twentyfourteen-style' ), '20140711' );
+	wp_style_add_data( 'twentyfourteen-ie', 'conditional', 'lt IE 9' );
 
 	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
 		wp_enqueue_script( 'comment-reply' );

--- a/src/wp-content/themes/twentyfourteen/genericons/genericons.css
+++ b/src/wp-content/themes/twentyfourteen/genericons/genericons.css
@@ -44,16 +44,6 @@
 }
 
 /**
- * IE7 and IE6 hacks
- */
-
-.genericon {
-	*overflow: auto;
-	*zoom: 1;
-	*display: inline;
-}
-
-/**
  * Individual icons
  */
 

--- a/src/wp-content/themes/twentyfourteen/header.php
+++ b/src/wp-content/themes/twentyfourteen/header.php
@@ -9,24 +9,13 @@
  * @since Twenty Fourteen 1.0
  */
 ?><!DOCTYPE html>
-<!--[if IE 7]>
-<html class="ie ie7" <?php language_attributes(); ?>>
-<![endif]-->
-<!--[if IE 8]>
-<html class="ie ie8" <?php language_attributes(); ?>>
-<![endif]-->
-<!--[if !(IE 7) & !(IE 8)]><!-->
 <html <?php language_attributes(); ?>>
-<!--<![endif]-->
 <head>
 	<meta charset="<?php bloginfo( 'charset' ); ?>">
 	<meta name="viewport" content="width=device-width">
 	<title><?php wp_title( '|', true, 'right' ); ?></title>
 	<link rel="profile" href="https://gmpg.org/xfn/11">
 	<link rel="pingback" href="<?php echo esc_url( get_bloginfo( 'pingback_url' ) ); ?>">
-	<!--[if lt IE 9]>
-	<script src="<?php echo esc_url( get_template_directory_uri() ); ?>/js/html5.js?ver=3.7.0"></script>
-	<![endif]-->
 	<?php wp_head(); ?>
 </head>
 

--- a/src/wp-content/themes/twentyfourteen/inc/custom-header.php
+++ b/src/wp-content/themes/twentyfourteen/inc/custom-header.php
@@ -76,7 +76,6 @@ if ( ! function_exists( 'twentyfourteen_header_style' ) ) :
 			?>
 		.site-title,
 		.site-description {
-			clip: rect(1px 1px 1px 1px); /* IE7 */
 			clip: rect(1px, 1px, 1px, 1px);
 			position: absolute;
 		}


### PR DESCRIPTION
Remove IE specific checks from default themes in Twenty Fourteen

Trac ticket: [56699](https://core.trac.wordpress.org/ticket/56699)