### PR TITLE
#58832 - Bump default theme versions for WordPress 6.4

### DIFF
--- a/src/wp-content/themes/twentyeleven/readme.txt
+++ b/src/wp-content/themes/twentyeleven/readme.txt
@@ -1,7 +1,7 @@
 === Twenty Eleven ===
 Contributors: wordpressdotorg
 Requires at least: 3.2
-Tested up to: 6.3
+Tested up to: 6.4
 Requires PHP: 5.2.4
 Stable tag: 4.4
 License: GPLv2 or later

--- a/src/wp-content/themes/twentyeleven/style.css
+++ b/src/wp-content/themes/twentyeleven/style.css
@@ -6,7 +6,7 @@ Author URI: https://wordpress.org/
 Description: The 2011 theme for WordPress is sophisticated, lightweight, and adaptable. Make it yours with a custom menu, header image, and background -- then go further with available theme options for light or dark color scheme, custom link colors, and three layout choices. Twenty Eleven comes equipped with a Showcase page template that transforms your front page into a showcase to show off your best content, widget support galore (sidebar, three footer areas, and a Showcase page widget area), and a custom "Ephemera" widget to display your Aside, Link, Quote, or Status posts. Included are styles for print and for the admin editor, support for featured images (as custom header images on posts and pages and as large images on featured "sticky" posts), and special styles for six different post formats.
 Version: 4.4
 Requires at least: 3.2
-Tested up to: 6.3
+Tested up to: 6.4
 Requires PHP: 5.2.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/src/wp-content/themes/twentyfifteen/readme.txt
+++ b/src/wp-content/themes/twentyfifteen/readme.txt
@@ -1,7 +1,7 @@
 === Twenty Fifteen ===
 Contributors: wordpressdotorg
 Requires at least: 4.1
-Tested up to: 6.3
+Tested up to: 6.4
 Requires PHP: 5.2.4
 Version: 3.5
 License: GPLv2 or later

--- a/src/wp-content/themes/twentyfifteen/style.css
+++ b/src/wp-content/themes/twentyfifteen/style.css
@@ -6,7 +6,7 @@ Author URI: https://wordpress.org/
 Description: Our 2015 default theme is clean, blog-focused, and designed for clarity. Twenty Fifteen's simple, straightforward typography is readable on a wide variety of screen sizes, and suitable for multiple languages. We designed it using a mobile-first approach, meaning your content takes center-stage, regardless of whether your visitors arrive by smartphone, tablet, laptop, or desktop computer.
 Version: 3.5
 Requires at least: 4.1
-Tested up to: 6.3
+Tested up to: 6.4
 Requires PHP: 5.2.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/src/wp-content/themes/twentyfourteen/readme.txt
+++ b/src/wp-content/themes/twentyfourteen/readme.txt
@@ -1,7 +1,7 @@
 === Twenty Fourteen ===
 Contributors: wordpressdotorg
 Requires at least: 3.6
-Tested up to: 6.3
+Tested up to: 6.4
 Requires PHP: 5.2.4
 Stable tag: 3.7
 License: GPLv2 or later

--- a/src/wp-content/themes/twentyfourteen/style.css
+++ b/src/wp-content/themes/twentyfourteen/style.css
@@ -6,7 +6,7 @@ Author URI: https://wordpress.org/
 Description: In 2014, our default theme lets you create a responsive magazine website with a sleek, modern design. Feature your favorite homepage content in either a grid or a slider. Use the three widget areas to customize your website, and change your content's layout with a full-width page template and a contributor page to show off your authors. Creating a magazine website with WordPress has never been easier.
 Version: 3.7
 Requires at least: 3.6
-Tested up to: 6.3
+Tested up to: 6.4
 Requires PHP: 5.2.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/src/wp-content/themes/twentynineteen/readme.txt
+++ b/src/wp-content/themes/twentynineteen/readme.txt
@@ -2,7 +2,7 @@
 Contributors: wordpressdotorg
 Tags: one-column, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, block-patterns
 Requires at least: 4.9.6
-Tested up to: 6.3
+Tested up to: 6.4
 Requires PHP: 5.2.4
 Stable tag: 2.6
 License: GPLv2 or later

--- a/src/wp-content/themes/twentynineteen/style-rtl.css
+++ b/src/wp-content/themes/twentynineteen/style-rtl.css
@@ -5,7 +5,7 @@ Theme URI: https://wordpress.org/themes/twentynineteen/
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Our 2019 default theme is designed to show off the power of the block editor. It features custom styles for all the default blocks, and is built so that what you see in the editor looks like what you'll see on your website. Twenty Nineteen is designed to be adaptable to a wide range of websites, whether you’re running a photo blog, launching a new business, or supporting a non-profit. Featuring ample whitespace and modern sans-serif headlines paired with classic serif body text, it's built to be beautiful on all screen sizes.
-Tested up to: 6.3
+Tested up to: 6.4
 Requires at least: 4.9.6
 Requires PHP: 5.2.4
 Version: 2.6

