### PR TITLE
Revert the introduction of the `no-store` and `private` cache control directives

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -1483,15 +1483,11 @@ function status_header( $code, $description = '' ) {
  * is handled by different browsers.
  *
  * @since 2.8.0
- * @since 6.3.0 The `Cache-Control` header for logged in users now includes the
- *              `no-store` and `private` directives.
  *
  * @return array The associative array of header names and field values.
  */
 function wp_get_nocache_headers() {
-	$cache_control = ( function_exists( 'is_user_logged_in' ) && is_user_logged_in() )
-		? 'no-cache, must-revalidate, max-age=0, no-store, private'
-		: 'no-cache, must-revalidate, max-age=0';
+	$cache_control = 'no-cache, must-revalidate, max-age=0';
 
 	$headers = array(
 		'Expires'       => 'Wed, 11 Jan 1984 05:00:00 GMT',


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/21938