### PR TITLE
Return whether a development mode is beiung used

### DIFF
--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -325,10 +325,12 @@ function wp_get_development_mode() {
  * @param string $mode Development mode to check for. Either 'core', 'plugin', 'theme', or 'all'.
  * @return bool True if the given mode is covered by the current development mode, false otherwise.
  */
-function wp_is_development_mode( $mode ) {
+function wp_is_development_mode( $mode = null ) {
 	$current_mode = wp_get_development_mode();
 	if ( empty( $current_mode ) ) {
 		return false;
+	} elseif ( empty( $mode ) ) {
+		return (bool) $current_mode;
 	}
 
 	// Return true if the current mode encompasses all modes.


### PR DESCRIPTION
Make one function responsible for getting the development mode state.

Trac ticket: https://core.trac.wordpress.org/ticket/58855
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
