### PR TITLE
change label for post status pending from Pending to Pending Review

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -592,7 +592,7 @@ function create_initial_post_types() {
 	register_post_status(
 		'pending',
 		array(
-			'label'         => _x( 'Pending', 'post status' ),
+			'label'         => _x( 'Pending Review', 'post status' ),
 			'protected'     => true,
 			'_builtin'      => true, /* internal use only. */
 			/* translators: %s: Number of pending posts. */


### PR DESCRIPTION
Fixes : [https://core.trac.wordpress.org/ticket/58617#ticket](https://core.trac.wordpress.org/ticket/58617#ticket)

Changed the label for post status **pending** from Pending to Pending Review in get_post_stati() funnction to make it consistent with label for post status **pending** get_post_statuses() function

