### PR TITLE
External Libraries: Update the Requests library to version 2.0.8.

### DIFF
--- a/src/wp-includes/Requests/src/Requests.php
+++ b/src/wp-includes/Requests/src/Requests.php
@@ -148,7 +148,7 @@ class Requests {
 	 *
 	 * @var string
 	 */
-	const VERSION = '2.0.6';
+	const VERSION = '2.0.8';
 
 	/**
 	 * Selected transport name

--- a/src/wp-includes/Requests/src/Transport/Curl.php
+++ b/src/wp-includes/Requests/src/Transport/Curl.php
@@ -25,6 +25,7 @@ use WpOrg\Requests\Utility\InputValidator;
 final class Curl implements Transport {
 	const CURL_7_10_5 = 0x070A05;
 	const CURL_7_16_2 = 0x071002;
+	const CURL_7_22_0 = 0x071600;
 
 	/**
 	 * Raw HTTP data
@@ -363,7 +364,7 @@ final class Curl implements Transport {
 		$options['hooks']->dispatch('curl.before_request', [&$this->handle]);
 
 		// Force closing the connection for old versions of cURL (<7.22).
-		if (!isset($headers['Connection'])) {
+		if ($this->version < self::CURL_7_22_0 && !isset($headers['Connection'])) {
 			$headers['Connection'] = 'close';
 		}
 


### PR DESCRIPTION
This PR updates the Requests library from version 2.0.6 to 2.0.8.

Trac ticket: https://core.trac.wordpress.org/ticket/59322
