### PR TITLE
Remove null coalescing operator from layout.

### DIFF
--- a/src/wp-includes/block-supports/layout.php
+++ b/src/wp-includes/block-supports/layout.php
@@ -770,7 +770,7 @@ function wp_render_layout_support_flag( $block_content, $block ) {
 	 * @var string|null
 	 */
 	$inner_block_wrapper_classes = null;
-	$first_chunk                 = isset($block['innerContent'][0]) ? $block['innerContent'][0] : null;
+	$first_chunk                 = isset( $block['innerContent'][0] ) ? $block['innerContent'][0] : null;
 	if ( is_string( $first_chunk ) && count( $block['innerContent'] ) > 1 ) {
 		$first_chunk_processor = new WP_HTML_Tag_Processor( $first_chunk );
 		while ( $first_chunk_processor->next_tag() ) {

--- a/src/wp-includes/block-supports/layout.php
+++ b/src/wp-includes/block-supports/layout.php
@@ -549,7 +549,7 @@ function wp_get_layout_style( $selector, $layout, $has_block_gap_support = false
 function wp_render_layout_support_flag( $block_content, $block ) {
 	$block_type            = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
 	$block_supports_layout = block_has_support( $block_type, 'layout', false ) || block_has_support( $block_type, '__experimentalLayout', false );
-	$layout_from_parent    = $block['attrs']['style']['layout']['selfStretch'] ?? null;
+	$layout_from_parent    = isset($block['attrs']['style']['layout']['selfStretch']) ? $block['attrs']['style']['layout']['selfStretch'] : null;
 
 	if ( ! $block_supports_layout && ! $layout_from_parent ) {
 		return $block_content;
@@ -770,7 +770,7 @@ function wp_render_layout_support_flag( $block_content, $block ) {
 	 * @var string|null
 	 */
 	$inner_block_wrapper_classes = null;
-	$first_chunk                 = $block['innerContent'][0] ?? null;
+	$first_chunk                 = isset($block['innerContent'][0]) ? $block['innerContent'][0] : null;
 	if ( is_string( $first_chunk ) && count( $block['innerContent'] ) > 1 ) {
 		$first_chunk_processor = new WP_HTML_Tag_Processor( $first_chunk );
 		while ( $first_chunk_processor->next_tag() ) {

--- a/src/wp-includes/block-supports/layout.php
+++ b/src/wp-includes/block-supports/layout.php
@@ -549,7 +549,7 @@ function wp_get_layout_style( $selector, $layout, $has_block_gap_support = false
 function wp_render_layout_support_flag( $block_content, $block ) {
 	$block_type            = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
 	$block_supports_layout = block_has_support( $block_type, 'layout', false ) || block_has_support( $block_type, '__experimentalLayout', false );
-	$layout_from_parent    = isset($block['attrs']['style']['layout']['selfStretch']) ? $block['attrs']['style']['layout']['selfStretch'] : null;
+	$layout_from_parent    = isset( $block['attrs']['style']['layout']['selfStretch'] ) ? $block['attrs']['style']['layout']['selfStretch'] : null;
 
 	if ( ! $block_supports_layout && ! $layout_from_parent ) {
 		return $block_content;


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/59443

Follow-up to #5252: replaces uses of null coalescing operator in that PR due to it [not being officially supported](https://core.trac.wordpress.org/ticket/58874) in WP yet.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