--- a/src/wp-content/themes/twentynineteen/style.css
+++ b/src/wp-content/themes/twentynineteen/style.css
@@ -5,7 +5,7 @@ Theme URI: https://wordpress.org/themes/twentynineteen/
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Our 2019 default theme is designed to show off the power of the block editor. It features custom styles for all the default blocks, and is built so that what you see in the editor looks like what you'll see on your website. Twenty Nineteen is designed to be adaptable to a wide range of websites, whether you’re running a photo blog, launching a new business, or supporting a non-profit. Featuring ample whitespace and modern sans-serif headlines paired with classic serif body text, it's built to be beautiful on all screen sizes.
-Tested up to: 6.3
+Tested up to: 6.4
 Requires at least: 4.9.6
 Requires PHP: 5.2.4
 Version: 2.6

--- a/src/wp-content/themes/twentynineteen/style.scss
+++ b/src/wp-content/themes/twentynineteen/style.scss
@@ -4,7 +4,7 @@ Theme URI: https://wordpress.org/themes/twentynineteen/
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Our 2019 default theme is designed to show off the power of the block editor. It features custom styles for all the default blocks, and is built so that what you see in the editor looks like what you'll see on your website. Twenty Nineteen is designed to be adaptable to a wide range of websites, whether you’re running a photo blog, launching a new business, or supporting a non-profit. Featuring ample whitespace and modern sans-serif headlines paired with classic serif body text, it's built to be beautiful on all screen sizes.
-Tested up to: 6.3
+Tested up to: 6.4
 Requires at least: 4.9.6
 Requires PHP: 5.2.4
 Version: 2.6

--- a/src/wp-content/themes/twentyseventeen/readme.txt
+++ b/src/wp-content/themes/twentyseventeen/readme.txt
@@ -1,7 +1,7 @@
 === Twenty Seventeen ===
 Contributors: wordpressdotorg
 Requires at least: 4.7
-Tested up to: 6.3
+Tested up to: 6.4
 Requires PHP: 5.2.4
 Version: 3.3
 License: GPLv2 or later

--- a/src/wp-content/themes/twentyseventeen/style.css
+++ b/src/wp-content/themes/twentyseventeen/style.css
@@ -5,7 +5,7 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Twenty Seventeen brings your site to life with header video and immersive featured images. With a focus on business sites, it features multiple sections on the front page as well as widgets, navigation and social menus, a logo, and more. Personalize its asymmetrical grid with a custom color scheme and showcase your multimedia content with post formats. Our default theme for 2017 works great in many languages, for any abilities, and on any device.
 Version: 3.3
-Tested up to: 6.3
+Tested up to: 6.4
 Requires at least: 4.7
 Requires PHP: 5.2.4
 License: GNU General Public License v2 or later

--- a/src/wp-content/themes/twentysixteen/readme.txt
+++ b/src/wp-content/themes/twentysixteen/readme.txt
@@ -1,7 +1,7 @@
 === Twenty Sixteen ===
 Contributors: wordpressdotorg
 Requires at least: 4.4
-Tested up to: 6.3
+Tested up to: 6.4
 Requires PHP: 5.2.4
 Version: 3.0
 License: GPLv2 or later

--- a/src/wp-content/themes/twentysixteen/style.css
+++ b/src/wp-content/themes/twentysixteen/style.css
@@ -5,7 +5,7 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Twenty Sixteen is a modernized take on an ever-popular WordPress layout — the horizontal masthead with an optional right sidebar that works perfectly for blogs and websites. It has custom color options with beautiful default color schemes, a harmonious fluid grid using a mobile-first approach, and impeccable polish in every detail. Twenty Sixteen will make your WordPress look beautiful everywhere.
 Version: 3.0
-Tested up to: 6.3
+Tested up to: 6.4
 Requires at least: 4.4
 Requires PHP: 5.2.4
 License: GNU General Public License v2 or later

--- a/src/wp-content/themes/twentyten/readme.txt
+++ b/src/wp-content/themes/twentyten/readme.txt
@@ -1,7 +1,7 @@
 === Twenty Ten ===
 Contributors: wordpressdotorg
 Requires at least: 3.0
-Tested up to: 6.3
+Tested up to: 6.4
 Requires PHP: 5.2.4
 Stable tag: 3.9
 License: GPLv2 or later

