### PR TITLE
Patterns: Insert hooked blocks upon registration

### DIFF
--- a/src/wp-includes/class-wp-block-patterns-registry.php
+++ b/src/wp-includes/class-wp-block-patterns-registry.php
@@ -115,6 +115,12 @@ final class WP_Block_Patterns_Registry {
 			array( 'name' => $pattern_name )
 		);
 
+		// Set `theme` attribute in Template Part blocks, and insert hooked blocks.
+		$blocks               = parse_blocks( $pattern['content'] );
+		$before_block_visitor = make_before_block_visitor( $pattern );
+		$after_block_visitor  = make_after_block_visitor( $pattern );
+		$pattern['content']   = traverse_and_serialize_blocks( $blocks, $before_block_visitor, $after_block_visitor );
+
 		$this->registered_patterns[ $pattern_name ] = $pattern;
 
 		// If the pattern is registered inside an action other than `init`, store it
@@ -165,13 +171,7 @@ final class WP_Block_Patterns_Registry {
 			return null;
 		}
 
-		$pattern              = $this->registered_patterns[ $pattern_name ];
-		$blocks               = parse_blocks( $pattern['content'] );
-		$before_block_visitor = make_before_block_visitor( $pattern );
-		$after_block_visitor  = make_after_block_visitor( $pattern );
-		$pattern['content']   = traverse_and_serialize_blocks( $blocks, $before_block_visitor, $after_block_visitor );
-
-		return $pattern;
+		return $this->registered_patterns[ $pattern_name ];
 	}
 
 	/**
@@ -184,19 +184,11 @@ final class WP_Block_Patterns_Registry {
 	 *                 and per style.
 	 */
 	public function get_all_registered( $outside_init_only = false ) {
-		$patterns = array_values(
+		return array_values(
 			$outside_init_only
 				? $this->registered_patterns_outside_init
 				: $this->registered_patterns
 		);
-
-		foreach ( $patterns as $index => $pattern ) {
-			$blocks                        = parse_blocks( $pattern['content'] );
-			$before_block_visitor          = make_before_block_visitor( $pattern );
-			$after_block_visitor           = make_after_block_visitor( $pattern );
-			$patterns[ $index ]['content'] = traverse_and_serialize_blocks( $blocks, $before_block_visitor, $after_block_visitor );
-		}
-		return $patterns;
 	}
 
 	/**


### PR DESCRIPTION
It has been brought up that performance for block themes that make heavy use of patterns is currently lacking.

The new Block Hooks feature (introduced in #5261) needs to have hooked blocks automatically inserted into patterns. Since the API surface for patterns is fairly small (it's basically just the `WP_Block_Patterns_Registry` class, which has only a few methods to register/unregister and look up patterns), this was originally done at lookup time, i.e. in that class's `get_registered` and `get_all_registered` methods.

As an alternative, we could consider inserting hooked blocks during registration of patterns -- assuming that a given pattern might be looked up multiple time, but will typically only be registered once.

As of #5299, we have some test coverage for the patterns registry, which should provide a certain level of protection against regressions.

Trac ticket: https://core.trac.wordpress.org/ticket/59541

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
