### PR TITLE
Implement 'template' filter for the block template HTML

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1184,54 +1184,16 @@ function parse_blocks( $content ) {
  * Parses dynamic blocks out of `post_content` and re-renders them.
  *
  * @since 5.0.0
- * @since 6.4.0 The $context parameter was added.
- *
- * @global WP_Query $wp_query
  *
  * @param string $content Post content.
- * @param string $context Optional. Additional context to parse blocks.
- *                        Defaults to `current_filter()` when not set.
  * @return string Updated post content.
  */
-function do_blocks( $content, $context = null ) {
-	global $wp_query;
+function do_blocks( $content ) {
+	$blocks = parse_blocks( $content );
+	$output = '';
 
-	if ( null === $context ) {
-		$context = current_filter();
-	}
-
-	/*
-	 * Most block themes omit the `core/query` and `core/post-template` blocks in their singular content templates.
-	 * While this technically still works since singular content templates are always for only one post, it results in
-	 * the main query loop never being entered which causes bugs in core and the plugin ecosystem.
-	 *
-	 * The workaround below ensures that the loop is started even for those singular templates. The while loop will by
-	 * definition only go through a single iteration, i.e. `do_blocks()` is only called once. Additional safeguard
-	 * checks are included to ensure the main query loop has not been tampered with and really only encompasses a
-	 * single post.
-	 *
-	 * Even if the block template contained a `core/query` and `core/post-template` block referencing the main query
-	 * loop, it would not cause errors since it would use a cloned instance and go through the same loop of a single
-	 * post, within the actual main query loop.
-	 */
-	if ( 'template' === $context && is_singular() && 1 === $wp_query->post_count && have_posts() ) {
-		while ( have_posts() ) {
-			the_post();
-
-			$blocks = parse_blocks( $content );
-			$output = '';
-
-			foreach ( $blocks as $block ) {
-				$output .= render_block( $block );
-			}
-		}
-	} else {
-		$blocks = parse_blocks( $content );
-		$output = '';
-
-		foreach ( $blocks as $block ) {
-			$output .= render_block( $block );
-		}
+	foreach ( $blocks as $block ) {
+		$output .= render_block( $block );
 	}
 
 	// If there are blocks in this content, we shouldn't run wpautop() on it later.

--- a/src/wp-includes/class-wp-embed.php
+++ b/src/wp-includes/class-wp-embed.php
@@ -30,7 +30,7 @@ class WP_Embed {
 	 */
 	public function __construct() {
 		// Hack to get the [embed] shortcode to run before wpautop().
-		add_filter( 'template', array( $this, 'run_shortcode' ), 6 );
+		add_filter( 'the_block_template_html', array( $this, 'run_shortcode' ), 6 );
 		add_filter( 'the_content', array( $this, 'run_shortcode' ), 8 );
 		add_filter( 'widget_text_content', array( $this, 'run_shortcode' ), 8 );
 		add_filter( 'widget_block_content', array( $this, 'run_shortcode' ), 8 );
@@ -39,7 +39,7 @@ class WP_Embed {
 		add_shortcode( 'embed', '__return_false' );
 
 		// Attempts to embed all URLs in a post.
-		add_filter( 'template', array( $this, 'autoembed' ), 6 );
+		add_filter( 'the_block_template_html', array( $this, 'autoembed' ), 6 );
 		add_filter( 'the_content', array( $this, 'autoembed' ), 8 );
 		add_filter( 'widget_text_content', array( $this, 'autoembed' ), 8 );
 		add_filter( 'widget_block_content', array( $this, 'autoembed' ), 8 );

--- a/src/wp-includes/class-wp-embed.php
+++ b/src/wp-includes/class-wp-embed.php
@@ -30,6 +30,7 @@ class WP_Embed {
 	 */
 	public function __construct() {
 		// Hack to get the [embed] shortcode to run before wpautop().
+		add_filter( 'template', array( $this, 'run_shortcode' ), 6 );
 		add_filter( 'the_content', array( $this, 'run_shortcode' ), 8 );
 		add_filter( 'widget_text_content', array( $this, 'run_shortcode' ), 8 );
 		add_filter( 'widget_block_content', array( $this, 'run_shortcode' ), 8 );
@@ -38,6 +39,7 @@ class WP_Embed {
 		add_shortcode( 'embed', '__return_false' );
 
 		// Attempts to embed all URLs in a post.
+		add_filter( 'template', array( $this, 'autoembed' ), 6 );
 		add_filter( 'the_content', array( $this, 'autoembed' ), 8 );
 		add_filter( 'widget_text_content', array( $this, 'autoembed' ), 8 );
 		add_filter( 'widget_block_content', array( $this, 'autoembed' ), 8 );

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -604,6 +604,14 @@ add_action( 'wp_footer', 'wp_enqueue_global_styles', 1 );
 // Global styles custom CSS.
 add_action( 'wp_enqueue_scripts', 'wp_enqueue_global_styles_custom_css' );
 
+// Block template.
+add_filter( 'template', 'shortcode_unautop', 7 );
+add_filter( 'template', 'do_shortcode', 8 );
+add_filter( 'template', 'do_blocks', 9 );
+add_filter( 'template', 'wptexturize' );
+add_filter( 'template', 'wp_filter_content_tags' );
+add_filter( 'template', 'convert_smilies', 20 );
+
 // Block supports, and other styles parsed and stored in the Style Engine.
 add_action( 'wp_enqueue_scripts', 'wp_enqueue_stored_styles' );
 add_action( 'wp_footer', 'wp_enqueue_stored_styles', 1 );

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -605,12 +605,12 @@ add_action( 'wp_footer', 'wp_enqueue_global_styles', 1 );
 add_action( 'wp_enqueue_scripts', 'wp_enqueue_global_styles_custom_css' );
 
 // Block template.
-add_filter( 'template', 'shortcode_unautop', 7 );
-add_filter( 'template', 'do_shortcode', 8 );
-add_filter( 'template', 'do_blocks', 9 );
-add_filter( 'template', 'wptexturize' );
-add_filter( 'template', 'wp_filter_content_tags' );
-add_filter( 'template', 'convert_smilies', 20 );
+add_filter( 'the_block_template_html', 'shortcode_unautop', 7 );
+add_filter( 'the_block_template_html', 'do_shortcode', 8 );
+add_filter( 'the_block_template_html', 'do_block_template_blocks', 9 );
+add_filter( 'the_block_template_html', 'wptexturize' );
+add_filter( 'the_block_template_html', 'wp_filter_content_tags' );
+add_filter( 'the_block_template_html', 'convert_smilies', 20 );
 
 // Block supports, and other styles parsed and stored in the Style Engine.
 add_action( 'wp_enqueue_scripts', 'wp_enqueue_stored_styles' );

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -1822,6 +1822,11 @@ function wp_lazy_loading_enabled( $tag_name, $context ) {
 function wp_filter_content_tags( $content, $context = null ) {
 	if ( null === $context ) {
 		$context = current_filter();
+
+		// For backward compatibility, continue using the 'template' context for the block template.
+		if ( 'the_block_template_html' === $context ) {
+			$context = 'template';
+		}
 	}
 
 	$add_iframe_loading_attr = wp_lazy_loading_enabled( 'iframe', $context );


### PR DESCRIPTION
See https://core.trac.wordpress.org/ticket/55996#comment:39 for context.

* Introduce a `template` filter for the block template HTML.
    * The name is based on the context that is already being used for this purpose in `wp_filter_content_tags()`, to keep parity. It is also short and concise.
* Move all hard-coded function calls to become filters, run in the same order as today.
    * The only exception is that `convert_smilies()` is now run after `wp_filter_content_tags()`, which functionally shouldn't matter since these two functions do not interfere with each other. The reason `convert_smilies()` now runs later is to get parity with how the same callback is added to `the_content`, at priority 20.
* Move the logic to conditionally wrap the parsing of block template blocks in a singular main query loop (see https://core.trac.wordpress.org/ticket/58154) into `do_blocks`, only running it for the `template` context.
    * This keeps things as they are today, however directly implemented into the main function.
    * Having context available for parsing blocks may also come in handy in the future.

Trac ticket: https://core.trac.wordpress.org/ticket/55996

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
