### PR TITLE
Remove unused function parameters and variable from Twenty Twenty

### DIFF
--- a/src/wp-content/themes/twentytwenty/classes/class-twentytwenty-walker-page.php
+++ b/src/wp-content/themes/twentytwenty/classes/class-twentytwenty-walker-page.php
@@ -38,10 +38,8 @@ if ( ! class_exists( 'TwentyTwenty_Walker_Page' ) ) {
 
 			if ( isset( $args['item_spacing'] ) && 'preserve' === $args['item_spacing'] ) {
 				$t = "\t";
-				$n = "\n";
 			} else {
 				$t = '';
-				$n = '';
 			}
 			if ( $depth ) {
 				$indent = str_repeat( $t, $depth );

--- a/src/wp-content/themes/twentytwenty/inc/template-tags.php
+++ b/src/wp-content/themes/twentytwenty/inc/template-tags.php
@@ -241,8 +241,6 @@ add_filter( 'edit_post_link', 'twentytwenty_edit_post_link', 10, 3 );
  *
  * @since Twenty Twenty 1.0
  *
- * @global WP_Post $post Global post object.
- *
  * @param int    $post_id  The ID of the post.
  * @param string $location The location where the meta is shown.
  */
@@ -331,7 +329,6 @@ function twentytwenty_get_post_meta( $post_id = null, $location = 'single-top' )
 		// Make sure we don't output an empty container.
 		$has_meta = false;
 
-		global $post;
 		$the_post = get_post( $post_id );
 		setup_postdata( $the_post );
 

--- a/src/wp-content/themes/twentytwenty/inc/template-tags.php
+++ b/src/wp-content/themes/twentytwenty/inc/template-tags.php
@@ -545,10 +545,9 @@ function twentytwenty_get_post_meta( $post_id = null, $location = 'single-top' )
  * @param WP_Post  $page         Page data object.
  * @param int      $depth        Depth of page, used for padding.
  * @param array    $args         An array of arguments.
- * @param int      $current_page ID of the current page.
  * @return array CSS class names.
  */
-function twentytwenty_filter_wp_list_pages_item_classes( $css_class, $page, $depth, $args, $current_page ) {
+function twentytwenty_filter_wp_list_pages_item_classes( $css_class, $page, $depth, $args ) {
 
 	// Only apply to wp_list_pages() calls with match_menu_classes set to true.
 	$match_menu_classes = isset( $args['match_menu_classes'] );
@@ -571,7 +570,7 @@ function twentytwenty_filter_wp_list_pages_item_classes( $css_class, $page, $dep
 
 }
 
-add_filter( 'page_css_class', 'twentytwenty_filter_wp_list_pages_item_classes', 10, 5 );
+add_filter( 'page_css_class', 'twentytwenty_filter_wp_list_pages_item_classes', 10, 4 );
 
 /**
  * Adds a Sub Nav Toggle to the Expanded Menu and Mobile Menu.
@@ -580,10 +579,9 @@ add_filter( 'page_css_class', 'twentytwenty_filter_wp_list_pages_item_classes', 
  *
  * @param stdClass $args  An object of wp_nav_menu() arguments.
  * @param WP_Post  $item  Menu item data object.
- * @param int      $depth Depth of menu item. Used for padding.
  * @return stdClass An object of wp_nav_menu() arguments.
  */
-function twentytwenty_add_sub_toggles_to_main_menu( $args, $item, $depth ) {
+function twentytwenty_add_sub_toggles_to_main_menu( $args, $item ) {
 
 	// Add sub menu toggles to the Expanded Menu with toggles.
 	if ( isset( $args->show_toggles ) && $args->show_toggles ) {
@@ -622,7 +620,7 @@ function twentytwenty_add_sub_toggles_to_main_menu( $args, $item, $depth ) {
 
 }
 
-add_filter( 'nav_menu_item_args', 'twentytwenty_add_sub_toggles_to_main_menu', 10, 3 );
+add_filter( 'nav_menu_item_args', 'twentytwenty_add_sub_toggles_to_main_menu', 10, 2 );
 
 /**
  * Displays SVG icons in social links menu.


### PR DESCRIPTION
- Removes `$n` variable from `TwentyTwenty_Walker_Page` class `start_el()`
- Removes last parameter from `twentytwenty_filter_wp_list_pages_item_classes()` and `twentytwenty_add_sub_toggles_to_main_menu()`

Trac ticket: https://core.trac.wordpress.org/ticket/57371

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
