### PR TITLE
E2E tests: update cache control headers tests.

### DIFF
--- a/tests/e2e/specs/cache-control-headers-directives.test.js
+++ b/tests/e2e/specs/cache-control-headers-directives.test.js
@@ -22,8 +22,8 @@ describe( 'Cache Control header directives', () => {
 		const response = await page.goto( createURL( '/hello-world/' ) );
 		const cacheControl = response.headers();
 
-		expect( cacheControl[ 'cache-control' ] ).not.toContain( 'no-store' );
-		expect( cacheControl[ 'cache-control' ] ).not.toContain( 'private' );
+		expect( cacheControl ).toEqual( expect.not.objectContaining( { "cache-control": "no-store" } ) );
+		expect( cacheControl ).toEqual( expect.not.objectContaining( { "cache-control": "private" } ) );
 	} );
 
 	it( 'Private directive header present in cache control when logged in.', async () => {


### PR DESCRIPTION
This adjusts the "No private directive present in cache control when user not logged in" test so they won't fail if the headers don't contain a `cache-control` key at all.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
While trying to debug why E2E tests have been flaky, I noticed that the logged out test for cache control headers was often failing locally because the response headers don't have a `cache-control` key at all, resulting in a `Matcher error: received value must not be null nor undefined` failure. This adjusts the tests to use `expect.not.objectContaining()` instead.

Trac ticket: https://core.trac.wordpress.org/ticket/21938

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
