### PR TITLE
Build/Test Tools: Add `sys_get_temp_dir()` to `open_basedir` tests.

### DIFF
--- a/tests/phpunit/tests/admin/wpAutomaticUpdater.php
+++ b/tests/phpunit/tests/admin/wpAutomaticUpdater.php
@@ -610,7 +610,7 @@ class Tests_Admin_WpAutomaticUpdater extends WP_UnitTestCase {
 
 		$open_basedir_backup = ini_get( 'open_basedir' );
 		// Allow access to the directory one level above the repository.
-		ini_set( 'open_basedir', wp_normalize_path( $abspath_grandparent ) );
+		ini_set( 'open_basedir', sys_get_temp_dir() . PATH_SEPARATOR . wp_normalize_path( $abspath_grandparent ) );
 
 		// Checking an allowed directory should succeed.
 		$actual = self::$updater->is_allowed_dir( wp_normalize_path( ABSPATH ) );
@@ -645,7 +645,7 @@ class Tests_Admin_WpAutomaticUpdater extends WP_UnitTestCase {
 
 		$open_basedir_backup = ini_get( 'open_basedir' );
 		// Allow access to the directory one level above the repository.
-		ini_set( 'open_basedir', wp_normalize_path( $abspath_grandparent ) );
+		ini_set( 'open_basedir', sys_get_temp_dir() . PATH_SEPARATOR . wp_normalize_path( $abspath_grandparent ) );
 
 		// Checking a directory not within the allowed path should trigger an `open_basedir` warning.
 		$actual = self::$updater->is_allowed_dir( '/.git' );


### PR DESCRIPTION
In PHPUnit 9.6.13, the child processes used for process isolation now use temporary files to communicate their result to the parent process. This caused a failure in some tests that set the `open_basedir` PHP directive.

This adds `sys_get_temp_dir()` to the `open_basedir` value set by the tests.

References:
- https://github.com/sebastianbergmann/phpunit/issues/5356

Trac ticket: https://core.trac.wordpress.org/ticket/59394