### PR TITLE
Backport changes from gutenberg#46896 for 6.3

### DIFF
--- a/src/wp-includes/block-supports/shadow.php
+++ b/src/wp-includes/block-supports/shadow.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Shadow block support flag.
+ *
+ * @package WordPress
+ * @since 6.3.0
+ */
+
+/**
+ * Registers the style and shadow block attributes for block types that support it.
+ *
+ * @since 6.3.0
+ * @access private
+ * 
+ * @param WP_Block_Type $block_type Block Type.
+ */
+function wp_register_shadow_support( $block_type ) {
+	$has_shadow_support = block_has_support( $block_type, array( 'shadow' ), false );
+
+	if ( ! $has_shadow_support ) {
+		return;
+	}
+
+	if ( ! $block_type->attributes ) {
+		$block_type->attributes = array();
+	}
+
+	if ( $has_shadow_support && ! array_key_exists( 'style', $block_type->attributes ) ) {
+		$block_type->attributes['style'] = array(
+			'type' => 'object',
+		);
+	}
+
+	if ( $has_shadow_support && ! array_key_exists( 'shadow', $block_type->attributes ) ) {
+		$block_type->attributes['shadow'] = array(
+			'type' => 'string',
+		);
+	}
+}
+
+/**
+ * Add CSS classes and inline styles for shadow features to the incoming attributes array.
+ * This will be applied to the block markup in
+ * the front-end.
+ * 
+ * @since 6.3.0
+ * @access private
+ *
+ * @param  WP_Block_Type $block_type       Block type.
+ * @param  array         $block_attributes Block attributes.
+ *
+ * @return array Shadow CSS classes and inline styles.
+ */
+function wp_apply_shadow_support( $block_type, $block_attributes ) {
+	$has_shadow_support = block_has_support( $block_type, array( 'shadow' ), false );
+
+	if ( ! $has_shadow_support ) {
+		return array();
+	}
+
+	$shadow_block_styles = array();
+
+	$preset_shadow                 = array_key_exists( 'shadow', $block_attributes ) ? "var:preset|shadow|{$block_attributes['shadow']}" : null;
+	$custom_shadow                 = isset( $block_attributes['style']['shadow'] ) ? $block_attributes['style']['shadow'] : null;
+	$shadow_block_styles['shadow'] = $preset_shadow ? $preset_shadow : $custom_shadow;
+
+	$attributes = array();
+	$styles     = wp_style_engine_get_styles( $shadow_block_styles );
+
+	if ( ! empty( $styles['css'] ) ) {
+		$attributes['style'] = $styles['css'];
+	}
+
+	return $attributes;
+}
+
+// Register the block support.
+WP_Block_Supports::get_instance()->register(
+	'shadow',
+	array(
+		'register_attribute' => 'wp_register_shadow_support',
+		'apply'              => 'wp_apply_shadow_support',
+	)
+);

--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -2447,6 +2447,7 @@ function safecss_filter_attr( $css, $deprecated = '' ) {
 			'bottom',
 			'left',
 			'z-index',
+			'box-shadow',
 			'aspect-ratio',
 
 			// Custom CSS properties.

--- a/src/wp-includes/style-engine/class-wp-style-engine.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine.php
@@ -147,6 +147,17 @@ final class WP_Style_Engine {
 				),
 			),
 		),
+		'shadow'     => array(
+			'shadow' => array(
+				'property_keys' => array(
+					'default' => 'box-shadow',
+				),
+				'path'          => array( 'shadow' ),
+				'css_vars'      => array(
+					'shadow' => '--wp--preset--shadow--$slug',
+				),
+			),
+		),
 		'dimensions' => array(
 			'minHeight' => array(
 				'property_keys' => array(

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -331,6 +331,7 @@ require ABSPATH . WPINC . '/block-supports/colors.php';
 require ABSPATH . WPINC . '/block-supports/custom-classname.php';
 require ABSPATH . WPINC . '/block-supports/dimensions.php';
 require ABSPATH . WPINC . '/block-supports/duotone.php';
+require ABSPATH . WPINC . '/block-supports/shadow.php';
 require ABSPATH . WPINC . '/block-supports/elements.php';
 require ABSPATH . WPINC . '/block-supports/generated-classname.php';
 require ABSPATH . WPINC . '/block-supports/layout.php';


### PR DESCRIPTION
This PR adds the PHP changes for the following Gutenberg PRs:

https://github.com/WordPress/gutenberg/pull/46896

There are no front-end changes in this PR.

Testing instructions:

* Enable supports for blocks such as `post-title`

`src/wp-includes/blocks/post-title/block.json`
```
{
...
"supports": {
  "shadow": true,
  ...
}
```

In the theme template add shadow attribute as follows.

```
<!-- wp:post-title {"shadow":"natural"} /-->
```

Verify the post title UI to have the applied shadow.

<img width="519" alt="image" src="https://github.com/WordPress/wordpress-develop/assets/1935113/12172326-42ef-446c-9dfd-28c54267176a">

