### PR TITLE
Add `wp_get_theme_data_custom_templates`

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -411,7 +411,7 @@ function _add_block_template_info( $template_item ) {
 		return $template_item;
 	}
 
-	$theme_data = WP_Theme_JSON_Resolver::get_theme_data( array(), array( 'with_supports' => false ) )->get_custom_templates();
+	$theme_data = wp_get_theme_data_custom_templates();
 	if ( isset( $theme_data[ $template_item['slug'] ] ) ) {
 		$template_item['title']     = $theme_data[ $template_item['slug'] ]['title'];
 		$template_item['postTypes'] = $theme_data[ $template_item['slug'] ]['postTypes'];

--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -442,6 +442,17 @@ function wp_get_theme_directory_pattern_slugs() {
 }
 
 /**
+ * Returns the metadata for the custom templates defined by the theme via theme.json.
+ *
+ * @since 6.4.0
+ *
+ * @return array
+ */
+function wp_get_theme_data_custom_templates() {
+	WP_Theme_JSON_Resolver::get_theme_data( array(), array( 'with_supports' => false ) )->get_custom_templates();
+}
+
+/**
  * Returns the metadata for the template parts defined by the theme.
  *
  * @since 6.4.0

--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -446,7 +446,8 @@ function wp_get_theme_directory_pattern_slugs() {
  *
  * @since 6.4.0
  *
- * @return array Associative array of `$template_name => $template_data` pairs, with `$template_data` having "title" and "postTypes" fields.
+ * @return array Associative array of `$template_name => $template_data` pairs,
+ *               with `$template_data` having "title" and "postTypes" fields.
  */
 function wp_get_theme_data_custom_templates() {
 	return WP_Theme_JSON_Resolver::get_theme_data( array(), array( 'with_supports' => false ) )->get_custom_templates();

--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -446,7 +446,7 @@ function wp_get_theme_directory_pattern_slugs() {
  *
  * @since 6.4.0
  *
- * @return array
+ * @return array Associative array of `$template_name => $template_data` pairs, with `$template_data` having "title" and "postTypes" fields.
  */
 function wp_get_theme_data_custom_templates() {
 	return WP_Theme_JSON_Resolver::get_theme_data( array(), array( 'with_supports' => false ) )->get_custom_templates();

--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -449,7 +449,7 @@ function wp_get_theme_directory_pattern_slugs() {
  * @return array
  */
 function wp_get_theme_data_custom_templates() {
-	WP_Theme_JSON_Resolver::get_theme_data( array(), array( 'with_supports' => false ) )->get_custom_templates();
+	return WP_Theme_JSON_Resolver::get_theme_data( array(), array( 'with_supports' => false ) )->get_custom_templates();
 }
 
 /**


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/45171
Trac ticket: https://core.trac.wordpress.org/ticket/59137

## What

This PR adds a new public function `wp_get_theme_data_custom_templates` to offer access to metadata stored under `customTemplates` in `theme.json`.

## Why

There is a no public function to get access to that data, so consumers need to resort to private APIs. This follows the steps of `wp_get_global_settings`, `wp_theme_has_theme_json`, `wp_get_theme_directory_pattern_slugs`, and `wp_get_theme_data_template_parts`.

## How

It creates a new function that uses the private calls and substitutes all the instances of the old one in the codebase.

## How to test

TBD.

## Commit message

```
Themes: add `wp_get_theme_data_custom_templates` function.

Adds a new public function, `wp_get_theme_data_custom_templates` that returns the `customTemplates` defined by the active theme from `theme.json`. It also substitutes the usage of private APIs by this new API.

Props johnbillion, audrasjb.
Fixes #59137
```