### PR TITLE
Login and Registration: Check redirect_to type before calling `str_contains()`

### DIFF
--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -759,7 +759,7 @@ switch ( $action ) {
 
 		wp_logout();
 
-		if ( ! empty( $_REQUEST['redirect_to'] ) ) {
+		if ( ! empty( $_REQUEST['redirect_to'] ) && is_string( $_REQUEST['redirect_to'] ) ) {
 			$redirect_to           = $_REQUEST['redirect_to'];
 			$requested_redirect_to = $redirect_to;
 		} else {
@@ -1264,7 +1264,7 @@ switch ( $action ) {
 			}
 		}
 
-		$requested_redirect_to = isset( $_REQUEST['redirect_to'] ) ? $_REQUEST['redirect_to'] : '';
+		$requested_redirect_to = ! empty( $_REQUEST['redirect_to'] ) && is_string( $_REQUEST['redirect_to'] ) ? $_REQUEST['redirect_to'] : '';
 		/**
 		 * Filters the login redirect URL.
 		 *
@@ -1366,7 +1366,7 @@ switch ( $action ) {
 				$errors->add( 'updated', __( '<strong>You have successfully updated WordPress!</strong> Please log back in to see what&#8217;s new.' ), 'message' );
 			} elseif ( WP_Recovery_Mode_Link_Service::LOGIN_ACTION_ENTERED === $action ) {
 				$errors->add( 'enter_recovery_mode', __( 'Recovery Mode Initialized. Please log in to continue.' ), 'message' );
-			} elseif ( isset( $_GET['redirect_to'] ) && str_contains( $_GET['redirect_to'], 'wp-admin/authorize-application.php' ) ) {
+			} elseif ( isset( $_GET['redirect_to'] ) && is_string( $_GET['redirect_to'] ) && str_contains( $_GET['redirect_to'], 'wp-admin/authorize-application.php' ) ) {
 				$query_component = wp_parse_url( $_GET['redirect_to'], PHP_URL_QUERY );
 				$query           = array();
 				if ( $query_component ) {


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/59373.

This prevents URLs like `/wp-login.php?redirect_to[x]=y` from triggering a HTTP 500 response as result of

> ```
> PHP Fatal error: Uncaught TypeError: str_contains():
> Argument #1 ($haystack) must be of type string, array given
> ```

I considered changing the case for "authorize-application.php" to re-use the `$requested_redirect_to` variable but left it as-is because this case reads from _GET whereas the variable also considers POST parameters (via _REQUEST), which might be intentional. This case was introduced in [49109] for #42790.

* change 49109: https://github.com/WordPress/wordpress-develop/commit/1856d0fe2ad01b53daaf8338a4250088367ac948
* issue 42790: https://core.trac.wordpress.org/ticket/42790

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
