### PR TITLE
Improve codespaces somewhat

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
         "ghcr.io/devcontainers/features/node:1": {
             "version": "16"
         },
-        "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+        "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
         "ghcr.io/devcontainers/features/git:1": {}
     },
     "onCreateCommand": "sudo chmod +x .devcontainer/install-tools.sh && .devcontainer/install-tools.sh",

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       WORDPRESS_DB_NAME: exampledb
     volumes:
       - ../..:/workspaces:cached
+      - ../src:/var/www/html
 
   db:
     image: mariadb

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -11,6 +11,12 @@ services:
       WORDPRESS_DB_USER: exampleuser
       WORDPRESS_DB_PASSWORD: examplepass
       WORDPRESS_DB_NAME: exampledb
+      WORDPRESS_CONFIG_EXTRA: |
+        // Use forwarded host if available.
+        if ( ! empty( $$_SERVER['HTTP_X_FORWARDED_HOST'] ) ) {
+          $$_SERVER['HTTP_HOST'] = $$_SERVER['HTTP_X_FORWARDED_HOST'];
+        }
+
     volumes:
       - ../..:/workspaces:cached
       - ../src:/var/www/html

--- a/.devcontainer/install-tools.sh
+++ b/.devcontainer/install-tools.sh
@@ -13,3 +13,5 @@ sudo apt-get -y install --no-install-recommends chromium
 
 # Copy the welcome message
 sudo cp .devcontainer/welcome-message.txt /usr/local/etc/vscode-dev-containers/first-run-notice.txt
+SITE_URL="https://${CODESPACE_NAME}-8080.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}"
+sudo sed -i "s!SITE_URL!$SITE_URL!" /usr/local/etc/vscode-dev-containers/first-run-notice.txt

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -9,7 +9,6 @@ else
 fi
 
 # Install dependencies
-cd /workspaces/wordpress-develop
 npm install && npm run build:dev
 
 # Install WordPress and activate the plugin/theme.

--- a/.devcontainer/welcome-message.txt
+++ b/.devcontainer/welcome-message.txt
@@ -1,6 +1,13 @@
 👋 Welcome to "WordPress Core Development" in Codespaces!
 
-🛠️  Your environment is fully setup with all the required software.
+🛠️ Your environment is fully setup with all the required software.
 
-🚀 To get started, wait for the "postCreateCommand" to finish setting things up, then open the portforwarded URL and append '/wp-admin'.
+🚀 Wait for the postCreateCommand build to complete (view the log via Cmd/Ctrl + P, "> View Creation Log"),
+   then your site will be ready to view at:
 
+     SITE_URL
+
+  - Cmd/Ctrl + Click any link in the terminal to open it
+  - The default username is "admin" with password "password"
+
+Happy hacking!


### PR DESCRIPTION
* Switches from docker-in-docker to docker-outside-of-docker to fix `docker` CLI commands
* Mounts `/src` into the container so that Codespaces *actually* runs trunk
* Fixes the host mapping problem by using overridden host name
* Removes unneeded, potentially-inaccurate cd call

Trac ticket: https://core.trac.wordpress.org/ticket/57896

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
