### PR TITLE
Editor: Normalize paths in `register_core_block_style_handles()`.

### DIFF
--- a/src/wp-includes/blocks/index.php
+++ b/src/wp-includes/blocks/index.php
@@ -48,16 +48,16 @@ function register_core_block_style_handles() {
 		$transient_name = 'wp_core_block_css_files';
 		$files          = get_transient( $transient_name );
 		if ( ! $files ) {
-			$files = glob( __DIR__ . '/**/**.css' );
+			$files = glob( wp_normalize_path( __DIR__ . '/**/**.css' ) );
 			set_transient( $transient_name, $files );
 		}
 	} else {
-		$files = glob( __DIR__ . '/**/**.css' );
+		$files = glob( wp_normalize_path( __DIR__ . '/**/**.css' ) );
 	}
 
 	$register_style = static function( $name, $filename, $style_handle ) use ( $includes_path, $includes_url, $suffix, $wp_styles, $files ) {
 		$style_path = "blocks/{$name}/{$filename}{$suffix}.css";
-		$path       = $includes_path . $style_path;
+		$path       = wp_normalize_path( $includes_path . $style_path );
 
 		if ( ! in_array( $path, $files, true ) ) {
 			$wp_styles->add(


### PR DESCRIPTION
Previously, this function did not normalize paths before using `glob()` or registering styles. This led to a mixture of forward-slashes and back-slashes in Windows environments.

This change uses `wp_normalize_path()` to ensure Windows compatibility.

Trac ticket: https://core.trac.wordpress.org/ticket/58711
