### PR TITLE
Lazily load Duotone settings only when needed. 

### DIFF
--- a/src/wp-includes/block-supports/duotone.php
+++ b/src/wp-includes/block-supports/duotone.php
@@ -41,7 +41,7 @@ WP_Block_Supports::get_instance()->register(
 );
 
 // Add classnames to blocks using duotone support.
-add_filter( 'render_block', array( 'WP_Duotone', 'render_duotone_support' ), 10, 2 );
+add_filter( 'render_block', array( 'WP_Duotone', 'render_duotone_support' ), 10, 3 );
 
 // Enqueue styles.
 // Block styles (core-block-supports-inline-css) before the style engine (wp_enqueue_stored_styles).

--- a/src/wp-includes/block-supports/duotone.php
+++ b/src/wp-includes/block-supports/duotone.php
@@ -40,10 +40,6 @@ WP_Block_Supports::get_instance()->register(
 	)
 );
 
-// Set up metadata prior to rendering any blocks.
-add_action( 'wp_loaded', array( 'WP_Duotone', 'set_global_styles_presets' ), 10 );
-add_action( 'wp_loaded', array( 'WP_Duotone', 'set_global_style_block_names' ), 10 );
-
 // Add classnames to blocks using duotone support.
 add_filter( 'render_block', array( 'WP_Duotone', 'render_duotone_support' ), 10, 2 );
 

