### PR TITLE
Blocks: Introduce helper function to retrieve hooked blocks

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -740,6 +740,27 @@ function get_dynamic_block_names() {
 }
 
 /**
+ * Retrieves block types (and positions) hooked into the given block.
+ *
+ * @since 6.4.0
+ *
+ * @param string $name Block type name including namespace.
+ * @return array Associative array of `$block_type_name => $position` pairs.
+ */
+function get_hooked_blocks( $name ) {
+	$block_types = WP_Block_Type_Registry::get_instance()->get_all_registered();
+	$hooked_blocks = array();
+	foreach ( $block_types as $block_type ) {
+		foreach ( $block_type->block_hooks as $anchor_block_type => $relative_position ) {
+			if ( $anchor_block_type === $name ) {
+				$hooked_blocks[ $block_type->name ] = $relative_position;
+			}
+		}
+	}
+	return $hooked_blocks;
+}
+
+/**
  * Given an array of attributes, returns a string in the serialized attributes
  * format prepared for post content.
  *

--- a/tests/phpunit/tests/blocks/blockHooks.php
+++ b/tests/phpunit/tests/blocks/blockHooks.php
@@ -43,13 +43,8 @@ class Tests_Blocks_BlockHooks extends WP_UnitTestCase {
 	 * @ticket 59313
 	 *
 	 * @covers ::get_hooked_blocks
-	 *
-	 * @dataProvider data_block_hooked_blocks
-	 *
-	 * @param string $block_name Block name.
-	 * @param array  $expected   Expected hooked blocks.
 	 */
