### PR TITLE
Added parameter check

### DIFF
--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -2349,6 +2349,12 @@ add_shortcode( 'caption', 'img_caption_shortcode' );
  * @return string HTML content to display the caption.
  */
 function img_caption_shortcode( $attr, $content = '' ) {
+	// validate input parameter type for compatibility with newer versions of PHP
+	// (this maintains behavior consistent with how this function worked on 
+	// PHP versions 7.0 and older.)
+	if (!isset($attr) || !is_array($attr)) {
+		$attr = array();
+	}
 	// New-style shortcode with the caption inside the shortcode with the link and image tags.
 	if ( ! isset( $attr['caption'] ) ) {
 		if ( preg_match( '#((?:<a [^>]+>\s*)?<img [^>]+>(?:\s*</a>)?)(.*)#is', $content, $matches ) ) {

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -2349,9 +2349,11 @@ add_shortcode( 'caption', 'img_caption_shortcode' );
  * @return string HTML content to display the caption.
  */
 function img_caption_shortcode( $attr, $content = '' ) {
-	// validate input parameter type for compatibility with newer versions of PHP
-	// (this maintains behavior consistent with how this function worked on 
-	// PHP versions 7.0 and older.)
+	/*
+	 * validate input parameter type for compatibility with newer versions of PHP
+	 * (this maintains behavior consistent with how this function worked on 
+	 * PHP versions 7.0 and older.)
+	 */
 	if (!isset($attr) || !is_array($attr)) {
 		$attr = array();
 	}

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -2354,7 +2354,7 @@ function img_caption_shortcode( $attr, $content = '' ) {
 	 * (this maintains behavior consistent with how this function worked on 
 	 * PHP versions 7.0 and older.)
 	 */
-	if (!isset($attr) || !is_array($attr)) {
+	if ( ! isset( $attr ) || ! is_array( $attr ) ) {
 		$attr = array();
 	}
 	// New-style shortcode with the caption inside the shortcode with the link and image tags.


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

In versions of PHP 7.0 and prior, if anything other than an array was passed into this function, it would be cast to an array at `$attr['caption'] = trim( $matches[2] );`

To maintain that behavior in newer versions of PHP, I added a type check that would explicitly perform this behavior.

Trac ticket: https://core.trac.wordpress.org/ticket/45929

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
