### PR TITLE
Image caption shortcode   parameter validation

### DIFF
--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -2349,6 +2349,12 @@ add_shortcode( 'caption', 'img_caption_shortcode' );
  * @return string HTML content to display the caption.
  */
 function img_caption_shortcode( $attr, $content = '' ) {
+	// validate input parameter type for compatibility with newer versions of PHP
+	// (this maintains behavior consistent with how this function worked on 
+	// PHP versions 7.0 and older.)
+	if (!isset($attr) || !is_array($attr)) {
+		$attr = array();
+	}
 	// New-style shortcode with the caption inside the shortcode with the link and image tags.
 	if ( ! isset( $attr['caption'] ) ) {
 		if ( preg_match( '#((?:<a [^>]+>\s*)?<img [^>]+>(?:\s*</a>)?)(.*)#is', $content, $matches ) ) {

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -2349,7 +2349,7 @@ add_shortcode( 'caption', 'img_caption_shortcode' );
  * @return string HTML content to display the caption.
  */
 function img_caption_shortcode( $attr, $content = '' ) {
-	/**
+	/*
 	 * Validate input parameter type for compatibility with newer versions of PHP. This maintains behavior
 	 * consistent with how this function worked on PHP versions 7.0 and older.
 	 */

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -2349,12 +2349,14 @@ add_shortcode( 'caption', 'img_caption_shortcode' );
  * @return string HTML content to display the caption.
  */
 function img_caption_shortcode( $attr, $content = '' ) {
-	// validate input parameter type for compatibility with newer versions of PHP
-	// (this maintains behavior consistent with how this function worked on 
-	// PHP versions 7.0 and older.)
-	if (!isset($attr) || !is_array($attr)) {
+	/**
+	 * Validate input parameter type for compatibility with newer versions of PHP. This maintains behavior
+	 * consistent with how this function worked on PHP versions 7.0 and older.
+	 */
+	if ( ! isset( $attr ) || ! is_array( $attr ) ) {
 		$attr = array();
 	}
+
 	// New-style shortcode with the caption inside the shortcode with the link and image tags.
 	if ( ! isset( $attr['caption'] ) ) {
 		if ( preg_match( '#((?:<a [^>]+>\s*)?<img [^>]+>(?:\s*</a>)?)(.*)#is', $content, $matches ) ) {

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -269,6 +269,19 @@ CAP;
 		$this->assertSame( 1, substr_count( $result, 'aria-describedby="caption-myId"' ) );
 	}
 
+	/**
+	 * @ticket 45929
+	 */
+	public function test_image_caption_shortcode_with_empty_string() {
+		$errors = array();
+		try {
+			img_caption_shortcode( '', self::IMG_CONTENT . self::HTML_CONTENT );
+		} catch ( TypeError $t ) {
+			$errors[] = $t;
+		}
+		$this->assertEmpty( $errors );
+	}
+
 	public function test_add_remove_oembed_provider() {
 		wp_oembed_add_provider( 'http://foo.bar/*', 'http://foo.bar/oembed' );
 		$this->assertTrue( wp_oembed_remove_provider( 'http://foo.bar/*' ) );


### PR DESCRIPTION
Refresh of #4939

> In versions of PHP 7.0 and prior, if anything other than an array was passed into this function, it would be cast to an array at $attr['caption'] = trim( $matches[2] );
>
> To maintain that behavior in newer versions of PHP, I added a type check that would explicitly perform this behavior.

* Added unit test
* Formatted existing patch (after @mukeshpanchal27 review)

Trac ticket: https://core.trac.wordpress.org/ticket/45929