### PR TITLE
Expanded database testing: approach 1

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -89,17 +89,9 @@ jobs:
         exclude:
           # MySQL and MariaDB have different valid versions. Exclude combinations that don't exist.
           - db_type: 'mysql'
-            db_version: '10.4'
-          - db_type: 'mysql'
-            db_version: '10.6'
-          - db_type: 'mysql'
-            db_version: '10.11'
-          - db_type: 'mysql'
-            db_version: '11.0'
+            db_version: [ '10.4', '10.6', '10.11', '11.0' ]
           - db_type: 'mariadb'
-            db_version: '5.7'
-          - db_type: 'mariadb'
-            db_version: '8.0'
+            db_version: [ '5.7', '8.0' ]
 
     env:
       LOCAL_PHP: ${{ matrix.php }}-fpm

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -55,7 +55,7 @@ jobs:
   # - Checks out the WordPress Test reporter repository.
   # - Submit the test results to the WordPress.org host test results.
   test-php:
-    name: PHP ${{ matrix.php }} / ${{ 'mariadb' == matrix.db_type && 'MariaDB' || 'MySQL' }} ${{ matrix.db_version }}${{ matrix.multisite && ' multisite' || '' }}${{ matrix.memcached && ' with memcached' || '' }}
+    name: ${{ matrix.report && 'Test reporter - ' || '' }}PHP ${{ matrix.php }} / ${{ 'mariadb' == matrix.db_type && 'MariaDB' || 'MySQL' }} ${{ matrix.db_version }}${{ matrix.multisite && ' multisite' || '' }}${{ matrix.memcached && ' with memcached' || '' }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -71,18 +71,37 @@ jobs:
         memcached: [ false ]
         multisite: [ false, true ]
         include:
-          # Include jobs for PHP 7.4 with memcached.
+          # Include jobs for PHP 7.4 with memcached and MySQL.
           - php: '7.4'
             os: ubuntu-latest
+            db_type: 'mysql'
+            db_version: '5.7'
             memcached: true
             multisite: false
           - php: '7.4'
             os: ubuntu-latest
+            db_type: 'mysql'
+            db_version: '5.7'
+            memcached: true
+            multisite: true
+          # Include jobs for PHP 7.4 with memcached and MariaDB.
+          - php: '7.4'
+            os: ubuntu-latest
+            db_type: 'mariadb'
+            db_version: '11.0'
+            memcached: true
+            multisite: false
+          - php: '7.4'
+            os: ubuntu-latest
+            db_type: 'mariadb'
+            db_version: '11.0'
             memcached: true
             multisite: true
           # Report the results of the PHP 7.4 without memcached job.
           - php: '7.4'
             os: ubuntu-latest
+            db_type: 'mysql'
+            db_version: '5.7'
             memcached: false
             multisite: false
             report: true

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -55,7 +55,7 @@ jobs:
   # - Checks out the WordPress Test reporter repository.
   # - Submit the test results to the WordPress.org host test results.
   test-php:
-    name: PHP ${{ matrix.php }} / ${{ 'mariadb' == matrix.db_type && 'MariaDB' || 'MySQL' }} ${{ matrix.db_version }}${{ matrix.multisite && ' multisite' || '' }}${{ matrix.memcached && ' with memcached' || '' }}${{ inputs.report && ' (test reporting enabled)' || '' }}
+    name: PHP ${{ matrix.php }} / ${{ 'mariadb' == matrix.db_type && 'MariaDB' || 'MySQL' }} ${{ matrix.db_version }}${{ matrix.multisite && ' multisite' || '' }}${{ matrix.memcached && ' with memcached' || '' }}${{ matrix.report && ' (test reporting enabled)' || '' }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -70,6 +70,7 @@ jobs:
         os: [ ubuntu-latest ]
         memcached: [ false ]
         multisite: [ false, true ]
+        report: [ false ]
         include:
           # Include jobs for PHP 7.4 with memcached and MySQL.
           - php: '7.4'
@@ -78,12 +79,14 @@ jobs:
             db_version: '5.7'
             memcached: true
             multisite: false
+            report: false
           - php: '7.4'
             os: ubuntu-latest
             db_type: 'mysql'
             db_version: '5.7'
             memcached: true
             multisite: true
+            report: false
           # Include jobs for PHP 7.4 with memcached and MariaDB.
           - php: '7.4'
             os: ubuntu-latest
@@ -91,12 +94,14 @@ jobs:
             db_version: '11.0'
             memcached: true
             multisite: false
+            report: false
           - php: '7.4'
             os: ubuntu-latest
             db_type: 'mariadb'
             db_version: '11.0'
             memcached: true
             multisite: true
+            report: false
           # Report the results of the PHP 7.4 without memcached job.
           - php: '7.4'
             os: ubuntu-latest

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -56,7 +56,7 @@ jobs:
   # - Checks out the WordPress Test reporter repository.
   # - Submit the test results to the WordPress.org host test results.
   test-php:
-    name: PHP ${{ matrix.php }}${{ matrix.multisite && ' multisite' || '' }}${{ matrix.memcached && ' with memcached' || '' }} with ${{ matrix.db_type }} ${{ matrix.db_version || '5.7' }}
+    name: PHP ${{ matrix.php }}${{ matrix.multisite && ' multisite' || '' }}${{ matrix.memcached && ' with memcached' || '' }} with ${{ 'mariadb' == matrix.db_type && 'MariaDB' || 'MySQL' }} ${{ matrix.db_version || '5.7' }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - trunk
+      - expanded-db-testing-one-workflow
       - '3.[7-9]'
       - '[4-9].[0-9]'
     tags:
@@ -12,7 +13,6 @@ on:
   pull_request:
     branches:
       - trunk
-      - expanded-db-testing-one-workflow
       - '3.[7-9]'
       - '[4-9].[0-9]'
   workflow_dispatch:

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -12,6 +12,7 @@ on:
   pull_request:
     branches:
       - trunk
+      - expanded-db-testing-one-workflow
       - '3.[7-9]'
       - '[4-9].[0-9]'
   workflow_dispatch:
@@ -55,7 +56,7 @@ jobs:
   # - Checks out the WordPress Test reporter repository.
   # - Submit the test results to the WordPress.org host test results.
   test-php:
-    name: ${{ matrix.php }}${{ matrix.multisite && ' multisite' || '' }}${{ matrix.memcached && ' with memcached' || '' }} on ${{ matrix.os }}
+    name: PHP ${{ matrix.php }}${{ matrix.multisite && ' multisite' || '' }}${{ matrix.memcached && ' with memcached' || '' }} with ${{ matrix.db_type }} ${{ matrix.db_version || '5.7' }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -65,6 +66,8 @@ jobs:
       fail-fast: false
       matrix:
         php: [ '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2' ]
+        db_type: [ 'mysql', 'mariadb' ]
+        db_version: [ '5.7', '8.0', '10.4', '10.6', '10.11', '11.0'  ]
         os: [ ubuntu-latest ]
         memcached: [ false ]
         multisite: [ false, true ]
@@ -87,6 +90,8 @@ jobs:
 
     env:
       LOCAL_PHP: ${{ matrix.php }}-fpm
+      LOCAL_DB_TYPE: ${{ matrix.db_type || 'mysql' }}
+      LOCAL_DB_VERSION: ${{ matrix.db_version || '5.7' }}
       LOCAL_PHP_MEMCACHED: ${{ matrix.memcached }}
       PHPUNIT_CONFIG: ${{ matrix.multisite && 'tests/phpunit/multisite.xml' || 'phpunit.xml.dist' }}
 

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -70,7 +70,6 @@ jobs:
         os: [ ubuntu-latest ]
         memcached: [ false ]
         multisite: [ false, true ]
-        report: [ false ]
         include:
           # Include jobs for PHP 7.4 with memcached and MySQL.
           - php: '7.4'
@@ -79,14 +78,12 @@ jobs:
             db_version: '5.7'
             memcached: true
             multisite: false
-            report: false
           - php: '7.4'
             os: ubuntu-latest
             db_type: 'mysql'
             db_version: '5.7'
             memcached: true
             multisite: true
-            report: false
           # Include jobs for PHP 7.4 with memcached and MariaDB.
           - php: '7.4'
             os: ubuntu-latest
@@ -94,14 +91,12 @@ jobs:
             db_version: '11.0'
             memcached: true
             multisite: false
-            report: false
           - php: '7.4'
             os: ubuntu-latest
             db_type: 'mariadb'
             db_version: '11.0'
             memcached: true
             multisite: true
-            report: false
           # Report the results of the PHP 7.4 without memcached job.
           - php: '7.4'
             os: ubuntu-latest

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -55,7 +55,7 @@ jobs:
   # - Checks out the WordPress Test reporter repository.
   # - Submit the test results to the WordPress.org host test results.
   test-php:
-    name: PHP ${{ matrix.php }}/${{ 'mariadb' == matrix.db_type && 'MariaDB' || 'MySQL' }} ${{ matrix.db_version }}${{ matrix.multisite && ' multisite' || '' }}${{ matrix.memcached && ' with memcached' || '' }}
+    name: PHP ${{ matrix.php }} / ${{ 'mariadb' == matrix.db_type && 'MariaDB' || 'MySQL' }} ${{ matrix.db_version }}${{ matrix.multisite && ' multisite' || '' }}${{ matrix.memcached && ' with memcached' || '' }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -89,9 +89,17 @@ jobs:
         exclude:
           # MySQL and MariaDB have different valid versions. Exclude combinations that don't exist.
           - db_type: 'mysql'
-            db_version: [ '10.4', '10.6', '10.11', '11.0' ]
+            db_version: '10.4'
+          - db_type: 'mysql'
+            db_version: '10.6'
+          - db_type: 'mysql'
+            db_version: '10.11'
+          - db_type: 'mysql'
+            db_version: '11.0'
           - db_type: 'mariadb'
-            db_version: [ '5.7', '8.0' ]
+            db_version: '5.7'
+          - db_type: 'mariadb'
+            db_version: '8.0'
 
     env:
       LOCAL_PHP: ${{ matrix.php }}-fpm

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -56,7 +56,7 @@ jobs:
   # - Checks out the WordPress Test reporter repository.
   # - Submit the test results to the WordPress.org host test results.
   test-php:
-    name: PHP/${{ 'mariadb' == matrix.db_type && 'MariaDB' || 'MySQL' }} ${{ matrix.db_version }}${{ matrix.php }}${{ matrix.multisite && ' multisite' || '' }}${{ matrix.memcached && ' with memcached' || '' }}
+    name: PHP ${{ matrix.php }}/${{ 'mariadb' == matrix.db_type && 'MariaDB' || 'MySQL' }} ${{ matrix.db_version }}${{ matrix.multisite && ' multisite' || '' }}${{ matrix.memcached && ' with memcached' || '' }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -87,6 +87,19 @@ jobs:
             memcached: false
             multisite: false
             report: true
+        exclude:
+          - db_type: 'mysql'
+            db_version: '10.4'
+          - db_type: 'mysql'
+            db_version: '10.6'
+          - db_type: 'mysql'
+            db_version: '10.11'
+          - db_type: 'mysql'
+            db_version: '11.0'
+          - db_type: 'mariadb'
+            db_version: '5.7'
+          - db_type: 'mariadb'
+            db_version: '8.0'
 
     env:
       LOCAL_PHP: ${{ matrix.php }}-fpm

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -56,7 +56,7 @@ jobs:
   # - Checks out the WordPress Test reporter repository.
   # - Submit the test results to the WordPress.org host test results.
   test-php:
-    name: PHP ${{ matrix.php }}${{ matrix.multisite && ' multisite' || '' }}${{ matrix.memcached && ' with memcached' || '' }} with ${{ 'mariadb' == matrix.db_type && 'MariaDB' || 'MySQL' }} ${{ matrix.db_version || '5.7' }}
+    name: PHP/${{ 'mariadb' == matrix.db_type && 'MariaDB' || 'MySQL' }} ${{ matrix.db_version }}${{ matrix.php }}${{ matrix.multisite && ' multisite' || '' }}${{ matrix.memcached && ' with memcached' || '' }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -88,6 +88,7 @@ jobs:
             multisite: false
             report: true
         exclude:
+          # MySQL and MariaDB have different valid versions. Exclude combinations that don't exist.
           - db_type: 'mysql'
             db_version: '10.4'
           - db_type: 'mysql'
@@ -170,7 +171,7 @@ jobs:
 
       - name: WordPress Docker container debug information
         run: |
-          docker-compose run --rm mysql mysql --version
+          docker-compose run --rm mysql ${{ env.LOCAL_DB_TYPE }} --version
           docker-compose run --rm php php --version
           docker-compose run --rm php php -m
           docker-compose run --rm php php -i

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -55,7 +55,7 @@ jobs:
   # - Checks out the WordPress Test reporter repository.
   # - Submit the test results to the WordPress.org host test results.
   test-php:
-    name: ${{ matrix.report && 'Test reporter - ' || '' }}PHP ${{ matrix.php }} / ${{ 'mariadb' == matrix.db_type && 'MariaDB' || 'MySQL' }} ${{ matrix.db_version }}${{ matrix.multisite && ' multisite' || '' }}${{ matrix.memcached && ' with memcached' || '' }}
+    name: PHP ${{ matrix.php }} / ${{ 'mariadb' == matrix.db_type && 'MariaDB' || 'MySQL' }} ${{ matrix.db_version }}${{ matrix.multisite && ' multisite' || '' }}${{ matrix.memcached && ' with memcached' || '' }}${{ inputs.report && ' (test reporting enabled)' || '' }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -61,7 +61,7 @@ jobs:
     permissions:
       contents: read
     timeout-minutes: 20
-    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: ${{ github.repository == 'desrosj/wordpress-develop' || github.event_name == 'pull_request' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - trunk
-      - expanded-db-testing-one-workflow
       - '3.[7-9]'
       - '[4-9].[0-9]'
     tags:
@@ -61,7 +60,7 @@ jobs:
     permissions:
       contents: read
     timeout-minutes: 20
-    if: ${{ github.repository == 'desrosj/wordpress-develop' || github.event_name == 'pull_request' }}
+    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This option keeps everything to do with the PHPUnit workflow the same and just expands the strategy matrix. This is a cleaner diff, but does require a half dozen `exclude` statements to be added in order to avoid invalid combinations.

Trac ticket: https://core.trac.wordpress.org/ticket/30462.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
