### PR TITLE
Cast uses of ceil() to integer

### DIFF
--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -1023,9 +1023,9 @@ function get_comment_pages_count( $comments = null, $per_page = null, $threaded 
 
 	if ( $threaded ) {
 		$walker = new Walker_Comment();
-		$count  = ceil( $walker->get_number_of_root_elements( $comments ) / $per_page );
+		$count  = (int) ceil( $walker->get_number_of_root_elements( $comments ) / $per_page );
 	} else {
-		$count = ceil( count( $comments ) / $per_page );
+		$count = (int) ceil( count( $comments ) / $per_page );
 	}
 
 	return $count;

--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -1025,7 +1025,7 @@ function get_comment_pages_count( $comments = null, $per_page = null, $threaded 
 		$walker = new Walker_Comment();
 		$count  = (int) ceil( $walker->get_number_of_root_elements( $comments ) / $per_page );
 	} else {
-		$count = (int ) ceil( count( $comments ) / $per_page );
+		$count = (int) ceil( count( $comments ) / $per_page );
 	}
 
 	return $count;

--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -1025,7 +1025,7 @@ function get_comment_pages_count( $comments = null, $per_page = null, $threaded 
 		$walker = new Walker_Comment();
 		$count  = (int) ceil( $walker->get_number_of_root_elements( $comments ) / $per_page );
 	} else {
-		$count = (int) ceil( count( $comments ) / $per_page );
+		$count = (int ) ceil( count( $comments ) / $per_page );
 	}
 
 	return $count;

--- a/src/wp-includes/embed.php
+++ b/src/wp-includes/embed.php
@@ -575,7 +575,7 @@ function get_oembed_response_data( $post, $width ) {
 	);
 
 	$width  = min( max( $min_max_width['min'], $width ), $min_max_width['max'] );
-	$height = max( ceil( $width / 16 * 9 ), 200 );
+	$height = max( (int) ceil( $width / 16 * 9 ), 200 );
 
 	$data = array(
 		'version'       => '1.0',

--- a/src/wp-includes/embed.php
+++ b/src/wp-includes/embed.php
@@ -73,7 +73,7 @@ function wp_embed_defaults( $url = '' ) {
 		$width = 500;
 	}
 
-	$height = min( ceil( $width * 1.5 ), 1000 );
+	$height = min( (int) ceil( $width * 1.5 ), 1000 );
 
 	/**
 	 * Filters the default array of embed dimensions.


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Handful of functions use `ceil()`, which returns a float, but the functions expect an integer. Change those functions to cast `ceil()` to an integer.

Trac ticket: https://core.trac.wordpress.org/ticket/58683

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
