### PR TITLE
Twenty Twenty: fix Table block border colors (both default and custom)

### DIFF
--- a/src/wp-content/themes/twentytwenty/assets/css/editor-style-block-rtl.css
+++ b/src/wp-content/themes/twentytwenty/assets/css/editor-style-block-rtl.css
@@ -532,6 +532,10 @@ Inter variable font. Usage:
 	border-color: #dcd7ca;
 }
 
+.editor-styles-wrapper .wp-block-table table:where(.has-text-color) * {
+	border-color: currentColor;
+}
+
 .editor-styles-wrapper .wp-block-table tr {
 	border: none;
 }

--- a/src/wp-content/themes/twentytwenty/assets/css/editor-style-block.css
+++ b/src/wp-content/themes/twentytwenty/assets/css/editor-style-block.css
@@ -536,6 +536,10 @@ Inter variable font. Usage:
 	border-color: #dcd7ca;
 }
 
+.editor-styles-wrapper .wp-block-table table:where(.has-text-color) * {
+	border-color: currentColor;
+}
+
 .editor-styles-wrapper .wp-block-table tr {
 	border: none;
 }

--- a/src/wp-content/themes/twentytwenty/style-rtl.css
+++ b/src/wp-content/themes/twentytwenty/style-rtl.css
@@ -3356,6 +3356,14 @@ hr.wp-block-separator {
 
 /* Block: Table ------------------------------ */
 
+.wp-block-table table * {
+	border-color: inherit;
+}
+
+.wp-block-table table:where(.has-text-color) * {
+	border-color: currentColor;
+}
+
 .wp-block-table.is-style-stripes tbody tr:nth-child(odd) {
 	background: #dcd7ca;
 }

--- a/src/wp-content/themes/twentytwenty/style-rtl.css
+++ b/src/wp-content/themes/twentytwenty/style-rtl.css
@@ -3356,12 +3356,8 @@ hr.wp-block-separator {
 
 /* Block: Table ------------------------------ */
 
-.wp-block-table table * {
+.wp-block-table table:where(:not(.has-text-color)) * {
 	border-color: inherit;
-}
-
-.wp-block-table table:where(.has-text-color) * {
-	border-color: currentColor;
 }
 
 .wp-block-table.is-style-stripes tbody tr:nth-child(odd) {

--- a/src/wp-content/themes/twentytwenty/style.css
+++ b/src/wp-content/themes/twentytwenty/style.css
@@ -3376,12 +3376,8 @@ hr.wp-block-separator {
 
 /* Block: Table ------------------------------ */
 
-.wp-block-table table * {
+.wp-block-table table:where(:not(.has-text-color)) * {
 	border-color: inherit;
-}
-
-.wp-block-table table:where(.has-text-color) * {
-	border-color: currentColor;
 }
 
 .wp-block-table.is-style-stripes tbody tr:nth-child(odd) {

--- a/src/wp-content/themes/twentytwenty/style.css
+++ b/src/wp-content/themes/twentytwenty/style.css
@@ -3376,6 +3376,14 @@ hr.wp-block-separator {
 
 /* Block: Table ------------------------------ */
 
+.wp-block-table table * {
+	border-color: inherit;
+}
+
+.wp-block-table table:where(.has-text-color) * {
+	border-color: currentColor;
+}
+
 .wp-block-table.is-style-stripes tbody tr:nth-child(odd) {
 	background: #dcd7ca;
 }


### PR DESCRIPTION
Combines code from 58022.2.patch and 58022.alternative.patch, moving editor style change earlier in the stylesheet.

- On the front end, the change restores the theme's default border color when (and only when) the block's text color is the default. This overrides [Table block cell styles added in WordPress 6.1.1](https://github.com/WordPress/gutenberg/blob/16dcc04a63dd250f89f3bf75b21b6fd10adabe47/packages/block-library/src/table/style.scss#L25) (GB45069).
- In the editor, these styles repurpose the user-selected color for the border, to match the front.

Editor with patch:
![Table blocks with a special text color use the same for the border](https://github.com/WordPress/wordpress-develop/assets/17100257/77cf2e4a-fbcb-4902-b621-d1c08b0f4d6b)

Front end with patch:
![Table blocks with default text color have a light brown border](https://github.com/WordPress/wordpress-develop/assets/17100257/a58d0e58-9c31-4fab-94d6-0596c028a219)

[Trac 58022](https://core.trac.wordpress.org/ticket/58022)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
