### PR TITLE
Docs: Wrap inline `@see` tags in curly braces.

### DIFF
--- a/src/wp-admin/includes/class-language-pack-upgrader.php
+++ b/src/wp-admin/includes/class-language-pack-upgrader.php
@@ -153,7 +153,7 @@ class Language_Pack_Upgrader extends WP_Upgrader {
 	 *
 	 * @global WP_Filesystem_Base $wp_filesystem WordPress filesystem subclass.
 	 *
-	 * @param object[] $language_updates Optional. Array of language packs to update. @see wp_get_translation_updates().
+	 * @param object[] $language_updates Optional. Array of language packs to update. See {@see wp_get_translation_updates()}.
 	 *                                   Default empty array.
 	 * @param array    $args {
 	 *     Other arguments for upgrading multiple language packs. Default empty array.

--- a/src/wp-admin/includes/class-walker-category-checklist.php
+++ b/src/wp-admin/includes/class-walker-category-checklist.php
@@ -32,7 +32,7 @@ class Walker_Category_Checklist extends Walker {
 	 *
 	 * @param string $output Used to append additional content (passed by reference).
 	 * @param int    $depth  Depth of category. Used for tab indentation.
-	 * @param array  $args   An array of arguments. @see wp_terms_checklist()
+	 * @param array  $args   An array of arguments. See {@see wp_terms_checklist()}.
 	 */
 	public function start_lvl( &$output, $depth = 0, $args = array() ) {
 		$indent  = str_repeat( "\t", $depth );
@@ -48,7 +48,7 @@ class Walker_Category_Checklist extends Walker {
 	 *
 	 * @param string $output Used to append additional content (passed by reference).
 	 * @param int    $depth  Depth of category. Used for tab indentation.
-	 * @param array  $args   An array of arguments. @see wp_terms_checklist()
+	 * @param array  $args   An array of arguments. See {@see wp_terms_checklist()}.
 	 */
 	public function end_lvl( &$output, $depth = 0, $args = array() ) {
 		$indent  = str_repeat( "\t", $depth );
@@ -67,7 +67,7 @@ class Walker_Category_Checklist extends Walker {
 	 * @param string  $output            Used to append additional content (passed by reference).
 	 * @param WP_Term $data_object       The current term object.
 	 * @param int     $depth             Depth of the term in reference to parents. Default 0.
-	 * @param array   $args              An array of arguments. @see wp_terms_checklist()
+	 * @param array   $args              An array of arguments. See {@see wp_terms_checklist()}.
 	 * @param int     $current_object_id Optional. ID of the current term. Default 0.
 	 */
 	public function start_el( &$output, $data_object, $depth = 0, $args = array(), $current_object_id = 0 ) {
@@ -130,7 +130,7 @@ class Walker_Category_Checklist extends Walker {
 	 * @param string  $output      Used to append additional content (passed by reference).
 	 * @param WP_Term $data_object The current term object.
 	 * @param int     $depth       Depth of the term in reference to parents. Default 0.
-	 * @param array   $args        An array of arguments. @see wp_terms_checklist()
+	 * @param array   $args        An array of arguments. See {@see wp_terms_checklist()}.
 	 */
 	public function end_el( &$output, $data_object, $depth = 0, $args = array() ) {
 		$output .= "</li>\n";

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -777,9 +777,9 @@ function validate_file_to_edit( $file, $allowed_files = array() ) {
  *     An array of override parameters for this file, or boolean false if none are provided.
  *
  *     @type callable $upload_error_handler     Function to call when there is an error during the upload process.
- *                                              @see wp_handle_upload_error().
+ *                                              See {@see wp_handle_upload_error()}.
  *     @type callable $unique_filename_callback Function to call when determining a unique file name for the file.
- *                                              @see wp_unique_filename().
+ *                                              See {@see wp_unique_filename()}.
  *     @type string[] $upload_error_strings     The strings that describe the error indicated in
  *                                              `$_FILES[{form field}]['error']`.
  *     @type bool     $test_form                Whether to test that the `$_POST['action']` parameter is as expected.
@@ -845,7 +845,7 @@ function _wp_handle_upload( &$file, $overrides, $time, $action ) {
 	 * @since 5.7.0
 	 *
 	 * @param array|false $overrides An array of override parameters for this file. Boolean false if none are
-	 *                               provided. @see _wp_handle_upload().
+	 *                               provided. See {@see _wp_handle_upload()}.
 	 * @param array       $file      {
 	 *     Reference to a single element from `$_FILES`.
 	 *

--- a/src/wp-includes/category.php
+++ b/src/wp-includes/category.php
@@ -307,7 +307,7 @@ function get_tags( $args = '' ) {
 		 *
 		 * @param WP_Term[]|int|WP_Error $tags Array of 'post_tag' term objects, a count thereof,
 		 *                                     or WP_Error if any of the taxonomies do not exist.
-		 * @param array                  $args An array of arguments. @see get_terms()
+		 * @param array                  $args An array of arguments. See {@see get_terms()}.
 		 */
 		$tags = apply_filters( 'get_tags', $tags, $args );
 	}

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -4312,7 +4312,7 @@ class WP_Query {
 	 * If you set a static page for the front page of your site, this function will return
 	 * true when viewing that page.
 	 *
-	 * Otherwise the same as @see WP_Query::is_home()
+	 * Otherwise the same as {@see WP_Query::is_home()}.
 	 *
 	 * @since 3.1.0
 	 *

--- a/src/wp-includes/customize/class-wp-customize-themes-section.php
+++ b/src/wp-includes/customize/class-wp-customize-themes-section.php
@@ -115,7 +115,7 @@ class WP_Customize_Themes_Section extends WP_Customize_Section {
 	 * Render the filter bar portion of a themes section as a JS template.
 	 *
 	 * The template is only rendered by PHP once, so all actions are prepared at once on the server side.
-	 * The filter bar container is rendered by @see `render_template()`.
+	 * The filter bar container is rendered by {@see render_template()}.
 	 *
 	 * @since 4.9.0
 	 */
@@ -179,7 +179,7 @@ class WP_Customize_Themes_Section extends WP_Customize_Section {
 	/**
 	 * Render the filter drawer portion of a themes section as a JS template.
 	 *
-	 * The filter bar container is rendered by @see `render_template()`.
+	 * The filter bar container is rendered by {@see render_template()}.
 	 *
 	 * @since 4.9.0
 	 */

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -3207,7 +3207,7 @@ function wp_audio_shortcode( $attr, $content = '' ) {
 	 * @since 3.6.0
 	 *
 	 * @param string $html     Empty variable to be replaced with shortcode markup.
-	 * @param array  $attr     Attributes of the shortcode. @see wp_audio_shortcode()
+	 * @param array  $attr     Attributes of the shortcode. See {@see wp_audio_shortcode()}.
 	 * @param string $content  Shortcode content.
 	 * @param int    $instance Unique numeric ID of this audio shortcode instance.
 	 */
@@ -3429,7 +3429,7 @@ function wp_video_shortcode( $attr, $content = '' ) {
 	 * @see wp_video_shortcode()
 	 *
 	 * @param string $html     Empty variable to be replaced with shortcode markup.
-	 * @param array  $attr     Attributes of the shortcode. @see wp_video_shortcode()
+	 * @param array  $attr     Attributes of the shortcode. See {@see wp_video_shortcode()}.
 	 * @param string $content  Video shortcode content.
 	 * @param int    $instance Unique numeric ID of this video shortcode instance.
 	 */
@@ -4501,7 +4501,7 @@ function wp_prepare_attachment_for_js( $attachment ) {
 	 *
 	 * @since 3.5.0
 	 *
-	 * @param array       $response   Array of prepared attachment data. @see wp_prepare_attachment_for_js().
+	 * @param array       $response   Array of prepared attachment data. See {@see wp_prepare_attachment_for_js()}.
 	 * @param WP_Post     $attachment Attachment object.
 	 * @param array|false $meta       Array of attachment meta data, or false if there is none.
 	 */

--- a/src/wp-includes/ms-site.php
+++ b/src/wp-includes/ms-site.php
@@ -844,7 +844,7 @@ function wp_uninitialize_site( $site_id ) {
 	 *
 	 * @since MU (3.0.0)
 	 *
-	 * @param string $basedir Uploads path without subdirectory. @see wp_upload_dir()
+	 * @param string $basedir Uploads path without subdirectory. See {@see wp_upload_dir()}.
 	 * @param int    $site_id The site ID.
 	 */
 	$dir     = apply_filters( 'wpmu_delete_blog_upload_dir', $uploads['basedir'], $site->id );

--- a/src/wp-includes/query.php
+++ b/src/wp-includes/query.php
@@ -451,7 +451,7 @@ function is_comment_feed() {
  * If you set a static page for the front page of your site, this function will return
  * true when viewing that page.
  *
- * Otherwise the same as @see is_home()
+ * Otherwise the same as {@see is_home()}.
  *
  * For more information on this and similar theme functions, check out
  * the {@link https://developer.wordpress.org/themes/basics/conditional-tags/

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -515,7 +515,7 @@ do_action( 'sanitize_comment_cookies' );
 $GLOBALS['wp_the_query'] = new WP_Query();
 
 /**
- * Holds the reference to @see $wp_the_query
+ * Holds the reference to {@see $wp_the_query}.
  * Use this global for WordPress queries
  *
  * @global WP_Query $wp_query WordPress Query object.


### PR DESCRIPTION
This wraps inline `@see` tags in curly braces to fix broken references on DevHub.

Trac ticket: https://core.trac.wordpress.org/ticket/58858
