### PR TITLE
Backport: opt out for Navigation fallback creation

### DIFF
--- a/src/wp-includes/class-wp-navigation-fallback.php
+++ b/src/wp-includes/class-wp-navigation-fallback.php
@@ -26,9 +26,18 @@ class WP_Navigation_Fallback {
 	 */
 	public static function get_fallback() {
 
+		/**
+		 * Filters whether or not a fallback should be created.
+		 *
+		 * @since 6.3.0
+		 *
+		 * @param bool Whether or not to create a fallback.
+		 */
+		$should_create_fallback = apply_filters( 'wp_navigation_should_create_fallback', true );
+
 		$fallback = static::get_most_recently_published_navigation();
 
-		if ( $fallback ) {
+		if ( $fallback || ! $should_create_fallback ) {
 			return $fallback;
 		}
 

--- a/src/wp-includes/class-wp-navigation-fallback.php
+++ b/src/wp-includes/class-wp-navigation-fallback.php
@@ -31,7 +31,7 @@ class WP_Navigation_Fallback {
 		 *
 		 * @since 6.3.0
 		 *
-		 * @param bool Whether or not to create a fallback.
+		 * @param bool Whether to create a fallback navigation menu. Default true.
 		 */
 		$should_create_fallback = apply_filters( 'wp_navigation_should_create_fallback', true );
 

--- a/tests/phpunit/tests/editor/navigation-fallback.php
+++ b/tests/phpunit/tests/editor/navigation-fallback.php
@@ -57,12 +57,12 @@ class WP_Navigation_Fallback_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket 58557
+	 * @ticket 58750
 	 * @covers WP_REST_Navigation_Fallback_Controller::get_fallback
 	 */
 	public function test_should_not_automatically_create_fallback_if_filter_is_falsey() {
 
-		add_filter( 'gutenberg_navigation_should_create_fallback', '__return_false' );
+		add_filter( 'wp_navigation_should_create_fallback', '__return_false' );
 
 		$data = Gutenberg_Navigation_Fallback::get_fallback();
 

--- a/tests/phpunit/tests/editor/navigation-fallback.php
+++ b/tests/phpunit/tests/editor/navigation-fallback.php
@@ -64,7 +64,7 @@ class WP_Navigation_Fallback_Test extends WP_UnitTestCase {
 
 		add_filter( 'wp_navigation_should_create_fallback', '__return_false' );
 
-		$data = Gutenberg_Navigation_Fallback::get_fallback();
+		$data = WP_Navigation_Fallback::get_fallback();
 
 		$this->assertEmpty( $data );
 

--- a/tests/phpunit/tests/editor/navigation-fallback.php
+++ b/tests/phpunit/tests/editor/navigation-fallback.php
@@ -58,6 +58,7 @@ class WP_Navigation_Fallback_Test extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 58750
+	 *
 	 * @covers WP_REST_Navigation_Fallback_Controller::get_fallback
 	 */
 	public function test_should_not_automatically_create_fallback_if_filter_is_falsey() {

--- a/tests/phpunit/tests/editor/navigation-fallback.php
+++ b/tests/phpunit/tests/editor/navigation-fallback.php
@@ -72,7 +72,7 @@ class WP_Navigation_Fallback_Test extends WP_UnitTestCase {
 
 		$this->assertCount( 0, $navs_in_db, 'The fallback Navigation post should not have been created.' );
 
-		remove_filter( 'gutenberg_navigation_should_create_fallback', '__return_false' );
+		remove_filter( 'wp_navigation_should_create_fallback', '__return_false' );
 	}
 
 	/**

--- a/tests/phpunit/tests/editor/navigation-fallback.php
+++ b/tests/phpunit/tests/editor/navigation-fallback.php
@@ -60,6 +60,25 @@ class WP_Navigation_Fallback_Test extends WP_UnitTestCase {
 	 * @ticket 58557
 	 * @covers WP_REST_Navigation_Fallback_Controller::get_fallback
 	 */
+	public function test_should_not_automatically_create_fallback_if_filter_is_falsey() {
+
+		add_filter( 'gutenberg_navigation_should_create_fallback', '__return_false' );
+
+		$data = Gutenberg_Navigation_Fallback::get_fallback();
+
+		$this->assertEmpty( $data );
+
+		$navs_in_db = $this->get_navigations_in_database();
+
+		$this->assertCount( 0, $navs_in_db, 'The fallback Navigation post should not have been created.' );
+
+		remove_filter( 'gutenberg_navigation_should_create_fallback', '__return_false' );
+	}
+
+	/**
+	 * @ticket 58557
+	 * @covers WP_REST_Navigation_Fallback_Controller::get_fallback
+	 */
 	public function test_should_return_a_default_fallback_navigation_menu_with_no_blocks_if_page_list_block_is_not_registered() {
 
 		$original_page_list_block = WP_Block_Type_Registry::get_instance()->get_registered( 'core/page-list' );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Updates original backport from https://core.trac.wordpress.org/ticket/58557 to also allow developers to opt out of the auto-creation of the fallback.

Why? Because if we automatically create something (even if it requires interaction with the WP site or editor) we should allow folks to opt out of that.

Trac ticket: https://core.trac.wordpress.org/ticket/58750

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
