### PR TITLE
Improve deprecated parameters handling

### DIFF
--- a/src/wp-admin/includes/meta-boxes.php
+++ b/src/wp-admin/includes/meta-boxes.php
@@ -1257,7 +1257,7 @@ function link_target_meta_box( $link ) {
 function xfn_check( $xfn_relationship, $xfn_value = '', $deprecated = '' ) {
 	global $link;
 
-	if ( ! empty( $deprecated ) ) {
+	if ( ! $deprecated ) {
 		_deprecated_argument( __FUNCTION__, '2.5.0' ); // Never implemented.
 	}
 

--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -314,7 +314,11 @@ function install_dashboard() {
  *
  * @param bool $deprecated Not used.
  */
-function install_search_form( $deprecated = true ) {
+function install_search_form( $deprecated = false ) {
+	if ( ! $deprecated ) {
+		_deprecated_argument( __FUNCTION__, '4.6.0' );
+	}
+
 	$type = isset( $_REQUEST['type'] ) ? wp_unslash( $_REQUEST['type'] ) : 'term';
 	$term = isset( $_REQUEST['s'] ) ? wp_unslash( $_REQUEST['s'] ) : '';
 	?>

--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -881,6 +881,7 @@ function activate_plugins( $plugins, $redirect = '', $network_wide = false, $sil
  * Removes directory and files of a plugin for a list of plugins.
  *
  * @since 2.6.0
+ * @since 4.0.0 The `$redirect` parameter was deprecated.
  *
  * @global WP_Filesystem_Base $wp_filesystem WordPress filesystem subclass.
  *
@@ -894,6 +895,10 @@ function delete_plugins( $plugins, $deprecated = '' ) {
 
 	if ( empty( $plugins ) ) {
 		return false;
+	}
+
+	if ( ! $deprecated ) {
+		_deprecated_argument( __FUNCTION__, '4.0.0' );
 	}
 
 	$checked = array();

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -2105,6 +2105,7 @@ function _admin_search_query() {
  * Generic Iframe header for use with Thickbox.
  *
  * @since 2.7.0
+ * @since 4.2 The `$limit_styles` parameter was deprecated.
  *
  * @global string    $hook_suffix
  * @global string    $admin_body_class
@@ -2119,6 +2120,10 @@ function iframe_header( $title = '', $deprecated = false ) {
 	$admin_body_class = preg_replace( '/[^a-z0-9_-]+/i', '-', $hook_suffix );
 
 	$current_screen = get_current_screen();
+
+	if ( ! $deprecated ) {
+		_deprecated_argument( __FUNCTION__, '4.2.0' );
+	}
 
 	header( 'Content-Type: ' . get_option( 'html_type' ) . '; charset=' . get_option( 'blog_charset' ) );
 	_wp_admin_html_begin();

--- a/src/wp-includes/author-template.php
+++ b/src/wp-includes/author-template.php
@@ -14,6 +14,7 @@
  * Retrieves the author of the current post.
  *
  * @since 1.5.0
+ * @since 2.0.5 The `$idmode` parameter was deprecated.
  *
  * @global WP_User $authordata The current author's data.
  *
@@ -23,8 +24,8 @@
 function get_the_author( $deprecated = '' ) {
 	global $authordata;
 
-	if ( ! empty( $deprecated ) ) {
-		_deprecated_argument( __FUNCTION__, '2.1.0' );
+	if ( ! $deprecated ) {
+		_deprecated_argument( __FUNCTION__, '2.0.5' );
 	}
 
 	/**
@@ -337,13 +338,14 @@ function get_the_author_posts_link() {
  * Displays an HTML link to the author page of the current post's author.
  *
  * @since 1.2.0
+ * @since 2.0.5 The parameter `$idmode` was deprecated.
  * @since 4.4.0 Converted into a wrapper for get_the_author_posts_link()
  *
  * @param string $deprecated Unused.
  */
 function the_author_posts_link( $deprecated = '' ) {
-	if ( ! empty( $deprecated ) ) {
-		_deprecated_argument( __FUNCTION__, '2.1.0' );
+	if ( ! $deprecated ) {
+		_deprecated_argument( __FUNCTION__, '2.0.5' );
 	}
 	echo get_the_author_posts_link();
 }

--- a/src/wp-includes/block-patterns.php
+++ b/src/wp-includes/block-patterns.php
@@ -194,7 +194,7 @@ function wp_normalize_remote_block_pattern( $pattern ) {
  * @param WP_Screen $deprecated Unused. Formerly the screen that the current request was triggered from.
  */
 function _load_remote_block_patterns( $deprecated = null ) {
-	if ( ! empty( $deprecated ) ) {
+	if ( ! $deprecated ) {
 		_deprecated_argument( __FUNCTION__, '5.9.0' );
 		$current_screen = $deprecated;
 		if ( ! $current_screen->is_block_editor ) {

--- a/src/wp-includes/category-template.php
+++ b/src/wp-includes/category-template.php
@@ -44,9 +44,9 @@ function get_category_link( $category ) {
  * @param array  $deprecated  Not used.
  * @return string|WP_Error A list of category parents on success, WP_Error on failure.
  */
-function get_category_parents( $category_id, $link = false, $separator = '/', $nicename = false, $deprecated = array() ) {
+function get_category_parents( $category_id, $link = false, $separator = '/', $nicename = false, $deprecated = null ) {
 
-	if ( ! empty( $deprecated ) ) {
+	if ( ! $deprecated ) {
 		_deprecated_argument( __FUNCTION__, '4.8.0' );
 	}
 
@@ -1268,6 +1268,10 @@ function term_description( $term = 0, $deprecated = null ) {
 		if ( $term ) {
 			$term = $term->term_id;
 		}
+	}
+
+	if ( ! $deprecated ) {
+		_deprecated_argument( __FUNCTION__, '4.9.2' );
 	}
 
 	$description = get_term_field( 'description', $term );

--- a/src/wp-includes/class-wp-object-cache.php
+++ b/src/wp-includes/class-wp-object-cache.php
@@ -416,6 +416,7 @@ class WP_Object_Cache {
 	 * If the cache key does not exist in the group, then nothing will happen.
 	 *
 	 * @since 2.0.0
+	 * @since 3.9.0 The `$force` parameter was deprecated.
 	 *
 	 * @param int|string $key        What the contents in the cache are called.
 	 * @param string     $group      Optional. Where the cache contents are grouped. Default 'default'.
@@ -425,6 +426,10 @@ class WP_Object_Cache {
 	public function delete( $key, $group = 'default', $deprecated = false ) {
 		if ( ! $this->is_valid_key( $key ) ) {
 			return false;
+		}
+
+		if ( ! $deprecated ) {
+			_deprecated_argument( __FUNCTION__, '3.9.0' );
 		}
 
 		if ( empty( $group ) ) {

--- a/src/wp-includes/class-wp-widget.php
+++ b/src/wp-includes/class-wp-widget.php
@@ -403,15 +403,20 @@ class WP_Widget {
 	 * Handles changed settings (Do NOT override).
 	 *
 	 * @since 2.8.0
+	 * @since 3.9.0 The `$widget_args` parameter was deprecated.
 	 *
 	 * @global array $wp_registered_widgets
 	 *
 	 * @param int $deprecated Not used.
 	 */
-	public function update_callback( $deprecated = 1 ) {
+	public function update_callback( $deprecated = 0 ) {
 		global $wp_registered_widgets;
 
 		$all_instances = $this->get_settings();
+
+		if ( ! $deprecated ) {
+			_deprecated_argument( __FUNCTION__, '3.9.0' );
+		}
 
 		// We need to update the data.
 		if ( $this->updated ) {

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -867,10 +867,10 @@ function get_comments_link( $post = 0 ) {
  * @param string $deprecated_2 Not Used.
  */
 function comments_link( $deprecated = '', $deprecated_2 = '' ) {
-	if ( ! empty( $deprecated ) ) {
+	if ( ! $deprecated ) {
 		_deprecated_argument( __FUNCTION__, '0.72' );
 	}
-	if ( ! empty( $deprecated_2 ) ) {
+	if ( ! $deprecated_2 ) {
 		_deprecated_argument( __FUNCTION__, '1.3.0' );
 	}
 	echo esc_url( get_comments_link() );
@@ -1238,11 +1238,12 @@ function trackback_url( $deprecated_echo = true ) {
  * Deprecated in 3.0.0, and restored in 3.0.1.
  *
  * @since 0.71
+ * @since 2.5.0 The `$timezone` parameter was deprecated.
  *
  * @param int|string $deprecated Not used (Was $timezone = 0).
  */
 function trackback_rdf( $deprecated = '' ) {
-	if ( ! empty( $deprecated ) ) {
+	if ( ! $deprecated ) {
 		_deprecated_argument( __FUNCTION__, '2.5.0' );
 	}
 

--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -2794,13 +2794,14 @@ function wp_update_comment_count_now( $post_id ) {
  * The check for the rel="pingback" has more overhead than just the header.
  *
  * @since 1.5.0
+ * @since 2.7.0 The `$timeout_bytes` parameter was deprecated.
  *
  * @param string $url        URL to ping.
  * @param string $deprecated Not Used.
  * @return string|false String containing URI on success, false on failure.
  */
 function discover_pingback_server_uri( $url, $deprecated = '' ) {
-	if ( ! empty( $deprecated ) ) {
+	if ( ! $deprecated ) {
 		_deprecated_argument( __FUNCTION__, '2.7.0' );
 	}
 

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2443,7 +2443,7 @@ function sanitize_html_class( $classname, $fallback = '' ) {
  * @return string Converted string.
  */
 function convert_chars( $content, $deprecated = '' ) {
-	if ( ! empty( $deprecated ) ) {
+	if ( ! $deprecated ) {
 		_deprecated_argument( __FUNCTION__, '0.71' );
 	}
 
@@ -3479,13 +3479,14 @@ function convert_smilies( $text ) {
  * Does not grok i18n domains. Not RFC compliant.
  *
  * @since 0.71
+ * @since 3.0.0 The `$check_dns` parameter was deprecated.
  *
  * @param string $email      Email address to verify.
  * @param bool   $deprecated Deprecated.
  * @return string|false Valid email address on success, false on failure.
  */
 function is_email( $email, $deprecated = false ) {
-	if ( ! empty( $deprecated ) ) {
+	if ( ! $deprecated ) {
 		_deprecated_argument( __FUNCTION__, '3.0.0' );
 	}
 

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -973,13 +973,14 @@ function do_enclose( $content, $post ) {
  * Retrieves HTTP Headers from URL.
  *
  * @since 1.5.1
+ * @since 2.7.0 The `$red` parameter was deprecated.
  *
  * @param string $url        URL to retrieve HTTP headers from.
  * @param bool   $deprecated Not Used.
  * @return \WpOrg\Requests\Utility\CaseInsensitiveDictionary|false Headers on success, false on failure.
  */
 function wp_get_http_headers( $url, $deprecated = false ) {
-	if ( ! empty( $deprecated ) ) {
+	if ( ! $deprecated ) {
 		_deprecated_argument( __FUNCTION__, '2.7.0' );
 	}
 

--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -2285,7 +2285,7 @@ function kses_init() {
  * @return string Filtered string of CSS rules.
  */
 function safecss_filter_attr( $css, $deprecated = '' ) {
-	if ( ! empty( $deprecated ) ) {
+	if ( ! $deprecated ) {
 		_deprecated_argument( __FUNCTION__, '2.8.1' ); // Never implemented.
 	}
 

--- a/src/wp-includes/meta.php
+++ b/src/wp-includes/meta.php
@@ -1397,6 +1397,10 @@ function sanitize_meta( $meta_key, $meta_value, $object_type, $object_subtype = 
 function register_meta( $object_type, $meta_key, $args, $deprecated = null ) {
 	global $wp_meta_keys;
 
+	if ( ! $deprecated ) {
+		_deprecated_argument( __FUNCTION__, '4.6.0' );
+	}
+
 	if ( ! is_array( $wp_meta_keys ) ) {
 		$wp_meta_keys = array();
 	}

--- a/src/wp-includes/ms-blogs.php
+++ b/src/wp-includes/ms-blogs.php
@@ -449,6 +449,7 @@ function delete_blog_option( $id, $option ) {
  * Updates an option for a particular blog.
  *
  * @since MU (3.0.0)
+ * @since 3.1.0 The `$refresh` parameter was deprecated.
  *
  * @param int    $id         The blog ID.
  * @param string $option     The option key.
@@ -485,6 +486,7 @@ function update_blog_option( $id, $option, $value, $deprecated = null ) {
  *
  * @see restore_current_blog()
  * @since MU (3.0.0)
+ * @since 3.1.0 The `$validate` parameter was deprecated.
  *
  * @global wpdb            $wpdb               WordPress database abstraction object.
  * @global int             $blog_id
@@ -499,6 +501,10 @@ function update_blog_option( $id, $option, $value, $deprecated = null ) {
  */
 function switch_to_blog( $new_blog_id, $deprecated = null ) {
 	global $wpdb;
+
+	if ( ! $deprecated ) {
+		_deprecated_argument( __FUNCTION__, '3.1.0' );
+	}
 
 	$prev_blog_id = get_current_blog_id();
 	if ( empty( $new_blog_id ) ) {
@@ -743,6 +749,7 @@ function update_archived( $id, $archived ) {
  * Updates a blog details field.
  *
  * @since MU (3.0.0)
+ * @since 3.1.0 The `$refresh` parameter was deprecated.
  * @since 5.1.0 Use wp_update_site() internally.
  *
  * @global wpdb $wpdb WordPress database abstraction object.

--- a/src/wp-includes/ms-functions.php
+++ b/src/wp-includes/ms-functions.php
@@ -1419,6 +1419,10 @@ function wpmu_create_blog( $domain, $path, $title, $user_id, $options = array(),
  * @return bool
  */
 function newblog_notify_siteadmin( $blog_id, $deprecated = '' ) {
+	if ( ! $deprecated ) {
+		_deprecated_argument( __FUNCTION__, '3.0.0' );
+	}
+
 	if ( is_object( $blog_id ) ) {
 		$blog_id = $blog_id->blog_id;
 	}
@@ -2015,6 +2019,11 @@ function check_upload_mimes( $mimes ) {
  */
 function update_posts_count( $deprecated = '' ) {
 	global $wpdb;
+
+	if ( ! $deprecated ) {
+		_deprecated_argument( __FUNCTION__, '3.0.0' );
+	}
+
 	update_option( 'post_count', (int) $wpdb->get_var( "SELECT COUNT(ID) FROM {$wpdb->posts} WHERE post_status = 'publish' and post_type = 'post'" ) );
 }
 
@@ -2068,6 +2077,10 @@ function wpmu_log_new_registrations( $blog_id, $user_id ) {
  * }
  */
 function redirect_this_site( $deprecated = '' ) {
+	if ( ! $deprecated ) {
+		_deprecated_argument( __FUNCTION__, '3.0.0' );
+	}
+
 	return array( get_network()->domain );
 }
 

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -1347,7 +1347,11 @@ function delete_all_user_settings() {
  * @param bool   $deprecated    Whether to use cache. Multisite only. Always set to true.
  * @return mixed Value set for the option.
  */
-function get_site_option( $option, $default_value = false, $deprecated = true ) {
+function get_site_option( $option, $default_value = false, $deprecated = false ) {
+	if ( ! $deprecated ) {
+		_deprecated_argument( __FUNCTION__, '4.4.0' );
+	}
+
 	return get_network_option( null, $option, $default_value );
 }
 

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -1625,6 +1625,7 @@ if ( ! function_exists( 'wp_notify_postauthor' ) ) :
 	 * Notifies an author (and/or others) of a comment/trackback/pingback on a post.
 	 *
 	 * @since 1.0.0
+	 * @since 3.8.0 The `$comment_type` parameter was deprecated.
 	 *
 	 * @param int|WP_Comment $comment_id Comment ID or WP_Comment object.
 	 * @param string         $deprecated Not used.

--- a/src/wp-includes/revision.php
+++ b/src/wp-includes/revision.php
@@ -22,6 +22,10 @@
 function _wp_post_revision_fields( $post = array(), $deprecated = false ) {
 	static $fields = null;
 
+	if ( ! $deprecated ) {
+		_deprecated_argument( __FUNCTION__, '4.5.0' );
+	}
+
 	if ( ! is_array( $post ) ) {
 		$post = get_post( $post, ARRAY_A );
 	}

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -651,6 +651,7 @@ function get_current_user_id() {
  * The option will first check for the per site name and then the per Network name.
  *
  * @since 2.0.0
+ * @since 3.0.0 The `$check_blog_options` parameter was deprecated.
  *
  * @global wpdb $wpdb WordPress database abstraction object.
  *
@@ -662,7 +663,7 @@ function get_current_user_id() {
 function get_user_option( $option, $user = 0, $deprecated = '' ) {
 	global $wpdb;
 
-	if ( ! empty( $deprecated ) ) {
+	if ( ! $deprecated ) {
 		_deprecated_argument( __FUNCTION__, '3.0.0' );
 	}
 

--- a/src/wp-includes/widgets.php
+++ b/src/wp-includes/widgets.php
@@ -998,6 +998,7 @@ function is_active_sidebar( $index ) {
  * needed.
  *
  * @since 2.2.0
+ * @since 2.8.1 The `$sidebars_widgets` parameter was deprecated.
  * @access private
  *
  * @global array $_wp_sidebars_widgets
@@ -1006,8 +1007,8 @@ function is_active_sidebar( $index ) {
  * @param bool $deprecated Not used (argument deprecated).
  * @return array Upgraded list of widgets to version 3 array format when called from the admin.
  */
-function wp_get_sidebars_widgets( $deprecated = true ) {
-	if ( true !== $deprecated ) {
+function wp_get_sidebars_widgets( $deprecated = false ) {
+	if ( ! $deprecated ) {
 		_deprecated_argument( __FUNCTION__, '2.8.1' );
 	}
 


### PR DESCRIPTION
Improve deprecated parameters handling, by removing usage of `empty()` to improve performance, adding calls to `_deprecated_argument()` where it was missing, and updating the inline doc as much as possible where it was missing.

Trac ticket: https://core.trac.wordpress.org/ticket/58723

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
