### PR TITLE
Style engine: update docs for css_var 

### DIFF
--- a/src/wp-includes/style-engine/class-wp-style-engine.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine.php
@@ -26,26 +26,19 @@
 #[AllowDynamicProperties]
 final class WP_Style_Engine {
 	/**
-	 * Style definitions that contain the instructions to
-	 * parse/output valid Gutenberg styles from a block's attributes.
-	 *
-	 * For every style definition, the following properties are valid:
-	 *
-	 *  - classnames    => (array) An array of classnames to be returned for block styles.
-	 *                     The key is a classname or pattern.
-	 *                     A value of `true` means the classname should be applied always.
-	 *                     Otherwise, a valid CSS property (string) to match the incoming value,
-	 *                     e.g. "color" to match var:preset|color|somePresetSlug.
-	 *  - css_vars      => (array) An array of key value pairs used to generate CSS var values.
-	 *                     The key is a CSS var pattern, whose `$slug` fragment will be replaced with a preset slug.
-	 *                     The value should be a valid CSS property (string) to match the incoming value,
-	 *                     e.g. "color" to match var:preset|color|somePresetSlug.
-	 *  - property_keys => (array) An array of keys whose values represent a valid CSS property,
-	 *                     e.g. "margin" or "border".
-	 *  - path          => (array) A path that accesses the corresponding style value in the block style object.
-	 *  - value_func    => (string) The name of a function to generate a CSS definition array
-	 *                     for a particular style object. The output of this function should be
-	 *                     `array( "$property" => "$value", ... )`.
+	 * Style definitions that contain the instructions to parse/output valid Gutenberg styles from a block's attributes.
+	 * For every style definition, the follow properties are valid:
+	 *  - classnames    => (array) an array of classnames to be returned for block styles. The key is a classname or pattern.
+	 *                    A value of `true` means the classname should be applied always. Otherwise, a valid CSS property (string)
+	 *                    to match the incoming value, e.g., "color" to match var:preset|color|somePresetSlug.
+	 *  - css_vars      => (array) an array of key value pairs used to generate CSS var values.
+	 *                     The key should be the CSS property name that matches the second element of the preset string value,
+	 *                     i.e., "color" in var:preset|color|somePresetSlug. The value is a CSS var pattern (e.g. `--wp--preset--color--$slug`),
+	 *                     whose `$slug` fragment will be replaced with the preset slug, which is the third element of the preset string value,
+	 *                     i.e., `somePresetSlug` in var:preset|color|somePresetSlug.
+	 *  - property_keys => (array) array of keys whose values represent a valid CSS property, e.g., "margin" or "border".
+	 *  - path          => (array) a path that accesses the corresponding style value in the block style object.
+	 *  - value_func    => (string) the name of a function to generate a CSS definition array for a particular style object. The output of this function should be `array( "$property" => "$value", ... )`.
 	 *
 	 * @since 6.1.0
 	 * @var array

--- a/src/wp-includes/style-engine/class-wp-style-engine.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine.php
@@ -27,7 +27,9 @@
 final class WP_Style_Engine {
 	/**
 	 * Style definitions that contain the instructions to parse/output valid Gutenberg styles from a block's attributes.
+	 *
 	 * For every style definition, the follow properties are valid:
+	 *
 	 *  - classnames    => (array) an array of classnames to be returned for block styles. The key is a classname or pattern.
 	 *                    A value of `true` means the classname should be applied always. Otherwise, a valid CSS property (string)
 	 *                    to match the incoming value, e.g., "color" to match var:preset|color|somePresetSlug.


### PR DESCRIPTION
The doc comments for css_var were topsy turvy.

The css_var property used to be this way, e.g., '--wp--preset--color--$slug' => 'color' , but then we swapped it around.

Syncing Gutenberg commit from https://github.com/WordPress/gutenberg/pull/53710

Trac ticket: https://core.trac.wordpress.org/ticket/59401

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
