### PR TITLE
HTML API: Add `matches_breadcrumbs()` to HTML Processor for better querying

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -432,6 +432,50 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	}
 
 	/**
+	 * Indicates if the currently-matched tag matches the given breadcrumbs.
+	 *
+	 * A "*" represents a single tag wildcard, where any tag matches, but not no tags.
+	 *
+	 * At some point this function _may_ support a `**` syntax for matching any number
+	 * of unspecified tags in the breadcrumb stack. This has been intentionally left
+	 * out, however, to keep this function simple and to avoid introducing backtracking,
+	 * which could open up surprising performance breakdowns.
+	 *
+	 * Example:
+	 *
+	 *     $processor = WP_HTML_Processor::createFragment( '<div><span><figure><img></figure></span></div>' );
+	 *     $processor->next_tag( 'img' );
+	 *     true  === $processor->matches_breadcrumbs( array( 'figure', 'img' ) );
+	 *     true  === $processor->matches_breadcrumbs( array( 'span', 'figure', 'img' ) );
+	 *     false === $processor->matches_breadcrumbs( array( 'span', 'img' ) );
+	 *     true  === $processor->matches_breadcrumbs( array( 'span', '*', 'img' ) );
+	 *
+	 * @param string[] $breadcrumbs list of HTML tag names representing nested structure.
+	 * @return bool Whether the currently-matched tag is found at the given nested structure.
+	 */
+	public function matches_breadcrumbs( $breadcrumbs ) {
+		if ( ! $this->get_tag() || 0 === count( $breadcrumbs ) ) {
+			return false;
+		}
+
+		$crumb_at = count( $breadcrumbs ) - 1;
+
+		foreach ( $this->state->stack_of_open_elements->walk_up() as $node ) {
+			$crumb = strtoupper( $breadcrumbs[ $crumb_at ] );
+
+			if ( '*' !== $crumb && $node->node_name !== $crumb ) {
+				return false;
+			}
+
+			if ( --$crumb_at < 0 ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Steps through the HTML document and stop at the next tag, if any.
 	 *
 	 * @since 6.4.0

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -454,7 +454,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		// Start at the last crumb.
 		$crumb = end( $breadcrumbs );
 
-		if ( $this->get_tag() !== strtoupper( $crumb ) ) {
+		if ( '*' !== $crumb && $this->get_tag() !== strtoupper( $crumb ) ) {
 			return false;
 		}
 

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -357,6 +357,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 *                                     Defaults to first tag.
 	 *     @type string|null $class_name   Tag must contain this whole class name to match.
 	 *     @type string[]    $breadcrumbs  DOM sub-path at which element is found, e.g. `array( 'FIGURE', 'IMG' )`.
+	 *                                     May also contain the wildcard `*` which matches a single element, e.g. `array( 'SECTION', '*' )`.
 	 * }
 	 * @return bool Whether a tag was matched.
 	 */
@@ -436,7 +437,8 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 *
 	 * @since 6.4.0
 	 *
-	 * @param string[] $breadcrumbs list of HTML tag names representing nested structure.
+	 * @param string[] $breadcrumbs DOM sub-path at which element is found, e.g. `array( 'FIGURE', 'IMG' )`.
+	 *                              May also contain the wildcard `*` which matches a single element, e.g. `array( 'SECTION', '*' )`.
 	 * @return bool Whether the currently-matched tag is found at the given nested structure.
 	 */
 	public function matches_breadcrumbs( $breadcrumbs ) {
@@ -450,20 +452,20 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		}
 
 		// Start at the last crumb.
-		$crumb_at = count( $breadcrumbs ) - 1;
+		$crumb = end( $breadcrumbs );
 
-		if ( $this->get_tag() !== strtoupper( $breadcrumbs[ $crumb_at ] ) ) {
+		if ( $this->get_tag() !== strtoupper( $crumb ) ) {
 			return false;
 		}
 
 		foreach ( $this->state->stack_of_open_elements->walk_up() as $node ) {
-			$crumb = strtoupper( $breadcrumbs[ $crumb_at ] );
+			$crumb = strtoupper( current( $breadcrumbs ) );
 
 			if ( '*' !== $crumb && $node->node_name !== $crumb ) {
 				return false;
 			}
 
-			if ( --$crumb_at < 0 ) {
+			if ( false === prev( $breadcrumbs ) ) {
 				return true;
 			}
 		}

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -406,26 +406,10 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		$breadcrumbs  = $query['breadcrumbs'];
 		$match_offset = isset( $query['match_offset'] ) ? (int) $query['match_offset'] : 1;
 
-		$crumb  = end( $breadcrumbs );
-		$target = strtoupper( $crumb );
 		while ( $match_offset > 0 && $this->step() ) {
-			if ( $target !== $this->get_tag() ) {
-				continue;
+			if ( $this->matches_breadcrumbs( $breadcrumbs ) && 0 === --$match_offset ) {
+				return true;
 			}
-
-			// Look up the stack to see if the breadcrumbs match.
-			foreach ( $this->state->stack_of_open_elements->walk_up() as $node ) {
-				if ( strtoupper( $crumb ) !== $node->node_name ) {
-					break;
-				}
-
-				$crumb = prev( $breadcrumbs );
-				if ( false === $crumb && 0 === --$match_offset && ! $this->is_tag_closer() ) {
-					return true;
-				}
-			}
-
-			$crumb = end( $breadcrumbs );
 		}
 
 		return false;
@@ -450,15 +434,27 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 *     false === $processor->matches_breadcrumbs( array( 'span', 'img' ) );
 	 *     true  === $processor->matches_breadcrumbs( array( 'span', '*', 'img' ) );
 	 *
+	 * @since 6.4.0
+	 *
 	 * @param string[] $breadcrumbs list of HTML tag names representing nested structure.
 	 * @return bool Whether the currently-matched tag is found at the given nested structure.
 	 */
 	public function matches_breadcrumbs( $breadcrumbs ) {
-		if ( ! $this->get_tag() || 0 === count( $breadcrumbs ) ) {
+		if ( ! $this->get_tag() ) {
 			return false;
 		}
 
+		// Everything matches when there are zero constraints.
+		if ( 0 === count( $breadcrumbs ) ) {
+			return true;
+		}
+
+		// Start at the last crumb.
 		$crumb_at = count( $breadcrumbs ) - 1;
+
+		if ( $this->get_tag() !== strtoupper( $breadcrumbs[ $crumb_at ] ) ) {
+			return false;
+		}
 
 		foreach ( $this->state->stack_of_open_elements->walk_up() as $node ) {
 			$crumb = strtoupper( $breadcrumbs[ $crumb_at ] );

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorBreadcrumbs.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorBreadcrumbs.php
@@ -403,6 +403,10 @@ class Tests_HtmlApi_WpHtmlProcessorBreadcrumbs extends WP_UnitTestCase {
 			'Inner P no wildcard'            => array( '<div><span><figure></p target></figure></span></div>', array( 'span', 'p' ), false ),
 			'Full specification (P)'         => array( '<div><span><figure></p target></figure></span></div>', array( 'html', 'body', 'div', 'span', 'figure', 'p' ), false ),
 			'Invalid Full specification (P)' => array( '<div><span><figure></p target></figure></span></div>', array( 'html', 'div', 'span', 'figure', 'p' ), false ),
+
+			// Test wildcard behaviors.
+			'Single wildcard element'        => array( '<figure><code><div><p><span><img target></span></p></div></code></figure>', array( '*' ), true ),
+			'Child of wildcard element'      => array( '<figure><code><div><p><span><img target></span></p></div></code></figure>', array( 'SPAN', '*' ), true ),
 		);
 	}
 

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorBreadcrumbs.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorBreadcrumbs.php
@@ -353,7 +353,7 @@ class Tests_HtmlApi_WpHtmlProcessorBreadcrumbs extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket {TICKET_NUMBER}
+	 * @ticket 59400
 	 *
 	 * @dataProvider data_html_with_breadcrumbs_of_various_specificity
 	 *
@@ -383,11 +383,26 @@ class Tests_HtmlApi_WpHtmlProcessorBreadcrumbs extends WP_UnitTestCase {
 	 */
 	public function data_html_with_breadcrumbs_of_various_specificity() {
 		return array(
-			'Inner IMG'                  => array( '<div><span><figure><img target></figure></span></div>', array( 'span', 'figure', 'img' ), true ),
-			'Inner IMG wildcard'         => array( '<div><span><figure><img target></figure></span></div>', array( 'span', '*', 'img' ), true ),
-			'Inner IMG no wildcard'      => array( '<div><span><figure><img target></figure></span></div>', array( 'span', 'img' ), false ),
-			'Full specification'         => array( '<div><span><figure><img target></figure></span></div>', array( 'html', 'body', 'div', 'span', 'figure', 'img' ), true ),
-			'Invalid Full specification' => array( '<div><span><figure><img target></figure></span></div>', array( 'html', 'div', 'span', 'figure', 'img' ), false ),
+			// Test with void elements.
+			'Inner IMG'                      => array( '<div><span><figure><img target></figure></span></div>', array( 'span', 'figure', 'img' ), true ),
+			'Inner IMG wildcard'             => array( '<div><span><figure><img target></figure></span></div>', array( 'span', '*', 'img' ), true ),
+			'Inner IMG no wildcard'          => array( '<div><span><figure><img target></figure></span></div>', array( 'span', 'img' ), false ),
+			'Full specification'             => array( '<div><span><figure><img target></figure></span></div>', array( 'html', 'body', 'div', 'span', 'figure', 'img' ), true ),
+			'Invalid Full specification'     => array( '<div><span><figure><img target></figure></span></div>', array( 'html', 'div', 'span', 'figure', 'img' ), false ),
+
+			// Test also with non-void elements that open and close.
+			'Inner P'                        => array( '<div><span><figure><p target></figure></span></div>', array( 'span', 'figure', 'p' ), true ),
+			'Inner P wildcard'               => array( '<div><span><figure><p target></figure></span></div>', array( 'span', '*', 'p' ), true ),
+			'Inner P no wildcard'            => array( '<div><span><figure><p target></figure></span></div>', array( 'span', 'p' ), false ),
+			'Full specification (P)'         => array( '<div><span><figure><p target></figure></span></div>', array( 'html', 'body', 'div', 'span', 'figure', 'p' ), true ),
+			'Invalid Full specification (P)' => array( '<div><span><figure><p target></figure></span></div>', array( 'html', 'div', 'span', 'figure', 'p' ), false ),
+
+			// Ensure that matches aren't on tag closers.
+			'Inner P'                        => array( '<div><span><figure></p target></figure></span></div>', array( 'span', 'figure', 'p' ), false ),
+			'Inner P wildcard'               => array( '<div><span><figure></p target></figure></span></div>', array( 'span', '*', 'p' ), false ),
+			'Inner P no wildcard'            => array( '<div><span><figure></p target></figure></span></div>', array( 'span', 'p' ), false ),
+			'Full specification (P)'         => array( '<div><span><figure></p target></figure></span></div>', array( 'html', 'body', 'div', 'span', 'figure', 'p' ), false ),
+			'Invalid Full specification (P)' => array( '<div><span><figure></p target></figure></span></div>', array( 'html', 'div', 'span', 'figure', 'p' ), false ),
 		);
 	}
 


### PR DESCRIPTION
Trac ticket: [#59400](https://core.trac.wordpress.org/ticket/59400#ticket)

 - [x] Cleared for Gutenberg WPCS issues in WordPress/gutenberg#54629

Inside a `next_tag()` loop it can be challenging to use breadcrumbs because they are only exposed inside the call to `next_tag()` via the `$query` arg.

In this patch a new method, `matches_breadcrumbs()` is exposed which allows for querying within the `next_tag()` loop for more complicated queries.

This method exposes a wildcard `*` operator to allow matching _any HTML tag_ that the currently-matched tag is a child or descendant of.