### PR TITLE
Typo fixed in doc block

### DIFF
--- a/src/wp-admin/includes/class-wp-media-list-table.php
+++ b/src/wp-admin/includes/class-wp-media-list-table.php
@@ -297,7 +297,7 @@ class WP_Media_List_Table extends WP_List_Table {
 				<?php
 				$this->extra_tablenav( 'bar' );
 
-				/** This filter is documented in wp-admin/inclues/class-wp-list-table.php */
+				/** This filter is documented in wp-admin/includes/class-wp-list-table.php */
 				$views = apply_filters( "views_{$this->screen->id}", array() );
 
 				// Back compat for pre-4.0 view links.


### PR DESCRIPTION
A small typo has been found in a doc block in this trac ticket. 
[#59102](https://core.trac.wordpress.org/ticket/59102)

Let's fix that. :)