### PR TITLE
Use Elvis operator (`a ?: b`) where possible to replace `a ? a : b` style of ternary expressions

### DIFF
--- a/src/wp-admin/async-upload.php
+++ b/src/wp-admin/async-upload.php
@@ -60,7 +60,7 @@ if ( isset( $_REQUEST['attachment_id'] ) && (int) $_REQUEST['attachment_id'] && 
 					// Title shouldn't ever be empty, but use filename just in case.
 					$file     = get_attached_file( $post->ID );
 					$file_url = wp_get_attachment_url( $post->ID );
-					$title    = $post->post_title ? $post->post_title : wp_basename( $file );
+					$title    = $post->post_title ?: wp_basename( $file );
 					?>
 					<div class="filename new">
 						<span class="media-list-title"><strong><?php echo esc_html( wp_html_excerpt( $title, 60, '&hellip;' ) ); ?></strong></span>

--- a/src/wp-admin/authorize-application.php
+++ b/src/wp-admin/authorize-application.php
@@ -127,7 +127,7 @@ wp_localize_script(
 		'site_url'   => site_url(),
 		'user_login' => $user->user_login,
 		'success'    => $success_url,
-		'reject'     => $reject_url ? $reject_url : admin_url(),
+		'reject'     => $reject_url ?: admin_url(),
 	)
 );
 

