### PR TITLE
Fix custom button block style so that its path is correctly provided

### DIFF
--- a/src/wp-content/themes/twentytwentyfour/functions.php
+++ b/src/wp-content/themes/twentytwentyfour/functions.php
@@ -33,20 +33,11 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 			'core/button',
 			array(
 				'handle' => 'twentytwentyfour-button-style-outline',
-				'src'    => get_template_directory_uri() . '/assets/css/button-outline.css',
+				'src'    => get_theme_file_uri( 'assets/css/button-outline.css' ),
 				'ver'    => wp_get_theme()->get( 'Version' ),
+				'path'   => get_theme_file_path( 'assets/css/button-outline.css' ),
 			)
 		);
-
-		/**
-		 * Add the `path` data to our stylesheet.
-		 *
-		 * This will let WordPress determine the best loading strategy for the stylesheet:
-		 * Small stylesheets will get inlined, while larger stylesheets will be loaded separately.
-		 *
-		 * See https://make.wordpress.org/core/2021/07/01/block-styles-loading-enhancements-in-wordpress-5-8/#inlining-small-assets for more info.
-		 */
-		wp_style_add_data( 'twentytwentyfour-button-style-outline', 'path', get_theme_file_path( 'assets/css/button-outline.css' ) );
 
 		register_block_style(
 			'core/details',
@@ -63,11 +54,11 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 					padding-bottom: var(--wp--preset--spacing--10);
 					border-bottom: 1px solid rgba(255, 255, 255, 0.20);
 				}
-				
+
 				.is-style-arrow-icon-details summary {
 					list-style-type: "\2193\00a0\00a0\00a0";
 				}
-				
+
 				.is-style-arrow-icon-details[open]>summary {
 					list-style-type: "\2192\00a0\00a0\00a0";
 				}',
@@ -90,7 +81,7 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 					padding: 0.375rem 0.875rem;
 					border-radius: var(--wp--preset--spacing--20);
 				}
-				
+
 				.is-style-pill a:hover {
 					background-color: var(--wp--preset--color--contrast-3);
 				}',
@@ -109,7 +100,7 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 				ul.is-style-checkmark-list {
 					list-style-type: "\2713";
 				}
-				
+
 				ul.is-style-checkmark-list li {
 					padding-inline-start: 1ch;
 				}',
@@ -129,15 +120,15 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 					clip-path: path('M11.93.684v8.039l5.633-5.633 1.216 1.23-5.66 5.66h8.04v1.737H13.2l5.701 5.701-1.23 1.23-5.742-5.742V21h-1.737v-8.094l-5.77 5.77-1.23-1.217 5.743-5.742H.842V9.98h8.162l-5.701-5.7 1.23-1.231 5.66 5.66V.684h1.737Z');
 					display: block;
 				}
-				
+
 				.is-style-asterisk.has-text-align-center:before {
 					margin: 0 auto;
 				}
-				
+
 				.is-style-asterisk.has-text-align-right:before {
 					margin-left: auto;
 				}
-				
+
 				.rtl .is-style-asterisk.has-text-align-left:before {
 					margin-right: auto;
 				}",

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -3154,6 +3154,7 @@ function wp_enqueue_stored_styles( $options = array() ) {
  *     @type string[]         $deps   Array of registered stylesheet handles this stylesheet depends on.
  *     @type string|bool|null $ver    Stylesheet version number.
  *     @type string           $media  The media for which this stylesheet has been defined.
+ *     @type string|null      $path   Absolute path to the stylesheet, so that it can potentially be inlined.
  * }
  */
 function wp_enqueue_block_style( $block_name, $args ) {


### PR DESCRIPTION
* The `'path'` argument of `wp_enqueue_block_style()` needs to be used instead of `wp_style_add_data()`. The latter only works when using `wp_register_style()` or `wp_enqueue_style()`.
* The URL and path need to be provided using the same set of functions - preferably `get_theme_file_uri()` and `get_theme_file_path()`, so that they can be optionally overwritten in a child theme.
* The `wp_enqueue_block_style()` function has its documentation improved to add the missing parameter.
* A few empty lines were modified to no longer include tabs, which shouldn't be the case per WPCS.

Trac ticket: https://core.trac.wordpress.org/ticket/59466

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
