### PR TITLE
Templates: Introduce _remove_theme_attribute_from_template_part_block function

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1266,7 +1266,7 @@ function wp_generate_block_templates_export_file() {
 		$template->content = traverse_and_serialize_blocks(
 			parse_blocks( $template->content ),
 			'_remove_theme_attribute_from_template_part_block'
-		)
+		);
 
 		$zip->addFromString(
 			'templates/' . $template->slug . '.html',

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -493,12 +493,19 @@ function _inject_theme_attribute_in_template_part_block( &$block ) {
  * Parses a block template and removes the theme attribute from each template part.
  *
  * @since 5.9.0
+ * @deprecated 6.4.0 Use traverse_and_serialize_blocks( parse_blocks( $template_content ), '_remove_theme_attribute_from_template_part_block' ) instead.
  * @access private
  *
  * @param string $template_content Serialized block template content.
  * @return string Updated block template content.
  */
 function _remove_theme_attribute_in_block_template_content( $template_content ) {
+	_deprecated_function(
+		__FUNCTION__,
+		'6.4.0',
+		'traverse_and_serialize_blocks( parse_blocks( $template_content ), "_remove_theme_attribute_from_template_part_block" )'
+	);
+
 	$has_updated_content = false;
 	$new_content         = '';
 	$template_blocks     = parse_blocks( $template_content );

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1303,7 +1303,11 @@ function wp_generate_block_templates_export_file() {
 	// Load templates into the zip file.
 	$templates = get_block_templates();
 	foreach ( $templates as $template ) {
-		$template->content = _remove_theme_attribute_in_block_template_content( $template->content );
+		$template_blocks   = parse_blocks( $template->content );
+		$template->content = traverse_and_serialize_blocks(
+			$template_blocks,
+			'_remove_theme_attribute_from_template_part_block'
+		)
 
 		$zip->addFromString(
 			'templates/' . $template->slug . '.html',

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1303,9 +1303,8 @@ function wp_generate_block_templates_export_file() {
 	// Load templates into the zip file.
 	$templates = get_block_templates();
 	foreach ( $templates as $template ) {
-		$template_blocks   = parse_blocks( $template->content );
 		$template->content = traverse_and_serialize_blocks(
-			$template_blocks,
+			parse_blocks( $template->content ),
 			'_remove_theme_attribute_from_template_part_block'
 		)
 

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -490,46 +490,6 @@ function _inject_theme_attribute_in_template_part_block( &$block ) {
 }
 
 /**
- * Parses a block template and removes the theme attribute from each template part.
- *
- * @since 5.9.0
- * @deprecated 6.4.0 Use traverse_and_serialize_blocks( parse_blocks( $template_content ), '_remove_theme_attribute_from_template_part_block' ) instead.
- * @access private
- *
- * @param string $template_content Serialized block template content.
- * @return string Updated block template content.
- */
-function _remove_theme_attribute_in_block_template_content( $template_content ) {
-	_deprecated_function(
-		__FUNCTION__,
-		'6.4.0',
-		'traverse_and_serialize_blocks( parse_blocks( $template_content ), "_remove_theme_attribute_from_template_part_block" )'
-	);
-
-	$has_updated_content = false;
-	$new_content         = '';
-	$template_blocks     = parse_blocks( $template_content );
-
-	$blocks = _flatten_blocks( $template_blocks );
-	foreach ( $blocks as $key => $block ) {
-		if ( 'core/template-part' === $block['blockName'] && isset( $block['attrs']['theme'] ) ) {
-			unset( $blocks[ $key ]['attrs']['theme'] );
-			$has_updated_content = true;
-		}
-	}
-
-	if ( ! $has_updated_content ) {
-		return $template_content;
-	}
-
-	foreach ( $template_blocks as $block ) {
-		$new_content .= serialize_block( $block );
-	}
-
-	return $new_content;
-}
-
-/**
  * Removes the `theme` attribute from a given template part block.
  *
  * @since 6.4.0

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -523,6 +523,24 @@ function _remove_theme_attribute_in_block_template_content( $template_content ) 
 }
 
 /**
+ * Removes the `theme` attribute from a given template part block.
+ *
+ * @since 6.4.0
+ * @access private
+ *
+ * @param array $block a parsed block.
+ * @return void
+ */
+function _remove_theme_attribute_from_template_part_block( &$block ) {
+	if (
+		'core/template-part' === $block['blockName'] &&
+		isset( $block['attrs']['theme'] )
+	) {
+		unset( $block['attrs']['theme'] );
+	}
+}
+
+/**
  * Builds a unified template object based on a theme file.
  *
  * @since 5.9.0

--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -6084,3 +6084,43 @@ function _inject_theme_attribute_in_block_template_content( $template_content ) 
 
 	return $template_content;
 }
+
+/**
+ * Parses a block template and removes the theme attribute from each template part.
+ *
+ * @since 5.9.0
+ * @deprecated 6.4.0 Use traverse_and_serialize_blocks( parse_blocks( $template_content ), '_remove_theme_attribute_from_template_part_block' ) instead.
+ * @access private
+ *
+ * @param string $template_content Serialized block template content.
+ * @return string Updated block template content.
+ */
+function _remove_theme_attribute_in_block_template_content( $template_content ) {
+	_deprecated_function(
+		__FUNCTION__,
+		'6.4.0',
+		'traverse_and_serialize_blocks( parse_blocks( $template_content ), "_remove_theme_attribute_from_template_part_block" )'
+	);
+
+	$has_updated_content = false;
+	$new_content         = '';
+	$template_blocks     = parse_blocks( $template_content );
+
+	$blocks = _flatten_blocks( $template_blocks );
+	foreach ( $blocks as $key => $block ) {
+		if ( 'core/template-part' === $block['blockName'] && isset( $block['attrs']['theme'] ) ) {
+			unset( $blocks[ $key ]['attrs']['theme'] );
+			$has_updated_content = true;
+		}
+	}
+
+	if ( ! $has_updated_content ) {
+		return $template_content;
+	}
+
+	foreach ( $template_blocks as $block ) {
+		$new_content .= serialize_block( $block );
+	}
+
+	return $new_content;
+}

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -368,6 +368,29 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		$this->assertSame( $expected, _remove_theme_attribute_in_block_template_content( $template_content ) );
 	}
 
+	/**
+	 * @ticket 59460
+	 *
+	 * @covers ::_remove_theme_attribute_from_template_part_block
+	 * @covers ::traverse_and_serialize_blocks
+	 *
+	 * @dataProvider data_remove_theme_attribute_in_block_template_content
+	 *
+	 * @param string $template_content The template markup.
+	 * @param string $expected         The expected markup after removing the theme attribute from Template Part blocks.
+	 */
+	public function test_remove_theme_attribute_from_template_part_block( $template_content, $expected ) {
+		$template_content_parsed_blocks = parse_blocks( $template_content );
+
+		$this->assertSame(
+			$expected,
+			traverse_and_serialize_blocks(
+				$template_content_parsed_blocks,
+				'_remove_theme_attribute_from_template_part_block'
+			)
+		);
+	}
+
 	public function data_remove_theme_attribute_in_block_template_content() {
 		return array(
 			array(

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -361,8 +361,11 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 54448
+	 * @ticket 59460
 	 *
 	 * @dataProvider data_remove_theme_attribute_in_block_template_content
+	 *
+	 * @expectedDeprecated _remove_theme_attribute_in_block_template_content
 	 */
 	public function test_remove_theme_attribute_in_block_template_content( $template_content, $expected ) {
 		$this->assertSame( $expected, _remove_theme_attribute_in_block_template_content( $template_content ) );


### PR DESCRIPTION
Introduce a `_remove_theme_attribute_from_template_part_block()` function that can be used as a callback argument for `traverse_and_serialize_block(s)` on a parsed block tree in order to remove the `theme` attribute from all Template Part blocks found therein, and deprecate `_remove_theme_attribute_in_block_template_content()`.

Counterpart to `_inject_theme_attribute_in_template_part_block` from #59338 (which superseded `_inject_theme_attribute_in_block_template_content`, deprecated in #59452).

Trac ticket: https://core.trac.wordpress.org/ticket/59460

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
