### PR TITLE
Fix test leakage in WP_List_Table tests

### DIFF
--- a/tests/phpunit/tests/admin/wpListTable.php
+++ b/tests/phpunit/tests/admin/wpListTable.php
@@ -12,17 +12,34 @@ class Tests_Admin_WpListTable extends WP_UnitTestCase {
 	 *
 	 * @var WP_List_Table $list_table
 	 */
-	protected static $list_table;
+	private $list_table;
+
+	/**
+	 * Original value of $GLOBALS['hook_suffix'].
+	 *
+	 * @var string
+	 */
+	private static $original_hook_suffix;
 
 	public static function set_up_before_class() {
-		global $hook_suffix;
-
 		parent::set_up_before_class();
 
-		require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
+		static::$original_hook_suffix = $GLOBALS['hook_suffix'];
 
+		require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
+	}
+
+	public function set_up() {
+		parent::set_up();
+		global $hook_suffix;
 		$hook_suffix      = '_wp_tests';
-		self::$list_table = new WP_List_Table();
+		$this->list_table = new WP_List_Table();
+	}
+
+	public function clean_up_global_scope() {
+		global $hook_suffix;
+		$hook_suffix = static::$original_hook_suffix;
+		parent::clean_up_global_scope();
 	}
 
 	/**
@@ -142,10 +159,10 @@ class Tests_Admin_WpListTable extends WP_UnitTestCase {
 	 * @param array $expected
 	 */
 	public function test_get_views_links( $link_data, $expected ) {
-		$get_views_links = new ReflectionMethod( self::$list_table, 'get_views_links' );
+		$get_views_links = new ReflectionMethod( $this->list_table, 'get_views_links' );
 		$get_views_links->setAccessible( true );
 
-		$actual = $get_views_links->invokeArgs( self::$list_table, array( $link_data ) );
+		$actual = $get_views_links->invokeArgs( $this->list_table, array( $link_data ) );
 
 		$this->assertSameSetsWithIndex( $expected, $actual );
 	}
@@ -257,9 +274,9 @@ class Tests_Admin_WpListTable extends WP_UnitTestCase {
 	 * }
 	 */
 	public function test_get_views_links_doing_it_wrong( $link_data ) {
-		$get_views_links = new ReflectionMethod( self::$list_table, 'get_views_links' );
+		$get_views_links = new ReflectionMethod( $this->list_table, 'get_views_links' );
 		$get_views_links->setAccessible( true );
-		$get_views_links->invokeArgs( self::$list_table, array( $link_data ) );
+		$get_views_links->invokeArgs( $this->list_table, array( $link_data ) );
 	}
 
 	/**


### PR DESCRIPTION
Fixes tests leaking into other tests by:

* Restoring the original `$hook_suffix` global value. Rather than modifying the global for all tests, restore the original value between tests. Why? To ensure each test starts at a known state.

* Using a new instance of `WP_List_Table` for each test. A test may modify the $list_table object. If it does, it could impact tests yet to run. By instantiating a new instance in the `set_up()` test fixture, each test is isolated from the others.

Note: This was original found and resolved in https://github.com/WordPress/wordpress-develop/pull/4905, but the fix is unrelated to that scope of work. Separating the fix for its own commit.

Trac ticket: https://core.trac.wordpress.org/ticket/58955

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
