### PR TITLE
Upgrade/Install: Only show errors if there is nothing to update.

### DIFF
--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -1037,13 +1037,21 @@ if ( 'upgrade-core' === $action ) {
 
 	<?php
 	if ( $upgrade_error ) {
-		echo '<div class="error"><p>';
 		if ( 'themes' === $upgrade_error ) {
-			_e( 'Please select one or more themes to update.' );
+			$theme_updates = get_theme_updates();
+			if ( ! empty( $theme_updates ) ) {
+				echo '<div class="error"><p>';
+				_e( 'Please select one or more themes to update.' );
+				echo '</p></div>';
+			}
 		} else {
-			_e( 'Please select one or more plugins to update.' );
+			$plugin_updates = get_plugin_updates();
+			if ( ! empty( $plugin_updates ) ) {
+				echo '<div class="error"><p>';
+				_e( 'Please select one or more plugins to update.' );
+				echo '</p></div>';
+			}
 		}
-		echo '</p></div>';
 	}
 
 	$last_update_check = false;


### PR DESCRIPTION
Previously, when the `do-plugin-upgrade` or `do-theme-upgrade` actions were accessed directly on `update-core.php`, an error message stating "Select one or more (plugins|themes) to update" would be shown even if there was nothing to update.

This ensures that the error message only appears when there is something to update.

Trac ticket: https://core.trac.wordpress.org/ticket/57999
