### PR TITLE
Style engine: update docs for css_var with spelling correction

### DIFF
--- a/src/wp-includes/style-engine/class-wp-style-engine.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine.php
@@ -29,7 +29,7 @@ final class WP_Style_Engine {
 	/**
 	 * Style definitions that contain the instructions to parse/output valid Gutenberg styles from a block's attributes.
 	 *
-	 * For every style definition, the follow properties are valid:
+	 * For every style definition, the following properties are valid:
 	 *
 	 *  - classnames    => (array) an array of classnames to be returned for block styles. The key is a classname or pattern.
 	 *                    A value of `true` means the classname should be applied always. Otherwise, a valid CSS property (string)


### PR DESCRIPTION
Follow up to https://github.com/WordPress/wordpress-develop/pull/5255

A spelling error was detected but the PR was closed before changes could be made.

Props to @audrasjb and @tellthemachines 

Trac ticket: https://core.trac.wordpress.org/ticket/59401

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
