### PR TITLE
Blocks: Check `wp_doing_ajax` before filtering `excerpt_length`.

### DIFF
--- a/src/wp-includes/blocks/post-excerpt.php
+++ b/src/wp-includes/blocks/post-excerpt.php
@@ -84,7 +84,7 @@ add_action( 'init', 'register_block_core_post_excerpt' );
  * Returns 100 because 100 is the max length in the setting.
  */
 if ( is_admin() ||
-	defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+	defined( 'REST_REQUEST' ) && REST_REQUEST && ! wp_doing_ajax() ) {
 	add_filter(
 		'excerpt_length',
 		static function () {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

`wp-include/blocks/post-excerpt.php:86`

hooks `excerpt_length` with a value of `100` and priority of `PHP_INT_MAX` for admin and rest requests. As a result, `excerpt_length` is set to `100` for ajax requests (`is_admin()` is `true` for these)

Presumably this is incorrect. If a post is being rendered via ajax, it's excerpt length shouldn't be hijacked by block logic.

Trac ticket: (https://core.trac.wordpress.org/ticket/59504)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
