### PR TITLE
Flushing 'user_activation_key' after successful login

### DIFF
--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -110,6 +110,17 @@ function wp_signon( $credentials = array(), $secure_cookie = '' ) {
 	}
 
 	wp_set_auth_cookie( $user->ID, $credentials['remember'], $secure_cookie );
+
+	// Flush `user_activation_key` after successful login
+	global $wpdb;
+	$wpdb->update(
+		$wpdb->users,
+		array(
+			'user_activation_key' => '',
+		),
+		array( 'ID' => $user->ID )
+	);
+
 	/**
 	 * Fires after the user has successfully logged in.
 	 *

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -111,7 +111,7 @@ function wp_signon( $credentials = array(), $secure_cookie = '' ) {
 
 	wp_set_auth_cookie( $user->ID, $credentials['remember'], $secure_cookie );
 
-	// Flush `user_activation_key` after successful login
+	// Flush `user_activation_key` after successful login.
 	global $wpdb;
 	$wpdb->update(
 		$wpdb->users,


### PR DESCRIPTION
Flushing 'user_activation_key' after successful login

Trac ticket: https://core.trac.wordpress.org/ticket/58901

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
