### PR TITLE
fix: theme twentynineteen button line-height

### DIFF
--- a/src/wp-content/themes/twentynineteen/sass/blocks/_blocks.scss
+++ b/src/wp-content/themes/twentynineteen/sass/blocks/_blocks.scss
@@ -165,13 +165,13 @@
 
 	//! Button
 	.wp-block-button {
+		line-height: $font__line-height-heading;
 
 		.wp-block-button__link {
 			@include button-transition;
 			border: none;
 			font-size: $font__size-sm;
 			@include font-family( $font__heading );
-			line-height: $font__line-height-heading;
 			box-sizing: border-box;
 			font-weight: bold;
 			text-decoration: none;

--- a/src/wp-content/themes/twentynineteen/style-rtl.css
+++ b/src/wp-content/themes/twentynineteen/style-rtl.css
@@ -5484,12 +5484,15 @@ body.page .main-navigation {
   width: 100%;
 }
 
+.entry .entry-content .wp-block-button {
+  line-height: 1.2;
+}
+
 .entry .entry-content .wp-block-button .wp-block-button__link {
   transition: background 150ms ease-in-out;
   border: none;
   font-size: 0.88889em;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  line-height: 1.2;
   box-sizing: border-box;
   font-weight: bold;
   text-decoration: none;

--- a/src/wp-content/themes/twentynineteen/style.css
+++ b/src/wp-content/themes/twentynineteen/style.css
@@ -5496,15 +5496,12 @@ body.page .main-navigation {
   width: 100%;
 }
 
-.entry .entry-content .wp-block-button {
-  line-height: 1.2;
-}
-
 .entry .entry-content .wp-block-button .wp-block-button__link {
   transition: background 150ms ease-in-out;
   border: none;
   font-size: 0.88889em;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  line-height: 1.2;
   box-sizing: border-box;
   font-weight: bold;
   text-decoration: none;

--- a/src/wp-content/themes/twentynineteen/style.css
+++ b/src/wp-content/themes/twentynineteen/style.css
@@ -5496,12 +5496,15 @@ body.page .main-navigation {
   width: 100%;
 }
 
+.entry .entry-content .wp-block-button {
+  line-height: 1.2;
+}
+
 .entry .entry-content .wp-block-button .wp-block-button__link {
   transition: background 150ms ease-in-out;
   border: none;
   font-size: 0.88889em;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  line-height: 1.2;
   box-sizing: border-box;
   font-weight: bold;
   text-decoration: none;


### PR DESCRIPTION
I moved line-height default definition from .wp-block-button__link to .wp-block-button, as a result, it allowed for overriding by style and block editor.

Trac ticket: https://core.trac.wordpress.org/ticket/58443