### PR TITLE
PHP 8.3 | Tests: fix uses of ReflectionProperty::setValue() for static properties

### DIFF
--- a/tests/phpunit/tests/rest-api/wpRestBlockPatternCategoriesController.php
+++ b/tests/phpunit/tests/rest-api/wpRestBlockPatternCategoriesController.php
@@ -65,7 +65,7 @@ class Tests_REST_WpRestBlockPatternCategoriesController extends WP_Test_REST_Con
 		self::$registry_instance_property = new ReflectionProperty( 'WP_Block_Pattern_Categories_Registry', 'instance' );
 		self::$registry_instance_property->setAccessible( true );
 		$test_registry = new WP_Block_Pattern_Categories_Registry();
-		self::$registry_instance_property->setValue( $test_registry );
+		self::$registry_instance_property->setValue( null, $test_registry );
 
 		// Register some categories in the test registry.
 		$test_registry->register(
@@ -88,7 +88,7 @@ class Tests_REST_WpRestBlockPatternCategoriesController extends WP_Test_REST_Con
 		self::delete_user( self::$admin_id );
 
 		// Restore the original registry instance.
-		self::$registry_instance_property->setValue( self::$orig_registry );
+		self::$registry_instance_property->setValue( null, self::$orig_registry );
 		self::$registry_instance_property->setAccessible( false );
 		self::$registry_instance_property = null;
 		self::$orig_registry              = null;

--- a/tests/phpunit/tests/rest-api/wpRestBlockPatternsController.php
+++ b/tests/phpunit/tests/rest-api/wpRestBlockPatternsController.php
@@ -65,7 +65,7 @@ class Tests_REST_WpRestBlockPatternsController extends WP_Test_REST_Controller_T
 		self::$registry_instance_property = new ReflectionProperty( 'WP_Block_Patterns_Registry', 'instance' );
 		self::$registry_instance_property->setAccessible( true );
 		$test_registry = new WP_Block_Pattern_Categories_Registry();
-		self::$registry_instance_property->setValue( $test_registry );
+		self::$registry_instance_property->setValue( null, $test_registry );
 
 		// Register some patterns in the test registry.
 		$test_registry->register(
@@ -106,7 +106,7 @@ class Tests_REST_WpRestBlockPatternsController extends WP_Test_REST_Controller_T
 		self::delete_user( self::$admin_id );
 
 		// Restore the original registry instance.
-		self::$registry_instance_property->setValue( self::$orig_registry );
+		self::$registry_instance_property->setValue( null, self::$orig_registry );
 		self::$registry_instance_property->setAccessible( false );
 		self::$registry_instance_property = null;
 		self::$orig_registry              = null;

--- a/tests/phpunit/tests/theme/wpThemeJsonResolver.php
+++ b/tests/phpunit/tests/theme/wpThemeJsonResolver.php
@@ -81,8 +81,8 @@ class Tests_Theme_wpThemeJsonResolver extends WP_UnitTestCase {
 	}
 
 	public static function tear_down_after_class() {
-		static::$property_blocks_cache->setValue( WP_Theme_JSON_Resolver::class, static::$property_blocks_cache_orig_value );
-		static::$property_core->setValue( WP_Theme_JSON_Resolver::class, static::$property_core_orig_value );
+		static::$property_blocks_cache->setValue( null, static::$property_blocks_cache_orig_value );
+		static::$property_core->setValue( null, static::$property_core_orig_value );
 		parent::tear_down_after_class();
 	}
 
@@ -759,7 +759,7 @@ class Tests_Theme_wpThemeJsonResolver extends WP_UnitTestCase {
 		// Force-unset $i18n_schema property to "unload" translation schema.
 		$property = new ReflectionProperty( $theme_json_resolver, 'i18n_schema' );
 		$property->setAccessible( true );
-		$property->setValue( null );
+		$property->setValue( null, null );
 
 		// A completely empty theme.json data set still has the 'version' key when parsed.
 		$empty_theme_json = array( 'version' => WP_Theme_JSON::LATEST_SCHEMA );


### PR DESCRIPTION
The single parameter signature, which was used for setting the value on a static property, is deprecated since PHP 8.3. A cross-version solution is to pass `null` as the first parameter.

This fixes all instances of the use of the deprecated signature in WP Core.

https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures#reflectionpropertysetvalue

Trac ticket: https://core.trac.wordpress.org/ticket/59231

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
