### PR TITLE
Ensure only a block's viewScript gets defer loading strategy

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -164,6 +164,11 @@ function register_block_script_handle( $metadata, $field_name, $index = 0 ) {
 			: get_theme_file_uri( str_replace( $stylesheet_path_norm, '', $script_path_norm ) );
 	}
 
+	$script_args = array();
+	if ( 'viewScript' === $field_name ) {
+		$script_args['strategy'] = 'defer';
+	}
+
 	$script_asset        = require $script_asset_path;
 	$script_dependencies = isset( $script_asset['dependencies'] ) ? $script_asset['dependencies'] : array();
 	$result              = wp_register_script(
@@ -171,7 +176,7 @@ function register_block_script_handle( $metadata, $field_name, $index = 0 ) {
 		$script_uri,
 		$script_dependencies,
 		isset( $script_asset['version'] ) ? $script_asset['version'] : false,
-		array( 'strategy' => 'defer' )
+		$script_args
 	);
 	if ( ! $result ) {
 		return false;


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/59115

Commit message:

```
Editor: Ensure defer loading strategy is only applied to a block's viewScript.

Amends [56398].
Props gziolo, westonruter.
Fixes #59115.
```

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
