### PR TITLE
Update BackBone.JS to 1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7729,8 +7729,8 @@
 			}
 		},
 		"backbone": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/backbone/-/backbone-1.4.1.tgz",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/backbone/-/backbone-1.5.0.tgz",
 			"integrity": "sha512-ADy1ztN074YkWbHi8ojJVFe3vAanO/lrzMGZWUClIP7oDD/Pjy2vrASraUP+2EVCfIiTtCW4FChVow01XneivA==",
 			"requires": {
 				"underscore": ">=1.8.3"

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
 		"@wordpress/warning": "2.35.1",
 		"@wordpress/widgets": "3.12.11",
 		"@wordpress/wordcount": "3.35.1",
-		"backbone": "1.4.1",
+		"backbone": "1.5.0",
 		"clipboard": "2.0.11",
 		"core-js-url-browser": "3.6.4",
 		"element-closest": "^3.0.2",

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1013,7 +1013,7 @@ function wp_default_scripts( $scripts ) {
 	did_action( 'init' ) && $scripts->add_data( 'json2', 'conditional', 'lt IE 8' );
 
 	$scripts->add( 'underscore', "/wp-includes/js/underscore$dev_suffix.js", array(), '1.13.4', 1 );
-	$scripts->add( 'backbone', "/wp-includes/js/backbone$dev_suffix.js", array( 'underscore', 'jquery' ), '1.4.1', 1 );
+	$scripts->add( 'backbone', "/wp-includes/js/backbone$dev_suffix.js", array( 'underscore', 'jquery' ), '1.5.0', 1 );
 
 	$scripts->add( 'wp-util', "/wp-includes/js/wp-util$suffix.js", array( 'underscore', 'jquery' ), false, 1 );
 	did_action( 'init' ) && $scripts->localize(


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Updating the BackBone.JS library to 1.5.0

Trac ticket: https://core.trac.wordpress.org/ticket/58930

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
