### PR TITLE
Trac 58978: Suppress console errors from sessionStorage usage in sandboxed post embed iframe

### DIFF
--- a/src/js/_enqueues/lib/emoji-loader.js
+++ b/src/js/_enqueues/lib/emoji-loader.js
@@ -74,22 +74,17 @@
 	 */
 	function getSessionSupportTests() {
 		try {
+			/** @type {SessionSupportTests} */
+			var item = JSON.parse(
+				sessionStorage.getItem( sessionStorageKey )
+			);
 			if (
-				typeof sessionStorage !== 'undefined' &&
-				sessionStorageKey in sessionStorage
+				typeof item === 'object' &&
+				typeof item.timestamp === 'number' &&
+				new Date().valueOf() < item.timestamp + 604800 && // Note: Number is a week in seconds.
+				typeof item.supportTests === 'object'
 			) {
-				/** @type {SessionSupportTests} */
-				var item = JSON.parse(
-					sessionStorage.getItem( sessionStorageKey )
-				);
-				if (
-					typeof item === 'object' &&
-					typeof item.timestamp === 'number' &&
-					new Date().valueOf() < item.timestamp + 604800 && // Note: Number is a week in seconds.
-					typeof item.supportTests === 'object'
-				) {
-					return item.supportTests;
-				}
+				return item.supportTests;
 			}
 		} catch ( e ) {}
 		return null;
@@ -106,18 +101,16 @@
 	 */
 	function setSessionSupportTests( supportTests ) {
 		try {
-			if ( typeof sessionStorage !== 'undefined' ) {
-				/** @type {SessionSupportTests} */
-				var item = {
-					supportTests: supportTests,
-					timestamp: new Date().valueOf()
-				};
+			/** @type {SessionSupportTests} */
+			var item = {
+				supportTests: supportTests,
+				timestamp: new Date().valueOf()
+			};
 
-				sessionStorage.setItem(
-					sessionStorageKey,
-					JSON.stringify( item )
-				);
-			}
+			sessionStorage.setItem(
+				sessionStorageKey,
+				JSON.stringify( item )
+			);
 		} catch ( e ) {}
 	}
 

--- a/src/js/_enqueues/lib/emoji-loader.js
+++ b/src/js/_enqueues/lib/emoji-loader.js
@@ -73,11 +73,11 @@
 	 * @returns {?SupportTests} Support tests, or null if not set or older than 1 week.
 	 */
 	function getSessionSupportTests() {
-		if (
-			typeof sessionStorage !== 'undefined' &&
-			sessionStorageKey in sessionStorage
-		) {
-			try {
+		try {
+			if (
+				typeof sessionStorage !== 'undefined' &&
+				sessionStorageKey in sessionStorage
+			) {
 				/** @type {SessionSupportTests} */
 				var item = JSON.parse(
 					sessionStorage.getItem( sessionStorageKey )
@@ -90,8 +90,8 @@
 				) {
 					return item.supportTests;
 				}
-			} catch ( e ) {}
-		}
+			}
+		} catch ( e ) {}
 		return null;
 	}
 
@@ -105,8 +105,8 @@
 	 * @param {SupportTests} supportTests Support tests.
 	 */
 	function setSessionSupportTests( supportTests ) {
-		if ( typeof sessionStorage !== 'undefined' ) {
-			try {
+		try {
+			if ( typeof sessionStorage !== 'undefined' ) {
 				/** @type {SessionSupportTests} */
 				var item = {
 					supportTests: supportTests,
@@ -117,8 +117,8 @@
 					sessionStorageKey,
 					JSON.stringify( item )
 				);
-			} catch ( e ) {}
-		}
+			}
+		} catch ( e ) {}
 	}
 
 	/**


### PR DESCRIPTION
This removes the `if` statements which were attempting to prevent errors related to interacting with `sessionStorage`. It turns out that merely referencing the `sessionStorage` object will cause an error, although the error does not cause an interruption in execution (in Chrome at least).

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/58978

Commit message:

```
Emoji: Suppress console errors from sessionStorage usage in sandboxed post embed iframe.

Amends [56074].

Props westonruter, flixos90.
Fixes #58978.
See #58472.
```

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
