### PR TITLE
59318: Add unit test demonstrating render method can return null

### DIFF
--- a/src/wp-includes/blocks/template-part.php
+++ b/src/wp-includes/blocks/template-part.php
@@ -109,16 +109,20 @@ function render_block_core_template_part( $attributes ) {
 	// is set in `wp_debug_mode()`.
 	$is_debug = WP_DEBUG && WP_DEBUG_DISPLAY;
 
-	if ( is_null( $content ) && $is_debug ) {
-		if ( ! isset( $attributes['slug'] ) ) {
-			// If there is no slug this is a placeholder and we dont want to return any message.
-			return;
+	if ( is_null( $content ) ) {
+		if ( $is_debug ) {
+			if ( ! isset( $attributes['slug'] ) ) {
+				// If there is no slug this is a placeholder and we dont want to return any message.
+				return '';
+			}
+			return sprintf(
+				/* translators: %s: Template part slug. */
+				__( 'Template part has been deleted or is unavailable: %s' ),
+				$attributes['slug']
+			);
 		}
-		return sprintf(
-			/* translators: %s: Template part slug. */
-			__( 'Template part has been deleted or is unavailable: %s' ),
-			$attributes['slug']
-		);
+
+		return '';
 	}
 
 	if ( isset( $seen_ids[ $template_part_id ] ) ) {

--- a/tests/phpunit/tests/blocks/template-part.php
+++ b/tests/phpunit/tests/blocks/template-part.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Tests for template part rendering.
+ *
+ * @package WordPress
+ *
+ * @group block-templates
+ */
+class Tests_Block_Template_Part extends WP_UnitTestCase {
+	/**
+	 * @ticket 59318
+	 */
+	public function test_render_block_core_template_part_missing_template() {
+		$output = render_block_core_template_part( [] );
+		$this->assertNotNull( $output );
+		$this->assertEquals( '', $output );
+	}
+}


### PR DESCRIPTION
Implements failing unit test demonstrating that render_block_core_template_part method can return NULL in some situations. This can go on to cause a fatal elsewhere, as detailed in 59318.

Trac ticket: https://core.trac.wordpress.org/ticket/59318

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
