### PR TITLE
Enqueue `commands` package styles

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1670,12 +1670,14 @@ function wp_default_styles( $styles ) {
 		'block-library'        => array(),
 		'block-directory'      => array(),
 		'components'           => array(),
+		'commands'             => array(),
 		'edit-post'            => array(
 			'wp-components',
 			'wp-block-editor',
 			'wp-editor',
 			'wp-edit-blocks',
 			'wp-block-library',
+			'wp-commands',
 		),
 		'editor'               => array(
 			'wp-components',
@@ -1707,6 +1709,7 @@ function wp_default_styles( $styles ) {
 			'wp-components',
 			'wp-block-editor',
 			'wp-edit-blocks',
+			'wp-commands',
 		),
 	);
 
@@ -1762,6 +1765,7 @@ function wp_default_styles( $styles ) {
 		'wp-block-editor',
 		'wp-block-library',
 		'wp-block-directory',
+		'wp-commands',
 		'wp-components',
 		'wp-customize-widgets',
 		'wp-edit-post',


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/58667

As far as I can tell, the CSS for the command package for the Command Palette feature is bundled with the core. However, they do not appear to be enqueued.

## Before

![actual](https://github.com/WordPress/wordpress-develop/assets/54422211/b0a18e26-e638-4977-8a77-2c5bfe6ec401)

## After

✅ In the Site Editor, the CSS with id `wp-commands-css` should be enqueued

![site-editor](https://github.com/WordPress/wordpress-develop/assets/54422211/bebe7cd4-0281-42cc-96a1-ebe833e6986f)

✅ In the Post Editor, the CSS with id `wp-commands-css` should be enqueued

![edit-post](https://github.com/WordPress/wordpress-develop/assets/54422211/26abaeb9-d6d0-4dd5-8933-d049ea666c54)

✅ If the language is RTL, the CSS with id `wp-commands-rtl-css` should be enqueued

![rtl](https://github.com/WordPress/wordpress-develop/assets/54422211/9bdf8ce0-0741-49a9-9557-f179ac9f7f48)

✅ These CSS should not be enqueued in the Block Widget Editor and Customized Widget Editor