### PR TITLE
Backport: Navigation Post Edit Link

### DIFF
--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1474,6 +1474,9 @@ function get_edit_post_link( $post = 0, $context = 'display' ) {
 	if ( 'wp_template' === $post->post_type || 'wp_template_part' === $post->post_type ) {
 		$slug = urlencode( get_stylesheet() . '//' . $post->post_name );
 		$link = admin_url( sprintf( $post_type_object->_edit_link, $post->post_type, $slug ) );
+	} elseif ( 'wp_navigation' === $post->post_type ) {
+		$id               = $post->ID;
+		$link             = admin_url( sprintf( $post_type_object->_edit_link, $id ) );
 	} elseif ( $post_type_object->_edit_link ) {
 		$link = admin_url( sprintf( $post_type_object->_edit_link . $action, $post->ID ) );
 	}

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1475,8 +1475,7 @@ function get_edit_post_link( $post = 0, $context = 'display' ) {
 		$slug = urlencode( get_stylesheet() . '//' . $post->post_name );
 		$link = admin_url( sprintf( $post_type_object->_edit_link, $post->post_type, $slug ) );
 	} elseif ( 'wp_navigation' === $post->post_type ) {
-		$id               = $post->ID;
-		$link             = admin_url( sprintf( $post_type_object->_edit_link, $id ) );
+		$link = admin_url( sprintf( $post_type_object->_edit_link, (string) $post->ID ) );
 	} elseif ( $post_type_object->_edit_link ) {
 		$link = admin_url( sprintf( $post_type_object->_edit_link . $action, $post->ID ) );
 	}

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -490,6 +490,14 @@ function create_initial_post_types() {
 		)
 	);
 
