### PR TITLE
WIP: Move wp_block sync status to top level field

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -1931,10 +1931,15 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			}
 		}
 
-		if ( rest_is_field_included( 'meta', $fields ) ) {
+		if ( rest_is_field_included( 'meta', $fields ) && 'wp_block' !== $this->post_type ) {
 			$data['meta'] = $this->meta->get_value( $post->ID, $request );
 		}
 
+		if ( 'wp_block' === $this->post_type ) {
+			$wp_block_meta = $this->meta->get_value( $post->ID, $request );
+			$data['sync_status'] = $wp_block_meta['sync_status'];
+		}
+		
 		$taxonomies = wp_list_filter( get_object_taxonomies( $this->post_type, 'objects' ), array( 'show_in_rest' => true ) );
 
 		foreach ( $taxonomies as $taxonomy ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -1931,7 +1931,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			}
 		}
 
-		if ( rest_is_field_included( 'meta', $fields )) {
+		if ( rest_is_field_included( 'meta', $fields ) ) {
 			$data['meta'] = $this->meta->get_value( $post->ID, $request );
 		}
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -1931,11 +1931,12 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			}
 		}
 
-		if ( rest_is_field_included( 'meta', $fields ) && 'wp_block' !== $this->post_type ) {
+		if ( rest_is_field_included( 'meta', $fields )) {
 			$data['meta'] = $this->meta->get_value( $post->ID, $request );
 		}
 
 		if ( 'wp_block' === $this->post_type ) {
+			unset($data['meta']['sync_status']);
 			$wp_block_meta = $this->meta->get_value( $post->ID, $request );
 			$data['sync_status'] = $wp_block_meta['sync_status'];
 		}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -1936,7 +1936,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		}
 
 		if ( 'wp_block' === $this->post_type ) {
-			unset($data['meta']['sync_status']);
+			unset( $data['meta']['sync_status'] );
 			$wp_block_meta = $this->meta->get_value( $post->ID, $request );
 			$data['sync_status'] = $wp_block_meta['sync_status'];
 		}


### PR DESCRIPTION
Just experimental at this stage looking for ways to move the new sync_status postmeta to a top-level field as suggested on https://github.com/WordPress/wordpress-develop/pull/4646
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
