### PR TITLE
#57512: Resolve warnings and logical error while parsing REST API authorization header

### DIFF
--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -126,7 +126,12 @@ function wp_populate_basic_auth_from_authorization_header() {
 	$token    = substr( $header, 6 );
 	$userpass = base64_decode( $token );
 
-	list( $user, $pass ) = explode( ':', $userpass );
+	// There must be at least one colon in the string.
+	if ( ! str_contains( $userpass, ':' ) ) {
+		return;
+	}
+
+	list( $user, $pass ) = explode( ':', $userpass, 2 );
 
 	// Now shove them in the proper keys where we're expecting later on.
 	$_SERVER['PHP_AUTH_USER'] = $user;

--- a/tests/phpunit/tests/auth.php
+++ b/tests/phpunit/tests/auth.php
@@ -844,4 +844,46 @@ class Tests_Auth extends WP_UnitTestCase {
 			'not allowed' => array( 'subscriber', false ),
 		);
 	}
+
+	/*
+	 * @ticket 57512
+	 * @covers ::wp_populate_basic_auth_from_authorization_header
+	 */
+	public function tests_basic_http_authentication_with_username_and_password() {
+		// Header passed as "username:password".
+		$_SERVER['HTTP_AUTHORIZATION'] = 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=';
+
+		wp_populate_basic_auth_from_authorization_header();
+
+		$this->assertSame($_SERVER['PHP_AUTH_USER'], 'username');
+		$this->assertSame($_SERVER['PHP_AUTH_PW'], 'password');
+	}
+
+	/*
+	 * @ticket 57512
+	 * @covers ::wp_populate_basic_auth_from_authorization_header
+	 */
+	public function tests_basic_http_authentication_with_username_only() {
+		// Malformed header passed as "username" with no password.
+		$_SERVER['HTTP_AUTHORIZATION'] = 'Basic dXNlcm5hbWU=';
+
+		wp_populate_basic_auth_from_authorization_header();
+
+		$this->assertArrayNotHasKey('PHP_AUTH_USER', $_SERVER);
+		$this->assertArrayNotHasKey('PHP_AUTH_PW', $_SERVER);
+	}
+
+	/*
+	 * @ticket 57512
+	 * @covers ::wp_populate_basic_auth_from_authorization_header
+	 */
+	public function tests_basic_http_authentication_with_more_than_2_parts() {
+		// Header passed as "username:pass:word" where password contains colon.
+		$_SERVER['HTTP_AUTHORIZATION'] = 'Basic dXNlcm5hbWU6cGFzczp3b3Jk';
+
+		wp_populate_basic_auth_from_authorization_header();
+
+		$this->assertSame($_SERVER['PHP_AUTH_USER'], 'username');
+		$this->assertSame($_SERVER['PHP_AUTH_PW'], 'pass:word');
+	}
 }

--- a/tests/phpunit/tests/auth.php
+++ b/tests/phpunit/tests/auth.php
@@ -855,8 +855,8 @@ class Tests_Auth extends WP_UnitTestCase {
 
 		wp_populate_basic_auth_from_authorization_header();
 
-		$this->assertSame($_SERVER['PHP_AUTH_USER'], 'username');
-		$this->assertSame($_SERVER['PHP_AUTH_PW'], 'password');
+		$this->assertSame( $_SERVER['PHP_AUTH_USER'], 'username' );
+		$this->assertSame( $_SERVER['PHP_AUTH_PW'], 'password' );
 	}
 
 	/*
@@ -869,21 +869,21 @@ class Tests_Auth extends WP_UnitTestCase {
 
 		wp_populate_basic_auth_from_authorization_header();
 
-		$this->assertArrayNotHasKey('PHP_AUTH_USER', $_SERVER);
-		$this->assertArrayNotHasKey('PHP_AUTH_PW', $_SERVER);
+		$this->assertArrayNotHasKey( 'PHP_AUTH_USER', $_SERVER );
+		$this->assertArrayNotHasKey( 'PHP_AUTH_PW', $_SERVER );
 	}
 
 	/*
 	 * @ticket 57512
 	 * @covers ::wp_populate_basic_auth_from_authorization_header
 	 */
-	public function tests_basic_http_authentication_with_more_than_2_parts() {
+	public function tests_basic_http_authentication_with_colon_in_password() {
 		// Header passed as "username:pass:word" where password contains colon.
 		$_SERVER['HTTP_AUTHORIZATION'] = 'Basic dXNlcm5hbWU6cGFzczp3b3Jk';
 
 		wp_populate_basic_auth_from_authorization_header();
 
-		$this->assertSame($_SERVER['PHP_AUTH_USER'], 'username');
-		$this->assertSame($_SERVER['PHP_AUTH_PW'], 'pass:word');
+		$this->assertSame( $_SERVER['PHP_AUTH_USER'], 'username' );
+		$this->assertSame( $_SERVER['PHP_AUTH_PW'], 'pass:word' );
 	}
 }


### PR DESCRIPTION
Update of https://core.trac.wordpress.org/attachment/ticket/57512/57512_with_tests_2.diff with minor changes to comment formatting.

Trac ticket: https://core.trac.wordpress.org/ticket/57512

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
