### PR TITLE
Check current user's `unfiltered_html` cap before checking commenter's cap in `wp_update_comment`

### DIFF
--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -2502,7 +2502,7 @@ function wp_update_comment( $commentarr, $wp_error = false ) {
 	}
 
 	$filter_comment = false;
-	if ( ! has_filter( 'pre_comment_content', 'wp_filter_kses' ) ) {
+	if ( ! current_user_can( 'unfiltered_html' ) && ! has_filter( 'pre_comment_content', 'wp_filter_kses' ) ) {
 		$filter_comment = ! user_can( isset( $comment['user_id'] ) ? $comment['user_id'] : 0, 'unfiltered_html' );
 	}
 

--- a/tests/phpunit/tests/comment.php
+++ b/tests/phpunit/tests/comment.php
@@ -166,7 +166,7 @@ class Tests_Comment extends WP_UnitTestCase {
 		);
 
 		$comment = get_comment( $comment_id );
-		$this->assertSame( '<a href="http://example.localhost/something.html" rel="nofollow ugc">click</a>', $comment->comment_content, 'Comment: ' . $comment->comment_content );
+		$this->assertSame( '<a href="http://example.localhost/something.html" disallowed=attribute rel="nofollow ugc">click</a>', $comment->comment_content, 'Comment: ' . $comment->comment_content );
 		wp_set_current_user( 0 );
 	}
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/57979

