### PR TITLE
Block Support: Add unit tests for Elements support.

### DIFF
--- a/src/wp-includes/block-supports/elements.php
+++ b/src/wp-includes/block-supports/elements.php
@@ -36,6 +36,9 @@ function wp_render_elements_support( $block_content, $block ) {
 	}
 
 	$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
+	if ( ! $block_type ) {
+		return $block_content;
+	}
 
 	$element_color_properties = array(
 		'button'  => array(

--- a/tests/phpunit/tests/block-supports/wpRenderElementsSupport.php
+++ b/tests/phpunit/tests/block-supports/wpRenderElementsSupport.php
@@ -19,129 +19,34 @@ class Tests_Block_Supports_WpRenderElementsSupport extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that no output is generated when a block's markup is empty.
+	 * Tests that block supports leaves block content alone if the block type
+	 * isn't registered.
 	 *
 	 * @ticket 59578
 	 *
-	 * @dataProvider data_elements_block_support_class
-	 *
 	 * @covers ::wp_render_elements_support
-	 *
-	 * @param array  $color_settings  The color block support settings used for elements support.
-	 * @param array  $elements_styles The elements styles within the block attributes.
-	 * @param string $block_markup    Original block markup.
-	 * @param string $expected_markup Resulting markup after application of elements block support.
 	 *
 	 * @return void
 	 */
-	public function test_leaves_empty_block_content_empty( $color_settings, $elements_styles, $block_markup, $expected_markup ) {
-		$this->test_block_name = 'test/element-block-supports';
-
-		register_block_type(
-			$this->test_block_name,
-			array(
-				'api_version' => 3,
-				'attributes'  => array(
-					'style' => array(
-						'type' => 'object',
-					),
-				),
-				'supports'    => array(
-					'color' => $color_settings,
-				),
-			)
-		);
-
+	public function test_leaves_block_content_alone_when_block_type_not_registered() {
 		$block = array(
-			'blockName' => $this->test_block_name,
+			'blockName' => 'test/element-block-supports',
 			'attrs'     => array(
 				'style' => array(
-					'elements' => $elements_styles,
+					'elements' => array(
+						'button' => array(
+							'color' => array(
+								'text'       => 'var:preset|color|vivid-red',
+								'background' => '#fff',
+							),
+						),
+					),
 				),
 			),
 		);
 
-		$actual = wp_render_elements_support( '', $block );
-
-		$this->assertSame( '', $actual, 'Expected empty block output HTML but found rendered markup instead.' );
-	}
-
-	/**
-	 * Tests that no output is generated when a block's attributes are missing.
-	 *
-	 * No block supports should be active without an attribute requesting so.
-	 *
-	 * @ticket 59578
-	 *
-	 * @dataProvider data_elements_block_support_class
-	 *
-	 * @covers ::wp_render_elements_support
-	 *
-	 * @param array  $color_settings  The color block support settings used for elements support.
-	 * @param array  $elements_styles The elements styles within the block attributes.
-	 * @param string $block_markup    Original block markup.
-	 * @param string $expected_markup Resulting markup after application of elements block support.
-	 *
-	 * @return void
-	 */
-	public function test_leaves_unrequested_block_content_as_is( $color_settings, $elements_styles, $block_markup, $expected_markup ) {
-		$this->test_block_name = 'test/element-block-supports';
-
-		register_block_type(
-			$this->test_block_name,
-			array(
-				'api_version' => 3,
-				'attributes'  => array(
-					'style' => array(
-						'type' => 'object',
-					),
-				),
-				'supports'    => array(
-					'color' => $color_settings,
-				),
-			)
-		);
-
-		$block = array(
-			'blockName' => $this->test_block_name,
-		);
-
-		$actual = wp_render_elements_support( $block_markup, $block );
-		$this->assertSame( $block_markup, $actual, 'Expected an unmodified block but found transformation.' );
-
-		$actual_when_empty = wp_render_elements_support( '', $block );
-		$this->assertSame( '', $actual_when_empty, 'Expected empty block output HTML but found content instead.' );
-	}
-
-	/**
-	 * Tests that block supports leaves block content alone if the block type isn't registered.
-	 *
-	 * @ticket 59578
-	 *
-	 * @dataProvider data_elements_block_support_class
-	 *
-	 * @covers ::wp_render_elements_support
-	 *
-	 * @param array  $color_settings  The color block support settings used for elements support.
-	 * @param array  $elements_styles The elements styles within the block attributes.
-	 * @param string $block_markup    Original block markup.
-	 * @param string $expected_markup Resulting markup after application of elements block support.
-	 *
-	 * @return void
-	 */
-	public function test_leaves_block_content_alone_when_block_type_not_registered( $color_settings, $elements_styles, $block_markup, $expected_markup ) {
-		$this->test_block_name = 'test/element-block-supports';
-
-		$block = array(
-			'blockName' => $this->test_block_name,
-			'attrs'     => array(
-				'style' => array(
-					'elements' => $elements_styles,
-				),
-			),
-		);
-
-		$actual = wp_render_elements_support( $block_markup, $block );
+		$block_markup = '<p>Hello <a href="http://www.wordpress.org/">WordPress</a>!</p>';
+		$actual       = wp_render_elements_support( $block_markup, $block );
 
 		$this->assertSame( $block_markup, $actual, 'Expected to leave block content unmodified, but found changes.' );
 	}
@@ -192,7 +97,7 @@ class Tests_Block_Supports_WpRenderElementsSupport extends WP_UnitTestCase {
 		$this->assertMatchesRegularExpression(
 			$expected_markup,
 			$actual,
-			'Position block wrapper markup should be correct'
+			'Block wrapper markup should be correct'
 		);
 	}
 
@@ -208,6 +113,34 @@ class Tests_Block_Supports_WpRenderElementsSupport extends WP_UnitTestCase {
 		);
 
 		return array(
+			// @ticket 59578
+			'empty block markup remains untouched'         => array(
+				'color_settings'  => array(
+					'button' => true,
+				),
+				'elements_styles' => array(
+					'button' => array( 'color' => $color_styles ),
+				),
+				'block_markup'    => '',
+				'expected_markup' => '/^$/',
+			),
+			'empty block markup remains untouched when no block attributes' => array(
+				'color_settings'  => array(
+					'button' => true,
+				),
+				'elements_styles' => null,
+				'block_markup'    => '',
+				'expected_markup' => '/^$/',
+			),
+			'block markup remains untouched when block has no attributes' => array(
+				'color_settings'  => array(
+					'button' => true,
+				),
+				'elements_styles' => null,
+				'block_markup'    => '<p>Hello <a href="http://www.wordpress.org/">WordPress</a>!</p>',
+				'expected_markup' => '/^<p>Hello <a href="http:\/\/www.wordpress.org\/">WordPress<\/a>!<\/p>$/',
+			),
+			// @ticket 5418
 			'button element styles with serialization skipped' => array(
 				'color_settings'  => array(
 					'button'                          => true,

--- a/tests/phpunit/tests/block-supports/wpRenderElementsSupport.php
+++ b/tests/phpunit/tests/block-supports/wpRenderElementsSupport.php
@@ -19,6 +19,134 @@ class Tests_Block_Supports_WpRenderElementsSupport extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that no output is generated when a block's markup is empty.
+	 *
+	 * @ticket 59578
+	 *
+	 * @dataProvider data_elements_block_support_class
+	 *
+	 * @covers ::wp_render_elements_support
+	 *
+	 * @param array  $color_settings  The color block support settings used for elements support.
+	 * @param array  $elements_styles The elements styles within the block attributes.
+	 * @param string $block_markup    Original block markup.
+	 * @param string $expected_markup Resulting markup after application of elements block support.
+	 *
+	 * @return void
+	 */
+	public function test_leaves_empty_block_content_empty( $color_settings, $elements_styles, $block_markup, $expected_markup ) {
+		$this->test_block_name = 'test/element-block-supports';
+
+		register_block_type(
+			$this->test_block_name,
+			array(
+				'api_version' => 3,
+				'attributes'  => array(
+					'style' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array(
+					'color' => $color_settings,
+				),
+			)
+		);
+
+		$block = array(
+			'blockName' => $this->test_block_name,
+			'attrs'     => array(
+				'style' => array(
+					'elements' => $elements_styles,
+				),
+			),
+		);
+
+		$actual = wp_render_elements_support( '', $block );
+
+		$this->assertSame( '', $actual, 'Expected empty block output HTML but found rendered markup instead.' );
+	}
+
+	/**
+	 * Tests that no output is generated when a block's attributes are missing.
+	 *
+	 * No block supports should be active without an attribute requesting so.
+	 *
+	 * @ticket 59578
+	 *
+	 * @dataProvider data_elements_block_support_class
+	 *
+	 * @covers ::wp_render_elements_support
+	 *
+	 * @param array  $color_settings  The color block support settings used for elements support.
+	 * @param array  $elements_styles The elements styles within the block attributes.
+	 * @param string $block_markup    Original block markup.
+	 * @param string $expected_markup Resulting markup after application of elements block support.
+	 *
+	 * @return void
+	 */
+	public function test_leaves_unrequested_block_content_as_is( $color_settings, $elements_styles, $block_markup, $expected_markup ) {
+		$this->test_block_name = 'test/element-block-supports';
+
+		register_block_type(
+			$this->test_block_name,
+			array(
+				'api_version' => 3,
+				'attributes'  => array(
+					'style' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array(
+					'color' => $color_settings,
+				),
+			)
+		);
+
+		$block = array(
+			'blockName' => $this->test_block_name,
+		);
+
+		$actual = wp_render_elements_support( $block_markup, $block );
+		$this->assertSame( $block_markup, $actual, 'Expected an unmodified block but found transformation.' );
+
+		$actual_when_empty = wp_render_elements_support( '', $block );
+		$this->assertSame( '', $actual_when_empty, 'Expected empty block output HTML but found content instead.' );
+	}
+
+	/**
+	 * Tests that block supports leaves block content alone if the block type isn't registered.
+	 *
+	 * @ticket 59578
+	 *
+	 * @dataProvider data_elements_block_support_class
+	 *
+	 * @covers ::wp_render_elements_support
+	 *
+	 * @param array  $color_settings  The color block support settings used for elements support.
+	 * @param array  $elements_styles The elements styles within the block attributes.
+	 * @param string $block_markup    Original block markup.
+	 * @param string $expected_markup Resulting markup after application of elements block support.
+	 *
+	 * @return void
+	 */
+	public function test_leaves_block_content_alone_when_block_type_not_registered( $color_settings, $elements_styles, $block_markup, $expected_markup ) {
+		$this->test_block_name = 'test/element-block-supports';
+
+		$block = array(
+			'blockName' => $this->test_block_name,
+			'attrs'     => array(
+				'style' => array(
+					'elements' => $elements_styles,
+				),
+			),
+		);
+
+		$actual = wp_render_elements_support( $block_markup, $block );
+
+		$this->assertSame( $block_markup, $actual, 'Expected to leave block content unmodified, but found changes.' );
+	}
+
+	/**
 	 * Tests that elements block support applies the correct classname.
 	 *
 	 * @ticket 59555


### PR DESCRIPTION
Trac ticket: [#59578](https://core.trac.wordpress.org/ticket/59578)

Follow-up to #59544

Adds additional unit tests to confirm the behavior of elements block supports when certain conditions aren't met.

cc: @aaronrobertshaw I modified the behavior when a block isn't registered. I'm not sure what _should_ be occurring here, so I took a guess. I would think that an un-registered block should be left alone, but it's trivial to update this to preserve the existing behavior, which is to go ahead and modify un-registered blocks.