### PR TITLE
Blocks: Pass parent block, block index, chunk index to `serialize_block(s)` callback argument

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -858,16 +858,16 @@ function get_comment_delimited_block_content( $block_name, $block_attributes, $b
 function serialize_block( $block, $callback = null ) {
 	$block_content = '';
 
-	$index = 0;
+	$block_index = 0;
 	foreach ( $block['innerContent'] as $chunk ) {
 		if ( is_string( $chunk ) ) {
 			$block_content .= $chunk;
 		} else {
-			$inner_block = $block['innerBlocks'][ $index ];
+			$inner_block = $block['innerBlocks'][ $block_index ];
 			if ( is_callable( $callback ) ) {
-				$inner_block = call_user_func( $callback, $inner_block, $block, $index );
+				$inner_block = call_user_func( $callback, $inner_block, $block, $block_index );
 			}
-			$index++;
+			$block_index++;
 			$block_content .= serialize_block( $inner_block, $callback );
 		}
 	}

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -860,11 +860,15 @@ function serialize_block( $block, $callback = null ) {
 
 	$index = 0;
 	foreach ( $block['innerContent'] as $chunk ) {
-		$inner_block = $block['innerBlocks'][ $index++ ];
-		if ( is_callable( $callback ) ) {
-			$inner_block = call_user_func( $callback, $inner_block, $block );
+		if ( is_string( $chunk ) ) {
+			$block_content .= $chunk;
+		} else {
+			$inner_block = $block['innerBlocks'][ $index++ ];
+			if ( is_callable( $callback ) ) {
+				$inner_block = call_user_func( $callback, $inner_block, $block );
+			}
+			$block_content .= serialize_block( $inner_block, $callback );
 		}
-		$block_content .= is_string( $chunk ) ? $chunk : serialize_block( $inner_block, $callback );
 	}
 
 	if ( ! is_array( $block['attrs'] ) ) {

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -859,13 +859,13 @@ function serialize_block( $block, $callback = null ) {
 	$block_content = '';
 
 	$block_index = 0;
-	foreach ( $block['innerContent'] as $chunk ) {
+	foreach ( $block['innerContent'] as $chunk_index => $chunk ) {
 		if ( is_string( $chunk ) ) {
 			$block_content .= $chunk;
 		} else {
 			$inner_block = $block['innerBlocks'][ $block_index ];
 			if ( is_callable( $callback ) ) {
-				$inner_block = call_user_func( $callback, $inner_block, $block, $block_index );
+				$inner_block = call_user_func( $callback, $inner_block, $block, $block_index, $chunk_index );
 			}
 			$block_index++;
 			$block_content .= serialize_block( $inner_block, $callback );

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -900,6 +900,7 @@ function serialize_blocks( $blocks, $callback = null ) {
 	$result = '';
 	foreach ( $blocks as $block ) {
 		if ( is_callable( $callback ) ) {
+			// At the top level, there is no parent block, block index, or chunk index to pass to the callback.
 			$block = call_user_func( $callback, $block );
 		}
 		$result .= serialize_block( $block, $callback );

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -863,10 +863,11 @@ function serialize_block( $block, $callback = null ) {
 		if ( is_string( $chunk ) ) {
 			$block_content .= $chunk;
 		} else {
-			$inner_block = $block['innerBlocks'][ $index++ ];
+			$inner_block = $block['innerBlocks'][ $index ];
 			if ( is_callable( $callback ) ) {
 				$inner_block = call_user_func( $callback, $inner_block, $block );
 			}
+			$index++;
 			$block_content .= serialize_block( $inner_block, $callback );
 		}
 	}

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -865,7 +865,7 @@ function serialize_block( $block, $callback = null ) {
 		} else {
 			$inner_block = $block['innerBlocks'][ $index ];
 			if ( is_callable( $callback ) ) {
-				$inner_block = call_user_func( $callback, $inner_block, $block );
+				$inner_block = call_user_func( $callback, $inner_block, $block, $index );
 			}
 			$index++;
 			$block_content .= serialize_block( $inner_block, $callback );

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -862,7 +862,7 @@ function serialize_block( $block, $callback = null ) {
 	foreach ( $block['innerContent'] as $chunk ) {
 		$inner_block = $block['innerBlocks'][ $index++ ];
 		if ( is_callable( $callback ) ) {
-			$inner_block = call_user_func( $callback, $inner_block );
+			$inner_block = call_user_func( $callback, $inner_block, $block );
 		}
 		$block_content .= is_string( $chunk ) ? $chunk : serialize_block( $inner_block, $callback );
 	}

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -853,6 +853,7 @@ function get_comment_delimited_block_content( $block_name, $block_attributes, $b
  *
  * @param array         $block    A representative array of a single parsed block object. See WP_Block_Parser_Block.
  * @param callable|null $callback Optional. Callback to run on each block in the tree before serialization. Default null.
+ *                                It is called with the following arguments: $block, $parent_block, $block_index, $chunk_index.
  * @return string String of rendered HTML.
  */
 function serialize_block( $block, $callback = null ) {
@@ -892,6 +893,7 @@ function serialize_block( $block, $callback = null ) {
  *
  * @param array[]       $blocks   An array of representative arrays of parsed block objects. See serialize_block().
  * @param callable|null $callback Optional. Callback to run on each block in the tree before serialization. Default null.
+ *                                It is called with the following arguments: $block, $parent_block, $block_index, $chunk_index.
  * @return string String of rendered HTML.
  */
 function serialize_blocks( $blocks, $callback = null ) {

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -856,15 +856,15 @@ function get_comment_delimited_block_content( $block_name, $block_attributes, $b
  * @return string String of rendered HTML.
  */
 function serialize_block( $block, $callback = null ) {
-	if ( is_callable( $callback ) ) {
-		$block = call_user_func( $callback, $block );
-	}
-
 	$block_content = '';
 
 	$index = 0;
 	foreach ( $block['innerContent'] as $chunk ) {
-		$block_content .= is_string( $chunk ) ? $chunk : serialize_block( $block['innerBlocks'][ $index++ ], $callback );
+		$inner_block = $block['innerBlocks'][ $index++ ];
+		if ( is_callable( $callback ) ) {
+			$inner_block = call_user_func( $callback, $inner_block );
+		}
+		$block_content .= is_string( $chunk ) ? $chunk : serialize_block( $inner_block, $callback );
 	}
 
 	if ( ! is_array( $block['attrs'] ) ) {
@@ -892,6 +892,9 @@ function serialize_block( $block, $callback = null ) {
 function serialize_blocks( $blocks, $callback = null ) {
 	$result = '';
 	foreach ( $blocks as $block ) {
+		if ( is_callable( $callback ) ) {
+			$block = call_user_func( $callback, $block );
+		}
 		$result .= serialize_block( $block, $callback );
 	}
 	return $result;


### PR DESCRIPTION
See https://core.trac.wordpress.org/ticket/59313.

TODO: 
- [ ] Needs a ton more test coverage
- [ ] Could maybe even pass the innerBlock (and innerChunk?) indices to the callback -- a bit like JS/lodash does

Trac ticket: TBD

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
