### PR TITLE
Fast follow: post parent ID cache

### DIFF
--- a/src/wp-includes/class-wp-post.php
+++ b/src/wp-includes/class-wp-post.php
@@ -247,7 +247,9 @@ final class WP_Post {
 			}
 
 			$_post = sanitize_post( $_post, 'raw' );
-			wp_cache_add( $_post->ID, $_post, 'posts' );
+			// Store as variable as parameter is passed by reference.
+			$_update_post_cache = array( $_post );
+			update_post_cache( $_update_post_cache );
 		} elseif ( empty( $_post->filter ) || 'raw' !== $_post->filter ) {
 			$_post = sanitize_post( $_post, 'raw' );
 		}

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -3191,7 +3191,7 @@ class WP_Query {
 
 						return $this->posts;
 					} elseif ( 'id=>parent' === $q['fields'] ) {
-						_prime_post_parents_caches( $post_ids );
+						_prime_post_parent_id_caches( $post_ids );
 
 						/** @var int[] */
 						$post_parents = wp_cache_get_multiple( $post_ids, 'post_parent' );

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -7222,14 +7222,17 @@ function update_post_cache( &$posts ) {
 		return;
 	}
 
-	$data = array();
+	$data       = array();
+	$parent_ids = array();
 	foreach ( $posts as $post ) {
 		if ( empty( $post->filter ) || 'raw' !== $post->filter ) {
 			$post = sanitize_post( $post, 'raw' );
 		}
 		$data[ $post->ID ] = $post;
+		$parent_ids[ (int) $post->ID ] = (int) $post->post_parent;
 	}
 	wp_cache_add_multiple( $data, 'posts' );
+	wp_cache_add_multiple( $parent_ids, 'post_parent' );
 }
 
 /**

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -7228,7 +7228,7 @@ function update_post_cache( &$posts ) {
 		if ( empty( $post->filter ) || 'raw' !== $post->filter ) {
 			$post = sanitize_post( $post, 'raw' );
 		}
-		$data[ $post->ID ] = $post;
+		$data[ $post->ID ]             = $post;
 		$parent_ids[ (int) $post->ID ] = (int) $post->post_parent;
 	}
 	wp_cache_add_multiple( $data, 'posts' );

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -7771,11 +7771,15 @@ function _update_term_count_on_transition_post_status( $new_status, $old_status,
  *
  * @global wpdb $wpdb WordPress database abstraction object.
  *
- * @param int[] $ids               ID list.
- * @param bool  $update_term_cache Optional. Whether to update the term cache. Default true.
- * @param bool  $update_meta_cache Optional. Whether to update the meta cache. Default true.
+ * @param int[] $ids                    ID list.
+ * @param bool  $update_term_cache      Optional. Whether to update the term cache. Default true.
+ * @param bool  $update_meta_cache      Optional. Whether to update the meta cache. Default true.
+ * @param bool  $update_parent_id_cache Optional. Whether to update the post parent ID cache. To avoid additional
+ *                                      queries later, the parent ID is always cached for currently unprimed post
+ *                                      objects. This parameter only affects unprimed parent caches when the post
+ *                                      object is already primed. Default true.
  */
