### PR TITLE
Add wp_set_option_autoload() function

### DIFF
--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -2589,3 +2589,39 @@ function filter_default_option( $default_value, $option, $passed_default ) {
 
 	return $registered[ $option ]['default'];
 }
+
+/**
+ * Sets an option autoload value
+ *
+ * @global wpdb $wpdb WordPress database abstraction object.
+ *
+ * @param string      $option   Name of the option to update the autoload value. Expected to not be SQL-escaped.
+ * @param string|bool $autoload Value to set the autoload to.
+ *                              Accepts 'yes'|true to enable or 'no'|false to disable.
+ * @return bool True if the autoload value was updated, false otherwise.
+ */
+function wp_set_option_autoload( $option, $autoload ) {
+	global $wpdb;
+
+	if ( is_scalar( $option ) ) {
+		$option = trim( $option );
+	}
+
+	if ( empty( $option ) ) {
+		return false;
+	}
+
+	wp_protect_special_option( $option );
+
+	$update_args = array(
+		'autoload' => ( 'no' === $autoload || false === $autoload ) ? 'no' : 'yes',
+	);
+
+	$result = $wpdb->update( $wpdb->options, $update_args, array( 'option_name' => $option ) );
+
+	if ( ! $result ) {
+		return false;
+	}
+
+	return true;
+}

--- a/tests/phpunit/tests/option/wpSetOptionAutoload.php
+++ b/tests/phpunit/tests/option/wpSetOptionAutoload.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @group option
+ */
+class Tests_Option_WpSetOptionAutoload extends WP_UnitTestCase {
+	/**
+	 * @ticket 58964
+	 *
+	 * @covers ::wp_set_option_autoload
+	 */
+	public function test_autoload_should_set_yes() {
+		global $wpdb;
+
+		add_option( 'foo', 'bar', '', 'no' );
+
+		$updated = wp_set_option_autoload( 'foo', 'yes' );
+		$this->assertTrue( $updated );
+
+		$this->flush_cache();
+
+		// Populate the alloptions cache, which includes autoload=yes options.
+		wp_load_alloptions();
+
+		$before = $wpdb->num_queries;
+		$value  = get_option( 'foo' );
+
+		$this->assertSame( $before, $wpdb->num_queries );
+	}
+
+	public function test_autoload_should_set_no() {
+		global $wpdb;
+
+		add_option( 'foo', 'bar', '', 'yes' );
+
+		$updated = wp_set_option_autoload( 'foo', 'no' );
+		$this->assertTrue( $updated );
+
+		$this->flush_cache();
+
+		// Populate the alloptions cache, which includes autoload=yes options.
+		wp_load_alloptions();
+
+		$before = $wpdb->num_queries;
+		$value  = get_option( 'foo' );
+
+		$this->assertSame( $before + 1, $wpdb->num_queries );
+	}
+}


### PR DESCRIPTION
Add a new function `wp_set_option_autoload( $option, $autoload )` to modify the autoload value of an option without having to modify its value.

Trac ticket: https://core.trac.wordpress.org/ticket/58964

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
