### PR TITLE
Add `has_filter()` to noop to prevent fatal error in `load-styles.php`

### DIFF
--- a/src/wp-admin/includes/noop.php
+++ b/src/wp-admin/includes/noop.php
@@ -25,6 +25,13 @@ function add_filter() {}
 /**
  * @ignore
  */
+function has_filter() {
+	return false;
+}
+
+/**
+ * @ignore
+ */
 function esc_attr() {}
 
 /**


### PR DESCRIPTION
* The fatal error in `load-styles.php` is happening due to the newly added `has_filter()` calls in https://core.trac.wordpress.org/changeset/56635/trunk/src/wp-includes/theme.php.
* `has_filter()` can easily be added to `noop.php`, which shouldn't be controversial given that other filter functions are already present there as well.
* Just having that function present will fix the bug. The lack of the _actual_ `add_filter()` function does not lead to any problems with the new code.

Trac ticket: https://core.trac.wordpress.org/ticket/59417

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
