### PR TITLE
Reinstate support for get_pages() post_modified_gmt sort column value

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -6066,8 +6066,18 @@ function get_pages( $args = array() ) {
 		$query_args['post_parent'] = $parent;
 	}
 
+	/*
+	 * Maintain backward compatibility for `sort_column` key.
+	 * Additionally to `WP_Query`, it has been supporting the `post_modified_gmt` field, so this logic will translate
+	 * it to `post_modified` which should result in the same order given the two dates in the fields match.
+	 */
 	$orderby = wp_parse_list( $parsed_args['sort_column'] );
 	$orderby = array_map( 'trim', $orderby );
+	foreach ( $orderby as $index => $orderby_field ) {
+		if ( 'post_modified_gmt' === $orderby_field || 'modified_gmt' === $orderby_field ) {
+			$orderby[ $index ] = str_replace( '_gmt', '', $orderby_field );
+		}
+	}
 	if ( $orderby ) {
 		$query_args['orderby'] = array_fill_keys( $orderby, $parsed_args['sort_order'] );
 	}

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -6072,12 +6072,16 @@ function get_pages( $args = array() ) {
 	 * it to `post_modified` which should result in the same order given the two dates in the fields match.
 	 */
 	$orderby = wp_parse_list( $parsed_args['sort_column'] );
-	$orderby = array_map( 'trim', $orderby );
-	foreach ( $orderby as $index => $orderby_field ) {
-		if ( 'post_modified_gmt' === $orderby_field || 'modified_gmt' === $orderby_field ) {
-			$orderby[ $index ] = str_replace( '_gmt', '', $orderby_field );
-		}
-	}
+	$orderby = array_map(
+		static function( $orderby_field ) {
+			$orderby_field = trim( $orderby_field );
+			if ( 'post_modified_gmt' === $orderby_field || 'modified_gmt' === $orderby_field ) {
+				$orderby_field = str_replace( '_gmt', '', $orderby_field );
+			}
+			return $orderby_field;
+		},
+		$orderby
+	);
 	if ( $orderby ) {
 		$query_args['orderby'] = array_fill_keys( $orderby, $parsed_args['sort_order'] );
 	}

--- a/tests/phpunit/tests/post/getPages.php
+++ b/tests/phpunit/tests/post/getPages.php
@@ -1181,4 +1181,35 @@ class Tests_Post_GetPages extends WP_UnitTestCase {
 			'Check that ORDER is post date.'
 		);
 	}
+
+	/**
+	 * Tests that the legacy `post_modified_gmt` orderby values are translated to the proper `WP_Query` values.
+	 *
+	 * @ticket 59226
+	 */
+	public function test_get_pages_order_by_post_modified_gmt() {
+		global $wpdb;
+
+		get_pages(
+			array(
+				'sort_column' => 'post_modified_gmt',
+			)
+		);
+		$this->assertStringContainsString(
+			"ORDER BY $wpdb->posts.post_modified ASC",
+			$wpdb->last_query,
+			'Check that ORDER is post modified when using post_modified_gmt.'
+		);
+
+		get_pages(
+			array(
+				'sort_column' => 'modified_gmt',
+			)
+		);
+		$this->assertStringContainsString(
+			"ORDER BY $wpdb->posts.post_modified ASC",
+			$wpdb->last_query,
+			'Check that ORDER is post modified when using modified_gmt.'
+		);
+	}
 }


### PR DESCRIPTION
This PR reinstates the missing support for `post_modified_gmt` and `modified_gmt` as possible values for the `sort_column` key in `get_pages()`.

These two are the only values that aren't anyway supported by `WP_Query`.

Trac ticket: https://core.trac.wordpress.org/ticket/59226

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
