### PR TITLE
Added relative time strings for the `wp-date` inline script output.

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -329,6 +329,7 @@ function wp_default_packages_scripts( $scripts ) {
  * Adds inline scripts required for the WordPress JavaScript packages.
  *
  * @since 5.0.0
+ * @since 6.4.0 Added relative time strings for the `wp-date` inline script output.
  *
  * @global WP_Locale $wp_locale WordPress date and time locale object.
  * @global wpdb      $wpdb      WordPress database abstraction object.
@@ -427,9 +428,33 @@ function wp_default_packages_inline_scripts( $scripts ) {
 						'meridiem'      => (object) $wp_locale->meridiem,
 						'relative'      => array(
 							/* translators: %s: Duration. */
-							'future' => __( '%s from now' ),
+							'future' => __( '%s from now', 'default' ),
 							/* translators: %s: Duration. */
-							'past'   => __( '%s ago' ),
+							'past'   => __( '%s ago', 'default' ),
+							/* translators: One second from or to a particular datetime, e.g., "a second ago" or "a second from now". */
+							's'      => __( 'a second', 'default' ),
+							/* translators: %s: Duration in seconds from or to a particular datetime, e.g., "4 seconds ago" or "4 seconds from now". */
+							'ss'     => __( '%d seconds', 'default' ),
+							/* translators: One minute from or to a particular datetime, e.g., "a minute ago" or "a minute from now". */
+							'm'      => __( 'a minute', 'default' ),
+							/* translators: %s: Duration in minutes from or to a particular datetime, e.g., "4 minutes ago" or "4 minutes from now". */
+							'mm'     => __( '%d minutes', 'default' ),
+							/* translators: %s: One hour from or to a particular datetime, e.g., "an hour ago" or "an hour from now". */
+							'h'      => __( 'an hour', 'default' ),
+							/* translators: %s: Duration in hours from or to a particular datetime, e.g., "4 hours ago" or "4 hours from now". */
+							'hh'     => __( '%d hours', 'default' ),
+							/* translators: %s: One day from or to a particular datetime, e.g., "a day ago" or "a day from now". */
+							'd'      => __( 'a day', 'default' ),
+							/* translators: %s: Duration in days from or to a particular datetime, e.g., "4 days ago" or "4 days from now". */
+							'dd'     => __( '%d days', 'default' ),
+							/* translators: %s: One month from or to a particular datetime, e.g., "a month ago" or "a month from now". */
+							'M'      => __( 'a month', 'default' ),
+							/* translators: %s: Duration in months from or to a particular datetime, e.g., "4 months ago" or "4 months from now". */
+							'MM'     => __( '%d months', 'default' ),
+							/* translators: %s: One year from or to a particular datetime, e.g., "a year ago" or "a year from now". */
+							'y'      => __( 'a year', 'default' ),
+							/* translators: %s: Duration in years from or to a particular datetime, e.g., "4 years ago" or "4 years from now". */
+							'yy'     => __( '%d years', 'default' ),
 						),
 						'startOfWeek'   => (int) get_option( 'start_of_week', 0 ),
 					),

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -428,33 +428,33 @@ function wp_default_packages_inline_scripts( $scripts ) {
 						'meridiem'      => (object) $wp_locale->meridiem,
 						'relative'      => array(
 							/* translators: %s: Duration. */
-							'future' => __( '%s from now', 'default' ),
+							'future' => __( '%s from now' ),
 							/* translators: %s: Duration. */
-							'past'   => __( '%s ago', 'default' ),
+							'past'   => __( '%s ago' ),
 							/* translators: One second from or to a particular datetime, e.g., "a second ago" or "a second from now". */
-							's'      => __( 'a second', 'default' ),
+							's'      => __( 'a second' ),
 							/* translators: %s: Duration in seconds from or to a particular datetime, e.g., "4 seconds ago" or "4 seconds from now". */
-							'ss'     => __( '%d seconds', 'default' ),
+							'ss'     => __( '%d seconds' ),
 							/* translators: One minute from or to a particular datetime, e.g., "a minute ago" or "a minute from now". */
-							'm'      => __( 'a minute', 'default' ),
+							'm'      => __( 'a minute' ),
 							/* translators: %s: Duration in minutes from or to a particular datetime, e.g., "4 minutes ago" or "4 minutes from now". */
-							'mm'     => __( '%d minutes', 'default' ),
+							'mm'     => __( '%d minutes' ),
 							/* translators: %s: One hour from or to a particular datetime, e.g., "an hour ago" or "an hour from now". */
-							'h'      => __( 'an hour', 'default' ),
+							'h'      => __( 'an hour' ),
 							/* translators: %s: Duration in hours from or to a particular datetime, e.g., "4 hours ago" or "4 hours from now". */
-							'hh'     => __( '%d hours', 'default' ),
+							'hh'     => __( '%d hours' ),
 							/* translators: %s: One day from or to a particular datetime, e.g., "a day ago" or "a day from now". */
-							'd'      => __( 'a day', 'default' ),
+							'd'      => __( 'a day' ),
 							/* translators: %s: Duration in days from or to a particular datetime, e.g., "4 days ago" or "4 days from now". */
-							'dd'     => __( '%d days', 'default' ),
+							'dd'     => __( '%d days' ),
 							/* translators: %s: One month from or to a particular datetime, e.g., "a month ago" or "a month from now". */
-							'M'      => __( 'a month', 'default' ),
+							'M'      => __( 'a month' ),
 							/* translators: %s: Duration in months from or to a particular datetime, e.g., "4 months ago" or "4 months from now". */
-							'MM'     => __( '%d months', 'default' ),
+							'MM'     => __( '%d months' ),
 							/* translators: %s: One year from or to a particular datetime, e.g., "a year ago" or "a year from now". */
-							'y'      => __( 'a year', 'default' ),
+							'y'      => __( 'a year' ),
 							/* translators: %s: Duration in years from or to a particular datetime, e.g., "4 years ago" or "4 years from now". */
-							'yy'     => __( '%d years', 'default' ),
+							'yy'     => __( '%d years' ),
 						),
 						'startOfWeek'   => (int) get_option( 'start_of_week', 0 ),
 					),


### PR DESCRIPTION
This PR syncs the changes in:

- https://github.com/WordPress/gutenberg/pull/53931

Updates `wp_default_packages_inline_scripts()` to add relative time strings to the `wp-date` inline script.

This is so the [JS version](https://github.com/WordPress/gutenberg/blob/eed863a1aacecf166b43eaa90077ccd0f287ad41/packages/date/src/index.js#L592C8-L592C44) of [human_time_diff](https://developer.wordpress.org/reference/functions/human_time_diff/) can output translated strings.

It uses these translated strings in moment calculations. See the relevant model: https://momentjscom.readthedocs.io/en/latest/moment/07-customization/07-relative-time/

Trac ticket: https://core.trac.wordpress.org/ticket/59219

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
