### PR TITLE
40370 refresh at 6 4

### DIFF
--- a/src/wp-includes/class-wp-image-editor-gd.php
+++ b/src/wp-includes/class-wp-image-editor-gd.php
@@ -556,7 +556,7 @@ class WP_Image_Editor_GD extends WP_Image_Editor {
 			'file'      => wp_basename( apply_filters( 'image_make_intermediate_size', $filename ) ),
 			'width'     => $this->size['width'],
 			'height'    => $this->size['height'],
-			'hash'    	=> $this->hash,
+			'hash'      => $this->hash,
 			'mime-type' => $mime_type,
 			'filesize'  => wp_filesize( $filename ),
 		);

--- a/src/wp-includes/class-wp-image-editor-gd.php
+++ b/src/wp-includes/class-wp-image-editor-gd.php
@@ -156,7 +156,7 @@ class WP_Image_Editor_GD extends WP_Image_Editor {
 	/**
 	 * Sets or updates current image size.
 	 *
-	 * @since 5.1.0
+	 * @since 6.4.0
 	 *
 	 * @param bool|array $crop
 	 * @param int $dst_w

--- a/src/wp-includes/class-wp-image-editor-gd.php
+++ b/src/wp-includes/class-wp-image-editor-gd.php
@@ -154,6 +154,27 @@ class WP_Image_Editor_GD extends WP_Image_Editor {
 	}
 
 	/**
+	 * Sets or updates current image size.
+	 *
+	 * @since 5.1.0
+	 *
+	 * @param bool|array $crop
+	 * @param int $dst_w
+	 * @param int $dst_h
+	 * @return true
+	 */
+	protected function create_crop_hash( $crop, $dst_w, $dst_h ) {
+		if ( ! is_array( $crop ) ) {
+			return false;
+		}
+
+		$str = $crop[0] . $crop[1] . $dst_w . $dst_h;
+		$hash = substr( md5( $str ), 0, 8 );
+		
+		return parent::create_crop_hash( $hash );
+	}
+
+	/**
 	 * Resizes current image.
 	 *
 	 * Wraps `::_resize()` which returns a GD resource or GdImage instance.
@@ -220,6 +241,7 @@ class WP_Image_Editor_GD extends WP_Image_Editor {
 		imagecopyresampled( $resized, $this->image, $dst_x, $dst_y, $src_x, $src_y, $dst_w, $dst_h, $src_w, $src_h );
 
 		if ( is_gd_image( $resized ) ) {
+			$this->create_crop_hash( $crop, $dst_w, $dst_h );
 			$this->update_size( $dst_w, $dst_h );
 			return $resized;
 		}
@@ -534,6 +556,7 @@ class WP_Image_Editor_GD extends WP_Image_Editor {
 			'file'      => wp_basename( apply_filters( 'image_make_intermediate_size', $filename ) ),
 			'width'     => $this->size['width'],
 			'height'    => $this->size['height'],
+			'hash'    	=> $this->hash,
 			'mime-type' => $mime_type,
 			'filesize'  => wp_filesize( $filename ),
 		);

--- a/src/wp-includes/class-wp-image-editor-imagick.php
+++ b/src/wp-includes/class-wp-image-editor-imagick.php
@@ -310,6 +310,27 @@ class WP_Image_Editor_Imagick extends WP_Image_Editor {
 	}
 
 	/**
+	 * Sets or updates current image size.
+	 *
+	 * @since 5.1.0
+	 *
+	 * @param bool|array $crop
+	 * @param int $dst_w
+	 * @param int $dst_h
+	 * @return true
+	 */
+	protected function create_crop_hash( $crop, $dst_w, $dst_h ) {
+		if ( ! is_array( $crop ) ) {
+			return false;
+		}
+
+		$str = $crop[0] . $crop[1] . $dst_w . $dst_h;
+		$hash = substr( md5( $str ), 0, 8 );
+		
+		return parent::create_crop_hash( $hash );
+	}
+
+	/**
 	 * Resizes current image.
 	 *
 	 * At minimum, either a height or width must be provided.
@@ -343,6 +364,7 @@ class WP_Image_Editor_Imagick extends WP_Image_Editor {
 		list( $dst_x, $dst_y, $src_x, $src_y, $dst_w, $dst_h, $src_w, $src_h ) = $dims;
 
 		if ( $crop ) {
+			$this->create_crop_hash( $crop, $dst_w, $dst_h );
 			return $this->crop( $src_x, $src_y, $src_w, $src_h, $dst_w, $dst_h );
 		}
 
@@ -837,6 +859,7 @@ class WP_Image_Editor_Imagick extends WP_Image_Editor {
 			'file'      => wp_basename( apply_filters( 'image_make_intermediate_size', $filename ) ),
 			'width'     => $this->size['width'],
 			'height'    => $this->size['height'],
+			'hash'    	=> $this->hash,
 			'mime-type' => $mime_type,
 			'filesize'  => wp_filesize( $filename ),
 		);

--- a/src/wp-includes/class-wp-image-editor-imagick.php
+++ b/src/wp-includes/class-wp-image-editor-imagick.php
@@ -312,7 +312,7 @@ class WP_Image_Editor_Imagick extends WP_Image_Editor {
 	/**
 	 * Sets or updates current image size.
 	 *
-	 * @since 5.1.0
+	 * @since 6.4.0
 	 *
 	 * @param bool|array $crop
 	 * @param int $dst_w

--- a/src/wp-includes/class-wp-image-editor-imagick.php
+++ b/src/wp-includes/class-wp-image-editor-imagick.php
@@ -859,7 +859,7 @@ class WP_Image_Editor_Imagick extends WP_Image_Editor {
 			'file'      => wp_basename( apply_filters( 'image_make_intermediate_size', $filename ) ),
 			'width'     => $this->size['width'],
 			'height'    => $this->size['height'],
-			'hash'    	=> $this->hash,
+			'hash'      => $this->hash,
 			'mime-type' => $mime_type,
 			'filesize'  => wp_filesize( $filename ),
 		);

--- a/src/wp-includes/class-wp-image-editor.php
+++ b/src/wp-includes/class-wp-image-editor.php
@@ -242,7 +242,7 @@ abstract class WP_Image_Editor {
 	 * @param string $hash
 	 * @return true
 	 */
-	protected function create_crop_hash( $hash = null ) {
+	protected function update_crop_hash( $hash = null ) {
 		$this->hash = $hash;
 		return true;
 	}

--- a/src/wp-includes/class-wp-image-editor.php
+++ b/src/wp-includes/class-wp-image-editor.php
@@ -15,6 +15,7 @@
 abstract class WP_Image_Editor {
 	protected $file              = null;
 	protected $size              = null;
+	protected $hash         	 = null;
 	protected $mime_type         = null;
 	protected $output_mime_type  = null;
 	protected $default_mime_type = 'image/jpeg';
@@ -218,6 +219,31 @@ abstract class WP_Image_Editor {
 			'width'  => (int) $width,
 			'height' => (int) $height,
 		);
+		return true;
+	}
+
+
+	/**
+	 * Gets current image hash (when crop position has been set).
+	 *
+	 * @since 5.1.0
+	 *
+	 * @return string $hash 8 character hash
+	 */
+	public function get_crop_hash() {
+		return $this->hash;
+	}
+
+	/**
+	 * Sets current image hash (when crop position has been set).
+	 *
+	 * @since 5.1.0
+	 *
+	 * @param string $hash
+	 * @return true
+	 */
+	protected function create_crop_hash( $hash = null ) {
+		$this->hash = $hash;
 		return true;
 	}
 
@@ -486,7 +512,13 @@ abstract class WP_Image_Editor {
 			return false;
 		}
 
-		return "{$this->size['width']}x{$this->size['height']}";
+		$suffix = "{$this->size['width']}x{$this->size['height']}";
+
+		if( $this->get_crop_hash() ){
+			$suffix = $suffix . "-{$this->hash}";
+		}
+		
+		return $suffix;
 	}
 
 	/**

--- a/src/wp-includes/class-wp-image-editor.php
+++ b/src/wp-includes/class-wp-image-editor.php
@@ -15,7 +15,7 @@
 abstract class WP_Image_Editor {
 	protected $file              = null;
 	protected $size              = null;
-	protected $hash         	 = null;
+	protected $hash              = null;
 	protected $mime_type         = null;
 	protected $output_mime_type  = null;
 	protected $default_mime_type = 'image/jpeg';

--- a/src/wp-includes/class-wp-image-editor.php
+++ b/src/wp-includes/class-wp-image-editor.php
@@ -237,7 +237,7 @@ abstract class WP_Image_Editor {
 	/**
 	 * Sets current image hash (when crop position has been set).
 	 *
-	 * @since 5.1.0
+	 * @since 6.4.0
 	 *
 	 * @param string $hash
 	 * @return true


### PR DESCRIPTION
Patches failed on 6.4.
Updated patch for WP 6.4.

Trac ticket: [`add_image_sizes` does not create the "crop position" versions of the image](https://core.trac.wordpress.org/ticket/40370)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
