### PR TITLE
Experiment: Load theme's block patterns concurrently using stream_select()

### DIFF
--- a/src/wp-includes/block-patterns.php
+++ b/src/wp-includes/block-patterns.php
@@ -423,6 +423,10 @@ function _register_theme_block_patterns() {
 		// Grab the next batch.
 		foreach ( array_splice( $queue, 0, $max_concurrency - count( $fds ) ) as $file_path ) {
 			$fd = fopen( $file_path, 'r' );
+			// If the file can't be opened, skip it.
+			if ( false === $fd ) {
+				continue;
+			}
 			stream_set_blocking( $fd, false );
 
 			$fds[ $file_path ] = $fd;

--- a/src/wp-includes/block-patterns.php
+++ b/src/wp-includes/block-patterns.php
@@ -438,7 +438,7 @@ function _register_theme_block_patterns() {
 			throw new Error( 'Should not have died.' );
 		}
 
-		if ( 0 === count( $streams ) ) {
+		if ( 0 === $streams ) {
 			continue;
 		}
 

--- a/src/wp-includes/block-patterns.php
+++ b/src/wp-includes/block-patterns.php
@@ -396,15 +396,16 @@ function _register_theme_block_patterns() {
 		}
 
 		while ( false !== ( $pattern_file = readdir( $pattern_directory_handle ) ) ) {
+			$file_path = "{$pattern_directory_path}/{$pattern_file}";
 			if (
 				4 >= strlen( $pattern_file ) ||
 				'.php' !== substr( $pattern_file, -4 ) ||
-				! is_file( $pattern_file )
+				! is_file( $file_path )
 			) {
 				continue;
 			}
 
-			$pattern_files[] = $pattern_file;
+			$pattern_files[] = $file_path;
 		}
 	}
 

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -6809,8 +6809,29 @@ function get_file_data( $file, $default_headers, $context = '' ) {
 		$file_data = '';
 	}
 
+	return get_file_data_from_string( $file_data, $default_headers, $context );
+}
+
+/**
+ * Retrieves metadata from a file's contents.
+ *
+ * Searches for metadata in the beginning of a file's contents, such as from a
+ * plugin or theme. Each piece of metadata must be on its own line. Fields can
+ * not span multiple lines, the value will get cut at the end of the first line.
+ *
+ * @link https://codex.wordpress.org/File_Header
+ *
+ * @since 6.4.0
+ *
+ * @param string $file_contents   All or part of a file's contents. Must start at beginning of file. E.g. pass the first 8 KB of a file.
+ * @param array  $default_headers List of headers, in the format `array( 'HeaderKey' => 'Header Name' )`.
+ * @param string $context         Optional. If specified adds filter hook {@see 'extra_$context_headers'}.
+ *                                Default empty string.
+ * @return string[] Array of file header values keyed by header name.
+ */
+function get_file_data_from_string( $file_contents, $default_headers, $context = '' ) {
 	// Make sure we catch CR-only line endings.
-	$file_data = str_replace( "\r", "\n", $file_data );
+	$file_contents = str_replace( "\r", "\n", $file_contents );
 
 	/**
 	 * Filters extra file headers by context.
@@ -6831,7 +6852,7 @@ function get_file_data( $file, $default_headers, $context = '' ) {
 	}
 
 	foreach ( $all_headers as $field => $regex ) {
-		if ( preg_match( '/^(?:[ \t]*<\?php)?[ \t\/*#@]*' . preg_quote( $regex, '/' ) . ':(.*)$/mi', $file_data, $match ) && $match[1] ) {
+		if ( preg_match( '/^(?:[ \t]*<\?php)?[ \t\/*#@]*' . preg_quote( $regex, '/' ) . ':(.*)$/mi', $file_contents, $match ) && $match[1] ) {
 			$all_headers[ $field ] = _cleanup_header_comment( $match[1] );
 		} else {
 			$all_headers[ $field ] = '';

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -6830,6 +6830,14 @@ function get_file_data( $file, $default_headers, $context = '' ) {
  * @return string[] Array of file header values keyed by header name.
  */
 function get_file_data_from_string( $file_contents, $default_headers, $context = '' ) {
+	/**
+	 * Metadata MUST appear in the first 8 KB of a file. So if
+	 * this given file contents is longer it must be trimmed.
+	 */
+	if ( 8 * KB_IN_BYTES < strlen( $file_contents ) ) {
+		$file_contents = substr( $file_contents, 0, 8 + KB_IN_BYTES );
+	}
+
 	// Make sure we catch CR-only line endings.
 	$file_contents = str_replace( "\r", "\n", $file_contents );
 


### PR DESCRIPTION
Is there enough I/O wait time that serializes the load time for a theme with many patterns that we can eliminate that lag by using `stream_select()`?

Non-blocking streaming I/O like this carries its own overhead, but it also presents the opportunity of lining up lots of I/O in parallel so that the initial wait time that was previously serial will collapse roughly into a single lag.

Previously:

    For each file in the patterns directory:
        Read file data (wait to open file)
                       (process contents)

        Read entire file (wait to open file)
                         (wait to read entire file)
                         (register block)

        Move to next file

In this patch:

    For each file in the patterns directory:
        Queue file for reading

    While queue contains items:
        (Wait for data from any of the active streams)

        For each stream with data available:
            Read data chunk (no wait time, because the data is ready)

            If file not yet verified but 8 KB is available:
                If file data indicates it's not a pattern:
                    Remove file from queue

            If file is verified:
                Append data chunk to file contents.

            If done reading file and it's verified:
                Register the pattern

In comparing these situations we can see that wait time is minimized if PHP returns early enough to queue multiple file-opens and file-reads and if this ends up being faster than calling `file_get_contents()` directly with the serialized wait times.

This patch is probably broken; currently it's an experiment.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**

## Performance

Output from Google's tool (on laptop battery)

```
> research
> ./cli/run.mjs benchmark-server-timing -u http://dev.xkq.io:3880 -n 1000 -c 10 -p -o csv
```

**This branch**

```
wp-total (p10),102.45
wp-total (p25),102.6
wp-total (p50),102.93
wp-total (p75),103.54
wp-total (p90),105.43
```

**`trunk`**
```
wp-total (p10),101.7
wp-total (p25),102.44
wp-total (p50),103.08
wp-total (p75),104.56
wp-total (p90),105
```

The results seem to fluctuate a lot while running, which may be because I'm on battery and doing other things while running the tests. Still, without a drastic impact on performance I think this shows that this PR isn't an obvious win. Still, there are a few thoughts to consider:

 - The first time the block patterns are loaded on a given computer they will be loaded into the filesystem cache and subsequence lookup may be much faster because the server doesn't have to go to disk for reading the file.
 - The laptop I'm on has a high quality and fast SSD. Many WordPress shared hosts still run farms of spinning disks. The initial I/O latency (the part that this PR tackles) on those setups is _significantly_ different than on my laptop.

So not only will common hosts experience less caching in memory for the pattern files, but this patch is addressing a potential point that they are going to experience that almost no develop or CI environment will see.

For comparison, here are the results for `twentytwentythree`

```
> research
> ./cli/run.mjs benchmark-server-timing -u http://dev.xkq.io:3880 -n 1000 -c 10 -p -o csv
```

**this branch**
```
wp-total (p10),59.75
wp-total (p25),60.04
wp-total (p50),60.71
wp-total (p75),61.78
wp-total (p90),63.58
```

**`trunk`**

```
wp-total (p10),60.13
wp-total (p25),60.47
wp-total (p50),61.02
wp-total (p75),62.05
wp-total (p90),63.59
```

Upon further inspection my results are more clear: _this change does reduce the file I/O wait time_ but the metric doesn't matter that much.

| branch | time waiting on `get_file_data` | time waiting on `include $file` |
|---|---|---|
|trunk|164µs|268µs|
|concurrent|107µs|71µs|

Obvious wins, and I do believe that this is from the mechanism in place: when looping sequentially through the files we're stacking the initial I/O lag for each file, but when reading concurrently we collapse that initial lag to roughly the same amount as it would be for a single file.

Prepping the reads initially appears to have an even more outsized impact when it comes time to load the files into PHP as source-code, which I am assuming is caused by caching effects in RAM.

 - ❓ Could we do a quick single pass with `get_file_data()` and then come back for a second pass of all the patterns with `include $file` and get similar speedups, because we've prepped the OS file cache?

 - Do these numbers make sense? There are around 50 patterns, all which fit within 8 KB. If it takes `trunk` 160µs to read these then that implies that read latency is less than 3µs per file. That seems way too fast for an SSD read, so I think it's already in the filesystem cache and all these numbers are biased.

Either way, measuring the impact of the entire `_register_theme_block_patterns()` files shows something else: it doesn't matter. *The measured difference with `hrtime( true )` shows only around 30µs change from one branch to the other.*

Probably something else is causing the slowdown because the page render from `twentytwentythree` to `twentytwentyfour` is measuring around 60ms slower, but not because of this function.

---

I attempted to run the same performance benchmarks after rebooting the system each time before measuring. This should flush out any impact of filesystem caching. No other applications were opened apart from a terminal. These are all running with power provided by a full wall adapter.

```
> research
> ./cli/run.mjs benchmark-server-timing -u http://dev.xkq.io:3880 -n 1000 -c 10 -p -o csv
```

**this branch**
```
wp-total (p10),73.05
wp-total (p25),74.19
wp-total (p50),75.22
wp-total (p75),76.02
wp-total (p90),104.35
```

**`trunk`**
```
wp-total (p10),69.29
wp-total (p25),69.83
wp-total (p50),70.53
wp-total (p75),70.65
wp-total (p90),71.17
```