### PR TITLE
[Ignore] Check if tests detect missing injected theme attribute

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -565,7 +565,7 @@ function _build_block_template_result_from_file( $template_file, $template_type 
 	$template                 = new WP_Block_Template();
 	$template->id             = $theme . '//' . $template_file['slug'];
 	$template->theme          = $theme;
-	//$template->content        = _inject_theme_attribute_in_block_template_content( $template_content );
+	$template->content        = $template_content ;
 	$template->slug           = $template_file['slug'];
 	$template->source         = 'theme';
 	$template->type           = $template_type;

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -565,7 +565,7 @@ function _build_block_template_result_from_file( $template_file, $template_type 
 	$template                 = new WP_Block_Template();
 	$template->id             = $theme . '//' . $template_file['slug'];
 	$template->theme          = $theme;
-	$template->content        = $template_content ;
+	$template->content        = $template_content;
 	$template->slug           = $template_file['slug'];
 	$template->source         = 'theme';
 	$template->type           = $template_type;

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -565,7 +565,7 @@ function _build_block_template_result_from_file( $template_file, $template_type 
 	$template                 = new WP_Block_Template();
 	$template->id             = $theme . '//' . $template_file['slug'];
 	$template->theme          = $theme;
-	$template->content        = _inject_theme_attribute_in_block_template_content( $template_content );
+	//$template->content        = _inject_theme_attribute_in_block_template_content( $template_content );
 	$template->slug           = $template_file['slug'];
 	$template->source         = 'theme';
 	$template->type           = $template_type;


### PR DESCRIPTION
We have a dedicated test for this: https://github.com/WordPress/wordpress-develop/blob/bd594f72a83e0512d60aec5436ab653ed5966678/tests/phpunit/tests/block-template-utils.php#L164-L203

If I remove theme attribute injection (as done by this branch), the test still seems to pass locally 🤔 

To reproduce:
- Check out this branch
- `npm run test:php -- --group=block-templates`