### PR TITLE
Reverted last occurrence of str_starts_with() in update-core.php

### DIFF
--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -1431,9 +1431,13 @@ function update_core( $from, $to ) {
 		} else {
 			$lang_dir = WP_CONTENT_DIR . '/languages';
 		}
-
+		/*
+		 * Note: str_starts_with() is not used here, as this file is included
+		 * when updating from older WordPress versions, in which case
+		 * the polyfills from wp-includes/compat.php may not be available.
+		 */
 		// Check if the language directory exists first.
-		if ( ! @is_dir( $lang_dir ) && str_starts_with( $lang_dir, ABSPATH ) ) {
+		if ( ! @is_dir( $lang_dir ) && 0 === strpos( $lang_dir, ABSPATH ) ) {
 			// If it's within the ABSPATH we can handle it here, otherwise they're out of luck.
 			$wp_filesystem->mkdir( $to . str_replace( ABSPATH, '', $lang_dir ), FS_CHMOD_DIR );
 			clearstatcache(); // For FTP, need to clear the stat cache.


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Quoting: @azaozz 
> Fixes updating WordPress from 5.7 and earlier versions. When updating this file runs first in the old version where the polifills may not be available.

In commit 45363a5 the use of `str_starts_with()` has been reverted everywhere but from [line 1429](https://github.com/WordPress/wordpress-develop/commit/45363a59765611b8348c73e062fb8520c282cd7b#diff-f68ba9503d4987be6509ad375b12b197e75f7e13aaeb24cc13f0d4a7eb41ddfbR1429)
That line raise a `Fatal error: Uncaught Error: Call to undefined function str_starts_with() [...]` when upgrading from < 5.7  

https://core.trac.wordpress.org/ticket/58206

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