--- a/src/wp-content/themes/twentyten/style.css
+++ b/src/wp-content/themes/twentyten/style.css
@@ -5,7 +5,7 @@ Description: The 2010 theme for WordPress is stylish, customizable, simple, and 
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Version: 3.9
-Tested up to: 6.3
+Tested up to: 6.4
 Requires at least: 3.0
 Requires PHP: 5.2.4
 License: GNU General Public License v2 or later

--- a/src/wp-content/themes/twentythirteen/readme.txt
+++ b/src/wp-content/themes/twentythirteen/readme.txt
@@ -1,7 +1,7 @@
 === Twenty Thirteen ===
 Contributors: wordpressdotorg
 Requires at least: 3.6
-Tested up to: 6.3
+Tested up to: 6.4
 Requires PHP: 5.2.4
 Stable tag: 3.9
 License: GPLv2 or later

--- a/src/wp-content/themes/twentythirteen/style.css
+++ b/src/wp-content/themes/twentythirteen/style.css
@@ -5,7 +5,7 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: The 2013 theme for WordPress takes us back to the blog, featuring a full range of post formats, each displayed beautifully in their own unique way. Design details abound, starting with a vibrant color scheme and matching header images, beautiful typography and icons, and a flexible layout that looks great on any device, big or small.
 Version: 3.9
-Tested up to: 6.3
+Tested up to: 6.4
 Requires at least: 3.6
 Requires PHP: 5.2.4
 License: GNU General Public License v2 or later

--- a/src/wp-content/themes/twentytwelve/readme.txt
+++ b/src/wp-content/themes/twentytwelve/readme.txt
@@ -1,7 +1,7 @@
 === Twenty Twelve ===
 Contributors: wordpressdotorg
 Requires at least: 3.5
-Tested up to: 6.3
+Tested up to: 6.4
 Requires PHP: 5.2.4
 Stable tag: 4.0
 License: GPLv2 or later

--- a/src/wp-content/themes/twentytwelve/style.css
+++ b/src/wp-content/themes/twentytwelve/style.css
@@ -5,7 +5,7 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: The 2012 theme for WordPress is a fully responsive theme that looks great on any device. Features include a front page template with its own widgets, an optional display font, styling for post formats on both index and single views, and an optional no-sidebar page template. Make it yours with a custom menu, header image, and background.
 Version: 4.0
-Tested up to: 6.3
+Tested up to: 6.4
 Requires at least: 3.5
 Requires PHP: 5.2.4
 License: GNU General Public License v2 or later

--- a/src/wp-content/themes/twentytwenty/readme.txt
+++ b/src/wp-content/themes/twentytwenty/readme.txt
@@ -1,7 +1,7 @@
 === Twenty Twenty ===
 Contributors: the WordPress team
 Requires at least: 4.7
-Tested up to: 6.3
+Tested up to: 6.4
 Requires PHP: 5.2.4
 Stable tag: 2.3
 License: GPLv2 or later

--- a/src/wp-content/themes/twentytwenty/style-rtl.css
+++ b/src/wp-content/themes/twentytwenty/style-rtl.css
@@ -2,7 +2,7 @@
 Theme Name: Twenty Twenty
 Text Domain: twentytwenty
 Version: 2.3
-Tested up to: 6.3
+Tested up to: 6.4
 Requires at least: 4.7
 Requires PHP: 5.2.4
 Description: Our default theme for 2020 is designed to take full advantage of the flexibility of the block editor. Organizations and businesses have the ability to create dynamic landing pages with endless layouts using the group and column blocks. The centered content column and fine-tuned typography also makes it perfect for traditional blogs. Complete editor styles give you a good idea of what your content will look like, even before you publish. You can give your site a personal touch by changing the background colors and the accent color in the Customizer. The colors of all elements on your site are automatically calculated based on the colors you pick, ensuring a high, accessible color contrast for your visitors.

--- a/src/wp-content/themes/twentytwenty/style.css
+++ b/src/wp-content/themes/twentytwenty/style.css
@@ -2,7 +2,7 @@
 Theme Name: Twenty Twenty
 Text Domain: twentytwenty
 Version: 2.3
-Tested up to: 6.3
+Tested up to: 6.4
 Requires at least: 4.7
 Requires PHP: 5.2.4
 Description: Our default theme for 2020 is designed to take full advantage of the flexibility of the block editor. Organizations and businesses have the ability to create dynamic landing pages with endless layouts using the group and column blocks. The centered content column and fine-tuned typography also makes it perfect for traditional blogs. Complete editor styles give you a good idea of what your content will look like, even before you publish. You can give your site a personal touch by changing the background colors and the accent color in the Customizer. The colors of all elements on your site are automatically calculated based on the colors you pick, ensuring a high, accessible color contrast for your visitors.

