### PR TITLE
fix the get_bloginfo documentation

### DIFF
--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -787,7 +787,7 @@ function bloginfo( $show = '' ) {
  *
  * Deprecated arguments include:
  *
- * - 'siteurl' - Use 'url' instead
+ * - 'siteurl' - Use 'wpurl' instead
  * - 'home' - Use 'url' instead
  *
  * @since 0.71


### PR DESCRIPTION
Small fix for get_bloginfo() function doc.  **'siteurl' - Use 'url' instead** was a bit misleading.

Ticket: https://core.trac.wordpress.org/ticket/59169