### PR TITLE
Backport: Navigation Post Edit Link (from #4657)

### DIFF
--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1438,6 +1438,8 @@ function get_preview_post_link( $post = null, $query_args = array(), $preview_li
  * pages, posts, attachments, revisions, global styles, templates, and template parts.
  *
  * @since 2.3.0
+ * @since 6.3.0 Adds custom link for wp_navigation post types.
+ *              Adds custom links for wp_template_part and wp_template post types.
  *
  * @param int|WP_Post $post    Optional. Post ID or post object. Default is the global `$post`.
  * @param string      $context Optional. How to output the '&' character. Default '&amp;'.

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1474,6 +1474,9 @@ function get_edit_post_link( $post = 0, $context = 'display' ) {
 	if ( 'wp_template' === $post->post_type || 'wp_template_part' === $post->post_type ) {
 		$slug = urlencode( get_stylesheet() . '//' . $post->post_name );
 		$link = admin_url( sprintf( $post_type_object->_edit_link, $post->post_type, $slug ) );
+	} elseif ( 'wp_navigation' === $post->post_type ) {
+		$id               = $post->ID;
+		$link             = admin_url( sprintf( $post_type_object->_edit_link, $id ) );
 	} elseif ( $post_type_object->_edit_link ) {
 		$link = admin_url( sprintf( $post_type_object->_edit_link . $action, $post->ID ) );
 	}

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1475,8 +1475,7 @@ function get_edit_post_link( $post = 0, $context = 'display' ) {
 		$slug = urlencode( get_stylesheet() . '//' . $post->post_name );
 		$link = admin_url( sprintf( $post_type_object->_edit_link, $post->post_type, $slug ) );
 	} elseif ( 'wp_navigation' === $post->post_type ) {
-		$id               = $post->ID;
-		$link             = admin_url( sprintf( $post_type_object->_edit_link, $id ) );
+		$link = admin_url( sprintf( $post_type_object->_edit_link, (string) $post->ID ) );
 	} elseif ( $post_type_object->_edit_link ) {
 		$link = admin_url( sprintf( $post_type_object->_edit_link . $action, $post->ID ) );
 	}

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -521,8 +521,7 @@ function create_initial_post_types() {
 				'filter_items_list'     => __( 'Filter Navigation Menu list' ),
 				'items_list_navigation' => __( 'Navigation Menus list navigation' ),
 				'items_list'            => __( 'Navigation Menus list' ),
-				/* internal use only. don't use this when registering your own post type. */
-				'_edit_link'            => $navigation_post_edit_link,
+				'_edit_link'            => $navigation_post_edit_link, /* internal use only. don't use this when registering your own post type. */
 			),
 			'description'           => __( 'Navigation menus that can be inserted into your site.' ),
 			'public'                => false,

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -521,11 +521,11 @@ function create_initial_post_types() {
 				'filter_items_list'     => __( 'Filter Navigation Menu list' ),
 				'items_list_navigation' => __( 'Navigation Menus list navigation' ),
 				'items_list'            => __( 'Navigation Menus list' ),
-				'_edit_link'            => $navigation_post_edit_link, /* internal use only. don't use this when registering your own post type. */
 			),
 			'description'           => __( 'Navigation menus that can be inserted into your site.' ),
 			'public'                => false,
 			'_builtin'              => true, /* internal use only. don't use this when registering your own post type. */
+			'_edit_link'            => $navigation_post_edit_link, /* internal use only. don't use this when registering your own post type. */
 			'has_archive'           => false,
 			'show_ui'               => true,
 			'show_in_menu'          => false,

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -523,7 +523,6 @@ function create_initial_post_types() {
 				'items_list'            => __( 'Navigation Menus list' ),
 				/* internal use only. don't use this when registering your own post type. */
 				'_edit_link'            => $navigation_post_edit_link,
-
 			),
 			'description'           => __( 'Navigation menus that can be inserted into your site.' ),
 			'public'                => false,

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -491,6 +491,14 @@ function create_initial_post_types() {
 		)
 	);
 
+	$navigation_post_edit_link = 'site-editor.php?' . build_query(
+		array(
+			'postId'   => '%s',
+			'postType' => 'wp_navigation',
+			'canvas'   => 'edit',
+		)
+	);
+
 	register_post_type(
 		'wp_navigation',
 		array(
@@ -513,6 +521,9 @@ function create_initial_post_types() {
 				'filter_items_list'     => __( 'Filter Navigation Menu list' ),
 				'items_list_navigation' => __( 'Navigation Menus list navigation' ),
 				'items_list'            => __( 'Navigation Menus list' ),
+				/* internal use only. don't use this when registering your own post type. */
+				'_edit_link'            => $navigation_post_edit_link,
+
 			),
 			'description'           => __( 'Navigation menus that can be inserted into your site.' ),
 			'public'                => false,
@@ -552,7 +563,8 @@ function create_initial_post_types() {
 		array(
 			'label'       => _x( 'Published', 'post status' ),
 			'public'      => true,
-			'_builtin'    => true, /* internal use only. */
+			'_builtin'    => true, /*
+		internal use only. */
 			/* translators: %s: Number of published posts. */
 			'label_count' => _n_noop(
 				'Published <span class="count">(%s)</span>',
@@ -566,7 +578,8 @@ function create_initial_post_types() {
 		array(
 			'label'       => _x( 'Scheduled', 'post status' ),
 			'protected'   => true,
-			'_builtin'    => true, /* internal use only. */
+			'_builtin'    => true, /*
+		internal use only. */
 			/* translators: %s: Number of scheduled posts. */
 			'label_count' => _n_noop(
 				'Scheduled <span class="count">(%s)</span>',
@@ -580,7 +593,8 @@ function create_initial_post_types() {
 		array(
 			'label'         => _x( 'Draft', 'post status' ),
 			'protected'     => true,
-			'_builtin'      => true, /* internal use only. */
+			'_builtin'      => true, /*
+		internal use only. */
 			/* translators: %s: Number of draft posts. */
 			'label_count'   => _n_noop(
 				'Draft <span class="count">(%s)</span>',
@@ -595,7 +609,8 @@ function create_initial_post_types() {
 		array(
 			'label'         => _x( 'Pending', 'post status' ),
 			'protected'     => true,
-			'_builtin'      => true, /* internal use only. */
+			'_builtin'      => true, /*
+		internal use only. */
 			/* translators: %s: Number of pending posts. */
 			'label_count'   => _n_noop(
 				'Pending <span class="count">(%s)</span>',
@@ -610,7 +625,8 @@ function create_initial_post_types() {
 		array(
 			'label'       => _x( 'Private', 'post status' ),
 			'private'     => true,
-			'_builtin'    => true, /* internal use only. */
+			'_builtin'    => true, /*
+		internal use only. */
 			/* translators: %s: Number of private posts. */
 			'label_count' => _n_noop(
 				'Private <span class="count">(%s)</span>',
@@ -624,7 +640,8 @@ function create_initial_post_types() {
 		array(
 			'label'                     => _x( 'Trash', 'post status' ),
 			'internal'                  => true,
-			'_builtin'                  => true, /* internal use only. */
+			'_builtin'                  => true, /*
+		internal use only. */
 			/* translators: %s: Number of trashed posts. */
 			'label_count'               => _n_noop(
 				'Trash <span class="count">(%s)</span>',
@@ -659,7 +676,8 @@ function create_initial_post_types() {
 		array(
 			'label'               => _x( 'Pending', 'request status' ),
 			'internal'            => true,
-			'_builtin'            => true, /* internal use only. */
+			'_builtin'            => true, /*
+		internal use only. */
 			/* translators: %s: Number of pending requests. */
 			'label_count'         => _n_noop(
 				'Pending <span class="count">(%s)</span>',
@@ -674,7 +692,8 @@ function create_initial_post_types() {
 		array(
 			'label'               => _x( 'Confirmed', 'request status' ),
 			'internal'            => true,
-			'_builtin'            => true, /* internal use only. */
+			'_builtin'            => true, /*
+		internal use only. */
 			/* translators: %s: Number of confirmed requests. */
 			'label_count'         => _n_noop(
 				'Confirmed <span class="count">(%s)</span>',
@@ -689,7 +708,8 @@ function create_initial_post_types() {
 		array(
 			'label'               => _x( 'Failed', 'request status' ),
 			'internal'            => true,
-			'_builtin'            => true, /* internal use only. */
+			'_builtin'            => true, /*
+		internal use only. */
 			/* translators: %s: Number of failed requests. */
 			'label_count'         => _n_noop(
 				'Failed <span class="count">(%s)</span>',
@@ -704,7 +724,8 @@ function create_initial_post_types() {
 		array(
 			'label'               => _x( 'Completed', 'request status' ),
 			'internal'            => true,
-			'_builtin'            => true, /* internal use only. */
+			'_builtin'            => true, /*
+		internal use only. */
 			/* translators: %s: Number of completed requests. */
 			'label_count'         => _n_noop(
 				'Completed <span class="count">(%s)</span>',

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -563,8 +563,7 @@ function create_initial_post_types() {
 		array(
 			'label'       => _x( 'Published', 'post status' ),
 			'public'      => true,
-			'_builtin'    => true, /*
-		internal use only. */
+			'_builtin'    => true, /* internal use only. */
 			/* translators: %s: Number of published posts. */
 			'label_count' => _n_noop(
 				'Published <span class="count">(%s)</span>',
@@ -578,8 +577,7 @@ function create_initial_post_types() {
 		array(
 			'label'       => _x( 'Scheduled', 'post status' ),
 			'protected'   => true,
-			'_builtin'    => true, /*
-		internal use only. */
+			'_builtin'    => true, /* internal use only. */
 			/* translators: %s: Number of scheduled posts. */
 			'label_count' => _n_noop(
 				'Scheduled <span class="count">(%s)</span>',
@@ -593,8 +591,7 @@ function create_initial_post_types() {
 		array(
 			'label'         => _x( 'Draft', 'post status' ),
 			'protected'     => true,
-			'_builtin'      => true, /*
-		internal use only. */
+			'_builtin'      => true, /* internal use only. */
 			/* translators: %s: Number of draft posts. */
 			'label_count'   => _n_noop(
 				'Draft <span class="count">(%s)</span>',
@@ -609,8 +606,7 @@ function create_initial_post_types() {
 		array(
 			'label'         => _x( 'Pending', 'post status' ),
 			'protected'     => true,
-			'_builtin'      => true, /*
-		internal use only. */
+			'_builtin'      => true, /* internal use only. */
 			/* translators: %s: Number of pending posts. */
 			'label_count'   => _n_noop(
 				'Pending <span class="count">(%s)</span>',
@@ -625,8 +621,7 @@ function create_initial_post_types() {
 		array(
 			'label'       => _x( 'Private', 'post status' ),
 			'private'     => true,
-			'_builtin'    => true, /*
-		internal use only. */
+			'_builtin'    => true, /* internal use only. */
 			/* translators: %s: Number of private posts. */
 			'label_count' => _n_noop(
 				'Private <span class="count">(%s)</span>',
@@ -640,8 +635,7 @@ function create_initial_post_types() {
 		array(
 			'label'                     => _x( 'Trash', 'post status' ),
 			'internal'                  => true,
-			'_builtin'                  => true, /*
-		internal use only. */
+			'_builtin'                  => true, /* internal use only. */
 			/* translators: %s: Number of trashed posts. */
 			'label_count'               => _n_noop(
 				'Trash <span class="count">(%s)</span>',
@@ -676,8 +670,7 @@ function create_initial_post_types() {
 		array(
 			'label'               => _x( 'Pending', 'request status' ),
 			'internal'            => true,
-			'_builtin'            => true, /*
-		internal use only. */
+			'_builtin'            => true, /* internal use only. */
 			/* translators: %s: Number of pending requests. */
 			'label_count'         => _n_noop(
 				'Pending <span class="count">(%s)</span>',
@@ -692,8 +685,7 @@ function create_initial_post_types() {
 		array(
 			'label'               => _x( 'Confirmed', 'request status' ),
 			'internal'            => true,
-			'_builtin'            => true, /*
-		internal use only. */
+			'_builtin'            => true, /* internal use only. */
 			/* translators: %s: Number of confirmed requests. */
 			'label_count'         => _n_noop(
 				'Confirmed <span class="count">(%s)</span>',
@@ -708,8 +700,7 @@ function create_initial_post_types() {
 		array(
 			'label'               => _x( 'Failed', 'request status' ),
 			'internal'            => true,
-			'_builtin'            => true, /*
-		internal use only. */
+			'_builtin'            => true, /* internal use only. */
 			/* translators: %s: Number of failed requests. */
 			'label_count'         => _n_noop(
 				'Failed <span class="count">(%s)</span>',
@@ -724,8 +715,7 @@ function create_initial_post_types() {
 		array(
 			'label'               => _x( 'Completed', 'request status' ),
 			'internal'            => true,
-			'_builtin'            => true, /*
-		internal use only. */
+			'_builtin'            => true, /* internal use only. */
 			/* translators: %s: Number of completed requests. */
 			'label_count'         => _n_noop(
 				'Completed <span class="count">(%s)</span>',

--- a/tests/phpunit/tests/link/getEditPostLink.php
+++ b/tests/phpunit/tests/link/getEditPostLink.php
@@ -132,6 +132,11 @@ class Tests_Link_GetEditPostLink extends WP_UnitTestCase {
 		$this->assertSame( $link_custom_context, get_edit_post_link( $template_part_post, 'something-else' ), 'Pass non-default value in second argument.' );
 	}
 
+	/**
+	 * Tests getting the edit post link for a wp_navigation post type.
+	 *
+	 * @ticket 58589
+	 * */
 	public function test_get_edit_post_link_for_wp_navigation_post_type() {
 		$navigation_post = self::factory()->post->create_and_get(
 			array(

--- a/tests/phpunit/tests/link/getEditPostLink.php
+++ b/tests/phpunit/tests/link/getEditPostLink.php
@@ -131,4 +131,24 @@ class Tests_Link_GetEditPostLink extends WP_UnitTestCase {
 		$this->assertSame( $link_default_context, get_edit_post_link( $template_part_post ), 'Second argument `$context` has a default context of `"display"`.' );
 		$this->assertSame( $link_custom_context, get_edit_post_link( $template_part_post, 'something-else' ), 'Pass non-default value in second argument.' );
 	}
+
+	public function test_get_edit_post_link_for_wp_navigation_post_type() {
+		$navigation_post = self::factory()->post->create_and_get(
+			array(
+				'post_type'    => 'wp_navigation',
+				'post_name'    => 'my_navigation',
+				'post_title'   => 'My Navigation',
+				'post_content' => '<!-- wp:navigation-link {"label":"WordPress","type":"custom","url":"http://www.wordpress.org/","kind":"custom"} /-->',
+				'post_excerpt' => 'Description of my Navigation',
+			)
+		);
+
+		$post_type_object     = get_post_type_object( $navigation_post->post_type );
+
+		$link_default_context = admin_url( sprintf( $post_type_object->_edit_link, $navigation_post->ID ) );
+		$link_custom_context  = admin_url( sprintf( $post_type_object->_edit_link, $navigation_post->ID ) );
+
+		$this->assertSame( $link_default_context, get_edit_post_link( $navigation_post ), 'Second argument `$context` has a default context of `"display"`.' );
+		$this->assertSame( $link_custom_context, get_edit_post_link( $navigation_post, 'something-else' ), 'Pass non-default value in second argument.' );
+	}
 }

--- a/tests/phpunit/tests/link/getEditPostLink.php
+++ b/tests/phpunit/tests/link/getEditPostLink.php
@@ -143,7 +143,7 @@ class Tests_Link_GetEditPostLink extends WP_UnitTestCase {
 			)
 		);
 
-		$post_type_object     = get_post_type_object( $navigation_post->post_type );
+		$post_type_object = get_post_type_object( $navigation_post->post_type );
 
 		$link_default_context = admin_url( sprintf( $post_type_object->_edit_link, $navigation_post->ID ) );
 		$link_custom_context  = admin_url( sprintf( $post_type_object->_edit_link, $navigation_post->ID ) );


### PR DESCRIPTION
Backports changes that amend the Post Edit link for wp_navigation posts from https://github.com/WordPress/gutenberg/pull/39286 to Core.

This PR is an exact match of https://github.com/WordPress/wordpress-develop/pull/4657, but with some annotations required pre-core commit. 

Props @getdave 

`npm run test:php -- --filter Tests_Link_GetEditPostLink`

Trac ticket: https://core.trac.wordpress.org/ticket/58589

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
