### PR TITLE
Fix body content alignment and avoid sticky menu when there is a PHP notice

### DIFF
--- a/src/wp-admin/css/admin-menu.css
+++ b/src/wp-admin/css/admin-menu.css
@@ -326,7 +326,7 @@ div.wp-menu-image:before {
 }
 
 /* Sticky admin menu */
-.sticky-menu #adminmenuwrap {
+.sticky-menu:not(.php-error) #adminmenuwrap {
 	position: fixed;
 }
 

--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -29,6 +29,11 @@
 	overflow: visible;
 }
 
+/* Additional margin when there is a PHP notice */
+.php-error #wpbody-content {
+	margin-top: 2em;
+}
+
 /* inner 2 column liquid layout */
 
 .inner-sidebar {
@@ -4097,12 +4102,20 @@ img {
 		padding-top: 0;
 	}
 
+	html.wp-toolbar body.php-error {
+		padding-top: 46px;
+	}
+
 	.screen-reader-shortcut:focus {
 		top: 7px;
 	}
 
 	#wpbody {
 		padding-top: 46px;
+	}
+
+	body.php-error #wpbody {
+		padding-top: 0px;
 	}
 
 	/* Keep full-width boxes on Edit Post page from causing horizontal scroll */

--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -851,6 +851,10 @@ html:lang(he-il) .rtl #wpadminbar * {
 		top: -3px;
 	}
 
+	.php-error #wpadminbar #wp-admin-bar-wp-logo > .ab-item .ab-icon:before {
+		top: 9px;
+	}
+
 	#wpadminbar .ab-icon,
 	#wpadminbar .ab-item:before {
 		padding: 0;
@@ -1109,6 +1113,10 @@ html:lang(he-il) .rtl #wpadminbar * {
 	#wpadminbar .ab-top-menu > .menupop li > .ab-sub-wrapper {
 		position: static;
 		box-shadow: none;
+	}
+
+	.php-error #wpadminbar {
+		position: fixed;
 	}
 }
 


### PR DESCRIPTION
PR fixes the alignment of #body-content and sticky admin menu when there is PHP notice.

**Note:** For the block editor page(add/edit post) php notices are partially hidden by the block editor. Not sure if that falls into the scope of this ticket, any suggestions?

Trac ticket: https://core.trac.wordpress.org/ticket/58455

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
