### PR TITLE
Fix: Draft post date change in quick edit

### DIFF
--- a/src/js/_enqueues/admin/inline-edit-post.js
+++ b/src/js/_enqueues/admin/inline-edit-post.js
@@ -449,13 +449,6 @@ window.wp = window.wp || {};
 		};
 
 		fields = $('#edit-'+id).find(':input').serialize();
-
-		var status = $(':input[name="_status"]').val();
-
-		if ( [ 'draft', 'pending', 'auto-draft' ].includes( status ) ) {
-			params.edit_date = 'false';
-		}
-
 		params = fields + '&' + $.param(params);
 
 		// Make Ajax request.

--- a/src/wp-admin/includes/post.php
+++ b/src/wp-admin/includes/post.php
@@ -197,7 +197,7 @@ function _wp_translate_postdata( $update = false, $post_data = null ) {
 		 * Posts shouldn't be assigned a date unless date explicitly done by the user when needed.
 		 * Change edit_date flag based on post_date changes and if post_date changes is done by user,
 		 * Then set post_date and post_date_gmt in $post_data.
-		 * 
+		 *
 		 * This changes is done considering ticket #59125 issue and previously ticket task #19907 done patch,
 		 * Which create issues ( not updating date/time ) for post status - ( 'draft', 'pending', 'auto-draft' ).
 		 */

--- a/src/wp-admin/includes/post.php
+++ b/src/wp-admin/includes/post.php
@@ -194,12 +194,8 @@ function _wp_translate_postdata( $update = false, $post_data = null ) {
 		}
 
 		/*
-		 * Posts shouldn't be assigned a date unless date explicitly done by the user when needed.
-		 * Change edit_date flag based on post_date changes and if post_date changes is done by user,
-		 * Then set post_date and post_date_gmt in $post_data.
-		 *
-		 * This changes is done considering ticket #59125 issue and previously ticket task #19907 done patch,
-		 * Which create issues ( not updating date/time ) for post status - ( 'draft', 'pending', 'auto-draft' ).
+		 * Only assign a post date if the user has explicitly set a new value.
+		 * See #59125 and #19907.
 		 */
 		$previous_date = $post_id ? get_post_field( 'post_date', $post_id ) : false;
 		if ( $previous_date && $previous_date !== $post_data['post_date'] ) {
@@ -208,6 +204,7 @@ function _wp_translate_postdata( $update = false, $post_data = null ) {
 		} else {
 			$post_data['edit_date'] = false;
 			unset( $post_data['post_date'] );
+			unset( $post_data['post_date_gmt'] );
 		}
 	}
 

--- a/tests/phpunit/tests/ajax/wpAjaxInlineSave.php
+++ b/tests/phpunit/tests/ajax/wpAjaxInlineSave.php
@@ -142,9 +142,7 @@ class Tests_Ajax_wpAjaxInlineSave extends WP_Ajax_UnitTestCase {
 
 		$post_date = sprintf( '%04d-%02d-%02d %02d:%02d:%02d', $_POST['aa'], $_POST['mm'], $_POST['jj'], $_POST['hh'], $_POST['mn'], $_POST['ss'] );
 
-		$this->assertEquals( get_post_field( 'post_date', $post->ID ), $post_date );
-
-		//$this->assertEquals( '0000-00-00 00:00:00', $post->post_date_gmt );
+		$this->assertEquals( '0000-00-00 00:00:00', $post->post_date_gmt );
 	}
 
 	/**

--- a/tests/phpunit/tests/ajax/wpAjaxInlineSave.php
+++ b/tests/phpunit/tests/ajax/wpAjaxInlineSave.php
@@ -140,6 +140,10 @@ class Tests_Ajax_wpAjaxInlineSave extends WP_Ajax_UnitTestCase {
 
 		$post = get_post( $post->ID );
 
+		$post_date = sprintf( '%04d-%02d-%02d %02d:%02d:%02d', $_POST['aa'], $_POST['mm'], $_POST['jj'], $_POST['hh'], $_POST['mn'], $_POST['ss'] );
+
+		$this->assertEquals( get_post_field( 'post_date', $post->ID ), $post_date );
+
 		$this->assertEquals( '0000-00-00 00:00:00', $post->post_date_gmt );
 	}
 
@@ -194,10 +198,6 @@ class Tests_Ajax_wpAjaxInlineSave extends WP_Ajax_UnitTestCase {
 		}
 
 		$post = get_post( $post->ID );
-
-		$post_date = sprintf( '%04d-%02d-%02d %02d:%02d:%02d', $_POST['aa'], $_POST['mm'], $_POST['jj'], $_POST['hh'], $_POST['mn'], $_POST['ss'] );
-
-		$this->assertEquals( get_post_field( 'post_date', $post->ID ), $post_date );
 
 		$this->assertEquals( '2020-09-11 19:20:11', $post->post_date_gmt );
 	}

--- a/tests/phpunit/tests/ajax/wpAjaxInlineSave.php
+++ b/tests/phpunit/tests/ajax/wpAjaxInlineSave.php
@@ -124,12 +124,12 @@ class Tests_Ajax_wpAjaxInlineSave extends WP_Ajax_UnitTestCase {
 		$_POST['screen']       = 'edit-post';
 		$_POST['post_view']    = 'list';
 		$_POST['edit_date']    = 'false';
-		$_POST['mm']           = get_the_date( 'm', $post->post_date );
-		$_POST['jj']           = get_the_date( 'd', $post->post_date );
-		$_POST['aa']           = get_the_date( 'Y', $post->post_date );
-		$_POST['hh']           = get_the_date( 'H', $post->post_date );
-		$_POST['mn']           = get_the_date( 'i', $post->post_date );
-		$_POST['ss']           = get_the_date( 's', $post->post_date );
+		$_POST['mm']           = get_the_date( 'm', $post );
+		$_POST['jj']           = get_the_date( 'd', $post );
+		$_POST['aa']           = get_the_date( 'Y', $post );
+		$_POST['hh']           = get_the_date( 'H', $post );
+		$_POST['mn']           = get_the_date( 'i', $post );
+		$_POST['ss']           = get_the_date( 's', $post );
 
 		// Make the request.
 		try {
@@ -144,7 +144,7 @@ class Tests_Ajax_wpAjaxInlineSave extends WP_Ajax_UnitTestCase {
 
 		$this->assertEquals( get_post_field( 'post_date', $post->ID ), $post_date );
 
-		$this->assertEquals( '0000-00-00 00:00:00', $post->post_date_gmt );
+		//$this->assertEquals( '0000-00-00 00:00:00', $post->post_date_gmt );
 	}
 
 	/**

--- a/tests/phpunit/tests/ajax/wpAjaxInlineSave.php
+++ b/tests/phpunit/tests/ajax/wpAjaxInlineSave.php
@@ -178,7 +178,7 @@ class Tests_Ajax_wpAjaxInlineSave extends WP_Ajax_UnitTestCase {
 		$_POST['post_author']  = $user;
 		$_POST['screen']       = 'edit-post';
 		$_POST['post_view']    = 'list';
-		$_POST['edit_date']    = 'false';
+		$_POST['edit_date']    = 'true';
 		$_POST['mm']           = '09';
 		$_POST['jj']           = 11;
 		$_POST['aa']           = 2020;
@@ -194,6 +194,10 @@ class Tests_Ajax_wpAjaxInlineSave extends WP_Ajax_UnitTestCase {
 		}
 
 		$post = get_post( $post->ID );
+
+		$post_date = sprintf( '%04d-%02d-%02d %02d:%02d:%02d', $_POST['aa'], $_POST['mm'], $_POST['jj'], $_POST['hh'], $_POST['mn'], $_POST['ss'] );
+
+		$this->assertEquals( get_post_field( 'post_date', $post->ID ), $post_date );
 
 		$this->assertEquals( '2020-09-11 19:20:11', $post->post_date_gmt );
 	}

--- a/tests/phpunit/tests/ajax/wpAjaxInlineSave.php
+++ b/tests/phpunit/tests/ajax/wpAjaxInlineSave.php
@@ -127,9 +127,9 @@ class Tests_Ajax_wpAjaxInlineSave extends WP_Ajax_UnitTestCase {
 		$_POST['mm']           = get_the_date( 'm', $post->post_date );
 		$_POST['jj']           = get_the_date( 'd', $post->post_date );
 		$_POST['aa']           = get_the_date( 'Y', $post->post_date );
-		$_POST['hh']           = '00';
-		$_POST['mn']           = '00';
-		$_POST['ss']           = '00';
+		$_POST['hh']           = get_the_date( 'H', $post->post_date );
+		$_POST['mn']           = get_the_date( 'i', $post->post_date );
+		$_POST['ss']           = get_the_date( 's', $post->post_date );
 
 		// Make the request.
 		try {

--- a/tests/phpunit/tests/ajax/wpAjaxInlineSave.php
+++ b/tests/phpunit/tests/ajax/wpAjaxInlineSave.php
@@ -124,9 +124,9 @@ class Tests_Ajax_wpAjaxInlineSave extends WP_Ajax_UnitTestCase {
 		$_POST['screen']       = 'edit-post';
 		$_POST['post_view']    = 'list';
 		$_POST['edit_date']    = 'false';
-		$_POST['mm']           = '00';
-		$_POST['jj']           = '00';
-		$_POST['aa']           = '0000';
+		$_POST['mm']           = get_the_date( 'm', $post->post_date );
+		$_POST['jj']           = get_the_date( 'd', $post->post_date );
+		$_POST['aa']           = get_the_date( 'Y', $post->post_date );
 		$_POST['hh']           = '00';
 		$_POST['mn']           = '00';
 		$_POST['ss']           = '00';

--- a/tests/phpunit/tests/ajax/wpAjaxInlineSave.php
+++ b/tests/phpunit/tests/ajax/wpAjaxInlineSave.php
@@ -89,13 +89,68 @@ class Tests_Ajax_wpAjaxInlineSave extends WP_Ajax_UnitTestCase {
 	}
 
 	/**
-	 * When updating a draft in quick edit mode, it should not set the publish date of the post when this one will be published.
+	 * When updating a draft in quick edit mode, it should not set the publish date of the post if the date passed is unchanged.
 	 *
 	 * @ticket 19907
 	 *
 	 * @covers ::edit_post
 	 */
 	public function test_quick_edit_draft_should_not_set_publish_date() {
+		// Become an administrator.
+		$this->_setRole( 'administrator' );
+
+		$user = get_current_user_id();
+
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_status' => 'draft',
+				'post_author' => $user,
+			)
+		);
+
+		$this->assertSame( 'draft', $post->post_status );
+
+		$this->assertEquals( '0000-00-00 00:00:00', $post->post_date_gmt );
+
+		// Set up a request.
+		$_POST['_inline_edit'] = wp_create_nonce( 'inlineeditnonce' );
+		$_POST['post_ID']      = $post->ID;
+		$_POST['post_type']    = 'post';
+		$_POST['content']      = 'content test';
+		$_POST['excerpt']      = 'excerpt test';
+		$_POST['_status']      = $post->post_status;
+		$_POST['post_status']  = $post->post_status;
+		$_POST['post_author']  = $user;
+		$_POST['screen']       = 'edit-post';
+		$_POST['post_view']    = 'list';
+		$_POST['edit_date']    = 'false';
+		$_POST['mm']           = '00';
+		$_POST['jj']           = '00';
+		$_POST['aa']           = '0000';
+		$_POST['hh']           = '00';
+		$_POST['mn']           = '00';
+		$_POST['ss']           = '00';
+
+		// Make the request.
+		try {
+			$this->_handleAjax( 'inline-save' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+		}
+
+		$post = get_post( $post->ID );
+
+		$this->assertEquals( '0000-00-00 00:00:00', $post->post_date_gmt );
+	}
+
+	/**
+	 * When updating a draft in quick edit mode, it should set the publish date of the post if there is a new date set.
+	 *
+	 * @ticket 59125
+	 *
+	 * @covers ::edit_post
+	 */
+	public function test_quick_edit_draft_should_set_publish_date() {
 		// Become an administrator.
 		$this->_setRole( 'administrator' );
 
@@ -140,6 +195,6 @@ class Tests_Ajax_wpAjaxInlineSave extends WP_Ajax_UnitTestCase {
 
 		$post = get_post( $post->ID );
 
-		$this->assertEquals( '0000-00-00 00:00:00', $post->post_date_gmt );
+		$this->assertEquals( '2020-09-11 19:20:11', $post->post_date_gmt );
 	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This PR fix draft post date change save issues in quick edit, considering ticket #59125 issue and previously ticket task #19907 done patch which create issues ( not updating date/time ) for post status - ( 'draft', 'pending', 'auto-draft' ).

Trac ticket: https://core.trac.wordpress.org/ticket/59125

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
