### PR TITLE
Fluid typography: add min and max viewport width configurable options

### DIFF
--- a/src/wp-includes/block-supports/typography.php
+++ b/src/wp-includes/block-supports/typography.php
@@ -471,6 +471,7 @@ function wp_get_computed_fluid_typography_value( $args = array() ) {
  * @since 6.1.1 Adjusted rules for min and max font sizes.
  * @since 6.2.0 Added 'settings.typography.fluid.minFontSize' support.
  * @since 6.3.0 Using layout.wideSize as max viewport width, and logarithmic scale factor to calculate minimum font scale.
+ * @since 6.4.0 Added configurable min and max viewport width values to the typography.fluid theme.json schema.
  *
  * @param array $preset                     {
  *     Required. fontSizes preset value as seen in theme.json.

--- a/src/wp-includes/block-supports/typography.php
+++ b/src/wp-includes/block-supports/typography.php
@@ -517,14 +517,21 @@ function wp_get_typography_font_size_value( $preset, $should_use_fluid_typograph
 		: array();
 
 	// Defaults.
-	$default_maximum_viewport_width       = isset( $layout_settings['wideSize'] ) && ! empty( wp_get_typography_value_and_unit( $layout_settings['wideSize'] ) ) ? $layout_settings['wideSize'] : '1600px';
+	$default_maximum_viewport_width       = '1600px';
 	$default_minimum_viewport_width       = '320px';
 	$default_minimum_font_size_factor_max = 0.75;
 	$default_minimum_font_size_factor_min = 0.25;
 	$default_scale_factor                 = 1;
-	$has_min_font_size                    = isset( $fluid_settings['minFontSize'] ) &&
-		! empty( wp_get_typography_value_and_unit( $fluid_settings['minFontSize'] ) );
-	$default_minimum_font_size_limit      = $has_min_font_size ? $fluid_settings['minFontSize'] : '14px';
+	$default_minimum_font_size_limit      = '14px';
+
+	// Defaults overrides.
+	$minimum_viewport_width = isset( $fluid_settings['minViewportWidth'] ) ? $fluid_settings['minViewportWidth'] : $default_minimum_viewport_width;
+	$maximum_viewport_width = isset( $layout_settings['wideSize'] ) && ! empty( wp_get_typography_value_and_unit( $layout_settings['wideSize'] ) ) ? $layout_settings['wideSize'] : $default_maximum_viewport_width;
+	if ( isset( $fluid_settings['maxViewportWidth'] ) ) {
+		$maximum_viewport_width = $fluid_settings['maxViewportWidth'];
+	}
+	$has_min_font_size       = isset( $fluid_settings['minFontSize'] ) && ! empty( wp_get_typography_value_and_unit( $fluid_settings['minFontSize'] ) );
+	$minimum_font_size_limit = $has_min_font_size ? $fluid_settings['minFontSize'] : $default_minimum_font_size_limit;
 
 	// Font sizes.
 	$fluid_font_size_settings = isset( $preset['fluid'] ) ? $preset['fluid'] : null;
@@ -551,7 +558,7 @@ function wp_get_typography_font_size_value( $preset, $should_use_fluid_typograph
 	 * in order to perform comparative checks.
 	 */
 	$minimum_font_size_limit = wp_get_typography_value_and_unit(
-		$default_minimum_font_size_limit,
+		$minimum_font_size_limit,
 		array(
 			'coerce_to' => $preferred_size['unit'],
 		)
@@ -600,8 +607,8 @@ function wp_get_typography_font_size_value( $preset, $should_use_fluid_typograph
 
 	$fluid_font_size_value = wp_get_computed_fluid_typography_value(
 		array(
-			'minimum_viewport_width' => $default_minimum_viewport_width,
-			'maximum_viewport_width' => $default_maximum_viewport_width,
+			'minimum_viewport_width' => $minimum_viewport_width,
+			'maximum_viewport_width' => $maximum_viewport_width,
 			'minimum_font_size'      => $minimum_font_size_raw,
 			'maximum_font_size'      => $maximum_font_size_raw,
 			'scale_factor'           => $default_scale_factor,

--- a/tests/phpunit/data/themedir1/block-theme-child-with-fluid-typography-config/theme.json
+++ b/tests/phpunit/data/themedir1/block-theme-child-with-fluid-typography-config/theme.json
@@ -7,7 +7,9 @@
 		},
 		"typography": {
 			"fluid": {
-				"minFontSize": "16px"
+				"minFontSize": "16px",
+				"maxViewportWidth": "1200px",
+				"minViewportWidth": "640px"
 			}
 		}
 	}

--- a/tests/phpunit/tests/block-supports/typography.php
+++ b/tests/phpunit/tests/block-supports/typography.php
@@ -622,6 +622,7 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 	 * @ticket 57529
 	 * @ticket 58522
 	 * @ticket 58523
+	 * @ticket 59048
 	 *
 	 * @covers ::wp_register_typography_support
 	 *

--- a/tests/phpunit/tests/block-supports/typography.php
+++ b/tests/phpunit/tests/block-supports/typography.php
@@ -692,7 +692,7 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 			'returns clamp value using custom fluid config' => array(
 				'font_size_value' => '17px',
 				'theme_slug'      => 'block-theme-child-with-fluid-typography-config',
-				'expected_output' => 'font-size:clamp(16px, 1rem + ((1vw - 3.2px) * 0.147), 17px);',
+				'expected_output' => 'font-size:clamp(16px, 1rem + ((1vw - 6.4px) * 0.179), 17px);',
 			),
 			'returns value when font size <= custom min font size bound' => array(
 				'font_size_value' => '15px',


### PR DESCRIPTION
🤞🏻 for WordPress 6.4

Backporting PHP changes from:

- https://github.com/WordPress/gutenberg/pull/53081

This PR adds configurable min and max viewport width values to the typography.fluid theme.json schema, to allow theme developers to configure their own default min and max viewport widths for calculating fluid font sizes.

The min and max viewport widths the boundaries, in terms of viewport widths, at which font size clamp values will stop being "fluid". 


See https://github.com/WordPress/gutenberg/pull/53081 for testing instructions. 

Note that this PR will only affect the frontend.

A package update is required for the editor to reflect the changes. 

Trac ticket: https://core.trac.wordpress.org/ticket/59048

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
