### PR TITLE
Add wp_trigger_error() and tests

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -6040,6 +6040,55 @@ function _doing_it_wrong( $function_name, $message, $version ) {
 }
 
 /**
+ * Generates a user-level error/warning/notice/deprecation message.
+ *
+ * Generates the message when `WP_DEBUG` is true.
+ *
+ * @since 6.4.0
+ *
+ * @param string $function_name The function that triggered the error.
+ * @param string $message       The message explaining the error.
+ * @param int    $error_level   Optional. The designated error type for this error.
+ *                              Only works with E_USER family of constants. Default E_USER_NOTICE.
+ */
+function wp_trigger_error( $function_name, $message, $error_level = E_USER_NOTICE ) {
+
+	// Bail out if WP_DEBUG is not turned on.
+	if ( ! WP_DEBUG ) {
+		return;
+	}
+
+	// If invalid, set the error level to the default.
+	if (
+			E_USER_ERROR !== $error_level &&
+			E_USER_WARNING !== $error_level &&
+			E_USER_NOTICE !== $error_level &&
+			E_USER_DEPRECATED !== $error_level
+	) {
+		$error_level = E_USER_NOTICE;
+	}
+
+	/**
+	 * Fires when the given function triggers a user-level error/warning/notice/deprecation message.
+	 *
+	 * Can be used for debug backtracking.
+	 *
+	 * @since 6.4.0
+	 *
+	 * @param string $function_name The function that was called.
+	 * @param string $message       A message explaining what has been done incorrectly.
+	 * @param int    $error_level   The designated error type for this error.
+	 */
+	do_action( 'wp_trigger_error_run', $function_name, $message, $error_level );
+
+	if ( ! empty( $function_name ) ) {
+		$message = sprintf( '%s(): %s', $function_name, $message );
+	}
+
+	trigger_error( $message, $error_level );
+}
+
+/**
  * Determines whether the server is running an earlier than 1.5.0 version of lighttpd.
  *
  * @since 2.5.0

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -6075,6 +6075,13 @@ function wp_trigger_error( $function_name, $message, $error_level = E_USER_NOTIC
 		$message = sprintf( '%s(): %s', $function_name, $message );
 	}
 
+	/*
+	 * If the message appears in the browser, then it needs to be escaped.
+	 * Note the warning in the `trigger_error()` PHP manual.
+	 * @link https://www.php.net/manual/en/function.trigger-error.php
+	 */
+	$message = esc_html( $message );
+
 	trigger_error( $message, $error_level );
 }
 

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -6058,16 +6058,6 @@ function wp_trigger_error( $function_name, $message, $error_level = E_USER_NOTIC
 		return;
 	}
 