--- a/src/wp-content/themes/twentytwentyone/readme.txt
+++ b/src/wp-content/themes/twentytwentyone/readme.txt
@@ -1,7 +1,7 @@
 === Twenty Twenty-One ===
 Contributors: wordpressdotorg
 Requires at least: 5.3
-Tested up to: 6.3
+Tested up to: 6.4
 Requires PHP: 5.6
 Stable tag: 1.9
 License: GPLv2 or later

--- a/src/wp-content/themes/twentytwentyone/style-rtl.css
+++ b/src/wp-content/themes/twentytwentyone/style-rtl.css
@@ -7,7 +7,7 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Twenty Twenty-One is a blank canvas for your ideas and it makes the block editor your best brush. With new block patterns, which allow you to create a beautiful layout in a matter of seconds, this theme’s soft colors and eye-catching — yet timeless — design will let your work shine. Take it for a spin! See how Twenty Twenty-One elevates your portfolio, business website, or personal blog.
 Requires at least: 5.3
-Tested up to: 6.3
+Tested up to: 6.4
 Requires PHP: 5.6
 Version: 1.9
 License: GNU General Public License v2 or later

--- a/src/wp-content/themes/twentytwentyone/style.css
+++ b/src/wp-content/themes/twentytwentyone/style.css
@@ -7,7 +7,7 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Twenty Twenty-One is a blank canvas for your ideas and it makes the block editor your best brush. With new block patterns, which allow you to create a beautiful layout in a matter of seconds, this theme’s soft colors and eye-catching — yet timeless — design will let your work shine. Take it for a spin! See how Twenty Twenty-One elevates your portfolio, business website, or personal blog.
 Requires at least: 5.3
-Tested up to: 6.3
+Tested up to: 6.4
 Requires PHP: 5.6
 Version: 1.9
 License: GNU General Public License v2 or later

--- a/src/wp-content/themes/twentytwentythree/readme.txt
+++ b/src/wp-content/themes/twentytwentythree/readme.txt
@@ -1,7 +1,7 @@
 === Twenty Twenty-Three ===
 Contributors: wordpressdotorg
 Requires at least: 6.1
-Tested up to: 6.3
+Tested up to: 6.4
 Requires PHP: 5.6
 Stable tag: 1.2
 License: GPLv2 or later

--- a/src/wp-content/themes/twentytwentythree/style.css
+++ b/src/wp-content/themes/twentytwentythree/style.css
@@ -5,7 +5,7 @@ Author: the WordPress team
 Author URI: https://wordpress.org
 Description: Twenty Twenty-Three is designed to take advantage of the new design tools introduced in WordPress 6.1. With a clean, blank base as a starting point, this default theme includes ten diverse style variations created by members of the WordPress community. Whether you want to build a complex or incredibly simple website, you can do it quickly and intuitively through the bundled styles or dive into creation and full customization yourself.
 Requires at least: 6.1
-Tested up to: 6.3
+Tested up to: 6.4
 Requires PHP: 5.6
 Version: 1.2
 License: GNU General Public License v2 or later

--- a/src/wp-content/themes/twentytwentytwo/readme.txt
+++ b/src/wp-content/themes/twentytwentytwo/readme.txt
@@ -1,7 +1,7 @@
 === Twenty Twenty-Two ===
 Contributors: wordpressdotorg
 Requires at least: 5.9
-Tested up to: 6.3
+Tested up to: 6.4
 Requires PHP: 5.6
 Stable tag: 1.5
 License: GPLv2 or later

--- a/src/wp-content/themes/twentytwentytwo/style.css
+++ b/src/wp-content/themes/twentytwentytwo/style.css
@@ -5,7 +5,7 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Built on a solidly designed foundation, Twenty Twenty-Two embraces the idea that everyone deserves a truly unique website. The theme’s subtle styles are inspired by the diversity and versatility of birds: its typography is lightweight yet strong, its color palette is drawn from nature, and its layout elements sit gently on the page. The true richness of Twenty Twenty-Two lies in its opportunity for customization. The theme is built to take advantage of the Site Editor features introduced in WordPress 5.9, which means that colors, typography, and the layout of every single page on your site can be customized to suit your vision. It also includes dozens of block patterns, opening the door to a wide range of professionally designed layouts in just a few clicks. Whether you’re building a single-page website, a blog, a business website, or a portfolio, Twenty Twenty-Two will help you create a site that is uniquely yours.
 Requires at least: 5.9
-Tested up to: 6.3
+Tested up to: 6.4
 Requires PHP: 5.6
 Version: 1.5
 License: GNU General Public License v2 or later


### PR DESCRIPTION
Bump default theme versions for WordPress 6.4

Trac ticket: [#58832](https://core.trac.wordpress.org/ticket/58832)
