### PR TITLE
Ensure that the page parameter is scalar in wp-query 

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -2020,7 +2020,7 @@ class WP_Query {
 		}
 
 		if ( isset( $q['page'] ) ) {
-			$qv['page']    = is_scalar( $qv['page'] ) ? trim( $q['page'], '/' )  : '';
+			$qv['page']    = is_scalar( $qv['page'] ) ? trim( $q['page'], '/' ) : '';
 			$qv['page']    = is_scalar( $qv['page'] ) ? absint( $qv['page'] ) : 0;
 		}
 

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -2021,7 +2021,7 @@ class WP_Query {
 
 		if ( isset( $q['page'] ) ) {
 			$q['page'] = is_scalar( $q['page'] ) ? trim( $q['page'], '/' ) : '';
-			$q['page'] = is_scalar( $q['page'] ) ? absint( $q['page'] ) : 0;
+			$q['page'] = absint( $q['page'] );
 		}
 
 		// If true, forcibly turns off SQL_CALC_FOUND_ROWS even when limits are present.

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -2020,8 +2020,8 @@ class WP_Query {
 		}
 
 		if ( isset( $q['page'] ) ) {
-			$qv['page']    = is_scalar( $qv['page'] ) ? trim( $q['page'], '/' ) : '';
-			$qv['page']    = is_scalar( $qv['page'] ) ? absint( $qv['page'] ) : 0;
+			$q['page'] = is_scalar( $q['page'] ) ? trim( $q['page'], '/' ) : '';
+			$q['page'] = is_scalar( $q['page'] ) ? absint( $q['page'] ) : 0;
 		}
 
 		// If true, forcibly turns off SQL_CALC_FOUND_ROWS even when limits are present.

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -2020,8 +2020,8 @@ class WP_Query {
 		}
 
 		if ( isset( $q['page'] ) ) {
-			$q['page'] = trim( $q['page'], '/' );
-			$q['page'] = absint( $q['page'] );
+			$qv['page']    = is_scalar( $qv['page'] ) ? trim( $q['page'], '/' )  : '';
+			$qv['page']    = is_scalar( $qv['page'] ) ? absint( $qv['page'] ) : 0;
 		}
 
 		// If true, forcibly turns off SQL_CALC_FOUND_ROWS even when limits are present.


### PR DESCRIPTION
This PR builds on the work completed with the closure of Trac-17737

It ensures that the value of $page in a query is scalar prior to attempting to trim or assign it to an absint avoiding a fatal error if an array is passed.

Fixes:  (comment 2)

Trac ticket:[https://core.trac.wordpress.org/ticket/56558](https://core.trac.wordpress.org/ticket/56558)


Edit: update first Trac link as the PR was associated with the wrong trac ticket.