### PR TITLE
Update get_available_post_mime_types filter name

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -7874,7 +7874,7 @@ function get_available_post_mime_types( $type = 'attachment' ) {
 	 * @param string[]|null $mime_types An array of MIME types. Default null.
 	 * @param string        $type       The post type name. Usually 'attachment' but can be any post type.
 	 */
-	$mime_types = apply_filters( 'get_available_post_mime_types', null, $type );
+	$mime_types = apply_filters( 'pre_get_available_post_mime_types', null, $type );
 
 	if ( ! is_array( $mime_types ) ) {
 		$mime_types = $wpdb->get_col( $wpdb->prepare( "SELECT DISTINCT post_mime_type FROM $wpdb->posts WHERE post_type = %s", $type ) );


### PR DESCRIPTION
Updating the filter name to `pre_get_available_post_mime_types`.

Trac ticket: https://core.trac.wordpress.org/ticket/52759
