### PR TITLE
Administration: Use `wp_admin_notice()` in `/wp-includes/`.

### DIFF
--- a/src/wp-includes/media-template.php
+++ b/src/wp-includes/media-template.php
@@ -375,7 +375,13 @@ function wp_print_media_templates() {
 		<div class="attachment-media-view {{ data.orientation }}">
 			<?php
 			if ( isset( $_GET['error'] ) && 'deprecated' === $_GET['error'] ) {
-				echo '<div id="message" class="error notice"><p>' . __( 'The Edit Media screen is deprecated as of WordPress 6.3. Please use the Media Library instead.' ) . '</p></div>';
+				wp_admin_notice(
+					__( 'The Edit Media screen is deprecated as of WordPress 6.3. Please use the Media Library instead.' ),
+					array(
+						'id'                 => 'message',
+						'additional_classes' => array( 'error' ),
+					)
+				);
 			}
 			?>
 			<h2 class="screen-reader-text"><?php /* translators: Hidden accessibility text. */ _e( 'Attachment Preview' ); ?></h2>

--- a/src/wp-includes/widgets/class-wp-widget-media-audio.php
+++ b/src/wp-includes/widgets/class-wp-widget-media-audio.php
@@ -189,13 +189,25 @@ class WP_Widget_Media_Audio extends WP_Widget_Media {
 		?>
 		<script type="text/html" id="tmpl-wp-media-widget-audio-preview">
 			<# if ( data.error && 'missing_attachment' === data.error ) { #>
-				<div class="notice notice-error notice-alt notice-missing-attachment">
-					<p><?php echo $this->l10n['missing_attachment']; ?></p>
-				</div>
+				<?php
+				wp_admin_notice(
+					$this->l10n['missing_attachment'],
+					array(
+						'type'               => 'error',
+						'additional_classes' => array( 'notice-alt', 'notice-missing-attachment' ),
+					)
+				);
+				?>
 			<# } else if ( data.error ) { #>
-				<div class="notice notice-error notice-alt">
-					<p><?php _e( 'Unable to preview media due to an unknown error.' ); ?></p>
-				</div>
+				<?php
+				wp_admin_notice(
+					__( 'Unable to preview media due to an unknown error.' ),
+					array(
+						'type'               => 'error',
+						'additional_classes' => array( 'notice-alt' ),
+					)
+				);
+				?>
 			<# } else if ( data.model && data.model.src ) { #>
 				<?php wp_underscore_audio_template(); ?>
 			<# } #>

--- a/src/wp-includes/widgets/class-wp-widget-media-image.php
+++ b/src/wp-includes/widgets/class-wp-widget-media-image.php
@@ -363,13 +363,25 @@ class WP_Widget_Media_Image extends WP_Widget_Media {
 		</script>
 		<script type="text/html" id="tmpl-wp-media-widget-image-preview">
 			<# if ( data.error && 'missing_attachment' === data.error ) { #>
-				<div class="notice notice-error notice-alt notice-missing-attachment">
-					<p><?php echo $this->l10n['missing_attachment']; ?></p>
-				</div>
+				<?php
+				wp_admin_notice(
+					$this->l10n['missing_attachment'],
+					array(
+						'type'               => 'error',
+						'additional_classes' => array( 'notice-alt', 'notice-missing-attachment' ),
+					)
+				);
+				?>
 			<# } else if ( data.error ) { #>
-				<div class="notice notice-error notice-alt">
-					<p><?php _e( 'Unable to preview media due to an unknown error.' ); ?></p>
-				</div>
+				<?php
+				wp_admin_notice(
+					__( 'Unable to preview media due to an unknown error.' ),
+					array(
+						'type'               => 'error',
+						'additional_classes' => array( 'notice-alt' ),
+					)
+				);
+				?>
 			<# } else if ( data.url ) { #>
 				<img class="attachment-thumb" src="{{ data.url }}" draggable="false" alt="{{ data.alt }}"
 					<# if ( ! data.alt && data.currentFilename ) { #>

--- a/src/wp-includes/widgets/class-wp-widget-media-video.php
+++ b/src/wp-includes/widgets/class-wp-widget-media-video.php
@@ -228,17 +228,35 @@ class WP_Widget_Media_Video extends WP_Widget_Media {
 		?>
 		<script type="text/html" id="tmpl-wp-media-widget-video-preview">
 			<# if ( data.error && 'missing_attachment' === data.error ) { #>
-				<div class="notice notice-error notice-alt notice-missing-attachment">
-					<p><?php echo $this->l10n['missing_attachment']; ?></p>
-				</div>
+				<?php
+				wp_admin_notice(
+					$this->l10n['missing_attachment'],
+					array(
+						'type'               => 'error',
+						'additional_classes' => array( 'notice-alt', 'notice-missing-attachment' ),
+					)
+				);
+				?>
 			<# } else if ( data.error && 'unsupported_file_type' === data.error ) { #>
-				<div class="notice notice-error notice-alt notice-missing-attachment">
-					<p><?php echo $this->l10n['unsupported_file_type']; ?></p>
-				</div>
+				<?php
+				wp_admin_notice(
+					$this->l10n['unsupported_file_type'],
+					array(
+						'type'               => 'error',
+						'additional_classes' => array( 'notice-alt', 'notice-missing-attachment' ),
+					)
+				);
+				?>
 			<# } else if ( data.error ) { #>
-				<div class="notice notice-error notice-alt">
-					<p><?php _e( 'Unable to preview media due to an unknown error.' ); ?></p>
-				</div>
+				<?php
+				wp_admin_notice(
+					__( 'Unable to preview media due to an unknown error.' ),
+					array(
+						'type'               => 'error',
+						'additional_classes' => array( 'notice-alt' ),
+					)
+				);
+				?>
 			<# } else if ( data.is_oembed && data.model.poster ) { #>
 				<a href="{{ data.model.src }}" target="_blank" class="media-widget-video-link">
 					<img src="{{ data.model.poster }}" />

--- a/src/wp-includes/widgets/class-wp-widget-text.php
+++ b/src/wp-includes/widgets/class-wp-widget-text.php
@@ -495,13 +495,21 @@ class WP_Widget_Text extends WP_Widget {
 				<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title:' ); ?></label>
 				<input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo esc_attr( $instance['title'] ); ?>" />
 			</p>
-			<div class="notice inline notice-info notice-alt">
-				<?php if ( ! isset( $instance['visual'] ) ) : ?>
-					<p><?php _e( 'This widget may contain code that may work better in the &#8220;Custom HTML&#8221; widget. How about trying that widget instead?' ); ?></p>
-				<?php else : ?>
-					<p><?php _e( 'This widget may have contained code that may work better in the &#8220;Custom HTML&#8221; widget. If you have not yet, how about trying that widget instead?' ); ?></p>
-				<?php endif; ?>
-			</div>
+			<?php
+			if ( ! isset( $instance['visual'] ) ) {
+				$widget_info_message = __( 'This widget may contain code that may work better in the &#8220;Custom HTML&#8221; widget. How about trying that widget instead?' );
+			} else {
+				$widget_info_message = __( 'This widget may have contained code that may work better in the &#8220;Custom HTML&#8221; widget. If you have not yet, how about trying that widget instead?' );
+			}
+
+			wp_admin_notice(
+				$widget_info_message,
+				array(
+					'type'               => 'info',
+					'additional_classes' => array( 'notice-alt', 'inline' ),
+				)
+			);
+			?>
 			<p>
 				<label for="<?php echo $this->get_field_id( 'text' ); ?>"><?php _e( 'Content:' ); ?></label>
 				<textarea class="widefat" rows="16" cols="20" id="<?php echo $this->get_field_id( 'text' ); ?>" name="<?php echo $this->get_field_name( 'text' ); ?>"><?php echo esc_textarea( $instance['text'] ); ?></textarea>


### PR DESCRIPTION
Adds further usages of `wp_admin_notice()` in the root level of `/wp-includes/` on `.error` and `.notice-info`.

Ongoing task to implement new function across core.

Trac ticket: https://core.trac.wordpress.org/ticket/57791