### PR TITLE
Update Pattern edit_item string to Edit Block Pattern

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -287,7 +287,7 @@ function create_initial_post_types() {
 				'add_new'                  => _x( 'Add New', 'Pattern' ),
 				'add_new_item'             => __( 'Add new Pattern' ),
 				'new_item'                 => __( 'New Pattern' ),
-				'edit_item'                => __( 'Edit Pattern' ),
+				'edit_item'                => __( 'Edit Block Pattern' ),
 				'view_item'                => __( 'View Pattern' ),
 				'view_items'               => __( 'View Patterns' ),
 				'all_items'                => __( 'All Patterns' ),


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/58716

Update the Pattern post type's `edit_item` label to be `Edit Block Pattern` instead of `Edit Pattern` to resolve an edge case in Google Chrome where `Edit Pattern` causes the browser to think that the page is in German, and therefore displays the translation popup.

After some digging, I couldn't work out why exactly Google Chrome thinks that the page is in German based on the string `Edit Pattern`, but my suspicion is that the server-rendered view of the block editor doesn't involve very many words, which could potentially contribute to it not recognising the language correctly (it appears to ignore the `lang` attribute set on the page). Updating to `Edit Block Pattern` appears to resolve the issue.

| Before | After |
| --- | --- |
| <img width="816" alt="image" src="https://github.com/WordPress/wordpress-develop/assets/14988353/c4de6bed-8637-42fd-b068-c21c47f39f80"> | <img width="813" alt="image" src="https://github.com/WordPress/wordpress-develop/assets/14988353/e113fab3-9418-44a8-82e7-564dc22817cc"> |

## Testing instructions

1. Go to http://localhost:8889/wp-admin/edit.php?post_type=wp_block
2. Edit an existing pattern (if you don't have any patterns, you'll need to add one first, then go back to the list and click Edit)
3. With this PR applied, Google Chrome should no longer prompt to translate the page when the editor loads

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
