### PR TITLE
Administration: Use `wp_admin_notice()` in `/wp-admin/includes/`.

### DIFF
--- a/src/wp-admin/includes/class-bulk-upgrader-skin.php
+++ b/src/wp-admin/includes/class-bulk-upgrader-skin.php
@@ -143,10 +143,16 @@ class Bulk_Upgrader_Skin extends WP_Upgrader_Skin {
 		echo '</p></div>';
 		if ( $this->error || ! $this->result ) {
 			if ( $this->error ) {
-				echo '<div class="error"><p>' . sprintf( $this->upgrader->strings['skin_update_failed_error'], $title, '<strong>' . $this->error . '</strong>' ) . '</p></div>';
+				$after_error_message = sprintf( $this->upgrader->strings['skin_update_failed_error'], $title, '<strong>' . $this->error . '</strong>' );
 			} else {
-				echo '<div class="error"><p>' . sprintf( $this->upgrader->strings['skin_update_failed'], $title ) . '</p></div>';
+				$after_error_message = sprintf( $this->upgrader->strings['skin_update_failed'], $title );
 			}
+			wp_admin_notice(
+				$after_error_message,
+				array(
+					'additional_classes' => array( 'error' ),
+				)
+			);
 
 			echo '<script type="text/javascript">jQuery(\'#progress-' . esc_js( $this->upgrader->update_current ) . '\').show();</script>';
 		}

--- a/src/wp-admin/includes/class-custom-background.php
+++ b/src/wp-admin/includes/class-custom-background.php
@@ -256,16 +256,20 @@ class Custom_Background {
 		}
 
 		if ( ! empty( $this->updated ) ) {
-			?>
-<div id="message" class="updated">
-	<p>
-			<?php
-			/* translators: %s: Home URL. */
-			printf( __( 'Background updated. <a href="%s">Visit your site</a> to see how it looks.' ), esc_url( home_url( '/' ) ) );
-			?>
-	</p>
-</div>
-		<?php } ?>
+			$updated_message = sprintf(
+				/* translators: %s: Home URL. */
+				__( 'Background updated. <a href="%s">Visit your site</a> to see how it looks.' ),
+				esc_url( home_url( '/' ) )
+			);
+			wp_admin_notice(
+				$updated_message,
+				array(
+					'id'                 => 'message',
+					'additional_classes' => array( 'updated' ),
+				)
+			);
+		}
+		?>
 
 <h2><?php _e( 'Background Image' ); ?></h2>
 

--- a/src/wp-admin/includes/class-custom-image-header.php
+++ b/src/wp-admin/includes/class-custom-image-header.php
@@ -524,18 +524,22 @@ class Custom_Image_Header {
 				)
 			);
 		}
-		?>
 
-		<?php if ( ! empty( $this->updated ) ) { ?>
-<div id="message" class="updated">
-	<p>
-			<?php
-			/* translators: %s: Home URL. */
-			printf( __( 'Header updated. <a href="%s">Visit your site</a> to see how it looks.' ), esc_url( home_url( '/' ) ) );
-			?>
-	</p>
-</div>
-		<?php } ?>
+		if ( ! empty( $this->updated ) ) {
+			$updated_message = sprintf(
+				/* translators: %s: Home URL. */
+				__( 'Header updated. <a href="%s">Visit your site</a> to see how it looks.' ),
+				esc_url( home_url( '/' ) )
+			);
+			wp_admin_notice(
+				$updated_message,
+				array(
+					'id'                 => 'message',
+					'additional_classes' => array( 'updated' ),
+				)
+			);
+		}
+		?>
 
 <h2><?php _e( 'Header Image' ); ?></h2>
 

