### PR TITLE
HTML API: Stop proceeding HTML when encountering unsupported markup.

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -432,6 +432,11 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * @return bool Whether a tag was matched.
 	 */
 	public function step( $node_to_process = self::PROCESS_NEXT_NODE ) {
+		// Refuse to proceed if there was a previous error.
+		if ( null !== $this->last_error ) {
+			return false;
+		}
+
 		if ( self::PROCESS_NEXT_NODE === $node_to_process ) {
 			$top_node = $this->state->stack_of_open_elements->current_node();
 			if ( $top_node && self::is_void( $top_node->node_name ) ) {
@@ -744,6 +749,10 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * @return string|null Name of currently matched tag in input HTML, or `null` if none found.
 	 */
 	public function get_tag() {
+		if ( null !== $this->last_error ) {
+			return null;
+		}
+
 		$tag_name = parent::get_tag();
 
 		switch ( $tag_name ) {

--- a/tests/phpunit/tests/html-api/wpHtmlProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessor.php
@@ -43,6 +43,40 @@ class Tests_HtmlApi_WpHtmlProcessor extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Once stepping to the end of the document, WP_HTML_Processor::get_tag
+	 * should no longer report a tag. It should report `null` because there
+	 * is no tag matched or open.
+	 *
+	 * @ticket {TICKET_NUMBER}
+	 *
+	 * @covers WP_HTML_Processor::get_tag
+	 */
+	public function test_get_tag_is_null_once_document_is_finished() {
+		$p = WP_HTML_Processor::createFragment( '<div class="test">Test</div>' );
+		$p->next_tag();
+		$this->assertSame( 'DIV', $p->get_tag() );
+
+		$this->assertFalse( $p->next_tag() );
+		$this->assertNull( $p->get_tag() );
+	}
+
+	/**
+	 * Ensures that if the HTML Processor encounters inputs that it can't properly handle,
+	 * that it stops processing the rest of the document. This prevents data corruption.
+	 *
+	 * @ticket {TICKET_NUMBER}
+	 *
+	 * @covers WP_HTML_Processor::next_tag
+	 */
+	public function test_stops_processing_after_unsupported_elements() {
+		$p = WP_HTML_Processor::createFragment( '<p><x-not-supported></p><p></p>' );
+		$p->next_tag( 'P' );
+		$this->assertFalse( $p->next_tag(), 'Stepped into a tag after encountering X-NOT-SUPPORTED element when it should have aborted.' );
+		$this->assertNull( $p->get_tag(), "Should have aborted processing, but still reported tag {$p->get_tag()} after properly failing to step into tag." );
+		$this->assertFalse( $p->next_tag( 'P' ), 'Stepped into normal P element after X-NOT-SUPPORTED element when it should have aborted.' );
+	}
+
+	/**
 	 * Ensures that the HTML Processor maintains its internal state through seek calls.
 	 *
 	 * Because the HTML Processor must track a stack of open elements and active formatting

--- a/tests/phpunit/tests/html-api/wpHtmlProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessor.php
@@ -47,7 +47,7 @@ class Tests_HtmlApi_WpHtmlProcessor extends WP_UnitTestCase {
 	 * should no longer report a tag. It should report `null` because there
 	 * is no tag matched or open.
 	 *
-	 * @ticket {TICKET_NUMBER}
+	 * @ticket 59167
 	 *
 	 * @covers WP_HTML_Processor::get_tag
 	 */
@@ -64,7 +64,7 @@ class Tests_HtmlApi_WpHtmlProcessor extends WP_UnitTestCase {
 	 * Ensures that if the HTML Processor encounters inputs that it can't properly handle,
 	 * that it stops processing the rest of the document. This prevents data corruption.
 	 *
-	 * @ticket {TICKET_NUMBER}
+	 * @ticket 59167
 	 *
 	 * @covers WP_HTML_Processor::next_tag
 	 */


### PR DESCRIPTION
Trac ticket: [#59167-trac](https://core.trac.wordpress.org/ticket/59167)

It was a design goal of the HTML Processor to abort processing its input document when encountering unsupported markup. Unfortunately there was no test for this and so-far, the HTML Processor has paused, but continued processing in these situations.

In this patch a new test ensures that the HTML Processor stops and refuses to move forward after encountering any unsupported markup. It also ensures that it doesn't report any current tag names since unsupported markup could imply that the read tag name is different than the parsed tag name.