### PR TITLE
Add block-template viewport meta tag filter

### DIFF
--- a/src/wp-includes/block-template.php
+++ b/src/wp-includes/block-template.php
@@ -271,7 +271,20 @@ function get_the_block_template_html() {
  * @since 5.8.0
  */
 function _block_template_viewport_meta_tag() {
-	echo '<meta name="viewport" content="width=device-width, initial-scale=1" />' . "\n";
+	$content_attr = 'width=device-width, initial-scale=1';
+	$meta_tag = sprintf('<meta name="viewport" content="%s" />', $content_attr);
+
+	/**
+	 * Filters the default block-template viewport meta tag
+	 *
+	 * @since 6.4.0
+	 *
+	 * @param string $meta_tag The complete HTML viewport meta tag.
+	 * @param string $content_attr  Value of the meta tag's content attribute.
+	 */
+	$meta_tag = apply_filters('block_template_viewport_meta_tag', $meta_tag, $content_attr);
+
+	echo $meta_tag . "\n";
 }
 
 /**

--- a/src/wp-includes/block-template.php
+++ b/src/wp-includes/block-template.php
@@ -272,7 +272,7 @@ function get_the_block_template_html() {
  */
 function _block_template_viewport_meta_tag() {
 	$content_attr = 'width=device-width, initial-scale=1';
-	$meta_tag = sprintf('<meta name="viewport" content="%s" />', $content_attr);
+	$meta_tag     = sprintf( '<meta name="viewport" content="%s" />', $content_attr );
 
 	/**
 	 * Filters the default block-template viewport meta tag
@@ -282,7 +282,7 @@ function _block_template_viewport_meta_tag() {
 	 * @param string $meta_tag The complete HTML viewport meta tag.
 	 * @param string $content_attr  Value of the meta tag's content attribute.
 	 */
-	$meta_tag = apply_filters('block_template_viewport_meta_tag', $meta_tag, $content_attr);
+	$meta_tag = apply_filters( 'block_template_viewport_meta_tag', $meta_tag, $content_attr );
 
 	echo $meta_tag . "\n";
 }


### PR DESCRIPTION
This ticket introduces a new filter which allows for customization of the block-template's viewport meta tag.

Despite being inserted into wp_head by the _block_template_viewport_meta_tag action hook, the actual tag is basically [hard coded and untouchable](https://github.com/WordPress/wordpress-develop/blob/00ed25e2c9b20607418cbe8a6103c336d1bf92bd/src/wp-includes/block-template.php#L273-L275).

Trac ticket: https://core.trac.wordpress.org/ticket/59510
