### PR TITLE
Templates: Deprecate _inject_theme_attribute_in_block_template_content().

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -475,12 +475,15 @@ function _flatten_blocks( &$blocks ) {
  * stylesheet as a theme attribute into each wp_template_part
  *
  * @since 5.9.0
+ * @deprecated 6.4.0 Use _inject_theme_attribute_in_template_part_block() with traverse_and_serialize_blocks() instead.
  * @access private
  *
  * @param string $template_content serialized wp_template content.
  * @return string Updated 'wp_template' content.
  */
 function _inject_theme_attribute_in_block_template_content( $template_content ) {
+	_deprecated_function( __FUNCTION__, '6.4.0' );
+
 	$has_updated_content = false;
 	$new_content         = '';
 	$template_blocks     = parse_blocks( $template_content );

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -475,14 +475,18 @@ function _flatten_blocks( &$blocks ) {
  * stylesheet as a theme attribute into each wp_template_part
  *
  * @since 5.9.0
- * @deprecated 6.4.0 Use _inject_theme_attribute_in_template_part_block() with traverse_and_serialize_blocks() instead.
+ * @deprecated 6.4.0 Use traverse_and_serialize_blocks( parse_blocks( $template_content ), '_inject_theme_attribute_in_template_part_block' ) instead.
  * @access private
  *
  * @param string $template_content serialized wp_template content.
  * @return string Updated 'wp_template' content.
  */
 function _inject_theme_attribute_in_block_template_content( $template_content ) {
-	_deprecated_function( __FUNCTION__, '6.4.0' );
+	_deprecated_function(
+		__FUNCTION__,
+		'6.4.0',
+		'traverse_and_serialize_blocks( parse_blocks( $template_content ), "_inject_theme_attribute_in_template_part_block" )'
+	);
 
 	$has_updated_content = false;
 	$new_content         = '';

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -312,6 +312,10 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 59452
+	 *
+	 * @covers ::_inject_theme_attribute_in_block_template_content
+	 *
 	 * @expectedDeprecated _inject_theme_attribute_in_block_template_content
 	 */
 	public function test_inject_theme_attribute_in_block_template_content() {

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -311,6 +311,9 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * @expectedDeprecated _inject_theme_attribute_in_block_template_content
+	 */
 	public function test_inject_theme_attribute_in_block_template_content() {
 		$theme                           = get_stylesheet();
 		$content_without_theme_attribute = '<!-- wp:template-part {"slug":"header","align":"full", "tagName":"header","className":"site-header"} /-->';


### PR DESCRIPTION
I'd like to deprecate `_inject_theme_attribute_in_block_template_content()`, as it can be replaced by using `_inject_theme_attribute_in_template_part_block()` in combination with `traverse_and_serialize_blocks()` on the parsed template blocks instead. Note that the function has always had `@access private` set in its PHPDoc.

The only code in Core that it's called from is synced from Gutenberg (dynamic blocks' PHP code).
- It was removed from the Template Part block in https://github.com/WordPress/gutenberg/pull/52892. This change will be synced to Core before Beta 1.
- It was added to the Pattern block in https://github.com/WordPress/gutenberg/pull/53423.
  - [Per https://github.com/WordPress/wordpress-develop/pull/5261](https://github.com/WordPress/wordpress-develop/pull/5261/files#diff-119add4c8563b7b812d6ee6496a8416e25ecd0ef945310478d8344c0bbcdee93), it is no longer needed for WP >= 6.4.
  - Per https://github.com/WordPress/gutenberg/pull/54651, it is only called from inside the Pattern block for WP < 6.4. That PR is [scheduled for inclusion in WP 6.4 Beta 1](https://github.com/WordPress/gutenberg/pull/54651#issuecomment-1735670004).
 
Trac ticket: https://core.trac.wordpress.org/ticket/59452

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
