### PR TITLE
Check if $path is null and return false early if so

### DIFF
--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -409,6 +409,11 @@ function wp_theme_has_theme_json() {
 	/** This filter is documented in wp-includes/link-template.php */
 	$path = apply_filters( 'theme_file_path', $path, 'theme.json' );
 
+	if ( ! $path ) {
+		$theme_has_support[ $stylesheet ] = false;
+		return false;
+	}
+
 	$theme_has_support[ $stylesheet ] = file_exists( $path );
 
 	return $theme_has_support[ $stylesheet ];


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/59507

I added a check for the `$path` variable and then return false in `wp_theme_has_theme_json` to avoid a call to `file_exists()` with  nullish argument.
