### PR TITLE
Fix incorrect hook being used in automated performance tests

### DIFF
--- a/tests/performance/wp-content/mu-plugins/server-timing.php
+++ b/tests/performance/wp-content/mu-plugins/server-timing.php
@@ -1,6 +1,6 @@
 <?php
 
-add_action(
+add_filter(
 	'template_include',
 	static function( $template ) {
 

--- a/tests/performance/wp-content/mu-plugins/server-timing.php
+++ b/tests/performance/wp-content/mu-plugins/server-timing.php
@@ -1,8 +1,8 @@
 <?php
 
 add_action(
-	'template_redirect',
-	static function() {
+	'template_include',
+	static function( $template ) {
 
 		global $timestart;
 
@@ -38,6 +38,8 @@ add_action(
 			},
 			PHP_INT_MIN
 		);
+
+		return $template;
 	},
 	PHP_INT_MAX
 );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/58674

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
