### PR TITLE
REST API: Improve the block type schema for the `name` field

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
@@ -16,6 +16,8 @@
  */
 class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 
+	const NAME_PATTERN = '^[a-z][a-z0-9-]*/[a-z][a-z0-9-]*$';
+
 	/**
 	 * Instance of WP_Block_Type_Registry.
 	 *
@@ -402,6 +404,8 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 					'name'        => array(
 						'description' => __( 'The name of the inner block.' ),
 						'type'        => 'string',
+						'pattern'     => self::NAME_PATTERN,
+						'required'    => true,
 					),
 					'attributes'  => array(
 						'description' => __( 'The attributes of the inner block.' ),
@@ -479,7 +483,8 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 				'name'                  => array(
 					'description' => __( 'Unique name identifying the block type.' ),
 					'type'        => 'string',
-					'default'     => '',
+					'pattern'     => self::NAME_PATTERN,
+					'required'    => true,
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
@@ -689,7 +694,8 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 					'description' => __( 'Parent blocks.' ),
 					'type'        => array( 'array', 'null' ),
 					'items'       => array(
-						'type' => 'string',
+						'type'    => 'string',
+						'pattern' => self::NAME_PATTERN,
 					),
 					'default'     => null,
 					'context'     => array( 'embed', 'view', 'edit' ),
@@ -699,7 +705,8 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 					'description' => __( 'Ancestor blocks.' ),
 					'type'        => array( 'array', 'null' ),
 					'items'       => array(
-						'type' => 'string',
+						'type'    => 'string',
+						'pattern' => self::NAME_PATTERN,
 					),
 					'default'     => null,
 					'context'     => array( 'embed', 'view', 'edit' ),
@@ -711,7 +718,7 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 					'description'       => __( 'This block is automatically inserted near any occurence of the block types used as keys of this map, into a relative position given by the corresponding value.' ),
 					'type'              => 'object',
 					'patternProperties' => array(
-						'^[a-zA-Z0-9-]+/[a-zA-Z0-9-]+$' => array(
+						self::NAME_PATTERN => array(
 							'type' => 'string',
 							'enum' => array( 'before', 'after', 'first_child', 'last_child' ),
 						),


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/59346

The goal of this PR is to align the schema between `block.json` and the REST API endpoint for block types. It looks like the `name` field isn't validated in all places and if it uses pattern matching in the REST API code, then it's slightly different.

https://github.com/WordPress/gutenberg/blob/aa938166f28bcfff6c7b8d1caac5a95f78852f97/schemas/json/block.json#L26

https://github.com/WordPress/gutenberg/blob/f6d16f0b9f0a71d51c7178d35902c078b0d33c08/packages/blocks/src/api/registration.js#L231

I opted for using the same pattern as during block registration in JavaScript:

```php
'^[a-z][a-z0-9-]*/[a-z][a-z0-9-]*$'
```


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
