### PR TITLE
Blocks: Change get_hooked_blocks() to returned hooked blocks grouped by relative position

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -740,29 +740,28 @@ function get_dynamic_block_names() {
 }
 
 /**
- * Retrieves block types (and positions) hooked into the given block.
+ * Retrieves block types hooked into the given block, grouped by their relative position.
  *
  * @since 6.4.0
  *
- * @param string $name              Block type name including namespace.
- * @param string $relative_position Optional. Relative position of the hooked block. Default empty string.
- * @return array Associative array of `$block_type_name => $position` pairs.
+ * @param string $name Block type name including namespace.
+ * @return array[] Array of block types grouped by their relative position.
  */
-function get_hooked_blocks( $name, $relative_position = '' ) {
+function get_hooked_blocks( $name ) {
 	$block_types   = WP_Block_Type_Registry::get_instance()->get_all_registered();
 	$hooked_blocks = array();
 	foreach ( $block_types as $block_type ) {
 		if ( ! ( $block_type instanceof WP_Block_Type ) || ! is_array( $block_type->block_hooks ) ) {
 			continue;
 		}
-		foreach ( $block_type->block_hooks as $anchor_block_type => $position ) {
+		foreach ( $block_type->block_hooks as $anchor_block_type => $relative_position ) {
 			if ( $anchor_block_type !== $name ) {
 				continue;
 			}
-			if ( $relative_position && $relative_position !== $position ) {
-				continue;
+			if ( ! array_key_exists( $relative_position, $hooked_blocks ) ) {
+				$hooked_blocks[ $relative_position ] = array();
 			}
-			$hooked_blocks[ $block_type->name ] = $position;
+			$hooked_blocks[ $relative_position ][] = $block_type->name;
 		}
 	}
 	return $hooked_blocks;
@@ -804,7 +803,14 @@ function make_before_block_visitor( $context ) {
 			// Candidate for first-child insertion.
 			$relative_position  = 'first_child';
 			$anchor_block_type  = $parent['blockName'];
-			$hooked_block_types = array_keys( get_hooked_blocks( $anchor_block_type, $relative_position ) );
+			$hooked_block_types = get_hooked_blocks( $anchor_block_type );
+
+			if ( array_key_exists( $relative_position, $hooked_block_types ) ) {
+				$hooked_block_types = $hooked_block_types[ $relative_position ];
+			} else {
+				$hooked_block_types = array();
+			}
+
 			/**
 			 * Filters the list of hooked block types for a given anchor block type and relative position.
 			 *
@@ -824,7 +830,14 @@ function make_before_block_visitor( $context ) {
 
 		$relative_position  = 'before';
 		$anchor_block_type  = $block['blockName'];
-		$hooked_block_types = array_keys( get_hooked_blocks( $anchor_block_type, $relative_position ) );
+		$hooked_block_types = get_hooked_blocks( $anchor_block_type );
+
+		if ( array_key_exists( $relative_position, $hooked_block_types ) ) {
+			$hooked_block_types = $hooked_block_types[ $relative_position ];
+		} else {
+			$hooked_block_types = array();
+		}
+
 		/** This filter is documented in wp-includes/blocks.php */
 		$hooked_block_types = apply_filters( 'hooked_block_types', $hooked_block_types, $relative_position, $anchor_block_type, $context );
 		foreach ( $hooked_block_types as $hooked_block_type ) {
@@ -866,7 +879,14 @@ function make_after_block_visitor( $context ) {
 
 		$relative_position  = 'after';
 		$anchor_block_type  = $block['blockName'];
-		$hooked_block_types = array_keys( get_hooked_blocks( $anchor_block_type, $relative_position ) );
+		$hooked_block_types = get_hooked_blocks( $anchor_block_type );
+
+		if ( array_key_exists( $relative_position, $hooked_block_types ) ) {
+			$hooked_block_types = $hooked_block_types[ $relative_position ];
+		} else {
+			$hooked_block_types = array();
+		}
+
 		/** This filter is documented in wp-includes/blocks.php */
 		$hooked_block_types = apply_filters( 'hooked_block_types', $hooked_block_types, $relative_position, $anchor_block_type, $context );
 		foreach ( $hooked_block_types as $hooked_block_type ) {
@@ -877,7 +897,14 @@ function make_after_block_visitor( $context ) {
 			// Candidate for last-child insertion.
 			$relative_position  = 'last_child';
 			$anchor_block_type  = $parent['blockName'];
-			$hooked_block_types = array_keys( get_hooked_blocks( $anchor_block_type, $relative_position ) );
+			$hooked_block_types = get_hooked_blocks( $anchor_block_type );
+
+			if ( array_key_exists( $relative_position, $hooked_block_types ) ) {
+				$hooked_block_types = $hooked_block_types[ $relative_position ];
+			} else {
+				$hooked_block_types = array();
+			}
+
 			/** This filter is documented in wp-includes/blocks.php */
 			$hooked_block_types = apply_filters( 'hooked_block_types', $hooked_block_types, $relative_position, $anchor_block_type, $context );
 			foreach ( $hooked_block_types as $hooked_block_type ) {

--- a/tests/phpunit/tests/blocks/blockHooks.php
+++ b/tests/phpunit/tests/blocks/blockHooks.php
@@ -70,45 +70,59 @@ class Tests_Blocks_BlockHooks extends WP_UnitTestCase {
 
 		$this->assertSame(
 			array(
-				'tests/injected-one' => 'before',
-				'tests/injected-two' => 'before',
+				'before' => array(
+					'tests/injected-one',
+					'tests/injected-two',
+				),
 			),
 			get_hooked_blocks( 'tests/hooked-at-before' ),
 			'block hooked at the before position'
 		);
 		$this->assertSame(
 			array(
-				'tests/injected-one' => 'after',
-				'tests/injected-two' => 'after',
+				'after' => array(
+					'tests/injected-one',
+					'tests/injected-two',
+				),
 			),
 			get_hooked_blocks( 'tests/hooked-at-after' ),
 			'block hooked at the after position'
 		);
 		$this->assertSame(
 			array(
-				'tests/injected-two' => 'first_child',
+				'first_child' => array(
+					'tests/injected-two',
+				),
 			),
 			get_hooked_blocks( 'tests/hooked-at-first-child' ),
 			'block hooked at the first child position'
 		);
 		$this->assertSame(
 			array(
-				'tests/injected-two' => 'last_child',
+				'last_child' => array(
+					'tests/injected-two',
+				),
 			),
 			get_hooked_blocks( 'tests/hooked-at-last-child' ),
 			'block hooked at the last child position'
 		);
 		$this->assertSame(
 			array(
-				'tests/injected-one' => 'before',
-				'tests/injected-two' => 'after',
+				'before' => array(
+					'tests/injected-one',
+				),
+				'after'  => array(
+					'tests/injected-two',
+				),
 			),
 			get_hooked_blocks( 'tests/hooked-at-before-and-after' ),
 			'block hooked before one block and after another'
 		);
 		$this->assertSame(
 			array(
-				'tests/injected-one' => 'before',
+				'before' => array(
+					'tests/injected-one'
+				),
 			),
 			get_hooked_blocks( 'tests/hooked-at-before-and-after', 'before' ),
 			'block hooked before one block and after another, filtered for before'


### PR DESCRIPTION
See the unit test diff to see how the return format has changed.

The main reason for doing is is that all existing calls of `get_hooked_blocks` in production code used to need an extra `array_keys` call. This seemed beside the point.

Furthermore, this allows us to remove the extra `$relative_position` argument from the function again, as the same data can now be simply fetched via array access.

Trac ticket: TBD

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
