### PR TITLE
Footnotes: Trim footnote anchors from excerpts backport from Gutenberg

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1010,6 +1010,24 @@ function excerpt_remove_blocks( $content ) {
 }
 
 /**
+ * Parses footnotes markup out of a content string,
+ * and renders those appropriate for the excerpt.
+ *
+ * @since 6.3.0
+ *
+ * @param string $content The content to parse.
+ * @return string The parsed and filtered content.
+ */
+function excerpt_remove_footnotes( $content ) {
+	if ( false === strpos( $content, 'data-fn=' ) ) {
+		return $content;
+	}
+
+	static $footnote_pattern = '_<sup data-fn="[^"]+" class="[^"]+">\s*<a href="[^"]+" id="[^"]+">\d+</a>\s*</sup>_';
+	return preg_replace( $footnote_pattern, '', $content );
+}
+
+/**
  * Renders inner blocks from the allowed wrapper blocks
  * for generating an excerpt.
  *

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1019,12 +1019,15 @@ function excerpt_remove_blocks( $content ) {
  * @return string The parsed and filtered content.
  */
 function excerpt_remove_footnotes( $content ) {
-	if ( false === strpos( $content, 'data-fn=' ) ) {
+	if ( ! str_contains( $content, 'data-fn=' ) ) {
 		return $content;
 	}
 
-	static $footnote_pattern = '_<sup data-fn="[^"]+" class="[^"]+">\s*<a href="[^"]+" id="[^"]+">\d+</a>\s*</sup>_';
-	return preg_replace( $footnote_pattern, '', $content );
+	return preg_replace(
+		'_<sup data-fn="[^"]+" class="[^"]+">\s*<a href="[^"]+" id="[^"]+">\d+</a>\s*</sup>_',
+		'',
+		$content
+	);
 }
 
 /**

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -3952,6 +3952,7 @@ function human_time_diff( $from, $to = 0 ) {
  *
  * @since 1.5.0
  * @since 5.2.0 Added the `$post` parameter.
+ * @since 6.3.0 Removes footnotes markup from the excerpt content.
  *
  * @param string             $text Optional. The excerpt. If set to empty, an excerpt is generated.
  * @param WP_Post|object|int $post Optional. WP_Post instance or Post ID/object. Default null.
@@ -3966,6 +3967,7 @@ function wp_trim_excerpt( $text = '', $post = null ) {
 
 		$text = strip_shortcodes( $text );
 		$text = excerpt_remove_blocks( $text );
+		$text = excerpt_remove_footnotes( $text );
 
 		/*
 		 * Temporarily unhook wp_filter_content_tags() since any tags
@@ -4008,6 +4010,7 @@ function wp_trim_excerpt( $text = '', $post = null ) {
 		 */
 		$excerpt_more = apply_filters( 'excerpt_more', ' ' . '[&hellip;]' );
 		$text         = wp_trim_words( $text, $excerpt_length, $excerpt_more );
+
 	}
 
 	/**

--- a/tests/phpunit/tests/formatting/excerptRemoveFootnotes.php
+++ b/tests/phpunit/tests/formatting/excerptRemoveFootnotes.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * @group formatting
+ * @ticket 58805
+ *
+ * @covers ::excerpt_remove_footnotes
+ */
+
+class Tests_Formatting_ExcerptRemoveFootnotes extends WP_UnitTestCase {
+	/**
+	 * @ticket 58805
+	 *
+	 * @dataProvider data_remove_footnotes
+	 *
+	 * @param string $expected  Expected output.
+	 * @param string $content   Content to run strip_shortcodes() on.
+	 * @param string $message   The test message.
+	 */
+	public function test_remove_footnotes( $expected, $content, $message = '' ) {
+		$this->assertSame( $expected, excerpt_remove_footnotes( $content ), $message );
+	}
+
+	public function data_remove_footnotes() {
+		return array(
+			array(
+				'<p>This is a paragraph<sup class="fn" id="1"><a href="#1" id="1a">1</a></sup>.</p>',
+				'<p>This is a paragraph<sup class="fn" id="1"><a href="#1" id="1a">1</a></sup>.</p>',
+				'Should not replace if no footnote attribute is found in the content.',
+			),
+			array(
+				'<p>This is a <a href="https://wordpress.org" data-type="URL" data-id="https://wordpress.org">paragraph</a>.</p>',
+				'<p>This is a <a href="https://wordpress.org" data-type="URL" data-id="https://wordpress.org">paragraph</a><sup data-fn="d3b825b6-1890-4cb3-b276-002137515e99" class="fn"><a href="#d3b825b6-1890-4cb3-b276-002137515e99" id="d3b825b6-1890-4cb3-b276-002137515e99-link">1</a></sup>.</p>',
+				'Footnote should be removed from HTML content.',
+			),
+			array(
+				'<!-- wp:list --><ul><!-- wp:list-item --><li><strong>This</strong><em><strong><sup></sup></strong></em><strong> is a list</strong></li><!-- /wp:list-item --></ul><!-- /wp:list -->',
+				'<!-- wp:list --><ul><!-- wp:list-item --><li><strong>This</strong><em><strong><sup><sup data-fn="e2fce624-74a5-4068-a20c-6ef793f1644c" class="fn"><a href="#e2fce624-74a5-4068-a20c-6ef793f1644c" id="e2fce624-74a5-4068-a20c-6ef793f1644c-link">2</a></sup></sup></strong></em><strong> is a list</strong><sup data-fn="ea7e892e-7bc2-424b-936b-36ec64f1c2fc" class="fn"><a href="#ea7e892e-7bc2-424b-936b-36ec64f1c2fc" id="ea7e892e-7bc2-424b-936b-36ec64f1c2fc-link">3</a></sup></li><!-- /wp:list-item --></ul><!-- /wp:list -->',
+				'Multiple footnotes should be removed from block content.',
+			),
+			array(
+				'<h2 class="wp-block-heading has-background" style="background-color:#f93b3b">これは見出しです</h2>',
+				'<h2 class="wp-block-heading has-background" style="background-color:#f93b3b">これは<sup data-fn="382b3e39-4b0d-4b83-8461-c13f82fdbcfb" class="fn"><a href="#382b3e39-4b0d-4b83-8461-c13f82fdbcfb" id="382b3e39-4b0d-4b83-8461-c13f82fdbcfb-link">1</a></sup>見出しです<sup data-fn="addb0459-a048-453a-9101-dba64f63a630" class="fn"><a href="#addb0459-a048-453a-9101-dba64f63a630" id="addb0459-a048-453a-9101-dba64f63a630-link">2</a></sup></h2>',
+				'Footnotes around non latin script should be removed from HTML content.',
+			),
+		);
+	}
+}

