### PR TITLE
#58955 Promote some test skipping to failures

### DIFF
--- a/tests/phpunit/includes/testcase-xml.php
+++ b/tests/phpunit/includes/testcase-xml.php
@@ -41,7 +41,7 @@ abstract class WP_Test_XML_TestCase extends WP_UnitTestCase {
 	 */
 	public function normalizeXML( $xml, $options = 0 ) {
 		if ( ! class_exists( 'XSLTProcessor' ) ) {
-			$this->markTestSkipped( 'This test requires the XSL extension.' );
+			$this->fail( 'This test requires the XSL extension.' );
 		}
 
 		static $xslt_proc;

--- a/tests/phpunit/tests/admin/wpAutomaticUpdater.php
+++ b/tests/phpunit/tests/admin/wpAutomaticUpdater.php
@@ -69,7 +69,7 @@ class Tests_Admin_WpAutomaticUpdater extends WP_UnitTestCase {
 		$has_failed     = ! empty( $failed );
 
 		if ( ! $has_successful && ! $has_failed ) {
-			$this->markTestSkipped( 'This test requires at least one successful or failed plugin update object.' );
+			$this->fail( 'This test requires at least one successful or failed plugin update object.' );
 		}
 
 		$type = $has_successful && $has_failed ? 'mixed' : ( ! $has_failed ? 'success' : 'fail' );
@@ -337,7 +337,7 @@ class Tests_Admin_WpAutomaticUpdater extends WP_UnitTestCase {
 		$has_failed     = ! empty( $failed );
 
 		if ( ! $has_successful && ! $has_failed ) {
-			$this->markTestSkipped( 'This test requires at least one successful or failed plugin update object.' );
+			$this->fail( 'This test requires at least one successful or failed plugin update object.' );
 		}
 
 		$type = $has_successful && $has_failed ? 'mixed' : ( ! $has_failed ? 'success' : 'fail' );

--- a/tests/phpunit/tests/cache.php
+++ b/tests/phpunit/tests/cache.php
@@ -349,7 +349,7 @@ class Tests_Cache extends WP_UnitTestCase {
 
 	public function test_switch_to_blog() {
 		if ( ! method_exists( $this->cache, 'switch_to_blog' ) ) {
-			$this->markTestSkipped( 'This test requires a switch_to_blog() method on the cache object.' );
+			$this->fail( 'This test requires a switch_to_blog() method on the cache object.' );
 		}
 
 		$key  = __FUNCTION__;

--- a/tests/phpunit/tests/compat/arrayKeyFirst.php
+++ b/tests/phpunit/tests/compat/arrayKeyFirst.php
@@ -24,15 +24,10 @@ class Tests_Compat_arrayKeyFirst extends WP_UnitTestCase {
 	 * @param array $arr     The array to get first key from.
 	 */
 	public function test_array_key_first( $expected, $arr ) {
-		if ( ! function_exists( 'array_key_first' ) ) {
-			$this->markTestSkipped( 'array_key_first() is not available.' );
-		} else {
-			$this->assertSame(
-				$expected,
-				array_key_first( $arr )
-			);
-		}
-
+		$this->assertSame(
+			$expected,
+			array_key_first( $arr )
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/compat/arrayKeyLast.php
+++ b/tests/phpunit/tests/compat/arrayKeyLast.php
@@ -25,11 +25,7 @@ class Tests_Compat_ArrayKeyLast extends WP_UnitTestCase {
 	 * @param array $arr      The array to get last key from.
 	 */
 	public function test_array_key_last( $expected, $arr ) {
-		if ( ! function_exists( 'array_key_last' ) ) {
-			$this->markTestSkipped( 'array_key_last() is not available.' );
-		} else {
-			$this->assertSame( $expected, array_key_last( $arr ) );
-		}
+		$this->assertSame( $expected, array_key_last( $arr ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/compat/strContains.php
+++ b/tests/phpunit/tests/compat/strContains.php
@@ -26,15 +26,10 @@ class Tests_Compat_strContains extends WP_UnitTestCase {
 	 * @param string $needle   The substring to search for in `$haystack`.
 	 */
 	public function test_str_contains( $expected, $haystack, $needle ) {
-		if ( ! function_exists( 'str_contains' ) ) {
-			$this->markTestSkipped( 'str_contains() is not available.' );
-		} else {
-			$this->assertSame(
-				$expected,
-				str_contains( $haystack, $needle )
-			);
-		}
-
+		$this->assertSame(
+			$expected,
+			str_contains( $haystack, $needle )
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/compat/strEndsWith.php
+++ b/tests/phpunit/tests/compat/strEndsWith.php
@@ -26,15 +26,10 @@ class Tests_Compat_StrEndsWith extends WP_UnitTestCase {
 	 * @param string $needle   The substring to search for at the end of `$haystack`.
 	 */
 	public function test_str_ends_with( $expected, $haystack, $needle ) {
-		if ( ! function_exists( 'str_ends_with' ) ) {
-			$this->markTestSkipped( 'str_ends_with() is not available.' );
-		} else {
-			$this->assertSame(
-				$expected,
-				str_ends_with( $haystack, $needle )
-			);
-		}
-
+		$this->assertSame(
+			$expected,
+			str_ends_with( $haystack, $needle )
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/compat/strStartsWith.php
+++ b/tests/phpunit/tests/compat/strStartsWith.php
@@ -26,15 +26,10 @@ class Tests_Compat_StrStartsWith extends WP_UnitTestCase {
 	 * @param string $needle   The substring to search for at the start of `$haystack`.
 	 */
 	public function test_str_starts_with( $expected, $haystack, $needle ) {
-		if ( ! function_exists( 'str_starts_with' ) ) {
-			$this->markTestSkipped( 'str_starts_with() is not available.' );
-		} else {
-			$this->assertSame(
-				$expected,
-				str_starts_with( $haystack, $needle )
-			);
-		}
-
+		$this->assertSame(
+			$expected,
+			str_starts_with( $haystack, $needle )
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/db.php
+++ b/tests/phpunit/tests/db.php
@@ -86,7 +86,7 @@ class Tests_DB extends WP_UnitTestCase {
 		// Switch to a locale using comma as a decimal point separator.
 		$flag = setlocale( LC_ALL, 'ru_RU.utf8', 'rus', 'fr_FR.utf8', 'fr_FR', 'de_DE.utf8', 'de_DE', 'es_ES.utf8', 'es_ES' );
 		if ( false === $flag ) {
-			$this->markTestSkipped( 'No European locales available for testing.' );
+			$this->fail( 'No European locales available for testing.' );
 		}
 
 		// Try an update query.

--- a/tests/phpunit/tests/file.php
+++ b/tests/phpunit/tests/file.php
@@ -424,7 +424,7 @@ class Tests_File extends WP_UnitTestCase {
 
 		// Check to see if the system parameters prevent signature verifications.
 		if ( is_wp_error( $verify ) && 'signature_verification_unsupported' === $verify->get_error_code() ) {
-			$this->markTestSkipped( 'This system does not support Signature Verification.' );
+			$this->fail( 'This system does not support Signature Verification.' );
 		}
 
 		$this->assertNotWPError( $verify );
@@ -444,7 +444,7 @@ class Tests_File extends WP_UnitTestCase {
 		unlink( $file );
 
 		if ( is_wp_error( $verify ) && 'signature_verification_unsupported' === $verify->get_error_code() ) {
-			$this->markTestSkipped( 'This system does not support Signature Verification.' );
+			$this->fail( 'This system does not support Signature Verification.' );
 		}
 
 		$this->assertWPError( $verify );

--- a/tests/phpunit/tests/functions.php
+++ b/tests/phpunit/tests/functions.php
@@ -1224,7 +1224,7 @@ class Tests_Functions extends WP_UnitTestCase {
 	 */
 	public function test_wp_raise_memory_limit() {
 		if ( -1 !== WP_MAX_MEMORY_LIMIT ) {
-			$this->markTestSkipped( 'WP_MAX_MEMORY_LIMIT should be set to -1.' );
+			$this->fail( 'WP_MAX_MEMORY_LIMIT should be set to -1.' );
 		}
 
 		$ini_limit_before = ini_get( 'memory_limit' );
@@ -1338,7 +1338,7 @@ class Tests_Functions extends WP_UnitTestCase {
 	 */
 	public function test_wp_get_image_mime( $file, $expected ) {
 		if ( ! is_callable( 'exif_imagetype' ) && ! function_exists( 'getimagesize' ) ) {
-			$this->markTestSkipped( 'The exif PHP extension is not loaded.' );
+			$this->fail( 'The exif PHP extension is not loaded.' );
 		}
 
 		$this->assertSame( $expected, wp_get_image_mime( $file ) );
@@ -1405,7 +1405,7 @@ class Tests_Functions extends WP_UnitTestCase {
 	 */
 	public function test_wp_getimagesize( $file, $expected ) {
 		if ( ! is_callable( 'exif_imagetype' ) && ! function_exists( 'getimagesize' ) ) {
-			$this->markTestSkipped( 'The exif PHP extension is not loaded.' );
+			$this->fail( 'The exif PHP extension is not loaded.' );
 		}
 
 		$result = wp_getimagesize( $file );
@@ -1917,7 +1917,7 @@ class Tests_Functions extends WP_UnitTestCase {
 	 */
 	public function test_wp_is_stream( $path, $expected ) {
 		if ( ! extension_loaded( 'openssl' ) && false !== strpos( $path, 'https://' ) ) {
-			$this->markTestSkipped( 'The openssl PHP extension is not loaded.' );
+			$this->fail( 'The openssl PHP extension is not loaded.' );
 		}
 
 		$this->assertSame( $expected, wp_is_stream( $path ) );

--- a/tests/phpunit/tests/general/template_CheckedSelectedHelper.php
+++ b/tests/phpunit/tests/general/template_CheckedSelectedHelper.php
@@ -59,7 +59,7 @@ class Tests_General_Template_CheckedSelectedHelper extends WP_UnitTestCase {
 	 */
 	public function test_readonly_with_equal_values() {
 		if ( ! function_exists( 'readonly' ) ) {
-			$this->markTestSkipped( 'readonly() function is not available on PHP 8.1' );
+			$this->markTestSkipped( 'readonly() function does not exist' );
 		}
 
 		$this->setExpectedDeprecated( 'readonly' );

--- a/tests/phpunit/tests/image/functions.php
+++ b/tests/phpunit/tests/image/functions.php
@@ -753,7 +753,7 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 
 		$editor = wp_get_image_editor( $test_file );
 		if ( is_wp_error( $editor ) ) {
-			$this->markTestSkipped( $editor->get_error_message() );
+			$this->fail( $editor->get_error_message() );
 		}
 
 		$attachment_id = self::factory()->attachment->create_object(
@@ -831,7 +831,7 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 
 		$editor = wp_get_image_editor( $test_file );
 		if ( is_wp_error( $editor ) ) {
-			$this->markTestSkipped( $editor->get_error_message() );
+			$this->fail( $editor->get_error_message() );
 		}
 
 		$attachment_id = self::factory()->attachment->create_object(
@@ -905,7 +905,7 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 
 		$editor = wp_get_image_editor( $test_file );
 		if ( is_wp_error( $editor ) ) {
-			$this->markTestSkipped( $editor->get_error_message() );
+			$this->fail( $editor->get_error_message() );
 		}
 
 		$attachment_id = self::factory()->attachment->create_object(
@@ -980,7 +980,7 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 
 		$editor = wp_get_image_editor( $pdf_path );
 		if ( is_wp_error( $editor ) ) {
-			$this->markTestSkipped( $editor->get_error_message() );
+			$this->fail( $editor->get_error_message() );
 		}
 
 		$attachment_id = self::factory()->attachment->create_object(

--- a/tests/phpunit/tests/l10n/getLocale.php
+++ b/tests/phpunit/tests/l10n/getLocale.php
@@ -40,10 +40,6 @@ class Tests_L10n_GetLocale extends WP_UnitTestCase {
 	 * @group ms-required
 	 */
 	public function test_network_option_should_be_fallback_on_multisite() {
-		if ( ! is_multisite() ) {
-			$this->markTestSkipped( 'This test requires Multisite.' );
-		}
-
 		global $locale;
 		$old_locale = $locale;
 		$locale     = null;
@@ -60,10 +56,6 @@ class Tests_L10n_GetLocale extends WP_UnitTestCase {
 	 * @group ms-excluded
 	 */
 	public function test_option_should_be_respected_on_nonmultisite() {
-		if ( is_multisite() ) {
-			$this->markTestSkipped( 'This test does not apply to Multisite.' );
-		}
-
 		global $locale;
 		$old_locale = $locale;
 		$locale     = null;

--- a/tests/phpunit/tests/l10n/getUserLocale.php
+++ b/tests/phpunit/tests/l10n/getUserLocale.php
@@ -67,10 +67,6 @@ class Tests_L10n_GetUserLocale extends WP_UnitTestCase {
 	 * @group ms-required
 	 */
 	public function test_user_locale_is_same_across_network() {
-		if ( ! is_multisite() ) {
-			$this->markTestSkipped( 'This test requires Multisite.' );
-		}
-
 		$user_locale = get_user_locale();
 
 		switch_to_blog( self::factory()->blog->create() );

--- a/tests/phpunit/tests/privacy/wpPrivacyGeneratePersonalDataExportFile.php
+++ b/tests/phpunit/tests/privacy/wpPrivacyGeneratePersonalDataExportFile.php
@@ -71,7 +71,7 @@ class Tests_Privacy_wpPrivacyGeneratePersonalDataExportFile extends WP_UnitTestC
 		$this->export_file_name = '';
 
 		if ( ! $this->remove_exports_dir() ) {
-			$this->markTestSkipped( 'Existing exports directory could not be removed. Skipping test.' );
+			$this->fail( 'Existing exports directory could not be removed. Skipping test.' );
 		}
 
 		// We need to override the die handler. Otherwise, the unit tests will die too.

--- a/tests/phpunit/tests/rest-api/rest-search-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-search-controller.php
@@ -424,7 +424,7 @@ class WP_Test_REST_Search_Controller extends WP_Test_REST_Controller_Testcase {
 	 */
 	public function test_prepare_item_limit_fields() {
 		if ( ! method_exists( 'WP_REST_Controller', 'get_fields_for_response' ) ) {
-			$this->markTestSkipped( 'Limiting fields requires the WP_REST_Controller::get_fields_for_response() method.' );
+			$this->fail( 'Limiting fields requires the WP_REST_Controller::get_fields_for_response() method.' );
 		}
 
 		$response = $this->do_request_with_params(
@@ -533,7 +533,7 @@ class WP_Test_REST_Search_Controller extends WP_Test_REST_Controller_Testcase {
 	 */
 	public function test_custom_search_handler_prepare_item_limit_fields() {
 		if ( ! method_exists( 'WP_REST_Controller', 'get_fields_for_response' ) ) {
-			$this->markTestSkipped( 'Limiting fields requires the WP_REST_Controller::get_fields_for_response() method.' );
+			$this->fail( 'Limiting fields requires the WP_REST_Controller::get_fields_for_response() method.' );
 		}
 
 		$controller = new WP_REST_Search_Controller( array( new WP_REST_Test_Search_Handler( 10 ) ) );

--- a/tests/phpunit/tests/theme.php
+++ b/tests/phpunit/tests/theme.php
@@ -867,14 +867,14 @@ class Tests_Theme extends WP_UnitTestCase {
 
 		// Skip if the block theme is not available.
 		if ( ! wp_get_theme( $block_theme )->exists() ) {
-			$this->markTestSkipped( "$block_theme must be available." );
+			$this->fail( "$block_theme must be available." );
 		}
 
 		switch_theme( $block_theme );
 
 		// Skip if we could not switch to the block theme.
 		if ( wp_get_theme()->stylesheet !== $block_theme ) {
-			$this->markTestSkipped( "Could not switch to $block_theme." );
+			$this->fail( "Could not switch to $block_theme." );
 		}
 	}
 }


### PR DESCRIPTION
Trac ticket:
https://core.trac.wordpress.org/ticket/60705
https://core.trac.wordpress.org/ticket/59647
https://core.trac.wordpress.org/ticket/58955

This changes several instances of test skipping to test failures, and removes some unnecessary `function_exists()` checks for compat functions.

If any of the checks in these test aren't satisfied then the test should fail rather than be skipped.

In addition, I removed some multisite test skipping which is redundant as it's handled by the `ms-required` and `ms-excluded` test group handling.

Previously:

* https://core.trac.wordpress.org/ticket/40533
* https://core.trac.wordpress.org/ticket/53009

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
