### PR TITLE
Font Face: Fix getting the font-family name

### DIFF
--- a/src/wp-includes/fonts/class-wp-font-face-resolver.php
+++ b/src/wp-includes/fonts/class-wp-font-face-resolver.php
@@ -50,28 +50,52 @@ class WP_Font_Face_Resolver {
 		foreach ( $settings['typography']['fontFamilies'] as $font_families ) {
 			foreach ( $font_families as $definition ) {
 
-				// Skip if font-family "name" is not defined.
-				if ( empty( $definition['name'] ) ) {
-					continue;
-				}
-
 				// Skip if "fontFace" is not defined, meaning there are no variations.
 				if ( empty( $definition['fontFace'] ) ) {
 					continue;
 				}
 
-				$font_family = $definition['name'];
-
-				// Prepare the fonts array structure for this font-family.
-				if ( ! array_key_exists( $font_family, $fonts ) ) {
-					$fonts[ $font_family ] = array();
+				// Skip if "fontFamily" is not defined.
+				if ( empty( $definition['fontFamily'] ) ) {
+					continue;
 				}
 
-				$fonts[ $font_family ] = static::convert_font_face_properties( $definition['fontFace'], $font_family );
+				$font_family_name = static::maybe_parse_name_from_comma_separated_list( $definition['fontFamily'] );
+
+				// Skip if no font family is defined.
+				if ( empty( $font_family_name ) ) {
+					continue;
+				}
+
+				// Prepare the fonts array structure for this font-family.
+				if ( ! array_key_exists( $font_family_name, $fonts ) ) {
+					$fonts[ $font_family_name ] = array();
+				}
+
+				$fonts[ $font_family_name ] = static::convert_font_face_properties( $definition['fontFace'], $font_family_name );
 			}
 		}
 
 		return $fonts;
+	}
+
+	/**
+	 * Parse font-family name from comma-separated lists.
+	 *
+	 * If the given `fontFamily` is a comma-separated lists (example: "Inter, sans-serif" ),
+	 * parse and return the fist font from the list.
+	 *
+	 * @since 6.4.0
+	 *
+	 * @param string $font_family Font family `fontFamily' to parse.
+	 * @return string Font-family name.
+	 */
+	private static function maybe_parse_name_from_comma_separated_list( $font_family ) {
+		if ( str_contains( $font_family, ',' ) ) {
+			$font_family = explode( ',', $font_family )[0];
+		}
+
+		return trim( $font_family, "\"'" );
 	}
 
 	/**

--- a/tests/phpunit/tests/fonts/font-face/wpFontFaceResolver/getFontsFromThemeJson.php
+++ b/tests/phpunit/tests/fonts/font-face/wpFontFaceResolver/getFontsFromThemeJson.php
@@ -96,4 +96,108 @@ class Tests_Fonts_WPFontFaceResolver_GetFontsFromThemeJson extends WP_Font_Face_
 			),
 		);
 	}
+
+	/**
+	 * @dataProvider data_should_get_font_family_name
+	 *
+	 * @param array  $fonts         Fonts to test.
+	 * @param string $expected_name Expected font-family name.
+	 */
+	public function test_should_get_font_family_name( $fonts, $expected_name ) {
+		switch_theme( static::FONTS_THEME );
+
+		$replace_fonts = static function ( $theme_json_data ) use ( $fonts ) {
+			$data = $theme_json_data->get_data();
+
+			// Replace typography.fontFamilies.
+			$data['settings']['typography']['fontFamilies']['theme'] = $fonts;
+
+			return new WP_Theme_JSON_Data( $data );
+		};
+		add_filter( 'wp_theme_json_data_theme', $replace_fonts );
+		$fonts = WP_Font_Face_Resolver::get_fonts_from_theme_json();
+		remove_filter( 'wp_theme_json_data_theme', $replace_fonts );
+
+		$this->assertArrayHasKey( $expected_name, $fonts );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_should_get_font_family_name() {
+		$font_face = array(
+			array(
+				'fontFamily'  => 'DM Sans',
+				'fontStretch' => 'normal',
+				'fontStyle'   => 'normal',
+				'fontWeight'  => '400',
+				'src'         => array(
+					'file:./assets/fonts/dm-sans/DMSans-Regular.woff2',
+				),
+			),
+			array(
+				'fontFamily'  => 'DM Sans',
+				'fontStretch' => 'normal',
+				'fontStyle'   => 'italic',
+				'fontWeight'  => '400',
+				'src'         => array(
+					'file:./assets/fonts/dm-sans/DMSans-Regular-Italic.woff2',
+				),
+			),
+			array(
+				'fontFamily'  => 'DM Sans',
+				'fontStretch' => 'normal',
+				'fontStyle'   => 'italic',
+				'fontWeight'  => '700',
+				'src'         => array(
+					'file:./assets/fonts/dm-sans/DMSans-Bold.woff2',
+				),
+			),
+			array(
+				'fontFamily'  => 'DM Sans',
+				'fontStretch' => 'normal',
+				'fontStyle'   => 'italic',
+				'fontWeight'  => '700',
+				'src'         => array(
+					'file:./assets/fonts/dm-sans/DMSans-Bold-Italic.woff2',
+				),
+			),
+		);
+
+		return array(
+			'name declared'                   => array(
+				'fonts'         => array(
+					array(
+						'fontFamily' => 'DM Sans',
+						'name'       => 'DM Sans Family',
+						'slug'       => 'dm-sans',
+						'fontFace'   => $font_face,
+					),
+				),
+				'expected_name' => 'DM Sans',
+			),
+			'name not declared'               => array(
+				'fonts'         => array(
+					array(
+						'fontFamily' => 'DM Sans',
+						'slug'       => 'dm-sans',
+						'fontFace'   => $font_face,
+					),
+				),
+				'expected_name' => 'DM Sans',
+			),
+			'fontFamily comma-separated list' => array(
+				'fonts'         => array(
+					array(
+						'fontFamily' => '"DM Sans", sans-serif',
+						'slug'       => 'dm-sans',
+						'fontFace'   => $font_face,
+					),
+				),
+				'expected_name' => 'DM Sans',
+			),
+		);
+	}
 }


### PR DESCRIPTION
Fixes a BC break in how the font-family name is pulled from the incoming font data.

Merge from Gutenberg's PR https://github.com/WordPress/gutenberg/pull/54615.

## What?

Gets the font-family name from the `"fontFamily"` field, instead of  the `"name"` field.

## Why?
To avoid a back-compatibility (BC) break for themes that do not have the `"name"` field defined.

WP Core also does not require the `"name"` setting. Using it exclusively is a BC break.

It's not clearly documented that the `"name"` setting is required. Thus, it's been optional.

## How?

Uses the font-family's `fontFamily` field instead of  its `name` field.

As the `fontFamily` field could be a comma-separated list of font-families, it parses the list to extract the first entry.

### Why `fontFamily` setting?

`WP_Theme_JSON` schema requires the `fontFamily` setting in each of the `typography.fontFamilies`. 

Trac ticket: https://core.trac.wordpress.org/ticket/59165

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
