### PR TITLE
[Obsolete] Trac 58978: Suppress console errors from sessionStorage usage in sandboxed post embed iframe

### DIFF
--- a/src/js/_enqueues/lib/emoji-loader.js
+++ b/src/js/_enqueues/lib/emoji-loader.js
@@ -73,11 +73,11 @@
 	 * @returns {?SupportTests} Support tests, or null if not set or older than 1 week.
 	 */
 	function getSessionSupportTests() {
-		if (
-			typeof sessionStorage !== 'undefined' &&
-			sessionStorageKey in sessionStorage
-		) {
-			try {
+		try {
+			if (
+				typeof sessionStorage !== 'undefined' &&
+				sessionStorageKey in sessionStorage
+			) {
 				/** @type {SessionSupportTests} */
 				var item = JSON.parse(
 					sessionStorage.getItem( sessionStorageKey )
@@ -90,8 +90,8 @@
 				) {
 					return item.supportTests;
 				}
-			} catch ( e ) {}
-		}
+			}
+		} catch ( e ) {}
 		return null;
 	}
 
@@ -105,8 +105,8 @@
 	 * @param {SupportTests} supportTests Support tests.
 	 */
 	function setSessionSupportTests( supportTests ) {
-		if ( typeof sessionStorage !== 'undefined' ) {
-			try {
+		try {
+			if ( typeof sessionStorage !== 'undefined' ) {
 				/** @type {SessionSupportTests} */
 				var item = {
 					supportTests: supportTests,
@@ -117,8 +117,8 @@
 					sessionStorageKey,
 					JSON.stringify( item )
 				);
-			} catch ( e ) {}
-		}
+			}
+		} catch ( e ) {}
 	}
 
 	/**


### PR DESCRIPTION
This simply moves the try/catch blocks from inside the `if` statements that reference `sessionStorage` to instead wrap these `if` statements.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/58978

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
