### PR TITLE
add parents__in parameter for get_terms

### DIFF
--- a/src/wp-includes/class-wp-term-query.php
+++ b/src/wp-includes/class-wp-term-query.php
@@ -174,6 +174,8 @@ class WP_Term_Query {
 	 *                                                   are passed, `$child_of` is ignored. Default 0.
 	 *     @type int             $parent                 Parent term ID to retrieve direct-child terms of.
 	 *                                                   Default empty.
+	 *     @type int[]           $parents__in            Array of comma separated parent terms ID to retrieve child terms of given array.
+	 *                                                   Default empty array.
 	 *     @type bool            $childless              True to limit results to terms that have no children.
 	 *                                                   This parameter has no effect on non-hierarchical taxonomies.
 	 *                                                   Default false.
@@ -220,6 +222,7 @@ class WP_Term_Query {
 			'get'                    => '',
 			'child_of'               => 0,
 			'parent'                 => '',
+			'parents__in'            => array(),
 			'childless'              => false,
 			'cache_domain'           => 'core',
 			'cache_results'          => true,
@@ -619,6 +622,12 @@ class WP_Term_Query {
 		if ( '' !== $parent ) {
 			$parent                               = (int) $parent;
 			$this->sql_clauses['where']['parent'] = "tt.parent = '$parent'";
+		}
+
+		$parents__in = array_filter( $args['parents__in'], 'intval' );
+		if( ! empty( $parents__in ) && is_array( $parents__in ) ) {
+			$parents__in = implode( ', ', $parents__in );
+			$this->sql_clauses['where']['parent'] = "tt.parent IN ( $parents__in ) ";
 		}
 
 		$hierarchical = $args['hierarchical'];


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Currently, there is no option to get child terms of multiple parent terms. There is a '**`parent`**' parameter that returns child terms of only one parent term.
There is a '**`post_parent__in`**' parameter for '**`WP_Query`**' and '**`get_posts()`**' to get child posts of multiple parent posts, but there is no similar parameter for '**`WP_Term_Query`**', and '**`get_terms()`**'.
So, I suggest a new parameter '**`parents__in`**' to get child terms from multiple parent terms IDs. The parameter on **`get_terms()`** will be like below:
```
<?php
    /**
     *
     *  @type int[] $parents__in 
     *  Array of comma-separated parent terms ID to retrieve child terms of given array.
     *  Default empty array.
     *
     */
    get_terms( array(
        'taxonomy'    => 'category',
        'parents__in' => array( 2, 3, 4 )
    ) );
```

Trac ticket: https://core.trac.wordpress.org/ticket/59503

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
