### PR TITLE
Added screen reader text "remove" to accompany bulk edit help text icon

### DIFF
--- a/src/wp-admin/edit.php
+++ b/src/wp-admin/edit.php
@@ -288,7 +288,11 @@ if ( 'post' === $post_type ) {
 			'title'   => __( 'Bulk actions' ),
 			'content' =>
 					'<p>' . __( 'You can also edit or move multiple posts to the Trash at once. Select the posts you want to act on using the checkboxes, then select the action you want to take from the Bulk actions menu and click Apply.' ) . '</p>' .
-							'<p>' . __( 'When using Bulk Edit, you can change the metadata (categories, author, etc.) for all selected posts at once. To remove a post from the grouping, just click the x next to its name in the Bulk Edit area that appears.' ) . '</p>',
+					'<p>' . sprintf(
+						/* translators: %s: The 'x' icon used for buttons that dismiss or remove. */
+						__( 'When using Bulk Edit, you can change the metadata (categories, author, etc.) for all selected posts at once. To remove a post from the grouping, just click the %s button next to its name in the Bulk Edit area that appears.' ),
+						'<span class="dashicons dashicons-dismiss" aria-hidden="true" style="font-size: 16px; width: 16px; vertical-align: middle;"></span><span class="screen-reader-text">' . __( 'remove' ) . '</span>'
+					) . '</p>',
 		)
 	);
 

--- a/src/wp-admin/edit.php
+++ b/src/wp-admin/edit.php
@@ -290,8 +290,8 @@ if ( 'post' === $post_type ) {
 					'<p>' . __( 'You can also edit or move multiple posts to the Trash at once. Select the posts you want to act on using the checkboxes, then select the action you want to take from the Bulk actions menu and click Apply.' ) . '</p>' .
 					'<p>' . sprintf(
 						/* translators: %s: The 'x' icon used for buttons that dismiss or remove. */
-						__( 'When using Bulk Edit, you can change the metadata (categories, author, etc.) for all selected posts at once. To remove a post from the grouping, just click the %s button next to its name in the Bulk Edit area that appears.' ),
-						'<span class="dashicons dashicons-dismiss" aria-hidden="true" style="font-size: 16px; width: 16px; vertical-align: middle;"></span><span class="screen-reader-text">' . __( 'remove' ) . '</span>'
+						__( 'When using Bulk Edit, you can change the metadata (categories, author, etc.) for all selected posts at once. To remove a post from the grouping, just click the %s<span class="screen-reader-text">remove</span> button next to its name in the Bulk Edit area that appears.' ),
+						'<span class="dashicons dashicons-dismiss" aria-hidden="true" style="font-size: 16px; width: 16px; vertical-align: middle;"></span>'
 					) . '</p>',
 		)
 	);


### PR DESCRIPTION
Added screen reader text "remove" to accompany bulk edit help text icon

Trac ticket: [58785](https://core.trac.wordpress.org/ticket/58785)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
