### PR TITLE
Only load `WP_Metadata_Lazyloader` once

### DIFF
--- a/src/wp-includes/meta.php
+++ b/src/wp-includes/meta.php
@@ -10,7 +10,7 @@
  * @subpackage Meta
  */
 
-require ABSPATH . WPINC . '/class-wp-metadata-lazyloader.php';
+require_once ABSPATH . WPINC . '/class-wp-metadata-lazyloader.php';
 
 /**
  * Adds metadata for the specified object.


### PR DESCRIPTION
This addresses an issue on some environments where the `class-wp-metadata-lazyloader.php` file is loaded twice, resulting in a fatal error.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/59057

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