--- a/src/wp-admin/includes/class-wp-comments-list-table.php
+++ b/src/wp-admin/includes/class-wp-comments-list-table.php
@@ -295,7 +295,7 @@ class WP_Comments_List_Table extends WP_List_Table {
 				$current_user_id    = get_current_user_id();
 				$num_comments->mine = get_comments(
 					array(
-						'post_id' => $post_id ? $post_id : 0,
+						'post_id' => $post_id ?: 0,
 						'user_id' => $current_user_id,
 						'count'   => true,
 					)

--- a/src/wp-admin/includes/class-wp-debug-data.php
+++ b/src/wp-admin/includes/class-wp-debug-data.php
@@ -96,7 +96,7 @@ class WP_Debug_Data {
 				),
 				'permalink'              => array(
 					'label' => __( 'Permalink structure' ),
-					'value' => $permalink_structure ? $permalink_structure : __( 'No permalink structure set' ),
+					'value' => $permalink_structure ?: __( 'No permalink structure set' ),
 					'debug' => $permalink_structure,
 				),
 				'https_status'           => array(
@@ -325,7 +325,7 @@ class WP_Debug_Data {
 				),
 				'WP_DEVELOPMENT_MODE' => array(
 					'label' => 'WP_DEVELOPMENT_MODE',
-					'value' => WP_DEVELOPMENT_MODE ? WP_DEVELOPMENT_MODE : __( 'Disabled' ),
+					'value' => WP_DEVELOPMENT_MODE ?: __( 'Disabled' ),
 					'debug' => WP_DEVELOPMENT_MODE,
 				),
 				'DB_CHARSET'          => array(
@@ -533,7 +533,7 @@ class WP_Debug_Data {
 
 		$info['wp-media']['fields']['imagick_version'] = array(
 			'label' => __( 'Imagick version' ),
-			'value' => ( $imagick_version ) ? $imagick_version : __( 'Not available' ),
+			'value' => $imagick_version ?: __( 'Not available' ),
 		);
 
 		if ( ! function_exists( 'ini_get' ) ) {
@@ -1157,8 +1157,8 @@ class WP_Debug_Data {
 			),
 			'author_website' => array(
 				'label' => __( 'Author website' ),
-				'value' => ( $active_theme_author_uri ? $active_theme_author_uri : __( 'Undefined' ) ),
-				'debug' => ( $active_theme_author_uri ? $active_theme_author_uri : '(undefined)' ),
+				'value' => $active_theme_author_uri ?: __( 'Undefined' ),
+				'debug' => $active_theme_author_uri ?: '(undefined)',
 			),
 			'parent_theme'   => array(
 				'label' => __( 'Parent theme' ),
@@ -1252,8 +1252,8 @@ class WP_Debug_Data {
 				),
 				'author_website' => array(
 					'label' => __( 'Author website' ),
-					'value' => ( $parent_theme_author_uri ? $parent_theme_author_uri : __( 'Undefined' ) ),
-					'debug' => ( $parent_theme_author_uri ? $parent_theme_author_uri : '(undefined)' ),
+					'value' => $parent_theme_author_uri ?: __( 'Undefined' ),
+					'debug' => $parent_theme_author_uri ?: '(undefined)',
 				),
 				'theme_path'     => array(
 					'label' => __( 'Theme directory location' ),

--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -1003,7 +1003,7 @@ class WP_Plugins_List_Table extends WP_List_Table {
 		}
 
 		if ( 'dropins' !== $context ) {
-			$description = '<p>' . ( $plugin_data['Description'] ? $plugin_data['Description'] : '&nbsp;' ) . '</p>';
+			$description = '<p>' . ( $plugin_data['Description'] ?: '&nbsp;' ) . '</p>';
 			$plugin_name = $plugin_data['Name'];
 		}
 

--- a/src/wp-admin/includes/class-wp-screen.php
+++ b/src/wp-admin/includes/class-wp-screen.php
@@ -319,7 +319,7 @@ final class WP_Screen {
 					break;
 				case 'edit-tags':
 				case 'term':
-					if ( null === $post_type && is_object_in_taxonomy( 'post', $taxonomy ? $taxonomy : 'post_tag' ) ) {
+					if ( null === $post_type && is_object_in_taxonomy( 'post', $taxonomy ?: 'post_tag') ) {
 						$post_type = 'post';
 					}
 					break;

--- a/src/wp-admin/includes/deprecated.php
+++ b/src/wp-admin/includes/deprecated.php
@@ -775,7 +775,7 @@ function wp_tiny_mce( $teeny = false, $settings = false ) {
 
 	$set = array(
 		'teeny' => $teeny,
-		'tinymce' => $settings ? $settings : true,
+		'tinymce' => $settings ?: TRUE,
 		'quicktags' => false
 	);
 

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -3314,7 +3314,7 @@ function attachment_submitbox_metadata() {
 	$uploaded_by_link = '';
 
 	if ( $author->exists() ) {
-		$uploaded_by_name = $author->display_name ? $author->display_name : $author->nickname;
+		$uploaded_by_name = $author->display_name ?: $author->nickname;
 		$uploaded_by_link = get_edit_user_link( $author->ID );
 	}
 	?>
@@ -3330,7 +3330,7 @@ function attachment_submitbox_metadata() {
 	if ( $post->post_parent ) {
 		$post_parent = get_post( $post->post_parent );
 		if ( $post_parent ) {
-			$uploaded_to_title = $post_parent->post_title ? $post_parent->post_title : __( '(no title)' );
+			$uploaded_to_title = $post_parent->post_title ?: __( '(no title)' );
 			$uploaded_to_link  = get_edit_post_link( $post->post_parent, 'raw' );
 			?>
 			<div class="misc-pub-section misc-pub-uploadedto">

--- a/src/wp-admin/includes/post.php
+++ b/src/wp-admin/includes/post.php
@@ -130,7 +130,7 @@ function _wp_translate_postdata( $update = false, $post_data = null ) {
 	$previous_status = $post_id ? get_post_field( 'post_status', $post_id ) : false;
 
 	if ( isset( $post_data['post_status'] ) && 'private' === $post_data['post_status'] && ! current_user_can( $ptype->cap->publish_posts ) ) {
-		$post_data['post_status'] = $previous_status ? $previous_status : 'pending';
+		$post_data['post_status'] = $previous_status ?: 'pending';
 	}
 
 	$published_statuses = array( 'publish', 'future' );
@@ -1442,7 +1442,7 @@ function get_sample_permalink( $post, $title = null, $name = null ) {
 	// Hack: get_permalink() would return plain permalink for drafts, so we will fake that our post is published.
 	if ( in_array( $post->post_status, array( 'draft', 'pending', 'future' ), true ) ) {
 		$post->post_status = 'publish';
-		$post->post_name   = sanitize_title( $post->post_name ? $post->post_name : $post->post_title, $post->ID );
+		$post->post_name   = sanitize_title( $post->post_name ?: $post->post_title, $post->ID );
 	}
 
 	/*
@@ -1450,7 +1450,7 @@ function get_sample_permalink( $post, $title = null, $name = null ) {
 	 * Note: if empty name is supplied -- use the title instead, see #6072.
 	 */
 	if ( ! is_null( $name ) ) {
-		$post->post_name = sanitize_title( $name ? $name : $title, $post->ID );
+		$post->post_name = sanitize_title( $name ?: $title, $post->ID );
 	}
 
 	$post->post_name = wp_unique_post_slug( $post->post_name, $post->ID, $post->post_status, $post->post_type, $post->post_parent );
@@ -1650,7 +1650,7 @@ function _wp_post_thumbnail_html( $thumbnail_id = null, $post = null ) {
 		}
 	}
 
-	$content .= '<input type="hidden" id="_thumbnail_id" name="_thumbnail_id" value="' . esc_attr( $thumbnail_id ? $thumbnail_id : '-1' ) . '" />';
+	$content .= '<input type="hidden" id="_thumbnail_id" name="_thumbnail_id" value="' . esc_attr( $thumbnail_id ?: '-1' ) . '" />';
 
 	/**
 	 * Filters the admin post thumbnail HTML markup to return.

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -2587,7 +2587,7 @@ function get_submit_button( $text = '', $type = 'primary large', $name = 'submit
 	// Remove empty items, remove duplicate items, and finally build a string.
 	$class = implode( ' ', array_unique( array_filter( $classes ) ) );
 
-	$text = $text ? $text : __( 'Save Changes' );
+	$text = $text ?: __( 'Save Changes' );
 
 	// Default the id attribute to $name unless an id was specifically provided in $other_attributes.
 	$id = $name;

--- a/src/wp-admin/includes/translation-install.php
+++ b/src/wp-admin/includes/translation-install.php
@@ -175,7 +175,7 @@ function wp_install_language_form( $languages ) {
 				'<option value="%s" lang="%s" data-continue="%s"%s>%s</option>' . "\n",
 				esc_attr( $language['language'] ),
 				esc_attr( current( $language['iso'] ) ),
-				esc_attr( $language['strings']['continue'] ? $language['strings']['continue'] : 'Continue' ),
+				esc_attr( $language['strings']['continue'] ?: 'Continue' ),
 				in_array( $language['language'], $installed_languages, true ) ? ' data-installed="1"' : '',
 				esc_html( $language['native_name'] )
 			);
@@ -189,7 +189,7 @@ function wp_install_language_form( $languages ) {
 			'<option value="%s" lang="%s" data-continue="%s"%s>%s</option>' . "\n",
 			esc_attr( $language['language'] ),
 			esc_attr( current( $language['iso'] ) ),
-			esc_attr( $language['strings']['continue'] ? $language['strings']['continue'] : 'Continue' ),
+			esc_attr( $language['strings']['continue'] ?: 'Continue' ),
 			in_array( $language['language'], $installed_languages, true ) ? ' data-installed="1"' : '',
 			esc_html( $language['native_name'] )
 		);

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -367,7 +367,7 @@ function update_right_now_message() {
 				'<a href="%s" class="button" aria-describedby="wp-version">%s</a> ',
 				network_admin_url( 'update-core.php' ),
 				/* translators: %s: WordPress version number, or 'Latest' string. */
-				sprintf( __( 'Update to %s' ), $cur->current ? $cur->current : __( 'Latest' ) )
+				sprintf( __( 'Update to %s' ), $cur->current ?: __( 'Latest' ) )
 			);
 		}
 	}

--- a/src/wp-admin/network/themes.php
+++ b/src/wp-admin/network/themes.php
@@ -206,7 +206,7 @@ if ( $action ) {
 				);
 			}
 
-			$paged = ( $_REQUEST['paged'] ) ? $_REQUEST['paged'] : 1;
+			$paged = ( $_REQUEST['paged'] ) ?: 1;
 			wp_redirect(
 				add_query_arg(
 					array(

--- a/src/wp-admin/plugin-editor.php
+++ b/src/wp-admin/plugin-editor.php
@@ -189,7 +189,7 @@ $content = esc_textarea( $content );
 <?php elseif ( is_wp_error( $edit_error ) ) : ?>
 	<div id="message" class="notice notice-error">
 		<p><?php _e( 'There was an error while trying to update the file. You may need to fix something and try updating again.' ); ?></p>
-		<pre><?php echo esc_html( $edit_error->get_error_message() ? $edit_error->get_error_message() : $edit_error->get_error_code() ); ?></pre>
+		<pre><?php echo esc_html( $edit_error->get_error_message() ?: $edit_error->get_error_code() ); ?></pre>
 	</div>
 <?php endif; ?>
 

--- a/src/wp-admin/theme-editor.php
+++ b/src/wp-admin/theme-editor.php
@@ -196,7 +196,7 @@ if ( $file_description !== $file_show ) {
 <?php elseif ( is_wp_error( $edit_error ) ) : ?>
 	<div id="message" class="notice notice-error">
 		<p><?php _e( 'There was an error while trying to update the file. You may need to fix something and try updating again.' ); ?></p>
-		<pre><?php echo esc_html( $edit_error->get_error_message() ? $edit_error->get_error_message() : $edit_error->get_error_code() ); ?></pre>
+		<pre><?php echo esc_html( $edit_error->get_error_message() ?: $edit_error->get_error_code() ); ?></pre>
 	</div>
 <?php endif; ?>
 

--- a/src/wp-admin/upload.php
+++ b/src/wp-admin/upload.php
@@ -128,7 +128,7 @@ if ( ! empty( $_GET['message'] ) && isset( $messages[ $_GET['message'] ] ) ) {
 	$_SERVER['REQUEST_URI'] = remove_query_arg( array( 'message' ), $_SERVER['REQUEST_URI'] );
 }
 
-$mode  = get_user_option( 'media_library_mode', get_current_user_id() ) ? get_user_option( 'media_library_mode', get_current_user_id() ) : 'grid';
+$mode  = get_user_option( 'media_library_mode', get_current_user_id() ) ?: 'grid';
 $modes = array( 'grid', 'list' );
 
 if ( isset( $_GET['mode'] ) && in_array( $_GET['mode'], $modes, true ) ) {

--- a/src/wp-content/themes/twentyeleven/functions.php
+++ b/src/wp-content/themes/twentyeleven/functions.php
@@ -640,7 +640,7 @@ function twentyeleven_get_first_url() {
 	}
 
 	/** This filter is documented in wp-includes/link-template.php */
-	return ( $has_url ) ? $has_url : apply_filters( 'the_permalink', get_permalink() );
+	return ( $has_url ) ?: apply_filters( 'the_permalink', get_permalink() );
 }
 
 /**

--- a/src/wp-content/themes/twentyfifteen/inc/template-tags.php
+++ b/src/wp-content/themes/twentyfifteen/inc/template-tags.php
@@ -246,7 +246,7 @@ if ( ! function_exists( 'twentyfifteen_get_link_url' ) ) :
 	function twentyfifteen_get_link_url() {
 		$has_url = get_url_in_content( get_the_content() );
 
-		return $has_url ? $has_url : apply_filters( 'the_permalink', get_permalink() );
+		return $has_url ?: apply_filters( 'the_permalink', get_permalink() );
 	}
 endif;
 

--- a/src/wp-content/themes/twentythirteen/functions.php
+++ b/src/wp-content/themes/twentythirteen/functions.php
@@ -702,7 +702,7 @@ function twentythirteen_get_link_url() {
 	$content = get_the_content();
 	$has_url = get_url_in_content( $content );
 
-	return ( $has_url ) ? $has_url : apply_filters( 'the_permalink', get_permalink() );
+	return ( $has_url ) ?: apply_filters( 'the_permalink', get_permalink() );
 }
 
 if ( ! function_exists( 'twentythirteen_excerpt_more' ) && ! is_admin() ) :

--- a/src/wp-includes/block-supports/border.php
+++ b/src/wp-includes/block-supports/border.php
@@ -103,7 +103,7 @@ function wp_apply_border_support( $block_type, $block_attributes ) {
 	) {
 		$preset_border_color          = array_key_exists( 'borderColor', $block_attributes ) ? "var:preset|color|{$block_attributes['borderColor']}" : null;
 		$custom_border_color          = _wp_array_get( $block_attributes, array( 'style', 'border', 'color' ), null );
-		$border_block_styles['color'] = $preset_border_color ? $preset_border_color : $custom_border_color;
+		$border_block_styles['color'] = $preset_border_color ?: $custom_border_color;
 	}
 
 	// Generates styles for individual border sides.

--- a/src/wp-includes/block-supports/colors.php
+++ b/src/wp-includes/block-supports/colors.php
@@ -88,21 +88,21 @@ function wp_apply_colors_support( $block_type, $block_attributes ) {
 	if ( $has_text_colors_support && ! wp_should_skip_block_supports_serialization( $block_type, 'color', 'text' ) ) {
 		$preset_text_color          = array_key_exists( 'textColor', $block_attributes ) ? "var:preset|color|{$block_attributes['textColor']}" : null;
 		$custom_text_color          = _wp_array_get( $block_attributes, array( 'style', 'color', 'text' ), null );
-		$color_block_styles['text'] = $preset_text_color ? $preset_text_color : $custom_text_color;
+		$color_block_styles['text'] = $preset_text_color ?: $custom_text_color;
 	}
 
 	// Background colors.
 	if ( $has_background_colors_support && ! wp_should_skip_block_supports_serialization( $block_type, 'color', 'background' ) ) {
 		$preset_background_color          = array_key_exists( 'backgroundColor', $block_attributes ) ? "var:preset|color|{$block_attributes['backgroundColor']}" : null;
 		$custom_background_color          = _wp_array_get( $block_attributes, array( 'style', 'color', 'background' ), null );
-		$color_block_styles['background'] = $preset_background_color ? $preset_background_color : $custom_background_color;
+		$color_block_styles['background'] = $preset_background_color ?: $custom_background_color;
 	}
 
 	// Gradients.
 	if ( $has_gradients_support && ! wp_should_skip_block_supports_serialization( $block_type, 'color', 'gradients' ) ) {
 		$preset_gradient_color          = array_key_exists( 'gradient', $block_attributes ) ? "var:preset|gradient|{$block_attributes['gradient']}" : null;
 		$custom_gradient_color          = _wp_array_get( $block_attributes, array( 'style', 'color', 'gradient' ), null );
-		$color_block_styles['gradient'] = $preset_gradient_color ? $preset_gradient_color : $custom_gradient_color;
+		$color_block_styles['gradient'] = $preset_gradient_color ?: $custom_gradient_color;
 	}
 
 	$attributes = array();

--- a/src/wp-includes/block-supports/layout.php
+++ b/src/wp-includes/block-supports/layout.php
@@ -275,8 +275,8 @@ function wp_get_layout_style( $selector, $layout, $has_block_gap_support = false
 		$wide_size       = isset( $layout['wideSize'] ) ? $layout['wideSize'] : '';
 		$justify_content = isset( $layout['justifyContent'] ) ? $layout['justifyContent'] : 'center';
 
-		$all_max_width_value  = $content_size ? $content_size : $wide_size;
-		$wide_max_width_value = $wide_size ? $wide_size : $content_size;
+		$all_max_width_value  = $content_size ?: $wide_size;
+		$wide_max_width_value = $wide_size ?: $content_size;
 
 		// Make sure there is a single CSS rule, and all tags are stripped for security.
 		$all_max_width_value  = safecss_filter_attr( explode( ';', $all_max_width_value )[0] );

--- a/src/wp-includes/block-supports/shadow.php
+++ b/src/wp-includes/block-supports/shadow.php
@@ -60,7 +60,7 @@ function wp_apply_shadow_support( $block_type, $block_attributes ) {
 
 	$preset_shadow                 = array_key_exists( 'shadow', $block_attributes ) ? "var:preset|shadow|{$block_attributes['shadow']}" : null;
 	$custom_shadow                 = isset( $block_attributes['style']['shadow'] ) ? $block_attributes['style']['shadow'] : null;
-	$shadow_block_styles['shadow'] = $preset_shadow ? $preset_shadow : $custom_shadow;
+	$shadow_block_styles['shadow'] = $preset_shadow ?: $custom_shadow;
 
 	$attributes = array();
 	$styles     = wp_style_engine_get_styles( $shadow_block_styles );

--- a/src/wp-includes/block-supports/typography.php
+++ b/src/wp-includes/block-supports/typography.php
@@ -125,7 +125,7 @@ function wp_apply_typography_support( $block_type, $block_attributes ) {
 		$custom_font_size                    = isset( $block_attributes['style']['typography']['fontSize'] )
 			? $block_attributes['style']['typography']['fontSize']
 			: null;
-		$typography_block_styles['fontSize'] = $preset_font_size ? $preset_font_size : wp_get_typography_font_size_value(
+		$typography_block_styles['fontSize'] = $preset_font_size ?: wp_get_typography_font_size_value(
 			array(
 				'size' => $custom_font_size,
 			)
@@ -139,7 +139,7 @@ function wp_apply_typography_support( $block_type, $block_attributes ) {
 		$custom_font_family                    = isset( $block_attributes['style']['typography']['fontFamily'] )
 			? wp_typography_get_preset_inline_style_value( $block_attributes['style']['typography']['fontFamily'], 'font-family' )
 			: null;
-		$typography_block_styles['fontFamily'] = $preset_font_family ? $preset_font_family : $custom_font_family;
+		$typography_block_styles['fontFamily'] = $preset_font_family ?: $custom_font_family;
 	}
 
 	if (

--- a/src/wp-includes/block-template.php
+++ b/src/wp-includes/block-template.php
@@ -313,7 +313,7 @@ function _resolve_template_for_new_post( $wp_query ) {
 	// Posts, including custom post types.
 	$p = isset( $wp_query->query['p'] ) ? $wp_query->query['p'] : null;
 
-	$post_id = $page_id ? $page_id : $p;
+	$post_id = $page_id ?: $p;
 	$post    = get_post( $post_id );
 
 	if (

--- a/src/wp-includes/blocks/avatar.php
+++ b/src/wp-includes/blocks/avatar.php
@@ -113,7 +113,7 @@ function get_block_core_avatar_border_attributes( $attributes ) {
 	// Border color.
 	$preset_color           = array_key_exists( 'borderColor', $attributes ) ? "var:preset|color|{$attributes['borderColor']}" : null;
 	$custom_color           = _wp_array_get( $attributes, array( 'style', 'border', 'color' ), null );
-	$border_styles['color'] = $preset_color ? $preset_color : $custom_color;
+	$border_styles['color'] = $preset_color ?: $custom_color;
 
 	// Individual border styles e.g. top, left etc.
 	foreach ( $sides as $side ) {

--- a/src/wp-includes/blocks/calendar.php
+++ b/src/wp-includes/blocks/calendar.php
@@ -45,12 +45,12 @@ function render_block_core_calendar( $attributes ) {
 	// Text color.
 	$preset_text_color          = array_key_exists( 'textColor', $attributes ) ? "var:preset|color|{$attributes['textColor']}" : null;
 	$custom_text_color          = _wp_array_get( $attributes, array( 'style', 'color', 'text' ), null );
-	$color_block_styles['text'] = $preset_text_color ? $preset_text_color : $custom_text_color;
+	$color_block_styles['text'] = $preset_text_color ?: $custom_text_color;
 
 	// Background Color.
 	$preset_background_color          = array_key_exists( 'backgroundColor', $attributes ) ? "var:preset|color|{$attributes['backgroundColor']}" : null;
 	$custom_background_color          = _wp_array_get( $attributes, array( 'style', 'color', 'background' ), null );
-	$color_block_styles['background'] = $preset_background_color ? $preset_background_color : $custom_background_color;
+	$color_block_styles['background'] = $preset_background_color ?: $custom_background_color;
 
 	// Generate color styles and classes.
 	$styles        = wp_style_engine_get_styles( array( 'color' => $color_block_styles ), array( 'convert_vars_to_classnames' => true ) );

--- a/src/wp-includes/blocks/gallery.php
+++ b/src/wp-includes/blocks/gallery.php
@@ -84,7 +84,7 @@ function block_core_gallery_render( $attributes, $content ) {
 	// --gallery-block--gutter-size is deprecated. --wp--style--gallery-gap-default should be used by themes that want to set a default
 	// gap on the gallery.
 	$fallback_gap = 'var( --wp--style--gallery-gap-default, var( --gallery-block--gutter-size, var( --wp--style--block-gap, 0.5em ) ) )';
-	$gap_value    = $gap ? $gap : $fallback_gap;
+	$gap_value    = $gap ?: $fallback_gap;
 	$gap_column   = $gap_value;
 
 	if ( is_array( $gap_value ) ) {

--- a/src/wp-includes/blocks/post-featured-image.php
+++ b/src/wp-includes/blocks/post-featured-image.php
@@ -191,7 +191,7 @@ function get_block_core_post_featured_image_border_attributes( $attributes ) {
 	// Border color.
 	$preset_color           = array_key_exists( 'borderColor', $attributes ) ? "var:preset|color|{$attributes['borderColor']}" : null;
 	$custom_color           = _wp_array_get( $attributes, array( 'style', 'border', 'color' ), null );
-	$border_styles['color'] = $preset_color ? $preset_color : $custom_color;
+	$border_styles['color'] = $preset_color ?: $custom_color;
 
 	// Individual border styles e.g. top, left etc.
 	foreach ( $sides as $side ) {

--- a/src/wp-includes/class-wp-block-parser.php
+++ b/src/wp-includes/class-wp-block-parser.php
@@ -330,7 +330,7 @@ class WP_Block_Parser {
 	 * @param null $length how many bytes of document text to output.
 	 */
 	public function add_freeform( $length = null ) {
-		$length = $length ? $length : strlen( $this->document ) - $this->offset;
+		$length = $length ?: strlen( $this->document ) - $this->offset;
 
 		if ( 0 === $length ) {
 			return;
@@ -361,7 +361,7 @@ class WP_Block_Parser {
 		}
 
 		$parent->block->innerContent[] = null;
-		$parent->prev_offset           = $last_offset ? $last_offset : $token_start + $token_length;
+		$parent->prev_offset           = $last_offset ?: $token_start + $token_length;
 	}
 
 	/**

--- a/src/wp-includes/class-wp-editor.php
+++ b/src/wp-includes/class-wp-editor.php
@@ -181,7 +181,7 @@ final class _WP_Editors {
 			$autocomplete = ' autocomplete="off"';
 
 			if ( self::$this_quicktags ) {
-				$default_editor = $set['default_editor'] ? $set['default_editor'] : wp_default_editor();
+				$default_editor = $set['default_editor'] ?: wp_default_editor();
 				// 'html' is used for the "Text" editor tab.
 				if ( 'html' !== $default_editor ) {
 					$default_editor = 'tinymce';

--- a/src/wp-includes/class-wp-image-editor.php
+++ b/src/wp-includes/class-wp-image-editor.php
@@ -451,7 +451,7 @@ abstract class WP_Image_Editor {
 		$ext = pathinfo( $this->file, PATHINFO_EXTENSION );
 
 		$name    = wp_basename( $this->file, ".$ext" );
-		$new_ext = strtolower( $extension ? $extension : $ext );
+		$new_ext = strtolower( $extension ?: $ext );
 
 		if ( ! is_null( $dest_path ) ) {
 			if ( ! wp_is_stream( $dest_path ) ) {

--- a/src/wp-includes/class-wp-post-type.php
+++ b/src/wp-includes/class-wp-post-type.php
@@ -795,7 +795,7 @@ final class WP_Post_Type {
 			return null;
 		}
 
-		$class = $this->rest_controller_class ? $this->rest_controller_class : WP_REST_Posts_Controller::class;
+		$class = $this->rest_controller_class ?: WP_REST_Posts_Controller::class;
 
 		if ( ! class_exists( $class ) ) {
 			return null;

--- a/src/wp-includes/class-wp-scripts.php
+++ b/src/wp-includes/class-wp-scripts.php
@@ -295,7 +295,7 @@ class WP_Scripts extends WP_Dependencies {
 		if ( null === $obj->ver ) {
 			$ver = '';
 		} else {
-			$ver = $obj->ver ? $obj->ver : $this->default_version;
+			$ver = $obj->ver ?: $this->default_version;
 		}
 
 		if ( isset( $this->args[ $handle ] ) ) {

--- a/src/wp-includes/class-wp-styles.php
+++ b/src/wp-includes/class-wp-styles.php
@@ -158,7 +158,7 @@ class WP_Styles extends WP_Dependencies {
 		if ( null === $obj->ver ) {
 			$ver = '';
 		} else {
-			$ver = $obj->ver ? $obj->ver : $this->default_version;
+			$ver = $obj->ver ?: $this->default_version;
 		}
 
 		if ( isset( $this->args[ $handle ] ) ) {

--- a/src/wp-includes/class-wp-taxonomy.php
+++ b/src/wp-includes/class-wp-taxonomy.php
@@ -571,7 +571,7 @@ final class WP_Taxonomy {
 			return null;
 		}
 
-		$class = $this->rest_controller_class ? $this->rest_controller_class : WP_REST_Terms_Controller::class;
+		$class = $this->rest_controller_class ?: WP_REST_Terms_Controller::class;
 
 		if ( ! class_exists( $class ) ) {
 			return null;

--- a/src/wp-includes/class-wpdb.php
+++ b/src/wp-includes/class-wpdb.php
@@ -3053,14 +3053,14 @@ class wpdb {
 		}
 
 		if ( OBJECT === $output ) {
-			return $this->last_result[ $y ] ? $this->last_result[ $y ] : null;
+			return $this->last_result[ $y ] ?: NULL;
 		} elseif ( ARRAY_A === $output ) {
 			return $this->last_result[ $y ] ? get_object_vars( $this->last_result[ $y ] ) : null;
 		} elseif ( ARRAY_N === $output ) {
 			return $this->last_result[ $y ] ? array_values( get_object_vars( $this->last_result[ $y ] ) ) : null;
 		} elseif ( OBJECT === strtoupper( $output ) ) {
 			// Back compat for OBJECT being previously case-insensitive.
-			return $this->last_result[ $y ] ? $this->last_result[ $y ] : null;
+			return $this->last_result[ $y ] ?: NULL;
 		} else {
 			$this->print_error( ' $db->get_row(string query, output type, int offset) -- Output type must be one of: OBJECT, ARRAY_A, ARRAY_N' );
 		}

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -6415,7 +6415,7 @@ function wp_timezone_choice( $selected_zone, $locale = null ) {
 
 	// Load translations for continents and cities.
 	if ( ! $mo_loaded || $locale !== $locale_loaded ) {
-		$locale_loaded = $locale ? $locale : get_locale();
+		$locale_loaded = $locale ?: get_locale();
 		$mofile        = WP_LANG_DIR . '/continents-cities-' . $locale_loaded . '.mo';
 		unload_textdomain( 'continents-cities' );
 		load_textdomain( 'continents-cities', $mofile, $locale_loaded );

--- a/src/wp-includes/html-api/class-wp-html-active-formatting-elements.php
+++ b/src/wp-includes/html-api/class-wp-html-active-formatting-elements.php
@@ -84,7 +84,7 @@ class WP_HTML_Active_Formatting_Elements {
 	public function current_node() {
 		$current_node = end( $this->stack );
 
-		return $current_node ? $current_node : null;
+		return $current_node ?: NULL;
 	}
 
 	/**

--- a/src/wp-includes/html-api/class-wp-html-open-elements.php
+++ b/src/wp-includes/html-api/class-wp-html-open-elements.php
@@ -91,7 +91,7 @@ class WP_HTML_Open_Elements {
 	public function current_node() {
 		$current_node = end( $this->stack );
 
-		return $current_node ? $current_node : null;
+		return $current_node ?: NULL;
 	}
 
 	/**

--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -108,7 +108,7 @@ function get_user_locale( $user = 0 ) {
 
 	$locale = $user_object->locale;
 
-	return $locale ? $locale : get_locale();
+	return $locale ?: get_locale();
 }
 
 /**

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -4320,7 +4320,7 @@ function wp_prepare_attachment_for_js( $attachment ) {
 	$author = new WP_User( $attachment->post_author );
 
 	if ( $author->exists() ) {
-		$author_name            = $author->display_name ? $author->display_name : $author->nickname;
+		$author_name            = $author->display_name ?: $author->nickname;
 		$response['authorName'] = html_entity_decode( $author_name, ENT_QUOTES, get_bloginfo( 'charset' ) );
 		$response['authorLink'] = get_edit_user_link( $author->ID );
 	} else {
@@ -4330,7 +4330,7 @@ function wp_prepare_attachment_for_js( $attachment ) {
 	if ( $attachment->post_parent ) {
 		$post_parent = get_post( $attachment->post_parent );
 		if ( $post_parent ) {
-			$response['uploadedToTitle'] = $post_parent->post_title ? $post_parent->post_title : __( '(no title)' );
+			$response['uploadedToTitle'] = $post_parent->post_title ?: __( '(no title)' );
 			$response['uploadedToLink']  = get_edit_post_link( $attachment->post_parent, 'raw' );
 		}
 	}
@@ -4351,7 +4351,7 @@ function wp_prepare_attachment_for_js( $attachment ) {
 	}
 
 	$context             = get_post_meta( $attachment->ID, '_wp_attachment_context', true );
-	$response['context'] = ( $context ) ? $context : '';
+	$response['context'] = ( $context ) ?: '';
 
 	if ( current_user_can( 'edit_post', $attachment->ID ) ) {
 		$response['nonces']['update'] = wp_create_nonce( 'update-post_' . $attachment->ID );
@@ -4718,7 +4718,7 @@ function wp_enqueue_media( $args = array() ) {
 
 		if ( $thumbnail_support ) {
 			$featured_image_id                   = get_post_meta( $post->ID, '_thumbnail_id', true );
-			$settings['post']['featuredImageId'] = $featured_image_id ? $featured_image_id : -1;
+			$settings['post']['featuredImageId'] = $featured_image_id ?: -1;
 		}
 	}
 

--- a/src/wp-includes/ms-load.php
+++ b/src/wp-includes/ms-load.php
@@ -369,7 +369,7 @@ function ms_load_current_site_and_network( $domain, $path, $subdomain = false ) 
 		// Find the site by the domain and at most the first path segment.
 		$current_blog = get_site_by_path( $domain, $path, 1 );
 		if ( $current_blog ) {
-			$current_site = WP_Network::get_instance( $current_blog->site_id ? $current_blog->site_id : 1 );
+			$current_site = WP_Network::get_instance( $current_blog->site_id ?: 1 );
 		} else {
 			// If you don't have a site with the same domain/path as a network, you're pretty screwed, but:
 			$current_site = WP_Network::get_by_path( $domain, $path, 1 );

--- a/src/wp-includes/nav-menu-template.php
+++ b/src/wp-includes/nav-menu-template.php
@@ -252,7 +252,7 @@ function wp_nav_menu( $args = array() ) {
 	}
 	$menu_id_slugs[] = $wrap_id;
 
-	$wrap_class = $args->menu_class ? $args->menu_class : '';
+	$wrap_class = $args->menu_class ?: '';
 
 	/**
 	 * Filters the HTML list content for navigation menus.

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -3994,10 +3994,10 @@ function wp_get_recent_posts( $args = array(), $output = ARRAY_A ) {
 		foreach ( $results as $key => $result ) {
 			$results[ $key ] = get_object_vars( $result );
 		}
-		return $results ? $results : array();
+		return $results ?: array();
 	}
 
-	return $results ? $results : false;
+	return $results ?: FALSE;
 
 }
 
@@ -5631,7 +5631,7 @@ function trackback_url_list( $tb_list, $post_id ) {
 		$postdata = get_post( $post_id, ARRAY_A );
 
 		// Form an excerpt.
-		$excerpt = strip_tags( $postdata['post_excerpt'] ? $postdata['post_excerpt'] : $postdata['post_content'] );
+		$excerpt = strip_tags( $postdata['post_excerpt'] ?: $postdata['post_content'] );
 
 		if ( strlen( $excerpt ) > 255 ) {
 			$excerpt = substr( $excerpt, 0, 252 ) . '&hellip;';

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-application-passwords-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-application-passwords-controller.php
@@ -618,7 +618,7 @@ class WP_REST_Application_Passwords_Controller extends WP_REST_Controller {
 			'name'      => $item['name'],
 			'created'   => gmdate( 'Y-m-d\TH:i:s', $item['created'] ),
 			'last_used' => $item['last_used'] ? gmdate( 'Y-m-d\TH:i:s', $item['last_used'] ) : null,
-			'last_ip'   => $item['last_ip'] ? $item['last_ip'] : null,
+			'last_ip'   => $item['last_ip'] ?: NULL,
 		);
 
 		if ( isset( $item['new_password'] ) ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-directory-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-directory-controller.php
@@ -127,7 +127,7 @@ class WP_REST_Block_Directory_Controller extends WP_REST_Controller {
 		// A data array containing the properties we'll return.
 		$block = array(
 			'name'                => $block_data['name'],
-			'title'               => ( $block_data['title'] ? $block_data['title'] : $plugin['name'] ),
+			'title'               => $block_data['title'] ?: $plugin['name'],
 			'description'         => wp_trim_words( $plugin['short_description'], 30, '...' ),
 			'id'                  => $plugin['slug'],
 			'rating'              => $plugin['rating'] / 20,

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-menu-items-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-menu-items-controller.php
@@ -436,7 +436,7 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 
 		// If post type archive, check if post type exists.
 		if ( 'post_type_archive' === $prepared_nav_item['menu-item-type'] ) {
-			$post_type = $prepared_nav_item['menu-item-object'] ? $prepared_nav_item['menu-item-object'] : false;
+			$post_type = $prepared_nav_item['menu-item-object'] ?: FALSE;
 			$original  = get_post_type_object( $post_type );
 			if ( ! $original ) {
 				$error->add( 'rest_post_invalid_type', __( 'Invalid post type.' ), array( 'status' => 400 ) );

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -264,7 +264,7 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 
 		if ( rest_is_field_included( 'screenshot', $fields ) ) {
 			// Using $theme->get_screenshot() with no args to get absolute URL.
-			$data['screenshot'] = $theme->get_screenshot() ? $theme->get_screenshot() : '';
+			$data['screenshot'] = $theme->get_screenshot() ?: '';
 		}
 
 		$rich_field_mappings = array(

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -46,13 +46,13 @@ function create_initial_taxonomies() {
 		$rewrite          = array(
 			'category'    => array(
 				'hierarchical' => true,
-				'slug'         => get_option( 'category_base' ) ? get_option( 'category_base' ) : 'category',
+				'slug'         => get_option( 'category_base' ) ?: 'category',
 				'with_front'   => ! get_option( 'category_base' ) || $wp_rewrite->using_index_permalinks(),
 				'ep_mask'      => EP_CATEGORIES,
 			),
 			'post_tag'    => array(
 				'hierarchical' => false,
-				'slug'         => get_option( 'tag_base' ) ? get_option( 'tag_base' ) : 'tag',
+				'slug'         => get_option( 'tag_base' ) ?: 'tag',
 				'with_front'   => ! get_option( 'tag_base' ) || $wp_rewrite->using_index_permalinks(),
 				'ep_mask'      => EP_TAGS,
 			),

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -1128,7 +1128,7 @@ function _wp_delete_all_temp_backups() {
 
 	$temp_backup_dir = $wp_filesystem->wp_content_dir() . 'upgrade-temp-backup/';
 	$dirlist         = $wp_filesystem->dirlist( $temp_backup_dir );
-	$dirlist         = $dirlist ? $dirlist : array();
+	$dirlist         = $dirlist ?: array();
 
 	foreach ( array_keys( $dirlist ) as $dir ) {
 		if ( '.' === $dir || '..' === $dir ) {

--- a/src/wp-includes/widgets/class-wp-nav-menu-widget.php
+++ b/src/wp-includes/widgets/class-wp-nav-menu-widget.php
@@ -74,7 +74,7 @@ class WP_Nav_Menu_Widget extends WP_Widget {
 		if ( 'html5' === $format ) {
 			// The title may be filtered: Strip out HTML and make sure the aria-label is never empty.
 			$title      = trim( strip_tags( $title ) );
-			$aria_label = $title ? $title : $default_title;
+			$aria_label = $title ?: $default_title;
 
 			$nav_menu_args = array(
 				'fallback_cb'          => '',

--- a/src/wp-includes/widgets/class-wp-widget-archives.php
+++ b/src/wp-includes/widgets/class-wp-widget-archives.php
@@ -132,7 +132,7 @@ class WP_Widget_Archives extends WP_Widget {
 			if ( 'html5' === $format ) {
 				// The title may be filtered: Strip out HTML and make sure the aria-label is never empty.
 				$title      = trim( strip_tags( $title ) );
-				$aria_label = $title ? $title : $default_title;
+				$aria_label = $title ?: $default_title;
 				echo '<nav aria-label="' . esc_attr( $aria_label ) . '">';
 			}
 			?>

--- a/src/wp-includes/widgets/class-wp-widget-categories.php
+++ b/src/wp-includes/widgets/class-wp-widget-categories.php
@@ -119,7 +119,7 @@ class WP_Widget_Categories extends WP_Widget {
 			if ( 'html5' === $format ) {
 				// The title may be filtered: Strip out HTML and make sure the aria-label is never empty.
 				$title      = trim( strip_tags( $title ) );
-				$aria_label = $title ? $title : $default_title;
+				$aria_label = $title ?: $default_title;
 				echo '<nav aria-label="' . esc_attr( $aria_label ) . '">';
 			}
 			?>

--- a/src/wp-includes/widgets/class-wp-widget-meta.php
+++ b/src/wp-includes/widgets/class-wp-widget-meta.php
@@ -63,7 +63,7 @@ class WP_Widget_Meta extends WP_Widget {
 		if ( 'html5' === $format ) {
 			// The title may be filtered: Strip out HTML and make sure the aria-label is never empty.
 			$title      = trim( strip_tags( $title ) );
-			$aria_label = $title ? $title : $default_title;
+			$aria_label = $title ?: $default_title;
 			echo '<nav aria-label="' . esc_attr( $aria_label ) . '">';
 		}
 		?>

--- a/src/wp-includes/widgets/class-wp-widget-pages.php
+++ b/src/wp-includes/widgets/class-wp-widget-pages.php
@@ -100,7 +100,7 @@ class WP_Widget_Pages extends WP_Widget {
 			if ( 'html5' === $format ) {
 				// The title may be filtered: Strip out HTML and make sure the aria-label is never empty.
 				$title      = trim( strip_tags( $title ) );
-				$aria_label = $title ? $title : $default_title;
+				$aria_label = $title ?: $default_title;
 				echo '<nav aria-label="' . esc_attr( $aria_label ) . '">';
 			}
 			?>

--- a/src/wp-includes/widgets/class-wp-widget-recent-comments.php
+++ b/src/wp-includes/widgets/class-wp-widget-recent-comments.php
@@ -133,7 +133,7 @@ class WP_Widget_Recent_Comments extends WP_Widget {
 		if ( 'html5' === $format ) {
 			// The title may be filtered: Strip out HTML and make sure the aria-label is never empty.
 			$title      = trim( strip_tags( $title ) );
-			$aria_label = $title ? $title : $default_title;
+			$aria_label = $title ?: $default_title;
 			$output    .= '<nav aria-label="' . esc_attr( $aria_label ) . '">';
 		}
 

--- a/src/wp-includes/widgets/class-wp-widget-recent-posts.php
+++ b/src/wp-includes/widgets/class-wp-widget-recent-posts.php
@@ -102,7 +102,7 @@ class WP_Widget_Recent_Posts extends WP_Widget {
 		if ( 'html5' === $format ) {
 			// The title may be filtered: Strip out HTML and make sure the aria-label is never empty.
 			$title      = trim( strip_tags( $title ) );
-			$aria_label = $title ? $title : $default_title;
+			$aria_label = $title ?: $default_title;
 			echo '<nav aria-label="' . esc_attr( $aria_label ) . '">';
 		}
 		?>

--- a/src/wp-includes/widgets/class-wp-widget-rss.php
+++ b/src/wp-includes/widgets/class-wp-widget-rss.php
@@ -126,7 +126,7 @@ class WP_Widget_RSS extends WP_Widget {
 		if ( 'html5' === $format ) {
 			// The title may be filtered: Strip out HTML and make sure the aria-label is never empty.
 			$title      = trim( strip_tags( $title ) );
-			$aria_label = $title ? $title : __( 'RSS Feed' );
+			$aria_label = $title ?: __( 'RSS Feed' );
 			echo '<nav aria-label="' . esc_attr( $aria_label ) . '">';
 		}
 

--- a/src/wp-includes/widgets/class-wp-widget-tag-cloud.php
+++ b/src/wp-includes/widgets/class-wp-widget-tag-cloud.php
@@ -101,7 +101,7 @@ class WP_Widget_Tag_Cloud extends WP_Widget {
 		if ( 'html5' === $format ) {
 			// The title may be filtered: Strip out HTML and make sure the aria-label is never empty.
 			$title      = trim( strip_tags( $title ) );
-			$aria_label = $title ? $title : $default_title;
+			$aria_label = $title ?: $default_title;
 			echo '<nav aria-label="' . esc_attr( $aria_label ) . '">';
 		}
 


### PR DESCRIPTION
 This is a somewhat big change, but a simple one at that.

Replaces `a ? a : b` patterns of ternary statements to use the Elvis operator `a ?: b`.

Null coalescing operator (`??`) was added in PHP 7.0, which WordPress now requires as the minimum version. However, to make this ticket focused and easier to review, this ticket only proposes the Elvis operator.

On tainted lines, it follows WordPress CS to use uppercase constants (NULL instead of null, for example), and removes a few cases of unnecessary braces. Apart from them, the diff output should be quite minimal and straight forward.

Perhaps, the review will be easier with word-diff (`git show --word-diff`), or on GitHub, where it highlights word diffs in the line-diff mode.

Trac ticket: https://core.trac.wordpress.org/ticket/58948

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
