### PR TITLE
Bugfix - $role_data['capabilities'] sometimes Null in class-wp-user-query.php

### DIFF
--- a/src/wp-includes/class-wp-user-query.php
+++ b/src/wp-includes/class-wp-user-query.php
@@ -480,7 +480,12 @@ class WP_User_Query {
 		$caps_with_roles = array();
 
 		foreach ( $available_roles as $role => $role_data ) {
-			$role_caps = array_keys( array_filter( $role_data['capabilities'] ) );
+			$role_caps = '';
+			if(isset($role_data['capabilities'])){
+				$role_caps = array_keys( array_filter( $role_data['capabilities'] ) );
+			}else{
+				return false;
+			}
 
 			foreach ( $capabilities as $cap ) {
 				if ( in_array( $cap, $role_caps, true ) ) {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Found  a bug where there a variable was not checked before it tries to do an operation on it, and for some reason, in this install, it crashes even with no plugins and twenty twenty.

Created a bit of code that checks for what the variable is before trying to do the array_filter, and if it doesn't exist, bail.

Trac ticket: https://core.trac.wordpress.org/ticket/59585#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
