### PR TITLE
Trac 58896: Option 3 to fix WP_List_Table dynamic properties

### DIFF
--- a/src/wp-admin/includes/class-wp-list-table.php
+++ b/src/wp-admin/includes/class-wp-list-table.php
@@ -179,7 +179,7 @@ class WP_List_Table {
 	 * @deprecated 6.4.0 Getting a dynamic property is deprecated.
 	 *
 	 * @param string $name Property to get.
-	 * @return null Does not return dynamic property value.
+	 * @return null Does not get a dynamic property's value.
 	 */
 	public function __get( $name ) {
 		trigger_error(
@@ -224,7 +224,7 @@ class WP_List_Table {
 	 * @deprecated 6.4.0 Checking a dynamic property is deprecated.
 	 *
 	 * @param string $name Property to check if set.
-	 * @return bool False, as a dynamic property.
+	 * @return bool False, does not check a dynamic property.
 	 */
 	public function __isset( $name ) {
 		trigger_error(

--- a/src/wp-admin/includes/class-wp-list-table.php
+++ b/src/wp-admin/includes/class-wp-list-table.php
@@ -27,41 +27,46 @@ class WP_List_Table {
 	 * Various information about the current table.
 	 *
 	 * @since 3.1.0
+	 * @since 6.4.0 Made public for backward compatibility.
 	 * @var array
 	 */
-	protected $_args;
+	public $_args;
 
 	/**
 	 * Various information needed for displaying the pagination.
 	 *
 	 * @since 3.1.0
+	 * @since 6.4.0 Made public for backward compatibility.
 	 * @var array
 	 */
-	protected $_pagination_args = array();
+	public $_pagination_args = array();
 
 	/**
 	 * The current screen.
 	 *
 	 * @since 3.1.0
+	 * @since 6.4.0 Made public for backward compatibility.
 	 * @var WP_Screen
 	 */
-	protected $screen;
+	public $screen;
 
 	/**
 	 * Cached bulk actions.
 	 *
 	 * @since 3.1.0
+	 * @since 6.4.0 Made public for backward compatibility.
 	 * @var array
 	 */
-	private $_actions;
+	public $_actions;
 
 	/**
 	 * Cached pagination output.
 	 *
 	 * @since 3.1.0
+	 * @since 6.4.0 Made public for backward compatibility.
 	 * @var string
 	 */
-	private $_pagination;
+	public $_pagination;
 
 	/**
 	 * The view switcher modes.
@@ -78,13 +83,6 @@ class WP_List_Table {
 	 * @var array
 	 */
 	protected $_column_headers;
-
-	/**
-	 * {@internal Missing Summary}
-	 *
-	 * @var array
-	 */
-	protected $compat_fields = array( '_args', '_pagination_args', 'screen', '_actions', '_pagination' );
 
 	/**
 	 * {@internal Missing Summary}
@@ -173,61 +171,93 @@ class WP_List_Table {
 	}
 
 	/**
-	 * Makes private properties readable for backward compatibility.
+	 * Unused. Deprecated for backward compatibility.
+	 *
+	 * This magic method is retained in case a plugin or theme has a dynamic (undefined) property.
 	 *
 	 * @since 4.0.0
+	 * @deprecated 6.4.0 Getting a dynamic property is deprecated.
 	 *
 	 * @param string $name Property to get.
-	 * @return mixed Property.
+	 * @return null Does not return dynamic property value.
 	 */
 	public function __get( $name ) {
-		if ( in_array( $name, $this->compat_fields, true ) ) {
-			return $this->$name;
-		}
+		trigger_error(
+			sprintf(
+				/* translators: 1: The property name. */
+				__( 'Getting the dynamic (undefined) property %1$s is <strong>deprecated</strong> since version 6.4.0! Instead, define the %1$s property on the class.' ),
+				$name
+			),
+			E_USER_DEPRECATED
+		);
+		return null;
 	}
 
 	/**
-	 * Makes private properties settable for backward compatibility.
+	 * Unused. Deprecated for backward compatibility.
+	 *
+	 * This magic method is retained in case a plugin or theme has a dynamic (undefined) property.
 	 *
 	 * @since 4.0.0
+	 * @deprecated 6.4.0 Setting a dynamic property is deprecated.
 	 *
 	 * @param string $name  Property to check if set.
 	 * @param mixed  $value Property value.
-	 * @return mixed Newly-set property.
 	 */
 	public function __set( $name, $value ) {
-		if ( in_array( $name, $this->compat_fields, true ) ) {
-			return $this->$name = $value;
-		}
+		trigger_error(
+			sprintf(
+				/* translators: 1: The property name. */
+				__( 'Setting the dynamic (undefined) property %1$s is <strong>deprecated</strong> since version 6.4.0! Instead, define the %1$s property on the class.' ),
+				$name
+			),
+			E_USER_DEPRECATED
+		);
 	}
 
 	/**
-	 * Makes private properties checkable for backward compatibility.
+	 * Unused. Deprecated for backward compatibility.
+	 *
+	 * This magic method is retained in case a plugin or theme has a dynamic (undefined) property.
 	 *
 	 * @since 4.0.0
+	 * @deprecated 6.4.0 Checking a dynamic property is deprecated.
 	 *
 	 * @param string $name Property to check if set.
-	 * @return bool Whether the property is a back-compat property and it is set.
+	 * @return bool False, as a dynamic property.
 	 */
 	public function __isset( $name ) {
-		if ( in_array( $name, $this->compat_fields, true ) ) {
-			return isset( $this->$name );
-		}
-
+		trigger_error(
+			sprintf(
+				/* translators: 1: The property name, 2: isset(). */
+				__( 'Checking %2$s on the dynamic (undefined) property %1$s is <strong>deprecated</strong> since version 6.4.0! Instead, define the %1$s property on the class.' ),
+				$name,
+				'<code>isset()</code>'
+			),
+			E_USER_DEPRECATED
+		);
 		return false;
 	}
 
 	/**
-	 * Makes private properties un-settable for backward compatibility.
+	 * Unused. Deprecated for backward compatibility.
+	 *
+	 * This magic method is retained in case a plugin or theme has a dynamic (undefined) property.
 	 *
 	 * @since 4.0.0
+	 * @deprecated 6.4.0 Unsetting a dynamic property is deprecated.
 	 *
 	 * @param string $name Property to unset.
 	 */
 	public function __unset( $name ) {
-		if ( in_array( $name, $this->compat_fields, true ) ) {
-			unset( $this->$name );
-		}
+		trigger_error(
+			sprintf(
+				/* translators: 1: The property name. */
+				__( 'Unsetting the dynamic (undefined) property %1$s is <strong>deprecated</strong> since version 6.4.0! Instead, define the %1$s property on the class.' ),
+				$name
+			),
+			E_USER_DEPRECATED
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/admin/wpListTable.php
+++ b/tests/phpunit/tests/admin/wpListTable.php
@@ -344,4 +344,48 @@ class Tests_Admin_WpListTable extends WP_UnitTestCase {
 			),
 		);
 	}
+
+	/**
+	 * @ticket 58896
+	 *
+	 * @covers WP_List_Table::__get()
+	 */
+	public function test_get_dynamic_property_should_throw_deprecation_return_null() {
+		$this->expectDeprecation();
+		$this->expectDeprecationMessage( 'Getting the dynamic (undefined) property undefined_property is <strong>deprecated</strong> since version 6.4.0! Instead, define the undefined_property property on the class.' );
+		$this->assertNull( static::$list_table->undefined_property, 'Getting a dynamic property should return null from WP_List_Table::__get()' );
+	}
+
+	/**
+	 * @ticket 58896
+	 *
+	 * @covers WP_List_Table::__set()
+	 */
+	public function test_set_of_dynamic_property_should_throw_deprecation() {
+		$this->expectDeprecation();
+		$this->expectDeprecationMessage( 'Setting the dynamic (undefined) property undefined_property is <strong>deprecated</strong> since version 6.4.0! Instead, define the undefined_property property on the class.' );
+		static::$list_table->undefined_property = 'some value';
+	}
+
+	/**
+	 * @ticket 58896
+	 *
+	 * @covers WP_List_Table::__isset()
+	 */
+	public function test_isset_of_dynamic_property_should_throw_deprecation() {
+		$this->expectDeprecation();
+		$this->expectDeprecationMessage( 'Checking <code>isset()</code> on the dynamic (undefined) property undefined_property is <strong>deprecated</strong> since version 6.4.0! Instead, define the undefined_property property on the class.' );
+		$this->assertFalse( isset( static::$list_table->undefined_property ) );
+	}
+
+	/**
+	 * @ticket 58896
+	 *
+	 * @covers WP_List_Table::__unset()
+	 */
+	public function test_unset_of_dynamic_property_should_throw_deprecation() {
+		$this->expectDeprecation();
+		$this->expectDeprecationMessage( 'Unsetting the dynamic (undefined) property undefined_property is <strong>deprecated</strong> since version 6.4.0! Instead, define the undefined_property property on the class.' );
+		unset( static::$list_table->undefined_property );
+	}
 }


### PR DESCRIPTION
Implements Option 3, see explanation in the Trac ticket https://core.trac.wordpress.org/ticket/58896#comment:12.

Fixes the dynamic properties for PHP 8.2 compatibility by:

1. Defined properties: restores each to `public` (as each has been public through the magic methods).
2. Removes the `$compat_fields` and logic.
3. Deprecates each property magic method.

Trac ticket: https://core.trac.wordpress.org/ticket/58896

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
