### PR TITLE
Backport: Navigation: Remove one preloaded endpoint

### DIFF
--- a/src/wp-admin/site-editor.php
+++ b/src/wp-admin/site-editor.php
@@ -100,22 +100,7 @@ $preload_paths = array(
 				'per_page'  => 100,
 				'order'     => 'desc',
 				'orderby'   => 'date',
-				'_locale'   => 'user',
 				// array indices are required to avoid query being encoded and not matching in cache.
-				'status[0]' => 'publish',
-				'status[1]' => 'draft',
-			),
-			$navigation_rest_route
-		),
-		'GET',
-	),
-	$preload_paths[] = array(
-		add_query_arg(
-			array(
-				'context'   => 'edit',
-				'per_page'  => 100,
-				'order'     => 'desc',
-				'orderby'   => 'date',
 				'status[0]' => 'publish',
 				'status[1]' => 'draft',
 			),


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This backports https://github.com/WordPress/gutenberg/pull/52115 to core.

We don't need the _locale param for preloading to work, which means we can remove one of the preloaded endpoints.

Trac ticket: https://core.trac.wordpress.org/ticket/58749

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
