### PR TITLE
Introduce filters to modify/inspect the blocks returned by `do_blocks()`

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1502,11 +1502,31 @@ function parse_blocks( $content ) {
  */
 function do_blocks( $content ) {
 	$blocks = parse_blocks( $content );
+
+	/**
+	 * Filter to allow plugins to inspect or change the array of parsed block
+	 * objects.
+	 *
+	 * @since 6.4.0
+	 *
+	 * @param array[] $blocks Array of parsed block objects.
+	 */
+	$blocks = apply_filters( 'do_blocks_pre_render', $blocks );
+
 	$output = '';
 
 	foreach ( $blocks as $block ) {
 		$output .= render_block( $block );
 	}
+
+	/**
+	 * Filter to allow plugins to inspect or change the rendered HTML.
+	 *
+	 * @since 6.4.0
+	 *
+	 * @param string $output String of rendered HTML.
+	 */
+	$output = apply_filters( 'do_blocks_post_render', $output );
 
 	// If there are blocks in this content, we shouldn't run wpautop() on it later.
 	$priority = has_filter( 'the_content', 'wpautop' );

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1504,8 +1504,9 @@ function do_blocks( $content ) {
 	$blocks = parse_blocks( $content );
 
 	/**
-	 * Filter to allow plugins to inspect or change the array of parsed block
-	 * objects.
+	 * Filter that allows plugins to inspect or manipulate the array of parsed
+	 * block objects. The parsed blocks form a hierarchy, rather than a flat
+	 * array, as blocks can be nested within each other during parsing.
 	 *
 	 * @since 6.4.0
 	 *
@@ -1520,7 +1521,7 @@ function do_blocks( $content ) {
 	}
 
 	/**
-	 * Filter to allow plugins to inspect or change the rendered HTML.
+	 * Filter to allow plugins to inspect or manipulate the final HTML output.
 	 *
 	 * @since 6.4.0
 	 *

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1504,9 +1504,23 @@ function do_blocks( $content ) {
 	$blocks = parse_blocks( $content );
 
 	/**
-	 * Filter that allows plugins to inspect or manipulate the array of parsed
-	 * block objects. The parsed blocks form a hierarchy, rather than a flat
-	 * array, as blocks can be nested within each other during parsing.
+	 * Filters the tree of raw parsed blocks before they are rendered.
+	 *
+	 * The parsed blocks form a hierarchy, rather than a flat array, as blocks can
+	 * be nested within each other. Also, take into account that calls to
+	 * `do_blocks` could be nested if there are blocks that use `do_blocks` in
+	 * their own rendering.
+	 *
+	 * Example:
+	 *
+	 *     add_filter( 'do_blocks_pre_render', function ( $blocks ) {
+	 *       foreach ( $blocks as $index => $block ) {
+	 *         if ( str_contains( $block['innerHTML'], 'foo' ) ) {
+	 *           unset( $blocks[ $index ] );
+	 *         }
+	 *       }
+	 *       return $blocks;
+	 *     }, 10, 1 );
 	 *
 	 * @since 6.4.0
 	 *
@@ -1521,7 +1535,21 @@ function do_blocks( $content ) {
 	}
 
 	/**
-	 * Filter to allow plugins to inspect or manipulate the final HTML output.
+	 * Filters the final HTML output from block rendering.
+	 *
+	 * This hook provides a post-processing step where it's possible to perform
+	 * cleanup or finish what was started during the rendering pass. This filter
+	 * runs only after all of the blocks have been rendered and there are no more
+	 * block objects available; only HTML. Also, take into account that calls to
+	 * `do_blocks` could be nested if there are blocks that use `do_blocks` in
+	 * their own rendering.
+	 *
+	 * Example:
+	 *
+	 *     add_filter( 'do_blocks_post_render', function ( $output ) {
+	 *       $counter = sprintf( __( 'This post contains %1$s words.' ), count_words( $output ) );
+	 *       return "<p>$counter</p>$output";
+	 *     }, 10, 1 );
 	 *
 	 * @since 6.4.0
 	 *

--- a/tests/phpunit/tests/blocks/renderHooks.php
+++ b/tests/phpunit/tests/blocks/renderHooks.php
@@ -15,25 +15,22 @@ class Tests_Blocks_Render_Hooks extends WP_UnitTestCase {
 	public function test_do_blocks_pre_render_filter() {
 		$remove_blocks_containing_wordpress = static function( $blocks ) {
 			foreach ( $blocks as $index => $block ) {
-				if ( strpos( $block['innerHTML'], 'WordPress' ) !== false ) {
+				if ( str_contains( $block['innerHTML'], 'WordPress' ) ) {
 					unset( $blocks[ $index ] );
 				}
 			}
 			return $blocks;
 		};
 
-		$block_content = '
-			<!-- wp:core/paragraph --><p>Hello</p><!-- /wp:core/paragraph -->
-			<!-- wp:core/paragraph --><p>WordPress</p><!-- /wp:core/paragraph -->
-		';
+		$hello_block = '<!-- wp:core/paragraph --><p>Hello</p><!-- /wp:core/paragraph -->';
+		$press_block = '<!-- wp:core/paragraph --><p>WordPress</p><!-- /wp:core/paragraph -->';
 
 		add_filter( 'do_blocks_pre_render', $remove_blocks_containing_wordpress );
-
-		$result = do_blocks( $block_content );
-
+		$filtered_output = do_blocks( $hello_block . $press_block );
 		remove_filter( 'do_blocks_pre_render', $remove_blocks_containing_wordpress );
 
-		$this->assertSame( '<p>Hello</p>', trim( $result ) );
+		$wanted_output = do_blocks( $hello_block );
+		$this->assertSame( $wanted_output, $filtered_output, "Did not exclude the intended blocks before rendering." );
 	}
 
 	/**
@@ -45,17 +42,14 @@ class Tests_Blocks_Render_Hooks extends WP_UnitTestCase {
 			return $content;
 		};
 
-		$block_content = '
-			<!-- wp:core/paragraph --><p>Hello</p><!-- /wp:core/paragraph -->
-			<!-- wp:core/paragraph --><p>WordPress</p><!-- /wp:core/paragraph -->
-		';
+		$hello_block = '<!-- wp:core/paragraph --><p>Hello</p><!-- /wp:core/paragraph -->';
+		$press_block = '<!-- wp:core/paragraph --><p>WordPress</p><!-- /wp:core/paragraph -->';
 
 		add_filter( 'do_blocks_post_render', $remove_wordpress_paragraph );
-
-		$result = do_blocks( $block_content );
-
+		$filtered_output = do_blocks( $hello_block . $press_block );
 		remove_filter( 'do_blocks_post_render', $remove_wordpress_paragraph );
 
-		$this->assertSame( '<p>Hello</p>', trim( $result ) );
+		$wanted_output = do_blocks( $hello_block );
+		$this->assertSame( $wanted_output, $filtered_output, "Did not exclude the intended content before rendering." );
 	}
 }

--- a/tests/phpunit/tests/blocks/renderHooks.php
+++ b/tests/phpunit/tests/blocks/renderHooks.php
@@ -19,22 +19,22 @@ class Tests_Blocks_Render_Hooks extends WP_UnitTestCase {
 		';
 
 		add_filter( 'do_blocks_pre_render', array( $this, 'do_blocks_pre_render_filter' ) );
-		
+
 		$result = do_blocks( $block_content );
-		
+
 		$this->assertSame( '<p>Hello</p>', trim( $result ) );
-		
+
 		remove_filter( 'do_blocks_pre_render', array( $this, 'do_blocks_pre_render_filter' ) );
 	}
 	public function do_blocks_pre_render_filter( $blocks ) {
 		foreach ( $blocks as $index => $block ) {
 			if ( strpos( $block['innerHTML'], 'WordPress' ) !== false ) {
-				unset( $blocks[$index] );
+				unset( $blocks[ $index ] );
 			}
 		}
 		return $blocks;
 	}
-	
+
 	/**
 	 * @ticket 59131
 	 */

--- a/tests/phpunit/tests/blocks/renderHooks.php
+++ b/tests/phpunit/tests/blocks/renderHooks.php
@@ -13,7 +13,7 @@ class Tests_Blocks_Render_Hooks extends WP_UnitTestCase {
 	 * @ticket 59131
 	 */
 	public function test_do_blocks_pre_render_filter() {
-		$remove_blocks_containing_wordpress = static function( $blocks ) {
+		$remove_blocks_containing_wordpress = static function ( $blocks ) {
 			foreach ( $blocks as $index => $block ) {
 				if ( str_contains( $block['innerHTML'], 'WordPress' ) ) {
 					unset( $blocks[ $index ] );
@@ -30,14 +30,14 @@ class Tests_Blocks_Render_Hooks extends WP_UnitTestCase {
 		remove_filter( 'do_blocks_pre_render', $remove_blocks_containing_wordpress );
 
 		$wanted_output = do_blocks( $hello_block );
-		$this->assertSame( $wanted_output, $filtered_output, "Did not exclude the intended blocks before rendering." );
+		$this->assertSame( $wanted_output, $filtered_output, 'Did not exclude the intended blocks before rendering.' );
 	}
 
 	/**
 	 * @ticket 59131
 	 */
 	public function test_do_blocks_post_render_filter() {
-		$remove_wordpress_paragraph = static function( $content ) {
+		$remove_wordpress_paragraph = static function ( $content ) {
 			$content = str_replace( '<p>WordPress</p>', '', $content );
 			return $content;
 		};
@@ -50,6 +50,6 @@ class Tests_Blocks_Render_Hooks extends WP_UnitTestCase {
 		remove_filter( 'do_blocks_post_render', $remove_wordpress_paragraph );
 
 		$wanted_output = do_blocks( $hello_block );
-		$this->assertSame( $wanted_output, $filtered_output, "Did not exclude the intended content before rendering." );
+		$this->assertSame( $wanted_output, $filtered_output, 'Did not exclude the intended content before rendering.' );
 	}
 }

--- a/tests/phpunit/tests/blocks/renderHooks.php
+++ b/tests/phpunit/tests/blocks/renderHooks.php
@@ -13,47 +13,49 @@ class Tests_Blocks_Render_Hooks extends WP_UnitTestCase {
 	 * @ticket 59131
 	 */
 	public function test_do_blocks_pre_render_filter() {
+		$remove_blocks_containing_wordpress = static function( $blocks ) {
+			foreach ( $blocks as $index => $block ) {
+				if ( strpos( $block['innerHTML'], 'WordPress' ) !== false ) {
+					unset( $blocks[ $index ] );
+				}
+			}
+			return $blocks;
+		};
+
 		$block_content = '
 			<!-- wp:core/paragraph --><p>Hello</p><!-- /wp:core/paragraph -->
 			<!-- wp:core/paragraph --><p>WordPress</p><!-- /wp:core/paragraph -->
 		';
 
-		add_filter( 'do_blocks_pre_render', array( $this, 'remove_blocks_containing_wordpress' ) );
+		add_filter( 'do_blocks_pre_render', $remove_blocks_containing_wordpress );
 
 		$result = do_blocks( $block_content );
 
-		remove_filter( 'do_blocks_pre_render', array( $this, 'remove_blocks_containing_wordpress' ) );
+		remove_filter( 'do_blocks_pre_render', $remove_blocks_containing_wordpress );
 
 		$this->assertSame( '<p>Hello</p>', trim( $result ) );
-	}
-	public function remove_blocks_containing_wordpress( $blocks ) {
-		foreach ( $blocks as $index => $block ) {
-			if ( strpos( $block['innerHTML'], 'WordPress' ) !== false ) {
-				unset( $blocks[ $index ] );
-			}
-		}
-		return $blocks;
 	}
 
 	/**
 	 * @ticket 59131
 	 */
 	public function test_do_blocks_post_render_filter() {
+		$remove_wordpress_paragraph = static function( $content ) {
+			$content = str_replace( '<p>WordPress</p>', '', $content );
+			return $content;
+		};
+
 		$block_content = '
 			<!-- wp:core/paragraph --><p>Hello</p><!-- /wp:core/paragraph -->
 			<!-- wp:core/paragraph --><p>WordPress</p><!-- /wp:core/paragraph -->
 		';
 
-		add_filter( 'do_blocks_post_render', array( $this, 'remove_wordpress_paragraph' ) );
+		add_filter( 'do_blocks_post_render', $remove_wordpress_paragraph );
 
 		$result = do_blocks( $block_content );
 
-		remove_filter( 'do_blocks_post_render', array( $this, 'remove_wordpress_paragraph' ) );
+		remove_filter( 'do_blocks_post_render', $remove_wordpress_paragraph );
 
 		$this->assertSame( '<p>Hello</p>', trim( $result ) );
-	}
-	public function remove_wordpress_paragraph( $content ) {
-		$content = str_replace( '<p>WordPress</p>', '', $content );
-		return $content;
 	}
 }

--- a/tests/phpunit/tests/blocks/renderHooks.php
+++ b/tests/phpunit/tests/blocks/renderHooks.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests for block rendering functions.
+ * Tests for the hooks of the block rendering functions.
  *
  * @package WordPress
  * @subpackage Blocks

--- a/tests/phpunit/tests/blocks/renderHooks.php
+++ b/tests/phpunit/tests/blocks/renderHooks.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Tests for block rendering functions.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ * @since 6.4.0
+ *
+ * @group blocks
+ */
+class Tests_Blocks_Render_Hooks extends WP_UnitTestCase {
+	/**
+	 * @ticket 59131
+	 */
+	public function test_do_blocks_pre_render_filter() {
+		$block_content = '
+			<!-- wp:core/paragraph --><p>Hello</p><!-- /wp:core/paragraph -->
+			<!-- wp:core/paragraph --><p>WordPress!</p><!-- /wp:core/paragraph -->
+		';
+
+		add_filter( 'do_blocks_pre_render', array( $this, 'do_blocks_pre_render_filter' ) );
+		
+		$result = do_blocks( $block_content );
+		
+		$this->assertSame( '<p>Hello</p>', trim( $result ) );
+		
+		remove_filter( 'do_blocks_pre_render', array( $this, 'do_blocks_pre_render_filter' ) );
+	}
+	public function do_blocks_pre_render_filter( $blocks ) {
+		foreach ( $blocks as $index => $block ) {
+			if ( strpos( $block['innerHTML'], 'WordPress' ) !== false ) {
+				unset( $blocks[$index] );
+			}
+		}
+		return $blocks;
+	}
+	
+	/**
+	 * @ticket 59131
+	 */
+	public function test_do_blocks_post_render_filter() {
+		$block_content = '
+			<!-- wp:core/paragraph --><p>Hello</p><!-- /wp:core/paragraph -->
+			<!-- wp:core/paragraph --><p>WordPress!</p><!-- /wp:core/paragraph -->
+		';
+
+		add_filter( 'do_blocks_post_render', array( $this, 'do_blocks_post_render_filter' ) );
+
+		$result = do_blocks( $block_content );
+
+		$this->assertSame( '<p>Hello</p>', trim( $result ) );
+
+		remove_filter( 'do_blocks_post_render', array( $this, 'do_blocks_post_render_filter' ) );
+	}
+	public function do_blocks_post_render_filter( $content ) {
+		$content = str_replace( '<p>WordPress!</p>', '', $content );
+		return $content;
+	}
+}

--- a/tests/phpunit/tests/blocks/renderHooks.php
+++ b/tests/phpunit/tests/blocks/renderHooks.php
@@ -15,18 +15,18 @@ class Tests_Blocks_Render_Hooks extends WP_UnitTestCase {
 	public function test_do_blocks_pre_render_filter() {
 		$block_content = '
 			<!-- wp:core/paragraph --><p>Hello</p><!-- /wp:core/paragraph -->
-			<!-- wp:core/paragraph --><p>WordPress!</p><!-- /wp:core/paragraph -->
+			<!-- wp:core/paragraph --><p>WordPress</p><!-- /wp:core/paragraph -->
 		';
 
-		add_filter( 'do_blocks_pre_render', array( $this, 'do_blocks_pre_render_filter' ) );
+		add_filter( 'do_blocks_pre_render', array( $this, 'remove_blocks_containing_wordpress' ) );
 
 		$result = do_blocks( $block_content );
 
-		remove_filter( 'do_blocks_pre_render', array( $this, 'do_blocks_pre_render_filter' ) );
+		remove_filter( 'do_blocks_pre_render', array( $this, 'remove_blocks_containing_wordpress' ) );
 
 		$this->assertSame( '<p>Hello</p>', trim( $result ) );
 	}
-	public function do_blocks_pre_render_filter( $blocks ) {
+	public function remove_blocks_containing_wordpress( $blocks ) {
 		foreach ( $blocks as $index => $block ) {
 			if ( strpos( $block['innerHTML'], 'WordPress' ) !== false ) {
 				unset( $blocks[ $index ] );
@@ -41,19 +41,19 @@ class Tests_Blocks_Render_Hooks extends WP_UnitTestCase {
 	public function test_do_blocks_post_render_filter() {
 		$block_content = '
 			<!-- wp:core/paragraph --><p>Hello</p><!-- /wp:core/paragraph -->
-			<!-- wp:core/paragraph --><p>WordPress!</p><!-- /wp:core/paragraph -->
+			<!-- wp:core/paragraph --><p>WordPress</p><!-- /wp:core/paragraph -->
 		';
 
-		add_filter( 'do_blocks_post_render', array( $this, 'do_blocks_post_render_filter' ) );
+		add_filter( 'do_blocks_post_render', array( $this, 'remove_wordpress_paragraph' ) );
 
 		$result = do_blocks( $block_content );
 
-		remove_filter( 'do_blocks_post_render', array( $this, 'do_blocks_post_render_filter' ) );
+		remove_filter( 'do_blocks_post_render', array( $this, 'remove_wordpress_paragraph' ) );
 
 		$this->assertSame( '<p>Hello</p>', trim( $result ) );
 	}
-	public function do_blocks_post_render_filter( $content ) {
-		$content = str_replace( '<p>WordPress!</p>', '', $content );
+	public function remove_wordpress_paragraph( $content ) {
+		$content = str_replace( '<p>WordPress</p>', '', $content );
 		return $content;
 	}
 }

--- a/tests/phpunit/tests/blocks/renderHooks.php
+++ b/tests/phpunit/tests/blocks/renderHooks.php
@@ -22,9 +22,9 @@ class Tests_Blocks_Render_Hooks extends WP_UnitTestCase {
 
 		$result = do_blocks( $block_content );
 
-		$this->assertSame( '<p>Hello</p>', trim( $result ) );
-
 		remove_filter( 'do_blocks_pre_render', array( $this, 'do_blocks_pre_render_filter' ) );
+
+		$this->assertSame( '<p>Hello</p>', trim( $result ) );
 	}
 	public function do_blocks_pre_render_filter( $blocks ) {
 		foreach ( $blocks as $index => $block ) {
@@ -48,9 +48,9 @@ class Tests_Blocks_Render_Hooks extends WP_UnitTestCase {
 
 		$result = do_blocks( $block_content );
 
-		$this->assertSame( '<p>Hello</p>', trim( $result ) );
-
 		remove_filter( 'do_blocks_post_render', array( $this, 'do_blocks_post_render_filter' ) );
+
+		$this->assertSame( '<p>Hello</p>', trim( $result ) );
 	}
 	public function do_blocks_post_render_filter( $content ) {
 		$content = str_replace( '<p>WordPress!</p>', '', $content );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

The `do_blocks()` function provides a way to process blocks including block parsing and their subsequent rendering. Currently, it is impossible for plugins (including Gutenberg) to inspect those values or customize that logic.  

A couple of filters should be introduced that allow to modify or inspect the blocks before they are included in the final response:  

- The first one receives the array of parsed blocks returned by the `parse_blocks` function. This filter provides an easy way to inspect or even modify the blocks as a whole, and also gives the opportunity to know when a call to `do_blocks` has started.
- The second one receives the final HTML rendered returned by the recursive call to `render_block`. This filter provides an easy way to inspect or even modify the final rendered output as whole, and also gives the opportunity to know when a call to `do_blocks` is about to finish.

With the combination of these two filters, it's also possible to ignore nested calls of `do_blocks` and avoid processing the HTML of blocks more than once, something that is not possible today using `render_block` alone.  

---

Trac ticket: https://core.trac.wordpress.org/ticket/59131

#### Questions

- ~~Do I need to add tests for these filters?~~ (done)
- Are the `do_blocks_pre/post_render` filter names ok?
- @dmsnell: is this what you had in mind, or is there something missing?