### PR TITLE
Excerpt length fix for admin-ajax requests.

### DIFF
--- a/src/wp-includes/blocks/post-excerpt.php
+++ b/src/wp-includes/blocks/post-excerpt.php
@@ -83,7 +83,7 @@ add_action( 'init', 'register_block_core_post_excerpt' );
  * the excerpt length block setting has no effect.
  * Returns 100 because 100 is the max length in the setting.
  */
-if ( is_admin() ||
+if ( is_admin() && ! wp_doing_ajax() ||
 	defined( 'REST_REQUEST' ) && REST_REQUEST ) {
 	add_filter(
 		'excerpt_length',


### PR DESCRIPTION
Trac Ticket: [59350](https://core.trac.wordpress.org/ticket/59350)

This PR adds an additional check for `wp_doing_ajax()` to allow custom `excerpt_length` hooks in themes and plugins to run on the frontend when being called via `admin-ajax`. 

The code in the following file was introduced around 6.3 and appears to be a global hook that doesn't consider `admin-ajax` frontend requests.
https://github.com/WordPress/WordPress/blob/master/wp-includes/blocks/post-excerpt.php#L86-L95