### PR TITLE
Update Twenty Twenty version to 2.4

### DIFF
--- a/src/wp-content/themes/twentytwenty/package-lock.json
+++ b/src/wp-content/themes/twentytwenty/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "twentytwenty",
-	"version": "2.3.0",
+	"version": "2.4.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "twentytwenty",
-			"version": "2.3.0",
+			"version": "2.4.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@wordpress/browserslist-config": "^5.24.0",

--- a/src/wp-content/themes/twentytwenty/package.json
+++ b/src/wp-content/themes/twentytwenty/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "twentytwenty",
-	"version": "2.3.0",
+	"version": "2.4.0",
 	"description": "Default WP Theme",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/src/wp-content/themes/twentytwenty/readme.txt
+++ b/src/wp-content/themes/twentytwenty/readme.txt
@@ -3,7 +3,7 @@ Contributors: the WordPress team
 Requires at least: 4.7
 Tested up to: 6.3
 Requires PHP: 5.2.4
-Stable tag: 2.3
+Stable tag: 2.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,6 +23,11 @@ all elements on your site are automatically calculated based on the colors
 you pick, ensuring a high, accessible color contrast for your visitors.
 
 == Changelog ==
+
+= 2.4 =
+* Released: October 12, 2023
+
+https://wordpress.org/documentation/article/twenty-twenty-changelog/#Version_2.4
 
 = 2.3 =
 * Released: August 8, 2023

--- a/src/wp-content/themes/twentytwenty/style-rtl.css
+++ b/src/wp-content/themes/twentytwenty/style-rtl.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Twenty Twenty
 Text Domain: twentytwenty
-Version: 2.3
+Version: 2.4
 Tested up to: 6.3
 Requires at least: 4.7
 Requires PHP: 5.2.4

--- a/src/wp-content/themes/twentytwenty/style.css
+++ b/src/wp-content/themes/twentytwenty/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Twenty Twenty
 Text Domain: twentytwenty
-Version: 2.3
+Version: 2.4
 Tested up to: 6.3
 Requires at least: 4.7
 Requires PHP: 5.2.4


### PR DESCRIPTION
If Twenty Twenty has an updated package before WordPress 6.4, the theme version will need to be updated.

[Trac 59576](https://core.trac.wordpress.org/ticket/59576)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
