### PR TITLE
Posts, Post Types: Don't force trailing slashes in `get_pagenum_link()`.

### DIFF
--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -2445,7 +2445,7 @@ function get_pagenum_link( $pagenum = 1, $escape = true ) {
 		$request = preg_replace( '|^' . preg_quote( $wp_rewrite->index, '|' ) . '|i', '', $request );
 		$request = ltrim( $request, '/' );
 
-		if ( $wp_rewrite->using_index_permalinks() && ( $pagenum > 1 || '' != $request ) ) {
+		if ( $wp_rewrite->using_index_permalinks() && ( $pagenum > 1 || '' !== $request ) ) {
 			$parts[] = $wp_rewrite->index;
 		}
 

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -2446,7 +2446,7 @@ function get_pagenum_link( $pagenum = 1, $escape = true ) {
 		$request = ltrim( $request, '/' );
 
 		if ( $wp_rewrite->using_index_permalinks() && ( $pagenum > 1 || '' != $request ) ) {
-			$parts[] = 'index.php';
+			$parts[] = $wp_rewrite->index;
 		}
 
 		$parts[] = untrailingslashit( $request );

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -2456,8 +2456,10 @@ function get_pagenum_link( $pagenum = 1, $escape = true ) {
 			$parts[] = $pagenum;
 		}
 
-		$parts[] = $query_string;
-		$result  = user_trailingslashit( implode( '/', array_filter( $parts ) ), 'paged' );
+		$result = user_trailingslashit( implode( '/', array_filter( $parts ) ), 'paged' );
+		if ( ! empty( $query_string ) ) {
+			$result .= $query_string;
+		}
 	}
 
 	/**

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -2431,6 +2431,9 @@ function get_pagenum_link( $pagenum = 1, $escape = true ) {
 		$qs_regex = '|\?.*?$|';
 		preg_match( $qs_regex, $request, $qs_match );
 
+		$parts   = array();
+		$parts[] = untrailingslashit( get_bloginfo( 'url' ) );
+
 		if ( ! empty( $qs_match[0] ) ) {
 			$query_string = $qs_match[0];
 			$request      = preg_replace( $qs_regex, '', $request );
@@ -2442,17 +2445,19 @@ function get_pagenum_link( $pagenum = 1, $escape = true ) {
 		$request = preg_replace( '|^' . preg_quote( $wp_rewrite->index, '|' ) . '|i', '', $request );
 		$request = ltrim( $request, '/' );
 
-		$base = trailingslashit( get_bloginfo( 'url' ) );
-
-		if ( $wp_rewrite->using_index_permalinks() && ( $pagenum > 1 || '' !== $request ) ) {
-			$base .= $wp_rewrite->index . '/';
+		if ( $wp_rewrite->using_index_permalinks() && ( $pagenum > 1 || '' != $request ) ) {
+			$parts[] = 'index.php';
 		}
+
+		$parts[] = untrailingslashit( $request );
 
 		if ( $pagenum > 1 ) {
-			$request = ( ( ! empty( $request ) ) ? trailingslashit( $request ) : $request ) . user_trailingslashit( $wp_rewrite->pagination_base . '/' . $pagenum, 'paged' );
+			$parts[] = $wp_rewrite->pagination_base;
+			$parts[] = $pagenum;
 		}
 
-		$result = $base . $request . $query_string;
+		$parts[] = $query_string;
+		$result  = user_trailingslashit( implode( '/', array_filter( $parts ) ), 'paged' );
 	}
 
 	/**

--- a/tests/phpunit/tests/link.php
+++ b/tests/phpunit/tests/link.php
@@ -4,28 +4,6 @@
  */
 class Tests_Link extends WP_UnitTestCase {
 
-	public function get_pagenum_link_cb( $url ) {
-		return $url . '/WooHoo';
-	}
-
-	/**
-	 * @ticket 8847
-	 */
-	public function test_get_pagenum_link_case_insensitivity() {
-		$old_req_uri = $_SERVER['REQUEST_URI'];
-
-		$this->set_permalink_structure( '/%year%/%monthnum%/%day%/%postname%/' );
-
-		add_filter( 'home_url', array( $this, 'get_pagenum_link_cb' ) );
-		$_SERVER['REQUEST_URI'] = '/woohoo';
-		$paged                  = get_pagenum_link( 2 );
-
-		remove_filter( 'home_url', array( $this, 'get_pagenum_link_cb' ) );
-		$this->assertSame( $paged, home_url( '/WooHoo/page/2/' ) );
-
-		$_SERVER['REQUEST_URI'] = $old_req_uri;
-	}
-
 	public function test_wp_get_shortlink() {
 		$post_id  = self::factory()->post->create();
 		$post_id2 = self::factory()->post->create();

--- a/tests/phpunit/tests/link/getPagenumLink.php
+++ b/tests/phpunit/tests/link/getPagenumLink.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @group  link
+ * @covers ::get_pagenum_link
+ */
+class Tests_Link_GetPagenumLink extends WP_UnitTestCase {
+
+	public function get_pagenum_link_cb( $url ) {
+		return $url . '/WooHoo';
+	}
+
+	/**
+	 * @ticket 8847
+	 */
+	public function test_get_pagenum_link_case_insensitivity() {
+		$old_req_uri = $_SERVER['REQUEST_URI'];
+
+		$this->set_permalink_structure( '/%year%/%monthnum%/%day%/%postname%/' );
+
+		add_filter( 'home_url', array( $this, 'get_pagenum_link_cb' ) );
+		$_SERVER['REQUEST_URI'] = '/woohoo';
+		$paged                  = get_pagenum_link( 2 );
+
+		remove_filter( 'home_url', array( $this, 'get_pagenum_link_cb' ) );
+		$this->assertSame( $paged, home_url( '/WooHoo/page/2/' ) );
+
+		$_SERVER['REQUEST_URI'] = $old_req_uri;
+	}
+
+	/**
+	 * @ticket 2877
+	 */
+	function test_get_pagenum_link_firstpage_trailingslash() {
+		$old_req_uri = $_SERVER['REQUEST_URI'];
+
+		$this->set_permalink_structure( '/%year%/%monthnum%/%day%/%postname%' );
+
+		add_filter( 'home_url', array( $this, 'get_pagenum_link_cb' ) );
+		$_SERVER['REQUEST_URI'] = '/woohoo';
+		$paged                  = get_pagenum_link( 1 );
+
+		remove_filter( 'home_url', array( $this, 'get_pagenum_link_cb' ) );
+		$this->assertEquals( home_url( '/WooHoo' ), $paged );
+
+		$_SERVER['REQUEST_URI'] = $old_req_uri;
+	}
+}

--- a/tests/phpunit/tests/link/getPagenumLink.php
+++ b/tests/phpunit/tests/link/getPagenumLink.php
@@ -1,17 +1,46 @@
 <?php
 
 /**
- * @group  link
+ * @group link
  * @covers ::get_pagenum_link
  */
 class Tests_Link_GetPagenumLink extends WP_UnitTestCase {
 
 	/**
+	 * The original value of `$_SERVER['REQUEST_URI']`.
+	 *
+	 * @var string|null
+	 */
+	protected static $request_uri_original;
+
+	/**
+	 * Backs up the value of `$_SERVER['REQUEST_URI']` before any tests run.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		if ( isset( $_SERVER['REQUEST_URI'] ) ) {
+			self::$request_uri_original = $_SERVER['REQUEST_URI'];
+		}
+	}
+
+	/**
+	 * Restores the value of `$_SERVER['REQUEST_URI']` after each test runs.
+	 */
+	public function tear_down() {
+		if ( null === self::$request_uri_original ) {
+			unset( $_SERVER['REQUEST_URI'] );
+		} else {
+			$_SERVER['REQUEST_URI'] = self::$request_uri_original;
+		}
+
+		parent::tear_down();
+	}
+
+	/**
 	 * @ticket 8847
 	 */
 	public function test_get_pagenum_link_case_insensitivity() {
-		$old_req_uri = $_SERVER['REQUEST_URI'];
-
 		$this->set_permalink_structure( '/%year%/%monthnum%/%day%/%postname%/' );
 
 		add_filter( 'home_url', array( $this, 'get_pagenum_link_cb' ) );
@@ -20,71 +49,151 @@ class Tests_Link_GetPagenumLink extends WP_UnitTestCase {
 
 		remove_filter( 'home_url', array( $this, 'get_pagenum_link_cb' ) );
 		$this->assertSame( $paged, home_url( '/WooHoo/page/2/' ) );
-
-		$_SERVER['REQUEST_URI'] = $old_req_uri;
 	}
 
 	/**
-	 * @ticket 2877
+	 * Appends '/WooHoo' to the provided URL.
+	 *
+	 * Callback for the 'home_url' filter hook.
+	 *
+	 * @param string $url The base URL.
+	 * @return string The base URL with '/WooHoo' appended.
 	 */
-	public function test_get_pagenum_link_firstpage_no_trailingslash() {
-		$old_req_uri = $_SERVER['REQUEST_URI'];
-
-		$this->set_permalink_structure( '/%year%/%monthnum%/%day%/%postname%' );
-		$_SERVER['REQUEST_URI'] = '/woohoo/page/2/';
-		$paged                  = get_pagenum_link( 1 );
-
-		$this->assertEquals( home_url( '/woohoo' ), $paged );
-
-		$_SERVER['REQUEST_URI'] = $old_req_uri;
-	}
-
-	/**
-	 * @ticket 2877
-	 */
-	public function test_get_pagenum_link_paged_no_trailingslash() {
-		$old_req_uri = $_SERVER['REQUEST_URI'];
-
-		$this->set_permalink_structure( '/%year%/%monthnum%/%day%/%postname%' );
-		$_SERVER['REQUEST_URI'] = '/woohoo';
-		$paged                  = get_pagenum_link( 2 );
-
-		$this->assertEquals( home_url( '/woohoo/page/2' ), $paged );
-
-		$_SERVER['REQUEST_URI'] = $old_req_uri;
-	}
-
-	/**
-	 * @ticket 2877
-	 */
-	public function test_get_pagenum_link_firstpage_no_trailingslash_queryargs() {
-		$old_req_uri = $_SERVER['REQUEST_URI'];
-
-		$this->set_permalink_structure( '/%year%/%monthnum%/%day%/%postname%' );
-		$_SERVER['REQUEST_URI'] = '/woohoo/page/2?test=1234';
-		$paged                  = get_pagenum_link( 1 );
-
-		$this->assertEquals( home_url( '/woohoo?test=1234' ), $paged );
-
-		$_SERVER['REQUEST_URI'] = $old_req_uri;
-	}
-
-	/**
-	 * @ticket 2877
-	 */
-	public function test_get_pagenum_link_paged_no_trailingslash_query_args() {
-		$old_req_uri = $_SERVER['REQUEST_URI'];
-
-		$this->set_permalink_structure( '/%year%/%monthnum%/%day%/%postname%' );
-		$_SERVER['REQUEST_URI'] = '/woohoo?test=1234';
-		$paged                  = get_pagenum_link( 2 );
-
-		$this->assertEquals( home_url( '/woohoo/page/2?test=1234' ), $paged );
-
-		$_SERVER['REQUEST_URI'] = $old_req_uri;
-	}
-
 	public function get_pagenum_link_cb( $url ) {
 		return $url . '/WooHoo';
+	}
+
+	/**
+	 * Tests that a trailing slash is not added to the link.
+	 *
+	 * @ticket 2877
+	 *
+	 * @dataProvider data_get_pagenum_link_plain_permalinks
+	 * @dataProvider data_get_pagenum_link
+	 *
+	 * @param string $permalink_structure The structure to use for permalinks.
+	 * @param string $request_uri         The value for `$_SERVER['REQUEST_URI']`.
+	 * @param int    $pagenum             The page number to get the link for.
+	 * @param string $expected            The expected relative URL.
+	 */
+	public function test_get_pagenum_link_should_not_add_trailing_slash( $permalink_structure, $request_uri, $pagenum, $expected ) {
+		$this->set_permalink_structure( $permalink_structure );
+		$_SERVER['REQUEST_URI'] = $request_uri;
+		$paged                  = get_pagenum_link( $pagenum );
+
+		$this->assertSame( home_url( $expected ), $paged );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_get_pagenum_link_plain_permalinks() {
+		return array(
+			'page 1 and plain permalinks' => array(
+				'permalink_structure' => '',
+				'request_uri'         => '/?paged=2',
+				'pagenum'             => 1,
+				'expected'            => '/',
+			),
+			'page 2 and plain permalinks' => array(
+				'permalink_structure' => '',
+				'request_uri'         => '/',
+				'pagenum'             => 2,
+				'expected'            => '/?paged=2',
+			),
+		);
+	}
+
+	/**
+	 * Tests that a trailing slash is added to the link when a trailing slash
+	 * exists in the permalink structure.
+	 *
+	 * @ticket 2877
+	 *
+	 * @dataProvider data_get_pagenum_link
+	 *
+	 * @param string $permalink_structure The structure to use for permalinks.
+	 * @param string $request_uri         The value for `$_SERVER['REQUEST_URI']`.
+	 * @param int    $pagenum             The page number to get the link for.
+	 * @param string $expected            The expected relative URL.
+	 */
+	public function test_get_pagenum_link_should_add_trailing_slash( $permalink_structure, $request_uri, $pagenum, $expected ) {
+		// Ensure the permalink structure has a trailing slash.
+		$permalink_structure = trailingslashit( $permalink_structure );
+
+		// Ensure the expected value has a trailing slash at the appropriate position.
+		if ( str_contains( $expected, '?' ) ) {
+			// Contains query args.
+			$parts    = explode( '?', $expected, 2 );
+			$expected = trailingslashit( $parts[0] ) . '?' . $parts[1];
+		} else {
+			$expected = trailingslashit( $expected );
+		}
+
+		$this->set_permalink_structure( $permalink_structure );
+		$_SERVER['REQUEST_URI'] = $request_uri;
+		$paged                  = get_pagenum_link( $pagenum );
+
+		$this->assertSame( home_url( $expected ), $paged );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_get_pagenum_link() {
+		return array(
+			'page 1 and index.php'                  => array(
+				'permalink_structure' => '/index.php/%year%/%monthnum%/%day%/%postname%',
+				'request_uri'         => '/index.php/woohoo/page/2/',
+				'pagenum'             => 1,
+				'expected'            => '/index.php/woohoo',
+			),
+			'page 2 and index.php'                  => array(
+				'permalink_structure' => '/index.php/%year%/%monthnum%/%day%/%postname%',
+				'request_uri'         => '/index.php/woohoo/page/2/',
+				'pagenum'             => 2,
+				'expected'            => '/index.php/woohoo/page/2',
+			),
+			'page 1 with date-based permalinks'     => array(
+				'permalink_structure' => '/%year%/%monthnum%/%day%/%postname%',
+				'request_uri'         => '/woohoo/page/2/',
+				'pagenum'             => 1,
+				'expected'            => '/woohoo',
+			),
+			'page 2 with date-based permalinks'     => array(
+				'permalink_structure' => '/%year%/%monthnum%/%day%/%postname%',
+				'request_uri'         => '/woohoo',
+				'pagenum'             => 2,
+				'expected'            => '/woohoo/page/2',
+			),
+			'page 1 with postname-based permalinks' => array(
+				'permalink_structure' => '/%postname%',
+				'request_uri'         => '/woohoo/page/2',
+				'pagenum'             => 1,
+				'expected'            => '/woohoo',
+			),
+			'page 2 with postname-based permalinks' => array(
+				'permalink_structure' => '/%postname%',
+				'request_uri'         => '/woohoo',
+				'pagenum'             => 2,
+				'expected'            => '/woohoo/page/2',
+			),
+			'page 1 with postname-based permalinks and query args' => array(
+				'permalink_structure' => '/%postname%',
+				'request_uri'         => '/woohoo/page/2?test=1234',
+				'pagenum'             => 1,
+				'expected'            => '/woohoo?test=1234',
+			),
+			'page 2 with postname-based permalinks and query args' => array(
+				'permalink_structure' => '/%postname%',
+				'request_uri'         => '/woohoo?test=1234',
+				'pagenum'             => 2,
+				'expected'            => '/woohoo/page/2?test=1234',
+			),
+		);
 	}
 }

--- a/tests/phpunit/tests/link/getPagenumLink.php
+++ b/tests/phpunit/tests/link/getPagenumLink.php
@@ -6,10 +6,6 @@
  */
 class Tests_Link_GetPagenumLink extends WP_UnitTestCase {
 
-	public function get_pagenum_link_cb( $url ) {
-		return $url . '/WooHoo';
-	}
-
 	/**
 	 * @ticket 8847
 	 */
@@ -31,18 +27,64 @@ class Tests_Link_GetPagenumLink extends WP_UnitTestCase {
 	/**
 	 * @ticket 2877
 	 */
-	function test_get_pagenum_link_firstpage_trailingslash() {
+	public function test_get_pagenum_link_firstpage_no_trailingslash() {
 		$old_req_uri = $_SERVER['REQUEST_URI'];
 
 		$this->set_permalink_structure( '/%year%/%monthnum%/%day%/%postname%' );
-
-		add_filter( 'home_url', array( $this, 'get_pagenum_link_cb' ) );
-		$_SERVER['REQUEST_URI'] = '/woohoo';
+		$_SERVER['REQUEST_URI'] = '/woohoo/page/2/';
 		$paged                  = get_pagenum_link( 1 );
 
-		remove_filter( 'home_url', array( $this, 'get_pagenum_link_cb' ) );
-		$this->assertEquals( home_url( '/WooHoo' ), $paged );
+		$this->assertEquals( home_url( '/woohoo' ), $paged );
 
 		$_SERVER['REQUEST_URI'] = $old_req_uri;
+	}
+
+	/**
+	 * @ticket 2877
+	 */
+	public function test_get_pagenum_link_paged_no_trailingslash() {
+		$old_req_uri = $_SERVER['REQUEST_URI'];
+
+		$this->set_permalink_structure( '/%year%/%monthnum%/%day%/%postname%' );
+		$_SERVER['REQUEST_URI'] = '/woohoo';
+		$paged                  = get_pagenum_link( 2 );
+
+		$this->assertEquals( home_url( '/woohoo/page/2' ), $paged );
+
+		$_SERVER['REQUEST_URI'] = $old_req_uri;
+	}
+
+	/**
+	 * @ticket 2877
+	 */
+	public function test_get_pagenum_link_firstpage_no_trailingslash_queryargs() {
+		$old_req_uri = $_SERVER['REQUEST_URI'];
+
+		$this->set_permalink_structure( '/%year%/%monthnum%/%day%/%postname%' );
+		$_SERVER['REQUEST_URI'] = '/woohoo/page/2?test=1234';
+		$paged                  = get_pagenum_link( 1 );
+
+		$this->assertEquals( home_url( '/woohoo?test=1234' ), $paged );
+
+		$_SERVER['REQUEST_URI'] = $old_req_uri;
+	}
+
+	/**
+	 * @ticket 2877
+	 */
+	public function test_get_pagenum_link_paged_no_trailingslash_query_args() {
+		$old_req_uri = $_SERVER['REQUEST_URI'];
+
+		$this->set_permalink_structure( '/%year%/%monthnum%/%day%/%postname%' );
+		$_SERVER['REQUEST_URI'] = '/woohoo?test=1234';
+		$paged                  = get_pagenum_link( 2 );
+
+		$this->assertEquals( home_url( '/woohoo/page/2?test=1234' ), $paged );
+
+		$_SERVER['REQUEST_URI'] = $old_req_uri;
+	}
+
+	public function get_pagenum_link_cb( $url ) {
+		return $url . '/WooHoo';
 	}
 }


### PR DESCRIPTION
Previously, a trailing slash was appended to the link returned from this function. If the permalink structure didn't contain a trailing slash, this link could fail.

This change removes trailing slashes and only appends one if the site is set for adding trailing slashes.

---

This PR is an update of #3931 which makes various test improvements, including:
- Documentation updates.
- Backing up `$_SERVER['REQUEST_URI']` before any tests run, and restoring it after each test has run.
- Using a data provider to group related datasets.
- Adding datasets that account for `index.php` in the permalink structure.
- Adding datasets that account for plain permalinks, date-based permalinks, and postname-based permalinks.
- Adding a test that verifies that `get_pagenum_link()` adds a trailing slash when the permalink structure contains a trailing slash.

Trac ticket: https://core.trac.wordpress.org/ticket/2877