### PR TITLE
Performance: Directly mutate array in wp_parse_args

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -4852,7 +4852,10 @@ function wp_parse_args( $args, $defaults = array() ) {
 	}
 
 	if ( is_array( $defaults ) && $defaults ) {
-		return array_merge( $defaults, $parsed_args );
+		foreach ( $parsed_args as $key => $value ) {
+			$defaults[ $key ] = $value;
+		}
+		return $defaults;
 	}
 	return $parsed_args;
 }

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -4852,6 +4852,14 @@ function wp_parse_args( $args, $defaults = array() ) {
 	}
 
 	if ( is_array( $defaults ) && $defaults ) {
+		if ( count( $defaults ) < 3 ) {
+			foreach ( $defaults as $key => $value ) {
+				if ( ! isset( $parsed_args[ $key ] ) && ! array_key_exists( $key, $parsed_args ) ) {
+					$parsed_args[ $key ] = $value;
+				}
+			}
+			return $parsed_args;
+		}
 		foreach ( $parsed_args as $key => $value ) {
 			$defaults[ $key ] = $value;
 		}


### PR DESCRIPTION
Memory use + runtime? **Nope**

![5478-no-array-merge](https://github.com/WordPress/wordpress-develop/assets/5431237/0c1ef330-2a46-45ac-826e-ef33c9837004)

This is a good demonstration on the bias that profiling can introduce. XDebug shows a reduction in runtime by 16%, but there's actually _no_ reduction.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
