### PR TITLE
Fixed quick edit dates for draft posts

### DIFF
--- a/src/wp-admin/includes/post.php
+++ b/src/wp-admin/includes/post.php
@@ -171,6 +171,16 @@ function _wp_translate_postdata( $update = false, $post_data = null ) {
 		}
 	}
 
+	if ( isset( $post_data['action'] ) && 'inline-save' === $post_data['action'] ) {
+		$post_data['edit_date'] = '1';
+		foreach ( array( 'aa', 'mm', 'jj', 'hh', 'mn' ) as $timeunit ) {
+			if ( ! isset( $post_data[ $timeunit ] ) ) {
+				$post_data['edit_date'] = false;
+				break;
+			}
+		}
+	}
+
 	if ( isset( $post_data['edit_date'] ) && 'false' === $post_data['edit_date'] ) {
 		$post_data['edit_date'] = false;
 	}

--- a/tests/phpunit/tests/ajax/wpAjaxInlineSave.php
+++ b/tests/phpunit/tests/ajax/wpAjaxInlineSave.php
@@ -95,7 +95,7 @@ class Tests_Ajax_wpAjaxInlineSave extends WP_Ajax_UnitTestCase {
 	 *
 	 * @covers ::edit_post
 	 */
-	public function test_quick_edit_draft_should_not_set_publish_date() {
+	public function test_quick_edit_draft_should_set_post_date() {
 		// Become an administrator.
 		$this->_setRole( 'administrator' );
 

--- a/tests/phpunit/tests/ajax/wpAjaxInlineSave.php
+++ b/tests/phpunit/tests/ajax/wpAjaxInlineSave.php
@@ -89,9 +89,9 @@ class Tests_Ajax_wpAjaxInlineSave extends WP_Ajax_UnitTestCase {
 	}
 
 	/**
-	 * When updating a draft in quick edit mode, it should not set the publish date of the post when this one will be published.
+	 * When updating a draft in quick edit mode, it should set the post date if the date submitted.
 	 *
-	 * @ticket 19907
+	 * @ticket 59125
 	 *
 	 * @covers ::edit_post
 	 */
@@ -140,6 +140,6 @@ class Tests_Ajax_wpAjaxInlineSave extends WP_Ajax_UnitTestCase {
 
 		$post = get_post( $post->ID );
 
-		$this->assertEquals( '0000-00-00 00:00:00', $post->post_date_gmt );
+		$this->assertEquals( '2020-09-11 19:20:11', $post->post_date_gmt );
 	}
 }


### PR DESCRIPTION
Hello,

I've added a condition to `_wp_translate_postdata()` which allow to save the date for draft posts with the quick edit form. 
Please review.

Trac ticket: https://core.trac.wordpress.org/ticket/59125
