### PR TITLE
HTML API: Add support for BUTTON element

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-open-elements.php
+++ b/src/wp-includes/html-api/class-wp-html-open-elements.php
@@ -115,6 +115,15 @@ class WP_HTML_Open_Elements {
 			if ( $node->node_name === $tag_name ) {
 				return true;
 			}
+
+			switch ( $node->node_name ) {
+				case 'HTML':
+					return false;
+			}
+
+			if ( in_array( $node->node_name, $termination_list, true ) ) {
+				return true;
+			}
 		}
 
 		return false;
@@ -175,19 +184,7 @@ class WP_HTML_Open_Elements {
 	 * @return bool Whether given element is in scope.
 	 */
 	public function has_element_in_button_scope( $tag_name ) {
-		return $this->has_element_in_specific_scope(
-			$tag_name,
-			array(
-
-				/*
-				 * Because it's not currently possible to encounter
-				 * one of the termination elements, they don't need
-				 * to be listed here. If they were, they would be
-				 * unreachable and only waste CPU cycles while
-				 * scanning through HTML.
-				 */
-			)
-		);
+		return $this->has_element_in_specific_scope( $tag_name, array( 'BUTTON' ) );
 	}
 
 	/**
@@ -394,6 +391,10 @@ class WP_HTML_Open_Elements {
 		 * cases where the precalculated value needs to change.
 		 */
 		switch ( $item->node_name ) {
+			case 'BUTTON':
+				$this->has_p_in_button_scope = false;
+				break;
+
 			case 'P':
 				$this->has_p_in_button_scope = true;
 				break;
@@ -419,6 +420,10 @@ class WP_HTML_Open_Elements {
 		 * cases where the precalculated value needs to change.
 		 */
 		switch ( $item->node_name ) {
+			case 'BUTTON':
+				$this->has_p_in_button_scope = $this->has_element_in_button_scope( 'P' );
+				break;
+
 			case 'P':
 				$this->has_p_in_button_scope = $this->has_element_in_button_scope( 'P' );
 				break;

--- a/src/wp-includes/html-api/class-wp-html-processor-state.php
+++ b/src/wp-includes/html-api/class-wp-html-processor-state.php
@@ -108,6 +108,19 @@ class WP_HTML_Processor_State {
 	public $context_node = null;
 
 	/**
+	 * The frameset-ok flag indicates if a `FRAMESET` element is allowed in the current state.
+	 *
+	 * > The frameset-ok flag is set to "ok" when the parser is created. It is set to "not ok" after certain tokens are seen.
+	 *
+	 * @since 6.4.0
+	 *
+	 * @see https://html.spec.whatwg.org/#frameset-ok-flag
+	 *
+	 * @var bool
+	 */
+	public $frameset_ok = true;
+
+	/**
 	 * Constructor - creates a new and empty state value.
 	 *
 	 * @since 6.4.0

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorBreadcrumbs.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorBreadcrumbs.php
@@ -39,6 +39,7 @@ class Tests_HtmlApi_WpHtmlProcessorBreadcrumbs extends WP_UnitTestCase {
 			'A',
 			'B',
 			'BIG',
+			'BUTTON',
 			'CODE',
 			'DIV',
 			'EM',
@@ -111,7 +112,6 @@ class Tests_HtmlApi_WpHtmlProcessorBreadcrumbs extends WP_UnitTestCase {
 			'BLINK', // Deprecated
 			'BODY',
 			'BR',
-			'BUTTON',
 			'CANVAS',
 			'CAPTION',
 			'CENTER', // Neutralized

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorSemanticRules.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorSemanticRules.php
@@ -16,6 +16,110 @@ class Tests_HtmlApi_WpHtmlProcessorSemanticRules extends WP_UnitTestCase {
 	 * RULES FOR "IN BODY" MODE
 	 *******************************************************************/
 
+	/**
+	 * Verifies that when encountering an end tag for which there is no corresponding
+	 * element in scope, that it skips the tag entirely.
+	 *
+	 * @ticket {TICKET_NUMBER}
+	 *
+	 * @since 6.4.0
+	 *
+	 * @throws Exception
+	 */
+	public function test_in_body_skips_unexpected_button_closer() {
+		$p = WP_HTML_Processor::createFragment( '<div>Test</button></div>' );
+
+		$p->step();
+		$this->assertEquals( 'DIV', $p->get_tag(), 'Did not stop at initial DIV tag.' );
+		$this->assertFalse( $p->is_tag_closer(), 'Did not find that initial DIV tag is an opener.' );
+
+		$this->assertTrue( $p->step(), 'Found no further tags when it should have found the closing DIV' );
+		$this->assertEquals( 'DIV', $p->get_tag(), "Did not skip unexpected BUTTON; stopped at {$p->get_tag()}." );
+		$this->assertTrue( $p->is_tag_closer(), 'Did not find that the terminal DIV tag is a closer.' );
+	}
+
+	/**
+	 * Verifies insertion of a BUTTON element when no existing BUTTON is already in scope.
+	 *
+	 * @ticket 58961
+	 *
+	 * @since 6.4.0
+	 *
+	 * @throws WP_HTML_Unsupported_Exception
+	 */
+	public function test_in_body_button_with_no_button_in_scope() {
+		$p = WP_HTML_Processor::createFragment( '<div><p>Click the button <button one>here</button>!</p></div><button two>not here</button>' );
+
+		$this->assertTrue( $p->next_tag( 'BUTTON' ), 'Could not find expected first button.' );
+		$this->assertTrue( $p->get_attribute( 'one' ), 'Failed to match expected attribute on first button.' );
+		$this->assertSame( array( 'HTML', 'BODY', 'DIV', 'P', 'BUTTON' ), $p->get_breadcrumbs(), 'Failed to produce expected DOM nesting for first button.' );
+
+		$this->assertTrue( $p->next_tag( 'BUTTON' ), 'Could not find expected second button.' );
+		$this->assertTrue( $p->get_attribute( 'two' ), 'Failed to match expected attribute on second button.' );
+		$this->assertSame( array( 'HTML', 'BODY', 'BUTTON' ), $p->get_breadcrumbs(), 'Failed to produce expected DOM nesting for second button.' );
+	}
+
+	/**
+	 * Verifies what when inserting a BUTTON element, when a BUTTON is already in scope,
+	 * that the open button is closed with all other elements inside of it.
+	 *
+	 * @ticket 58961
+	 *
+	 * @since 6.4.0
+	 *
+	 * @throws WP_HTML_Unsupported_Exception
+	 */
+	public function test_in_body_button_with_button_in_scope_as_parent() {
+		$p = WP_HTML_Processor::createFragment( '<div><p>Click the button <button one>almost<button two>here</button>!</p></div><button three>not here</button>' );
+
+		$this->assertTrue( $p->next_tag( 'BUTTON' ), 'Could not find expected first button.' );
+		$this->assertTrue( $p->get_attribute( 'one' ), 'Failed to match expected attribute on first button.' );
+		$this->assertSame( array( 'HTML', 'BODY', 'DIV', 'P', 'BUTTON' ), $p->get_breadcrumbs(), 'Failed to produce expected DOM nesting for first button.' );
+
+		$this->assertTrue( $p->next_tag( 'BUTTON' ), 'Could not find expected second button.' );
+		$this->assertTrue( $p->get_attribute( 'two' ), 'Failed to match expected attribute on second button.' );
+		$this->assertSame( array( 'HTML', 'BODY', 'DIV', 'P', 'BUTTON' ), $p->get_breadcrumbs(), 'Failed to produce expected DOM nesting for second button.' );
+
+		$this->assertTrue( $p->next_tag( 'BUTTON' ), 'Could not find expected third button.' );
+		$this->assertTrue( $p->get_attribute( 'three' ), 'Failed to match expected attribute on third button.' );
+		$this->assertSame( array( 'HTML', 'BODY', 'BUTTON' ), $p->get_breadcrumbs(), 'Failed to produce expected DOM nesting for third button.' );
+	}
+
+	/**
+	 * Verifies what when inserting a BUTTON element, when a BUTTON is already in scope,
+	 * that the open button is closed with all other elements inside of it, even if the
+	 * BUTTON in scope is not a direct parent of the new BUTTON element.
+	 *
+	 * @ticket 58961
+	 *
+	 * @since 6.4.0
+	 *
+	 * @throws WP_HTML_Unsupported_Exception
+	 */
+	public function test_in_body_button_with_button_in_scope_as_ancestor() {
+		$p = WP_HTML_Processor::createFragment( '<div><button one><p>Click the button <span><button two>here</button>!</span></p></div><button three>not here</button>' );
+
+		// This button finds itself normally nesting inside the DIV.
+		$this->assertTrue( $p->next_tag( 'BUTTON' ), 'Could not find expected first button.' );
+		$this->assertTrue( $p->get_attribute( 'one' ), 'Failed to match expected attribute on first button.' );
+		$this->assertSame( array( 'HTML', 'BODY', 'DIV', 'BUTTON' ), $p->get_breadcrumbs(), 'Failed to produce expected DOM nesting for first button.' );
+
+		/*
+		 * Because the second button appears while a BUTTON is in scope, it generates implied end tags and closes
+		 * the BUTTON, P, and SPAN elements. It looks like the BUTTON is inside the SPAN, but we have another case
+		 * of an unexpected closing SPAN tag because the SPAN was closed by the second BUTTON. This element finds
+		 * itself a child of the most-recent open element above the most-recent BUTTON, or the DIV.
+		 */
+		$this->assertTrue( $p->next_tag( 'BUTTON' ), 'Could not find expected second button.' );
+		$this->assertTrue( $p->get_attribute( 'two' ), 'Failed to match expected attribute on second button.' );
+		$this->assertSame( array( 'HTML', 'BODY', 'DIV', 'BUTTON' ), $p->get_breadcrumbs(), 'Failed to produce expected DOM nesting for second button.' );
+
+		// The third button is back to normal, because everything has been implicitly or explicitly closed by now.
+		$this->assertTrue( $p->next_tag( 'BUTTON' ), 'Could not find expected third button.' );
+		$this->assertTrue( $p->get_attribute( 'three' ), 'Failed to match expected attribute on third button.' );
+		$this->assertSame( array( 'HTML', 'BODY', 'BUTTON' ), $p->get_breadcrumbs(), 'Failed to produce expected DOM nesting for third button.' );
+	}
+
 	/*
 	 * Verifies that when "in body" and encountering "any other end tag"
 	 * that the HTML processor ignores the end tag if there's a special
@@ -57,7 +161,7 @@ class Tests_HtmlApi_WpHtmlProcessorSemanticRules extends WP_UnitTestCase {
 		$this->assertSame( 'CODE', $p->get_tag(), "Expected to start test on CODE element but found {$p->get_tag()} instead." );
 		$this->assertSame( array( 'HTML', 'BODY', 'DIV', 'SPAN', 'CODE' ), $p->get_breadcrumbs(), 'Failed to produce expected DOM nesting.' );
 
-		$this->assertTrue( $p->next_tag(), 'Failed to advance past CODE tag to expected SPAN closer.' );
+		$this->assertTrue( $p->step(), 'Failed to advance past CODE tag to expected SPAN closer.' );
 		$this->assertTrue( $p->is_tag_closer(), 'Expected to find closing SPAN, but found opener instead.' );
 		$this->assertSame( array( 'HTML', 'BODY', 'DIV' ), $p->get_breadcrumbs(), 'Failed to advance past CODE tag to expected DIV opener.' );
 

--- a/tests/phpunit/tests/html-api/wpHtmlSupportRequiredOpenElements.php
+++ b/tests/phpunit/tests/html-api/wpHtmlSupportRequiredOpenElements.php
@@ -176,8 +176,6 @@ class Tests_HtmlApi_WpHtmlSupportRequiredOpenElements extends WP_UnitTestCase {
 		$this->ensure_support_is_added_everywhere( 'FOREIGNOBJECT' );
 		$this->ensure_support_is_added_everywhere( 'DESC' );
 		$this->ensure_support_is_added_everywhere( 'TITLE' );
-
-		$this->ensure_support_is_added_everywhere( 'BUTTON' );
 	}
 
 	/**
@@ -218,9 +216,6 @@ class Tests_HtmlApi_WpHtmlSupportRequiredOpenElements extends WP_UnitTestCase {
 		$this->ensure_support_is_added_everywhere( 'FOREIGNOBJECT' );
 		$this->ensure_support_is_added_everywhere( 'DESC' );
 		$this->ensure_support_is_added_everywhere( 'TITLE' );
-
-		// This element is specific to BUTTON scope.
-		$this->ensure_support_is_added_everywhere( 'BUTTON' );
 	}
 
 	/**
@@ -261,8 +256,6 @@ class Tests_HtmlApi_WpHtmlSupportRequiredOpenElements extends WP_UnitTestCase {
 		$this->ensure_support_is_added_everywhere( 'FOREIGNOBJECT' );
 		$this->ensure_support_is_added_everywhere( 'DESC' );
 		$this->ensure_support_is_added_everywhere( 'TITLE' );
-
-		$this->ensure_support_is_added_everywhere( 'BUTTON' );
 	}
 
 	/**


### PR DESCRIPTION
Ticket: [#58961](https://core.trac.wordpress.org/ticket/58961)

In this patch we're adding support to process the BUTTON element. This requires adding some additional semantic rules to handle situations where a BUTTON element is already in scope.

Also included is a fixup to enforce that `WP_HTML_Processor::next_tag()` never returns for a tag closer. This is useful with the Tag Processor, but not for the HTML Processor. There were tests relying on this behavior to assert that internal processes were working as they should, but those tests have been updated to use the semi-private `step()` function, which does stop on tag closers.

This patch is one in a series of changes to expand support within the HTML API, moving gradually to allow for more focused changes that are easier to review and test. The HTML Processor is a work in progress with a certain set of features slated to be ready and tested by 6.4.0, but it will only contain partial support of the HTML5 specification even after that. Whenever it cannot positively recognize and process its input it bails, and certain function stubs and logical stubs exist to structure future expansions of support.