### PR TITLE
#57897: REST attachments controller: Handle terms on creation

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -186,6 +186,12 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			return $fields_update;
 		}
 
+		$terms_update = $this->handle_terms( $attachment_id, $request );
+
+		if ( is_wp_error( $terms_update ) ) {
+			return $terms_update;
+		}
+
 		$request->set_param( 'context', 'edit' );
 
 		/**

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -1062,7 +1062,9 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$request->set_param( 'categories', array( $category['term_id'] ) );
 		$response   = rest_get_server()->dispatch( $request );
 		$attachment = $response->get_data();
-		$this->assertSame( array( $category['term_id'] ), wp_list_pluck( wp_get_post_terms( $attachment['id'], 'category' ), 'term_id' ) );
+
+		$term = wp_get_post_terms( $attachment['id'], 'category' );
+		$this->assertSame( $category['term_id'], $term[0]->term_id );
 	}
 
 	public function test_update_item() {

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -1046,6 +1046,8 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	}
 
 	/**
+	 * @ticket 57897
+	 *
 	 * @requires function imagejpeg
 	 */
 	public function test_create_item_with_terms() {


### PR DESCRIPTION
PR adds handle terms in the REST attachments controller to assign terms to the freshly created attachment. 

Currently, `\WP_REST_Attachments_Controller::create_item()` does not call `parent::create_item()`, thus it also doesn't call `\WP_REST_Posts_Controller::handle_terms()`. That means it's impossible to assign terms to the freshly uploaded attachment. As suggested in the ticket description, PR adds `handle_terms()` in `WP_REST_Attachments_Controller` to fix this issue.

Trac ticket: https://core.trac.wordpress.org/ticket/57897

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
