### PR TITLE
WP_List_Table: add doing_it_wrong() when trying to use dynamic class properties

### DIFF
--- a/src/wp-admin/includes/class-wp-list-table.php
+++ b/src/wp-admin/includes/class-wp-list-table.php
@@ -214,7 +214,6 @@ class WP_List_Table {
 			'deprecated since version 6.4.0! Instead, define the property on the class.',
 			E_USER_DEPRECATED
 		);
-		return null;
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-list-table.php
+++ b/src/wp-admin/includes/class-wp-list-table.php
@@ -250,6 +250,7 @@ class WP_List_Table {
 	public function __unset( $name ) {
 		if ( in_array( $name, $this->compat_fields, true ) ) {
 			unset( $this->$name );
+			return;
 		}
 
 		trigger_error(

--- a/src/wp-admin/includes/class-wp-list-table.php
+++ b/src/wp-admin/includes/class-wp-list-table.php
@@ -184,6 +184,17 @@ class WP_List_Table {
 		if ( in_array( $name, $this->compat_fields, true ) ) {
 			return $this->$name;
 		}
+
+		_doing_it_wrong(
+			__METHOD__,
+			sprintf(
+			// translators: 1: The name of the non-existent class property.
+				__( 'The "%1$s" property is not defined. Dynamic properties are deprecated in PHP 8.2 and above.' ),
+				$name
+			),
+			'6.4.0'
+		);
+		return null;
 	}
 
 	/**
@@ -193,12 +204,22 @@ class WP_List_Table {
 	 *
 	 * @param string $name  Property to check if set.
 	 * @param mixed  $value Property value.
-	 * @return mixed Newly-set property.
 	 */
 	public function __set( $name, $value ) {
 		if ( in_array( $name, $this->compat_fields, true ) ) {
-			return $this->$name = $value;
+			$this->$name = $value;
+			return;
 		}
+
+		_doing_it_wrong(
+			__METHOD__,
+			sprintf(
+			// translators: 1: The name of the non-existent class property.
+				__( 'The "%1$s" property is not defined. Dynamic properties are deprecated in PHP 8.2 and above.' ),
+				$name
+			),
+			'6.4.0'
+		);
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-list-table.php
+++ b/src/wp-admin/includes/class-wp-list-table.php
@@ -176,6 +176,7 @@ class WP_List_Table {
 	 * Makes private properties readable for backward compatibility.
 	 *
 	 * @since 4.0.0
+	 * @since 6.4.0 Getting a dynamic property is deprecated.
 	 *
 	 * @param string $name Property to get.
 	 * @return mixed Property.
@@ -185,14 +186,10 @@ class WP_List_Table {
 			return $this->$name;
 		}
 
-		_doing_it_wrong(
-			__METHOD__,
-			sprintf(
-			// translators: 1: The name of the non-existent class property.
-				__( 'The "%1$s" property is not defined. Dynamic properties are deprecated in PHP 8.2 and above.' ),
-				$name
-			),
-			'6.4.0'
+		trigger_error(
+			"The property `{$name}` is not defined. Getting a dynamic (undefined) property is " .
+			'deprecated since version 6.4.0! Instead, define the property on the class.',
+			E_USER_DEPRECATED
 		);
 		return null;
 	}
@@ -201,6 +198,7 @@ class WP_List_Table {
 	 * Makes private properties settable for backward compatibility.
 	 *
 	 * @since 4.0.0
+	 * @since 6.4.0 Setting a dynamic property is deprecated.
 	 *
 	 * @param string $name  Property to check if set.
 	 * @param mixed  $value Property value.
@@ -211,21 +209,19 @@ class WP_List_Table {
 			return;
 		}
 
-		_doing_it_wrong(
-			__METHOD__,
-			sprintf(
-			// translators: 1: The name of the non-existent class property.
-				__( 'The "%1$s" property is not defined. Dynamic properties are deprecated in PHP 8.2 and above.' ),
-				$name
-			),
-			'6.4.0'
+		trigger_error(
+			"The property `{$name}` is not defined. Setting a dynamic (undefined) property is " .
+			'deprecated since version 6.4.0! Instead, define the property on the class.',
+			E_USER_DEPRECATED
 		);
+		return null;
 	}
 
 	/**
 	 * Makes private properties checkable for backward compatibility.
 	 *
 	 * @since 4.0.0
+	 * @since 6.4.0 Checking a dynamic property is deprecated.
 	 *
 	 * @param string $name Property to check if set.
 	 * @return bool Whether the property is a back-compat property and it is set.
@@ -235,6 +231,11 @@ class WP_List_Table {
 			return isset( $this->$name );
 		}
 
+		trigger_error(
+			"The property `{$name}` is not defined. Checking `isset()` on a dynamic (undefined) property " .
+			'is deprecated since version 6.4.0! Instead, define the property on the class.',
+			E_USER_DEPRECATED
+		);
 		return false;
 	}
 
@@ -242,6 +243,7 @@ class WP_List_Table {
 	 * Makes private properties un-settable for backward compatibility.
 	 *
 	 * @since 4.0.0
+	 * @since 6.4.0 Unsetting a dynamic property is deprecated.
 	 *
 	 * @param string $name Property to unset.
 	 */
@@ -249,6 +251,12 @@ class WP_List_Table {
 		if ( in_array( $name, $this->compat_fields, true ) ) {
 			unset( $this->$name );
 		}
+
+		trigger_error(
+			"A property `{$name}` is not defined. Unsetting a dynamic (undefined) property is " .
+			'deprecated since version 6.4.0! Instead, define the property on the class.',
+			E_USER_DEPRECATED
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/admin/wpListTable.php
+++ b/tests/phpunit/tests/admin/wpListTable.php
@@ -363,46 +363,22 @@ class Tests_Admin_WpListTable extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @dataProvider data_should_allow_predefined_dynamic_properties
-	 * @ticket       58896
+	 * @dataProvider data_compat_fields
+	 * @ticket 58896
 	 *
-	 * @covers WP_List_Table::__set
-	 * @covers WP_List_Table::__get
+	 * @covers WP_List_Table::__get()
 	 *
-	 * @param string $property_name Name of the class property.
+	 * @param string $property_name Property name to get.
+	 * @param mixed $expected       Expected value.
 	 */
-	public function test_should_allow_predefined_dynamic_properties( $property_name ) {
-		$value = uniqid();
+	public function test_should_get_compat_fields_defined_property( $property_name, $expected ) {
+		$list_table = new WP_List_Table( array( 'plural' => '_wp_tests__get' ) );
 
-		// Calling the getter first to make sure it doesn't cause errors.
-		static::$list_table->$property_name;
-
-		static::$list_table->$property_name = $value;
-		$this->assertSame( $value, static::$list_table->$property_name );
-	}
-
-	/**
-	 * Data provider.
-	 *
-	 * @return array
-	 */
-	public function data_should_allow_predefined_dynamic_properties() {
-		// This code doesn't have access to self::$list_table, so the WP_List_Table object has to be called this way.
-		$list_table             = new WP_List_Table();
-		$compat_fields_property = new ReflectionProperty( $list_table, 'compat_fields' );
-		$compat_fields_property->setAccessible( true );
-
-		$predefined_properties = $compat_fields_property->getValue( $list_table );
-
-		$compat_fields_property->setAccessible( false );
-		$predefined_properties = array_map(
-			function ( $property_name ) {
-				return array( $property_name );
-			},
-			$predefined_properties
-		);
-
-		return $predefined_properties;
+		if ( 'screen' === $property_name ) {
+			$this->assertInstanceOf( $expected, $list_table->$property_name );
+		} else {
+			$this->assertSame( $expected, $list_table->$property_name );
+		}
 	}
 
 	/**
@@ -410,13 +386,28 @@ class Tests_Admin_WpListTable extends WP_UnitTestCase {
 	 *
 	 * @covers WP_List_Table::__get()
 	 */
-	public function test_get_dynamic_property_should_throw_deprecation_return_null() {
+	public function test_should_throw_deprecation_when_getting_dynamic_property() {
 		$this->expectDeprecation();
 		$this->expectDeprecationMessage(
 			'The property `undefined_property` is not defined. Getting a dynamic (undefined) property is ' .
 			'deprecated since version 6.4.0! Instead, define the property on the class.'
 		);
-		$this->assertNull( static::$list_table->undefined_property, 'Getting a dynamic property should return null from WP_List_Table::__get()' );
+		$this->assertNull( $this->list_table->undefined_property, 'Getting a dynamic property should return null from WP_List_Table::__get()' );
+	}
+
+	/**
+	 * @dataProvider data_compat_fields
+	 * @ticket 58896
+	 *
+	 * @covers WP_List_Table::__set()
+	 *
+	 * @param string $property_name Property name to set.
+	 */
+	public function test_should_set_compat_fields_defined_property( $property_name ) {
+		$value                            = uniqid();
+		$this->list_table->$property_name = $value;
+
+		$this->assertSame( $value, $this->list_table->$property_name );
 	}
 
 	/**
@@ -424,13 +415,31 @@ class Tests_Admin_WpListTable extends WP_UnitTestCase {
 	 *
 	 * @covers WP_List_Table::__set()
 	 */
-	public function test_set_of_dynamic_property_should_throw_deprecation() {
+	public function test_should_throw_deprecation_when_setting_dynamic_property() {
 		$this->expectDeprecation();
 		$this->expectDeprecationMessage(
 			'The property `undefined_property` is not defined. Setting a dynamic (undefined) property is ' .
 			'deprecated since version 6.4.0! Instead, define the property on the class.'
 		);
-		static::$list_table->undefined_property = 'some value';
+		$this->list_table->undefined_property = 'some value';
+	}
+
+	/**
+	 * @dataProvider data_compat_fields
+	 * @ticket 58896
+	 *
+	 * @covers WP_List_Table::__isset()
+	 *
+	 * @param string $property_name Property name to check.
+	 * @param mixed $expected       Expected value.
+	 */
+	public function test_should_isset_compat_fields_defined_property( $property_name, $expected ) {
+		$actual = isset( $this->list_table->$property_name );
+		if ( is_null( $expected ) ) {
+			$this->assertFalse( $actual );
+		} else {
+			$this->assertTrue( $actual );
+		}
 	}
 
 	/**
@@ -438,13 +447,26 @@ class Tests_Admin_WpListTable extends WP_UnitTestCase {
 	 *
 	 * @covers WP_List_Table::__isset()
 	 */
-	public function test_isset_of_dynamic_property_should_throw_deprecation() {
+	public function test_should_throw_deprecation_when_isset_of_dynamic_property() {
 		$this->expectDeprecation();
 		$this->expectDeprecationMessage(
 			'The property `undefined_property` is not defined. Checking `isset()` on a dynamic (undefined) property ' .
-			'is deprecated since version 6.4.0! Instead, define the property on the class.',
+			'is deprecated since version 6.4.0! Instead, define the property on the class.'
 		);
-		$this->assertFalse( isset( static::$list_table->undefined_property ), 'Checking a dyanmic property should return false from WP_List_Table::__isset()' );
+		$this->assertFalse( isset( $this->list_table->undefined_property ), 'Checking a dyanmic property should return false from WP_List_Table::__isset()' );
+	}
+
+	/**
+	 * @dataProvider data_compat_fields
+	 * @ticket 58896
+	 *
+	 * @covers WP_List_Table::__unset()
+	 *
+	 * @param string $property_name Property name to unset.
+	 */
+	public function test_should_unset_compat_fields_defined_property( $property_name ) {
+		unset( $this->list_table->$property_name );
+		$this->assertFalse( isset( $this->list_table->$property_name ) );
 	}
 
 	/**
@@ -452,12 +474,47 @@ class Tests_Admin_WpListTable extends WP_UnitTestCase {
 	 *
 	 * @covers WP_List_Table::__unset()
 	 */
-	public function test_unset_of_dynamic_property_should_throw_deprecation() {
+	public function test_should_throw_deprecation_when_unset_of_dynamic_property() {
 		$this->expectDeprecation();
 		$this->expectDeprecationMessage(
 			'A property `undefined_property` is not defined. Unsetting a dynamic (undefined) property is ' .
-			'deprecated since version 6.4.0! Instead, define the property on the class.',
+			'deprecated since version 6.4.0! Instead, define the property on the class.'
 		);
-		unset( static::$list_table->undefined_property );
+		unset( $this->list_table->undefined_property );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_compat_fields() {
+		return array(
+			'_args'            => array(
+				'property_name' => '_args',
+				'expected'      => array(
+					'plural'   => '_wp_tests__get',
+					'singular' => '',
+					'ajax'     => false,
+					'screen'   => null,
+				),
+			),
+			'_pagination_args' => array(
+				'property_name' => '_pagination_args',
+				'expected'      => array(),
+			),
+			'screen'           => array(
+				'property_name' => 'screen',
+				'expected'      => WP_Screen::class,
+			),
+			'_actions'         => array(
+				'property_name' => '_actions',
+				'expected'      => null,
+			),
+			'_pagination'      => array(
+				'property_name' => '_pagination',
+				'expected'      => null,
+			),
+		);
 	}
 }

--- a/tests/phpunit/tests/admin/wpListTable.php
+++ b/tests/phpunit/tests/admin/wpListTable.php
@@ -408,40 +408,56 @@ class Tests_Admin_WpListTable extends WP_UnitTestCase {
 	/**
 	 * @ticket 58896
 	 *
-	 * @covers WP_List_Table::__get
+	 * @covers WP_List_Table::__get()
 	 */
-	public function test_should_not_allow_to_get_dynamic_properties() {
-		$this->enable_doing_it_wrong_error();
-		$property_name = uniqid();
-		$this->setExpectedIncorrectUsage( 'WP_List_Table::__get' );
-		$this->expectNotice();
-		$this->expectNoticeMessageMatches( '/^.+' . $property_name . '.+$/' );
-
-		// Invoking WP_List_Table::__get.
-		static::$list_table->$property_name;
+	public function test_get_dynamic_property_should_throw_deprecation_return_null() {
+		$this->expectDeprecation();
+		$this->expectDeprecationMessage(
+			'The property `undefined_property` is not defined. Getting a dynamic (undefined) property is ' .
+			'deprecated since version 6.4.0! Instead, define the property on the class.'
+		);
+		$this->assertNull( static::$list_table->undefined_property, 'Getting a dynamic property should return null from WP_List_Table::__get()' );
 	}
 
 	/**
 	 * @ticket 58896
 	 *
-	 * @covers WP_List_Table::__set
+	 * @covers WP_List_Table::__set()
 	 */
-	public function test_should_not_allow_to_set_dynamic_properties() {
-		$this->enable_doing_it_wrong_error();
-		$property_name = uniqid();
-		$this->setExpectedIncorrectUsage( 'WP_List_Table::__set' );
-		$this->expectNotice();
-		$this->expectNoticeMessageMatches( '/^.+' . $property_name . '.+$/' );
-
-		// Invoking WP_List_Table::__set.
-		static::$list_table->$property_name = 'value';
+	public function test_set_of_dynamic_property_should_throw_deprecation() {
+		$this->expectDeprecation();
+		$this->expectDeprecationMessage(
+			'The property `undefined_property` is not defined. Setting a dynamic (undefined) property is ' .
+			'deprecated since version 6.4.0! Instead, define the property on the class.'
+		);
+		static::$list_table->undefined_property = 'some value';
 	}
 
 	/**
-	 * This function is needed to remove the filter and disable triggering
-	 * the "doing it wrong" error.
+	 * @ticket 58896
+	 *
+	 * @covers WP_List_Table::__isset()
 	 */
-	private function enable_doing_it_wrong_error() {
-		add_filter( 'doing_it_wrong_trigger_error', '__return_true', 9999 );
+	public function test_isset_of_dynamic_property_should_throw_deprecation() {
+		$this->expectDeprecation();
+		$this->expectDeprecationMessage(
+			'The property `undefined_property` is not defined. Checking `isset()` on a dynamic (undefined) property ' .
+			'is deprecated since version 6.4.0! Instead, define the property on the class.',
+		);
+		$this->assertFalse( isset( static::$list_table->undefined_property ), 'Checking a dyanmic property should return false from WP_List_Table::__isset()' );
+	}
+
+	/**
+	 * @ticket 58896
+	 *
+	 * @covers WP_List_Table::__unset()
+	 */
+	public function test_unset_of_dynamic_property_should_throw_deprecation() {
+		$this->expectDeprecation();
+		$this->expectDeprecationMessage(
+			'A property `undefined_property` is not defined. Unsetting a dynamic (undefined) property is ' .
+			'deprecated since version 6.4.0! Instead, define the property on the class.',
+		);
+		unset( static::$list_table->undefined_property );
 	}
 }

--- a/tests/phpunit/tests/admin/wpListTable.php
+++ b/tests/phpunit/tests/admin/wpListTable.php
@@ -361,4 +361,87 @@ class Tests_Admin_WpListTable extends WP_UnitTestCase {
 			),
 		);
 	}
+
+	/**
+	 * @dataProvider data_should_allow_predefined_dynamic_properties
+	 * @ticket       58896
+	 *
+	 * @covers WP_List_Table::__set
+	 * @covers WP_List_Table::__get
+	 *
+	 * @param string $property_name Name of the class property.
+	 */
+	public function test_should_allow_predefined_dynamic_properties( $property_name ) {
+		$value = uniqid();
+
+		// Calling the getter first to make sure it doesn't cause errors.
+		static::$list_table->$property_name;
+
+		static::$list_table->$property_name = $value;
+		$this->assertSame( $value, static::$list_table->$property_name );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_should_allow_predefined_dynamic_properties() {
+		// This code doesn't have access to self::$list_table, so the WP_List_Table object has to be called this way.
+		$list_table             = new WP_List_Table();
+		$compat_fields_property = new ReflectionProperty( $list_table, 'compat_fields' );
+		$compat_fields_property->setAccessible( true );
+
+		$predefined_properties = $compat_fields_property->getValue( $list_table );
+
+		$compat_fields_property->setAccessible( false );
+		$predefined_properties = array_map(
+			function ( $property_name ) {
+				return array( $property_name );
+			},
+			$predefined_properties
+		);
+
+		return $predefined_properties;
+	}
+
+	/**
+	 * @ticket 58896
+	 *
+	 * @covers WP_List_Table::__get
+	 */
+	public function test_should_not_allow_to_get_dynamic_properties() {
+		$this->enable_doing_it_wrong_error();
+		$property_name = uniqid();
+		$this->setExpectedIncorrectUsage( 'WP_List_Table::__get' );
+		$this->expectNotice();
+		$this->expectNoticeMessageMatches( '/^.+' . $property_name . '.+$/' );
+
+		// Invoking WP_List_Table::__get.
+		static::$list_table->$property_name;
+	}
+
+	/**
+	 * @ticket 58896
+	 *
+	 * @covers WP_List_Table::__set
+	 */
+	public function test_should_not_allow_to_set_dynamic_properties() {
+		$this->enable_doing_it_wrong_error();
+		$property_name = uniqid();
+		$this->setExpectedIncorrectUsage( 'WP_List_Table::__set' );
+		$this->expectNotice();
+		$this->expectNoticeMessageMatches( '/^.+' . $property_name . '.+$/' );
+
+		// Invoking WP_List_Table::__set.
+		static::$list_table->$property_name = 'value';
+	}
+
+	/**
+	 * This function is needed to remove the filter and disable triggering
+	 * the "doing it wrong" error.
+	 */
+	private function enable_doing_it_wrong_error() {
+		add_filter( 'doing_it_wrong_trigger_error', '__return_true', 9999 );
+	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This PR aims to call `doint_it_wrong()` when trying to use dynamic properties on the `WP_List_Table` class. Dynamic properties are not compatible with PHP 8.2 and above.

Trac ticket: https://core.trac.wordpress.org/ticket/58896

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