+	$navigation_post_edit_link = 'site-editor.php?' . build_query(
+		array(
+			'postId'   => '%s',
+			'postType' => 'wp_navigation',
+			'canvas'   => 'edit',
+		)
+	);
+
 	register_post_type(
 		'wp_navigation',
 		array(
@@ -512,6 +520,9 @@ function create_initial_post_types() {
 				'filter_items_list'     => __( 'Filter Navigation Menu list' ),
 				'items_list_navigation' => __( 'Navigation Menus list navigation' ),
 				'items_list'            => __( 'Navigation Menus list' ),
+				/* internal use only. don't use this when registering your own post type. */
+				'_edit_link'            => $navigation_post_edit_link,
+
 			),
 			'description'           => __( 'Navigation menus that can be inserted into your site.' ),
 			'public'                => false,
@@ -551,7 +562,8 @@ function create_initial_post_types() {
 		array(
 			'label'       => _x( 'Published', 'post status' ),
 			'public'      => true,
-			'_builtin'    => true, /* internal use only. */
+			'_builtin'    => true, /*
+		internal use only. */
 			/* translators: %s: Number of published posts. */
 			'label_count' => _n_noop(
 				'Published <span class="count">(%s)</span>',
@@ -565,7 +577,8 @@ function create_initial_post_types() {
 		array(
 			'label'       => _x( 'Scheduled', 'post status' ),
 			'protected'   => true,
-			'_builtin'    => true, /* internal use only. */
+			'_builtin'    => true, /*
+		internal use only. */
 			/* translators: %s: Number of scheduled posts. */
 			'label_count' => _n_noop(
 				'Scheduled <span class="count">(%s)</span>',
@@ -579,7 +592,8 @@ function create_initial_post_types() {
 		array(
 			'label'         => _x( 'Draft', 'post status' ),
 			'protected'     => true,
-			'_builtin'      => true, /* internal use only. */
+			'_builtin'      => true, /*
+		internal use only. */
 			/* translators: %s: Number of draft posts. */
 			'label_count'   => _n_noop(
 				'Draft <span class="count">(%s)</span>',
@@ -594,7 +608,8 @@ function create_initial_post_types() {
 		array(
 			'label'         => _x( 'Pending', 'post status' ),
 			'protected'     => true,
-			'_builtin'      => true, /* internal use only. */
+			'_builtin'      => true, /*
+		internal use only. */
 			/* translators: %s: Number of pending posts. */
 			'label_count'   => _n_noop(
 				'Pending <span class="count">(%s)</span>',
@@ -609,7 +624,8 @@ function create_initial_post_types() {
 		array(
 			'label'       => _x( 'Private', 'post status' ),
 			'private'     => true,
-			'_builtin'    => true, /* internal use only. */
+			'_builtin'    => true, /*
+		internal use only. */
 			/* translators: %s: Number of private posts. */
 			'label_count' => _n_noop(
 				'Private <span class="count">(%s)</span>',
@@ -623,7 +639,8 @@ function create_initial_post_types() {
 		array(
 			'label'                     => _x( 'Trash', 'post status' ),
 			'internal'                  => true,
-			'_builtin'                  => true, /* internal use only. */
+			'_builtin'                  => true, /*
+		internal use only. */
 			/* translators: %s: Number of trashed posts. */
 			'label_count'               => _n_noop(
 				'Trash <span class="count">(%s)</span>',
@@ -658,7 +675,8 @@ function create_initial_post_types() {
 		array(
 			'label'               => _x( 'Pending', 'request status' ),
 			'internal'            => true,
-			'_builtin'            => true, /* internal use only. */
+			'_builtin'            => true, /*
+		internal use only. */
 			/* translators: %s: Number of pending requests. */
 			'label_count'         => _n_noop(
 				'Pending <span class="count">(%s)</span>',
@@ -673,7 +691,8 @@ function create_initial_post_types() {
 		array(
 			'label'               => _x( 'Confirmed', 'request status' ),
 			'internal'            => true,
-			'_builtin'            => true, /* internal use only. */
+			'_builtin'            => true, /*
+		internal use only. */
 			/* translators: %s: Number of confirmed requests. */
 			'label_count'         => _n_noop(
 				'Confirmed <span class="count">(%s)</span>',
@@ -688,7 +707,8 @@ function create_initial_post_types() {
 		array(
 			'label'               => _x( 'Failed', 'request status' ),
 			'internal'            => true,
-			'_builtin'            => true, /* internal use only. */
+			'_builtin'            => true, /*
+		internal use only. */
 			/* translators: %s: Number of failed requests. */
 			'label_count'         => _n_noop(
 				'Failed <span class="count">(%s)</span>',
@@ -703,7 +723,8 @@ function create_initial_post_types() {
 		array(
 			'label'               => _x( 'Completed', 'request status' ),
 			'internal'            => true,
-			'_builtin'            => true, /* internal use only. */
+			'_builtin'            => true, /*
+		internal use only. */
 			/* translators: %s: Number of completed requests. */
 			'label_count'         => _n_noop(
 				'Completed <span class="count">(%s)</span>',

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -520,8 +520,7 @@ function create_initial_post_types() {
 				'filter_items_list'     => __( 'Filter Navigation Menu list' ),
 				'items_list_navigation' => __( 'Navigation Menus list navigation' ),
 				'items_list'            => __( 'Navigation Menus list' ),
-				/* internal use only. don't use this when registering your own post type. */
-				'_edit_link'            => $navigation_post_edit_link,
+				'_edit_link'            => $navigation_post_edit_link, /* internal use only. don't use this when registering your own post type. */
 			),
 			'description'           => __( 'Navigation menus that can be inserted into your site.' ),
 			'public'                => false,

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -562,8 +562,7 @@ function create_initial_post_types() {
 		array(
 			'label'       => _x( 'Published', 'post status' ),
 			'public'      => true,
-			'_builtin'    => true, /*
-		internal use only. */
+			'_builtin'    => true, /* internal use only. */
 			/* translators: %s: Number of published posts. */
 			'label_count' => _n_noop(
 				'Published <span class="count">(%s)</span>',
@@ -577,8 +576,7 @@ function create_initial_post_types() {
 		array(
 			'label'       => _x( 'Scheduled', 'post status' ),
 			'protected'   => true,
-			'_builtin'    => true, /*
-		internal use only. */
+			'_builtin'    => true, /* internal use only. */
 			/* translators: %s: Number of scheduled posts. */
 			'label_count' => _n_noop(
 				'Scheduled <span class="count">(%s)</span>',
@@ -592,8 +590,7 @@ function create_initial_post_types() {
 		array(
 			'label'         => _x( 'Draft', 'post status' ),
 			'protected'     => true,
-			'_builtin'      => true, /*
-		internal use only. */
+			'_builtin'      => true, /* internal use only. */
 			/* translators: %s: Number of draft posts. */
 			'label_count'   => _n_noop(
 				'Draft <span class="count">(%s)</span>',
@@ -608,8 +605,7 @@ function create_initial_post_types() {
 		array(
 			'label'         => _x( 'Pending', 'post status' ),
 			'protected'     => true,
-			'_builtin'      => true, /*
-		internal use only. */
+			'_builtin'      => true, /* internal use only. */
 			/* translators: %s: Number of pending posts. */
 			'label_count'   => _n_noop(
 				'Pending <span class="count">(%s)</span>',
@@ -624,8 +620,7 @@ function create_initial_post_types() {
 		array(
 			'label'       => _x( 'Private', 'post status' ),
 			'private'     => true,
-			'_builtin'    => true, /*
-		internal use only. */
+			'_builtin'    => true, /* internal use only. */
 			/* translators: %s: Number of private posts. */
 			'label_count' => _n_noop(
 				'Private <span class="count">(%s)</span>',
@@ -639,8 +634,7 @@ function create_initial_post_types() {
 		array(
 			'label'                     => _x( 'Trash', 'post status' ),
 			'internal'                  => true,
-			'_builtin'                  => true, /*
-		internal use only. */
+			'_builtin'                  => true, /* internal use only. */
 			/* translators: %s: Number of trashed posts. */
 			'label_count'               => _n_noop(
 				'Trash <span class="count">(%s)</span>',
@@ -675,8 +669,7 @@ function create_initial_post_types() {
 		array(
 			'label'               => _x( 'Pending', 'request status' ),
 			'internal'            => true,
-			'_builtin'            => true, /*
-		internal use only. */
+			'_builtin'            => true, /* internal use only. */
 			/* translators: %s: Number of pending requests. */
 			'label_count'         => _n_noop(
 				'Pending <span class="count">(%s)</span>',
@@ -691,8 +684,7 @@ function create_initial_post_types() {
 		array(
 			'label'               => _x( 'Confirmed', 'request status' ),
 			'internal'            => true,
-			'_builtin'            => true, /*
-		internal use only. */
+			'_builtin'            => true, /* internal use only. */
 			/* translators: %s: Number of confirmed requests. */
 			'label_count'         => _n_noop(
 				'Confirmed <span class="count">(%s)</span>',
@@ -707,8 +699,7 @@ function create_initial_post_types() {
 		array(
 			'label'               => _x( 'Failed', 'request status' ),
 			'internal'            => true,
-			'_builtin'            => true, /*
-		internal use only. */
+			'_builtin'            => true, /* internal use only. */
 			/* translators: %s: Number of failed requests. */
 			'label_count'         => _n_noop(
 				'Failed <span class="count">(%s)</span>',
@@ -723,8 +714,7 @@ function create_initial_post_types() {
 		array(
 			'label'               => _x( 'Completed', 'request status' ),
 			'internal'            => true,
-			'_builtin'            => true, /*
-		internal use only. */
+			'_builtin'            => true, /* internal use only. */
 			/* translators: %s: Number of completed requests. */
 			'label_count'         => _n_noop(
 				'Completed <span class="count">(%s)</span>',

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -522,7 +522,6 @@ function create_initial_post_types() {
 				'items_list'            => __( 'Navigation Menus list' ),
 				/* internal use only. don't use this when registering your own post type. */
 				'_edit_link'            => $navigation_post_edit_link,
-
 			),
 			'description'           => __( 'Navigation menus that can be inserted into your site.' ),
 			'public'                => false,

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -520,11 +520,11 @@ function create_initial_post_types() {
 				'filter_items_list'     => __( 'Filter Navigation Menu list' ),
 				'items_list_navigation' => __( 'Navigation Menus list navigation' ),
 				'items_list'            => __( 'Navigation Menus list' ),
-				'_edit_link'            => $navigation_post_edit_link, /* internal use only. don't use this when registering your own post type. */
 			),
 			'description'           => __( 'Navigation menus that can be inserted into your site.' ),
 			'public'                => false,
 			'_builtin'              => true, /* internal use only. don't use this when registering your own post type. */
+			'_edit_link'            => $navigation_post_edit_link, /* internal use only. don't use this when registering your own post type. */
 			'has_archive'           => false,
 			'show_ui'               => true,
 			'show_in_menu'          => false,

--- a/tests/phpunit/tests/link/getEditPostLink.php
+++ b/tests/phpunit/tests/link/getEditPostLink.php
@@ -131,4 +131,24 @@ class Tests_Link_GetEditPostLink extends WP_UnitTestCase {
 		$this->assertSame( $link_default_context, get_edit_post_link( $template_part_post ), 'Second argument `$context` has a default context of `"display"`.' );
 		$this->assertSame( $link_custom_context, get_edit_post_link( $template_part_post, 'something-else' ), 'Pass non-default value in second argument.' );
 	}
+
+	public function test_get_edit_post_link_for_wp_navigation_post_type() {
+		$navigation_post = self::factory()->post->create_and_get(
+			array(
+				'post_type'    => 'wp_navigation',
+				'post_name'    => 'my_navigation',
+				'post_title'   => 'My Navigation',
+				'post_content' => '<!-- wp:navigation-link {"label":"WordPress","type":"custom","url":"http://www.wordpress.org/","kind":"custom"} /-->',
+				'post_excerpt' => 'Description of my Navigation',
+			)
+		);
+
+		$post_type_object     = get_post_type_object( $navigation_post->post_type );
+
+		$link_default_context = admin_url( sprintf( $post_type_object->_edit_link, $navigation_post->ID ) );
+		$link_custom_context  = admin_url( sprintf( $post_type_object->_edit_link, $navigation_post->ID ) );
+
+		$this->assertSame( $link_default_context, get_edit_post_link( $navigation_post ), 'Second argument `$context` has a default context of `"display"`.' );
+		$this->assertSame( $link_custom_context, get_edit_post_link( $navigation_post, 'something-else' ), 'Pass non-default value in second argument.' );
+	}
 }

--- a/tests/phpunit/tests/link/getEditPostLink.php
+++ b/tests/phpunit/tests/link/getEditPostLink.php
@@ -143,7 +143,7 @@ class Tests_Link_GetEditPostLink extends WP_UnitTestCase {
 			)
 		);
 
-		$post_type_object     = get_post_type_object( $navigation_post->post_type );
+		$post_type_object = get_post_type_object( $navigation_post->post_type );
 
 		$link_default_context = admin_url( sprintf( $post_type_object->_edit_link, $navigation_post->ID ) );
 		$link_custom_context  = admin_url( sprintf( $post_type_object->_edit_link, $navigation_post->ID ) );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Backports changes that amend the Post Edit link for wp_navigation posts from https://github.com/WordPress/gutenberg/pull/39286 to Core.

Trac ticket: https://core.trac.wordpress.org/ticket/58589

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
