### PR TITLE
Site editor: Combine id and class into one element

### DIFF
--- a/src/wp-admin/site-editor.php
+++ b/src/wp-admin/site-editor.php
@@ -132,9 +132,7 @@ do_action( 'enqueue_block_editor_assets' );
 require_once ABSPATH . 'wp-admin/admin-header.php';
 ?>
 
-<div class="edit-site">
-	<div id="site-editor"></div>
-
+<div class="edit-site" id="site-editor">
 	<?php // JavaScript is disabled. ?>
 	<div class="wrap hide-if-js site-editor-no-js">
 		<h1 class="wp-heading-inline"><?php _e( 'Edit site' ); ?></h1>


### PR DESCRIPTION
The changes in https://github.com/WordPress/wordpress-develop/commit/aef1cb9847e9e513e0f4a7a4fe93c54ddabf6168 have broken the site editor in view and editor modes.

It added an additional wrapper for the site-editor div, which breaks flexbox styling.

props @kevin940726 for finding the bug and proposing the fix


## Before

<img width="1083" alt="Screenshot 2023-06-26 at 12 24 43 pm" src="https://github.com/WordPress/wordpress-develop/assets/6458278/25987753-c3fe-4f0a-b954-e34307bf8b2e">
<img width="1082" alt="Screenshot 2023-06-26 at 12 24 37 pm" src="https://github.com/WordPress/wordpress-develop/assets/6458278/4ba25f4f-2d1d-45b4-a540-541a14e7508c">


## After
<img width="1031" alt="Screenshot 2023-06-26 at 12 30 12 pm" src="https://github.com/WordPress/wordpress-develop/assets/6458278/6375d30d-4855-4b6f-b072-6b3ff653025e">
<img width="1063" alt="Screenshot 2023-06-26 at 12 30 07 pm" src="https://github.com/WordPress/wordpress-develop/assets/6458278/b816d86a-86cc-40b3-a4c6-d8fcca15afef">

<img width="977" alt="Screenshot 2023-06-26 at 12 27 49 pm" src="https://github.com/WordPress/wordpress-develop/assets/6458278/d7753bce-0718-4d31-9a85-a8bf8d8e4649">



Trac ticket: https://core.trac.wordpress.org/ticket/56228

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
