### PR TITLE
Multisite: Use helper functions for admin notices.

### DIFF
--- a/src/wp-admin/includes/class-wp-ms-themes-list-table.php
+++ b/src/wp-admin/includes/class-wp-ms-themes-list-table.php
@@ -859,7 +859,13 @@ class WP_MS_Themes_List_Table extends WP_List_Table {
 		 */
 		echo apply_filters( 'theme_auto_update_setting_html', $html, $stylesheet, $theme );
 
-		echo '<div class="notice notice-error notice-alt inline hidden"><p></p></div>';
+		wp_admin_notice(
+			'',
+			array(
+				'type'               => 'error',
+				'additional_classes' => array( 'notice-alt', 'inline', 'hidden' ),
+			)
+		);
 	}
 
 	/**

--- a/src/wp-admin/includes/network.php
+++ b/src/wp-admin/includes/network.php
@@ -125,11 +125,14 @@ function network_step1( $errors = false ) {
 
 	$active_plugins = get_option( 'active_plugins' );
 	if ( ! empty( $active_plugins ) ) {
-		echo '<div class="notice notice-warning"><p><strong>' . __( 'Warning:' ) . '</strong> ' . sprintf(
-			/* translators: %s: URL to Plugins screen. */
-			__( 'Please <a href="%s">deactivate your plugins</a> before enabling the Network feature.' ),
-			admin_url( 'plugins.php?plugin_status=active' )
-		) . '</p></div>';
+		wp_admin_notice(
+			'<strong>' . __( 'Warning:' ) . '</strong> ' . sprintf(
+				/* translators: %s: URL to Plugins screen. */
+				__( 'Please <a href="%s">deactivate your plugins</a> before enabling the Network feature.' ),
+				admin_url( 'plugins.php?plugin_status=active' )
+			),
+			array( 'type' => 'warning' )
+		);
 		echo '<p>' . __( 'Once the network is created, you may reactivate your plugins.' ) . '</p>';
 		echo '</div>';
 		require_once ABSPATH . 'wp-admin/admin-footer.php';