--- a/src/wp-admin/includes/class-wp-plugin-install-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugin-install-list-table.php
@@ -290,10 +290,17 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 	/**
 	 */
 	public function no_items() {
-		if ( isset( $this->error ) ) { ?>
-			<div class="inline error"><p><?php echo $this->error->get_error_message(); ?></p>
-				<p class="hide-if-no-js"><button class="button try-again"><?php _e( 'Try Again' ); ?></button></p>
-			</div>
+		if ( isset( $this->error ) ) {
+			$error_message  = '<p>' . $this->error->get_error_message() . '</p>';
+			$error_message .= '<p class="hide-if-no-js"><button class="button try-again">' . __( 'Try Again' ) . '</button></p>';
+			wp_admin_notice(
+				$error_message,
+				array(
+					'additional_classes' => array( 'inline', 'error' ),
+					'paragraph_wrap'     => false,
+				)
+			);
+			?>
 		<?php } else { ?>
 			<div class="no-plugin-results"><?php _e( 'No plugins found. Try a different search.' ); ?></div>
 			<?php

--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -1282,56 +1282,64 @@ class WP_Plugins_List_Table extends WP_List_Table {
 			printf(
 				'<tr class="plugin-update-tr">' .
 				'<td colspan="%s" class="plugin-update colspanchange">' .
-				'<div class="update-message notice inline notice-error notice-alt"><p>',
 				esc_attr( $this->get_column_count() )
 			);
 
+			$incompatible_message = '';
 			if ( ! $compatible_php && ! $compatible_wp ) {
-				_e( 'This plugin does not work with your versions of WordPress and PHP.' );
+				$incompatible_message .= __( 'This plugin does not work with your versions of WordPress and PHP.' );
 				if ( current_user_can( 'update_core' ) && current_user_can( 'update_php' ) ) {
-					printf(
+					$incompatible_message .= sprintf(
 						/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
 						' ' . __( '<a href="%1$s">Please update WordPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
 						self_admin_url( 'update-core.php' ),
 						esc_url( wp_get_update_php_url() )
 					);
-					wp_update_php_annotation( '</p><p><em>', '</em>' );
+					$incompatible_message .= wp_update_php_annotation( '</p><p><em>', '</em>', false );
 				} elseif ( current_user_can( 'update_core' ) ) {
-					printf(
+					$incompatible_message .= sprintf(
 						/* translators: %s: URL to WordPress Updates screen. */
 						' ' . __( '<a href="%s">Please update WordPress</a>.' ),
 						self_admin_url( 'update-core.php' )
 					);
 				} elseif ( current_user_can( 'update_php' ) ) {
-					printf(
+					$incompatible_message .= sprintf(
 						/* translators: %s: URL to Update PHP page. */
 						' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
 						esc_url( wp_get_update_php_url() )
 					);
-					wp_update_php_annotation( '</p><p><em>', '</em>' );
+					$incompatible_message .= wp_update_php_annotation( '</p><p><em>', '</em>', false );
 				}
 			} elseif ( ! $compatible_wp ) {
-				_e( 'This plugin does not work with your version of WordPress.' );
+				$incompatible_message .= __( 'This plugin does not work with your version of WordPress.' );
 				if ( current_user_can( 'update_core' ) ) {
-					printf(
+					$incompatible_message .= sprintf(
 						/* translators: %s: URL to WordPress Updates screen. */
 						' ' . __( '<a href="%s">Please update WordPress</a>.' ),
 						self_admin_url( 'update-core.php' )
 					);
 				}
 			} elseif ( ! $compatible_php ) {
-				_e( 'This plugin does not work with your version of PHP.' );
+				$incompatible_message .= __( 'This plugin does not work with your version of PHP.' );
 				if ( current_user_can( 'update_php' ) ) {
-					printf(
+					$incompatible_message .= sprintf(
 						/* translators: %s: URL to Update PHP page. */
 						' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
 						esc_url( wp_get_update_php_url() )
 					);
-					wp_update_php_annotation( '</p><p><em>', '</em>' );
+					$incompatible_message .= wp_update_php_annotation( '</p><p><em>', '</em>', false );
 				}
 			}
 
-			echo '</p></div></td></tr>';
+			wp_admin_notice(
+				$incompatible_message,
+				array(
+					'type'               => 'error',
+					'additional_classes' => array( 'notice-alt', 'inline', 'update-message' ),
+				)
+			);
+
+			echo '</td></tr>';
 		}
 
 		/**

--- a/src/wp-admin/includes/class-wp-privacy-policy-content.php
+++ b/src/wp-admin/includes/class-wp-privacy-policy-content.php
@@ -138,19 +138,20 @@ final class WP_Privacy_Policy_Content {
 			return;
 		}
 
-		?>
-		<div class="policy-text-updated notice notice-warning is-dismissible">
-			<p>
-			<?php
-				printf(
-					/* translators: %s: Privacy Policy Guide URL. */
-					__( 'The suggested privacy policy text has changed. Please <a href="%s">review the guide</a> and update your privacy policy.' ),
-					esc_url( admin_url( 'privacy-policy-guide.php?tab=policyguide' ) )
-				);
-			?>
-			</p>
-		</div>
-		<?php
+		$privacy_message = sprintf(
+			/* translators: %s: Privacy Policy Guide URL. */
+			__( 'The suggested privacy policy text has changed. Please <a href="%s">review the guide</a> and update your privacy policy.' ),
+			esc_url( admin_url( 'privacy-policy-guide.php?tab=policyguide' ) )
+		);
+
+		wp_admin_notice(
+			$privacy_message,
+			array(
+				'type'               => 'warning',
+				'additional_classes' => array( 'policy-text-updated' ),
+				'dismissible'        => true,
+			)
+		);
 	}
 
 	/**

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -573,9 +573,16 @@ function wp_dashboard_quick_press( $error_msg = false ) {
 
 	<form name="post" action="<?php echo esc_url( admin_url( 'post.php' ) ); ?>" method="post" id="quick-press" class="initial-form hide-if-no-js">
 
-		<?php if ( $error_msg ) : ?>
-		<div class="error"><?php echo $error_msg; ?></div>
-		<?php endif; ?>
+		<?php
+		if ( $error_msg ) {
+			wp_admin_notice(
+				$error_msg,
+				array(
+					'additional_classes' => array( 'error' ),
+				)
+			);
+		}
+		?>
 
 		<div class="input-text-wrap" id="title-wrap">
 			<label for="title">
@@ -1157,8 +1164,15 @@ function wp_dashboard_rss_output( $widget_id ) {
  * @return bool True on success, false on failure.
  */
 function wp_dashboard_cached_rss_widget( $widget_id, $callback, $check_urls = array(), ...$args ) {
-	$loading    = '<p class="widget-loading hide-if-no-js">' . __( 'Loading&hellip;' ) . '</p><div class="hide-if-js notice notice-error inline"><p>' . __( 'This widget requires JavaScript.' ) . '</p></div>';
 	$doing_ajax = wp_doing_ajax();
+	$loading    = '<p class="widget-loading hide-if-no-js">' . __( 'Loading&hellip;' ) . '</p>';
+	$loading   .= wp_get_admin_notice(
+		__( 'This widget requires JavaScript.' ),
+		array(
+			'type'               => 'error',
+			'additional_classes' => array( 'inline', 'hide-if-js' ),
+		)
+	);
 
 	if ( empty( $check_urls ) ) {
 		$widgets = get_option( 'dashboard_widget_options' );
@@ -1340,25 +1354,19 @@ function wp_dashboard_events_news() {
  * @since 4.8.0
  */
 function wp_print_community_events_markup() {
-	?>
+	$community_events_notice  = '<p class="hide-if-js">' . ( 'This widget requires JavaScript.' ) . '</p>';
+	$community_events_notice .= '<p class="community-events-error-occurred" aria-hidden="true">' . __( 'An error occurred. Please try again.' ) . '</p>';
+	$community_events_notice .= '<p class="community-events-could-not-locate" aria-hidden="true"></p>';
 
-	<div class="community-events-errors notice notice-error inline hide-if-js">
-		<p class="hide-if-js">
-			<?php _e( 'This widget requires JavaScript.' ); ?>
-		</p>
+	wp_admin_notice(
+		$community_events_notice,
+		array(
+			'type'               => 'error',
+			'additional_classes' => array( 'community-events-errors', 'inline', 'hide-if-js' ),
+			'paragraph_wrap'     => false,
+		)
+	);
 
-		<p class="community-events-error-occurred" aria-hidden="true">
-			<?php _e( 'An error occurred. Please try again.' ); ?>
-		</p>
-
-		<p class="community-events-could-not-locate" aria-hidden="true"></p>
-	</div>
-
-	<div class="community-events-loading hide-if-no-js">
-		<?php _e( 'Loading&hellip;' ); ?>
-	</div>
-
-	<?php
 	/*
 	 * Hide the main element when the page first loads, because the content
 	 * won't be ready until wp.communityEvents.renderEventsTemplate() has run.

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -2426,7 +2426,13 @@ function request_filesystem_credentials( $form_post, $type = '', $error = false,
 		if ( is_wp_error( $error ) ) {
 			$error_string = esc_html( $error->get_error_message() );
 		}
-		echo '<div id="message" class="error"><p>' . $error_string . '</p></div>';
+		wp_admin_notice(
+			$error_string,
+			array(
+				'id'                 => 'message',
+				'additional_classes' => array( 'error' ),
+			)
+		);
 	}
 
 	$types = array();

--- a/src/wp-admin/includes/ms.php
+++ b/src/wp-admin/includes/ms.php
@@ -692,11 +692,20 @@ function site_admin_notice() {
 	}
 
 	if ( (int) get_site_option( 'wpmu_upgrade_site' ) !== $wp_db_version ) {
-		echo "<div class='update-nag notice notice-warning inline'>" . sprintf(
+		$upgrade_network_message = sprintf(
 			/* translators: %s: URL to Upgrade Network screen. */
 			__( 'Thank you for Updating! Please visit the <a href="%s">Upgrade Network</a> page to update all your sites.' ),
 			esc_url( network_admin_url( 'upgrade.php' ) )
-		) . '</div>';
+		);
+
+		wp_admin_notice(
+			$upgrade_network_message,
+			array(
+				'type'               => 'warning',
+				'additional_classes' => array( 'update-nag', 'inline' ),
+				'paragraph_wrap'     => false,
+			)
+		);
 	}
 }
 

--- a/src/wp-admin/includes/nav-menu.php
+++ b/src/wp-admin/includes/nav-menu.php
@@ -1437,7 +1437,13 @@ function wp_nav_menu_update_menu_items( $nav_menu_selected_id, $nav_menu_selecte
 			);
 
 			if ( is_wp_error( $menu_item_db_id ) ) {
-				$messages[] = '<div id="message" class="error"><p>' . $menu_item_db_id->get_error_message() . '</p></div>';
+				$messages[] = wp_get_admin_notice(
+					$menu_item_db_id->get_error_message(),
+					array(
+						'id'                 => 'message',
+						'additional_classes' => array( 'error' ),
+					)
+				);
 			} else {
 				unset( $menu_items[ $menu_item_db_id ] );
 			}

--- a/src/wp-admin/includes/network.php
+++ b/src/wp-admin/includes/network.php
@@ -183,6 +183,7 @@ function network_step1( $errors = false ) {
 			$network_created_error_message,
 			array(
 				'additional_classes' => array( 'error' ),
+				'paragraph_wrap'     => false,
 			)
 		);
 		$error_codes = $errors->get_error_codes();

--- a/src/wp-admin/includes/network.php
+++ b/src/wp-admin/includes/network.php
@@ -113,11 +113,20 @@ function network_step1( $errors = false ) {
 	global $is_apache;
 
 	if ( defined( 'DO_NOT_UPGRADE_GLOBAL_TABLES' ) ) {
-		echo '<div class="error"><p><strong>' . __( 'Error:' ) . '</strong> ' . sprintf(
+		$cannot_define_constant_message  = '<strong>' . __( 'Error:' ) . '</strong> ';
+		$cannot_define_constant_message .= sprintf(
 			/* translators: %s: DO_NOT_UPGRADE_GLOBAL_TABLES */
 			__( 'The constant %s cannot be defined when creating a network.' ),
 			'<code>DO_NOT_UPGRADE_GLOBAL_TABLES</code>'
-		) . '</p></div>';
+		);
+
+		wp_admin_notice(
+			$cannot_define_constant_message,
+			array(
+				'additional_classes' => array( 'error' ),
+			)
+		);
+
 		echo '</div>';
 		require_once ABSPATH . 'wp-admin/admin-footer.php';
 		die();
@@ -142,7 +151,13 @@ function network_step1( $errors = false ) {
 	$hostname  = get_clean_basedomain();
 	$has_ports = strstr( $hostname, ':' );
 	if ( ( false !== $has_ports && ! in_array( $has_ports, array( ':80', ':443' ), true ) ) ) {
-		echo '<div class="error"><p><strong>' . __( 'Error:' ) . '</strong> ' . __( 'You cannot install a network of sites with your server address.' ) . '</p></div>';
+		wp_admin_notice(
+			'<strong>' . __( 'Error:' ) . '</strong> ' . __( 'You cannot install a network of sites with your server address.' ),
+			array(
+				'additional_classes' => array( 'error' ),
+			)
+		);
+
 		echo '<p>' . sprintf(
 			/* translators: %s: Port number. */
 			__( 'You cannot use port numbers such as %s.' ),
@@ -160,11 +175,16 @@ function network_step1( $errors = false ) {
 
 	$error_codes = array();
 	if ( is_wp_error( $errors ) ) {
-		echo '<div class="error"><p><strong>' . __( 'Error: The network could not be created.' ) . '</strong></p>';
+		$network_created_error_message = '<p><strong>' . __( 'Error: The network could not be created.' ) . '</strong></p>';
 		foreach ( $errors->get_error_messages() as $error ) {
-			echo "<p>$error</p>";
+			$network_created_error_message .= "<p>$error</p>";
 		}
-		echo '</div>';
+		wp_admin_notice(
+			$network_created_error_message,
+			array(
+				'additional_classes' => array( 'error' ),
+			)
+		);
 		$error_codes = $errors->get_error_codes();
 	}
 
@@ -195,33 +215,39 @@ function network_step1( $errors = false ) {
 		$subdomain_install = false;
 		$got_mod_rewrite   = got_mod_rewrite();
 		if ( $got_mod_rewrite ) { // Dangerous assumptions.
-			echo '<div class="updated inline"><p><strong>' . __( 'Note:' ) . '</strong> ';
-			printf(
+			$message_class = 'updated';
+			$message       = '<p><strong>' . __( 'Warning:' ) . '</strong> ';
+			$message      .= '<p>' . sprintf(
 				/* translators: %s: mod_rewrite */
 				__( 'Please make sure the Apache %s module is installed as it will be used at the end of this installation.' ),
 				'<code>mod_rewrite</code>'
-			);
-			echo '</p>';
+			) . '</p>';
 		} elseif ( $is_apache ) {
-			echo '<div class="error inline"><p><strong>' . __( 'Warning:' ) . '</strong> ';
-			printf(
+			$message_class = 'error';
+			$message       = '<p><strong>' . __( 'Warning:' ) . '</strong> ';
+			$message      .= sprintf(
 				/* translators: %s: mod_rewrite */
 				__( 'It looks like the Apache %s module is not installed.' ),
 				'<code>mod_rewrite</code>'
-			);
-			echo '</p>';
+			) . '</p>';
 		}
 
 		if ( $got_mod_rewrite || $is_apache ) { // Protect against mod_rewrite mimicry (but ! Apache).
-			echo '<p>';
-			printf(
+			$message .= '<p>' . sprintf(
 				/* translators: 1: mod_rewrite, 2: mod_rewrite documentation URL, 3: Google search for mod_rewrite. */
 				__( 'If %1$s is disabled, ask your administrator to enable that module, or look at the <a href="%2$s">Apache documentation</a> or <a href="%3$s">elsewhere</a> for help setting it up.' ),
 				'<code>mod_rewrite</code>',
 				'https://httpd.apache.org/docs/mod/mod_rewrite.html',
 				'https://www.google.com/search?q=apache+mod_rewrite'
+			) . '</p>';
+
+			wp_admin_notice(
+				$message,
+				array(
+					'additional_classes' => array( $message_class, 'inline' ),
+					'paragraph_wrap'     => false,
+				)
 			);
-			echo '</p></div>';
 		}
 	}
 
@@ -263,7 +289,14 @@ function network_step1( $errors = false ) {
 	endif;
 
 	if ( WP_CONTENT_DIR !== ABSPATH . 'wp-content' && ( allow_subdirectory_install() || ! allow_subdomain_install() ) ) {
-		echo '<div class="error inline"><p><strong>' . __( 'Warning:' ) . '</strong> ' . __( 'Subdirectory networks may not be fully compatible with custom wp-content directories.' ) . '</p></div>';
+		$subdirectory_warning_message  = '<strong>' . __( 'Warning:' ) . '</strong> ';
+		$subdirectory_warning_message .= __( 'Subdirectory networks may not be fully compatible with custom wp-content directories.' );
+		wp_admin_notice(
+			$subdirectory_warning_message,
+			array(
+				'additional_classes' => array( 'error', 'inline' ),
+			)
+		);
 	}
 
 	$is_www = str_starts_with( $hostname, 'www.' );
@@ -409,7 +442,12 @@ function network_step2( $errors = false ) {
 
 	// Wildcard DNS message.
 	if ( is_wp_error( $errors ) ) {
-		echo '<div class="error">' . $errors->get_error_message() . '</div>';
+		wp_admin_notice(
+			$errors->get_error_message(),
+			array(
+				'additional_classes' => array( 'error' ),
+			)
+		);
 	}
 
 	if ( $_POST ) {
@@ -426,8 +464,14 @@ function network_step2( $errors = false ) {
 			<?php
 		} else {
 			$subdomain_install = (bool) $wpdb->get_var( "SELECT meta_value FROM $wpdb->sitemeta WHERE site_id = 1 AND meta_key = 'subdomain_install'" );
+
+			wp_admin_notice(
+				'<strong>' . __( 'Warning:' ) . '</strong> ' . __( 'An existing WordPress network was detected.' ),
+				array(
+					'additional_classes' => array( 'error' ),
+				)
+			);
 			?>
-	<div class="error"><p><strong><?php _e( 'Warning:' ); ?></strong> <?php _e( 'An existing WordPress network was detected.' ); ?></p></div>
 	<p><?php _e( 'Please complete the configuration steps. To create a new network, you will need to empty or remove the network database tables.' ); ?></p>
 			<?php
 		}

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -1013,10 +1013,15 @@ function wp_import_upload_form( $action ) {
 	$size       = size_format( $bytes );
 	$upload_dir = wp_upload_dir();
 	if ( ! empty( $upload_dir['error'] ) ) :
-		?>
-		<div class="error"><p><?php _e( 'Before you can upload your import file, you will need to fix the following error:' ); ?></p>
-		<p><strong><?php echo $upload_dir['error']; ?></strong></p></div>
-		<?php
+		$upload_directory_error  = '<p>' . __( 'Before you can upload your import file, you will need to fix the following error:' ) . '</p>';
+		$upload_directory_error .= '<p><strong>' . $upload_dir['error'] . '</strong></p>';
+		wp_admin_notice(
+			$upload_directory_error,
+			array(
+				'additonal_classes' => array( 'error' ),
+				'paragraph_wrap'    => false,
+			)
+		);
 	else :
 		?>
 <form enctype="multipart/form-data" id="import-upload-form" method="post" class="wp-upload-form" action="<?php echo esc_url( wp_nonce_url( $action, 'import-upload' ) ); ?>">
@@ -1434,16 +1439,17 @@ function do_meta_boxes( $screen, $context, $data_object ) {
 					if ( WP_DEBUG && ! $block_compatible && 'edit' === $screen->parent_base && ! $screen->is_block_editor() && ! isset( $_GET['meta-box-loader'] ) ) {
 						$plugin = _get_plugin_from_callback( $box['callback'] );
 						if ( $plugin ) {
-							?>
-							<div class="error inline">
-								<p>
-									<?php
-										/* translators: %s: The name of the plugin that generated this meta box. */
-										printf( __( 'This meta box, from the %s plugin, is not compatible with the block editor.' ), "<strong>{$plugin['Name']}</strong>" );
-									?>
-								</p>
-							</div>
-							<?php
+							$meta_box_not_compatible_message = sprintf(
+								/* translators: %s: The name of the plugin that generated this meta box. */
+								__( 'This meta box, from the %s plugin, is not compatible with the block editor.' ),
+								"<strong>{$plugin['Name']}</strong>"
+							);
+							wp_admin_notice(
+								$meta_box_not_compatible_message,
+								array(
+									'additional_classes' => array( 'error', 'inline' ),
+								)
+							);
 						}
 					}
 
@@ -2695,17 +2701,22 @@ function convert_to_screen( $hook_name ) {
  * @access private
  */
 function _local_storage_notice() {
-	?>
-	<div id="local-storage-notice" class="hidden notice is-dismissible">
-	<p class="local-restore">
-		<?php _e( 'The backup of this post in your browser is different from the version below.' ); ?>
-		<button type="button" class="button restore-backup"><?php _e( 'Restore the backup' ); ?></button>
-	</p>
-	<p class="help">
-		<?php _e( 'This will replace the current editor content with the last backup version. You can use undo and redo in the editor to get the old content back or to return to the restored version.' ); ?>
-	</p>
-	</div>
-	<?php
+	$local_storage_message  = '<p class="local-restore">';
+	$local_storage_message .= __( 'The backup of this post in your browser is different from the version below.' );
+	$local_storage_message .= '<button type="button" class="button restore-backup">' . __( 'Restore the backup' ) . '</button></p>';
+	$local_storage_message .= '<p class="help">';
+	$local_storage_message .= __( 'This will replace the current editor content with the last backup version. You can use undo and redo in the editor to get the old content back or to return to the restored version.' );
+	$local_storage_message .= '</p>';
+
+	wp_admin_notice(
+		$local_storage_message,
+		array(
+			'id'                 => 'local-storage-notice',
+			'additional_classes' => array( 'hidden' ),
+			'dismissible'        => true,
+			'paragraph_wrap'     => false,
+		)
+	);
 }
 
 /**

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -342,7 +342,14 @@ function update_nag() {
 		);
 	}
 
-	echo "<div class='update-nag notice notice-warning inline'>$msg</div>";
+	wp_admin_notice(
+		$msg,
+		array(
+			'type'              => 'warning',
+			'additonal_classes' => array( 'update-nag', 'inline' ),
+			'paragraph_wrap'    => false,
+		)
+	);
 }
 
 /**
@@ -884,7 +891,14 @@ function maintenance_nag() {
 		$msg = __( 'An automated WordPress update has failed to complete! Please notify the site administrator.' );
 	}
 
-	echo "<div class='update-nag notice notice-warning inline'>$msg</div>";
+	wp_admin_notice(
+		$msg,
+		array(
+			'type'               => 'warning',
+			'additional_classes' => array( 'update-nag', 'inline' ),
+			'paragraph_wrap'     => false,
+		)
+	);
 }
 
 /**

--- a/src/wp-admin/includes/user.php
+++ b/src/wp-admin/includes/user.php
@@ -535,28 +535,30 @@ function default_password_nag() {
 	if ( 'profile.php' === $pagenow || ! get_user_option( 'default_password_nag' ) ) {
 		return;
 	}
-	?>
-	<div class="error default-password-nag">
-		<p>
-			<strong><?php _e( 'Notice:' ); ?></strong>
-			<?php _e( 'You are using the auto-generated password for your account. Would you like to change it?' ); ?>
-		</p>
-		<p>
-		<?php
-		printf(
-			'<a href="%1$s">%2$s</a> | ',
-			esc_url( get_edit_profile_url() . '#password' ),
-			__( 'Yes, take me to my profile page' )
-		);
-		printf(
-			'<a href="%1$s" id="default-password-nag-no">%2$s</a>',
-			'?default_password_nag=0',
-			__( 'No thanks, do not remind me again' )
-		);
-		?>
-		</p>
-	</div>
-	<?php
+
+	$default_password_nag_message  = sprintf(
+		'<p><strong>%1$s</strong> %2$s</p>',
+		__( 'Notice:' ),
+		__( 'You are using the auto-generated password for your account. Would you like to change it?' )
+	);
+	$default_password_nag_message .= sprintf(
+		'<p><a href="%1$s">%2$s</a> | ',
+		esc_url( get_edit_profile_url() . '#password' ),
+		__( 'Yes, take me to my profile page' )
+	);
+	$default_password_nag_message .= sprintf(
+		'<a href="%1$s" id="default-password-nag-no">%2$s</a></p>',
+		'?default_password_nag=0',
+		__( 'No thanks, do not remind me again' )
+	);
+
+	wp_admin_notice(
+		$default_password_nag_message,
+		array(
+			'additional_classes' => array( 'error', 'default-password-nag' ),
+			'paragraph_wrap'     => false,
+		)
+	);
 }
 
 /**


### PR DESCRIPTION
Adds further usages of `wp_admin_notice()` in the root level of `/wp-admin/includes/` on
`.notice-error`, `.notice-warning`, `.error`, and `.updated`.

Ongoing task to implement new function across core.

Trac ticket: https://core.trac.wordpress.org/ticket/57791