### PR TITLE
Prefer $navigation_post->found_posts to count( $navigation_post->posts )

### DIFF
--- a/src/wp-includes/class-wp-navigation-fallback.php
+++ b/src/wp-includes/class-wp-navigation-fallback.php
@@ -71,7 +71,7 @@ class WP_Navigation_Fallback {
 
 		$navigation_post = new WP_Query( $parsed_args );
 
-		if ( count( $navigation_post->posts ) > 0 ) {
+		if ( $navigation_post->found_posts > 0 ) {
 			return $navigation_post->posts[0];
 		}
 


### PR DESCRIPTION
Following up on feedback from https://github.com/WordPress/wordpress-develop/pull/4713#pullrequestreview-1499992051

Let's use the found_posts [property](https://github.com/WordPress/wordpress-develop/blob/c226fa18f0877b86dc33947a92d304d67d0fc406/src/wp-includes/class-wp-query.php#L3571).

Props @mukeshpanchal27

Trac ticket: https://core.trac.wordpress.org/ticket/58557


Gutenberg backport over here: https://github.com/WordPress/gutenberg/pull/51999

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
