### PR TITLE
Rename `initialize_theme_preview_hooks` to `wp_initialize_theme_preview_hooks` for consistency

### DIFF
--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -531,7 +531,7 @@ add_action( 'delete_attachment', '_delete_attachment_theme_mod' );
 add_action( 'transition_post_status', '_wp_keep_alive_customize_changeset_dependent_auto_drafts', 20, 3 );
 
 // Block Theme Previews.
-add_action( 'plugins_loaded', 'initialize_theme_preview_hooks', 1 );
+add_action( 'plugins_loaded', 'wp_initialize_theme_preview_hooks', 1 );
 
 // Calendar widget cache.
 add_action( 'save_post', 'delete_get_calendar_cache' );

--- a/src/wp-includes/theme-previews.php
+++ b/src/wp-includes/theme-previews.php
@@ -83,7 +83,7 @@ function wp_block_theme_activate_nonce() {
  *
  * @since 6.3.2
  */
-function initialize_theme_preview_hooks() {
+function wp_initialize_theme_preview_hooks() {
 	if ( ! empty( $_GET['wp_theme_preview'] ) ) {
 		add_filter( 'stylesheet', 'wp_get_theme_preview_path' );
 		add_filter( 'template', 'wp_get_theme_preview_path' );

--- a/tests/phpunit/tests/theme-previews.php
+++ b/tests/phpunit/tests/theme-previews.php
@@ -17,7 +17,7 @@ class Tests_Theme_Previews extends WP_UnitTestCase {
 
 	public function test_initialize_theme_preview_hooks() {
 		$_GET['wp_theme_preview'] = 'twentytwentythree';
-		do_action( 'plugins_loaded' ); // Ensure `plugins_loaded` triggers `initialize_theme_preview_hooks`.
+		do_action( 'plugins_loaded' ); // Ensure `plugins_loaded` triggers `wp_initialize_theme_preview_hooks`.
 
 		$this->assertEquals( has_filter( 'stylesheet', 'wp_get_theme_preview_path' ), 10 );
 		$this->assertEquals( has_filter( 'template', 'wp_get_theme_preview_path' ), 10 );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Updated the name of `initialize_theme_preview_hooks` to align with WordPress standards by prefixing with `wp_`. This is for consistency and reducing naming conflicts.

Trac ticket: https://core.trac.wordpress.org/ticket/59000

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
