### PR TITLE
6.4 Backport: Add a taxonomy for user pattern categories

### DIFF
--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -240,7 +240,7 @@ function create_initial_taxonomies() {
 			'show_in_nav_menus' => false,
 			'show_in_rest'      => true,
 			'show_admin_column' => true,
-		),
+		)
 	);
 }
 

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -222,6 +222,26 @@ function create_initial_taxonomies() {
 			'show_in_rest'      => false,
 		)
 	);
+
+	register_taxonomy(
+		'wp_pattern_category',
+		array( 'wp_block' ),
+		array(
+			'public'            => true,
+			'hierarchical'      => false,
+			'labels'            => array(
+				'name'          => _x( 'Pattern Categories', 'taxonomy general name' ),
+				'singular_name' => _x( 'Pattern Category', 'taxonomy singular name' ),
+			),
+			'query_var'         => false,
+			'rewrite'           => false,
+			'show_ui'           => true,
+			'_builtin'          => true,
+			'show_in_nav_menus' => false,
+			'show_in_rest'      => true,
+			'show_admin_column' => true,
+		),
+	);
 }
 
 /**

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -227,19 +227,20 @@ function create_initial_taxonomies() {
 		'wp_pattern_category',
 		array( 'wp_block' ),
 		array(
-			'public'            => true,
-			'hierarchical'      => false,
-			'labels'            => array(
-				'name'          => _x( 'Pattern Categories', 'taxonomy general name' ),
-				'singular_name' => _x( 'Pattern Category', 'taxonomy singular name' ),
+			'public'             => true,
+			'publicly_queryable' => false,
+			'hierarchical'       => false,
+			'labels'             => array(
+				'name'           => _x( 'Pattern Categories', 'taxonomy general name' ),
+				'singular_name'  => _x( 'Pattern Category', 'taxonomy singular name' ),
 			),
-			'query_var'         => false,
-			'rewrite'           => false,
-			'show_ui'           => true,
-			'_builtin'          => true,
-			'show_in_nav_menus' => false,
-			'show_in_rest'      => true,
-			'show_admin_column' => true,
+			'query_var'          => false,
+			'rewrite'            => false,
+			'show_ui'            => true,
+			'_builtin'           => true,
+			'show_in_nav_menus'  => false,
+			'show_in_rest'       => true,
+			'show_admin_column'  => true,
 		)
 	);
 }

--- a/tests/phpunit/tests/rest-api/rest-schema-setup.php
+++ b/tests/phpunit/tests/rest-api/rest-schema-setup.php
@@ -186,6 +186,8 @@ class WP_Test_REST_Schema_Initialization extends WP_Test_REST_TestCase {
 			'/wp-site-health/v1/tests/authorization-header',
 			'/wp-site-health/v1/tests/page-cache',
 			'/wp-site-health/v1/directory-sizes',
+			'/wp/v2/wp_pattern_category',
+			'/wp/v2/wp_pattern_category/(?P<id>[\d]+)',
 		);
 
 		$this->assertSameSets( $expected_routes, $routes );

--- a/tests/phpunit/tests/taxonomy.php
+++ b/tests/phpunit/tests/taxonomy.php
@@ -12,6 +12,10 @@ class Tests_Taxonomy extends WP_UnitTestCase {
 		$this->assertSame( array( 'link_category' ), get_object_taxonomies( 'link' ) );
 	}
 
+	public function test_get_block_taxonomies() {
+		$this->assertSame( array( 'wp_pattern_category' ), get_object_taxonomies( 'wp_block' ) );
+	}
+
 	/**
 	 * @ticket 5417
 	 */
