### PR TITLE
Fix: depreciated notice when call preg_replace method in wp-admin/includes/plugin.php

### DIFF
--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -2089,7 +2089,7 @@ function get_plugin_page_hookname( $plugin_page, $parent_page ) {
 		$page_type = $admin_page_hooks[ $parent ];
 	}
 
-	$plugin_name = preg_replace( '!\.php!', '', $plugin_page );
+	$plugin_name = $plugin_page ? preg_replace( '!\.php!', '', $plugin_page ) : $plugin_page;
 
 	return $page_type . '_page_' . $plugin_name;
 }

--- a/src/wp-includes/class-wp-block-list.php
+++ b/src/wp-includes/class-wp-block-list.php
@@ -7,7 +7,7 @@
  */
 
 /**
- * Class representing a list of block instanczes.
+ * Class representing a list of block instances.
  *
  * @since 5.5.0
  */

--- a/src/wp-includes/class-wp-block-list.php
+++ b/src/wp-includes/class-wp-block-list.php
@@ -7,7 +7,7 @@
  */
 
 /**
- * Class representing a list of block instances.
+ * Class representing a list of block instanczes.
  *
  * @since 5.5.0
  */


### PR DESCRIPTION
Ticket : https://core.trac.wordpress.org/ticket/59365


### Description:
Check the string before using preg_replace method in wp-admin/includes/plugin.php file


<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
