### PR TITLE
Initialize Block Theme Previews hooks on `plugins_loaded` action

### DIFF
--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -533,7 +533,7 @@ add_action( 'admin_enqueue_scripts', '_wp_customize_loader_settings' );
 add_action( 'delete_attachment', '_delete_attachment_theme_mod' );
 add_action( 'transition_post_status', '_wp_keep_alive_customize_changeset_dependent_auto_drafts', 20, 3 );
 
-// Block Theme Previews
+// Block Theme Previews. 
 add_action( 'plugins_loaded', 'initialize_theme_preview_hooks' );
 
 // Calendar widget cache.

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -533,7 +533,7 @@ add_action( 'admin_enqueue_scripts', '_wp_customize_loader_settings' );
 add_action( 'delete_attachment', '_delete_attachment_theme_mod' );
 add_action( 'transition_post_status', '_wp_keep_alive_customize_changeset_dependent_auto_drafts', 20, 3 );
 
-// Block Theme Previews. 
+// Block Theme Previews.
 add_action( 'plugins_loaded', 'initialize_theme_preview_hooks' );
 
 // Calendar widget cache.

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -533,6 +533,9 @@ add_action( 'admin_enqueue_scripts', '_wp_customize_loader_settings' );
 add_action( 'delete_attachment', '_delete_attachment_theme_mod' );
 add_action( 'transition_post_status', '_wp_keep_alive_customize_changeset_dependent_auto_drafts', 20, 3 );
 
+// Block Theme Previews
+add_action( 'plugins_loaded', 'initialize_theme_preview_hooks' );
+
 // Calendar widget cache.
 add_action( 'save_post', 'delete_get_calendar_cache' );
 add_action( 'delete_post', 'delete_get_calendar_cache' );

--- a/src/wp-includes/theme-previews.php
+++ b/src/wp-includes/theme-previews.php
@@ -75,10 +75,12 @@ function wp_block_theme_activate_nonce() {
 	<?php
 }
 
-// Attaches filters to enable theme previews in the Site Editor.
-if ( ! empty( $_GET['wp_theme_preview'] ) ) {
-	add_filter( 'stylesheet', 'wp_get_theme_preview_path' );
-	add_filter( 'template', 'wp_get_theme_preview_path' );
-	add_action( 'init', 'wp_attach_theme_preview_middleware' );
-	add_action( 'admin_head', 'wp_block_theme_activate_nonce' );
+// Attaches filters and actions to enable Block Theme Previews in the Site Editor.
+function initialize_theme_preview_hooks() {
+	if ( ! empty( $_GET['wp_theme_preview'] ) ) {
+		add_filter( 'stylesheet', 'wp_get_theme_preview_path' );
+		add_filter( 'template', 'wp_get_theme_preview_path' );
+		add_action( 'init', 'wp_attach_theme_preview_middleware' );
+		add_action( 'admin_head', 'wp_block_theme_activate_nonce' );
+	}
 }

--- a/src/wp-includes/theme-previews.php
+++ b/src/wp-includes/theme-previews.php
@@ -75,7 +75,14 @@ function wp_block_theme_activate_nonce() {
 	<?php
 }
 
-// Attaches filters and actions to enable Block Theme Previews in the Site Editor.
+/**
+ * Attache filters and actions to enable Block Theme Previews in the Site Editor.
+ *
+ * The filters and actions have to be added after `pluggable.php` is included as they may
+ * trigger code that uses `current_user_can()` which requires functionality from `pluggable.php`.
+ *
+ * @since 6.3.2
+ */
 function initialize_theme_preview_hooks() {
 	if ( ! empty( $_GET['wp_theme_preview'] ) ) {
 		add_filter( 'stylesheet', 'wp_get_theme_preview_path' );

--- a/tests/phpunit/tests/theme-previews.php
+++ b/tests/phpunit/tests/theme-previews.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * test wp-includes/theme-previews.php
+ *
+ * @group themes
+ */
+class Tests_Theme_Previews extends WP_UnitTestCase {
+	public function set_up() {
+		parent::set_up();
+	}
+
+	public function tear_down() {
+		unset( $_GET['wp_theme_preview'] );
+		parent::tear_down();
+	}
+
+	public function test_initialize_theme_preview_hooks() {
+		$_GET['wp_theme_preview'] = 'twentytwentythree';
+		do_action( 'plugins_loaded' ); // Ensure `plugins_loaded` triggers `initialize_theme_preview_hooks`.
+		$this->assertEquals( has_filter( 'stylesheet', 'wp_get_theme_preview_path' ), 10 );
+		$this->assertEquals( has_filter( 'template', 'wp_get_theme_preview_path' ), 10 );
+		$this->assertEquals( has_action( 'init', 'wp_attach_theme_preview_middleware' ), 10 );
+		$this->assertEquals( has_action( 'admin_head', 'wp_block_theme_activate_nonce' ), 10 );
+	}
+}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

This PR ensures theme preview hooks are added after the `plugins_loaded` action fires. This change aligns with best practices and helps avoid the fatal error on Block Theme Previews.

- Encapsulated the action and filter hooks related to theme previews into a function `initialize_theme_preview_hooks`
- Hooked `initialize_theme_preview_hooks` to the `plugins_loaded` action in `default-filters.php`

Trac ticket: https://core.trac.wordpress.org/ticket/59000
Fixes: https://github.com/WordPress/gutenberg/issues/53284

## Why 

Currently, the action and filter hooks related to theme previews are added in the global scope, which could lead to unexpected behaviors with other plugins or internal functionalities. See https://core.trac.wordpress.org/ticket/59000#comment:15 and https://github.com/WordPress/gutenberg/issues/53284. This change ensures that the hooks are added at the appropriate time in the lifecycle, specifically after all plugins have been loaded.

## Testing

- Navigate to `/wp-admin/themes.php` and click the `Live Preview` button on any Block theme (e.g. Twenty Twenty-Two).
- Verify that Block Theme Previews functionality works as expected.
- Test with third-party plugins, such as CoBlocks, to ensure there is no fatal error on Block Theme Previews.


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
