### PR TITLE
Fast follow: post parent ID cache V2

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -3191,7 +3191,7 @@ class WP_Query {
 
 						return $this->posts;
 					} elseif ( 'id=>parent' === $q['fields'] ) {
-						_prime_post_parents_caches( $post_ids );
+						_prime_post_parent_id_caches( $post_ids );
 
 						/** @var int[] */
 						$post_parents = wp_cache_get_multiple( $post_ids, 'post_parent' );

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -547,6 +547,7 @@ add_action( 'init', 'create_initial_post_types', 0 ); // Highest priority.
 add_action( 'admin_menu', '_add_post_type_submenus' );
 add_action( 'before_delete_post', '_reset_front_page_settings_for_post' );
 add_action( 'wp_trash_post', '_reset_front_page_settings_for_post' );
+add_action( 'save_post', '_set_post_parent_cache', 10, 2 );
 add_action( 'change_locale', 'create_initial_post_types' );
 
 // Post Formats.

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -3572,7 +3572,7 @@ function _reset_front_page_settings_for_post( $post_id ) {
  * @param WP_Post $post   The post object representing the post.
  */
 function _set_post_parent_cache( $post_id, $post ) {
-	wp_cache_set( $post_id, $post->post_parent );
+	wp_cache_set( $post_id, $post->post_parent, 'post_parent' );
 }
 
 /**

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -7805,7 +7805,7 @@ function _prime_post_caches( $ids, $update_term_cache = true, $update_meta_cache
  *
  * @param int[] $ids ID list.
  */
-function _prime_post_parents_caches( array $ids ) {
+function _prime_post_parent_id_caches( array $ids ) {
 	global $wpdb;
 
 	$non_cached_ids = _get_non_cached_ids( $ids, 'post_parent' );

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -3560,6 +3560,22 @@ function _reset_front_page_settings_for_post( $post_id ) {
 }
 
 /**
+ * Set or update the post parent cache for a specific post.
+ *
+ * This function sets or updates the post parent cache for a given post ID.
+ * The post parent cache is used to store the parent ID of a post for quick retrieval.
+ *
+ *  @since 6.4.0
+ *  @access private
+ *
+ * @param int    $post_id The ID of the post for which to set or update the parent cache.
+ * @param WP_Post $post   The post object representing the post.
+ */
+function _set_post_parent_cache( $post_id, $post ) {
+	wp_cache_set( $post_id, $post->post_parent );
+}
+
+/**
  * Moves a post or page to the Trash
  *
  * If Trash is disabled, the post or page is permanently deleted.

--- a/tests/phpunit/tests/post/primePostParentIdCaches.php
+++ b/tests/phpunit/tests/post/primePostParentIdCaches.php
@@ -73,12 +73,13 @@ class Tests_Post_PrimePostParentIdCaches extends WP_UnitTestCase {
 	 * @ticket 59188
 	 */
 	public function test_prime_post_parent_id_caches_update() {
-		$page_id            = self::factory()->post->create(
+		$page_id = self::factory()->post->create(
 			array(
 				'post_type'   => 'page',
 				'post_parent' => self::$posts[0],
 			)
 		);
+		clean_post_cache( $page_id );
 		$before_num_queries = get_num_queries();
 		_prime_post_parent_id_caches( array( $page_id ) );
 		$num_queries = get_num_queries() - $before_num_queries;
@@ -97,7 +98,7 @@ class Tests_Post_PrimePostParentIdCaches extends WP_UnitTestCase {
 		_prime_post_parent_id_caches( array( $page_id ) );
 		$num_queries = get_num_queries() - $before_num_queries;
 
-		$this->assertSame( 1, $num_queries, 'Unexpected number of queries on second run' );
+		$this->assertSame( 0, $num_queries, 'Unexpected number of queries on second run' );
 		$this->assertSameSets( array( self::$posts[1] ), wp_cache_get_multiple( array( $page_id ), 'post_parent' ), 'Array of parent ids with post 1 as parent' );
 	}
 
@@ -105,17 +106,18 @@ class Tests_Post_PrimePostParentIdCaches extends WP_UnitTestCase {
 	 * @ticket 59188
 	 */
 	public function test_prime_post_parent_id_caches_delete() {
-		$parent_page_id     = self::factory()->post->create(
+		$parent_page_id = self::factory()->post->create(
 			array(
 				'post_type' => 'page',
 			)
 		);
-		$page_id            = self::factory()->post->create(
+		$page_id        = self::factory()->post->create(
 			array(
 				'post_type'   => 'page',
 				'post_parent' => $parent_page_id,
 			)
 		);
+		clean_post_cache( $page_id );
 		$before_num_queries = get_num_queries();
 		_prime_post_parent_id_caches( array( $page_id ) );
 		$num_queries = get_num_queries() - $before_num_queries;

--- a/tests/phpunit/tests/post/primePostParentIdCaches.php
+++ b/tests/phpunit/tests/post/primePostParentIdCaches.php
@@ -1,19 +1,19 @@
 <?php
 /**
- * Test `_prime_post_parents_caches()`.
+ * Test `_prime_post_parent_id_caches()`.
  *
  * @package WordPress
  */
 
 /**
- * Test class for `_prime_post_parents_caches()`.
+ * Test class for `_prime_post_parent_id_caches()`.
  *
  * @group post
  * @group cache
  *
- * @covers ::_prime_post_parents_caches
+ * @covers ::_prime_post_parent_id_caches
  */
-class Tests_Post_PrimePostParentsCaches extends WP_UnitTestCase {
+class Tests_Post_PrimePostParentIdCaches extends WP_UnitTestCase {
 
 	/**
 	 * Post IDs.
@@ -34,11 +34,11 @@ class Tests_Post_PrimePostParentsCaches extends WP_UnitTestCase {
 	/**
 	 * @ticket 59188
 	 */
-	public function test_prime_post_parents_caches() {
+	public function test_prime_post_parent_id_caches() {
 		$post_id = self::$posts[0];
 
 		$before_num_queries = get_num_queries();
-		_prime_post_parents_caches( array( $post_id ) );
+		_prime_post_parent_id_caches( array( $post_id ) );
 		$num_queries = get_num_queries() - $before_num_queries;
 
 		$this->assertSame( 1, $num_queries, 'Unexpected number of queries.' );
@@ -48,9 +48,9 @@ class Tests_Post_PrimePostParentsCaches extends WP_UnitTestCase {
 	/**
 	 * @ticket 59188
 	 */
-	public function test_prime_post_parents_caches_multiple() {
+	public function test_prime_post_parent_id_caches_multiple() {
 		$before_num_queries = get_num_queries();
-		_prime_post_parents_caches( self::$posts );
+		_prime_post_parent_id_caches( self::$posts );
 		$num_queries = get_num_queries() - $before_num_queries;
 
 		$this->assertSame( 1, $num_queries, 'Unexpected number of queries.' );
@@ -60,10 +60,10 @@ class Tests_Post_PrimePostParentsCaches extends WP_UnitTestCase {
 	/**
 	 * @ticket 59188
 	 */
-	public function test_prime_post_parents_caches_multiple_runs() {
-		_prime_post_parents_caches( self::$posts );
+	public function test_prime_post_parent_id_caches_multiple_runs() {
+		_prime_post_parent_id_caches( self::$posts );
 		$before_num_queries = get_num_queries();
-		_prime_post_parents_caches( self::$posts );
+		_prime_post_parent_id_caches( self::$posts );
 		$num_queries = get_num_queries() - $before_num_queries;
 
 		$this->assertSame( 0, $num_queries, 'Unexpected number of queries.' );
@@ -72,7 +72,7 @@ class Tests_Post_PrimePostParentsCaches extends WP_UnitTestCase {
 	/**
 	 * @ticket 59188
 	 */
-	public function test_prime_post_parents_caches_update() {
+	public function test_prime_post_parent_id_caches_update() {
 		$page_id            = self::factory()->post->create(
 			array(
 				'post_type'   => 'page',
@@ -80,7 +80,7 @@ class Tests_Post_PrimePostParentsCaches extends WP_UnitTestCase {
 			)
 		);
 		$before_num_queries = get_num_queries();
-		_prime_post_parents_caches( array( $page_id ) );
+		_prime_post_parent_id_caches( array( $page_id ) );
 		$num_queries = get_num_queries() - $before_num_queries;
 
 		$this->assertSame( 1, $num_queries, 'Unexpected number of queries on first run' );
@@ -94,7 +94,7 @@ class Tests_Post_PrimePostParentsCaches extends WP_UnitTestCase {
 		);
 
 		$before_num_queries = get_num_queries();
-		_prime_post_parents_caches( array( $page_id ) );
+		_prime_post_parent_id_caches( array( $page_id ) );
 		$num_queries = get_num_queries() - $before_num_queries;
 
 		$this->assertSame( 1, $num_queries, 'Unexpected number of queries on second run' );
@@ -104,7 +104,7 @@ class Tests_Post_PrimePostParentsCaches extends WP_UnitTestCase {
 	/**
 	 * @ticket 59188
 	 */
-	public function test_prime_post_parents_caches_delete() {
+	public function test_prime_post_parent_id_caches_delete() {
 		$parent_page_id     = self::factory()->post->create(
 			array(
 				'post_type' => 'page',
@@ -117,7 +117,7 @@ class Tests_Post_PrimePostParentsCaches extends WP_UnitTestCase {
 			)
 		);
 		$before_num_queries = get_num_queries();
-		_prime_post_parents_caches( array( $page_id ) );
+		_prime_post_parent_id_caches( array( $page_id ) );
 		$num_queries = get_num_queries() - $before_num_queries;
 
 		$this->assertSame( 1, $num_queries, 'Unexpected number of queries on first run' );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

PR is based on https://github.com/WordPress/wordpress-develop/pull/5386. It is simplier PR, that just changes the function name and prime the post parent cache on post save. 

Trac ticket: https://core.trac.wordpress.org/ticket/59188

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
