### PR TITLE
Block Themes: Ensure that `_build_block_template_result_from_file()` injects `theme` attribute

### DIFF
--- a/src/wp-content/themes/twentytwentyone/.npmrc
+++ b/src/wp-content/themes/twentytwentyone/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps = true

--- a/src/wp-content/themes/twentytwentyone/.npmrc
+++ b/src/wp-content/themes/twentytwentyone/.npmrc
@@ -1,1 +1,0 @@
-legacy-peer-deps = true

--- a/tests/phpunit/data/templates/template-with-nested-template-part.html
+++ b/tests/phpunit/data/templates/template-with-nested-template-part.html
@@ -1,0 +1,3 @@
+<!-- wp:group -->
+<!-- wp:template-part {"slug":"header","align":"full", "tagName":"header","className":"site-header"} /-->
+<!-- /wp:group -->

--- a/tests/phpunit/data/templates/template-with-template-part-with-existing-theme-attribute.html
+++ b/tests/phpunit/data/templates/template-with-template-part-with-existing-theme-attribute.html
@@ -1,0 +1,1 @@
+<!-- wp:template-part {"slug":"header","theme":"fake-theme","align":"full", "tagName":"header","className":"site-header"} /-->

--- a/tests/phpunit/data/templates/template-with-template-part.html
+++ b/tests/phpunit/data/templates/template-with-template-part.html
@@ -1,0 +1,1 @@
+<!-- wp:template-part {"slug":"header","align":"full", "tagName":"header","className":"site-header"} /-->

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -190,7 +190,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 	public function data_build_block_template_result_from_file_injects_theme_attribute() {
 		$theme = 'block-theme';
 		return array(
-			'a template with a template part block' => array(
+			'a template with a template part block'  => array(
 				'filename' => 'template-with-template-part.html',
 				'expected' => sprintf(
 					'<!-- wp:template-part {"slug":"header","align":"full","tagName":"header","className":"site-header","theme":"%s"} /-->',

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -161,6 +161,47 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		$this->assertEmpty( $template_part->modified );
 	}
 
+	/**
+	 * @dataProvider data_build_block_template_result_from_file_injects_theme_attribute
+	 */
+	public function test_build_block_template_result_from_file_injects_theme_attribute( $filename, $expected_content ) {
+		$template = _build_block_template_result_from_file(
+			array(
+				'slug' => 'single',
+				'path' => __DIR__ . '/../data/templates/' . $filename,
+			),
+			'wp_template'
+		);
+		$this->assertSame( $expected_content, $template->content );
+	}
+
+	public function data_build_block_template_result_from_file_injects_theme_attribute() {
+		$theme = 'block-theme';
+		return array(
+			array(
+				'template-with-template-part.html',
+				sprintf(
+					'<!-- wp:template-part {"slug":"header","align":"full","tagName":"header","className":"site-header","theme":"%s"} /-->',
+					$theme
+				)
+			),
+			array(
+				'template-with-nested-template-part.html',
+				sprintf(
+					'<!-- wp:group -->
+<!-- wp:template-part {"slug":"header","align":"full","tagName":"header","className":"site-header","theme":"%s"} /-->
+<!-- /wp:group -->',
+					$theme
+				)
+			),
+			array(
+				'template-with-template-part-with-existing-theme-attribute.html',
+				'<!-- wp:template-part {"slug":"header","theme":"fake-theme","align":"full", "tagName":"header","className":"site-header"} /-->'
+			),
+		);
+	}
+
+
 	public function test_inject_theme_attribute_in_block_template_content() {
 		$theme                           = get_stylesheet();
 		$content_without_theme_attribute = '<!-- wp:template-part {"slug":"header","align":"full", "tagName":"header","className":"site-header"} /-->';

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -198,6 +198,12 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 				'template-with-template-part-with-existing-theme-attribute.html',
 				'<!-- wp:template-part {"slug":"header","theme":"fake-theme","align":"full", "tagName":"header","className":"site-header"} /-->',
 			),
+			array(
+				'template.html',
+				'<!-- wp:paragraph -->
+<p>Just a paragraph</p>
+<!-- /wp:paragraph -->',
+			),
 		);
 	}
 

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -175,7 +175,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		$template = _build_block_template_result_from_file(
 			array(
 				'slug' => 'single',
-				'path' => __DIR__ . '/../data/templates/' . $filename,
+				'path' => DIR_TESTDATA . "/templates/$filename",
 			),
 			'wp_template'
 		);

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -182,6 +182,11 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		$this->assertSame( $expected, $template->content );
 	}
 
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
 	public function data_build_block_template_result_from_file_injects_theme_attribute() {
 		$theme = 'block-theme';
 		return array(

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -168,10 +168,10 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_build_block_template_result_from_file_injects_theme_attribute
 	 *
-	 * @param string $filename         The template's filename.
-	 * @param string $expected_content The expected block markup.
+	 * @param string $filename The template's filename.
+	 * @param string $expected The expected block markup.
 	 */
-	public function test_build_block_template_result_from_file_injects_theme_attribute( $filename, $expected_content ) {
+	public function test_build_block_template_result_from_file_injects_theme_attribute( $filename, $expected ) {
 		$template = _build_block_template_result_from_file(
 			array(
 				'slug' => 'single',
@@ -179,7 +179,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 			),
 			'wp_template'
 		);
-		$this->assertSame( $expected_content, $template->content );
+		$this->assertSame( $expected, $template->content );
 	}
 
 	public function data_build_block_template_result_from_file_injects_theme_attribute() {

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -219,7 +219,6 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		);
 	}
 
-
 	public function test_inject_theme_attribute_in_block_template_content() {
 		$theme                           = get_stylesheet();
 		$content_without_theme_attribute = '<!-- wp:template-part {"slug":"header","align":"full", "tagName":"header","className":"site-header"} /-->';

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -190,29 +190,29 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 	public function data_build_block_template_result_from_file_injects_theme_attribute() {
 		$theme = 'block-theme';
 		return array(
-			array(
-				'template-with-template-part.html',
-				sprintf(
+			'a template with a template part block' => array(
+				'filename' => 'template-with-template-part.html',
+				'expected' => sprintf(
 					'<!-- wp:template-part {"slug":"header","align":"full","tagName":"header","className":"site-header","theme":"%s"} /-->',
 					$theme
 				),
 			),
-			array(
-				'template-with-nested-template-part.html',
-				sprintf(
+			'a template with a template part block nested inside another block' => array(
+				'filename' => 'template-with-nested-template-part.html',
+				'expected' => sprintf(
 					'<!-- wp:group -->
 <!-- wp:template-part {"slug":"header","align":"full","tagName":"header","className":"site-header","theme":"%s"} /-->
 <!-- /wp:group -->',
 					$theme
 				),
 			),
-			array(
-				'template-with-template-part-with-existing-theme-attribute.html',
-				'<!-- wp:template-part {"slug":"header","theme":"fake-theme","align":"full", "tagName":"header","className":"site-header"} /-->',
+			'a template with a template part block with an existing theme attribute' => array(
+				'filename' => 'template-with-template-part-with-existing-theme-attribute.html',
+				'expected' => '<!-- wp:template-part {"slug":"header","theme":"fake-theme","align":"full", "tagName":"header","className":"site-header"} /-->',
 			),
-			array(
-				'template.html',
-				'<!-- wp:paragraph -->
+			'a template with no template part block' => array(
+				'filename' => 'template.html',
+				'expected' => '<!-- wp:paragraph -->
 <p>Just a paragraph</p>
 <!-- /wp:paragraph -->',
 			),

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -183,7 +183,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 				sprintf(
 					'<!-- wp:template-part {"slug":"header","align":"full","tagName":"header","className":"site-header","theme":"%s"} /-->',
 					$theme
-				)
+				),
 			),
 			array(
 				'template-with-nested-template-part.html',
@@ -192,11 +192,11 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 <!-- wp:template-part {"slug":"header","align":"full","tagName":"header","className":"site-header","theme":"%s"} /-->
 <!-- /wp:group -->',
 					$theme
-				)
+				),
 			),
 			array(
 				'template-with-template-part-with-existing-theme-attribute.html',
-				'<!-- wp:template-part {"slug":"header","theme":"fake-theme","align":"full", "tagName":"header","className":"site-header"} /-->'
+				'<!-- wp:template-part {"slug":"header","theme":"fake-theme","align":"full", "tagName":"header","className":"site-header"} /-->',
 			),
 		);
 	}

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -162,7 +162,14 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 59325
+	 *
+	 * @covers ::_build_block_template_result_from_file
+	 *
 	 * @dataProvider data_build_block_template_result_from_file_injects_theme_attribute
+	 *
+	 * @param string $filename         The template's filename.
+	 * @param string $expected_content The expected block markup.
 	 */
 	public function test_build_block_template_result_from_file_injects_theme_attribute( $filename, $expected_content ) {
 		$template = _build_block_template_result_from_file(


### PR DESCRIPTION
While we have coverage for `_inject_theme_attribute_in_block_template_content`, those tests only verify that that function does what is supposed to do; there's however no guarantee that `_build_block_template_result_from_file` uses that function (or whatever other technique) to actually inject the theme attribute ([see](https://github.com/WordPress/wordpress-develop/pull/5155)).

### Testing Instructions

- Apply the following patch first on `trunk`, and run unit tests (`npm run test:php -- --group=block-templates`). Verify that they pass (although they shouldn't) ✅ 👎 
- Then, apply the patch on top of this branch, and run unit tests again. Verify that this time, they fail. :x: 👍 
- Finally, remove the patch (or check CI for this branch): Unit tests should pass ✅ 👍 

```diff
diff --git a/src/wp-includes/block-template-utils.php b/src/wp-includes/block-template-utils.php
index b8538ee3b43e..11d4141aa342 100644
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -565,7 +565,7 @@ function _build_block_template_result_from_file( $template_file, $template_type
 	$template                 = new WP_Block_Template();
 	$template->id             = $theme . '//' . $template_file['slug'];
 	$template->theme          = $theme;
-	$template->content        = _inject_theme_attribute_in_block_template_content( $template_content );
+	$template->content        = $template_content;
 	$template->slug           = $template_file['slug'];
 	$template->source         = 'theme';
 	$template->type           = $template_type;
```

Trac ticket: https://core.trac.wordpress.org/ticket/59325

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
