### PR TITLE
External Libraries: Check `PHP_OS`, not `php_uname()` in PclZip.

### DIFF
--- a/src/wp-admin/includes/class-pclzip.php
+++ b/src/wp-admin/includes/class-pclzip.php
@@ -5714,7 +5714,7 @@
   // --------------------------------------------------------------------------------
   function PclZipUtilTranslateWinPath($p_path, $p_remove_disk_letter=true)
   {
-    if (stristr(php_uname(), 'windows')) {
+    if (strtoupper(substr(PHP_OS, 0, 3)) == 'WIN') {
       // ----- Look for potential disk letter
       if (($p_remove_disk_letter) && (($v_position = strpos($p_path, ':')) != false)) {
           $p_path = substr($p_path, $v_position+1);


### PR DESCRIPTION
Some hosts disable `php_uname()`.
To ensure detection of Windows continues, check `PHP_OS`.

Trac ticket: https://core.trac.wordpress.org/ticket/57711
