### PR TITLE
Update post.php

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -3295,7 +3295,7 @@ function wp_match_mime_types( $wildcard_mime_types, $real_mime_types ) {
 	foreach ( $patternses as $patterns ) {
 		foreach ( $patterns as $type => $pattern ) {
 			foreach ( (array) $real_mime_types as $real ) {
-				if ( preg_match( "#$pattern#", $real )
+				if ( is_string( $real ) && ! empty( $real ) && preg_match( "#$pattern#", $real )
 					&& ( empty( $matches[ $type ] ) || false === array_search( $real, $matches[ $type ], true ) )
 				) {
 					$matches[ $type ][] = $real;


### PR DESCRIPTION
Prevent passing null to param #2 of preg_match()

Since param #2 of preg_match() needs to be a string, this checks to make sure `$real` is a string, and that `$real` is not empty, since it's a waste of CPU to run preg_match() on an empty string/value.

Trac ticket: https://core.trac.wordpress.org/ticket/59195

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
