### PR TITLE
Sync minor code quality tweaks to WP_REST_Global_Styles_Controller

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-controller.php
@@ -663,6 +663,8 @@ class WP_REST_Global_Styles_Controller extends WP_REST_Controller {
 	 * Returns the given theme global styles variations.
 	 *
 	 * @since 6.0.0
+	 * @since 6.2.0 Returns parent theme variations, if they exist.
+	 * @since 6.4.0 Removed unnecessary local variable.
 	 *
 	 * @param WP_REST_Request $request The request instance.
 	 *
@@ -679,9 +681,8 @@ class WP_REST_Global_Styles_Controller extends WP_REST_Controller {
 		}
 
 		$variations = WP_Theme_JSON_Resolver::get_style_variations();
-		$response   = rest_ensure_response( $variations );
 
-		return $response;
+		return rest_ensure_response( $variations );
 	}
 
 	/**
@@ -690,11 +691,12 @@ class WP_REST_Global_Styles_Controller extends WP_REST_Controller {
 	 * Currently just checks for invalid markup.
 	 *
 	 * @since 6.2.0
+	 * @since 6.4.0 Changed method visibility to protected.
 	 *
 	 * @param string $css CSS to validate.
 	 * @return true|WP_Error True if the input was validated, otherwise WP_Error.
 	 */
-	private function validate_custom_css( $css ) {
+	protected function validate_custom_css( $css ) {
 		if ( preg_match( '#</?\w+#', $css ) ) {
 			return new WP_Error(
 				'rest_custom_css_illegal_markup',

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-controller.php
@@ -664,7 +664,6 @@ class WP_REST_Global_Styles_Controller extends WP_REST_Controller {
 	 *
 	 * @since 6.0.0
 	 * @since 6.2.0 Returns parent theme variations, if they exist.
-	 * @since 6.4.0 Removed unnecessary local variable.
 	 *
 	 * @param WP_REST_Request $request The request instance.
 	 *


### PR DESCRIPTION
For 6.4, sync a couple of minor code quality tweaks to the WP_REST_Global_Styles_Controller class.

1. Remove unnecessary local variable in `::get_theme_items()`
2. Change `::validate_custom_css()` access modifier from private to protected so that the method is inherited if the class is extended


Gutenberg PRs:

- https://github.com/WordPress/gutenberg/pull/53618
- https://github.com/WordPress/gutenberg/pull/52819


Trac ticket: https://core.trac.wordpress.org/ticket/59296

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
