### PR TITLE
WIP: HTML API: Allow extending input document for chunked processing.

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -438,11 +438,13 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				$this->state->stack_of_open_elements->pop();
 			}
 
-			parent::next_tag( self::VISIT_EVERYTHING );
+			$found_tag = parent::next_tag( self::VISIT_EVERYTHING );
+		} else {
+			$found_tag = true;
 		}
 
 		// Finish stepping when there are no more tokens in the document.
-		if ( null === $this->get_tag() ) {
+		if ( ! $found_tag ) {
 			return false;
 		}
 

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -326,6 +326,8 @@ class WP_HTML_Tag_Processor {
 	 */
 	private $bytes_already_parsed = 0;
 
+	private $previously_parsed = 0;
+
 	/**
 	 * Byte offset in input document where current tag name starts.
 	 *
@@ -507,6 +509,14 @@ class WP_HTML_Tag_Processor {
 		$this->html = $html;
 	}
 
+	public function extend_input( $html ) {
+		if ( $this->bytes_already_parsed >= strlen( $this->html ) ) {
+			$this->bytes_already_parsed = $this->previously_parsed;
+		}
+
+		$this->html .= $html;
+	}
+
 	/**
 	 * Finds the next tag matching the $query.
 	 *
@@ -527,6 +537,7 @@ class WP_HTML_Tag_Processor {
 	public function next_tag( $query = null ) {
 		$this->parse_query( $query );
 		$already_found = 0;
+		$this->previously_parsed = $this->bytes_already_parsed;
 
 		do {
 			if ( $this->bytes_already_parsed >= strlen( $this->html ) ) {


### PR DESCRIPTION
**This work is still at an early stage.** It will change, possibly substantially, before it's ready for full review.

## Description

In some situations it may be useful to process an HTML document as it's being generated. This requires the ability to add chunks of text to the end of the input HTML.

In this patch the `WP_HTML_Tag_Processor::extend_input( $html )` method is providing this ability. It is designed to allow for splitting an HTML at arbitrary boundaries.

```php
$p = WP_HTML_Processor::createFragment( '<div><p><em>This</em> is <str' );
while ( $p->next_tag() ) {
	// Process everything up to this point.
}

$p->extend_input( 'ong>incomplete.</strong></p><img></div>' );
while ( $p->next_tag() ) {
	// Continue processing with the full contents.
}
```