### PR TITLE
#58784 - Making it clearer for end users where the media editor is now

### DIFF
--- a/src/wp-includes/media-template.php
+++ b/src/wp-includes/media-template.php
@@ -557,7 +557,7 @@ function wp_print_media_templates() {
 					<# if ( data.link ) { #>
 						<span class="links-separator">|</span>
 					<# } #>
-					<a href="{{ data.editLink }}"><?php _e( 'Edit more details' ); ?></a>
+					<a href="{{ data.editLink }}"><?php _e( 'Edit attachment and attachment details' ); ?></a>
 				<# } #>
 				<# if ( data.can.save && data.link ) { #>
 					<span class="links-separator">|</span>


### PR DESCRIPTION
In this PR, I change a text line since in WP 6.3 the media editor moved and now it's not too clear for end users that it's underneath one button. So, I suggest changing that button to another bit of text so end users can find it again :)

Trac ticket: [#58784](https://core.trac.wordpress.org/ticket/58784)

