### PR TITLE
WP_User_Query: deprecate dynamic property usage in magic methods

### DIFF
--- a/src/wp-includes/class-wp-user-query.php
+++ b/src/wp-includes/class-wp-user-query.php
@@ -1109,6 +1109,7 @@ class WP_User_Query {
 	 * Makes private properties readable for backward compatibility.
 	 *
 	 * @since 4.0.0
+	 * @since 6.4.0 Getting a dynamic property is deprecated.
 	 *
 	 * @param string $name Property to get.
 	 * @return mixed Property.
@@ -1118,14 +1119,10 @@ class WP_User_Query {
 			return $this->$name;
 		}
 
-		_doing_it_wrong(
-			__METHOD__,
-			sprintf(
-			// translators: 1: The name of the non-existent class property.
-				__( 'The "%1$s" property is not defined. Dynamic properties are deprecated in PHP 8.2 and above.' ),
-				$name
-			),
-			'6.4.0'
+		trigger_error(
+			"The property `{$name}` is not declared. Getting a dynamic property is " .
+			'deprecated since version 6.4.0! Instead, declare the property on the class.',
+			E_USER_DEPRECATED
 		);
 		return null;
 	}
@@ -1134,6 +1131,7 @@ class WP_User_Query {
 	 * Makes private properties settable for backward compatibility.
 	 *
 	 * @since 4.0.0
+	 * @since 6.4.0 Setting a dynamic property is deprecated.
 	 *
 	 * @param string $name  Property to check if set.
 	 * @param mixed  $value Property value.
@@ -1144,14 +1142,10 @@ class WP_User_Query {
 			return;
 		}
 
-		_doing_it_wrong(
-			__METHOD__,
-			sprintf(
-			// translators: 1: The name of the non-existent class property.
-				__( 'The "%1$s" property is not defined. Dynamic properties are deprecated in PHP 8.2 and above.' ),
-				$name
-			),
-			'6.4.0'
+		trigger_error(
+			"The property `{$name}` is not declared. Setting a dynamic property is " .
+			'deprecated since version 6.4.0! Instead, declare the property on the class.',
+			E_USER_DEPRECATED
 		);
 	}
 
@@ -1159,6 +1153,7 @@ class WP_User_Query {
 	 * Makes private properties checkable for backward compatibility.
 	 *
 	 * @since 4.0.0
+	 * @since 6.4.0 Checking a dynamic property is deprecated.
 	 *
 	 * @param string $name Property to check if set.
 	 * @return bool Whether the property is set.
@@ -1168,6 +1163,11 @@ class WP_User_Query {
 			return isset( $this->$name );
 		}
 
+		trigger_error(
+			"The property `{$name}` is not declared. Checking `isset()` on a dynamic property " .
+			'is deprecated since version 6.4.0! Instead, declare the property on the class.',
+			E_USER_DEPRECATED
+		);
 		return false;
 	}
 
@@ -1175,13 +1175,21 @@ class WP_User_Query {
 	 * Makes private properties un-settable for backward compatibility.
 	 *
 	 * @since 4.0.0
+	 * @since 6.4.0 Unsetting a dynamic property is deprecated.
 	 *
 	 * @param string $name Property to unset.
 	 */
 	public function __unset( $name ) {
 		if ( in_array( $name, $this->compat_fields, true ) ) {
 			unset( $this->$name );
+			return;
 		}
+
+		trigger_error(
+			"A property `{$name}` is not declared. Unsetting a dynamic property is " .
+			'deprecated since version 6.4.0! Instead, declare the property on the class.',
+			E_USER_DEPRECATED
+		);
 	}
 
 	/**

--- a/src/wp-includes/class-wp-user-query.php
+++ b/src/wp-includes/class-wp-user-query.php
@@ -1117,6 +1117,17 @@ class WP_User_Query {
 		if ( in_array( $name, $this->compat_fields, true ) ) {
 			return $this->$name;
 		}
+
+		_doing_it_wrong(
+			__METHOD__,
+			sprintf(
+			// translators: 1: The name of the non-existent class property.
+				__( 'The "%1$s" property is not defined. Dynamic properties are deprecated in PHP 8.2 and above.' ),
+				$name
+			),
+			'6.4.0'
+		);
+		return null;
 	}
 
 	/**
@@ -1126,12 +1137,22 @@ class WP_User_Query {
 	 *
 	 * @param string $name  Property to check if set.
 	 * @param mixed  $value Property value.
-	 * @return mixed Newly-set property.
 	 */
 	public function __set( $name, $value ) {
 		if ( in_array( $name, $this->compat_fields, true ) ) {
-			return $this->$name = $value;
+			$this->$name = $value;
+			return;
 		}
+
+		_doing_it_wrong(
+			__METHOD__,
+			sprintf(
+			// translators: 1: The name of the non-existent class property.
+				__( 'The "%1$s" property is not defined. Dynamic properties are deprecated in PHP 8.2 and above.' ),
+				$name
+			),
+			'6.4.0'
+		);
 	}
 
 	/**
@@ -1146,6 +1167,8 @@ class WP_User_Query {
 		if ( in_array( $name, $this->compat_fields, true ) ) {
 			return isset( $this->$name );
 		}
+
+		return false;
 	}
 
 	/**

--- a/tests/phpunit/tests/user/query.php
+++ b/tests/phpunit/tests/user/query.php
@@ -2229,23 +2229,133 @@ class Tests_User_Query extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @dataProvider data_should_allow_predefined_dynamic_properties
-	 * @ticket       58897
+	 * @dataProvider data_compat_fields
+	 * @ticket 58897
 	 *
-	 * @covers WP_User_Query::__set
-	 * @covers WP_User_Query::__get
+	 * @covers WP_User_Query::__get()
 	 *
-	 * @param string $property_name Name of the class property.
+	 * @param string $property_name Property name to get.
+	 * @param mixed $expected       Expected value.
 	 */
-	public function test_should_allow_predefined_dynamic_properties( $property_name ) {
-		$value      = uniqid();
+	public function test_should_get_compat_fields( $property_name, $expected ) {
 		$user_query = new WP_User_Query();
 
-		// Calling the getter first to make sure it doesn't cause errors.
-		$user_query->$property_name;
+		$this->assertSame( $expected, $user_query->$property_name );
+	}
+
+	/**
+	 * @ticket 58897
+	 *
+	 * @covers WP_User_Query::__get()
+	 */
+	public function test_should_throw_deprecation_when_getting_dynamic_property() {
+		$user_query = new WP_User_Query();
+
+		$this->expectDeprecation();
+		$this->expectDeprecationMessage(
+			'The property `undefined_property` is not declared. Getting a dynamic property is ' .
+			'deprecated since version 6.4.0! Instead, declare the property on the class.'
+		);
+		$this->assertNull( $user_query->undefined_property, 'Getting a dynamic property should return null from WP_User_Query::__get()' );
+	}
+
+	/**
+	 * @dataProvider data_compat_fields
+	 * @ticket 58897
+	 *
+	 * @covers WP_User_Query::__set()
+	 *
+	 * @param string $property_name Property name to set.
+	 */
+	public function test_should_set_compat_fields( $property_name ) {
+		$user_query = new WP_User_Query();
+		$value      = uniqid();
 
 		$user_query->$property_name = $value;
 		$this->assertSame( $value, $user_query->$property_name );
+	}
+
+	/**
+	 * @ticket 58897
+	 *
+	 * @covers WP_User_Query::__set()
+	 */
+	public function test_should_throw_deprecation_when_setting_dynamic_property() {
+		$user_query = new WP_User_Query();
+
+		$this->expectDeprecation();
+		$this->expectDeprecationMessage(
+			'The property `undefined_property` is not declared. Setting a dynamic property is ' .
+			'deprecated since version 6.4.0! Instead, declare the property on the class.'
+		);
+		$user_query->undefined_property = 'some value';
+	}
+
+	/**
+	 * @dataProvider data_compat_fields
+	 * @ticket 58897
+	 *
+	 * @covers WP_User_Query::__isset()
+	 *
+	 * @param string $property_name Property name to check.
+	 * @param mixed $expected       Expected value.
+	 */
+	public function test_should_isset_compat_fields( $property_name, $expected ) {
+		$user_query = new WP_User_Query();
+
+		$actual = isset( $user_query->$property_name );
+		if ( is_null( $expected ) ) {
+			$this->assertFalse( $actual );
+		} else {
+			$this->assertTrue( $actual );
+		}
+	}
+
+	/**
+	 * @ticket 58897
+	 *
+	 * @covers WP_User_Query::__isset()
+	 */
+	public function test_should_throw_deprecation_when_isset_of_dynamic_property() {
+		$user_query = new WP_User_Query();
+
+		$this->expectDeprecation();
+		$this->expectDeprecationMessage(
+			'The property `undefined_property` is not declared. Checking `isset()` on a dynamic property ' .
+			'is deprecated since version 6.4.0! Instead, declare the property on the class.'
+		);
+		$this->assertFalse( isset( $user_query->undefined_property ), 'Checking a dynamic property should return false from WP_User_Query::__isset()' );
+	}
+
+	/**
+	 * @dataProvider data_compat_fields
+	 * @ticket 58897
+	 *
+	 * @covers WP_User_Query::__unset()
+	 *
+	 * @param string $property_name Property name to unset.
+	 */
+	public function test_should_unset_compat_fields( $property_name ) {
+		$user_query = new WP_User_Query();
+
+		unset( $user_query->$property_name );
+		$this->assertFalse( isset( $user_query->$property_name ) );
+	}
+
+	/**
+	 * @ticket 58897
+	 *
+	 * @covers WP_User_Query::__unset()
+	 */
+	public function test_should_throw_deprecation_when_unset_of_dynamic_property() {
+		$user_query = new WP_User_Query();
+
+		$this->expectDeprecation();
+		$this->expectDeprecationMessage(
+			'A property `undefined_property` is not declared. Unsetting a dynamic property is ' .
+			'deprecated since version 6.4.0! Instead, declare the property on the class.'
+		);
+		unset( $user_query->undefined_property );
 	}
 
 	/**
@@ -2253,63 +2363,16 @@ class Tests_User_Query extends WP_UnitTestCase {
 	 *
 	 * @return array
 	 */
-	public function data_should_allow_predefined_dynamic_properties() {
-		$user_query             = new WP_User_Query();
-		$compat_fields_property = new ReflectionProperty( $user_query, 'compat_fields' );
-		$compat_fields_property->setAccessible( true );
-
-		$predefined_properties = $compat_fields_property->getValue( $user_query );
-
-		$compat_fields_property->setAccessible( false );
-		$predefined_properties = array_map(
-			function ( $property_name ) {
-				return array( $property_name );
-			},
-			$predefined_properties
+	public function data_compat_fields() {
+		return array(
+			'results'     => array(
+				'property_name' => 'results',
+				'expected'      => null,
+			),
+			'total_users' => array(
+				'property_name' => 'total_users',
+				'expected'      => 0,
+			),
 		);
-
-		return $predefined_properties;
-	}
-
-	/**
-	 * @ticket 58897
-	 *
-	 * @covers WP_User_Query::__get
-	 */
-	public function test_should_not_allow_to_get_dynamic_properties() {
-		$this->enable_doing_it_wrong_error();
-		$property_name = uniqid();
-		$this->setExpectedIncorrectUsage( 'WP_User_Query::__get' );
-		$this->expectNotice();
-		$this->expectNoticeMessageMatches( '/^.+' . $property_name . '.+$/' );
-
-		$user_query = new WP_User_Query();
-		// Invoking WP_User_Query::__get.
-		$user_query->$property_name;
-	}
-
-	/**
-	 * @ticket 58897
-	 *
-	 * @covers WP_User_Query::__set
-	 */
-	public function test_should_not_allow_to_set_dynamic_properties() {
-		$this->enable_doing_it_wrong_error();
-		$property_name = uniqid();
-		$this->setExpectedIncorrectUsage( 'WP_User_Query::__set' );
-		$this->expectNotice();
-		$this->expectNoticeMessageMatches( '/^.+' . $property_name . '.+$/' );
-
-		$user_query = new WP_User_Query();
-		// Invoking WP_User_Query::__set.
-		$user_query->$property_name = 'value';
-	}
-
-	/**
-	 * This function is needed to remove the filter and disable triggering
-	 * the "doing it wrong" error.
-	 */
-	private function enable_doing_it_wrong_error() {
-		add_filter( 'doing_it_wrong_trigger_error', '__return_true', 9999 );
 	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Deprecates dynamic property usage in the `WP_User_Query` `__get()`, `__set()`, `__isset()`, and `__unset()` methods, using the same strategy done for `WP_List_Table` in changeset https://core.trac.wordpress.org/changeset/56349.

Trac ticket: https://core.trac.wordpress.org/ticket/58897

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
