### PR TITLE
Blocks: Add post-block callback arg to `traverse_and_serialize_block()`, change signature

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -515,16 +515,15 @@ function _inject_theme_attribute_in_block_template_content( $template_content ) 
  * @access private
  *
  * @param array $block a parsed block.
- * @return array Updated block.
+ * @return void
  */
-function _inject_theme_attribute_in_template_part_block( $block ) {
+function _inject_theme_attribute_in_template_part_block( &$block ) {
 	if (
 		'core/template-part' === $block['blockName'] &&
 		! isset( $block['attrs']['theme'] )
 	) {
 		$block['attrs']['theme'] = get_stylesheet();
 	}
-	return $block;
 }
 
 /**

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -225,7 +225,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 	 * @covers ::_inject_theme_attribute_in_template_part_block
 	 */
 	public function test_inject_theme_attribute_in_template_part_block() {
-		$template_part_block_without_theme_attribute = array(
+		$template_part_block = array(
 			'blockName'    => 'core/template-part',
 			'attrs'        => array(
 				'slug'      => 'header',
@@ -238,7 +238,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 			'innerBlocks'  => array(),
 		);
 
-		$actual   = _inject_theme_attribute_in_template_part_block( $template_part_block_without_theme_attribute );
+		_inject_theme_attribute_in_template_part_block( $template_part_block );
 		$expected = array(
 			'blockName'    => 'core/template-part',
 			'attrs'        => array(
@@ -254,7 +254,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		);
 		$this->assertSame(
 			$expected,
-			$actual,
+			$template_part_block,
 			'`theme` attribute was not correctly injected in template part block.'
 		);
 	}
@@ -265,7 +265,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 	 * @covers ::_inject_theme_attribute_in_template_part_block
 	 */
 	public function test_not_inject_theme_attribute_in_template_part_block_theme_attribute_exists() {
-		$template_part_block_with_existing_theme_attribute = array(
+		$template_part_block = array(
 			'blockName'    => 'core/template-part',
 			'attrs'        => array(
 				'slug'      => 'header',
@@ -279,10 +279,11 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 			'innerBlocks'  => array(),
 		);
 
-		$actual = _inject_theme_attribute_in_template_part_block( $template_part_block_with_existing_theme_attribute );
+		$expected = $template_part_block;
+		_inject_theme_attribute_in_template_part_block( $template_part_block );
 		$this->assertSame(
-			$template_part_block_with_existing_theme_attribute,
-			$actual,
+			$expected,
+			$template_part_block,
 			'Existing `theme` attribute in template part block was not respected by attribute injection.'
 		);
 	}
@@ -301,10 +302,11 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 			'innerBlocks'  => array(),
 		);
 
-		$actual = _inject_theme_attribute_in_template_part_block( $non_template_part_block );
+		$expected = $non_template_part_block;
+		_inject_theme_attribute_in_template_part_block( $non_template_part_block );
 		$this->assertSame(
+			$expected,
 			$non_template_part_block,
-			$actual,
 			'`theme` attribute injection modified non-template-part block.'
 		);
 	}

--- a/tests/phpunit/tests/blocks/serialize.php
+++ b/tests/phpunit/tests/blocks/serialize.php
@@ -58,6 +58,7 @@ class Tests_Blocks_Serialize extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 59327
+	 * @ticket 59412
 	 *
 	 * @covers ::traverse_and_serialize_blocks
 	 */
@@ -73,15 +74,15 @@ class Tests_Blocks_Serialize extends WP_UnitTestCase {
 		);
 	}
 
-	public static function add_attribute_to_inner_block( $block ) {
+	public static function add_attribute_to_inner_block( &$block ) {
 		if ( 'core/inner' === $block['blockName'] ) {
 			$block['attrs']['myattr'] = 'myvalue';
 		}
-		return $block;
 	}
 
 	/**
 	 * @ticket 59327
+	 * @ticket 59412
 	 *
 	 * @covers ::traverse_and_serialize_blocks
 	 *
@@ -92,12 +93,7 @@ class Tests_Blocks_Serialize extends WP_UnitTestCase {
 	public function test_traverse_and_serialize_identity_from_parsed( $original ) {
 		$blocks = parse_blocks( $original );
 
-		$actual = traverse_and_serialize_blocks(
-			$blocks,
-			function ( $block ) {
-				return $block;
-			}
-		);
+		$actual = traverse_and_serialize_blocks( $blocks );
 
 		$this->assertSame( $original, $actual );
 	}


### PR DESCRIPTION
Per https://github.com/WordPress/wordpress-develop/pull/5247#discussion_r1331151853, I realized that sibling block insertion wasn't likely going to work the way I had planned. As a consequence, I had to come up with a new way to make it work.

Basically, we:
- Change the signature of the existing callback such that:
  - the function arguments are now a _reference_ to the current block (so it can be modified inline, which is important e.g. for `theme` attribute insertion), the parent block, and the previous block (instead of the block index and chunk index)
  - the return value is now a string that will be prepended to the result of the inner block traversal and serialization.
- Add a second callback argument to `traverse_and_serialize_block`, which is called _after_ the current inner block is traversed and serialized.
  - Its function arguments are a reference to the current block, the parent block, and the next block.

Its usage is demonstrated in #5261: The callback arguments are now sufficient to insert the serialized hooked blocks as strings, rather than via `insert_inner_block`, `prepend_inner block`, or `append_inner_block`.

Trac ticket: https://core.trac.wordpress.org/ticket/59412

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
