### PR TITLE
Fix post editor layout when content block has no attributes.

### DIFF
--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -414,7 +414,7 @@ function wp_get_first_block( $blocks, $block_name ) {
  *
  * @global int $post_ID
  *
- * @return array Post Content block attributes or empty array if they don't exist.
+ * @return array|null Post Content block attributes array or null if Post Content block doesn't exist.
  */
 function wp_get_post_content_block_attributes() {
 	global $post_ID;
@@ -422,7 +422,7 @@ function wp_get_post_content_block_attributes() {
 	$is_block_theme = wp_is_block_theme();
 
 	if ( ! $is_block_theme || ! $post_ID ) {
-		return array();
+		return null;
 	}
 
 	$template_slug = get_page_template_slug( $post_ID );

--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -409,7 +409,7 @@ function wp_get_first_block( $blocks, $block_name ) {
  * Retrieves Post Content block attributes from the current post template.
  *
  * @since 6.3.0
- * @since 6.4.0 return null by default and return empty array when Post Content block exists. but has no attributes.
+ * @since 6.4.0 return null by default or an empty array when the Post Content block exists but has no attributes.
  * @access private
  *
  * @global int $post_ID

--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -409,6 +409,7 @@ function wp_get_first_block( $blocks, $block_name ) {
  * Retrieves Post Content block attributes from the current post template.
  *
  * @since 6.3.0
+ * @since 6.4.0 return null by default and return empty array when Post Content block exists. but has no attributes.
  * @access private
  *
  * @global int $post_ID
@@ -462,7 +463,7 @@ function wp_get_post_content_block_attributes() {
 		}
 	}
 
-	return array();
+	return null;
 }
 
 /**

--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -457,7 +457,7 @@ function wp_get_post_content_block_attributes() {
 		$template_blocks    = parse_blocks( $current_template[0]->content );
 		$post_content_block = wp_get_first_block( $template_blocks, 'core/post-content' );
 
-		if ( ! empty( $post_content_block['attrs'] ) ) {
+		if ( isset( $post_content_block['attrs'] ) ) {
 			return $post_content_block['attrs'];
 		}
 	}
@@ -635,7 +635,7 @@ function get_block_editor_settings( array $custom_settings, $block_editor_contex
 
 	$post_content_block_attributes = wp_get_post_content_block_attributes();
 
-	if ( ! empty( $post_content_block_attributes ) ) {
+	if ( isset( $post_content_block_attributes ) ) {
 		$editor_settings['postContentAttributes'] = $post_content_block_attributes;
 	}
 

--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -409,7 +409,7 @@ function wp_get_first_block( $blocks, $block_name ) {
  * Retrieves Post Content block attributes from the current post template.
  *
  * @since 6.3.0
- * @since 6.4.0 return null by default or an empty array when the Post Content block exists but has no attributes.
+ * @since 6.4.0 Return null if there is no post content block.
  * @access private
  *
  * @global int $post_ID

--- a/tests/phpunit/data/themedir1/block-theme-post-content-default/style.css
+++ b/tests/phpunit/data/themedir1/block-theme-post-content-default/style.css
@@ -1,0 +1,7 @@
+/*
+Theme Name: Block Theme Post Content Default
+Theme URI: https://wordpress.org/
+Description: For testing purposes only.
+Version: 1.0.0
+Text Domain: block-theme-post-content-default
+*/

--- a/tests/phpunit/data/themedir1/block-theme-post-content-default/templates/index.html
+++ b/tests/phpunit/data/themedir1/block-theme-post-content-default/templates/index.html
@@ -1,0 +1,3 @@
+<!-- wp:paragraph -->
+<p>Index Template</p>
+<!-- /wp:paragraph -->

--- a/tests/phpunit/data/themedir1/block-theme-post-content-default/templates/single.html
+++ b/tests/phpunit/data/themedir1/block-theme-post-content-default/templates/single.html
@@ -1,0 +1,2 @@
+<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} /-->
+<!-- wp:post-content /-->

--- a/tests/phpunit/data/themedir1/block-theme-post-content-default/theme.json
+++ b/tests/phpunit/data/themedir1/block-theme-post-content-default/theme.json
@@ -1,0 +1,104 @@
+{
+	"version": 1,
+	"title": "Block theme",
+	"settings": {
+		"color": {
+			"palette": [
+				{
+					"slug": "light",
+					"name": "Light",
+					"color": "#f5f7f9"
+				},
+				{
+					"slug": "dark",
+					"name": "Dark",
+					"color": "#000"
+				}
+			],
+			"gradients": [
+				{
+					"name": "Custom gradient",
+					"gradient": "linear-gradient(135deg,rgba(0,0,0) 0%,rgb(0,0,0) 100%)",
+					"slug": "custom-gradient"
+				}
+			],
+			"duotone": [
+				{
+					"colors": [ "#333333", "#aaaaaa" ],
+					"slug": "custom-duotone",
+					"name": "Custom Duotone"
+				}
+			],
+			"custom": false,
+			"customGradient": false
+		},
+		"typography": {
+			"fontSizes": [
+				{
+					"name": "Custom",
+					"slug": "custom",
+					"size": "100px"
+				}
+			],
+			"customFontSize": false,
+			"customLineHeight": true
+		},
+		"spacing": {
+			"units": ["rem"],
+			"customPadding": true,
+			"blockGap": true
+		},
+		"blocks": {
+			"core/paragraph": {
+				"color": {
+					"palette": [
+						{
+							"slug": "light",
+							"name": "Light",
+							"color": "#f5f7f9"
+						}
+					]
+				}
+			}
+		}
+	},
+	"styles" : {
+		"blocks" :{
+			"core/post-featured-image": {
+				"shadow": "10px 10px 5px 0px rgba(0,0,0,0.66)",
+				"filter": {
+					"duotone": "var(--wp--preset--duotone--custom-duotone)"
+				}
+			}
+		},
+		"elements": {
+			"button": {
+				"shadow": "10px 10px 5px 0px rgba(0,0,0,0.66)"
+			},
+			"link": {
+				"typography": {
+					"textDecoration": "none"
+				},
+				"border": {
+					"bottom": {
+						"width": "2px",
+						"color": "currentColor",
+						"style": "solid"
+					}
+				},
+				":hover": {
+					"typography": {
+						"textDecoration": "none"
+					},
+					"border": {
+						"bottom": {
+							"width": "2px",
+							"color": "#000",
+							"style": "dotted"
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/tests/phpunit/tests/blocks/editor.php
+++ b/tests/phpunit/tests/blocks/editor.php
@@ -455,11 +455,9 @@ class Tests_Blocks_Editor extends WP_UnitTestCase {
 	}
 
 	public function test_wp_get_post_content_block_attributes_no_layout() {
-		$attributes_empty = array();
-
 		switch_theme( 'block-theme-post-content-default' );
 
-		$this->assertSame( $attributes_empty, wp_get_post_content_block_attributes() );
+		$this->assertSame( array(), wp_get_post_content_block_attributes() );
 	}
 
 	/**

--- a/tests/phpunit/tests/blocks/editor.php
+++ b/tests/phpunit/tests/blocks/editor.php
@@ -454,6 +454,14 @@ class Tests_Blocks_Editor extends WP_UnitTestCase {
 		$this->assertSame( $attributes_with_layout, wp_get_post_content_block_attributes() );
 	}
 
+	public function test_wp_get_post_content_block_attributes_no_layout() {
+		$attributes_empty = array();
+
+		switch_theme( 'block-theme-post-content-default' );
+
+		$this->assertSame( $attributes_empty, wp_get_post_content_block_attributes() );
+	}
+
 	/**
 	 * @ticket 53458
 	 */

--- a/tests/phpunit/tests/blocks/editor.php
+++ b/tests/phpunit/tests/blocks/editor.php
@@ -447,7 +447,7 @@ class Tests_Blocks_Editor extends WP_UnitTestCase {
 			),
 		);
 		// With no block theme, expect an empty array.
-		$this->assertSame( array(), wp_get_post_content_block_attributes() );
+		$this->assertSame( null, wp_get_post_content_block_attributes() );
 
 		switch_theme( 'block-theme' );
 

--- a/tests/phpunit/tests/blocks/editor.php
+++ b/tests/phpunit/tests/blocks/editor.php
@@ -534,6 +534,19 @@ class Tests_Blocks_Editor extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 59358
+	 */
+	public function test_get_block_editor_settings_without_post_content_block() {
+
+		$post_editor_context = new WP_Block_Editor_Context( array( 'post' => get_post() ) );
+
+		$settings = get_block_editor_settings( array(), $post_editor_context );
+
+		$this->assertArrayNotHasKey( 'postContentAttributes', $settings );
+
+	}
+
+	/**
 	 * @ticket 52920
 	 * @expectedDeprecated block_editor_settings
 	 */

--- a/tests/phpunit/tests/blocks/editor.php
+++ b/tests/phpunit/tests/blocks/editor.php
@@ -446,7 +446,7 @@ class Tests_Blocks_Editor extends WP_UnitTestCase {
 				'type' => 'constrained',
 			),
 		);
-		// With no block theme, expect an empty array.
+		// With no block theme, expect null.
 		$this->assertNull( wp_get_post_content_block_attributes() );
 
 		switch_theme( 'block-theme' );

--- a/tests/phpunit/tests/blocks/editor.php
+++ b/tests/phpunit/tests/blocks/editor.php
@@ -447,7 +447,7 @@ class Tests_Blocks_Editor extends WP_UnitTestCase {
 			),
 		);
 		// With no block theme, expect an empty array.
-		$this->assertSame( null, wp_get_post_content_block_attributes() );
+		$this->assertNull( wp_get_post_content_block_attributes() );
 
 		switch_theme( 'block-theme' );
 

--- a/tests/phpunit/tests/theme/themeDir.php
+++ b/tests/phpunit/tests/theme/themeDir.php
@@ -184,6 +184,7 @@ class Tests_Theme_ThemeDir extends WP_UnitTestCase {
 			'Block Theme [0.4.0]',
 			'Block Theme [1.0.0] in subdirectory',
 			'Block Theme Deprecated Path',
+			'Block Theme Post Content Default',
 			'Block Theme with defined Typography Fonts',
 			'Empty `fontFace` in theme.json - no webfonts defined',
 			'A theme with the Update URI header',


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/59358

This PR syncs the changes from https://github.com/WordPress/gutenberg/pull/54485 and adds a test for the Post Content block with empty attributes.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
