### PR TITLE
GMT Offset Type Errors

### DIFF
--- a/src/wp-admin/options-general.php
+++ b/src/wp-admin/options-general.php
@@ -230,7 +230,7 @@ if ( ! empty( $languages ) || ! empty( $translations ) ) {
 ?>
 <tr>
 <?php
-$current_offset = get_option( 'gmt_offset' );
+$current_offset = current_gmt_offset();
 $tzstring       = get_option( 'timezone_string' );
 
 $check_zone_info = true;

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -1079,7 +1079,7 @@ if ( 'upgrade-core' === $action ) {
 	$current           = get_site_transient( 'update_core' );
 
 	if ( $current && isset( $current->last_checked ) ) {
-		$last_update_check = $current->last_checked + get_option( 'gmt_offset' ) * HOUR_IN_SECONDS;
+		$last_update_check = $current->last_checked + current_gmt_offset() * HOUR_IN_SECONDS;
 	}
 
 	echo '<h2 class="wp-current-version">';

--- a/src/wp-includes/bookmark-template.php
+++ b/src/wp-includes/bookmark-template.php
@@ -90,7 +90,7 @@ function _walk_bookmarks( $bookmarks, $args = '' ) {
 					__( 'Last updated: %s' ),
 					gmdate(
 						get_option( 'links_updated_date_format' ),
-						$bookmark->link_updated_f + ( get_option( 'gmt_offset' ) * HOUR_IN_SECONDS )
+						$bookmark->link_updated_f + ( current_gmt_offset() * HOUR_IN_SECONDS )
 					)
 				);
 				$title .= ')';

--- a/src/wp-includes/customize/class-wp-customize-date-time-control.php
+++ b/src/wp-includes/customize/class-wp-customize-date-time-control.php
@@ -280,7 +280,7 @@ class WP_Customize_Date_Time_Control extends WP_Customize_Control {
 				$timezone_info['description'] = '';
 			}
 		} else {
-			$formatted_gmt_offset = $this->format_gmt_offset( (int) get_option( 'gmt_offset', 0 ) );
+			$formatted_gmt_offset = $this->format_gmt_offset( current_gmt_offset() );
 
 			$timezone_info['description'] = sprintf(
 				/* translators: 1: UTC abbreviation and offset, 2: UTC offset. */

--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -981,7 +981,7 @@ function get_links($category = -1, $before = '', $after = '<br />', $between = '
 
 		if ( $show_updated )
 			if ( !str_starts_with($row->link_updated_f, '00') )
-				$title .= ' ('.__('Last updated') . ' ' . gmdate(get_option('links_updated_date_format'), $row->link_updated_f + (get_option('gmt_offset') * HOUR_IN_SECONDS)) . ')';
+				$title .= ' ('.__('Last updated') . ' ' . gmdate(get_option('links_updated_date_format'), $row->link_updated_f + (current_gmt_offset() * HOUR_IN_SECONDS)) . ')';
 
 		if ( '' != $title )
 			$title = ' title="' . $title . '"';

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -73,7 +73,7 @@ function mysql2date( $format, $date, $translate = true ) {
 function current_time( $type, $gmt = 0 ) {
 	// Don't use non-GMT timestamp, unless you know the difference and really need to.
 	if ( 'timestamp' === $type || 'U' === $type ) {
-		return $gmt ? time() : time() + (int) ( get_option( 'gmt_offset' ) * HOUR_IN_SECONDS );
+		return $gmt ? time() : time() + (int) ( current_gmt_offset() * HOUR_IN_SECONDS );
 	}
 
 	if ( 'mysql' === $type ) {
@@ -95,6 +95,19 @@ function current_time( $type, $gmt = 0 ) {
  */
 function current_datetime() {
 	return new DateTimeImmutable( 'now', wp_timezone() );
+}
+
+/**
+ * Retrieves the current GMT offset set for the site.
+ *
+ *  - Default to 0 if the option is not set or invalid
+ *
+ * @since 6.4.0
+ *
+ * @return float
+ */
+function current_gmt_offset() {
+	return (float) get_option( 'gmt_offset', 0 );
 }
 
 /**
@@ -123,7 +136,7 @@ function wp_timezone_string() {
 		return $timezone_string;
 	}
 
-	$offset  = (float) get_option( 'gmt_offset' );
+	$offset  = current_gmt_offset();
 	$hours   = (int) $offset;
 	$minutes = ( $offset - $hours );
 

--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -1265,7 +1265,7 @@ class WP_REST_Server {
 			'description'     => get_option( 'blogdescription' ),
 			'url'             => get_option( 'siteurl' ),
 			'home'            => home_url(),
-			'gmt_offset'      => get_option( 'gmt_offset' ),
+			'gmt_offset'      => current_gmt_offset(),
 			'timezone_string' => get_option( 'timezone_string' ),
 			'namespaces'      => array_keys( $this->namespaces ),
 			'authentication'  => array(),

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -1802,7 +1802,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			 * with the site's timezone offset applied.
 			 */
 			if ( '0000-00-00 00:00:00' === $post->post_modified_gmt ) {
-				$post_modified_gmt = gmdate( 'Y-m-d H:i:s', strtotime( $post->post_modified ) - ( get_option( 'gmt_offset' ) * HOUR_IN_SECONDS ) );
+				$post_modified_gmt = gmdate( 'Y-m-d H:i:s', strtotime( $post->post_modified ) - ( current_gmt_offset() * HOUR_IN_SECONDS ) );
 			} else {
 				$post_modified_gmt = $post->post_modified_gmt;
 			}

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -444,7 +444,7 @@ function wp_default_packages_inline_scripts( $scripts ) {
 						'datetimeAbbreviated' => __( 'M j, Y g:i a' ),
 					),
 					'timezone' => array(
-						'offset' => (float) get_option( 'gmt_offset', 0 ),
+						'offset' => current_gmt_offset(),
 						'string' => $timezone_string,
 						'abbr'   => $timezone_abbr,
 					),

--- a/src/wp-mail.php
+++ b/src/wp-mail.php
@@ -44,7 +44,7 @@ if ( $last_checked ) {
 
 set_transient( 'mailserver_last_checked', true, WP_MAIL_INTERVAL );
 
-$time_difference = get_option( 'gmt_offset' ) * HOUR_IN_SECONDS;
+$time_difference = current_gmt_offset() * HOUR_IN_SECONDS;
 
 $phone_delim = '::';
 

--- a/tests/phpunit/tests/date/currentGmtOffset.php
+++ b/tests/phpunit/tests/date/currentGmtOffset.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * @group date
+ * @group datetime
+ * @covers ::current_gmt_offset()
+ */
+class Tests_Date_CurrentGmtOffset extends WP_UnitTestCase {
+
+	/**
+	 * Cleans up.
+	 */
+	public function tear_down() {
+		// Reset changed options to their default value.
+		update_option( 'gmt_offset', 0 );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * @ticket 58986
+	 */
+	public function test_current_gmt_offset_empty_is_default() {
+		delete_option( 'gmt_offset' );
+
+		$this->assertIsFloat( current_gmt_offset(), 'Missing current GMT offset is default of 0');
+	}
+
+	/**
+	 * @ticket 58986
+	 */
+	public function test_current_gmt_offset_invalid_boolean_true() {
+		update_option( 'gmt_offset', true );
+
+		$this->assertEquals( 0, current_gmt_offset(), 'Invalid current GMT offset of boolean true is 0');
+	}
+
+	/**
+	 * @ticket 58986
+	 */
+	public function test_current_gmt_offset_invalid_string() {
+		update_option( 'gmt_offset', 'NinePointFive' );
+
+		$this->assertEquals( 0, current_gmt_offset(), 'Invalid current GMT offset of non-numeric text is 0');
+	}
+
+	/**
+	 * @ticket 58986
+	 */
+	public function test_current_gmt_offset_is_float() {
+		update_option( 'gmt_offset', 9.5 );
+
+		$this->assertIsFloat( current_gmt_offset(), 'Current GMT offset is a float');
+	}
+}

--- a/tests/phpunit/tests/date/currentGmtOffset.php
+++ b/tests/phpunit/tests/date/currentGmtOffset.php
@@ -23,7 +23,7 @@ class Tests_Date_CurrentGmtOffset extends WP_UnitTestCase {
 	public function test_current_gmt_offset_empty_is_default() {
 		delete_option( 'gmt_offset' );
 
-		$this->assertIsFloat( current_gmt_offset(), 'Missing current GMT offset is default of 0');
+		$this->assertIsFloat( current_gmt_offset(), 'Missing current GMT offset is default of 0' );
 	}
 
 	/**
@@ -32,7 +32,7 @@ class Tests_Date_CurrentGmtOffset extends WP_UnitTestCase {
 	public function test_current_gmt_offset_invalid_boolean_true() {
 		update_option( 'gmt_offset', true );
 
-		$this->assertEquals( 0, current_gmt_offset(), 'Invalid current GMT offset of boolean true is 0');
+		$this->assertEquals( 0, current_gmt_offset(), 'Invalid current GMT offset of boolean true is 0' );
 	}
 
 	/**
@@ -41,7 +41,7 @@ class Tests_Date_CurrentGmtOffset extends WP_UnitTestCase {
 	public function test_current_gmt_offset_invalid_string() {
 		update_option( 'gmt_offset', 'NinePointFive' );
 
-		$this->assertEquals( 0, current_gmt_offset(), 'Invalid current GMT offset of non-numeric text is 0');
+		$this->assertEquals( 0, current_gmt_offset(), 'Invalid current GMT offset of non-numeric text is 0' );
 	}
 
 	/**
@@ -50,6 +50,6 @@ class Tests_Date_CurrentGmtOffset extends WP_UnitTestCase {
 	public function test_current_gmt_offset_is_float() {
 		update_option( 'gmt_offset', 9.5 );
 
-		$this->assertIsFloat( current_gmt_offset(), 'Current GMT offset is a float');
+		$this->assertIsFloat( current_gmt_offset(), 'Current GMT offset is a float' );
 	}
 }

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -10,7 +10,7 @@ mockedApiResponse.Schema = {
     "description": "",
     "url": "http://example.org",
     "home": "http://example.org",
-    "gmt_offset": "0",
+    "gmt_offset": 0,
     "timezone_string": "",
     "namespaces": [
         "oembed/1.0",


### PR DESCRIPTION
Edge cases of a missing/invalid GMT offset can cause type casting error. Additionally, Core contained multiple direct calls to retrieve this option with an inconsistent usage and an apparent misconception in some resolutions that the offset was an integer, where it is actually a float/double.

To address the issue, I added `current_gmt_offset` to ensure a valid float, with default offset of 0, and further replaced all instances of the direct data retrieval with this function as a proxy. 

Trac tickets: [Ticket #58986](https://core.trac.wordpress.org/ticket/58986) and [Ticket # 57035](https://core.trac.wordpress.org/ticket/57035)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
