### PR TITLE
Moving body background color from `_elements.scss` to `_typography.scss` in Twenty Nineteen

### DIFF
--- a/src/wp-content/themes/twentynineteen/sass/elements/_elements.scss
+++ b/src/wp-content/themes/twentynineteen/sass/elements/_elements.scss
@@ -18,6 +18,7 @@ html {
 
 body {
 	background-color: $color__background-body;
+	color: $color__text-main;
 }
 
 a {

--- a/src/wp-content/themes/twentynineteen/sass/elements/_elements.scss
+++ b/src/wp-content/themes/twentynineteen/sass/elements/_elements.scss
@@ -16,11 +16,6 @@ html {
 	box-sizing: inherit;
 }
 
-body {
-	background-color: $color__background-body;
-	color: $color__text-main;
-}
-
 a {
 	@include link-transition;
 	color: $color__link;

--- a/src/wp-content/themes/twentynineteen/sass/typography/_typography.scss
+++ b/src/wp-content/themes/twentynineteen/sass/typography/_typography.scss
@@ -6,6 +6,7 @@ html {
 body {
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
+	background-color: $color__background-body;
 	color: $color__text-main;
 	@include font-family( $font__body );
 	font-weight: 400;

--- a/src/wp-content/themes/twentynineteen/style-rtl.css
+++ b/src/wp-content/themes/twentynineteen/style-rtl.css
@@ -2219,6 +2219,7 @@ html {
 body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background-color: #fff;
   color: #111;
   font-family: "NonBreakingSpaceOverride", "Hoefler Text", Garamond, "Times New Roman", serif;
   font-weight: 400;
@@ -2491,10 +2492,6 @@ html {
 *:before,
 *:after {
   box-sizing: inherit;
-}
-
-body {
-  background-color: #fff;
 }
 
 a {

--- a/src/wp-content/themes/twentynineteen/style.css
+++ b/src/wp-content/themes/twentynineteen/style.css
@@ -2219,6 +2219,7 @@ html {
 body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background-color: #fff;
   color: #111;
   font-family: "NonBreakingSpaceOverride", "Hoefler Text", Garamond, "Times New Roman", serif;
   font-weight: 400;
@@ -2491,10 +2492,6 @@ html {
 *:before,
 *:after {
   box-sizing: inherit;
-}
-
-body {
-  background-color: #fff;
 }
 
 a {


### PR DESCRIPTION
The background color is set earlier, making the second `body` selector unnecessary.

Trac ticket: https://core.trac.wordpress.org/ticket/45916

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
