### PR TITLE
Add inline notice for when no items selected on posts/plugins page

### DIFF
--- a/src/js/_enqueues/wp/updates.js
+++ b/src/js/_enqueues/wp/updates.js
@@ -270,6 +270,38 @@
 	};
 
 	/**
+	 * Helper function to insert an inline notice of success or failure.
+	 *
+	 * @param {jQuery Object} $this   The button element: the message will be inserted
+	 *                                above this button
+	 * @param {bool}          success Whether the message is a success message.
+	 * @param {string}        message The message to insert.
+	 * 
+	 * @since 6.4.0
+	 */
+	wp.updates.addInlineNotice = function( $this, success, message ) {
+		var resultDiv = $("<div />");
+
+		// Set up the notice div.
+		resultDiv.addClass("notice inline");
+
+		// Add a class indicating success or failure.
+		resultDiv.addClass("notice-" + (success ? "success" : "error"));
+
+		// Add the message, wrapping in a p tag, with a fadein to highlight each message.
+		resultDiv.text($($.parseHTML(message)).text()).wrapInner("<p />");
+
+		// Disable the button when the callback has succeeded.
+		$this.prop("disabled", success);
+
+		// Remove any previous notices.
+		$this.siblings(".notice").remove();
+
+		// Insert the notice.
+		$this.before(resultDiv);
+	}
+
+	/**
 	 * Handles Ajax requests to WordPress.
 	 *
 	 * @since 4.6.0
@@ -2027,6 +2059,7 @@
 	$( function() {
 		var $pluginFilter        = $( '#plugin-filter' ),
 			$bulkActionForm      = $( '#bulk-action-form' ),
+			$postFilterForm      = $( '#posts-filter' ),
 			$filesystemForm      = $( '#request-filesystem-credentials-form' ),
 			$filesystemModal     = $( '#request-filesystem-credentials-dialog' ),
 			$pluginSearch        = $( '.plugins-php .wp-filter-search' ),
@@ -2416,13 +2449,14 @@
 			// Bail if there were no items selected.
 			if ( ! itemsSelected.length ) {
 				event.preventDefault();
-				$( 'html, body' ).animate( { scrollTop: 0 } );
 
-				return wp.updates.addAdminNotice( {
-					id:        'no-items-selected',
-					className: 'notice-error is-dismissible',
-					message:   __( 'Please select at least one item to perform this action on.' )
-				} );
+				wp.a11y.speak( wp.i18n.__( 'Please select at least one item to perform this action on.' ) );
+
+				return wp.updates.addInlineNotice(
+					$(".bulkactions"),
+					false,
+					"Please select at least one item to perform this action on."
+				);
 			}
 
 			// Determine the type of request we're dealing with.
@@ -2535,6 +2569,32 @@
 
 			// Check the queue, now that the event handlers have been added.
 			wp.updates.queueChecker();
+		} );
+		
+		/**
+		 * Bulk action handler for posts/pages.
+		 *
+		 * Handles the scenario where no items are selected.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @param {Event} event Event interface.
+		 */
+		$postFilterForm.on( 'click', '#doaction, #doaction2', function( event ) {
+			var itemsSelected = $postFilterForm.find( 'input[name="post[]"]:checked' );
+
+			// Bail if there were no items selected.
+			if ( ! itemsSelected.length ) {
+				event.preventDefault();
+
+				wp.a11y.speak( wp.i18n.__( 'Please select at least one item to perform this action on.' ) );
+
+				return wp.updates.addInlineNotice(
+					$(".bulkactions"),
+					false,
+					"Please select at least one item to perform this action on."
+				);
+			}
 		} );
 
 		if ( $pluginInstallSearch.length ) {

--- a/src/wp-admin/edit.php
+++ b/src/wp-admin/edit.php
@@ -236,6 +236,7 @@ $wp_list_table->prepare_items();
 
 wp_enqueue_script( 'inline-edit-post' );
 wp_enqueue_script( 'heartbeat' );
+wp_enqueue_script( 'updates' );
 
 if ( 'wp_block' === $post_type ) {
 	wp_enqueue_script( 'wp-list-reusable-blocks' );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->
https://core.trac.wordpress.org/ticket/58479
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