--- a/src/wp-includes/class-wp-duotone.php
+++ b/src/wp-includes/class-wp-duotone.php
@@ -997,18 +997,19 @@ class WP_Duotone {
 	 * @return array An array of global styles presets, keyed on the filter ID.
 	 */
 	private static function get_all_global_styles_presets() {
-		if ( ! isset( self::$global_styles_presets ) ) {
-			// Get the per block settings from the theme.json.
-			$tree              = wp_get_global_settings();
-			$presets_by_origin = _wp_array_get( $tree, array( 'color', 'duotone' ), array() );
+		if ( isset( self::$global_styles_presets ) ) {
+			return self::$global_styles_presets;
+		}
+		// Get the per block settings from the theme.json.
+		$tree              = wp_get_global_settings();
+		$presets_by_origin = _wp_array_get( $tree, array( 'color', 'duotone' ), array() );
 
-			self::$global_styles_presets = array();
-			foreach ( $presets_by_origin as $presets ) {
-				foreach ( $presets as $preset ) {
-					$filter_id = self::get_filter_id( _wp_to_kebab_case( $preset['slug'] ) );
+		self::$global_styles_presets = array();
+		foreach ( $presets_by_origin as $presets ) {
+			foreach ( $presets as $preset ) {
+				$filter_id = self::get_filter_id( _wp_to_kebab_case( $preset['slug'] ) );
 
-					self::$global_styles_presets[ $filter_id ] = $preset;
-				}
+				self::$global_styles_presets[ $filter_id ] = $preset;
 			}
 		}
 
@@ -1026,33 +1027,34 @@ class WP_Duotone {
 	 * @return string[] An array of global style block slugs, keyed on the block name.
 	 */
 	private static function get_all_global_style_block_names() {
-		if ( ! isset( self::$global_styles_block_names ) ) {
-			// Get the per block settings from the theme.json.
-			$tree        = WP_Theme_JSON_Resolver::get_merged_data();
-			$block_nodes = $tree->get_styles_block_nodes();
-			$theme_json  = $tree->get_raw_data();
+		if ( isset( self::$global_styles_block_names ) ) {
+			return self::$global_styles_block_names;
+		}
+		// Get the per block settings from the theme.json.
+		$tree        = WP_Theme_JSON_Resolver::get_merged_data();
+		$block_nodes = $tree->get_styles_block_nodes();
+		$theme_json  = $tree->get_raw_data();
 
-			self::$global_styles_block_names = array();
+		self::$global_styles_block_names = array();
 
-			foreach ( $block_nodes as $block_node ) {
-				// This block definition doesn't include any duotone settings. Skip it.
-				if ( empty( $block_node['duotone'] ) ) {
-					continue;
-				}
+		foreach ( $block_nodes as $block_node ) {
+			// This block definition doesn't include any duotone settings. Skip it.
+			if ( empty( $block_node['duotone'] ) ) {
+				continue;
+			}
 
-				// Value looks like this: 'var(--wp--preset--duotone--blue-orange)' or 'var:preset|duotone|blue-orange'.
-				$duotone_attr_path = array_merge( $block_node['path'], array( 'filter', 'duotone' ) );
-				$duotone_attr      = _wp_array_get( $theme_json, $duotone_attr_path, array() );
+			// Value looks like this: 'var(--wp--preset--duotone--blue-orange)' or 'var:preset|duotone|blue-orange'.
+			$duotone_attr_path = array_merge( $block_node['path'], array( 'filter', 'duotone' ) );
+			$duotone_attr      = _wp_array_get( $theme_json, $duotone_attr_path, array() );
 
-				if ( empty( $duotone_attr ) ) {
-					continue;
-				}
-				// If it has a duotone filter preset, save the block name and the preset slug.
-				$slug = self::get_slug_from_attribute( $duotone_attr );
+			if ( empty( $duotone_attr ) ) {
+				continue;
+			}
+			// If it has a duotone filter preset, save the block name and the preset slug.
+			$slug = self::get_slug_from_attribute( $duotone_attr );
 
-				if ( $slug && $slug !== $duotone_attr ) {
-					self::$global_styles_block_names[ $block_node['name'] ] = $slug;
-				}
+			if ( $slug && $slug !== $duotone_attr ) {
+				self::$global_styles_block_names[ $block_node['name'] ] = $slug;
 			}
 		}
 		return self::$global_styles_block_names;

--- a/src/wp-includes/class-wp-duotone.php
+++ b/src/wp-includes/class-wp-duotone.php
@@ -953,6 +953,10 @@ class WP_Duotone {
 	 * @return string The CSS selector or null if there is no support.
 	 */
 	private static function get_selector( $block_type ) {
+		if ( ! ( $block_type instanceof WP_Block_Type ) ) {
+			return null;
+		}
+
 		/*
 		 * Backwards compatibility with `supports.color.__experimentalDuotone`
 		 * is provided via the `block_type_metadata_settings` filter. If

--- a/src/wp-includes/class-wp-duotone.php
+++ b/src/wp-includes/class-wp-duotone.php
@@ -54,7 +54,7 @@ class WP_Duotone {
 	 *
 	 * @var array
 	 */
-	private static $global_styles_block_names = array();
+	private static $global_styles_block_names;
 
 	/**
 	 * An array of duotone filter data from global, theme, and custom presets.
@@ -78,7 +78,7 @@ class WP_Duotone {
 	 *
 	 * @var array
 	 */
-	private static $global_styles_presets = array();
+	private static $global_styles_presets;
 
 	/**
 	 * All of the duotone filter data from presets for CSS custom properties on
@@ -575,7 +575,7 @@ class WP_Duotone {
 		$slug      = self::get_slug_from_attribute( $duotone_attr );
 		$filter_id = self::get_filter_id( $slug );
 
-		return array_key_exists( $filter_id, self::$global_styles_presets );
+		return array_key_exists( $filter_id, self::_get_global_styles_presets() );
 	}
 
 	/**
@@ -897,7 +897,8 @@ class WP_Duotone {
 	 * @param string $filter_value     The filter CSS value. e.g. 'url(#wp-duotone-blue-orange)' or 'unset'.
 	 */
 	private static function enqueue_global_styles_preset( $filter_id, $duotone_selector, $filter_value ) {
-		if ( ! array_key_exists( $filter_id, self::$global_styles_presets ) ) {
+		$global_styles_presets = self::_get_global_styles_presets();
+		if ( ! array_key_exists( $filter_id, $global_styles_presets ) ) {
 			$error_message = sprintf(
 				/* translators: %s: duotone filter ID */
 				__( 'The duotone id "%s" is not registered in theme.json settings' ),
@@ -906,8 +907,8 @@ class WP_Duotone {
 			_doing_it_wrong( __METHOD__, $error_message, '6.3.0' );
 			return;
 		}
-		self::$used_global_styles_presets[ $filter_id ] = self::$global_styles_presets[ $filter_id ];
-		self::enqueue_custom_filter( $filter_id, $duotone_selector, $filter_value, self::$global_styles_presets[ $filter_id ] );
+		self::$used_global_styles_presets[ $filter_id ] = $global_styles_presets[ $filter_id ];
+		self::enqueue_custom_filter( $filter_id, $duotone_selector, $filter_value, $global_styles_presets[ $filter_id ] );
 	}
 
 	/**
@@ -1013,6 +1014,21 @@ class WP_Duotone {
 	}
 
 	/**
+	 * Get global styles presets.
+	 *
+	 * @since 6.3.0
+	 *
+	 * @return array
+	 */
+	private static function _get_global_styles_presets() {
+		if ( ! isset( self::$global_styles_presets ) ) {
+			self::set_global_styles_presets();
+		}
+
+		return self::$global_styles_presets;
+	}
+
+	/**
 	 * Scrape all block names from global styles and store in self::$global_styles_block_names.
 	 *
 	 * Used in conjunction with self::render_duotone_support to output the
@@ -1049,6 +1065,20 @@ class WP_Duotone {
 	}
 
 	/**
+	 * Get global style block names.
+	 *
+	 * @since 6.3.0
+	 *
+	 * @return array
+	 */
+	private static function _get_global_style_block_names() {
+		if ( ! isset( self::$global_styles_block_names ) ) {
+			self::set_global_style_block_names();
+		}
+		return self::$global_styles_block_names;
+	}
+
+	/**
 	 * Render out the duotone CSS styles and SVG.
 	 *
 	 * The hooks self::set_global_style_block_names and self::set_global_styles_presets
@@ -1063,9 +1093,11 @@ class WP_Duotone {
 	public static function render_duotone_support( $block_content, $block ) {
 		$duotone_selector = self::get_selector( $block['blockName'] );
 
+		$global_styles_block_names = self::_get_global_style_block_names();
+
 		// The block should have a duotone attribute or have duotone defined in its theme.json to be processed.
 		$has_duotone_attribute     = isset( $block['attrs']['style']['color']['duotone'] );
-		$has_global_styles_duotone = array_key_exists( $block['blockName'], self::$global_styles_block_names );
+		$has_global_styles_duotone = array_key_exists( $block['blockName'], $global_styles_block_names );
 
 		if (
 			empty( $block_content ) ||
@@ -1119,7 +1151,7 @@ class WP_Duotone {
 				self::enqueue_custom_filter( $filter_id, $duotone_selector, $filter_value, $filter_data );
 			}
 		} elseif ( $has_global_styles_duotone ) {
-			$slug         = self::$global_styles_block_names[ $block['blockName'] ]; // e.g. 'blue-orange'.
+			$slug         = $global_styles_block_names[ $block['blockName'] ]; // e.g. 'blue-orange'.
 			$filter_id    = self::get_filter_id( $slug ); // e.g. 'wp-duotone-filter-blue-orange'.
 			$filter_value = self::get_css_var( $slug ); // e.g. 'var(--wp--preset--duotone--blue-orange)'.
 
@@ -1198,14 +1230,15 @@ class WP_Duotone {
 	 * @return array The editor settings with duotone SVGs and CSS custom properties.
 	 */
 	public static function add_editor_settings( $settings ) {
-		if ( ! empty( self::$global_styles_presets ) ) {
+		$global_styles_presets = self::_get_global_styles_presets();
+		if ( ! empty( $global_styles_presets ) ) {
 			if ( ! isset( $settings['styles'] ) ) {
 				$settings['styles'] = array();
 			}
 
 			$settings['styles'][] = array(
 				// For the editor we can add all of the presets by default.
-				'assets'         => self::get_svg_definitions( self::$global_styles_presets ),
+				'assets'         => self::get_svg_definitions( $global_styles_presets ),
 				// The 'svgs' type is new in 6.3 and requires the corresponding JS changes in the EditorStyles component to work.
 				'__unstableType' => 'svgs',
 				// These styles not generated by global styles, so this must be false or they will be stripped out in wp_get_block_editor_settings.
@@ -1214,7 +1247,7 @@ class WP_Duotone {
 
 			$settings['styles'][] = array(
 				// For the editor we can add all of the presets by default.
-				'css'            => self::get_global_styles_presets( self::$global_styles_presets ),
+				'css'            => self::get_global_styles_presets( $global_styles_presets ),
 				// This must be set and must be something other than 'theme' or they will be stripped out in the post editor <Editor> component.
 				'__unstableType' => 'presets',
 				// These styles are no longer generated by global styles, so this must be false or they will be stripped out in wp_get_block_editor_settings.

--- a/src/wp-includes/class-wp-duotone.php
+++ b/src/wp-includes/class-wp-duotone.php
@@ -946,8 +946,9 @@ class WP_Duotone {
 	 *
 	 * @internal
 	 * @since 6.3.0
+	 *
 	 * @param WP_Block_Type $block_type Block type to check for support.
-	 * @return string The CSS selector or null if there is no support.
+	 * @return string|null The CSS selector or null if there is no support.
 	 */
 	private static function get_selector( $block_type ) {
 		if ( ! ( $block_type instanceof WP_Block_Type ) ) {

--- a/src/wp-includes/class-wp-duotone.php
+++ b/src/wp-includes/class-wp-duotone.php
@@ -575,7 +575,7 @@ class WP_Duotone {
 		$slug      = self::get_slug_from_attribute( $duotone_attr );
 		$filter_id = self::get_filter_id( $slug );
 
-		return array_key_exists( $filter_id, self::_get_global_styles_presets() );
+		return array_key_exists( $filter_id, self::get_all_global_styles_presets() );
 	}
 
 	/**
@@ -897,7 +897,7 @@ class WP_Duotone {
 	 * @param string $filter_value     The filter CSS value. e.g. 'url(#wp-duotone-blue-orange)' or 'unset'.
 	 */
 	private static function enqueue_global_styles_preset( $filter_id, $duotone_selector, $filter_value ) {
-		$global_styles_presets = self::_get_global_styles_presets();
+		$global_styles_presets = self::get_all_global_styles_presets();
 		if ( ! array_key_exists( $filter_id, $global_styles_presets ) ) {
 			$error_message = sprintf(
 				/* translators: %s: duotone filter ID */
@@ -999,7 +999,7 @@ class WP_Duotone {
 	 *
 	 * @since 6.3.0
 	 */
-	public static function set_global_styles_presets() {
+	public static function load_global_styles_presets() {
 		// Get the per block settings from the theme.json.
 		$tree              = wp_get_global_settings();
 		$presets_by_origin = _wp_array_get( $tree, array( 'color', 'duotone' ), array() );
@@ -1021,9 +1021,9 @@ class WP_Duotone {
 	 *
 	 * @return array
 	 */
-	private static function _get_global_styles_presets() {
+	private static function get_all_global_styles_presets() {
 		if ( ! isset( self::$global_styles_presets ) ) {
-			self::set_global_styles_presets();
+			self::load_global_styles_presets();
 		}
 
 		return self::$global_styles_presets;
@@ -1037,7 +1037,7 @@ class WP_Duotone {
 	 *
 	 * @since 6.3.0
 	 */
-	public static function set_global_style_block_names() {
+	public static function load_global_style_block_names() {
 		// Get the per block settings from the theme.json.
 		$tree        = WP_Theme_JSON_Resolver::get_merged_data();
 		$block_nodes = $tree->get_styles_block_nodes();
@@ -1074,9 +1074,9 @@ class WP_Duotone {
 	 *
 	 * @return array
 	 */
-	private static function _get_global_style_block_names() {
+	private static function get_all_global_style_block_names() {
 		if ( ! isset( self::$global_styles_block_names ) ) {
-			self::set_global_style_block_names();
+			self::load_global_style_block_names();
 		}
 		return self::$global_styles_block_names;
 	}
@@ -1103,7 +1103,7 @@ class WP_Duotone {
 			return $block_content;
 		}
 
-		$global_styles_block_names = self::_get_global_style_block_names();
+		$global_styles_block_names = self::get_all_global_style_block_names();
 
 		// The block should have a duotone attribute or have duotone defined in its theme.json to be processed.
 		$has_duotone_attribute     = isset( $block['attrs']['style']['color']['duotone'] );
@@ -1236,7 +1236,7 @@ class WP_Duotone {
 	 * @return array The editor settings with duotone SVGs and CSS custom properties.
 	 */
 	public static function add_editor_settings( $settings ) {
-		$global_styles_presets = self::_get_global_styles_presets();
+		$global_styles_presets = self::get_all_global_styles_presets();
 		if ( ! empty( $global_styles_presets ) ) {
 			if ( ! isset( $settings['styles'] ) ) {
 				$settings['styles'] = array();

--- a/src/wp-includes/class-wp-duotone.php
+++ b/src/wp-includes/class-wp-duotone.php
@@ -921,6 +921,10 @@ class WP_Duotone {
 	 * @param WP_Block_Type $block_type Block Type.
 	 */
 	public static function register_duotone_support( $block_type ) {
+		/*
+		 * Previous `color.__experimentalDuotone` support flag is migrated
+		 * to `filter.duotone` via `block_type_metadata_settings` filter.
+		 */
 		if ( block_has_support( $block_type, array( 'filter', 'duotone' ) ) ) {
 			if ( ! $block_type->attributes ) {
 				$block_type->attributes = array();

--- a/src/wp-includes/class-wp-duotone.php
+++ b/src/wp-includes/class-wp-duotone.php
@@ -940,7 +940,7 @@ class WP_Duotone {
 	 * This handles selectors defined in `color.__experimentalDuotone` support
 	 * if `filter.duotone` support is not defined.
 	 *
-	 * @param string $block_name The block name.
+	 * @param WP_Block_Type $block_type  Block type to check for support.
 	 *
 	 * @internal
 	 *
@@ -948,13 +948,7 @@ class WP_Duotone {
 	 *
 	 * @return string The CSS selector or null if there is no support.
 	 */
-	private static function get_selector( $block_name ) {
-		$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block_name );
-
-		if ( ! $block_type ) {
-			return null;
-		}
-
+	private static function get_selector( $block_type ) {
 		/*
 		 * Backwards compatibility with `supports.color.__experimentalDuotone`
 		 * is provided via the `block_type_metadata_settings` filter. If
@@ -1084,13 +1078,14 @@ class WP_Duotone {
 	 *
 	 * @param  string $block_content Rendered block content.
 	 * @param  array  $block         Block object.
+	 * @param  WP_Block $wp_block      The block instance.
 	 * @return string                Filtered block content.
 	 */
-	public static function render_duotone_support( $block_content, $block ) {
+	public static function render_duotone_support( $block_content, $block, $wp_block ) {
 		if ( empty( $block_content ) || ! $block['blockName'] ) {
 			return $block_content;
 		}
-		$duotone_selector = self::get_selector( $block['blockName'] );
+		$duotone_selector = self::get_selector( $wp_block->block_type );
 
 		if ( ! $duotone_selector ) {
 			return $block_content;

--- a/src/wp-includes/class-wp-duotone.php
+++ b/src/wp-includes/class-wp-duotone.php
@@ -925,7 +925,7 @@ class WP_Duotone {
 		 * Previous `color.__experimentalDuotone` support flag is migrated
 		 * to `filter.duotone` via `block_type_metadata_settings` filter.
 		 */
-		if ( block_has_support( $block_type, array( 'filter', 'duotone' ) ) ) {
+		if ( block_has_support( $block_type, array( 'filter', 'duotone' ), null ) ) {
 			if ( ! $block_type->attributes ) {
 				$block_type->attributes = array();
 			}

--- a/src/wp-includes/class-wp-duotone.php
+++ b/src/wp-includes/class-wp-duotone.php
@@ -1078,7 +1078,7 @@ class WP_Duotone {
 	 *
 	 * @param  string $block_content Rendered block content.
 	 * @param  array  $block         Block object.
-	 * @param  WP_Block $wp_block      The block instance.
+	 * @param  WP_Block $wp_block    The block instance.
 	 * @return string                Filtered block content.
 	 */
 	public static function render_duotone_support( $block_content, $block, $wp_block ) {

--- a/src/wp-includes/class-wp-duotone.php
+++ b/src/wp-includes/class-wp-duotone.php
@@ -940,7 +940,7 @@ class WP_Duotone {
 	 * This handles selectors defined in `color.__experimentalDuotone` support
 	 * if `filter.duotone` support is not defined.
 	 *
-	 * @param WP_Block_Type $block_type  Block type to check for support.
+	 * @param WP_Block_Type $block_type Block type to check for support.
 	 *
 	 * @internal
 	 *

--- a/src/wp-includes/class-wp-duotone.php
+++ b/src/wp-includes/class-wp-duotone.php
@@ -989,32 +989,23 @@ class WP_Duotone {
 	 * use duotone preset filters.
 	 *
 	 * @since 6.3.0
-	 */
-	public static function load_global_styles_presets() {
-		// Get the per block settings from the theme.json.
-		$tree              = wp_get_global_settings();
-		$presets_by_origin = _wp_array_get( $tree, array( 'color', 'duotone' ), array() );
-
-		self::$global_styles_presets = array();
-		foreach ( $presets_by_origin as $presets ) {
-			foreach ( $presets as $preset ) {
-				$filter_id = self::get_filter_id( _wp_to_kebab_case( $preset['slug'] ) );
-
-				self::$global_styles_presets[ $filter_id ] = $preset;
-			}
-		}
-	}
-
-	/**
-	 * Get global styles presets.
 	 *
-	 * @since 6.3.0
-	 *
-	 * @return array
+	 * @return array An array of global styles presets, keyed on the filter ID.
 	 */
 	private static function get_all_global_styles_presets() {
 		if ( ! isset( self::$global_styles_presets ) ) {
-			self::load_global_styles_presets();
+			// Get the per block settings from the theme.json.
+			$tree              = wp_get_global_settings();
+			$presets_by_origin = _wp_array_get( $tree, array( 'color', 'duotone' ), array() );
+
+			self::$global_styles_presets = array();
+			foreach ( $presets_by_origin as $presets ) {
+				foreach ( $presets as $preset ) {
+					$filter_id = self::get_filter_id( _wp_to_kebab_case( $preset['slug'] ) );
+
+					self::$global_styles_presets[ $filter_id ] = $preset;
+				}
+			}
 		}
 
 		return self::$global_styles_presets;
@@ -1027,47 +1018,38 @@ class WP_Duotone {
 	 * duotone filters defined in the theme.json global styles.
 	 *
 	 * @since 6.3.0
-	 */
-	public static function load_global_style_block_names() {
-		// Get the per block settings from the theme.json.
-		$tree        = WP_Theme_JSON_Resolver::get_merged_data();
-		$block_nodes = $tree->get_styles_block_nodes();
-		$theme_json  = $tree->get_raw_data();
-
-		self::$global_styles_block_names = array();
-
-		foreach ( $block_nodes as $block_node ) {
-			// This block definition doesn't include any duotone settings. Skip it.
-			if ( empty( $block_node['duotone'] ) ) {
-				continue;
-			}
-
-			// Value looks like this: 'var(--wp--preset--duotone--blue-orange)' or 'var:preset|duotone|blue-orange'.
-			$duotone_attr_path = array_merge( $block_node['path'], array( 'filter', 'duotone' ) );
-			$duotone_attr      = _wp_array_get( $theme_json, $duotone_attr_path, array() );
-
-			if ( empty( $duotone_attr ) ) {
-				continue;
-			}
-			// If it has a duotone filter preset, save the block name and the preset slug.
-			$slug = self::get_slug_from_attribute( $duotone_attr );
-
-			if ( $slug && $slug !== $duotone_attr ) {
-				self::$global_styles_block_names[ $block_node['name'] ] = $slug;
-			}
-		}
-	}
-
-	/**
-	 * Get global style block names.
 	 *
-	 * @since 6.3.0
-	 *
-	 * @return array
+	 * @return string[] An array of global style block slugs, keyed on the block name.
 	 */
 	private static function get_all_global_style_block_names() {
 		if ( ! isset( self::$global_styles_block_names ) ) {
-			self::load_global_style_block_names();
+			// Get the per block settings from the theme.json.
+			$tree        = WP_Theme_JSON_Resolver::get_merged_data();
+			$block_nodes = $tree->get_styles_block_nodes();
+			$theme_json  = $tree->get_raw_data();
+
+			self::$global_styles_block_names = array();
+
+			foreach ( $block_nodes as $block_node ) {
+				// This block definition doesn't include any duotone settings. Skip it.
+				if ( empty( $block_node['duotone'] ) ) {
+					continue;
+				}
+
+				// Value looks like this: 'var(--wp--preset--duotone--blue-orange)' or 'var:preset|duotone|blue-orange'.
+				$duotone_attr_path = array_merge( $block_node['path'], array( 'filter', 'duotone' ) );
+				$duotone_attr      = _wp_array_get( $theme_json, $duotone_attr_path, array() );
+
+				if ( empty( $duotone_attr ) ) {
+					continue;
+				}
+				// If it has a duotone filter preset, save the block name and the preset slug.
+				$slug = self::get_slug_from_attribute( $duotone_attr );
+
+				if ( $slug && $slug !== $duotone_attr ) {
+					self::$global_styles_block_names[ $block_node['name'] ] = $slug;
+				}
+			}
 		}
 		return self::$global_styles_block_names;
 	}

--- a/src/wp-includes/class-wp-duotone.php
+++ b/src/wp-includes/class-wp-duotone.php
@@ -969,7 +969,7 @@ class WP_Duotone {
 		 * If the experimental duotone support was set, that value is to be
 		 * treated as a selector and requires scoping.
 		 */
-		$experimental_duotone = block_has_support( $block_type, array( 'color', '__experimentalDuotone' ) );
+		$experimental_duotone = _wp_array_get( $block_type->supports, array( 'color', '__experimentalDuotone' ), false );
 		if ( $experimental_duotone ) {
 			$root_selector = wp_get_block_css_selector( $block_type );
 			return is_string( $experimental_duotone )

--- a/src/wp-includes/class-wp-duotone.php
+++ b/src/wp-includes/class-wp-duotone.php
@@ -1076,10 +1076,11 @@ class WP_Duotone {
 	 *
 	 * @since 6.3.0
 	 *
-	 * @param  string $block_content Rendered block content.
-	 * @param  array  $block         Block object.
-	 * @param  WP_Block $wp_block    The block instance.
-	 * @return string                Filtered block content.
+	 * @param  string   $block_content Rendered block content.
+	 * @param  array    $block         Block object.
+	 * @param  WP_Block $wp_block      The block instance.
+	 *
+	 * @return string Filtered block content.
 	 */
 	public static function render_duotone_support( $block_content, $block, $wp_block ) {
 		if ( empty( $block_content ) || ! $block['blockName'] ) {

--- a/src/wp-includes/class-wp-duotone.php
+++ b/src/wp-includes/class-wp-duotone.php
@@ -944,12 +944,9 @@ class WP_Duotone {
 	 * This handles selectors defined in `color.__experimentalDuotone` support
 	 * if `filter.duotone` support is not defined.
 	 *
-	 * @param WP_Block_Type $block_type Block type to check for support.
-	 *
 	 * @internal
-	 *
 	 * @since 6.3.0
-	 *
+	 * @param WP_Block_Type $block_type Block type to check for support.
 	 * @return string The CSS selector or null if there is no support.
 	 */
 	private static function get_selector( $block_type ) {
@@ -958,7 +955,7 @@ class WP_Duotone {
 		}
 
 		/*
-		 * Backwards compatibility with `supports.color.__experimentalDuotone`
+		 * Backward compatibility with `supports.color.__experimentalDuotone`
 		 * is provided via the `block_type_metadata_settings` filter. If
 		 * `supports.filter.duotone` has not been set and the experimental
 		 * property has been, the experimental property value is copied into

--- a/src/wp-includes/class-wp-duotone.php
+++ b/src/wp-includes/class-wp-duotone.php
@@ -1004,6 +1004,7 @@ class WP_Duotone {
 		$tree              = wp_get_global_settings();
 		$presets_by_origin = _wp_array_get( $tree, array( 'color', 'duotone' ), array() );
 
+		self::$global_styles_presets = array();
 		foreach ( $presets_by_origin as $presets ) {
 			foreach ( $presets as $preset ) {
 				$filter_id = self::get_filter_id( _wp_to_kebab_case( $preset['slug'] ) );
@@ -1041,6 +1042,8 @@ class WP_Duotone {
 		$tree        = WP_Theme_JSON_Resolver::get_merged_data();
 		$block_nodes = $tree->get_styles_block_nodes();
 		$theme_json  = $tree->get_raw_data();
+
+		self::$global_styles_block_names = array();
 
 		foreach ( $block_nodes as $block_node ) {
 			// This block definition doesn't include any duotone settings. Skip it.
@@ -1091,7 +1094,14 @@ class WP_Duotone {
 	 * @return string                Filtered block content.
 	 */
 	public static function render_duotone_support( $block_content, $block ) {
+		if ( empty( $block_content ) ) {
+			return $block_content;
+		}
 		$duotone_selector = self::get_selector( $block['blockName'] );
+
+		if ( ! $duotone_selector ) {
+			return $block_content;
+		}
 
 		$global_styles_block_names = self::_get_global_style_block_names();
 
@@ -1099,11 +1109,7 @@ class WP_Duotone {
 		$has_duotone_attribute     = isset( $block['attrs']['style']['color']['duotone'] );
 		$has_global_styles_duotone = array_key_exists( $block['blockName'], $global_styles_block_names );
 
-		if (
-			empty( $block_content ) ||
-			! $duotone_selector ||
-			( ! $has_duotone_attribute && ! $has_global_styles_duotone )
-		) {
+		if ( ! $has_duotone_attribute && ! $has_global_styles_duotone ) {
 			return $block_content;
 		}
 

--- a/src/wp-includes/class-wp-duotone.php
+++ b/src/wp-includes/class-wp-duotone.php
@@ -1071,7 +1071,6 @@ class WP_Duotone {
 	 * @param  string   $block_content Rendered block content.
 	 * @param  array    $block         Block object.
 	 * @param  WP_Block $wp_block      The block instance.
-	 *
 	 * @return string Filtered block content.
 	 */
 	public static function render_duotone_support( $block_content, $block, $wp_block ) {
@@ -1262,7 +1261,6 @@ class WP_Duotone {
 	 *
 	 * @param array $settings Current block type settings.
 	 * @param array $metadata Block metadata as read in via block.json.
-	 *
 	 * @return array Filtered block type settings.
 	 */
 	public static function migrate_experimental_duotone_support_flag( $settings, $metadata ) {

--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -5215,7 +5215,8 @@ function wp_register_duotone_support( $block_type ) {
  */
 function wp_render_duotone_support( $block_content, $block ) {
 	_deprecated_function( __FUNCTION__, '6.3.0', 'WP_Duotone::render_duotone_support()' );
-	return WP_Duotone::render_duotone_support( $block_content, $block );
+	$wp_block = new WP_Block( $block );
+	return WP_Duotone::render_duotone_support( $block_content, $block, $wp_block );
 }
 
 /**

--- a/tests/phpunit/tests/block-supports/duotone.php
+++ b/tests/phpunit/tests/block-supports/duotone.php
@@ -27,9 +27,10 @@ class Tests_Block_Supports_DuoTones extends WP_UnitTestCase {
 			'blockName' => 'core/image',
 			'attrs'     => array( 'style' => array( 'color' => array( 'duotone' => 'var:preset|duotone|blue-orange' ) ) ),
 		);
+		$wp_block      = new WP_Block( $block );
 		$block_content = '<figure class="wp-block-image size-full"><img src="/my-image.jpg" /></figure>';
 		$expected      = '<figure class="wp-block-image size-full wp-duotone-blue-orange"><img src="/my-image.jpg" /></figure>';
-		$this->assertSame( $expected, WP_Duotone::render_duotone_support( $block_content, $block ) );
+		$this->assertSame( $expected, WP_Duotone::render_duotone_support( $block_content, $block, $wp_block ) );
 	}
 
 	/**
@@ -44,9 +45,10 @@ class Tests_Block_Supports_DuoTones extends WP_UnitTestCase {
 			'blockName' => 'core/image',
 			'attrs'     => array( 'style' => array( 'color' => array( 'duotone' => 'unset' ) ) ),
 		);
+		$wp_block      = new WP_Block( $block );
 		$block_content = '<figure class="wp-block-image size-full"><img src="/my-image.jpg" /></figure>';
 		$expected      = '/<figure class="wp-block-image size-full wp-duotone-unset-\d+"><img src="\\/my-image.jpg" \\/><\\/figure>/';
-		$this->assertMatchesRegularExpression( $expected, WP_Duotone::render_duotone_support( $block_content, $block ) );
+		$this->assertMatchesRegularExpression( $expected, WP_Duotone::render_duotone_support( $block_content, $block, $wp_block ) );
 	}
 
 	/**
@@ -59,9 +61,10 @@ class Tests_Block_Supports_DuoTones extends WP_UnitTestCase {
 			'blockName' => 'core/image',
 			'attrs'     => array( 'style' => array( 'color' => array( 'duotone' => array( '#FFFFFF', '#000000' ) ) ) ),
 		);
+		$wp_block      = new WP_Block( $block );
 		$block_content = '<figure class="wp-block-image size-full"><img src="/my-image.jpg" /></figure>';
 		$expected      = '/<figure class="wp-block-image size-full wp-duotone-ffffff-000000-\d+"><img src="\\/my-image.jpg" \\/><\\/figure>/';
-		$this->assertMatchesRegularExpression( $expected, WP_Duotone::render_duotone_support( $block_content, $block ) );
+		$this->assertMatchesRegularExpression( $expected, WP_Duotone::render_duotone_support( $block_content, $block, $wp_block ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/blocks/supportedStyles.php
+++ b/tests/phpunit/tests/blocks/supportedStyles.php
@@ -695,13 +695,14 @@ class Tests_Blocks_SupportedStyles extends WP_UnitTestCase {
 		);
 		$this->register_block_type( 'core/example', $block_type_settings );
 
-		$block = array(
+		$block    = array(
 			'blockName'    => 'core/example',
 			'attrs'        => array(),
 			'innerBlock'   => array(),
 			'innerContent' => array(),
 			'innerHTML'    => array(),
 		);
+		$wp_block = new WP_Block( $block );
 
 		// Custom error handler's see Warnings even if they are suppressed by the @ symbol.
 		$errors = array();
@@ -714,7 +715,7 @@ class Tests_Blocks_SupportedStyles extends WP_UnitTestCase {
 
 		// HTML5 elements like <time> are not supported by the DOMDocument parser used by the block supports feature.
 		// This specific example is emitted by the "Display post date" setting in the latest-posts block.
-		apply_filters( 'render_block', '<div><time datetime="2020-06-18T04:01:43+10:00" class="wp-block-latest-posts__post-date">June 18, 2020</time></div>', $block );
+		apply_filters( 'render_block', '<div><time datetime="2020-06-18T04:01:43+10:00" class="wp-block-latest-posts__post-date">June 18, 2020</time></div>', $block, $wp_block );
 
 		restore_error_handler();
 


### PR DESCRIPTION
This PR does a number of things. 

- Fixes the original issue by deferring loading of logic until there is a block that needs the data ( one with duo tone ). This remove logic from wp_loaded, that use resulting in the issue on install. 
- Lazily loading data on when needed, so when there is a block that support duo tone. 
- Improved readability by using the `tblock_has_support` util. 
- Check for block with null as block name ( can happen with empty spaces ). 
- Improved performance of `render_duotone_support`, by reuse type already passed in filter. 
- Fix tests that by passing all params to filter. 

When testing this, it is important to test with pages / posts with and without blocks that support duo tone. 

Trac ticket: https://core.trac.wordpress.org/ticket/58673

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
