### PR TITLE
Twenty Nineteen: Add fragment ID to paginated links

### DIFF
--- a/src/wp-content/themes/twentynineteen/inc/template-functions.php
+++ b/src/wp-content/themes/twentynineteen/inc/template-functions.php
@@ -223,3 +223,20 @@ function twentynineteen_add_mobile_parent_nav_menu_items( $sorted_menu_items, $a
 	return $amended_menu_items;
 }
 add_filter( 'wp_nav_menu_objects', 'twentynineteen_add_mobile_parent_nav_menu_items', 10, 2 );
+
+/**
+ * Add a fragment identifier (to the content) to paginated links.
+ *
+ * @since 6.3.0
+ *
+ * @param string $link The page number HTML output.
+ * @param int    $i    Page number for paginated posts' page links.
+ * @return string Formatted output in HTML.
+ */
+function twentynineteen_link_pages_link( $link, $i ) {
+	if ( $i > 1 && preg_match( '/href="([^"]*)"/', $link, $matches ) ) {
+		$link = str_replace( $matches[1], $matches[1] . '#content', $link );
+	}
+	return $link;
+}
+add_filter( 'wp_link_pages_link', 'twentynineteen_link_pages_link', 10, 2 );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/45920

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
