### PR TITLE
Improve `generate_cache_key` to reduce cache miss while avoiding collision 

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -4867,16 +4867,6 @@ class WP_Query {
 
 		// Replace wpdb placeholder in the SQL statement used by the cache key.
 		$sql = $wpdb->remove_placeholder_escape( $sql );
-
-		/*
-		* We need to unset the `post_type` parameter because:
-		* 1. `post_type` from get_posts() may have values like `any` or even `null`.
-		* 2. Including `post_type` in the query arguments might generate
-		* different cache keys for identical queries, leading to unnecessary cache misses.
-		* It's essential to unset `post_type` only after using it for any necessary
-		* wpdb placeholder replacements in the statement.
-		*/
-		unset( $args['post_type'] );
 		$key = md5( $sql );
 
 		$last_changed = wp_cache_get_last_changed( 'posts' );

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -4867,7 +4867,17 @@ class WP_Query {
 
 		// Replace wpdb placeholder in the SQL statement used by the cache key.
 		$sql = $wpdb->remove_placeholder_escape( $sql );
-		$key = md5( serialize( $args ) . $sql );
+
+		/*
+		* We need to unset the `post_type` parameter because:
+		* 1. `post_type` from get_posts() may have values like `any` or even `null`.
+		* 2. Including `post_type` in the query arguments might generate
+		* different cache keys for identical queries, leading to unnecessary cache misses.
+		* It's essential to unset `post_type` only after using it for any necessary
+		* wpdb placeholder replacements in the statement.
+		*/
+		unset( $args['post_type'] );
+		$key = md5( $sql );
 
 		$last_changed = wp_cache_get_last_changed( 'posts' );
 		if ( ! empty( $this->tax_query->queries ) ) {

--- a/src/wp-includes/class-wp-term-query.php
+++ b/src/wp-includes/class-wp-term-query.php
@@ -1175,7 +1175,7 @@ class WP_Term_Query {
 		// Replace wpdb placeholder in the SQL statement used by the cache key.
 		$sql = $wpdb->remove_placeholder_escape( $sql );
 
-		$key          = md5( $sql );
+		$key          = md5( serialize( $cache_args ) . serialize( $taxonomies ) . $sql );
 		$last_changed = wp_cache_get_last_changed( 'terms' );
 		return "get_terms:$key:$last_changed";
 	}

--- a/src/wp-includes/class-wp-term-query.php
+++ b/src/wp-includes/class-wp-term-query.php
@@ -1175,7 +1175,7 @@ class WP_Term_Query {
 		// Replace wpdb placeholder in the SQL statement used by the cache key.
 		$sql = $wpdb->remove_placeholder_escape( $sql );
 
-		$key          = md5( serialize( $cache_args ) . serialize( $taxonomies ) . $sql );
+		$key          = md5( $sql );
 		$last_changed = wp_cache_get_last_changed( 'terms' );
 		return "get_terms:$key:$last_changed";
 	}

--- a/tests/phpunit/tests/query/cacheResults.php
+++ b/tests/phpunit/tests/query/cacheResults.php
@@ -1429,21 +1429,21 @@ class Test_Query_CacheResults extends WP_UnitTestCase {
 
 		$query1 = new WP_Query(
 			array(
-					'cache_results' => true,
-					'fields'        => 'ids',
-					'post_type'     => 'post',
-				)
-			);
-			
+				'cache_results' => true,
+				'fields'        => 'ids',
+				'post_type'     => 'post',
+			)
+		);
+
 		$reflection1 = new ReflectionMethod( $query1, 'generate_cache_key' );
 		$reflection1->setAccessible( true );
 		// Cache key with post_type
 		$cache_key_1 = $reflection1->invoke( $query1, $query1->query_vars, $query1->request );
 		$reflection1->setAccessible( false );
-
 		$num_queries_start = get_num_queries();
+
 		// Following query without `post_type` leads to exact same SQL request as query1.
-		$query2 = new WP_Query(
+		$query2      = new WP_Query(
 			array(
 				'cache_results' => true,
 				'fields'        => 'ids',

--- a/tests/phpunit/tests/query/cacheResults.php
+++ b/tests/phpunit/tests/query/cacheResults.php
@@ -1424,7 +1424,7 @@ class Test_Query_CacheResults extends WP_UnitTestCase {
 	 *
 	 * @covers WP_Query::generate_cache_key
 	 */
-	public function test_generate_cache_key_avoid_post_type() {
+	public function test_generate_cache_key_avoid_args() {
 		global $wpdb;
 
 		$query1 = new WP_Query(

--- a/tests/phpunit/tests/query/cacheResults.php
+++ b/tests/phpunit/tests/query/cacheResults.php
@@ -1418,4 +1418,48 @@ class Test_Query_CacheResults extends WP_UnitTestCase {
 		// No additional queries expected.
 		$this->assertSame( 0, $num_queries, 'Unexpected number of queries during second query of term meta.' );
 	}
+	
+	/**
+	 * @ticket 59442
+	 *
+	 * @covers WP_Query::generate_cache_key
+	 */
+	public function test_generate_cache_key_avoid_post_type() {
+		global $wpdb;
+
+		$query1 = new WP_Query(
+			array(
+				'cache_results' => true,
+				'fields'        => 'ids',
+				'post_type'     => 'post',
+				)
+			);
+			
+		$reflection1 = new ReflectionMethod( $query1, 'generate_cache_key' );
+		$reflection1->setAccessible( true );
+		// Cache key with post_type
+		$cache_key_1 = $reflection1->invoke( $query1, $query1->query_vars, $query1->request );
+		$reflection1->setAccessible( false );
+
+		$num_queries_start = get_num_queries();
+		// Following query without `post_type` leads to exact same SQL request as query1.
+		$query2 = new WP_Query(
+			array(
+				'cache_results' => true,
+				'fields'        => 'ids',
+			)
+		);
+		$num_queries = get_num_queries() - $num_queries_start;
+
+		$reflection2 = new ReflectionMethod( $query2, 'generate_cache_key' );
+		$reflection2->setAccessible( true );
+		// Cache key without `post_type`.
+		$cache_key_2 = $reflection2->invoke( $query2, $query2->query_vars, $query2->request );
+		$reflection2->setAccessible( false );
+
+		// Ensure SQL request formed with and without `post_type` were similar.
+		$this->assertSame( $query1->request, $query2->request, 'SQL request formed are not similar.' );
+		$this->assertSame( $cache_key_1, $cache_key_2, 'Cache key differs when `post_type` not passed in args.' );
+		$this->assertSame( 0, $num_queries, 'Second call executed additional queries.' );
+	}
 }

--- a/tests/phpunit/tests/query/cacheResults.php
+++ b/tests/phpunit/tests/query/cacheResults.php
@@ -1418,7 +1418,7 @@ class Test_Query_CacheResults extends WP_UnitTestCase {
 		// No additional queries expected.
 		$this->assertSame( 0, $num_queries, 'Unexpected number of queries during second query of term meta.' );
 	}
-	
+
 	/**
 	 * @ticket 59442
 	 *
@@ -1429,9 +1429,9 @@ class Test_Query_CacheResults extends WP_UnitTestCase {
 
 		$query1 = new WP_Query(
 			array(
-				'cache_results' => true,
-				'fields'        => 'ids',
-				'post_type'     => 'post',
+					'cache_results' => true,
+					'fields'        => 'ids',
+					'post_type'     => 'post',
 				)
 			);
 			


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/59516

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
