### PR TITLE
Blocks: Refactor the check against self for block hooks

### DIFF
--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -522,20 +522,6 @@ class WP_Block_Type {
 		$args = apply_filters( 'register_block_type_args', $args, $this->name );
 
 		foreach ( $args as $property_name => $property_value ) {
-			// Avoid infinite recursion in block hooks (hooking to itself).
-			if ( 'block_hooks' === $property_name ) {
-				if ( ! is_array( $property_value ) ) {
-					continue;
-				}
-				if ( array_key_exists( $this->name, $property_value ) ) {
-					_doing_it_wrong(
-						__METHOD__,
-						__( 'Cannot hook block to itself.' ),
-						'6.4.0'
-					);
-					unset( $property_value[ $this->name ] );
-				}
-			}
 			$this->$property_name = $property_value;
 		}
 	}

--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -523,13 +523,18 @@ class WP_Block_Type {
 
 		foreach ( $args as $property_name => $property_value ) {
 			// Avoid infinite recursion in block hooks (hooking to itself).
-			if ( 'block_hooks' === $property_name && array_key_exists( $this->name, $property_value ) ) {
-				_doing_it_wrong(
-					__METHOD__,
-					__( 'Cannot hook block to itself.' ),
-					'6.4.0'
-				);
-				unset( $property_value[ $this->name ] );
+			if ( 'block_hooks' === $property_name ) {
+				if ( ! is_array( $property_value ) ) {
+					continue;
+				}
+				if ( array_key_exists( $this->name, $property_value ) ) {
+					_doing_it_wrong(
+						__METHOD__,
+						__( 'Cannot hook block to itself.' ),
+						'6.4.0'
+					);
+					unset( $property_value[ $this->name ] );
+				}
 			}
 			$this->$property_name = $property_value;
 		}

--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -522,6 +522,15 @@ class WP_Block_Type {
 		$args = apply_filters( 'register_block_type_args', $args, $this->name );
 
 		foreach ( $args as $property_name => $property_value ) {
+			// Avoid infinite recursion in block hooks (hooking to itself).
+			if ( 'block_hooks' === $property_name && array_key_exists( $this->name, $property_value ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					__( 'Cannot hook block to itself.' ),
+					'6.4.0'
+				);
+				unset( $property_value[ $this->name ] );
+			}
 			$this->$property_name = $property_value;
 		}
 	}

--- a/tests/phpunit/data/blocks/hooked-block-error/block.json
+++ b/tests/phpunit/data/blocks/hooked-block-error/block.json
@@ -1,0 +1,8 @@
+{
+	"name": "tests/hooked-block-error",
+	"description": "A block that throws an error because it tries to hook a block to itself.",
+	"blockHooks": {
+		"tests/hooked-block-error": "before",
+		"tests/other-block": "after"
+	}
+}

--- a/tests/phpunit/data/blocks/notice/block.json
+++ b/tests/phpunit/data/blocks/notice/block.json
@@ -31,7 +31,10 @@
 		"root": ".wp-block-notice"
 	},
 	"blockHooks": {
-		"core/post-content": "before"
+		"tests/before": "before",
+		"tests/after": "after",
+		"tests/first-child": "firstChild",
+		"tests/last-child": "lastChild"
 	},
 	"supports": {
 		"align": true,

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -645,8 +645,13 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 			'Block type should contain selectors from metadata.'
 		);
 		// @ticket 59346
-		$this->assertSame(
-			array( 'core/post-content' => 'before' ),
+		$this->assertSameSets(
+			array(
+				'tests/before'      => 'before',
+				'tests/after'       => 'after',
+				'tests/first-child' => 'first_child',
+				'tests/last-child'  => 'last_child',
+			),
 			$result->block_hooks,
 			'Block type should contain block hooks from metadata.'
 		);
@@ -1068,5 +1073,30 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 
 		$actual = register_block_style( 'core/query', $block_styles );
 		$this->assertTrue( $actual );
+	}
+
+	/**
+	 * @ticket 59346
+	 *
+	 * @covers ::register_block_type
+	 *
+	 * @expectedIncorrectUsage WP_Block_Type::set_props
+	 */
+	public function test_register_block_hooks_targeting_itself() {
+		$block_name = 'tests/block-name';
+		$block_type = register_block_type(
+			$block_name,
+			array(
+				'block_hooks' => array(
+					$block_name         => 'first',
+					'tests/other-block' => 'last',
+				),
+			)
+		);
+
+		$this->assertSameSets(
+			array( 'tests/other-block' => 'last' ),
+			$block_type->block_hooks
+		 );
 	}
 }

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -1097,6 +1097,6 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 		$this->assertSameSets(
 			array( 'tests/other-block' => 'last' ),
 			$block_type->block_hooks
-		 );
+		);
 	}
 }

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -1080,22 +1080,15 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 	 *
 	 * @covers ::register_block_type
 	 *
-	 * @expectedIncorrectUsage WP_Block_Type::set_props
+	 * @expectedIncorrectUsage register_block_type_from_metadata
 	 */
 	public function test_register_block_hooks_targeting_itself() {
-		$block_name = 'tests/block-name';
 		$block_type = register_block_type(
-			$block_name,
-			array(
-				'block_hooks' => array(
-					$block_name         => 'first',
-					'tests/other-block' => 'last',
-				),
-			)
+			DIR_TESTDATA . '/blocks/hooked-block-error'
 		);
 
-		$this->assertSameSets(
-			array( 'tests/other-block' => 'last' ),
+		$this->assertSame(
+			array( 'tests/other-block' => 'after' ),
 			$block_type->block_hooks
 		);
 	}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/59346


I added some refactorings discussed in https://github.com/WordPress/wordpress-develop/pull/5203#pullrequestreview-1626828337:
- ~https://github.com/WordPress/wordpress-develop/pull/5203#discussion_r1326102815 - `gutenberg` text domain remove~ committed with https://core.trac.wordpress.org/changeset/56592.
- There is custom logic for mapping `blockHooks` to `block_hooks` when handling metadata. I covered that part in unit tests.
- One last bit of feedback was for the _doing_it_wrong logic. I moved the check to the `WP_Block_Type` class to cover also the case when someone registers the block with a regular `register_block_type` call without using metadata file.
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
