### PR TITLE
webfonts handler: use `wp_get_global_settings` instead of private API

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -3248,7 +3248,7 @@ function _wp_theme_json_webfonts_handler() {
 	 */
 	$fn_get_webfonts_from_theme_json = static function() {
 		// Get settings from theme.json.
-		$settings = WP_Theme_JSON_Resolver::get_merged_data()->get_settings();
+		$settings = wp_get_global_settings();
 
 		// If in the editor, add webfonts defined in variations.
 		if ( is_admin() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {


### PR DESCRIPTION
Trac ticket https://core.trac.wordpress.org/ticket/59028

## What

This substitutes the call to a private API `WP_Theme_JSON_Resolver::get_merged_data()->get_settings();` for the public API equivalent `wp_get_global_settings()`.

## Why

We should use our public APIs when possible.

## How to test

Verify all tests pass.