### PR TITLE
Sync: Don't enqueue edit site stylesheet in iframe

### DIFF
--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -299,7 +299,7 @@ function get_legacy_widget_block_editor_settings() {
  * }
  */
 function _wp_get_iframed_editor_assets() {
-	global $wp_styles, $wp_scripts, $pagenow;
+	global $wp_styles, $wp_scripts;
 
 	// Keep track of the styles and scripts instance to restore later.
 	$current_wp_styles  = $wp_styles;
@@ -328,10 +328,6 @@ function _wp_get_iframed_editor_assets() {
 	wp_enqueue_script( 'wp-polyfill' );
 	// Enqueue the `editorStyle` handles for all core block, and dependencies.
 	wp_enqueue_style( 'wp-edit-blocks' );
-
-	if ( 'site-editor.php' === $pagenow ) {
-		wp_enqueue_style( 'wp-edit-site' );
-	}
 
 	if ( current_theme_supports( 'wp-block-styles' ) ) {
 		wp_enqueue_style( 'wp-block-library-theme' );


### PR DESCRIPTION
Note: This is probably better to merge after packages are synced, because without CSS changes from the PR the site editor produced as console warning.

```
index.js:148 wp-edit-site-css was added to the iframe incorrectly. Please use block.json or enqueue_block_assets to add styles to the iframe.
```

Gutenberg PR: https://github.com/WordPress/gutenberg/pull/54254
Trac ticket: https://core.trac.wordpress.org/ticket/59456

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
