### PR TITLE
PHPCS: improve the PHPCompatibility ruleset

### DIFF
--- a/phpcompat.xml.dist
+++ b/phpcompat.xml.dist
@@ -2,10 +2,12 @@
 <ruleset name="WordPress PHP Compatibility">
 	<description>Apply PHP compatibility checks to all WordPress Core files</description>
 
-	<rule ref="PHPCompatibilityWP"/>
-
-	<!-- WordPress Core currently supports PHP 7.0+. -->
-	<config name="testVersion" value="7.0-"/>
+	<!--
+	#############################################################################
+	COMMAND LINE ARGUMENTS
+	https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-Ruleset
+	#############################################################################
+	-->
 
 	<!-- Only scan PHP files. -->
 	<arg name="extensions" value="php"/>
@@ -28,6 +30,13 @@
 	<!-- Show sniff codes in all reports. -->
 	<arg value="ps"/>
 
+	<!--
+	#############################################################################
+	FILE SELECTION
+	Set which files will be subject to the scans executed using this ruleset.
+	#############################################################################
+	-->
+
 	<!-- For now, only the files in src are scanned. -->
 	<file>./src/</file>
 
@@ -40,13 +49,13 @@
 	-->
 	<exclude-pattern>/vendor/*</exclude-pattern>
 
-	<!-- Must-Use plugins. -->
+	<!-- But not Must-Use plugins. -->
 	<exclude-pattern>/src/wp-content/mu-plugins/*</exclude-pattern>
 
-	<!-- Plugins. -->
+	<!-- Nor Plugins. -->
 	<exclude-pattern>/src/wp-content/plugins/*</exclude-pattern>
 
-	<!-- Themes except the twenty* themes. -->
+	<!-- Nor Themes except the twenty* themes. -->
 	<exclude-pattern>/src/wp-content/themes/(?!twenty)*</exclude-pattern>
 
 	<!--
@@ -54,6 +63,24 @@
 		However, because these files are included in a non-standard path, false positives are triggered in WordPress Core.
 	-->
 	<exclude-pattern>src/wp-includes/sodium_compat/lib/php72compat_const\.php$</exclude-pattern>
+
+	<!--
+	#############################################################################
+	SET UP THE RULESET
+	#############################################################################
+	-->
+
+	<rule ref="PHPCompatibilityWP"/>
+
+	<!-- WordPress Core currently supports PHP 7.0+. -->
+	<config name="testVersion" value="7.0-"/>
+
+	<!--
+	#############################################################################
+	SELECTIVE EXCLUSIONS
+	Exclude specific files for specific sniffs and/or exclude sub-groups in sniffs.
+	#############################################################################
+	-->
 
 	<rule ref="PHPCompatibility.FunctionUse.NewFunctions.sodium_crypto_sign_keypair_from_secretkey_and_publickeyFound">
 		<exclude-pattern>/sodium_compat/src/Compat\.php$</exclude-pattern>
@@ -81,4 +108,5 @@
 	<rule ref="PHPCompatibility.FunctionUse.RemovedFunctions.mcrypt_create_ivDeprecatedRemoved">
 		<exclude-pattern>/random_compat/random_bytes_mcrypt\.php$</exclude-pattern>
 	</rule>
+
 </ruleset>

--- a/phpcompat.xml.dist
+++ b/phpcompat.xml.dist
@@ -40,15 +40,6 @@
 	<!-- For now, only the files in src are scanned. -->
 	<file>./src/</file>
 
-	<!-- Code which doesn't go into production may have different requirements. -->
-	<exclude-pattern>/node_modules/*</exclude-pattern>
-
-	<!--
-		Currently, there are no dependencies managed by Composer.
-		This will need to be modified when that changes to ensure external packages meet compatibility requirements.
-	-->
-	<exclude-pattern>/vendor/*</exclude-pattern>
-
 	<!-- But not Must-Use plugins. -->
 	<exclude-pattern>/src/wp-content/mu-plugins/*</exclude-pattern>
 
@@ -90,23 +81,6 @@
 	</rule>
 	<rule ref="PHPCompatibility.FunctionUse.NewFunctions.sodium_unpadFound">
 		<exclude-pattern>/sodium_compat/src/Compat\.php$</exclude-pattern>
-	</rule>
-
-	<!--
-		PHPCompatibilityParagonieRandomCompat prevents false positives in `random_compat`.
-		However, because these files are included in a non-standard path, false positives are triggered in WordPress Core.
-	-->
-	<rule ref="PHPCompatibility.IniDirectives.RemovedIniDirectives.mbstring_func_overloadDeprecated">
-		<exclude-pattern>/random_compat/byte_safe_strings\.php$</exclude-pattern>
-	</rule>
-	<rule ref="PHPCompatibility.Constants.RemovedConstants.mcrypt_dev_urandomDeprecatedRemoved">
-		<exclude-pattern>/random_compat/random_bytes_mcrypt\.php$</exclude-pattern>
-	</rule>
-	<rule ref="PHPCompatibility.Extensions.RemovedExtensions.mcryptDeprecatedRemoved">
-		<exclude-pattern>/random_compat/random_bytes_mcrypt\.php$</exclude-pattern>
-	</rule>
-	<rule ref="PHPCompatibility.FunctionUse.RemovedFunctions.mcrypt_create_ivDeprecatedRemoved">
-		<exclude-pattern>/random_compat/random_bytes_mcrypt\.php$</exclude-pattern>
 	</rule>
 
 </ruleset>


### PR DESCRIPTION
### PHPCS: improve organisation of the PHPCompatibility ruleset

No functional changes.

This commit:
* Adds section headers to the ruleset file.
* Organizes all directives in their respective sections.

### PHPCS: remove unnecessary directives in PHPCompatibility ruleset

This commit:
* Removes the unnecessary exclusion patterns for the `node_modules` and the `vendor` directory.
    As this ruleset only scans the `src` directory, those directories would never be scanned anyway.
* Removes the selective excludes related to the Random Compat package.
    This package was removed in WP 6.3, so these excludes are no longer necessary.

--- 

Trac ticket: https://core.trac.wordpress.org/ticket/58831

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
