### PR TITLE
Introduce wp_in_development_mode() function and new possible value 'all'

### DIFF
--- a/src/wp-includes/blocks/index.php
+++ b/src/wp-includes/blocks/index.php
@@ -44,7 +44,7 @@ function register_core_block_style_handles() {
 	 * Ignore transient cache when the development mode is set to 'core'. Why? To avoid interfering with
 	 * the core developer's workflow.
 	 */
-	if ( 'core' !== wp_get_development_mode() ) {
+	if ( ! wp_in_development_mode( 'core' ) ) {
 		$transient_name = 'wp_core_block_css_files';
 		$files          = get_transient( $transient_name );
 		if ( ! $files ) {

--- a/src/wp-includes/default-constants.php
+++ b/src/wp-includes/default-constants.php
@@ -79,8 +79,8 @@ function wp_initial_constants() {
 
 	/*
 	 * Add define( 'WP_DEVELOPMENT_MODE', 'core' ) or define( 'WP_DEVELOPMENT_MODE', 'plugin' ) or
-	 * define( 'WP_DEVELOPMENT_MODE', 'theme' ) to wp-config.php to signify development mode for WordPress core, a
-	 * plugin, or a theme respectively.
+	 * define( 'WP_DEVELOPMENT_MODE', 'theme' ) or define( 'WP_DEVELOPMENT_MODE', 'all' ) to wp-config.php
+	 * to signify development mode for WordPress core, a plugin, a theme, or all three types respectively.
 	 */
 	if ( ! defined( 'WP_DEVELOPMENT_MODE' ) ) {
 		define( 'WP_DEVELOPMENT_MODE', '' );

--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -5233,7 +5233,7 @@ function wp_get_global_styles_svg_filters() {
 	 * Ignore cache when the development mode is set to 'theme', so it doesn't interfere with the theme
 	 * developer's workflow.
 	 */
-	$can_use_cached = wp_get_development_mode() !== 'theme';
+	$can_use_cached = ! wp_in_development_mode( 'theme' );
 	$cache_group    = 'theme_json';
 	$cache_key      = 'wp_get_global_styles_svg_filters';
 	if ( $can_use_cached ) {

--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -69,7 +69,7 @@ function wp_get_global_settings( $path = array(), $context = array() ) {
 	 * Ignore cache when the development mode is set to 'theme', so it doesn't interfere with the theme
 	 * developer's workflow.
 	 */
-	$can_use_cached = wp_get_development_mode() !== 'theme';
+	$can_use_cached = ! wp_in_development_mode( 'theme' );
 
 	$settings = false;
 	if ( $can_use_cached ) {
@@ -152,7 +152,7 @@ function wp_get_global_stylesheet( $types = array() ) {
 	 * Ignore cache when the development mode is set to 'theme', so it doesn't interfere with the theme
 	 * developer's workflow.
 	 */
-	$can_use_cached = empty( $types ) && wp_get_development_mode() !== 'theme';
+	$can_use_cached = empty( $types ) && ! wp_in_development_mode( 'theme' );
 
 	/*
 	 * By using the 'theme_json' group, this data is marked to be non-persistent across requests.
@@ -251,7 +251,7 @@ function wp_get_global_styles_custom_css() {
 	 * Ignore cache when the development mode is set to 'theme', so it doesn't interfere with the theme
 	 * developer's workflow.
 	 */
-	$can_use_cached = wp_get_development_mode() !== 'theme';
+	$can_use_cached = ! wp_in_development_mode( 'theme' );
 
 	/*
 	 * By using the 'theme_json' group, this data is marked to be non-persistent across requests.
@@ -360,7 +360,7 @@ function wp_theme_has_theme_json() {
 		 * Ignore static cache when the development mode is set to 'theme', to avoid interfering with
 		 * the theme developer's workflow.
 		 */
-		wp_get_development_mode() !== 'theme'
+		! wp_in_development_mode( 'theme' )
 	) {
 		return $theme_has_support[ $stylesheet ];
 	}

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -277,6 +277,9 @@ function wp_get_environment_type() {
  * Developer mode is considered separately from `WP_DEBUG` and {@see wp_get_environment_type()}. It does not affect
  * debugging output, but rather functional nuances in WordPress.
  *
+ * This function controls the currently set development mode value. To check for whether a specific development mode is
+ * enabled, use {@see wp_in_development_mode()}.
+ *
  * @since 6.3.0
  *
  * @return string The current development mode.

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -278,7 +278,7 @@ function wp_get_environment_type() {
  * debugging output, but rather functional nuances in WordPress.
  *
  * This function controls the currently set development mode value. To check for whether a specific development mode is
- * enabled, use {@see wp_in_development_mode()}.
+ * enabled, use wp_in_development_mode().
  *
  * @since 6.3.0
  *
@@ -320,7 +320,7 @@ function wp_get_development_mode() {
  * @since 6.3.0
  *
  * @param string $mode Development mode to check for. Either 'core', 'plugin', 'theme', or 'all'.
- * @return bool True if the given $mode is covered by the current development mode, false otherwise.
+ * @return bool True if the given mode is covered by the current development mode, false otherwise.
  */
 function wp_in_development_mode( $mode ) {
 	$current_mode = wp_get_development_mode();

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -271,7 +271,8 @@ function wp_get_environment_type() {
  * The development mode affects how certain parts of the WordPress application behave, which is relevant when
  * developing for WordPress.
  *
- * Valid developer modes are 'core', 'plugin', 'theme', or an empty string to disable developer mode.
+ * Valid development modes are 'core', 'plugin', 'theme', 'all', or an empty string to disable development mode.
+ * 'all' is a special value to signify that all three development modes 'core', 'plugin', and 'theme' are enabled.
  *
  * Developer mode is considered separately from `WP_DEBUG` and {@see wp_get_environment_type()}. It does not affect
  * debugging output, but rather functional nuances in WordPress.
@@ -298,6 +299,7 @@ function wp_get_development_mode() {
 		'core',
 		'plugin',
 		'theme',
+		'all',
 		'',
 	);
 	if ( ! in_array( $development_mode, $valid_modes, true ) ) {
@@ -307,6 +309,29 @@ function wp_get_development_mode() {
 	$current_mode = $development_mode;
 
 	return $current_mode;
+}
+
+/**
+ * Checks whether the site is in the given development mode.
+ *
+ * @since 6.3.0
+ *
+ * @param string $mode Development mode to check for. Either 'core', 'plugin', 'theme', or 'all'.
+ * @return bool True if the given $mode is covered by the current development mode, false otherwise.
+ */
+function wp_in_development_mode( $mode ) {
+	$current_mode = wp_get_development_mode();
+	if ( empty( $current_mode ) ) {
+		return false;
+	}
+
+	// Return true if the current mode encompasses all modes.
+	if ( 'all' === $current_mode ) {
+		return true;
+	}
+
+	// Return true if the current mode is the given mode.
+	return $mode === $current_mode;
 }
 
 /**

--- a/tests/phpunit/tests/load/wpGetDevelopmentMode.php
+++ b/tests/phpunit/tests/load/wpGetDevelopmentMode.php
@@ -57,101 +57,100 @@ class Test_WP_Get_Development_Mode extends WP_UnitTestCase {
 		$_wp_tests_development_mode = $current;
 
 		if ( $expected ) {
-			$this->assertTrue( wp_in_development_mode( $given ) );
+			$this->assertTrue( wp_in_development_mode( $given ), "{$given} is expected to pass in {$current} mode" );
 		} else {
-			$this->assertFalse( wp_in_development_mode( $given ) );
+			$this->assertFalse( wp_in_development_mode( $given ), "{$given} is expected to fail in {$current} mode" );
 		}
 	}
 
 	/**
 	 * Data provider that returns test scenarios for the `test_wp_in_development_mode()` method.
 	 *
-	 * @return array Test scenarios, each one with 3 entries for currently set development mode (string), given
-	 *               development mode (string), and expected result (boolean).
+	 * @return array[]
 	 */
 	public function data_wp_in_development_mode() {
 		return array(
-			array(
+			'core mode, testing for core' => array(
 				'core',
 				'core',
 				true,
 			),
-			array(
+			'plugin mode, testing for plugin' => array(
 				'plugin',
 				'plugin',
 				true,
 			),
-			array(
+			'theme mode, testing for theme' => array(
 				'theme',
 				'theme',
 				true,
 			),
-			array(
+			'core mode, testing for plugin' => array(
 				'core',
 				'plugin',
 				false,
 			),
-			array(
+			'core mode, testing for theme' => array(
 				'core',
 				'theme',
 				false,
 			),
-			array(
+			'plugin mode, testing for core' => array(
 				'plugin',
 				'core',
 				false,
 			),
-			array(
+			'plugin mode, testing for theme' => array(
 				'plugin',
 				'theme',
 				false,
 			),
-			array(
+			'theme mode, testing for core' => array(
 				'theme',
 				'core',
 				false,
 			),
-			array(
+			'theme mode, testing for plugin' => array(
 				'theme',
 				'plugin',
 				false,
 			),
-			array(
+			'all mode, testing for core' => array(
 				'all',
 				'core',
 				true,
 			),
-			array(
+			'all mode, testing for plugin' => array(
 				'all',
 				'plugin',
 				true,
 			),
-			array(
+			'all mode, testing for theme' => array(
 				'all',
 				'theme',
 				true,
 			),
-			array(
+			'all mode, testing for all' => array(
 				'all',
 				'all',
 				true,
 			),
-			array(
+			'all mode, testing for non-standard value' => array(
 				'all',
 				'random',
 				true,
 			),
-			array(
+			'invalid mode, testing for core' => array(
 				'invalid',
 				'core',
 				false,
 			),
-			array(
+			'invalid mode, testing for plugin' => array(
 				'invalid',
 				'plugin',
 				false,
 			),
-			array(
+			'invalid mode, testing for theme' => array(
 				'invalid',
 				'theme',
 				false,

--- a/tests/phpunit/tests/load/wpGetDevelopmentMode.php
+++ b/tests/phpunit/tests/load/wpGetDevelopmentMode.php
@@ -70,67 +70,67 @@ class Test_WP_Get_Development_Mode extends WP_UnitTestCase {
 	 */
 	public function data_wp_in_development_mode() {
 		return array(
-			'core mode, testing for core' => array(
+			'core mode, testing for core'              => array(
 				'core',
 				'core',
 				true,
 			),
-			'plugin mode, testing for plugin' => array(
+			'plugin mode, testing for plugin'          => array(
 				'plugin',
 				'plugin',
 				true,
 			),
-			'theme mode, testing for theme' => array(
+			'theme mode, testing for theme'            => array(
 				'theme',
 				'theme',
 				true,
 			),
-			'core mode, testing for plugin' => array(
+			'core mode, testing for plugin'            => array(
 				'core',
 				'plugin',
 				false,
 			),
-			'core mode, testing for theme' => array(
+			'core mode, testing for theme'             => array(
 				'core',
 				'theme',
 				false,
 			),
-			'plugin mode, testing for core' => array(
+			'plugin mode, testing for core'            => array(
 				'plugin',
 				'core',
 				false,
 			),
-			'plugin mode, testing for theme' => array(
+			'plugin mode, testing for theme'           => array(
 				'plugin',
 				'theme',
 				false,
 			),
-			'theme mode, testing for core' => array(
+			'theme mode, testing for core'             => array(
 				'theme',
 				'core',
 				false,
 			),
-			'theme mode, testing for plugin' => array(
+			'theme mode, testing for plugin'           => array(
 				'theme',
 				'plugin',
 				false,
 			),
-			'all mode, testing for core' => array(
+			'all mode, testing for core'               => array(
 				'all',
 				'core',
 				true,
 			),
-			'all mode, testing for plugin' => array(
+			'all mode, testing for plugin'             => array(
 				'all',
 				'plugin',
 				true,
 			),
-			'all mode, testing for theme' => array(
+			'all mode, testing for theme'              => array(
 				'all',
 				'theme',
 				true,
 			),
-			'all mode, testing for all' => array(
+			'all mode, testing for all'                => array(
 				'all',
 				'all',
 				true,
@@ -140,17 +140,17 @@ class Test_WP_Get_Development_Mode extends WP_UnitTestCase {
 				'random',
 				true,
 			),
-			'invalid mode, testing for core' => array(
+			'invalid mode, testing for core'           => array(
 				'invalid',
 				'core',
 				false,
 			),
-			'invalid mode, testing for plugin' => array(
+			'invalid mode, testing for plugin'         => array(
 				'invalid',
 				'plugin',
 				false,
 			),
-			'invalid mode, testing for theme' => array(
+			'invalid mode, testing for theme'          => array(
 				'invalid',
 				'theme',
 				false,

--- a/tests/phpunit/tests/load/wpGetDevelopmentMode.php
+++ b/tests/phpunit/tests/load/wpGetDevelopmentMode.php
@@ -8,6 +8,7 @@
  *
  * @group load.php
  * @covers ::wp_get_development_mode
+ * @covers ::wp_in_development_mode
  */
 class Test_WP_Get_Development_Mode extends WP_UnitTestCase {
 
@@ -42,5 +43,119 @@ class Test_WP_Get_Development_Mode extends WP_UnitTestCase {
 
 		$_wp_tests_development_mode = 'invalid';
 		$this->assertSame( '', wp_get_development_mode() );
+	}
+
+	/**
+	 * Tests that `wp_in_development_mode()` returns expected results.
+	 *
+	 * @ticket 57487
+	 * @dataProvider data_wp_in_development_mode
+	 */
+	public function test_wp_in_development_mode( $current, $given, $expected ) {
+		global $_wp_tests_development_mode;
+
+		$_wp_tests_development_mode = $current;
+
+		if ( $expected ) {
+			$this->assertTrue( wp_in_development_mode( $given ) );
+		} else {
+			$this->assertFalse( wp_in_development_mode( $given ) );
+		}
+	}
+
+	/**
+	 * Data provider that returns test scenarios for the `test_wp_in_development_mode()` method.
+	 *
+	 * @return array Test scenarios, each one with 3 entries for currently set development mode (string), given
+	 *               development mode (string), and expected result (boolean).
+	 */
+	public function data_wp_in_development_mode() {
+		return array(
+			array(
+				'core',
+				'core',
+				true,
+			),
+			array(
+				'plugin',
+				'plugin',
+				true,
+			),
+			array(
+				'theme',
+				'theme',
+				true,
+			),
+			array(
+				'core',
+				'plugin',
+				false,
+			),
+			array(
+				'core',
+				'theme',
+				false,
+			),
+			array(
+				'plugin',
+				'core',
+				false,
+			),
+			array(
+				'plugin',
+				'theme',
+				false,
+			),
+			array(
+				'theme',
+				'core',
+				false,
+			),
+			array(
+				'theme',
+				'plugin',
+				false,
+			),
+			array(
+				'all',
+				'core',
+				true,
+			),
+			array(
+				'all',
+				'plugin',
+				true,
+			),
+			array(
+				'all',
+				'theme',
+				true,
+			),
+			array(
+				'all',
+				'all',
+				true,
+			),
+			array(
+				'all',
+				'random',
+				true,
+			),
+			array(
+				'invalid',
+				'core',
+				false,
+			),
+			array(
+				'invalid',
+				'plugin',
+				false,
+			),
+			array(
+				'invalid',
+				'theme',
+				false,
+			),
+		);
 	}
 }


### PR DESCRIPTION
This PR implements the enhancements discussed on the ticket:
* New utility function `wp_in_development_mode()` that simplifies checking for a specific development mode. With this change, `wp_get_development_mode()` becomes a more low-level function.
* New possible value 'all' for `WP_DEVELOPMENT_MODE` constant. This value effectively means all 3 other development modes are enabled.

Trac ticket: https://core.trac.wordpress.org/ticket/57487

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
