### PR TITLE
Trac 58668: wrong "domain" returned by wpmu_validate_blog_signup when using on subsite in subdomain multisite

### DIFF
--- a/src/wp-includes/ms-functions.php
+++ b/src/wp-includes/ms-functions.php
@@ -601,7 +601,6 @@ function wpmu_validate_user_signup( $user_name, $user_email ) {
  * @since MU (3.0.0)
  *
  * @global wpdb   $wpdb   WordPress database abstraction object.
- * @global string $domain
  *
  * @param string         $blogname   The site name provided by the user. Must be unique.
  * @param string         $blog_title The site title provided by the user.
@@ -619,10 +618,11 @@ function wpmu_validate_user_signup( $user_name, $user_email ) {
  * }
  */
 function wpmu_validate_blog_signup( $blogname, $blog_title, $user = '' ) {
-	global $wpdb, $domain;
+	global $wpdb;
 
 	$current_network = get_network();
 	$base            = $current_network->path;
+	$domain          = $current_network->domain;
 
 	$blog_title = strip_tags( $blog_title );
 


### PR DESCRIPTION
Changes wpmu_validate_blog_signup so it uses `$domain` from `$current_network` instead of global `$domain`

Trac ticket: https://core.trac.wordpress.org/ticket/58668

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
