### PR TITLE
Blocks: Introduce filter to allow easy addition of hooked blocks

### DIFF
--- a/tests/phpunit/tests/blocks/blockHooks.php
+++ b/tests/phpunit/tests/blocks/blockHooks.php
@@ -49,8 +49,9 @@ class Tests_Blocks_BlockHooks extends WP_UnitTestCase {
 			'tests/injected-one',
 			array(
 				'block_hooks' => array(
-					'tests/hooked-at-before' => 'before',
-					'tests/hooked-at-after'  => 'after',
+					'tests/hooked-at-before'           => 'before',
+					'tests/hooked-at-after'            => 'after',
+					'tests/hooked-at-before-and-after' => 'before',
 				),
 			)
 		);
@@ -58,10 +59,11 @@ class Tests_Blocks_BlockHooks extends WP_UnitTestCase {
 			'tests/injected-two',
 			array(
 				'block_hooks' => array(
-					'tests/hooked-at-before'      => 'before',
-					'tests/hooked-at-after'       => 'after',
-					'tests/hooked-at-first-child' => 'first_child',
-					'tests/hooked-at-last-child'  => 'last_child',
+					'tests/hooked-at-before'           => 'before',
+					'tests/hooked-at-after'            => 'after',
+					'tests/hooked-at-before-and-after' => 'after',
+					'tests/hooked-at-first-child'      => 'first_child',
+					'tests/hooked-at-last-child'       => 'last_child',
 				),
 			)
 		);
@@ -95,6 +97,21 @@ class Tests_Blocks_BlockHooks extends WP_UnitTestCase {
 			),
 			get_hooked_blocks( 'tests/hooked-at-last-child' ),
 			'block hooked at the last child position'
+		);
+		$this->assertSame(
+			array(
+				'tests/injected-one' => 'before',
+				'tests/injected-two' => 'after',
+			),
+			get_hooked_blocks( 'tests/hooked-at-before-and-after' ),
+			'block hooked before one block and after another'
+		);
+		$this->assertSame(
+			array(
+				'tests/injected-one' => 'before',
+			),
+			get_hooked_blocks( 'tests/hooked-at-before-and-after', 'before' ),
+			'block hooked before one block and after another, filtered for before'
 		);
 	}
 }


### PR DESCRIPTION
Introduce a `hooked_block_types` filter that allows even easier conditional addition (or removal) of hooked blocks for a given anchor block and relative position.

```php
function insert_shopping_cart_hooked_block( $hooked_blocks, $position, $anchor_block, $context ) {
	if ( 'after' === $position && 'core/navigation' === $anchor_block && /** $context is header template part **/ ) {
		$hooked_blocks[] = 'mycommerce/shopping-cart';
	}
	return $hooked_blocks;
}
add_filter( 'hooked_block_types', 'insert_shopping_cart_hooked_block', 10, 4 );
```

Based on an idea by @gziolo that we discussed during a call earlier today.

Trac ticket: https://core.trac.wordpress.org/ticket/59424

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
