### PR TITLE
Invalidate `wp_theme_has_theme_json()` cache when stylesheet/theme directories change

### DIFF
--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -357,15 +357,15 @@ function wp_theme_has_theme_json() {
 	$stylesheet_directory = get_stylesheet_directory();
 	$template_directory   = get_template_directory();
 
-	// Make sure that the cached $theme_has_support value is reset the theme changes.
-	if ( $prev_stylesheet_directory && $stylesheet_directory !== $prev_stylesheet_directory ) {
+	// Make sure that the cached $theme_has_support value is reset when the theme changes.
+	if ( null !== $theme_has_support && (
+		$stylesheet_directory !== $prev_stylesheet_directory ||
+		$template_directory !== $prev_template_directory
+	) ) {
 		$theme_has_support = null;
 	}
 	$prev_stylesheet_directory = $stylesheet_directory;
-	if ( $prev_template_directory && $template_directory !== $prev_template_directory ) {
-		$theme_has_support = null;
-	}
-	$prev_template_directory = $template_directory;
+	$prev_template_directory   = $template_directory;
 
 	if (
 		null !== $theme_has_support &&

--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -350,7 +350,22 @@ function wp_add_global_styles_for_blocks() {
  * @return bool Returns true if theme or its parent has a theme.json file, false otherwise.
  */
 function wp_theme_has_theme_json() {
-	static $theme_has_support = null;
+	static $theme_has_support         = null;
+	static $prev_stylesheet_directory = null;
+	static $prev_template_directory   = null;
+
+	$stylesheet_directory = get_stylesheet_directory();
+	$template_directory   = get_template_directory();
+
+	// Make sure that the cached $theme_has_support value is reset the theme changes.
+	if ( $prev_stylesheet_directory && $stylesheet_directory !== $prev_stylesheet_directory ) {
+		$theme_has_support = null;
+	}
+	$prev_stylesheet_directory = $stylesheet_directory;
+	if ( $prev_template_directory && $template_directory !== $prev_template_directory ) {
+		$theme_has_support = null;
+	}
+	$prev_template_directory = $template_directory;
 
 	if (
 		null !== $theme_has_support &&
@@ -358,18 +373,10 @@ function wp_theme_has_theme_json() {
 		 * Ignore static cache when the development mode is set to 'theme', to avoid interfering with
 		 * the theme developer's workflow.
 		 */
-		wp_get_development_mode() !== 'theme' &&
-		/*
-		 * Ignore cache when automated test suites are running. Why? To ensure
-		 * the static cache is reset between each test.
-		 */
-		! ( defined( 'WP_RUN_CORE_TESTS' ) && WP_RUN_CORE_TESTS )
+		wp_get_development_mode() !== 'theme'
 	) {
 		return $theme_has_support;
 	}
-
-	$stylesheet_directory = get_stylesheet_directory();
-	$template_directory   = get_template_directory();
 
 	// This is the same as get_theme_file_path(), which isn't available in load-styles.php context
 	if ( $stylesheet_directory !== $template_directory && file_exists( $stylesheet_directory . '/theme.json' ) ) {


### PR DESCRIPTION

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/58758

Core commit draft:

```
Themes: Invalidate `wp_theme_has_theme_json()` cache when stylesheet/template directories change.

Props westonruter, flixos90, thelovekesh.
Fixes #58758.
```

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
