### PR TITLE
Remove deprecated 'print_emoji_styles' when generating the block editor's iframe assets

### DIFF
--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -359,10 +359,23 @@ function _wp_get_iframed_editor_assets() {
 		}
 	}
 
+	/**
+	 * Remove the deprecated `print_emoji_styles` handler.
+	 * It avoids breaking style generation with a deprecation message.
+	 */
+	$has_emoji_styles = has_action( 'wp_print_styles', 'print_emoji_styles' );
+	if ( $has_emoji_styles ) {
+		remove_action( 'wp_print_styles', 'print_emoji_styles' );
+	}
+
 	ob_start();
 	wp_print_styles();
 	wp_print_font_faces();
 	$styles = ob_get_clean();
+
+	if ( $has_emoji_styles ) {
+		add_action( 'wp_print_styles', 'print_emoji_styles' );
+	}
 
 	ob_start();
 	wp_print_head_scripts();


### PR DESCRIPTION
PR removes the recently deprecated `print_emoji_styles` handler when generating the block editor's iframe assets.

## Why

Deprecation notice triggered by the callback breaks editor styles when `WP_DEBUG` is set to true.

## Testing Instructions.

1. Enable debugging:

```
define( 'WP_DEBUG', true );
define( 'WP_DEBUG_LOG', false );
define( 'WP_DEBUG_DISPLAY', true );
```

2. Open a post or page.
3. Insert a group block.
4. Placeholder styles shouldn't be broken.
5. Run the following script on the DevTools console - `wp.data.select( 'core/block-editor' ).getSettings().__unstableResolvedAssets.styles`
6. Returned value shouldn't include a deprecation message.

## Screenshot
![CleanShot 2023-09-26 at 15 34 26](https://github.com/WordPress/wordpress-develop/assets/240569/f21ae7b6-de72-4e03-bb0e-1f1f6df7ceac)

Trac ticket: https://core.trac.wordpress.org/ticket/58775.

