### PR TITLE
Block.json: Refactor and stabilize selectors API

### DIFF
--- a/src/wp-includes/block-supports/settings.php
+++ b/src/wp-includes/block-supports/settings.php
@@ -66,7 +66,7 @@ function _wp_add_block_level_presets_class( $block_content, $block ) {
  * @internal
  *
  * @since 6.2.0
- * @since 6.3.0 Updates preset styles to use Selectors API.
+ * @since 6.3.0 Updated preset styles to use Selectors API.
  * @access private
  *
  * @param string|null $pre_render   The pre-rendered content. Default null.

--- a/src/wp-includes/block-supports/settings.php
+++ b/src/wp-includes/block-supports/settings.php
@@ -66,6 +66,7 @@ function _wp_add_block_level_presets_class( $block_content, $block ) {
  * @internal
  *
  * @since 6.2.0
+ * @since 6.3.0 Updates preset styles to use Selectors API.
  * @access private
  *
  * @param string|null $pre_render   The pre-rendered content. Default null.
@@ -95,11 +96,14 @@ function _wp_add_block_level_preset_styles( $pre_render, $block ) {
 	$registry                = WP_Block_Type_Registry::get_instance();
 	$blocks                  = $registry->get_all_registered();
 	foreach ( $blocks as $block_type ) {
-		if (
-			isset( $block_type->supports['__experimentalSelector'] ) &&
-			is_string( $block_type->supports['__experimentalSelector'] )
-		) {
-			$variables_root_selector .= ',' . $block_type->supports['__experimentalSelector'];
+		// We only want to append selectors for block's using custom selectors
+		// i.e. not `wp-block-<name>`.
+		$has_custom_selector =
+			( isset( $block_type->supports['__experimentalSelector'] ) && is_string( $block_type->supports['__experimentalSelector'] ) ) ||
+			( isset( $block_type->selectors['root'] ) && is_string( $block_type->selectors['root'] ) );
+
+		if ( $has_custom_selector ) {
+			$variables_root_selector .= ',' . wp_get_block_css_selector( $block_type );
 		}
 	}
 	$variables_root_selector = WP_Theme_JSON::scope_selector( $class_name, $variables_root_selector );

--- a/src/wp-includes/block-supports/settings.php
+++ b/src/wp-includes/block-supports/settings.php
@@ -96,8 +96,10 @@ function _wp_add_block_level_preset_styles( $pre_render, $block ) {
 	$registry                = WP_Block_Type_Registry::get_instance();
 	$blocks                  = $registry->get_all_registered();
 	foreach ( $blocks as $block_type ) {
-		// We only want to append selectors for block's using custom selectors
-		// i.e. not `wp-block-<name>`.
+		/*
+		* We only want to append selectors for block's using custom selectors
+		* i.e. not `wp-block-<name>`.
+		*/
 		$has_custom_selector =
 			( isset( $block_type->supports['__experimentalSelector'] ) && is_string( $block_type->supports['__experimentalSelector'] ) ) ||
 			( isset( $block_type->selectors['root'] ) && is_string( $block_type->selectors['root'] ) );

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -2403,8 +2403,7 @@ class WP_Theme_JSON {
 
 		// 3. Generate and append the rules that use the duotone selector.
 		if ( isset( $block_metadata['duotone'] ) && ! empty( $declarations_duotone ) ) {
-			$selector_duotone = static::scope_selector( $block_metadata['selector'], $block_metadata['duotone'] );
-			$block_rules     .= static::to_ruleset( $selector_duotone, $declarations_duotone );
+			$block_rules .= static::to_ruleset( $block_metadata['duotone'], $declarations_duotone );
 		}
 
 		// 4. Generate Layout block gap styles.

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -879,6 +879,7 @@ class WP_Theme_JSON {
 	 * @since 5.8.0
 	 * @since 5.9.0 Added `duotone` key with CSS selector.
 	 * @since 6.1.0 Added `features` key with block support feature level selectors.
+	 * @since 6.3.0 Refactored and stabilized selectors API.
 	 *
 	 * @return array Block metadata.
 	 */
@@ -893,56 +894,33 @@ class WP_Theme_JSON {
 		}
 
 		foreach ( $blocks as $block_name => $block_type ) {
-			if (
-				isset( $block_type->supports['__experimentalSelector'] ) &&
-				is_string( $block_type->supports['__experimentalSelector'] )
-			) {
-				static::$blocks_metadata[ $block_name ]['selector'] = $block_type->supports['__experimentalSelector'];
-			} else {
-				static::$blocks_metadata[ $block_name ]['selector'] = '.wp-block-' . str_replace( '/', '-', str_replace( 'core/', '', $block_name ) );
+			$root_selector = wp_get_block_css_selector( $block_type );
+
+			static::$blocks_metadata[ $block_name ]['selector']  = $root_selector;
+			static::$blocks_metadata[ $block_name ]['selectors'] = static::get_block_selectors( $block_type, $root_selector );
+
+			$elements = static::get_block_element_selectors( $root_selector );
+			if ( ! empty( $elements ) ) {
+				static::$blocks_metadata[ $block_name ]['elements'] = $elements;
 			}
 
-			if (
-				isset( $block_type->supports['color']['__experimentalDuotone'] ) &&
-				is_string( $block_type->supports['color']['__experimentalDuotone'] )
-			) {
-				static::$blocks_metadata[ $block_name ]['duotone'] = $block_type->supports['color']['__experimentalDuotone'];
-			}
+			// The block may or may not have a duotone selector.
+			$duotone_selector = wp_get_block_css_selector( $block_type, 'filter.duotone' );
 
-			// Generate block support feature level selectors if opted into
-			// for the current block.
-			$features = array();
-			foreach ( static::BLOCK_SUPPORT_FEATURE_LEVEL_SELECTORS as $key => $feature ) {
-				if (
-					isset( $block_type->supports[ $key ]['__experimentalSelector'] ) &&
-					$block_type->supports[ $key ]['__experimentalSelector']
-				) {
-					$features[ $feature ] = static::scope_selector(
-						static::$blocks_metadata[ $block_name ]['selector'],
-						$block_type->supports[ $key ]['__experimentalSelector']
-					);
+			// Keep backwards compatibility for support.color.__experimentalDuotone.
+			if ( null === $duotone_selector ) {
+				$duotone_support = _wp_array_get( $block_type->supports, array( 'color', '__experimentalDuotone' ), null );
+
+				if ( $duotone_support ) {
+					$root_selector    = wp_get_block_css_selector( $block_type );
+					$duotone_selector = WP_Theme_JSON::scope_selector( $root_selector, $duotone_support );
 				}
 			}
 
-			if ( ! empty( $features ) ) {
-				static::$blocks_metadata[ $block_name ]['features'] = $features;
+			if ( null !== $duotone_selector ) {
+				static::$blocks_metadata[ $block_name ]['duotone'] = $duotone_selector;
 			}
 
-			// Assign defaults, then overwrite those that the block sets by itself.
-			// If the block selector is compounded, will append the element to each
-			// individual block selector.
-			$block_selectors = explode( ',', static::$blocks_metadata[ $block_name ]['selector'] );
-			foreach ( static::ELEMENTS as $el_name => $el_selector ) {
-				$element_selector = array();
-				foreach ( $block_selectors as $selector ) {
-					if ( $selector === $el_selector ) {
-						$element_selector = array( $el_selector );
-						break;
-					}
-					$element_selector[] = static::prepend_to_selector( $el_selector, $selector . ' ' );
-				}
-				static::$blocks_metadata[ $block_name ]['elements'][ $el_name ] = implode( ',', $element_selector );
-			}
 			// If the block has style variations, append their selectors to the block metadata.
 			if ( ! empty( $block_type->styles ) ) {
 				$style_selectors = array();
@@ -2223,6 +2201,7 @@ class WP_Theme_JSON {
 	 * An internal method to get the block nodes from a theme.json file.
 	 *
 	 * @since 6.1.0
+	 * @since 6.3.0 Refactored and stabilized selectors API.
 	 *
 	 * @param array $theme_json The theme.json converted to an array.
 	 * @return array The block nodes in theme.json.
@@ -2251,8 +2230,8 @@ class WP_Theme_JSON {
 			}
 
 			$feature_selectors = null;
-			if ( isset( $selectors[ $name ]['features'] ) ) {
-				$feature_selectors = $selectors[ $name ]['features'];
+			if ( isset( $selectors[ $name ]['selectors'] ) ) {
+				$feature_selectors = $selectors[ $name ]['selectors'];
 			}
 
 			$variation_selectors = array();
@@ -2269,6 +2248,7 @@ class WP_Theme_JSON {
 				'name'       => $name,
 				'path'       => array( 'styles', 'blocks', $name ),
 				'selector'   => $selector,
+				'selectors'  => $feature_selectors,
 				'duotone'    => $duotone_selector,
 				'features'   => $feature_selectors,
 				'variations' => $variation_selectors,
@@ -2311,45 +2291,11 @@ class WP_Theme_JSON {
 	 * @return string Styles for the block.
 	 */
 	public function get_styles_for_block( $block_metadata ) {
-		$node             = _wp_array_get( $this->theme_json, $block_metadata['path'], array() );
-		$use_root_padding = isset( $this->theme_json['settings']['useRootPaddingAwareAlignments'] ) && true === $this->theme_json['settings']['useRootPaddingAwareAlignments'];
-		$selector         = $block_metadata['selector'];
-		$settings         = _wp_array_get( $this->theme_json, array( 'settings' ) );
-
-		/*
-		 * Process style declarations for block support features the current
-		 * block contains selectors for. Values for a feature with a custom
-		 * selector are filtered from the theme.json node before it is
-		 * processed as normal.
-		*/
-		$feature_declarations = array();
-
-		if ( ! empty( $block_metadata['features'] ) ) {
-			foreach ( $block_metadata['features'] as $feature_name => $feature_selector ) {
-				if ( ! empty( $node[ $feature_name ] ) ) {
-					// Create temporary node containing only the feature data
-					// to leverage existing `compute_style_properties` function.
-					$feature = array( $feature_name => $node[ $feature_name ] );
-					// Generate the feature's declarations only.
-					$new_feature_declarations = static::compute_style_properties( $feature, $settings, null, $this->theme_json );
-
-					// Merge new declarations with any that already exist for
-					// the feature selector. This may occur when multiple block
-					// support features use the same custom selector.
-					if ( isset( $feature_declarations[ $feature_selector ] ) ) {
-						foreach ( $new_feature_declarations as $new_feature_declaration ) {
-							$feature_declarations[ $feature_selector ][] = $new_feature_declaration;
-						}
-					} else {
-						$feature_declarations[ $feature_selector ] = $new_feature_declarations;
-					}
-
-					// Remove the feature from the block's node now the
-					// styles will be included under the feature level selector.
-					unset( $node[ $feature_name ] );
-				}
-			}
-		}
+		$node                 = _wp_array_get( $this->theme_json, $block_metadata['path'], array() );
+		$use_root_padding     = isset( $this->theme_json['settings']['useRootPaddingAwareAlignments'] ) && true === $this->theme_json['settings']['useRootPaddingAwareAlignments'];
+		$selector             = $block_metadata['selector'];
+		$settings             = _wp_array_get( $this->theme_json, array( 'settings' ) );
+		$feature_declarations = static::get_feature_declarations_for_node( $block_metadata, $node );
 
 		// If there are style variations, generate the declarations for them, including any feature selectors the block may have.
 		$style_variation_declarations = array();
@@ -3537,6 +3483,159 @@ class WP_Theme_JSON {
 	}
 
 	/**
+	 * Returns the selectors metadata for a block.
+	 *
+	 * @since 6.3.0
+	 *
+	 * @param object $block_type    The block type.
+	 * @param string $root_selector The block's root selector.
+	 *
+	 * @return array The custom selectors set by the block.
+	 */
+	protected static function get_block_selectors( $block_type, $root_selector ) {
+		if ( ! empty( $block_type->selectors ) ) {
+			return $block_type->selectors;
+		}
+
+		$selectors = array( 'root' => $root_selector );
+		foreach ( static::BLOCK_SUPPORT_FEATURE_LEVEL_SELECTORS as $key => $feature ) {
+			$feature_selector = wp_get_block_css_selector( $block_type, $key );
+			if ( null !== $feature_selector ) {
+				$selectors[ $feature ] = array( 'root' => $feature_selector );
+			}
+		}
+
+		return $selectors;
+	}
+
+	/**
+	 * Generates all the element selectors for a block.
+	 *
+	 * @since 6.3.0
+	 *
+	 * @param string $root_selector The block's root CSS selector.
+	 * @return array The block's element selectors.
+	 */
+	protected static function get_block_element_selectors( $root_selector ) {
+		// Assign defaults, then override those that the block sets by itself.
+		// If the block selector is compounded, will append the element to each
+		// individual block selector.
+		$block_selectors   = explode( ',', $root_selector );
+		$element_selectors = array();
+
+		foreach ( static::ELEMENTS as $el_name => $el_selector ) {
+			$element_selector = array();
+			foreach ( $block_selectors as $selector ) {
+				if ( $selector === $el_selector ) {
+					$element_selector = array( $el_selector );
+					break;
+				}
+				$element_selector[] = static::prepend_to_selector( $el_selector, $selector . ' ' );
+			}
+			$element_selectors[ $el_name ] = implode( ',', $element_selector );
+		}
+
+		return $element_selectors;
+	}
+
+	/**
+	 * Generates style declarations for a node's features e.g., color, border,
+	 * typography etc. that have custom selectors in their related block's
+	 * metadata.
+	 *
+	 * @since 6.3.0
+	 *
+	 * @param object $metadata The related block metadata containing selectors.
+	 * @param object $node     A merged theme.json node for block or variation.
+	 *
+	 * @return array The style declarations for the node's features with custom
+	 * selectors.
+	 */
+	protected function get_feature_declarations_for_node( $metadata, &$node ) {
+		$declarations = array();
+
+		if ( ! isset( $metadata['selectors'] ) ) {
+			return $declarations;
+		}
+
+		$settings = _wp_array_get( $this->theme_json, array( 'settings' ) );
+
+		foreach ( $metadata['selectors'] as $feature => $feature_selectors ) {
+			// Skip if this is the block's root selector or the block doesn't
+			// have any styles for the feature.
+			if ( 'root' === $feature || empty( $node[ $feature ] ) ) {
+				continue;
+			}
+
+			if ( is_array( $feature_selectors ) ) {
+				foreach ( $feature_selectors as $subfeature => $subfeature_selector ) {
+					if ( 'root' === $subfeature || empty( $node[ $feature ][ $subfeature ] ) ) {
+						continue;
+					}
+
+					// Create temporary node containing only the subfeature data
+					// to leverage existing `compute_style_properties` function.
+					$subfeature_node = array(
+						$feature => array(
+							$subfeature => $node[ $feature ][ $subfeature ],
+						),
+					);
+
+					// Generate style declarations.
+					$new_declarations = static::compute_style_properties( $subfeature_node, $settings, null, $this->theme_json );
+
+					// Merge subfeature declarations into feature declarations.
+					if ( isset( $declarations[ $subfeature_selector ] ) ) {
+						foreach ( $new_declarations as $new_declaration ) {
+							$declarations[ $subfeature_selector ][] = $new_declaration;
+						}
+					} else {
+						$declarations[ $subfeature_selector ] = $new_declarations;
+					}
+
+					// Remove the subfeature from the block's node now its
+					// styles will be included under its own selector not the
+					// block's.
+					unset( $node[ $feature ][ $subfeature ] );
+				}
+			}
+
+			// Now subfeatures have been processed and removed we can process
+			// feature root selector or simple string selector.
+			if (
+				is_string( $feature_selectors ) ||
+				( isset( $feature_selectors['root'] ) && $feature_selectors['root'] )
+			) {
+				$feature_selector = is_string( $feature_selectors ) ? $feature_selectors : $feature_selectors['root'];
+
+				// Create temporary node containing only the feature data
+				// to leverage existing `compute_style_properties` function.
+				$feature_node = array( $feature => $node[ $feature ] );
+
+				// Generate the style declarations.
+				$new_declarations = static::compute_style_properties( $feature_node, $settings, null, $this->theme_json );
+
+				// Merge new declarations with any that already exist for
+				// the feature selector. This may occur when multiple block
+				// support features use the same custom selector.
+				if ( isset( $declarations[ $feature_selector ] ) ) {
+					foreach ( $new_declarations as $new_declaration ) {
+						$declarations[ $feature_selector ][] = $new_declaration;
+					}
+				} else {
+					$declarations[ $feature_selector ] = $new_declarations;
+				}
+
+				// Remove the feature from the block's node now its styles
+				// will be included under its own selector not the block's.
+				unset( $node[ $feature ] );
+			}
+		}
+
+		return $declarations;
+	}
+
+	/**
 	 * Replaces CSS variables with their values in place.
 	 *
 	 * @since 6.3.0
@@ -3608,5 +3707,4 @@ class WP_Theme_JSON {
 		$theme_json->theme_json['styles'] = self::convert_variables_to_value( $styles, $vars );
 		return $theme_json;
 	}
-
 }

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -2301,48 +2301,33 @@ class WP_Theme_JSON {
 		$style_variation_declarations = array();
 		if ( ! empty( $block_metadata['variations'] ) ) {
 			foreach ( $block_metadata['variations'] as $style_variation ) {
-				$style_variation_node     = _wp_array_get( $this->theme_json, $style_variation['path'], array() );
-				$style_variation_selector = $style_variation['selector'];
+				$style_variation_node           = _wp_array_get( $this->theme_json, $style_variation['path'], array() );
+				$clean_style_variation_selector = trim( $style_variation['selector'] );
 
-				// If the block has feature selectors, generate the declarations for them within the current style variation.
-				if ( ! empty( $block_metadata['features'] ) ) {
-					$clean_style_variation_selector = trim( $style_variation_selector );
-					foreach ( $block_metadata['features'] as $feature_name => $feature_selector ) {
-						if ( empty( $style_variation_node[ $feature_name ] ) ) {
-							continue;
-						}
-						// Prepend the variation selector to the feature selector.
-						$split_feature_selectors    = explode( ',', $feature_selector );
-						$feature_selectors          = array_map(
-							static function( $split_feature_selector ) use ( $clean_style_variation_selector ) {
-								return $clean_style_variation_selector . trim( $split_feature_selector );
-							},
-							$split_feature_selectors
-						);
-						$combined_feature_selectors = implode( ',', $feature_selectors );
+				// Generate any feature/subfeature style declarations for the current style variation.
+				$variation_declarations = static::get_feature_declarations_for_node( $block_metadata, $style_variation_node );
 
-						// Compute declarations for the feature.
-						$new_feature_declarations = static::compute_style_properties( array( $feature_name => $style_variation_node[ $feature_name ] ), $settings, null, $this->theme_json );
+				// Combine selectors with style variation's selector and add to overall style variation declarations.
+				foreach ( $variation_declarations as $current_selector => $new_declarations ) {
+					// If current selector includes block classname, remove it but leave the whitespace in.
+					$shortened_selector = str_replace( $block_metadata['selector'] . ' ', ' ', $current_selector );
 
-						/*
-						 * Merge new declarations with any that already exist for
-						 * the feature selector. This may occur when multiple block
-						 * support features use the same custom selector.
-						 */
-						if ( isset( $style_variation_declarations[ $combined_feature_selectors ] ) ) {
-							$style_variation_declarations[ $combined_feature_selectors ] = array_merge( $style_variation_declarations[ $combined_feature_selectors ], $new_feature_declarations );
-						} else {
-							$style_variation_declarations[ $combined_feature_selectors ] = $new_feature_declarations;
-						}
-						/*
-						 * Remove the feature from the variation's node now the
-						 * styles will be included under the feature level selector.
-						 */
-						unset( $style_variation_node[ $feature_name ] );
-					}
+					// Prepend the variation selector to the current selector.
+					$split_selectors    = explode( ',', $shortened_selector );
+					$updated_selectors  = array_map(
+						static function( $split_selector ) use ( $clean_style_variation_selector ) {
+							return $clean_style_variation_selector . $split_selector;
+						},
+						$split_selectors
+					);
+					$combined_selectors = implode( ',', $updated_selectors );
+
+					// Add the new declarations to the overall results under the modified selector.
+					$style_variation_declarations[ $combined_selectors ] = $new_declarations;
 				}
+
 				// Compute declarations for remaining styles not covered by feature level selectors.
-				$style_variation_declarations[ $style_variation_selector ] = static::compute_style_properties( $style_variation_node, $settings, null, $this->theme_json );
+				$style_variation_declarations[ $style_variation['selector'] ] = static::compute_style_properties( $style_variation_node, $settings, null, $this->theme_json );
 			}
 		}
 		/*

--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -443,3 +443,108 @@ function wp_clean_theme_json_cache() {
 function wp_get_theme_directory_pattern_slugs() {
 	return WP_Theme_JSON_Resolver::get_theme_data( array(), array( 'with_supports' => false ) )->get_patterns();
 }
+
+/**
+ * Determines the CSS selector for the block type and property provided,
+ * returning it if available.
+ *
+ * @since 6.3.0
+ *
+ * @param WP_Block_Type $block_type The block's type.
+ * @param string|array  $target     The desired selector's target, `root` or array path.
+ * @param boolean       $fallback   Whether to fall back to broader selector.
+ *
+ * @return string|null CSS selector or `null` if no selector available.
+ */
+function wp_get_block_css_selector( $block_type, $target = 'root', $fallback = false ) {
+	if ( empty( $target ) ) {
+		return null;
+	}
+
+	$has_selectors = ! empty( $block_type->selectors );
+
+	// Root Selector.
+
+	// Calculated before returning as it can be used as fallback for
+	// feature selectors later on.
+	$root_selector = null;
+
+	if ( $has_selectors && isset( $block_type->selectors['root'] ) ) {
+		// Use the selectors API if available.
+		$root_selector = $block_type->selectors['root'];
+	} elseif ( isset( $block_type->supports['__experimentalSelector'] ) && is_string( $block_type->supports['__experimentalSelector'] ) ) {
+		// Use the old experimental selector supports property if set.
+		$root_selector = $block_type->supports['__experimentalSelector'];
+	} else {
+		// If no root selector found, generate default block class selector.
+		$block_name    = str_replace( '/', '-', str_replace( 'core/', '', $block_type->name ) );
+		$root_selector = ".wp-block-{$block_name}";
+	}
+
+	// Return selector if it's the root target we are looking for.
+	if ( 'root' === $target ) {
+		return $root_selector;
+	}
+
+	// If target is not `root` we have a feature or subfeature as the target.
+	// If the target is a string convert to an array.
+	if ( is_string( $target ) ) {
+		$target = explode( '.', $target );
+	}
+
+	// Feature Selectors ( May fallback to root selector ).
+	if ( 1 === count( $target ) ) {
+		$fallback_selector = $fallback ? $root_selector : null;
+
+		// Prefer the selectors API if available.
+		if ( $has_selectors ) {
+			// Look for selector under `feature.root`.
+			$path             = array_merge( $target, array( 'root' ) );
+			$feature_selector = _wp_array_get( $block_type->selectors, $path, null );
+
+			if ( $feature_selector ) {
+				return $feature_selector;
+			}
+
+			// Check if feature selector is set via shorthand.
+			$feature_selector = _wp_array_get( $block_type->selectors, $target, null );
+
+			return is_string( $feature_selector ) ? $feature_selector : $fallback_selector;
+		}
+
+		// Try getting old experimental supports selector value.
+		$path             = array_merge( $target, array( '__experimentalSelector' ) );
+		$feature_selector = _wp_array_get( $block_type->supports, $path, null );
+
+		// Nothing to work with, provide fallback or null.
+		if ( null === $feature_selector ) {
+			return $fallback_selector;
+		}
+
+		// Scope the feature selector by the block's root selector.
+		return WP_Theme_JSON::scope_selector( $root_selector, $feature_selector );
+	}
+
+	// Subfeature selector
+	// This may fallback either to parent feature or root selector.
+	$subfeature_selector = null;
+
+	// Use selectors API if available.
+	if ( $has_selectors ) {
+		$subfeature_selector = _wp_array_get( $block_type->selectors, $target, null );
+	}
+
+	// Only return if we have a subfeature selector.
+	if ( $subfeature_selector ) {
+		return $subfeature_selector;
+	}
+
+	// To this point we don't have a subfeature selector. If a fallback
+	// has been requested, remove subfeature from target path and return
+	// results of a call for the parent feature's selector.
+	if ( $fallback ) {
+		return wp_get_block_css_selector( $block_type, $target[0], $fallback );
+	}
+
+	return null;
+}

--- a/tests/phpunit/tests/theme/wpGetBlockCssSelector.php
+++ b/tests/phpunit/tests/theme/wpGetBlockCssSelector.php
@@ -2,6 +2,8 @@
 /**
  * Tests wp_get_block_css_selector().
  *
+ * @since 6.3.0
+ *
  * @group themes
  *
  * @covers ::wp_get_block_css_selector
@@ -18,30 +20,26 @@ class Tests_Theme_WpGetBlockCssSelector extends WP_Theme_UnitTestCase {
 	public function tear_down() {
 		unregister_block_type( $this->test_block_name );
 		$this->test_block_name = null;
-		set_current_screen( '' );
 		parent::tear_down();
 	}
 
-	private function register_test_block( $name, $selectors = null, $supports = null, $editor_selectors = null ) {
+	private function register_test_block( $name, $selectors = null, $supports = null ) {
 		$this->test_block_name = $name;
 
 		return register_block_type(
 			$this->test_block_name,
 			array(
-				'api_version'      => 2,
-				'attributes'       => array(),
-				'selectors'        => $selectors,
-				'editor_selectors' => $editor_selectors,
-				'supports'         => $supports,
+				'api_version' => 2,
+				'attributes'  => array(),
+				'selectors'   => $selectors,
+				'supports'    => $supports,
 			)
 		);
 	}
 
-	private function set_screen_to_block_editor() {
-		set_current_screen( 'edit-post' );
-		get_current_screen()->is_block_editor( true );
-	}
-
+	/**
+	* @ticket 58586
+	*/
 	public function test_get_root_selector_via_selectors_api() {
 		$block_type = self::register_test_block(
 			'test/block-with-selectors',
@@ -52,6 +50,9 @@ class Tests_Theme_WpGetBlockCssSelector extends WP_Theme_UnitTestCase {
 		$this->assertEquals( '.wp-custom-block-class', $selector );
 	}
 
+	/**
+	 * @ticket 58586
+	 */
 	public function test_get_root_selector_via_experimental_property() {
 		$block_type = self::register_test_block(
 			'test/block-without-selectors',
@@ -63,6 +64,9 @@ class Tests_Theme_WpGetBlockCssSelector extends WP_Theme_UnitTestCase {
 		$this->assertEquals( '.experimental-selector', $selector );
 	}
 
+	/**
+	 * @ticket 58586
+	 */
 	public function test_default_root_selector_generation_for_core_block() {
 		$block_type = self::register_test_block(
 			'core/without-selectors-or-supports',
@@ -74,6 +78,9 @@ class Tests_Theme_WpGetBlockCssSelector extends WP_Theme_UnitTestCase {
 		$this->assertEquals( '.wp-block-without-selectors-or-supports', $selector );
 	}
 
+	/**
+	 * @ticket 58586
+	 */
 	public function test_default_root_selector_generation() {
 		$block_type = self::register_test_block(
 			'test/without-selectors-or-supports',
@@ -85,30 +92,9 @@ class Tests_Theme_WpGetBlockCssSelector extends WP_Theme_UnitTestCase {
 		$this->assertEquals( '.wp-block-test-without-selectors-or-supports', $selector );
 	}
 
-	public function test_get_duotone_selector_via_selectors_api() {
-		$block_type = self::register_test_block(
-			'test/duotone-selector',
-			array(
-				'filters' => array( 'duotone' => '.duotone-selector' ),
-			),
-			null
-		);
-
-		$selector = wp_get_block_css_selector( $block_type, array( 'filters', 'duotone' ) );
-		$this->assertEquals( '.duotone-selector', $selector );
-	}
-
-	public function test_no_duotone_selector_set() {
-		$block_type = self::register_test_block(
-			'test/null-duotone-selector',
-			null,
-			null
-		);
-
-		$selector = wp_get_block_css_selector( $block_type, 'filters.duotone' );
-		$this->assertEquals( null, $selector );
-	}
-
+	/**
+	 * @ticket 58586
+	 */
 	public function test_get_feature_selector_via_selectors_api() {
 		$block_type = self::register_test_block(
 			'test/feature-selector',
@@ -120,6 +106,9 @@ class Tests_Theme_WpGetBlockCssSelector extends WP_Theme_UnitTestCase {
 		$this->assertEquals( '.typography', $selector );
 	}
 
+	/**
+	 * @ticket 58586
+	 */
 	public function test_get_feature_selector_via_selectors_api_shorthand_property() {
 		$block_type = self::register_test_block(
 			'test/shorthand-feature-selector',
@@ -131,6 +120,9 @@ class Tests_Theme_WpGetBlockCssSelector extends WP_Theme_UnitTestCase {
 		$this->assertEquals( '.typography', $selector );
 	}
 
+	/**
+	 * @ticket 58586
+	 */
 	public function test_no_feature_level_selector_via_selectors_api() {
 		$block_type = self::register_test_block(
 			'test/null-feature-selector',
@@ -142,6 +134,9 @@ class Tests_Theme_WpGetBlockCssSelector extends WP_Theme_UnitTestCase {
 		$this->assertEquals( null, $selector );
 	}
 
+	/**
+	 * @ticket 58586
+	 */
 	public function test_fallback_feature_level_selector_via_selectors_api_to_generated_class() {
 		$block_type = self::register_test_block(
 			'test/fallback-feature-selector',
@@ -153,7 +148,9 @@ class Tests_Theme_WpGetBlockCssSelector extends WP_Theme_UnitTestCase {
 		$this->assertEquals( '.wp-block-test-fallback-feature-selector', $selector );
 	}
 
-
+	/**
+	 * @ticket 58586
+	 */
 	public function test_fallback_feature_level_selector_via_selectors_api() {
 		$block_type = self::register_test_block(
 			'test/fallback-feature-selector',
@@ -165,6 +162,9 @@ class Tests_Theme_WpGetBlockCssSelector extends WP_Theme_UnitTestCase {
 		$this->assertEquals( '.fallback-root-selector', $selector );
 	}
 
+	/**
+	 * @ticket 58586
+	 */
 	public function test_get_feature_selector_via_experimental_property() {
 		$block_type = self::register_test_block(
 			'test/experimental-feature-selector',
@@ -180,6 +180,9 @@ class Tests_Theme_WpGetBlockCssSelector extends WP_Theme_UnitTestCase {
 		$this->assertEquals( '.wp-block-test-experimental-feature-selector .experimental-typography', $selector );
 	}
 
+	/**
+	 * @ticket 58586
+	 */
 	public function test_fallback_feature_selector_via_experimental_property() {
 		$block_type = self::register_test_block(
 			'test/fallback-feature-selector',
@@ -191,6 +194,9 @@ class Tests_Theme_WpGetBlockCssSelector extends WP_Theme_UnitTestCase {
 		$this->assertEquals( '.wp-block-test-fallback-feature-selector', $selector );
 	}
 
+	/**
+	 * @ticket 58586
+	 */
 	public function test_no_feature_selector_via_experimental_property() {
 		$block_type = self::register_test_block(
 			'test/null-experimental-feature-selector',
@@ -202,6 +208,9 @@ class Tests_Theme_WpGetBlockCssSelector extends WP_Theme_UnitTestCase {
 		$this->assertEquals( null, $selector );
 	}
 
+	/**
+	 * @ticket 58586
+	 */
 	public function test_get_subfeature_selector_via_selectors_api() {
 		$block_type = self::register_test_block(
 			'test/subfeature-selector',
@@ -221,6 +230,9 @@ class Tests_Theme_WpGetBlockCssSelector extends WP_Theme_UnitTestCase {
 		$this->assertEquals( '.root .typography .text-decoration', $selector );
 	}
 
+	/**
+	 * @ticket 58586
+	 */
 	public function test_fallback_subfeature_selector_via_selectors_api() {
 		$block_type = self::register_test_block(
 			'test/subfeature-selector',
@@ -239,6 +251,9 @@ class Tests_Theme_WpGetBlockCssSelector extends WP_Theme_UnitTestCase {
 		$this->assertEquals( '.root .typography', $selector );
 	}
 
+	/**
+	 * @ticket 58586
+	 */
 	public function test_no_subfeature_level_selector_via_selectors_api() {
 		$block_type = self::register_test_block(
 			'test/null-subfeature-selector',
@@ -250,6 +265,9 @@ class Tests_Theme_WpGetBlockCssSelector extends WP_Theme_UnitTestCase {
 		$this->assertEquals( null, $selector );
 	}
 
+	/**
+	 * @ticket 58586
+	 */
 	public function test_fallback_subfeature_selector_via_experimental_property() {
 		$block_type = self::register_test_block(
 			'test/fallback-subfeature-selector',
@@ -265,6 +283,9 @@ class Tests_Theme_WpGetBlockCssSelector extends WP_Theme_UnitTestCase {
 		$this->assertEquals( '.wp-block-test-fallback-subfeature-selector', $selector );
 	}
 
+	/**
+	 * @ticket 58586
+	 */
 	public function test_no_subfeature_selector_via_experimental_property() {
 		$block_type = self::register_test_block(
 			'test/null-experimental-subfeature-selector',
@@ -279,6 +300,9 @@ class Tests_Theme_WpGetBlockCssSelector extends WP_Theme_UnitTestCase {
 		$this->assertEquals( null, $selector );
 	}
 
+	/**
+	 * @ticket 58586
+	 */
 	public function test_empty_target_returns_null() {
 		$block_type = self::register_test_block(
 			'test/null-experimental-subfeature-selector',
@@ -293,6 +317,9 @@ class Tests_Theme_WpGetBlockCssSelector extends WP_Theme_UnitTestCase {
 		$this->assertEquals( null, $selector );
 	}
 
+	/**
+	 * @ticket 58586
+	 */
 	public function test_string_targets_for_features() {
 		$block_type = self::register_test_block(
 			'test/target-types-for-features',
@@ -307,6 +334,9 @@ class Tests_Theme_WpGetBlockCssSelector extends WP_Theme_UnitTestCase {
 		$this->assertEquals( '.found', $selector );
 	}
 
+	/**
+	 * @ticket 58586
+	 */
 	public function test_string_targets_for_subfeatures() {
 		$block_type = self::register_test_block(
 			'test/target-types-for-features',
@@ -321,108 +351,6 @@ class Tests_Theme_WpGetBlockCssSelector extends WP_Theme_UnitTestCase {
 
 		$selector = wp_get_block_css_selector( $block_type, array( 'typography', 'fontSize' ) );
 		$this->assertEquals( '.found', $selector );
-	}
-
-	public function test_editor_only_root_selector() {
-		self::set_screen_to_block_editor();
-
-		$block_type = self::register_test_block(
-			'test/editor-only-selectors',
-			array( 'root' => '.wp-custom-block-class' ),
-			null,
-			array( 'root' => '.wp-custom-block-class' )
-		);
-
-		$selector = wp_get_block_css_selector( $block_type, 'root' );
-		$this->assertEquals( '.wp-custom-block-class', $selector );
-	}
-
-	public function test_editor_only_duotone_selector() {
-		self::set_screen_to_block_editor();
-
-		$block_type = self::register_test_block(
-			'test/editor-duotone-selector',
-			array(
-				'filters' => array( 'duotone' => '.duotone-selector' ),
-			),
-			null,
-			array(
-				'filters' => array( 'duotone' => '.duotone-selector' ),
-			)
-		);
-
-		$selector = wp_get_block_css_selector( $block_type, 'filters.duotone' );
-		$this->assertEquals( '.duotone-selector', $selector );
-	}
-
-	public function test_editor_only_feature_selector() {
-		self::set_screen_to_block_editor();
-
-		$block_type = self::register_test_block(
-			'test/editor-feature-selector',
-			array( 'typography' => array( 'root' => '.typography' ) ),
-			null,
-			array( 'typography' => array( 'root' => '.typography' ) )
-		);
-
-		$selector = wp_get_block_css_selector( $block_type, 'typography' );
-		$this->assertEquals( '.typography', $selector );
-	}
-
-	public function test_editor_only_feature_selector_shorthand() {
-		self::set_screen_to_block_editor();
-
-		$block_type = self::register_test_block(
-			'test/editor-feature-selector',
-			array( 'typography' => '.typography' ),
-			null,
-			array( 'typography' => '.typography' )
-		);
-
-		$selector = wp_get_block_css_selector( $block_type, 'typography' );
-		$this->assertEquals( '.typography', $selector );
-	}
-
-	public function test_editor_only_subfeature_selector() {
-		self::set_screen_to_block_editor();
-
-		$block_type = self::register_test_block(
-			'test/editor-subfeature-selector',
-			array( 'typography' => array( 'fontSize' => '.font-size' ) ),
-			null,
-			array( 'typography' => array( 'fontSize' => '.font-size' ) )
-		);
-
-		$selector = wp_get_block_css_selector( $block_type, 'typography.fontSize' );
-		$this->assertEquals( '.font-size', $selector );
-	}
-
-	public function test_non_editor_subfeature_does_not_fall_back_to_editor_only_feature_selector() {
-		self::set_screen_to_block_editor();
-
-		$block_type = self::register_test_block(
-			'test/editor-subfeature-selector',
-			array( 'typography' => array( 'fontSize' => '.font-size' ) ),
-			null,
-			array( 'typography' => '.font-size' )
-		);
-
-		$selector = wp_get_block_css_selector( $block_type, 'typography.fontSize', true );
-		$this->assertEquals( '.font-size', $selector );
-	}
-
-	public function test_unspecified_subfeature_falls_back_to_editor_only_feature_selector() {
-		self::set_screen_to_block_editor();
-
-		$block_type = self::register_test_block(
-			'test/editor-subfeature-selector',
-			array( 'typography' => '.typography' ),
-			null,
-			array( 'typography' => '.typography' )
-		);
-
-		$selector = wp_get_block_css_selector( $block_type, 'typography.fontSize', true );
-		$this->assertEquals( '.typography', $selector );
 	}
 }
 

--- a/tests/phpunit/tests/theme/wpGetBlockCssSelector.php
+++ b/tests/phpunit/tests/theme/wpGetBlockCssSelector.php
@@ -100,21 +100,6 @@ class Tests_Theme_WpGetBlockCssSelector extends WP_Theme_UnitTestCase {
 		$this->assertEquals( '.duotone-selector', $selector );
 	}
 
-	public function test_get_duotone_selector_via_experimental_property() {
-		$block_type = self::register_test_block(
-			'test/experimental-duotone-selector',
-			null,
-			array(
-				'color' => array(
-					'__experimentalDuotone' => '.experimental-duotone',
-				),
-			)
-		);
-
-		$selector = wp_get_block_css_selector( $block_type, 'filters.duotone' );
-		$this->assertEquals( '.experimental-duotone', $selector );
-	}
-
 	public function test_no_duotone_selector_set() {
 		$block_type = self::register_test_block(
 			'test/null-duotone-selector',
@@ -347,11 +332,11 @@ class Tests_Theme_WpGetBlockCssSelector extends WP_Theme_UnitTestCase {
 			'test/editor-only-selectors',
 			array( 'root' => '.wp-custom-block-class' ),
 			null,
-			array( 'root' => '.editor-only.wp-custom-block-class' )
+			array( 'root' => '.wp-custom-block-class' )
 		);
 
 		$selector = wp_get_block_css_selector( $block_type, 'root' );
-		$this->assertEquals( '.editor-only.wp-custom-block-class', $selector );
+		$this->assertEquals( '.wp-custom-block-class', $selector );
 	}
 
 	public function test_editor_only_duotone_selector() {
@@ -364,12 +349,12 @@ class Tests_Theme_WpGetBlockCssSelector extends WP_Theme_UnitTestCase {
 			),
 			null,
 			array(
-				'filters' => array( 'duotone' => '.editor-duotone-selector' ),
+				'filters' => array( 'duotone' => '.duotone-selector' ),
 			)
 		);
 
 		$selector = wp_get_block_css_selector( $block_type, 'filters.duotone' );
-		$this->assertEquals( '.editor-duotone-selector', $selector );
+		$this->assertEquals( '.duotone-selector', $selector );
 	}
 
 	public function test_editor_only_feature_selector() {
@@ -379,11 +364,11 @@ class Tests_Theme_WpGetBlockCssSelector extends WP_Theme_UnitTestCase {
 			'test/editor-feature-selector',
 			array( 'typography' => array( 'root' => '.typography' ) ),
 			null,
-			array( 'typography' => array( 'root' => '.editor-typography' ) )
+			array( 'typography' => array( 'root' => '.typography' ) )
 		);
 
 		$selector = wp_get_block_css_selector( $block_type, 'typography' );
-		$this->assertEquals( '.editor-typography', $selector );
+		$this->assertEquals( '.typography', $selector );
 	}
 
 	public function test_editor_only_feature_selector_shorthand() {
@@ -393,11 +378,11 @@ class Tests_Theme_WpGetBlockCssSelector extends WP_Theme_UnitTestCase {
 			'test/editor-feature-selector',
 			array( 'typography' => '.typography' ),
 			null,
-			array( 'typography' => '.editor-typography' )
+			array( 'typography' => '.typography' )
 		);
 
 		$selector = wp_get_block_css_selector( $block_type, 'typography' );
-		$this->assertEquals( '.editor-typography', $selector );
+		$this->assertEquals( '.typography', $selector );
 	}
 
 	public function test_editor_only_subfeature_selector() {
@@ -407,11 +392,11 @@ class Tests_Theme_WpGetBlockCssSelector extends WP_Theme_UnitTestCase {
 			'test/editor-subfeature-selector',
 			array( 'typography' => array( 'fontSize' => '.font-size' ) ),
 			null,
-			array( 'typography' => array( 'fontSize' => '.editor-font-size' ) )
+			array( 'typography' => array( 'fontSize' => '.font-size' ) )
 		);
 
 		$selector = wp_get_block_css_selector( $block_type, 'typography.fontSize' );
-		$this->assertEquals( '.editor-font-size', $selector );
+		$this->assertEquals( '.font-size', $selector );
 	}
 
 	public function test_non_editor_subfeature_does_not_fall_back_to_editor_only_feature_selector() {
@@ -421,7 +406,7 @@ class Tests_Theme_WpGetBlockCssSelector extends WP_Theme_UnitTestCase {
 			'test/editor-subfeature-selector',
 			array( 'typography' => array( 'fontSize' => '.font-size' ) ),
 			null,
-			array( 'typography' => '.editor-font-size' )
+			array( 'typography' => '.font-size' )
 		);
 
 		$selector = wp_get_block_css_selector( $block_type, 'typography.fontSize', true );
@@ -435,11 +420,11 @@ class Tests_Theme_WpGetBlockCssSelector extends WP_Theme_UnitTestCase {
 			'test/editor-subfeature-selector',
 			array( 'typography' => '.typography' ),
 			null,
-			array( 'typography' => '.editor-typography' )
+			array( 'typography' => '.typography' )
 		);
 
 		$selector = wp_get_block_css_selector( $block_type, 'typography.fontSize', true );
-		$this->assertEquals( '.editor-typography', $selector );
+		$this->assertEquals( '.typography', $selector );
 	}
 }
 

--- a/tests/phpunit/tests/theme/wpGetBlockCssSelector.php
+++ b/tests/phpunit/tests/theme/wpGetBlockCssSelector.php
@@ -1,7 +1,4 @@
 <?php
-
-require_once __DIR__ . '/base.php';
-
 /**
  * Tests wp_get_block_css_selector().
  *
@@ -9,6 +6,7 @@ require_once __DIR__ . '/base.php';
  *
  * @covers ::wp_get_block_css_selector
  */
+
 class Tests_Theme_WpGetBlockCssSelector extends WP_Theme_UnitTestCase {
 	private $test_block_name;
 

--- a/tests/phpunit/tests/theme/wpGetBlockCssSelector.php
+++ b/tests/phpunit/tests/theme/wpGetBlockCssSelector.php
@@ -1,0 +1,445 @@
+<?php
+
+require_once __DIR__ . '/base.php';
+
+/**
+ * Tests wp_get_block_css_selector().
+ *
+ * @group themes
+ *
+ * @covers ::wp_get_block_css_selector
+ */
+class Tests_Theme_WpGetBlockCssSelector extends WP_Theme_UnitTestCase {
+	private $test_block_name;
+
+	public function set_up() {
+		parent::set_up();
+		$this->test_block_name = null;
+	}
+
+	public function tear_down() {
+		unregister_block_type( $this->test_block_name );
+		$this->test_block_name = null;
+		set_current_screen( '' );
+		parent::tear_down();
+	}
+
+	private function register_test_block( $name, $selectors = null, $supports = null, $editor_selectors = null ) {
+		$this->test_block_name = $name;
+
+		return register_block_type(
+			$this->test_block_name,
+			array(
+				'api_version'      => 2,
+				'attributes'       => array(),
+				'selectors'        => $selectors,
+				'editor_selectors' => $editor_selectors,
+				'supports'         => $supports,
+			)
+		);
+	}
+
+	private function set_screen_to_block_editor() {
+		set_current_screen( 'edit-post' );
+		get_current_screen()->is_block_editor( true );
+	}
+
+	public function test_get_root_selector_via_selectors_api() {
+		$block_type = self::register_test_block(
+			'test/block-with-selectors',
+			array( 'root' => '.wp-custom-block-class' )
+		);
+
+		$selector = wp_get_block_css_selector( $block_type );
+		$this->assertEquals( '.wp-custom-block-class', $selector );
+	}
+
+	public function test_get_root_selector_via_experimental_property() {
+		$block_type = self::register_test_block(
+			'test/block-without-selectors',
+			null,
+			array( '__experimentalSelector' => '.experimental-selector' )
+		);
+
+		$selector = wp_get_block_css_selector( $block_type );
+		$this->assertEquals( '.experimental-selector', $selector );
+	}
+
+	public function test_default_root_selector_generation_for_core_block() {
+		$block_type = self::register_test_block(
+			'core/without-selectors-or-supports',
+			null,
+			null
+		);
+
+		$selector = wp_get_block_css_selector( $block_type );
+		$this->assertEquals( '.wp-block-without-selectors-or-supports', $selector );
+	}
+
+	public function test_default_root_selector_generation() {
+		$block_type = self::register_test_block(
+			'test/without-selectors-or-supports',
+			null,
+			null
+		);
+
+		$selector = wp_get_block_css_selector( $block_type );
+		$this->assertEquals( '.wp-block-test-without-selectors-or-supports', $selector );
+	}
+
+	public function test_get_duotone_selector_via_selectors_api() {
+		$block_type = self::register_test_block(
+			'test/duotone-selector',
+			array(
+				'filters' => array( 'duotone' => '.duotone-selector' ),
+			),
+			null
+		);
+
+		$selector = wp_get_block_css_selector( $block_type, array( 'filters', 'duotone' ) );
+		$this->assertEquals( '.duotone-selector', $selector );
+	}
+
+	public function test_get_duotone_selector_via_experimental_property() {
+		$block_type = self::register_test_block(
+			'test/experimental-duotone-selector',
+			null,
+			array(
+				'color' => array(
+					'__experimentalDuotone' => '.experimental-duotone',
+				),
+			)
+		);
+
+		$selector = wp_get_block_css_selector( $block_type, 'filters.duotone' );
+		$this->assertEquals( '.experimental-duotone', $selector );
+	}
+
+	public function test_no_duotone_selector_set() {
+		$block_type = self::register_test_block(
+			'test/null-duotone-selector',
+			null,
+			null
+		);
+
+		$selector = wp_get_block_css_selector( $block_type, 'filters.duotone' );
+		$this->assertEquals( null, $selector );
+	}
+
+	public function test_get_feature_selector_via_selectors_api() {
+		$block_type = self::register_test_block(
+			'test/feature-selector',
+			array( 'typography' => array( 'root' => '.typography' ) ),
+			null
+		);
+
+		$selector = wp_get_block_css_selector( $block_type, 'typography' );
+		$this->assertEquals( '.typography', $selector );
+	}
+
+	public function test_get_feature_selector_via_selectors_api_shorthand_property() {
+		$block_type = self::register_test_block(
+			'test/shorthand-feature-selector',
+			array( 'typography' => '.typography' ),
+			null
+		);
+
+		$selector = wp_get_block_css_selector( $block_type, 'typography' );
+		$this->assertEquals( '.typography', $selector );
+	}
+
+	public function test_no_feature_level_selector_via_selectors_api() {
+		$block_type = self::register_test_block(
+			'test/null-feature-selector',
+			array( 'root' => '.fallback-root-selector' ),
+			null
+		);
+
+		$selector = wp_get_block_css_selector( $block_type, 'typography' );
+		$this->assertEquals( null, $selector );
+	}
+
+	public function test_fallback_feature_level_selector_via_selectors_api_to_generated_class() {
+		$block_type = self::register_test_block(
+			'test/fallback-feature-selector',
+			array(),
+			null
+		);
+
+		$selector = wp_get_block_css_selector( $block_type, 'typography', true );
+		$this->assertEquals( '.wp-block-test-fallback-feature-selector', $selector );
+	}
+
+
+	public function test_fallback_feature_level_selector_via_selectors_api() {
+		$block_type = self::register_test_block(
+			'test/fallback-feature-selector',
+			array( 'root' => '.fallback-root-selector' ),
+			null
+		);
+
+		$selector = wp_get_block_css_selector( $block_type, 'typography', true );
+		$this->assertEquals( '.fallback-root-selector', $selector );
+	}
+
+	public function test_get_feature_selector_via_experimental_property() {
+		$block_type = self::register_test_block(
+			'test/experimental-feature-selector',
+			null,
+			array(
+				'typography' => array(
+					'__experimentalSelector' => '.experimental-typography',
+				),
+			)
+		);
+
+		$selector = wp_get_block_css_selector( $block_type, 'typography' );
+		$this->assertEquals( '.wp-block-test-experimental-feature-selector .experimental-typography', $selector );
+	}
+
+	public function test_fallback_feature_selector_via_experimental_property() {
+		$block_type = self::register_test_block(
+			'test/fallback-feature-selector',
+			null,
+			array()
+		);
+
+		$selector = wp_get_block_css_selector( $block_type, 'typography', true );
+		$this->assertEquals( '.wp-block-test-fallback-feature-selector', $selector );
+	}
+
+	public function test_no_feature_selector_via_experimental_property() {
+		$block_type = self::register_test_block(
+			'test/null-experimental-feature-selector',
+			null,
+			array()
+		);
+
+		$selector = wp_get_block_css_selector( $block_type, 'typography' );
+		$this->assertEquals( null, $selector );
+	}
+
+	public function test_get_subfeature_selector_via_selectors_api() {
+		$block_type = self::register_test_block(
+			'test/subfeature-selector',
+			array(
+				'typography' => array(
+					'textDecoration' => '.root .typography .text-decoration',
+				),
+			),
+			null
+		);
+
+		$selector = wp_get_block_css_selector(
+			$block_type,
+			array( 'typography', 'textDecoration' )
+		);
+
+		$this->assertEquals( '.root .typography .text-decoration', $selector );
+	}
+
+	public function test_fallback_subfeature_selector_via_selectors_api() {
+		$block_type = self::register_test_block(
+			'test/subfeature-selector',
+			array(
+				'typography' => array( 'root' => '.root .typography' ),
+			),
+			null
+		);
+
+		$selector = wp_get_block_css_selector(
+			$block_type,
+			array( 'typography', 'textDecoration' ),
+			true
+		);
+
+		$this->assertEquals( '.root .typography', $selector );
+	}
+
+	public function test_no_subfeature_level_selector_via_selectors_api() {
+		$block_type = self::register_test_block(
+			'test/null-subfeature-selector',
+			array(),
+			null
+		);
+
+		$selector = wp_get_block_css_selector( $block_type, array( 'typography', 'fontSize' ) );
+		$this->assertEquals( null, $selector );
+	}
+
+	public function test_fallback_subfeature_selector_via_experimental_property() {
+		$block_type = self::register_test_block(
+			'test/fallback-subfeature-selector',
+			null,
+			array()
+		);
+
+		$selector = wp_get_block_css_selector(
+			$block_type,
+			array( 'typography', 'fontSize' ),
+			true
+		);
+		$this->assertEquals( '.wp-block-test-fallback-subfeature-selector', $selector );
+	}
+
+	public function test_no_subfeature_selector_via_experimental_property() {
+		$block_type = self::register_test_block(
+			'test/null-experimental-subfeature-selector',
+			null,
+			array()
+		);
+
+		$selector = wp_get_block_css_selector(
+			$block_type,
+			array( 'typography', 'fontSize' )
+		);
+		$this->assertEquals( null, $selector );
+	}
+
+	public function test_empty_target_returns_null() {
+		$block_type = self::register_test_block(
+			'test/null-experimental-subfeature-selector',
+			null,
+			array()
+		);
+
+		$selector = wp_get_block_css_selector( $block_type, array() );
+		$this->assertEquals( null, $selector );
+
+		$selector = wp_get_block_css_selector( $block_type, '' );
+		$this->assertEquals( null, $selector );
+	}
+
+	public function test_string_targets_for_features() {
+		$block_type = self::register_test_block(
+			'test/target-types-for-features',
+			array( 'typography' => '.found' ),
+			null
+		);
+
+		$selector = wp_get_block_css_selector( $block_type, 'typography' );
+		$this->assertEquals( '.found', $selector );
+
+		$selector = wp_get_block_css_selector( $block_type, array( 'typography' ) );
+		$this->assertEquals( '.found', $selector );
+	}
+
+	public function test_string_targets_for_subfeatures() {
+		$block_type = self::register_test_block(
+			'test/target-types-for-features',
+			array(
+				'typography' => array( 'fontSize' => '.found' ),
+			),
+			null
+		);
+
+		$selector = wp_get_block_css_selector( $block_type, 'typography.fontSize' );
+		$this->assertEquals( '.found', $selector );
+
+		$selector = wp_get_block_css_selector( $block_type, array( 'typography', 'fontSize' ) );
+		$this->assertEquals( '.found', $selector );
+	}
+
+	public function test_editor_only_root_selector() {
+		self::set_screen_to_block_editor();
+
+		$block_type = self::register_test_block(
+			'test/editor-only-selectors',
+			array( 'root' => '.wp-custom-block-class' ),
+			null,
+			array( 'root' => '.editor-only.wp-custom-block-class' )
+		);
+
+		$selector = wp_get_block_css_selector( $block_type, 'root' );
+		$this->assertEquals( '.editor-only.wp-custom-block-class', $selector );
+	}
+
+	public function test_editor_only_duotone_selector() {
+		self::set_screen_to_block_editor();
+
+		$block_type = self::register_test_block(
+			'test/editor-duotone-selector',
+			array(
+				'filters' => array( 'duotone' => '.duotone-selector' ),
+			),
+			null,
+			array(
+				'filters' => array( 'duotone' => '.editor-duotone-selector' ),
+			)
+		);
+
+		$selector = wp_get_block_css_selector( $block_type, 'filters.duotone' );
+		$this->assertEquals( '.editor-duotone-selector', $selector );
+	}
+
+	public function test_editor_only_feature_selector() {
+		self::set_screen_to_block_editor();
+
+		$block_type = self::register_test_block(
+			'test/editor-feature-selector',
+			array( 'typography' => array( 'root' => '.typography' ) ),
+			null,
+			array( 'typography' => array( 'root' => '.editor-typography' ) )
+		);
+
+		$selector = wp_get_block_css_selector( $block_type, 'typography' );
+		$this->assertEquals( '.editor-typography', $selector );
+	}
+
+	public function test_editor_only_feature_selector_shorthand() {
+		self::set_screen_to_block_editor();
+
+		$block_type = self::register_test_block(
+			'test/editor-feature-selector',
+			array( 'typography' => '.typography' ),
+			null,
+			array( 'typography' => '.editor-typography' )
+		);
+
+		$selector = wp_get_block_css_selector( $block_type, 'typography' );
+		$this->assertEquals( '.editor-typography', $selector );
+	}
+
+	public function test_editor_only_subfeature_selector() {
+		self::set_screen_to_block_editor();
+
+		$block_type = self::register_test_block(
+			'test/editor-subfeature-selector',
+			array( 'typography' => array( 'fontSize' => '.font-size' ) ),
+			null,
+			array( 'typography' => array( 'fontSize' => '.editor-font-size' ) )
+		);
+
+		$selector = wp_get_block_css_selector( $block_type, 'typography.fontSize' );
+		$this->assertEquals( '.editor-font-size', $selector );
+	}
+
+	public function test_non_editor_subfeature_does_not_fall_back_to_editor_only_feature_selector() {
+		self::set_screen_to_block_editor();
+
+		$block_type = self::register_test_block(
+			'test/editor-subfeature-selector',
+			array( 'typography' => array( 'fontSize' => '.font-size' ) ),
+			null,
+			array( 'typography' => '.editor-font-size' )
+		);
+
+		$selector = wp_get_block_css_selector( $block_type, 'typography.fontSize', true );
+		$this->assertEquals( '.font-size', $selector );
+	}
+
+	public function test_unspecified_subfeature_falls_back_to_editor_only_feature_selector() {
+		self::set_screen_to_block_editor();
+
+		$block_type = self::register_test_block(
+			'test/editor-subfeature-selector',
+			array( 'typography' => '.typography' ),
+			null,
+			array( 'typography' => '.editor-typography' )
+		);
+
+		$selector = wp_get_block_css_selector( $block_type, 'typography.fontSize', true );
+		$this->assertEquals( '.editor-typography', $selector );
+	}
+}
+


### PR DESCRIPTION
This is a backport PR for WordPress 6.3 that includes the following PHP Gutenberg changes:

- https://github.com/WordPress/gutenberg/pull/46496
- https://github.com/WordPress/gutenberg/pull/49427
- https://github.com/WordPress/gutenberg/pull/49423 (changes not applied by the [duotone backport](https://github.com/WordPress/wordpress-develop/pull/4619))
- https://github.com/WordPress/gutenberg/pull/49393 (changes not applied by the [duotone backport](https://github.com/WordPress/wordpress-develop/pull/4619))

Related (original code introduced in 6.2):

- https://github.com/WordPress/wordpress-develop/pull/3942

Trac ticket: https://core.trac.wordpress.org/ticket/58586

cc @aaronrobertshaw

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
