### PR TITLE
Update kses.php to allow HTML tags that contain colons like <esi:include>

### DIFF
--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -1102,7 +1102,7 @@ function wp_kses_split2( $content, $allowed_html, $allowed_protocols ) {
 	}
 
 	// It's seriously malformed.
-	if ( ! preg_match( '%^<\s*(/\s*)?([a-zA-Z0-9-]+:?+[a-zA-Z0-9-]*)([^>]*)>?$%', $content, $matches ) ) {
+	if ( ! preg_match( '%^<\s*(/\s*)?([a-zA-Z0-9-:]+)([^>]*)>?$%', $content, $matches ) ) {
 		return '';
 	}
 

--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -1102,7 +1102,7 @@ function wp_kses_split2( $content, $allowed_html, $allowed_protocols ) {
 	}
 
 	// It's seriously malformed.
-	if ( ! preg_match( '%^<\s*(/\s*)?([a-zA-Z0-9-]+:?[a-zA-Z0-9-]+)([^>]*)>?$%', $content, $matches ) ) {
+	if ( ! preg_match( '%^<\s*(/\s*)?([a-zA-Z0-9-]+:?+[a-zA-Z0-9-]*)([^>]*)>?$%', $content, $matches ) ) {
 		return '';
 	}
 

--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -1102,7 +1102,7 @@ function wp_kses_split2( $content, $allowed_html, $allowed_protocols ) {
 	}
 
 	// It's seriously malformed.
-	if ( ! preg_match( '%^<\s*(/\s*)?([a-zA-Z0-9-]+)([^>]*)>?$%', $content, $matches ) ) {
+	if ( ! preg_match( '%^<\s*(/\s*)?([a-zA-Z0-9-]+:?[a-zA-Z0-9-]+)([^>]*)>?$%', $content, $matches ) ) {
 		return '';
 	}
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

This allows HTML tag names that contain a colon such as `<esi:include>`

The changed regex now allows zero or one colon within the tag name. 

(`<esi:include>` tags are specified by the ESI Languages Specification: https://www.w3.org/TR/esi-lang/)

Trac ticket: https://core.trac.wordpress.org/ticket/58921

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
