### PR TITLE
Help/About: Adjust the About menu on medium sized screens.

### DIFF
--- a/src/wp-admin/css/about.css
+++ b/src/wp-admin/css/about.css
@@ -623,6 +623,12 @@
 	color: inherit;
 }
 
+@media (min-width: 783px) and (max-width: 926px) {
+	.about__header-navigation .nav-tab {
+		padding: calc(var(--gap) * 0.75) calc(var(--gap) * 0.5);
+	}
+}
+
 .about__header-navigation .nav-tab:hover,
 .about__header-navigation .nav-tab:active {
 	background-color: var(--nav-current);

--- a/src/wp-admin/css/about.css
+++ b/src/wp-admin/css/about.css
@@ -623,7 +623,6 @@
 	color: inherit;
 }
 
-
 .about__header-navigation .nav-tab:hover,
 .about__header-navigation .nav-tab:active {
 	background-color: var(--nav-current);

--- a/src/wp-admin/css/about.css
+++ b/src/wp-admin/css/about.css
@@ -623,11 +623,6 @@
 	color: inherit;
 }
 
-@media (min-width: 783px) and (max-width: 926px) {
-	.about__header-navigation .nav-tab {
-		padding: calc(var(--gap) * 0.75) calc(var(--gap) * 0.5);
-	}
-}
 
 .about__header-navigation .nav-tab:hover,
 .about__header-navigation .nav-tab:active {
@@ -661,6 +656,10 @@
 	.contribute-php .about__header-title h1 {
 		/* Fluid font size scales on browser size 600px - 960px. */
 		font-size: clamp(3rem, 6.67vw - 0.5rem, 4.5rem);
+	}
+
+	.about__header-navigation .nav-tab {
+		padding: calc(var(--gap) * 0.75) calc(var(--gap) * 0.5);
 	}
 }
 


### PR DESCRIPTION
Specifically between 783px and 926px, the menu for the About / Credits / Freedoms / Privacy / Get Involved tabs expands beyond the container when the side admin menu is expanded. This wasn't an issue when there were fewer tabs previously, or when the Get Involved tab was called Contribute.

Video demonstrating the issue:

https://github.com/WordPress/wordpress-develop/assets/79332690/d9f737d2-d139-4b74-b059-bb7fbaf7e7c2

This change adjusts horizontal padding on the tabs under 960px to resolve the issue.

Trac ticket: https://core.trac.wordpress.org/ticket/23348