### PR TITLE
HTML API: Expose raw tag markup to support existing filters

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -712,6 +712,41 @@ class WP_HTML_Tag_Processor {
 
 
 	/**
+	 * Allow internal WordPress code to extract raw HTML snippets associated with a matched tag.
+	 *
+	 * This is meant for internal use to support existing filters that pass segments of input HTML
+	 * for further analysis. Filters which rely on these values should be updated to interact with
+	 * the structural methods this class provides.
+	 *
+	 * @access private
+	 *
+	 * @since 6.4.0
+	 *
+	 * @param string $internal_use_only Required to accept liability for exposing system internals through this function.
+	 * @param string $content           What portion of the raw HTML markup to return: 'entire-tag' or 'only-attributes'.
+	 * @return string|null Raw HTML markup from input document for matched tag, if matched, else NULL.
+	 */
+	public function _wp_internal_extract_raw_token_markup( $internal_use_only, $contents = 'entire-tag' ) {
+		$disclaimer = <<<INTERNAL_ONLY
+			I understand that this is only for internal WordPress usage and something
+			will likely break if used elsewhere. This function comes with no warranty.
+INTERNAL_ONLY;
+
+		if ( $internal_use_only !== $disclaimer || null === $this->tag_name_starts_at ) {
+			return null;
+		}
+
+		switch ( $contents ) {
+			case 'entire-tag':
+				return substr( $this->html, $this->tag_name_starts_at - 1, $this->tag_ends_at - $this->tag_name_starts_at + 2 );
+
+			case 'only-attributes':
+				return substr( $this->html, $this->tag_name_starts_at + $this->tag_name_length + 1, $this->tag_ends_at - $this->tag_name_starts_at - $this->tag_name_length - 1 );
+		}
+	}
+
+
+	/**
 	 * Skips contents of title and textarea tags.
 	 *
 	 * @since 6.2.0

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor-internals.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor-internals.php
@@ -32,7 +32,8 @@ class Tests_HtmlApi_WpHtmlTagProcessor_Internals extends WP_UnitTestCase {
 				<<<INTERNAL_ONLY
 			I understand that this is only for internal WordPress usage and something
 			will likely break if used elsewhere. This function comes with no warranty.
-INTERNAL_ONLY,
+INTERNAL_ONLY
+				,
 				'entire-tag'
 			),
 			'Failed to exactly extract raw HTML for matched tag.'
@@ -76,7 +77,8 @@ INTERNAL_ONLY,
 				<<<INTERNAL_ONLY
 			I understand that this is only for internal WordPress usage and something
 			will likely break if used elsewhere. This function comes with no warranty.
-INTERNAL_ONLY,
+INTERNAL_ONLY
+				,
 				'only-attributes'
 			),
 			'Failed to exactly extract raw HTML for matched tag.'

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor-internals.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor-internals.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Unit tests covering WP_HTML_Tag_Processor internal helpers.
+ *
+ * @package WordPress
+ * @subpackage HTML-API
+ */
+
+/**
+ * @group html-api
+ *
+ * @coversDefaultClass WP_HTML_Tag_Processor
+ */
+class Tests_HtmlApi_WpHtmlTagProcessor_Internals extends WP_UnitTestCase {
+	/**
+	 * @ticket {TICKET NUMBER}
+	 *
+	 * @dataProvider data_html_with_entire_tag_raw_markup
+	 *
+	 * @param string $html_with_target_element HTML with a tag containing "target" attribute.
+	 * @param string $expected_raw_markup      Expect full raw markup for targeted tag.
+	 */
+	public function test_returns_raw_html_markup_for_entire_tag( $html_with_target_element, $expected_raw_markup ) {
+		$processor = new WP_HTML_Tag_Processor( $html_with_target_element );
+		while ( $processor->next_tag() && null == $processor->get_attribute( 'target' ) ) {
+			continue;
+		}
+
+		$this->assertSame(
+			$expected_raw_markup,
+			$processor->_wp_internal_extract_raw_token_markup(
+				<<<INTERNAL_ONLY
+			I understand that this is only for internal WordPress usage and something
+			will likely break if used elsewhere. This function comes with no warranty.
+INTERNAL_ONLY,
+				'entire-tag'
+			),
+			'Failed to exactly extract raw HTML for matched tag.'
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[].
+	 */
+	public function data_html_with_entire_tag_raw_markup() {
+		return array(
+			'Tag at start of string'          => array( '<img target src="atat.png">', '<img target src="atat.png">' ),
+			'Tag in middle of string'         => array( '<a href="#"><img target src="atat.png"></a>', '<img target src="atat.png">' ),
+			'Tag at end of string'            => array( '<a href="#"><img src="atat.png"><div id="5" target class="dingy">', '<div id="5" target class="dingy">' ),
+			'Tab after tag name'              => array( "<img\ttarget>", "<img\ttarget>" ),
+			'Space after attributes'          => array( '<img target    >', '<img target    >' ),
+			'Unquoted attribute'              => array( '<span id = 5 class=sunshine target>', '<span id = 5 class=sunshine target>' ),
+			'Value with character references' => array( '<a href="#" title="This is &gt; That" target>', '<a href="#" title="This is &gt; That" target>' ),
+		);
+	}
+
+	/**
+	 * @ticket {TICKET NUMBER}
+	 *
+	 * @dataProvider data_html_with_only_attributes_raw_markup
+	 *
+	 * @param string $html_with_target_element HTML with a tag containing "target" attribute.
+	 * @param string $expected_raw_markup      Expect raw markup for targeted tag containing only the attributes.
+	 */
+	public function test_returns_raw_html_markup_for_only_attributes( $html_with_target_element, $expected_raw_markup ) {
+		$processor = new WP_HTML_Tag_Processor( $html_with_target_element );
+		while ( $processor->next_tag() && null == $processor->get_attribute( 'target' ) ) {
+			continue;
+		}
+
+		$this->assertSame(
+			$expected_raw_markup,
+			$processor->_wp_internal_extract_raw_token_markup(
+				<<<INTERNAL_ONLY
+			I understand that this is only for internal WordPress usage and something
+			will likely break if used elsewhere. This function comes with no warranty.
+INTERNAL_ONLY,
+				'only-attributes'
+			),
+			'Failed to exactly extract raw HTML for matched tag.'
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[].
+	 */
+	public function data_html_with_only_attributes_raw_markup() {
+		return array(
+			'Tag at start of string'          => array( '<img target src="atat.png">', 'target src="atat.png"' ),
+			'Tag in middle of string'         => array( '<a href="#"><img target src="atat.png"></a>', 'target src="atat.png"' ),
+			'Tag at end of string'            => array( '<a href="#"><img src="atat.png"><div id="5" target class="dingy">', 'id="5" target class="dingy"' ),
+			'Tab after tag name'              => array( "<img\ttarget>", "target" ),
+			'Space after attributes'          => array( '<img target    >', 'target    ' ),
+			'Unquoted attribute'              => array( '<span id = 5 class=sunshine target>', 'id = 5 class=sunshine target' ),
+			'Value with character references' => array( '<a href="#" title="This is &gt; That" target>', 'href="#" title="This is &gt; That" target' ),
+		);
+	}
+}

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor-internals.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor-internals.php
@@ -13,16 +13,16 @@
  */
 class Tests_HtmlApi_WpHtmlTagProcessor_Internals extends WP_UnitTestCase {
 	/**
-	 * @ticket {TICKET NUMBER}
+	 * @ticket 59291
 	 *
 	 * @dataProvider data_html_with_entire_tag_raw_markup
 	 *
 	 * @param string $html_with_target_element HTML with a tag containing "target" attribute.
-	 * @param string $expected_raw_markup      Expect full raw markup for targeted tag.
+	 * @param string $expected_raw_markup      Expected full raw markup for targeted tag.
 	 */
 	public function test_returns_raw_html_markup_for_entire_tag( $html_with_target_element, $expected_raw_markup ) {
 		$processor = new WP_HTML_Tag_Processor( $html_with_target_element );
-		while ( $processor->next_tag() && null == $processor->get_attribute( 'target' ) ) {
+		while ( $processor->next_tag() && null === $processor->get_attribute( 'target' ) ) {
 			continue;
 		}
 
@@ -58,16 +58,16 @@ INTERNAL_ONLY
 	}
 
 	/**
-	 * @ticket {TICKET NUMBER}
+	 * @ticket 59291
 	 *
 	 * @dataProvider data_html_with_only_attributes_raw_markup
 	 *
 	 * @param string $html_with_target_element HTML with a tag containing "target" attribute.
-	 * @param string $expected_raw_markup      Expect raw markup for targeted tag containing only the attributes.
+	 * @param string $expected_raw_markup      Expected raw markup for targeted tag containing only the attributes.
 	 */
 	public function test_returns_raw_html_markup_for_only_attributes( $html_with_target_element, $expected_raw_markup ) {
 		$processor = new WP_HTML_Tag_Processor( $html_with_target_element );
-		while ( $processor->next_tag() && null == $processor->get_attribute( 'target' ) ) {
+		while ( $processor->next_tag() && null === $processor->get_attribute( 'target' ) ) {
 			continue;
 		}
 

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor-internals.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor-internals.php
@@ -95,7 +95,7 @@ INTERNAL_ONLY
 			'Tag at start of string'          => array( '<img target src="atat.png">', 'target src="atat.png"' ),
 			'Tag in middle of string'         => array( '<a href="#"><img target src="atat.png"></a>', 'target src="atat.png"' ),
 			'Tag at end of string'            => array( '<a href="#"><img src="atat.png"><div id="5" target class="dingy">', 'id="5" target class="dingy"' ),
-			'Tab after tag name'              => array( "<img\ttarget>", "target" ),
+			'Tab after tag name'              => array( "<img\ttarget>", 'target' ),
 			'Space after attributes'          => array( '<img target    >', 'target    ' ),
 			'Unquoted attribute'              => array( '<span id = 5 class=sunshine target>', 'id = 5 class=sunshine target' ),
 			'Value with character references' => array( '<a href="#" title="This is &gt; That" target>', 'href="#" title="This is &gt; That" target' ),


### PR DESCRIPTION
Trac ticket: [#59291-trac](https://core.trac.wordpress.org/ticket/59291#ticket)

## Current status:

Probably this will never merge and never should merge. It's an exploration of one way to preserve backwards compatability.

## Summary

Many existing filters in Core pass segments of the raw HTML markup for matched tags where code implementing those hooks perform futher analyis on those segments. The HTML API attempts to hide the raw inner markup as much as possible, making it hard to provide full backwards compatability with these existing filters.

In this patch a new function is added which extracts the raw markup to maintain those existing behaviors. It requires a disclaimer to operate to try and encourage folks to use the structural and semantic methods provided by the HTML API.

Where possible, existing code and filters should be updated so that they no longer depend on the raw HTML.

## To Consider

We could canonicalize the output here using the HTML5 serialization algorithm. This implies writing all attributes as double-quoted strings with proper escaping. Whitespace between attributes and the tag name should be normalized. Characters are properly escaped and quoted. This is already trivial to reconstruct through the existing methods, but incurs a runtime cost.

In this patch I've opted to propose a RAW method to avoid that cost, particularly since this is designed to be used in places in Core that are running frequently and on all data (kses, formatting, etc…). Using the raw contents risks leaving "broken" markup broken, leaving existing breakages in place, but should not break existing code relying on those breakages.

If, on the other hand, we normalize the HTML, we could potentially close existing bugs that fail because of the typical kind of parsing failures, regexps looking for double-quoted attributes, etc…

We can introduce another function to generate the normalized output, but I am hesitant to make things look too easy and accidentally encourage people to work around the semantic methods in the HTML API in favor of "easier" regexp parsing.