### PR TITLE
Blocks: Implement insert_hooked_blocks()

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -760,6 +760,29 @@ function get_hooked_blocks( $name ) {
 	return $hooked_blocks;
 }
 
+function insert_hooked_blocks( $block, $parent, $block_index, $chunk_index ) {
+	$hooked_blocks = get_hooked_blocks( $block['blockName'] );
+	foreach ( $hooked_blocks as $hooked_block_type => $relative_position ) {
+		$hooked_block = array(
+			'blockName'    => $hooked_block_type,
+			'attrs'        => array(),
+			'innerHTML'    => '',
+			'innerContent' => array(),
+			'innerBlocks'  => array(),
+		);
+		if ( 'before' === $relative_position ) {
+			insert_inner_block( $parent, $block_index, $chunk_index, $hooked_block );
+		} elseif ( 'after' === $relative_position ) {
+			insert_inner_block( $parent, $block_index + 1, $chunk_index, $hooked_block );
+		} elseif ( 'first_child' === $relative_position ) {
+			prepend_inner_block( $block, $hooked_block );
+		} elseif ( 'last_child' === $relative_position ) {
+			append_inner_block( $block, $hooked_block );
+		}
+	}
+	return $block;
+}
+
 /**
  * Insert a parsed block into a parent block's inner blocks.
  *

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -760,7 +760,7 @@ function get_hooked_blocks( $name ) {
 	return $hooked_blocks;
 }
 
-function insert_hooked_blocks( $block, $parent, $block_index, $chunk_index ) {
+function insert_hooked_blocks( $block, $parent = null, $block_index = null, $chunk_index = null ) {
 	$hooked_blocks = get_hooked_blocks( $block['blockName'] );
 	foreach ( $hooked_blocks as $hooked_block_type => $relative_position ) {
 		$hooked_block = array(


### PR DESCRIPTION
WIP. See [`#59313`](https://core.trac.wordpress.org/ticket/59313) and https://github.com/WordPress/wordpress-develop/pull/5158.

For [`#59313`](https://core.trac.wordpress.org/ticket/59313), we need a function that will plug into parsed block tree traversal and serialization (https://github.com/WordPress/wordpress-develop/pull/5246). For each block traversed, it will obtain the list of all hooked blocks that use it as their anchor block (`get_hooked_blocks`, https://github.com/WordPress/wordpress-develop/pull/5239), and insert those hooked blocks into the parsed block tree (`insert_inner_block`, `prepend_inner_block`, `append_inner_block`, https://github.com/WordPress/wordpress-develop/pull/5240).

TODO:
- [ ] Add test coverage for all four possible relative insertion positions.

---

For early testing, use the [Like Button block](https://github.com/ockham/like-button/releases/download/v0.4.1/like-button.zip) and apply the following diff:

```diff
diff --git a/src/wp-includes/class-wp-block-patterns-registry.php b/src/wp-includes/class-wp-block-patterns-registry.php
index a83b35185b..7f617dbbea 100644
--- a/src/wp-includes/class-wp-block-patterns-registry.php
+++ b/src/wp-includes/class-wp-block-patterns-registry.php
@@ -165,7 +165,10 @@ final class WP_Block_Patterns_Registry {
                        return null;
                }
 
-               return $this->registered_patterns[ $pattern_name ];
+               $pattern            = $this->registered_patterns[ $pattern_name ];
+               $blocks             = parse_blocks( $pattern['content'] );
+               $pattern['content'] = traverse_and_serialize_blocks( $blocks, 'insert_hooked_blocks' );
+               return $pattern;
        }
 
        /**
```

Trac ticket: https://core.trac.wordpress.org/ticket/59399

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
