### PR TITLE
Update the environment variable that skips downloading Chrome/Chromium binaries

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -143,7 +143,7 @@ jobs:
     timeout-minutes: 20
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
     env:
-      PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: ${{ true }}
+      PUPPETEER_SKIP_DOWNLOAD: ${{ true }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/phpunit-tests-run.yml
+++ b/.github/workflows/phpunit-tests-run.yml
@@ -51,7 +51,7 @@ env:
   LOCAL_DB_VERSION: ${{ inputs.db-version }}
   LOCAL_PHP_MEMCACHED: ${{ inputs.memcached }}
   PHPUNIT_CONFIG: ${{ inputs.phpunit-config }}
-  PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: ${{ true }}
+  PUPPETEER_SKIP_DOWNLOAD: ${{ true }}
 
 jobs:
   # Runs the PHPUnit tests for WordPress.

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -29,7 +29,7 @@ on:
 permissions: {}
 
 env:
-  PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: ${{ true }}
+  PUPPETEER_SKIP_DOWNLOAD: ${{ true }}
   LOCAL_PHP: '7.4-fpm'
   LOCAL_PHP_XDEBUG: true
   LOCAL_PHP_XDEBUG_MODE: 'coverage'

--- a/.github/workflows/test-npm.yml
+++ b/.github/workflows/test-npm.yml
@@ -38,7 +38,7 @@ concurrency:
 permissions: {}
 
 env:
-  PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: ${{ true }}
+  PUPPETEER_SKIP_DOWNLOAD: ${{ true }}
 
 jobs:
   # Verifies that installing npm dependencies and building WordPress works as expected.


### PR DESCRIPTION
Since [version 20.0.0, puppeteer uses Chrome instead of Chromium for testing](https://github.com/puppeteer/puppeteer/releases/tag/puppeteer-v20.0.0). The `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD` environment variable was removed in favor of `PUPPETEER_SKIP_DOWNLOAD`.

`puppeteer` is a peer dependency of `grunt-contrib-qunit`, which was updated in [[56647](https://core.trac.wordpress.org/changeset/56647)].

This changes `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD` to `PUPPETEER_SKIP_DOWNLOAD` in order to restore the previous behavior of not downloading the desired binary in workflows where it's not required.

I tracked this down after a recent workflow failed while trying to download Chrome: https://github.com/WordPress/wordpress-develop/actions/runs/6265644591/job/17014933910#step:7:34.
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket:  https://core.trac.wordpress.org/ticket/58863

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
