### PR TITLE
WIP: HTML API: Extract previous text and HTML chunks while processing.

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1916,7 +1916,6 @@ class WP_HTML_Tag_Processor {
 	public function get_previous_text_chunk() {
 		if ( $this->bytes_already_parsed >= strlen( $this->html ) ) {
 			$chunk = substr( $this->html, $this->last_position->end === 0 ? 0 : $this->last_position->end + 1 );
-			$chunk = preg_replace( '/<[^a-z].*>/i', '', $chunk );
 			return html_entity_decode( $chunk, ENT_HTML5 | ENT_QUOTES | ENT_SUBSTITUTE );
 		}
 
@@ -1927,7 +1926,6 @@ class WP_HTML_Tag_Processor {
 		$chunk_start = $this->last_position->end === 0 ? 0 : $this->last_position->end + 1;
 		$chunk_end   = $this->is_tag_closer() ? $this->tag_name_starts_at - 2 : $this->tag_name_starts_at - 1;
 		$chunk       = substr( $this->html, $chunk_start, $chunk_end - $chunk_start );
-		$chunk = preg_replace( '/<[^a-z].*>/i', '', $chunk );
 		return html_entity_decode( $chunk, ENT_HTML5 | ENT_QUOTES | ENT_SUBSTITUTE );
 	}
 

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -379,6 +379,15 @@ class WP_HTML_Tag_Processor {
 	private $is_closing_tag;
 
 	/**
+	 * Stores the position of the last-matched tag, or the start of the document if not matched yet.
+	 *
+	 * @var WP_HTML_Span
+	 */
+	private $last_position = null;
+
+	private $last_token_end = 0;
+
+	/**
 	 * Lazily-built index of attributes found within an HTML tag, keyed by the attribute name.
 	 *
 	 * Example:
@@ -507,6 +516,8 @@ class WP_HTML_Tag_Processor {
 	 */
 	public function __construct( $html ) {
 		$this->html = $html;
+
+		$this->last_position = new WP_HTML_Span( 0, 0 );
 	}
 
 	/**
@@ -529,6 +540,16 @@ class WP_HTML_Tag_Processor {
 	public function next_tag( $query = null ) {
 		$this->parse_query( $query );
 		$already_found = 0;
+
+		if ( null !== $this->tag_name_starts_at ) {
+			$rewind_amount = $this->is_closing_tag ? 2 : 1;
+			$before_tag    = $this->tag_name_starts_at - $rewind_amount;
+			$end_of_tag    = $this->tag_ends_at;
+
+			$this->last_position->start = $before_tag;
+			$this->last_position->end   = $end_of_tag;
+			$this->last_token_end       = $this->tag_ends_at + 1;
+		}
 
 		do {
 			if ( $this->bytes_already_parsed >= strlen( $this->html ) ) {
@@ -1874,6 +1895,74 @@ class WP_HTML_Tag_Processor {
 	 */
 	public function is_tag_closer() {
 		return $this->is_closing_tag;
+	}
+
+	/**
+	 * Returns the chunk of text from the end of the preceding tag or token to the
+	 * start of the matched tag or token, with decoded character references.
+	 *
+	 * Example:
+	 *
+	 *     $q = array( 'tag_closers' => 'visit' );
+	 *     $processor = new WP_HTML_Tag_Processor( 'Before<div>Inside</div>After' );
+	 *     $processor->next_tag( $q ); 'Before' === $processor->get_prev_text_chunk();
+	 *     $processor->next_tag( $q ); 'Inside' === $processor->get_prev_text_chunk();
+	 *     $processor->next_tag( $q ); 'After'  === $processor->get_prev_text_chunk();
+	 *
+	 * @since 6.4.0
+	 *
+	 * @return string|null Chunk of text from end of last token to current token, or NULL if not yet matched.
+	 */
+	public function get_previous_text_chunk() {
+		if ( $this->bytes_already_parsed >= strlen( $this->html ) ) {
+			$chunk = substr( $this->html, $this->last_position->end === 0 ? 0 : $this->last_position->end + 1 );
+			$chunk = preg_replace( '/<[^a-z].*>/i', '', $chunk );
+			return html_entity_decode( $chunk, ENT_HTML5 | ENT_QUOTES | ENT_SUBSTITUTE );
+		}
+
+		if ( ! $this->tag_name_starts_at ) {
+			return null;
+		}
+
+		$chunk_start = $this->last_position->end === 0 ? 0 : $this->last_position->end + 1;
+		$chunk_end   = $this->is_tag_closer() ? $this->tag_name_starts_at - 2 : $this->tag_name_starts_at - 1;
+		$chunk       = substr( $this->html, $chunk_start, $chunk_end - $chunk_start );
+		$chunk = preg_replace( '/<[^a-z].*>/i', '', $chunk );
+		return html_entity_decode( $chunk, ENT_HTML5 | ENT_QUOTES | ENT_SUBSTITUTE );
+	}
+
+	/**
+	 * Returns the chunk of html from the start of the preceding tag or token to the
+	 * start of the matched tag or token, without decoded character references.
+	 *
+	 * Example:
+	 *
+	 *     $q = array( 'tag_closers' => 'visit' );
+	 *     $processor = new WP_HTML_Tag_Processor( 'Before<div>Inside</div>After' );
+	 *     $processor->next_tag( $q ); 'Before'       === $processor->get_prev_text_chunk();
+	 *     $processor->next_tag( $q ); '<div>Inside'  === $processor->get_prev_text_chunk();
+	 *     $processor->next_tag( $q ); '</div>After'  === $processor->get_prev_text_chunk();
+	 *
+	 * @since 6.4.0
+	 *
+	 * @return array|null Chunk of text from end of last token to current token, or NULL if not yet matched.
+	 */
+	public function get_previous_html_chunk() {
+		if ( $this->bytes_already_parsed >= strlen( $this->html ) ) {
+			$html = substr( $this->html, $this->last_position->start, $this->last_token_end - $this->last_position->start );
+			$text = substr( $this->html, $this->last_token_end );
+
+			return array( $html, $text );
+		}
+
+		if ( ! $this->tag_name_starts_at ) {
+			return null;
+		}
+
+		$html = substr( $this->html, $this->last_position->start, $this->last_token_end - $this->last_position->start );
+		$text = substr( $this->html, $this->last_token_end, ( $this->is_tag_closer() ? $this->tag_name_starts_at - 2 : $this->tag_name_starts_at - 1 ) - $this->last_token_end );
+
+		return array( $html, $text );
 	}
 
 	/**

--- a/tests/phpunit/tests/html-api/wpHtmlProcessor-stringBuilder.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessor-stringBuilder.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Unit tests covering WP_HTML_Processor string building functionality.
+ *
+ * @package WordPress
+ * @subpackage HTML-API
+ */
+
+/**
+ * @group html-api
+ *
+ * @coversDefaultClass WP_HTML_Processor
+ */
+class Tests_HtmlApi_WpHtmlProcessor_StringBuilder extends WP_UnitTestCase {
+	/**
+	 * @ticket {TICKET_NUMBER}
+	 *
+	 * @dataProvider data_html_and_associated_text_content
+	 *
+	 * @param string $html         HTML containing text that should be extracted.
+	 * @param string $text_content Plaintext content represented inside the given HTML.
+	 */
+	public function test_extracts_text_chunks_properly( $html, $text_content ) {
+		$processor = new WP_HTML_Tag_Processor( $html );
+
+		$extracted_text_content = '';
+		while ( $processor->next_tag( array( 'tag_closers' => 'visit' ) ) ) {
+			$extracted_text_content .= $processor->get_previous_text_chunk();
+		}
+		$extracted_text_content .= $processor->get_previous_text_chunk();
+
+		$this->assertEquals( $text_content, $extracted_text_content, 'Extracted unexpected text content.' );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[].
+	 */
+	public function data_html_and_associated_text_content() {
+		return array(
+			'Basic text without HTML.'               => array( 'This is plain text.', 'This is plain text.' ),
+			'Basic text with a character reference.' => array( 'A &lt; B', 'A < B' ),
+			'Text before tag.'                       => array( 'Before<img>', 'Before' ),
+			'Text after tag.'                        => array( '<img>After', 'After' ),
+			'Text inside tag.'                       => array( '<div>Inside</div>', 'Inside' ),
+			'Text around tag.'                       => array( 'In <em>the</em> jungle.', 'In the jungle.' ),
+			'Text interrupted by many tags.'         => array( 'A <em>wild <a><img><span>adventure</span></a> awaits.', 'A wild adventure awaits.' ),
+			'Text with comment inside it.'           => array( 'Ignore <!-- everything inside this --> comment.', 'Ignore  comment.' ),
+			'Text with empty comment inside it.'     => array( 'Ignore <!--> comment.', 'Ignore  comment.' ),
+			'Text with invalid comment inside it.'   => array( 'Ignore </^$%> comment.', 'Ignore  comment.' ),
+			'Skipping SCRIPT content.'               => array( '<div>This <script>does not exist</script> in the output.', 'This  in the output.' ),
+		);
+	}
+
+	/**
+	 * @ticket {TICKET_NUMBER}
+	 *
+	 * @dataProvider data_html_and_associated_html_content
+	 *
+	 * @param string $html            HTML containing text that should be extracted.
+	 * @param int    $max_code_points Stop iterating after this many code points have been extracted.
+	 * @param string $html_content    Full HTML containing text of max code point length from input.
+	 */
+	public function test_extracts_html_chunks_properly( $html, $max_code_points, $html_content ) {
+		$processor = new WP_HTML_Tag_Processor( $html );
+
+		$code_points            = 0;
+		$extracted_html_content = '';
+		while ( $processor->next_tag( array( 'tag_closers' => 'visit' ) ) ) {
+			$text_chunk = $processor->get_previous_text_chunk();
+			$chunk_cps           = mb_strlen( $text_chunk );
+			list( $html, $text ) = $processor->get_previous_html_chunk();
+			$extracted_html_content .= $html;
+			if ( 0 === $max_code_points || $code_points + $chunk_cps <= $max_code_points ) {
+				$extracted_html_content .= $text;
+				$code_points            += $chunk_cps;
+			} else {
+				break;
+			}
+		}
+
+		$text_chunk = $processor->get_previous_text_chunk();
+		$chunk_cps  = mb_strlen( $text_chunk );
+		list( $html, $text ) = $processor->get_previous_html_chunk();
+		$extracted_html_content .= $html;
+		if ( 0 === $max_code_points || $code_points + $chunk_cps <= $max_code_points ) {
+			$extracted_html_content .= $text;
+		}
+
+		$this->assertEquals( $html_content, $extracted_html_content, 'Extracted unexpected HTML content.' );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[].
+	 */
+	public function data_html_and_associated_html_content() {
+		return array(
+			'Basic text without HTML.'               => array( 'This is plain text.', 0, 'This is plain text.' ),
+			'Basic text without HTML (too long).'    => array( 'This is plain text.', 8, '' ),
+			'Basic text with a character reference.' => array( 'A &lt; B', 0, 'A &lt; B' ),
+			'Character reference wider than text'    => array( 'A &lt; B', 5, 'A &lt; B' ),
+			'Text before tag.'                       => array( 'Before<img>', 0, 'Before<img>' ),
+			'Text after tag.'                        => array( '<img>After', 0, '<img>After' ),
+			'Text inside tag.'                       => array( '<div>Inside</div>', 0, '<div>Inside</div>' ),
+			'Text around tag.'                       => array( 'In <em>the</em> jungle.', 0, 'In <em>the</em> jungle.' ),
+			'Text interrupted by many tags.'         => array( 'A <em>wild <a><img><span>adventure</span></a> awaits.', 0, 'A <em>wild <a><img><span>adventure</span></a> awaits.' ),
+			'Text interrupted by many tags (long).'  => array( 'A <em>wild <a><img><span>adventure</span></a> awaits.', 16, 'A <em>wild <a><img><span>adventure</span></a>' ),
+			'Text with comment inside it.'           => array( 'Ignore <!-- everything inside this --> comment.', 0, 'Ignore <!-- everything inside this --> comment.' ),
+		);
+	}
+}


### PR DESCRIPTION
## Notes

The motivation for this was to create something like `strip_tags()` or `wp_strip_all_tags()` but which can be limited to a given length, also can be used to create an excerpt of a document that preserves the HTML up to a given text length.

Consider you want to [create a post excerpt with up to 200 words](https://github.com/WordPress/wordpress-develop/pull/5208/commits/e3d35cfd24752f645388cc8443c31e326de175db).

```php
$excerpt_text = '';
$excerpt      = '';
while ( $processor->next_tag() ) {
	$text = $processor->get_prev_text_chunk();
	if ( word_count( $excerpt + $text ) > $excerpt_length ) {
		break;
	}

	$excerpt_text .= $text;
	// This will be better, but for now the array is necessary, ignore it.
	list( $html_stuff, $text_stuff ) = $processor->get_prev_html_chunk();
	$excerpt .= $html_stuff . $text_stuff;
}

return $excerpt;
```

Now this is neato because we've only parsed the input HTML up until the point where the `.textContent`/`.innerText` contains 200 words. In addition to that, we've preserved the HTML formatting that appeared up to and around those 200 words.

```php
$excerpt = get_excerpt( '<div>this  is a <em>&x1F622; shame</em> to be missing</div>', 5, 'words' );
$except === '<div>this is a <em>&x1F622; shame</em>';
```

Furthermore if all we want to do is run `strip_tags()` and get a plaintext form of the document we get that too.

```php
$processor = new WP_HTML_Tag_Processor( '<div>this is a <em>&x1F622; shame</em> to be missing</div>' );

$text = '';
while ( $processor->next_tag( $visit_everything ) ) {
	$text .= $processor->get_prev_text_chunk();
}
$text .= $processor->get_prev_text_chunk();

$text === 'this is a 😢 shame to be missing';
```

This explores the low-level primitives necessary to make this possible.

## Description

The HTML API should be able to provide the ability to generate excerpts from HTML documents given a specific maximum length.

In this patch we're exploring the addition of text and HTML chunks that can be extracted while processing in order to do just this. The text chunks are similar to `.textContent` on the DOM while the HTML chunks contain raw and unprocessed HTML.

These functions should likely remain low-level in the Tag Processor and be exposed from the HTML Processor to ensure that proper semantics are heeded when extracting this information, such as how `PRE` tags ignore a leading newline inside their content or how `SCRIPT` and `STYLE` content isn't part of what we want with something like `strip_tags()`.

In the process of this work it's evident again that the Tag Processor ought to expose the ability to visit every token and non-tag tokens should be classified. This has already been explored in dmsnell/wordpress-develop#7.

cc: @westonruter @ockham 