### PR TITLE
Block Hooks: Remove block visitor indirection

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -549,10 +549,13 @@ function _build_block_template_result_from_file( $template_file, $template_type 
 		$template->area = $template_file['area'];
 	}
 
-	$blocks               = parse_blocks( $template_content );
-	$before_block_visitor = make_before_block_visitor( $template );
-	$after_block_visitor  = make_after_block_visitor( $template );
-	$template->content    = traverse_and_serialize_blocks( $blocks, $before_block_visitor, $after_block_visitor );
+	$blocks            = parse_blocks( $template_content );
+	$template->content = traverse_and_serialize_blocks(
+		$blocks,
+		'visit_before_block',
+		'visit_after_block',
+		$template
+	);
 
 	return $template;
 }

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -757,10 +757,10 @@ function get_hooked_blocks( $name ) {
  * Furthermore, prepend the markup for any blocks hooked `before` the given block and as its parent's
  * `first_child`, respectively, to the serialized markup for the given block.
  *
+ * Use as `$pre_callback` argument for {@see 'traverse_and_serialize_blocks()'}.
+ *
  * @since 6.4.0
  * @access private
- *
- * @see traverse_and_serialize_blocks()
  *
  * @param array                   $block        The block to inject the theme attribute into, and hooked blocks before.
  * @param array                   $parent_block The parent block of the given block.
@@ -821,10 +821,10 @@ function visit_before_block( &$block, $parent_block = null, $prev = null, $conte
  * Append the markup for any blocks hooked `after` the given block and as its parent's
  * `last_child`, respectively, to the serialized markup for the given block.
  *
+ * Use as `$post_callback` argument for {@see 'traverse_and_serialize_blocks()'}.
+ *
  * @since 6.4.0
  * @access private
- *
- * @see traverse_and_serialize_blocks()
  *
  * @param array                   $block        The block to inject the hooked blocks after.
  * @param array                   $parent_block The parent block of the given block.

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -760,6 +760,8 @@ function get_hooked_blocks( $name ) {
  * @since 6.4.0
  * @access private
  *
+ * @see traverse_and_serialize_blocks()
+ *
  * @param array                   $block        The block to inject the theme attribute into, and hooked blocks before.
  * @param array                   $parent_block The parent block of the given block.
  * @param array                   $prev         The previous sibling block of the given block.
@@ -821,6 +823,8 @@ function visit_before_block( &$block, $parent_block = null, $prev = null, $conte
  *
  * @since 6.4.0
  * @access private
+ *
+ * @see traverse_and_serialize_blocks()
  *
  * @param array                   $block        The block to inject the hooked blocks after.
  * @param array                   $parent_block The parent block of the given block.

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -760,10 +760,10 @@ function get_hooked_blocks( $name ) {
  * @since 6.4.0
  * @access private
  *
- * @param array $block        The block to inject the theme attribute into, and hooked blocks before.
- * @param array $parent_block The parent block of the given block.
- * @param array $prev         The previous sibling block of the given block.
- * @param mixed $context      Additional information.
+ * @param array                   $block        The block to inject the theme attribute into, and hooked blocks before.
+ * @param array                   $parent_block The parent block of the given block.
+ * @param array                   $prev         The previous sibling block of the given block.
+ * @param WP_Block_Template|array $context      The block template, template part, or pattern that the anchor block belongs to.
  * @return string The serialized markup for the given block, with the markup for any hooked blocks prepended to it.
  */
 function visit_before_block( &$block, $parent_block = null, $prev = null, $context = null ) {
@@ -822,10 +822,10 @@ function visit_before_block( &$block, $parent_block = null, $prev = null, $conte
  * @since 6.4.0
  * @access private
  *
- * @param array $block        The block to inject the hooked blocks after.
- * @param array $parent_block The parent block of the given block.
- * @param array $next         The next sibling block of the given block.
- * @param mixed $context      Additional information.
+ * @param array                   $block        The block to inject the hooked blocks after.
+ * @param array                   $parent_block The parent block of the given block.
+ * @param array                   $prev         The next sibling block of the given block.
+ * @param WP_Block_Template|array $context      The block template, template part, or pattern that the anchor block belongs to.
  * @return string The serialized markup for the given block, with the markup for any hooked blocks appended to it.
  */
 function visit_after_block( &$block, $parent_block = null, $next = null, $context = null ) {

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -766,7 +766,7 @@ function get_hooked_blocks( $name ) {
  * @param mixed $context      Additional information.
  * @return string The serialized markup for the given block, with the markup for any hooked blocks prepended to it.
  */
-function visit_before_block ( &$block, $parent_block = null, $prev = null, $context = null ) {
+function visit_before_block( &$block, $parent_block = null, $prev = null, $context = null ) {
 	_inject_theme_attribute_in_template_part_block( $block );
 
 	$markup = '';
@@ -828,7 +828,7 @@ function visit_before_block ( &$block, $parent_block = null, $prev = null, $cont
  * @param mixed $context      Additional information.
  * @return string The serialized markup for the given block, with the markup for any hooked blocks appended to it.
  */
-function visit_after_block ( &$block, $parent_block = null, $next = null, $context = null ) {
+function visit_after_block( &$block, $parent_block = null, $next = null, $context = null ) {
 	$markup = '';
 
 	$relative_position  = 'after';

--- a/src/wp-includes/class-wp-block-patterns-registry.php
+++ b/src/wp-includes/class-wp-block-patterns-registry.php
@@ -165,11 +165,14 @@ final class WP_Block_Patterns_Registry {
 			return null;
 		}
 
-		$pattern              = $this->registered_patterns[ $pattern_name ];
-		$blocks               = parse_blocks( $pattern['content'] );
-		$before_block_visitor = make_before_block_visitor( $pattern );
-		$after_block_visitor  = make_after_block_visitor( $pattern );
-		$pattern['content']   = traverse_and_serialize_blocks( $blocks, $before_block_visitor, $after_block_visitor );
+		$pattern            = $this->registered_patterns[ $pattern_name ];
+		$blocks             = parse_blocks( $pattern['content'] );
+		$pattern['content'] = traverse_and_serialize_blocks(
+			$blocks,
+			'visit_before_block',
+			'visit_after_block',
+			$pattern
+		);
 
 		return $pattern;
 	}
@@ -192,9 +195,12 @@ final class WP_Block_Patterns_Registry {
 
 		foreach ( $patterns as $index => $pattern ) {
 			$blocks                        = parse_blocks( $pattern['content'] );
-			$before_block_visitor          = make_before_block_visitor( $pattern );
-			$after_block_visitor           = make_after_block_visitor( $pattern );
-			$patterns[ $index ]['content'] = traverse_and_serialize_blocks( $blocks, $before_block_visitor, $after_block_visitor );
+			$patterns[ $index ]['content'] = traverse_and_serialize_blocks(
+				$blocks,
+				'visit_before_block',
+				'visit_after_block',
+				$pattern
+			);
 		}
 		return $patterns;
 	}

--- a/tests/phpunit/tests/blocks/serialize.php
+++ b/tests/phpunit/tests/blocks/serialize.php
@@ -74,7 +74,7 @@ class Tests_Blocks_Serialize extends WP_UnitTestCase {
 		);
 	}
 
-	public static function add_attribute_to_inner_block( &$block, $parent, $prev, $data ) {
+	public static function add_attribute_to_inner_block( &$block, $parent_block, $prev, $data ) {
 		if ( 'core/inner' === $block['blockName'] ) {
 			$block['attrs']['myattr'] = $data;
 		}

--- a/tests/phpunit/tests/blocks/serialize.php
+++ b/tests/phpunit/tests/blocks/serialize.php
@@ -66,7 +66,7 @@ class Tests_Blocks_Serialize extends WP_UnitTestCase {
 		$markup = "<!-- wp:outer --><!-- wp:inner {\"key\":\"value\"} -->Example.<!-- /wp:inner -->\n\nExample.\n\n<!-- wp:void /--><!-- /wp:outer -->";
 		$blocks = parse_blocks( $markup );
 
-		$actual = traverse_and_serialize_blocks( $blocks, array( __CLASS__, 'add_attribute_to_inner_block' ) );
+		$actual = traverse_and_serialize_blocks( $blocks, array( __CLASS__, 'add_attribute_to_inner_block' ), null, 'myvalue' );
 
 		$this->assertSame(
 			"<!-- wp:outer --><!-- wp:inner {\"key\":\"value\",\"myattr\":\"myvalue\"} -->Example.<!-- /wp:inner -->\n\nExample.\n\n<!-- wp:void /--><!-- /wp:outer -->",
@@ -74,9 +74,9 @@ class Tests_Blocks_Serialize extends WP_UnitTestCase {
 		);
 	}
 
-	public static function add_attribute_to_inner_block( &$block ) {
+	public static function add_attribute_to_inner_block( &$block, $parent, $prev, $data ) {
 		if ( 'core/inner' === $block['blockName'] ) {
-			$block['attrs']['myattr'] = 'myvalue';
+			$block['attrs']['myattr'] = $data;
 		}
 	}
 


### PR DESCRIPTION
As discussed with @gziolo, it might make sense to remove the extra indirection (i.e. the `make_before_block_visitor` and `make_after_block_visitor` factories) that we currently have around the visitor callbacks that we pass to `traverse_and_serialize_blocks`.

The original idea behind that indirection was a clean-room level separation of concerns: While I wanted the `hooked_block_types` filter to be aware of the template, template part, or pattern that it belongs to, I wanted to keep `traverse_and_serialize_block(s)` perfectly unaware of this extra information. The best way I could think of at the time was the indirection through the `make_` factories.

However, I'm coming round to considering the alternative of passing the extra context to `traverse_and_serialize_block(s)` after all, and then have that function pass it as an argument to the callbacks. Importantly, to preserve separation of context, for the purpose of `traverse_and_serialize_block(s)`, I'd like the extra data to be completely generic (i.e. a `mixed` datatype with no assumptions with regard to what it contains); it's solely up to the caller what that extra data looks like, and how it is used by the callbacks.

This might help improve performance of Block Hooks related logic a bit. Furthermore, it unlocks the ability to pass additional data to the callbacks. @gziolo E.g. for #5399, we might change `$data` to include both `$context` and `$hooked_blocks` :blush:

Trac ticket: https://core.trac.wordpress.org/ticket/59549

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
