### PR TITLE
Blocks: Insert hooked blocks

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -601,8 +601,10 @@ function _build_block_template_result_from_file( $template_file, $template_type 
 		$template->area = $template_file['area'];
 	}
 
-	$blocks            = parse_blocks( $template_content );
-	$template->content = traverse_and_serialize_blocks( $blocks, '_inject_theme_attribute_in_template_part_block' );
+	$blocks               = parse_blocks( $template_content );
+	$before_block_visitor = make_before_block_visitor( $template );
+	$after_block_visitor  = make_after_block_visitor( $template );
+	$template->content    = traverse_and_serialize_blocks( $blocks, $before_block_visitor, $after_block_visitor );
 
 	return $template;
 }

--- a/src/wp-includes/class-wp-block-patterns-registry.php
+++ b/src/wp-includes/class-wp-block-patterns-registry.php
@@ -165,7 +165,13 @@ final class WP_Block_Patterns_Registry {
 			return null;
 		}
 
-		return $this->registered_patterns[ $pattern_name ];
+		$pattern              = $this->registered_patterns[ $pattern_name ];
+		$blocks               = parse_blocks( $pattern['content'] );
+		$before_block_visitor = make_before_block_visitor( $pattern );
+		$after_block_visitor  = make_after_block_visitor( $pattern );
+		$pattern['content']   = traverse_and_serialize_blocks( $blocks, $before_block_visitor, $after_block_visitor );
+
+		return $pattern;
 	}
 
 	/**
@@ -178,11 +184,19 @@ final class WP_Block_Patterns_Registry {
 	 *                 and per style.
 	 */
 	public function get_all_registered( $outside_init_only = false ) {
-		return array_values(
+		$patterns = array_values(
 			$outside_init_only
 				? $this->registered_patterns_outside_init
 				: $this->registered_patterns
 		);
+
+		foreach ( $patterns as $index => $pattern ) {
+			$blocks                        = parse_blocks( $pattern['content'] );
+			$before_block_visitor          = make_before_block_visitor( $pattern );
+			$after_block_visitor           = make_after_block_visitor( $pattern );
+			$patterns[ $index ]['content'] = traverse_and_serialize_blocks( $blocks, $before_block_visitor, $after_block_visitor );
+		}
+		return $patterns;
 	}
 
 	/**

--- a/tests/phpunit/tests/blocks/serialize.php
+++ b/tests/phpunit/tests/blocks/serialize.php
@@ -62,7 +62,7 @@ class Tests_Blocks_Serialize extends WP_UnitTestCase {
 	 *
 	 * @covers ::traverse_and_serialize_blocks
 	 */
-	public function test_traverse_and_serialize_blocks() {
+	public function test_traverse_and_serialize_blocks_pre_callback_modifies_current_block() {
 		$markup = "<!-- wp:outer --><!-- wp:inner {\"key\":\"value\"} -->Example.<!-- /wp:inner -->\n\nExample.\n\n<!-- wp:void /--><!-- /wp:outer -->";
 		$blocks = parse_blocks( $markup );
 
@@ -78,6 +78,144 @@ class Tests_Blocks_Serialize extends WP_UnitTestCase {
 		if ( 'core/inner' === $block['blockName'] ) {
 			$block['attrs']['myattr'] = 'myvalue';
 		}
+	}
+
+	/**
+	 * @ticket 59313
+	 *
+	 * @covers ::traverse_and_serialize_blocks
+	 */
+	public function test_traverse_and_serialize_blocks_pre_callback_prepends_to_inner_block() {
+		$markup = "<!-- wp:outer --><!-- wp:inner {\"key\":\"value\"} -->Example.<!-- /wp:inner -->\n\nExample.\n\n<!-- wp:void /--><!-- /wp:outer -->";
+		$blocks = parse_blocks( $markup );
+
+		$actual = traverse_and_serialize_blocks( $blocks, array( __CLASS__, 'insert_next_to_inner_block_callback' ) );
+
+		$this->assertSame(
+			"<!-- wp:outer --><!-- wp:tests/inserted-block /--><!-- wp:inner {\"key\":\"value\"} -->Example.<!-- /wp:inner -->\n\nExample.\n\n<!-- wp:void /--><!-- /wp:outer -->",
+			$actual
+		);
+	}
+
+	/**
+	 * @ticket 59313
+	 *
+	 * @covers ::traverse_and_serialize_blocks
+	 */
+	public function test_traverse_and_serialize_blocks_post_callback_appends_to_inner_block() {
+		$markup = "<!-- wp:outer --><!-- wp:inner {\"key\":\"value\"} -->Example.<!-- /wp:inner -->\n\nExample.\n\n<!-- wp:void /--><!-- /wp:outer -->";
+		$blocks = parse_blocks( $markup );
+
+		$actual = traverse_and_serialize_blocks( $blocks, null, array( __CLASS__, 'insert_next_to_inner_block_callback' ) );
+
+		$this->assertSame(
+			"<!-- wp:outer --><!-- wp:inner {\"key\":\"value\"} -->Example.<!-- /wp:inner --><!-- wp:tests/inserted-block /-->\n\nExample.\n\n<!-- wp:void /--><!-- /wp:outer -->",
+			$actual
+		);
+	}
+
+	public static function insert_next_to_inner_block_callback( $block ) {
+		if ( 'core/inner' !== $block['blockName'] ) {
+			return '';
+		}
+
+		return get_comment_delimited_block_content( 'tests/inserted-block', array(), '' );
+	}
+
+	/**
+	 * @ticket 59313
+	 *
+	 * @covers ::traverse_and_serialize_blocks
+	 */
+	public function test_traverse_and_serialize_blocks_pre_callback_prepends_to_child_blocks() {
+		$markup = "<!-- wp:outer --><!-- wp:inner {\"key\":\"value\"} -->Example.<!-- /wp:inner -->\n\nExample.\n\n<!-- wp:void /--><!-- /wp:outer -->";
+		$blocks = parse_blocks( $markup );
+
+		$actual = traverse_and_serialize_blocks( $blocks, array( __CLASS__, 'insert_next_to_child_blocks_callback' ) );
+
+		$this->assertSame(
+			"<!-- wp:outer --><!-- wp:tests/inserted-block {\"parent\":\"core/outer\"} /--><!-- wp:inner {\"key\":\"value\"} -->Example.<!-- /wp:inner -->\n\nExample.\n\n<!-- wp:tests/inserted-block {\"parent\":\"core/outer\"} /--><!-- wp:void /--><!-- /wp:outer -->",
+			$actual
+		);
+	}
+
+	/**
+	 * @ticket 59313
+	 *
+	 * @covers ::traverse_and_serialize_blocks
+	 */
+	public function test_traverse_and_serialize_blocks_post_callback_appends_to_child_blocks() {
+		$markup = "<!-- wp:outer --><!-- wp:inner {\"key\":\"value\"} -->Example.<!-- /wp:inner -->\n\nExample.\n\n<!-- wp:void /--><!-- /wp:outer -->";
+		$blocks = parse_blocks( $markup );
+
+		$actual = traverse_and_serialize_blocks( $blocks, null, array( __CLASS__, 'insert_next_to_child_blocks_callback' ) );
+
+		$this->assertSame(
+			"<!-- wp:outer --><!-- wp:inner {\"key\":\"value\"} -->Example.<!-- /wp:inner --><!-- wp:tests/inserted-block {\"parent\":\"core/outer\"} /-->\n\nExample.\n\n<!-- wp:void /--><!-- wp:tests/inserted-block {\"parent\":\"core/outer\"} /--><!-- /wp:outer -->",
+			$actual
+		);
+	}
+
+	public static function insert_next_to_child_blocks_callback( $block, $parent_block ) {
+		if ( ! isset( $parent_block ) ) {
+			return '';
+		}
+
+		return get_comment_delimited_block_content(
+			'tests/inserted-block',
+			array(
+				'parent' => $parent_block['blockName'],
+			),
+			''
+		);
+	}
+
+	/**
+	 * @ticket 59313
+	 *
+	 * @covers ::traverse_and_serialize_blocks
+	 */
+	public function test_traverse_and_serialize_blocks_pre_callback_prepends_if_prev_block() {
+		$markup = "<!-- wp:outer --><!-- wp:inner {\"key\":\"value\"} -->Example.<!-- /wp:inner -->\n\nExample.\n\n<!-- wp:void /--><!-- /wp:outer -->";
+		$blocks = parse_blocks( $markup );
+
+		$actual = traverse_and_serialize_blocks( $blocks, array( __CLASS__, 'insert_next_to_if_prev_or_next_block_callback' ) );
+
+		$this->assertSame(
+			"<!-- wp:outer --><!-- wp:inner {\"key\":\"value\"} -->Example.<!-- /wp:inner -->\n\nExample.\n\n<!-- wp:tests/inserted-block {\"prev_or_next\":\"core/inner\"} /--><!-- wp:void /--><!-- /wp:outer -->",
+			$actual
+		);
+	}
+
+	/**
+	 * @ticket 59313
+	 *
+	 * @covers ::traverse_and_serialize_blocks
+	 */
+	public function test_traverse_and_serialize_blocks_post_callback_appends_if_prev_block() {
+		$markup = "<!-- wp:outer --><!-- wp:inner {\"key\":\"value\"} -->Example.<!-- /wp:inner -->\n\nExample.\n\n<!-- wp:void /--><!-- /wp:outer -->";
+		$blocks = parse_blocks( $markup );
+
+		$actual = traverse_and_serialize_blocks( $blocks, null, array( __CLASS__, 'insert_next_to_if_prev_or_next_block_callback' ) );
+
+		$this->assertSame(
+			"<!-- wp:outer --><!-- wp:inner {\"key\":\"value\"} -->Example.<!-- /wp:inner --><!-- wp:tests/inserted-block {\"prev_or_next\":\"core/void\"} /-->\n\nExample.\n\n<!-- wp:void /--><!-- /wp:outer -->",
+			$actual
+		);
+	}
+
+	public static function insert_next_to_if_prev_or_next_block_callback( $block, $parent_block, $prev_or_next ) {
+		if ( ! isset( $prev_or_next ) ) {
+			return '';
+		}
+
+		return get_comment_delimited_block_content(
+			'tests/inserted-block',
+			array(
+				'prev_or_next' => $prev_or_next['blockName'],
+			),
+			''
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/rest-block-type-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-block-type-controller.php
@@ -62,6 +62,8 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		self::delete_user( self::$admin_id );
 		self::delete_user( self::$subscriber_id );
 		unregister_block_type( 'fake/test' );
+		unregister_block_type( 'fake/invalid' );
+		unregister_block_type( 'fake/false' );
 	}
 
 	/**


### PR DESCRIPTION
## Synopsis

This feature is meant to provide an extensibility mechanism for Block Themes, in analogy to WordPress' [Hooks](https://developer.wordpress.org/plugins/hooks/) concept that has allowed extending Classic Themes through filters and actions.

Specifically, Block Hooks allow a third-party block to specify a position relative to a given block into which it will then be automatically inserted (e.g. a "Like" button block can ask to be inserted after the Post Content block, or an eCommerce shopping cart block can ask to be inserted after the Navigation block).

The two core tenets for block hooks are:

1. Insertion into the frontend should happen right after a plugin containing a hooked block is activated (i.e. the user isn't required to insert the block manually in the editor first); similarly, disabling the plugin should remove the hooked block from the frontend.
2. The user has the ultimate power to customize that automatic insertion: The hooked block is also visible in the editor, and the user's decision to persist, dismiss, customize, or move it will be respected (and reflected on the frontend).

To account for both tenets, we've made the **tradeoff** that automatic block insertion only works for unmodified templates (and template parts, respectively). The reason for this is that the simplest way of storing the information whether a block has been persisted to (or dismissed from) a given template (or part) is right in the template markup. This was first suggested [here](https://github.com/WordPress/gutenberg/issues/39439#issuecomment-1150278043).

To accommodate for that tradeoff, we've [added UI controls (toggles)](https://github.com/WordPress/gutenberg/pull/52969) to increase visibility of hooked blocks, and to allow their later insertion into templates (or parts) that already have been modified by the user.

## Implementation

Since we wanted hooked blocks to appear both in the frontend and in the editor (see tenet number 2), we had to make sure they were inserted into both the frontend markup and the REST API (templates and patterns endpoints) equally. As a consequence, this means that automatic insertion couldn't only be implemented at block _render_ stage, as for the editor, we needed to modify the _serialized_ (but _unrendered_) markup.

However, thanks to the tradeoff we made (see above), we could at least limit ourselves to only inserting hooked blocks into unmodified templates (and parts), i.e. those that were coming directly from a Block Theme's template (or parts) file, rather than the database, and patterns.

It turns out that there's a rather natural stage for automatic insertion of hooked blocks to happen, which is during template file retrieval (and loading of patterns, respectively).

Trac ticket: https://core.trac.wordpress.org/ticket/59313

Supersedes #5158.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
