### PR TITLE
Navigation submenu block: deprecate deleted block_core_navigation_submenu_build_css_colors function

### DIFF
--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -5295,6 +5295,7 @@ function wp_global_styles_render_svg_filters() {
  * Build an array with CSS classes and inline styles defining the colors
  * which will be applied to the navigation markup in the front-end.
  *
+ * @since 5.9.0
  * @deprecated 6.3.0 This was removed from the Navigation Submenu block in favour of `wp_apply_colors_support()`.
  *                   `wp_apply_colors_support()` returns an array with similar class and style values,
  *                   but with different keys: `class` and `style`.

--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -5290,3 +5290,78 @@ function wp_global_styles_render_svg_filters() {
 		echo $filters;
 	}
 }
+
+/**
+ * Build an array with CSS classes and inline styles defining the colors
+ * which will be applied to the navigation markup in the front-end.
+ *
+ * @deprecated 6.3.0 This was removed from the Navigation Submenu block in favour of `wp_apply_colors_support()`.
+ *                   `wp_apply_colors_support()` returns an array with similar class and style values,
+ *                   but with different keys: `class` and `style`.
+ *
+ * @param  array $context     Navigation block context.
+ * @param  array $attributes  Block attributes.
+ * @param  bool  $is_sub_menu Whether the block is a sub-menu.
+ * @return array Colors CSS classes and inline styles.
+ */
+function block_core_navigation_submenu_build_css_colors( $context, $attributes, $is_sub_menu = false ) {
+	_deprecated_function( __FUNCTION__, '6.3.0' );
+	$colors = array(
+		'css_classes'   => array(),
+		'inline_styles' => '',
+	);
+
+	// Text color.
+	$named_text_color  = null;
+	$custom_text_color = null;
+
+	if ( $is_sub_menu && array_key_exists( 'customOverlayTextColor', $context ) ) {
+		$custom_text_color = $context['customOverlayTextColor'];
+	} elseif ( $is_sub_menu && array_key_exists( 'overlayTextColor', $context ) ) {
+		$named_text_color = $context['overlayTextColor'];
+	} elseif ( array_key_exists( 'customTextColor', $context ) ) {
+		$custom_text_color = $context['customTextColor'];
+	} elseif ( array_key_exists( 'textColor', $context ) ) {
+		$named_text_color = $context['textColor'];
+	} elseif ( isset( $context['style']['color']['text'] ) ) {
+		$custom_text_color = $context['style']['color']['text'];
+	}
+
+	// If has text color.
+	if ( ! is_null( $named_text_color ) ) {
+		// Add the color class.
+		array_push( $colors['css_classes'], 'has-text-color', sprintf( 'has-%s-color', $named_text_color ) );
+	} elseif ( ! is_null( $custom_text_color ) ) {
+		// Add the custom color inline style.
+		$colors['css_classes'][]  = 'has-text-color';
+		$colors['inline_styles'] .= sprintf( 'color: %s;', $custom_text_color );
+	}
+
+	// Background color.
+	$named_background_color  = null;
+	$custom_background_color = null;
+
+	if ( $is_sub_menu && array_key_exists( 'customOverlayBackgroundColor', $context ) ) {
+		$custom_background_color = $context['customOverlayBackgroundColor'];
+	} elseif ( $is_sub_menu && array_key_exists( 'overlayBackgroundColor', $context ) ) {
+		$named_background_color = $context['overlayBackgroundColor'];
+	} elseif ( array_key_exists( 'customBackgroundColor', $context ) ) {
+		$custom_background_color = $context['customBackgroundColor'];
+	} elseif ( array_key_exists( 'backgroundColor', $context ) ) {
+		$named_background_color = $context['backgroundColor'];
+	} elseif ( isset( $context['style']['color']['background'] ) ) {
+		$custom_background_color = $context['style']['color']['background'];
+	}
+
+	// If has background color.
+	if ( ! is_null( $named_background_color ) ) {
+		// Add the background-color class.
+		array_push( $colors['css_classes'], 'has-background', sprintf( 'has-%s-background-color', $named_background_color ) );
+	} elseif ( ! is_null( $custom_background_color ) ) {
+		// Add the custom background-color inline style.
+		$colors['css_classes'][]  = 'has-background';
+		$colors['inline_styles'] .= sprintf( 'background-color: %s;', $custom_background_color );
+	}
+
+	return $colors;
+}


### PR DESCRIPTION
`block_core_navigation_submenu_build_css_colors` was deprecated in https://github.com/WordPress/gutenberg/pull/48936 in favour of `wp_apply_colors_support`

This commit adds a deprecation to core.

See comment: https://github.com/WordPress/wordpress-develop/pull/4699/files#r1243172213

Props to @peterwilsoncc 



Trac ticket: https://core.trac.wordpress.org/ticket/58623

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
