### PR TITLE
Apply check_package() on bulk plugin update

### DIFF
--- a/src/wp-admin/includes/class-plugin-upgrader.php
+++ b/src/wp-admin/includes/class-plugin-upgrader.php
@@ -343,6 +343,7 @@ class Plugin_Upgrader extends WP_Upgrader {
 
 			$this->skin->plugin_active = is_plugin_active( $plugin );
 
+			add_filter( 'upgrader_source_selection', array( $this, 'check_package' ) );
 			$result = $this->run(
 				array(
 					'package'           => $r->package,
@@ -360,6 +361,7 @@ class Plugin_Upgrader extends WP_Upgrader {
 					),
 				)
 			);
+			remove_filter( 'upgrader_source_selection', array( $this, 'check_package' ) );
 
 			$results[ $plugin ] = $result;
 


### PR DESCRIPTION
Apply check_package() on bulk plugin update via the "upgrader_source_selection" filter.

This applies the same PHP minimum version checks
on bulk plugin update that are applied on a
single plugin update.

Trac ticket: https://core.trac.wordpress.org/ticket/59198