### PR TITLE
Prevent races and stampedes when flush_rewrite_rules() is called

### DIFF
--- a/src/wp-includes/class-wp-rewrite.php
+++ b/src/wp-includes/class-wp-rewrite.php
@@ -1509,8 +1509,10 @@ class WP_Rewrite {
 		$this->rewrite_rules();
 
 		if ( ! did_action( 'wp_loaded' ) ) {
-			// Is not safe to save the results right now, as the rules may be partial.
-			// Need to give all rules the chance to register.
+			/*
+			 * Is not safe to save the results right now, as the rules may be partial.
+			 * Need to give all rules the chance to register.
+			 */
 			add_action( 'wp_loaded', array( $this, 'flush_rules' ) );
 		} else {
 			update_option( 'rewrite_rules', $this->rules );

--- a/src/wp-includes/class-wp-rewrite.php
+++ b/src/wp-includes/class-wp-rewrite.php
@@ -1485,11 +1485,13 @@ class WP_Rewrite {
 	 *
 	 * @since 1.5.0
 	 *
+	 * @param boolean $should_flush Whether or not the rules should be flushed. Default false.
 	 * @return string[] Array of rewrite rules keyed by their regex pattern.
 	 */
-	public function wp_rewrite_rules() {
+	public function wp_rewrite_rules( $should_flush = false ) {
 		$this->rules = get_option( 'rewrite_rules' );
-		if ( empty( $this->rules ) ) {
+		if ( empty( $this->rules ) || $should_flush ) {
+			$this->rules   = '';
 			$this->matches = 'matches';
 			$this->rewrite_rules();
 			if ( ! did_action( 'wp_loaded' ) ) {
@@ -1864,8 +1866,7 @@ class WP_Rewrite {
 			unset( $do_hard_later );
 		}
 
-		update_option( 'rewrite_rules', '' );
-		$this->wp_rewrite_rules();
+		$this->wp_rewrite_rules( true );
 
 		/**
 		 * Filters whether a "hard" rewrite rule flush should be performed when requested.

--- a/src/wp-includes/class-wp-rewrite.php
+++ b/src/wp-includes/class-wp-rewrite.php
@@ -1500,7 +1500,7 @@ class WP_Rewrite {
 	 * Refreshes the rewrite rules, saving the fresh value to the database.
 	 * If the `wp_loaded` action has not occurred yet, will postpone saving to the database.
 	 *
-	 * @return void
+	 * @since 6.4.0
 	 */
 	private function refresh_rewrite_rules() {
 		$this->rules   = '';


### PR DESCRIPTION
Rather than deleting/setting the `rewrite_rules` to an empty string, which has an effect on all other incoming requests at the same time, only the request that asked to flush the rewrite rules should be responsible for generating them.

The only scenario I can think of where this will introduce problematic behavior is if a flush is requested and the `wp_loaded` hook as not been called and a non-traditional boot-up path is chosen where it will never request the rewrite rules. In that case, the rules won't actually be flushed. We could account for this, in a means similar to `$do_hard_later` in flush_rules(), but I'm not entirely sure that's really necessary/likely.

Trac ticket: https://core.trac.wordpress.org/ticket/58998#ticket