### PR TITLE
40370-patch

### DIFF
--- a/src/wp-includes/class-wp-image-editor-gd.php
+++ b/src/wp-includes/class-wp-image-editor-gd.php
@@ -154,6 +154,27 @@ class WP_Image_Editor_GD extends WP_Image_Editor {
 	}
 
 	/**
+	 * Sets or updates current image size.
+	 *
+	 * @since 6.4.0
+	 *
+	 * @param bool|array $crop
+	 * @param int $dst_w
+	 * @param int $dst_h
+	 * @return true
+	 */
+	protected function create_crop_hash( $crop, $dst_w, $dst_h ) {
+		if ( ! is_array( $crop ) ) {
+			return false;
+		}
+
+		$str = $crop[0] . $crop[1] . $dst_w . $dst_h;
+		$hash = substr( md5( $str ), 0, 8 );
+		
+		return parent::update_crop_hash( $hash );
+	}
+
+	/**
 	 * Resizes current image.
 	 *
 	 * Wraps `::_resize()` which returns a GD resource or GdImage instance.
@@ -220,6 +241,7 @@ class WP_Image_Editor_GD extends WP_Image_Editor {
 		imagecopyresampled( $resized, $this->image, $dst_x, $dst_y, $src_x, $src_y, $dst_w, $dst_h, $src_w, $src_h );
 
 		if ( is_gd_image( $resized ) ) {
+			$this->create_crop_hash( $crop, $dst_w, $dst_h );
 			$this->update_size( $dst_w, $dst_h );
 			return $resized;
 		}
@@ -534,6 +556,7 @@ class WP_Image_Editor_GD extends WP_Image_Editor {
 			'file'      => wp_basename( apply_filters( 'image_make_intermediate_size', $filename ) ),
 			'width'     => $this->size['width'],
 			'height'    => $this->size['height'],
+			'hash'      => $this->hash,
 			'mime-type' => $mime_type,
 			'filesize'  => wp_filesize( $filename ),
 		);

--- a/src/wp-includes/class-wp-image-editor-imagick.php
+++ b/src/wp-includes/class-wp-image-editor-imagick.php
@@ -310,6 +310,27 @@ class WP_Image_Editor_Imagick extends WP_Image_Editor {
 	}
 
 	/**
+	 * Sets or updates current image size.
+	 *
+	 * @since 6.4.0
+	 *
+	 * @param bool|array $crop
+	 * @param int $dst_w
+	 * @param int $dst_h
+	 * @return true
+	 */
+	protected function create_crop_hash( $crop, $dst_w, $dst_h ) {
+		if ( ! is_array( $crop ) ) {
+			return false;
+		}
+
+		$str = $crop[0] . $crop[1] . $dst_w . $dst_h;
+		$hash = substr( md5( $str ), 0, 8 );
+		
+		return parent::update_crop_hash( $hash );
+	}
+
+	/**
 	 * Resizes current image.
 	 *
 	 * At minimum, either a height or width must be provided.
@@ -343,6 +364,7 @@ class WP_Image_Editor_Imagick extends WP_Image_Editor {
 		list( $dst_x, $dst_y, $src_x, $src_y, $dst_w, $dst_h, $src_w, $src_h ) = $dims;
 
 		if ( $crop ) {
+			$this->create_crop_hash( $crop, $dst_w, $dst_h );
 			return $this->crop( $src_x, $src_y, $src_w, $src_h, $dst_w, $dst_h );
 		}
 
@@ -837,6 +859,7 @@ class WP_Image_Editor_Imagick extends WP_Image_Editor {
 			'file'      => wp_basename( apply_filters( 'image_make_intermediate_size', $filename ) ),
 			'width'     => $this->size['width'],
 			'height'    => $this->size['height'],
+			'hash'      => $this->hash,
 			'mime-type' => $mime_type,
 			'filesize'  => wp_filesize( $filename ),
 		);

--- a/src/wp-includes/class-wp-image-editor.php
+++ b/src/wp-includes/class-wp-image-editor.php
@@ -15,6 +15,7 @@
 abstract class WP_Image_Editor {
 	protected $file              = null;
 	protected $size              = null;
+	protected $hash              = null;
 	protected $mime_type         = null;
 	protected $output_mime_type  = null;
 	protected $default_mime_type = 'image/jpeg';
@@ -218,6 +219,31 @@ abstract class WP_Image_Editor {
 			'width'  => (int) $width,
 			'height' => (int) $height,
 		);
+		return true;
+	}
+
+
+	/**
+	 * Gets current image hash (when crop position has been set).
+	 *
+	 * @since 5.1.0
+	 *
+	 * @return string $hash 8 character hash
+	 */
+	public function get_crop_hash() {
+		return $this->hash;
+	}
+
+	/**
+	 * Sets current image hash (when crop position has been set).
+	 *
+	 * @since 5.1.0
+	 *
+	 * @param string $hash
+	 * @return true
+	 */
+	protected function update_crop_hash( $hash = null ) {
+		$this->hash = $hash;
 		return true;
 	}
 
