### PR TITLE
Editor: mention reusable block rename to pattern(s) in each doc

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -653,9 +653,11 @@ function has_blocks( $post = null ) {
  *
  * This test optimizes for performance rather than strict accuracy, detecting
  * whether the block type exists but not validating its structure and not checking
- * reusable blocks. For strict accuracy, you should use the block parser on post content.
+ * patterns (previously referred to as reusable blocks). For strict accuracy, you
+ * should use the block parser on post content.
  *
  * @since 5.0.0
+ * @since 6.3.0 Reusable Blocks renamed to Patterns.
  *
  * @see parse_blocks()
  *

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -653,7 +653,7 @@ function has_blocks( $post = null ) {
  *
  * This test optimizes for performance rather than strict accuracy, detecting
  * whether the block type exists but not validating its structure and not checking
- * patterns (previously referred to as reusable blocks). For strict accuracy, you
+ * synced pattern (previously referred to as reusable blocks). For strict accuracy, you
  * should use the block parser on post content.
  *
  * @since 5.0.0

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -653,7 +653,7 @@ function has_blocks( $post = null ) {
  *
  * This test optimizes for performance rather than strict accuracy, detecting
  * whether the block type exists but not validating its structure and not checking
- * synced pattern (formerly called reusable blocks). For strict accuracy, you
+ * synced patterns (formerly called reusable blocks). For strict accuracy, you
  * should use the block parser on post content.
  *
  * @since 5.0.0

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -653,7 +653,7 @@ function has_blocks( $post = null ) {
  *
  * This test optimizes for performance rather than strict accuracy, detecting
  * whether the block type exists but not validating its structure and not checking
- * synced pattern (previously referred to as reusable blocks). For strict accuracy, you
+ * synced pattern (formerly called reusable blocks). For strict accuracy, you
  * should use the block parser on post content.
  *
  * @since 5.0.0

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -657,7 +657,6 @@ function has_blocks( $post = null ) {
  * should use the block parser on post content.
  *
  * @since 5.0.0
- * @since 6.3.0 Reusable Blocks renamed to Patterns.
  *
  * @see parse_blocks()
  *

--- a/src/wp-includes/blocks/block.php
+++ b/src/wp-includes/blocks/block.php
@@ -8,8 +8,6 @@
 /**
  * Renders the `core/block` block on server.
  *
- * @since 6.3.0 Reusable Blocks renamed to Patterns.
- *
  * @param array $attributes The block attributes.
  *
  * @return string Rendered HTML of the referenced block.

--- a/src/wp-includes/blocks/block.php
+++ b/src/wp-includes/blocks/block.php
@@ -8,6 +8,8 @@
 /**
  * Renders the `core/block` block on server.
  *
+ * @since 6.3.0 Reusable Blocks renamed to Patterns.
+ *
  * @param array $attributes The block attributes.
  *
  * @return string Rendered HTML of the referenced block.

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-blocks-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-blocks-controller.php
@@ -9,7 +9,7 @@
 
 /**
  * Controller which provides a REST endpoint for the editor to read, create,
- * edit and delete synced pattern (previously referred to as reusable blocks).
+ * edit and delete synced pattern (formerly called reusable blocks).
  * Patterns are stored as posts with the wp_block post type.
  *
  * @since 5.0.0
@@ -20,12 +20,12 @@
 class WP_REST_Blocks_Controller extends WP_REST_Posts_Controller {
 
 	/**
-	 * Checks if a synced pattern (previously referred to as reusable block) can be read.
+	 * Checks if a synced pattern (formerly called reusable blocks) can be read.
 	 *
 	 * @since 5.0.0
 	 *
 	 * @param WP_Post $post Post object that backs the block.
-	 * @return bool Whether the synced pattern (previously referred to as reusable block) can be read.
+	 * @return bool Whether the synced pattern (formerly called reusable blocks) can be read.
 	 */
 	public function check_read_permission( $post ) {
 		// By default the read_post capability is mapped to edit_posts.
@@ -51,8 +51,8 @@ class WP_REST_Blocks_Controller extends WP_REST_Posts_Controller {
 
 		/*
 		 * Remove `title.rendered` and `content.rendered` from the response. It
-		 * doesn't make sense for a synced pattern (previously referred to as
-		 * reusable block) to have rendered content on its own, since rendering
+		 * doesn't make sense for a synced pattern (formerly called reusable blocks)
+		 * to have rendered content on its own, since rendering
 		 * a block requires it to be inside a post or a page.
 		 */
 		unset( $data['title']['rendered'] );
@@ -65,7 +65,7 @@ class WP_REST_Blocks_Controller extends WP_REST_Posts_Controller {
 	}
 
 	/**
-	 * Retrieves the synced pattern (previously referred to as reusable blocks) schema, conforming
+	 * Retrieves the synced pattern (formerly called reusable blocks) schema, conforming
 	 * to JSON Schema.
 	 *
 	 * @since 5.0.0
@@ -81,16 +81,16 @@ class WP_REST_Blocks_Controller extends WP_REST_Posts_Controller {
 
 		/*
 		 * Allow all contexts to access `title.raw` and `content.raw`. Clients always
-		 * need the raw markup of a synced pattern (previously referred to as reusable
-		 * block) to do anything useful, e.g. parse it or display it in an editor.
+		 * need the raw markup of a synced pattern (formerly called reusable blocks)
+		 * to do anything useful, e.g. parse it or display it in an editor.
 		 */
 		$schema['properties']['title']['properties']['raw']['context']   = array( 'view', 'edit' );
 		$schema['properties']['content']['properties']['raw']['context'] = array( 'view', 'edit' );
 
 		/*
 		 * Remove `title.rendered` and `content.rendered` from the schema. It doesn’t
-		 * make sense for a synced pattern (previously referred to as reusable block)
-		 * to have rendered content on its own, since rendering a block requires it
+		 * make sense for a synced pattern (formerly called reusable blocks) to
+		 * have rendered content on its own, since rendering a block requires it
 		 * to be inside a post or a page.
 		 */
 		unset( $schema['properties']['title']['properties']['rendered'] );

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-blocks-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-blocks-controller.php
@@ -9,11 +9,10 @@
 
 /**
  * Controller which provides a REST endpoint for the editor to read, create,
- * edit and delete patterns (previously referred to as reusable blocks). Patterns are
- * stored as posts with the wp_block post type.
+ * edit and delete synced pattern (previously referred to as reusable blocks).
+ * Patterns are stored as posts with the wp_block post type.
  *
  * @since 5.0.0
- * @since 6.3.0 Reusable Blocks renamed to Patterns.
  *
  * @see WP_REST_Posts_Controller
  * @see WP_REST_Controller
@@ -21,13 +20,12 @@
 class WP_REST_Blocks_Controller extends WP_REST_Posts_Controller {
 
 	/**
-	 * Checks if a pattern (previously referred to as reusable block) can be read.
+	 * Checks if a synced pattern (previously referred to as reusable block) can be read.
 	 *
 	 * @since 5.0.0
-   * @since 6.3.0 Reusable Blocks renamed to Patterns.
 	 *
 	 * @param WP_Post $post Post object that backs the block.
-	 * @return bool Whether the pattern (previously referred to as reusable block) can be read.
+	 * @return bool Whether the synced pattern (previously referred to as reusable block) can be read.
 	 */
 	public function check_read_permission( $post ) {
 		// By default the read_post capability is mapped to edit_posts.
@@ -43,7 +41,6 @@ class WP_REST_Blocks_Controller extends WP_REST_Posts_Controller {
 	 *
 	 * @since 5.0.0
 	 * @since 6.3.0 Adds the `wp_pattern_sync_status` postmeta property to the top level of response.
-	 * @since 6.3.0 Reusable Blocks renamed to Patterns.
 	 *
 	 * @param array  $data    Response data to filter.
 	 * @param string $context Context defined in the schema.
@@ -54,8 +51,9 @@ class WP_REST_Blocks_Controller extends WP_REST_Posts_Controller {
 
 		/*
 		 * Remove `title.rendered` and `content.rendered` from the response. It
-		 * doesn't make sense for a reusable block to have rendered content on its
-		 * own, since rendering a block requires it to be inside a post or a page.
+		 * doesn't make sense for a synced pattern (previously referred to as
+		 * reusable block) to have rendered content on its own, since rendering
+		 * a block requires it to be inside a post or a page.
 		 */
 		unset( $data['title']['rendered'] );
 		unset( $data['content']['rendered'] );
@@ -67,11 +65,10 @@ class WP_REST_Blocks_Controller extends WP_REST_Posts_Controller {
 	}
 
 	/**
-	 * Retrieves the patterns (previously referred to as reusable blocks) schema, conforming
+	 * Retrieves the synced pattern (previously referred to as reusable blocks) schema, conforming
 	 * to JSON Schema.
 	 *
 	 * @since 5.0.0
-	 * @since 6.3.0 Reusable Blocks renamed to Patterns.
 	 *
 	 * @return array Item schema data.
 	 */
@@ -84,16 +81,17 @@ class WP_REST_Blocks_Controller extends WP_REST_Posts_Controller {
 
 		/*
 		 * Allow all contexts to access `title.raw` and `content.raw`. Clients always
-		 * need the raw markup of a reusable block to do anything useful, e.g. parse
-		 * it or display it in an editor.
+		 * need the raw markup of a synced pattern (previously referred to as reusable
+		 * block) to do anything useful, e.g. parse it or display it in an editor.
 		 */
 		$schema['properties']['title']['properties']['raw']['context']   = array( 'view', 'edit' );
 		$schema['properties']['content']['properties']['raw']['context'] = array( 'view', 'edit' );
 
 		/*
 		 * Remove `title.rendered` and `content.rendered` from the schema. It doesn’t
-		 * make sense for a reusable block to have rendered content on its own, since
-		 * rendering a block requires it to be inside a post or a page.
+		 * make sense for a synced pattern (previously referred to as reusable block)
+		 * to have rendered content on its own, since rendering a block requires it
+		 * to be inside a post or a page.
 		 */
 		unset( $schema['properties']['title']['properties']['rendered'] );
 		unset( $schema['properties']['content']['properties']['rendered'] );

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-blocks-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-blocks-controller.php
@@ -9,7 +9,7 @@
 
 /**
  * Controller which provides a REST endpoint for the editor to read, create,
- * edit and delete synced pattern (formerly called reusable blocks).
+ * edit and delete synced patterns (formerly called reusable blocks).
  * Patterns are stored as posts with the wp_block post type.
  *
  * @since 5.0.0

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-blocks-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-blocks-controller.php
@@ -9,10 +9,11 @@
 
 /**
  * Controller which provides a REST endpoint for the editor to read, create,
- * edit and delete reusable blocks. Blocks are stored as posts with the wp_block
- * post type.
+ * edit and delete patterns (previously referred to as reusable blocks). Patterns are
+ * stored as posts with the wp_block post type.
  *
  * @since 5.0.0
+ * @since 6.3.0 Reusable Blocks renamed to Patterns.
  *
  * @see WP_REST_Posts_Controller
  * @see WP_REST_Controller
@@ -20,12 +21,13 @@
 class WP_REST_Blocks_Controller extends WP_REST_Posts_Controller {
 
 	/**
-	 * Checks if a block can be read.
+	 * Checks if a pattern (previously referred to as reusable block) can be read.
 	 *
 	 * @since 5.0.0
+   * @since 6.3.0 Reusable Blocks renamed to Patterns.
 	 *
 	 * @param WP_Post $post Post object that backs the block.
-	 * @return bool Whether the block can be read.
+	 * @return bool Whether the pattern (previously referred to as reusable block) can be read.
 	 */
 	public function check_read_permission( $post ) {
 		// By default the read_post capability is mapped to edit_posts.
@@ -41,6 +43,7 @@ class WP_REST_Blocks_Controller extends WP_REST_Posts_Controller {
 	 *
 	 * @since 5.0.0
 	 * @since 6.3.0 Adds the `wp_pattern_sync_status` postmeta property to the top level of response.
+	 * @since 6.3.0 Reusable Blocks renamed to Patterns.
 	 *
 	 * @param array  $data    Response data to filter.
 	 * @param string $context Context defined in the schema.
@@ -64,9 +67,11 @@ class WP_REST_Blocks_Controller extends WP_REST_Posts_Controller {
 	}
 
 	/**
-	 * Retrieves the block's schema, conforming to JSON Schema.
+	 * Retrieves the patterns (previously referred to as reusable blocks) schema, conforming
+	 * to JSON Schema.
 	 *
 	 * @since 5.0.0
+	 * @since 6.3.0 Reusable Blocks renamed to Patterns.
 	 *
 	 * @return array Item schema data.
 	 */

--- a/tests/phpunit/tests/rest-api/rest-blocks-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-blocks-controller.php
@@ -98,7 +98,7 @@ class REST_Blocks_Controller_Test extends WP_UnitTestCase {
 
 	/**
 	 * Exhaustively check that each role either can or cannot create, edit,
-	 * update, and delete synced pattern (formerly called reusable blocks).
+	 * update, and delete synced patterns (formerly called reusable blocks).
 	 *
 	 * @ticket 45098
 	 *

--- a/tests/phpunit/tests/rest-api/rest-blocks-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-blocks-controller.php
@@ -98,7 +98,7 @@ class REST_Blocks_Controller_Test extends WP_UnitTestCase {
 
 	/**
 	 * Exhaustively check that each role either can or cannot create, edit,
-	 * update, and delete synced pattern (previously referred to as reusable blocks).
+	 * update, and delete synced pattern (formerly called reusable blocks).
 	 *
 	 * @ticket 45098
 	 *

--- a/tests/phpunit/tests/rest-api/rest-blocks-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-blocks-controller.php
@@ -98,11 +98,13 @@ class REST_Blocks_Controller_Test extends WP_UnitTestCase {
 
 	/**
 	 * Exhaustively check that each role either can or cannot create, edit,
-	 * update, and delete reusable blocks.
+	 * update, and delete patterns (previously referred to as reusable blocks).
 	 *
 	 * @ticket 45098
 	 *
 	 * @dataProvider data_capabilities
+	 *
+	 * @since 6.3.0 Reusable Blocks renamed to Patterns.
 	 *
 	 * @param string $action          Action to perform in the test.
 	 * @param string $role            User role to test.

--- a/tests/phpunit/tests/rest-api/rest-blocks-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-blocks-controller.php
@@ -98,13 +98,11 @@ class REST_Blocks_Controller_Test extends WP_UnitTestCase {
 
 	/**
 	 * Exhaustively check that each role either can or cannot create, edit,
-	 * update, and delete patterns (previously referred to as reusable blocks).
+	 * update, and delete synced pattern (previously referred to as reusable blocks).
 	 *
 	 * @ticket 45098
 	 *
 	 * @dataProvider data_capabilities
-	 *
-	 * @since 6.3.0 Reusable Blocks renamed to Patterns.
 	 *
 	 * @param string $action          Action to perform in the test.
 	 * @param string $role            User role to test.


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This adds comments in the docs that patterns and reusable blocks are the same, and that patterns is the new name since 6.3.0.

Trac ticket: https://core.trac.wordpress.org/ticket/59388

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
