### PR TITLE
Use wp_kses() in wp_trigger_error()

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -6046,6 +6046,10 @@ function _doing_it_wrong( $function_name, $message, $version ) {
  *
  * @param string $function_name The function that triggered the error.
  * @param string $message       The message explaining the error.
+ *                              The message can contain allowed HTML 'a' (with href), 'code',
+ *                              'br', 'em', and 'strong' tags and http or https protocols.
+ *                              If it contains other HTML tags or protocols, the message should be escaped
+ *                              before passing to this function to avoid being stripped {@see wp_kses()}.
  * @param int    $error_level   Optional. The designated error type for this error.
  *                              Only works with E_USER family of constants. Default E_USER_NOTICE.
  */
@@ -6073,12 +6077,17 @@ function wp_trigger_error( $function_name, $message, $error_level = E_USER_NOTIC
 		$message = sprintf( '%s(): %s', $function_name, $message );
 	}
 
-	/*
-	 * If the message appears in the browser, then it needs to be escaped.
-	 * Note the warning in the `trigger_error()` PHP manual.
-	 * @link https://www.php.net/manual/en/function.trigger-error.php
-	 */
-	$message = esc_html( $message );
+	$message = wp_kses(
+		$message,
+		array(
+			'a' => array( 'href' ),
+			'br',
+			'code',
+			'em',
+			'strong',
+		),
+		array( 'http', 'https' )
+	);
 
 	trigger_error( $message, $error_level );
 }


### PR DESCRIPTION
Implements the balance between security and readability:

* Replaces `esc_html()` with `wp_kses()` with a list of allowed HTML tags and protocols.
* Documents extenders need to first escape HTML that is disallowed before passing the message to the function. Else, the disallowed tags and protocols will be stripped from the message.

Trac ticket: https://core.trac.wordpress.org/ticket/57686

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
