### PR TITLE
Fix for template retrieval: do not include parent template if a child template is defined

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -364,12 +364,7 @@ function _get_block_templates_files( $template_type, $query = array() ) {
 			 * The child theme items (stylesheet) are processed before the parent theme's (template).
 			 * If a child theme defines a template, prevent the parent template from being added to the list as well.
 			 */
-			$slug_already_present = false !== array_search(
-				$template_slug,
-				wp_list_pluck( $template_files, 'slug' ),
-				true
-			);
-			if ( $slug_already_present ) {
+			if ( isset( $template_files[ $template_slug ]) ) {
 				continue;
 			}
 
@@ -383,7 +378,7 @@ function _get_block_templates_files( $template_type, $query = array() ) {
 			if ( 'wp_template_part' === $template_type ) {
 				$candidate = _add_block_template_part_area_info( $new_template_item );
 				if ( ! isset( $area ) || ( isset( $area ) && $area === $candidate['area'] ) ) {
-					$template_files[] = $candidate;
+					$template_files[ $template_slug ] = $candidate;
 				}
 			}
 
@@ -393,13 +388,13 @@ function _get_block_templates_files( $template_type, $query = array() ) {
 					! $post_type ||
 					( $post_type && isset( $candidate['postTypes'] ) && in_array( $post_type, $candidate['postTypes'], true ) )
 				) {
-					$template_files[] = $candidate;
+					$template_files[ $template_slug ] = $candidate;
 				}
 			}
 		}
 	}
 
-	return $template_files;
+	return array_values( $template_files );
 }
 
 /**

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -360,8 +360,10 @@ function _get_block_templates_files( $template_type, $query = array() ) {
 				continue;
 			}
 
-			// The child theme items (stylesheet) are processed before the parent theme's (template).
-			// If a child theme defines a template, prevent the parent template from being added to the list as well.
+			/*
+			 * The child theme items (stylesheet) are processed before the parent theme's (template).
+			 * If a child theme defines a template, prevent the parent template from being added to the list as well.
+			 */
 			$slug_already_present = false !== array_search(
 				$template_slug,
 				wp_list_pluck( $template_files, 'slug' ),

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -360,6 +360,17 @@ function _get_block_templates_files( $template_type, $query = array() ) {
 				continue;
 			}
 
+			// The child theme items (stylesheet) are processed before the parent theme's (template).
+			// If a child theme defines a template, prevent the parent template from being added to the list as well.
+			$slug_already_present = false !== array_search(
+				$template_slug,
+				wp_list_pluck( $template_files, 'slug' ),
+				true
+			);
+			if ( $slug_already_present ) {
+				continue;
+			}
+
 			$new_template_item = array(
 				'slug'  => $template_slug,
 				'path'  => $template_file,

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -364,7 +364,7 @@ function _get_block_templates_files( $template_type, $query = array() ) {
 			 * The child theme items (stylesheet) are processed before the parent theme's (template).
 			 * If a child theme defines a template, prevent the parent template from being added to the list as well.
 			 */
-			if ( isset( $template_files[ $template_slug ]) ) {
+			if ( isset( $template_files[ $template_slug ] ) ) {
 				continue;
 			}
 


### PR DESCRIPTION
Trac ticket https://core.trac.wordpress.org/ticket/57756
Follow-up to https://github.com/WordPress/wordpress-develop/pull/4097
Fixes https://github.com/WordPress/gutenberg/issues/53138

## What

While improving the performance of the block template retrieval at https://github.com/WordPress/wordpress-develop/pull/4097/ the condition to skip templates from the parent theme that were already defined by the child theme was unintentionally removed. This PR brings it back.

## Why

It's a regression from current behavior.

## How to test

See instructions at https://github.com/WordPress/gutenberg/issues/53138