-	// If invalid, set the error level to the default.
-	if (
-			E_USER_ERROR !== $error_level &&
-			E_USER_WARNING !== $error_level &&
-			E_USER_NOTICE !== $error_level &&
-			E_USER_DEPRECATED !== $error_level
-	) {
-		$error_level = E_USER_NOTICE;
-	}
-
 	/**
 	 * Fires when the given function triggers a user-level error/warning/notice/deprecation message.
 	 *

--- a/tests/phpunit/tests/functions/wpTriggerError.php
+++ b/tests/phpunit/tests/functions/wpTriggerError.php
@@ -3,8 +3,6 @@
 /**
  * Test cases for the `wp_trigger_error()` function.
  *
- * @package WordPress\UnitTests
- *
  * @since 6.4.0
  *
  * @group functions.php
@@ -13,6 +11,8 @@
 class Tests_Functions_WpTriggerError extends WP_UnitTestCase {
 
 	/**
+	 * @ticket 57686
+	 *
 	 * @dataProvider data_should_trigger_error
 	 *
 	 * @param string $function_name    The function name to test.
@@ -27,6 +27,8 @@ class Tests_Functions_WpTriggerError extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 57686
+	 *
 	 * @dataProvider data_should_trigger_error
 	 *
 	 * @param string $function_name    The function name to test.
@@ -41,6 +43,8 @@ class Tests_Functions_WpTriggerError extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 57686
+	 *
 	 * @dataProvider data_should_trigger_error
 	 *
 	 * @param string $function_name    The function name to test.
@@ -55,6 +59,8 @@ class Tests_Functions_WpTriggerError extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 57686
+	 *
 	 * @dataProvider data_should_trigger_error
 	 *
 	 * @param string $function_name    The function name to test.
@@ -94,6 +100,8 @@ class Tests_Functions_WpTriggerError extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 57686
+	 *
 	 * @dataProvider data_should_use_default_error_level_when_invalid
 	 *
 	 * @param mixed $error_level Invalid error level to test.

--- a/tests/phpunit/tests/functions/wpTriggerError.php
+++ b/tests/phpunit/tests/functions/wpTriggerError.php
@@ -1,0 +1,129 @@
+<?php
+
+/**
+ * Test cases for the `wp_trigger_error()` function.
+ *
+ * @package WordPress\UnitTests
+ *
+ * @since 6.4.0
+ *
+ * @group functions.php
+ * @covers ::wp_trigger_error
+ */
+class Tests_Functions_WpTriggerError extends WP_UnitTestCase {
+
+	/**
+	 * @dataProvider data_should_trigger_error
+	 *
+	 * @param string $function_name    The function name to test.
+	 * @param string $message          The message to test.
+	 * @param string $expected_message The expected error message.
+	 */
+	public function test_should_trigger_error( $function_name, $message, $expected_message ) {
+		$this->expectError();
+		$this->expectErrorMessage( $expected_message );
+
+		wp_trigger_error( $function_name, $message, E_USER_ERROR );
+	}
+
+	/**
+	 * @dataProvider data_should_trigger_error
+	 *
+	 * @param string $function_name    The function name to test.
+	 * @param string $message          The message to test.
+	 * @param string $expected_message The expected error message.
+	 */
+	public function test_should_trigger_warning( $function_name, $message, $expected_message ) {
+		$this->expectWarning();
+		$this->expectWarningMessage( $expected_message );
+
+		wp_trigger_error( $function_name, $message, E_USER_WARNING );
+	}
+
+	/**
+	 * @dataProvider data_should_trigger_error
+	 *
+	 * @param string $function_name    The function name to test.
+	 * @param string $message          The message to test.
+	 * @param string $expected_message The expected error message.
+	 */
+	public function test_should_trigger_notice( $function_name, $message, $expected_message ) {
+		$this->expectNotice();
+		$this->expectNoticeMessage( $expected_message );
+
+		wp_trigger_error( $function_name, $message );
+	}
+
+	/**
+	 * @dataProvider data_should_trigger_error
+	 *
+	 * @param string $function_name    The function name to test.
+	 * @param string $message          The message to test.
+	 * @param string $expected_message The expected error message.
+	 */
+	public function test_should_trigger_deprecation( $function_name, $message, $expected_message ) {
+		$this->expectDeprecation();
+		$this->expectDeprecationMessage( $expected_message );
+
+		wp_trigger_error( $function_name, $message, E_USER_DEPRECATED );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_should_trigger_error() {
+		return array(
+			'function name and message are given' => array(
+				'function_name'    => 'some_function',
+				'message'          => 'expected the function name and message',
+				'expected_message' => 'some_function(): expected the function name and message',
+			),
+			'message is given'                    => array(
+				'function_name'    => '',
+				'message'          => 'expect only the message',
+				'expected_message' => 'expect only the message',
+			),
+			'function name is given'              => array(
+				'function_name'    => 'some_function',
+				'message'          => '',
+				'expected_message' => 'some_function(): ',
+			),
+		);
+	}
+
+	/**
+	 * @dataProvider data_should_use_default_error_level_when_invalid
+	 *
+	 * @param mixed $error_level Invalid error level to test.
+	 */
+	public function test_should_use_default_error_level_when_invalid( $error_level ) {
+		$message          = 'Should use E_USER_NOTICE when given invalid error level';
+		$expected_message = sprintf(
+			'%s(): %s',
+			__METHOD__,
+			$message
+		);
+
+		$this->expectNotice();
+		$this->expectNoticeMessage( $expected_message );
+
+		wp_trigger_error( __METHOD__, $message, $error_level );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_should_use_default_error_level_when_invalid() {
+		return array(
+			'E_WARNING'           => array( E_WARNING ),
+			'E_PARSE'             => array( E_PARSE ),
+			'E_NOTICE'            => array( E_NOTICE ),
+			'E_DEPRECATED'        => array( E_DEPRECATED ),
+			'string E_USER_ERROR' => array( 'E_USER_ERROR' ),
+		);
+	}
+}

--- a/tests/phpunit/tests/functions/wpTriggerError.php
+++ b/tests/phpunit/tests/functions/wpTriggerError.php
@@ -98,40 +98,4 @@ class Tests_Functions_WpTriggerError extends WP_UnitTestCase {
 			),
 		);
 	}
