### PR TITLE
Test/classic theme json custom font

### DIFF
--- a/tests/phpunit/data/themedir1/webfonts-theme-classic/style.css
+++ b/tests/phpunit/data/themedir1/webfonts-theme-classic/style.css
@@ -1,0 +1,7 @@
+/*
+Theme Name: Classic theme with custom font
+Theme URI: https://wordpress.org/
+Description: For testing purposes only.
+Version: 1.0.0
+Text Domain: webfonts-theme-classic
+*/

--- a/tests/phpunit/data/themedir1/webfonts-theme-classic/theme.json
+++ b/tests/phpunit/data/themedir1/webfonts-theme-classic/theme.json
@@ -1,0 +1,30 @@
+{
+	"version": 2,
+	"settings": {
+		"typography": {
+			"fontFamilies": [
+				{
+					"fontFamily": "\"Source Serif Pro\", serif",
+					"name": "Source Serif Pro",
+					"slug": "source-serif-pro",
+					"fontFace": [
+						{
+							"fontFamily": "Source Serif Pro",
+							"fontWeight": "200 900",
+							"fontStyle": "normal",
+							"fontStretch": "normal",
+							"src": ["file:./assets/fonts/SourceSerif4Variable-Roman.ttf.woff2"]
+						},
+						{
+							"fontFamily": "Source Serif Pro",
+							"fontWeight": "200 900",
+							"fontStyle": "italic",
+							"fontStretch": "normal",
+							"src": ["file:./assets/fonts/SourceSerif4Variable-Italic.ttf.woff2"]
+						}
+					]
+				}
+			]
+		}
+	}
+}

--- a/tests/phpunit/tests/webfonts/wpThemeJsonWebfontsHandler.php
+++ b/tests/phpunit/tests/webfonts/wpThemeJsonWebfontsHandler.php
@@ -105,6 +105,7 @@ EOF;
 	public function data_font_face_generated_from_themejson() {
 		return array(
 			'block theme with custom font'   => array( 'webfonts-theme' ),
+			'classic theme with custom font' => array( 'webfonts-theme-classic' ),
 		);
 	}
 

--- a/tests/phpunit/tests/webfonts/wpThemeJsonWebfontsHandler.php
+++ b/tests/phpunit/tests/webfonts/wpThemeJsonWebfontsHandler.php
@@ -74,12 +74,14 @@ class Tests_Webfonts_wpThemeJsonWebfontsHandler extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @dataProvider data_font_face_generated_from_themejson
+	 *
 	 * @ticket 55567
 	 * @ticket 46370
 	 * @ticket 57430
 	 */
-	public function test_font_face_generated_from_themejson() {
-		$this->setup_theme_and_test( 'webfonts-theme' );
+	public function test_font_face_generated_from_themejson( $theme_name ) {
+		$this->setup_theme_and_test( $theme_name );
 
 		$expected = <<<EOF
 <style id='wp-webfonts-inline-css' type='text/css'>
@@ -92,6 +94,17 @@ EOF;
 		$this->assertStringContainsString(
 			$expected,
 			get_echo( 'wp_print_styles' )
+		);
+	}
+
+	/**
+	 * Data provider for happy paths.
+	 *
+	 * @return string[][]
+	 */
+	public function data_font_face_generated_from_themejson() {
+		return array(
+			'block theme with custom font'   => array( 'webfonts-theme' ),
 		);
 	}
 


### PR DESCRIPTION
Adds a unit test to validate printing of `@font-face` declarations in a classic theme with a custom font defined in `theme.json`. Also updates `test_font_face_generated_from_themejson()` to use a data provider to include the new theme (`webfonts-theme-classic`).

Previously, only a block theme (`webfonts-theme`) was subject to this test.

Trac ticket: https://core.trac.wordpress.org/ticket/57841

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
