### PR TITLE
Fix font paths in iframed editor

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -3522,13 +3522,6 @@ function _wp_theme_json_webfonts_handler() {
 
 		foreach ( $value as $item ) {
 
-			if (
-				str_starts_with( $item['url'], site_url() ) ||
-				str_starts_with( $item['url'], home_url() )
-			) {
-				$item['url'] = wp_make_link_relative( $item['url'] );
-			}
-
 			$src .= ( 'data' === $item['format'] )
 				? ", url({$item['url']})"
 				: ", url('{$item['url']}') format('{$item['format']}')";


### PR DESCRIPTION
Merge fix from Fonts API: https://github.com/WordPress/gutenberg/pull/51178. To summarize: 

> The font asset files are not being loaded within an iframe. Why? The relative URL to the asset files are relative to the iframe's https://github.com/WordPress/gutenberg/pull/50875 was merged. By making the URLs absolute, it ensures each font asset file does properly relate to the actual location of the files.

Trac ticket: https://core.trac.wordpress.org/ticket/58672

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
