### PR TITLE
Patterns: Update wp-admin action notices

### DIFF
--- a/src/wp-admin/edit.php
+++ b/src/wp-admin/edit.php
@@ -381,17 +381,17 @@ $bulk_messages['page']     = array(
 	'untrashed' => _n( '%s page restored from the Trash.', '%s pages restored from the Trash.', $bulk_counts['untrashed'] ),
 );
 $bulk_messages['wp_block'] = array(
-	/* translators: %s: Number of blocks. */
-	'updated'   => _n( '%s block updated.', '%s blocks updated.', $bulk_counts['updated'] ),
-	'locked'    => ( 1 === $bulk_counts['locked'] ) ? __( '1 block not updated, somebody is editing it.' ) :
-					/* translators: %s: Number of blocks. */
-					_n( '%s block not updated, somebody is editing it.', '%s blocks not updated, somebody is editing them.', $bulk_counts['locked'] ),
-	/* translators: %s: Number of blocks. */
-	'deleted'   => _n( '%s block permanently deleted.', '%s blocks permanently deleted.', $bulk_counts['deleted'] ),
-	/* translators: %s: Number of blocks. */
-	'trashed'   => _n( '%s block moved to the Trash.', '%s blocks moved to the Trash.', $bulk_counts['trashed'] ),
-	/* translators: %s: Number of blocks. */
-	'untrashed' => _n( '%s block restored from the Trash.', '%s blocks restored from the Trash.', $bulk_counts['untrashed'] ),
+	/* translators: %s: Number of patterns. */
+	'updated'   => _n( '%s pattern updated.', '%s patterns updated.', $bulk_counts['updated'] ),
+	'locked'    => ( 1 === $bulk_counts['locked'] ) ? __( '1 pattern not updated, somebody is editing it.' ) :
+					/* translators: %s: Number of patterns. */
+					_n( '%s pattern not updated, somebody is editing it.', '%s patterns not updated, somebody is editing them.', $bulk_counts['locked'] ),
+	/* translators: %s: Number of patterns. */
+	'deleted'   => _n( '%s pattern permanently deleted.', '%s patterns permanently deleted.', $bulk_counts['deleted'] ),
+	/* translators: %s: Number of patterns. */
+	'trashed'   => _n( '%s pattern moved to the Trash.', '%s patterns moved to the Trash.', $bulk_counts['trashed'] ),
+	/* translators: %s: Number of patterns. */
+	'untrashed' => _n( '%s pattern restored from the Trash.', '%s patterns restored from the Trash.', $bulk_counts['untrashed'] ),
 );
 
 /**


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Update the wp-admin notices when performing actions on the `wp_block` post type to refer to patterns now that reusable blocks have been renamed to patterns.

First reported in https://github.com/WordPress/gutenberg/issues/53370.

Test instructions:

1. Add a new pattern via `wp-admin/post-new.php?post_type=wp_block`
2. Navigate back to the Patterns wp-admin page: `wp-admin/edit.php?post_type=wp_block`
3. Perform actions such as deleting or restoring the new pattern
4. The notices should now refer to a "pattern" instead of "block" as per screenshots below.

<img width="554" alt="Screenshot 2023-09-07 at 10 32 08 am" src="https://github.com/WordPress/wordpress-develop/assets/60436221/987e1087-1de9-464d-9ab5-a18d425684ea">
<img width="556" alt="Screenshot 2023-09-07 at 10 31 14 am" src="https://github.com/WordPress/wordpress-develop/assets/60436221/f3d3e3cc-cf4c-46d0-b13b-f5cfba6411c2">
<img width="567" alt="Screenshot 2023-09-07 at 10 30 57 am" src="https://github.com/WordPress/wordpress-develop/assets/60436221/1211471c-2f76-430d-86a4-4426bf903d69">


Trac ticket: https://core.trac.wordpress.org/ticket/59305

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
