### PR TITLE
Use wp_trigger_error() for dynamic properties in magic methods

### DIFF
--- a/src/wp-admin/includes/class-wp-list-table.php
+++ b/src/wp-admin/includes/class-wp-list-table.php
@@ -186,7 +186,8 @@ class WP_List_Table {
 			return $this->$name;
 		}
 
-		trigger_error(
+		wp_trigger_error(
+			__METHOD__,
 			"The property `{$name}` is not declared. Getting a dynamic property is " .
 			'deprecated since version 6.4.0! Instead, declare the property on the class.',
 			E_USER_DEPRECATED
@@ -209,7 +210,8 @@ class WP_List_Table {
 			return;
 		}
 
-		trigger_error(
+		wp_trigger_error(
+			__METHOD__,
 			"The property `{$name}` is not declared. Setting a dynamic property is " .
 			'deprecated since version 6.4.0! Instead, declare the property on the class.',
 			E_USER_DEPRECATED
@@ -230,7 +232,8 @@ class WP_List_Table {
 			return isset( $this->$name );
 		}
 
-		trigger_error(
+		wp_trigger_error(
+			__METHOD__,
 			"The property `{$name}` is not declared. Checking `isset()` on a dynamic property " .
 			'is deprecated since version 6.4.0! Instead, declare the property on the class.',
 			E_USER_DEPRECATED
@@ -252,7 +255,8 @@ class WP_List_Table {
 			return;
 		}
 
-		trigger_error(
+		wp_trigger_error(
+			__METHOD__,
 			"A property `{$name}` is not declared. Unsetting a dynamic property is " .
 			'deprecated since version 6.4.0! Instead, declare the property on the class.',
 			E_USER_DEPRECATED

--- a/src/wp-includes/class-wp-text-diff-renderer-table.php
+++ b/src/wp-includes/class-wp-text-diff-renderer-table.php
@@ -521,7 +521,8 @@ class WP_Text_Diff_Renderer_Table extends Text_Diff_Renderer {
 			return $this->$name;
 		}
 
-		trigger_error(
+		wp_trigger_error(
+			__METHOD__,
 			"The property `{$name}` is not declared. Getting a dynamic property is " .
 			'deprecated since version 6.4.0! Instead, declare the property on the class.',
 			E_USER_DEPRECATED
@@ -544,7 +545,8 @@ class WP_Text_Diff_Renderer_Table extends Text_Diff_Renderer {
 			return;
 		}
 
-		trigger_error(
+		wp_trigger_error(
+			__METHOD__,
 			"The property `{$name}` is not declared. Setting a dynamic property is " .
 			'deprecated since version 6.4.0! Instead, declare the property on the class.',
 			E_USER_DEPRECATED
@@ -565,7 +567,8 @@ class WP_Text_Diff_Renderer_Table extends Text_Diff_Renderer {
 			return isset( $this->$name );
 		}
 
-		trigger_error(
+		wp_trigger_error(
+			__METHOD__,
 			"The property `{$name}` is not declared. Checking `isset()` on a dynamic property " .
 			'is deprecated since version 6.4.0! Instead, declare the property on the class.',
 			E_USER_DEPRECATED
@@ -587,7 +590,8 @@ class WP_Text_Diff_Renderer_Table extends Text_Diff_Renderer {
 			return;
 		}
 
-		trigger_error(
+		wp_trigger_error(
+			__METHOD__,
 			"A property `{$name}` is not declared. Unsetting a dynamic property is " .
 			'deprecated since version 6.4.0! Instead, declare the property on the class.',
 			E_USER_DEPRECATED

--- a/src/wp-includes/class-wp-user-query.php
+++ b/src/wp-includes/class-wp-user-query.php
@@ -1122,7 +1122,8 @@ class WP_User_Query {
 			return $this->$name;
 		}
 
-		trigger_error(
+		wp_trigger_error(
+			__METHOD__,
 			"The property `{$name}` is not declared. Getting a dynamic property is " .
 			'deprecated since version 6.4.0! Instead, declare the property on the class.',
 			E_USER_DEPRECATED
@@ -1145,7 +1146,8 @@ class WP_User_Query {
 			return;
 		}
 
-		trigger_error(
+		wp_trigger_error(
+			__METHOD__,
 			"The property `{$name}` is not declared. Setting a dynamic property is " .
 			'deprecated since version 6.4.0! Instead, declare the property on the class.',
 			E_USER_DEPRECATED
@@ -1166,7 +1168,8 @@ class WP_User_Query {
 			return isset( $this->$name );
 		}
 
-		trigger_error(
+		wp_trigger_error(
+			__METHOD__,
 			"The property `{$name}` is not declared. Checking `isset()` on a dynamic property " .
 			'is deprecated since version 6.4.0! Instead, declare the property on the class.',
 			E_USER_DEPRECATED
@@ -1188,7 +1191,8 @@ class WP_User_Query {
 			return;
 		}
 
-		trigger_error(
+		wp_trigger_error(
+			__METHOD__,
 			"A property `{$name}` is not declared. Unsetting a dynamic property is " .
 			'deprecated since version 6.4.0! Instead, declare the property on the class.',
 			E_USER_DEPRECATED

--- a/tests/phpunit/tests/admin/wpListTable.php
+++ b/tests/phpunit/tests/admin/wpListTable.php
@@ -389,6 +389,7 @@ class Tests_Admin_WpListTable extends WP_UnitTestCase {
 	public function test_should_throw_deprecation_when_getting_dynamic_property() {
 		$this->expectDeprecation();
 		$this->expectDeprecationMessage(
+			'WP_List_Table::__get(): ' .
 			'The property `undeclared_property` is not declared. Getting a dynamic property is ' .
 			'deprecated since version 6.4.0! Instead, declare the property on the class.'
 		);
@@ -418,6 +419,7 @@ class Tests_Admin_WpListTable extends WP_UnitTestCase {
 	public function test_should_throw_deprecation_when_setting_dynamic_property() {
 		$this->expectDeprecation();
 		$this->expectDeprecationMessage(
+			'WP_List_Table::__set(): ' .
 			'The property `undeclared_property` is not declared. Setting a dynamic property is ' .
 			'deprecated since version 6.4.0! Instead, declare the property on the class.'
 		);
@@ -450,6 +452,7 @@ class Tests_Admin_WpListTable extends WP_UnitTestCase {
 	public function test_should_throw_deprecation_when_isset_of_dynamic_property() {
 		$this->expectDeprecation();
 		$this->expectDeprecationMessage(
+			'WP_List_Table::__isset(): ' .
 			'The property `undeclared_property` is not declared. Checking `isset()` on a dynamic property ' .
 			'is deprecated since version 6.4.0! Instead, declare the property on the class.'
 		);
@@ -477,6 +480,7 @@ class Tests_Admin_WpListTable extends WP_UnitTestCase {
 	public function test_should_throw_deprecation_when_unset_of_dynamic_property() {
 		$this->expectDeprecation();
 		$this->expectDeprecationMessage(
+			'WP_List_Table::__unset(): ' .
 			'A property `undeclared_property` is not declared. Unsetting a dynamic property is ' .
 			'deprecated since version 6.4.0! Instead, declare the property on the class.'
 		);

--- a/tests/phpunit/tests/diff/wpTextDiffRendererTable.php
+++ b/tests/phpunit/tests/diff/wpTextDiffRendererTable.php
@@ -43,6 +43,7 @@ class Tests_Diff_WpTextDiffRendererTable extends WP_UnitTestCase {
 	public function test_should_throw_deprecation_when_getting_dynamic_property() {
 		$this->expectDeprecation();
 		$this->expectDeprecationMessage(
+			'WP_Text_Diff_Renderer_Table::__get(): ' .
 			'The property `undeclared_property` is not declared. Getting a dynamic property is ' .
 			'deprecated since version 6.4.0! Instead, declare the property on the class.'
 		);
@@ -72,6 +73,7 @@ class Tests_Diff_WpTextDiffRendererTable extends WP_UnitTestCase {
 	public function test_should_throw_deprecation_when_setting_dynamic_property() {
 		$this->expectDeprecation();
 		$this->expectDeprecationMessage(
+			'WP_Text_Diff_Renderer_Table::__set(): ' .
 			'The property `undeclared_property` is not declared. Setting a dynamic property is ' .
 			'deprecated since version 6.4.0! Instead, declare the property on the class.'
 		);
@@ -104,6 +106,7 @@ class Tests_Diff_WpTextDiffRendererTable extends WP_UnitTestCase {
 	public function test_should_throw_deprecation_when_isset_of_dynamic_property() {
 		$this->expectDeprecation();
 		$this->expectDeprecationMessage(
+			'WP_Text_Diff_Renderer_Table::__isset(): ' .
 			'The property `undeclared_property` is not declared. Checking `isset()` on a dynamic property ' .
 			'is deprecated since version 6.4.0! Instead, declare the property on the class.'
 		);
@@ -131,6 +134,7 @@ class Tests_Diff_WpTextDiffRendererTable extends WP_UnitTestCase {
 	public function test_should_throw_deprecation_when_unset_of_dynamic_property() {
 		$this->expectDeprecation();
 		$this->expectDeprecationMessage(
+			'WP_Text_Diff_Renderer_Table::__unset(): ' .
 			'A property `undeclared_property` is not declared. Unsetting a dynamic property is ' .
 			'deprecated since version 6.4.0! Instead, declare the property on the class.'
 		);

--- a/tests/phpunit/tests/user/query.php
+++ b/tests/phpunit/tests/user/query.php
@@ -2253,6 +2253,7 @@ class Tests_User_Query extends WP_UnitTestCase {
 
 		$this->expectDeprecation();
 		$this->expectDeprecationMessage(
+			'WP_User_Query::__get(): ' .
 			'The property `undefined_property` is not declared. Getting a dynamic property is ' .
 			'deprecated since version 6.4.0! Instead, declare the property on the class.'
 		);
@@ -2285,6 +2286,7 @@ class Tests_User_Query extends WP_UnitTestCase {
 
 		$this->expectDeprecation();
 		$this->expectDeprecationMessage(
+			'WP_User_Query::__set(): ' .
 			'The property `undefined_property` is not declared. Setting a dynamic property is ' .
 			'deprecated since version 6.4.0! Instead, declare the property on the class.'
 		);
@@ -2321,6 +2323,7 @@ class Tests_User_Query extends WP_UnitTestCase {
 
 		$this->expectDeprecation();
 		$this->expectDeprecationMessage(
+			'WP_User_Query::__isset(): ' .
 			'The property `undefined_property` is not declared. Checking `isset()` on a dynamic property ' .
 			'is deprecated since version 6.4.0! Instead, declare the property on the class.'
 		);
@@ -2352,6 +2355,7 @@ class Tests_User_Query extends WP_UnitTestCase {
 
 		$this->expectDeprecation();
 		$this->expectDeprecationMessage(
+			'WP_User_Query::__unset(): ' .
 			'A property `undefined_property` is not declared. Unsetting a dynamic property is ' .
 			'deprecated since version 6.4.0! Instead, declare the property on the class.'
 		);


### PR DESCRIPTION
Replaces `trigger_error()` with `wp_trigger_error()` for the deprecation notices of dynamic properties in magic methods.

- `WP_List_Table` added by [changeset 56349](https://core.trac.wordpress.org/changeset/56349) / [Trac 58896](https://core.trac.wordpress.org/ticket/58896)

- `WP_User_Query` added by [changeset 56353](https://core.trac.wordpress.org/changeset/56353) / [Trac 58897](https://core.trac.wordpress.org/ticket/58897)

- `WP_Text_Diff_Renderer_Table` added by [changeset 56354](https://core.trac.wordpress.org/changeset/56354) / [Trac 58898](https://core.trac.wordpress.org/ticket/58898)

Trac ticket: https://core.trac.wordpress.org/ticket/57686

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