-	public function test_get_hooked_blocks_matches_found( $block_name, $expected ) {
+	public function test_get_hooked_blocks_matches_found() {
 		register_block_type(
 			'tests/my-block',
 			array(
@@ -72,49 +67,34 @@ class Tests_Blocks_BlockHooks extends WP_UnitTestCase {
 		);
 
 		$this->assertSame(
-			$expected,
-			get_hooked_blocks( $block_name )
+			array(
+				'tests/my-block'           => 'before',
+				'tests/my-container-block' => 'before',
+			),
+			get_hooked_blocks( 'tests/hooked-before' ),
+			'block hooked at the before position'
 		);
-	}
-
-	/**
-	 * Data provider for hooked blocks.
-	 *
-	 * @return array {
-	 *     @type array {
-	 *         @type string Block name.
-	 *         @type array  Expected hooked blocks.
-	 *     }
-	 * }
-	 */
-	public function data_block_hooked_blocks() {
-		return array(
-			'block hooked at the before position'      => array(
-				'tests/hooked-before',
-				array(
-					'tests/my-block'           => 'before',
-					'tests/my-container-block' => 'before',
-				),
+		$this->assertSame(
+			array(
+				'tests/my-block'           => 'after',
+				'tests/my-container-block' => 'after',
 			),
-			'block hooked at the after position'       => array(
-				'tests/hooked-after',
-				array(
-					'tests/my-block'           => 'after',
-					'tests/my-container-block' => 'after',
-				),
+			get_hooked_blocks( 'tests/hooked-after' ),
+			'block hooked at the after position'
+		);
+		$this->assertSame(
+			array(
+				'tests/my-container-block' => 'first_child',
 			),
-			'block hooked at the first child position' => array(
-				'tests/hooked-first-child',
-				array(
-					'tests/my-container-block' => 'first_child',
-				),
+			get_hooked_blocks( 'tests/hooked-first-child' ),
+			'block hooked at the first child position'
+		);
+		$this->assertSame(
+			array(
+				'tests/my-container-block' => 'last_child',
 			),
-			'block hooked at the last child position'  => array(
-				'tests/hooked-last-child',
-				array(
-					'tests/my-container-block' => 'last_child',
-				),
-			),
+			get_hooked_blocks( 'tests/hooked-last-child' ),
+			'block hooked at the last child position'
 		);
 	}
 }

--- a/tests/phpunit/tests/blocks/blockHooks.php
+++ b/tests/phpunit/tests/blocks/blockHooks.php
@@ -46,54 +46,54 @@ class Tests_Blocks_BlockHooks extends WP_UnitTestCase {
 	 */
 	public function test_get_hooked_blocks_matches_found() {
 		register_block_type(
-			'tests/my-block',
+			'tests/injected-one',
 			array(
 				'block_hooks' => array(
-					'tests/hooked-before' => 'before',
-					'tests/hooked-after'  => 'after',
+					'tests/hooked-at-before' => 'before',
+					'tests/hooked-at-after'  => 'after',
 				),
 			)
 		);
 		register_block_type(
-			'tests/my-container-block',
+			'tests/injected-two',
 			array(
 				'block_hooks' => array(
-					'tests/hooked-before'      => 'before',
-					'tests/hooked-after'       => 'after',
-					'tests/hooked-first-child' => 'first_child',
-					'tests/hooked-last-child'  => 'last_child',
+					'tests/hooked-at-before'      => 'before',
+					'tests/hooked-at-after'       => 'after',
+					'tests/hooked-at-first-child' => 'first_child',
+					'tests/hooked-at-last-child'  => 'last_child',
 				),
 			)
 		);
 
 		$this->assertSame(
 			array(
-				'tests/my-block'           => 'before',
-				'tests/my-container-block' => 'before',
+				'tests/injected-one' => 'before',
+				'tests/injected-two' => 'before',
 			),
-			get_hooked_blocks( 'tests/hooked-before' ),
+			get_hooked_blocks( 'tests/hooked-at-before' ),
 			'block hooked at the before position'
 		);
 		$this->assertSame(
 			array(
-				'tests/my-block'           => 'after',
-				'tests/my-container-block' => 'after',
+				'tests/injected-one' => 'after',
+				'tests/injected-two' => 'after',
 			),
-			get_hooked_blocks( 'tests/hooked-after' ),
+			get_hooked_blocks( 'tests/hooked-at-after' ),
 			'block hooked at the after position'
 		);
 		$this->assertSame(
 			array(
-				'tests/my-container-block' => 'first_child',
+				'tests/injected-two' => 'first_child',
 			),
-			get_hooked_blocks( 'tests/hooked-first-child' ),
+			get_hooked_blocks( 'tests/hooked-at-first-child' ),
 			'block hooked at the first child position'
 		);
 		$this->assertSame(
 			array(
-				'tests/my-container-block' => 'last_child',
+				'tests/injected-two' => 'last_child',
 			),
-			get_hooked_blocks( 'tests/hooked-last-child' ),
+			get_hooked_blocks( 'tests/hooked-at-last-child' ),
 			'block hooked at the last child position'
 		);
 	}

--- a/tests/phpunit/tests/blocks/blockHooks.php
+++ b/tests/phpunit/tests/blocks/blockHooks.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Tests for block hooks feature functions.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ *
+ * @since 6.4.0
+ *
+ * @group blocks
+ */
+class Tests_Blocks_BlockHooks extends WP_UnitTestCase {
+
+	/**
+	 * Tear down after each test.
+	 *
+	 * @since 6.4.0
+	 */
+	public function tear_down() {
+		$registry = WP_Block_Type_Registry::get_instance();
+
+		foreach ( array( 'tests/my-block', 'tests/my-container-block' ) as $block_name ) {
+			if ( $registry->is_registered( $block_name ) ) {
+				$registry->unregister( $block_name );
+			}
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * @ticket 59313
+	 *
+	 * @covers ::get_hooked_blocks
+	 */
+	public function test_get_hooked_blocks_no_match_found() {
+		$result = get_hooked_blocks( 'tests/no-hooked-blocks' );
+
+		$this->assertSame( array(), $result );
+	}
+
+	/**
+	 * @ticket 59313
+	 *
+	 * @covers ::get_hooked_blocks
+	 *
+	 * @dataProvider data_block_hooked_blocks
+	 *
+	 * @param string $block_name Block name.
+	 * @param array  $expected   Expected hooked blocks.
+	 */
+	public function test_get_hooked_blocks_matches_found( $block_name, $expected ) {
+		register_block_type(
+			'tests/my-block',
+			array(
+				'block_hooks' => array(
+					'tests/hooked-before' => 'before',
+					'tests/hooked-after'  => 'after',
+				),
+			)
+		);
+		register_block_type(
+			'tests/my-container-block',
+			array(
+				'block_hooks' => array(
+					'tests/hooked-before'      => 'before',
+					'tests/hooked-after'       => 'after',
+					'tests/hooked-first-child' => 'first_child',
+					'tests/hooked-last-child'  => 'last_child',
+				),
+			)
+		);
+
+		$this->assertSame(
+			$expected,
+			get_hooked_blocks( $block_name )
+		);
+	}
+
+	/**
+	 * Data provider for hooked blocks.
+	 *
+	 * @return array {
+	 *     @type array {
+	 *         @type string Block name.
+	 *         @type array  Expected hooked blocks.
+	 *     }
+	 * }
+	 */
+	public function data_block_hooked_blocks() {
+		return array(
+			'block hooked at the before position'      => array(
+				'tests/hooked-before',
+				array(
+					'tests/my-block'           => 'before',
+					'tests/my-container-block' => 'before',
+				),
+			),
+			'block hooked at the after position'       => array(
+				'tests/hooked-after',
+				array(
+					'tests/my-block'           => 'after',
+					'tests/my-container-block' => 'after',
+				),
+			),
+			'block hooked at the first child position' => array(
+				'tests/hooked-first-child',
+				array(
+					'tests/my-container-block' => 'first_child',
+				),
+			),
+			'block hooked at the last child position'  => array(
+				'tests/hooked-last-child',
+				array(
+					'tests/my-container-block' => 'last_child',
+				),
+			),
+		);
+	}
+}

--- a/tests/phpunit/tests/blocks/blockHooks.php
+++ b/tests/phpunit/tests/blocks/blockHooks.php
@@ -29,7 +29,7 @@ class Tests_Blocks_BlockHooks extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket 59313
+	 * @ticket 59383
 	 *
 	 * @covers ::get_hooked_blocks
 	 */
@@ -40,7 +40,7 @@ class Tests_Blocks_BlockHooks extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket 59313
+	 * @ticket 59383
 	 *
 	 * @covers ::get_hooked_blocks
 	 */


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/59383

In order to implement Block Hooks (see [#59313](https://core.trac.wordpress.org/ticket/59313)), we added `block_hooks` field to the `WP_Block_Type` class, as well as to block registration related functions. In this follow-up, new helper function gets introduced that is going to compute the list of hooked blocks by other registered blocks for a given block type.

Extracted from https://github.com/WordPress/wordpress-develop/pull/5158 and covered with unit tests.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
