### PR TITLE
Deprecated functions should be called out as being deprecated

### DIFF
--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -2849,6 +2849,8 @@ function wp_ajax_time_format() {
  * @deprecated 4.3.0
  */
 function wp_ajax_wp_fullscreen_save_post() {
+	_deprecated_function( __FUNCTION__, '4.3.0' );
+
 	$post_id = isset( $_POST['post_ID'] ) ? (int) $_POST['post_ID'] : 0;
 
 	$post = null;
@@ -5293,13 +5295,15 @@ function wp_ajax_wp_privacy_erase_personal_data() {
  * @see WP_REST_Site_Health_Controller::test_dotorg_communication()
  */
 function wp_ajax_health_check_dotorg_communication() {
+	_deprecated_function( __FUNCTION__, '5.6.0', 'WP_REST_Site_Health_Controller::test_dotorg_communication()' );
+
 	_doing_it_wrong(
 		'wp_ajax_health_check_dotorg_communication',
 		sprintf(
 		// translators: 1: The Site Health action that is no longer used by core. 2: The new function that replaces it.
 			__( 'The Site Health check for %1$s has been replaced with %2$s.' ),
 			'wp_ajax_health_check_dotorg_communication',
-			'WP_REST_Site_Health_Controller::test_dotorg_communication'
+			'WP_REST_Site_Health_Controller::test_dotorg_communication()'
 		),
 		'5.6.0'
 	);
@@ -5326,13 +5330,15 @@ function wp_ajax_health_check_dotorg_communication() {
  * @see WP_REST_Site_Health_Controller::test_background_updates()
  */
 function wp_ajax_health_check_background_updates() {
+	_deprecated_function( __FUNCTION__, '5.6.0', 'WP_REST_Site_Health_Controller::test_background_updates()' );
+
 	_doing_it_wrong(
 		'wp_ajax_health_check_background_updates',
 		sprintf(
 		// translators: 1: The Site Health action that is no longer used by core. 2: The new function that replaces it.
 			__( 'The Site Health check for %1$s has been replaced with %2$s.' ),
 			'wp_ajax_health_check_background_updates',
-			'WP_REST_Site_Health_Controller::test_background_updates'
+			'WP_REST_Site_Health_Controller::test_background_updates()'
 		),
 		'5.6.0'
 	);
@@ -5359,13 +5365,15 @@ function wp_ajax_health_check_background_updates() {
  * @see WP_REST_Site_Health_Controller::test_loopback_requests()
  */
 function wp_ajax_health_check_loopback_requests() {
+	_deprecated_function( __FUNCTION__, '5.6.0', 'WP_REST_Site_Health_Controller::test_loopback_requests()' );
+
 	_doing_it_wrong(
 		'wp_ajax_health_check_loopback_requests',
 		sprintf(
 		// translators: 1: The Site Health action that is no longer used by core. 2: The new function that replaces it.
 			__( 'The Site Health check for %1$s has been replaced with %2$s.' ),
 			'wp_ajax_health_check_loopback_requests',
-			'WP_REST_Site_Health_Controller::test_loopback_requests'
+			'WP_REST_Site_Health_Controller::test_loopback_requests()'
 		),
 		'5.6.0'
 	);
@@ -5409,13 +5417,15 @@ function wp_ajax_health_check_site_status_result() {
  * @see WP_REST_Site_Health_Controller::get_directory_sizes()
  */
 function wp_ajax_health_check_get_sizes() {
+	_deprecated_function( __FUNCTION__, '5.6.0', 'WP_REST_Site_Health_Controller::get_directory_sizes()' );
+
 	_doing_it_wrong(
 		'wp_ajax_health_check_get_sizes',
 		sprintf(
 		// translators: 1: The Site Health action that is no longer used by core. 2: The new function that replaces it.
 			__( 'The Site Health check for %1$s has been replaced with %2$s.' ),
 			'wp_ajax_health_check_get_sizes',
-			'WP_REST_Site_Health_Controller::get_directory_sizes'
+			'WP_REST_Site_Health_Controller::get_directory_sizes()'
 		),
 		'5.6.0'
 	);

--- a/src/wp-admin/includes/deprecated.php
+++ b/src/wp-admin/includes/deprecated.php
@@ -861,6 +861,8 @@ function screen_options( $screen ) {
  * @see WP_Screen::render_screen_meta()
  */
 function screen_meta( $screen ) {
+	_deprecated_function( __FUNCTION__, '3.3.0', 'WP_Screen::render_screen_meta()' );
+
 	$current_screen = get_current_screen();
 	$current_screen->render_screen_meta();
 }
@@ -1256,14 +1258,18 @@ function get_screen_icon() {
  * @since 2.5.0
  * @deprecated 3.8.0
  */
-function wp_dashboard_incoming_links_output() {}
+function wp_dashboard_incoming_links_output() {
+	_deprecated_function( __FUNCTION__, '3.8.0' );
+}
 
 /**
  * Deprecated dashboard secondary output.
  *
  * @deprecated 3.8.0
  */
-function wp_dashboard_secondary_output() {}
+function wp_dashboard_secondary_output() {
+	_deprecated_function( __FUNCTION__, '3.8.0' );
+}
 
 /**
  * Deprecated dashboard widget controls.
@@ -1271,49 +1277,63 @@ function wp_dashboard_secondary_output() {}
  * @since 2.7.0
  * @deprecated 3.8.0
  */
-function wp_dashboard_incoming_links() {}
+function wp_dashboard_incoming_links() {
+	_deprecated_function( __FUNCTION__, '3.8.0' );
+}
 
 /**
  * Deprecated dashboard incoming links control.
  *
  * @deprecated 3.8.0
  */
-function wp_dashboard_incoming_links_control() {}
+function wp_dashboard_incoming_links_control() {
+	_deprecated_function( __FUNCTION__, '3.8.0' );
+}
 
 /**
  * Deprecated dashboard plugins control.
  *
  * @deprecated 3.8.0
  */
-function wp_dashboard_plugins() {}
+function wp_dashboard_plugins() {
+	_deprecated_function( __FUNCTION__, '3.8.0' );
+}
 
 /**
  * Deprecated dashboard primary control.
  *
  * @deprecated 3.8.0
  */
-function wp_dashboard_primary_control() {}
+function wp_dashboard_primary_control() {
+	_deprecated_function( __FUNCTION__, '3.8.0' );
+}
 
 /**
  * Deprecated dashboard recent comments control.
  *
  * @deprecated 3.8.0
  */
-function wp_dashboard_recent_comments_control() {}
+function wp_dashboard_recent_comments_control() {
+	_deprecated_function( __FUNCTION__, '3.8.0' );
+}
 
 /**
  * Deprecated dashboard secondary section.
  *
  * @deprecated 3.8.0
  */
-function wp_dashboard_secondary() {}
+function wp_dashboard_secondary() {
+	_deprecated_function( __FUNCTION__, '3.8.0' );
+}
 
 /**
  * Deprecated dashboard secondary control.
  *
  * @deprecated 3.8.0
  */
-function wp_dashboard_secondary_control() {}
+function wp_dashboard_secondary_control() {
+	_deprecated_function( __FUNCTION__, '3.8.0' );
+}
 
 /**
  * Display plugins text for the WordPress news widget.
@@ -1509,6 +1529,7 @@ function post_form_autocomplete_off() {
  * @deprecated 4.9.0
  */
 function options_permalink_add_js() {
+	_deprecated_function( __FUNCTION__, '4.9.0' );
 	?>
 	<script type="text/javascript">
 		jQuery( function() {

--- a/src/wp-admin/includes/ms-deprecated.php
+++ b/src/wp-admin/includes/ms-deprecated.php
@@ -107,7 +107,9 @@ function wpmu_get_blog_allowedthemes( $blog_id = 0 ) {
  *
  * @deprecated 3.5.0
  */
-function ms_deprecated_blogs_file() {}
+function ms_deprecated_blogs_file() {
+	_deprecated_function( __FUNCTION__, '3.5.0' );
+}
 
 if ( ! function_exists( 'install_global_terms' ) ) :
 	/**

--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -2133,6 +2133,7 @@ function upgrade_460() {
  * @deprecated 5.1.0
  */
 function upgrade_500() {
+	_deprecated_function( __FUNCTION__, '5.1.0' );
 }
 
 /**

--- a/src/wp-content/themes/twentyfifteen/functions.php
+++ b/src/wp-content/themes/twentyfifteen/functions.php
@@ -494,6 +494,8 @@ add_action( 'enqueue_block_editor_assets', 'twentyfifteen_block_editor_styles' )
  * @return array URLs to print for resource hints.
  */
 function twentyfifteen_resource_hints( $urls, $relation_type ) {
+	_deprecated_function( __FUNCTION__, 'Twenty Fifteen 3.4' );
+
 	if ( wp_style_is( 'twentyfifteen-fonts', 'queue' ) && 'preconnect' === $relation_type ) {
 		if ( version_compare( $GLOBALS['wp_version'], '4.7-alpha', '>=' ) ) {
 			$urls[] = array(

--- a/src/wp-content/themes/twentyfourteen/functions.php
+++ b/src/wp-content/themes/twentyfourteen/functions.php
@@ -404,6 +404,8 @@ add_action( 'admin_print_scripts-appearance_page_custom-header', 'twentyfourteen
  * @return array URLs to print for resource hints.
  */
 function twentyfourteen_resource_hints( $urls, $relation_type ) {
+	_deprecated_function( __FUNCTION__, 'Twenty Fourteen 3.6' );
+
 	if ( wp_style_is( 'twentyfourteen-lato', 'queue' ) && 'preconnect' === $relation_type ) {
 		if ( version_compare( $GLOBALS['wp_version'], '4.7-alpha', '>=' ) ) {
 			$urls[] = array(

--- a/src/wp-content/themes/twentynineteen/functions.php
+++ b/src/wp-content/themes/twentynineteen/functions.php
@@ -283,6 +283,8 @@ add_action( 'wp_enqueue_scripts', 'twentynineteen_scripts' );
  * @link https://git.io/vWdr2
  */
 function twentynineteen_skip_link_focus_fix() {
+	_deprecated_function( __FUNCTION__, 'Twenty Nineteen 2.6' );
+
 	// The following is minified via `terser --compress --mangle -- js/skip-link-focus-fix.js`.
 	?>
 	<script>

--- a/src/wp-content/themes/twentyseventeen/functions.php
+++ b/src/wp-content/themes/twentyseventeen/functions.php
@@ -319,6 +319,8 @@ endif;
  * @return array URLs to print for resource hints.
  */
 function twentyseventeen_resource_hints( $urls, $relation_type ) {
+	_deprecated_function( __FUNCTION__, 'Twenty Seventeen 3.2' );
+
 	if ( wp_style_is( 'twentyseventeen-fonts', 'queue' ) && 'preconnect' === $relation_type ) {
 		$urls[] = array(
 			'href' => 'https://fonts.gstatic.com',

--- a/src/wp-content/themes/twentysixteen/functions.php
+++ b/src/wp-content/themes/twentysixteen/functions.php
@@ -261,6 +261,8 @@ add_action( 'after_setup_theme', 'twentysixteen_content_width', 0 );
  * @return array URLs to print for resource hints.
  */
 function twentysixteen_resource_hints( $urls, $relation_type ) {
+	_deprecated_function( __FUNCTION__, 'Twenty Sixteen 2.9' );
+
 	if ( wp_style_is( 'twentysixteen-fonts', 'queue' ) && 'preconnect' === $relation_type ) {
 		$urls[] = array(
 			'href' => 'https://fonts.gstatic.com',

--- a/src/wp-content/themes/twentyten/functions.php
+++ b/src/wp-content/themes/twentyten/functions.php
@@ -399,6 +399,8 @@ add_filter( 'use_default_gallery_style', '__return_false' );
  * @return string The gallery style filter, with the styles themselves removed.
  */
 function twentyten_remove_gallery_css( $css ) {
+	_deprecated_function( __FUNCTION__, 'Twenty Ten 1.2' );
+
 	return preg_replace( "#<style type='text/css'>(.*?)</style>#s", '', $css );
 }
 // Backward compatibility with WordPress 3.0.

--- a/src/wp-content/themes/twentythirteen/functions.php
+++ b/src/wp-content/themes/twentythirteen/functions.php
@@ -353,6 +353,8 @@ add_action( 'wp_enqueue_scripts', 'twentythirteen_scripts_styles' );
  * @return array URLs to print for resource hints.
  */
 function twentythirteen_resource_hints( $urls, $relation_type ) {
+	_deprecated_function( __FUNCTION__, 'Twenty Thirteen 3.8' );
+
 	if ( wp_style_is( 'twentythirteen-fonts', 'queue' ) && 'preconnect' === $relation_type ) {
 		if ( version_compare( $GLOBALS['wp_version'], '4.7-alpha', '>=' ) ) {
 			$urls[] = array(

--- a/src/wp-content/themes/twentytwelve/functions.php
+++ b/src/wp-content/themes/twentytwelve/functions.php
@@ -233,6 +233,8 @@ add_action( 'enqueue_block_editor_assets', 'twentytwelve_block_editor_styles' );
  * @return array URLs to print for resource hints.
  */
 function twentytwelve_resource_hints( $urls, $relation_type ) {
+	_deprecated_function( __FUNCTION__, 'Twenty Twelve 3.9' );
+
 	if ( wp_style_is( 'twentytwelve-fonts', 'queue' ) && 'preconnect' === $relation_type ) {
 		if ( version_compare( $GLOBALS['wp_version'], '4.7-alpha', '>=' ) ) {
 			$urls[] = array(

--- a/src/wp-content/themes/twentytwenty/functions.php
+++ b/src/wp-content/themes/twentytwenty/functions.php
@@ -232,6 +232,8 @@ add_action( 'wp_enqueue_scripts', 'twentytwenty_register_scripts' );
  * @link https://git.io/vWdr2
  */
 function twentytwenty_skip_link_focus_fix() {
+	_deprecated_function( __FUNCTION__, 'Twenty Twenty 2.3' );
+
 	// The following is minified via `terser --compress --mangle -- assets/js/skip-link-focus-fix.js`.
 	?>
 	<script>

--- a/src/wp-content/themes/twentytwentyone/functions.php
+++ b/src/wp-content/themes/twentytwentyone/functions.php
@@ -490,6 +490,7 @@ add_action( 'enqueue_block_editor_assets', 'twentytwentyone_block_editor_script'
  * @link https://git.io/vWdr2
  */
 function twenty_twenty_one_skip_link_focus_fix() {
+	_deprecated_function( __FUNCTION__, 'Twenty Twenty-One 1.9' );
 
 	// If SCRIPT_DEBUG is defined and true, print the unminified file.
 	if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {

--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -2451,6 +2451,7 @@ function get_usernumposts( $userid ) {
  * @return string An HTML entity
  */
 function funky_javascript_callback($matches) {
+	_deprecated_function( __FUNCTION__, '3.0.0' );
 	return "&#".base_convert($matches[1],16,10).";";
 }
 
@@ -3301,7 +3302,9 @@ function user_pass_ok($user_login, $user_pass) {
  * @since 2.3.0
  * @deprecated 3.5.0
  */
-function _save_post_hook() {}
+function _save_post_hook() {
+	_deprecated_function( __FUNCTION__, '3.5.0' );
+}
 
 /**
  * Check if the installed version of GD supports particular image type
@@ -3417,6 +3420,7 @@ function rich_edit_exists() {
  * @return int Number of topics.
  */
 function default_topic_count_text( $count ) {
+	_deprecated_function( __FUNCTION__, '3.9.0' );
 	return $count;
 }
 
@@ -4108,6 +4112,8 @@ function remove_option_whitelist( $del_options, $options = '' ) {
  * @return mixed Slashes $value
  */
 function wp_slash_strings_only( $value ) {
+	_deprecated_function( __FUNCTION__, '5.6.0', 'wp_slash()' );
+
 	return map_deep( $value, 'addslashes_strings_only' );
 }
 
@@ -4123,6 +4129,8 @@ function wp_slash_strings_only( $value ) {
  * @return mixed
  */
 function addslashes_strings_only( $value ) {
+	_deprecated_function( __FUNCTION__, '5.6.0' );
+
 	return is_string( $value ) ? addslashes( $value ) : $value;
 }
 

--- a/src/wp-includes/embed.php
+++ b/src/wp-includes/embed.php
@@ -372,7 +372,9 @@ function wp_oembed_add_discovery_links() {
  * @since 4.4.0
  * @deprecated 5.9.0 Use {@see wp_maybe_enqueue_oembed_host_js()} instead.
  */
-function wp_oembed_add_host_js() {}
+function wp_oembed_add_host_js() {
+	_deprecated_function( __FUNCTION__, '5.9.0', 'wp_maybe_enqueue_oembed_host_js()' );
+}
 
 /**
  * Enqueue the wp-embed script if the provided oEmbed HTML contains a post embed.

--- a/src/wp-includes/embed.php
+++ b/src/wp-includes/embed.php
@@ -369,12 +369,12 @@ function wp_oembed_add_discovery_links() {
  * in `wp_maybe_enqueue_oembed_host_js()` to see if `wp_oembed_add_host_js()` has not been unhooked from running at the
  * `wp_head` action.
  *
+ * Note: _deprecated_function() is not used here, as the function is still hooked to 'wp_head'.
+ *
  * @since 4.4.0
  * @deprecated 5.9.0 Use {@see wp_maybe_enqueue_oembed_host_js()} instead.
  */
-function wp_oembed_add_host_js() {
-	_deprecated_function( __FUNCTION__, '5.9.0', 'wp_maybe_enqueue_oembed_host_js()' );
-}
+function wp_oembed_add_host_js() {}
 
 /**
  * Enqueue the wp-embed script if the provided oEmbed HTML contains a post embed.

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -3253,6 +3253,8 @@ function wp_rel_nofollow( $text ) {
  * @return string HTML A Element with `rel="nofollow"`.
  */
 function wp_rel_nofollow_callback( $matches ) {
+	_deprecated_function( __FUNCTION__, '5.3.0', 'wp_rel_callback()' );
+
 	return wp_rel_callback( $matches, 'nofollow' );
 }
 

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -316,6 +316,8 @@ function wp_get_development_mode() {
  * @deprecated 5.4.0 Deprecated in favor of do_favicon().
  */
 function wp_favicon_request() {
+	_deprecated_function( __FUNCTION__, '5.4.0', 'do_favicon()' );
+
 	if ( '/favicon.ico' === $_SERVER['REQUEST_URI'] ) {
 		header( 'Content-Type: image/vnd.microsoft.icon' );
 		exit;
@@ -1206,6 +1208,8 @@ function shutdown_action_hook() {
  * @return object The cloned object.
  */
 function wp_clone( $input_object ) {
+	_deprecated_function( __FUNCTION__, '3.2.0' );
+
 	// Use parens for clone to accommodate PHP 4. See #17880.
 	return clone( $input_object );
 }

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -5687,6 +5687,8 @@ function get_all_page_ids() {
  * @return WP_Post|array|null WP_Post or array on success, null on failure.
  */
 function get_page( $page, $output = OBJECT, $filter = 'raw' ) {
+	_deprecated_function( __FUNCTION__, '3.5.0', 'get_post()' );
+
 	return get_post( $page, $output, $filter );
 }
 


### PR DESCRIPTION
Adds missing `_deprecated_function()` calls.

Trac ticket: https://core.trac.wordpress.org/ticket/41121

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
