### PR TITLE
Rename sync_status top wp_sync_status and move to top level field of wp_block post type

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -8040,14 +8040,14 @@ function use_block_editor_for_post_type( $post_type ) {
 /**
  * Registers any additional post meta fields.
  *
- * @since 6.3.0 Adds sync_status meta field to the wp_block post type so an unsynced option can be added.
+ * @since 6.3.0 Adds wp_sync_status meta field to the wp_block post type so an unsynced option can be added.
  *
  * @link https://github.com/WordPress/gutenberg/pull/51144
  */
 function wp_create_initial_post_meta() {
 	register_post_meta(
 		'wp_block',
-		'sync_status',
+		'wp_sync_status',
 		array(
 			'sanitize_callback' => 'sanitize_text_field',
 			'single'            => true,

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -8040,7 +8040,7 @@ function use_block_editor_for_post_type( $post_type ) {
 /**
  * Registers any additional post meta fields.
  *
- * @since 6.3.0 Adds wp_sync_status meta field to the wp_block post type so an unsynced option can be added.
+ * @since 6.3.0 Adds `wp_sync_status` meta field to the wp_block post type so an unsynced option can be added.
  *
  * @link https://github.com/WordPress/gutenberg/pull/51144
  */

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -8040,14 +8040,14 @@ function use_block_editor_for_post_type( $post_type ) {
 /**
  * Registers any additional post meta fields.
  *
- * @since 6.3.0 Adds `wp_sync_status` meta field to the wp_block post type so an unsynced option can be added.
+ * @since 6.3.0 Adds `wp_pattern_sync_status` meta field to the wp_block post type so an unsynced option can be added.
  *
  * @link https://github.com/WordPress/gutenberg/pull/51144
  */
 function wp_create_initial_post_meta() {
 	register_post_meta(
 		'wp_block',
-		'wp_sync_status',
+		'wp_pattern_sync_status',
 		array(
 			'sanitize_callback' => 'sanitize_text_field',
 			'single'            => true,

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-blocks-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-blocks-controller.php
@@ -40,7 +40,7 @@ class WP_REST_Blocks_Controller extends WP_REST_Posts_Controller {
 	 * Filters a response based on the context defined in the schema.
 	 *
 	 * @since 5.0.0
-	 * @since 6.3 Adds the `wp_sync_status` postmeta property to the toplevel of response.
+	 * @since 6.3 Adds the `wp_pattern_sync_status` postmeta property to the toplevel of response.
 	 *
 	 * @param array  $data    Response data to filter.
 	 * @param string $context Context defined in the schema.
@@ -57,9 +57,9 @@ class WP_REST_Blocks_Controller extends WP_REST_Posts_Controller {
 		unset( $data['title']['rendered'] );
 		unset( $data['content']['rendered'] );
 
-		// Add the core wp_sync_status meta as top level property to the response.
-		$data['wp_sync_status'] = $data['meta']['wp_sync_status'];
-		unset( $data['meta']['wp_sync_status'] );
+		// Add the core wp_pattern_sync_status meta as top level property to the response.
+		$data['wp_pattern_sync_status'] = $data['meta']['wp_pattern_sync_status'];
+		unset( $data['meta']['wp_pattern_sync_status'] );
 		return $data;
 	}
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-blocks-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-blocks-controller.php
@@ -58,8 +58,7 @@ class WP_REST_Blocks_Controller extends WP_REST_Posts_Controller {
 		unset( $data['content']['rendered'] );
 
 		// Add the core wp_sync_status meta as top level property to the response.
-		$wp_sync_status         = $data['meta']['wp_sync_status'];
-		$data['wp_sync_status'] = $wp_sync_status;
+		$data['wp_sync_status'] = $data['meta']['wp_sync_status'];
 		unset( $data['meta']['wp_sync_status'] );
 		return $data;
 	}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-blocks-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-blocks-controller.php
@@ -40,6 +40,7 @@ class WP_REST_Blocks_Controller extends WP_REST_Posts_Controller {
 	 * Filters a response based on the context defined in the schema.
 	 *
 	 * @since 5.0.0
+	 * @since 6.3 Adds the `wp_sync_status` postmeta property to the toplevel of response.
 	 *
 	 * @param array  $data    Response data to filter.
 	 * @param string $context Context defined in the schema.
@@ -56,6 +57,10 @@ class WP_REST_Blocks_Controller extends WP_REST_Posts_Controller {
 		unset( $data['title']['rendered'] );
 		unset( $data['content']['rendered'] );
 
+		// Add the core wp_sync_status meta as top level property to the response.
+		$wp_sync_status         = $data['meta']['wp_sync_status'];
+		$data['wp_sync_status'] = $wp_sync_status;
+		unset( $data['meta']['wp_sync_status'] );
 		return $data;
 	}
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-blocks-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-blocks-controller.php
@@ -40,7 +40,7 @@ class WP_REST_Blocks_Controller extends WP_REST_Posts_Controller {
 	 * Filters a response based on the context defined in the schema.
 	 *
 	 * @since 5.0.0
-	 * @since 6.3 Adds the `wp_pattern_sync_status` postmeta property to the toplevel of response.
+	 * @since 6.3 Adds the `wp_pattern_sync_status` postmeta property to the top level of response.
 	 *
 	 * @param array  $data    Response data to filter.
 	 * @param string $context Context defined in the schema.

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-blocks-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-blocks-controller.php
@@ -58,7 +58,7 @@ class WP_REST_Blocks_Controller extends WP_REST_Posts_Controller {
 		unset( $data['content']['rendered'] );
 
 		// Add the core wp_pattern_sync_status meta as top level property to the response.
-		$data['wp_pattern_sync_status'] = $data['meta']['wp_pattern_sync_status'];
+		$data['wp_pattern_sync_status'] = isset( $data['meta']['wp_pattern_sync_status'] ) ? $data['meta']['wp_pattern_sync_status'] : '';
 		unset( $data['meta']['wp_pattern_sync_status'] );
 		return $data;
 	}

--- a/tests/phpunit/tests/rest-api/rest-blocks-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-blocks-controller.php
@@ -220,4 +220,39 @@ class REST_Blocks_Controller_Test extends WP_UnitTestCase {
 			$data['content']
 		);
 	}
+
+	/**
+	 * Check that the `wp_pattern_sync_status` postmeta is moved from meta array to top
+	 * level of response.
+	 *
+	 * @ticket 58677
+	 */
+	public function test_wp_patterns_sync_status_post_meta() {
+		register_post_meta(
+			'wp_block',
+			'wp_pattern_sync_status',
+			array(
+				'single'            => true,
+				'type'              => 'string',
+				'show_in_rest'      => array(
+					'schema' => array(
+						'type'       => 'string',
+						'properties' => array(
+							'sync_status' => array(
+								'type' => 'string',
+							),
+						),
+					),
+				),
+			)
+		);
+		wp_set_current_user( self::$user_ids['author'] );
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/blocks/' . self::$post_id );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertArrayHasKey( 'wp_pattern_sync_status', $data );
+		$this->assertArrayNotHasKey( 'wp_pattern_sync_status', $data['meta'] );
+	}
 }

--- a/tests/phpunit/tests/rest-api/rest-blocks-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-blocks-controller.php
@@ -232,9 +232,9 @@ class REST_Blocks_Controller_Test extends WP_UnitTestCase {
 			'wp_block',
 			'wp_pattern_sync_status',
 			array(
-				'single'            => true,
-				'type'              => 'string',
-				'show_in_rest'      => array(
+				'single'       => true,
+				'type'         => 'string',
+				'show_in_rest' => array(
 					'schema' => array(
 						'type'       => 'string',
 						'properties' => array(


### PR DESCRIPTION
As [discussed here](https://github.com/WordPress/wordpress-develop/pull/4646#issuecomment-1603668189)  this moves the `sync_status` postmeta to a top level field of `wp_block`, and also renames it to `wp_pattern_sync_status` as [discussed here](https://wordpress.slack.com/archives/C02QB2JS7/p1688091498250399).

Trac ticket: https://core.trac.wordpress.org/ticket/58677

## Testing Instructions

- This change will break the sync status of unsynced patterns added in previous betas. All previous unsycned patterns will display as synced. Deleting these and adding new unsynced patterns is the easiest way to test
- Switch to this branch with 16.2 RC or trunk GB plugin installed and in the post editor add some new synced and unsynced patterns - make sure the synced ones appear in the Sync Patterns inserter tab and that the unsynced ones appear in Patterns tab under Custom patterns
- Follow the Manage All Patterns link in the Editors top right settings menu
- Edit each pattern and make sure sync status displays correctly in right post info panel
- When editing an unsycned pattern check rest endpoint (/wp/v2/blocks?) return to see that post meta field is empty but  `wp_pattern_status` field is set
- In the Site editor library check that the patterns appear in the correct Synced and unsynced sections
- In the Site editor add new synced and unsynced patterns and make sure the appear in the correct sections

## Screenshots or screencast <!-- if applicable -->

Before:
<img width="305" alt="Screenshot 2023-07-03 at 5 13 32 PM" src="https://github.com/WordPress/gutenberg/assets/3629020/6fb15ebe-7933-4eba-94b0-0ef4bfeb00d4">

After:
<img width="332" alt="Screenshot 2023-07-04 at 2 02 30 PM" src="https://github.com/WordPress/gutenberg/assets/3629020/7a8b6f8a-b7a5-4d1f-9193-f8e933d7c2c6">

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
