### PR TITLE
Idea to add dimension attributes and image loading optimization attributes for images included in block template files

### DIFF
--- a/src/wp-content/themes/twentytwentyfour/functions.php
+++ b/src/wp-content/themes/twentytwentyfour/functions.php
@@ -63,11 +63,11 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 					padding-bottom: var(--wp--preset--spacing--10);
 					border-bottom: 1px solid rgba(255, 255, 255, 0.20);
 				}
-				
+
 				.is-style-arrow-icon-details summary {
 					list-style-type: "\2193\00a0\00a0\00a0";
 				}
-				
+
 				.is-style-arrow-icon-details[open]>summary {
 					list-style-type: "\2192\00a0\00a0\00a0";
 				}',
@@ -90,7 +90,7 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 					padding: 0.375rem 0.875rem;
 					border-radius: var(--wp--preset--spacing--20);
 				}
-				
+
 				.is-style-pill a:hover {
 					background-color: var(--wp--preset--color--contrast-3);
 				}',
@@ -109,7 +109,7 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 				ul.is-style-checkmark-list {
 					list-style-type: "\2713";
 				}
-				
+
 				ul.is-style-checkmark-list li {
 					padding-inline-start: 1ch;
 				}',
@@ -129,15 +129,15 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 					clip-path: path('M11.93.684v8.039l5.633-5.633 1.216 1.23-5.66 5.66h8.04v1.737H13.2l5.701 5.701-1.23 1.23-5.742-5.742V21h-1.737v-8.094l-5.77 5.77-1.23-1.217 5.743-5.742H.842V9.98h8.162l-5.701-5.7 1.23-1.231 5.66 5.66V.684h1.737Z');
 					display: block;
 				}
-				
+
 				.is-style-asterisk.has-text-align-center:before {
 					margin: 0 auto;
 				}
-				
+
 				.is-style-asterisk.has-text-align-right:before {
 					margin-left: auto;
 				}
-				
+
 				.rtl .is-style-asterisk.has-text-align-left:before {
 					margin-right: auto;
 				}",
@@ -147,3 +147,22 @@ if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 endif;
 
 add_action( 'init', 'twentytwentyfour_block_styles' );
+
+if ( ! function_exists( 'twentytwentyfour_img_tag_add_width_and_height_attr' ) ) :
+
+	function twentytwentyfour_img_tag_add_width_and_height_attr( $value, $image, $context, $attachment_id, $image_src ) {
+		$theme_dir = get_template_directory_uri();
+
+		switch ( $image_src ) {
+			case "{$theme_dir}/assets/images/business-hero.webp":
+				return array(
+					'width'  => 2560,
+					'height' => 1200,
+				);
+		}
+
+		return $value;
+	}
+endif;
+
+add_filter( 'wp_img_tag_add_width_and_height_attr', 'twentytwentyfour_img_tag_add_width_and_height_attr', 10, 5 );

