### PR TITLE
Fix PHP notice error when template part is created

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
@@ -596,7 +596,7 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 				$changes->tax_input['wp_template_part_area'] = _filter_block_template_part_area( $request['area'] );
 			} elseif ( null !== $template && 'custom' !== $template->source && $template->area ) {
 				$changes->tax_input['wp_template_part_area'] = _filter_block_template_part_area( $template->area );
-			} elseif ( ! $template->area ) {
+			} elseif ( empty( $template->area ) ) {
 				$changes->tax_input['wp_template_part_area'] = WP_TEMPLATE_PART_AREA_UNCATEGORIZED;
 			}
 		}

--- a/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
+++ b/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
@@ -868,23 +868,21 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 
 		$prepared = $prepare_item_for_database->invoke( $endpoint, $request );
 
-		$this->assertInstanceOf( 'stdClass', $prepared );
+		$this->assertInstanceOf( 'stdClass', $prepared, 'The item could not be prepared for the database.' );
 
-		$prepared_array = (array) $prepared;
+		$this->assertObjectHasAttribute( 'post_type', $prepared, 'The "post_type" was not included in the prepared template part.' );
+		$this->assertObjectHasAttribute( 'post_status', $prepared, 'The "post_status" was not included in the prepared template part.' );
+		$this->assertObjectHasAttribute( 'tax_input', $prepared, 'The "tax_input" was not included in the prepared template part.' );
+		$this->assertArrayHasKey( 'wp_theme', $prepared->tax_input, 'The "wp_theme" tax was not included in the prepared template part.' );
+		$this->assertArrayHasKey( 'wp_template_part_area', $prepared->tax_input, 'The "wp_template_part_area" tax was not included in the prepared template part.' );
+		$this->assertObjectHasAttribute( 'post_content', $prepared, 'The "post_content" was not included in the prepared template part.' );
+		$this->assertObjectHasAttribute( 'post_title', $prepared, 'The "post_title" was not included in the prepared template part.' );
 
-		$this->assertArrayHasKey( 'post_type', $prepared_array );
-		$this->assertArrayHasKey( 'post_status', $prepared_array );
-		$this->assertArrayHasKey( 'tax_input', $prepared_array );
-		$this->assertArrayHasKey( 'wp_theme', $prepared_array['tax_input'] );
-		$this->assertArrayHasKey( 'wp_template_part_area', $prepared_array['tax_input'] );
-		$this->assertArrayHasKey( 'post_content', $prepared_array );
-		$this->assertArrayHasKey( 'post_title', $prepared_array );
+		$this->assertSame( 'wp_template_part', $prepared->post_type, 'The "post_type" was not be correct in the prepared template part.' );
+		$this->assertSame( 'publish', $prepared->post_status, 'The post status was not be correct in the prepared template part.' );
+		$this->assertSame( WP_TEMPLATE_PART_AREA_UNCATEGORIZED, $prepared->tax_input['wp_template_part_area'], 'The area was not be correct in the prepared template part.' );
+		$this->assertSame( 'Untitled Template Part', $prepared->post_title, 'The title was not correct in the prepared template part.' );
 
-		$this->assertSame( 'wp_template_part', $prepared_array['post_type'] );
-		$this->assertSame( 'publish', $prepared_array['post_status'] );
-		$this->assertSame( WP_TEMPLATE_PART_AREA_UNCATEGORIZED, $prepared_array['tax_input']['wp_template_part_area'] );
-		$this->assertSame( 'Untitled Template Part', $prepared_array['post_title'] );
-
-		$this->assertEmpty( $prepared_array['post_content'] );
+		$this->assertEmpty( $prepared->post_content, 'The content was not correct in the prepared template part.' );
 	}
 }

--- a/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
+++ b/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
@@ -848,6 +848,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 
 	/**
 	 * @ticket 57851
+	 *
 	 * @covers WP_REST_Templates_Controller::prepare_item_for_database
 	 */
 	public function test_prepare_item_for_database() {

--- a/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
+++ b/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
@@ -878,9 +878,9 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 		$this->assertObjectHasAttribute( 'post_content', $prepared, 'The "post_content" was not included in the prepared template part.' );
 		$this->assertObjectHasAttribute( 'post_title', $prepared, 'The "post_title" was not included in the prepared template part.' );
 
-		$this->assertSame( 'wp_template_part', $prepared->post_type, 'The "post_type" was not be correct in the prepared template part.' );
-		$this->assertSame( 'publish', $prepared->post_status, 'The post status was not be correct in the prepared template part.' );
-		$this->assertSame( WP_TEMPLATE_PART_AREA_UNCATEGORIZED, $prepared->tax_input['wp_template_part_area'], 'The area was not be correct in the prepared template part.' );
+		$this->assertSame( 'wp_template_part', $prepared->post_type, 'The "post_type" in the prepared template part should be "wp_template_part".' );
+		$this->assertSame( 'publish', $prepared->post_status, 'The post status in the prepared template part should be "publish".' );
+		$this->assertSame( WP_TEMPLATE_PART_AREA_UNCATEGORIZED, $prepared->tax_input['wp_template_part_area'], 'The area in the prepared template part should be uncategorized.' );
 		$this->assertSame( 'Untitled Template Part', $prepared->post_title, 'The title was not correct in the prepared template part.' );
 
 		$this->assertEmpty( $prepared->post_content, 'The content was not correct in the prepared template part.' );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

This PR fixes the PHP notice when a template part is created in the site editor and adds a unit test to cover `WP_REST_Templates_Controller::prepare_item_for_database`.

Trac ticket: 57851

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
