### PR TITLE
Docs: Remove period from the end of `@since` annotations.

### DIFF
--- a/src/wp-includes/class-wp-classic-to-block-menu-converter.php
+++ b/src/wp-includes/class-wp-classic-to-block-menu-converter.php
@@ -9,7 +9,7 @@
 /**
  * Converts a Classic Menu to Block Menu blocks.
  *
- * @since 6.3.0.
+ * @since 6.3.0
  * @access public
  */
 class WP_Classic_To_Block_Menu_Converter {
@@ -17,7 +17,7 @@ class WP_Classic_To_Block_Menu_Converter {
 	/**
 	 * Converts a Classic Menu to blocks.
 	 *
-	 * @since 6.3.0.
+	 * @since 6.3.0
 	 *
 	 * @param WP_Term $menu The Menu term object of the menu to convert.
 	 * @return string the serialized and normalized parsed blocks.
@@ -58,7 +58,7 @@ class WP_Classic_To_Block_Menu_Converter {
 	/**
 	 * Returns an array of menu items grouped by the id of the parent menu item.
 	 *
-	 * @since 6.3.0.
+	 * @since 6.3.0
 	 *
 	 * @param array $menu_items An array of menu items.
 	 * @return array
@@ -76,7 +76,7 @@ class WP_Classic_To_Block_Menu_Converter {
 	/**
 	 * Turns menu item data into a nested array of parsed blocks
 	 *
-	 * @since 6.3.0.
+	 * @since 6.3.0
 	 *
 	 * @param array $menu_items               An array of menu items that represent
 	 *                                        an individual level of a menu.

--- a/src/wp-includes/class-wp-navigation-fallback.php
+++ b/src/wp-includes/class-wp-navigation-fallback.php
@@ -13,14 +13,14 @@
  * Manages fallback behavior for Navigation menus.
  *
  * @access public
- * @since 6.3.0.
+ * @since 6.3.0
  */
 class WP_Navigation_Fallback {
 
 	/**
 	 * Gets (and/or creates) an appropriate fallback Navigation Menu.
 	 *
-	 * @since 6.3.0.
+	 * @since 6.3.0
 	 *
 	 * @return WP_Post|null the fallback Navigation Post or null.
 	 */
@@ -61,7 +61,7 @@ class WP_Navigation_Fallback {
 	/**
 	 * Finds the most recently published `wp_navigation` post type.
 	 *
-	 * @since 6.3.0.
+	 * @since 6.3.0
 	 *
 	 * @return WP_Post|null the first non-empty Navigation or null.
 	 */
@@ -90,7 +90,7 @@ class WP_Navigation_Fallback {
 	/**
 	 * Creates a Navigation Menu post from a Classic Menu.
 	 *
-	 * @since 6.3.0.
+	 * @since 6.3.0
 	 *
 	 * @return int|WP_Error The post ID of the default fallback menu or a WP_Error object.
 	 */
@@ -127,7 +127,7 @@ class WP_Navigation_Fallback {
 	/**
 	 * Determine the most appropriate classic navigation menu to use as a fallback.
 	 *
-	 * @since 6.3.0.
+	 * @since 6.3.0
 	 *
 	 * @return WP_Term|null The most appropriate classic navigation menu to use as a fallback.
 	 */
@@ -157,7 +157,7 @@ class WP_Navigation_Fallback {
 	/**
 	 * Sorts the classic menus and returns the most recently created one.
 	 *
-	 * @since 6.3.0.
+	 * @since 6.3.0
 	 *
 	 * @param WP_Term[] $classic_nav_menus Array of classic nav menu term objects.
 	 * @return WP_Term The most recently created classic nav menu.
@@ -176,7 +176,7 @@ class WP_Navigation_Fallback {
 	/**
 	 * Returns the classic menu with the slug `primary` if it exists.
 	 *
-	 * @since 6.3.0.
+	 * @since 6.3.0
 	 *
 	 * @param WP_Term[] $classic_nav_menus Array of classic nav menu term objects.
 	 * @return WP_Term|null The classic nav menu with the slug `primary` or null.
@@ -196,7 +196,7 @@ class WP_Navigation_Fallback {
 	 * Gets the classic menu assigned to the `primary` navigation menu location
 	 * if it exists.
 	 *
-	 * @since 6.3.0.
+	 * @since 6.3.0
 	 *
 	 * @return WP_Term|null The classic nav menu assigned to the `primary` location or null.
 	 */
@@ -217,7 +217,7 @@ class WP_Navigation_Fallback {
 	/**
 	 * Creates a default Navigation Block Menu fallback.
 	 *
-	 * @since 6.3.0.
+	 * @since 6.3.0
 	 *
 	 * @return int|WP_Error The post ID of the default fallback menu or a WP_Error object.
 	 */
@@ -243,7 +243,7 @@ class WP_Navigation_Fallback {
 	/**
 	 * Gets the rendered markup for the default fallback blocks.
 	 *
-	 * @since 6.3.0.
+	 * @since 6.3.0
 	 *
 	 * @return string default blocks markup to use a the fallback.
 	 */

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-navigation-fallback-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-navigation-fallback-controller.php
@@ -12,14 +12,14 @@
 /**
  * REST Controller to fetch a fallback Navigation Block Menu. If needed it creates one.
  *
- * @since 6.3.0.
+ * @since 6.3.0
  */
 class WP_REST_Navigation_Fallback_Controller extends WP_REST_Controller {
 
 	/**
 	 * The Post Type for the Controller
 	 *
-	 * @since 6.3.0.
+	 * @since 6.3.0
 	 *
 	 * @var string
 	 */
@@ -28,7 +28,7 @@ class WP_REST_Navigation_Fallback_Controller extends WP_REST_Controller {
 	/**
 	 * Constructs the controller.
 	 *
-	 * @since 6.3.0.
+	 * @since 6.3.0
 	 */
 	public function __construct() {
 		$this->namespace = 'wp-block-editor/v1';
@@ -39,7 +39,7 @@ class WP_REST_Navigation_Fallback_Controller extends WP_REST_Controller {
 	/**
 	 * Registers the controllers routes.
 	 *
-	 * @since 6.3.0.
+	 * @since 6.3.0
 	 *
 	 * @return void
 	 */
@@ -64,7 +64,7 @@ class WP_REST_Navigation_Fallback_Controller extends WP_REST_Controller {
 	/**
 	 * Checks if a given request has access to read fallbacks.
 	 *
-	 * @since 6.3.0.
+	 * @since 6.3.0
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
@@ -96,7 +96,7 @@ class WP_REST_Navigation_Fallback_Controller extends WP_REST_Controller {
 	/**
 	 * Gets the most appropriate fallback Navigation Menu.
 	 *
-	 * @since 6.3.0.
+	 * @since 6.3.0
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
@@ -116,7 +116,7 @@ class WP_REST_Navigation_Fallback_Controller extends WP_REST_Controller {
 	/**
 	 * Retrieves the fallbacks' schema, conforming to JSON Schema.
 	 *
-	 * @since 6.3.0.
+	 * @since 6.3.0
 	 *
 	 * @return array Item schema data.
 	 */
@@ -145,7 +145,7 @@ class WP_REST_Navigation_Fallback_Controller extends WP_REST_Controller {
 	/**
 	 * Matches the post data to the schema we want.
 	 *
-	 * @since 6.3.0.
+	 * @since 6.3.0
 	 *
 	 * @param WP_Post         $item     The wp_navigation Post object whose response is being prepared.
 	 * @param WP_REST_Request $request  Request object.
@@ -177,7 +177,7 @@ class WP_REST_Navigation_Fallback_Controller extends WP_REST_Controller {
 	/**
 	 * Prepares the links for the request.
 	 *
-	 * @since 6.3.0.
+	 * @since 6.3.0
 	 *
 	 * @param WP_Post $post the Navigation Menu post object.
 	 * @return array Links for the given request.


### PR DESCRIPTION
This removes the period from several `@since` annotations which included a period after the version number.

Trac ticket: https://core.trac.wordpress.org/ticket/58834
