### PR TITLE
Ensure WP_Text_Diff_Renderer_Table is PHP 8.2 compatible

### DIFF
--- a/src/wp-includes/class-wp-text-diff-renderer-table.php
+++ b/src/wp-includes/class-wp-text-diff-renderer-table.php
@@ -33,7 +33,7 @@ class WP_Text_Diff_Renderer_Table extends Text_Diff_Renderer {
 	/**
 	 * Title of the item being compared.
 	 *
-	 * @since 6.4.0
+	 * @since 6.4.0 Explicitly declare dynamic class property.
 	 * @var string|null
 	 */
 	public $_title;
@@ -41,7 +41,7 @@ class WP_Text_Diff_Renderer_Table extends Text_Diff_Renderer {
 	/**
 	 * Title for the left column.
 	 *
-	 * @since 6.4.0
+	 * @since 6.4.0 Explicitly declare dynamic class property.
 	 * @var string|null
 	 */
 	public $_title_left;
@@ -49,7 +49,7 @@ class WP_Text_Diff_Renderer_Table extends Text_Diff_Renderer {
 	/**
 	 * Title for the right column.
 	 *
-	 * @since 6.4.0
+	 * @since 6.4.0 Explicitly declare dynamic class property.
 	 * @var string|null
 	 */
 	public $_title_right;

--- a/src/wp-includes/class-wp-text-diff-renderer-table.php
+++ b/src/wp-includes/class-wp-text-diff-renderer-table.php
@@ -31,6 +31,30 @@ class WP_Text_Diff_Renderer_Table extends Text_Diff_Renderer {
 	public $_trailing_context_lines = 10000;
 
 	/**
+	 * Title of the item being compared.
+	 *
+	 * @since 6.4.0
+	 * @var string|null
+	 */
+	public $_title;
+
+	/**
+	 * Title for the left column.
+	 *
+	 * @since 6.4.0
+	 * @var string|null
+	 */
+	public $_title_left;
+
+	/**
+	 * Title for the right column.
+	 *
+	 * @since 6.4.0
+	 * @var string|null
+	 */
+	public $_title_right;
+
+	/**
 	 * Threshold for when a diff should be saved or omitted.
 	 *
 	 * @var float

--- a/src/wp-includes/class-wp-text-diff-renderer-table.php
+++ b/src/wp-includes/class-wp-text-diff-renderer-table.php
@@ -33,7 +33,7 @@ class WP_Text_Diff_Renderer_Table extends Text_Diff_Renderer {
 	/**
 	 * Title of the item being compared.
 	 *
-	 * @since 6.4.0 Explicitly declare dynamic class property to ensure PHP 8.2 compatibility.
+	 * @since 6.4.0 Declared a previously dynamic property.
 	 * @var string|null
 	 */
 	public $_title;
@@ -41,7 +41,7 @@ class WP_Text_Diff_Renderer_Table extends Text_Diff_Renderer {
 	/**
 	 * Title for the left column.
 	 *
-	 * @since 6.4.0 Explicitly declare dynamic class property to ensure PHP 8.2 compatibility.
+	 * @since 6.4.0 Declared a previously dynamic property.
 	 * @var string|null
 	 */
 	public $_title_left;
@@ -49,7 +49,7 @@ class WP_Text_Diff_Renderer_Table extends Text_Diff_Renderer {
 	/**
 	 * Title for the right column.
 	 *
-	 * @since 6.4.0 Explicitly declare dynamic class property to ensure PHP 8.2 compatibility.
+	 * @since 6.4.0 Declared a previously dynamic property.
 	 * @var string|null
 	 */
 	public $_title_right;

--- a/src/wp-includes/class-wp-text-diff-renderer-table.php
+++ b/src/wp-includes/class-wp-text-diff-renderer-table.php
@@ -33,7 +33,7 @@ class WP_Text_Diff_Renderer_Table extends Text_Diff_Renderer {
 	/**
 	 * Title of the item being compared.
 	 *
-	 * @since 6.4.0 Explicitly declare dynamic class property.
+	 * @since 6.4.0 Explicitly declare dynamic class property to ensure PHP 8.2 compatibility.
 	 * @var string|null
 	 */
 	public $_title;
@@ -41,7 +41,7 @@ class WP_Text_Diff_Renderer_Table extends Text_Diff_Renderer {
 	/**
 	 * Title for the left column.
 	 *
-	 * @since 6.4.0 Explicitly declare dynamic class property.
+	 * @since 6.4.0 Explicitly declare dynamic class property to ensure PHP 8.2 compatibility.
 	 * @var string|null
 	 */
 	public $_title_left;
@@ -49,7 +49,7 @@ class WP_Text_Diff_Renderer_Table extends Text_Diff_Renderer {
 	/**
 	 * Title for the right column.
 	 *
-	 * @since 6.4.0 Explicitly declare dynamic class property.
+	 * @since 6.4.0 Explicitly declare dynamic class property to ensure PHP 8.2 compatibility.
 	 * @var string|null
 	 */
 	public $_title_right;


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This PR aims to add missing class properties to ensure `WP_Text_Diff_Renderer_Table` is PHP 8.2 compatible.

Trac ticket: https://core.trac.wordpress.org/ticket/59431

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
