### PR TITLE
Add missing @ to return tag in `wp_get_theme_data_template_parts`

### DIFF
--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -446,7 +446,8 @@ function wp_get_theme_directory_pattern_slugs() {
  *
  * @since 6.4.0
  *
- * return array Associative array of `$part_name => $part_data` pairs, with `$part_data` having "title" and "area" fields.
+ * @return array Associative array of `$part_name => $part_data` pairs,
+ *               with `$part_data` having "title" and "area" fields.
  */
 function wp_get_theme_data_template_parts() {
 	$cache_group    = 'theme_json';


### PR DESCRIPTION
Trac ticket https://core.trac.wordpress.org/ticket/59003

```txt
Add missing `@` to the return tag in the `wp_get_theme_data_template_parts` function.

Props audrasjb, johnbillion.
Fixes #59003
```