### PR TITLE
Blocks: Allow reading the script handle from asset files

### DIFF
--- a/tests/phpunit/data/blocks/notice/shared-script.asset.php
+++ b/tests/phpunit/data/blocks/notice/shared-script.asset.php
@@ -1,0 +1,7 @@
+<?php
+
+return array(
+	'handle'       => 'tests-my-shared-script',
+	'dependencies' => array(),
+	'version'      => 'test',
+);

--- a/tests/phpunit/data/blocks/notice/shared-script.js
+++ b/tests/phpunit/data/blocks/notice/shared-script.js
@@ -1,0 +1,1 @@
+/* Another test JavaScript file. */

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -52,16 +52,17 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 	 * @since 5.0.0
 	 */
 	public function tear_down() {
-		$registry = WP_Block_Type_Registry::get_instance();
-
-		foreach ( array( 'core/test-static', 'core/test-dynamic', 'tests/notice' ) as $block_name ) {
-			if ( $registry->is_registered( $block_name ) ) {
-				$registry->unregister( $block_name );
+		// Removes test block types registered by test cases.
+		$block_types = WP_Block_Type_Registry::get_instance()->get_all_registered();
+		foreach ( $block_types as $block_type ) {
+			$block_name = $block_type->name;
+			if ( str_starts_with( $block_name, 'tests/' ) ) {
+				unregister_block_type( $block_name );
 			}
 		}
 
 		foreach ( wp_scripts()->registered as $script_handle => $script ) {
-			if ( str_starts_with( $script_handle, 'unit-tests-' ) ) {
+			if ( str_starts_with( $script_handle, 'tests-' ) ) {
 				wp_deregister_script( $script_handle );
 			}
 		}
@@ -82,7 +83,7 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 	 * @ticket 45109
 	 */
 	public function test_register_affects_main_registry() {
-		$name     = 'core/test-static';
+		$name     = 'tests/static';
 		$settings = array(
 			'icon' => 'text',
 		);
@@ -97,7 +98,7 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 	 * @ticket 45109
 	 */
 	public function test_unregister_affects_main_registry() {
-		$name     = 'core/test-static';
+		$name     = 'tests/static';
 		$settings = array(
 			'icon' => 'text',
 		);
@@ -141,43 +142,43 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 	 * @ticket 60233
 	 */
 	public function test_generate_block_asset_handle() {
-		$block_name = 'unit-tests/my-block';
+		$block_name = 'tests/my-block';
 
 		$this->assertSame(
-			'unit-tests-my-block-editor-script',
+			'tests-my-block-editor-script',
 			generate_block_asset_handle( $block_name, 'editorScript' )
 		);
 		$this->assertSame(
-			'unit-tests-my-block-script',
+			'tests-my-block-script',
 			generate_block_asset_handle( $block_name, 'script', 0 )
 		);
 		$this->assertSame(
-			'unit-tests-my-block-view-script-100',
+			'tests-my-block-view-script-100',
 			generate_block_asset_handle( $block_name, 'viewScript', 99 )
 		);
 		$this->assertSame(
-			'unit-tests-my-block-view-script-module',
+			'tests-my-block-view-script-module',
 			generate_block_asset_handle( $block_name, 'viewScriptModule' )
 		);
 		$this->assertSame(
-			'unit-tests-my-block-view-script-module-2',
+			'tests-my-block-view-script-module-2',
 			generate_block_asset_handle( $block_name, 'viewScriptModule', 1 )
 		);
 		$this->assertSame(
-			'unit-tests-my-block-view-script-module-100',
+			'tests-my-block-view-script-module-100',
 			generate_block_asset_handle( $block_name, 'viewScriptModule', 99 )
 		);
 		$this->assertSame(
-			'unit-tests-my-block-editor-style-2',
+			'tests-my-block-editor-style-2',
 			generate_block_asset_handle( $block_name, 'editorStyle', 1 )
 		);
 		$this->assertSame(
-			'unit-tests-my-block-style',
+			'tests-my-block-style',
 			generate_block_asset_handle( $block_name, 'style' )
 		);
 		// @ticket 59673
 		$this->assertSame(
-			'unit-tests-my-block-view-style',
+			'tests-my-block-view-style',
 			generate_block_asset_handle( $block_name, 'viewStyle' ),
 			'asset handle for viewStyle is not generated correctly'
 		);
@@ -335,12 +336,12 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 	public function test_missing_asset_file_register_block_script_module_id() {
 		$metadata = array(
 			'file'             => __FILE__,
-			'name'             => 'unit-tests/test-block',
+			'name'             => 'tests/test-block',
 			'viewScriptModule' => 'file:./blocks/notice/missing-asset.js',
 		);
 		$result   = register_block_script_module_id( $metadata, 'viewScriptModule' );
 
-		$this->assertSame( 'unit-tests-test-block-view-script-module', $result );
+		$this->assertSame( 'tests-test-block-view-script-module', $result );
 	}
 
 	/**
@@ -376,14 +377,14 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 	public function test_success_register_block_script_module_id() {
 		$metadata = array(
 			'file'             => DIR_TESTDATA . '/blocks/notice/block.json',
-			'name'             => 'unit-tests/test-block',
+			'name'             => 'tests/test-block',
 			'viewScriptModule' => 'file:./block.js',
 		);
 		$result   = register_block_script_module_id( $metadata, 'viewScriptModule' );
 
-		$this->assertSame( 'unit-tests-test-block-view-script-module', $result );
+		$this->assertSame( 'tests-test-block-view-script-module', $result );
 
-		// Test the behavior directly within the unit test
+		// Test the behavior directly within the unit test.
 		$this->assertFalse(
 			strpos(
 				wp_normalize_path( realpath( dirname( $metadata['file'] ) . '/' . $metadata['viewScriptModule'] ) ),
@@ -430,12 +431,12 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 	public function test_missing_asset_file_register_block_script_handle_with_default_settings() {
 		$metadata = array(
 			'file'   => __FILE__,
-			'name'   => 'unit-tests/test-block',
+			'name'   => 'tests/test-block',
 			'script' => 'file:./blocks/notice/missing-asset.js',
 		);
 		$result   = register_block_script_handle( $metadata, 'script' );
 
-		$this->assertSame( 'unit-tests-test-block-script', $result );
+		$this->assertSame( 'tests-test-block-script', $result );
 	}
 
 	/**
@@ -444,14 +445,14 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 	public function test_success_register_block_script_handle() {
 		$metadata = array(
 			'file'   => DIR_TESTDATA . '/blocks/notice/block.json',
-			'name'   => 'unit-tests/test-block',
+			'name'   => 'tests/test-block',
 			'script' => 'file:./block.js',
 		);
 		$result   = register_block_script_handle( $metadata, 'script' );
 
-		$this->assertSame( 'unit-tests-test-block-script', $result );
+		$this->assertSame( 'tests-test-block-script', $result );
 
-		// Test the behavior directly within the unit test
+		// Test the behavior directly within the unit test.
 		$this->assertFalse(
 			strpos(
 				wp_normalize_path( realpath( dirname( $metadata['file'] ) . '/' . $metadata['script'] ) ),
@@ -464,6 +465,51 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 				wp_normalize_path( realpath( dirname( $metadata['file'] ) . '/' . $metadata['script'] ) ),
 				trailingslashit( wp_normalize_path( get_stylesheet_directory() ) )
 			) === 0
+		);
+	}
+
+		/**
+	 * @ticket TBD...
+	 */
+	public function test_success_register_block_script_handle_with_custom_handle_name() {
+		$custom_script_handle = 'tests-my-shared-script';
+		$metadata             = array(
+			'file'   => DIR_TESTDATA . '/blocks/notice/block.json',
+			'name'   => 'tests/sample-block',
+			'script' => 'file:./shared-script.js',
+		);
+		$result               = register_block_script_handle( $metadata, 'script' );
+
+		$this->assertSame( $custom_script_handle, $result );
+		$this->assertStringEndsWith(
+			'shared-script.js',
+			wp_scripts()->registered[ $custom_script_handle ]->src
+		);
+	}
+
+	/**
+	 * @ticket TBD...
+	 */
+	public function test_reuse_registered_block_script_handle_with_custom_handle_name() {
+		$custom_script_handle = 'tests-my-shared-script';
+		$custom_script_src    = 'https://example.com/foo.js';
+		wp_register_script( $custom_script_handle, $custom_script_src );
+
+		$this->assertTrue(
+			wp_script_is( $custom_script_handle, 'registered' )
+		);
+
+		$metadata = array(
+			'file'   => DIR_TESTDATA . '/blocks/notice/block.json',
+			'name'   => 'tests/sample-block',
+			'script' => 'file:./shared-script.js',
+		);
+		$result   = register_block_script_handle( $metadata, 'script' );
+
+		$this->assertSame( $custom_script_handle, $result );
+		$this->assertSame(
+			$custom_script_src,
+			wp_scripts()->registered[ $custom_script_handle ]->src
 		);
 	}
 
@@ -620,33 +666,33 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 	public function test_success_register_block_style_handle() {
 		$metadata = array(
 			'file'      => DIR_TESTDATA . '/blocks/notice/block.json',
-			'name'      => 'unit-tests/test-block',
+			'name'      => 'tests/test-block',
 			'style'     => 'file:./block.css',
 			'viewStyle' => 'file:./block-view.css',
 		);
 		$result   = register_block_style_handle( $metadata, 'style' );
 
-		$this->assertSame( 'unit-tests-test-block-style', $result );
-		$this->assertFalse( wp_styles()->get_data( 'unit-tests-test-block-style', 'rtl' ) );
+		$this->assertSame( 'tests-test-block-style', $result );
+		$this->assertFalse( wp_styles()->get_data( 'tests-test-block-style', 'rtl' ) );
 
 		// @ticket 50328
 		$this->assertSame(
 			wp_normalize_path( realpath( DIR_TESTDATA . '/blocks/notice/block.css' ) ),
-			wp_normalize_path( wp_styles()->get_data( 'unit-tests-test-block-style', 'path' ) )
+			wp_normalize_path( wp_styles()->get_data( 'tests-test-block-style', 'path' ) )
 		);
 
 		// Test viewStyle property
 		$result = register_block_style_handle( $metadata, 'viewStyle' );
-		$this->assertSame( 'unit-tests-test-block-view-style', $result );
+		$this->assertSame( 'tests-test-block-view-style', $result );
 
 		// @ticket 59673
 		$this->assertSame(
 			wp_normalize_path( realpath( DIR_TESTDATA . '/blocks/notice/block-view.css' ) ),
-			wp_normalize_path( wp_styles()->get_data( 'unit-tests-test-block-view-style', 'path' ) ),
+			wp_normalize_path( wp_styles()->get_data( 'tests-test-block-view-style', 'path' ) ),
 			'viewStyle asset path is not correct'
 		);
 
-		// Test the behavior directly within the unit test
+		// Test the behavior directly within the unit test.
 		$this->assertFalse(
 			strpos(
 				wp_normalize_path( realpath( dirname( $metadata['file'] ) . '/' . $metadata['style'] ) ),
@@ -675,7 +721,7 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 
 		$metadata = array(
 			'file'  => DIR_TESTDATA . '/blocks/notice/block.json',
-			'name'  => 'unit-tests/test-block-rtl',
+			'name'  => 'tests/test-block-rtl',
 			'style' => 'file:./block.css',
 		);
 
@@ -683,14 +729,14 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 		$wp_locale->text_direction = 'rtl';
 
 		$handle       = register_block_style_handle( $metadata, 'style' );
-		$extra_rtl    = wp_styles()->get_data( 'unit-tests-test-block-rtl-style', 'rtl' );
-		$extra_suffix = wp_styles()->get_data( 'unit-tests-test-block-rtl-style', 'suffix' );
-		$extra_path   = wp_normalize_path( wp_styles()->get_data( 'unit-tests-test-block-rtl-style', 'path' ) );
+		$extra_rtl    = wp_styles()->get_data( 'tests-test-block-rtl-style', 'rtl' );
+		$extra_suffix = wp_styles()->get_data( 'tests-test-block-rtl-style', 'suffix' );
+		$extra_path   = wp_normalize_path( wp_styles()->get_data( 'tests-test-block-rtl-style', 'path' ) );
 
 		$wp_locale->text_direction = $orig_text_dir;
 
 		$this->assertSame(
-			'unit-tests-test-block-rtl-style',
+			'tests-test-block-rtl-style',
 			$handle,
 			'The handle did not match the expected handle.'
 		);
@@ -720,13 +766,13 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 	public function test_register_nonexistent_stylesheet() {
 		$metadata = array(
 			'file'  => DIR_TESTDATA . '/blocks/notice/block.json',
-			'name'  => 'unit-tests/test-block-nonexistent-stylesheet',
+			'name'  => 'tests/test-block-nonexistent-stylesheet',
 			'style' => 'file:./nonexistent.css',
 		);
 		register_block_style_handle( $metadata, 'style' );
 
 		global $wp_styles;
-		$this->assertFalse( $wp_styles->registered['unit-tests-test-block-nonexistent-stylesheet-style']->src );
+		$this->assertFalse( $wp_styles->registered['tests-test-block-nonexistent-stylesheet-style']->src );
 	}
 
 	/**
@@ -1044,13 +1090,13 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 		// @ticket 50328
 		$this->assertSame(
 			wp_normalize_path( realpath( DIR_TESTDATA . '/blocks/notice/block.css' ) ),
-			wp_normalize_path( wp_styles()->get_data( 'unit-tests-test-block-style', 'path' ) )
+			wp_normalize_path( wp_styles()->get_data( 'tests-test-block-style', 'path' ) )
 		);
 
 		// @ticket 59673
 		$this->assertSame(
 			wp_normalize_path( realpath( DIR_TESTDATA . '/blocks/notice/block-view.css' ) ),
-			wp_normalize_path( wp_styles()->get_data( 'unit-tests-test-block-view-style', 'path' ) ),
+			wp_normalize_path( wp_styles()->get_data( 'tests-test-block-view-style', 'path' ) ),
 			'viewStyle asset path is not correct'
 		);
 
@@ -1089,10 +1135,10 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 	 */
 	public function test_register_block_type_accepts_editor_script_array( $editor_script, $expected ) {
 		$settings = array( 'editor_script' => $editor_script );
-		register_block_type( 'core/test-static', $settings );
+		register_block_type( 'tests/static', $settings );
 
 		$registry   = WP_Block_Type_Registry::get_instance();
-		$block_type = $registry->get_registered( 'core/test-static' );
+		$block_type = $registry->get_registered( 'tests/static' );
 		$this->assertObjectHasProperty( 'editor_script_handles', $block_type );
 		$actual_script         = $block_type->editor_script;
 		$actual_script_handles = $block_type->editor_script_handles;
@@ -1155,10 +1201,10 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 	 */
 	public function test_register_block_type_throws_doing_it_wrong( $editor_script, $expected ) {
 		$settings = array( 'editor_script' => $editor_script );
-		register_block_type( 'core/test-static', $settings );
+		register_block_type( 'tests/static', $settings );
 
 		$registry   = WP_Block_Type_Registry::get_instance();
-		$block_type = $registry->get_registered( 'core/test-static' );
+		$block_type = $registry->get_registered( 'tests/static' );
 		$this->assertObjectHasProperty( 'editor_script_handles', $block_type );
 		$actual_script         = $block_type->editor_script;
 		$actual_script_handles = $block_type->editor_script_handles;
@@ -1248,13 +1294,13 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 	 * @ticket 45109
 	 */
 	public function test_get_dynamic_block_names() {
-		register_block_type( 'core/test-static', array() );
-		register_block_type( 'core/test-dynamic', array( 'render_callback' => array( $this, 'render_stub' ) ) );
+		register_block_type( 'tests/static', array() );
+		register_block_type( 'tests/dynamic', array( 'render_callback' => array( $this, 'render_stub' ) ) );
 
 		$dynamic_block_names = get_dynamic_block_names();
 
-		$this->assertContains( 'core/test-dynamic', $dynamic_block_names );
-		$this->assertNotContains( 'core/test-static', $dynamic_block_names );
+		$this->assertContains( 'tests/dynamic', $dynamic_block_names );
+		$this->assertNotContains( 'tests/static', $dynamic_block_names );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

- Part of https://github.com/WordPress/gutenberg/issues/2768.

---

Trac ticket: https://core.trac.wordpress.org/ticket/60485

In the [documentation for WPDefinedAsset definition](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#wpdefinedasset) for block metadata there is a note about handle:

> `handle` (`string`) – the name of the script. If omitted, it will be auto-generated.

We never implemented it, but it would be very useful for block authors. One of the limitations of the way scripts get registered for blocks is that whenever a single file needs to be shared between blocks, then it has to be registered using `wp_register_script` separately, and the script handle used needs to be passed to one of the script fields in `block.json`: `editorScript`, `script` or `viewScript`. It would be great if we could pass the predictable script handle in the `.asset.php` file so you could still use local paths in `block.json` and the rest would get automatically handled by WordPress core. In effect, the logic proposed would read the script handle from the asset file and ensure that all other occurrences reuse the script that is already registered under the same name. It would open the possibility to have firs-class support for shared chunks or runtimes generated by bundlers like webpack.

My initial goal was to find a way to enable runtime chunk for `@wordpress/scripts` in development mode and automatically register it in WordPress core to ensure that React Fast Refresh works correctly with more than one block as summarized in https://github.com/WordPress/gutenberg/issues/25188#issuecomment-1104898123. 

However, I figured out that we could also use the exact mechanism with any shared chunk that @jsnajdr made possible in the first place with https://github.com/WordPress/gutenberg/pull/41002 by improving asset file generation in the webpack plugin that handles dependencies for WP core. 

---

Note: This work, if we agree it's the good direction, is going to require follow-up changes (not a blocker for this patch) to the `@wordpress/dependency-extraction-webpack-plugin`, example `build/shared-script.js`:

```php
<?php

return array(
	'handle'       => 'my-plugin-shared-script',
	'dependencies' => array(),
	'version'      => 'test',
);
```

My initial thinking is that we can auto-generate the script handle based on the combination of the name of the webpack config or the project, plus the sanitized path of the entry file relative to the `build` folder:

`'my-plugin' + '-' + 'shared-script'`


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
