### PR TITLE
Ensure `id` property is always cast as integer

### DIFF
--- a/src/wp-includes/class-wp-network.php
+++ b/src/wp-includes/class-wp-network.php
@@ -131,7 +131,7 @@ class WP_Network {
 	 */
 	public function __construct( $network ) {
 		foreach ( get_object_vars( $network ) as $key => $value ) {
-			$this->$key = $value;
+			$this->__set( $key, $value );
 		}
 
 		$this->_set_site_name();


### PR DESCRIPTION
Before: when the `WP_Network` object was populated via `WP_Network::get_instance()`, the WPDB query would return `id` as a string, and the constructor would then set the `id` property as that string. However, elsewhere the class assumes the `id` will always be an integer, and strictly typed comparisons (e.g. l.242) were therefore returning an unexpected result. This resulted in multi-sites where the network URL (set via the `wp_site` table) did not point to the same blog as the `BLOG_ID_CURRENT_SITE` breaking in WordPress 6.3 and up.

Now: the constructor uses the `__set()` method to ensure that properties are always cast to the expected type.

Trac ticket: https://core.trac.wordpress.org/ticket/59522

