### PR TITLE
define dynamic variables to avoid deprecation warnings

### DIFF
--- a/src/wp-includes/class-wp-text-diff-renderer-table.php
+++ b/src/wp-includes/class-wp-text-diff-renderer-table.php
@@ -16,6 +16,10 @@
 #[AllowDynamicProperties]
 class WP_Text_Diff_Renderer_Table extends Text_Diff_Renderer {
 
+	protected $_title;
+	protected $_title_left;
+	protected $_title_right;
+	
 	/**
 	 * @see Text_Diff_Renderer::_leading_context_lines
 	 * @var int


### PR DESCRIPTION
added 3 protected variables, so at least the warnings go away

Trac ticket: https://core.trac.wordpress.org/ticket/59431