### PR TITLE
Setting Email Sending validation when password reset is sent from the Users page

### DIFF
--- a/src/wp-admin/users.php
+++ b/src/wp-admin/users.php
@@ -638,7 +638,7 @@ switch ( $wp_list_table->current_action() ) {
 						$message = __( 'Password reset link sent.' );
 					} else {
 						/* translators: %s: Number of users. */
-						$message = _n( 'Password reset link sent to %s user.', 'Password reset links sent to %s users.', $reset_count );
+						$message = _n( 'Password reset links sent to %s user.', 'Password reset links sent to %s users.', $reset_count );
 					}
 
 					// Check if the transient flag for email failure exists

--- a/src/wp-admin/users.php
+++ b/src/wp-admin/users.php
@@ -652,7 +652,7 @@ switch ( $wp_list_table->current_action() ) {
 					}
 				
 					$messages[] = '<div id="message" class="updated notice is-dismissible"><p>' . sprintf( $message, number_format_i18n( $reset_count ) ) . '</p></div>';
-					break;				
+					break;
 				case 'promote':
 					$messages[] = '<div id="message" class="updated notice is-dismissible"><p>' . __( 'Changed roles.' ) . '</p></div>';
 					break;

--- a/src/wp-admin/users.php
+++ b/src/wp-admin/users.php
@@ -644,13 +644,13 @@ switch ( $wp_list_table->current_action() ) {
 					// Check if the transient flag for email failure exists.
 					if ( get_transient( 'reset_password_email_failure' ) ) {
 						$message = __( '<strong>Error:</strong> The email could not be sent. Your site may not be correctly configured to send emails. <a href="%s">Get support for resetting your password</a>.' );
-						$messages[] = '<div id="message" class="notice error is-dismissible"><p>' . sprintf( $message, esc_url('https://wordpress.org/documentation/article/reset-your-password') ) . '</p></div>';
+						$messages[] = '<div id="message" class="notice error is-dismissible"><p>' . sprintf( $message, esc_url( 'https://wordpress.org/documentation/article/reset-your-password') ) . '</p></div>';
 
 						// Delete the transient to prevent displaying the error on subsequent page loads
 						delete_transient( 'reset_password_email_failure' );
 						break;
 					}
-				
+
 					$messages[] = '<div id="message" class="updated notice is-dismissible"><p>' . sprintf( $message, number_format_i18n( $reset_count ) ) . '</p></div>';
 					break;
 				case 'promote':

--- a/src/wp-admin/users.php
+++ b/src/wp-admin/users.php
@@ -644,7 +644,7 @@ switch ( $wp_list_table->current_action() ) {
 					// Check if the transient flag for email failure exists.
 					if ( get_transient( 'reset_password_email_failure' ) ) {
 						$message = __( '<strong>Error:</strong> The email could not be sent. Your site may not be correctly configured to send emails. <a href="%s">Get support for resetting your password</a>.' );
-						$messages[] = '<div id="message" class="notice error is-dismissible"><p>' . sprintf( $message, esc_url( 'https://wordpress.org/documentation/article/reset-your-password') ) . '</p></div>';
+						$messages[] = '<div id="message" class="notice error is-dismissible"><p>' . sprintf( $message, esc_url( 'https://wordpress.org/documentation/article/reset-your-password' ) ) . '</p></div>';
 
 						// Delete the transient to prevent displaying the error on subsequent page loads
 						delete_transient( 'reset_password_email_failure' );

--- a/src/wp-admin/users.php
+++ b/src/wp-admin/users.php
@@ -641,7 +641,7 @@ switch ( $wp_list_table->current_action() ) {
 						$message = _n( 'Password reset links sent to %s user.', 'Password reset links sent to %s users.', $reset_count );
 					}
 
-					// Check if the transient flag for email failure exists
+					// Check if the transient flag for email failure exists.
 					if ( get_transient( 'reset_password_email_failure' ) ) {
 						$message = __( '<strong>Error:</strong> The email could not be sent. Your site may not be correctly configured to send emails. <a href="%s">Get support for resetting your password</a>.' );
 						$messages[] = '<div id="message" class="notice error is-dismissible"><p>' . sprintf( $message, esc_url('https://wordpress.org/documentation/article/reset-your-password') ) . '</p></div>';

--- a/src/wp-admin/users.php
+++ b/src/wp-admin/users.php
@@ -638,10 +638,21 @@ switch ( $wp_list_table->current_action() ) {
 						$message = __( 'Password reset link sent.' );
 					} else {
 						/* translators: %s: Number of users. */
-						$message = _n( 'Password reset links sent to %s user.', 'Password reset links sent to %s users.', $reset_count );
+						$message = _n( 'Password reset link sent to %s user.', 'Password reset links sent to %s users.', $reset_count );
 					}
+
+					// Check if the transient flag for email failure exists
+					if ( get_transient( 'reset_password_email_failure' ) ) {
+						$message = __( '<strong>Error:</strong> The email could not be sent. Your site may not be correctly configured to send emails. <a href="%s">Get support for resetting your password</a>.' );
+						$messages[] = '<div id="message" class="notice error is-dismissible"><p>' . sprintf( $message, esc_url('https://wordpress.org/documentation/article/reset-your-password') ) . '</p></div>';
+
+						// Delete the transient to prevent displaying the error on subsequent page loads
+						delete_transient( 'reset_password_email_failure' );
+						break;
+					}
+				
 					$messages[] = '<div id="message" class="updated notice is-dismissible"><p>' . sprintf( $message, number_format_i18n( $reset_count ) ) . '</p></div>';
-					break;
+					break;				
 				case 'promote':
 					$messages[] = '<div id="message" class="updated notice is-dismissible"><p>' . __( 'Changed roles.' ) . '</p></div>';
 					break;

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -3275,6 +3275,7 @@ function retrieve_password( $user_login = null ) {
 				esc_url( __( 'https://wordpress.org/documentation/article/reset-your-password/' ) )
 			)
 		);
+		set_transient( 'reset_password_email_failure', true, 60 );
 		return $errors;
 	}
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Checking if Email Sending is possible, and showing appropriate admin notices when a password reset is requested from the Users page.

Trac ticket: https://core.trac.wordpress.org/ticket/58917

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
