### PR TITLE
WP_Text_Diff_Renderer_Table: deprecate dynamic property usage in magic methods 

### DIFF
--- a/src/wp-includes/class-wp-text-diff-renderer-table.php
+++ b/src/wp-includes/class-wp-text-diff-renderer-table.php
@@ -519,6 +519,17 @@ class WP_Text_Diff_Renderer_Table extends Text_Diff_Renderer {
 		if ( in_array( $name, $this->compat_fields, true ) ) {
 			return $this->$name;
 		}
+
+		_doing_it_wrong(
+			__METHOD__,
+			sprintf(
+			// translators: 1: The name of the non-existent class property.
+				__( 'The "%1$s" property is not defined. Dynamic properties are deprecated in PHP 8.2 and above.' ),
+				$name
+			),
+			'6.4.0'
+		);
+		return null;
 	}
 
 	/**
@@ -533,7 +544,19 @@ class WP_Text_Diff_Renderer_Table extends Text_Diff_Renderer {
 	public function __set( $name, $value ) {
 		if ( in_array( $name, $this->compat_fields, true ) ) {
 			return $this->$name = $value;
+			$this->$name = $value;
+			return;
 		}
+
+		_doing_it_wrong(
+			__METHOD__,
+			sprintf(
+			// translators: 1: The name of the non-existent class property.
+				__( 'The "%1$s" property is not defined. Dynamic properties are deprecated in PHP 8.2 and above.' ),
+				$name
+			),
+			'6.4.0'
+		);
 	}
 
 	/**
@@ -548,6 +571,8 @@ class WP_Text_Diff_Renderer_Table extends Text_Diff_Renderer {
 		if ( in_array( $name, $this->compat_fields, true ) ) {
 			return isset( $this->$name );
 		}
+
+		return false;
 	}
 
 	/**

--- a/src/wp-includes/class-wp-text-diff-renderer-table.php
+++ b/src/wp-includes/class-wp-text-diff-renderer-table.php
@@ -511,23 +511,20 @@ class WP_Text_Diff_Renderer_Table extends Text_Diff_Renderer {
 	 * Make private properties readable for backward compatibility.
 	 *
 	 * @since 4.0.0
+	 * @since 6.4.0 Getting a dynamic property is deprecated.
 	 *
 	 * @param string $name Property to get.
-	 * @return mixed Property.
+	 * @return mixed A declared property's value, else null.
 	 */
 	public function __get( $name ) {
 		if ( in_array( $name, $this->compat_fields, true ) ) {
 			return $this->$name;
 		}
 
-		_doing_it_wrong(
-			__METHOD__,
-			sprintf(
-			// translators: 1: The name of the non-existent class property.
-				__( 'The "%1$s" property is not defined. Dynamic properties are deprecated in PHP 8.2 and above.' ),
-				$name
-			),
-			'6.4.0'
+		trigger_error(
+			"The property `{$name}` is not declared. Getting a dynamic property is " .
+			'deprecated since version 6.4.0! Instead, declare the property on the class.',
+			E_USER_DEPRECATED
 		);
 		return null;
 	}
@@ -536,26 +533,21 @@ class WP_Text_Diff_Renderer_Table extends Text_Diff_Renderer {
 	 * Make private properties settable for backward compatibility.
 	 *
 	 * @since 4.0.0
+	 * @since 6.4.0 Setting a dynamic property is deprecated.
 	 *
 	 * @param string $name  Property to check if set.
 	 * @param mixed  $value Property value.
-	 * @return mixed Newly-set property.
 	 */
 	public function __set( $name, $value ) {
 		if ( in_array( $name, $this->compat_fields, true ) ) {
-			return $this->$name = $value;
 			$this->$name = $value;
 			return;
 		}
 
-		_doing_it_wrong(
-			__METHOD__,
-			sprintf(
-			// translators: 1: The name of the non-existent class property.
-				__( 'The "%1$s" property is not defined. Dynamic properties are deprecated in PHP 8.2 and above.' ),
-				$name
-			),
-			'6.4.0'
+		trigger_error(
+			"The property `{$name}` is not declared. Setting a dynamic property is " .
+			'deprecated since version 6.4.0! Instead, declare the property on the class.',
+			E_USER_DEPRECATED
 		);
 	}
 
@@ -563,6 +555,7 @@ class WP_Text_Diff_Renderer_Table extends Text_Diff_Renderer {
 	 * Make private properties checkable for backward compatibility.
 	 *
 	 * @since 4.0.0
+	 * @since 6.4.0 Checking a dynamic property is deprecated.
 	 *
 	 * @param string $name Property to check if set.
 	 * @return bool Whether the property is set.
@@ -572,6 +565,11 @@ class WP_Text_Diff_Renderer_Table extends Text_Diff_Renderer {
 			return isset( $this->$name );
 		}
 
+		trigger_error(
+			"The property `{$name}` is not declared. Checking `isset()` on a dynamic property " .
+			'is deprecated since version 6.4.0! Instead, declare the property on the class.',
+			E_USER_DEPRECATED
+		);
 		return false;
 	}
 
@@ -579,12 +577,20 @@ class WP_Text_Diff_Renderer_Table extends Text_Diff_Renderer {
 	 * Make private properties un-settable for backward compatibility.
 	 *
 	 * @since 4.0.0
+	 * @since 6.4.0 Unsetting a dynamic property is deprecated.
 	 *
 	 * @param string $name Property to unset.
 	 */
 	public function __unset( $name ) {
 		if ( in_array( $name, $this->compat_fields, true ) ) {
 			unset( $this->$name );
+			return;
 		}
+
+		trigger_error(
+			"A property `{$name}` is not declared. Unsetting a dynamic property is " .
+			'deprecated since version 6.4.0! Instead, declare the property on the class.',
+			E_USER_DEPRECATED
+		);
 	}
 }

--- a/tests/phpunit/tests/diff/wpTextDiffRendererTable.php
+++ b/tests/phpunit/tests/diff/wpTextDiffRendererTable.php
@@ -1,8 +1,8 @@
 <?php
-require_once ABSPATH . 'wp-includes/Text/Diff/Renderer.php';
-require_once ABSPATH . 'wp-includes/class-wp-text-diff-renderer-table.php';
 
 /**
+ * Tests for WP_Text_Diff_Renderer_Table.
+ *
  * @group diff
  */
 class Tests_Diff_WpTextDiffRendererTable extends WP_UnitTestCase {
@@ -13,6 +13,8 @@ class Tests_Diff_WpTextDiffRendererTable extends WP_UnitTestCase {
 
 	public static function set_up_before_class() {
 		parent::set_up_before_class();
+		require_once ABSPATH . 'wp-includes/Text/Diff/Renderer.php';
+		require_once ABSPATH . 'wp-includes/class-wp-text-diff-renderer-table.php';
 	}
 
 	public function set_up() {
@@ -21,22 +23,118 @@ class Tests_Diff_WpTextDiffRendererTable extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @dataProvider data_should_allow_predefined_dynamic_properties
-	 * @ticket       58898
+	 * @dataProvider data_compat_fields
+	 * @ticket 58898
 	 *
-	 * @covers       WP_Text_Diff_Renderer_Table::__set
-	 * @covers       WP_Text_Diff_Renderer_Table::__get
+	 * @covers WP_Text_Diff_Renderer_Table::__get()
 	 *
-	 * @param string $property_name Name of the class property.
+	 * @param string $property_name Property name to get.
+	 * @param mixed $expected       Expected value.
 	 */
-	public function test_should_allow_predefined_dynamic_properties( $property_name ) {
-		$value = uniqid();
+	public function test_should_get_compat_fields( $property_name, $expected ) {
+		$this->assertSame( $expected, $this->diff_renderer_table->$property_name );
+	}
 
-		// Calling the getter first to make sure it doesn't cause errors.
-		$this->diff_renderer_table->$property_name;
+	/**
+	 * @ticket 58898
+	 *
+	 * @covers WP_Text_Diff_Renderer_Table::__get()
+	 */
+	public function test_should_throw_deprecation_when_getting_dynamic_property() {
+		$this->expectDeprecation();
+		$this->expectDeprecationMessage(
+			'The property `undeclared_property` is not declared. Getting a dynamic property is ' .
+			'deprecated since version 6.4.0! Instead, declare the property on the class.'
+		);
+		$this->assertNull( $this->diff_renderer_table->undeclared_property, 'Getting a dynamic property should return null from WP_Text_Diff_Renderer_Table::__get()' );
+	}
 
+	/**
+	 * @dataProvider data_compat_fields
+	 * @ticket 58898
+	 *
+	 * @covers WP_Text_Diff_Renderer_Table::__set()
+	 *
+	 * @param string $property_name Property name to set.
+	 */
+	public function test_should_set_compat_fields( $property_name ) {
+		$value                                     = uniqid();
 		$this->diff_renderer_table->$property_name = $value;
+
 		$this->assertSame( $value, $this->diff_renderer_table->$property_name );
+	}
+
+	/**
+	 * @ticket 58898
+	 *
+	 * @covers WP_Text_Diff_Renderer_Table::__set()
+	 */
+	public function test_should_throw_deprecation_when_setting_dynamic_property() {
+		$this->expectDeprecation();
+		$this->expectDeprecationMessage(
+			'The property `undeclared_property` is not declared. Setting a dynamic property is ' .
+			'deprecated since version 6.4.0! Instead, declare the property on the class.'
+		);
+		$this->diff_renderer_table->undeclared_property = 'some value';
+	}
+
+	/**
+	 * @dataProvider data_compat_fields
+	 * @ticket 58898
+	 *
+	 * @covers WP_Text_Diff_Renderer_Table::__isset()
+	 *
+	 * @param string $property_name Property name to check.
+	 * @param mixed $expected       Expected value.
+	 */
+	public function test_should_isset_compat_fields( $property_name, $expected ) {
+		$actual = isset( $this->diff_renderer_table->$property_name );
+		if ( is_null( $expected ) ) {
+			$this->assertFalse( $actual );
+		} else {
+			$this->assertTrue( $actual );
+		}
+	}
+
+	/**
+	 * @ticket 58898
+	 *
+	 * @covers WP_Text_Diff_Renderer_Table::__isset()
+	 */
+	public function test_should_throw_deprecation_when_isset_of_dynamic_property() {
+		$this->expectDeprecation();
+		$this->expectDeprecationMessage(
+			'The property `undeclared_property` is not declared. Checking `isset()` on a dynamic property ' .
+			'is deprecated since version 6.4.0! Instead, declare the property on the class.'
+		);
+		$this->assertFalse( isset( $this->diff_renderer_table->undeclared_property ), 'Checking a dynamic property should return false from WP_Text_Diff_Renderer_Table::__isset()' );
+	}
+
+	/**
+	 * @dataProvider data_compat_fields
+	 * @ticket 58898
+	 *
+	 * @covers WP_Text_Diff_Renderer_Table::__unset()
+	 *
+	 * @param string $property_name Property name to unset.
+	 */
+	public function test_should_unset_compat_fields( $property_name ) {
+		unset( $this->diff_renderer_table->$property_name );
+		$this->assertFalse( isset( $this->diff_renderer_table->$property_name ) );
+	}
+
+	/**
+	 * @ticket 58898
+	 *
+	 * @covers WP_Text_Diff_Renderer_Table::__unset()
+	 */
+	public function test_should_throw_deprecation_when_unset_of_dynamic_property() {
+		$this->expectDeprecation();
+		$this->expectDeprecationMessage(
+			'A property `undeclared_property` is not declared. Unsetting a dynamic property is ' .
+			'deprecated since version 6.4.0! Instead, declare the property on the class.'
+		);
+		unset( $this->diff_renderer_table->undeclared_property );
 	}
 
 	/**
@@ -44,62 +142,20 @@ class Tests_Diff_WpTextDiffRendererTable extends WP_UnitTestCase {
 	 *
 	 * @return array
 	 */
-	public function data_should_allow_predefined_dynamic_properties() {
-		// This code doesn't have access to self::$renderer_table, so the WP_Text_Diff_Renderer_Table object has to be instantiated this way.
-		$renderer_table         = new WP_Text_Diff_Renderer_Table();
-		$compat_fields_property = new ReflectionProperty( $renderer_table, 'compat_fields' );
-		$compat_fields_property->setAccessible( true );
-
-		$predefined_properties = $compat_fields_property->getValue( $renderer_table );
-
-		$compat_fields_property->setAccessible( false );
-		$predefined_properties = array_map(
-			function ( $property_name ) {
-				return array( $property_name );
-			},
-			$predefined_properties
+	public function data_compat_fields() {
+		return array(
+			'_show_split_view'     => array(
+				'property_name' => '_show_split_view',
+				'expected'      => true,
+			),
+			'inline_diff_renderer' => array(
+				'property_name' => 'inline_diff_renderer',
+				'expected'      => 'WP_Text_Diff_Renderer_inline',
+			),
+			'_diff_threshold'      => array(
+				'property_name' => '_diff_threshold',
+				'expected'      => 0.6,
+			),
 		);
-
-		return $predefined_properties;
-	}
-
-	/**
-	 * @ticket 58898
-	 *
-	 * @covers WP_Text_Diff_Renderer_Table::__get
-	 */
-	public function test_should_not_allow_to_get_dynamic_properties() {
-		$this->enable_doing_it_wrong_error();
-		$property_name = uniqid();
-		$this->setExpectedIncorrectUsage( 'WP_Text_Diff_Renderer_Table::__get' );
-		$this->expectNotice();
-		$this->expectNoticeMessageMatches( '/^.+' . $property_name . '.+$/' );
-
-		// Invoking WP_Text_Diff_Renderer_Table::__get.
-		$this->diff_renderer_table->$property_name;
-	}
-
-	/**
-	 * @ticket 58898
-	 *
-	 * @covers WP_Text_Diff_Renderer_Table::__set
-	 */
-	public function test_should_not_allow_to_set_dynamic_properties() {
-		$this->enable_doing_it_wrong_error();
-		$property_name = uniqid();
-		$this->setExpectedIncorrectUsage( 'WP_Text_Diff_Renderer_Table::__set' );
-		$this->expectNotice();
-		$this->expectNoticeMessageMatches( '/^.+' . $property_name . '.+$/' );
-
-		// Invoking WP_Text_Diff_Renderer_Table::__set.
-		$this->diff_renderer_table->$property_name = 'value';
-	}
-
-	/**
-	 * This function is needed to remove the filter and disable triggering
-	 * the "doing it wrong" error.
-	 */
-	private function enable_doing_it_wrong_error() {
-		add_filter( 'doing_it_wrong_trigger_error', '__return_true', 9999 );
 	}
 }

--- a/tests/phpunit/tests/diff/wpTextDiffRendererTable.php
+++ b/tests/phpunit/tests/diff/wpTextDiffRendererTable.php
@@ -1,0 +1,105 @@
+<?php
+require_once ABSPATH . 'wp-includes/Text/Diff/Renderer.php';
+require_once ABSPATH . 'wp-includes/class-wp-text-diff-renderer-table.php';
+
+/**
+ * @group diff
+ */
+class Tests_Diff_WpTextDiffRendererTable extends WP_UnitTestCase {
+	/**
+	 * @var WP_Text_Diff_Renderer_Table
+	 */
+	private $diff_renderer_table;
+
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+	}
+
+	public function set_up() {
+		parent::set_up();
+		$this->diff_renderer_table = new WP_Text_Diff_Renderer_Table();
+	}
+
+	/**
+	 * @dataProvider data_should_allow_predefined_dynamic_properties
+	 * @ticket       58898
+	 *
+	 * @covers       WP_Text_Diff_Renderer_Table::__set
+	 * @covers       WP_Text_Diff_Renderer_Table::__get
+	 *
+	 * @param string $property_name Name of the class property.
+	 */
+	public function test_should_allow_predefined_dynamic_properties( $property_name ) {
+		$value = uniqid();
+
+		// Calling the getter first to make sure it doesn't cause errors.
+		$this->diff_renderer_table->$property_name;
+
+		$this->diff_renderer_table->$property_name = $value;
+		$this->assertSame( $value, $this->diff_renderer_table->$property_name );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_should_allow_predefined_dynamic_properties() {
+		// This code doesn't have access to self::$renderer_table, so the WP_Text_Diff_Renderer_Table object has to be instantiated this way.
+		$renderer_table         = new WP_Text_Diff_Renderer_Table();
+		$compat_fields_property = new ReflectionProperty( $renderer_table, 'compat_fields' );
+		$compat_fields_property->setAccessible( true );
+
+		$predefined_properties = $compat_fields_property->getValue( $renderer_table );
+
+		$compat_fields_property->setAccessible( false );
+		$predefined_properties = array_map(
+			function ( $property_name ) {
+				return array( $property_name );
+			},
+			$predefined_properties
+		);
+
+		return $predefined_properties;
+	}
+
+	/**
+	 * @ticket 58898
+	 *
+	 * @covers WP_Text_Diff_Renderer_Table::__get
+	 */
+	public function test_should_not_allow_to_get_dynamic_properties() {
+		$this->enable_doing_it_wrong_error();
+		$property_name = uniqid();
+		$this->setExpectedIncorrectUsage( 'WP_Text_Diff_Renderer_Table::__get' );
+		$this->expectNotice();
+		$this->expectNoticeMessageMatches( '/^.+' . $property_name . '.+$/' );
+
+		// Invoking WP_Text_Diff_Renderer_Table::__get.
+		$this->diff_renderer_table->$property_name;
+	}
+
+	/**
+	 * @ticket 58898
+	 *
+	 * @covers WP_Text_Diff_Renderer_Table::__set
+	 */
+	public function test_should_not_allow_to_set_dynamic_properties() {
+		$this->enable_doing_it_wrong_error();
+		$property_name = uniqid();
+		$this->setExpectedIncorrectUsage( 'WP_Text_Diff_Renderer_Table::__set' );
+		$this->expectNotice();
+		$this->expectNoticeMessageMatches( '/^.+' . $property_name . '.+$/' );
+
+		// Invoking WP_Text_Diff_Renderer_Table::__set.
+		$this->diff_renderer_table->$property_name = 'value';
+	}
+
+	/**
+	 * This function is needed to remove the filter and disable triggering
+	 * the "doing it wrong" error.
+	 */
+	private function enable_doing_it_wrong_error() {
+		add_filter( 'doing_it_wrong_trigger_error', '__return_true', 9999 );
+	}
+}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Deprecates dynamic property usage in the `WP_Text_Diff_Renderer_Table ` `__get()`, `__set()`, `__isset()`, and `__unset()` methods, using the same strategy done for `WP_List_Table` in changeset https://core.trac.wordpress.org/changeset/56349.

Trac ticket: https://core.trac.wordpress.org/ticket/58898

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
