### PR TITLE
Sitemaps: ignore users who only authored pages

### DIFF
--- a/src/wp-includes/sitemaps/providers/class-wp-sitemaps-users.php
+++ b/src/wp-includes/sitemaps/providers/class-wp-sitemaps-users.php
@@ -136,8 +136,9 @@ class WP_Sitemaps_Users extends WP_Sitemaps_Provider {
 			)
 		);
 
-		// We're not supporting sitemaps for author pages for attachments.
+		// We're not supporting sitemaps for author pages for attachments and pages.
 		unset( $public_post_types['attachment'] );
+		unset( $public_post_types['page'] );
 
 		/**
 		 * Filters the query arguments for authors with public posts.


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/57816

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