-function _prime_post_caches( $ids, $update_term_cache = true, $update_meta_cache = true ) {
+function _prime_post_caches( $ids, $update_term_cache = true, $update_meta_cache = true, $update_parent_id_cache = true ) {
 	global $wpdb;
 
 	$non_cached_ids = _get_non_cached_ids( $ids, 'posts' );
@@ -7796,6 +7800,10 @@ function _prime_post_caches( $ids, $update_term_cache = true, $update_meta_cache
 		$post_types = array_map( 'get_post_type', $ids );
 		$post_types = array_unique( $post_types );
 		update_object_term_cache( $ids, $post_types );
+	}
+
+	if ( $update_parent_id_cache ) {
+		_prime_post_parent_id_caches( $ids );
 	}
 }
 

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -7797,13 +7797,17 @@ function _prime_post_caches( $ids, $update_term_cache = true, $update_meta_cache
 }
 
 /**
- * Prime post parent caches.
+ * Prime post parent ID caches.
+ *
+ * Prime the cache containing the parent ID of various post objects.
+ *
+ * @since 6.4.0
  *
  * @global wpdb $wpdb WordPress database abstraction object.
  *
  * @param int[] $ids ID list.
  */
-function _prime_post_parents_caches( array $ids ) {
+function _prime_post_parent_id_caches( array $ids ) {
 	global $wpdb;
 
 	$non_cached_ids = _get_non_cached_ids( $ids, 'post_parent' );

--- a/tests/phpunit/tests/post/primePostCaches.php
+++ b/tests/phpunit/tests/post/primePostCaches.php
@@ -82,6 +82,9 @@ class Tests_Post_PrimePostCaches extends WP_UnitTestCase {
 
 		$this->assertNotEmpty( $categories, 'Categories does return an empty result set.' );
 		$this->assertSame( 0, $num_queries, 'Unexpected number of queries.' );
+
+		// Test parent ID cache.
+		$this->assertSame( array(), _get_non_cached_ids( array( $post_id ), 'post_parent' ), 'Parent ID is not cached.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/post/primePostParentsCaches.php
+++ b/tests/phpunit/tests/post/primePostParentsCaches.php
@@ -1,17 +1,17 @@
 <?php
 /**
- * Test `_prime_post_parents_caches()`.
+ * Test `_prime_post_parent_id_caches()`.
  *
  * @package WordPress
  */
 
 /**
- * Test class for `_prime_post_parents_caches()`.
+ * Test class for `_prime_post_parent_id_caches()`.
  *
  * @group post
  * @group cache
  *
- * @covers ::_prime_post_parents_caches
+ * @covers ::_prime_post_parent_id_caches
  */
 class Tests_Post_PrimePostParentsCaches extends WP_UnitTestCase {
 
@@ -34,11 +34,11 @@ class Tests_Post_PrimePostParentsCaches extends WP_UnitTestCase {
 	/**
 	 * @ticket 59188
 	 */
-	public function test_prime_post_parents_caches() {
+	public function test_prime_post_parent_id_caches() {
 		$post_id = self::$posts[0];
 
 		$before_num_queries = get_num_queries();
-		_prime_post_parents_caches( array( $post_id ) );
+		_prime_post_parent_id_caches( array( $post_id ) );
 		$num_queries = get_num_queries() - $before_num_queries;
 
 		$this->assertSame( 1, $num_queries, 'Unexpected number of queries.' );
@@ -48,9 +48,9 @@ class Tests_Post_PrimePostParentsCaches extends WP_UnitTestCase {
 	/**
 	 * @ticket 59188
 	 */
-	public function test_prime_post_parents_caches_multiple() {
+	public function test_prime_post_parent_id_caches_multiple() {
 		$before_num_queries = get_num_queries();
-		_prime_post_parents_caches( self::$posts );
+		_prime_post_parent_id_caches( self::$posts );
 		$num_queries = get_num_queries() - $before_num_queries;
 
 		$this->assertSame( 1, $num_queries, 'Unexpected number of queries.' );
@@ -60,10 +60,10 @@ class Tests_Post_PrimePostParentsCaches extends WP_UnitTestCase {
 	/**
 	 * @ticket 59188
 	 */
-	public function test_prime_post_parents_caches_multiple_runs() {
-		_prime_post_parents_caches( self::$posts );
+	public function test_prime_post_parent_id_caches_multiple_runs() {
+		_prime_post_parent_id_caches( self::$posts );
 		$before_num_queries = get_num_queries();
-		_prime_post_parents_caches( self::$posts );
+		_prime_post_parent_id_caches( self::$posts );
 		$num_queries = get_num_queries() - $before_num_queries;
 
 		$this->assertSame( 0, $num_queries, 'Unexpected number of queries.' );
@@ -72,7 +72,7 @@ class Tests_Post_PrimePostParentsCaches extends WP_UnitTestCase {
 	/**
 	 * @ticket 59188
 	 */
-	public function test_prime_post_parents_caches_update() {
+	public function test_prime_post_parent_id_caches_update() {
 		$page_id            = self::factory()->post->create(
 			array(
 				'post_type'   => 'page',
@@ -80,7 +80,7 @@ class Tests_Post_PrimePostParentsCaches extends WP_UnitTestCase {
 			)
 		);
 		$before_num_queries = get_num_queries();
-		_prime_post_parents_caches( array( $page_id ) );
+		_prime_post_parent_id_caches( array( $page_id ) );
 		$num_queries = get_num_queries() - $before_num_queries;
 
 		$this->assertSame( 1, $num_queries, 'Unexpected number of queries on first run' );
@@ -94,7 +94,7 @@ class Tests_Post_PrimePostParentsCaches extends WP_UnitTestCase {
 		);
 
 		$before_num_queries = get_num_queries();
-		_prime_post_parents_caches( array( $page_id ) );
+		_prime_post_parent_id_caches( array( $page_id ) );
 		$num_queries = get_num_queries() - $before_num_queries;
 
 		$this->assertSame( 1, $num_queries, 'Unexpected number of queries on second run' );
@@ -104,7 +104,7 @@ class Tests_Post_PrimePostParentsCaches extends WP_UnitTestCase {
 	/**
 	 * @ticket 59188
 	 */
-	public function test_prime_post_parents_caches_delete() {
+	public function test_prime_post_parent_id_caches_delete() {
 		$parent_page_id     = self::factory()->post->create(
 			array(
 				'post_type' => 'page',
@@ -117,7 +117,7 @@ class Tests_Post_PrimePostParentsCaches extends WP_UnitTestCase {
 			)
 		);
 		$before_num_queries = get_num_queries();
-		_prime_post_parents_caches( array( $page_id ) );
+		_prime_post_parent_id_caches( array( $page_id ) );
 		$num_queries = get_num_queries() - $before_num_queries;
 
 		$this->assertSame( 1, $num_queries, 'Unexpected number of queries on first run' );


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/59188

* primes parent id cache in `update_post_cache()`
* adds `@since` annotation
* renames function for clarity --- it is currently a little unclear and could imply the parent post object is cached in its entirity
* adds parameter to `_prime_post_caches` for priming the post parent ID caches if not already primed.

The docblock for the new parameter needs some work.