### PR TITLE
A11y: Freeze animated plugin icons when reduced motion is enabled.

### DIFF
--- a/src/js/_enqueues/admin/common.js
+++ b/src/js/_enqueues/admin/common.js
@@ -2194,6 +2194,25 @@ $( function( $ ) {
 		pub.freezeAll();
 	}
 
+	// Listen for jQuery AJAX events
+	jQuery(document).ajaxComplete(function(event, xhr, settings) {
+		// Check if this is the 'search-install-plugins' request
+		if (settings.data && settings.data.includes('action=search-install-plugins')) {
+			// Recheck if the user prefers reduced motion
+			if (window.matchMedia) {
+				var mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+				if (mediaQuery.matches) {
+					pub.freezeAll();
+				}
+			} else {
+				// Fallback for browsers that don't support matchMedia
+				if (true === priv.pauseAll) {
+					pub.freezeAll();
+				}
+			}
+		}
+	});
+
 	// Expose public methods
 	return pub;
 })();

--- a/src/js/_enqueues/admin/common.js
+++ b/src/js/_enqueues/admin/common.js
@@ -2147,8 +2147,9 @@ $( function( $ ) {
 
 			if ( isInsideUpdateTable ) {
 				// Transfer computed styles from image to canvas.
-				var computedStyles = window.getComputedStyle( img );
-				for ( var i = 0, var max = computedStyles.length; i < max; i++ ) {
+				var computedStyles = window.getComputedStyle( img ),
+					i, max;
+				for ( i = 0, max = computedStyles.length; i < max; i++ ) {
 					var propName = computedStyles[ i ];
 					var propValue = computedStyles.getPropertyValue( propName );
 					canvas.style[ propName ] = propValue;
@@ -2196,7 +2197,7 @@ $( function( $ ) {
 
 	// Listen for jQuery AJAX events.
 	( function( $ ) {
-		$.ajaxComplete( function( event, xhr, settings ) {
+		$( document ).ajaxComplete( function( event, xhr, settings ) {
 			// Check if this is the 'search-install-plugins' request.
 			if ( settings.data && settings.data.includes( 'action=search-install-plugins' ) ) {
 				// Recheck if the user prefers reduced motion.

--- a/src/js/_enqueues/admin/common.js
+++ b/src/js/_enqueues/admin/common.js
@@ -2104,3 +2104,96 @@ $( function( $ ) {
 })();
 
 }( jQuery, window ));
+
+/**
+ * Freeze animated plugin icons when reduced motion is enabled.
+ *
+ * When the user has enabled the 'prefers-reduced-motion' setting, this module stops animations for all GIFs
+ * on the page with the class 'plugin-icon' or plugin icon images in the update plugins table.
+ *
+ * @since 6.4
+ */
+var wpFreezeAnimatedPluginIcons = (function() {
+	// Private variables and methods
+	var priv = {};
+	var pub = {};
+	var mediaQuery;
+
+	// Initialize pauseAll to false; it will be set to true if reduced motion is preferred.
+	priv.pauseAll = false;
+	if (window.matchMedia) {
+		mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+		if (!mediaQuery || mediaQuery.matches) {
+			priv.pauseAll = true;
+		}
+	}
+
+	// Method to replace animated GIFs with a static frame.
+	priv.freezeAnimatedPluginIcons = function(img) {
+		var coverImage = function() {
+			var width = img.width;
+			var height = img.height;
+			var canvas = document.createElement('canvas');
+			
+			// Set canvas dimensions
+			canvas.width = width;
+			canvas.height = height;
+
+			// Copy classes from the image to the canvas
+			canvas.className = img.className;
+
+			// Check if the image is inside a specific table
+			var isInsideUpdateTable = img.closest('#update-plugins-table');
+
+			if (isInsideUpdateTable) {
+				// Transfer computed styles from image to canvas
+				var computedStyles = window.getComputedStyle(img);
+				for (var i = 0; i < computedStyles.length; i++) {
+					var propName = computedStyles[i];
+					var propValue = computedStyles.getPropertyValue(propName);
+					canvas.style[propName] = propValue;
+				}
+			}
+
+			// Draw the image onto the canvas
+			canvas.getContext('2d').drawImage(img, 0, 0, width, height);
+
+			// Set accessibility attributes on canvas
+			canvas.setAttribute('aria-hidden', 'true');
+			canvas.setAttribute('role', 'presentation');
+
+			// Insert canvas before the image and set the image to be near-invisible
+			var parent = img.parentNode;
+			parent.insertBefore(canvas, img);
+			img.style.opacity = 0.01;
+			img.style.width = '0px';
+			img.style.height = '0px';
+		};
+
+		// If the image is already loaded, apply the coverImage function
+		if (img.complete) {
+			coverImage();
+		} else {
+			// Otherwise, wait for the image to load
+			img.addEventListener('load', coverImage, true);
+		}
+	};
+
+	// Public method to freeze all relevant GIFs on the page
+	pub.freezeAll = function() {
+		var images = document.querySelectorAll('.plugin-icon, #update-plugins-table img');
+		for (var x = 0; x < images.length; x++) {
+			if (/\.gif(?:\?|$)/i.test(images[x].src)) {
+				priv.freezeAnimatedPluginIcons(images[x]);
+			}
+		}
+	};
+
+	// Only run the freezeAll method if the user prefers reduced motion
+	if (true === priv.pauseAll) {
+		pub.freezeAll();
+	}
+
+	// Expose public methods
+	return pub;
+})();

--- a/src/js/_enqueues/admin/common.js
+++ b/src/js/_enqueues/admin/common.js
@@ -2114,105 +2114,107 @@ $( function( $ ) {
  * @since 6.4
  */
 (function() {
-	// Private variables and methods
-	var priv = {};
-	var pub = {};
-	var mediaQuery;
+	// Private variables and methods.
+	var priv = {},
+		pub = {},
+		mediaQuery;
 
 	// Initialize pauseAll to false; it will be set to true if reduced motion is preferred.
 	priv.pauseAll = false;
-	if (window.matchMedia) {
-		mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-		if (!mediaQuery || mediaQuery.matches) {
+	if ( window.matchMedia ) {
+		mediaQuery = window.matchMedia( '(prefers-reduced-motion: reduce)' );
+		if ( ! mediaQuery || mediaQuery.matches ) {
 			priv.pauseAll = true;
 		}
 	}
 
 	// Method to replace animated GIFs with a static frame.
-	priv.freezeAnimatedPluginIcons = function(img) {
+	priv.freezeAnimatedPluginIcons = function( img ) {
 		var coverImage = function() {
 			var width = img.width;
 			var height = img.height;
-			var canvas = document.createElement('canvas');
+			var canvas = document.createElement( 'canvas' );
 			
-			// Set canvas dimensions
+			// Set canvas dimensions.
 			canvas.width = width;
 			canvas.height = height;
 
-			// Copy classes from the image to the canvas
+			// Copy classes from the image to the canvas.
 			canvas.className = img.className;
 
-			// Check if the image is inside a specific table
-			var isInsideUpdateTable = img.closest('#update-plugins-table');
+			// Check if the image is inside a specific table.
+			var isInsideUpdateTable = img.closest( '#update-plugins-table' );
 
-			if (isInsideUpdateTable) {
-				// Transfer computed styles from image to canvas
-				var computedStyles = window.getComputedStyle(img);
-				for (var i = 0; i < computedStyles.length; i++) {
-					var propName = computedStyles[i];
-					var propValue = computedStyles.getPropertyValue(propName);
-					canvas.style[propName] = propValue;
+			if ( isInsideUpdateTable ) {
+				// Transfer computed styles from image to canvas.
+				var computedStyles = window.getComputedStyle( img );
+				for ( var i = 0, var max = computedStyles.length; i < max; i++ ) {
+					var propName = computedStyles[ i ];
+					var propValue = computedStyles.getPropertyValue( propName );
+					canvas.style[ propName ] = propValue;
 				}
 			}
 
-			// Draw the image onto the canvas
-			canvas.getContext('2d').drawImage(img, 0, 0, width, height);
+			// Draw the image onto the canvas.
+			canvas.getContext( '2d' ).drawImage( img, 0, 0, width, height );
 
-			// Set accessibility attributes on canvas
-			canvas.setAttribute('aria-hidden', 'true');
-			canvas.setAttribute('role', 'presentation');
+			// Set accessibility attributes on canvas.
+			canvas.setAttribute( 'aria-hidden', 'true' );
+			canvas.setAttribute( 'role', 'presentation' );
 
-			// Insert canvas before the image and set the image to be near-invisible
+			// Insert canvas before the image and set the image to be near-invisible.
 			var parent = img.parentNode;
-			parent.insertBefore(canvas, img);
+			parent.insertBefore( canvas, img );
 			img.style.opacity = 0.01;
 			img.style.width = '0px';
 			img.style.height = '0px';
 		};
 
-		// If the image is already loaded, apply the coverImage function
-		if (img.complete) {
+		// If the image is already loaded, apply the coverImage function.
+		if ( img.complete ) {
 			coverImage();
 		} else {
-			// Otherwise, wait for the image to load
-			img.addEventListener('load', coverImage, true);
+			// Otherwise, wait for the image to load.
+			img.addEventListener( 'load', coverImage, true );
 		}
 	};
 
-	// Public method to freeze all relevant GIFs on the page
+	// Public method to freeze all relevant GIFs on the page.
 	pub.freezeAll = function() {
-		var images = document.querySelectorAll('.plugin-icon, #update-plugins-table img');
-		for (var x = 0; x < images.length; x++) {
-			if (/\.gif(?:\?|$)/i.test(images[x].src)) {
-				priv.freezeAnimatedPluginIcons(images[x]);
+		var images = document.querySelectorAll( '.plugin-icon, #update-plugins-table img' );
+		for ( var x = 0; x < images.length; x++ ) {
+			if ( /\.gif(?:\?|$)/i.test( images[ x ].src ) ) {
+				priv.freezeAnimatedPluginIcons( images[ x ] );
 			}
 		}
 	};
 
-	// Only run the freezeAll method if the user prefers reduced motion
-	if (true === priv.pauseAll) {
+	// Only run the freezeAll method if the user prefers reduced motion.
+	if ( true === priv.pauseAll ) {
 		pub.freezeAll();
 	}
 
-	// Listen for jQuery AJAX events
-	jQuery(document).ajaxComplete(function(event, xhr, settings) {
-		// Check if this is the 'search-install-plugins' request
-		if (settings.data && settings.data.includes('action=search-install-plugins')) {
-			// Recheck if the user prefers reduced motion
-			if (window.matchMedia) {
-				var mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-				if (mediaQuery.matches) {
-					pub.freezeAll();
-				}
-			} else {
-				// Fallback for browsers that don't support matchMedia
-				if (true === priv.pauseAll) {
-					pub.freezeAll();
+	// Listen for jQuery AJAX events.
+	( function( $ ) {
+		$.ajaxComplete( function( event, xhr, settings ) {
+			// Check if this is the 'search-install-plugins' request.
+			if ( settings.data && settings.data.includes( 'action=search-install-plugins' ) ) {
+				// Recheck if the user prefers reduced motion.
+				if ( window.matchMedia ) {
+					var mediaQuery = window.matchMedia( '(prefers-reduced-motion: reduce)' );
+					if ( mediaQuery.matches ) {
+						pub.freezeAll();
+					}
+				} else {
+					// Fallback for browsers that don't support matchMedia.
+					if ( true === priv.pauseAll ) {
+						pub.freezeAll();
+					}
 				}
 			}
-		}
-	});
+		} );
+	} )( jQuery );
 
-	// Expose public methods
+	// Expose public methods.
 	return pub;
 })();

--- a/src/js/_enqueues/admin/common.js
+++ b/src/js/_enqueues/admin/common.js
@@ -2113,7 +2113,7 @@ $( function( $ ) {
  *
  * @since 6.4
  */
-var wpFreezeAnimatedPluginIcons = (function() {
+(function() {
 	// Private variables and methods
 	var priv = {};
 	var pub = {};
@@ -2122,7 +2122,7 @@ var wpFreezeAnimatedPluginIcons = (function() {
 	// Initialize pauseAll to false; it will be set to true if reduced motion is preferred.
 	priv.pauseAll = false;
 	if (window.matchMedia) {
-		mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+		mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
 		if (!mediaQuery || mediaQuery.matches) {
 			priv.pauseAll = true;
 		}


### PR DESCRIPTION
Freeze animated plugin icons when reduced motion is enabled. When the user has enabled the 'prefers-reduced-motion' setting, this module stops animations for all GIFs on the page with the class 'plugin-icon' or plugin icon images in the update plugins table.

Added to wp-admin/js/common.js. I'm not sure if this is the best location for this javascript. Open to suggestions if this is not the proper location for such code.

Trac ticket: https://core.trac.wordpress.org/ticket/55723

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
