### PR TITLE
Performance: Try refactoring `get_hooked_blocks()` to check impact

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -551,10 +551,10 @@ function _build_block_template_result_from_file( $template_file, $template_type 
 
 	$before_block_visitor = '_inject_theme_attribute_in_template_part_block';
 	$after_block_visitor  = null;
-	$block_hooks          = get_hooked_blocks();
-	if ( ! empty( $block_hooks ) || has_filter( 'hooked_block_types' ) ) {
-		$before_block_visitor = make_before_block_visitor( $template, $block_hooks );
-		$after_block_visitor  = make_after_block_visitor( $template, $block_hooks );
+	$hooked_blocks        = get_hooked_blocks();
+	if ( ! empty( $hooked_blocks ) || has_filter( 'hooked_block_types' ) ) {
+		$before_block_visitor = make_before_block_visitor( $hooked_blocks, $template );
+		$after_block_visitor  = make_after_block_visitor( $hooked_blocks, $template );
 	}
 	$blocks            = parse_blocks( $template_content );
 	$template->content = traverse_and_serialize_blocks( $blocks, $before_block_visitor, $after_block_visitor );

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -549,10 +549,15 @@ function _build_block_template_result_from_file( $template_file, $template_type 
 		$template->area = $template_file['area'];
 	}
 
-	$blocks               = parse_blocks( $template_content );
-	$before_block_visitor = make_before_block_visitor( $template );
-	$after_block_visitor  = make_after_block_visitor( $template );
-	$template->content    = traverse_and_serialize_blocks( $blocks, $before_block_visitor, $after_block_visitor );
+	$before_block_visitor = '_inject_theme_attribute_in_template_part_block';
+	$after_block_visitor  = null;
+	$block_hooks          = get_hooked_blocks();
+	if ( ! empty( $block_hooks ) || has_filter( 'hooked_block_types' ) ) {
+		$before_block_visitor = make_before_block_visitor( $template, $block_hooks );
+		$after_block_visitor  = make_after_block_visitor( $template, $block_hooks );
+	}
+	$blocks            = parse_blocks( $template_content );
+	$template->content = traverse_and_serialize_blocks( $blocks, $before_block_visitor, $after_block_visitor );
 
 	return $template;
 }

--- a/src/wp-includes/class-wp-block-patterns-registry.php
+++ b/src/wp-includes/class-wp-block-patterns-registry.php
@@ -153,18 +153,21 @@ final class WP_Block_Patterns_Registry {
 	}
 
 	/**
-	 * Prepares the content of a block pattern.
+	 * Prepares the content of a block pattern. If hooked blocks are registered, they get injected into the pattern,
+	 * when they met the defined criteria.
 	 *
-	 * @param array $pattern     Registered pattern properties.
-	 * @param array $block_hooks The list of hooked blocks.
+	 * @since 6.4.0
+	 *
+	 * @param array $pattern       Registered pattern properties.
+	 * @param array $hooked_blocks The list of hooked blocks.
 	 * @return string The content of the block pattern.
 	 */
-	private function prepare_content( $pattern, $block_hooks ) {
+	private function prepare_content( $pattern, $hooked_blocks ) {
 		$content = $pattern['content'];
-		if ( ! empty( $block_hooks ) || has_filter( 'hooked_block_types' ) ) {
+		if ( ! empty( $hooked_blocks ) || has_filter( 'hooked_block_types' ) ) {
 			$blocks               = parse_blocks( $content );
-			$before_block_visitor = make_before_block_visitor( $pattern, $block_hooks );
-			$after_block_visitor  = make_after_block_visitor( $pattern, $block_hooks );
+			$before_block_visitor = make_before_block_visitor( $hooked_blocks, $pattern );
+			$after_block_visitor  = make_after_block_visitor( $hooked_blocks, $pattern );
 			$content              = traverse_and_serialize_blocks( $blocks, $before_block_visitor, $after_block_visitor );
 		}
 
@@ -200,14 +203,14 @@ final class WP_Block_Patterns_Registry {
 	 *                 and per style.
 	 */
 	public function get_all_registered( $outside_init_only = false ) {
-		$patterns    = array_values(
+		$patterns      = array_values(
 			$outside_init_only
 				? $this->registered_patterns_outside_init
 				: $this->registered_patterns
 		);
-		$block_hooks = get_hooked_blocks();
+		$hooked_blocks = get_hooked_blocks();
 		foreach ( $patterns as $index => $pattern ) {
-			$patterns[ $index ]['content'] = $this->prepare_content( $pattern, $block_hooks );
+			$patterns[ $index ]['content'] = $this->prepare_content( $pattern, $hooked_blocks );
 		}
 		return $patterns;
 	}

--- a/tests/phpunit/tests/blocks/getHookedBlocks.php
+++ b/tests/phpunit/tests/blocks/getHookedBlocks.php
@@ -96,7 +96,7 @@ class Tests_Blocks_GetHookedBlocks extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertEquals(
+		$this->assertSame(
 			array(
 				'tests/hooked-at-before'           => array(
 					'before' => array(
@@ -110,6 +110,14 @@ class Tests_Blocks_GetHookedBlocks extends WP_UnitTestCase {
 						'tests/injected-two',
 					),
 				),
+				'tests/hooked-at-before-and-after' => array(
+					'before' => array(
+						'tests/injected-one',
+					),
+					'after'  => array(
+						'tests/injected-two',
+					),
+				),
 				'tests/hooked-at-first-child'      => array(
 					'first_child' => array(
 						'tests/injected-two',
@@ -117,14 +125,6 @@ class Tests_Blocks_GetHookedBlocks extends WP_UnitTestCase {
 				),
 				'tests/hooked-at-last-child'       => array(
 					'last_child' => array(
-						'tests/injected-two',
-					),
-				),
-				'tests/hooked-at-before-and-after' => array(
-					'before' => array(
-						'tests/injected-one',
-					),
-					'after'  => array(
 						'tests/injected-two',
 					),
 				),

--- a/tests/phpunit/tests/blocks/getHookedBlocks.php
+++ b/tests/phpunit/tests/blocks/getHookedBlocks.php
@@ -98,24 +98,24 @@ class Tests_Blocks_GetHookedBlocks extends WP_UnitTestCase {
 
 		$this->assertEquals(
 			array(
-				'tests/hooked-at-before' => array(
+				'tests/hooked-at-before'           => array(
 					'before' => array(
 						'tests/injected-one',
 						'tests/injected-two',
 					),
 				),
-				'tests/hooked-at-after' => array(
+				'tests/hooked-at-after'            => array(
 					'after' => array(
 						'tests/injected-one',
 						'tests/injected-two',
 					),
 				),
-				'tests/hooked-at-first-child' => array(
+				'tests/hooked-at-first-child'      => array(
 					'first_child' => array(
 						'tests/injected-two',
 					),
 				),
-				'tests/hooked-at-last-child' => array(
+				'tests/hooked-at-last-child'       => array(
 					'last_child' => array(
 						'tests/injected-two',
 					),

--- a/tests/phpunit/tests/blocks/getHookedBlocks.php
+++ b/tests/phpunit/tests/blocks/getHookedBlocks.php
@@ -62,7 +62,7 @@ class Tests_Blocks_GetHookedBlocks extends WP_UnitTestCase {
 	 * @covers ::get_hooked_blocks
 	 */
 	public function test_get_hooked_blocks_no_match_found() {
-		$result = get_hooked_blocks( 'tests/no-hooked-blocks' );
+		$result = get_hooked_blocks();
 
 		$this->assertSame( array(), $result );
 	}
@@ -96,55 +96,40 @@ class Tests_Blocks_GetHookedBlocks extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertSame(
+		$this->assertEquals(
 			array(
-				'before' => array(
-					'tests/injected-one',
-					'tests/injected-two',
+				'tests/hooked-at-before' => array(
+					'before' => array(
+						'tests/injected-one',
+						'tests/injected-two',
+					),
+				),
+				'tests/hooked-at-after' => array(
+					'after' => array(
+						'tests/injected-one',
+						'tests/injected-two',
+					),
+				),
+				'tests/hooked-at-first-child' => array(
+					'first_child' => array(
+						'tests/injected-two',
+					),
+				),
+				'tests/hooked-at-last-child' => array(
+					'last_child' => array(
+						'tests/injected-two',
+					),
+				),
+				'tests/hooked-at-before-and-after' => array(
+					'before' => array(
+						'tests/injected-one',
+					),
+					'after'  => array(
+						'tests/injected-two',
+					),
 				),
 			),
-			get_hooked_blocks( 'tests/hooked-at-before' ),
-			'block hooked at the before position'
-		);
-		$this->assertSame(
-			array(
-				'after' => array(
-					'tests/injected-one',
-					'tests/injected-two',
-				),
-			),
-			get_hooked_blocks( 'tests/hooked-at-after' ),
-			'block hooked at the after position'
-		);
-		$this->assertSame(
-			array(
-				'first_child' => array(
-					'tests/injected-two',
-				),
-			),
-			get_hooked_blocks( 'tests/hooked-at-first-child' ),
-			'block hooked at the first child position'
-		);
-		$this->assertSame(
-			array(
-				'last_child' => array(
-					'tests/injected-two',
-				),
-			),
-			get_hooked_blocks( 'tests/hooked-at-last-child' ),
-			'block hooked at the last child position'
-		);
-		$this->assertSame(
-			array(
-				'before' => array(
-					'tests/injected-one',
-				),
-				'after'  => array(
-					'tests/injected-two',
-				),
-			),
-			get_hooked_blocks( 'tests/hooked-at-before-and-after' ),
-			'block hooked before one block and after another'
+			get_hooked_blocks()
 		);
 	}
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/59383

**Important: This is an experiment! The focus should be on testing the performance as I don't think it's worth landing it if there is no positive impact.**

I tried refactoring `get_hooked_blocks` to see if that would have any noticeable impact on the performance of the block themes like Twenty Twenty-Three or Twenty Twenty-Four. **Let's keep in mind that there are no active hooked blocks in WordPress core**, so it means that by default, `get_hooked_blocks` won't be fully battle-tested in the context of performance without registering custom blocks using Block Hooks. However, there is a [test theme present](https://github.com/WordPress/wordpress-develop/tree/trunk/tests/phpunit/data/themedir1/block-theme-with-hooked-blocks) in the codebase that is used to verify the feature in [unit tests](https://github.com/WordPress/wordpress-develop/blob/trunk/tests/phpunit/tests/blocks/getHookedBlocks.php).

The most important consideration in this PR was related to the fact that `get_hooked_blocks` iterates on every block type in the registry. I was seeking the most optimal way to minimize the number of `get_hooked_blocks` calls. Before this PR, `get_hooked_blocks` was called 4 times per every parsed block when processing every template, template part, and pattern. With this PR, `get_hooked_blocks` gets called once per template, template part, or pattern.

Some additional improvements are also applied, like calling `get_hooked_blocks` only once when returning the list of all registered patterns. The last modification proposed brings the implementation closer to what we had before Block Hooks. When we ensure that there are no registered block hooks or filters that could impact them, we omit the parsing and serializing step.


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
