### PR TITLE
wp_trim_excerpt parses and renders blocks twice  also avoid unwanted block parsing

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -944,6 +944,10 @@ function filter_block_kses_value( $value, $allowed_html, $allowed_protocols = ar
  * @return string The parsed and filtered content.
  */
 function excerpt_remove_blocks( $content ) {
+	if ( ! has_blocks( $content ) ) {
+		return $content;
+	}
+
 	$allowed_inner_blocks = array(
 		// Classic blocks have their blockName set to null.
 		null,

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -3976,22 +3976,28 @@ function wp_trim_excerpt( $text = '', $post = null ) {
 		$text = excerpt_remove_footnotes( $text );
 
 		/*
-		 * Temporarily unhook wp_filter_content_tags() since any tags
+		 * Temporarily unhook wp_filter_content_tags() and do_blocks() since any tags
 		 * within the excerpt are stripped out. Modifying the tags here
 		 * is wasteful and can lead to bugs in the image counting logic.
 		 */
-		$filter_removed = remove_filter( 'the_content', 'wp_filter_content_tags' );
+		$filter_image_removed = remove_filter( 'the_content', 'wp_filter_content_tags' );
+		$filter_block_removed = remove_filter( 'the_content', 'do_blocks', 9 );
 
 		/** This filter is documented in wp-includes/post-template.php */
 		$text = apply_filters( 'the_content', $text );
 		$text = str_replace( ']]>', ']]&gt;', $text );
+
+		// Restore the original filter if removed.
+		if ( $filter_block_removed ) {
+			add_filter( 'the_content', 'do_blocks', 9 );
+		}
 
 		/**
 		 * Only restore the filter callback if it was removed above. The logic
 		 * to unhook and restore only applies on the default priority of 10,
 		 * which is generally used for the filter callback in WordPress core.
 		 */
-		if ( $filter_removed ) {
+		if ( $filter_image_removed ) {
 			add_filter( 'the_content', 'wp_filter_content_tags' );
 		}
 

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -3997,7 +3997,7 @@ function wp_trim_excerpt( $text = '', $post = null ) {
 			add_filter( 'the_content', 'do_blocks', 9 );
 		}
 
-		/**
+		/*
 		 * Only restore the filter callback if it was removed above. The logic
 		 * to unhook and restore only applies on the default priority of 10,
 		 * which is generally used for the filter callback in WordPress core.

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -3984,7 +3984,7 @@ function wp_trim_excerpt( $text = '', $post = null ) {
 
 		/**
 		 * Temporarily unhook do_blocks() since excerpt_remove_blocks( $text )
-		 * handels block rendering need for excerpt.
+		 * handels block rendering needed for excerpt.
 		 */
 		$filter_block_removed = remove_filter( 'the_content', 'do_blocks', 9 );
 

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -3982,7 +3982,7 @@ function wp_trim_excerpt( $text = '', $post = null ) {
 		 */
 		$filter_image_removed = remove_filter( 'the_content', 'wp_filter_content_tags' );
 
-		/**
+		/*
 		 * Temporarily unhook do_blocks() since excerpt_remove_blocks( $text )
 		 * handels block rendering needed for excerpt.
 		 */

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -3976,11 +3976,16 @@ function wp_trim_excerpt( $text = '', $post = null ) {
 		$text = excerpt_remove_footnotes( $text );
 
 		/*
-		 * Temporarily unhook wp_filter_content_tags() and do_blocks() since any tags
+		 * Temporarily unhook wp_filter_content_tags() since any tags
 		 * within the excerpt are stripped out. Modifying the tags here
 		 * is wasteful and can lead to bugs in the image counting logic.
 		 */
 		$filter_image_removed = remove_filter( 'the_content', 'wp_filter_content_tags' );
+
+		/**
+		 * Temporarily unhook do_blocks() since excerpt_remove_blocks( $text )
+		 * handels block rendering need for excerpt.
+		 */
 		$filter_block_removed = remove_filter( 'the_content', 'do_blocks', 9 );
 
 		/** This filter is documented in wp-includes/post-template.php */

--- a/tests/phpunit/tests/formatting/wpTrimExcerpt.php
+++ b/tests/phpunit/tests/formatting/wpTrimExcerpt.php
@@ -153,6 +153,8 @@ class Tests_Formatting_wpTrimExcerpt extends WP_UnitTestCase {
 	 * Tests that `wp_trim_excerpt()` does process valid blocks.
 	 *
 	 * @ticket 58682
+	 *
+	 * @covers ::wp_trim_excerpt
 	 */
 	public function test_wp_trim_excerpt_check_if_block_renders() {
 		$post = self::factory()->post->create(
@@ -170,6 +172,8 @@ class Tests_Formatting_wpTrimExcerpt extends WP_UnitTestCase {
 	 * Tests that `wp_trim_excerpt()` unhooks `do_blocks()` from 'the_content' filter.
 	 *
 	 * @ticket 58682
+	 *
+	 * @covers ::wp_trim_excerpt
 	 */
 	public function test_wp_trim_excerpt_unhooks_do_blocks() {
 		$post = self::factory()->post->create();
@@ -196,6 +200,8 @@ class Tests_Formatting_wpTrimExcerpt extends WP_UnitTestCase {
 	 * Tests that `wp_trim_excerpt()` doesn't permanently unhook `do_blocks()` from 'the_content' filter.
 	 *
 	 * @ticket 58682
+	 *
+	 * @covers ::wp_trim_excerpt
 	 */
 	public function test_wp_trim_excerpt_should_not_permanently_unhook_do_blocks() {
 		$post = self::factory()->post->create();
@@ -209,6 +215,8 @@ class Tests_Formatting_wpTrimExcerpt extends WP_UnitTestCase {
 	 * Tests that `wp_trim_excerpt()` doesn't restore `do_blocks()` if it was previously unhooked.
 	 *
 	 * @ticket 58682
+	 *
+	 * @covers ::wp_trim_excerpt
 	 */
 	public function test_wp_trim_excerpt_does_not_restore_do_blocks_if_previously_unhooked() {
 		$post = self::factory()->post->create();

--- a/tests/phpunit/tests/formatting/wpTrimExcerpt.php
+++ b/tests/phpunit/tests/formatting/wpTrimExcerpt.php
@@ -150,6 +150,23 @@ class Tests_Formatting_wpTrimExcerpt extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that `wp_trim_excerpt()` does process valid blocks.
+	 *
+	 * @ticket 58682
+	 */
+	public function test_wp_trim_excerpt_check_if_block_renders() {
+		$post = self::factory()->post->create(
+			array(
+				'post_content' => '<!-- wp:paragraph --> <p>A test paragraph</p> <!-- /wp:paragraph -->',
+			)
+		);
+
+		$output_text = wp_trim_excerpt( '', $post );
+
+		$this->assertSame( 'A test paragraph', $output_text, 'wp_trim_excerpt() did not process paragraph block.' );
+	}
+
+	/**
 	 * Tests that `wp_trim_excerpt()` unhooks `do_blocks()` from 'the_content' filter.
 	 *
 	 * @ticket 58682

--- a/tests/phpunit/tests/formatting/wpTrimExcerpt.php
+++ b/tests/phpunit/tests/formatting/wpTrimExcerpt.php
@@ -148,4 +148,60 @@ class Tests_Formatting_wpTrimExcerpt extends WP_UnitTestCase {
 		// Assert that the filter callback was not restored after running 'the_content'.
 		$this->assertFalse( has_filter( 'the_content', 'wp_filter_content_tags' ) );
 	}
+
+	/**
+	 * Tests that `wp_trim_excerpt()` unhooks `do_blocks()` from 'the_content' filter.
+	 *
+	 * @ticket 58682
+	 */
+	public function test_wp_trim_excerpt_unhooks_do_blocks() {
+		$post = self::factory()->post->create();
+
+		/*
+		 * Record that during 'the_content' filter run by wp_trim_excerpt() the
+		 * do_blocks() callback is not used.
+		 */
+		$has_filter = true;
+		add_filter(
+			'the_content',
+			static function( $content ) use ( &$has_filter ) {
+				$has_filter = has_filter( 'the_content', 'do_blocks' );
+				return $content;
+			}
+		);
+
+		wp_trim_excerpt( '', $post );
+
+		$this->assertFalse( $has_filter, 'do_blocks() was not unhooked in wp_trim_excerpt()' );
+	}
+
+	/**
+	 * Tests that `wp_trim_excerpt()` doesn't permanently unhook `do_blocks()` from 'the_content' filter.
+	 *
+	 * @ticket 58682
+	 */
+	public function test_wp_trim_excerpt_should_not_permanently_unhook_do_blocks() {
+		$post = self::factory()->post->create();
+
+		wp_trim_excerpt( '', $post );
+
+		$this->assertSame( 9, has_filter( 'the_content', 'do_blocks' ), 'do_blocks() was not restored in wp_trim_excerpt()' );
+	}
+
+	/**
+	 * Tests that `wp_trim_excerpt()` doesn't restore `do_blocks()` if it was previously unhooked.
+	 *
+	 * @ticket 58682
+	 */
+	public function test_wp_trim_excerpt_does_not_restore_do_blocks_if_previously_unhooked() {
+		$post = self::factory()->post->create();
+
+		// Remove do_blocks() from 'the_content' filter generally.
+		remove_filter( 'the_content', 'do_blocks', 9 );
+
+		wp_trim_excerpt( '', $post );
+
+		// Assert that the filter callback was not restored after running 'the_content'.
+		$this->assertFalse( has_filter( 'the_content', 'do_blocks' ) );
+	}
 }


### PR DESCRIPTION
#### Performance benchmark with `trunk`

| Metric                       | trunk   | After PR |
|------------------------------|---------|----------|
| **Response Time (median)**   | 164.52  | 151.95   |
| **wp-before-template (median)** | 62.44  | 59.18    |
| **wp-template (median)**     | 98.5    | 89.83    |
| **wp-total (median)**        | 161.7   | 149.38   |




Trac ticket: [https://core.trac.wordpress.org/ticket/58682](https://core.trac.wordpress.org/ticket/58682)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
