### PR TITLE
Don't cache id=>parent queries without limits

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -3170,6 +3170,11 @@ class WP_Query {
 			$id_query_is_cacheable = false;
 		}
 
+		// Don't cache the query if it's for id=>parent relationships for all posts.
+		if ( 'id=>parent' === $q['fields'] && -1 === $q['posts_per_page'] ) {
+			$id_query_is_cacheable = false;
+		}
+
 		if ( $q['cache_results'] && $id_query_is_cacheable ) {
 			$new_request = str_replace( $fields, "{$wpdb->posts}.*", $this->request );
 			$cache_key   = $this->generate_cache_key( $q, $new_request );


### PR DESCRIPTION
Fixes a bug whereby the Pages list view in the admin (or any other hierarchical post type) performs a query for `id=>parent` with a limit of `-1` which results in priming post caches for all posts of that post type, including postmeta and terms, that aren't already in the cache, which can crash sites with an empty cache and a lot of posts/postmeta.

Trac ticket: https://core.trac.wordpress.org/ticket/59188