### PR TITLE
Escape theme activation nonce for output.

### DIFF
--- a/src/wp-includes/theme-previews.php
+++ b/src/wp-includes/theme-previews.php
@@ -70,7 +70,7 @@ function wp_block_theme_activate_nonce() {
 	$nonce_handle = 'switch-theme_' . wp_get_theme_preview_path();
 	?>
 	<script type="text/javascript">
-		window.WP_BLOCK_THEME_ACTIVATE_NONCE = '<?php echo wp_create_nonce( $nonce_handle ); ?>';
+		window.WP_BLOCK_THEME_ACTIVATE_NONCE = <?php echo wp_json_encode( $nonce_handle ); ?>;
 	</script>
 	<?php
 }

--- a/src/wp-includes/theme-previews.php
+++ b/src/wp-includes/theme-previews.php
@@ -70,7 +70,7 @@ function wp_block_theme_activate_nonce() {
 	$nonce_handle = 'switch-theme_' . wp_get_theme_preview_path();
 	?>
 	<script type="text/javascript">
-		window.WP_BLOCK_THEME_ACTIVATE_NONCE = <?php echo wp_json_encode( $nonce_handle ); ?>;
+		window.WP_BLOCK_THEME_ACTIVATE_NONCE = <?php echo wp_json_encode( wp_create_nonce( $nonce_handle ) ); ?>;
 	</script>
 	<?php
 }


### PR DESCRIPTION
Adds escaping to the output of the nonce for activating themes while previewing. While escaping isn't required for the core implementation of nonces, it is for custom implimentations that may include special characters such as `'` or `;`.

https://core.trac.wordpress.org/ticket/58712

Follow up to [r56199](https://core.trac.wordpress.org/changeset/56199) / 78135240236a366df708db7a21290db08ab21644