### PR TITLE
Update class-wp-xmlrpc-server.php

### DIFF
--- a/src/wp-includes/class-wp-xmlrpc-server.php
+++ b/src/wp-includes/class-wp-xmlrpc-server.php
@@ -1067,6 +1067,7 @@ class wp_xmlrpc_server extends IXR_Server {
 			'description'      => $media_item->post_content,
 			'metadata'         => wp_get_attachment_metadata( $media_item->ID ),
 			'type'             => $media_item->post_mime_type,
+			'alt'              => get_post_meta( $media_item->ID, '_wp_attachment_image_alt', true ),
 		);
 
 		$thumbnail_src = image_downsize( $media_item->ID, $thumbnail_size );

--- a/tests/phpunit/tests/xmlrpc/wp/getMediaItem.php
+++ b/tests/phpunit/tests/xmlrpc/wp/getMediaItem.php
@@ -25,6 +25,7 @@ class Tests_XMLRPC_wp_getMediaItem extends WP_XMLRPC_UnitTestCase {
 
 		$this->attachment_id   = $this->_make_attachment( $upload, self::$post_id );
 		$this->attachment_data = get_post( $this->attachment_id, ARRAY_A );
+		update_post_meta( $this->attachment_id, '_wp_attachment_image_alt', 'Waffle has alt text' );
 
 		set_post_thumbnail( self::$post_id, $this->attachment_id );
 	}
@@ -60,6 +61,7 @@ class Tests_XMLRPC_wp_getMediaItem extends WP_XMLRPC_UnitTestCase {
 		$this->assertIsString( $result['link'] );
 		$this->assertIsString( $result['thumbnail'] );
 		$this->assertIsArray( $result['metadata'] );
+		$this->assertIsString( $result['alt'] );
 
 		// Check expected values.
 		$this->assertStringMatchesFormat( '%d', $result['attachment_id'] );


### PR DESCRIPTION
Updated _prepare_media_item to include user-provided attachment alt text

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Add alt text to _premare_media_item in class-wp-xmlrpc-server.php

Trac ticket: https://core.trac.wordpress.org/ticket/58582
props: thomashorta, jivygraphics

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