--- a/src/wp-content/themes/twentytwentyfour/functions.php
+++ b/src/wp-content/themes/twentytwentyfour/functions.php
@@ -154,6 +154,7 @@ if ( ! function_exists( 'twentytwentyfour_img_tag_add_width_and_height_attr' ) )
 		$theme_dir = get_template_directory_uri();
 
 		switch ( $image_src ) {
+			// TODO: Add clauses for all other theme bundled images here.
 			case "{$theme_dir}/assets/images/business-hero.webp":
 				return array(
 					'width'  => 2560,

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -1879,7 +1879,7 @@ function wp_filter_content_tags( $content, $context = null ) {
 			$attachment_id  = $images[ $match[0] ];
 
 			// Add 'width' and 'height' attributes if applicable.
-			if ( $attachment_id > 0 && ! str_contains( $filtered_image, ' width=' ) && ! str_contains( $filtered_image, ' height=' ) ) {
+			if ( ! str_contains( $filtered_image, ' width=' ) && ! str_contains( $filtered_image, ' height=' ) ) {
 				$filtered_image = wp_img_tag_add_width_and_height_attr( $filtered_image, $context, $attachment_id );
 			}
 
@@ -2104,22 +2104,32 @@ function wp_img_tag_add_width_and_height_attr( $image, $context, $attachment_id 
 	 * Returning anything else than `true` will not add the attributes.
 	 *
 	 * @since 5.5.0
+	 * @since 6.4.0 The $value parameter can now be used to return an array with specific 'width' and 'height'.
+	 * @since 6.4.0 The $image_src parameter was added.
 	 *
-	 * @param bool   $value         The filtered value, defaults to `true`.
-	 * @param string $image         The HTML `img` tag where the attribute should be added.
-	 * @param string $context       Additional context about how the function was called or where the img tag is.
-	 * @param int    $attachment_id The image attachment ID.
+	 * @param bool|array $value         The filtered value, defaults to `true`.
+	 * @param string     $image         The HTML `img` tag where the attribute should be added.
+	 * @param string     $context       Additional context about how the function was called or where the img tag is.
+	 * @param int        $attachment_id The image attachment ID.
+	 * @param string     $image_src     The image src attribute value.
 	 */
-	$add = apply_filters( 'wp_img_tag_add_width_and_height_attr', true, $image, $context, $attachment_id );
+	$add = apply_filters( 'wp_img_tag_add_width_and_height_attr', true, $image, $context, $attachment_id, $image_src );
 
-	if ( true === $add ) {
+	$size_array = null;
+	if ( true === $add && $attachment_id > 0 ) {
 		$image_meta = wp_get_attachment_metadata( $attachment_id );
 		$size_array = wp_image_src_get_dimensions( $image_src, $image_meta, $attachment_id );
-
-		if ( $size_array ) {
-			$hw = trim( image_hwstring( $size_array[0], $size_array[1] ) );
-			return str_replace( '<img', "<img {$hw}", $image );
+	} elseif ( is_array( $add ) ) {
+		$width  = isset( $add['width'] ) ? (int) $add['width'] : 0;
+		$height = isset( $add['height'] ) ? (int) $add['height'] : 0;
+		if ( $width && $height ) {
+			$size_array = array( $width, $height );
 		}
+	}
+
+	if ( $size_array ) {
+		$hw = trim( image_hwstring( $size_array[0], $size_array[1] ) );
+		return str_replace( '<img', "<img {$hw}", $image );
 	}
 
 	return $image;
@@ -5634,10 +5644,11 @@ function wp_get_loading_optimization_attributes( $tag_name, $attr, $context ) {
 	$loading_attrs = array();
 
 	/*
-	 * Skip lazy-loading for the overall block template, as it is handled more granularly.
-	 * The skip is also applicable for `fetchpriority`.
+	 * Skip processing images for the overall block template, as it is handled more granularly.
+	 * The only exception are images that haven't been processed before, which can more or less reliably be determined
+	 * by checking presence of the `decoding="async"` attribute, since _every_ image receives that attribute.
 	 */
-	if ( 'template' === $context ) {
+	if ( 'template' === $context && ( 'img' !== $tag_name || isset( $attr['decoding'] ) && 'async' === $attr['decoding'] ) ) {
 		/** This filter is documented in wp-includes/media.php */
 		return apply_filters( 'wp_get_loading_optimization_attributes', $loading_attrs, $tag_name, $attr, $context );
 	}
@@ -5776,8 +5787,11 @@ function wp_get_loading_optimization_attributes( $tag_name, $attr, $context ) {
 			 * Any image before the loop, but after the header has started should not be lazy-loaded,
 			 * except when the footer has already started which can happen when the current template
 			 * does not include any loop.
+			 *
+			 * Block themes may not include a header template part, so for those the overall
+			 * 'template' context is explicitly supported.
 			 */
-			&& did_action( 'get_header' ) && ! did_action( 'get_footer' )
+			&& ( did_action( 'get_header' ) || 'template' === $context ) && ! did_action( 'get_footer' )
 			) {
 			$maybe_in_viewport    = true;
 			$maybe_increase_count = true;


### PR DESCRIPTION
See https://core.trac.wordpress.org/ticket/59464#comment:3 for context: This PR explores an approach with which block template files with images can receive their image dimensions in a way that keeps the blocks compliant with the block editor markup. It also addresses an additional issue in `wp_get_loading_optimization_attributes()` that prevents the loading optimization attributes to be granted on the overall block template, which is relevant for the TT4 theme as it displays several images outside of block template parts.

There's a lot to unpack here, so bear with me:
* To add `width` and `height` attributes to images in block template files:
    * Most importantly, this PR enhances the existing `wp_img_tag_add_width_and_height_attr` filter so that it can be used to return specific `width` and `height` attributes for an image. It'll furthermore pass the image src value to the filter, and the filter is run for images that aren't for an attachment as well - since the attachment ID is only necessary to _automatically_ fetch the dimension attributes anyway, which is still the default behavior from the filter's `true` value.
    * The new filter behavior is used in TT4 to return dimensions for the bundled images specifically. For now, since this is just an early draft, only the main hero image is covered, but this could easily be expanded to all other images.
* To make loading optimization attributes work on images that are _directly_ within a block template:
    * The `template` context was so far completely skipped, however TT4 proves that that's not a reasonable approach, since images may also be included directly in a block template, i.e. outside of a template part.
    * The PR changes the logic to only skip images in the `template` context if they were already modified, which can be more or less reliably be assumed based on the presence of `decoding="async"`, which is added to every image.
    * The PR then also caters for block themes that do not use the `header` template part, in which case the `get_header` action never fires.

There are obviously many changes included here, and this is an early draft for consideration. We may decide some of these approaches are reasonable while others are not. When testing though, it can be seen that the TT4 hero image on the home page is now properly receiving all expected attributes.

Trac ticket: https://core.trac.wordpress.org/ticket/59464

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
