### PR TITLE
sync-gutenberg-packages: Fix unresolvable conflicts detection

### DIFF
--- a/tools/release/sync-gutenberg-packages.js
+++ b/tools/release/sync-gutenberg-packages.js
@@ -120,8 +120,8 @@ function getMismatchedNonWordPressDependencies() {
 	;
 
 	// Ensure that all the conflicts can be resolved with the same version
-	const unresolvableConflicts = Object.entries( groupBy( versionConflicts, ( [name] ) => name ) )
-		.map( ( [name, group] ) => [name, group.map( ( [, { required }] ) => required )] )
+	const unresolvableConflicts = Object.entries( groupBy( versionConflicts, ( {name} ) => name ) )
+		.map( ( [name, group] ) => [name, uniq( group.map( ( { required } ) => required ) )] )
 		.filter( ( [, group] ) => group.length > 1 );
 	if ( unresolvableConflicts.length > 0 ) {
 		console.error( "Can't resolve some conflicts automatically." );


### PR DESCRIPTION
Running `npm run sync-gutenberg-packages -- --dist-tag=wp-6.3` would currently result in the following error:

```
~/src/wordpress-develop/tools/release/sync-gutenberg-packages.js:126
		.map( ( [name, group] ) => [name, group.map( ( [, { required }] ) => required )] )
		                                             ^

TypeError: undefined is not a function
```

after which script execution resumed, thus typically hiding the error behind a lot of other output. 
It would, however, result in `package.json` not being updated with the expected version bumps.

This PR attempts to fix that logic.

### Testing Instructions

- On `trunk`, run `npm run sync-gutenberg-packages -- --dist-tag=wp-6.3`. Scroll up near the start of the resulting output and verify that the above warning is present. Furthermore, verify that `package.json` is unchanged after running the script.
- Switch to this branch, and re-run that command. Verify that the warning doesn't appear this time around, and that `package.json` is indeed changed. (Note that only three or so third-party dependencies' versions are  changed, whereas no `@wordpress/` packages are; this is due to a separate issue.)

Trac ticket: https://core.trac.wordpress.org/ticket/58628

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
