### PR TITLE
Override PHP's default error and exception handler printing

### DIFF
--- a/src/wp-error-handling.php
+++ b/src/wp-error-handling.php
@@ -29,7 +29,25 @@ if ( function_exists( 'error_reporting' ) ) {
 }
 
 /**
- * Handler for PHP's `set_error_handler`.
+ * Previous error handler for chaining. Private.
+ *
+ * @since 6.4.0
+ * @private
+ * @var callable|null
+ */
+$_wp_error_handling_previous_error_handler = set_error_handler( 'wp_error_handler' );
+
+/**
+ * Previous exception handler for chaining. Private.
+ *
+ * @since 6.4.0
+ * @private
+ * @var callable|null
+ */
+$_wp_error_handling_previous_exception_handler = set_exception_handler( 'wp_exception_handler' );
+
+/**
+ * Display errors like PHP's `display_errors` would.
  *
  * We have two conflicting goals here:
  *  1. We want to not print error text containing arbitrary HTML to the browser.
@@ -42,15 +60,14 @@ if ( function_exists( 'error_reporting' ) ) {
  * error was unhandled so PHP does everything else it would normally do.
  *
  * @since 6.4.0
+ * @private
  *
  * @param int         $errno   Level of the error raised.
  * @param string      $errstr  Error message.
  * @param string|null $errfile Filename the error was raised in.
  * @param int         $errline Line number where the error was raised.
- *
- * @return bool True to indicate the error was handled, false if not.
  */
