### PR TITLE
Fix duplicated filter docs and remove from deprecated function

### DIFF
--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -4779,19 +4779,7 @@ function wp_img_tag_add_loading_attr( $image, $context ) {
 		return $image;
 	}
 
-	/**
-	 * Filters the `loading` attribute value to add to an image. Default `lazy`.
-	 *
-	 * Returning `false` or an empty string will not add the attribute.
-	 * Returning `true` will add the default value.
-	 *
-	 * @since 5.5.0
-	 *
-	 * @param string|bool $value   The `loading` attribute value. Returning a falsey value will result in
-	 *                             the attribute being omitted for the image.
-	 * @param string      $image   The HTML `img` tag to be filtered.
-	 * @param string      $context Additional context about how the function was called or where the img tag is.
-	 */
+	/** This filter is documented in wp-admin/includes/media.php */
 	$value = apply_filters( 'wp_img_tag_add_loading_attr', $value, $image, $context );
 
 	if ( $value ) {

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -1963,15 +1963,14 @@ function wp_img_tag_add_loading_optimization_attrs( $image, $context ) {
 	if ( empty( $loading_val ) && $loading_attrs_enabled ) {
 		/**
 		 * Filters the `loading` attribute value to add to an image. Default `lazy`.
-		 * This filter is added in for backward compatibility.
 		 *
 		 * Returning `false` or an empty string will not add the attribute.
 		 * Returning `true` will add the default value.
-		 * `true` and `false` usage supported for backward compatibility.
 		 *
 		 * @since 5.5.0
 		 *
-		 * @param string|bool $loading Current value for `loading` attribute for the image.
+		 * @param string|bool $value   The `loading` attribute value. Returning a falsey value will result in
+		 *                             the attribute being omitted for the image.
 		 * @param string      $image   The HTML `img` tag to be filtered.
 		 * @param string      $context Additional context about how the function was called or where the img tag is.
 		 */


### PR DESCRIPTION
Based on https://github.com/WordPress/wordpress-develop/pull/4726#discussion_r1244408335, technically a follow-up to https://core.trac.wordpress.org/changeset/56037 / https://core.trac.wordpress.org/ticket/58235.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
