### PR TITLE
`update_network_option()` strict checks can cause false negatives

### DIFF
--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -2144,6 +2144,7 @@ function update_network_option( $network_id, $option, $value ) {
 	 */
 	$value = apply_filters( "pre_update_site_option_{$option}", $value, $old_value, $option, $network_id );
 
+	$is_multisite = is_multisite();
 	/*
 	 * If the new and old values are the same, no need to update.
 	 *
@@ -2156,6 +2157,11 @@ function update_network_option( $network_id, $option, $value ) {
 		$value === $old_value ||
 		(
 			false !== $old_value &&
+			/*
+			 * Multisite uses the `meta_value` database field, which is nullable.
+			 * Don't check for values that are equal to `null`.
+			 */
+			( ! $is_multisite || ( null !== $old_value && null !== $value ) ) &&
 			_is_equal_database_value( $old_value, $value )
 		)
 	) {
@@ -2174,7 +2180,7 @@ function update_network_option( $network_id, $option, $value ) {
 		wp_cache_set( $notoptions_key, $notoptions, 'site-options' );
 	}
 
-	if ( ! is_multisite() ) {
+	if ( ! $is_multisite ) {
 		$result = update_option( $option, $value, 'no' );
 	} else {
 		$value = sanitize_option( $option, $value );

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -2147,13 +2147,18 @@ function update_network_option( $network_id, $option, $value ) {
 	/*
 	 * If the new and old values are the same, no need to update.
 	 *
-	 * Unserialized values will be adequate in most cases. If the unserialized
-	 * data differs, the (maybe) serialized data is checked to avoid
-	 * unnecessary database calls for otherwise identical object instances.
+	 * An exception applies when no value is set in the database, i.e. the old value is the default.
+	 * In that case, the new value should always be added as it may be intentional to store it rather than relying on the default.
 	 *
-	 * See https://core.trac.wordpress.org/ticket/44956
+	 * See https://core.trac.wordpress.org/ticket/44956 and https://core.trac.wordpress.org/ticket/22192 and https://core.trac.wordpress.org/ticket/59360
 	 */
-	if ( $value === $old_value || maybe_serialize( $value ) === maybe_serialize( $old_value ) ) {
+	if (
+		$value === $old_value ||
+		(
+			false !== $old_value &&
+			_is_equal_database_value( $old_value, $value )
+		)
+	) {
 		return false;
 	}
 

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -2172,8 +2172,6 @@ function update_network_option( $network_id, $option, $value ) {
 			$raw_old_value = get_network_option( $network_id, $option );
 		} else {
 			$raw_old_value = get_option( $option, $default_value );
-			/** This filter is documented in wp-includes/option.php */
-			$default_value = apply_filters( "default_option_{$option}", $default_value, $option, true );
 		}
 
 		if ( $has_site_filter ) {
@@ -2184,10 +2182,11 @@ function update_network_option( $network_id, $option, $value ) {
 		}
 	} else {
 		$raw_old_value = $old_value;
-		if ( ! is_multisite() ) {
-			/** This filter is documented in wp-includes/option.php */
-			$default_value = apply_filters( "default_option_{$option}", $default_value, $option, true );
-		}
+	}
+
+	if ( ! is_multisite() ) {
+		/** This filter is documented in wp-includes/option.php */
+		$default_value = apply_filters( "default_option_{$option}", $default_value, $option, true );
 	}
 
 	/*

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -2201,8 +2201,15 @@ function update_network_option( $network_id, $option, $value ) {
 		$value === $raw_old_value ||
 		(
 			false !== $raw_old_value &&
-			// Site meta values are nullable. Don't check if the values are loosely equal to null.
-			( ! is_multisite() || ( null !== $raw_old_value && null !== $value ) ) &&
+			/*
+			 * Single site stores values in the `option_value` field, which cannot be set to NULL.
+			 * This means a PHP `null` value will be cast to an empty string, which can be considered
+			 * equal to values such as an empty string, or false when cast to string.
+			 *
+			 * However, Multisite stores values in the `meta_value` field, which can be set to NULL.
+			 * As NULL is unique in the database, skip checking an old or new value of NULL
+			 * against any other value.
+			 */
 			_is_equal_database_value( $raw_old_value, $value )
 		)
 	) {

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -2144,8 +2144,6 @@ function update_network_option( $network_id, $option, $value ) {
 	 */
 	$value = apply_filters( "pre_update_site_option_{$option}", $value, $old_value, $option, $network_id );
 
-	$is_multisite = is_multisite();
-
 	/*
 	 * To get the actual raw old value from the database, any existing pre filters need to be temporarily disabled.
 	 * Immediately after getting the raw value, they are reinstated.
@@ -2177,7 +2175,7 @@ function update_network_option( $network_id, $option, $value ) {
 		(
 			false !== $raw_old_value &&
 			// Site meta values are nullable. Don't check if the values are loosely equal to null.
-			( ! $is_multisite || ( null !== $raw_old_value && null !== $value ) ) &&
+			( ! is_multisite() || ( null !== $raw_old_value && null !== $value ) ) &&
 			_is_equal_database_value( $raw_old_value, $value )
 		)
 	) {
@@ -2196,7 +2194,7 @@ function update_network_option( $network_id, $option, $value ) {
 		wp_cache_set( $notoptions_key, $notoptions, 'site-options' );
 	}
 
-	if ( ! $is_multisite ) {
+	if ( ! is_multisite() ) {
 		$result = update_option( $option, $value, 'no' );
 	} else {
 		$value = sanitize_option( $option, $value );

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -2156,7 +2156,9 @@ function update_network_option( $network_id, $option, $value ) {
 	if ( has_filter( $pre_option_hook ) ) {
 		$old_filters = $wp_filter[ $pre_option_hook ];
 		unset( $wp_filter[ $pre_option_hook ] );
-		$raw_old_value = get_network_option( $network_id, $option );
+		/** This filter is documented in wp-includes/options.php */
+		$default_value  = apply_filters( 'default_site_option_' . $option, false, $option, $network_id );
+		$raw_old_value = is_multisite() ? get_network_option( $network_id, $option ) : get_option( $option, $default_value );
 		$wp_filter[ $pre_option_hook ] = $old_filters;
 	} else {
 		$raw_old_value = $old_value;

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -2152,13 +2152,16 @@ function update_network_option( $network_id, $option, $value ) {
 	 */
 	global $wp_filter;
 
-	$pre_option_hook = is_multisite() ? "pre_site_option_{$option}" : "pre_option_{$option}";
+	$default_value_hook = is_multisite() ? "default_site_option_{$option}" : "default_option_{$option}";
+	$default_value      = apply_filters( $default_value_hook, false, $option, $network_id );
+	$pre_option_hook    = is_multisite() ? "pre_site_option_{$option}" : "pre_option_{$option}";
+
 	if ( has_filter( $pre_option_hook ) ) {
 		$old_filters = $wp_filter[ $pre_option_hook ];
 		unset( $wp_filter[ $pre_option_hook ] );
-		/** This filter is documented in wp-includes/options.php */
-		$default_value  = apply_filters( 'default_site_option_' . $option, false, $option, $network_id );
+
 		$raw_old_value = is_multisite() ? get_network_option( $network_id, $option ) : get_option( $option, $default_value );
+
 		$wp_filter[ $pre_option_hook ] = $old_filters;
 	} else {
 		$raw_old_value = $old_value;
@@ -2184,7 +2187,7 @@ function update_network_option( $network_id, $option, $value ) {
 		return false;
 	}
 
-	if ( false === $raw_old_value ) {
+	if ( $default_value === $raw_old_value ) {
 		return add_network_option( $network_id, $option, $value );
 	}
 

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -2125,7 +2125,7 @@ function update_network_option( $network_id, $option, $value ) {
 
 	wp_protect_special_option( $option );
 
-	$old_value = get_network_option( $network_id, $option, false );
+	$old_value = get_network_option( $network_id, $option );
 
 	/**
 	 * Filters a specific network option before its value is updated.
@@ -2156,7 +2156,7 @@ function update_network_option( $network_id, $option, $value ) {
 	if ( has_filter( $pre_option_hook ) ) {
 		$old_filters = $wp_filter[ $pre_option_hook ];
 		unset( $wp_filter[ $pre_option_hook ] );
-		$raw_old_value = is_multisite() ? get_network_option( $network_id, $option ) : get_option( $option );
+		$raw_old_value = get_network_option( $network_id, $option );
 		$wp_filter[ $pre_option_hook ] = $old_filters;
 	} else {
 		$raw_old_value = $old_value;

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -2210,6 +2210,7 @@ function update_network_option( $network_id, $option, $value ) {
 			 * As NULL is unique in the database, skip checking an old or new value of NULL
 			 * against any other value.
 			 */
+			( ! is_multisite() || ! ( null === $raw_old_value || null === $value ) ) &&
 			_is_equal_database_value( $raw_old_value, $value )
 		)
 	) {

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -2152,6 +2152,7 @@ function update_network_option( $network_id, $option, $value ) {
 	 */
 	global $wp_filter;
 
+	/** This filter is documented in wp-includes/option.php */
 	$default_value = apply_filters( "default_site_option_{$option}", false, $option, $network_id );
 
 	$has_site_filter   = has_filter( "pre_site_option_{$option}" );
@@ -2167,7 +2168,13 @@ function update_network_option( $network_id, $option, $value ) {
 			unset( $wp_filter[ "pre_option_{$option}" ] );
 		}
 
-		$raw_old_value = is_multisite() ? get_network_option( $network_id, $option ) : get_option( $option, $default_value );
+		if ( is_multisite() ) {
+			$raw_old_value = get_network_option( $network_id, $option );
+		} else {
+			$raw_old_value = get_option( $option, $default_value );
+			/** This filter is documented in wp-includes/option.php */
+			$default_value = apply_filters( "default_option_{$option}", $default_value, $option, true );
+		}
 
 		if ( $has_site_filter ) {
 			$wp_filter[ "pre_site_option_{$option}" ] = $old_ms_filters;
@@ -2177,6 +2184,10 @@ function update_network_option( $network_id, $option, $value ) {
 		}
 	} else {
 		$raw_old_value = $old_value;
+		if ( ! is_multisite() ) {
+			/** This filter is documented in wp-includes/option.php */
+			$default_value = apply_filters( "default_option_{$option}", $default_value, $option, true );
+		}
 	}
 
 	/*

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -2150,14 +2150,14 @@ function update_network_option( $network_id, $option, $value ) {
 	 * The raw value is only used to determine whether a value is present in the database. It is not used anywhere
 	 * else, and is not passed to any of the hooks either.
 	 */
-	if ( has_filter( "pre_site_option_{$option}" ) ) {
-		global $wp_filter;
+	global $wp_filter;
 
-		$old_filters = $wp_filter[ "pre_site_option_{$option}" ];
-		unset( $wp_filter[ "pre_site_option_{$option}" ] );
-
-		$raw_old_value                            = get_network_option( $network_id, $option, false );
-		$wp_filter[ "pre_site_option_{$option}" ] = $old_filters;
+	$pre_option_hook = is_multisite() ? "pre_site_option_{$option}" : "pre_option_{$option}";
+	if ( has_filter( $pre_option_hook ) ) {
+		$old_filters = $wp_filter[ $pre_option_hook ];
+		unset( $wp_filter[ $pre_option_hook ] );
+		$raw_old_value = is_multisite() ? get_network_option( $network_id, $option ) : get_option( $option );
+		$wp_filter[ $pre_option_hook ] = $old_filters;
 	} else {
 		$raw_old_value = $old_value;
 	}

--- a/tests/phpunit/tests/option/networkOption.php
+++ b/tests/phpunit/tests/option/networkOption.php
@@ -407,9 +407,7 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 		// Comparison will happen against value cached during add_option() above.
 		$updated = update_network_option( null, 'foo', $new_value );
 
-		$expected_queries = $old_value === $new_value || ! is_multisite() ? 0 : 1;
-		$this->assertSame( $expected_queries, get_num_queries() - $num_queries, "The number of queries should have increased by $expected_queries." );
-
+		$this->assertSame( $num_queries, get_num_queries(), 'No additional queries should have run.' );
 		$this->assertFalse( $updated, 'update_network_option() should have returned false.' );
 	}
 
@@ -446,9 +444,7 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 			$old_value = (string) $old_value;
 		}
 
-		$expected_queries = $old_value === $new_value || ! is_multisite() ? 1 : 2;
-		$this->assertSame( $expected_queries, get_num_queries() - $num_queries, "The number of queries should have increased by $expected_queries." );
-
+		$this->assertSame( 1, get_num_queries() - $num_queries, 'One additional query should have run to update the value.' );
 		$this->assertFalse( $updated, 'update_network_option() should have returned false.' );
 	}
 
@@ -480,9 +476,7 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 		 * Strictly equal old and new values will cause an early return
 		 * with no additional queries.
 		 */
-		$expected_queries = $old_value === $new_value || ! is_multisite() ? 0 : 1;
-		$this->assertSame( $expected_queries, get_num_queries() - $num_queries, "The number of queries should have increased by $expected_queries." );
-
+		$this->assertSame( $num_queries, get_num_queries(), 'No additional queries should have run.' );
 		$this->assertFalse( $updated, 'update_network_option() should have returned false.' );
 	}
 
@@ -567,8 +561,8 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 	 * On Single Site, this will result in no additional queries as
 	 * the option_value database field is not nullable.
 	 *
-	 * On Multisite, this will result in one additional query as
-	 * the meta_value database field is nullable.
+	 * On Multisite, this will result in no additional query because
+	 * of early return.
 	 *
 	 * @ticket 59360
 	 *
@@ -582,14 +576,8 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 		// Comparison will happen against value cached during add_option() above.
 		$updated = update_network_option( null, 'foo', null );
 
-		$expected_queries = is_multisite() ? 1 : 0;
-		$this->assertSame( $expected_queries, get_num_queries() - $num_queries, "The number of queries should have increased by $expected_queries." );
-
-		if ( is_multisite() ) {
-			$this->assertTrue( $updated, 'update_network_option() should have returned true.' );
-		} else {
-			$this->assertFalse( $updated, 'update_network_option() should have returned false.' );
-		}
+		$this->assertSame( $num_queries, get_num_queries(), 'No additional queries should have run.' );
+		$this->assertFalse( $updated, 'update_network_option() should have returned false.' );
 	}
 
 	/**
@@ -599,8 +587,8 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 	 * On Single Site, this will result in only 1 additional query as
 	 * the option_value database field is not nullable.
 	 *
-	 * On Multisite, this will result in two additional queries as
-	 * the meta_value database field is nullable.
+	 * On Multisite, this will result in only 1 additional queries as
+	 * the meta_value database field is not nullable.
 	 *
 	 * @ticket 59360
 	 *
@@ -618,14 +606,8 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 
 		$updated = update_network_option( null, 'foo', null );
 
-		$expected_queries = is_multisite() ? 2 : 1;
-		$this->assertSame( $expected_queries, get_num_queries() - $num_queries, "The number of queries should have increased by $expected_queries." );
-
-		if ( is_multisite() ) {
-			$this->assertTrue( $updated, 'update_network_option() should have returned true.' );
-		} else {
-			$this->assertFalse( $updated, 'update_network_option() should have returned false.' );
-		}
+		$this->assertSame( 1, get_num_queries() - $num_queries, 'One additional query should have run to update the value.' );
+		$this->assertFalse( $updated, 'update_network_option() should have returned false.' );
 	}
 
 	/**
@@ -635,8 +617,8 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 	 * On Single Site, this will result in no additional queries as
 	 * the option_value database field is not nullable.
 	 *
-	 * On Multisite, this will result in one additional query as
-	 * the meta_value database field is nullable.
+	 * On Multisite, this will result in no additional query as
+	 * the meta_value database field is not nullable.
 	 *
 	 * @ticket 59360
 	 *
@@ -652,14 +634,8 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 		$num_queries = get_num_queries();
 		$updated     = update_network_option( null, 'foo', null );
 
-		$expected_queries = is_multisite() ? 1 : 0;
-		$this->assertSame( $expected_queries, get_num_queries() - $num_queries, "The number of queries should have increased by $expected_queries." );
-
-		if ( is_multisite() ) {
-			$this->assertTrue( $updated, 'update_network_option() should have returned true.' );
-		} else {
-			$this->assertFalse( $updated, 'update_network_option() should have returned false.' );
-		}
+		$this->assertSame( $num_queries, get_num_queries(), 'No additional queries should have run.' );
+		$this->assertFalse( $updated, 'update_network_option() should have returned false.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/option/networkOption.php
+++ b/tests/phpunit/tests/option/networkOption.php
@@ -926,6 +926,56 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that update_network_option() applies 'pre_site_option_{$option}' and 'pre_option_{$option}' filters on Single Site.
+	 *
+	 * @ticket 59360
+	 *
+	 * @covers ::update_network_option
+	 */
+	public function test_update_network_option_should_apply_pre_site_option_and_pre_option_filters_on_single_site() {
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'This test should only run on Single Site.' );
+		}
+
+		$option      = 'foo';
+		$site_hook   = new MockAction();
+		$option_hook = new MockAction();
+
+		add_filter( "pre_site_option_{$option}", array( $site_hook, 'filter' ) );
+		add_filter( "pre_option_{$option}", array( $option_hook, 'filter' ) );
+
+		update_network_option( null, $option, 'false' );
+
+		$this->assertSame( 1, $site_hook->get_call_count(), "'pre_site_option_{$option}' filters were not applied." );
+		$this->assertSame( 1, $option_hook->get_call_count(), "'pre_option_{$option}' filters were not applied." );
+	}
+
+	/**
+	 * Tests that update_network_option() applies only 'pre_site_option_{$option}' filters on Multisite.
+	 *
+	 * @ticket 59360
+	 *
+	 * @covers ::update_network_option
+	 */
+	public function test_update_network_option_should_apply_only_pre_site_option_filters_on_multisite() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'This test should only run on Multisite.' );
+		}
+
+		$option      = 'foo';
+		$site_hook   = new MockAction();
+		$option_hook = new MockAction();
+
+		add_filter( "pre_site_option_{$option}", array( $site_hook, 'filter' ) );
+		add_filter( "pre_option_{$option}", array( $option_hook, 'filter' ) );
+
+		update_network_option( null, $option, 'false' );
+
+		$this->assertSame( 1, $site_hook->get_call_count(), "'pre_site_option_{$option}' filters were not applied." );
+		$this->assertSame( 0, $option_hook->get_call_count(), "'pre_option_{$option}' filters were not applied." );
+	}
+
+	/**
 	 * Tests that update_network_option() adds a non-existent option that uses a filtered default value.
 	 *
 	 * @ticket 59360

--- a/tests/phpunit/tests/option/networkOption.php
+++ b/tests/phpunit/tests/option/networkOption.php
@@ -767,8 +767,8 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 
 		update_network_option( null, $option, 'false' );
 
-		$this->assertSame( 1, $site_hook->get_call_count(), "'pre_site_option_{$option}' filters should have been applied once." );
-		$this->assertSame( is_multisite() ? 0 : 1, $option_hook->get_call_count(), "'pre_option_{$option}' filters should have been applied once." );
+		$this->assertSame( 1, $site_hook->get_call_count(), "'pre_site_option_{$option}' filters occurred an unexpected number of times." );
+		$this->assertSame( is_multisite() ? 0 : 1, $option_hook->get_call_count(), "'pre_option_{$option}' filters occurred an unexpected number of times." );
 	}
 
 	/**
@@ -789,8 +789,8 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 
 		update_network_option( null, $option, 'false' );
 
-		$this->assertSame( 2, $site_hook->get_call_count(), "'default_site_option_{$option}' filters should have been applied twice." );
-		$this->assertSame( is_multisite() ? 0 : 2, $option_hook->get_call_count(), "'default_option_{$option}' filters should have been applied twice." );
+		$this->assertSame( 2, $site_hook->get_call_count(), "'default_site_option_{$option}' filters occurred an unexpected number of times." );
+		$this->assertSame( is_multisite() ? 0 : 2, $option_hook->get_call_count(), "'default_option_{$option}' filters occurred an unexpected number of times." );
 	}
 
 	/**

--- a/tests/phpunit/tests/option/networkOption.php
+++ b/tests/phpunit/tests/option/networkOption.php
@@ -897,7 +897,7 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 		update_network_option( null, $option, 'false' );
 
 		$this->assertSame( 2, $site_hook->get_call_count(), "'default_site_option_{$option}' filters were not applied." );
-		$this->assertSame( 1, $option_hook->get_call_count(), "'default_option_{$option}' filters were not applied." );
+		$this->assertSame( 2, $option_hook->get_call_count(), "'default_option_{$option}' filters were not applied." );
 	}
 
 	/**

--- a/tests/phpunit/tests/option/networkOption.php
+++ b/tests/phpunit/tests/option/networkOption.php
@@ -439,11 +439,6 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 
 		$updated = update_network_option( null, 'foo', $new_value );
 
-		// Mimic the behavior of the database by casting the old value to string.
-		if ( is_scalar( $old_value ) ) {
-			$old_value = (string) $old_value;
-		}
-
 		$this->assertSame( 1, get_num_queries() - $num_queries, 'One additional query should have run to update the value.' );
 		$this->assertFalse( $updated, 'update_network_option() should have returned false.' );
 	}

--- a/tests/phpunit/tests/option/networkOption.php
+++ b/tests/phpunit/tests/option/networkOption.php
@@ -561,8 +561,8 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 	 * On Single Site, this will result in no additional queries as
 	 * the option_value database field is not nullable.
 	 *
-	 * On Multisite, this will result in no additional query because
-	 * of early return.
+	 * On Multisite, this will result in one additional query as
+	 * the meta_value database field is nullable.
 	 *
 	 * @ticket 59360
 	 *
@@ -576,8 +576,14 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 		// Comparison will happen against value cached during add_option() above.
 		$updated = update_network_option( null, 'foo', null );
 
-		$this->assertSame( $num_queries, get_num_queries(), 'No additional queries should have run.' );
-		$this->assertFalse( $updated, 'update_network_option() should have returned false.' );
+		$expected_queries = is_multisite() ? 1 : 0;
+		$this->assertSame( $expected_queries, get_num_queries() - $num_queries, "The number of queries should have increased by $expected_queries." );
+
+		if ( is_multisite() ) {
+			$this->assertTrue( $updated, 'update_network_option() should have returned true.' );
+		} else {
+			$this->assertFalse( $updated, 'update_network_option() should have returned false.' );
+		}
 	}
 
 	/**
@@ -587,8 +593,8 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 	 * On Single Site, this will result in only 1 additional query as
 	 * the option_value database field is not nullable.
 	 *
-	 * On Multisite, this will result in only 1 additional queries as
-	 * the meta_value database field is not nullable.
+	 * On Multisite, this will result in two additional queries as
+	 * the meta_value database field is nullable.
 	 *
 	 * @ticket 59360
 	 *
@@ -606,8 +612,14 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 
 		$updated = update_network_option( null, 'foo', null );
 
-		$this->assertSame( 1, get_num_queries() - $num_queries, 'One additional query should have run to update the value.' );
-		$this->assertFalse( $updated, 'update_network_option() should have returned false.' );
+		$expected_queries = is_multisite() ? 2 : 1;
+		$this->assertSame( $expected_queries, get_num_queries() - $num_queries, "The number of queries should have increased by $expected_queries." );
+
+		if ( is_multisite() ) {
+			$this->assertTrue( $updated, 'update_network_option() should have returned true.' );
+		} else {
+			$this->assertFalse( $updated, 'update_network_option() should have returned false.' );
+		}
 	}
 
 	/**
@@ -617,8 +629,8 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 	 * On Single Site, this will result in no additional queries as
 	 * the option_value database field is not nullable.
 	 *
-	 * On Multisite, this will result in no additional query as
-	 * the meta_value database field is not nullable.
+	 * On Multisite, this will result in one additional query as
+	 * the meta_value database field is nullable.
 	 *
 	 * @ticket 59360
 	 *
@@ -634,8 +646,14 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 		$num_queries = get_num_queries();
 		$updated     = update_network_option( null, 'foo', null );
 
-		$this->assertSame( $num_queries, get_num_queries(), 'No additional queries should have run.' );
-		$this->assertFalse( $updated, 'update_network_option() should have returned false.' );
+		$expected_queries = is_multisite() ? 1 : 0;
+		$this->assertSame( $expected_queries, get_num_queries() - $num_queries, "The number of queries should have increased by $expected_queries." );
+
+		if ( is_multisite() ) {
+			$this->assertTrue( $updated, 'update_network_option() should have returned true.' );
+		} else {
+			$this->assertFalse( $updated, 'update_network_option() should have returned false.' );
+		}
 	}
 
 	/**

--- a/tests/phpunit/tests/option/networkOption.php
+++ b/tests/phpunit/tests/option/networkOption.php
@@ -896,8 +896,8 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 
 		update_network_option( null, $option, 'false' );
 
-		$this->assertSame( 2, $site_hook->get_call_count(), "'default_site_option_{$option}' filters were not applied." );
-		$this->assertSame( 2, $option_hook->get_call_count(), "'default_option_{$option}' filters were not applied." );
+		$this->assertSame( 2, $site_hook->get_call_count(), "'default_site_option_{$option}' filters should have been applied twice." );
+		$this->assertSame( 2, $option_hook->get_call_count(), "'default_option_{$option}' filters should have been applied twice." );
 	}
 
 	/**
@@ -921,8 +921,8 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 
 		update_network_option( null, $option, 'false' );
 
-		$this->assertSame( 2, $site_hook->get_call_count(), "'default_site_option_{$option}' filters were not applied." );
-		$this->assertSame( 0, $option_hook->get_call_count(), "'default_option_{$option}' filters were not applied." );
+		$this->assertSame( 2, $site_hook->get_call_count(), "'default_site_option_{$option}' filters should have been applied twice." );
+		$this->assertSame( 0, $option_hook->get_call_count(), "'default_option_{$option}' filters should not have been applied." );
 	}
 
 	/**
@@ -946,8 +946,8 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 
 		update_network_option( null, $option, 'false' );
 
-		$this->assertSame( 1, $site_hook->get_call_count(), "'pre_site_option_{$option}' filters were not applied." );
-		$this->assertSame( 1, $option_hook->get_call_count(), "'pre_option_{$option}' filters were not applied." );
+		$this->assertSame( 1, $site_hook->get_call_count(), "'pre_site_option_{$option}' filters should have been applied once." );
+		$this->assertSame( 1, $option_hook->get_call_count(), "'pre_option_{$option}' filters should have been applied once." );
 	}
 
 	/**
@@ -971,8 +971,8 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 
 		update_network_option( null, $option, 'false' );
 
-		$this->assertSame( 1, $site_hook->get_call_count(), "'pre_site_option_{$option}' filters were not applied." );
-		$this->assertSame( 0, $option_hook->get_call_count(), "'pre_option_{$option}' filters were not applied." );
+		$this->assertSame( 1, $site_hook->get_call_count(), "'pre_site_option_{$option}' filters should have been applied once." );
+		$this->assertSame( 0, $option_hook->get_call_count(), "'pre_option_{$option}' filters should not have been applied." );
 	}
 
 	/**

--- a/tests/phpunit/tests/option/networkOption.php
+++ b/tests/phpunit/tests/option/networkOption.php
@@ -697,13 +697,10 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 	 * @covers ::update_network_option
 	 */
 	public function test_update_network_option_with_pre_filter_adds_missing_option() {
-
-		if ( is_multisite() ) {
-			$this->markTestSkipped( 'This test should only run on Single Site.' );
-		}
+		$hook_name = is_multisite() ? 'pre_site_option_foo' : 'pre_option_foo';
 
 		// Force a return value of integer 0.
-		add_filter( 'pre_option_foo', '__return_zero' );
+		add_filter( $hook_name, '__return_zero' );
 
 		/*
 		 * This should succeed, since the 'foo' option does not exist in the database.
@@ -720,16 +717,13 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 	 * @covers ::update_network_option
 	 */
 	public function test_update_network_option_with_pre_filter_updates_option_with_different_value() {
-
-		if ( is_multisite() ) {
-			$this->markTestSkipped( 'This test should only run on Single Site.' );
-		}
+		$hook_name = is_multisite() ? 'pre_site_option_foo' : 'pre_option_foo';
 
 		// Add the option with a value of 1 to the database.
 		update_network_option( null, 'foo', 1 );
 
 		// Force a return value of integer 0.
-		add_filter( 'pre_option_foo', '__return_zero' );
+		add_filter( $hook_name, '__return_zero' );
 
 		/*
 		 * This should succeed, since the 'foo' option has a value of 1 in the database.
@@ -746,86 +740,61 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 	 * @covers ::update_network_option
 	 */
 	public function test_update_network_option_maintains_pre_filters() {
-		if ( is_multisite() ) {
-			$this->markTestSkipped( 'This test should only run on Single Site.' );
-		}
+		$hook_name = is_multisite() ? 'pre_site_option_foo' : 'pre_option_foo';
 
-		add_filter( 'pre_option_foo', '__return_zero' );
+		add_filter( $hook_name, '__return_zero' );
 		update_network_option( null, 'foo', 0 );
 
 		// Assert that the filter is still present.
-		$this->assertSame( 10, has_filter( 'pre_option_foo', '__return_zero' ) );
+		$this->assertSame( 10, has_filter( $hook_name, '__return_zero' ) );
 	}
 
 	/**
-	 * Tests that a non-existent option is added even when its pre filter returns a value.
+	 * Tests that update_network_option() conditionally applies
+	 * 'pre_site_option_{$option}' and 'pre_option_{$option}' filters.
 	 *
 	 * @ticket 59360
 	 *
 	 * @covers ::update_network_option
 	 */
-	public function test_multisite_update_network_option_with_pre_filter_adds_missing_option() {
-		if ( ! is_multisite() ) {
-			$this->markTestSkipped( 'This test should only run on Multisite.' );
-		}
+	public function test_update_network_option_should_conditionally_apply_pre_site_option_and_pre_option_filters() {
+		$option      = 'foo';
+		$site_hook   = new MockAction();
+		$option_hook = new MockAction();
 
-		// Force a return value of integer 0.
-		add_filter( 'pre_site_option_foo', '__return_zero' );
+		add_filter( "pre_site_option_{$option}", array( $site_hook, 'filter' ) );
+		add_filter( "pre_option_{$option}", array( $option_hook, 'filter' ) );
 
-		/*
-		 * This should succeed, since the 'foo' option does not exist in the database.
-		 * The default value is false, so it differs from 0.
-		 */
-		$this->assertTrue( update_network_option( null, 'foo', 0 ) );
+		update_network_option( null, $option, 'false' );
+
+		$this->assertSame( 1, $site_hook->get_call_count(), "'pre_site_option_{$option}' filters should have been applied once." );
+		$this->assertSame( is_multisite() ? 0 : 1, $option_hook->get_call_count(), "'pre_option_{$option}' filters should have been applied once." );
 	}
 
 	/**
-	 * Tests that an existing option is updated even when its pre filter returns the same value.
+	 * Tests that update_network_option() conditionally applies
+	 * 'default_site_{$option}' and 'default_option_{$option}' filters.
 	 *
 	 * @ticket 59360
 	 *
 	 * @covers ::update_network_option
 	 */
-	public function test_multisite_update_network_option_with_pre_filter_updates_option_with_different_value() {
-		if ( ! is_multisite() ) {
-			$this->markTestSkipped( 'This test should only run on Multisite.' );
-		}
+	public function test_update_network_option_should_conditionally_apply_site_and_option_default_value_filters() {
+		$option      = 'foo';
+		$site_hook   = new MockAction();
+		$option_hook = new MockAction();
 
-		// Add the option with a value of 1 to the database.
-		update_network_option( null, 'foo', 1 );
+		add_filter( "default_site_option_{$option}", array( $site_hook, 'filter' ) );
+		add_filter( "default_option_{$option}", array( $option_hook, 'filter' ) );
 
-		// Force a return value of integer 0.
-		add_filter( 'pre_site_option_foo', '__return_zero' );
+		update_network_option( null, $option, 'false' );
 
-		/*
-		 * This should succeed, since the 'foo' option has a value of 1 in the database.
-		 * Therefore it differs from 0 and should be updated.
-		 */
-		$this->assertTrue( update_network_option( null, 'foo', 0 ) );
+		$this->assertSame( 2, $site_hook->get_call_count(), "'default_site_option_{$option}' filters should have been applied twice." );
+		$this->assertSame( is_multisite() ? 0 : 2, $option_hook->get_call_count(), "'default_option_{$option}' filters should have been applied twice." );
 	}
 
 	/**
-	 * Tests that calling update_network_option() does not permanently remove pre filters.
-	 *
-	 * @ticket 59360
-	 *
-	 * @covers ::update_network_option
-	 */
-	public function test_multisite_update_network_option_maintains_pre_filters() {
-		if ( ! is_multisite() ) {
-			$this->markTestSkipped( 'This test should only run on Multisite.' );
-		}
-
-		add_filter( 'pre_site_option_foo', '__return_zero' );
-		update_network_option( null, 'foo', 0 );
-
-		// Assert that the filter is still present.
-		$this->assertSame( 10, has_filter( 'pre_site_option_foo', '__return_zero' ) );
-	}
-
-	/**
-	 * Tests that update_network_option() adds a non-existent option that uses
-	 * a filtered default site value and a filtered default option value in Single Site.
+	 * Tests that update_network_option() adds a non-existent option that uses a filtered default value.
 	 *
 	 * @ticket 59360
 	 *
@@ -833,10 +802,6 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 	 */
 	public function test_update_network_option_should_add_option_with_filtered_default_value() {
 		global $wpdb;
-
-		if ( is_multisite() ) {
-			$this->markTestSkipped( 'This test should only run on Single Site.' );
-		}
 
 		$option               = 'foo';
 		$default_site_value   = 'default-site-value';
@@ -863,158 +828,26 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 		 */
 		$this->assertTrue( update_network_option( null, $option, false ), 'update_network_option() should have returned true.' );
 
-		$actual = $wpdb->get_row(
-			$wpdb->prepare(
-				"SELECT option_value FROM $wpdb->options WHERE option_name = %s LIMIT 1",
-				$option
-			)
-		);
+		if ( is_multisite() ) {
+			$actual = $wpdb->get_row(
+				$wpdb->prepare(
+					"SELECT meta_value FROM $wpdb->sitemeta WHERE meta_key = %s LIMIT 1",
+					$option
+				)
+			);
+		} else {
+			$actual = $wpdb->get_row(
+				$wpdb->prepare(
+					"SELECT option_value FROM $wpdb->options WHERE option_name = %s LIMIT 1",
+					$option
+				)
+			);
+		}
+
+		$value_field = is_multisite() ? 'meta_value' : 'option_value';
 
 		$this->assertIsObject( $actual, 'The option was not added to the database.' );
-		$this->assertObjectHasProperty( 'option_value', $actual, 'The "option_value" property was not included.' );
-		$this->assertSame( '', $actual->option_value, 'The new value was not stored in the database.' );
-	}
-
-	/**
-	 * Tests that update_network_option() applies site and option default value filters on Single Site.
-	 *
-	 * @ticket 59360
-	 *
-	 * @covers ::update_network_option
-	 */
-	public function test_update_network_option_should_apply_site_and_option_default_value_filters_on_single_site() {
-		if ( is_multisite() ) {
-			$this->markTestSkipped( 'This test should only run on Single Site.' );
-		}
-
-		$option      = 'foo';
-		$site_hook   = new MockAction();
-		$option_hook = new MockAction();
-
-		add_filter( "default_site_option_{$option}", array( $site_hook, 'filter' ) );
-		add_filter( "default_option_{$option}", array( $option_hook, 'filter' ) );
-
-		update_network_option( null, $option, 'false' );
-
-		$this->assertSame( 2, $site_hook->get_call_count(), "'default_site_option_{$option}' filters should have been applied twice." );
-		$this->assertSame( 2, $option_hook->get_call_count(), "'default_option_{$option}' filters should have been applied twice." );
-	}
-
-	/**
-	 * Tests that update_network_option() applies only site option default value filters on Multisite.
-	 *
-	 * @ticket 59360
-	 *
-	 * @covers ::update_network_option
-	 */
-	public function test_update_network_option_should_apply_only_site_default_value_filters_on_multisite() {
-		if ( ! is_multisite() ) {
-			$this->markTestSkipped( 'This test should only run on Multisite.' );
-		}
-
-		$option      = 'foo';
-		$site_hook   = new MockAction();
-		$option_hook = new MockAction();
-
-		add_filter( "default_site_option_{$option}", array( $site_hook, 'filter' ) );
-		add_filter( "default_option_{$option}", array( $option_hook, 'filter' ) );
-
-		update_network_option( null, $option, 'false' );
-
-		$this->assertSame( 2, $site_hook->get_call_count(), "'default_site_option_{$option}' filters should have been applied twice." );
-		$this->assertSame( 0, $option_hook->get_call_count(), "'default_option_{$option}' filters should not have been applied." );
-	}
-
-	/**
-	 * Tests that update_network_option() applies 'pre_site_option_{$option}' and 'pre_option_{$option}' filters on Single Site.
-	 *
-	 * @ticket 59360
-	 *
-	 * @covers ::update_network_option
-	 */
-	public function test_update_network_option_should_apply_pre_site_option_and_pre_option_filters_on_single_site() {
-		if ( is_multisite() ) {
-			$this->markTestSkipped( 'This test should only run on Single Site.' );
-		}
-
-		$option      = 'foo';
-		$site_hook   = new MockAction();
-		$option_hook = new MockAction();
-
-		add_filter( "pre_site_option_{$option}", array( $site_hook, 'filter' ) );
-		add_filter( "pre_option_{$option}", array( $option_hook, 'filter' ) );
-
-		update_network_option( null, $option, 'false' );
-
-		$this->assertSame( 1, $site_hook->get_call_count(), "'pre_site_option_{$option}' filters should have been applied once." );
-		$this->assertSame( 1, $option_hook->get_call_count(), "'pre_option_{$option}' filters should have been applied once." );
-	}
-
-	/**
-	 * Tests that update_network_option() applies only 'pre_site_option_{$option}' filters on Multisite.
-	 *
-	 * @ticket 59360
-	 *
-	 * @covers ::update_network_option
-	 */
-	public function test_update_network_option_should_apply_only_pre_site_option_filters_on_multisite() {
-		if ( ! is_multisite() ) {
-			$this->markTestSkipped( 'This test should only run on Multisite.' );
-		}
-
-		$option      = 'foo';
-		$site_hook   = new MockAction();
-		$option_hook = new MockAction();
-
-		add_filter( "pre_site_option_{$option}", array( $site_hook, 'filter' ) );
-		add_filter( "pre_option_{$option}", array( $option_hook, 'filter' ) );
-
-		update_network_option( null, $option, 'false' );
-
-		$this->assertSame( 1, $site_hook->get_call_count(), "'pre_site_option_{$option}' filters should have been applied once." );
-		$this->assertSame( 0, $option_hook->get_call_count(), "'pre_option_{$option}' filters should not have been applied." );
-	}
-
-	/**
-	 * Tests that update_network_option() adds a non-existent option that uses a filtered default value.
-	 *
-	 * @ticket 59360
-	 *
-	 * @covers ::update_network_option
-	 */
-	public function test_multisite_update_network_option_should_add_option_with_filtered_default_value() {
-		global $wpdb;
-
-		if ( ! is_multisite() ) {
-			$this->markTestSkipped( 'This test should only run on Multisite.' );
-		}
-
-		$option        = 'foo';
-		$default_value = 'default-value';
-
-		add_filter(
-			"default_site_option_{$option}",
-			static function () use ( $default_value ) {
-				return $default_value;
-			}
-		);
-
-		/*
-		 * For a non existing option with the unfiltered default of false, passing false here wouldn't work.
-		 * Because the default is different than false here though, passing false is expected to result in
-		 * a database update.
-		 */
-		$this->assertTrue( update_network_option( null, $option, false ), 'update_network_option() should have returned true.' );
-
-		$actual = $wpdb->get_row(
-			$wpdb->prepare(
-				"SELECT meta_value FROM $wpdb->sitemeta WHERE meta_key = %s LIMIT 1",
-				$option
-			)
-		);
-
-		$this->assertIsObject( $actual, 'The option was not added to the database.' );
-		$this->assertObjectHasProperty( 'meta_value', $actual, 'The "meta_value" property was not included.' );
-		$this->assertSame( '', $actual->meta_value, 'The new value was not stored in the database.' );
+		$this->assertObjectHasProperty( $value_field, $actual, "The '$value_field' property was not included." );
+		$this->assertSame( '', $actual->$value_field, 'The new value was not stored in the database.' );
 	}
 }


### PR DESCRIPTION
<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/59360

This PR update the production code of `update_network_option()` and the unit tests. The unit tests update shows that after the code change it will reduce some queries for multisite.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
