### PR TITLE
wp_block post type: add `delete_posts` to capabilities.

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -320,6 +320,8 @@ function create_initial_post_types() {
 				'edit_posts'             => 'edit_posts',
 				'edit_published_posts'   => 'edit_published_posts',
 				'delete_published_posts' => 'delete_published_posts',
+				// Enables trashing draft posts as well.
+				'delete_posts'           => 'delete_posts',
 				'edit_others_posts'      => 'edit_others_posts',
 				'delete_others_posts'    => 'delete_others_posts',
 			),


### PR DESCRIPTION
Syncing changes from:

- https://github.com/WordPress/gutenberg/pull/53405

Adds `'delete_posts'` to the wp_block (patterns) capabilities.

Required to allow users to delete draft posts from wp-admin/edit.php?post_type=wp_block

See Gutenberg issue:

- https://github.com/WordPress/gutenberg/issues/53367

### Testing Instructions

1. Add a pattern in the post editor (wp-admin/edit.php?post_type=wp_block)
2. Save it in draft status
3. Go back to the list table
4. Try to trash the pattern (the row action will not be there)


## Screenshots or screencast <!-- if applicable -->

### Before
https://github.com/WordPress/gutenberg/assets/6458278/ec585568-1362-4742-acd0-d3be30a28f9d

### After
https://github.com/WordPress/gutenberg/assets/6458278/2c9be9a7-c2bf-4de0-aed4-1341335cc75d



Trac ticket: https://core.trac.wordpress.org/ticket/59041

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
