### PR TITLE
Fix incorrect right paren

### DIFF
--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -1207,8 +1207,7 @@ class WP_Upgrader {
 			if ( ! $wp_filesystem->delete( $temp_backup_dir, true ) ) {
 				$errors->add(
 					'temp_backup_delete_failed',
-					sprintf( $this->strings['temp_backup_delete_failed'] ),
-					$args['slug']
+					sprintf( $this->strings['temp_backup_delete_failed'], $args['slug'] )
 				);
 				continue;
 			}


### PR DESCRIPTION
Fix incorrect right paren for `sprintf()`.

Trac ticket: https://core.trac.wordpress.org/ticket/59320

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
