### PR TITLE
Patterns: Allow for filtering of block patterns by source

### DIFF
--- a/src/wp-includes/block-patterns.php
+++ b/src/wp-includes/block-patterns.php
@@ -31,7 +31,7 @@ function _register_core_block_patterns_and_categories() {
 
 		foreach ( $core_block_patterns as $core_block_pattern ) {
 			$pattern           = require __DIR__ . '/block-patterns/' . $core_block_pattern . '.php';
-			$pattern['source'] = 'core'; // Added in 6.3.0.
+			$pattern['source'] = 'core';
 			register_block_pattern( 'core/' . $core_block_pattern, $pattern );
 		}
 	}
@@ -225,7 +225,7 @@ function _load_remote_block_patterns( $deprecated = null ) {
 		$patterns = $response->get_data();
 
 		foreach ( $patterns as $pattern ) {
-			$pattern['source']  = 'pattern-directory/core'; // Added in 6.3.0.
+			$pattern['source']  = 'pattern-directory/core';
 			$normalized_pattern = wp_normalize_remote_block_pattern( $pattern );
 			$pattern_name       = 'core/' . sanitize_title( $normalized_pattern['title'] );
 			register_block_pattern( $pattern_name, $normalized_pattern );
@@ -261,7 +261,7 @@ function _load_remote_featured_patterns() {
 	$patterns = $response->get_data();
 	$registry = WP_Block_Patterns_Registry::get_instance();
 	foreach ( $patterns as $pattern ) {
-		$pattern['source']  = 'pattern-directory/featured'; // Added in 6.3.0.
+		$pattern['source']  = 'pattern-directory/featured';
 		$normalized_pattern = wp_normalize_remote_block_pattern( $pattern );
 		$pattern_name       = sanitize_title( $normalized_pattern['title'] );
 		// Some patterns might be already registered as core patterns with the `core` prefix.
@@ -306,7 +306,7 @@ function _register_remote_theme_patterns() {
 	$patterns          = $response->get_data();
 	$patterns_registry = WP_Block_Patterns_Registry::get_instance();
 	foreach ( $patterns as $pattern ) {
-		$pattern['source']  = 'pattern-directory/theme'; // Added in 6.3.0.
+		$pattern['source']  = 'pattern-directory/theme';
 		$normalized_pattern = wp_normalize_remote_block_pattern( $pattern );
 		$pattern_name       = sanitize_title( $normalized_pattern['title'] );
 		// Some patterns might be already registered as core patterns with the `core` prefix.

--- a/src/wp-includes/block-patterns.php
+++ b/src/wp-includes/block-patterns.php
@@ -190,7 +190,7 @@ function wp_normalize_remote_block_pattern( $pattern ) {
  * @since 5.9.0 The $current_screen argument was removed.
  * @since 6.2.0 Normalize the pattern from the API (snake_case) to the
  *              format expected by `register_block_pattern` (camelCase).
- * @since 6.3.0 Add 'pattern-directory/core' to the pattern's source.
+ * @since 6.3.0 Add 'pattern-directory/core' to the pattern's 'source'.
  *
  * @param WP_Screen $deprecated Unused. Formerly the screen that the current request was triggered from.
  */

--- a/src/wp-includes/block-patterns.php
+++ b/src/wp-includes/block-patterns.php
@@ -12,6 +12,7 @@ add_theme_support( 'core-block-patterns' );
  * Registers the core block patterns and categories.
  *
  * @since 5.5.0
+ * @since 6.3.0 Added source to core block patterns.
  * @access private
  */
 function _register_core_block_patterns_and_categories() {
@@ -29,10 +30,9 @@ function _register_core_block_patterns_and_categories() {
 		);
 
 		foreach ( $core_block_patterns as $core_block_pattern ) {
-			register_block_pattern(
-				'core/' . $core_block_pattern,
-				require __DIR__ . '/block-patterns/' . $core_block_pattern . '.php'
-			);
+			$pattern           = require ABSPATH . WPINC . '/block-patterns/' . $core_block_pattern . '.php';
+			$pattern['source'] = 'core'; // Added in 6.3.0.
+			register_block_pattern( 'core/' . $core_block_pattern, $pattern );
 		}
 	}
 
@@ -190,6 +190,7 @@ function wp_normalize_remote_block_pattern( $pattern ) {
  * @since 5.9.0 The $current_screen argument was removed.
  * @since 6.2.0 Normalize the pattern from the API (snake_case) to the
  *              format expected by `register_block_pattern` (camelCase).
+ * @since 6.3.0 Add 'pattern-directory/core' to the pattern's source.
  *
  * @param WP_Screen $deprecated Unused. Formerly the screen that the current request was triggered from.
  */
@@ -224,6 +225,7 @@ function _load_remote_block_patterns( $deprecated = null ) {
 		$patterns = $response->get_data();
 
 		foreach ( $patterns as $pattern ) {
+			$pattern['source']  = 'pattern-directory/core'; // Added in 6.3.0.
 			$normalized_pattern = wp_normalize_remote_block_pattern( $pattern );
 			$pattern_name       = 'core/' . sanitize_title( $normalized_pattern['title'] );
 			register_block_pattern( $pattern_name, $normalized_pattern );
@@ -237,6 +239,7 @@ function _load_remote_block_patterns( $deprecated = null ) {
  * @since 5.9.0
  * @since 6.2.0 Normalized the pattern from the API (snake_case) to the
  *              format expected by `register_block_pattern()` (camelCase).
+ * @since 6.3.0 Add 'pattern-directory/featured' to the pattern's 'source'.
  */
 function _load_remote_featured_patterns() {
 	$supports_core_patterns = get_theme_support( 'core-block-patterns' );
@@ -258,6 +261,7 @@ function _load_remote_featured_patterns() {
 	$patterns = $response->get_data();
 	$registry = WP_Block_Patterns_Registry::get_instance();
 	foreach ( $patterns as $pattern ) {
+		$pattern['source']  = 'pattern-directory/featured'; // Added in 6.3.0.
 		$normalized_pattern = wp_normalize_remote_block_pattern( $pattern );
 		$pattern_name       = sanitize_title( $normalized_pattern['title'] );
 		// Some patterns might be already registered as core patterns with the `core` prefix.
@@ -275,6 +279,7 @@ function _load_remote_featured_patterns() {
  * @since 6.0.0
  * @since 6.2.0 Normalized the pattern from the API (snake_case) to the
  *              format expected by `register_block_pattern()` (camelCase).
+ * @since 6.3.0 Add 'pattern-directory/theme' to the pattern's 'source'.
  * @access private
  */
 function _register_remote_theme_patterns() {
@@ -301,6 +306,7 @@ function _register_remote_theme_patterns() {
 	$patterns          = $response->get_data();
 	$patterns_registry = WP_Block_Patterns_Registry::get_instance();
 	foreach ( $patterns as $pattern ) {
+		$pattern['source']  = 'pattern-directory/theme'; // Added in 6.3.0.
 		$normalized_pattern = wp_normalize_remote_block_pattern( $pattern );
 		$pattern_name       = sanitize_title( $normalized_pattern['title'] );
 		// Some patterns might be already registered as core patterns with the `core` prefix.

--- a/src/wp-includes/block-patterns.php
+++ b/src/wp-includes/block-patterns.php
@@ -30,7 +30,7 @@ function _register_core_block_patterns_and_categories() {
 		);
 
 		foreach ( $core_block_patterns as $core_block_pattern ) {
-			$pattern           = require ABSPATH . WPINC . '/block-patterns/' . $core_block_pattern . '.php';
+			$pattern           = require __DIR__ . '/block-patterns/' . $core_block_pattern . '.php';
 			$pattern['source'] = 'core'; // Added in 6.3.0.
 			register_block_pattern( 'core/' . $core_block_pattern, $pattern );
 		}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-patterns-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-patterns-controller.php
@@ -155,6 +155,7 @@ class WP_REST_Block_Patterns_Controller extends WP_REST_Controller {
 	 * Prepare a raw block pattern before it gets output in a REST API response.
 	 *
 	 * @since 6.0.0
+	 * @since 6.3.0 Added `source` property.
 	 *
 	 * @param array           $item    Raw pattern as registered, before any changes.
 	 * @param WP_REST_Request $request Request object.
@@ -174,6 +175,7 @@ class WP_REST_Block_Patterns_Controller extends WP_REST_Controller {
 			'blockTypes'    => 'block_types',
 			'postTypes'     => 'post_types',
 			'templateTypes' => 'template_types',
+			'source'        => 'source',
 		);
 		$data   = array();
 		foreach ( $keys as $item_key => $rest_key ) {
@@ -192,6 +194,7 @@ class WP_REST_Block_Patterns_Controller extends WP_REST_Controller {
 	 * Retrieves the block pattern schema, conforming to JSON Schema.
 	 *
 	 * @since 6.0.0
+	 * @since 6.3.0 Added `source` property.
 	 *
 	 * @return array Item schema data.
 	 */
@@ -266,6 +269,20 @@ class WP_REST_Block_Patterns_Controller extends WP_REST_Controller {
 					'type'        => 'array',
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit', 'embed' ),
+				),
+				'source'         => array(
+					'description' => __( 'Where the pattern comes from e.g. core' ),
+					'type'        => 'string',
+					'readonly'    => true,
+					'context'     => array( 'view', 'edit', 'embed' ),
+					'enum'        => array(
+						'core',
+						'plugin',
+						'theme',
+						'pattern-directory/core',
+						'pattern-directory/theme',
+						'pattern-directory/featured',
+					),
 				),
 			),
 		);

--- a/tests/phpunit/tests/rest-api/wpRestBlockPatternsController.php
+++ b/tests/phpunit/tests/rest-api/wpRestBlockPatternsController.php
@@ -127,7 +127,7 @@ class Tests_REST_WpRestBlockPatternsController extends WP_Test_REST_Controller_T
 		wp_set_current_user( self::$admin_id );
 
 		$request            = new WP_REST_Request( 'GET', static::REQUEST_ROUTE );
-		$request['_fields'] = 'name,content,template_types';
+		$request['_fields'] = 'name,content,source,template_types';
 		$response           = rest_get_server()->dispatch( $request );
 		$data               = $response->get_data();
 

--- a/tests/phpunit/tests/rest-api/wpRestBlockPatternsController.php
+++ b/tests/phpunit/tests/rest-api/wpRestBlockPatternsController.php
@@ -76,6 +76,7 @@ class Tests_REST_WpRestBlockPatternsController extends WP_Test_REST_Controller_T
 				'viewportWidth' => 1440,
 				'categories'    => array( 'test' ),
 				'templateTypes' => array( 'page' ),
+				'source'        => 'theme',
 			)
 		);
 
@@ -86,6 +87,7 @@ class Tests_REST_WpRestBlockPatternsController extends WP_Test_REST_Controller_T
 				'content'       => '<!-- wp:paragraph --><p>Two</p><!-- /wp:paragraph -->',
 				'categories'    => array( 'test' ),
 				'templateTypes' => array( 'single' ),
+				'source'        => 'core',
 			)
 		);
 
@@ -95,6 +97,7 @@ class Tests_REST_WpRestBlockPatternsController extends WP_Test_REST_Controller_T
 				'title'      => 'Pattern Three',
 				'content'    => '<!-- wp:paragraph --><p>Three</p><!-- /wp:paragraph -->',
 				'categories' => array( 'test', 'buttons', 'query' ),
+				'source'     => 'pattern-directory/featured',
 			)
 		);
 	}
@@ -135,6 +138,7 @@ class Tests_REST_WpRestBlockPatternsController extends WP_Test_REST_Controller_T
 				'name'           => 'test/one',
 				'content'        => '<!-- wp:heading {"level":1} --><h1>One</h1><!-- /wp:heading -->',
 				'template_types' => array( 'page' ),
+				'source'         => 'theme',
 			),
 			$data[0],
 			'WP_REST_Block_Patterns_Controller::get_items() should return test/one'
@@ -144,6 +148,7 @@ class Tests_REST_WpRestBlockPatternsController extends WP_Test_REST_Controller_T
 				'name'           => 'test/two',
 				'content'        => '<!-- wp:paragraph --><p>Two</p><!-- /wp:paragraph -->',
 				'template_types' => array( 'single' ),
+				'source'         => 'core',
 			),
 			$data[1],
 			'WP_REST_Block_Patterns_Controller::get_items() should return test/two'


### PR DESCRIPTION
This is a backport PR for WordPress 6.3 that includes the following PHP Gutenberg changes:

- https://github.com/WordPress/gutenberg/pull/51672

Trac ticket: https://core.trac.wordpress.org/ticket/58622

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