@@ -438,35 +441,36 @@ function network_step2( $errors = false ) {
 		?>
 		<h3><?php esc_html_e( 'Enabling the Network' ); ?></h3>
 		<p><?php _e( 'Complete the following steps to enable the features for creating a network of sites.' ); ?></p>
-		<div class="notice notice-warning inline"><p>
 		<?php
+		$notice_message = '<strong>' . __( 'Caution:' ) . '</strong> ';
+		$notice_args    = array(
+			'type'               => 'warning',
+			'additional_classes' => 'inline',
+		);
+
 		if ( file_exists( $home_path . '.htaccess' ) ) {
-			echo '<strong>' . __( 'Caution:' ) . '</strong> ';
-			printf(
+			$notice_message .= sprintf(
 				/* translators: 1: wp-config.php, 2: .htaccess */
 				__( 'You should back up your existing %1$s and %2$s files.' ),
 				'<code>wp-config.php</code>',
 				'<code>.htaccess</code>'
 			);
 		} elseif ( file_exists( $home_path . 'web.config' ) ) {
-			echo '<strong>' . __( 'Caution:' ) . '</strong> ';
-			printf(
+			$notice_message .= sprintf(
 				/* translators: 1: wp-config.php, 2: web.config */
 				__( 'You should back up your existing %1$s and %2$s files.' ),
 				'<code>wp-config.php</code>',
 				'<code>web.config</code>'
 			);
 		} else {
-			echo '<strong>' . __( 'Caution:' ) . '</strong> ';
-			printf(
+			$notice_message .= sprintf(
 				/* translators: %s: wp-config.php */
 				__( 'You should back up your existing %s file.' ),
 				'<code>wp-config.php</code>'
 			);
 		}
-		?>
-		</p></div>
-		<?php
+
+		wp_admin_notice( $notice_message, $notice_args );
 	}
 	?>
 	<ol>

--- a/src/wp-admin/my-sites.php
+++ b/src/wp-admin/my-sites.php
@@ -55,9 +55,17 @@ get_current_screen()->set_help_sidebar(
 
 require_once ABSPATH . 'wp-admin/admin-header.php';
 
-if ( $updated ) { ?>
-	<div id="message" class="notice notice-success is-dismissible"><p><strong><?php _e( 'Settings saved.' ); ?></strong></p></div>
-<?php } ?>
+if ( $updated ) {
+	wp_admin_notice(
+		'<strong>' . __( 'Settings saved.' ) . '</strong>',
+		array(
+			'type'        => 'success',
+			'dismissible' => true,
+			'id'          => 'message',
+		)
+	);
+}
+?>
 
 <div class="wrap">
 <h1 class="wp-heading-inline">
@@ -74,8 +82,14 @@ if ( in_array( get_site_option( 'registration' ), array( 'all', 'blog' ), true )
 }
 
 if ( empty( $blogs ) ) :
+	wp_admin_notice(
+		'<strong>' . __( 'You must be a member of at least one site to use this page.' ) . '</strong>',
+		array(
+			'type'        => 'error',
+			'dismissible' => true,
+		)
+	);
 	?>
-	<div class="notice notice-error is-dismissible"><p><strong><?php _e( 'You must be a member of at least one site to use this page.' ); ?></strong></p></div>
 	<?php
 else :
 	?>

--- a/src/wp-admin/network/settings.php
+++ b/src/wp-admin/network/settings.php
@@ -138,9 +138,14 @@ if ( $_POST ) {
 require_once ABSPATH . 'wp-admin/admin-header.php';
 
 if ( isset( $_GET['updated'] ) ) {
-	?>
-	<div id="message" class="notice notice-success is-dismissible"><p><?php _e( 'Settings saved.' ); ?></p></div>
-	<?php
+	wp_admin_notice(
+		__( 'Settings saved.' ),
+		array(
+			'type'        => 'success',
+			'dismissible' => true,
+			'id'          => 'message',
+		)
+	);
 }
 ?>
 
@@ -167,24 +172,28 @@ if ( isset( $_GET['updated'] ) ) {
 					<?php
 					$new_admin_email = get_site_option( 'new_admin_email' );
 					if ( $new_admin_email && get_site_option( 'admin_email' ) !== $new_admin_email ) :
-						?>
-						<div class="notice notice-warning is-dismissible inline">
-						<p>
-						<?php
-							printf(
-								/* translators: %s: New network admin email. */
-								__( 'There is a pending change of the network admin email to %s.' ),
-								'<code>' . esc_html( $new_admin_email ) . '</code>'
-							);
-							printf(
-								' <a href="%1$s">%2$s</a>',
-								esc_url( wp_nonce_url( network_admin_url( 'settings.php?dismiss=new_network_admin_email' ), 'dismiss_new_network_admin_email' ) ),
-								__( 'Cancel' )
-							);
-						?>
-						</p>
-						</div>
-					<?php endif; ?>
+						$notice_message = sprintf(
+							/* translators: %s: New network admin email. */
+							__( 'There is a pending change of the network admin email to %s.' ),
+							'<code>' . esc_html( $new_admin_email ) . '</code>'
+						);
+
+						$notice_message .= sprintf(
+							' <a href="%1$s">%2$s</a>',
+							esc_url( wp_nonce_url( network_admin_url( 'settings.php?dismiss=new_network_admin_email' ), 'dismiss_new_network_admin_email' ) ),
+							__( 'Cancel' )
+						);
+
+						wp_admin_notice(
+							$notice_message,
+							array(
+								'type'               => 'warning',
+								'dismissible'        => true,
+								'additional_classes' => array( 'inline' ),
+							)
+						);
+					endif;
+					?>
 				</td>
 			</tr>
 		</table>

--- a/src/wp-admin/network/site-info.php
+++ b/src/wp-admin/network/site-info.php
@@ -146,8 +146,14 @@ network_edit_site_nav(
 );
 
 if ( ! empty( $messages ) ) {
+	$notice_args = array(
+		'type'        => 'success',
+		'dismissible' => true,
+		'id'          => 'message',
+	);
+
 	foreach ( $messages as $msg ) {
-		echo '<div id="message" class="notice notice-success is-dismissible"><p>' . $msg . '</p></div>';
+		wp_admin_notice( $msg, $notice_args );
 	}
 }
 ?>

--- a/src/wp-admin/network/site-new.php
+++ b/src/wp-admin/network/site-new.php
@@ -192,8 +192,14 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 <h1 id="add-new-site"><?php _e( 'Add New Site' ); ?></h1>
 <?php
 if ( ! empty( $messages ) ) {
+	$notice_args = array(
+		'type'        => 'success',
+		'dismissible' => true,
+		'id'          => 'message',
+	);
+
 	foreach ( $messages as $msg ) {
-		echo '<div id="message" class="notice notice-success is-dismissible"><p>' . $msg . '</p></div>';
+		wp_admin_notice( $msg, $notice_args );
 	}
 }
 ?>

--- a/src/wp-admin/network/site-settings.php
+++ b/src/wp-admin/network/site-settings.php
@@ -104,8 +104,14 @@ network_edit_site_nav(
 );
 
 if ( ! empty( $messages ) ) {
+	$notice_args = array(
+		'type'        => 'success',
+		'dismissible' => true,
+		'id'          => 'message',
+	);
+
 	foreach ( $messages as $msg ) {
-		echo '<div id="message" class="notice notice-success is-dismissible"><p>' . $msg . '</p></div>';
+		wp_admin_notice( $msg, $notice_args );
 	}
 }
 ?>

--- a/src/wp-admin/network/site-themes.php
+++ b/src/wp-admin/network/site-themes.php
@@ -196,7 +196,15 @@ if ( isset( $_GET['enabled'] ) ) {
 		/* translators: %s: Number of themes. */
 		$message = _n( '%s theme enabled.', '%s themes enabled.', $enabled );
 	}
-	echo '<div id="message" class="notice notice-success is-dismissible"><p>' . sprintf( $message, number_format_i18n( $enabled ) ) . '</p></div>';
+
+	wp_admin_notice(
+		sprintf( $message, number_format_i18n( $enabled ) ),
+		array(
+			'type'        => 'success',
+			'dismissible' => true,
+			'id'          => 'message',
+		)
+	);
 } elseif ( isset( $_GET['disabled'] ) ) {
 	$disabled = absint( $_GET['disabled'] );
 	if ( 1 === $disabled ) {
@@ -205,9 +213,24 @@ if ( isset( $_GET['enabled'] ) ) {
 		/* translators: %s: Number of themes. */
 		$message = _n( '%s theme disabled.', '%s themes disabled.', $disabled );
 	}
-	echo '<div id="message" class="notice notice-success is-dismissible"><p>' . sprintf( $message, number_format_i18n( $disabled ) ) . '</p></div>';
+
+	wp_admin_notice(
+		sprintf( $message, number_format_i18n( $disabled ) ),
+		array(
+			'type'        => 'success',
+			'dismissible' => true,
+			'id'          => 'message',
+		)
+	);
 } elseif ( isset( $_GET['error'] ) && 'none' === $_GET['error'] ) {
-	echo '<div id="message" class="notice notice-error is-dismissible"><p>' . __( 'No theme selected.' ) . '</p></div>';
+	wp_admin_notice(
+		__( 'No theme selected.' ),
+		array(
+			'type'        => 'error',
+			'dismissible' => true,
+			'id'          => 'message',
+		)
+	);
 }
 ?>
 

--- a/src/wp-admin/network/site-users.php
+++ b/src/wp-admin/network/site-users.php
@@ -234,41 +234,57 @@ network_edit_site_nav(
 );
 
 if ( isset( $_GET['update'] ) ) :
+	$message = '';
+	$type    = 'error';
+
 	switch ( $_GET['update'] ) {
 		case 'adduser':
-			echo '<div id="message" class="notice notice-success is-dismissible"><p>' . __( 'User added.' ) . '</p></div>';
+			$type    = 'success';
+			$message = __( 'User added.' );
 			break;
 		case 'err_add_member':
-			echo '<div id="message" class="notice notice-error  is-dismissible"><p>' . __( 'User is already a member of this site.' ) . '</p></div>';
+			$message = __( 'User is already a member of this site.' );
 			break;
 		case 'err_add_fail':
-			echo '<div id="message" class="notice notice-error is-dismissible"><p>' . __( 'User could not be added to this site.' ) . '</p></div>';
+			$message = __( 'User could not be added to this site.' );
 			break;
 		case 'err_add_notfound':
-			echo '<div id="message" class="notice notice-error is-dismissible"><p>' . __( 'Enter the username of an existing user.' ) . '</p></div>';
+			$message = __( 'Enter the username of an existing user.' );
 			break;
 		case 'promote':
-			echo '<div id="message" class="notice notice-success is-dismissible"><p>' . __( 'Changed roles.' ) . '</p></div>';
+			$type    = 'success';
+			$message = __( 'Changed roles.' );
 			break;
 		case 'err_promote':
-			echo '<div id="message" class="notice notice-error is-dismissible"><p>' . __( 'Select a user to change role.' ) . '</p></div>';
+			$message = __( 'Select a user to change role.' );
 			break;
 		case 'remove':
-			echo '<div id="message" class="notice notice-success is-dismissible"><p>' . __( 'User removed from this site.' ) . '</p></div>';
+			$type    = 'success';
+			$message = __( 'User removed from this site.' );
 			break;
 		case 'err_remove':
-			echo '<div id="message" class="notice notice-error is-dismissible"><p>' . __( 'Select a user to remove.' ) . '</p></div>';
+			$message = __( 'Select a user to remove.' );
 			break;
 		case 'newuser':
-			echo '<div id="message" class="notice notice-success is-dismissible"><p>' . __( 'User created.' ) . '</p></div>';
+			$type    = 'success';
+			$message = __( 'User created.' );
 			break;
 		case 'err_new':
-			echo '<div id="message" class="notice notice-error is-dismissible"><p>' . __( 'Enter the username and email.' ) . '</p></div>';
+			$message = __( 'Enter the username and email.' );
 			break;
 		case 'err_new_dup':
-			echo '<div id="message" class="notice notice-error is-dismissible"><p>' . __( 'Duplicated username or email address.' ) . '</p></div>';
+			$message = __( 'Duplicated username or email address.' );
 			break;
 	}
+
+	wp_admin_notice(
+		$message,
+		array(
+			'type'        => $type,
+			'dismissible' => true,
+			'id'          => 'message',
+		)
+	);
 endif;
 ?>
 

--- a/src/wp-admin/network/sites.php
+++ b/src/wp-admin/network/sites.php
@@ -358,7 +358,14 @@ if ( isset( $_GET['updated'] ) ) {
 	}
 
 	if ( ! empty( $msg ) ) {
-		$msg = '<div id="message" class="notice notice-success is-dismissible"><p>' . $msg . '</p></div>';
+		$msg = wp_get_admin_notice(
+			$msg,
+			array(
+				'type'        => 'success',
+				'dismissible' => true,
+				'id'          => 'message',
+			)
+		);
 	}
 }
 

--- a/src/wp-admin/network/themes.php
+++ b/src/wp-admin/network/themes.php
@@ -367,57 +367,82 @@ if ( isset( $_REQUEST['s'] ) && strlen( $_REQUEST['s'] ) ) {
 <hr class="wp-header-end">
 
 <?php
+$message = '';
+$type    = 'success';
+
 if ( isset( $_GET['enabled'] ) ) {
 	$enabled = absint( $_GET['enabled'] );
 	if ( 1 === $enabled ) {
 		$message = __( 'Theme enabled.' );
 	} else {
-		/* translators: %s: Number of themes. */
-		$message = _n( '%s theme enabled.', '%s themes enabled.', $enabled );
+		$message = sprintf(
+			/* translators: %s: Number of themes. */
+			_n( '%s theme enabled.', '%s themes enabled.', $enabled ),
+			number_format_i18n( $enabled )
+		);
 	}
-	echo '<div id="message" class="notice notice-success is-dismissible"><p>' . sprintf( $message, number_format_i18n( $enabled ) ) . '</p></div>';
 } elseif ( isset( $_GET['disabled'] ) ) {
 	$disabled = absint( $_GET['disabled'] );
 	if ( 1 === $disabled ) {
 		$message = __( 'Theme disabled.' );
 	} else {
-		/* translators: %s: Number of themes. */
-		$message = _n( '%s theme disabled.', '%s themes disabled.', $disabled );
+		$message = sprintf(
+			/* translators: %s: Number of themes. */
+			_n( '%s theme disabled.', '%s themes disabled.', $disabled ),
+			number_format_i18n( $disabled )
+		);
 	}
-	echo '<div id="message" class="notice notice-success is-dismissible"><p>' . sprintf( $message, number_format_i18n( $disabled ) ) . '</p></div>';
 } elseif ( isset( $_GET['deleted'] ) ) {
 	$deleted = absint( $_GET['deleted'] );
 	if ( 1 === $deleted ) {
 		$message = __( 'Theme deleted.' );
 	} else {
-		/* translators: %s: Number of themes. */
-		$message = _n( '%s theme deleted.', '%s themes deleted.', $deleted );
+		$message = sprintf(
+			/* translators: %s: Number of themes. */
+			_n( '%s theme deleted.', '%s themes deleted.', $deleted ),
+			number_format_i18n( $deleted )
+		);
 	}
-	echo '<div id="message" class="notice notice-success is-dismissible"><p>' . sprintf( $message, number_format_i18n( $deleted ) ) . '</p></div>';
 } elseif ( isset( $_GET['enabled-auto-update'] ) ) {
 	$enabled = absint( $_GET['enabled-auto-update'] );
 	if ( 1 === $enabled ) {
 		$message = __( 'Theme will be auto-updated.' );
 	} else {
-		/* translators: %s: Number of themes. */
-		$message = _n( '%s theme will be auto-updated.', '%s themes will be auto-updated.', $enabled );
+		$message = sprintf(
+			/* translators: %s: Number of themes. */
+			_n( '%s theme will be auto-updated.', '%s themes will be auto-updated.', $enabled ),
+			number_format_i18n( $enabled )
+		);
 	}
-	echo '<div id="message" class="notice notice-success is-dismissible"><p>' . sprintf( $message, number_format_i18n( $enabled ) ) . '</p></div>';
 } elseif ( isset( $_GET['disabled-auto-update'] ) ) {
 	$disabled = absint( $_GET['disabled-auto-update'] );
 	if ( 1 === $disabled ) {
 		$message = __( 'Theme will no longer be auto-updated.' );
 	} else {
-		/* translators: %s: Number of themes. */
-		$message = _n( '%s theme will no longer be auto-updated.', '%s themes will no longer be auto-updated.', $disabled );
+		$message = sprintf(
+			/* translators: %s: Number of themes. */
+			_n( '%s theme will no longer be auto-updated.', '%s themes will no longer be auto-updated.', $disabled ),
+			number_format_i18n( $disabled )
+		);
 	}
-	echo '<div id="message" class="notice notice-success is-dismissible"><p>' . sprintf( $message, number_format_i18n( $disabled ) ) . '</p></div>';
 } elseif ( isset( $_GET['error'] ) && 'none' === $_GET['error'] ) {
-	echo '<div id="message" class="notice notice-error is-dismissible"><p>' . __( 'No theme selected.' ) . '</p></div>';
+	$message = __( 'No theme selected.' );
+	$type    = 'error';
 } elseif ( isset( $_GET['error'] ) && 'main' === $_GET['error'] ) {
-	echo '<div id="message" class="notice notice-error is-dismissible"><p>' . __( 'You cannot delete a theme while it is active on the main site.' ) . '</p></div>';
+	$message = __( 'You cannot delete a theme while it is active on the main site.' );
+	$type    = 'error';
 }
 
+if ( '' !== $message ) {
+	wp_admin_notice(
+		$message,
+		array(
+			'type'        => $type,
+			'dismissible' => true,
+			'id'          => 'message',
+		)
+	);
+}
 ?>
 
 <form method="get">

--- a/src/wp-admin/network/user-new.php
+++ b/src/wp-admin/network/user-new.php
@@ -107,19 +107,33 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 <h1 id="add-new-user"><?php _e( 'Add New User' ); ?></h1>
 <?php
 if ( '' !== $message ) {
-	echo '<div id="message" class="notice notice-success is-dismissible"><p>' . $message . '</p></div>';
+	wp_admin_notice(
+		$message,
+		array(
+			'type'        => 'success',
+			'dismissible' => true,
+			'id'          => 'message',
+		)
+	);
 }
 
 if ( isset( $add_user_errors ) && is_wp_error( $add_user_errors ) ) {
-	?>
-	<div id="message" class="notice notice-error is-dismissible">
-		<?php
-		foreach ( $add_user_errors->get_error_messages() as $error ) {
-			echo "<p>$error</p>";
-		}
-		?>
-	</div>
-<?php } ?>
+	$error_messages = '';
+	foreach ( $add_user_errors->get_error_messages() as $error ) {
+		$error_messages .= "<p>$error</p>";
+	}
+
+	wp_admin_notice(
+		$error_messages,
+		array(
+			'type'           => 'error',
+			'dismissible'    => true,
+			'id'             => 'message',
+			'paragraph_wrap' => false,
+		)
+	);
+}
+?>
 	<form action="<?php echo esc_url( network_admin_url( 'user-new.php?action=add-user' ) ); ?>" id="adduser" method="post" novalidate="novalidate">
 		<p><?php echo wp_required_field_message(); ?></p>
 		<table class="form-table" role="presentation">

--- a/src/wp-admin/network/users.php
+++ b/src/wp-admin/network/users.php
@@ -254,29 +254,33 @@ get_current_screen()->set_screen_reader_content(
 require_once ABSPATH . 'wp-admin/admin-header.php';
 
 if ( isset( $_REQUEST['updated'] ) && 'true' === $_REQUEST['updated'] && ! empty( $_REQUEST['action'] ) ) {
-	?>
-	<div id="message" class="notice notice-success is-dismissible"><p>
-		<?php
-		switch ( $_REQUEST['action'] ) {
-			case 'delete':
-				_e( 'User deleted.' );
-				break;
-			case 'all_spam':
-				_e( 'Users marked as spam.' );
-				break;
-			case 'all_notspam':
-				_e( 'Users removed from spam.' );
-				break;
-			case 'all_delete':
-				_e( 'Users deleted.' );
-				break;
-			case 'add':
-				_e( 'User added.' );
-				break;
-		}
-		?>
-	</p></div>
-	<?php
+	$message = '';
+	switch ( $_REQUEST['action'] ) {
+		case 'delete':
+			$message = __( 'User deleted.' );
+			break;
+		case 'all_spam':
+			$message = __( 'Users marked as spam.' );
+			break;
+		case 'all_notspam':
+			$message = __( 'Users removed from spam.' );
+			break;
+		case 'all_delete':
+			$message = __( 'Users deleted.' );
+			break;
+		case 'add':
+			$message = __( 'User added.' );
+			break;
+	}
+
+	wp_admin_notice(
+		$message,
+		array(
+			'type'        => 'success',
+			'dismissible' => true,
+			'id'          => 'message',
+		)
+	);
 }
 ?>
 <div class="wrap">


### PR DESCRIPTION
This implements the new `wp_admin_notice()` and `wp_get_admin_notice()` functions in multisite administration pages.

This PR is blocked and CI failures are expected until #4119 is committed.

Trac ticket: https://core.trac.wordpress.org/ticket/57791
