### PR TITLE
Unit tests for resetting email with apostrophe

### DIFF
--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -2095,6 +2095,9 @@ function wp_insert_user( $userdata ) {
 			return new WP_Error( 'invalid_user_id', __( 'Invalid user ID.' ) );
 		}
 
+		// Prevent failures in comparisons later.
+		$old_user_data->user_email = wp_slash( $old_user_data->user_email );
+
 		// Hashed in wp_update_user(), plaintext if called directly.
 		$user_pass = ! empty( $userdata['user_pass'] ) ? $userdata['user_pass'] : $old_user_data->user_pass;
 	} else {

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -2978,6 +2978,8 @@ function check_password_reset_key( $key, $login ) {
 
 	$user = get_user_by( 'login', $login );
 
+	$login = wp_unslash( $login );
+
 	if ( ! $user ) {
 		return new WP_Error( 'invalid_key', __( 'Invalid key.' ) );
 	}

--- a/tests/phpunit/tests/auth.php
+++ b/tests/phpunit/tests/auth.php
@@ -449,7 +449,7 @@ class Tests_Auth extends WP_UnitTestCase {
 	 */
 	public function test_reset_password_with_apostrophe_in_email() {
 		$user_args = array(
-			'user_email' => "mail\'@example.com",
+			'user_email' => "mail@example.com",
 			'user_pass'  => 'password',
 		);
 		$user_id = self::factory()->user->create( $user_args );

--- a/tests/phpunit/tests/auth.php
+++ b/tests/phpunit/tests/auth.php
@@ -445,6 +445,24 @@ class Tests_Auth extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 52529
+	 */
+	public function test_reset_password_with_apostrophe_in_email() {
+		$user_args = array(
+			'user_email' => "mail\'@example.com",
+			'user_pass'  => 'password',
+		);
+		$user_id = self::factory()->user->create( $user_args );
+
+		$key = get_password_reset_key( get_user_by( 'id', $user_id ) );
+
+		$check = check_password_reset_key( $key, $user_args['user_email'] );
+		$this->assertNotWPError( $check );
+		$this->assertInstanceOf( 'WP_User', $check );
+		$this->assertSame( $user_id, $check->ID );
+	}
+
+	/**
 	 * Tests that PHP 8.1 "passing null to non-nullable" deprecation notices
 	 * are not thrown when `user_login` and `user_password` parameters are empty.
 	 *


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Unit tests for resetting email with an apostrophe

Trac ticket: https://core.trac.wordpress.org/ticket/52529

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
