### PR TITLE
Updating inline documentation for autoload parameter

### DIFF
--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -623,9 +623,9 @@ function update_option( $option, $value, $autoload = null ) {
  *                                Default is enabled. Accepts 'no' to disable for legacy reasons.
  *                                Autoloading too many options can lead to performance problems, especially if the
  *                                options are not frequently used. For options which are accessed across several places
- * 								  in the frontend, it is recommended to autoload them, by using 'yes'|true.
- * 								  For options which are accessed only on few specific URLs, it is recommended
- * 								  to not autoload them, by using 'no'|false.
+ *                                in the frontend, it is recommended to autoload them, by using 'yes'|true.
+ *                                For options which are accessed only on few specific URLs, it is recommended
+ *                                to not autoload them, by using 'no'|false.
  * @return bool True if the option was added, false otherwise.
  */
 function add_option( $option, $value = '', $deprecated = '', $autoload = 'yes' ) {

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -430,11 +430,11 @@ function wp_load_core_site_options( $network_id = null ) {
  *                              `$autoload` can only be updated using `update_option()` if `$value` is also changed.
  *                              Accepts 'yes'|true to enable or 'no'|false to disable. For non-existent options,
  *                              the default value is 'yes'. Default null.
- *                              Autoloading too many options can lead to performance problems, especially if the 
- * 								options are not frequently used. For options which are accessed across several places 
- * 								in the frontend, it is recommended to autoload them, by using 'yes'|true. 
- * 								For options which are accessed only on few specific URLs, it is recommended 
- * 								to not autoload them, by using 'no'|false.
+ *                              Autoloading too many options can lead to performance problems, especially if the
+ *                              options are not frequently used. For options which are accessed across several places
+ *                              in the frontend, it is recommended to autoload them, by using 'yes'|true.
+ *                              For options which are accessed only on few specific URLs, it is recommended
+ *                              to not autoload them, by using 'no'|false.
  * @return bool True if the value was updated, false otherwise.
  */
 function update_option( $option, $value, $autoload = null ) {
@@ -621,10 +621,10 @@ function update_option( $option, $value, $autoload = null ) {
  * @param string      $deprecated Optional. Description. Not used anymore.
  * @param string|bool $autoload   Optional. Whether to load the option when WordPress starts up.
  *                                Default is enabled. Accepts 'no' to disable for legacy reasons.
- *                                Autoloading too many options can lead to performance problems, especially if the 
- * 		   						  options are not frequently used. For options which are accessed across several places 
- * 								  in the frontend, it is recommended to autoload them, by using 'yes'|true. 
- * 								  For options which are accessed only on few specific URLs, it is recommended 
+ *                                Autoloading too many options can lead to performance problems, especially if the
+ *                                options are not frequently used. For options which are accessed across several places
+ * 								  in the frontend, it is recommended to autoload them, by using 'yes'|true.
+ * 								  For options which are accessed only on few specific URLs, it is recommended
  * 								  to not autoload them, by using 'no'|false.
  * @return bool True if the option was added, false otherwise.
  */

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -620,7 +620,7 @@ function update_option( $option, $value, $autoload = null ) {
  *                                Expected to not be SQL-escaped.
  * @param string      $deprecated Optional. Description. Not used anymore.
  * @param string|bool $autoload   Optional. Whether to load the option when WordPress starts up.
- *                                Default is enabled. Accepts 'no' to disable for legacy reasons.
+ *                                Accepts 'yes'|true to enable or 'no'|false to disable. Default 'yes'.
  *                                Autoloading too many options can lead to performance problems, especially if the
  *                                options are not frequently used. For options which are accessed across several places
  *                                in the frontend, it is recommended to autoload them, by using 'yes'|true.

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -428,13 +428,13 @@ function wp_load_core_site_options( $network_id = null ) {
  * @param mixed       $value    Option value. Must be serializable if non-scalar. Expected to not be SQL-escaped.
  * @param string|bool $autoload Optional. Whether to load the option when WordPress starts up. For existing options,
  *                              `$autoload` can only be updated using `update_option()` if `$value` is also changed.
- *                              Accepts 'yes'|true to enable or 'no'|false to disable. For non-existent options,
- *                              the default value is 'yes'. Default null.
+ *                              Accepts 'yes'|true to enable or 'no'|false to disable.
  *                              Autoloading too many options can lead to performance problems, especially if the
  *                              options are not frequently used. For options which are accessed across several places
  *                              in the frontend, it is recommended to autoload them, by using 'yes'|true.
  *                              For options which are accessed only on few specific URLs, it is recommended
- *                              to not autoload them, by using 'no'|false.
+ *                              to not autoload them, by using 'no'|false. For non-existent options, the default value is
+ *                              'yes'. Default null.
  * @return bool True if the value was updated, false otherwise.
  */
 function update_option( $option, $value, $autoload = null ) {
@@ -620,12 +620,12 @@ function update_option( $option, $value, $autoload = null ) {
  *                                Expected to not be SQL-escaped.
  * @param string      $deprecated Optional. Description. Not used anymore.
  * @param string|bool $autoload   Optional. Whether to load the option when WordPress starts up.
- *                                Accepts 'yes'|true to enable or 'no'|false to disable. Default 'yes'.
+ *                                Accepts 'yes'|true to enable or 'no'|false to disable.
  *                                Autoloading too many options can lead to performance problems, especially if the
  *                                options are not frequently used. For options which are accessed across several places
  *                                in the frontend, it is recommended to autoload them, by using 'yes'|true.
  *                                For options which are accessed only on few specific URLs, it is recommended
- *                                to not autoload them, by using 'no'|false.
+ *                                to not autoload them, by using 'no'|false. Default 'yes'.
  * @return bool True if the option was added, false otherwise.
  */
 function add_option( $option, $value = '', $deprecated = '', $autoload = 'yes' ) {

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -430,6 +430,13 @@ function wp_load_core_site_options( $network_id = null ) {
  *                              `$autoload` can only be updated using `update_option()` if `$value` is also changed.
  *                              Accepts 'yes'|true to enable or 'no'|false to disable. For non-existent options,
  *                              the default value is 'yes'. Default null.
+ *                              When an option is autoloaded, it means it will be automatically retrieved
+ *                              from the database and cached in memory on every page load. Autoloading
+ *                              too many options can lead to performance problems, especially if the options
+ *                              are not frequently used.
+ *                              Use 'no'|false for options that are rarely used or when the value is large,
+ *                              and set it to 'yes'|true only for options that need to be accessed
+ *                              regularly and quickly.
  * @return bool True if the value was updated, false otherwise.
  */
 function update_option( $option, $value, $autoload = null ) {
@@ -614,8 +621,17 @@ function update_option( $option, $value, $autoload = null ) {
  * @param mixed       $value      Optional. Option value. Must be serializable if non-scalar.
  *                                Expected to not be SQL-escaped.
  * @param string      $deprecated Optional. Description. Not used anymore.
- * @param string|bool $autoload   Optional. Whether to load the option when WordPress starts up.
- *                                Default is enabled. Accepts 'no' to disable for legacy reasons.
+ * @param string|bool $autoload Optional. Whether to load the option when WordPress starts up. For existing options,
+ *                              `$autoload` can only be updated using `update_option()` if `$value` is also changed.
+ *                              Accepts 'yes'|true to enable or 'no'|false to disable. For non-existent options,
+ *                              the default value is 'yes'. Default null.
+ *                              When an option is autoloaded, it means it will be automatically retrieved
+ *                              from the database and cached in memory on every page load. Autoloading
+ *                              too many options can lead to performance problems, especially if the options
+ *                              are not frequently used.
+ *                              Use 'no'|false for options that are rarely used or when the value is large,
+ *                              and set it to 'yes'|true only for options that need to be accessed
+ *                              regularly and quickly.
  * @return bool True if the option was added, false otherwise.
  */
 function add_option( $option, $value = '', $deprecated = '', $autoload = 'yes' ) {

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -430,13 +430,11 @@ function wp_load_core_site_options( $network_id = null ) {
  *                              `$autoload` can only be updated using `update_option()` if `$value` is also changed.
  *                              Accepts 'yes'|true to enable or 'no'|false to disable. For non-existent options,
  *                              the default value is 'yes'. Default null.
- *                              When an option is autoloaded, it means it will be automatically retrieved
- *                              from the database and cached in memory on every page load. Autoloading
- *                              too many options can lead to performance problems, especially if the options
- *                              are not frequently used.
- *                              Use 'no'|false for options that are rarely used or when the value is large,
- *                              and set it to 'yes'|true only for options that need to be accessed
- *                              regularly and quickly.
+ *                              Autoloading too many options can lead to performance problems, especially if the 
+ * 								options are not frequently used. For options which are accessed across several places 
+ * 								in the frontend, it is recommended to autoload them, by using 'yes'|true. 
+ * 								For options which are accessed only on few specific URLs, it is recommended 
+ * 								to not autoload them, by using 'no'|false.
  * @return bool True if the value was updated, false otherwise.
  */
 function update_option( $option, $value, $autoload = null ) {
@@ -621,17 +619,13 @@ function update_option( $option, $value, $autoload = null ) {
  * @param mixed       $value      Optional. Option value. Must be serializable if non-scalar.
  *                                Expected to not be SQL-escaped.
  * @param string      $deprecated Optional. Description. Not used anymore.
- * @param string|bool $autoload Optional. Whether to load the option when WordPress starts up. For existing options,
- *                              `$autoload` can only be updated using `update_option()` if `$value` is also changed.
- *                              Accepts 'yes'|true to enable or 'no'|false to disable. For non-existent options,
- *                              the default value is 'yes'. Default null.
- *                              When an option is autoloaded, it means it will be automatically retrieved
- *                              from the database and cached in memory on every page load. Autoloading
- *                              too many options can lead to performance problems, especially if the options
- *                              are not frequently used.
- *                              Use 'no'|false for options that are rarely used or when the value is large,
- *                              and set it to 'yes'|true only for options that need to be accessed
- *                              regularly and quickly.
+ * @param string|bool $autoload   Optional. Whether to load the option when WordPress starts up.
+ *                                Default is enabled. Accepts 'no' to disable for legacy reasons.
+ *                                Autoloading too many options can lead to performance problems, especially if the 
+ * 		   						  options are not frequently used. For options which are accessed across several places 
+ * 								  in the frontend, it is recommended to autoload them, by using 'yes'|true. 
+ * 								  For options which are accessed only on few specific URLs, it is recommended 
+ * 								  to not autoload them, by using 'no'|false.
  * @return bool True if the option was added, false otherwise.
  */
 function add_option( $option, $value = '', $deprecated = '', $autoload = 'yes' ) {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Improving inline doc for the add_option(), and update_option()

Trac ticket: https://core.trac.wordpress.org/ticket/58963

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
