### PR TITLE
Add Block Hooks (a.k.a. Auto-inserting Blocks)

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -514,6 +514,26 @@ function _inject_theme_attribute_in_block_template_content( $template_content ) 
 }
 
 /**
+ * Injects the active theme's stylesheet as a `theme` attribute
+ * into a given template part block.
+ *
+ * @since 6.4.0
+ * @access private
+ *
+ * @param array $block a parsed block.
+ * @return array Updated block.
+ */
+function _inject_theme_attribute_in_template_part_block( $block ) {
+	if (
+		'core/template-part' === $block['blockName'] &&
+		! isset( $block['attrs']['theme'] )
+	) {
+		$block['attrs']['theme'] = get_stylesheet();
+	}
+	return $block;
+}
+
+/**
  * Parses a block template and removes the theme attribute from each template part.
  *
  * @since 5.9.0
@@ -565,7 +585,6 @@ function _build_block_template_result_from_file( $template_file, $template_type 
 	$template                 = new WP_Block_Template();
 	$template->id             = $theme . '//' . $template_file['slug'];
 	$template->theme          = $theme;
-	$template->content        = _inject_theme_attribute_in_block_template_content( $template_content );
 	$template->slug           = $template_file['slug'];
 	$template->source         = 'theme';
 	$template->type           = $template_type;
@@ -588,6 +607,9 @@ function _build_block_template_result_from_file( $template_file, $template_type 
 	if ( 'wp_template_part' === $template_type && isset( $template_file['area'] ) ) {
 		$template->area = $template_file['area'];
 	}
+
+	$blocks            = parse_blocks( $template_content );
+	$template->content = serialize_blocks( $blocks, '_inject_theme_attribute_in_template_part_block' );
 
 	return $template;
 }

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -432,7 +432,6 @@ function register_block_type_from_metadata( $file_or_folder, $args = array() ) {
 		'usesContext'     => 'uses_context',
 		'selectors'       => 'selectors',
 		'supports'        => 'supports',
-		'blockHooks'      => 'block_hooks',
 		'styles'          => 'styles',
 		'variations'      => 'variations',
 		'example'         => 'example',
@@ -511,6 +510,39 @@ function register_block_type_from_metadata( $file_or_folder, $args = array() ) {
 				}
 			}
 			$settings[ $settings_field_name ] = $processed_styles;
+		}
+	}
+
+	if ( ! empty( $metadata['blockHooks'] ) ) {
+		/**
+		 * Map camelCased position string (from block.json) to snake_cased block type position.
+		 *
+		 * @var array
+		 */
+		$position_mappings = array(
+			'before'     => 'before',
+			'after'      => 'after',
+			'firstChild' => 'first_child',
+			'lastChild'  => 'last_child',
+		);
+
+		$settings['block_hooks'] = array();
+		foreach ( $metadata['blockHooks'] as $anchor_block_name => $position ) {
+			// Avoid infinite recursion (hooking to itself).
+			if ( $metadata['name'] === $anchor_block_name ) {
+				_doing_it_wrong(
+					__METHOD__,
+					__( 'Cannot hook block to itself.', 'gutenberg' ),
+					'6.4.0'
+				);
+				continue;
+			}
+
+			if ( ! isset( $position_mappings[ $position ] ) ) {
+				continue;
+			}
+
+			$settings['block_hooks'][ $anchor_block_name ] = $position_mappings[ $position ];
 		}
 	}
 

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -432,6 +432,7 @@ function register_block_type_from_metadata( $file_or_folder, $args = array() ) {
 		'usesContext'     => 'uses_context',
 		'selectors'       => 'selectors',
 		'supports'        => 'supports',
+		'blockHooks'      => 'block_hooks',
 		'styles'          => 'styles',
 		'variations'      => 'variations',
 		'example'         => 'example',

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -869,7 +869,7 @@ function serialize_block( $block, $callback = null ) {
  */
 function serialize_blocks( $blocks, $callback = null ) {
 	$result = '';
-	foreach( $blocks as $block ) {
+	foreach ( $blocks as $block ) {
 		$result .= serialize_block( $block, $callback );
 	};
 	return $result;

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -828,12 +828,18 @@ function serialize_block( $block, $callback = null ) {
  * parsed blocks.
  *
  * @since 5.3.1
+ * @since 6.4.0 The `$callback` parameter was added.
  *
  * @param array[] $blocks An array of representative arrays of parsed block objects. See serialize_block().
+ * @param string $callback Optional. Callback to run on the blocks before serialization.
  * @return string String of rendered HTML.
  */
-function serialize_blocks( $blocks ) {
-	return implode( '', array_map( 'serialize_block', $blocks ) );
+function serialize_blocks( $blocks, $callback = null ) {
+	$result = '';
+	foreach( $blocks as $block ) {
+		$result .= serialize_block( $block, $callback );
+	};
+	return $result;
 }
 
 /**

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1633,3 +1633,25 @@ function get_comments_pagination_arrow( $block, $pagination_type = 'next' ) {
 	}
 	return null;
 }
+
+/**
+ * Retrieves block types (and positions) hooked into the given block.
+ *
+ * @since 6.4.0
+ *
+ * @param string $name Block type name including namespace.
+ * @return array Associative array of `$block_type_name => $position` pairs.
+ */
+function get_hooked_blocks( $name ) {
+	$block_types = WP_Block_Type_Registry::get_instance()->get_all_registered();
+	$hooked_blocks = array();
+	foreach ( $block_types as $block_type ) {
+		foreach ( $block_type->block_hooks as $anchor_block_type => $relative_position ) {
+			echo "$anchor_block_type $name\n";
+			if ( $anchor_block_type === $name ) {
+				$hooked_blocks[ $block_type->name ] = $relative_position;
+			}
+		}
+	}
+	return $hooked_blocks;
+}

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -829,8 +829,8 @@ function get_comment_delimited_block_content( $block_name, $block_attributes, $b
  * @since 5.3.1
  * @since 6.4.0 The `$callback` parameter was added.
  *
- * @param array $block A representative array of a single parsed block object. See WP_Block_Parser_Block.
- * @param string $callback Optional. Callback to run on the block before serialization.
+ * @param array  $block    A representative array of a single parsed block object. See WP_Block_Parser_Block.
+ * @param string $callback Optional. Callback to run on the block before serialization. Default null.
  * @return string String of rendered HTML.
  */
 function serialize_block( $block, $callback = null ) {

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -863,8 +863,8 @@ function serialize_block( $block, $callback = null ) {
  * @since 5.3.1
  * @since 6.4.0 The `$callback` parameter was added.
  *
- * @param array[] $blocks An array of representative arrays of parsed block objects. See serialize_block().
- * @param string $callback Optional. Callback to run on the blocks before serialization.
+ * @param array[] $blocks   An array of representative arrays of parsed block objects. See serialize_block().
+ * @param string  $callback Optional. Callback to run on the blocks before serialization. Default null.
  * @return string String of rendered HTML.
  */
 function serialize_blocks( $blocks, $callback = null ) {

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1647,7 +1647,6 @@ function get_hooked_blocks( $name ) {
 	$hooked_blocks = array();
 	foreach ( $block_types as $block_type ) {
 		foreach ( $block_type->block_hooks as $anchor_block_type => $relative_position ) {
-			echo "$anchor_block_type $name\n";
 			if ( $anchor_block_type === $name ) {
 				$hooked_blocks[ $block_type->name ] = $relative_position;
 			}

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1725,9 +1725,11 @@ function insert_hooked_blocks( $block ) {
 function insert_hooked_block( $inserted_block, $relative_position, $anchor_block ) {
 	if ( 'first_child' === $relative_position ) {
 		array_unshift( $anchor_block['innerBlocks'], $inserted_block );
-		// Since WP_Block::render() iterates over `inner_content` (rather than `inner_blocks`)
-		// when rendering blocks, we also need to prepend a value (`null`, to mark a block
-		// location) to that array.
+		/*
+		 * Since WP_Block::render() iterates over `inner_content` (rather than `inner_blocks`)
+		 * when rendering blocks, we also need to prepend a value (`null`, to mark a block
+		 * location) to that array.
+		 */
 		array_unshift( $anchor_block['innerContent'], null );
 	} elseif ( 'last_child' === $relative_position ) {
 		array_push( $anchor_block['innerBlocks'], $inserted_block );

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -794,16 +794,22 @@ function get_comment_delimited_block_content( $block_name, $block_attributes, $b
  * instead preserve the markup as parsed.
  *
  * @since 5.3.1
+ * @since 6.4.0 The `$callback` parameter was added.
  *
  * @param array $block A representative array of a single parsed block object. See WP_Block_Parser_Block.
+ * @param string $callback Optional. Callback to run on the block before serialization.
  * @return string String of rendered HTML.
  */
-function serialize_block( $block ) {
+function serialize_block( $block, $callback = null ) {
+	if ( is_callable( $callback ) ) {
+		$block = call_user_func( $callback, $block );
+	}
+
 	$block_content = '';
 
 	$index = 0;
 	foreach ( $block['innerContent'] as $chunk ) {
-		$block_content .= is_string( $chunk ) ? $chunk : serialize_block( $block['innerBlocks'][ $index++ ] );
+		$block_content .= is_string( $chunk ) ? $chunk : serialize_block( $block['innerBlocks'][ $index++ ], $callback );
 	}
 
 	if ( ! is_array( $block['attrs'] ) ) {

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1704,7 +1704,7 @@ function insert_hooked_blocks( $block ) {
 }
 
 /**
- * Auto-insert a block next to a given "anchor" block.
+ * Auto-inserts a block next to a given "anchor" block.
  *
  * This is a helper function used in the implementation of block hooks.
  * It is not meant for public use.

--- a/src/wp-includes/class-wp-block-patterns-registry.php
+++ b/src/wp-includes/class-wp-block-patterns-registry.php
@@ -182,11 +182,19 @@ final class WP_Block_Patterns_Registry {
 	 *                 and per style.
 	 */
 	public function get_all_registered( $outside_init_only = false ) {
-		return array_values(
+		$patterns = array_values(
 			$outside_init_only
 				? $this->registered_patterns_outside_init
 				: $this->registered_patterns
 		);
+
+		foreach ( $patterns as $index => $pattern ) {
+			$blocks                        = parse_blocks( $pattern['content'] );
+			$visitor                       = _parsed_block_visitor( $pattern ); // TODO: Should we use different functions for template vs pattern?
+			$patterns[ $index ]['content'] = serialize_blocks( $blocks, $visitor );
+		}
+
+		return $patterns;
 	}
 
 	/**

--- a/src/wp-includes/class-wp-block-patterns-registry.php
+++ b/src/wp-includes/class-wp-block-patterns-registry.php
@@ -165,7 +165,11 @@ final class WP_Block_Patterns_Registry {
 			return null;
 		}
 
-		return $this->registered_patterns[ $pattern_name ];
+		$pattern            = $this->registered_patterns[ $pattern_name ];
+		$blocks             = parse_blocks( $pattern['content'] );
+		$visitor            = _parsed_block_visitor( $pattern ); // TODO: Should we use different functions for template vs pattern?
+		$pattern['content'] = serialize_blocks( $blocks, $visitor );
+		return $pattern;
 	}
 
 	/**

--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -214,6 +214,18 @@ class WP_Block_Type {
 	public $style_handles = array();
 
 	/**
+	 * Block hooks for this block type.
+	 *
+	 * A block hook is specified by a block type and a relative position.
+	 * The hooked block will be automatically inserted in the given position
+	 * next to the "anchor" block whenever the latter is encountered.
+	 *
+	 * @since 6.4.0
+	 * @var array|null
+	 */
+	public $block_hooks = array();
+
+	/**
 	 * Deprecated block type properties for script and style handles.
 	 *
 	 * @since 6.1.0
@@ -254,6 +266,7 @@ class WP_Block_Type {
 	 *              `editor_style_handles`, and `style_handles` properties.
 	 *              Deprecated the `editor_script`, `script`, `view_script`, `editor_style`, and `style` properties.
 	 * @since 6.3.0 Added the `selectors` property.
+	 * @since 6.4.0 Added the `block_hooks` property.
 	 *
 	 * @see register_block_type()
 	 *
@@ -279,6 +292,7 @@ class WP_Block_Type {
 	 *     @type array[]       $variations               Block variations.
 	 *     @type array         $selectors                Custom CSS selectors for theme.json style generation.
 	 *     @type array|null    $supports                 Supported features.
+	 *     @type array|null    $block_hooks              Block hooks.
 	 *     @type array|null    $example                  Structured data for the block preview.
 	 *     @type callable|null $render_callback          Block type render callback.
 	 *     @type array|null    $attributes               Block type attributes property schemas.

--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -221,7 +221,7 @@ class WP_Block_Type {
 	 * next to the "anchor" block whenever the latter is encountered.
 	 *
 	 * @since 6.4.0
-	 * @var array|null
+	 * @var array
 	 */
 	public $block_hooks = array();
 
@@ -292,7 +292,7 @@ class WP_Block_Type {
 	 *     @type array[]       $variations               Block variations.
 	 *     @type array         $selectors                Custom CSS selectors for theme.json style generation.
 	 *     @type array|null    $supports                 Supported features.
-	 *     @type array|null    $block_hooks              Block hooks.
+	 *     @type array         $block_hooks              Block hooks.
 	 *     @type array|null    $example                  Structured data for the block preview.
 	 *     @type callable|null $render_callback          Block type render callback.
 	 *     @type array|null    $attributes               Block type attributes property schemas.


### PR DESCRIPTION
Port the Block Hooks feature ([formerly known as Auto-inserting Blocks](https://github.com/WordPress/gutenberg/pull/54147)) from Gutenberg to Core.

WIP. Might break this into separate PRs later.

### Testing Instructions

- Test with https://github.com/ockham/like-button/releases/download/v0.4.1/like-button.zip. This version has the `block.json` field name set to `blockHooks` and will work with this PR out-of-the-box.
- Since that block makes use of the Interactivity API which was made private as of Gutenberg 16.4, you need to also install [Gutenberg 16.3](https://downloads.wordpress.org/plugin/gutenberg.16.3.0.zip), and enable the "Interactivity API" experiment **(but _not_ the Auto-inserting Blocks experiment!)**

Trac ticket: https://core.trac.wordpress.org/ticket/59313

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
