### PR TITLE
Setting the default value of COOKIE_DOMAIN to null value

### DIFF
--- a/src/wp-includes/default-constants.php
+++ b/src/wp-includes/default-constants.php
@@ -327,7 +327,7 @@ function wp_cookie_constants() {
 	 * @since 2.0.0
 	 */
 	if ( ! defined( 'COOKIE_DOMAIN' ) ) {
-		define('COOKIE_DOMAIN', '');
+		define( 'COOKIE_DOMAIN', '' );
 	}
 
 	if ( ! defined( 'RECOVERY_MODE_COOKIE' ) ) {

--- a/src/wp-includes/default-constants.php
+++ b/src/wp-includes/default-constants.php
@@ -327,7 +327,7 @@ function wp_cookie_constants() {
 	 * @since 2.0.0
 	 */
 	if ( ! defined( 'COOKIE_DOMAIN' ) ) {
-		define( 'COOKIE_DOMAIN', false );
+		define('COOKIE_DOMAIN', '');
 	}
 
 	if ( ! defined( 'RECOVERY_MODE_COOKIE' ) ) {

--- a/src/wp-includes/default-constants.php
+++ b/src/wp-includes/default-constants.php
@@ -325,6 +325,7 @@ function wp_cookie_constants() {
 
 	/**
 	 * @since 2.0.0
+  	 * @since 6.4.0 The default value is empty.
 	 */
 	if ( ! defined( 'COOKIE_DOMAIN' ) ) {
 		define( 'COOKIE_DOMAIN', '' );

--- a/src/wp-includes/default-constants.php
+++ b/src/wp-includes/default-constants.php
@@ -325,7 +325,7 @@ function wp_cookie_constants() {
 
 	/**
 	 * @since 2.0.0
-  	 * @since 6.4.0 The default value is empty.
+	 * @since 6.4.0 The default value is empty.
 	 */
 	if ( ! defined( 'COOKIE_DOMAIN' ) ) {
 		define( 'COOKIE_DOMAIN', '' );

--- a/src/wp-includes/default-constants.php
+++ b/src/wp-includes/default-constants.php
@@ -328,7 +328,7 @@ function wp_cookie_constants() {
 	 */
 	if ( ! defined( 'COOKIE_DOMAIN' ) ) {
 		/**
-		 * @since 6.4.0 The default value has changed from false to an empty string.
+		 * @since 6.5.0 The value has changed from false to an empty string.
 		 *
 		 * @var string
 		 */

--- a/src/wp-includes/default-constants.php
+++ b/src/wp-includes/default-constants.php
@@ -325,7 +325,9 @@ function wp_cookie_constants() {
 
 	/**
 	 * @since 2.0.0
-	 * @since 6.4.0 The default value is empty.
+	 * @since 6.4.0 The default value has changed from false to an empty string.
+  	 *
+  	 * @var string
 	 */
 	if ( ! defined( 'COOKIE_DOMAIN' ) ) {
 		define( 'COOKIE_DOMAIN', '' );

--- a/src/wp-includes/default-constants.php
+++ b/src/wp-includes/default-constants.php
@@ -329,7 +329,7 @@ function wp_cookie_constants() {
 	if ( ! defined( 'COOKIE_DOMAIN' ) ) {
 		/**
 		 * @since 6.4.0 The default value has changed from false to an empty string.
-		 * 
+		 *
 		 * @var string
 		 */
 		define( 'COOKIE_DOMAIN', '' );

--- a/src/wp-includes/default-constants.php
+++ b/src/wp-includes/default-constants.php
@@ -325,11 +325,13 @@ function wp_cookie_constants() {
 
 	/**
 	 * @since 2.0.0
-	 * @since 6.4.0 The default value has changed from false to an empty string.
-  	 *
-  	 * @var string
 	 */
 	if ( ! defined( 'COOKIE_DOMAIN' ) ) {
+		/**
+		 * @since 6.4.0 The default value has changed from false to an empty string.
+		 * 
+		 * @var string
+		 */
 		define( 'COOKIE_DOMAIN', '' );
 	}
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Setting the default value of COOKIE_DOMAIN to a null value

Trac ticket: https://core.trac.wordpress.org/ticket/46550

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