@@ -119,6 +123,7 @@ class Tests_Taxonomy extends WP_UnitTestCase {
 		$this->assertTrue( taxonomy_exists( 'category' ) );
 		$this->assertTrue( taxonomy_exists( 'post_tag' ) );
 		$this->assertTrue( taxonomy_exists( 'link_category' ) );
+		$this->assertTrue( taxonomy_exists( 'wp_pattern_category' ) );
 	}
 
 	public function test_taxonomy_exists_unknown() {

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -4440,6 +4440,92 @@ mockedApiResponse.Schema = {
                                 "type": "string"
                             },
                             "required": false
+                        },
+                        "tax_relation": {
+                            "description": "Limit result set based on relationship between multiple taxonomies.",
+                            "type": "string",
+                            "enum": [
+                                "AND",
+                                "OR"
+                            ],
+                            "required": false
+                        },
+                        "wp_pattern_category": {
+                            "description": "Limit result set to items with specific terms assigned in the wp_pattern_category taxonomy.",
+                            "type": [
+                                "object",
+                                "array"
+                            ],
+                            "oneOf": [
+                                {
+                                    "title": "Term ID List",
+                                    "description": "Match terms with the listed IDs.",
+                                    "type": "array",
+                                    "items": {
+                                        "type": "integer"
+                                    }
+                                },
+                                {
+                                    "title": "Term ID Taxonomy Query",
+                                    "description": "Perform an advanced term query.",
+                                    "type": "object",
+                                    "properties": {
+                                        "terms": {
+                                            "description": "Term IDs.",
+                                            "type": "array",
+                                            "items": {
+                                                "type": "integer"
+                                            },
+                                            "default": []
+                                        },
+                                        "operator": {
+                                            "description": "Whether items must be assigned all or any of the specified terms.",
+                                            "type": "string",
+                                            "enum": [
+                                                "AND",
+                                                "OR"
+                                            ],
+                                            "default": "OR"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            ],
+                            "required": false
+                        },
+                        "wp_pattern_category_exclude": {
+                            "description": "Limit result set to items except those with specific terms assigned in the wp_pattern_category taxonomy.",
+                            "type": [
+                                "object",
+                                "array"
+                            ],
+                            "oneOf": [
+                                {
+                                    "title": "Term ID List",
+                                    "description": "Match terms with the listed IDs.",
+                                    "type": "array",
+                                    "items": {
+                                        "type": "integer"
+                                    }
+                                },
+                                {
+                                    "title": "Term ID Taxonomy Query",
+                                    "description": "Perform an advanced term query.",
+                                    "type": "object",
+                                    "properties": {
+                                        "terms": {
+                                            "description": "Term IDs.",
+                                            "type": "array",
+                                            "items": {
+                                                "type": "integer"
+                                            },
+                                            "default": []
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            ],
+                            "required": false
                         }
                     }
                 },
@@ -4548,6 +4634,14 @@ mockedApiResponse.Schema = {
                         "template": {
                             "description": "The theme file to use to display the post.",
                             "type": "string",
+                            "required": false
+                        },
+                        "wp_pattern_category": {
+                            "description": "The terms assigned to the post in the wp_pattern_category taxonomy.",
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            },
                             "required": false
                         }
                     }
@@ -4710,6 +4804,14 @@ mockedApiResponse.Schema = {
                         "template": {
                             "description": "The theme file to use to display the post.",
                             "type": "string",
+                            "required": false
+                        },
+                        "wp_pattern_category": {
+                            "description": "The terms assigned to the post in the wp_pattern_category taxonomy.",
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            },
                             "required": false
                         }
                     }
@@ -5032,6 +5134,14 @@ mockedApiResponse.Schema = {
                         "template": {
                             "description": "The theme file to use to display the post.",
                             "type": "string",
+                            "required": false
+                        },
+                        "wp_pattern_category": {
+                            "description": "The terms assigned to the post in the wp_pattern_category taxonomy.",
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            },
                             "required": false
                         }
                     }
@@ -8281,6 +8391,260 @@ mockedApiResponse.Schema = {
                 }
             ]
         },