-
-	/**
-	 * @ticket 57686
-	 *
-	 * @dataProvider data_should_use_default_error_level_when_invalid
-	 *
-	 * @param mixed $error_level Invalid error level to test.
-	 */
-	public function test_should_use_default_error_level_when_invalid( $error_level ) {
-		$message          = 'Should use E_USER_NOTICE when given invalid error level';
-		$expected_message = sprintf(
-			'%s(): %s',
-			__METHOD__,
-			$message
-		);
-
-		$this->expectNotice();
-		$this->expectNoticeMessage( $expected_message );
-
-		wp_trigger_error( __METHOD__, $message, $error_level );
-	}
-
-	/**
-	 * Data provider.
-	 *
-	 * @return array
-	 */
-	public function data_should_use_default_error_level_when_invalid() {
-		return array(
-			'E_WARNING'           => array( E_WARNING ),
-			'E_PARSE'             => array( E_PARSE ),
-			'E_NOTICE'            => array( E_NOTICE ),
-			'E_DEPRECATED'        => array( E_DEPRECATED ),
-			'string E_USER_ERROR' => array( 'E_USER_ERROR' ),
-		);
-	}
 }


### PR DESCRIPTION
Introduces `wp_trigger_error()` as a _wrapper_ around PHP's native `trigger_error()`. 

As a wrapper, it's lean and not opinionated about the message.

## The What

* Does not trigger the error if `WP_DEBUG` is not `true`.

* Includes `wp_trigger_error_run` action to allow hooking in for backtracing and deeper debug.

`_doing_it_wrong()` includes a similar action.

* Pass the function name.
Currently the function name is passed to it, similar to `_doing_it_wrong()`. The function's name is added to the start of the message to tie the function to the message.

The function name could be computed from:
```php
$stack = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 2 );
```

But then I wondered: 

Are there use cases where the developer does not want the function name put into the message, but rather would like to construct the message themselves?

Or are there use cases where the developer does not want the function name at all in the message?

For both of these cases, the developer can pass an empty string for the `$function_name` parameter.

* No WordPress version is passed to it.

Unlike `_doing_it_wrong()`, this new function is a wrapper to only trigger the error when in `WP_DEBUG` mode. Where `_doing_it_wrong()` intends to loudly alert developers "Hey you're doing it wrong - fix it", `wp_trigger_error()` is not opinionated and does not add wording. Rather, it passes the given message to `trigger_error()`.

>but "milder" messaging

Let the messaging come from the calling code, i.e. at the point in the call stack where the error/warning/notice/deprecation happens. Keep it simple.

References:
* PHP native `trigger_error()` https://www.php.net/manual/en/function.trigger-error.php
* Error constants are found here https://www.php.net/manual/en/errorfunc.constants.php

Trac ticket: https://core.trac.wordpress.org/ticket/57686

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
