### PR TITLE
Alt/22192 tests

### DIFF
--- a/tests/phpunit/tests/option/option.php
+++ b/tests/phpunit/tests/option/option.php
@@ -381,13 +381,17 @@ class Tests_Option_Option extends WP_UnitTestCase {
 	public function test_update_loosey_options( $old_value, $new_value, $update = false ) {
 		add_option( 'foo', $old_value );
 
+		$num_queries = get_num_queries();
+
 		// Comparison will happen against value cached during add_option() above.
 		$updated = update_option( 'foo', $new_value );
 
 		if ( $update ) {
 			$this->assertTrue( $updated, 'This loosely equal option should trigger an update.' );
+			$this->assertSame( 1, get_num_queries() - $num_queries, 'There should be one additional database query to update the option.' );
 		} else {
 			$this->assertFalse( $updated, 'Loosely equal option should not trigger an update.' );
+			$this->assertSame( $num_queries, get_num_queries(), 'The number of database queries should not change.' );
 		}
 	}
 
@@ -403,14 +407,18 @@ class Tests_Option_Option extends WP_UnitTestCase {
 	public function test_update_loosey_options_from_db( $old_value, $new_value, $update = false ) {
 		add_option( 'foo', $old_value );
 
+		$num_queries = get_num_queries();
+
 		// Delete cache.
 		wp_cache_delete( 'alloptions', 'options' );
 		$updated = update_option( 'foo', $new_value );
 
 		if ( $update ) {
 			$this->assertTrue( $updated, 'This loosely equal option should trigger an update.' );
+			$this->assertSame( 1, get_num_queries() - $num_queries, 'There should be one additional database query to update the option.' );
 		} else {
 			$this->assertFalse( $updated, 'Loosely equal option should not trigger an update.' );
+			$this->assertSame( $num_queries, get_num_queries(), 'The number of database queries should not change.' );
 		}
 	}
 
@@ -426,6 +434,8 @@ class Tests_Option_Option extends WP_UnitTestCase {
 	public function test_update_loosey_options_from_refreshed_cache( $old_value, $new_value, $update = false ) {
 		add_option( 'foo', $old_value );
 
+		$num_queries = get_num_queries();
+
 		// Delete and refresh cache from DB.
 		wp_cache_delete( 'alloptions', 'options' );
 		wp_load_alloptions();
@@ -434,8 +444,10 @@ class Tests_Option_Option extends WP_UnitTestCase {
 
 		if ( $update ) {
 			$this->assertTrue( $updated, 'This loosely equal option should trigger an update.' );
+			$this->assertSame( 1, get_num_queries() - $num_queries, 'There should be one additional database query to update the option.' );
 		} else {
 			$this->assertFalse( $updated, 'Loosely equal option should not trigger an update.' );
+			$this->assertSame( $num_queries, get_num_queries(), 'The number of database queries should not change.' );
 		}
 	}
 

--- a/tests/phpunit/tests/option/option.php
+++ b/tests/phpunit/tests/option/option.php
@@ -461,6 +461,13 @@ class Tests_Option_Option extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function data_update_option_type_juggling() {
+		/*
+		 * This set of use cases returns params for unit tests in the following format.
+		 *
+		 * @param any       $old_value The initial option value before an update.
+		 * @param any       $new_value The new value being passed to update_option().
+		 * @param null|bool $updated   Optional. The expected return value from update_option. Default false.
+		 */
 		return array(
 			/*
 			 * Truthy values.

--- a/tests/phpunit/tests/option/option.php
+++ b/tests/phpunit/tests/option/option.php
@@ -413,12 +413,15 @@ class Tests_Option_Option extends WP_UnitTestCase {
 		wp_cache_delete( 'alloptions', 'options' );
 		$updated = update_option( 'foo', $new_value );
 
+		// One query will run to get the original value, when not in cache.
+		$expected_queries = $num_queries + 1;
+
 		if ( $update ) {
 			$this->assertTrue( $updated, 'This loosely equal option should trigger an update.' );
-			$this->assertSame( 1, get_num_queries() - $num_queries, 'There should be one additional database query to update the option.' );
+			$this->assertSame( 1, get_num_queries() - $expected_queries, 'There should be one additional database query to update the option.' );
 		} else {
 			$this->assertFalse( $updated, 'Loosely equal option should not trigger an update.' );
-			$this->assertSame( $num_queries, get_num_queries(), 'The number of database queries should not change.' );
+			$this->assertSame( $expected_queries, get_num_queries(), 'No additional queries should run.' );
 		}
 	}
 
@@ -434,11 +437,12 @@ class Tests_Option_Option extends WP_UnitTestCase {
 	public function test_update_loosey_options_from_refreshed_cache( $old_value, $new_value, $update = false ) {
 		add_option( 'foo', $old_value );
 
-		$num_queries = get_num_queries();
-
 		// Delete and refresh cache from DB.
 		wp_cache_delete( 'alloptions', 'options' );
 		wp_load_alloptions();
+
+		// Get the current number of queries after the cache is refreshed.
+		$num_queries = get_num_queries();
 
 		$updated = update_option( 'foo', $new_value );
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
This PR is an alternate approach to https://github.com/WordPress/wordpress-develop/pull/5272, which updates the unit tests to account for query counts without refactoring all of the tests and associated data providers. For context and initial discussion, see [this comment](https://github.com/WordPress/wordpress-develop/pull/5272#issuecomment-1741519838) and the following conversation.

Trac ticket: https://core.trac.wordpress.org/ticket/22192

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
