### PR TITLE
Font Face: Remove static instance in wp_print_font_faces()

### DIFF
--- a/src/wp-includes/fonts.php
+++ b/src/wp-includes/fonts.php
@@ -39,7 +39,6 @@
  * }
  */
 function wp_print_font_faces( $fonts = array() ) {
-	static $wp_font_face = null;
 
 	if ( empty( $fonts ) ) {
 		$fonts = WP_Font_Face_Resolver::get_fonts_from_theme_json();
@@ -49,9 +48,6 @@ function wp_print_font_faces( $fonts = array() ) {
 		return;
 	}
 
-	if ( null === $wp_font_face ) {
-		$wp_font_face = new WP_Font_Face();
-	}
-
+	$wp_font_face = new WP_Font_Face();
 	$wp_font_face->generate_and_print( $fonts );
 }

--- a/tests/phpunit/tests/fonts/font-face/wpPrintFontFaces.php
+++ b/tests/phpunit/tests/fonts/font-face/wpPrintFontFaces.php
@@ -6,17 +6,11 @@
  * @subpackage Fonts
  *
  * @since 6.4.0
- */
-require_once __DIR__ . '/base.php';
-
-/**
+ *
  * @group fonts
  * @group fontface
  *
  * @covers wp_print_font_faces
- *
- * @runTestsInSeparateProcesses
- * @preserveGlobalState disabled
  */
 class Tests_Fonts_WpPrintFontFaces extends WP_Font_Face_UnitTestCase {
 	const FONTS_THEME = 'fonts-block-theme';


### PR DESCRIPTION
Removes the static instance in `wp_print_font_faces()`.

Why?

The static instance of `WP_Font_Face` is not needed. It was originally introduced when a singleton was needed to persist internal data. However, that functionality was previously removed. The remaining static artifact should have also been removed. 

Removing the static instance also removes the need to run `wp_print_font_faces()` tests in separate processes.

Ref: [Gutenberg PR 54228](https://github.com/WordPress/gutenberg/pull/54228).

Trac ticket: https://core.trac.wordpress.org/ticket/59165

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
