### PR TITLE
Try storing the E2E screenshots as artifcats when the tests fail.

### DIFF
--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -110,6 +110,14 @@ jobs:
       - name: Run E2E tests
         run: npm run test:e2e
 
+      - name: Archive debug artifacts (screenshots, HTML snapshots)
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        if: always()
+        with:
+            name: failures-artifacts
+            path: artifacts
+            if-no-files-found: ignore
+
       - name: Ensure version-controlled files are not modified or deleted
         run: git diff --exit-code
 

--- a/tests/e2e/specs/dashboard.test.js
+++ b/tests/e2e/specs/dashboard.test.js
@@ -44,7 +44,7 @@ describe( 'Quick Draft', () => {
 
 		expect(
 			await postsListDraft.evaluate( ( element ) => element.innerText )
-		).toContain( 'Peter edited this to force the tests to fail. Note to self: Revert.' );
+		).toContain( 'Test Draft Title' );
 	} );
 
 	it( 'Allows draft to be created without Title or Content', async () => {

--- a/tests/e2e/specs/dashboard.test.js
+++ b/tests/e2e/specs/dashboard.test.js
@@ -44,7 +44,7 @@ describe( 'Quick Draft', () => {
 
 		expect(
 			await postsListDraft.evaluate( ( element ) => element.innerText )
-		).toContain( 'Test Draft Title' );
+		).toContain( 'Peter edited this to force the tests to fail. Note to self: Revert.' );
 	} );
 
 	it( 'Allows draft to be created without Title or Content', async () => {


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/58596

* [Failed E2E run](https://github.com/WordPress/wordpress-develop/actions/runs/5342076459)
* [Passing E2E run](https://github.com/WordPress/wordpress-develop/actions/runs/5342138202)