### PR TITLE
Weekly wp_get_archives has invalid link (link for month instead of year)

### DIFF
--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -2150,7 +2150,7 @@ function wp_get_archives( $args = '' ) {
 					$arc_week_end   = date_i18n( get_option( 'date_format' ), $arc_week['end'] );
 					$url            = add_query_arg(
 						array(
-							'm' => $arc_year,
+							'y' => $arc_year,
 							'w' => $result->week,
 						),
 						home_url( '/' )


### PR DESCRIPTION
If you call wp_get_archives function with type set to weekly, the resulted link contains two parameters: m => year, w => week.
This results in unwanted behaviour, as you get a month like 2023 which is invalid.
The link should contain ?y={year}&w={week}.

Trac ticket: https://core.trac.wordpress.org/ticket/59027

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