+        "/wp/v2/wp_pattern_category": {
+            "namespace": "wp/v2",
+            "methods": [
+                "GET",
+                "POST"
+            ],
+            "endpoints": [
+                {
+                    "methods": [
+                        "GET"
+                    ],
+                    "allow_batch": {
+                        "v1": true
+                    },
+                    "args": {
+                        "context": {
+                            "description": "Scope under which the request is made; determines fields present in response.",
+                            "type": "string",
+                            "enum": [
+                                "view",
+                                "embed",
+                                "edit"
+                            ],
+                            "default": "view",
+                            "required": false
+                        },
+                        "page": {
+                            "description": "Current page of the collection.",
+                            "type": "integer",
+                            "default": 1,
+                            "minimum": 1,
+                            "required": false
+                        },
+                        "per_page": {
+                            "description": "Maximum number of items to be returned in result set.",
+                            "type": "integer",
+                            "default": 10,
+                            "minimum": 1,
+                            "maximum": 100,
+                            "required": false
+                        },
+                        "search": {
+                            "description": "Limit results to those matching a string.",
+                            "type": "string",
+                            "required": false
+                        },
+                        "exclude": {
+                            "description": "Ensure result set excludes specific IDs.",
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            },
+                            "default": [],
+                            "required": false
+                        },
+                        "include": {
+                            "description": "Limit result set to specific IDs.",
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            },
+                            "default": [],
+                            "required": false
+                        },
+                        "offset": {
+                            "description": "Offset the result set by a specific number of items.",
+                            "type": "integer",
+                            "required": false
+                        },
+                        "order": {
+                            "description": "Order sort attribute ascending or descending.",
+                            "type": "string",
+                            "default": "asc",
+                            "enum": [
+                                "asc",
+                                "desc"
+                            ],
+                            "required": false
+                        },
+                        "orderby": {
+                            "description": "Sort collection by term attribute.",
+                            "type": "string",
+                            "default": "name",
+                            "enum": [
+                                "id",
+                                "include",
+                                "name",
+                                "slug",
+                                "include_slugs",
+                                "term_group",
+                                "description",
+                                "count"
+                            ],
+                            "required": false
+                        },
+                        "hide_empty": {
+                            "description": "Whether to hide terms not assigned to any posts.",
+                            "type": "boolean",
+                            "default": false,
+                            "required": false
+                        },
+                        "post": {
+                            "description": "Limit result set to terms assigned to a specific post.",
+                            "type": "integer",
+                            "default": null,
+                            "required": false
+                        },
+                        "slug": {
+                            "description": "Limit result set to terms with one or more specific slugs.",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "required": false
+                        }
+                    }
+                },
+                {
+                    "methods": [
+                        "POST"
+                    ],
+                    "allow_batch": {
+                        "v1": true
+                    },
+                    "args": {
+                        "description": {
+                            "description": "HTML description of the term.",
+                            "type": "string",
+                            "required": false
+                        },
+                        "name": {
+                            "description": "HTML title for the term.",
+                            "type": "string",
+                            "required": true
+                        },
+                        "slug": {
+                            "description": "An alphanumeric identifier for the term unique to its type.",
+                            "type": "string",
+                            "required": false
+                        },
+                        "meta": {
+                            "description": "Meta fields.",
+                            "type": "object",
+                            "properties": [],
+                            "required": false
+                        }
+                    }
+                }
+            ],
+            "_links": {
+                "self": [
+                    {
+                        "href": "http://example.org/index.php?rest_route=/wp/v2/wp_pattern_category"
+                    }
+                ]
+            }
+        },
+        "/wp/v2/wp_pattern_category/(?P<id>[\\d]+)": {
+            "namespace": "wp/v2",
+            "methods": [
+                "GET",
+                "POST",
+                "PUT",
+                "PATCH",
+                "DELETE"
+            ],
+            "endpoints": [
+                {
+                    "methods": [
+                        "GET"
+                    ],
+                    "allow_batch": {
+                        "v1": true
+                    },
+                    "args": {
+                        "id": {
+                            "description": "Unique identifier for the term.",
+                            "type": "integer",
+                            "required": false
+                        },
+                        "context": {
+                            "description": "Scope under which the request is made; determines fields present in response.",
+                            "type": "string",
+                            "enum": [
+                                "view",
+                                "embed",
+                                "edit"
+                            ],
+                            "default": "view",
+                            "required": false
+                        }
+                    }
+                },
+                {
+                    "methods": [
+                        "POST",
+                        "PUT",
+                        "PATCH"
+                    ],
+                    "allow_batch": {
+                        "v1": true
+                    },
+                    "args": {
+                        "id": {
+                            "description": "Unique identifier for the term.",
+                            "type": "integer",
+                            "required": false
+                        },
+                        "description": {
+                            "description": "HTML description of the term.",
+                            "type": "string",
+                            "required": false
+                        },
+                        "name": {
+                            "description": "HTML title for the term.",
+                            "type": "string",
+                            "required": false
+                        },
+                        "slug": {
+                            "description": "An alphanumeric identifier for the term unique to its type.",
+                            "type": "string",
+                            "required": false
+                        },
+                        "meta": {
+                            "description": "Meta fields.",
+                            "type": "object",
+                            "properties": [],
+                            "required": false
+                        }
+                    }
+                },
+                {
+                    "methods": [
+                        "DELETE"
+                    ],
+                    "allow_batch": {
+                        "v1": true
+                    },
+                    "args": {
+                        "id": {
+                            "description": "Unique identifier for the term.",
+                            "type": "integer",
+                            "required": false
+                        },
+                        "force": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "Required to be true, as terms do not support trashing.",
+                            "required": false
+                        }
+                    }
+                }
+            ]
+        },
         "/wp/v2/users": {
             "namespace": "wp/v2",
             "methods": [
@@ -9452,6 +9816,7 @@ mockedApiResponse.Schema = {
                                     "page",
                                     "category",
                                     "post_tag",
+                                    "wp_pattern_category",
                                     "any"
                                 ],
                                 "type": "string"
@@ -12026,7 +12391,9 @@ mockedApiResponse.TypesCollection = {
         "name": "Patterns",
         "slug": "wp_block",
         "icon": null,
-        "taxonomies": [],
+        "taxonomies": [
+            "wp_pattern_category"
+        ],
         "rest_base": "blocks",
         "rest_namespace": "wp/v2",
         "_links": {
@@ -12331,6 +12698,36 @@ mockedApiResponse.TaxonomiesCollection = {
             "wp:items": [
                 {
                     "href": "http://example.org/index.php?rest_route=/wp/v2/menus"
+                }
+            ],
+            "curies": [
+                {
+                    "name": "wp",
+                    "href": "https://api.w.org/{rel}",
+                    "templated": true
+                }
+            ]
+        }
+    },
+    "wp_pattern_category": {
+        "name": "Pattern Categories",
+        "slug": "wp_pattern_category",
+        "description": "",
+        "types": [
+            "wp_block"
+        ],
+        "hierarchical": false,
+        "rest_base": "wp_pattern_category",
+        "rest_namespace": "wp/v2",
+        "_links": {
+            "collection": [
+                {
+                    "href": "http://example.org/index.php?rest_route=/wp/v2/taxonomies"
+                }
+            ],
+            "wp:items": [
+                {
+                    "href": "http://example.org/index.php?rest_route=/wp/v2/wp_pattern_category"
                 }
             ],
             "curies": [


### PR DESCRIPTION
## Description

Adds a custom taxonomy `wp_pattern_category` to allow users to assign categories to their custom patterns.

[Gutenberg PR ](https://github.com/WordPress/gutenberg/pull/53835/files#diff-9b2e4b2c76b3e26900ed3e87747f01869e84cc02435c0aeba7d788eb102d48e0L17).

Trac ticket: https://core.trac.wordpress.org/ticket/59379

## Testing Instructions

- Go to `/wp-admin/edit.php?post_type=wp_block` and add a new pattern
- Make sure the Category option appears in the right settings panel and that you can add new categories

## Screenshots or screencast <!-- if applicable -->

https://github.com/WordPress/gutenberg/assets/3629020/63895ddc-415a-4fea-ac7a-177813d138a4

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
