### PR TITLE
Add `CI=true` in GHA while running `npm ci` command

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -162,6 +162,8 @@ jobs:
 
       - name: Install npm Dependencies
         run: npm ci
+        env:
+          CI: true
 
       - name: Run JSHint
         run: npm run grunt jshint

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -87,6 +87,8 @@ jobs:
 
       - name: Install npm Dependencies
         run: npm ci
+        env:
+          CI: true
 
       - name: Build WordPress
         run: npm run build

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -79,6 +79,8 @@ jobs:
 
       - name: Install npm Dependencies
         run: npm ci
+        env:
+          CI: true
 
       - name: Run QUnit tests
         run: npm run grunt qunit:compiled

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -100,6 +100,8 @@ jobs:
 
       - name: Install npm dependencies
         run: npm ci
+        env:
+          CI: true
 
       - name: Build WordPress
         run: npm run build

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -127,6 +127,8 @@ jobs:
 
       - name: Install npm dependencies
         run: npm ci
+        env:
+          CI: true
 
       - name: General debug information
         run: |

--- a/.github/workflows/test-and-zip-default-themes.yml
+++ b/.github/workflows/test-and-zip-default-themes.yml
@@ -92,6 +92,8 @@ jobs:
 
       - name: Install npm dependencies
         run: npm ci
+        env:
+          CI: true
 
       - name: Build theme
         run: npm run build

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -106,6 +106,8 @@ jobs:
 
       - name: Install npm Dependencies
         run: npm ci
+        env:
+          CI: true
 
       - name: Log debug information
         run: |

--- a/.github/workflows/test-npm.yml
+++ b/.github/workflows/test-npm.yml
@@ -86,6 +86,8 @@ jobs:
 
       - name: Install npm Dependencies
         run: npm ci
+        env:
+          CI: true
 
       - name: Build WordPress in /src
         run: npm run build:dev
@@ -152,6 +154,8 @@ jobs:
 
       - name: Install npm Dependencies
         run: npm ci
+        env:
+          CI: true
 
       - name: Build WordPress in /src
         run: npm run build:dev


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/57865

Add a `CI` environment variable to notify npm that packages are being installed in a CI environment. 

Also see: https://docs.npmjs.com/cli/v8/using-npm/registry#does-npm-send-any-information-about-me-back-to-the-registry

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
