### PR TITLE
Fix bug when comparing options that have a pre filter.

### DIFF
--- a/tests/phpunit/tests/option/option.php
+++ b/tests/phpunit/tests/option/option.php
@@ -439,7 +439,6 @@ class Tests_Option_Option extends WP_UnitTestCase {
 		}
 	}
 
-
 	/**
 	 * Data provider.
 	 *
@@ -580,5 +579,59 @@ class Tests_Option_Option extends WP_UnitTestCase {
 		);
 
 		$this->assertSame( 1, $actual );
+	}
+
+	/**
+	 * Tests that a non-existing option is added even when its pre filter returns a value.
+	 *
+	 * @ticket 22192
+	 *
+	 * @covers ::update_option
+	 */
+	public function test_update_option_with_pre_filter_adds_missing_option() {
+		// Force a return value of integer 0.
+		add_filter( 'pre_option_foo', '__return_zero' );
+
+		/*
+		 * This should succeed, since the 'foo' option does not exist in the database.
+		 * The default value is false, so it differs from 0.
+		 */
+		$this->assertTrue( update_option( 'foo', 0 ) );
+	}
+
+	/**
+	 * Tests that an existing option is updated even when its pre filter returns the same value.
+	 *
+	 * @ticket 22192
+	 *
+	 * @covers ::update_option
+	 */
+	public function test_update_option_with_pre_filter_updates_option_with_different_value() {
+		// Add the option with a value of 1 to the database.
+		add_option( 'foo', 1 );
+
+		// Force a return value of integer 0.
+		add_filter( 'pre_option_foo', '__return_zero' );
+
+		/*
+		 * This should succeed, since the 'foo' option has a value of 1 in the database.
+		 * Therefore it differs from 0 and should be updated.
+		 */
+		$this->assertTrue( update_option( 'foo', 0 ) );
+	}
+
+	/**
+	 * Tests that calling update_option() does not permanently remove pre filters.
+	 *
+	 * @ticket 22192
+	 *
+	 * @covers ::update_option
+	 */
+	public function test_update_option_maintains_pre_filters() {
+		add_filter( 'pre_option_foo', '__return_zero' );
+		update_option( 'foo', 0 );
+
+		// Assert that the filter is still present.
+		$this->assertSame( 10, has_filter( 'pre_option_foo', '__return_zero' ) );
 	}
 }


### PR DESCRIPTION
This implements my first suggestion from https://core.trac.wordpress.org/ticket/22192#comment:55, addressing the follow up bug for options with pre filters.

Tests are included and proves this fixes the issue: Without the changes in `option.php`, the new tests `test_update_option_with_pre_filter_adds_missing_option()` and `test_update_option_with_pre_filter_updates_option_with_different_value()` fail.

Trac ticket: https://core.trac.wordpress.org/ticket/22192

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
