### PR TITLE
Editor: Remove obsolete @wordpress/nux dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4893,22 +4893,6 @@
 			"integrity": "sha512-GSlBzFjzsKwfdewbwTZvXqEcPlGT0PxmDTT6Hn2H/rgcxCisFhbVRelfoLuR9NMkCwUoMXDgIfF8XLAuQYooig==",
 			"dev": true
 		},
-		"@wordpress/nux": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/nux/-/nux-6.0.0.tgz",
-			"integrity": "sha512-9zv7SpCnsoSWw3Gh7Am4TqlSRrA38MSZG8kkPa1RqfuTeonMS3ptIGFMu9I/gA4//+cNxYRW6NeWosZlhlDVlQ==",
-			"requires": {
-				"@babel/runtime": "^7.16.0",
-				"@wordpress/components": "^23.0.0",
-				"@wordpress/compose": "^6.0.0",
-				"@wordpress/data": "^8.0.0",
-				"@wordpress/deprecated": "^3.23.0",
-				"@wordpress/element": "^5.0.0",
-				"@wordpress/i18n": "^4.23.0",
-				"@wordpress/icons": "^9.14.0",
-				"rememo": "^4.0.0"
-			}
-		},
 		"@wordpress/plugins": {
 			"version": "5.3.3",
 			"resolved": "https://registry.npmjs.org/@wordpress/plugins/-/plugins-5.3.3.tgz",
@@ -11954,7 +11938,7 @@
 		"from2-string": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/from2-string/-/from2-string-1.1.0.tgz",
-			"integrity": "sha512-m8vCh+KnXXXBtfF2VUbiYlQ+nczLcntB0BrtNgpmLkHylhObe9WF1b2LZjBBzrZzA6P4mkEla6ZYQoOUTG8cYA==",
+			"integrity": "sha1-GCgrJ9CKJnyzAwzSuLSw8hKvdSo=",
 			"requires": {
 				"from2": "^2.0.3"
 			}
@@ -21112,7 +21096,7 @@
 		"promise-polyfill": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-1.1.6.tgz",
-			"integrity": "sha512-7rrONfyLkDEc7OJ5QBkqa4KI4EBhCd340xRuIUPGCfu13znS+vx+VDdrT9ODAJHlXm7w4lbxN3DRjyv58EuzDg=="
+			"integrity": "sha1-zQTv9G9clcOn0EVZHXm14+AfEtc="
 		},
 		"prompts": {
 			"version": "2.4.2",
@@ -23251,7 +23235,7 @@
 		"stream-from-promise": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/stream-from-promise/-/stream-from-promise-1.0.0.tgz",
-			"integrity": "sha512-j84KLkudt+gr8KJ21RB02btPLx61uGbrLnewsWz6QKmsz8/c4ZFqXw6mJh5+G4oRN7DgDxdbjPxnpySpg1mUig=="
+			"integrity": "sha1-djaH9913fkyJT2QIMz/Gs/yKYbs="
 		},
 		"stream-to-string": {
 			"version": "1.2.0",
@@ -24519,7 +24503,7 @@
 		"toposort": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
-			"integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg=="
+			"integrity": "sha1-riF2gXXRVZ1IvvNUILL0li8JwzA="
 		},
 		"totalist": {
 			"version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,6 @@
 		"@wordpress/list-reusable-blocks": "4.3.7",
 		"@wordpress/media-utils": "4.17.2",
 		"@wordpress/notices": "3.26.3",
-		"@wordpress/nux": "6.0.0",
 		"@wordpress/plugins": "5.3.3",
 		"@wordpress/preferences": "3.3.7",
 		"@wordpress/preferences-persistence": "1.18.1",


### PR DESCRIPTION
Running `npm run sync-gutenberg-packages -- --dist-tag=wp-6.3` currently results in the following error:

```
Running "wp-packages:update" task
Updating WordPress packages (--dist-tag=wp-6.3)
npm ERR! code ETARGET
npm ERR! notarget No matching version found for @wordpress/nux@wp-6.3.
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.
```

after which script execution resumed, thus typically hiding the error behind a lot of other output. 

However, this results in `package.json` not being updated with the expected version bumps to `@wordpress/*` packages.

This PR seeks to remediate the issue by removing the dependency on `@wordpress/nux`. There seems to be some related discussion on `@wordpress/nux` deprecation in https://core.trac.wordpress.org/ticket/57643.

### Testing instructions

- On `trunk`, run `npm run sync-gutenberg-packages -- --dist-tag=wp-6.3`. Scroll up near the start of the resulting output and verify that the above warning is present. Furthermore, verify that `package.json` doesn't contain any changes to `@wordpress/` packages. 
- Switch to this branch, and re-run that command. Verify that the warning doesn't appear this time around, and that `@wordpress/` package versions in `package.json` are now indeed updated.

Trac ticket: https://core.trac.wordpress.org/ticket/58633

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
