### PR TITLE
Move tabindex from PHP notice output to JS notice handling

### DIFF
--- a/src/js/_enqueues/admin/application-passwords.js
+++ b/src/js/_enqueues/admin/application-passwords.js
@@ -60,7 +60,7 @@
 				name: response.name,
 				password: response.password
 			} ) );
-			$( '.new-application-password-notice' ).trigger( 'focus' );
+			$( '.new-application-password-notice' ).attr( 'tabindex', '-1' ).trigger( 'focus' );
 
 			$appPassTbody.prepend( tmplAppPassRow( response ) );
 

--- a/src/js/_enqueues/lib/image-edit.js
+++ b/src/js/_enqueues/lib/image-edit.js
@@ -858,7 +858,7 @@
 				elementToSetFocusTo = $( '.imgedit-wrap' ).find( ':tabbable:first' );
 			}
 
-			elementToSetFocusTo.trigger( 'focus' );
+			elementToSetFocusTo.attr( 'tabindex', '-1' ).trigger( 'focus' );
 		}, 100 );
 	},
 

--- a/src/wp-admin/includes/image-edit.php
+++ b/src/wp-admin/includes/image-edit.php
@@ -39,9 +39,9 @@ function wp_image_editor( $post_id, $msg = false ) {
 
 	if ( $msg ) {
 		if ( isset( $msg->error ) ) {
-			$note = "<div class='notice notice-error' tabindex='-1' role='alert'><p>$msg->error</p></div>";
+			$note = "<div class='notice notice-error' role='alert'><p>$msg->error</p></div>";
 		} elseif ( isset( $msg->msg ) ) {
-			$note = "<div class='notice notice-success' tabindex='-1' role='alert'><p>$msg->msg</p></div>";
+			$note = "<div class='notice notice-success' role='alert'><p>$msg->msg</p></div>";
 		}
 	}
 

--- a/src/wp-admin/user-edit.php
+++ b/src/wp-admin/user-edit.php
@@ -965,7 +965,7 @@ switch ( $action ) {
 
 <?php if ( isset( $application_passwords_list_table ) ) : ?>
 	<script type="text/html" id="tmpl-new-application-password">
-		<div class="notice notice-success is-dismissible new-application-password-notice" role="alert" tabindex="-1">
+		<div class="notice notice-success is-dismissible new-application-password-notice" role="alert">
 			<p class="application-password-display">
 				<label for="new-application-password-value">
 					<?php


### PR DESCRIPTION
Moves tabindex from the PHP output of notices to the JS handler for that notice. Allows us to avoid adding tabindex to the globally allowed attributes in KSES.

Trac ticket: https://core.trac.wordpress.org/ticket/57791

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
