### PR TITLE
Ignore fonts upload folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ wp-tests-config.php
 
 # Files and folders that get created in wp-content
 /src/wp-content/blogs.dir
+/src/wp-content/fonts
 /src/wp-content/languages
 /src/wp-content/mu-plugins
 /src/wp-content/plugins


### PR DESCRIPTION
Adds the `/src/wp-content/fonts` directory to `.gitignore`, treating it like the plugins and uploads directories. The fonts upload storage location was most recently updated in https://github.com/WordPress/gutenberg/pull/54122.

Discussions around where to store installed fonts can be found [here](https://github.com/WordPress/gutenberg/pull/52704#discussion_r1271167455), and later [here](https://github.com/WordPress/wordpress-develop/pull/5285/files#r1342814940).

Trac ticket: https://core.trac.wordpress.org/ticket/59166

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
