### PR TITLE
Fix `wp_get_archives` for years <1000

### DIFF
--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -2125,7 +2125,7 @@ function wp_get_archives( $args = '' ) {
 				if ( 'post' !== $parsed_args['post_type'] ) {
 					$url = add_query_arg( 'post_type', $parsed_args['post_type'], $url );
 				}
-				$date = sprintf( '%1$d-%2$02d-%3$02d 00:00:00', $result->year, $result->month, $result->dayofmonth );
+				$date = sprintf( '%1$s-%2$02d-%3$02d 00:00:00', $result->year, $result->month, $result->dayofmonth );
 				$text = mysql2date( get_option( 'date_format' ), $date );
 				if ( $parsed_args['show_post_count'] ) {
 					$parsed_args['after'] = '&nbsp;(' . $result->posts . ')' . $after;

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -2066,7 +2066,9 @@ function wp_get_archives( $args = '' ) {
 		if ( $results ) {
 			$after = $parsed_args['after'];
 			foreach ( (array) $results as $result ) {
-				$url = get_month_link( $result->year, $result->month );
+				// Add leading zeros when year has lower than 4 digits.
+				$year = str_pad( $result->year, 4, '0', STR_PAD_LEFT );
+				$url  = get_month_link( $year, $result->month );
 				if ( 'post' !== $parsed_args['post_type'] ) {
 					$url = add_query_arg( 'post_type', $parsed_args['post_type'], $url );
 				}

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -2067,13 +2067,13 @@ function wp_get_archives( $args = '' ) {
 			$after = $parsed_args['after'];
 			foreach ( (array) $results as $result ) {
 				// Add leading zeros when year has lower than 4 digits.
-				$year = str_pad( $result->year, 4, '0', STR_PAD_LEFT );
-				$url  = get_month_link( $year, $result->month );
+				$result->year = str_pad( $result->year, 4, '0', STR_PAD_LEFT );
+				$url          = get_month_link( $result->year, $result->month );
 				if ( 'post' !== $parsed_args['post_type'] ) {
 					$url = add_query_arg( 'post_type', $parsed_args['post_type'], $url );
 				}
 				/* translators: 1: Month name, 2: 4-digit year. */
-				$text = sprintf( __( '%1$s %2$d' ), $wp_locale->get_month( $result->month ), $result->year );
+				$text = sprintf( __( '%1$s %2$s' ), $wp_locale->get_month( $result->month ), $result->year );
 				if ( $parsed_args['show_post_count'] ) {
 					$parsed_args['after'] = '&nbsp;(' . $result->posts . ')' . $after;
 				}
@@ -2093,11 +2093,13 @@ function wp_get_archives( $args = '' ) {
 		if ( $results ) {
 			$after = $parsed_args['after'];
 			foreach ( (array) $results as $result ) {
-				$url = get_year_link( $result->year );
+				// Add leading zeros when year has lower than 4 digits.
+				$result->year = str_pad( $result->year, 4, '0', STR_PAD_LEFT );
+				$url          = get_year_link( $result->year );
 				if ( 'post' !== $parsed_args['post_type'] ) {
 					$url = add_query_arg( 'post_type', $parsed_args['post_type'], $url );
 				}
-				$text = sprintf( '%d', $result->year );
+				$text = sprintf( '%s', $result->year );
 				if ( $parsed_args['show_post_count'] ) {
 					$parsed_args['after'] = '&nbsp;(' . $result->posts . ')' . $after;
 				}
@@ -2117,7 +2119,9 @@ function wp_get_archives( $args = '' ) {
 		if ( $results ) {
 			$after = $parsed_args['after'];
 			foreach ( (array) $results as $result ) {
-				$url = get_day_link( $result->year, $result->month, $result->dayofmonth );
+				// Add leading zeros when year has lower than 4 digits.
+				$result->year = str_pad( $result->year, 4, '0', STR_PAD_LEFT );
+				$url          = get_day_link( $result->year, $result->month, $result->dayofmonth );
 				if ( 'post' !== $parsed_args['post_type'] ) {
 					$url = add_query_arg( 'post_type', $parsed_args['post_type'], $url );
 				}


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/59381

This PR adds leading zeros when year has less than 4 digits.

## Steps to Test

1. With a block theme active, add an Archive block to a page template.
2. Set permalinks to use "Month" based URL structure.
3. Create or modify a post and set the post date to a year earlier than 1000, for example 420.
4. Save and view/preview the post on the frontend.
5. The Archive block's representation of the year should include leading zeros.
6. The `/420` archive listing page should work and does not show to a 404.