### PR TITLE
Fix fatal in single-site wp_user_query with orderby=post_count&who=authors

### DIFF
--- a/src/wp-includes/class-wp-user-query.php
+++ b/src/wp-includes/class-wp-user-query.php
@@ -1072,7 +1072,7 @@ class WP_User_Query {
 			$blog_id = absint( $args['blog_id'] );
 		}
 		if ( ( $args['has_published_posts'] && $blog_id ) || in_array( 'post_count', $ordersby, true ) ) {
-			$switch = get_current_blog_id() !== $blog_id;
+			$switch = $blog_id && get_current_blog_id() !== $blog_id;
 			if ( $switch ) {
 				switch_to_blog( $blog_id );
 			}

--- a/src/wp-includes/class-wp-user-query.php
+++ b/src/wp-includes/class-wp-user-query.php
@@ -1071,7 +1071,7 @@ class WP_User_Query {
 		if ( isset( $args['blog_id'] ) ) {
 			$blog_id = absint( $args['blog_id'] );
 		}
-		if ( ( $args['has_published_posts'] && $blog_id ) || in_array( 'post_count', $ordersby, true ) ) {
+		if ( $args['has_published_posts'] || in_array( 'post_count', $ordersby, true ) ) {
 			$switch = $blog_id && get_current_blog_id() !== $blog_id;
 			if ( $switch ) {
 				switch_to_blog( $blog_id );

--- a/tests/phpunit/tests/user/queryCache.php
+++ b/tests/phpunit/tests/user/queryCache.php
@@ -621,8 +621,9 @@ class Tests_User_Query_Cache extends WP_UnitTestCase {
 	/**
 	 * Verify orderby post_count doesn't fatal.
 	 * @ticket 59011
+	 * @expectedDeprecated WP_User_Query
 	 */
-	public function test_generate_cache_key_post_count() {
+	public function test_generate_cache_key_post_count_with_who_authors() {
 		global $wpdb;
 		$query = new WP_User_Query(
 			array(

--- a/tests/phpunit/tests/user/queryCache.php
+++ b/tests/phpunit/tests/user/queryCache.php
@@ -619,6 +619,24 @@ class Tests_User_Query_Cache extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Verify orderby post_count doesn't fatal.
+	 * @ticket 59011
+	 */
+	public function test_generate_cache_key_post_count() {
+		global $wpdb;
+		$query = new WP_User_Query(
+			array(
+				'fields'  => 'ID',
+				'orderby' => 'post_count',
+				'order'   => 'DESC',
+				'who'     => 'authors',
+			)
+		);
+
+		$this->assertTrue( true );
+	}
+
+	/**
 	 * @ticket 40613
 	 * @group ms-required
 	 * @covers ::query


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/59011

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
