### PR TITLE
HTML API: Add support for SPAN element.

### DIFF
--- a/tests/phpunit/tests/html-api/wpHtmlProcessorBreadcrumbs.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorBreadcrumbs.php
@@ -49,6 +49,7 @@ class Tests_HtmlApi_WpHtmlProcessorBreadcrumbs extends WP_UnitTestCase {
 			'IMG',
 			'P',
 			'SMALL',
+			'SPAN',
 			'STRIKE',
 			'STRONG',
 			'TT',
@@ -191,7 +192,6 @@ class Tests_HtmlApi_WpHtmlProcessorBreadcrumbs extends WP_UnitTestCase {
 			'SLOT',
 			'SOURCE',
 			'SPACER', // Deprecated
-			'SPAN',
 			'STYLE',
 			'SUB',
 			'SUMMARY',

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorSemanticRules.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorSemanticRules.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Unit tests covering WP_HTML_Processor compliance with HTML5 semantic parsing rules.
+ *
+ * @package WordPress
+ * @subpackage HTML-API
+ *
+ * @since 6.4.0
+ *
+ * @group html-api
+ *
+ * @coversDefaultClass WP_HTML_Processor
+ */
+class Tests_HtmlApi_WpHtmlProcessorSemanticRules extends WP_UnitTestCase {
+	/*******************************************************************
+	 * RULES FOR "IN BODY" MODE
+	 *******************************************************************/
+
+	/*
+	 * Verifies that when "in body" and encountering "any other end tag"
+	 * that the HTML processor ignores the end tag if there's a special
+	 * element on the stack of open elements before the matching opening.
+	 *
+	 * @ticket 58907
+	 *
+	 * @since 6.4.0
+	 *
+	 * @covers WP_HTML_Processor::step_in_body
+	 */
+	public function test_in_body_any_other_end_tag_with_unclosed_special_element() {
+		$p = WP_HTML_Processor::createFragment( '<div><span><p></span><div>' );
+
+		$p->next_tag( 'P' );
+		$this->assertSame( 'P', $p->get_tag(), "Expected to start test on P element but found {$p->get_tag()} instead." );
+		$this->assertSame( array( 'HTML', 'BODY', 'DIV', 'SPAN', 'P' ), $p->get_breadcrumbs(), 'Failed to produce expected DOM nesting.' );
+
+		$this->assertTrue( $p->next_tag(), 'Failed to advance past P tag to expected DIV opener.' );
+		$this->assertSame( 'DIV', $p->get_tag(), "Expected to find DIV element, but found {$p->get_tag()} instead." );
+		$this->assertSame( array( 'HTML', 'BODY', 'DIV', 'SPAN', 'DIV' ), $p->get_breadcrumbs(), 'Failed to produce expected DOM nesting: SPAN should still be open and DIV should be its child.' );
+	}
+
+	/*
+	 * Verifies that when "in body" and encountering "any other end tag"
+	 * that the HTML processor closes appropriate elements on the stack of
+	 * open elements up to the matching opening.
+	 *
+	 * @ticket 58907
+	 *
+	 * @since 6.4.0
+	 *
+	 * @covers WP_HTML_Processor::step_in_body
+	 */
+	public function test_in_body_any_other_end_tag_with_unclosed_non_special_element() {
+		$p = WP_HTML_Processor::createFragment( '<div><span><code></span><div>' );
+
+		$p->next_tag( 'CODE' );
+		$this->assertSame( 'CODE', $p->get_tag(), "Expected to start test on CODE element but found {$p->get_tag()} instead." );
+		$this->assertSame( array( 'HTML', 'BODY', 'DIV', 'SPAN', 'CODE' ), $p->get_breadcrumbs(), 'Failed to produce expected DOM nesting.' );
+
+		$this->assertTrue( $p->next_tag(), 'Failed to advance past CODE tag to expected SPAN closer.' );
+		$this->assertTrue( $p->is_tag_closer(), 'Expected to find closing SPAN, but found opener instead.' );
+		$this->assertSame( array( 'HTML', 'BODY', 'DIV' ), $p->get_breadcrumbs(), 'Failed to advance past CODE tag to expected DIV opener.' );
+
+		$this->assertTrue( $p->next_tag(), 'Failed to advance past SPAN closer to expected DIV opener.' );
+		$this->assertSame( 'DIV', $p->get_tag(), "Expected to find DIV element, but found {$p->get_tag()} instead." );
+		$this->assertSame( array( 'HTML', 'BODY', 'DIV', 'DIV' ), $p->get_breadcrumbs(), 'Failed to produce expected DOM nesting: SPAN should be closed and DIV should be its sibling.' );
+	}
+}

--- a/tests/phpunit/tests/html-api/wpHtmlSupportRequiredHtmlProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlSupportRequiredHtmlProcessor.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Unit tests for the HTML API indicating that changes are needed to the
+ * WP_HTML_Processor class before specific features are added to the API.
+ *
+ * Note! Duplication of test cases and the helper function in this file are intentional.
+ * This test file exists to warn developers of related areas of code that need to update
+ * together when adding support for new elements to the HTML Processor. For example,
+ * when adding support for the LI element it's necessary to update the function which
+ * generates implied end tags. This is because each element might bring with it semantic
+ * rules that impact the way the document should be parsed.
+ *
+ * Without these tests a developer needs to investigate all possible places they
+ * might need to update when adding support for more elements and risks overlooking
+ * important parts that, in the absence of the related support, will lead to errors.
+ *
+ * @package WordPress
+ * @subpackage HTML-API
+ *
+ * @since 6.4.0
+ *
+ * @group html-api
+ *
+ * @coversDefaultClass WP_HTML_Processor
+ */
+class Tests_HtmlApi_WpHtmlSupportRequiredHtmlProcessor extends WP_UnitTestCase {
+	/**
+	 * Fails to assert if the HTML Processor handles the given tag.
+	 *
+	 * This test helper is used throughout this test file for one purpose only: to
+	 * fail a test if the HTML Processor handles the given tag. In other words, it
+	 * ensures that the HTML Processor aborts when encountering the given tag.
+	 *
+	 * This is used to ensure that when support for a new tag is added to the
+	 * HTML Processor it receives full support and not partial support, which
+	 * could lead to a variety of issues.
+	 *
+	 * Do not remove this helper function as it provides semantic meaning to the
+	 * assertions in the tests in this file and its behavior is incredibly specific
+	 * and limited and doesn't warrant adding a new abstraction into WP_UnitTestCase.
+	 *
+	 * @param string $tag_name the HTML Processor should abort when encountering this tag, e.g. "BUTTON".
+	 */
+	private function ensure_support_is_added_everywhere( $tag_name ) {
+		$p = WP_HTML_Processor::createFragment( "<$tag_name>" );
+
+		$this->assertFalse( $p->step(), "Must support terminating elements in specific scope check before adding support for the {$tag_name} element." );
+	}
+
+	/**
+	 * Generating implied end tags walks up the stack of open elements
+	 * as long as any of the following missing elements is the current node.
+	 *
+	 * @since 6.4.0
+	 *
+	 * @ticket 58907
+	 *
+	 * @covers WP_HTML_Processor::generate_implied_end_tags
+	 */
+	public function test_generate_implied_end_tags_needs_support() {
+		$this->ensure_support_is_added_everywhere( 'DD' );
+		$this->ensure_support_is_added_everywhere( 'DT' );
+		$this->ensure_support_is_added_everywhere( 'LI' );
+		$this->ensure_support_is_added_everywhere( 'OPTGROUP' );
+		$this->ensure_support_is_added_everywhere( 'OPTION' );
+		$this->ensure_support_is_added_everywhere( 'RB' );
+		$this->ensure_support_is_added_everywhere( 'RP' );
+		$this->ensure_support_is_added_everywhere( 'RT' );
+		$this->ensure_support_is_added_everywhere( 'RTC' );
+	}
+
+	/**
+	 * Generating implied end tags thoroughly walks up the stack of open elements
+	 * as long as any of the following missing elements is the current node.
+	 *
+	 * @since 6.4.0
+	 *
+	 * @ticket 58907
+	 *
+	 * @covers WP_HTML_Processor::generate_implied_end_tags_thoroughly
+	 */
+	public function test_generate_implied_end_tags_thoroughly_needs_support() {
+		$this->ensure_support_is_added_everywhere( 'CAPTION' );
+		$this->ensure_support_is_added_everywhere( 'COLGROUP' );
+		$this->ensure_support_is_added_everywhere( 'DD' );
+		$this->ensure_support_is_added_everywhere( 'DT' );
+		$this->ensure_support_is_added_everywhere( 'LI' );
+		$this->ensure_support_is_added_everywhere( 'OPTGROUP' );
+		$this->ensure_support_is_added_everywhere( 'OPTION' );
+		$this->ensure_support_is_added_everywhere( 'RB' );
+		$this->ensure_support_is_added_everywhere( 'RP' );
+		$this->ensure_support_is_added_everywhere( 'RT' );
+		$this->ensure_support_is_added_everywhere( 'RTC' );
+		$this->ensure_support_is_added_everywhere( 'TBODY' );
+		$this->ensure_support_is_added_everywhere( 'TD' );
+		$this->ensure_support_is_added_everywhere( 'TFOOT' );
+		$this->ensure_support_is_added_everywhere( 'TH' );
+		$this->ensure_support_is_added_everywhere( 'HEAD' );
+		$this->ensure_support_is_added_everywhere( 'TR' );
+	}
+}


### PR DESCRIPTION
See [#58907-trac](https://core.trac.wordpress.org/ticket/58907#ticket)

In this patch we're introducing support for the SPAN element, which is the first in the class of "any other tag" in the "in body" insertion mode.

This patch introduces the mechanisms required to handle that class of tags but only introduces SPAN to keep the change focused. With the tests and mechanisms in place it will be possible to follow-up and add another limited set of tags.

It's important that this not use the default catch-all in the switch handling `step_in_body` because that would catch tags that have specific rules in previous case statements that aren't yet added. For example, we don't want to treat the `TABLE` element as "any other tag".