### PR TITLE
Remove users from user-sitemap

### DIFF
--- a/src/wp-includes/sitemaps/providers/class-wp-sitemaps-users.php
+++ b/src/wp-includes/sitemaps/providers/class-wp-sitemaps-users.php
@@ -138,7 +138,7 @@ class WP_Sitemaps_Users extends WP_Sitemaps_Provider {
 
 		// We're not supporting sitemaps for author pages for attachments.
 		unset( $public_post_types['attachment'] );
-
+		unset( $public_post_types['page'] );
 		/**
 		 * Filters the query arguments for authors with public posts.
 		 *


### PR DESCRIPTION
Trac Ticket   -> https://core.trac.wordpress.org/ticket/57816
This PR addresses the issue of including users in the user sitemap who have not published any posts but have published pages.

To resolve this, we have implemented a modification. By using the unset( $public_post_types['page'] ); function, we remove the public post type "page" from the query arguments. This ensures that users who have only published pages are not included in the user sitemap.