### PR TITLE
Code Styling: Add missing star to make comment a docblock comment

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -923,7 +923,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		}
 	}
 
-	/*
+	/**
 	 * Closes elements that have implied end tags, thoroughly.
 	 *
 	 * See the HTML specification for an explanation why this is


### PR DESCRIPTION
Trac Ticket: [#59010](https://core.trac.wordpress.org/ticket/59010)

No explanation needed; this is a fix for something that was missed during multiple rounds of reviews and CI checks.