### PR TITLE
Fix test @covers annotation to refer to use recommended pattern for function names

### DIFF
--- a/tests/phpunit/tests/rest-api/rest-navigation-fallback-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-navigation-fallback-controller.php
@@ -153,7 +153,7 @@ class WP_REST_Navigation_Fallback_Controller_Test extends WP_Test_REST_Controlle
 	 *
 	 * @ticket 58557
 	 *
-	 * @covers wp_add_fields_to_navigation_fallback_embedded_links
+	 * @covers ::wp_add_fields_to_navigation_fallback_embedded_links
 	 *
 	 * @since 6.3.0 Added Navigation Fallbacks endpoint.
 	 */

--- a/tests/phpunit/tests/theme/customHeader.php
+++ b/tests/phpunit/tests/theme/customHeader.php
@@ -88,7 +88,7 @@ class Tests_Theme_CustomHeader extends WP_UnitTestCase {
 	 *
 	 * @ticket 56180
 	 *
-	 * @covers get_header_image
+	 * @covers ::get_header_image
 	 *
 	 * @dataProvider data_filter_header_image
 	 *


### PR DESCRIPTION
PHPUnit `@covers` annotations recommend declaring the function names with a `::` prefix. We already do so for a lot of functions, but this found two instances that were missing the prefix.

 - https://docs.phpunit.de/en/10.0/code-coverage.html#code-coverage-specifying-covered-parts

Trac ticket: https://core.trac.wordpress.org/ticket/59069

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
