### PR TITLE
Add a notice if a theme is requested too early when previewing a theme

### DIFF
--- a/src/wp-includes/theme-previews.php
+++ b/src/wp-includes/theme-previews.php
@@ -76,6 +76,36 @@ function wp_block_theme_activate_nonce() {
 }
 
 /**
+ * Add `_doing_it_wrong()` notice if the theme is requested before `pluggable.php` is loaded.
+ *
+ * @since 6.3.2
+ * @param string $current The current theme's stylesheet or template path.
+ * @return string Return the current theme's stylesheet or template path as is.
+ */
+function wp_theme_preview_maybe_doing_it_wrong( $current ) {
+	if ( ! empty( $_GET['wp_theme_preview'] ) && ! function_exists( 'wp_get_current_user' ) ) {
+		if ( current_filter() === 'template' ) {
+			$function_name = 'get_template()';
+		} else {
+			$function_name = 'get_stylesheet()';
+		}
+
+		_doing_it_wrong(
+			$function_name,
+			sprintf(
+				/* translators: translators: Developer debugging message. 1: PHP function name */
+				__( 'Calling %s before pluggable.php has loaded can result in getting the current theme instead of the previewed theme. Please ensure that you are using these functions after the plugins_loaded action has fired if this is not intended.' ),
+				$function_name
+			),
+			'6.3.2'
+		);
+	}
+	return $current;
+}
+add_filter( 'stylesheet', 'wp_theme_preview_maybe_doing_it_wrong' );
+add_filter( 'template', 'wp_theme_preview_maybe_doing_it_wrong' );
+
+/**
  * Add filters and actions to enable Block Theme Previews in the Site Editor.
  *
  * The filters and actions should be added after `pluggable.php` is included as they may


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This PR adds a `_doing_it_wrong` notice if a theme is requested too early when previewing a theme.

Trac ticket: https://core.trac.wordpress.org/ticket/59000
Related: https://github.com/WordPress/gutenberg/issues/53284

## Why 

This is a follow-up for https://github.com/WordPress/wordpress-develop/pull/5107.

The approach in https://github.com/WordPress/wordpress-develop/pull/5107, “running the filters later”, works in most cases. The one exception is the case when the site has a plugin that runs `stylesheet` or `templates` before `pluggable.php` (which means a plugin is loaded before `plugin_loaded`), AND when the plugin wants to show the previewing theme. In this case, it gets the active theme’s stylesheet (not the previewing theme), which may lead to inconsistency. 

For such a case, this PR adds a `_doing_it_wrong` notice if a theme is requested too early when previewing a theme.

## Testing

- Add a file in `wp-content/plugins/sample-plugin/sample-plugin.php` on your site.
```php
<?php
/*
Plugin Name: Sample plugin
*/

$wp_theme = wp_get_theme();
$wp_theme->get_stylesheet();
```
- Navigate to `/wp-admin/themes.php` and click the `Live Preview` button on any Block theme (e.g. Twenty Twenty-Two).
- See a notice in your `debug.php`: `Function get_stylesheet() was called <strong>incorrectly</strong>. Calling get_stylesheet() before pluggable.php has loaded can result in getting the current theme instead of the previewed theme. Please ensure that you are using these functions after the plugins_loaded action has fired if this is not intended.`


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
