### PR TITLE
Build/Test Tools: Add test matrix for E2E tests.

### DIFF
--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        script_debug: [ true, false ]
+        LOCAL_SCRIPT_DEBUG: [ true, false ]
 
     steps:
       - name: Configure environment variables
@@ -109,10 +109,9 @@ jobs:
           docker-compose run --rm php locale -a
 
       - name: Install WordPress
+        env:
+          LOCAL_SCRIPT_DEBUG: ${{ matrix.LOCAL_SCRIPT_DEBUG }}
         run: npm run env:install
-
-      - name: Set SCRIPT_DEBUG constant
-        run: docker-compose run --rm cli config set SCRIPT_DEBUG ${{ matrix.script_debug }} --raw --type=constant
 
       - name: Run E2E tests
         run: npm run test:e2e

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -56,6 +56,10 @@ jobs:
       contents: read
     timeout-minutes: 20
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        script_debug: [ true, false ]
 
     steps:
       - name: Configure environment variables
@@ -106,6 +110,9 @@ jobs:
 
       - name: Install WordPress
         run: npm run env:install
+
+      - name: Set SCRIPT_DEBUG constant
+        run: docker-compose run --rm cli config set SCRIPT_DEBUG ${{ matrix.script_debug }} --raw --type=constant
 
       - name: Run E2E tests
         run: npm run test:e2e


### PR DESCRIPTION
The E2E tests initially always perform tests with `SCRIPT_DEBUG` set to `true`, to capture any console warnings that may be present.

By adding a matrix where we test both scenarios, we can capture failures where minified files are causing problems as well.

The test intentionally applies `fail-fast: false` as well, to ensure that both tests can finish, as there may be different failures in them, and one should not prevent the other to ensure we get as clear a picture as possible.

Trac ticket: https://core.trac.wordpress.org/ticket/58661

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
