### PR TITLE
Upgrade to WordPressCS 3.0.0

### DIFF
--- a/src/wp-includes/blocks/calendar.php
+++ b/src/wp-includes/blocks/calendar.php
@@ -33,10 +33,8 @@ function render_block_core_calendar( $attributes ) {
 			str_contains( $permalink_structure, '%monthnum%' ) &&
 			str_contains( $permalink_structure, '%year%' )
 		) {
-			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited
 			$monthnum = $attributes['month'];
-			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited
-			$year = $attributes['year'];
+			$year     = $attributes['year'];
 		}
 	}
 
@@ -70,10 +68,8 @@ function render_block_core_calendar( $attributes ) {
 		$calendar
 	);
 
-	// phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited
 	$monthnum = $previous_monthnum;
-	// phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited
-	$year = $previous_year;
+	$year     = $previous_year;
 
 	return $output;
 }

--- a/src/wp-includes/class-wp-block-parser-block.php
+++ b/src/wp-includes/class-wp-block-parser-block.php
@@ -21,7 +21,7 @@ class WP_Block_Parser_Block {
 	 * @since 5.0.0
 	 * @var string
 	 */
-	public $blockName; // phpcs:ignore WordPress.NamingConventions.ValidVariableName
+	public $blockName;
 
 	/**
 	 * Optional set of attributes from block comment delimiters
@@ -40,7 +40,7 @@ class WP_Block_Parser_Block {
 	 * @since 5.0.0
 	 * @var WP_Block_Parser_Block[]
 	 */
-	public $innerBlocks; // phpcs:ignore WordPress.NamingConventions.ValidVariableName
+	public $innerBlocks;
 
 	/**
 	 * Resultant HTML from inside block comment delimiters
@@ -51,7 +51,7 @@ class WP_Block_Parser_Block {
 	 * @since 5.0.0
 	 * @var string
 	 */
-	public $innerHTML; // phpcs:ignore WordPress.NamingConventions.ValidVariableName
+	public $innerHTML;
 
 	/**
 	 * List of string fragments and null markers where inner blocks were found
@@ -65,7 +65,7 @@ class WP_Block_Parser_Block {
 	 * @since 4.2.0
 	 * @var array
 	 */
-	public $innerContent; // phpcs:ignore WordPress.NamingConventions.ValidVariableName
+	public $innerContent;
 
 	/**
 	 * Constructor.
@@ -81,10 +81,10 @@ class WP_Block_Parser_Block {
 	 * @param array  $inner_content List of string fragments and null markers where inner blocks were found.
 	 */
 	public function __construct( $name, $attrs, $inner_blocks, $inner_html, $inner_content ) {
-		$this->blockName    = $name;          // phpcs:ignore WordPress.NamingConventions.ValidVariableName
+		$this->blockName    = $name;
 		$this->attrs        = $attrs;
-		$this->innerBlocks  = $inner_blocks;  // phpcs:ignore WordPress.NamingConventions.ValidVariableName
-		$this->innerHTML    = $inner_html;    // phpcs:ignore WordPress.NamingConventions.ValidVariableName
-		$this->innerContent = $inner_content; // phpcs:ignore WordPress.NamingConventions.ValidVariableName
+		$this->innerBlocks  = $inner_blocks;
+		$this->innerHTML    = $inner_html;
+		$this->innerContent = $inner_content;
 	}
 }


### PR DESCRIPTION
### CS: align equal signs for consecutive statements (pre-existing)

### Composer: update CS dependencies

WordPressCS 3.0.0 has been released.

This commit updates the Composer dependencies to use the new version, including updating the underlying PHP_CodeSniffer dependency to the new minimum supported version for WPCS.

Note: the Composer PHPCS installer plugin is no longer explicitly required as it is now a dependency of WordPressCS, so we inherit the dependency automatically.

### PHPCS: improve organisation of the WordPressCS based PHPCS ruleset

No functional changes.

This commit:
* Adds section headers to the ruleset file.
* Organizes all directives in their respective sections.

### PHPCS: update the ruleset for WordPressCS 3.0.0

This commit:
* Raises the memory limit to be on the safe side as WPCS 3.0.0 contains a lot more sniffs.
* Removes explicit inclusions of extra rules, which have now been added to the `WordPress-Core` ruleset..
* Updates property names for select sniffs.
* Updates one exclusion - the `WordPress.CodeAnalysis.AssignmentInCondition` sniff has been (partially) replaced by the `Generic.CodeAnalysis.AssignmentInCondition` sniff.
* Adds one new exclusion.

### PHPCS: remove the custom property for the FileName sniff

Test files should comply with the naming conventions accepted by PHPUnit, not with the WP naming conventions.

While the `WordPress.File.FileName` sniff makes a best effort to prevent throwing errors for files containing test classes, the recommended manner to deal with test files is to exclude the complete test directory from being subject to this sniff.

This updates the ruleset to follow the recommendation.

### PHPCS: downgrade one new error to a warning

The `Generic.Files.OneObjectStructurePerFile` sniff enforces that there is only one OO structure declaration per file.

At this time, this sniff would yield 29 errors.

By downgrading the sniff to a _warning_, the build can pass and we buy ourselves time to fix these 29 issues.

For the time being, the test directory will be excluded until the issues are fixed (as the test directory CS run does not allow for warnings).

### CS: update ignore annotations for WPCS 3.0.0

### CS: remove redundant ignore annotations [1] / never needed

Remove ignore annotations which are ignoring an error which would not be thrown for that code.

Includes tidying up the format of the ignore annotation:
* Customary one space between the `//` and the start of the comment.
* There should be no spaces in the comma-separated sniff list.

### CS: remove redundant ignore annotations [2] / not needed

Remove ignore annotations which are unnecessary due to the configuration in the `phpcs.xml.dist` ruleset already taking care of this.

### CS: remove redundant ignore annotations [3] / no longer needed

Remove ignore annotations about invalid function names for deprecated functions. Those are ignored by design by WPCS since version 2.2.0.

### CS: remove redundant ignore annotations [4] / Unused WPCS rules

Remove ignore annotations related to sniffs which are not used by WP Core (like sniffs which are in the `WordPress-Extra` ruleset).

### CS: remove redundant ignore annotations [5] / Non-WPCS rules

The `VariableAnalysis` standard is not used by WP Core.

### CS: use pre-[in|de]crement instead of post-[in|de]crement for stand-alone statements

### CS: remove superfluous blank line(s) at end of file

### CS: remove redundant blank line(s) at end of classes

### CS: remove redundant blank line(s) at end of functions

### CS: fix spacing for spread operators

No space allowed between the operator and the variable it applies to.

### Modernize: use dirname() with the $levels parameter

PHP 7.0 introduced the `$levels` parameter to the `dirname()` function, which means nested calls to `dirname()` are no longer needed.

Ref: https://www.php.net/manual/en/function.dirname.php

### CS: one space after function keyword for closures

### CS: remove redundant semi-colons

As these are not closures/anonymous classes, these semi-colons are redundant and create an empty PHP statement.

### 🆕 QA: don't use reserved keyword as parameter in newly introduced function

Introduced via Trac 41125.

### GH Actions: tweak coding standards workflow

The PHPCS run can now be run on the latest PHP version as all known PHP 8.x compatibility issues (in WPCS) have been fixed.

Trac ticket: https://core.trac.wordpress.org/ticket/59161

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
