### PR TITLE
Ensure WP_UnitTestCase foundation resets main query global

### DIFF
--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -142,15 +142,18 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 	 * After a test method runs, resets any state in WordPress the test method might have changed.
 	 */
 	public function tear_down() {
-		global $wpdb, $wp_query, $wp;
+		global $wpdb, $wp_the_query, $wp_query, $wp;
 		$wpdb->query( 'ROLLBACK' );
 		if ( is_multisite() ) {
 			while ( ms_is_switched() ) {
 				restore_current_blog();
 			}
 		}
-		$wp_query = new WP_Query();
-		$wp       = new WP();
+
+		// Reset query, main query, and WP globals similar to wp-settings.php.
+		$wp_the_query = new WP_Query();
+		$wp_query     = $wp_the_query;
+		$wp           = new WP();
 
 		// Reset globals related to the post loop and `setup_postdata()`.
 		$post_globals = array( 'post', 'id', 'authordata', 'currentday', 'currentmonth', 'page', 'pages', 'multipage', 'more', 'numpages' );

--- a/tests/phpunit/tests/query/isTerm.php
+++ b/tests/phpunit/tests/query/isTerm.php
@@ -25,9 +25,6 @@ class Tests_Query_IsTerm extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		$GLOBALS['wp_the_query'] = new WP_Query();
-		$GLOBALS['wp_query']     = $GLOBALS['wp_the_query'];
-
 		$this->set_permalink_structure( '/%year%/%monthnum%/%day%/%postname%/' );
 
 		create_initial_taxonomies();


### PR DESCRIPTION
This PR fixes a problem in the WordPress PHPUnit test suite that was initially spotted in https://github.com/WordPress/wordpress-develop/pull/4799#issuecomment-1629114720: The test base class has not been resetting the main query global `$wp_the_query`, which results in unexpected test behavior where some tests can pollute the global scope for subsequent tests. Since the WordPress PHPUnit test suite generally resets crucial globals related to the post loop, core developers should be able to expect that the `$wp_the_query` global is covered by that mechanism as well.

Similar to how `wp-settings.php` sets them up for the actual WordPress bootstrap process, the `$wp_the_query` and `$wp_query` global should have the same values / point to the same `WP_Query` instance before each test run.

Additionally, the PR removes one existing workaround in `tests/phpunit/tests/query/isTerm.php` that was only relevant due to the bug that this fixes, but with the fix is no longer needed.

Trac ticket: https://core.trac.wordpress.org/ticket/58776

### Test instructions
* Possibly the only tests that modify the `$wp_the_query` global are in `tests/phpunit/tests/media.php`. For example, consider running the tests associated with ticket 58235 which encompasses several of those tests.
* Add the following "debugging" code to the top of the `WP_UnitTestCase_Base::set_up()` method:
```php
var_dump( isset( $GLOBALS['wp_the_query'] ) );
if ( isset( $GLOBALS['wp_the_query'] ) ) {
	var_dump( $GLOBALS['wp_the_query'] === $GLOBALS['wp_query'] );
}
```
* Then run a set of relevant tests, e.g. via `npm run test:php -- --group=58235`.
* Without this PR, you'll see in your CLI logs that at the beginning you get both outputs be `bool(true)`, but on subsequent runs they'll be pairs of `bool(true)` and `bool(false)`, which shows that one of the globals (`$wp_the_query`) gets polluted between the tests.
* With this PR, all output will be `bool(true)`, showing that the globals now behave consistently between tests.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
