### PR TITLE
Replace `php_sapi_name` function with `PHP_SAPI` constant

### DIFF
--- a/src/wp-admin/includes/class-wp-debug-data.php
+++ b/src/wp-admin/includes/class-wp-debug-data.php
@@ -700,8 +700,8 @@ class WP_Debug_Data {
 			$php_version_debug .= ' 64bit';
 		}
 
-		if ( function_exists( 'php_sapi_name' ) ) {
-			$php_sapi = php_sapi_name();
+		if ( defined( 'PHP_SAPI' ) ) {
+			$php_sapi = PHP_SAPI;
 		} else {
 			$php_sapi = 'unknown';
 		}

--- a/src/wp-admin/includes/class-wp-debug-data.php
+++ b/src/wp-admin/includes/class-wp-debug-data.php
@@ -700,12 +700,6 @@ class WP_Debug_Data {
 			$php_version_debug .= ' 64bit';
 		}
 
-		if ( defined( 'PHP_SAPI' ) ) {
-			$php_sapi = PHP_SAPI;
-		} else {
-			$php_sapi = 'unknown';
-		}
-
 		$info['wp-server']['fields']['server_architecture'] = array(
 			'label' => __( 'Server architecture' ),
 			'value' => ( 'unknown' !== $server_architecture ? $server_architecture : __( 'Unable to determine server architecture' ) ),
@@ -723,8 +717,8 @@ class WP_Debug_Data {
 		);
 		$info['wp-server']['fields']['php_sapi']            = array(
 			'label' => __( 'PHP SAPI' ),
-			'value' => ( 'unknown' !== $php_sapi ? $php_sapi : __( 'Unable to determine PHP SAPI' ) ),
-			'debug' => $php_sapi,
+			'value' => PHP_SAPI,
+			'debug' => PHP_SAPI,
 		);
 
 		// Some servers disable `ini_set()` and `ini_get()`, we check this before trying to get configuration values.


### PR DESCRIPTION
Super-micro optimization that replaces `php_sapi_name` function call with PHP_SAPI constant. One fewer function call, although it would take millions of calls to have a meaningful difference.

Trac ticket: https://core.trac.wordpress.org/ticket/58942

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
