### PR TITLE
PHP Deprecated: ltrim(): Passing null to parameter #59154

### DIFF
--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -2511,12 +2511,8 @@ function get_next_posts_page_link( $max_page = 0 ) {
  * @return string|void The link URL for next posts page if `$display = false`.
  */
 function next_posts( $max_page = 0, $display = true ) {
-	$link = get_next_posts_page_link( $max_page );
-
-	$output = '';
-	if ( $link ) {
-		$output = esc_url( $link );
-	}
+	$link   = get_next_posts_page_link( $max_page );
+	$output = $link ? esc_url( $link ) : '';
 
 	if ( $display ) {
 		echo $output;

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -2511,7 +2511,12 @@ function get_next_posts_page_link( $max_page = 0 ) {
  * @return string|void The link URL for next posts page if `$display = false`.
  */
 function next_posts( $max_page = 0, $display = true ) {
-	$output = esc_url( get_next_posts_page_link( $max_page ) );
+	$link = get_next_posts_page_link( $max_page );
+
+	$output = '';
+	if ( $link ) {
+		$output = esc_url( $link );
+	}
 
 	if ( $display ) {
 		echo $output;

--- a/tests/phpunit/tests/link/nextPosts.php
+++ b/tests/phpunit/tests/link/nextPosts.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Tests the `next_posts()` function.
+ *
+ * @since 6.4.0
+ *
+ * @group link
+ *
+ * @covers ::next_posts
+ */
+class Tests_Link_NextPosts extends WP_UnitTestCase {
+
+	/**
+	 * Creates posts before any tests run.
+	 *
+	 * @param WP_UnitTest_Factory $factory
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		global $wp_query, $paged;
+
+		$factory->post->create_many( 3 );
+		$paged    = 2;
+		$wp_query = new WP_Query(
+			array(
+				'post_type'      => 'post',
+				'posts_per_page' => 1,
+				'paged'          => $paged,
+			)
+		);
+	}
+
+	/**
+	 * The absence of a deprecation notice on PHP 8.1+ also shows that the issue is resolved.
+	 *
+	 * @ticket 59154
+	 */
+	public function test_should_return_empty_string_when_no_next_posts_page_link() {
+		$this->assertSame( '', next_posts( 1, false ) );
+	}
+}


### PR DESCRIPTION
I added a check before filtering the link using the esc_url function.

function next_posts( $max_page = 0, $display = true ) {
	$link = get_next_posts_page_link( $max_page );

	$output = '';
	if ( $link ) {
		$output = esc_url( $link );
	}

	if ( $display ) {
		echo $output;
	} else {
		return $output;
	}
}

Trac ticket: 59154