### PR TITLE
wp_trigger_error(): Remove escaping and document message

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -6073,13 +6073,6 @@ function wp_trigger_error( $function_name, $message, $error_level = E_USER_NOTIC
 		$message = sprintf( '%s(): %s', $function_name, $message );
 	}
 
-	/*
-	 * If the message appears in the browser, then it needs to be escaped.
-	 * Note the warning in the `trigger_error()` PHP manual.
-	 * @link https://www.php.net/manual/en/function.trigger-error.php
-	 */
-	$message = esc_html( $message );
-
 	trigger_error( $message, $error_level );
 }
 

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -6045,7 +6045,8 @@ function _doing_it_wrong( $function_name, $message, $version ) {
  * @since 6.4.0
  *
  * @param string $function_name The function that triggered the error.
- * @param string $message       The message explaining the error.
+ * @param string $message       The message explaining the error. If it contains HTML or dynamic content,
+ *                              it should be escaped for browser output before passing to this function.
  * @param int    $error_level   Optional. The designated error type for this error.
  *                              Only works with E_USER family of constants. Default E_USER_NOTICE.
  */


### PR DESCRIPTION
wp_trigger_error():

Removes the message escaping and documents the message is expected to be escaped for HTML.

Trac ticket: https://core.trac.wordpress.org/ticket/57686

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
