### PR TITLE
Add optional callback argument to serialize_block(s)

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -796,8 +796,8 @@ function get_comment_delimited_block_content( $block_name, $block_attributes, $b
  * @since 5.3.1
  * @since 6.4.0 The `$callback` parameter was added.
  *
- * @param array  $block    A representative array of a single parsed block object. See WP_Block_Parser_Block.
- * @param string $callback Optional. Callback to run on the block before serialization. Default null.
+ * @param array         $block    A representative array of a single parsed block object. See WP_Block_Parser_Block.
+ * @param callable|null $callback Optional. Callback to run on the block before serialization. Default null.
  * @return string String of rendered HTML.
  */
 function serialize_block( $block, $callback = null ) {
@@ -830,8 +830,8 @@ function serialize_block( $block, $callback = null ) {
  * @since 5.3.1
  * @since 6.4.0 The `$callback` parameter was added.
  *
- * @param array[] $blocks   An array of representative arrays of parsed block objects. See serialize_block().
- * @param string  $callback Optional. Callback to run on the blocks before serialization. Default null.
+ * @param array[]       $blocks   An array of representative arrays of parsed block objects. See serialize_block().
+ * @param callable|null $callback Optional. Callback to run on the blocks before serialization. Default null.
  * @return string String of rendered HTML.
  */
 function serialize_blocks( $blocks, $callback = null ) {

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -797,7 +797,7 @@ function get_comment_delimited_block_content( $block_name, $block_attributes, $b
  * @since 6.4.0 The `$callback` parameter was added.
  *
  * @param array         $block    A representative array of a single parsed block object. See WP_Block_Parser_Block.
- * @param callable|null $callback Optional. Callback to run on the block before serialization. Default null.
+ * @param callable|null $callback Optional. Callback to run on each block in the tree before serialization. Default null.
  * @return string String of rendered HTML.
  */
 function serialize_block( $block, $callback = null ) {
@@ -831,7 +831,7 @@ function serialize_block( $block, $callback = null ) {
  * @since 6.4.0 The `$callback` parameter was added.
  *
  * @param array[]       $blocks   An array of representative arrays of parsed block objects. See serialize_block().
- * @param callable|null $callback Optional. Callback to run on the blocks before serialization. Default null.
+ * @param callable|null $callback Optional. Callback to run on each block in the tree before serialization. Default null.
  * @return string String of rendered HTML.
  */
 function serialize_blocks( $blocks, $callback = null ) {

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -794,16 +794,22 @@ function get_comment_delimited_block_content( $block_name, $block_attributes, $b
  * instead preserve the markup as parsed.
  *
  * @since 5.3.1
+ * @since 6.4.0 The `$callback` parameter was added.
  *
- * @param array $block A representative array of a single parsed block object. See WP_Block_Parser_Block.
+ * @param array  $block    A representative array of a single parsed block object. See WP_Block_Parser_Block.
+ * @param string $callback Optional. Callback to run on the block before serialization. Default null.
  * @return string String of rendered HTML.
  */
-function serialize_block( $block ) {
+function serialize_block( $block, $callback = null ) {
+	if ( is_callable( $callback ) ) {
+		$block = call_user_func( $callback, $block );
+	}
+
 	$block_content = '';
 
 	$index = 0;
 	foreach ( $block['innerContent'] as $chunk ) {
-		$block_content .= is_string( $chunk ) ? $chunk : serialize_block( $block['innerBlocks'][ $index++ ] );
+		$block_content .= is_string( $chunk ) ? $chunk : serialize_block( $block['innerBlocks'][ $index++ ], $callback );
 	}
 
 	if ( ! is_array( $block['attrs'] ) ) {
@@ -822,12 +828,18 @@ function serialize_block( $block ) {
  * parsed blocks.
  *
  * @since 5.3.1
+ * @since 6.4.0 The `$callback` parameter was added.
  *
- * @param array[] $blocks An array of representative arrays of parsed block objects. See serialize_block().
+ * @param array[] $blocks   An array of representative arrays of parsed block objects. See serialize_block().
+ * @param string  $callback Optional. Callback to run on the blocks before serialization. Default null.
  * @return string String of rendered HTML.
  */
-function serialize_blocks( $blocks ) {
-	return implode( '', array_map( 'serialize_block', $blocks ) );
+function serialize_blocks( $blocks, $callback = null ) {
+	$result = '';
+	foreach ( $blocks as $block ) {
+		$result .= serialize_block( $block, $callback );
+	};
+	return $result;
 }
 
 /**

--- a/tests/phpunit/tests/blocks/serialize.php
+++ b/tests/phpunit/tests/blocks/serialize.php
@@ -54,4 +54,23 @@ class Tests_Blocks_Serialize extends WP_UnitTestCase {
 		$this->assertSame( 'example', strip_core_block_namespace( 'core/example' ) );
 		$this->assertSame( 'plugin/example', strip_core_block_namespace( 'plugin/example' ) );
 	}
+
+	public function test_callback_argument() {
+		$markup = "<!-- wp:outer --><!-- wp:inner {\"key\":\"value\"} -->Example.<!-- /wp:inner -->\n\nExample.\n\n<!-- wp:void /--><!-- /wp:outer -->";
+		$blocks = parse_blocks( $markup );
+
+		$actual = serialize_blocks( $blocks, array( __CLASS__, 'add_attribute_to_inner_block' ) );
+
+		$this->assertSame(
+			"<!-- wp:outer --><!-- wp:inner {\"key\":\"value\",\"myattr\":\"myvalue\"} -->Example.<!-- /wp:inner -->\n\nExample.\n\n<!-- wp:void /--><!-- /wp:outer -->",
+			$actual
+		);
+	}
+
+	public static function add_attribute_to_inner_block( $block ) {
+		if ( 'core/inner' === $block['blockName'] ) {
+			$block['attrs']['myattr'] = 'myvalue';
+		}
+		return $block;
+	}
 }

--- a/tests/phpunit/tests/blocks/serialize.php
+++ b/tests/phpunit/tests/blocks/serialize.php
@@ -55,6 +55,11 @@ class Tests_Blocks_Serialize extends WP_UnitTestCase {
 		$this->assertSame( 'plugin/example', strip_core_block_namespace( 'plugin/example' ) );
 	}
 
+	/**
+	 * @ticket 59327
+	 *
+	 * @covers ::serialize_blocks
+	 */
 	public function test_callback_argument() {
 		$markup = "<!-- wp:outer --><!-- wp:inner {\"key\":\"value\"} -->Example.<!-- /wp:inner -->\n\nExample.\n\n<!-- wp:void /--><!-- /wp:outer -->";
 		$blocks = parse_blocks( $markup );


### PR DESCRIPTION
For some operations, we need to traverse the parsed block tree (before it is eventually serialized). In order to minimize the number of tree traversals (which is a potentially costly operation), it seems that adding a callback function argument to `serialize_block()` -- which inevitably has to traverse the entire tree anyway -- is a natural fit.

Examples where this could come in handy:
- `theme` arg injection into a block template loaded from a file.
- automatic insertion of hooked blocks (see https://core.trac.wordpress.org/ticket/59313)

Spun off from #5158.

Trac ticket: https://core.trac.wordpress.org/ticket/59327

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