-function wp_error_handler( $errno, $errstr, $errfile, $errline ) {
+function _wp_error_handler_printer( $errno, $errstr, $errfile, $errline ) {
 	static $display_errors = false;
 
 	$v = ini_get( 'display_errors' );
@@ -69,112 +86,142 @@ function wp_error_handler( $errno, $errstr, $errfile, $errline ) {
 		}
 	}
 
-	if ( $display_errors && ( error_reporting() & $errno ) !== 0 ) {
+	if ( ! $display_errors || ( error_reporting() & $errno ) === 0 ) {
+		return;
+	}
 
-		// From https://github.com/php/php-src/blob/3f38105740d160e448881b268ebc44bfed20c7db/main/main.c#L1236-L1250
-		if ( ini_get( 'ignore_repeated_errors' ) ) {
-			$last = error_get_last();
-			if ( $last && $last['message'] === $errstr && (
-				ini_get( 'ignore_repeated_source' ) ||
-				(int) $last['line'] === (int) $errline && $last['file'] === $errfile
-			) ) {
-				return false;
-			}
-		}
-
-		switch ( $errno ) {
-			case E_ERROR:
-			case E_CORE_ERROR:
-			case E_COMPILE_ERROR:
-			case E_USER_ERROR:
-				$type_str = 'Fatal error';
-				break;
-			case E_RECOVERABLE_ERROR:
-				$type_str = 'Recoverable fatal error';
-				break;
-			case E_WARNING:
-			case E_CORE_WARNING:
-			case E_COMPILE_WARNING:
-			case E_USER_WARNING:
-				$type_str = 'Warning';
-				break;
-			case E_PARSE:
-				$type_str = 'Parse error';
-				break;
-			case E_NOTICE:
-			case E_USER_NOTICE:
-				$type_str = 'Notice';
-				break;
-			case E_STRICT:
-				$type_str = 'Strict Standards';
-				break;
-			case E_DEPRECATED:
-			case E_USER_DEPRECATED:
-				$type_str = 'Deprecated';
-				break;
-			default:
-				$type_str = 'Unknown error';
-				break;
-		}
-
-		$errfile = (string) $errfile;
-		if ( '' === $errfile ) {
-			$errfile = 'Unknown';
-		}
-
-		// Adapted from https://github.com/php/php-src/blob/3f38105740d160e448881b268ebc44bfed20c7db/main/main.c#L1352-L1379
-		// with the addition of some `htmlspecialchars()` calls.
-		if ( ini_get( 'xmlrpc_errors' ) ) {
-			printf(
-				'<?xml version="1.0"?><methodResponse><fault><value><struct><member><name>faultCode</name><value><int>%d</int></value></member><member><name>faultString</name><value><string>%s:%s in %s on line %u</string></value></member></struct></value></fault></methodResponse>',
-				ini_get( 'xmlrpc_error_number' ),
-				$type_str,
-				htmlspecialchars( $errstr, ENT_QUOTES | ENT_XML1 ),
-				htmlspecialchars( $errfile, ENT_QUOTES | ENT_XML1 ),
-				$errline
-			);
-		} else {
-			$error_prepend_string = (string) ini_get( 'error_prepend_string' );
-			$error_append_string  = (string) ini_get( 'error_append_string' );
-
-			if ( PHP_SAPI !== 'cli' && PHP_SAPI !== 'phpdbg' ) {
-				$errstr  = htmlspecialchars( $errstr, ENT_QUOTES | ENT_HTML401 );
-				$errfile = htmlspecialchars( $errfile, ENT_QUOTES | ENT_HTML401 );
-			}
-
-			if ( ini_get( 'html_errors' ) ) {
-				printf( "%s<br />\n<b>%s</b>:  %s in <b>%s</b> on line <b>%u</b><br />\n%s", $error_prepend_string, $type_str, $errstr, $errfile, $errline, $error_append_string );
-			} elseif ( 'stderr' === $display_errors && ( PHP_SAPI === 'cli' || PHP_SAPI === 'cgi' || PHP_SAPI === 'phpdbg' ) ) {
-				fprintf( STDERR, "%s: %s in %s on line %u\n", $type_str, $errstr, $errfile, $errline );
-				fflush( STDERR );
-			} else {
-				printf( "%s\n%s: %s in %s on line %u\n%s", $error_prepend_string, $type_str, $errstr, $errfile, $errline, $error_append_string );
-			}
+	// From https://github.com/php/php-src/blob/3f38105740d160e448881b268ebc44bfed20c7db/main/main.c#L1236-L1250
+	if ( ini_get( 'ignore_repeated_errors' ) ) {
+		$last = error_get_last();
+		if ( $last && $last['message'] === $errstr && (
+			ini_get( 'ignore_repeated_source' ) ||
+			(int) $last['line'] === (int) $errline && $last['file'] === $errfile
+		) ) {
+			return;
 		}
 	}
 
-	return false;
+	switch ( $errno ) {
+		case E_ERROR:
+		case E_CORE_ERROR:
+		case E_COMPILE_ERROR:
+		case E_USER_ERROR:
+			$type_str = 'Fatal error';
+			break;
+		case E_RECOVERABLE_ERROR:
+			$type_str = 'Recoverable fatal error';
+			break;
+		case E_WARNING:
+		case E_CORE_WARNING:
+		case E_COMPILE_WARNING:
+		case E_USER_WARNING:
+			$type_str = 'Warning';
+			break;
+		case E_PARSE:
+			$type_str = 'Parse error';
+			break;
+		case E_NOTICE:
+		case E_USER_NOTICE:
+			$type_str = 'Notice';
+			break;
+		case E_STRICT:
+			$type_str = 'Strict Standards';
+			break;
+		case E_DEPRECATED:
+		case E_USER_DEPRECATED:
+			$type_str = 'Deprecated';
+			break;
+		default:
+			$type_str = 'Unknown error';
+			break;
+	}
+
+	$errfile = (string) $errfile;
+	if ( '' === $errfile ) {
+		$errfile = 'Unknown';
+	}
+
+	// Adapted from https://github.com/php/php-src/blob/3f38105740d160e448881b268ebc44bfed20c7db/main/main.c#L1352-L1379
+	// with the addition of some `htmlspecialchars()` calls.
+	if ( ini_get( 'xmlrpc_errors' ) ) {
+		printf(
+			'<?xml version="1.0"?><methodResponse><fault><value><struct><member><name>faultCode</name><value><int>%d</int></value></member><member><name>faultString</name><value><string>%s:%s in %s on line %u</string></value></member></struct></value></fault></methodResponse>',
+			ini_get( 'xmlrpc_error_number' ),
+			$type_str,
+			htmlspecialchars( $errstr, ENT_QUOTES | ENT_XML1 ),
+			htmlspecialchars( $errfile, ENT_QUOTES | ENT_XML1 ),
+			$errline
+		);
+	} else {
+		$error_prepend_string = (string) ini_get( 'error_prepend_string' );
+		$error_append_string  = (string) ini_get( 'error_append_string' );
+
+		if ( PHP_SAPI !== 'cli' && PHP_SAPI !== 'phpdbg' ) {
+			$errstr  = htmlspecialchars( $errstr, ENT_QUOTES | ENT_HTML401 );
+			$errfile = htmlspecialchars( $errfile, ENT_QUOTES | ENT_HTML401 );
+		}
+
+		if ( ini_get( 'html_errors' ) ) {
+			printf( "%s<br />\n<b>%s</b>:  %s in <b>%s</b> on line <b>%u</b><br />\n%s", $error_prepend_string, $type_str, $errstr, $errfile, $errline, $error_append_string );
+		} elseif ( 'stderr' === $display_errors && ( PHP_SAPI === 'cli' || PHP_SAPI === 'cgi' || PHP_SAPI === 'phpdbg' ) ) {
+			fprintf( STDERR, "%s: %s in %s on line %u\n", $type_str, $errstr, $errfile, $errline );
+			fflush( STDERR );
+		} else {
+			printf( "%s\n%s: %s in %s on line %u\n%s", $error_prepend_string, $type_str, $errstr, $errfile, $errline, $error_append_string );
+		}
+	}
+}
+
+/**
+ * Handler for PHP's `set_error_handler`.
+ *
+ * Calls `_wp_error_handler_printer()` to handle printing and resetting of `display_errors`, then
+ * chains to the next handler or returns false to let the default handler handle the rest of it.
+ *
+ * @since 6.4.0
+ *
+ * @param int         $errno   Level of the error raised.
+ * @param string      $errstr  Error message.
+ * @param string|null $errfile Filename the error was raised in.
+ * @param int         $errline Line number where the error was raised.
+ *
+ * @return bool True to indicate the error was handled, false if not.
+ */
+function wp_error_handler( $errno, $errstr, $errfile, $errline ) {
+	global $_wp_error_handling_previous_error_handler;
+
+	_wp_error_handler_printer( $errno, $errstr, $errfile, $errline );
+
+	if ( $_wp_error_handling_previous_error_handler ) {
+		return $_wp_error_handling_previous_error_handler( $errno, $errstr, $errfile, $errline );
+	} else {
+		return false;
+	}
 }
 
 /**
  * Handler for PHP's `set_exception_handler`.
  *
- * Calls `wp_error_handler()` to handle printing and resetting of `display_errors`, then
- * rethrows the exception to let the default handler handle the rest of it.
+ * Calls `_wp_error_handler_printer()` to handle printing and resetting of `display_errors`, then
+ * chains to the next handler or rethrows the exception to let the default handler handle
+ * the rest of it.
  *
  * @since 6.4.0
  *
  * @param Throwable $ex Object that was thrown.
  */
 function wp_exception_handler( Throwable $ex ) {
+	global $_wp_error_handling_previous_exception_handler;
+
 	try {
 		// Adapted from https://github.com/php/php-src/blob/3f38105740d160e448881b268ebc44bfed20c7db/Zend/zend_exceptions.c#L954-L956
-		wp_error_handler( E_ERROR, "Uncaught {$ex->__toString()}\n  thrown", $ex->getFile(), $ex->getLine() );
+		_wp_error_handler_printer( E_ERROR, "Uncaught {$ex->__toString()}\n  thrown", $ex->getFile(), $ex->getLine() );
 	} catch ( Throwable $t ) {
 		// Probably $ex->__toString() is broken. Let the default handler handle that.
 	}
-	throw $ex;
+	if ( $_wp_error_handling_previous_exception_handler ) {
+		$_wp_error_handling_previous_exception_handler( $ex );
+	} else {
+		throw $ex;
+	}
 }
-
-set_error_handler( 'wp_error_handler' );
-set_exception_handler( 'wp_exception_handler' );

--- a/src/wp-error-handling.php
+++ b/src/wp-error-handling.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * Set up basic error handling for WordPress.
+ *
+ * Initially we simply want to avoid error messages accidentally containing
+ * HTML in certain configurations. In the future we may improve the display
+ * beyond what PHP does by default.
+ *
+ * @package WordPress
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die();
+}
+
+/*
+ * The error_reporting() function can be disabled in php.ini. On systems where that is the case,
+ * it's best to add a dummy function to the wp-config.php file, but as this call to the function
+ * is run prior to wp-config.php loading, it is wrapped in a function_exists() check.
+ */
+if ( function_exists( 'error_reporting' ) ) {
+	/*
+	 * Initialize error reporting to a known set of levels.
+	 *
+	 * This will be adapted in wp_debug_mode() located in wp-includes/load.php based on WP_DEBUG.
+	 * @see https://www.php.net/manual/en/errorfunc.constants.php List of known error levels.
+	 */
+	error_reporting( E_CORE_ERROR | E_CORE_WARNING | E_COMPILE_ERROR | E_ERROR | E_WARNING | E_PARSE | E_USER_ERROR | E_USER_WARNING | E_RECOVERABLE_ERROR );
+}
+
+/**
+ * Handler for PHP's `set_error_handler`.
+ *
+ * We have two conflicting goals here:
+ *  1. We want to not print error text containing arbitrary HTML to the browser.
+ *  2. We want all PHP's built-in stuff like `error_get_last()` to work despite
+ *     bugs like https://bugs.php.net/bug.php?id=60575.
+ *
+ * Fortunately PHP doesn't normalize values set to `display_errors` via `ini_set()`, and
+ * it treats any unrecognized value as "off". So what we do here is save whatever is in
+ * `display_errors`, set it to "wp", print the error if appropriate, and then claims the
+ * error was unhandled so PHP does everything else it would normally do.
+ *
+ * @since 6.4.0
+ *
+ * @param int         $errno   Level of the error raised.
+ * @param string      $errstr  Error message.
+ * @param string|null $errfile Filename the error was raised in.
+ * @param int         $errline Line number where the error was raised.
+ *
+ * @return bool True to indicate the error was handled, false if not.
+ */
+function wp_error_handler( $errno, $errstr, $errfile, $errline ) {
+	static $display_errors = false;
+
+	$v = ini_get( 'display_errors' );
+	if ( 'wp' !== $v ) {
+		$display_errors = strtolower( $v ) === 'stderr' ? 'stderr' : (bool) $v;
+		ini_set( 'display_errors', 'wp' );
+	}
+
+	if ( $display_errors && ( error_reporting() & $errno ) !== 0 ) {
+
+		// From https://github.com/php/php-src/blob/3f38105740d160e448881b268ebc44bfed20c7db/main/main.c#L1236-L1250
+		if ( ini_get( 'ignore_repeated_errors' ) ) {
+			$last = error_get_last();
+			if ( $last && $last['message'] === $errstr && (
+				ini_get( 'ignore_repeated_source' ) ||
+				(int) $last['line'] === (int) $errline && $last['file'] === $errfile
+			) ) {
+				return false;
+			}
+		}
+
+		switch ( $errno ) {
+			case E_ERROR:
+			case E_CORE_ERROR:
+			case E_COMPILE_ERROR:
+			case E_USER_ERROR:
+				$type_str = 'Fatal error';
+				break;
+			case E_RECOVERABLE_ERROR:
+				$type_str = 'Recoverable fatal error';
+				break;
+			case E_WARNING:
+			case E_CORE_WARNING:
+			case E_COMPILE_WARNING:
+			case E_USER_WARNING:
+				$type_str = 'Warning';
+				break;
+			case E_PARSE:
+				$type_str = 'Parse error';
+				break;
+			case E_NOTICE:
+			case E_USER_NOTICE:
+				$type_str = 'Notice';
+				break;
+			case E_STRICT:
+				$type_str = 'Strict Standards';
+				break;
+			case E_DEPRECATED:
+			case E_USER_DEPRECATED:
+				$type_str = 'Deprecated';
+				break;
+			default:
+				$type_str = 'Unknown error';
+				break;
+		}
+
+		$errfile = (string) $errfile;
+		if ( '' === $errfile ) {
+			$errfile = 'Unknown';
+		}
+
+		// Adapted from https://github.com/php/php-src/blob/3f38105740d160e448881b268ebc44bfed20c7db/main/main.c#L1352-L1379
+		// with the addition of some `htmlspecialchars()` calls.
+		if ( ini_get( 'xmlrpc_errors' ) ) {
+			printf(
+				'<?xml version="1.0"?><methodResponse><fault><value><struct><member><name>faultCode</name><value><int>%d</int></value></member><member><name>faultString</name><value><string>%s:%s in %s on line %u</string></value></member></struct></value></fault></methodResponse>',
+				ini_get( 'xmlrpc_error_number' ),
+				$type_str,
+				htmlspecialchars( $errstr, ENT_QUOTES | ENT_XML1 ),
+				htmlspecialchars( $errfile, ENT_QUOTES | ENT_XML1 ),
+				$errline
+			);
+		} else {
+			$error_prepend_string = (string) ini_get( 'error_prepend_string' );
+			$error_append_string  = (string) ini_get( 'error_append_string' );
+
+			if ( PHP_SAPI !== 'cli' && PHP_SAPI !== 'phpdbg' ) {
+				$errstr  = htmlspecialchars( $errstr, ENT_QUOTES | ENT_HTML401 );
+				$errfile = htmlspecialchars( $errfile, ENT_QUOTES | ENT_HTML401 );
+			}
+
+			if ( ini_get( 'html_errors' ) ) {
+				printf( "%s<br />\n<b>%s</b>:  %s in <b>%s</b> on line <b>%u</b><br />\n%s", $error_prepend_string, $type_str, $errstr, $errfile, $errline, $error_append_string );
+			} elseif ( 'stderr' === $display_errors && ( PHP_SAPI === 'cli' || PHP_SAPI === 'cgi' || PHP_SAPI === 'phpdbg' ) ) {
+				fprintf( STDERR, "%s: %s in %s on line %u\n", $type_str, $errstr, $errfile, $errline );
+				fflush( STDERR );
+			} else {
+				printf( "%s\n%s: %s in %s on line %u\n%s", $error_prepend_string, $type_str, $errstr, $errfile, $errline, $error_append_string );
+			}
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Handler for PHP's `set_exception_handler`.
+ *
+ * Calls `wp_error_handler()` to handle printing and resetting of `display_errors`, then
+ * rethrows the exception to let the default handler handle the rest of it.
+ *
+ * @since 6.4.0
+ *
+ * @param Throwable $ex Object that was thrown.
+ */
+function wp_exception_handler( Throwable $ex ) {
+	try {
+		// Adapted from https://github.com/php/php-src/blob/3f38105740d160e448881b268ebc44bfed20c7db/Zend/zend_exceptions.c#L954-L956
+		wp_error_handler( E_ERROR, "Uncaught {$ex->__toString()}\n  thrown", $ex->getFile(), $ex->getLine() );
+	} catch ( Throwable $t ) {
+		// Probably $ex->__toString() is broken. Let the default handler handle that.
+	}
+	throw $ex;
+}
+
+set_error_handler( 'wp_error_handler' );
+set_exception_handler( 'wp_exception_handler' );

--- a/src/wp-error-handling.php
+++ b/src/wp-error-handling.php
@@ -9,6 +9,10 @@
  * @package WordPress
  */
 
+namespace WpOrg\Error_Handling;
+
+use Throwable;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die();
 }
@@ -35,7 +39,7 @@ if ( function_exists( 'error_reporting' ) ) {
  * @private
  * @var callable|null
  */
-$_wp_error_handling_previous_error_handler = set_error_handler( 'wp_error_handler' );
+$_wp_error_handling_previous_error_handler = set_error_handler( __NAMESPACE__ . '\\wp_error_handler' );
 
 /**
  * Previous exception handler for chaining. Private.
@@ -44,7 +48,7 @@ $_wp_error_handling_previous_error_handler = set_error_handler( 'wp_error_handle
  * @private
  * @var callable|null
  */
-$_wp_error_handling_previous_exception_handler = set_exception_handler( 'wp_exception_handler' );
+$_wp_error_handling_previous_exception_handler = set_exception_handler( __NAMESPACE__ . '\\wp_exception_handler' );
 
 /**
  * Display errors like PHP's `display_errors` would.
@@ -167,14 +171,15 @@ function _wp_error_handler_printer( $errno, $errstr, $errfile, $errline ) {
 		$error_prepend_string = (string) ini_get( 'error_prepend_string' );
 		$error_append_string  = (string) ini_get( 'error_append_string' );
 
-		if ( PHP_SAPI !== 'cli' && PHP_SAPI !== 'phpdbg' ) {
+		$sapi = php_sapi_name();
+		if ( 'cli' !== $sapi && 'phpdbg' !== $sapi ) {
 			$errstr  = htmlspecialchars( $errstr, ENT_QUOTES | ENT_HTML401 );
 			$errfile = htmlspecialchars( $errfile, ENT_QUOTES | ENT_HTML401 );
 		}
 
 		if ( $ini_get_bool( 'html_errors' ) ) {
 			printf( "%s<br />\n<b>%s</b>:  %s in <b>%s</b> on line <b>%u</b><br />\n%s", $error_prepend_string, $type_str, $errstr, $errfile, $errline, $error_append_string );
-		} elseif ( 'stderr' === $display_errors_ini_value && ( PHP_SAPI === 'cli' || PHP_SAPI === 'cgi' || PHP_SAPI === 'phpdbg' ) ) {
+		} elseif ( 'stderr' === $display_errors_ini_value && ( 'cli' === $sapi || 'cgi' === $sapi || 'phpdbg' === $sapi ) ) {
 			fprintf( STDERR, "%s: %s in %s on line %u\n", $type_str, $errstr, $errfile, $errline );
 			fflush( STDERR );
 		} else {

--- a/src/wp-error-handling.php
+++ b/src/wp-error-handling.php
@@ -116,6 +116,9 @@ function _wp_error_handler_printer( $errno, $errstr, $errfile, $errline ) {
 		}
 	}
 
+	// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Avoid warnings for constant deprecated in 8.4, while still supporting it for earlier versions.
+	$e_strict = defined( 'E_STRICT' ) ? @E_STRICT : 'E_STRICT';
+
 	switch ( $errno ) {
 		case E_ERROR:
 		case E_CORE_ERROR:
@@ -139,7 +142,7 @@ function _wp_error_handler_printer( $errno, $errstr, $errfile, $errline ) {
 		case E_USER_NOTICE:
 			$type_str = 'Notice';
 			break;
-		case E_STRICT:
+		case $e_strict:
 			$type_str = 'Strict Standards';
 			break;
 		case E_DEPRECATED:

--- a/src/wp-load.php
+++ b/src/wp-load.php
@@ -21,20 +21,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', __DIR__ . '/' );
 }
 
-/*
- * The error_reporting() function can be disabled in php.ini. On systems where that is the case,
- * it's best to add a dummy function to the wp-config.php file, but as this call to the function
- * is run prior to wp-config.php loading, it is wrapped in a function_exists() check.
- */
-if ( function_exists( 'error_reporting' ) ) {
-	/*
-	 * Initialize error reporting to a known set of levels.
-	 *
-	 * This will be adapted in wp_debug_mode() located in wp-includes/load.php based on WP_DEBUG.
-	 * @see https://www.php.net/manual/en/errorfunc.constants.php List of known error levels.
-	 */
-	error_reporting( E_CORE_ERROR | E_CORE_WARNING | E_COMPILE_ERROR | E_ERROR | E_WARNING | E_PARSE | E_USER_ERROR | E_USER_WARNING | E_RECOVERABLE_ERROR );
-}
+/** Set up basic error handling. */
+require_once ABSPATH . 'wp-error-handling.php';
 
 /*
  * If wp-config.php exists in the WordPress root, or if it exists in the root and wp-settings.php

--- a/tests/phpunit/tests/wp-error-handling.php
+++ b/tests/phpunit/tests/wp-error-handling.php
@@ -1,0 +1,473 @@
+<?php
+
+namespace WpOrg\Error_Handling;
+
+// Dummy functions for testing.
+
+$mock_function_data = null;
+
+function ini_get( $setting ) {
+	global $mock_function_data;
+	if ( null === $mock_function_data ) {
+		return \ini_get( $setting );
+	}
+
+	if ( array_key_exists( $setting, $mock_function_data['ini'] ) ) {
+		return $mock_function_data['ini'][ $setting ];
+	}
+	throw new \RuntimeException( "Ini setting `$setting` was not mocked" );
+}
+
+function ini_set( $setting, $value ) {
+	global $mock_function_data;
+	if ( null === $mock_function_data ) {
+		return \ini_set( $setting, $value );
+	}
+
+	if ( array_key_exists( $setting, $mock_function_data['ini'] ) ) {
+		$ret                                   = $mock_function_data['ini'][ $setting ];
+		$mock_function_data['ini'][ $setting ] = $value;
+		return $ret;
+	}
+	throw new \RuntimeException( "Ini setting `$setting` was not mocked" );
+}
+
+function php_sapi_name() {
+	global $mock_function_data;
+	if ( null === $mock_function_data ) {
+		return \php_sapi_name();
+	}
+
+	return $mock_function_data['sapi'];
+}
+
+function error_reporting( $level = null ) {
+	global $mock_function_data;
+	if ( null === $mock_function_data ) {
+		return null === $level ? \error_reporting() : \error_reporting( $level );
+	}
+
+	// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+	$ret = \error_reporting() === @\error_reporting() ? @\error_reporting() : $mock_function_data['ini']['error_reporting'];
+	if ( null !== $level ) {
+		$mock_function_data['ini']['error_reporting'] = $level;
+	}
+	return $ret;
+}
+
+function error_get_last() {
+	global $mock_function_data;
+	if ( null === $mock_function_data ) {
+		return \error_get_last();
+	}
+
+	return isset( $mock_function_data['last'] ) ? $mock_function_data['last'] : null;
+}
+
+/**
+ * @group wp-error-handling.php
+ */
+class Tests_WP_Error_Handling extends \WP_UnitTestCase {
+
+	/**
+	 * Globals to restore.
+	 *
+	 * @var array
+	 */
+	private $restore_globals = array();
+
+	public static function set_up_before_class() {
+		global $_wp_error_handling_previous_error_handler, $_wp_error_handling_previous_exception_handler;
+
+		parent::set_up_before_class();
+
+		if ( ! function_exists( 'wp_error_handler' ) ) {
+			// We're just wanting to test the functions, not the other stuff.
+			// So undo the other stuff after the require.
+			$old_error_reporting = error_reporting();
+			require_once ABSPATH . 'wp-error-handling.php';
+			error_reporting( $old_error_reporting );
+			restore_error_handler();
+			restore_exception_handler();
+			$_wp_error_handling_previous_error_handler     = null;
+			$_wp_error_handling_previous_exception_handler = null;
+		}
+	}
+
+	public function set_up() {
+		global $mock_function_data, $_wp_error_handling_previous_error_handler, $_wp_error_handling_previous_exception_handler;
+
+		parent::set_up();
+
+		$mock_function_data = array(
+			'ini'  => array(
+				'display_errors'         => 'on',
+				'xmlrpc_errors'          => 'off',
+				'xmlrpc_error_number'    => 8675309,
+				'ignore_repeated_errors' => 'off',
+				'ignore_repeated_source' => 'off',
+				'error_prepend_string'   => '',
+				'error_append_string'    => '',
+				'html_errors'            => 'on',
+				'error_reporting'        => E_ALL,
+			),
+			'sapi' => 'apache',
+		);
+
+		$this->restore_globals = array(
+			'mock_function_data'                        => null,
+			'_wp_error_handling_previous_error_handler' => $_wp_error_handling_previous_error_handler,
+			'_wp_error_handling_previous_exception_handler' => $_wp_error_handling_previous_exception_handler,
+		);
+	}
+
+	public function tear_down() {
+		parent::tear_down();
+
+		foreach ( $this->restore_globals as $k => $v ) {
+			$GLOBALS[ $k ] = $v;
+		}
+	}
+
+	/**
+	 * @dataProvider data_wp_error_handler_printer
+	 */
+	public function test_wp_error_handler_printer( $mock_data, $calls, $expect ) {
+		global $mock_function_data;
+
+		$mock_function_data = array_replace_recursive( $mock_function_data, $mock_data );
+
+		$this->expectOutputString( $expect );
+		foreach ( $calls as list( $errno, $errstr, $errfile, $errline, $new_display_errors_value ) ) {
+			_wp_error_handler_printer( $errno, $errstr, $errfile, $errline );
+			$this->assertSame( $new_display_errors_value, ini_get( 'display_errors' ) );
+			$mock_function_data['last'] = array(
+				'type'    => $errno,
+				'message' => $errstr,
+				'file'    => $errfile,
+				'line'    => $errline,
+			);
+		}
+	}
+
+	public function data_wp_error_handler_printer() {
+		return array(
+			'display_errors off'                        => array(
+				array( 'ini' => array( 'display_errors' => 'off' ) ),
+				array(
+					array( E_ERROR, 'Some error', 'some-file.php', 42, 'off' ),
+				),
+				'',
+			),
+			'error_reporting off'                       => array(
+				array( 'ini' => array( 'error_reporting' => E_ALL & ~E_ERROR ) ),
+				array(
+					array( E_ERROR, 'Some error', 'some-file.php', 42, 'wp' ),
+				),
+				'',
+			),
+			'some errors'                               => array(
+				array(),
+				array(
+					array( E_NOTICE, '<i>Some notice</i>', 'some-file.php', 40, 'wp' ),
+					array( E_WARNING, '<i>Some warning</i>', 'some-file-&-what.php', 41, 'wp' ),
+					array( E_ERROR, '<i>Some error</i>', 'some-file.php', 42, 'wp' ),
+				),
+				"<br />\n<b>Notice</b>:  &lt;i&gt;Some notice&lt;/i&gt; in <b>some-file.php</b> on line <b>40</b><br />\n"
+				. "<br />\n<b>Warning</b>:  &lt;i&gt;Some warning&lt;/i&gt; in <b>some-file-&amp;-what.php</b> on line <b>41</b><br />\n"
+				. "<br />\n<b>Fatal error</b>:  &lt;i&gt;Some error&lt;/i&gt; in <b>some-file.php</b> on line <b>42</b><br />\n",
+			),
+			'some errors, cli'                          => array(
+				array( 'sapi' => 'cli' ),
+				array(
+					array( E_NOTICE, '<i>Some notice</i>', 'some-file.php', 40, 'wp' ),
+					array( E_WARNING, '<i>Some warning</i>', 'some-file-&-what.php', 41, 'wp' ),
+					array( E_ERROR, '<i>Some error</i>', 'some-file.php', 42, 'wp' ),
+				),
+				"<br />\n<b>Notice</b>:  <i>Some notice</i> in <b>some-file.php</b> on line <b>40</b><br />\n"
+				. "<br />\n<b>Warning</b>:  <i>Some warning</i> in <b>some-file-&-what.php</b> on line <b>41</b><br />\n"
+				. "<br />\n<b>Fatal error</b>:  <i>Some error</i> in <b>some-file.php</b> on line <b>42</b><br />\n",
+			),
+			'without html_errors'                       => array(
+				array( 'ini' => array( 'html_errors' => 'off' ) ),
+				array(
+					array( E_NOTICE, '<i>Some notice</i>', 'some-file.php', 40, 'wp' ),
+					array( E_WARNING, '<i>Some warning</i>', 'some-file-&-what.php', 41, 'wp' ),
+					array( E_ERROR, '<i>Some error</i>', 'some-file.php', 42, 'wp' ),
+				),
+				"\nNotice: &lt;i&gt;Some notice&lt;/i&gt; in some-file.php on line 40\n"
+				. "\nWarning: &lt;i&gt;Some warning&lt;/i&gt; in some-file-&amp;-what.php on line 41\n"
+				. "\nFatal error: &lt;i&gt;Some error&lt;/i&gt; in some-file.php on line 42\n",
+			),
+			'without html_errors, cli'                  => array(
+				array(
+					'ini'  => array( 'html_errors' => 'off' ),
+					'sapi' => 'cli',
+				),
+				array(
+					array( E_NOTICE, '<i>Some notice</i>', 'some-file.php', 40, 'wp' ),
+					array( E_WARNING, '<i>Some warning</i>', 'some-file-&-what.php', 41, 'wp' ),
+					array( E_ERROR, '<i>Some error</i>', 'some-file.php', 42, 'wp' ),
+				),
+				"\nNotice: <i>Some notice</i> in some-file.php on line 40\n"
+				. "\nWarning: <i>Some warning</i> in some-file-&-what.php on line 41\n"
+				. "\nFatal error: <i>Some error</i> in some-file.php on line 42\n",
+			),
+			'error_prepend_string'                      => array(
+				array(
+					'ini' => array(
+						'error_prepend_string' => '<div>',
+						'error_append_string'  => '</div>',
+					),
+				),
+				array(
+					array( E_NOTICE, '<i>Some notice</i>', 'some-file.php', 40, 'wp' ),
+					array( E_ERROR, '<i>Some error</i>', 'some-file.php', 42, 'wp' ),
+				),
+				"<div><br />\n<b>Notice</b>:  &lt;i&gt;Some notice&lt;/i&gt; in <b>some-file.php</b> on line <b>40</b><br />\n</div>"
+				. "<div><br />\n<b>Fatal error</b>:  &lt;i&gt;Some error&lt;/i&gt; in <b>some-file.php</b> on line <b>42</b><br />\n</div>",
+			),
+			'error_prepend_string without html_errors'  => array(
+				array(
+					'ini' => array(
+						'error_prepend_string' => '<div>',
+						'error_append_string'  => '</div>',
+						'html_errors'          => 'off',
+					),
+				),
+				array(
+					array( E_NOTICE, '<i>Some notice</i>', 'some-file.php', 40, 'wp' ),
+					array( E_ERROR, '<i>Some error</i>', 'some-file.php', 42, 'wp' ),
+				),
+				"<div>\nNotice: &lt;i&gt;Some notice&lt;/i&gt; in some-file.php on line 40\n</div>"
+				. "<div>\nFatal error: &lt;i&gt;Some error&lt;/i&gt; in some-file.php on line 42\n</div>",
+			),
+			'error_prepend_string, cli, no html_errors' => array(
+				array(
+					'ini'  => array(
+						'error_prepend_string' => '<div>',
+						'error_append_string'  => '</div>',
+						'html_errors'          => 'off',
+					),
+					'sapi' => 'cli',
+				),
+				array(
+					array( E_NOTICE, '<i>Some notice</i>', 'some-file.php', 40, 'wp' ),
+					array( E_ERROR, '<i>Some error</i>', 'some-file.php', 42, 'wp' ),
+				),
+				"<div>\nNotice: <i>Some notice</i> in some-file.php on line 40\n</div>"
+				. "<div>\nFatal error: <i>Some error</i> in some-file.php on line 42\n</div>",
+			),
+			'error_prepend_string, cli, no html_errors, display to stderr' => array(
+				array(
+					'ini'  => array(
+						'display_errors'       => 'stderr',
+						'error_prepend_string' => '<div>',
+						'error_append_string'  => '</div>',
+						'html_errors'          => 'off',
+						'error_reporting'      => 0,
+					),
+					'sapi' => 'cli',
+				),
+				array(
+					array( E_NOTICE, '<i>Some notice</i>', 'some-file.php', 40, 'wp' ),
+					array( E_ERROR, '<i>Some error</i>', 'some-file.php', 42, 'wp' ),
+				),
+				'',
+			),
+			'null filename'                             => array(
+				array(),
+				array(
+					array( E_NOTICE, '<i>Some notice</i>', '', 40, 'wp' ),
+					array( E_WARNING, '<i>Some warning</i>', null, 41, 'wp' ),
+				),
+				"<br />\n<b>Notice</b>:  &lt;i&gt;Some notice&lt;/i&gt; in <b>Unknown</b> on line <b>40</b><br />\n"
+				. "<br />\n<b>Warning</b>:  &lt;i&gt;Some warning&lt;/i&gt; in <b>Unknown</b> on line <b>41</b><br />\n",
+			),
+			'all error codes'                           => array(
+				array(),
+				array(
+					array( E_ERROR, 'E_ERROR', 'file.php', 1, 'wp' ),
+					array( E_CORE_ERROR, 'E_CORE_ERROR', 'file.php', 1, 'wp' ),
+					array( E_COMPILE_ERROR, 'E_COMPILE_ERROR', 'file.php', 1, 'wp' ),
+					array( E_USER_ERROR, 'E_USER_ERROR', 'file.php', 1, 'wp' ),
+					array( E_RECOVERABLE_ERROR, 'E_RECOVERABLE_ERROR', 'file.php', 1, 'wp' ),
+					array( E_WARNING, 'E_WARNING', 'file.php', 1, 'wp' ),
+					array( E_CORE_WARNING, 'E_CORE_WARNING', 'file.php', 1, 'wp' ),
+					array( E_COMPILE_WARNING, 'E_COMPILE_WARNING', 'file.php', 1, 'wp' ),
+					array( E_USER_WARNING, 'E_USER_WARNING', 'file.php', 1, 'wp' ),
+					array( E_PARSE, 'E_PARSE', 'file.php', 1, 'wp' ),
+					array( E_NOTICE, 'E_NOTICE', 'file.php', 1, 'wp' ),
+					array( E_USER_NOTICE, 'E_USER_NOTICE', 'file.php', 1, 'wp' ),
+					array( E_STRICT, 'E_STRICT', 'file.php', 1, 'wp' ),
+					array( E_DEPRECATED, 'E_DEPRECATED', 'file.php', 1, 'wp' ),
+					array( E_USER_DEPRECATED, 'E_USER_DEPRECATED', 'file.php', 1, 'wp' ),
+					array( -1, 'neg-one', 'file.php', 1, 'wp' ),
+				),
+				"<br />\n<b>Fatal error</b>:  E_ERROR in <b>file.php</b> on line <b>1</b><br />\n"
+				. "<br />\n<b>Fatal error</b>:  E_CORE_ERROR in <b>file.php</b> on line <b>1</b><br />\n"
+				. "<br />\n<b>Fatal error</b>:  E_COMPILE_ERROR in <b>file.php</b> on line <b>1</b><br />\n"
+				. "<br />\n<b>Fatal error</b>:  E_USER_ERROR in <b>file.php</b> on line <b>1</b><br />\n"
+				. "<br />\n<b>Recoverable fatal error</b>:  E_RECOVERABLE_ERROR in <b>file.php</b> on line <b>1</b><br />\n"
+				. "<br />\n<b>Warning</b>:  E_WARNING in <b>file.php</b> on line <b>1</b><br />\n"
+				. "<br />\n<b>Warning</b>:  E_CORE_WARNING in <b>file.php</b> on line <b>1</b><br />\n"
+				. "<br />\n<b>Warning</b>:  E_COMPILE_WARNING in <b>file.php</b> on line <b>1</b><br />\n"
+				. "<br />\n<b>Warning</b>:  E_USER_WARNING in <b>file.php</b> on line <b>1</b><br />\n"
+				. "<br />\n<b>Parse error</b>:  E_PARSE in <b>file.php</b> on line <b>1</b><br />\n"
+				. "<br />\n<b>Notice</b>:  E_NOTICE in <b>file.php</b> on line <b>1</b><br />\n"
+				. "<br />\n<b>Notice</b>:  E_USER_NOTICE in <b>file.php</b> on line <b>1</b><br />\n"
+				. "<br />\n<b>Strict Standards</b>:  E_STRICT in <b>file.php</b> on line <b>1</b><br />\n"
+				. "<br />\n<b>Deprecated</b>:  E_DEPRECATED in <b>file.php</b> on line <b>1</b><br />\n"
+				. "<br />\n<b>Deprecated</b>:  E_USER_DEPRECATED in <b>file.php</b> on line <b>1</b><br />\n"
+				. "<br />\n<b>Unknown error</b>:  neg-one in <b>file.php</b> on line <b>1</b><br />\n",
+			),
+			'xmlrpc_errors'                             => array(
+				array( 'ini' => array( 'xmlrpc_errors' => 'on' ) ),
+				array(
+					array( E_ERROR, '<i>Some error</i>', 'some-&-file.php', 42, 'wp' ),
+				),
+				'<?xml version="1.0"?><methodResponse><fault><value><struct><member><name>faultCode</name><value><int>8675309</int></value></member><member><name>faultString</name><value><string>Fatal error:&lt;i&gt;Some error&lt;/i&gt; in some-&amp;-file.php on line 42</string></value></member></struct></value></fault></methodResponse>',
+			),
+			'ignore_repeated_errors'                    => array(
+				array( 'ini' => array( 'ignore_repeated_errors' => 'on' ) ),
+				array(
+					array( E_ERROR, '<i>Some error</i>', 'some-file.php', 40, 'wp' ),
+					array( E_ERROR, '<i>Some error</i>', 'some-file.php', 40, 'wp' ),
+					array( E_ERROR, '<i>Some error</i>', 'some-file.php', 40, 'wp' ),
+					array( E_ERROR, '<i>Some error</i>', 'some-file.php', 41, 'wp' ),
+					array( E_ERROR, '<i>Some other error</i>', 'some-file.php', 42, 'wp' ),
+				),
+				"<br />\n<b>Fatal error</b>:  &lt;i&gt;Some error&lt;/i&gt; in <b>some-file.php</b> on line <b>40</b><br />\n"
+				. "<br />\n<b>Fatal error</b>:  &lt;i&gt;Some error&lt;/i&gt; in <b>some-file.php</b> on line <b>41</b><br />\n"
+				. "<br />\n<b>Fatal error</b>:  &lt;i&gt;Some other error&lt;/i&gt; in <b>some-file.php</b> on line <b>42</b><br />\n",
+			),
+			'ignore_repeated_source'                    => array(
+				array(
+					'ini' => array(
+						'ignore_repeated_errors' => 'on',
+						'ignore_repeated_source' => 'on',
+					),
+				),
+				array(
+					array( E_ERROR, '<i>Some error</i>', 'some-file.php', 40, 'wp' ),
+					array( E_ERROR, '<i>Some error</i>', 'some-file.php', 40, 'wp' ),
+					array( E_ERROR, '<i>Some error</i>', 'some-file.php', 40, 'wp' ),
+					array( E_ERROR, '<i>Some error</i>', 'some-file.php', 41, 'wp' ),
+					array( E_ERROR, '<i>Some other error</i>', 'some-file.php', 42, 'wp' ),
+				),
+				"<br />\n<b>Fatal error</b>:  &lt;i&gt;Some error&lt;/i&gt; in <b>some-file.php</b> on line <b>40</b><br />\n"
+				. "<br />\n<b>Fatal error</b>:  &lt;i&gt;Some other error&lt;/i&gt; in <b>some-file.php</b> on line <b>42</b><br />\n",
+			),
+		);
+	}
+
+	public function test_wp_error_handler_printer_turn_off() {
+		$this->expectOutputString(
+			"<br />\n<b>Notice</b>:  &lt;i&gt;Some notice&lt;/i&gt; in <b>some-file.php</b> on line <b>40</b><br />\n"
+			. "<br />\n<b>Notice</b>:  &lt;i&gt;Some notice&lt;/i&gt; in <b>some-file.php</b> on line <b>42</b><br />\n"
+			. "<br />\n<b>Notice</b>:  &lt;i&gt;Some notice&lt;/i&gt; in <b>some-file.php</b> on line <b>60</b><br />\n"
+			. "<br />\n<b>Notice</b>:  &lt;i&gt;Some notice&lt;/i&gt; in <b>some-file.php</b> on line <b>62</b><br />\n"
+		);
+		_wp_error_handler_printer( E_NOTICE, '<i>Some notice</i>', 'some-file.php', 40 );
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		@_wp_error_handler_printer( E_NOTICE, '<i>Some notice</i>', 'some-file.php', 41 );
+		_wp_error_handler_printer( E_NOTICE, '<i>Some notice</i>', 'some-file.php', 42 );
+		ini_set( 'display_errors', 'off' );
+		_wp_error_handler_printer( E_NOTICE, '<i>Some notice</i>', 'some-file.php', 50 );
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		@_wp_error_handler_printer( E_NOTICE, '<i>Some notice</i>', 'some-file.php', 51 );
+		_wp_error_handler_printer( E_NOTICE, '<i>Some notice</i>', 'some-file.php', 52 );
+		ini_set( 'display_errors', 'on' );
+		_wp_error_handler_printer( E_NOTICE, '<i>Some notice</i>', 'some-file.php', 60 );
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		@_wp_error_handler_printer( E_NOTICE, '<i>Some notice</i>', 'some-file.php', 61 );
+		_wp_error_handler_printer( E_NOTICE, '<i>Some notice</i>', 'some-file.php', 62 );
+	}
+
+	public function test_wp_error_handler_no_chaining() {
+		global $_wp_error_handling_previous_error_handler;
+
+		$this->expectOutputString( "<br />\n<b>Notice</b>:  &lt;i&gt;Some notice&lt;/i&gt; in <b>some-file.php</b> on line <b>40</b><br />\n" );
+
+		$_wp_error_handling_previous_error_handler = null;
+		$this->assertFalse( wp_error_handler( E_NOTICE, '<i>Some notice</i>', 'some-file.php', 40 ) );
+	}
+
+	public function test_wp_error_handler_chaining() {
+		global $_wp_error_handling_previous_error_handler;
+
+		$this->expectOutputString( "<br />\n<b>Notice</b>:  &lt;i&gt;Some notice&lt;/i&gt; in <b>some-file.php</b> on line <b>40</b><br />\n" );
+
+		$was_called                                = array();
+		$_wp_error_handling_previous_error_handler = function () use ( &$was_called ) {
+			$was_called[] = func_get_args();
+			return 'ok';
+		};
+		$this->assertSame( 'ok', wp_error_handler( E_NOTICE, '<i>Some notice</i>', 'some-file.php', 40 ) );
+		$this->assertSame( array( array( E_NOTICE, '<i>Some notice</i>', 'some-file.php', 40 ) ), $was_called );
+	}
+
+	public function test_wp_exception_handler_no_chaining() {
+		global $_wp_error_handling_previous_error_handler, $_wp_error_handling_previous_exception_handler;
+
+		$ex   = new \Exception( '<i>Some exception</i>' );
+		$str  = htmlspecialchars( $ex->__toString(), ENT_QUOTES | ENT_HTML401 );
+		$file = htmlspecialchars( $ex->getFile(), ENT_QUOTES | ENT_HTML401 );
+		$this->expectOutputString( "<br />\n<b>Fatal error</b>:  Uncaught $str\n  thrown in <b>$file</b> on line <b>{$ex->getLine()}</b><br />\n" );
+
+		$_wp_error_handling_previous_error_handler = function () {
+			$this->fail( '_wp_error_handling_previous_error_handler should not have been called' );
+		};
+
+		$_wp_error_handling_previous_exception_handler = null;
+
+		try {
+			wp_exception_handler( $ex );
+			$this->fail( 'Expected exception to be thrown' );
+		} catch ( \Throwable $t ) {
+			$this->assertSame( $ex, $t );
+		}
+	}
+
+	public function test_wp_exception_handler_chaining() {
+		global $_wp_error_handling_previous_error_handler, $_wp_error_handling_previous_exception_handler;
+
+		$ex   = new \Exception( '<i>Some exception</i>' );
+		$str  = htmlspecialchars( $ex->__toString(), ENT_QUOTES | ENT_HTML401 );
+		$file = htmlspecialchars( $ex->getFile(), ENT_QUOTES | ENT_HTML401 );
+		$this->expectOutputString( "<br />\n<b>Fatal error</b>:  Uncaught $str\n  thrown in <b>$file</b> on line <b>{$ex->getLine()}</b><br />\n" );
+
+		$_wp_error_handling_previous_error_handler = function () use ( &$error_handler_was_called ) {
+			$this->fail( '_wp_error_handling_previous_error_handler should not have been called' );
+		};
+
+		$was_called                                    = array();
+		$_wp_error_handling_previous_exception_handler = function () use ( &$was_called ) {
+			$was_called[] = func_get_args();
+		};
+
+		wp_exception_handler( $ex );
+
+		$this->assertSame( array( array( $ex ) ), $was_called );
+	}
+
+	public function test_wp_exception_handler_bad_tostring() {
+		global $_wp_error_handling_previous_exception_handler;
+
+		$ex = new class ( '<i>Some exception</i>' ) extends \Exception {
+			public function __toString() {
+				throw new \Exception( 'Error in __toString()' );
+			}
+		};
+		$this->expectOutputString( '' );
+
+		$was_called                                    = array();
+		$_wp_error_handling_previous_exception_handler = function () use ( &$was_called ) {
+			$was_called[] = func_get_args();
+		};
+
+		wp_exception_handler( $ex );
+
+		$this->assertSame( array( array( $ex ) ), $was_called );
+	}
+}

--- a/tests/phpunit/tests/wp-error-handling.php
+++ b/tests/phpunit/tests/wp-error-handling.php
@@ -454,7 +454,7 @@ class Tests_WP_Error_Handling extends \WP_UnitTestCase {
 	public function test_wp_exception_handler_bad_tostring() {
 		global $_wp_error_handling_previous_exception_handler;
 
-		$ex = new class ( '<i>Some exception</i>' ) extends \Exception {
+		$ex = new class( '<i>Some exception</i>' ) extends \Exception {
 			public function __toString() {
 				throw new \Exception( 'Error in __toString()' );
 			}

--- a/tests/phpunit/tests/wp-error-handling.php
+++ b/tests/phpunit/tests/wp-error-handling.php
@@ -151,7 +151,7 @@ class Tests_WP_Error_Handling extends \WP_UnitTestCase {
 	}
 
 	public function data_wp_error_handler_printer() {
-		return array(
+		$tests = array(
 			'display_errors off'                        => array(
 				array( 'ini' => array( 'display_errors' => 'off' ) ),
 				array(
@@ -299,7 +299,6 @@ class Tests_WP_Error_Handling extends \WP_UnitTestCase {
 					array( E_PARSE, 'E_PARSE', 'file.php', 1, 'wp' ),
 					array( E_NOTICE, 'E_NOTICE', 'file.php', 1, 'wp' ),
 					array( E_USER_NOTICE, 'E_USER_NOTICE', 'file.php', 1, 'wp' ),
-					array( E_STRICT, 'E_STRICT', 'file.php', 1, 'wp' ),
 					array( E_DEPRECATED, 'E_DEPRECATED', 'file.php', 1, 'wp' ),
 					array( E_USER_DEPRECATED, 'E_USER_DEPRECATED', 'file.php', 1, 'wp' ),
 					array( -1, 'neg-one', 'file.php', 1, 'wp' ),
@@ -316,7 +315,6 @@ class Tests_WP_Error_Handling extends \WP_UnitTestCase {
 				. "<br />\n<b>Parse error</b>:  E_PARSE in <b>file.php</b> on line <b>1</b><br />\n"
 				. "<br />\n<b>Notice</b>:  E_NOTICE in <b>file.php</b> on line <b>1</b><br />\n"
 				. "<br />\n<b>Notice</b>:  E_USER_NOTICE in <b>file.php</b> on line <b>1</b><br />\n"
-				. "<br />\n<b>Strict Standards</b>:  E_STRICT in <b>file.php</b> on line <b>1</b><br />\n"
 				. "<br />\n<b>Deprecated</b>:  E_DEPRECATED in <b>file.php</b> on line <b>1</b><br />\n"
 				. "<br />\n<b>Deprecated</b>:  E_USER_DEPRECATED in <b>file.php</b> on line <b>1</b><br />\n"
 				. "<br />\n<b>Unknown error</b>:  neg-one in <b>file.php</b> on line <b>1</b><br />\n",
@@ -359,6 +357,20 @@ class Tests_WP_Error_Handling extends \WP_UnitTestCase {
 				. "<br />\n<b>Fatal error</b>:  &lt;i&gt;Some other error&lt;/i&gt; in <b>some-file.php</b> on line <b>42</b><br />\n",
 			),
 		);
+
+		if ( defined( 'E_STRICT' ) ) {
+			$tests['Deprecated error code E_STRICT'] = array(
+				// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Avoid warnings for constant deprecated in 8.4, while still supporting it for earlier versions.
+				array( 'ini' => array( 'error_reporting' => E_ALL | @E_STRICT ) ),
+				array(
+					// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Avoid warnings for constant deprecated in 8.4, while still supporting it for earlier versions.
+					array( @E_STRICT, 'E_STRICT', 'file.php', 1, 'wp' ),
+				),
+				"<br />\n<b>Strict Standards</b>:  E_STRICT in <b>file.php</b> on line <b>1</b><br />\n",
+			);
+		}
+
+		return $tests;
 	}
 
 	public function test_wp_error_handler_printer_turn_off() {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

WordPress relies on PHP's `display_errors` setting for error reporting. One unfortunate result of that is that errors containing HTML may be served to the browser unescaped.

WordPress/WordPress-Coding-Standards tries to help avoid this by having a sniff (WordPress.Security.EscapeOutput) that, among other things, asks that strings passed to `trigger_error()` and `throw new SomeClass()` be escaped. This is not a very good solution for a few reasons:

* It doesn't do anything about errors or exceptions thrown by PHP itself.
* It doesn't do anything about errors or exceptions thrown by libraries that might be bundled into themes or plugins or any custom code blog authors might inject.
* It means that text-based log files, non-HTML emails, CLI output, and the like will contain HTML entities.

Instead we should follow the principle that values should be escaped close to the point of output, when we know what kind of escaping will be needed. Which, in the context of PHP, means using `set_error_handler()` and `set_exception_handler()` to handle the outputting.

But WordPress also relies on various other things that PHP's default handlers do, not all of which we can duplicate. But on the plus side since `display_errors` is not exactly a boolean (and PHP doesn't care anyway) we can have the handlers themselves set `display_errors` to a sentinel value that PHP will interpret as "off", do any necessary output, and then hand off to PHP's default handlers to do everything else.

Trac ticket: https://core.trac.wordpress.org/ticket/59282

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
