### PR TITLE
Admin Bar: add "Learn WordPress" link

### DIFF
--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -194,6 +194,16 @@ function wp_admin_bar_wp_menu( $wp_admin_bar ) {
 		)
 	);
 
+	// Add learn link.
+	$wp_admin_bar->add_node(
+		array(
+			'parent' => 'wp-logo-external',
+			'id'     => 'learn',
+			'title'  => __( 'Learn WordPress' ),
+			'href'   => __( 'https://learn.wordpress.org/' ),
+		)
+	);
+
 	// Add forums link.
 	$wp_admin_bar->add_node(
 		array(

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -200,7 +200,7 @@ function wp_admin_bar_wp_menu( $wp_admin_bar ) {
 			'parent' => 'wp-logo-external',
 			'id'     => 'learn',
 			'title'  => __( 'Learn WordPress' ),
-			'href'   => __( 'https://learn.wordpress.org/' ),
+			'href'   => 'https://learn.wordpress.org/',
 		)
 	);
 


### PR DESCRIPTION
Adding a link to WordPress.org' Learn section would be a great addition to the menu, providing quick access to those resources from anywhere in your WordPress dashboard.

Trac ticket: https://core.trac.wordpress.org/ticket/58820

