### PR TITLE
HTML API: Skip over contents of RAWTEXT elements such as STYLE.

### DIFF
--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -1872,6 +1872,43 @@ HTML;
 	}
 
 	/**
+	 * @ticket 59292
+	 *
+	 * @covers WP_HTML_Tag_Processor::next_tag
+	 *
+	 * @dataProvider data_next_tag_ignores_contents_of_rawtext_tags
+	 *
+	 * @param string $rawtext_element_then_target_node HTML starting with a RAWTEXT-specifying element such as STYLE,
+	 *                                                 then an element afterward containing the "target" attribute.
+	 */
+	public function test_next_tag_ignores_contents_of_rawtext_tags( $rawtext_element_then_target_node ) {
+		$processor = new WP_HTML_Tag_Processor( $rawtext_element_then_target_node );
+		$processor->next_tag();
+
+		$processor->next_tag();
+		$this->assertNotNull(
+			$processor->get_attribute( 'target' ),
+			"Expected to find element with target attribute but found {$processor->get_tag()} instead."
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[].
+	 */
+	public function data_next_tag_ignores_contents_of_rawtext_tags() {
+		return array(
+			'IFRAME'           => array( '<iframe><section>Inside</section></iframe><section target>' ),
+			'NOEMBED'          => array( '<noembed><p></p></noembed><div target>' ),
+			'NOFRAMES'         => array( '<noframes><p>Check the rules here.</p></noframes><div target>' ),
+			'NOSCRIPT'         => array( '<noscript><span>This assumes that scripting mode is enabled.</span></noscript><p target>' ),
+			'STYLE'            => array( '<style>* { margin: 0 }</style><div target>' ),
+			'STYLE hiding DIV' => array( '<style>li::before { content: "<div non-target>" }</style><div target>' ),
+		);
+	}
+
+	/**
 	 * Ensures that the invalid comment closing syntax "--!>" properly closes a comment.
 	 *
 	 * @ticket 58007


### PR DESCRIPTION
Trac Ticket: [#59292](https://core.trac.wordpress.org/ticket/59292#ticket)

When encountering elements that imply switching into the RAWTEXT parsing state, the Tag Processor should skip processing until existing the RAWTEXT state.

In this patch the Tag Processor does just that, except for the case of the deprecated XMP element which implies further and more complicated rules.

There's an implicit assumption that the SCRIPT ENABLED flag in HTML parsing is enabled so that the contents of NOSCRIPT can be skipped. Otherwise, it would be required to parse the contents of that tag.

_This was not a reported bug; it was discovered through the Core unit test cases for `kses`_