@@ -486,7 +512,13 @@ abstract class WP_Image_Editor {
 			return false;
 		}
 
-		return "{$this->size['width']}x{$this->size['height']}";
+		$suffix = "{$this->size['width']}x{$this->size['height']}";
+
+		if( $this->get_crop_hash() ){
+			$suffix = $suffix . "-{$this->hash}";
+		}
+		
+		return $suffix;
 	}
 
 	/**

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -1364,6 +1364,64 @@ VIDEO;
 	}
 
 	/**
+	 * @ticket 40370
+	 */
+	public function test_media_handle_upload_add_image_size() {
+		global $_wp_additional_image_sizes; 
+
+		$iptc_file = DIR_TESTDATA . '/images/test-image-iptc.jpg';
+
+		// Make a copy of this file as it gets moved during the file upload
+		$tmp_name = wp_tempnam( $iptc_file );
+
+		copy( $iptc_file, $tmp_name );
+
+		// FIXME : change to correct upload method that creates thumbnails
+		// and resuts in the new filenames with hashes
+		$_FILES['async-upload'] = array(
+			'tmp_name' => $tmp_name,
+			'name'     => 'test-image-iptc.jpg',
+			'type'     => 'image/jpeg',
+			'error'    => 0,
+			'size'     => filesize( $iptc_file ),
+		);
+
+		// add multiple image sizes
+		add_image_size( 'newscentered', 400, 400, array( 'center', 'center') ); 
+		add_image_size( 'newstop', 400, 400, array( 'center', 'top' ) ); 
+		add_image_size( 'newsbottom', 400, 400, array( 'center', 'bottom' ) ); 
+
+		$info = wp_upload_dir();
+
+		$orig = array_map('basename', glob( ABSPATH . 'wp-content/uploads'
+					. $info['subdir'] .'/*.png'));
+
+		// upload file
+		$post_id = media_handle_upload(
+			'async-upload',
+			0,
+			array(),
+			array(
+				'action'    => 'test_iptc_upload',
+				'test_form' => false,
+			)
+		);
+
+		unset( $_FILES['upload'] );
+
+		// Clean up.
+		wp_delete_attachment( $post_id );
+
+		// 3 new files should be created
+		$new = array_map('basename', glob( ABSPATH . 'wp-content/uploads'
+					. $info['subdir'] .'/*.{jpg, png}', GLOB_BRACE));
+		$new_files = array_diff($new, $orig);
+
+		$this->assertCount(3, $new_files );
+		
+	}
+
+	/**
 	 * @ticket 33016
 	 */
 	public function test_multiline_cdata() {


### PR DESCRIPTION
- Applied 3 patches
- Inserted patch updates that failed
- Corrected code formatted for newly added code

----

**Additional**

Unit testing is required.

In manual tests, I found that an image uploaded when there are 3 image sizes with the same dimensions, but different crop settings, separate images were created for each of the images sizes. 

Given the usecase:

```php
add_image_size( 'newscentered', 400, 400, array( 'center', 'center') );
add_image_size( 'newstop', 400, 400, array( 'center', 'top' ) );
add_image_size( 'newsbottom', 400, 400, array( 'center', 'bottom' ) );
```
Uploaded the image `carmella-red-dress.png`

Produced the following files:
`carmella-red-dress.png` (original file)
`carmella-red-dress-400x400-53fd9f7a.png`
`carmella-red-dress-400x400-420047e7.png`
`carmella-red-dress-400x400-34920233.png`

Trac ticket: [add_image_sizes does not create the "crop position" versions of the image](https://core.trac.wordpress.org/ticket/40370)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
