### PR TITLE
Update the parameters name in WP_Block_List class to be consistent with ArrayAccess interface

### DIFF
--- a/src/wp-includes/class-wp-block-list.php
+++ b/src/wp-includes/class-wp-block-list.php
@@ -63,59 +63,59 @@ class WP_Block_List implements Iterator, ArrayAccess, Countable {
 	}
 
 	/**
-	 * Returns true if a block exists by the specified block index, or false
+	 * Returns true if a block exists by the specified block offset, or false
 	 * otherwise.
 	 *
 	 * @since 5.5.0
 	 *
 	 * @link https://www.php.net/manual/en/arrayaccess.offsetexists.php
 	 *
-	 * @param string $index Index of block to check.
+	 * @param string $offset Offset of block to check for.
 	 * @return bool Whether block exists.
 	 */
 	#[ReturnTypeWillChange]
-	public function offsetExists( $index ) {
-		return isset( $this->blocks[ $index ] );
+	public function offsetExists( $offset ) {
+		return isset( $this->blocks[ $offset ] );
 	}
 
 	/**
-	 * Returns the value by the specified block index.
+	 * Returns the value by the specified block offset.
 	 *
 	 * @since 5.5.0
 	 *
 	 * @link https://www.php.net/manual/en/arrayaccess.offsetget.php
 	 *
-	 * @param string $index Index of block value to retrieve.
+	 * @param string $offset Offset of block value to retrieve.
 	 * @return mixed|null Block value if exists, or null.
 	 */
 	#[ReturnTypeWillChange]
-	public function offsetGet( $index ) {
-		$block = $this->blocks[ $index ];
+	public function offsetGet( $offset ) {
+		$block = $this->blocks[ $offset ];
 
 		if ( isset( $block ) && is_array( $block ) ) {
 			$block                  = new WP_Block( $block, $this->available_context, $this->registry );
-			$this->blocks[ $index ] = $block;
+			$this->blocks[ $offset ] = $block;
 		}
 
 		return $block;
 	}
 
 	/**
-	 * Assign a block value by the specified block index.
+	 * Assign a block value by the specified block offset.
 	 *
 	 * @since 5.5.0
 	 *
 	 * @link https://www.php.net/manual/en/arrayaccess.offsetset.php
 	 *
-	 * @param string $index Index of block value to set.
+	 * @param string $offset Offset of block value to set.
 	 * @param mixed  $value Block value.
 	 */
 	#[ReturnTypeWillChange]
-	public function offsetSet( $index, $value ) {
-		if ( is_null( $index ) ) {
+	public function offsetSet( $offset, $value ) {
+		if ( is_null( $offset ) ) {
 			$this->blocks[] = $value;
 		} else {
-			$this->blocks[ $index ] = $value;
+			$this->blocks[ $offset ] = $value;
 		}
 	}
 
@@ -126,11 +126,11 @@ class WP_Block_List implements Iterator, ArrayAccess, Countable {
 	 *
 	 * @link https://www.php.net/manual/en/arrayaccess.offsetunset.php
 	 *
-	 * @param string $index Index of block value to unset.
+	 * @param string $offset Offset of block value to unset.
 	 */
 	#[ReturnTypeWillChange]
-	public function offsetUnset( $index ) {
-		unset( $this->blocks[ $index ] );
+	public function offsetUnset( $offset ) {
+		unset( $this->blocks[ $offset ] );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This PR updates the parameter names in the WP_Block_List class to follow the same defined in the [ArrayAccess interface](https://www.php.net/manual/en/class.arrayaccess.php).


Trac ticket: https://core.trac.wordpress.org/ticket/58976

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
