### PR TITLE
Replace `is_a` calls in core with `instanceof`

### DIFF
--- a/src/wp-content/themes/twentyseventeen/inc/template-tags.php
+++ b/src/wp-content/themes/twentyseventeen/inc/template-tags.php
@@ -140,7 +140,7 @@ endif;
  * @param int                  $id      Front page section to display.
  */
 function twentyseventeen_front_page_section( $partial = null, $id = 0 ) {
-	if ( is_a( $partial, 'WP_Customize_Partial' ) ) {
+	if ( $partial instanceof WP_Customize_Partial ) {
 		// Find out the ID and set it up during a selective refresh.
 		global $twentyseventeencounter;
 

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -897,7 +897,7 @@ function wp_admin_bar_edit_menu( $wp_admin_bar ) {
 					)
 				);
 			}
-		} elseif ( is_a( $current_object, 'WP_User' ) && current_user_can( 'edit_user', $current_object->ID ) ) {
+		} elseif ( ( $current_object instanceof WP_User ) && current_user_can( 'edit_user', $current_object->ID ) ) {
 			$edit_user_link = get_edit_user_link( $current_object->ID );
 			if ( $edit_user_link ) {
 				$wp_admin_bar->add_node(

--- a/src/wp-includes/http.php
+++ b/src/wp-includes/http.php
@@ -354,7 +354,7 @@ function wp_remote_retrieve_cookie( $response, $name ) {
 function wp_remote_retrieve_cookie_value( $response, $name ) {
 	$cookie = wp_remote_retrieve_cookie( $response, $name );
 
-	if ( ! is_a( $cookie, 'WP_Http_Cookie' ) ) {
+	if ( ! ( $cookie instanceof WP_Http_Cookie ) ) {
 		return '';
 	}
 

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -4032,7 +4032,7 @@ function _wp_privacy_account_request_confirmed( $request_id ) {
 function _wp_privacy_send_request_confirmation_notification( $request_id ) {
 	$request = wp_get_user_request( $request_id );
 
-	if ( ! is_a( $request, 'WP_User_Request' ) || 'request-confirmed' !== $request->status ) {
+	if ( ! ( $request instanceof WP_User_Request ) || 'request-confirmed' !== $request->status ) {
 		return;
 	}
 
@@ -4244,7 +4244,7 @@ All at ###SITENAME###
 function _wp_privacy_send_erasure_fulfillment_notification( $request_id ) {
 	$request = wp_get_user_request( $request_id );
 
-	if ( ! is_a( $request, 'WP_User_Request' ) || 'request-completed' !== $request->status ) {
+	if ( ! ( $request instanceof WP_User_Request ) || 'request-completed' !== $request->status ) {
 		return;
 	}
 

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -1303,7 +1303,7 @@ switch ( $action ) {
 			}
 
 			// Check if it is time to add a redirect to the admin email confirmation screen.
-			if ( is_a( $user, 'WP_User' ) && $user->exists() && $user->has_cap( 'manage_options' ) ) {
+			if ( ( $user instanceof WP_User ) && $user->exists() && $user->has_cap( 'manage_options' ) ) {
 				$admin_email_lifespan = (int) get_option( 'admin_email_lifespan' );
 
 				/*


### PR DESCRIPTION
Replaces all `is_a` function calls with `instanceof` keyword, which in theory should be faster, and provides more code clarity. The replacements use extra braces to enhance the clarity although they are technically not necessary.

Trac ticket: https://core.trac.wordpress.org/ticket/58943#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
