### PR TITLE
Improve assumed main plugin file in Plugin_Upgrader class

### DIFF
--- a/src/wp-admin/includes/class-plugin-upgrader.php
+++ b/src/wp-admin/includes/class-plugin-upgrader.php
@@ -544,9 +544,19 @@ class Plugin_Upgrader extends WP_Upgrader {
 		}
 
 		// Assume the requested plugin is the first in the list.
-		$pluginfiles = array_keys( $plugin );
+		$pluginfile = array_keys( $plugin )[0];
 
-		return $this->result['destination_name'] . '/' . $pluginfiles[0];
+		if ( false !== strpos( $pluginfile, '/' ) ) {
+			// Prefer first top-level file to remain consistent with
+			// get_plugins() default behavior with WP_PLUGIN_DIR.
+			foreach ( $plugin as $file => &$data ) {
+				if ( false === strpos( $file, '/' ) ) {
+					$pluginfile = $file;
+				}
+			}
+		}
+
+		return $this->result['destination_name'] . '/' . $pluginfile;
 	}
 
 	/**


### PR DESCRIPTION
The `Plugin_Upgrader` class may use a plugin file nested deeper than typically found (eg. `WP_Plugins_List_Table`). This change improves which plugin file is assumed to be the actual plugin file of the uploaded plugin. See Trac ticket for full details.

Trac ticket: https://core.trac.wordpress.org/ticket/59375

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
