### PR TITLE
Use regular core button styling for page header buttons

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -639,15 +639,7 @@ code {
 	background: #f6f7f7;
 	cursor: pointer;
 
-	display: inline-block;
-	line-height: 2.15384615;
-	min-height: 30px;
-	padding: 0 10px;
-	-webkit-appearance: none;
-	border-radius: 3px;
-	white-space: nowrap;
-	box-sizing: border-box;
-	font-weight: 400;
+
 	
 }
 

--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -643,9 +643,6 @@ code {
 	line-height: 2.15384615;
 	min-height: 30px;
 	padding: 0 10px;
-	cursor: pointer;
-	border-width: 1px;
-	border-style: solid;
 	-webkit-appearance: none;
 	border-radius: 3px;
 	white-space: nowrap;

--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -639,7 +639,15 @@ code {
 	background: #f6f7f7;
 	cursor: pointer;
 
-
+	display: inline-block;
+	line-height: 2.15384615;
+	min-height: 30px;
+	padding: 0 10px;
+	-webkit-appearance: none;
+	border-radius: 3px;
+	white-space: nowrap;
+	box-sizing: border-box;
+	font-weight: 400;
 	
 }
 

--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -638,6 +638,20 @@ code {
 	color: #2271b1; /* use the standard color used for buttons */
 	background: #f6f7f7;
 	cursor: pointer;
+
+	display: inline-block;
+	line-height: 2.15384615;
+	min-height: 30px;
+	padding: 0 10px;
+	cursor: pointer;
+	border-width: 1px;
+	border-style: solid;
+	-webkit-appearance: none;
+	border-radius: 3px;
+	white-space: nowrap;
+	box-sizing: border-box;
+	font-weight: 400;
+	
 }
 
 .wrap .wp-heading-inline + .page-title-action {

--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -624,31 +624,26 @@ code {
 .wrap .add-new-h2:active, /* deprecated */
 .wrap .page-title-action,
 .wrap .page-title-action:active {
-	margin-left: 4px;
-	padding: 4px 8px;
-	position: relative;
-	top: -3px;
-	text-decoration: none;
-	border: 1px solid #2271b1;
-	border-radius: 2px;
-	text-shadow: none;
-	font-weight: 600;
-	font-size: 13px;
-	line-height: normal; /* IE8-IE11 need this for buttons */
-	color: #2271b1; /* use the standard color used for buttons */
-	background: #f6f7f7;
-	cursor: pointer;
-
 	display: inline-block;
-	line-height: 2.15384615;
-	min-height: 30px;
-	padding: 0 10px;
-	-webkit-appearance: none;
-	border-radius: 3px;
-	white-space: nowrap;
+	position: relative;
 	box-sizing: border-box;
+	cursor: pointer;
+	white-space: nowrap;
+	text-decoration: none;
+	text-shadow: none;
+	top: -3px;
+	margin-left: 4px;
+	border: 1px solid #2271b1;
+	border-radius: 3px;
+	background: #f6f7f7;
+	font-size: 13px;
 	font-weight: 400;
-	
+	line-height: 2.15384615;
+	color: #2271b1; /* use the standard color used for buttons */
+	padding: 0 10px;
+	min-height: 30px;
+	-webkit-appearance: none;
+
 }
 
 .wrap .wp-heading-inline + .page-title-action {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Modified styles of .page-title-action button to match that of the secondary buttons.

Trac ticket: https://core.trac.wordpress.org/ticket/41986

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
