### PR TITLE
Fixed action menu appearing in the Media Library

### DIFF
--- a/src/js/media/controllers/state.js
+++ b/src/js/media/controllers/state.js
@@ -165,9 +165,12 @@ var State = Backbone.Model.extend(/** @lends wp.media.controller.State.prototype
 	_menu: function() {
 		var menu = this.frame.menu,
 			mode = this.get('menu'),
+			actionMenuItems = this.frame.menu.get('views'),
+			actionMenuLength = actionMenuItems ? actionMenuItems.views.get().length : 0,
 			view;
 
-		this.frame.$el.toggleClass( 'hide-menu', ! mode );
+		// Show action menu only if it is active and has more than one default element
+		this.frame.$el.toggleClass( 'hide-menu', ! mode || actionMenuLength < 2 );
 		if ( ! mode ) {
 			return;
 		}


### PR DESCRIPTION
Hi there! 

I've added a small fix for the issue. Now, the Action menu shows only if it has more than one item, the same way like it happens here: [wp.media.view.Menu.visibility](https://github.com/WordPress/wordpress-develop/blob/415c9f6bb488facb48c44141a7ed4ffc2444e22a/src/js/media/views/menu.js#L90)

Trac ticket: https://core.trac.wordpress.org/ticket/58973