### PR TITLE
Use `wp_admin_notice()` in wp-includes.

### DIFF
--- a/src/wp-includes/customize/class-wp-customize-theme-control.php
+++ b/src/wp-includes/customize/class-wp-customize-theme-control.php
@@ -240,7 +240,15 @@ class WP_Customize_Theme_Control extends WP_Customize_Control {
 						<button type="button" class="button button-primary customize-theme" aria-label="<?php echo esc_attr( $customize_label ); ?>"><?php _e( 'Customize' ); ?></button>
 					</div>
 				</div>
-				<div class="notice notice-success notice-alt"><p><?php _ex( 'Installed', 'theme' ); ?></p></div>
+				<?php
+				wp_admin_notice(
+					_x( 'Installed', 'theme' ),
+					array(
+						'type'               => 'success',
+						'additional_classes' => array( 'notice-alt' ),
+					)
+				);
+				?>
 			<# } else if ( 'installed' === data.theme.type ) { #>
 				<# if ( data.theme.blockTheme ) { #>
 					<div class="theme-id-container">
@@ -255,21 +263,26 @@ class WP_Customize_Theme_Control extends WP_Customize_Control {
 							<# } #>
 						</div>
 					</div>
-					<div class="notice notice-error notice-alt"><p>
-					<?php
-						_e( 'This theme doesn\'t support Customizer.' );
-					?>
+					<?php $customizer_not_supported_message = __( 'This theme doesn\'t support Customizer.' ); ?>
 					<# if ( data.theme.actions.activate ) { #>
 						<?php
-							echo ' ';
-							printf(
+							$customizer_not_supported_message .= ' ' . sprintf(
 								/* translators: %s: URL to the themes page (also it activates the theme). */
 								__( 'However, you can still <a href="%s">activate this theme</a>, and use the Site Editor to customize it.' ),
 								'{{{ data.theme.actions.activate }}}'
 							);
 						?>
 					<# } #>
-					</p></div>
+
+					<?php
+					wp_admin_notice(
+						$customizer_not_supported_message,
+						array(
+							'type'               => 'error',
+							'additional_classes' => array( 'notice-alt' ),
+						)
+					);
+					?>
 				<# } else { #>
 					<div class="theme-id-container">
 						<h3 class="theme-name" id="{{ data.section }}-{{ data.theme.id }}-name">{{ data.theme.name }}</h3>
@@ -281,7 +294,15 @@ class WP_Customize_Theme_Control extends WP_Customize_Control {
 							<# } #>
 						</div>
 					</div>
-					<div class="notice notice-success notice-alt"><p><?php _ex( 'Installed', 'theme' ); ?></p></div>
+					<?php
+					wp_admin_notice(
+						_x( 'Installed', 'theme' ),
+						array(
+							'type'               => 'success',
+							'additional_classes' => array( 'notice-alt' ),
+						)
+					);
+					?>
 				<# } #>
 			<# } else { #>
 				<div class="theme-id-container">

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -3761,8 +3761,12 @@ function new_user_email_admin_notice() {
 	if ( 'profile.php' === $pagenow && isset( $_GET['updated'] ) ) {
 		$email = get_user_meta( get_current_user_id(), '_new_email', true );
 		if ( $email ) {
-			/* translators: %s: New email address. */
-			echo '<div class="notice notice-info"><p>' . sprintf( __( 'Your email address has not been updated yet. Please check your inbox at %s for a confirmation email.' ), '<code>' . esc_html( $email['newemail'] ) . '</code>' ) . '</p></div>';
+			$message = sprintf(
+				/* translators: %s: New email address. */
+				__( 'Your email address has not been updated yet. Please check your inbox at %s for a confirmation email.' ),
+				'<code>' . esc_html( $email['newemail'] ) . '</code>'
+			);
+			wp_admin_notice( $message, array( 'type' => 'info' ) );
 		}
 	}
 }


### PR DESCRIPTION
The `wp_admin_notice()` function was introduced in [56408].

This change implements this function in `wp-includes/` files.

Trac ticket: https://core.trac.wordpress.org/ticket/57791