### PR TITLE
Inject theme attribute during serialization

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -514,6 +514,26 @@ function _inject_theme_attribute_in_block_template_content( $template_content ) 
 }
 
 /**
+ * Injects the active theme's stylesheet as a `theme` attribute
+ * into a given template part block.
+ *
+ * @since 6.4.0
+ * @access private
+ *
+ * @param array $block a parsed block.
+ * @return array Updated block.
+ */
+function _inject_theme_attribute_in_template_part_block( $block ) {
+	if (
+		'core/template-part' === $block['blockName'] &&
+		! isset( $block['attrs']['theme'] )
+	) {
+		$block['attrs']['theme'] = get_stylesheet();
+	}
+	return $block;
+}
+
+/**
  * Parses a block template and removes the theme attribute from each template part.
  *
  * @since 5.9.0
@@ -565,7 +585,6 @@ function _build_block_template_result_from_file( $template_file, $template_type 
 	$template                 = new WP_Block_Template();
 	$template->id             = $theme . '//' . $template_file['slug'];
 	$template->theme          = $theme;
-	$template->content        = _inject_theme_attribute_in_block_template_content( $template_content );
 	$template->slug           = $template_file['slug'];
 	$template->source         = 'theme';
 	$template->type           = $template_type;
@@ -588,6 +607,9 @@ function _build_block_template_result_from_file( $template_file, $template_type 
 	if ( 'wp_template_part' === $template_type && isset( $template_file['area'] ) ) {
 		$template->area = $template_file['area'];
 	}
+
+	$blocks            = parse_blocks( $template_content );
+	$template->content = serialize_blocks( $blocks, '_inject_theme_attribute_in_template_part_block' );
 
 	return $template;
 }

--- a/tests/phpunit/data/templates/template-with-template-part-with-existing-theme-attribute.html
+++ b/tests/phpunit/data/templates/template-with-template-part-with-existing-theme-attribute.html
@@ -1,1 +1,1 @@
-<!-- wp:template-part {"slug":"header","theme":"fake-theme","align":"full", "tagName":"header","className":"site-header"} /-->
+<!-- wp:template-part {"slug":"header","theme":"fake-theme","align":"full","tagName":"header","className":"site-header"} /-->

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -231,7 +231,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 				'slug'      => 'header',
 				'align'     => 'full',
 				'tagName'   => 'header',
-				'className' => 'site-header'
+				'className' => 'site-header',
 			),
 			'innerHTML'    => '',
 			'innerContent' => array(),

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -226,7 +226,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 	 */
 	public function test_inject_theme_attribute_in_template_part_block() {
 		$template_part_block_without_theme_attribute = array(
-			'blockName'    => 'wp:template-part',
+			'blockName'    => 'core/template-part',
 			'attrs'        => array(
 				'slug'      => 'header',
 				'align'     => 'full',
@@ -240,7 +240,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 
 		$actual   = _inject_theme_attribute_in_template_part_block( $template_part_block_without_theme_attribute );
 		$expected = array(
-			'blockName'    => 'wp:template-part',
+			'blockName'    => 'core/template-part',
 			'attrs'        => array(
 				'slug'      => 'header',
 				'align'     => 'full',
@@ -256,7 +256,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 
 		// Does not inject theme when there is an existing theme attribute.
 		$template_part_block_with_existing_theme_attribute = array(
-			'blockName'    => 'wp:template-part',
+			'blockName'    => 'core/template-part',
 			'attrs'        => array(
 				'slug'      => 'header',
 				'align'     => 'full',
@@ -274,7 +274,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 
 		// Does not inject theme when there is no template part.
 		$non_template_part_block = array(
-			'blockName'    => 'wp:post-content',
+			'blockName'    => 'core/post-content',
 			'attrs'        => array(),
 			'innerHTML'    => '',
 			'innerContent' => array(),

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -252,7 +252,11 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 			'innerContent' => array(),
 			'innerBlocks'  => array(),
 		);
-		$this->assertSame( $expected, $actual );
+		$this->assertSame(
+			$expected,
+			$actual,
+			'`theme` attribute was not correctly injected in template part block.'
+		);
 
 		// Does not inject theme when there is an existing theme attribute.
 		$template_part_block_with_existing_theme_attribute = array(
@@ -270,7 +274,11 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		);
 
 		$actual = _inject_theme_attribute_in_template_part_block( $template_part_block_with_existing_theme_attribute );
-		$this->assertSame( $template_part_block_with_existing_theme_attribute, $actual );
+		$this->assertSame(
+			$template_part_block_with_existing_theme_attribute,
+			$actual,
+			'Existing `theme` attribute in template part block was not respected by attribute injection.'
+		);
 
 		// Does not inject theme when there is no template part.
 		$non_template_part_block = array(
@@ -282,7 +290,11 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		);
 
 		$actual = _inject_theme_attribute_in_template_part_block( $non_template_part_block );
-		$this->assertSame( $non_template_part_block, $actual );
+		$this->assertSame(
+			$non_template_part_block,
+			$actual,
+			'`theme` attribute injection modified non-template-part block.'
+		);
 	}
 
 	public function test_inject_theme_attribute_in_block_template_content() {

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -208,7 +208,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 			),
 			'a template with a template part block with an existing theme attribute' => array(
 				'filename' => 'template-with-template-part-with-existing-theme-attribute.html',
-				'expected' => '<!-- wp:template-part {"slug":"header","theme":"fake-theme","align":"full", "tagName":"header","className":"site-header"} /-->',
+				'expected' => '<!-- wp:template-part {"slug":"header","theme":"fake-theme","align":"full","tagName":"header","className":"site-header"} /-->',
 			),
 			'a template with no template part block' => array(
 				'filename' => 'template.html',

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -219,6 +219,72 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * @ticket 59338
+	 *
+	 * @covers ::test_inject_theme_attribute_in_template_part_block
+	 */
+	public function test_inject_theme_attribute_in_template_part_block() {
+		$template_part_block_without_theme_attribute = array(
+			'blockName'    => 'wp:template-part',
+			'attrs'        => array(
+				'slug'      => 'header',
+				'align'     => 'full',
+				'tagName'   => 'header',
+				'className' => 'site-header'
+			),
+			'innerHTML'    => '',
+			'innerContent' => array(),
+			'innerBlocks'  => array(),
+		);
+
+		$actual   = _inject_theme_attribute_in_template_part_block( $template_part_block_without_theme_attribute );
+		$expected = array(
+			'blockName'    => 'wp:template-part',
+			'attrs'        => array(
+				'slug'      => 'header',
+				'align'     => 'full',
+				'tagName'   => 'header',
+				'className' => 'site-header',
+				'theme'     => get_stylesheet(),
+			),
+			'innerHTML'    => '',
+			'innerContent' => array(),
+			'innerBlocks'  => array(),
+		);
+		$this->assertSame( $expected, $actual );
+
+		// Does not inject theme when there is an existing theme attribute.
+		$template_part_block_with_existing_theme_attribute = array(
+			'blockName'    => 'wp:template-part',
+			'attrs'        => array(
+				'slug'      => 'header',
+				'align'     => 'full',
+				'tagName'   => 'header',
+				'className' => 'site-header',
+				'theme'     => 'fake-theme',
+			),
+			'innerHTML'    => '',
+			'innerContent' => array(),
+			'innerBlocks'  => array(),
+		);
+
+		$actual = _inject_theme_attribute_in_template_part_block( $template_part_block_with_existing_theme_attribute );
+		$this->assertSame( $template_part_block_with_existing_theme_attribute, $actual );
+
+		// Does not inject theme when there is no template part.
+		$non_template_part_block = array(
+			'blockName'    => 'wp:post-content',
+			'attrs'        => array(),
+			'innerHTML'    => '',
+			'innerContent' => array(),
+			'innerBlocks'  => array(),
+		);
+
+		$actual = _inject_theme_attribute_in_template_part_block( $non_template_part_block );
+		$this->assertSame( $non_template_part_block, $actual );
+	}
+
 	public function test_inject_theme_attribute_in_block_template_content() {
 		$theme                           = get_stylesheet();
 		$content_without_theme_attribute = '<!-- wp:template-part {"slug":"header","align":"full", "tagName":"header","className":"site-header"} /-->';


### PR DESCRIPTION
Rather than using `_inject_theme_attribute_in_block_template_content` to inject the `theme` attribute into all Template Part blocks found in a given file-based Block Template, introduce a new function tentatively called `_inject_theme_attribute_in_template_part_block`, and use that as second argument to `serialize_blocks()` (introduced in #5187) in order to inject said attribute during tree traversal for serialization.

This allows for a more modular approach that will eventually be extended to implement automatic insertion of hooked blocks ([see](https://core.trac.wordpress.org/ticket/59313)).

Note that we're guarding `_build_block_template_result_from_file()` (i.e. the callsite of `_inject_theme_attribute_in_template_part_block` and previously of `_inject_theme_attribute_in_block_template_content`) against regressions through additional unit test coverage added in #5186.

Trac ticket: https://core.trac.wordpress.org/ticket/59338

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
