### PR TITLE
fix: Writing reset key for email with apostrophe

### DIFF
--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -2095,6 +2095,9 @@ function wp_insert_user( $userdata ) {
 			return new WP_Error( 'invalid_user_id', __( 'Invalid user ID.' ) );
 		}
 
+		// Slash current user email to compare it later with slashed new user email.
+		$old_user_data->user_email = wp_slash( $old_user_data->user_email );
+
 		// Hashed in wp_update_user(), plaintext if called directly.
 		$user_pass = ! empty( $userdata['user_pass'] ) ? $userdata['user_pass'] : $old_user_data->user_pass;
 	} else {

--- a/tests/phpunit/tests/auth.php
+++ b/tests/phpunit/tests/auth.php
@@ -838,6 +838,27 @@ class Tests_Auth extends WP_UnitTestCase {
 		}
 	}
 
+	/**
+	 * @ticket 52529
+	 */
+	public function test_reset_password_with_apostrophe_in_email() {
+		$user_args = array(
+			'user_email' => "jo'hn@example.com",
+			'user_pass'  => 'password',
+		);
+		$user_id = self::factory()->user->create( $user_args );
+
+		$user = get_userdata( $user_id );
+		$key  = get_password_reset_key( $user );
+
+		// A correctly saved key should be accepted.
+		$check = check_password_reset_key( $key, $user->user_login );
+
+		$this->assertNotWPError( $check );
+		$this->assertInstanceOf( 'WP_User', $check );
+		$this->assertSame( $user_id, $check->ID );
+	}
+
 	public function data_application_passwords_can_use_capability_checks_to_determine_feature_availability() {
 		return array(
 			'allowed'     => array( 'editor', true ),

--- a/tests/phpunit/tests/auth.php
+++ b/tests/phpunit/tests/auth.php
@@ -846,6 +846,7 @@ class Tests_Auth extends WP_UnitTestCase {
 			'user_email' => "jo'hn@example.com",
 			'user_pass'  => 'password',
 		);
+
 		$user_id = self::factory()->user->create( $user_args );
 
 		$user = get_userdata( $user_id );


### PR DESCRIPTION
Setting a new password using the reset link is impossible for the reason that the user's email contains an apostrophe.

Trac ticket: https://core.trac.wordpress.org/ticket/52529