### PR TITLE
Deprecated arguments should be called out as being deprecated

### DIFF
--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -315,6 +315,10 @@ function install_dashboard() {
  * @param bool $deprecated Not used.
  */
 function install_search_form( $deprecated = true ) {
+	if ( true !== $deprecated ) {
+		_deprecated_argument( __FUNCTION__, '4.6.0' );
+	}
+
 	$type = isset( $_REQUEST['type'] ) ? wp_unslash( $_REQUEST['type'] ) : 'term';
 	$term = isset( $_REQUEST['s'] ) ? wp_unslash( $_REQUEST['s'] ) : '';
 	?>

--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -894,6 +894,10 @@ function activate_plugins( $plugins, $redirect = '', $network_wide = false, $sil
 function delete_plugins( $plugins, $deprecated = '' ) {
 	global $wp_filesystem;
 
+	if ( '' !== $deprecated ) {
+		_deprecated_argument( __FUNCTION__, '4.0.0' );
+	}
+
 	if ( empty( $plugins ) ) {
 		return false;
 	}

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -2112,6 +2112,10 @@ function _admin_search_query() {
  * @param bool   $deprecated Not used.
  */
 function iframe_header( $title = '', $deprecated = false ) {
+	if ( false !== $deprecated ) {
+		_deprecated_argument( __FUNCTION__, '4.2.0' );
+	}
+
 	show_admin_bar( false );
 	global $hook_suffix, $admin_body_class, $wp_locale;
 	$admin_body_class = preg_replace( '/[^a-z0-9_-]+/i', '-', $hook_suffix );

--- a/src/wp-includes/category-template.php
+++ b/src/wp-includes/category-template.php
@@ -1263,6 +1263,10 @@ function tag_description( $tag = 0 ) {
  * @return string Term description, if available.
  */
 function term_description( $term = 0, $deprecated = null ) {
+	if ( ! empty( $deprecated ) ) {
+		_deprecated_argument( __FUNCTION__, '4.9.2' );
+	}
+
 	if ( ! $term && ( is_tax() || is_tag() || is_category() ) ) {
 		$term = get_queried_object();
 		if ( $term ) {

--- a/src/wp-includes/meta.php
+++ b/src/wp-includes/meta.php
@@ -1401,6 +1401,10 @@ function sanitize_meta( $meta_key, $meta_value, $object_type, $object_subtype = 
 function register_meta( $object_type, $meta_key, $args, $deprecated = null ) {
 	global $wp_meta_keys;
 
+	if ( isset( $deprecated ) ) {
+		_deprecated_argument( __FUNCTION__, '4.6.0' );
+	}
+
 	if ( ! is_array( $wp_meta_keys ) ) {
 		$wp_meta_keys = array();
 	}

--- a/src/wp-includes/ms-blogs.php
+++ b/src/wp-includes/ms-blogs.php
@@ -500,6 +500,10 @@ function update_blog_option( $id, $option, $value, $deprecated = null ) {
 function switch_to_blog( $new_blog_id, $deprecated = null ) {
 	global $wpdb;
 
+	if ( isset( $deprecated ) ) {
+		_deprecated_argument( __FUNCTION__, '3.5.0' );
+	}
+
 	$prev_blog_id = get_current_blog_id();
 	if ( empty( $new_blog_id ) ) {
 		$new_blog_id = $prev_blog_id;

--- a/src/wp-includes/ms-functions.php
+++ b/src/wp-includes/ms-functions.php
@@ -1423,6 +1423,10 @@ function wpmu_create_blog( $domain, $path, $title, $user_id, $options = array(),
  * @return bool
  */
 function newblog_notify_siteadmin( $blog_id, $deprecated = '' ) {
+	if ( '' !== $deprecated ) {
+		_deprecated_argument( __FUNCTION__, '3.0.0' );
+	}
+
 	if ( is_object( $blog_id ) ) {
 		$blog_id = $blog_id->blog_id;
 	}
@@ -2021,6 +2025,11 @@ function check_upload_mimes( $mimes ) {
  */
 function update_posts_count( $deprecated = '' ) {
 	global $wpdb;
+
+	if ( '' !== $deprecated ) {
+		_deprecated_argument( __FUNCTION__, '3.0.0' );
+	}
+
 	update_option( 'post_count', (int) $wpdb->get_var( "SELECT COUNT(ID) FROM {$wpdb->posts} WHERE post_status = 'publish' and post_type = 'post'" ) );
 }
 
@@ -2074,6 +2083,10 @@ function wpmu_log_new_registrations( $blog_id, $user_id ) {
  * }
  */
 function redirect_this_site( $deprecated = '' ) {
+	if ( '' !== $deprecated ) {
+		_deprecated_argument( __FUNCTION__, '3.0.0' );
+	}
+
 	return array( get_network()->domain );
 }
 

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -1363,6 +1363,10 @@ function delete_all_user_settings() {
  * @return mixed Value set for the option.
  */
 function get_site_option( $option, $default_value = false, $deprecated = true ) {
+	if ( true !== $deprecated ) {
+		_deprecated_argument( __FUNCTION__, '4.4.0' );
+	}
+
 	return get_network_option( null, $option, $default_value );
 }
 
@@ -2490,6 +2494,10 @@ function unregister_setting( $option_group, $option_name, $deprecated = '' ) {
 	 * Please consider writing more inclusive code.
 	 */
 	$GLOBALS['new_whitelist_options'] = &$new_allowed_options;
+
+	if ( '' !== $deprecated ) {
+		_deprecated_argument( __FUNCTION__, '4.7.0' );
+	}
 
 	if ( 'misc' === $option_group ) {
 		_deprecated_argument(

--- a/src/wp-includes/revision.php
+++ b/src/wp-includes/revision.php
@@ -22,6 +22,10 @@
 function _wp_post_revision_fields( $post = array(), $deprecated = false ) {
 	static $fields = null;
 
+	if ( false !== $deprecated ) {
+		_deprecated_argument( __FUNCTION__, '4.5.0' );
+	}
+
 	if ( ! is_array( $post ) ) {
 		$post = get_post( $post, ARRAY_A );
 	}

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -1246,11 +1246,11 @@ function get_term_to_edit( $id, $taxonomy ) {
  * @since 2.3.0
  * @since 4.2.0 Introduced 'name' and 'childless' parameters.
  * @since 4.4.0 Introduced the ability to pass 'term_id' as an alias of 'id' for the `orderby` parameter.
- *              Introduced the 'meta_query' and 'update_term_meta_cache' parameters. Converted to return
+ *              Introduced the 'meta_query' and 'update_term_meta_cache' array indexes. Converted to return
  *              a list of WP_Term objects.
  * @since 4.5.0 Changed the function signature so that the `$args` array can be provided as the first parameter.
  *              Introduced 'meta_key' and 'meta_value' parameters. Introduced the ability to order results by metadata.
- * @since 4.8.0 Introduced 'suppress_filter' parameter.
+ * @since 4.8.0 Introduced 'suppress_filter' array index.
  *
  * @internal The `$deprecated` parameter is parsed for backward compatibility only.
  *


### PR DESCRIPTION
Based on a scan of the codebase to update the WPCS sniffs.

Notes:
* For functions which are deprecated which also have deprecated arguments, I've not added the call to `_deprecated_argument()`.
* There were also a couple of functions for which it was explicitly documented in the docblock why the call to `_deprecated_argument()` was missing. I've also left those alone.

### To Do

- [ ] Careful verification of the version numbers used in the calls to `_deprecated_argument()`.
    For some this was clear-cut as there was a `@since` changelog entry, but for about half of these, it is unclear in which version the parameter was deprecated.
    This will need backtracing through `git blame`.
- [ ] Add tests to safeguard the new code throwing the deprecation notices.


Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
