### PR TITLE
Destroy logged in sessions after successfully password reset

### DIFF
--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -2780,6 +2780,9 @@ if ( ! function_exists( 'wp_set_password' ) ) :
 
 		clean_user_cache( $user_id );
 
+		$user_sessions = WP_Session_Tokens::get_instance( $user_id );
+		$user_sessions->destroy_all();
+
 		/**
 		 * Fires after the user password is set.
 		 *


### PR DESCRIPTION
Destroyed user's sessions using `WP_Session_Tokens` class.

Trac ticket: https://core.trac.wordpress.org/ticket/58911

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
