### PR TITLE
Global styles revisions: update private methods to protected

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-revisions-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-revisions-controller.php
@@ -21,7 +21,7 @@ class WP_REST_Global_Styles_Revisions_Controller extends WP_REST_Controller {
 	 * @since 6.3.0
 	 * @var string
 	 */
-	private $parent_post_type;
+	protected $parent_post_type;
 
 	/**
 	 * The base of the parent controller's route.
@@ -29,7 +29,7 @@ class WP_REST_Global_Styles_Revisions_Controller extends WP_REST_Controller {
 	 * @since 6.3.0
 	 * @var string
 	 */
-	private $parent_base;
+	protected $parent_base;
 
 	/**
 	 * Constructor.
@@ -102,7 +102,7 @@ class WP_REST_Global_Styles_Revisions_Controller extends WP_REST_Controller {
 	 * @param string $raw_json Encoded JSON from global styles custom post content.
 	 * @return Array|WP_Error
 	 */
-	private function get_decoded_global_styles_json( $raw_json ) {
+	protected function get_decoded_global_styles_json( $raw_json ) {
 		$decoded_json = json_decode( $raw_json, true );
 
 		if ( is_array( $decoded_json ) && isset( $decoded_json['isGlobalStylesUserThemeJSON'] ) && true === $decoded_json['isGlobalStylesUserThemeJSON'] ) {


### PR DESCRIPTION
Updates the private vars and methods in the Global styles revisions rest API controller to be protected.

Why? So class entities that inherit from the base can use them, and we can iterate on 6.3 features without having to copy over private methods to new classes all the time.

Gutenberg PR: https://github.com/WordPress/gutenberg/pull/52748

Trac ticket: https://core.trac.wordpress.org/ticket/58846

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
