### PR TITLE
In `register_core_block_style_handles` store CSS files with relative path in transient

### DIFF
--- a/src/wp-includes/blocks/index.php
+++ b/src/wp-includes/blocks/index.php
@@ -30,18 +30,17 @@ function register_core_block_style_handles() {
 		return;
 	}
 
-	$includes_url  = includes_url();
-	$includes_path = ABSPATH . WPINC . '/';
-	$suffix        = wp_scripts_get_suffix();
-	$wp_styles     = wp_styles();
-	$style_fields  = array(
+	$includes_url = includes_url();
+	$suffix       = wp_scripts_get_suffix();
+	$wp_styles    = wp_styles();
+	$style_fields = array(
 		'style'       => 'style',
 		'editorStyle' => 'editor',
 	);
 
 	static $core_blocks_meta;
 	if ( ! $core_blocks_meta ) {
-		$core_blocks_meta = require $includes_path . 'blocks/blocks-json.php';
+		$core_blocks_meta = require BLOCKS_PATH . 'blocks-json.php';
 	}
 
 	$files          = false;
@@ -68,10 +67,10 @@ function register_core_block_style_handles() {
 	}
 
 	if ( ! $files ) {
-		$files = glob( wp_normalize_path( __DIR__ . '/**/**.css' ) );
+		$files = glob( wp_normalize_path( BLOCKS_PATH . '**/**.css' ) );
 		$files = array_map(
-			static function ( $file ) use ( $includes_path ) {
-				return str_replace( $includes_path, '', $file );
+			static function ( $file ) {
+				return str_replace( BLOCKS_PATH, '', $file );
 			},
 			$files
 		);
@@ -88,9 +87,9 @@ function register_core_block_style_handles() {
 		}
 	}
 
-	$register_style = static function( $name, $filename, $style_handle ) use ( $includes_path, $includes_url, $suffix, $wp_styles, $files ) {
-		$style_path = "blocks/{$name}/{$filename}{$suffix}.css";
-		$path       = wp_normalize_path( $includes_path . $style_path );
+	$register_style = static function( $name, $filename, $style_handle ) use ( $includes_url, $suffix, $wp_styles, $files ) {
+		$style_path = "{$name}/{$filename}{$suffix}.css";
+		$path       = wp_normalize_path( BLOCKS_PATH . $style_path );
 
 		if ( ! in_array( $style_path, $files, true ) ) {
 			$wp_styles->add(

--- a/src/wp-includes/blocks/index.php
+++ b/src/wp-includes/blocks/index.php
@@ -49,13 +49,6 @@ function register_core_block_style_handles() {
 		$files          = get_transient( $transient_name );
 		if ( ! $files ) {
 			$files = glob( wp_normalize_path( __DIR__ . '/**/**.css' ) );
-
-			/*
-			 * Make CSS files path relative before storing them in transient.
-			 *
-			 * Remove the `wp-includes` part to avoid issue when moving site (and the database) to another server :
-			 * /path/to/wp-includes/blocks/xxx/yyy.css => blocks/xxx/yyy.css
-			 */
 			$files = array_map(
 				static function ( $file ) use ( $includes_path ) {
 					return str_replace( $includes_path, '', $file );
@@ -64,28 +57,21 @@ function register_core_block_style_handles() {
 			);
 			set_transient( $transient_name, $files );
 		}
-
-		/*
-		 * Rebuild the full path for all CSS file when loading them from transient.
-		 *
-		 * Add the `wp-includes` part back :
-		 * blocks/xxx/yyy.css => /path/to/wp-includes/blocks/xxx/yyy.css
-		 */
+	} else {
+		$files = glob( wp_normalize_path( __DIR__ . '/**/**.css' ) );
 		$files = array_map(
 			static function ( $file ) use ( $includes_path ) {
-				return $includes_path . $file;
+				return str_replace( $includes_path, '', $file );
 			},
 			$files
 		);
-	} else {
-		$files = glob( wp_normalize_path( __DIR__ . '/**/**.css' ) );
 	}
 
 	$register_style = static function( $name, $filename, $style_handle ) use ( $includes_path, $includes_url, $suffix, $wp_styles, $files ) {
 		$style_path = "blocks/{$name}/{$filename}{$suffix}.css";
 		$path       = wp_normalize_path( $includes_path . $style_path );
 
-		if ( ! in_array( $path, $files, true ) ) {
+		if ( ! in_array( $style_path, $files, true ) ) {
 			$wp_styles->add(
 				$style_handle,
 				false

--- a/src/wp-includes/blocks/index.php
+++ b/src/wp-includes/blocks/index.php
@@ -99,7 +99,7 @@ function register_core_block_style_handles() {
 			return;
 		}
 
-		$wp_styles->add( $style_handle, $includes_url . $style_path );
+		$wp_styles->add( $style_handle, $includes_url . '/blocks/' . $style_path );
 		$wp_styles->add_data( $style_handle, 'path', $path );
 
 		$rtl_file = str_replace( "{$suffix}.css", "-rtl{$suffix}.css", $path );

--- a/src/wp-includes/blocks/index.php
+++ b/src/wp-includes/blocks/index.php
@@ -57,7 +57,7 @@ function register_core_block_style_handles() {
 			 * /path/to/wp-includes/blocks/xxx/yyy.css => blocks/xxx/yyy.css
 			 */
 			$files = array_map(
-				function ( $file ) use ( $includes_path ) {
+				static function ( $file ) use ( $includes_path ) {
 					return str_replace( $includes_path, '', $file );
 				},
 				$files

--- a/src/wp-includes/blocks/index.php
+++ b/src/wp-includes/blocks/index.php
@@ -52,7 +52,7 @@ function register_core_block_style_handles() {
 	 * the core developer's workflow.
 	 */
 	$can_use_cached = ! wp_is_development_mode( 'core' );
-	
+
 	if ( $can_use_cached ) {
 		$cached_files = get_transient( $transient_name );
 

--- a/src/wp-includes/blocks/index.php
+++ b/src/wp-includes/blocks/index.php
@@ -47,6 +47,12 @@ function register_core_block_style_handles() {
 	if ( ! wp_is_development_mode( 'core' ) ) {
 		$transient_name = 'wp_core_block_css_files';
 		$files          = get_transient( $transient_name );
+
+		// Ensure cached values use relative paths.
+		if ( is_array( $files ) && ! str_starts_with( reset( $files ), 'blocks/' ) ) {
+			$files = false;
+		}
+
 		if ( ! $files ) {
 			$files = glob( wp_normalize_path( __DIR__ . '/**/**.css' ) );
 			$files = array_map(

--- a/src/wp-includes/blocks/index.php
+++ b/src/wp-includes/blocks/index.php
@@ -49,8 +49,34 @@ function register_core_block_style_handles() {
 		$files          = get_transient( $transient_name );
 		if ( ! $files ) {
 			$files = glob( wp_normalize_path( __DIR__ . '/**/**.css' ) );
+
+			/*
+			 * Make CSS files path relative before storing them in transient.
+			 *
+			 * Remove the `wp-includes` part to avoid issue when moving site (and the database) to another server :
+			 * /path/to/wp-includes/blocks/xxx/yyy.css => blocks/xxx/yyy.css
+			 */
+			$files = array_map(
+				function ( $file ) use ( $includes_path ) {
+					return str_replace( $includes_path, '', $file );
+				},
+				$files
+			);
 			set_transient( $transient_name, $files );
 		}
+
+		/*
+		 * Rebuild the full path for all CSS file when loading them from transient.
+		 *
+		 * Add the `wp-includes` part back :
+		 * blocks/xxx/yyy.css => /path/to/wp-includes/blocks/xxx/yyy.css
+		 */
+		$files = array_map(
+			function ( $file ) use ( $includes_path ) {
+				return $includes_path . $file;
+			},
+			$files
+		);
 	} else {
 		$files = glob( wp_normalize_path( __DIR__ . '/**/**.css' ) );
 	}

--- a/src/wp-includes/blocks/index.php
+++ b/src/wp-includes/blocks/index.php
@@ -46,26 +46,24 @@ function register_core_block_style_handles() {
 
 	$files          = false;
 	$transient_name = 'wp_core_block_css_files';
+
 	/*
 	 * Ignore transient cache when the development mode is set to 'core'. Why? To avoid interfering with
 	 * the core developer's workflow.
 	 */
-	if ( ! wp_is_development_mode( 'core' ) ) {
+	$can_use_cached = ! wp_is_development_mode( 'core' );
+	
+	if ( $can_use_cached ) {
 		$cached_files = get_transient( $transient_name );
 
-		/*
-		 * Check the validity of cached values.
-		 *  - Should match the current WordPress version
-		 *  - Should use relative paths for the files
-		 */
-		if ( is_array( $cached_files ) ) {
-			if ( ! isset( $cached_files['version'] ) || $cached_files['version'] !== $wp_version ) {
-				$files = false;
-			} elseif ( ! isset( $cached_files['files'] ) || empty( $cached_files['files'] ) || ! str_starts_with( reset( $cached_files['files'] ), 'blocks/' ) ) {
-				$files = false;
-			} else {
-				$files = $cached_files['files'];
-			}
+		// Check the validity of cached values by checking against the current WordPress version.
+		if (
+			is_array( $cached_files )
+			&& isset( $cached_files['version'] )
+			&& $cached_files['version'] === $wp_version
+			&& isset( $cached_files['files'] )
+		) {
+			$files = $cached_files['files'];
 		}
 	}
 
@@ -79,7 +77,7 @@ function register_core_block_style_handles() {
 		);
 
 		// Save core block style paths in cache when not in development mode.
-		if ( ! wp_is_development_mode( 'core' ) ) {
+		if ( $can_use_cached ) {
 			set_transient(
 				$transient_name,
 				array(

--- a/src/wp-includes/blocks/index.php
+++ b/src/wp-includes/blocks/index.php
@@ -30,7 +30,7 @@ function register_core_block_style_handles() {
 		return;
 	}
 
-	$includes_url = includes_url();
+	$blocks_url   = includes_url( 'blocks/' );
 	$suffix       = wp_scripts_get_suffix();
 	$wp_styles    = wp_styles();
 	$style_fields = array(
@@ -87,7 +87,7 @@ function register_core_block_style_handles() {
 		}
 	}
 
-	$register_style = static function( $name, $filename, $style_handle ) use ( $includes_url, $suffix, $wp_styles, $files ) {
+	$register_style = static function( $name, $filename, $style_handle ) use ( $blocks_url, $suffix, $wp_styles, $files ) {
 		$style_path = "{$name}/{$filename}{$suffix}.css";
 		$path       = wp_normalize_path( BLOCKS_PATH . $style_path );
 
@@ -99,7 +99,7 @@ function register_core_block_style_handles() {
 			return;
 		}
 
-		$wp_styles->add( $style_handle, $includes_url . '/blocks/' . $style_path );
+		$wp_styles->add( $style_handle, $blocks_url . $style_path );
 		$wp_styles->add_data( $style_handle, 'path', $path );
 
 		$rtl_file = str_replace( "{$suffix}.css", "-rtl{$suffix}.css", $path );

--- a/src/wp-includes/blocks/index.php
+++ b/src/wp-includes/blocks/index.php
@@ -72,7 +72,7 @@ function register_core_block_style_handles() {
 		 * blocks/xxx/yyy.css => /path/to/wp-includes/blocks/xxx/yyy.css
 		 */
 		$files = array_map(
-			function ( $file ) use ( $includes_path ) {
+			static function ( $file ) use ( $includes_path ) {
 				return $includes_path . $file;
 			},
 			$files

--- a/src/wp-includes/blocks/index.php
+++ b/src/wp-includes/blocks/index.php
@@ -28,7 +28,7 @@ function register_core_block_style_handles() {
 
 	static $core_blocks_meta;
 	if ( ! $core_blocks_meta ) {
-		$core_blocks_meta = require ABSPATH . WPINC . '/blocks/blocks-json.php';
+		$core_blocks_meta = require BLOCKS_PATH . 'blocks-json.php';
 	}
 
 	$includes_url  = includes_url();


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This PR propose a solution to fix the ticket 59111.

This is loosely based on the second option suggested, this PR will do additional change to the CSS files paths before storing and after retrieving them in the transient. Paths stored in the transient doesn't contain the path to the `wp-includes` folder in the server. 

Trac ticket: https://core.trac.wordpress.org/ticket/59111

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
