### PR TITLE
Allow deletion of user id 1 via Dashboard

### DIFF
--- a/src/wp-admin/network/users.php
+++ b/src/wp-admin/network/users.php
@@ -27,7 +27,7 @@ if ( isset( $_GET['action'] ) ) {
 			check_admin_referer( 'deleteuser' );
 
 			$id = (int) $_GET['id'];
-			if ( $id > 1 ) {
+			if ( $id > 0 ) {
 				$_POST['allusers'] = array( $id ); // confirm_delete_users() can only handle arrays.
 
 				// Used in the HTML title tag.


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

As the latest patch was comparing the id with a string '0', I'm updating it to use an integer instead. Regarding tests, it seems it would belong to an e2e test instead of a unit test, no? Otherwise, we would need to send a request to the action=delete page, and putting that into a unit test seems a bit out of place.

Trac ticket: https://core.trac.wordpress.org/ticket/16293

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
