### PR TITLE
Fix undefined index/array key warning with `isset`

### DIFF
--- a/src/wp-includes/class-wp-duotone.php
+++ b/src/wp-includes/class-wp-duotone.php
@@ -209,8 +209,9 @@ class WP_Duotone {
 			'rad'  => 360 / ( M_PI * 2 ),
 		);
 
-		$factor = $angle_units[ $unit ];
-		if ( ! $factor ) {
+		if ( isset( $angle_units[ $unit ] ) ) {
+			$factor = $angle_units[ $unit ];
+		} else {
 			$factor = 1;
 		}
 


### PR DESCRIPTION
Added an if statement with `isset()` to confirm that `$angle_units[ $unit ]` is valid before assigning it to `$factor` to avoid outputting a PHP warning.

Trac ticket: https://core.trac.wordpress.org/ticket/59496