### PR TITLE
Add `decoding` as a default argument

### DIFF
--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -2845,6 +2845,7 @@ if ( ! function_exists( 'get_avatar' ) ) :
 			'loading'       => null,
 			'fetchpriority' => null,
 			'extra_attr'    => '',
+			'decoding'      => 'async',
 		);
 
 		if ( empty( $args ) ) {

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -2845,7 +2845,7 @@ if ( ! function_exists( 'get_avatar' ) ) :
 			'loading'       => null,
 			'fetchpriority' => null,
 			'extra_attr'    => '',
-			'decoding'      => 'async',
+			'decoding'      => null,
 		);
 
 		if ( empty( $args ) ) {


### PR DESCRIPTION
This PR fixes a regression introduced on [#58892](https://core.trac.wordpress.org/ticket/58892) when [moving](https://github.com/WordPress/wordpress-develop/pull/4991/commits/828130034c5a7790ed8e53660b34eeaf214b4e0d) the responsibility for the `decoding` attribute to the `wp_get_loading_optimization_attributes`. 

This will add the `decoding` attribute to the `get_avatar()`. As trunk currently is, this context will fail to get any optimization attributes while running `the_content` filter.

Trac ticket: [#58892](https://core.trac.wordpress.org/ticket/58892)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
