### PR TITLE
Performance optimization of wp_get_block_css_selector() to remove array_merge()

### DIFF
--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -539,7 +539,7 @@ function wp_get_block_css_selector( $block_type, $target = 'root', $fallback = f
 		// Prefer the selectors API if available.
 		if ( $has_selectors ) {
 			// Look for selector under `feature.root`.
-			$path             = array_merge( $target, array( 'root' ) );
+			$path             = array( current( $target ), 'root' );
 			$feature_selector = _wp_array_get( $block_type->selectors, $path, null );
 
 			if ( $feature_selector ) {
@@ -553,7 +553,7 @@ function wp_get_block_css_selector( $block_type, $target = 'root', $fallback = f
 		}
 
 		// Try getting old experimental supports selector value.
-		$path             = array_merge( $target, array( '__experimentalSelector' ) );
+		$path             = array( current( $target ), '__experimentalSelector' );
 		$feature_selector = _wp_array_get( $block_type->supports, $path, null );
 
 		// Nothing to work with, provide fallback or null.


### PR DESCRIPTION
Performance optimization of wp_get_block_css_selector() by removing array_merge() with an inline array. The current() function only works because  must only have one element to within the block.

Trac ticket: https://core.trac.wordpress.org/ticket/59178