### PR TITLE
Solved bug in wp_set_post_categories function #59215

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -5344,7 +5344,7 @@ function wp_set_post_categories( $post_id = 0, $post_categories = array(), $appe
 		return true;
 	}
 
-	return wp_set_post_terms( $post_id, $post_categories, 'category', $append );
+	return wp_set_post_terms( $post_id, $post_categories, $post_type, $append );
 }
 
 /**


### PR DESCRIPTION
In the wp_set_post_categories function in the wp-includes/post.php file.

Before update:
return wp_set_post_terms( $post_id, $post_categories, 'category', $append );

After update:
return wp_set_post_terms( $post_id, $post_categories, $post_type, $append );

Trac ticket: [59215](https://core.trac.wordpress.org/ticket/59215)

