### PR TITLE
Permalinks: Force draft permalinks to be unique

### DIFF
--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -2128,12 +2128,6 @@ function wp_ajax_inline_save() {
 		}
 	}
 
-	// Hack: wp_unique_post_slug() doesn't work for drafts, so we will fake that our post is published.
-	if ( ! empty( $data['post_name'] ) && in_array( $post['post_status'], array( 'draft', 'pending' ), true ) ) {
-		$post['post_status'] = 'publish';
-		$data['post_name']   = wp_unique_post_slug( $data['post_name'], $post['ID'], $post['post_status'], $post['post_type'], $post['post_parent'] );
-	}
-
 	// Update the post.
 	edit_post();
 

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -4214,11 +4214,11 @@ function wp_insert_post( $postarr, $wp_error = false, $fire_after_hooks = true )
 	}
 
 	/*
-	 * Create a valid post name. Drafts and pending posts are allowed to have
+	 * Create a valid post name. Auto-Drafts and pending posts are allowed to have
 	 * an empty post name.
 	 */
 	if ( empty( $post_name ) ) {
-		if ( ! in_array( $post_status, array( 'draft', 'pending', 'auto-draft' ), true ) ) {
+		if ( ! in_array( $post_status, array( 'pending', 'auto-draft' ), true ) ) {
 			$post_name = sanitize_title( $post_title );
 		} else {
 			$post_name = '';
@@ -4509,7 +4509,7 @@ function wp_insert_post( $postarr, $wp_error = false, $fire_after_hooks = true )
 		$where = array( 'ID' => $post_id );
 	}
 
-	if ( empty( $data['post_name'] ) && ! in_array( $data['post_status'], array( 'draft', 'pending', 'auto-draft' ), true ) ) {
+	if ( empty( $data['post_name'] ) && ! in_array( $data['post_status'], array( 'pending', 'auto-draft' ), true ) ) {
 		$data['post_name'] = wp_unique_post_slug( sanitize_title( $data['post_title'], $post_id ), $post_id, $data['post_status'], $post_type, $post_parent );
 
 		$wpdb->update( $wpdb->posts, array( 'post_name' => $data['post_name'] ), $where );
@@ -5011,13 +5011,13 @@ function wp_resolve_post_date( $post_date = '', $post_date_gmt = '' ) {
  *
  * @param string $slug        The desired slug (post_name).
  * @param int    $post_id     Post ID.
- * @param string $post_status No uniqueness checks are made if the post is still draft or pending.
+ * @param string $post_status No uniqueness checks are made if the post is still auto-draft or pending.
  * @param string $post_type   Post type.
  * @param int    $post_parent Post parent ID.
  * @return string Unique slug for the post, based on $post_name (with a -1, -2, etc. suffix)
  */
 function wp_unique_post_slug( $slug, $post_id, $post_status, $post_type, $post_parent ) {
-	if ( in_array( $post_status, array( 'draft', 'pending', 'auto-draft' ), true )
+	if ( in_array( $post_status, array( 'pending', 'auto-draft' ), true )
 		|| ( 'inherit' === $post_status && 'revision' === $post_type ) || 'user_request' === $post_type
 	) {
 		return $slug;


### PR DESCRIPTION
Currently the wp_unique_post_slug function does not check on draft posts which can cause data from the wrong post to display if a slug is reused, as it does not properly append -2.

This change treats drafts the same as published, something that is already hackey fixed for the block editor.

It has been tested with and without classic editor active.

Trac ticket: https://core.trac.wordpress.org/ticket/58813