### PR TITLE
Build/Test Tools: Fix 404s in Cache-Control headers directives E2E test.

### DIFF
--- a/tests/e2e/specs/cache-control-headers-directives.test.js
+++ b/tests/e2e/specs/cache-control-headers-directives.test.js
@@ -1,6 +1,7 @@
 import {
 	visitAdminPage,
 	createNewPost,
+	publishPost,
 	trashAllPosts,
 	createURL,
 	logout,
@@ -13,10 +14,8 @@ describe( 'Cache Control header directives', () => {
 	} );
 
 	it( 'No private directive present in cache control when user not logged in.', async () => {
-		await createNewPost( {
-			title: 'Hello World',
-			post_status: 'publish',
-		} );
+		await createNewPost( { title: 'Hello World' } );
+		await publishPost();
 		await logout();
 
 		const response = await page.goto( createURL( '/hello-world/' ) );

--- a/tests/e2e/specs/cache-control-headers-directives.test.js
+++ b/tests/e2e/specs/cache-control-headers-directives.test.js
@@ -26,7 +26,7 @@ describe( 'Cache Control header directives', () => {
 	} );
 
 	it( 'Private directive header present in cache control when logged in.', async () => {
-		await visitAdminPage( '/wp-admin' );
+		await visitAdminPage( '/' );
 
 		const response = await page.goto( createURL( '/wp-admin' ) );
 		const responseHeaders = response.headers();


### PR DESCRIPTION
Previously, an attempt to view a new post as a logged-out user and an attempt to visit an admin page resulted in 404s.

This change ensures that both URLs are reachable.

Trac ticket: https://core.trac.wordpress.org/ticket/58777
