### PR TITLE
Blocks: Add more unit test covering edge cases for Block Hooks

### DIFF
--- a/tests/phpunit/tests/blocks/serialize.php
+++ b/tests/phpunit/tests/blocks/serialize.php
@@ -242,7 +242,7 @@ class Tests_Blocks_Serialize extends WP_UnitTestCase {
 	 * @covers ::traverse_and_serialize_blocks
 	 */
 	public function test_traverse_and_serialize_blocks_do_not_insert_in_void_block() {
-		$markup = "<!-- wp:void /-->";
+		$markup = '<!-- wp:void /-->';
 		$blocks = parse_blocks( $markup );
 
 		$actual = traverse_and_serialize_blocks(
@@ -260,7 +260,7 @@ class Tests_Blocks_Serialize extends WP_UnitTestCase {
 	 * @covers ::traverse_and_serialize_blocks
 	 */
 	public function test_traverse_and_serialize_blocks_do_not_insert_in_empty_parent_block() {
-		$markup = "<!-- wp:outer --><div class=\"wp-block-outer\"></div><!-- /wp:outer -->";
+		$markup = '<!-- wp:outer --><div class="wp-block-outer"></div><!-- /wp:outer -->';
 		$blocks = parse_blocks( $markup );
 
 		$actual = traverse_and_serialize_blocks(

--- a/tests/phpunit/tests/blocks/serialize.php
+++ b/tests/phpunit/tests/blocks/serialize.php
@@ -235,4 +235,40 @@ class Tests_Blocks_Serialize extends WP_UnitTestCase {
 
 		$this->assertSame( $original, $actual );
 	}
+
+	/**
+	 * @ticket 59313
+	 *
+	 * @covers ::traverse_and_serialize_blocks
+	 */
+	public function test_traverse_and_serialize_blocks_do_not_insert_in_void_block() {
+		$markup = "<!-- wp:void /-->";
+		$blocks = parse_blocks( $markup );
+
+		$actual = traverse_and_serialize_blocks(
+			$blocks,
+			array( __CLASS__, 'insert_next_to_child_blocks_callback' ),
+			array( __CLASS__, 'insert_next_to_child_blocks_callback' )
+		);
+
+		$this->assertSame( $markup, $actual );
+	}
+
+	/**
+	 * @ticket 59313
+	 *
+	 * @covers ::traverse_and_serialize_blocks
+	 */
+	public function test_traverse_and_serialize_blocks_do_not_insert_in_empty_parent_block() {
+		$markup = "<!-- wp:outer --><div class=\"wp-block-outer\"></div><!-- /wp:outer -->";
+		$blocks = parse_blocks( $markup );
+
+		$actual = traverse_and_serialize_blocks(
+			$blocks,
+			array( __CLASS__, 'insert_next_to_child_blocks_callback' ),
+			array( __CLASS__, 'insert_next_to_child_blocks_callback' )
+		);
+
+		$this->assertSame( $markup, $actual );
+	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/59313

Follow-up for: https://core.trac.wordpress.org/changeset/56649

These two new unit tests document how Block Hooks behave with `firstChild` and `lastChild` relative positions. The hooked blocks will only get inserted in the case where the parent block has at least one child block present. While it seems like a limitation, in practice, it's hard to think of a case where the template would use a parent block without its children. It's more likely to happen with patterns in general, but in the case of patterns wired with the block theme, it also seems unlikely. The reasoning here is that out of the box, the block theme should produce a fully functional and valid HTML.

Replaces unit tests that cover similar cases in the Gutenberg plugin that are going to be removed with https://github.com/WordPress/gutenberg/pull/54651.


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
