### PR TITLE
#57775: wp_create_file_in_uploads Called as Action Hook

### DIFF
--- a/src/wp-admin/includes/class-custom-background.php
+++ b/src/wp-admin/includes/class-custom-background.php
@@ -571,8 +571,8 @@ class Custom_Background {
 		$thumbnail = wp_get_attachment_image_src( $id, 'thumbnail' );
 		set_theme_mod( 'background_image_thumb', sanitize_url( $thumbnail[0] ) );
 
-		/** This action is documented in wp-admin/includes/class-custom-image-header.php */
-		do_action( 'wp_create_file_in_uploads', $file, $id ); // For replication.
+		/** This filter is documented in wp-admin/includes/class-custom-image-header.php */
+		$file = apply_filters( 'wp_create_file_in_uploads', $file, $id ); // For replication.
 		$this->updated = true;
 	}
 

--- a/src/wp-admin/includes/class-custom-image-header.php
+++ b/src/wp-admin/includes/class-custom-image-header.php
@@ -889,7 +889,7 @@ endif;
 			 * @param string $file          Path to the file.
 			 * @param int    $attachment_id Attachment ID.
 			 */
-			do_action( 'wp_create_file_in_uploads', $file, $attachment_id ); // For replication.
+			$file = apply_filters( 'wp_create_file_in_uploads', $file, $attachment_id ); // For replication.
 
 			return $this->finished();
 		} elseif ( $width > $max_width ) {


### PR DESCRIPTION
Changes instances of `wp_create_file_in_uploads` from action hooks to filter hooks.

Trac ticket: https://core.trac.wordpress.org/ticket/57775

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
