### PR TITLE
Twenty Twelve: Table Block does not align centre on front end

### DIFF
--- a/src/wp-content/themes/twentytwelve/css/blocks.css
+++ b/src/wp-content/themes/twentytwelve/css/blocks.css
@@ -221,8 +221,7 @@ pre.wp-block-code {
 	border-spacing: 0;
 	font-size: 14px;
 	line-height: 2;
-	margin: 0 0 20px;
-	width: 100%;
+	margin-bottom: 20px;
 }
 
 .wp-block-table th {

--- a/src/wp-content/themes/twentytwelve/css/editor-blocks.css
+++ b/src/wp-content/themes/twentytwelve/css/editor-blocks.css
@@ -307,8 +307,20 @@ p.has-drop-cap:not(:focus)::first-letter {
 	border-spacing: 0;
 	font-size: 14px;
 	line-height: 2;
-	margin: 0 0 20px;
-	width: 100%;
+	margin-bottom: 20px;
+}
+
+/* Aligns bottom border when table block is aligned center in editor. */
+.wp-block[data-align=center] > .wp-block-table {
+	clear: both;
+	width: fit-content;
+	margin-left: auto;
+	margin-right: auto;
+}
+
+/* Aligns bottom margin when table block is aligned center in editor. */
+.wp-block[data-align=center] > .wp-block-table table {
+	margin-bottom: 24px;
 }
 
 .editor-styles-wrapper .has-text-color th {


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/58934

## Description
- This PR fixes the `Twenty Twelve` theme's table block styles for both front-end & editor-end.

## Screenshots/Screencasts

### Editor End

| Before | After |
| :--: | :--: |
| <img width="1440" alt="Screenshot 2023-08-02 at 10 58 39 AM" src="https://github.com/Pathan-Amaankhan/wordpress-develop/assets/63953699/4688b8e0-58f0-426b-a457-c0ad3ac69f7d"> | <img width="1440" alt="Screenshot 2023-08-02 at 11 07 50 AM" src="https://github.com/Pathan-Amaankhan/wordpress-develop/assets/63953699/51ae913c-031a-4a99-94a6-6a7548547c90"> |

### Front End
| Before | After |
| :--: | :--: |
| <img width="1440" alt="Screenshot 2023-08-02 at 11 04 00 AM" src="https://github.com/Pathan-Amaankhan/wordpress-develop/assets/63953699/dbbff6a9-40f1-4e5a-97e3-96f213c612f5"> | <img width="1440" alt="Screenshot 2023-08-02 at 11 11 13 AM" src="https://github.com/Pathan-Amaankhan/wordpress-develop/assets/63953699/a95565b7-75c9-4395-b6aa-6c32ca6ae4de"> |

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
