### PR TITLE
[Try] Replace `gutenberg_` with `wp_`.

### DIFF
--- a/src/wp-includes/blocks/navigation-submenu.php
+++ b/src/wp-includes/blocks/navigation-submenu.php
@@ -199,9 +199,9 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 			$attributes['style']['color']['background'] = $block->context['customOverlayBackgroundColor'];
 		}
 
-		// This allows us to be able to get a response from gutenberg_apply_colors_support.
+		// This allows us to be able to get a response from wp_apply_colors_support.
 		$block->block_type->supports['color'] = true;
-		$colors_supports                      = gutenberg_apply_colors_support( $block->block_type, $attributes );
+		$colors_supports                      = wp_apply_colors_support( $block->block_type, $attributes );
 		$css_classes                          = 'wp-block-navigation__submenu-container';
 		if ( array_key_exists( 'class', $colors_supports ) ) {
 			$css_classes .= ' ' . $colors_supports['class'];


### PR DESCRIPTION
This may have side-effects as it isn't accompanied by a packages update. However, no other instances of `gutenberg_apply_colors_support` appears in Core other than this instance. The rest appear to be the correct `wp_apply_colors_support`.

Trac ticket: https://core.trac.wordpress.org/ticket/58651