### PR TITLE
Block template utils tests: insert correct template part object to test modified prop

### DIFF
--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -101,7 +101,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		$this->assertSame( 'My Template', $template->title );
 		$this->assertSame( 'Description of my template', $template->description );
 		$this->assertSame( 'wp_template', $template->type );
-		$this->assertSame( self::$template_post->post_modified, $template->modified );
+		$this->assertSame( self::$template_post->post_modified, $template->modified, 'Template result properties match' );
 
 		// Test template parts.
 		$template_part = _build_block_template_result_from_post(
@@ -118,7 +118,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		$this->assertSame( 'Description of my template part', $template_part->description );
 		$this->assertSame( 'wp_template_part', $template_part->type );
 		$this->assertSame( WP_TEMPLATE_PART_AREA_HEADER, $template_part->area );
-		$this->assertSame( self::$template_part_post->post_modified, $template->modified );
+		$this->assertSame( self::$template_part_post->post_modified, $template_part->modified, 'Template part result properties match' );
 	}
 
 	public function test_build_block_template_result_from_file() {


### PR DESCRIPTION
In https://github.com/WordPress/wordpress-develop/pull/4613 tests were added to cover changes to `_build_block_template_result_from_post` that reflect the new `modified` property.

The wrong object was used in the template part assertion.

This commit corrects that and fixes the failing tests.

Trac ticket: https://core.trac.wordpress.org/ticket/58540

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
