### PR TITLE
Database: support uca14.0.0 collation from MariaDB-10.10.1+

### DIFF
--- a/src/wp-includes/class-wpdb.php
+++ b/src/wp-includes/class-wpdb.php
@@ -881,9 +881,16 @@ class wpdb {
 			}
 		}
 
-		// _unicode_520_ is a better collation, we should use that when it's available.
-		if ( $this->has_cap( 'utf8mb4_520' ) && 'utf8mb4_unicode_ci' === $collate ) {
-			$collate = 'utf8mb4_unicode_520_ci';
+		/*
+		 * _uca1400_ai_ci_ is a better collation, we should use that when it's available.
+		 * but fall back to _unicode_520_ when it's available.
+		 */
+		if ( 'utf8mb4_unicode_ci' === $collate ) {
+			if ( $this->has_cap( 'uca1400' ) ) {
+				$collate = 'uca1400_ai_ci';
+			} elseif ( $this->has_cap( 'utf8mb4_520' ) ) {
+				$collate = 'utf8mb4_unicode_520_ci';
+			}
 		}
 
 		return compact( 'charset', 'collate' );
@@ -3509,6 +3516,7 @@ class wpdb {
 			'utf8mb3_general_ci',
 			'utf8mb4_bin',
 			'utf8mb4_general_ci',
+			'uca1400_ai_ci',
 		);
 
 		foreach ( $this->col_meta[ $table ] as $col ) {
@@ -4042,12 +4050,13 @@ class wpdb {
 	 * @since 4.1.0 Added support for the 'utf8mb4' feature.
 	 * @since 4.6.0 Added support for the 'utf8mb4_520' feature.
 	 * @since 6.2.0 Added support for the 'identifier_placeholders' feature.
+	 * @since 6.4.0 Added support for the 'uca1400' feature.
 	 *
 	 * @see wpdb::db_version()
 	 *
 	 * @param string $db_cap The feature to check for. Accepts 'collation', 'group_concat',
 	 *                       'subqueries', 'set_charset', 'utf8mb4', 'utf8mb4_520',
-	 *                       or 'identifier_placeholders'.
+	 *                       'identifier_placeholders' or 'uca1400'.
 	 * @return bool True when the database feature is supported, false otherwise.
 	 */
 	public function has_cap( $db_cap ) {
@@ -4105,6 +4114,13 @@ class wpdb {
 				 * e.g. table/field names.
 				 */
 				return true;
+			case 'uca1400': // @since 6.4.0
+				$res = mysqli_query( $this->dbh, 'SHOW COLLATION WHERE Collation=\'uca1400_ai_ci\'' );
+
+				if ( $res ) {
+					return mysqli_num_rows( $res ) > 0;
+				}
+				return false;
 		}
 
 		return false;

--- a/tests/phpunit/tests/db.php
+++ b/tests/phpunit/tests/db.php
@@ -1452,6 +1452,26 @@ class Tests_DB extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 58871
+	 *
+	 * @covers wpdb::determine_charset
+	 */
+	public function test_collate_switched_to_uca1400() {
+		global $wpdb;
+
+		if ( ! $wpdb->has_cap( 'uca1400' ) ) {
+			$this->markTestSkipped( 'This test requires uca1400 support.' );
+		}
+
+		$charset = 'utf8';
+		$collate = 'utf8_general_ci';
+
+		$result = $wpdb->determine_charset( $charset, $collate );
+
+		$this->assertSame( 'uca1400_ai_ci', $result['collate'] );
+	}
+
+	/**
 	 * @ticket 32105
 	 * @ticket 36917
 	 */
@@ -1460,6 +1480,10 @@ class Tests_DB extends WP_UnitTestCase {
 
 		if ( ! $wpdb->has_cap( 'utf8mb4_520' ) ) {
 			$this->markTestSkipped( 'This test requires utf8mb4_520 support.' );
+		}
+
+		if ( $wpdb->has_cap( 'uca1400' ) ) {
+			$this->markTestSkipped( 'This test requires uca1400 to not be supported.' );
 		}
 
 		$charset = 'utf8';


### PR DESCRIPTION
Use UCA-14.0.0 that was added in MariaDB-10.10.1 as default.

Trac ticket: https://core.trac.wordpress.org/ticket/58871