### PR TITLE
Remove misleading comment in class-wp-rest-blocks-controller.php

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-blocks-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-blocks-controller.php
@@ -75,7 +75,6 @@ class WP_REST_Blocks_Controller extends WP_REST_Posts_Controller {
 			return $this->add_additional_fields_schema( $this->schema );
 		}
 
-		// Do not cache this schema because all properties are derived from parent controller.
 		$schema = parent::get_item_schema();
 
 		/*


### PR DESCRIPTION
Remove misleading comment in class-wp-rest-blocks-controller.php

Trac ticket: [https://core.trac.wordpress.org/ticket/59193](https://core.trac.wordpress.org/ticket/59193)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
