### PR TITLE
Toolbar: Make the 'Edit site' link aware of the current template

### DIFF
--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -419,7 +419,7 @@ function wp_admin_bar_site_menu( $wp_admin_bar ) {
  *
  * @since 5.9.0
  *
- * @global string _wp_current_template_id
+ * @global string $_wp_current_template_id
  *
  * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar instance.
  */

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -419,6 +419,8 @@ function wp_admin_bar_site_menu( $wp_admin_bar ) {
  *
  * @since 5.9.0
  *
+ * @global string _wp_current_template_id
+ *
  * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar instance.
  */
 function wp_admin_bar_edit_site_menu( $wp_admin_bar ) {

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -422,6 +422,8 @@ function wp_admin_bar_site_menu( $wp_admin_bar ) {
  * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar instance.
  */
 function wp_admin_bar_edit_site_menu( $wp_admin_bar ) {
+	global $_wp_current_template_id;
+
 	// Don't show if a block theme is not activated.
 	if ( ! wp_is_block_theme() ) {
 		return;
@@ -436,7 +438,13 @@ function wp_admin_bar_edit_site_menu( $wp_admin_bar ) {
 		array(
 			'id'    => 'site-editor',
 			'title' => __( 'Edit site' ),
-			'href'  => admin_url( 'site-editor.php' ),
+			'href'  => add_query_arg(
+				array(
+					'postType' => 'wp_template',
+					'postId'   => $_wp_current_template_id,
+				),
+				admin_url( 'site-editor.php' )
+			),
 		)
 	);
 }

--- a/src/wp-includes/block-template.php
+++ b/src/wp-includes/block-template.php
@@ -32,7 +32,7 @@ function _add_template_loader_filters() {
  * @return string The path to the Site Editor template canvas file, or the fallback PHP template.
  */
 function locate_block_template( $template, $type, array $templates ) {
-	global $_wp_current_template_content;
+	global $_wp_current_template_content, $_wp_current_template_id;
 
 	if ( ! current_theme_supports( 'block-templates' ) ) {
 		return $template;
@@ -64,6 +64,8 @@ function locate_block_template( $template, $type, array $templates ) {
 	$block_template = resolve_block_template( $type, $templates, $template );
 
 	if ( $block_template ) {
+		$_wp_current_template_id = $block_template->id;
+
 		if ( empty( $block_template->content ) && is_user_logged_in() ) {
 			$_wp_current_template_content =
 			sprintf(

--- a/src/wp-includes/block-template.php
+++ b/src/wp-includes/block-template.php
@@ -25,7 +25,7 @@ function _add_template_loader_filters() {
  * @since 5.8.0
  *
  * @global string $_wp_current_template_content
- * @global string _wp_current_template_id
+ * @global string $_wp_current_template_id
  *
  * @param string   $template  Path to the template. See locate_template().
  * @param string   $type      Sanitized filename without extension.

--- a/src/wp-includes/block-template.php
+++ b/src/wp-includes/block-template.php
@@ -25,6 +25,7 @@ function _add_template_loader_filters() {
  * @since 5.8.0
  *
  * @global string $_wp_current_template_content
+ * @global string _wp_current_template_id
  *
  * @param string   $template  Path to the template. See locate_template().
  * @param string   $type      Sanitized filename without extension.


### PR DESCRIPTION
PR makes the 'Edit site' link in the toolbar contextually aware of the current template.

## How

Introduces a new global `$_wp_current_template_id` that stores the current template ID during the template resolution.

We can't use the existing `$_wp_current_template_content` global as it only stores template contents.

## Refs

Gutenberg issue: https://github.com/WordPress/gutenberg/issues/37850
Trac ticket: https://core.trac.wordpress.org/ticket/58746
