### PR TITLE
Rename `wp_in_development_mode()` to `wp_is_development_mode()`

### DIFF
--- a/src/wp-includes/blocks/index.php
+++ b/src/wp-includes/blocks/index.php
@@ -44,7 +44,7 @@ function register_core_block_style_handles() {
 	 * Ignore transient cache when the development mode is set to 'core'. Why? To avoid interfering with
 	 * the core developer's workflow.
 	 */
-	if ( ! wp_in_development_mode( 'core' ) ) {
+	if ( ! wp_is_development_mode( 'core' ) ) {
 		$transient_name = 'wp_core_block_css_files';
 		$files          = get_transient( $transient_name );
 		if ( ! $files ) {

--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -5234,7 +5234,7 @@ function wp_get_global_styles_svg_filters() {
 	 * Ignore cache when the development mode is set to 'theme', so it doesn't interfere with the theme
 	 * developer's workflow.
 	 */
-	$can_use_cached = ! wp_in_development_mode( 'theme' );
+	$can_use_cached = ! wp_is_development_mode( 'theme' );
 	$cache_group    = 'theme_json';
 	$cache_key      = 'wp_get_global_styles_svg_filters';
 	if ( $can_use_cached ) {

--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -69,7 +69,7 @@ function wp_get_global_settings( $path = array(), $context = array() ) {
 	 * Ignore cache when the development mode is set to 'theme', so it doesn't interfere with the theme
 	 * developer's workflow.
 	 */
-	$can_use_cached = ! wp_in_development_mode( 'theme' );
+	$can_use_cached = ! wp_is_development_mode( 'theme' );
 
 	$settings = false;
 	if ( $can_use_cached ) {
@@ -152,7 +152,7 @@ function wp_get_global_stylesheet( $types = array() ) {
 	 * Ignore cache when the development mode is set to 'theme', so it doesn't interfere with the theme
 	 * developer's workflow.
 	 */
-	$can_use_cached = empty( $types ) && ! wp_in_development_mode( 'theme' );
+	$can_use_cached = empty( $types ) && ! wp_is_development_mode( 'theme' );
 
 	/*
 	 * By using the 'theme_json' group, this data is marked to be non-persistent across requests.
@@ -251,7 +251,7 @@ function wp_get_global_styles_custom_css() {
 	 * Ignore cache when the development mode is set to 'theme', so it doesn't interfere with the theme
 	 * developer's workflow.
 	 */
-	$can_use_cached = ! wp_in_development_mode( 'theme' );
+	$can_use_cached = ! wp_is_development_mode( 'theme' );
 
 	/*
 	 * By using the 'theme_json' group, this data is marked to be non-persistent across requests.
@@ -360,7 +360,7 @@ function wp_theme_has_theme_json() {
 		 * Ignore static cache when the development mode is set to 'theme', to avoid interfering with
 		 * the theme developer's workflow.
 		 */
-		! wp_in_development_mode( 'theme' )
+		! wp_is_development_mode( 'theme' )
 	) {
 		return $theme_has_support[ $stylesheet ];
 	}

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -321,33 +321,17 @@ function wp_get_development_mode() {
  *
  * @since 6.3.0
  *
- * @param string|null $mode Optional. Development mode to check for. Either 'core', 'plugin', 'theme', or 'all'.
- *                          If no mode is passed, it will check for any development mode. Defaults to null.
+ * @param string $mode Development mode to check for. Either 'core', 'plugin', 'theme', or 'all'.
  * @return bool True if the given mode is covered by the current development mode, false otherwise.
  */
-function wp_is_development_mode( $mode = null ) {
+function wp_is_development_mode( $mode ) {
 	$current_mode = wp_get_development_mode();
-
 	if ( empty( $current_mode ) ) {
 		return false;
 	}
 
 	// Return true if the current mode encompasses all modes.
 	if ( 'all' === $current_mode ) {
-		return true;
-	}
-
-	$valid_modes = array(
-		'core',
-		'plugin',
-		'theme',
-		'all',
-	);
-
-	/**
-	 * If no mode is passed, return true if any valid development mode is set.
-	 */
-	if ( empty( $mode ) && in_array( $current_mode, $valid_modes, true ) ) {
 		return true;
 	}
 

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -280,7 +280,7 @@ function wp_get_environment_type() {
  * It does not affect debugging output, but rather functional nuances in WordPress.
  *
  * This function retrieves the currently set development mode value. To check whether
- * a specific development mode is enabled, use wp_in_development_mode().
+ * a specific development mode is enabled, use wp_is_development_mode().
  *
  * @since 6.3.0
  *
@@ -324,7 +324,7 @@ function wp_get_development_mode() {
  * @param string $mode Development mode to check for. Either 'core', 'plugin', 'theme', or 'all'.
  * @return bool True if the given mode is covered by the current development mode, false otherwise.
  */
-function wp_in_development_mode( $mode ) {
+function wp_is_development_mode( $mode ) {
 	$current_mode = wp_get_development_mode();
 	if ( empty( $current_mode ) ) {
 		return false;

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -321,17 +321,33 @@ function wp_get_development_mode() {
  *
  * @since 6.3.0
  *
- * @param string $mode Development mode to check for. Either 'core', 'plugin', 'theme', or 'all'.
+ * @param string|null $mode Optional. Development mode to check for. Either 'core', 'plugin', 'theme', or 'all'.
+ *                          If no mode is passed, it will check for any development mode. Defaults to null.
  * @return bool True if the given mode is covered by the current development mode, false otherwise.
  */
-function wp_is_development_mode( $mode ) {
+function wp_is_development_mode( $mode = null ) {
 	$current_mode = wp_get_development_mode();
+
 	if ( empty( $current_mode ) ) {
 		return false;
 	}
 
 	// Return true if the current mode encompasses all modes.
 	if ( 'all' === $current_mode ) {
+		return true;
+	}
+
+	$valid_modes = array(
+		'core',
+		'plugin',
+		'theme',
+		'all',
+	);
+
+	/**
+	 * If no mode is passed, return true if any valid development mode is set.
+	 */
+	if ( empty( $mode ) && in_array( $current_mode, $valid_modes, true ) ) {
 		return true;
 	}
 

--- a/tests/phpunit/tests/load/wpGetDevelopmentMode.php
+++ b/tests/phpunit/tests/load/wpGetDevelopmentMode.php
@@ -8,7 +8,7 @@
  *
  * @group load.php
  * @covers ::wp_get_development_mode
- * @covers ::wp_in_development_mode
+ * @covers ::wp_is_development_mode
  */
 class Test_WP_Get_Development_Mode extends WP_UnitTestCase {
 
@@ -46,29 +46,29 @@ class Test_WP_Get_Development_Mode extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that `wp_in_development_mode()` returns expected results.
+	 * Tests that `wp_is_development_mode()` returns expected results.
 	 *
 	 * @ticket 57487
-	 * @dataProvider data_wp_in_development_mode
+	 * @dataProvider data_wp_is_development_mode
 	 */
-	public function test_wp_in_development_mode( $current, $given, $expected ) {
+	public function test_wp_is_development_mode( $current, $given, $expected ) {
 		global $_wp_tests_development_mode;
 
 		$_wp_tests_development_mode = $current;
 
 		if ( $expected ) {
-			$this->assertTrue( wp_in_development_mode( $given ), "{$given} is expected to pass in {$current} mode" );
+			$this->assertTrue( wp_is_development_mode( $given ), "{$given} is expected to pass in {$current} mode" );
 		} else {
-			$this->assertFalse( wp_in_development_mode( $given ), "{$given} is expected to fail in {$current} mode" );
+			$this->assertFalse( wp_is_development_mode( $given ), "{$given} is expected to fail in {$current} mode" );
 		}
 	}
 
 	/**
-	 * Data provider that returns test scenarios for the `test_wp_in_development_mode()` method.
+	 * Data provider that returns test scenarios for the `test_wp_is_development_mode()` method.
 	 *
 	 * @return array[]
 	 */
-	public function data_wp_in_development_mode() {
+	public function data_wp_is_development_mode() {
 		return array(
 			'core mode, testing for core'              => array(
 				'core',


### PR DESCRIPTION
This is a follow up to [56223] which replaces the `wp_in_` prefix with `wp_is_` to be more consistent with other boolean functions in WordPress, like wp_is_maintenance_mode(), wp_is_recovery_mode(), etc.

See #57487.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/57487

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
