### PR TITLE
Backport for 6.3: Add a description key to theme.json style variations

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -313,10 +313,12 @@ class WP_Theme_JSON {
 	 * @since 5.8.0 As `ALLOWED_TOP_LEVEL_KEYS`.
 	 * @since 5.9.0 Renamed from `ALLOWED_TOP_LEVEL_KEYS` to `VALID_TOP_LEVEL_KEYS`,
 	 *              added the `customTemplates` and `templateParts` values.
+	 * @since 6.3.0 Added the `description` value.
 	 * @var string[]
 	 */
 	const VALID_TOP_LEVEL_KEYS = array(
 		'customTemplates',
+		'description',
 		'patterns',
 		'settings',
 		'styles',


### PR DESCRIPTION
Backporting changes from https://github.com/WordPress/gutenberg/pull/45242

Adds `description` to `VALID_TOP_LEVEL_KEYS` in `class-wp-theme-json.php` to allow for an accessibility improvement.

The description is added to the aria label of the style variation container. If the style variation has no description, only the title is used.

props @carolinan


Trac ticket: https://core.trac.wordpress.org/ticket/58614

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
