### PR TITLE
Add `wp_get_theme_data_template_parts`: create public API to access `templateParts` from `theme.json`

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -431,7 +431,7 @@ function _add_block_template_info( $template_item ) {
  */
 function _add_block_template_part_area_info( $template_info ) {
 	if ( wp_theme_has_theme_json() ) {
-		$theme_data = wp_get_theme_template_part_metadata();
+		$theme_data = wp_get_theme_data_template_parts();
 	}
 
 	if ( isset( $theme_data[ $template_info['slug'] ]['area'] ) ) {

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -431,7 +431,7 @@ function _add_block_template_info( $template_item ) {
  */
 function _add_block_template_part_area_info( $template_info ) {
 	if ( wp_theme_has_theme_json() ) {
-		$theme_data = WP_Theme_JSON_Resolver::get_theme_data( array(), array( 'with_supports' => false ) )->get_template_parts();
+		$theme_data = wp_get_theme_template_part_metadata();
 	}
 
 	if ( isset( $theme_data[ $template_info['slug'] ]['area'] ) ) {

--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -425,6 +425,7 @@ function wp_clean_theme_json_cache() {
 	wp_cache_delete( 'wp_get_global_settings_custom', 'theme_json' );
 	wp_cache_delete( 'wp_get_global_settings_theme', 'theme_json' );
 	wp_cache_delete( 'wp_get_global_styles_custom_css', 'theme_json' );
+	wp_cache_delete( 'wp_get_theme_template_part_metada', 'theme_json' );
 	WP_Theme_JSON_Resolver::clean_cached_data();
 }
 

--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -448,7 +448,26 @@ function wp_get_theme_directory_pattern_slugs() {
  * return string[]
  */
 function wp_get_theme_template_part_metadata() {
-	return WP_Theme_JSON_Resolver::get_theme_data( array(), array( 'with_supports' => false ) )->get_template_parts();
+	$cache_group    = 'theme_json';
+	$cache_key      = 'wp_get_theme_template_part_metadata';
+	$can_use_cached = ! wp_is_development_mode( 'theme' );
+
+	$metadata = false;
+	if ( $can_use_cached ) {
+		$metadata = wp_cache_get( $cache_key, $cache_group );
+		if ( false !== $metadata ) {
+			return $metadata;
+		}
+	}
+
+	if ( false === $metadata ) {
+		$metadata = WP_Theme_JSON_Resolver::get_theme_data( array(), array( 'with_supports' => false ) )->get_template_parts();
+		if ( $can_use_cached ) {
+			wp_cache_set( $cache_key, $metadata, $cache_group );
+		}
+	}
+
+	return $metadata;
 }
 
 /**

--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -441,6 +441,17 @@ function wp_get_theme_directory_pattern_slugs() {
 }
 
 /**
+ * Returns the metadata for the template parts defined by the theme.
+ *
+ * @since 6.4.0
+ *
+ * return string[]
+ */
+function wp_get_theme_template_part_metadata() {
+	return WP_Theme_JSON_Resolver::get_theme_data( array(), array( 'with_supports' => false ) )->get_template_parts();
+}
+
+/**
  * Determines the CSS selector for the block type and property provided,
  * returning it if available.
  *

--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -425,7 +425,7 @@ function wp_clean_theme_json_cache() {
 	wp_cache_delete( 'wp_get_global_settings_custom', 'theme_json' );
 	wp_cache_delete( 'wp_get_global_settings_theme', 'theme_json' );
 	wp_cache_delete( 'wp_get_global_styles_custom_css', 'theme_json' );
-	wp_cache_delete( 'wp_get_theme_template_part_metada', 'theme_json' );
+	wp_cache_delete( 'wp_get_theme_data_template_parts', 'theme_json' );
 	WP_Theme_JSON_Resolver::clean_cached_data();
 }
 
@@ -448,9 +448,9 @@ function wp_get_theme_directory_pattern_slugs() {
  *
  * return string[]
  */
-function wp_get_theme_template_part_metadata() {
+function wp_get_theme_data_template_parts() {
 	$cache_group    = 'theme_json';
-	$cache_key      = 'wp_get_theme_template_part_metadata';
+	$cache_key      = 'wp_get_theme_data_template_parts';
 	$can_use_cached = ! wp_is_development_mode( 'theme' );
 
 	$metadata = false;

--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -446,7 +446,7 @@ function wp_get_theme_directory_pattern_slugs() {
  *
  * @since 6.4.0
  *
- * return string[]
+ * return array Associative array of `$part_name => $part_data` pairs, with `$part_data` having "title" and "area" fields.
  */
 function wp_get_theme_data_template_parts() {
 	$cache_group    = 'theme_json';


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/45171
Trac ticket: https://core.trac.wordpress.org/ticket/59003

## What

This PR adds a new public function `wp_get_theme_template_part_metadata` to offer access to metadata stored under `templateParts` in `theme.json`.

## Why

There is a no public function to get access to that data, so consumers need to resort to private APIs. This follows the steps of `wp_get_global_settings`, `wp_theme_has_theme_json`, or `wp_get_theme_directory_pattern_slugs`.

## How

It creates a new function that uses the private calls and substitutes all instances of the old one in the codebase.

## Performance 

**This proves to be a small improvement (less than 5%) in the tests performed.**

Tested loading a single post (hello world) with a site configured as production (`WP_DEBUG`, `SCRIPT_DEBUG`, `WP_DEBUG_LOG`, `WP_DEBUG_DISPLAY` to `false`).

Taking advantage of the new function, it adds a cache following the steps of similar functions such `wp_get_global_settings` or `wp_get_global_stylesheet`. This results in a reduction of calls to `WP_Theme_JSON_Resolver::get_theme_data` from 15 to 8.

| Trunk | Branch |
| --- | --- |
| <img width="1624" alt="Captura de ecrã 2023-08-07, às 16 12 53" src="https://github.com/WordPress/wordpress-develop/assets/583546/5a363819-80d3-4887-b23b-9c433fcc0ce3"> | <img width="1624" alt="Captura de ecrã 2023-08-07, às 16 13 02" src="https://github.com/WordPress/wordpress-develop/assets/583546/b5027eb7-11da-4d98-8670-4cb6c9f0eca9"> |

In terms of benchmarking with "production" sites, I've done the same test using different tools for comparison.

- `benchmark-server-timing`

```sh
npm run research -- benchmark-server-timing -p --url http://localhost:8889/2023/08/08/hello-world/ -n 100
```

| Theme | Trunk | This PR | Improvement |
| --- | --- | --- | --- |
| TwentyTwentyThree | 165.69ms | 168.51ms | -2.82ms (1.70% faster) |
| TwentyTwentyOne | 84.66ms | 85.49ms | -0.82ms (0.98% faster) |

- `benchmark-web-vitals`

```sh
npm run research -- benchmark-web-vitals -p --url http://localhost:8889/2023/08/08/hello-world/ -n 100
```

TTFB

| Theme | Trunk | This PR | Improvement |
| --- | --- | --- | --- |
| TwentyTwentyThree | 228.3ms | 225.95ms | -2.35ms (1.02% faster) |
| TwentyTwentyOne | 126.1ms | 125.85ms | -0.25ms (0.19%faster) |

LCP

| Theme | Trunk | This PR | Improvement |
| --- | --- | --- | --- |
| TwentyTwentyThree | 314.9ms | 307.15ms | -7.75ms (2.46% faster) |
| TwentyTwentyOne | 199.55ms | 200.45ms | +0.9ms (0.45% slower) |

LCP-TTFB

| Theme | Trunk | This PR | Improvement |
| --- | --- | --- | --- |
| TwentyTwentyThree | 92.2ms | 92.4ms | +0.2ms (0.21% slower) |
| TwentyTwentyOne | 85.95ms | 84.45ms | -1.5ms (1.74% faster) |

- `curl`

```sh
seq 100 | xargs -Iz curl -o /dev/null -H 'Cache-Control: no-cache' -s -w "%{time_starttransfer}\n" http://localhost:8889 | awk '{sum+=$1} END {print sum/NR}' | pbcopy
```

| Theme | Trunk | This PR | Improvement |
| --- | --- | --- | --- |
| TwentyTwentyThree | 154.60ms | 152.471ms | -2.3ms (1.37% faster) |
| TwentyTwentyOne | 65.89ms | 65.68ms | -0.21ms (0.32% faster) |

## How to test

Using the TwentyTwentyThree theme:

1. Go to "Appearance > Editor > Patterns" and click on "Template Parts > General".
2. Verify that there are two template parts whose titles are "Comments" and "**Post meta**".

And then:

1. Go and edit the `theme.json` of the theme by removing the "post-meta" template part declared in `templateParts`.
2. Go to "Appearance > Editor > Patterns" and click on "Template Parts > General".
3. Verify that there are two template parts whose titles are "Comments" and "**post-meta**" (note how the title is taken from the template part file and not from `theme.json`).

## Commit message

```
Themes: add wp_get_theme_data_template_parts function.

Adds a new public function, `wp_get_theme_data_template_parts` that returns the `templateParts` defined by the active theme from `theme.json`. It also substitutes the usage of private APIs by this new API.

Props felixarntz.
Fixes #59003
```