### PR TITLE
Include a full DB version string, and the DB interface type.

### DIFF
--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -74,10 +74,25 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 	$current->last_checked = time();
 	set_site_transient( 'update_core', $current );
 
-	if ( method_exists( $wpdb, 'db_version' ) ) {
+	// Populate the DB version
+	if ( method_exists( $wpdb, 'db_server_info' ) ) {
+		$mysql_version = $wpdb->db_server_info();
+	} elseif ( method_exists( $wpdb, 'db_version' ) ) {
 		$mysql_version = preg_replace( '/[^0-9.].*/', '', $wpdb->db_version() );
 	} else {
 		$mysql_version = 'N/A';
+	}
+
+	// Populate the interface DB interface Type
+	if ( is_resource( $wpdb->dbh ) ) {
+		// Old mysql extension.
+		$mysql_interface = 'mysql';
+	} elseif ( is_object( $wpdb->dbh ) ) {
+		// mysqli, PDO, custom class.
+		$mysql_interface = get_class( $wpdb->dbh );
+	} else {
+		// Unknown sql extension.
+		$mysql_interface = false;
 	}
 
 	if ( is_multisite() ) {
@@ -97,6 +112,7 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 		'php'                => $php_version,
 		'locale'             => $locale,
 		'mysql'              => $mysql_version,
+		'mysql_interface'    => $mysql_interface,
 		'local_package'      => isset( $wp_local_package ) ? $wp_local_package : '',
 		'blogs'              => $num_blogs,
 		'users'              => get_user_count(),

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -74,7 +74,7 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 	$current->last_checked = time();
 	set_site_transient( 'update_core', $current );
 
-	// Populate the DB version
+	// Populate the DB version.
 	if ( method_exists( $wpdb, 'db_server_info' ) ) {
 		$mysql_version = $wpdb->db_server_info();
 	} elseif ( method_exists( $wpdb, 'db_version' ) ) {
@@ -83,7 +83,7 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 		$mysql_version = 'N/A';
 	}
 
-	// Populate the interface DB interface Type
+	// Populate the interface DB interface Type.
 	if ( is_resource( $wpdb->dbh ) ) {
 		// Old mysql extension.
 		$mysql_interface = 'mysql';

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -83,18 +83,6 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 		$mysql_version = 'N/A';
 	}
 
-	// Populate the interface DB interface Type.
-	if ( is_resource( $wpdb->dbh ) ) {
-		// Old mysql extension.
-		$mysql_interface = 'mysql';
-	} elseif ( is_object( $wpdb->dbh ) ) {
-		// mysqli, PDO, custom class.
-		$mysql_interface = get_class( $wpdb->dbh );
-	} else {
-		// Unknown sql extension.
-		$mysql_interface = false;
-	}
-
 	if ( is_multisite() ) {
 		$num_blogs         = get_blog_count();
 		$wp_install        = network_site_url();
@@ -112,7 +100,6 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 		'php'                => $php_version,
 		'locale'             => $locale,
 		'mysql'              => $mysql_version,
-		'mysql_interface'    => $mysql_interface,
 		'local_package'      => isset( $wp_local_package ) ? $wp_local_package : '',
 		'blogs'              => $num_blogs,
 		'users'              => get_user_count(),


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

- Sends the raw *SQL version field from WPDB if available
- Lifts the 'interface' code from Site Health and sends that too.

For example:
| | Current | After |
| --- | --- | --- |
| MariaDB | mysql_verison: 5.5.5 | mysql_version: 5.5.5-10.2.44-MariaDB <br> mysql_interface: mysqli |
| WordPress Playground <br> w/ SQLite driver | mysql_verison: 5.5 | mysql_version: 3.40.1 <br> mysql_interface: WP_SQLite_Translator |

Unlike Site Health, this doesn't use `SELECT VERSION()`, as it seems unlikely to be needed.

Trac ticket: https://core.trac.wordpress.org/ticket/58584

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
