### PR TITLE
Fix HTML5 validation error for skip-link css on footer

### DIFF
--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -707,7 +707,8 @@ add_filter( 'user_has_cap', 'wp_maybe_grant_site_health_caps', 1, 4 );
 add_filter( 'render_block_context', '_block_template_render_without_post_block_context' );
 add_filter( 'pre_wp_unique_post_slug', 'wp_filter_wp_template_unique_post_slug', 10, 5 );
 add_action( 'save_post_wp_template_part', 'wp_set_unique_slug_on_create_template_part' );
-add_action( 'wp_footer', 'the_block_template_skip_link' );
+add_action( 'wp_enqueue_scripts', 'the_block_template_skip_link_style' );
+add_action( 'wp_footer', 'the_block_template_skip_link_script' );
 add_action( 'setup_theme', 'wp_enable_block_templates' );
 add_action( 'wp_loaded', '_add_template_loader_filters' );
 

--- a/src/wp-includes/theme-templates.php
+++ b/src/wp-includes/theme-templates.php
@@ -99,14 +99,14 @@ function wp_filter_wp_template_unique_post_slug( $override_slug, $slug, $post_id
 }
 
 /**
- * Prints the skip-link script & styles.
+ * Prints the skip-link styles.
  *
  * @access private
- * @since 5.8.0
+ * @since 6.4.0
  *
  * @global string $_wp_current_template_content
  */
-function the_block_template_skip_link() {
+function the_block_template_skip_link_style() {
 	global $_wp_current_template_content;
 
 	// Early exit if not a block theme.
@@ -158,6 +158,28 @@ function the_block_template_skip_link() {
 	wp_register_style( $handle, false );
 	wp_add_inline_style( $handle, $skip_link_styles );
 	wp_enqueue_style( $handle );
+}
+
+/**
+ * Prints the skip-link script.
+ *
+ * @access private
+ * @since 6.4.0
+ *
+ * @global string $_wp_current_template_content
+ */
+function the_block_template_skip_link_script() {
+	global $_wp_current_template_content;
+
+	// Early exit if not a block theme.
+	if ( ! current_theme_supports( 'block-templates' ) ) {
+		return;
+	}
+
+	// Early exit if not a block template.
+	if ( ! $_wp_current_template_content ) {
+		return;
+	}
 
 	/**
 	 * Enqueue the skip-link script.


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Fix the following HTML5 validation error by moving `skip-link` CSS to head from the body:

> Error: Element [style](https://html.spec.whatwg.org/multipage/#the-style-element) not allowed as child of element [body](https://html.spec.whatwg.org/multipage/#the-body-element) in this context. (Suppressing further errors from this subtree.)

Trac ticket: https://core.trac.wordpress.org/ticket/59505

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
