### PR TITLE
Fix auto-draft post permalink structure

### DIFF
--- a/src/wp-admin/includes/post.php
+++ b/src/wp-admin/includes/post.php
@@ -1463,7 +1463,7 @@ function get_sample_permalink( $post, $title = null, $name = null ) {
 	$original_filter = $post->filter;
 
 	// Hack: get_permalink() would return plain permalink for drafts, so we will fake that our post is published.
-	if ( in_array( $post->post_status, array( 'draft', 'pending', 'future' ), true ) ) {
+	if ( in_array( $post->post_status, array( 'auto-draft', 'draft', 'pending', 'future' ), true ) ) {
 		$post->post_status = 'publish';
 		$post->post_name   = sanitize_title( $post->post_name ? $post->post_name : $post->post_title, $post->ID );
 	}

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -1219,7 +1219,7 @@ function get_post_mime_type( $post = null ) {
  * @return string|false Post status on success, false on failure.
  */
 function get_post_status( $post = null ) {
-	if ( is_object( $post ) && isset( $post->filter ) && 'sample' === $post->filter ) {
+	if ( $post instanceof WP_Post && isset( $post->filter ) && 'sample' === $post->filter ) {
 		// Skip normalization
 	} else {
 		$post = get_post( $post );

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -1219,7 +1219,9 @@ function get_post_mime_type( $post = null ) {
  * @return string|false Post status on success, false on failure.
  */
 function get_post_status( $post = null ) {
-	$post = get_post( $post );
+	if ( ! is_object( $post ) ) {
+		$post = get_post( $post );
+	}
 
 	if ( ! is_object( $post ) ) {
 		return false;

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -1219,8 +1219,11 @@ function get_post_mime_type( $post = null ) {
  * @return string|false Post status on success, false on failure.
  */
 function get_post_status( $post = null ) {
-	if ( ! is_object( $post ) ) {
-		$post = get_post( $post );
+	if ( is_object( $post ) && isset( $post->filter ) && 'sample' === $post->filter ) {
+		$sample = true;
+	} else {
+		$post   = get_post( $post );
+		$sample = false;
 	}
 
 	if ( ! is_object( $post ) ) {

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -1220,10 +1220,9 @@ function get_post_mime_type( $post = null ) {
  */
 function get_post_status( $post = null ) {
 	if ( is_object( $post ) && isset( $post->filter ) && 'sample' === $post->filter ) {
-		$sample = true;
+		// Skip normalization
 	} else {
-		$post   = get_post( $post );
-		$sample = false;
+		$post = get_post( $post );
 	}
 
 	if ( ! is_object( $post ) ) {

--- a/tests/phpunit/tests/admin/includesPost.php
+++ b/tests/phpunit/tests/admin/includesPost.php
@@ -932,6 +932,28 @@ class Tests_Admin_IncludesPost extends WP_UnitTestCase {
 		$this->assertEquals( $post_original, $post, 'get_sample_permalink() modifies the post object.' );
 	}
 
+	/**
+	 * @ticket 59283
+	 */
+	public function test_get_sample_permalink_should_return_pretty_permalink_for_posts_with_post_status_auto_draft() {
+		$permalink_structure = '%postname%';
+		$this->set_permalink_structure( "/$permalink_structure/" );
+
+		$future_date = gmdate( 'Y-m-d H:i:s', time() + 100 );
+		$p           = self::factory()->post->create(
+			array(
+				'post_status' => 'auto-draft',
+				'post_name'   => 'foo',
+				'post_date'   => $future_date,
+			)
+		);
+
+		$found    = get_sample_permalink( $p );
+		$expected = trailingslashit( home_url( $permalink_structure ) );
+
+		$this->assertSame( $expected, $found[0] );
+	}
+
 	public function test_post_exists_should_match_title() {
 		$p = self::factory()->post->create(
 			array(


### PR DESCRIPTION
When loading the post editor the `permalink_template` property is not set properly on the post object (REST API) (it uses the plain post permalink instead of the pretty permalink). This causes the editor to not offer a way to edit the slug before actually saving the post which results in the permalink_template being set properly.

I tracked this down to `get_sample_permalink` and `get_permalink` return the plain permalink structure for auto-draft posts.

I'm not entirely certain about this fix as it's a bit low level, would appreciate a review from folks familiar with this.

Trac ticket: https://core.trac.wordpress.org/ticket/59283

