### PR TITLE
Do not export categories and terms twice

### DIFF
--- a/src/wp-admin/includes/export.php
+++ b/src/wp-admin/includes/export.php
@@ -160,7 +160,7 @@ function export_wp( $args = array() ) {
 		$tags       = (array) get_tags( array( 'get' => 'all' ) );
 
 		$custom_taxonomies = get_taxonomies( array( '_builtin' => false ) );
-		$custom_terms      = (array) get_terms(
+		$custom_terms      = empty( $custom_taxonomies ) ? array() : (array) get_terms(
 			array(
 				'taxonomy' => $custom_taxonomies,
 				'get'      => 'all',


### PR DESCRIPTION
When exporting all content and no custom taxonomies are defined.

Trac ticket: https://core.trac.wordpress.org/ticket/52470