--- a/tests/phpunit/tests/formatting/excerptRemoveFootnotes.php
+++ b/tests/phpunit/tests/formatting/excerptRemoveFootnotes.php
@@ -12,35 +12,36 @@ class Tests_Formatting_ExcerptRemoveFootnotes extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_remove_footnotes
 	 *
-	 * @param string $expected  Expected output.
-	 * @param string $content   Content to run strip_shortcodes() on.
-	 * @param string $message   The test message.
+	 * @param string $expected Expected output.
+	 * @param string $content  Content to run strip_shortcodes() on.
 	 */
-	public function test_remove_footnotes( $expected, $content, $message = '' ) {
-		$this->assertSame( $expected, excerpt_remove_footnotes( $content ), $message );
+	public function test_remove_footnotes( $expected, $content ) {
+		$this->assertSame( $expected, excerpt_remove_footnotes( $content ) );
 	}
 
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
 	public function data_remove_footnotes() {
 		return array(
-			array(
-				'<p>This is a paragraph<sup class="fn" id="1"><a href="#1" id="1a">1</a></sup>.</p>',
-				'<p>This is a paragraph<sup class="fn" id="1"><a href="#1" id="1a">1</a></sup>.</p>',
-				'Should not replace if no footnote attribute is found in the content.',
+			'no footnote'                         => array(
+				'expected' => '<p>This is a paragraph<sup class="fn" id="1"><a href="#1" id="1a">1</a></sup>.</p>',
+				'content'  => '<p>This is a paragraph<sup class="fn" id="1"><a href="#1" id="1a">1</a></sup>.</p>',
 			),
-			array(
-				'<p>This is a <a href="https://wordpress.org" data-type="URL" data-id="https://wordpress.org">paragraph</a>.</p>',
-				'<p>This is a <a href="https://wordpress.org" data-type="URL" data-id="https://wordpress.org">paragraph</a><sup data-fn="d3b825b6-1890-4cb3-b276-002137515e99" class="fn"><a href="#d3b825b6-1890-4cb3-b276-002137515e99" id="d3b825b6-1890-4cb3-b276-002137515e99-link">1</a></sup>.</p>',
-				'Footnote should be removed from HTML content.',
+			'one footnote'                        => array(
+				'expected' => '<p>This is a <a href="https://wordpress.org" data-type="URL" data-id="https://wordpress.org">paragraph</a>.</p>',
+				'content'  => '<p>This is a <a href="https://wordpress.org" data-type="URL" data-id="https://wordpress.org">paragraph</a><sup data-fn="d3b825b6-1890-4cb3-b276-002137515e99" class="fn"><a href="#d3b825b6-1890-4cb3-b276-002137515e99" id="d3b825b6-1890-4cb3-b276-002137515e99-link">1</a></sup>.</p>',
+
 			),
-			array(
-				'<!-- wp:list --><ul><!-- wp:list-item --><li><strong>This</strong><em><strong><sup></sup></strong></em><strong> is a list</strong></li><!-- /wp:list-item --></ul><!-- /wp:list -->',
-				'<!-- wp:list --><ul><!-- wp:list-item --><li><strong>This</strong><em><strong><sup><sup data-fn="e2fce624-74a5-4068-a20c-6ef793f1644c" class="fn"><a href="#e2fce624-74a5-4068-a20c-6ef793f1644c" id="e2fce624-74a5-4068-a20c-6ef793f1644c-link">2</a></sup></sup></strong></em><strong> is a list</strong><sup data-fn="ea7e892e-7bc2-424b-936b-36ec64f1c2fc" class="fn"><a href="#ea7e892e-7bc2-424b-936b-36ec64f1c2fc" id="ea7e892e-7bc2-424b-936b-36ec64f1c2fc-link">3</a></sup></li><!-- /wp:list-item --></ul><!-- /wp:list -->',
-				'Multiple footnotes should be removed from block content.',
+			'multiple footnotes in block content' => array(
+				'expected' => '<!-- wp:list --><ul><!-- wp:list-item --><li><strong>This</strong><em><strong><sup></sup></strong></em><strong> is a list</strong></li><!-- /wp:list-item --></ul><!-- /wp:list -->',
+				'content'  => '<!-- wp:list --><ul><!-- wp:list-item --><li><strong>This</strong><em><strong><sup><sup data-fn="e2fce624-74a5-4068-a20c-6ef793f1644c" class="fn"><a href="#e2fce624-74a5-4068-a20c-6ef793f1644c" id="e2fce624-74a5-4068-a20c-6ef793f1644c-link">2</a></sup></sup></strong></em><strong> is a list</strong><sup data-fn="ea7e892e-7bc2-424b-936b-36ec64f1c2fc" class="fn"><a href="#ea7e892e-7bc2-424b-936b-36ec64f1c2fc" id="ea7e892e-7bc2-424b-936b-36ec64f1c2fc-link">3</a></sup></li><!-- /wp:list-item --></ul><!-- /wp:list -->',
 			),
-			array(
-				'<h2 class="wp-block-heading has-background" style="background-color:#f93b3b">これは見出しです</h2>',
-				'<h2 class="wp-block-heading has-background" style="background-color:#f93b3b">これは<sup data-fn="382b3e39-4b0d-4b83-8461-c13f82fdbcfb" class="fn"><a href="#382b3e39-4b0d-4b83-8461-c13f82fdbcfb" id="382b3e39-4b0d-4b83-8461-c13f82fdbcfb-link">1</a></sup>見出しです<sup data-fn="addb0459-a048-453a-9101-dba64f63a630" class="fn"><a href="#addb0459-a048-453a-9101-dba64f63a630" id="addb0459-a048-453a-9101-dba64f63a630-link">2</a></sup></h2>',
-				'Footnotes around non latin script should be removed from HTML content.',
+			'footnotes around non-latin script'   => array(
+				'expected' => '<h2 class="wp-block-heading has-background" style="background-color:#f93b3b">これは見出しです</h2>',
+				'content'  => '<h2 class="wp-block-heading has-background" style="background-color:#f93b3b">これは<sup data-fn="382b3e39-4b0d-4b83-8461-c13f82fdbcfb" class="fn"><a href="#382b3e39-4b0d-4b83-8461-c13f82fdbcfb" id="382b3e39-4b0d-4b83-8461-c13f82fdbcfb-link">1</a></sup>見出しです<sup data-fn="addb0459-a048-453a-9101-dba64f63a630" class="fn"><a href="#addb0459-a048-453a-9101-dba64f63a630" id="addb0459-a048-453a-9101-dba64f63a630-link">2</a></sup></h2>',
 			),
 		);
 	}


### PR DESCRIPTION
Backports changes from https://github.com/WordPress/gutenberg/pull/52518

Adding a function to `wp_trim_excerpt` that removes footnotes from content.
Adds tests

Trac ticket: https://core.trac.wordpress.org/ticket/58805

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
