### PR TITLE
Replace problematic `wp_content_img_tag` filter with context-specific filter

### DIFF
--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -1901,12 +1901,31 @@ function wp_filter_content_tags( $content, $context = null ) {
 			 * Filters an img tag within the content for a given context.
 			 *
 			 * @since 6.0.0
+			 * @deprecated 6.4.0 Use {@see 'wp_img_tag_the_content'} instead.
 			 *
 			 * @param string $filtered_image Full img tag with attributes that will replace the source img tag.
 			 * @param string $context        Additional context, like the current filter name or the function name from where this was called.
 			 * @param int    $attachment_id  The image attachment ID. May be 0 in case the image is not an attachment.
 			 */
-			$filtered_image = apply_filters( 'wp_content_img_tag', $filtered_image, $context, $attachment_id );
+			$filtered_image = apply_filters_deprecated(
+				'wp_content_img_tag',
+				array( $filtered_image, $context, $attachment_id ),
+				'6.4.0',
+				'wp_img_tag_the_content'
+			);
+
+			/**
+			 * Filters an img tag within a blob of HTML for the given context.
+			 *
+			 * The dynamic portion of the hook name, `$context`, refers to the context for which the HTML is being
+			 * parsed, e.g. 'the_content' for post content or 'template' for block template content.
+			 *
+			 * @since 6.4.0
+			 *
+			 * @param string $filtered_image Full img tag with attributes that will replace the source img tag.
+			 * @param int    $attachment_id  The image attachment ID. May be 0 in case the image is not an attachment.
+			 */
+			$filtered_image = apply_filters( "wp_img_tag_{$context}", $filtered_image, $attachment_id );
 
 			if ( $filtered_image !== $match[0] ) {
 				$content = str_replace( $match[0], $filtered_image, $content );


### PR DESCRIPTION
See https://core.trac.wordpress.org/ticket/55996#comment:39 for context.

* Introduce filter `wp_img_tag_{$context}` as a replacement for the generic `wp_content_img_tag` filter. Can be used e.g. like `wp_img_tag_the_content` for post content images or `wp_img_tag_template` for block template images.
* Deprecate `wp_content_img_tag`, recommending the context specific filters instead.
    * The current/old filter should no longer be used as it can lead to problems if the developer using it is unaware of the filter being applied in different contexts. Having specific filter names per context avoids that intuitively, so that if a developer wants to modify in-post-content images, they can do so safely without having to worry about that same content being parsed again in another context.

Trac ticket: https://core.trac.wordpress.org/ticket/55996

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
