### PR TITLE
Add a check for wp_get_current_user to current_user_can

### DIFF
--- a/src/wp-includes/capabilities.php
+++ b/src/wp-includes/capabilities.php
@@ -874,6 +874,9 @@ function map_meta_cap( $cap, $user_id, ...$args ) {
  *              passed, whether the current user has the given meta capability for the given object.
  */
 function current_user_can( $capability, ...$args ) {
+	if ( ! function_exists( 'wp_get_current_user' ) ) {
+		return false;
+	}
 	return user_can( wp_get_current_user(), $capability, ...$args );
 }
 


### PR DESCRIPTION
This is an attempt to fix https://github.com/WordPress/gutenberg/issues/53284.

The problem is that it's possible to call `current_user_can` before `wp_get_current_user` has been defined. We could guard against this by checking whether `wp_get_current_user` is defined before calling `current_user_can` each time, but adding the check here seems simpler.

I'm not sure if it makes sense to return false in this case, maybe we should return an error instead?

Fixes https://core.trac.wordpress.org/ticket/59000