### PR TITLE
Fix block editor stylesheet being registered with wrong URL

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -219,11 +219,7 @@ function register_block_style_handle( $metadata, $field_name, $index = 0 ) {
 	// Check whether styles should have a ".min" suffix or not.
 	$suffix = SCRIPT_DEBUG ? '' : '.min';
 	if ( $is_core_block ) {
-		if ( 'editorStyle' === $field_name ) {
-			$style_path = "editor$suffix.css";
-		} else {
-			$style_path = "style$suffix.css";
-		}
+		$style_path = ( 'editorStyle' === $field_name ) ? "editor$suffix.css" : "style$suffix.css";
 	}
 
 	$style_path_norm = wp_normalize_path( realpath( dirname( $metadata['file'] ) . '/' . $style_path ) );

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -219,7 +219,11 @@ function register_block_style_handle( $metadata, $field_name, $index = 0 ) {
 	// Check whether styles should have a ".min" suffix or not.
 	$suffix = SCRIPT_DEBUG ? '' : '.min';
 	if ( $is_core_block ) {
-		$style_path = "style$suffix.css";
+		if ( 'editorStyle' === $field_name ) {
+			$style_path = "editor$suffix.css";
+		} else {
+			$style_path = "style$suffix.css";
+		}
 	}
 
 	$style_path_norm = wp_normalize_path( realpath( dirname( $metadata['file'] ) . '/' . $style_path ) );
@@ -239,7 +243,8 @@ function register_block_style_handle( $metadata, $field_name, $index = 0 ) {
 		if ( $is_theme_block ) {
 			$style_uri = get_theme_file_uri( str_replace( $theme_path_norm, '', $style_path_norm ) );
 		} elseif ( $is_core_block ) {
-			$style_uri = includes_url( 'blocks/' . str_replace( 'core/', '', $metadata['name'] ) . "/style$suffix.css" );
+			// All possible $style_path variants for core blocks are hard-coded above.
+			$style_uri = includes_url( 'blocks/' . str_replace( 'core/', '', $metadata['name'] ) . '/' . $style_path );
 		}
 	} else {
 		$style_uri = false;

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -219,7 +219,7 @@ function register_block_style_handle( $metadata, $field_name, $index = 0 ) {
 	// Check whether styles should have a ".min" suffix or not.
 	$suffix = SCRIPT_DEBUG ? '' : '.min';
 	if ( $is_core_block ) {
-		$style_path = ( 'editorStyle' === $field_name ) ? "editor$suffix.css" : "style$suffix.css";
+		$style_path = ( 'editorStyle' === $field_name ) ? "editor{$suffix}.css" : "style{$suffix}.css";
 	}
 
 	$style_path_norm = wp_normalize_path( realpath( dirname( $metadata['file'] ) . '/' . $style_path ) );

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -348,9 +348,11 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 		// Ensure block assets are separately registered.
 		add_filter( 'should_load_separate_core_block_assets', '__return_true' );
 
-		// Account for minified asset path.
+		// Account for minified asset path and ensure the file exists.
+		// This may not be the case in the testing environment since it requires the build process to place them.
 		if ( is_string( $expected_path ) ) {
 			$expected_path = str_replace( '.css', wp_scripts_get_suffix() . '.css', $expected_path );
+			self::touch( ABSPATH . $expected_path );
 		}
 
 		$result = register_block_style_handle( $metadata, $style_field );

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -323,6 +323,71 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 58605
+	 * @dataProvider data_register_block_style_handle_uses_correct_core_stylesheet
+	 *
+	 * @param string      $block_json_path Path to the `block.json` file, relative to ABSPATH.
+	 * @param string      $style_field     Either 'style' or 'editorStyle'.
+	 * @param string|bool $expected_path   Expected path of registered stylesheet, relative to ABSPATH.
+	 */
+	public function test_register_block_style_handle_uses_correct_core_stylesheet( $block_json_path, $style_field, $expected_path ) {
+		$metadata_file = ABSPATH . $block_json_path;
+		$metadata      = wp_json_file_decode( $metadata_file, array( 'associative' => true ) );
+
+		$block_name = str_replace( 'core/', '', $metadata['name'] );
+
+		// Normalize metadata similar to `register_block_type_from_metadata()`.
+		$metadata['file'] = wp_normalize_path( realpath( $metadata_file ) );
+		if ( ! isset( $metadata['style'] ) ) {
+			$metadata['style'] = "wp-block-$block_name";
+		}
+		if ( ! isset( $metadata['editorStyle'] ) ) {
+			$metadata['editorStyle'] = "wp-block-{$block_name}-editor";
+		}
+
+		// Ensure block assets are separately registered.
+		add_filter( 'should_load_separate_core_block_assets', '__return_true' );
+
+		// Account for minified asset path.
+		if ( is_string( $expected_path ) ) {
+			$expected_path = str_replace( '.css', wp_scripts_get_suffix() . '.css', $expected_path );
+		}
+
+		$result = register_block_style_handle( $metadata, $style_field );
+		$this->assertSame( $metadata[ $style_field ], $result, 'Core block registration failed' );
+		if ( $expected_path ) {
+			$this->assertStringEndsWith( $expected_path, wp_styles()->registered[ $result ]->src, 'Core block stylesheet path incorrect' );
+		} else {
+			$this->assertFalse( wp_styles()->registered[ $result ]->src, 'Core block stylesheet src should be false' );
+		}
+	}
+
+	public function data_register_block_style_handle_uses_correct_core_stylesheet() {
+		return array(
+			'block with style'           => array(
+				WPINC . '/blocks/archives/block.json',
+				'style',
+				WPINC . '/blocks/archives/style.css',
+			),
+			'block with editor style'    => array(
+				WPINC . '/blocks/archives/block.json',
+				'editorStyle',
+				WPINC . '/blocks/archives/editor.css',
+			),
+			'block without style'        => array(
+				WPINC . '/blocks/widget-group/block.json',
+				'style',
+				false,
+			),
+			'block without editor style' => array(
+				WPINC . '/blocks/widget-group/block.json',
+				'editorStyle',
+				false,
+			),
+		);
+	}
+
+	/**
 	 * @ticket 50263
 	 */
 	public function test_handle_passed_register_block_style_handle() {

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -324,6 +324,7 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 58605
+	 *
 	 * @dataProvider data_register_block_style_handle_uses_correct_core_stylesheet
 	 *
 	 * @param string      $block_json_path Path to the `block.json` file, relative to ABSPATH.

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -349,8 +349,10 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 		// Ensure block assets are separately registered.
 		add_filter( 'should_load_separate_core_block_assets', '__return_true' );
 
-		// Account for minified asset path and ensure the file exists.
-		// This may not be the case in the testing environment since it requires the build process to place them.
+		/*
+		 * Account for minified asset path and ensure the file exists.
+		 * This may not be the case in the testing environment since it requires the build process to place them.
+		 */
 		if ( is_string( $expected_path ) ) {
 			$expected_path = str_replace( '.css', wp_scripts_get_suffix() . '.css', $expected_path );
 			self::touch( ABSPATH . $expected_path );


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/58605

This PR also includes test coverage for the core-specific code paths of `register_block_style_handle()` which was missing before.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
