### PR TITLE
Ensure Twenty Twenty JS continues to load in head in WP<6.3

### DIFF
--- a/src/wp-content/themes/twentytwenty/functions.php
+++ b/src/wp-content/themes/twentytwenty/functions.php
@@ -215,13 +215,13 @@ function twentytwenty_register_scripts() {
 		wp_enqueue_script( 'comment-reply' );
 	}
 
-	wp_enqueue_script(
-		'twentytwenty-js',
-		get_template_directory_uri() . '/assets/js/index.js',
-		array(),
-		$theme_version,
-		false // Because involves header. The $args array is not used here to avoid unintentional footer placement in WP<6.3.
-	);
+	/*
+	 * This script is intentionally printed in the head because it involves the page header. The `defer` script loading
+	 * strategy ensures that it does not block rendering; being in the head it will start loading earlier so that it
+	 * will execute sooner once the DOM has loaded. The $args array is not used here to avoid unintentional footer
+	 * placement in WP<6.3; the wp_script_add_data() call is used instead.
+	 */
+	wp_enqueue_script( 'twentytwenty-js', get_template_directory_uri() . '/assets/js/index.js', array(), $theme_version );
 	wp_script_add_data( 'twentytwenty-js', 'strategy', 'defer' );
 }
 

--- a/src/wp-content/themes/twentytwenty/functions.php
+++ b/src/wp-content/themes/twentytwenty/functions.php
@@ -220,11 +220,9 @@ function twentytwenty_register_scripts() {
 		get_template_directory_uri() . '/assets/js/index.js',
 		array(),
 		$theme_version,
-		array(
-			'in_footer' => false, // Because involves header.
-			'strategy'  => 'defer',
-		)
+		false // Because involves header. The $args array is not used here to avoid unintentional footer placement in WP<6.3.
 	);
+	wp_script_add_data( 'twentytwenty-js', 'strategy', 'defer' );
 }
 
 add_action( 'wp_enqueue_scripts', 'twentytwenty_register_scripts' );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/59316

# Commit Message

Bundled Themes: Ensure Twenty Twenty's main script loads in `head` for WP<6.3.

Amends [56556].
Props westonruter, flixos90, peterwilsoncc.
Fixes #59316.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
