### PR TITLE
Fix multiline comment indentation

### DIFF
--- a/src/wp-includes/block-supports/settings.php
+++ b/src/wp-includes/block-supports/settings.php
@@ -97,9 +97,9 @@ function _wp_add_block_level_preset_styles( $pre_render, $block ) {
 	$blocks                  = $registry->get_all_registered();
 	foreach ( $blocks as $block_type ) {
 		/*
-		* We only want to append selectors for block's using custom selectors
-		* i.e. not `wp-block-<name>`.
-		*/
+		 * We only want to append selectors for blocks using custom selectors
+		 * i.e. not `wp-block-<name>`.
+		 */
 		$has_custom_selector =
 			( isset( $block_type->supports['__experimentalSelector'] ) && is_string( $block_type->supports['__experimentalSelector'] ) ) ||
 			( isset( $block_type->selectors['root'] ) && is_string( $block_type->selectors['root'] ) );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/58586

Fix comment indentation issue noted [here](https://core.trac.wordpress.org/ticket/58586#comment:19)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
