### PR TITLE
Tests: use assertCount where applicable

### DIFF
--- a/tests/phpunit/tests/blocks/getBlockTemplates.php
+++ b/tests/phpunit/tests/blocks/getBlockTemplates.php
@@ -161,7 +161,7 @@ class Tests_Blocks_GetBlockTemplates extends WP_UnitTestCase {
 		$this->assertNotEmpty( $block_templates, 'get_block_templates() must return a non-empty value.' );
 
 		$block_template_ids = wp_list_pluck( $block_templates, 'id' );
-		$this->assertSame( count( array_unique( $block_template_ids ) ), count( $block_template_ids ), $error_message );
+		$this->assertCount( count( array_unique( $block_template_ids ) ), $block_template_ids, $error_message );
 	}
 
 	/**

--- a/tests/phpunit/tests/customize/widgets.php
+++ b/tests/phpunit/tests/customize/widgets.php
@@ -236,7 +236,7 @@ class Tests_WP_Customize_Widgets extends WP_UnitTestCase {
 
 		$selective_refreshable_widgets = $this->manager->widgets->get_selective_refreshable_widgets();
 		$this->assertIsArray( $selective_refreshable_widgets );
-		$this->assertSame( count( $wp_widget_factory->widgets ), count( $selective_refreshable_widgets ) );
+		$this->assertCount( count( $wp_widget_factory->widgets ), $selective_refreshable_widgets );
 		$this->assertArrayHasKey( 'text', $selective_refreshable_widgets );
 		$this->assertTrue( $selective_refreshable_widgets['text'] );
 		$this->assertArrayHasKey( 'search', $selective_refreshable_widgets );

--- a/tests/phpunit/tests/date/query.php
+++ b/tests/phpunit/tests/date/query.php
@@ -1186,7 +1186,7 @@ class Tests_Date_Query extends WP_UnitTestCase {
 
 		$parts = mb_split( '\)\s+AND\s+\(', $sql );
 		$this->assertIsArray( $parts, 'SQL query cannot be split into multiple parts using operator AND.' );
-		$this->assertSame( 2, count( $parts ), 'SQL query does not contain correct number of AND operators.' );
+		$this->assertCount( 2, $parts, 'SQL query does not contain correct number of AND operators.' );
 
 		$this->assertStringNotContainsString( 'OR', $sql, 'SQL query contains conditions joined by operator OR.' );
 	}
@@ -1233,7 +1233,7 @@ class Tests_Date_Query extends WP_UnitTestCase {
 
 		$parts = mb_split( '\)\s+OR\s+\(', $sql );
 		$this->assertIsArray( $parts, 'SQL query cannot be split into multiple parts using operator OR.' );
-		$this->assertSame( 2, count( $parts ), 'SQL query does not contain correct number of OR operators.' );
+		$this->assertCount( 2, $parts, 'SQL query does not contain correct number of OR operators.' );
 
 		// Checking number of occurrences of AND while skipping the one at the beginning.
 		$this->assertSame( 2, substr_count( substr( $sql, 5 ), 'AND' ), 'SQL query does not contain expected number conditions joined by operator AND.' );
@@ -1279,7 +1279,7 @@ class Tests_Date_Query extends WP_UnitTestCase {
 
 		$parts = mb_split( '\)\s+AND\s+\(', $sql );
 		$this->assertIsArray( $parts, 'SQL query cannot be split into multiple parts using operator AND.' );
-		$this->assertSame( 2, count( $parts ), 'SQL query does not contain correct number of AND operators.' );
+		$this->assertCount( 2, $parts, 'SQL query does not contain correct number of AND operators.' );
 
 		$this->assertStringNotContainsString( 'OR', $sql, 'SQL query contains conditions joined by operator OR.' );
 	}

--- a/tests/phpunit/tests/feed/rss2.php
+++ b/tests/phpunit/tests/feed/rss2.php
@@ -247,7 +247,7 @@ class Tests_Feed_RSS2 extends WP_UnitTestCase {
 			}
 			$cats = array_filter( $cats );
 			// Should be the same number of categories.
-			$this->assertSame( count( $cats ), count( $categories ) );
+			$this->assertCount( count( $cats ), $categories );
 
 			// ..with the same names.
 			foreach ( $cats as $id => $cat ) {

--- a/tests/phpunit/tests/meta.php
+++ b/tests/phpunit/tests/meta.php
@@ -151,56 +151,47 @@ class Tests_Meta extends WP_UnitTestCase {
 		$this->assertNotEquals( $this->author->user_login, $u[0]->user_login );
 
 		// Test EXISTS and NOT EXISTS together, no users should be found.
-		$this->assertSame(
-			0,
-			count(
-				get_users(
-					array(
-						'meta_query' => array(
-							array(
-								'key'     => 'meta_key',
-								'compare' => 'NOT EXISTS',
-							),
-							array(
-								'key'     => 'delete_meta_key',
-								'compare' => 'EXISTS',
-							),
+		$this->assertCount(
+			0, get_users(
+				array(
+					'meta_query' => array(
+						array(
+							'key'     => 'meta_key',
+							'compare' => 'NOT EXISTS',
 						),
-					)
+						array(
+							'key'     => 'delete_meta_key',
+							'compare' => 'EXISTS',
+						),
+					),
 				)
 			)
 		);
 
-		$this->assertSame(
-			2,
-			count(
-				get_users(
-					array(
-						'meta_query' => array(
-							array(
-								'key'     => 'non_existing_meta',
-								'compare' => 'NOT EXISTS',
-							),
+		$this->assertCount(
+			2, get_users(
+				array(
+					'meta_query' => array(
+						array(
+							'key'     => 'non_existing_meta',
+							'compare' => 'NOT EXISTS',
 						),
-					)
+					),
 				)
 			)
 		);
 
 		delete_metadata( 'user', $this->author->ID, 'meta_key' );
 
-		$this->assertSame(
-			2,
-			count(
-				get_users(
-					array(
-						'meta_query' => array(
-							array(
-								'key'     => 'meta_key',
-								'compare' => 'NOT EXISTS',
-							),
+		$this->assertCount(
+			2, get_users(
+				array(
+					'meta_query' => array(
+						array(
+							'key'     => 'meta_key',
+							'compare' => 'NOT EXISTS',
 						),
-					)
+					),
 				)
 			)
 		);

--- a/tests/phpunit/tests/post/getPages.php
+++ b/tests/phpunit/tests/post/getPages.php
@@ -274,25 +274,19 @@ class Tests_Post_GetPages extends WP_UnitTestCase {
 		add_post_meta( $posts[1], 'some-meta-key', '' );
 		add_post_meta( $posts[2], 'some-meta-key', '1' );
 
-		$this->assertSame(
-			1,
-			count(
-				get_pages(
-					array(
-						'meta_key'   => 'some-meta-key',
-						'meta_value' => '0',
-					)
+		$this->assertCount(
+			1, get_pages(
+				array(
+					'meta_key'   => 'some-meta-key',
+					'meta_value' => '0',
 				)
 			)
 		);
-		$this->assertSame(
-			1,
-			count(
-				get_pages(
-					array(
-						'meta_key'   => 'some-meta-key',
-						'meta_value' => '1',
-					)
+		$this->assertCount(
+			1, get_pages(
+				array(
+					'meta_key'   => 'some-meta-key',
+					'meta_value' => '1',
 				)
 			)
 		);

--- a/tests/phpunit/tests/rest-api/rest-categories-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-categories-controller.php
@@ -223,7 +223,7 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 			'parent'     => 0,
 		);
 		$categories = get_terms( 'category', $args );
-		$this->assertSame( count( $categories ), count( $data ) );
+		$this->assertCount( count( $categories ), $data );
 	}
 
 	public function test_get_items_parent_zero_arg_string() {
@@ -255,7 +255,7 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 			'parent'     => 0,
 		);
 		$categories = get_terms( 'category', $args );
-		$this->assertSame( count( $categories ), count( $data ) );
+		$this->assertCount( count( $categories ), $data );
 	}
 
 	public function test_get_items_by_parent_non_found() {
@@ -1189,7 +1189,7 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 			'hide_empty' => false,
 		);
 		$categories = get_terms( 'category', $args );
-		$this->assertSame( count( $categories ), count( $data ) );
+		$this->assertCount( count( $categories ), $data );
 		$this->assertSame( $categories[0]->term_id, $data[0]['id'] );
 		$this->assertSame( $categories[0]->name, $data[0]['name'] );
 		$this->assertSame( $categories[0]->slug, $data[0]['slug'] );

--- a/tests/phpunit/tests/rest-api/rest-post-types-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-post-types-controller.php
@@ -36,7 +36,7 @@ class WP_Test_REST_Post_Types_Controller extends WP_Test_REST_Controller_Testcas
 
 		$data       = $response->get_data();
 		$post_types = get_post_types( array( 'show_in_rest' => true ), 'objects' );
-		$this->assertSame( count( $post_types ), count( $data ) );
+		$this->assertCount( count( $post_types ), $data );
 		$this->assertSame( $post_types['post']->name, $data['post']['slug'] );
 		$this->check_post_type_obj( 'view', $post_types['post'], $data['post'], $data['post']['_links'] );
 		$this->assertSame( $post_types['page']->name, $data['page']['slug'] );

--- a/tests/phpunit/tests/rest-api/rest-tags-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-tags-controller.php
@@ -1409,7 +1409,7 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 			'hide_empty' => false,
 		);
 		$tags = get_terms( 'post_tag', $args );
-		$this->assertSame( count( $tags ), count( $data ) );
+		$this->assertCount( count( $tags ), $data );
 		$this->assertSame( $tags[0]->term_id, $data[0]['id'] );
 		$this->assertSame( $tags[0]->name, $data[0]['name'] );
 		$this->assertSame( $tags[0]->slug, $data[0]['slug'] );

--- a/tests/phpunit/tests/rest-api/rest-taxonomies-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-taxonomies-controller.php
@@ -50,7 +50,7 @@ class WP_Test_REST_Taxonomies_Controller extends WP_Test_REST_Controller_Testcas
 		$response   = rest_get_server()->dispatch( $request );
 		$data       = $response->get_data();
 		$taxonomies = $this->get_public_taxonomies( get_taxonomies( '', 'objects' ) );
-		$this->assertSame( count( $taxonomies ), count( $data ) );
+		$this->assertCount( count( $taxonomies ), $data );
 		$this->assertSame( 'Categories', $data['category']['name'] );
 		$this->assertSame( 'category', $data['category']['slug'] );
 		$this->assertTrue( $data['category']['hierarchical'] );
@@ -69,7 +69,7 @@ class WP_Test_REST_Taxonomies_Controller extends WP_Test_REST_Controller_Testcas
 		$taxonomies = get_taxonomies( '', 'objects' );
 		unset( $taxonomies['nav_menu'] ); // Menus are not editable by contributors.
 		$taxonomies = $this->get_public_taxonomies( $taxonomies );
-		$this->assertSame( count( $taxonomies ), count( $data ) );
+		$this->assertCount( count( $taxonomies ), $data );
 		$this->assertSame( 'Categories', $data['category']['name'] );
 		$this->assertSame( 'category', $data['category']['slug'] );
 		$this->assertTrue( $data['category']['hierarchical'] );
@@ -286,7 +286,7 @@ class WP_Test_REST_Taxonomies_Controller extends WP_Test_REST_Controller_Testcas
 		$this->assertSame( 200, $response->get_status() );
 		$data       = $response->get_data();
 		$taxonomies = $this->get_public_taxonomies( get_object_taxonomies( $type, 'objects' ) );
-		$this->assertSame( count( $taxonomies ), count( $data ) );
+		$this->assertCount( count( $taxonomies ), $data );
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/wpRestMenuItemsController.php
+++ b/tests/phpunit/tests/rest-api/wpRestMenuItemsController.php
@@ -743,7 +743,7 @@ class Tests_REST_WpRestMenuItemsController extends WP_Test_REST_Post_Type_Contro
 		$response   = rest_get_server()->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertSame( 18, count( $properties ) );
+		$this->assertCount( 18, $properties );
 		$this->assertArrayHasKey( 'type_label', $properties );
 		$this->assertArrayHasKey( 'attr_title', $properties );
 		$this->assertArrayHasKey( 'classes', $properties );

--- a/tests/phpunit/tests/rest-api/wpRestMenuLocationsController.php
+++ b/tests/phpunit/tests/rest-api/wpRestMenuLocationsController.php
@@ -181,7 +181,7 @@ class Tests_REST_WpRestMenuLocationsController extends WP_Test_REST_Controller_T
 		$response   = rest_get_server()->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertSame( 3, count( $properties ) );
+		$this->assertCount( 3, $properties );
 		$this->assertArrayHasKey( 'name', $properties );
 		$this->assertArrayHasKey( 'description', $properties );
 		$this->assertArrayHasKey( 'menu', $properties );

--- a/tests/phpunit/tests/rest-api/wpRestMenusController.php
+++ b/tests/phpunit/tests/rest-api/wpRestMenusController.php
@@ -338,7 +338,7 @@ class Tests_REST_WpRestMenusController extends WP_Test_REST_Controller_Testcase 
 		$response   = rest_get_server()->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertSame( 7, count( $properties ) );
+		$this->assertCount( 7, $properties );
 		$this->assertArrayHasKey( 'id', $properties );
 		$this->assertArrayHasKey( 'description', $properties );
 		$this->assertArrayHasKey( 'meta', $properties );
@@ -573,7 +573,7 @@ class Tests_REST_WpRestMenusController extends WP_Test_REST_Controller_Testcase 
 			'hide_empty' => false,
 		);
 		$tags = get_terms( self::TAXONOMY, $args );
-		$this->assertSame( count( $tags ), count( $data ) );
+		$this->assertCount( count( $tags ), $data );
 		$this->assertSame( $tags[0]->term_id, $data[0]['id'] );
 		$this->assertSame( $tags[0]->name, $data[0]['name'] );
 		$this->assertSame( $tags[0]->slug, $data[0]['slug'] );

--- a/tests/phpunit/tests/term/getTerms.php
+++ b/tests/phpunit/tests/term/getTerms.php
@@ -3142,7 +3142,7 @@ class Tests_Term_getTerms extends WP_UnitTestCase {
 		$num_queries_1 = get_num_queries();
 		$query2        = get_terms( $args_2 );
 		$this->assertSame( $num_queries_1, get_num_queries() );
-		$this->assertSame( count( $query1 ), count( $query2 ) );
+		$this->assertCount( count( $query1 ), $query2 );
 	}
 
 	/**

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -2085,15 +2085,12 @@ class Tests_User extends WP_UnitTestCase {
 		$this->assertCount( 12, $actual['data'][0]['data'] );
 
 		// Check that the item added by the filter was retained.
-		$this->assertSame(
-			1,
-			count(
-				wp_list_filter(
-					$actual['data'][0]['data'],
-					array(
-						'name'  => 'Test Additional Data Name',
-						'value' => 'Test Additional Data Value',
-					)
+		$this->assertCount(
+			1, wp_list_filter(
+				$actual['data'][0]['data'],
+				array(
+					'name'  => 'Test Additional Data Name',
+					'value' => 'Test Additional Data Value',
 				)
 			)
 		);
@@ -2117,28 +2114,22 @@ class Tests_User extends WP_UnitTestCase {
 		$this->assertCount( 12, $actual['data'][0]['data'] );
 
 		// Check that the duplicate 'name' => 'User ID' was stripped.
-		$this->assertSame(
-			1,
-			count(
-				wp_list_filter(
-					$actual['data'][0]['data'],
-					array(
-						'name' => 'User ID',
-					)
+		$this->assertCount(
+			1, wp_list_filter(
+				$actual['data'][0]['data'],
+				array(
+					'name' => 'User ID',
 				)
 			)
 		);
 
 		// Check that the item added by the filter was retained.
-		$this->assertSame(
-			1,
-			count(
-				wp_list_filter(
-					$actual['data'][0]['data'],
-					array(
-						'name'  => 'Test Additional Data Name',
-						'value' => 'Test Additional Data Value',
-					)
+		$this->assertCount(
+			1, wp_list_filter(
+				$actual['data'][0]['data'],
+				array(
+					'name'  => 'Test Additional Data Name',
+					'value' => 'Test Additional Data Value',
 				)
 			)
 		);

--- a/tests/phpunit/tests/widgets/wpWidgetMedia.php
+++ b/tests/phpunit/tests/widgets/wpWidgetMedia.php
@@ -76,7 +76,7 @@ class Tests_Widgets_wpWidgetMedia extends WP_UnitTestCase {
 			),
 			array_keys( $widget->l10n )
 		);
-		$this->assertSame( count( $widget->l10n ), count( array_filter( $widget->l10n ) ), 'Expected all translation strings to be defined.' );
+		$this->assertCount( count( $widget->l10n ), array_filter( $widget->l10n ), 'Expected all translation strings to be defined.' );
 		$this->assertSame( 10, has_action( 'admin_print_scripts-widgets.php', array( $widget, 'enqueue_admin_scripts' ) ) );
 		$this->assertFalse( has_action( 'wp_enqueue_scripts', array( $widget, 'enqueue_preview_scripts' ) ), 'Did not expect preview scripts to be enqueued when not in customize preview context.' );
 		$this->assertSame( 10, has_action( 'admin_footer-widgets.php', array( $widget, 'render_control_template_scripts' ) ) );


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/58956

Some of the `assertEquals` and `assertSame` calls that compare array/iterable counts can be replaced with `assertCount` calls to indicate the intent better. I hope I'm not derailing the ticket with this PR, but hopefully you will find it relevant in the same context. 

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
